### PR TITLE
YAML editor: enable word wrap

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -37,7 +37,7 @@ export const config: Config = {
         '--disable-gpu',
         '--headless',
         '--no-sandbox',
-        '--window-size=1400,1050',
+        '--window-size=1920,1200',
         '--disable-background-timer-throttling',
         '--disable-renderer-backgrounding',
         '--disable-raf-throttling'

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -151,8 +151,7 @@ export const EditYAML = connect(stateToProps)(
         const es = this.ace.getSession();
         es.setMode('ace/mode/yaml');
         this.ace.setTheme('ace/theme/clouds');
-        // Disable line wrap so that our tests pass on small screens.
-        es.setUseWrapMode(false);
+        es.setUseWrapMode(true);
         this.doc = es.getDocument();
       }
       let yaml;


### PR DESCRIPTION
We only disabled word wrap to fix tests. Turns out we can have working tests and word wrap.