### PR TITLE
frontend: fix null in pod logs when no containers available

### DIFF
--- a/frontend/public/components/pod-logs.jsx
+++ b/frontend/public/components/pod-logs.jsx
@@ -16,7 +16,13 @@ const containersToStatuses = ({ status }, containers) => {
   }, {});
 };
 
-const containerToLogSourceStatus = ({ state, lastState }) => {
+const containerToLogSourceStatus = (container) => {
+  if (!container) {
+    return LOG_SOURCE_WAITING;
+  }
+
+  const { state, lastState } = container;
+
   if (state.waiting && !_.isEmpty(lastState)) {
     return LOG_SOURCE_RESTARTING;
   }
@@ -51,7 +57,7 @@ export class PodLogs extends React.Component {
     newState.initContainers = containersToStatuses(build, initContainers);
     if (!currentKey) {
       const firstContainer = _.find(newState.containers, { order: 0 });
-      newState.currentKey = firstContainer.name;
+      newState.currentKey = firstContainer ? firstContainer.name : '';
     }
     return newState;
   }
@@ -74,7 +80,7 @@ export class PodLogs extends React.Component {
 
     return <div className="co-m-pane__body">
       <ResourceLog
-        containerName={currentContainer.name}
+        containerName={currentContainer ? currentContainer.name : ''}
         kind="Pod"
         dropdown={containerDropdown}
         namespace={namespace}

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -411,7 +411,7 @@ ActionsMenu.propTypes = {
 };
 
 const containerLabel = (container) =>
-  <ResourceName name={container.name} kind="Container" />;
+  <ResourceName name={container ? container.name : ''} kind="Container" />;
 
 export class ContainerDropdown extends React.PureComponent {
 
@@ -429,6 +429,9 @@ export class ContainerDropdown extends React.PureComponent {
 
   render() {
     const {currentKey, containers, initContainers, onChange} = this.props;
+    if (_.isEmpty(containers) && _.isEmpty(initContainers)) {
+      return null;
+    }
     const firstInitContainer = _.find(initContainers, {order: 0});
     const firstContainer = _.find(containers, {order: 0});
     const spacerBefore = this.getSpacer(firstInitContainer);


### PR DESCRIPTION
Happened in a pod with pending state which did not have any container statuses

Looks like this after the fix.

![poddetail](https://user-images.githubusercontent.com/3648838/43266065-aecb62d6-90ea-11e8-8599-ce7ffa6680c4.png)

Should I disable the pod button or all the logs in this case?

