### PR TITLE
Fix env var bug adding a new config map or secret value to container with index > 1.

### DIFF
--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -26,9 +26,9 @@ export const NameValueEditor = DragDropContext(HTML5Backend)(class NameValueEdit
   }
 
   _appendConfigMapOrSecret() {
-    const {updateParentData, nameValuePairs} = this.props;
+    const {updateParentData, nameValuePairs, nameValueId} = this.props;
     const configMapSecretKeyRef = {name: '', key: ''};
-    updateParentData({nameValuePairs: nameValuePairs.concat([['', {configMapSecretKeyRef}, nameValuePairs.length]])});
+    updateParentData({nameValuePairs: nameValuePairs.concat([['', {configMapSecretKeyRef}, nameValuePairs.length]])}, nameValueId);
   }
 
   _remove(i) {


### PR DESCRIPTION
Fix issue: https://github.com/openshift/console/issues/362

Pass in the container id so the config map or secret env var gets set to the correct container instance.