### PR TITLE
Add Config Map and Secret Values to Env Editor

### DIFF
--- a/frontend/public/components/utils/_name-value-editor.scss
+++ b/frontend/public/components/utils/_name-value-editor.scss
@@ -13,6 +13,12 @@
 
 .pairs-list__btn {
   cursor: pointer;
+  padding-right: 8px;
+}
+
+.pairs-list__action-divider {
+  color: $color-pf-black-500;
+  padding-right: 10px;
 }
 
 .pairs-list__delete-icon {

--- a/frontend/public/components/utils/_value-from-pair.scss
+++ b/frontend/public/components/utils/_value-from-pair.scss
@@ -1,4 +1,18 @@
 .value-from-pair {
   float: left;
   width: 50%;
+
+  .btn--dropdown {
+    width: 100%;
+  }
+
+  .caret {
+    position: absolute;
+    right: 14px;
+    top: 9px;
+  }
+
+  .dropdown-menu {
+    width: 100%;
+  }
 }

--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import * as _ from 'lodash-es';
+import * as fuzzy from 'fuzzysearch';
+
+import { Dropdown, ResourceName} from './';
 
 // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#envvarsource-v1-core
 //   valueFrom:
@@ -22,21 +26,109 @@ import * as PropTypes from 'prop-types';
 //       resource: requests.cpu
 //       divisor: 1 // 1 is default
 
-const FieldRef = ({data: {fieldPath}}) => <span>
+const getSpacer = (configMap, secret) => {
+  const spacerBefore = new Set();
+  return _.isEmpty(configMap) || _.isEmpty(secret) ? spacerBefore : spacerBefore.add(secret);
+};
 
+const getHeaders = (configMap, secret) => {
+  if (_.isEmpty(configMap) && _.isEmpty(secret)) {
+    return {};
+  } else if (_.isEmpty(configMap)) {
+    return {[secret]: 'Secrets'};
+  } else if (_.isEmpty(secret)) {
+    return {[configMap]: 'Config Maps'};
+  }
+  return {
+    [configMap]: 'Config Maps',
+    [secret]: 'Secrets'
+  };
+};
+
+const getKeys = (keyMap) => {
+  const itemKeys = {};
+  _.mapKeys(keyMap, (value, key) => itemKeys[key] = key);
+  return itemKeys;
+};
+
+const NameKeyDropdownPair = ({name, key, configMaps, secrets, onChange, kind, nameTitle, placeholderString}) => {
+  let itemKeys = {};
+  let keyRefString;
+  const cmItems = {};
+  const secretItems = {};
+  const nameAutocompleteFilter = (text, item) => fuzzy(text, item.props.name);
+  const keyAutocompleteFilter = (text, item) => fuzzy(text, item);
+  const keyTitle = _.isEmpty(key) ? <span className="text-muted">Select a key</span> : <span>{key}</span>;
+
+  _.each(configMaps.items, (v) => {
+    cmItems[`${v.metadata.name}:configMapKeyRef`] = <ResourceName kind="ConfigMap" name={v.metadata.name} />;
+    if (kind === 'ConfigMap' && _.isEqual(v.metadata.name, name)) {
+      keyRefString = 'configMapKeyRef';
+      itemKeys = getKeys(v.data);
+    }
+  });
+  _.each(secrets.items, (v) => {
+    secretItems[`${v.metadata.name}:secretKeyRef`] = <ResourceName kind="Secret" name={v.metadata.name} />;
+    if (kind === 'Secret' && _.isEqual(v.metadata.name, name)) {
+      keyRefString = 'secretKeyRef';
+      itemKeys = getKeys(v.data);
+    }
+  });
+
+  const firstConfigMap = _.isEmpty(cmItems) ? {} : Object.keys(cmItems)[0];
+  const firstSecret = _.isEmpty(secretItems) ? {} : Object.keys(secretItems)[0];
+  const headerBefore = getHeaders(firstConfigMap, firstSecret);
+  const spacerBefore = getSpacer(firstConfigMap, firstSecret);
+  const items = _.assign({}, cmItems, secretItems);
+  return <React.Fragment>
+    <Dropdown
+      menuClassName="co-namespace-selector__menu"
+      className="value-from-pair"
+      autocompleteFilter={nameAutocompleteFilter}
+      autocompletePlaceholder={placeholderString}
+      items={items}
+      selectedKey={name}
+      title={nameTitle}
+      headerBefore={headerBefore}
+      spacerBefore={spacerBefore}
+      onChange={val => {
+        const keyValuePair = _.split(val, ':');
+        onChange({
+          [keyValuePair[1]]:
+            {'name': keyValuePair[0], 'key': ''}
+        });
+      }}
+    />
+    <Dropdown
+      menuClassName="co-namespace-selector__menu"
+      className="value-from-pair"
+      autocompleteFilter={keyAutocompleteFilter}
+      autocompletePlaceholder="Key"
+      items={itemKeys}
+      selectedKey={key}
+      title={keyTitle}
+      onChange={val => onChange({[keyRefString]:{'name': name, 'key': val}})}
+    />
+  </React.Fragment>;
+};
+
+const FieldRef = ({data: {fieldPath}}) => <span>
   <input type="text" className="form-control value-from-pair" value="FieldRef" disabled />
   <input type="text" className="form-control value-from-pair" value={fieldPath} disabled />
 </span>;
 
-const SecretKeyRef = ({data: {name, key}}) => <span>
-  <input type="text" className="form-control value-from-pair" value={`${name} - Secret`} disabled />
-  <input type="text" className="form-control value-from-pair" value={key} disabled />
-</span>;
+const ConfigMapSecretKeyRef = ({data: {name, key}, configMaps, secrets, onChange, disabled, kind}) => {
+  const placeholderString = 'Config Map or Secret';
+  const nameTitle = _.isEmpty(name) ? <span className="text-muted">Select a resource</span> : <ResourceName kind={kind} name={name} />;
 
-const ConfigMapKeyRef = ({data: {name, key}}) => <span>
-  <input type="text" className="form-control value-from-pair" value={`${name} - ConfigMap`} disabled />
-  <input type="text" className="form-control value-from-pair" value={key} disabled />
-</span>;
+  if (disabled) {
+    return <span>
+      <input type="text" className="form-control value-from-pair" value={`${name} - ${kind}`} disabled />
+      <input type="text" className="form-control value-from-pair" value={key} disabled />
+    </span>;
+  }
+  return NameKeyDropdownPair({name, key, configMaps, secrets, onChange, kind, nameTitle, placeholderString});
+};
 
 const ResourceFieldRef = ({data: {containerName, resource}}) => <span>
   <input type="text" className="form-control value-from-pair" value={`${containerName} - Resource Field`} disabled />
@@ -45,8 +137,17 @@ const ResourceFieldRef = ({data: {containerName, resource}}) => <span>
 
 const keyStringToComponent = {
   fieldRef: FieldRef,
-  secretKeyRef: SecretKeyRef,
-  configMapKeyRef: ConfigMapKeyRef,
+  secretKeyRef: {
+    component: ConfigMapSecretKeyRef,
+    kind: 'Secret'
+  },
+  configMapKeyRef: {
+    component: ConfigMapSecretKeyRef,
+    kind: 'ConfigMap'
+  },
+  configMapSecretKeyRef: {
+    component: ConfigMapSecretKeyRef
+  },
   resourceFieldRef: ResourceFieldRef,
 };
 
@@ -54,16 +155,28 @@ export class ValueFromPair extends React.PureComponent {
   constructor (props) {
     super(props);
 
-    this.valueFromKey = Object.keys(this.props.pair)[0];
-    this.Component = keyStringToComponent[this.valueFromKey];
+    this.onChangeVal = (...args) => this._onChangeVal(...args);
+  }
+
+  _onChangeVal(value) {
+    const {onChange} = this.props;
+    const e = {'target': {value}};
+    return onChange(e);
   }
 
   render () {
-    const data = this.props.pair[this.valueFromKey];
+    const {pair, configMaps, secrets, disabled} = this.props;
+    const valueFromKey = Object.keys(this.props.pair)[0];
+    const componentInfo = keyStringToComponent[valueFromKey];
+    const Component = componentInfo.component;
 
-    return <this.Component data={data} />;
+    return <Component data={pair[valueFromKey]} configMaps={configMaps} secrets={secrets} kind={componentInfo.kind} onChange={this.onChangeVal} disabled={disabled} />;
   }
 }
 ValueFromPair.propTypes = {
-  pair: PropTypes.object.isRequired
+  pair: PropTypes.object.isRequired,
+  configMaps: PropTypes.object,
+  secrets: PropTypes.object,
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool
 };


### PR DESCRIPTION
Add Config Map and Secret Value to Env Editor via new link button. Allow config map and secret additions as well as editing existing config maps and secrets on the env editor page.

This PR was created for: https://jira.coreos.com/browse/CONSOLE-556 and https://jira.coreos.com/browse/CONSOLE-413

- Load config maps and secrets on ComponentDidMount of Environment Page and display page loading state similar to loading of env vars.

- Pass config maps and secrets to name value editor and Value from Pair objects (config maps, secrets, etc.).

- Add Link Button to add config maps

- Add Link Button to add secrets

- Add Config Map or Secret link and combined combo box to add or edit a config map or secret, and activate the key combo box to load keys from the config map or secret resource. Make secret and combo box a single dropdown

- Add setter methods to set the valueFrom.configMapKeyRefs and valueFrom.secretKeyRefs in yaml for config map and secret env vars.

- Preserve read-only state for pods and builds when displaying config map and secret editing controls in env editor.

![combinedsandcm](https://user-images.githubusercontent.com/35978579/42400841-164c86ce-8141-11e8-9f61-9e95133235b3.gif)




