### PR TITLE
Fix Broken Public Path for Fonts and Images in CSS

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -58,7 +58,12 @@ let config: webpack.Configuration = {
         test: /\.s?css$/,
         exclude: /node_modules/,
         use: [
-          MiniCssExtractPlugin.loader,
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPath: './'
+            }
+          },
           { loader: 'cache-loader' },
           { loader: 'thread-loader' },
           {
@@ -83,19 +88,10 @@ let config: webpack.Configuration = {
         ],
       },
       {
-        test: /\.(png|jpg|jpeg|gif|svg)(\?.*$|$)/,
+        test: /\.(png|jpg|jpeg|gif|svg|woff2?|ttf|eot|otf)(\?.*$|$)/,
         loader: 'file-loader',
         options: {
           name: 'assets/[name].[ext]',
-        },
-      },
-      // Something's shoving 'static/' onto web fonts already. I have no clue what. - ggreer
-      {
-        test: /\.(woff2?|ttf|eot|otf)(\?.*$|$)/,
-        loader: 'file-loader',
-        options: {
-          name: 'assets/[name].[ext]',
-          publicPath: './',
         },
       },
     ]


### PR DESCRIPTION
### Description

Adds `publicPath` option to `min-css-extract-plugin` to fix all the `url()` calls in CSS files.

Fixes https://jira.coreos.com/browse/CONSOLE-473