### PR TITLE
Align event timestamps and fix resource name overflow

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -82,27 +82,29 @@ $color-dark-border: #ddd;
   flex: none;
 }
 
-.co-sysevent__timestamp {
-  display: inline-block;
-}
-
-.co-sysevent__header {
-  justify-content: space-between;
+.co-sysevent__details {
   display: flex;
+  justify-content: space-between;
 }
 
-.co-sysevent__header__link {
-  flex: 1 0;
+.co-sysevent__resourcelink {
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.co-sysevent__subheader {
+  display: flex;
+  justify-content: space-between;
   white-space: pre;
 }
 
 .co-sysevent__source {
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: pre;
-  display: block;
+  white-space: nowrap;
 }
 
 .co-sysevent__message {

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -47,23 +47,24 @@ class Inner extends React.PureComponent {
       </div>
       <div className="co-sysevent__box">
         <div className="co-sysevent__header">
-          <div className="co-sysevent__header__link">
+          <div className="co-sysevent__subheader">
             <ResourceLink
+              className="co-sysevent__resourcelink"
               kind={obj.kind}
               namespace={obj.namespace}
               name={obj.name}
               title={obj.uid}
             />
+            <Timestamp timestamp={lastTimestamp} />
+          </div>
+          <div className="co-sysevent__details">
             <small className="co-sysevent__source">
               Generated from <span>{source.component}</span>
               {source.component === 'kubelet' &&
                 <span> on <Link to={`/k8s/cluster/nodes/${source.host}`}>{source.host}</Link></span>
               }
             </small>
-          </div>
-          <div className="co-sysevent__timestamp">
-            <Timestamp timestamp={lastTimestamp} />
-            {count > 1 && <small className="co-sysevent__source text-secondary">
+            {count > 1 && <small className="co-sysevent__count text-secondary">
               {count} times in the last <Timestamp timestamp={firstTimestamp} simple={true} omitSuffix={true} />
             </small>}
           </div>

--- a/frontend/public/components/utils/resource-link.jsx
+++ b/frontend/public/components/utils/resource-link.jsx
@@ -1,6 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import * as classNames from 'classnames';
 
 import { ResourceIcon } from './index';
 import { modelFor, referenceForModel } from '../../module/k8s';
@@ -54,14 +55,14 @@ export const resourcePath = (kind, name, namespace) => {
 export const resourceObjPath = (obj, kind) => resourcePath(kind, _.get(obj, 'metadata.name'), _.get(obj, 'metadata.namespace'));
 
 export const ResourceLink = connectToModel(
-  ({kind, name, namespace, title, displayName, linkTo = true, kindsInFlight}) => {
+  ({className, kind, name, namespace, title, displayName, linkTo = true, kindsInFlight}) => {
     if (kindsInFlight) {
       return null;
     }
     const path = resourcePath(kind, name, namespace);
     const value = displayName ? displayName : name;
 
-    return <span className="co-resource-link">
+    return <span className={classNames('co-resource-link', className)}>
       <ResourceIcon kind={kind} />
       {(path && linkTo) ? <Link to={path} title={title} className="co-resource-link__resource-name">{value}</Link> : <span className="co-resource-link__resource-name">{value}</span>}
     </span>;


### PR DESCRIPTION
Fixes [CONSOLE-647](https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-647).

Fixed resource names so they'll get cut off with ellipsis when they overflow. Also right aligned the timestamps.

<img width="355" alt="screen shot 2018-07-27 at 3 51 18 pm" src="https://user-images.githubusercontent.com/7014965/43343644-f6e955bc-91b4-11e8-82a7-8ede0e865925.png">
