### PR TITLE
Add tooltip to overview row metrics

### DIFF
--- a/frontend/public/components/overview/_project-overview.scss
+++ b/frontend/public/components/overview/_project-overview.scss
@@ -106,6 +106,23 @@
     font-weight: 300;
   }
 
+  .project-overview__metric-tooltip {
+    display: flex;
+  }
+
+  .project-overview__metric-tooltip-name {
+    flex: 2;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .project-overview__metric-tooltip-value {
+    flex: 1;
+    text-align: right;
+  }
+
   .project-overview__metric-unit {
     color: $color-text-muted;
     font-size: 10px;

--- a/frontend/public/components/utils/tooltip.tsx
+++ b/frontend/public/components/utils/tooltip.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Tooltip as RLT } from 'react-lightweight-tooltip';
 
@@ -32,4 +34,12 @@ const tooltipOverrides = Object.freeze({
   },
 });
 
-export const Tooltip = ({ content, children }) => <RLT content={content} styles={tooltipOverrides}>{children}</RLT>;
+export const Tooltip: React.SFC<TooltipProps> = ({ content, styles, children }) => {
+  const mergedStyles = styles ? _.merge({}, tooltipOverrides, styles) : tooltipOverrides;
+  return <RLT content={content} styles={mergedStyles}>{children}</RLT>;
+};
+
+type TooltipProps = {
+  content: React.ReactNode;
+  styles?: any;
+};


### PR DESCRIPTION
This makes it clear we're showing a total rather than an average and  shows the metrics for each pod.

<img width="1193" alt="screen shot 2018-10-23 at 7 22 58 pm" src="https://user-images.githubusercontent.com/1167259/47399855-a6073300-d708-11e8-8fec-c47443f09ca8.png">

/assign @TheRealJon 