### PR TITLE
Break camel case words at capital letters

### DIFF
--- a/frontend/public/components/_icon-and-text.scss
+++ b/frontend/public/components/_icon-and-text.scss
@@ -1,8 +1,8 @@
-.co-timestamp {
+.co-icon-and-text {
   align-items: baseline;
   display: flex;
 }
 
-.co-timestamp__icon {
+.co-icon-and-text__icon {
   margin-right: 5px;
 }

--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 
 import { Timestamp } from './utils';
+import { CamelCaseWrap } from './utils/camel-case-wrap';
 
 export const Conditions: React.SFC<ConditionsProps> = ({conditions}) => {
   const rows = _.map(conditions, condition => <div className="row" key={condition.type}>
     <div className="col-xs-4 col-sm-2 col-md-2">
-      {condition.type}
+      <CamelCaseWrap value={condition.type} />
     </div>
     <div className="col-xs-4 col-sm-2 col-md-2">
       {condition.status}
@@ -14,8 +15,8 @@ export const Conditions: React.SFC<ConditionsProps> = ({conditions}) => {
     <div className="hidden-xs hidden-sm col-md-2">
       <Timestamp timestamp={condition.lastUpdateTime || condition.lastTransitionTime} />
     </div>
-    <div className="col-xs-4 col-sm-3 col-md-2 co-break-word">
-      {condition.reason || '-'}
+    <div className="col-xs-4 col-sm-3 col-md-2">
+      <CamelCaseWrap value={condition.reason} />
     </div>
     {/* remove initial newline which appears in route messages */}
     <div className="hidden-xs col-sm-5 col-md-4 co-pre-line">

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -8,6 +8,7 @@ import { PodsPage } from './pod';
 import { Cog, navFactory, LabelList, ResourceCog, Heading, ResourceLink, Timestamp, units, cloudProviderNames, cloudProviderID, pluralize, containerLinuxUpdateOperator } from './utils';
 import { Line, requirePrometheus } from './graphs';
 import { NodeModel } from '../models';
+import { CamelCaseWrap } from './utils/camel-case-wrap';
 
 const MarkAsUnschedulable = (kind, obj) => ({
   label: 'Mark as Unschedulable...',
@@ -243,9 +244,9 @@ const Details = ({obj: node}) => {
           </thead>
           <tbody>
             {_.map(node.status.conditions, (c, i) => <tr key={i}>
-              <td>{c.type}</td>
+              <td><CamelCaseWrap value={c.type} /></td>
               <td>{c.status || '-'}</td>
-              <td>{c.reason || '-'}</td>
+              <td><CamelCaseWrap value={c.reason} /></td>
               <td><Timestamp timestamp={c.lastHeartbeatTime} /></td>
               <td><Timestamp timestamp={c.lastTransitionTime} /></td>
             </tr>)}

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -13,6 +13,7 @@ import { Line, requirePrometheus } from './graphs';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { EnvironmentPage } from './environment';
 import { formatDuration } from './utils/datetime';
+import { CamelCaseWrap } from './utils/camel-case-wrap';
 
 const menuActions = [Cog.factory.EditEnvironment, ...Cog.factory.common];
 const validReadinessStates = new Set(['Ready', 'PodCompleted']);
@@ -39,11 +40,11 @@ export const Readiness = ({pod}) => {
     return null;
   }
   if (validReadinessStates.has(readiness)) {
-    return <span>{readiness}</span>;
+    return <CamelCaseWrap value={readiness} />;
   }
-  return <span className="co-error">
-    <i className="fa fa-times-circle co-icon-space-r" />
-    {readiness}
+  return <span className="co-error co-icon-and-text">
+    <i className="fa fa-times-circle co-icon-and-text__icon" aria-hidden="true" />
+    <CamelCaseWrap value={readiness} />
   </span>;
 };
 
@@ -52,8 +53,8 @@ Readiness.displayName = 'Readiness';
 export const PodRow = ({obj: pod}) => {
   const phase = podPhase(pod);
   const status = validStatuses.has(phase)
-    ? phase
-    : <span className="co-error"><i className="fa fa-times-circle co-icon-space-r" />{phase}</span>;
+    ? <CamelCaseWrap value={phase} />
+    : <span className="co-error co-icon-and-text"><i className="fa fa-times-circle co-icon-and-text__icon" aria-hidden="true" /><CamelCaseWrap value={phase} /></span>;
 
   return <ResourceRow obj={pod}>
     <div className="col-lg-2 col-md-3 col-sm-4 col-xs-6 co-resource-link-wrapper">

--- a/frontend/public/components/utils/camel-case-wrap.tsx
+++ b/frontend/public/components/utils/camel-case-wrap.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable no-undef */
+
+import * as React from 'react';
+
+const MEMO = {};
+
+export const CamelCaseWrap: React.SFC<CamelCaseWrapProps> = ({value}) => {
+  if (!value) {
+    return '-';
+  }
+
+  if (MEMO[value]) {
+    return MEMO[value];
+  }
+
+  // Add word break points before capital letters (but keep consecutive capital letters together).
+  const words = value.match(/[A-Z]+[^A-Z]*|[^A-Z]+/g);
+  const rendered = <React.Fragment>
+    {words.map((word, i) => <React.Fragment key={i}>{word}{i !== words.length - 1 && <wbr />}</React.Fragment>)}
+  </React.Fragment>;
+  MEMO[value] = rendered;
+  return rendered;
+};
+
+export type CamelCaseWrapProps = {
+  value: string;
+};

--- a/frontend/public/components/utils/timestamp.jsx
+++ b/frontend/public/components/utils/timestamp.jsx
@@ -128,8 +128,8 @@ export class Timestamp extends SafetyFirst {
       return timestamp;
     }
 
-    return <div className="co-timestamp">
-      <i className="fa fa-globe co-timestamp__icon" aria-hidden="true" />
+    return <div className="co-timestamp co-icon-and-text">
+      <i className="fa fa-globe co-icon-and-text__icon" aria-hidden="true" />
       <Tooltip content={[<span className="co-nowrap" key="co-timestamp">{ mdate.toISOString() }</span>]}>
         { timestamp }
       </Tooltip>

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -62,7 +62,7 @@
 @import "components/service";
 @import "components/sysevent-icon";
 @import "components/sysevent-stream";
-@import "components/timestamp";
+@import "components/icon-and-text";
 @import "components/toggle-play";
 @import "components/users";
 @import "components/volume-icon";


### PR DESCRIPTION
@robszumski @tlwu2013 @rhamilto As long as we're fixing word wrap problems...

/assign @benjaminapetersen 

Improves word wrapping for status reasons and other camel case text in tables by inserting `<wbr>` word break points before capital letters.

![screen shot 2018-07-20 at 1 55 31 pm](https://user-images.githubusercontent.com/1167259/43017575-99dcdcd0-8c24-11e8-8470-5fa97a8d9bf7.png)

![screen shot 2018-07-20 at 1 54 13 pm](https://user-images.githubusercontent.com/1167259/43017539-7afd57e0-8c24-11e8-97d2-e4ebbe633826.png)

![screen shot 2018-07-20 at 1 36 29 pm](https://user-images.githubusercontent.com/1167259/43016860-461f7f1e-8c22-11e8-8b97-3aed772b29d5.png)

![screen shot 2018-07-20 at 1 36 45 pm](https://user-images.githubusercontent.com/1167259/43016874-4da422bc-8c22-11e8-9f33-63bb54f6b82d.png)

![localhost details openshift origin 2018-07-20 13-40-17](https://user-images.githubusercontent.com/1167259/43016946-86e79338-8c22-11e8-8b1b-ff89af92bea2.png)
