### PR TITLE
Add separator and header to pod logs with init containers.

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -25,6 +25,14 @@ $color-bookmarker: #DDD;
   background-color: $color-grey-when-selected;
 }
 
+.dropdown-menu__header {
+  color: $co-gray;
+  flex-grow: 1;
+  font-size: 11px;
+  padding: 3px 10px;
+  text-transform: uppercase;
+}
+
 .dropdown-menu__filter {
   padding: 5px 10px 10px;
 }


### PR DESCRIPTION
Add separator and header to pod logs container dropdown if the pod has init containers.

![screenshot-localhost-9000-2018 06 13-15-08-18](https://user-images.githubusercontent.com/22625502/41372604-cc19a35c-6f1b-11e8-89fa-5d3c8dd38dcf.png)


@openshift/team-ux-review 