### PR TITLE
Update openshift-logos-icon to v1.7.0 so Jaeger icon is available

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
     "js-base64": "^2.4.5",
     "js-yaml": "3.x",
     "lodash-es": "4.x",
-    "openshift-logos-icon": "1.6.0",
+    "openshift-logos-icon": "1.7.0",
     "patternfly": "^3.45.0",
     "patternfly-react": "^2.16.0",
     "patternfly-react-extensions": "2.5.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7843,9 +7843,9 @@ opener@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
-openshift-logos-icon@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/openshift-logos-icon/-/openshift-logos-icon-1.6.0.tgz#7cc3b3a7ada6971baeb5bec73e3b860a0c4ae975"
+openshift-logos-icon@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/openshift-logos-icon/-/openshift-logos-icon-1.7.0.tgz#614f1073416566f79d6dcc860c7030b72923ba23"
 
 optical-properties@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
cc: @jpkrohling 