### PR TITLE
Rename modal primary button id to 'confirm-action'

### DIFF
--- a/frontend/integration-tests/tests/base.scenario.ts
+++ b/frontend/integration-tests/tests/base.scenario.ts
@@ -36,7 +36,7 @@ describe('Basic console test', () => {
       await crudView.createYAMLButton.click();
       await browser.wait(until.presenceOf($('.modal-body__field')));
       await $$('.modal-body__field').get(0).$('input').sendKeys(testName);
-      await $('.modal-content').$('#confirm-delete').click();
+      await $('.modal-content').$('#confirm-action').click();
       await browser.wait(until.urlContains(`/namespaces/${testName}`), BROWSER_TIMEOUT);
     }
 

--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -185,7 +185,7 @@ describe('Kubernetes resource CRUD operations', () => {
       await browser.wait(until.presenceOf($('.modal-body__field')));
       await $$('.modal-body__field').get(0).$('input').sendKeys(name);
       leakedResources.add(JSON.stringify({name, plural: 'namespaces'}));
-      await $('#confirm-delete').click();
+      await $('#confirm-action').click();
       await browser.wait(until.invisibilityOf($('.modal-content')), K8S_CREATION_TIMEOUT);
 
       expect(browser.getCurrentUrl()).toContain(`/k8s/cluster/namespaces/${testName}-ns`);
@@ -293,7 +293,7 @@ describe('Kubernetes resource CRUD operations', () => {
       await $('.tags input').sendKeys(labelValue, Key.ENTER);
       // This only works because there's only one label
       await browser.wait(until.textToBePresentInElement($('.tags .tag-item'), labelValue), 1000);
-      await $('.modal-footer #confirm-delete').click();
+      await $('.modal-footer #confirm-action').click();
     });
 
     it('updates the resource instance labels', async() => {
@@ -314,8 +314,8 @@ describe('Kubernetes resource CRUD operations', () => {
       await crudView.actionsDropdown.click();
       await browser.wait(until.presenceOf(crudView.actionsDropdownMenu), 1000);
       await crudView.actionsDropdownMenu.element(by.partialLinkText('Delete ')).click();
-      await browser.wait(until.presenceOf($('#confirm-delete')));
-      await $('.modal-footer #confirm-delete').click();
+      await browser.wait(until.presenceOf($('#confirm-action')));
+      await $('.modal-footer #confirm-action').click();
 
       leakedResources.delete(JSON.stringify({name, plural, namespace: testName}));
     });

--- a/frontend/integration-tests/tests/modal-annotations.scenario.ts
+++ b/frontend/integration-tests/tests/modal-annotations.scenario.ts
@@ -101,7 +101,7 @@ describe('Modal Annotations', () => {
     }
 
     await modalAnnotationsView.isLoaded();
-    await modalAnnotationsView.saveChangesBtn.click();
+    await modalAnnotationsView.confirmActionBtn.click();
     await crudView.isLoaded();
   };
 
@@ -162,7 +162,7 @@ describe('Modal Annotations', () => {
     await modalAnnotationsView.isLoaded();
     await modalAnnotationsView.addAnnotation(annotationKey,annotationValue);
     await modalAnnotationsView.isLoaded();
-    await modalAnnotationsView.saveChangesBtn.click();
+    await modalAnnotationsView.confirmActionBtn.click();
     await crudView.isLoaded();
     await crudView.selectOptionFromGear(WORKLOAD_NAME, crudView.gearOptions.annotations);
     await modalAnnotationsView.isLoaded();

--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -40,11 +40,11 @@ export const deleteRow = (kind: string) => (name: string) => rowForName(name).$$
         await $('input[placeholder="Enter name"]').sendKeys(name);
         break;
       default:
-        await browser.wait(until.presenceOf($('#confirm-delete')));
+        await browser.wait(until.presenceOf($('#confirm-action')));
         break;
     }
 
-    await $('#confirm-delete').click();
+    await $('#confirm-action').click();
 
     const cogIsDisabled = until.presenceOf(rowForName(name).$('.co-m-cog--disabled'));
     const listIsEmpty = until.textToBePresentInElement($('.cos-status-box > .text-center'), 'No ');

--- a/frontend/integration-tests/views/modal-annotations.view.ts
+++ b/frontend/integration-tests/views/modal-annotations.view.ts
@@ -4,7 +4,7 @@ const BROWSER_TIMEOUT = 15000;
 
 const addMoreBtn = $('.btn-link');
 export const cancelBtn = $$('.btn-default').filter(link => link.getText().then(text => text.startsWith('Cancel'))).first();
-export const saveChangesBtn = $('#confirm-delete');
+export const confirmActionBtn = $('#confirm-action');
 const annotationRows = $$('.pairs-list__row');
 export const annotationRowsKey = $$('[placeholder="key"]');
 export const annotationRowsValue = $$('[placeholder="value"]');

--- a/frontend/public/components/factory/modal.jsx
+++ b/frontend/public/components/factory/modal.jsx
@@ -61,7 +61,7 @@ export const ModalSubmitFooter = ({message, errorMessage, inProgress, cancel, su
   };
   return <ModalFooter inProgress={inProgress} errorMessage={errorMessage} message={message}>
     <button type="button" onClick={onCancelClick} className="btn btn-default">Cancel</button>
-    <button type="submit" className="btn btn-primary" disabled={submitDisabled} id="confirm-delete">{submitText}</button>
+    <button type="submit" className="btn btn-primary" disabled={submitDisabled} id="confirm-action">{submitText}</button>
   </ModalFooter>;
 };
 


### PR DESCRIPTION
I've noticed that we have hardcoded `confirm-delete` for primaty button on our modals component.
Renamed to `confirm-action` since it's a bit weird to have a test that is creating a resource by clicking on button with `confirm-delete` id.

@alecmerdler PTAL