### PR TITLE
[WIP] Introduce optional horizontally scrollable table functionality for review

### DIFF
--- a/frontend/public/components/_list.scss
+++ b/frontend/public/components/_list.scss
@@ -56,3 +56,38 @@
   right: 0;
   bottom: 0;
 }
+
+/* Make resource list (co-m-table-grid) scrollable
+--------------------------------------------------- */
+
+@media(max-width: $grid-float-breakpoint) {
+  .table-grid-wrapper {
+    overflow: hidden;
+    @include scroll-shadows-horizontal-other();
+  }
+  .co-m-table-grid--responsive {
+    .row {
+      display: flex;
+      // so scrollbar doesn't appear unless necessary, (tablet - left/right gutters)
+      min-width: ($screen-xs-max - ($grid-gutter-width * 2));
+      &--2col {
+        min-width: 320px;
+      }
+      &--3col,
+      &--4col {
+        min-width: ($screen-xs-max - ($grid-gutter-width * 2)); // 707
+      }
+      &--5col,
+      &--6col,
+      &--7col {
+        min-width: $screen-sm-max; // 991
+      }
+    }
+  }
+  .co-overflow-y-fade {
+    white-space: normal; // allow wrapping
+  }
+  .co-m-overflow__gradient {
+    background: none !important; // Prevent overlay with scroll-shadows
+  }
+}

--- a/frontend/public/components/factory/list.jsx
+++ b/frontend/public/components/factory/list.jsx
@@ -210,8 +210,9 @@ ColHead.propTypes = {
   sortFunc: PropTypes.string,
 };
 
-export const ListHeader = ({children}) => <div className="row co-m-table-grid__head">{children}</div>;
-ListHeader.displayName = 'ListHeader';
+export const ListHeader = ({children}) => <div className={`co-m-table-grid__head row row--${React.Children.count(children)}col`}>
+  {children}
+</div>;
 
 export const WorkloadListHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-2 col-md-3 col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
@@ -312,7 +313,7 @@ const stateToProps = ({UI}, {data, filters, loaded, reduxID, reduxIDs, staticFil
 export const List = connect(stateToProps, {sortList: UIActions.sortList})(
   /** @param props {{Header: React.ComponentType, Row: React.ComponentType, data: any[]}} */
   function ListInner (props) {
-    const {currentSortField, currentSortFunc, currentSortOrder, expand, Header, listId, Row, sortList, fake} = props;
+    const {currentSortField, currentSortFunc, currentSortOrder, expand, Header, listId, Row, sortList, fake, responsive} = props;
     const componentProps = _.pick(props, ['data', 'filters', 'selected', 'match', 'kindObj']);
 
     const children = <React.Fragment>
@@ -327,9 +328,17 @@ export const List = connect(stateToProps, {sortList: UIActions.sortList})(
       <Rows key="rows" expand={expand} Row={Row} {...componentProps} />
     </React.Fragment>;
 
-    return <div className="co-m-table-grid co-m-table-grid--bordered">
-      { fake ? children : <StatusBox {...props}>{children}</StatusBox> }
-    </div>;
+    const content = fake ? children : <StatusBox {...props}>{children}</StatusBox>;
+
+    return responsive
+      ? <div className="table-grid-wrapper">
+        <div className="co-m-table-grid co-m-table-grid--bordered co-m-table-grid--responsive scroll-shadows-cover">
+          {content}
+        </div>
+      </div>
+      : <div className="co-m-table-grid co-m-table-grid--bordered">
+        {content}
+      </div>;
   });
 
 List.propTypes = {
@@ -373,7 +382,8 @@ export class ResourceRow extends React.Component {
   }
 
   render () {
-    return <div className="row co-resource-list__item" style={this.props.style}>{this.props.children}</div>;
+    const {children, style} = this.props;
+    return <div className={`row co-resource-list__item row--${React.Children.count(children)}col`} style={style}>{children}</div>;
   }
 }
 

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -46,37 +46,39 @@ const getTLSCert = (ingress) => {
 };
 
 const IngressListHeader = props => <ListHeader>
-  <ColHead {...props} className="col-md-3 col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-md-3 col-sm-4 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
-  <ColHead {...props} className="col-md-3 col-sm-4 hidden-xs" sortField="metadata.labels">Labels</ColHead>
-  <ColHead {...props} className="col-md-3 hidden-sm hidden-xs" sortFunc="ingressValidHosts">Hosts</ColHead>
+  <ColHead {...props} className="col-md-3 col-sm-4 col-xs-3" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-md-3 col-sm-4 col-xs-3" sortField="metadata.namespace">Namespace</ColHead>
+  <ColHead {...props} className="col-md-3 col-sm-4 col-xs-3" sortField="metadata.labels">Labels</ColHead>
+  <ColHead {...props} className="col-md-3 hidden-sm col-xs-3" sortFunc="ingressValidHosts">Hosts</ColHead>
 </ListHeader>;
 
-const IngressListRow = ({obj: ingress}) => <ResourceRow obj={ingress}>
-  <div className="col-md-3 col-sm-4 col-xs-6">
+const IngressListRow = ({obj: ingress}) => <ResourceRow obj={ingress} rowColumns="row--4col">
+  <div className="col-md-3 col-sm-4 col-xs-3">
     <ResourceCog actions={menuActions} kind="Ingress" resource={ingress} />
     <ResourceLink kind="Ingress" name={ingress.metadata.name}
       namespace={ingress.metadata.namespace} title={ingress.metadata.uid} />
   </div>
-  <div className="col-md-3 col-sm-4 col-xs-6">
+  <div className="col-md-3 col-sm-4 col-xs-3">
     <ResourceLink kind="Namespace" name={ingress.metadata.namespace} title={ingress.metadata.namespace} />
   </div>
-  <div className="col-md-3 col-sm-4 hidden-xs">
+  <div className="col-md-3 col-sm-4 col-xs-3">
     <LabelList kind="Ingress" labels={ingress.metadata.labels} />
   </div>
-  <div className="col-md-3 hidden-sm hidden-xs">{getHosts(ingress)}</div>
+  <div className="col-md-3 hidden-sm col-xs-3">{getHosts(ingress)}</div>
 </ResourceRow>;
 
 const RulesHeader = () => <div className="row co-m-table-grid__head">
-  <div className="col-xs-3">Host</div>
-  <div className="col-xs-3">Path</div>
-  <div className="col-xs-3">Service</div>
-  <div className="col-xs-2">Service Port</div>
+  <div className="row row--4col">
+    <div className="col-xs-3">Host</div>
+    <div className="col-xs-3">Path</div>
+    <div className="col-xs-3">Service</div>
+    <div className="col-xs-3">Service Port</div>
+  </div>
 </div>;
 
 const RulesRow = ({rule, namespace}) => {
 
-  return <div className="row co-resource-list__item">
+  return <div className="row row--4col co-resource-list__item">
     <div className="col-xs-3">
       <div>{rule.host}</div>
     </div>
@@ -86,7 +88,7 @@ const RulesRow = ({rule, namespace}) => {
     <div className="col-xs-3">
       <ResourceLink kind="Service" name={rule.serviceName} namespace={namespace} />
     </div>
-    <div className="col-xs-2">
+    <div className="col-xs-3">
       <div>{rule.servicePort}</div>
     </div>
   </div>;
@@ -127,9 +129,11 @@ const Details = ({obj: ingress}) => <React.Fragment>
   <div className="co-m-pane__body">
     <Heading text="Ingress Rules" />
     <p className="co-m-pane__explanation">These rules are handled by a routing layer (Ingress Controller) which is updated as the rules are modified. The Ingress controller implementation defines how headers and other metadata are forwarded or manipulated.</p>
-    <div className="co-m-table-grid co-m-table-grid--bordered">
-      <RulesHeader />
-      <RulesRows spec={ingress.spec} namespace={ingress.metadata.namespace} />
+    <div className="table-grid-wrapper">
+      <div className="co-m-table-grid co-m-table-grid--bordered scroll-shadows-cover">
+        <RulesHeader />
+        <RulesRows spec={ingress.spec} namespace={ingress.metadata.namespace} />
+      </div>
     </div>
   </div>
 </React.Fragment>;
@@ -139,7 +143,7 @@ const IngressesDetailsPage = props => <DetailsPage
   menuActions={menuActions}
   pages={[navFactory.details(detailsPage(Details)), navFactory.editYaml()]}
 />;
-const IngressesList = props => <List {...props} Header={IngressListHeader} Row={IngressListRow} />;
+const IngressesList = props => <List {...props} Header={IngressListHeader} Row={IngressListRow} responsive={true} />;
 const IngressesPage = props => <ListPage ListComponent={IngressesList} canCreate={true} {...props} />;
 
 export {IngressesList, IngressesPage, IngressesDetailsPage};

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -59,33 +59,33 @@ export const PodRow = ({obj: pod}) => {
   }
 
   return <ResourceRow obj={pod}>
-    <div className="col-lg-2 col-md-3 col-sm-4 col-xs-6">
+    <div className="col-lg-2 col-md-3 col-sm-4 col-xs-2">
       <ResourceCog actions={menuActions} kind="Pod" resource={pod} isDisabled={phase === 'Terminating'} />
       <ResourceLink kind="Pod" name={pod.metadata.name} namespace={pod.metadata.namespace} title={pod.metadata.uid} />
     </div>
-    <div className="col-lg-2 col-md-3 col-sm-4 col-xs-6">
+    <div className="col-lg-2 col-md-3 col-sm-4 col-xs-2">
       <ResourceLink kind="Namespace" name={pod.metadata.namespace} title={pod.metadata.namespace} />
     </div>
-    <div className="col-lg-3 col-md-3 col-sm-4 hidden-xs">
+    <div className="col-lg-3 col-md-3 col-sm-4 col-xs-2">
       <LabelList kind="Pod" labels={pod.metadata.labels} />
     </div>
-    <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">
+    <div className="col-lg-2 col-md-2 hidden-sm col-xs-2">
       <NodeLink name={pod.spec.nodeName} />
     </div>
-    <div className="col-lg-2 col-md-1 hidden-sm hidden-xs">{status}</div>
-    <div className="col-lg-1 hidden-md hidden-sm hidden-xs"><Readiness pod={pod} /></div>
+    <div className="col-lg-2 col-md-1 hidden-sm col-xs-2">{status}</div>
+    <div className="col-lg-1 hidden-md hidden-sm col-xs-2"><Readiness pod={pod} /></div>
   </ResourceRow>;
 };
 
 PodRow.displayName = 'PodRow';
 
 const PodHeader = props => <ListHeader>
-  <ColHead {...props} className="col-lg-2 col-md-3 col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-lg-2 col-md-3 col-sm-4 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
-  <ColHead {...props} className="col-lg-3 col-md-3 col-sm-4 hidden-xs" sortField="metadata.labels">Pod Labels</ColHead>
-  <ColHead {...props} className="col-lg-2 col-md-2 hidden-sm hidden-xs" sortField="spec.nodeName">Node</ColHead>
-  <ColHead {...props} className="col-lg-2 col-md-1 hidden-sm hidden-xs" sortFunc="podPhase">Status</ColHead>
-  <ColHead {...props} className="col-lg-1 hidden-md hidden-sm hidden-xs" sortFunc="podReadiness">Readiness</ColHead>
+  <ColHead {...props} className="col-lg-2 col-md-3 col-sm-4 col-xs-2" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-lg-2 col-md-3 col-sm-4 col-xs-2" sortField="metadata.namespace">Namespace</ColHead>
+  <ColHead {...props} className="col-lg-3 col-md-3 col-sm-4 col-xs-2" sortField="metadata.labels">Pod Labels</ColHead>
+  <ColHead {...props} className="col-lg-2 col-md-2 hidden-sm col-xs-2" sortField="spec.nodeName">Node</ColHead>
+  <ColHead {...props} className="col-lg-2 col-md-1 hidden-sm col-xs-2" sortFunc="podPhase">Status</ColHead>
+  <ColHead {...props} className="col-lg-1 hidden-md hidden-sm col-xs-2" sortFunc="podReadiness">Readiness</ColHead>
 </ListHeader>;
 
 const ContainerLink = ({pod, name}) => <span className="co-resource-link">
@@ -278,7 +278,7 @@ export const PodsDetailsPage = props => <DetailsPage
 />;
 PodsDetailsPage.displayName = 'PodsDetailsPage';
 
-export const PodList = props => <List {...props} Header={PodHeader} Row={PodRow} />;
+export const PodList = props => <List {...props} Header={PodHeader} Row={PodRow} responsive={true} />;
 PodList.displayName = 'PodList';
 
 const filters = [{

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -21,6 +21,7 @@
 // Mixins
 @import "style/mixin/prefix";
 @import "style/mixin/break-word";
+@import "style/mixin/scroll-shadows";
 
 /* CUSTOM STYLES */
 

--- a/frontend/public/style/mixin/_scroll-shadows.scss
+++ b/frontend/public/style/mixin/_scroll-shadows.scss
@@ -1,0 +1,38 @@
+$scroll-shadows-bg-color: rgba(255, 255, 255, 1);
+$scroll-shadows-bg-color-transparent: rgba(255, 255, 255, 0);
+
+// Horizontal scroll drop shadows
+// Adds drop shadows to left and right edges that display when scrollable content is hidden
+// $bg-color should be an rgba color with opacity at 1 (e.g., rgba(255,0,0,1))
+// $bg-color-transparent should be the same rgb color as $bg-color but with opacity at 0 (e.g., rgba(255,0,0,0))
+
+@mixin scroll-shadows-horizontal($bg-color: $scroll-shadows-bg-color) {
+  background-attachment: scroll;
+  background-color: $bg-color;
+  background-image:
+    radial-gradient(ellipse at left, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 75%), // left shadow
+    radial-gradient(ellipse at right, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 75%); // right shadow
+  background-position: 0 0, 100% 0;
+  background-repeat: no-repeat;
+  background-size: 8px 100%;
+  -ms-overflow-style: auto; // so Edge will scroll correctly
+  overflow-x: auto; // make horizontally scrollable
+}
+
+// use for elements that are not tables
+// IMPORTANT: requires application of .scroll-shadows-cover on the inner element; does not work on all elements
+// in IE11/Edge (e.g., <pre>) as IE/Edge fails to properly attach the right background (i.e., "local" is
+// rendered as "scroll" )
+@mixin scroll-shadows-horizontal-other($bg-color: $scroll-shadows-bg-color, $bg-color-transparent: $scroll-shadows-bg-color-transparent) {
+  @include scroll-shadows-horizontal($bg-color);
+  > .scroll-shadows-cover {
+    background-attachment: local;
+    background-color: transparent;
+    background-image:
+      linear-gradient(to left, $bg-color-transparent 30%, $bg-color 70%), // left shadow cover
+      linear-gradient(to right, $bg-color-transparent 30%, $bg-color 70%);  // right shadow cover
+    background-position:  0 0, 100% 0;
+    background-repeat: no-repeat;
+    background-size: 20px 100%;
+  }
+}


### PR DESCRIPTION
These changes are a carry over of work from an earlier PR to the /bridge repo https://github.com/coreos-inc/bridge/pull/2293

By adding `responsive={true}` to a sections `<List ...>` at mobile widths (>768), a table would be enabled to horizontally scroll, and set at a min width, based on the number of columns.

In this PR the only views with tables enabled to scroll are on Pods and Ingress pages.

@spadgett, @robszumski, @rhamilto 
