### PR TITLE
Don't cut off text in CRD filter label

### DIFF
--- a/frontend/public/components/custom-resource-definition.jsx
+++ b/frontend/public/components/custom-resource-definition.jsx
@@ -72,4 +72,4 @@ const CRDRow = ({obj: crd}) => <div className="row co-resource-list__item">
 </div>;
 
 export const CustomResourceDefinitionsList = props => <List {...props} Header={CRDHeader} Row={CRDRow} />;
-export const CustomResourceDefinitionsPage = props => <ListPage {...props} ListComponent={CustomResourceDefinitionsList} kind="CustomResourceDefinition" canCreate={true} />;
+export const CustomResourceDefinitionsPage = props => <ListPage {...props} ListComponent={CustomResourceDefinitionsList} kind="CustomResourceDefinition" canCreate={true} filterLabel="CRDs by name" />;


### PR DESCRIPTION
Before:
![custom resource definitions openshift origin 2018-07-23 11-42-48](https://user-images.githubusercontent.com/1167259/43087318-8c07af68-8e6d-11e8-99b1-158511442794.png)

After:
![custom resource definitions openshift origin 2018-07-23 11-40-18](https://user-images.githubusercontent.com/1167259/43087216-4c81eae8-8e6d-11e8-9ed3-3aded5796f98.png)

Fixes CONSOLE-531

/assign @rhamilto 
@serenamarie125 fyi