### PR TITLE
Route status updates

### DIFF
--- a/frontend/__tests__/components/route-pages.spec.tsx
+++ b/frontend/__tests__/components/route-pages.spec.tsx
@@ -224,7 +224,7 @@ describe(RouteStatus.displayName, () => {
     };
 
     const wrapper = shallow(<RouteStatus obj={route} />);
-    expect(wrapper.find('.fa-times').exists()).toBe(true);
+    expect(wrapper.find('.fa-times-circle').exists()).toBe(true);
     expect(wrapper.text()).toEqual('Rejected');
   });
 

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -110,20 +110,20 @@ export const RouteStatus: React.SFC<RouteStatusProps> = ({obj: route}) => {
 
   switch (status) {
     case 'Pending':
-      return <React.Fragment>
-        <div className="fa fa-hourglass-half co-m-route-status-icon" aria-hidden="true"></div>
+      return <span>
+        <span className="fa fa-hourglass-half co-m-route-status-icon" aria-hidden="true"></span>
         Pending
-      </React.Fragment>;
+      </span>;
     case 'Accepted':
-      return <React.Fragment>
-        <div className="fa fa-check route-accepted co-m-route-status-icon" aria-hidden="true"></div>
-        <span className="route-accepted">Accepted</span>
-      </React.Fragment>;
+      return <span className="route-accepted">
+        <span className="fa fa-check co-m-route-status-icon" aria-hidden="true"></span>
+        Accepted
+      </span>;
     case 'Rejected':
-      return <React.Fragment>
-        <div className="fa fa-times route-rejected co-m-route-status-icon" aria-hidden="true"></div>
-        <span className="route-rejected">Rejected</span>
-      </React.Fragment>;
+      return <span className="route-rejected">
+        <span className="fa fa-times-circle co-m-route-status-icon" aria-hidden="true"></span>
+        Rejected
+      </span>;
     default:
       break;
   }

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -116,13 +116,13 @@ export const RouteStatus: React.SFC<RouteStatusProps> = ({obj: route}) => {
       </React.Fragment>;
     case 'Accepted':
       return <React.Fragment>
-        <div className="fa fa-check text-success co-m-route-status-icon" aria-hidden="true"></div>
-      Accepted
+        <div className="fa fa-check route-accepted co-m-route-status-icon" aria-hidden="true"></div>
+        <span className="route-accepted">Accepted</span>
       </React.Fragment>;
     case 'Rejected':
       return <React.Fragment>
-        <div className="fa fa-times text-danger co-m-route-status-icon" aria-hidden="true"></div>
-      Rejected
+        <div className="fa fa-times route-rejected co-m-route-status-icon" aria-hidden="true"></div>
+        <span className="route-rejected">Rejected</span>
       </React.Fragment>;
     default:
       break;

--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -6,6 +6,14 @@
   color: $color-red-error;
 }
 
+.route-accepted {
+  color: $color-green-success;
+}
+
+.route-rejected {
+  color: $color-red-error;
+}
+
 .co-icon-space-l {
   margin-left: 0.25em;
 }

--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -1,15 +1,9 @@
-.node-ready {
+.node-ready,
+.route-accepted {
   color: $color-pf-green-400;
 }
 
-.node-not-ready {
-  color: $color-red-error;
-}
-
-.route-accepted {
-  color: $color-green-success;
-}
-
+.node-not-ready,
 .route-rejected {
   color: $color-red-error;
 }


### PR DESCRIPTION
Route status styles should be consistent with node status
https://jira.coreos.com/browse/CONSOLE-517
**Before:**
![image](https://user-images.githubusercontent.com/12733153/41313897-2583006e-6e59-11e8-9341-6da7223d17e8.png)
**After:**
![image](https://user-images.githubusercontent.com/12733153/41313927-3ba98516-6e59-11e8-9d83-e8eabf2ff93b.png)


Route Details: Add Error Message box around Status Warnings
https://jira.coreos.com/browse/CONSOLE-533
**Before:**
![image](https://user-images.githubusercontent.com/12733153/41313947-4ac87390-6e59-11e8-89d2-9d70bdda2837.png)
**After:**
![image](https://user-images.githubusercontent.com/12733153/41313950-4e15f95a-6e59-11e8-95d5-d8a524d98caf.png)

@openshift/team-ux-review 