### PR TITLE
Better responsive behavior of metrics, status, alerts.

### DIFF
--- a/frontend/public/components/overview/_project-overview.scss
+++ b/frontend/public/components/overview/_project-overview.scss
@@ -1,31 +1,49 @@
 // Nesting increases specificity so that pf list styles are always overridden
 .project-overview {
   .project-overview__additional-info {
-    align-items: center;
+    align-items: baseline;
     display: grid;
-    grid-column-gap: 5%;
-    grid-template-areas: "alert memory cpu status";
-    grid-template-columns: 16.6% 16.6% 16.6% 35%;
+    grid-column-gap: 3%;
+    grid-row-gap: 10px;
+    grid-template-columns: auto minmax(min-content, 1fr) 85px;
     width: 100%;
+    @media (min-width: $screen-xs-min) {
+      grid-template-columns: auto minmax(min-content, 1fr) 135px;
+    }
+    @media (min-width: $screen-md-min) {
+      grid-template-areas: "alert memory cpu status";
+      grid-template-columns: 27% 18% 18% 28%;
+    }
   }
 
   .project-overview__detail--alert {
-    grid-area: alert;
     min-width: 0; // To enable text-overflow: ellipsis within a css-grid area
+    @media (max-width: $screen-sm-max) {
+      grid-row: 2;
+    }
+    @media (min-width: $screen-md-min) {
+      grid-area: alert;
+    }
   }
 
   .project-overview__detail--cpu {
-    grid-area: cpu;
     min-width: 0; // To enable text-overflow: ellipsis within a css-grid area
+    @media (min-width: $screen-md-min) {
+      grid-area: cpu;
+    }
   }
 
   .project-overview__detail--memory {
-    grid-area: memory;
     min-width: 0; // To enable text-overflow: ellipsis within a css-grid area
+    @media (min-width: $screen-md-min) {
+      grid-area: memory;
+    }
   }
 
   .project-overview__detail--status {
-    grid-area: status;
+    @media (min-width: $screen-md-min) {
+      grid-area: status;
+    }
   }
 
   .project-overview__item {
@@ -49,6 +67,9 @@
   .project-overview__item-heading {
     font-size: 16px;
     margin: 0;
+    @media(max-width: $screen-sm-max) {
+      margin-bottom: 10px;
+    }
   }
 
   .project-overview__group {
@@ -92,11 +113,6 @@
     }
   }
 
-  .project-overview__item-heading {
-    font-size: 16px;
-    margin: 0;
-  }
-
   .project-overview__list {
     margin-top: 0;
   }
@@ -110,30 +126,6 @@
     color: $color-text-muted;
     font-size: 10px;
     margin-left: 3px;
-  }
-
-  @media (max-width: $screen-sm-max) {
-    .project-overview__additional-info {
-      grid-template-columns: auto;
-      grid-template-rows: auto auto;
-      grid-template-areas:
-        "alert"
-        "memory"
-        "cpu"
-        "status";
-    }
-
-    .project-overview__detail {
-      margin-bottom: 10px;
-
-      &:last-child {
-        margin-bottom: 0px;
-      }
-    }
-
-    .project-overview__item-heading {
-      margin-bottom: 20px;
-    }
   }
 
   @media (min-width: $screen-md-min) {
@@ -150,7 +142,6 @@
 
     .project-overview__detail--cpu,
     .project-overview__detail--memory {
-      margin-right: 5px;
       text-align: right;
     }
 
@@ -176,8 +167,10 @@
 
     .project-overview__additional-info {
       grid-column-gap: 5%;
-      grid-template-areas: "alert status";
       grid-template-columns: 35% 55%;
+    }
+    .project-overview__detail--status {
+      grid-column: 2;
     }
   }
 }


### PR DESCRIPTION
*note: addition of `<div className="project-overview__detail--alert-block">` depends on https://github.com/openshift/console/pull/687#issuecomment-432333602

Also, further reducing of list-item row height at mobile could be accomplished by rendering `<Alerts>` inline with title using something like [react-sizes](https://github.com/renatorib/react-sizes) to show content blocks based on viewport dimensions.


<img width="1340" alt="screen shot 2018-10-23 at 2 16 12 pm" src="https://user-images.githubusercontent.com/1874151/47381854-f82b6280-d6ce-11e8-8c3a-70c76ffefd90.png">

<img width="982" alt="screen shot 2018-10-23 at 2 20 41 pm" src="https://user-images.githubusercontent.com/1874151/47381816-e1850b80-d6ce-11e8-89b6-7e8b87563260.png">

<img width="736" alt="screen shot 2018-10-23 at 12 42 20 pm" src="https://user-images.githubusercontent.com/1874151/47381550-4e4bd600-d6ce-11e8-93ea-0746719b9178.png">

<img width="375" alt="screen shot 2018-10-23 at 12 41 38 pm" src="https://user-images.githubusercontent.com/1874151/47381582-5d328880-d6ce-11e8-9ad1-4af6868d22c9.png">
