### PR TITLE
Integration Tests: Wait until cog is clickable before deleting row

### DIFF
--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -25,7 +25,7 @@ export const gearOptions = {
  * Deletes a row from a list. Does not wait until the row is no longer visible.
  */
 export const deleteRow = (kind: string) => (name: string) => rowForName(name).$$('.co-m-cog').first().click()
-  .then(() => browser.wait(until.visibilityOf(rowForName(name).$('.co-m-cog__dropdown'))))
+  .then(() => browser.wait(until.elementToBeClickable(rowForName(name).$('.co-m-cog__dropdown'))))
   .then(() => rowForName(name).$('.co-m-cog__dropdown').$$('a').filter(link => link.getText().then(text => text.startsWith('Delete'))).first().click())
   .then(async() => {
     switch (kind) {


### PR DESCRIPTION
We delete the test resource immediately after closing the annotation dialog when the annotation tests are finished. Due to the closing animation, the modal overlay can prevent the cog from being clicked even though the cog is visible.

Change the check from `until.visibilityOf` to `until.elementToBeClickable` to wait until the cog is really clickable, not just on the screen.