### PR TITLE
Create/Edit generic secret

### DIFF
--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -9,32 +9,12 @@ import { SecretType } from './secrets/create-secret';
 
 export const WebHookSecretKey = 'WebHookSecretKey';
 
-// Edit in YAML if not editing:
-// - source secrets
-// - image secret, both formats:
-//     - kubernetes.io/dockerconfigjson
-//     - kubernetes.io/dockercfg
-// - webhook secret with one key.
-const editInYaml = obj => {
-  switch (obj.type) {
-    case SecretType.basicAuth:
-    case SecretType.sshAuth:
-    case SecretType.dockercfg:
-    case SecretType.dockerconfigjson:
-      return false;
-    case SecretType.opaque:
-      return !_.has(obj, ['data', WebHookSecretKey]) || _.size(obj.data) !== 1;
-    default:
-      return true;
-  }
-};
-
 const menuActions = [
   Cog.factory.ModifyLabels,
   Cog.factory.ModifyAnnotations,
   (kind, obj) => ({
     label: `Edit ${kind.label}`,
-    href: editInYaml(obj) ? `${resourceObjPath(obj, kind.kind)}/edit-yaml` : `${resourceObjPath(obj, kind.kind)}/edit`,
+    href: `${resourceObjPath(obj, kind.kind)}/edit`,
   }),
   Cog.factory.Delete,
 ];
@@ -126,8 +106,8 @@ const filters = [{
 
 const SecretsPage = props => {
   const createItems = {
+    generic: 'Key/Value Secret',
     image: 'Image Pull Secret',
-    // generic: 'Create Key/Value Secret',
     source: 'Source Secret',
     webhook: 'Webhook Secret',
     yaml: 'Secret from YAML',

--- a/frontend/public/components/secrets/_create-secret.scss
+++ b/frontend/public/components/secrets/_create-secret.scss
@@ -3,7 +3,7 @@
   margin-bottom: 10px;
 }
 
-.co-create-image-secret__form-wrapper {
+.co-create-secret__form-entry-wrapper {
   position: relative;
 }
 
@@ -12,19 +12,19 @@
 }
 
 .co-create-secret-form__link--remove-entry {
-  position: absolute;
-  right: 0;
+  display: flex;
+  flex-flow: row-reverse;
 }
 
 .co-create-image-secret__form {
   margin-bottom: 25px;
 }
 
-.co-create-secret-form__link--remove-entry + .co-create-image-secret__form {
-  padding-top: 25px;
-}
-
-.co-create-image-secret__form-wrapper + .co-create-image-secret__form-wrapper {
+.co-create-secret__form-entry-wrapper + .co-create-secret__form-entry-wrapper {
   border-top: 1px solid #ccc;
   padding-top: 10px;
+}
+
+.co-create-generic-secret__form .co-file-dropzone__textarea {
+  min-height: 80px;
 }

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -8,6 +8,7 @@ import { k8sCreate, k8sUpdate, K8sResourceKind } from '../../module/k8s';
 import { ButtonBar, Firehose, history, kindObj, StatusBox, LoadingBox, Dropdown } from '../utils';
 import { formatNamespacedRouteForResource } from '../../ui/ui-actions';
 import { AsyncComponent } from '../utils/async';
+import { WebHookSecretKey } from '../secret';
 
 enum SecretTypeAbstraction {
   generic = 'generic',
@@ -39,7 +40,7 @@ const secretFormExplanation = {
   [SecretTypeAbstraction.webhook]: 'Webhook secrets allow you to authenticate a webhook trigger.',
 };
 
-const toDefaultSecretType = (typeAbstraction: SecretTypeAbstraction) => {
+const toDefaultSecretType = (typeAbstraction: SecretTypeAbstraction): SecretType => {
   switch (typeAbstraction) {
     case SecretTypeAbstraction.source:
       return SecretType.basicAuth;
@@ -51,7 +52,8 @@ const toDefaultSecretType = (typeAbstraction: SecretTypeAbstraction) => {
 };
 
 
-const toTypeAbstraction = (type: SecretType): SecretTypeAbstraction => {
+const toTypeAbstraction = (obj): SecretTypeAbstraction => {
+  const { data, type } = obj;
   switch (type) {
     case (SecretType.basicAuth):
     case (SecretType.sshAuth):
@@ -60,7 +62,10 @@ const toTypeAbstraction = (type: SecretType): SecretTypeAbstraction => {
     case (SecretType.dockercfg):
       return SecretTypeAbstraction.image;
     default:
-      return SecretTypeAbstraction.webhook;
+      if (data[WebHookSecretKey] && _.size(data) === 1) {
+        return SecretTypeAbstraction.webhook;
+      }
+      return SecretTypeAbstraction.generic;
   }
 };
 
@@ -91,7 +96,9 @@ const withSecretForm = (SubForm) => class SecretFormComponent extends React.Comp
       secret: secret,
       inProgress: false,
       type: defaultSecretType,
-      stringData: _.mapValues(_.get(props.obj, 'data'), window.atob),
+      stringData: _.mapValues(_.get(props.obj, 'data'), (value) => {
+        return value ? window.atob(value) : '';
+      }),
       disableForm: false,
     };
     this.onDataChanged = this.onDataChanged.bind(this);
@@ -358,11 +365,13 @@ export type CreateConfigSubformState = {
   isDockerconfigjson: boolean,
   hasDuplicate: boolean,
   secretEntriesArray: {
-    address: string,
-    username: string,
-    password: string,
-    email: string,
-    auth: string,
+    entry: {
+      address: string,
+      username: string,
+      password: string,
+      email: string,
+      auth: string,
+    }
     uid: string,
   }[],
 };
@@ -380,11 +389,13 @@ class CreateConfigSubform extends React.Component<CreateConfigSubformProps, Crea
   }
   newImageSecretEntry() {
     return {
-      address: '',
-      username: '',
-      password: '',
-      email: '',
-      auth: '',
+      entry: {
+        address: '',
+        username: '',
+        password: '',
+        email: '',
+        auth: '',
+      },
       uid: _.uniqueId(),
     };
   }
@@ -398,11 +409,13 @@ class CreateConfigSubform extends React.Component<CreateConfigSubformProps, Crea
       const decodedAuth = window.atob(_.get(v, 'auth', ''));
       const parsedAuth = _.isEmpty(decodedAuth) ? _.fill(Array(2), '') : _.split(decodedAuth, ':');
       imageSecretArray.push({
-        address: k,
-        username: _.get(v, 'username', parsedAuth[0]),
-        password: _.get(v, 'password', parsedAuth[1]),
-        email: _.get(v, 'email', ''),
-        auth: _.get(v, 'auth', ''),
+        entry: {
+          address: k,
+          username: _.get(v, 'username', parsedAuth[0]),
+          password: _.get(v, 'password', parsedAuth[1]),
+          email: _.get(v, 'email', ''),
+          auth: _.get(v, 'auth', ''),
+        },
         uid: _.get(v, 'uid', _.uniqueId()),
       });
     });
@@ -410,31 +423,24 @@ class CreateConfigSubform extends React.Component<CreateConfigSubformProps, Crea
   }
   imageSecretArrayToObject(imageSecretArray) {
     const imageSecretsObject = {};
-    _.each(imageSecretArray, (entry) => {
-      const entryCredentials = {
-        username: entry.username,
-        password: entry.password,
-        auth: entry.auth,
-        email: entry.email
-      };
-      imageSecretsObject[entry.address] = entryCredentials;
+    _.each(imageSecretArray, (value) => {
+      imageSecretsObject[value.entry.address] = _.pick(value.entry, ['username', 'password', 'auth', 'email']);
     });
     return imageSecretsObject;
-  }
-  // Image secrets entry address can't be duplicate in the secret, else the first one will be deleted.
-  checkEntryAddressForDuplicates(updatedData, updatedIndex) {
-    return this.state.secretEntriesArray.some((entry, i) => i !== updatedIndex && _.isEqual(entry.address, updatedData.address));
   }
   propagateEntryChange(secretEntriesArray) {
     const imageSecretObject = this.imageSecretArrayToObject(secretEntriesArray);
     this.props.onChange(this.state.isDockerconfigjson ? {[AUTHS_KEY]: imageSecretObject} : imageSecretObject);
   }
-  onDataChanged(updatedEntryData, entryID) {
+  onDataChanged(updatedEntry, entryID) {
     const updatedSecretEntriesArray = [...this.state.secretEntriesArray];
-    updatedSecretEntriesArray.splice(entryID, 1, updatedEntryData);
+    const updatedEntryData = {
+      uid: updatedSecretEntriesArray[entryID].uid,
+      entry: updatedEntry,
+    };
+    updatedSecretEntriesArray[entryID] = updatedEntryData;
     this.setState({
       secretEntriesArray: updatedSecretEntriesArray,
-      hasDuplicate: this.checkEntryAddressForDuplicates(updatedEntryData, entryID)
     }, () => {
       this.propagateEntryChange(this.state.secretEntriesArray);
     });
@@ -456,12 +462,14 @@ class CreateConfigSubform extends React.Component<CreateConfigSubformProps, Crea
     });
   }
   render() {
-    const secretEntriesList = _.map(this.state.secretEntriesArray, (entry, index) => {
-      return <div className="co-create-image-secret__form-wrapper" key={entry.uid}>
-        {_.size(this.state.secretEntriesArray) > 1 && <button className="btn btn-link co-create-secret-form__link--remove-entry" type="button" key={entry.uid} onClick={() => this.removeEntry(index)}>
-          <i className="fa fa-minus-circle" aria-hidden="true" /> Remove Credentials
-        </button>}
-        <ConfigEntryForm id={index} key={`${entry.uid}-form`} entry={entry} onChange={this.onDataChanged} />
+    const secretEntriesList = _.map(this.state.secretEntriesArray, (entryData, index) => {
+      return <div className="co-create-secret__form-entry-wrapper" key={entryData.uid}>
+        {_.size(this.state.secretEntriesArray) > 1 && <div className="co-create-secret-form__link--remove-entry">
+          <button className="btn btn-link" type="button" onClick={() => this.removeEntry(index)}>
+            <i className="fa fa-minus-circle" aria-hidden="true" /> Remove Credentials
+          </button>
+        </div>}
+        <ConfigEntryForm id={index} entry={entryData.entry} onChange={this.onDataChanged} />
       </div>;
     });
     return (
@@ -470,7 +478,6 @@ class CreateConfigSubform extends React.Component<CreateConfigSubformProps, Crea
         <button className="btn btn-link co-create-secret-form__link--add-entry" type="button" onClick={() => this.addEntry()}>
           <i className="fa fa-plus-circle" aria-hidden="true" /> Add Credentials
         </button>
-        { this.state.hasDuplicate && <div className="co-create-secret-warning">Updated <b>Registry Server Address</b> is duplicate. Remove it, or it will be removed upon saving.</div> }
       </React.Fragment>
     );
   }
@@ -509,7 +516,8 @@ class UploadConfigSubform extends React.Component<UploadConfigSubformProps, Uplo
         id="docker-config"
         label="Configuration File"
         inputFieldHelpText="Upload a .dockercfg or .docker/config.json file."
-        textareaFieldHelpText="File with credentials and other configuration for connecting to a secured image registry." />
+        textareaFieldHelpText="File with credentials and other configuration for connecting to a secured image registry."
+        isRequired={true} />
       { this.state.parseError && <div className="co-create-secret-warning">Configuration file should be in JSON format.</div> }
     </React.Fragment>;
   }
@@ -671,19 +679,184 @@ class SSHAuthSubform extends React.Component<SSHAuthSubformProps, SSHAuthSubform
       inputFileData={this.state['ssh-privatekey']}
       id="ssh-privatekey"
       label="SSH Private Key"
-      inputFieldHelpText="Drag and drop your private SSH key here or browse to upload it."
-      textareaFieldHelpText="Private SSH key file for Git authentication." />;
+      inputFieldHelpText="Drag and drop file with your private SSH key here or browse to upload it."
+      textareaFieldHelpText="Private SSH key file for Git authentication."
+      isRequired={true} />;
   }
 }
 
-const secretFormFactory = (secretType: SecretTypeAbstraction) => {
+export type KeyValueEntryFormState = {
+  key: string,
+  value: string,
+};
+
+export type KeyValueEntryFormProps = {
+  entry: KeyValueEntryFormState
+  id: number,
+  onChange: Function,
+};
+
+export type GenericSecretFormProps = {
+  onChange: Function,
+  stringData: {
+    [key: string]: string
+  },
+  secretType: SecretType,
+  isCreate: boolean,
+};
+
+export type GenericSecretFormState = {
+  secretEntriesArray: {
+    entry: KeyValueEntryFormState,
+    uid: string,
+  }[],
+};
+
+class GenericSecretForm extends React.Component<GenericSecretFormProps, GenericSecretFormState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      secretEntriesArray: this.genericSecretObjectToArray(this.props.stringData),
+    };
+    this.onDataChanged = this.onDataChanged.bind(this);
+  }
+  newGenericSecretEntry() {
+    return {
+      entry: {
+        key: '',
+        value: '',
+      },
+      uid: _.uniqueId(),
+    };
+  }
+  genericSecretObjectToArray(genericSecretObject) {
+    if (_.isEmpty(genericSecretObject)) {
+      return [this.newGenericSecretEntry()];
+    }
+    return _.map(genericSecretObject, (value, key) => {
+      return { uid: _.uniqueId(),
+        entry: {
+          key: key,
+          value: value,
+        },
+      };
+    });
+  }
+  genericSecretArrayToObject(genericSecretArray) {
+    return _.reduce(genericSecretArray, (acc, k) => (_.assign(acc, {[k.entry.key]: k.entry.value})), {});
+  }
+  onDataChanged (updatedEntry, entryID) {
+    const updatedSecretEntriesArray = [...this.state.secretEntriesArray];
+    const updatedEntryData = {
+      uid: updatedSecretEntriesArray[entryID].uid,
+      entry: updatedEntry,
+    };
+    updatedSecretEntriesArray[entryID] = updatedEntryData;
+    this.setState({
+      secretEntriesArray: updatedSecretEntriesArray,
+    }, () => this.props.onChange({
+      stringData: this.genericSecretArrayToObject(this.state.secretEntriesArray),
+      type: SecretType.opaque,
+    }));
+  }
+  removeEntry(entryID){
+    const updatedSecretEntriesArray = [...this.state.secretEntriesArray];
+    updatedSecretEntriesArray.splice(entryID, 1);
+    this.setState({
+      secretEntriesArray: updatedSecretEntriesArray
+    }, () => this.props.onChange({
+      stringData: this.genericSecretArrayToObject(this.state.secretEntriesArray),
+      type: SecretType.opaque,
+    }));
+  }
+  addEntry(){
+    this.setState({
+      secretEntriesArray: _.concat(this.state.secretEntriesArray, this.newGenericSecretEntry())
+    }, () => this.props.onChange({
+      stringData: this.genericSecretArrayToObject(this.state.secretEntriesArray),
+      type: SecretType.opaque,
+    }));
+  }
+  render() {
+    const secretEntriesList = _.map(this.state.secretEntriesArray, (entryData, index) => {
+      return <div className="co-create-secret__form-entry-wrapper" key={entryData.uid}>
+        {_.size(this.state.secretEntriesArray) > 1 && <div className="co-create-secret-form__link--remove-entry">
+          <button className="btn btn-link" type="button" onClick={() => this.removeEntry(index)}>
+            <i className="fa fa-minus-circle" aria-hidden="true" /> Remove Key/Value
+          </button>
+        </div>}
+        <KeyValueEntryForm id={index} entry={entryData.entry} onChange={this.onDataChanged} />
+      </div>;
+    });
+    return (
+      <React.Fragment>
+        {secretEntriesList}
+        <button className="btn btn-link co-create-secret-form__link--add-entry" type="button" onClick={() => this.addEntry()}>
+          <i className="fa fa-plus-circle" aria-hidden="true" /> Add Key/Value
+        </button>
+      </React.Fragment>
+    );
+  }
+}
+
+class KeyValueEntryForm extends React.Component<KeyValueEntryFormProps, KeyValueEntryFormState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      key: props.entry.key,
+      value: props.entry.value,
+    };
+    this.onValueChange = this.onValueChange.bind(this);
+    this.onKeyChange = this.onKeyChange.bind(this);
+  }
+  onValueChange(fileData) {
+    this.setState({
+      value: fileData,
+    }, () => this.props.onChange(this.state, this.props.id));
+  }
+  onKeyChange(event) {
+    this.setState({
+      key: event.target.value,
+    }, () => this.props.onChange(this.state, this.props.id));
+  }
+  render() {
+    return <div className="co-create-generic-secret__form">
+      <div className="form-group">
+        <label className="control-label" htmlFor={`${this.props.id}-key`}>Key</label>
+        <div>
+          <input className="form-control"
+            id={`${this.props.id}-key`}
+            type="text"
+            name="key"
+            onChange={this.onKeyChange}
+            value={this.state.key}
+            required />
+        </div>
+      </div>
+      <div className="form-group">
+        <div>
+          <DroppableFileInput
+            onChange={this.onValueChange}
+            inputFileData={this.state.value}
+            id={`${this.props.id}-value`}
+            label="Value"
+            inputFieldHelpText="Drag and drop file with your value here or browse to upload it." />
+        </div>
+      </div>
+    </div>;
+  }
+}
+
+const secretFormFactory = (secretType: SecretTypeAbstraction, ) => {
   switch (secretType) {
     case SecretTypeAbstraction.source:
       return withSecretForm(SourceSecretForm);
     case SecretTypeAbstraction.image:
       return withSecretForm(ImageSecretForm);
-    default:
+    case SecretTypeAbstraction.webhook:
       return withSecretForm(WebHookSecretForm);
+    default:
+      return withSecretForm(GenericSecretForm);
   }
 };
 
@@ -691,7 +864,7 @@ const SecretLoadingWrapper = props => {
   if (!props.obj.loaded) {
     return <LoadingBox />;
   }
-  const secretTypeAbstraction = toTypeAbstraction(props.obj.data.type);
+  const secretTypeAbstraction = toTypeAbstraction(props.obj.data);
   const SecretFormComponent = secretFormFactory(secretTypeAbstraction);
   const fixed = _.reduce(props.fixedKeys, (acc, k) => ({...acc, k: _.get(props.obj.data, k)}), {});
   return <StatusBox {...props.obj}>

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -26,7 +26,7 @@ export class FileInput extends React.Component<FileInputProps, FileInputState> {
     this.readFile(event.target.files[0]);
   }
   render() {
-    const { connectDropTarget, isOver, canDrop, id } = this.props;
+    const { connectDropTarget, isOver, canDrop, id, isRequired } = this.props;
     const klass = classNames('co-file-dropzone-container', {'co-file-dropzone--drop-over': isOver});
     return (
       connectDropTarget(
@@ -55,7 +55,7 @@ export class FileInput extends React.Component<FileInputProps, FileInputState> {
                 onChange={this.onDataChange}
                 value={this.props.inputFileData}
                 aria-describedby={`${id}-textarea-help`}
-                required>
+                required={isRequired}>
               </textarea>
               <p className="help-block" id={`${id}-textarea-help`}>{this.props.textareaFieldHelpText}</p>
             </div>
@@ -128,6 +128,7 @@ export type DroppableFileInputProps = {
   id: string,
   inputFieldHelpText: string,
   textareaFieldHelpText: string,
+  isRequired: boolean,
 };
 export type DroppableFileInputState = {
   inputFileData: string,
@@ -149,5 +150,6 @@ export type FileInputProps = {
   id: string,
   inputFieldHelpText: string,
   textareaFieldHelpText: string,
+  isRequired: boolean,
 };
 /* eslint-enable no-undef */


### PR DESCRIPTION
Adding form for creating and editing generic(`opaque`) secrets.

The functionality is similar to the ImageSecret form, where user is able to add and remove key/value entries.
As mentioned, `GenericSecretForm` and  `CreateConfigSubformState` classes have similar function notation, but they differ in the way how they handle data, since image secret data have different structure from the generic secret, so the functions of both classes have different semantics. Therefor I've separated those two into different classes (wasn't sure if having a single class for both, would be more of a win then having more readable code).
Also I've changed the structure of the `state` array objects for `CreateConfigSubformState` into:
```js
// image-secret entry before
{
  uid: number
  address: string,
  username: string,
  password: string,
  email: string,
  auth: string,
}
// image-secret entry after
{
  uid: number
  entry: {
    address: string,
    username: string,
    password: string,
    email: string,
    auth: string,
  }
  isDuplicate: bool
}
``` 

Generic secret entry type:
```js
{
  uid: number
  entry: {
    key: string
  }
  isDuplicate: bool
}
```

For the value input I've used `DroppableFileInput` component, since the value could be uploaded from a file as well. Here I wasn't sure if we want to have the input field with Browse button visible since it would make the form more compact, in case of a lot of entries. Would need suggestion form @openshift/team-ux-review here.
Screens:
With input&browse
![1](https://user-images.githubusercontent.com/1668218/45027638-419df080-b042-11e8-86dc-4c7bcffd7e7e.png)

Without input&browse
![2](https://user-images.githubusercontent.com/1668218/45027642-44004a80-b042-11e8-8a16-5e7d70c45d9e.png)

I kinda like the one without the input field more.

/assign @spadgett 
