### PR TITLE
Better Types for Redux Helper Functions

### DIFF
--- a/frontend/__tests__/features.spec.tsx
+++ b/frontend/__tests__/features.spec.tsx
@@ -1,8 +1,9 @@
-/* eslint-disable no-undef */
+/* eslint-disable no-undef, no-unused-vars */
 
+import * as React from 'react';
 import * as Immutable from 'immutable';
 
-import { FLAGS, featureReducer, DEFAULTS_ } from '../public/features';
+import { FLAGS, featureReducer, DEFAULTS_, connectToFlags } from '../public/features';
 import { types } from '../public/module/k8s/k8s-actions';
 import { ClusterServiceVersionModel } from '../public/models';
 
@@ -41,5 +42,22 @@ describe('featureReducer', () => {
       [FLAGS.MULTI_CLUSTER]: false,
       [FLAGS.CHARGEBACK]: false,
     }));
+  });
+});
+
+describe('connectToFlags', () => {
+  type MyComponentProps = {propA: number, propB: boolean, flags: {[key: string]: boolean}};
+
+  class MyComponent extends React.Component<MyComponentProps> {
+    render() {
+      return <div>{this.props.propA}</div>;
+    }
+  }
+
+  it('returns a component which preserves needed props and removes `flags` prop', () => {
+    const MyComponentWithFlags = connectToFlags<MyComponentProps>()(MyComponent);
+    const jsx = <MyComponentWithFlags propA={42} propB={false} />;
+
+    expect(jsx).toBeDefined();
   });
 });

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -6,7 +6,7 @@ import * as _ from 'lodash-es';
 import { resourceListPages, resourceDetailPages } from './resource-pages';
 import { connectToPlural } from '../kinds';
 import { LoadingBox } from './utils';
-import { K8sResourceKindReference, referenceForModel } from '../module/k8s';
+import { K8sResourceKindReference, referenceForModel, K8sKind } from '../module/k8s';
 import { ErrorPage404 } from './error';
 import { FLAGS, connectToFlags, flagPending } from '../features';
 import { OpenShiftGettingStarted } from './start-guide';
@@ -76,11 +76,15 @@ export type ResourceListPageProps = {
   flags: any,
   modelRef: K8sResourceKindReference;
   match: match<any>;
+  kindObj: K8sKind;
+  kindsInFlight: boolean;
 };
 
 export type ResourceDetailsPageProps = {
   modelRef: K8sResourceKindReference;
   match: match<any>;
+  kindObj: K8sKind;
+  kindsInFlight: boolean;
 };
 /* eslint-enable no-undef, no-unused-vars */
 

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef, no-unused-vars */
+
 import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';
@@ -180,13 +182,13 @@ export const stateToProps = (desiredFlags: string[], state) => {
   return {flags};
 };
 
-export const mergeProps = (stateProps, dispatchProps, ownProps) => Object.assign({}, ownProps, stateProps, dispatchProps);
+type WithFlagsProps = {
+  flags: {[key: string]: boolean};
+};
 
-export const areStatesEqual = (next, previous) => next.FLAGS.equals(previous.FLAGS) &&
-  next.UI.get('activeNamespace') === previous.UI.get('activeNamespace') &&
-  next.UI.get('location') === previous.UI.get('location');
-
-export const connectToFlags = (...flags) => connect(state => stateToProps(flags, state));
+export type ConnectToFlags = <P extends WithFlagsProps>(...flags: FLAGS[]) => (C: React.ComponentType<P>) =>
+  React.ComponentType<Omit<P, keyof WithFlagsProps>> & {WrappedComponent: React.ComponentType<P>};
+export const connectToFlags: ConnectToFlags = (...flags) => connect(state => stateToProps(flags, state));
 
 // Flag detection is not complete if the flag's value is `undefined`.
 export const flagPending = flag => flag === undefined;

--- a/frontend/public/kinds.ts
+++ b/frontend/public/kinds.ts
@@ -18,11 +18,20 @@ export const connectToModel = connect((state: State, props: {kind: K8sResourceKi
   return {kindObj, kindsInFlight: state.k8s.getIn(['RESOURCES', 'inFlight'])} as any;
 });
 
+type WithPluralProps = {
+  kindObj?: K8sKind;
+  modelRef?: K8sResourceKindReference;
+  kindsInFlight?: boolean;
+};
+
+export type ConnectToPlural = <P extends WithPluralProps>(C: React.ComponentType<P>) =>
+  React.ComponentType<Omit<P, keyof WithPluralProps>> & {WrappedComponent: React.ComponentType<P>};
+
 /**
  * @deprecated TODO(alecmerdler): `plural` is not a unique lookup key, remove uses of this.
  * FIXME(alecmerdler): Not returning correctly typed `WrappedComponent`
  */
-export const connectToPlural = connect((state: State, props: {plural?: GroupVersionKind | string, match: match<{plural: GroupVersionKind | string}>}) => {
+export const connectToPlural: ConnectToPlural = connect((state: State, props: {plural?: GroupVersionKind | string, match: match<{plural: GroupVersionKind | string}>}) => {
   const plural = props.plural || _.get(props, 'match.params.plural');
 
   const kindObj = isGroupVersionKind(plural)
@@ -31,7 +40,7 @@ export const connectToPlural = connect((state: State, props: {plural?: GroupVers
 
   const modelRef = isGroupVersionKind(plural) ? plural : _.get(kindObj, 'kind');
 
-  return {kindObj, modelRef, kindsInFlight: state.k8s.getIn(['RESOURCES', 'inFlight'])} as any;
+  return {kindObj, modelRef, kindsInFlight: state.k8s.getIn(['RESOURCES', 'inFlight'])};
 });
 
 type State = {k8s: ImmutableMap<string, any>};


### PR DESCRIPTION
### Description

The `connect()` function handles type inference pretty well, but not when we wrap it in `connectToFlags` and `connectToPlural`. This makes those functions accept an invisible generic type and pass it to `connect`.