### PR TITLE
Env Var Editor: Reduce props and code to determine which object type is being edited

### DIFF
--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -9,7 +9,7 @@ import { BuildStrategy, Cog, LabelList, history, navFactory, ResourceCog, Resour
 import { BuildsPage } from './build';
 import { fromNow } from './utils/datetime';
 import { registerTemplate } from '../yaml-templates';
-import { EnvironmentPage, envVarsToArrayForObject } from './environment';
+import { EnvironmentPage } from './environment';
 
 // Pushes to the image stream created by the image stream YAML template.
 registerTemplate('build.openshift.io/v1.BuildConfig', `apiVersion: build.openshift.io/v1
@@ -72,13 +72,12 @@ export const BuildConfigsDetails: React.SFC<BuildConfigsDetailsProps> = ({obj: b
 
 const BuildsTabPage = ({obj: buildConfig}) => <BuildsPage namespace={buildConfig.metadata.namespace} showTitle={false} selector={{ 'openshift.io/build-config.name': buildConfig.metadata.name}} />;
 
+const envPath = ['spec', 'strategy', 'sourceStrategy'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
   rawEnvData={props.obj.spec.strategy.sourceStrategy}
-  envPath="/spec/strategy/sourceStrategy"
+  envPath={envPath}
   readOnly={false}
-  isBuildObject={true}
-  toArrayFn={envVarsToArrayForObject}
 />;
 
 const pages = [navFactory.details(BuildConfigsDetails), navFactory.editYaml(), navFactory.envEditor(environmentComponent), navFactory.builds(BuildsTabPage)];

--- a/frontend/public/components/daemonset.jsx
+++ b/frontend/public/components/daemonset.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { Cog, LabelList, ResourceCog, ResourceLink, ResourceSummary, Selector, navFactory, detailsPage } from './utils';
-import { EnvironmentPage, envVarsToArrayForArray } from './environment';
+import { EnvironmentPage } from './environment';
 import { registerTemplate } from '../yaml-templates';
 
 registerTemplate('apps/v1.DaemonSet', `apiVersion: apps/v1
@@ -72,13 +72,12 @@ const Details = ({obj: daemonset}) => <div className="co-m-pane__body">
   </div>
 </div>;
 
+const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
   rawEnvData={props.obj.spec.template.spec.containers}
-  envPath="/spec/template/spec/containers"
+  envPath={envPath}
   readOnly={false}
-  isBuildObject={false}
-  toArrayFn={envVarsToArrayForArray}
 />;
 
 const {details, pods, editYaml, envEditor} = navFactory;

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -8,7 +8,7 @@ import { DeploymentConfigModel } from '../models';
 import { DetailsPage, List, ListPage, WorkloadListHeader, WorkloadListRow } from './factory';
 import { Cog, DeploymentPodCounts, navFactory, LoadingInline, pluralize, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
-import { EnvironmentPage, envVarsToArrayForArray } from './environment';
+import { EnvironmentPage } from './environment';
 
 registerTemplate('apps.openshift.io/v1.DeploymentConfig', `apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
@@ -101,13 +101,12 @@ export const DeploymentConfigsDetails: React.SFC<{obj: any}> = ({obj: deployment
   </div>;
 };
 
+const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
   rawEnvData={props.obj.spec.template.spec.containers}
-  envPath="/spec/template/spec/containers"
+  envPath={envPath}
   readOnly={false}
-  isBuildObject={false}
-  toArrayFn={envVarsToArrayForArray}
 />;
 
 const pages = [navFactory.details(DeploymentConfigsDetails), navFactory.editYaml(), navFactory.pods(), navFactory.envEditor(environmentComponent)];

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -5,7 +5,7 @@ import { configureUpdateStrategyModal, configureRevisionHistoryLimitModal } from
 import { DetailsPage, List, ListPage, WorkloadListHeader, WorkloadListRow } from './factory';
 import { Cog, DeploymentPodCounts, navFactory, LoadingInline, pluralize, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
-import { EnvironmentPage, envVarsToArrayForArray } from './environment';
+import { EnvironmentPage } from './environment';
 
 registerTemplate('apps/v1.Deployment', `apiVersion: apps/v1
 kind: Deployment
@@ -79,13 +79,12 @@ const DeploymentDetails = ({obj: deployment}) => {
   </div>;
 };
 
+const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
   rawEnvData={props.obj.spec.template.spec.containers}
-  envPath="/spec/template/spec/containers"
+  envPath={envPath}
   readOnly={false}
-  isBuildObject={false}
-  toArrayFn={envVarsToArrayForArray}
 />;
 
 const {details, editYaml, pods, envEditor} = navFactory;

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -11,7 +11,7 @@ import { PodLogs } from './pod-logs';
 import { registerTemplate } from '../yaml-templates';
 import { Line } from './graphs';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
-import { EnvironmentPage, envVarsToArrayForArray } from './environment';
+import { EnvironmentPage } from './environment';
 
 const menuActions = [Cog.factory.EditEnvironment, ...Cog.factory.common];
 const validReadinessStates = new Set(['Ready', 'PodCompleted']);
@@ -235,13 +235,12 @@ const Details = ({obj: pod}) => {
   </React.Fragment>;
 };
 
+const envPath = ['spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
   rawEnvData={props.obj.spec.containers}
-  envPath="/spec/containers"
+  envPath={envPath}
   readOnly={true}
-  isBuildObject={false}
-  toArrayFn={envVarsToArrayForArray}
 />;
 
 /** @type {React.SFC<any>} */

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -4,7 +4,7 @@ import { DetailsPage, List, ListPage, WorkloadListHeader, WorkloadListRow } from
 import { Cog, navFactory, Heading, ResourceSummary, ResourcePodCount } from './utils';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { registerTemplate } from '../yaml-templates';
-import { EnvironmentPage, envVarsToArrayForArray } from './environment';
+import { EnvironmentPage } from './environment';
 
 registerTemplate('apps/v1.ReplicaSet', `apiVersion: apps/v1
 kind: ReplicaSet
@@ -44,13 +44,12 @@ const Details = ({obj: replicaSet}) => <React.Fragment>
   </div>
 </React.Fragment>;
 
+const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
   rawEnvData={props.obj.spec.template.spec.containers}
-  envPath="/spec/template/spec/containers"
+  envPath={envPath}
   readOnly={false}
-  isBuildObject={false}
-  toArrayFn={envVarsToArrayForArray}
 />;
 
 const {details, editYaml, pods, envEditor} = navFactory;

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -6,7 +6,7 @@ import { replicaSetMenuActions } from './replicaset';
 import { navFactory, Heading, ResourceSummary, ResourcePodCount } from './utils';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { registerTemplate } from '../yaml-templates';
-import { EnvironmentPage, envVarsToArrayForArray } from './environment';
+import { EnvironmentPage } from './environment';
 
 registerTemplate('v1.ReplicationController', `apiVersion: v1
 kind: ReplicationController
@@ -43,13 +43,12 @@ const Details = ({obj: replicationController}) => <React.Fragment>
   </div>
 </React.Fragment>;
 
+const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
   rawEnvData={props.obj.spec.template.spec.containers}
-  envPath="/spec/template/spec/containers"
+  envPath={envPath}
   readOnly={false}
-  isBuildObject={false}
-  toArrayFn={envVarsToArrayForArray}
 />;
 
 const {details, editYaml, pods, envEditor, events} = navFactory;

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { Cog, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
-import { EnvironmentPage, envVarsToArrayForArray } from './environment';
+import { EnvironmentPage } from './environment';
 
 registerTemplate('apps/v1.StatefulSet', `apiVersion: apps/v1
 kind: StatefulSet
@@ -67,13 +67,12 @@ const Details = ({obj: ss}) => <React.Fragment>
   </div>
 </React.Fragment>;
 
+const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
   rawEnvData={props.obj.spec.template.spec.containers}
-  envPath="/spec/template/spec/containers"
+  envPath={envPath}
   readOnly={false}
-  isBuildObject={false}
-  toArrayFn={envVarsToArrayForArray}
 />;
 
 export const StatefulSetsList = props => <List {...props} Header={Header} Row={Row} />;


### PR DESCRIPTION
1. Instead of using the isBuildObject prop to discern whether we have an array of containers with env, or just an env object we can
    a. just look at the rawEnvData to discern obj vs array ie _.isArray(rawEnvData)
    b. get rid of all the _.gets except for one
2. Similarly, the toArray fn is not necessary because we can do the same check as above in the conversion function to decide how to parse the incoming data.

No functional changes introduced.

https://jira.coreos.com/browse/CONSOLE-466

Update to pass in variable with array path instead of passing directly.