### PR TITLE
Fix scroll issue on empty event stream

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -2,6 +2,7 @@ $color-dark-border: #ddd;
 
 .co-sysevent-stream {
   padding: 60px 0 50px 0;
+  position: relative;
 }
 
 .slide-entering {

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -385,30 +385,31 @@ class EventStream extends SafetyFirst {
           There are no events before <Timestamp timestamp={this.state.oldestTimestamp} />
           </div>
         </div>
-
-        <WindowScroller>
-          {({height, isScrolling, registerChild, onChildScroll, scrollTop}) =>
-            <AutoSizer disableHeight>
-              {({width}) => <div ref={registerChild}>
-                <VirtualList
-                  autoHeight
-                  data={filteredMessages}
-                  height={height}
-                  isScrolling={isScrolling}
-                  onScroll={onChildScroll}
-                  rowRenderer={this.rowRenderer}
-                  scrollTop={scrollTop}
-                  width={width}
-                  rowCount={count}
-                  tabIndex={null}
-                  // TODO: set rowHeight based on media query
-                  // @media screen and (min-width: 768px)...
-                  // rowHeight={width > 548 ? 135 : 250}
-                  rowHeight={135}
-                />
-              </div>}
-            </AutoSizer> }
-        </WindowScroller>
+        { count > 0 &&
+            <WindowScroller>
+              {({height, isScrolling, registerChild, onChildScroll, scrollTop}) =>
+                <AutoSizer disableHeight>
+                  {({width}) => <div ref={registerChild}>
+                    <VirtualList
+                      autoHeight
+                      data={filteredMessages}
+                      height={height}
+                      isScrolling={isScrolling}
+                      onScroll={onChildScroll}
+                      rowRenderer={this.rowRenderer}
+                      scrollTop={scrollTop}
+                      width={width}
+                      rowCount={count}
+                      tabIndex={null}
+                      // TODO: set rowHeight based on media query
+                      // @media screen and (min-width: 768px)...
+                      // rowHeight={width > 548 ? 135 : 250}
+                      rowHeight={135}
+                    />
+                  </div>}
+                </AutoSizer> }
+            </WindowScroller>
+        }
         { sysEventStatus }
       </div>
     </div>;


### PR DESCRIPTION
Only use react-virtualized if there are actually events to render. WindowScroller component causes strange scrolling behavior when other content is rendered below the event list.