### PR TITLE
[WIP] Show resource names in Breadcrumbs

### DIFF
--- a/frontend/public/components/image-stream-tag.tsx
+++ b/frontend/public/components/image-stream-tag.tsx
@@ -126,9 +126,12 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
   </div>;
 };
 
-export const getImageStreamNameForTag = (imageStreamTag: K8sResourceKind): string => {
-  const name = _.get(imageStreamTag, 'metadata.name', '');
-  return name.split(':')[0];
+export const getImageStreamNameForTag = (imageStreamTag: K8sResourceKind): {[key: string]: string} => {
+  const imageStreamTagArray = _.get(imageStreamTag, 'metadata.name', '').split(':');
+  return {
+    imageStream: _.head(imageStreamTagArray),
+    tag: _.last(imageStreamTagArray)
+  }
 };
 
 const pages = [navFactory.details(ImageStreamTagsDetails), navFactory.editYaml()];
@@ -136,12 +139,12 @@ export const ImageStreamTagsDetailsPage: React.SFC<ImageStreamTagsDetailsPagePro
   <DetailsPage
     {...props}
     breadcrumbsFor={obj => {
-      const imageStreamName = getImageStreamNameForTag(obj);
+      const imageStreamTag = getImageStreamNameForTag(obj);
       return [{
-        name: imageStreamName,
-        path: `/k8s/ns/${obj.metadata.namespace}/imagestreams/${imageStreamName}`,
+        name: imageStreamTag.imageStream,
+        path: `/k8s/ns/${obj.metadata.namespace}/imagestreams/${imageStreamTag.imageStream}`,
       }, {
-        name: 'ImageStreamTag Details',
+        name: imageStreamTag.tag,
         path: props.match.url,
       }];
     }}


### PR DESCRIPTION
Our breadcrumbs are not showing resource names, eg tag names for IST, just `ImageStreamTag Details`.
This also applies to other resources:
- pods
- replicationControllers
- builds
...

Before:
![2](https://user-images.githubusercontent.com/1668218/44350869-b4369a00-a4a0-11e8-8cda-f2f100ace473.png)


After:
![1](https://user-images.githubusercontent.com/1668218/44350871-b7318a80-a4a0-11e8-8673-318ed9daa333.png)


IMHO the breadcrumbs with names looks better then with just `'ResourceKindName' Details`.

@spadgett would like to have your ACK before changing this on all the places. Thanks !