### PR TITLE
Set co-resource-list__item text alignment to top, since it has display flex the default alignment is flex-start.

### DIFF
--- a/frontend/public/components/_list.scss
+++ b/frontend/public/components/_list.scss
@@ -27,7 +27,6 @@
 }
 
 .co-resource-list__item {
-  align-items: center;
   display: flex;
   flex-wrap: wrap;
   height: 100%;


### PR DESCRIPTION
@spadgett 
fixes https://github.com/openshift/console/issues/234

a few pages for reference.
<img width="992" alt="screen shot 2018-07-16 at 2 56 31 pm" src="https://user-images.githubusercontent.com/1874151/42778052-da72b3aa-8909-11e8-9301-52aea471df9b.png">
<img width="1007" alt="screen shot 2018-07-16 at 2 56 01 pm" src="https://user-images.githubusercontent.com/1874151/42778053-da7d2e70-8909-11e8-93e7-b8844905c430.png">
<img width="891" alt="screen shot 2018-07-16 at 2 52 33 pm" src="https://user-images.githubusercontent.com/1874151/42778055-da977708-8909-11e8-8295-decb4fdc9fec.png">
