### PR TITLE
Refactor overview component 

### DIFF
--- a/frontend/public/components/daemon-set.jsx
+++ b/frontend/public/components/daemon-set.jsx
@@ -81,23 +81,21 @@ export const DaemonSetOverview = connectToModel(({kindObj, resource: ds}) =>
     </div>
   </div>);
 
-const Details = ({obj: daemonset}) => <React.Fragment>
-  <div className="co-m-pane__body">
-    <SectionHeading text="Daemon Set Overview" />
-    <div className="row">
-      <div className="col-lg-6">
-        <ResourceSummary resource={daemonset} />
-      </div>
-      <div className="col-lg-6">
-        <DaemonSetDetailsList ds={daemonset} />
-      </div>
+const Details = ({obj: daemonset}) => <div className="co-m-pane__body">
+  <SectionHeading text="Daemon Set Overview" />
+  <div className="row">
+    <div className="col-lg-6">
+      <ResourceSummary resource={daemonset} />
+    </div>
+    <div className="col-lg-6">
+      <DaemonSetDetailsList ds={daemonset} />
     </div>
   </div>
   <div className="co-m-pane__body">
     <SectionHeading text="Containers" />
     <ContainerTable containers={daemonset.spec.template.spec.containers} />
   </div>
-</React.Fragment>;
+</div>;
 
 const EnvironmentPage = (props) => <AsyncComponent loader={() => import('./environment.jsx').then(c => c.EnvironmentPage)} {...props} />;
 


### PR DESCRIPTION
Refactor Overview component to allow for more granular control over how each resource type is converted into an overview item. Include a new 'readiness' property on overview items to provide a consolidated source for displaying pod readiness. Standard resource is also now nested in each overview item, with additional resources added as a parallel property.
Example:

``` js
{
  controller: latestReplicationController,
  obj: deploymentConfig, 
  readiness: {
    ready: numberOfReadyPods,
    desired: desiredNumberOfPods
  },
  replicationControllers: [
    {
      obj: replicationController, 
      pods: [
         // ...
      ]
    },
   // ...
  ]
}
```