### PR TITLE
Fix z-index of pod terminal vs. container dropdown

### DIFF
--- a/frontend/public/components/_terminal.scss
+++ b/frontend/public/components/_terminal.scss
@@ -9,13 +9,16 @@ $console-collapse-link-z-index: $console-z-index + 20;
   background-color: $color-pf-black;
 }
 
+.console > .terminal.fullscreen {
+  z-index: $console-z-index; // in fullscreen mode, to get above $zindex-navbar-fixed
+}
+
 .console {
   width: 100%;
   height: 100%;
   padding: 0;
   background-color: $color-pf-black;
   position: relative;
-  z-index: $console-z-index; // in fullscreen mode, to get above 'xterm fullscreen's and $zindex-navbar-fixed
 }
 
 .console-collapse-link {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1601712

Higher z-index is only applied to terminal window when in fullscreen.