### PR TITLE
Fix breadcrumb links when owner ref points to a CR

### DIFF
--- a/frontend/__tests__/components/cloud-services/install-plan.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/install-plan.spec.tsx
@@ -217,7 +217,7 @@ describe(InstallPlanDetailsPage.displayName, () => {
 
     expect(breadcrumbsFor(testInstallPlan)).toEqual([{
       name: testInstallPlan.metadata.ownerReferences[0].name,
-      path: `/k8s/ns/default/subscriptions/${testInstallPlan.metadata.ownerReferences[0].name}`,
+      path: `/k8s/ns/default/operators.coreos.com:v1alpha1:Subscription/${testInstallPlan.metadata.ownerReferences[0].name}`,
     }, {
       name: 'Install Plan Details',
       path: match.url,

--- a/frontend/public/components/utils/breadcrumbs.ts
+++ b/frontend/public/components/utils/breadcrumbs.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash-es';
 
 // eslint-disable-next-line no-unused-vars
 import { modelFor, referenceForOwnerRef, K8sResourceKind } from '../../module/k8s';
+import { resourcePathFromModel } from './resource-link';
 
 export const breadcrumbsForOwnerRefs = (obj: K8sResourceKind) => {
   const ownerRefs = _.get(obj, 'metadata.ownerReferences');
@@ -16,7 +17,7 @@ export const breadcrumbsForOwnerRefs = (obj: K8sResourceKind) => {
 
     return {
       name: ref.name,
-      path: `/k8s/ns/${obj.metadata.namespace}/${model.plural}/${ref.name}`,
+      path: resourcePathFromModel(model, ref.name, obj.metadata.namespace),
     };
   }));
 };

--- a/frontend/public/components/utils/resource-link.jsx
+++ b/frontend/public/components/utils/resource-link.jsx
@@ -8,19 +8,7 @@ import { connectToModel } from '../../kinds';
 
 const unknownKinds = new Set();
 
-/**
- * NOTE: This will not work for runtime-defined resources. Use a `connect`-ed component like `ResourceLink` instead.
- */
-export const resourcePath = (kind, name, namespace = undefined) => {
-  const model = modelFor(kind);
-  if (!model) {
-    if (!unknownKinds.has(kind)) {
-      unknownKinds.add(kind);
-      // eslint-disable-next-line no-console
-      console.error(`resourcePath: no model for "${kind}"`);
-    }
-    return;
-  }
+export const resourcePathFromModel = (model, name, namespace) => {
   const {path, namespaced, crd} = model;
 
   let url = '/k8s/';
@@ -44,6 +32,23 @@ export const resourcePath = (kind, name, namespace = undefined) => {
   }
 
   return url;
+};
+
+/**
+ * NOTE: This will not work for runtime-defined resources. Use a `connect`-ed component like `ResourceLink` instead.
+ */
+export const resourcePath = (kind, name, namespace) => {
+  const model = modelFor(kind);
+  if (!model) {
+    if (!unknownKinds.has(kind)) {
+      unknownKinds.add(kind);
+      // eslint-disable-next-line no-console
+      console.error(`resourcePath: no model for "${kind}"`);
+    }
+    return;
+  }
+
+  return resourcePathFromModel(model, name, namespace);
 };
 
 export const resourceObjPath = (obj, kind) => resourcePath(kind, _.get(obj, 'metadata.name'), _.get(obj, 'metadata.namespace'));


### PR DESCRIPTION
Use group/version/kind in the URL, which prevents a runtime error clicking the link.

/assign @alecmerdler 