### PR TITLE
Fix Row Filters for Operator Custom Resources

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
@@ -89,7 +89,7 @@ export const ClusterServiceVersionResourcesPage = connect(inFlightStateToProps)(
 
     const rowFilters = [{
       type: 'clusterserviceversion-resource-kind',
-      selected: firehoseResources.map(({kind}) => kind),
+      selected: firehoseResources.map(({kind}) => kindForReference(kind)),
       reducer: ({kind}) => kind,
       items: firehoseResources.map(({kind}) => ({id: kindForReference(kind), title: kindForReference(kind)})),
     }];


### PR DESCRIPTION
### Description

Needed to use `kind` instead of `GroupVersionKind`.

Fixes https://jira.coreos.com/browse/CONSOLE-480