### PR TITLE
Remove "View All" link from Events box on Status page

### DIFF
--- a/frontend/public/components/cluster-overview.jsx
+++ b/frontend/public/components/cluster-overview.jsx
@@ -12,7 +12,6 @@ import { Gauge, prometheusBasePath, requirePrometheus } from './graphs';
 import { Status, errorStatus } from './graphs/status';
 import { EventStreamPage } from './events';
 import { SoftwareDetails } from './software-details';
-import { formatNamespacedRouteForResource } from '../ui/ui-actions';
 import { FLAGS, connectToFlags, flagPending } from '../features';
 import { connectToURLs, MonitoringRoutes } from '../monitoring';
 
@@ -159,7 +158,6 @@ const GraphsPage = ({fake, limited, namespace, openshiftFlag}) => {
       <div className={classNames('group', {'co-disabled': fake})}>
         <div className="group__title">
           <h2 className="h3">Events</h2>
-          <a href={formatNamespacedRouteForResource('events', namespace)}>View All</a>
         </div>
         <div className="group__body group__body--filter-bar">
           <EventStreamPage namespace={namespace} showTitle={false} autoFocus={false} fake={fake} />


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-783

I opted to remove the link because:
* I struggled to find a "good" label
* there is no real need to go to the standalone events page from the Status page since the Events box is displaying the same data

Before:
![screen shot 2018-09-19 at 1 11 49 pm](https://user-images.githubusercontent.com/895728/45769478-c0cc2080-bc0d-11e8-8d18-6852ed227f7b.PNG)

After:
![screen shot 2018-09-19 at 1 12 23 pm](https://user-images.githubusercontent.com/895728/45769489-c88bc500-bc0d-11e8-8ba8-995c7dddbbb4.PNG)

