### PR TITLE
Service catalog fixes

### DIFF
--- a/frontend/integration-tests/tests/performance.scenario.ts
+++ b/frontend/integration-tests/tests/performance.scenario.ts
@@ -84,6 +84,8 @@ describe('Performance test', () => {
     it(`downloads new bundle for ${routeName}`, async() => {
       await browser.get(`${appHost}/status/all-namespaces`);
       await browser.wait(until.presenceOf(crudView.resourceTitle));
+      // Avoid problems where the Operators nav section appears where Workloads was at the moment the tests try to click.
+      await browser.wait(until.visibilityOf(sidenavView.navSectionFor('Operators')));
       await sidenavView.clickNavLink([route.section, route.name]);
       await crudView.isLoaded();
 

--- a/frontend/integration-tests/tests/service-catalog/service-broker.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-broker.scenario.ts
@@ -28,6 +28,7 @@ describe('Test for Cluster Service Broker', () => {
     await crudView.navTabFor('Service Classes').click();
     await crudView.isLoaded();
 
+    await crudView.filterForName('MongoDB');
     await srvCatalogView.linkForCSC('MongoDB').click();
     await crudView.isLoaded();
 

--- a/frontend/integration-tests/tests/service-catalog/service-broker.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-broker.scenario.ts
@@ -18,7 +18,7 @@ describe('Test for Cluster Service Broker', () => {
     checkErrors();
   });
 
-  it('displays `MongoDB` service class for `template-service-broker`', async() => {
+  it('displays `MariaDB` service class for `template-service-broker`', async() => {
     await sidenavView.clickNavLink(['Service Catalog', 'Service Brokers']);
     await crudView.isLoaded();
 
@@ -28,10 +28,10 @@ describe('Test for Cluster Service Broker', () => {
     await crudView.navTabFor('Service Classes').click();
     await crudView.isLoaded();
 
-    await crudView.filterForName('MongoDB');
-    await srvCatalogView.linkForCSC('MongoDB').click();
+    await crudView.filterForName('MariaDB');
+    await srvCatalogView.linkForCSC('MariaDB').click();
     await crudView.isLoaded();
 
-    expect(crudView.resourceTitle.getText()).toEqual('MongoDB');
+    expect(crudView.resourceTitle.getText()).toEqual('MariaDB');
   });
 });

--- a/frontend/integration-tests/tests/service-catalog/service-catalog.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-catalog.scenario.ts
@@ -31,14 +31,14 @@ describe('Test for existence of Service Catalog nav items', () => {
     expect(crudView.rowForName('template-service-broker').isDisplayed()).toBe(true);
   });
 
-  it('displays `MongoDB` service class', async() => {
+  it('displays `MariaDB` service class', async() => {
     await sidenavView.clickNavLink(['Service Catalog', 'Service Classes']);
     await crudView.isLoaded();
 
-    await crudView.filterForName('MongoDB');
+    await crudView.filterForName('MariaDB');
     await srvCatalogView.cscLinksPresent();
 
-    expect(srvCatalogView.linkForCSC('MongoDB').isDisplayed()).toBe(true);
+    expect(srvCatalogView.linkForCSC('MariaDB').isDisplayed()).toBe(true);
   });
 
   it('initially displays no service instances', async() => {

--- a/frontend/integration-tests/tests/service-catalog/service-class.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-class.scenario.ts
@@ -19,16 +19,16 @@ describe('Test for Cluster Service Class', () => {
     checkErrors();
   });
 
-  it('displays `default` service plan for service class `MongoDB`', async() => {
+  it('displays `default` service plan for service class `MariaDB`', async() => {
     await sidenavView.clickNavLink(['Service Catalog', 'Service Classes']);
     await crudView.isLoaded();
 
     // Filter by service class name to make sure it is on the first page of results.
     // Otherwise the tests fail since we do virtual scrolling and the element isn't found.
-    await crudView.filterForName('MongoDB');
+    await crudView.filterForName('MariaDB');
     await srvCatalogView.cscLinksPresent();
 
-    await srvCatalogView.linkForCSC('MongoDB').click();
+    await srvCatalogView.linkForCSC('MariaDB').click();
     await crudView.isLoaded();
 
     await crudView.navTabFor('Service Plans').click();
@@ -40,17 +40,17 @@ describe('Test for Cluster Service Class', () => {
     expect(crudView.resourceTitle.getText()).toEqual('default');
   });
 
-  it('creates a new instance for service class `MongoDB`', async() => {
+  it('creates a new instance for service class `MariaDB`', async() => {
     await sidenavView.clickNavLink(['Service Catalog', 'Service Classes']);
     await crudView.isLoaded();
 
     // Filter by service class name to make sure it is on the first page of results.
     // Otherwise the tests fail since we do virtual scrolling and the element isn't found.
-    await crudView.filterForName('MongoDB');
+    await crudView.filterForName('MariaDB');
     await srvCatalogView.cscLinksPresent();
-    expect(srvCatalogView.linkForCSC('MongoDB').isPresent()).toBe(true);
+    expect(srvCatalogView.linkForCSC('MariaDB').isPresent()).toBe(true);
 
-    await srvCatalogView.linkForCSC('MongoDB').click();
+    await srvCatalogView.linkForCSC('MariaDB').click();
     await crudView.isLoaded();
 
     expect(srvCatalogView.createInstanceButton.isDisplayed()).toBe(true);
@@ -63,8 +63,8 @@ describe('Test for Cluster Service Class', () => {
     await srvCatalogView.createButton.click();
     await crudView.isLoaded();
 
-    expect(crudView.resourceTitle.getText()).toEqual('mongodb-persistent');
+    expect(crudView.resourceTitle.getText()).toEqual('mariadb-persistent');
 
-    execSync(`kubectl delete -n ${testName} serviceinstance mongodb-persistent`);
+    execSync(`kubectl delete -n ${testName} serviceinstance mariadb-persistent`);
   });
 });

--- a/frontend/integration-tests/views/service-catalog.view.ts
+++ b/frontend/integration-tests/views/service-catalog.view.ts
@@ -1,10 +1,8 @@
 /* eslint-disable no-undef, no-unused-vars */
 
-import {browser, $, ExpectedConditions as until, $$, by} from 'protractor';
+import {browser, $, ExpectedConditions as until, by, element} from 'protractor';
 
-const cscLinks = $$('.co-cluster-service-class-link');
-
-export const linkForCSC = (name: string) => cscLinks.filter((row) => row.getText().then(text => text === name)).first();
+export const linkForCSC = (name: string) => element(by.linkText(name));
 export const cscLinksPresent = () => browser.wait(until.presenceOf($('.co-cluster-service-class-link')), 10000);
 
 export const createInstanceButton = $('.btn-primary.co-action-buttons__btn');

--- a/frontend/integration-tests/views/sidenav.view.ts
+++ b/frontend/integration-tests/views/sidenav.view.ts
@@ -1,11 +1,8 @@
 /* eslint-disable no-undef, no-unused-vars */
 
-import { $$, by, browser, ExpectedConditions as until } from 'protractor';
+import { $$, by, browser, element, ExpectedConditions as until } from 'protractor';
 
-export const navSections = $$('.navigation-container__section:not(.navigation-container__section--cluster-picker)');
-
-export const navSectionFor = (name: string) => navSections.filter((_, i) => $$('.navigation-container__section__title').get(i).getText()
-  .then(text => text === name)).first();
+export const navSectionFor = (name: string) => element(by.cssContainingText('.navigation-container__section:not(.navigation-container__section--cluster-picker)', name));
 
 export const clickNavLink = (path: [string, string]) => browser.wait(until.visibilityOf(navSectionFor(path[0])))
   .then(() => navSectionFor(path[0]).click())

--- a/frontend/public/components/catalog.jsx
+++ b/frontend/public/components/catalog.jsx
@@ -58,8 +58,9 @@ class CatalogListPage extends React.Component {
 
   normalizeClusterServiceClasses(serviceClasses, kind) {
     const {namespace = ''} = this.props;
-    const activeServiceClasses = _.filter(serviceClasses, serviceClass => {
-      return !serviceClass.status.removedFromBrokerCatalog;
+    const activeServiceClasses = _.reject(serviceClasses, serviceClass => {
+      const tags = _.get(serviceClass, 'spec.tags');
+      return serviceClass.status.removedFromBrokerCatalog || _.includes(tags, 'hidden');
     });
 
     return _.map(activeServiceClasses, serviceClass => {

--- a/frontend/public/components/cluster-service-broker.tsx
+++ b/frontend/public/components/cluster-service-broker.tsx
@@ -71,6 +71,7 @@ const ClusterServiceBrokerDetails: React.SFC<ClusterServiceBrokerDetailsProps> =
   </React.Fragment>;
 };
 
+const ServiceClassTabPage = ({obj}) => <ClusterServiceClassPage showTitle={false} fieldSelector={`spec.clusterServiceBrokerName=${obj.metadata.name}`} />;
 export const ClusterServiceBrokerDetailsPage: React.SFC<ClusterServiceBrokerDetailsPageProps> = props => <DetailsPage
   {...props}
   kind={ClusterServiceBrokerReference}
@@ -78,8 +79,7 @@ export const ClusterServiceBrokerDetailsPage: React.SFC<ClusterServiceBrokerDeta
   pages={[
     navFactory.details(detailsPage(ClusterServiceBrokerDetails)),
     navFactory.editYaml(),
-    navFactory.clusterServiceClasses(({obj}) => <ClusterServiceClassPage showTitle={false}
-      fieldSelector={`spec.clusterServiceBrokerName=${obj.metadata.name}`} />)
+    navFactory.clusterServiceClasses(ServiceClassTabPage),
   ]}
 />;
 export const ClusterServiceBrokerList: React.SFC = props => <List {...props} Header={ClusterServiceBrokerHeader} Row={ClusterServiceBrokerListRow} />;


### PR DESCRIPTION
* Fix filtering on service classes tab of broker page
* Hide service classes with `hidden` tag
* Fix integration test errors when there are too many templates
* Fix StaleElementReferenceError in service catalog tests

Fixes https://jira.coreos.com/browse/CONSOLE-931
Fixes https://jira.coreos.com/browse/CONSOLE-923

/assign @dtaylor113 
@kyoto fyi