### PR TITLE
Show resource requests and readiness probes for containers

### DIFF
--- a/frontend/public/module/k8s/probe.js
+++ b/frontend/public/module/k8s/probe.js
@@ -169,7 +169,7 @@ export const mapLifecycleConfigToFields = function(c) {
   return f;
 };
 
-export const mapLivenessProbeToFields = function(c, podIP) {
+export const mapProbeToFields = function(c, podIP) {
   const f = {
     initialDelaySeconds: '',
     type: 'exec',


### PR DESCRIPTION
We were previously showing limits and liveness probes, but not requests
and readiness probes. Use `pre` tags for multiline probe commands.

![openshift origin 2018-07-17 07-30-43](https://user-images.githubusercontent.com/1167259/42814821-72087270-8993-11e8-85a3-2b70c515f392.png)

/assign @rhamilto 