### PR TITLE
Remove noise from the console logs

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -159,7 +159,6 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				} else {
 					proxiedHeader.Set("Sec-Websocket-Protocol", protocol)
 					subProtocol = protocol
-					log.Printf("subprotol: %v", protocol)
 				}
 			}
 		}


### PR DESCRIPTION
The WebSocket protocol logging is not helpful and makes the logs noisy.
Plus it's misspelled :)

/assign @jhadvig 