### PR TITLE
e2e test flake fix: wait for username input to render

### DIFF
--- a/frontend/integration-tests/tests/secrets.scenario.ts
+++ b/frontend/integration-tests/tests/secrets.scenario.ts
@@ -105,7 +105,6 @@ describe('Interacting with the create secret forms', () => {
 
     it('edits SSH source secret', async() => {
       await secretsView.editSecret(testName, sshSourceSecretName, async() => {
-        await browser.wait(until.presenceOf(secretsView.uploadFileTextArea));
         await secretsView.uploadFileTextArea.clear();
         await secretsView.uploadFileTextArea.sendKeys(sshSourceSecretSSHKeUpdated);
       });
@@ -187,7 +186,6 @@ describe('Interacting with the create secret forms', () => {
 
     it('edits registry credentials image secret', async() => {
       await secretsView.editSecret(testName, credentialsImageSecretName, async() => {
-        await browser.wait(until.presenceOf(secretsView.removeSecretEntryLink));
         await secretsView.removeSecretEntryLink.click();
         await secretsView.secretAddressInput.clear();
         await secretsView.secretAddressInput.sendKeys(addressUpdated);
@@ -273,7 +271,6 @@ describe('Interacting with the create secret forms', () => {
 
     it('edits Key/Value secret', async() => {
       await secretsView.editSecret(testName, keyValueSecretName, async() => {
-        await browser.wait(until.presenceOf(secretsView.removeSecretEntryLink));
         await secretsView.removeSecretEntryLink.click();
         await secretsView.secretKeyInput.clear();
         await secretsView.secretKeyInput.sendKeys(keyUpdated);

--- a/frontend/integration-tests/views/secrets.view.ts
+++ b/frontend/integration-tests/views/secrets.view.ts
@@ -40,6 +40,7 @@ export const encode = (username, password) => Base64.encode(`${username}:${passw
 export const createSecret = async(linkElement: ElementFinder, ns: string, name: string, updateForm: Function) => {
   await crudView.createItemButton.click();
   await linkElement.click();
+  await browser.wait(until.presenceOf(secretNameInput));
   await secretNameInput.sendKeys(name);
   await updateForm();
   await saveButton.click();
@@ -64,6 +65,7 @@ export const editSecret = async(ns: string, name: string, updateForm: Function) 
   await browser.wait(until.presenceOf(crudView.actionsDropdownMenu), 500);
   await crudView.actionsDropdownMenu.element(by.linkText('Edit Secret')).click();
   await browser.wait(until.urlContains(`/k8s/ns/${ns}/secrets/${name}/edit`));
+  await browser.wait(until.presenceOf(secretNameInput));
   await updateForm();
   await saveButton.click();
   expect(crudView.errorMessage.isPresent()).toBe(false);


### PR DESCRIPTION
Hit following flake several times today:
```
Failed Specs:

1) Interacting with the create secret forms Basic source secrets : edits basic source secret
   NoSuchElementError: No element found using locator: By(css selector, input[name=username])
       at elementArrayFinder.getWebElements.then /go/src/github.com/openshift/console/frontend/node_modules/protractor/built/element.js:814:27
```

Updated the secrets tests so upon each edit step there is a check for the first input element. Some of the `updateForm()` call already had that check, so I've added the check as a part of the `editSecret` function.

/assign @spadgett 