### PR TITLE
Add `PackageManifest` Model

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-import { K8sResourceKind, GroupVersionKind, OwnerReference } from '../../module/k8s';
+import { K8sResourceKind, GroupVersionKind, OwnerReference, K8sKind } from '../../module/k8s';
 import { Descriptor } from './descriptors/types';
 import * as operatorLogo from '../../imgs/operator.svg';
 
@@ -158,11 +158,39 @@ export type CatalogSourceKind = {
   },
 } & K8sResourceKind;
 
+// TODO(alecmerdler): Remove this in favor of `PackageManifest`
 export type Package = {
   packageName: string;
   channels: {name: string, currentCSV: string}[];
   defaultChannel?: string;
 };
+
+export type PackageManifest = {
+  apiVersion: 'packages.app.redhat.com/v1alpha1';
+  kind: 'PackageManifest';
+  spec: {};
+  status: {
+    catalogSource: string;
+    catalogSourceNamespace: string;
+    provider: {
+      name: string;
+    };
+    packageName: string;
+    channels: {
+      name: string;
+      currentCSV: string;
+      currentCSVDesc: {
+        displayName: string;
+        icon: {mediatype: string, data: string}[];
+        version: string;
+        provider: {
+          name: string;
+        };
+      }
+    }[];
+    defaultChannel: string;
+  };
+} & K8sKind;
 
 export const olmNamespace = 'operator-lifecycle-manager';
 

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -14,6 +14,19 @@ export const CatalogSourceModel: K8sKind = {
   plural: 'catalogsources',
 };
 
+export const PackageManifestModel: K8sKind = {
+  kind: 'PackageManifest',
+  label: 'PackageManifest',
+  labelPlural: 'PackageManifests',
+  apiGroup: 'packages.apps.redhat.com',
+  apiVersion: 'v1alpha1',
+  path: 'packagemanifests',
+  abbr: 'PM',
+  namespaced: true,
+  crd: true,
+  plural: 'packagemanifests',
+};
+
 export const ClusterServiceVersionModel: K8sKind = {
   kind: 'ClusterServiceVersion',
   label: 'ClusterServiceVersion',


### PR DESCRIPTION
### Description

Adds the `PackageManifest` model, which will be used by OLM and Marketplace UIs to display available Operators to install.

Addresses https://jira.coreos.com/browse/ALM-720