### PR TITLE
add title attribute to resource badges

### DIFF
--- a/frontend/public/components/utils/resource-icon.tsx
+++ b/frontend/public/components/utils/resource-icon.tsx
@@ -19,7 +19,10 @@ export const ResourceIcon = (props: ResourceIconProps) => {
   const klass = classNames(`co-m-resource-icon co-m-resource-${kindStr.toLowerCase()}`, className);
   const iconLabel = (kindObj && kindObj.abbr) || kindToAbbr(kindStr);
 
-  const rendered = <span className={klass}>{iconLabel}</span>;
+  const rendered = <React.Fragment>
+    <span className="sr-only">{kindStr}</span>
+    <span className={klass} title={kindStr}>{iconLabel}</span>
+  </React.Fragment>;
   if (kindObj) {
     MEMO[memoKey] = rendered;
   }


### PR DESCRIPTION
Add `title` attribute on resource badges. 
Add `sr-only` span with the resource label for screen readers.