### PR TITLE
Display custom message when self provisioning is disabled on cluster

### DIFF
--- a/frontend/public/components/start-guide.jsx
+++ b/frontend/public/components/start-guide.jsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { SafetyFirst } from './safety-first';
 import { DocumentationSidebar } from './utils';
 import { FLAGS, connectToFlags, flagPending } from '../features';
+import { createProjectMessageStateToProps } from '../ui/ui-reducers';
 
 const seenGuide = 'seenGuide';
 
@@ -54,12 +56,18 @@ export const StartGuidePage = () => <div className="co-p-has-sidebar">
   <DocumentationSidebar />
 </div>;
 
-export const OpenShiftGettingStarted = () => <div className="co-well">
+const OpenShiftGettingStarted_ = ({createProjectMessage}) => <div className="co-well">
   <h4>Getting Started</h4>
-  <p>
-    OpenShift helps you quickly develop, host, and scale applications. Create a project for your application.
-  </p>
+  { createProjectMessage
+    ? <p className="co-pre-line">{createProjectMessage}</p>
+    : <p>
+        OpenShift helps you quickly develop, host, and scale applications.
+        To get started, create a project for your application.
+    </p>
+  }
   <Link to="/k8s/cluster/projects">
     <button className="btn btn-info">View My Projects</button>
   </Link>
 </div>;
+
+export const OpenShiftGettingStarted = connect(createProjectMessageStateToProps)(OpenShiftGettingStarted_);

--- a/frontend/public/ui/ui-actions.js
+++ b/frontend/public/ui/ui-actions.js
@@ -70,6 +70,7 @@ export const types = {
   startImpersonate: 'startImpersonate',
   stopImpersonate: 'stopImpersonate',
   sortList: 'sortList',
+  setCreateProjectMessage: 'setCreateProjectMessage'
 };
 
 export const UIActions = {
@@ -151,4 +152,6 @@ export const UIActions = {
     history.replace(`${url.pathname}?${sp.toString()}${url.hash}`);
     return {listId, field, func, orderBy, type: types.sortList};
   },
+
+  [types.setCreateProjectMessage]: message => ({type: types.setCreateProjectMessage, message})
 };

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -24,6 +24,7 @@ export default (state, action) => {
       activeNavSectionId: 'workloads',
       location: pathname,
       activeNamespace: activeNamespace || 'default',
+      createProjectMessage: ''
     });
   }
 
@@ -53,8 +54,15 @@ export default (state, action) => {
     case types.sortList:
       return state.mergeIn(['listSorts', action.listId], _.pick(action, ['field', 'func', 'orderBy']));
 
+    case types.setCreateProjectMessage:
+      return state.set('createProjectMessage', action.message);
+
     default:
       break;
   }
   return state;
+};
+
+export const createProjectMessageStateToProps = ({UI}) => {
+  return {createProjectMessage: UI.get('createProjectMessage')};
 };


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-652

Use master config 'createProjectMessage' setting in console when self provisioning is disabled for a user. This will replace 'create a project' instructions on the projects list page and in getting started messages.

**Projects List Page**
![image](https://user-images.githubusercontent.com/22625502/43486489-04811e5a-94e2-11e8-9d62-deee08d1c1c9.png)

**Getting Started Message**
![image](https://user-images.githubusercontent.com/22625502/43486520-137b4ba6-94e2-11e8-9d88-8441a45d9ff3.png)