### PR TITLE
Fix username masthead bugs

### DIFF
--- a/frontend/public/components/masthead.scss
+++ b/frontend/public/components/masthead.scss
@@ -39,7 +39,8 @@
   &__user {
     display: none;
     @media (min-width: $grid-float-breakpoint) {
-      display: block;
+      align-items: baseline;
+      display: flex;
       margin-left: auto;
       margin-right: 20px;
     }
@@ -59,6 +60,8 @@
     max-width: 200px;
     overflow: hidden;
     text-overflow: ellipsis;
+    // if the username is long and contains a space, prevent wrapping
+    white-space: nowrap;
     @media(min-width: $screen-md-min) {
       max-width: 300px;
     }


### PR DESCRIPTION
* a space in a username could allow it to wrap
* truncation of long usernames does not occur if the dropdown is not present

Before:
![screen shot 2018-09-19 at 11 35 57 am](https://user-images.githubusercontent.com/895728/45764323-76907280-bc00-11e8-9aba-5339b4280ce3.PNG)
![screen shot 2018-09-19 at 11 35 41 am](https://user-images.githubusercontent.com/895728/45764322-76907280-bc00-11e8-93ca-d5651fb6a4a1.PNG)

After:
![screen shot 2018-09-19 at 11 39 22 am](https://user-images.githubusercontent.com/895728/45764472-c4a57600-bc00-11e8-9d64-c4954e4bc638.PNG)
![screen shot 2018-09-19 at 11 34 54 am](https://user-images.githubusercontent.com/895728/45764335-7e501700-bc00-11e8-9323-763339d5e784.PNG)
