### PR TITLE
Use Bootstrap styles for checkbox in delete modal

### DIFF
--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -1,7 +1,3 @@
-.co-delete-modal__checkbox {
-  padding-top: 30px;
-}
-
 .co-delete-modal {
   display: flex;
 }

--- a/frontend/public/components/modals/delete-modal.jsx
+++ b/frontend/public/components/modals/delete-modal.jsx
@@ -51,10 +51,10 @@ class DeleteModal extends PromiseComponent {
           <p className="lead">Delete {resource.metadata.name}?</p>
           <div>Are you sure you want to delete <strong>{resource.metadata.name}</strong>
             {_.has(resource.metadata, 'namespace') && <span> in namespace <strong>{ resource.metadata.namespace }</strong>?</span>}
-            {_.has(kind, 'propagationPolicy') && <div className="co-delete-modal__checkbox">
-              <label className="co-delete-modal__checkbox-label">
+            {_.has(kind, 'propagationPolicy') && <div className="checkbox">
+              <label className="control-label">
                 <input type="checkbox" onChange={() => this.setState({isChecked: !this.state.isChecked})} checked={!!this.state.isChecked} />
-                &nbsp;&nbsp; <span>Delete dependent objects of this resource</span>
+                Delete dependent objects of this resource
               </label>
             </div>}
           </div>


### PR DESCRIPTION
The spacing for this checkbox looked off to me. This does deemphasize the checkbox label, but I think that's OK. Most of the time you want the default, which is to cascade. Opinion?

/assign @rhamilto 

Before:

<img width="616" alt="screen shot 2018-10-14 at 12 34 16 pm" src="https://user-images.githubusercontent.com/1167259/46919456-bc491c80-cfad-11e8-8976-2dfb8ca68c27.png">

After:

<img width="631" alt="screen shot 2018-10-14 at 12 33 50 pm" src="https://user-images.githubusercontent.com/1167259/46919460-c0753a00-cfad-11e8-933a-583c861c9b0c.png">
