### PR TITLE
Move line-height:1 to .co-m-table-grid .row so that it doesn't effect .alert icon position

### DIFF
--- a/frontend/public/components/_list.scss
+++ b/frontend/public/components/_list.scss
@@ -19,7 +19,6 @@
 }
 
 .co-m-table-grid {
-  line-height: 1;
   &__head {
     color: $color-text-secondary;
     text-transform: uppercase;

--- a/frontend/public/style/coreos.css
+++ b/frontend/public/style/coreos.css
@@ -131,6 +131,7 @@ input[type="radio"] {
   padding: 0 0 30px 0; }
 
 .co-m-table-grid .row {
+  line-height: 1;
   margin: 0; }
 
 .co-m-table-grid .row,


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-430

**before**
![replica sets tectonic 2018-04-27 16-44-00](https://user-images.githubusercontent.com/1874151/40501918-4e0dd312-5f57-11e8-8880-f91baa8b1914.png)


**after**
<img width="789" alt="screen shot 2018-05-24 at 11 12 46 am" src="https://user-images.githubusercontent.com/1874151/40501903-452a282c-5f57-11e8-852f-ddcd5b51f344.png">
