### PR TITLE
Fix pod list filter count

### DIFF
--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { AutoSizer, List as VirtualList, WindowScroller, CellMeasurerCache, CellMeasurer } from 'react-virtualized';
 
-import { getJobTypeAndCompletions, isNodeReady, podPhase, podReadiness, K8sResourceKind, K8sKind, K8sResourceKindReference } from '../../module/k8s';
+import { getJobTypeAndCompletions, isNodeReady, podPhase, podPhaseFilterReducer, podReadiness, K8sResourceKind, K8sKind, K8sResourceKindReference } from '../../module/k8s';
 import { isScanned, isSupported, makePodvuln, numFixables } from '../../module/k8s/podvulns';
 import { UIActions } from '../../ui/ui-actions';
 import { ingressValidHosts } from '../ingress';
@@ -50,7 +50,7 @@ const listFilters = {
       return true;
     }
 
-    const phase = podPhase(pod);
+    const phase = podPhaseFilterReducer(pod);
     return phases.selected.has(phase) || !_.includes(phases.all, phase);
   },
 

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
 
-import { getVolumeType, getVolumeLocation, getVolumeMountPermissions, getVolumeMountsByPermissions, getRestartPolicyLabel, podPhase, podReadiness } from '../module/k8s/pods';
+import { getVolumeType, getVolumeLocation, getVolumeMountPermissions, getVolumeMountsByPermissions, getRestartPolicyLabel, podPhase, podPhaseFilterReducer, podReadiness } from '../module/k8s/pods';
 import { getContainerState, getContainerStatus } from '../module/k8s/docker';
 import { ResourceEventStream } from './events';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import { Cog, LabelList, navFactory, Overflow, ResourceCog, ResourceIcon, ResourceLink, ResourceSummary, Selector, Timestamp, VolumeIcon, units, AsyncComponent} from './utils';
+import { Cog, LabelList, navFactory, Overflow, ResourceCog, ResourceIcon, ResourceLink, ResourceSummary, Selector, Timestamp, VolumeIcon, units, AsyncComponent } from './utils';
 import { PodLogs } from './pod-logs';
 import { registerTemplate } from '../yaml-templates';
 import { Line, requirePrometheus } from './graphs';
@@ -51,13 +51,9 @@ Readiness.displayName = 'Readiness';
 
 export const PodRow = ({obj: pod}) => {
   const phase = podPhase(pod);
-  let status = phase;
-
-  if (!validStatuses.has(status)) {
-    status = <span className="co-error">
-      <i className="fa fa-times-circle co-icon-space-r" />{phase}
-    </span>;
-  }
+  const status = validStatuses.has(phase)
+    ? phase
+    : <span className="co-error"><i className="fa fa-times-circle co-icon-space-r" />{phase}</span>;
 
   return <ResourceRow obj={pod}>
     <div className="col-lg-2 col-md-3 col-sm-4 col-xs-6 co-break-word">
@@ -289,15 +285,17 @@ PodList.displayName = 'PodList';
 
 const filters = [{
   type: 'pod-status',
-  selected: ['Running', 'Pending', 'Terminating', 'CrashLoopBackOff'],
-  reducer: podPhase,
+  selected: [ 'Running', 'Pending', 'Terminating', 'CrashLoopBackOff' ],
+  reducer: podPhaseFilterReducer,
   items: [
-    {id: 'Running', title: 'Running'},
-    {id: 'Pending', title: 'Pending'},
-    {id: 'Terminating', title: 'Terminating'},
-    {id: 'CrashLoopBackOff', title: 'CrashLoopBackOff'},
-    {id: 'Completed', title: 'Completed'},
-  ],
+    { id: 'Running', title: 'Running' },
+    { id: 'Pending', title: 'Pending' },
+    { id: 'Terminating', title: 'Terminating' },
+    { id: 'CrashLoopBackOff', title: 'CrashLoopBackOff' },
+    { id: 'Succeeded', title: 'Succeeded' },
+    { id: 'Failed', title: 'Failed' },
+    { id: 'Unknown', title: 'Unknown '}
+  ]
 }];
 
 export class PodsPage extends React.Component {

--- a/frontend/public/module/k8s/pods.ts
+++ b/frontend/public/module/k8s/pods.ts
@@ -209,6 +209,17 @@ export const podPhase = (pod): PodPhase => {
   return phase;
 };
 
+export const podPhaseFilterReducer = (pod): PodPhase => {
+  const status = podPhase(pod);
+  if (status === 'Terminating') {
+    return status;
+  }
+  if (status.includes('CrashLoopBackOff')) {
+    return 'CrashLoopBackOff';
+  }
+  return _.get(pod, 'status.phase', 'Unknown');
+};
+
 export const podReadiness = ({status}): PodReadiness => {
   if (_.isEmpty(status.conditions)) {
     return null;


### PR DESCRIPTION
Fix https://jira.coreos.com/browse/CONSOLE-541

Added new filter reducer for pod status which makes the filters use the higher level pod phase instead of the underlying container status. The only exceptions to this are in the case of a CrashLoopBackOff condition, or if the pod is Terminating. The filter values now correspond to the 5 pod phase values defined in the API, with the addition of the aforementioned edge cases.

![screenshot-localhost-9000-2018 07 12-12-28-06](https://user-images.githubusercontent.com/22625502/42646530-2240b274-85cf-11e8-8562-62d1e71e7f33.png)


@openshift/team-ux-review 