### PR TITLE
Use more precise regex for delete-modal redirect

### DIFF
--- a/frontend/public/components/modals/delete-modal.jsx
+++ b/frontend/public/components/modals/delete-modal.jsx
@@ -30,7 +30,7 @@ class DeleteModal extends PromiseComponent {
     this.handlePromise( k8sKill(kind, resource, {}, json)).then(() => {
       this.props.close();
       // If we are currently on the deleted resource's page, redirect to the resource list page
-      const re = new RegExp(`/${resource.metadata.name}.*$`);
+      const re = new RegExp(`/${resource.metadata.name}(/|$)`);
       if (re.test(window.location.pathname)) {
         history.push( resource.metadata.namespace
           ? formatNamespacedRouteForResource(kind.path)


### PR DESCRIPTION
Follow on to #193

There are probably still edge cases here. (I suspect deleting a resource named `search` on the search page will unexpectedly redirect.)

/assign @dtaylor113 