### PR TITLE
Don't show header on YAML tab for existing resources

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -304,7 +304,7 @@ export const EditYAML = connect(stateToProps)(
       */
 
       const {error, success, stale} = this.state;
-      const {create, obj, download = true, showHeader = true, readOnly} = this.props;
+      const {create, obj, download = true, showHeader, readOnly} = this.props;
       const kind = obj && obj.kind;
       const model = this.getModel(obj);
 


### PR DESCRIPTION
This still shows the header for the Create pages and Import YAML, but not on the YAML tab for existing resources.

/assign @rhamilto 