### PR TITLE
Bug 1600047 - Don't follow logout redirect on 401 unauthenticated

### DIFF
--- a/frontend/public/module/auth.js
+++ b/frontend/public/module/auth.js
@@ -48,23 +48,19 @@ export const authSvc = {
 
     coFetch(window.SERVER_FLAGS.logoutURL, {
       method: 'POST',
-    }).then(() => authSvc._onLogout()).catch(e => {
+    }).catch(e => {
       // eslint-disable-next-line no-console
       console.error('ERROR LOGGING OUT', e);
-      authSvc._onLogout();
+    }).finally(() => {
+      if (window.SERVER_FLAGS.logoutRedirect && !next) {
+        window.location = window.SERVER_FLAGS.logoutRedirect;
+      } else {
+        authSvc.login();
+      }
     });
   },
 
-  _onLogout: () => {
-    if (window.SERVER_FLAGS.logoutRedirect) {
-      window.location = window.SERVER_FLAGS.logoutRedirect;
-    } else {
-      authSvc.login();
-    }
-  },
-
   login: () => {
-    setNext(window.location.pathname);
     window.location = window.SERVER_FLAGS.loginURL;
   },
 };


### PR DESCRIPTION
This prevents the user from being able to login again. Only go to the
logout redirect when the user logs out from the masthead user menu.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600047

/assign @jhadvig 