### PR TITLE
Console 639 fix: fix non-updating loading state for event stream.

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -258,7 +258,7 @@ class EventStream extends SafetyFirst {
   }
 
   static getDerivedStateFromProps (nextProps, prevState) {
-    const {filter, kind, category, textFilter} = prevState;
+    const {filter, kind, category, textFilter, loading} = prevState;
 
     if (_.isEqual(filter, nextProps.filter)
       && kind === nextProps.kind
@@ -269,7 +269,7 @@ class EventStream extends SafetyFirst {
 
     return {
       active: !nextProps.fake,
-      loading: !nextProps.fake,
+      loading: !nextProps.fake && loading,
       // update the filteredMessages
       filteredMessages: EventStream.filterMessages(prevState.sortedMessages, nextProps),
       // we need these for bookkeeping because getDerivedStateFromProps doesn't get prevProps


### PR DESCRIPTION
Fix for: https://jira.coreos.com/browse/CONSOLE-639

If fake prop is true set loading state to false, otherwise use existing loading state.

Fixes issue on events page where loading ellipsis never goes away after loading state is complete.

