### PR TITLE
Remove title attribute and help cursor from event rows

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -113,7 +113,6 @@ $color-dark-border: #ddd;
 
 .co-sysevent__message {
   @include co-break-word;
-  cursor: help;
   margin-top: 10px;
   position: relative;
 }

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -90,7 +90,7 @@ const Inner = connectToFlags(FLAGS.CAN_LIST_NODE)(class Inner extends React.Pure
           </div>
         </div>
 
-        <div className="co-sysevent__message" title={_.trim(message)}>
+        <div className="co-sysevent__message">
           {message}
         </div>
       </div>


### PR DESCRIPTION
This is no longer needed since we now show the full event message.

/assign @rhamilto 