### PR TITLE
Remove unnecessary `bind` calls for create instance/binding pages

### DIFF
--- a/frontend/public/components/service-catalog/create-binding.tsx
+++ b/frontend/public/components/service-catalog/create-binding.tsx
@@ -48,10 +48,6 @@ class CreateBindingForm extends React.Component<CreateBindingProps, CreateBindin
       formData: {},
       inProgress: false,
     };
-
-    this.onNameChange = this.onNameChange.bind(this);
-    this.onFormChange = this.onFormChange.bind(this);
-    this.save = this.save.bind(this);
   }
 
   onNameChange: React.ReactEventHandler<HTMLInputElement> = event => {

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -30,11 +30,6 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
       formData: {},
       inProgress: false,
     };
-
-    this.onNamespaceChange = this.onNamespaceChange.bind(this);
-    this.onNameChange = this.onNameChange.bind(this);
-    this.onFormChange = this.onFormChange.bind(this);
-    this.save = this.save.bind(this);
   }
 
   static getDerivedStateFromProps(props: CreateInstanceProps, state: CreateInstanceState) {


### PR DESCRIPTION
These methods are declared using `=>`, so `bind` is not needed.

/assign @rhamilto 