### PR TITLE
Secret e2e image + Image Secret form fix

### DIFF
--- a/frontend/integration-tests/tests/secrets.scenario.ts
+++ b/frontend/integration-tests/tests/secrets.scenario.ts
@@ -20,7 +20,7 @@ describe('Interacting with the create secret forms', () => {
 
     it('creates webhook secret', async() => {
       await secretsView.createSecret(secretsView.createWebhookSecretLink, testName, webhookSecretName, async() => {
-        await secretsView.webhookSecretValueInput.sendKeys(webhookSecretValue);
+        await secretsView.secretWebhookInput.sendKeys(webhookSecretValue);
       });
     });
 
@@ -56,8 +56,8 @@ describe('Interacting with the create secret forms', () => {
 
     it('creates basic source secret', async() => {
       await secretsView.createSecret(secretsView.createSourceSecretLink, testName, basicSourceSecretName, async() => {
-        await secretsView.sourceSecretUsernameInput.sendKeys(basicSourceSecretUsername);
-        await secretsView.sourceSecretPasswordInput.sendKeys(basicSourceSecretPassword);
+        await secretsView.secretUsernameInput.sendKeys(basicSourceSecretUsername);
+        await secretsView.secretPasswordInput.sendKeys(basicSourceSecretPassword);
       });
     });
 
@@ -67,10 +67,10 @@ describe('Interacting with the create secret forms', () => {
 
     it('edits basic source secret', async() => {
       await secretsView.editSecret(testName, basicSourceSecretName, async() => {
-        await secretsView.sourceSecretUsernameInput.clear();
-        await secretsView.sourceSecretUsernameInput.sendKeys(basicSourceSecretUsernameUpdated);
-        await secretsView.sourceSecretPasswordInput.clear();
-        await secretsView.sourceSecretPasswordInput.sendKeys(basicSourceSecretPasswordUpdated);
+        await secretsView.secretUsernameInput.clear();
+        await secretsView.secretUsernameInput.sendKeys(basicSourceSecretUsernameUpdated);
+        await secretsView.secretPasswordInput.clear();
+        await secretsView.secretPasswordInput.sendKeys(basicSourceSecretPasswordUpdated);
       });
     });
 
@@ -93,8 +93,8 @@ describe('Interacting with the create secret forms', () => {
     it('creates SSH source secret', async() => {
       await secretsView.createSecret(secretsView.createSourceSecretLink, testName, sshSourceSecretName, async() => {
         await secretsView.authTypeDropdown.click().then(() => browser.actions().sendKeys(Key.ARROW_UP, Key.ENTER).perform());
-        await browser.wait(until.presenceOf(secretsView.sourceSecretSSHTextArea));
-        await secretsView.sourceSecretSSHTextArea.sendKeys(sshSourceSecretSSHKey);
+        await browser.wait(until.presenceOf(secretsView.uploadFileTextArea));
+        await secretsView.uploadFileTextArea.sendKeys(sshSourceSecretSSHKey);
       });
     });
 
@@ -104,9 +104,9 @@ describe('Interacting with the create secret forms', () => {
 
     it('edits SSH source secret', async() => {
       await secretsView.editSecret(testName, sshSourceSecretName, async() => {
-        await browser.wait(until.presenceOf(secretsView.sourceSecretSSHTextArea));
-        await secretsView.sourceSecretSSHTextArea.clear();
-        await secretsView.sourceSecretSSHTextArea.sendKeys(sshSourceSecretSSHKeUpdated);
+        await browser.wait(until.presenceOf(secretsView.uploadFileTextArea));
+        await secretsView.uploadFileTextArea.clear();
+        await secretsView.uploadFileTextArea.sendKeys(sshSourceSecretSSHKeUpdated);
       });
     });
 
@@ -116,6 +116,129 @@ describe('Interacting with the create secret forms', () => {
 
     it('deletes the SSH source secret', async() => {
       await crudView.deleteResource('secrets', 'Secret', sshSourceSecretName);
+    });
+  });
+
+  describe('Registry credentials image secrets', () => {
+    const credentialsImageSecretName = 'registry-credentials-image-secret';
+    const address = 'https://index.openshift.io/v';
+    const addressUpdated = 'https://index.openshift.io/updated/v1';
+    const username = 'username';
+    const password = 'password';
+    const username0 = 'username0';
+    const password0 = 'password0';
+    const username1 = 'username1';
+    const password1 = 'password1';
+    const usernameUpdated = 'usernameUpdated';
+    const passwordUpdated = 'passwordUpdated';
+    const mail = 'test@secret.com';
+    const mailUpdated = 'testUpdated@secret.com';
+
+    const credentialsToCheck = {
+      '.dockerconfigjson': {
+        auths:{
+          'https://index.openshift.io/v0':{
+            username: username0,
+            password: password0,
+            auth: secretsView.encode(username0, password0),
+            email: 'test@secret.com0'
+          },
+          'https://index.openshift.io/v1':{
+            username: username1,
+            password: password1,
+            auth: secretsView.encode(username1, password1),
+            email: 'test@secret.com1'
+          }
+        }
+      }
+    };
+    const updatedCredentialsToCheck = {
+      '.dockerconfigjson': {
+        auths:{
+          'https://index.openshift.io/updated/v1':{
+            username: usernameUpdated,
+            password: passwordUpdated,
+            auth: secretsView.encode(usernameUpdated, passwordUpdated),
+            email: 'testUpdated@secret.com'
+          }
+        }
+      }
+    };
+
+    beforeAll(async() => secretsView.visitSecretsPage(appHost, testName));
+
+    it('creates registry credentials image secret', async() => {
+      await secretsView.createSecret(secretsView.createImageSecretLink, testName, credentialsImageSecretName, async() => {
+        await browser.wait(until.presenceOf(secretsView.addSecretEntryLink));
+        await secretsView.addSecretEntryLink.click();
+        await secretsView.imageSecretForm.each(async(el, index) => {
+          await el.$('input[name=address]').sendKeys(address + index);
+          await el.$('input[name=username]').sendKeys(username + index);
+          await el.$('input[name=password]').sendKeys(password + index);
+          await el.$('input[name=email]').sendKeys(mail + index);
+        });
+      });
+    });
+
+    it('check for created registry credentials image secret values', async() => {
+      await secretsView.checkSecret(testName, credentialsImageSecretName, credentialsToCheck, true);
+    });
+
+    it('edits registry credentials image secret', async() => {
+      await secretsView.editSecret(testName, credentialsImageSecretName, async() => {
+        await browser.wait(until.presenceOf(secretsView.removeSecretEntryLink));
+        await secretsView.removeSecretEntryLink.click();
+        await secretsView.secretAddressInput.clear();
+        await secretsView.secretAddressInput.sendKeys(addressUpdated);
+        await secretsView.secretUsernameInput.clear();
+        await secretsView.secretUsernameInput.sendKeys(usernameUpdated);
+        await secretsView.secretPasswordInput.clear();
+        await secretsView.secretPasswordInput.sendKeys(passwordUpdated);
+        await secretsView.secretEmailInput.clear();
+        await secretsView.secretEmailInput.sendKeys(mailUpdated);
+      });
+    });
+
+    it('check for edited registry credentials image secret value', async() => {
+      await secretsView.checkSecret(testName, credentialsImageSecretName, updatedCredentialsToCheck, true);
+    });
+
+    it('deletes the registry credentials image secret', async() => {
+      await crudView.deleteResource('secrets', 'Secret', credentialsImageSecretName);
+    });
+  });
+
+  describe('Upload configuration file image secret', () => {
+    const uploadConfigFileImageSecretName = 'upload-configuration-file-image-secret';
+    const username = 'username';
+    const password = 'password';
+    const configFile = {
+      auths:{
+        'https://index.openshift.io/v1':{
+          username: username,
+          password: password,
+          auth: secretsView.encode(username, password),
+          email: 'test@secret.com'
+        }
+      }
+    };
+
+    beforeAll(async() => secretsView.visitSecretsPage(appHost, testName));
+
+    it('creates image secret by uploading configuration file', async() => {
+      await secretsView.createSecret(secretsView.createImageSecretLink, testName, uploadConfigFileImageSecretName, async() => {
+        await secretsView.authTypeDropdown.click().then(() => browser.actions().sendKeys(Key.ARROW_UP, Key.ENTER).perform());
+        await browser.wait(until.presenceOf(secretsView.uploadFileTextArea));
+        await secretsView.uploadFileTextArea.sendKeys(JSON.stringify(configFile));
+      });
+    });
+
+    it('check for created image secret values from uploaded configuration file', async() => {
+      await secretsView.checkSecret(testName, uploadConfigFileImageSecretName, {'.dockerconfigjson': configFile}, true);
+    });
+
+    it('deletes the image secret created from uploaded configuration file', async() => {
+      await crudView.deleteResource('secrets', 'Secret', uploadConfigFileImageSecretName);
     });
   });
 });

--- a/frontend/integration-tests/views/secrets.view.ts
+++ b/frontend/integration-tests/views/secrets.view.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { $, $$, browser, by, ExpectedConditions as until, element, ElementFinder } from 'protractor';
+import { Base64 } from 'js-base64';
 
 import * as crudView from '../views/crud.view';
 
@@ -10,18 +11,28 @@ export const dt = $$('dl.secret-data dt');
 export const saveButton = $('#save-changes');
 export const authTypeDropdown = $('#dropdown-selectbox');
 
-export const webhookSecretValueInput = $('input[name=webhookSecretKey]');
-export const sourceSecretUsernameInput = $('input[name=username]');
-export const sourceSecretPasswordInput = $('input[name=password]');
-export const sourceSecretSSHTextArea = $('.co-file-dropzone__textarea');
+export const secretWebhookInput = $('input[name=webhookSecretKey]');
+export const secretAddressInput = $('input[name=address]');
+export const secretUsernameInput = $('input[name=username]');
+export const secretPasswordInput = $('input[name=password]');
+export const secretEmailInput = $('input[name=email]');
+
+export const uploadFileTextArea = $('.co-file-dropzone__textarea');
 
 export const createWebhookSecretLink = $('#webhook-link');
 export const createSourceSecretLink = $('#source-link');
+export const createImageSecretLink = $('#image-link');
+
+export const addSecretEntryLink = $('.co-create-secret-form__link--add-entry');
+export const removeSecretEntryLink = $('.co-create-secret-form__link--remove-entry .btn-link');
+export const imageSecretForm = $$('.co-create-image-secret__form');
 
 export const visitSecretsPage = async(appHost: string, ns: string) => {
   await browser.get(`${appHost}/k8s/ns/${ns}/secrets`);
   await crudView.isLoaded();
 };
+
+export const encode = (username, password) => Base64.encode(`${username}:${password}`);
 
 export const createSecret = async(linkElement: ElementFinder, ns: string, name: string, updateForm: Function) => {
   await crudView.createItemButton.click();
@@ -32,14 +43,14 @@ export const createSecret = async(linkElement: ElementFinder, ns: string, name: 
   expect(crudView.errorMessage.isPresent()).toBe(false);
 };
 
-export const checkSecret = async(ns: string, name: string, keyValuesToCheck: Object) => {
+export const checkSecret = async(ns: string, name: string, keyValuesToCheck: Object, jsonOutput: boolean = false) => {
   await browser.wait(until.urlContains(`/k8s/ns/${ns}/secrets/${name}`));
   await browser.wait(until.textToBePresentInElement($('.co-m-pane__heading'), name));
   await element(by.partialButtonText('Reveal Values')).click();
   const renderedKeyValues = await dt.reduce(async(acc, el, index) => {
     const key = await el.getAttribute('textContent');
     const value = await pre.get(index).getText();
-    acc[key] = value;
+    acc[key] = jsonOutput ? JSON.parse(value) : value;
     return acc;
   }, {});
   expect(renderedKeyValues).toEqual(keyValuesToCheck);

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -302,7 +302,7 @@ class ConfigEntryForm extends React.Component<ConfigEntryFormProps, ConfigEntryF
       password: _.get(this.props.entry, 'password'),
       email: _.get(this.props.entry, 'email'),
       auth: _.get(this.props.entry, 'auth'),
-      uid: _.get(this.props.entry, 'uid'),
+      uid: _.get(this.props, 'uid'),
     };
     this.changeData = this.changeData.bind(this);
   }
@@ -313,10 +313,14 @@ class ConfigEntryForm extends React.Component<ConfigEntryFormProps, ConfigEntryF
       : this.state.auth;
   }
   changeData(event) {
+    const { name, value } = event.target;
     this.setState({
-      auth: this.updateAuth(event.target.name),
-      [event.target.name]: event.target.value
-    } as ConfigEntryFormState, () => this.props.onChange(this.state, this.props.id));
+      [name]: value
+    } as ConfigEntryFormState, () => {
+      this.setState({
+        auth: this.updateAuth(name)
+      } as ConfigEntryFormState, () => this.props.onChange(this.state, this.props.id));
+    });
   }
   render() {
     return <div className="co-create-image-secret__form">


### PR DESCRIPTION
Adding e2e tests for image secret create form.
While adding the tests I've found a bug where the image secrets `auth` field (which is base64 encoded `$username:$password` string) was not encoding the updated `username` and `password` but the previous values, since the `username` and `password` state needs to be updated first and after the update the `auth` state can be modified. 

Split it into two commits so the changes are obvious.

/assign @spadgett 