### PR TITLE
Prevent long resource names from causing layout to break

### DIFF
--- a/frontend/public/components/_list.scss
+++ b/frontend/public/components/_list.scss
@@ -31,8 +31,7 @@
     margin-left: 10px;
   }
   [class^="col-"] {
-    word-wrap: break-word; // IE 11/16/17 requires legacy name "word-wrap" rather than "overflow-wrap".
-    overflow-wrap: break-word; // new name as per the CSS3 spec
+    @include co-break-word;
   }
 }
 

--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -18,10 +18,11 @@ $height: 18px;
     height: 24px;
     line-height: 24px;
     margin-left: 0;
+    margin-right: 7px;
     min-width: 24px;
     padding: 0 7px;
     position: relative;
-    top: -2px;
+    top: 4px;
   }
 }
 

--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -142,6 +142,7 @@ $color-dark-border: #ddd;
     padding: 20px;
     flex: 1 2 auto;
     border: solid 1px $color-grey-border;
+    min-width: 0%; // necessary for wrapping since its a flex child
   }
 
   .co-sysevent__icon-box {

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -171,29 +171,26 @@ const Details = ({obj: pod}) => {
       <br />
 
       <div className="row">
-        <div className="col-lg-8">
-          <div className="row">
-            <div className="col-sm-6">
-              <ResourceSummary resource={pod} showPodSelector={false} showNodeSelector={false}>
-                <dt>Node Selector</dt>
-                <dd><Selector kind="Node" selector={pod.spec.nodeSelector} /></dd>
-              </ResourceSummary>
-            </div>
-            <div className="col-sm-6">
-              <dl className="co-m-pane__details">
-                <dt>Status</dt>
-                <dd>{podPhase(pod)}</dd>
-                <dt>Pod IP</dt>
-                <dd>{pod.status.podIP || '-'}</dd>
-                <dt>Node</dt>
-                <dd><NodeLink name={pod.spec.nodeName} /></dd>
-                <dt>Restart Policy</dt>
-                <dd>{getRestartPolicyLabel(pod)}</dd>
-              </dl>
-            </div>
-          </div>
+        <div className="col-sm-6">
+          <ResourceSummary resource={pod} showPodSelector={false} showNodeSelector={false}>
+            <dt>Node Selector</dt>
+            <dd><Selector kind="Node" selector={pod.spec.nodeSelector} /></dd>
+          </ResourceSummary>
+        </div>
+        <div className="col-sm-6">
+          <dl className="co-m-pane__details">
+            <dt>Status</dt>
+            <dd>{podPhase(pod)}</dd>
+            <dt>Pod IP</dt>
+            <dd>{pod.status.podIP || '-'}</dd>
+            <dt>Node</dt>
+            <dd><NodeLink name={pod.spec.nodeName} /></dd>
+            <dt>Restart Policy</dt>
+            <dd>{getRestartPolicyLabel(pod)}</dd>
+          </dl>
         </div>
       </div>
+
     </div>
 
     <div className="co-m-pane__body">

--- a/frontend/public/components/utils/_selector.scss
+++ b/frontend/public/components/utils/_selector.scss
@@ -1,18 +1,5 @@
-$height: 18px;
-
-.co-m-selector {
-  display: inline-flex;
-  flex-wrap: nowrap;
-}
-
 .co-m-requirement {
-  display: inline-block;
   font-size: $font-size-base;
-  height: $height;
   line-height: $height;
   vertical-align: middle;
-
-  a {
-    display: inline-block;
-  }
 }

--- a/frontend/public/components/utils/nav-title.tsx
+++ b/frontend/public/components/utils/nav-title.tsx
@@ -30,7 +30,7 @@ export const NavTitle = connectToModel((props: NavTitleProps) => {
   const isCSV = !_.isEmpty(data) && referenceFor(data) === referenceForModel(ClusterServiceVersionModel);
   const logo = isCSV
     ? <ClusterServiceVersionLogo icon={_.get(data, 'spec.icon', [])[0]} displayName={data.spec.displayName} version={data.spec.version} provider={data.spec.provider} />
-    : <div>{ kind && <ResourceIcon kind={kind} className="co-m-resource-icon--lg" /> } <span id="resource-title">{title}</span></div>;
+    : <div className="co-m-pane__name">{ kind && <ResourceIcon kind={kind} className="co-m-resource-icon--lg pull-left" /> } <span id="resource-title">{title}</span></div>;
 
   return <div className={classNames('co-m-nav-title', {'co-m-nav-title--detail': detail}, {'co-m-nav-title--logo': isCSV}, {'co-m-nav-title--breadcrumbs': breadcrumbsFor && !_.isEmpty(data)})} style={style}>
     { breadcrumbsFor && !_.isEmpty(data) && <BreadCrumbs breadcrumbs={breadcrumbsFor(data)} /> }

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -18,6 +18,7 @@
 
 // Mixins
 @import "style/mixin/prefix";
+@import "style/mixin/break-word";
 
 /* CUSTOM STYLES */
 

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -66,7 +66,6 @@
 }
 
 .co-m-pane__heading {
-  align-items: center;
   display: flex;
   justify-content: space-between;
   margin: 0 0 $grid-gutter-width;
@@ -74,8 +73,16 @@
     justify-content: center;
   }
   &--logo {
+    align-items: center;
     margin-bottom: ($grid-gutter-width / 2);
   }
+}
+
+.co-m-pane__name {
+  @include co-break-word;
+  flex: 1;
+  margin-right: 10px;
+  min-width: 0; // necessary for wrapping since its a flex child
 }
 
 .co-m-pane__top-controls {
@@ -121,6 +128,7 @@
   }
   dd {
     font-size: 14px;
+    @include co-break-word;
   }
 }
 
@@ -177,4 +185,8 @@ input[type=number]::-webkit-outer-spin-button {
   font-size: 14px;
   padding: 2px 12px;
   background-color: #D64456;
+}
+
+.co-break-word {
+  @include co-break-word;
 }

--- a/frontend/public/style/coreos.css
+++ b/frontend/public/style/coreos.css
@@ -34,10 +34,6 @@
 .co-nowrap {
   white-space: nowrap; }
 
-.co-break-word {
-  overflow-wrap: break-word;
-}
-
 /* Animations */
 .co-an-fade-in-out {
   -webkit-transition-property: compact(opacity, false, false, false, false, false, false, false, false, false);

--- a/frontend/public/style/mixin/_break-word.scss
+++ b/frontend/public/style/mixin/_break-word.scss
@@ -1,0 +1,6 @@
+// Generic mixin for break-word. Note if element is a flex child then min-width: 0% is necessary for it to wrap.
+
+@mixin co-break-word() {
+  overflow-wrap: break-word; // new name as per the CSS3 spec
+  word-wrap: break-word; // IE 11, Edge 16/17 requires legacy name "word-wrap" rather than "overflow-wrap".
+}


### PR DESCRIPTION
Create mixin for `.co-break-word` and adjust markup to enable break-word.
applied to 
`h1.co-m-pane__heading`
`dl..co-m-pane__details dd`

https://jira.coreos.com/browse/CONSOLE-460

**before**
![screen shot 2018-05-11 at 8 35 48 am](https://user-images.githubusercontent.com/1874151/40324437-8084da50-5d06-11e8-811d-700c448e2233.png)

**after**
<img width="876" alt="screen shot 2018-05-21 at 2 36 20 pm" src="https://user-images.githubusercontent.com/1874151/40323912-dd780874-5d04-11e8-821d-ab382786ff00.png">

**before**
<img width="610" alt="screen shot 2018-05-21 at 2 48 21 pm" src="https://user-images.githubusercontent.com/1874151/40324431-7760508a-5d06-11e8-80a9-197090e12925.png">


**after**
<img width="611" alt="screen shot 2018-05-21 at 1 11 55 pm" src="https://user-images.githubusercontent.com/1874151/40322172-874b2602-5cff-11e8-8a02-41cb3ef324c9.png">

**before**
<img width="876" alt="screen shot 2018-05-21 at 2 49 08 pm" src="https://user-images.githubusercontent.com/1874151/40324399-67455a6a-5d06-11e8-839f-6a98a35b3a32.png">


**after**
<img width="874" alt="screen shot 2018-05-21 at 2 49 33 pm" src="https://user-images.githubusercontent.com/1874151/40324384-5b63d05a-5d06-11e8-8e99-a2d22174c353.png">

**before**
![screen shot 2018-05-11 at 8 34 53 am](https://user-images.githubusercontent.com/1874151/40324533-c451d79c-5d06-11e8-8150-4b9754370098.png)


**after**
<img width="1141" alt="screen shot 2018-05-21 at 1 15 57 pm" src="https://user-images.githubusercontent.com/1874151/40322237-adc2ae04-5cff-11e8-9374-094a008d5591.png">


