### PR TITLE
Add missing classes for CRD links

### DIFF
--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -26,8 +26,10 @@ const namespaced = crd => crd.spec.scope === 'Namespaced';
 const CRDRow = ({obj: crd}) => <div className="row co-resource-list__item">
   <div className="col-lg-4 col-md-4 col-sm-4 col-xs-6 co-resource-link-wrapper">
     <ResourceCog actions={menuActions} kind="CustomResourceDefinition" resource={crd} />
-    <ResourceIcon kind="CustomResourceDefinition" />
-    <Link to={`/k8s/all-namespaces/customresourcedefinitions/${referenceForCRD(crd)}`}>{_.get(crd, 'spec.names.kind', crd.metadata.name)}</Link>
+    <span className="co-resource-link">
+      <ResourceIcon kind="CustomResourceDefinition" />
+      <Link className="co-resource-link__resource-name" to={`/k8s/all-namespaces/customresourcedefinitions/${referenceForCRD(crd)}`}>{_.get(crd, 'spec.names.kind', crd.metadata.name)}</Link>
+    </span>
   </div>
   <div className="col-lg-3 col-md-4 col-sm-4 col-xs-6 co-break-word">
     { crd.spec.group }


### PR DESCRIPTION
Before:
![2](https://user-images.githubusercontent.com/1668218/45538798-516ac100-b808-11e8-89bf-1106a8609960.png)

After:
![1](https://user-images.githubusercontent.com/1668218/45538810-5465b180-b808-11e8-9896-34f1d65d436f.png)

/assign @spadgett 