### PR TITLE
Bug 1600343 - Remove use of `Promise.finally` from login flow

### DIFF
--- a/frontend/public/module/auth.js
+++ b/frontend/public/module/auth.js
@@ -48,16 +48,19 @@ export const authSvc = {
 
     coFetch(window.SERVER_FLAGS.logoutURL, {
       method: 'POST',
-    }).catch(e => {
+    }).then(() => authSvc._onLogout(next)).catch(e => {
       // eslint-disable-next-line no-console
       console.error('ERROR LOGGING OUT', e);
-    }).finally(() => {
-      if (window.SERVER_FLAGS.logoutRedirect && !next) {
-        window.location = window.SERVER_FLAGS.logoutRedirect;
-      } else {
-        authSvc.login();
-      }
+      authSvc._onLogout(next);
     });
+  },
+
+  _onLogout: (next) => {
+    if (window.SERVER_FLAGS.logoutRedirect && !next) {
+      window.location = window.SERVER_FLAGS.logoutRedirect;
+    } else {
+      authSvc.login();
+    }
   },
 
   login: () => {


### PR DESCRIPTION
`Promise.finally` does not work on all browsers.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600343
/assign @rhamilto 