### PR TITLE
Support Multiple CatalogSources in the Global OLM Namespace

### DIFF
--- a/frontend/__tests__/components/cloud-services/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/clusterserviceversion.spec.tsx
@@ -276,7 +276,7 @@ describe(ClusterServiceVersionsPage.displayName, () => {
     const listPage = wrapper.find(MultiListPage).at(0);
 
     expect(listPage.props().resources).toEqual([
-      {kind: referenceForModel(ClusterServiceVersionModel), namespaced: true, prop: 'ClusterServiceVersion', selector: {matchLabels: {[appCatalogLabel]: AppCatalog.ocs}}},
+      {kind: referenceForModel(ClusterServiceVersionModel), namespaced: true, prop: 'ClusterServiceVersion', selector: {matchLabels: {[appCatalogLabel]: AppCatalog.rhOperators}}},
       {kind: 'Deployment', namespaced: true, isList: true, prop: 'Deployment'},
     ]);
     expect(listPage.props().dropdownFilters).toBeDefined();

--- a/frontend/__tests__/components/cloud-services/subscription.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/subscription.spec.tsx
@@ -206,8 +206,8 @@ describe(SubscriptionDetailsPage.displayName, () => {
     const wrapper = shallow(<SubscriptionDetailsPage match={match} namespace="default" />);
 
     expect(wrapper.find(DetailsPage).props().resources).toEqual([
-      {kind: ConfigMapModel.kind, name: 'ocs', namespace: olmNamespace, isList: false, prop: 'ocsConfigMap'},
-      {kind: ConfigMapModel.kind, namespace: 'default', isList: true, prop: 'configMaps'},
+      {kind: ConfigMapModel.kind, namespace: olmNamespace, isList: true, prop: 'globalConfigMaps'},
+      {kind: ConfigMapModel.kind, namespace: 'default', isList: true, prop: 'localConfigMaps'},
       {kind: referenceForModel(ClusterServiceVersionModel), namespace: 'default', isList: true, prop: 'clusterServiceVersions'},
     ]);
   });

--- a/frontend/integration-tests/tests/olm/etcd.scenario.ts
+++ b/frontend/integration-tests/tests/olm/etcd.scenario.ts
@@ -36,7 +36,7 @@ describe('Interacting with the etcd OCS', () => {
     await catalogView.entryRowFor('etcd').element(by.buttonText('Create Subscription')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
     const content = await yamlView.editorContent.getText();
-    const newContent = defaultsDeep({}, {metadata: {generateName: `${testName}-etcd-`, namespace: testName, labels: {[testLabel]: testName}}, spec: {channel: 'alpha', source: 'ocs', name: 'etcd'}}, safeLoad(content));
+    const newContent = defaultsDeep({}, {metadata: {generateName: `${testName}-etcd-`, namespace: testName, labels: {[testLabel]: testName}}, spec: {channel: 'alpha', source: 'rh-operators', name: 'etcd'}}, safeLoad(content));
     await yamlView.setContent(safeDump(newContent));
     await $('#save-changes').click();
     await crudView.isLoaded();

--- a/frontend/integration-tests/tests/olm/prometheus.scenario.ts
+++ b/frontend/integration-tests/tests/olm/prometheus.scenario.ts
@@ -35,7 +35,7 @@ describe('Interacting with the Prometheus OCS', () => {
     await catalogView.entryRowFor('Prometheus Operator').element(by.buttonText('Create Subscription')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
     const content = await yamlView.editorContent.getText();
-    const newContent = defaultsDeep({}, {metadata: {generateName: `${testName}-prometheus-`, namespace: testName, labels: {[testLabel]: testName}}, spec: {channel: 'alpha', source: 'ocs', name: 'prometheus'}}, safeLoad(content));
+    const newContent = defaultsDeep({}, {metadata: {generateName: `${testName}-prometheus-`, namespace: testName, labels: {[testLabel]: testName}}, spec: {channel: 'alpha', source: 'rh-operators', name: 'prometheus'}}, safeLoad(content));
     await yamlView.setContent(safeDump(newContent));
     await $('#save-changes').click();
     await crudView.isLoaded();

--- a/frontend/public/components/cloud-services/catalog-source.tsx
+++ b/frontend/public/components/cloud-services/catalog-source.tsx
@@ -212,7 +212,7 @@ export const CreateSubscriptionYAML: React.SFC<CreateSubscriptionYAMLProps> = (p
           generateName: ${pkg.packageName}-
           namespace: default
         spec:
-          source: ocs
+          source: ${createProps.ConfigMap.data.metadata.name}
           name: ${pkg.packageName}
           startingCSV: ${channel.currentCSV}
           channel: ${channel.name}

--- a/frontend/public/components/cloud-services/clusterserviceversion.tsx
+++ b/frontend/public/components/cloud-services/clusterserviceversion.tsx
@@ -167,7 +167,7 @@ export const ClusterServiceVersionsPage = connect(stateToProps)(
             {...this.props}
             namespace={this.props.match.params.ns}
             resources={[
-              {...csvResource, selector: {matchLabels: {[appCatalogLabel]: AppCatalog.ocs}}},
+              {...csvResource, selector: {matchLabels: {[appCatalogLabel]: AppCatalog.rhOperators}}},
               {kind: 'Deployment', namespaced: true, isList: true, prop: 'Deployment'},
               ...this.state.resourceDescriptions.map(crdDesc => ({kind: referenceForCRDDesc(crdDesc), namespaced: true, optional: true, prop: crdDesc.kind, selector: null})),
             ]}

--- a/frontend/public/components/cloud-services/index.tsx
+++ b/frontend/public/components/cloud-services/index.tsx
@@ -14,15 +14,9 @@ export { ClusterServiceVersionResourcesDetailsPage, ClusterServiceVersionResourc
 export { CatalogSourceDetailsPage, CreateSubscriptionYAML } from './catalog-source';
 export { SubscriptionsPage } from './subscription';
 
-export const catalogEntryVisibilityLabel = 'tectonic-visibility';
-export enum CatalogEntryVisibility {
-  catalogEntryVisibilityTectonicFeature = 'tectonic-feature',
-  catalogEntryVisibilityOCS = 'ocs',
-}
-
 export const appCatalogLabel = 'alm-catalog';
 export enum AppCatalog {
-  ocs = 'ocs',
+  rhOperators = 'rh-operators',
 }
 
 export enum ALMSpecDescriptors {

--- a/frontend/public/components/cloud-services/subscription.tsx
+++ b/frontend/public/components/cloud-services/subscription.tsx
@@ -190,8 +190,8 @@ export const SubscriptionDetailsPage: React.SFC<SubscriptionDetailsPageProps> = 
   const installedCSV: InstalledCSV = clusterServiceVersions => obj => clusterServiceVersions.find(csv => csv.metadata.name === _.get(obj, 'status.installedCSV'));
 
   type DetailsProps = {
-    configMaps?: ConfigMapKind[];
-    ocsConfigMap?: ConfigMapKind;
+    localConfigMaps?: ConfigMapKind[];
+    globalConfigMaps?: ConfigMapKind[];
     clusterServiceVersions?: ClusterServiceVersionKind[];
     obj: SubscriptionKind;
   };
@@ -202,17 +202,16 @@ export const SubscriptionDetailsPage: React.SFC<SubscriptionDetailsPageProps> = 
     kind={referenceForModel(SubscriptionModel)}
     name={props.match.params.name}
     pages={[
-      navFactory.details((detailsProps: DetailsProps) =>
-        <SubscriptionDetails
-          obj={detailsProps.obj}
-          pkg={pkgFor(detailsProps.configMaps.concat(!_.isEmpty(detailsProps.ocsConfigMap) ? [detailsProps.ocsConfigMap] : []))(detailsProps.obj)}
-          installedCSV={installedCSV(detailsProps.clusterServiceVersions)(detailsProps.obj)} />
-      ),
+      navFactory.details((detailsProps: DetailsProps) => <SubscriptionDetails
+        obj={detailsProps.obj}
+        pkg={pkgFor(detailsProps.localConfigMaps.concat(detailsProps.globalConfigMaps || []))(detailsProps.obj)}
+        installedCSV={installedCSV(detailsProps.clusterServiceVersions)(detailsProps.obj)}
+      />),
       navFactory.editYaml(),
     ]}
     resources={[
-      {kind: ConfigMapModel.kind, name: 'ocs', namespace: olmNamespace, isList: false, prop: 'ocsConfigMap'},
-      {kind: ConfigMapModel.kind, namespace: props.namespace, isList: true, prop: 'configMaps'},
+      {kind: ConfigMapModel.kind, namespace: olmNamespace, isList: true, prop: 'globalConfigMaps'},
+      {kind: ConfigMapModel.kind, namespace: props.namespace, isList: true, prop: 'localConfigMaps'},
       {kind: referenceForModel(ClusterServiceVersionModel), namespace: props.namespace, isList: true, prop: 'clusterServiceVersions'},
     ]}
     menuActions={Cog.factory.common} />;


### PR DESCRIPTION
### Description

Removes the hard-coded `CatalogSource` name ("ocs") and instead fetches all `ConfigMaps` in the global catalog namespace (`operator-lifecycle-manager`).

Addresses https://jira.coreos.com/browse/ALM-684