### PR TITLE
Better API Discovery

### DIFF
--- a/frontend/__tests__/module/k8s/k8s-actions.spec.ts
+++ b/frontend/__tests__/module/k8s/k8s-actions.spec.ts
@@ -1,12 +1,53 @@
 /* eslint-disable no-undef, no-unused-vars */
 
 import Spy = jasmine.Spy;
+import { Map as ImmutableMap } from 'immutable';
 
 import k8sActions, { types } from '../../../public/module/k8s/k8s-actions';
 import * as k8sResource from '../../../public/module/k8s/resource';
 import { K8sResourceKind } from '../../../public/module/k8s';
-import { PodModel } from '../../../public/models';
+import { PodModel, APIServiceModel } from '../../../public/models';
 import { testResourceInstance } from '../../../__mocks__/k8sResourcesMocks';
+import * as coFetch from '../../../public/co-fetch';
+
+describe('watchAPIServices', () => {
+  const {watchAPIServices} = k8sActions;
+
+  it('does nothing if already watching `APIServices`', () => {
+    const getState = jasmine.createSpy('getState').and.returnValue({k8s: ImmutableMap().set('apiservices', [])});
+    const dispatch = jasmine.createSpy('dispatch').and.callFake(() => {
+      fail('Should not call `dispatch`');
+    });
+
+    watchAPIServices()(dispatch, getState);
+  });
+
+  it('attempts to list `APIServices`', (done) => {
+    const getState = jasmine.createSpy('getState').and.returnValue({k8s: ImmutableMap()});
+    const dispatch = jasmine.createSpy('dispatch');
+    spyOn(k8sActions, 'watchK8sList').and.returnValue({});
+
+    spyOn(k8sResource, 'k8sList').and.callFake((model) => new Promise(() => {
+      expect(model).toEqual(APIServiceModel);
+      done();
+    }));
+
+    watchAPIServices()(dispatch, getState);
+  });
+
+  it('falls back to polling Kubernetes `/apis` endpoint if cannot list `APIServices`', (done) => {
+    const getState = jasmine.createSpy('getState').and.returnValue({k8s: ImmutableMap()});
+    const dispatch = jasmine.createSpy('dispatch');
+    spyOn(k8sActions, 'watchK8sList').and.returnValue({});
+    spyOn(k8sResource, 'k8sList').and.returnValue(Promise.reject());
+    spyOn(coFetch, 'coFetchJSON').and.callFake((path) => {
+      expect(path).toEqual('api/kubernetes/apis');
+      done();
+    });
+
+    watchAPIServices()(dispatch, getState);
+  });
+});
 
 describe(types.watchK8sList, () => {
   const {watchK8sList} = k8sActions;

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -211,7 +211,7 @@ class App extends React.PureComponent {
 }
 
 _.each(featureActions, store.dispatch);
-store.dispatch(k8sActions.getResources());
+store.dispatch(k8sActions.watchAPIServices());
 store.dispatch(detectMonitoringURLs);
 
 analyticsSvc.push({tier: 'tectonic'});

--- a/frontend/public/components/error.tsx
+++ b/frontend/public/components/error.tsx
@@ -1,10 +1,12 @@
+/* eslint-disable no-unused-vars, no-undef */
+
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 
-import {NavTitle, getQueryArgument} from './utils';
+import { NavTitle, getQueryArgument } from './utils';
 
-//User messages for error_types returned in auth.go
+// User messages for error_types returned in auth.go
 const messages = {
   auth: {
     'oauth_error': 'There was an error generating OAuth client from OIDC client.',
@@ -38,7 +40,7 @@ const getErrMessage = () => {
   return '';
 };
 
-const ErrorComponent = ({title, message, errMessage}) => <React.Fragment>
+const ErrorComponent: React.SFC<ErrorComponentProps> = ({title, message, errMessage}) => <React.Fragment>
   <NavTitle detail={true} title="Error" />
   <div className="co-m-pane__body">
     <h1 className="co-m-pane__heading co-m-pane__heading--center">{title}</h1>
@@ -47,16 +49,25 @@ const ErrorComponent = ({title, message, errMessage}) => <React.Fragment>
   </div>
 </React.Fragment>;
 
-export const ErrorPage = () => <div>
+export const ErrorPage: React.SFC<ErrorPageProps> = () => <div>
   <Helmet>
     <title>Error</title>
   </Helmet>
   <ErrorComponent title="Oh no! Something went wrong." message={urlMessage()} errMessage={getErrMessage()} />
 </div>;
 
-export const ErrorPage404 = () => <div>
+export const ErrorPage404: React.SFC<ErrorPage404Props> = (props) => <div>
   <Helmet>
     <title>Page Not Found (404)</title>
   </Helmet>
-  <ErrorComponent title="404: Page Not Found" />
+  <ErrorComponent title="404: Page Not Found" message={props.message} errMessage={props.errMessage} />
 </div>;
+
+export type ErrorComponentProps = {
+  title: string;
+  message?: string;
+  errMessage?: string;
+};
+
+export type ErrorPageProps = {};
+export type ErrorPage404Props = Omit<ErrorComponentProps, 'title'>;

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -7,7 +7,7 @@ import * as _ from 'lodash-es';
 
 import { connectToPlural } from '../kinds';
 import { LoadingBox, AsyncComponent } from './utils';
-import { K8sResourceKindReference, referenceForModel, K8sKind } from '../module/k8s';
+import { K8sResourceKindReference, referenceForModel, K8sKind, isGroupVersionKind, kindForReference, apiVersionForReference } from '../module/k8s';
 import { ErrorPage404 } from './error';
 import { FLAGS, connectToFlags, flagPending } from '../features';
 import { OpenShiftGettingStarted } from './start-guide';
@@ -18,13 +18,14 @@ import { DefaultPage, DefaultDetailsPage } from './default-resource';
 const allParams = props => Object.assign({}, _.get(props, 'match.params'), props);
 
 const ResourceListPage_ = connectToPlural((props: ResourceListPageProps) => {
-  const { flags, kindObj, kindsInFlight, modelRef, ns } = allParams(props);
+  const { flags, kindObj, kindsInFlight, modelRef, ns, plural } = allParams(props);
 
   if (!kindObj) {
     if (kindsInFlight) {
       return <LoadingBox />;
     }
-    return <ErrorPage404 />;
+    const missingType = isGroupVersionKind(plural) ? `"${kindForReference(plural)}" in "${apiVersionForReference(plural)}"` : `"${plural}"`;
+    return <ErrorPage404 message={`The server doesn't have a resource type ${missingType}. Try refreshing the page if it was recently added.`} />;
   }
 
   const notProjectsListPage = kindObj.labelPlural !== 'Projects';

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -746,3 +746,17 @@ export const LimitRangeModel: K8sKind = {
   id: 'limitrange',
   labelPlural: 'Limit Ranges'
 };
+
+export const APIServiceModel: K8sKind = {
+  label: 'API Service',
+  labelPlural: 'API Services',
+  apiVersion: 'v1',
+  path: 'apiservices',
+  apiGroup: 'apiregistration.k8s.io',
+  plural: 'apiservices',
+  abbr: 'APIS',
+  namespaced: false,
+  kind: 'APIService',
+  id: 'apiservice',
+  crd: true,
+};

--- a/frontend/public/module/k8s/k8s-reducers.ts
+++ b/frontend/public/module/k8s/k8s-reducers.ts
@@ -84,6 +84,8 @@ export default (state: ImmutableMap<string, any>, action) => {
   switch (action.type) {
     case types.getResourcesInFlight:
       return state.setIn(['RESOURCES', 'inFlight'], true);
+    case types.setAPIGroups:
+      return state.setIn(['RESOURCES', 'apiGroups'], action.value);
     case types.resources:
       return action.resources.models
         .filter(model => !state.getIn(['RESOURCES', 'models']).has(referenceForModel(model)))


### PR DESCRIPTION
### Description

Update models in Redux when new Kubernetes APIs are added to the cluster. This corrects existing behavior which only performs API discovery on app startup.

This is achieved by watching `/apis/apiregistration.k8s.io/v1/apiservices` and dispatching `getResources` whenever a new `APIService` is added to the list. Falls back to polling Kubernetes `/apis` endpoint if RBAC restricts listing `APIServices` (which is a much less satisfactory solution).

Also updates 404 error views to include a message to refresh the page if the model isn't registered.

### Screenshots

**404 list view (`GroupVersionKind` URL):**
![screenshot_20180913_161001](https://user-images.githubusercontent.com/11700385/45520798-dbb31680-b76f-11e8-83f4-b98a35fddb88.png)

**404 list view (`plural` URL):**
![screenshot_20180913_160737](https://user-images.githubusercontent.com/11700385/45520795-d8b82600-b76f-11e8-9247-7490cb331b95.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1602194
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1609731