### PR TITLE
Only show getting started on EventsPage when title is shown

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -140,7 +140,7 @@ class EventsStreamPage_ extends React.Component {
     const showGettingStarted = flags.OPENSHIFT && !flags.PROJECTS_AVAILABLE;
 
     return <React.Fragment>
-      { showGettingStarted && <OpenShiftGettingStarted /> }
+      { showGettingStarted && showTitle && <OpenShiftGettingStarted /> }
       <div className={classNames({'co-disabled': showGettingStarted })}>
         { showTitle && <Helmet>
           <title>Events</title>


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-650

Getting started message on EventsPage will only show when `showTitle` prop is true.