### PR TITLE
Change labels to use "Edit"

### DIFF
--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -289,7 +289,7 @@ describe('Kubernetes resource CRUD operations', () => {
       await browser.wait(until.presenceOf(crudView.actionsDropdown));
       await crudView.actionsDropdown.click();
       await browser.wait(until.presenceOf(crudView.actionsDropdownMenu), 500);
-      await crudView.actionsDropdownMenu.element(by.linkText('Modify Labels...')).click();
+      await crudView.actionsDropdownMenu.element(by.linkText('Edit Labels')).click();
       await browser.wait(until.presenceOf($('.tags input')), 500);
       await $('.tags input').sendKeys(labelValue, Key.ENTER);
       // This only works because there's only one label

--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -16,9 +16,9 @@ export const rowForName = (name: string) => resourceRows.filter((row) => row.$$(
 export const labelsForRow = (name: string) => rowForName(name).$$('.co-m-label');
 export const textFilter = $('.co-m-pane__filter-bar-group--filter input');
 export const gearOptions = {
-  nodeSelector: 'Modify Node Selector',
-  labels: 'Modify Labels',
-  annotations: 'Modify Annotations',
+  nodeSelector: 'Edit Node Selector',
+  labels: 'Edit Labels',
+  annotations: 'Edit Annotations',
   edit: 'Edit',
   delete: 'Delete',
 };

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -34,12 +34,12 @@ spec:
 const {ModifyCount, ModifyNodeSelector, EditEnvironment, common} = Cog.factory;
 
 const RevisionHistory = (kind, deployment) => ({
-  label: 'Revision History...',
+  label: 'Edit Revision History Limit',
   callback: () => configureRevisionHistoryLimitModal({deployment}),
 });
 
 const UpdateStrategy = (kind, deployment) => ({
-  label: 'Update Strategy...',
+  label: 'Edit Update Strategy',
   callback: () => configureUpdateStrategyModal({deployment}),
 });
 

--- a/frontend/public/components/job.jsx
+++ b/frontend/public/components/job.jsx
@@ -25,7 +25,7 @@ spec:
       restartPolicy: Never`);
 
 const ModifyJobParallelism = (kind, obj) => ({
-  label: 'Modify Parallelism...',
+  label: 'Edit Parallelism',
   callback: () => configureJobParallelismModal({
     resourceKind: kind,
     resource: obj,

--- a/frontend/public/components/modals/configure-count-modal.jsx
+++ b/frontend/public/components/modals/configure-count-modal.jsx
@@ -81,7 +81,7 @@ export const configureCountModal = createModalLauncher(ConfigureCountModal);
 export const configureReplicaCountModal = (props) => {
   return configureCountModal(_.defaults({}, {
     defaultValue: 0,
-    title: 'Modify Desired Count',
+    title: 'Edit Count',
     message: `${props.resourceKind.labelPlural} maintain the desired number of healthy pods.`,
     path: '/spec/replicas',
     buttonText: 'Save Desired Count'
@@ -91,7 +91,7 @@ export const configureReplicaCountModal = (props) => {
 export const configureJobParallelismModal = (props) => {
   return configureCountModal(_.defaults({}, {
     defaultValue: 1,
-    title: 'Modify Desired Parallelism',
+    title: 'Edit Parallelism',
     message: `${props.resourceKind.labelPlural} create one or more pods and ensure that a specified number of them successfully terminate. When the specified number of completions is successfully reached, the job is complete.`,
     path: '/spec/parallelism',
     buttonText: 'Save Desired Parallelism'
@@ -101,7 +101,7 @@ export const configureJobParallelismModal = (props) => {
 export const configureClusterSizeModal = (props) => {
   return configureCountModal(_.defaults({}, {
     defaultValue: 0,
-    title: 'Modify Cluster Size',
+    title: 'Edit Cluster Size',
     message: `${props.resourceKind.labelPlural} maintain the desired number of healthy pods.`,
     path: '/spec/size',
     buttonText: 'Save Cluster Size'

--- a/frontend/public/components/modals/configure-revision-history-limit-modal.jsx
+++ b/frontend/public/components/modals/configure-revision-history-limit-modal.jsx
@@ -44,7 +44,7 @@ class ConfigureRevisionHistoryLimitModal extends PromiseComponent {
 
   render() {
     return <form onSubmit={this._submit} name="form">
-      <ModalTitle>Revision History Limit</ModalTitle>
+      <ModalTitle>Edit Revision History Limit</ModalTitle>
       <ModalBody>
         <div className="co-m-form-row">
           <p>

--- a/frontend/public/components/modals/configure-unschedulable-modal.jsx
+++ b/frontend/public/components/modals/configure-unschedulable-modal.jsx
@@ -24,7 +24,7 @@ class UnscheduleNodeModal extends PromiseComponent {
 
   render() {
     return <form onSubmit={this._submit} name="form">
-      <ModalTitle>Mark as unschedulable</ModalTitle>
+      <ModalTitle>Mark as Unschedulable</ModalTitle>
       <ModalBody>
         Unschedulable nodes won&#39;t accept new pods. This is useful for scheduling maintenance or preparing to decommission a node.
       </ModalBody>

--- a/frontend/public/components/modals/configure-update-strategy-modal.jsx
+++ b/frontend/public/components/modals/configure-update-strategy-modal.jsx
@@ -62,7 +62,7 @@ class ConfigureUpdateStrategyModal extends PromiseComponent {
     const maxSurge = _.get(this.deployment.spec, 'strategy.rollingUpdate.maxSurge', '');
 
     return <form onSubmit={this._submit} name="form">
-      <ModalTitle>Deployment Update Strategy</ModalTitle>
+      <ModalTitle>Edit Update Strategy</ModalTitle>
       <ModalBody>
         <div className="co-m-form-row">
           <p>

--- a/frontend/public/components/modals/labels-modal.jsx
+++ b/frontend/public/components/modals/labels-modal.jsx
@@ -52,7 +52,7 @@ class BaseLabelsModal extends PromiseComponent {
     const { kind, resource, description, message, labelClassName } = this.props;
 
     return <form onSubmit={this._submit} name="form">
-      <ModalTitle>Modify {description || `${kind.label} Labels`}</ModalTitle>
+      <ModalTitle>Edit {description || 'Labels'}</ModalTitle>
       <ModalBody>
         <div className="row co-m-form-row">
           <div className="col-sm-12">{message || 'Labels help you organize and select resources. Adding labels below will let you query for objects that have similar, overlapping or dissimilar labels.'}</div>

--- a/frontend/public/components/modals/tags.jsx
+++ b/frontend/public/components/modals/tags.jsx
@@ -69,6 +69,6 @@ class TagsModal extends PromiseComponent {
 export const annotationsModal = createModalLauncher(props => <TagsModal
   path="/metadata/annotations"
   tags={props.resource.metadata.annotations}
-  title="Annotations"
+  title="Edit Annotations"
   {...props}
 />);

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -11,7 +11,7 @@ import { NodeModel } from '../models';
 import { CamelCaseWrap } from './utils/camel-case-wrap';
 
 const MarkAsUnschedulable = (kind, obj) => ({
-  label: 'Mark as Unschedulable...',
+  label: 'Mark as Unschedulable',
   hidden: _.get(obj, 'spec.unschedulable'),
   callback: () => configureUnschedulableModal({resource: obj}),
 });

--- a/frontend/public/components/utils/cog.tsx
+++ b/frontend/public/components/utils/cog.tsx
@@ -21,53 +21,53 @@ const CogItems: React.SFC<CogItemsProps> = ({options, onClick}) => {
 
 const cogFactory: CogFactory = {
   Delete: (kind, obj) => ({
-    label: `Delete ${kind.label}...`,
+    label: `Delete ${kind.label}`,
     callback: () => deleteModal({
       kind: kind,
       resource: obj,
     }),
   }),
   Edit: (kind, obj) => ({
-    label: `Edit ${kind.label}...`,
+    label: `Edit ${kind.label}`,
     href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/yaml`,
   }),
   ModifyLabels: (kind, obj) => ({
-    label: 'Modify Labels...',
+    label: 'Edit Labels',
     callback: () => labelsModal({
       kind: kind,
       resource: obj,
     }),
   }),
   ModifyPodSelector: (kind, obj) => ({
-    label: 'Modify Pod Selector...',
+    label: 'Edit Pod Selector',
     callback: () => podSelectorModal({
       kind: kind,
       resource:  obj,
     }),
   }),
   ModifyNodeSelector: (kind, obj) => ({
-    label: 'Modify Node Selector...',
+    label: 'Edit Node Selector',
     callback: () => nodeSelectorModal({
       kind: kind,
       resource: obj,
     }),
   }),
   ModifyAnnotations: (kind, obj) => ({
-    label: 'Modify Annotations...',
+    label: 'Edit Annotations',
     callback: () => annotationsModal({
       kind: kind,
       resource: obj,
     }),
   }),
   ModifyCount: (kind, obj) => ({
-    label: 'Modify Count...',
+    label: 'Edit Count',
     callback: () => configureReplicaCountModal({
       resourceKind: kind,
       resource: obj,
     }),
   }),
   EditEnvironment: (kind, obj) => ({
-    label: `${kind.kind === 'Pod' ? 'View' : 'Edit'} Environment...`,
+    label: `${kind.kind === 'Pod' ? 'View' : 'Edit'} Environment`,
     href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/environment`,
   }),
 };

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -385,7 +385,7 @@ export const ActionsMenu = (props) => {
   const {actions, title = undefined, menuClassName = undefined, noButton = false} = props;
   const shownActions = _.reject(actions, o => _.get(o, 'hidden', false));
   const items = _.fromPairs(_.map(shownActions, (v, k) => [k, v.label]));
-  const btnTitle = title || <span id="action-dropdown"><i className="fa fa-cog" /> Actions</span>;
+  const btnTitle = title || <span id="action-dropdown">Actions</span>;
   const onChange = (key, e) => {
     const action = shownActions[key];
     if (action.callback) {


### PR DESCRIPTION
Fixes [CONSOLE-623](https://jira.coreos.com/browse/CONSOLE-623).

Updated labels in dropdowns to use "edit" rather than "modify" or nothing.

Before:
![screen shot 2018-08-06 at 9 38 57 am](https://user-images.githubusercontent.com/7014965/43719759-94e18498-995c-11e8-8994-b4bbf61cec9c.png)

After:
![screen shot 2018-08-06 at 9 32 36 am](https://user-images.githubusercontent.com/7014965/43719456-c4aa75d2-995b-11e8-97fb-4e448a08c9be.png)

I also changed some of the modals' titles to match; let me know if that's a terrible idea and I'll switch them back.

Before:
![screen shot 2018-08-06 at 9 37 21 am](https://user-images.githubusercontent.com/7014965/43719698-65d893ee-995c-11e8-80a1-c7390db1a39e.png)

After:
![screen shot 2018-08-06 at 9 33 56 am](https://user-images.githubusercontent.com/7014965/43719506-e1c09912-995b-11e8-9b58-64d971c67030.png)

@openshift/team-ux-review - can you please review this? Thanks!