### PR TITLE
Fix Expandable Rows Styling

### DIFF
--- a/frontend/public/components/_list.scss
+++ b/frontend/public/components/_list.scss
@@ -28,7 +28,8 @@
 
 .co-resource-list__item {
   align-items: center;
-  display:flex;
+  display: flex;
+  flex-wrap: wrap;
   height: 100%;
   transition: all 0.25s;
 }

--- a/frontend/public/components/graphs/index.jsx
+++ b/frontend/public/components/graphs/index.jsx
@@ -42,6 +42,7 @@ const canAccessPrometheus = (openshiftFlag, prometheusFlag, canListNS) => {
 };
 
 // HOC that will hide WrappedComponent when Prometheus isn't configured or the user doesn't have permission to query Prometheus.
+/** @type {(WrappedComponent: React.SFC<P>) => React.ComponentType<P & {isOpenShift: boolean}>} */
 export const requirePrometheus = WrappedComponent => connectToFlags(FLAGS.OPENSHIFT, FLAGS.PROMETHEUS, FLAGS.CAN_LIST_NS)(props => {
   const { flags } = props;
   const openshiftFlag = flags[FLAGS.OPENSHIFT];

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -5,8 +5,9 @@ import { ResourceEventStream } from './events';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { configureUnschedulableModal } from './modals';
 import { PodsPage } from './pod';
-import { Cog, navFactory, kindObj, LabelList, ResourceCog, Heading, ResourceLink, Timestamp, units, cloudProviderNames, cloudProviderID, pluralize, containerLinuxUpdateOperator } from './utils';
+import { Cog, navFactory, LabelList, ResourceCog, Heading, ResourceLink, Timestamp, units, cloudProviderNames, cloudProviderID, pluralize, containerLinuxUpdateOperator } from './utils';
 import { Line, requirePrometheus } from './graphs';
+import { NodeModel } from '../models';
 
 const MarkAsUnschedulable = (kind, obj) => ({
   label: 'Mark as Unschedulable...',
@@ -80,7 +81,7 @@ const NodeCLStatusRow = ({node}) => {
 const NodeRow = ({obj: node, expand}) => {
   const isOperatorInstalled = containerLinuxUpdateOperator.isOperatorInstalled(node);
 
-  return <ResourceRow obj={node} expand={expand}>
+  return <ResourceRow obj={node}>
     <div className="col-xs-4 co-break-word">
       <NodeCog node={node} />
       <ResourceLink kind="Node" name={node.metadata.name} title={node.metadata.uid} />
@@ -128,7 +129,7 @@ const dropdownFilters = [{
 export const NodesPage = props => <ListPage {...props} ListComponent={NodesList} dropdownFilters={dropdownFilters} canExpand={true} />;
 
 const NodeGraphs = requirePrometheus(({node}) => {
-  const nodeIp = _.find(node.status.addresses, {type: 'InternalIP'});
+  const nodeIp = _.find<{type: string, address: string}>(node.status.addresses, {type: 'InternalIP'});
   const ipQuery = nodeIp && `{instance=~'.*${nodeIp.address}.*'}`;
   const memoryLimit = units.dehumanize(node.status.allocatable.memory, 'binaryBytesWithoutB').value;
   const integerLimit = input => parseInt(input, 10);
@@ -176,7 +177,7 @@ const Details = ({obj: node}) => {
             <dt>Node Labels</dt>
             <dd><LabelList kind="Node" labels={node.metadata.labels} /></dd>
             <dt>Annotations</dt>
-            <dd><a className="co-m-modal-link" onClick={Cog.factory.ModifyAnnotations(kindObj('node'), node).callback}>{pluralize(_.size(node.metadata.annotations), 'Annotation')}</a></dd>
+            <dd><a className="co-m-modal-link" onClick={Cog.factory.ModifyAnnotations(NodeModel, node).callback}>{pluralize(_.size(node.metadata.annotations), 'Annotation')}</a></dd>
             <dt>Provider ID</dt>
             <dd>{cloudProviderNames([cloudProviderID(node)])}</dd>
             {_.has(node, 'spec.unschedulable') && <dt>Unschedulable</dt>}

--- a/frontend/public/components/utils/timestamp.jsx
+++ b/frontend/public/components/utils/timestamp.jsx
@@ -25,7 +25,7 @@ const updateTimestamps = () => {
   }
 };
 
-/** @augments {React.Component<{timestamp: string}>} */
+/** @augments {React.Component<{timestamp: string, isUnix?: boolean}>} */
 export class Timestamp extends SafetyFirst {
   constructor (props) {
     super(props);


### PR DESCRIPTION
### Description

Adding virtual scrolling broke lists which had expandable rows (`Nodes`, etc). Made some other fixes as well for converting `list.jsx` to TypeScript.

**Before:**
![screenshot_20180702_133630](https://user-images.githubusercontent.com/11700385/42178060-f73bac2a-7dfc-11e8-8aac-9d26be02fb0f.png)

**After:**
![screenshot_20180702_133704](https://user-images.githubusercontent.com/11700385/42178080-04600dec-7dfd-11e8-87da-8639b19e57a2.png)

Fixes https://jira.coreos.com/browse/CONSOLE-581