### PR TITLE
Add `getBlob` function to LineBuffer component and use in ResourceLog for downloads

### DIFF
--- a/frontend/public/components/utils/line-buffer.ts
+++ b/frontend/public/components/utils/line-buffer.ts
@@ -41,6 +41,10 @@ export class LineBuffer {
     return this._buffer;
   }
 
+  getBlob(options): Blob {
+    return new Blob([this._buffer.join('')], options);
+  }
+
   length(): number {
     return this._buffer.length;
   }

--- a/frontend/public/components/utils/resource-log.jsx
+++ b/frontend/public/components/utils/resource-log.jsx
@@ -106,10 +106,11 @@ export class ResourceLog extends SafetyFirst {
 
   // Download currently displayed log content
   _download () {
-    const blob = new Blob([this._buffer.join('')], {type: 'text/plain;charset=utf-8'});
-    let filename = this.props.resourceName;
-    if (this.props.containerName) {
-      filename = `${filename}-${this.props.containerName}`;
+    const {resourceName, containerName} = this.props;
+    const blob = this._buffer.getBlob({type: 'text/plain;charset=utf-8'});
+    let filename = resourceName;
+    if (containerName) {
+      filename = `${filename}-${containerName}`;
     }
     saveAs(blob, `${filename}.log`);
   }


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-660

**Cause:** 
When downloading log content, a `Blob` was constructed from the `_buffer` property of the ResourceLog component, which used to be an array of strings. When refactoring this component to use LineBuffer, a reference to this old array was missed.

**Consequence:** 
Log download feature did nothing when button was clicked and logged an error in console.

**Fix:** 
Updated ResourceLog component `_download` function to use LineBuffer component's new `getBlob` function.

**Result:**
Download feature works as expected.