### PR TITLE
Remove display:flex and flex-wrap:wrap from resource-list.

### DIFF
--- a/frontend/public/components/_list.scss
+++ b/frontend/public/components/_list.scss
@@ -27,8 +27,6 @@
 }
 
 .co-resource-list__item {
-  display: flex;
-  flex-wrap: wrap;
   height: 100%;
   transition: all 0.25s;
 }


### PR DESCRIPTION
`flex-wrap:wrap` can not be used around a bootstap row columns. It causes the last column to wrap incorrectly in Safari.
Fixes https://jira.coreos.com/browse/CONSOLE-622

This pr removes display:flex and align-items:center. Since row contents should be top aligned so those styles are not needed. These styles were carried over from `.middler ` which was removed in a [previous pr](https://github.com/openshift/console/commit/f2466203b570fa29c98d34e58531adf9a24a1e32#diff-8465e1dd4367eb1a79d891349e2d7f26L16).


Fixes https://github.com/openshift/console/issues/234
<img width="463" alt="screen shot 2018-07-16 at 6 02 31 pm" src="https://user-images.githubusercontent.com/1874151/42785979-719485fc-8922-11e8-8784-22b5e57a09dc.png">

---

`.middler` wrapper was used on these pages [before being removed ](https://github.com/openshift/console/commit/f2466203b570fa29c98d34e58531adf9a24a1e32
) and vertically centered `col-* `contents.
frontend/public/components/image-stream.tsx
frontend/public/components/node.jsx
frontend/public/components/pod.jsx
frontend/public/components/secscan/pod-vuln.jsx

<img width="811" alt="screen shot 2018-07-16 at 5 55 28 pm" src="https://user-images.githubusercontent.com/1874151/42785812-ca46710c-8921-11e8-8cca-519c4aa5f4b1.png">


