### PR TITLE
Kubernetes Marketplace - basic page

### DIFF
--- a/frontend/__tests__/features.spec.tsx
+++ b/frontend/__tests__/features.spec.tsx
@@ -43,6 +43,7 @@ describe('featureReducer', () => {
       [FLAGS.CHARGEBACK]: false,
       [FLAGS.SERVICE_CATALOG]: false,
       [FLAGS.OPERATOR_LIFECYCLE_MANAGER]: true,
+      [FLAGS.KUBERNETES_MARKETPLACE]: false,
     }));
   });
 });

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -147,9 +147,7 @@ class App extends React.PureComponent {
             <LazyRoute path="/cluster-health" exact loader={() => import('./cluster-health' /* webpackChunkName: "cluster-health" */).then(m => m.ClusterHealth)} />
             <LazyRoute path="/start-guide" exact loader={() => import('./start-guide' /* webpackChunkName: "start-guide" */).then(m => m.StartGuidePage)} />
 
-            <LazyRoute path="/marketplace/all-namespaces" exact loader={() => import('./marketplace/kubernetes-marketplace' /* webpackChunkName: "marketplace" */).then(m => m.MarketplacePage)} />
-            <LazyRoute path="/marketplace/ns/:ns" exact loader={() => import('./marketplace/kubernetes-marketplace' /* webpackChunkName: "marketplace" */).then(m => m.MarketplacePage)} />
-            <Route path="/marketplace" exact component={NamespaceRedirect} />
+            <LazyRoute path="/marketplace" exact loader={() => import('./marketplace/kubernetes-marketplace' /* webpackChunkName: "marketplace" */).then(m => m.MarketplacePage)} />
 
             <LazyRoute path={`/k8s/ns/:ns/${SubscriptionModel.plural}/new`} exact loader={() => import('./operator-lifecycle-manager').then(m => NamespaceFromURL(m.CreateSubscriptionYAML))} />
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -147,6 +147,10 @@ class App extends React.PureComponent {
             <LazyRoute path="/cluster-health" exact loader={() => import('./cluster-health' /* webpackChunkName: "cluster-health" */).then(m => m.ClusterHealth)} />
             <LazyRoute path="/start-guide" exact loader={() => import('./start-guide' /* webpackChunkName: "start-guide" */).then(m => m.StartGuidePage)} />
 
+            <LazyRoute path="/marketplace/all-namespaces" exact loader={() => import('./marketplace/kubernetes-marketplace' /* webpackChunkName: "marketplace" */).then(m => m.MarketplacePage)} />
+            <LazyRoute path="/marketplace/ns/:ns" exact loader={() => import('./marketplace/kubernetes-marketplace' /* webpackChunkName: "marketplace" */).then(m => m.MarketplacePage)} />
+            <Route path="/marketplace" exact component={NamespaceRedirect} />
+
             <LazyRoute path={`/k8s/ns/:ns/${SubscriptionModel.plural}/new`} exact loader={() => import('./operator-lifecycle-manager').then(m => NamespaceFromURL(m.CreateSubscriptionYAML))} />
 
             <LazyRoute path="/k8s/cluster/clusterserviceclasses/:name/create-instance" exact loader={() => import('./service-catalog/create-instance').then(m => m.CreateInstancePage)} />

--- a/frontend/public/components/marketplace/kubernetes-marketplace.jsx
+++ b/frontend/public/components/marketplace/kubernetes-marketplace.jsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import * as PropTypes from 'prop-types';
+import { Helmet } from 'react-helmet';
+
+import { FLAGS, connectToFlags, flagPending } from '../../features';
+import { Firehose, PageHeading, StatusBox } from '../utils';
+import { CatalogTileViewPage } from '../catalog-items';
+import { referenceForModel } from '../../module/k8s';
+import { getServiceClassIcon, getServiceClassImage } from '../catalog-item-icon';
+import { PackageManifestModel } from '../../models';
+
+class MarketplaceListPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      items: [],
+    };
+  }
+  componentDidUpdate(prevProps) {
+    const {packagemanifests, namespace} = this.props;
+    if (packagemanifests !== prevProps.packagemanifests ||
+      namespace !== prevProps.namespace) {
+      this.createMarketplaceData();
+    }
+  }
+  createMarketplaceData() {
+    const {packagemanifests, loaded} = this.props;
+    let packageManifestItems = null;
+    if (!loaded) {
+      return;
+    }
+    if (packagemanifests) {
+      packageManifestItems = this.normalizePackageManifests(packagemanifests.data, 'PackageManifest');
+    }
+    const items = _.sortBy([...packageManifestItems], 'tileName');
+    this.setState({items});
+  }
+  normalizePackageManifests(packageManifests, kind) {
+    const activePackageManifests = _.filter(packageManifests, packageManifest => {
+      return !packageManifest.status.removedFromBrokerCatalog;
+    });
+    return _.map(activePackageManifests, packageManifest => {
+      const tileName = packageManifest.metadata.name;
+      const iconClass = getServiceClassIcon(packageManifest);
+      const tileImgUrl = getServiceClassImage(packageManifest, iconClass);
+      const tileIconClass = tileImgUrl ? null : iconClass;
+      const tileDescription = packageManifest.metadata.description;
+      const tileProvider = packageManifest.metadata.labels.provider;
+      const tags = packageManifest.metadata.tags;
+      const { name, namespace } = packageManifest.metadata;
+      const href = null;
+      return {
+        obj: packageManifest,
+        kind,
+        tileName,
+        tileIconClass,
+        tileImgUrl,
+        tileDescription,
+        tileProvider,
+        href,
+        tags,
+      };
+    });
+  }
+  render() {
+    const { loaded, loadError } = this.props;
+    const { items } = this.state;
+    return <StatusBox data={items} loaded={loaded} loadError={loadError} label="Resources">
+      <CatalogTileViewPage items={items} />
+    </StatusBox>;
+  }
+}
+MarketplaceListPage.displayName = 'MarketplaceList';
+MarketplaceListPage.propTypes = {
+  obj: PropTypes.object,
+  namespace: PropTypes.string,
+};
+// eventually may use namespace
+// eslint-disable-next-line no-unused-vars
+export const Marketplace = connectToFlags(FLAGS.OPENSHIFT, FLAGS.SERVICE_CATALOG)(({namespace, flags}) => {
+  if (flagPending(flags.OPENSHIFT) || flagPending(flags.SERVICE_CATALOG)) {
+    return null;
+  }
+  const resources = [];
+  resources.push({
+    isList: true,
+    kind: referenceForModel(PackageManifestModel),
+    namespace: 'kube-system',
+    prop: 'packagemanifests'
+  });
+  return <Firehose resources={resources}>
+    <MarketplaceListPage namespace={namespace} />
+  </Firehose>;
+});
+Marketplace.displayName = 'Marketplace';
+Marketplace.propTypes = {
+  namespace: PropTypes.string,
+};
+export const MarketplacePage = ({match}) => {
+  const namespace = _.get(match, 'params.ns');
+  return <React.Fragment>
+    <Helmet>
+      <title>Kubernetes Marketplace</title>
+    </Helmet>
+    <div className="co-catalog">
+      <PageHeading title="Kubernetes Marketplace" />
+      <Marketplace namespace={namespace} />
+    </div>
+  </React.Fragment>;
+};

--- a/frontend/public/components/marketplace/kubernetes-marketplace.jsx
+++ b/frontend/public/components/marketplace/kubernetes-marketplace.jsx
@@ -3,12 +3,12 @@ import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 
-import { FLAGS, connectToFlags, flagPending } from '../../features';
 import { Firehose, PageHeading, StatusBox } from '../utils';
-import { CatalogTileViewPage } from '../catalog-items';
 import { referenceForModel } from '../../module/k8s';
-import { getServiceClassIcon, getServiceClassImage } from '../catalog-item-icon';
+import { normalizeIconClass } from '../catalog-item-icon';
 import { PackageManifestModel } from '../../models';
+import CatalogTileView from 'patternfly-react-extensions/dist/esm/components/CatalogTileView/CatalogTileView';
+import CatalogTile from 'patternfly-react-extensions/dist/esm/components/CatalogTile/CatalogTile';
 
 class MarketplaceListPage extends React.Component {
   constructor(props) {
@@ -42,14 +42,12 @@ class MarketplaceListPage extends React.Component {
     });
     return _.map(activePackageManifests, packageManifest => {
       const tileName = packageManifest.metadata.name;
-      const iconClass = getServiceClassIcon(packageManifest);
-      const tileImgUrl = getServiceClassImage(packageManifest, iconClass);
+      const iconClass = 'fa fa-clone'; // TODO: get this info from the packagemanifest
+      const tileImgUrl = null; // TODO: get this info from the packagemanifest
       const tileIconClass = tileImgUrl ? null : iconClass;
       const tileDescription = packageManifest.metadata.description;
       const tileProvider = packageManifest.metadata.labels.provider;
       const tags = packageManifest.metadata.tags;
-      const { name, namespace } = packageManifest.metadata;
-      const href = null;
       return {
         obj: packageManifest,
         kind,
@@ -58,16 +56,49 @@ class MarketplaceListPage extends React.Component {
         tileImgUrl,
         tileDescription,
         tileProvider,
-        href,
         tags,
       };
     });
   }
+
+  renderTiles() {
+    const { items } = this.state;
+
+    return (
+      <CatalogTileView.Category totalItems={items.length} viewAll={true}>
+        {_.map(items, ((item) => {
+          const { tileName, tileImgUrl, tileIconClass, tileProvider, tileDescription } = item;
+          const uid = tileName;
+          const iconClass = tileIconClass ? `icon ${normalizeIconClass(tileIconClass)}` : null;
+          const vendor = tileProvider ? `Provided by ${tileProvider}` : null;
+          return <CatalogTile
+            id={uid}
+            key={uid}
+            title={tileName}
+            iconImg={tileImgUrl}
+            iconClass={iconClass}
+            vendor={vendor}
+            description={tileDescription}
+          />;
+        }))}
+      </CatalogTileView.Category>
+    );
+  }
+
   render() {
     const { loaded, loadError } = this.props;
     const { items } = this.state;
     return <StatusBox data={items} loaded={loaded} loadError={loadError} label="Resources">
-      <CatalogTileViewPage items={items} />
+      <div className="co-catalog-page">
+        <div className="co-catalog-page__content">
+          <div>
+            <div className="co-catalog-page__num-items">{_.size(items)} items</div>
+          </div>
+          <CatalogTileView>
+            {this.renderTiles()}
+          </CatalogTileView>
+        </div>
+      </div>
     </StatusBox>;
   }
 }
@@ -76,23 +107,19 @@ MarketplaceListPage.propTypes = {
   obj: PropTypes.object,
   namespace: PropTypes.string,
 };
-// eventually may use namespace
-// eslint-disable-next-line no-unused-vars
-export const Marketplace = connectToFlags(FLAGS.OPENSHIFT, FLAGS.SERVICE_CATALOG)(({namespace, flags}) => {
-  if (flagPending(flags.OPENSHIFT) || flagPending(flags.SERVICE_CATALOG)) {
-    return null;
-  }
+
+export const Marketplace = ({namespace}) => {
   const resources = [];
   resources.push({
     isList: true,
     kind: referenceForModel(PackageManifestModel),
-    namespace: 'kube-system',
+    namespace: undefined, // shows operators from all-namespaces - when backend is hooked up we will use 'marketplace'
     prop: 'packagemanifests'
   });
   return <Firehose resources={resources}>
     <MarketplaceListPage namespace={namespace} />
   </Firehose>;
-});
+};
 Marketplace.displayName = 'Marketplace';
 Marketplace.propTypes = {
   namespace: PropTypes.string,

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -380,7 +380,7 @@ export class Nav extends React.Component {
           </NavSection>
 
           <NavSection required={FLAGS.OPERATOR_LIFECYCLE_MANAGER} text="Operators" img={operatorImg} activeImg={operatorActiveImg} >
-            <HrefLink href="/marketplace" name="Kubernetes Marketplace" activePath="/marketplace/" onClick={this.close} />
+            <HrefLink required={FLAGS.KUBERNETES_MARKETPLACE} href="/marketplace" name="Kubernetes Marketplace" activePath="/marketplace/" onClick={this.close} />
             <ResourceNSLink model={ClusterServiceVersionModel} resource={ClusterServiceVersionModel.plural} name="Cluster Service Versions" onClick={this.close} />
             <Sep />
             <ResourceNSLink model={CatalogSourceModel} resource={CatalogSourceModel.plural} name="Catalog Sources" onClick={this.close} />

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -380,6 +380,7 @@ export class Nav extends React.Component {
           </NavSection>
 
           <NavSection required={FLAGS.OPERATOR_LIFECYCLE_MANAGER} text="Operators" img={operatorImg} activeImg={operatorActiveImg} >
+            <HrefLink href="/marketplace" name="Kubernetes Marketplace" activePath="/marketplace/" onClick={this.close} />
             <ResourceNSLink model={ClusterServiceVersionModel} resource={ClusterServiceVersionModel.plural} name="Cluster Service Versions" onClick={this.close} />
             <Sep />
             <ResourceNSLink model={CatalogSourceModel} resource={CatalogSourceModel.plural} name="Catalog Sources" onClick={this.close} />

--- a/frontend/public/components/utils/link.jsx
+++ b/frontend/public/components/utils/link.jsx
@@ -17,7 +17,7 @@ export const legalNamePattern = /[a-z0-9](?:[-a-z0-9]*[a-z0-9])?/;
 
 const basePathPattern = new RegExp(`^/?${window.SERVER_FLAGS.basePath}`);
 
-export const namespacedPrefixes = ['/search', '/status', '/k8s', '/overview', '/catalog', '/marketplace'];
+export const namespacedPrefixes = ['/search', '/status', '/k8s', '/overview', '/catalog'];
 
 export const stripBasePath = path => path.replace(basePathPattern, '/');
 

--- a/frontend/public/components/utils/link.jsx
+++ b/frontend/public/components/utils/link.jsx
@@ -17,7 +17,7 @@ export const legalNamePattern = /[a-z0-9](?:[-a-z0-9]*[a-z0-9])?/;
 
 const basePathPattern = new RegExp(`^/?${window.SERVER_FLAGS.basePath}`);
 
-export const namespacedPrefixes = ['/search', '/status', '/k8s', '/overview', '/catalog'];
+export const namespacedPrefixes = ['/search', '/status', '/k8s', '/overview', '/catalog', '/marketplace'];
 
 export const stripBasePath = path => path.replace(basePathPattern, '/');
 

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';
 
-import { SelfSubjectAccessReviewModel, ChannelOperatorConfigModel, PrometheusModel, ClusterServiceVersionModel, ClusterModel, ChargebackReportModel, ClusterServiceClassModel } from './models';
+import { SelfSubjectAccessReviewModel, ChannelOperatorConfigModel, PrometheusModel, ClusterServiceVersionModel, ClusterModel, ChargebackReportModel, ClusterServiceClassModel, PackageManifestModel } from './models';
 import { k8sBasePath, referenceForModel } from './module/k8s/k8s';
 import { k8sCreate } from './module/k8s/resource';
 import { types } from './module/k8s/k8s-actions';
@@ -47,6 +47,7 @@ export enum FLAGS {
   CAN_CREATE_PROJECT = 'CAN_CREATE_PROJECT',
   PROJECTS_AVAILABLE = 'PROJECTS_AVAILABLE',
   SERVICE_CATALOG = 'SERVICE_CATALOG',
+  KUBERNETES_MARKETPLACE = 'KUBERNETES_MARKETPLACE',
 }
 
 export const DEFAULTS_ = _.mapValues(FLAGS, flag => flag === FLAGS.AUTH_ENABLED
@@ -61,6 +62,7 @@ export const CRDs = {
   [referenceForModel(ChargebackReportModel)]: FLAGS.CHARGEBACK,
   [referenceForModel(ClusterServiceClassModel)]: FLAGS.SERVICE_CATALOG,
   [referenceForModel(ClusterServiceVersionModel)]: FLAGS.OPERATOR_LIFECYCLE_MANAGER,
+  [referenceForModel(PackageManifestModel)]: FLAGS.KUBERNETES_MARKETPLACE,
 };
 
 const SET_FLAG = 'SET_FLAG';


### PR DESCRIPTION
### Description

- [x] Create lazy route to "Kubernetes Marketplace" tab
- [x] Use Firehose and Package Manifest to get operator data
- [x] Display tile view of operators if data is returned

Solves [JIRA 763](https://jira.coreos.com/browse/CONSOLE-763)

#### Requirements

Requires Openshift 3.10+ and [OLM 0.7.1](https://github.com/operator-framework/operator-lifecycle-manager/tree/master/deploy/upstream/manifests/0.7.1)+ deployed. To view operators in the tile view, we recommend also running ```oc create -f``` on [OLM 0.6.0](https://github.com/operator-framework/operator-lifecycle-manager/tree/master/deploy/upstream/manifests/0.6.0)