### PR TITLE
Empty value secret not displayed properly

### DIFF
--- a/frontend/public/components/configmap-and-secret-data.jsx
+++ b/frontend/public/components/configmap-and-secret-data.jsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import * as _ from 'lodash-es';
 
 import { CopyToClipboard, EmptyBox, SectionHeading } from './utils';
 
@@ -31,7 +30,7 @@ export class SecretData extends React.PureComponent {
   }
 
   getValue(rawValue) {
-    if (_.isNil(rawValue)) {
+    if (!rawValue) {
       return <span className="text-muted">No value</span>;
     }
 


### PR DESCRIPTION
After creating a secret without a value and checking the value in the display page, the `No value` muted text is shown for a blink of a second, but afterwards `CopyToClipboard` component is rendered instead.
Updated the check to handle both null and empty string.

Demo:
![secrets okd](https://user-images.githubusercontent.com/1668218/44988604-90d51a00-af8b-11e8-9824-0fccc74eacec.gif)

/assign @spadgett 