### PR TITLE
Bug 1612656 - fix 'View Log' url for Jenkins Pipeline build

### DIFF
--- a/frontend/public/components/build-pipeline.tsx
+++ b/frontend/public/components/build-pipeline.tsx
@@ -17,7 +17,7 @@ const getJenkinsStatus = (resource: K8sResourceKind) => {
   return _.isError(status) ? {} : status;
 };
 
-export const getJenkinsLogURL = (resource: K8sResourceKind): string => _.get(resource, ['metadata', 'annotations', 'openshift.io/jenkins-log-url']);
+export const getJenkinsLogURL = (resource: K8sResourceKind): string => _.get(resource, ['metadata', 'annotations', 'openshift.io/jenkins-console-log-url']);
 export const getJenkinsBuildURL = (resource: K8sResourceKind): string => _.get(resource, ['metadata', 'annotations', 'openshift.io/jenkins-build-uri']);
 
 const BuildSummaryStatusIcon: React.SFC<BuildSummaryStatusIconProps> = ({ status }) => {


### PR DESCRIPTION
Fix [BZ 1612656](https://bugzilla.redhat.com/show_bug.cgi?id=1612656)

Get log URL from  `openshift.io/jenkins-console-log-url` rather than `openshift.io/jenkins-log-url`(display in plain text and doesn't get refreshed)