### PR TITLE
Load Testing ServiceWorker with Pagination

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -75,6 +75,8 @@ func main() {
 	fLogoImageName := fs.String("logo-image-name", "", "Logo image used in the masthead")
 	fGoogleTagManagerID := fs.String("google-tag-manager-id", "", "Google Tag Manager ID. External analytics are disabled if this is not set.")
 
+	fLoadTestFactor := fs.Int("load-test-factor", 0, "DEV ONLY. The factor used to multiply k8s API list responses for load testing purposes.")
+
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
@@ -117,6 +119,7 @@ func main() {
 		OpenshiftConsoleURL: *fOpenshiftConsoleURL,
 		LogoImageName:       *fLogoImageName,
 		GoogleTagManagerID:  *fGoogleTagManagerID,
+		LoadTestFactor:      *fLoadTestFactor,
 	}
 
 	if (*fKubectlClientID == "") != (*fKubectlClientSecret == "" && *fKubectlClientSecretFile == "") {

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -248,10 +248,11 @@ window.onunhandledrejection = function (e) {
 };
 
 if ('serviceWorker' in navigator) {
-  if (window.location.search.indexOf('loadTest') > -1) {
+  if (window.SERVER_FLAGS['loadTestFactor'] > 1) {
+    // TODO(alecmerdler): Can we use TypeScript?
     import('file-loader?name=load-test.sw.js!../load-test.sw.js')
       .then(() => navigator.serviceWorker.register('/load-test.sw.js'))
-      .then(() => navigator.serviceWorker.controller.postMessage({topic: 'setFactor', value: Number(new URLSearchParams(window.location.search).get('loadTest'))}));
+      .then(() => navigator.serviceWorker.controller.postMessage({topic: 'setFactor', value: window.SERVER_FLAGS['loadTestFactor']}));
   } else {
     navigator.serviceWorker.getRegistrations().then((registrations) => registrations.forEach(reg => reg.unregister()));
   }

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -248,11 +248,11 @@ window.onunhandledrejection = function (e) {
 };
 
 if ('serviceWorker' in navigator) {
-  if (window.SERVER_FLAGS['loadTestFactor'] > 1) {
-    // TODO(alecmerdler): Can we use TypeScript?
+  if (window.SERVER_FLAGS.loadTestFactor > 1) {
     import('file-loader?name=load-test.sw.js!../load-test.sw.js')
       .then(() => navigator.serviceWorker.register('/load-test.sw.js'))
-      .then(() => navigator.serviceWorker.controller.postMessage({topic: 'setFactor', value: window.SERVER_FLAGS['loadTestFactor']}));
+      .then(() => new Promise(r => navigator.serviceWorker.controller ? r() : navigator.serviceWorker.addEventListener('controllerchange', () => r())))
+      .then(() => navigator.serviceWorker.controller.postMessage({topic: 'setFactor', value: window.SERVER_FLAGS.loadTestFactor}));
   } else {
     navigator.serviceWorker.getRegistrations().then((registrations) => registrations.forEach(reg => reg.unregister()));
   }

--- a/frontend/public/load-test.sw.js
+++ b/frontend/public/load-test.sw.js
@@ -8,25 +8,67 @@ const uuidFor = () => {
   });
 };
 
-const clonePod = (pod, num) => ({...pod, metadata: {...pod.metadata, name: `${pod.metadata.name}-clone-${num}`, uid: uuidFor()}});
+const pageFromToken = (continueToken) => continueToken ? parseInt(continueToken.replace('toPage', ''), 10) : 0;
 
-let multiplicationFactor = 50;
+const cloneResource = (obj, num) => ({...obj, metadata: {...obj.metadata, name: `${obj.metadata.name}-clone-${num}`, uid: uuidFor()}});
+
+const strippedURLFor = (request) => {
+  const url = new URL(request.url);
+  url.searchParams.delete('limit');
+  url.searchParams.delete('continue');
+
+  return url.toString();
+};
+
+let multiplicationFactor = 20;
 
 /**
- * Simple Service Worker which multiplies every `/api/kubernetes/api/v1/pods` response for load testing.
+ * Only match core resource list requests.
+ */
+const workloads = new Set()
+  .add(/\/api\/kubernetes\/apis\/apps\/v1(\/namespaces\/.*)?\/daemonsets(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/apis\/apps\/v1(\/namespaces\/.*)?\/deployments(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/apis\/apps\/v1(\/namespaces\/.*)?\/replicasets(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/api\/v1(\/namespaces\/.*)?\/replicationcontrollers(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/api\/v1(\/namespaces\/.*)?\/persistentvolumeclaims(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/apis\/batch\/v1(\/namespaces\/.*)?\/jobs(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/apis\/batch\/v1beta1(\/namespaces\/.*)?\/cronjobs(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/api\/v1(\/namespaces\/.*)?\/pods(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/api\/v1(\/namespaces\/.*)?\/configmaps(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/api\/v1(\/namespaces\/.*)?\/secrets(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/api\/v1(\/namespaces\/.*)?\/resourcequotas(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/apis\/extensions\/v1beta1(\/namespaces\/.*)?\/ingresses(\?(.*))?$/)
+  .add(/\/api\/kubernetes\/api\/v1(\/namespaces\/.*)?\/services(\?(.*))?$/);
+
+/**
+ * Simple Service Worker which multiplies resource list responses for load testing.
+ * Also mocks k8s pagination.
  */
 self.addEventListener('fetch', (event) => {
-  // TODO(alecmerdler): Make this work for all workload lists
-  if (/\/api\/kubernetes\/api\/v1(\/namespaces\/.*)?\/pods/.test(event.request.url)) {
+  if ([...workloads].some(url => url.test(event.request.url))) {
     event.respondWith((async() => {
-      const response = await fetch(event.request);
-      const json = await response.json();
+      const response = await fetch(strippedURLFor(event.request));
+      try {
+        const json = await response.json();
 
-      // TODO(alecmerdler): Mock the k8s pagination implmentation (limit/continue)
-      json.items = json.items.map(item => Array.from(Array(multiplicationFactor)).map((_, i) => clonePod(item, i)).concat([item]))
-        .reduce((flattened, items) => flattened.concat(items), []);
+        const limit = parseInt(new URL(event.request.url).searchParams.get('limit'), 10);
+        const continueToken = new URL(event.request.url).searchParams.get('continue');
 
-      return new Response(new Blob([JSON.stringify(json)], {type: 'application/json'}), {headers: response.headers});
+        const allItems = json.items.map(item => Array.from(Array(multiplicationFactor)).map((_, i) => cloneResource(item, i)).concat([item]))
+          .reduce((flattened, items) => flattened.concat(items), []);
+
+        json.items = limit
+          ? allItems.slice(pageFromToken(continueToken) * limit, (pageFromToken(continueToken) + 1) * limit)
+          : allItems;
+
+        if (limit && pageFromToken(continueToken) < (allItems.length / limit)) {
+          json.metadata.continue = `toPage${pageFromToken(continueToken) + 1}`;
+        }
+
+        return new Response(new Blob([JSON.stringify(json)], {type: 'application/json'}), {headers: response.headers});
+      } catch (e) {
+        return response;
+      }
     })());
   }
 });
@@ -41,10 +83,5 @@ self.addEventListener('message', (event) => {
   }
 });
 
-self.addEventListener('install', (event) => {
-  event.waitUntil(self.skipWaiting());
-});
-
-self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
-});
+self.addEventListener('install', event => event.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', event => event.waitUntil(self.clients.claim()));

--- a/frontend/public/load-test.sw.js
+++ b/frontend/public/load-test.sw.js
@@ -16,11 +16,13 @@ let multiplicationFactor = 50;
  * Simple Service Worker which multiplies every `/api/kubernetes/api/v1/pods` response for load testing.
  */
 self.addEventListener('fetch', (event) => {
+  // TODO(alecmerdler): Make this work for all workload lists
   if (/\/api\/kubernetes\/api\/v1(\/namespaces\/.*)?\/pods/.test(event.request.url)) {
     event.respondWith((async() => {
       const response = await fetch(event.request);
       const json = await response.json();
 
+      // TODO(alecmerdler): Mock the k8s pagination implmentation (limit/continue)
       json.items = json.items.map(item => Array.from(Array(multiplicationFactor)).map((_, i) => clonePod(item, i)).concat([item]))
         .reduce((flattened, items) => flattened.concat(items), []);
 

--- a/server/server.go
+++ b/server/server.go
@@ -160,6 +160,7 @@ func (s *Server) HTTPHandler() http.Handler {
 	staticHandler := http.StripPrefix(proxy.SingleJoiningSlash(s.BaseURL.Path, "/static/"), http.FileServer(http.Dir(s.PublicDir)))
 	handle("/static/", securityHeadersMiddleware(staticHandler))
 
+	// Scope of Service Worker needs to be higher than the requests it is intercepting (https://stackoverflow.com/a/35780776/6909941)
 	handleFunc("/load-test.sw.js", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, path.Join(s.PublicDir, "load-test.sw.js"))
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -58,6 +58,7 @@ type jsGlobals struct {
 	ClusterName         string `json:"clusterName"`
 	CSRFToken           string `json:"CSRFToken"`
 	GoogleTagManagerID  string `json:"googleTagManagerID"`
+	LoadTestFactor      int    `json:"loadTestFactor"`
 }
 
 type Server struct {
@@ -74,6 +75,7 @@ type Server struct {
 	OpenshiftConsoleURL string
 	LogoImageName       string
 	GoogleTagManagerID  string
+	LoadTestFactor      int
 	// Helpers for logging into kubectl and rendering kubeconfigs. These fields
 	// may be nil.
 	KubectlAuther                  *auth.Authenticator
@@ -157,6 +159,10 @@ func (s *Server) HTTPHandler() http.Handler {
 
 	staticHandler := http.StripPrefix(proxy.SingleJoiningSlash(s.BaseURL.Path, "/static/"), http.FileServer(http.Dir(s.PublicDir)))
 	handle("/static/", securityHeadersMiddleware(staticHandler))
+
+	handleFunc("/load-test.sw.js", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, path.Join(s.PublicDir, "load-test.sw.js"))
+	})
 
 	handleFunc("/health", health.Checker{
 		Checks: []health.Checkable{},
@@ -246,6 +252,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		OpenshiftConsoleURL: s.OpenshiftConsoleURL,
 		LogoImageName:       s.LogoImageName,
 		GoogleTagManagerID:  s.GoogleTagManagerID,
+		LoadTestFactor:      s.LoadTestFactor,
 	}
 
 	if !s.authDisabled() {


### PR DESCRIPTION
### Description

This adds a basic pagination implementation to the load-testing Service Worker so we can use it with our new components. Also actually adds the endpoint to serve the `load-test.sw.js` file and makes the factor passed as a command-line arg.

**Note:** Requires running `./build-backend` to add the new static handler endpoint.

### Testing

1. Run `./bin/bridge --load-test-factor 20`
2. Refresh console a couple times to register Service Worker
3. Run below script in browser console
```javascript
const testPagination = async(continueToken = '') => {
  const response = await fetch(`http://localhost:9000/api/kubernetes/api/v1/pods?limit=50${continueToken ? `&continue=${continueToken}` : ''}`);
  const json = await response.json();

  console.log(json.items.length);
  return json.metadata.continue ? testPagination(json.metadata.continue) : json.metadata.resourceVersion;
};
testPagination();
```
4. Observe the network requests made by the browser and Service Worker, and the chunks of 50 pods being returned.

Addresses https://jira.coreos.com/browse/CONSOLE-483