### PR TITLE
Set active namespace when a project or namespace is viewed

### DIFF
--- a/frontend/public/components/utils/link.jsx
+++ b/frontend/public/components/utils/link.jsx
@@ -31,13 +31,12 @@ export const getNamespace = path => {
     return ALL_NAMESPACES_KEY;
   }
 
-  if (split[1] !== 'ns') {
-    return;
-  }
-
-  const ns = split[2];
-
-  if (!ns) {
+  let ns;
+  if (split[1] === 'cluster' && ['namespaces', 'projects'].includes(split[2]) && split[3]) {
+    ns = split[3];
+  } else if (split[1] === 'ns' && split[2]) {
+    ns = split[2];
+  } else {
     return;
   }
 


### PR DESCRIPTION
Continuation of https://github.com/openshift/console/pull/57

Active namespace should be set when user navigates to a namespace or project detail page.

Partially fixes https://jira.coreos.com/browse/CONSOLE-548