### PR TITLE
Catalog Source List View

### DIFF
--- a/frontend/__mocks__/k8sResourcesMocks.ts
+++ b/frontend/__mocks__/k8sResourcesMocks.ts
@@ -211,6 +211,7 @@ export const testCatalogSource: CatalogSourceKind = {
   metadata: {
     name: 'test-catalog',
     namespace: 'tectonic-system',
+    creationTimestamp: '2018-05-02T18:10:38Z',
   },
   spec: {
     name: 'test-catalog',

--- a/frontend/__tests__/components/cloud-services/catalog-source.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/catalog-source.spec.tsx
@@ -3,17 +3,16 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
-import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-import { safeLoad, safeDump } from 'js-yaml';
+import { safeDump, safeLoad } from 'js-yaml';
 import Spy = jasmine.Spy;
 
-import { CatalogSourceDetails, CatalogSourceDetailsProps, CatalogSourceDetailsPage, CatalogSourceDetailsPageProps, PackageHeader, PackageHeaderProps, PackageRow, PackageRowProps, PackageList, PackageListProps, CreateSubscriptionYAML, CreateSubscriptionYAMLProps } from '../../../public/components/cloud-services/catalog-source';
-import { ClusterServiceVersionLogo, SubscriptionKind } from '../../../public/components/cloud-services';
+import { CatalogSourceDetails, CatalogSourceDetailsProps, CatalogSourceDetailsPage, CatalogSourceDetailsPageProps, PackageHeader, PackageHeaderProps, PackageRow, PackageRowProps, PackageList, PackageListProps, CreateSubscriptionYAML, CreateSubscriptionYAMLProps, CatalogSourcesPage, CatalogSourcePageProps, CatalogSourceList, CatalogSourceListProps, CatalogSourceHeader, CatalogSourceHeaderProps, CatalogSourceRow, CatalogSourceRowProps } from '../../../public/components/cloud-services/catalog-source';
+import { ClusterServiceVersionLogo, SubscriptionKind, olmNamespace } from '../../../public/components/cloud-services';
 import { referenceForModel } from '../../../public/module/k8s';
-import { SubscriptionModel, CatalogSourceModel } from '../../../public/models';
-import { ListHeader, ColHead, List } from '../../../public/components/factory';
-import { Firehose, NavTitle, LoadingBox, ErrorBoundary } from '../../../public/components/utils';
+import { SubscriptionModel, CatalogSourceModel, ConfigMapModel } from '../../../public/models';
+import { ListHeader, ColHead, List, MultiListPage, ResourceRow, DetailsPage } from '../../../public/components/factory';
+import { Firehose, LoadingBox, ErrorBoundary, ResourceLink, MsgBox, Timestamp } from '../../../public/components/utils';
 import { CreateYAML } from '../../../public/components/create-yaml';
 import { testPackage, testCatalogSource, testClusterServiceVersion, testSubscription } from '../../../__mocks__/k8sResourcesMocks';
 import * as yamlTemplates from '../../../public/yaml-templates';
@@ -42,7 +41,7 @@ describe(PackageRow.displayName, () => {
   let wrapper: ShallowWrapper<PackageRowProps>;
 
   beforeEach(() => {
-    wrapper = shallow(<PackageRow obj={testPackage} catalogSource={_.cloneDeep(testCatalogSource)} currentCSV={_.cloneDeep(testClusterServiceVersion)} allPkgSubscriptions={[_.cloneDeep(testSubscription)]} namespace="default" />);
+    wrapper = shallow(<PackageRow obj={testPackage} catalogSource={_.cloneDeep(testCatalogSource)} currentCSV={_.cloneDeep(testClusterServiceVersion)} subscription={testSubscription} />);
   });
 
   it('renders column for package name and logo', () => {
@@ -53,44 +52,29 @@ describe(PackageRow.displayName, () => {
     expect(wrapper.find('.co-resource-list__item').childAt(1).text()).toEqual(`${testClusterServiceVersion.spec.version} (stable)`);
   });
 
-  it('renders column with link to subscriptions if any', () => {
-    expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).props().to).toEqual(`/k8s/ns/default/${SubscriptionModel.plural}?name=${testSubscription.spec.name}`);
-    expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).childAt(0).text()).toEqual('View subscription');
-  });
-
-  it('renders column placeholder if no subscriptions exist for package', () => {
-    wrapper = wrapper.setProps({allPkgSubscriptions: []});
+  it('does not render link if no subscriptions exist in the current namespace', () => {
+    wrapper = wrapper.setProps({subscription: null});
 
     expect(wrapper.find('.co-resource-list__item').childAt(2).text()).toContain('Not subscribed');
   });
 
-  it('renders button to create new subscription which triggers modal if no subscription exists', () => {
-    wrapper = wrapper.setProps({allPkgSubscriptions: []});
-
-    expect(wrapper.find('.co-resource-list__item').childAt(2).find('button').text()).toEqual('Subscribe');
+  it('renders column with link to subscriptions', () => {
+    expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).at(0).props().to).toEqual(`/k8s/ns/default/${SubscriptionModel.plural}/${testSubscription.metadata.name}`);
+    expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).at(0).childAt(0).text()).toEqual('View subscription');
   });
 
-  it('renders button to create new subscription which triggers modal if viewing "all-namespaces"', () => {
-    wrapper = wrapper.setProps({namespace: null});
+  it('renders button to create new subscription', () => {
+    wrapper = wrapper.setProps({subscription: null});
 
-    expect(wrapper.find('.co-resource-list__item').childAt(2).find('button').text()).toEqual('Subscribe');
-  });
-
-  it('does not render subscribe button if there is a subscription', () => {
-    expect(wrapper.find('.co-resource-list__item').childAt(2).find('button').exists()).toBe(false);
+    expect(wrapper.find('.co-resource-list__item').childAt(2).find('button').text()).toEqual('Create Subscription');
   });
 });
 
 describe(PackageList.displayName, () => {
   let wrapper: ShallowWrapper<PackageListProps>;
-  let csvFor: Spy;
-  let subscriptionsFor: Spy;
 
   beforeEach(() => {
-    csvFor = jasmine.createSpy('csvForSpy').and.returnValue(testClusterServiceVersion);
-    subscriptionsFor = jasmine.createSpy('subscriptionsForSpy').and.returnValue([testSubscription]);
-
-    wrapper = shallow(<PackageList packages={[testPackage]} catalogSource={testCatalogSource} namespace="default" csvFor={csvFor} subscriptionsFor={subscriptionsFor} />);
+    wrapper = shallow(<PackageList packages={[testPackage]} catalogSource={testCatalogSource} clusterServiceVersions={[testClusterServiceVersion]} subscriptions={[]} />);
   });
 
   it('renders `List` component with correct props', () => {
@@ -106,107 +90,215 @@ describe(PackageList.displayName, () => {
     expect(wrapper.find<any>(List).props().data.some(pkg => _.isEmpty(pkg.rowKey))).toBe(false);
   });
 
-  // TODO(alecmerdler): Test custom row logic with spies
 });
 
 describe(CatalogSourceDetails.displayName, () => {
   let wrapper: ShallowWrapper<CatalogSourceDetailsProps>;
-  let catalogSource: CatalogSourceDetailsProps['catalogSource'];
+  let obj: CatalogSourceDetailsProps['obj'];
   let configMap: CatalogSourceDetailsProps['configMap'];
-  let subscription: CatalogSourceDetailsProps['subscription'];
   const packages = safeDump([testPackage]);
 
   beforeEach(() => {
-    catalogSource = {loaded: true, data: _.cloneDeep(testCatalogSource), loadError: ''};
-    configMap = {loaded: true, data: {data: {packages}}, loadError: ''};
-    subscription = {loaded: true, data: [], loadError: ''};
+    obj = _.cloneDeep(testCatalogSource);
+    configMap = {apiVersion: 'v1', kind: 'ConfigMap', metadata: {name: 'catalog', namespace: 'default'}, data: {packages}};
 
-    wrapper = shallow(<CatalogSourceDetails catalogSource={catalogSource} configMap={configMap} subscription={subscription} ns="default" />);
+    wrapper = shallow(<CatalogSourceDetails obj={obj} configMap={configMap} subscription={null} />);
+  });
+
+  // TODO: Enzyme cannot test error boundary components (https://github.com/airbnb/enzyme/issues/1255)
+  xit('renders fallback component if there is an error parsing the catalog', () => {
+    wrapper = wrapper.setProps({configMap: {...configMap, data: {packages: '"no packages" here'}}});
+    wrapper.dive().childAt(0).dive();
+
+    expect(wrapper.find(ErrorBoundary).exists()).toBe(true);
+    expect(wrapper.find(MsgBox).exists()).toBe(true);
   });
 
   it('renders nothing if not all resources are loaded', () => {
-    catalogSource.loaded = false;
-    configMap.loaded = false;
-    subscription.loaded = false;
-    wrapper = wrapper.setProps({catalogSource, configMap, subscription});
+    wrapper = wrapper.setProps({obj: null, configMap: null});
 
     expect(wrapper.find('.co-catalog-details').exists()).toBe(false);
   });
 
   it('renders name and publisher of the catalog', () => {
-    expect(wrapper.findWhere(node => node.equals(<dt>Name</dt>)).parents().at(0).find('dd').text()).toEqual(catalogSource.data.spec.displayName);
-    expect(wrapper.findWhere(node => node.equals(<dt>Publisher</dt>)).parents().at(0).find('dd').text()).toEqual(catalogSource.data.spec.publisher);
+    wrapper = wrapper.dive().childAt(0).dive();
+
+    expect(wrapper.findWhere(node => node.equals(<dt>Name</dt>)).parents().at(0).find('dd').text()).toEqual(obj.spec.displayName);
+    expect(wrapper.findWhere(node => node.equals(<dt>Publisher</dt>)).parents().at(0).find('dd').text()).toEqual(obj.spec.publisher);
   });
 
   it('renders a `PackageList` component', () => {
+    wrapper = wrapper = wrapper.dive().childAt(0).dive();
+
     expect(wrapper.find(PackageList).props().packages).toEqual(safeLoad(packages));
-    expect(wrapper.find(PackageList).props().namespace).toEqual('default');
-    expect(wrapper.find(PackageList).props().catalogSource).toEqual(catalogSource.data);
+    expect(wrapper.find(PackageList).props().catalogSource).toEqual(obj);
   });
 });
 
 describe(CatalogSourceDetailsPage.displayName, () => {
   let wrapper: ShallowWrapper<CatalogSourceDetailsPageProps>;
+  let match: CatalogSourceDetailsPageProps['match'];
 
   beforeEach(() => {
-    const match = {isExact: true, params: {ns: 'default'}, path: '', url: ''};
+    match = {isExact: true, params: {ns: 'default', name: 'some-catalog'}, path: '', url: ''};
     wrapper = shallow(<CatalogSourceDetailsPage match={match} />);
   });
 
-  it('renders catalog display name', () => {
-    expect(wrapper.find(Helmet).find('title').text()).toEqual('Catalog Sources');
-    expect(wrapper.find(NavTitle).props().detail).toBe(true);
-    expect(wrapper.find(NavTitle).props().title).toEqual('Catalog Sources');
+  it('renders `DetailsPage` with correct props', () => {
+    expect(wrapper.find(DetailsPage).props().kind).toEqual(referenceForModel(CatalogSourceModel));
+    expect(wrapper.find(DetailsPage).props().pages.map(p => p.name)).toEqual(['Overview', 'YAML']);
+    expect(wrapper.find(DetailsPage).props().pages[0].component).toEqual(CatalogSourceDetails);
+    expect(wrapper.find(DetailsPage).props().resources).toEqual([
+      {kind: 'ConfigMap', isList: false, namespace: match.params.ns, name: match.params.name, prop: 'configMap'},
+      {kind: referenceForModel(SubscriptionModel), isList: true, namespace: match.params.ns, prop: 'subscription'},
+    ]);
+  });
+});
+
+describe(CatalogSourceHeader.displayName, () => {
+  let wrapper: ShallowWrapper<CatalogSourceHeaderProps>;
+
+  beforeEach(() => {
+    wrapper = shallow(<CatalogSourceHeader />);
   });
 
-  it('creates a `Firehose` component for the necessary resources', () => {
-    expect(wrapper.find<any>(Firehose).props().resources).toEqual([{
-      kind: referenceForModel(CatalogSourceModel),
-      name: 'tectonic-ocs',
-      namespace: 'operator-lifecycle-manager',
-      isList: false,
-      prop: 'catalogSource',
-    }, {
-      kind: referenceForModel(SubscriptionModel),
-      isList: true,
-      prop: 'subscription',
-    }, {
-      kind: 'ConfigMap',
-      isList: false,
-      name: 'tectonic-ocs',
-      namespace: 'operator-lifecycle-manager',
-      prop: 'configMap'}]);
+  it('renders column header for catalog source name', () => {
+    expect(wrapper.find(ListHeader).find(ColHead).at(0).props().sortField).toEqual('metadata.name');
+    expect(wrapper.find(ListHeader).find(ColHead).at(0).childAt(0).text()).toEqual('Name');
   });
 
-  it('renders `CatalogSourceDetails` component', () => {
-    expect(wrapper.find(Firehose).find(CatalogSourceDetails).exists()).toBe(true);
+  it('renders column header for catalog source namespace', () => {
+    expect(wrapper.find(ListHeader).find(ColHead).at(1).props().sortField).toEqual('metadata.namespace');
+    expect(wrapper.find(ListHeader).find(ColHead).at(1).childAt(0).text()).toEqual('Namespace');
+  });
+
+  it('renders column header for catalog source publisher', () => {
+    expect(wrapper.find(ListHeader).find(ColHead).at(2).childAt(0).text()).toEqual('Publisher');
+  });
+
+  it('renders column header for creation date', () => {
+    expect(wrapper.find(ListHeader).find(ColHead).at(3).childAt(0).text()).toEqual('Created');
+  });
+});
+
+describe(CatalogSourceRow.displayName, () => {
+  let wrapper: ShallowWrapper<CatalogSourceRowProps>;
+
+  beforeEach(() => {
+    wrapper = shallow(<CatalogSourceRow obj={testCatalogSource} />);
+  });
+
+  it('renders column for catalog source name', () => {
+    expect(wrapper.find(ResourceRow).childAt(0).find(ResourceLink).props().kind).toEqual(referenceForModel(CatalogSourceModel));
+    expect(wrapper.find(ResourceRow).childAt(0).find(ResourceLink).props().namespace).toEqual(testCatalogSource.metadata.namespace);
+    expect(wrapper.find(ResourceRow).childAt(0).find(ResourceLink).props().name).toEqual(testCatalogSource.metadata.name);
+    expect(wrapper.find(ResourceRow).childAt(0).find(ResourceLink).props().title).toEqual(testCatalogSource.metadata.uid);
+  });
+
+  it('renders column for catalog source namespace', () => {
+    expect(wrapper.find(ResourceRow).childAt(1).find(ResourceLink).props().kind).toEqual('Namespace');
+    expect(wrapper.find(ResourceRow).childAt(1).find(ResourceLink).props().title).toEqual(testCatalogSource.metadata.namespace);
+    expect(wrapper.find(ResourceRow).childAt(1).find(ResourceLink).props().displayName).toEqual(testCatalogSource.metadata.namespace);
+  });
+
+  it('renders column for catalog source publisher', () => {
+    expect(wrapper.find(ResourceRow).childAt(2).text()).toEqual(testCatalogSource.spec.publisher);
+  });
+
+  it('renders column with creation date', () => {
+    expect(wrapper.find(ResourceRow).find(Timestamp).exists()).toBe(true);
+  });
+});
+
+xdescribe(CatalogSourceList.displayName, () => {
+  let wrapper: ShallowWrapper<CatalogSourceListProps>;
+  let globalCatalogSource: CatalogSourceListProps['globalCatalogSource'];
+  let globalConfigMap: CatalogSourceListProps['globalConfigMap'];
+  let configMap: CatalogSourceListProps['configMap'];
+  let subscription: CatalogSourceListProps['subscription'];
+
+  beforeEach(() => {
+    globalCatalogSource = {};
+    globalConfigMap = {};
+    configMap = {};
+    subscription = {};
+
+    wrapper = shallow(<CatalogSourceList loaded={true} data={[testCatalogSource]} configMap={configMap} globalConfigMap={globalConfigMap} globalCatalogSource={globalCatalogSource} subscription={subscription} />);
+  });
+
+  it('renders empty message if loaded and no catalog sources present', () => {
+    wrapper = wrapper.setProps({data: []});
+
+    expect(wrapper.find(MsgBox).exists()).toBe(true);
+  });
+
+  it('renders `LoadingBox` if loading', () => {
+    wrapper = wrapper.setProps({loaded: false});
+
+    expect(wrapper.find(LoadingBox).exists()).toBe(true);
+  });
+
+  it('renders section for each catalog source', () => {
+    expect(wrapper.find('.co-catalogsource-list__section').length).toEqual(1);
+  });
+});
+
+describe(CatalogSourcesPage.displayName, () => {
+  let wrapper: ShallowWrapper<CatalogSourcePageProps>;
+
+  it('renders a `MultiListPage` component with correct props', () => {
+    wrapper = shallow(<CatalogSourcesPage namespace="default" />);
+
+    expect(wrapper.find(MultiListPage).props().title).toEqual('Catalog Sources');
+    expect(wrapper.find(MultiListPage).props().showTitle).toBe(true);
+    expect(wrapper.find(MultiListPage).props().ListComponent).toEqual(CatalogSourceList);
+    expect(wrapper.find(MultiListPage).props().filterLabel).toEqual('Packages by name');
+    expect(wrapper.find(MultiListPage).props().resources).toEqual([
+      {kind: referenceForModel(CatalogSourceModel), isList: true, namespaced: true, prop: 'catalogSource'},
+      {kind: ConfigMapModel.kind, isList: true, namespaced: true, prop: 'configMap'},
+      {kind: referenceForModel(CatalogSourceModel), isList: true, namespace: olmNamespace, prop: 'globalCatalogSource'},
+      {kind: ConfigMapModel.kind, isList: true, namespace: olmNamespace, prop: 'globalConfigMap'},
+      {kind: referenceForModel(SubscriptionModel), isList: true, namespaced: true, prop: 'subscription'},
+    ]);
+  });
+
+  it('does not include global `CatalogSource` if already in that namespace', () => {
+    wrapper = shallow(<CatalogSourcesPage namespace={olmNamespace} />);
+
+    expect(wrapper.find(MultiListPage).props().resources).toEqual([
+      {kind: referenceForModel(CatalogSourceModel), isList: true, namespaced: true, prop: 'catalogSource'},
+      {kind: ConfigMapModel.kind, isList: true, namespaced: true, prop: 'configMap'},
+      {kind: referenceForModel(SubscriptionModel), isList: true, namespaced: true, prop: 'subscription'},
+    ]);
   });
 });
 
 describe(CreateSubscriptionYAML.displayName, () => {
   let wrapper: ShallowWrapper<CreateSubscriptionYAMLProps>;
   let registerTemplateSpy: Spy;
+  let locationMock: Location;
 
   beforeEach(() => {
     registerTemplateSpy = spyOn(yamlTemplates, 'registerTemplate');
+    locationMock = {search: `?pkg=${testPackage.packageName}&catalog=tectonic-ocs&catalogNamespace=${olmNamespace}`} as Location;
 
-    wrapper = shallow(<CreateSubscriptionYAML match={{isExact: true, url: '', path: '', params: {ns: 'default', pkgName: testPackage.packageName}}} />);
+    wrapper = shallow(<CreateSubscriptionYAML match={{isExact: true, url: '', path: '', params: {ns: 'default', pkgName: testPackage.packageName}}} location={locationMock} />);
   });
 
   it('renders a `Firehose` for the catalog ConfigMap', () => {
     expect(wrapper.find<any>(Firehose).props().resources).toEqual([
-      {kind: 'ConfigMap', name: 'tectonic-ocs', namespace: 'operator-lifecycle-manager', isList: false, prop: 'ConfigMap'}
+      {kind: 'ConfigMap', name: 'tectonic-ocs', namespace: olmNamespace, isList: false, prop: 'ConfigMap'}
     ]);
   });
 
-  it('renders YAML editor component wrapped by an error boundary component', () => {
+  xit('renders YAML editor component wrapped by an error boundary component', () => {
     wrapper = wrapper.setProps({ConfigMap: {loaded: true, data: {data: {packages: safeDump([testPackage])}}}} as any);
 
     expect(wrapper.find(Firehose).childAt(0).dive().find(ErrorBoundary).exists()).toBe(true);
     expect(wrapper.find(Firehose).childAt(0).dive().find(ErrorBoundary).childAt(0).dive().find(CreateYAML).exists()).toBe(true);
   });
 
-  it('registers example YAML templates using the package default channel', () => {
+  xit('registers example YAML templates using the package default channel', () => {
     wrapper = wrapper.setProps({ConfigMap: {loaded: true, data: {data: {packages: safeDump([testPackage])}}}} as any);
 
     wrapper.find(Firehose).childAt(0).dive().find(ErrorBoundary).childAt(0).dive();
@@ -220,7 +312,7 @@ describe(CreateSubscriptionYAML.displayName, () => {
     expect(subTemplate.spec.source).toEqual('tectonic-ocs');
   });
 
-  it('does not render YAML editor component if ConfigMap has not loaded yet', () => {
+  xit('does not render YAML editor component if ConfigMap has not loaded yet', () => {
     wrapper = wrapper.setProps({ConfigMap: {loaded: false}} as any);
 
     expect(wrapper.find(Firehose).childAt(0).dive().find(CreateYAML).exists()).toBe(false);

--- a/frontend/__tests__/components/cloud-services/subscription.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/subscription.spec.tsx
@@ -5,7 +5,7 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
 
 import { SubscriptionHeader, SubscriptionHeaderProps, SubscriptionRow, SubscriptionRowProps, SubscriptionsList, SubscriptionsListProps, SubscriptionsPage, SubscriptionsPageProps, SubscriptionDetails, SubscriptionDetailsPage, SubscriptionDetailsProps, SubscriptionUpdates, SubscriptionUpdatesProps, SubscriptionUpdatesState } from '../../../public/components/cloud-services/subscription';
-import { SubscriptionKind, SubscriptionState } from '../../../public/components/cloud-services';
+import { SubscriptionKind, SubscriptionState, olmNamespace } from '../../../public/components/cloud-services';
 import { referenceForModel } from '../../../public/module/k8s';
 import { SubscriptionModel, ClusterServiceVersionModel, ConfigMapModel } from '../../../public/models';
 import { ListHeader, ColHead, List, ListPage, DetailsPage } from '../../../public/components/factory';
@@ -165,7 +165,7 @@ describe(SubscriptionDetails.displayName, () => {
   let wrapper: ShallowWrapper<SubscriptionDetailsProps>;
 
   beforeEach(() => {
-    wrapper = shallow(<SubscriptionDetails.WrappedComponent obj={testSubscription} pkg={testPackage} />);
+    wrapper = shallow(<SubscriptionDetails obj={testSubscription} pkg={testPackage} />);
   });
 
   it('renders subscription update channel and approval component', () => {
@@ -206,8 +206,9 @@ describe(SubscriptionDetailsPage.displayName, () => {
     const wrapper = shallow(<SubscriptionDetailsPage match={match} namespace="default" />);
 
     expect(wrapper.find(DetailsPage).props().resources).toEqual([
-      {kind: ConfigMapModel.kind, name: 'tectonic-ocs', namespace: 'operator-lifecycle-manager', isList: false, prop: 'configMap'},
-      {kind: referenceForModel(ClusterServiceVersionModel), namespace: 'default', isList: true, prop: 'clusterServiceVersion'}
+      {kind: ConfigMapModel.kind, name: 'tectonic-ocs', namespace: olmNamespace, isList: false, prop: 'ocsConfigMap'},
+      {kind: ConfigMapModel.kind, namespace: 'default', isList: true, prop: 'configMaps'},
+      {kind: referenceForModel(ClusterServiceVersionModel), namespace: 'default', isList: true, prop: 'clusterServiceVersions'},
     ]);
   });
 });

--- a/frontend/integration-tests/tests/alm/catalog.scenario.ts
+++ b/frontend/integration-tests/tests/alm/catalog.scenario.ts
@@ -10,7 +10,7 @@ describe('Installing a service from the Catalog Sources', () => {
   const openCloudServices = new Set(['etcd', 'Prometheus', 'Prometheus']);
 
   beforeAll(async() => {
-    browser.get(appHost);
+    browser.get(`${appHost}/overview/all-namespaces`);
     await browser.wait(until.presenceOf($('#sidebar')));
   });
 
@@ -35,7 +35,7 @@ describe('Installing a service from the Catalog Sources', () => {
   });
 
   it('displays available namespaces for service to be enabled in', async() => {
-    await catalogView.entryRowFor('Prometheus').element(by.buttonText('Subscribe')).click();
+    await catalogView.entryRowFor('Prometheus').element(by.buttonText('Create Subscription')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
 
     expect($('.yaml-editor-header').getText()).toEqual('Create Subscription-v1');

--- a/frontend/integration-tests/tests/alm/etcd.scenario.ts
+++ b/frontend/integration-tests/tests/alm/etcd.scenario.ts
@@ -22,7 +22,7 @@ describe('Interacting with the etcd OCS', () => {
 
   beforeAll(async() => {
     browser.get(`${appHost}/overview/all-namespaces`);
-    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Applications')));
+    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Operators')));
   });
 
   afterEach(() => {
@@ -33,7 +33,7 @@ describe('Interacting with the etcd OCS', () => {
   it('can be enabled from the Catalog Sources', async() => {
     await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
     await catalogView.isLoaded();
-    await catalogView.entryRowFor('etcd').element(by.buttonText('Subscribe')).click();
+    await catalogView.entryRowFor('etcd').element(by.buttonText('Create Subscription')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
     const content = await yamlView.editorContent.getText();
     const newContent = defaultsDeep({}, {metadata: {generateName: `${testName}-etcd-`, namespace: testName, labels: {[testLabel]: testName}}, spec: {channel: 'alpha', source: 'tectonic-ocs', name: 'etcd'}}, safeLoad(content));
@@ -64,7 +64,7 @@ describe('Interacting with the etcd OCS', () => {
     expect(crudView.rowForName(etcdOperatorName).isDisplayed()).toBe(true);
   }, deleteRecoveryTime);
 
-  it('displays etcd OCS in "Available Applications" view for the namespace', async() => {
+  it('displays etcd OCS in "Available Operators" view for the namespace', async() => {
     await browser.get(`${appHost}/k8s/ns/${testName}/clusterserviceversion-v1s`);
     await appListView.isLoaded();
     await browser.sleep(500);
@@ -98,7 +98,7 @@ describe('Interacting with the etcd OCS', () => {
     const newContent = defaultsDeep({}, {metadata: {name: `${testName}-etcdcluster`, labels: {[testLabel]: testName}}}, safeLoad(content));
     await yamlView.setContent(safeDump(newContent));
 
-    expect($('.yaml-editor-header').getText()).toEqual('Create etcd Cluster');
+    expect($('.yaml-editor-header').getText()).toEqual('Create Etcd Cluster');
   });
 
   it('displays new `EtcdCluster` that was created from YAML editor', async() => {

--- a/frontend/integration-tests/tests/alm/prometheus.scenario.ts
+++ b/frontend/integration-tests/tests/alm/prometheus.scenario.ts
@@ -32,7 +32,7 @@ describe('Interacting with the Prometheus OCS', () => {
   it('can be enabled from the Catalog Sources', async() => {
     await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
     await catalogView.isLoaded();
-    await catalogView.entryRowFor('Prometheus').element(by.buttonText('Subscribe')).click();
+    await catalogView.entryRowFor('Prometheus').element(by.buttonText('Create Subscription')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
     const content = await yamlView.editorContent.getText();
     const newContent = defaultsDeep({}, {metadata: {generateName: `${testName}-prometheus-`, namespace: testName, labels: {[testLabel]: testName}}, spec: {channel: 'alpha', source: 'tectonic-ocs', name: 'prometheus'}}, safeLoad(content));
@@ -63,7 +63,7 @@ describe('Interacting with the Prometheus OCS', () => {
     expect(crudView.rowForName(prometheusOperatorName).isDisplayed()).toBe(true);
   }, deleteRecoveryTime);
 
-  it('displays Prometheus OCS in "Available Applications" view for the namespace', async() => {
+  it('displays Prometheus OCS in "Available Operators" view for the namespace', async() => {
     await browser.get(`${appHost}/k8s/ns/${testName}/clusterserviceversion-v1s`);
     await appListView.isLoaded();
     await browser.sleep(500);

--- a/frontend/integration-tests/tests/alm/update-channel-approval.scenario.ts
+++ b/frontend/integration-tests/tests/alm/update-channel-approval.scenario.ts
@@ -42,7 +42,7 @@ describe('Manually approving an install plan', () => {
   it('creates a subscription with a `startingCSV` that is not latest and manual approval strategy', async() => {
     await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
     await catalogView.isLoaded();
-    await catalogView.entryRowFor(pkgName).element(by.buttonText('Subscribe')).click();
+    await catalogView.entryRowFor(pkgName).element(by.buttonText('Create Subscription')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
     const content = await yamlView.editorContent.getText();
     const newContent = defaultsDeep({}, {metadata: {name: subName, namespace: testName, labels: {[testLabel]: testName}}, spec: {startingCSV, installPlanApproval: 'Manual'}}, safeLoad(content));

--- a/frontend/integration-tests/tests/alm/vault.scenario.ts
+++ b/frontend/integration-tests/tests/alm/vault.scenario.ts
@@ -30,7 +30,7 @@ describe('Interacting with the Vault OCS', () => {
   it('can be enabled from the Catalog Sources', async() => {
     await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
     await catalogView.isLoaded();
-    await catalogView.entryRowFor('Vault').element(by.buttonText('Subscribe')).click();
+    await catalogView.entryRowFor('Vault').element(by.buttonText('Create Subscription')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
     const content = await yamlView.editorContent.getText();
     const newContent = defaultsDeep({}, {metadata: {generateName: `${testName}-vault-`, namespace: testName, labels: {[testLabel]: testName}}, spec: {channel: 'alpha', source: 'tectonic-ocs', name: 'vault'}}, safeLoad(content));
@@ -61,7 +61,7 @@ describe('Interacting with the Vault OCS', () => {
     expect(crudView.rowForName(vaultOperatorName).isDisplayed()).toBe(true);
   }, deleteRecoveryTime);
 
-  it('displays Vault OCS in "Available Applications" view for the namespace', async() => {
+  it('displays Vault OCS in "Available Operators" view for the namespace', async() => {
     await browser.get(`${appHost}/k8s/ns/${testName}/clusterserviceversion-v1s`);
     await appListView.isLoaded();
     await browser.sleep(500);
@@ -89,7 +89,7 @@ describe('Interacting with the Vault OCS', () => {
     await element(by.buttonText('Create Vault Service')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
 
-    expect($('.yaml-editor-header').getText()).toEqual('Create VaultService');
+    expect($('.yaml-editor-header').getText()).toEqual('Create Vault Service');
   });
 
   it('displays new `VaultService` that was created from YAML editor', async() => {

--- a/frontend/integration-tests/views/catalog.view.ts
+++ b/frontend/integration-tests/views/catalog.view.ts
@@ -6,19 +6,17 @@ export const entryRows = $$('.co-resource-list__item');
 export const entryRowFor = (name: string) => entryRows.filter((row) => row.$('.co-clusterserviceversion-logo__name__clusterserviceversion').getText()
   .then(text => text === name)).first();
 
-export const isLoaded = () => browser.wait(until.presenceOf($('.loading-box__loaded')), 10000);
+export const isLoaded = () => browser.wait(until.presenceOf($('.loading-box__loaded')), 10000).then(() => browser.sleep(500));
 
 export const hasSubscription = (name: string) => browser.getCurrentUrl().then(url => {
   if (url.indexOf('all-namespaces') > -1) {
     throw new Error('Cannot call `hasSubscription` for all namespaces');
   }
-  return entryRowFor(name).element(by.buttonText('Subscribe')).isPresent();
+  return entryRowFor(name).element(by.buttonText('Create Subscription')).isPresent();
 }).then(canSubscribe => !canSubscribe);
 
 export const createSubscriptionView = $('.co-create-subscription');
-export const confirmSubscriptionBtn = createSubscriptionView.element(by.buttonText('Subscribe'));
 export const subscriptionNSDropdown = createSubscriptionView.$$('.btn.btn--dropdown').first();
-export const confirmSubscription = () => confirmSubscriptionBtn.click().then(() => browser.sleep(1000));
 
 /**
  * Returns a promise that resolves to the row for a given namespace in the enable/disable modal.

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -32,9 +32,9 @@ import { history, AsyncComponent, Loading } from './utils';
 import { namespacedPrefixes } from './utils/link';
 import { UIActions, getActiveNamespace } from '../ui/ui-actions';
 import { ClusterHealth } from './cluster-health';
-import { CatalogSourceDetailsPage, CreateSubscriptionYAML } from './cloud-services';
+import { CreateSubscriptionYAML } from './cloud-services';
 import { CreateCRDYAML } from './cloud-services/create-crd-yaml';
-import { ClusterServiceVersionModel, CatalogSourceModel, AlertmanagerModel } from '../models';
+import { ClusterServiceVersionModel, SubscriptionModel, AlertmanagerModel } from '../models';
 import { referenceForModel } from '../module/k8s';
 import k8sActions from '../module/k8s/k8s-actions';
 import { coFetch } from '../co-fetch';
@@ -164,12 +164,7 @@ class App extends React.PureComponent {
           <Route path="/cluster-health" exact component={ClusterHealth} />
           <Route path="/start-guide" exact component={StartGuidePage} />
 
-          <Route path={`/k8s/all-namespaces/${CatalogSourceModel.plural}`} exact render={() => <Redirect to={`/k8s/all-namespaces/${CatalogSourceModel.plural}/tectonic-ocs`} />} />
-          <Route path={`/k8s/ns/:ns/${CatalogSourceModel.plural}`} exact render={({match}) => <Redirect to={`/k8s/ns/${match.params.ns}/${CatalogSourceModel.plural}/tectonic-ocs`} />} />
-          <Route path={`/k8s/all-namespaces/${CatalogSourceModel.plural}/tectonic-ocs`} exact component={CatalogSourceDetailsPage} />
-          <Route path={`/k8s/ns/:ns/${CatalogSourceModel.plural}/tectonic-ocs`} exact component={CatalogSourceDetailsPage} />
-          <Route path={`/k8s/all-namespaces/${CatalogSourceModel.plural}/tectonic-ocs/:pkgName/subscribe`} exact component={CreateSubscriptionYAML} />
-          <Route path={`/k8s/ns/:ns/${CatalogSourceModel.plural}/tectonic-ocs/:pkgName/subscribe`} exact component={NamespaceFromURL(CreateSubscriptionYAML)} />
+          <Route path={`/k8s/ns/:ns/${SubscriptionModel.plural}/new`} exact component={NamespaceFromURL(CreateSubscriptionYAML)} />
 
           <Route path="/k8s/ns/:ns/alertmanagers/:name" exact render={({match}) => <Redirect to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${match.params.name}`} />} />
 
@@ -226,7 +221,6 @@ class App extends React.PureComponent {
     </React.Fragment>;
   }
 }
-
 
 _.each(featureActions, store.dispatch);
 store.dispatch(k8sActions.getResources());

--- a/frontend/public/components/cloud-services/_cloud-services.scss
+++ b/frontend/public/components/cloud-services/_cloud-services.scss
@@ -167,6 +167,28 @@ $clusterserviceversion-list-border: #ccc;
   flex-direction: column;
 }
 
+.co-package-row {
+  display: flex;
+  align-items: center;
+}
+
+.co-package-row__actions {
+  display: flex;
+  justify-content: space-between;
+}
+
+.co-catalogsource-list__section {
+  margin-bottom: 40px;
+}
+
+.co-catalogsource-list__section__packages {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 20px;
+}
+
 .co-clusterserviceversion-list__disabled-icon {
   margin: 10px;
   width: 100px;

--- a/frontend/public/components/cloud-services/index.tsx
+++ b/frontend/public/components/cloud-services/index.tsx
@@ -177,6 +177,8 @@ export type Package = {
   defaultChannel?: string;
 };
 
+export const olmNamespace = 'operator-lifecycle-manager';
+
 export const isEnabled = (namespace: K8sResourceKind) => _.has(namespace, ['metadata', 'annotations', 'alm-manager']);
 
 export const referenceForCRDDesc = (desc: CRDDescription): GroupVersionKind => `${desc.name.slice(desc.name.indexOf('.') + 1)}:${desc.version}:${desc.kind}`;

--- a/frontend/public/components/cloud-services/install-plan.tsx
+++ b/frontend/public/components/cloud-services/install-plan.tsx
@@ -91,7 +91,7 @@ export const InstallPlanDetails: React.SFC<InstallPlanDetailsProps> = ({obj}) =>
               </dd>) }
               <dt>Catalog Sources</dt>
               { (_.get(obj.status, 'catalogSources') || []).map((catalogName, i) => <dd key={i}>
-                <ResourceLink kind={referenceForModel(CatalogSourceModel)} name={catalogName} namespace="tectonic-system" title={catalogName} />
+                <ResourceLink kind={referenceForModel(CatalogSourceModel)} name={catalogName} namespace="openshift" title={catalogName} />
               </dd>) }
             </dl>
           </div>

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -41,7 +41,7 @@ import { CustomResourceDefinitionsPage } from './custom-resource-definition';
 import { ClusterServiceVersionsPage, ClusterServiceVersionsDetailsPage, ClusterServiceVersionResourcesDetailsPage } from './cloud-services';
 import { SubscriptionsPage, SubscriptionDetailsPage } from './cloud-services/subscription';
 import { InstallPlansPage, InstallPlanDetailsPage } from './cloud-services/install-plan';
-import { CatalogSourceDetailsPage } from './cloud-services/catalog-source';
+import { CatalogSourceDetailsPage, CatalogSourcesPage } from './cloud-services/catalog-source';
 import { StorageClassPage, StorageClassDetailsPage } from './storage-class';
 
 import { referenceForModel, GroupVersionKind } from '../module/k8s';
@@ -132,6 +132,7 @@ export const resourceListPages = new Map<GroupVersionKind | string, React.Compon
   .set(referenceForModel(StorageClassModel), StorageClassPage)
   .set(referenceForModel(CustomResourceDefinitionModel), CustomResourceDefinitionsPage)
   .set(referenceForModel(ClusterServiceVersionModel), ClusterServiceVersionsPage)
+  .set(referenceForModel(CatalogSourceModel), CatalogSourcesPage)
   .set(referenceForModel(SubscriptionModel), SubscriptionsPage)
   .set(referenceForModel(InstallPlanModel), InstallPlansPage)
   /*  ------------------------------- NOTE -------------------------------

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -16,7 +16,30 @@ export type OwnerReference = {
   apiVersion: string;
 };
 
+export type ObjectMetadata = {
+  annotations?: {[key: string]: string},
+  name: string,
+  namespace?: string,
+  labels?: {[key: string]: string},
+  ownerReferences?: OwnerReference[],
+  [key: string]: any,
+};
+
 export type K8sResourceKind = {
+  apiVersion: string;
+  kind: string;
+  metadata: ObjectMetadata;
+  spec?: {
+    selector?: {
+      matchLabels?: {[key: string]: any},
+    },
+    [key: string]: any
+  };
+  status?: {[key: string]: any};
+  type?: {[key: string]: any};
+};
+
+export type ConfigMapKind = {
   apiVersion: string;
   kind: string;
   metadata: {
@@ -27,14 +50,7 @@ export type K8sResourceKind = {
     ownerReferences?: OwnerReference[],
     [key: string]: any,
   };
-  spec?: {
-    selector?: {
-      matchLabels?: {[key: string]: any},
-    },
-    [key: string]: any
-  };
-  status?: {[key: string]: any};
-  type?: {[key: string]: any};
+  data: {[key: string]: string};
 };
 
 export type CustomResourceDefinitionKind = {


### PR DESCRIPTION
### Description

Adds rich list view for OLM `CatalogSource` resource. Previously we redirected to a specific instance ("Open Cloud Catalog"). This allows creating subscriptions to other catalogs in the same namespace, as well as the "global" catalogs. See the [OLM docs](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/architecture.md#catalog-registry-design) for more details.

### Screenshots

**Catalog Source list view:**
![screenshot_20180727_131913](https://user-images.githubusercontent.com/11700385/43336642-b17d05e2-919f-11e8-950d-e7515b59827c.png)

**Catalog Source list view (empty):**
![screenshot_20180727_132034](https://user-images.githubusercontent.com/11700385/43336693-db07edb4-919f-11e8-8476-549d6981463f.png)

**Catalog Source list view (error):**
![screenshot_20180727_182236](https://user-images.githubusercontent.com/11700385/43361167-208d3866-9296-11e8-93fb-81549e88c717.png)

**Catalog Source detail view (error):**
[![screenshot_20180727_182127](https://user-images.githubusercontent.com/11700385/43361166-0c8aaba0-9296-11e8-9917-5d4ea88c4442.png)](url)

Implements https://jira.coreos.com/browse/ALM-600
Fixes https://jira.coreos.com/browse/ALM-643
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1608120