### PR TITLE
Fix GUI tests when user dropdown present

### DIFF
--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -59,8 +59,9 @@ export const activeRowFilters = $$('.row-filter--box__active');
 export const statusMessageTitle = $('.cos-status-box__title');
 export const statusMessageDetail = $('.cos-status-box__detail');
 
-export const actionsDropdown = $('.btn--actions').$('button');
-export const actionsDropdownMenu = $('.btn--actions').$$('.dropdown-menu').first();
+const actionsButton = $('.co-m-nav-title .btn--actions');
+export const actionsDropdown = actionsButton.$('button');
+export const actionsDropdownMenu = actionsButton.$$('.dropdown-menu').first();
 
 export const resourceTitle = $('#resource-title');
 


### PR DESCRIPTION
`.btn--actions` is not unique on the page when there is a user menu
in the masthead. This breaks the tests when the user menu appears
(for instance, when running the tests on an OpenShift cluster).

/assign @alecmerdler @jhadvig 