### PR TITLE
Move Deploy Image to non-namespaced route and auto-select namespace

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -171,7 +171,7 @@ class App extends React.PureComponent {
             // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
           }
 
-          <LazyRoute path="/k8s/ns/:ns/deploymentconfigs/new/image" exact loader={() => import('./deploy-image').then(m => m.DeployImage)} />
+          <LazyRoute path="/deploy-image" exact loader={() => import('./deploy-image').then(m => m.DeployImage)} />
 
           <LazyRoute path="/k8s/ns/:ns/secrets/new/:type" exact kind="Secret" loader={() => import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(m => m.CreateSecret)} />
           <LazyRoute path="/k8s/ns/:ns/secrets/:name/edit" exact kind="Secret" loader={() => import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(m => m.EditSecret)} />

--- a/frontend/public/components/deploy-image.tsx
+++ b/frontend/public/components/deploy-image.tsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 
 import { getPorts } from './source-to-image';
 import { history, Loading, NavTitle, resourcePathFromModel, Timestamp, units } from './utils';
-import { getActiveNamespace } from '../ui/ui-actions';
+import { formatNamespacedRouteForResource } from '../ui/ui-actions';
 import { NsDropdown } from './RBAC/bindings';
 import { k8sCreate } from '../module/k8s';
 import { ButtonBar } from './utils/button-bar';
@@ -30,8 +30,11 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
   constructor (props) {
     super(props);
 
+    const params = new URLSearchParams(props.location.search);
+    const ns = params.get('ns');
+
     this.state = {
-      namespace: '',
+      namespace: ns,
       imageName: '',
       loading: false,
       inProgress: false,
@@ -363,7 +366,7 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
           </div>
           <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress}>
             <button type="submit" className="btn btn-primary" disabled={!this.state.namespace || !this.state.imageName || !this.state.name}>Deploy</button>
-            <Link to={`/k8s/ns/${getActiveNamespace() || 'default'}/deploymentconfigs`} className="btn btn-default">Cancel</Link>
+            <Link to={formatNamespacedRouteForResource('deploymentconfigs')} className="btn btn-default">Cancel</Link>
           </ButtonBar>
         </form>
       </div>
@@ -371,7 +374,9 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
   }
 }
 
-export type DeployImageProps = {};
+export type DeployImageProps = {
+  location: any,
+};
 
 export type DeployImageState = {
   namespace: string,

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -141,7 +141,9 @@ export const DeploymentConfigsPage: React.SFC<DeploymentConfigsPageProps> = prop
 
   const createProps = {
     items: createItems,
-    createLink: type => `/k8s/ns/${props.namespace || 'default'}/deploymentconfigs/new/${type !== 'yaml' ? type : ''}`
+    createLink: type => type === 'image'
+      ? `/deploy-image${props.namespace ? `?ns=${props.namespace}` : ''}`
+      : `/k8s/ns/${props.namespace || 'default'}/deploymentconfigs/new`
   };
   return <ListPage {...props} title="Deployment Configs" kind={DeploymentConfigsReference} ListComponent={DeploymentConfigsList} canCreate={true} createButtonText="Create" createProps={createProps} filterLabel={props.filterLabel} />;
 };


### PR DESCRIPTION
... if namespace is not "all projects"

And fix bug where cancel button resulted in a 404 if "all projects" is the currently selected namespace.

When "all projects" is selected namespace:
![localhost_9000_k8s_all-namespaces_deploymentconfigs](https://user-images.githubusercontent.com/895728/45758522-cf0d4300-bbf3-11e8-913d-2c8f744ff086.png)
![localhost_9000_k8s_all-namespaces_deploymentconfigs 1](https://user-images.githubusercontent.com/895728/45758556-dfbdb900-bbf3-11e8-870d-c93a05c8dd4b.png)

When a specific namespace is selected:
![localhost_9000_k8s_all-namespaces_deploymentconfigs 2](https://user-images.githubusercontent.com/895728/45758564-e2b8a980-bbf3-11e8-815e-86f06abb1213.png)
![localhost_9000_k8s_all-namespaces_deploymentconfigs 3](https://user-images.githubusercontent.com/895728/45758565-e2b8a980-bbf3-11e8-9efc-13fe44a4e94e.png)

