### PR TITLE
Fix https://jira.coreos.com/browse/CONSOLE-734

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -525,18 +525,23 @@ const BaseEditRoleBinding = connect(null, {setActiveNamespace: UIActions.setActi
     }
   });
 
-export const CreateRoleBinding = ({match: {params}}) => <BaseEditRoleBinding
-  metadata={{
-    namespace: getActiveNamespace(),
-  }}
-  fixed={{
-    kind: (params.ns || params.rolekind === 'Role') ? 'RoleBinding' : undefined,
+export const CreateRoleBinding = ({match: {params}, location}) => {
+  const searchParams = new URLSearchParams(location.search);
+  const roleKind = searchParams.get('rolekind');
+  const roleName = searchParams.get('rolename');
+  const metadata = {namespace: getActiveNamespace()};
+  const fixed = {
+    kind: (params.ns || roleKind === 'Role') ? 'RoleBinding' : undefined,
     metadata: {namespace: params.ns},
-    roleRef: {kind: params.rolekind, name: params.rolename},
-  }}
-  isCreate={true}
-  titleVerb="Create"
-/>;
+    roleRef: {kind: roleKind, name: roleName},
+  };
+  return <BaseEditRoleBinding
+    metadata={metadata}
+    fixed={fixed}
+    isCreate={true}
+    titleVerb="Create"
+  />;
+};
 
 const getSubjectIndex = () => {
   const subjectIndex = getQueryArgument('subjectIndex') || '0';

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -127,7 +127,7 @@ const BindingRow = ({obj: binding}) => <ResourceRow obj={binding}>
 const BindingsListComponent = props => <BindingsList {...props} Header={BindingHeader} Row={BindingRow} />;
 
 export const BindingsForRolePage = (props) => {
-  const {match: {params: {name, ns}}, kind} = props;
+  const {match: {params: {name, ns}}, obj:{kind}} = props;
   let resources = [{kind: 'RoleBinding', namespaced: true}];
   if (!ns) {
     resources.push({kind: 'ClusterRoleBinding', namespaced: false, optional: true});
@@ -135,7 +135,7 @@ export const BindingsForRolePage = (props) => {
   return <MultiListPage
     canCreate={true}
     createButtonText="Create Binding"
-    createProps={{to: `/k8s/cluster/rolebindings/new?${ns ? `ns=${ns}&` : ''}rolekind=${kind}&rolename=${name}`}}
+    createProps={{to: `/k8s/${ns ? `ns/${ns}` : 'cluster'}/rolebindings/new?rolekind=${kind}&rolename=${name}`}}
     ListComponent={BindingsListComponent}
     staticFilters={[{'role-binding-roleRef': name}]}
     resources={resources}


### PR DESCRIPTION
Fix https://jira.coreos.com/browse/CONSOLE-734.

Create role binding page now has prefilled read-only namespace and role name fields when 'Create Binding' option is selected from a Role details page. 