### PR TITLE
Fix YAML Editor `RangeError`

### DIFF
--- a/frontend/__tests__/module/k8s/autocomplete.spec.ts
+++ b/frontend/__tests__/module/k8s/autocomplete.spec.ts
@@ -73,6 +73,17 @@ describe('getCompletions', () => {
     });
   });
 
+  it('does not invoke callback with completions if no matches for property values', (done) => {
+    sessionMock.getLine = jasmine.createSpy('getLineSpy').and.returnValue('apiVersion: ');
+    position = {row: 0, column: 'apiVersion: '.length};
+
+    getCompletions(editorMock, sessionMock, position, '', () => {
+      fail('Should not be called');
+      done();
+    });
+    done();
+  });
+
   it('invokes callback with appropriate completions for properties', (done) => {
     const swagger = {
       definitions: {

--- a/frontend/public/module/k8s/autocomplete.ts
+++ b/frontend/public/module/k8s/autocomplete.ts
@@ -159,9 +159,14 @@ export const getPropertyValueCompletions = async(state: Editor, session: IEditSe
   const line = session.getLine(pos.row).substr(0, pos.column);
   const field = (/([\w]+):[^:]*$/.exec(line) || {})[1];
 
-  const parentPropertyFor = (currentRow: number): string => session.getLine(currentRow - 1).trim().endsWith(':')
-    ? (/([\w]+):[^:]*$/.exec(session.getLine(currentRow - 1)) || {})[1]
-    : parentPropertyFor(currentRow - 1);
+  const parentPropertyFor = (currentRow: number): string => {
+    if (currentRow < 1) {
+      return '';
+    }
+    return session.getLine(currentRow - 1).trim().endsWith(':')
+      ? (/([\w]+):[^:]*$/.exec(session.getLine(currentRow - 1)) || {})[1]
+      : parentPropertyFor(currentRow - 1);
+  };
 
   if (simpleCompletions.has(field)) {
     callback(null, simpleCompletions.get(field).map((value, i) => ({


### PR DESCRIPTION
### Description

Don't try and check the parent property for completions if already on the first row.

Fixes https://jira.coreos.com/browse/CONSOLE-641