### PR TITLE
Add 'co-break-word' class to the type on the secrets page

### DIFF
--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -64,7 +64,7 @@ const SecretRow = ({obj: secret}) => {
     <div className="col-md-3 col-sm-4 col-xs-6 co-break-word">
       <ResourceLink kind="Namespace" name={secret.metadata.namespace} title={secret.metadata.namespace} />
     </div>
-    <div className="col-md-3 col-sm-4 hidden-xs">{secret.type}</div>
+    <div className="col-md-3 col-sm-4 hidden-xs co-break-word">{secret.type}</div>
     <div className="col-md-1 hidden-sm hidden-xs">{data}</div>
     <div className="col-md-2 hidden-sm hidden-xs">{age}</div>
   </ResourceRow>;


### PR DESCRIPTION
Some of the secret types are pretty long strings, which can cause overflowing on narrow disaplys, eg.:

 ![1](https://user-images.githubusercontent.com/1668218/43133679-cdbe1ece-8f3f-11e8-9dd9-5c94031b8f52.png)

![2](https://user-images.githubusercontent.com/1668218/43133768-0e64a2a4-8f40-11e8-87db-44fb863026d7.png)


... was thinking about using `OverflowYFade` component here instead but I think it would be better to show the whole secret type name.

@spadgett PTAL