### PR TITLE
Update Dropdown component to handle long strings of text

### DIFF
--- a/frontend/public/components/RBAC/_rbac.scss
+++ b/frontend/public/components/RBAC/_rbac.scss
@@ -77,16 +77,17 @@
 
 .rbac-edit-binding {
 
-  .co-m-resource-icon {
-    margin-left: 0;
-  }
-
   .alert {
     margin-top: 20px;
   }
 
   .btn--dropdown {
-    width: 400px;
+    max-width: 400px;
+    width: 100%;
+  }
+
+  .btn-group {
+    width: 100%;
   }
 
   .form-control {
@@ -94,19 +95,11 @@
   }
   .dropdown {
     max-width: 400px;
-    .form-control {
-      width: 380px;
-    }
   }
 
-  .dropdown {
-    .caret {
-      position: absolute;
-      right: 14px;
-      top: 9px;
-    }
+  @media (min-width: $grid-float-breakpoint) {
     .dropdown-menu {
-      width: 400px;
+      min-width: 400px;
     }
   }
 

--- a/frontend/public/components/_cluster-overview.scss
+++ b/frontend/public/components/_cluster-overview.scss
@@ -21,6 +21,13 @@
   border-top: none;
 }
 
+// Maintain uniform spacing above filter-bar and
+// allow group__body borders to connect with group__title bar
+.group__body--filter-bar {
+  margin-top: -$grid-gutter-width;
+  padding-top: $grid-gutter-width;
+}
+
 .group__documentation {
   padding-bottom: 12px;
   padding-top: 12px;

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -6,6 +6,9 @@ $color-bookmarker: #DDD;
 
 .dropdown {
   position: relative;
+  .co-m-resource-icon {
+    margin-left: 2px;
+  }
 }
 
 .dropdown__disabled {
@@ -47,6 +50,7 @@ $color-bookmarker: #DDD;
 
 .dropdown-menu {
   display: block;
+  max-width: 100%;
 
   ul {
     padding: 0;
@@ -63,6 +67,8 @@ $color-bookmarker: #DDD;
     a {
       cursor: pointer;
       flex-grow: 1;
+      white-space: normal;
+      width: 100%;
       &.next-to-bookmark {
         padding-left: 5px
       }
@@ -156,6 +162,11 @@ $color-bookmarker: #DDD;
     min-width: 250px;
   }
 
+  a {
+    white-space: nowrap;
+    width: auto;
+  }
+
   .dropdown__selected {
     background-color: inherit;
     color: inherit;
@@ -235,9 +246,30 @@ $color-bookmarker: #DDD;
   }
 }
 
+.btn--dropdown {
+  max-width: 100%;
+  .caret {
+    flex: 0 0 auto;
+    margin-left: 5px;
+  }
+}
+
+.btn--dropdown__item {
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  .co-resource-link__resource-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
 .btn--dropdown__content-wrap {
-  display: flex;
   align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  justify-content: space-between;
+  min-width: 0;
 }
 
 .btn--actions {

--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -1,20 +1,14 @@
 .co-type-selector {
-  .co-type-selector__icon-wrapper {
-    display: inline-block;
-    text-align: center;
-    width: 40px;
-  }
-
-  .dropdown .btn {
-    margin-right: -2px;
-  }
-
+  margin-right: -2px;
+  min-width: 0;
   .dropdown-menu {
-    max-height: 80vh;
+    max-height: 75vh;
+    min-width: 270px;
     overflow-x: hidden;
     overflow-y: auto;
     a {
       padding: 4px 20px 4px 6px;
+      white-space: nowrap;
     }
   }
 }

--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -3,6 +3,7 @@ $height: 18px;
 .co-m-resource-icon {
   display: inline-block;
   font-size: $font-size-base - 1;
+  font-weight: normal;
   text-align: center;
   border-radius: 10px;
   height: $height;
@@ -24,6 +25,13 @@ $height: 18px;
     position: relative;
     top: 4px;
   }
+}
+
+.co-resource-icon--fixed-width {
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  width: 40px;
 }
 
 .co-m-resource-clusterrole,

--- a/frontend/public/components/cluster-overview.jsx
+++ b/frontend/public/components/cluster-overview.jsx
@@ -162,7 +162,7 @@ const GraphsPage = ({fake, limited, namespace, openshiftFlag}) => {
           <h2 className="h3">Events</h2>
           <a href={formatNamespacedRouteForResource('events', namespace)}>View All</a>
         </div>
-        <div className="group__body">
+        <div className="group__body group__body--filter-bar">
           <EventStreamPage namespace={namespace} showTitle={false} autoFocus={false} fake={fake} />
         </div>
       </div>

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -145,7 +145,7 @@ class EventsStreamPage_ extends React.Component {
           <title>Events</title>
         </Helmet> }
         { showTitle && <NavTitle title="Events" /> }
-        <div className="co-m-pane__filter-bar co-m-pane__filter-bar--group__body">
+        <div className="co-m-pane__filter-bar">
           <div className="co-m-pane__filter-bar-group">
             <ResourceListDropdown title="All Types" className="btn-group" onChange={v => this.setState({kind: v})} showAll selected={kind} />
             <Dropdown title="All Categories" className="btn-group" items={categories} onChange={v => this.setState({category: v})} />

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -172,7 +172,7 @@ export const FireMan_ = connect(null, {filterList: k8sActions.filterList})(
       }
 
       const {title} = this.props;
-      return <div>
+      return <React.Fragment>
         {title && <NavTitle title={title} />}
         <div className="co-m-pane__filter-bar">
           {createLink && <div className="co-m-pane__filter-bar-group">
@@ -195,7 +195,7 @@ export const FireMan_ = connect(null, {filterList: k8sActions.filterList})(
             reduxIDs: this.state.reduxIDs,
           })}
         </div>
-      </div>;
+      </React.Fragment>;
     }
   }
 );

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -40,11 +40,15 @@ const blacklistResources = ImmutableSet([
 ]);
 
 const DropdownItem: React.SFC<DropdownItemProps> = ({model, showGroup}) => <React.Fragment>
-  <span className="co-type-selector__icon-wrapper">
-    <ResourceIcon kind={model.kind} />
+  <span className="co-resource-link">
+    <span className="co-resource-icon--fixed-width">
+      <ResourceIcon kind={model.kind} />
+    </span>
+    <span className="co-resource-link__resource-name">
+      {model.kind}
+      {showGroup && <React.Fragment>&nbsp;<small className="text-muted">&ndash; {model.apiGroup || 'core'}/{model.apiVersion}</small></React.Fragment>}
+    </span>
   </span>
-  {model.kind}
-  {showGroup && <React.Fragment>&nbsp;<small className="text-muted">&ndash; {model.apiGroup || 'core'}/{model.apiVersion}</small></React.Fragment>}
 </React.Fragment>;
 
 const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
@@ -81,9 +85,13 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
   // Add an "All" item to the top if `showAll`.
   const allItems = (showAll
     ? OrderedMap({all: <React.Fragment>
-      <span className="co-type-selector__icon-wrapper">
-        <ResourceIcon kind="All" />
-      </span>All Types
+      <span className="co-resource-link">
+        <span className="co-resource-icon--fixed-width">
+          <ResourceIcon kind="All" />
+        </span>
+        <span className="co-resource-link__resource-name">All Types</span>
+      </span>
+      {/* <ResourceIcon kind="All" /> */}
     </React.Fragment>}).concat(items)
     : items
     )

--- a/frontend/public/components/search.jsx
+++ b/frontend/public/components/search.jsx
@@ -80,7 +80,7 @@ class SearchPage_ extends React.PureComponent {
         </Helmet>
         <NavTitle detail={true} title="Search" >
           <div className="co-search">
-            <div className="input-group">
+            <div className="input-group input-group-select">
               <div className="input-group-btn">
                 <ResourceListDropdown selected={kind} onChange={this.onSelectorChange} />
               </div>

--- a/frontend/public/components/utils/_value-from-pair.scss
+++ b/frontend/public/components/utils/_value-from-pair.scss
@@ -9,13 +9,14 @@
     width: 100%;
   }
 
-  .caret {
-    position: absolute;
-    right: 14px;
-    top: 9px;
-  }
-
   .dropdown-menu {
+    min-width: 250px;
     width: 100%;
+  }
+}
+@media (max-width: $screen-xs-max) {
+  .value-from__menu {
+    left: auto;
+    right: 0;
   }
 }

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -400,7 +400,7 @@ export class Dropdown extends DropdownMixin {
     }
 
     //Adding `dropDownClassName` specifically to use patternfly's context selector component, which expects `bootstrap-select` class on the dropdown. We can remove this additional property if that changes in upcoming patternfly versions.
-    return <div className={className} ref={this.dropdownElement} style={this.props.style}>
+    return <div className={classNames(className)} ref={this.dropdownElement} style={this.props.style}>
       <div className={classNames('dropdown', dropDownClassName)}>
         {
           noButton
@@ -410,8 +410,10 @@ export class Dropdown extends DropdownMixin {
             </div>
             : <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('btn', 'btn--dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id}>
               <div className="btn--dropdown__content-wrap">
-                {titlePrefix && `${titlePrefix}: `}
-                {title}&nbsp;&nbsp;<Caret />
+                <span className="btn--dropdown__item">
+                  {titlePrefix && `${titlePrefix}: `}
+                  {title}
+                </span><Caret />
               </div>
             </button>
         }

--- a/frontend/public/components/utils/resource-icon.tsx
+++ b/frontend/public/components/utils/resource-icon.tsx
@@ -42,6 +42,6 @@ export type ResourceNameProps = {
 };
 /* eslint-enable no-undef */
 
-export const ResourceName: React.SFC<ResourceNameProps> = (props) => <span><ResourceIcon kind={props.kind} /> {props.name}</span>;
+export const ResourceName: React.SFC<ResourceNameProps> = (props) => <span className="co-resource-link"><ResourceIcon kind={props.kind} /> <span className="co-resource-link__resource-name">{props.name}</span></span>;
 
 ResourceName.displayName = 'ResourceName';

--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -82,7 +82,7 @@ const NameKeyDropdownPair = ({name, key, configMaps, secrets, onChange, kind, na
   const items = _.assign({}, cmItems, secretItems);
   return <React.Fragment>
     <Dropdown
-      menuClassName="co-namespace-selector__menu"
+      menuClassName="value-from__menu"
       className="value-from"
       autocompleteFilter={nameAutocompleteFilter}
       autocompletePlaceholder={placeholderString}
@@ -100,7 +100,7 @@ const NameKeyDropdownPair = ({name, key, configMaps, secrets, onChange, kind, na
       }}
     />
     <Dropdown
-      menuClassName="co-namespace-selector__menu"
+      menuClassName="value-from__menu"
       className="value-from"
       autocompleteFilter={keyAutocompleteFilter}
       autocompletePlaceholder="Key"

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -14,12 +14,12 @@
 .co-m-pane__filter-bar {
   display: flex;
   flex-wrap: wrap;
-  margin: 10px ($grid-gutter-width / 2) 20px;
+  justify-content: space-between;
+  margin: 20px ($grid-gutter-width / 2);
   @media (min-width: $grid-float-breakpoint) {
     margin-left: $grid-gutter-width;
     margin-right: $grid-gutter-width;
     margin-top: $grid-gutter-width;
-
   }
   .btn-group,
   .co-m-primary-action,
@@ -28,6 +28,7 @@
   }
   .btn-group {
     margin-right: 10px;
+    min-width: 0; // enables truncation of selected item, if needed
   }
   &--alt {
     margin-left: 0;
@@ -42,10 +43,13 @@
 .co-m-pane__filter-bar-group {
   display: flex;
   flex: 1 1 auto;
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 .co-m-pane__filter-bar-group--filter {
   @media(min-width: $screen-xs-min) {
+    flex: 1 1 auto;
     justify-content: flex-end;
   }
 }
@@ -55,10 +59,6 @@
   justify-content: space-between;
   .btn-group {
     display: flex;
-    .btn {
-      // necessary since .btn is a grandchild of .btn-group and not a child
-      margin-left: -1px;
-    }
   }
   .co-m-pane__filter-bar-group + & {
     flex-grow: 0;
@@ -174,6 +174,23 @@
   padding-bottom: 30px;
   .input-group-btn {
     vertical-align: top;
+    @media(max-width: $grid-float-breakpoint-max) {
+      display: flex;
+      min-width: 0;
+      width: auto;
+      .co-type-selector {
+        width: 100%;
+      }
+    }
+  }
+  @media(max-width: $grid-float-breakpoint-max) {
+    .input-group-select {
+      display: block;
+      .btn--dropdown {
+        margin-bottom: 2px;
+        width: 100%;
+      }
+    }
   }
 }
 
@@ -183,6 +200,7 @@
   padding: 20px;
   margin: 30px;
 }
+
 
 // Prevent iOS phones from zooming on form inputs
 @supports (-webkit-overflow-scrolling: touch) { // Target mobile Safari
@@ -253,20 +271,25 @@ input[type=number]::-webkit-outer-spin-button {
 .co-toolbar {
   align-items: stretch;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   margin-bottom: 5px;
 }
 
 .co-toolbar__item {
+  max-width: 100%;
   padding: 5px 0;
+  .btn-group {
+    max-width: 100%;
+  }
 }
 
 .co-toolbar__group {
   align-items: center;
   display: flex;
-  flex-grow: 1;
   flex-wrap: wrap;
   justify-content: center;
+  min-width: 0;
 
   @media (max-width: $screen-xs-max) {
     flex-direction: column;
@@ -286,8 +309,10 @@ input[type=number]::-webkit-outer-spin-button {
 
 .co-toolbar__group--right {
   justify-content: flex-end;
-  .co-toolbar__item {
-    padding-left: 15px;
+  @media (min-width: $screen-xs-min) {
+    .co-toolbar__item {
+      padding-left: 15px;
+    }
   }
   @media (max-width: $screen-xs-max) {
     align-items: flex-end;


### PR DESCRIPTION
Enable `dropdown-menu` items to wrap long text.
Enable `.btn--dropdown` select fields to truncate long text.
fixes https://github.com/openshift/console/issues/220

<img width="524" alt="screen shot 2018-07-31 at 12 43 55 pm" src="https://user-images.githubusercontent.com/1874151/43528344-bba243f4-9576-11e8-966f-32334b5e948c.png">
<img width="293" alt="screen shot 2018-07-31 at 12 45 56 pm" src="https://user-images.githubusercontent.com/1874151/43528349-bdd9eb68-9576-11e8-954c-ae8c69370b6b.png">
<img width="329" alt="screen shot 2018-07-31 at 12 46 12 pm" src="https://user-images.githubusercontent.com/1874151/43528358-c20e708c-9576-11e8-9152-d17b20123b8f.png">
<img width="885" alt="screen shot 2018-07-31 at 12 52 49 pm" src="https://user-images.githubusercontent.com/1874151/43528362-c495d82c-9576-11e8-803e-5dd34415dfd8.png">
<img width="676" alt="screen shot 2018-07-31 at 12 50 55 pm" src="https://user-images.githubusercontent.com/1874151/43528364-c4a374be-9576-11e8-9f1c-8167d202c00c.png">
<img width="384" alt="screen shot 2018-07-31 at 12 49 54 pm" src="https://user-images.githubusercontent.com/1874151/43528365-c4b032c6-9576-11e8-85a1-9285e51d8c83.png">

also fix for stacking the search `input-group` at mobile.
**before**
<img width="380" alt="screen shot 2018-08-01 at 11 05 11 am" src="https://user-images.githubusercontent.com/1874151/43533341-9b2bf7f8-9582-11e8-8541-1fbb890c35a9.png">
**after**
<img width="323" alt="screen shot 2018-08-01 at 11 58 57 am" src="https://user-images.githubusercontent.com/1874151/43533346-9d0721ec-9582-11e8-9501-434812aeaa75.png">


