### PR TITLE
downstream install uses yarn deps from sources

### DIFF
--- a/Dockerfile.product
+++ b/Dockerfile.product
@@ -1,3 +1,6 @@
+##################################################
+#
+# go backend build
 FROM openshift/origin-release:golang AS gobuilder
 RUN mkdir -p /go/src/github.com/openshift/console/
 ADD . /go/src/github.com/openshift/console/
@@ -5,16 +8,36 @@ WORKDIR /go/src/github.com/openshift/console/
 RUN ./build-backend.sh
 
 
-# note: front end built separately in order to keep a record of any build tools 
-# from yarn/npm that might have been updated between builds.
-FROM openshift3/origin-console-nodebuilder AS nodebuilder
+##################################################
+#
+# nodejs frontend build
+FROM rhscl/nodejs-8-rhel7 AS nodebuilder
+
+ADD . .
+
+USER 0
+# extract the yarn dependencies that must be provided in the dist-git lookaside cache
+RUN tar fx yarn-offline.tar
+
+# bootstrap yarn so we can install and run the other tools.
+RUN container-entrypoint npm install ./yarn-1.9.4.tgz
+
+# prevent download of chromedriver, sass binary, and node headers as part of module installs
+ENV CHROMEDRIVER_FILEPATH=$HOME/fake_chromedriver.zip \
+    SKIP_SASS_BINARY_DOWNLOAD_FOR_CI=true \
+    NPM_CONFIG_TARBALL=$HOME/node-v8.9.4-headers.tar.gz
+
+# run the build
+RUN container-entrypoint ./build-frontend.sh
 
 
+##################################################
+#
 # actual base image for final product
 FROM openshift3/origin-base
 RUN mkdir -p /opt/bridge/bin
 COPY --from=gobuilder /go/src/github.com/openshift/console/bin/bridge /opt/bridge/bin
-COPY --from=nodebuilder /go/src/github.com/openshift/console/frontend/public/dist /opt/bridge/static
+COPY --from=nodebuilder /opt/app-root/src/frontend/public/dist /opt/bridge/static
 
 WORKDIR /
 # doesn't require a root user.
@@ -26,7 +49,7 @@ LABEL \
         io.k8s.description="This is a component of OpenShift Container Platform and provides a web console." \
         com.redhat.component="openshift-enterprise-console-container" \
         maintainer="Samuel Padgett <spadgett@redhat.com>" \
-        name="openshift3/ose-console" \ 
+        name="openshift3/ose-console" \
         License="Apache 2.0" \
         io.k8s.display-name="OpenShift Console" \
         vendor="Red Hat" \

--- a/sources
+++ b/sources
@@ -1,0 +1,2 @@
+401aa1438604b8e32306fa2bd4f8e211  node-v8.9.4-headers.tar.gz
+6eb618b42413ed28fb9ce0ca4130722e  yarn-offline.tar


### PR DESCRIPTION
master edition of the same conversion from the 3.11 branch, just using latest master yarn.lock.