### PR TITLE
RBAC Check for Operators Nav Section 

### DIFF
--- a/frontend/__tests__/features.spec.ts
+++ b/frontend/__tests__/features.spec.ts
@@ -39,7 +39,6 @@ describe('featureReducer', () => {
       [FLAGS.CLUSTER_UPDATES]: false,
       [FLAGS.PROMETHEUS]: false,
       [FLAGS.MULTI_CLUSTER]: false,
-      [FLAGS.CLOUD_SERVICES]: true,
       [FLAGS.CHARGEBACK]: false,
     }));
   });

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -367,6 +367,7 @@ export class Nav extends React.Component {
         <div ref={this.scroller} onWheel={this.preventScroll} className="navigation-container">
           <NavSection text="Overview" icon="fa fa-tachometer" href="/overview" activePath="/overview/" onClick={this.close} />
 
+          {/* TODO(alecmerdler): RBAC check for `app.coreos.com` API group */}
           <NavSection required={FLAGS.CLOUD_SERVICES} text="Operators" img={operatorImg} activeImg={operatorActiveImg} >
             <ResourceNSLink model={ClusterServiceVersionModel} resource={ClusterServiceVersionModel.plural} name="Cluster Service Versions" onClick={this.close} />
             <Sep />

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -52,8 +52,6 @@ export const DEFAULTS_ = _.mapValues(FLAGS, flag => flag === FLAGS.AUTH_ENABLED
 export const CRDs = {
   [referenceForModel(ChannelOperatorConfigModel)]: FLAGS.CLUSTER_UPDATES,
   [referenceForModel(PrometheusModel)]: FLAGS.PROMETHEUS,
-  // FIXME(alecmerdler): This should look for OLM+Catalog deployments instead of CRD
-  [referenceForModel(ClusterServiceVersionModel)]: FLAGS.CLOUD_SERVICES,
   [referenceForModel(ClusterModel)]: FLAGS.MULTI_CLUSTER,
   [referenceForModel(ChargebackReportModel)]: FLAGS.CHARGEBACK,
 };
@@ -118,6 +116,7 @@ export let featureActions = [
   [FLAGS.CAN_LIST_PV, { resource: 'persistentvolumes', verb: 'list' }],
   [FLAGS.CAN_LIST_STORE, { group: 'storage.k8s.io', resource: 'storageclasses', verb: 'list' }],
   [FLAGS.CAN_LIST_CRD, { group: 'apiextensions.k8s.io', resource: 'customresourcedefinitions', verb: 'list' }],
+  [FLAGS.CLOUD_SERVICES, { group: ClusterServiceVersionModel.apiGroup, resource: ClusterServiceVersionModel.plural, verb: 'list' }],
 ].forEach(_.spread((FLAG, resourceAttributes) => {
   const req = {
     spec: { resourceAttributes }


### PR DESCRIPTION
### Description

Changes the detection of `CLOUD_SERVICES` flag to check for RBAC permissions to the `app.coreos.com` API group instead of just the presence of the CRDs in the cluster.

Fixes:
- https://bugzilla.redhat.com/show_bug.cgi?id=1609183
- https://jira.coreos.com/browse/CONSOLE-631