### PR TITLE
Fix partial object metadata requests

### DIFF
--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -125,7 +125,8 @@ export const coFetchJSON = (url, method = 'GET', options = {}) => {
       headers['Impersonate-Group'] = name;
     }
   }
-  const allOptions = _.defaultsDeep({method, headers}, options);
+  // Pass headers last to let callers to override Accept.
+  const allOptions = _.defaultsDeep({method}, options, {headers});
   return coFetch(url, allOptions).then(response => {
     if (!response.ok) {
       return response.text().then(text => {

--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -100,8 +100,7 @@ export const k8sList = (kind, params={}, raw=false, options = {}) => {
 };
 
 export const k8sListPartialMetadata = (kind, params = {}, raw = false) => {
-  // FIXME: Use v1beta1 in kube 1.10
-  return k8sList(kind, params, raw, {headers: {Accept: 'application/json;as=PartialObjectMetadataList;v=v1alpha1;g=meta.k8s.io,application/json'}});
+  return k8sList(kind, params, raw, {headers: {Accept: 'application/json;as=PartialObjectMetadataList;v=v1beta1;g=meta.k8s.io,application/json'}});
 };
 
 export const k8sWatch = (kind, query = {}, wsOptions = {}) => {


### PR DESCRIPTION
* Correctly propagate the Accept header
* Use `v1beta1` (required since kube 1.10)

/assign @alecmerdler 