### PR TITLE
Bug 1622372 - Require CSRF token on all proxied requests

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -228,7 +228,7 @@ func testReferer(t *testing.T, referer string, accept bool) {
 		r.Header.Set("Referer", referer)
 	}
 
-	err = a.VerifyReferer(r)
+	err = a.VerifySourceOrigin(r)
 
 	if err != nil && accept {
 		t.Errorf("Unexpected error for referer `%v`:\n%v", referer, err)

--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -248,7 +248,7 @@ func main() {
 
 		srv.K8sProxyConfig = &proxy.Config{
 			TLSClientConfig: tlsConfig,
-			HeaderBlacklist: []string{"Cookie"},
+			HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
 			Endpoint:        k8sEndpoint,
 		}
 
@@ -268,7 +268,7 @@ func main() {
 			// Only proxy requests to the Prometheus API, not the UI.
 			srv.PrometheusProxyConfig = &proxy.Config{
 				TLSClientConfig: prometheusTLSConfig,
-				HeaderBlacklist: []string{"Cookie"},
+				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
 				Endpoint:        &url.URL{Scheme: "https", Host: openshiftPrometheusHost, Path: "/api"},
 			}
 		} else if !os.IsNotExist(err) {
@@ -283,7 +283,7 @@ func main() {
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: *fK8sModeOffClusterSkipVerifyTLS,
 			},
-			HeaderBlacklist: []string{"Cookie"},
+			HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
 			Endpoint:        k8sEndpoint,
 		}
 	default:

--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -84,16 +84,14 @@ export class TimeoutError extends Error {
 }
 
 const cookiePrefix = 'csrf-token=';
-const getCSRFToken = () => document && document.cookie && document.cookie.split(';')
+export const getCSRFToken = () => document && document.cookie && document.cookie.split(';')
   .map(c => _.trim(c))
   .filter(c => c.startsWith(cookiePrefix))
   .map(c => c.slice(cookiePrefix.length)).pop();
 
 export const coFetch = (url, options = {}, timeout=20000) => {
   const allOptions = _.defaultsDeep({}, initDefaults, options);
-  if (allOptions.method !== 'GET') {
-    allOptions.headers['X-CSRFToken'] = getCSRFToken();
-  }
+  allOptions.headers['X-CSRFToken'] = getCSRFToken();
 
   // If the URL being requested is absolute (and therefore, not a local request),
   // remove the authorization header to prevent credentials from leaking.

--- a/frontend/public/module/ws-factory.js
+++ b/frontend/public/module/ws-factory.js
@@ -5,6 +5,15 @@
  */
 /* eslint-disable no-console */
 
+import { getCSRFToken } from '../co-fetch';
+
+function addCSRFQueryParam(href) {
+  const url = new URL(href);
+  const csrfToken = getCSRFToken();
+  url.searchParams.set('x-csrf-token', csrfToken);
+  return url.href;
+}
+
 function createURL(host, path) {
   let url;
 
@@ -22,7 +31,8 @@ function createURL(host, path) {
   if (path) {
     url += path;
   }
-  return url;
+
+  return addCSRFQueryParam(url);
 }
 
 export function WSFactory(id, options) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -85,9 +85,12 @@ func decodeSubprotocol(encodedProtocol string) (string, error) {
 	return string(decodedProtocol), err
 }
 
-var headerBlacklist = []string{"Cookie"}
+var headerBlacklist = []string{"Cookie", "X-CSRFToken"}
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Block scripts from running in proxied content for browsers that support Content-Security-Policy.
+	w.Header().Set("Content-Security-Policy", "default-src 'none';")
+
 	isWebsocket := false
 	upgrades := r.Header["Upgrade"]
 

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -27,27 +27,16 @@ func authMiddlewareWithUser(a *auth.Authenticator, handlerFunc func(user *auth.U
 
 		r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", user.Token))
 
-		safe := false
-		switch r.Method {
-		case
-			"GET",
-			"HEAD",
-			"OPTIONS",
-			"TRACE":
-			safe = true
+		if err := a.VerifySourceOrigin(r); err != nil {
+			plog.Infof("invalid source origin: %v", err)
+			w.WriteHeader(http.StatusForbidden)
+			return
 		}
 
-		if !safe {
-			if err := a.VerifyReferer(r); err != nil {
-				plog.Infof("Invalid referer %v", err)
-				w.WriteHeader(http.StatusForbidden)
-				return
-			}
-			if err := a.VerifyCSRFToken(r); err != nil {
-				plog.Infof("Invalid CSRFToken %v", err)
-				w.WriteHeader(http.StatusForbidden)
-				return
-			}
+		if err := a.VerifyCSRFToken(r); err != nil {
+			plog.Infof("invalid CSRFToken: %v", err)
+			w.WriteHeader(http.StatusForbidden)
+			return
 		}
 
 		handlerFunc(user, w, r)

--- a/server/server.go
+++ b/server/server.go
@@ -61,7 +61,6 @@ type jsGlobals struct {
 	Branding             string `json:"branding"`
 	DocumentationBaseURL string `json:"documentationBaseURL"`
 	ClusterName          string `json:"clusterName"`
-	CSRFToken            string `json:"CSRFToken"`
 	GoogleTagManagerID   string `json:"googleTagManagerID"`
 	LoadTestFactor       int    `json:"loadTestFactor"`
 }


### PR DESCRIPTION
* Require a CSRF token on all proxied requests. This prevents loading
  content hosted from a pod under the console domain by clicking on a
  link that uses the console proxy. Previously, it was not required for
  GET requests.
* Do not forward the X-CSRFToken header through the proxy.
* Set `Content-Security-Policy: default-src 'none'` in the proxied
  response to prevent scripts from running in proxied content.

In order to support the CSRF token for WebSockets, this adds an
`x-csrf-token` query parameter when headers can't be set. It also updates
the console to check the `Origin` header when present since `Referer` is
not set for WebSockets.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1622372

/assign @liggitt 