### PR TITLE
Add reorder for environment variables via drag and drop ui using handle icons.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,6 +69,8 @@
     "prop-types": "15.6.x",
     "react": "16.x",
     "react-copy-to-clipboard": "5.x",
+    "react-dnd": "^2.6.0",
+    "react-dnd-html5-backend": "^2.6.0",
     "react-dom": "16.x",
     "react-helmet": "5.x",
     "react-lightweight-tooltip": "1.x",

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -3,8 +3,14 @@ import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
 
 import { modelFor, k8sPatch } from '../module/k8s';
-import { NameValueEditor, NAME, VALUE } from './utils/name-value-editor';
-import { PromiseComponent } from './utils';
+import { PromiseComponent, NameValueEditorPair } from './utils';
+import { AsyncComponent } from './utils/async';
+
+/**
+ * Set up an AsyncComponent to wrap the name-value-editor to allow on demand loading to reduce the
+ * vendor footprint size.
+ */
+const NameValueEditorComponent = (props) => <AsyncComponent loader={() => import('./utils/name-value-editor.jsx').then(c => c.NameValueEditor)} {...props} />;
 
 /**
  * Set up initial value for the environment vars state. Use this in constructor or cancelChanges.
@@ -15,9 +21,10 @@ import { PromiseComponent } from './utils';
  */
 const getPairsFromObject = (element) => {
   if (_.isUndefined(element.env)) {
-    return [['', '']];
+    return [['', '', 0]];
   }
-  return _.map(element.env, (leafNode) => {
+  return _.map(element.env, (leafNode, i) => {
+    leafNode.ID = i;
     return Object.values(leafNode);
   });
 };
@@ -66,17 +73,17 @@ export class EnvironmentPage extends PromiseComponent {
    * @private
    */
   _envVarsToNameVal(finalEnvPairs) {
-    return _.filter(finalEnvPairs, finalEnvPair => !_.isEmpty(finalEnvPair[NAME]))
+    return _.filter(finalEnvPairs, finalEnvPair => !_.isEmpty(finalEnvPair[NameValueEditorPair.Name]))
       .map(finalPairForContainer => {
-        if (finalPairForContainer[VALUE] instanceof Object) {
+        if (finalPairForContainer[NameValueEditorPair.Value] instanceof Object) {
           return {
-            'name': finalPairForContainer[NAME],
-            'valueFrom': finalPairForContainer[VALUE]
+            'name': finalPairForContainer[NameValueEditorPair.Name],
+            'valueFrom': finalPairForContainer[NameValueEditorPair.Value]
           };
         }
         return {
-          'name': finalPairForContainer[NAME],
-          'value': finalPairForContainer[VALUE]
+          'name': finalPairForContainer[NameValueEditorPair.Name],
+          'value': finalPairForContainer[NameValueEditorPair.Value]
         };
       });
   }
@@ -186,7 +193,7 @@ export class EnvironmentPage extends PromiseComponent {
       const keyString = _.isArray(rawEnvData) ? rawEnvData[i].name : rawEnvData.from.name;
       return <div key={keyString} className="co-m-pane__body-group">
         { _.isArray(rawEnvData) && <h1 className="co-section-title">Container {keyString}</h1> }
-        <NameValueEditor nameValueId={i} nameValuePairs={envVar} updateParentData={this.updateEnvVars} addString="Add Value" nameString="Name" readOnly={readOnly}/>
+        <NameValueEditorComponent nameValueId={i} nameValuePairs={envVar} updateParentData={this.updateEnvVars} addString="Add Value" nameString="Name" readOnly={readOnly} allowSorting={true}/>
       </div>;
     });
 

--- a/frontend/public/components/utils/_name-value-editor.scss
+++ b/frontend/public/components/utils/_name-value-editor.scss
@@ -2,6 +2,11 @@
   padding-bottom: 15px;
 }
 
+.pairs-list__row-dragging {
+  padding-bottom: 15px;
+  opacity: 0
+}
+
 .pairs-list__field {
   padding-right: 0;
 }

--- a/frontend/public/components/utils/draggable-item-types.js
+++ b/frontend/public/components/utils/draggable-item-types.js
@@ -1,0 +1,3 @@
+export const DRAGGABLE_TYPE = {
+  ROW: 'row',
+};

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -37,3 +37,15 @@ export * from './deployment-pod-counts';
 export * from './entitlements';
 export * from './build-strategy';
 export * from './copy-to-clipboard';
+
+/*
+  Add the enum for NameValueEditorPair here and not in its namesake file because the editor should always be
+  loaded asynchronously in order not to bloat the vendor file. The enum reference into the editor
+  will cause it not to load asynchronously.
+ */
+/* eslint-disable no-undef */
+export const enum NameValueEditorPair {
+  Name = 0,
+  Value,
+  Index
+}

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -1,22 +1,27 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash-es';
+import * as classNames from 'classnames';
+import { DragDropContext, DragSource, DropTarget } from 'react-dnd';
+import { DRAGGABLE_TYPE } from './draggable-item-types';
+import HTML5Backend from 'react-dnd-html5-backend';
 
+import { NameValueEditorPair } from './index';
 import { ValueFromPair } from './value-from-pair';
 
-export const NAME = 0;
-export const VALUE = 1;
-
-export class NameValueEditor extends React.Component {
+export const NameValueEditor = DragDropContext(HTML5Backend)(class NameValueEditor extends React.Component {
   constructor (props) {
     super(props);
     this._append = this._append.bind(this);
+    this._change = this._change.bind(this);
+    this._move = this._move.bind(this);
+    this._remove = this._remove.bind(this);
   }
 
   _append() {
-    const {updateParentData, nameValuePairs, nameValueId} = this.props;
+    const {updateParentData, nameValuePairs, nameValueId, allowSorting} = this.props;
 
-    updateParentData({nameValuePairs: nameValuePairs.concat([['', '']])}, nameValueId);
+    updateParentData({nameValuePairs: allowSorting ? nameValuePairs.concat([['', '', nameValuePairs.length]]) : nameValuePairs.concat([['', '']])}, nameValueId);
   }
 
   _remove(i) {
@@ -31,42 +36,24 @@ export class NameValueEditor extends React.Component {
     const {updateParentData, nameValueId} = this.props;
     const nameValuePairs = _.cloneDeep(this.props.nameValuePairs);
 
-    nameValuePairs[i][type === NAME ? NAME : VALUE] = e.target.value;
+    nameValuePairs[i][type === NameValueEditorPair.Name ? NameValueEditorPair.Name : NameValueEditorPair.Value] = e.target.value;
+    updateParentData({nameValuePairs}, nameValueId);
+  }
+
+  _move(dragIndex, hoverIndex) {
+    const {updateParentData, nameValueId} = this.props;
+    const nameValuePairs = _.cloneDeep(this.props.nameValuePairs);
+    const movedPair = nameValuePairs[dragIndex];
+
+    nameValuePairs[dragIndex] = nameValuePairs[hoverIndex];
+    nameValuePairs[hoverIndex] = movedPair;
     updateParentData({nameValuePairs}, nameValueId);
   }
 
   render () {
-    const {nameString, valueString, addString, nameValuePairs, allowSorting, readOnly} = this.props;
-
+    const {nameString, valueString, addString, nameValuePairs, allowSorting, readOnly, nameValueId} = this.props;
     const pairElems = nameValuePairs.map((pair, i) => {
-
-      let iconSection = null;
-      if (!readOnly) {
-        iconSection = allowSorting ?
-          <div className="col-xs-1">
-            <span className="pairs-list__span-btns">
-              <i className="fa fa-bars pairs-list__reorder-icon" />
-              <i className="fa fa-minus-circle pairs-list__btn pairs-list__delete-icon" onClick={() => this._remove(i)}></i>
-            </span>
-          </div> :
-          <div className="col-xs-1">
-            <i className="fa fa-minus-circle pairs-list__btn pairs-list__delete-icon" onClick={() => this._remove(i)}></i>
-          </div>;
-      }
-
-      return <div className="row pairs-list__row" key={i}>
-        <div className="col-xs-5 pairs-list__field">
-          <input type="text" className="form-control" placeholder={nameString.toLowerCase()} value={pair[NAME]} onChange={e => this._change(e, i, NAME)} disabled={readOnly} />
-        </div>
-        <div className="col-xs-6 pairs-list__field">
-          {
-            _.isPlainObject(pair[VALUE]) ?
-              <ValueFromPair pair={pair[VALUE]} /> :
-              <input type="text" className="form-control" placeholder={valueString.toLowerCase()} value={pair[VALUE] || ''} onChange={e => this._change(e, i, VALUE)} disabled={readOnly}/>
-          }
-        </div>
-        { iconSection }
-      </div>;
+      return <PairElement onChange={this._change} index={i} nameString={nameString} valueString={valueString} allowSorting={allowSorting} readOnly={readOnly} pair={pair} key={pair[NameValueEditorPair.Index]} onRemove={this._remove} onMove={this._move} rowSourceId={nameValueId}/>;
     });
 
     return <div>
@@ -88,8 +75,7 @@ export class NameValueEditor extends React.Component {
       </div>
     </div>;
   }
-}
-
+});
 NameValueEditor.propTypes = {
   nameString: PropTypes.string,
   valueString: PropTypes.string,
@@ -101,6 +87,7 @@ NameValueEditor.propTypes = {
     PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.object])),
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number])),
     ])
   ).isRequired,
   updateParentData: PropTypes.func.isRequired
@@ -113,3 +100,151 @@ NameValueEditor.defaultProps = {
   readOnly: false,
   nameValueId: 0
 };
+
+
+const pairSource = {
+  beginDrag(props) {
+    return {
+      index: props.index,
+      rowSourceId: props.rowSourceId
+    };
+  }
+};
+
+const itemTarget = {
+  hover(props, monitor, component) {
+    const dragIndex = monitor.getItem().index;
+    const hoverIndex = props.index;
+
+    // Don't replace items with themselves or with other row groupings on the page
+    if (dragIndex === hoverIndex || monitor.getItem().rowSourceId !== props.rowSourceId) {
+      return;
+    }
+
+    // Determine rectangle on screen
+    const hoverBoundingRect = component.node.getBoundingClientRect();
+
+    // Get vertical middle
+    const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+
+    // Determine mouse position
+    const clientOffset = monitor.getClientOffset();
+
+    // Get pixels to the top
+    const hoverClientY = clientOffset.y - hoverBoundingRect.top;
+
+    // Only perform the move when the mouse has crossed half of the items height
+    // When dragging downwards, only move when the cursor is below 50%
+    // When dragging upwards, only move when the cursor is above 50%
+
+    // Dragging downwards
+    if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
+      return;
+    }
+
+    // Dragging upwards
+    if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
+      return;
+    }
+
+    // Time to actually perform the action
+    props.onMove(dragIndex, hoverIndex);
+
+    // Note: we're mutating the monitor item here!
+    // Generally it's better to avoid mutations,
+    // but it's good here for the sake of performance
+    // to avoid expensive index searches.
+    monitor.getItem().index = hoverIndex;
+  }
+};
+
+const collectSourcePair = (connect, monitor) => ({
+  connectDragSource: connect.dragSource(),
+  connectDragPreview: connect.dragPreview(),
+  isDragging: monitor.isDragging()
+});
+
+const collectTargetPair = (connect) => ({
+  connectDropTarget: connect.dropTarget(),
+});
+
+const PairElement = DragSource(DRAGGABLE_TYPE.ROW, pairSource, collectSourcePair)(DropTarget(DRAGGABLE_TYPE.ROW, itemTarget, collectTargetPair)(class PairElement extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this._onRemove = this._onRemove.bind(this);
+    this._onChangeName = this._onChangeName.bind(this);
+    this._onChangeValue = this._onChangeValue.bind(this);
+  }
+
+  _onRemove() {
+    const {index, onRemove} = this.props;
+    onRemove(index);
+  }
+
+  _onChangeName(e) {
+    const {index, onChange} = this.props;
+    onChange(e, index, NameValueEditorPair.Name);
+  }
+
+  _onChangeValue(e) {
+    const {index, onChange} = this.props;
+    onChange(e, index, NameValueEditorPair.Value);
+  }
+
+  render() {
+    const {isDragging, connectDragSource, connectDragPreview, connectDropTarget, nameString, valueString, allowSorting, readOnly, pair} = this.props;
+    const deleteButton = <React.Fragment><i className="fa fa-minus-circle pairs-list__btn pairs-list__delete-icon" aria-hidden={true} onClick={this._onRemove}></i><span className="sr-only">Delete</span></React.Fragment>;
+
+    return connectDropTarget(
+      connectDragPreview(
+        <div className={classNames('row', isDragging ? 'pairs-list__row-dragging' : 'pairs-list__row')} ref={node => this.node = node}>
+          <div className="col-xs-5 pairs-list__field">
+            <input type="text" className="form-control" placeholder={nameString.toLowerCase()} value={pair[NameValueEditorPair.Name]} onChange={this._onChangeName} disabled={readOnly}/>
+          </div>
+          <div className="col-xs-6 pairs-list__field">
+            {
+              _.isPlainObject(pair[NameValueEditorPair.Value]) ?
+                <ValueFromPair pair={pair[NameValueEditorPair.Value]}/> :
+                <input type="text" className="form-control" placeholder={valueString.toLowerCase()} value={pair[NameValueEditorPair.Value] || ''} onChange={this._onChangeValue} disabled={readOnly}/>
+            }
+          </div>
+          {
+            readOnly ? null :
+              <div className="col-xs-1">
+                <span className={classNames(allowSorting ? 'pairs-list__span-btns' : null)}>
+                  {
+                    allowSorting ?
+                      <React.Fragment>
+                        {connectDragSource(<i className="fa fa-bars pairs-list__reorder-icon"/>)}
+                        {deleteButton}
+                      </React.Fragment>
+                      :
+                      deleteButton
+                  }
+                </span>
+              </div>
+          }
+        </div>)
+    );
+  }
+}));
+PairElement.propTypes = {
+  nameString: PropTypes.string,
+  valueString: PropTypes.string,
+  readOnly: PropTypes.bool,
+  index: PropTypes.number.isRequired,
+  pair: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.object])),
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number])),
+  ]),
+  allowSorting: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+  connectDragSource: PropTypes.func,
+  connectDropTarget: PropTypes.func,
+  isDragging: PropTypes.bool,
+  onMove: PropTypes.func.isRequired,
+  rowSourceId: PropTypes.number.isRequired
+};
+

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -486,7 +486,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@~2.0.3:
+asap@^2.0.6, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -2786,6 +2786,19 @@ discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
+disposables@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/disposables/-/disposables-1.0.2.tgz#36c6a674475f55a2d6913567a601444e487b4b6e"
+
+dnd-core@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-2.6.0.tgz#12bad66d58742c6e5f7cf2943fb6859440f809c4"
+  dependencies:
+    asap "^2.0.6"
+    invariant "^2.0.0"
+    lodash "^4.2.0"
+    redux "^3.7.1"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -4820,7 +4833,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.1.0, hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -5097,7 +5110,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3:
+invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -6323,6 +6336,10 @@ lodash@3.10.0:
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lodash@^4.2.0:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -8416,6 +8433,23 @@ react-copy-to-clipboard@5.x:
     copy-to-clipboard "^3"
     prop-types "^15.5.8"
 
+react-dnd-html5-backend@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-2.6.0.tgz#590cd1cca78441bb274edd571fef4c0b16ddcf8e"
+  dependencies:
+    lodash "^4.2.0"
+
+react-dnd@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-2.6.0.tgz#7fa25676cf827d58a891293e3c1ab59da002545a"
+  dependencies:
+    disposables "^1.0.1"
+    dnd-core "^2.6.0"
+    hoist-non-react-statics "^2.1.0"
+    invariant "^2.1.0"
+    lodash "^4.2.0"
+    prop-types "^15.5.10"
+
 react-dom@16.x:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.1.tgz#6a3c90a4fb62f915bdbcf6204422d93a7d4ca573"
@@ -8727,7 +8761,7 @@ redux-thunk@2.x:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
-redux@3.x, redux@^3.6.0:
+redux@3.x, redux@^3.6.0, redux@^3.7.1:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
   dependencies:


### PR DESCRIPTION
Jira Link: https://jira.coreos.com/browse/CONSOLE-412

1. Introduce React-dnd implementation for drag and drop and create the first type of ROW in draggable types.
2. Add PairElement component as draggable source/destination.
2. Introduce an id for the environment vars to distinguish when reordering the pair elements.
3. Make the name-value-editor a drag drop context for draggable elements.

![envdndgif](https://user-images.githubusercontent.com/35978579/40850793-87d06bf4-6593-11e8-80bc-156695275e2d.gif)


@openshift/team-ux-review