### PR TITLE
Adjust overview__main-column width so safari scrollbar isn't positioned over sidebar details

### DIFF
--- a/frontend/public/components/_overview.scss
+++ b/frontend/public/components/_overview.scss
@@ -79,7 +79,10 @@
 
     @media(min-width: $screen-lg-min) {
       .overview__main-column {
-        width: calc(100% - 505px);
+        width: calc(100% - 535px);
+        .co-m-pane__body {
+          padding-right: 0;
+        }
       }
 
       .overview__sidebar {

--- a/frontend/public/components/_project-overview.scss
+++ b/frontend/public/components/_project-overview.scss
@@ -3,9 +3,9 @@
   .project-overview__additional-info {
     align-items: center;
     display: grid;
-    grid-column-gap: 10px;
+    grid-column-gap: 5%;
     grid-template-areas: "alert memory cpu status";
-    grid-template-columns: 20% 20% 20% 40%;
+    grid-template-columns: 16.6% 16.6% 16.6% 35%;
     width: 100%;
   }
 
@@ -77,7 +77,7 @@
       display: none;
       font-family: 'FontAwesome';
       position: absolute;
-      right: 25px;
+      right: 30px;
     }
 
     &--selected::after,
@@ -156,7 +156,7 @@
 
     .project-overview__detail--status {
       // Give enough margin for the chevron.
-      margin-right: 60px;
+      margin-right: 40px;
       text-align: right;
     }
   }
@@ -175,8 +175,9 @@
     }
 
     .project-overview__additional-info {
+      grid-column-gap: 5%;
       grid-template-areas: "alert status";
-      grid-template-columns: 40% 60%;
+      grid-template-columns: 35% 55%;
     }
   }
 }


### PR DESCRIPTION
…
Fixes https://jira.coreos.com/browse/CONSOLE-877

Also, switch grid-column-gap to percentage and adjust grid-area widths totals to 100%
![chevron-scroll-issue](https://user-images.githubusercontent.com/1874151/46980624-1a0b6080-d0a3-11e8-8d8a-8cac40873934.gif)
