### PR TITLE
Replace OLM ConfigMap Parsing with Packages API

### DIFF
--- a/frontend/__mocks__/k8sResourcesMocks.ts
+++ b/frontend/__mocks__/k8sResourcesMocks.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { ClusterServiceVersionKind, ClusterServiceVersionResourceKind, Package, InstallPlanKind, ClusterServiceVersionPhase, CSVConditionReason, SubscriptionKind, CatalogSourceKind, InstallPlanApproval } from '../public/components/operator-lifecycle-manager';
+import { ClusterServiceVersionKind, ClusterServiceVersionResourceKind, InstallPlanKind, ClusterServiceVersionPhase, CSVConditionReason, SubscriptionKind, CatalogSourceKind, InstallPlanApproval, PackageManifestKind } from '../public/components/operator-lifecycle-manager';
 import { StatusCapability, SpecCapability } from '../public/components/operator-lifecycle-manager/descriptors/types';
 import { CustomResourceDefinitionKind, K8sResourceKind, K8sKind } from '../public/module/k8s';
 /* eslint-enable no-unused-vars */
@@ -219,10 +219,37 @@ export const testOwnedResourceInstance: ClusterServiceVersionResourceKind = {
   },
 };
 
-export const testPackage: Package = {
-  packageName: 'testapp-package',
-  channels: [{name: 'stable', currentCSV: 'testapp'}],
-  defaultChannel: 'stable',
+export const testPackageManifest: PackageManifestKind = {
+  apiVersion: 'packages.app.redhat.com/v1alpha1',
+  kind: 'PackageManifest',
+  metadata: {
+    name: 'test-package',
+    namespace: 'default',
+  },
+  spec: {},
+  status: {
+    catalogSource: 'test-catalog',
+    catalogSourceNamespace: 'tectonic-system',
+    catalogSourceDisplayName: 'Test Catalog',
+    catalogSourcePublisher: 'Test Publisher',
+    provider: {
+      name: 'CoreOS, Inc',
+    },
+    packageName: 'test-package',
+    channels: [{
+      name: 'alpha',
+      currentCSV: 'testapp',
+      currentCSVDesc: {
+        displayName: 'Test App',
+        icon: [{mediatype: 'image/png', data: ''}],
+        version: '0.0.1',
+        provider: {
+          name: 'CoreOS, Inc',
+        },
+      }
+    }],
+    defaultChannel: 'alpha',
+  },
 };
 
 export const testCatalogSource: CatalogSourceKind = {

--- a/frontend/__tests__/components/modals/subscription-channel-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/subscription-channel-modal.spec.tsx
@@ -7,8 +7,8 @@ import * as _ from 'lodash-es';
 
 import { SubscriptionChannelModal, SubscriptionChannelModalProps, SubscriptionChannelModalState } from '../../../public/components/modals/subscription-channel-modal';
 import { ModalTitle, ModalSubmitFooter, ModalBody } from '../../../public/components/factory/modal';
-import { testSubscription } from '../../../__mocks__/k8sResourcesMocks';
-import { SubscriptionKind, Package } from '../../../public/components/operator-lifecycle-manager/index';
+import { testSubscription, testPackageManifest } from '../../../__mocks__/k8sResourcesMocks';
+import { SubscriptionKind, PackageManifestKind } from '../../../public/components/operator-lifecycle-manager/index';
 import { SubscriptionModel } from '../../../public/models';
 import { RadioInput } from '../../../public/components/radio';
 
@@ -18,18 +18,38 @@ describe(SubscriptionChannelModal.name, () => {
   let close: Spy;
   let cancel: Spy;
   let subscription: SubscriptionKind;
-  let pkg: Package;
+  let pkg: PackageManifestKind;
 
   beforeEach(() => {
     k8sUpdate = jasmine.createSpy('k8sUpdate').and.returnValue(Promise.resolve());
     close = jasmine.createSpy('close');
     cancel = jasmine.createSpy('cancel');
     subscription = _.cloneDeep(testSubscription);
-    pkg = {
-      packageName: 'testapp-package',
-      channels: [{name: 'stable', currentCSV: 'testapp'}, {name: 'nightly', currentCSV: 'testapp-nightly'}],
-      defaultChannel: 'stable',
-    };
+    pkg = _.cloneDeep(testPackageManifest);
+    pkg.status.defaultChannel = 'stable';
+    pkg.status.channels = [{
+      name: 'stable',
+      currentCSV: 'testapp',
+      currentCSVDesc: {
+        displayName: 'Test App',
+        icon: [{mediatype: 'image/png', data: ''}],
+        version: '0.0.1',
+        provider: {
+          name: 'CoreOS, Inc',
+        },
+      }
+    }, {
+      name: 'nightly',
+      currentCSV: 'testapp-nightly',
+      currentCSVDesc: {
+        displayName: 'Test App',
+        icon: [{mediatype: 'image/png', data: ''}],
+        version: '0.0.1',
+        provider: {
+          name: 'CoreOS, Inc',
+        },
+      }
+    }];
 
     wrapper = shallow(<SubscriptionChannelModal subscription={subscription} pkg={pkg} k8sUpdate={k8sUpdate} close={close} cancel={cancel} />);
   });
@@ -41,7 +61,7 @@ describe(SubscriptionChannelModal.name, () => {
   });
 
   it('renders a radio button for each available channel in the package', () => {
-    expect(wrapper.find(ModalBody).find(RadioInput).length).toEqual(pkg.channels.length);
+    expect(wrapper.find(ModalBody).find(RadioInput).length).toEqual(pkg.status.channels.length);
   });
 
   it('calls `props.k8sUpdate` to update the subscription when form is submitted', (done) => {

--- a/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
@@ -3,133 +3,41 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
-import { Link } from 'react-router-dom';
-import { safeDump, safeLoad } from 'js-yaml';
+import { safeDump } from 'js-yaml';
 
-import { CatalogSourceDetails, CatalogSourceDetailsProps, CatalogSourceDetailsPage, CatalogSourceDetailsPageProps, PackageHeader, PackageHeaderProps, PackageRow, PackageRowProps, PackageList, PackageListProps, CreateSubscriptionYAML, CreateSubscriptionYAMLProps, CatalogSourcesPage, CatalogSourcePageProps, CatalogSourceList, CatalogSourceListProps, CatalogSourceHeader, CatalogSourceHeaderProps, CatalogSourceRow, CatalogSourceRowProps } from '../../../public/components/operator-lifecycle-manager/catalog-source';
-import { ClusterServiceVersionLogo, olmNamespace } from '../../../public/components/operator-lifecycle-manager';
+import { CatalogSourceDetails, CatalogSourceDetailsProps, CatalogSourceDetailsPage, CatalogSourceDetailsPageProps, CreateSubscriptionYAML, CreateSubscriptionYAMLProps } from '../../../public/components/operator-lifecycle-manager/catalog-source';
+import { PackageManifestList } from '../../../public/components/operator-lifecycle-manager/package-manifest';
 import { referenceForModel } from '../../../public/module/k8s';
-import { SubscriptionModel, CatalogSourceModel, ConfigMapModel } from '../../../public/models';
-import { ListHeader, ColHead, List, MultiListPage, ResourceRow, DetailsPage } from '../../../public/components/factory';
-import { Firehose, LoadingBox, ErrorBoundary, ResourceLink, MsgBox, Timestamp } from '../../../public/components/utils';
+import { SubscriptionModel, CatalogSourceModel, PackageManifestModel } from '../../../public/models';
+import { DetailsPage } from '../../../public/components/factory';
+import { Firehose, LoadingBox, ErrorBoundary } from '../../../public/components/utils';
 import { CreateYAML, CreateYAMLProps } from '../../../public/components/create-yaml';
-import { testPackage, testCatalogSource, testClusterServiceVersion, testSubscription } from '../../../__mocks__/k8sResourcesMocks';
-
-describe(PackageHeader.displayName, () => {
-  let wrapper: ShallowWrapper<PackageHeaderProps>;
-
-  beforeEach(() => {
-    wrapper = shallow(<PackageHeader />);
-  });
-
-  it('renders column header for package name', () => {
-    expect(wrapper.find(ListHeader).find(ColHead).at(0).childAt(0).text()).toEqual('Name');
-  });
-
-  it('renders column header for latest CSV version for package in catalog', () => {
-    expect(wrapper.find(ListHeader).find(ColHead).at(1).childAt(0).text()).toEqual('Latest Version');
-  });
-
-  it('renders column header for subscriptions', () => {
-    expect(wrapper.find(ListHeader).find(ColHead).at(2).childAt(0).text()).toEqual('Subscriptions');
-  });
-});
-
-describe(PackageRow.displayName, () => {
-  let wrapper: ShallowWrapper<PackageRowProps>;
-
-  beforeEach(() => {
-    wrapper = shallow(<PackageRow obj={testPackage} catalogSource={_.cloneDeep(testCatalogSource)} currentCSV={_.cloneDeep(testClusterServiceVersion)} subscription={testSubscription} />);
-  });
-
-  it('renders column for package name and logo', () => {
-    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ClusterServiceVersionLogo).props().displayName).toEqual(testClusterServiceVersion.spec.displayName);
-  });
-
-  it('renders column for latest CSV version for package in catalog', () => {
-    expect(wrapper.find('.co-resource-list__item').childAt(1).text()).toEqual(`${testClusterServiceVersion.spec.version} (stable)`);
-  });
-
-  it('does not render link if no subscriptions exist in the current namespace', () => {
-    wrapper = wrapper.setProps({subscription: null});
-
-    expect(wrapper.find('.co-resource-list__item').childAt(2).text()).toContain('Not subscribed');
-  });
-
-  it('renders column with link to subscriptions', () => {
-    expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).at(0).props().to).toEqual(`/k8s/ns/default/${SubscriptionModel.plural}/${testSubscription.metadata.name}`);
-    expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).at(0).childAt(0).text()).toEqual('View subscription');
-  });
-
-  it('renders button to create new subscription', () => {
-    wrapper = wrapper.setProps({subscription: null});
-
-    expect(wrapper.find('.co-resource-list__item').childAt(2).find('button').text()).toEqual('Create Subscription');
-  });
-});
-
-describe(PackageList.displayName, () => {
-  let wrapper: ShallowWrapper<PackageListProps>;
-
-  beforeEach(() => {
-    wrapper = shallow(<PackageList packages={[testPackage]} catalogSource={testCatalogSource} clusterServiceVersions={[testClusterServiceVersion]} subscriptions={[]} />);
-  });
-
-  it('renders `List` component with correct props', () => {
-    expect(wrapper.find<any>(List).props().data.length).toEqual(1);
-    expect(wrapper.find<any>(List).props().Row).toBeDefined();
-    expect(wrapper.find<any>(List).props().Header).toEqual(PackageHeader);
-    expect(wrapper.find<any>(List).props().label).toEqual('Packages');
-    expect(wrapper.find<any>(List).props().loaded).toBe(true);
-    expect(wrapper.find<any>(List).props().EmptyMsg).toBeDefined();
-  });
-
-  it('adds `rowKey` to package data passed to `List` component', () => {
-    expect(wrapper.find<any>(List).props().data.some(pkg => _.isEmpty(pkg.rowKey))).toBe(false);
-  });
-
-});
+import { testCatalogSource, testPackageManifest } from '../../../__mocks__/k8sResourcesMocks';
 
 describe(CatalogSourceDetails.displayName, () => {
   let wrapper: ShallowWrapper<CatalogSourceDetailsProps>;
   let obj: CatalogSourceDetailsProps['obj'];
-  let configMap: CatalogSourceDetailsProps['configMap'];
-  const packages = safeDump([testPackage]);
 
   beforeEach(() => {
     obj = _.cloneDeep(testCatalogSource);
-    configMap = {apiVersion: 'v1', kind: 'ConfigMap', metadata: {name: 'catalog', namespace: 'default'}, data: {packages}};
 
-    wrapper = shallow(<CatalogSourceDetails obj={obj} configMap={configMap} subscription={null} />);
-  });
-
-  // TODO: Enzyme cannot test error boundary components (https://github.com/airbnb/enzyme/issues/1255)
-  xit('renders fallback component if there is an error parsing the catalog', () => {
-    wrapper = wrapper.setProps({configMap: {...configMap, data: {packages: '"no packages" here'}}});
-    wrapper.dive().childAt(0).dive();
-
-    expect(wrapper.find(ErrorBoundary).exists()).toBe(true);
-    expect(wrapper.find(MsgBox).exists()).toBe(true);
+    wrapper = shallow(<CatalogSourceDetails obj={obj} packageManifests={[testPackageManifest]} subscriptions={[]} />);
   });
 
   it('renders nothing if not all resources are loaded', () => {
-    wrapper = wrapper.setProps({obj: null, configMap: null});
+    wrapper = wrapper.setProps({obj: null});
 
     expect(wrapper.find('.co-catalog-details').exists()).toBe(false);
   });
 
   it('renders name and publisher of the catalog', () => {
-    wrapper = wrapper.dive().childAt(0).dive();
-
     expect(wrapper.findWhere(node => node.equals(<dt>Name</dt>)).parents().at(0).find('dd').text()).toEqual(obj.spec.displayName);
     expect(wrapper.findWhere(node => node.equals(<dt>Publisher</dt>)).parents().at(0).find('dd').text()).toEqual(obj.spec.publisher);
   });
 
-  it('renders a `PackageList` component', () => {
-    wrapper = wrapper = wrapper.dive().childAt(0).dive();
-
-    expect(wrapper.find(PackageList).props().packages).toEqual(safeLoad(packages));
-    expect(wrapper.find(PackageList).props().catalogSource).toEqual(obj);
+  it('renders a `PackageManifestList` component', () => {
+    expect(wrapper.find(PackageManifestList).props().data).toEqual([testPackageManifest]);
+    expect(wrapper.find(PackageManifestList).props().catalogSource).toEqual(obj);
   });
 });
 
@@ -143,130 +51,14 @@ describe(CatalogSourceDetailsPage.displayName, () => {
   });
 
   it('renders `DetailsPage` with correct props', () => {
+    const selector = {matchLabels: {catalog: match.params.name}};
+
     expect(wrapper.find(DetailsPage).props().kind).toEqual(referenceForModel(CatalogSourceModel));
     expect(wrapper.find(DetailsPage).props().pages.map(p => p.name)).toEqual(['Overview', 'YAML']);
     expect(wrapper.find(DetailsPage).props().pages[0].component).toEqual(CatalogSourceDetails);
     expect(wrapper.find(DetailsPage).props().resources).toEqual([
-      {kind: 'ConfigMap', isList: false, namespace: match.params.ns, name: match.params.name, prop: 'configMap'},
-      {kind: referenceForModel(SubscriptionModel), isList: true, namespace: match.params.ns, prop: 'subscription'},
-    ]);
-  });
-});
-
-describe(CatalogSourceHeader.displayName, () => {
-  let wrapper: ShallowWrapper<CatalogSourceHeaderProps>;
-
-  beforeEach(() => {
-    wrapper = shallow(<CatalogSourceHeader />);
-  });
-
-  it('renders column header for catalog source name', () => {
-    expect(wrapper.find(ListHeader).find(ColHead).at(0).props().sortField).toEqual('metadata.name');
-    expect(wrapper.find(ListHeader).find(ColHead).at(0).childAt(0).text()).toEqual('Name');
-  });
-
-  it('renders column header for catalog source namespace', () => {
-    expect(wrapper.find(ListHeader).find(ColHead).at(1).props().sortField).toEqual('metadata.namespace');
-    expect(wrapper.find(ListHeader).find(ColHead).at(1).childAt(0).text()).toEqual('Namespace');
-  });
-
-  it('renders column header for catalog source publisher', () => {
-    expect(wrapper.find(ListHeader).find(ColHead).at(2).childAt(0).text()).toEqual('Publisher');
-  });
-
-  it('renders column header for creation date', () => {
-    expect(wrapper.find(ListHeader).find(ColHead).at(3).childAt(0).text()).toEqual('Created');
-  });
-});
-
-describe(CatalogSourceRow.displayName, () => {
-  let wrapper: ShallowWrapper<CatalogSourceRowProps>;
-
-  beforeEach(() => {
-    wrapper = shallow(<CatalogSourceRow obj={testCatalogSource} />);
-  });
-
-  it('renders column for catalog source name', () => {
-    expect(wrapper.find(ResourceRow).childAt(0).find(ResourceLink).props().kind).toEqual(referenceForModel(CatalogSourceModel));
-    expect(wrapper.find(ResourceRow).childAt(0).find(ResourceLink).props().namespace).toEqual(testCatalogSource.metadata.namespace);
-    expect(wrapper.find(ResourceRow).childAt(0).find(ResourceLink).props().name).toEqual(testCatalogSource.metadata.name);
-    expect(wrapper.find(ResourceRow).childAt(0).find(ResourceLink).props().title).toEqual(testCatalogSource.metadata.uid);
-  });
-
-  it('renders column for catalog source namespace', () => {
-    expect(wrapper.find(ResourceRow).childAt(1).find(ResourceLink).props().kind).toEqual('Namespace');
-    expect(wrapper.find(ResourceRow).childAt(1).find(ResourceLink).props().title).toEqual(testCatalogSource.metadata.namespace);
-    expect(wrapper.find(ResourceRow).childAt(1).find(ResourceLink).props().displayName).toEqual(testCatalogSource.metadata.namespace);
-  });
-
-  it('renders column for catalog source publisher', () => {
-    expect(wrapper.find(ResourceRow).childAt(2).text()).toEqual(testCatalogSource.spec.publisher);
-  });
-
-  it('renders column with creation date', () => {
-    expect(wrapper.find(ResourceRow).find(Timestamp).exists()).toBe(true);
-  });
-});
-
-xdescribe(CatalogSourceList.displayName, () => {
-  let wrapper: ShallowWrapper<CatalogSourceListProps>;
-  let globalCatalogSource: CatalogSourceListProps['globalCatalogSource'];
-  let globalConfigMap: CatalogSourceListProps['globalConfigMap'];
-  let configMap: CatalogSourceListProps['configMap'];
-  let subscription: CatalogSourceListProps['subscription'];
-
-  beforeEach(() => {
-    globalCatalogSource = {};
-    globalConfigMap = {};
-    configMap = {};
-    subscription = {};
-
-    wrapper = shallow(<CatalogSourceList loaded={true} data={[testCatalogSource]} configMap={configMap} globalConfigMap={globalConfigMap} globalCatalogSource={globalCatalogSource} subscription={subscription} />);
-  });
-
-  it('renders empty message if loaded and no catalog sources present', () => {
-    wrapper = wrapper.setProps({data: []});
-
-    expect(wrapper.find(MsgBox).exists()).toBe(true);
-  });
-
-  it('renders `LoadingBox` if loading', () => {
-    wrapper = wrapper.setProps({loaded: false});
-
-    expect(wrapper.find(LoadingBox).exists()).toBe(true);
-  });
-
-  it('renders section for each catalog source', () => {
-    expect(wrapper.find('.co-catalogsource-list__section').length).toEqual(1);
-  });
-});
-
-describe(CatalogSourcesPage.displayName, () => {
-  let wrapper: ShallowWrapper<CatalogSourcePageProps>;
-
-  it('renders a `MultiListPage` component with correct props', () => {
-    wrapper = shallow(<CatalogSourcesPage namespace="default" />);
-
-    expect(wrapper.find(MultiListPage).props().title).toEqual('Operator Catalog Sources');
-    expect(wrapper.find(MultiListPage).props().showTitle).toBe(true);
-    expect(wrapper.find(MultiListPage).props().ListComponent).toEqual(CatalogSourceList);
-    expect(wrapper.find(MultiListPage).props().filterLabel).toEqual('Packages by name');
-    expect(wrapper.find(MultiListPage).props().resources).toEqual([
-      {kind: referenceForModel(CatalogSourceModel), isList: true, namespaced: true, prop: 'catalogSource'},
-      {kind: ConfigMapModel.kind, isList: true, namespaced: true, prop: 'configMap'},
-      {kind: referenceForModel(CatalogSourceModel), isList: true, namespace: olmNamespace, prop: 'globalCatalogSource'},
-      {kind: ConfigMapModel.kind, isList: true, namespace: olmNamespace, prop: 'globalConfigMap'},
-      {kind: referenceForModel(SubscriptionModel), isList: true, namespaced: true, prop: 'subscription'},
-    ]);
-  });
-
-  it('does not include global `CatalogSource` if already in that namespace', () => {
-    wrapper = shallow(<CatalogSourcesPage namespace={olmNamespace} />);
-
-    expect(wrapper.find(MultiListPage).props().resources).toEqual([
-      {kind: referenceForModel(CatalogSourceModel), isList: true, namespaced: true, prop: 'catalogSource'},
-      {kind: ConfigMapModel.kind, isList: true, namespaced: true, prop: 'configMap'},
-      {kind: referenceForModel(SubscriptionModel), isList: true, namespaced: true, prop: 'subscription'},
+      {kind: referenceForModel(PackageManifestModel), isList: true, namespace: match.params.ns, selector, prop: 'packageManifests'},
+      {kind: referenceForModel(SubscriptionModel), isList: true, namespace: match.params.ns, prop: 'subscriptions'},
     ]);
   });
 });
@@ -276,39 +68,43 @@ describe(CreateSubscriptionYAML.displayName, () => {
   let locationMock: Location;
 
   beforeEach(() => {
-    locationMock = {search: `?pkg=${testPackage.packageName}&catalog=ocs&catalogNamespace=${olmNamespace}`} as Location;
+    locationMock = {search: `?pkg=${testPackageManifest.metadata.name}&catalog=ocs&catalogNamespace=default`} as Location;
 
-    wrapper = shallow(<CreateSubscriptionYAML match={{isExact: true, url: '', path: '', params: {ns: 'default', pkgName: testPackage.packageName}}} location={locationMock} />);
+    wrapper = shallow(<CreateSubscriptionYAML match={{isExact: true, url: '', path: '', params: {ns: 'default', pkgName: testPackageManifest.metadata.name}}} location={locationMock} />);
   });
 
-  it('renders a `Firehose` for the catalog ConfigMap', () => {
-    expect(wrapper.find<any>(Firehose).props().resources).toEqual([
-      {kind: 'ConfigMap', name: 'ocs', namespace: olmNamespace, isList: false, prop: 'ConfigMap'}
-    ]);
+  it('renders a `Firehose` for the `PackageManfest` specified in the URL', () => {
+    expect(wrapper.find<any>(Firehose).props().resources).toEqual([{
+      kind: referenceForModel(PackageManifestModel),
+      name: testPackageManifest.metadata.name,
+      namespace: 'default',
+      isList: false,
+      prop: 'packageManifest'
+    }]);
   });
 
   xit('renders YAML editor component wrapped by an error boundary component', () => {
-    wrapper = wrapper.setProps({ConfigMap: {loaded: true, data: {data: {packages: safeDump([testPackage])}}}} as any);
+    wrapper = wrapper.setProps({packageManifest: {loaded: true, data: testPackageManifest}} as any);
 
     expect(wrapper.find(Firehose).childAt(0).dive().find(ErrorBoundary).exists()).toBe(true);
     expect(wrapper.find(Firehose).childAt(0).dive().find(ErrorBoundary).childAt(0).dive().find(CreateYAML).exists()).toBe(true);
   });
 
   xit('passes example YAML templates using the package default channel', () => {
-    wrapper = wrapper.setProps({ConfigMap: {loaded: true, data: {data: {packages: safeDump([testPackage])}}}} as any);
+    wrapper = wrapper.setProps({packageManifest: {loaded: true, data: testPackageManifest}} as any);
 
     const createYAML = wrapper.find(Firehose).childAt(0).dive().find(ErrorBoundary).childAt(0).dive<CreateYAMLProps, {}>();
     const subTemplate = safeDump(createYAML.props().template);
 
     expect(subTemplate.kind).toContain(SubscriptionModel.kind);
-    expect(subTemplate.spec.name).toEqual(testPackage.packageName);
-    expect(subTemplate.spec.channel).toEqual(testPackage.channels[0].name);
-    expect(subTemplate.spec.startingCSV).toEqual(testPackage.channels[0].currentCSV);
+    expect(subTemplate.spec.name).toEqual(testPackageManifest.metadata.name);
+    expect(subTemplate.spec.channel).toEqual(testPackageManifest.spec.channels[0].name);
+    expect(subTemplate.spec.startingCSV).toEqual(testPackageManifest.spec.channels[0].currentCSV);
     expect(subTemplate.spec.source).toEqual('ocs');
   });
 
-  xit('does not render YAML editor component if ConfigMap has not loaded yet', () => {
-    wrapper = wrapper.setProps({ConfigMap: {loaded: false}} as any);
+  xit('does not render YAML editor component if `PackageManifest` has not loaded yet', () => {
+    wrapper = wrapper.setProps({packageManifest: {loaded: false}} as any);
 
     expect(wrapper.find(Firehose).childAt(0).dive().find(CreateYAML).exists()).toBe(false);
     expect(wrapper.find(Firehose).childAt(0).dive().find(ErrorBoundary).childAt(0).dive().find(LoadingBox).exists()).toBe(true);

--- a/frontend/__tests__/components/operator-lifecycle-manager/package-manifest.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/package-manifest.spec.tsx
@@ -1,0 +1,98 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { shallow, ShallowWrapper } from 'enzyme';
+import * as _ from 'lodash-es';
+
+import { PackageManifestHeader, PackageManifestHeaderProps, PackageManifestRow, PackageManifestRowProps, PackageManifestList, PackageManifestListProps } from '../../../public/components/operator-lifecycle-manager/package-manifest';
+import { ClusterServiceVersionLogo, PackageManifestKind } from '../../../public/components/operator-lifecycle-manager';
+import { SubscriptionModel } from '../../../public/models';
+import { ListHeader, ColHead, List } from '../../../public/components/factory';
+import { testPackageManifest, testCatalogSource, testSubscription } from '../../../__mocks__/k8sResourcesMocks';
+
+describe(PackageManifestHeader.displayName, () => {
+  let wrapper: ShallowWrapper<PackageManifestHeaderProps>;
+
+  beforeEach(() => {
+    wrapper = shallow(<PackageManifestHeader />);
+  });
+
+  it('renders column header for package name', () => {
+    expect(wrapper.find(ListHeader).find(ColHead).at(0).childAt(0).text()).toEqual('Name');
+  });
+
+  it('renders column header for latest CSV version for package in catalog', () => {
+    expect(wrapper.find(ListHeader).find(ColHead).at(1).childAt(0).text()).toEqual('Latest Version');
+  });
+
+  it('renders column header for subscriptions', () => {
+    expect(wrapper.find(ListHeader).find(ColHead).at(2).childAt(0).text()).toEqual('Subscriptions');
+  });
+});
+
+describe(PackageManifestRow.displayName, () => {
+  let wrapper: ShallowWrapper<PackageManifestRowProps>;
+
+  beforeEach(() => {
+    wrapper = shallow(<PackageManifestRow obj={testPackageManifest} catalogSourceNamespace={testCatalogSource.metadata.namespace} catalogSourceName={testCatalogSource.metadata.name} subscription={testSubscription} />);
+  });
+
+  it('renders column for package name and logo', () => {
+    expect(wrapper.find('.co-resource-list__item').childAt(0).find(ClusterServiceVersionLogo).props().displayName).toEqual(testPackageManifest.status.channels[0].currentCSVDesc.displayName);
+  });
+
+  it('renders column for latest CSV version for package in catalog', () => {
+    const {name, currentCSVDesc: {version}} = testPackageManifest.status.channels[0];
+    expect(wrapper.find('.co-resource-list__item').childAt(1).text()).toEqual(`${version} (${name})`);
+  });
+
+  it('does not render link if no subscriptions exist in the current namespace', () => {
+    wrapper = wrapper.setProps({subscription: null});
+
+    expect(wrapper.find('.co-resource-list__item').childAt(2).text()).toContain('Not subscribed');
+  });
+
+  it('renders column with link to subscriptions', () => {
+    expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).at(0).props().to).toEqual(`/k8s/ns/default/${SubscriptionModel.plural}/${testSubscription.metadata.name}`);
+    expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).at(0).childAt(0).text()).toEqual('View subscription');
+  });
+
+  it('renders button to create new subscription', () => {
+    wrapper = wrapper.setProps({subscription: null});
+
+    expect(wrapper.find('.co-resource-list__item').childAt(2).find('button').text()).toEqual('Create Subscription');
+  });
+});
+
+describe(PackageManifestList.displayName, () => {
+  let wrapper: ShallowWrapper<PackageManifestListProps>;
+  let packages: PackageManifestKind[];
+
+  beforeEach(() => {
+    let otherPackageManifest = _.cloneDeep(testPackageManifest);
+    otherPackageManifest.status.catalogSource = 'another-catalog-source';
+    otherPackageManifest.status.catalogSourceDisplayName = 'Another Catalog Source';
+    otherPackageManifest.status.catalogSourcePublisher = 'Some Publisher';
+    packages = [testPackageManifest, otherPackageManifest];
+
+    wrapper = shallow(<PackageManifestList loaded={true} data={packages} catalogSource={{}} subscription={{}} />);
+  });
+
+  it('renders a section for each unique `CatalogSource` for the given packages', () => {
+    expect(wrapper.find('.co-catalogsource-list__section').length).toEqual(2);
+    packages.forEach(({status}, i) => {
+      expect(wrapper.find('.co-catalogsource-list__section').at(i).find('h3').text()).toEqual(status.catalogSourceDisplayName);
+      expect(wrapper.find('.co-catalogsource-list__section').at(i).find('h3').text()).toEqual(status.catalogSourceDisplayName);
+    });
+  });
+
+  it('renders `List` component with correct props for each section', () => {
+    expect(wrapper.find(List).length).toEqual(2);
+    packages.forEach(({status}, i) => {
+      expect(wrapper.find('.co-catalogsource-list__section').at(i).find(List).props().Header).toEqual(PackageManifestHeader);
+      expect(wrapper.find('.co-catalogsource-list__section').at(i).find(List).props().data.length).toEqual(1);
+      expect(wrapper.find('.co-catalogsource-list__section').at(i).find(List).props().label).toEqual('Package Manifests');
+    });
+  });
+});

--- a/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
@@ -5,12 +5,12 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
 
 import { SubscriptionHeader, SubscriptionHeaderProps, SubscriptionRow, SubscriptionRowProps, SubscriptionsList, SubscriptionsListProps, SubscriptionsPage, SubscriptionsPageProps, SubscriptionDetails, SubscriptionDetailsPage, SubscriptionDetailsProps, SubscriptionUpdates, SubscriptionUpdatesProps, SubscriptionUpdatesState } from '../../../public/components/operator-lifecycle-manager/subscription';
-import { SubscriptionKind, SubscriptionState, olmNamespace } from '../../../public/components/operator-lifecycle-manager';
+import { SubscriptionKind, SubscriptionState } from '../../../public/components/operator-lifecycle-manager';
 import { referenceForModel } from '../../../public/module/k8s';
-import { SubscriptionModel, ClusterServiceVersionModel, ConfigMapModel } from '../../../public/models';
+import { SubscriptionModel, ClusterServiceVersionModel, PackageManifestModel } from '../../../public/models';
 import { ListHeader, ColHead, List, ListPage, DetailsPage } from '../../../public/components/factory';
 import { ResourceCog, ResourceLink, Cog } from '../../../public/components/utils';
-import { testSubscription, testClusterServiceVersion, testPackage } from '../../../__mocks__/k8sResourcesMocks';
+import { testSubscription, testClusterServiceVersion, testPackageManifest } from '../../../__mocks__/k8sResourcesMocks';
 
 describe(SubscriptionHeader.displayName, () => {
   let wrapper: ShallowWrapper<SubscriptionHeaderProps>;
@@ -136,7 +136,7 @@ describe(SubscriptionsPage.displayName, () => {
     expect(wrapper.find(ListPage).props().title).toEqual('Subscriptions');
     expect(wrapper.find(ListPage).props().showTitle).toBe(true);
     expect(wrapper.find(ListPage).props().canCreate).toBe(true);
-    expect(wrapper.find(ListPage).props().createProps).toEqual({to: '/k8s/ns/default/catalogsources'});
+    expect(wrapper.find(ListPage).props().createProps).toEqual({to: `/k8s/ns/default/${referenceForModel(PackageManifestModel)}`});
     expect(wrapper.find(ListPage).props().createButtonText).toEqual('Create Subscription');
     expect(wrapper.find(ListPage).props().filterLabel).toEqual('Subscriptions by package');
     expect(wrapper.find(ListPage).props().kind).toEqual(referenceForModel(SubscriptionModel));
@@ -147,7 +147,7 @@ describe(SubscriptionUpdates.name, () => {
   let wrapper: ShallowWrapper<SubscriptionUpdatesProps, SubscriptionUpdatesState>;
 
   beforeEach(() => {
-    wrapper = shallow(<SubscriptionUpdates obj={testSubscription} pkg={testPackage} />);
+    wrapper = shallow(<SubscriptionUpdates obj={testSubscription} pkg={testPackageManifest} />);
   });
 
   it('renders link to configure update channel', () => {
@@ -167,7 +167,7 @@ describe(SubscriptionDetails.displayName, () => {
   let wrapper: ShallowWrapper<SubscriptionDetailsProps>;
 
   beforeEach(() => {
-    wrapper = shallow(<SubscriptionDetails obj={testSubscription} pkg={testPackage} />);
+    wrapper = shallow(<SubscriptionDetails obj={testSubscription} pkg={testPackageManifest} />);
   });
 
   it('renders subscription update channel and approval component', () => {
@@ -211,8 +211,7 @@ describe(SubscriptionDetailsPage.displayName, () => {
     const wrapper = shallow(<SubscriptionDetailsPage match={match} namespace="default" />);
 
     expect(wrapper.find(DetailsPage).props().resources).toEqual([
-      {kind: ConfigMapModel.kind, namespace: olmNamespace, isList: true, prop: 'globalConfigMaps'},
-      {kind: ConfigMapModel.kind, namespace: 'default', isList: true, prop: 'localConfigMaps'},
+      {kind: referenceForModel(PackageManifestModel), namespace: 'default', isList: true, prop: 'packageManifests'},
       {kind: referenceForModel(ClusterServiceVersionModel), namespace: 'default', isList: true, prop: 'clusterServiceVersions'},
     ]);
   });

--- a/frontend/integration-tests/tests/olm/catalog.scenario.ts
+++ b/frontend/integration-tests/tests/olm/catalog.scenario.ts
@@ -6,7 +6,7 @@ import { appHost, checkLogs, checkErrors, testName } from '../../protractor.conf
 import * as catalogView from '../../views/catalog.view';
 import * as sidenavView from '../../views/sidenav.view';
 
-describe('Installing a service from the Catalog Sources', () => {
+describe('Installing a service from a Catalog Source', () => {
   const openCloudServices = new Set(['etcd', 'Prometheus Operator']);
 
   beforeAll(async() => {
@@ -25,8 +25,8 @@ describe('Installing a service from the Catalog Sources', () => {
     expect(sidenavView.navSectionFor('Operators').isDisplayed()).toBe(true);
   });
 
-  it('displays Catalog Sources with expected available services', async() => {
-    await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
+  it('displays Catalog Source with expected available packages', async() => {
+    await sidenavView.clickNavLink(['Operators', 'Package Manifests']);
     await catalogView.isLoaded();
     await catalogView.viewCatalogDetail('Red Hat Operators');
     await catalogView.isLoaded();

--- a/frontend/integration-tests/tests/olm/etcd.scenario.ts
+++ b/frontend/integration-tests/tests/olm/etcd.scenario.ts
@@ -29,8 +29,8 @@ describe('Interacting with the etcd OCS', () => {
     checkErrors();
   });
 
-  it('can be enabled from the Catalog Sources', async() => {
-    await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
+  it('can be enabled from the Catalog Source', async() => {
+    await sidenavView.clickNavLink(['Operators', 'Package Manifests']);
     await catalogView.isLoaded();
     await catalogView.viewCatalogDetail('Red Hat Operators');
     await catalogView.isLoaded();
@@ -41,7 +41,7 @@ describe('Interacting with the etcd OCS', () => {
     await yamlView.setContent(safeDump(newContent));
     await $('#save-changes').click();
     await crudView.isLoaded();
-    await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
+    await sidenavView.clickNavLink(['Operators', 'Package Manifests']);
     await catalogView.isLoaded();
 
     expect(catalogView.hasSubscription('etcd')).toBe(true);

--- a/frontend/integration-tests/tests/olm/prometheus.scenario.ts
+++ b/frontend/integration-tests/tests/olm/prometheus.scenario.ts
@@ -28,8 +28,8 @@ describe('Interacting with the Prometheus OCS', () => {
     checkErrors();
   });
 
-  it('can be enabled from the Catalog Sources', async() => {
-    await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
+  it('can be enabled from the Catalog Source', async() => {
+    await sidenavView.clickNavLink(['Operators', 'Package Manifests']);
     await catalogView.isLoaded();
     await catalogView.viewCatalogDetail('Red Hat Operators');
     await catalogView.isLoaded();
@@ -40,7 +40,7 @@ describe('Interacting with the Prometheus OCS', () => {
     await yamlView.setContent(safeDump(newContent));
     await $('#save-changes').click();
     await crudView.isLoaded();
-    await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
+    await sidenavView.clickNavLink(['Operators', 'Package Manifests']);
     await catalogView.isLoaded();
 
     expect(catalogView.hasSubscription('Prometheus Operator')).toBe(true);

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -12,6 +12,9 @@ export type FirehoseResource = {
   name?: string;
   namespace: string;
   isList?: boolean;
+  selector?: {
+    matchLabels?: {[label: string]: string};
+  };
   prop: string;
 };
 

--- a/frontend/public/components/modals/subscription-channel-modal.tsx
+++ b/frontend/public/components/modals/subscription-channel-modal.tsx
@@ -6,7 +6,7 @@ import * as _ from 'lodash-es';
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
 import { PromiseComponent, ResourceLink } from '../utils';
 import { K8sKind, K8sResourceKind, referenceForModel } from '../../module/k8s';
-import { SubscriptionKind, Package } from '../operator-lifecycle-manager/index';
+import { SubscriptionKind, PackageManifestKind } from '../operator-lifecycle-manager/index';
 import { SubscriptionModel, ClusterServiceVersionModel } from '../../models';
 import { RadioInput } from '../radio';
 
@@ -16,7 +16,7 @@ export class SubscriptionChannelModal extends PromiseComponent {
   constructor(public props: SubscriptionChannelModalProps) {
     super(props);
 
-    this.state.selectedChannel = props.subscription.spec.channel || props.pkg.channels[0].name;
+    this.state.selectedChannel = props.subscription.spec.channel || props.pkg.status.channels[0].name;
   }
 
   private submit(event): void {
@@ -35,7 +35,7 @@ export class SubscriptionChannelModal extends PromiseComponent {
           <p>Which channel is used to receive updates?</p>
         </div>
         <div className="co-m-form-row row">
-          { this.props.pkg.channels.map((channel, i) => <div key={i} className="col-sm-12">
+          { this.props.pkg.status.channels.map((channel, i) => <div key={i} className="col-sm-12">
             <RadioInput
               onChange={(e) => this.setState({selectedChannel: e.target.value})}
               value={channel.name}
@@ -57,7 +57,7 @@ export type SubscriptionChannelModalProps = {
   close: () => void;
   k8sUpdate: (kind: K8sKind, newObj: K8sResourceKind) => Promise<any>;
   subscription: SubscriptionKind;
-  pkg: Package;
+  pkg: PackageManifestKind;
 };
 
 export type SubscriptionChannelModalState = {

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -8,7 +8,7 @@ import * as PropTypes from 'prop-types';
 import { FLAGS, connectToFlags, featureReducerName, flagPending } from '../features';
 import { MonitoringRoutes, connectToURLs } from '../monitoring';
 import { formatNamespacedRouteForResource } from '../ui/ui-actions';
-import { BuildConfigModel, BuildModel, ClusterServiceVersionModel, DeploymentConfigModel, ImageStreamModel, SubscriptionModel, InstallPlanModel, CatalogSourceModel } from '../models';
+import { BuildConfigModel, BuildModel, ClusterServiceVersionModel, DeploymentConfigModel, ImageStreamModel, SubscriptionModel, InstallPlanModel, PackageManifestModel } from '../models';
 import { referenceForModel } from '../module/k8s';
 import { authSvc } from '../module/auth';
 
@@ -382,7 +382,7 @@ export class Nav extends React.Component {
           <NavSection required={FLAGS.OPERATOR_LIFECYCLE_MANAGER} text="Operators" img={operatorImg} activeImg={operatorActiveImg} >
             <ResourceNSLink model={ClusterServiceVersionModel} resource={ClusterServiceVersionModel.plural} name="Cluster Service Versions" onClick={this.close} />
             <Sep />
-            <ResourceNSLink model={CatalogSourceModel} resource={CatalogSourceModel.plural} name="Catalog Sources" onClick={this.close} />
+            <ResourceNSLink model={PackageManifestModel} resource={PackageManifestModel.plural} name="Package Manifests" onClick={this.close} />
             <ResourceNSLink model={SubscriptionModel} resource={SubscriptionModel.plural} name="Subscriptions" onClick={this.close} />
             <ResourceNSLink model={InstallPlanModel} resource={InstallPlanModel.plural} name="Install Plans" onClick={this.close} />
           </NavSection>

--- a/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
@@ -2,179 +2,39 @@
 
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import { match, Link } from 'react-router-dom';
-import { safeLoad } from 'js-yaml';
+import { match } from 'react-router-dom';
 
-import { SectionHeading, Firehose, MsgBox, LoadingBox, ResourceCog, ResourceLink, Cog, navFactory, resourceObjPath, Timestamp, StatusBox } from '../utils';
+import { SectionHeading, Firehose, MsgBox, LoadingBox, Cog, navFactory } from '../utils';
 import { withFallback } from '../utils/error-boundary';
 import { CreateYAML } from '../create-yaml';
-import { ClusterServiceVersionLogo, CatalogSourceKind, ClusterServiceVersionKind, Package, SubscriptionKind, olmNamespace } from './index';
-import { SubscriptionModel, CatalogSourceModel, ConfigMapModel } from '../../models';
-import { referenceForModel, K8sResourceKind, ConfigMapKind } from '../../module/k8s';
-import { List, ListHeader, ColHead, ResourceRow, DetailsPage, MultiListPage } from '../factory';
-import { getActiveNamespace } from '../../ui/ui-actions';
-import { ALL_NAMESPACES_KEY } from '../../const';
+import { CatalogSourceKind, SubscriptionKind, PackageManifestKind } from './index';
+import { PackageManifestList } from './package-manifest';
+import { SubscriptionModel, CatalogSourceModel, PackageManifestModel } from '../../models';
+import { referenceForModel } from '../../module/k8s';
+import { DetailsPage } from '../factory';
 
-type ConfigMapFor = (data: {data?: ConfigMapKind[]}) => (name: string) => ConfigMapKind;
-const configMapFor: ConfigMapFor = data => name => _.get(data, 'data', [] as ConfigMapKind[]).find(cm => cm.metadata.name === name);
-
-type SubscriptionsFor = (subs: SubscriptionKind[]) => (obj: CatalogSourceKind) => SubscriptionKind[];
-const subscriptionsFor: SubscriptionsFor = subs => obj => subs.filter(sub => sub.spec.source === obj.metadata.name);
-
-type PackagesFor = (configMap: ConfigMapKind) => Package[];
-const packagesFor: PackagesFor = configMap => _.get(configMap, 'data.packages')
-  ? safeLoad(_.get(configMap, 'data.packages', ''))
-  : [];
-
-type ClusterServiceVersionsFor = (configMap: ConfigMapKind) => ClusterServiceVersionKind[];
-const clusterServiceVersionsFor: ClusterServiceVersionsFor = configMap => _.get(configMap, 'data.clusterServiceVersions')
-  ? safeLoad(_.get(configMap, 'data.clusterServiceVersions', ''))
-  : [];
-
-export const PackageHeader: React.SFC<PackageHeaderProps> = (props) => <ListHeader>
-  <ColHead {...props} className="col-sm-4 col-xs-6">Name</ColHead>
-  <ColHead {...props} className="col-sm-4 hidden-xs">Latest Version</ColHead>
-  <ColHead {...props} className="col-sm-4 col-xs-6">Subscriptions</ColHead>
-</ListHeader>;
-
-export const PackageRow: React.SFC<PackageRowProps> = (props) => {
-  const {obj, catalogSource, currentCSV, subscription} = props;
-  const {displayName, icon = [], version, provider} = currentCSV.spec;
-  const ns = getActiveNamespace();
-  const channel = !_.isEmpty(obj.defaultChannel) ? obj.channels.find(ch => ch.name === obj.defaultChannel) : obj.channels[0];
-
-  const subscriptionLink = () => ns !== ALL_NAMESPACES_KEY
-    ? <Link to={`/k8s/ns/${ns}/${SubscriptionModel.plural}/${subscription.metadata.name}`}>View subscription</Link>
-    : <Link to={`/k8s/all-namespaces/${SubscriptionModel.plural}?name=${obj.packageName}`}>View subscriptions</Link>;
-
-  const createSubscriptionLink = () => `/k8s/ns/${ns === ALL_NAMESPACES_KEY ? 'default' : ns}/${SubscriptionModel.plural}/new?pkg=${obj.packageName}&catalog=${catalogSource.metadata.name}&catalogNamespace=${catalogSource.metadata.namespace}`;
-
-  return <div className="row co-resource-list__item co-package-row">
-    <div className="col-sm-4 col-xs-6">
-      <ClusterServiceVersionLogo displayName={displayName} icon={_.get(icon, '[0]')} provider={provider.name} />
-    </div>
-    <div className="col-xs-4 hidden-xs">{version} ({channel.name})</div>
-    <div className="col-sm-4 col-xs-6 co-package-row__actions">
-      { subscription
-        ? subscriptionLink()
-        : <span className="text-muted">Not subscribed</span> }
-      { (!subscription || ns === ALL_NAMESPACES_KEY) && <Link to={createSubscriptionLink()}>
-        <button className="btn btn-primary">Create Subscription</button>
-      </Link> }
-    </div>
-  </div>;
-};
-
-export const PackageList: React.SFC<PackageListProps> = (props) => <List
-  loaded={true}
-  // TODO(alecmerdler): Adding `metadata` as a hack to get text filter to work until `Package` is a real k8s resource
-  data={props.packages.map(pkg => ({...pkg, rowKey: pkg.packageName, metadata: {name: pkg.packageName}}))}
-  filters={props.filters}
-  Header={PackageHeader}
-  Row={(rowProps: {obj: Package}) => <PackageRow
-    obj={rowProps.obj}
-    currentCSV={props.clusterServiceVersions.find(({metadata}) => metadata.name === rowProps.obj.channels[0].currentCSV)}
-    catalogSource={props.catalogSource}
-    subscription={props.subscriptions.find(sub => sub.spec.name === rowProps.obj.packageName)} />}
-  label="Packages"
-  EmptyMsg={() => <MsgBox title="No Packages Found" detail="The catalog author has not added any packages." />} />;
-
-export const CatalogSourceDetails = withFallback<CatalogSourceDetailsProps>(({obj, configMap, subscription}) => {
-  const packages = packagesFor(configMap) || [];
-  const clusterServiceVersions = clusterServiceVersionsFor(configMap) || [];
-  const subscriptions = subscriptionsFor(_.get(subscription, 'data', []))(obj);
-
-  return !_.isEmpty(obj) && !_.isEmpty(configMap)
-    ? <div className="co-catalog-details co-m-pane">
-      <div className="co-m-pane__body">
-        <div className="col-xs-4">
-          <dl className="co-m-pane__details">
-            <dt>Name</dt>
-            <dd>{obj.spec.displayName}</dd>
-          </dl>
-        </div>
-        <div className="col-xs-4">
-          <dl className="co-m-pane__details">
-            <dt>Publisher</dt>
-            <dd>{obj.spec.publisher}</dd>
-          </dl>
-        </div>
+export const CatalogSourceDetails: React.SFC<CatalogSourceDetailsProps> = ({obj, packageManifests, subscriptions}) => !_.isEmpty(obj)
+  ? <div className="co-catalog-details co-m-pane">
+    <div className="co-m-pane__body">
+      <div className="col-xs-4">
+        <dl className="co-m-pane__details">
+          <dt>Name</dt>
+          <dd>{obj.spec.displayName}</dd>
+        </dl>
       </div>
-      <div className="co-m-pane__body">
-        <SectionHeading text="Packages" />
-        <PackageList packages={packages} catalogSource={obj} clusterServiceVersions={clusterServiceVersions} subscriptions={subscriptions} />
+      <div className="col-xs-4">
+        <dl className="co-m-pane__details">
+          <dt>Publisher</dt>
+          <dd>{obj.spec.publisher}</dd>
+        </dl>
       </div>
     </div>
-    : <div />;
-}, () => <MsgBox title="Error Parsing Catalog" detail="The contents of the catalog source could not be retrieved." />);
-
-export const CatalogSourceHeader: React.SFC<CatalogSourceHeaderProps> = (props) => <ListHeader>
-  <ColHead {...props} className="col-md-3" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-md-2" sortField="metadata.namespace">Namespace</ColHead>
-  <ColHead {...props} className="col-md-2" sortField="spec.publisher">Publisher</ColHead>
-  <ColHead {...props} className="col-md-2">Created</ColHead>
-</ListHeader>;
-
-export const CatalogSourceRow: React.SFC<CatalogSourceRowProps> = (props) => <ResourceRow obj={props.obj}>
-  <div className="col-md-3 co-resource-link-wrapper">
-    <ResourceCog actions={Cog.factory.common} kind={referenceForModel(CatalogSourceModel)} resource={props.obj} />
-    <ResourceLink kind={referenceForModel(CatalogSourceModel)} namespace={props.obj.metadata.namespace} name={props.obj.metadata.name} title={props.obj.metadata.uid} />
+    <div className="co-m-pane__body">
+      <SectionHeading text="Packages" />
+      <PackageManifestList loaded={true} data={packageManifests} catalogSource={obj} subscription={{loaded: true, data: subscriptions}} />
+    </div>
   </div>
-  <div className="col-md-2">
-    <ResourceLink kind="Namespace" name={props.obj.metadata.namespace} title={props.obj.metadata.namespace} displayName={props.obj.metadata.namespace} />
-  </div>
-  <div className="col-md-2">{props.obj.spec.publisher}</div>
-  <div className="col-md-2"><Timestamp timestamp={props.obj.metadata.creationTimestamp} /></div>
-</ResourceRow>;
-
-export const CatalogSourceList = withFallback((props: CatalogSourceListProps) => {
-  const cmFor = configMapFor({data: [..._.get(props.configMap, 'data', []), ..._.get(props.globalConfigMap, 'data', [])]});
-  const pkgsFor = (obj: CatalogSourceKind) => packagesFor(cmFor(obj.spec.configMap));
-  const csvsFor = (obj: CatalogSourceKind) => clusterServiceVersionsFor(cmFor(obj.spec.configMap));
-  const subsFor = subscriptionsFor(_.get(props.subscription, 'data', [] as SubscriptionKind[]));
-
-  const data = [...props.data, ..._.get(props.globalCatalogSource, 'data', [])];
-
-  return props.loaded
-    ? <React.Fragment>
-      { _.isEmpty(data) && <MsgBox title="No Catalog Sources Found" detail="Catalog Sources contain packaged Operators which can be subscribed to for automatic upgrades." /> }
-      {/* TODO(alecmerdler): Handle filtering based on package name */}
-      { data.map((obj) => <div key={obj.metadata.uid} className="co-catalogsource-list__section">
-        <div className="co-catalogsource-list__section__packages">
-          <div>
-            <h3>{obj.spec.displayName || obj.metadata.name}</h3>
-            <span className="text-muted">Packaged by {obj.spec.publisher}</span>
-          </div>
-          <Link to={`/k8s/ns/${obj.metadata.namespace}/${CatalogSourceModel.plural}/${obj.metadata.name}`}>View catalog details</Link>
-        </div>
-        <PackageList catalogSource={obj} clusterServiceVersions={csvsFor(obj)} packages={pkgsFor(obj)} subscriptions={subsFor(obj)} filters={props.filters} />
-      </div>) }
-    </React.Fragment>
-    : <StatusBox loaded={props.loaded} loadError={props.loadError} label={CatalogSourceModel.labelPlural} />;
-}, () => <MsgBox title="Error Parsing Catalog" detail="The contents of the catalog source could not be retrieved." />);
-
-export const CatalogSourcesPage: React.SFC<CatalogSourcePageProps> = (props) => {
-  type Flatten = (resources: {[kind: string]: {data: K8sResourceKind[]}}) => K8sResourceKind[];
-  const flatten: Flatten = resources => _.get(resources.catalogSource, 'data', []);
-  const HelpText = <p className="co-help-text">Catalogs are groups of Operators you can make available on the cluster. Subscribe and grant a namespace access to use the installed Operators.</p>;
-
-  return <MultiListPage
-    {...props}
-    title="Operator Catalog Sources"
-    showTitle={true}
-    helpText={HelpText}
-    ListComponent={CatalogSourceList}
-    filterLabel="Packages by name"
-    flatten={flatten}
-    resources={[
-      {kind: referenceForModel(CatalogSourceModel), isList: true, namespaced: true, prop: 'catalogSource'},
-      {kind: ConfigMapModel.kind, isList: true, namespaced: true, prop: 'configMap'},
-      // FIXME(alecmerdler): Don't hard-code catalog namespace, use the `alm-manager` annotation on the current namespace
-      ...((props.namespace || olmNamespace) !== olmNamespace ? {kind: referenceForModel(CatalogSourceModel), isList: true, namespace: olmNamespace, prop: 'globalCatalogSource'} : []),
-      ...((props.namespace || olmNamespace) !== olmNamespace ? {kind: ConfigMapModel.kind, isList: true, namespace: olmNamespace, prop: 'globalConfigMap'} : []),
-      {kind: referenceForModel(SubscriptionModel), isList: true, namespaced: true, prop: 'subscription'},
-    ]} />;
-};
+  : <div />;
 
 export const CatalogSourceDetailsPage: React.SFC<CatalogSourceDetailsPageProps> = (props) => <DetailsPage
   {...props}
@@ -185,38 +45,39 @@ export const CatalogSourceDetailsPage: React.SFC<CatalogSourceDetailsPageProps> 
     navFactory.details(CatalogSourceDetails),
     navFactory.editYaml(),
   ]}
-  menuActions={[...Cog.factory.common, (kind, obj) => ({label: 'View Contents...', href: resourceObjPath(obj, ConfigMapModel.kind)})]}
+  menuActions={Cog.factory.common}
   resources={[{
-    kind: ConfigMapModel.kind,
-    isList: false,
+    kind: referenceForModel(PackageManifestModel),
+    isList: true,
     namespace: props.match.params.ns,
-    name: props.match.params.name,
-    prop: 'configMap'
+    selector: {matchLabels: {catalog: props.match.params.name}},
+    prop: 'packageManifests'
   }, {
     kind: referenceForModel(SubscriptionModel),
     isList: true,
     namespace: props.match.params.ns,
-    prop: 'subscription',
+    prop: 'subscriptions',
   }]}
 />;
 
 export const CreateSubscriptionYAML: React.SFC<CreateSubscriptionYAMLProps> = (props) => {
-  type CreateProps = {ConfigMap: {loaded: boolean, data: K8sResourceKind}};
+  type CreateProps = {packageManifest: {loaded: boolean, data: PackageManifestKind}};
   const Create = withFallback<CreateProps>((createProps) => {
-    if (createProps.ConfigMap.loaded && createProps.ConfigMap.data) {
-      const pkg: Package = (_.get(createProps.ConfigMap.data, 'data.packages') ? safeLoad(_.get(createProps.ConfigMap.data, 'data.packages')) : [])
-        .find(({packageName}) => packageName === new URLSearchParams(props.location.search).get('pkg'));
-      const channel = _.get(pkg, 'channels[0]');
+    if (createProps.packageManifest.loaded && createProps.packageManifest.data) {
+      const pkg = createProps.packageManifest.data;
+      const channel = pkg.status.defaultChannel
+        ? pkg.status.channels.find(({name}) => name === pkg.status.defaultChannel)
+        : pkg.status.channels[0];
 
       const template = `
         apiVersion: ${SubscriptionModel.apiGroup}/${SubscriptionModel.apiVersion}
         kind: ${SubscriptionModel.kind},
         metadata:
-          generateName: ${pkg.packageName}-
+          generateName: ${pkg.metadata.name}-
           namespace: default
         spec:
-          source: ${createProps.ConfigMap.data.metadata.name}
-          name: ${pkg.packageName}
+          source: ${new URLSearchParams(props.location.search).get('catalog')}
+          name: ${pkg.metadata.name}
           startingCSV: ${channel.currentCSV}
           channel: ${channel.name}
       `;
@@ -226,63 +87,21 @@ export const CreateSubscriptionYAML: React.SFC<CreateSubscriptionYAMLProps> = (p
   }, () => <MsgBox title="Package Not Found" detail="Cannot create a Subscription to a non-existent package." />);
 
   return <Firehose resources={[{
-    kind: ConfigMapModel.kind,
+    kind: referenceForModel(PackageManifestModel),
     isList: false,
-    name: new URLSearchParams(props.location.search).get('catalog'),
+    name: new URLSearchParams(props.location.search).get('pkg'),
     namespace: new URLSearchParams(props.location.search).get('catalogNamespace'),
-    prop: 'ConfigMap',
+    prop: 'packageManifest',
   }]}>
     {/* FIXME(alecmerdler): Hack because `Firehose` injects props without TypeScript knowing about it */}
     <Create {...props as any} />
   </Firehose>;
 };
 
-export type PackageHeaderProps = {
-
-};
-
-export type PackageRowProps = {
-  obj: Package;
-  catalogSource: CatalogSourceKind;
-  currentCSV: ClusterServiceVersionKind;
-  subscription?: SubscriptionKind;
-};
-
-export type PackageListProps = {
-  catalogSource: CatalogSourceKind;
-  packages: Package[];
-  clusterServiceVersions: ClusterServiceVersionKind[];
-  subscriptions: SubscriptionKind[];
-  filters?: {[name: string]: string};
-};
-
-export type CatalogSourceHeaderProps = {
-
-};
-
-export type CatalogSourceRowProps = {
-  obj: CatalogSourceKind;
-};
-
-export type CatalogSourceListProps = {
-  configMap: {loaded?: boolean, data?: ConfigMapKind[]};
-  globalConfigMap: {loaded?: boolean, data?: ConfigMapKind[]};
-  data: CatalogSourceKind[];
-  filters?: {[name: string]: string};
-  globalCatalogSource: {loaded?: boolean, data?: CatalogSourceKind[]};
-  subscription: {loaded?: boolean, data?: SubscriptionKind[]}
-  loaded: boolean;
-  loadError?: string | Object;
-};
-
-export type CatalogSourcePageProps = {
-  namespace?: string;
-};
-
 export type CatalogSourceDetailsProps = {
   obj: CatalogSourceKind;
-  configMap: K8sResourceKind & {data: {packages: string}};
-  subscription: {loaded?: boolean, data?: SubscriptionKind[]};
+  subscriptions: SubscriptionKind[];
+  packageManifests: PackageManifestKind[];
 };
 
 export type CatalogSourceDetailsPageProps = {
@@ -294,13 +113,6 @@ export type CreateSubscriptionYAMLProps = {
   location: Location;
 };
 
-PackageHeader.displayName = 'PackageHeader';
-PackageRow.displayName = 'PackageRow';
-PackageList.displayName = 'PackageList';
-CatalogSourceHeader.displayName = 'CatalogSourceHeader';
-CatalogSourceRow.displayName = 'CatalogSourceRow';
-CatalogSourceList.displayName = 'CatalogSourceList';
-CatalogSourcesPage.displayName = 'CatalogSourcePage';
 CatalogSourceDetails.displayName = 'CatalogSourceDetails';
 CatalogSourceDetailsPage.displayName = 'CatalogSourceDetailPage';
 CreateSubscriptionYAML.displayName = 'CreateSubscriptionYAML';

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-import { K8sResourceKind, GroupVersionKind, OwnerReference, K8sKind } from '../../module/k8s';
+import { K8sResourceKind, GroupVersionKind, OwnerReference } from '../../module/k8s';
 import { Descriptor } from './descriptors/types';
 import * as operatorLogo from '../../imgs/operator.svg';
 
@@ -158,20 +158,15 @@ export type CatalogSourceKind = {
   },
 } & K8sResourceKind;
 
-// TODO(alecmerdler): Remove this in favor of `PackageManifest`
-export type Package = {
-  packageName: string;
-  channels: {name: string, currentCSV: string}[];
-  defaultChannel?: string;
-};
-
-export type PackageManifest = {
+export type PackageManifestKind = {
   apiVersion: 'packages.app.redhat.com/v1alpha1';
   kind: 'PackageManifest';
   spec: {};
   status: {
     catalogSource: string;
     catalogSourceNamespace: string;
+    catalogSourceDisplayName: string;
+    catalogSourcePublisher: string;
     provider: {
       name: string;
     };
@@ -190,8 +185,9 @@ export type PackageManifest = {
     }[];
     defaultChannel: string;
   };
-} & K8sKind;
+} & K8sResourceKind;
 
+// TODO(alecmerdler): Shouldn't be needed anymore
 export const olmNamespace = 'operator-lifecycle-manager';
 
 export const isEnabled = (namespace: K8sResourceKind) => _.has(namespace, ['metadata', 'annotations', 'alm-manager']);

--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -1,0 +1,132 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import { Link } from 'react-router-dom';
+
+import { referenceForModel, K8sResourceKind } from '../../module/k8s';
+import { PackageManifestKind, SubscriptionKind, CatalogSourceKind, ClusterServiceVersionLogo } from './index';
+import { PackageManifestModel, SubscriptionModel, CatalogSourceModel } from '../../models';
+import { StatusBox, MsgBox } from '../utils';
+import { List, ListHeader, ColHead, MultiListPage } from '../factory';
+import { getActiveNamespace } from '../../ui/ui-actions';
+import { ALL_NAMESPACES_KEY } from '../../const';
+
+export const PackageManifestHeader: React.SFC<PackageManifestHeaderProps> = (props) => <ListHeader>
+  <ColHead {...props} className="col-sm-4 col-xs-6">Name</ColHead>
+  <ColHead {...props} className="col-sm-4 hidden-xs">Latest Version</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6">Subscriptions</ColHead>
+</ListHeader>;
+
+export const PackageManifestRow: React.SFC<PackageManifestRowProps> = (props) => {
+  const {obj, catalogSourceName, catalogSourceNamespace, subscription} = props;
+  const ns = getActiveNamespace();
+  const channel = !_.isEmpty(obj.status.defaultChannel) ? obj.status.channels.find(ch => ch.name === obj.status.defaultChannel) : obj.status.channels[0];
+  const {displayName, icon = [], version, provider} = channel.currentCSVDesc;
+
+  const subscriptionLink = () => ns !== ALL_NAMESPACES_KEY
+    ? <Link to={`/k8s/ns/${ns}/${SubscriptionModel.plural}/${subscription.metadata.name}`}>View subscription</Link>
+    : <Link to={`/k8s/all-namespaces/${SubscriptionModel.plural}?name=${obj.metadata.name}`}>View subscriptions</Link>;
+
+  const createSubscriptionLink = () => `/k8s/ns/${ns === ALL_NAMESPACES_KEY ? 'default' : ns}/${SubscriptionModel.plural}/new?pkg=${obj.metadata.name}&catalog=${catalogSourceName}&catalogNamespace=${catalogSourceNamespace}`;
+
+  return <div className="row co-resource-list__item co-package-row">
+    <div className="col-sm-4 col-xs-6">
+      <ClusterServiceVersionLogo displayName={displayName} icon={_.get(icon, '[0]')} provider={provider.name} />
+    </div>
+    <div className="col-xs-4 hidden-xs">{version} ({channel.name})</div>
+    <div className="col-sm-4 col-xs-6 co-package-row__actions">
+      { subscription
+        ? subscriptionLink()
+        : <span className="text-muted">Not subscribed</span> }
+      { (!subscription || ns === ALL_NAMESPACES_KEY) && <Link to={createSubscriptionLink()}>
+        <button className="btn btn-primary">Create Subscription</button>
+      </Link> }
+    </div>
+  </div>;
+};
+
+export const PackageManifestList: React.SFC<PackageManifestListProps> = (props) => {
+  type CatalogSourceInfo = {displayName: string, name: string, publisher: string, namespace: string};
+  const catalogs = (props.data || []).reduce((allCatalogs, {status}) => allCatalogs.set(status.catalogSource, {
+    displayName: status.catalogSourceDisplayName,
+    name: status.catalogSource,
+    publisher: status.catalogSourcePublisher,
+    namespace: status.catalogSourceNamespace
+  }), new Map<string, CatalogSourceInfo>());
+
+  return props.loaded
+    ? <React.Fragment>
+      { _.isEmpty(props.data) && <MsgBox title="No Package Manifests Found" detail="Package Manifests are packaged Operators which can be subscribed to for automatic upgrades." /> }
+      { [...catalogs.values()].map(catalog => <div key={catalog.name} className="co-catalogsource-list__section">
+        <div className="co-catalogsource-list__section__packages">
+          <div>
+            <h3>{catalog.displayName}</h3>
+            <span className="text-muted">Packaged by {catalog.publisher}</span>
+          </div>
+          <Link to={`/k8s/ns/${catalog.namespace}/${referenceForModel(CatalogSourceModel)}/${catalog.name}`}>View catalog details</Link>
+        </div>
+        <List
+          loaded={true}
+          data={props.data.filter(pkg => pkg.status.catalogSource === catalog.name)}
+          filters={props.filters}
+          Header={PackageManifestHeader}
+          Row={(rowProps: {obj: PackageManifestKind}) => <PackageManifestRow
+            obj={rowProps.obj}
+            catalogSourceName={catalog.name}
+            catalogSourceNamespace={catalog.namespace}
+            subscription={props.subscription.data.find(sub => sub.spec.name === rowProps.obj.metadata.name)} />}
+          label="Package Manifests"
+          EmptyMsg={() => <MsgBox title="No PackageManifests Found" detail="The catalog author has not added any packages." />} />
+      </div>) }
+    </React.Fragment>
+    : <StatusBox loaded={props.loaded} loadError={props.loadError} label={PackageManifestModel.labelPlural} />;
+};
+
+export const PackageManifestsPage: React.SFC<PackageManifestsPageProps> = (props) => {
+  type Flatten = (resources: {[kind: string]: {data: K8sResourceKind[]}}) => K8sResourceKind[];
+  const flatten: Flatten = resources => _.get(resources.packageManifest, 'data', []);
+  const HelpText = <p className="co-help-text">Catalogs are groups of Operators you can make available on the cluster. Subscribe and grant a namespace access to use the installed Operators.</p>;
+
+  return <MultiListPage
+    {...props}
+    title="Operator Catalog Sources"
+    showTitle={true}
+    helpText={HelpText}
+    ListComponent={PackageManifestList}
+    filterLabel="Packages by name"
+    flatten={flatten}
+    resources={[
+      {kind: referenceForModel(PackageManifestModel), isList: true, namespaced: true, prop: 'packageManifest'},
+      {kind: referenceForModel(CatalogSourceModel), isList: true, namespaced: true, prop: 'catalogSource'},
+      {kind: referenceForModel(SubscriptionModel), isList: true, namespaced: true, prop: 'subscription'},
+    ]} />;
+};
+
+export type PackageManifestsPageProps = {
+  namespace?: string;
+};
+
+export type PackageManifestListProps = {
+  data: PackageManifestKind[];
+  filters?: {[name: string]: string};
+  catalogSource: {loaded?: boolean, data?: CatalogSourceKind[]};
+  subscription: {loaded?: boolean, data?: SubscriptionKind[]}
+  loaded: boolean;
+  loadError?: string | Object;
+};
+
+export type PackageManifestHeaderProps = {
+
+};
+
+export type PackageManifestRowProps = {
+  obj: PackageManifestKind;
+  catalogSourceName: string;
+  catalogSourceNamespace: string;
+  subscription?: SubscriptionKind;
+};
+
+PackageManifestHeader.displayName = 'PackageHeader';
+PackageManifestRow.displayName = 'PackageRow';
+PackageManifestList.displayName = 'PackageList';

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -52,6 +52,7 @@ import {
   StatefulSetModel,
   StorageClassModel,
   SubscriptionModel,
+  PackageManifestModel,
 } from '../models';
 
 export const resourceDetailPages = ImmutableMap<GroupVersionKind | string, () => Promise<React.ComponentType<any>>>()
@@ -145,7 +146,7 @@ export const resourceListPages = ImmutableMap<GroupVersionKind | string, () => P
   .set(referenceForModel(StorageClassModel), () => import('./storage-class' /* webpackChunkName: "storage-class" */).then(m => m.StorageClassPage))
   .set(referenceForModel(CustomResourceDefinitionModel), () => import('./custom-resource-definition' /* webpackChunkName: "custom-resource-definition" */).then(m => m.CustomResourceDefinitionsPage))
   .set(referenceForModel(ClusterServiceVersionModel), () => import('./operator-lifecycle-manager/clusterserviceversion' /* webpackChunkName: "clusterserviceversion" */).then(m => m.ClusterServiceVersionsPage))
-  .set(referenceForModel(CatalogSourceModel), () => import('./operator-lifecycle-manager/catalog-source' /* webpackChunkName: "catalog-source" */).then(m => m.CatalogSourcesPage))
+  .set(referenceForModel(PackageManifestModel), () => import('./operator-lifecycle-manager/package-manifest' /* webpackChunkName: "package-manifest" */).then(m => m.PackageManifestsPage))
   .set(referenceForModel(SubscriptionModel), () => import('./operator-lifecycle-manager/subscription' /* webpackChunkName: "subscription" */).then(m => m.SubscriptionsPage))
   .set(referenceForModel(InstallPlanModel), () => import('./operator-lifecycle-manager/install-plan' /* webpackChunkName: "install-plan" */).then(m => m.InstallPlansPage));
 


### PR DESCRIPTION
### Description

Removes code that parsed the `ConfigMap` associated with a `CatalogSource` and instead consume the new `PackageManifest` API directly. This allows us to use the standard Kubernetes data components for this resource and eliminates a lot of ugly code.

### Changes

- add `PackageManifets` components
- change "Catalog Sources" nav item to "Package Manifests" (the view remains the same)
- hit `PackageManifest` API instead of parsing configmap

Addresses https://jira.coreos.com/browse/ALM-720
Fixes https://jira.coreos.com/browse/ALM-718
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1625084