### PR TITLE
Bug 1622818 - Simplify dropdown

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -223,7 +223,6 @@ const namespaceDropdownStateToProps = state => {
   return { activeNamespace, canListNS };
 };
 
-
 class NamespaceDropdown_ extends React.Component {
 
   componentDidUpdate() {
@@ -243,26 +242,21 @@ class NamespaceDropdown_ extends React.Component {
     const { loaded, data } = this.props.namespace;
     const model = getModel(useProjects);
     const allNamespacesTitle = `all ${model.labelPlural.toLowerCase()}`;
-    const sortedNames = _.map(data, 'metadata.name');
-    const allNamespacesActive = (activeNamespace === ALL_NAMESPACES_KEY);
-    const title = allNamespacesActive
-      ? allNamespacesTitle
-      : activeNamespace;
-    const items = _.reduce(sortedNames, (result, name) => {
-      result[name] = name;
-      return result;
-    }, {});
-    const titleInItems = loaded && _.has(items, title);
-    if (!allNamespacesActive && !titleInItems) {
-      items[title] = title;
-      sortedNames.push(title);
-    }
-    sortedNames.sort();
+    const items = {};
     if (canListNS) {
-      // we always want ALL_NAMESPACES_KEY first!
-      sortedNames.unshift(ALL_NAMESPACES_KEY);
       items[ALL_NAMESPACES_KEY] = allNamespacesTitle;
     }
+
+    _.map(data, 'metadata.name').sort().forEach(name => items[name] = name);
+
+    let title = activeNamespace;
+    if (activeNamespace === ALL_NAMESPACES_KEY) {
+      title = allNamespacesTitle;
+    } else if (loaded && !_.has(items, title)) {
+      // If the currently active namespace is not found in the list of all namespaces, put it in anyway
+      items[title] = title;
+    }
+
     const onChange = newNamespace => dispatch(UIActions.setActiveNamespace(newNamespace));
 
     return <div className="co-namespace-selector">
@@ -272,7 +266,6 @@ class NamespaceDropdown_ extends React.Component {
         noButton
         canFavorite
         items={items}
-        sortedItemKeys={sortedNames}
         titlePrefix={model.label}
         title={title}
         onChange={onChange}

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -104,7 +104,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
       return false;
     }
 
-    return fuzzy(_.toLower(text), _.toLower(model.abbr + model.kind));
+    return fuzzy(_.toLower(text), _.toLower(model.kind));
   };
 
   return <Dropdown


### PR DESCRIPTION
This reverts some recent dropdown changes, which have caused a number of
bugs, and generally simplifies things.

Note that this does reintroduce the wrong sort for projects with names
like "111" in Chrome only since Chrome does not preserve insertion order
in objects. I believe the right solution is to switch to a Map or
OrderedMap to preserve order, but that is a larger change.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1622818