### PR TITLE
Add events tab

### DIFF
--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -12,6 +12,7 @@ import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { fromNow } from './utils/datetime';
 import { EnvironmentPage } from './environment';
 import { BuildLogs } from './build-logs';
+import { ResourceEventStream } from './events';
 
 const BuildsReference: K8sResourceKindReference = 'Build';
 
@@ -107,7 +108,14 @@ export const BuildEnvironmentComponent = (props) => {
   </div>;
 };
 
-const pages = [navFactory.details(BuildsDetails), navFactory.editYaml(), navFactory.envEditor(BuildEnvironmentComponent), navFactory.logs(BuildLogs)];
+const pages = [
+  navFactory.details(BuildsDetails),
+  navFactory.editYaml(),
+  navFactory.envEditor(BuildEnvironmentComponent),
+  navFactory.logs(BuildLogs),
+  navFactory.events(ResourceEventStream)
+];
+
 export const BuildsDetailsPage: React.SFC<BuildsDetailsPageProps> = props =>
   <DetailsPage
     {...props}

--- a/frontend/public/components/cron-job.jsx
+++ b/frontend/public/components/cron-job.jsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { Cog, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary, Timestamp } from './utils';
 import { registerTemplate } from '../yaml-templates';
+import { ResourceEventStream } from './events';
 
 registerTemplate('batch/v1beta1.CronJob', `apiVersion: batch/v1beta1
 kind: CronJob
@@ -98,5 +99,5 @@ export const CronJobsPage = props => <ListPage {...props} ListComponent={CronJob
 export const CronJobsDetailsPage = props => <DetailsPage
   {...props}
   menuActions={menuActions}
-  pages={[navFactory.details(Details), navFactory.editYaml()]}
+  pages={[navFactory.details(Details), navFactory.editYaml(), navFactory.events(ResourceEventStream)]}
 />;

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -10,6 +10,7 @@ import { Cog, DeploymentPodCounts, navFactory, LoadingInline, pluralize, Resourc
 import { registerTemplate } from '../yaml-templates';
 import { Conditions } from './conditions';
 import { EnvironmentPage } from './environment';
+import { ResourceEventStream } from './events';
 
 registerTemplate('apps.openshift.io/v1.DeploymentConfig', `apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
@@ -116,7 +117,14 @@ const environmentComponent = (props) => <EnvironmentPage
   readOnly={false}
 />;
 
-const pages = [navFactory.details(DeploymentConfigsDetails), navFactory.editYaml(), navFactory.pods(), navFactory.envEditor(environmentComponent)];
+const pages = [
+  navFactory.details(DeploymentConfigsDetails),
+  navFactory.editYaml(),
+  navFactory.pods(),
+  navFactory.envEditor(environmentComponent),
+  navFactory.events(ResourceEventStream)
+];
+
 export const DeploymentConfigsDetailsPage: React.SFC<DeploymentConfigsDetailsPageProps> = props => {
   return <DetailsPage {...props} kind={DeploymentConfigsReference} menuActions={menuActions} pages={pages} />;
 };

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -7,6 +7,7 @@ import { Cog, DeploymentPodCounts, navFactory, LoadingInline, pluralize, Resourc
 import { registerTemplate } from '../yaml-templates';
 import { Conditions } from './conditions';
 import { EnvironmentPage } from './environment';
+import { ResourceEventStream } from './events';
 
 registerTemplate('apps/v1.Deployment', `apiVersion: apps/v1
 kind: Deployment
@@ -94,11 +95,11 @@ const environmentComponent = (props) => <EnvironmentPage
   readOnly={false}
 />;
 
-const {details, editYaml, pods, envEditor} = navFactory;
+const {details, editYaml, pods, envEditor, events} = navFactory;
 const DeploymentsDetailsPage = props => <DetailsPage
   {...props}
   menuActions={menuActions}
-  pages={[details(DeploymentDetails), editYaml(), pods(), envEditor(environmentComponent)]}
+  pages={[details(DeploymentDetails), editYaml(), pods(), envEditor(environmentComponent), events(ResourceEventStream)]}
 />;
 
 const Row = props => <WorkloadListRow {...props} kind="Deployment" actions={menuActions} />;

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -420,4 +420,4 @@ EventStream.propTypes = {
 };
 
 
-export const ResourceEventStream = ({obj: {metadata: {name, namespace}}}) => <EventStream filter={{name}} namespace={namespace} />;
+export const ResourceEventStream = ({obj: {kind, metadata: {name, namespace}}}) => <EventStream filter={{name, kind}} namespace={namespace} />;

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -7,6 +7,7 @@ import { Conditions } from './conditions';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { Cog, LabelList, navFactory, ResourceCog, ResourceLink, ResourceSummary, Timestamp } from './utils';
 import { registerTemplate } from '../yaml-templates';
+import { ResourceEventStream } from './events';
 
 // Pushes to the HPA created by the HPA YAML template.
 registerTemplate('autoscaling/v2beta1.HorizontalPodAutoscaler', `apiVersion: autoscaling/v2beta1
@@ -182,7 +183,7 @@ export const HorizontalPodAutoscalersDetails: React.SFC<HorizontalPodAutoscalers
   </div>
 </React.Fragment>;
 
-const pages = [navFactory.details(HorizontalPodAutoscalersDetails), navFactory.editYaml()];
+const pages = [navFactory.details(HorizontalPodAutoscalersDetails), navFactory.editYaml(), navFactory.events(ResourceEventStream)];
 export const HorizontalPodAutoscalersDetailsPage: React.SFC<HorizontalPodAutoscalersDetailsPageProps> = props =>
   <DetailsPage
     {...props}

--- a/frontend/public/components/job.jsx
+++ b/frontend/public/components/job.jsx
@@ -6,6 +6,7 @@ import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from '.
 import { configureJobParallelismModal } from './modals';
 import { Cog, Heading, LabelList, ResourceCog, ResourceLink, ResourceSummary, Timestamp, navFactory } from './utils';
 import { registerTemplate } from '../yaml-templates';
+import { ResourceEventStream } from './events';
 
 registerTemplate('batch/v1.Job', `apiVersion: batch/v1
 kind: Job
@@ -99,11 +100,11 @@ const Details = ({obj: job}) => <div className="co-m-pane__body">
   </div>
 </div>;
 
-const {details, pods, editYaml} = navFactory;
+const {details, pods, editYaml, events} = navFactory;
 const JobsDetailsPage = props => <DetailsPage
   {...props}
   menuActions={menuActions}
-  pages={[details(Details), editYaml(), pods()]}
+  pages={[details(Details), editYaml(), pods(), events(ResourceEventStream)]}
 />;
 const JobsList = props => <List {...props} Header={JobHeader} Row={JobRow} />;
 const JobsPage = props => <ListPage ListComponent={JobsList} canCreate={true} {...props} />;

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -5,6 +5,7 @@ import { FLAGS, connectToFlags } from '../features';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { Cog, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary, Selector } from './utils';
 import { registerTemplate } from '../yaml-templates';
+import { ResourceEventStream } from './events';
 
 registerTemplate('v1.PersistentVolumeClaim', `kind: PersistentVolumeClaim
 apiVersion: v1
@@ -123,5 +124,5 @@ export const PersistentVolumeClaimsPage = props => <ListPage {...props} ListComp
 export const PersistentVolumeClaimsDetailsPage = props => <DetailsPage
   {...props}
   menuActions={menuActions}
-  pages={[navFactory.details(Details), navFactory.editYaml()]}
+  pages={[navFactory.details(Details), navFactory.editYaml(), navFactory.events(ResourceEventStream)]}
 />;

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -5,6 +5,7 @@ import { Cog, navFactory, Heading, ResourceSummary, ResourcePodCount } from './u
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { registerTemplate } from '../yaml-templates';
 import { EnvironmentPage } from './environment';
+import { ResourceEventStream } from './events';
 
 registerTemplate('apps/v1.ReplicaSet', `apiVersion: apps/v1
 kind: ReplicaSet
@@ -52,7 +53,7 @@ const environmentComponent = (props) => <EnvironmentPage
   readOnly={false}
 />;
 
-const {details, editYaml, pods, envEditor} = navFactory;
+const {details, editYaml, pods, envEditor, events} = navFactory;
 const ReplicaSetsDetailsPage = props => <DetailsPage
   {...props}
   breadcrumbsFor={obj => breadcrumbsForOwnerRefs(obj).concat({
@@ -60,7 +61,7 @@ const ReplicaSetsDetailsPage = props => <DetailsPage
     path: props.match.url,
   })}
   menuActions={replicaSetMenuActions}
-  pages={[details(Details), editYaml(), pods(), envEditor(environmentComponent)]}
+  pages={[details(Details), editYaml(), pods(), envEditor(environmentComponent), events(ResourceEventStream)]}
 />;
 
 const Row = props => <WorkloadListRow {...props} kind="ReplicaSet" actions={replicaSetMenuActions} />;

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -4,6 +4,7 @@ import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { Cog, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
 import { EnvironmentPage } from './environment';
+import { ResourceEventStream } from './events';
 
 registerTemplate('apps/v1.StatefulSet', `apiVersion: apps/v1
 kind: StatefulSet
@@ -78,8 +79,16 @@ const environmentComponent = (props) => <EnvironmentPage
 export const StatefulSetsList = props => <List {...props} Header={Header} Row={Row} />;
 export const StatefulSetsPage = props => <ListPage {...props} ListComponent={StatefulSetsList} kind={kind} canCreate={true} />;
 
+const pages = [
+  navFactory.details(Details),
+  navFactory.editYaml(),
+  navFactory.pods(),
+  navFactory.envEditor(environmentComponent),
+  navFactory.events(ResourceEventStream)
+];
+
 export const StatefulSetsDetailsPage = props => <DetailsPage
   {...props}
   menuActions={menuActions}
-  pages={[navFactory.details(Details), navFactory.editYaml(), navFactory.pods(), navFactory.envEditor(environmentComponent)]}
+  pages={pages}
 />;


### PR DESCRIPTION
Fixes [CONSOLE-522](https://jira.coreos.com/browse/CONSOLE-522).

Added events tab to StatefulSet, Deployment, ReplicaSet, PVC, HPA, Jobs, and CronJobs details, as well as Builds and Deployment Configs. (Node already had one.)

Also added an extra resource type filter to ResourceEventStream so that a Pod named "example" will only show its own events. Before this, it would show events for all resource types named example.

Some screenshots:

![screen shot 2018-07-03 at 11 51 06 am](https://user-images.githubusercontent.com/7014965/42230622-720c4f58-7eb7-11e8-9170-8957ff57a8bd.png)

![screen shot 2018-07-03 at 11 52 04 am](https://user-images.githubusercontent.com/7014965/42230671-89ad80c8-7eb7-11e8-9afb-1a101c6f6257.png)

![screen shot 2018-07-03 at 11 53 24 am](https://user-images.githubusercontent.com/7014965/42230738-bc6d270c-7eb7-11e8-9236-33d31d3d0710.png)
