### PR TITLE
Changes to sidebar to fix where classes inadvertently changed.

### DIFF
--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -68,7 +68,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
 
 export const SectionHeading: React.SFC<SectionHeadingProps> = ({text, children, style}) => <h2 className="co-section-heading" style={style}>{text}{children}</h2>;
 
-export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = ({kindObj, actions, resource}) => <div className="co-m-nav-title resource-overview__heading">
+export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = ({kindObj, actions, resource}) => <div className="overview__sidebar-pane-head resource-overview__heading">
   <h1 className="co-m-pane__heading">
     <div className="co-m-pane__name">
       <ResourceIcon className="co-m-resource-icon--lg pull-left" kind={kindObj.kind} />


### PR DESCRIPTION
Adding `overview__sidebar-pane-head` and removing `co-m-nav-title`
[Initially added in this pr](https://github.com/openshift/console/pull/566/files#diff-ab5df7e0f5f614db897f1625e0565dc2R82)

<img width="1039" alt="screen shot 2018-10-02 at 5 11 48 pm" src="https://user-images.githubusercontent.com/1874151/46377319-487e4a00-c666-11e8-8b54-558cc043c113.png">
