### PR TITLE
Unify resource sidebar component

### DIFF
--- a/frontend/public/components/sidebars/build-config-sidebar.jsx
+++ b/frontend/public/components/sidebars/build-config-sidebar.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { BuildConfigModel } from '../../models';
 import { referenceForModel } from '../../module/k8s';
+import { SampleYaml } from './resource-sidebar';
 
 const samples = [
   {
@@ -24,25 +25,6 @@ const samples = [
     kind: referenceForModel(BuildConfigModel),
   }
 ];
-
-const SampleYaml = ({sample, loadSampleYaml, downloadSampleYaml}) => {
-  const {header, subHeader, details, templateName, kind} = sample;
-  return <li className="co-resource-sidebar-item">
-    <h5 className="co-resource-sidebar-item__header">
-      {header} <span className="co-role-sidebar-subheader">{subHeader}</span>
-    </h5>
-    <p className="co-resource-sidebar-item__details">
-      {details}
-    </p>
-    <button className="btn btn-link" onClick={() => loadSampleYaml(templateName, kind)}>
-      <span className="fa fa-fw fa-paste" aria-hidden="true"></span> Try it
-    </button>
-    <button className="btn btn-link pull-right" onClick={() => downloadSampleYaml(templateName, kind)}>
-      <span className="fa fa-fw fa-download" aria-hidden="true"></span> Download yaml
-    </button>
-  </li>;
-};
-
 
 export const BuildConfigSidebar = ({loadSampleYaml, downloadSampleYaml}) => {
   return <ol className="co-resource-sidebar-list">

--- a/frontend/public/components/sidebars/network-policy-sidebar.jsx
+++ b/frontend/public/components/sidebars/network-policy-sidebar.jsx
@@ -10,11 +10,12 @@ import * as webDbAllowAllNsImg from '../../imgs/network-policy-samples/6-web-db-
 import * as webAllowProductionImg from '../../imgs/network-policy-samples/7-web-allow-production.svg';
 import { NetworkPolicyModel } from '../../models';
 import { referenceForModel } from '../../module/k8s';
+import { SampleYaml } from './resource-sidebar';
 
 const samples = [
   {
     highlightText: 'Limit',
-    subheader: 'access to the current namespace',
+    header: 'access to the current namespace',
     img: denyOtherNamespacesImg,
     details: 'Deny traffic from other namespaces while allowing all traffic from the namespaces the Pod is living in.',
     templateName: 'deny-other-namespaces',
@@ -22,7 +23,7 @@ const samples = [
   },
   {
     highlightText: 'Limit',
-    subheader: 'traffic to an application within the same namespace',
+    header: 'traffic to an application within the same namespace',
     img: limitCertainAppImg,
     details: 'Allow inbound traffic from only certain Pods. One typical use case is to restrict the connections to a database only to the specific applications.',
     templateName: 'db-or-api-allow-app',
@@ -30,7 +31,7 @@ const samples = [
   },
   {
     highlightText: 'Allow',
-    subheader: 'http and https ingress within the same namespace',
+    header: 'http and https ingress within the same namespace',
     img: allowIngressImg,
     details: 'Define ingress rules for specific port numbers of an application. The rule applies to all port numbers if not specified.',
     templateName: 'api-allow-http-and-https',
@@ -38,7 +39,7 @@ const samples = [
   },
   {
     highlightText: 'Deny',
-    subheader: 'all non-whitelisted traffic in the current namespace',
+    header: 'all non-whitelisted traffic in the current namespace',
     img: defaultDenyAllImg,
     details: 'A fundamental policy by blocking all cross-pod traffics expect whitelisted ones through the other Network Policies being deployed.',
     templateName: 'default-deny-all',
@@ -46,7 +47,7 @@ const samples = [
   },
   {
     highlightText: 'Allow',
-    subheader: 'traffic from external clients',
+    header: 'traffic from external clients',
     img: webAllowExternalImg,
     details: 'Allow external service from public Internet directly or through a Load Balancer to access the pod.',
     templateName: 'web-allow-external',
@@ -54,7 +55,7 @@ const samples = [
   },
   {
     highlightText: 'Allow',
-    subheader: 'traffic to an application from all namespaces',
+    header: 'traffic to an application from all namespaces',
     img: webDbAllowAllNsImg,
     details: 'One typical use case is for a common database which is used by deployments in different namespaces.',
     templateName: 'web-db-allow-all-ns',
@@ -62,33 +63,13 @@ const samples = [
   },
   {
     highlightText: 'Allow',
-    subheader: 'traffic from all pods in a particular namespace',
+    header: 'traffic from all pods in a particular namespace',
     img: webAllowProductionImg,
     details: 'Typical use case should be "only allow deployments in production namespaces to access the database" or "allow monitoring tools (in another namespace) to scrape metrics from current namespace."',
     templateName: 'web-allow-production',
     kind: referenceForModel(NetworkPolicyModel),
   },
-
 ];
-
-const SampleYaml = ({sample, loadSampleYaml, downloadSampleYaml}) => {
-  const {highlightText, subheader, img, details, templateName, kind} = sample;
-  return <li className="co-resource-sidebar-item">
-    <h5 className="co-resource-sidebar-item__header">
-      <span className="text-uppercase">{highlightText}</span> {subheader}
-    </h5>
-    <img src={img} className="co-resource-sidebar-item__img" />
-    <p className="co-resource-sidebar-item__details">
-      {details}
-    </p>
-    <button className="btn btn-link" onClick={() => loadSampleYaml(templateName, kind)}>
-      <span className="fa fa-fw fa-paste" aria-hidden="true"></span> Try policy
-    </button>
-    <button className="btn btn-link pull-right" onClick={() => downloadSampleYaml(templateName, kind)}>
-      <span className="fa fa-fw fa-download" aria-hidden="true"></span> Download yaml
-    </button>
-  </li>;
-};
 
 export const NetworkPolicySidebar = ({loadSampleYaml, downloadSampleYaml}) => <ol className="co-resource-sidebar-list">
   {_.map(samples, (sample) => <SampleYaml

--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -37,6 +37,25 @@ export class ResourceSidebarWrapper extends React.Component {
   }
 }
 
+export const SampleYaml = ({sample, loadSampleYaml, downloadSampleYaml}) => {
+  const {highlightText, header, subheader, img, details, templateName, kind} = sample;
+  return <li className="co-resource-sidebar-item">
+    <h5 className="co-resource-sidebar-item__header">
+      <span className="text-uppercase">{highlightText}</span> {header} <span className="co-role-sidebar-subheader">{subheader}</span>
+    </h5>
+    {img && <img src={img} className="co-resource-sidebar-item__img" />}
+    <p className="co-resource-sidebar-item__details">
+      {details}
+    </p>
+    <button className="btn btn-link" onClick={() => loadSampleYaml(templateName, kind)}>
+      <span className="fa fa-fw fa-paste" aria-hidden="true"></span> Try it
+    </button>
+    <button className="btn btn-link pull-right" onClick={() => downloadSampleYaml(templateName, kind)}>
+      <span className="fa fa-fw fa-download" aria-hidden="true"></span> Download yaml
+    </button>
+  </li>;
+};
+
 export const ResourceSidebar = props => {
   const {kindObj, height} = props;
   if (!kindObj) {

--- a/frontend/public/components/sidebars/role-sidebar.jsx
+++ b/frontend/public/components/sidebars/role-sidebar.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { RoleModel, ClusterRoleModel } from '../../models';
 import { referenceForModel } from '../../module/k8s';
+import { SampleYaml } from './resource-sidebar';
 
 const samples = [
   {
@@ -25,46 +26,26 @@ const samples = [
   },
   {
     header: 'Allow reading a ConfigMap in a specific namespace',
-    subHeader: '(for RoleBinding)',
+    subheader: '(for RoleBinding)',
     details: 'This "Role" is allowed to read a "ConfigMap" named "my-config" (must be bound with a "RoleBinding" to limit to a single "ConfigMap" in a single namespace).',
     templateName: 'read-configmap-within-ns',
     kind: referenceForModel(RoleModel),
   },
   {
     header: 'Allow reading Nodes in the core API groups',
-    subHeader: '(for ClusterRoleBinding)',
+    subheader: '(for ClusterRoleBinding)',
     details: 'This "ClusterRole" is allowed to read the resource "nodes" in the core group (because a Node is cluster-scoped, this must be bound with a "ClusterRoleBinding" to be effective).',
     templateName: 'read-nodes',
     kind: referenceForModel(ClusterRoleModel),
   },
   {
     header: '"GET/POST" requests to non-resource endpoint and all subpaths',
-    subHeader: '(for ClusterRoleBinding)',
+    subheader: '(for ClusterRoleBinding)',
     details: 'This "ClusterRole" is allowed to "GET" and "POST" requests to the non-resource endpoint "/healthz" and all subpaths (must be in the "ClusterRole" bound with a "ClusterRoleBinding" to be effective).',
     templateName: 'get-and-post-to-non-resource-endpoints',
     kind: referenceForModel(ClusterRoleModel),
   },
-
 ];
-
-const SampleYaml = ({sample, loadSampleYaml, downloadSampleYaml}) => {
-  const {header, subHeader, details, templateName, kind} = sample;
-  return <li className="co-resource-sidebar-item">
-    <h5 className="co-resource-sidebar-item__header">
-      {header} <span className="co-role-sidebar-subheader">{subHeader}</span>
-    </h5>
-    <p className="co-resource-sidebar-item__details">
-      {details}
-    </p>
-    <button className="btn btn-link" onClick={() => loadSampleYaml(templateName, kind)}>
-      <span className="fa fa-fw fa-paste" aria-hidden="true"></span> Try policy
-    </button>
-    <button className="btn btn-link pull-right" onClick={() => downloadSampleYaml(templateName, kind)}>
-      <span className="fa fa-fw fa-download" aria-hidden="true"></span> Download yaml
-    </button>
-  </li>;
-};
-
 
 export const RoleSidebar = ({kindObj, loadSampleYaml, downloadSampleYaml, isCreateMode}) => {
   const filteredSamples = isCreateMode ? samples : _.filter(samples, {'kind' : referenceForModel(kindObj)});


### PR DESCRIPTION
Noticed that each resource with sidebar has its own  `SampleYaml` component, just with slight differences. Also there have been a slight naming differences in the `sample` object fields (subheader used instead of header, subheader <-> subHeader, ...).
Also Create Role page contained an naming issue where the `Try role` link was containing `Try policy` string:
![1](https://user-images.githubusercontent.com/1668218/44342417-34520500-a48b-11e8-985f-064dd9993de6.png)


Now there will be `Try it` link for all the sidebars.
Unified this component since there is no point to have one for each.


Compared the sidebars before and after change and they should be identical.

/assign @alecmerdler 