### PR TITLE
Fix Subscription Link for All Namespaces

### DIFF
--- a/frontend/public/components/cloud-services/catalog-source.tsx
+++ b/frontend/public/components/cloud-services/catalog-source.tsx
@@ -43,7 +43,7 @@ export const PackageRow: React.SFC<PackageRowProps> = (props) => {
   const ns = getActiveNamespace();
   const channel = !_.isEmpty(obj.defaultChannel) ? obj.channels.find(ch => ch.name === obj.defaultChannel) : obj.channels[0];
 
-  const subscriptionLink = () => ns
+  const subscriptionLink = () => ns !== ALL_NAMESPACES_KEY
     ? <Link to={`/k8s/ns/${ns}/${SubscriptionModel.plural}/${subscription.metadata.name}`}>View subscription</Link>
     : <Link to={`/k8s/all-namespaces/${SubscriptionModel.plural}?name=${obj.packageName}`}>View subscriptions</Link>;
 


### PR DESCRIPTION
### Description

Check for `ns !== ALL_NAMESPACES_KEY` instead of `ns !== null`.

Fixes https://jira.coreos.com/browse/CONSOLE-712