### PR TITLE
Creating secret with 'all projects' selected uses project 'undefined'

### DIFF
--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -130,7 +130,7 @@ const SecretsPage = props => {
 
   const createProps = {
     items: createItems,
-    createLink: (type) => `/k8s/ns/${props.namespace}/secrets/new/${type !== 'yaml' ? type : ''}`
+    createLink: (type) => `/k8s/ns/${props.namespace || 'default'}/secrets/new/${type !== 'yaml' ? type : ''}`
   };
 
   return <ListPage ListComponent={SecretsList} canCreate={true} rowFilters={filters} createButtonText="Create" createProps={createProps} {...props} />;


### PR DESCRIPTION
Originally I wanted to move the exported `NsDropdown` component (together with underlying `ListDropdown` component) into a separate file into `utils` directory, but would rather do that as a refactoring followUp, if you dont mind.

With single project selected:
![1](https://user-images.githubusercontent.com/1668218/44103844-95bfaeca-9fed-11e8-9c16-88416239362a.png)

With `All Projects` selected:
![2](https://user-images.githubusercontent.com/1668218/44103883-a9e6dd7e-9fed-11e8-8a0a-360ba4613916.png)


Fixes https://jira.coreos.com/browse/CONSOLE-698

@spadgett PTAL