### PR TITLE
Add missing data to image stream, image stream tag pages

### DIFF
--- a/frontend/public/components/image-stream-tag.tsx
+++ b/frontend/public/components/image-stream-tag.tsx
@@ -43,6 +43,7 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
   const exposedPorts = _.keys(config.ExposedPorts).join(', ');
   const size = _.get(imageStreamTag, 'image.dockerImageMetadata.Size');
   const humanizedSize = _.isFinite(size) && humanizeMem(size);
+  const architecture = _.get(imageStreamTag, 'image.dockerImageMetadata.Architecture');
 
   return <div className="co-m-pane__body">
     <div className="co-m-pane__body-group">
@@ -71,8 +72,8 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
             {exposedPorts && <dd><Overflow value={exposedPorts} /></dd>}
             {config.User && <dt>User</dt>}
             {config.User && <dd>{config.User}</dd>}
-            {config.Architecture && <dt>Architecture</dt>}
-            {config.Architecture && <dd>{config.Architecture}</dd>}
+            {architecture && <dt>Architecture</dt>}
+            {architecture && <dd>{architecture}</dd>}
           </dl>
         </div>
       </div>

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -52,6 +52,8 @@ const ImageStreamTagsRow: React.SFC<ImageStreamTagsRowProps> = ({imageStream, sp
 
 export const ImageStreamsDetails: React.SFC<ImageStreamsDetailsProps> = ({obj: imageStream}) => {
   const imageRepository = _.get(imageStream, 'status.dockerImageRepository');
+  const publicImageRepository = _.get(imageStream, 'status.publicDockerImageRepository');
+  const imageCount = _.get(imageStream, 'status.tags.length');
   const specTagByName = _.keyBy(imageStream.spec.tags, 'name');
 
   return <div>
@@ -59,6 +61,10 @@ export const ImageStreamsDetails: React.SFC<ImageStreamsDetailsProps> = ({obj: i
       <ResourceSummary resource={imageStream} showPodSelector={false} showNodeSelector={false}>
         {imageRepository && <dt>Image Repository</dt>}
         {imageRepository && <dd>{imageRepository}</dd>}
+        {publicImageRepository && <dt>Public Image Repository</dt>}
+        {publicImageRepository && <dd>{publicImageRepository}</dd>}
+        <dt>Image Count</dt>
+        <dd>{imageCount ? imageCount : 0}</dd>
       </ResourceSummary>
     </div>
     <div className="co-m-pane__body">


### PR DESCRIPTION
* Add public image repository, image count to image stream page
* Fix bug where architecture didn't appear on image stream tag page

![localhost_9000_k8s_ns_robb-imagestream_imagestreams_example 1](https://user-images.githubusercontent.com/895728/42650536-a842f750-85da-11e8-9cf0-a987ff4a18cc.png)
![localhost_9000_k8s_ns_robb-imagestream_imagestreams_ruby-ex_ 6](https://user-images.githubusercontent.com/895728/42643914-4ad87a5c-85c8-11e8-9d58-7ee98128b2d8.png)


