### PR TITLE
Bug 1609691 - Failed to load and update pod selector for service on console

### DIFF
--- a/frontend/public/components/modals/labels-modal.jsx
+++ b/frontend/public/components/modals/labels-modal.jsx
@@ -77,7 +77,7 @@ export const labelsModal = createModalLauncher((props) => <BaseLabelsModal
 />);
 
 export const podSelectorModal = createModalLauncher((props) => <BaseLabelsModal
-  path={['replicationcontroller', 'service'].includes(props.kind.id) ? '/spec/selector' : '/spec/selector/matchLabels'}
+  path={['replicationcontrolleres', 'services'].includes(props.kind.plural) ? '/spec/selector' : '/spec/selector/matchLabels'}
   isPodSelector={true}
   description="Pod Selector"
   message={`Determines the set of pods targeted by this ${props.kind.label.toLowerCase()}.`}


### PR DESCRIPTION
Fixes two issues:
- loading service pod selectors for the modal
- updating the pod selectors via the modal

The issue is related to the fact that we are using a wrong path for Service resource. Tha [path that is used](https://github.com/openshift/console/blob/master/frontend/public/components/modals/labels-modal.jsx#L80) is `/spec/selector/matchLabels`, which only applies for newer resources such as Job, Deployment, Replica Set, and Daemon Set, ... based on the [docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#), at the buttom.
The overall problem is in fact that `kind.id`, that is [returned by API](https://github.com/openshift/console/blob/master/frontend/public/module/k8s/get-resources.ts#L14) as [singularName](https://github.com/openshift/console/blob/master/frontend/public/module/k8s/get-resources.ts#L40-L50) variable is an empty string. And it's not just for Service resource but for all the resources.
I could reproduce it on 3.9, 3.10 and 3.11 origin.

@spadgett PTAL