### PR TITLE
[WIP] Console extensions using CRDs

### DIFF
--- a/extensions/console-extension.crd.yaml
+++ b/extensions/console-extension.crd.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleextensions.config.openshift.io
+  annotations:
+    displayName: ConsoleExtension
+    description: Extension for configuring openshift web console.
+spec:
+  group: config.openshift.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Cluster
+  names:
+    plural: consoleextensions
+    singular: consoleextension
+    kind: ConsoleExtension
+    listKind: ConsoleExtensionList
+  additionalPrinterColumns:
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Represents console extension spec
+          required:
+          - navExtension
+          - reference
+          - scope
+          properties:
+            navExtension:
+              type: object
+              description: Object that holds navigation bar extensions
+              required:
+                - navSection
+              properties:
+                displayName:
+                  type: string
+                  description: Name of the CRD
+                navSection:
+                  type: string
+                  description: Navigation section where the CRD should be placed
+                  enum:
+                  - Home
+                  - Operators
+                  - Workloads
+                  - Networking
+                  - Storage
+                  - Builds
+                  - Service Catalog
+                  - Monitoring
+                  - Administration
+            reference:
+              type: string
+              description: Reference of the CRD
+            scope:
+              type: string
+              enum:
+              - Namespaced
+              - Cluster

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -239,6 +239,7 @@ class App extends React.PureComponent {
 
 _.each(featureActions, store.dispatch);
 store.dispatch(k8sActions.watchAPIServices());
+store.dispatch(UIActions.setConsoleExtensions());
 store.dispatch(detectMonitoringURLs);
 
 analyticsSvc.push({tier: 'tectonic'});

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -3,11 +3,23 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import { ColHead, List, ListHeader, ListPage } from './factory';
+import { FLAGS } from '../features';
 import { Cog, ResourceCog, ResourceIcon } from './utils';
 import { referenceForCRD } from '../module/k8s';
+import { promoteCrdModal } from './modals';
 
 const { common } = Cog.factory;
-const menuActions = [...common];
+const PromoteCRD = (kind, crd) => ({
+  label: 'Promote Custom Recource Definition',
+  callback: () => promoteCrdModal({
+    title: 'Promote CRD',
+    btnText: 'Promote',
+    kind: kind,
+    crd: crd,
+  }),
+});
+
+const menuActions = FLAGS.CAN_PROMOTE_CRD ? [...common, PromoteCRD] : [...common];
 
 const CRDHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-4 col-md-4 col-sm-4 col-xs-6" sortField="spec.names.kind">Name</ColHead>

--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -1,8 +1,8 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { connect } from 'react-redux';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { fromNow } from './utils/datetime';
 import { referenceFor, kindForReference } from '../module/k8s';
 import { connectToModel } from '../kinds';
 import {
@@ -19,27 +19,58 @@ import {
 const { common } = Cog.factory;
 const menuActions = [...common];
 
-const Header = props => <ListHeader>
-  <ColHead {...props} className="col-xs-6 col-sm-4" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-xs-6 col-sm-4" sortField="metadata.namespace">Namespace</ColHead>
-  <ColHead {...props} className="col-sm-4 hidden-xs" sortField="metadata.creationTimestamp">Created</ColHead>
-</ListHeader>;
+const computeColumnSizes = (columns, isResourceNamespaced) => {
+  const columnsNumber = isResourceNamespaced ? _.size(columns) + 1 : _.size(columns);
+  const columnsSize = Math.floor(12 / columnsNumber);
+  const fistColumnSize = 12 - (columnsSize * (columnsNumber-1));
+  return {
+    fistColumnSize,
+    columnsSize
+  };
+};
 
-const RowForKind = kind => function RowForKind_ ({obj}) {
+const CustomHeader_ = props => {
+  if (!_.get(props, ['resourceTable', 'table'])) {
+    return null;
+  }
+  const { table, isNamespaced } = props.resourceTable;
+  const { fistColumnSize, columnsSize } = computeColumnSizes(table.columnDefinitions, isNamespaced);
+  const heads = _.map(table.columnDefinitions, (column, index) => {
+    const size = index === 0 ? fistColumnSize : columnsSize;
+    return <ColHead key={_.uniqueId()} className={`col-xs-${size}`}>{column.name}</ColHead>;
+  });
+  isNamespaced && heads.splice(1, 0, (<ColHead key={_.uniqueId()} className={`col-xs-${columnsSize}`}>Namespace</ColHead>));
+  return <ListHeader>
+    {heads}
+  </ListHeader>;
+};
+
+const stateToProps = ({UI}) => {
+  const resourceTable = UI.get('resourceTable');
+  return {resourceTable};
+};
+
+const CustomHeader = connect(stateToProps)(CustomHeader_);
+
+const RowForKind = (kind, rows, isNamespaced) => function RowForKind_ ({obj, index}) {
+  if (!rows) {
+    return null;
+  }
+  const rowCells = rows[index].cells;
+  const namespace = _.get(rows[index], ['object', 'metadata', 'namespace']);
+  const { fistColumnSize, columnsSize } = computeColumnSizes(rowCells, isNamespaced);
+  const renderedRows = _.map(rowCells, (column, i) => {
+    if (i === 0 ) {
+      return <div key={_.uniqueId()} className={`col-xs-${fistColumnSize} co-resource-link-wrapper`}>
+        <ResourceCog actions={menuActions} kind={referenceFor(obj) || kind} resource={obj} />
+        <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
+      </div>;
+    }
+    return <div key={_.uniqueId()} className={`col-xs-${columnsSize} co-break-word`}>{column}</div>;
+  });
+  isNamespaced && renderedRows.splice(1, 0, (<div key={_.uniqueId()} className={`col-xs-${columnsSize} co-break-word`}>{namespace}</div>));
   return <div className="row co-resource-list__item">
-    <div className="col-xs-6 col-sm-4 co-resource-link-wrapper">
-      <ResourceCog actions={menuActions} kind={referenceFor(obj) || kind} resource={obj} />
-      <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-    </div>
-    <div className="col-xs-6 col-sm-4 co-break-word">
-      { obj.metadata.namespace
-        ? <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
-        : 'None'
-      }
-    </div>
-    <div className="col-xs-6 col-sm-4 hidden-xs">
-      { fromNow(obj.metadata.creationTimestamp) }
-    </div>
+    {renderedRows}
   </div>;
 };
 
@@ -52,16 +83,24 @@ const DetailsForKind = kind => function DetailsForKind_ ({obj}) {
   </React.Fragment>;
 };
 
-export const DefaultList = props => {
-  const { kinds } = props;
-  const Row = RowForKind(kinds[0]);
+export const DefaultList_ = props => {
+  const { kinds, resourceTable } = props;
+  if (!_.get(resourceTable, 'table')) {
+    return null;
+  }
+  const { table, isNamespaced } = resourceTable;
+  const Row = RowForKind(kinds[0], table.rows, isNamespaced);
   Row.displayName = 'RowForKind';
-  return <List {...props} Header={Header} Row={Row} />;
+  return <List {...props} Header={CustomHeader} Row={Row} />;
 };
+
+const DefaultList = connect(stateToProps)(DefaultList_);
+
 DefaultList.displayName = DefaultList;
 
-export const DefaultPage = props =>
-  <ListPage {...props} ListComponent={DefaultList} canCreate={props.canCreate || _.get(kindObj(props.kind), 'crd')} />;
+export const DefaultPage = props => {
+  return <ListPage {...props} ListComponent={DefaultList} canCreate={props.canCreate || _.get(kindObj(props.kind), 'crd')} />;
+};
 DefaultPage.displayName = 'DefaultPage';
 
 

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -4,8 +4,10 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 import * as PropTypes from 'prop-types';
+import store from '../../redux';
 
 import k8sActions from '../../module/k8s/k8s-actions';
+import { UIActions } from '../../ui/ui-actions';
 import { CheckBoxes, storagePrefix } from '../row-filter';
 import { ErrorPage404 } from '../error';
 import { makeReduxID, makeQuery } from '../utils/k8s-watcher';
@@ -57,6 +59,14 @@ TextFilter.displayName = 'TextFilter';
 
 /** @augments {React.PureComponent<{ListComponent: React.ComponentType<any>, kinds: string[], flatten?: function, data?: any[], rowFilters?: any[]}>} */
 export class ListPageWrapper_ extends React.PureComponent {
+  componentDidMount() {
+    if (!_.isEmpty(this.props.kinds) && _.size(this.props.kinds) === 1) {
+      store.dispatch(UIActions.setTableObject(kindObj(this.props.kinds[0])));
+    }
+  }
+  componentWillUnmount() {
+    store.dispatch(UIActions.unsetTableObject());
+  }
   render () {
     const {kinds, ListComponent, rowFilters, reduxIDs, flatten} = this.props;
     const data = flatten ? flatten(this.props.resources) : [];

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -54,3 +54,6 @@ export const tokenInfoModal = (props) => import('./token-info-modal' /* webpackC
 
 export const deleteModal = (props) => import('./delete-modal' /* webpackChunkName: "delete-modal" */)
   .then(m => m.deleteModal(props));
+
+export const promoteCrdModal = (props) => import('./promote-crd-modal' /* webpackChunkName: "configure-update-strategy-modal" */)
+  .then(m => m.promoteCrdModal(props));

--- a/frontend/public/components/modals/promote-crd-modal.tsx
+++ b/frontend/public/components/modals/promote-crd-modal.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import { FLAGS } from '../../features';
+import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
+import { k8sCreate, referenceForCRD } from '../../module/k8s/';
+import { ConsoleExtensionModel } from '../../models';
+import { PromiseComponent, Dropdown } from '../utils';
+const constructConsoleExtensionInstance = (crd, navSection) => {
+  const displayName = _.get(crd, ['metadata', 'annotations', 'displayName'], crd.spec.names.kind);
+  return {
+    apiVersion: 'config.openshift.io/v1',
+    kind: 'ConsoleExtension',
+    metadata: {
+      name: `${crd.spec.names.singular}-console-extension`
+    },
+    spec: {
+      navExtension: {
+        displayName: displayName,
+        navSection: navSection,
+      },
+      scope: crd.spec.scope,
+      reference: referenceForCRD(crd),
+    }
+  };
+};
+export class PromoteCrdModal extends PromiseComponent {
+  constructor(props) {
+    super(props);
+    this.state = Object.assign(this.state, {
+      section: 'Home',
+      displayName: this.props.crd.spec.names.kind,
+    });
+    this._submit = this._submit.bind(this);
+    this._onSectionChange = this._onSectionChange.bind(this);
+    this._onDisplayNameChange = this._onDisplayNameChange.bind(this);
+  }
+  _submit(event) {
+    event.preventDefault();
+    const consoleExtension = constructConsoleExtensionInstance(this.props.crd, this.state.section);
+    this.handlePromise(k8sCreate(ConsoleExtensionModel, consoleExtension)).then(() => this.props.close());
+  }
+  _onSectionChange(section) {
+    this.setState({
+      section: section
+    });
+  }
+  _onDisplayNameChange(event) {
+    this.setState({
+      displayName: event.target.value
+    });
+  }
+  render() {
+    const sections = ['Home', 'Operators', 'Workloads', 'Networking', 'Storage', 'Builds', 'Service Catalog', 'Monitoring', 'Administration'];
+    const sectionsObject = _.reduce(sections, (acc, section) => {
+      if (section === 'Operators' && !FLAGS.OPERATOR_LIFECYCLE_MANAGER) {
+        return;
+      }
+      if (section === 'Builds' && !FLAGS.OPENSHIFT) {
+        return;
+      }
+      if (section === 'Service Catalog' && !FLAGS.SERVICE_CATALOG) {
+        return;
+      }
+      // TODO -> MONITORING
+      return _.assign(acc, {[section]: section});
+    }, {});
+    return <form onSubmit={this._submit} name="form">
+      <ModalTitle>{this.props.title}</ModalTitle>
+      <ModalBody>
+        <div className="form-group">
+          <label className="control-label" htmlFor="display-name">Display Name</label>
+          <div>
+            <input className="form-control"
+              id="display-name"
+              aria-describedby="display-name-help"
+              type="text"
+              name="display-name"
+              onChange={this._onDisplayNameChange}
+              value={this.state.displayName} />
+            <p className="help-block" id="display-name-help">Name to display <b>{this.props.crd.spec.names.kind}</b> in the navigation bar</p>
+          </div>
+        </div>
+        <div className="form-group">
+          {this.props.message}
+          <label className="control-label" htmlFor="secret-type">Navigation Section</label>.
+          <Dropdown title="Home" items={sectionsObject} dropDownClassName="dropdown--full-width" id="dropdown-selectbox" onChange={this._onSectionChange} />
+          <p className="help-block">Select navigation bar section where the <b>{this.props.crd.spec.names.kind}</b> should be placed.</p>
+        </div>
+      </ModalBody>
+      <ModalSubmitFooter errorMessage={this.state.errorMessage} inProgress={this.state.inProgress} submitText={this.props.btnText || 'Confirm'} cancel={this.props.cancel.bind(this)} />
+    </form>;
+  }
+}
+
+export const promoteCrdModal = createModalLauncher(PromoteCrdModal);

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -33,6 +33,7 @@ const ResourceListPage_ = connectToPlural((props: ResourceListPageProps) => {
   const noProjectsAvailable = !flagPending(flags.PROJECTS_AVAILABLE) && !flags.PROJECTS_AVAILABLE;
   const showGettingStarted = notProjectsListPage && isOpenShift && noProjectsAvailable;
 
+  // const ref = props.match.path.indexOf('customresourcedefinitions') === -1 ? referenceForModel(kindObj) : referenceForCRD(kindObj);
   const ref = props.match.path.indexOf('customresourcedefinitions') === -1 ? referenceForModel(kindObj) : null;
   const componentLoader = resourceListPages.get(ref, () => Promise.resolve(DefaultPage));
 
@@ -57,6 +58,7 @@ export const ResourceDetailsPage = connectToPlural((props: ResourceDetailsPagePr
     return <ErrorPage404 />;
   }
 
+  // const ref = props.match.path.indexOf('customresourcedefinitions') === -1 ? referenceForModel(kindObj) : referenceForCRD(kindObj);
   const ref = props.match.path.indexOf('customresourcedefinitions') === -1 ? referenceForModel(kindObj) : null;
   const componentLoader = props.match.params.appName
     ? () => import('./operator-lifecycle-manager/clusterserviceversion-resource' /* webpackChunkName: "csv-resource" */).then(m => m.ClusterServiceVersionResourcesDetailsPage)

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -26,6 +26,7 @@ import { UIActions } from './ui/ui-actions';
   CAN_LIST_PV: false,
   CAN_LIST_STORE: false,
   CAN_LIST_CRD: false,
+  CAN_PROMOTE_CRD: false,
   CAN_CREATE_PROJECT: false,
   PROJECTS_AVAILABLE: false,
   SERVICE_CATALOG: false,
@@ -44,6 +45,7 @@ export enum FLAGS {
   CAN_LIST_PV = 'CAN_LIST_PV',
   CAN_LIST_STORE = 'CAN_LIST_STORE',
   CAN_LIST_CRD = 'CAN_LIST_CRD',
+  CAN_PROMOTE_CRD = 'CAN_PROMOTE_CRD',
   CAN_CREATE_PROJECT = 'CAN_CREATE_PROJECT',
   PROJECTS_AVAILABLE = 'PROJECTS_AVAILABLE',
   SERVICE_CATALOG = 'SERVICE_CATALOG',
@@ -137,6 +139,7 @@ export let featureActions = [
   [FLAGS.CAN_LIST_PV, { resource: 'persistentvolumes', verb: 'list' }],
   [FLAGS.CAN_LIST_STORE, { group: 'storage.k8s.io', resource: 'storageclasses', verb: 'list' }],
   [FLAGS.CAN_LIST_CRD, { group: 'apiextensions.k8s.io', resource: 'customresourcedefinitions', verb: 'list' }],
+  [FLAGS.CAN_PROMOTE_CRD, { group: 'config.openshift.io', resource: 'consoleextensions', verb: 'create'}],
 ].forEach(_.spread((FLAG, resourceAttributes) => {
   const req = {
     spec: { resourceAttributes }

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -1,6 +1,20 @@
 // eslint-disable-next-line no-unused-vars
 import { K8sKind } from '../module/k8s';
 
+export const ConsoleExtensionModel: K8sKind = {
+  kind:'ConsoleExtension',
+  namespaced: false,
+  label:'Console Extension',
+  plural:'consoleextensions',
+  apiVersion:'v1',
+  abbr:'CE',
+  apiGroup:'config.openshift.io',
+  labelPlural:'Console Extensions',
+  path:'consoleextensions',
+  id:'consoleextension',
+  crd:true
+};
+
 export const CatalogSourceModel: K8sKind = {
   kind: 'CatalogSource',
   label: 'CatalogSource',

--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -2,7 +2,7 @@
 
 import * as _ from 'lodash-es';
 
-import { K8sResourceKindReference, GroupVersionKind, CustomResourceDefinitionKind, K8sResourceKind, K8sKind, OwnerReference } from './index';
+import { K8sResourceKindReference, GroupVersionKind, K8sResourceKind, K8sKind, OwnerReference } from './index';
 
 export const getQN: (obj: K8sResourceKind) => string = ({metadata: {name, namespace}}) => (namespace ? `(${namespace})-` : '') + name;
 
@@ -19,9 +19,11 @@ export const referenceFor = (obj: K8sResourceKind): GroupVersionKind => obj.kind
   ? `${groupVersionFor(obj.apiVersion).group}:${groupVersionFor(obj.apiVersion).version}:${obj.kind}`
   : '';
 
-export const referenceForCRD = (obj: CustomResourceDefinitionKind): GroupVersionKind => (
-  `${obj.spec.group}:${obj.spec.version}:${obj.spec.names.kind}`
-);
+export const referenceForCRD = (obj) => {
+  return obj.apiGroup
+    ? `${obj.apiGroup}:${obj.apiVersion}:${obj.kind}`
+    : `${obj.spec.group}:${obj.spec.version}:${obj.spec.names.kind}`;
+};
 
 export const referenceForOwnerRef = (ownerRef: OwnerReference): GroupVersionKind => (
   `${groupVersionFor(ownerRef.apiVersion).group}:${groupVersionFor(ownerRef.apiVersion).version}:${ownerRef.kind}`

--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -99,6 +99,10 @@ export const k8sList = (kind, params={}, raw=false, options = {}) => {
   return coFetchJSON(`${listURL}?${query}`, 'GET', options).then(result => raw ? result : result.items);
 };
 
+export const k8sListTableColumns = (kind, params = {}, raw = true) => {
+  return k8sList(kind, params, raw, {headers: {Accept: 'application/json;as=Table;v=v1beta1;g=meta.k8s.io,application/json'}});
+};
+
 export const k8sListPartialMetadata = (kind, params = {}, raw = false) => {
   return k8sList(kind, params, raw, {headers: {Accept: 'application/json;as=PartialObjectMetadataList;v=v1beta1;g=meta.k8s.io,application/json'}});
 };

--- a/frontend/public/redux.js
+++ b/frontend/public/redux.js
@@ -15,7 +15,7 @@ const reducers = combineReducers({
   [monitoringReducerName]: monitoringReducer,
 });
 
-const store = createStore(reducers, {}, applyMiddleware(thunk));
+const store = createStore(reducers, window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(), applyMiddleware(thunk));
 export default store;
 
 // eslint-disable-next-line no-undef

--- a/frontend/public/ui/ui-actions.js
+++ b/frontend/public/ui/ui-actions.js
@@ -3,6 +3,9 @@ import { history } from '../components/utils/router';
 import { ALL_NAMESPACES_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY } from '../const';
 import { getNSPrefix } from '../components/utils/link';
 import { allModels } from '../module/k8s/k8s-models';
+import { k8sList, k8sListTableColumns } from '../module/k8s/resource';
+import { ConsoleExtensionModel } from '../models';
+
 
 // URL routes that can be namespaced
 export const namespacedResources = new Set();
@@ -72,6 +75,9 @@ export const types = {
   sortList: 'sortList',
   setCreateProjectMessage: 'setCreateProjectMessage',
   setMonitoringData: 'setMonitoringData',
+  setConsoleExtensions: 'setConsoleExtensions',
+  setTableObject: 'setTableObject',
+  unsetTableObject: 'unsetTableObject',
 };
 
 export const UIActions = {
@@ -155,6 +161,21 @@ export const UIActions = {
   },
 
   [types.setCreateProjectMessage]: message => ({type: types.setCreateProjectMessage, message}),
+
+  [types.setConsoleExtensions]: () => (dispatch) => {
+    k8sList(ConsoleExtensionModel, {}).then((obj) => {
+      dispatch({type: types.setConsoleExtensions, obj});
+    });
+  },
+  [types.setTableObject]: (crdModel) => dispatch => {
+    const activeNamespace = getActiveNamespace();
+    const ns = activeNamespace === ALL_NAMESPACES_KEY ? {} : {ns: activeNamespace};
+    k8sListTableColumns(crdModel, ns).then((table) => {
+      const isNamespaced = crdModel.namespaced;
+      dispatch({type: types.setTableObject, table, isNamespaced});
+    });
+  },
+  [types.unsetTableObject]: () => ({type: types.unsetTableObject}),
 
   monitoringLoading: key => ({type: types.setMonitoringData, key, data: {loaded: false, loadError: null, data: null}}),
 

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -24,7 +24,9 @@ export default (state, action) => {
       activeNavSectionId: 'workloads',
       location: pathname,
       activeNamespace: activeNamespace || 'default',
-      createProjectMessage: ''
+      createProjectMessage: '',
+      consoleExtensions: [],
+      resourceTable: {},
     });
   }
 
@@ -59,7 +61,12 @@ export default (state, action) => {
 
     case types.setMonitoringData:
       return state.setIn(['monitoring', action.key], action.data);
-
+    case types.setConsoleExtensions:
+      return state.set('consoleExtensions', action.obj);
+    case types.setTableObject:
+      return state.set('resourceTable', _.pick(action, ['table', 'isNamespaced']));
+    case types.unsetTableObject:
+      return state.set('resourceTable', {});
     default:
       break;
   }


### PR DESCRIPTION
Story: https://jira.coreos.com/browse/CONSOLE-552

First draft on how the console navigation could be using *ConsoleExtension*(CE) CRD.
ATM the CE is only able to add specific CRD to a one of the navbar sections we have (Home, Workloads, ...). This is being done by "Promoting" the CRD itself.

Workflow:
1. If user is able to create CE CRD he will see the `Promote Custom Resource Definition` option in the cog.
![1](https://user-images.githubusercontent.com/1668218/47006701-d2361900-d136-11e8-9493-5d16f10fc2fc.png)

2. after clicking a Promoting modal will be launched, where user can specify Section where the CRD link will be displayed in the navbar and also displayName (since the CRDs name might not reflekt the name user will want see).
![2](https://user-images.githubusercontent.com/1668218/47006844-26d99400-d137-11e8-804c-14237a183f76.png)

3. The CE CRD is created after the picked CRD is promoted and is will be available in the picked section.
![3](https://user-images.githubusercontent.com/1668218/47006901-4a044380-d137-11e8-9a69-5c1db10644d9.png)

As part of the work I've also redefined which and how data will be rendered in the DefaultResource list page. For that we will be using special [accept header](https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables) that returns listed data in the form of table. This table matches the output of `oc`. This comes in hand since for the unknown CRDs we dont have Header and Row functions defined.
Example of the output for CatalogSources CRD:
![4](https://user-images.githubusercontent.com/1668218/47007315-3c9b8900-d138-11e8-92ae-d29217de67f9.png)
Con of this approach is that the column based sorting is not available since ATM I'm only rendering the table (could be implemented in the future).

Other thing is that in case the response table includes a more columns then we want to render, eg:
![5](https://user-images.githubusercontent.com/1668218/47008295-563dd000-d13a-11e8-8fe4-682352c25fc1.png)

Good thing is that each column also defines it's priority [0-n] so the easiest solution would be to render only columns with priority 0 and let everything else be rendered in the details page. On the other hand there is no upper limit for the columns with priority 0, so we would need to determine number of rendered columns based on the screen width probably.

Could someone from @openshift/team-ux-review please take a look on the screen so we can iterate on the design ?

@spadgett @rhamilto PTAL 
  