### PR TITLE
Remove unnecessary `poll` parameter

### DIFF
--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -219,7 +219,7 @@ class CreateInstanceForm extends React.Component<CreateInstanceFormProps, Create
 
 export const CreateInstance = (props) => {
   const resources = [
-    {kind: 'ClusterServiceClass', name: props.match.params.name, isList: false, prop: 'obj', poll: true},
+    {kind: 'ClusterServiceClass', name: props.match.params.name, isList: false, prop: 'obj'},
     {kind: 'ClusterServicePlan', isList: true, prop: 'plans', fieldSelector: `spec.clusterServiceClassRef.name=${props.match.params.name}`}
   ];
   return <Firehose resources={resources}>

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -149,9 +149,9 @@ export const Firehose = connect(
         });
       }
 
-      this.firehoses.forEach(({ id, query, k8sKind, isList, name, namespace, poll }) => isList
+      this.firehoses.forEach(({ id, query, k8sKind, isList, name, namespace }) => isList
         ? watchK8sList(id, query, k8sKind)
-        : watchK8sObject(id, name, namespace, query, k8sKind, poll)
+        : watchK8sObject(id, name, namespace, query, k8sKind)
       );
     }
 

--- a/frontend/public/module/k8s/k8s-actions.ts
+++ b/frontend/public/module/k8s/k8s-actions.ts
@@ -50,7 +50,7 @@ const actions = {
     return {id, name, value, type: types.filterList};
   },
 
-  watchK8sObject: (id, name, namespace, query, k8sType, poll = false) => (dispatch, getState) => {
+  watchK8sObject: (id, name, namespace, query, k8sType) => (dispatch, getState) => {
     if (id in REF_COUNTS) {
       REF_COUNTS[id] += 1;
       return nop;
@@ -72,9 +72,6 @@ const actions = {
     };
     POLLs[id] = setInterval(poller, 30 * 1000);
     poller();
-    if (poll) {
-      return;
-    }
 
     const {subprotocols} = getState().UI.get('impersonate', {});
 


### PR DESCRIPTION
Remove the `poll` flag added in #457. Service catalog resources now let you watch using a `fieldSelector` on `metadata.name`.

See https://jira.coreos.com/browse/CONSOLE-744

/assign @rhamilto 