### PR TITLE
Implement build logs

### DIFF
--- a/frontend/__tests__/line-buffer.js
+++ b/frontend/__tests__/line-buffer.js
@@ -1,10 +1,10 @@
-import { lineBuffer } from '../public/components/utils/line-buffer';
+import { LineBuffer } from '../public/components/utils/line-buffer';
 
 describe('lineBuffer', () => {
   let buffer;
 
   beforeEach(() => {
-    buffer = lineBuffer(3);
+    buffer = new LineBuffer(3);
   });
 
   it('should allow no newlines', () => {

--- a/frontend/public/components/_pod-logs.scss
+++ b/frontend/public/components/_pod-logs.scss
@@ -1,4 +1,0 @@
-.log-container-selector__text {
-  padding-left: 15px;
-  padding-right: 15px;
-}

--- a/frontend/public/components/_toggle-play.scss
+++ b/frontend/public/components/_toggle-play.scss
@@ -8,11 +8,11 @@
 
   // play icon
   &.co-toggle-play--inactive:before {
-    content: "\f04b";
+    content: $fa-var-play;
   }
   // pause icon
   &.co-toggle-play--active:before {
-    content: "\f04c";
+    content: $fa-var-pause;
   }
 
   &.co-toggle-play--active {

--- a/frontend/public/components/build-logs.jsx
+++ b/frontend/public/components/build-logs.jsx
@@ -1,0 +1,33 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+
+import { ResourceLog } from './utils';
+
+export class BuildLogs extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      eof: false
+    };
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const eof = ['Complete', 'Failed', 'Error', 'Cancelled'].includes(_.get(nextProps.obj, 'status.phase'));
+    if (prevState.eof !== eof){
+      return {eof};
+    }
+    return null;
+  }
+
+  render() {
+    const namespace = _.get(this.props.obj, 'metadata.namespace');
+    const buildName = _.get(this.props.obj, 'metadata.name');
+    return <div className="co-m-pane__body">
+      <ResourceLog
+        eof={this.state.eof}
+        kind="Build"
+        namespace={namespace}
+        resourceName={buildName} />
+    </div>;
+  }
+}

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -10,6 +10,7 @@ import { BuildStrategy, Cog, history, navFactory, ResourceCog, ResourceLink, res
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { fromNow } from './utils/datetime';
 import { EnvironmentPage } from './environment';
+import { BuildLogs } from './build-logs';
 
 const BuildsReference: K8sResourceKindReference = 'Build';
 
@@ -68,7 +69,7 @@ const environmentComponent = (props) => <EnvironmentPage
   readOnly={true}
 />;
 
-const pages = [navFactory.details(BuildsDetails), navFactory.editYaml(), navFactory.envEditor(environmentComponent)];
+const pages = [navFactory.details(BuildsDetails), navFactory.editYaml(), navFactory.envEditor(environmentComponent), navFactory.logs(BuildLogs)];
 export const BuildsDetailsPage: React.SFC<BuildsDetailsPageProps> = props =>
   <DetailsPage
     {...props}

--- a/frontend/public/components/pod-logs.jsx
+++ b/frontend/public/components/pod-logs.jsx
@@ -1,194 +1,67 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 
-import { resourceURL } from '../module/k8s';
-import { PodModel } from '../models';
-import { SafetyFirst } from './safety-first';
-import { Dropdown, LoadingInline, LogWindow, ResourceIcon, TogglePlay, lineBuffer, stream } from './utils';
+import { Dropdown, LoadingInline, ResourceLog, ResourceName } from './utils';
 
-const dataHasFailureMsg = (data) => {
-  return _.includes(data, '"status": "Failure"');
+// Component to container dropdown or conatiner name if only one container in pod.
+const ContainerDropdown = ({currentContainer, containers, kind, onChange}) => {
+  const resourceName = (container) => <ResourceName name={container.name || <LoadingInline />} kind={kind} />;
+  const dropdownItems = _.mapValues(containers, resourceName);
+  return <Dropdown className="btn-group" items={dropdownItems} title={resourceName(currentContainer)} onChange={onChange} />;
 };
 
-const dataHasHTML = (data) => {
-  return _.includes(data, '<html') || _.includes(data, '<HTML');
-};
-
-export class PodLogs extends SafetyFirst {
+export class PodLogs extends React.Component {
   constructor(props) {
     super(props);
-
-    this._buffer = lineBuffer(1000);
-    this._loadTime = Date.now();
-    this._pendingReload = null;
-
-    this._touchLoadTimeState = _.throttle(this._touchLoadTimeState, 100);
     this._selectContainer = this._selectContainer.bind(this);
-    this._updateLogState = this._updateLogState.bind(this);
-    this._toggleLogState = this._toggleLogState.bind(this);
 
     this.state = {
-      containerNames: [],
-      currentContainer: '',
-      logURL: '',
-      loadTime: 0,
-      logState: 'loading'
+      containers: [],
+      currentContainer: null,
     };
-    this.state = _.defaults({}, this._initialState(), this.state);
   }
 
-  componentDidMount() {
-    super.componentDidMount();
-    this._beginStreaming();
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.setState(this._initialState(nextProps.obj));
-  }
-
-  componentWillUnmount() {
-    super.componentWillUnmount();
-    this._endStreaming();
-  }
-
-  _initialState(obj = this.props.obj) {
+  static getDerivedStateFromProps(nextProps, prevState) {
     const newState = {};
-
-    const containers = _.get(obj, 'spec.containers', []);
-    newState.containerNames = _.map(containers, 'name');
-
-    if (!this.state.currentContainer && newState.containerNames.length > 0) {
-      newState.currentContainer = newState.containerNames[0];
-    }
-
-    const currentContainer = newState.currentContainer || this.state.currentContainer;
-    newState.logURL = this._logURL(obj, currentContainer);
-
-    return newState;
-  }
-
-  _logURL(obj, currentContainer) {
-    return resourceURL(PodModel, {
-      ns: _.get(obj, 'metadata.namespace'),
-      name: _.get(obj, 'metadata.name'),
-      path: 'log',
-      queryParams: {
-        container: currentContainer,
-        follow: 'true',
-        tailLines: this._buffer.maxSize
-      }
+    const containers = _.get(nextProps.obj, 'status.containerStatuses', []);
+    newState.containers = _.map(containers, (container) => {
+      return {
+        name: container.name,
+        eof: !_.isEmpty(container.state.terminated)
+      };
     });
+
+    newState.currentContainer = prevState.currentContainer || newState.containers[0];
+    if( !_.isEqual(prevState.currentContainer, newState.currentContainer)
+        || !_.isEqual(prevState.containers, newState.containers)) {
+      return newState;
+    }
+    return null;
   }
 
   _selectContainer(index) {
-    this._endStreaming();
-    this._buffer = lineBuffer(1000);
-    const currentContainer = this.state.containerNames[index];
-    this.setState({
-      currentContainer,
-      logURL: this._logURL(this.props.obj, currentContainer),
-      logState: 'loading'
-    }, this._beginStreaming);
-  }
-
-  _updateLogState(newState) {
-    this.setState({
-      logState: newState
-    });
-  }
-
-  _toggleLogState() {
-    this.setState({
-      logState: this.state.logState === 'streaming' ? 'paused' : 'streaming'
-    });
-  }
-
-  _touchLoadTime() {
-    this._touchLoadTimeState();
-    this._loadTime = Date.now();
-  }
-
-  // separate function so that it can be throttled
-  _touchLoadTimeState() {
-    this.setState({
-      loadTime: this.state.loadTime + 1
-    });
-  }
-
-  _endStreaming() {
-    this._stream.abort();
-    clearTimeout(this._pendingReload);
-  }
-
-  _resetPendingReload() {
-    const sinceLastLoad = Date.now() - this._loadTime;
-    const wait = Math.max(0, (1000 * 5) - sinceLastLoad);
-    this._pendingReload = setTimeout(() => {
-      if (this.state.logState === 'paused') {
-        // don't reset stream if the user paused the stream
-        this._touchLoadTime();
-        this._resetPendingReload();
-        return;
-      }
-      this._beginStreaming();
-    }, wait);
-  }
-
-  _loadStarted() {
-    this.setState({
-      logState: 'streaming'
-    });
-  }
-
-  _processData(data) {
-    if (dataHasHTML(data)) {
-      this._buffer.push('Logs are currently unavailable');
-    } else if (!dataHasFailureMsg(data)) {
-      this._buffer.push(data);
-    }
-
-    this._touchLoadTime();
-  }
-
-  _beginStreaming() {
-    clearTimeout(this._pendingReload);
-    this._pendingReload = null;
-    this._buffer = lineBuffer(1000);
-
-    this._stream = stream(this.state.logURL, this._loadStarted.bind(this), this._processData.bind(this));
-    this._stream.promise
-      .then(() => !this._pendingReload && this._resetPendingReload()) // Load ended
-      .catch((why) => { // Load failed/aborted
-        if (why === 'abort') {
-          return;
-        }
-
-        this._loadStarted();
-        this._buffer.push(`Error: ${why}`);
-        this._touchLoadTime();
-        if (!this._pendingReload) {
-          this._resetPendingReload();
-        }
-      });
+    const currentContainer = this.state.containers[index];
+    this.setState({currentContainer});
   }
 
   render() {
-    const nameWithIcon = (name) => <span><span className="co-icon-space-r"><ResourceIcon kind="Container" /></span>{name}</span>;
+    const {currentContainer, containers} = this.state;
+    const namespace = _.get(this.props.obj, 'metadata.namespace');
+    const podName = _.get(this.props.obj, 'metadata.name');
+    const containerDropdown = <ContainerDropdown
+      currentContainer={currentContainer}
+      containers={containers}
+      kind="Container"
+      onChange={this._selectContainer} />;
 
     return <div className="co-m-pane__body">
-      <div className="co-m-pane__top-controls">
-        { this.state.logState === 'loading'
-          ? <span className="co-icon-space-l"><LoadingInline /></span>
-          : <TogglePlay active={this.state.logState === 'streaming'} onClick={this._toggleLogState} /> }
-        <span className="log-container-selector__text">
-          { this.state.logState === 'streaming' && <span>Streaming logs from</span> }
-          { this.state.logState === 'paused' && <span>Log stream is paused.</span> }
-          { this.state.logState === 'loading' && <span>Loading log...</span> }
-        </span>
-        <Dropdown className="btn-group" items={_.mapValues(this.state.containerNames, nameWithIcon)} title={nameWithIcon(this.state.currentContainer || <LoadingInline />)} onChange={this._selectContainer} />
-      </div>
-
-      <LogWindow buffer={this._buffer} logName={this.state.currentContainer} logState={this.state.logState} updateLogState={this._updateLogState} loadGeneration={this.state.loadTime} />
+      <ResourceLog
+        containerName={currentContainer.name}
+        eof={currentContainer.eof}
+        kind="Pod"
+        dropdown={containerDropdown}
+        namespace={namespace}
+        resourceName={podName} />
     </div>;
   }
 }

--- a/frontend/public/components/utils/_log-window.scss
+++ b/frontend/public/components/utils/_log-window.scss
@@ -31,10 +31,6 @@ $color-log-window-divider: $color-log-window-header-bg;
   width: 0;
 }
 
-.log-window__contents__text--divider {
-  border-bottom: 1px solid $color-log-window-divider;
-}
-
 .log-window__footer {
   background-color: $color-log-window-header-bg;
   cursor: pointer;

--- a/frontend/public/components/utils/_resource-log.scss
+++ b/frontend/public/components/utils/_resource-log.scss
@@ -1,0 +1,7 @@
+.log-stream-control {
+  margin-right: 15px;
+}
+
+.log-container-selector__text {
+  margin-right: 15px;
+}

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -7,6 +7,7 @@ export * from './line-buffer';
 export * from './log-window';
 export * from './resource-icon';
 export * from './resource-link';
+export * from './resource-log';
 export * from './volume-icon';
 export * from './timestamp';
 export * from './vertnav';

--- a/frontend/public/components/utils/line-buffer.js
+++ b/frontend/public/components/utils/line-buffer.js
@@ -2,42 +2,45 @@
 // containing a newline (a logical "line")
 const LINE_PATTERN = /[^\n]+(?:\n|$)/g;
 
-export const lineBuffer = (maxSize) => {
-  let buffer = [];
+export class LineBuffer {
 
-  return {
-    totalLineCount: 0,
-    maxSize: maxSize,
-    clear: function() {
-      buffer.splice(0, buffer.length);
-    },
-    push: function(data) {
-      if (data === '') {
-        return;
-      }
+  constructor(maxSize){
+    this.totalLineCount = 0;
+    this.maxSize = maxSize;
+    this.buffer = [];
+  }
 
-      let overflow = 0;
-      let lines = data.match(LINE_PATTERN) || [data];
-      let trailer = buffer.pop() || '';
+  clear() {
+    this.buffer.splice(0, this.buffer.length);
+  }
 
-      if (trailer.substr(-1) !== '\n') {
-        trailer = trailer + (lines.shift() || '');
-        if (trailer !== '') {
-          this.totalLineCount = this.totalLineCount + 1;
-        }
-      }
-
-      this.totalLineCount = this.totalLineCount + lines.length;
-
-      buffer.push(trailer);
-      buffer = buffer.concat(lines);
-      overflow = buffer.length - maxSize;
-      if (overflow > 0) {
-        buffer.splice(0, overflow);
-      }
-    },
-    lines: function() {
-      return buffer;
+  push(data) {
+    if (data === '') {
+      return;
     }
-  };
-};
+
+    let overflow = 0;
+    let lines = data.match(LINE_PATTERN) || [data];
+    let trailer = this.buffer.pop() || '';
+
+    if (trailer.substr(-1) !== '\n') {
+      trailer = trailer + (lines.shift() || '');
+      if (trailer !== '') {
+        this.totalLineCount = this.totalLineCount + 1;
+      }
+    }
+
+    this.totalLineCount = this.totalLineCount + lines.length;
+
+    this.buffer.push(trailer);
+    this.buffer = this.buffer.concat(lines);
+    overflow = this.buffer.length - this.maxSize;
+    if (overflow > 0) {
+      this.buffer.splice(0, overflow);
+    }
+  }
+
+  lines() {
+    return this.buffer;
+  }
+}

--- a/frontend/public/components/utils/resource-log.jsx
+++ b/frontend/public/components/utils/resource-log.jsx
@@ -1,0 +1,208 @@
+import * as _ from 'lodash-es';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+
+import { resourceURL, modelFor } from '../../module/k8s';
+import { SafetyFirst } from '../safety-first';
+import { LineBuffer, LoadingInline, LogWindow, stream, TogglePlay } from './';
+
+const logStatusMessages = {
+  eof: 'Log stream ended.',
+  loading: 'Loading log...',
+  paused: 'Log stream paused.',
+  streaming: 'Log streaming...'
+};
+
+const dataHasFailureMsg = (data) => {
+  return _.includes(data, '"status": "Failure"');
+};
+
+const dataHasHTML = (data) => {
+  return _.includes(data, '<html') || _.includes(data, '<HTML');
+};
+
+// Component for the streaming controls
+const LogControls = ({status, toggleStreaming, dropdown}) => {
+  return <div className="co-m-pane__top-controls">
+    { status === 'loading' && <span className="co-icon-space-l"><LoadingInline /></span> }
+    { ['streaming', 'paused'].includes(status) && <span className="log-stream-control"><TogglePlay active={status === 'streaming'} onClick={toggleStreaming}/></span>}
+    <span className="log-container-selector__text">
+      {logStatusMessages[status]}
+    </span>
+    {dropdown && <span>{dropdown}</span>}
+  </div>;
+};
+
+export class ResourceLog extends SafetyFirst {
+  constructor(props) {
+    super(props);
+
+    this._buffer = new LineBuffer(this.props.bufferSize);
+    this._loadStarted = this._loadStarted.bind(this);
+    this._processData = this._processData.bind(this);
+    this._retry = _.throttle(this._retry, 5000);
+    this._toggleStreaming = this._toggleStreaming.bind(this);
+    this._updateStatus = this._updateStatus.bind(this);
+
+    this.state = {
+      touched: Date.now(),
+      status: 'loading',
+    };
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const newState = {};
+
+    if(nextProps.eof){
+      newState.status = prevState.status === 'paused' ? 'paused' : 'eof';
+    }
+    return newState;
+  }
+
+  componentDidMount() {
+    super.componentDidMount();
+    this._beginStreaming();
+  }
+
+  componentDidUpdate(prevProps){
+    // If container changed, restart streaming
+    if (this.props.containerName && this.props.containerName !== prevProps.containerName) {
+      this._restartStreaming();
+    }
+  }
+
+  componentWillUnmount() {
+    super.componentWillUnmount();
+    this._endStreaming();
+  }
+
+  // Updates log status as long as eof has not been reached
+  _updateStatus(newStatus) {
+    // If log is at eof, don't update state to anything other than eof
+    this.setState((prevState, props) => {
+      return {
+        status: props.eof ? 'eof' : newStatus
+      };
+    });
+  }
+
+  // use _updateStatus toggle streaming/paused state instead of directly
+  // setting logState
+  _toggleStreaming() {
+    this._updateStatus(this.state.status === 'streaming' ? 'paused' : 'streaming');
+  }
+
+  // separate function so that it can be throttled
+  _touch() {
+    this.setState({
+      touched: Date.now()
+    });
+  }
+
+  _pushToBuffer(data){
+    this._buffer.push(data);
+    this._touch();
+  }
+
+  _clearBuffer(){
+    this._buffer.clear();
+    this._touch();
+  }
+
+  // Callback which handles the XMLHttpRequest "loadstart" event.
+  _loadStarted() {
+    this._updateStatus('streaming');
+  }
+
+  // Callback to process data from the XMLHttpRequest "progress" event
+  _processData(data) {
+    if (dataHasHTML(data)) {
+      this._pushToBuffer('Logs are currently unavailable');
+    } else if (!dataHasFailureMsg(data)) {
+      this._pushToBuffer(data);
+    }
+  }
+
+  // Retry loading logs every five seconds (see constructor where this function is throttled).
+  _retry() {
+    // If stream is paused, don't begin stream agian
+    if (this.state.status === 'paused') {
+      this._touch();
+      this._retry(); // Try to refresh again
+    } else {
+      this._beginStreaming();
+    }
+  }
+
+  // Resets buffer and starts a new stream.
+  _beginStreaming() {
+    const url = resourceURL(modelFor(this.props.kind), {
+      ns: this.props.namespace,
+      name: this.props.resourceName,
+      path: 'log',
+      queryParams: {
+        container: this.props.containerName || '',
+        follow: 'true',
+        tailLines: this.props.bufferSize
+      }
+    });
+    this._clearBuffer();
+    this._stream = stream(url, this._loadStarted, this._processData);
+    this._stream.promise
+      .then(() => {
+        // Resource is no longer running/generating new log content, so stop streaming
+        if (this.props.eof){
+          this._endStreaming();
+        } else {
+          // Request resolved, but resource is still in a non-terminated state, retry streaming
+          this._retry();
+        }
+      })
+      .catch((why) => { // Load failed/aborted
+        if (why !== 'abort') {
+          this._pushToBuffer(`Error: ${why}`);
+          this._retry();
+        }
+      });
+  }
+
+  // Abort XMLHttpRequest
+  _endStreaming() {
+    this._stream && this._stream.abort();
+  }
+
+  // Ends current stream and starts a new one.
+  _restartStreaming(){
+    this._endStreaming();
+    this._beginStreaming();
+  }
+
+  render() {
+    return <div className="co-m-pane__body">
+      <LogControls
+        dropdown={this.props.dropdown}
+        status={this.state.status}
+        toggleStreaming={this._toggleStreaming} />
+      <LogWindow
+        buffer={this._buffer}
+        touched={this.state.touched}
+        status={this.state.status}
+        updateStatus={this._updateStatus} />
+    </div>;
+  }
+}
+
+ResourceLog.defaultProps = {
+  bufferSize: 1000,
+  label: '',
+};
+
+ResourceLog.propTypes = {
+  bufferSize: PropTypes.number.isRequired,
+  containerName: PropTypes.string,
+  dropdown: PropTypes.element,
+  eof: PropTypes.bool.isRequired,
+  kind: PropTypes.string.isRequired,
+  namespace: PropTypes.string.isRequired,
+  resourceName: PropTypes.string.isRequired,
+};

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -4,9 +4,10 @@
 @import "style/config";
 
 // External dependencies that are required/extended by our custom styles (tilde tells Webpack not to use relative path)
-@import '~patternfly/dist/sass/patternfly/variables';
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/variables";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins";
+@import "~font-awesome-sass/assets/stylesheets/font-awesome/variables";
+@import '~patternfly/dist/sass/patternfly/variables';
 
 @import "style/base";
 
@@ -35,6 +36,8 @@
 @import "components/utils/number-spinner";
 @import "components/utils/status-box";
 @import "components/utils/selector";
+@import "components/utils/resource-log";
+@import "components/utils/log-window";
 @import "components/chargeback";
 @import "components/cluster-overview";
 @import "components/cluster-settings/cluster-settings";
@@ -47,8 +50,6 @@
 @import "components/nav-title";
 @import "components/node-ip-list";
 @import "components/overflow";
-@import "components/pod-logs";
-@import "components/log-window";
 @import "components/RBAC/rbac";
 @import "components/resource";
 @import "components/resource-dropdown";


### PR DESCRIPTION
# Description
Add logs to Build detail view.

# Changes
- Create new ResourceLog component which accepts props to make API request for log and manages log status.
    - Broke out a few stateless components like LogControls and ContainerDropdown which are used to render the the controls above the log window.
    - Added a new log status, 'eof', which will disable the streaming controls and stop requests to the API
    - Accepts an `eof` property from the parent which is used to trigger the 'eof' state.
    - Log status changes are now all funneled through `_updateLogStatus` function to always check for eof condition before updating to a different state.
    
- Create BuildLog component which uses the new ResourceLog component
- Refactor PodLogs component to use ResourceLog
- Add handling for case where Build/Container is no longer running and streaming controls should be disabled

# Screen Shots
Pod Logs (without play/pause button)
![screenshot-localhost-9000-2018 05 24-11-29-39](https://user-images.githubusercontent.com/22625502/40495674-d4d6c884-5f45-11e8-8c5c-da623e3c76e9.png)

Build Logs (no dropdown or label since it is in the page heading)
![screenshot-localhost-9000-2018 05 24-11-28-42](https://user-images.githubusercontent.com/22625502/40495676-d4e833da-5f45-11e8-890d-d2e1bc8ca1d5.png)