### PR TITLE
Containers page should have a breadcrumb back to the pod

### DIFF
--- a/frontend/public/components/container.jsx
+++ b/frontend/public/components/container.jsx
@@ -143,6 +143,8 @@ const Details = (props) => {
           <dd><Timestamp timestamp={state.startedAt} /></dd>
           <dt>Finished</dt>
           <dd><Timestamp timestamp={state.finishedAt} /></dd>
+          <dt>Pod</dt>
+          <dd><ResourceLink kind="Pod" name={props.match.params.podName} namespace={props.match.params.ns} /></dd>
         </dl>
       </div>
 


### PR DESCRIPTION
Related to [CONSOLE-544](https://jira.coreos.com/browse/CONSOLE-544).

See [this comment](https://github.com/openshift/console/pull/136#issuecomment-398792890) for most recent discussion.

**Old discussion (in short: breadcrumbs not possible as-is):**

Asked to add breadcrumbs to the ContainerDetailsPage, but there was already code for breadcrumbs there. Breadcrumbs weren't rendering for containers because the NavTitle component in the ContainerDetailsPage didn't have an obj prop.

(There are conditional rendering statements in nav-title.tsx that control whether breadcrumbs are displayed and whether the breadcrumbs CSS class is applied. The NavTitle won't render the breadcrumbs unless there's data in the obj prop. If you remove the two !_.isEmpty(data) checks in the NavTitle in nav-title.tsx, the breadcrumbs show up correctly on the Container detail page.)

Modified the route and details page to be more similar to those of other components, but still running some problems getting the page to display correctly.