### PR TITLE
Fix to only render correct catalog items

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
     "js-yaml": "3.x",
     "lodash-es": "4.x",
     "openshift-logos-icon": "1.7.1",
-    "patternfly": "^3.45.0",
+    "patternfly": "^3.54.8",
     "patternfly-react": "^2.16.0",
     "patternfly-react-extensions": "2.9.1",
     "plotly.js": "1.28.x",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,7 +67,7 @@
     "openshift-logos-icon": "1.7.1",
     "patternfly": "^3.45.0",
     "patternfly-react": "^2.16.0",
-    "patternfly-react-extensions": "2.8.1",
+    "patternfly-react-extensions": "2.9.1",
     "plotly.js": "1.28.x",
     "prop-types": "15.6.x",
     "react": "16.x",

--- a/frontend/public/components/_catalog.scss
+++ b/frontend/public/components/_catalog.scss
@@ -69,18 +69,6 @@ $catalog-item-icon-size-sm: 24px;
   }
 }
 
-.co-catalog-item-tile {
-  color: inherit;
-  text-decoration: none;
-
-  &:active,
-  &:hover,
-  &:visited {
-    color: inherit;
-    text-decoration: none;
-  }
-}
-
 .co-catalog-page {
   background: #fff;
   box-shadow: 0 0.0625rem 0.125rem 0 rgba(3,3,3,.2);

--- a/frontend/public/components/catalog-items.jsx
+++ b/frontend/public/components/catalog-items.jsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
-import {Link} from 'react-router-dom';
 import {CatalogTileView} from 'patternfly-react-extensions/dist/esm/components/CatalogTileView';
 import {CatalogTile} from 'patternfly-react-extensions/dist/esm/components/CatalogTile';
 import {VerticalTabs} from 'patternfly-react-extensions/dist/esm/components/VerticalTabs';
@@ -244,15 +243,17 @@ export class CatalogTileViewPage extends React.Component {
         const uid = obj.metadata.uid;
         const iconClass = tileIconClass ? `icon ${normalizeIconClass(tileIconClass)}` : null;
         const vendor = tileProvider ? `Provided by ${tileProvider}` : null;
-        const catalogTile = <CatalogTile
-          id={uid}
-          key={uid}
-          title={tileName}
-          iconImg={tileImgUrl}
-          iconClass={iconClass}
-          vendor={vendor}
-          description={tileDescription} />;
-        return href ? <Link key={uid} className="co-catalog-item-tile" to={href}>{catalogTile}</Link> : catalogTile;
+        return (
+          <CatalogTile
+            id={uid}
+            key={uid}
+            href={href}
+            title={tileName}
+            iconImg={tileImgUrl}
+            iconClass={iconClass}
+            vendor={vendor}
+            description={tileDescription} />
+        );
       }))}
     </CatalogTileView.Category>;
   }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1720,12 +1720,6 @@ bootstrap-select@1.12.2:
   dependencies:
     jquery ">=1.8"
 
-bootstrap-select@^1.12.2:
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/bootstrap-select/-/bootstrap-select-1.12.4.tgz#7f15d3c0ce978868d9c09c70f96624f55fa02ee1"
-  dependencies:
-    jquery ">=1.8"
-
 bootstrap-slider-without-jquery@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/bootstrap-slider-without-jquery/-/bootstrap-slider-without-jquery-10.0.0.tgz#5c304461b3b915037c7c118806c8ca08102f5de3"
@@ -8210,37 +8204,7 @@ patternfly-react@^2.21.0:
     sortabular "^1.5.1"
     table-resolver "^3.2.0"
 
-patternfly@^3.45.0:
-  version "3.45.0"
-  resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.45.0.tgz#5b27bde3e3ef68a1542906b96016654aa089a7f3"
-  dependencies:
-    bootstrap "~3.3.7"
-    font-awesome "^4.7.0"
-    jquery "~3.2.1"
-  optionalDependencies:
-    bootstrap-datepicker "^1.7.1"
-    bootstrap-sass "^3.3.7"
-    bootstrap-select "^1.12.2"
-    bootstrap-slider "^9.9.0"
-    bootstrap-switch "~3.3.4"
-    bootstrap-touchspin "~3.1.1"
-    c3 "~0.4.11"
-    d3 "~3.5.17"
-    datatables.net "^1.10.15"
-    datatables.net-colreorder "^1.4.1"
-    datatables.net-colreorder-bs "~1.3.2"
-    datatables.net-select "~1.2.0"
-    drmonty-datatables-colvis "~1.1.2"
-    eonasdan-bootstrap-datetimepicker "^4.17.47"
-    font-awesome-sass "^4.7.0"
-    google-code-prettify "~1.0.5"
-    jquery-match-height "^0.7.2"
-    moment "^2.19.1"
-    moment-timezone "^0.4.1"
-    patternfly-bootstrap-combobox "~1.1.7"
-    patternfly-bootstrap-treeview "~2.1.0"
-
-patternfly@^3.52.1, patternfly@^3.52.4:
+patternfly@^3.52.1, patternfly@^3.52.4, patternfly@^3.54.8:
   version "3.54.8"
   resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.54.8.tgz#fd6c69714dc460575d2534c9f29017a58b442a83"
   dependencies:

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8154,25 +8154,25 @@ patternfly-bootstrap-treeview@~2.1.0:
     bootstrap "3.3.x"
     jquery ">= 2.1.x"
 
-patternfly-react-extensions@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/patternfly-react-extensions/-/patternfly-react-extensions-2.8.1.tgz#bdbf1ebe9b046bdd2ae80fad68be69338ee76ffd"
+patternfly-react-extensions@2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/patternfly-react-extensions/-/patternfly-react-extensions-2.9.1.tgz#ccc0eb393adc7897f5c25d45ac397e7dab1056f6"
   dependencies:
     breakjs "^1.0.0"
     classnames "^2.2.5"
     css-element-queries "^1.0.1"
     patternfly "^3.52.1"
-    patternfly-react "^2.15.0"
+    patternfly-react "^2.21.0"
 
-patternfly-react@^2.15.0:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.19.1.tgz#38ddbd09f2d3914051a3b3e4a0918c8b1cc00408"
+patternfly-react@^2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.16.0.tgz#5268662e2a7e795e63467e3ccdff3005eef2a67b"
   dependencies:
     bootstrap-slider-without-jquery "^10.0.0"
     breakjs "^1.0.0"
     classnames "^2.2.5"
     css-element-queries "^1.0.1"
-    patternfly "^3.52.4"
+    patternfly "^3.52.1"
     react-bootstrap "^0.32.1"
     react-bootstrap-switch "^15.5.3"
     react-bootstrap-typeahead "^3.1.3"
@@ -8187,15 +8187,15 @@ patternfly-react@^2.15.0:
     sortabular "^1.5.1"
     table-resolver "^3.2.0"
 
-patternfly-react@^2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.16.0.tgz#5268662e2a7e795e63467e3ccdff3005eef2a67b"
+patternfly-react@^2.21.0:
+  version "2.21.1"
+  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.21.1.tgz#620db1a5efe7c48f6fd5e0dafc52da986867965b"
   dependencies:
     bootstrap-slider-without-jquery "^10.0.0"
     breakjs "^1.0.0"
     classnames "^2.2.5"
     css-element-queries "^1.0.1"
-    patternfly "^3.52.1"
+    patternfly "^3.52.4"
     react-bootstrap "^0.32.1"
     react-bootstrap-switch "^15.5.3"
     react-bootstrap-typeahead "^3.1.3"

--- a/sources
+++ b/sources
@@ -1,2 +1,2 @@
 401aa1438604b8e32306fa2bd4f8e211  node-v8.9.4-headers.tar.gz
-c2e254d2462e23aed3524ab07eb99ecd  yarn-offline.tar
+4d9651a62b920a31ac8733dc63a16940  yarn-offline.tar


### PR DESCRIPTION
CatalogTile components should be direct descendants in the CatalogTileView component.

Updates to patternfly-react-extensions 2.9.1

Fixes #657