### PR TITLE
Show revision link with resource name in overview row

### DIFF
--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -1,6 +1,7 @@
 // TODO file should be renamed replica-set.jsx to match convention
 
 import * as React from 'react';
+import * as _ from 'lodash-es';
 
 import { DetailsPage, List, ListPage, WorkloadListHeader, WorkloadListRow } from './factory';
 import {Cog, ContainerTable, navFactory, SectionHeading, ResourceSummary, ResourcePodCount, AsyncComponent} from './utils';
@@ -10,23 +11,31 @@ import { ResourceEventStream } from './events';
 const {ModifyCount, EditEnvironment, common} = Cog.factory;
 export const replicaSetMenuActions = [ModifyCount, EditEnvironment, ...common];
 
-const Details = ({obj: replicaSet}) => <React.Fragment>
-  <div className="co-m-pane__body">
-    <SectionHeading text="Replica Set Overview" />
-    <div className="row">
-      <div className="col-md-6">
-        <ResourceSummary resource={replicaSet} />
-      </div>
-      <div className="col-md-6">
-        <ResourcePodCount resource={replicaSet} />
+const Details = ({obj: replicaSet}) => {
+  const revision = _.get(replicaSet, ['metadata', 'annotations', 'deployment.kubernetes.io/revision']);
+  return <React.Fragment>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Replica Set Overview" />
+      <div className="row">
+        <div className="col-md-6">
+          <ResourceSummary resource={replicaSet}>
+            {revision && <React.Fragment>
+              <dt>Deployment Revision</dt>
+              <dd>{revision}</dd>
+            </React.Fragment>}
+          </ResourceSummary>
+        </div>
+        <div className="col-md-6">
+          <ResourcePodCount resource={replicaSet} />
+        </div>
       </div>
     </div>
-  </div>
-  <div className="co-m-pane__body">
-    <SectionHeading text="Containers" />
-    <ContainerTable containers={replicaSet.spec.template.spec.containers} />
-  </div>
-</React.Fragment>;
+    <div className="co-m-pane__body">
+      <SectionHeading text="Containers" />
+      <ContainerTable containers={replicaSet.spec.template.spec.containers} />
+    </div>
+  </React.Fragment>;
+};
 
 const EnvironmentPage = (props) => <AsyncComponent loader={() => import('./environment.jsx').then(c => c.EnvironmentPage)} {...props} />;
 

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash-es';
 
 import { ResourceEventStream } from './events';
 import { DetailsPage, List, ListPage, WorkloadListHeader, WorkloadListRow } from './factory';
@@ -6,23 +7,31 @@ import { replicaSetMenuActions } from './replicaset';
 import { ContainerTable, navFactory, SectionHeading, ResourceSummary, ResourcePodCount, AsyncComponent} from './utils';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 
-const Details = ({obj: replicationController}) => <React.Fragment>
-  <div className="co-m-pane__body">
-    <SectionHeading text="Replication Controller Overview" />
-    <div className="row">
-      <div className="col-md-6">
-        <ResourceSummary resource={replicationController} />
-      </div>
-      <div className="col-md-6">
-        <ResourcePodCount resource={replicationController} />
+const Details = ({obj: replicationController}) => {
+  const revision = _.get(replicationController, ['metadata', 'annotations', 'openshift.io/deployment-config.latest-version']);
+  return <React.Fragment>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Replication Controller Overview" />
+      <div className="row">
+        <div className="col-md-6">
+          <ResourceSummary resource={replicationController}>
+            {revision && <React.Fragment>
+              <dt>Deployment Revision</dt>
+              <dd>{revision}</dd>
+            </React.Fragment>}
+          </ResourceSummary>
+        </div>
+        <div className="col-md-6">
+          <ResourcePodCount resource={replicationController} />
+        </div>
       </div>
     </div>
-  </div>
-  <div className="co-m-pane__body">
-    <SectionHeading text="Containers" />
-    <ContainerTable containers={replicationController.spec.template.spec.containers} />
-  </div>
-</React.Fragment>;
+    <div className="co-m-pane__body">
+      <SectionHeading text="Containers" />
+      <ContainerTable containers={replicationController.spec.template.spec.containers} />
+    </div>
+  </React.Fragment>;
+};
 
 const EnvironmentPage = (props) => <AsyncComponent loader={() => import('./environment.jsx').then(c => c.EnvironmentPage)} {...props} />;
 


### PR DESCRIPTION
Link to the current controller using the revision number by the name in
the overview list row. This saves space in the row to be used for other
details like metrics.

Display the deployment revision on the replica set and replication
controller pages.

@sg00dwin I'll probably need your help with the CSS grid template changes.

/assign @TheRealJon 

<img width="1189" alt="project overview okd 2018-09-20 21-14-36" src="https://user-images.githubusercontent.com/1167259/45855308-89e53000-bd1d-11e8-8fed-b8c4745c70e8.png">
