### PR TITLE
Add monitoring alerts list and details pages

### DIFF
--- a/frontend/__tests__/module/monitoring.js
+++ b/frontend/__tests__/module/monitoring.js
@@ -1,0 +1,34 @@
+import { alertRuleState } from '../../public/module/monitoring';
+
+describe('alertRuleState', () => {
+  it('recognizes valid alert states', () => {
+    expect(alertRuleState({alerts: [{state: 'firing'}]})).toEqual('firing');
+    expect(alertRuleState({alerts: [{state: 'pending'}]})).toEqual('pending');
+    expect(alertRuleState({alerts: [{state: 'firing'}, {state: 'firing'}]})).toEqual('firing');
+  });
+
+  it('ignores pending alerts if at least one alert is firing', () => {
+    expect(alertRuleState({alerts: [{state: 'pending'}, {state: 'firing'}, {state: 'pending'}]})).toEqual('firing');
+  });
+
+  it('returns "inactive" if there are no alerts', () => {
+    expect(alertRuleState({alerts: []})).toEqual('inactive');
+    expect(alertRuleState({alerts: null})).toEqual('inactive');
+    expect(alertRuleState({hi: [{state: 'firing'}]})).toEqual('inactive');
+    expect(alertRuleState(null)).toEqual('inactive');
+  });
+
+  it('ignores rules without a "state" attribute', () => {
+    expect(alertRuleState({alerts: [{}]})).toEqual('inactive');
+    expect(alertRuleState({alerts: [{hello: 'hi'}]})).toEqual('inactive');
+    expect(alertRuleState({alerts: [null]})).toEqual('inactive');
+    expect(alertRuleState({alerts: [{hello: 'hi'}, {state: 'firing'}]})).toEqual('firing');
+  });
+
+  it('ignores unrecognized states', () => {
+    expect(alertRuleState({alerts: [{state: 'hi'}]})).toEqual('inactive');
+    expect(alertRuleState({alerts: [{state: null}]})).toEqual('inactive');
+    expect(alertRuleState({alerts: [{state: 'FIRING'}]})).toEqual('inactive');
+    expect(alertRuleState({alerts: [{state: 'hi'}, {state: 'pending'}]})).toEqual('pending');
+  });
+});

--- a/frontend/public/components/_alert.scss
+++ b/frontend/public/components/_alert.scss
@@ -1,0 +1,34 @@
+.monitoring-heading {
+  display: flex;
+  justify-content: space-between;
+}
+
+$monitoring-line-height: 18px;
+
+.monitoring-description, .monitoring-timestamp {
+  line-height: $monitoring-line-height;
+  margin-top: 4px;
+}
+
+.monitoring-description {
+  margin-left: 3px;
+
+  // Limit to $num-lines lines of text. Truncate with an ellipsis in WebKit. Just overflow hidden for other browsers.
+  $num-lines: 2;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: $num-lines;
+  height: $num-lines * $monitoring-line-height;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.monitoring-timestamp {
+  display: flex;
+  flex-flow: row wrap;
+  font-size: 11px;
+}
+
+.monitoring-query {
+  color: $color-pf-blue-400;
+}

--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -59,10 +59,12 @@ $height: 18px;
   background-color: $color-node-dark;
 }
 
+.co-m-resource-alertrule,
 .co-m-resource-configmap {
   background-color: $color-configmap-dark;
 }
 
+.co-m-resource-alert,
 .co-m-resource-container {
   background-color: $color-container-dark;
 }

--- a/frontend/public/components/alert.tsx
+++ b/frontend/public/components/alert.tsx
@@ -1,0 +1,469 @@
+import * as _ from 'lodash-es';
+import * as classNames from 'classnames';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+import { coFetchJSON } from '../co-fetch';
+import { alertRuleState } from '../module/monitoring';
+import k8sActions from '../module/k8s/k8s-actions';
+import { MonitoringRoutes, connectToURLs } from '../monitoring';
+import store from '../redux';
+import { UIActions } from '../ui/ui-actions';
+import { ColHead, List, ListHeader, ResourceRow, TextFilter } from './factory';
+import { CheckBoxes } from './row-filter';
+import { SafetyFirst } from './safety-first';
+import { BreadCrumbs, history, NavTitle, SectionHeading, StatusBox, Timestamp, withFallback } from './utils';
+import { formatDuration } from './utils/datetime';
+
+const AlertResource = {
+  kind: 'Alert',
+  label: 'Alert',
+  path: '/monitoring/alerts',
+  abbr: 'AL',
+};
+
+const AlertRuleResource = {
+  kind: 'AlertRule',
+  label: 'Alert Rule',
+  path: '/monitoring/alerts/rules',
+  abbr: 'AR',
+};
+
+const reduxID = 'monitoringRules';
+
+const detailsURL = (resource, name, labels) => `${resource.path}/${name}?${_.map(labels, (v, k) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join('&')}`;
+
+const ExternalLink = ({href, text}) => <a className="co-external-link" href={href} target="_blank" rel="noopener noreferrer">{text}</a>;
+
+const ResourceIcon = props => {
+  const {className, resource} = props;
+  return <span className={classNames(`co-m-resource-icon co-m-resource-${resource.kind.toLowerCase()}`, className)} title={resource.label}>{resource.abbr}</span>;
+};
+
+const stateToIconClassName = {
+  firing: 'fa fa-bell alert-firing',
+  pending: 'fa fa-exclamation-triangle alert-pending',
+};
+
+const State: React.SFC<StateProps> = ({state}) => {
+  if (state === 'inactive') {
+    return <span className="text-muted">{_.startCase(state)}</span>;
+  }
+  const klass = stateToIconClassName[state];
+  return klass ? <React.Fragment><i className={klass} aria-hidden="true"></i> {_.startCase(state)}</React.Fragment> : null;
+};
+
+const Annotation = ({children, title}) => _.isNil(children)
+  ? null
+  : <React.Fragment><dt>{title}</dt><dd>{children}</dd></React.Fragment>;
+
+const getURLSearchParams = () => {
+  const labels = {};
+  const params: any = new URLSearchParams(window.location.search);
+  for (let [k, v] of params.entries()) {
+    labels[k] = v;
+  }
+  return labels;
+};
+
+class AlertsPageWrapper extends SafetyFirst<AlertsPageWrapperProps, null> {
+  componentDidMount () {
+    super.componentDidMount();
+
+    const {prometheusBaseURL} = (window as any).SERVER_FLAGS;
+    if (!prometheusBaseURL) {
+      store.dispatch(UIActions.monitoringRulesErrored(new Error('prometheusBaseURL not set')));
+      return;
+    }
+
+    store.dispatch(UIActions.monitoringRulesLoading());
+    const poller = () => {
+      coFetchJSON(`${prometheusBaseURL}/api/v1/rules`)
+        .then(response => {
+          // Flatten the rules data to make it easier to work with and also discard non-alerting rules since those are
+          // the only ones we will be using
+          const allRules = _.flatMap(response.data.groups, 'rules');
+          const alertingRules = _.filter(allRules, {type: 'alerting'});
+          store.dispatch(UIActions.monitoringRulesLoaded(alertingRules));
+        })
+        .catch(e => store.dispatch(UIActions.monitoringRulesErrored(e)))
+        .then(() => setTimeout(() => {
+          if (this.isMounted_) {
+            poller();
+          }
+        }, 15 * 1000));
+    };
+    poller();
+  }
+
+  render () {
+    const {Page, ...pageProps} = this.props;
+    return <Page {...pageProps} />;
+  }
+}
+const connectPage = Page => withFallback(props => <AlertsPageWrapper {...props} Page={Page} />);
+
+const alertStateToProps = ({UI}, {match}): AlertsDetailsPageProps => {
+  const {loaded, loadError, rules}: ReduxData = UI.get(reduxID) || {};
+  const name = _.get(match, 'params.name');
+  const labels = getURLSearchParams();
+
+  for (let rule of _.filter(rules, {name})) {
+    const alert = _.find(_.get(rule, 'alerts'), {labels});
+    if (alert) {
+      return {alert, loaded, loadError, name, rule};
+    }
+  }
+  return {alert: null, loaded, loadError, name, rule: _.find(rules, {name, labels})};
+};
+
+const AlertsDetailsPage_ = connect(alertStateToProps)((props: AlertsDetailsPageProps) => {
+  const {alert, loaded, loadError, name, rule} = props;
+  const severity = _.get(rule, 'labels.severity');
+  const activeAt = _.get(alert, 'activeAt');
+  const annotations = _.get(alert || rule, 'annotations', {});
+
+  return <React.Fragment>
+    <div className="co-m-nav-title co-m-nav-title--detail">
+      <h1 className="co-m-pane__heading">
+        <div className="co-m-pane__name"><ResourceIcon className="co-m-resource-icon--lg pull-left" resource={AlertResource} />{name}</div>
+      </h1>
+    </div>
+    <StatusBox data={rule} loaded={loaded} loadError={loadError}>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Alert Overview" />
+        <div className="co-m-pane__body-group">
+          <div className="row">
+            <div className="col-sm-6">
+              <dl className="co-m-pane__details">
+                <dt>Name</dt>
+                <dd>{name}</dd>
+                {severity && <React.Fragment>
+                  <dt>Severity</dt>
+                  <dd>{_.startCase(severity)}</dd>
+                </React.Fragment>}
+                <dt>State</dt>
+                <dd>
+                  <State state={alertRuleState(rule)} />
+                  {activeAt && <div className="text-muted monitoring-timestamp">Active since&nbsp;<Timestamp timestamp={activeAt} /></div>}
+                </dd>
+                <dt>Alert Rule</dt>
+                <dd>
+                  <div className="co-resource-link">
+                    <ResourceIcon resource={AlertRuleResource} />
+                    <Link to={detailsURL(AlertRuleResource, name, _.get(rule, 'labels'))} className="co-resource-link__resource-name">{name}</Link>
+                  </div>
+                </dd>
+              </dl>
+            </div>
+            <div className="col-sm-6">
+              <dl className="co-m-pane__details">
+                <Annotation title="Description">{annotations.description}</Annotation>
+                <Annotation title="Summary">{annotations.summary}</Annotation>
+                <Annotation title="Message">{annotations.message}</Annotation>
+                {annotations.runbook_url && <React.Fragment>
+                  <dt>Runbook</dt>
+                  <dd><ExternalLink href={annotations.runbook_url} text={annotations.runbook_url} /></dd>
+                </React.Fragment>}
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </StatusBox>
+  </React.Fragment>;
+});
+export const AlertsDetailsPage = connectPage(AlertsDetailsPage_);
+
+const ViewInPrometheusLink_ = ({rule, urls}) => {
+  const baseUrl = urls[MonitoringRoutes.Prometheus];
+  const query = _.get(rule, 'query');
+  if (!baseUrl || !query) {
+    return null;
+  }
+  const href = `${baseUrl}/graph?g0.expr=${encodeURIComponent(query)}&g0.tab=0`;
+  return <ExternalLink href={href} text="View in Prometheus UI" />;
+};
+const ViewInPrometheusLink = connectToURLs(MonitoringRoutes.Prometheus)(ViewInPrometheusLink_);
+
+const ActiveAlerts = ({alerts}) => <div className="co-m-table-grid co-m-table-grid--bordered">
+  <div className="row co-m-table-grid__head">
+    <div className="col-xs-6">Description</div>
+    <div className="col-xs-2">Active Since</div>
+    <div className="col-xs-2">State</div>
+    <div className="col-xs-2">Value</div>
+  </div>
+  <div className="co-m-table-grid__body">
+    {alerts.map((a, i) => {
+      const name = a.labels.alertname;
+      const description = _.get(a, 'annotations.description') || _.get(a, 'annotations.message') || name;
+      return <ResourceRow key={i} obj={a}>
+        <div className="col-xs-6 co-resource-link-wrapper">
+          <Link className="co-resource-link" to={detailsURL(AlertResource, name, a.labels)}>{description}</Link>
+        </div>
+        <div className="col-xs-2"><Timestamp timestamp={a.activeAt} /></div>
+        <div className="col-xs-2"><State state={a.state} /></div>
+        <div className="col-xs-2">{a.value}</div>
+      </ResourceRow>;
+    })}
+  </div>
+</div>;
+
+const ruleStateToProps = ({UI}, {match}): AlertRulesDetailsPageProps => {
+  const {loaded, loadError, rules}: ReduxData = UI.get(reduxID) || {};
+  const name = _.get(match, 'params.name');
+  const rule = _.find(rules, {name, labels: getURLSearchParams()});
+  return {loaded, loadError, name, rule};
+};
+
+const AlertRulesDetailsPage_ = connect(ruleStateToProps)((props: AlertRulesDetailsPageProps) => {
+  const {loaded, loadError, name, rule} = props;
+  const annotations = _.get(rule, 'annotations', {});
+  const labels = _.get(rule, 'labels');
+  const severity = _.get(labels, 'severity');
+  const alerts = _.get(rule, 'alerts');
+  const duration = _.get(rule, 'duration');
+  const breadcrumbs = [
+    {name, path: detailsURL(AlertResource, name, labels)},
+    {name: `${AlertRuleResource.label} Details`, path: null},
+  ];
+
+  return <React.Fragment>
+    <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
+      <BreadCrumbs breadcrumbs={breadcrumbs} />
+      <h1 className="co-m-pane__heading">
+        <div className="co-m-pane__name"><ResourceIcon className="co-m-resource-icon--lg pull-left" resource={AlertRuleResource} />{name}</div>
+      </h1>
+    </div>
+    <StatusBox data={rule} loaded={loaded} loadError={loadError}>
+      <div className="co-m-pane__body">
+        <div className="monitoring-heading">
+          <SectionHeading text="Alert Rule Overview" />
+          <ViewInPrometheusLink rule={rule} />
+        </div>
+        <div className="co-m-pane__body-group">
+          <div className="row">
+            <div className="col-sm-6">
+              <dl className="co-m-pane__details">
+                <dt>Name</dt>
+                <dd>{name}</dd>
+                {severity && <React.Fragment>
+                  <dt>Severity</dt>
+                  <dd>{_.startCase(severity)}</dd>
+                </React.Fragment>}
+                <Annotation title="Description">{annotations.description}</Annotation>
+                <Annotation title="Summary">{annotations.summary}</Annotation>
+                <Annotation title="Message">{annotations.message}</Annotation>
+              </dl>
+            </div>
+            <div className="col-sm-6">
+              <dl className="co-m-pane__details">
+                {_.isInteger(duration) && <React.Fragment>
+                  <dt>For</dt>
+                  <dd>{formatDuration(duration * 1000)}</dd>
+                </React.Fragment>}
+                <dt>Expression</dt>
+                <dd><pre className="monitoring-query">{_.get(rule, 'query')}</pre></dd>
+                {annotations.runbook_url && <React.Fragment>
+                  <dt>Runbook</dt>
+                  <dd><ExternalLink href={annotations.runbook_url} text={annotations.runbook_url} /></dd>
+                </React.Fragment>}
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="co-m-pane__body">
+        <div className="co-m-pane__body-group">
+          <SectionHeading text="Active Alerts" />
+          <div className="row">
+            <div className="col-xs-12">
+              {_.isEmpty(alerts) ? <div className="text-center">None Found</div> : <ActiveAlerts alerts={alerts} />}
+            </div>
+          </div>
+        </div>
+      </div>
+    </StatusBox>
+  </React.Fragment>;
+});
+export const AlertRulesDetailsPage = connectPage(AlertRulesDetailsPage_);
+
+const Row = ({obj}) => {
+  const {alerts, annotations, labels, name} = obj;
+  const activeAt = _.min(_.map(alerts, 'activeAt'));
+
+  return <ResourceRow obj={obj}>
+    <div className="col-xs-7">
+      <div className="co-resource-link-wrapper">
+        <span className="co-resource-link">
+          <ResourceIcon resource={AlertResource} />
+          <Link to={detailsURL(AlertResource, name, labels)} className="co-resource-link__resource-name">{name}</Link>
+        </span>
+      </div>
+      <div className="monitoring-description">{_.get(annotations, 'description') || _.get(annotations, 'message')}</div>
+    </div>
+    <div className="col-xs-3">
+      <State state={alertRuleState(obj)} />
+      {activeAt && <div className="text-muted monitoring-timestamp">since&nbsp;<Timestamp timestamp={activeAt} /></div>}
+    </div>
+    <div className="col-xs-2">{_.startCase(_.get(labels, 'severity', '-'))}</div>
+  </ResourceRow>;
+};
+
+const AlertHeader = props => <ListHeader>
+  <ColHead {...props} className="col-xs-7" sortField="name">Name</ColHead>
+  <ColHead {...props} className="col-xs-3" sortFunc="alertRuleState">State</ColHead>
+  <ColHead {...props} className="col-xs-2" sortField="labels.severity">Severity</ColHead>
+</ListHeader>;
+
+const AlertsPageDescription_ = ({urls}) => <div className="co-m-pane__filter-bar-group--description">
+  OpenShift ships with a pre-configured and self-updating monitoring stack powered by <ExternalLink href={urls[MonitoringRoutes.Prometheus]} text="Prometheus" />
+</div>;
+const AlertsPageDescription = connectToURLs(MonitoringRoutes.Prometheus)(AlertsPageDescription_);
+
+const rowFilter = {
+  type: 'alert-rule-state',
+  selected: ['firing', 'pending'],
+  reducer: alertRuleState,
+  items: [
+    {id: 'firing', title: 'Firing'},
+    {id: 'pending', title: 'Pending'},
+    {id: 'inactive', title: 'Inactive'},
+  ],
+};
+
+const nameFilterID = 'alert-rule-name';
+
+// Row filter settings are stored in "k8s"
+const listStateToProps = ({k8s, UI}): AlertsPageProps => {
+  const {loaded, loadError, rules}: ReduxData = UI.get(reduxID) || {};
+  const filtersMap = k8s.getIn([reduxID, 'filters']);
+  return {filters: filtersMap ? filtersMap.toJS() : null, loaded, loadError, rules};
+};
+
+const AlertsPage_ = connect(listStateToProps)(class InnerAlertsPage_ extends React.Component<AlertsPageProps> {
+  /* eslint-disable no-undef */
+  props: AlertsPageProps;
+  defaultNameFilter: string;
+  /* eslint-enable no-undef */
+
+  constructor (props) {
+    super(props);
+    this.applyTextFilter = this.applyTextFilter.bind(this);
+  }
+
+  applyTextFilter (e) {
+    const v = e.target.value;
+    store.dispatch(k8sActions.filterList(reduxID, nameFilterID, v));
+
+    const params = new URLSearchParams(window.location.search);
+    if (v) {
+      params.set(nameFilterID, v);
+    } else {
+      params.delete(nameFilterID);
+    }
+    const url = new URL(window.location.href);
+    history.replace(`${url.pathname}?${params.toString()}${url.hash}`);
+  }
+
+  componentWillMount () {
+    const params = new URLSearchParams(window.location.search);
+
+    // Ensure the current name filter value matches the name filter GET param
+    this.defaultNameFilter = params.get(nameFilterID);
+    store.dispatch(k8sActions.filterList(reduxID, nameFilterID, this.defaultNameFilter));
+
+    if (!params.get('sortBy')) {
+      // Sort by rule name by default
+      store.dispatch(UIActions.sortList(reduxID, 'name', undefined, 'asc', 'Name'));
+    }
+  }
+
+  render () {
+    const {filters, loaded, loadError, rules} = this.props;
+
+    return <React.Fragment>
+      <NavTitle title="Monitoring Alerts" />
+      <div className="co-m-pane__filter-bar">
+        <div className="co-m-pane__filter-bar-group">
+          <AlertsPageDescription />
+          <div className="co-m-pane__filter-bar-group--filter">
+            <TextFilter defaultValue={this.defaultNameFilter} label="Alerts by name" onChange={this.applyTextFilter} />
+          </div>
+        </div>
+      </div>
+      <div className="co-m-pane__body">
+        <div className="row">
+          <CheckBoxes
+            items={rowFilter.items}
+            numbers={_.countBy(rules, rowFilter.reducer)}
+            reduxIDs={[reduxID]}
+            selected={rowFilter.selected}
+            type={rowFilter.type}
+          />
+        </div>
+        <div className="row">
+          <div className="col-xs-12">
+            <List
+              Header={AlertHeader}
+              Row={Row}
+              data={rules}
+              filters={filters}
+              loadError={loadError}
+              loaded={loaded}
+              reduxID={reduxID}
+            />
+          </div>
+        </div>
+      </div>
+    </React.Fragment>;
+  }
+});
+export const AlertsPage = connectPage(AlertsPage_);
+
+/* eslint-disable no-undef, no-unused-vars */
+type Alert = {
+  activeAt: string;
+  annotations: any;
+  labels: {[key: string]: string};
+  state: string;
+  value: any,
+};
+type Rule = {
+  alerts: Array<Alert>;
+  annotations: any;
+  duration: number;
+  labels: {[key: string]: string};
+  query: string;
+};
+type ReduxData = {
+  loaded: boolean;
+  loadError?: string;
+  rules: Array<Rule>;
+};
+type StateProps = {
+  state: string;
+};
+type AlertsPageWrapperProps = {
+  Page: React.ComponentType<any>;
+};
+export type AlertsDetailsPageProps = {
+  alert: Alert;
+  loaded: boolean;
+  loadError?: string;
+  name: string;
+  rule: Rule;
+};
+export type AlertRulesDetailsPageProps = {
+  loaded: boolean;
+  loadError?: string;
+  name: string;
+  rule: Rule;
+};
+export type AlertsPageProps = {
+  filters: {[key: string]: any};
+  loaded: boolean;
+  loadError?: string;
+  rules: Array<Rule>;
+};

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -12,6 +12,7 @@ import { ALL_NAMESPACES_KEY } from '../const';
 import { connectToFlags, featureActions, flagPending, FLAGS } from '../features';
 import { detectMonitoringURLs } from '../monitoring';
 import { analyticsSvc } from '../module/analytics';
+import { AlertsPage, AlertsDetailsPage, AlertRulesDetailsPage } from './alert';
 import { GlobalNotifications } from './global-notifications';
 import { Masthead } from './masthead';
 import { NamespaceSelector } from './namespace';
@@ -172,6 +173,10 @@ class App extends React.PureComponent {
           <LazyRoute path="/k8s/ns/:ns/rolebindings/:name/edit" exact kind="RoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRoleBinding)} />
           <LazyRoute path="/k8s/cluster/clusterrolebindings/:name/copy" exact kind="ClusterRoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CopyRoleBinding)} />
           <LazyRoute path="/k8s/cluster/clusterrolebindings/:name/edit" exact kind="ClusterRoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRoleBinding)} />
+
+          <Route path="/monitoring/alerts" exact component={AlertsPage} />
+          <Route path="/monitoring/alerts/:name" exact component={AlertsDetailsPage} />
+          <Route path="/monitoring/alerts/rules/:name" exact component={AlertRulesDetailsPage} />
 
           <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
           <LazyRoute path="/k8s/cluster/:plural/new" exact loader={() => import('./create-yaml' /* webpackChunkName: "create-yaml" */).then(m => m.CreateYAML)} />

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -20,6 +20,7 @@ import {
   podPhaseFilterReducer,
   podReadiness,
   serviceClassDisplayName } from '../../module/k8s';
+import { alertRuleState } from '../../module/monitoring';
 import { UIActions } from '../../ui/ui-actions';
 import { ingressValidHosts } from '../ingress';
 import { routeStatus } from '../routes';
@@ -32,6 +33,10 @@ const fuzzyCaseInsensitive = (a, b) => fuzzy(_.toLower(a), _.toLower(b));
 // TODO: Having list filters here is undocumented, stringly-typed, and non-obvious. We can change that
 const listFilters = {
   'name': (filter, obj) => fuzzyCaseInsensitive(filter, obj.metadata.name),
+
+  'alert-rule-name': (filter, alertRule) => fuzzyCaseInsensitive(filter, alertRule.name),
+
+  'alert-rule-state': (filter, alertRule) => filter.selected.has(alertRuleState(alertRule)),
 
   // Filter role by role kind
   'role-kind': (filter, role) => filter.selected.has(roleType(role)),
@@ -157,6 +162,7 @@ const filterPropType = (props, propName, componentName) => {
 };
 
 const sorts = {
+  alertRuleState,
   daemonsetNumScheduled: daemonset => _.toInteger(_.get(daemonset, 'status.currentNumberScheduled')),
   dataSize: resource => _.size(_.get(resource, 'data')),
   ingressValidHosts,

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -281,8 +281,9 @@ const MonitoringNavSection_ = ({urls, closeMenu}) => {
   const grafanaURL = urls[MonitoringRoutes.Grafana];
   return prometheusURL || alertManagerURL || grafanaURL
     ? <NavSection text="Monitoring" icon="pficon pficon-screen">
+      {prometheusURL && <HrefLink href="/monitoring/alerts" name="Alerts" onClick={closeMenu} />}
       {prometheusURL && <HrefLink href={prometheusURL} target="_blank" name="Metrics" onClick={closeMenu} isExternal={true} />}
-      {alertManagerURL && <HrefLink href={alertManagerURL} target="_blank" name="Alerts" onClick={closeMenu} isExternal={true} />}
+      {alertManagerURL && <HrefLink href={alertManagerURL} target="_blank" name="Alertmanager" onClick={closeMenu} isExternal={true} />}
       {grafanaURL && <HrefLink href={grafanaURL} target="_blank" name="Dashboards" onClick={closeMenu} isExternal={true} />}
     </NavSection>
     : null;

--- a/frontend/public/components/row-filter.jsx
+++ b/frontend/public/components/row-filter.jsx
@@ -90,4 +90,5 @@ class CheckBoxes_ extends React.Component {
   }
 }
 
+/** @type {React.SFC<{items: Array, numbers: any, reduxIDs: Array, selected?: Array, type: string}>} */
 export const CheckBoxes = connect(null, {filterList: k8sActions.filterList})(CheckBoxes_);

--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -89,7 +89,7 @@ export const fromNow = (dateTime, now=undefined, options = { omitSuffix: false }
 
 export const isValid = (dateTime: Date) => dateTime instanceof Date && !_.isNaN(dateTime.valueOf());
 
-// Formats a duration in milliseconds like '1h10m23s'.
+// Formats a duration in milliseconds like '1h 10m 23s'.
 export const formatDuration = (ms: number) => {
   if (!_.isFinite(ms) || ms < 0) {
     return '';

--- a/frontend/public/module/monitoring.js
+++ b/frontend/public/module/monitoring.js
@@ -1,0 +1,14 @@
+import * as _ from 'lodash-es';
+
+// Return "firing" if the rule has a firing alert
+// Return "pending" if the rule has no firing alerts, but has a pending alert
+// Otherwise return "inactive"
+export const alertRuleState = rule => {
+  const states = _.map(_.get(rule, 'alerts'), 'state');
+  if (_.includes(states, 'firing')) {
+    return 'firing';
+  } else if (_.includes(states, 'pending')) {
+    return 'pending';
+  }
+  return 'inactive';
+};

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -44,6 +44,7 @@
 @import "components/utils/selector";
 @import "components/utils/log-window";
 @import "components/utils/resource-log";
+@import "components/alert";
 @import "components/build-pipeline";
 @import "components/chargeback";
 @import "components/cluster-overview";

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -47,6 +47,10 @@
   min-width: 0;
 }
 
+.co-m-pane__filter-bar-group--description {
+  margin-right: 20px;
+}
+
 .co-m-pane__filter-bar-group--filter {
   @media(min-width: $screen-xs-min) {
     flex: 1 1 auto;

--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -18,9 +18,14 @@
   color: $color-pf-green-400;
 }
 
+.alert-firing,
 .node-not-ready,
 .pvc-lost,
 .route-rejected,
 .status-failed {
   color: $color-red-error;
+}
+
+.alert-pending {
+  color: $color-orange-warning;
 }

--- a/frontend/public/style/_text.scss
+++ b/frontend/public/style/_text.scss
@@ -1,4 +1,6 @@
 $kinds: (
+  alert: $color-alert-dark,
+  alertrule: $color-alertrule-dark,
   configmap: $color-configmap-dark,
   daemonset: $color-replicaset-dark,
   deployment: $color-deployment-dark,

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -26,6 +26,8 @@ $color-petset-dark: $color-controller-dark;
 
 $color-serviceaccount-dark: $color-configmap-dark;
 
+$color-alert-dark: $color-container-dark;
+$color-alertrule-dark: $color-configmap-dark;
 $color-alertmanager-dark: $color-pf-orange-500;
 
 $color-ingress-dark: $color-pf-purple-700;

--- a/frontend/public/ui/ui-actions.js
+++ b/frontend/public/ui/ui-actions.js
@@ -70,7 +70,8 @@ export const types = {
   startImpersonate: 'startImpersonate',
   stopImpersonate: 'stopImpersonate',
   sortList: 'sortList',
-  setCreateProjectMessage: 'setCreateProjectMessage'
+  setCreateProjectMessage: 'setCreateProjectMessage',
+  setMonitoringRules: 'setMonitoringRules',
 };
 
 export const UIActions = {
@@ -153,5 +154,11 @@ export const UIActions = {
     return {listId, field, func, orderBy, type: types.sortList};
   },
 
-  [types.setCreateProjectMessage]: message => ({type: types.setCreateProjectMessage, message})
+  [types.setCreateProjectMessage]: message => ({type: types.setCreateProjectMessage, message}),
+
+  monitoringRulesLoading: () => ({type: types.setMonitoringRules, data: {loaded: false, loadError: null, rules: null}}),
+
+  monitoringRulesLoaded: rules => ({type: types.setMonitoringRules, data: {loaded: true, loadError: null, rules}}),
+
+  monitoringRulesErrored: loadError => ({type: types.setMonitoringRules, data: {loaded: true, loadError, rules: null}}),
 };

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -57,6 +57,9 @@ export default (state, action) => {
     case types.setCreateProjectMessage:
       return state.set('createProjectMessage', action.message);
 
+    case types.setMonitoringRules:
+      return state.set('monitoringRules', action.data);
+
     default:
       break;
   }


### PR DESCRIPTION
Adds an Alerts list page, an Alert details page and an Alert Rule details page.

All data is fetched from the Prometheus `/rules` endpoint (proxied through the backend).

The Alert and Alert Rule details pages use GET params to uniquely identify the object to be displayed because there is no unique ID associated with these objects.

Leaves the Prometheus and Alertmanager links in the sidebar for now (and renames "Alerts" to "AlertManager").

Left for future PRs:
- Labels list on the alert details page (because there is currently no Search page Alerts list to link to)
- End-to-end tests

<img width="1398" alt="screenshot-list" src="https://user-images.githubusercontent.com/460802/44198365-2bf08600-a17c-11e8-8d75-2f06ece9090a.png">

<img width="1399" alt="screenshot-alert" src="https://user-images.githubusercontent.com/460802/44198374-327efd80-a17c-11e8-9799-b7d3f528d66b.png">

<img width="1396" alt="screenshot-rule" src="https://user-images.githubusercontent.com/460802/44198383-3579ee00-a17c-11e8-86f3-65b6cd365f69.png">