### PR TITLE
Fix Link to CatalogSource on Subscription Detail View

### DIFF
--- a/frontend/public/components/cloud-services/index.tsx
+++ b/frontend/public/components/cloud-services/index.tsx
@@ -160,6 +160,7 @@ export type SubscriptionKind = {
     name: string;
     channel?: string;
     startingCSV?: string;
+    sourceNamespace?: string;
     installPlanApproval?: InstallPlanApproval;
   },
   status?: {

--- a/frontend/public/components/cloud-services/subscription.tsx
+++ b/frontend/public/components/cloud-services/subscription.tsx
@@ -83,6 +83,7 @@ export const SubscriptionsPage: React.SFC<SubscriptionsPageProps> = (props) => <
 
 export const SubscriptionDetails: React.SFC<SubscriptionDetailsProps> = (props) => {
   const {obj, installedCSV, pkg} = props;
+  const catalogNS = obj.spec.sourceNamespace || olmNamespace;
 
   return <div className="co-m-pane__body">
     <SectionHeading text="Subscription Overview" />
@@ -106,7 +107,7 @@ export const SubscriptionDetails: React.SFC<SubscriptionDetailsProps> = (props) 
             <dd>{obj.spec.startingCSV || 'None'}</dd>
             <dt>Catalog</dt>
             <dd>
-              <ResourceLink kind={referenceForModel(CatalogSourceModel)} name={obj.spec.source} namespace={obj.metadata.namespace} title={obj.spec.source} />
+              <ResourceLink kind={referenceForModel(CatalogSourceModel)} name={obj.spec.source} namespace={catalogNS} title={obj.spec.source} />
             </dd>
           </dl>
         </div>


### PR DESCRIPTION
### Description

If `spec.sourceNamespace` isn't set on a `Subscription`, then we know that the `CatalogSource` it is pulling from is in the global OLM namespace. Update the `ResourceLink` to reflect this.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1624773 (and duplicate issues)