### PR TITLE
Temporarily disable add / edit rule page

### DIFF
--- a/frontend/public/components/RBAC/index.js
+++ b/frontend/public/components/RBAC/index.js
@@ -1,4 +1,4 @@
 export * from './bindings';
-export * from './edit-rule';
+// export * from './edit-rule';
 export * from './role';
 export * from './rules';

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -1,7 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as fuzzy from 'fuzzysearch';
-import { Link } from 'react-router-dom';
+// import { Link } from 'react-router-dom';
 
 import { ColHead, DetailsPage, List, ListHeader, MultiListPage, ResourceRow, TextFilter } from '../factory';
 import { Cog, SectionHeading, MsgBox, navFactory, ResourceCog, ResourceLink, Timestamp } from '../utils';
@@ -11,15 +11,16 @@ import { flagPending, connectToFlags, FLAGS } from '../../features';
 
 export const isSystemRole = role => _.startsWith(role.metadata.name, 'system:');
 
-const addHref = (name, ns) => ns ? `/k8s/ns/${ns}/roles/${name}/add-rule` : `/k8s/cluster/clusterroles/${name}/add-rule`;
+// const addHref = (name, ns) => ns ? `/k8s/ns/${ns}/roles/${name}/add-rule` : `/k8s/cluster/clusterroles/${name}/add-rule`;
 
 export const roleKind = role => role.metadata.namespace ? 'Role' : 'ClusterRole';
 
 const menuActions = [
-  (kind, role) => ({
-    label: 'Add Rule...',
-    href: addHref(role.metadata.name, role.metadata.namespace),
-  }),
+  // This page is temporarily disabled until we update the safe resources list.
+  // (kind, role) => ({
+  //   label: 'Add Rule...',
+  //   href: addHref(role.metadata.name, role.metadata.namespace),
+  // }),
   (kind, role) => ({
     label: 'Add Role Binding...',
     href: `/k8s/cluster/rolebindings/new?rolekind=${roleKind(role)}&rolename=${role.metadata.name}`,
@@ -87,11 +88,13 @@ class Details extends React.Component {
       <div className="co-m-pane__body">
         <SectionHeading text="Rules" />
         <div className="co-m-pane__filter-bar co-m-pane__filter-bar--alt">
+          {/* This page is temporarily disabled until we update the safe resources list.
           <div className="co-m-pane__filter-bar-group">
             <Link to={addHref(name, namespace)} className="co-m-primary-action">
               <button className="btn btn-primary">Add Rule</button>
             </Link>
           </div>
+          */}
           <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--filter">
             <TextFilter label="Rules by action or resource" onChange={this.changeFilter} />
           </div>

--- a/frontend/public/components/RBAC/rules.jsx
+++ b/frontend/public/components/RBAC/rules.jsx
@@ -101,14 +101,15 @@ const DeleteRule = (name, namespace, i) => ({
   })
 });
 
-const EditRule = (name, namespace, i) => ({
-  label: 'Edit Rule...',
-  href: namespace ? `/k8s/ns/${namespace}/roles/${name}/${i}/edit` : `/k8s/cluster/clusterroles/${name}/${i}/edit`,
-});
+// This page is temporarily disabled until we update the safe resources list.
+// const EditRule = (name, namespace, i) => ({
+//   label: 'Edit Rule...',
+//   href: namespace ? `/k8s/ns/${namespace}/roles/${name}/${i}/edit` : `/k8s/cluster/clusterroles/${name}/${i}/edit`,
+// });
 
 const RuleCog = ({name, namespace, i}) => {
   const options = [
-    EditRule,
+    // EditRule,
     DeleteRule,
   ].map(f => f(name, namespace, i));
   return <Cog options={options} />;

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -152,12 +152,17 @@ class App extends React.PureComponent {
           <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural" exact component={ResourceListPage} />
           <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural/:name" component={ResourceDetailsPage} />
 
-          <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-          <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+          {
+            // These pages are temporarily disabled. We need to update the safe resources list.
+            // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+            // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+          }
           <Route path="/k8s/cluster/clusterroles/:name" component={props => <ResourceDetailsPage {...props} plural="clusterroles" />} />
 
-          <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-          <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+          {
+            // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+            // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+          }
 
           <LazyRoute path="/k8s/ns/:ns/secrets/new/:type" exact kind="Secret" loader={() => import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(m => m.CreateSecret)} />
           <LazyRoute path="/k8s/ns/:ns/secrets/:name/edit" exact kind="Secret" loader={() => import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(m => m.EditSecret)} />


### PR DESCRIPTION
The page currently defaults to adding a number of dangerous resources
like OpenShift `oauthaccesstokens` by default under the "Safe Resources"
section. This is because the list of admin resources is hard-coded and
unknown resources are assumed to be "safe." This became a problem when
we switched to API discovery, which added a bunch of new resources.

We should revisit the approach we take to building the safe resources
list.

/assign @rhamilto 
@jwforres FYI