### PR TITLE
Remove breadcrumb from Create Instance; Highlight nav for S2I

### DIFF
--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -260,7 +260,7 @@ const searchStartsWith = ['search'];
 const rolesStartsWith = ['roles', 'clusterroles'];
 const rolebindingsStartsWith = ['rolebindings', 'clusterrolebindings'];
 const quotaStartsWith = ['resourcequotas', 'clusterresourcequotas'];
-const imagestreamsStartsWith = ['imagestreams', 'imagestreamtags'];
+const imagestreamsStartsWith = ['imagestreams', 'imagestreamtags', 'source-to-image'];
 const clusterSettingsStartsWith = ['settings/cluster', 'settings/ldap'];
 
 const ClusterPickerNavSection = connectToFlags(FLAGS.OPENSHIFT)(({flags}) => {

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -8,8 +8,8 @@ import { IChangeEvent, ISubmitEvent } from 'react-jsonschema-form';
 import { createParametersSecret, getInstanceCreateSchema, getInstanceCreateParametersForm, ServiceCatalogParametersForm, getUISchema } from './schema-form';
 import { LoadingBox } from '../utils/status-box';
 import { history, Firehose, NavTitle, resourcePathFromModel } from '../utils';
-import { ClusterServiceClassModel, ServiceInstanceModel } from '../../models';
-import { k8sCreate, K8sResourceKind, serviceClassDisplayName } from '../../module/k8s';
+import { ServiceInstanceModel } from '../../models';
+import { k8sCreate, K8sResourceKind } from '../../module/k8s';
 import { NsDropdown } from '../RBAC/bindings';
 import { ClusterServiceClassInfo } from '../cluster-service-class-info';
 import { ButtonBar } from '../utils/button-bar';
@@ -116,14 +116,13 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
   }
 
   render() {
-    const { obj, plans, match } = this.props;
+    const { obj, plans } = this.props;
     if (!obj.loaded) {
       return <LoadingBox />;
     }
 
     const serviceClass = _.get(obj, 'data');
     const title = 'Create Service Instance';
-    const displayName = serviceClassDisplayName(serviceClass);
 
     const { plan: selectedPlanName } = this.state;
     const availablePlans = getAvailablePlans(plans);
@@ -146,14 +145,7 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
       <Helmet>
         <title>{title}</title>
       </Helmet>
-      <NavTitle
-        title={title}
-        obj={obj}
-        breadcrumbsFor={() => [
-          {name: displayName, path: resourcePathFromModel(ClusterServiceClassModel, serviceClass.metadata.name)},
-          {name: `${title}`, path: `${match.url}`}
-        ]}
-      />
+      <NavTitle title={title} />
       <div className="co-m-pane__body co-create-service-instance">
         <div className="row">
           <div className="col-md-7 col-md-push-5 co-catalog-item-info">
@@ -194,7 +186,7 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
   }
 }
 
-export const CreateInstancePage: React.SFC<CreateInstancePageProps> = (props) => {
+export const CreateInstancePage = (props) => {
   const resources = [
     {kind: 'ClusterServiceClass', name: props.match.params.name, isList: false, prop: 'obj'},
     {kind: 'ClusterServicePlan', isList: true, prop: 'plans', fieldSelector: `spec.clusterServiceClassRef.name=${props.match.params.name}`},
@@ -220,8 +212,4 @@ export type CreateInstanceState = {
   formData: any,
   inProgress: boolean,
   error?: any,
-};
-
-export type CreateInstancePageProps = {
-  match: any,
 };


### PR DESCRIPTION
Electing to remove or not include the breadcrumb since there are two ways you can arrive at these create pages:
1. from Catalog
2. from Service Instance details or Image Stream details

![screen shot 2018-09-28 at 3 17 13 pm](https://user-images.githubusercontent.com/895728/46228994-01284e80-c332-11e8-8641-bd9d2054f42d.PNG)
![screen shot 2018-09-28 at 3 17 04 pm](https://user-images.githubusercontent.com/895728/46228998-04bbd580-c332-11e8-81b0-03b5edcf18c9.PNG)
