### PR TITLE
Fix runtime error visiting create page directly

### DIFF
--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -39,6 +39,10 @@ export class ResourceSidebarWrapper extends React.Component {
 
 export const ResourceSidebar = props => {
   const {kindObj, height} = props;
+  if (!kindObj) {
+    return null;
+  }
+
   const {kind, label} = kindObj;
   let SidebarComponent = resourceSidebars.get(kind);
   if (SidebarComponent) {


### PR DESCRIPTION
If you directly hit one of the `/new` URLs, the app will white screen
since discovery hasn't completed. Make sure the model is loaded before
trying to show the resource sidebar.

/assign @rhamilto 