### PR TITLE
Fix hidden modal header

### DIFF
--- a/frontend/public/components/factory/_modal-wrapper.scss
+++ b/frontend/public/components/factory/_modal-wrapper.scss
@@ -5,7 +5,7 @@
   position: fixed;
   right: 0;
   top: 0;
-  z-index: 1002;
+  z-index: $zindex-modal;
 }
 
 .ReactModal__Content {


### PR DESCRIPTION
Modal that we are using for creating Projects and Namespaces have hidden header:
![header-missing](https://user-images.githubusercontent.com/1668218/41478411-d9578162-70c7-11e8-9555-ce3cd0889c37.png)

Adding additional margin fixes the issue:
![header-missing2](https://user-images.githubusercontent.com/1668218/41478463-03d9e272-70c8-11e8-9e70-ffd6267c159d.png)


/assign @spadgett