### PR TITLE
Use `stringData` in Secret template

### DIFF
--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -12,9 +12,9 @@ kind: Secret
 metadata:
   name: example
 type: Opaque
-data:
-  username: YWRtaW4=
-  password: MWYyZDFlMmU2N2Rm`);
+stringData:
+  username: admin
+  password: opensesame`);
 
 export const WebHookSecretKey = 'WebHookSecretKey';
 


### PR DESCRIPTION
`stringData` is easier to work with when creating the secret because you
don't need to base64 encode the values.

/assign @benjaminapetersen 