### PR TITLE
Tweak positioning of namespace/project dropdown

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -125,13 +125,13 @@ $color-bookmarker: #DDD;
 
 .co-namespace-selector__menu.dropdown-menu {
   left: 15px;
+  margin-top: 0;
   max-height: calc(100vh - (#{$masthead-height-mobile} + #{$co-namespace-selector-mobile}));
   max-width: 100%;
   min-width: 210px;
   overflow-y: auto;
 
   @media (min-width: $grid-float-breakpoint) {
-    left: 105px;
     max-height: calc(100vh - (#{$masthead-height-desktop} + #{$co-namespace-selector-desktop}));
     min-width: 250px;
   }


### PR DESCRIPTION
When the dropdown label prefix is "Project:" instead of "Namespace:", the positioning of the dropdown is odd, especially with short project names.

![screen shot 2018-07-18 at 10 12 36 am](https://user-images.githubusercontent.com/895728/42887106-2e97afde-8a73-11e8-80e1-519d6f4076db.PNG)

Given the label prefix is now also clickable as a result of #213, I think it probably makes sense to align the dropdown with the clickable area.  Also correct the slight vertical alignment of the dropdown so the top border of the dropdown doesn't overlap the dark grey bar.

![screen shot 2018-07-18 at 10 38 18 am](https://user-images.githubusercontent.com/895728/42888726-d715d1a6-8a76-11e8-8713-b6ec71f2cee1.PNG)

