### PR TITLE
Add hashlink to "Software Info" when right column isn't present

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,6 +78,7 @@
     "react-modal": "3.x",
     "react-redux": "5.x",
     "react-router-dom": "4.x",
+    "react-router-hash-link": "^1.2.0",
     "react-tagsinput": "3.19.x",
     "react-transition-group": "2.3.x",
     "react-virtualized": "9.x",

--- a/frontend/public/components/cluster-overview.jsx
+++ b/frontend/public/components/cluster-overview.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
+import { HashLink } from 'react-router-hash-link';
 
 import { coFetch, coFetchJSON } from '../co-fetch';
 import { NavTitle, AsyncComponent, Firehose, StatusBox, DocumentationLinks, AdditionalSupportLinks } from './utils';
@@ -166,7 +167,7 @@ const GraphsPage = ({fake, limited, namespace, openshiftFlag}) => {
       </div>
     </div>
     <div className="col-lg-4 col-md-12">
-      <div className="group">
+      <div className="group" id="software-info">
         <div className="group__title">
           <h2 className="h3">Software Info</h2>
         </div>
@@ -241,7 +242,11 @@ const ClusterOverviewPage_ = props => {
     <Helmet>
       <title>{fake ? 'Overview' : title}</title>
     </Helmet>
-    <NavTitle title={fake ? 'Overview' : title} />
+    <NavTitle title={fake ? 'Overview' : title} style={{alignItems: 'baseline', display: 'flex', justifyContent: 'space-between'}}>
+      <p className="hidden-lg">
+        <HashLink smooth to="#software-info">Software Info</HashLink>
+      </p>
+    </NavTitle>
     <div className="cluster-overview-cell container-fluid">
       <AsyncComponent namespace={namespace} loader={permissionedLoader} openshiftFlag={openshiftFlag} fake={fake} />
     </div>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8681,6 +8681,12 @@ react-router-dom@4.x:
     react-router "^4.2.0"
     warning "^3.0.0"
 
+react-router-hash-link@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-router-hash-link/-/react-router-hash-link-1.2.0.tgz#ce824cc5f0502ce9b0686bb6dd9c08659b24094c"
+  dependencies:
+    prop-types "^15.6.0"
+
 react-router@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-604

Before:
`< 1200px`
![console apps ui-preserve origin-gce dev openshift com_k8s_cluster_projects](https://user-images.githubusercontent.com/895728/43093346-cf090a40-8e7d-11e8-9b31-65151d1230f0.png)

After (note, the scroll is smooth, but the GIF makes it look choppy):
`< 1200px`
![rmmtk69v1p](https://user-images.githubusercontent.com/895728/43157149-19b8e232-8f4a-11e8-830a-72320c45bd53.gif)
`> 1199px`
![localhost_9000_overview_all-namespaces 1](https://user-images.githubusercontent.com/895728/43093291-ab03056a-8e7d-11e8-8c92-b22bb5bc91b2.png)


