### PR TITLE
Append .co-external-link icon to link using psuedo element and make it an inline-block

### DIFF
--- a/frontend/public/components/cloud-services/clusterserviceversion.tsx
+++ b/frontend/public/components/cloud-services/clusterserviceversion.tsx
@@ -71,7 +71,7 @@ export const ClusterServiceVersionRow = withFallback<ClusterServiceVersionRowPro
 });
 
 const EmptyAppsMsg = () => <MsgBox title="No Applications Found" detail={<div>
-  Applications are installed per namespace from the Open Cloud Catalog. For more information, see <a href="https://coreos.com/tectonic/docs/latest/alm/using-ocs.html" target="_blank" rel="noopener noreferrer">Using Open Cloud Services <i className="fa fa-external-link" /></a>.
+  Applications are installed per namespace from the Open Cloud Catalog. For more information, see <a href="https://coreos.com/tectonic/docs/latest/alm/using-ocs.html" target="_blank" className="co-external-link" rel="noopener noreferrer">Using Open Cloud Services</a>.
 </div>} />;
 
 export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps> = (props) => {
@@ -121,7 +121,7 @@ const stateToProps = ({k8s, FLAGS}, {match}) => ({
 });
 
 const EmptyCustomAppsMsg = () => <MsgBox title="No Custom Applications Found" detail={<div>
-  Create custom applications by using the <a href="https://github.com/operator-framework/helm-app-operator-kit" target="_blank" rel="noopener noreferrer">Helm App Operator Kit <i className="fa fa-external-link" /></a>.
+  Create custom applications by using the <a href="https://github.com/operator-framework/helm-app-operator-kit" target="_blank" className="co-external-link" rel="noopener noreferrer">Helm App Operator Kit</a>.
 </div>} />;
 
 export const ClusterServiceVersionsPage = connect(stateToProps)(

--- a/frontend/public/components/cluster-overview.jsx
+++ b/frontend/public/components/cluster-overview.jsx
@@ -30,7 +30,7 @@ const fetchTectonicHealth = () => coFetchJSON('health')
   .catch(() => ({short: 'ERROR', long: 'The console service cannot be reached', status: 'ERROR'}));
 
 
-const DashboardLink = ({to, id}) => <Link id={id} target="_blank" to={to}>View Grafana Dashboard&nbsp;&nbsp;<i className="fa fa-external-link" /></Link>;
+const DashboardLink = ({to, id}) => <Link id={id} className="co-external-link" target="_blank" to={to}>View Grafana Dashboard</Link>;
 
 
 const Graphs = ({namespace}) => <React.Fragment>
@@ -159,7 +159,7 @@ const GraphsPage = connectToFlags(FLAGS.OPENSHIFT)(({limited, namespace, flags})
       <div className="group">
         <div className="group__title">
           <h2 className="h3">Software Info</h2>
-          {!openshiftFlag && <a href="https://coreos.com/tectonic/releases/" target="_blank" rel="noopener noreferrer">Release Notes&nbsp;&nbsp;<i className="fa fa-external-link" /></a>}
+          {!openshiftFlag && <a href="https://coreos.com/tectonic/releases/" target="_blank" className="co-external-link" rel="noopener noreferrer">Release Notes</a>}
         </div>
         <div className="container-fluid group__body">
           <SoftwareDetails />
@@ -168,7 +168,7 @@ const GraphsPage = connectToFlags(FLAGS.OPENSHIFT)(({limited, namespace, flags})
       <div className="group">
         <div className="group__title">
           <h2 className="h3">Documentation</h2>
-          {!openshiftFlag && <a href={tectonicHelpBase} target="_blank" rel="noopener noreferrer">Full Documentation&nbsp;&nbsp;<i className="fa fa-external-link" /></a>}
+          {!openshiftFlag && <a href={tectonicHelpBase} target="_blank" className="co-external-link" rel="noopener noreferrer">Full Documentation</a>}
         </div>
         <div className="container-fluid group__body group__documentation">
           {openshiftFlag ? <OpenShiftDocumentationLinks /> : <TectonicDocumentationLinks />}

--- a/frontend/public/components/cluster-settings/cluster-monitoring.jsx
+++ b/frontend/public/components/cluster-settings/cluster-monitoring.jsx
@@ -184,12 +184,12 @@ const MemCPUModalLink = ({section, type, config, obj}) => {
       ? <div className="col-xs-12 text-muted" style={{paddingTop: 15, paddingBottom: 10}}>
         Requests and limits for CPU resources are measured in &ldquo;cpu units&rdquo; in absolute quantities.
         The expression &ldquo;100m&rdquo; can be read as &ldquo;one hundred millicpus&rdquo; or &ldquo;one hundred millicores&rdquo;.
-        See <a href="https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu" target="_blank" rel="noopener noreferrer">Meaning of CPU <i className="fa fa-external-link"/></a> for details.
+        See <a href="https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu" target="_blank" className="co-external-link" rel="noopener noreferrer">Meaning of CPU</a> for details.
       </div>
       : <div className="col-xs-12 text-muted" style={{paddingTop: 15, paddingBottom: 10}}>
         Requests and limits for memory are measured in bytes.
         For example, the following are roughly equivalent: 128974848 ≈ 129M ≈ 123Mi.
-        See <a href="https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory" target="_blank" rel="noopener  noreferrer">Meaning of memory <i className="fa fa-external-link"/></a> for more details.
+        See <a href="https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory" target="_blank" className="co-external-link" rel="noopener  noreferrer">Meaning of memory</a> for more details.
       </div>;
 
     const FormBody = ({error}) => <div>

--- a/frontend/public/components/clusters.tsx
+++ b/frontend/public/components/clusters.tsx
@@ -42,7 +42,7 @@ const ClustersRow: React.SFC<ClustersRowProps> = ({obj}) => {
     <div className="col-xs-5">
       {clusterLink
         ? <span className="text-muted">Console:&nbsp;
-          <a href={clusterLink.toString()} target="_blank" rel="noopener noreferrer">{clusterLink} <i className="fa fa-external-link"></i></a>
+          <a href={clusterLink.toString()} target="_blank" className="co-external-link" rel="noopener noreferrer">{clusterLink}</a>
         </span>
         : '—'
       }

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -78,9 +78,8 @@ const getRouteLabel = (route) => {
 };
 
 export const RouteLocation: React.SFC<RouteHostnameProps> = ({obj}) => <div>
-  {isWebRoute(obj) ? <a href={getRouteWebURL(obj)} target="_blank" rel="noopener noreferrer">
-    {getRouteLabel(obj)}&nbsp;<i className="fa fa-external-link" aria-hidden="true"/>
-  </a> : getRouteLabel(obj)
+  {isWebRoute(obj) ? <a href={getRouteWebURL(obj)} target="_blank" className="co-external-link" rel="noopener noreferrer">
+    {getRouteLabel(obj)}</a> : getRouteLabel(obj)
   }
 </div>;
 RouteLocation.displayName = 'RouteLocation';

--- a/frontend/public/components/start-guide.jsx
+++ b/frontend/public/components/start-guide.jsx
@@ -62,8 +62,8 @@ class StartGuide_ extends SafetyFirst {
       <hr />
       <h2>You may also be interested in</h2>
       <ul>
-        <li>Grant and manage user access with Tectonic Identity. See <a href="https://coreos.com/tectonic/docs/latest/users/tectonic-identity-config.html" target="_blank" rel="noopener">User Management through Tectonic Identity <i className="fa fa-external-link" /></a>.</li>
-        <li>Troubleshoot your Tectonic clusters. See <a href="https://coreos.com/tectonic/docs/latest/troubleshooting/troubleshooting.html" target="_blank" rel="noopener">Troubleshooting Tectonic <i className="fa fa-external-link" /></a>.</li>
+        <li>Grant and manage user access with Tectonic Identity. See <a href="https://coreos.com/tectonic/docs/latest/users/tectonic-identity-config.html" target="_blank" className="co-external-link" rel="noopener">User Management through Tectonic Identity</a></li>
+        <li>Troubleshoot your Tectonic clusters. See <a href="https://coreos.com/tectonic/docs/latest/troubleshooting/troubleshooting.html" className="co-external-link" target="_blank" rel="noopener">Troubleshooting Tectonic</a></li>
       </ul>
     </div>;
     /* eslint-enable react/jsx-no-target-blank */

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -190,3 +190,21 @@ input[type=number]::-webkit-outer-spin-button {
 .co-break-word {
   @include co-break-word;
 }
+
+// append external-link icon to <a> so that it doesn't wrap without text
+// there must be no white space between the text and the closing </a> tag holding the pseudo element
+.co-external-link:after {
+  content: "\f08e";
+  display:inline-block;
+  font-family: 'FontAwesome';
+  height: 16px;
+  position:relative;
+  margin-left: 5px;
+  margin-right: -25px; // width + margin-left
+  top:0;
+  width: 20px;
+}
+.co-external-link {
+  display: inline-block;
+  padding-right: 25px;
+}


### PR DESCRIPTION
... this enables it to stay appended to the text and won't wrap by itself. Also the `:hover` underline is limited to text.

Fixes https://jira.coreos.com/browse/CONSOLE-488

**before**
<img width="1206" alt="screen shot 2018-05-29 at 1 38 42 pm" src="https://user-images.githubusercontent.com/1874151/40675616-37e4639c-6346-11e8-9c06-6859f752651d.png">

**after**
<img width="1206" alt="screen shot 2018-05-29 at 1 39 09 pm" src="https://user-images.githubusercontent.com/1874151/40675619-3b209198-6346-11e8-8dd6-0cd67afdd35e.png">

**before**
<img width="749" alt="screen shot 2018-05-29 at 11 31 53 am" src="https://user-images.githubusercontent.com/1874151/40674257-3ce73bde-6342-11e8-93e3-3cd09e25fc9b.png">

**after**
<img width="748" alt="screen shot 2018-05-29 at 11 32 24 am" src="https://user-images.githubusercontent.com/1874151/40674252-3a82feaa-6342-11e8-8979-87b363b5ec67.png">

**before**
<img width="223" alt="screen shot 2018-05-29 at 11 34 39 am" src="https://user-images.githubusercontent.com/1874151/40674272-5078bf06-6342-11e8-8431-1145c781bd61.png">

**after**
<img width="245" alt="screen shot 2018-05-29 at 11 34 13 am" src="https://user-images.githubusercontent.com/1874151/40674280-5608aaf8-6342-11e8-80dc-f127e8d0eb98.png">
