### PR TITLE
Filter for secret's list page

### DIFF
--- a/frontend/public/components/factory/list.jsx
+++ b/frontend/public/components/factory/list.jsx
@@ -99,6 +99,13 @@ const listFilters = {
 
     let status = routeStatus(route);
     return statuses.selected.has(status) || !_.includes(statuses.all, status);
+  },
+  'secret-type': (types, secret) => {
+    if (!types || !types.selected || !types.selected.size) {
+      return true;
+    }
+    const type = secret.type;
+    return types.selected.has(type) || !_.includes(types.all, type);
   }
 };
 

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -58,7 +58,25 @@ const SecretDetails = ({obj: secret}) => {
 const SecretsList = props => <List {...props} Header={SecretHeader} Row={SecretRow} />;
 SecretsList.displayName = 'SecretsList';
 
-const SecretsPage = props => <ListPage ListComponent={SecretsList} canCreate={true} {...props} />;
+const secretType = secret => secret.type;
+
+const filters = [{
+  type: 'secret-type',
+  selected: ['kubernetes.io/service-account-token', 'kubernetes.io/dockercfg', 'kubernetes.io/dockerconfigjson', 'kubernetes.io/basic-auth', 'kubernetes.io/ssh-auth', 'kubernetes.io/tls', 'Opaque'],
+  reducer: secretType,
+  items: [
+    {id: 'kubernetes.io/basic-auth', title: 'basic-auth'},
+    {id: 'kubernetes.io/dockercfg', title: 'dockercfg'},
+    {id: 'kubernetes.io/dockerconfigjson', title: 'dockerconfigjson'},
+    {id: 'kubernetes.io/service-account-token', title: 'service-account-token'},
+    {id: 'kubernetes.io/ssh-auth', title: 'ssh-auth'},
+    {id: 'kubernetes.io/tls', title: 'tls'},
+    {id: 'Opaque', title: 'Opaque'}
+  ],
+}];
+
+const SecretsPage = props => <ListPage ListComponent={SecretsList} rowFilters={filters} canCreate={true} {...props} />;
+
 const SecretsDetailsPage = props => <DetailsPage
   {...props}
   menuActions={menuActions}


### PR DESCRIPTION
Adding secret type filter to the list page, since the list can get pretty long.
Wasn't sure if we want to keep the original secret types names or shorthand them somehow.
For now I've kept the original type names:
![1](https://user-images.githubusercontent.com/1668218/40610419-9627362a-6272-11e8-9f79-f00353d6d609.png)


But if here are some shorthands:
![2](https://user-images.githubusercontent.com/1668218/40610431-a48a94aa-6272-11e8-9ec9-b73172535fea.png)
![3](https://user-images.githubusercontent.com/1668218/40610432-a4a859b8-6272-11e8-8aab-96aeb8ddb345.png)


Personally I'm for the original names

@dtaylor113 @spadgett PTAL  