### PR TITLE
Consolidate the number of secret type filters

### DIFF
--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -13,9 +13,10 @@ import { getJobTypeAndCompletions, isNodeReady, podPhase, podPhaseFilterReducer,
 import { isScanned, isSupported, makePodvuln, numFixables } from '../../module/k8s/podvulns';
 import { UIActions } from '../../ui/ui-actions';
 import { ingressValidHosts } from '../ingress';
+import { routeStatus } from '../routes';
+import { secretTypeFilterReducer } from '../secret';
 import { bindingType, roleType } from '../RBAC';
 import { LabelList, ResourceCog, ResourceLink, resourcePath, Selector, StatusBox, containerLinuxUpdateOperator, EmptyBox } from '../utils';
-import { routeStatus } from '../routes';
 
 const fuzzyCaseInsensitive = (a, b) => fuzzy(_.toLower(a), _.toLower(b));
 
@@ -120,7 +121,7 @@ const listFilters = {
     if (!types || !types.selected || !types.selected.size) {
       return true;
     }
-    const type = secret.type;
+    const type = secretTypeFilterReducer(secret);
     return types.selected.has(type) || !_.includes(types.all, type);
   },
 

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -84,21 +84,48 @@ const SecretDetails = ({obj: secret}) => {
 const SecretsList = props => <List {...props} Header={SecretHeader} Row={SecretRow} />;
 SecretsList.displayName = 'SecretsList';
 
-const secretType = secret => secret.type;
+const IMAGE_FILTER_VALUE = 'Image';
+const SOURCE_FILTER_VALUE = 'Source';
+const TLS_FILTER_VALUE = 'TLS';
+const SA_TOKEN_FILTER_VALUE = 'Service Account Token';
+const OPAQUE_FILTER_VALUE = 'Opaque';
+
+const secretTypeFilterValues = [
+  IMAGE_FILTER_VALUE,
+  SOURCE_FILTER_VALUE,
+  TLS_FILTER_VALUE,
+  SA_TOKEN_FILTER_VALUE,
+  OPAQUE_FILTER_VALUE
+];
+
+export const secretTypeFilterReducer = secret => {
+  switch (secret.type) {
+    case SecretType.dockercfg:
+    case SecretType.dockerconfigjson:
+      return IMAGE_FILTER_VALUE;
+
+    case SecretType.basicAuth:
+    case SecretType.sshAuth:
+      return SOURCE_FILTER_VALUE;
+
+    case SecretType.tls:
+      return TLS_FILTER_VALUE;
+
+    case SecretType.serviceAccountToken:
+      return SA_TOKEN_FILTER_VALUE;
+
+    default:
+      // This puts all unrecognized types under "Opaque". Since unrecognized types should be uncommon,
+      // it avoids an "Other" category that is usually empty.
+      return OPAQUE_FILTER_VALUE;
+  }
+};
 
 const filters = [{
   type: 'secret-type',
-  selected: ['kubernetes.io/service-account-token', 'kubernetes.io/dockercfg', 'kubernetes.io/dockerconfigjson', 'kubernetes.io/basic-auth', 'kubernetes.io/ssh-auth', 'kubernetes.io/tls', 'Opaque'],
-  reducer: secretType,
-  items: [
-    {id: 'kubernetes.io/basic-auth', title: 'basic-auth'},
-    {id: 'kubernetes.io/dockercfg', title: 'dockercfg'},
-    {id: 'kubernetes.io/dockerconfigjson', title: 'dockerconfigjson'},
-    {id: 'kubernetes.io/service-account-token', title: 'service-account-token'},
-    {id: 'kubernetes.io/ssh-auth', title: 'ssh-auth'},
-    {id: 'kubernetes.io/tls', title: 'tls'},
-    {id: 'Opaque', title: 'Opaque'}
-  ],
+  selected: secretTypeFilterValues,
+  reducer: secretTypeFilterReducer,
+  items: secretTypeFilterValues.map(filterValue => ({ id: filterValue, title: filterValue })),
 }];
 
 const SecretsPage = props => {

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -17,8 +17,12 @@ enum SecretTypeAbstraction {
 
 export enum SecretType {
   basicAuth = 'kubernetes.io/basic-auth',
+  dockercfg = 'kubernetes.io/dockercfg',
+  dockerconfigjson = 'kubernetes.io/dockerconfigjson',
+  opaque = 'Opaque',
+  serviceAccountToken = 'kubernetes.io/service-account-token',
   sshAuth = 'kubernetes.io/ssh-auth',
-  opaque = 'Opaque'
+  tls = 'kubernetes.io/tls',
 }
 
 export type BasicAuthSubformState = {


### PR DESCRIPTION
We're making an effort to consolidate the number of filters at the top of lists so there aren't as many.

/assign @jhadvig 
cc @robszumski @openshift/team-ux-review 

Before:

![secrets openshift origin 2018-07-24 08-49-35](https://user-images.githubusercontent.com/1167259/43138970-81b9b392-8f1e-11e8-8e80-f913745d2d15.png)

After:

![secrets openshift origin 2018-07-24 08-47-53](https://user-images.githubusercontent.com/1167259/43138897-553d40c2-8f1e-11e8-8397-8fe5bbed205f.png)
