### PR TITLE
Update OLM Namespace

### DIFF
--- a/frontend/__tests__/components/cloud-services/catalog-source.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/catalog-source.spec.tsx
@@ -163,7 +163,7 @@ describe(CatalogSourceDetailsPage.displayName, () => {
     expect(wrapper.find<any>(Firehose).props().resources).toEqual([{
       kind: referenceForModel(CatalogSourceModel),
       name: 'tectonic-ocs',
-      namespace: 'tectonic-system',
+      namespace: 'operator-lifecycle-manager',
       isList: false,
       prop: 'catalogSource',
     }, {
@@ -174,7 +174,7 @@ describe(CatalogSourceDetailsPage.displayName, () => {
       kind: 'ConfigMap',
       isList: false,
       name: 'tectonic-ocs',
-      namespace: 'tectonic-system',
+      namespace: 'operator-lifecycle-manager',
       prop: 'configMap'}]);
   });
 
@@ -195,7 +195,7 @@ describe(CreateSubscriptionYAML.displayName, () => {
 
   it('renders a `Firehose` for the catalog ConfigMap', () => {
     expect(wrapper.find<any>(Firehose).props().resources).toEqual([
-      {kind: 'ConfigMap', name: 'tectonic-ocs', namespace: 'tectonic-system', isList: false, prop: 'ConfigMap'}
+      {kind: 'ConfigMap', name: 'tectonic-ocs', namespace: 'operator-lifecycle-manager', isList: false, prop: 'ConfigMap'}
     ]);
   });
 

--- a/frontend/__tests__/components/cloud-services/subscription.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/subscription.spec.tsx
@@ -206,7 +206,7 @@ describe(SubscriptionDetailsPage.displayName, () => {
     const wrapper = shallow(<SubscriptionDetailsPage match={match} namespace="default" />);
 
     expect(wrapper.find(DetailsPage).props().resources).toEqual([
-      {kind: ConfigMapModel.kind, name: 'tectonic-ocs', namespace: 'tectonic-system', isList: false, prop: 'configMap'},
+      {kind: ConfigMapModel.kind, name: 'tectonic-ocs', namespace: 'operator-lifecycle-manager', isList: false, prop: 'configMap'},
       {kind: referenceForModel(ClusterServiceVersionModel), namespace: 'default', isList: true, prop: 'clusterServiceVersion'}
     ]);
   });

--- a/frontend/public/components/cloud-services/catalog-source.tsx
+++ b/frontend/public/components/cloud-services/catalog-source.tsx
@@ -107,7 +107,7 @@ export const CatalogSourceDetailsPage: React.SFC<CatalogSourceDetailsPageProps> 
     resources={[{
       kind: referenceForModel(CatalogSourceModel),
       name: 'tectonic-ocs',
-      namespace: 'tectonic-system',
+      namespace: 'operator-lifecycle-manager',
       isList: false,
       prop: 'catalogSource',
     }, {
@@ -118,7 +118,7 @@ export const CatalogSourceDetailsPage: React.SFC<CatalogSourceDetailsPageProps> 
       kind: 'ConfigMap',
       isList: false,
       name: 'tectonic-ocs',
-      namespace: 'tectonic-system',
+      namespace: 'operator-lifecycle-manager',
       prop: 'configMap'}]}>
     {/* FIXME(alecmerdler): Hack because `Firehose` injects props without TypeScript knowing about it */}
     <CatalogSourceDetails {...props as any} ns={props.match.params.ns} />
@@ -154,7 +154,7 @@ export const CreateSubscriptionYAML: React.SFC<CreateSubscriptionYAMLProps> = (p
     kind: 'ConfigMap',
     isList: false,
     name: 'tectonic-ocs',
-    namespace: 'tectonic-system',
+    namespace: 'operator-lifecycle-manager',
     prop: 'ConfigMap'
   }]}>
     {/* FIXME(alecmerdler): Hack because `Firehose` injects props without TypeScript knowing about it */}

--- a/frontend/public/components/cloud-services/subscription.tsx
+++ b/frontend/public/components/cloud-services/subscription.tsx
@@ -84,7 +84,7 @@ export const SubscriptionsPage: React.SFC<SubscriptionsPageProps> = (props) => <
 const stateToProps = ({k8s}, {obj}) => ({
   installedCSV: k8s.getIn([makeReduxID(ClusterServiceVersionModel, makeQuery(obj.metadata.namespace)), 'data'], ImmutableMap())
     .find((csv, key) => csv.getIn(['metadata', 'name']) === _.get(obj, 'status.installedCSV')),
-  pkg: (safeLoad(k8s.getIn([makeReduxID(ConfigMapModel, makeQuery('tectonic-system', null, null, obj.spec.source)), 'data', 'data', 'packages'], null)) || [])
+  pkg: (safeLoad(k8s.getIn([makeReduxID(ConfigMapModel, makeQuery('operator-lifecycle-manager', null, null, obj.spec.source)), 'data', 'data', 'packages'], null)) || [])
     .find((pkg: Package) => pkg.packageName === obj.spec.name),
 });
 
@@ -198,7 +198,7 @@ export const SubscriptionDetailsPage: React.SFC<SubscriptionDetailsPageProps> = 
   ]}
   resources={[
     // FIXME: Only including `tectonic-ocs` catalog's configmap, need to revise when we support more catalog sources
-    {kind: ConfigMapModel.kind, name: 'tectonic-ocs', namespace: 'tectonic-system', isList: false, prop: 'configMap'},
+    {kind: ConfigMapModel.kind, name: 'tectonic-ocs', namespace: 'operator-lifecycle-manager', isList: false, prop: 'configMap'},
     {kind: referenceForModel(ClusterServiceVersionModel), namespace: props.namespace, isList: true, prop: 'clusterServiceVersion'},
   ]}
   menuActions={Cog.factory.common} />;


### PR DESCRIPTION
### Description

Changes hard-coded `tectonic-system` namespace to `operator-lifecycle-manager`. The OLM CI has already been updated to deploy to this namespace.

Fixes https://jira.coreos.com/browse/ALM-643