### PR TITLE
e2e test for source secret - basic & ssh auth

### DIFF
--- a/frontend/integration-tests/tests/secrets.scenario.ts
+++ b/frontend/integration-tests/tests/secrets.scenario.ts
@@ -1,64 +1,121 @@
-import { $, element, browser, by, ExpectedConditions as until } from 'protractor';
+/* eslint-disable max-nested-callbacks */
+import { $, element, browser, by, ExpectedConditions as until, Key } from 'protractor';
 
 import { appHost, testName, checkLogs, checkErrors } from '../protractor.conf';
 import * as crudView from '../views/crud.view';
 import * as secretsView from '../views/secrets.view';
 
-const SECRET_NAME = `secret-${testName}`;
-
 describe('Interacting with the create secret forms', () => {
-
-  beforeAll(async() => {
-    await browser.get(`${appHost}/k8s/ns/${testName}/secrets`);
-    await crudView.isLoaded();
-  });
 
   afterEach(() => {
     checkLogs();
     checkErrors();
   });
 
-  afterAll(async() => {
-    await browser.get(`${appHost}/k8s/ns/${testName}/secrets`);
-    await crudView.isLoaded();
-    await crudView.filterForName(testName);
-    await crudView.resourceRowsPresent();
-    await crudView.deleteRow('secret')(SECRET_NAME);
-    checkLogs();
-    checkErrors();
-  });
+  describe('Webhook secret', () => {
+    const webhookSecretName = 'webhook-secret';
+    const webhookSecretValue = 'webhookValue';
 
-  describe('Webhook secrets', () => {
+    beforeAll(async() => secretsView.visitSecretsPage(appHost, testName));
 
     it('creates webhook secret', async() => {
-      await crudView.createItemButton.click();
-      await secretsView.createWebhookSecretLink.click();
-      await secretsView.secretNameInput.sendKeys(SECRET_NAME);
-      await secretsView.webhookSecretValueInput.sendKeys(secretsView.webhookSecretValue);
-      await secretsView.saveButton.click();
-      expect(secretsView.errorMessage.isPresent()).toBe(false);
+      await secretsView.createSecret(secretsView.createWebhookSecretLink, testName, webhookSecretName, async() => {
+        await secretsView.webhookSecretValueInput.sendKeys(webhookSecretValue);
+      });
     });
 
     it('check for created webhook secret value', async() => {
-      await browser.wait(until.textToBePresentInElement($('.co-m-pane__heading'), SECRET_NAME));
-      await element(by.partialButtonText('Reveal Values')).click();
-      expect(secretsView.pre.get(0).getText()).toEqual(secretsView.webhookSecretValue);
+      await secretsView.checkSecret(testName, webhookSecretName, {'WebHookSecretKey': webhookSecretValue});
     });
 
     it('edits webhook secret', async() => {
-      await crudView.actionsDropdown.click();
-      await browser.wait(until.presenceOf(crudView.actionsDropdownMenu), 500);
-      await crudView.actionsDropdownMenu.element(by.linkText('Edit Secret')).click();
-      await browser.wait(until.urlContains(`/k8s/ns/${testName}/secrets/${SECRET_NAME}/edit`));
-      await element(by.buttonText('Generate')).click();
-      await secretsView.saveButton.click();
-      expect(secretsView.errorMessage.isPresent()).toBe(false);
+      await secretsView.editSecret(testName, webhookSecretName, async() => {
+        await element(by.buttonText('Generate')).click();
+      });
     });
 
     it('check for edited webhook secret value', async() => {
-      await browser.wait(until.textToBePresentInElement($('.co-m-pane__heading'), SECRET_NAME));
+      await browser.wait(until.textToBePresentInElement($('.co-m-pane__heading'), webhookSecretName));
       await element(by.partialButtonText('Reveal Values')).click();
-      expect(secretsView.pre.get(0).getText()).not.toEqual(secretsView.webhookSecretValue);
+      expect(secretsView.pre.get(0).getText()).not.toEqual(webhookSecretValue);
+    });
+
+    it('deletes the webhook secret', async() => {
+      await crudView.deleteResource('secrets', 'Secret', webhookSecretName);
+    });
+  });
+
+  describe('Basic source secrets', () => {
+    const basicSourceSecretName = 'basic-source-secret';
+    const basicSourceSecretUsername = 'username';
+    const basicSourceSecretUsernameUpdated = 'usernameUpdated';
+    const basicSourceSecretPassword = 'password';
+    const basicSourceSecretPasswordUpdated = 'passwordUpdated';
+
+    beforeAll(async() => secretsView.visitSecretsPage(appHost, testName));
+
+    it('creates basic source secret', async() => {
+      await secretsView.createSecret(secretsView.createSourceSecretLink, testName, basicSourceSecretName, async() => {
+        await secretsView.sourceSecretUsernameInput.sendKeys(basicSourceSecretUsername);
+        await secretsView.sourceSecretPasswordInput.sendKeys(basicSourceSecretPassword);
+      });
+    });
+
+    it('check for created basic source secret values', async() => {
+      await secretsView.checkSecret(testName, basicSourceSecretName, {'username': basicSourceSecretUsername, 'password': basicSourceSecretPassword});
+    });
+
+    it('edits basic source secret', async() => {
+      await secretsView.editSecret(testName, basicSourceSecretName, async() => {
+        await secretsView.sourceSecretUsernameInput.clear();
+        await secretsView.sourceSecretUsernameInput.sendKeys(basicSourceSecretUsernameUpdated);
+        await secretsView.sourceSecretPasswordInput.clear();
+        await secretsView.sourceSecretPasswordInput.sendKeys(basicSourceSecretPasswordUpdated);
+      });
+    });
+
+    it('check for edited basic source secret values', async() => {
+      await secretsView.checkSecret(testName, basicSourceSecretName, {'username': basicSourceSecretUsernameUpdated, 'password': basicSourceSecretPasswordUpdated});
+    });
+
+    it('deletes the basic source secret', async() => {
+      await crudView.deleteResource('secrets', 'Secret', basicSourceSecretName);
+    });
+  });
+
+  describe('SSH source secrets', () => {
+    const sshSourceSecretName = 'ssh-source-secret';
+    const sshSourceSecretSSHKey = 'sshKey';
+    const sshSourceSecretSSHKeUpdated = 'sshKeyUpdated';
+
+    beforeAll(async() => secretsView.visitSecretsPage(appHost, testName));
+
+    it('creates SSH source secret', async() => {
+      await secretsView.createSecret(secretsView.createSourceSecretLink, testName, sshSourceSecretName, async() => {
+        await secretsView.authTypeDropdown.click().then(() => browser.actions().sendKeys(Key.ARROW_UP, Key.ENTER).perform());
+        await browser.wait(until.presenceOf(secretsView.sourceSecretSSHTextArea));
+        await secretsView.sourceSecretSSHTextArea.sendKeys(sshSourceSecretSSHKey);
+      });
+    });
+
+    it('check for created SSH source secret values', async() => {
+      await secretsView.checkSecret(testName, sshSourceSecretName, {'ssh-privatekey': sshSourceSecretSSHKey});
+    });
+
+    it('edits SSH source secret', async() => {
+      await secretsView.editSecret(testName, sshSourceSecretName, async() => {
+        await browser.wait(until.presenceOf(secretsView.sourceSecretSSHTextArea));
+        await secretsView.sourceSecretSSHTextArea.clear();
+        await secretsView.sourceSecretSSHTextArea.sendKeys(sshSourceSecretSSHKeUpdated);
+      });
+    });
+
+    it('check for edited SSH source secret values', async() => {
+      await secretsView.checkSecret(testName, sshSourceSecretName, {'ssh-privatekey': sshSourceSecretSSHKeUpdated});
+    });
+
+    it('deletes the SSH source secret', async() => {
+      await crudView.deleteResource('secrets', 'Secret', sshSourceSecretName);
     });
   });
 });

--- a/frontend/integration-tests/views/secrets.view.ts
+++ b/frontend/integration-tests/views/secrets.view.ts
@@ -1,12 +1,57 @@
-import { $, $$ } from 'protractor';
+/* eslint-disable no-unused-vars */
+import { $, $$, browser, by, ExpectedConditions as until, element, ElementFinder } from 'protractor';
+
+import * as crudView from '../views/crud.view';
 
 export const secretNameInput = $('#secret-name');
 export const pre = $$('.co-copy-to-clipboard__text');
+export const dt = $$('dl.secret-data dt');
 
 export const saveButton = $('#save-changes');
 export const errorMessage = $('.alert-danger');
+export const authTypeDropdown = $('#dropdown-selectbox');
 
-export const webhookSecretValue = 'webhookValue';
-export const webhookSecretValueInput = $('#webhook-secret-key');
+export const webhookSecretValueInput = $('input[name=webhookSecretKey]');
+export const sourceSecretUsernameInput = $('input[name=username]');
+export const sourceSecretPasswordInput = $('input[name=password]');
+export const sourceSecretSSHTextArea = $('.co-file-dropzone__textarea');
 
 export const createWebhookSecretLink = $('#webhook-link');
+export const createSourceSecretLink = $('#source-link');
+
+export const visitSecretsPage = async(appHost: string, ns: string) => {
+  await browser.get(`${appHost}/k8s/ns/${ns}/secrets`);
+  await crudView.isLoaded();
+};
+
+export const createSecret = async(linkElement: ElementFinder, ns: string, name: string, updateForm: Function) => {
+  await crudView.createItemButton.click();
+  await linkElement.click();
+  await secretNameInput.sendKeys(name);
+  await updateForm();
+  await saveButton.click();
+  expect(errorMessage.isPresent()).toBe(false);
+};
+
+export const checkSecret = async(ns: string, name: string, keyValuesToCheck: Object) => {
+  await browser.wait(until.urlContains(`/k8s/ns/${ns}/secrets/${name}`));
+  await browser.wait(until.textToBePresentInElement($('.co-m-pane__heading'), name));
+  await element(by.partialButtonText('Reveal Values')).click();
+  const renderedKeyValues = await dt.reduce(async(acc, el, index) => {
+    const key = await el.getAttribute('textContent');
+    const value = await pre.get(index).getText();
+    acc[key] = value;
+    return acc;
+  }, {});
+  expect(renderedKeyValues).toEqual(keyValuesToCheck);
+};
+
+export const editSecret = async(ns: string, name: string, updateForm: Function) => {
+  await crudView.actionsDropdown.click();
+  await browser.wait(until.presenceOf(crudView.actionsDropdownMenu), 500);
+  await crudView.actionsDropdownMenu.element(by.linkText('Edit Secret')).click();
+  await browser.wait(until.urlContains(`/k8s/ns/${ns}/secrets/${name}/edit`));
+  await updateForm();
+  await saveButton.click();
+  expect(errorMessage.isPresent()).toBe(false);
+};

--- a/frontend/public/components/configmap-and-secret-data.jsx
+++ b/frontend/public/components/configmap-and-secret-data.jsx
@@ -59,7 +59,7 @@ export class SecretData extends React.PureComponent {
           </button>
           : null}
       </SectionHeading>
-      {dl.length ? <dl>{dl}</dl> : <EmptyBox label="Data" />}
+      {dl.length ? <dl className="secret-data">{dl}</dl> : <EmptyBox label="Data" />}
     </React.Fragment>;
   }
 }


### PR DESCRIPTION
Created helpers in the secrets.view.ts that contain common logic for the secret scenario.
`createSecret` and `editSecret` take as an argument a function that contains steps specific for creating and editing each secret type.

/assign @spadgett 