### PR TITLE
Bug 1618670 - Could not update deployment strategy from Recreate to Rolling from console

### DIFF
--- a/frontend/public/components/modals/configure-update-strategy-modal.jsx
+++ b/frontend/public/components/modals/configure-update-strategy-modal.jsx
@@ -44,10 +44,10 @@ class ConfigureUpdateStrategyModal extends PromiseComponent {
     const patch = { path: '/spec/strategy/rollingUpdate' };
     if (type === 'RollingUpdate') {
       patch.value = {
-        maxUnavailable: getNumberOrPercent(event.target.elements['input-max-unavailable'].value),
-        maxSurge: getNumberOrPercent(event.target.elements['input-max-surge'].value)
+        maxUnavailable: getNumberOrPercent(event.target.elements['input-max-unavailable'].value || '25%'),
+        maxSurge: getNumberOrPercent(event.target.elements['input-max-surge'].value || '25%')
       };
-      patch.op = 'replace';
+      patch.op = 'add';
     } else {
       patch.op = 'remove';
     }
@@ -94,7 +94,7 @@ class ConfigureUpdateStrategyModal extends PromiseComponent {
                     <div className="form-inline">
                       <div className="input-group">
                         <input disabled={this.state.strategyType !== 'RollingUpdate'}
-                          placeholder="1" size="5" type="text" className="form-control"
+                          placeholder="25%" size="5" type="text" className="form-control"
                           id="input-max-unavailable"
                           defaultValue={maxUnavailable} />
                         <span className="input-group-addon">
@@ -113,7 +113,7 @@ class ConfigureUpdateStrategyModal extends PromiseComponent {
                   <div className="co-m-form-col col-sm-9">
                     <div className="form-inline">
                       <div className="input-group">
-                        <input disabled={this.state.strategyType !== 'RollingUpdate'} placeholder="1" size="5" type="text" className="form-control"
+                        <input disabled={this.state.strategyType !== 'RollingUpdate'} placeholder="25%" size="5" type="text" className="form-control"
                           id="input-max-surge"
                           defaultValue={maxSurge} />
                         <span className="input-group-addon">


### PR DESCRIPTION
So the `replace` call was causing following error:
> jsonpatch replace operation does not apply: doc is missing key: /spec/strategy/rollingUpdate

since the `rollingUpdate` field was not present in strategy field. Adding the field does the trick.

Also I've `maxUnavailable` and `maxSurge` to 25% since its the default value based on the [docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) (although I kinda liked the whole number and default to 1 more...)
Also if user haven't entered any value there would be 422 RC, since the `getNumberOrPercent()` return `0` on empty field:
![1](https://user-images.githubusercontent.com/1668218/44263313-b4bffe00-a21e-11e8-9d4b-ac5bc9fa1886.png)

FYI we use the percentage default in the origin-web-console as well 

/assign @spadgett 