### PR TITLE
Search View Displays Resources from API Discovery

### DIFF
--- a/frontend/integration-tests/tests/filter.scenario.ts
+++ b/frontend/integration-tests/tests/filter.scenario.ts
@@ -1,17 +1,17 @@
-import { browser, ExpectedConditions as until, Key} from 'protractor';
+import { browser, ExpectedConditions as until, Key } from 'protractor';
 import { safeLoad, safeDump } from 'js-yaml';
 import * as _ from 'lodash';
 
 import { appHost, testName, checkLogs, checkErrors } from '../protractor.conf';
 import * as crudView from '../views/crud.view';
-import * as search from '../views/search.view';
+import * as searchView from '../views/search.view';
 import * as yamlView from '../views/yaml.view';
 
 const BROWSER_TIMEOUT = 15000;
 const WORKLOAD_NAME = `filter-${testName}`;
 const WORKLOAD_LABEL = `lbl-filter=${testName}`;
 
-describe('Filter', () => {
+describe('Filtering', () => {
 
   beforeAll(async() => {
     await browser.get(`${appHost}/k8s/ns/${testName}/daemonsets`);
@@ -37,17 +37,7 @@ describe('Filter', () => {
     await crudView.deleteRow('daemonset')(WORKLOAD_NAME);
   });
 
-  // Scenario: Filter Pod from object detail
-  // Given I log in into the console if it's required
-  //   And I select the namespace "default"
-  //   And I create a daemon set called "example"
-  //   And I go to the daemon sets list page
-  //   And I type "example" in the filter
-  //   And I go to the detail on the daemonset "example"
-  //   And I go to Pods tabdropdownLinks
-  //  When I type "example" in the filter
-  //  Then I expect to see one pod whose name starts with "example" listed in the results
-  it('Filter Pod from object detail', async() => {
+  it('filters Pod from object detail', async() => {
     await browser.get(`${appHost}/k8s/ns/${testName}/daemonsets`);
     await browser.wait(until.elementToBeClickable(crudView.resourceRowNamesAndNs.first()), BROWSER_TIMEOUT);
     expect(crudView.resourceRowNamesAndNs.first().getText()).toContain(WORKLOAD_NAME);
@@ -59,17 +49,7 @@ describe('Filter', () => {
     expect(crudView.resourceRowNamesAndNs.first().getText()).toContain(WORKLOAD_NAME);
   });
 
-  // Scenario: Filter invalid Pod from object detail
-  // Given I log in into the console if it's required
-  //   And I select the namespace "default"
-  //   And I create a daemon set called "example"
-  //   And I go to the daemon sets list pageprotractor
-  //   And I type "example" in the filter
-  //   And I go to the detail on the daemonset "example"
-  //   And I go to Pods tab
-  //  When I type "XYZ123" in the filter
-  //  Then I expect to see the message "No Pods Found"
-  it('Filter invalid Pod from object detail', async() => {
+  it('filters invalid Pod from object detail', async() => {
     await browser.get(`${appHost}/k8s/ns/${testName}/daemonsets/${WORKLOAD_NAME}/pods`);
     await browser.wait(until.elementToBeClickable(crudView.nameFilter), BROWSER_TIMEOUT);
     await crudView.nameFilter.sendKeys('XYZ123');
@@ -77,15 +57,7 @@ describe('Filter', () => {
     expect(crudView.messageLbl.isPresent()).toBe(true);
   });
 
-  // Scenario: Filter Daemon set from other namespace
-  // Given I log in into the console if it's required
-  //   And I select the namespace "default"
-  //   And I create a daemon set called "example"
-  //   And I go to the daemon sets list page
-  //  When I select the namespace "kube-system"
-  //   And I type "example" in the filter
-  //  Then I expect to see the message "No Daemon Sets Found"
-  it('Filter Daemon set from other namespace', async() => {
+  it('filters DaemonSet from other namespace', async() => {
     await browser.get(`${appHost}/k8s/ns/kube-system/daemonsets`);
     await browser.wait(until.elementToBeClickable(crudView.nameFilter), BROWSER_TIMEOUT);
     await crudView.nameFilter.sendKeys(WORKLOAD_NAME);
@@ -93,15 +65,7 @@ describe('Filter', () => {
     expect(crudView.messageLbl.isPresent()).toBe(true);
   });
 
-  // Scenario: Filter from Pods listcat chicken cosplay
-  // Given I log in into the console if it's required
-  //   And I select the namespace "deWORKLOAD_LABELfault"
-  //   And I create a daemon set called "example"
-  //   And I select the namespace "all namespaces"
-  //   And I go to Pods page
-  //  When I type "example" in the filter
-  //  Then I expect to see one pod whose name starts with "example" listed in the results
-  it('Filter from Pods list', async() => {
+  it('filters from Pods list', async() => {
     await browser.get(`${appHost}/k8s/all-namespaces/pods`);
     await browser.wait(until.elementToBeClickable(crudView.nameFilter), BROWSER_TIMEOUT);
     await crudView.nameFilter.sendKeys(WORKLOAD_NAME);
@@ -109,54 +73,28 @@ describe('Filter', () => {
     expect(crudView.resourceRowNamesAndNs.first().getText()).toContain(WORKLOAD_NAME);
   });
 
-  // Scenario: Search object by label
-  // Given I log in into the console if it's required
-  //   And I select the namespace "default"
-  //   And I create a daemon set called "example"
-  //   And I go to Search page
-  //  When I select "Daemon Sets"
-  //   And I type "app=nginx" in the label filter
-  //  Then I expect to see one object listed in the results with a name that starts with "example"
-  it('Search object by label', async() => {
+  it('searches for object by label', async() => {
     await browser.get(`${appHost}/search/ns/${testName}`);
-    await browser.wait(until.elementToBeClickable(search.dropdown), BROWSER_TIMEOUT);
-    await search.selectSearchType('Daemon Sets');
-    await search.labelFilter.sendKeys(WORKLOAD_LABEL, Key.ENTER);
+    await browser.wait(until.elementToBeClickable(searchView.dropdown), BROWSER_TIMEOUT);
+    await searchView.selectSearchType('Daemon Sets (apps/v1beta2)');
+    await searchView.labelFilter.sendKeys(WORKLOAD_LABEL, Key.ENTER);
     await browser.wait(until.elementToBeClickable(crudView.resourceRowNamesAndNs.first()), BROWSER_TIMEOUT);
     expect(crudView.resourceRowNamesAndNs.first().getText()).toContain(WORKLOAD_NAME);
   });
 
-  // Scenario: Search pod by label and filtering by name
-  // Given I log in into the console if it's required
-  //   And I select the namespace "default"
-  //   And I create a daemon set called "example"
-  //   And I go to Search page
-  //   And I select the namespace "all namespaces"
-  //  When I select "Pods"
-  //   And I type "example" in the name filter
-  //   And I type "app=hello-openshift" in the label filter
-  //  Then I expect to see one object WORKLOAD_LABELlisted in the results with a name that starts with "example"
-  it('Search pod by label and filtering by name', async() => {
+  it('searches for pod by label and filtering by name', async() => {
     await browser.get(`${appHost}/search/all-namespaces?kind=Pod`);
     await crudView.isLoaded();
     await crudView.nameFilter.sendKeys(WORKLOAD_NAME);
-    await search.labelFilter.sendKeys('app=hello-openshift', Key.ENTER);
+    await searchView.labelFilter.sendKeys('app=hello-openshift', Key.ENTER);
     await browser.wait(until.elementToBeClickable(crudView.resourceRowNamesAndNs.first()), BROWSER_TIMEOUT);
     expect(crudView.resourceRowNamesAndNs.first().getText()).toContain(WORKLOAD_NAME);
   });
 
-  // Scenario: Search object by label using by other kind of workload
-  // Given I log in into the console if it's required
-  //   And I select the namespace "default"
-  //   And I create a daemon set called "example"
-  //   And I go to Search page
-  //  When I select "Deployments"
-  //   And I type "app=nginx" in the label filter
-  //  Then I expect to see one object listed in the results with a name that starts with "example"
-  it('Search object by label using by other kind of workload', async() => {
+  it('searches for object by label using by other kind of workload', async() => {
     await browser.get(`${appHost}/search/all-namespaces?kind=Deployment`);
     await crudView.isLoaded();
-    await search.labelFilter.sendKeys(WORKLOAD_LABEL, Key.ENTER);
+    await searchView.labelFilter.sendKeys(WORKLOAD_LABEL, Key.ENTER);
     await crudView.nameFilter.sendKeys(WORKLOAD_NAME);
     await browser.wait(until.elementToBeClickable(crudView.messageLbl), BROWSER_TIMEOUT);
     expect(crudView.messageLbl.isPresent()).toBe(true);

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { render } from 'react-dom';
 import { Helmet } from 'react-helmet';
-import { Provider } from 'react-redux';
+import { Provider, connect } from 'react-redux';
 import { Redirect, Route, Router, Switch } from 'react-router-dom';
 import * as PropTypes from 'prop-types';
 
@@ -275,7 +275,11 @@ if ('serviceWorker' in navigator) {
   }
 }
 
-const AppGuard = (props) => <AsyncComponent loader={() => coFetch('api/tectonic/version').then(() => App)} {...props} />;
+const AppGuard = connect(({k8s}) => ({inFlight: k8s.getIn(['RESOURCES', 'inFlight'])}))(
+  (props) => props.inFlight
+    ? <Loading />
+    : <AsyncComponent loader={() => coFetch('api/tectonic/version').then(() => App)} {...props} />
+);
 
 render((
   <Provider store={store}>

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -1,123 +1,43 @@
-import * as _ from 'lodash-es';
+/* eslint-disable no-undef, no-unused-vars */
+
 import * as React from 'react';
 import { connect } from 'react-redux';
 import * as PropTypes from 'prop-types';
+import { Map as ImmutableMap } from 'immutable';
+import * as classNames from 'classnames';
 
 import { Dropdown, ResourceIcon } from './utils';
-// eslint-disable-next-line no-unused-vars
-import { allModels, K8sKind } from '../module/k8s';
-import { FLAGS, featureReducerName, flagPending } from '../features';
-import * as classNames from 'classnames';
-import { ClusterServiceVersionModel, EtcdClusterModel, PrometheusModel, ServiceMonitorModel, AlertmanagerModel } from '../models';
+import { K8sKind, K8sResourceKindReference, referenceForModel } from '../module/k8s';
 
-/*  ------------------------------- NOTE -------------------------------
+const DropdownItem: React.SFC<DropdownItemProps> = ({model}) => <React.Fragment>
+  <span className="co-type-selector__icon-wrapper">
+    <ResourceIcon kind={model.kind} />
+  </span>
+  {model.kind}&nbsp;<span className="text-muted">({model.apiGroup}/{model.apiVersion})</span>
+</React.Fragment>;
 
-To avoid circular imports, the keys in this list are manually duplicated in ./resource-pages.tsx !
+const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
+  const { selected, onChange, allModels, showAll, className } = props;
 
-------------------------------------------------------------------------
-*/
-const resources = [
-  'Alertmanagers',
-  'ClusterServiceVersion-v1s',
-  'Clusters',
-  'ConfigMaps',
-  'CronJobs',
-  'CustomResourceDefinitions',
-  'DaemonSets',
-  'Default',
-  'Deployments',
-  'EtcdClusters',
-  'HorizontalPodAutoscalers',
-  'Ingresses',
-  'Jobs',
-  'Namespaces',
-  'NetworkPolicies',
-  'Nodes',
-  'PersistentVolumeClaims',
-  'PersistentVolumes',
-  'PodVulns',
-  'Pods',
-  'Prometheuses',
-  'ReplicaSets',
-  'ReplicationControllers',
-  'ReportGenerationQuerys',
-  'Reports',
-  'ResourceQuotas',
-  'RoleBindings',
-  'Roles',
-  'Secrets',
-  'ServiceAccounts',
-  'ServiceMonitors',
-  'Services',
-  'StatefulSets',
-  'StorageClasses',
-];
+  const items = (allModels
+    .sort((modelA, modelB) => modelA.kind[0] > modelB.kind[0] ? 1 : -1)
+    .map((model) => <DropdownItem key={referenceForModel(model)} model={model} />) as ImmutableMap<string, JSX.Element>)
+    .merge(showAll
+      ? ImmutableMap({all: <React.Fragment>
+        <span className="co-type-selector__icon-wrapper">
+          <ResourceIcon kind="All" />
+        </span>All Types
+      </React.Fragment>})
+      : ImmutableMap()
+    )
+    .toJS() as {[s: string]: JSX.Element};
 
-const openshiftResources = [
-  'BuildConfigs',
-  'Builds',
-  'DeploymentConfigs',
-  'ImageStreamTags',
-  'ImageStreams',
-  'Projects',
-  'Routes',
-];
-
-const DropdownItem = ({kind}) => {
-  const [modelRef, kindObj] = allModels().findEntry((v) => v.kind === kind);
-  return <span>
-    <span className="co-type-selector__icon-wrapper">
-      <ResourceIcon kind={modelRef} />
-    </span>
-    {kindObj.labelPlural}
-  </span>;
+return <Dropdown className={classNames('co-type-selector', className)} items={items} title={items[selected]} onChange={onChange} selectedKey={selected} />;
 };
 
-const ResourceListDropdown_: React.StatelessComponent<ResourceListDropdownProps> = props => {
-  const { selected, onChange, allkinds, openshiftFlag, showAll, className } = props;
-  if (flagPending(openshiftFlag)) {
-    return null;
-  }
-
-  const items: {[s: string]: JSX.Element} = {};
-  const kinds = {};
-  _.each(allModels().toJS(), (ko: K8sKind) => kinds[ko.labelPlural.replace(/ /g, '')] = ko.kind);
-
-  if (showAll) {
-    items.all = <span>
-      <span className="co-type-selector__icon-wrapper">
-        <ResourceIcon kind="All" />
-      </span>All Types</span>;
-  }
-
-  const allResources = openshiftFlag ? _.concat(resources, openshiftResources) : resources;
-  allResources.filter(k => k !== ClusterServiceVersionModel.labelPlural)
-    .sort()
-    .forEach(k => {
-      const kind: string = kinds[k];
-      if (!kind) {
-        return;
-      }
-      const model = allkinds[kind];
-      if (model && model.crd && ![EtcdClusterModel, PrometheusModel, ServiceMonitorModel, AlertmanagerModel].some(m => m.kind === k)) {
-        return;
-      }
-      items[kind] = <DropdownItem kind={kind} />;
-    });
-
-  // If user somehow gets to the search page with Kind=(a CRD kind), show something in the dropdown
-  if (selected && !items[selected]) {
-    items[selected] = <DropdownItem kind={selected} />;
-  }
-  return <Dropdown className={classNames('co-type-selector', className)} items={items} title={items[selected]} onChange={onChange} selectedKey={selected} />;
-};
-
-const resourceListDropdownStateToProps = (state): any => {
-  const allkinds = state.k8s.getIn(['RESOURCES', 'models']).toJSON();
-  const openshiftFlag = state[featureReducerName].get(FLAGS.OPENSHIFT);
-
-  return { allkinds, openshiftFlag };
-};
+const resourceListDropdownStateToProps = ({k8s}) => ({
+  allModels: k8s.getIn(['RESOURCES', 'models'])
+});
 
 export const ResourceListDropdown = connect(resourceListDropdownStateToProps)(ResourceListDropdown_);
 
@@ -129,14 +49,16 @@ ResourceListDropdown.propTypes = {
   id: PropTypes.string,
 };
 
-/* eslint-disable no-undef */
 export type ResourceListDropdownProps = {
+  // FIXME: `selected` should be GroupVersionKind
   selected: string,
   onChange: Function,
-  allkinds: {[s: string]: K8sKind},
-  openshiftFlag?: boolean,
+  allModels: ImmutableMap<K8sResourceKindReference, K8sKind>,
   className?: string,
   id?: string,
   showAll?: boolean,
 };
-/* eslint-enable no-undef */
+
+type DropdownItemProps = {
+  model: K8sKind;
+};

--- a/frontend/public/components/search.jsx
+++ b/frontend/public/components/search.jsx
@@ -7,17 +7,14 @@ import * as PropTypes from 'prop-types';
 import { history, NavTitle, SelectorInput, LoadingBox } from './utils';
 
 import { namespaceProptype } from '../propTypes';
-import { allModels } from '../module/k8s';
 import { split, selectorFromString } from '../module/k8s/selector';
 import { requirementFromString } from '../module/k8s/selector-requirement';
 import { resourceListPages } from './resource-pages';
 import { ResourceListDropdown } from './resource-dropdown';
+import { connectToModel } from '../kinds';
 
-
-function ResourceList ({kind, namespace, selector}) {
-  const kindObj = allModels().find((v) => v.kind === kind) || {};
-
-  if (!kindObj || !kindObj.labelPlural) {
+const ResourceList = connectToModel(({kind, kindObj, kindsInFlight, namespace, selector}) => {
+  if (kindsInFlight) {
     return <LoadingBox />;
   }
 
@@ -26,7 +23,7 @@ function ResourceList ({kind, namespace, selector}) {
   const ns = kindObj.namespaced ? namespace : undefined;
 
   return <ListPage namespace={ns} selector={selector} kind={kind} showTitle={false} autoFocus={false} />;
-}
+});
 
 const updateUrlParams = (k, v) => {
   const url = new URL(window.location);

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -152,7 +152,6 @@ export const ChargebackReportModel: K8sKind = {
 
 export const ServiceModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Service',
   path: 'services',
   plural: 'services',
@@ -165,7 +164,6 @@ export const ServiceModel: K8sKind = {
 
 export const PodModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Pod',
   path: 'pods',
   plural: 'pods',
@@ -178,7 +176,6 @@ export const PodModel: K8sKind = {
 
 export const ContainerModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Container',
   path: 'containers',
   plural: 'containers',
@@ -204,7 +201,6 @@ export const DaemonSetModel: K8sKind = {
 
 export const ReplicationControllerModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Replication Controller',
   path: 'replicationcontrollers',
   plural: 'replicationcontrollers',
@@ -231,7 +227,6 @@ export const HorizontalPodAutoscalerModel: K8sKind = {
 
 export const ServiceAccountModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Service Account',
   path: 'serviceaccounts',
   plural: 'serviceaccounts',
@@ -356,7 +351,6 @@ export const JobModel: K8sKind = {
 
 export const NodeModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Node',
   path: 'nodes',
   plural: 'nodes',
@@ -368,7 +362,6 @@ export const NodeModel: K8sKind = {
 
 export const EventModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Event',
   path: 'events',
   plural: 'events',
@@ -381,7 +374,6 @@ export const EventModel: K8sKind = {
 
 export const ComponentStatusModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Component Status',
   labelPlural: 'Component Statuses',
   path: 'componentstatuses',
@@ -393,7 +385,6 @@ export const ComponentStatusModel: K8sKind = {
 
 export const NamespaceModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Namespace',
   path: 'namespaces',
   plural: 'namespaces',
@@ -455,7 +446,6 @@ export const RouteModel: K8sKind = {
 
 export const ConfigMapModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Config Map',
   path: 'configmaps',
   plural: 'configmaps',
@@ -468,7 +458,6 @@ export const ConfigMapModel: K8sKind = {
 
 export const SecretModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Secret',
   path: 'secrets',
   plural: 'secrets',
@@ -584,7 +573,6 @@ export const AppVersionModel: K8sKind = {
 export const PersistentVolumeModel: K8sKind = {
   label: 'Persistent Volume',
   apiVersion: 'v1',
-  legacy: true,
   path: 'persistentvolumes',
   plural: 'persistentvolumes',
   abbr: 'PV',
@@ -596,7 +584,6 @@ export const PersistentVolumeModel: K8sKind = {
 export const PersistentVolumeClaimModel: K8sKind = {
   label: 'Persistent Volume Claim',
   apiVersion: 'v1',
-  legacy: true,
   path: 'persistentvolumeclaims',
   plural: 'persistentvolumeclaims',
   abbr: 'PVC',
@@ -608,7 +595,6 @@ export const PersistentVolumeClaimModel: K8sKind = {
 
 export const PetsetModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Petset',
   plural: 'petsets',
   abbr: 'PS',
@@ -636,7 +622,6 @@ export const StatefulSetModel: K8sKind = {
 export const ResourceQuotaModel: K8sKind = {
   label: 'Resource Quota',
   apiVersion: 'v1',
-  legacy: true,
   path: 'resourcequotas',
   plural: 'resourcequotas',
   abbr: 'RQ',
@@ -661,7 +646,6 @@ export const NetworkPolicyModel: K8sKind = {
 
 export const PodVulnModel: K8sKind = {
   apiVersion: 'v1',
-  legacy: true,
   label: 'Pod Vuln',
   labelPlural: 'Pod Vulns',
   path: 'podvulns',

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -65,9 +65,6 @@ export type K8sKind = {
   crd?: boolean;
   apiVersion: string;
   apiGroup?: string;
-  // https://kubernetes.io/docs/reference/api-overview/#api-groups
-  legacy?: boolean;
-  // basePath?: string;
   namespaced?: boolean;
   selector?: {matchLabels?: {[key: string]: string}};
   labels?: {[key: string]: string};

--- a/frontend/public/module/k8s/k8s-reducers.ts
+++ b/frontend/public/module/k8s/k8s-reducers.ts
@@ -5,8 +5,8 @@ import { Map as ImmutableMap, fromJS } from 'immutable';
 
 import { types } from './k8s-actions';
 import { getQN, referenceForModel } from './k8s';
-import { K8sResourceKind } from './index';
 import { allModels } from './k8s-models';
+import { K8sResourceKind, K8sKind } from './index';
 import { namespacedResources } from '../../ui/ui-actions';
 
 const moreRecent = (a, b) => {
@@ -74,7 +74,7 @@ const loadList = (oldList, resources) => {
 
 export default (state: ImmutableMap<string, any>, action) => {
   if (!state) {
-    return fromJS({RESOURCES: {inFlight: false, models: allModels()}});
+    return fromJS({RESOURCES: {inFlight: false, models: ImmutableMap<string, K8sKind>()}});
   }
   const {k8sObjects, id} = action;
   const list: ImmutableMap<string, any> = state.getIn([id, 'data']);
@@ -95,7 +95,14 @@ export default (state: ImmutableMap<string, any>, action) => {
           model.namespaced ? namespacedResources.add(referenceForModel(model)) : namespacedResources.delete(referenceForModel(model));
           return model;
         })
-        .reduce((prevState, newModel) => prevState.updateIn(['RESOURCES', 'models'], models => models.set(referenceForModel(newModel), newModel)), state)
+        .reduce((prevState, newModel) => {
+          // TODO(alecmerdler): Use static model if it exists?
+          const modelRef = allModels().find(staticModel => !staticModel.crd && referenceForModel(staticModel) === referenceForModel(newModel))
+            // FIXME: Need to use `kind` as model reference for legacy components accessing k8s primitives
+            ? newModel.kind
+            : referenceForModel(newModel);
+          return prevState.updateIn(['RESOURCES', 'models'], models => models.set(modelRef, newModel));
+        }, state)
         // TODO: Determine where these are used and implement filtering in that component instead of storing in Redux
         .setIn(['RESOURCES', 'allResources'], action.resources.allResources)
         .setIn(['RESOURCES', 'safeResources'], action.resources.safeResources)

--- a/frontend/public/module/k8s/k8s-reducers.ts
+++ b/frontend/public/module/k8s/k8s-reducers.ts
@@ -96,7 +96,6 @@ export default (state: ImmutableMap<string, any>, action) => {
           return model;
         })
         .reduce((prevState, newModel) => {
-          // TODO(alecmerdler): Use static model if it exists?
           const modelRef = allModels().find(staticModel => !staticModel.crd && referenceForModel(staticModel) === referenceForModel(newModel))
             // FIXME: Need to use `kind` as model reference for legacy components accessing k8s primitives
             ? newModel.kind
@@ -108,6 +107,7 @@ export default (state: ImmutableMap<string, any>, action) => {
         .setIn(['RESOURCES', 'safeResources'], action.resources.safeResources)
         .setIn(['RESOURCES', 'adminResources'], action.resources.adminResources)
         .setIn(['RESOURCES', 'namespacedSet'], action.resources.namespacedSet)
+        .setIn(['RESOURCES', 'preferredVersions'], action.resources.preferredVersions)
         .setIn(['RESOURCES', 'inFlight'], false);
 
     case types.filterList:


### PR DESCRIPTION
### Description

Updates the Kubernetes API discovery code to omit static models from Redux if they are not present on the cluster. Also refactors the "Search" view to show all resources present on the cluster. Exposes the still-present tech debt of referencing resources using `kind` and not `GroupVersionKind`.

Also updates API discovery code to only fetch the `preferredVersion` for each APIGroup, significantly reducing the number of requests.

### Screenshots

**Search view (notice `apiVersion` added to dropdown items):**
![screenshot_20180724_122913](https://user-images.githubusercontent.com/11700385/43152681-35164fcc-8f3d-11e8-85a7-badd1175fe4b.png)

Fixes https://jira.coreos.com/browse/CONSOLE-627
Fixes https://jira.coreos.com/browse/CONSOLE-618