### PR TITLE
Add height for SVG images so SVGs without default size render correctly

### DIFF
--- a/frontend/public/components/_cluster-service-class.scss
+++ b/frontend/public/components/_cluster-service-class.scss
@@ -41,9 +41,17 @@ $cluster-service-class-icon-size-sm: 24px;
     max-height: $cluster-service-class-icon-size-sm;
     max-width: $cluster-service-class-icon-size-sm;
 
+    &[src$=".svg"] {
+      height: $cluster-service-class-icon-size-sm;
+    }
+
     &--large {
       max-height: $cluster-service-class-icon-size-lg;
       max-width: $cluster-service-class-icon-size-lg;
+
+      &[src$=".svg"] {
+        height: $cluster-service-class-icon-size-lg;
+      }
     }
   }
 }


### PR DESCRIPTION
Before:
![screen shot 2018-08-28 at 3 48 55 pm](https://user-images.githubusercontent.com/895728/44748394-ace54100-aadd-11e8-85ce-038c190dcb4b.PNG)

After:
![screen shot 2018-08-28 at 4 15 39 pm](https://user-images.githubusercontent.com/895728/44748415-b9699980-aadd-11e8-8d9d-231b48f849a6.PNG)

Partially fixes https://jira.coreos.com/browse/CONSOLE-725