### PR TITLE
Refact & Remove dups. from e2e test

### DIFF
--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -108,7 +108,7 @@ describe('Kubernetes resource CRUD operations', () => {
         leakedResources.add(JSON.stringify({name: testName, plural: resource, namespace: namespaced ? testName : undefined}));
         await yamlView.saveButton.click();
 
-        expect(yamlView.errorMessage.isPresent()).toBe(false);
+        expect(crudView.errorMessage.isPresent()).toBe(false);
       });
 
       it('displays detail view for new resource instance', async() => {
@@ -167,7 +167,7 @@ describe('Kubernetes resource CRUD operations', () => {
       await $('#subject-name').sendKeys('subject-name');
       leakedResources.add(JSON.stringify({name: bindingName, plural: 'rolebindings', namespace: testName}));
       await crudView.saveChangesBtn.click();
-      expect(yamlView.errorMessage.isPresent()).toBe(false);
+      expect(crudView.errorMessage.isPresent()).toBe(false);
     });
 
     it('search view displays created RoleBinding', async() => {
@@ -255,7 +255,7 @@ describe('Kubernetes resource CRUD operations', () => {
       await yamlView.saveButton.click();
       await browser.wait(until.urlContains(name), K8S_CREATION_TIMEOUT);
 
-      expect(yamlView.errorMessage.isPresent()).toBe(false);
+      expect(crudView.errorMessage.isPresent()).toBe(false);
     });
 
     it('displays YAML editor for creating a new custom resource instance', async() => {
@@ -273,7 +273,7 @@ describe('Kubernetes resource CRUD operations', () => {
       leakedResources.add(JSON.stringify({name, plural: 'customresourcedefinitions'}));
       await yamlView.saveButton.click();
 
-      expect(yamlView.errorMessage.isPresent()).toBe(false);
+      expect(crudView.errorMessage.isPresent()).toBe(false);
     });
 
     it('deletes the `CustomResourceDefinition`', async() => {

--- a/frontend/integration-tests/tests/olm/etcd.scenario.ts
+++ b/frontend/integration-tests/tests/olm/etcd.scenario.ts
@@ -122,9 +122,9 @@ describe('Interacting with the etcd OCS', () => {
     await element(by.linkText('YAML')).click();
     await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
     await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
-    await browser.wait(until.visibilityOf($('.alert-success')), 2000);
+    await browser.wait(until.visibilityOf(crudView.successMessage), 2000);
 
-    expect($('.alert-success').getText()).toContain(`${etcdcluster} has been updated to version`);
+    expect(crudView.successMessage.getText()).toContain(`${etcdcluster} has been updated to version`);
   });
 
   it('displays Kubernetes objects associated with the `EtcdCluster` in its "Resources" section', async() => {
@@ -171,9 +171,9 @@ describe('Interacting with the etcd OCS', () => {
     await element(by.linkText('YAML')).click();
     await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
     await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
-    await browser.wait(until.visibilityOf($('.alert-success')), 2000);
+    await browser.wait(until.visibilityOf(crudView.successMessage), 2000);
 
-    expect($('.alert-success').getText()).toContain(`${etcdbackup} has been updated to version`);
+    expect(crudView.successMessage.getText()).toContain(`${etcdbackup} has been updated to version`);
   });
 
   it('displays Kubernetes objects associated with the `EtcdBackup` in its "Resources" section', async() => {
@@ -220,9 +220,9 @@ describe('Interacting with the etcd OCS', () => {
     await element(by.linkText('YAML')).click();
     await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
     await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
-    await browser.wait(until.visibilityOf($('.alert-success')), 2000);
+    await browser.wait(until.visibilityOf(crudView.successMessage), 2000);
 
-    expect($('.alert-success').getText()).toContain(`${etcdrestore} has been updated to version`);
+    expect(crudView.successMessage.getText()).toContain(`${etcdrestore} has been updated to version`);
   });
 
   it('displays Kubernetes objects associated with the `EtcdRestore` in its "Resources" section', async() => {

--- a/frontend/integration-tests/tests/olm/prometheus.scenario.ts
+++ b/frontend/integration-tests/tests/olm/prometheus.scenario.ts
@@ -119,9 +119,9 @@ describe('Interacting with the Prometheus OCS', () => {
     await element(by.linkText('YAML')).click();
     await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
     await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
-    await browser.wait(until.visibilityOf($('.alert-success')), 1000);
+    await browser.wait(until.visibilityOf(crudView.successMessage), 1000);
 
-    expect($('.alert-success').getText()).toContain('example has been updated to version');
+    expect(crudView.successMessage.getText()).toContain('example has been updated to version');
   });
 
   it('displays Kubernetes objects associated with the `Prometheus` in its "Resources" section', async() => {
@@ -164,9 +164,9 @@ describe('Interacting with the Prometheus OCS', () => {
     await element(by.linkText('YAML')).click();
     await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
     await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
-    await browser.wait(until.visibilityOf($('.alert-success')), 1000);
+    await browser.wait(until.visibilityOf(crudView.successMessage), 1000);
 
-    expect($('.alert-success').getText()).toContain('alertmanager-main has been updated to version');
+    expect(crudView.successMessage.getText()).toContain('alertmanager-main has been updated to version');
   });
 
   it('displays Kubernetes objects associated with the `Alertmanager` in its "Resources" section', async() => {
@@ -208,9 +208,9 @@ describe('Interacting with the Prometheus OCS', () => {
     await element(by.linkText('YAML')).click();
     await browser.wait(until.presenceOf($('.yaml-editor--buttons')));
     await $('.yaml-editor--buttons').element(by.buttonText('Save')).click();
-    await browser.wait(until.visibilityOf($('.alert-success')), 1000);
+    await browser.wait(until.visibilityOf(crudView.successMessage), 1000);
 
-    expect($('.alert-success').getText()).toContain('example has been updated to version');
+    expect(crudView.successMessage.getText()).toContain('example has been updated to version');
   });
 
   it('displays Kubernetes objects associated with the `ServiceMonitor` in its "Resources" section', async() => {

--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -129,3 +129,6 @@ export const checkResourceExists = async(resource: string, name: string) => {
 };
 
 export const emptyState = $('.cos-status-box').$('.text-center');
+
+export const errorMessage = $('.alert-danger');
+export const successMessage = $('.alert-success');

--- a/frontend/integration-tests/views/login.view.ts
+++ b/frontend/integration-tests/views/login.view.ts
@@ -3,5 +3,5 @@
 import { $ } from 'protractor';
 
 export const nameInput = $('input[name=login]');
-export const passwordInput = $('input[name=password');
+export const passwordInput = $('input[name=password]');
 export const submitButton = $('button[type=submit]');

--- a/frontend/integration-tests/views/secrets.view.ts
+++ b/frontend/integration-tests/views/secrets.view.ts
@@ -8,7 +8,6 @@ export const pre = $$('.co-copy-to-clipboard__text');
 export const dt = $$('dl.secret-data dt');
 
 export const saveButton = $('#save-changes');
-export const errorMessage = $('.alert-danger');
 export const authTypeDropdown = $('#dropdown-selectbox');
 
 export const webhookSecretValueInput = $('input[name=webhookSecretKey]');
@@ -30,7 +29,7 @@ export const createSecret = async(linkElement: ElementFinder, ns: string, name: 
   await secretNameInput.sendKeys(name);
   await updateForm();
   await saveButton.click();
-  expect(errorMessage.isPresent()).toBe(false);
+  expect(crudView.errorMessage.isPresent()).toBe(false);
 };
 
 export const checkSecret = async(ns: string, name: string, keyValuesToCheck: Object) => {
@@ -53,5 +52,5 @@ export const editSecret = async(ns: string, name: string, updateForm: Function) 
   await browser.wait(until.urlContains(`/k8s/ns/${ns}/secrets/${name}/edit`));
   await updateForm();
   await saveButton.click();
-  expect(errorMessage.isPresent()).toBe(false);
+  expect(crudView.errorMessage.isPresent()).toBe(false);
 };

--- a/frontend/integration-tests/views/source-to-image.view.ts
+++ b/frontend/integration-tests/views/source-to-image.view.ts
@@ -10,7 +10,6 @@ export const nameInput = $('#name');
 export const trySampleButton = element(by.partialButtonText('Try Sample'));
 export const routeCheckbox = $('.checkbox input');
 export const submitButton = $('.btn-primary');
-export const errorMessage = $('.alert-danger');
 
 export const visitOpenShiftImageStream = async(name: string) => {
   await browser.get(`${appHost}/k8s/ns/openshift/imagestreams/${name}`);

--- a/frontend/integration-tests/views/yaml.view.ts
+++ b/frontend/integration-tests/views/yaml.view.ts
@@ -14,6 +14,3 @@ export const setContent = (text: string) => editorContent.click()
   .then(() => editorInput.sendKeys(Key.chord(Key.CONTROL, 'a'), Key.BACK_SPACE))
   .then(() => editorInput.sendKeys(Key.chord(Key.COMMAND, 'a'), Key.BACK_SPACE)) // For those OSX users...
   .then(() => text.split(/\n/g).map(line => editorInput.sendKeys(line, Key.ENTER, Key.HOME)));
-
-export const errorMessage = $('.alert-danger');
-export const successMessage = $('.alert-success');


### PR DESCRIPTION
Moved `errorMessage` and `sucsessMessage` to *crud.view.ts* since they are used in different tests
/assign @spadgett 