### PR TITLE
Delete ClusterServiceVersion Only when Specified

### DIFF
--- a/frontend/__tests__/components/cloud-services/subscription.spec.tsx
+++ b/frontend/__tests__/components/cloud-services/subscription.spec.tsx
@@ -59,12 +59,14 @@ describe(SubscriptionRow.displayName, () => {
   });
 
   it('renders actions cog', () => {
+    const menuArgs = [ClusterServiceVersionModel, subscription];
     expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().kind).toEqual(referenceForModel(SubscriptionModel));
     expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().resource).toEqual(subscription);
-    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().actions[0]().label).toEqual('Remove Subscription...');
-    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().actions[0]().callback).toBeDefined();
-    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().actions[1]().label).toEqual(`View ${ClusterServiceVersionModel.kind}...`);
-    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().actions[1]().href).toEqual(`/k8s/ns/${testClusterServiceVersion.metadata.namespace}/${ClusterServiceVersionModel.plural}/${subscription.status.installedCSV}`);
+    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().actions[0]).toEqual(Cog.factory.Edit);
+    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().actions[1]().label).toEqual('Remove Subscription...');
+    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().actions[1]().callback).toBeDefined();
+    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().actions[2](...menuArgs).label).toEqual(`View ${ClusterServiceVersionModel.kind}...`);
+    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ResourceCog).props().actions[2](...menuArgs).href).toEqual(`/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp.v1.0.0`);
   });
 
   it('renders column for namespace name', () => {
@@ -193,12 +195,15 @@ describe(SubscriptionDetails.displayName, () => {
 describe(SubscriptionDetailsPage.displayName, () => {
 
   it('renders `DetailsPage` with correct props', () => {
+    const menuArgs = [ClusterServiceVersionModel, testSubscription];
     const match = {params: {ns: 'default', name: 'example-sub'}, url: '', isExact: true, path: ''};
     const wrapper = shallow(<SubscriptionDetailsPage match={match} namespace="default" />);
 
     expect(wrapper.find(DetailsPage).props().kind).toEqual(referenceForModel(SubscriptionModel));
     expect(wrapper.find(DetailsPage).props().pages.length).toEqual(2);
-    expect(wrapper.find(DetailsPage).props().menuActions).toEqual(Cog.factory.common);
+    expect(wrapper.find(DetailsPage).props().menuActions[0]).toEqual(Cog.factory.Edit);
+    expect(wrapper.find(DetailsPage).props().menuActions[1](...menuArgs).label).toEqual('Remove Subscription...');
+    expect(wrapper.find(DetailsPage).props().menuActions[2](...menuArgs).label).toEqual(`View ${ClusterServiceVersionModel.kind}...`);
   });
 
   it('passes additional resources to watch', () => {

--- a/frontend/__tests__/components/modals/disable-application-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/disable-application-modal.spec.tsx
@@ -30,22 +30,20 @@ describe(DisableApplicationModal.name, () => {
   it('renders a modal form', () => {
     expect(wrapper.find('form').props().name).toEqual('form');
     expect(wrapper.find(ModalTitle).exists()).toBe(true);
-    expect(wrapper.find(ModalSubmitFooter).props().submitText).toEqual('Disable');
+    expect(wrapper.find(ModalSubmitFooter).props().submitText).toEqual('Remove');
   });
 
   it('renders checkbox for setting cascading delete', () => {
     expect(wrapper.find('.co-delete-modal-checkbox-label').find('input').props().checked).toBe(true);
-    expect(wrapper.find('.co-delete-modal-checkbox-label').text()).toContain('Completely remove application instances and resources from the selected namespace');
+    expect(wrapper.find('.co-delete-modal-checkbox-label').text()).toContain('Also completely remove the test-package Operator from the selected namespace.');
   });
 
   it('calls `props.k8sKill` to delete the subscription when form is submitted', (done) => {
-    wrapper = wrapper.setState({cascadeDelete: false});
-
     close.and.callFake(() => {
       expect(k8sKill.calls.argsFor(0)[0]).toEqual(SubscriptionModel);
       expect(k8sKill.calls.argsFor(0)[1]).toEqual(subscription);
       expect(k8sKill.calls.argsFor(0)[2]).toEqual({});
-      expect(k8sKill.calls.argsFor(0)[3]).toBe(null);
+      expect(k8sKill.calls.argsFor(0)[3]).toEqual({kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy: 'Foreground'});
       done();
     });
 
@@ -53,14 +51,12 @@ describe(DisableApplicationModal.name, () => {
   });
 
   it('calls `props.k8sKill` to delete the `ClusterServiceVersion` from the subscription namespace when form is submitted', (done) => {
-    wrapper = wrapper.setState({cascadeDelete: false});
-
     close.and.callFake(() => {
       expect(k8sKill.calls.argsFor(1)[0]).toEqual(ClusterServiceVersionModel);
       expect(k8sKill.calls.argsFor(1)[1].metadata.namespace).toEqual(testSubscription.metadata.namespace);
       expect(k8sKill.calls.argsFor(1)[1].metadata.name).toEqual('testapp.v1.0.0');
       expect(k8sKill.calls.argsFor(1)[2]).toEqual({});
-      expect(k8sKill.calls.argsFor(1)[3]).toBe(null);
+      expect(k8sKill.calls.argsFor(1)[3]).toEqual({kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy: 'Foreground'});
       done();
     });
 
@@ -68,7 +64,18 @@ describe(DisableApplicationModal.name, () => {
   });
 
   it('does not call `props.k8sKill` to delete `ClusterServiceVersion` if `status.installedCSV` field missing from subscription', (done) => {
-    wrapper = wrapper.setState({cascadeDelete: false});
+    wrapper = wrapper.setProps({subscription: testSubscription});
+
+    close.and.callFake(() => {
+      expect(k8sKill.calls.count()).toEqual(1);
+      done();
+    });
+
+    wrapper.find('form').simulate('submit', new Event('submit'));
+  });
+
+  it('does not call `props.k8sKill` to delete `ClusterServiceVersion` if `state.deleteCSV` is false', (done) => {
+    wrapper = wrapper.setState({deleteCSV: false});
     wrapper = wrapper.setProps({subscription: testSubscription});
 
     close.and.callFake(() => {
@@ -80,7 +87,7 @@ describe(DisableApplicationModal.name, () => {
   });
 
   it('adds delete options with `propagationPolicy` if cascading delete checkbox is checked', (done) => {
-    wrapper = wrapper.setState({cascadeDelete: true});
+    wrapper = wrapper.setState({deleteCSV: true});
 
     close.and.callFake(() => {
       expect(k8sKill.calls.argsFor(0)[3]).toEqual({kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy: 'Foreground'});

--- a/frontend/public/components/cloud-services/subscription.tsx
+++ b/frontend/public/components/cloud-services/subscription.tsx
@@ -31,20 +31,22 @@ const subscriptionState = (state: SubscriptionState) => {
   }
 };
 
-export const SubscriptionRow: React.SFC<SubscriptionRowProps> = (props) => {
-  const disableAction = () => ({
+const menuActions = [
+  Cog.factory.Edit,
+  (kind, obj) => ({
     label: 'Remove Subscription...',
-    callback: () => createDisableApplicationModal({k8sKill, subscription: props.obj}),
-  });
-  const viewCSVAction = () => ({
+    callback: () => createDisableApplicationModal({k8sKill, subscription: obj}),
+  }),
+  (kind, obj) => ({
     label: `View ${ClusterServiceVersionModel.kind}...`,
-    href: `/k8s/ns/${props.obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${_.get(props.obj.status, 'installedCSV')}`,
-  });
-  const actions = [disableAction, ...(_.get(props.obj.status, 'installedCSV') ? [viewCSVAction] : [])];
+    href: `/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${_.get(obj.status, 'installedCSV')}`,
+  })
+];
 
+export const SubscriptionRow: React.SFC<SubscriptionRowProps> = (props) => {
   return <div className="row co-resource-list__item">
     <div className="col-xs-6 col-sm-4 col-md-3 co-resource-link-wrapper">
-      <ResourceCog actions={actions} kind={referenceForModel(SubscriptionModel)} resource={props.obj} />
+      <ResourceCog actions={_.get(props.obj.status, 'installedCSV') ? menuActions : menuActions.slice(0, -1)} kind={referenceForModel(SubscriptionModel)} resource={props.obj} />
       <ResourceLink kind={referenceForModel(SubscriptionModel)} name={props.obj.metadata.name} namespace={props.obj.metadata.namespace} title={props.obj.metadata.name} />
     </div>
     <div className="col-xs-6 col-sm-4 col-md-3">
@@ -214,7 +216,7 @@ export const SubscriptionDetailsPage: React.SFC<SubscriptionDetailsPageProps> = 
       {kind: ConfigMapModel.kind, namespace: props.namespace, isList: true, prop: 'localConfigMaps'},
       {kind: referenceForModel(ClusterServiceVersionModel), namespace: props.namespace, isList: true, prop: 'clusterServiceVersions'},
     ]}
-    menuActions={Cog.factory.common} />;
+    menuActions={menuActions} />;
 };
 
 export type SubscriptionsPageProps = {

--- a/frontend/public/components/modals/disable-application-modal.tsx
+++ b/frontend/public/components/modals/disable-application-modal.tsx
@@ -14,16 +14,16 @@ export class DisableApplicationModal extends PromiseComponent {
 
   constructor(public props: DisableApplicationModalProps) {
     super(props);
-    this.state.cascadeDelete = true;
+    this.state.deleteCSV = true;
   }
 
   private submit(event): void {
     event.preventDefault();
 
     const {subscription, k8sKill} = this.props;
-    const deleteOptions = this.state.cascadeDelete ? {kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy: 'Foreground'} : null;
+    const deleteOptions = {kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy: 'Foreground'};
     const killPromises = [k8sKill(SubscriptionModel, subscription, {}, deleteOptions)]
-      .concat(_.get(this.props.subscription, 'status.installedCSV')
+      .concat(_.get(this.props.subscription, 'status.installedCSV') && this.state.deleteCSV
         ? k8sKill(ClusterServiceVersionModel, {metadata: {name: subscription.status.installedCSV, namespace: subscription.metadata.namespace}} as ClusterServiceVersionKind, {}, deleteOptions)
         : []);
 
@@ -31,22 +31,24 @@ export class DisableApplicationModal extends PromiseComponent {
   }
 
   render() {
+    const {name} = this.props.subscription.spec;
+
     return <form onSubmit={this.submit.bind(this)} name="form" className="co-catalog-install-modal">
       <ModalTitle className="modal-header">Remove Subscription</ModalTitle>
       <ModalBody>
         <div>
           <p>
-            This will completely remove the <b>{this.props.subscription.spec.name}</b> subscription and service from {this.props.subscription.metadata.namespace}.
+            This will remove the <b>{name}</b> subscription from <i>{this.props.subscription.metadata.namespace}</i> and the Operator will no longer receive updates.
           </p>
         </div>
         <div>
           <label className="co-delete-modal-checkbox-label">
-            <input type="checkbox" checked={this.state.cascadeDelete} onChange={() => this.setState({cascadeDelete: !this.state.cascadeDelete})} />
-            &nbsp;&nbsp; <strong>Completely remove application instances and resources from the selected namespace</strong>
+            <input type="checkbox" checked={this.state.deleteCSV} onChange={() => this.setState({deleteCSV: !this.state.deleteCSV})} />
+            &nbsp;&nbsp; <strong>Also completely remove the <b>{name}</b> Operator from the selected namespace.</strong>
           </label>
         </div>
       </ModalBody>
-      <ModalSubmitFooter inProgress={this.state.inProgress} errorMessage={this.state.errorMessage} cancel={this.props.cancel.bind(this)} submitText="Disable" />
+      <ModalSubmitFooter inProgress={this.state.inProgress} errorMessage={this.state.errorMessage} cancel={this.props.cancel.bind(this)} submitText="Remove" />
     </form>;
   }
 }
@@ -63,7 +65,7 @@ export type DisableApplicationModalProps = {
 export type DisableApplicationModalState = {
   inProgress: boolean;
   errorMessage: string;
-  cascadeDelete: boolean;
+  deleteCSV: boolean;
 };
 
 type ModalProps = Omit<DisableApplicationModalProps, 'cancel' | 'close'>;


### PR DESCRIPTION
### Description

Fix delete subscription modal to only delete the current `ClusterServiceVersion` if specified by the user. Otherwise, leave the Operator installed but opt out of updates via OLM.

### Screenshots

**Delete subscription modal (updated text):**
![screenshot_20180904_115928](https://user-images.githubusercontent.com/11700385/45042972-00094780-b03a-11e8-92bd-3f95f8c1ebfa.png)

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1624782