### PR TITLE
Removed orphaned var `$color-green-success`

### DIFF
--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -37,7 +37,6 @@ $color-grey-background: #f5f5f5;
 $color-grey-background-border: #ccc;
 
 $color-red-error: #D64456;
-$color-green-success: #2fc98e;
 $color-orange-warning: #fca657;
 
 $color-highlight-blue: #52a3d9;


### PR DESCRIPTION
The only reference was removed in #123

We could instead keep the var and assign it to `$color-pf-green-400` instead, then update routes and nodes to use it. I'm not sure what's better. @rhamilto opinion?