### PR TITLE
Add Init Container support to env editor

### DIFF
--- a/frontend/public/components/daemon-set.jsx
+++ b/frontend/public/components/daemon-set.jsx
@@ -102,7 +102,7 @@ const EnvironmentPage = (props) => <AsyncComponent loader={() => import('./envir
 const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
-  rawEnvData={props.obj.spec.template.spec.containers}
+  rawEnvData={props.obj.spec.template.spec}
   envPath={envPath}
   readOnly={false}
 />;

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -152,7 +152,7 @@ const EnvironmentPage = (props) => <AsyncComponent loader={() => import('./envir
 const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
-  rawEnvData={props.obj.spec.template.spec.containers}
+  rawEnvData={props.obj.spec.template.spec}
   envPath={envPath}
   readOnly={false}
 />;

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -115,7 +115,7 @@ const EnvironmentPage = (props) => <AsyncComponent loader={() => import('./envir
 const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
-  rawEnvData={props.obj.spec.template.spec.containers}
+  rawEnvData={props.obj.spec.template.spec}
   envPath={envPath}
   readOnly={false}
 />;

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -229,7 +229,7 @@ const EnvironmentPage = (props) => <AsyncComponent loader={() => import('./envir
 const envPath = ['spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
-  rawEnvData={props.obj.spec.containers}
+  rawEnvData={props.obj.spec}
   envPath={envPath}
   readOnly={true}
 />;

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -33,7 +33,7 @@ const EnvironmentPage = (props) => <AsyncComponent loader={() => import('./envir
 const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
-  rawEnvData={props.obj.spec.template.spec.containers}
+  rawEnvData={props.obj.spec.template.spec}
   envPath={envPath}
   readOnly={false}
 />;

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -29,7 +29,7 @@ const EnvironmentPage = (props) => <AsyncComponent loader={() => import('./envir
 const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
-  rawEnvData={props.obj.spec.template.spec.containers}
+  rawEnvData={props.obj.spec.template.spec}
   envPath={envPath}
   readOnly={false}
 />;

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -40,7 +40,7 @@ const EnvironmentPage = (props) => <AsyncComponent loader={() => import('./envir
 const envPath = ['spec','template','spec','containers'];
 const environmentComponent = (props) => <EnvironmentPage
   obj={props.obj}
-  rawEnvData={props.obj.spec.template.spec.containers}
+  rawEnvData={props.obj.spec.template.spec}
   envPath={envPath}
   readOnly={false}
 />;


### PR DESCRIPTION
PR for: https://jira.coreos.com/browse/CONSOLE-780
In addition to containers, now init containers are supported for environment variable editing/viewing. They are available for all previously supported workloads except builds and build configs.

![screen shot 2018-09-18 at 12 20 36 pm](https://user-images.githubusercontent.com/35978579/45701620-c0fceb00-bb3d-11e8-984b-50697f2bc6d0.png)

![screen shot 2018-09-18 at 12 21 14 pm](https://user-images.githubusercontent.com/35978579/45701628-c5c19f00-bb3d-11e8-8129-fdb0b81afe18.png)
