### PR TITLE
[WIP] Scope `dropdown-menu` display style to avoid breaking Patternfly dropdowns

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -66,7 +66,9 @@ $color-bookmarker: #DDD;
 }
 
 .dropdown-menu {
-  display: block;
+  &--block {
+    display: block;
+  }
 
   ul {
     padding: 0;

--- a/frontend/public/components/utils/cog.tsx
+++ b/frontend/public/components/utils/cog.tsx
@@ -14,7 +14,7 @@ import { connectToModel } from '../../kinds';
 const CogItems: React.SFC<CogItemsProps> = ({options, onClick}) => {
   const visibleOptions = _.reject(options, o => _.get(o, 'hidden', false));
   const lis = _.map(visibleOptions, (o, i) => <li key={i}><a onClick={e => onClick(e, o)}>{o.label}</a></li>);
-  return <ul className="dropdown-menu co-m-cog__dropdown">
+  return <ul className="dropdown-menu dropdown-menu--block co-m-cog__dropdown">
     {lis}
   </ul>;
 };

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -336,7 +336,7 @@ export class Dropdown extends DropdownMixin {
             </button>
         }
         {
-          active && <ul role="listbox" ref={this.dropdownList} className={classNames('dropdown-menu', menuClassName)}>
+          active && <ul role="listbox" ref={this.dropdownList} className={classNames('dropdown-menu', 'dropdown-menu--block', menuClassName)}>
             {
               autocompleteFilter && <div className="dropdown-menu__filter">
                 <input


### PR DESCRIPTION
@dtaylor113 @SamiSousa @sg00dwin FYI

Not sure if this fixes the problem or if other changes are needed... (There might be a cleaner fix as well.)