### PR TITLE
Remove tab index from react-virtualized list

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -390,6 +390,7 @@ class EventStream extends SafetyFirst {
                   scrollTop={scrollTop}
                   width={width}
                   rowCount={count}
+                  tabIndex={null}
                   // TODO: set rowHeight based on media query
                   // @media screen and (min-width: 768px)...
                   // rowHeight={width > 548 ? 135 : 250}

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -95,8 +95,6 @@ tags-input .tags .tag-item {
 tags-input .tags .tag-item.selected {
   border: solid 1px;
 }
-tags-input .tags .tag-item.selected .remove-button {
-}
 
 tags-input .tags .tag-item .remove-button {
   margin: 0 0 0 2px;
@@ -190,8 +188,4 @@ tags-input .autocomplete .suggestion-item em {
 
 .modal-footer .alert {
   text-align: left;
-}
-
-.ReactVirtualized__List:focus {
-  outline: none;
 }


### PR DESCRIPTION
The events can still be reached by keyboard, but this prevents focus
disappearing while tabbing through (and still avoids the outline).

/cc @kans @amrutac @rhamilto 