### PR TITLE
Create import YAML page

### DIFF
--- a/frontend/integration-tests/tests/olm/catalog.scenario.ts
+++ b/frontend/integration-tests/tests/olm/catalog.scenario.ts
@@ -40,6 +40,6 @@ describe('Installing a service from the Catalog Sources', () => {
     await catalogView.createSubscriptionFor('Prometheus Operator');
     await browser.wait(until.presenceOf($('.ace_text-input')));
 
-    expect($('.yaml-editor-header').getText()).toEqual('Create Subscription');
+    expect($('.yaml-editor__header').getText()).toEqual('Create Subscription');
   });
 });

--- a/frontend/integration-tests/tests/olm/etcd.scenario.ts
+++ b/frontend/integration-tests/tests/olm/etcd.scenario.ts
@@ -99,7 +99,7 @@ describe('Interacting with the etcd OCS', () => {
     const newContent = defaultsDeep({}, {metadata: {name: `${testName}-etcdcluster`, labels: {[testLabel]: testName}}}, safeLoad(content));
     await yamlView.setContent(safeDump(newContent));
 
-    expect($('.yaml-editor-header').getText()).toEqual('Create Etcd Cluster');
+    expect($('.yaml-editor__header').getText()).toEqual('Create Etcd Cluster');
   });
 
   it('displays new `EtcdCluster` that was created from YAML editor', async() => {
@@ -120,8 +120,8 @@ describe('Interacting with the etcd OCS', () => {
 
   it('displays the raw YAML for the `EtcdCluster`', async() => {
     await element(by.linkText('YAML')).click();
-    await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
-    await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
+    await browser.wait(until.presenceOf($('.yaml-editor__buttons')));
+    await $('.yaml-editor__buttons').element(by.buttonText('Save')).click();
     await browser.wait(until.visibilityOf(crudView.successMessage), 2000);
 
     expect(crudView.successMessage.getText()).toContain(`${etcdcluster} has been updated to version`);
@@ -148,7 +148,7 @@ describe('Interacting with the etcd OCS', () => {
     const newContent = defaultsDeep({}, {metadata: {name: `${testName}-etcdbackup`, labels: {[testLabel]: testName}}}, safeLoad(content));
     await yamlView.setContent(safeDump(newContent));
 
-    expect($('.yaml-editor-header').getText()).toEqual('Create Etcd Backup');
+    expect($('.yaml-editor__header').getText()).toEqual('Create Etcd Backup');
   });
 
   it('displays new `EtcdBackup` that was created from YAML editor', async() => {
@@ -169,8 +169,8 @@ describe('Interacting with the etcd OCS', () => {
 
   it('displays the raw YAML for the `EtcdBackup`', async() => {
     await element(by.linkText('YAML')).click();
-    await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
-    await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
+    await browser.wait(until.presenceOf($('.yaml-editor__buttons')));
+    await $('.yaml-editor__buttons').element(by.buttonText('Save')).click();
     await browser.wait(until.visibilityOf(crudView.successMessage), 2000);
 
     expect(crudView.successMessage.getText()).toContain(`${etcdbackup} has been updated to version`);
@@ -197,7 +197,7 @@ describe('Interacting with the etcd OCS', () => {
     const newContent = defaultsDeep({}, {metadata: {name: `${testName}-etcdrestore`, labels: {[testLabel]: testName}}}, safeLoad(content));
     await yamlView.setContent(safeDump(newContent));
 
-    expect($('.yaml-editor-header').getText()).toEqual('Create Etcd Restore');
+    expect($('.yaml-editor__header').getText()).toEqual('Create Etcd Restore');
   });
 
   it('displays new `EtcdRestore` that was created from YAML editor', async() => {
@@ -218,8 +218,8 @@ describe('Interacting with the etcd OCS', () => {
 
   it('displays the raw YAML for the `EtcdRestore`', async() => {
     await element(by.linkText('YAML')).click();
-    await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
-    await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
+    await browser.wait(until.presenceOf($('.yaml-editor__buttons')));
+    await $('.yaml-editor__buttons').element(by.buttonText('Save')).click();
     await browser.wait(until.visibilityOf(crudView.successMessage), 2000);
 
     expect(crudView.successMessage.getText()).toContain(`${etcdrestore} has been updated to version`);

--- a/frontend/integration-tests/tests/olm/prometheus.scenario.ts
+++ b/frontend/integration-tests/tests/olm/prometheus.scenario.ts
@@ -97,7 +97,7 @@ describe('Interacting with the Prometheus OCS', () => {
     await $$('.dropdown-menu').first().element(by.linkText('Prometheus')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
 
-    expect($('.yaml-editor-header').getText()).toEqual('Create Prometheus');
+    expect($('.yaml-editor__header').getText()).toEqual('Create Prometheus');
   });
 
   it('displays new `Prometheus` that was created from YAML editor', async() => {
@@ -117,9 +117,9 @@ describe('Interacting with the Prometheus OCS', () => {
 
   it('displays the raw YAML for the `Prometheus`', async() => {
     await element(by.linkText('YAML')).click();
-    await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
-    await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
-    await browser.wait(until.visibilityOf(crudView.successMessage), 1000);
+    await browser.wait(until.presenceOf($('.yaml-editor__buttons')));
+    await $('.yaml-editor__buttons').element(by.buttonText('Save')).click();
+    await browser.wait(until.visibilityOf($('.alert-success')), 1000);
 
     expect(crudView.successMessage.getText()).toContain('example has been updated to version');
   });
@@ -141,7 +141,7 @@ describe('Interacting with the Prometheus OCS', () => {
     await $$('.dropdown-menu').first().element(by.linkText('Alertmanager')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
 
-    expect($('.yaml-editor-header').getText()).toEqual('Create Alertmanager');
+    expect($('.yaml-editor__header').getText()).toEqual('Create Alertmanager');
   });
 
   it('displays new `Alertmanager` that was created from YAML editor', async() => {
@@ -162,8 +162,8 @@ describe('Interacting with the Prometheus OCS', () => {
 
   it('displays the raw YAML for the `Alertmanager`', async() => {
     await element(by.linkText('YAML')).click();
-    await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
-    await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
+    await browser.wait(until.presenceOf($('.yaml-editor__buttons')));
+    await $('.yaml-editor__buttons').element(by.buttonText('Save')).click();
     await browser.wait(until.visibilityOf(crudView.successMessage), 1000);
 
     expect(crudView.successMessage.getText()).toContain('alertmanager-main has been updated to version');
@@ -186,7 +186,7 @@ describe('Interacting with the Prometheus OCS', () => {
     await $$('.dropdown-menu').first().element(by.linkText('Service Monitor')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')), 10000);
 
-    expect($('.yaml-editor-header').getText()).toEqual('Create Service Monitor');
+    expect($('.yaml-editor__header').getText()).toEqual('Create Service Monitor');
   });
 
   it('displays new `ServiceMonitor` that was created from YAML editor', async() => {
@@ -206,8 +206,8 @@ describe('Interacting with the Prometheus OCS', () => {
 
   it('displays the raw YAML for the `ServiceMonitor`', async() => {
     await element(by.linkText('YAML')).click();
-    await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
-    await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
+    await browser.wait(until.presenceOf($('.yaml-editor__buttons')));
+    await $('.yaml-editor__buttons').element(by.buttonText('Save')).click();
     await browser.wait(until.visibilityOf(crudView.successMessage), 1000);
 
     expect(crudView.successMessage.getText()).toContain('example has been updated to version');

--- a/frontend/integration-tests/views/yaml.view.ts
+++ b/frontend/integration-tests/views/yaml.view.ts
@@ -2,8 +2,8 @@
 
 import { $, $$, by, Key, browser, ExpectedConditions as until } from 'protractor';
 
-export const saveButton = $('.yaml-editor--buttons').$('#save-changes');
-export const cancelButton = $('.yaml-editor--buttons').element(by.buttonText('Cancel'));
+export const saveButton = $('.yaml-editor__buttons').$('#save-changes');
+export const cancelButton = $('.yaml-editor__buttons').element(by.buttonText('Cancel'));
 
 export const isLoaded = () => browser.wait(until.visibilityOf(saveButton));
 

--- a/frontend/public/components/_edit-yaml.scss
+++ b/frontend/public/components/_edit-yaml.scss
@@ -1,24 +1,27 @@
-.yaml-editor-header {
+.yaml-editor__header {
   border-bottom: 1px solid #ddd;
   font-size: 16px;
-  height: 45px;
   padding: 10px 20px;
+}
+
+.yaml-editor__subheader {
+  font-size: 13px;
 }
 
 .yaml-editor {
   position: relative;
 }
 
-.yaml-editor--flexbox {
+.yaml-editor__flexbox {
   display: flex;
   flex-direction: column;
 }
 
-.yaml-editor--acebox {
+.yaml-editor__acebox {
   flex: 1;
 }
 
-.yaml-editor--buttons {
+.yaml-editor__buttons {
   background: white;
   border-top: 1px solid #ddd;
   padding: 20px ($grid-gutter-width / 2);

--- a/frontend/public/components/_import-yaml.scss
+++ b/frontend/public/components/_import-yaml.scss
@@ -1,0 +1,15 @@
+.co-import-yaml-link {
+  margin-left: auto;
+
+  &:hover {
+    background-color: transparent;
+  }
+
+  @media (min-width: $grid-float-breakpoint) {
+    padding-top: 7px !important;
+  }
+}
+
+.co-create-from-yaml__add-icon {
+  margin-right: 9px;
+}

--- a/frontend/public/components/_nav.scss
+++ b/frontend/public/components/_nav.scss
@@ -3,6 +3,7 @@ $link-padding-left: 40px;
 $section-padding-left: 13px;
 $active-border: 3px;
 
+.co-m-masthead-link,
 .co-m-nav-link {
   display: block;
   float: none;
@@ -28,13 +29,15 @@ $active-border: 3px;
       color: #fff;
     }
   }
+}
 
+.co-m-nav-link {
   &:hover {
-   background-color: $color-os-nav-background-active;
+    background-color: $color-os-nav-background-active;
   }
 
   &:focus {
-   background-color: transparent;
+    background-color: transparent;
   }
 }
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -165,6 +165,9 @@ class App extends React.PureComponent {
             <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
             <Route path="/search" exact component={ActiveNamespaceRedirect} />
 
+            <LazyRoute path="/k8s/all-namespaces/import" exact loader={() => import('./import-yaml').then(m => NamespaceFromURL(m.ImportYamlPage))} />
+            <LazyRoute path="/k8s/ns/:ns/import/" exact loader={() => import('./import-yaml').then(m => NamespaceFromURL(m.ImportYamlPage))} />
+
             <Route path="/k8s/ns/:ns/customresourcedefinitions/:plural" exact component={ResourceListPage} />
             <Route path="/k8s/ns/:ns/customresourcedefinitions/:plural/:name" component={ResourceDetailsPage} />
             <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural" exact component={ResourceListPage} />

--- a/frontend/public/components/create-yaml.tsx
+++ b/frontend/public/components/create-yaml.tsx
@@ -11,7 +11,7 @@ import { ErrorPage404 } from './error';
 import { ClusterServiceVersionModel } from '../models';
 
 export const CreateYAML = connectToPlural((props: CreateYAMLProps) => {
-  const {match, kindsInFlight, kindObj} = props;
+  const {match, kindsInFlight, kindObj, showHeader = true} = props;
   const {params} = match;
 
   if (!kindObj) {
@@ -38,7 +38,7 @@ export const CreateYAML = connectToPlural((props: CreateYAMLProps) => {
   // TODO: if someone edits namespace, we'll redirect to old namespace
   const redirectURL = params.appName ? `/k8s/ns/${namespace}/${ClusterServiceVersionModel.plural}/${params.appName}/instances` : null;
 
-  return <AsyncComponent loader={() => import('./edit-yaml').then(c => c.EditYAML)} obj={obj} create={true} kind={kindObj.kind} redirectURL={redirectURL} showHeader={true} />;
+  return <AsyncComponent loader={() => import('./edit-yaml').then(c => c.EditYAML)} obj={obj} create={true} kind={kindObj.kind} redirectURL={redirectURL} showHeader={showHeader} />;
 });
 
 export const EditYAMLPage: React.SFC<EditYAMLPageProps> = (props) => {
@@ -54,6 +54,8 @@ export type CreateYAMLProps = {
   kindsInFlight: boolean;
   kindObj: K8sKind;
   template?: string;
+  download?: boolean;
+  showHeader?: boolean;
 };
 
 export type EditYAMLPageProps = {

--- a/frontend/public/components/import-yaml.tsx
+++ b/frontend/public/components/import-yaml.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { AsyncComponent } from './utils';
+
+export const ImportYamlPage = () => {
+
+  return <React.Fragment>
+    <div className="yaml-editor__header">
+      <div>Import YAML</div>
+      <div className="yaml-editor__subheader">Create resources from their YAML or JSON definitions.</div>
+    </div>
+    <AsyncComponent loader={() => import('./edit-yaml').then(c => c.EditYAML)} create={true} showHeader={false} download={false} />;
+  </React.Fragment>;
+
+};

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -7,7 +7,7 @@ import * as fuzzy from 'fuzzysearch';
 
 import { NamespaceModel, ProjectModel, SecretModel } from '../models';
 import { k8sGet } from '../module/k8s';
-import { UIActions } from '../ui/ui-actions';
+import { formatNamespacedRouteForResource, UIActions } from '../ui/ui-actions';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { SafetyFirst } from './safety-first';
 import { Cog, Dropdown, Firehose, LabelList, LoadingInline, navFactory, ResourceCog, SectionHeading, ResourceLink, ResourceSummary, humanizeMem, MsgBox } from './utils';
@@ -275,6 +275,11 @@ class NamespaceDropdown_ extends React.Component {
         defaultBookmarks={defaultBookmarks}
         storageKey={NAMESPACE_LOCAL_STORAGE_KEY}
         shortCut="n" />
+      <div className="co-import-yaml-link co-m-masthead-link">
+        <Link to={formatNamespacedRouteForResource('import', activeNamespace)}>
+          <span className="pficon pficon-add-circle-o co-create-from-yaml__add-icon" aria-hidden="true"></span>Import YAML
+        </Link>
+      </div>
     </div>;
   }
 }

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -95,3 +95,4 @@
 @import "components/list-view";
 @import "components/deploy-image";
 @import "components/source-to-image";
+@import "components/import-yaml";


### PR DESCRIPTION
Here is the page as it stands ATM.
I put the link to Create from YAML under the Home navigation, because I'm not sure it makes sense to have a project selector at the top of a generic uploader. The namespace is specified in the YAML and if they have one project selected, but then paste some YAML for a different namespace, I'm not sure what the behavior should be. 

![screen shot 2018-09-18 at 10 58 58 am](https://user-images.githubusercontent.com/26305082/45696543-dc61f900-bb31-11e8-9d8f-10b33aab3b7b.png)
