### PR TITLE
Fixed redirection to list page when deleting resource from details page

### DIFF
--- a/frontend/public/components/modals/delete-modal.jsx
+++ b/frontend/public/components/modals/delete-modal.jsx
@@ -33,9 +33,11 @@ class DeleteModal extends PromiseComponent {
     this.handlePromise( k8sKill(kind, resource, {}, json)).then(() => {
       this.props.close();
       // If we are currently on the deleted resource's page, redirect to the resource list page
-      const re = new RegExp(`/${resource.metadata.name}/.*$`);
+      const re = new RegExp(`/${resource.metadata.name}.*$`);
       if (re.test(window.location.pathname)) {
-        history.push(formatNamespacedRouteForResource(kind.path));
+        history.push( resource.metadata.namespace
+          ? formatNamespacedRouteForResource(kind.path)
+          : `/k8s/cluster/${kind.path}` );
       }
     });
   }


### PR DESCRIPTION
Also, handles non-namespaced resources such as:
```
http://0.0.0.0:9001/k8s/cluster/nodes
http://0.0.0.0:9001/k8s/cluster/persistentvolumes
http://0.0.0.0:9001/k8s/cluster/storageclasses
http://0.0.0.0:9001/k8s/cluster/customresourcedefinitions
```
JIRA: https://jira.coreos.com/browse/CONSOLE-584

**Before:**
![image](https://user-images.githubusercontent.com/12733153/42175946-40d326a4-7df5-11e8-944c-0650bf22c605.png)
![image](https://user-images.githubusercontent.com/12733153/42175949-45e7aa98-7df5-11e8-80d2-6c4579cc18df.png)

**After:**
![image](https://user-images.githubusercontent.com/12733153/42175813-cdbe5346-7df4-11e8-994a-32d5487bd84d.png)
![image](https://user-images.githubusercontent.com/12733153/42175821-d5c29f0c-7df4-11e8-9d97-404a958c990d.png)
