### PR TITLE
Create PVC Form - Add form to Attach Storage

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -210,10 +210,9 @@ class ListDropdown_ extends React.Component {
     if (!loaded) {
       return;
     }
-
     const state = {};
+    const { resources, dataFilter, selectedKey } = nextProps;
 
-    const { resources, dataFilter } = nextProps;
     state.items = {};
     _.each(resources, ({data}, kindLabel) => {
       _.reduce(data, (acc, resource) => {
@@ -224,9 +223,8 @@ class ListDropdown_ extends React.Component {
       }, state.items);
     });
 
-    const { selectedKey } = this.state;
     // did we switch from !loaded -> loaded ?
-    if (!this.props.loaded && !selectedKey) {
+    if (!this.props.loaded || !selectedKey) {
       state.title = <span className="text-muted">{nextProps.placeholder}</span>;
     }
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -202,6 +202,7 @@ class App extends React.PureComponent {
             <LazyRoute path="/k8s/cluster/clusterrolebindings/:name/edit" exact kind="ClusterRoleBinding" loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRoleBinding)} />
             <LazyRoute path="/k8s/ns/:ns/:plural/:name/attach-storage" exact loader={() => import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(m => m.AttachStorage)} />
 
+            <LazyRoute path="/k8s/ns/:ns/persistentvolumeclaims/new/form" exact kind="PersistentVolumeClaim" loader={() => import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(m => m.CreatePVC)} />
             <Redirect from="/monitoring" exact to="/monitoring/alerts" />
             <Route path="/monitoring/alerts" exact component={AlertsPage} />
             <Route path="/monitoring/alerts/:name" exact component={AlertsDetailsPage} />

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -103,7 +103,18 @@ const filters = [{
 
 
 export const PersistentVolumeClaimsList = props => <List {...props} Header={Header} Row={Row} />;
-export const PersistentVolumeClaimsPage = props => <ListPage {...props} ListComponent={PersistentVolumeClaimsList} kind={kind} canCreate={true} rowFilters={filters} />;
+export const PersistentVolumeClaimsPage = props => {
+  const createItems = {
+    form: 'From Form',
+    yaml: 'From YAML',
+  };
+  const createProps = {
+    items: createItems,
+    btnActionItemKey: 'form',
+    createLink: type => `/k8s/ns/${props.namespace}/persistentvolumeclaims/new/${type !== 'yaml' ? 'form' : ''}`,
+  };
+  return <ListPage {...props} ListComponent={PersistentVolumeClaimsList} kind={kind} canCreate={true} rowFilters={filters} createProps={createProps} />;
+};
 export const PersistentVolumeClaimsDetailsPage = props => <DetailsPage
   {...props}
   menuActions={menuActions}

--- a/frontend/public/components/radio.jsx
+++ b/frontend/public/components/radio.jsx
@@ -3,20 +3,26 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 
 export const RadioInput = (props) => {
-  const inputProps = _.omit(props, ['title', 'subTitle', 'desc', 'children']);
-  return <div className="radio-item form-group">
-    <label>
+  const inputProps = _.omit(props, ['title', 'subTitle', 'desc', 'children', 'inline']);
+  const labelClass = props.inline ? 'radio-inline' : '';
+  const inputElement = <React.Fragment>
+    <label className={labelClass}>
       <input type="radio" {...inputProps} />
-      {props.title} { props.subTitle && <span className="co-no-bold">{props.subTitle}</span>}
+      {props.title} {props.subTitle && <span className="co-no-bold">{props.subTitle}</span>}
     </label>
     {props.desc && <p className="co-m-radio-desc text-muted">{props.desc}</p>}
     {props.children}
-  </div>;
+  </React.Fragment>;
+
+  return props.inline ? inputElement : <div className="radio-item form-group">{inputElement}</div>;
+
 };
+
 RadioInput.propTypes = {
   children: PropTypes.node,
   desc: PropTypes.node,
   title: PropTypes.node.isRequired,
+  inline?: PropTypes.bool,
 };
 
 export const RadioGroup = ({currentValue, onChange, items}) => <div>

--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -1,0 +1,327 @@
+/* eslint-disable no-undef */
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+
+import { k8sCreate, K8sResourceKind, referenceFor } from '../../module/k8s';
+import { ButtonBar, history, NameValueEditor, resourceObjPath, RequestSizeInput } from '../utils';
+import { ListDropdown } from '../RBAC/bindings';
+import { RadioInput } from '../radio';
+import { Checkbox } from '../checkbox';
+import { PersistentVolumeClaimModel } from '../../models/index';
+
+const StorageClassDropdown: React.SFC<StorageClassDropdownProps> = props => {
+  const kind = 'StorageClass';
+  const resources = [{ kind }];
+  const { selectedKey, required, namespace } = props;
+  return (
+    <ListDropdown
+      {...props}
+      desc="Storage Classes"
+      resources={resources}
+      selectedKeyKind={kind}
+      placeholder="Select storage class"
+      selectedKey={selectedKey}
+      required={required}
+      namespace={namespace}
+      name={name}
+    />
+  );
+};
+// This form is done a little odd since it is used in both its own page and as
+// a sub form inside the attach storage page.
+export class CreatePVCForm extends React.Component<CreatePVCFormProps, CreatePVCFormState> {
+  state = {
+    storageClass: '',
+    pvcName: '',
+    accessMode: 'ReadWriteOnce',
+    requestSizeValue: '',
+    requestSizeUnit: 'Gi',
+    disableForm: false,
+    showLabelSelectors: false,
+    nameValuePairs: [['', '']],
+    accessModeRadios: [
+      {
+        value: 'ReadWriteOnce',
+        title: 'Single User (RWO)',
+      },
+      {
+        value: 'ReadWriteMany',
+        title: 'Shared Access (RWX)',
+      },
+      {
+        value: 'ReadOnlyMany',
+        title: 'Read Only (ROX)',
+      },
+    ],
+    dropdownUnits: {
+      Mi: 'MiB',
+      Gi: 'GiB',
+      Ti: 'TiB',
+    },
+  };
+
+
+  handleChange: React.ReactEventHandler<HTMLInputElement> = event => {
+    // this handles pvcName, accessMode, size
+    const { name, value } = event.currentTarget;
+    this.setState({ [name]: value } as any, this.onChange);
+  };
+
+  handleNameValuePairs = ({ nameValuePairs }) => {
+    this.setState({ nameValuePairs }, this.onChange);
+  };
+
+  handleStorageClass = storageClass => {
+    this.setState({ storageClass }, this.onChange);
+  };
+
+  HandleRequestSizeInputChange = obj => {
+    this.setState({ requestSizeValue: obj.value, requestSizeUnit: obj.unit }, this.onChange);
+  }
+
+  clearStorageClass = () => {
+    this.setState({ storageClass: '' }, this.onChange);
+  };
+
+  toggleShowLabelSelectors = () => {
+    this.setState({ showLabelSelectors: !this.state.showLabelSelectors });
+  };
+
+  nameValueArrayToObject = nvpArray => {
+    return _.reduce(nvpArray, (acc, [key, value]) => {
+      return key ? { ...acc, [key]: value } : acc;
+    }, {});
+  };
+
+  onChange = () => {
+    return this.props.onChange(this.updatePVC());
+  }
+
+  updatePVC = () => {
+    const { namespace } = this.props;
+    const { pvcName, accessMode, requestSizeValue, requestSizeUnit, storageClass, nameValuePairs } = this.state;
+    const valuePairs = this.nameValueArrayToObject(nameValuePairs);
+
+    const obj = {
+      apiVersion: 'v1',
+      kind: 'PersistentVolumeClaim',
+      metadata: {
+        name: pvcName,
+        namespace,
+      },
+      spec: {
+        accessModes: [accessMode],
+        storageClassName: storageClass,
+        resources: {
+          requests: {
+            storage: `${requestSizeValue}${requestSizeUnit}`,
+          },
+        },
+        selector: {
+          matchLabels: valuePairs,
+        },
+      },
+    };
+    return obj;
+  };
+
+  render() {
+    const { dropdownUnits, showLabelSelectors, nameValuePairs, requestSizeUnit, requestSizeValue, storageClass } = this.state;
+    const { namespace } = this.props;
+    return (
+      <div>
+        <label className="control-label" htmlFor="storageclass-dropdown">
+          Storage Class
+        </label>
+        <div className="form-group">
+          <StorageClassDropdown
+            onChange={this.handleStorageClass}
+            id="storageclass-dropdown"
+            selectedKey={storageClass}
+            namespace={namespace}
+            required={false}
+            name="storageClass"
+            placeholder="Select storage class"
+          />
+          {storageClass && <button className="btn btn-link" type="button" onClick={this.clearStorageClass}>Clear Selection</button>}
+          <p className="help-block" id="storageclass-dropdown-help">
+            Optional storage class for the new claim.
+          </p>
+        </div>
+        <label className="control-label co-required" htmlFor="pvc-name">
+          Name
+        </label>
+        <div className="form-group">
+          <input
+            className="form-control"
+            type="text"
+            onChange={this.handleChange}
+            placeholder="my-storage-claim"
+            aria-describedby="pvc-name-help"
+            id="pvc-name"
+            name="pvcName"
+            pattern="[a-z0-9](?:[-a-z0-9]*[a-z0-9])?"
+            required
+          />
+          <p className="help-block" id="pvc-name-help">
+            A unique name for the storage claim within the project.
+          </p>
+        </div>
+        <label className="control-label co-required" htmlFor="access-mode">
+          Access Mode
+        </label>
+        <div className="form-group">
+          {this.state.accessModeRadios.map(radio => {
+            const checked = radio.value === this.state.accessMode;
+            return (
+              <RadioInput
+                {...radio}
+                key={radio.value}
+                onChange={this.handleChange}
+                inline={true}
+                checked={checked}
+                aria-describedby="access-mode-help"
+                name="accessMode"
+              />
+            );
+          })}
+          <p className="help-block" id="access-mode-help">
+            Permissions to the mounted drive.
+          </p>
+        </div>
+        <label className="control-label co-required" htmlFor="request-size-input">
+          Size
+        </label>
+        <RequestSizeInput
+          name="requestSize"
+          required={false}
+          onChange={this.HandleRequestSizeInputChange}
+          defaultRequestSizeUnit={requestSizeUnit}
+          defaultRequestSizeValue={requestSizeValue}
+          dropdownUnits={dropdownUnits}
+          describedBy="request-size-help"
+        />
+        <p className="help-block" id="request-size-help">
+          Desired storage capacity.
+        </p>
+        <Checkbox
+          label="Use label selectors to request storage"
+          onChange={this.toggleShowLabelSelectors}
+          checked={showLabelSelectors}
+          name="showLabelSelector"
+        />
+        <div className="form-group">
+          {showLabelSelectors && (
+            <NameValueEditor
+              nameValuePairs={nameValuePairs}
+              valueString="Selector"
+              nameString="Label"
+              addString="Add Value"
+              readOnly={false}
+              allowSorting={false}
+              updateParentData={this.handleNameValuePairs}
+            />
+          )}
+          <p className="help-block" id="label-selector-help">
+            Use label selectors to define how storage is created.
+          </p>
+        </div>
+      </div>
+
+    );
+  }
+}
+
+class CreatePVCPage extends React.Component<CreatePVCPageProps, CreatePVCPageState> {
+  state = {
+    error: '',
+    inProgress: false,
+    title: 'Create Storage',
+    pvcObj: null,
+  };
+
+  onChange = (pvcObj: K8sResourceKind) => {
+    this.setState({ pvcObj });
+  };
+
+  save = (e: React.FormEvent<EventTarget>) => {
+    e.preventDefault();
+    this.setState({ inProgress: true });
+    k8sCreate(PersistentVolumeClaimModel, this.state.pvcObj).then(
+      resource => {
+        this.setState({ inProgress: false });
+        history.push(resourceObjPath(resource, referenceFor(resource)));
+      },
+      err => this.setState({ error: err.message, inProgress: false })
+    );
+  };
+
+  render() {
+    const { title, error, inProgress } = this.state;
+    const { namespace } = this.props;
+    return (
+      <div className="co-m-pane__body">
+        <Helmet>
+          <title>{title}</title>
+        </Helmet>
+        <h1 className="co-m-pane__heading">{title}</h1>
+        <form className="co-m-pane__body-group " onSubmit={this.save}>
+          <CreatePVCForm onChange={this.onChange} namespace={namespace} />
+          <ButtonBar errorMessage={error} inProgress={inProgress}>
+            <button type="submit" className="btn btn-primary" id="save-changes">
+              Create
+            </button>
+            <button type="button" className="btn btn-default" onClick={history.goBack}>
+              Cancel
+            </button>
+          </ButtonBar>
+        </form>
+      </div>
+    );
+  }
+}
+
+export const CreatePVC = ({ match: { params } }) => {
+  return <CreatePVCPage namespace={params.ns} />;
+};
+
+export type StorageClassDropdownProps = {
+  namespace: string;
+  selectedKey: string;
+  required: boolean;
+  onChange: (string) => void;
+  id: string;
+  name: string;
+  placeholder?: string;
+};
+
+export type CreatePVCFormProps = {
+  namespace: string;
+  onChange: Function;
+};
+
+export type CreatePVCFormState = {
+  storageClass: string;
+  pvcName: string;
+  accessMode: string;
+  requestSizeValue: string;
+  requestSizeUnit: string;
+  disableForm: boolean;
+  accessModeRadios: { value: string, title: string }[];
+  dropdownUnits: { [key: string]: string };
+  showLabelSelectors: boolean;
+  nameValuePairs: string[][];
+};
+
+export type CreatePVCPageProps = {
+  namespace: string;
+};
+
+export type CreatePVCPageState = {
+  inProgress: boolean;
+  error: string;
+  title: string;
+  pvcObj: K8sResourceKind;
+};
+/* eslint-enable no-undef */

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -44,6 +44,8 @@ export * from './service-catalog-status';
 export * from './close-button';
 export * from './container-table';
 export * from './simple-tab-nav';
+export * from './request-size-input';
+export * from './name-value-editor';
 
 /*
   Add the enum for NameValueEditorPair here and not in its namesake file because the editor should always be

--- a/frontend/public/components/utils/request-size-input.tsx
+++ b/frontend/public/components/utils/request-size-input.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable no-undef, no-unused-vars */
+import * as React from 'react';
+import { Dropdown } from '.';
+
+export class RequestSizeInput extends React.Component<RequestSizeInputProps> {
+  state = {
+    unit: this.props.defaultRequestSizeUnit,
+    value: this.props.defaultRequestSizeValue,
+  }
+
+  onValueChange: React.ReactEventHandler<HTMLInputElement> = event => {
+    this.setState({ value: event.currentTarget.value });
+    this.props.onChange({ value: event.currentTarget.value, unit: this.state.unit });
+  };
+
+  onUnitChange = unit => {
+    this.setState({ unit });
+    this.props.onChange({ value: this.state.value, unit });
+  }
+
+  render() {
+    const { describedBy, name } = this.props;
+    const inputName = `${name}Value`;
+    const dropdownName = `${name}Unit`;
+    return (
+      <div className="form-group">
+        <div className="input-group">
+          <input
+            className="form-control"
+            type="number"
+            onChange={this.onValueChange}
+            placeholder={this.props.placeholder}
+            aria-describedby={describedBy}
+            name={inputName}
+            required={this.props.required}
+          />
+          <Dropdown
+            title={this.props.defaultRequestSizeUnit}
+            selectedKey={this.props.defaultRequestSizeUnit}
+            name={dropdownName}
+            className="btn-group"
+            items={this.props.dropdownUnits}
+            onChange={this.onUnitChange}
+            required={this.props.required}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+export type RequestSizeInputProps = {
+  placeholder?: string;
+  name: string;
+  onChange: Function;
+  required?: boolean;
+  dropdownUnits: any;
+  defaultRequestSizeUnit: string;
+  defaultRequestSizeValue: string;
+  describedBy?: string;
+};


### PR DESCRIPTION
This is part 2 and now part 3 for the attach storage overall project.  This specifically creates a form component that will allow users to create a new persistent volume claim.  Although this form will exist within the attach storage form, it still makes sense to give this a page of its own from the pvc section of the console.  The attach storage screen now also contains the create pvc form. See images below.

![create-pvc-create-dropdown](https://user-images.githubusercontent.com/18728857/47051928-96657880-d163-11e8-93a6-fe646c89e350.png)
![create-pvc1](https://user-images.githubusercontent.com/18728857/47051932-9a919600-d163-11e8-8aa7-ca3f231ce54e.png)
![clear-selection](https://user-images.githubusercontent.com/18728857/47611656-52aa2300-da2f-11e8-96a7-dcaecd7e737d.png)
![create-pvc-with-clear-selection-and-dropdown](https://user-images.githubusercontent.com/18728857/47611689-c815f380-da2f-11e8-8039-0bbb0fc3bd0b.png)

![create-pvc-sc-dropdown](https://user-images.githubusercontent.com/18728857/47051936-9ebdb380-d163-11e8-9de4-cd1e202add93.png)
![create-pvc-labels](https://user-images.githubusercontent.com/18728857/47051940-a4b39480-d163-11e8-9321-dc689a6a5b66.png)

These are the images for attach storage with the create pvc form.
![attach-storage-with-pvc1](https://user-images.githubusercontent.com/18728857/47611654-43c37080-da2f-11e8-996c-c239d9a38402.png)
![attach-storage-with-pvc-active](https://user-images.githubusercontent.com/18728857/47611655-4920bb00-da2f-11e8-877e-447b956d3a56.png)
