### PR TITLE
Initial Catalog View

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "openshift-logos-icon": "1.6.0",
     "patternfly": "^3.45.0",
     "patternfly-react": "^2.16.0",
+    "patternfly-react-extensions": "2.5.0",
     "plotly.js": "1.28.x",
     "prop-types": "15.6.x",
     "react": "16.x",

--- a/frontend/public/components/_catalog-item.scss
+++ b/frontend/public/components/_catalog-item.scss
@@ -55,3 +55,14 @@ $catalog-item-icon-size-sm: 24px;
     }
   }
 }
+
+a.co-catalog-item-tile {
+  color: inherit;
+  text-decoration: none;
+  :active,
+  :hover,
+  :visited {
+    color: inherit;
+    text-decoration: none;
+  }
+}

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -61,14 +61,14 @@ _.each(namespacedPrefixes, p => {
   namespacedRoutes.push(`${p}/all-namespaces`);
 });
 
-const NamespaceRedirect = () => {
+const NamespaceRedirect = ({location}) => {
   const activeNamespace = getActiveNamespace();
 
   let to;
   if (activeNamespace === ALL_NAMESPACES_KEY) {
-    to = '/status/all-namespaces';
+    to = `${location.pathname}/all-namespaces`;
   } else if (activeNamespace) {
-    to = `/status/ns/${activeNamespace}`;
+    to = `${location.pathname}/ns/${activeNamespace}`;
   }
   // TODO: check if namespace exists
   return <Redirect to={to} />;
@@ -129,9 +129,15 @@ class App extends React.PureComponent {
         <GlobalNotifications />
         <Switch>
           <Route path={['/all-namespaces', '/ns/:ns',]} component={RedirectComponent} />
+
+          <LazyRoute path="/catalog/all-namespaces" exact loader={() => import('./catalog' /* webpackChunkName: "catalog" */).then(m => m.CatalogPage)} />
+          <LazyRoute path="/catalog/ns/:ns" exact loader={() => import('./catalog' /* webpackChunkName: "catalog" */).then(m => m.CatalogPage)} />
+          <Route path="/catalog" exact component={NamespaceRedirect} />
+
           <LazyRoute path="/status/all-namespaces" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
           <LazyRoute path="/status/ns/:ns" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
           <Route path="/status" exact component={NamespaceRedirect} />
+
           <LazyRoute path="/cluster-health" exact loader={() => import('./cluster-health' /* webpackChunkName: "cluster-health" */).then(m => m.ClusterHealth)} />
           <LazyRoute path="/start-guide" exact loader={() => import('./start-guide' /* webpackChunkName: "start-guide" */).then(m => m.StartGuidePage)} />
           <LazyRoute path="/overview/ns/:ns" exact loader={() => import('./overview' /* webpackChunkName: "overview" */).then(m => m.OverviewPage)} />

--- a/frontend/public/components/catalog-item-icon.tsx
+++ b/frontend/public/components/catalog-item-icon.tsx
@@ -175,14 +175,31 @@ const logos = new Map()
   .set('icon-xamarin', xamarinImg)
   .set('icon-zend', zendImg);
 
-const normalizeIconClass = (iconClass) => {
+export const normalizeIconClass = (iconClass) => {
   return _.startsWith(iconClass, 'icon-') ? `font-icon ${iconClass}` : iconClass;
 };
 
+export const getImageForIconClass = (iconClass) => {
+  return logos.get(iconClass);
+};
+
+export const getServiceClassIcon = (serviceClass) => {
+  return _.get(serviceClass, ['spec', 'externalMetadata', 'console.openshift.io/iconClass'], 'fa fa-clone');
+};
+
+export const getServiceClassImage = (serviceClass) => {
+  const iconClass = getServiceClassIcon(serviceClass);
+  const iconClassImg = getImageForIconClass(iconClass);
+  return _.get(serviceClass, ['spec', 'externalMetadata', 'imageUrl']) || iconClassImg;
+};
+
+export const getImageStreamIcon = (tag) => {
+  return _.get(tag, 'annotations.iconClass');
+};
+
 export const ClusterServiceClassIcon: React.SFC<ClusterServiceClassIconProps> = ({serviceClass, iconSize}) => {
-  const iconClass = _.get(serviceClass, ['spec', 'externalMetadata', 'console.openshift.io/iconClass'], 'fa fa-clone');
-  const iconClassImg = logos.get(iconClass);
-  const imageUrl = _.get(serviceClass, ['spec', 'externalMetadata', 'imageUrl']) || iconClassImg;
+  const iconClass = getServiceClassIcon(serviceClass);
+  const imageUrl = getServiceClassImage(serviceClass);
   return <span className="co-catalog-item-icon">
     { imageUrl
       ? <img className={classNames('co-catalog-item-icon__img', iconSize && `co-catalog-item-icon__img--${iconSize}`)} src={imageUrl} />
@@ -197,8 +214,8 @@ export type ClusterServiceClassIconProps = {
 };
 
 export const ImageStreamIcon: React.SFC<ImageStreamIconProps> = ({tag, iconSize}) => {
-  const iconClass = _.get(tag, 'annotations.iconClass');
-  const iconClassImg = logos.get(iconClass);
+  const iconClass = getImageStreamIcon(tag);
+  const iconClassImg = getImageForIconClass(iconClass);
   return <span className="co-catalog-item-icon">
     { iconClassImg
       ? <img className={classNames('co-catalog-item-icon__img', iconSize && `co-catalog-item-icon__img--${iconSize}`)} src={iconClassImg} />

--- a/frontend/public/components/catalog-items.jsx
+++ b/frontend/public/components/catalog-items.jsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import * as PropTypes from 'prop-types';
+
+import {CatalogTileView} from 'patternfly-react-extensions/dist/esm/components/CatalogTileView';
+import {CatalogTile} from 'patternfly-react-extensions/dist/esm/components/CatalogTile';
+import {normalizeIconClass} from './catalog-item-icon';
+import {Link} from 'react-router-dom';
+
+const CatalogItem = ({item}) => {
+  const catalogTile = <CatalogTile
+    id={item.obj.metadata.uid}
+    key={item.obj.metadata.uid}
+    title={item.tileName}
+    iconImg={item.tileImgUrl}
+    iconClass={item.tileIconClass ? `icon ${normalizeIconClass(item.tileIconClass)}` : null}
+    vendor={item.tileProvider ? `Provided by ${item.tileProvider}` : null}
+    description={item.tileDescription}
+  />;
+  return item.href ? <Link className="co-catalog-item-tile" to={item.href}>{catalogTile}</Link> : catalogTile;
+};
+
+CatalogItem.displayName = 'CatalogItem';
+
+CatalogItem.propTypes = {
+  item: PropTypes.shape({
+    obj: PropTypes.object.isRequired,
+    kind: PropTypes.string.isRequired,
+    tileName: PropTypes.string.isRequired,
+    tileIconClass: PropTypes.string,
+    tileImgUrl: PropTypes.string,
+    tileDescription: PropTypes.string.isRequired,
+    tileProvider: PropTypes.string,
+  }).isRequired
+};
+
+export const CatalogList = ({items}) =>
+  <CatalogTileView>
+    <CatalogTileView.Category key="all" title="All">
+      {_.map(items, (item) => <CatalogItem key={item.obj.metadata.uid} item={item} />)}
+    </CatalogTileView.Category>
+  </CatalogTileView>;
+
+CatalogList.displayName = 'CatalogList';
+
+CatalogList.propTypes = {
+  items: PropTypes.array.isRequired
+};

--- a/frontend/public/components/catalog.jsx
+++ b/frontend/public/components/catalog.jsx
@@ -1,0 +1,167 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import * as PropTypes from 'prop-types';
+import { Helmet } from 'react-helmet';
+
+import { FLAGS, connectToFlags, flagPending } from '../features';
+import { Firehose, NavTitle, StatusBox } from './utils';
+import { CatalogList } from './catalog-items';
+import { getMostRecentBuilderTag, isBuilder} from './image-stream';
+import { serviceClassDisplayName } from '../module/k8s';
+import { getServiceClassIcon, getServiceClassImage, getImageStreamIcon, getImageForIconClass } from './catalog-item-icon';
+
+class CatalogListPage extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      items: [],
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    const {clusterserviceclasses, imagestreams, namespace} = this.props;
+    if (namespace !== prevProps.namespace ||
+      clusterserviceclasses !== prevProps.clusterserviceclasses ||
+      imagestreams !== prevProps.imagestreams) {
+      this.createCatalogData();
+    }
+  }
+
+  createCatalogData() {
+    const {clusterserviceclasses, imagestreams, loaded} = this.props;
+
+    if (!loaded) {
+      return;
+    }
+
+    const clusterServiceClassItems = this.normalizeClusterServiceClasses(clusterserviceclasses.data, 'ClusterServiceClass');
+    const imageStreamsItems = this.normalizeImagestreams(imagestreams.data, 'ImageStream');
+
+    const items = _.sortBy([...clusterServiceClassItems, ...imageStreamsItems], 'tileName');
+
+    this.setState({items});
+  }
+
+  normalizeClusterServiceClasses(serviceClasses, kind) {
+    const activeServiceClasses = _.filter(serviceClasses, serviceClass => {
+      return !serviceClass.status.removedFromBrokerCatalog;
+    });
+
+    return _.map(activeServiceClasses, serviceClass => {
+      const tileName = serviceClassDisplayName(serviceClass);
+      const iconClass = getServiceClassIcon(serviceClass);
+      const tileImgUrl = getServiceClassImage(serviceClass, iconClass);
+      const tileIconClass = tileImgUrl ? null : iconClass;
+      const tileDescription = _.get(serviceClass, 'spec.description');
+      const tileProvider = _.get(serviceClass, 'spec.externalMetadata.providerDisplayName');
+      const href = `/k8s/cluster/clusterserviceclasses/${serviceClass.metadata.name}/create-instance`;
+      return {
+        obj: serviceClass,
+        kind,
+        tileName,
+        tileIconClass,
+        tileImgUrl,
+        tileDescription,
+        tileProvider,
+        href,
+      };
+    });
+  }
+
+  normalizeImagestreams(imagestreams, kind) {
+    const builderImageStreams = _.filter(imagestreams, imagestream => {
+      return isBuilder(imagestream);
+    });
+
+    return _.map(builderImageStreams, imagestream => {
+      const tag = getMostRecentBuilderTag(imagestream);
+      const tileName = _.get(imagestream, ['metadata', 'annotations', 'openshift.io/display-name']) || imagestream.metadata.name;
+      const iconClass = getImageStreamIcon(tag);
+      const tileImgUrl = getImageForIconClass(iconClass);
+      const tileIconClass = tileImgUrl ? null : iconClass;
+      const tileDescription = _.get(tag, 'annotations.description');
+      const tileProvider = _.get(tag, 'annotations.openshift.io/provider-display-name');
+      const { name, namespace } = imagestream.metadata;
+      const href = `/source-to-image?imagestream=${name}&ns=${namespace}`;
+      return {
+        obj: imagestream,
+        kind,
+        tileName,
+        tileIconClass,
+        tileImgUrl,
+        tileDescription,
+        tileProvider,
+        href,
+      };
+    });
+  }
+
+  render() {
+    const {loaded, loadError} = this.props;
+    const {items} = this.state;
+
+    return <div className="co-m-pane">
+      <div className="co-m-pane__body">
+        <StatusBox data={items} loaded={loaded} loadError={loadError} label="Resources">
+          <CatalogList items={items} />
+        </StatusBox>
+      </div>
+    </div>;
+  }
+}
+
+CatalogListPage.displayName = 'CatalogList';
+
+CatalogListPage.propTypes = {
+  obj: PropTypes.object
+};
+
+// eventually may use namespace
+// eslint-disable-next-line no-unused-vars
+export const Catalog = connectToFlags(FLAGS.OPENSHIFT, FLAGS.SERVICE_CATALOG)(({namespace, flags}) => {
+
+  if (flagPending(flags.OPENSHIFT) || flagPending(flags.SERVICE_CATALOG)) {
+    return null;
+  }
+
+  const resources = [];
+  if (flags.SERVICE_CATALOG) {
+    resources.push({
+      isList: true,
+      kind: 'ClusterServiceClass',
+      namespaced: false,
+      prop: 'clusterserviceclasses'
+    });
+  }
+  if (flags.OPENSHIFT) {
+    resources.push({
+      isList: true,
+      kind: 'ImageStream',
+      namespace: 'openshift',
+      prop: 'imagestreams'
+    });
+  }
+  return <div className="catalog">
+    <Firehose resources={resources}>
+      <CatalogListPage />
+    </Firehose>
+  </div>;
+});
+
+Catalog.displayName = 'Catalog';
+
+Catalog.propTypes = {
+  namespace: PropTypes.string.isRequired,
+};
+
+export const CatalogPage = ({match}) => {
+  const namespace = _.get(match, 'params.ns');
+  return <React.Fragment>
+    <Helmet>
+      <title>Catalog</title>
+    </Helmet>
+    <NavTitle title="Catalog" />
+    <Catalog namespace={namespace} />
+  </React.Fragment>;
+};

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -372,6 +372,7 @@ export class Nav extends React.Component {
         <div ref={this.scroller} onWheel={this.preventScroll} className="navigation-container">
           <NavSection text="Home" icon="pficon pficon-home">
             <HrefLink href="/status" name="Status" activePath="/status/" onClick={this.close} />
+            <HrefLink href="/catalog" name="Catalog" activePath="/catalog/" onClick={this.close} />
             <HrefLink href="/search" name="Search" onClick={this.close} startsWith={searchStartsWith} />
             <ResourceNSLink resource="events" name="Events" onClick={this.close} />
           </NavSection>

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
-import { Link } from 'react-router-dom';
 import { IChangeEvent, ISubmitEvent } from 'react-jsonschema-form';
 
 import { createParametersSecret, getInstanceCreateSchema, ServiceCatalogParametersForm } from './schema-form';
@@ -182,7 +181,7 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
             <ServiceCatalogParametersForm schema={schema} onSubmit={this.save} formData={this.state.formData} onChange={this.onFormChange}>
               <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress}>
                 <button type="submit" className="btn btn-primary">Create</button>
-                <Link to={resourcePathFromModel(ClusterServiceClassModel, serviceClass.metadata.name)} className="btn btn-default">Cancel</Link>
+                <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>
               </ButtonBar>
             </ServiceCatalogParametersForm>
           </div>

--- a/frontend/public/components/source-to-image.tsx
+++ b/frontend/public/components/source-to-image.tsx
@@ -4,14 +4,13 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-import * as semver from 'semver';
 
 import { LoadingBox, LoadError } from './utils/status-box';
 import { Dropdown, Firehose, history, MsgBox, ResourceName, resourcePathFromModel } from './utils';
 import { BuildConfigModel, DeploymentConfigModel, ImageStreamModel, ImageStreamTagModel, RouteModel, ServiceModel } from '../models';
 import { ContainerPort, k8sCreate, k8sGet, K8sResourceKind } from '../module/k8s';
 import { ImageStreamIcon } from './catalog-item-icon';
-import { getAnnotationTags, getBuilderTags } from './image-stream';
+import { getAnnotationTags, getBuilderTagsSortedByVersion } from './image-stream';
 import { NsDropdown } from './RBAC/bindings';
 import { ButtonBar } from './utils/button-bar';
 
@@ -94,20 +93,7 @@ class BuildSource extends React.Component<BuildSourceProps, BuildSourceState> {
     if (obj !== prevProps.obj && obj.loaded) {
       const previousTag = this.state.selectedTag;
       // Sort tags in reverse order by semver, falling back to a string comparison if not a valid version.
-      const tags = getBuilderTags(obj.data).sort(({name: a}, {name: b}) => {
-        const v1 = semver.coerce(a);
-        const v2 = semver.coerce(b);
-        if (!v1 && !v2) {
-          return a.localeCompare(b);
-        }
-        if (!v1) {
-          return 1;
-        }
-        if (!v2) {
-          return -1;
-        }
-        return semver.rcompare(v1, v2);
-      });
+      const tags = getBuilderTagsSortedByVersion(obj.data);
       // Select the first tag if the current tag is missing or empty.
       const selectedTag = previousTag && _.includes(tags, previousTag)
         ? previousTag

--- a/frontend/public/components/utils/link.jsx
+++ b/frontend/public/components/utils/link.jsx
@@ -14,7 +14,7 @@ export const legalNamePattern = /[a-z0-9](?:[-a-z0-9]*[a-z0-9])?/;
 
 const basePathPattern = new RegExp(`^/?${window.SERVER_FLAGS.basePath}`);
 
-export const namespacedPrefixes = ['/search', '/status', '/k8s', '/overview'];
+export const namespacedPrefixes = ['/search', '/status', '/k8s', '/overview', '/catalog'];
 
 export const stripBasePath = path => path.replace(basePathPattern, '/');
 

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -9,6 +9,7 @@
 @import '~patternfly/dist/sass/patternfly/variables';
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/variables";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins";
+@import '~patternfly-react-extensions/dist/sass/patternfly-react-extensions';
 @import "~font-awesome-sass/assets/stylesheets/font-awesome/variables";
 @import "~xterm/dist/addons/fullscreen/fullscreen";
 @import "~openshift-logos-icon/style";

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8141,6 +8141,39 @@ patternfly-bootstrap-treeview@~2.1.0:
     bootstrap "3.3.x"
     jquery ">= 2.1.x"
 
+patternfly-react-extensions@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/patternfly-react-extensions/-/patternfly-react-extensions-2.5.0.tgz#50631d2ca9bc143cb8cd13a2534518e352344375"
+  dependencies:
+    breakjs "^1.0.0"
+    classnames "^2.2.5"
+    css-element-queries "^1.0.1"
+    patternfly "^3.52.1"
+    patternfly-react "^2.15.0"
+
+patternfly-react@^2.15.0:
+  version "2.17.3"
+  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.17.3.tgz#def0c43c5cef213d24ebbadc5dcdb88621150c0b"
+  dependencies:
+    bootstrap-slider-without-jquery "^10.0.0"
+    breakjs "^1.0.0"
+    classnames "^2.2.5"
+    css-element-queries "^1.0.1"
+    patternfly "^3.52.4"
+    react-bootstrap "^0.32.1"
+    react-bootstrap-switch "^15.5.3"
+    react-bootstrap-typeahead "^3.1.3"
+    react-c3js "^0.1.20"
+    react-click-outside "^3.0.1"
+    react-collapse "^4.0.3"
+    react-fontawesome "^1.6.1"
+    react-motion "^0.5.2"
+    reactabular-table "^8.14.0"
+    recompose "^0.26.0"
+  optionalDependencies:
+    sortabular "^1.5.1"
+    table-resolver "^3.2.0"
+
 patternfly-react@^2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.16.0.tgz#5268662e2a7e795e63467e3ccdff3005eef2a67b"
@@ -8197,6 +8230,37 @@ patternfly@^3.45.0:
 patternfly@^3.52.1:
   version "3.54.2"
   resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.54.2.tgz#58b4b424462c4b01aaebf41db2da3bcd63bedfbf"
+  dependencies:
+    bootstrap "~3.3.7"
+    font-awesome "^4.7.0"
+    jquery "~3.2.1"
+  optionalDependencies:
+    "@types/c3" "^0.6.0"
+    bootstrap-datepicker "^1.7.1"
+    bootstrap-sass "^3.3.7"
+    bootstrap-select "1.12.2"
+    bootstrap-slider "^9.9.0"
+    bootstrap-switch "~3.3.4"
+    bootstrap-touchspin "~3.1.1"
+    c3 "~0.4.11"
+    d3 "~3.5.17"
+    datatables.net "^1.10.15"
+    datatables.net-colreorder "^1.4.1"
+    datatables.net-colreorder-bs "~1.3.2"
+    datatables.net-select "~1.2.0"
+    drmonty-datatables-colvis "~1.1.2"
+    eonasdan-bootstrap-datetimepicker "^4.17.47"
+    font-awesome-sass "^4.7.0"
+    google-code-prettify "~1.0.5"
+    jquery-match-height "^0.7.2"
+    moment "^2.19.1"
+    moment-timezone "^0.4.1"
+    patternfly-bootstrap-combobox "~1.1.7"
+    patternfly-bootstrap-treeview "~2.1.0"
+
+patternfly@^3.52.4:
+  version "3.54.3"
+  resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.54.3.tgz#4626c4f5506d6d993f7089ae14849646645fa4b2"
   dependencies:
     bootstrap "~3.3.7"
     font-awesome "^4.7.0"


### PR DESCRIPTION
**Todo:**
- [x] Add 'Catalog' namespaced navigation
- [x] Add ClusterServiceClasses
- [x] Add ImageStreams in the `openshift` namespace with the `builder` tag and no `hidden` tag in the catalog
- [x] Integrate with patternfly-react-extension's CatalogTileView
- [x] Click on Catalog tile and launch Create form(s)
- [ ] Add OLMs
- [ ] Use TypeScript for new components

![image](https://user-images.githubusercontent.com/12733153/45758719-4511aa00-bbf4-11e8-9706-97cd6b9c4e4c.png)

**Click on any Catalog tile and launch Create form:**
![image](https://user-images.githubusercontent.com/12733153/45763258-18629000-bbfe-11e8-9aae-217c4b8591dd.png)
