### PR TITLE
Make user menu responsive

### DIFF
--- a/frontend/public/components/_nav.scss
+++ b/frontend/public/components/_nav.scss
@@ -118,6 +118,9 @@ $active-border: 3px;
   &.fa-folder-open-o {
     font-size: 16px;
   }
+  &.fa-user {
+    font-size: 17px;
+  }
 }
 
 .navigation-container__section__title__icon--active {

--- a/frontend/public/components/masthead.scss
+++ b/frontend/public/components/masthead.scss
@@ -37,15 +37,30 @@
     height: 100%;
   }
   &__user {
-    margin-left: auto;
-    margin-right: 15px;
+    display: none;
     @media (min-width: $grid-float-breakpoint) {
+      display: block;
+      margin-left: auto;
       margin-right: 20px;
+    }
+    .dropdown__not-btn,
+    .dropdown__not-btn__title {
+      align-items: baseline;
+      display: flex;
     }
   }
   &__user-icon {
     font-size: 14px;
     margin-right: 5px;
+  }
+  &__username {
+    // truncate very long usernames
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    @media(min-width: $screen-md-min) {
+      max-width: 300px;
+    }
   }
 }
 

--- a/frontend/public/components/masthead.tsx
+++ b/frontend/public/components/masthead.tsx
@@ -19,9 +19,10 @@ const logout = e => {
 };
 
 const UserMenu: React.StatelessComponent<UserMenuProps> = ({username, actions}) => {
-  const title = <span>
-    <i className="fa fa-user co-masthead__user-icon" aria-hidden="true"></i>{username}
-  </span>;
+  const title = <React.Fragment>
+    <i className="fa fa-user co-masthead__user-icon" aria-hidden="true"></i>
+    <span className="co-masthead__username">{username}</span>
+  </React.Fragment>;
   return <ActionsMenu actions={actions}
     title={title}
     noButton={true} />;
@@ -127,7 +128,7 @@ export const Masthead = () => <header role="banner" className="co-masthead">
   <div className="co-masthead__console-picker">
     { (window as any).SERVER_FLAGS.openshiftConsoleURL && <ContextSwitcher /> }
   </div>
-  <div className="co-masthead__user navbar-right">
+  <div className="co-masthead__user">
     <UserMenuWrapper />
   </div>
 </header>;


### PR DESCRIPTION
* Set max-width on username so very long usernames don't take up too much space
* Relocate the user menu from the masthead to the sidebar at mobile

![localhost_9000_k8s_ns_myproject_deployments ipad](https://user-images.githubusercontent.com/895728/42042563-77845212-7ac2-11e8-8d93-a76730a9c472.png)
![localhost_9000_k8s_ns_myproject_deployments iphone 6_7_8 plus](https://user-images.githubusercontent.com/895728/42042565-77a143cc-7ac2-11e8-8c78-5bd1891c52d9.png)
