### PR TITLE
Add Prometheus proxy for OpenShift

### DIFF
--- a/frontend/public/components/graphs/index.jsx
+++ b/frontend/public/components/graphs/index.jsx
@@ -5,7 +5,11 @@ import { k8sBasePath } from '../../module/k8s';
 
 export { Status, errorStatus } from './status';
 
-export const prometheusBasePath = `${k8sBasePath}/api/v1/proxy/namespaces/tectonic-system/services/prometheus:9090`;
+// Use the prometheus proxy if set up for OpenShift. Otherwise, fall back to the k8s API proxy for Tectonic installs.
+export const prometheusBasePath = window.SERVER_FLAGS.prometheusBaseURL
+  ? window.SERVER_FLAGS.prometheusBaseURL.replace(/\/$/, '')
+  : `${k8sBasePath}/api/v1/proxy/namespaces/tectonic-system/services/prometheus:9090`;
+
 export const Bar = props => <AsyncComponent loader={() => import('./graph-loader').then(c => c.Bar)} {...props} />;
 export const Gauge = props => <AsyncComponent loader={() => import('./graph-loader').then(c => c.Gauge)} {...props} />;
 export const Line = props => <AsyncComponent loader={() => import('./graph-loader').then(c => c.Line)} {...props} />;


### PR DESCRIPTION
This adds a proxy to the prometheus-k8s service in the openshift-monitoring namespace. It passes the user's API token through and is secure end-to-end. (Currently only cluster-reader / cluster-admin can get metrics.)

<img width="1207" alt="screen shot 2018-06-27 at 6 20 34 pm" src="https://user-images.githubusercontent.com/1167259/42003019-6c82134e-7a37-11e8-9658-8ff51cfc4411.png">

<img width="1272" alt="screen shot 2018-06-27 at 9 00 22 pm" src="https://user-images.githubusercontent.com/1167259/42007302-42106ec4-7a4d-11e8-8c75-4893e0cf7852.png">

<img width="1272" alt="screen shot 2018-06-27 at 9 00 33 pm" src="https://user-images.githubusercontent.com/1167259/42007308-4922a452-7a4d-11e8-9975-1eae71d48a76.png">

TODO:

- [x] Continue to use the k8s proxy for Tectonic metrics

@kyoto @brancz @robszumski @jwforres 