### PR TITLE
Fix bug where timeline border appeared when empty

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -25,13 +25,6 @@ $color-dark-border: #ddd;
   top: 35px;
 }
 
-.co-sysevent-stream__timeline--empty {
-  border: none;
-  .co-sysevent-stream__timeline__end-message {
-    display: none;
-  }
-}
-
 .co-sysevent-stream__status {
   display: flex;
   justify-content: space-between;
@@ -58,6 +51,9 @@ $color-dark-border: #ddd;
   transform: translateY(50%);
   white-space: nowrap;
   z-index: 1;
+  .co-sysevent-stream__timeline--empty & {
+    display: none;
+  }
 }
 
 .co-sysevent-stream__timeline__btn {
@@ -160,6 +156,9 @@ $color-dark-border: #ddd;
     border-bottom: 3px solid $color-grey-border;
     border-left: 3px solid $color-grey-border;
     margin-left: 10px;
+    &--empty {
+      border: 0;
+    }
   }
 
   .co-sysevent-stream__timeline__btn {


### PR DESCRIPTION
I introduced this regression in https://github.com/openshift/console/pull/11/files.  SMH

Before:
![screen shot 2018-05-15 at 4 27 14 pm](https://user-images.githubusercontent.com/895728/40081773-01d5d4aa-585d-11e8-8442-a410a8238ce0.PNG)

After:
![screen shot 2018-05-15 at 4 26 57 pm](https://user-images.githubusercontent.com/895728/40081783-0677e5b6-585d-11e8-8f07-448979c11e9c.PNG)
