### PR TITLE
Drag&Drop for FileInput

### DIFF
--- a/frontend/public/components/_secret.scss
+++ b/frontend/public/components/_secret.scss
@@ -1,4 +1,0 @@
-.co-create-secret-form__textarea {
-  min-height: 300px;
-  width: 100%;
-}

--- a/frontend/public/components/utils/_file-input.scss
+++ b/frontend/public/components/utils/_file-input.scss
@@ -1,6 +1,6 @@
 .co-btn-file {
-  position: relative;
   overflow: hidden;
+  position: relative;
   input[type=file] {
     background: white;
     cursor: inherit;
@@ -16,4 +16,39 @@
     text-align: right;
     top: 0;
   }
+}
+
+.co-file-dropzone {
+  position: relative;
+  .co-file-dropzone-container {
+    border: 3px solid $color-grey-background-border;
+    background: rgba(0,0,0,0.3);
+    bottom: 0;
+    color: #fff;
+    left: 0;
+    margin: -3px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 1001;
+    &.co-file-dropzone--drop-over {
+      border-color: $color-pf-blue-300;
+      color: $color-pf-blue-300;
+    }
+  }
+}
+
+.co-file-dropzone__textarea {
+  min-height: 300px;
+  width: 100%;
+}
+
+.co-file-dropzone__drop-text {
+  font-size: 20px;
+  font-weight: bolder;
+  left: 50%;
+  margin-right: -50%;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
 }

--- a/frontend/public/components/utils/drag-drop-context.tsx
+++ b/frontend/public/components/utils/drag-drop-context.tsx
@@ -1,0 +1,6 @@
+import {DragDropContext} from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+
+// Need to create this decorator, because of the issue with react-dnd module:
+// https://github.com/react-dnd/react-dnd/issues/186#issuecomment-282789420
+export default DragDropContext(HTML5Backend);

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -1,50 +1,153 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
+import { NativeTypes } from 'react-dnd-html5-backend';
+// eslint-disable-next-line no-unused-vars
+import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd';
+import withDragDropContext from '../utils/drag-drop-context';
 
 export class FileInput extends React.Component<FileInputProps, FileInputState> {
   constructor(props) {
     super(props);
+    this.onDataChange = this.onDataChange.bind(this);
+    this.onFileUpload = this.onFileUpload.bind(this);
+  }
+  onDataChange(event) {
+    this.props.onChange(event.target.value);
+  }
+  readFile(file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const input = reader.result;
+      this.props.onChange(input, file.name);
+    };
+    reader.readAsText(file, 'UTF-8');
+  }
+  onFileUpload(event) {
+    this.readFile(event.target.files[0]);
+  }
+  render() {
+    const { connectDropTarget, isOver, canDrop, id } = this.props;
+    const klass = classNames('co-file-dropzone-container', {'co-file-dropzone--drop-over': isOver});
+    return (
+      connectDropTarget(
+        <div className="co-file-dropzone">
+          { canDrop && <div className={klass}><p className="co-file-dropzone__drop-text">Drop file here</p></div> }
+
+          <div className="form-group">
+            <label className="control-label" htmlFor={id}>{this.props.label}</label>
+            <div className="modal-body__field">
+              <div className="input-group">
+                <input type="text"
+                  className="form-control"
+                  value={this.props.inputFileName}
+                  aria-describedby={`${id}-help`}
+                  readOnly
+                  disabled />
+                <span className="input-group-btn">
+                  <span className="btn btn-default co-btn-file">
+                    Browse&hellip;
+                    <input type="file" onChange={this.onFileUpload} className="form-control" />
+                  </span>
+                </span>
+              </div>
+              <p className="help-block" id={`${id}-help`}>{this.props.inputFieldHelpText}</p>
+              <textarea className="form-control co-file-dropzone__textarea"
+                onChange={this.onDataChange}
+                value={this.props.inputFileData}
+                aria-describedby={`${id}-textarea-help`}
+                required>
+              </textarea>
+              <p className="help-block" id={`${id}-textarea-help`}>{this.props.textareaFieldHelpText}</p>
+            </div>
+          </div>
+        </div>
+      )
+    );
+  }
+}
+
+const boxTarget = {
+  drop(props: FileInputProps, monitor: DropTargetMonitor) {
+    if (props.onDrop && monitor.isOver()) {
+      props.onDrop(props, monitor);
+    }
+  },
+};
+
+const FileInputComponent = DropTarget(NativeTypes.FILE, boxTarget, (connect, monitor) => ({
+  connectDropTarget: connect.dropTarget(),
+  isOver: monitor.isOver(),
+  canDrop: monitor.canDrop()
+}))(FileInput);
+
+export const DroppableFileInput = withDragDropContext(class DroppableFileInput extends React.Component<DroppableFileInputProps, DroppableFileInputState>{
+  constructor(props) {
+    super(props);
     this.state = {
       inputFileName: '',
-      inputFileData: '',
+      inputFileData: this.props.inputFileData || '',
     };
-    this.onFileChange = this.onFileChange.bind(this);
+    this.handleFileDrop = this.handleFileDrop.bind(this);
+    this.onDataChange = this.onDataChange.bind(this);
   }
-  onFileChange(event) {
-    const file = event.target.files[0];
-    this.setState({ inputFileName: file.name });
+  handleFileDrop(item: any, monitor: DropTargetMonitor) {
+    if (!monitor) {
+      return;
+    }
+    const file = monitor.getItem().files[0];
     const reader = new FileReader();
     reader.onload = () => {
       const input = reader.result;
       this.setState({
+        inputFileName: file.name,
         inputFileData: input
-      }, () => this.props.onChange(this.state.inputFileData));
+      }, () => this.props.onChange(input));
     };
     reader.readAsText(file, 'UTF-8');
   }
-  render() {
-    return <div className="input-group">
-      <input type="text"
-        className="form-control"
-        value={this.state.inputFileName}
-        readOnly
-        disabled />
-      <span className="input-group-btn">
-        <span className="btn btn-default co-btn-file">
-          Browse&hellip;
-          <input type="file" onChange={this.onFileChange} className="form-control" />
-        </span>
-      </span>
-    </div>;
+  onDataChange(fileData, fileName) {
+    this.setState({
+      inputFileData: fileData,
+      inputFileName: !fileName ? '' : fileName
+    }, () => this.props.onChange(fileData));
   }
-}
-
+  render() {
+    return <FileInputComponent
+      {...this.props}
+      onDrop={this.handleFileDrop}
+      onChange={this.onDataChange}
+      inputFileData={this.state.inputFileData}
+      inputFileName={this.state.inputFileName} />;
+  }
+});
 /* eslint-disable no-undef */
+export type DroppableFileInputProps = {
+  inputFileData: string,
+  onChange: Function,
+  label: string,
+  id: string,
+  inputFieldHelpText: string,
+  textareaFieldHelpText: string,
+};
+export type DroppableFileInputState = {
+  inputFileData: string,
+  inputFileName: string,
+};
 export type FileInputState = {
   inputFileData: string,
   inputFileName: string,
 };
-
 export type FileInputProps = {
+  connectDropTarget?: ConnectDropTarget,
+  isOver?: boolean,
+  canDrop?: boolean,
+  onDrop: (props: FileInputProps, monitor: DropTargetMonitor) => void,
+  inputFileData: string,
+  inputFileName: string,
   onChange: Function,
+  label: string,
+  id: string,
+  inputFieldHelpText: string,
+  textareaFieldHelpText: string,
 };
 /* eslint-enable no-undef */

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -14,7 +14,6 @@ export * from './vertnav';
 export * from './details-page';
 export * from './inject';
 export * from './disabled';
-export * from './file-input';
 export * from './firehose';
 export * from './dropdown';
 export * from './status-box';

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -60,7 +60,6 @@
 @import "components/resource-dropdown";
 @import "components/row-filter";
 @import "components/route";
-@import "components/secret";
 @import "components/service";
 @import "components/sysevent-icon";
 @import "components/sysevent-stream";


### PR DESCRIPTION
Updated the `FileInput` component with having Drag&Drop functionality using the `react-dropzone` pkg.
Screen:
![1](https://user-images.githubusercontent.com/1668218/41986684-222b36ea-7a37-11e8-99c7-905dbcc04640.png)

Originally I wanted to create a HOC component that would wrap passed component with D&D functionality, but that turned out to be a bit more complicated since the data (fileName, fileData) needed to be passed back and forth. But I've figured out that the FileInput should have this functionality by default. So until we will need other components that would need D&D functionality, would leave this as is.

![create source secret tectonic](https://user-images.githubusercontent.com/1668218/41987058-67493780-7a38-11e8-8931-4767509bae65.gif)

@spadgett @openshift/team-ux-review  PTAL
