### PR TITLE
Make namespace column a link

### DIFF
--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -102,7 +102,7 @@ const BuildConfigsRow: React.SFC<BuildConfigsRowProps> = ({obj}) => <div classNa
     <ResourceLink kind={BuildConfigsReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
   </div>
   <div className="col-xs-3">
-    {obj.metadata.namespace}
+    <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
   </div>
   <div className="col-xs-3">
     <LabelList kind={BuildConfigsReference} labels={obj.metadata.labels} />

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -95,7 +95,7 @@ const BuildsRow: React.SFC<BuildsRowProps> = ({obj}) => <div className="row co-r
     <ResourceLink kind={BuildsReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
   </div>
   <div className="col-xs-3">
-    {obj.metadata.namespace}
+    <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
   </div>
   <div className="col-xs-3">
     {obj.status.phase}

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -111,7 +111,7 @@ const ImageStreamsRow: React.SFC<ImageStreamsRowProps> = ({obj}) => <div classNa
     <ResourceLink kind={ImageStreamsReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
   </div>
   <div className="col-xs-3">
-    {obj.metadata.namespace}
+    <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
   </div>
   <div className="col-xs-3">
     <LabelList kind={ImageStreamsReference} labels={obj.metadata.labels} />


### PR DESCRIPTION
Make namespace a link in the BuildConfig, Build, and ImageStream tables
to be consistent with other resource lists.