### PR TITLE
Copy to clipboard for secret and configMap data

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "plotly.js": "1.28.x",
     "prop-types": "15.6.x",
     "react": "16.x",
+    "react-copy-to-clipboard": "5.x",
     "react-dom": "16.x",
     "react-helmet": "5.x",
     "react-lightweight-tooltip": "1.x",

--- a/frontend/public/components/configmap-and-secret-data.jsx
+++ b/frontend/public/components/configmap-and-secret-data.jsx
@@ -1,14 +1,19 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { Heading } from './utils';
+import { Heading, CopyToClipboard } from './utils';
+
+const MaskedData = () => <React.Fragment>
+  <span className="sr-only">Value hidden</span>
+  <span aria-hidden="true">&bull;&bull;&bull;&bull;&bull;</span>
+</React.Fragment>;
 
 export const ConfigMapData = ({data}) => {
   const dl = [];
   Object.keys(data || {}).sort().forEach(k => {
+    const value = data[k];
     dl.push(<dt key={`${k}-k`}>{k}</dt>);
-    dl.push(<dd key={`${k}-v`}><pre className="co-pre-wrap">{data[k]}</pre></dd>);
+    dl.push(<dd key={`${k}-v`}><CopyToClipboard value={value} /></dd>);
   });
-
   return <dl>{dl}</dl>;
 };
 
@@ -27,17 +32,21 @@ export class SecretData extends React.PureComponent {
     const { data } = this.props;
     const { showSecret } = this.state;
     const dl = [];
-    const masked = <React.Fragment>
-      <span className="sr-only">value hidden</span>
-      <span aria-hidden="true">&bull;&bull;&bull;&bull;&bull;</span>
-    </React.Fragment>;
-    Object.keys(data).sort().forEach(k => {
+    Object.keys(data || {}).sort().forEach(k => {
+      const value = window.atob(data[k]);
+      const visibleValue = showSecret ? value : <MaskedData /> ;
       dl.push(<dt key={`${k}-k`}>{k}</dt>);
-      dl.push(<dd key={`${k}-v`}><pre className="co-pre-wrap">{showSecret ? window.atob(data[k]) : masked}</pre></dd>);
+      dl.push(<dd key={`${k}-v`}><CopyToClipboard value={value} visibleValue={visibleValue}/></dd>);
     });
     return <React.Fragment>
-      <Heading text="Data" >
-        <button className="btn btn-link" type="button" onClick={this.toggleSecret}>{showSecret ? 'Hide Values' : 'Reveal Values'}</button>
+      <Heading text="Data">
+        <button className="btn btn-link" type="button" onClick={this.toggleSecret}>
+          {
+            showSecret
+              ? <React.Fragment><i className="fa fa-eye-slash" aria-hidden="true"></i> Hide Values</React.Fragment>
+              : <React.Fragment><i className="fa fa-eye" aria-hidden="true"></i> Reveal Values</React.Fragment>
+          }
+        </button>
       </Heading>
       <dl>{dl}</dl>
     </React.Fragment>;

--- a/frontend/public/components/utils/_copy-to-clipboard.scss
+++ b/frontend/public/components/utils/_copy-to-clipboard.scss
@@ -1,0 +1,16 @@
+.co-copy-to-clipboard {
+  font-family: $font-family-monospace;
+  position: relative;
+}
+
+.co-copy-to-clipboard__btn {
+  position: absolute;
+  right: 0px;
+  top: 0px;
+  width: 42px;
+  height: 42px;
+}
+
+.co-copy-to-clipboard__text {
+  padding-right: 50px;
+}

--- a/frontend/public/components/utils/copy-to-clipboard.jsx
+++ b/frontend/public/components/utils/copy-to-clipboard.jsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+import { CopyToClipboard as CTC } from 'react-copy-to-clipboard';
+
+export const CopyToClipboard = ({value, visibleValue = value}) => <React.Fragment>
+  <div className="co-copy-to-clipboard">
+    <pre className="co-pre-wrap co-copy-to-clipboard__text">{visibleValue}</pre>
+    <CTC text={value}>
+      <button className="btn btn-default co-copy-to-clipboard__btn" type="button">
+        <i className="fa fa-clipboard" aria-hidden="true"></i>
+        <span className="sr-only">Copy to Clipboard</span>
+      </button>
+    </CTC>
+  </div>
+</React.Fragment>;

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -35,3 +35,4 @@ export * from './error-boundary';
 export * from './deployment-pod-counts';
 export * from './entitlements';
 export * from './build-strategy';
+export * from './copy-to-clipboard';

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -29,6 +29,7 @@
 @import "style/status";
 
 // React Components
+@import "components/utils/copy-to-clipboard";
 @import "components/utils/label";
 @import "components/utils/number-spinner";
 @import "components/utils/status-box";

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2240,6 +2240,12 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+copy-to-clipboard@^3:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
+  dependencies:
+    toggle-selection "^1.0.3"
+
 core-js@2.x, core-js@^2.0.0, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
@@ -8291,6 +8297,13 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-copy-to-clipboard@5.x:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#8eae107bb400be73132ed3b6a7b4fb156090208e"
+  dependencies:
+    copy-to-clipboard "^3"
+    prop-types "^15.5.8"
+
 react-dom@16.x:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.1.tgz#6a3c90a4fb62f915bdbcf6204422d93a7d4ca573"
@@ -10068,6 +10081,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
 to-utf8@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/to-utf8/-/to-utf8-0.0.1.tgz#d17aea72ff2fba39b9e43601be7b3ff72e089852"
+
+toggle-selection@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 topojson-client@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Follow up of https://github.com/openshift/console/pull/23
Added:
- eye and eye-slash icon to the toggle secret visibility link
- copy to clipboard button to each value

Screens:

- Hidden secret values
![download](https://user-images.githubusercontent.com/1668218/40364633-2295a38e-5dd3-11e8-9380-539883490d56.png)


- Visible secret values
![download 1](https://user-images.githubusercontent.com/1668218/40364649-2af8757e-5dd3-11e8-85e3-d81f8635b66f.png)


- ConfigMap values
![download 2](https://user-images.githubusercontent.com/1668218/40364711-4891e584-5dd3-11e8-8bef-d351a7006ed5.png)


@spadgett @benjaminapetersen PTAL

@beanh66 @serenamarie125 fyi
