### PR TITLE
Use Kubernetes Pagination for Lists

### DIFF
--- a/frontend/__tests__/module/k8s/k8s-actions.spec.ts
+++ b/frontend/__tests__/module/k8s/k8s-actions.spec.ts
@@ -1,0 +1,79 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import Spy = jasmine.Spy;
+
+import k8sActions, { types } from '../../../public/module/k8s/k8s-actions';
+import * as k8sResource from '../../../public/module/k8s/resource';
+import { K8sResourceKind } from '../../../public/module/k8s';
+import { PodModel } from '../../../public/models';
+import { testResourceInstance } from '../../../__mocks__/k8sResourcesMocks';
+
+describe(types.watchK8sList, () => {
+  const {watchK8sList} = k8sActions;
+  const id = 'some-redux-id';
+  let k8sList: Spy;
+  let websocket: {[method: string]: Spy};
+  let resourceList: {items: K8sResourceKind[], metadata: {resourceVersion: string, continue?: string}, kind: string, apiVersion: string};
+
+  beforeEach(() => {
+    websocket = {
+      onclose: jasmine.createSpy('onclose'),
+      ondestroy: jasmine.createSpy('ondestroy'),
+      onbulkmessage: jasmine.createSpy('onbulkmessage')
+    };
+    websocket.onclose.and.returnValue(websocket);
+    websocket.ondestroy.and.returnValue(websocket);
+    websocket.onbulkmessage.and.returnValue(websocket);
+
+    resourceList = {
+      apiVersion: testResourceInstance.apiVersion,
+      kind: `${testResourceInstance.kind}List`,
+      items: new Array(300).fill(testResourceInstance),
+      metadata: {resourceVersion: '10000000'},
+    };
+
+    k8sList = spyOn(k8sResource, 'k8sList').and.returnValue(Promise.resolve({}));
+    spyOn(k8sResource, 'k8sWatch').and.returnValue(websocket);
+  });
+
+  it('incrementally fetches lists until `continue` token is no longer returned in response', (done) => {
+    k8sList.and.callFake((k8sKind, params, raw) => {
+      expect(params.limit).toEqual(250);
+      if (k8sList.calls.count() > 1) {
+        expect(params.continue).toEqual('toNextPage');
+      }
+
+      resourceList.metadata.resourceVersion = (parseInt(resourceList.metadata.resourceVersion, 10) + 1).toString();
+      resourceList.metadata.continue = parseInt(resourceList.metadata.resourceVersion, 10) > 10000005 ? null : 'toNextPage';
+      return resourceList;
+    });
+
+    const dispatch = jasmine.createSpy('dispatch').and.callFake((action) => {
+      switch (action.type) {
+        case types.watchK8sList:
+          expect(action.id).toEqual(id);
+          expect(action.query).toEqual({});
+          break;
+        case types.bulkAddToList:
+          expect(action.k8sObjects).toEqual(resourceList.items);
+          expect(dispatch.calls.allArgs().filter(args => args[0].type === types.bulkAddToList).length).toEqual(k8sList.calls.count());
+          break;
+        case types.errored:
+          fail(action.k8sObjects);
+          break;
+        case types.loaded:
+          expect(k8sList.calls.count()).toEqual(1);
+          done();
+          break;
+        default:
+          break;
+      }
+    });
+
+    watchK8sList(id, {}, PodModel)(dispatch);
+  });
+
+  xit('stops incrementally fetching if `stopK8sWatch` action is dispatched', () => {
+    // TODO(alecmerdler)
+  });
+});

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -12,7 +12,6 @@ import { ErrorPage404 } from '../error';
 import { makeReduxID, makeQuery } from '../utils/k8s-watcher';
 import { referenceForModel } from '../../module/k8s';
 
-
 export const CompactExpandButtons = ({expand = false, onExpandChange = _.noop}) => <div className="btn-group btn-group-sm" data-toggle="buttons">
   <label className={classNames('btn compaction-btn', expand ? 'btn-default' : 'btn-primary')}>
     <input type="radio" onClick={() => onExpandChange(false)} /> Compact

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -236,7 +236,7 @@ FireMan_.propTypes = {
 
 /** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, namespace?: string, filterLabel?: string, title?: string, showTitle?: boolean, dropdownFilters?: any[], rowFilters?: any[], selector?: string, fieldSelector?: string, canCreate?: boolean, fake?: boolean}>} */
 export const ListPage = props => {
-  const {createButtonText, createHandler, filterLabel, kind, namespace, selector, name, fieldSelector, filters, showTitle = true, fake} = props;
+  const {createButtonText, createHandler, filterLabel, kind, namespace, selector, name, fieldSelector, filters, limit, showTitle = true, fake} = props;
   const ko = kindObj(kind);
   const {labelPlural, plural, namespaced, label} = ko;
   const title = props.title || labelPlural;
@@ -248,7 +248,7 @@ export const ListPage = props => {
     } catch (unused) { /**/ }
   }
   const createProps = createHandler ? {onClick: createHandler} : {to: href};
-  const resources = [{ kind, name, namespaced, selector, fieldSelector, filters }];
+  const resources = [{ kind, name, namespaced, selector, fieldSelector, filters, limit }];
 
   if (!namespaced && namespace) {
     return <ErrorPage404 />;

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { inject } from './index';
 import actions from '../../module/k8s/k8s-actions';
 
-
 export const makeReduxID = (k8sKind = {}, query) => {
   let qs = '';
   if (!_.isEmpty(query)) {

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -16,7 +16,8 @@ export const makeReduxID = (k8sKind = {}, query) => {
   return `${k8sKind.plural}${qs}`;
 };
 
-export const makeQuery = (namespace, labelSelector, fieldSelector, name) => {
+/** @type {(namespace: string, labelSelector: any, fieldSelector: any, name: string) => {[key: string]: string}} */
+export const makeQuery = (namespace, labelSelector, fieldSelector, name, limit) => {
   const query = {};
 
   if (!_.isEmpty(labelSelector)) {
@@ -33,6 +34,10 @@ export const makeQuery = (namespace, labelSelector, fieldSelector, name) => {
 
   if (fieldSelector) {
     query.fieldSelector = fieldSelector;
+  }
+
+  if (limit) {
+    query.limit = limit;
   }
   return query;
 };

--- a/frontend/public/module/k8s/k8s.js
+++ b/frontend/public/module/k8s/k8s.js
@@ -1,3 +1,0 @@
-export const getQN = ({metadata: {name, namespace}}) => (namespace ? `(${namespace})-` : '') + name;
-
-export const k8sBasePath = `${window.SERVER_FLAGS.basePath}api/kubernetes`;

--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -1,0 +1,7 @@
+/* eslint-disable no-unused-vars */
+
+import { K8sResourceKind } from './index';
+
+export const getQN: (obj: K8sResourceKind) => string = ({metadata: {name, namespace}}) => (namespace ? `(${namespace})-` : '') + name;
+
+export const k8sBasePath = `${(window as any).SERVER_FLAGS.basePath}api/kubernetes`;


### PR DESCRIPTION
### Description

Modifies the `watchK8sList` Redux action to use [basic k8s pagination](https://github.com/kubernetes/website/blob/master/content/en/docs/reference/api-concepts.md#retrieving-large-results-sets-in-chunks) to incrementally `fetch` the full list of k8s objects (set to `?limit=250`). This achieves a reduction in the _perceived_ load time for users with huge cluster workloads.

**Note:** Still needs `react-virtualized` components to address actual view performance.

### Screenshots

**Incremental loading (set `limit=20` for demo purposes):**
![console-pagination](https://user-images.githubusercontent.com/11700385/40394087-fe98ce26-5def-11e8-8a8a-3a3dd9d415fb.gif)

Addresses https://jira.coreos.com/browse/CONSOLE-377
