### PR TITLE
Fix YAML Autocomplete

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -67,7 +67,7 @@ export const EditYAML = connect(stateToProps)(
       // Retrieve k8s API spec for autocompletion
       if (!window.sessionStorage.getItem(`${window.SERVER_FLAGS.consoleVersion}--swagger.json`)) {
         coFetchJSON('api/kubernetes/swagger.json')
-          .then(swagger => window.localStorage.setItem(`${window.SERVER_FLAGS.consoleVersion}--swagger.json`, JSON.stringify(swagger)));
+          .then(swagger => window.sessionStorage.setItem(`${window.SERVER_FLAGS.consoleVersion}--swagger.json`, JSON.stringify(swagger)));
       }
     }
 


### PR DESCRIPTION
### Description

Accidentally was calling `localStorage.setItem()` but `sessionStorage.getItem()`...
This is why we write unit tests.

Addresses my lack of attention to details.