### PR TITLE
Redirect to creates resource instead of list page

### DIFF
--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -164,7 +164,11 @@ describe('Kubernetes resource CRUD operations', () => {
       await $('#subject-name').sendKeys('subject-name');
       leakedResources.add(JSON.stringify({name: bindingName, plural: 'rolebindings', namespace: testName}));
       await crudView.saveChangesBtn.click();
-      await browser.wait(until.urlContains(`/k8s/ns/${testName}/rolebindings`));
+      expect(yamlView.errorMessage.isPresent()).toBe(false);
+    });
+
+    it('search view displays created RoleBinding', async() => {
+      await browser.get(`${appHost}/k8s/ns/${testName}/rolebindings`);
       // Filter by resource name to make sure the resource is on the first page of results.
       // Otherwise the tests fail since we do virtual scrolling and the element isn't found.
       await crudView.filterForName(bindingName);

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import * as PropTypes from 'prop-types';
 
-import { getQN, k8sCreate, k8sPatch } from '../../module/k8s';
+import { getQN, k8sCreate, k8sPatch, referenceFor } from '../../module/k8s';
 import { getActiveNamespace, formatNamespacedRouteForResource, UIActions } from '../../ui/ui-actions';
 import { ColHead, List, ListHeader, MultiListPage, ResourceRow } from '../factory';
 import { RadioGroup } from '../radio';
@@ -443,16 +443,13 @@ const BaseEditRoleBinding = connect(null, {setActiveNamespace: UIActions.setActi
       (this.props.isCreate
         ? k8sCreate(ko, this.state.data)
         : k8sPatch(ko, {metadata}, [{op: 'replace', path: `/subjects/${this.subjectIndex}`, value: subject}])
-      ).then(
-        () => {
-          this.setState({inProgress: false});
-          if (metadata.namespace) {
-            this.props.setActiveNamespace(metadata.namespace);
-          }
-          history.push(formatNamespacedRouteForResource('rolebindings'));
-        },
-        err => this.setState({error: err.message, inProgress: false})
-      );
+      ).then(obj => {
+        this.setState({inProgress: false});
+        if (metadata.namespace) {
+          this.props.setActiveNamespace(metadata.namespace);
+        }
+        history.push(resourceObjPath(obj, referenceFor(obj)));
+      }, err => this.setState({error: err.message, inProgress: false}));
     }
 
     render () {

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -4,8 +4,8 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 
-import { k8sCreate, k8sUpdate, K8sResourceKind } from '../../module/k8s';
-import { ButtonBar, Firehose, history, kindObj, StatusBox, LoadingBox, Dropdown } from '../utils';
+import { k8sCreate, k8sUpdate, K8sResourceKind, referenceFor } from '../../module/k8s';
+import { ButtonBar, Firehose, history, kindObj, StatusBox, LoadingBox, Dropdown, resourceObjPath } from '../utils';
 import { formatNamespacedRouteForResource } from '../../ui/ui-actions';
 import { AsyncComponent } from '../utils/async';
 import { WebHookSecretKey } from '../secret';
@@ -148,9 +148,9 @@ const withSecretForm = (SubForm) => class SecretFormComponent extends React.Comp
     (this.props.isCreate
       ? k8sCreate(ko, newSecret)
       : k8sUpdate(ko, newSecret, metadata.namespace, newSecret.metadata.name)
-    ).then(() => {
+    ).then(secret => {
       this.setState({inProgress: false});
-      history.push(formatNamespacedRouteForResource('secrets'));
+      history.push(resourceObjPath(secret, referenceFor(secret)));
     }, err => this.setState({error: err.message, inProgress: false}));
   }
   render () {


### PR DESCRIPTION
When creating secret & roleBindings & clusterRoleBinding user is redirected to the resource list page. Instead he should be redirected to newly created resource.

Updated tests for roleBindings accordingly.

/assign @spadgett    