### PR TITLE
Fix misaligned Dropdown panel

### DIFF
--- a/frontend/__tests__/components/cloud-services/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/clusterserviceversion.spec.tsx
@@ -362,11 +362,10 @@ describe(ClusterServiceVersionDetails.displayName, () => {
     let obj = _.cloneDeep(testClusterServiceVersion);
     obj.spec.customresourcedefinitions.owned.push({name: 'foobars.testapp.coreos.com', displayName: 'Foo Bars', version: 'v1', kind: 'FooBars'});
     wrapper.setProps({obj});
-    const createButton: ShallowWrapper<any> = wrapper.find('.btn-primary');
+    const createButton: ShallowWrapper<any> = wrapper.find('Dropdown');
 
     expect(createButton.type()).toEqual(Dropdown);
     expect(createButton.props().title).toEqual('Create New');
-    expect(createButton.props().noButton).toEqual(true);
     expect(createButton.props().items).toEqual({'testresource.testapp.coreos.com': 'Test Resource', 'foobars.testapp.coreos.com': 'Foo Bars'});
     expect(createButton.props().onChange).toBeDefined();
   });

--- a/frontend/integration-tests/tests/alm/etcd.scenario.ts
+++ b/frontend/integration-tests/tests/alm/etcd.scenario.ts
@@ -89,7 +89,7 @@ describe('Interacting with the etcd OCS', () => {
   });
 
   it('displays YAML editor for creating a new `EtcdCluster` instance', async() => {
-    await $$('.dropdown__not-btn').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
+    await $$('.dropdown').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
     await browser.wait(until.visibilityOf($$('.dropdown-menu').first()), 1000);
     await $$('.dropdown-menu').first().element(by.linkText('etcd Cluster')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -138,7 +138,7 @@ describe('Interacting with the etcd OCS', () => {
   it('displays YAML editor for creating a new `EtcdBackup` instance', async() => {
     await $$('.breadcrumb-link').get(0).click();
     await crudView.isLoaded();
-    await $$('.dropdown__not-btn').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
+    await $$('.dropdown').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
     await browser.wait(until.visibilityOf($$('.dropdown-menu').first()), 1000);
     await $$('.dropdown-menu').first().element(by.linkText('etcd Backup')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -187,7 +187,7 @@ describe('Interacting with the etcd OCS', () => {
   it('displays YAML editor for creating a new `EtcdRestore` instance', async() => {
     await $$('.breadcrumb-link').get(0).click();
     await crudView.isLoaded();
-    await $$('.dropdown__not-btn').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
+    await $$('.dropdown').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
     await browser.wait(until.visibilityOf($$('.dropdown-menu').first()), 1000);
     await $$('.dropdown-menu').first().element(by.linkText('etcd Restore')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));

--- a/frontend/integration-tests/tests/alm/prometheus.scenario.ts
+++ b/frontend/integration-tests/tests/alm/prometheus.scenario.ts
@@ -91,7 +91,7 @@ describe('Interacting with the Prometheus OCS', () => {
   });
 
   it('displays YAML editor for creating a new `Prometheus` instance', async() => {
-    await $$('.dropdown__not-btn').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
+    await $$('.dropdown').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
     await browser.wait(until.visibilityOf($$('.dropdown-menu').first()), 1000);
     await $$('.dropdown-menu').first().element(by.linkText('Prometheus')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -135,7 +135,7 @@ describe('Interacting with the Prometheus OCS', () => {
   it('displays YAML editor for creating a new `Alertmanager` instance', async() => {
     await $$('.breadcrumb-link').first().click();
     await crudView.isLoaded();
-    await $$('.dropdown__not-btn').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
+    await $$('.dropdown').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
     await browser.wait(until.visibilityOf($$('.dropdown-menu').first()), 1000);
     await $$('.dropdown-menu').first().element(by.linkText('Alert Manager')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -180,7 +180,7 @@ describe('Interacting with the Prometheus OCS', () => {
   it('displays YAML editor for creating a new `ServiceMonitor` instance', async() => {
     await $$('.breadcrumb-link').first().click();
     await crudView.isLoaded();
-    await $$('.dropdown__not-btn').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
+    await $$('.dropdown').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
     await browser.wait(until.visibilityOf($$('.dropdown-menu').first()), 1000);
     await $$('.dropdown-menu').first().element(by.linkText('Service Monitor')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')), 10000);

--- a/frontend/public/components/cloud-services/clusterserviceversion.tsx
+++ b/frontend/public/components/cloud-services/clusterserviceversion.tsx
@@ -215,8 +215,7 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
       <div style={{marginBottom: '15px'}}>
         { status.phase !== ClusterServiceVersionPhase.CSVPhaseSucceeded && <button disabled={true} className="btn btn-primary">Create New</button> }
         { status.phase === ClusterServiceVersionPhase.CSVPhaseSucceeded && ownedCRDs.length > 1 && <Dropdown
-          noButton={true}
-          className="btn btn-primary"
+          buttonClassName="btn-primary"
           title="Create New"
           items={ownedCRDs.reduce((acc, crd) => ({...acc, [crd.name]: crd.displayName}), {})}
           onChange={(name) => history.push(route(name))} /> }

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -162,7 +162,7 @@ export const FireMan_ = connect(null, {filterList: k8sActions.filterList})(
           </Link>;
         } else if (createProps.items) {
           createLink = <div className="co-m-primary-action">
-            <Dropdown noButton={true} className="btn btn-primary" id="item-create" title={createButtonText} items={createProps.items} onChange={(name) => history.push(createProps.createLink(name))} />
+            <Dropdown buttonClassName="btn-primary" id="item-create" title={createButtonText} items={createProps.items} onChange={(name) => history.push(createProps.createLink(name))} />
           </div>;
         } else {
           createLink = <div className="co-m-primary-action">

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -109,7 +109,7 @@ const ResourceListDropdown_: React.StatelessComponent<ResourceListDropdownProps>
   if (selected && !items[selected]) {
     items[selected] = <DropdownItem kind={selected} />;
   }
-  return <Dropdown className={classNames('co-type-selector', {[className]: className})} items={items} title={items[selected]} onChange={onChange} selectedKey={selected} />;
+  return <Dropdown className={classNames('co-type-selector', className)} items={items} title={items[selected]} onChange={onChange} selectedKey={selected} />;
 };
 
 const resourceListDropdownStateToProps = (state): any => {

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -287,19 +287,7 @@ export class Dropdown extends DropdownMixin {
 
   render() {
     const {active, autocompleteText, selectedKey, items, title, bookmarks, keyboardHoverKey, favoriteKey} = this.state;
-    const {autocompleteFilter, autocompletePlaceholder, noButton, noSelection, className, menuClassName, storageKey, canFavorite, dropDownClassName, titlePrefix} = this.props;
-
-    const button = noButton
-      ? <div onClick={this.toggle} className="dropdown__not-btn" id={this.props.id}>
-        {titlePrefix && `${titlePrefix}: `}
-        <span className="dropdown__not-btn__title">{title}</span>&nbsp;<Caret />
-      </div>
-      : <button onClick={this.toggle} type="button" className="btn btn-default btn--dropdown dropdown-toggle" id={this.props.id}>
-        <div className="btn--dropdown__content-wrap">
-          {titlePrefix && `${titlePrefix}: `}
-          {title}&nbsp;&nbsp;<Caret />
-        </div>
-      </button>;
+    const {autocompleteFilter, autocompletePlaceholder, noButton, noSelection, className, buttonClassName, menuClassName, storageKey, canFavorite, dropDownClassName, titlePrefix} = this.props;
 
     const spacerBefore = this.props.spacerBefore || new Set();
     const headerBefore = this.props.headerBefore || {};
@@ -327,7 +315,19 @@ export class Dropdown extends DropdownMixin {
     //Adding `dropDownClassName` specifically to use patternfly's context selector component, which expects `bootstrap-select` class on the dropdown. We can remove this additional property if that changes in upcoming patternfly versions.
     return <div className={className} ref={this.dropdownElement} style={this.props.style}>
       <div className={classNames('dropdown', dropDownClassName)}>
-        {button}
+        {
+          noButton
+            ? <div onClick={this.toggle} className="dropdown__not-btn" id={this.props.id}>
+              {titlePrefix && `${titlePrefix}: `}
+              <span className="dropdown__not-btn__title">{title}</span>&nbsp;<Caret />
+            </div>
+            : <button onClick={this.toggle} type="button" className={classNames('btn', 'btn--dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id}>
+              <div className="btn--dropdown__content-wrap">
+                {titlePrefix && `${titlePrefix}: `}
+                {title}&nbsp;&nbsp;<Caret />
+              </div>
+            </button>
+        }
         {
           active && <ul className={classNames('dropdown-menu', menuClassName)}>
             {
@@ -388,7 +388,8 @@ export const ActionsMenu = (props) => {
       history.push(action.href);
     }
   };
-  return <Dropdown className="btn--actions"
+  return <Dropdown
+    className="btn--actions"
     menuClassName={menuClassName || 'dropdown-menu-right'}
     items={items}
     title={btnTitle}


### PR DESCRIPTION
Fixes [issue #154](https://github.com/openshift/console/issues/154).

Adjusted classes on button and outer Dropdown div. Button classes are now applied to the correct div when we're faking a button. Dropdowns with real buttons should be unaffected.

![screen shot 2018-06-25 at 1 28 22 pm](https://user-images.githubusercontent.com/7014965/41865669-c0c0600e-787b-11e8-9475-9111b88a1349.png)