### PR TITLE
Virtual Scrolling for Resource List Views

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -116,7 +116,7 @@ export const RoleLink = ({binding}) => {
   return <ResourceLink kind={kind} name={binding.roleRef.name} namespace={ns} />;
 };
 
-const Row = ({obj: binding}) => <ResourceRow obj={binding}>
+const Row = ({obj: binding}, style) => <ResourceRow obj={binding} style={style}>
   <div className="col-xs-3">
     <BindingName binding={binding} />
   </div>

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -42,7 +42,7 @@ const Header = props => <ListHeader>
   <ColHead {...props} className="col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
 </ListHeader>;
 
-const Row = ({obj: role}) => <div className="row co-resource-list__item">
+const Row = ({obj: role, style}) => <div className="row co-resource-list__item" style={style}>
   <div className="col-xs-6">
     <ResourceCog actions={menuActions} kind={roleKind(role)} resource={role} />
     <ResourceLink kind={roleKind(role)} name={role.metadata.name} namespace={role.metadata.namespace} />

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -67,8 +67,8 @@ const ReportsHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-2 col-md-2 hidden-sm hidden-xs" sortField="spec.reportingEnd">Reporting End</ColHead>
 </ListHeader>;
 
-const ReportsRow: React.StatelessComponent<ReportsRowProps> = ({obj}) => {
-  return <div className="row co-resource-list__item">
+const ReportsRow: React.StatelessComponent<ReportsRowProps> = ({obj, style}) => {
+  return <div className="row co-resource-list__item" style={style}>
     <div className="col-lg-3 col-md-3 col-xs-4">
       <ResourceCog actions={menuActions} kind={ReportReference} resource={obj} />
       <ResourceLink kind={ReportReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
@@ -468,6 +468,7 @@ export const ReportGenerationQueriesDetailsPage: React.StatelessComponent<Report
 /* eslint-disable no-undef */
 export type ReportsRowProps = {
   obj: any,
+  style: any,
 };
 
 export type ReportsDetailsProps = {

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -30,7 +30,7 @@ const ConfigMapHeader = props => <ListHeader>
   <ColHead {...props} className="col-sm-2 hidden-xs" sortField="metadata.creationTimestamp">Created</ColHead>
 </ListHeader>;
 
-const ConfigMapRow = ({obj: configMap}) => <ResourceRow obj={configMap}>
+const ConfigMapRow = ({obj: configMap, style}) => <ResourceRow obj={configMap} style={style}>
   <div className="col-sm-4 col-xs-6">
     <ResourceCog actions={menuActions} kind="ConfigMap" resource={configMap} />
     <ResourceLink kind="ConfigMap" name={configMap.metadata.name} namespace={configMap.metadata.namespace} title={configMap.metadata.uid} />

--- a/frontend/public/components/cron-job.jsx
+++ b/frontend/public/components/cron-job.jsx
@@ -37,7 +37,7 @@ const Header = props => <ListHeader>
 </ListHeader>;
 
 const kind = 'CronJob';
-const Row = ({obj: cronjob}) => <div className="row co-resource-list__item">
+const Row = ({obj: cronjob, style}) => <div className="row co-resource-list__item" style={style}>
   <div className="col-lg-3 col-md-3 col-sm-4 col-xs-6">
     <ResourceCog actions={menuActions} kind={kind} resource={cronjob} />
     <ResourceLink kind={kind} name={cronjob.metadata.name} title={cronjob.metadata.name} namespace={cronjob.metadata.namespace} />

--- a/frontend/public/components/custom-resource-definition.jsx
+++ b/frontend/public/components/custom-resource-definition.jsx
@@ -48,7 +48,7 @@ const isEstablished = conditions => {
 
 const namespaced = crd => crd.spec.scope === 'Namespaced';
 
-const CRDRow = ({obj: crd}) => <div className="row co-resource-list__item">
+const CRDRow = ({obj: crd, style}) => <div className="row co-resource-list__item" style={style}>
   <div className="col-lg-4 col-md-4 col-sm-4 col-xs-6">
     <ResourceCog actions={menuActions} kind="CustomResourceDefinition" resource={crd} />
     <ResourceLink kind={referenceForCRD(crd)} displayName={_.get(crd, 'spec.names.kind', crd.metadata.name)} namespace={crd.metadata.namespace} title={crd.metadata.name} />

--- a/frontend/public/components/daemonset.jsx
+++ b/frontend/public/components/daemonset.jsx
@@ -35,7 +35,7 @@ const DaemonSetHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-3 hidden-md hidden-sm hidden-xs" sortField="spec.selector">Pod Selector</ColHead>
 </ListHeader>;
 
-const DaemonSetRow = ({obj: daemonset}) => <ResourceRow obj={daemonset}>
+const DaemonSetRow = ({obj: daemonset, style}) => <ResourceRow obj={daemonset} style={style}>
   <div className="col-lg-2 col-md-3 col-sm-4 col-xs-6">
     <ResourceCog actions={menuActions} kind="DaemonSet" resource={daemonset} />
     <ResourceLink kind="DaemonSet" name={daemonset.metadata.name} namespace={daemonset.metadata.namespace} title={daemonset.metadata.uid} />

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -128,6 +128,7 @@ DeploymentConfigsPage.displayName = 'DeploymentConfigsListPage';
 /* eslint-disable no-undef */
 export type DeploymentConfigsRowProps = {
   obj: any,
+  style: any,
 };
 
 export type DeploymentConfigsPageProps = {

--- a/frontend/public/components/factory/list.jsx
+++ b/frontend/public/components/factory/list.jsx
@@ -216,6 +216,7 @@ export class Rows extends React.Component {
 
   _rowRenderer({index, style, key, parent}) {
     const {data, expand, Row, kindObj} = this.props;
+    const obj = data[index];
 
     return (
       <CellMeasurer
@@ -225,7 +226,7 @@ export class Rows extends React.Component {
         rowIndex={index}
         parent={parent}>
         <div style={style}>
-          <Row key={key} obj={data[index]} expand={expand} kindObj={kindObj} index={index} />
+          <Row key={obj.metadata.uid} obj={obj} expand={expand} kindObj={kindObj} index={index} />
         </div>
       </CellMeasurer>
     );
@@ -233,7 +234,7 @@ export class Rows extends React.Component {
 
   render () {
     const data = this.props.data;
-    return <div className="co-m-table-grid__body">
+    return <div className="co-m-table-grid__body" id="virtualized-list">
       <WindowScroller>
         {({height, isScrolling, registerChild, onChildScroll, scrollTop}) =>
           <AutoSizer disableHeight>

--- a/frontend/public/components/factory/list.jsx
+++ b/frontend/public/components/factory/list.jsx
@@ -209,6 +209,7 @@ export class Rows extends React.Component {
     this.measurementCache = new CellMeasurerCache({
       fixedWidth: true,
       minHeight: 50,
+      keyMapper: rowIndex => this.props.data[rowIndex].metadata.uid,
     });
 
     this.rowRenderer = this._rowRenderer.bind(this);
@@ -218,18 +219,16 @@ export class Rows extends React.Component {
     const {data, expand, Row, kindObj} = this.props;
     const obj = data[index];
 
-    return (
-      <CellMeasurer
-        cache={this.measurementCache}
-        columnIndex={0}
-        key={key}
-        rowIndex={index}
-        parent={parent}>
-        <div style={style}>
-          <Row key={obj.metadata.uid} obj={obj} expand={expand} kindObj={kindObj} index={index} />
-        </div>
-      </CellMeasurer>
-    );
+    return <CellMeasurer
+      cache={this.measurementCache}
+      columnIndex={0}
+      key={key}
+      rowIndex={index}
+      parent={parent}>
+      <div style={style}>
+        <Row key={obj.metadata.uid} obj={obj} expand={expand} kindObj={kindObj} index={index} />
+      </div>
+    </CellMeasurer>;
   }
 
   render () {
@@ -241,7 +240,6 @@ export class Rows extends React.Component {
             {({width}) => <div ref={registerChild}>
               <VirtualList
                 autoHeight
-                data={data}
                 height={height}
                 deferredMeasurementCache={this.measurementCache}
                 rowHeight={this.measurementCache.rowHeight}

--- a/frontend/public/components/factory/list.jsx
+++ b/frontend/public/components/factory/list.jsx
@@ -5,6 +5,7 @@ import * as classNames from'classnames';
 import * as fuzzy from 'fuzzysearch';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { AutoSizer, List as VirtualList, WindowScroller, CellMeasurerCache, CellMeasurer } from 'react-virtualized';
 
 import { getJobTypeAndCompletions, isNodeReady, podPhase, podReadiness } from '../../module/k8s';
 import { isScanned, isSupported, makePodvuln, numFixables } from '../../module/k8s/podvulns';
@@ -13,6 +14,7 @@ import { ingressValidHosts } from '../ingress';
 import { bindingType, roleType } from '../RBAC';
 import { LabelList, ResourceCog, ResourceLink, resourcePath, Selector, StatusBox, containerLinuxUpdateOperator } from '../utils';
 import { routeStatus } from '../routes';
+
 
 // TODO: Having list filters here is undocumented, stringly-typed, and non-obvious. We can change that
 const listFilters = {
@@ -200,9 +202,62 @@ export const WorkloadListHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-3 hidden-md hidden-sm hidden-xs" sortField="spec.selector">Pod Selector</ColHead>
 </ListHeader>;
 
-const Rows = ({data, expand, Row, kindObj}) => <div className="co-m-table-grid__body">
-  {data.map(obj => <Row key={obj.rowKey || obj.metadata.uid} obj={obj} expand={expand} kindObj={kindObj} />)}
-</div>;
+export class Rows extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.measurementCache = new CellMeasurerCache({
+      fixedWidth: true,
+      minHeight: 50,
+    });
+
+    this.rowRenderer = this._rowRenderer.bind(this);
+  }
+
+  _rowRenderer({index, style, key, parent}) {
+    const {data, expand, Row, kindObj} = this.props;
+
+    return (
+      <CellMeasurer
+        cache={this.measurementCache}
+        columnIndex={0}
+        key={key}
+        rowIndex={index}
+        parent={parent}>
+        <div style={style}>
+          <Row key={key} obj={data[index]} expand={expand} kindObj={kindObj} index={index} />
+        </div>
+      </CellMeasurer>
+    );
+  }
+
+  render () {
+    const data = this.props.data;
+    return <div className="co-m-table-grid__body">
+      <WindowScroller>
+        {({height, isScrolling, registerChild, onChildScroll, scrollTop}) =>
+          <AutoSizer disableHeight>
+            {({width}) => <div ref={registerChild}>
+              <VirtualList
+                autoHeight
+                data={data}
+                height={height}
+                deferredMeasurementCache={this.measurementCache}
+                rowHeight={this.measurementCache.rowHeight}
+                isScrolling={isScrolling}
+                onScroll={onChildScroll}
+                rowRenderer={this.rowRenderer}
+                rowCount={data.length}
+                scrollTop={scrollTop}
+                width={width}
+                tabIndex={null}
+              />
+            </div>}
+          </AutoSizer> }
+      </WindowScroller>
+    </div>;
+  }
+}
 
 Rows.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object),
@@ -300,11 +355,11 @@ export class ResourceRow extends React.Component {
   }
 
   render () {
-    return <div className="row co-resource-list__item">{this.props.children}</div>;
+    return <div className="row co-resource-list__item" style={this.props.style}>{this.props.children}</div>;
   }
 }
 
-export const WorkloadListRow = ({kind, actions, obj: o}) => <ResourceRow obj={o}>
+export const WorkloadListRow = ({kind, actions, obj: o, style}) => <ResourceRow obj={o} style={style}>
   <div className="col-lg-2 col-md-3 col-sm-4 col-xs-6">
     <ResourceCog actions={actions} kind={kind} resource={o} />
     <ResourceLink kind={kind} name={o.metadata.name} namespace={o.metadata.namespace} title={o.metadata.uid} />

--- a/frontend/public/components/factory/list.jsx
+++ b/frontend/public/components/factory/list.jsx
@@ -233,13 +233,14 @@ export class Rows extends React.Component {
 
   render () {
     const data = this.props.data;
-    return <div className="co-m-table-grid__body" id="virtualized-list">
+    return <div className="co-m-table-grid__body">
       <WindowScroller>
         {({height, isScrolling, registerChild, onChildScroll, scrollTop}) =>
           <AutoSizer disableHeight>
             {({width}) => <div ref={registerChild}>
               <VirtualList
                 autoHeight
+                data={data}
                 height={height}
                 deferredMeasurementCache={this.measurementCache}
                 rowHeight={this.measurementCache.rowHeight}

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -52,7 +52,7 @@ const IngressListHeader = props => <ListHeader>
   <ColHead {...props} className="col-md-3 hidden-sm hidden-xs" sortFunc="ingressValidHosts">Hosts</ColHead>
 </ListHeader>;
 
-const IngressListRow = ({obj: ingress}) => <ResourceRow obj={ingress}>
+const IngressListRow = ({obj: ingress, style}) => <ResourceRow obj={ingress} style={style}>
   <div className="col-md-3 col-sm-4 col-xs-6">
     <ResourceCog actions={menuActions} kind="Ingress" resource={ingress} />
     <ResourceLink kind="Ingress" name={ingress.metadata.name}

--- a/frontend/public/components/job.jsx
+++ b/frontend/public/components/job.jsx
@@ -40,10 +40,10 @@ const JobHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-2 hidden-md hidden-sm hidden-xs" sortFunc="jobType">Type</ColHead>
 </ListHeader>;
 
-const JobRow = ({obj: job}) => {
+const JobRow = ({obj: job, style}) => {
   const {type, completions} = getJobTypeAndCompletions(job);
   return (
-    <ResourceRow obj={job}>
+    <ResourceRow obj={job} style={style}>
       <div className="col-lg-2 col-md-3 col-sm-4 col-xs-6">
         <ResourceCog actions={menuActions} kind="Job" resource={job} />
         <ResourceLink kind="Job" name={job.metadata.name} namespace={job.metadata.namespace} title={job.metadata.uid} />

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -49,7 +49,7 @@ const NamespaceHeader = props => <ListHeader>
   <ColHead {...props} className="col-xs-4" sortField="metadata.labels">Labels</ColHead>
 </ListHeader>;
 
-const NamespaceRow = ({obj: ns}) => <ResourceRow obj={ns}>
+const NamespaceRow = ({obj: ns, style}) => <ResourceRow obj={ns} style={style}>
   <div className="col-xs-4">
     <ResourceCog actions={nsMenuActions} kind="Namespace" resource={ns} />
     <ResourceLink kind="Namespace" name={ns.metadata.name} title={ns.metadata.uid} />

--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -38,7 +38,7 @@ const Header = props => <ListHeader>
 </ListHeader>;
 
 const kind = 'NetworkPolicy';
-const Row = ({obj: np}) => <div className="row co-resource-list__item">
+const Row = ({obj: np, style}) => <div className="row co-resource-list__item" style={style}>
   <div className="col-xs-4">
     <ResourceCog actions={menuActions} kind={kind} resource={np} />
     <ResourceLink kind={kind} name={np.metadata.name} namespace={np.metadata.namespace} title={np.metadata.name} />

--- a/frontend/public/components/node.jsx
+++ b/frontend/public/components/node.jsx
@@ -78,10 +78,10 @@ const NodeCLStatusRow = ({node}) => {
   return updateStatus ? <span>{updateStatus.className && <span><i className={updateStatus.className}></i>&nbsp;&nbsp;</span>}{updateStatus.text}</span> : null;
 };
 
-const NodeRow = ({obj: node, expand}) => {
+const NodeRow = ({obj: node, expand, style}) => {
   const isOperatorInstalled = containerLinuxUpdateOperator.isOperatorInstalled(node);
 
-  return <ResourceRow obj={node} expand={expand}>
+  return <ResourceRow obj={node} expand={expand} style={style}>
     <div className="middler">
       <div className="col-xs-4">
         <NodeCog node={node} />

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -30,7 +30,7 @@ const Header = props => <ListHeader>
 </ListHeader>;
 
 const kind = 'PersistentVolumeClaim';
-const Row = ({obj}) => <div className="row co-resource-list__item">
+const Row = ({obj, style}) => <div className="row co-resource-list__item" style={style}>
   <div className="col-xs-4">
     <ResourceCog actions={menuActions} kind={kind} resource={obj} />
     <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />

--- a/frontend/public/components/persistent-volume.jsx
+++ b/frontend/public/components/persistent-volume.jsx
@@ -29,7 +29,7 @@ const Header = props => <ListHeader>
 </ListHeader>;
 
 const kind = 'PersistentVolume';
-const Row = ({obj}) => <div className="row co-resource-list__item">
+const Row = ({obj, style}) => <div className="row co-resource-list__item" style={style}>
   <div className="col-xs-4">
     <ResourceCog actions={menuActions} kind={kind} resource={obj} />
     <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -48,7 +48,7 @@ export const Readiness = ({pod}) => {
 
 Readiness.displayName = 'Readiness';
 
-export const PodRow = ({obj: pod}) => {
+export const PodRow = ({obj: pod, style}) => {
   const phase = podPhase(pod);
   let status = phase;
 
@@ -58,7 +58,7 @@ export const PodRow = ({obj: pod}) => {
     </span>;
   }
 
-  return <ResourceRow obj={pod}>
+  return <ResourceRow obj={pod} style={style}>
     <div className="col-lg-2 col-md-3 col-sm-4 col-xs-6">
       <ResourceCog actions={menuActions} kind="Pod" resource={pod} isDisabled={phase === 'Terminating'} />
       <ResourceLink kind="Pod" name={pod.metadata.name} namespace={pod.metadata.namespace} title={pod.metadata.uid} />

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -26,7 +26,7 @@ const Header = props => <ListHeader>
 </ListHeader>;
 
 const kind = 'ResourceQuota';
-const Row = ({obj: rq}) => <div className="row co-resource-list__item">
+const Row = ({obj: rq, style}) => <div className="row co-resource-list__item" style={style}>
   <div className="col-xs-4">
     <ResourceCog actions={menuActions} kind={kind} resource={rq} />
     <ResourceLink kind={kind} name={rq.metadata.name} namespace={rq.metadata.namespace} title={rq.metadata.name} />

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -26,11 +26,11 @@ const SecretHeader = props => <ListHeader>
   <ColHead {...props} className="col-md-2 hidden-sm hidden-xs" sortField="metadata.creationTimestamp">Created</ColHead>
 </ListHeader>;
 
-const SecretRow = ({obj: secret}) => {
+const SecretRow = ({obj: secret, style}) => {
   const data = _.size(secret.data);
   const age = fromNow(secret.metadata.creationTimestamp);
 
-  return <ResourceRow obj={secret}>
+  return <ResourceRow obj={secret} style={style}>
     <div className="col-md-3 col-sm-4 col-xs-6">
       <ResourceCog actions={menuActions} kind="Secret" resource={secret} />
       <ResourceLink kind="Secret" name={secret.metadata.name} namespace={secret.metadata.namespace} title={secret.metadata.uid} />

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -76,11 +76,11 @@ const Header = props => <ListHeader>
   <ColHead {...props} className="col-xs-3" sortField="metadata.creationTimestamp">Age</ColHead>
 </ListHeader>;
 
-const ServiceAccountRow = ({obj: serviceaccount}) => {
+const ServiceAccountRow = ({obj: serviceaccount, style}) => {
   const {metadata: {name, namespace, uid, creationTimestamp}, secrets} = serviceaccount;
 
   return (
-    <ResourceRow obj={serviceaccount}>
+    <ResourceRow obj={serviceaccount} style={style}>
       <div className="col-xs-3">
         <ResourceCog actions={menuActions} kind="ServiceAccount" resource={serviceaccount} />
         <ResourceLink kind="ServiceAccount" name={name} namespace={namespace} title={uid} />

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -36,7 +36,7 @@ const ServiceHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-2 hidden-md hidden-sm hidden-xs" sortField="spec.clusterIP">Location</ColHead>
 </ListHeader>;
 
-const ServiceRow = ({obj: s}) => <ResourceRow obj={s}>
+const ServiceRow = ({obj: s, style}) => <ResourceRow obj={s} style={style}>
   <div className="col-lg-3 col-md-3 col-sm-4 col-xs-6">
     <ResourceCog actions={menuActions} kind="Service" resource={s} />
     <ResourceLink kind="Service" name={s.metadata.name} namespace={s.metadata.namespace} title={s.metadata.uid} />

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -50,7 +50,7 @@ const Header = props => <ListHeader>
 </ListHeader>;
 
 const kind = 'StatefulSet';
-const Row = ({obj: ss}) => <div className="row co-resource-list__item">
+const Row = ({obj: ss, style}) => <div className="row co-resource-list__item" style={style}>
   <div className="col-xs-4">
     <ResourceCog actions={menuActions} kind={kind} resource={ss} />
     <ResourceLink kind={kind} name={ss.metadata.name} namespace={ss.metadata.namespace} title={ss.metadata.name} />

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -28,8 +28,8 @@ const StorageClassHeader = props => <ListHeader>
 </ListHeader>;
 
 
-const StorageClassRow: React.SFC<StorageClassRowProps> = ({obj}) => {
-  return <div className="row co-resource-list__item">
+const StorageClassRow: React.SFC<StorageClassRowProps> = ({obj, style}) => {
+  return <div className="row co-resource-list__item" style={style}>
     <div className="col-xs-3">
       <ResourceCog actions={menuActions} kind={StorageClassReference} resource={obj} />
       <ResourceLink kind={StorageClassReference} name={obj.metadata.name} namespace={undefined} title={obj.metadata.name} />
@@ -71,6 +71,7 @@ StorageClassDetailsPage.displayName = 'StorageClassDetailsPage';
 /* eslint-disable no-undef */
 export type StorageClassRowProps = {
   obj: any,
+  style: any,
 };
 
 export type StorageClassDetailsProps = {

--- a/frontend/public/components/utils/cog.jsx
+++ b/frontend/public/components/utils/cog.jsx
@@ -1,9 +1,8 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-
 import * as classNames from'classnames';
 import { Tooltip } from './tooltip';
+
 import { annotationsModal, configureReplicaCountModal, labelsModal, nodeSelectorModal, podSelectorModal, deleteModal } from '../modals';
 import { DropdownMixin } from './dropdown';
 import { history, resourceObjPath } from './index';
@@ -17,22 +16,6 @@ const CogItems = ({options, onClick}) => {
     {lis}
   </ul>;
 };
-
-// class CogItems extends React.Component {
-//   getListComponent() {
-//     const {options, onClick} = this.props;
-//     const visibleOptions = _.reject(options, o => _.get(o, 'hidden', false));
-//     const lis = _.map(visibleOptions, (o, i) => <li key={i}><a onClick={e =>onClick(e, o)}>{o.label}</a></li>);
-//     return <ul className="dropdown-menu co-m-cog__dropdown">
-//       {lis}
-//     </ul>;
-//   }
-
-//   render() {
-//     return ReactDOM.createPortal(this.getListComponent(), document.querySelector('#virtualized-list'));
-//     //return ReactDOM.createPortal(this.getListComponent(), document.querySelector(`#${this.props.id}`));
-//   }
-// }
 
 export class Cog extends DropdownMixin {
   constructor(props) {
@@ -56,8 +39,8 @@ export class Cog extends DropdownMixin {
 
   render () {
     const {options, anchor, isDisabled, id} = this.props;
-    return (
 
+    return (
       <div className={classNames('co-m-cog-wrapper', {'co-m-cog-wrapper--enabled': !isDisabled})} id={id}>
         { isDisabled ?
           <Tooltip content="disabled">
@@ -67,11 +50,10 @@ export class Cog extends DropdownMixin {
           </Tooltip> :
           <div ref={this.dropdownElement} onClick={this.toggle} className={classNames('co-m-cog', `co-m-cog--anchor-${anchor || 'left'}`, {'co-m-cog--disabled' : isDisabled})} >
             <span className={classNames('co-m-cog', 'co-m-cog__icon', 'fa', 'fa-cog', {'co-m-cog__icon--disabled' : isDisabled})}></span>
-            { this.state.active && <CogItems options={options} onClick={this.onClick} id={id} /> }
+            { this.state.active && <CogItems options={options} onClick={this.onClick} /> }
           </div>
         }
       </div>
-
     );
   }
 }

--- a/frontend/public/components/utils/cog.jsx
+++ b/frontend/public/components/utils/cog.jsx
@@ -1,8 +1,9 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
 import * as classNames from'classnames';
 import { Tooltip } from './tooltip';
-
 import { annotationsModal, configureReplicaCountModal, labelsModal, nodeSelectorModal, podSelectorModal, deleteModal } from '../modals';
 import { DropdownMixin } from './dropdown';
 import { history, resourceObjPath } from './index';
@@ -16,6 +17,22 @@ const CogItems = ({options, onClick}) => {
     {lis}
   </ul>;
 };
+
+// class CogItems extends React.Component {
+//   getListComponent() {
+//     const {options, onClick} = this.props;
+//     const visibleOptions = _.reject(options, o => _.get(o, 'hidden', false));
+//     const lis = _.map(visibleOptions, (o, i) => <li key={i}><a onClick={e =>onClick(e, o)}>{o.label}</a></li>);
+//     return <ul className="dropdown-menu co-m-cog__dropdown">
+//       {lis}
+//     </ul>;
+//   }
+
+//   render() {
+//     return ReactDOM.createPortal(this.getListComponent(), document.querySelector('#virtualized-list'));
+//     //return ReactDOM.createPortal(this.getListComponent(), document.querySelector(`#${this.props.id}`));
+//   }
+// }
 
 export class Cog extends DropdownMixin {
   constructor(props) {
@@ -39,8 +56,8 @@ export class Cog extends DropdownMixin {
 
   render () {
     const {options, anchor, isDisabled, id} = this.props;
-
     return (
+
       <div className={classNames('co-m-cog-wrapper', {'co-m-cog-wrapper--enabled': !isDisabled})} id={id}>
         { isDisabled ?
           <Tooltip content="disabled">
@@ -50,10 +67,11 @@ export class Cog extends DropdownMixin {
           </Tooltip> :
           <div ref={this.dropdownElement} onClick={this.toggle} className={classNames('co-m-cog', `co-m-cog--anchor-${anchor || 'left'}`, {'co-m-cog--disabled' : isDisabled})} >
             <span className={classNames('co-m-cog', 'co-m-cog__icon', 'fa', 'fa-cog', {'co-m-cog__icon--disabled' : isDisabled})}></span>
-            { this.state.active && <CogItems options={options} onClick={this.onClick} /> }
+            { this.state.active && <CogItems options={options} onClick={this.onClick} id={id} /> }
           </div>
         }
       </div>
+
     );
   }
 }

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -172,7 +172,6 @@ input[type=number]::-webkit-outer-spin-button {
 
 .co-error {
   color: $color-red-error;
-  white-space: nowrap;
 }
 
 .co-overflow-y-fade {

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -189,3 +189,11 @@ tags-input .autocomplete .suggestion-item em {
 .modal-footer .alert {
   text-align: left;
 }
+
+// FIXME: Pass as `style` prop to `List` once this is resolved (https://github.com/bvaughn/react-virtualized/issues/876)
+.ReactVirtualized__Grid.ReactVirtualized__List {
+  overflow: visible !important;
+}
+.ReactVirtualized__Grid__innerScrollContainer {
+  overflow: visible !important;
+}


### PR DESCRIPTION
### Description

Improves performance for huge resource lists (they don't crash) using `react-virtualized`.

### Testing

1. Run using load testing ServiceWorker: `./bin/bridge --load-test-factor 30`
2. View "Workloads"->"Pods"
3. Observe the smooth scrolling

Addresses https://jira.coreos.com/browse/CONSOLE-467