### PR TITLE
Make entire namespace selector clickable

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -91,29 +91,31 @@ $color-bookmarker: #DDD;
   display: flex;
   font-size: ($font-size-base + 1);
   height: $co-namespace-selector-mobile;
+  padding-right: 15px;
   white-space: nowrap;
-  padding: 0 15px;
 
   @media (min-width: $grid-float-breakpoint) {
     border-left: 1px solid $color-os-nav-item-seperator;
     font-size: ($font-size-base + 3);
     height: $co-namespace-selector-desktop;
-    padding-bottom: 5px;
-    padding-top: 5px;
   }
 
   &__dropdown {
-    flex: 0 1 auto;
-    max-width: 70%;
-    padding-left: 5px;
+    max-width: 95%;
   }
 
   .dropdown__not-btn {
     align-items: baseline;
     display: flex;
+    padding: 2px 15px;
+
+    @media (min-width: $grid-float-breakpoint) {
+      padding: 7px 15px;
+    }
 
     &__title {
       flex: 0 1 auto;
+      margin-left: 10px;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -122,12 +124,14 @@ $color-bookmarker: #DDD;
 }
 
 .co-namespace-selector__menu.dropdown-menu {
+  left: 15px;
   max-height: calc(100vh - (#{$masthead-height-mobile} + #{$co-namespace-selector-mobile}));
   max-width: 100%;
   min-width: 210px;
   overflow-y: auto;
 
   @media (min-width: $grid-float-breakpoint) {
+    left: 105px;
     max-height: calc(100vh - (#{$masthead-height-desktop} + #{$co-namespace-selector-desktop}));
     min-width: 250px;
   }

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -247,13 +247,13 @@ class NamespaceDropdown_ extends React.Component {
     const onChange = newNamespace => dispatch(UIActions.setActiveNamespace(newNamespace));
 
     return <div className="co-namespace-selector">
-      <span>{model.label}:</span>
       <Dropdown
         className="co-namespace-selector__dropdown"
         menuClassName="co-namespace-selector__menu"
         noButton
         canFavorite
         items={items}
+        titlePrefix={model.label}
         title={title}
         onChange={onChange}
         selectedKey={activeNamespace || ALL_NAMESPACES_KEY}

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -287,14 +287,16 @@ export class Dropdown extends DropdownMixin {
 
   render() {
     const {active, autocompleteText, selectedKey, items, title, bookmarks, keyboardHoverKey, favoriteKey} = this.state;
-    const {autocompleteFilter, autocompletePlaceholder, noButton, noSelection, className, menuClassName, storageKey, canFavorite, dropDownClassName} = this.props;
+    const {autocompleteFilter, autocompletePlaceholder, noButton, noSelection, className, menuClassName, storageKey, canFavorite, dropDownClassName, titlePrefix} = this.props;
 
     const button = noButton
       ? <div onClick={this.toggle} className="dropdown__not-btn" id={this.props.id}>
+        {titlePrefix && `${titlePrefix}: `}
         <span className="dropdown__not-btn__title">{title}</span>&nbsp;<Caret />
       </div>
       : <button onClick={this.toggle} type="button" className="btn btn-default btn--dropdown dropdown-toggle" id={this.props.id}>
         <div className="btn--dropdown__content-wrap">
+          {titlePrefix && `${titlePrefix}: `}
           {title}&nbsp;&nbsp;<Caret />
         </div>
       </button>;


### PR DESCRIPTION
Also made "Namespace" label text `pf-black-500` so that it is differentiated from the actual name.

https://jira.coreos.com/browse/CONSOLE-592?filter=-1

<img width="295" alt="screen shot 2018-07-09 at 2 58 10 pm" src="https://user-images.githubusercontent.com/1874151/42470476-8f3876d0-8388-11e8-9e64-d940d0d7eed8.png">


**before**
<img width="483" alt="screen shot 2018-07-09 at 2 41 33 pm" src="https://user-images.githubusercontent.com/1874151/42470206-c9593102-8387-11e8-83c2-549b36d8c909.png">
**after**
<img width="489" alt="screen shot 2018-07-09 at 2 41 46 pm" src="https://user-images.githubusercontent.com/1874151/42470205-c94b5a46-8387-11e8-95cb-6e7989720c31.png">
**before**
<img width="561" alt="screen shot 2018-07-09 at 2 40 59 pm" src="https://user-images.githubusercontent.com/1874151/42470207-c9678e96-8387-11e8-97af-d2cae3cced1f.png">
**after**
<img width="555" alt="screen shot 2018-07-09 at 2 40 22 pm" src="https://user-images.githubusercontent.com/1874151/42470208-c973cd82-8387-11e8-9999-f84298ddaeb0.png">


---

![namespace-selector4](https://user-images.githubusercontent.com/1874151/42470277-f8df2cb0-8387-11e8-8b32-49a75d2a2741.gif)
