### PR TITLE
Project overview tweaks to font sizes of names and headings.

### DIFF
--- a/frontend/public/components/_list-view.scss
+++ b/frontend/public/components/_list-view.scss
@@ -1,0 +1,4 @@
+.list-view-pf-description {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/public/components/_project-overview.scss
+++ b/frontend/public/components/_project-overview.scss
@@ -3,9 +3,15 @@
 }
 
 .project-overview__group-heading {
-  border-bottom: 1px solid black;
+  border-bottom: 1px solid $color-pf-black-400;
+  font-size: 22px;
+  font-weight: 300;
+  line-height: normal;
   margin: 0;
+  overflow: hidden;
   padding: 5px 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .project-overview__list {
@@ -13,12 +19,14 @@
 }
 
 .project-overview__item-heading {
+  font-size: 16px;
   margin: 0;
 }
 
 .project-overview__additional-info {
   align-items: center;
   display: grid;
+  grid-column-gap: 10px;
   grid-template-columns: 50% 50%;
   grid-template-areas: "controller status";
   width: 100%;
@@ -26,6 +34,7 @@
 
 .project-overview__detail--controller {
   grid-area: controller;
+  min-width: 0; // To enable text-overflow: ellipsis within a css-grid area
 }
 
 .project-overview__detail--status {

--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -11,7 +11,7 @@ $height: 18px;
   padding: 0 4px;
   line-height: $height;
   color: #fff;
-  margin: 0 4px;
+  margin-right: 4px;
   background-color: $color-container-dark;
   &--lg {
     border-radius: 12px;
@@ -124,6 +124,15 @@ $height: 18px;
   }
   .co-m-resource-icon {
     flex-shrink: 0;
+  }
+}
+
+.co-resource-link-truncate {
+  white-space: nowrap;
+  .co-resource-link__resource-name {
+    line-height: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 

--- a/frontend/public/components/project-overview.jsx
+++ b/frontend/public/components/project-overview.jsx
@@ -13,6 +13,7 @@ const ProjectOverviewListItem = ({obj}) => {
   const {namespace, name, uid} = metadata;
   const heading = <h3 className="project-overview__item-heading">
     <ResourceLink
+      className="co-resource-link-truncate"
       kind={kind}
       name={name}
       namespace={namespace}
@@ -24,6 +25,7 @@ const ProjectOverviewListItem = ({obj}) => {
       <div className="project-overview__detail project-overview__detail--controller">
         <ComponentLabel text={_.startCase(currentController.kind)} />
         <ResourceLink
+          className="co-resource-link-truncate"
           kind={currentController.kind}
           name={currentController.metadata.name}
           namespace={namespace}

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -91,3 +91,4 @@
 @import "components/cluster-service-instance";
 @import "components/overview";
 @import "components/project-overview";
+@import "components/list-view";

--- a/frontend/public/style/coreos.css
+++ b/frontend/public/style/coreos.css
@@ -303,7 +303,8 @@ input[type="radio"] {
   pointer-events: none; }
 
 .co-m-cog-wrapper {
-  display: inline-block; }
+  display: inline-block;
+  margin-right: 4px; }
 
 .co-m-cog__icon--disabled {
   color: #ddd; }


### PR DESCRIPTION
First pass of ui adjustments
- Enable text truncation of long strings for resource names.
- Minor spacing changds for better alignment and prevent text blocks from touching.
- Font size & weight adjustments to match current origin-web-console overview.

* Follow on to align page heading and filter toolbar

tested in Chrome, Safari, FF, Edge

<img width="1247" alt="screen shot 2018-09-07 at 12 56 55 pm" src="https://user-images.githubusercontent.com/1874151/45236486-f84fda00-b2a9-11e8-8c51-c783a806dc63.png">

<img width="386" alt="screen shot 2018-09-07 at 12 55 11 pm" src="https://user-images.githubusercontent.com/1874151/45236499-fd148e00-b2a9-11e8-84c6-7bfed26135a1.png">
