### PR TITLE
Updated color on Node ready status message

### DIFF
--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -1,5 +1,5 @@
 .node-ready {
-  color: $color-green-success;
+  color: $color-pf-green-400;
 }
 
 .node-not-ready {


### PR DESCRIPTION
Fixes [CONSOLE-543](https://jira.coreos.com/browse/CONSOLE-543).

Changed color of "ready" status to pf-green-400. The node-ready class was only being used for the Node icon/status message and for the Custom Resource Definition status icon, so the change should only affect them:

<img width="1273" alt="screen shot 2018-06-12 at 12 24 59 pm" src="https://user-images.githubusercontent.com/7014965/41304156-59088f06-6e3d-11e8-9951-48b2624779df.png">

<img width="1274" alt="screen shot 2018-06-12 at 12 24 44 pm" src="https://user-images.githubusercontent.com/7014965/41304159-5d348f80-6e3d-11e8-9e24-e820c0902b12.png">

@openshift/team-ux-review and @tlwu2013 - can you please review this? Thanks!
