### PR TITLE
Remove "(fuzzy)" from events filter placeholder text

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -140,7 +140,7 @@ export class EventStreamPage extends React.Component {
           <Dropdown title="All Categories" className="btn-group" items={categories} onChange={v => this.setState({category: v})} />
         </div>
         <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--filter">
-          <TextFilter label="Events by message (fuzzy)" onChange={e => this.setState({textFilter: e.target.value || ''})} autoFocus={autoFocus} />
+          <TextFilter label="Events by message" onChange={e => this.setState({textFilter: e.target.value || ''})} autoFocus={autoFocus} />
         </div>
       </div>
       <EventStream {...this.props} category={category} kind={kind} textFilter={textFilter} />


### PR DESCRIPTION
Feedback from @jwforres that this looked strange, and it might be more confusing than helpful

![screen shot 2018-06-12 at 1 46 01 pm](https://user-images.githubusercontent.com/1167259/41307363-f93659be-6e46-11e8-8fb4-16939bb4cceb.png)

/assign @rhamilto 