### PR TITLE
Preview Operator Install Plan Resources

### DIFF
--- a/frontend/public/components/cloud-services/_cloud-services.scss
+++ b/frontend/public/components/cloud-services/_cloud-services.scss
@@ -151,6 +151,7 @@ $clusterserviceversion-list-border: #ccc;
   background: #ffe6e6;
   color: #dd1326;
   font-size: 14px;
+  margin-bottom: 10px;
 }
 
 .co-catalog-install-modal .modal-header .co-clusterserviceversion-logo__icon {
@@ -177,4 +178,9 @@ $clusterserviceversion-list-border: #ccc;
   border: 1px solid #eee;
   padding: 20px 0 5px 20px;
   margin-top: 10px;
+}
+
+.step--present {
+  color: $color-pf-green-400;
+
 }

--- a/frontend/public/components/cloud-services/index.tsx
+++ b/frontend/public/components/cloud-services/index.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-import { K8sResourceKind, CustomResourceDefinitionKind, GroupVersionKind, OwnerReference } from '../../module/k8s';
+import { K8sResourceKind, GroupVersionKind, OwnerReference } from '../../module/k8s';
 import { SpecDescriptor } from './spec-descriptors';
 import { StatusDescriptor } from './status-descriptors';
 
@@ -112,6 +112,20 @@ export type ClusterServiceVersionResourceKind = {
 
 } & K8sResourceKind;
 
+export type StepResource = {
+  group: string;
+  version: string;
+  kind: string;
+  name: string;
+  manifest?: string;
+};
+
+export type Step = {
+  resolving: string;
+  resource: StepResource;
+  status: 'Unknown' | 'NotPresent' | 'Present' | 'Created';
+};
+
 export type InstallPlanKind = {
   spec: {
     clusterServiceVersionNames: string[];
@@ -121,10 +135,7 @@ export type InstallPlanKind = {
   status?: {
     phase: 'Planning' | 'RequiresApproval' | 'Installing' | 'Complete' | 'Failed';
     catalogSources: string[];
-    plan: {
-      resolving: string;
-      resource: CustomResourceDefinitionKind;
-    }[];
+    plan: Step[];
   }
 } & K8sResourceKind;
 


### PR DESCRIPTION
### Description

Adds "Components" tab to the `InstallPlan-v1` detail view, which lets users see what resources will be added to the cluster before (and after) the plan is executed. This is most useful when using `approval: Manual` on `InstallPlan-v1s`.

### Screenshots

**Overview tab (needs approval):**
![screenshot_20180618_180113](https://user-images.githubusercontent.com/11700385/41564710-b4a97742-7321-11e8-852a-a2b5a8f42498.png)

**Components tab (before execution):**
![screenshot_20180618_180125](https://user-images.githubusercontent.com/11700385/41564719-bd914b78-7321-11e8-8c1c-808c671d1dc9.png)

**Components tab (unresolved):**
![screenshot_20180618_180737](https://user-images.githubusercontent.com/11700385/41564914-81de89fa-7322-11e8-8285-b3a4f09343de.png)

Addresses https://jira.coreos.com/browse/ALM-619