### PR TITLE
Fix margin issue with cluster overview

### DIFF
--- a/frontend/public/components/_cluster-overview.scss
+++ b/frontend/public/components/_cluster-overview.scss
@@ -36,8 +36,6 @@
 
 .cluster-overview-cell {
   margin-top: -($grid-gutter-width / 2);
-  margin-left: $grid-gutter-width / 2;
-  margin-right: $grid-gutter-width / 2;
   @media(min-width: $screen-lg-min) {
     .col-lg-8 {
       padding-right: 0;


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-638

Margins were added to make sure content and 'Getting Started' message had the same spacing, but looks like another solution will be necessary.