### PR TITLE
Set fixedrange on line charts

### DIFF
--- a/frontend/public/components/graphs/line.jsx
+++ b/frontend/public/components/graphs/line.jsx
@@ -29,12 +29,14 @@ export class Line extends BaseGraph {
         zeroline: false,
         ticks: '',
         showline: false,
+        fixedrange: true,
       },
       xaxis: {
         zeroline: false,
         tickformat:'%H:%M',
         ticks: '',
         showline: false,
+        fixedrange: true,
       },
       legend: {
         x: 0, y: 1,


### PR DESCRIPTION
This disables pan on drag because there's no data outside the range we
show in the line charts.