### PR TITLE
Rename for packaging: coreos-inc/bridge -> openshift/console.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .vscode
 /bin
 /gopath
-/Godeps/_workspace/src/github.com/coreos-inc/bridge
+/Godeps/_workspace/src/github.com/openshift/console
 /frontend/.cache-loader
 /frontend/__coverage__
 /frontend/public/bower_components

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Remove the `--headless` flag to Chrome (chromeOptions) in `frontend/integration-
 
 Checkout and build [dex](https://github.com/coreos/dex/).
 
-`./bin/dex serve ../../coreos-inc/bridge/contrib/dex-config-dev.yaml`
+`./bin/dex serve ../../openshift/console/contrib/dex-config-dev.yaml`
 
 Run bridge with the following options:
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -35,7 +35,7 @@ const (
 	errorInvalidCode = "invalid_code"
 )
 
-var log = capnslog.NewPackageLogger("github.com/coreos-inc/bridge", "auth")
+var log = capnslog.NewPackageLogger("github.com/openshift/console", "auth")
 
 type Authenticator struct {
 	tokenVerifier func(string) (*loginState, error)

--- a/build-backend
+++ b/build-backend
@@ -8,6 +8,6 @@ set -e
 PROJECT_DIR=$(basename ${PWD})
 
 GIT_TAG=`git describe --always --tags HEAD`
-LD_FLAGS="-w -X github.com/coreos-inc/bridge/version.Version=${GIT_TAG}"
+LD_FLAGS="-w -X github.com/openshift/console/version.Version=${GIT_TAG}"
 
-CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o bin/bridge github.com/coreos-inc/bridge/cmd/bridge
+CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o bin/bridge github.com/openshift/console/cmd/bridge

--- a/builder-run
+++ b/builder-run
@@ -29,6 +29,6 @@ done
 docker run $ENV_STR --rm --net=host \
        --user="${BUILDER_RUN_USER}" \
        $VOLUME_MOUNT \
-       -v "$(pwd)":/go/src/github.com/coreos-inc/bridge \
-       -w /go/src/github.com/coreos-inc/bridge \
+       -v "$(pwd)":/go/src/github.com/openshift/console \
+       -w /go/src/github.com/openshift/console \
        $BUILDER_IMAGE "$@"

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -15,13 +15,13 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	"github.com/coreos/pkg/flagutil"
 
-	"github.com/coreos-inc/bridge/auth"
-	"github.com/coreos-inc/bridge/pkg/proxy"
-	"github.com/coreos-inc/bridge/server"
+	"github.com/openshift/console/auth"
+	"github.com/openshift/console/pkg/proxy"
+	"github.com/openshift/console/server"
 )
 
 var (
-	log = capnslog.NewPackageLogger("github.com/coreos-inc/bridge", "cmd/main")
+	log = capnslog.NewPackageLogger("github.com/openshift/console", "cmd/main")
 )
 
 const (
@@ -30,7 +30,7 @@ const (
 )
 
 func main() {
-	rl := capnslog.MustRepoLogger("github.com/coreos-inc/bridge")
+	rl := capnslog.MustRepoLogger("github.com/openshift/console")
 	capnslog.SetFormatter(capnslog.NewStringFormatter(os.Stderr))
 
 	fs := flag.NewFlagSet("bridge", flag.ExitOnError)

--- a/docs-internal/operators.md
+++ b/docs-internal/operators.md
@@ -4,13 +4,13 @@ The UI detects if operators are installed in the cluster and conditionally enabl
 
 ## Operator feature detection
 
-We determine if the feature is enabled by first checking if the operator feature exists. For more information, see [k8s/k8s.js](https://github.com/coreos-inc/bridge/blob/master/frontend/public/module/k8s/k8s.js).
+We determine if the feature is enabled by first checking if the operator feature exists. For more information, see [k8s/k8s.js](https://github.com/openshift/console/blob/master/frontend/public/module/k8s/k8s.js).
 
 ## UI Components
 
 The update UI is divided into several key components and is abstracted such that additional channels could be added in the future e.g. Tectonic channel, Container Linux channel, etc.
 
-All components live in [components/cluster-updates](https://github.com/coreos-inc/bridge/blob/master/frontend/public/components/cluster-updates). Each major component has a description in the file of how it's intended to be used.
+All components live in [components/cluster-updates](https://github.com/openshift/console/blob/master/frontend/public/components/cluster-updates). Each major component has a description in the file of how it's intended to be used.
 
 ## Data flow
 

--- a/docs-internal/releases.md
+++ b/docs-internal/releases.md
@@ -8,7 +8,7 @@ Decide on an incremented release semantic $VERSION.
 
 ## Docs
 
-Add changes to the [changelog](https://github.com/coreos-inc/bridge/blob/master/CHANGES.md) for the new version.
+Add changes to the [changelog](https://github.com/openshift/console/blob/master/CHANGES.md) for the new version.
 Make note of any newly introduced known issues, breaking changes or removed features.
 
 ## Tag
@@ -33,7 +33,7 @@ docker push quay.io/coreos/tectonic-console:$VERSION
 
 ## Github
 
-Create a [release](https://github.com/coreos-inc/bridge/releases) on Github with release notes by copying the changelog.
+Create a [release](https://github.com/openshift/console/releases) on Github with release notes by copying the changelog.
 
 ## Update Installer
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bridge",
   "description": "CoreOS Tectonic Dashboard",
-  "repository": "https://github.com/coreos-inc/bridge",
+  "repository": "https://github.com/openshift/console",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/coreos-inc/bridge
+package: github.com/openshift/console
 testImports: []
 import:
 - package: gopkg.in/square/go-jose.v2

--- a/jenkins
+++ b/jenkins
@@ -36,7 +36,7 @@ EOF
     # shellcheck disable=SC2154
     curl -o /dev/null --silent -X POST --user "${GITHUB_CREDENTIALS}" \
     --data "$data" \
-    "https://api.github.com/repos/coreos-inc/bridge/statuses/${ghprbActualCommit}"
+    "https://api.github.com/repos/openshift/console/statuses/${ghprbActualCommit}"
     set -x
 }
 

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/coreos-inc/bridge/auth"
+	"github.com/openshift/console/auth"
 )
 
 // Middleware generates a middleware wrapper for request hanlders.

--- a/server/server.go
+++ b/server/server.go
@@ -21,9 +21,9 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	"github.com/coreos/pkg/health"
 
-	"github.com/coreos-inc/bridge/auth"
-	"github.com/coreos-inc/bridge/pkg/proxy"
-	"github.com/coreos-inc/bridge/version"
+	"github.com/openshift/console/auth"
+	"github.com/openshift/console/pkg/proxy"
+	"github.com/openshift/console/version"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	plog = capnslog.NewPackageLogger("github.com/coreos-inc/bridge", "server")
+	plog = capnslog.NewPackageLogger("github.com/openshift/console", "server")
 )
 
 type jsGlobals struct {

--- a/test-backend
+++ b/test-backend
@@ -37,7 +37,7 @@ fi
 
 # split TEST into an array and prepend repo path to each local package
 split=(${TEST// / })
-TEST=${split[@]/#/github.com/coreos-inc/bridge/}
+TEST=${split[@]/#/github.com/openshift/console/}
 
 echo "Running tests..."
 go test ${COVER} $@ ${TEST}

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 // version.Version should be provided at build time with
-//-ldflags "-X github.com/coreos-inc/bridge/version.Version $GIT_TAG"
+//-ldflags "-X github.com/openshift/console/version.Version $GIT_TAG"
 var Version string


### PR DESCRIPTION
Fixes issues with `go get` and confusing docs.
