### PR TITLE
Openssl base64 won't work on long strings without the -A flag...

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If the CA bundle of the OpenShift API server is unavailable, fetch the CA certif
 
 ```
 oc get secrets -n default --field-selector type=kubernetes.io/service-account-token -o json | \
-    jq '.items[0].data."service-ca.crt"' -r | openssl base64 -d > examples/ca.crt
+    jq '.items[0].data."service-ca.crt"' -r | python -m base64 -d > examples/ca.crt
 # Note: use "openssl base64" because the "base64" tool is different between mac and linux
 ```
 


### PR DESCRIPTION
This is crazy enough that I prefer we use python instead.

> warning base64 line length is limited to 76 characters by default in openssl ( and generated with 64 characters / line ).... to be able to decode a base64 line without line feed that exceed 76 characters use -A option 

https://wiki.openssl.org/index.php/Command_Line_Utilities#Base64