### PR TITLE
Dockerfile changes for OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
-FROM alpine:3.7
+FROM openshift/origin-base
+
 ADD frontend/public/dist /opt/bridge/static
 ADD bin/bridge /opt/bridge/bin/bridge
 ADD etc/ssl /etc/ssl
-CMD /opt/bridge/bin/bridge --public-dir=/opt/bridge/static
+
+LABEL io.k8s.display-name="OpenShift Console" \
+      io.k8s.description="This is a component of OpenShift Container Platform and provides a web console." \
+      io.openshift.tags="openshift" \
+      maintainer="Samuel Padgett <spadgett@redhat.com>"
+
+# doesn't require a root user.
+USER 1001
+
+CMD [ "/opt/bridge/bin/bridge", "--public-dir=/opt/bridge/static" ]


### PR DESCRIPTION
* Use openshift/origin-base as the base image
* Add image labels and user

/cc @adammhaile @jwforres 