### PR TITLE
YAML Editor Snippets

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -9,8 +9,9 @@ import 'brace/ext/searchbox';
 import 'brace/mode/yaml';
 import 'brace/theme/clouds';
 import 'brace/ext/language_tools';
+import 'brace/snippets/yaml';
 
-import { k8sCreate, k8sUpdate, referenceFor, modelFor, getCompletions, apiVersionForModel } from '../module/k8s';
+import { k8sCreate, k8sUpdate, referenceFor, modelFor, getCompletions, apiVersionForModel, snippets } from '../module/k8s';
 import { history, Loading, resourceObjPath } from './utils';
 import { SafetyFirst } from './safety-first';
 import { coFetchJSON } from '../co-fetch';
@@ -18,9 +19,11 @@ import { coFetchJSON } from '../co-fetch';
 import { ResourceSidebar } from './sidebars/resource-sidebar';
 import { TEMPLATES } from '../yaml-templates';
 
-let id = 0;
-
+const { snippetManager } = ace.acequire('ace/snippets');
+snippetManager.register([...snippets.values()], 'yaml');
 ace.acequire('ace/ext/language_tools').addCompleter({getCompletions});
+
+let id = 0;
 
 const generateObjToLoad = (kind, templateName, namespace = 'default') => {
   const kindObj = modelFor(kind) || {};
@@ -167,7 +170,7 @@ export const EditYAML = connect(stateToProps)(
       this.ace.setOption('scrollPastEnd', 0.1);
       this.ace.setOption('tabSize', 2);
       this.ace.setOption('showPrintMargin', false);
-      this.ace.setOptions({enableBasicAutocompletion: true, enableLiveAutocompletion: !window.navigator.webdriver});
+      this.ace.setOptions({enableBasicAutocompletion: true, enableLiveAutocompletion: !window.navigator.webdriver, enableSnippets: true});
 
       // Allow undo after saving but not after first loading the document
       if (!this.state.initialized) {

--- a/frontend/public/module/k8s/autocomplete.ts
+++ b/frontend/public/module/k8s/autocomplete.ts
@@ -9,6 +9,86 @@ import { K8sKind, K8sResourceKind } from '../../module/k8s';
 import { k8sListPartialMetadata } from '../../module/k8s/resource';
 import { getActiveNamespace } from '../../ui/ui-actions';
 
+export type AceSnippet = {
+  content: string;
+  name?: string;
+  guard?: string;
+  trigger?: string;
+  endTrigger?: string;
+  endGuard?: string;
+  tabTrigger?: string;
+};
+
+export const snippets = ImmutableMap<string, string>()
+  .set('metadata', `
+    metadata:
+      name: \${1}
+      namespace: \${2}
+      labels: 
+        \${3}
+      annotations:
+        \${4}
+  `)
+  .set('selector', `
+    selector:
+      matchLabels:
+        \${1}
+  `)
+  .set('containers', `
+    containers:
+      - name: \${1}
+        image: \${2}
+        ports:
+          - containerPort: \${3}
+        volumeMounts:
+          - name: \${4}
+            mountPath: \${5}
+        command:
+          - \${6}
+  `)
+  .set('volumeClaimTemplates', `
+    volumeClaimTemplates:
+      - metadata:
+          name: \${1}
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          storageClassName: \${2}
+          resources:
+            requests:
+              storage: 1Gi
+  `)
+  .set('rules', `
+    rules:
+      - http:
+          paths:
+            - path: /\${1}
+              backend:
+                serviceName: \${2}
+                servicePort: 80
+  `)
+  .set('ports', `
+    ports:
+      - protocol: TCP
+        port: 80
+        targetPort: \${1}
+  `)
+  .set('parameters', `
+    parameters:
+      - name: \${1}
+        value: \${2}
+        description: \${3}
+  `)
+  .set('triggers', `
+    triggers:
+      - imageChange:
+          from:
+            kind: ImageStreamTag
+            name: \${1}
+        type: ImageChange
+  `)
+  .map((content, name) => ({name, content: content.split('\n').slice(1, content.split('\n').length - 1).map(s => s.substring(4)).join('\n')} as AceSnippet));
+
 /**
  * Defines a bunch of possibilities for property value completion, defined in the OpenAPI/Swagger spec.
  */


### PR DESCRIPTION
### Description

Adds snippet support to the YAML editor, along with a few commonly used k8s snippets.

### Screenshots

**Metadata and containers snippets:**
![yaml-snippets](https://user-images.githubusercontent.com/11700385/42294923-4a399a1a-7fb3-11e8-86df-050c68b0d796.gif)

Addresses https://jira.coreos.com/browse/CONSOLE-595