### PR TITLE
Heading consistency updates

### DIFF
--- a/frontend/__tests__/components/cloud-services/clusterserviceversion-resource.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/clusterserviceversion-resource.spec.tsx
@@ -161,7 +161,7 @@ describe(ClusterServiceVersionResourceDetails.displayName, () => {
   });
 
   it('renders description title', () => {
-    const title = wrapper.find('.co-section-title');
+    const title = wrapper.find('.co-section-heading');
     expect(title.text()).toEqual('Test Resource Overview');
   });
 

--- a/frontend/public/components/RBAC/edit-rule.jsx
+++ b/frontend/public/components/RBAC/edit-rule.jsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import { k8sGet, k8sUpdate } from '../../module/k8s';
 import { RoleModel, ClusterRoleModel } from '../../models';
 import { errorModal } from '../modals';
-import { Heading, history, ResourceIcon, resourceObjPath, PromiseComponent, ButtonBar, LoadingBox } from '../utils';
+import { SectionHeading, history, ResourceIcon, resourceObjPath, PromiseComponent, ButtonBar, LoadingBox } from '../utils';
 import k8sActions from '../../module/k8s/k8s-actions';
 
 const NON_RESOURCE_VERBS = ['get', 'post', 'put', 'delete'];
@@ -266,7 +266,7 @@ const EditRule = connect(state => state.k8s.get('RESOURCES') || {}, {getResource
             <title>{`${name} · ${heading}`}</title>
           </Helmet>
           <div className="co-m-pane__body">
-            <Heading text={heading} />
+            <SectionHeading text={heading} />
             <div className="row">
               <div className="col-xs-12">
                 <p className="text-secondary">

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -4,7 +4,7 @@ import * as fuzzy from 'fuzzysearch';
 import { Link } from 'react-router-dom';
 
 import { ColHead, DetailsPage, List, ListHeader, MultiListPage, ResourceRow, TextFilter } from '../factory';
-import { Cog, Heading, MsgBox, navFactory, ResourceCog, ResourceLink, Timestamp } from '../utils';
+import { Cog, SectionHeading, MsgBox, navFactory, ResourceCog, ResourceLink, Timestamp } from '../utils';
 import { BindingName, BindingsList, RulesList } from './index';
 import { registerTemplate } from '../../yaml-templates';
 import { flatten as bindingsFlatten } from './bindings';
@@ -74,7 +74,7 @@ class Details extends React.Component {
 
     return <div>
       <div className="co-m-pane__body">
-        <Heading text="Role Overview" />
+        <SectionHeading text="Role Overview" />
         <div className="row">
           <div className="col-xs-6">
             <dl className="co-m-pane__details">
@@ -95,7 +95,7 @@ class Details extends React.Component {
         </div>
       </div>
       <div className="co-m-pane__body">
-        <Heading text="Rules" />
+        <SectionHeading text="Rules" />
         <div className="co-m-pane__filter-bar co-m-pane__filter-bar--alt">
           <div className="co-m-pane__filter-bar-group">
             <Link to={addHref(name, namespace)} className="co-m-primary-action">

--- a/frontend/public/components/alert-manager.jsx
+++ b/frontend/public/components/alert-manager.jsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { referenceForModel } from '../module/k8s';
 import { SafetyFirst } from './safety-first';
 import { ColHead, List, ListHeader, ListPage, ResourceRow, DetailsPage } from './factory';
-import { LabelList, navFactory, ResourceLink, Selector, Firehose, LoadingInline, pluralize } from './utils';
+import { SectionHeading, LabelList, navFactory, ResourceLink, Selector, Firehose, LoadingInline, pluralize } from './utils';
 import { SettingsRow, SettingsContent } from './cluster-settings/cluster-settings';
 import { configureReplicaCountModal } from './modals';
 import { AlertmanagerModel } from '../models';
@@ -43,8 +43,7 @@ class Details extends SafetyFirst {
     const {metadata, spec} = alertManager;
     return <div>
       <div className="co-m-pane__body">
-        <h1 className="co-section-title">Alert Manager Overview</h1>
-
+        <SectionHeading text="Alert Manager Overview" />
         <div className="row">
           <div className="col-sm-6 col-xs-12">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -6,7 +6,7 @@ import { K8sResourceKindReference, referenceFor } from '../module/k8s';
 import { startBuild } from '../module/k8s/builds';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { errorModal } from './modals';
-import { BuildHooks, BuildStrategy, Cog, LabelList, history, navFactory, ResourceCog, ResourceLink, resourceObjPath, ResourceSummary, WebhookTriggers } from './utils';
+import { BuildHooks, BuildStrategy, Cog, SectionHeading, LabelList, history, navFactory, ResourceCog, ResourceLink, resourceObjPath, ResourceSummary, WebhookTriggers } from './utils';
 import { BuildsPage, BuildEnvironmentComponent } from './build';
 import { fromNow } from './utils/datetime';
 import { registerTemplate } from '../yaml-templates';
@@ -62,7 +62,7 @@ const menuActions = [
 
 export const BuildConfigsDetails: React.SFC<BuildConfigsDetailsProps> = ({obj: buildConfig}) => <React.Fragment>
   <div className="co-m-pane__body">
-    <h1 className="co-m-pane__heading">Build Config Overview</h1>
+    <SectionHeading text="Build Config Overview" />
     <div className="row">
       <div className="col-sm-6">
         <ResourceSummary resource={buildConfig} showPodSelector={false} showNodeSelector={false} />

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -6,7 +6,7 @@ import { K8sResourceKindReference, referenceFor } from '../module/k8s';
 import { cloneBuild, formatBuildDuration } from '../module/k8s/builds';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { errorModal } from './modals';
-import { BuildHooks, BuildStrategy, Cog, history, navFactory, ResourceCog, ResourceLink, resourceObjPath, ResourceSummary, Timestamp } from './utils';
+import { BuildHooks, BuildStrategy, Cog, SectionHeading, history, navFactory, ResourceCog, ResourceLink, resourceObjPath, ResourceSummary, Timestamp } from './utils';
 import { BuildPipeline } from './build-pipeline';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { fromNow } from './utils/datetime';
@@ -42,7 +42,7 @@ export const BuildsDetails: React.SFC<BuildsDetailsProps> = ({ obj: build }) => 
 
   return <React.Fragment>
     <div className="co-m-pane__body">
-      <h1 className="co-m-pane__heading">Build Overview</h1>
+      <SectionHeading text="Build Overview" />
       {hasPipeline && <div className="row">
         <div className="col-xs-12">
           <BuildPipeline obj={build} />

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -5,7 +5,7 @@ import * as classNames from 'classnames';
 import { SafetyFirst } from './safety-first';
 import { FLAGS, connectToFlags, flagPending } from '../features';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, navFactory, NavBar, NavTitle, ResourceCog, Heading, ResourceLink, ResourceSummary, Timestamp, LabelList, DownloadButton } from './utils';
+import { Cog, navFactory, NavBar, NavTitle, ResourceCog, SectionHeading, ResourceLink, ResourceSummary, Timestamp, LabelList, DownloadButton } from './utils';
 import { LoadError, LoadingBox, LoadingInline, MsgBox } from './utils/status-box';
 import { getQueryArgument, setQueryArgument } from './utils/router';
 import { coFetchJSON } from '../co-fetch';
@@ -89,7 +89,7 @@ class ReportsDetails extends React.Component<ReportsDetailsProps> {
     const phase = _.get(obj, ['status', 'phase']);
     return <div>
       <div className="co-m-pane__body">
-        <Heading text="Report Overview" />
+        <SectionHeading text="Report Overview" />
         <div className="row">
           <div className="col-sm-6 col-xs-12">
             <ResourceSummary resource={obj} showNodeSelector={false} showPodSelector={false} showAnnotations={true} />
@@ -335,9 +335,9 @@ class ReportData extends SafetyFirst<ReportDataProps, ReportDataState> {
 
     return <div>
       <div className="co-m-pane__body">
-        <Heading text="Usage Report">
+        <SectionHeading text="Usage Report">
           <DownloadButton className="pull-right" url={downloadURL} filename={`${name}.${format}`} />
-        </Heading>
+        </SectionHeading>
         <div className="row">
           <div className="col-sm-6 col-xs-12">
             <div className="btn-group">
@@ -427,7 +427,7 @@ const ReportGenerationQueriesDetails: React.SFC<ReportGenerationQueriesDetailsPr
 
   return <div>
     <div className="co-m-pane__body">
-      <Heading text="Chargeback Report Generation Query" />
+      <SectionHeading text="Chargeback Report Generation Query" />
       <ResourceSummary resource={obj} showNodeSelector={false} showPodSelector={false} showAnnotations={true}>
         <dt>Query</dt>
         <dd><pre><code>{_.get(obj, ['spec', 'query'])}</code></pre></dd>

--- a/frontend/public/components/cloud-services/catalog-source.tsx
+++ b/frontend/public/components/cloud-services/catalog-source.tsx
@@ -6,7 +6,7 @@ import { match, Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { safeLoad } from 'js-yaml';
 
-import { NavTitle, Firehose, MsgBox, LoadingBox, withFallback } from '../utils';
+import { NavTitle, SectionHeading, Firehose, MsgBox, LoadingBox, withFallback } from '../utils';
 import { CreateYAML } from '../create-yaml';
 import { ClusterServiceVersionLogo, SubscriptionKind, CatalogSourceKind, ClusterServiceVersionKind, Package } from './index';
 import { SubscriptionModel, CatalogSourceModel } from '../../models';
@@ -84,14 +84,8 @@ export const CatalogSourceDetails: React.SFC<CatalogSourceDetailsProps> = ({cata
         </div>
       </div>
       <div className="co-m-pane__body">
-        <div className="row">
-          <div className="col-xs-12">
-            <h2>Applications</h2>
-          </div>
-        </div>
-        <div style={{marginTop: '15px'}}>
-          <PackageList packages={packages} namespace={ns} catalogSource={catalogSource.data} subscriptionsFor={subscriptionsFor} csvFor={csvFor} />
-        </div>
+        <SectionHeading text="Applications" />
+        <PackageList packages={packages} namespace={ns} catalogSource={catalogSource.data} subscriptionsFor={subscriptionsFor} csvFor={csvFor} />
       </div>
     </div>
     : <div />;

--- a/frontend/public/components/cloud-services/clusterserviceversion-resource.tsx
+++ b/frontend/public/components/cloud-services/clusterserviceversion-resource.tsx
@@ -175,7 +175,7 @@ export const ClusterServiceVersionResourceDetails = connectToModel(
 
       return <div className="co-clusterserviceversion-resource-details co-m-pane">
         <div className="co-m-pane__body">
-          <h1 className="co-section-title">{`${thisDefinition ? thisDefinition.displayName : kind} Overview`}</h1>
+          <h2 className="co-section-heading">{`${thisDefinition ? thisDefinition.displayName : kind} Overview`}</h2>
           <div className="row">
             { podStatusesDescriptor && <div className="col-sm-6 col-md-4"><PodStatusChart statusDescriptor={podStatusesDescriptor} fetcher={() => blockValue(podStatusesDescriptor, status)} /></div> }
             { metricsValue && metricsValue.queries.map((query: ClusterServiceVersionPrometheusQuery, i) => (

--- a/frontend/public/components/cloud-services/clusterserviceversion.tsx
+++ b/frontend/public/components/cloud-services/clusterserviceversion.tsx
@@ -162,7 +162,7 @@ export const ClusterServiceVersionsPage = connect(stateToProps)(
         </Box>
         : <React.Fragment>
           <NavTitle title="Available Applications" />
-          <h3 className="co-clusterserviceversion-list__title">Open Cloud Services</h3>
+          <h2 className="co-clusterserviceversion-list__title co-section-heading">Open Cloud Services</h2>
           <MultiListPage
             {...this.props}
             namespace={this.props.match.params.ns}
@@ -176,7 +176,7 @@ export const ClusterServiceVersionsPage = connect(stateToProps)(
             ListComponent={ClusterServiceVersionList}
             filterLabel="Applications by name"
             showTitle={false} />
-          <h3 className="co-clusterserviceversion-list__title">Custom Applications</h3>
+          <h2 className="co-clusterserviceversion-list__title co-section-heading">Custom Applications</h2>
           <MultiListPage
             {...this.props}
             namespace={this.props.match.params.ns}

--- a/frontend/public/components/cloud-services/install-plan.tsx
+++ b/frontend/public/components/cloud-services/install-plan.tsx
@@ -6,7 +6,7 @@ import { match, Link } from 'react-router-dom';
 import { Map as ImmutableMap } from 'immutable';
 
 import { ListPage, List, ListHeader, ColHead, ResourceRow, DetailsPage } from '../factory';
-import { MsgBox, ResourceLink, ResourceCog, Cog, ResourceIcon, navFactory, ResourceSummary } from '../utils';
+import { SectionHeading, MsgBox, ResourceLink, ResourceCog, Cog, ResourceIcon, navFactory, ResourceSummary } from '../utils';
 import { InstallPlanKind, InstallPlanApproval, Step } from './index';
 import { referenceForModel, referenceForOwnerRef, k8sUpdate } from '../../module/k8s';
 import { SubscriptionModel, ClusterServiceVersionModel, InstallPlanModel, CatalogSourceModel } from '../../models';
@@ -73,6 +73,7 @@ export const InstallPlanDetails: React.SFC<InstallPlanDetailsProps> = ({obj}) =>
       </Link>
     </div> }
     <div className="co-m-pane__body">
+      <SectionHeading text="Install Plan Overview" />
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
@@ -136,7 +137,7 @@ export class InstallPlanPreview extends React.Component<InstallPlanPreviewProps,
           </button>
         </div> }
         { stepsByCSV.map((steps, i) => <div key={i} className="co-m-pane__body">
-          <h1 className="co-section-title">{steps[0].resolving}</h1>
+          <SectionHeading text={steps[0].resolving} />
           <div className="co-table-container">
             <table className="table">
               <thead>

--- a/frontend/public/components/cloud-services/subscription.tsx
+++ b/frontend/public/components/cloud-services/subscription.tsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 
 import { List, ListHeader, ColHead, DetailsPage, ListPage } from '../factory';
-import { MsgBox, ResourceLink, ResourceCog, navFactory, Cog, ResourceSummary, LoadingInline, makeQuery, makeReduxID } from '../utils';
+import { MsgBox, SectionHeading, ResourceLink, ResourceCog, navFactory, Cog, ResourceSummary, LoadingInline, makeQuery, makeReduxID } from '../utils';
 import { SubscriptionKind, SubscriptionState, Package, InstallPlanApproval, ClusterServiceVersionKind } from './index';
 import { referenceForModel, k8sKill, k8sUpdate } from '../../module/k8s';
 import { SubscriptionModel, ClusterServiceVersionModel, CatalogSourceModel, ConfigMapModel, InstallPlanModel } from '../../models';
@@ -92,6 +92,7 @@ export const SubscriptionDetails = connect(stateToProps, null)((props: Subscript
   const {obj, pkg, installedCSV} = props;
 
   return <div className="co-m-pane__body">
+    <SectionHeading text="Subscription Overview" />
     <div className="co-m-pane__body-group">
       <SubscriptionUpdates pkg={pkg} obj={obj} installedCSV={installedCSV} />
     </div>

--- a/frontend/public/components/cluster-settings/ldap.jsx
+++ b/frontend/public/components/cluster-settings/ldap.jsx
@@ -471,7 +471,7 @@ const LDAPs = reduxForm({
         const populated = !!this.state.populated[stepName];
         const lastStep = i === Steps.length - 1;
         const step = <div key={`step-${stepName}`}>
-          { s.name && <h1 className="co-section-title ldap-group">{s.name}</h1> }
+          { s.name && <h2 className="co-section-heading ldap-group">{s.name}</h2> }
           { s.description && <p className="co-m-form-row">{s.description}</p> }
           { _.map(fields, FieldRow) }
           { stepName === 'Globals' && <Security /> }
@@ -520,7 +520,7 @@ const LDAPs = reduxForm({
           <button className="btn btn-primary" onClick={e => this.continue(e)} disabled={disabled}>Continue</button>
           }
           {stateMachine === STATES.updating && <div>
-            <h1 className="co-section-title ldap-group">Update Tectonic Identity</h1>
+            <h2 className="co-section-heading ldap-group">Update Tectonic Identity</h2>
             <p>
             The last step is to apply the updated configuration to the cluster.
             This is done via <code>kubectl</code> to avoid locking yourself out if something goes wrong.

--- a/frontend/public/components/clusters.tsx
+++ b/frontend/public/components/clusters.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 
 import { FLAGS, connectToFlags, flagPending } from '../features';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, detailsPage, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary, LoadingBox, MsgBox } from './utils';
+import { Cog, detailsPage, navFactory, ResourceCog, SectionHeading, ResourceLink, ResourceSummary, LoadingBox, MsgBox } from './utils';
 // eslint-disable-next-line no-unused-vars
 import { referenceForModel, apiVersionForModel } from '../module/k8s';
 import { registerTemplate } from '../yaml-templates';
@@ -52,7 +52,7 @@ const ClustersRow: React.SFC<ClustersRowProps> = ({obj}) => {
 
 const ClustersDetails: React.SFC<ClustersDetailsProps> = ({obj}) => <React.Fragment>
   <div className="co-m-pane__body">
-    <Heading text="Cluster Overview" />
+    <SectionHeading text="Cluster Overview" />
     <ResourceSummary resource={obj} showNodeSelector={false} showPodSelector={false} />
   </div>
 </React.Fragment>;

--- a/frontend/public/components/configmap-and-secret-data.jsx
+++ b/frontend/public/components/configmap-and-secret-data.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash-es';
-import { Heading, CopyToClipboard } from './utils';
+import { SectionHeading, CopyToClipboard } from './utils';
 
 export const MaskedData = () => <React.Fragment>
   <span className="sr-only">Value hidden</span>
@@ -50,7 +50,7 @@ export class SecretData extends React.PureComponent {
       dl.push(<dd key={`${k}-v`}>{value}</dd>);
     });
     return <React.Fragment>
-      <Heading text="Data">
+      <SectionHeading text="Data">
         <button className="btn btn-link" type="button" onClick={this.toggleSecret}>
           {
             showSecret
@@ -58,7 +58,7 @@ export class SecretData extends React.PureComponent {
               : <React.Fragment><i className="fa fa-eye" aria-hidden="true"></i> Reveal Values</React.Fragment>
           }
         </button>
-      </Heading>
+      </SectionHeading>
       <dl>{dl}</dl>
     </React.Fragment>;
   }

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { ConfigMapData } from './configmap-and-secret-data';
-import { Cog, Heading, navFactory, ResourceCog, ResourceLink, ResourceSummary } from './utils';
+import { Cog, SectionHeading, navFactory, ResourceCog, ResourceLink, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
 import { fromNow } from './utils/datetime';
 
@@ -45,10 +45,11 @@ const ConfigMapRow = ({obj: configMap}) => <ResourceRow obj={configMap}>
 const ConfigMapDetails = ({obj: configMap}) => {
   return <React.Fragment>
     <div className="co-m-pane__body">
+      <SectionHeading text="Config Map Overview" />
       <ResourceSummary resource={configMap} showPodSelector={false} showNodeSelector={false} />
     </div>
     <div className="co-m-pane__body">
-      <Heading text="Data" />
+      <SectionHeading text="Data" />
       <ConfigMapData data={configMap.data} />
     </div>
   </React.Fragment>;

--- a/frontend/public/components/container.jsx
+++ b/frontend/public/components/container.jsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 
 import { getContainerState, getContainerStatus, getPullPolicyLabel } from '../module/k8s/docker';
 import * as k8sProbe from '../module/k8s/probe';
-import { Firehose, Overflow, MsgBox, NavTitle, Timestamp, VertNav, ResourceLink } from './utils';
+import { SectionHeading, Firehose, Overflow, MsgBox, NavTitle, Timestamp, VertNav, ResourceLink } from './utils';
 
 const formatComputeResources = resources => _.map(resources, (v, k) => `${k}: ${v}`).join(', ');
 
@@ -149,7 +149,7 @@ const Details = (props) => {
   return <div className="co-m-pane__body">
     <div className="row">
       <div className="col-lg-4">
-        <h1 className="co-section-title">Container Overview</h1>
+        <SectionHeading text="Container Overview" />
         <dl className="co-m-pane__details">
           <dt>State</dt>
           <dd>{state.label}</dd>
@@ -177,7 +177,7 @@ const Details = (props) => {
       </div>
 
       <div className="col-lg-4">
-        <h1 className="co-section-title">Image Details</h1>
+        <SectionHeading text="Image Details" />
         <dl className="co-m-pane__details">
           <dt>Image</dt>
           <dd><Overflow value={imageName || '-'} /></dd>
@@ -193,7 +193,7 @@ const Details = (props) => {
       </div>
 
       <div className="col-lg-4">
-        <h1 className="co-section-title">Network</h1>
+        <SectionHeading text="Network" />
         <dl className="co-m-pane__details">
           <dt>Node</dt>
           <dd><ResourceLink kind="Node" name={pod.spec.nodeName} title={pod.spec.nodeName} /></dd>
@@ -207,21 +207,21 @@ const Details = (props) => {
 
     <div className="row">
       <div className="col-lg-4">
-        <h1 className="co-section-title">Ports</h1>
+        <SectionHeading text="Ports" />
         <div className="co-table-container">
           <Ports ports={container.ports} />
         </div>
       </div>
 
       <div className="col-lg-4">
-        <h1 className="co-section-title">Mounted Volumes</h1>
+        <SectionHeading text="Mounted Volumes" />
         <div className="co-table-container">
           <Volumes volumes={container.volumeMounts} />
         </div>
       </div>
 
       <div className="col-lg-4">
-        <h1 className="co-section-title">Environment Variables</h1>
+        <SectionHeading text="Environment Variables" />
         <div className="co-table-container">
           <Env env={container.env} />
         </div>

--- a/frontend/public/components/cron-job.jsx
+++ b/frontend/public/components/cron-job.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary, Timestamp } from './utils';
+import { Cog, navFactory, ResourceCog, SectionHeading, ResourceLink, ResourceSummary, Timestamp } from './utils';
 import { registerTemplate } from '../yaml-templates';
 import { ResourceEventStream } from './events';
 
@@ -62,7 +62,7 @@ const Details = ({obj: cronjob}) => {
   return <div className="co-m-pane__body">
     <div className="row">
       <div className="col-md-6">
-        <Heading text="CronJob Overview" />
+        <SectionHeading text="CronJob Overview" />
         <ResourceSummary resource={cronjob} showNodeSelector={false} showPodSelector={false} showAnnotations={false}>
           <dt>Schedule</dt>
           <dd>{cronjob.spec.schedule}</dd>
@@ -73,7 +73,7 @@ const Details = ({obj: cronjob}) => {
         </ResourceSummary>
       </div>
       <div className="col-md-6">
-        <Heading text="Job Overview" />
+        <SectionHeading text="Job Overview" />
         <ResourceSummary resource={cronjob} showNodeSelector={false}>
           <dt>Desired Completions</dt>
           <dd>{job.spec.completions || '-'}</dd>

--- a/frontend/public/components/daemonset.jsx
+++ b/frontend/public/components/daemonset.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import { Cog, LabelList, ResourceCog, ResourceLink, ResourceSummary, Selector, navFactory, detailsPage } from './utils';
+import { SectionHeading, Cog, LabelList, ResourceCog, ResourceLink, ResourceSummary, Selector, navFactory, detailsPage } from './utils';
 import { EnvironmentPage } from './environment';
 import { registerTemplate } from '../yaml-templates';
 
@@ -57,6 +57,7 @@ const DaemonSetRow = ({obj: daemonset}) => <ResourceRow obj={daemonset}>
 </ResourceRow>;
 
 const Details = ({obj: daemonset}) => <div className="co-m-pane__body">
+  <SectionHeading text="Daemon Set Overview" />
   <div className="row">
     <div className="col-lg-6">
       <ResourceSummary resource={daemonset} />

--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary, kindObj } from './utils';
+import { Cog, navFactory, ResourceCog, SectionHeading, ResourceLink, ResourceSummary, kindObj } from './utils';
 import { fromNow } from './utils/datetime';
 import { referenceFor, kindForReference } from '../module/k8s';
 
@@ -36,7 +36,7 @@ const RowForKind = kind => function RowForKind_ ({obj}) {
 const DetailsForKind = kind => function DetailsForKind_ ({obj}) {
   return <React.Fragment>
     <div className="co-m-pane__body">
-      <Heading text={`${kindForReference(kind)} Overview`} />
+      <SectionHeading text={`${kindForReference(kind)} Overview`} />
       <ResourceSummary resource={obj} podSelector="spec.podSelector" showNodeSelector={false} />
     </div>
   </React.Fragment>;

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -6,7 +6,7 @@ import { k8sCreate, K8sResourceKindReference } from '../module/k8s';
 import { errorModal } from './modals';
 import { DeploymentConfigModel } from '../models';
 import { DetailsPage, List, ListPage, WorkloadListHeader, WorkloadListRow } from './factory';
-import { Cog, DeploymentPodCounts, LoadingInline, navFactory, pluralize, ResourceSummary } from './utils';
+import { Cog, DeploymentPodCounts, SectionHeading, LoadingInline, navFactory, pluralize, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
 import { Conditions } from './conditions';
 import { EnvironmentPage } from './environment';
@@ -78,8 +78,8 @@ export const DeploymentConfigsDetails: React.SFC<{obj: any}> = ({obj: deployment
 
   return <React.Fragment>
     <div className="co-m-pane__body">
+      <SectionHeading text="Deployment Config Overview" />
       <DeploymentPodCounts resource={deploymentConfig} resourceKind={DeploymentConfigModel} />
-
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
@@ -116,11 +116,11 @@ export const DeploymentConfigsDetails: React.SFC<{obj: any}> = ({obj: deployment
       </div>
     </div>
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Containers</h1>
+      <SectionHeading text="Containers" />
       <ContainerTable containers={deploymentConfig.spec.template.spec.containers} />
     </div>
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Conditions</h1>
+      <SectionHeading text="Conditions" />
       <Conditions conditions={deploymentConfig.status.conditions} />
     </div>
   </React.Fragment>;

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash-es';
 import { DeploymentModel } from '../models';
 import { configureUpdateStrategyModal, configureRevisionHistoryLimitModal } from './modals';
 import { DetailsPage, List, ListPage, WorkloadListHeader, WorkloadListRow } from './factory';
-import { Cog, DeploymentPodCounts, LoadingInline, navFactory, Overflow, pluralize, ResourceSummary } from './utils';
+import { Cog, DeploymentPodCounts, SectionHeading, LoadingInline, navFactory, Overflow, pluralize, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
 import { Conditions } from './conditions';
 import { EnvironmentPage } from './environment';
@@ -83,8 +83,8 @@ const DeploymentDetails = ({obj: deployment}) => {
 
   return <React.Fragment>
     <div className="co-m-pane__body">
+      <SectionHeading text="Deployment Overview" />
       <DeploymentPodCounts resource={deployment} resourceKind={DeploymentModel} />
-
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
@@ -111,11 +111,11 @@ const DeploymentDetails = ({obj: deployment}) => {
       </div>
     </div>
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Containers</h1>
+      <SectionHeading text="Containers" />
       <ContainerTable containers={deployment.spec.template.spec.containers} />
     </div>
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Conditions</h1>
+      <SectionHeading text="Conditions" />
       <Conditions conditions={deployment.status.conditions} />
     </div>
   </React.Fragment>;

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -232,7 +232,7 @@ export const EnvironmentPage = connect(stateToProps)(
       const containerVars = currentEnvVars.map((envVar, i) => {
         const keyString = _.isArray(rawEnvData) ? rawEnvData[i].name : obj.metadata.name;
         return <div key={keyString} className="co-m-pane__body-group">
-          { _.isArray(rawEnvData) && <h1 className="co-section-title co-section-title--contains-resource-icon"><ResourceIcon kind="Container" className="co-m-resource-icon--align-left co-m-resource-icon--flex-child" /> {keyString}</h1> }
+          { _.isArray(rawEnvData) && <h2 className="co-section-heading co-section-heading--contains-resource-icon"><ResourceIcon kind="Container" className="co-m-resource-icon--align-left co-m-resource-icon--flex-child" /> {keyString}</h2> }
           <NameValueEditorComponent nameValueId={i} nameValuePairs={envVar} updateParentData={this.updateEnvVars} addString="Add Value" nameString="Name" readOnly={readOnly} allowSorting={true} configMaps={configMaps} secrets={secrets} />
         </div>;
       });

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -5,7 +5,7 @@ import * as _ from 'lodash-es';
 import { K8sResourceKindReference } from '../module/k8s';
 import { Conditions } from './conditions';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, LabelList, navFactory, ResourceCog, ResourceLink, ResourceSummary, Timestamp } from './utils';
+import { Cog, SectionHeading, LabelList, navFactory, ResourceCog, ResourceLink, ResourceSummary, Timestamp } from './utils';
 import { registerTemplate } from '../yaml-templates';
 import { ResourceEventStream } from './events';
 
@@ -115,7 +115,7 @@ const resourceRow = (metric, current, key) => {
 
 const MetricsTable: React.SFC<MetricsTableProps> = ({obj: hpa}) => {
   return <React.Fragment>
-    <h1 className="co-section-title">Metrics</h1>
+    <SectionHeading text="Metrics" />
     <div className="co-m-table-grid co-m-table-grid--bordered">
       <div className="row co-m-table-grid__head">
         <div className="col-xs-6">Type</div>
@@ -150,6 +150,7 @@ const MetricsTable: React.SFC<MetricsTableProps> = ({obj: hpa}) => {
 
 export const HorizontalPodAutoscalersDetails: React.SFC<HorizontalPodAutoscalersDetailsProps> = ({obj: hpa}) => <React.Fragment>
   <div className="co-m-pane__body">
+    <SectionHeading text="Horizontal Pod Autoscaler Overview" />
     <div className="row">
       <div className="col-sm-6">
         <ResourceSummary resource={hpa} showPodSelector={false} showNodeSelector={false} />
@@ -178,7 +179,7 @@ export const HorizontalPodAutoscalersDetails: React.SFC<HorizontalPodAutoscalers
     <MetricsTable obj={hpa} />
   </div>
   <div className="co-m-pane__body">
-    <h1 className="co-section-title">Conditions</h1>
+    <SectionHeading text="Conditions" />
     <Conditions conditions={hpa.status.conditions} />
   </div>
 </React.Fragment>;

--- a/frontend/public/components/image-stream-tag.tsx
+++ b/frontend/public/components/image-stream-tag.tsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash-es';
 // eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { DetailsPage } from './factory';
-import { Cog, navFactory, Overflow, ResourceSummary } from './utils';
+import { Cog, SectionHeading, navFactory, Overflow, ResourceSummary } from './utils';
 import { humanizeMem } from './utils/units';
 
 const ImageStreamTagsReference: K8sResourceKindReference = 'ImageStreamTag';
@@ -49,7 +49,7 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
     <div className="co-m-pane__body-group">
       <div className="row">
         <div className="col-md-6 col-sm-12">
-          <h1 className="co-section-title">Image Overview</h1>
+          <SectionHeading text="Image Overview" />
           <ResourceSummary resource={imageStreamTag} showPodSelector={false} showNodeSelector={false}>
             {labels.name && <dt>Image Name</dt>}
             {labels.name && <dd>{labels.name}</dd>}
@@ -60,7 +60,7 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
           </ResourceSummary>
         </div>
         <div className="col-md-6 col-sm-12">
-          <h1 className="co-section-title">Configuration</h1>
+          <SectionHeading text="Configuration" />
           <dl className="co-m-pane__details">
             {entrypoint && <dt>Entrypoint</dt>}
             {entrypoint && <dd><Overflow value={entrypoint} /></dd>}
@@ -79,7 +79,7 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
       </div>
     </div>
     <div className="co-m-pane__body-group">
-      <h1 className="co-section-title">Image Labels</h1>
+      <SectionHeading text="Image Labels" />
       {_.isEmpty(sortedLabels)
         ? <span className="text-muted">No labels</span>
         : <div className="co-table-container">
@@ -100,7 +100,7 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
         </div>}
     </div>
     <div className="co-m-pane__body-group">
-      <h1 className="co-section-title">Environment Variables</h1>
+      <SectionHeading text="Environment Variables" />
       {_.isEmpty(config.Env)
         ? <span className="text-muted">No environment variables</span>
         : <div className="co-table-container">

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash-es';
 // eslint-disable-next-line no-unused-vars
 import { K8sResourceKindReference } from '../module/k8s';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, LabelList, navFactory, Overflow, ResourceCog, ResourceLink, ResourceSummary, Timestamp } from './utils';
+import { Cog, SectionHeading, LabelList, navFactory, Overflow, ResourceCog, ResourceLink, ResourceSummary, Timestamp } from './utils';
 import { fromNow } from './utils/datetime';
 import { registerTemplate } from '../yaml-templates';
 
@@ -58,6 +58,7 @@ export const ImageStreamsDetails: React.SFC<ImageStreamsDetailsProps> = ({obj: i
 
   return <div>
     <div className="co-m-pane__body">
+      <SectionHeading text="Image Stream Overview" />
       <ResourceSummary resource={imageStream} showPodSelector={false} showNodeSelector={false}>
         {imageRepository && <dt>Image Repository</dt>}
         {imageRepository && <dd>{imageRepository}</dd>}
@@ -68,7 +69,7 @@ export const ImageStreamsDetails: React.SFC<ImageStreamsDetailsProps> = ({obj: i
       </ResourceSummary>
     </div>
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Tags</h1>
+      <SectionHeading text="Tags" />
       {_.isEmpty(imageStream.status.tags)
         ? <span className="text-muted">No tags</span>
         : <div className="row">

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import { Cog, Heading, LabelList, ResourceCog, ResourceIcon, detailsPage, EmptyBox, navFactory, ResourceLink, ResourceSummary } from './utils';
+import { Cog, SectionHeading, LabelList, ResourceCog, ResourceIcon, detailsPage, EmptyBox, navFactory, ResourceLink, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
 
 const menuActions = Cog.factory.common;
@@ -129,13 +129,14 @@ const RulesRows = (props) => {
 
 const Details = ({obj: ingress}) => <React.Fragment>
   <div className="co-m-pane__body">
+    <SectionHeading text="Ingress Overview" />
     <ResourceSummary resource={ingress} showPodSelector={false} showNodeSelector={false}>
       <dt>TLS Certificate</dt>
       <dd>{getTLSCert(ingress)}</dd>
     </ResourceSummary>
   </div>
   <div className="co-m-pane__body">
-    <Heading text="Ingress Rules" />
+    <SectionHeading text="Ingress Rules" />
     <p className="co-m-pane__explanation">These rules are handled by a routing layer (Ingress Controller) which is updated as the rules are modified. The Ingress controller implementation defines how headers and other metadata are forwarded or manipulated.</p>
     <div className="co-m-table-grid co-m-table-grid--bordered">
       <RulesHeader />

--- a/frontend/public/components/job.jsx
+++ b/frontend/public/components/job.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { getJobTypeAndCompletions } from '../module/k8s';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { configureJobParallelismModal } from './modals';
-import { Cog, Heading, LabelList, ResourceCog, ResourceLink, ResourceSummary, Timestamp, navFactory } from './utils';
+import { Cog, SectionHeading, LabelList, ResourceCog, ResourceLink, ResourceSummary, Timestamp, navFactory } from './utils';
 import { registerTemplate } from '../yaml-templates';
 import { ResourceEventStream } from './events';
 
@@ -70,7 +70,7 @@ const JobRow = ({obj: job}) => {
 const Details = ({obj: job}) => <div className="co-m-pane__body">
   <div className="row">
     <div className="col-md-6">
-      <Heading text="Job Overview" />
+      <SectionHeading text="Job Overview" />
       <ResourceSummary resource={job} showNodeSelector={false}>
         <dt>Desired Completions</dt>
         <dd>{job.spec.completions || '-'}</dd>
@@ -81,7 +81,7 @@ const Details = ({obj: job}) => <div className="co-m-pane__body">
       </ResourceSummary>
     </div>
     <div className="col-md-6">
-      <Heading text="Job Status" />
+      <SectionHeading text="Job Status" />
       <dl className="co-m-pane__details">
         <dt>Status</dt>
         <dd>{job.status.conditions ? job.status.conditions[0].type : 'In Progress'}</dd>

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -10,7 +10,7 @@ import { k8sGet } from '../module/k8s';
 import { UIActions } from '../ui/ui-actions';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { SafetyFirst } from './safety-first';
-import { Cog, Dropdown, Firehose, LabelList, LoadingInline, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary, humanizeMem, MsgBox } from './utils';
+import { Cog, Dropdown, Firehose, LabelList, LoadingInline, navFactory, ResourceCog, SectionHeading, ResourceLink, ResourceSummary, humanizeMem, MsgBox } from './utils';
 import { createNamespaceModal, createProjectModal, deleteNamespaceModal, configureNamespacePullSecretModal } from './modals';
 import { RoleBindingsPage } from './RBAC';
 import { Bar, Line, requirePrometheus } from './graphs';
@@ -141,7 +141,7 @@ class PullSecret extends SafetyFirst {
 }
 
 const ResourceUsage = requirePrometheus(({ns}) => <div className="co-m-pane__body">
-  <Heading text="Resource Usage" />
+  <SectionHeading text="Resource Usage" />
   <div className="row">
     <div className="col-sm-6 col-xs-12">
       <Line title="CPU Shares" query={[
@@ -168,7 +168,7 @@ const Details = ({obj: ns}) => {
   const requester = getRequester(ns);
   return <div>
     <div className="co-m-pane__body">
-      <Heading text="Namespace Overview" />
+      <SectionHeading text="Namespace Overview" />
       <div className="row">
         <div className="col-sm-6 col-xs-12">
           <ResourceSummary resource={ns} showPodSelector={false} showNodeSelector={false}>

--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import {ColHead, DetailsPage, List, ListHeader, ListPage} from './factory';
-import {Cog, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary, Selector} from './utils';
+import {Cog, navFactory, ResourceCog, SectionHeading, ResourceLink, ResourceSummary, Selector} from './utils';
 import { registerTemplate } from '../yaml-templates';
 
 registerTemplate('v1.NetworkPolicy', `apiVersion: networking.k8s.io/v1
@@ -114,11 +114,11 @@ const IngressRow = ({ingress, namespace, podSelector}) => {
 
 const Details = ({obj: np}) => <React.Fragment>
   <div className="co-m-pane__body">
-    <Heading text="Namespace Overview" />
+    <SectionHeading text="Namespace Overview" />
     <ResourceSummary resource={np} podSelector={'spec.podSelector'} showNodeSelector={false} />
   </div>
   <div className="co-m-pane__body">
-    <Heading text="Ingress Rules" />
+    <SectionHeading text="Ingress Rules" />
     <p className="co-m-pane__explanation">
       Pods accept all traffic by default.
       They can be isolated via Network Policies which specify a whitelist of ingress rules.

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -5,7 +5,7 @@ import { ResourceEventStream } from './events';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { configureUnschedulableModal } from './modals';
 import { PodsPage } from './pod';
-import { Cog, navFactory, LabelList, ResourceCog, Heading, ResourceLink, Timestamp, units, cloudProviderNames, cloudProviderID, pluralize, containerLinuxUpdateOperator } from './utils';
+import { Cog, navFactory, LabelList, ResourceCog, SectionHeading, ResourceLink, Timestamp, units, cloudProviderNames, cloudProviderID, pluralize, containerLinuxUpdateOperator } from './utils';
 import { Line, requirePrometheus } from './graphs';
 import { NodeModel } from '../models';
 import { CamelCaseWrap } from './utils/camel-case-wrap';
@@ -164,7 +164,7 @@ const NodeGraphs = requirePrometheus(({node}) => {
 const Details = ({obj: node}) => {
   return <React.Fragment>
     <div className="co-m-pane__body">
-      <Heading text="Node Overview" />
+      <SectionHeading text="Node Overview" />
       <NodeGraphs node={node} />
       <div className="row">
         <div className="col-md-6 col-xs-12">
@@ -210,7 +210,7 @@ const Details = ({obj: node}) => {
     </div>
 
     { containerLinuxUpdateOperator.isOperatorInstalled(node) && <div className="co-m-pane__body">
-      <h1 className="co-section-title">Container Linux</h1>
+      <SectionHeading text="Container Linux" />
       <div className="row">
         <div className="col-md-6 col-xs-12">
           <dl className="co-m-pane__details">
@@ -230,7 +230,7 @@ const Details = ({obj: node}) => {
     </div> }
 
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Node Conditions</h1>
+      <SectionHeading text="Node Conditions" />
       <div className="co-table-container">
         <table className="table">
           <thead>
@@ -256,7 +256,7 @@ const Details = ({obj: node}) => {
     </div>
 
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Images</h1>
+      <SectionHeading text="Images" />
       <div className="co-table-container">
         <table className="table">
           <thead>

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 
 import { FLAGS, connectToFlags } from '../features';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary, Selector } from './utils';
+import { Cog, navFactory, ResourceCog, SectionHeading, ResourceLink, ResourceSummary, Selector } from './utils';
 import { registerTemplate } from '../yaml-templates';
 import { ResourceEventStream } from './events';
 
@@ -75,7 +75,7 @@ const Details_ = ({flags, obj: pvc}) => {
   const storage = _.get(pvc, 'status.capacity.storage');
   const accessModes = _.get(pvc, 'status.accessModes');
   return <div className="co-m-pane__body">
-    <Heading text="PersistentVolumeClaim Overview" />
+    <SectionHeading text="PersistentVolumeClaim Overview" />
     <div className="row">
       <div className="col-sm-6">
         <ResourceSummary resource={pvc} showPodSelector={false} showNodeSelector={false}>

--- a/frontend/public/components/persistent-volume.jsx
+++ b/frontend/public/components/persistent-volume.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, LabelList, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary, Timestamp } from './utils';
+import { Cog, LabelList, navFactory, ResourceCog, SectionHeading, ResourceLink, ResourceSummary, Timestamp } from './utils';
 import { registerTemplate } from '../yaml-templates';
 
 registerTemplate('v1.PersistentVolume', `apiVersion: v1
@@ -44,7 +44,7 @@ const Row = ({obj}) => <div className="row co-resource-list__item">
 
 const Details = ({obj}) => <React.Fragment>
   <div className="co-m-pane__body">
-    <Heading text="PersistentVolume Overview" />
+    <SectionHeading text="PersistentVolume Overview" />
     <ResourceSummary resource={obj} podSelector="spec.podSelector" showNodeSelector={false} />
   </div>
 </React.Fragment>;

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -6,7 +6,7 @@ import { getVolumeType, getVolumeLocation, getVolumeMountPermissions, getVolumeM
 import { getContainerState, getContainerStatus } from '../module/k8s/docker';
 import { ResourceEventStream } from './events';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import { Cog, LabelList, navFactory, Overflow, ResourceCog, ResourceIcon, ResourceLink, ResourceSummary, Selector, Timestamp, VolumeIcon, units, AsyncComponent } from './utils';
+import { SectionHeading, Cog, LabelList, navFactory, Overflow, ResourceCog, ResourceIcon, ResourceLink, ResourceSummary, Selector, Timestamp, VolumeIcon, units, AsyncComponent } from './utils';
 import { PodLogs } from './pod-logs';
 import { registerTemplate } from '../yaml-templates';
 import { Line, requirePrometheus } from './graphs';
@@ -134,7 +134,7 @@ const Volume = ({pod, volume}) => {
 };
 
 const ContainerTable = ({heading, containers, pod}) => <div className="co-m-pane__body">
-  <h1 className="co-section-title">{heading}</h1>
+  <SectionHeading text={heading} />
   <div className="row">
     <div className="co-m-table-grid co-m-table-grid--bordered">
       <div className="row co-m-table-grid__head">
@@ -187,7 +187,7 @@ const Details = ({obj: pod}) => {
 
   return <React.Fragment>
     <div className="co-m-pane__body">
-      <h1 className="co-m-pane__heading">Pod Overview</h1>
+      <SectionHeading text="Pod Overview" />
       <PodGraphs pod={pod} />
       <div className="row">
         <div className="col-sm-6">
@@ -231,7 +231,7 @@ const Details = ({obj: pod}) => {
     <ContainerTable key="containerTable" heading="Containers" containers={pod.spec.containers} pod={pod} />
 
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Pod Volumes</h1>
+      <SectionHeading text="Pod Volumes" />
       <div className="row">
         <div className="co-m-table-grid co-m-table-grid--bordered">
           <div className="row co-m-table-grid__head">

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { DetailsPage, List, ListPage, WorkloadListHeader, WorkloadListRow } from './factory';
-import { Cog, navFactory, Heading, ResourceSummary, ResourcePodCount } from './utils';
+import { Cog, navFactory, SectionHeading, ResourceSummary, ResourcePodCount } from './utils';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { registerTemplate } from '../yaml-templates';
 import { EnvironmentPage } from './environment';
@@ -33,7 +33,7 @@ export const replicaSetMenuActions = [ModifyCount, ModifyNodeSelector, EditEnvir
 
 const Details = ({obj: replicaSet}) => <React.Fragment>
   <div className="co-m-pane__body">
-    <Heading text="Replica Set Overview" />
+    <SectionHeading text="Replica Set Overview" />
     <div className="row">
       <div className="col-md-6">
         <ResourceSummary resource={replicaSet} />

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { ResourceEventStream } from './events';
 import { DetailsPage, List, ListPage, WorkloadListHeader, WorkloadListRow } from './factory';
 import { replicaSetMenuActions } from './replicaset';
-import { navFactory, Heading, ResourceSummary, ResourcePodCount } from './utils';
+import { navFactory, SectionHeading, ResourceSummary, ResourcePodCount } from './utils';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { registerTemplate } from '../yaml-templates';
 import { EnvironmentPage } from './environment';
@@ -31,7 +31,7 @@ spec:
 
 const Details = ({obj: replicationController}) => <React.Fragment>
   <div className="co-m-pane__body">
-    <Heading text="Replication Controller Overview" />
+    <SectionHeading text="Replication Controller Overview" />
     <div className="row">
       <div className="col-md-6">
         <ResourceSummary resource={replicationController} />

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary } from './utils';
+import { Cog, SectionHeading, navFactory, ResourceCog, ResourceLink, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
 
 registerTemplate('v1.ResourceQuota', `apiVersion: v1
@@ -38,7 +38,7 @@ const Row = ({obj: rq}) => <div className="row co-resource-list__item">
 
 const Details = ({obj: rq}) => <React.Fragment>
   <div className="co-m-pane__body">
-    <Heading text="ResourceQuota Overview" />
+    <SectionHeading text="Resource Quota Overview" />
     <ResourceSummary resource={rq} podSelector="spec.podSelector" showNodeSelector={false} />
   </div>
 </React.Fragment>;

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import { Cog, CopyToClipboard, ResourceCog, detailsPage, navFactory, ResourceLink, ResourceSummary } from './utils';
+import { Cog, CopyToClipboard, SectionHeading, ResourceCog, detailsPage, navFactory, ResourceLink, ResourceSummary } from './utils';
 import { MaskedData } from './configmap-and-secret-data';
 
 import { registerTemplate } from '../yaml-templates';
@@ -226,20 +226,21 @@ const RouteIngressStatus: React.SFC<RouteIngressStatusProps> = ({ingresses}) =>
   <React.Fragment>
     {_.map(ingresses, (ingress) =>
       <div key={ingress.routerName} className="co-m-route-ingress-status">
-        <h1 className="co-section-title">Router: {ingress.routerName}</h1>
+        <SectionHeading text={`Router: ${ingress.routerName}`} />
         <dl>
           <dt>Hostname</dt>
           <dd>{ingress.host}</dd>
           <dt>Wildcard Policy</dt>
           <dd>{ingress.wildcardPolicy}</dd>
         </dl>
-        <h2 className="co-section-title-secondary">Conditions</h2>
+        <h3 className="co-section-heading-secondary">Conditions</h3>
         <Conditions conditions={ingress.conditions} />
       </div>)}
   </React.Fragment>;
 
 const RouteDetails: React.SFC<RoutesDetailsProps> = ({obj: route}) => <React.Fragment>
   <div className="co-m-pane__body">
+    <SectionHeading text="Route Overview" />
     <div className="row">
       <div className="col-sm-6">
         <ResourceSummary resource={route} showPodSelector={false} showNodeSelector={false}>
@@ -266,11 +267,11 @@ const RouteDetails: React.SFC<RoutesDetailsProps> = ({obj: route}) => <React.Fra
     </div>
   </div>
   <div className="co-m-pane__body">
-    <h1 className="co-section-title">TLS Settings</h1>
+    <SectionHeading text="TLS Settings" />
     <TLSSettings tls={route.spec.tls} />
   </div>
   { !_.isEmpty(route.spec.alternateBackends) && <div className="co-m-pane__body">
-    <h1 className="co-section-title">Traffic</h1>
+    <SectionHeading text="Traffic" />
     <p className="co-m-pane__explanation">
       This route splits traffic across multiple services.
     </p>

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { SecretData } from './configmap-and-secret-data';
-import { Cog, ResourceCog, ResourceLink, ResourceSummary, detailsPage, navFactory, resourceObjPath } from './utils';
+import { Cog, SectionHeading, ResourceCog, ResourceLink, ResourceSummary, detailsPage, navFactory, resourceObjPath } from './utils';
 import { fromNow } from './utils/datetime';
 import { registerTemplate } from '../yaml-templates';
 import { SecretType } from './secrets/create-secret';
@@ -73,6 +73,7 @@ const SecretRow = ({obj: secret}) => {
 const SecretDetails = ({obj: secret}) => {
   return <React.Fragment>
     <div className="co-m-pane__body">
+      <SectionHeading text="Secret Overview" />
       <ResourceSummary resource={secret} showPodSelector={false} showNodeSelector={false} />
     </div>
     <div className="co-m-pane__body">

--- a/frontend/public/components/secscan/pod-vuln.jsx
+++ b/frontend/public/components/secscan/pod-vuln.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 import { ContainerRow } from '../pod';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from '../factory';
-import { MsgBox, navFactory, Overflow, ResourceIcon, ResourceLink, ResourceSummary, Timestamp } from '../utils';
+import { SectionHeading, MsgBox, navFactory, Overflow, ResourceIcon, ResourceLink, ResourceSummary, Timestamp } from '../utils';
 import { isScanned, isSupported, imagesScanned, hasAccess, makePodvuln, CountVulnerabilityFilter, severityBreakdownInfo } from '../../module/k8s/podvulns';
 import { AsyncComponent } from '../utils/async';
 
@@ -162,7 +162,7 @@ const Details = ({obj: pod}) => {
 
   return <React.Fragment>
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Pod Vulnerability Overview</h1>
+      <SectionHeading text="Pod Vulnerability Overview" />
       <div className="row">
         <div className="col-sm-8 col-xs-12">
           <div className="row">
@@ -187,7 +187,7 @@ const Details = ({obj: pod}) => {
     </div>
 
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Containers</h1>
+      <SectionHeading text="Containers" />
       <div className="co-m-table-grid co-m-table-grid--bordered">
         <div className="row co-m-table-grid__head">
           <div className="col-sm-2 col-xs-4">Name</div>
@@ -205,7 +205,7 @@ const Details = ({obj: pod}) => {
     </div>
 
     <div className="co-m-pane__body">
-      <h1 className="co-section-title">Container Vulnerabilities</h1>
+      <SectionHeading text="Container Vulnerabilities" />
       <div className="co-m-table-grid co-m-table-grid--bordered">
         <div className="row co-m-table-grid__head">
           <div className="col-sm-2 col-xs-4">CVE</div>

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { safeDump } from 'js-yaml';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import { Cog, navFactory, NavTitle, ResourceCog, ResourceLink, ResourceSummary } from './utils';
+import { Cog, SectionHeading, navFactory, ResourceCog, ResourceLink, ResourceSummary } from './utils';
 import { fromNow } from './utils/datetime';
 import { k8sGet } from '../module/k8s';
 import { SecretModel } from '../models';
@@ -105,9 +105,10 @@ const Details = ({obj: serviceaccount}) => {
   return (
     <React.Fragment>
       <div className="co-m-pane__body">
+        <SectionHeading text="Service Account Overview" />
         <ResourceSummary resource={serviceaccount} showPodSelector={false} showNodeSelector={false} />
       </div>
-      <NavTitle title="Secrets" />
+      <SectionHeading text="Secrets" style={{marginLeft: '30px', marginTop: '30px', marginBottom: '-20px'}} />
       <SecretsPage kind="Secret" canCreate={false} namespace={namespace} filters={filters} autoFocus={false} showTitle={false} />
     </React.Fragment>
   );

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import { Cog, navFactory, LabelList, ResourceCog, Heading, ResourceIcon, ResourceLink, ResourceSummary, Selector } from './utils';
+import { Cog, navFactory, LabelList, ResourceCog, SectionHeading, ResourceIcon, ResourceLink, ResourceSummary, Selector } from './utils';
 import { registerTemplate } from '../yaml-templates';
 
 registerTemplate('v1.Service', `apiVersion: v1
@@ -114,14 +114,14 @@ const ServicePortMapping = ({s}) => <div>
 const Details = ({obj: s}) => <div className="co-m-pane__body">
   <div className="row">
     <div className="col-sm-6">
-      <Heading text="Service Overview" />
+      <SectionHeading text="Service Overview" />
       <ResourceSummary resource={s} showNodeSelector={false}>
         <dt>Session Affinity</dt>
         <dd>{s.spec.sessionAffinity || '-'}</dd>
       </ResourceSummary>
     </div>
     <div className="col-sm-6">
-      <Heading text="Service Routing" />
+      <SectionHeading text="Service Routing" />
       <dl>
         <dt>Service Address</dt>
         <dd className="service-ips">

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary } from './utils';
+import { Cog, navFactory, ResourceCog, SectionHeading, ResourceLink, ResourceSummary } from './utils';
 import { registerTemplate } from '../yaml-templates';
 import { EnvironmentPage } from './environment';
 import { ResourceEventStream } from './events';
@@ -63,7 +63,7 @@ const Row = ({obj: ss}) => <div className="row co-resource-list__item">
 
 const Details = ({obj: ss}) => <React.Fragment>
   <div className="co-m-pane__body">
-    <Heading text="StatefulSet Overview" />
+    <SectionHeading text="StatefulSet Overview" />
     <ResourceSummary resource={ss} showNodeSelector={false} />
   </div>
 </React.Fragment>;

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Cog, detailsPage, navFactory, ResourceCog, Heading, ResourceLink, ResourceSummary } from './utils';
+import { Cog, detailsPage, navFactory, ResourceCog, SectionHeading, ResourceLink, ResourceSummary } from './utils';
 import { fromNow } from './utils/datetime';
 // eslint-disable-next-line no-unused-vars
 import { K8sResourceKindReference } from '../module/k8s';
@@ -48,7 +48,7 @@ const StorageClassRow: React.SFC<StorageClassRowProps> = ({obj}) => {
 
 const StorageClassDetails: React.SFC<StorageClassDetailsProps> = ({obj}) => <React.Fragment>
   <div className="co-m-pane__body">
-    <Heading text="StorageClass Overview" />
+    <SectionHeading text="StorageClass Overview" />
     <ResourceSummary resource={obj} showNodeSelector={false} showPodSelector={false} />
   </div>
 </React.Fragment>;

--- a/frontend/public/components/utils/build-hooks.tsx
+++ b/frontend/public/components/utils/build-hooks.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 
 import { K8sResourceKind } from '../../module/k8s';
+import { SectionHeading } from '.';
 
 export const BuildHooks: React.SFC<BuildHooksProps> = ({ resource }) => {
   const postCommitArgs = _.get(resource, 'spec.postCommit.args');
@@ -10,7 +11,7 @@ export const BuildHooks: React.SFC<BuildHooksProps> = ({ resource }) => {
 
   return (!_.isEmpty(postCommitCommand) || !_.isEmpty(postCommitArgs) || postCommitScript)
     ? <div className="co-m-pane__body">
-      <h1 className="co-section-title">Post-Commit Hooks</h1>
+      <SectionHeading text="Post-Commit Hooks" />
       <dl className="co-m-pane__details">
         {!_.isEmpty(postCommitCommand) && <dt>Command</dt>}
         {!_.isEmpty(postCommitCommand) && <dd><code>{postCommitCommand.join(' ')}</code></dd>}

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -10,8 +10,6 @@ export const detailsPage = <T extends {}>(Component: React.ComponentType<T>) => 
   return <Component {...props} />;
 };
 
-export const Heading: React.SFC<HeadingProps> = ({text, children}) => <h1 className="co-m-pane__heading">{text}{children}</h1>;
-
 export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, resource, showPodSelector = true, showNodeSelector = true, showAnnotations = true, podSelector = 'spec.selector'}) => {
   const { metadata, type } = resource;
   const owners = (_.get(metadata, 'ownerReferences') || [])
@@ -48,11 +46,6 @@ export const ResourcePodCount: React.SFC<ResourcePodCountProps> = ({resource}) =
 </dl>;
 
 /* eslint-disable no-undef */
-export type HeadingProps = {
-  text: string;
-  children?: any;
-};
-
 export type ResourceSummaryProps = {
   resource: K8sResourceKind;
   showPodSelector?: boolean;
@@ -67,6 +60,5 @@ export type ResourcePodCountProps = {
 };
 /* eslint-enable no-undef */
 
-Heading.displayName = 'Heading';
 ResourceSummary.displayName = 'ResourceSummary';
 ResourcePodCount.displayName = 'ResourcePodCount';

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -40,6 +40,7 @@ export * from './build-strategy';
 export * from './copy-to-clipboard';
 export * from './build-hooks';
 export * from './webhooks';
+export * from './section-heading';
 
 /*
   Add the enum for NameValueEditorPair here and not in its namesake file because the editor should always be

--- a/frontend/public/components/utils/section-heading.tsx
+++ b/frontend/public/components/utils/section-heading.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+export const SectionHeading: React.SFC<SectionHeadingProps> = ({text, children, style}) => <h2 className="co-section-heading" style={style}>{text}{children}</h2>;
+
+/* eslint-disable no-undef */
+export type SectionHeadingProps = {
+  text: string;
+  children?: any;
+  style?: any;
+};
+
+/* eslint-enable no-undef */
+SectionHeading.displayName = 'SectionHeading';

--- a/frontend/public/components/utils/webhooks.tsx
+++ b/frontend/public/components/utils/webhooks.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 
 import { K8sResourceKind } from '../../module/k8s';
-import { ResourceLink } from './';
+import { SectionHeading, ResourceLink } from '.';
 import { Overflow } from './overflow';
 
 const kubeAPIServerURL = (window as any).SERVER_FLAGS.kubeAPIServerURL || 'https://<api-server>';
@@ -46,7 +46,7 @@ export const WebhookTriggers: React.SFC<WebhookTriggersProps> = ({ resource }) =
   };
 
   return <div className="co-m-pane__body">
-    <h1 className="co-section-title">Webhooks</h1>
+    <SectionHeading text="Webhooks" />
     <div className="co-table-container">
       <table className="table">
         <colgroup>

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -97,17 +97,19 @@
   color: $red;
 }
 
-.co-section-title {
+.co-section-heading {
+  display: flex;
   font-size: 20px;
   font-weight: 600;
+  justify-content: space-between;
   margin: 0 0 20px 0;
   &--contains-resource-icon {
     align-items: center;
-    display: flex;
+    justify-content: flex-start;
   }
 }
 
-.co-section-title-secondary {
+.co-section-heading-secondary {
   font-size: 16px;
   font-weight: 600;
   margin: 30px 0;


### PR DESCRIPTION
Set `<Heading>` to `<h2 className="co-m-pane__heading co-section-heading">`
Switch to <Heading> component where not used
Add headings where missing

http://jira.coreos.com/browse/CONSOLE-570

---

Proposed markup and visuals. If these are good, i'll move forward to apply consistently across pages.

Primary page heading => `h1`
Section heading => `h2`

![pod-details-heading-changes](https://user-images.githubusercontent.com/1874151/42772271-f08c4582-88f7-11e8-9b8d-53e0600c60ba.png)

@tlwu2013
cc @spadgett @rhamilto 
