### PR TITLE
Fix SearchPage for unknown kindObj

### DIFF
--- a/frontend/public/components/search.jsx
+++ b/frontend/public/components/search.jsx
@@ -21,6 +21,7 @@ const ResourceList = connectToModel(({kind, kindObj, kindsInFlight, namespace, s
     return <LoadingBox />;
   }
 
+  kindObj = kindObj || {labelPlural: 'Default'};
   const name = kindObj.labelPlural.replace(/ /g, '');
   const ListPage = resourceListPages.get(name) || resourceListPages.get('Default');
   const ns = kindObj.namespaced ? namespace : undefined;


### PR DESCRIPTION
If object kind is uknown (like for CRDs), the "Not found" message is
rendered.

Before this fix, a property of `undefined` object was accessed causing
application failure.