### PR TITLE
Add additional validation to branding flag

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -144,6 +144,13 @@ func main() {
 	if branding == "origin" {
 		branding = "okd"
 	}
+	switch branding {
+	case "okd":
+	case "ocp":
+	case "online":
+	default:
+		flagFatalf("branding", "value must be one of okd, ocp, or online")
+	}
 
 	srv := &server.Server{
 		PublicDir:            *fPublicDir,


### PR DESCRIPTION
Follow on to discussion in #371, this adds additional validation to the value set for `branding`.

Targeting for 3.11 since it's difficult to tighten validation in later releases since it can break existing configs.

/assign @jhadvig 