### PR TITLE
Bug 1619156 - Project/Namespace page has a semicolon at the bottom-left corner of right panel

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -206,7 +206,7 @@ const Details = ({obj: ns}) => {
         </div>
       </div>
     </div>
-    <ResourceUsage ns={ns} />;
+    <ResourceUsage ns={ns} />
   </div>;
 };
 


### PR DESCRIPTION
Fixing: https://bugzilla.redhat.com/show_bug.cgi?id=1619156

/assign @spadgett 