### PR TITLE
Move Alertmanager link from sidebar to top of monitoring pages

### DIFF
--- a/frontend/public/components/_monitoring.scss
+++ b/frontend/public/components/_monitoring.scss
@@ -3,6 +3,10 @@
   justify-content: space-between;
 }
 
+.monitoring-header-link {
+  font-size: 13px;
+}
+
 $monitoring-line-height: 18px;
 
 .monitoring-description, .monitoring-timestamp {

--- a/frontend/public/components/alert.tsx
+++ b/frontend/public/components/alert.tsx
@@ -24,7 +24,6 @@ import {
   ExternalLink,
   getURLSearchParams,
   history,
-  PageHeading,
   SectionHeading,
   StatusBox,
   Timestamp,
@@ -46,6 +45,9 @@ const silenceAction = alert => ({
   label: 'Silence Alert',
   href: `${SilenceResource.path}/new?${labelsToParams(alert.labels)}`,
 });
+
+const AlertmanagerLink_ = ({text, urls}) => <ExternalLink href={urls[MonitoringRoutes.AlertManager]} text={text} />;
+export const AlertmanagerLink = connectToURLs(MonitoringRoutes.AlertManager)(AlertmanagerLink_);
 
 export const MonitoringResourceIcon = props => {
   const {className, resource} = props;
@@ -430,7 +432,13 @@ export const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringL
       <Helmet>
         <title>Monitoring Alerts</title>
       </Helmet>
-      <PageHeading title="Monitoring Alerts" />
+      <div className="co-m-nav-title co-m-nav-title--detail">
+        <h1 className="co-m-pane__heading">
+          <div className="co-m-pane__name">
+            Monitoring Alerts &nbsp;<span className="monitoring-header-link"><AlertmanagerLink text="Alertmanager UI" /></span>
+          </div>
+        </h1>
+      </div>
       <ul className="co-m-horizontal-nav__menu">
         <li className={classNames('co-m-horizontal-nav__menu-item', {'co-m-horizontal-nav-item--active': match.path === AlertResource.path})}>
           <Link to={AlertResource.path}>Alerts</Link>

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -278,13 +278,11 @@ const ClusterPickerNavSection = connectToFlags(FLAGS.OPENSHIFT)(({flags}) => {
 
 const MonitoringNavSection_ = ({urls, closeMenu}) => {
   const prometheusURL = urls[MonitoringRoutes.Prometheus];
-  const alertManagerURL = urls[MonitoringRoutes.AlertManager];
   const grafanaURL = urls[MonitoringRoutes.Grafana];
-  return prometheusURL || alertManagerURL || grafanaURL
+  return prometheusURL || grafanaURL
     ? <NavSection text="Monitoring" icon="pficon pficon-screen">
       {prometheusURL && <HrefLink href="/monitoring" name="Alerts" onClick={closeMenu} />}
       {prometheusURL && <HrefLink href={prometheusURL} target="_blank" name="Metrics" onClick={closeMenu} isExternal={true} />}
-      {alertManagerURL && <HrefLink href={alertManagerURL} target="_blank" name="Alertmanager" onClick={closeMenu} isExternal={true} />}
       {grafanaURL && <HrefLink href={grafanaURL} target="_blank" name="Dashboards" onClick={closeMenu} isExternal={true} />}
     </NavSection>
     : null;

--- a/frontend/public/components/silence.tsx
+++ b/frontend/public/components/silence.tsx
@@ -8,7 +8,7 @@ import { coFetchJSON } from '../co-fetch';
 import { SilenceResource, silenceState } from '../module/monitoring';
 import { MonitoringRoutes, connectToURLs } from '../monitoring';
 import { monitoringAlertsToProps, monitoringSilencesToProps } from '../ui/ui-reducers';
-import { connectMonitoringPage, MonitoringListPage, MonitoringResourceIcon } from './alert';
+import { AlertmanagerLink, connectMonitoringPage, MonitoringListPage, MonitoringResourceIcon } from './alert';
 import { ColHead, ListHeader, ResourceRow } from './factory';
 import { confirmModal } from './modals';
 import { SafetyFirst } from './safety-first';
@@ -17,7 +17,6 @@ import {
   ActionsMenu,
   ButtonBar,
   Cog,
-  ExternalLink,
   getURLSearchParams,
   history,
   SectionHeading,
@@ -174,8 +173,7 @@ const SilenceHeader = props => <ListHeader>
   <ColHead {...props} className="col-xs-2">Silenced Alerts</ColHead>
 </ListHeader>;
 
-const SilencesPageDescription_ = ({urls}) => <p className="co-help-text">Silences are a straightforward way to simply mute alerts for a given time powered by <ExternalLink href={urls[MonitoringRoutes.AlertManager]} text="Alertmanager" /></p>;
-const SilencesPageDescription = connectToURLs(MonitoringRoutes.AlertManager)(SilencesPageDescription_);
+const SilencesPageDescription = () => <p className="co-help-text">Silences are a straightforward way to simply mute alerts for a given time powered by <AlertmanagerLink text="Alertmanager" /></p>;
 
 const silencesRowFilter = {
   type: 'silence-state',


### PR DESCRIPTION
### Before
![screenshot-2](https://user-images.githubusercontent.com/460802/47285328-78958900-d625-11e8-9cc3-f5d95a64cb74.png)

### After
![screenshot-1](https://user-images.githubusercontent.com/460802/47285332-7c291000-d625-11e8-9fab-6489927e6426.png)
