### PR TITLE
Adjust display of ContainerLinks in Pod Volumes table

### DIFF
--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -105,6 +105,10 @@ $height: 18px;
   display: flex;
   min-width: 0; // required so co-break-word works
   @include co-break-word;
+  &--inline {
+    display: inline-flex;
+    margin: 0 20px 0 0;
+  }
   &__resource-name {
     min-width: 0; // required so co-break-word works
   }

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -71,7 +71,7 @@ const PodHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-2 hidden-md hidden-sm hidden-xs" sortFunc="podReadiness">Readiness</ColHead>
 </ListHeader>;
 
-const ContainerLink = ({pod, name}) => <span className="co-resource-link">
+const ContainerLink = ({pod, name}) => <span className="co-resource-link co-resource-link--inline">
   <ResourceIcon kind="Container" />
   <Link to={`/k8s/ns/${pod.metadata.namespace}/pods/${pod.metadata.name}/containers/${name}`}>{name}</Link>
 </span>;
@@ -110,10 +110,9 @@ const Volume = ({pod, volume}) => {
     </div>
     <div className="col-sm-3 hidden-xs">{mountPermissions}</div>
     <div className="col-sm-3 col-xs-4">
-      {volume.mounts.map((m, i) => <div key={i}>
+      {volume.mounts.map((m, i) => <React.Fragment key={i}>
         <ContainerLink pod={pod} name={m.container} />
-        {i < volume.mounts.length - 1 && ', '}
-      </div>)}
+      </React.Fragment>)}
     </div>
   </div>;
 };


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-716

![screen shot 2018-08-17 at 3 25 23 pm](https://user-images.githubusercontent.com/895728/44285315-ddea8980-a232-11e8-8e8b-d2792eb17e9e.PNG)
![screen shot 2018-08-17 at 3 25 28 pm](https://user-images.githubusercontent.com/895728/44285316-ddea8980-a232-11e8-9ee6-a8a8d9c6d321.PNG)
![screen shot 2018-08-17 at 3 25 38 pm](https://user-images.githubusercontent.com/895728/44285317-ddea8980-a232-11e8-9bf2-1d48c141bc54.PNG)

And makes display similar to Resources in the Rules table of Roles details (but does not add spacing below each ContainerLink because that makes the entire row height increase).

![screen shot 2018-08-17 at 3 34 26 pm](https://user-images.githubusercontent.com/895728/44285391-2609ac00-a233-11e8-9462-4219b40b7c5e.PNG)


