### PR TITLE
Add custom field template to create instance form

### DIFF
--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
+import * as classNames from 'classnames';
 import Form from 'react-jsonschema-form';
 
 import { LoadingBox } from '../utils/status-box';
@@ -17,6 +18,14 @@ import { ButtonBar } from '../utils/button-bar';
 const PARAMETERS_SECRET_KEY = 'parameters';
 
 const getAvailablePlans = (plans: any[]): any[] => _.reject(_.get(plans, 'data'), plan => plan.status.removedFromBrokerCatalog);
+
+const CustomFieldTemplate = ({id, classNames: klass, label, help, required, description, errors, children}) => <div className={klass}>
+  <label htmlFor={id} className={classNames('control-label', {'co-required': required})}>{label}</label>
+  {children}
+  <div className="help-block">{description}</div>
+  {help}
+  {errors}
+</div>;
 
 class CreateInstanceForm extends React.Component<CreateInstanceFormProps, CreateInstanceFormState> {
   constructor (props) {
@@ -184,12 +193,11 @@ class CreateInstanceForm extends React.Component<CreateInstanceFormProps, Create
           <div className="col-md-5 col-md-pull-7">
             <form className="co-create-service-instance">
               <div className="form-group co-create-service-instance__namespace">
-                {/* Use the same required style as used by react-jsonschema-form for consistency. */}
-                <label className="control-label" htmlFor="dropdown-selectbox">Namespace<span className="required">*</span></label>
+                <label className="control-label co-required" htmlFor="dropdown-selectbox">Namespace</label>
                 <NsDropdown selectedKey={this.state.namespace} onChange={this.onNamespaceChange} id="dropdown-selectbox" />
               </div>
               <div className="form-group co-create-service-instance__name">
-                <label className="control-label" htmlFor="name">Service Instance Name<span className="required">*</span></label>
+                <label className="control-label co-required" htmlFor="name">Service Instance Name</label>
                 <input className="form-control"
                   type="text"
                   onChange={this.onNameChange}
@@ -204,7 +212,7 @@ class CreateInstanceForm extends React.Component<CreateInstanceFormProps, Create
                   : planOptions}
               </div>
             </form>
-            <Form schema={parameters} onSubmit={this.save}>
+            <Form FieldTemplate={CustomFieldTemplate} schema={parameters} onSubmit={this.save}>
               <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress}>
                 <button type="submit" className="btn btn-primary">Create</button>
                 <Link to={resourcePathFromModel(ClusterServiceClassModel, serviceClass.metadata.name)} className="btn btn-default">Cancel</Link>

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -32,6 +32,7 @@
 @import "style/icons";
 @import "style/layout";
 @import "style/text";
+@import "style/forms";
 @import "style/status";
 
 // React Components

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -1,0 +1,4 @@
+label.co-required:after {
+  content: '*';
+  padding-left: 3px;
+}


### PR DESCRIPTION
Add a custom field template so we have more control over the styles used by react-jsonschema-form.

Before:

<img width="970" alt="create instance okd 2018-08-29 21-47-27" src="https://user-images.githubusercontent.com/1167259/44824790-77bc1a00-abd5-11e8-82e2-25a18c886df5.png">

After:

<img width="971" alt="create instance okd 2018-08-29 21-50-18" src="https://user-images.githubusercontent.com/1167259/44824803-87d3f980-abd5-11e8-928f-75db29381a7e.png">

/assign @rhamilto 