### PR TITLE
Remove ellipses from edit secret action

### DIFF
--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -28,7 +28,7 @@ const menuActions = [
   Cog.factory.ModifyLabels,
   Cog.factory.ModifyAnnotations,
   (kind, obj) => ({
-    label: `Edit ${kind.label}...`,
+    label: `Edit ${kind.label}`,
     href: editInYaml(obj) ? `${resourceObjPath(obj, kind.kind)}/edit-yaml` : `${resourceObjPath(obj, kind.kind)}/edit`,
   }),
   Cog.factory.Delete,


### PR DESCRIPTION
We've removed the ellipses from other actions (#372), so we should be consistent here.

/assign @jhadvig 