### PR TITLE
Updates to address namespace dropdown-menu scrolling above masthead and limit dropdown menu height ...

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -1,3 +1,5 @@
+$co-namespace-selector-desktop: 40px;
+$co-namespace-selector-mobile: 27px;
 $color-dropdown-hover: rgba(0, 0, 0, .05);
 $color-bookmarker--hover: #AAA;
 $color-bookmarker: #DDD;
@@ -80,14 +82,14 @@ $color-bookmarker: #DDD;
   color: $color-os-nav-title;
   display: flex;
   font-size: ($font-size-base + 1);
-  height: 27px;
+  height: $co-namespace-selector-mobile;
   white-space: nowrap;
   padding: 0 15px;
 
   @media (min-width: $grid-float-breakpoint) {
     border-left: 1px solid $color-os-nav-item-seperator;
     font-size: ($font-size-base + 3);
-    height: 40px;
+    height: $co-namespace-selector-desktop;
     padding-bottom: 5px;
     padding-top: 5px;
   }
@@ -112,11 +114,13 @@ $color-bookmarker: #DDD;
 }
 
 .co-namespace-selector__menu.dropdown-menu {
+  max-height: calc(100vh - (#{$masthead-height-mobile} + #{$co-namespace-selector-mobile}));
   max-width: 100%;
   min-width: 210px;
-  overflow-y: inherit;
+  overflow-y: auto;
 
   @media (min-width: $grid-float-breakpoint) {
+    max-height: calc(100vh - (#{$masthead-height-desktop} + #{$co-namespace-selector-desktop}));
     min-width: 250px;
   }
 

--- a/frontend/public/components/masthead.scss
+++ b/frontend/public/components/masthead.scss
@@ -7,7 +7,7 @@
   left: 0;
   position: fixed;
   right: 0;
-  z-index: $zindex-navbar;
+  z-index: $zindex-navbar-fixed;
   @media (max-width: $grid-float-breakpoint-max) {
     padding-left: 50px; // make space for .sidebar-toggle
   }


### PR DESCRIPTION
… to slightly less than the viewport height.
cc @jwforres 

- Set `.co-namespace-selector__menu.dropdown-menu` max-height to be capped at (viewport height - (masthead-height-* + namespace-selector-*))
- set `.co-masthead` to higher z-index of `$zindex-navbar-fixed` 

<img width="841" alt="screen shot 2018-06-08 at 4 34 05 pm" src="https://user-images.githubusercontent.com/1874151/41180138-3fba57e6-6b3b-11e8-804a-3288c114078d.png">
<img width="742" alt="screen shot 2018-06-08 at 4 34 32 pm" src="https://user-images.githubusercontent.com/1874151/41180142-4312b0f0-6b3b-11e8-8ef2-1f683bd9b8b8.png">
<img width="352" alt="screen shot 2018-06-08 at 4 32 27 pm" src="https://user-images.githubusercontent.com/1874151/41180146-46242120-6b3b-11e8-819d-481471678624.png">
<img width="607" alt="screen shot 2018-06-08 at 4 33 03 pm" src="https://user-images.githubusercontent.com/1874151/41180151-4a6c6170-6b3b-11e8-8e78-eeca94f13356.png">

