### PR TITLE
Fix stale and error notifications for logs

### DIFF
--- a/frontend/public/components/build-logs.jsx
+++ b/frontend/public/components/build-logs.jsx
@@ -1,20 +1,37 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { ResourceLog, LOG_SOURCE_RUNNING, LOG_SOURCE_TERMINATED, LOG_SOURCE_WAITING } from './utils';
 
-import { ResourceLog } from './utils';
+const buildToLogSourceStatus = (phase) => {
+  switch (phase) {
+
+    case 'New':
+    case 'Pending':
+      return LOG_SOURCE_WAITING;
+    case 'Cancelled':
+    case 'Complete':
+    case 'Error':
+    case 'Failed':
+      return LOG_SOURCE_TERMINATED;
+
+    default:
+      return LOG_SOURCE_RUNNING;
+  }
+};
 
 export class BuildLogs extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      alive: true
+      status: LOG_SOURCE_WAITING
     };
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    const alive = _.get(nextProps.obj, 'status.phase') === 'Running';
-    if (prevState.alive !== alive){
-      return {alive};
+    const phase = _.get(nextProps.obj, 'status.phase');
+    const status = buildToLogSourceStatus(phase);
+    if (prevState.status !== status){
+      return {status};
     }
     return null;
   }
@@ -24,10 +41,11 @@ export class BuildLogs extends React.Component {
     const buildName = _.get(this.props.obj, 'metadata.name');
     return <div className="co-m-pane__body">
       <ResourceLog
-        alive={this.state.alive}
         kind="Build"
         namespace={namespace}
-        resourceName={buildName} />
+        resourceName={buildName}
+        resourceStatus={this.state.status}
+      />
     </div>;
   }
 }

--- a/frontend/public/components/utils/log-window.jsx
+++ b/frontend/public/components/utils/log-window.jsx
@@ -2,9 +2,9 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { pluralize } from './';
-import { LOG_EOF, LOG_PAUSED, LOG_STREAMING } from './resource-log';
+import { STREAM_EOF, STREAM_PAUSED, STREAM_ACTIVE } from './resource-log';
 
-// Subtracted from log window height to prevent scroll bar from appearing when footer is shown.
+// Subtracted from log window height to prevent scroll bar from appearing when resume button is shown.
 const FUDGE_FACTOR = 105;
 
 export class LogWindow extends React.PureComponent {
@@ -22,7 +22,7 @@ export class LogWindow extends React.PureComponent {
   }
 
   static getDerivedStateFromProps(nextProps) {
-    if (nextProps.status !== LOG_PAUSED) {
+    if (nextProps.status !== STREAM_PAUSED) {
       return {
         content: nextProps.lines.join(''),
       };
@@ -49,18 +49,18 @@ export class LogWindow extends React.PureComponent {
 
   _handleScroll() {
     // Stream is finished, take no action on scroll
-    if (this.props.status === LOG_EOF) {
+    if (this.props.status === STREAM_EOF) {
       return;
     }
 
     // 1px fudge for fractional heights
     const scrollTarget = this.scrollPane.scrollHeight - (this.scrollPane.clientHeight + 1);
     if (this.scrollPane.scrollTop < scrollTarget) {
-      if (this.props.status !== LOG_PAUSED) {
-        this.props.updateStatus(LOG_PAUSED);
+      if (this.props.status !== STREAM_PAUSED) {
+        this.props.updateStatus(STREAM_PAUSED);
       }
     } else {
-      this.props.updateStatus(LOG_STREAMING);
+      this.props.updateStatus(STREAM_ACTIVE);
     }
   }
 
@@ -76,10 +76,10 @@ export class LogWindow extends React.PureComponent {
   }
 
   _scrollToBottom() {
-    if (this.props.status === LOG_STREAMING) {
+    if (this.props.status === STREAM_ACTIVE) {
       // Async because scrollHeight depends on the size of the rendered pane
       setTimeout(() => {
-        if (this.scrollPane && this.props.status === LOG_STREAMING) {
+        if (this.scrollPane && this.props.status === STREAM_ACTIVE) {
           this.scrollPane.scrollTop = this.scrollPane.scrollHeight;
         }
       }, 0);
@@ -87,7 +87,7 @@ export class LogWindow extends React.PureComponent {
   }
 
   _unpause() {
-    this.props.updateStatus(LOG_STREAMING);
+    this.props.updateStatus(STREAM_ACTIVE);
   }
 
   render() {
@@ -115,7 +115,7 @@ export class LogWindow extends React.PureComponent {
           </div>
         </div>
       </div>
-      { status === LOG_PAUSED &&
+      { status === STREAM_PAUSED &&
         <button onClick={this._unpause} className="btn btn-block log-window__resume-btn">
           <span className="fa fa-play-circle-o" aria-hidden="true"></span>
           {resumeText}


### PR DESCRIPTION
Add `resourceStatus` prop to ResourceLog component to track simplified state of builds and containers. BuildLog and PodLog components map build phase or container status to one of four possible states:

**Builds**

| Build Phase | ResourceStatus |
| --- | --- |
| New, Pending | 'waiting' |
| Running | 'running' |
| Cancelled, Complete, Error, Fail | 'terminated' |

**Containers**

| Container Status | ResourceStatus |
| --- | --- |
| waiting (lastState is empty) | 'waiting' |
| waiting (lastState is not empty) | 'restarting' |
| running | 'running' |
| terminated | 'terminated' |

Resource log now uses the following logic:

```
// prevents error message when viewing logs for waiting containers or new/pending builds
If resourceStatus is 'waiting'
   don't start the stream yet

If resourceStatus transitions from 'waiting' to another state
    start streaming

// prevents stale notification on builds or first run of containers
If resourceStatus transitions from 'restarting' to another state
    show stale notification
```
