### PR TITLE
Better Firehose

### DIFF
--- a/frontend/__tests__/components/cloud-services/clusterserviceversion-resource.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/clusterserviceversion-resource.spec.tsx
@@ -302,6 +302,7 @@ describe(ClusterServiceVersionPrometheusGraph.displayName, () => {
 });
 
 describe('ResourcesList', () => {
+
   it('uses the resources defined in the CSV', () => {
     const kindObj: K8sKind = {
       abbr: '',

--- a/frontend/__tests__/components/cloud-services/create-crd-yaml.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/create-crd-yaml.spec.tsx
@@ -25,41 +25,45 @@ describe(CreateCRDYAML.displayName, () => {
   });
 
   it('renders a `Firehose` for the ClusterServiceVersion', () => {
-    expect(wrapper.find<any>(Firehose).props().resources).toEqual([
+    expect(wrapper.shallow().find(Firehose).props().resources).toEqual([
       {kind: referenceForModel(ClusterServiceVersionModel), name: 'example', namespace: 'default', isList: false, prop: 'ClusterServiceVersion'}
     ]);
   });
 
   it('renders YAML editor component', () => {
-    wrapper = wrapper.setProps({ClusterServiceVersion: {loaded: true, data: _.cloneDeep(testClusterServiceVersion)}} as any);
+    const render = wrapper.find('CreateCRDYAMLFirehose').prop<Function>('render');
+    wrapper = shallow(<div>{render({ClusterServiceVersion: {loaded: true, data: _.cloneDeep(testClusterServiceVersion)}})}</div>);
 
-    expect(wrapper.find(Firehose).childAt(0).dive().find(CreateYAML).exists()).toBe(true);
+    expect(wrapper.childAt(0).shallow().find(CreateYAML).exists()).toBe(true);
   });
 
   it('registers example YAML templates using annotations on the ClusterServiceVersion', () => {
     let data = _.cloneDeep(testClusterServiceVersion);
     data.metadata.annotations = {'alm-examples': JSON.stringify([testResourceInstance])};
-    wrapper = wrapper.setProps({ClusterServiceVersion: {loaded: true, data}} as any);
+    const render = wrapper.find('CreateCRDYAMLFirehose').prop<Function>('render');
+    wrapper = shallow(<div>{render({ClusterServiceVersion: {loaded: true, data}})}</div>);
 
-    wrapper.find(Firehose).childAt(0).dive();
+    wrapper.childAt(0).dive();
 
     expect(registerTemplateSpy.calls.count()).toEqual(1);
     expect(registerTemplateSpy.calls.argsFor(0)[1]).toEqual(safeDump(testResourceInstance));
   });
 
   it('registers fallback example YAML template if annotations not present on ClusterServiceVersion', () => {
-    wrapper = wrapper.setProps({ClusterServiceVersion: {loaded: true, data: _.cloneDeep(testClusterServiceVersion)}} as any);
+    const render = wrapper.find('CreateCRDYAMLFirehose').prop<Function>('render');
+    wrapper = shallow(<div>{render({ClusterServiceVersion: {loaded: true, data: _.cloneDeep(testClusterServiceVersion)}})}</div>);
 
-    wrapper.find(Firehose).childAt(0).dive();
+    wrapper.childAt(0).dive();
 
     expect(registerTemplateSpy.calls.count()).toEqual(1);
     expect(registerTemplateSpy.calls.argsFor(0)[1]).not.toEqual(safeDump(testResourceInstance));
   });
 
   it('does not render YAML editor component if ClusterServiceVersion has not loaded yet', () => {
-    wrapper = wrapper.setProps({ClusterServiceVersion: {loaded: false}} as any);
+    const render = wrapper.find('CreateCRDYAMLFirehose').prop<Function>('render');
+    wrapper = shallow(<div>{render({ClusterServiceVersion: {loaded: false}})}</div>);
 
-    expect(wrapper.find(Firehose).childAt(0).dive().find(CreateYAML).exists()).toBe(false);
-    expect(wrapper.find(Firehose).childAt(0).dive().find(LoadingBox).exists()).toBe(true);
+    expect(wrapper.childAt(0).dive().find(CreateYAML).exists()).toBe(false);
+    expect(wrapper.childAt(0).dive().find(LoadingBox).exists()).toBe(true);
   });
 });

--- a/frontend/__tests__/components/utils/firehose.spec.tsx
+++ b/frontend/__tests__/components/utils/firehose.spec.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable no-unused-vars, no-undef */
+
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import * as _ from 'lodash-es';
+
+import { Firehose, FirehoseResource, firehoseFor } from '../../../public/components/utils';
+
+describe('firehoseFor', () => {
+  type ComponentProps = {pods: any, namespace: string};
+  let resources: {pods: FirehoseResource};
+  const Component: React.SFC<ComponentProps> = (props) => <span>{props.pods.loaded}</span>;
+
+  beforeEach(() => {
+    resources = {
+      pods: {kind: 'Pod', isList: true},
+    };
+  });
+
+  it('returns a component which accepts a render callback', (done) => {
+    const FirehosedComponent = firehoseFor(resources);
+    const render = () => {
+      done();
+      return <div />;
+    };
+
+    shallow(<FirehosedComponent render={render} />).childAt(0).dive();
+  });
+
+  it('wraps render callback component in a `Firehose`', () => {
+    const FirehosedComponent = firehoseFor(resources);
+    const wrapper = shallow(<FirehosedComponent render={(props) => <Component namespace="default" pods={props.pods} />} />);
+
+    expect(wrapper.find(Firehose).childAt(0).shallow().find(Component).exists()).toBe(true);
+  });
+
+  it('passes `resources` to `Firehose` component', () => {
+    const FirehosedComponent = firehoseFor(resources);
+    const wrapper = shallow(<FirehosedComponent render={(props) => <Component namespace="default" pods={props.pods} />} />);
+
+    expect(wrapper.find(Firehose).props().resources).toEqual(_.map(resources, (res, prop) => ({...res, prop})));
+  });
+});

--- a/frontend/public/components/cloud-services/create-crd-yaml.tsx
+++ b/frontend/public/components/cloud-services/create-crd-yaml.tsx
@@ -5,7 +5,7 @@ import { safeDump } from 'js-yaml';
 import { match } from 'react-router-dom';
 import * as _ from 'lodash-es';
 
-import { Firehose, LoadingBox } from '../utils';
+import { firehoseFor, LoadingBox } from '../utils';
 import { CreateYAML } from '../create-yaml';
 import { referenceForModel, K8sResourceKind, K8sResourceKindReference, kindForReference, apiVersionForReference } from '../../module/k8s';
 import { ClusterServiceVersionModel } from '../../models';
@@ -18,6 +18,17 @@ import { ocsTemplates } from './ocs-templates';
  */
 export const CreateCRDYAML: React.SFC<CreateCRDYAMLProps> = (props) => {
   const annotationKey = 'alm-examples';
+
+  const CreateCRDYAMLFirehose = firehoseFor({
+    ClusterServiceVersion: {
+      kind: referenceForModel(ClusterServiceVersionModel),
+      name: props.match.params.appName,
+      namespace: props.match.params.ns,
+      isList: false,
+      prop: 'ClusterServiceVersion'
+    }
+  });
+  CreateCRDYAMLFirehose.displayName = 'CreateCRDYAMLFirehose';
 
   const Create = (createProps: {ClusterServiceVersion: {loaded: boolean, data: ClusterServiceVersionKind}}) => {
     if (createProps.ClusterServiceVersion.loaded && createProps.ClusterServiceVersion.data) {
@@ -34,15 +45,9 @@ export const CreateCRDYAML: React.SFC<CreateCRDYAMLProps> = (props) => {
     return <LoadingBox />;
   };
 
-  return <Firehose resources={[{
-    kind: referenceForModel(ClusterServiceVersionModel),
-    name: props.match.params.appName,
-    namespace: props.match.params.ns,
-    isList: false,
-    prop: 'ClusterServiceVersion'
-  }]}>
-    <Create {...props as any} />
-  </Firehose>;
+  return <CreateCRDYAMLFirehose render={({ClusterServiceVersion}) =>
+    <Create ClusterServiceVersion={ClusterServiceVersion} />
+  } />;
 };
 
 export type CreateCRDYAMLProps = {

--- a/frontend/public/components/create-yaml.tsx
+++ b/frontend/public/components/create-yaml.tsx
@@ -6,7 +6,7 @@ import { safeLoad } from 'js-yaml';
 import { TEMPLATES } from '../yaml-templates';
 import { connectToPlural } from '../kinds';
 import { AsyncComponent } from './utils/async';
-import { Firehose, LoadingBox } from './utils';
+import { LoadingBox, firehoseFor } from './utils';
 import { K8sKind, apiVersionForModel } from '../module/k8s';
 import { ErrorPage404 } from './error';
 import { ClusterServiceVersionModel } from '../models';
@@ -51,9 +51,14 @@ export const CreateYAML = connectToPlural((props: CreateYAMLProps) => {
 
 export const EditYAMLPage: React.SFC<EditYAMLPageProps> = (props) => {
   const Wrapper = (wrapperProps) => <AsyncComponent {...wrapperProps} obj={wrapperProps.obj.data} loader={() => import('./edit-yaml').then(c => c.EditYAML)} create={false} showHeader={true} />;
-  return <Firehose resources={[{kind: props.kind, name: props.match.params.name, namespace: props.match.params.ns, isList: false, prop: 'obj'}]}>
-    <Wrapper />
-  </Firehose>;
+  const EditYAMLPageFirehose = firehoseFor({
+    obj: {kind: props.kind, name: props.match.params.name, namespace: props.match.params.ns, isList: false},
+  });
+  EditYAMLPageFirehose.displayName = 'EditYAMLPageFirehose';
+
+  return <EditYAMLPageFirehose render={({obj}) =>
+    <Wrapper obj={obj} />
+  } />;
 };
 
 /* eslint-disable no-undef */


### PR DESCRIPTION
### Description

Introduces `firehoseFor` factory function, which returns a `Firehose`-like component that accepts a render callback and provides type autocompletion based on the `resources` provided.

### Changes

- [x] Add types to existing `firehose` module
- [x] Add `firehoseFor` factory function and tests
- [x] Convert all `<Firehose>` instances in TypeScript components to `firehoseFor`

Addresses https://jira.coreos.com/browse/CONSOLE-327
Previously https://github.com/coreos-inc/bridge/pull/2189