### PR TITLE
Update NodeLink component to use FLAGS.CAN_LIST_NODE

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -2,7 +2,6 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { CSSTransition } from 'react-transition-group';
 import { Helmet } from 'react-helmet';
-import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import { AutoSizer, List as VirtualList, WindowScroller } from 'react-virtualized';
@@ -13,7 +12,7 @@ import { watchURL } from '../module/k8s';
 import { EventModel } from '../models';
 import { SafetyFirst } from './safety-first';
 import { TextFilter } from './factory';
-import { Dropdown, ResourceLink, Box, Loading, NavTitle, Timestamp, TogglePlay, pluralize } from './utils';
+import { Dropdown, NodeLink, ResourceLink, Box, Loading, NavTitle, Timestamp, TogglePlay, pluralize } from './utils';
 import { WSFactory } from '../module/ws-factory';
 import { ResourceListDropdown } from './resource-dropdown';
 import { connectToFlags, FLAGS, flagPending } from '../features';
@@ -61,7 +60,7 @@ class Inner extends React.PureComponent {
             <small className="co-sysevent__source">
               Generated from <span>{source.component}</span>
               {source.component === 'kubelet' &&
-                <span> on <Link to={`/k8s/cluster/nodes/${source.host}`}>{source.host}</Link></span>
+                <span> on <NodeLink name={source.host} /></span>
               }
             </small>
             {count > 1 && <small className="co-sysevent__count text-secondary">

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -6,7 +6,7 @@ import { getVolumeType, getVolumeLocation, getVolumeMountPermissions, getVolumeM
 import { getContainerState, getContainerStatus } from '../module/k8s/docker';
 import { ResourceEventStream } from './events';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import { SectionHeading, Cog, LabelList, navFactory, Overflow, ResourceCog, ResourceIcon, ResourceLink, ResourceSummary, ScrollToTopOnMount, Selector, Timestamp, VolumeIcon, units, AsyncComponent } from './utils';
+import { SectionHeading, Cog, LabelList, navFactory, NodeLink, Overflow, ResourceCog, ResourceIcon, ResourceLink, ResourceSummary, ScrollToTopOnMount, Selector, Timestamp, VolumeIcon, units, AsyncComponent } from './utils';
 import { PodLogs } from './pod-logs';
 import { Line, requirePrometheus } from './graphs';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
@@ -75,8 +75,6 @@ const ContainerLink = ({pod, name}) => <span className="co-resource-link co-reso
   <ResourceIcon kind="Container" />
   <Link to={`/k8s/ns/${pod.metadata.namespace}/pods/${pod.metadata.name}/containers/${name}`}>{name}</Link>
 </span>;
-
-const NodeLink = ({name}) => name ? <Link to={`/k8s/cluster/nodes/${name}`}>{name}</Link> : <span>-</span>;
 
 export const ContainerRow = ({pod, container}) => {
   const cstatus = getContainerStatus(pod, container.name);

--- a/frontend/public/components/utils/resource-link.jsx
+++ b/frontend/public/components/utils/resource-link.jsx
@@ -6,6 +6,7 @@ import * as classNames from 'classnames';
 import { ResourceIcon } from './index';
 import { modelFor, referenceForModel } from '../../module/k8s';
 import { connectToModel } from '../../kinds';
+import { connectToFlags, FLAGS } from '../../features';
 
 const unknownKinds = new Set();
 
@@ -71,3 +72,15 @@ export const ResourceLink = connectToModel(
   });
 
 ResourceLink.displayName = 'ResourceLink';
+
+const NodeLink_ = (props) => {
+  const {name, flags} = props;
+  if (!name) {
+    return <React.Fragment>-</React.Fragment>;
+  }
+  return flags[FLAGS.CAN_LIST_NODE]
+    ? <ResourceLink kind="Node" name={name} title={name} />
+    : <React.Fragment>{name}</React.Fragment>;
+};
+
+export const NodeLink = connectToFlags(FLAGS.CAN_LIST_NODE)(NodeLink_);

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -374,7 +374,7 @@ export const NamespaceModel: K8sKind = {
   label: 'Namespace',
   path: 'namespaces',
   plural: 'namespaces',
-  abbr: 'N',
+  abbr: 'NS',
   kind: 'Namespace',
   id: 'namespace',
   labelPlural: 'Namespaces'


### PR DESCRIPTION
Works as follows:
- if no name, will show `-` as before
- if name, but user cannot list nodes, will show `{name}`
- if renders before FLAG.CAN_LIST_NODE is set, it will initially show `{name}` but will update to a link once the flag is resolved.


