### PR TITLE
Fix mobile navbar menu

### DIFF
--- a/frontend/public/components/masthead.scss
+++ b/frontend/public/components/masthead.scss
@@ -7,9 +7,7 @@
   left: 0;
   position: fixed;
   right: 0;
-  // The z-index of the masthead needs to be greater than the left sidebar so
-  // that the context selector opens over it.
-  z-index: $zindex-navbar-fixed + 1;
+  z-index: $masthead-z-index;
   @media (max-width: $grid-float-breakpoint-max) {
     padding-left: 50px; // make space for .sidebar-toggle
   }

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -24,7 +24,7 @@ body,
   position: fixed;
   top: $masthead-height-mobile;
   width: $sidebar-width;
-  z-index: $zindex-navbar-fixed;
+  z-index: $sidebar-z-index;
   @media (max-width: $grid-float-breakpoint-max) {
     left: -($sidebar-width);
     &.open {
@@ -45,7 +45,7 @@ body,
   margin: 4px 5px;
   padding: 9px 10px;
   position: fixed;
-  z-index: $zindex-navbar-fixed;
+  z-index: $masthead-z-index;
   @media (min-width: $grid-float-breakpoint) {
     display: none;
   }

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -51,6 +51,13 @@ $color-grey-when-selected: #e5e5e5;
 $color-text-muted: $co-gray;
 $color-text-secondary: $color-grey-medium;
 
+// TODO: Set to $zindex-navbar-fixed var from Bootstrap. (We can't currently
+// since Bootstrap vars are imported after this file.)
+$sidebar-z-index: 1030;
+
+// The z-index of the masthead needs to be greater than the left sidebar so
+// that the context selector opens over it.
+$masthead-z-index: $sidebar-z-index + 1;
 $masthead-height-desktop: 60px;
 $masthead-height-mobile: 40px;
 


### PR DESCRIPTION
The menu's z-index was lower than the masthead, so it was hidden.

Fixes a regression from #361

/assign @sg00dwin 