### PR TITLE
Fix apiVersion for CRD template

### DIFF
--- a/frontend/public/components/custom-resource-definition.jsx
+++ b/frontend/public/components/custom-resource-definition.jsx
@@ -31,7 +31,7 @@ spec:
     shortNames:
     - ct`;
 
-registerTemplate('v1beta1.CustomResourceDefinition', CRD);
+registerTemplate('apiextensions.k8s.io/v1beta1.CustomResourceDefinition', CRD);
 
 const CRDHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-4 col-md-4 col-sm-4 col-xs-6" sortField="spec.names.kind">Name</ColHead>


### PR DESCRIPTION
Issue was preventing loading of [CRD template](https://github.com/openshift/console/blob/master/frontend/public/components/custom-resource-definition.jsx#L11-L32)
/assign @spadgett