### PR TITLE
Fix padding on .co-clusterserviceversion-list__title at mobile

### DIFF
--- a/frontend/public/components/cloud-services/_cloud-services.scss
+++ b/frontend/public/components/cloud-services/_cloud-services.scss
@@ -32,7 +32,11 @@ $clusterserviceversion-list-border: #ccc;
 .co-clusterserviceversion-list__title {
   margin-bottom: 0;
   margin-top: 30px;
-  padding: 0 30px;
+  padding: 0 ($grid-gutter-width / 2);
+  @media(min-width: $grid-float-breakpoint) {
+    padding-left: $grid-gutter-width;
+    padding-right: $grid-gutter-width;
+  }
 }
 
 .co-clusterserviceversion-logo {


### PR DESCRIPTION
Before:
![screen shot 2018-05-15 at 1 51 45 pm](https://user-images.githubusercontent.com/895728/40074270-2ee9f7f2-5847-11e8-98a5-fab72608af0b.PNG)

After:
![screen shot 2018-05-15 at 1 51 29 pm](https://user-images.githubusercontent.com/895728/40074281-356d08d0-5847-11e8-988b-dacc412a6910.PNG)
