### PR TITLE
Hide "Create Pod" button on "Pods" tab

### DIFF
--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -316,9 +316,10 @@ export class PodsPage extends React.Component {
     return !_.isEqual(nextProps, this.props);
   }
   render() {
+    const { canCreate = true } = this.props;
     return <ListPage
       {...this.props}
-      canCreate={true}
+      canCreate={canCreate}
       kind="Pod"
       ListComponent={PodList}
       rowFilters={filters}

--- a/frontend/public/components/utils/vertnav.jsx
+++ b/frontend/public/components/utils/vertnav.jsx
@@ -13,7 +13,10 @@ const editYamlComponent = (props) => <AsyncComponent loader={() => import('../ed
 class PodsComponent extends React.PureComponent {
   render() {
     const {metadata: {namespace}, spec: {selector}} = this.props.obj;
-    return <PodsPage showTitle={false} namespace={namespace} selector={selector} />;
+    // Hide the create button to avoid confusion when showing pods for an object.
+    // Otherwise it might seem like you click "Create Pod" to add replicas instead
+    // of scaling the owner.
+    return <PodsPage showTitle={false} namespace={namespace} selector={selector} canCreate={false} />;
   }
 }
 


### PR DESCRIPTION
Don't show the "Create Pod" button when looking at pods for a
deployment. Otherwise it might seem like that's how you add replicas.

/assign @TheRealJon 