### PR TITLE
frontend: Modify "no events" message

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -318,7 +318,7 @@ class EventStream extends SafetyFirst {
   }
 
   render () {
-    const { fake } = this.props;
+    const { fake, resourceEventStream } = this.props;
     const {active, error, loading, filteredMessages, sortedMessages} = this.state;
     const count = filteredMessages.length;
     const allCount = sortedMessages.length;
@@ -326,7 +326,7 @@ class EventStream extends SafetyFirst {
     const noMatches = allCount > 0 && count === 0;
     let sysEventStatus, statusBtnTxt;
 
-    if (noEvents || fake) {
+    if (noEvents || fake || (noMatches && resourceEventStream)) {
       sysEventStatus = (
         <Box className="co-sysevent-stream__status-box-empty">
           <div className="text-center cos-status-box__detail">
@@ -335,7 +335,7 @@ class EventStream extends SafetyFirst {
         </Box>
       );
     }
-    if (noMatches) {
+    if (noMatches && !resourceEventStream) {
       sysEventStatus = (
         <Box className="co-sysevent-stream__status-box-empty">
           <div className="cos-status-box__title">No Matching Events</div>
@@ -433,4 +433,4 @@ EventStream.propTypes = {
 };
 
 
-export const ResourceEventStream = ({obj: {kind, metadata: {name, namespace}}}) => <EventStream filter={{name, kind}} namespace={namespace} />;
+export const ResourceEventStream = ({obj: {kind, metadata: {name, namespace}}}) => <EventStream filter={{name, kind}} namespace={namespace} resourceEventStream />;


### PR DESCRIPTION
Fixes [CONSOLE-617](https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-617?filter=myopenissues).

Changed resource events tab "events exist, but none match the current filter" message to the message used when there are no events - "No Events in the past hour."

Events:

![screen shot 2018-07-17 at 1 52 51 pm](https://user-images.githubusercontent.com/7014965/42836370-de3c0dd2-89c8-11e8-90a5-157d2e7f68ee.png)

No events:

![screen shot 2018-07-17 at 1 52 31 pm](https://user-images.githubusercontent.com/7014965/42836375-e22fa552-89c8-11e8-85ec-9cecca5a4363.png)
