### PR TITLE
Reduce .co-m-nav-link font size to fix bug

### DIFF
--- a/frontend/public/components/_nav.scss
+++ b/frontend/public/components/_nav.scss
@@ -6,11 +6,10 @@ $active-border: 3px;
 .co-m-nav-link {
   display: block;
   float: none;
-  padding: 2px 0;
-  padding-left: $link-padding-left;
-  line-height: 25px;
-  font-size: 14px;
+  font-size: 13px;
+  line-height: 23px;
   overflow-x: hidden;
+  padding: 2px 0 2px $link-padding-left;
   white-space: nowrap;
 
   a {


### PR DESCRIPTION
where the final "s" in "Persistent Volume Claims" could be masked by a scrollbar.  Has the added benefit of better distinguishing the secondary nav link (.co-m-nav-link) from primary nav links.  Possible downside is reduced readability?

Fixes https://jira.coreos.com/browse/CONSOLE-643

Before:
Chrome on macOS with scrollbars always visible
![screen shot 2018-07-26 at 12 26 26 pm](https://user-images.githubusercontent.com/895728/43275259-5528b078-90cf-11e8-8589-f26f73d26465.PNG)
Chrome on Windows
![screen shot 2018-07-26 at 12 40 27 pm](https://user-images.githubusercontent.com/895728/43275888-1969e35c-90d1-11e8-9ec5-933004c7cac6.PNG)

After:
Chrome on macOS with scrollbars always visible
![screen shot 2018-07-26 at 12 59 06 pm](https://user-images.githubusercontent.com/895728/43276775-e1dc0bf6-90d3-11e8-90b8-c95c346dec32.PNG)
Chrome on Windows
![screen shot 2018-07-26 at 12 59 43 pm](https://user-images.githubusercontent.com/895728/43276785-e9850790-90d3-11e8-80ce-67b5d4e12a93.PNG)

