### PR TITLE
Show event messages using title attribute for messages so that full text message can be read.

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -104,12 +104,25 @@ $color-dark-border: #ddd;
 }
 
 .co-sysevent__message {
+  cursor: help;
   margin-top: 10px;
   overflow: hidden;
   text-overflow: ellipsis;
   word-wrap: break-word;
-  height: 45px;
+  height: 40px;
+  position: relative;
 }
+.co-sysevent__message:after {
+  background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
+  bottom: 0;
+  content: "";
+  height: 1.2em;
+  position: absolute;
+  right: 0;
+  width: 15%;
+  text-align: right;
+}
+
 
 .co-sysevent__icon-box {
   flex: 0 0 100px;

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -64,7 +64,7 @@ class Inner extends React.PureComponent {
             <span> on <Link to={`/k8s/cluster/nodes/${source.host}`}>{source.host}</Link></span>
           }
         </small>
-        <div className="co-sysevent__message">
+        <div className="co-sysevent__message" title={_.trim(message)}>
           {message}
         </div>
       </div>


### PR DESCRIPTION
Event stream messages have a set height and `overflow:hidden` to display only 2 lines of text.

Opted to go with this simple solution because the number of messages where the full text isn't visible is relatively small and the majority of those are less than 4 lines, so...

- Add a short gradient fade to pseudo element at the end of the message to show a portion is hidden.
- To enable the full message to be shown on hover, set a title attribute and help cursor.

https://jira.coreos.com/browse/CONSOLE-540

[updated gif] whitespace trimmed
![event-tooltip](https://user-images.githubusercontent.com/1874151/41977005-4f0f05c4-79ec-11e8-992e-0bfba11c437f.gif)

