### PR TITLE
Fix self subject access review check

### DIFF
--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -89,7 +89,7 @@ const detectCanListNS = dispatch => {
   const req = {
     spec: {
       resourceAttributes: {
-        name: 'namespaces',
+        resource: 'namespaces',
         verb: 'list',
       },
     },


### PR DESCRIPTION
The request we were making was wrong, but happened to work for the cluster-admin role since it has `*/*` authority.

/assign @benjaminapetersen 

Here is what the CLI does:

```
❯ oc auth can-i list namespaces --all-namespaces --loglevel=8
I0608 11:02:27.353273   30165 loader.go:357] Config loaded from file /Users/sam/.kube/config
I0608 11:02:27.363345   30165 request.go:897] Request Body: {"kind":"SelfSubjectAccessReview","apiVersion":"authorization.k8s.io/v1","metadata":{"creationTimestamp":null},"spec":{"resourceAttributes":{"verb":"list","resource":"namespaces"}},"status":{"allowed":false}}
I0608 11:02:27.363404   30165 round_trippers.go:383] POST https://127.0.0.1:8443/apis/authorization.k8s.io/v1/selfsubjectaccessreviews
I0608 11:02:27.363411   30165 round_trippers.go:390] Request Headers:
I0608 11:02:27.363417   30165 round_trippers.go:393]     Accept: application/json, */*
I0608 11:02:27.363422   30165 round_trippers.go:393]     Content-Type: application/json
I0608 11:02:27.363427   30165 round_trippers.go:393]     User-Agent: oc/v1.10.0+b81c8f8 (darwin/amd64) kubernetes/b81c8f8
I0608 11:02:27.446144   30165 round_trippers.go:408] Response Status: 201 Created in 82 milliseconds
I0608 11:02:27.446162   30165 round_trippers.go:411] Response Headers:
I0608 11:02:27.446170   30165 round_trippers.go:414]     Cache-Control: no-store
I0608 11:02:27.446176   30165 round_trippers.go:414]     Content-Type: application/json
I0608 11:02:27.446181   30165 round_trippers.go:414]     Content-Length: 208
I0608 11:02:27.446186   30165 round_trippers.go:414]     Date: Fri, 08 Jun 2018 15:02:32 GMT
I0608 11:02:27.446230   30165 request.go:897] Response Body: {"kind":"SelfSubjectAccessReview","apiVersion":"authorization.k8s.io/v1","metadata":{"creationTimestamp":null},"spec":{"resourceAttributes":{"verb":"list","resource":"namespaces"}},"status":{"allowed":true}}
yes
```