### PR TITLE
Namespace services in the routes list page

### DIFF
--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -103,7 +103,7 @@ const RouteListRow: React.SFC<RoutesRowProps> = ({obj: route}) => <ResourceRow o
     <RouteHostname obj={route} />
   </div>
   <div className="col-md-2 col-sm-4 hidden-xs">
-    <ResourceLink kind="Service" name={route.spec.to.name} title={route.spec.to.name} />
+    <ResourceLink kind="Service" name={route.spec.to.name} namespace={route.metadata.namespace} title={route.spec.to.name} />
   </div>
   <div className="col-md-2 hidden-sm hidden-xs">{_.get(route, 'spec.port.targetPort', '')}</div>
   <div className="col-md-2 hidden-sm hidden-xs">{_.get(route, 'spec.tls.termination', '')}</div>


### PR DESCRIPTION
Service links in the Routes list page are not namespaced and so after clicking on a particular service, user is redirected to `/k8s/all-namespaces/services/test` instead of namespaced Service page `/k8s/ns/myproject/services/test`

@ggreer PTAL