### PR TITLE
Add tooltip to CopyToClipboard

### DIFF
--- a/frontend/public/components/utils/copy-to-clipboard.jsx
+++ b/frontend/public/components/utils/copy-to-clipboard.jsx
@@ -1,15 +1,76 @@
 import * as React from 'react';
 
 import { CopyToClipboard as CTC } from 'react-copy-to-clipboard';
+import { Tooltip } from 'react-lightweight-tooltip';
 
-export const CopyToClipboard = ({value, visibleValue = value}) => <React.Fragment>
-  <div className="co-copy-to-clipboard">
-    <pre className="co-pre-wrap co-copy-to-clipboard__text">{visibleValue}</pre>
-    <CTC text={value}>
-      <button className="btn btn-default co-copy-to-clipboard__btn" type="button">
-        <i className="fa fa-clipboard" aria-hidden="true"></i>
-        <span className="sr-only">Copy to Clipboard</span>
-      </button>
-    </CTC>
-  </div>
-</React.Fragment>;
+export class CopyToClipboard extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {copied: false};
+    this.showCopied = this.showCopied.bind(this);
+    this.showDefault = this.showDefault.bind(this);
+  }
+
+  showCopied() {
+    this.setState({copied: true});
+  }
+
+  showDefault() {
+    this.setState({copied: false});
+  }
+
+  render() {
+    const overrides = Object.freeze({
+      wrapper: {
+        position: 'absolute',
+        right: '0',
+        top: '0',
+        height: '42px',
+        padding: '0',
+      },
+      tooltip: {
+        position: 'absolute',
+        right: '55px',
+        bottom: '-6px',
+        left: 'auto',
+        maxWidth: '170px',
+        minWidth: 'auto',
+        padding: '0',
+        textAlign: 'center',
+        width: 'auto',
+        transform: 'translateX(0px)',
+      },
+      content: {
+        display: 'block',
+        fontFamily: '"Open Sans",Helvetica,Arial,sans-serif',
+        fontSize: '12px',
+        padding: '7px 12px',
+        whiteSpace: 'normal',
+      },
+      arrow: {
+        position: 'absolute',
+        bottom: '8px',
+        right: '-13px',
+        left: 'auto',
+        borderTop: '8px solid transparent',
+        borderBottom: '8px solid transparent',
+        borderLeft: '8px solid #000',
+      }
+    });
+
+    const tooltipText = this.state.copied ? 'Copied' : 'Copy to Clipboard';
+    const tooltipContent = [<span className="co-nowrap" key="nowrap">{tooltipText}</span>];
+
+    return <div className="co-copy-to-clipboard">
+      <pre className="co-pre-wrap co-copy-to-clipboard__text">{this.props.visibleValue}</pre>
+      <Tooltip content={tooltipContent} styles={overrides}>
+        <CTC text={this.props.value} onCopy={this.showCopied}>
+          <button onMouseEnter={this.showDefault} className="btn btn-default co-copy-to-clipboard__btn fix" type="button">
+            <i className="fa fa-clipboard" aria-hidden="true"></i>
+            <span className="sr-only">Copy to Clipboard</span>
+          </button>
+        </CTC>
+      </Tooltip>
+    </div>;
+  }
+}


### PR DESCRIPTION
Fixes [#144](https://github.com/openshift/console/issues/144).

There's now a tooltip when you mouse over the CopyToClipboard button. The regular tooltip text says "Copy to Clipboard" and the tooltip text changes to "Copied" once the button is clicked.

Not copied:
<img width="1349" alt="screen shot 2018-06-27 at 5 46 42 pm" src="https://user-images.githubusercontent.com/7014965/42001538-417e5d6a-7a32-11e8-9492-ea135910973c.png">

Copied:
<img width="1346" alt="screen shot 2018-06-27 at 5 46 47 pm" src="https://user-images.githubusercontent.com/7014965/42001545-46ff1734-7a32-11e8-9a56-c0133a03ed4a.png">


@openshift/team-ux-review, could you please review this?