### PR TITLE
Changes to fix issue with React virtualized WindowScroller by assigning the scrollElement property to a specific id

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -128,7 +128,7 @@ class App extends React.PureComponent {
       <div id="content">
         <Route path={namespacedRoutes} component={NamespaceSelector} />
         <GlobalNotifications />
-        <div className="content-scrollable">
+        <div id="content-scrollable">
           <Switch>
             <Route path={['/all-namespaces', '/ns/:ns',]} component={RedirectComponent} />
 

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -432,15 +432,16 @@ class EventStream extends SafetyFirst {
           There are no events before <Timestamp timestamp={this.state.oldestTimestamp} />
           </div>
         </div>
+        { /* Default `height` to 0 to avoid console errors from https://github.com/bvaughn/react-virtualized/issues/1158 */}
         { count > 0 &&
-            <WindowScroller>
+            <WindowScroller scrollElement={document.getElementById('content-scrollable')}>
               {({height, isScrolling, registerChild, onChildScroll, scrollTop}) =>
                 <AutoSizer disableHeight>
                   {({width}) => <div ref={registerChild}>
                     <VirtualList
                       autoHeight
                       data={filteredEvents}
-                      height={height}
+                      height={height || 0}
                       isScrolling={isScrolling}
                       onScroll={onChildScroll}
                       rowRenderer={this.rowRenderer}

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -271,10 +271,11 @@ export const Rows: React.SFC<RowsProps> = (props) => {
     </CellMeasurer>;
   };
 
+  // Default `height` to 0 to avoid console errors from https://github.com/bvaughn/react-virtualized/issues/1158
   return <div className="co-m-table-grid__body">
     { fake
       ? <EmptyBox label={label} />
-      : <WindowScroller>
+      : <WindowScroller scrollElement={document.getElementById('content-scrollable')}>
         {({height, isScrolling, registerChild, onChildScroll, scrollTop}) =>
           <AutoSizer disableHeight>
             {({width}) => <div ref={registerChild}>
@@ -282,7 +283,7 @@ export const Rows: React.SFC<RowsProps> = (props) => {
                 autoHeight
                 data={props.data}
                 expand={props.expand}
-                height={height}
+                height={height || 0}
                 deferredMeasurementCache={measurementCache}
                 rowHeight={measurementCache.rowHeight}
                 isScrolling={isScrolling}

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -10,7 +10,6 @@ body,
 #content {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   padding-top: $masthead-height-mobile;
   position: relative;
   @media (min-width: $grid-float-breakpoint) {
@@ -19,7 +18,7 @@ body,
   }
 }
 
-.content-scrollable {
+#content-scrollable {
   height: 100%;
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
Events and list pages height is now corrected.

