### PR TITLE
Better handling of overview groups with no label value

### DIFF
--- a/frontend/public/components/overview.jsx
+++ b/frontend/public/components/overview.jsx
@@ -31,6 +31,10 @@ import {
   StatusBox,
 } from './utils';
 
+// Should not be a valid label value to avoid conflicts.
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+const EMPTY_GROUP_LABEL = 'other resources';
+
 const getOwnedResources = ({metadata:{uid}}, resources) => {
   return _.filter(resources, ({metadata:{ownerReferences}}) => {
     return _.some(ownerReferences, {
@@ -208,10 +212,10 @@ class OverviewDetails extends React.Component {
 
   groupItems(items, label) {
     const compareGroups = (a, b) => {
-      if (a.name === 'other') {
+      if (a.name === EMPTY_GROUP_LABEL) {
         return 1;
       }
-      if (b.name === 'other') {
+      if (b.name === EMPTY_GROUP_LABEL) {
         return -1;
       }
       return a.name.localeCompare(b.name);
@@ -221,7 +225,7 @@ class OverviewDetails extends React.Component {
       return [{items}];
     }
 
-    const groups = _.groupBy(items, item => _.get(item, ['obj', 'metadata', 'labels', label], 'other'));
+    const groups = _.groupBy(items, item => _.get(item, ['obj', 'metadata', 'labels', label]) || EMPTY_GROUP_LABEL);
     return _.map(groups, (group, name) => {
       return {
         name,

--- a/frontend/public/components/project-overview.jsx
+++ b/frontend/public/components/project-overview.jsx
@@ -102,9 +102,9 @@ ProjectOverviewGroup.propTypes = {
 
 export const ProjectOverview = ({selectedItem, groups, onClickItem}) =>
   <div className="project-overview">
-    {_.map(groups, ({name, items}, index) =>
+    {_.map(groups, ({name, items}) =>
       <ProjectOverviewGroup
-        key={`overview-group-${name}${index}`}
+        key={name}
         heading={name}
         items={items}
         onClickItem={onClickItem}


### PR DESCRIPTION
* Differentiate between no label value and value "other"
* Don't use index in group key

Note that spaces aren't allowed in label values, so "other resources" should never conflict with a real value.

/assign @TheRealJon 