### PR TITLE
Create/Edit page for Webhook secrets

### DIFF
--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -85,7 +85,13 @@ describe('Kubernetes resource CRUD operations', () => {
       }
 
       it('displays a YAML editor for creating a new resource instance', async() => {
-        await crudView.createYAMLButton.click();
+        const exists = await crudView.createItemButton.isPresent();
+        if (exists) {
+          await crudView.createItemButton.click();
+          await crudView.createYAMLLink.click();
+        } else {
+          await crudView.createYAMLButton.click();
+        }
         await yamlView.isLoaded();
 
         const content = await yamlView.editorContent.getText();

--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -1,6 +1,8 @@
 import { $, $$, browser, ExpectedConditions as until } from 'protractor';
 
 export const createYAMLButton = $('#yaml-create');
+export const createItemButton = $('#item-create');
+export const createYAMLLink = $('#yaml-link');
 
 /**
  * Returns a promise that resolves after the loading spinner is not present.

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -24,6 +24,7 @@ import { Nav } from './nav';
 import { ProfilePage } from './profile';
 import { ResourceDetailsPage, ResourceListPage } from './resource-list';
 import { CopyRoleBinding, CreateRoleBinding, EditRoleBinding, EditRulePage } from './RBAC';
+import { CreateSecret, EditSecret } from './secrets/create-secret';
 import { StartGuidePage } from './start-guide';
 import { SearchPage } from './search';
 import { history, AsyncComponent, Loading } from './utils';
@@ -174,6 +175,10 @@ class App extends React.PureComponent {
           <Route path="/k8s/ns/:ns/roles/:name/add-rule" exact component={EditRulePage} />
           <Route path="/k8s/ns/:ns/roles/:name/:rule/edit" exact component={EditRulePage} />
           <Route path="/k8s/ns/:ns/roles" exact component={rolesListPage} />
+
+          <Route path="/k8s/ns/:ns/secrets/new/:type" exact component={props => <CreateSecret {...props} kind="Secret" />} />
+          <Route path="/k8s/ns/:ns/secrets/:name/edit" exact component={props => <EditSecret {...props} kind="Secret" />} />
+          <Route path="/k8s/ns/:ns/secrets/:name/edit-yaml" exact component={props => <EditYAMLPage {...props} kind="Secret" />} />
 
           <Route path="/k8s/cluster/rolebindings/new" exact component={props => <CreateRoleBinding {...props} kind="RoleBinding" />} />
           <Route path="/k8s/ns/:ns/rolebindings/new" exact component={props => <CreateRoleBinding {...props} kind="RoleBinding" />} />

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -162,7 +162,7 @@ export const FireMan_ = connect(null, {filterList: k8sActions.filterList})(
           </Link>;
         } else if (createProps.items) {
           createLink = <div className="co-m-primary-action">
-            <Dropdown noButton={true} className="btn btn-primary" id="yaml-create" title={createButtonText} items={createProps.items} onChange={(name) => history.push(createProps.createLink(name))} />
+            <Dropdown noButton={true} className="btn btn-primary" id="item-create" title={createButtonText} items={createProps.items} onChange={(name) => history.push(createProps.createLink(name))} />
           </div>;
         } else {
           createLink = <div className="co-m-primary-action">
@@ -236,6 +236,7 @@ FireMan_.propTypes = {
 /** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, namespace?: string, filterLabel?: string, title?: string, showTitle?: boolean, dropdownFilters?: any[], rowFilters?: any[], selector?: string, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, fake?: boolean}>} */
 export const ListPage = props => {
   const {createButtonText, createHandler, filterLabel, kind, namespace, selector, name, fieldSelector, filters, limit, showTitle = true, fake} = props;
+  let { createProps } = props;
   const ko = kindObj(kind);
   const {labelPlural, plural, namespaced, label} = ko;
   const title = props.title || labelPlural;
@@ -246,7 +247,8 @@ export const ListPage = props => {
       href = namespaced ? `/k8s/ns/${namespace || 'default'}/${ref}/new` : `/k8s/cluster/${ref}/new`;
     } catch (unused) { /**/ }
   }
-  const createProps = createHandler ? {onClick: createHandler} : {to: href};
+
+  createProps = createProps || (createHandler ? {onClick: createHandler} : {to: href});
   const resources = [{ kind, name, namespaced, selector, fieldSelector, filters, limit }];
 
   if (!namespaced && namespace) {

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { SecretData } from './configmap-and-secret-data';
-import { Cog, ResourceCog, ResourceLink, ResourceSummary, detailsPage, navFactory } from './utils';
+import { Cog, ResourceCog, ResourceLink, ResourceSummary, detailsPage, navFactory, resourceObjPath } from './utils';
 import { fromNow } from './utils/datetime';
 import { registerTemplate } from '../yaml-templates';
 
@@ -16,7 +16,20 @@ data:
   username: YWRtaW4=
   password: MWYyZDFlMmU2N2Rm`);
 
-const menuActions = Cog.factory.common;
+export const WebHookSecretKey = 'WebHookSecretKey';
+
+// Edit in YAML if not editing a webhook secret with one key.
+const editInYaml = obj => !_.has(obj, ['data', WebHookSecretKey]) || _.size(obj.data) !== 1;
+
+const menuActions = [
+  Cog.factory.ModifyLabels,
+  Cog.factory.ModifyAnnotations,
+  (kind, obj) => ({
+    label: `Edit ${kind.label}...`,
+    href: editInYaml(obj) ? `${resourceObjPath(obj, kind.kind)}/edit-yaml` : `${resourceObjPath(obj, kind.kind)}/edit`,
+  }),
+  Cog.factory.Delete,
+];
 
 const SecretHeader = props => <ListHeader>
   <ColHead {...props} className="col-md-3 col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
@@ -75,7 +88,22 @@ const filters = [{
   ],
 }];
 
-const SecretsPage = props => <ListPage ListComponent={SecretsList} rowFilters={filters} canCreate={true} {...props} />;
+const SecretsPage = props => {
+  const createItems = {
+    // source: 'Create Source Secret',
+    // image: 'Create Image Pull Secret',
+    // generic: 'Create Key/Value Secret',
+    webhook: 'Webhook Secret',
+    yaml: 'Secret from YAML',
+  };
+
+  const createProps = {
+    items: createItems,
+    createLink: (type) => `/k8s/ns/${props.namespace}/secrets/new/${type !== 'yaml' ? type : ''}`
+  };
+
+  return <ListPage ListComponent={SecretsList} canCreate={true} rowFilters={filters} createButtonText="Create" createProps={createProps} {...props} />;
+};
 
 const SecretsDetailsPage = props => <DetailsPage
   {...props}

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -1,0 +1,199 @@
+/* eslint-disable no-undef */
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+import { k8sCreate, k8sUpdate, K8sResourceKind } from '../../module/k8s';
+import { ButtonBar, Firehose, history, kindObj, StatusBox } from '../utils';
+import { getActiveNamespace, formatNamespacedRouteForResource, UIActions } from '../../ui/ui-actions';
+import { SafetyFirst } from '../safety-first';
+import { WebHookSecretKey } from '../secret';
+
+export enum SecretTypes {
+  webhook = 'webhook',
+  generic = 'generic',
+}
+
+const determineSecretTypeAbstraction = (data) => {
+  return _.has(data, WebHookSecretKey) ? SecretTypes.webhook : SecretTypes.generic;
+};
+
+class BaseEditSecret_ extends SafetyFirst<BaseEditSecretProps_, BaseEditSecretState_> {
+  constructor (props) {
+    super(props);
+    const existingObj = _.pick(props.obj, ['metadata', 'type']);
+    const existingData = _.get(props.obj, 'data');
+    const secret = _.defaultsDeep({}, props.fixed, existingObj, {
+      apiVersion: 'v1',
+      data: {},
+      kind: 'Secret',
+      metadata: {
+        name: '',
+      },
+      type: 'Opaque',
+    });
+
+    this.state = {
+      secretType: this.props.secretType || determineSecretTypeAbstraction(existingData),
+      secret: secret,
+      inProgress: false,
+      type: secret.type,
+      stringData: _.mapValues(existingData, window.atob),
+    };
+    this.onDataChanged = this.onDataChanged.bind(this);
+    this.onNameChanged = this.onNameChanged.bind(this);
+    this.save = this.save.bind(this);
+  }
+  onDataChanged (secretsData) {
+    this.setState({stringData: {...secretsData}});
+  }
+  onNameChanged (event) {
+    let secret = {...this.state.secret};
+    secret.metadata.name = event.target.value;
+    this.setState({secret});
+  }
+  save (e) {
+    e.preventDefault();
+    const { kind, metadata } = this.state.secret;
+    this.setState({ inProgress: true });
+
+    const newSecret = _.assign({}, this.state.secret, {stringData: this.state.stringData});
+    const ko = kindObj(kind);
+    (this.props.isCreate
+      ? k8sCreate(ko, newSecret)
+      : k8sUpdate(ko, newSecret, metadata.namespace, newSecret.metadata.name)
+    ).then(() => {
+      this.setState({inProgress: false});
+      history.push(formatNamespacedRouteForResource('secrets'));
+    },
+    err => this.setState({error: err.message, inProgress: false})
+    );
+  }
+  render () {
+    const title = `${this.props.titleVerb} ${_.upperFirst(this.state.secretType)} Secret`;
+    const { saveButtonText } = this.props;
+
+    const explanation = 'Webhook secrets allow you to authenticate a webhook trigger.';
+    const subform = <WebHookSecretSubform onChange={this.onDataChanged.bind(this)} stringData={this.state.stringData} />;
+
+    return <div className="co-m-pane__body">
+      <Helmet>
+        <title>{title}</title>
+      </Helmet>
+      <form className="co-m-pane__body-group" onSubmit={this.save}>
+        <h1 className="co-m-pane__heading">{title}</h1>
+        <p className="co-m-pane__explanation">{explanation}</p>
+
+        <fieldset disabled={!this.props.isCreate}>
+          <div className="form-group">
+            <label className="control-label">Secret Name</label>
+            <div>
+              <input className="form-control" type="text" onChange={this.onNameChanged} value={this.state.secret.metadata.name} required id="test--subject-name" />
+              <p className="help-block">Unique name of the new secret.</p>
+            </div>
+          </div>
+        </fieldset>
+        {subform}
+        <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress} >
+          <button type="submit" className="btn btn-primary" id="create-secret">{saveButtonText || 'Create'}</button>
+          <Link to={formatNamespacedRouteForResource('secrets')} className="btn btn-default">Cancel</Link>
+        </ButtonBar>
+      </form>
+    </div>;
+  }
+}
+
+const BaseEditSecret = connect(null, {setActiveNamespace: UIActions.setActiveNamespace})(
+  (props: BaseEditSecretProps_) => <BaseEditSecret_ {...props} />
+);
+
+const BindingLoadingWrapper = props => {
+  const fixed = _.reduce(props.fixedKeys, (acc, k) => ({...acc, k: _.get(props.obj.data, k)}), {});
+  return <StatusBox {...props.obj}>
+    <BaseEditSecret {...props} obj={props.obj.data} fixed={fixed} />
+  </StatusBox>;
+};
+
+export const CreateSecret = ({match: {params}}) => {
+  return <BaseEditSecret
+    fixed={{ metadata: {namespace: params.ns} }}
+    metadata={{ namespace: getActiveNamespace() }}
+    secretType={params.type}
+    titleVerb="Create"
+    isCreate={true}
+  />;
+};
+
+export const EditSecret = ({match: {params}, kind}) => <Firehose resources={[{kind: kind, name: params.name, namespace: params.ns, isList: false, prop: 'obj'}]}>
+  <BindingLoadingWrapper fixedKeys={['kind', 'metadata']} titleVerb="Edit" saveButtonText="Save Changes" />
+</Firehose>;
+
+const generateSecret = () => {
+  // http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
+  const s4 = () => Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+  return s4() + s4() + s4() + s4();
+};
+
+class WebHookSecretSubform extends React.Component<WebHookSecretSubformProps, WebHookSecretSubformState> {
+  constructor(props) {
+    super(props);
+    this.state = {WebHookSecretKey: this.props.stringData.WebHookSecretKey || ''};
+    this.changeWebHookSecretkey = this.changeWebHookSecretkey.bind(this);
+    this.generateWebHookSecret = this.generateWebHookSecret.bind(this);
+  }
+  changeWebHookSecretkey(event) {
+    this.setState({
+      WebHookSecretKey: event.target.value
+    }, () => this.props.onChange(this.state));
+  }
+  generateWebHookSecret() {
+    this.setState({
+      WebHookSecretKey: generateSecret()
+    }, () => this.props.onChange(this.state));
+  }
+  render () {
+    return <div className="form-group">
+      <label className="control-label" htmlFor="webhook-secret-key">Webhook Secret Key</label>
+      <div className="input-group">
+        <input className="form-control" id="webhook-secret-key" type="text" name="webhookSecretKey" onChange={this.changeWebHookSecretkey} value={this.state.WebHookSecretKey} required/>
+        <span className="input-group-btn">
+          <button type="button" onClick={this.generateWebHookSecret} className="btn btn-default">Generate</button>
+        </span>
+      </div>
+      <p className="help-block">Value of the secret will be supplied when invoking the webhook. </p>
+    </div>;
+  }
+}
+
+export type BaseEditSecretState_ = {
+  secretType?: string,
+  secret: K8sResourceKind,
+  inProgress: boolean,
+  type: string,
+  stringData: {[key: string]: string},
+  error?: any,
+};
+
+export type BaseEditSecretProps_ = {
+  obj?: K8sResourceKind,
+  fixed: any,
+  kind?: string,
+  isCreate: boolean,
+  titleVerb: string,
+  setActiveNamespace: Function,
+  secretType?: string,
+  saveButtonText?: string,
+  metadata: any,
+};
+
+export type WebHookSecretSubformState = {
+  WebHookSecretKey: string;
+};
+
+export type WebHookSecretSubformProps = {
+  onChange: Function;
+  stringData: {[WebHookSecretKey: string]: string};
+};
+/* eslint-enable no-undef */

--- a/frontend/public/components/utils/button-bar.jsx
+++ b/frontend/public/components/utils/button-bar.jsx
@@ -21,6 +21,7 @@ const InfoMessage = ({message}) => <div className="alert alert-info"><span class
 // NOTE: DO NOT use <a> elements within a ButtonBar.
 // They don't support the disabled attribute, and therefore
 // can't be disabled during a pending promise/request.
+/** @type {React.SFC<{children: any, className?: string, errorMessage?: string, infoMessage?: string, inProgress: boolean}}>} */
 export const ButtonBar = ({children, className, errorMessage, infoMessage, inProgress}) => {
   return <div className={classNames(className, 'co-m-btn-bar')}>
     {errorMessage && <ErrorMessage message={errorMessage} />}
@@ -35,4 +36,5 @@ ButtonBar.propTypes = {
   errorMessage: PropTypes.string,
   infoMessage: PropTypes.string,
   inProgress: PropTypes.bool.isRequired,
+  className: PropTypes.string,
 };

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -103,7 +103,7 @@ class DropDownRow extends React.PureComponent {
     }
     return <li className={className} key={itemKey}>
       {prefix}
-      <a ref={ref => this.ref=ref} className={classNames({'next-to-bookmark': !!prefix, focus: selected, hover})} onClick={e => onclick(itemKey, e)}>{content}</a>
+      <a ref={ref => this.ref=ref} id={`${itemKey}-link`} className={classNames({'next-to-bookmark': !!prefix, focus: selected, hover})} onClick={e => onclick(itemKey, e)}>{content}</a>
       {suffix}
     </li>;
   }


### PR DESCRIPTION
Added button with `Create New` dropdown button, which (for now, rest will be added in a follow up) contains:
- Create Webhook Secret
- Create via YAML

![1](https://user-images.githubusercontent.com/1668218/41368803-440c6364-6f43-11e8-87c6-0518a66f1b18.png)

When creating the secret Im adding all the values to the `stringData` which will take care of encoding the data.

![2](https://user-images.githubusercontent.com/1668218/41368927-a8867d20-6f43-11e8-91bd-1db2ae8d3546.png)

I've also added following actions for individual secrets:
- Modify Labels
- Modify Annotations
- Duplicate Secret
- Edit Secret
- Delete Secret

![3](https://user-images.githubusercontent.com/1668218/41368958-c361877a-6f43-11e8-9ff0-741a945fa477.png)

PTAL