### PR TITLE
Show sidebar only when creating resource

### DIFF
--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -58,7 +58,7 @@ export const SampleYaml = ({sample, loadSampleYaml, downloadSampleYaml}) => {
 
 export const ResourceSidebar = props => {
   const {kindObj, height} = props;
-  if (!kindObj) {
+  if (!kindObj || !props.isCreateMode) {
     return null;
   }
 


### PR DESCRIPTION
The resource-sidebar is shown when creating and also updating a resource with yaml-editor, but showing the samples only make sense when creating a resource, since user can replace his resource description with it.

/assign @spadgett 