### PR TITLE
Add "View Alert Rule" action to monitoring alerts cog and refactoring

### DIFF
--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -34,9 +34,9 @@ const fuzzyCaseInsensitive = (a, b) => fuzzy(_.toLower(a), _.toLower(b));
 const listFilters = {
   'name': (filter, obj) => fuzzyCaseInsensitive(filter, obj.metadata.name),
 
-  'alert-rule-name': (filter, alertRule) => fuzzyCaseInsensitive(filter, alertRule.name),
+  'alert-name': (filter, alert) => fuzzyCaseInsensitive(filter, _.get(alert, 'labels.alertname')),
 
-  'alert-rule-state': (filter, alertRule) => filter.selected.has(alertState(alertRule)),
+  'alert-state': (filter, alert) => filter.selected.has(alertState(alert)),
 
   'silence-name': (filter, silence) => fuzzyCaseInsensitive(filter, silence.name),
 


### PR DESCRIPTION
Add "View Alert Rule" action to alerts cog menu.

Refactor to create a fake inactive alert for rules that are not active,
which means that the alert details page knows it is always dealing with
an alert object, not a rule object.

Refactor to stop taking the alert name from a URL param and take it from
the alertname label instead.