### PR TITLE
Improve new user experience for Roles and Role Bindings pages

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -156,34 +156,39 @@ const roleResources = [
   {kind: 'ClusterRoleBinding', namespaced: false, optional: true},
 ];
 
-export const RoleBindingsPage = ({namespace, showTitle=true}) => <MultiListPage
-  ListComponent={BindingsList}
-  canCreate={true}
-  createButtonText="Create Binding"
-  createProps={{to: '/k8s/cluster/rolebindings/new'}}
-  filterLabel="Role Bindings by role or subject"
-  resources={roleResources}
-  rowFilters={[{
-    type: 'role-binding-kind',
-    selected: ['cluster', 'namespace'],
-    reducer: bindingType,
-    items: ({ClusterRoleBinding: data}) => {
-      const items = [
-        {id: 'namespace', title: 'Namespace Role Bindings'},
-        {id: 'system', title: 'System Role Bindings'},
-      ];
-      if (data && data.loaded && !data.loadError) {
-        items.unshift({id: 'cluster', title: 'Cluster-wide Role Bindings'});
-      }
-      return items;
-    },
-  }]}
-  namespace={namespace}
-  flatten={flatten}
-  textFilter="role-binding"
-  title="Role Bindings"
-  showTitle={showTitle}
-/>;
+export const RoleBindingsPage = ({namespace, showTitle=true, fake, kind}) => {
+  const {labelPlural} = kindObj(kind);
+  return <MultiListPage
+    canCreate={true}
+    createButtonText="Create Binding"
+    createProps={{to: '/k8s/cluster/rolebindings/new'}}
+    fake={fake}
+    filterLabel="Role Bindings by role or subject"
+    flatten={flatten}
+    label={labelPlural}
+    ListComponent={BindingsList}
+    namespace={namespace}
+    resources={roleResources}
+    rowFilters={[{
+      type: 'role-binding-kind',
+      selected: ['cluster', 'namespace'],
+      reducer: bindingType,
+      items: ({ClusterRoleBinding: data}) => {
+        const items = [
+          {id: 'namespace', title: 'Namespace Role Bindings'},
+          {id: 'system', title: 'System Role Bindings'},
+        ];
+        if (data && data.loaded && !data.loadError) {
+          items.unshift({id: 'cluster', title: 'Cluster-wide Role Bindings'});
+        }
+        return items;
+      },
+    }]}
+    showTitle={showTitle}
+    textFilter="role-binding"
+    title="Role Bindings"
+  />;
+};
 
 class ListDropdown_ extends React.Component {
   constructor (props) {

--- a/frontend/public/components/_cluster-overview.scss
+++ b/frontend/public/components/_cluster-overview.scss
@@ -2,21 +2,6 @@
   margin-bottom: ($grid-gutter-width / 2);
 }
 
-.group.group--fake::before {
-  background-color: #fff;
-  bottom: 0;
-  content: '';
-  cursor: not-allowed;
-  left: 0;
-  opacity: 0.4;
-  overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 0;
-  user-select: none;
-  z-index: 10;
-}
-
 .group__title {
   border: 1px solid $color-grey-background-border;
   background-color: $color-grey-background;
@@ -30,6 +15,7 @@
     margin: 0;
   }
 }
+
 .group__body {
   border: 1px solid $color-grey-background-border;
   border-top: none;
@@ -47,7 +33,6 @@
 .group__graphs {
   overflow: hidden;
 }
-
 
 .cluster-overview-cell {
   margin-top: -($grid-gutter-width / 2);

--- a/frontend/public/components/_list.scss
+++ b/frontend/public/components/_list.scss
@@ -35,20 +35,6 @@
   margin-right: 0 !important;
 }
 
-.fake-list {
-  user-select: none;
-  position: absolute;
-  opacity: 0.4;
-  background-color: #fff;
-  z-index: 10;
-  cursor: not-allowed;
-  overflow: hidden;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-}
-
 .co-m-cog__dropdown {
   margin-bottom: 10px;
 }

--- a/frontend/public/components/cluster-overview.jsx
+++ b/frontend/public/components/cluster-overview.jsx
@@ -155,7 +155,7 @@ const GraphsPage = ({fake, limited, namespace, openshiftFlag}) => {
   const body = <div className="row">
     <div className="col-lg-8 col-md-12">
       {!fake && graphs}
-      <div className={classNames('group', {'group--fake': fake})}>
+      <div className={classNames('group', {'co-disabled': fake})}>
         <div className="group__title">
           <h2 className="h3">Events</h2>
           <a href={formatNamespacedRouteForResource('events', namespace)}>View All</a>

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -7,7 +7,7 @@ import * as PropTypes from 'prop-types';
 
 import k8sActions from '../../module/k8s/k8s-actions';
 import { CheckBoxes, storagePrefix } from '../row-filter';
-import { Dropdown, Firehose, kindObj, NavTitle, history, inject} from '../utils';
+import { Dropdown, Firehose, kindObj, NavTitle, history, inject, Disabled} from '../utils';
 import { ErrorPage404 } from '../error';
 import { makeReduxID, makeQuery } from '../utils/k8s-watcher';
 import { referenceForModel } from '../../module/k8s';
@@ -309,10 +309,7 @@ export const MultiListPage = props => {
       <ListPageWrapper_ ListComponent={props.ListComponent} kinds={_.map(resources, 'kind')} rowFilters={props.rowFilters} staticFilters={props.staticFilters} flatten={flatten} label={props.label} fake={fake} />
     </Firehose>
   </FireMan_>;
-  if (fake) {
-    return <div style={{position: 'relative'}}><div className="fake-list" />{elems}</div>;
-  }
-  return elems;
+  return fake ? <Disabled>{elems}</Disabled> : elems;
 };
 
 MultiListPage.displayName = 'MultiListPage';

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -15,7 +15,7 @@ import { OpenShiftGettingStarted } from './start-guide';
 const allParams = props => Object.assign({}, _.get(props, 'match.params'), props);
 
 const ResourceListPage_ = connectToPlural((props: ResourceListPageProps) => {
-  const { ns, kindObj, kindsInFlight, flags } = allParams(props);
+  const { flags, kindObj, kindsInFlight, modelRef, ns } = allParams(props);
 
   if (!kindObj) {
     if (kindsInFlight) {
@@ -38,7 +38,7 @@ const ResourceListPage_ = connectToPlural((props: ResourceListPageProps) => {
     <Helmet>
       <title>{kindObj.labelPlural}</title>
     </Helmet>
-    {PageComponent && <PageComponent match={props.match} namespace={ns} kind={props.modelRef} fake={showGettingStarted}/>}
+    {PageComponent && <PageComponent fake={showGettingStarted} flags={flags} kind={modelRef} match={props.match} namespace={ns} />}
   </div>;
 });
 

--- a/frontend/public/components/utils/_disabled.scss
+++ b/frontend/public/components/utils/_disabled.scss
@@ -1,0 +1,18 @@
+.co-disabled {
+  position: relative;
+}
+
+.co-disabled::before {
+  background-color: #fff;
+  bottom: 0;
+  content: '';
+  cursor: not-allowed;
+  left: 0;
+  opacity: 0.4;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 0;
+  user-select: none;
+  z-index: 10;
+}

--- a/frontend/public/components/utils/disabled.tsx
+++ b/frontend/public/components/utils/disabled.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export const Disabled = (props) => <div className="co-disabled">
+  {props.children}
+</div>;

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -12,6 +12,7 @@ export * from './timestamp';
 export * from './vertnav';
 export * from './details-page';
 export * from './inject';
+export * from './disabled';
 export * from './file-input';
 export * from './firehose';
 export * from './dropdown';

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -34,6 +34,7 @@
 
 // React Components
 @import "components/utils/copy-to-clipboard";
+@import "components/utils/disabled";
 @import "components/utils/file-input";
 @import "components/utils/label";
 @import "components/utils/number-spinner";


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1601335
Roles page will now display cluster level roles to basic user even if user has no projects
Role Bindings page now shows the same getting started and disabled list experience as other workload resource list pages.

Refactored the way 'fake' list styling was accomplished. Implemented `Disabled` component which can be used to wrap any other element to make it appear disabled. The `.disabled` css class can also be used in the same way.