### PR TITLE
Route Details: Conditions table

### DIFF
--- a/frontend/__tests__/components/route-pages.spec.tsx
+++ b/frontend/__tests__/components/route-pages.spec.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import { RouteLocation, RouteStatus, RouteWarnings } from '../../public/components/routes';
+import { RouteLocation, RouteStatus } from '../../public/components/routes';
 import { K8sResourceKind } from '../../public/module/k8s';
 
 describe(RouteLocation.displayName, () => {
@@ -240,71 +240,5 @@ describe(RouteStatus.displayName, () => {
     const wrapper = shallow(<RouteStatus obj={route} />);
     expect(wrapper.find('.fa-hourglass-half').exists()).toBe(true);
     expect(wrapper.text()).toEqual('Pending');
-  });
-});
-
-describe(RouteWarnings.displayName, () => {
-  it('renders ingress warnings', () => {
-    const route: K8sResourceKind = {
-      'apiVersion': 'v1',
-      'kind': 'Route',
-      'metadata': {
-        name: 'example',
-      },
-      'status': {
-        'ingress': [
-          {
-            'conditions': [
-              {
-                'type': 'Admitted',
-                'status': 'False',
-                'reason': 'ExtendedValidationFailed',
-                'message': 'spec.tls.caCertificate: Invalid value:'
-              }
-            ]
-          }
-        ]
-      }
-    };
-
-    const wrapper = shallow(<RouteWarnings obj={route} />);
-    expect(wrapper.find('div').text()).toContain('Requested host \'<unknown host>\' was rejected by the router');
-    expect(wrapper.find('div').text()).toContain('spec.tls.caCertificate: Invalid value:');
-  });
-
-  it('renders no tls termination warning', () => {
-    const route: K8sResourceKind = {
-      'apiVersion': 'v1',
-      'kind': 'Route',
-      'metadata': {
-        name: 'example',
-      },
-      'spec': {
-        'host': 'www.example.com',
-        'tls': {}
-      }
-    };
-    const wrapper = shallow(<RouteWarnings obj={route} />);
-    expect(wrapper.find('div').text()).toContain('Route has a TLS configuration, but no TLS termination type');
-  });
-
-  it('renders tls passthrough & path warning', () => {
-    const route: K8sResourceKind = {
-      'apiVersion': 'v1',
-      'kind': 'Route',
-      'metadata': {
-        name: 'example',
-      },
-      'spec': {
-        'host': 'www.example.com',
-        'path': '/mypath',
-        'tls': {
-          'termination': 'passthrough'
-        }
-      }
-    };
-
-    const wrapper = shallow(<RouteWarnings obj={route} />);
-    expect(wrapper.find('div').text()).toContain('Route path "/mypath" will be ignored since the route uses passthrough termination.');
   });
 });

--- a/frontend/public/components/_route.scss
+++ b/frontend/public/components/_route.scss
@@ -3,10 +3,6 @@
   width: 16px;
 }
 
-.co-m-route-warnings {
-  white-space: pre-wrap;
-}
-
 .co-m-route-tls-reveal__title {
   display: flex;
   justify-content: space-between;
@@ -14,4 +10,27 @@
 
 .co-m-route-tls-reveal__btn {
   padding-right: 0;
+}
+
+.co-m-route__ingress-status-section {
+  .co-m-route__ingress-status {
+    padding-bottom: 40px;
+
+    .co-m-table-grid {
+      .co-m-table-grid__head,
+      .co-m-table-grid__body {
+        div {
+          padding-left: 0;
+        }
+      }
+    }
+  }
+
+  .co-m-route-ingress-status:last-child {
+    padding-bottom: 0px;
+  }
+}
+
+.co-m-route__ingress-status__conditions-heading {
+  margin-top: 20px;
 }

--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-export const Conditions: React.SFC<ConditionsProps> = ({obj}) => {
-  const conditions = _.get(obj, 'status.conditions');
+export const Conditions: React.SFC<ConditionsProps> = ({conditions}) => {
   const rows = _.map(conditions, condition => <div className="row" key={condition.type}>
     <div className="col-xs-3 col-sm-2">
       {condition.type}
@@ -11,15 +10,15 @@ export const Conditions: React.SFC<ConditionsProps> = ({obj}) => {
       {condition.status}
     </div>
     <div className="col-xs-3 col-sm-3">
-      {condition.reason}
+      {condition.reason || '-'}
     </div>
-    <div className="col-xs-3 col-sm-5">
-      {condition.message}
+    {/* remove initial newline which appears in route messages */}
+    <div className="col-xs-3 col-sm-5 co-pre-line">
+      {_.trim(condition.message) || '-'}
     </div>
   </div>);
 
   return <React.Fragment>
-    <h1 className="co-section-title">Conditions</h1>
     {conditions
       ? <div className="co-m-table-grid co-m-table-grid--bordered">
         <div className="row co-m-table-grid__head">
@@ -39,7 +38,17 @@ export const Conditions: React.SFC<ConditionsProps> = ({obj}) => {
 };
 
 /* eslint-disable no-undef */
+export type conditionProps = {
+  type: string;
+  status: boolean | string;
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+};
+
 export type ConditionsProps = {
-  obj: any,
+  conditions: conditionProps[],
+  title?: string,
+  subTitle?: string
 };
 /* eslint-enable no-undef */

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -174,7 +174,8 @@ export const HorizontalPodAutoscalersDetails: React.SFC<HorizontalPodAutoscalers
     <MetricsTable obj={hpa} />
   </div>
   <div className="co-m-pane__body">
-    <Conditions obj={hpa} />
+    <h1 className="co-section-title">Conditions</h1>
+    <Conditions conditions={hpa.status.conditions} />
   </div>
 </React.Fragment>;
 

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -145,6 +145,10 @@
   border-radius: 2px;
 }
 
+.co-pre-line {
+  white-space: pre-line;
+}
+
 .co-pre-wrap {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
On Route Details page replaced inline route status warning messages with a Conditions table to match what was done in #97.

**Before:**
![image](https://user-images.githubusercontent.com/12733153/41548978-68f29c5e-72f2-11e8-8c40-a86547e967c9.png)

**After:**
![image](https://user-images.githubusercontent.com/12733153/41548853-1844df10-72f2-11e8-9ad9-d403d666e200.png)
_New  Router Section_
![image](https://user-images.githubusercontent.com/12733153/41779047-8f37f13e-75fe-11e8-9510-f931667afaa0.png)

@openshift/team-ux-review 