### PR TITLE
Uppercase "YAML" in sidebar download link

### DIFF
--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -51,7 +51,7 @@ export const SampleYaml = ({sample, loadSampleYaml, downloadSampleYaml}) => {
       <span className="fa fa-fw fa-paste" aria-hidden="true"></span> Try it
     </button>
     <button className="btn btn-link pull-right" onClick={() => downloadSampleYaml(templateName, kind)}>
-      <span className="fa fa-fw fa-download" aria-hidden="true"></span> Download yaml
+      <span className="fa fa-fw fa-download" aria-hidden="true"></span> Download YAML
     </button>
   </li>;
 };


### PR DESCRIPTION
Fixes #510

This is the only place I could find that we use lowercase "yaml"

![okd 2018-09-10 12-17-05](https://user-images.githubusercontent.com/1167259/45310149-879bfe00-b4f3-11e8-8794-52e57c93ae16.png)

/assign @rhamilto 
/cc @cshinn @zherman0 