### PR TITLE
Add ux changes to env editor.

### DIFF
--- a/frontend/__tests__/components/environment.spec.tsx
+++ b/frontend/__tests__/components/environment.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { FieldLevelHelp } from 'patternfly-react';
 
 import { EnvironmentPage } from '../../public/components/environment';
 import * as k8s from '../../public/module/k8s';
@@ -22,8 +23,8 @@ describe(EnvironmentPage.name, () => {
       wrapperRO = shallow(environmentPageRO);
     });
 
-    it('does not show help text', () => {
-      expect(wrapperRO.find('p').exists()).toEqual(false);
+    it('does not show field level help', () => {
+      expect(wrapperRO.find(FieldLevelHelp).exists()).toEqual(false);
     });
 
     it('does not render save and reload buttons', () => {
@@ -44,8 +45,8 @@ describe(EnvironmentPage.name, () => {
       wrapper.setState({secrets, configMaps});
     });
 
-    it('shows help text', () => {
-      expect(wrapper.find('p').text()).toContain('Define environment variables as key-value pairs to store configuration settings.');
+    it('shows field level help component', () => {
+      expect(wrapper.find(FieldLevelHelp).exists()).toEqual(true);
     });
 
     it('renders save and reload buttons', () => {

--- a/frontend/public/components/_environment.scss
+++ b/frontend/public/components/_environment.scss
@@ -2,3 +2,7 @@
   border-top: 1px solid #ddd;
   padding-top: 20px;
 }
+
+.environment-resource-link {
+  display: inline-flex;
+}

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -457,8 +457,8 @@ export class ContainerDropdown extends React.PureComponent {
 }
 
 ContainerDropdown.propTypes = {
-  containers: PropTypes.object.isRequired,
-  currentKey: PropTypes.string,
+  containers: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
+  currentKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   initContainers: PropTypes.object,
   onChange: PropTypes.func.isRequired
 };

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -84,7 +84,7 @@ export const NameValueEditor = withDragDropContext(class NameValueEditor extends
                     <React.Fragment>
                       <span aria-hidden="true" className="co-action-divider hidden-xs">|</span>
                       <button type="button" className="btn btn-link" onClick={this._appendConfigMapOrSecret}>
-                        <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />Add Value from Config Map or Secret
+                        <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />Add from Config Map or Secret
                       </button>
                     </React.Fragment>
                 }
@@ -172,7 +172,7 @@ export const EnvFromEditor = withDragDropContext(class EnvFromEditor extends Rea
     const pairElems = nameValuePairs.map((pair, i) => {
       const key = _.get(pair, [EnvFromPair.Index], i);
 
-      return <EnvFromPairElement onChange={this._change} index={i} nameString="config map/secret" valueString="prefix (optional)" readOnly={readOnly} pair={pair} key={key} onRemove={this._remove} onMove={this._move} rowSourceId={nameValueId} configMaps={configMaps} secrets={secrets} />;
+      return <EnvFromPairElement onChange={this._change} index={i} nameString="config map/secret" valueString="" readOnly={readOnly} pair={pair} key={key} onRemove={this._remove} onMove={this._move} rowSourceId={nameValueId} configMaps={configMaps} secrets={secrets} />;
     });
 
     return <React.Fragment>
@@ -186,7 +186,7 @@ export const EnvFromEditor = withDragDropContext(class EnvFromEditor extends Rea
           {
             !readOnly &&
             <button type="button" className="btn-link pairs-list__btn" onClick={this._append}>
-              <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />Add All Values From Config Map or Secret
+              <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />Add All From Config Map or Secret
             </button>
           }
         </div>

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -111,10 +111,6 @@
   font-weight: 600;
   justify-content: space-between;
   margin: 0 0 20px 0;
-  &--contains-resource-icon {
-    align-items: center;
-    justify-content: flex-start;
-  }
 }
 
 .co-section-heading__title {
@@ -126,6 +122,12 @@
   font-size: 16px;
   font-weight: 600;
   margin: 30px 0;
+}
+
+.co-section-heading-tertiary {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 15px 0;
 }
 
 .co-table-container {
@@ -158,6 +160,7 @@
   margin-bottom: 30px;
 }
 
+.popover-content code,
 .co-m-pane__explanation code {
   background-color: $co-gray-lightest;
   color: $co-gray;

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -32,6 +32,7 @@
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/tooltip";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/utilities";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/responsive-utilities";
+@import "~bootstrap-sass/assets/stylesheets/bootstrap/popovers";
 @import "~patternfly/dist/sass/patternfly/mixins";  // Including this file breaks sourcemaps
 @import '~patternfly/dist/sass/patternfly/icons';  // Including this file breaks sourcemaps
 @import '~patternfly/dist/sass/patternfly/type';
@@ -44,3 +45,4 @@
 @import '~patternfly/dist/sass/patternfly/toolbar';
 @import '~patternfly/dist/sass/patternfly/blank-slate';
 @import '~patternfly/dist/sass/patternfly/list-view';
+@import '~patternfly/dist/sass/patternfly/popovers';


### PR DESCRIPTION
Based on jira card: https://jira.coreos.com/browse/CONSOLE-774 update design of environment editor to align more with changes located in design repo here: http://openshift.github.io/openshift-origin-design/web-console/4.0-designs/environment/environment

![env-ux-gif](https://user-images.githubusercontent.com/35978579/45320829-b45f0e00-b511-11e8-90d5-3c182ddb4693.gif)


Note: This doesn't include the drag and drop updates which are located in this issue: https://github.com/openshift/console/issues/102

Updated screenshots as of 9/11:
Remove placeholder from prefix and update envFrom add link name:
![screen shot 2018-09-11 at 2 38 43 pm](https://user-images.githubusercontent.com/35978579/45380373-8987bf00-b5d0-11e8-8425-acd2e43bfb3d.png)
Fix spacing issue under read-only alert:
![screen shot 2018-09-11 at 2 37 52 pm](https://user-images.githubusercontent.com/35978579/45380374-8987bf00-b5d0-11e8-8fe8-0370c45a44a2.png)
Fix spacing issue / color for FieldLevelHelp component:
![screen shot 2018-09-11 at 2 37 29 pm](https://user-images.githubusercontent.com/35978579/45380375-8987bf00-b5d0-11e8-8694-d37119a83069.png)


