### PR TITLE
Add Dockerfile.product

### DIFF
--- a/Dockerfile.product
+++ b/Dockerfile.product
@@ -1,0 +1,46 @@
+FROM openshift/origin-base
+
+ENV GOPATH=/go
+
+RUN mkdir -p /go/src/github.com/openshift/console/
+ADD . /go/src/github.com/openshift/console/
+WORKDIR /go/src/github.com/openshift/console/
+ADD etc/ssl /etc/ssl
+
+# TODO: Switch to multistage builds as soon as we can.
+#
+# Multi stage builds are not yet supported for product builds. For now, install
+# dependencies and do our best to clean up after building.
+#
+# Node.js 8+ is required, but EPEL only has Node.js 6.
+#
+# `rm -rf /tmp/*` is needed to remove chromedriver and other temporary files
+# created while building frontend assets.
+
+RUN curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - && \
+    curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
+    INSTALL_PKGS="git golang nodejs yarn" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    ./build.sh && \
+    mkdir -p /opt/bridge/bin && \
+    cp -R frontend/public/dist /opt/bridge/static && \
+    cp bin/bridge /opt/bridge/bin && \
+    yarn cache clean && \
+    yum autoremove -y $INSTALL_PKGS && \
+    yum clean all && \
+    rm /etc/yum.repos.d/yarn.repo && \
+    rm -rf /tmp/* && \
+    rm -rf /go
+
+WORKDIR /
+
+LABEL io.k8s.display-name="OpenShift Console" \
+      io.k8s.description="This is a component of OpenShift Container Platform and provides a web console." \
+      io.openshift.tags="openshift" \
+      maintainer="Samuel Padgett <spadgett@redhat.com>"
+
+# doesn't require a root user.
+USER 1001
+
+CMD [ "/opt/bridge/bin/bridge", "--public-dir=/opt/bridge/static" ]


### PR DESCRIPTION
This Dockerfile is a bit crazy, but avoids multi stage builds. It results in a final image that is about twice the size of the one built using https://github.com/openshift/console/blob/master/Dockerfile

Best I can tell the culprit is

```
ADD . /go/src/github.com/openshift/console/
```

which creates a 178MB layer and bloats the final image size even if `rm -rf /go` is called later. Maybe we can squash the layers.

Will this work? Let me know if there is a better way.

/cc @adammhaile @sosiouxme 
/hold

@jwforres FYI