### PR TITLE
Remove height on .co-ns-selector to fix bg color bug on catalog at mo…

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -264,7 +264,6 @@ $color-bookmarker: #DDD;
 }
 
 .co-ns-selector {
-  height: 42px;
   transition: 0.4s;
 }
 


### PR DESCRIPTION
…bile

Before:
![console apps ui-preserve origin-gce dev openshift com_k8s_cluster_projects iphone 6_7_8 plus](https://user-images.githubusercontent.com/895728/46761728-3e320080-cca3-11e8-9ffe-53401c15b93c.png)

After:
![localhost_9000_catalog_all-namespaces iphone 6_7_8 plus](https://user-images.githubusercontent.com/895728/46761732-42f6b480-cca3-11e8-8edb-f84ba4c31cde.png)

Note:  changes in https://github.com/openshift/console/pull/603 still result in the namespace picker bar fading on on some route changes.  I gather this is a bandaid to minimize the fact the picker is loading after the rest of the page, but the late load of the picker seems undesirable.  http://recordit.co/NBO3QtOZcf

