### PR TITLE
Fix styles for log view controls

### DIFF
--- a/frontend/public/components/_toggle-play.scss
+++ b/frontend/public/components/_toggle-play.scss
@@ -3,8 +3,9 @@
   border: 3px solid $color-grey-border;
   border-radius: 50%;
   height: 32px;
-  width: 32px;
+  margin-right: 15px;
   padding: 0;
+  width: 32px;
 
   // play icon
   &.co-toggle-play--inactive:before {

--- a/frontend/public/components/pod-exec.jsx
+++ b/frontend/public/components/pod-exec.jsx
@@ -160,11 +160,15 @@ export class PodExec extends React.PureComponent {
     }
 
     return <div>
-      <div className="co-m-pane__top-controls">
-        <span className="log-container-selector__text">
-          Connecting to
-        </span>
-        <Dropdown className="btn-group" items={_.mapValues(containers, nameWithIcon)} title={nameWithIcon(activeContainer || <LoadingInline />)} onChange={this.onChangeContainer} />
+      <div className="co-toolbar">
+        <div className="co-toolbar__group co-toolbar__group--left">
+          <div className="co-toolbar__item">
+            Connecting to
+          </div>
+          <div className="co-toolbar__item">
+            <Dropdown className="btn-group" items={_.mapValues(containers, nameWithIcon)} title={nameWithIcon(activeContainer || <LoadingInline />)} onChange={this.onChangeContainer} />
+          </div>
+        </div>
       </div>
       {contents}
     </div>;

--- a/frontend/public/components/utils/_resource-log.scss
+++ b/frontend/public/components/utils/_resource-log.scss
@@ -1,7 +1,0 @@
-.log-stream-control {
-  margin-right: 15px;
-}
-
-.log-container-selector__text {
-  margin-right: 15px;
-}

--- a/frontend/public/components/utils/resource-log.jsx
+++ b/frontend/public/components/utils/resource-log.jsx
@@ -20,16 +20,22 @@ const streamStatusMessages = {
 // Component for log stream controls
 // TODO Fix styling for this. If no dropdown is there, the download button will not right-align
 const LogControls = ({dropdown, onDownload, status, toggleStreaming}) => {
-  return <div className="co-m-pane__top-controls">
-    { status === 'loading' && <span className="co-icon-space-l"><LoadingInline />&nbsp;</span> }
-    { ['streaming', 'paused'].includes(status) && <span className="log-stream-control"><TogglePlay active={status === 'streaming'} onClick={toggleStreaming}/></span>}
-    <span className="log-container-selector__text">
-      {streamStatusMessages[status]}
-    </span>
-    {dropdown && <span style={{flexGrow: 1}}>{dropdown}</span>}
-    <button className="btn btn-default" onClick={onDownload}>
-      <i className="fa fa-download" aria-hidden="true"></i>&nbsp;Download
-    </button>
+  return <div className="co-toolbar">
+    <div className="co-toolbar__group co-toolbar__group--left">
+      <div className="co-toolbar__item">
+        { status === 'loading' && <React.Fragment><LoadingInline/>&nbsp;</React.Fragment> }
+        { ['streaming', 'paused'].includes(status) && <TogglePlay active={status === 'streaming'} onClick={toggleStreaming}/>}
+        {streamStatusMessages[status]}
+      </div>
+      {dropdown && <div className="co-toolbar__item">{dropdown}</div>}
+    </div>
+    <div className="co-toolbar__group co-toolbar__group--right">
+      <div className="co-toolbar__item">
+        <button className="btn btn-default" onClick={onDownload}>
+          <i className="fa fa-download" aria-hidden="true"></i>&nbsp;Download
+        </button>
+      </div>
+    </div>
   </div>;
 };
 

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -37,7 +37,6 @@
 @import "components/utils/number-spinner";
 @import "components/utils/status-box";
 @import "components/utils/selector";
-@import "components/utils/resource-log";
 @import "components/utils/log-window";
 @import "components/chargeback";
 @import "components/cluster-overview";

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -85,13 +85,6 @@
   min-width: 0; // necessary for wrapping since its a flex child
 }
 
-.co-m-pane__top-controls {
-  margin: 0 0 10px;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
 .co-inline-block {
   display: inline-block;
 }
@@ -210,4 +203,48 @@ input[type=number]::-webkit-outer-spin-button {
 .co-external-link {
   display: inline-block;
   padding-right: 25px;
+}
+
+.co-toolbar {
+  align-items: stretch;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 5px;
+}
+
+.co-toolbar__item {
+  padding: 5px 0;
+}
+
+.co-toolbar__group {
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  @media (max-width: $screen-xs-max) {
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+}
+
+.co-toolbar__group--left {
+  justify-content: flex-start;
+  .co-toolbar__item {
+    padding-right: 15px;
+  }
+  @media (max-width: $screen-xs-max) {
+    align-items: flex-start;
+  }
+}
+
+.co-toolbar__group--right {
+  justify-content: flex-end;
+  .co-toolbar__item {
+    padding-left: 15px;
+  }
+  @media (max-width: $screen-xs-max) {
+    align-items: flex-end;
+  }
 }


### PR DESCRIPTION
Fix mobile responsiveness for log view controls that sit above the log content window. Also, fix bug where download button is incorrectly positioned if the container dropdown is not present.

Styles were originally included in https://github.com/openshift/console/pull/77. Refactored and renamed css block level component to `co-toolbar` instead of `co-top-controls`.

![image](https://user-images.githubusercontent.com/22625502/41436734-88a4df8a-6ff0-11e8-8cac-00e43feda821.png)

@openshift/team-ux-review