### PR TITLE
Some sidebar adjustments to more closely match latest design docs

### DIFF
--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -23,24 +23,37 @@ $co-m-horizontal-nav__menu-item-link-padding-lr-mobile: 15px;
   font-size: 18px;
   margin: 0;
   text-align: center;
+  a,
+  button {
+    color: $color-pf-black-700;
+    position: relative;
+    &:hover,
+    &:focus {
+      color: #252525;
+      &::after {
+        background: $color-pf-black-400;
+      }
+    }
+    &::after {
+      bottom: -1px;
+      content: "";
+      display: block;
+      height: 2px;
+      left: $co-m-horizontal-nav__menu-item-link-padding-lr-mobile;
+      position: absolute;
+      right: $co-m-horizontal-nav__menu-item-link-padding-lr-mobile;
+      @media (min-width: $grid-float-breakpoint) {
+        left: $co-m-horizontal-nav__menu-item-link-padding-lr-desktop;
+        right: $co-m-horizontal-nav__menu-item-link-padding-lr-desktop;
+      }
+    }
+  }
   &.co-m-horizontal-nav-item--active {
     a,
     button {
       color: $color-highlight-blue;
-      position: relative;
       &::after {
         background: $color-highlight-blue;
-        bottom: 0;
-        content: "";
-        display: block;
-        height: 2px;
-        left: $co-m-horizontal-nav__menu-item-link-padding-lr-mobile;
-        position: absolute;
-        right: $co-m-horizontal-nav__menu-item-link-padding-lr-mobile;
-        @media (min-width: $grid-float-breakpoint) {
-          left: $co-m-horizontal-nav__menu-item-link-padding-lr-desktop;
-          right: $co-m-horizontal-nav__menu-item-link-padding-lr-desktop;
-        }
       }
     }
   }
@@ -48,7 +61,6 @@ $co-m-horizontal-nav__menu-item-link-padding-lr-mobile: 15px;
   button {
     background: none;
     border: none;
-    color: inherit;
     display: block;
     padding: 6px $co-m-horizontal-nav__menu-item-link-padding-lr-mobile 8px;
     text-decoration: none;
@@ -62,4 +74,14 @@ $co-m-horizontal-nav__menu-item-link-padding-lr-mobile: 15px;
 .co-m-horizontal-nav__menu-item--divider {
   border-left: 1px solid $color-grey-background-border;
   margin: 0 10px;
+}
+
+.overview__sidebar {
+  .co-m-horizontal-nav__menu {
+    padding: 0 20px;
+  }
+  .co-m-horizontal-nav__menu-item {
+    font-size: 16px;
+    line-height: normal;
+  }
 }

--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -93,10 +93,18 @@
   }
 
   .overview__sidebar-dismiss {
-    background: #fff;
-    border-bottom: 1px solid $color-grey-background-border;
-    padding: 5px 20px;
-    overflow: hidden;
+    background: $color-grey-background;
+    box-shadow: 0px 1px 0px 0px $color-grey-background-border;
+    padding: 0 5px;
+
+    .close {
+      // adjustments to increase click target and default color contrast because it's on a grey background
+      opacity: .3;
+      padding: 10px 15px;
+      &:hover, &:focus {
+        opacity: .6;
+      }
+    }
 
     .pficon-close {
       font-size: 16px;
@@ -112,7 +120,7 @@
 .overview__sidebar-pane-head {
   background-color: $color-grey-background;
   border-bottom: 1px solid $color-grey-background-border;
-  padding-top: 20px;
+  padding-top: 5px;
 
   .co-m-pane__heading {
     margin: 0 20px 25px;
@@ -147,4 +155,9 @@
 .resource-overview__summary {
   padding-right: 10px;
   width: 50%;
+}
+
+.sidebar__section-heading {
+  font-size: 18px;
+  margin-top: 30px;
 }

--- a/frontend/public/components/overview/networking-overview.tsx
+++ b/frontend/public/components/overview/networking-overview.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { Icon, ListGroup } from 'patternfly-react';
 
 import { K8sResourceKind } from '../../module/k8s';
-import { ResourceLink, SectionHeading } from '../utils';
+import { ResourceLink, SidebarSectionHeading } from '../utils';
 import { RouteLocation } from '../routes';
 
 const ServicePortList: React.SFC<ServicePortListProps> = ({service}) => {
@@ -48,23 +48,23 @@ const RoutesOverviewList: React.SFC<RoutesOverviewListProps> = ({routes}) => <Li
 </ListGroup>;
 
 export const NetworkingOverview: React.SFC<NetworkingOverviewProps> = ({routes, services}) => {
-  return <div className="co-m-pane">
-    <div className="co-m-pane__body">
-      <SectionHeading text="Services" />
-      {
-        _.isEmpty(services)
-          ? <span className="text-muted">No Services found for this resource.</span>
-          : <ServicesOverviewList services={services} />
-      }
-    </div>
-    <div className="co-m-pane__body">
-      <SectionHeading text="Routes" />
-      {
-        _.isEmpty(routes)
-          ? <span className="text-muted">No Routes found for this resource.</span>
-          : <RoutesOverviewList routes={routes} />
-      }
-    </div>
+  return <div className="overview__sidebar-pane-body">
+
+    <SidebarSectionHeading text="Services" />
+    {
+      _.isEmpty(services)
+        ? <span className="text-muted">No Services found for this resource.</span>
+        : <ServicesOverviewList services={services} />
+    }
+
+
+    <SidebarSectionHeading text="Routes" />
+    {
+      _.isEmpty(routes)
+        ? <span className="text-muted">No Routes found for this resource.</span>
+        : <RoutesOverviewList routes={routes} />
+    }
+
   </div>;
 };
 

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -68,6 +68,8 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
 
 export const SectionHeading: React.SFC<SectionHeadingProps> = ({text, children, style}) => <h2 className="co-section-heading" style={style}>{text}{children}</h2>;
 
+export const SidebarSectionHeading: React.SFC<SidebarSectionHeadingProps> = ({text, children, style}) => <h2 className="sidebar__section-heading" style={style}>{text}{children}</h2>;
+
 export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = ({kindObj, actions, resource}) => <div className="overview__sidebar-pane-head resource-overview__heading">
   <h1 className="co-m-pane__heading">
     <div className="co-m-pane__name">
@@ -114,9 +116,16 @@ export type SectionHeadingProps = {
   style?: any;
   text: string;
 };
+
+export type SidebarSectionHeadingProps = {
+  children?: any;
+  style?: any;
+  text: string;
+};
 /* eslint-enable no-undef */
 
 BreadCrumbs.displayName = 'BreadCrumbs';
 PageHeading.displayName = 'PageHeading';
 ResourceOverviewHeading.displayName = 'ResourceOverviewHeading';
 SectionHeading.displayName = 'SectionHeading';
+SidebarSectionHeading.displayName = 'SidebarSectionHeading';


### PR DESCRIPTION
@spadgett, @beanh66, @rhamilto 
 
- Make resources tab content side gutters consistent with overview tab
- Heading block and close bar now have same background color
- Adjust close icon color opacity darker since its on a grey background
- Make close button click target larger than just size of X
- Reduce height and size of sidebar horizontal tabs 
- Make tab `:hover,:focus` state match PF by adding a grey "bar"
- Move "bar" position down 1px to sit on bottom border matching PF

* [Design doc](https://raw.githubusercontent.com/openshift/openshift-origin-design/38f5fdbacfd53de669a1879ab304fd38f8e8f816/web-console/4.0-designs/overview/img/resources.png)

![sidebar-anim](https://user-images.githubusercontent.com/1874151/47525726-f6e36c80-d86b-11e8-97d0-3c105cdca977.gif)
<img width="176" alt="close-click-target" src="https://user-images.githubusercontent.com/1874151/47525735-fc40b700-d86b-11e8-9b84-8337138383fe.png">


**Before**
<img width="1084" alt="sidebar-before" src="https://user-images.githubusercontent.com/1874151/47525745-01056b00-d86c-11e8-92bf-773c5c88c4e5.png">


**After**

<img width="1085" alt="sidebar-after" src="https://user-images.githubusercontent.com/1874151/47525751-08c50f80-d86c-11e8-82ee-b589510c26a7.png">


jenkins push