### PR TITLE
Increase default width of popover content

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -40,6 +40,11 @@ small {
   margin: 0 !important;
 }
 
+// override patternfly popover width to make less narrow
+.popover {
+  max-width: 325px;
+}
+
 tags-input:focus,
 tags-input .host:focus {
   outline: none;


### PR DESCRIPTION
Look into addressing github comment: https://github.com/openshift/console/pull/514#issuecomment-420041075

@spadgett is this too broad an implementation to increase the default width for the fieldlevelhelp component in openshift?

Before:
<img width="802" alt="screen shot 2018-10-08 at 11 39 18 pm" src="https://user-images.githubusercontent.com/35978579/46645608-b1c4f800-cb53-11e8-8c40-72b79b3aa508.png">

After:
<img width="798" alt="screen shot 2018-10-08 at 11 38 49 pm" src="https://user-images.githubusercontent.com/35978579/46645636-d0c38a00-cb53-11e8-9aee-f77e83cb7f4f.png">


