### PR TITLE
Fix Re-Rendering Caused by API Discovery 

### DIFF
--- a/builder-run.sh
+++ b/builder-run.sh
@@ -30,5 +30,6 @@ docker run $ENV_STR --rm --net=host \
        --user="${BUILDER_RUN_USER}" \
        $VOLUME_MOUNT \
        -v "$(pwd)":/go/src/github.com/openshift/console \
+       --shm-size=512m \
        -w /go/src/github.com/openshift/console \
        $BUILDER_IMAGE "$@"

--- a/frontend/__tests__/components/utils/firehose.spec.tsx
+++ b/frontend/__tests__/components/utils/firehose.spec.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import * as React from 'react';
+import { ShallowWrapper, shallow } from 'enzyme';
+import { Map as ImmutableMap } from 'immutable';
+import Spy = jasmine.Spy;
+
+import { Firehose } from '../../../public/components/utils/firehose';
+import { FirehoseResource } from '../../../public/components/factory';
+import { K8sKind, K8sResourceKindReference } from '../../../public/module/k8s';
+import { PodModel, ServiceModel } from '../../../public/models';
+
+// TODO(alecmerdler): Use these once `Firehose` is converted to TypeScript
+type FirehoseProps = {
+  expand?: boolean;
+  forceUpdate?: boolean;
+  resources: FirehoseResource[];
+
+  // Provided by `connect`
+  k8sModels: ImmutableMap<K8sResourceKindReference, K8sKind>;
+  loaded: boolean;
+  inFlight: boolean;
+  stopK8sWatch: (id: string) => void;
+  watchK8sObject: (id: string, name: string, namespace: string, query: any, k8sKind: K8sKind) => void;
+  watchK8sList: (id: string, query: any, k8sKind: K8sKind) => void;
+};
+
+describe(Firehose.displayName, () => {
+  const Component: React.ComponentType<FirehoseProps> = Firehose.WrappedComponent as any;
+  let wrapper: ShallowWrapper<FirehoseProps>;
+  let resources: FirehoseResource[];
+  let k8sModels: ImmutableMap<K8sResourceKindReference, K8sKind>;
+  let stopK8sWatch: Spy;
+  let watchK8sObject: Spy;
+  let watchK8sList: Spy;
+
+  beforeEach(() => {
+    resources = [
+      {kind: PodModel.kind, namespace: 'default', prop: 'Pod', isList: true},
+    ];
+    k8sModels = ImmutableMap<K8sResourceKindReference, K8sKind>().set('Pod', PodModel);
+    stopK8sWatch = jasmine.createSpy('stopK8sWatch');
+    watchK8sObject = jasmine.createSpy('watchK8sObject');
+    watchK8sList = jasmine.createSpy('watchK8sList');
+
+    wrapper = shallow(<Component resources={resources} k8sModels={k8sModels} loaded={true} inFlight={false} stopK8sWatch={stopK8sWatch} watchK8sObject={watchK8sObject} watchK8sList={watchK8sList} />);
+  });
+
+  it('returns nothing if `props.inFlight` is true', () => {
+    wrapper = shallow(<Component resources={resources} k8sModels={k8sModels} loaded={false} inFlight={true} stopK8sWatch={stopK8sWatch} watchK8sObject={watchK8sObject} watchK8sList={watchK8sList} />);
+
+    expect(wrapper.html()).toBeNull();
+  });
+
+  it('does not re-render when `props.inFlight` changes but Firehose data is loaded', () => {
+    expect(wrapper.instance().shouldComponentUpdate({inFlight: true, loaded: true} as FirehoseProps, null, null)).toBe(false);
+  });
+
+  it('clears and restarts "firehoses" when `props.resources` change', () => {
+    resources = resources.concat([{kind: ServiceModel.kind, namespace: 'default', prop: 'Service', isList: true}]);
+    wrapper = wrapper.setProps({resources});
+
+    expect(stopK8sWatch.calls.count()).toEqual(1);
+    expect(watchK8sList.calls.count()).toEqual(2);
+  });
+});

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -263,6 +263,19 @@ $color-bookmarker: #DDD;
   }
 }
 
+.co-ns-selector {
+  height: 42px;
+  transition: 0.4s;
+}
+
+.co-ns-selector--hidden {
+  opacity: 0;
+}
+
+.co-ns-selector--visible {
+  opacity: 1;
+}
+
 .btn-dropdown {
   max-width: 100%;
   .caret {

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -178,7 +178,6 @@ class App extends React.PureComponent {
               // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
               // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
             }
-            <Route path="/k8s/cluster/clusterroles/:name" component={props => <ResourceDetailsPage {...props} plural="clusterroles" />} />
 
             {
               // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -286,16 +286,19 @@ class NamespaceDropdown_ extends React.Component {
 
 const NamespaceDropdown = connect(namespaceDropdownStateToProps)(NamespaceDropdown_);
 
-const NamespaceSelector_ = ({useProjects, inFlight}) => inFlight
-  ? <div className="co-namespace-selector" />
-  : <Firehose resources={[{ kind: getModel(useProjects).kind, prop: 'namespace', isList: true }]}>
+const NamespaceSelector_ = ({useProjects, loaded}) => <div className={`co-ns-selector co-ns-selector--${!loaded ? 'hidden' : 'visible'}`}>
+  <Firehose resources={[{kind: getModel(useProjects).kind, prop: 'namespace', isList: true}]}>
     <NamespaceDropdown useProjects={useProjects} />
-  </Firehose>;
+  </Firehose>
+</div>;
 
-const namespaceSelectorStateToProps = ({k8s}) => ({
-  inFlight: k8s.getIn(['RESOURCES', 'inFlight']),
-  useProjects: k8s.hasIn(['RESOURCES', 'models', ProjectModel.kind]),
-});
+const namespaceSelectorStateToProps = ({k8s}) => {
+  const useProjects = k8s.hasIn(['RESOURCES', 'models', ProjectModel.kind]);
+  return {
+    useProjects,
+    loaded: k8s.getIn([useProjects ? 'projects' : 'namespaces', 'loaded']),
+  };
+};
 
 export const NamespaceSelector = connect(namespaceSelectorStateToProps)(NamespaceSelector_);
 

--- a/frontend/public/components/source-to-image.tsx
+++ b/frontend/public/components/source-to-image.tsx
@@ -89,17 +89,24 @@ class BuildSource extends React.Component<BuildSourceProps, BuildSourceState> {
     };
   }
 
-  componentDidUpdate(prevProps) {
-    const { obj } = this.props;
-    if (obj !== prevProps.obj && obj.loaded) {
-      const previousTag = this.state.selectedTag;
-      // Sort tags in reverse order by semver, falling back to a string comparison if not a valid version.
-      const tags = getBuilderTagsSortedByVersion(obj.data);
-      // Select the first tag if the current tag is missing or empty.
-      const selectedTag = previousTag && _.includes(tags, previousTag)
-        ? previousTag
-        : _.get(_.head(tags), 'name');
-      this.setState({tags, selectedTag}, this.getImageStreamImage);
+  static getDerivedStateFromProps(props, state) {
+    if (_.isEmpty(props.obj.data)) {
+      return null;
+    }
+    const previousTag = state.selectedTag;
+    // Sort tags in reverse order by semver, falling back to a string comparison if not a valid version.
+    const tags = getBuilderTagsSortedByVersion(props.obj.data);
+    // Select the first tag if the current tag is missing or empty.
+    const selectedTag = previousTag && _.includes(tags, previousTag)
+      ? previousTag
+      : _.get(_.head(tags), 'name');
+
+    return {tags, selectedTag};
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.selectedTag !== this.state.selectedTag) {
+      this.getImageStreamImage();
     }
   }
 

--- a/frontend/public/components/utils/resource-link.jsx
+++ b/frontend/public/components/utils/resource-link.jsx
@@ -59,7 +59,7 @@ export const resourceObjPath = (obj, kind) => resourcePath(kind, _.get(obj, 'met
 
 export const ResourceLink = connectToModel(
   ({className, kind, name, namespace, title, displayName, linkTo = true, kindsInFlight}) => {
-    if (kindsInFlight) {
+    if (!kind && kindsInFlight) {
       return null;
     }
     const path = resourcePath(kind, name, namespace);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node",
     "outDir": "./public/dist/build/",
     "target": "es5",
-    "lib": ["dom", "es2015"],
+    "lib": ["dom", "es2015", "es2016.array.include"],
     "jsx": "react",
     "allowJs": true,
     "downlevelIteration": true,


### PR DESCRIPTION
### Description

Refactor `Firehose` component to simplify complex/hacky React lifecyle logic. Ensure that `Firehose` does not re-render when API discovery runs if its own data is loaded.

### Testing

Open a terminal alongside the browser window and create a CRD:
```
$ kubectl create -f https://gist.githubusercontent.com/alecmerdler/df6a32ef511721fd8e633251a8dbc140/raw/d272d015756c96651fc8a0cfbce5cdeab902d0d5/cluster.crd.yaml
```
The list/detail view should not be affected.

Addresses https://jira.coreos.com/browse/CONSOLE-812