### PR TITLE
Highlight Catalog nav item for create flows

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -151,9 +151,9 @@ class App extends React.PureComponent {
 
             <LazyRoute path={`/k8s/ns/:ns/${SubscriptionModel.plural}/new`} exact loader={() => import('./operator-lifecycle-manager').then(m => NamespaceFromURL(m.CreateSubscriptionYAML))} />
 
-            <LazyRoute path="/k8s/cluster/clusterserviceclasses/:name/create-instance" exact loader={() => import('./service-catalog/create-instance').then(m => m.CreateInstancePage)} />
+            <LazyRoute path="/catalog/create-service-instance" exact loader={() => import('./service-catalog/create-instance').then(m => m.CreateInstancePage)} />
             <LazyRoute path="/k8s/ns/:ns/serviceinstances/:name/create-binding" exact loader={() => import('./service-catalog/create-binding').then(m => m.CreateBindingPage)} />
-            <LazyRoute path="/source-to-image" exact loader={() => import('./source-to-image').then(m => m.SourceToImagePage)} />
+            <LazyRoute path="/catalog/source-to-image" exact loader={() => import('./source-to-image').then(m => m.SourceToImagePage)} />
 
             <Route path="/k8s/ns/:ns/alertmanagers/:name" exact render={({match}) => <Redirect to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${match.params.name}`} />} />
 

--- a/frontend/public/components/catalog.jsx
+++ b/frontend/public/components/catalog.jsx
@@ -71,7 +71,7 @@ class CatalogListPage extends React.Component {
       const tileDescription = _.get(serviceClass, 'spec.description');
       const tileProvider = _.get(serviceClass, 'spec.externalMetadata.providerDisplayName');
       const tags = _.get(serviceClass, 'spec.tags');
-      const href = `/k8s/cluster/clusterserviceclasses/${serviceClass.metadata.name}/create-instance?preselected-ns=${namespace}`;
+      const href = `/catalog/create-service-instance?cluster-service-class=${serviceClass.metadata.name}&preselected-ns=${namespace}`;
       return {
         obj: serviceClass,
         kind,
@@ -102,7 +102,7 @@ class CatalogListPage extends React.Component {
       const tags = getAnnotationTags(tag);
       const tileProvider = _.get(tag, 'annotations.openshift.io/provider-display-name');
       const { name, namespace } = imageStream.metadata;
-      const href = `/source-to-image?imagestream=${name}&imagestream-ns=${namespace}&preselected-ns=${currentNamespace}`;
+      const href = `/catalog/source-to-image?imagestream=${name}&imagestream-ns=${namespace}&preselected-ns=${currentNamespace}`;
       return {
         obj: imageStream,
         kind,

--- a/frontend/public/components/cluster-service-class.tsx
+++ b/frontend/public/components/cluster-service-class.tsx
@@ -21,7 +21,7 @@ const createInstance = (kindObj, serviceClass) => {
     return {
       btnClass: 'btn-primary',
       callback: () => {
-        history.push(`/k8s/cluster/clusterserviceclasses/${serviceClass.metadata.name}/create-instance`);
+        history.push(`/catalog/create-service-instance?cluster-service-class=${serviceClass.metadata.name}`);
       },
       label: 'Create Instance',
     };

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -68,7 +68,7 @@ const createApplication = (kindObj, imageStream) => {
   return {
     btnClass: 'btn-primary',
     callback: () => {
-      history.push(`/source-to-image?imagestream=${name}&imagestream-ns=${namespace}`);
+      history.push(`/catalog/source-to-image?imagestream=${name}&imagestream-ns=${namespace}`);
     },
     label: 'Create Application',
   };

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -260,7 +260,7 @@ const searchStartsWith = ['search'];
 const rolesStartsWith = ['roles', 'clusterroles'];
 const rolebindingsStartsWith = ['rolebindings', 'clusterrolebindings'];
 const quotaStartsWith = ['resourcequotas', 'clusterresourcequotas'];
-const imagestreamsStartsWith = ['imagestreams', 'imagestreamtags', 'source-to-image'];
+const imagestreamsStartsWith = ['imagestreams', 'imagestreamtags'];
 const clusterSettingsStartsWith = ['settings/cluster', 'settings/ldap'];
 
 const ClusterPickerNavSection = connectToFlags(FLAGS.OPENSHIFT)(({flags}) => {

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -201,12 +201,13 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
 }
 
 export const CreateInstancePage = (props) => {
-  const resources = [
-    {kind: 'ClusterServiceClass', name: props.match.params.name, isList: false, prop: 'obj'},
-    {kind: 'ClusterServicePlan', isList: true, prop: 'plans', fieldSelector: `spec.clusterServiceClassRef.name=${props.match.params.name}`},
-  ];
   const searchParams = new URLSearchParams(location.search);
+  const name = searchParams.get('cluster-service-class');
   const preselectedNamespace = searchParams.get('preselected-ns');
+  const resources = [
+    {kind: 'ClusterServiceClass', name, isList: false, prop: 'obj'},
+    {kind: 'ClusterServicePlan', isList: true, prop: 'plans', fieldSelector: `spec.clusterServiceClassRef.name=${name}`},
+  ];
   return <Firehose resources={resources}>
     <CreateInstance preselectedNamespace={preselectedNamespace} {...props as any} />
   </Firehose>;


### PR DESCRIPTION
Update the Source-to-Image and Create Service Instance forms to use the
Catalog nav item as their active item. This also makes the URL paths for
each form consistent.

![screen shot 2018-10-22 at 4 20 31 pm](https://user-images.githubusercontent.com/1167259/47317005-737d0d80-d616-11e8-8398-f333ce5a9779.png)

/assign @rhamilto 

@serenamarie125 @jeff-phillips-18 @rhamilto I think we agreed the Catalog nav item should be highlighted for these forms regardless of whether we add the details side panel. Let me know if you object.