### PR TITLE
Cache API discovery

### DIFF
--- a/frontend/__tests__/components/utils/firehose.spec.tsx
+++ b/frontend/__tests__/components/utils/firehose.spec.tsx
@@ -46,10 +46,24 @@ describe(Firehose.displayName, () => {
     wrapper = shallow(<Component resources={resources} k8sModels={k8sModels} loaded={true} inFlight={false} stopK8sWatch={stopK8sWatch} watchK8sObject={watchK8sObject} watchK8sList={watchK8sList} />);
   });
 
-  it('returns nothing if `props.inFlight` is true', () => {
-    wrapper = shallow(<Component resources={resources} k8sModels={k8sModels} loaded={false} inFlight={true} stopK8sWatch={stopK8sWatch} watchK8sObject={watchK8sObject} watchK8sList={watchK8sList} />);
+  it('returns nothing if there are no cached models and `props.inFlight` is true', () => {
+    const noModels = ImmutableMap<K8sResourceKindReference, K8sKind>();
+    wrapper = shallow(<Component resources={resources} k8sModels={noModels} loaded={false} inFlight={true} stopK8sWatch={stopK8sWatch} watchK8sObject={watchK8sObject} watchK8sList={watchK8sList} />);
 
     expect(wrapper.html()).toBeNull();
+  });
+
+  it('returns nothing if a required model from `props.resources` is missing and `props.inFlight` is true', () => {
+    const incompleteModels = ImmutableMap<K8sResourceKindReference, K8sKind>().set('Service', ServiceModel);
+    wrapper = shallow(<Component resources={resources} k8sModels={incompleteModels} loaded={false} inFlight={true} stopK8sWatch={stopK8sWatch} watchK8sObject={watchK8sObject} watchK8sList={watchK8sList} />);
+
+    expect(wrapper.html()).toBeNull();
+  });
+
+  it('renders if a cached model is available even if `props.inFlight` is true', () => {
+    wrapper = shallow(<Component resources={resources} k8sModels={k8sModels} loaded={false} inFlight={true} stopK8sWatch={stopK8sWatch} watchK8sObject={watchK8sObject} watchK8sList={watchK8sList} />);
+
+    expect(watchK8sList.calls.count()).toBeGreaterThan(0);
   });
 
   it('does not re-render when `props.inFlight` changes but Firehose data is loaded', () => {

--- a/frontend/public/components/search.jsx
+++ b/frontend/public/components/search.jsx
@@ -19,7 +19,7 @@ import { AsyncComponent } from './utils/async';
 import { DefaultPage } from './default-resource';
 
 const ResourceList = connectToModel(({kindObj, kindsInFlight, namespace, selector, fake}) => {
-  if (kindsInFlight) {
+  if (!kindObj && kindsInFlight) {
     return <LoadingBox />;
   }
 

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -166,7 +166,7 @@ export const Firehose = connect(
     start() {
       const { watchK8sList, watchK8sObject, resources, k8sModels, inFlight } = this.props;
 
-      if (inFlight) {
+      if (inFlight && _.some(resources, ({kind}) => !k8sModels.get(kind))) {
         this.firehoses = [];
       } else {
         this.firehoses = resources.map(resource => {

--- a/frontend/public/const.js
+++ b/frontend/public/const.js
@@ -17,5 +17,11 @@ export const EVENTS = {
 
 // Use a key for the "all" namespaces option that would be an invalid namespace name to avoid a potential clash
 export const ALL_NAMESPACES_KEY = '#ALL_NS#';
+
+// Prefix our localStorage items to avoid conflicts if another app ever runs on the same domain.
+const STORAGE_PREFIX = 'bridge';
+
+// This localStorage key predates the storage prefix.
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
-export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = 'bridge/last-namespace-name';
+export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-namespace-name`;
+export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;

--- a/frontend/public/module/k8s/k8s-actions.ts
+++ b/frontend/public/module/k8s/k8s-actions.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars, no-undef */
 
-import { getResources as getResources_ } from './get-resources';
+import { cacheResources, getResources as getResources_ } from './get-resources';
 import { k8sList, k8sWatch, k8sGet } from './resource';
 import { makeReduxID } from '../../components/utils/k8s-watcher';
 import { APIServiceModel } from '../../models';
@@ -70,7 +70,11 @@ const actions = {
   getResources: () => dispatch => {
     dispatch({type: types.getResourcesInFlight});
     getResources_()
-      .then(resources => dispatch({type: types.resources, resources}))
+      .then(resources => {
+        // Cache the resources whenever discovery completes to improve console load times.
+        cacheResources(resources);
+        dispatch({type: types.resources, resources});
+      })
       // eslint-disable-next-line no-console
       .catch(err => console.error(err));
   },


### PR DESCRIPTION
This builds on work from @alecmerdler in #497 and #603.

On initial console page load, use cached API discovery resources when
possible. This noticeably improves initial console load times. Wait
until discovery completes before requesting resources not in the cache.

We still perform discovery on load to refresh the cache, but don't block
when we have the models we need.

The cache is invalidated when the console version changes. This avoids
errors if the internal model representation changes between versions.

/assign @alecmerdler 