### PR TITLE
Decrease flush interval from 500ms to 100ms.

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -48,7 +48,7 @@ func NewProxy(cfg *Config) *Proxy {
 	}
 
 	reverseProxy := httputil.NewSingleHostReverseProxy(cfg.Endpoint)
-	reverseProxy.FlushInterval = time.Millisecond * 500
+	reverseProxy.FlushInterval = time.Millisecond * 100
 	reverseProxy.Transport = transport
 	reverseProxy.ModifyResponse = filterHeaders
 


### PR DESCRIPTION
Apparently we wait up to 500ms buffering up k8s responses before sending it back to the client. 100ms is a decent balance between improved performance for users and not spending all our time waking up to send stuff.