### PR TITLE
Add/Remove image secret entries

### DIFF
--- a/frontend/integration-tests/views/catalog.view.ts
+++ b/frontend/integration-tests/views/catalog.view.ts
@@ -16,7 +16,7 @@ export const hasSubscription = (name: string) => browser.getCurrentUrl().then(ur
 }).then(canSubscribe => !canSubscribe);
 
 export const createSubscriptionView = $('.co-create-subscription');
-export const subscriptionNSDropdown = createSubscriptionView.$$('.btn.btn--dropdown').first();
+export const subscriptionNSDropdown = createSubscriptionView.$$('.btn.btn-dropdown').first();
 
 /**
  * Returns a promise that resolves to the row for a given namespace in the enable/disable modal.

--- a/frontend/integration-tests/views/search.view.ts
+++ b/frontend/integration-tests/views/search.view.ts
@@ -2,7 +2,7 @@ import { $, $$, browser, by, element, ExpectedConditions as until } from 'protra
 
 const BROWSER_TIMEOUT = 15000;
 
-export const dropdown = $('.btn--dropdown__content-wrap');
+export const dropdown = $('.btn-dropdown__content-wrap');
 export const dropdownLinks = $$('.dropdown-menu a');
 export const labelFilter = $('.co-m-selector-input input');
 export const linkForType = type => element(by.partialLinkText(type));

--- a/frontend/public/components/RBAC/_rbac.scss
+++ b/frontend/public/components/RBAC/_rbac.scss
@@ -81,7 +81,7 @@
     margin-top: 20px;
   }
 
-  .btn--dropdown {
+  .btn-dropdown {
     max-width: 400px;
     width: 100%;
   }

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -11,6 +11,13 @@ $color-bookmarker: #DDD;
   }
 }
 
+.dropdown--full-width {
+  & > .btn-dropdown,
+  & > .dropdown-menu {
+    width: 100%;
+  }
+}
+
 .dropdown__disabled {
   color: $dropdown-link-disabled-color;
   cursor: not-allowed;
@@ -254,7 +261,7 @@ $color-bookmarker: #DDD;
   }
 }
 
-.btn--dropdown {
+.btn-dropdown {
   max-width: 100%;
   .caret {
     flex: 0 0 auto;
@@ -262,7 +269,7 @@ $color-bookmarker: #DDD;
   }
 }
 
-.btn--dropdown__item {
+.btn-dropdown__item {
   overflow: hidden;
   text-align: left;
   text-overflow: ellipsis;
@@ -272,7 +279,7 @@ $color-bookmarker: #DDD;
   }
 }
 
-.btn--dropdown__content-wrap {
+.btn-dropdown__content-wrap {
   align-items: center;
   display: flex;
   flex: 1 1 auto;

--- a/frontend/public/components/cluster-settings/_cluster-updates.scss
+++ b/frontend/public/components/cluster-settings/_cluster-updates.scss
@@ -205,7 +205,7 @@ $cluster-updates-width: 800px;
 .co-cluster-channel-dropdown {
   height: 120px;
   & > .dropdown {
-    & > .btn--dropdown {
+    & > .btn-dropdown {
       width: 250px;
     }
     & > .dropdown-menu {

--- a/frontend/public/components/secrets/_create-secret.scss
+++ b/frontend/public/components/secrets/_create-secret.scss
@@ -28,10 +28,3 @@
   border-top: 1px solid #ccc;
   padding-top: 10px;
 }
-
-.co-create-secret__dropdown {
-  .btn--dropdown,
-  .dropdown-menu {
-    width: 100%;
-  }
-}

--- a/frontend/public/components/secrets/_create-secret.scss
+++ b/frontend/public/components/secrets/_create-secret.scss
@@ -3,11 +3,35 @@
   margin-bottom: 10px;
 }
 
+.co-create-image-secret__form-wrapper {
+  position: relative;
+}
+
+.co-create-secret-form__link--add-entry {
+  padding: 0 0 15px 0;
+}
+
+.co-create-secret-form__link--remove-entry {
+  position: absolute;
+  right: 0;
+}
+
 .co-create-image-secret__form {
   margin-bottom: 25px;
 }
 
-.co-create-image-secret__form + .co-create-image-secret__form {
+.co-create-secret-form__link--remove-entry + .co-create-image-secret__form {
+  padding-top: 25px;
+}
+
+.co-create-image-secret__form-wrapper + .co-create-image-secret__form-wrapper {
   border-top: 1px solid #ccc;
   padding-top: 10px;
+}
+
+.co-create-secret__dropdown {
+  .btn--dropdown,
+  .dropdown-menu {
+    width: 100%;
+  }
 }

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -248,7 +248,7 @@ class ImageSecretForm extends React.Component<ImageSecretFormProps, ImageSecretF
       {this.props.isCreate && <div className="form-group">
         <label className="control-label" htmlFor="secret-type">Authentication Type</label>
         <div className="co-create-secret__dropdown">
-          <Dropdown title="Image Registry Credential" items={authTypes} id="dropdown-selectbox" onChange={this.changeFormType} />
+          <Dropdown title="Image Registry Credential" items={authTypes} dropDownClassName="dropdown--full-width" id="dropdown-selectbox" onChange={this.changeFormType} />
         </div>
       </div>
       }

--- a/frontend/public/components/utils/_value-from-pair.scss
+++ b/frontend/public/components/utils/_value-from-pair.scss
@@ -5,7 +5,7 @@
     width: 50%;
   }
 
-  .btn--dropdown {
+  .btn-dropdown {
     width: 100%;
   }
 

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -326,9 +326,9 @@ export class Dropdown extends DropdownMixin {
               {titlePrefix && `${titlePrefix}: `}
               <span className="dropdown__not-btn__title">{title}</span>&nbsp;<Caret />
             </div>
-            : <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('btn', 'btn--dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id}>
-              <div className="btn--dropdown__content-wrap">
-                <span className="btn--dropdown__item">
+            : <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('btn', 'btn-dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id}>
+              <div className="btn-dropdown__content-wrap">
+                <span className="btn-dropdown__item">
                   {titlePrefix && `${titlePrefix}: `}
                   {title}
                 </span><Caret />

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -194,7 +194,7 @@
   @media(max-width: $grid-float-breakpoint-max) {
     .input-group-select {
       display: block;
-      .btn--dropdown {
+      .btn-dropdown {
         margin-bottom: 2px;
         width: 100%;
       }


### PR DESCRIPTION
Implementing logic for adding/removing image secret credentials, since the secret can contain more then one credentials. Demo:
![secrets okd](https://user-images.githubusercontent.com/1668218/44657345-ce223080-a9fc-11e8-950e-2721f07cd95a.gif)

Used design suggested by @beanh66 (please help review) in https://github.com/openshift/console/pull/205#issuecomment-406587544 with small changes:
- The *Remove Credentials* button also contains `fa-minus-circle` icon, similarly to the *Add Credentials* button.
- All the entries have *Remove Credentials* button above then, aligned to the right side
- If there is just one entry, the *Remove Credentials* button will be hidden, since the form is meant for editing the secret, not for deletion.

Had to add additional `uid` field to the `ConfigEntryFormState` so React will re-render only updated entries. Could not use *index* of the entry in the array since thats not unique(since the entries on different positions can be now removed) or any other attribute of the entry(address, name, pw, mail), since that not unique as well and can be changed.

Tested the changes for both image secret formats and should work as described without issues.

One thing that I'm hesitating to change are the names that contain `entry` string. Since the Add/Remove buttons are referring to `credentials`. Kinda like the `entry` string in the code more. Also the code would require much more changes, and if we decide to go with the change I would rather do it in a separate commit, so the changes are obvious.

@spadgett PTAL