### PR TITLE
Overview sidebar mobile enhancements

### DIFF
--- a/frontend/public/components/_overview.scss
+++ b/frontend/public/components/_overview.scss
@@ -68,14 +68,14 @@
   }
 
   @media(max-width: $screen-xs-max) {
-    .overview__sidebar--entered {
-      transform: translateX(0);
-      opacity: 1;
-    }
-
-    .overview__sidebar--entering {
+    .overview__sidebar-appear {
       transform: translateX(7px);
       opacity: .75;
+    }
+
+    .overview__sidebar-appear-active {
+      transform: translateX(0);
+      opacity: 1;
     }
   }
 

--- a/frontend/public/components/_overview.scss
+++ b/frontend/public/components/_overview.scss
@@ -49,7 +49,13 @@
     position: absolute;
     right: 0;
     top: 0;
-    width: 50%;
+    width: calc(100% - 15px);
+    @media(min-width: $screen-sm-min) {
+      width: 550px;
+    }
+    transition:
+      transform 125ms ease-out,
+      opacity 175ms linear;
     z-index: 5;
 
     .resource-overview {
@@ -58,6 +64,18 @@
       overflow-x: hidden;
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
+    }
+  }
+
+  @media(max-width: $screen-xs-max) {
+    .overview__sidebar--entered {
+      transform: translateX(0);
+      opacity: 1;
+    }
+
+    .overview__sidebar--entering {
+      transform: translateX(7px);
+      opacity: .75;
     }
   }
 
@@ -75,7 +93,6 @@
       .overview__sidebar {
         min-height: 0;
         overflow: hidden;
-        width: 550px;
       }
     }
   }

--- a/frontend/public/components/overview.jsx
+++ b/frontend/public/components/overview.jsx
@@ -6,7 +6,7 @@ import * as classnames from 'classnames';
 import { Toolbar } from 'patternfly-react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-
+import { Transition } from 'react-transition-group';
 import { StartGuide } from './start-guide';
 import { TextFilter } from './factory';
 import { ProjectOverview } from './project-overview';
@@ -559,15 +559,25 @@ export class Overview extends React.Component {
       </div>
       {
         !_.isEmpty(selectedItem) &&
-        <div className="overview__sidebar">
-          <div className="overview__sidebar-dismiss clearfix">
-            <CloseButton onClick={() => this.selectItem({})} />
-          </div>
-          <ResourceOverviewPage
-            kind={selectedItem.obj.kind}
-            resource={selectedItem.obj}
-          />
-        </div>
+        <Transition
+          mountOnEnter={true}
+          in
+          exit={false}
+          timeout={0}
+          appear
+        >
+          {(status) => (
+            <div className={`overview__sidebar overview__sidebar--${status}`}>
+              <div className="overview__sidebar-dismiss clearfix">
+                <CloseButton onClick={() => this.selectItem({})} />
+              </div>
+              <ResourceOverviewPage
+                kind={selectedItem.obj.kind}
+                resource={selectedItem.obj}
+              />
+            </div>
+          )}
+        </Transition>
       }
     </div>;
   }

--- a/frontend/public/components/overview.jsx
+++ b/frontend/public/components/overview.jsx
@@ -6,7 +6,7 @@ import * as classnames from 'classnames';
 import { Toolbar } from 'patternfly-react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-import { Transition } from 'react-transition-group';
+import { CSSTransition } from 'react-transition-group';
 import { StartGuide } from './start-guide';
 import { TextFilter } from './factory';
 import { ProjectOverview } from './project-overview';
@@ -559,25 +559,17 @@ export class Overview extends React.Component {
       </div>
       {
         !_.isEmpty(selectedItem) &&
-        <Transition
-          mountOnEnter={true}
-          in
-          exit={false}
-          timeout={0}
-          appear
-        >
-          {(status) => (
-            <div className={`overview__sidebar overview__sidebar--${status}`}>
-              <div className="overview__sidebar-dismiss clearfix">
-                <CloseButton onClick={() => this.selectItem({})} />
-              </div>
-              <ResourceOverviewPage
-                kind={selectedItem.obj.kind}
-                resource={selectedItem.obj}
-              />
+        <CSSTransition in appear timeout={1} classNames="overview__sidebar">
+          <div className="overview__sidebar">
+            <div className="overview__sidebar-dismiss clearfix">
+              <CloseButton onClick={() => this.selectItem({})} />
             </div>
-          )}
-        </Transition>
+            <ResourceOverviewPage
+              kind={selectedItem.obj.kind}
+              resource={selectedItem.obj}
+            />
+          </div>
+        </CSSTransition>
       }
     </div>;
   }


### PR DESCRIPTION
A couple of options that show selecting an overview list item on a mobile device. Since this is an overlay, of the previous screen, I wanted to provide subtle indications that must be closed (not the back button). 

Both incorporate subtle transition of the panel as it enters.  One opens to `width: 100%` and the other `width: calc(100% - 15px)`so that the details panel `box-shadow` is visible.

thoughts?

![sidebar-mobile-transition-lc25fps](https://user-images.githubusercontent.com/1874151/46494322-8b642d00-c7e0-11e8-94c1-29053a316f0b.gif)

![sidebar-mobile-transition-lc25fps-full](https://user-images.githubusercontent.com/1874151/46494320-8b642d00-c7e0-11e8-989a-473fc83b9880.gif)

