### PR TITLE
MultiDetailsPage

### DIFF
--- a/frontend/__tests__/components/factory/details.spec.tsx
+++ b/frontend/__tests__/components/factory/details.spec.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable no-unused-vars */
+
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+
+import { DetailsPage, DetailsPageProps } from '../../../public/components/factory/details';
+import { PodModel, ConfigMapModel } from '../../../public/models';
+import { referenceForModel } from '../../../public/module/k8s';
+import { Firehose } from '../../../public/components/utils';
+
+describe(DetailsPage.displayName, () => {
+  let wrapper: ShallowWrapper<DetailsPageProps>;
+
+  beforeEach(() => {
+    const match = {params: {ns: 'default'}, isExact: true, path: '', url: ''};
+
+    wrapper = shallow(<DetailsPage match={match} name="test-name" namespace="default" kind={referenceForModel(PodModel)} pages={[]} />);
+  });
+
+  it('renders a `Firehose` using the given props', () => {
+    expect(wrapper.find<any>(Firehose).props().resources[0]).toEqual({
+      kind: referenceForModel(PodModel),
+      name: 'test-name',
+      namespace: 'default',
+      isList: false,
+      prop: 'obj',
+    });
+  });
+
+  it('adds extra resources to `Firehose` if provided in props', () => {
+    const resources = [{
+      kind: referenceForModel(ConfigMapModel),
+      name: 'test-configmap',
+      namespace: 'kube-system',
+      isList: false,
+      prop: 'configMap',
+    }];
+    wrapper = wrapper.setProps({resources});
+
+    expect(wrapper.find<any>(Firehose).props().resources.length).toEqual(resources.length + 1);
+    resources.forEach((resource, i) => {
+      expect(wrapper.find<any>(Firehose).props().resources[i + 1]).toEqual(resource);
+    });
+  });
+});

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -13,7 +13,7 @@ export const DetailsPage: React.SFC<DetailsPageProps> = (props) => <Firehose res
   namespace: props.namespace,
   isList: false,
   prop: 'obj',
-}]}>
+}].concat(props.resources || [])}>
   <NavTitle detail={true} title={props.name} menuActions={props.menuActions} kind={props.kind} breadcrumbsFor={props.breadcrumbsFor} />
   <VertNav pages={props.pages} className={`co-m-${_.get(props.kind, 'kind', props.kind)}`} match={props.match} label={props.label || (props.kind as any).label} />
 </Firehose>;
@@ -27,6 +27,7 @@ export type DetailsPageProps = {
   label?: string;
   name?: string;
   namespace?: string;
+  resources?: {kind: K8sResourceKindReference, name: string, namespace: string, isList: boolean, prop: string}[];
   breadcrumbsFor?: (obj: K8sResourceKind) => {name: string, path: string}[];
 };
 


### PR DESCRIPTION
### Description

Adds ability for `DetailsPage` to watch other resources by passing `props.resources`. Didn't implement as a separate component (like `MultiListPage`) because it is straightforward to add resources to the `<Firehose>`. This will clean up a lot of ugly code in the OLM UI, at least.