### PR TITLE
Bug 1600403 - Hide the network policy dropdown in the create project dialog

### DIFF
--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -103,7 +103,7 @@ class CreateNamespaceModal extends PromiseComponent {
             <SelectorInput labelClassName="co-text-namespace" onChange={this.onLabels.bind(this)} tags={[]} />
           </div>
         </div>}
-        <div className="form-group">
+        {!this.props.createProject && <div className="form-group">
           <label className="control-label">Default Network Policy</label>
           <div className="modal-body__field ">
             <select onChange={e => this.setState({np: e.target.value})} value={this.state.np} className="form-control">
@@ -111,7 +111,7 @@ class CreateNamespaceModal extends PromiseComponent {
               <option value={deny}>Deny all inbound traffic.</option>
             </select>
           </div>
-        </div>
+        </div>}
       </ModalBody>
       <ModalSubmitFooter errorMessage={this.state.errorMessage} inProgress={this.state.inProgress} submitText={`Create ${label}`} cancel={this.props.cancel.bind(this)} />
     </form>;


### PR DESCRIPTION
We don't know what network plugin is enabled, so we have no way to know
whether the network policy will actually take effect. Hide the dropdown
in the dialog to avoid confusion, but still let users who create network
policies later from the project page if needed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1600403

/assign @rhamilto 