### PR TITLE
Fix runtime error on Role -> Add Rule page

### DIFF
--- a/frontend/public/components/RBAC/edit-rule.jsx
+++ b/frontend/public/components/RBAC/edit-rule.jsx
@@ -53,7 +53,12 @@ const RadioButton = ({name, value, label, text, onChange, activeValue}) => <div>
 const HRMinor = () => <hr className="rbac-minor" />;
 const HRMajor = () => <hr className="rbac-major" />;
 
-const EditRule = connect(state => state.k8s.get('RESOURCES') || {}, {getResources: k8sActions.getResources}) (
+const stateToProps = state => {
+  const resourceMap = state.k8s.get('RESOURCES');
+  return resourceMap ? resourceMap.toObject() : {};
+};
+
+const EditRule = connect(stateToProps, {getResources: k8sActions.getResources}) (
   class EditRule_ extends PromiseComponent {
     constructor (props) {
       super(props);


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-637

`stateToProps` for EditRule was returning Map instead of plain object, causing runtime error.