### PR TITLE
Fixes a redirect bug that occurs after the user authenticates

### DIFF
--- a/frontend/public/tokener.html
+++ b/frontend/public/tokener.html
@@ -19,6 +19,11 @@
       if (!error) {
         var next = localStorage.getItem('next') || '';
         if (next) {
+          if (next[0] === '/' && json.loginSuccessURL.substr(-1) === '/') {
+            while (next[0] === '/') {
+              next = next.substr(1); //remove any slash in front of "next"
+            }
+          }
           localStorage.removeItem('next');
           window.location = json.loginSuccessURL + next;
         } else {


### PR DESCRIPTION
Fixes a bug where the browser is given a link with two /'s after the login page causing it to redirect to the proper URL. This is because the base url has a trailing slash and the redirect path has a beginning slash. The fix strips the beginning slash if both have their respective slashes.