### PR TITLE
Allow type ahead on all resource dropdowns

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -37,6 +37,10 @@ $color-bookmarker: #DDD;
   padding: 5px 10px 10px;
 }
 
+.dropdown--text-filter {
+  float: none !important;
+}
+
 .favorite {
   color: gold;
 }

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import * as PropTypes from 'prop-types';
 import { Map as ImmutableMap, OrderedMap, Set as ImmutableSet } from 'immutable';
 import * as classNames from 'classnames';
+import * as fuzzy from 'fuzzysearch';
 
 import { Dropdown, ResourceIcon } from './utils';
 import { K8sKind, K8sResourceKindReference, referenceForModel, apiVersionForReference, kindForReference } from '../module/k8s';
@@ -89,8 +90,23 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
     .toJS() as {[s: string]: JSX.Element};
 
   const selectedKey = allItems[selected] ? selected : kindForReference(selected);
+  const autocompleteFilter = (text, item) => {
+    const { model } = item.props;
+    if (!model) {
+      return false;
+    }
 
-  return <Dropdown className={classNames('co-type-selector', className)} items={allItems} title={allItems[selectedKey]} onChange={onChange} selectedKey={selectedKey} />;
+    return fuzzy(_.toLower(text), _.toLower(model.abbr + model.kind));
+  };
+
+  return <Dropdown
+    className={classNames('co-type-selector', className)}
+    items={allItems}
+    title={allItems[selectedKey]}
+    onChange={onChange}
+    autocompleteFilter={autocompleteFilter}
+    autocompletePlaceholder="Select Resource"
+    selectedKey={selectedKey} />;
 };
 
 const resourceListDropdownStateToProps = ({k8s}) => ({


### PR DESCRIPTION
[CONSOLE-683](https://jira.coreos.com/browse/CONSOLE-683)

Allows for searching by Resource Kind name, and by abbreviation.

![screen shot 2018-08-14 at 4 09 12 pm](https://user-images.githubusercontent.com/26305082/44115692-8d16d03e-9fdc-11e8-8153-66007f9675a8.png)
![screen shot 2018-08-14 at 4 09 41 pm](https://user-images.githubusercontent.com/26305082/44115695-8e93019e-9fdc-11e8-8763-45f06ea8e8fe.png)
![screen shot 2018-08-14 at 4 09 58 pm](https://user-images.githubusercontent.com/26305082/44115697-8fdbcb26-9fdc-11e8-92a7-ea4bea83fdf1.png)
