### PR TITLE
Implement download button feature for logs

### DIFF
--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -87,6 +87,9 @@
 
 .co-m-pane__top-controls {
   margin: 0 0 10px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .co-inline-block {


### PR DESCRIPTION
# Description
Log content can be downloaded via a download button on the top right corner of the log window. This downloads the currently displayed content (up to the last 1000 lines of the log).

# Changes
- Refactored `co-m-pane__top-controls` to `top-controls` and now uses flexbox.
  - `top-controls__group` and modifiers `top-controls__group--right`, and `--left` can now be used as children to distribute control item groups across the top controls element. Items within these groups are aligned as the class name suggests (center by default). This is a wrapper for a group of control items in the top control element.
  - `top-controls__item` should be used as a child of a top controls group element and are automatically vertically centered, and spaced 15px apart horizontally. This is a wrapper for each control item in a top controls group element.
- Implemented download functionality in the ResourceLog component
- Removed obsolete `_resource-log.scss`. Top controls style refactoring made these styles unnecessary.
- Update PodExec component to use new top controls styles (only other place where top controls was used).

# Screenshots
![screenshot-localhost-9000-2018 05 29-12-59-18](https://user-images.githubusercontent.com/22625502/40673641-5079d5d2-6340-11e8-934e-7561235b6945.png)

320px screen width
![screenshot-localhost-9000-2018 05 30-12-15-44](https://user-images.githubusercontent.com/22625502/40733848-b2345076-6404-11e8-8abb-277ede557c92.png)


@openshift/team-ux-review 