### PR TITLE
Bug 16113185, console-331: handle the case where an env var is set without a value

### DIFF
--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -25,6 +25,9 @@ const getPairsFromObject = (element) => {
     return [['', '', 0]];
   }
   return _.map(element.env, (leafNode, i) => {
+    if (!_.has(leafNode, 'value') && !_.has(leafNode, 'valueFrom')) {
+      leafNode.value = '';
+    }
     leafNode.ID = i;
     return Object.values(leafNode);
   });


### PR DESCRIPTION
fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1613185

When setting an env var with no value:
{name: 'bug331', value: ''}, the return object doesn't contain the 'value' property so adjust to add 'value': '' to the env objects with no value set in order to display them properly.