### PR TITLE
Default to current namespace when clicking catalog items

### DIFF
--- a/frontend/public/components/deploy-image.tsx
+++ b/frontend/public/components/deploy-image.tsx
@@ -31,10 +31,10 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
     super(props);
 
     const params = new URLSearchParams(props.location.search);
-    const ns = params.get('ns');
+    const namespace = params.get('preselected-ns');
 
     this.state = {
-      namespace: ns,
+      namespace,
       imageName: '',
       loading: false,
       inProgress: false,

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -185,7 +185,7 @@ export const DeploymentConfigsPage: React.SFC<DeploymentConfigsPageProps> = prop
   const createProps = {
     items: createItems,
     createLink: type => type === 'image'
-      ? `/deploy-image${props.namespace ? `?ns=${props.namespace}` : ''}`
+      ? `/deploy-image${props.namespace ? `?preselected-ns=${props.namespace}` : ''}`
       : `/k8s/ns/${props.namespace || 'default'}/deploymentconfigs/new`
   };
   return <ListPage {...props} title="Deployment Configs" kind={DeploymentConfigsReference} ListComponent={DeploymentConfigsList} canCreate={true} createButtonText="Create" createProps={createProps} filterLabel={props.filterLabel} />;

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -68,7 +68,7 @@ const createApplication = (kindObj, imageStream) => {
   return {
     btnClass: 'btn-primary',
     callback: () => {
-      history.push(`/source-to-image?imagestream=${name}&ns=${namespace}`);
+      history.push(`/source-to-image?imagestream=${name}&imagestream-ns=${namespace}`);
     },
     label: 'Create Application',
   };

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -22,9 +22,10 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
   constructor (props) {
     super(props);
 
+    const { preselectNamespace: namespace = ''} = this.props;
     this.state = {
       name: '',
-      namespace: '',
+      namespace,
       plan: '',
       formData: {},
       inProgress: false,
@@ -198,8 +199,10 @@ export const CreateInstancePage: React.SFC<CreateInstancePageProps> = (props) =>
     {kind: 'ClusterServiceClass', name: props.match.params.name, isList: false, prop: 'obj'},
     {kind: 'ClusterServicePlan', isList: true, prop: 'plans', fieldSelector: `spec.clusterServiceClassRef.name=${props.match.params.name}`},
   ];
+  const searchParams = new URLSearchParams(location.search);
+  const preselectNamespace = searchParams.get('preselect-ns');
   return <Firehose resources={resources}>
-    <CreateInstance {...props as any} />
+    <CreateInstance preselectNamespace={preselectNamespace} {...props as any} />
   </Firehose>;
 };
 
@@ -207,6 +210,7 @@ export type CreateInstanceProps = {
   obj: any,
   plans: any,
   match: any,
+  preselectNamespace: string,
 };
 
 export type CreateInstanceState = {

--- a/frontend/public/components/source-to-image.tsx
+++ b/frontend/public/components/source-to-image.tsx
@@ -74,9 +74,10 @@ class BuildSource extends React.Component<BuildSourceProps, BuildSourceState> {
   constructor (props) {
     super(props);
 
+    const { preselectNamespace: namespace = ''} = this.props;
     this.state = {
       tags: [],
-      namespace: '',
+      namespace,
       selectedTag: '',
       name: '',
       repository: '',
@@ -459,10 +460,11 @@ class BuildSource extends React.Component<BuildSourceProps, BuildSourceState> {
 export const SourceToImagePage = (props) => {
   const title = 'Create Source-to-Image Application';
   const searchParams = new URLSearchParams(location.search);
-  const namespace = searchParams.get('ns');
-  const name = searchParams.get('imagestream');
+  const imageStreamName = searchParams.get('imagestream');
+  const imageStreamNamespace = searchParams.get('imagestream-ns');
+  const preselectNamespace = searchParams.get('preselected-ns');
   const resources = [
-    {kind: 'ImageStream', name, namespace, isList: false, prop: 'obj'},
+    {kind: 'ImageStream', name: imageStreamName, namespace: imageStreamNamespace, isList: false, prop: 'obj'},
   ];
 
   return <React.Fragment>
@@ -472,7 +474,7 @@ export const SourceToImagePage = (props) => {
     <div className="co-m-pane__body">
       <h1 className="co-m-pane__heading">{title}</h1>
       <Firehose resources={resources}>
-        <BuildSource {...props} />
+        <BuildSource preselectNamespace={preselectNamespace} {...props} />
       </Firehose>
     </div>
   </React.Fragment>;
@@ -485,6 +487,7 @@ export type ImageStreamInfoProps = {
 
 export type BuildSourceProps = {
   obj: any,
+  preselectNamespace: string,
 };
 
 export type BuildSourceState = {


### PR DESCRIPTION
Avoid having the select the namespace again when browsing the catalog from within a namespace.

I've made this a query parameter instead of using active project so that the namespace is only preselected when coming from the catalog, not other contexts. (The preselected namespace would usually be wrong when clicking "Create Application" on the image stream page for instance.)

/cc @dtaylor113 @rhamilto 