### PR TITLE
Don't fail showing breadcrumbs when we don't have a model

### DIFF
--- a/frontend/public/components/utils/breadcrumbs.ts
+++ b/frontend/public/components/utils/breadcrumbs.ts
@@ -6,8 +6,18 @@ import { modelFor, referenceForOwnerRef } from '../../module/k8s/k8s-models';
 
 export const breadcrumbsForOwnerRefs = (obj: K8sResourceKind) => {
   const ownerRefs = _.get(obj, 'metadata.ownerReferences');
-  return _.map(ownerRefs, ref => ({
-    name: ref.name,
-    path: `/k8s/ns/${obj.metadata.namespace}/${modelFor(referenceForOwnerRef(ref)).plural}/${ref.name}`,
+  return _.compact(_.map(ownerRefs, ref => {
+    const model = modelFor(referenceForOwnerRef(ref));
+    // ownerReferences might reference resources we don't know about (or even
+    // ones that don't exist since it's not blocked by the API). Avoid runtime
+    // errors if we don't have a model for this reference.
+    if (!model) {
+      return null;
+    }
+
+    return {
+      name: ref.name,
+      path: `/k8s/ns/${obj.metadata.namespace}/${model.plural}/${ref.name}`,
+    };
   }));
 };


### PR DESCRIPTION
Avoid runtime errors when we don't have a model for the ownerReference.

/assign @alecmerdler 

@smarterclayton This fixes the problem you saw.