### PR TITLE
Fix Operator Description Font

### DIFF
--- a/frontend/public/components/cloud-services/markdown-view.tsx
+++ b/frontend/public/components/cloud-services/markdown-view.tsx
@@ -54,6 +54,7 @@ export class SyncMarkdownView extends React.Component<{content: string}, {}> {
           color: ${this.props.content ? '#333' : '#999'};
           background-color: transparent !important;
           min-width: auto !important;
+          font-family: "Open Sans",Helvetica,Arial,sans-serif
       }
       </style>
       <body><div>${markdownConvert(this.props.content || 'Not available')}</div></body>`;


### PR DESCRIPTION
### Description

Was falling back to system font (looked fine on Linux, but not Mac or Windows). Forces iframe to use `font-family: "Open Sans",Helvetica,Arial,sans-serif`.

Addresses https://jira.coreos.com/browse/ALM-690