### PR TITLE
Set co-m-table-grid > row line-height to normal

### DIFF
--- a/frontend/public/style/coreos.css
+++ b/frontend/public/style/coreos.css
@@ -131,7 +131,7 @@ input[type="radio"] {
   padding: 0 0 30px 0; }
 
 .co-m-table-grid .row {
-  line-height: 1;
+  line-height: normal;
   margin: 0; }
 
 .co-m-table-grid .row,


### PR DESCRIPTION
Prevents font descenders from being clipped.

Relates to https://github.com/openshift/console/pull/67#issuecomment-395158812

<img width="1101" alt="screen shot 2018-06-11 at 10 22 22 am" src="https://user-images.githubusercontent.com/1874151/41237795-6996b446-6d62-11e8-8291-a32a4d7b22ed.png">
