### PR TITLE
Discover Prometheus, Alert Manager, and Grafana URLs from routes

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -9,6 +9,7 @@ import * as PropTypes from 'prop-types';
 import store from '../redux';
 import { ALL_NAMESPACES_KEY } from '../const';
 import { connectToFlags, featureActions, flagPending, FLAGS } from '../features';
+import { detectMonitoringURLs } from '../monitoring';
 import { analyticsSvc } from '../module/analytics';
 import { ClusterOverviewContainer } from './cluster-overview-container';
 import { ClusterSettingsPage } from './cluster-settings/cluster-settings';
@@ -227,6 +228,7 @@ class App extends React.PureComponent {
 
 _.each(featureActions, store.dispatch);
 store.dispatch(k8sActions.getResources());
+store.dispatch(detectMonitoringURLs);
 
 analyticsSvc.push({tier: 'tectonic'});
 

--- a/frontend/public/components/graphs/base.jsx
+++ b/frontend/public/components/graphs/base.jsx
@@ -7,6 +7,7 @@ import { coFetchJSON } from '../../co-fetch';
 import { SafetyFirst } from '../safety-first';
 
 import { prometheusBasePath } from './index';
+import { MonitoringRoutes } from '../../monitoring';
 
 export class BaseGraph extends SafetyFirst {
   constructor(props) {
@@ -98,6 +99,11 @@ export class BaseGraph extends SafetyFirst {
   }
 
   prometheusURL () {
+    const base = this.props.urls && this.props.urls[MonitoringRoutes.Prometheus];
+    if (!base) {
+      return null;
+    }
+
     let queries = this.props.query;
     if (!_.isArray(queries)) {
       queries = [{
@@ -111,16 +117,19 @@ export class BaseGraph extends SafetyFirst {
       params.set(`g${i}.tab`, '0');
     });
 
-    return `/prometheus/graph?${params.toString()}`;
+    return `${base}/graph?${params.toString()}`;
   }
 
   render () {
-    return <a href={this.prometheusURL()} target="_blank" rel="noopener noreferrer" style={{textDecoration: 'none'}}>
-      <div className="graph-wrapper" style={this.style}>
-        <h5 className="graph-title">{this.props.title}</h5>
-        <div ref={this.setNode} style={{width: '100%'}}/>
-      </div>
-    </a>;
+    const url = this.prometheusURL();
+    const graph = <div className="graph-wrapper" style={this.style}>
+      <h5 className="graph-title">{this.props.title}</h5>
+      <div ref={this.setNode} style={{width: '100%'}}/>
+    </div>;
+
+    return url
+      ? <a href={url} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }}>{graph}</a>
+      : graph;
   }
 }
 
@@ -136,4 +145,8 @@ BaseGraph.propTypes = {
   title: PropTypes.string.isRequired,
   timeSpan: PropTypes.number,
   basePath: PropTypes.string,
+};
+
+BaseGraph.contextTypes = {
+  urls: PropTypes.object,
 };

--- a/frontend/public/components/graphs/gauge.jsx
+++ b/frontend/public/components/graphs/gauge.jsx
@@ -1,11 +1,13 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import * as PropTypes from 'prop-types';
 import { relayout, register } from 'plotly.js/lib/core';
 import * as pie from 'plotly.js/lib/pie';
 // Horrible hack to get around plotly vs webpack incompatibility
 register(pie);
 
 import { BaseGraph } from './base';
+import { connectToURLs, MonitoringRoutes } from '../../monitoring';
 
 const colors = {
   ok: 'rgb(46,201,141)',
@@ -22,7 +24,7 @@ const fontColors = {
   error: '#d64456',
 };
 
-export class Gauge extends BaseGraph {
+class Gauge_ extends BaseGraph {
   constructor (props) {
     super(props);
 
@@ -167,6 +169,7 @@ export class Gauge extends BaseGraph {
     relayout(this.node, this.layout);
   }
 }
+export const Gauge = connectToURLs(MonitoringRoutes.Prometheus)(Gauge_);
 
 Gauge.defaultProps = {
   invert: false,
@@ -174,4 +177,8 @@ Gauge.defaultProps = {
     warn: 67,
     error: 92,
   },
+};
+
+Gauge_.contextTypes = {
+  urls: PropTypes.object,
 };

--- a/frontend/public/components/graphs/line.jsx
+++ b/frontend/public/components/graphs/line.jsx
@@ -1,8 +1,10 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import * as PropTypes from 'prop-types';
 import { restyle } from 'plotly.js/lib/core';
 
 import { BaseGraph } from './base';
+import { connectToURLs, MonitoringRoutes } from '../../monitoring';
 
 const baseData = {
   x: [],
@@ -12,7 +14,7 @@ const baseData = {
   type: 'scatter',
 };
 
-export class Line extends BaseGraph {
+export class Line_ extends BaseGraph {
   constructor (props) {
     super(props);
 
@@ -121,3 +123,8 @@ export class Line extends BaseGraph {
     });
   }
 }
+export const Line = connectToURLs(MonitoringRoutes.Prometheus)(Line_);
+
+Line_.contextTypes = {
+  urls: PropTypes.object,
+};

--- a/frontend/public/monitoring.ts
+++ b/frontend/public/monitoring.ts
@@ -1,0 +1,62 @@
+/* eslint-disable no-undef */
+
+import { connect } from 'react-redux';
+import { Map as ImmutableMap } from 'immutable';
+import * as _ from 'lodash-es';
+
+import { k8sBasePath } from './module/k8s/k8s';
+import { coFetchJSON } from './co-fetch';
+
+export enum MonitoringRoutes {
+  Prometheus = 'prometheus-k8s',
+  AlertManager = 'alertmanager-main',
+  Grafana = 'grafana',
+}
+
+const SET_MONITORING_URL = 'setMonitoringURL';
+const DEFAULTS = _.mapValues(MonitoringRoutes, undefined);
+
+const monitoringRoutes = `${k8sBasePath}/apis/route.openshift.io/v1/namespaces/openshift-monitoring/routes/`;
+export const detectMonitoringURLs = dispatch => coFetchJSON(monitoringRoutes).then(res => {
+  const byName = _.keyBy(res.items, 'metadata.name');
+  _.each(MonitoringRoutes, name => {
+    const route = byName[name];
+    if (!route) {
+      return;
+    }
+    const scheme = _.get(route, 'spec.tls.termination') ? 'https' : 'http';
+    const url = `${scheme}://${route.spec.host}`;
+    // eslint-disable-next-line no-console
+    console.log(`${name} detected at ${url}`);
+    dispatch({ name, url, type: SET_MONITORING_URL });
+  });
+}).catch(res => {
+  const status = _.get(res, 'response.status');
+  // eslint-disable-next-line no-console
+  console.log('Could not get openshift-monitoring routes, status:', status);
+  if (!_.includes([401, 403, 404, 500], status)) {
+    setTimeout(() => detectMonitoringURLs(dispatch), 15000);
+  }
+});
+
+export const monitoringReducer = (state: ImmutableMap<string, any>, action) => {
+  if (!state) {
+    return ImmutableMap(DEFAULTS);
+  }
+
+  switch (action.type) {
+    case SET_MONITORING_URL:
+      return state.merge({ [action.name]: action.url });
+
+    default:
+      return state;
+  }
+};
+
+export const monitoringReducerName = 'monitoringURLs';
+const stateToProps = (desiredURLs: string[], state) => {
+  const urls = desiredURLs.reduce((previous, next) => ({...previous, [next]: state[monitoringReducerName].get(next)}), {});
+  return { urls };
+};
+
+export const connectToURLs = (...urls) => connect(state => stateToProps(urls, state));

--- a/frontend/public/redux.js
+++ b/frontend/public/redux.js
@@ -3,6 +3,7 @@ import { reducer as formReducer } from 'redux-form';
 import thunk from 'redux-thunk';
 
 import { featureReducer, featureReducerName } from './features';
+import { monitoringReducer, monitoringReducerName } from './monitoring';
 import k8sReducers from './module/k8s/k8s-reducers';
 import UIReducers from './ui/ui-reducers';
 
@@ -11,6 +12,7 @@ const reducers = combineReducers({
   UI: UIReducers,
   form: formReducer,
   [featureReducerName]: featureReducer,
+  [monitoringReducerName]: monitoringReducer,
 });
 
 const store = createStore(reducers, {}, applyMiddleware(thunk));


### PR DESCRIPTION
Use the routes in the openshift-monitoring namespace to discover the public URLs for monitoring apps.

@brancz @kyoto @jwforres 

It's not clear if we want to go this way, but this uses routes to discover the various URLs using the user's API token. Other options:

* Use the console service account to list the monitoring routes (server-side polling)
* Use the CRDs to get the Prometheus and Alert Manager URLs since they have `spec.externalUrl` (although I don't think there's a Grafana CRD)
* Configure the URLs in the console config (no discovery)

Note that the charts will still work even if we can't discover the URLs. We just can't link to the Prometheus UI.

TODO:

- [ ] Fallback to the well-known URLs for Tectonic when not running on OpenShift