### PR TITLE
Code Split Modals

### DIFF
--- a/frontend/__tests__/components/cloud-services/spec-descriptors/resource-requirements.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/spec-descriptors/resource-requirements.spec.tsx
@@ -19,7 +19,7 @@ describe(ResourceRequirementsModal.name, () => {
   beforeEach(() => {
     const Form: any = () => <div />;
     Form.formName = 'ResourceRequirements';
-    wrapper = shallow(<ResourceRequirementsModal title={title} description={description} obj={testResourceInstance} type="requests" cancel={cancel} Form={Form} path="resources" />);
+    wrapper = shallow(<ResourceRequirementsModal title={title} description={description} obj={testResourceInstance} type="requests" cancel={cancel} Form={Form} path="resources" close={null} />);
   });
 
   it('renders a modal form with given title and description', () => {

--- a/frontend/public/components/cloud-services/spec-descriptors/configure-size.tsx
+++ b/frontend/public/components/cloud-services/spec-descriptors/configure-size.tsx
@@ -4,7 +4,7 @@ import { configureCountModal } from '../../modals';
 import { K8sResourceKind, K8sKind } from '../../../module/k8s';
 import { SpecDescriptor } from '../spec-descriptors';
 
-export const configureSizeModal: ConfigureSizeModal = (kindObj, resource, specDescriptor, specValue, wasChanged) => {
+export const configureSizeModal = ({kindObj, resource, specDescriptor, specValue, wasChanged}: ConfigureSizeModalProps) => {
   return configureCountModal({
     resourceKind: kindObj,
     resource: resource,
@@ -22,4 +22,10 @@ export const configureSizeModal: ConfigureSizeModal = (kindObj, resource, specDe
   });
 };
 
-type ConfigureSizeModal = (kindObj: K8sKind, resource: K8sResourceKind, specDescriptor: SpecDescriptor, specValue: any, wasChanged: () => Promise<any>) => {result: Promise<any>};
+type ConfigureSizeModalProps = {
+  kindObj: K8sKind;
+  resource: K8sResourceKind;
+  specDescriptor: SpecDescriptor;
+  specValue: any;
+  wasChanged: () => Promise<any>;
+};

--- a/frontend/public/components/cloud-services/spec-descriptors/index.tsx
+++ b/frontend/public/components/cloud-services/spec-descriptors/index.tsx
@@ -34,7 +34,7 @@ export class ClusterServiceVersionResourceSpec extends React.Component<SpecDescr
     const controlElm = descriptors.reduce((result, specCapability) => {
       switch (specCapability) {
         case ALMSpecDescriptors.podCount:
-          return <a onClick={() => configureSizeModal(kindObj, resource, specDescriptor, specValue, wasChanged)} className="co-m-modal-link">{specValue} pods</a>;
+          return <a onClick={() => configureSizeModal({kindObj, resource, specDescriptor, specValue, wasChanged})} className="co-m-modal-link">{specValue} pods</a>;
         case ALMSpecDescriptors.endpointList:
           return <EndpointList endpoints={specValue} />;
         case ALMSpecDescriptors.label:

--- a/frontend/public/components/cloud-services/spec-descriptors/resource-requirements.tsx
+++ b/frontend/public/components/cloud-services/spec-descriptors/resource-requirements.tsx
@@ -46,7 +46,7 @@ export const ResourceRequirementsModalLink: React.SFC<ResourceRequirementsModalL
   const {cpu, memory} = _.get(obj.spec, `${path}.${type}`, {cpu: null, memory: null});
 
   const onClick = () => {
-    const modal = createModalLauncher(modalProps => <ResourceRequirementsModal {...modalProps} cancel={(e) => onChange().then(() => modalProps.cancel(e))} />);
+    const modal = createModalLauncher<ResourceRequirementsModalProps>(modalProps => <ResourceRequirementsModal {...modalProps} cancel={(e) => onChange().then(() => modalProps.cancel(e))} />);
     const description = `Define the ${type === 'limits' ? 'resource' : 'request'} limits for this ${obj.kind} instance.`;
     const title = `${obj.kind} ${type === 'limits' ? 'Resource' : 'Request'} Limits`;
 
@@ -77,6 +77,7 @@ export type ResourceRequirementsModalProps = {
   type: 'requests' | 'limits';
   path: string;
   cancel: (error: any) => void;
+  close: () => void;
 };
 
 export type ResourceRequirementsModalLinkProps = {

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef, no-unused-vars */
+
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -10,7 +12,7 @@ import store from '../../redux';
 import { ButtonBar } from '../utils/button-bar';
 import { history } from '../utils/router';
 
-export const createModalLauncher = (Component) => (props = {}) => {
+export const createModalLauncher: CreateModalLauncher = (Component) => (props) => {
   const modalContainer = document.getElementById('modal-container');
 
   const result = new Promise(resolve => {
@@ -27,7 +29,7 @@ export const createModalLauncher = (Component) => (props = {}) => {
     };
     Modal.setAppElement(modalContainer);
     ReactDOM.render(<Provider store={store}>
-      <Router history={history} basename={window.SERVER_FLAGS.basePath}>
+      <Router {...{history, basename: (window as any).SERVER_FLAGS.basePath}}>
         <Modal
           isOpen={true}
           contentLabel="Modal"
@@ -43,18 +45,17 @@ export const createModalLauncher = (Component) => (props = {}) => {
   return {result};
 };
 
-export const ModalTitle = ({children, className='modal-header'}) => <div className={className}><h4 className="modal-title">{children}</h4></div>;
+export const ModalTitle: React.SFC<ModalTitleProps> = ({children, className = 'modal-header'}) => <div className={className}><h4 className="modal-title">{children}</h4></div>;
 
-export const ModalBody = ({children}) => <div className="modal-body">{children}</div>;
+export const ModalBody: React.SFC<ModalBodyProps> = ({children}) => <div className="modal-body">{children}</div>;
 
-export const ModalFooter = ({message, errorMessage, inProgress, children}) => {
+export const ModalFooter: React.SFC<ModalFooterProps> = ({message, errorMessage, inProgress, children}) => {
   return <ButtonBar className="modal-footer" errorMessage={errorMessage} infoMessage={message} inProgress={inProgress}>
     {children}
   </ButtonBar>;
 };
 
-/** @type {React.SFC<{message?: string, errorMessage?: string, inProgress: boolean, cancel: (e: Event) => void, submitText: string, submitDisabled?: boolean}>} */
-export const ModalSubmitFooter = ({message, errorMessage, inProgress, cancel, submitText, submitDisabled}) => {
+export const ModalSubmitFooter: React.SFC<ModalSubmitFooterProps> = ({message, errorMessage, inProgress, cancel, submitText, submitDisabled}) => {
   const onCancelClick = e => {
     e.stopPropagation();
     cancel(e);
@@ -72,3 +73,38 @@ ModalSubmitFooter.propTypes = {
   message: PropTypes.string,
   submitText: PropTypes.node.isRequired,
 };
+
+export type CreateModalLauncherProps = {
+  blocking?: boolean;
+};
+
+export type ModalComponentProps = {
+  cancel: (e?: Event) => void;
+  close: (e?: Event) => void;
+};
+
+export type ModalTitleProps = {
+  className?: string;
+};
+
+export type ModalBodyProps = {
+
+};
+
+export type ModalFooterProps = {
+  message?: string;
+  errorMessage?: string;
+  inProgress: boolean;
+};
+
+export type ModalSubmitFooterProps = {
+  message?: string;
+  errorMessage?: string;
+  inProgress: boolean;
+  cancel: (e: Event) => void;
+  submitText: string;
+  submitDisabled?: boolean;
+};
+
+export type CreateModalLauncher = <P extends ModalComponentProps>(C: React.ComponentType<P>) =>
+  (props: Omit<P, keyof ModalComponentProps> & CreateModalLauncherProps) => {result: Promise<{}>};

--- a/frontend/public/components/modals/configure-count-modal.jsx
+++ b/frontend/public/components/modals/configure-count-modal.jsx
@@ -107,4 +107,3 @@ export const configureClusterSizeModal = (props) => {
     buttonText: 'Save Cluster Size'
   }, props));
 };
-

--- a/frontend/public/components/modals/disable-application-modal.tsx
+++ b/frontend/public/components/modals/disable-application-modal.tsx
@@ -51,7 +51,7 @@ export class DisableApplicationModal extends PromiseComponent {
   }
 }
 
-export const createDisableApplicationModal: (props: ModalProps) => {result: Promise<void>} = createModalLauncher(DisableApplicationModal);
+export const createDisableApplicationModal = createModalLauncher<DisableApplicationModalProps>(DisableApplicationModal);
 
 export type DisableApplicationModalProps = {
   cancel: (e: Event) => void;
@@ -65,5 +65,3 @@ export type DisableApplicationModalState = {
   errorMessage: string;
   cascadeDelete: boolean;
 };
-
-type ModalProps = Omit<DisableApplicationModalProps, 'cancel' | 'close'>;

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -1,15 +1,56 @@
-export * from './configure-count-modal';
-export * from './configure-operator-modal';
-export * from './configure-operator-channel-modal';
-export * from './confirm-modal';
-export * from './create-namespace-modal';
-export * from './delete-namespace-modal';
-export * from './error-modal';
-export * from './kubectl-config';
-export * from './configure-unschedulable-modal';
-export * from './configure-ns-pull-secret-modal';
-export * from './labels-modal';
-export * from './configure-update-strategy-modal';
-export * from './tags';
-export * from './token-info-modal';
-export * from './delete-modal';
+// This module utilizes dynamic `import()` to enable lazy-loading for each modal instead of including them in the main bundle.
+
+export const configureCountModal = (props) => import('./configure-count-modal' /* webpackChunkName: "configure-count-modal" */)
+  .then(m => m.configureCountModal(props));
+export const configureReplicaCountModal = (props) => import('./configure-count-modal' /* webpackChunkName: "configure-count-modal" */)
+  .then(m => m.configureReplicaCountModal(props));
+export const configureJobParallelismModal = (props) => import('./configure-count-modal' /* webpackChunkName: "configure-count-modal" */)
+  .then(m => m.configureJobParallelismModal(props));
+export const configureClusterSizeModal = (props) => import('./configure-count-modal' /* webpackChunkName: "configure-count-modal" */)
+  .then(m => m.configureClusterSizeModal(props));
+
+export const configureOperatorStrategyModal = (props) => import('./configure-operator-modal' /* webpackChunkName: "configure-operator-modal" */)
+  .then(m => m.configureOperatorStrategyModal(props));
+
+export const configureOperatorChannelModal = (props) => import('./configure-operator-channel-modal' /* webpackChunkName: "configure-operator-channel-modal" */)
+  .then(m => m.configureOperatorChannelModal(props));
+
+export const confirmModal = (props) => import('./confirm-modal' /* webpackChunkName: "confirm-modal" */)
+  .then(m => m.confirmModal(props));
+
+export const createNamespaceModal = (props) => import('./create-namespace-modal' /* webpackChunkName: "create-namespace-modal" */)
+  .then(m => m.createNamespaceModal(props));
+export const createProjectModal = (props) => import('./create-namespace-modal' /* webpackChunkName: "create-namespace-modal" */)
+  .then(m => m.createProjectModal(props));
+
+export const deleteNamespaceModal = (props) => import('./delete-namespace-modal' /* webpackChunkName: "delete-namespace-modal" */)
+  .then(m => m.deleteNamespaceModal(props));
+
+export const errorModal = (props) => import('./error-modal' /* webpackChunkName: "error-modal" */)
+  .then(m => m.errorModal(props));
+
+export const kubectlConfigModal = (props) => import('./kubectl-config' /* webpackChunkName: "kubectl-config" */)
+  .then(m => m.kubectlConfigModal(props));
+
+export const configureUnschedulableModal = (props) => import('./configure-unschedulable-modal' /* webpackChunkName: "configure-unschedulable-modal" */)
+  .then(m => m.configureUnschedulableModal(props));
+
+export const configureNamespacePullSecretModal = (props) => import('./configure-ns-pull-secret-modal' /* webpackChunkName: "configure-ns-pull-secret-modal" */)
+  .then(m => m.configureNamespacePullSecretModal(props));
+
+export const labelsModal = (props) => import('./labels-modal' /* webpackChunkName: "labels-modal" */)
+  .then(m => m.labelsModal(props));
+export const podSelectorModal = (props) => import('./labels-modal' /* webpackChunkName: "labels-modal" */)
+  .then(m => m.podSelectorModal(props));
+
+export const configureUpdateStrategyModal = (props) => import('./configure-update-strategy-modal' /* webpackChunkName: "configure-update-strategy-modal" */)
+  .then(m => m.configureUpdateStrategyModal(props));
+
+export const annotationsModal = (props) => import('./tags' /* webpackChunkName: "tags" */)
+  .then(m => m.annotationsModal(props));
+
+export const tokenInfoModal = (props) => import('./token-info-modal' /* webpackChunkName: "token-info-modal" */)
+  .then(m => m.tokenInfoModal(props));
+
+export const deleteModal = (props) => import('./delete-modal' /* webpackChunkName: "delete-modal" */)
+  .then(m => m.deleteModal(props));

--- a/frontend/public/components/modals/installplan-approval-modal.tsx
+++ b/frontend/public/components/modals/installplan-approval-modal.tsx
@@ -75,7 +75,7 @@ export class InstallPlanApprovalModal extends PromiseComponent {
   }
 }
 
-export const createInstallPlanApprovalModal: (props: ModalProps) => {result: Promise<void>} = createModalLauncher(InstallPlanApprovalModal);
+export const createInstallPlanApprovalModal = createModalLauncher<InstallPlanApprovalModalProps>(InstallPlanApprovalModal);
 
 export type InstallPlanApprovalModalProps = {
   cancel: (e: Event) => void;
@@ -89,5 +89,3 @@ export type InstallPlanApprovalModalState = {
   errorMessage: string;
   selectedApprovalStrategy: InstallPlanApproval;
 };
-
-type ModalProps = Omit<InstallPlanApprovalModalProps, 'cancel' | 'close'>;

--- a/frontend/public/components/modals/subscription-channel-modal.tsx
+++ b/frontend/public/components/modals/subscription-channel-modal.tsx
@@ -50,7 +50,7 @@ export class SubscriptionChannelModal extends PromiseComponent {
   }
 }
 
-export const createSubscriptionChannelModal: (props: ModalProps) => {result: Promise<void>} = createModalLauncher(SubscriptionChannelModal);
+export const createSubscriptionChannelModal = createModalLauncher<SubscriptionChannelModalProps>(SubscriptionChannelModal);
 
 export type SubscriptionChannelModalProps = {
   cancel: (e: Event) => void;
@@ -65,5 +65,3 @@ export type SubscriptionChannelModalState = {
   errorMessage: string;
   selectedChannel: string;
 };
-
-type ModalProps = Omit<SubscriptionChannelModalProps, 'cancel' | 'close'>;


### PR DESCRIPTION
### Description

Add code-splitting using dynamic `import()` to all modals so that they reduce the main bundle size.

### Screenshots

**After opening several modals (notice separate chunks in "Network" tab):**
![screenshot_20180816_132725](https://user-images.githubusercontent.com/11700385/44225183-c9d35900-a15a-11e8-8694-10026e1cb728.png)

Addresses https://jira.coreos.com/browse/CONSOLE-705