### PR TITLE
Create/Edit image secret

### DIFF
--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -11,11 +11,16 @@ export const WebHookSecretKey = 'WebHookSecretKey';
 
 // Edit in YAML if not editing:
 // - source secrets
+// - image secret, both formats:
+//     - kubernetes.io/dockerconfigjson
+//     - kubernetes.io/dockercfg
 // - webhook secret with one key.
 const editInYaml = obj => {
   switch (obj.type) {
     case SecretType.basicAuth:
     case SecretType.sshAuth:
+    case SecretType.dockercfg:
+    case SecretType.dockerconfigjson:
       return false;
     case SecretType.opaque:
       return !_.has(obj, ['data', WebHookSecretKey]) || _.size(obj.data) !== 1;
@@ -121,7 +126,7 @@ const filters = [{
 
 const SecretsPage = props => {
   const createItems = {
-    // image: 'Create Image Pull Secret',
+    image: 'Image Pull Secret',
     // generic: 'Create Key/Value Secret',
     source: 'Source Secret',
     webhook: 'Webhook Secret',

--- a/frontend/public/components/secrets/_create-secret.scss
+++ b/frontend/public/components/secrets/_create-secret.scss
@@ -1,0 +1,13 @@
+.co-create-secret-warning {
+  color: $color-orange-warning;
+  margin-bottom: 10px;
+}
+
+.co-create-image-secret__form {
+  margin-bottom: 25px;
+}
+
+.co-create-image-secret__form + .co-create-image-secret__form {
+  border-top: 1px solid #ccc;
+  padding-top: 10px;
+}

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -5,16 +5,18 @@ import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 
 import { k8sCreate, k8sUpdate, K8sResourceKind } from '../../module/k8s';
-import { ButtonBar, Firehose, history, kindObj, StatusBox } from '../utils';
+import { ButtonBar, Firehose, history, kindObj, StatusBox, LoadingBox } from '../utils';
 import { formatNamespacedRouteForResource } from '../../ui/ui-actions';
-import { WebHookSecretKey } from '../secret';
 import { AsyncComponent } from '../utils/async';
 
 enum SecretTypeAbstraction {
   generic = 'generic',
   source = 'source',
+  image = 'image',
   webhook = 'webhook',
 }
+
+const AUTHS_KEY = 'auths';
 
 export enum SecretType {
   basicAuth = 'kubernetes.io/basic-auth',
@@ -33,16 +35,33 @@ export type BasicAuthSubformState = {
 
 const secretFormExplanation = {
   [SecretTypeAbstraction.source]: 'Source secrets allow you to authenticate against the SCM server.',
+  [SecretTypeAbstraction.image]: 'Image secrets allow you to authenticate against a private image registry.',
   [SecretTypeAbstraction.webhook]: 'Webhook secrets allow you to authenticate a webhook trigger.',
 };
 
-const determineDefaultSecretType = (typeAbstraction: SecretTypeAbstraction) => {
-  return typeAbstraction === SecretTypeAbstraction.source ? SecretType.basicAuth : SecretType.opaque;
+const toDefaultSecretType = (typeAbstraction: SecretTypeAbstraction) => {
+  switch (typeAbstraction) {
+    case SecretTypeAbstraction.source:
+      return SecretType.basicAuth;
+    case SecretTypeAbstraction.image:
+      return SecretType.dockerconfigjson;
+    default:
+      return SecretType.opaque;
+  }
 };
 
 
-const determineSecretTypeAbstraction = (data) => {
-  return _.has(data, WebHookSecretKey) ? SecretTypeAbstraction.webhook : SecretTypeAbstraction.source;
+const toTypeAbstraction = (type: SecretType): SecretTypeAbstraction => {
+  switch (type) {
+    case (SecretType.basicAuth):
+    case (SecretType.sshAuth):
+      return SecretTypeAbstraction.source;
+    case (SecretType.dockerconfigjson):
+    case (SecretType.dockercfg):
+      return SecretTypeAbstraction.image;
+    default:
+      return SecretTypeAbstraction.webhook;
+  }
 };
 
 const generateSecret = () => {
@@ -51,12 +70,13 @@ const generateSecret = () => {
   return s4() + s4() + s4() + s4();
 };
 
+
 // withSecretForm returns SubForm which is a Higher Order Component for all the types of secret forms.
 const withSecretForm = (SubForm) => class SecretFormComponent extends React.Component<BaseEditSecretProps_, BaseEditSecretState_> {
-  constructor (props) {
+  constructor(props) {
     super(props);
     const existingSecret = _.pick(props.obj, ['metadata', 'type']);
-    const defaultSecretType = determineDefaultSecretType(this.props.secretTypeAbstraction);
+    const defaultSecretType = toDefaultSecretType(this.props.secretTypeAbstraction);
     const secret = _.defaultsDeep({}, props.fixed, existingSecret, {
       apiVersion: 'v1',
       data: {},
@@ -73,9 +93,12 @@ const withSecretForm = (SubForm) => class SecretFormComponent extends React.Comp
       inProgress: false,
       type: defaultSecretType,
       stringData: _.mapValues(_.get(props.obj, 'data'), window.atob),
+      disableForm: false,
     };
     this.onDataChanged = this.onDataChanged.bind(this);
     this.onNameChanged = this.onNameChanged.bind(this);
+    this.onError = this.onError.bind(this);
+    this.onFormDisable = this.onFormDisable.bind(this);
     this.save = this.save.bind(this);
   }
   onDataChanged (secretsData) {
@@ -84,16 +107,26 @@ const withSecretForm = (SubForm) => class SecretFormComponent extends React.Comp
       type: secretsData.type,
     });
   }
+  onError (err) {
+    this.setState({
+      error: err,
+      inProgress: false
+    });
+  }
   onNameChanged (event) {
     let secret = {...this.state.secret};
     secret.metadata.name = event.target.value;
     this.setState({secret});
   }
+  onFormDisable (disable) {
+    this.setState({
+      disableForm: disable,
+    });
+  }
   save (e) {
     e.preventDefault();
     const { kind, metadata } = this.state.secret;
     this.setState({ inProgress: true });
-
     const newSecret = _.assign({}, this.state.secret, {stringData: this.state.stringData}, {type: this.state.type});
     const ko = kindObj(kind);
     (this.props.isCreate
@@ -130,19 +163,322 @@ const withSecretForm = (SubForm) => class SecretFormComponent extends React.Comp
           </div>
         </fieldset>
         <SubForm
-          onChange={this.onDataChanged.bind(this)}
+          onChange={this.onDataChanged}
+          onError={this.onError}
+          onFormDisable={this.onFormDisable}
           stringData={this.state.stringData}
           secretType={this.state.secret.type}
           isCreate={this.props.isCreate}
         />
-        <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress} >
-          <button type="submit" className="btn btn-primary" id="save-changes">{this.props.saveButtonText || 'Create'}</button>
+        <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress}>
+          <button type="submit" disabled={this.state.disableForm} className="btn btn-primary" id="save-changes">{this.props.saveButtonText || 'Create'}</button>
           <Link to={formatNamespacedRouteForResource('secrets')} className="btn btn-default" id="cancel">Cancel</Link>
         </ButtonBar>
       </form>
     </div>;
   }
 };
+
+const getImageSecretKey = (secretType: SecretType): string => {
+  switch (secretType) {
+    case SecretType.dockercfg:
+      return '.dockercfg';
+    case SecretType.dockerconfigjson:
+      return '.dockerconfigjson';
+    default:
+      return secretType;
+  }
+};
+
+const getImageSecretType = (secretKey: string): SecretType => {
+  switch (secretKey) {
+    case '.dockercfg':
+      return SecretType.dockercfg;
+    case '.dockerconfigjson':
+      return SecretType.dockerconfigjson;
+    default:
+      return SecretType.opaque;
+  }
+};
+
+class ImageSecretForm extends React.Component<ImageSecretFormProps, ImageSecretFormState> {
+  constructor(props) {
+    super(props);
+    const data = this.props.isCreate ? {'.dockerconfigjson': '{}'} : this.props.stringData;
+    let parsedData;
+    try {
+      parsedData = _.mapValues(data, JSON.parse);
+    } catch (err) {
+      this.props.onError(`Error parsing secret's data: ${err.message}`);
+      parsedData = {'.dockerconfigjson': {}};
+    }
+    this.state = {
+      type: this.props.secretType,
+      dataKey: getImageSecretKey(this.props.secretType),
+      stringData: parsedData,
+      uploadConfig: 'false',
+    };
+    this.onDataChanged = this.onDataChanged.bind(this);
+    this.changeFormType = this.changeFormType.bind(this);
+    this.onFormDisable = this.onFormDisable.bind(this);
+  }
+  onDataChanged (secretData) {
+    this.setState({
+      stringData: {[this.state.dataKey]: secretData}
+    }, () => this.props.onChange({
+      stringData: _.mapValues(this.state.stringData, JSON.stringify),
+      type: getImageSecretType(this.state.dataKey),
+    }));
+  }
+  changeFormType(event) {
+    this.setState({
+      uploadConfig: event.target.value,
+    });
+  }
+  onFormDisable(disable) {
+    this.props.onFormDisable(disable);
+  }
+  render () {
+    const data = _.get(this.state.stringData, this.state.dataKey);
+    return <React.Fragment>
+      {this.props.isCreate && <div className="form-group">
+        <label className="control-label" htmlFor="secret-type">Authentication Type</label>
+        <div>
+          <select onChange={this.changeFormType} value={this.state.uploadConfig} className="form-control" id="secret-type">
+            <option value="false">Image Registry Credentials</option>
+            <option value="true">Upload Configuration File</option>
+          </select>
+        </div>
+      </div>
+      }
+      { this.state.uploadConfig === 'false'
+        ? <CreateConfigSubform onChange={this.onDataChanged} stringData={data} />
+        : <UploadConfigSubform onChange={this.onDataChanged} stringData={data} onDisable={this.onFormDisable} />
+      }
+    </React.Fragment>;
+  }
+}
+
+export type ConfigEntryFormState = {
+  address: string,
+  username: string,
+  password: string,
+  email: string,
+  auth: string,
+};
+
+export type ConfigEntryFormProps = {
+  id: number,
+  entry: Object,
+  onChange: Function,
+};
+
+class ConfigEntryForm extends React.Component<ConfigEntryFormProps, ConfigEntryFormState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      address: _.get(this.props.entry, 'address'),
+      username: _.get(this.props.entry, 'username'),
+      password: _.get(this.props.entry, 'password'),
+      email: _.get(this.props.entry, 'email'),
+      auth: _.get(this.props.entry, 'auth'),
+    };
+    this.changeData = this.changeData.bind(this);
+  }
+  // If 'username' or 'password' fields are updated, 'auth' field has to be updated as well, else stays the same.
+  updateAuth(updatedFieldName) {
+    return _.includes(['username', 'password'], updatedFieldName)
+      ? window.btoa(`${this.state.username}:${this.state.password}`)
+      : this.state.auth;
+  }
+  changeData(event) {
+    this.setState({
+      auth: this.updateAuth(event.target.name),
+      [event.target.name]: event.target.value
+    } as ConfigEntryFormState, () => this.props.onChange(this.state, this.props.id));
+  }
+  render() {
+    return <div className="co-create-image-secret__form">
+      <div className="form-group">
+        <label className="control-label" htmlFor={`${this.props.id}-address`}>Registry Server Address</label>
+        <div>
+          <input className="form-control"
+            id={`${this.props.id}-address`}
+            type="text"
+            name="address"
+            onChange={this.changeData}
+            value={this.state.address}
+            required />
+        </div>
+      </div>
+      <div className="form-group">
+        <label className="control-label" htmlFor={`${this.props.id}-username`}>Username</label>
+        <div>
+          <input className="form-control"
+            id={`${this.props.id}-username`}
+            type="text"
+            name="username"
+            onChange={this.changeData}
+            value={this.state.username}
+            required />
+        </div>
+      </div>
+      <div className="form-group">
+        <label className="control-label" htmlFor={`${this.props.id}-password`}>Password</label>
+        <div>
+          <input className="form-control"
+            id={`${this.props.id}-password`}
+            type="password"
+            name="password"
+            onChange={this.changeData}
+            value={this.state.password}
+            required />
+        </div>
+      </div>
+      <div className="form-group">
+        <label className="control-label" htmlFor={`${this.props.id}-email`}>Email</label>
+        <div>
+          <input className="form-control"
+            id={`${this.props.id}-email`}
+            type="text"
+            name="email"
+            onChange={this.changeData}
+            value={this.state.email}
+            required />
+        </div>
+      </div>
+    </div>;
+  }
+}
+
+export type CreateConfigSubformState = {
+  isDockerconfigjson: boolean,
+  hasDuplicate: boolean,
+  secretEntriesArray: {
+    address: string,
+    username: string,
+    password: string,
+    email: string,
+    auth: string
+  }[],
+};
+
+class CreateConfigSubform extends React.Component<CreateConfigSubformProps, CreateConfigSubformState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      // If user creates a new image secret by filling out the form a 'kubernetes.io/dockerconfigjson' secret will be created.
+      isDockerconfigjson: _.isEmpty(this.props.stringData) || Object.keys(this.props.stringData)[0] === AUTHS_KEY,
+      secretEntriesArray: this.imageSecretObjectToArray(this.props.stringData[AUTHS_KEY] || this.props.stringData),
+      hasDuplicate: false,
+    };
+    this.onDataChanged = this.onDataChanged.bind(this);
+  }
+  newImageSecretEntry() {
+    return {
+      address: '',
+      username: '',
+      password: '',
+      email: '',
+      auth: '',
+    };
+  }
+  imageSecretObjectToArray(imageSecretObject) {
+    const imageSecretArray = [];
+    if (_.isEmpty(imageSecretObject)) {
+      return _.concat(imageSecretArray, this.newImageSecretEntry());
+    }
+    _.each(imageSecretObject, (v, k) => {
+      // Decode and parse 'auth' in case 'username' and 'password' are not part of the secret.
+      const decodedAuth = window.atob(_.get(v, 'auth', ''));
+      const parsedAuth = _.isEmpty(decodedAuth) ? _.fill(Array(2), '') : _.split(decodedAuth, ':');
+      imageSecretArray.push({
+        address: k,
+        username: _.get(v, 'username', parsedAuth[0]),
+        password: _.get(v, 'password', parsedAuth[1]),
+        email: _.get(v, 'email', ''),
+        auth: _.get(v, 'auth', ''),
+      });
+    });
+    return imageSecretArray;
+  }
+  imageSecretArrayToObject(imageSecretArray) {
+    const imageSecretsObject = {};
+    _.each(imageSecretArray, (entry) => {
+      const entryCredentials = {
+        username: entry.username,
+        password: entry.password,
+        auth: entry.auth,
+        email: entry.email
+      };
+      imageSecretsObject[entry.address] = entryCredentials;
+    });
+    return imageSecretsObject;
+  }
+  // Image secrets entry address can't be duplicate in the secret, else the first one will be deleted.
+  checkEntryAddressForDuplicates(updatedData, updatedIndex) {
+    return this.state.secretEntriesArray.some((entry, i) => i !== updatedIndex && _.isEqual(entry.address, updatedData.address));
+  }
+  onDataChanged (updatedEntryData, entryID) {
+    const secretEntriesArray = this.state.secretEntriesArray;
+    secretEntriesArray.splice(entryID, 1, updatedEntryData);
+    this.setState({
+      secretEntriesArray: secretEntriesArray,
+      hasDuplicate: this.checkEntryAddressForDuplicates(updatedEntryData, entryID)
+    }, () => {
+      const imageSecretObject = this.imageSecretArrayToObject(this.state.secretEntriesArray);
+      this.props.onChange(this.state.isDockerconfigjson ? {[AUTHS_KEY]: imageSecretObject} : imageSecretObject);
+    });
+  }
+  render() {
+    const secretEntriesList = _.map(this.state.secretEntriesArray, (entry, index) => <ConfigEntryForm key={index} id={index} entry={entry} onChange={this.onDataChanged} />);
+    return (
+      <React.Fragment>
+        {secretEntriesList}
+        { this.state.hasDuplicate && <div className="co-create-secret-warning">Updated <b>Registry Server Address</b> is duplicate. Remove it, or it will be removed upon saving.</div> }
+      </React.Fragment>
+    );
+  }
+}
+
+class UploadConfigSubform extends React.Component<UploadConfigSubformProps, UploadConfigSubformState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      configFile: _.isEmpty(this.props.stringData) ? '' : JSON.stringify(this.props.stringData),
+      parseError: false,
+    };
+    this.changeData = this.changeData.bind(this);
+    this.onFileChange = this.onFileChange.bind(this);
+  }
+  changeData(event) {
+    this.updateState(_.attempt(JSON.parse, event.target.value), event.target.value);
+  }
+  onFileChange(fileData) {
+    this.updateState(_.attempt(JSON.parse, fileData), fileData);
+  }
+  updateState(parsedData, stringData) {
+    this.setState({
+      configFile: stringData,
+      parseError: _.isError(parsedData),
+    }, () => {
+      this.props.onChange(parsedData);
+      this.props.onDisable(this.state.parseError);
+    });
+  }
+  render() {
+    return <React.Fragment>
+      <DroppableFileInput
+        onChange={this.onFileChange}
+        inputFileData={this.state.configFile}
+        id="docker-config"
+        label="Configuration File"
+        inputFieldHelpText="Upload a .dockercfg or .docker/config.json file."
+        textareaFieldHelpText="File with credentials and other configuration for connecting to a secured image registry." />
+      { this.state.parseError && <div className="co-create-secret-warning">Configuration file should be in JSON format.</div> }
+    </React.Fragment>;
+  }
+}
 
 class WebHookSecretForm extends React.Component<WebHookSecretFormProps, WebHookSecretFormState> {
   constructor(props) {
@@ -185,7 +521,7 @@ class WebHookSecretForm extends React.Component<WebHookSecretFormProps, WebHookS
 }
 
 class SourceSecretForm extends React.Component<SourceSecretFormProps, SourceSecretFormState> {
-  constructor (props) {
+  constructor(props) {
     super(props);
     this.state = {
       type: this.props.secretType,
@@ -208,7 +544,7 @@ class SourceSecretForm extends React.Component<SourceSecretFormProps, SourceSecr
     return <React.Fragment>
       {this.props.isCreate
         ? <div className="form-group">
-          <label className="control-label" htmlFor="secret-type" >Authentication Type</label>
+          <label className="control-label" htmlFor="secret-type">Authentication Type</label>
           <div>
             <select onChange={this.changeAuthenticationType} value={this.state.type} className="form-control" id="secret-type">
               <option value={SecretType.basicAuth}>Basic Authentication</option>
@@ -227,7 +563,7 @@ class SourceSecretForm extends React.Component<SourceSecretFormProps, SourceSecr
 }
 
 export class BasicAuthSubform extends React.Component<BasicAuthSubformProps, BasicAuthSubformState> {
-  constructor (props) {
+  constructor(props) {
     super(props);
     this.state = {
       username: this.props.stringData.username || '',
@@ -276,7 +612,7 @@ export class BasicAuthSubform extends React.Component<BasicAuthSubformProps, Bas
 const DroppableFileInput = (props) => <AsyncComponent loader={() => import('../utils/file-input').then(c => c.DroppableFileInput)} {...props} />;
 
 class SSHAuthSubform extends React.Component<SSHAuthSubformProps, SSHAuthSubformState> {
-  constructor (props) {
+  constructor(props) {
     super(props);
     this.state = {
       'ssh-privatekey': this.props.stringData['ssh-privatekey'] || '',
@@ -305,12 +641,22 @@ class SSHAuthSubform extends React.Component<SSHAuthSubformProps, SSHAuthSubform
   }
 }
 
-const secretFormFactory = secretType => {
-  return secretType === SecretTypeAbstraction.webhook ? withSecretForm(WebHookSecretForm) : withSecretForm(SourceSecretForm);
+const secretFormFactory = (secretType: SecretTypeAbstraction) => {
+  switch (secretType) {
+    case SecretTypeAbstraction.source:
+      return withSecretForm(SourceSecretForm);
+    case SecretTypeAbstraction.image:
+      return withSecretForm(ImageSecretForm);
+    default:
+      return withSecretForm(WebHookSecretForm);
+  }
 };
 
 const SecretLoadingWrapper = props => {
-  const secretTypeAbstraction = determineSecretTypeAbstraction(_.get(props.obj.data, 'data'));
+  if (!props.obj.loaded) {
+    return <LoadingBox />;
+  }
+  const secretTypeAbstraction = toTypeAbstraction(props.obj.data.type);
   const SecretFormComponent = secretFormFactory(secretTypeAbstraction);
   const fixed = _.reduce(props.fixedKeys, (acc, k) => ({...acc, k: _.get(props.obj.data, k)}), {});
   return <StatusBox {...props.obj}>
@@ -346,6 +692,7 @@ export type BaseEditSecretState_ = {
     [key: string]: string
   },
   error?: any,
+  disableForm: boolean,
 };
 
 export type BaseEditSecretProps_ = {
@@ -363,6 +710,46 @@ export type BasicAuthSubformProps = {
   onChange: Function,
   stringData: {
     [key: string]: string
+  },
+};
+
+export type ImageSecretFormState = {
+  type: SecretType,
+  stringData: {
+    [key: string]: any
+  },
+  uploadConfig: string,
+  dataKey: string,
+};
+
+export type ImageSecretFormProps = {
+  onChange: Function,
+  onError: Function,
+  onFormDisable: Function,
+  stringData: {
+    [key: string]: string,
+  },
+  secretType: SecretType,
+  isCreate: boolean,
+};
+
+export type CreateConfigSubformProps = {
+  onChange: Function,
+  stringData: {
+    [key: string]: any,
+  },
+};
+
+export type UploadConfigSubformState = {
+  parseError: boolean,
+  configFile: string,
+};
+
+export type UploadConfigSubformProps = {
+  onChange: Function,
+  onDisable: Function,
+  stringData: {
+    [key: string]: Object,
   },
 };
 

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -3,7 +3,7 @@ import * as classNames from 'classnames';
 import { NativeTypes } from 'react-dnd-html5-backend';
 // eslint-disable-next-line no-unused-vars
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd';
-import withDragDropContext from '../utils/drag-drop-context';
+import withDragDropContext from './drag-drop-context';
 
 export class FileInput extends React.Component<FileInputProps, FileInputState> {
   constructor(props) {

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -58,6 +58,7 @@
 @import "components/node-ip-list";
 @import "components/overflow";
 @import "components/RBAC/rbac";
+@import "components/secrets/create-secret";
 @import "components/resource";
 @import "components/resource-dropdown";
 @import "components/row-filter";


### PR DESCRIPTION
Adding support for creating image pull secrets:
- kubernetes.io/dockerconfigjson - new format
```json
{
	"auths": {
		"https://index.docker.io/v1/": {
			"auth": "dGVzdHVzZXIzOnRlc3RwdzM=",
			"email": "jhadvig@test.com"
		}
	}
}
```

- kubernetes.io/dockercfg  - old format
```json
{
	"https://index.docker.io/v1/": {
		"auth": "dGVzdHVzZXIzOnRlc3RwdzM=",
		"email": "jhadvig@test.com"
	}
}
```

The secret contains credentials for 1-n registry entries. Each secret has to contain `auth` field, which is base64 encoded string, that encodes `${username}:${password}` string, or both `username` and `password` themselves. Also `mail` has to be there

User can either create a secret by providing the registry credentials in the `CreateConfigSubform` or upload configuration file in `UploadConfigSubform`.

![1](https://user-images.githubusercontent.com/1668218/42329745-be1db3ee-8071-11e8-94d4-0bec7ea37426.gif)

![2](https://user-images.githubusercontent.com/1668218/42329746-be451d12-8071-11e8-9d64-b7a7786aeb95.gif)

![3](https://user-images.githubusercontent.com/1668218/42329747-be62a3f0-8071-11e8-8ebc-6dd385e1f391.gif)

Editing of the image secret is for now done via `CreateConfigSubform` form and its possible to edit just the first registry credentials. Wasn't really sure how to approach this issue image secret can containe multiple registry credentials. There are couple of ideas how to tackle this issue:
- do the editation of the secret purely in the textarea of the `UploadConfigSubform` component.
   - cons: not the best UX + could cause some unintentional mistakes.
- have a `server address` picker above the `CreateConfigSubform` by which user can select and edit desired secret
   - cons: the `server address` should be also editable + not sure how server entry should be deleted then
- Just list all the registry entries using `CreateConfigSubform` component and will also be able to delete the particular entry
   - cons: list can get long

@spadgett @benjaminapetersen @openshift/team-ux-review PTAL



