### PR TITLE
Visual tweaks to vertical navigation

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -145,7 +145,7 @@ $color-bookmarker: #DDD;
   white-space: nowrap;
 
   @media (min-width: $grid-float-breakpoint) {
-    border-left: 1px solid $color-os-nav-item-seperator;
+    border-left: 1px solid $color-os-nav-border-bottom;
     height: $co-namespace-selector-desktop;
   }
 

--- a/frontend/public/components/_nav.scss
+++ b/frontend/public/components/_nav.scss
@@ -7,7 +7,7 @@ $active-border: 3px;
 .co-m-nav-link {
   display: block;
   float: none;
-  font-size: 13px;
+  font-size: 12px;
   line-height: 23px;
   overflow-x: hidden;
   padding: 2px 0 2px $link-padding-left;
@@ -22,9 +22,10 @@ $active-border: 3px;
   }
 
   &.active {
-    padding-left: $link-padding-left - $active-border;
-    background-color: #383F47;
+    background-color: $color-pf-black-700;
     border-left: $active-border solid $color-os-nav-border-left-active;
+    font-weight: 600;
+    padding-left: $link-padding-left - $active-border;
     a {
       color: #fff;
     }
@@ -52,6 +53,17 @@ $active-border: 3px;
   -webkit-overflow-scrolling: touch;
 }
 
+.navigation-container--open .navigation-container__separator {
+  border-bottom: 1px solid $color-pf-black;
+}
+
+.navigation-container--active {
+  background-color: $color-pf-black-800;
+  .navigation-container__separator {
+    border-bottom: 1px solid $color-os-nav-separator;
+  }
+}
+
 .navigation-container__list {
   margin: -10px 0 10px 0;
   overflow-y: hidden;
@@ -59,24 +71,12 @@ $active-border: 3px;
   transition: max-height 0.25s;
 }
 
-.navigation-container__section, .navigation-container__section__separator {
-  border-bottom: 1px solid $color-os-nav-item-seperator;
+.navigation-container__list--open {
+  margin: 5px 0 10px 0;
 }
 
-.navigation-container__section--active {
-  background-color: $color-os-nav-background-active;
-  position: relative;
-  &:before {
-    background: $color-os-nav-border-left-active;
-    content: "";
-    height: 100%;
-    position: absolute;
-    width: $active-border;
-  }
-}
-
-.navigation-container__section__separator {
-  margin: 8px 20px 8px 40px;
+.navigation-container__section {
+  border-bottom: 1px solid $color-os-nav-border-bottom;
 }
 
 .navigation-container__section__title {
@@ -84,7 +84,7 @@ $active-border: 3px;
   color: $color-os-nav-title;
   cursor: pointer;
   display: flex;
-  font-size: 15px;
+  font-size: 14px;
   line-height: 20px;
   padding: 20px 0px 20px $section-padding-left;
   width: 100%;
@@ -101,7 +101,34 @@ $active-border: 3px;
     display: inline-block;
     margin: 0 15px 0 11px;
   }
+  &:hover {
+    background-color: $color-pf-black-800;
+    .fa-angle-right {
+      display: inline-block;
+    }
+  }
 }
+
+.navigation-container__section__title--active {
+  color: #fff;
+  font-weight: 600;
+}
+
+.navigation-container__section__title--active-closed {
+  border-left: $active-border solid $color-os-nav-border-left-active;
+  padding-left: $section-padding-left - $active-border;
+}
+
+.navigation-container__section__title--active-open {
+  &:hover {
+    background-color: $color-os-nav-background-active;
+  }
+}
+
+.navigation-container__section__title--inactive-open:hover {
+  background-color: $color-pf-black-800;
+}
+
 .navigation-container__section__title__link,
 .navigation-container__section__title__link:hover,
 .navigation-container__section__title__link:focus  {
@@ -118,6 +145,15 @@ $active-border: 3px;
   &.fa {
     font-size: 15px;
   }
+  &.fa-angle-down {
+    font-size: 20px;
+    margin-left: auto;
+  }
+  &.fa-angle-right {
+    display: none;
+    font-size: 20px;
+    margin-left: auto;
+  }
   &.fa-cog {
     font-size: 18px;
   }
@@ -128,5 +164,9 @@ $active-border: 3px;
 }
 
 .navigation-container__section__title__icon--active {
-  color: $color-os-nav-border-left-active;
+  color: $color-pf-blue-300;
+}
+
+.navigation-container__separator {
+  margin: 8px 20px 8px 40px;
 }

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -212,6 +212,7 @@ const NavSection = connect(navSectionStateToProps)(
       }
 
       const { id, icon, img, text, children, activeNamespace, flags, href = null, activeImg, klass } = this.props;
+      const { isOpen } = this.state;
       const isActive = !!this.state.activeChild;
       // WARNING:
       // we transition on max-height because you can't transition to height 'inherit'
@@ -222,7 +223,6 @@ const NavSection = connect(navSectionStateToProps)(
       const maxHeight = !this.state.isOpen ? 0 : 29 * _.get(this.props.children, 'length', 1);
 
       const iconClassName = icon && `${icon} navigation-container__section__title__icon ${isActive ? 'navigation-container__section__title__icon--active' : ''}`;
-      const sectionClassName = isActive && href ? 'navigation-container__section navigation-container__section--active' : 'navigation-container__section';
 
       const Children = React.Children.map(children, c => {
         if (!c) {
@@ -238,22 +238,23 @@ const NavSection = connect(navSectionStateToProps)(
         return React.cloneElement(c, {key: name, isActive: name === this.state.activeChild, activeNamespace});
       });
 
-      return <div className={classNames(sectionClassName, klass)}>
-        <div id={id} className="navigation-container__section__title" onClick={this.toggle}>
+      return <div className={classNames('navigation-container__section', klass, {'navigation-container--active': isActive, 'navigation-container--open': isOpen})}>
+        <div id={id} className={classNames('navigation-container__section__title', {'navigation-container__section__title--active': isActive, 'navigation-container__section__title--active-closed': (isActive && !isOpen), 'navigation-container__section__title--active-open': (isActive && isOpen), 'navigation-container__section__title--inactive-open': (!isActive && isOpen)})} onClick={this.toggle}>
           {icon && <i className={iconClassName} aria-hidden="true"></i>}
           {img && <img src={isActive && activeImg ? activeImg : img} />}
           { !href
             ? text
             : <Link className="navigation-container__section__title__link" to={href} onClick={this.open}>{text}</Link>
           }
+          <i className={classNames('icon navigation-container__section__title__icon fa', isOpen ? 'fa-angle-down' : 'fa-angle-right')} aria-hidden="true" />
         </div>
-        {Children && <ul className="navigation-container__list" style={{maxHeight}}>{Children}</ul>}
+        {Children && <ul className={classNames('navigation-container__list', {'navigation-container__list--open': isOpen})} style={{maxHeight}}>{Children}</ul>}
       </div>;
     }
   }
 );
 
-const Sep = () => <div className="navigation-container__section__separator" />;
+const Sep = () => <div className="navigation-container__separator" />;
 
 // HrefLinks are PureComponents...
 const searchStartsWith = ['search'];

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -66,14 +66,15 @@ $masthead-height-mobile: 40px;
 $co-m-label-line-height: 19px;
 
 // Masthead and navigation colors
-$color-os-nav-title: $color-pf-black-300;
-$color-os-nav-background: $color-pf-black-900;
-$color-os-nav-background-active: $color-pf-black-800;
-$color-os-nav-item-seperator: #050505;
 $color-os-nav-active: $color-pf-black-800;
-$color-os-nav-hover: lighten($color-os-nav-active, 8%);
+$color-os-nav-background: $color-pf-black-900;
+$color-os-nav-background-active: $color-pf-black-700;
+$color-os-nav-border-bottom: #050505;
 $color-os-nav-border-left-active: $color-pf-blue-300;
+$color-os-nav-hover: lighten($color-os-nav-active, 8%);
 $color-os-nav-icon: $color-pf-black-600;
+$color-os-nav-separator: $color-pf-black-900;
+$color-os-nav-title: $color-pf-black-300;
 
 // Patternfly defaults to 12px, which is too small in many cases
 $font-size-base: 13px;


### PR DESCRIPTION
Adjusted background colors, borders, hover states, icons, and text color, size, and weight on nav.

I didn't address anything under the headline "Navigation Order" on the [design sheet](http://openshift.github.io/openshift-origin-design/web-console/4.0-designs/navigation/navigation#design) since the Jira task seemed to be about styling updates. Let me know if I should include that bit.

Poor-quality gif:
![navbar](https://user-images.githubusercontent.com/7014965/46832423-faf39280-cd73-11e8-9b63-527bc68bc90c.gif)

Closed:
<img width="1346" alt="screen shot 2018-10-11 at 4 23 55 pm" src="https://user-images.githubusercontent.com/7014965/46831708-22e1f680-cd72-11e8-9a0a-0126e91f9669.png">

Open:
<img width="1346" alt="screen shot 2018-10-11 at 4 24 09 pm" src="https://user-images.githubusercontent.com/7014965/46831717-27a6aa80-cd72-11e8-928b-c1380ca567ea.png">

Fixes [CONSOLE-900](https://jira.coreos.com/browse/CONSOLE-900?filter=-1).

@openshift/team-ux-review, can you please take a look? Thanks!