### PR TITLE
Operator Spec/Status Descriptor End-to-End Tests

### DIFF
--- a/frontend/__mocks__/k8sResourcesMocks.ts
+++ b/frontend/__mocks__/k8sResourcesMocks.ts
@@ -65,17 +65,11 @@ export const testClusterServiceVersion: ClusterServiceVersionKind = {
           'x-descriptors': [SpecCapability.podCount],
         }],
         statusDescriptors: [{
-          path: 'importantMetrics',
-          displayName: 'Important Metrics',
-          description: 'Important prometheus metrics ',
-          'x-descriptors': [StatusCapability.importantMetrics],
-          value: {
-            queries: [{
-              query: 'foobarbaz',
-              name: 'something',
-              type: 'gauge',
-            }],
-          }
+          path: 'podStatusus',
+          displayName: 'Member Status',
+          description: 'Status of each member pod ',
+          'x-descriptors': [StatusCapability.podStatuses],
+          value: {ready: ['pod-0', 'pod-1'], unhealthy: ['pod-2'], stopped: ['pod-3']},
         },
         {
           path: 'some-unfilled-path',

--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
@@ -5,7 +5,7 @@ import { match as RouterMatch } from 'react-router-dom';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash-es';
 
-import { ClusterServiceVersionResourceList, ClusterServiceVersionResourceListProps, ClusterServiceVersionResourcesPage, ClusterServiceVersionResourcesPageProps, ClusterServiceVersionResourceHeaderProps, ClusterServiceVersionResourcesDetailsState, ClusterServiceVersionResourceRowProps, ClusterServiceVersionResourceHeader, ClusterServiceVersionResourceRow, ClusterServiceVersionResourceDetails, ClusterServiceVersionPrometheusGraph, ClusterServiceVersionResourcesDetailsPageProps, ClusterServiceVersionResourcesDetailsProps, ClusterServiceVersionResourcesDetailsPage, PrometheusQueryTypes, ClusterServiceVersionResourceLink } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion-resource';
+import { ClusterServiceVersionResourceList, ClusterServiceVersionResourceListProps, ClusterServiceVersionResourcesPage, ClusterServiceVersionResourcesPageProps, ClusterServiceVersionResourceHeaderProps, ClusterServiceVersionResourcesDetailsState, ClusterServiceVersionResourceRowProps, ClusterServiceVersionResourceHeader, ClusterServiceVersionResourceRow, ClusterServiceVersionResourceDetails, ClusterServiceVersionResourcesDetailsPageProps, ClusterServiceVersionResourcesDetailsProps, ClusterServiceVersionResourcesDetailsPage, ClusterServiceVersionResourceLink } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion-resource';
 import { Resources } from '../../../public/components/operator-lifecycle-manager/k8s-resource';
 import { ClusterServiceVersionResourceKind } from '../../../public/components/operator-lifecycle-manager';
 import { StatusDescriptor } from '../../../public/components/operator-lifecycle-manager/descriptors/status';
@@ -13,7 +13,6 @@ import { SpecDescriptor } from '../../../public/components/operator-lifecycle-ma
 import { testCRD, testResourceInstance, testClusterServiceVersion, testOwnedResourceInstance } from '../../../__mocks__/k8sResourcesMocks';
 import { List, ColHead, ListHeader, DetailsPage, MultiListPage } from '../../../public/components/factory';
 import { Timestamp, LabelList, ResourceSummary, StatusBox, ResourceCog, Cog } from '../../../public/components/utils';
-import { Gauge, Scalar, Line, Bar } from '../../../public/components/graphs';
 import { referenceFor, K8sKind, referenceForModel } from '../../../public/module/k8s';
 import { ClusterServiceVersionModel } from '../../../public/models';
 
@@ -185,13 +184,6 @@ describe(ClusterServiceVersionResourceDetails.displayName, () => {
     expect(statusView.exists()).toBe(false);
   });
 
-  it('renders the specified important prometheus metrics as graphs', () => {
-    wrapper.setState({expanded: false});
-    const metric = wrapper.find('.co-clusterserviceversion-resource-details__section__metric');
-
-    expect(metric.exists()).toBe(true);
-  });
-
   it('does not render the extended information unless in expanded mode', () => {
     expect(wrapper.find(ResourceSummary).exists()).toBe(false);
   });
@@ -239,65 +231,6 @@ describe(ClusterServiceVersionResourceDetails.displayName, () => {
     wrapper = wrapper.setProps({clusterServiceVersion});
 
     expect(wrapper.find(SpecDescriptor).length).toEqual(1);
-  });
-});
-
-describe(ClusterServiceVersionPrometheusGraph.displayName, () => {
-
-  it('renders a counter', () => {
-    const query = {
-      'name': 'foo',
-      'unit': 'blargs',
-      'query': 'somequery',
-      'type': PrometheusQueryTypes.Counter,
-    };
-    const wrapper = shallow(<ClusterServiceVersionPrometheusGraph query={query} />);
-
-    expect(wrapper.is(Scalar)).toBe(true);
-  });
-
-  it('renders a gauge', () => {
-    const query = {
-      'name': 'foo',
-      'query': 'somequery',
-      'type': PrometheusQueryTypes.Gauge,
-    };
-    const wrapper = shallow(<ClusterServiceVersionPrometheusGraph query={query} />);
-
-    expect(wrapper.is(Gauge)).toBe(true);
-  });
-
-  it('renders a line', () => {
-    const query = {
-      'name': 'foo',
-      'query': 'somequery',
-      'type': PrometheusQueryTypes.Line,
-    };
-    const wrapper = shallow(<ClusterServiceVersionPrometheusGraph query={query} />);
-
-    expect(wrapper.is(Line)).toBe(true);
-  });
-
-  it('renders a bar', () => {
-    const query = {
-      'name': 'foo',
-      'query': 'somequery',
-      'type': PrometheusQueryTypes.Bar,
-    };
-    const wrapper = shallow(<ClusterServiceVersionPrometheusGraph query={query} />);
-
-    expect(wrapper.is(Bar)).toBe(true);
-  });
-
-  it('handles unknown kinds of metrics', () => {
-    const query: any = {
-      'name': 'foo',
-      'query': 'somequery',
-      'type': 'unknown',
-    };
-    const wrapper = shallow(<ClusterServiceVersionPrometheusGraph query={query} />);
-
-    expect(wrapper.html()).toBe('<span>Unknown graph type: unknown</span>');
   });
 });
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/index.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/index.spec.tsx
@@ -30,17 +30,17 @@ describe(StatusDescriptor.displayName, () => {
   it('renders a conditions status', () => {
     const value = [{
       lastUpdateTime: '2017-10-16 12:00:00',
-      phase: 'somephase',
+      type: 'SomeType',
     }];
     descriptor['x-descriptors'] = [StatusCapability.conditions];
     wrapper = wrapper.setProps({descriptor, value});
 
-    expect(wrapper.find('dd').childAt(0).shallow().text()).toEqual('somephase');
+    expect(wrapper.find('dd').childAt(0).shallow().text()).toEqual('SomeType');
   });
 
   it('renders a link status', () => {
     const value = 'https://example.com';
-    descriptor['x-descriptors'] = [StatusCapability.tectonicLink];
+    descriptor['x-descriptors'] = [StatusCapability.w3Link];
     wrapper = wrapper.setProps({descriptor, value});
 
     expect(wrapper.find('dd').childAt(0).shallow().text()).toEqual('example.com');

--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -89,7 +89,7 @@ export const config: Config = {
     filter: ['tests/base.scenario.ts', 'tests/filter.scenario.ts'],
     annotation: ['tests/base.scenario.ts', 'tests/modal-annotations.scenario.ts'],
     crud: ['tests/base.scenario.ts', 'tests/crud.scenario.ts', 'tests/filter.scenario.ts', 'tests/modal-annotations.scenario.ts', 'tests/environment.scenario.ts'],
-    olm: ['tests/base.scenario.ts', 'tests/olm/catalog.scenario.ts', 'tests/olm/etcd.scenario.ts', 'tests/olm/prometheus.scenario.ts'],
+    olm: ['tests/base.scenario.ts', 'tests/olm/descriptors.scenario.ts', 'tests/olm/catalog.scenario.ts', 'tests/olm/etcd.scenario.ts', 'tests/olm/prometheus.scenario.ts'],
     olmUpgrade: ['tests/base.scenario.ts', 'tests/olm/update-channel-approval.scenario.ts'],
     performance: ['tests/base.scenario.ts', 'tests/performance.scenario.ts'],
     all: ['tests/base.scenario.ts', 'tests/crud.scenario.ts', 'tests/olm/**/*.scenario.ts', 'tests/filter.scenario.ts', 'tests/modal-annotations.scenario.ts'],

--- a/frontend/integration-tests/tests/olm/descriptors.scenario.ts
+++ b/frontend/integration-tests/tests/olm/descriptors.scenario.ts
@@ -1,0 +1,195 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import { execSync } from 'child_process';
+import { browser, $$ } from 'protractor';
+import { safeDump } from 'js-yaml';
+
+import { appHost, testName, checkLogs, checkErrors } from '../../protractor.conf';
+import { SpecCapability, StatusCapability } from '../../../public/components/operator-lifecycle-manager/descriptors/types';
+import * as crudView from '../../views/crud.view';
+
+const defaultValueFor = <C extends SpecCapability | StatusCapability>(capability: C) => {
+  switch (capability) {
+    case SpecCapability.podCount: return 3;
+    case SpecCapability.endpointList: return [{port: 8080, scheme: 'TCP'}];
+    case SpecCapability.label: return 'app=openshift';
+    case SpecCapability.resourceRequirements: return {limits: {cpu: '500m', memory: '50Mi'}, requests: {cpu: '500m', memory: '50Mi'}};
+    case SpecCapability.namespaceSelector: return {matchNames: ['default']};
+
+    case StatusCapability.podStatuses: return {ready: ['pod-0', 'pod-1'], unhealthy: ['pod-2'], stopped: ['pod-3']};
+    case StatusCapability.podCount: return 3;
+    case StatusCapability.w3Link: return 'https://google.com';
+    case StatusCapability.conditions: return [
+      {type: 'Available', status: 'True', lastUpdateTime: '2018-08-22T23:27:55Z', lastTransitionTime: '2018-08-22T23:27:55Z', reason: 'AppReady', message: 'App is ready.'}
+    ];
+    case StatusCapability.text: return 'Some text';
+    case StatusCapability.prometheusEndpoint: return 'my-svc.my-namespace.svc.cluster.local';
+    case StatusCapability.k8sPhase: return 'Available';
+    case StatusCapability.k8sPhaseReason: return 'AppReady';
+
+    default: return null;
+  }
+};
+
+describe('Using OLM descriptor components', () => {
+  const testLabel = 'automatedTestName';
+  const prefixedCapabilities = new Set([SpecCapability.selector, SpecCapability.k8sResourcePrefix, StatusCapability.k8sResourcePrefix]);
+  const testCRD = {
+    apiVersion: 'apiextensions.k8s.io/v1beta1',
+    kind: 'CustomResourceDefinition',
+    metadata: {
+      name: 'apps.test.tectonic.com',
+      labels: {[testLabel]: testName},
+    },
+    spec: {
+      group: 'test.tectonic.com',
+      version: 'v1',
+      scope: 'Namespaced',
+      names: {
+        plural: 'apps',
+        singular: 'app',
+        kind: 'App',
+        listKind: 'Apps',
+      }
+    }
+  };
+  const testCR = {
+    apiVersion: `${testCRD.spec.group}/${testCRD.spec.version}`,
+    kind: testCRD.spec.names.kind,
+    metadata: {
+      name: 'olm-descriptors-test',
+      namespace: testName,
+      labels: {[testLabel]: testName},
+    },
+    spec: {
+      ...Object.keys(SpecCapability).filter(c => !prefixedCapabilities.has(SpecCapability[c])).reduce((acc, cur) => ({
+        ...acc, [cur]: defaultValueFor(SpecCapability[cur])
+      }), {}),
+    },
+    status: {
+      ...Object.keys(StatusCapability).filter(c => !prefixedCapabilities.has(StatusCapability[c])).reduce((acc, cur) => ({
+        ...acc, [cur]: defaultValueFor(StatusCapability[cur])
+      }), {}),
+    },
+  };
+  const testCSV = {
+    apiVersion: 'operators.coreos.com/v1alpha1',
+    kind: 'ClusterServiceVersion',
+    metadata: {
+      name: 'olm-descriptors-test',
+      namespace: testName,
+      labels: {[testLabel]: testName},
+    },
+    spec: {
+      displayName: 'Test Operator',
+      install: {
+        strategy: 'deployment',
+        spec: {
+          permissions: [],
+          deployments: [{
+            name: 'test-operator',
+            spec: {
+              replicas: 1,
+              selector: {
+                matchLabels: {
+                  name: 'test-operator-alm-owned'
+                }
+              },
+              template: {
+                metadata: {
+                  name: 'test-operator-alm-owned',
+                  labels: {
+                    name: 'test-operator-alm-owned'
+                  }
+                },
+                spec: {
+                  serviceAccountName: 'test-operator',
+                  containers: [{
+                    name: 'test-operator',
+                    image: 'nginx',
+                  }]
+                }
+              }
+            }
+          }]
+        }
+      },
+      customresourcedefinitions: {
+        owned: [
+          {
+            name: testCRD.metadata.name,
+            version: testCRD.spec.version,
+            kind: testCRD.spec.names.kind,
+            displayName: testCRD.spec.names.kind,
+            description: 'Application instance for testing descriptors',
+            resources: [],
+            specDescriptors: Object.keys(SpecCapability).filter(c => !prefixedCapabilities.has(SpecCapability[c])).map(capability => ({
+              description: `Spec descriptor for ${capability}`,
+              displayName: capability,
+              path: capability,
+              'x-descriptors': [SpecCapability[capability]],
+            })),
+            statusDescriptors: Object.keys(StatusCapability).filter(c => !prefixedCapabilities.has(StatusCapability[c])).map(capability => ({
+              description: `Status descriptor for ${capability}`,
+              displayName: capability,
+              path: capability,
+              'x-descriptors': [StatusCapability[capability]],
+            })),
+          }
+        ]
+      }
+    }
+  };
+
+  beforeAll(async() => {
+    console.log('\nUsing ClusterServiceVersion:');
+    console.log(safeDump(testCSV));
+    console.log('\nUsing custom resource:');
+    console.log(safeDump(testCR));
+
+    execSync(`echo '${JSON.stringify(testCRD)}' | kubectl create -f -`);
+    execSync(`echo '${JSON.stringify(testCSV)}' | kubectl create -f -`);
+    execSync(`echo '${JSON.stringify(testCR)}' | kubectl create -f -`);
+
+    await browser.get(`${appHost}/ns/${testName}/clusterserviceversions/${testCSV.metadata.name}/instances`);
+    await crudView.isLoaded();
+  });
+
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+
+  afterAll(() => {
+    execSync(`kubectl delete crd ${testCRD.metadata.name}`);
+    execSync(`kubectl delete -n ${testName} clusterserviceversion ${testCSV.metadata.name}`);
+  });
+
+  it('displays list containing custom resource', async() => {
+    expect(crudView.rowForName(testCR.metadata.name).isDisplayed()).toBe(true);
+  });
+
+  it('displays detail view for custom resource', async() => {
+    const {group, version, names: {kind}} = testCRD.spec;
+    await browser.get(`${appHost}/ns/${testName}/clusterserviceversions/${testCSV.metadata.name}/${group}:${version}:${kind}/${testCR.metadata.name}`);
+    await crudView.isLoaded();
+
+    expect(crudView.resourceTitle.getText()).toEqual(testCR.metadata.name);
+  });
+
+  testCSV.spec.customresourcedefinitions.owned[0].specDescriptors.forEach(descriptor => {
+    const label = $$('dt').filter(dt => dt.getText().then(text => text.toLowerCase() === descriptor.displayName.toLowerCase())).first();
+
+    it(`displays spec descriptor for ${descriptor.displayName}`, () => {
+      expect(label.isDisplayed()).toBe(true);
+    });
+  });
+
+  testCSV.spec.customresourcedefinitions.owned[0].statusDescriptors.forEach(descriptor => {
+    const label = $$('dt').filter(dt => dt.getText().then(text => text.toLowerCase() === descriptor.displayName.toLowerCase())).first();
+
+    it(`displays status descriptor for ${descriptor.displayName}`, () => {
+      expect(label.isDisplayed()).toBe(true);
+    });
+  });
+});

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/README.md
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/README.md
@@ -86,10 +86,10 @@ $ yarn run test
 #### E2E Tests
 
 Located at `frontend/integration-tests/tests/olm`.
+To sufficiently test your component, modify `descriptors.scenario.ts` and add a new case to `defaultValueFor` to provide a default value for your descriptor.
+
 Run the OLM end-to-end tests against a cluster with OLM installed:
 
 ```shell
 $ yarn run test-suite --suite olm
 ```
-
-TODO(alecmerdler0): Add all possible descriptors to a `ClusterServiceVersion` and run tests against it.

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/status/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/status/index.tsx
@@ -16,8 +16,9 @@ const Default: React.SFC<StatusCapabilityProps> = ({value}) => _.isEmpty(value) 
 
 const PodStatuses: React.SFC<StatusCapabilityProps> = (props) => <PodStatusChart fetcher={() => props.value} statusDescriptor={props.descriptor} />;
 
+// FIXME(alecmerdler): Need to revisit this component to show a table of conditions
 const Conditions: React.SFC<StatusCapabilityProps> = ({value}) => !_.isEmpty(value)
-  ? <span>{value.reduce((latest, next) => new Date(latest.lastUpdateTime) < new Date(next.lastUpdateTime) ? latest : next).phase}</span>
+  ? <span>{value.reduce((latest, next) => new Date(latest.lastUpdateTime) < new Date(next.lastUpdateTime) ? latest : next).type}</span>
   : <span className="text-muted">None</span>;
 
 const Link: React.SFC<StatusCapabilityProps> = ({value}) => <a href={value}>{value.replace(/https?:\/\//, '')}</a>;
@@ -31,7 +32,6 @@ const K8sResourceLink: React.SFC<StatusCapabilityProps> = (props) => <ResourceLi
 const capabilityComponents = ImmutableMap<StatusCapability, React.ComponentType<StatusCapabilityProps>>()
   .set(StatusCapability.podStatuses, PodStatuses)
   .set(StatusCapability.conditions, Conditions)
-  .set(StatusCapability.tectonicLink, Link)
   .set(StatusCapability.w3Link, Link)
   .set(StatusCapability.k8sPhase, K8sPhase)
   .set(StatusCapability.k8sPhaseReason, K8sPhaseReason)

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/types.ts
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/types.ts
@@ -13,15 +13,12 @@ export enum SpecCapability {
 }
 
 export enum StatusCapability {
-  metrics = 'urn:alm:descriptor:com.tectonic.ui:metrics',
   podStatuses = 'urn:alm:descriptor:com.tectonic.ui:podStatuses',
   podCount = 'urn:alm:descriptor:com.tectonic.ui:podCount',
   w3Link = 'urn:alm:descriptor:org.w3:link',
-  tectonicLink = 'urn:alm:descriptor:com.tectonic.ui:important.link',
   conditions = 'urn:alm:descriptor:io.kubernetes.conditions',
-  importantMetrics = 'urn:alm:descriptor:com.tectonic.ui:metrics',
   text = 'urn:alm:descriptor:text',
-  prometheus = 'urn:alm:descriptor:io.prometheus:api.v1',
+  prometheusEndpoint = 'urn:alm:descriptor:prometheusEndpoint',
   k8sPhase = 'urn:alm:descriptor:io.kubernetes.phase',
   k8sPhaseReason = 'urn:alm:descriptor:io.kubernetes.phase:reason',
   // Prefix for all kubernetes resource status descriptors.


### PR DESCRIPTION
### Description

Adds e2e scenario which tests all spec/status descriptor components using a single `ClusterServiceVersion`.

### Changes

- Adds e2e tests for all spec/status descriptors
-  updates `operator-lifecycle-manager/descriptors/README.md` with instructions on how to add tests for new capability components
- Removes Prometheus-based status descriptor (never used, need to align with Operator monitoring)

### Screenshots

**Detail view of custom resource with all spec/status descriptors:**
![screenshot_20180829_160308](https://user-images.githubusercontent.com/11700385/44812362-0c5a5400-aba5-11e8-9cc9-acc877253f43.png)

Addresses https://jira.coreos.com/browse/ALM-691