### PR TITLE
Wrap location with block element <div> so they don't word-break awkwardly in co-m-grid-table

### DIFF
--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -22,7 +22,7 @@ const menuActions = [Cog.factory.ModifyPodSelector, ...Cog.factory.common];
 const ServiceIP = ({s}) => {
   const children = _.map(s.spec.ports, (portObj, i) => {
     const clusterIP = s.spec.clusterIP === 'None' ? 'None' : `${s.spec.clusterIP}:${portObj.port}`;
-    return <span key={i}>{clusterIP}&nbsp;&nbsp;</span>;
+    return <div key={i}>{clusterIP}</div>;
   });
 
   return <p>{children}</p>;


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-487

<img width="984" alt="screen shot 2018-05-22 at 12 39 29 pm" src="https://user-images.githubusercontent.com/1874151/40377580-37bf0f0c-5dbf-11e8-9181-3771f0af51e3.png">
