### PR TITLE
frontend: Route Details - Updated TLS Settings to allow Copy and Mask settings

### DIFF
--- a/frontend/public/components/_route.scss
+++ b/frontend/public/components/_route.scss
@@ -6,3 +6,12 @@
 .co-m-route-warnings {
   white-space: pre-wrap;
 }
+
+.co-m-route-tls-reveal__title {
+  display: flex;
+  justify-content: space-between;
+}
+
+.co-m-route-tls-reveal__btn {
+  padding-right: 0;
+}

--- a/frontend/public/components/configmap-and-secret-data.jsx
+++ b/frontend/public/components/configmap-and-secret-data.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { Heading, CopyToClipboard } from './utils';
 
-const MaskedData = () => <React.Fragment>
+export const MaskedData = () => <React.Fragment>
   <span className="sr-only">Value hidden</span>
   <span aria-hidden="true">&bull;&bull;&bull;&bull;&bull;</span>
 </React.Fragment>;


### PR DESCRIPTION
Updated TLS Settings section of Route Details page:
![image](https://user-images.githubusercontent.com/12733153/40982843-4eda41f0-68ac-11e8-9193-e9bd43a0bf07.png)
----
![image](https://user-images.githubusercontent.com/12733153/40982861-57095d52-68ac-11e8-89db-e8ec68149a72.png)

@openshift/team-ux-review 

Related PRs for hide/reveal secrets; lots of design conversations:
https://github.com/openshift/console/pull/23
https://github.com/openshift/console/pull/50