### PR TITLE
Adjust events spacing, number

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -67,7 +67,7 @@ $color-dark-border: #ddd;
   display: flex;
   justify-content: flex-start;
   flex-wrap: wrap;
-  height: 115px;
+  height: 120px;
   .co-m-resource-icon {
     margin-left: 0;
   }
@@ -106,11 +106,11 @@ $color-dark-border: #ddd;
 }
 
 .co-sysevent__message {
+  @include co-break-word;
   cursor: help;
   margin-top: 10px;
   overflow: hidden;
   text-overflow: ellipsis;
-  word-wrap: break-word;
   height: 40px;
   position: relative;
 }
@@ -118,7 +118,7 @@ $color-dark-border: #ddd;
   background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
   bottom: 0;
   content: "";
-  height: 1.2em;
+  height: 25px;
   position: absolute;
   right: 0;
   width: 15%;
@@ -147,6 +147,17 @@ $color-dark-border: #ddd;
   width: 50%;
 }
 
+/* The AutoSizer/VirtualList height change kicks in here. This is meant to handle the remainder of the mobile view (which has a shorter row height). */
+@media(min-width: 508px) {
+  .co-sysevent {
+    height: 95px;
+  }
+
+  .co-sysevent__message {
+    height: 25px;
+  }
+}
+
 @media(min-width: $grid-float-breakpoint) {
   .co-sysevent {
     flex-wrap: nowrap;
@@ -154,7 +165,7 @@ $color-dark-border: #ddd;
   }
 
   .co-sysevent__box {
-    padding: 20px;
+    padding: 10px 10px 0 10px;
     flex: 1 2 auto;
     border: solid 1px $color-grey-border;
     min-width: 0%; // necessary for wrapping since its a flex child
@@ -165,6 +176,7 @@ $color-dark-border: #ddd;
   }
 
   .co-sysevent-stream {
+    padding-top: 50px;
     padding-left: 10px;
   }
 

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -401,10 +401,8 @@ class EventStream extends SafetyFirst {
                       width={width}
                       rowCount={count}
                       tabIndex={null}
-                      // TODO: set rowHeight based on media query
-                      // @media screen and (min-width: 768px)...
-                      // rowHeight={width > 548 ? 135 : 250}
-                      rowHeight={135}
+                      /* Width goes up to 675 and then goes down to 416 when the mobile/desktop breakpoint kicks in. It keeps increasing from there. You have to pick a number that won't overlap both ranges multiple times unless you want to write a ton of media queries. */
+                      rowHeight={width < 416 ? 140 : 110}
                     />
                   </div>}
                 </AutoSizer> }


### PR DESCRIPTION
Fixes [CONSOLE-605](https://jira.coreos.com/browse/CONSOLE-605).

I adjusted the padding and fixed heights in the event stream so events take up less vertical space. I also made the total number of displayed events smaller (100 rather than 500).

**Desktop:**

Before:
![screen shot 2018-07-18 at 9 50 46 am](https://user-images.githubusercontent.com/7014965/42885844-165a4466-8a70-11e8-9f58-34863d20bcf5.png)

After:
![screen shot 2018-07-18 at 9 06 15 am](https://user-images.githubusercontent.com/7014965/42883557-e7be824e-8a69-11e8-8b7b-305a496de69c.png)

**Mobile:**

Before:
![screen shot 2018-07-18 at 9 48 53 am](https://user-images.githubusercontent.com/7014965/42885779-e9c5ab52-8a6f-11e8-9964-b5c364092100.png)

After:
![screen shot 2018-07-18 at 9 05 54 am](https://user-images.githubusercontent.com/7014965/42883562-eab44c54-8a69-11e8-9d5a-5e39cb95e563.png)

@openshift/team-ux-review, could you please review this? Sam wanted a smaller change since there's a feature freeze.