### PR TITLE
Update environment drag and drop icon

### DIFF
--- a/frontend/__tests__/components/utils/name-value-editor.spec.tsx
+++ b/frontend/__tests__/components/utils/name-value-editor.spec.tsx
@@ -61,7 +61,7 @@ describe(NameValueEditor.displayName, () => {
         />
       );
       expect(wrapper.html()).not.toContain('pairs-list__delete-icon');
-      expect(wrapper.html()).not.toContain('pairs-list__reorder-icon');
+      expect(wrapper.html()).not.toContain('pairs-list__action-icon--reorder');
     });
   });
 
@@ -92,7 +92,7 @@ describe(NameValueEditor.displayName, () => {
       );
 
       expect(wrapper.html()).toContain('pairs-list__delete-icon');
-      expect(wrapper.html()).toContain('pairs-list__reorder-icon');
+      expect(wrapper.html()).toContain('pairs-list__action-icon--reorder');
     });
   });
 
@@ -106,7 +106,7 @@ describe(NameValueEditor.displayName, () => {
         />
       );
       expect(wrapper.html()).toContain('pairs-list__delete-icon');
-      expect(wrapper.html()).not.toContain('pairs-list__reorder-icon');
+      expect(wrapper.html()).not.toContain('pairs-list__action-icon--reorder');
     });
   });
 });

--- a/frontend/public/components/utils/_name-value-editor.scss
+++ b/frontend/public/components/utils/_name-value-editor.scss
@@ -1,10 +1,24 @@
+.co-empty__header {
+  width: auto;
+}
+
 .pairs-list__row {
   padding-bottom: 15px;
 }
 
 .pairs-list__row-dragging {
-  padding-bottom: 15px;
-  opacity: 0
+  background-color: $color-pf-black-200;
+  border: 1px dashed $color-pf-black-300;
+  border-radius: 4px;
+  height: 28px;
+  margin-left: 28px;
+  margin-bottom: 15px;
+  overflow: hidden;
+  padding-right: 100px;
+  width: calc(83.34% + 11px); /* sum of the widths of the input fields plus an offset for padding */
+  div {
+    opacity: 0; /* hides input boxes and other children so there's just a gray target */
+  }
 }
 
 .pairs-list__value-field,
@@ -32,18 +46,22 @@
   padding-right: 8px;
 }
 
-.pairs-list__delete-icon {
-  line-height: 32px;
+.pairs-list__action-icon {
+  padding-right: 0;
+  width: auto;
 }
 
-.pairs-list__reorder-icon {
-  line-height: 32px;
-  padding-right: 10px;
+.pairs-list__action-icon--reorder {
+  line-height: 35px;
   cursor: move;
 }
 
 .pairs-list__add-icon {
   margin-right: 6px;
+}
+
+.pairs-list__delete-icon {
+  line-height: 35px;
 }
 
 .pairs-list__span-btns {

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -66,12 +66,14 @@ export const NameValueEditor = withDragDropContext(class NameValueEditor extends
     });
     return <React.Fragment>
       <div className="row">
-        <div className="col-md-5 col-xs-5 text-secondary text-uppercase">{nameString}</div>
-        <div className="col-md-6 col-xs-5 text-secondary text-uppercase">{valueString}</div>
+        <div className="col-xs-1 co-empty__header"></div>
+        <div className="col-xs-5 text-secondary text-uppercase">{nameString}</div>
+        <div className="col-xs-5 text-secondary text-uppercase">{valueString}</div>
+        <div className="col-xs-1 co-empty__header"></div>
       </div>
       {pairElems}
       <div className="row">
-        <div className="col-md-12 col-xs-12">
+        <div className="col-xs-12">
           {
             readOnly ?
               null :
@@ -177,8 +179,10 @@ export const EnvFromEditor = withDragDropContext(class EnvFromEditor extends Rea
 
     return <React.Fragment>
       <div className="row">
-        <div className="col-md-5 col-xs-5 text-secondary text-uppercase">Config Map/Secret</div>
-        <div className="col-md-6 col-xs-5 text-secondary text-uppercase">Prefix (Optional)</div>
+        <div className="col-xs-1 co-empty__header"></div>
+        <div className="col-xs-5 text-secondary text-uppercase">Config Map/Secret</div>
+        <div className="col-xs-5 text-secondary text-uppercase">Prefix (Optional)</div>
+        <div className="col-xs-1 co-empty__header"></div>
       </div>
       {pairElems}
       <div className="row">
@@ -311,32 +315,29 @@ const PairElement = DragSource(DRAGGABLE_TYPE.ENV_ROW, pairSource, collectSource
     return connectDropTarget(
       connectDragPreview(
         <div className={classNames('row', isDragging ? 'pairs-list__row-dragging' : 'pairs-list__row')} ref={node => this.node = node}>
-          <div className="col-md-5 col-xs-5 pairs-list__name-field">
+          <div className="col-xs-1 pairs-list__action-icon">
+            { allowSorting &&
+              connectDragSource(<i className="pficon pficon-drag-drop pairs-list__action-icon--reorder" />)
+            }
+          </div>
+          <div className="col-xs-5 pairs-list__name-field">
             <input type="text" className="form-control" placeholder={nameString.toLowerCase()} value={pair[NameValueEditorPair.Name]} onChange={this._onChangeName} disabled={readOnly} />
           </div>
           {
             _.isPlainObject(pair[NameValueEditorPair.Value]) ?
-              <div className="col-md-6 col-xs-5 pairs-list__value-pair-field">
+              <div className="col-xs-5 pairs-list__value-pair-field">
                 <ValueFromPair pair={pair[NameValueEditorPair.Value]} configMaps={configMaps} secrets={secrets} onChange={this._onChangeValue} disabled={readOnly} />
               </div>
               :
-              <div className="col-md-6 col-xs-5 pairs-list__value-field">
+              <div className="col-xs-5 pairs-list__value-field">
                 <input type="text" className="form-control" placeholder={valueString.toLowerCase()} value={pair[NameValueEditorPair.Value] || ''} onChange={this._onChangeValue} disabled={readOnly} />
               </div>
           }
           {
             !readOnly &&
-              <div className="col-md-1 col-xs-2">
+              <div className="col-xs-1">
                 <span className={classNames(allowSorting ? 'pairs-list__span-btns' : null)}>
-                  {
-                    allowSorting ?
-                      <React.Fragment>
-                        {connectDragSource(<i className="fa fa-bars pairs-list__reorder-icon" />)}
-                        {deleteButton}
-                      </React.Fragment>
-                      :
-                      deleteButton
-                  }
+                  {deleteButton}
                 </span>
               </div>
           }
@@ -396,17 +397,21 @@ const EnvFromPairElement = DragSource(DRAGGABLE_TYPE.ENV_FROM_ROW, pairSource, c
     return connectDropTarget(
       connectDragPreview(
         <div className={classNames('row', isDragging ? 'pairs-list__row-dragging' : 'pairs-list__row')} ref={node => this.node = node}>
-          <div className="col-md-5 col-xs-5 pairs-list__value-pair-field">
+          <div className="col-xs-1 pairs-list__action-icon">
+            { !readOnly &&
+              <React.Fragment>{connectDragSource(<i className="pficon pficon-drag-drop pairs-list__action-icon--reorder" />)}</React.Fragment>
+            }
+          </div>
+          <div className="col-xs-5 pairs-list__value-pair-field">
             <ValueFromPair pair={pair[EnvFromPair.Resource]} configMaps={configMaps} secrets={secrets} onChange={this._onChangeResource} disabled={readOnly} />
           </div>
-          <div className="col-md-6 col-xs-5 pairs-list__name-field">
+          <div className="col-xs-5 pairs-list__name-field">
             <input type="text" className="form-control" placeholder={valueString.toLowerCase()} value={pair[EnvFromPair.Prefix]} onChange={this._onChangePrefix} disabled={readOnly} />
           </div>
           {
             readOnly ? null :
-              <div className="col-md-1 col-xs-2">
+              <div className="col-xs-1">
                 <span className="pairs-list__span-btns">
-                  {connectDragSource(<i className="fa fa-bars pairs-list__reorder-icon" />)}
                   {deleteButton}
                 </span>
               </div>


### PR DESCRIPTION
Updated environment drag and drop icon to new one in Patternfly. Added
CSS for gray box that serves at the drag target per [Colleen's screenshot](https://github.com/openshift/console/issues/102#issuecomment-402851247).

Old: 
<img width="1098" alt="screen shot 2018-10-09 at 10 12 04 am" src="https://user-images.githubusercontent.com/7014965/46675226-f1b7c980-cbab-11e8-98cd-0b53fab82f31.png">

New:
<img width="1217" alt="screen shot 2018-10-09 at 10 02 36 am" src="https://user-images.githubusercontent.com/7014965/46674856-2e36f580-cbab-11e8-9cc5-64ffd7ffb605.png">

Fixes [CONSOLE-891](https://jira.coreos.com/browse/CONSOLE-891).

I'm adding a follow-up subtask for styling the row as it's dragged; you need to use an advanced feature of the react-dnd library and it's more involved.

@openshift/team-ux-review, can you please review?