### PR TITLE
[WIP] From catalog, display create forms in overlay if not mobile

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,7 @@
     "lodash-es": "4.x",
     "openshift-logos-icon": "1.7.1",
     "patternfly": "^3.54.8",
-    "patternfly-react": "^2.16.0",
+    "patternfly-react": "^2.18.0",
     "patternfly-react-extensions": "2.9.1",
     "plotly.js": "1.28.x",
     "prop-types": "15.6.x",

--- a/frontend/public/components/_catalog.scss
+++ b/frontend/public/components/_catalog.scss
@@ -94,6 +94,18 @@ $catalog-item-icon-size-sm: 24px;
     padding: 0 0 20px;
   }
 
+  &__overlay {
+    .modal-body {
+      flex: 1 1 auto;
+      overflow-y: auto;
+      padding: 0;
+    }
+    .modal-content {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+
   &__tabs {
     flex: 0 0 170px;
     margin: 0 ($grid-gutter-width / 2) 0 0;

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -32,7 +32,7 @@ const PARAMETERS_SECRET_KEY = 'parameters';
 
 const getAvailablePlans = (plans: any): any[] => _.reject(plans.data, 'status.removedFromBrokerCatalog');
 
-class CreateInstance extends React.Component<CreateInstanceProps, CreateInstanceState> {
+export class CreateInstance extends React.Component<CreateInstanceProps, CreateInstanceState> {
   constructor (props) {
     super(props);
 

--- a/frontend/public/components/source-to-image.tsx
+++ b/frontend/public/components/source-to-image.tsx
@@ -70,7 +70,7 @@ const ImageStreamInfo: React.SFC<ImageStreamInfoProps> = ({imageStream, tag}) =>
   </div>;
 };
 
-class BuildSource extends React.Component<BuildSourceProps, BuildSourceState> {
+export class BuildSource extends React.Component<BuildSourceProps, BuildSourceState> {
   constructor (props) {
     super(props);
 

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -46,3 +46,4 @@
 @import '~patternfly/dist/sass/patternfly/blank-slate';
 @import '~patternfly/dist/sass/patternfly/list-view';
 @import '~patternfly/dist/sass/patternfly/popovers';
+@import '~patternfly-react/dist/sass/modeless-overlay';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8158,15 +8158,15 @@ patternfly-react-extensions@2.9.1:
     patternfly "^3.52.1"
     patternfly-react "^2.21.0"
 
-patternfly-react@^2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.16.0.tgz#5268662e2a7e795e63467e3ccdff3005eef2a67b"
+patternfly-react@^2.18.0:
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.21.2.tgz#69f6611c08cc97e9f0ee750a738c6d27cbfbc3be"
   dependencies:
     bootstrap-slider-without-jquery "^10.0.0"
     breakjs "^1.0.0"
     classnames "^2.2.5"
     css-element-queries "^1.0.1"
-    patternfly "^3.52.1"
+    patternfly "^3.52.4"
     react-bootstrap "^0.32.1"
     react-bootstrap-switch "^15.5.3"
     react-bootstrap-typeahead "^3.1.3"


### PR DESCRIPTION
Proof of concept (i.e., not review or merge ready) for putting the existing create source-to-image and create instance forms in an overlay for the purposes of exploring the interactions and surfacing any issues.

Known issues:
* PatternFly-React [Modal](http://patternfly-react.surge.sh/patternfly-3/index.html?knob-Size=default&knob-Right%20Side=true&selectedKind=patternfly-react%2FForms%20and%20Controls%2FModal%20Overlay&selectedStory=Modal&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs) has a few limitations/areas for improvement:
   * Scrolling within the modal is not enabled.
   * Even at its largest size, the modal feels too narrow and wide viewports [1].
   * The modal slide in animation feels a bit slow to me.  @sg00dwin, remind me what the recommended time amount is for such animation?  I know you'd researched this the last time around.
* This PR simply leverages the existing forms, which results in a couple of issues/deviations from the design:
   * The design specifies creation as a two step process (preview the item, then click through to a create form), but the preview and form are not broken out in to separate steps.
   * The `Create` and `Cancel` buttons redirect to the incorrect URLs.
 
[1] 
![1800px](https://user-images.githubusercontent.com/895728/47029482-a5373580-d139-11e8-8acc-25090e42f27d.png)
