### PR TITLE
Remove web fonts.

### DIFF
--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -67,6 +67,8 @@ $color-pf-black: black;
 $text-muted: $color-grey-text;
 // Patternfly defaults to 12px, which is too small in many cases
 $font-size-base: 13px;
+// Patternfly uses Open Sans. Use the one true font-family directive shared by Medium, GitHub, Wordpress, Bootstrap, etc. See: https://bitsofco.de/the-new-system-font-stack/
+$font-family-base: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, "Helvetica Neue", sans-serif;
 // Patternfly defaults to 40px, which leaves a lot more whitespace than we're used to
 $grid-gutter-width: 30px;
 

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -9,7 +9,6 @@
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/variables";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins";
 @import '~patternfly/dist/sass/patternfly/bootstrap-mixin-overrides';
-@import '~patternfly/dist/sass/patternfly/fonts';
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/normalize";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/scaffolding";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/type";  // Including this file breaks sourcemaps


### PR DESCRIPTION
Replace web fonts with the system UI font stack. See https://bitsofco.de/the-new-system-font-stack/
 for more info.

- Reduces our build artifact from 11.3MB to 7.6MB.
- Improves load times by 10-20% depending on the browser.
- Avoids a re-flow once the web fonts are downloaded.
- Avoids an entire class of rendering bugs across platforms. (Web fonts may look good on mac, but we've had issues with kerning & hinting on other platforms. See https://github.com/coreos-inc/bridge/pull/2077)