### PR TITLE
Remove some additional items from resource dropdown

### DIFF
--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -4,11 +4,39 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';
 import * as PropTypes from 'prop-types';
-import { Map as ImmutableMap } from 'immutable';
+import { Map as ImmutableMap, OrderedMap, Set as ImmutableSet } from 'immutable';
 import * as classNames from 'classnames';
 
 import { Dropdown, ResourceIcon } from './utils';
 import { K8sKind, K8sResourceKindReference, referenceForModel, apiVersionForReference } from '../module/k8s';
+
+// Blacklist known duplicate resources.
+const blacklistGroups = ImmutableSet([
+  // Prefer rbac.authorization.k8s.io/v1, which has the same resources.
+  'authorization.openshift.io',
+]);
+
+const blacklistResources = ImmutableSet([
+  // Unfortunately a few resources we want to show like Ingress exist only in extensions/v1beta1,
+  // so we can't blacklist the entire group. The API group is eventually going away.
+  // https://github.com/kubernetes/kubernetes/issues/43214
+
+  // Prefer apps/v1
+  'extensions/v1beta1.DaemonSet',
+  'extensions/v1beta1.Deployment',
+  'extensions/v1beta1.NetworkPolicy',
+  'extensions/v1beta1.ReplicaSet',
+
+  // Prefer policy/v1beta1
+  'extensions/v1beta1.PodSecurityPolicy',
+
+  // Prefer core/v1
+  'events.k8s.io/v1beta1.Event',
+  'security.openshift.io/v1.SecurityContextConstraints',
+
+  // Hide dummy resource
+  'extensions/v1beta1.ReplicationControllerDummy',
+]);
 
 const DropdownItem: React.SFC<DropdownItemProps> = ({model, showGroup}) => <React.Fragment>
   <span className="co-type-selector__icon-wrapper">
@@ -21,31 +49,46 @@ const DropdownItem: React.SFC<DropdownItemProps> = ({model, showGroup}) => <Reac
 const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
   const { selected, onChange, allModels, showAll, className, preferredVersions } = props;
 
-  const items = allModels
-    .filter(model => {
+  const resources = allModels
+    .filter(({apiGroup, apiVersion, kind, verbs}) => {
+      // Remove blacklisted items.
+      if (blacklistGroups.has(apiGroup) || blacklistResources.has(`${apiGroup}/${apiVersion}.${kind}`)) {
+        return false;
+      }
+
+      // Only show resources that can be listed.
+      if (!_.isEmpty(verbs) && !_.includes(verbs, 'list')) {
+        return false;
+      }
+
+      // Only show preferred version for resources in the same API group.
       const preferred = (m: K8sKind) => preferredVersions.some(v => v.groupVersion === apiVersionForReference(referenceForModel(m)));
-      const sameGroupKind = (m: K8sKind) => m.kind === model.kind && m.apiGroup === model.apiGroup && m.apiVersion !== model.apiVersion;
+      const sameGroupKind = (m: K8sKind) => m.kind === kind && m.apiGroup === apiGroup && m.apiVersion !== apiVersion;
 
       return !allModels.find(m => sameGroupKind(m) && preferred(m));
     })
-    .sort((modelA, modelB) => modelA.kind > modelB.kind ? 1 : -1);
+    .toOrderedMap()
+    .sortBy(({kind, apiGroup}) => `${kind} ${apiGroup}`);
 
   // Track duplicate names so we know when to show the group.
-  const kinds = _.groupBy(items.toJS(), 'kind');
-  const isDup = kind => _.size(kinds[kind]) > 1;
-  const dropdownItems = (items
-    .map((model) => <DropdownItem key={referenceForModel(model)} model={model} showGroup={isDup(model.kind)} />) as ImmutableMap<string, JSX.Element>)
-    .merge(showAll
-      ? ImmutableMap({all: <React.Fragment>
-        <span className="co-type-selector__icon-wrapper">
-          <ResourceIcon kind="All" />
-        </span>All Types
-      </React.Fragment>})
-      : ImmutableMap()
+  const kinds = resources.groupBy(m => m.kind);
+  const isDup = kind => kinds.get(kind).size > 1;
+
+  // Create dropdown items for each resource.
+  const items = resources.map((model) => <DropdownItem key={referenceForModel(model)} model={model} showGroup={isDup(model.kind)} />) as OrderedMap<string, JSX.Element>;
+
+  // Add an "All" item to the top if `showAll`.
+  const allItems = (showAll
+    ? OrderedMap({all: <React.Fragment>
+      <span className="co-type-selector__icon-wrapper">
+        <ResourceIcon kind="All" />
+      </span>All Types
+    </React.Fragment>}).concat(items)
+    : items
     )
     .toJS() as {[s: string]: JSX.Element};
 
-  return <Dropdown className={classNames('co-type-selector', className)} items={dropdownItems} title={dropdownItems[selected]} onChange={onChange} selectedKey={selected} />;
+  return <Dropdown className={classNames('co-type-selector', className)} items={allItems} title={allItems[selected]} onChange={onChange} selectedKey={selected} />;
 };
 
 const resourceListDropdownStateToProps = ({k8s}) => ({

--- a/frontend/public/components/utils/resource-icon.tsx
+++ b/frontend/public/components/utils/resource-icon.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash-es';
 
 import { K8sResourceKindReference } from '../../module/k8s';
 import { modelFor } from '../../module/k8s/k8s-models';
+import { kindToAbbr } from '../../module/k8s/get-resources';
 
 const MEMO = {};
 
@@ -16,7 +17,7 @@ export const ResourceIcon = (props: ResourceIconProps) => {
   const kindObj = modelFor(kind);
   const kindStr = _.get(kindObj, 'kind', kind);
   const klass = classNames(`co-m-resource-icon co-m-resource-${kindStr.toLowerCase()}`, className);
-  const iconLabel = (kindObj && kindObj.abbr) || kindStr.toUpperCase().slice(0, 3);
+  const iconLabel = (kindObj && kindObj.abbr) || kindToAbbr(kindStr);
 
   const rendered = <span className={klass}>{iconLabel}</span>;
   if (kindObj) {

--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -9,6 +9,8 @@ const ADMIN_RESOURCES = new Set(
   ['roles', 'rolebindings', 'clusterroles', 'clusterrolebindings', 'thirdpartyresources', 'nodes', 'secrets']
 );
 
+export const kindToAbbr = kind => (kind.replace(/[^A-Z]/g, '') || kind.toUpperCase()).slice(0, 3);
+
 export const getResources = () => coFetchJSON('api/kubernetes/apis')
   .then(res => {
     const preferredVersions = res.groups.map(group => group.preferredVersion);
@@ -31,15 +33,15 @@ export const getResources = () => coFetchJSON('api/kubernetes/apis')
         const adminResources = [];
 
         const defineModels = (list: APIResourceList): K8sKind[] => list.resources.filter(({name}) => !name.includes('/'))
-          .map(({name, singularName, namespaced, kind}) => {
+          .map(({name, singularName, namespaced, kind, verbs}) => {
             const label = kind.replace(/([A-Z]+)/g, ' $1').slice(1);
             const groupVersion = list.groupVersion.split('/').length === 2 ? list.groupVersion : `core/${list.groupVersion}`;
 
             return {
-              kind, namespaced, label,
+              kind, namespaced, label, verbs,
               plural: name,
               apiVersion: groupVersion.split('/')[1],
-              abbr: kind.replace(/([a-z+])/g, ''),
+              abbr: kindToAbbr(kind),
               apiGroup: groupVersion.split('/')[0],
               labelPlural: `${label}${label.endsWith('s') ? 'es' : 's'}`,
               path: name,

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -69,6 +69,7 @@ export type K8sKind = {
   selector?: {matchLabels?: {[key: string]: string}};
   labels?: {[key: string]: string};
   annotations?: {[key: string]: string};
+  verbs?: string[];
 };
 
 /**


### PR DESCRIPTION
Remove items that can't be listed and a few well-known items that
appear in different API groups.

This also improves the resource icon abbreviation to use the capital
letters from a resource instead of just the first 3 letters (which are
often repeated for many resources).

/cc @alecmerdler @rhamilto 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1609729
Fixes  https://bugzilla.redhat.com/show_bug.cgi?id=1609733
Fixes CONSOLE-651

<img width="327" alt="search openshift origin 2018-07-26 20-03-11" src="https://user-images.githubusercontent.com/1167259/43294733-f1e8cfa8-910e-11e8-9c4a-f514594a94f9.png">
