### PR TITLE
integration tests: wait for test resource to be created before continuing

### DIFF
--- a/frontend/integration-tests/tests/environment.scenario.ts
+++ b/frontend/integration-tests/tests/environment.scenario.ts
@@ -25,6 +25,8 @@ describe('Interacting with the environment variable editor', () => {
     const newContent = _.defaultsDeep({}, {metadata: {name: WORKLOAD_NAME, labels: {['lbl-env']: testName}}}, safeLoad(content));
     await yamlView.setContent(safeDump(newContent));
     await crudView.saveChangesBtn.click();
+    // Wait until the resource is created and the details page loads before continuing.
+    await browser.wait(until.presenceOf(crudView.actionsDropdown));
     checkLogs();
     checkErrors();
   });

--- a/frontend/integration-tests/tests/filter.scenario.ts
+++ b/frontend/integration-tests/tests/filter.scenario.ts
@@ -22,6 +22,8 @@ describe('Filtering', () => {
     const newContent = _.defaultsDeep({}, {metadata: {name: WORKLOAD_NAME, labels: {['lbl-filter']: testName}}}, safeLoad(content));
     await yamlView.setContent(safeDump(newContent));
     await crudView.saveChangesBtn.click();
+    // Wait until the resource is created and the details page loads before continuing.
+    await browser.wait(until.presenceOf(crudView.actionsDropdown));
   });
 
   afterEach(() => {


### PR DESCRIPTION
@alecmerdler I suspect we're changing URLs immediately after clicking save, so we're racing the POST request.

This change was already made in master-next for the annotations scenarios. I purposely left that out of this PR to avoid a conflict.

https://github.com/openshift/console/blob/master-next/frontend/integration-tests/tests/modal-annotations.scenario.ts#L30

/assign @alecmerdler 