### PR TITLE
Add secret's type to the SecretRow and SecretDetails

### DIFF
--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -19,10 +19,11 @@ data:
 const menuActions = Cog.factory.common;
 
 const SecretHeader = props => <ListHeader>
-  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
-  <ColHead {...props} className="col-sm-2 hidden-xs" sortFunc="dataSize">Size</ColHead>
-  <ColHead {...props} className="col-sm-2 hidden-xs" sortField="metadata.creationTimestamp">Created</ColHead>
+  <ColHead {...props} className="col-md-3 col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-md-3 col-sm-4 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
+  <ColHead {...props} className="col-md-3 col-sm-4 hidden-xs" sortField="type">Type</ColHead>
+  <ColHead {...props} className="col-md-1 hidden-sm hidden-xs" sortFunc="dataSize">Size</ColHead>
+  <ColHead {...props} className="col-md-2 hidden-sm hidden-xs" sortField="metadata.creationTimestamp">Created</ColHead>
 </ListHeader>;
 
 const SecretRow = ({obj: secret}) => {
@@ -30,15 +31,16 @@ const SecretRow = ({obj: secret}) => {
   const age = fromNow(secret.metadata.creationTimestamp);
 
   return <ResourceRow obj={secret}>
-    <div className="col-sm-4 col-xs-6">
+    <div className="col-md-3 col-sm-4 col-xs-6">
       <ResourceCog actions={menuActions} kind="Secret" resource={secret} />
       <ResourceLink kind="Secret" name={secret.metadata.name} namespace={secret.metadata.namespace} title={secret.metadata.uid} />
     </div>
-    <div className="col-sm-4 col-xs-6">
+    <div className="col-md-3 col-sm-4 col-xs-6">
       <ResourceLink kind="Namespace" name={secret.metadata.namespace} title={secret.metadata.namespace} />
     </div>
-    <div className="col-sm-2 hidden-xs">{data}</div>
-    <div className="col-sm-2 hidden-xs">{age}</div>
+    <div className="col-md-3 col-sm-4 hidden-xs">{secret.type}</div>
+    <div className="col-md-1 hidden-sm hidden-xs">{data}</div>
+    <div className="col-md-2 hidden-sm hidden-xs">{age}</div>
   </ResourceRow>;
 };
 

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -15,7 +15,7 @@ export const Heading: React.SFC<HeadingProps> = ({text, children}) => <div class
 </div>;
 
 export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, resource, showPodSelector = true, showNodeSelector = true, showAnnotations = true, podSelector = 'spec.selector'}) => {
-  const { metadata } = resource;
+  const { metadata, type } = resource;
   const owners = (_.get(metadata, 'ownerReferences') || [])
     .map((o, i) => <ResourceLink key={i} kind={referenceForOwnerRef(o)} name={o.name} namespace={metadata.namespace} title={o.uid} />);
 
@@ -24,6 +24,8 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, reso
     <dd>{metadata.name || '-'}</dd>
     { metadata.namespace ? <dt>Namespace</dt> : null }
     { metadata.namespace ? <dd><ResourceLink kind="Namespace" name={metadata.namespace} title={metadata.uid} namespace={null} /></dd> : null }
+    { type ? <dt>Type</dt> : null }
+    { type ? <dd>{type}</dd> : null }
     <dt>Labels</dt>
     <dd><LabelList kind={resource.kind} labels={metadata.labels} /></dd>
     {showPodSelector && <dt>Pod Selector</dt>}

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -34,6 +34,7 @@ export type K8sResourceKind = {
     [key: string]: any
   };
   status?: {[key: string]: any};
+  type?: {[key: string]: any};
 };
 
 export type CustomResourceDefinitionKind = {


### PR DESCRIPTION
Secret's key is one of the key fields for the secrets list and browse page, so it should be shown.

Attaching screens:
- List page
![download](https://user-images.githubusercontent.com/1668218/40007227-7e68a270-579c-11e8-9fd8-56e9e2c6c3e4.png)

- Browse page
![download 1](https://user-images.githubusercontent.com/1668218/40007237-84edbbda-579c-11e8-803e-e4afa159036b.png)


@ggreer @spadgett PTAL