### PR TITLE
OLM ClusterServiceVersion View Improvements

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
@@ -5,7 +5,7 @@ import { match as RouterMatch } from 'react-router-dom';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash-es';
 
-import { ClusterServiceVersionResourceList, ClusterServiceVersionResourceListProps, ClusterServiceVersionResourcesPage, ClusterServiceVersionResourcesPageProps, ClusterServiceVersionResourceHeaderProps, ClusterServiceVersionResourcesDetailsState, ClusterServiceVersionResourceRowProps, ClusterServiceVersionResourceHeader, ClusterServiceVersionResourceRow, ClusterServiceVersionResourceDetails, ClusterServiceVersionResourcesDetailsPageProps, ClusterServiceVersionResourcesDetailsProps, ClusterServiceVersionResourcesDetailsPage, ClusterServiceVersionResourceLink } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion-resource';
+import { ClusterServiceVersionResourceList, ClusterServiceVersionResourceListProps, ProvidedAPIsPage, ProvidedAPIsPageProps, ClusterServiceVersionResourceHeaderProps, ClusterServiceVersionResourcesDetailsState, ClusterServiceVersionResourceRowProps, ClusterServiceVersionResourceHeader, ClusterServiceVersionResourceRow, ClusterServiceVersionResourceDetails, ClusterServiceVersionResourcesDetailsPageProps, ClusterServiceVersionResourcesDetailsProps, ClusterServiceVersionResourcesDetailsPage, ClusterServiceVersionResourceLink } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion-resource';
 import { Resources } from '../../../public/components/operator-lifecycle-manager/k8s-resource';
 import { ClusterServiceVersionResourceKind, referenceForCRDDesc } from '../../../public/components/operator-lifecycle-manager';
 import { StatusDescriptor } from '../../../public/components/operator-lifecycle-manager/descriptors/status';
@@ -294,7 +294,7 @@ describe(ClusterServiceVersionResourcesDetailsPage.displayName, () => {
 
   it('passes function to create breadcrumbs for resource to `DetailsPage`', () => {
     expect(wrapper.find(DetailsPage).props().breadcrumbsFor(null)).toEqual([
-      {name: 'etcd', path: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/etcd/instances`},
+      {name: 'etcd', path: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/etcd/etcdclusters`},
       {name: `${testResourceInstance.kind} Details`, path: `/k8s/ns/default/${ClusterServiceVersionModel.plural}/etcd/etcdclusters/my-etcd`},
     ]);
   });
@@ -305,7 +305,7 @@ describe(ClusterServiceVersionResourcesDetailsPage.displayName, () => {
     wrapper.setProps({match});
 
     expect(wrapper.find(DetailsPage).props().breadcrumbsFor(null)).toEqual([
-      {name: 'example', path: `/k8s/ns/${ClusterServiceVersionModel.plural}/example/example/instances`},
+      {name: 'example', path: `/k8s/ns/${ClusterServiceVersionModel.plural}/example/example`},
       {name: `${testResourceInstance.kind} Details`, path: `/k8s/ns/${ClusterServiceVersionModel.plural}/example/example/example`},
     ]);
   });
@@ -344,11 +344,11 @@ describe(ClusterServiceVersionResourcesDetailsPage.displayName, () => {
   });
 });
 
-describe(ClusterServiceVersionResourcesPage.displayName, () => {
-  let wrapper: ShallowWrapper<ClusterServiceVersionResourcesPageProps>;
+describe(ProvidedAPIsPage.displayName, () => {
+  let wrapper: ShallowWrapper<ProvidedAPIsPageProps>;
 
   beforeEach(() => {
-    wrapper = shallow(<ClusterServiceVersionResourcesPage.WrappedComponent obj={testClusterServiceVersion} />);
+    wrapper = shallow(<ProvidedAPIsPage.WrappedComponent obj={testClusterServiceVersion} />);
   });
 
   it('renders a `StatusBox` if given app has no owned or required custom resources', () => {

--- a/frontend/integration-tests/tests/olm/descriptors.scenario.ts
+++ b/frontend/integration-tests/tests/olm/descriptors.scenario.ts
@@ -152,7 +152,7 @@ describe('Using OLM descriptor components', () => {
     execSync(`echo '${JSON.stringify(testCSV)}' | kubectl create -f -`);
     execSync(`echo '${JSON.stringify(testCR)}' | kubectl create -f -`);
 
-    await browser.get(`${appHost}/ns/${testName}/clusterserviceversions/${testCSV.metadata.name}/instances`);
+    await browser.get(`${appHost}/ns/${testName}/clusterserviceversions/${testCSV.metadata.name}/${testCRD.spec.group}~${testCRD.spec.version}~${testCRD.spec.names.kind}`);
     await crudView.isLoaded();
   });
 

--- a/frontend/integration-tests/tests/olm/etcd.scenario.ts
+++ b/frontend/integration-tests/tests/olm/etcd.scenario.ts
@@ -75,14 +75,16 @@ describe('Interacting with the etcd OCS', () => {
     await crudView.rowForOperator('etcd').$('.co-clusterserviceversion-logo').click();
     await browser.wait(until.presenceOf($('.loading-box__loaded')), 5000);
 
-    expect($('.co-clusterserviceversion-details__section--info').isDisplayed()).toBe(true);
-    expect($('.co-clusterserviceversion-details__section--description').isDisplayed()).toBe(true);
+    expect($('.co-m-pane__details').isDisplayed()).toBe(true);
   });
 
-  it('displays empty message in the "Instances" section', async() => {
-    await element(by.linkText('Instances')).click();
+  it('displays empty message in the "All Instances" section', async() => {
+    await element(by.linkText('All Instances')).click();
     await crudView.isLoaded();
 
+    expect(crudView.rowFilterFor('EtcdCluster').isDisplayed()).toBe(true);
+    expect(crudView.rowFilterFor('EtcdBackup').isDisplayed()).toBe(true);
+    expect(crudView.rowFilterFor('EtcdRestore').isDisplayed()).toBe(true);
     expect(crudView.statusMessageTitle.getText()).toEqual('No Application Resources Found');
     expect(crudView.statusMessageDetail.getText()).toEqual('Application resources are declarative components used to define the behavior of the application.');
   });
@@ -106,7 +108,6 @@ describe('Interacting with the etcd OCS', () => {
     await crudView.isLoaded();
     await browser.wait(until.visibilityOf(crudView.rowForName(etcdcluster)));
 
-    expect(crudView.rowFilters.count()).toEqual(3);
     expect(crudView.rowForName(etcdcluster).getText()).toContain('EtcdCluster');
   });
 
@@ -138,7 +139,9 @@ describe('Interacting with the etcd OCS', () => {
   it('displays YAML editor for creating a new `EtcdBackup` instance', async() => {
     await $$('.breadcrumb-link').get(0).click();
     await crudView.isLoaded();
-    await $$('.dropdown').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
+    await element(by.linkText('All Instances')).click();
+    await browser.wait(until.visibilityOf(element(by.buttonText('Create New'))));
+    await element(by.buttonText('Create New')).click();
     await browser.wait(until.visibilityOf($$('.dropdown-menu').first()), 1000);
     await $$('.dropdown-menu').first().element(by.linkText('etcd Backup')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -155,7 +158,6 @@ describe('Interacting with the etcd OCS', () => {
     await crudView.isLoaded();
     await browser.wait(until.visibilityOf(crudView.rowForName(etcdbackup)));
 
-    expect(crudView.rowFilters.count()).toEqual(3);
     expect(crudView.rowForName(etcdbackup).getText()).toContain('EtcdBackup');
   });
 
@@ -187,7 +189,9 @@ describe('Interacting with the etcd OCS', () => {
   it('displays YAML editor for creating a new `EtcdRestore` instance', async() => {
     await $$('.breadcrumb-link').get(0).click();
     await crudView.isLoaded();
-    await $$('.dropdown').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
+    await element(by.linkText('All Instances')).click();
+    await browser.wait(until.visibilityOf(element(by.buttonText('Create New'))));
+    await element(by.buttonText('Create New')).click();
     await browser.wait(until.visibilityOf($$('.dropdown-menu').first()), 1000);
     await $$('.dropdown-menu').first().element(by.linkText('etcd Restore')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -204,7 +208,6 @@ describe('Interacting with the etcd OCS', () => {
     await crudView.isLoaded();
     await browser.wait(until.visibilityOf(crudView.rowForName(etcdrestore)));
 
-    expect(crudView.rowFilters.count()).toEqual(3);
     expect(crudView.rowForName(etcdrestore).getText()).toContain('EtcdRestore');
   });
 

--- a/frontend/integration-tests/tests/olm/prometheus.scenario.ts
+++ b/frontend/integration-tests/tests/olm/prometheus.scenario.ts
@@ -74,17 +74,17 @@ describe('Interacting with the Prometheus OCS', () => {
     await crudView.rowForOperator('Prometheus Operator').$('.co-clusterserviceversion-logo').click();
     await browser.wait(until.presenceOf($('.loading-box__loaded')), 5000);
 
-    expect($('.co-clusterserviceversion-details__section--info').isDisplayed()).toBe(true);
-    expect($('.co-clusterserviceversion-details__section--description').isDisplayed()).toBe(true);
+    expect($('.co-m-pane__details').isDisplayed()).toBe(true);
   });
 
-  it('displays empty message in the "Instances" section', async() => {
-    await element(by.linkText('Instances')).click();
+  it('displays empty message in the "All Instances" section', async() => {
+    await element(by.linkText('All Instances')).click();
     await crudView.isLoaded();
 
     expect(crudView.rowFilterFor('Prometheus').isDisplayed()).toBe(true);
     expect(crudView.rowFilterFor('Alertmanager').isDisplayed()).toBe(true);
     expect(crudView.rowFilterFor('ServiceMonitor').isDisplayed()).toBe(true);
+    expect(crudView.rowFilterFor('PrometheusRule').isDisplayed()).toBe(true);
     expect(crudView.statusMessageTitle.getText()).toEqual('No Application Resources Found');
     expect(crudView.statusMessageDetail.getText()).toEqual('Application resources are declarative components used to define the behavior of the application.');
   });
@@ -104,7 +104,7 @@ describe('Interacting with the Prometheus OCS', () => {
     await crudView.isLoaded();
     await browser.wait(until.visibilityOf(crudView.rowForName('example')));
 
-    expect(crudView.rowFilterFor('Prometheus').$('.row-filter--number-bubble').getText()).toEqual('1');
+    expect(crudView.rowForName('example').getText()).toContain('Prometheus');
   });
 
   it('displays metadata about the created `Prometheus` in its "Overview" section', async() => {
@@ -135,7 +135,9 @@ describe('Interacting with the Prometheus OCS', () => {
   it('displays YAML editor for creating a new `Alertmanager` instance', async() => {
     await $$('.breadcrumb-link').first().click();
     await crudView.isLoaded();
-    await $$('.dropdown').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
+    await element(by.linkText('All Instances')).click();
+    await browser.wait(until.visibilityOf(element(by.buttonText('Create New'))));
+    await element(by.buttonText('Create New')).click();
     await browser.wait(until.visibilityOf($$('.dropdown-menu').first()), 1000);
     await $$('.dropdown-menu').first().element(by.linkText('Alertmanager')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -148,7 +150,6 @@ describe('Interacting with the Prometheus OCS', () => {
     await crudView.isLoaded();
     await browser.wait(until.visibilityOf(crudView.rowForName('alertmanager-main')));
 
-    expect(crudView.rowFilterFor('Alertmanager').$('.row-filter--number-bubble').getText()).toEqual('1');
     expect(crudView.rowForName('alertmanager-main').getText()).toContain('Alertmanager');
   });
 
@@ -180,7 +181,9 @@ describe('Interacting with the Prometheus OCS', () => {
   it('displays YAML editor for creating a new `ServiceMonitor` instance', async() => {
     await $$('.breadcrumb-link').first().click();
     await crudView.isLoaded();
-    await $$('.dropdown').filter(btn => btn.getText().then(text => text.startsWith('Create New'))).first().click();
+    await element(by.linkText('All Instances')).click();
+    await browser.wait(until.visibilityOf(element(by.buttonText('Create New'))));
+    await element(by.buttonText('Create New')).click();
     await browser.wait(until.visibilityOf($$('.dropdown-menu').first()), 1000);
     await $$('.dropdown-menu').first().element(by.linkText('Service Monitor')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')), 10000);
@@ -193,7 +196,7 @@ describe('Interacting with the Prometheus OCS', () => {
     await crudView.isLoaded();
     await browser.wait(until.visibilityOf(crudView.rowForName('example')));
 
-    expect(crudView.rowFilterFor('ServiceMonitor').$('.row-filter--number-bubble').getText()).toEqual('1');
+    expect(crudView.rowForName('example').getText()).toContain('ServiceMonitor');
   });
 
   it('displays metadata about the created `ServiceMonitor` in its "Overview" section', async() => {

--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -9,14 +9,35 @@ $co-m-horizontal-nav__menu-item-link-padding-lr-mobile: 15px;
 .co-m-horizontal-nav__menu {
   border-bottom: 1px solid $color-grey-background-border;
   display: flex;
-  flex-wrap: wrap;
   list-style: none;
   margin: 0;
   padding: 0;
+  white-space: nowrap;
   @media (min-width: $grid-float-breakpoint) {
     margin-left: (-$co-m-horizontal-nav__menu-item-link-padding-lr-desktop);
     padding: 0 30px;
   }
+}
+
+.co-m-horizontal-nav__menu__primary {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.co-m-horizontal-nav__menu__secondary {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  overflow-x: auto;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.co-m-horizontal-nav__menu__secondary::-webkit-scrollbar {
+  display: none;
 }
 
 .co-m-horizontal-nav__menu-item {

--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -5,7 +5,7 @@ import { Timestamp } from './utils';
 import { CamelCaseWrap } from './utils/camel-case-wrap';
 
 export const Conditions: React.SFC<ConditionsProps> = ({conditions}) => {
-  const rows = _.map(conditions, condition => <div className="row" key={condition.type}>
+  const rows = _.map(conditions, condition => <div className="row" key={JSON.stringify(condition)}>
     <div className="col-xs-4 col-sm-2 col-md-2">
       <CamelCaseWrap value={condition.type} />
     </div>

--- a/frontend/public/components/create-yaml.tsx
+++ b/frontend/public/components/create-yaml.tsx
@@ -36,7 +36,7 @@ export const CreateYAML = connectToPlural((props: CreateYAMLProps) => {
   }
 
   // TODO: if someone edits namespace, we'll redirect to old namespace
-  const redirectURL = params.appName ? `/k8s/ns/${namespace}/${ClusterServiceVersionModel.plural}/${params.appName}/instances` : null;
+  const redirectURL = params.appName ? `/k8s/ns/${namespace}/${ClusterServiceVersionModel.plural}/${params.appName}/${referenceForModel(kindObj)}` : null;
 
   return <AsyncComponent loader={() => import('./edit-yaml').then(c => c.EditYAML)} obj={obj} create={true} kind={kindObj.kind} redirectURL={redirectURL} showHeader={showHeader} />;
 });

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -35,11 +35,18 @@ export const DetailsPage: React.SFC<DetailsPageProps> = (props) => <Firehose res
     breadcrumbsFor={props.breadcrumbsFor} />
   <HorizontalNav
     pages={props.pages}
+    pagesFor={props.pagesFor}
     className={`co-m-${_.get(props.kind, 'kind', props.kind)}`}
     match={props.match}
     label={props.label || (props.kind as any).label}
     resourceKeys={_.map(props.resources, 'prop')} />
 </Firehose>;
+
+type Page = {
+  href: string;
+  name: string;
+  component?: React.ComponentType<any>;
+};
 
 export type DetailsPageProps = {
   match: match<any>;
@@ -47,7 +54,8 @@ export type DetailsPageProps = {
   titleFunc?: (obj: K8sResourceKind) => string | JSX.Element;
   menuActions?: any[];
   buttonActions?: any[];
-  pages: any[];
+  pages?: Page[];
+  pagesFor?: (obj: K8sResourceKind) => Page[];
   kind: K8sResourceKindReference;
   label?: string;
   name?: string;

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -267,7 +267,7 @@ FireMan_.propTypes = {
   title: PropTypes.string,
 };
 
-/** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, namespace?: string, filterLabel?: string, textFilter?: string, title?: string, showTitle?: boolean, dropdownFilters?: any[], rowFilters?: any[], selector?: any, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, mock?: boolean}>} */
+/** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, helpText?: any, namespace?: string, filterLabel?: string, textFilter?: string, title?: string, showTitle?: boolean, dropdownFilters?: any[], rowFilters?: any[], selector?: any, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, mock?: boolean}>} */
 export const ListPage = props => {
   const {
     autoFocus,

--- a/frontend/public/components/operator-lifecycle-manager/_operator-lifecycle-manager.scss
+++ b/frontend/public/components/operator-lifecycle-manager/_operator-lifecycle-manager.scss
@@ -1,36 +1,11 @@
-$clusterserviceversion-list-border: #ccc;
-
 .co-clusterserviceversion-list {
   display: flex;
   flex-wrap: wrap;
   margin: 0 -7.5px 0;
 }
 
-.co-clusterserviceversion-list__tile {
-  padding: 0 7.5px 15px;
-  width: 100%;
-  @media (min-width: $screen-sm) {
-    width: 50%;
-  }
-  @media (min-width: $screen-md) {
-    width: 33.333%;
-  }
-  @media (min-width: 1920px) {
-    width: 25%;
-  }
-}
-
-.co-clusterserviceversion-list-item {
-  border: 1px solid $clusterserviceversion-list-border;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: 20px;
-  height: 200px;
-}
-
-.co-clusterserviceversion-list-item--error {
-  border: 1px solid #dd1326;
+.co-clusterserviceversion-details__field {
+  padding-bottom: 10px;
 }
 
 .co-clusterserviceversion-logo {
@@ -67,17 +42,42 @@ $clusterserviceversion-list-border: #ccc;
   font-size: 13px;
 }
 
-.co-clusterserviceversion-list-item__actions {
-  align-items: center;
+.co-crd-card-row {
   display: flex;
-  justify-content: space-between;
+  flex-wrap: wrap;
+  margin-bottom: 15px;
 }
 
-.co-clusterserviceversion-list-item__description {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  padding: 10px 0;
+.co-crd-card {
+  border: 1px solid rgba(209,209,209,0.75);
+  box-shadow: 0 1px 1px rgba(3,3,3,0.175);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0 15px;
+  max-width: 300px;
+  min-width: 300px;
+  margin: 0 10px 20px 10px;
+}
+
+.co-crd-card:hover {
+  box-shadow: 0 1px 10px rgba(3,3,3,0.175);
+}
+
+.co-crd-card__title {
+  margin: 15px 0;
+  padding: 0;
+}
+
+.co-crd-card__body {
+  padding: 0 0 15px;
+}
+
+.co-crd-card__footer {
+  background-color: $color-pf-black-100;
+  border-top: 1px solid $color-pf-black-300;
+  margin: 0 -15px !important;
+  padding: 7.5px 15px;
 }
 
 .co-clusterserviceversion-resource-details__compact-expand {
@@ -88,64 +88,6 @@ $clusterserviceversion-list-border: #ccc;
 
 .co-clusterserviceversion-resource-details__section--info dd {
   margin-bottom: 20px;
-}
-
-.co-clusterserviceversion-details {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.co-clusterserviceversion-details__section--info {
-  display: flex;
-  flex-direction: column;
-  @media (min-width: 768px) {
-    width: 33%;
-  }
-  @media (min-width: 1024px) {
-    width: 25%;
-  }
-  @media (min-width: 1280px) {
-    width: 20%;
-  }
-  @media (min-width: 1440px) {
-    width: 20%;
-  }
-  @media (min-width: 1920px) {
-    width: 20%;
-  }
-}
-
-.co-clusterserviceversion-details__section--info__item {
-  margin-bottom: 15px;
-}
-
-.co-clusterserviceversion-details__section--description {
-  display: flex;
-  flex-direction: column;
-  @media (min-width: 768px) {
-    width: 66%;
-  }
-  @media (min-width: 1024px) {
-    width: 75%;
-  }
-  @media (min-width: 1280px) {
-    width: 80%;
-  }
-  @media (min-width: 1440px) {
-    width: 80%;
-  }
-  @media (min-width: 1920px) {
-    width: 80%;
-  }
-}
-
-.co-clusterserviceversion-detail__error-box {
-  padding: 10px;
-  border: 1px solid #dd1326;
-  background: #ffe6e6;
-  color: #dd1326;
-  font-size: 14px;
-  margin-bottom: 10px;
 }
 
 .co-catalog-install-modal .modal-header .co-clusterserviceversion-logo__icon {
@@ -200,9 +142,4 @@ $clusterserviceversion-list-border: #ccc;
   display: flex;
   align-items: center;
   height: 25px;
-}
-
-.step--present {
-  color: $color-pf-green-400;
-
 }

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -72,6 +72,15 @@ export type CRDDescription = {
   }[];
 };
 
+export type RequirementStatus = {
+  group: string;
+  version: string;
+  kind: string;
+  name: string;
+  status: string;
+  uuid?: string;
+};
+
 export type ClusterServiceVersionKind = {
   spec: {
     install: {
@@ -90,6 +99,7 @@ export type ClusterServiceVersionKind = {
   status?: {
     phase: ClusterServiceVersionPhase;
     reason: CSVConditionReason;
+    requirementStatus?: RequirementStatus[];
   };
 } & K8sResourceKind;
 


### PR DESCRIPTION
### Description

General improvements to the UI for the `ClusterServiceVersion` resource, including giving each `owned` CRD its own tab, which will eventually let us define custom columns for each resource type instead of a heterogeneous list with the same columns. Also display "Events" [now that they are emitted](https://github.com/operator-framework/operator-lifecycle-manager/pull/530).

### Screenshots

**`ClusterServiceVersion` detail view, "Overview" tab (cards for each "Provided API"):**
![screenshot_20181101_143745](https://user-images.githubusercontent.com/11700385/47871973-c6f41600-dde3-11e8-9c94-159002cd7c03.png)

**`ClusterServiceVersion` detail view, "Overview" tab (conditions):**
![screenshot_20181101_143924](https://user-images.githubusercontent.com/11700385/47872036-f9057800-dde3-11e8-8567-6f3d945a2fc4.png)

**`ClusterServiceVersion` detail view (failed):**
![screenshot_20181101_144027](https://user-images.githubusercontent.com/11700385/47872090-1e928180-dde4-11e8-8a6f-7c04716a9c86.png)

**`ClusterServiceVersion` detail view (events):**
![screenshot_20181101_144142](https://user-images.githubusercontent.com/11700385/47872163-4bdf2f80-dde4-11e8-862f-4e8d3a7f3d98.png)

**`ClusterServiceVersion` list view ("Provided APIs" shows CRDs managed by the Operator):**
![screenshot_20181101_144218](https://user-images.githubusercontent.com/11700385/47872195-5ef1ff80-dde4-11e8-84fe-344c96081d65.png)

Addresses https://jira.coreos.com/browse/ALM-776
Addresses https://jira.coreos.com/browse/ALM-778