### PR TITLE
Bump versions of various software in builder image.

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -2,7 +2,7 @@
 # (and committing your edits) you should run ./push-builder.sh to
 # push a new version of your image to quay.io/coreos/tectonic-console-builder
 
-FROM golang:1.9.2-stretch
+FROM golang:1.10-stretch
 
 MAINTAINER Ed Rooth - CoreOS
 
@@ -11,8 +11,8 @@ RUN go get -u github.com/golang/lint/golint
 RUN go get github.com/jstemmer/go-junit-report
 
 ### Install NodeJS and yarn
-ENV NODE_VERSION="v9.5.0"
-ENV YARN_VERSION="v1.3.2"
+ENV NODE_VERSION="v10.3.0"
+ENV YARN_VERSION="v1.7.0"
 
 # yarn needs a home writable by any user running the container
 ENV HOME /opt/home

--- a/builder-run.sh
+++ b/builder-run.sh
@@ -11,7 +11,7 @@ set -e
 # Without env vars:
 #   ./builder-run.sh ./my-script --my-script-arg1 --my-script-arg2
 
-BUILDER_IMAGE="quay.io/coreos/tectonic-console-builder:v15"
+BUILDER_IMAGE="quay.io/coreos/tectonic-console-builder:v16"
 
 # forward whitelisted env variables to docker
 ENV_STR=""


### PR DESCRIPTION
- Go v1.10
- Node v10.3
- Yarn v1.7.0
- Chrome v67