### PR TITLE
Adjust co-m-pane__heading margin

### DIFF
--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -88,7 +88,7 @@
 .co-m-pane__heading {
   display: flex;
   justify-content: space-between;
-  margin: 0 ($grid-gutter-width / 2) $grid-gutter-width 0;
+  margin: 0 0 $grid-gutter-width;
   &--center {
     justify-content: center;
   }


### PR DESCRIPTION
Remove right margin from `co-m-pane__heading` and use`.co-m-nav-title` to set it.

Fixes https://jira.coreos.com/browse/CONSOLE-893
