### PR TITLE
Add co-break-word to conditions message to fix overflow bug

### DIFF
--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -19,7 +19,7 @@ export const Conditions: React.SFC<ConditionsProps> = ({conditions}) => {
       <CamelCaseWrap value={condition.reason} />
     </div>
     {/* remove initial newline which appears in route messages */}
-    <div className="hidden-xs col-sm-5 col-md-4 co-pre-line">
+    <div className="hidden-xs col-sm-5 col-md-4 co-break-word co-pre-line">
       {_.trim(condition.message) || '-'}
     </div>
   </div>);


### PR DESCRIPTION
Before:
![screen shot 2018-08-29 at 9 27 37 am](https://user-images.githubusercontent.com/895728/44790825-393f4480-ab6e-11e8-9f58-8cfbaf0a8a79.PNG)

After:
![screen shot 2018-08-29 at 9 27 22 am](https://user-images.githubusercontent.com/895728/44790836-3e9c8f00-ab6e-11e8-8051-117a6a0c4b7e.PNG)

Fixes https://jira.coreos.com/browse/CONSOLE-728