### PR TITLE
Fix checkboxes in service catalog forms

### DIFF
--- a/frontend/public/components/service-catalog/schema-form.tsx
+++ b/frontend/public/components/service-catalog/schema-form.tsx
@@ -94,16 +94,29 @@ export const createParametersSecret = (secretName: string, key: string, paramete
 
 // Override react-jsonschema-form rendering of fields so we can use different required and description styles.
 // https://github.com/mozilla-services/react-jsonschema-form#field-template
-const CustomFieldTemplate: React.SFC<FieldTemplateProps> = ({id, classNames: klass, label, help, required, description, errors, children}) => <div className={klass}>
-  <label htmlFor={id} className={classNames('control-label', {'co-required': required})}>{label}</label>
+const CustomFieldTemplate: React.SFC<FieldTemplateProps> = ({id, classNames: klass, displayLabel, label, help, required, description, errors, children}) => <div className={klass}>
+  {displayLabel && <label htmlFor={id} className={classNames('control-label', {'co-required': required})}>{label}</label>}
   {children}
   <div className="help-block">{description}</div>
   {help}
   {errors}
 </div>;
 
+// Create a custom checkbox widget to prevent any checkbox from receiving a `required` attribute.
+// With HTML5 form validation, a required checkbox has to be checked to submit the form.
+const CustomCheckbox = ({onChange, label, value}) => <div className="checkbox">
+  <label className="control-label">
+    <input type="checkbox" onClick={() => onChange(!value)} checked={value} />
+    {label}
+  </label>
+</div>;
+
+const widgets: any = {
+  CheckboxWidget: CustomCheckbox,
+};
+
 export const ServiceCatalogParametersForm: React.SFC<FormProps<any>> = props =>
-  <Form className="co-service-catalog-parameters" FieldTemplate={CustomFieldTemplate} {...props} />;
+  <Form className="co-service-catalog-parameters" FieldTemplate={CustomFieldTemplate} widgets={widgets} {...props} />;
 
 export type ParameterFormItem = {
   key: string;


### PR DESCRIPTION
* Don't display the label twice
* Don't add the `required` attribute. Otherwise HTML5 form validation forces you to check the checkbox always.

<img width="725" alt="create service instance okd 2018-09-20 19-07-20" src="https://user-images.githubusercontent.com/1167259/45851369-84c9b600-bd08-11e8-854a-6d477a1634fd.png">

/assign @rhamilto 