### PR TITLE
Changes to overview with sidebar details view

### DIFF
--- a/frontend/public/components/_detail-table.scss
+++ b/frontend/public/components/_detail-table.scss
@@ -5,6 +5,8 @@
   white-space: nowrap;
 
   &__row {
+    display: flex;
+    flex-wrap: wrap;
     margin-left: 0;
     margin-right: 0;
   }
@@ -15,13 +17,14 @@
   }
 
   &__section {
-    display: flex;
     align-items: center;
-    justify-content: center;
     border-width: 1px 1px 0 0;
+    display: flex;
+    flex: 1 0 auto;
+    justify-content: center;
     padding: 20px 10px;
-    margin-top: -1px;
     margin-right: -1px;
+    margin-top: -1px;
 
     &--last {
       border-right-width: 0;

--- a/frontend/public/components/_overview.scss
+++ b/frontend/public/components/_overview.scss
@@ -35,7 +35,8 @@
 
   .overview__main-column {
     height: 100%;
-    overflow: hidden auto;
+    overflow-x: hidden;
+    overflow-y: auto;
     width: 100%;
     -webkit-overflow-scrolling: touch;
   }
@@ -54,7 +55,8 @@
     .resource-overview {
       height: 100%;
       min-height: 0;
-      overflow: hidden auto;
+      overflow-x: hidden;
+      overflow-y: auto;
       -webkit-overflow-scrolling: touch;
     }
   }

--- a/frontend/public/components/_overview.scss
+++ b/frontend/public/components/_overview.scss
@@ -26,29 +26,85 @@
 }
 
 .overview {
-  width: 100%;
+  bottom: 0;
   display: flex;
-}
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 
-.overview__body {
-  flex-grow: 1;
-}
-
-.overview__sidebar {
-  display: none;
-}
-
-.overview__sidebar-dismiss {
-  margin: 30px 30px 0 30px;
-}
-
-.overview.overview--sidebar-shown {
-  .overview__body {
-    width: 60%;
+  .overview__main-column {
+    height: 100%;
+    overflow: hidden auto;
+    width: 100%;
+    -webkit-overflow-scrolling: touch;
   }
 
   .overview__sidebar {
-    display: block;
-    width: 40%;
+    background: #fff;
+    bottom: 0;
+    box-shadow: -5px 0 3px 2px rgba(0,0,0,0.05), -1px 0px 3px 2px rgba(0,0,0,0.2);
+    display: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 50%;
+    z-index: 5;
+
+    .resource-overview {
+      height: 100%;
+      min-height: 0;
+      overflow: hidden auto;
+      -webkit-overflow-scrolling: touch;
+    }
+  }
+
+  &.overview--sidebar-shown {
+    .overview__sidebar {
+      display: flex;
+      flex-direction: column;
+    }
+
+    @media(min-width: $screen-lg-min) {
+      .overview__main-column {
+        width: calc(100% - 505px);
+      }
+
+      .overview__sidebar {
+        min-height: 0;
+        overflow: hidden;
+        width: 550px;
+      }
+    }
+  }
+
+  .overview__sidebar-dismiss {
+    background: #fff;
+    border-bottom: 1px solid $color-grey-background-border;
+    padding: 5px 20px;
+    overflow: hidden;
+
+    .pficon-close {
+      font-size: 16px;
+    }
+  }
+}
+
+.overview__sidebar-pane-body {
+  margin: $grid-gutter-width 0 0;
+  padding: 0 20px;
+}
+
+.overview__sidebar-pane-head {
+  background-color: $color-grey-background;
+  border-bottom: 1px solid $color-grey-background-border;
+  padding-top: 20px;
+
+  .co-m-pane__heading {
+    margin: 0 20px 25px;
+  }
+
+  .co-actions-menu {
+    margin-top: -3px;
   }
 }

--- a/frontend/public/components/_project-overview.scss
+++ b/frontend/public/components/_project-overview.scss
@@ -19,6 +19,25 @@
     grid-area: status;
   }
 
+  .project-overview__item--selected,
+  .project-overview__item.project-overview__item--selected:hover, {
+    background-color: $color-pf-blue-100;
+  }
+
+  .project-overview__item .project-overview__item-chevron {
+    visibility: hidden;
+  }
+
+  .project-overview__item:hover .project-overview__item-chevron,
+  .project-overview__item.project-overview__item--selected .project-overview__item-chevron {
+    visibility: visible;
+  }
+
+  .project-overview__item-heading {
+    font-size: 16px;
+    margin: 0;
+  }
+
   .project-overview__group {
     margin-bottom: 40px;
   }
@@ -36,15 +55,20 @@
   }
 
   .project-overview__item {
-    position: relative;
     cursor: pointer;
+    border-left: 0;
+    border-right: 0;
+    position: relative;
+    &:first-child {
+      border-top: 0;
+    }
 
     &::after {
       content: '\f054';
       display: none;
       font-family: 'FontAwesome';
       position: absolute;
-      right: 15px;
+      right: 25px;
     }
 
     &--selected::after,
@@ -55,6 +79,7 @@
     &--selected,
     &--selected:hover {
       background-color: $color-pf-blue-100;
+      border-color: $color-pf-blue-100;
     }
   }
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -128,99 +128,101 @@ class App extends React.PureComponent {
       <div id="content">
         <Route path={namespacedRoutes} component={NamespaceSelector} />
         <GlobalNotifications />
-        <Switch>
-          <Route path={['/all-namespaces', '/ns/:ns',]} component={RedirectComponent} />
+        <div className="content-scrollable">
+          <Switch>
+            <Route path={['/all-namespaces', '/ns/:ns',]} component={RedirectComponent} />
 
-          <LazyRoute path="/overview/ns/:ns" exact loader={() => import('./overview' /* webpackChunkName: "overview" */).then(m => m.OverviewPage)} />
-          <LazyRoute path="/overview/all-namespaces" exact loader={() => import('./overview' /* webpackChunkName: "overview" */).then(m => m.OverviewPage)} />
-          <Route path="/overview" exact component={NamespaceRedirect} />
+            <LazyRoute path="/overview/ns/:ns" exact loader={() => import('./overview' /* webpackChunkName: "overview" */).then(m => m.OverviewPage)} />
+            <LazyRoute path="/overview/all-namespaces" exact loader={() => import('./overview' /* webpackChunkName: "overview" */).then(m => m.OverviewPage)} />
+            <Route path="/overview" exact component={NamespaceRedirect} />
 
-          <LazyRoute path="/catalog/all-namespaces" exact loader={() => import('./catalog' /* webpackChunkName: "catalog" */).then(m => m.CatalogPage)} />
-          <LazyRoute path="/catalog/ns/:ns" exact loader={() => import('./catalog' /* webpackChunkName: "catalog" */).then(m => m.CatalogPage)} />
-          <Route path="/catalog" exact component={NamespaceRedirect} />
+            <LazyRoute path="/catalog/all-namespaces" exact loader={() => import('./catalog' /* webpackChunkName: "catalog" */).then(m => m.CatalogPage)} />
+            <LazyRoute path="/catalog/ns/:ns" exact loader={() => import('./catalog' /* webpackChunkName: "catalog" */).then(m => m.CatalogPage)} />
+            <Route path="/catalog" exact component={NamespaceRedirect} />
 
-          <LazyRoute path="/status/all-namespaces" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
-          <LazyRoute path="/status/ns/:ns" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
-          <Route path="/status" exact component={NamespaceRedirect} />
+            <LazyRoute path="/status/all-namespaces" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
+            <LazyRoute path="/status/ns/:ns" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
+            <Route path="/status" exact component={NamespaceRedirect} />
 
-          <LazyRoute path="/cluster-health" exact loader={() => import('./cluster-health' /* webpackChunkName: "cluster-health" */).then(m => m.ClusterHealth)} />
-          <LazyRoute path="/start-guide" exact loader={() => import('./start-guide' /* webpackChunkName: "start-guide" */).then(m => m.StartGuidePage)} />
+            <LazyRoute path="/cluster-health" exact loader={() => import('./cluster-health' /* webpackChunkName: "cluster-health" */).then(m => m.ClusterHealth)} />
+            <LazyRoute path="/start-guide" exact loader={() => import('./start-guide' /* webpackChunkName: "start-guide" */).then(m => m.StartGuidePage)} />
 
-          <LazyRoute path={`/k8s/ns/:ns/${SubscriptionModel.plural}/new`} exact loader={() => import('./operator-lifecycle-manager').then(m => NamespaceFromURL(m.CreateSubscriptionYAML))} />
+            <LazyRoute path={`/k8s/ns/:ns/${SubscriptionModel.plural}/new`} exact loader={() => import('./operator-lifecycle-manager').then(m => NamespaceFromURL(m.CreateSubscriptionYAML))} />
 
-          <LazyRoute path="/k8s/cluster/clusterserviceclasses/:name/create-instance" exact loader={() => import('./service-catalog/create-instance').then(m => m.CreateInstancePage)} />
-          <LazyRoute path="/k8s/ns/:ns/serviceinstances/:name/create-binding" exact loader={() => import('./service-catalog/create-binding').then(m => m.CreateBindingPage)} />
-          <LazyRoute path="/source-to-image" exact loader={() => import('./source-to-image').then(m => m.SourceToImagePage)} />
+            <LazyRoute path="/k8s/cluster/clusterserviceclasses/:name/create-instance" exact loader={() => import('./service-catalog/create-instance').then(m => m.CreateInstancePage)} />
+            <LazyRoute path="/k8s/ns/:ns/serviceinstances/:name/create-binding" exact loader={() => import('./service-catalog/create-binding').then(m => m.CreateBindingPage)} />
+            <LazyRoute path="/source-to-image" exact loader={() => import('./source-to-image').then(m => m.SourceToImagePage)} />
 
-          <Route path="/k8s/ns/:ns/alertmanagers/:name" exact render={({match}) => <Redirect to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${match.params.name}`} />} />
+            <Route path="/k8s/ns/:ns/alertmanagers/:name" exact render={({match}) => <Redirect to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${match.params.name}`} />} />
 
-          <LazyRoute path={`/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:name/edit`} exact loader={() => import('./create-yaml').then(m => m.EditYAMLPage)} kind={referenceForModel(ClusterServiceVersionModel)} />
-          <LazyRoute path={`/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/new`} exact loader={() => import('./operator-lifecycle-manager/create-crd-yaml').then(m => m.CreateCRDYAML)} />
-          <Route path={`/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/:name`} component={ResourceDetailsPage} />
+            <LazyRoute path={`/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:name/edit`} exact loader={() => import('./create-yaml').then(m => m.EditYAMLPage)} kind={referenceForModel(ClusterServiceVersionModel)} />
+            <LazyRoute path={`/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/new`} exact loader={() => import('./operator-lifecycle-manager/create-crd-yaml').then(m => m.CreateCRDYAML)} />
+            <Route path={`/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/:plural/:name`} component={ResourceDetailsPage} />
 
-          <LazyRoute path="/k8s/all-namespaces/events" exact loader={() => import('./events').then(m => NamespaceFromURL(m.EventStreamPage))} />
-          <LazyRoute path="/k8s/ns/:ns/events" exact loader={() => import('./events').then(m => NamespaceFromURL(m.EventStreamPage))} />
-          <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
-          <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
-          <Route path="/search" exact component={ActiveNamespaceRedirect} />
+            <LazyRoute path="/k8s/all-namespaces/events" exact loader={() => import('./events').then(m => NamespaceFromURL(m.EventStreamPage))} />
+            <LazyRoute path="/k8s/ns/:ns/events" exact loader={() => import('./events').then(m => NamespaceFromURL(m.EventStreamPage))} />
+            <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
+            <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
+            <Route path="/search" exact component={ActiveNamespaceRedirect} />
 
-          <Route path="/k8s/ns/:ns/customresourcedefinitions/:plural" exact component={ResourceListPage} />
-          <Route path="/k8s/ns/:ns/customresourcedefinitions/:plural/:name" component={ResourceDetailsPage} />
-          <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural" exact component={ResourceListPage} />
-          <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural/:name" component={ResourceDetailsPage} />
+            <Route path="/k8s/ns/:ns/customresourcedefinitions/:plural" exact component={ResourceListPage} />
+            <Route path="/k8s/ns/:ns/customresourcedefinitions/:plural/:name" component={ResourceDetailsPage} />
+            <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural" exact component={ResourceListPage} />
+            <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural/:name" component={ResourceDetailsPage} />
 
-          {
-            // These pages are temporarily disabled. We need to update the safe resources list.
-            // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-            // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-          }
-          <Route path="/k8s/cluster/clusterroles/:name" component={props => <ResourceDetailsPage {...props} plural="clusterroles" />} />
+            {
+              // These pages are temporarily disabled. We need to update the safe resources list.
+              // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+              // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+            }
+            <Route path="/k8s/cluster/clusterroles/:name" component={props => <ResourceDetailsPage {...props} plural="clusterroles" />} />
 
-          {
-            // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-            // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-          }
+            {
+              // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+              // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+            }
 
-          <LazyRoute path="/deploy-image" exact loader={() => import('./deploy-image').then(m => m.DeployImage)} />
+            <LazyRoute path="/deploy-image" exact loader={() => import('./deploy-image').then(m => m.DeployImage)} />
 
-          <LazyRoute path="/k8s/ns/:ns/secrets/new/:type" exact kind="Secret" loader={() => import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(m => m.CreateSecret)} />
-          <LazyRoute path="/k8s/ns/:ns/secrets/:name/edit" exact kind="Secret" loader={() => import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(m => m.EditSecret)} />
-          <LazyRoute path="/k8s/ns/:ns/secrets/:name/edit-yaml" exact kind="Secret" loader={() => import('./create-yaml').then(m => m.EditYAMLPage)} />
+            <LazyRoute path="/k8s/ns/:ns/secrets/new/:type" exact kind="Secret" loader={() => import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(m => m.CreateSecret)} />
+            <LazyRoute path="/k8s/ns/:ns/secrets/:name/edit" exact kind="Secret" loader={() => import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(m => m.EditSecret)} />
+            <LazyRoute path="/k8s/ns/:ns/secrets/:name/edit-yaml" exact kind="Secret" loader={() => import('./create-yaml').then(m => m.EditYAMLPage)} />
 
-          <LazyRoute path="/k8s/cluster/rolebindings/new" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CreateRoleBinding)} kind="RoleBinding" />
-          <LazyRoute path="/k8s/ns/:ns/rolebindings/new" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CreateRoleBinding)} kind="RoleBinding" />
-          <LazyRoute path="/k8s/ns/:ns/rolebindings/:name/copy" exact kind="RoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CopyRoleBinding)} />
-          <LazyRoute path="/k8s/ns/:ns/rolebindings/:name/edit" exact kind="RoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRoleBinding)} />
-          <LazyRoute path="/k8s/cluster/clusterrolebindings/:name/copy" exact kind="ClusterRoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CopyRoleBinding)} />
-          <LazyRoute path="/k8s/cluster/clusterrolebindings/:name/edit" exact kind="ClusterRoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRoleBinding)} />
+            <LazyRoute path="/k8s/cluster/rolebindings/new" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CreateRoleBinding)} kind="RoleBinding" />
+            <LazyRoute path="/k8s/ns/:ns/rolebindings/new" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CreateRoleBinding)} kind="RoleBinding" />
+            <LazyRoute path="/k8s/ns/:ns/rolebindings/:name/copy" exact kind="RoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CopyRoleBinding)} />
+            <LazyRoute path="/k8s/ns/:ns/rolebindings/:name/edit" exact kind="RoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRoleBinding)} />
+            <LazyRoute path="/k8s/cluster/clusterrolebindings/:name/copy" exact kind="ClusterRoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.CopyRoleBinding)} />
+            <LazyRoute path="/k8s/cluster/clusterrolebindings/:name/edit" exact kind="ClusterRoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRoleBinding)} />
 
-          <Redirect from="/monitoring" exact to="/monitoring/alerts" />
-          <Route path="/monitoring/alerts" exact component={AlertsPage} />
-          <Route path="/monitoring/alerts/:name" exact component={AlertsDetailsPage} />
-          <Route path="/monitoring/alertrules/:name" exact component={AlertRulesDetailsPage} />
-          <Route path="/monitoring/silences" exact component={SilencesPage} />
-          <Route path="/monitoring/silences/:id" exact component={SilencesDetailsPage} />
+            <Redirect from="/monitoring" exact to="/monitoring/alerts" />
+            <Route path="/monitoring/alerts" exact component={AlertsPage} />
+            <Route path="/monitoring/alerts/:name" exact component={AlertsDetailsPage} />
+            <Route path="/monitoring/alertrules/:name" exact component={AlertRulesDetailsPage} />
+            <Route path="/monitoring/silences" exact component={SilencesPage} />
+            <Route path="/monitoring/silences/:id" exact component={SilencesDetailsPage} />
 
-          <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
-          <LazyRoute path="/k8s/cluster/:plural/new" exact loader={() => import('./create-yaml' /* webpackChunkName: "create-yaml" */).then(m => m.CreateYAML)} />
-          <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
-          <LazyRoute path="/k8s/ns/:ns/pods/:podName/containers/:name" loader={() => import('./container').then(m => m.ContainersDetailsPage)} />
-          <LazyRoute path="/k8s/ns/:ns/:plural/new" exact loader={() => import('./create-yaml' /* webpackChunkName: "create-yaml" */).then(m => NamespaceFromURL(m.CreateYAML))} />
-          <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
-          <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
+            <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
+            <LazyRoute path="/k8s/cluster/:plural/new" exact loader={() => import('./create-yaml' /* webpackChunkName: "create-yaml" */).then(m => m.CreateYAML)} />
+            <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
+            <LazyRoute path="/k8s/ns/:ns/pods/:podName/containers/:name" loader={() => import('./container').then(m => m.ContainersDetailsPage)} />
+            <LazyRoute path="/k8s/ns/:ns/:plural/new" exact loader={() => import('./create-yaml' /* webpackChunkName: "create-yaml" */).then(m => NamespaceFromURL(m.CreateYAML))} />
+            <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
+            <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
 
-          <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
-          <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
+            <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
+            <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
 
-          <LazyRoute path="/settings/profile" exact loader={() => import('./profile').then(m => m.ProfilePage)} />
-          <LazyRoute path="/settings/ldap" exact loader={() => import('./cluster-settings/ldap').then(m => m.LDAPPage)} />
-          <LazyRoute path="/settings/cluster" exact loader={() => import('./cluster-settings/cluster-settings').then(m => m.ClusterSettingsPage)} />
+            <LazyRoute path="/settings/profile" exact loader={() => import('./profile').then(m => m.ProfilePage)} />
+            <LazyRoute path="/settings/ldap" exact loader={() => import('./cluster-settings/ldap').then(m => m.LDAPPage)} />
+            <LazyRoute path="/settings/cluster" exact loader={() => import('./cluster-settings/cluster-settings').then(m => m.ClusterSettingsPage)} />
 
-          <LazyRoute path="/error" exact loader={() => import('./error').then(m => m.ErrorPage)} />
-          <Route path="/" exact component={DefaultPage} />
+            <LazyRoute path="/error" exact loader={() => import('./error').then(m => m.ErrorPage)} />
+            <Route path="/" exact component={DefaultPage} />
 
-          <LazyRoute loader={() => import('./error').then(m => m.ErrorPage404)} />
-        </Switch>
+            <LazyRoute loader={() => import('./error').then(m => m.ErrorPage404)} />
+          </Switch>
+        </div>
       </div>
     </React.Fragment>;
   }

--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -71,13 +71,13 @@ export const DefaultDetailsPage = props => {
 };
 
 export const DefaultOverviewPage = connectToModel( ({kindObj: kindObject, resource}) =>
-  <div className="co-m-pane resource-overview">
+  <div className="overview__sidebar-pane resource-overview">
     <ResourceOverviewHeading
       actions={menuActions}
       kindObj={kindObject}
       resource={resource}
     />
-    <div className="co-m-pane__body resource-overview__body">
+    <div className="overview__sidebar-pane-body resource-overview__body">
       <div className="resource-overview__summary">
         <ResourceSummary resource={resource} />
       </div>

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -95,13 +95,13 @@ const DeploymentConfigDetailsList = ({dc}) => {
 };
 
 export const DeploymentConfigOverview = connectToModel(({resource: dc, kindObj}) =>
-  <div className="co-m-pane resource-overview">
+  <div className="overview__sidebar-pane resource-overview">
     <ResourceOverviewHeading
       actions={menuActions}
       kindObj={kindObj}
       resource={dc}
     />
-    <div className="co-m-pane__body resource-overview__body">
+    <div className="overview__sidebar-pane-body resource-overview__body">
       <div className="resource-overview__pod-counts">
         <DeploymentPodCounts resource={dc} resourceKind={DeploymentConfigModel} />
       </div>

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -59,13 +59,13 @@ const DeploymentDetailsList = ({deployment}) => {
 };
 
 export const DeploymentOverview = connectToModel(({kindObj, resource: deployment}) =>
-  <div className="co-m-pane resource-overview">
+  <div className="overview__sidebar-pane resource-overview">
     <ResourceOverviewHeading
       actions={menuActions}
       kindObj={kindObj}
       resource={deployment}
     />
-    <div className="co-m-pane__body resource-overview__body">
+    <div className="overview__sidebar-pane-body resource-overview__body">
       <div className="resource-overview__pod-counts">
         <DeploymentPodCounts resource={deployment} resourceKind={DeploymentModel} />
       </div>

--- a/frontend/public/components/overview.jsx
+++ b/frontend/public/components/overview.jsx
@@ -79,7 +79,7 @@ const sortReplicationControllersByRevision = (replicationControllers) => {
   return sortByRevision(replicationControllers, 'openshift.io/deployment-config.latest-version');
 };
 
-export const ResourceOverviewHeading = ({kindObj, actions, resource }) => <div className="co-m-nav-title resource-overview__heading">
+export const ResourceOverviewHeading = ({kindObj, actions, resource }) => <div className="overview__sidebar-pane-head resource-overview__heading">
   <h1 className="co-m-pane__heading">
     <div className="co-m-pane__name">
       <ResourceIcon className="co-m-resource-icon--lg pull-left" kind={kindObj.kind} />
@@ -520,15 +520,17 @@ export class Overview extends React.Component {
     }
 
     return <div className={className}>
-      <div className="overview__body">
-        <Firehose resources={resources} forceUpdate={true}>
-          <OverviewDetails
-            namespace={namespace}
-            selectedItem={selectedItem}
-            selectItem={this.selectItem}
-            title={title}
-          />
-        </Firehose>
+      <div className="overview__main-column">
+        <div className="overview__main-column-section">
+          <Firehose resources={resources} forceUpdate={true}>
+            <OverviewDetails
+              namespace={namespace}
+              selectedItem={selectedItem}
+              selectItem={this.selectItem}
+              title={title}
+            />
+          </Firehose>
+        </div>
       </div>
       {
         !_.isEmpty(selectedItem) &&

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -63,13 +63,13 @@ export const StatefulSetsDetailsPage = props => <DetailsPage
 />;
 
 export const StatefulSetOverview = connectToModel(({kindObj, resource: ss}) =>
-  <div className="co-m-pane resource-overview">
+  <div className="overview__sidebar-pane resource-overview">
     <ResourceOverviewHeading
       actions={menuActions}
       kindObj={kindObj}
       resource={ss}
     />
-    <div className="co-m-pane__body resource-overview__body">
+    <div className="overview__sidebar-pane-body resource-overview__body">
       <div className="resource-overview__summary">
         <ResourceSummary resource={ss} />
       </div>

--- a/frontend/public/components/utils/deployment-pod-counts.tsx
+++ b/frontend/public/components/utils/deployment-pod-counts.tsx
@@ -66,7 +66,7 @@ export class DeploymentPodCounts extends SafetyFirst<DPCProps, DPCState> {
     return <div className="co-m-pane__body-group">
       <div className="co-detail-table">
         <div className="co-detail-table__row row">
-          <div className="co-detail-table__section col-sm-3">
+          <div className="co-detail-table__section">
             <dl className="co-m-pane__details">
               <dt className="co-detail-table__section-header">Desired Count</dt>
               <dd>
@@ -78,7 +78,7 @@ export class DeploymentPodCounts extends SafetyFirst<DPCProps, DPCState> {
               </dd>
             </dl>
           </div>
-          <div className="co-detail-table__section col-sm-3">
+          <div className="co-detail-table__section">
             <dl className="co-m-pane__details">
               <dt className="co-detail-table__section-header">Up-to-date Count</dt>
               <dd>
@@ -88,7 +88,7 @@ export class DeploymentPodCounts extends SafetyFirst<DPCProps, DPCState> {
               </dd>
             </dl>
           </div>
-          <div className="co-detail-table__section co-detail-table__section--last col-sm-6">
+          <div className="co-detail-table__section co-detail-table__section--last">
             <dl className="co-m-pane__details">
               <dt className="co-detail-table__section-header">Matching Pods</dt>
               <dd>

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -8,11 +8,22 @@ body,
 }
 
 #content {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   padding-top: $masthead-height-mobile;
+  position: relative;
   @media (min-width: $grid-float-breakpoint) {
     padding-left: $sidebar-width;
     padding-top: $masthead-height-desktop;
   }
+}
+
+.content-scrollable {
+  height: 100%;
+  overflow: hidden auto;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
 }
 
 #sidebar {

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -21,7 +21,8 @@ body,
 
 .content-scrollable {
   height: 100%;
-  overflow: hidden auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   position: relative;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
Revisions and detailing of the overview with sidebar to bring it closer to the Tony's[ design specs](https://user-images.githubusercontent.com/1874151/45894812-7d082100-bd9d-11e8-8485-016768b01c95.png)(*).

At >1200px the middle panel and side panel share the viewport
< 1200px the right sidebar is fixed positioned to partially overlap the middle column

- includes various cleanup and tightening of ui elements.
- nav bar incorporates dark scroll thumbtab that is hidden until :hover, closely mimicking osx default behavior of hidden till scrolling. Overall I think it makes for a cleaner look. :)

More work to come...
- better mobile responsiveness 
- various spacing adjustments


<img width="1506" alt="screen shot 2018-09-21 at 9 58 00 pm" src="https://user-images.githubusercontent.com/1874151/45912050-8ae39380-bde9-11e8-8088-7db2cf85983b.png">


responsive
![overview-sidenav-full](https://user-images.githubusercontent.com/1874151/45896213-6e236d80-bda1-11e8-97f8-cf653ba49750.gif)
![sidenav-custom-scrollbars3](https://user-images.githubusercontent.com/1874151/45896244-85faf180-bda1-11e8-85be-9f14368f3310.gif)




----

* Design document
![2_overview__sidebar-expanded_overview__1280px 2x](https://user-images.githubusercontent.com/1874151/45894812-7d082100-bd9d-11e8-8485-016768b01c95.png)
