### PR TITLE
Add log status constants

### DIFF
--- a/frontend/public/components/utils/log-window.jsx
+++ b/frontend/public/components/utils/log-window.jsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { pluralize } from './';
+import { LOG_EOF, LOG_PAUSED, LOG_STREAMING } from './resource-log';
 
 // Subtracted from log window height to prevent scroll bar from appearing when footer is shown.
 const FUDGE_FACTOR = 105;
@@ -21,7 +22,7 @@ export class LogWindow extends React.PureComponent {
   }
 
   static getDerivedStateFromProps(nextProps) {
-    if (nextProps.status !== 'paused') {
+    if (nextProps.status !== LOG_PAUSED) {
       return {
         content: nextProps.lines.join(''),
       };
@@ -48,18 +49,18 @@ export class LogWindow extends React.PureComponent {
 
   _handleScroll() {
     // Stream is finished, take no action on scroll
-    if (this.props.status === 'eof') {
+    if (this.props.status === LOG_EOF) {
       return;
     }
 
     // 1px fudge for fractional heights
     const scrollTarget = this.scrollPane.scrollHeight - (this.scrollPane.clientHeight + 1);
     if (this.scrollPane.scrollTop < scrollTarget) {
-      if (this.props.status !== 'paused') {
-        this.props.updateStatus('paused');
+      if (this.props.status !== LOG_PAUSED) {
+        this.props.updateStatus(LOG_PAUSED);
       }
     } else {
-      this.props.updateStatus('streaming');
+      this.props.updateStatus(LOG_STREAMING);
     }
   }
 
@@ -75,10 +76,10 @@ export class LogWindow extends React.PureComponent {
   }
 
   _scrollToBottom() {
-    if (this.props.status === 'streaming') {
+    if (this.props.status === LOG_STREAMING) {
       // Async because scrollHeight depends on the size of the rendered pane
       setTimeout(() => {
-        if (this.scrollPane && this.props.status === 'streaming') {
+        if (this.scrollPane && this.props.status === LOG_STREAMING) {
           this.scrollPane.scrollTop = this.scrollPane.scrollHeight;
         }
       }, 0);
@@ -86,7 +87,7 @@ export class LogWindow extends React.PureComponent {
   }
 
   _unpause() {
-    this.props.updateStatus('streaming');
+    this.props.updateStatus(LOG_STREAMING);
   }
 
   render() {
@@ -114,7 +115,7 @@ export class LogWindow extends React.PureComponent {
           </div>
         </div>
       </div>
-      { status === 'paused' &&
+      { status === LOG_PAUSED &&
         <button onClick={this._unpause} className="btn btn-block log-window__resume-btn">
           <span className="fa fa-play-circle-o" aria-hidden="true"></span>
           {resumeText}


### PR DESCRIPTION
I think this addresses @benjaminapetersen's concern without the drawbacks of using a map for the statuses. If we ever convert to TypeScript, this can be changed to an `enum`.

/assign @TheRealJon @benjaminapetersen 