### PR TITLE
POC: Add Virtual Machines view

### DIFF
--- a/frontend/__tests__/features.spec.ts
+++ b/frontend/__tests__/features.spec.ts
@@ -40,6 +40,7 @@ describe('featureReducer', () => {
       [FLAGS.PROMETHEUS]: false,
       [FLAGS.MULTI_CLUSTER]: false,
       [FLAGS.CHARGEBACK]: false,
+      [FLAGS.KUBEVIRT]: false,
     }));
   });
 });

--- a/frontend/public/components/_vm.scss
+++ b/frontend/public/components/_vm.scss
@@ -1,0 +1,8 @@
+.dl-left dt {
+    text-align: left
+}
+
+.overview-section-title {
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 10px;
+}

--- a/frontend/public/components/modals/restart-vm-modal.jsx
+++ b/frontend/public/components/modals/restart-vm-modal.jsx
@@ -1,0 +1,36 @@
+import * as _ from 'lodash-es';
+import React from 'react';
+import { PromiseComponent } from '../utils';
+import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
+import { k8sKill,k8sList } from '../../module/k8s';
+import { VirtualMachineInstanceModel } from '../../models';
+
+class RestartVmModal extends PromiseComponent {
+  constructor(props) {
+    super(props);
+    this._cancel = this.props.cancel.bind(this);
+    this._submit = this.submit.bind(this);
+  }
+
+  submit(event) {
+    event.preventDefault();
+    const listPromise = k8sList(VirtualMachineInstanceModel, {ns: this.props.resource.metadata.namespace, labelSelector: {matchLabels: _.get(this.props.resource, 'spec.template.metadata.labels')}});
+    this.handlePromise(listPromise).then(list => {
+      const promise = k8sKill(VirtualMachineInstanceModel, list[0]);
+      this.handlePromise(promise).then(this.props.close);
+    });
+  }
+
+  render () {
+    const {resource} = this.props;
+    return <form onSubmit={this._submit} name="form">
+      <ModalTitle>Restart Virtual Machine</ModalTitle>
+      <ModalBody> Are you sure you want to restart <strong>{resource.metadata.name}</strong>
+        <span> in namespace <strong>{resource.metadata.namespace}</strong>?</span>
+      </ModalBody>
+      <ModalSubmitFooter errorMessage="" inProgress={false} submitText="Restart" cancel={this._cancel} />
+    </form>;
+  }
+}
+
+export const restartVmModal = createModalLauncher(RestartVmModal);

--- a/frontend/public/components/modals/start-stop-vm-modal.jsx
+++ b/frontend/public/components/modals/start-stop-vm-modal.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { PromiseComponent } from '../utils';
+import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
+import { k8sPatch } from '../../module/k8s';
+
+class StartStopVmModal extends PromiseComponent {
+  constructor(props) {
+    super(props);
+    this._cancel = this.props.cancel.bind(this);
+    this._submit = this.submit.bind(this);
+  }
+
+  submit(event) {
+    event.preventDefault();
+    const patch = [{
+      op: 'replace',
+      path: '/spec/running',
+      value: this.props.start
+    }];
+    const promise = k8sPatch(this.props.kind, this.props.resource, patch);
+    this.handlePromise(promise).then(this.props.close);
+  }
+
+  render () {
+    const {resource} = this.props;
+    const action = this.props.start? 'Start':'Stop';
+    return <form onSubmit={this._submit} name="form">
+      <ModalTitle>{action} Virtual Machine</ModalTitle>
+      <ModalBody>
+        Are you sure you want to {action} <strong>{resource.metadata.name}</strong>
+        <span> in namespace <strong>{resource.metadata.namespace}</strong>?</span>
+      </ModalBody>
+      <ModalSubmitFooter errorMessage="" inProgress={false} submitText={action} cancel={this._cancel} />
+    </form>;
+  }
+}
+
+export const startStopVmModal = createModalLauncher(StartStopVmModal);

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -395,6 +395,7 @@ export class Nav extends React.Component {
             <ResourceNSLink resource="secrets" name="Secrets" onClick={this.close} />
             <ResourceNSLink resource="resourcequotas" name="Resource Quotas" onClick={this.close} />
             <ResourceNSLink resource="horizontalpodautoscalers" name="HPAs" onClick={this.close} />
+            <ResourceNSLink resource="virtualmachines" name="Virtual Machines" onClick={this.close} required={FLAGS.KUBEVIRT} />
           </NavSection>
 
           <NavSection text="Networking" img={routingImg} activeImg={routingActiveImg} >

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -16,6 +16,7 @@ import { NamespacesPage, NamespacesDetailsPage, ProjectsPage, ProjectsDetailsPag
 import { NetworkPoliciesPage, NetworkPoliciesDetailsPage } from './network-policy';
 import { NodesPage, NodesDetailsPage } from './node';
 import { PodsPage, PodsDetailsPage } from './pod';
+import { VirtualMachinesPage, VirtualMachinesDetailsPage } from './vm';
 import { ReplicaSetsPage, ReplicaSetsDetailsPage } from './replicaset';
 import { ReplicationControllersPage, ReplicationControllersDetailsPage } from './replication-controller';
 import { SecretsPage, SecretsDetailsPage } from './secret';
@@ -87,6 +88,7 @@ import {
   ClusterRoleModel,
   ContainerModel,
   CatalogSourceModel,
+  VirtualMachineModel,
 } from '../models';
 
 export const resourceListPages = new Map<GroupVersionKind | string, React.ComponentType<any>>()
@@ -106,6 +108,7 @@ export const resourceListPages = new Map<GroupVersionKind | string, React.Compon
   .set(referenceForModel(NetworkPolicyModel), NetworkPoliciesPage)
   .set(referenceForModel(NodeModel), NodesPage)
   .set(referenceForModel(PodModel), PodsPage)
+  .set(referenceForModel(VirtualMachineModel), VirtualMachinesPage)
   .set(referenceForModel(ReplicaSetModel), ReplicaSetsPage)
   .set(referenceForModel(ReplicationControllerModel), ReplicationControllersPage)
   .set(referenceForModel(SecretModel), SecretsPage)
@@ -159,6 +162,7 @@ export const resourceDetailPages = new Map<GroupVersionKind | string, React.Comp
   .set(referenceForModel(NetworkPolicyModel), NetworkPoliciesDetailsPage)
   .set(referenceForModel(NodeModel), NodesDetailsPage)
   .set(referenceForModel(PodModel), PodsDetailsPage)
+  .set(referenceForModel(VirtualMachineModel), VirtualMachinesDetailsPage)
   .set(referenceForModel(ReplicaSetModel), ReplicaSetsDetailsPage)
   .set(referenceForModel(ReplicationControllerModel), ReplicationControllersDetailsPage)
   .set(referenceForModel(SecretModel), SecretsDetailsPage)

--- a/frontend/public/components/vm.jsx
+++ b/frontend/public/components/vm.jsx
@@ -1,0 +1,243 @@
+import * as _ from 'lodash-es';
+import React, { Component, Fragment } from 'react';
+import { ListHeader, ColHead, List, ListPage, ResourceRow, DetailsPage } from './factory';
+import { ResourceLink, navFactory, ResourceCog, Cog } from './utils';
+import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
+import { startStopVmModal } from './modals/start-stop-vm-modal';
+import { restartVmModal } from './modals/restart-vm-modal';
+import { Firehose } from './utils/firehose';
+import { VirtualMachineInstanceModel, VirtualMachineModel, PodModel, NamespaceModel } from '../models';
+
+const dashes = '---';
+const getLabelMatcher = (vm) => _.get(vm, 'spec.template.metadata.labels');
+
+const VMHeader = props => <ListHeader>
+  <ColHead {...props} className="col-lg-2 col-md-2 col-sm-2 col-xs-6" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-lg-2 col-md-2 col-sm-2 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
+  <ColHead {...props} className="col-lg-2 col-md-2 col-sm-2 hidden-xs" sortField="spec.running">State</ColHead>
+  <ColHead {...props} className="col-lg-2 col-md-2 col-sm-2 hidden-xs" sortField="metadata.phase">Phase</ColHead>
+  <ColHead {...props} className="col-lg-2 col-md-2 col-sm-2 hidden-xs">Virtual Machine Instance</ColHead>
+  <ColHead {...props} className="col-lg-2 col-md-2 col-sm-2 hidden-xs">Pod</ColHead>
+</ListHeader>;
+
+const getAction = (vm) => {
+  return vm.spec.running ? 'Stop Virtual Machine':'Start Virtual Machine';
+};
+
+const menuActionStart = (kind, vm) => ({
+  label: getAction(vm),
+  callback: () => startStopVmModal({
+    kind: kind,
+    resource: vm,
+    start: !vm.spec.running
+  })
+});
+
+const menuActionRestart = (kind, vm) => ({
+  hidden: !_.get(vm, 'spec.running', false),
+  label: 'Restart Virtual Machine',
+  callback: () => restartVmModal({
+    kind: kind,
+    resource: vm
+  })
+});
+
+const menuActions = [menuActionStart, menuActionRestart, Cog.factory.Delete];
+
+const StateColumn = props => {
+  if (props.loaded){
+    const vm = props.flatten(props.resources);
+    if (vm){
+      return vm.spec.running ? 'Running':'Stopped';
+    }
+  }
+  return dashes;
+};
+
+const PhaseColumn = props => {
+  if (props.loaded){
+    const vmi = props.flatten(props.resources);
+    if (vmi.length > 0) {
+      return vmi[0].status.phase;
+    }
+  }
+  return dashes;
+};
+
+const FirehoseResourceLink = props => {
+  const data = props.flatten(props.resources);
+  if (data.length > 0){
+    const name = data[0].metadata.name;
+    const namespace = data[0].metadata.namespace;
+    const title = data[0].metadata.uid;
+    const kind = data[0].kind || PodModel.kind;
+    return <ResourceLink kind={kind} name={name} namespace={namespace} title={title} />;
+  }
+  return dashes;
+};
+
+const getResourceKind = (kind, namespace, labelMatcher) => {
+  let res = { kind:kind, namespaced: true, namespace: namespace, isList: true, prop: kind};
+  if (labelMatcher) {
+    res = { ...res, selector: {matchLabels:labelMatcher}};
+  }
+  return [res];
+};
+
+const getFlattenForKind = (kind) => {
+  return resources => _.get(resources, kind, {}).data;
+};
+
+export const VMRow = ({obj: vm}) => {
+  const vmResource = [{ kind:VirtualMachineModel.kind, namespaced: true, namespace: vm.metadata.namespace, isList: false, prop: VirtualMachineModel.kind, name: vm.metadata.name}];
+  const vmiResources = getResourceKind(VirtualMachineInstanceModel.kind, vm.metadata.namespace, getLabelMatcher(vm));
+  const podResources = getResourceKind(PodModel.kind, vm.metadata.namespace, getLabelMatcher(vm));
+  return <ResourceRow obj={vm}>
+    <div className="col-lg-2 col-md-2 col-sm-2 col-xs-6 co-resource-link-wrapper">
+      <ResourceCog actions={menuActions} kind={VirtualMachineModel.kind} resource={vm} />
+      <ResourceLink kind={VirtualMachineModel.kind} name={vm.metadata.name} namespace={vm.metadata.namespace} title={vm.metadata.uid} />
+    </div>
+    <div className="col-lg-2 col-md-2 col-sm-2 col-xs-6 co-break-word">
+      <ResourceLink kind={NamespaceModel.kind} name={vm.metadata.namespace} title={vm.metadata.namespace} />
+    </div>
+    <div className="col-lg-2 col-md-2 col-sm-2 hidden-xs">
+      <Firehose resources={vmResource} flatten={getFlattenForKind(VirtualMachineModel.kind)}>
+        <StateColumn />
+      </Firehose>
+    </div>
+    <div className="col-lg-2 col-md-2 col-sm-2 hidden-xs">
+      <Firehose resources={vmiResources} flatten={getFlattenForKind(VirtualMachineInstanceModel.kind)}>
+        <PhaseColumn />
+      </Firehose>
+    </div>
+    <div className="col-lg-2 col-md-2 col-sm-2 hidden-xs">
+      <Firehose resources={vmiResources} flatten={getFlattenForKind(VirtualMachineInstanceModel.kind)}>
+        <FirehoseResourceLink />
+      </Firehose>
+    </div>
+    <div className="col-lg-2 col-md-2 col-sm-2 hidden-xs">
+      <Firehose resources={podResources} flatten={getFlattenForKind(PodModel.kind)}>
+        <FirehoseResourceLink />
+      </Firehose>
+    </div>
+  </ResourceRow>;
+};
+
+const VMStatus = (props) => {
+  const vmResource = [{ kind:VirtualMachineModel.kind, namespaced: true, namespace: props.vm.metadata.namespace, isList: false, prop: VirtualMachineModel.kind, name: props.vm.metadata.name}];
+  const vmiResources = getResourceKind(VirtualMachineInstanceModel.kind, props.vm.metadata.namespace, getLabelMatcher(props.vm));
+  const podResources = getResourceKind(PodModel.kind, props.vm.metadata.namespace, getLabelMatcher(props.vm));
+  return <div className="row">
+    <div className="col-lg-12">
+      <h3 className="overview-section-title">Status</h3>
+      <dl className="dl-horizontal dl-left">
+        <dt>Name:</dt>
+        <dd>{props.vm.metadata.name}</dd>
+        <dt>State:</dt>
+        <dd>
+          <Firehose resources={vmResource} flatten={getFlattenForKind(VirtualMachineModel.kind)}>
+            <StateColumn />
+          </Firehose>
+        </dd>
+        <dt>Phase:</dt>
+        <dd>
+          <Firehose resources={vmiResources} flatten={getFlattenForKind(VirtualMachineInstanceModel.kind)}>
+            <PhaseColumn />
+          </Firehose>
+        </dd>
+        <dt>VM Instance:</dt>
+        <dd>
+          <Firehose resources={vmiResources} flatten={getFlattenForKind(VirtualMachineInstanceModel.kind)}>
+            <FirehoseResourceLink />
+          </Firehose>
+        </dd>
+        <dt>Pod:</dt>
+        <dd>
+          <Firehose resources={podResources} flatten={getFlattenForKind(PodModel.kind)}>
+            <FirehoseResourceLink />
+          </Firehose>
+        </dd>
+      </dl>
+    </div>
+  </div>;
+};
+
+
+class VMResourceConfiguration extends Component {
+
+  getVMConfiguration() {
+    const configuration = {};
+    const data = this.props.flatten(this.props.resources);
+    configuration.cpu = _.get(data[0], 'spec.domain.cpu.cores');
+    configuration.memory = _.get(data[0], 'spec.domain.resources.requests.memory');
+    //configuration.os = _.get(this.props.vm,'metadata.selector.matchLabels.kubevirt.io/os');
+    return configuration;
+  }
+
+
+  render(){
+    const configuration = this.getVMConfiguration();
+    return <div className="row">
+      <div className="col-lg-12">
+        <h3 className="overview-section-title">Configuration</h3>
+        <dl className="dl-horizontal  dl-left">
+          <dt>Memory:</dt>
+          <dd>{configuration.memory || dashes}</dd>
+          <dt>CPU:</dt>
+          <dd>{configuration.cpu || dashes}</dd>
+          <dt>Operating System:</dt>
+          <dd>{configuration.os || dashes}</dd>
+        </dl>
+      </div>
+    </div>;
+  }
+}
+
+
+export const VMList = (props) => <List {...props} Header={VMHeader} Row={VMRow} />;
+
+const Details = ({obj: vm}) => {
+  const vmiResources = getResourceKind(VirtualMachineInstanceModel.kind, vm.metadata.namespace, getLabelMatcher(vm));
+  return <Fragment>
+    <div className="co-m-pane__body">
+      <h1 className="co-m-pane__heading">Virtual Machine Overview</h1>
+      <div className="co-m-pane__body">
+        <div className="row">
+          <div className="col-lg-6">
+            <VMStatus vm={vm} />
+          </div>
+          <div className="col-lg-6">
+            <Firehose resources={vmiResources} flatten={getFlattenForKind(VirtualMachineInstanceModel.kind)}>
+              <VMResourceConfiguration vm={vm} />
+            </Firehose>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Fragment>;
+};
+
+export const VirtualMachinesDetailsPage = props => <DetailsPage
+  {...props}
+  breadcrumbsFor={obj => breadcrumbsForOwnerRefs(obj).concat({
+    name: 'Virtual Machine Details',
+    path: props.match.url,
+  })}
+  menuActions={menuActions}
+  pages={[
+    navFactory.details(Details),
+    navFactory.editYaml()
+  ]}
+/>;
+
+export class VirtualMachinesPage extends Component {
+  render() {
+    return <ListPage
+      {...this.props}
+      canCreate={true}
+      kind={VirtualMachineModel.kind}
+      ListComponent={VMList}
+    />;
+  }
+
+}

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';
 
-import { SelfSubjectAccessReviewModel, ChannelOperatorConfigModel, PrometheusModel, ClusterServiceVersionModel, ClusterModel, ChargebackReportModel } from './models';
+import { SelfSubjectAccessReviewModel, ChannelOperatorConfigModel, PrometheusModel, ClusterServiceVersionModel, ClusterModel, ChargebackReportModel, VirtualMachineModel } from './models';
 import { k8sBasePath, referenceForModel } from './module/k8s/k8s';
 import { k8sCreate } from './module/k8s/resource';
 import { types } from './module/k8s/k8s-actions';
@@ -26,7 +26,8 @@ import { UIActions } from './ui/ui-actions';
   CAN_LIST_STORE: false,
   CAN_LIST_CRD: false,
   CAN_CREATE_PROJECT: false
-  PROJECTS_AVAILABLE: false
+  PROJECTS_AVAILABLE: false,
+  KUBEVIRT: false
  */
 export enum FLAGS {
   AUTH_ENABLED = 'AUTH_ENABLED',
@@ -45,6 +46,7 @@ export enum FLAGS {
   CAN_LIST_CRD = 'CAN_LIST_CRD',
   CAN_CREATE_PROJECT = 'CAN_CREATE_PROJECT',
   PROJECTS_AVAILABLE = 'PROJECTS_AVAILABLE',
+  KUBEVIRT = 'KUBEVIRT'
 }
 
 export const DEFAULTS_ = _.mapValues(FLAGS, flag => flag === FLAGS.AUTH_ENABLED
@@ -57,6 +59,7 @@ export const CRDs = {
   [referenceForModel(PrometheusModel)]: FLAGS.PROMETHEUS,
   [referenceForModel(ClusterModel)]: FLAGS.MULTI_CLUSTER,
   [referenceForModel(ChargebackReportModel)]: FLAGS.CHARGEBACK,
+  [referenceForModel(VirtualMachineModel)]: FLAGS.KUBEVIRT,
 };
 
 const SET_FLAG = 'SET_FLAG';

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -746,3 +746,44 @@ export const ServiceBindingModel: K8sKind = {
   kind: 'ServiceBinding',
   id: 'servicebinding'
 };
+
+export const VirtualMachineModel: K8sKind = {
+  label: 'Virtual Machine',
+  labelPlural: 'Virtual Machines',
+  apiVersion: 'v1alpha2',
+  path: 'virtualmachines',
+  apiGroup: 'kubevirt.io',
+  plural: 'virtualmachines',
+  abbr: 'VM',
+  namespaced: true,
+  kind: 'VirtualMachine',
+  id: 'virtualmachine'
+};
+
+export const VirtualMachineInstanceModel: K8sKind = {
+  label: 'Virtual Machine Instance',
+  labelPlural: 'Virtual Machine Instances',
+  apiVersion: 'v1alpha2',
+  path: 'virtualmachineinstances',
+  apiGroup: 'kubevirt.io',
+  plural: 'virtualmachineinstances',
+  abbr: 'VMI',
+  namespaced: true,
+  kind: 'VirtualMachineInstance',
+  id: 'virtualmachineinstance'
+};
+
+export const VirtualMachineInstancePresetModel: K8sKind = {
+  label: 'Virtual Machine Instance Preset',
+  labelPlural: 'Virtual Machine Instance Presets',
+  apiVersion: 'v1alpha2',
+  path: 'virtualmachineinstancepresets',
+  apiGroup: 'kubevirt.io',
+  plural: 'virtualmachineinstancepresets',
+  abbr: 'VMIP',
+  namespaced: true,
+  kind: 'VirtualMachineInstancePreset',
+  id: 'virtualmachineinstancepreset'
+};
+
+

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -84,3 +84,4 @@
 @import "components/utils/value-from-pair";
 @import "components/documentation";
 @import "components/terminal";
+@import "components/vm";


### PR DESCRIPTION
This PR adds Virtual Machines view which shows Kubevirt's VMs and VMIs and allows to start and stop the VM. 

Virtual Machines view is not visible if VirtualMachine CRD does not exist. 
Openshift console does not have any extension mechanism so the changes are hardcoded into the codebase.

![kubevirt1](https://user-images.githubusercontent.com/2078045/43464091-7907760a-94da-11e8-89b8-4dfb24dcefdd.png)
![kubevirt2](https://user-images.githubusercontent.com/2078045/43464099-7bc2491a-94da-11e8-9add-d9c953712d69.png)

@vojtechszocs @mareklibra
