### PR TITLE
Add css to fix rendering for read-only env editor controls.

### DIFF
--- a/frontend/public/components/utils/_name-value-editor.scss
+++ b/frontend/public/components/utils/_name-value-editor.scss
@@ -22,6 +22,11 @@
   }
 }
 
+.pairs-list__value-ro-field {
+  flex-grow: 1;
+  padding-top: 5px;
+}
+
 .pairs-list__btn {
   cursor: pointer;
   display: block;

--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -112,28 +112,40 @@ const NameKeyDropdownPair = ({name, key, configMaps, secrets, onChange, kind, na
   </React.Fragment>;
 };
 
-const FieldRef = ({data: {fieldPath}}) => <span>
-  <input type="text" className="form-control value-from" value="FieldRef" disabled />
-  <input type="text" className="form-control value-from" value={fieldPath} disabled />
-</span>;
+const FieldRef = ({data: {fieldPath}}) => <React.Fragment>
+  <div className="pairs-list__value-ro-field">
+    <input type="text" className="form-control" value="FieldRef" disabled />
+  </div>
+  <div className="pairs-list__value-ro-field">
+    <input type="text" className="form-control" value={fieldPath} disabled />
+  </div>
+</React.Fragment>;
 
 const ConfigMapSecretKeyRef = ({data: {name, key}, configMaps, secrets, onChange, disabled, kind}) => {
   const placeholderString = 'Config Map or Secret';
   const nameTitle = _.isEmpty(name) ? <span className="text-muted">Select a resource</span> : <ResourceName kind={kind} name={name} />;
 
   if (disabled) {
-    return <span>
-      <input type="text" className="form-control value-from" value={`${name} - ${kind}`} disabled />
-      <input type="text" className="form-control value-from" value={key} disabled />
-    </span>;
+    return <React.Fragment>
+      <div className="pairs-list__value-ro-field">
+        <input type="text" className="form-control" value={`${name} - ${kind}`} disabled />
+      </div>
+      <div className="pairs-list__value-ro-field">
+        <input type="text" className="form-control" value={key} disabled />
+      </div>
+    </React.Fragment>;
   }
   return NameKeyDropdownPair({name, key, configMaps, secrets, onChange, kind, nameTitle, placeholderString});
 };
 
-const ResourceFieldRef = ({data: {containerName, resource}}) => <span>
-  <input type="text" className="form-control value-from" value={`${containerName} - Resource Field`} disabled />
-  <input type="text" className="form-control value-from" value={resource} disabled />
-</span>;
+const ResourceFieldRef = ({data: {containerName, resource}}) => <React.Fragment>
+  <div className="pairs-list__value-ro-field">
+    <input type="text" className="form-control value-from" value={`${containerName} - Resource Field`} disabled />
+  </div>
+  <div className="pairs-list__value-ro-field">
+    <input type="text" className="form-control value-from" value={resource} disabled />
+  </div>
+</React.Fragment>;
 
 const keyStringToComponent = {
   fieldRef: {


### PR DESCRIPTION
Addresses: https://github.com/openshift/console/issues/276

Add css for read-only controls to allow for mobile and desktop resizing.

![screen shot 2018-07-19 at 4 43 21 pm](https://user-images.githubusercontent.com/35978579/42969093-1269bafe-8b73-11e8-8d65-2ee430d0d0df.png)
