### PR TITLE
Generate unique IDs for alerting rules

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,6 +64,7 @@
     "js-base64": "^2.4.5",
     "js-yaml": "3.x",
     "lodash-es": "4.x",
+    "murmurhash-js": "1.0.x",
     "openshift-logos-icon": "1.7.1",
     "patternfly": "^3.45.0",
     "patternfly-react": "^2.16.0",

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -205,7 +205,7 @@ class App extends React.PureComponent {
             <Redirect from="/monitoring" exact to="/monitoring/alerts" />
             <Route path="/monitoring/alerts" exact component={AlertsPage} />
             <Route path="/monitoring/alerts/:name" exact component={AlertsDetailsPage} />
-            <Route path="/monitoring/alertrules/:name" exact component={AlertRulesDetailsPage} />
+            <Route path="/monitoring/alertrules/:id" exact component={AlertRulesDetailsPage} />
             <Route path="/monitoring/silences" exact component={SilencesPage} />
             <Route path="/monitoring/silences/new" exact component={CreateSilence} />
             <Route path="/monitoring/silences/:id" exact component={SilencesDetailsPage} />

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7336,7 +7336,7 @@ mumath@^3.3.4:
   dependencies:
     almost-equal "^1.1.0"
 
-murmurhash-js@^1.0.0:
+murmurhash-js@1.0.x, murmurhash-js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
 


### PR DESCRIPTION
Alerting rules from Prometheus do not have an ID, so we were using the
name + labels to identify a rule, but that is not actually enough to
uniquely identify rules. Instead, let's use a key generated from enough
rule fields to ensure uniqueness.

Fixes a bug where clicking a link to one rule could take you to the
details page for a different rule with the same name and labels.