### PR TITLE
Add the environment variables editor to Deploy Image creation

### DIFF
--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -58,7 +58,7 @@ export const NameValueEditor = withDragDropContext(class NameValueEditor extends
   }
 
   render () {
-    const {nameString, valueString, addString, nameValuePairs, allowSorting, readOnly, nameValueId, configMaps, secrets, envFrom} = this.props;
+    const {nameString, valueString, addString, nameValuePairs, allowSorting, readOnly, nameValueId, configMaps, secrets, addConfigMapSecret} = this.props;
     const pairElems = nameValuePairs.map((pair, i) => {
       const key = _.get(pair, [NameValueEditorPair.Index], i);
 
@@ -82,7 +82,7 @@ export const NameValueEditor = withDragDropContext(class NameValueEditor extends
                   <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />{addString}
                 </button>
                 {
-                  allowSorting && !envFrom &&
+                  addConfigMapSecret &&
                     <React.Fragment>
                       <span aria-hidden="true" className="co-action-divider hidden-xs">|</span>
                       <button type="button" className="btn btn-link" onClick={this._appendConfigMapOrSecret}>
@@ -114,7 +114,7 @@ NameValueEditor.propTypes = {
   updateParentData: PropTypes.func.isRequired,
   configMaps: PropTypes.object,
   secrets: PropTypes.object,
-  envFrom: PropTypes.bool
+  addConfigMapSecret: PropTypes.bool,
 };
 NameValueEditor.defaultProps = {
   nameString: 'Key',
@@ -123,7 +123,7 @@ NameValueEditor.defaultProps = {
   allowSorting: false,
   readOnly: false,
   nameValueId: 0,
-  envFrom: false
+  addConfigMapSecret: false,
 };
 
 NameValueEditor.displayName = 'Name Value Editor';


### PR DESCRIPTION
Add env editor to deploy-image page.

Question @spadgett, @rhamilto: How would you like to handle changes in Namespace after the editor appears. The config maps and secrets are usually loaded based on Namespace in the editor, so currently no filtering is done and all are available. Do we want the Namespace to cause an event to update the config map/secret choices and if so what happens to entries already created? Are you ok with showing all of them? Should the Namespace change cause a reset and rerender of the current editor?

When referencing the previous implementation, I noted that only env variables were available, so envFrom vars are intentionally not available. Assuming thats correct :) should the Single Values `<h3>` element be removed or should envFrom actually be included along with both sub headings?

@openshift/team-ux-review

![env-deployimage](https://user-images.githubusercontent.com/35978579/47260858-5539d500-d491-11e8-8a6c-764f2eb5d9cf.gif)

<img width="1223" alt="screen shot 2018-10-20 at 5 52 32 pm" src="https://user-images.githubusercontent.com/35978579/47260861-5d921000-d491-11e8-8b1a-3f01e736e6ac.png">

Updated screenshot 10/24/2018:
![screen shot 2018-10-24 at 5 05 49 pm](https://user-images.githubusercontent.com/35978579/47461610-2c765000-d7af-11e8-8f9a-d6d7a6f77f24.png)
