### PR TITLE
Some containers can not run our command (/bin/sh)...

### DIFF
--- a/frontend/public/components/terminal.jsx
+++ b/frontend/public/components/terminal.jsx
@@ -25,6 +25,7 @@ export class Terminal extends React.Component {
       return;
     }
     terminal.reset();
+    terminal.clear();
     terminal.setOption('disableStdin', false);
   }
 


### PR DESCRIPTION
so we should tell users about that and just give up (for now).

![screen shot 2018-05-17 at 4 43 00 pm](https://user-images.githubusercontent.com/986627/40208958-6aea52b4-59f1-11e8-92c3-a7597ceeeb3b.png)


edit: this is the config reloader in alert manager... which is running [gcr.io/distroless/base](https://github.com/GoogleContainerTools/distroless/blob/master/base/README.md):

```
The image contains:

glibc
libssl
openssl
ca-certificates
A /etc/passwd entry for a root user
A /tmp directory
```

NOTE: I don't want to deal with the kubectl/oc split atm.  Lets do a pass over the whole project later.