### PR TITLE
Webhook secret e2e flake

### DIFF
--- a/frontend/integration-tests/tests/secrets.scenario.ts
+++ b/frontend/integration-tests/tests/secrets.scenario.ts
@@ -30,6 +30,7 @@ describe('Interacting with the create secret forms', () => {
 
     it('edits webhook secret', async() => {
       await secretsView.editSecret(testName, webhookSecretName, async() => {
+        await element(by.buttonText('Generate')).isPresent();
         await element(by.buttonText('Generate')).click();
       });
     });


### PR DESCRIPTION
Just a small fix since I've experience that the secret e2e tests have been failing on not finding the button, so we should wait until is present.

/assign @spadgett 