### PR TITLE
Add a logout redirect

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -46,6 +46,7 @@ func main() {
 	fUserAuthOIDCClientID := fs.String("user-auth-oidc-client-id", "", "The OIDC OAuth2 Client ID.")
 	fUserAuthOIDCClientSecret := fs.String("user-auth-oidc-client-secret", "", "The OIDC OAuth2 Client Secret.")
 	fUserAuthOIDCClientSecretFile := fs.String("user-auth-oidc-client-secret-file", "", "File containing the OIDC OAuth2 Client Secret.")
+	fUserAuthLogoutRedirect := fs.String("user-auth-logout-redirect", "", "Optional redirect URL on logout needed for some single sign-on identity providers.")
 
 	fK8sMode := fs.String("k8s-mode", "in-cluster", "in-cluster | off-cluster")
 	fK8sModeOffClusterEndpoint := fs.String("k8s-mode-off-cluster-endpoint", "", "URL of the Kubernetes API server.")
@@ -106,6 +107,11 @@ func main() {
 		caCertFilePath = k8sInClusterCA
 	}
 
+	logoutRedirect := &url.URL{}
+	if *fUserAuthLogoutRedirect != "" {
+		logoutRedirect = validateFlagIsURL("user-auth-logout-redirect", *fUserAuthLogoutRedirect)
+	}
+
 	if *fOpenshiftConsoleURL != "" && !strings.HasSuffix(*fOpenshiftConsoleURL, "/") {
 		flagFatalf("openshift-console-url", "value must end with slash")
 	}
@@ -114,6 +120,7 @@ func main() {
 		PublicDir:           *fPublicDir,
 		TectonicVersion:     *fTectonicVersion,
 		BaseURL:             baseURL,
+		LogoutRedirect:      logoutRedirect,
 		TectonicCACertFile:  caCertFilePath,
 		ClusterName:         *fTectonicClusterName,
 		OpenshiftConsoleURL: *fOpenshiftConsoleURL,

--- a/frontend/public/module/auth.js
+++ b/frontend/public/module/auth.js
@@ -45,13 +45,22 @@ export const authSvc = {
         console.error(e);
       }
     });
+
     coFetch(window.SERVER_FLAGS.logoutURL, {
       method: 'POST',
-    }).then(() => authSvc.login()).catch(e => {
+    }).then(() => authSvc._onLogout()).catch(e => {
       // eslint-disable-next-line no-console
       console.error('ERROR LOGGING OUT', e);
-      authSvc.login();
+      authSvc._onLogout();
     });
+  },
+
+  _onLogout: () => {
+    if (window.SERVER_FLAGS.logoutRedirect) {
+      window.location = window.SERVER_FLAGS.logoutRedirect;
+    } else {
+      authSvc.login();
+    }
   },
 
   login: () => {

--- a/server/server.go
+++ b/server/server.go
@@ -52,6 +52,7 @@ type jsGlobals struct {
 	LoginSuccessURL     string `json:"loginSuccessURL"`
 	LoginErrorURL       string `json:"loginErrorURL"`
 	LogoutURL           string `json:"logoutURL"`
+	LogoutRedirect      string `json:"logoutRedirect"`
 	KubeAPIServerURL    string `json:"kubeAPIServerURL"`
 	OpenshiftConsoleURL string `json:"openshiftConsoleURL"`
 	LogoImageName       string `json:"logoImageName"`
@@ -64,6 +65,7 @@ type jsGlobals struct {
 type Server struct {
 	K8sProxyConfig      *proxy.Config
 	BaseURL             *url.URL
+	LogoutRedirect      *url.URL
 	PublicDir           string
 	TectonicVersion     string
 	TectonicCACertFile  string
@@ -248,6 +250,7 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		LoginSuccessURL:     proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginSuccessEndpoint),
 		LoginErrorURL:       proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginErrorEndpoint),
 		LogoutURL:           proxy.SingleJoiningSlash(s.BaseURL.String(), authLogoutEndpoint),
+		LogoutRedirect:      s.LogoutRedirect.String(),
 		ClusterName:         s.ClusterName,
 		KubeAPIServerURL:    s.KubeAPIServerURL,
 		OpenshiftConsoleURL: s.OpenshiftConsoleURL,


### PR DESCRIPTION
This adds a logout redirect similar to OpenShift console logoutURL,
needed to destroy single sign-on sessions. I chose "logout redirect"
here since the console already has a "logout URL" with a different
meaning.

https://docs.openshift.com/container-platform/3.9/install_config/web_console_customization.html#changing-the-logout-url

/assign @jhadvig 