### PR TITLE
Use SSAR for additional resources: nodes, pvc, sc, crd

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -207,10 +207,8 @@ class App extends React.PureComponent {
   }
 }
 
-store.dispatch(featureActions.detectSecurityLabellerFlags);
-store.dispatch(featureActions.detectCalicoFlags);
-store.dispatch(featureActions.detectOpenShift);
-store.dispatch(featureActions.detectCanListNS);
+
+_.each(featureActions, store.dispatch);
 store.dispatch(k8sActions.getResources());
 
 analyticsSvc.push({tier: 'tectonic'});

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -345,16 +345,16 @@ export class Nav extends React.Component {
           <NavSection text="Administration" icon="fa-cog">
             <ResourceClusterLink resource="projects" name="Projects" onClick={this.close} required={FLAGS.OPENSHIFT} />
             <ResourceClusterLink resource="namespaces" name="Namespaces" onClick={this.close} required={FLAGS.CAN_LIST_NS} />
-            <ResourceClusterLink resource="nodes" name="Nodes" onClick={this.close} />
-            <ResourceClusterLink resource="persistentvolumes" name="Persistent Volumes" onClick={this.close} />
+            <ResourceClusterLink resource="nodes" name="Nodes" onClick={this.close} required={FLAGS.CAN_LIST_NODE} />
+            <ResourceClusterLink resource="persistentvolumes" name="Persistent Volumes" onClick={this.close} required={FLAGS.CAN_LIST_PV} />
             <HrefLink href="/settings/cluster" name="Cluster Settings" onClick={this.close} startsWith={clusterSettingsStartsWith} />
             <ResourceNSLink resource="serviceaccounts" name="Service Accounts" onClick={this.close} />
-            <ResourceClusterLink resource="storageclasses" name="Storage Classes" onClick={this.close} />
+            <ResourceClusterLink resource="storageclasses" name="Storage Classes" onClick={this.close} required={FLAGS.CAN_LIST_STORE} />
             <ResourceNSLink resource="roles" name="Roles" startsWith={rolesStartsWith} onClick={this.close} />
             <ResourceNSLink resource="rolebindings" name="Role Bindings" onClick={this.close} startsWith={rolebindingsStartsWith} />
             <ResourceNSLink resource="podvulns" name="Security Report" onClick={this.close} required={FLAGS.SECURITY_LABELLER} />
             <ResourceNSLink resource="chargeback.coreos.com:v1alpha1:Report" name="Chargeback" onClick={this.close} />
-            <ResourceClusterLink resource="customresourcedefinitions" name="CRDs" onClick={this.close} />
+            <ResourceClusterLink resource="customresourcedefinitions" name="CRDs" onClick={this.close} required={FLAGS.CAN_LIST_CRD} />
           </NavSection>
         </div>
       </div>


### PR DESCRIPTION
Addresses https://jira.coreos.com/browse/CONSOLE-498

This PR will show/hide some cluster-wide resources in the nav.  We discussed a follow-on where we specifically show/hide buttons in individual pages based on RBAC, which is not a part of this PR.

Before:
![screen shot 2018-06-06 at 3 26 33 pm](https://user-images.githubusercontent.com/280512/41060600-1487d42a-699e-11e8-80e0-73c1e2facdd5.png)

After:
![screen shot 2018-06-06 at 3 26 49 pm](https://user-images.githubusercontent.com/280512/41060607-1a67aae6-699e-11e8-9727-8765c9a49078.png)

