### PR TITLE
Port OpenShift log viewer styles to Tectonic log window

### DIFF
--- a/frontend/public/components/_log-window.scss
+++ b/frontend/public/components/_log-window.scss
@@ -1,33 +1,43 @@
-.log-area {
-  box-shadow: inset 0px 3px 5px 0px rgba(0,0,0,0.75);
-  font-size: 13px;
-  background-color: #333;
-  position: relative;
+// vars
+$color-log-window-body-bg: $color-pf-black;
+$color-log-window-header-bg: $color-pf-black-900;
+$color-log-window-text: $color-pf-black-150;
+$font-family-log-window-body: $font-family-monospace;
+$color-log-window-divider: $color-log-window-header-bg;
+
+.log-window {
+  color: $color-log-window-text;
 }
 
-.log-scroll-pane {
+.log-window__header {
+  background-color: $color-log-window-header-bg;
+  padding: 8px 10px 5px 10px;
+}
+
+.log-window__body {
+  background-color: $color-log-window-body-bg;
+  font-family: $font-family-log-window-body;
+}
+
+.log-window__scroll-pane {
   overflow: auto;
   padding-top: 10px;
 }
 
-.log-contents__block {
-  padding: 0px 10px;
+.log-window__contents__text{
+  padding-left: 10px;
+  padding-right: 10px;
   white-space: pre;
   width: 0;
 }
 
-.log-contents__block--divider {
-  border-bottom: 1px solid $color-border-brown;
+.log-window__contents__text--divider {
+  border-bottom: 1px solid $color-log-window-divider;
 }
 
-.log-paused-pane {
-  min-height: 30px;
-}
-
-.log-paused-pane__contents {
-  text-align: center;
-  background-color: #555;
-  padding: 4px 10px 4px 10px;
-  font-size: 13px;
+.log-window__footer {
+  background-color: $color-log-window-header-bg;
   cursor: pointer;
+  padding: 4px 10px;
+  text-align: center;
 }

--- a/frontend/public/components/_pod-logs.scss
+++ b/frontend/public/components/_pod-logs.scss
@@ -1,13 +1,3 @@
-.log-pane {
-  color: #fff;
-}
-
-.log-pane__header {
-  background-color: #555;
-  padding: 8px 10px 5px 10px;
-  font-size: 13px;
-}
-
 .log-container-selector__text {
   padding-left: 15px;
   padding-right: 15px;

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -53,13 +53,13 @@ $color-text-muted: $co-gray;
 $color-text-secondary: $color-grey-medium;
 
 //OpenShift color variables
-$color-os-nav-title: #d1d1d1;
-$color-os-nav-background: #2A2E34;
-$color-os-nav-background-active: #383f47;
-$color-os-nav-item-seperator: #050505;
-$color-os-nav-active: #383f47;
+$color-os-nav-title: #d1d1d1; // why not $color-pf-black-300
+$color-os-nav-background: #2A2E34; // why not $color-pf-black-900
+$color-os-nav-background-active: #383f47; // why not $color-pf-black-800
+$color-os-nav-item-seperator: #050505; // why not $color-pf-black
+$color-os-nav-active: #383f47; // why not $color-pf-black-800
 $color-os-nav-hover: lighten($color-os-nav-active, 8%);
-$color-os-nav-border-left-active: #39a5dc;
+$color-os-nav-border-left-active: #39a5dc; // why not $color-pf-blue-300
 
 // Patternfly defaults to dark gray. Override with black. Body text color is lighten()ed to #333
 $color-pf-black: black;


### PR DESCRIPTION
# Description
Update Tectonic log window styling to match more closely to the OpenShift web console log viewer. 
JIRA: https://jira.coreos.com/browse/CONSOLE-399

# Screen Shot
![screenshot-localhost-9000-2018 05 15-10-39-02](https://user-images.githubusercontent.com/22625502/40063908-60f6a51c-582c-11e8-994c-bae71f1649e5.png)

# Changes
- Simplify and refactor DOM structure and CSS class names
- Change log window body text to monospace font family
- Change log window body background and text colors to comparable OpenShift log viewer colors
- Change log window header and footer background colors to same as vertical nav background color