### PR TITLE
Toggle between secret's data visibility

### DIFF
--- a/frontend/public/components/configmap-and-secret-data.jsx
+++ b/frontend/public/components/configmap-and-secret-data.jsx
@@ -1,15 +1,53 @@
 import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import { Heading } from './utils';
 
-const ConfigMapAndSecretData = ({data, decode}) => {
-  decode = decode || (v => v);
-
+export const ConfigMapData = ({data}) => {
   const dl = [];
-  Object.keys(data || []).sort().forEach(k => {
+  Object.keys(data || {}).sort().forEach(k => {
     dl.push(<dt key={`${k}-k`}>{k}</dt>);
-    dl.push(<dd key={`${k}-v`}><pre className="co-pre-wrap">{decode(data[k])}</pre></dd>);
+    dl.push(<dd key={`${k}-v`}><pre className="co-pre-wrap">{data[k]}</pre></dd>);
   });
 
   return <dl>{dl}</dl>;
 };
 
-export default ConfigMapAndSecretData;
+export class SecretData extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = { showSecret: false };
+    this.toggleSecret = this.toggleSecret.bind(this);
+  }
+
+  toggleSecret() {
+    this.setState({ showSecret: !this.state.showSecret });
+  }
+
+  render() {
+    const { data } = this.props;
+    const { showSecret } = this.state;
+    const dl = [];
+    const masked = <React.Fragment>
+      <span className="sr-only">value hidden</span>
+      <span aria-hidden="true">&bull;&bull;&bull;&bull;&bull;</span>
+    </React.Fragment>;
+    Object.keys(data).sort().forEach(k => {
+      dl.push(<dt key={`${k}-k`}>{k}</dt>);
+      dl.push(<dd key={`${k}-v`}><pre className="co-pre-wrap">{showSecret ? window.atob(data[k]) : masked}</pre></dd>);
+    });
+    return <React.Fragment>
+      <Heading text="Data" >
+        <button className="btn btn-link" type="button" onClick={this.toggleSecret}>{showSecret ? 'Hide Values' : 'Reveal Values'}</button>
+      </Heading>
+      <dl>{dl}</dl>
+    </React.Fragment>;
+  }
+}
+
+SecretData.propTypes = {
+  data: PropTypes.object
+};
+
+SecretData.defaultProps = {
+  data: {}
+};

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import ConfigMapAndSecretData from './configmap-and-secret-data';
+import { ConfigMapData } from './configmap-and-secret-data';
 import { Cog, Heading, navFactory, ResourceCog, ResourceLink, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
 import { fromNow } from './utils/datetime';
@@ -49,7 +49,7 @@ const ConfigMapDetails = ({obj: configMap}) => {
     </div>
     <div className="co-m-pane__body">
       <Heading text="Data" />
-      <ConfigMapAndSecretData data={configMap.data} />
+      <ConfigMapData data={configMap.data} />
     </div>
   </React.Fragment>;
 };

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -2,8 +2,8 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import ConfigMapAndSecretData from './configmap-and-secret-data';
-import { Cog, Heading, ResourceCog, ResourceLink, ResourceSummary, detailsPage, navFactory } from './utils';
+import { SecretData } from './configmap-and-secret-data';
+import { Cog, ResourceCog, ResourceLink, ResourceSummary, detailsPage, navFactory } from './utils';
 import { fromNow } from './utils/datetime';
 import { registerTemplate } from '../yaml-templates';
 
@@ -50,8 +50,7 @@ const SecretDetails = ({obj: secret}) => {
       <ResourceSummary resource={secret} showPodSelector={false} showNodeSelector={false} />
     </div>
     <div className="co-m-pane__body">
-      <Heading text="Data" />
-      <ConfigMapAndSecretData data={secret.data} decode={window.atob} />
+      <SecretData data={secret.data} type={secret.type} />
     </div>
   </React.Fragment>;
 };


### PR DESCRIPTION
The secret's key values should be hidden by default and shown only on demand, similarly to what we did in the origin-web-console.
For that reason I've added `Reveal Secret / Hide Secret `  link next to the secret's `Data` section header. On clicking the actual value of the secret's keys will be revealed to the user. Clicking again will hide all the values.
By this I've decoupled `ConfigMapAndSecretData` into `ConfigMapData` and `SecretData`, each handling it's own part.
Screen:
![download](https://user-images.githubusercontent.com/1668218/40121525-12a8b0f2-5922-11e8-9cee-d5a52c255eb1.png)

Video:
![tectonic](https://user-images.githubusercontent.com/1668218/40121581-2ef2a61e-5922-11e8-8899-aacc01e8d4d9.gif)

@spadgett PTAL