### PR TITLE
Do not add active class to dropdown item if noSelection is true

### DIFF
--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -54,8 +54,8 @@ export class DropdownMixin extends React.PureComponent {
 
     this.setState({
       active: false,
-      selectedKey: selectedKey,
-      keyboardHoverKey: selectedKey,
+      selectedKey: noSelection ? undefined: selectedKey,
+      keyboardHoverKey: noSelection ? undefined: selectedKey,
       title: noSelection ? title : this.props.items[selectedKey]
     });
   }
@@ -91,7 +91,11 @@ export class DropdownMixin extends React.PureComponent {
   hide (e) {
     e && e.stopPropagation();
     window.removeEventListener('click', this.listener);
-    this.setState({active: false});
+    const keyboardHoverKey = this.props.noSelection ? undefined : this.state.keyboardHoverKey;
+    this.setState({
+      active: false,
+      keyboardHoverKey: keyboardHoverKey,
+    });
   }
 }
 
@@ -346,7 +350,7 @@ export class Dropdown extends DropdownMixin {
         return;
       }
 
-      const selected = key === selectedKey;
+      const selected = (key === selectedKey) && !this.props.noSelection;
       const hover = key === keyboardHoverKey;
       const klass = classNames({'active': selected});
       if (storageKey && bookmarks && bookmarks[key]) {


### PR DESCRIPTION
Open Pods View and go to any Pod's Details Page. Open Actions dropdown and click Edit Labels. Close the modal dialog and open Actions dropdown again -> Edit Labels is highlighted (active). 

This PR does not add active class/hover to dropdown item if noSelection property is set to true.

![active_item](https://user-images.githubusercontent.com/2078045/43960685-11696900-9cb3-11e8-9187-c10889989a1f.png)
