### PR TITLE
Fix bug where OCP logo abutted right edge of masthead

### DIFF
--- a/frontend/public/components/masthead.scss
+++ b/frontend/public/components/masthead.scss
@@ -24,9 +24,9 @@
     align-items: center;
     display: flex;
     height: 100%;
+    margin-right: 10px;
     @media (min-width: $grid-float-breakpoint) {
       margin-left: 20px;
-      margin-right: 10px;
     }
     img {
       max-width: 100%;


### PR DESCRIPTION
Note:  this exacerbates the logo pixelation at phone screen sizes **on low resolution displays such as computer monitors**, but that isn't a likely scenario other than testing.  The logo looks crisp on actual phone displays since they are high resolution.

Fixes https://jira.coreos.com/browse/CONSOLE-769

Before:
![localhost_9000_k8s_cluster_projects iphone 5_se 1](https://user-images.githubusercontent.com/895728/45762879-5b703380-bbfd-11e8-8c21-85367753b35e.png)

After:
![localhost_9000_k8s_cluster_projects iphone 5_se](https://user-images.githubusercontent.com/895728/45762893-61feab00-bbfd-11e8-9413-1bb529c57861.png)
