### PR TITLE
Service Catalog Integration Tests

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -97,13 +97,24 @@ export const config: Config = {
     olm: ['tests/base.scenario.ts', 'tests/olm/descriptors.scenario.ts', 'tests/olm/catalog.scenario.ts', 'tests/olm/etcd.scenario.ts', 'tests/olm/prometheus.scenario.ts'],
     olmUpgrade: ['tests/base.scenario.ts', 'tests/olm/update-channel-approval.scenario.ts'],
     performance: ['tests/base.scenario.ts', 'tests/performance.scenario.ts'],
-    all: ['tests/base.scenario.ts', 'tests/crud.scenario.ts', 'tests/secrets.scenario.ts', 'tests/olm/**/*.scenario.ts', 'tests/filter.scenario.ts', 'tests/modal-annotations.scenario.ts', 'tests/source-to-image.scenario.ts', 'tests/deploy-image.scenario.ts'],
+    serviceCatalog: ['tests/base.scenario.ts', 'tests/service-catalog/service-catalog.scenario.ts', 'tests/service-catalog/service-broker.scenario.ts', 'tests/service-catalog/service-class.scenario.ts', 'tests/service-catalog/service-binding.scenario.ts'],
+    all: ['tests/base.scenario.ts',
+      'tests/crud.scenario.ts',
+      'tests/secrets.scenario.ts',
+      'tests/olm/**/*.scenario.ts',
+      'tests/service-catalog/**/*.scenario.ts',
+      'tests/filter.scenario.ts',
+      'tests/modal-annotations.scenario.ts',
+      'tests/source-to-image.scenario.ts',
+      'tests/deploy-image.scenario.ts'],
   },
   params: {
     // Set to 'true' to enable OpenShift resources in the crud scenario.
     // Use a string rather than boolean so it can be specified on the command line:
     // $ yarn run test-gui --params.openshift true
-    openshift: 'false'
+    openshift: 'false',
+    // Set to 'true' to enable Service Catalog resources in the crud scenario.
+    servicecatalog: 'false'
   }
 };
 

--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -42,7 +42,10 @@ describe('Kubernetes resource CRUD operations', () => {
     .set('buildconfigs', {kind: 'BuildConfig'})
     .set('imagestreams', {kind: 'ImageStream'})
     .set('routes', {kind: 'Route'});
-  const testObjs = browser.params.openshift === 'true' ? k8sObjs.merge(openshiftObjs) : k8sObjs;
+  const serviceCatalogObjs = OrderedMap<string, {kind: string, namespaced?: boolean}>()
+    .set('clusterservicebrokers', {kind: 'ClusterServiceBroker', namespaced: false});
+  let testObjs = browser.params.openshift === 'true' ? k8sObjs.merge(openshiftObjs) : k8sObjs;
+  testObjs = browser.params.servicecatalog === 'true' ? testObjs.merge(serviceCatalogObjs) : testObjs;
 
   afterEach(() => {
     checkLogs();

--- a/frontend/integration-tests/tests/service-catalog/service-binding.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-binding.scenario.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import {execSync} from 'child_process';
+import {browser, $, $$, ExpectedConditions as until} from 'protractor';
+
+import { appHost, checkLogs, checkErrors, testName } from '../../protractor.conf';
+import * as srvCatalogView from '../../views/service-catalog.view';
+import * as sidenavView from '../../views/sidenav.view';
+import * as crudView from '../../views/crud.view';
+
+describe('Test for Cluster Service Binding', () => {
+  beforeAll(async() => {
+    browser.get(`${appHost}/status/ns/${testName}`);
+    await browser.wait(until.presenceOf($('#sidebar')));
+  });
+
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+
+  it('creates a new binding for new service instance `mysql-persistent`', async() => {
+    await sidenavView.clickNavLink(['Service Catalog', 'Service Classes']);
+    await crudView.isLoaded();
+
+    // Filter by service class name to make sure it is on the first page of results.
+    // Otherwise the tests fail since we do virtual scrolling and the element isn't found.
+    await crudView.filterForName('MySQL');
+    await srvCatalogView.cscLinksPresent();
+
+    await srvCatalogView.linkForCSC('MySQL').click();
+    await crudView.isLoaded();
+
+    expect(srvCatalogView.createInstanceButton.isDisplayed()).toBe(true);
+    await srvCatalogView.createInstanceButton.click();
+    await srvCatalogView.createInstanceFormIsLoaded();
+
+    // select test namespace, then submit create instance form
+    await $('#dropdown-selectbox').click();
+    await $$('.dropdown-menu').first().$(`#${testName}-Project-link`).click();
+    await srvCatalogView.createButton.click();
+    await crudView.isLoaded();
+
+    expect(crudView.resourceTitle.getText()).toEqual('mysql-persistent');
+
+    await crudView.createYAMLButton.click(); // embedded Create Service Binding button
+    await srvCatalogView.createBindingFormIsLoaded();
+    expect(crudView.resourceTitle.getText()).toEqual('Create Service Binding');
+
+    await srvCatalogView.createButton.click();
+    await crudView.isLoaded();
+    expect(crudView.resourceTitle.getText()).toEqual('mysql-persistent');
+
+    execSync(`kubectl delete -n ${testName} servicebinding mysql-persistent`);
+    execSync(`kubectl delete -n ${testName} serviceinstance mysql-persistent`);
+  });
+});

--- a/frontend/integration-tests/tests/service-catalog/service-broker.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-broker.scenario.ts
@@ -1,0 +1,36 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import {browser, $, ExpectedConditions as until, by} from 'protractor';
+
+import { appHost, checkLogs, checkErrors, testName } from '../../protractor.conf';
+import * as srvCatalogView from '../../views/service-catalog.view';
+import * as sidenavView from '../../views/sidenav.view';
+import * as crudView from '../../views/crud.view';
+
+describe('Test for Cluster Service Broker', () => {
+  beforeAll(async() => {
+    browser.get(`${appHost}/status/ns/${testName}`);
+    await browser.wait(until.presenceOf($('#sidebar')));
+  });
+
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+
+  it('displays `MongoDB` service class for `template-service-broker`', async() => {
+    await sidenavView.clickNavLink(['Service Catalog', 'Service Brokers']);
+    await crudView.isLoaded();
+
+    await crudView.rowForName('template-service-broker').element(by.linkText('template-service-broker')).click();
+    await crudView.isLoaded();
+
+    await crudView.navTabFor('Service Classes').click();
+    await crudView.isLoaded();
+
+    await srvCatalogView.linkForCSC('MongoDB').click();
+    await crudView.isLoaded();
+
+    expect(crudView.resourceTitle.getText()).toEqual('MongoDB');
+  });
+});

--- a/frontend/integration-tests/tests/service-catalog/service-catalog.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-catalog.scenario.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import {browser, $, ExpectedConditions as until} from 'protractor';
+
+import { appHost, checkLogs, checkErrors, testName } from '../../protractor.conf';
+import * as sidenavView from '../../views/sidenav.view';
+import * as crudView from '../../views/crud.view';
+import * as srvCatalogView from '../../views/service-catalog.view';
+
+describe('Test for existence of Service Catalog nav items', () => {
+  beforeAll(async() => {
+    browser.get(`${appHost}/status/ns/${testName}`);
+    await browser.wait(until.presenceOf($('#sidebar')));
+  });
+
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+
+  it('displays `Service Catalog` nav menu item in sidebar', async() => {
+    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Service Catalog')));
+
+    expect(sidenavView.navSectionFor('Service Catalog').isDisplayed()).toBe(true);
+  });
+
+  it('displays `template-service-broker`', async() => {
+    await sidenavView.clickNavLink(['Service Catalog', 'Service Brokers']);
+    await crudView.isLoaded();
+
+    expect(crudView.rowForName('template-service-broker').isDisplayed()).toBe(true);
+  });
+
+  it('displays `MongoDB` service class', async() => {
+    await sidenavView.clickNavLink(['Service Catalog', 'Service Classes']);
+    await crudView.isLoaded();
+
+    await crudView.filterForName('MongoDB');
+    await srvCatalogView.cscLinksPresent();
+
+    expect(srvCatalogView.linkForCSC('MongoDB').isDisplayed()).toBe(true);
+  });
+
+  it('initially displays no service instances', async() => {
+    await sidenavView.clickNavLink(['Service Catalog', 'Service Instances']);
+    await crudView.isLoaded();
+
+    expect(crudView.emptyState.getText()).toEqual('No Service Instances Found');
+  });
+
+  it('initially displays no service bindings', async() => {
+    await sidenavView.clickNavLink(['Service Catalog', 'Service Bindings']);
+    await crudView.isLoaded();
+
+    expect(crudView.emptyState.getText()).toEqual('No Service Bindings Found');
+  });
+});

--- a/frontend/integration-tests/tests/service-catalog/service-class.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-class.scenario.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import {browser, $, $$, ExpectedConditions as until, by} from 'protractor';
+
+import { appHost, checkLogs, checkErrors, testName } from '../../protractor.conf';
+import * as srvCatalogView from '../../views/service-catalog.view';
+import * as sidenavView from '../../views/sidenav.view';
+import * as crudView from '../../views/crud.view';
+import {execSync} from 'child_process';
+
+describe('Test for Cluster Service Class', () => {
+  beforeAll(async() => {
+    browser.get(`${appHost}/status/ns/${testName}`);
+    await browser.wait(until.presenceOf($('#sidebar')));
+  });
+
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+
+  it('displays `default` service plan for service class `MongoDB`', async() => {
+    await sidenavView.clickNavLink(['Service Catalog', 'Service Classes']);
+    await crudView.isLoaded();
+
+    // Filter by service class name to make sure it is on the first page of results.
+    // Otherwise the tests fail since we do virtual scrolling and the element isn't found.
+    await crudView.filterForName('MongoDB');
+    await srvCatalogView.cscLinksPresent();
+
+    await srvCatalogView.linkForCSC('MongoDB').click();
+    await crudView.isLoaded();
+
+    await crudView.navTabFor('Service Plans').click();
+    await crudView.isLoaded();
+
+    await crudView.rowForName('default').element(by.linkText('default')).click();
+    await crudView.isLoaded();
+
+    expect(crudView.resourceTitle.getText()).toEqual('default');
+  });
+
+  it('creates a new instance for service class `MongoDB`', async() => {
+    await sidenavView.clickNavLink(['Service Catalog', 'Service Classes']);
+    await crudView.isLoaded();
+
+    // Filter by service class name to make sure it is on the first page of results.
+    // Otherwise the tests fail since we do virtual scrolling and the element isn't found.
+    await crudView.filterForName('MongoDB');
+    await srvCatalogView.cscLinksPresent();
+    expect(srvCatalogView.linkForCSC('MongoDB').isPresent()).toBe(true);
+
+    await srvCatalogView.linkForCSC('MongoDB').click();
+    await crudView.isLoaded();
+
+    expect(srvCatalogView.createInstanceButton.isDisplayed()).toBe(true);
+    await srvCatalogView.createInstanceButton.click();
+    await srvCatalogView.createInstanceFormIsLoaded();
+
+    // select test namespace, then submit form
+    await $('#dropdown-selectbox').click();
+    await $$('.dropdown-menu').first().$(`#${testName}-Project-link`).click();
+    await srvCatalogView.createButton.click();
+    await crudView.isLoaded();
+
+    expect(crudView.resourceTitle.getText()).toEqual('mongodb-persistent');
+
+    execSync(`kubectl delete -n ${testName} serviceinstance mongodb-persistent`);
+  });
+});

--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -20,6 +20,9 @@ export const resourceRows = $$('.co-resource-list__item');
 export const resourceRowNamesAndNs = $$('.co-m-resource-icon + a');
 export const rowForName = (name: string) => resourceRows.filter((row) => row.$$('.co-m-resource-icon + a').first().getText().then(text => text === name)).first();
 export const rowForOperator = (name: string) => resourceRows.filter((row) => row.$('.co-clusterserviceversion-logo__name__clusterserviceversion').getText().then(text => text === name)).first();
+export const navTabs = $$('.co-m-horizontal-nav__menu-item > a');
+export const navTabFor = (name: string) => navTabs.filter((tab) => tab.getText().then(text => text === name)).first();
+
 export const labelsForRow = (name: string) => rowForName(name).$$('.co-m-label');
 export const textFilter = $('.co-m-pane__filter-bar-group--filter input');
 export const gearOptions = {
@@ -104,7 +107,6 @@ export const nameFilter = $('.form-control.text-filter');
 export const messageLbl = $('.cos-status-box');
 export const modalAnnotationsLink = element(by.partialLinkText('Annotation'));
 
-
 export const visitResource = async(resource: string, name: string) => {
   await browser.get(`${appHost}/k8s/ns/${testName}/${resource}/${name}`);
 };
@@ -125,3 +127,5 @@ export const checkResourceExists = async(resource: string, name: string) => {
   await browser.wait(until.presenceOf(actionsDropdown));
   expect(resourceTitle.getText()).toEqual(name);
 };
+
+export const emptyState = $('.cos-status-box').$('.text-center');

--- a/frontend/integration-tests/views/service-catalog.view.ts
+++ b/frontend/integration-tests/views/service-catalog.view.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import {browser, $, ExpectedConditions as until, $$, by} from 'protractor';
+
+const cscLinks = $$('.co-cluster-service-class-link');
+
+export const linkForCSC = (name: string) => cscLinks.filter((row) => row.getText().then(text => text === name)).first();
+export const cscLinksPresent = () => browser.wait(until.presenceOf($('.co-cluster-service-class-link')), 10000);
+
+export const createInstanceButton = $('.btn-primary.co-action-buttons__btn');
+export const createInstanceFormIsLoaded = () => browser.wait(until.presenceOf($('.co-create-service-instance__namespace')), 10000).then(() => browser.sleep(500));
+export const createBindingFormIsLoaded = () => browser.wait(until.presenceOf($('.co-create-service-binding__name')), 10000).then(() => browser.sleep(500));
+export const createButton = $('.co-m-btn-bar').element(by.buttonText('Create'));

--- a/frontend/integration-tests/views/sidenav.view.ts
+++ b/frontend/integration-tests/views/sidenav.view.ts
@@ -7,7 +7,8 @@ export const navSections = $$('.navigation-container__section:not(.navigation-co
 export const navSectionFor = (name: string) => navSections.filter((_, i) => $$('.navigation-container__section__title').get(i).getText()
   .then(text => text === name)).first();
 
-export const clickNavLink = (path: [string, string]) => navSectionFor(path[0]).click()
+export const clickNavLink = (path: [string, string]) => browser.wait(until.visibilityOf(navSectionFor(path[0])))
+  .then(() => navSectionFor(path[0]).click())
   .then(() => browser.wait(until.visibilityOf(navSectionFor(path[0]).element(by.linkText(path[1])))))
   .then(() => navSectionFor(path[0]).element(by.linkText(path[1])).click());
 

--- a/frontend/public/components/cluster-service-class.tsx
+++ b/frontend/public/components/cluster-service-class.tsx
@@ -43,7 +43,7 @@ const ClusterServiceClassListRow: React.SFC<ClusterServiceClassRowProps> = ({obj
   return <ResourceRow obj={serviceClass}>
     <div className="col-sm-6 col-xs-12 co-resource-link-wrapper">
       <ClusterServiceClassIcon serviceClass={serviceClass} />
-      <Link to={path}>{serviceClassDisplayName(serviceClass)}</Link>
+      <Link className="co-cluster-service-class-link" to={path}>{serviceClassDisplayName(serviceClass)}</Link>
     </div>
     <div className="col-sm-3 hidden-xs">
       {serviceClass.spec.externalName}

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -110,6 +110,7 @@ builder_run 'Tests' 0 1 ./test.sh
 builder_run 'GUI-Tests' 1 1 ./test-gui.sh crud
 builder_run 'GUI-Tests-New-App' 1 0 ./test-gui.sh newApp
 builder_run 'GUI-Tests-OLM' 1 0 ./test-gui.sh olm
+builder_run 'GUI-Tests-Service-Catalog' 1 0 ./test-gui.sh serviceCatalog
 
 status 'Performance' 'pending'
 if DOCKER_ENV="KUBECONFIG" ./builder-run.sh ./test-gui.sh performance

--- a/test-gui.sh
+++ b/test-gui.sh
@@ -38,9 +38,9 @@ yarn run webdriver-update --quiet > /dev/null 2>&1
 
 if [ $# -gt 0 ] && [ -n "$1" ];
 then
-  yarn run test-suite --suite "$1" --params.openshift true
+  yarn run test-suite --suite "$1" --params.openshift true --params.servicecatalog true
 else
-  yarn run test-gui --params.openshift true
+  yarn run test-gui --params.openshift true --params.servicecatalog true
 fi
 
 kill "$(cat ../bridge.pid)"


### PR DESCRIPTION
Added Service Catalog Integration Tests:

![image](https://user-images.githubusercontent.com/12733153/45179683-32a47300-b1e7-11e8-8bdd-8113c4b885fb.png)

To run crud integration tests using service catalog items, execute:
`yarn run test-suite --suite crud --params.servicecatalog true`