### PR TITLE
Disable modebar buttons on line charts

### DIFF
--- a/frontend/public/components/graphs/line.jsx
+++ b/frontend/public/components/graphs/line.jsx
@@ -53,6 +53,7 @@ export class Line extends BaseGraph {
     };
     this.options = {
       displaylogo: false,
+      displayModeBar: false,
     };
     this.style = { width: '100%' };
     this.onPlotlyRelayout = e => {


### PR DESCRIPTION
No one seems to like the buttons that appear on hover. Our charts are
generally small enough that the modebar obscures the data. Also the
buttons aren't working properly since clicking any of them just takes
you to a Prometheus page. Let's just disable the buttons.

The buttons themselves are customizable, so we could bring this back and
leave only the buttons we find really useful.

I've only seen the issue on line charts.