### PR TITLE
Fix environment value dropdowns

### DIFF
--- a/frontend/public/components/utils/_value-from-pair.scss
+++ b/frontend/public/components/utils/_value-from-pair.scss
@@ -17,5 +17,6 @@
 
   .dropdown-menu {
     width: 100%;
+    left: 0px;
   }
 }


### PR DESCRIPTION
Fixes [CONSOLE-648](https://jira.coreos.com/browse/CONSOLE-648).

Made dropdown menu flush with button (it was offset by a few pixels).

Before: 
![screen shot 2018-07-30 at 10 27 58 am](https://user-images.githubusercontent.com/7014965/43403547-47e70eca-93e3-11e8-85b2-2751b740e41d.png)

After:
![screen shot 2018-07-30 at 10 25 16 am](https://user-images.githubusercontent.com/7014965/43403381-ea942a64-93e2-11e8-9312-314b82c5d59f.png)