### PR TITLE
Bug 1602348 - Correctly orphan resource when requested in delete modal

### DIFF
--- a/frontend/public/components/modals/delete-modal.jsx
+++ b/frontend/public/components/modals/delete-modal.jsx
@@ -20,15 +20,12 @@ class DeleteModal extends PromiseComponent {
   _submit(event) {
     event.preventDefault();
     const {kind, resource} = this.props;
-    let json = null;
+
     //https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/
-    if (_.has(kind, 'propagationPolicy') && this.state.isChecked) {
-      json = {
-        kind : 'DeleteOptions',
-        apiVersion : 'v1',
-        propagationPolicy : kind.propagationPolicy
-      };
-    }
+    const propagationPolicy = this.state.isChecked ? kind.propagationPolicy : 'Orphan';
+    const json = propagationPolicy
+      ? { kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy }
+      : null;
 
     this.handlePromise( k8sKill(kind, resource, {}, json)).then(() => {
       this.props.close();


### PR DESCRIPTION
When "Delete dependent objects of this resource" is not checked, set `propagationPolicy` to 'Orphan'. Otherwise the default propagation policy is used, which is different for different resources and might cascade.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1602348

/assign @benjaminapetersen 