### PR TITLE
Fix Node Link on Container Detail View

### DIFF
--- a/frontend/public/components/container.jsx
+++ b/frontend/public/components/container.jsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
 
 import { getContainerState, getContainerStatus, getPullPolicyLabel } from '../module/k8s/docker';
 import * as k8sProbe from '../module/k8s/probe';
-import { Firehose, Overflow, MsgBox, NavTitle, Timestamp, VertNav } from './utils';
+import { Firehose, Overflow, MsgBox, NavTitle, Timestamp, VertNav, ResourceLink } from './utils';
 
 const getResourceLimitValue = container => {
   const limits = _.get(container, 'resources.limits');
@@ -166,7 +165,7 @@ const Details = (props) => {
         <h1 className="co-section-title">Network</h1>
         <dl className="co-m-pane__details">
           <dt>Node</dt>
-          <dd><Link to={`/nodes/${pod.spec.nodeName}`}>{pod.spec.nodeName}</Link></dd>
+          <dd><ResourceLink kind="Node" name={pod.spec.nodeName} title={pod.spec.nodeName} /></dd>
           <dt>Pod IP</dt>
           <dd>{pod.status.podIP || '-'}</dd>
         </dl>


### PR DESCRIPTION
### Description

Missing `/k8s/cluster` prefix.

Fixes https://jira.coreos.com/browse/CONSOLE-501