### PR TITLE
[WIP] Change 'Overview' to 'Dashboard'

### DIFF
--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -365,7 +365,7 @@ export class Nav extends React.Component {
       <div id="sidebar" className={classNames({'open': isOpen})}>
         <ClusterPickerNavSection />
         <div ref={this.scroller} onWheel={this.preventScroll} className="navigation-container">
-          <NavSection text="Overview" icon="fa fa-tachometer" href="/overview" activePath="/overview/" onClick={this.close} />
+          <NavSection text="Dashboard" icon="fa fa-tachometer" href="/overview" activePath="/overview/" onClick={this.close} />
 
           <NavSection required={FLAGS.CLOUD_SERVICES} text="Operators" img={operatorImg} activeImg={operatorActiveImg} >
             <ResourceNSLink model={ClusterServiceVersionModel} resource={ClusterServiceVersionModel.plural} name="Cluster Service Versions" onClick={this.close} />


### PR DESCRIPTION
Per https://github.com/openshift/console/issues/254#issuecomment-408204574.

Do we change the route to match the label (e.g., /dashboard)?

![screen shot 2018-07-26 at 3 50 50 pm](https://user-images.githubusercontent.com/895728/43285503-1f026b92-90ed-11e8-9705-efda7d61c876.PNG)
