### PR TITLE
Hide charts when Prometheus not available

### DIFF
--- a/frontend/public/components/graphs/base.jsx
+++ b/frontend/public/components/graphs/base.jsx
@@ -60,7 +60,10 @@ export class BaseGraph extends SafetyFirst {
           console.error(e);
         }
       })
-      .catch(error => this.updateGraph(null, error))
+      .catch(error => {
+        this.setState({error});
+        this.updateGraph(null, error);
+      })
       .then(() => this.interval = setTimeout(() => {
         if (this.isMounted_) {
           this.fetch();
@@ -115,12 +118,13 @@ export class BaseGraph extends SafetyFirst {
   }
 
   render () {
-    return <a href={this.prometheusURL()} target="_blank" rel="noopener noreferrer" style={{textDecoration: 'none'}}>
-      <div className="graph-wrapper" style={this.style}>
-        <h5 className="graph-title">{this.props.title}</h5>
-        <div ref={this.setNode} style={{width: '100%'}}/>
-      </div>
-    </a>;
+    return this.state.error ? null : (
+      <a href={this.prometheusURL()} target="_blank" rel="noopener noreferrer" style={{textDecoration: 'none'}}>
+        <div className="graph-wrapper" style={this.style}>
+          <h5 className="graph-title">{this.props.title}</h5>
+          <div ref={this.setNode} style={{width: '100%'}}/>
+        </div>
+      </a>);
   }
 }
 


### PR DESCRIPTION
Fixes [CONSOLE-439](https://jira.coreos.com/browse/CONSOLE-439)

When an error is thrown while trying to retrieve data for a chart, we will hide the chart rather than show and empty one.

I'm not positive if there are errors that we could get where we would not want to hide the charts. I was unable to locate any. But I can make the error checking in the render function more specific if I need to.