### PR TITLE
Remove hash link to "Software Info" as lazy loading routes broke it

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,7 +81,6 @@
     "react-modal": "3.x",
     "react-redux": "5.x",
     "react-router-dom": "4.x",
-    "react-router-hash-link": "^1.2.0",
     "react-tagsinput": "3.19.x",
     "react-transition-group": "2.3.x",
     "react-virtualized": "9.x",

--- a/frontend/public/components/cluster-overview.jsx
+++ b/frontend/public/components/cluster-overview.jsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-import { HashLink } from 'react-router-hash-link';
 
 import { coFetch, coFetchJSON } from '../co-fetch';
 import { NavTitle, AsyncComponent, Firehose, StatusBox, DocumentationLinks, AdditionalSupportLinks } from './utils';
@@ -168,7 +167,7 @@ const GraphsPage = ({fake, limited, namespace, openshiftFlag}) => {
       </div>
     </div>
     <div className="col-lg-4 col-md-12">
-      <div className="group" id="software-info">
+      <div className="group">
         <div className="group__title">
           <h2 className="h3">Software Info</h2>
         </div>
@@ -247,11 +246,7 @@ const ClusterOverviewPage_ = props => {
     <Helmet>
       <title>{fake ? 'Overview' : title}</title>
     </Helmet>
-    <NavTitle title={fake ? 'Overview' : title} style={{alignItems: 'baseline', display: 'flex', justifyContent: 'space-between'}}>
-      <p className="hidden-lg">
-        <HashLink smooth to="#software-info">Software Info</HashLink>
-      </p>
-    </NavTitle>
+    <NavTitle title={fake ? 'Overview' : title} />
     <div className="cluster-overview-cell container-fluid">
       <AsyncComponent namespace={namespace} loader={permissionedLoader} openshiftFlag={openshiftFlag} fake={fake} />
     </div>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9171,12 +9171,6 @@ react-router-dom@4.x:
     react-router "^4.2.0"
     warning "^3.0.0"
 
-react-router-hash-link@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-router-hash-link/-/react-router-hash-link-1.2.0.tgz#ce824cc5f0502ce9b0686bb6dd9c08659b24094c"
-  dependencies:
-    prop-types "^15.6.0"
-
 react-router@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"


### PR DESCRIPTION
...and we plan to migrate the software info details to a modal anyhow.

Fixes https://jira.coreos.com/browse/CONSOLE-788