### PR TITLE
Rework css to use custom .dropdown-menu--text-wrap class in cases to enable word wrapping within a dropdown list

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -259,8 +259,16 @@ class ListDropdown_ extends React.Component {
 
     const Component = fixed
       ? items[selectedKey]
-      : <Dropdown autocompleteFilter={this.autocompleteFilter} autocompletePlaceholder={placeholder} items={items} sortedItemKeys={sortedItems}
-        selectedKey={selectedKey} title={this.state.title} onChange={this.onChange} id={id} />;
+      : <Dropdown
+        autocompleteFilter={this.autocompleteFilter}
+        autocompletePlaceholder={placeholder}
+        items={items}
+        sortedItemKeys={sortedItems}
+        selectedKey={selectedKey}
+        title={this.state.title}
+        onChange={this.onChange}
+        id={id}
+        menuClassName="dropdown-menu--text-wrap" />;
 
     return <div>
       { Component }

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -40,6 +40,16 @@ $color-bookmarker: #DDD;
   padding: 5px 10px 10px;
 }
 
+.dropdown-menu--text-wrap {
+  max-width: 100%;
+  li a {
+    min-width: 0;
+    overflow-wrap: break-word;
+    white-space: normal;
+    word-wrap: break-word;
+  }
+}
+
 .dropdown--text-filter {
   float: none !important;
 }
@@ -50,7 +60,6 @@ $color-bookmarker: #DDD;
 
 .dropdown-menu {
   display: block;
-  max-width: 100%;
 
   ul {
     padding: 0;
@@ -67,7 +76,6 @@ $color-bookmarker: #DDD;
     a {
       cursor: pointer;
       flex-grow: 1;
-      white-space: normal;
       width: 100%;
       &.next-to-bookmark {
         padding-left: 5px

--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -3,12 +3,11 @@
   min-width: 0;
   .dropdown-menu {
     max-height: 75vh;
-    min-width: 270px;
+    min-width: 290px;
     overflow-x: hidden;
     overflow-y: auto;
     a {
       padding: 4px 20px 4px 6px;
-      white-space: nowrap;
     }
   }
 }

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -108,6 +108,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
   };
 
   return <Dropdown
+    menuClassName="dropdown-menu--text-wrap"
     className={classNames('co-type-selector', className)}
     items={allItems}
     title={allItems[selectedKey]}

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -530,6 +530,7 @@ export class ContainerDropdown extends React.PureComponent {
     const title = _.get(dropdownItems, currentKey) || containerLabel(firstContainer);
     return <Dropdown
       className="btn-group"
+      menuClassName="dropdown-menu--text-wrap"
       headerBefore={headerBefore}
       items={dropdownItems}
       spacerBefore={spacerBefore}

--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -82,7 +82,7 @@ const NameKeyDropdownPair = ({name, key, configMaps, secrets, onChange, kind, na
   const items = _.assign({}, cmItems, secretItems);
   return <React.Fragment>
     <Dropdown
-      menuClassName="value-from__menu"
+      menuClassName="value-from__menu dropdown-menu--text-wrap"
       className="value-from"
       autocompleteFilter={nameAutocompleteFilter}
       autocompletePlaceholder={placeholderString}
@@ -100,7 +100,7 @@ const NameKeyDropdownPair = ({name, key, configMaps, secrets, onChange, kind, na
       }}
     />
     <Dropdown
-      menuClassName="value-from__menu"
+      menuClassName="value-from__menu dropdown-menu--text-wrap"
       className="value-from"
       autocompleteFilter={keyAutocompleteFilter}
       autocompletePlaceholder="Key"


### PR DESCRIPTION
fixes https://jira.coreos.com/browse/CONSOLE-741

<img width="273" alt="screen shot 2018-08-27 at 12 22 46 pm" src="https://user-images.githubusercontent.com/1874151/44671693-3caec080-a9f4-11e8-876a-752a34a221c3.png">
<img width="309" alt="screen shot 2018-08-27 at 12 17 52 pm" src="https://user-images.githubusercontent.com/1874151/44671698-3fa9b100-a9f4-11e8-891e-643cd6012190.png">
<img width="319" alt="screen shot 2018-08-27 at 12 15 51 pm" src="https://user-images.githubusercontent.com/1874151/44671712-47695580-a9f4-11e8-9452-da6314f01eb6.png">
