### PR TITLE
Route Details: TLS Section - CopyToClipboard display issue

### DIFF
--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -181,7 +181,7 @@ class TLSSettings extends SafetyFirst<TLSDataProps, TLSDataState> {
         <dt>Insecure Traffic</dt>
         <dd>{tls.insecureEdgeTerminationPolicy || '-'}</dd>
         <dt>Certificate</dt>
-        <dd>{tls.certificate ? <CopyToClipboard value={tls.certificate}/> : '-'}</dd>
+        <dd>{tls.certificate ? <CopyToClipboard value={tls.certificate} visibleValue={tls.certificate}/> : '-'}</dd>
         <dt className="co-m-route-tls-reveal__title">Key {tls.key &&
           <button className="btn btn-link co-m-route-tls-reveal__btn" type="button" onClick={this.toggleKey}>
             {
@@ -193,10 +193,10 @@ class TLSSettings extends SafetyFirst<TLSDataProps, TLSDataState> {
         </dt>
         <dd>{tls.key ? <CopyToClipboard value={tls.key} visibleValue={visibleKeyValue}/> : '-'}</dd>
         <dt>CA Certificate</dt>
-        <dd>{tls.caCertificate ? <CopyToClipboard value={tls.caCertificate}/> : '-'}</dd>
+        <dd>{tls.caCertificate ? <CopyToClipboard value={tls.caCertificate} visibleValue={tls.caCertificate}/> : '-'}</dd>
         {tls.termination === 'reencrypt' && <React.Fragment>
           <dt>Destination CA Cert</dt>
-          <dd>{tls.destinationCACertificate ? <CopyToClipboard value={tls.destinationCACertificate}/> : '-'}</dd>
+          <dd>{tls.destinationCACertificate ? <CopyToClipboard value={tls.destinationCACertificate} visibleValue={tls.destinationCACertificate}/> : '-'}</dd>
         </React.Fragment>}
       </dl>;
   }


### PR DESCRIPTION
Added `visibleValue` prop to `<CopyToClipboard>` which fixed display issues:
### **Before**
![image](https://user-images.githubusercontent.com/12733153/42329643-31bfec00-803f-11e8-9b95-6daa1446e569.png)
### **After**
![image](https://user-images.githubusercontent.com/12733153/42338905-620b8d8c-8059-11e8-8ec4-a1294079bec6.png)
Fixes #204 