### PR TITLE
Bug 1620368 - Remove incorrect fields from cron job page

### DIFF
--- a/frontend/public/components/cron-job.jsx
+++ b/frontend/public/components/cron-job.jsx
@@ -45,27 +45,23 @@ const Details = ({obj: cronjob}) => {
           <dt>Schedule</dt>
           <dd>{cronjob.spec.schedule}</dd>
           <dt>Concurrency Policy</dt>
-          <dd>{_.get(cronjob.spec, 'concurrencyPolicy', '-')}</dd>
+          <dd>{cronjob.spec.concurrencyPolicy || '-'}</dd>
           <dt>Starting Deadline Seconds</dt>
-          <dd>{_.get(cronjob.spec, 'startingDeadlineSeconds', '-')}</dd>
+          <dd>{cronjob.spec.startingDeadlineSeconds || '-'}</dd>
+          <dt>Last Schedule Time</dt>
+          <dd><Timestamp timestamp={cronjob.status.lastScheduleTime} /></dd>
         </ResourceSummary>
       </div>
       <div className="col-md-6">
         <SectionHeading text="Job Overview" />
-        <ResourceSummary resource={cronjob} showNodeSelector={false}>
+        <dl className="co-m-pane__details">
           <dt>Desired Completions</dt>
           <dd>{job.spec.completions || '-'}</dd>
           <dt>Parallelism</dt>
           <dd>{job.spec.parallelism || '-'}</dd>
           <dt>Deadline</dt>
           <dd>{job.spec.activeDeadlineSeconds ? `${job.spec.activeDeadlineSeconds} seconds` : '-'}</dd>
-          <dt>Status</dt>
-          <dd>{_.get(job, 'status.conditions[0].type', 'In Progress')}</dd>
-          <dt>Start Time</dt>
-          <dd><Timestamp timestamp={_.get(job, 'status.startTime')} /></dd>
-          <dt>Completion Time</dt>
-          <dd><Timestamp timestamp={_.get(job, 'status.completionTime')} /></dd>
-        </ResourceSummary>
+        </dl>
       </div>
     </div>
   </div>;


### PR DESCRIPTION
Job status will not be set in the cron job resource. You have to look at
an individual job to see status. Remove these fields from the cron job page.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1620368

<img width="834" alt="example details okd 2018-08-23 08-45-03" src="https://user-images.githubusercontent.com/1167259/44526069-dd2d7980-a6b0-11e8-97c5-3e11976fc6c0.png">

/assign @jhadvig 