### PR TITLE
Fix Cog Menu Cutoff 

### DIFF
--- a/frontend/public/components/_list.scss
+++ b/frontend/public/components/_list.scss
@@ -50,3 +50,7 @@
   right: 0;
   bottom: 0;
 }
+
+.co-m-cog__dropdown {
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
### Description

Adds a bit of margin to help the last cog menu in a list push the viewport down.

