### PR TITLE
Add parameters to the service instance form

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,6 +75,7 @@
     "react-dnd-html5-backend": "^2.6.0",
     "react-dom": "16.x",
     "react-helmet": "5.x",
+    "react-jsonschema-form": "^1.0.4",
     "react-lightweight-tooltip": "1.x",
     "react-modal": "3.x",
     "react-redux": "5.x",

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -1,17 +1,20 @@
-/* eslint-disable no-undef */
+/* eslint-disable no-undef, no-unused-vars */
 
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
+import Form from 'react-jsonschema-form';
 
 import { LoadingBox } from '../utils/status-box';
-import { history, Firehose, kindObj, NavTitle, resourcePathFromModel } from '../utils';
-import { ClusterServiceClassModel, ServiceInstanceModel } from '../../models';
-import { k8sCreate, serviceClassDisplayName } from '../../module/k8s';
+import { history, Firehose, NavTitle, resourcePathFromModel } from '../utils';
+import { ClusterServiceClassModel, SecretModel, ServiceInstanceModel } from '../../models';
+import { k8sCreate, K8sResourceKind, serviceClassDisplayName } from '../../module/k8s';
 import { NsDropdown } from '../RBAC/bindings';
 import { ClusterServiceClassInfo } from '../cluster-service-class-info';
 import { ButtonBar } from '../utils/button-bar';
+
+const PARAMETERS_SECRET_KEY = 'parameters';
 
 const getAvailablePlans = (plans: any[]): any[] => _.reject(_.get(plans, 'data'), plan => plan.status.removedFromBrokerCatalog);
 
@@ -49,26 +52,33 @@ class CreateInstanceForm extends React.Component<CreateInstanceFormProps, Create
     return newState;
   }
 
-  onNamespaceChange = namespace => {
+  onNamespaceChange = (namespace: string) => {
     this.setState({namespace: namespace});
   };
 
-  onNameChange = event => {
-    this.setState({name: event.target.value});
+  onNameChange: React.ReactEventHandler<HTMLInputElement> = event => {
+    this.setState({name: event.currentTarget.value});
   }
 
-  onPlanChange = event => {
-    this.setState({plan: event.target.value});
+  onPlanChange: React.ReactEventHandler<HTMLInputElement> = event => {
+    this.setState({plan: event.currentTarget.value});
   }
 
-  save = (e) => {
-    e.preventDefault();
-    if (!this.state.name || !this.state.namespace || !this.state.plan) {
-      this.setState({error: 'Please complete all fields.'});
-      return;
-    }
-    this.setState({inProgress: true});
-    const newServiceInstance = {
+  asParameters = (formData: any): any => {
+    // Omit parameters values that are the empty string. These are always
+    // optional parameters since you can't submit the form when it's missing
+    // required values. The template broker will not generate values for
+    // "generated" parameters that are there, even if the value is empty
+    // string, which breaks many templates.
+    //
+    // Check specifically for the empty string rather than truthiness so that
+    // we don't omit other values like `false` for boolean parameters.
+    return _.omitBy(formData, value => value === '');
+  }
+
+  createInstance = (secretName: string): Promise<K8sResourceKind> => {
+    const parametersFrom = secretName ? [{ secretKeyRef: { name: secretName, key: PARAMETERS_SECRET_KEY } }] : [];
+    const serviceInstance: K8sResourceKind = {
       apiVersion: 'servicecatalog.k8s.io/v1beta1',
       kind: 'ServiceInstance',
       metadata: {
@@ -78,30 +88,76 @@ class CreateInstanceForm extends React.Component<CreateInstanceFormProps, Create
       spec: {
         clusterServiceClassExternalName: _.get(this.props.obj, 'data.spec.externalName'),
         clusterServicePlanExternalName: this.state.plan,
+        parametersFrom,
       }
     };
-    const ko = kindObj('ServiceInstance');
-    k8sCreate(ko, newServiceInstance).then(() => {
-      this.setState({inProgress: false});
-      history.push(resourcePathFromModel(ServiceInstanceModel, newServiceInstance.metadata.name, newServiceInstance.metadata.namespace));
-    }, err => this.setState({error: err.message, inProgress: false}));
+
+    return k8sCreate(ServiceInstanceModel, serviceInstance);
+  }
+
+  createParametersSecret = (instance: K8sResourceKind, secretName: string, parameters: any): Promise<K8sResourceKind> => {
+    const secret = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: secretName,
+        namespace: instance.metadata.namespace,
+        ownerReferences: [{
+          apiVersion: instance.apiVersion,
+          kind: instance.kind,
+          name: instance.metadata.name,
+          uid: instance.metadata.uid,
+          controller: false,
+          blockOwnerDeletion: false
+        }],
+      },
+      stringData: {
+        [PARAMETERS_SECRET_KEY]: JSON.stringify(parameters),
+      },
+    };
+
+    return k8sCreate(SecretModel, secret);
+  };
+
+  save = ({formData}) => {
+    const { name, namespace, plan } = this.state;
+    if (!name || !namespace || !plan) {
+      this.setState({error: 'Please complete all fields.'});
+      return;
+    }
+
+    this.setState({inProgress: true});
+    const parameters = this.asParameters(formData);
+    const secretName = _.isEmpty(parameters) ? null : `${this.state.name}-parameters`;
+
+    // Create the instance first so we can set an ownerRef from the parameters secret to the instance.
+    this.createInstance(secretName)
+      .then(instance => secretName ? this.createParametersSecret(instance, secretName, parameters) : null)
+      .then(() => {
+        this.setState({inProgress: false});
+        history.push(resourcePathFromModel(ServiceInstanceModel, name, namespace));
+      }, err => this.setState({error: err.message, inProgress: false}));
   };
 
   render() {
     const { obj, plans, match } = this.props;
-    const serviceClass = _.get(obj, 'data');
-    const scPlans = getAvailablePlans(plans);
-    const title = 'Create Instance';
-    const displayName = serviceClassDisplayName(serviceClass);
-
     if (!obj.loaded) {
       return <LoadingBox />;
     }
 
-    const scPlanOptions = _.map(scPlans, plan => {
+    const serviceClass = _.get(obj, 'data');
+    const title = 'Create Instance';
+    const displayName = serviceClassDisplayName(serviceClass);
+
+    const { plan: selectedPlanName } = this.state;
+    const availablePlans = getAvailablePlans(plans);
+    const selectedPlan = _.find(availablePlans, { spec: { externalName: selectedPlanName } });
+    const parameters = _.get(selectedPlan, 'spec.instanceCreateParameterSchema', { type: 'object', properties: {} });
+
+    const planOptions = _.map(availablePlans, plan => {
       return <div className="radio co-create-service-instance__plan" key={plan.spec.externalName}>
         <label>
-          <input type="radio" name="plan" id="plan" value={plan.spec.externalName} checked={this.state.plan === plan.spec.externalName} onChange={this.onPlanChange} />
+          <input type="radio" name="plan" id="plan" value={plan.spec.externalName} checked={selectedPlanName === plan.spec.externalName} onChange={this.onPlanChange} />
           {plan.spec.externalMetadata.displayName || plan.spec.externalName}
           {plan.spec.description && <div className="text-muted">{plan.spec.description}</div>}
         </label>
@@ -117,7 +173,7 @@ class CreateInstanceForm extends React.Component<CreateInstanceFormProps, Create
         obj={obj}
         breadcrumbsFor={() => [
           {name: displayName, path: resourcePathFromModel(ClusterServiceClassModel, serviceClass.metadata.name)},
-          {name: 'Create Instance', path: `${match.url}`}
+          {name: title, path: `${match.url}`}
         ]}
       />
       <div className="co-m-pane__body">
@@ -126,13 +182,14 @@ class CreateInstanceForm extends React.Component<CreateInstanceFormProps, Create
             <ClusterServiceClassInfo obj={serviceClass} />
           </div>
           <div className="col-md-5 col-md-pull-7">
-            <form className="co-create-service-instance" onSubmit={this.save}>
+            <form className="co-create-service-instance">
               <div className="form-group co-create-service-instance__namespace">
-                <label className="control-label" htmlFor="dropdown-selectbox">Namespace</label>
+                {/* Use the same required style as used by react-jsonschema-form for consistency. */}
+                <label className="control-label" htmlFor="dropdown-selectbox">Namespace<span className="required">*</span></label>
                 <NsDropdown selectedKey={this.state.namespace} onChange={this.onNamespaceChange} id="dropdown-selectbox" />
               </div>
               <div className="form-group co-create-service-instance__name">
-                <label className="control-label" htmlFor="name">Service Instance Name</label>
+                <label className="control-label" htmlFor="name">Service Instance Name<span className="required">*</span></label>
                 <input className="form-control"
                   type="text"
                   onChange={this.onNameChange}
@@ -142,15 +199,17 @@ class CreateInstanceForm extends React.Component<CreateInstanceFormProps, Create
               </div>
               <div className="form-group co-create-service-instance__plans">
                 <label className="control-label">Plans</label>
-                {_.isEmpty(scPlans)
+                {_.isEmpty(availablePlans)
                   ? <p>There are no plans currently available for this service.</p>
-                  : scPlanOptions}
+                  : planOptions}
               </div>
+            </form>
+            <Form schema={parameters} onSubmit={this.save}>
               <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress}>
                 <button type="submit" className="btn btn-primary">Create</button>
                 <Link to={resourcePathFromModel(ClusterServiceClassModel, serviceClass.metadata.name)} className="btn btn-default">Cancel</Link>
               </ButtonBar>
-            </form>
+            </Form>
           </div>
         </div>
       </div>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2399,6 +2399,10 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
+core-js@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+
 core-js@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.3.0.tgz#fab83fbb0b2d8dc85fa636c4b9d34c75420c6d65"
@@ -6479,6 +6483,10 @@ lodash.tail@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
 
+lodash.topath@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
+
 lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
@@ -8641,6 +8649,16 @@ react-helmet@5.x:
 react-is@^16.3.1:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.1.tgz#ee66e6d8283224a83b3030e110056798488359ba"
+
+react-jsonschema-form@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-1.0.4.tgz#e63a3ebffcf3987d0bfe8e05e2fae738fa5f6f19"
+  dependencies:
+    ajv "^5.2.3"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.7"
+    lodash.topath "^4.5.2"
+    prop-types "^15.5.8"
 
 react-lightweight-tooltip@1.x:
   version "1.0.0"


### PR DESCRIPTION
- [x] Add parameters to secret instead of inline
- [x] Consistent use of `*` for required fields
- [x] Correctly handle services with no schema

Follow on:

* Consider AsynComponent for loading react-jsonschema-form (not sure if really necessary since we split code by route now)
* Let users optionally inline parameters instead of using a secret?

![screen shot 2018-08-29 at 3 02 26 pm](https://user-images.githubusercontent.com/1167259/44809403-9c47d000-ab9c-11e8-8854-006830764c54.png)
