### PR TITLE
Change filter label from "Job Completed" to "Completed"

### DIFF
--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -286,7 +286,7 @@ const filters = [{
     {id: 'Pending', title: 'Pending'},
     {id: 'Terminating', title: 'Terminating'},
     {id: 'CrashLoopBackOff', title: 'CrashLoopBackOff'},
-    {id: 'Completed', title: 'Job Completed'},
+    {id: 'Completed', title: 'Completed'},
   ],
 }];
 


### PR DESCRIPTION
Not all completed pods are for jobs. Completed build pods are common in
OpenShift, for instance. It also makes it the same as the Kubernetes phase.