### PR TITLE
Environment Page Help Text

### DIFF
--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -198,7 +198,7 @@ export class EnvironmentPage extends PromiseComponent {
 
     return <div className="co-m-pane__body">
       { !readOnly &&
-          <p className="co-m-pane__explanation margin-bottom">Define environment variables as key-value pairs to store configuration settings. You can enter text or add values from a ConfigMap or Secret. Drag and drop environment variables to change the order in which they are run. A variable can reference any other variables that come before it in the list, for example <code>FULLDOMAIN = $(SUBDOMAIN).example.com</code>.</p>
+          <p className="co-m-pane__explanation">Define environment variables as key-value pairs to store configuration settings. You can enter text or add values from a ConfigMap or Secret. Drag and drop environment variables to change the order in which they are run. A variable can reference any other variables that come before it in the list, for example <code>FULLDOMAIN = $(SUBDOMAIN).example.com</code>.</p>
       }
       {containerVars}
       <div className="co-m-pane__body-group">

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -197,6 +197,9 @@ export class EnvironmentPage extends PromiseComponent {
     });
 
     return <div className="co-m-pane__body">
+      { !readOnly &&
+          <p className="co-m-pane__explanation margin-bottom">Define environment variables as key-value pairs to store configuration settings. You can enter text or add values from a ConfigMap or Secret. Drag and drop environment variables to change the order in which they are run. A variable can reference any other variables that come before it in the list, for example <code>FULLDOMAIN = $(SUBDOMAIN).example.com</code>.</p>
+      }
       {containerVars}
       <div className="co-m-pane__body-group">
         <div className="environment-buttons">

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -100,7 +100,7 @@
 .co-section-title {
   font-size: 20px;
   font-weight: 600;
-  margin: 0 0 30px 0;
+  margin: 0 0 20px 0;
 }
 
 .co-table-container {
@@ -130,7 +130,7 @@
 
 .co-m-pane__explanation {
   color: $color-grey-text;
-  margin-bottom: 20px;
+  margin-bottom: 30px;
 }
 
 .co-m-pane__explanation code {

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -133,6 +133,11 @@
   margin-bottom: 20px;
 }
 
+.co-m-pane__explanation code {
+  background-color: $co-gray-lightest;
+  color: $co-gray;
+}
+
 .co-btn--download {
   padding: 15px;
   font-size: 18px;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -40,6 +40,10 @@ small {
   margin: 0 !important;
 }
 
+.margin-bottom {
+  margin-bottom: 30px !important;
+}
+
 tags-input:focus,
 tags-input .host:focus {
   outline: none;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -40,10 +40,6 @@ small {
   margin: 0 !important;
 }
 
-.margin-bottom {
-  margin-bottom: 30px !important;
-}
-
 tags-input:focus,
 tags-input .host:focus {
   outline: none;


### PR DESCRIPTION
[Fixes #117](https://github.com/openshift/console/issues/117)

Added help text to Environment page. Shows only on pages that aren't read-only.

![screen shot 2018-06-11 at 1 57 35 pm](https://user-images.githubusercontent.com/7014965/41248668-bcab51d8-6d7f-11e8-8c35-bd5156f54ca8.png)

@openshift/team-ux-review, could you please review the design?

@stacymcauliffe - Chris & co. said I should ask you to verify the wording. Chris changed it slightly.