### PR TITLE
Hide columns at mobile for multiple list pages

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -93,13 +93,11 @@ const menuActions = ({subjectIndex, subjects}, startImpersonate) => {
 };
 
 const Header = props => <ListHeader>
-  <ColHead {...props} className="col-xs-3" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-xs-3" sortField="roleRef.name">Role Ref</ColHead>
-  <div className="col-xs-6">
-    <ColHead {...props} className="col-md-3 hidden-sm hidden-xs" sortField="subject.kind">Subject Kind</ColHead>
-    <ColHead {...props} className="col-md-5 col-xs-7" sortField="subject.name">Subject Name</ColHead>
-    <ColHead {...props} className="col-md-4 col-xs-5" sortField="metadata.namespace">Namespace</ColHead>
-  </div>
+  <ColHead {...props} className="col-md-3 col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-md-3 col-sm-4 hidden-xs" sortField="roleRef.name">Role Ref</ColHead>
+  <ColHead {...props} className="col-md-2 hidden-sm hidden-xs" sortField="subject.kind">Subject Kind</ColHead>
+  <ColHead {...props} className="col-md-2 hidden-sm hidden-xs" sortField="subject.name">Subject Name</ColHead>
+  <ColHead {...props} className="col-md-2 col-sm-4 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
 </ListHeader>;
 
 export const BindingName = connect(null, {startImpersonate: UIActions.startImpersonate})(
@@ -118,23 +116,21 @@ export const RoleLink = ({binding}) => {
 };
 
 const Row = ({obj: binding}) => <ResourceRow obj={binding}>
-  <div className="col-xs-3 co-resource-link-wrapper">
+  <div className="col-md-3 col-sm-4 col-xs-6 co-resource-link-wrapper">
     <BindingName binding={binding} />
   </div>
-  <OverflowYFade className="col-xs-3">
+  <OverflowYFade className="col-md-3 col-sm-4 hidden-xs">
     <RoleLink binding={binding} />
   </OverflowYFade>
-  <div className="col-xs-6">
-    <OverflowYFade className="col-md-3 hidden-sm hidden-xs">
-      {binding.subject.kind}
-    </OverflowYFade>
-    <OverflowYFade className="col-md-5 col-xs-7">
-      {binding.subject.name}
-    </OverflowYFade>
-    <OverflowYFade className="col-md-4 col-sm-5 col-xs-5">
-      {binding.metadata.namespace ? <ResourceLink kind="Namespace" name={binding.metadata.namespace} /> : 'all'}
-    </OverflowYFade>
-  </div>
+  <OverflowYFade className="col-md-2 hidden-sm hidden-xs">
+    {binding.subject.kind}
+  </OverflowYFade>
+  <OverflowYFade className="col-md-2 hidden-sm hidden-xs">
+    {binding.subject.name}
+  </OverflowYFade>
+  <OverflowYFade className="col-md-2 col-sm-4 col-xs-6 co-break-word">
+    {binding.metadata.namespace ? <ResourceLink kind="Namespace" name={binding.metadata.namespace} /> : 'all'}
+  </OverflowYFade>
 </ResourceRow>;
 
 const EmptyMsg = () => <MsgBox title="No Role Bindings Found" detail="Roles grant access to types of objects in the cluster. Roles are applied to a group or user via a Role Binding." />;

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -103,24 +103,24 @@ export const ImageStreamsDetailsPage: React.SFC<ImageStreamsDetailsPageProps> = 
 ImageStreamsDetailsPage.displayName = 'ImageStreamsDetailsPage';
 
 const ImageStreamsHeader = props => <ListHeader>
-  <ColHead {...props} className="col-xs-3" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-xs-3" sortField="metadata.namespace">Namespace</ColHead>
-  <ColHead {...props} className="col-xs-3" sortField="metadata.labels">Labels</ColHead>
-  <ColHead {...props} className="col-xs-3" sortField="metadata.creationTimestamp">Created</ColHead>
+  <ColHead {...props} className="col-sm-3 col-xs-6" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-sm-3 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
+  <ColHead {...props} className="col-sm-3 hidden-xs" sortField="metadata.labels">Labels</ColHead>
+  <ColHead {...props} className="col-sm-3 hidden-xs" sortField="metadata.creationTimestamp">Created</ColHead>
 </ListHeader>;
 
 const ImageStreamsRow: React.SFC<ImageStreamsRowProps> = ({obj}) => <div className="row co-resource-list__item">
-  <div className="col-xs-3 co-resource-link-wrapper">
+  <div className="col-sm-3 col-xs-6 co-resource-link-wrapper">
     <ResourceCog actions={menuActions} kind={ImageStreamsReference} resource={obj} />
     <ResourceLink kind={ImageStreamsReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
   </div>
-  <div className="col-xs-3 co-break-word">
+  <div className="col-sm-3 col-xs-6 co-break-word">
     <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
   </div>
-  <div className="col-xs-3">
+  <div className="col-sm-3 hidden-xs">
     <LabelList kind={ImageStreamsReference} labels={obj.metadata.labels} />
   </div>
-  <div className="col-xs-3">
+  <div className="col-sm-3 hidden-xs">
     { fromNow(obj.metadata.creationTimestamp) }
   </div>
 </div>;

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -45,20 +45,20 @@ const deleteModal = (kind, ns) => {
 const nsMenuActions = [Cog.factory.ModifyLabels, Cog.factory.ModifyAnnotations, Cog.factory.Edit, deleteModal];
 
 const NamespaceHeader = props => <ListHeader>
-  <ColHead {...props} className="col-xs-4" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-xs-4" sortField="status.phase">Status</ColHead>
-  <ColHead {...props} className="col-xs-4" sortField="metadata.labels">Labels</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="status.phase">Status</ColHead>
+  <ColHead {...props} className="col-sm-4 hidden-xs" sortField="metadata.labels">Labels</ColHead>
 </ListHeader>;
 
 const NamespaceRow = ({obj: ns}) => <ResourceRow obj={ns}>
-  <div className="col-xs-4 co-resource-link-wrapper">
+  <div className="col-sm-4 col-xs-6 co-resource-link-wrapper">
     <ResourceCog actions={nsMenuActions} kind="Namespace" resource={ns} />
     <ResourceLink kind="Namespace" name={ns.metadata.name} title={ns.metadata.uid} />
   </div>
-  <div className="col-xs-4 co-break-word">
+  <div className="col-sm-4 col-xs-6 co-break-word">
     {ns.status.phase}
   </div>
-  <div className="col-xs-4">
+  <div className="col-sm-4 hidden-xs">
     <LabelList kind="Namespace" labels={ns.metadata.labels} />
   </div>
 </ResourceRow>;

--- a/frontend/public/components/persistent-volume.jsx
+++ b/frontend/public/components/persistent-volume.jsx
@@ -23,21 +23,21 @@ spec:
 const menuActions = [Cog.factory.ModifyLabels, Cog.factory.ModifyAnnotations, Cog.factory.Edit, Cog.factory.Delete];
 
 const Header = props => <ListHeader>
-  <ColHead {...props} className="col-xs-4" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-xs-4" sortField="metadata.labels">Labels</ColHead>
-  <ColHead {...props} className="col-xs-4" sortField="metadata.creationTimestamp">Created</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.labels">Labels</ColHead>
+  <ColHead {...props} className="col-sm-4 hidden-xs" sortField="metadata.creationTimestamp">Created</ColHead>
 </ListHeader>;
 
 const kind = 'PersistentVolume';
 const Row = ({obj}) => <div className="row co-resource-list__item">
-  <div className="col-xs-4 co-resource-link-wrapper">
+  <div className="col-sm-4 col-xs-6 co-resource-link-wrapper">
     <ResourceCog actions={menuActions} kind={kind} resource={obj} />
     <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
   </div>
-  <div className="col-xs-4">
+  <div className="col-sm-4 col-xs-6">
     <LabelList kind={kind} labels={obj.metadata.labels} />
   </div>
-  <div className="col-xs-4">
+  <div className="col-sm-4 hidden-xs">
     <Timestamp timestamp={obj.metadata.creationTimestamp} />
   </div>
 </div>;

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -70,10 +70,10 @@ metadata:
   name: example`);
 
 const Header = props => <ListHeader>
-  <ColHead {...props} className="col-sm-4 col-xs-3" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-sm-4 col-xs-3" sortField="metadata.namespace">Namespace</ColHead>
-  <ColHead {...props} className="col-sm-2 col-xs-3" sortField="secrets">Secrets</ColHead>
-  <ColHead {...props} className="col-sm-2 col-xs-3" sortField="metadata.creationTimestamp">Age</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
+  <ColHead {...props} className="col-sm-2 hidden-xs" sortField="secrets">Secrets</ColHead>
+  <ColHead {...props} className="col-sm-2 hidden-xs" sortField="metadata.creationTimestamp">Age</ColHead>
 </ListHeader>;
 
 const ServiceAccountRow = ({obj: serviceaccount}) => {
@@ -81,17 +81,17 @@ const ServiceAccountRow = ({obj: serviceaccount}) => {
 
   return (
     <ResourceRow obj={serviceaccount}>
-      <div className="col-sm-4 col-xs-3 co-resource-link-wrapper">
+      <div className="col-sm-4 col-xs-6 co-resource-link-wrapper">
         <ResourceCog actions={menuActions} kind="ServiceAccount" resource={serviceaccount} />
         <ResourceLink kind="ServiceAccount" name={name} namespace={namespace} title={uid} />
       </div>
-      <div className="col-sm-4 col-xs-3 co-break-word">
+      <div className="col-sm-4 col-xs-6 co-break-word">
         <ResourceLink kind="Namespace" name={namespace} title={namespace}/> {}
       </div>
-      <div className="col-sm-2 col-xs-3">
+      <div className="col-sm-2 hidden-xs">
         {secrets ? secrets.length : 0}
       </div>
-      <div className="col-sm-2 col-xs-3">
+      <div className="col-sm-2 hidden-xs">
         {fromNow(creationTimestamp)}
       </div>
     </ResourceRow>

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -21,26 +21,26 @@ export const StorageClassReference: K8sResourceKindReference = 'StorageClass';
 const menuActions = [Cog.factory.ModifyLabels, Cog.factory.ModifyAnnotations, Cog.factory.Edit, Cog.factory.Delete];
 
 const StorageClassHeader = props => <ListHeader>
-  <ColHead {...props} className="col-xs-3" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-xs-3" sortField="provisioner">Provisioner</ColHead>
-  <ColHead {...props} className="col-xs-3" sortField="reclaimPolicy">Reclaim Policy</ColHead>
-  <ColHead {...props} className="col-xs-3" sortField="metadata.creationTimestamp">Created</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="provisioner">Provisioner</ColHead>
+  <ColHead {...props} className="col-sm-2 hidden-xs" sortField="reclaimPolicy">Reclaim Policy</ColHead>
+  <ColHead {...props} className="col-sm-2 hidden-xs" sortField="metadata.creationTimestamp">Created</ColHead>
 </ListHeader>;
 
 
 const StorageClassRow: React.SFC<StorageClassRowProps> = ({obj}) => {
   return <div className="row co-resource-list__item">
-    <div className="col-xs-3 co-break-word co-resource-link-wrapper">
+    <div className="col-sm-4 col-xs-6 co-break-word co-resource-link-wrapper">
       <ResourceCog actions={menuActions} kind={StorageClassReference} resource={obj} />
       <ResourceLink kind={StorageClassReference} name={obj.metadata.name} namespace={undefined} title={obj.metadata.name} />
     </div>
-    <div className="col-xs-3 co-break-word">
+    <div className="col-sm-4 col-xs-6 co-break-word">
       {obj.provisioner}
     </div>
-    <div className="col-xs-3">
+    <div className="col-sm-2 hidden-xs">
       {obj.reclaimPolicy}
     </div>
-    <div className="col-xs-3">
+    <div className="col-sm-2 hidden-xs">
       { fromNow(obj.metadata.creationTimestamp) }
     </div>
   </div>;


### PR DESCRIPTION
Extending the [Bug 1605100 - Hide some build config and build columns at mobile ](https://github.com/openshift/console/pull/280) PR, so the resource list for:
- role-bindings
- image-streams
- namespaces
- persistent-volumes
- service-account
- storage-class

since they are not readable on mobile.
/assign @spadgett