### PR TITLE
Fix display of overview when there are no groups

### DIFF
--- a/frontend/public/components/_project-overview.scss
+++ b/frontend/public/components/_project-overview.scss
@@ -47,7 +47,6 @@
   }
 
   .project-overview__group-heading {
-    border-bottom: 1px solid $color-pf-black-400;
     font-size: 22px;
     font-weight: 300;
     line-height: normal;
@@ -63,10 +62,6 @@
     border-left: 0;
     border-right: 0;
     position: relative;
-    &:first-child {
-      border-top: 0;
-    }
-
     &::after {
       align-self: center;
       content: $fa-var-chevron-right;

--- a/frontend/public/components/project-overview.jsx
+++ b/frontend/public/components/project-overview.jsx
@@ -114,9 +114,9 @@ ProjectOverviewGroup.propTypes = {
 
 export const ProjectOverview = ({selectedItem, groups, onClickItem}) =>
   <div className="project-overview">
-    {_.map(groups, ({name, items}) =>
+    {_.map(groups, ({name, items, index}) =>
       <ProjectOverviewGroup
-        key={name}
+        key={name || `_${index}`}
         heading={name}
         items={items}
         onClickItem={onClickItem}


### PR DESCRIPTION
* Update group styles to remove the darker line, which is not part of latest design
* Make sure `key` fallbacks back to a value based on the index when no group name

/cc @TheRealJon @sg00dwin 