### PR TITLE
Change GroupVersionKind String Format to Work in URLs

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
@@ -7,7 +7,7 @@ import * as _ from 'lodash-es';
 
 import { ClusterServiceVersionResourceList, ClusterServiceVersionResourceListProps, ClusterServiceVersionResourcesPage, ClusterServiceVersionResourcesPageProps, ClusterServiceVersionResourceHeaderProps, ClusterServiceVersionResourcesDetailsState, ClusterServiceVersionResourceRowProps, ClusterServiceVersionResourceHeader, ClusterServiceVersionResourceRow, ClusterServiceVersionResourceDetails, ClusterServiceVersionResourcesDetailsPageProps, ClusterServiceVersionResourcesDetailsProps, ClusterServiceVersionResourcesDetailsPage, ClusterServiceVersionResourceLink } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion-resource';
 import { Resources } from '../../../public/components/operator-lifecycle-manager/k8s-resource';
-import { ClusterServiceVersionResourceKind } from '../../../public/components/operator-lifecycle-manager';
+import { ClusterServiceVersionResourceKind, referenceForCRDDesc } from '../../../public/components/operator-lifecycle-manager';
 import { StatusDescriptor } from '../../../public/components/operator-lifecycle-manager/descriptors/status';
 import { SpecDescriptor } from '../../../public/components/operator-lifecycle-manager/descriptors/spec';
 import { testCRD, testResourceInstance, testClusterServiceVersion, testOwnedResourceInstance } from '../../../__mocks__/k8sResourcesMocks';
@@ -369,7 +369,7 @@ describe(ClusterServiceVersionResourcesPage.displayName, () => {
     expect(listPage.props().filterLabel).toEqual('Resources by name');
     expect(listPage.props().canCreate).toBe(true);
     expect(listPage.props().resources).toEqual(owned.concat(required).map((crdDesc) => ({
-      kind: `${crdDesc.name.slice(crdDesc.name.indexOf('.') + 1)}:${crdDesc.version}:${crdDesc.kind}`,
+      kind: referenceForCRDDesc(crdDesc),
       namespaced: true,
       prop: crdDesc.kind,
     })));
@@ -385,7 +385,7 @@ describe(ClusterServiceVersionResourcesPage.displayName, () => {
     expect(listPage.props().createButtonText).toEqual('Create New');
     expect(listPage.props().createProps.to).not.toBeDefined();
     expect(listPage.props().createProps.items).toEqual({'testresource.testapp.coreos.com': 'Test Resource', 'foobars.testapp.coreos.com': 'Foo Bars'});
-    expect(listPage.props().createProps.createLink(obj.spec.customresourcedefinitions.owned[0].name)).toEqual(`/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/testapp.coreos.com:v1:TestResource/new`);
+    expect(listPage.props().createProps.createLink(obj.spec.customresourcedefinitions.owned[0].name)).toEqual(`/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/testapp.coreos.com~v1~TestResource/new`);
   });
 
   it('passes `createProps` for single create button if app has only one owned CRD', () => {
@@ -394,7 +394,7 @@ describe(ClusterServiceVersionResourcesPage.displayName, () => {
     expect(listPage.props().createButtonText).toEqual(`Create ${testClusterServiceVersion.spec.customresourcedefinitions.owned[0].displayName}`);
     expect(listPage.props().createProps.items).not.toBeDefined();
     expect(listPage.props().createProps.createLink).not.toBeDefined();
-    expect(listPage.props().createProps.to).toEqual(`/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/testapp.coreos.com:v1:TestResource/new`);
+    expect(listPage.props().createProps.to).toEqual(`/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp/testapp.coreos.com~v1~TestResource/new`);
   });
 
   it('passes `flatten` function which removes `required` resources with owner references to items not in the same list', () => {

--- a/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
@@ -220,7 +220,7 @@ describe(InstallPlanDetailsPage.displayName, () => {
 
     expect(breadcrumbsFor(testInstallPlan)).toEqual([{
       name: testInstallPlan.metadata.ownerReferences[0].name,
-      path: `/k8s/ns/default/operators.coreos.com:v1alpha1:Subscription/${testInstallPlan.metadata.ownerReferences[0].name}`,
+      path: `/k8s/ns/default/operators.coreos.com~v1alpha1~Subscription/${testInstallPlan.metadata.ownerReferences[0].name}`,
     }, {
       name: 'Install Plan Details',
       path: match.url,

--- a/frontend/__tests__/module/k8s/k8s-models.spec.ts
+++ b/frontend/__tests__/module/k8s/k8s-models.spec.ts
@@ -5,36 +5,36 @@ import { PodModel, DeploymentModel } from '../../../public/models';
 describe('referenceFor', () => {
 
   it('returns a reference for objects without an API group', () => {
-    expect(referenceFor(testNamespace)).toEqual('core:v1:Namespace');
+    expect(referenceFor(testNamespace)).toEqual('core~v1~Namespace');
   });
 
   it('returns a reference for objects with an API group', () => {
-    expect(referenceFor(testClusterServiceVersion)).toEqual('operators.coreos.com:v1alpha1:ClusterServiceVersion');
+    expect(referenceFor(testClusterServiceVersion)).toEqual('operators.coreos.com~v1alpha1~ClusterServiceVersion');
   });
 });
 
 describe('referenceForCRD', () => {
 
   it('returns a reference for custom resource definitions', () => {
-    expect(referenceForCRD(testCRD)).toEqual('testapp.coreos.com:v1alpha1:TestResource');
+    expect(referenceForCRD(testCRD)).toEqual('testapp.coreos.com~v1alpha1~TestResource');
   });
 });
 
 describe('referenceForOwnerRef', () => {
 
   it('returns a reference for an ownerRef', () => {
-    expect(referenceForOwnerRef(testOwnedResourceInstance.metadata.ownerReferences[0])).toEqual('testapp.coreos.com:v1alpha1:TestResource');
+    expect(referenceForOwnerRef(testOwnedResourceInstance.metadata.ownerReferences[0])).toEqual('testapp.coreos.com~v1alpha1~TestResource');
   });
 });
 
 describe('referenceForModel', () => {
 
   it('returns a reference for a legacy k8s model', () => {
-    expect(referenceForModel(PodModel)).toEqual('core:v1:Pod');
+    expect(referenceForModel(PodModel)).toEqual('core~v1~Pod');
   });
 
   it('returns a reference for a non-legacy k8s model', () => {
-    expect(referenceForModel(DeploymentModel)).toEqual('apps:v1:Deployment');
+    expect(referenceForModel(DeploymentModel)).toEqual('apps~v1~Deployment');
   });
 });
 

--- a/frontend/integration-tests/tests/olm/descriptors.scenario.ts
+++ b/frontend/integration-tests/tests/olm/descriptors.scenario.ts
@@ -172,7 +172,7 @@ describe('Using OLM descriptor components', () => {
 
   it('displays detail view for custom resource', async() => {
     const {group, version, names: {kind}} = testCRD.spec;
-    await browser.get(`${appHost}/ns/${testName}/clusterserviceversions/${testCSV.metadata.name}/${group}:${version}:${kind}/${testCR.metadata.name}`);
+    await browser.get(`${appHost}/ns/${testName}/clusterserviceversions/${testCSV.metadata.name}/${group}~${version}~${kind}/${testCR.metadata.name}`);
     await crudView.isLoaded();
 
     expect(crudView.resourceTitle.getText()).toEqual(testCR.metadata.name);

--- a/frontend/integration-tests/tests/olm/etcd.scenario.ts
+++ b/frontend/integration-tests/tests/olm/etcd.scenario.ts
@@ -20,7 +20,7 @@ describe('Interacting with the etcd OCS', () => {
   const etcdrestore = `${testName}-etcdrestore`;
 
   beforeAll(async() => {
-    browser.get(`${appHost}/status/all-namespaces`);
+    await browser.get(`${appHost}/status/all-namespaces`);
     await browser.wait(until.presenceOf(sidenavView.navSectionFor('Operators')));
   });
 
@@ -31,8 +31,6 @@ describe('Interacting with the etcd OCS', () => {
 
   it('can be enabled from the Catalog Source', async() => {
     await sidenavView.clickNavLink(['Operators', 'Package Manifests']);
-    await catalogView.isLoaded();
-    await catalogView.viewCatalogDetail('Red Hat Operators');
     await catalogView.isLoaded();
     await catalogView.createSubscriptionFor('etcd');
     await browser.wait(until.presenceOf($('.ace_text-input')));

--- a/frontend/integration-tests/tests/olm/prometheus.scenario.ts
+++ b/frontend/integration-tests/tests/olm/prometheus.scenario.ts
@@ -19,7 +19,7 @@ describe('Interacting with the Prometheus OCS', () => {
   const testLabel = 'automatedTestName';
 
   beforeAll(async() => {
-    browser.get(`${appHost}/status/all-namespaces`);
+    await browser.get(`${appHost}/status/all-namespaces`);
     await browser.wait(until.presenceOf(sidenavView.navSectionFor('Operators')));
   });
 
@@ -30,8 +30,6 @@ describe('Interacting with the Prometheus OCS', () => {
 
   it('can be enabled from the Catalog Source', async() => {
     await sidenavView.clickNavLink(['Operators', 'Package Manifests']);
-    await catalogView.isLoaded();
-    await catalogView.viewCatalogDetail('Red Hat Operators');
     await catalogView.isLoaded();
     await catalogView.createSubscriptionFor('Prometheus Operator');
     await browser.wait(until.presenceOf($('.ace_text-input')));

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -36,9 +36,9 @@ import {
 } from './utils';
 
 export const ReportReference: GroupVersionKind = referenceForModel(ChargebackReportModel);
-export const ScheduledReportReference: GroupVersionKind = 'chargeback.coreos.com:v1alpha1:ScheduledReport';
-export const ReportGenerationQueryReference: GroupVersionKind = 'chargeback.coreos.com:v1alpha1:ReportGenerationQuery';
-export const ReportPrometheusQueryReference: GroupVersionKind = 'chargeback.coreos.com:v1alpha1:ReportPrometheusQuery';
+export const ScheduledReportReference: GroupVersionKind = 'chargeback.coreos.com~v1alpha1~ScheduledReport';
+export const ReportGenerationQueryReference: GroupVersionKind = 'chargeback.coreos.com~v1alpha1~ReportGenerationQuery';
+export const ReportPrometheusQueryReference: GroupVersionKind = 'chargeback.coreos.com~v1alpha1~ReportPrometheusQuery';
 
 const reportPages=[
   {name: 'All Reports', href: ReportReference},

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -8,7 +8,7 @@ import * as PropTypes from 'prop-types';
 import { FLAGS, connectToFlags, featureReducerName, flagPending } from '../features';
 import { MonitoringRoutes, connectToURLs } from '../monitoring';
 import { formatNamespacedRouteForResource } from '../ui/ui-actions';
-import { BuildConfigModel, BuildModel, ClusterServiceVersionModel, DeploymentConfigModel, ImageStreamModel, SubscriptionModel, InstallPlanModel, PackageManifestModel } from '../models';
+import { BuildConfigModel, BuildModel, ClusterServiceVersionModel, DeploymentConfigModel, ImageStreamModel, SubscriptionModel, InstallPlanModel, PackageManifestModel, ChargebackReportModel } from '../models';
 import { referenceForModel } from '../module/k8s';
 import { authSvc } from '../module/auth';
 
@@ -443,7 +443,7 @@ export class Nav extends React.Component {
             <ResourceNSLink resource="rolebindings" name="Role Bindings" onClick={this.close} startsWith={rolebindingsStartsWith} />
             <ResourceNSLink resource="resourcequotas" name="Resource Quotas" onClick={this.close} startsWith={quotaStartsWith} />
             <ResourceNSLink resource="limitranges" name="Limit Ranges" onClick={this.close} />
-            <ResourceNSLink resource="chargeback.coreos.com:v1alpha1:Report" name="Chargeback" onClick={this.close} disallowed={FLAGS.OPENSHIFT} />
+            <ResourceNSLink resource={referenceForModel(ChargebackReportModel)} name="Chargeback" onClick={this.close} disallowed={FLAGS.OPENSHIFT} />
             <ResourceClusterLink resource="customresourcedefinitions" name="CRDs" onClick={this.close} required={FLAGS.CAN_LIST_CRD} />
           </NavSection>
 

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -192,7 +192,7 @@ export const olmNamespace = 'operator-lifecycle-manager';
 
 export const isEnabled = (namespace: K8sResourceKind) => _.has(namespace, ['metadata', 'annotations', 'alm-manager']);
 
-export const referenceForCRDDesc = (desc: CRDDescription): GroupVersionKind => `${desc.name.slice(desc.name.indexOf('.') + 1)}:${desc.version}:${desc.kind}`;
+export const referenceForCRDDesc = (desc: CRDDescription): GroupVersionKind => `${desc.name.slice(desc.name.indexOf('.') + 1)}~${desc.version}~${desc.kind}`;
 
 export const ClusterServiceVersionLogo: React.SFC<ClusterServiceVersionLogoProps> = (props) => {
   const {icon, displayName, provider, version} = props;

--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -8,7 +8,7 @@ export const getQN: (obj: K8sResourceKind) => string = ({metadata: {name, namesp
 
 export const k8sBasePath = `${(window as any).SERVER_FLAGS.basePath}api/kubernetes`;
 
-export const isGroupVersionKind = (ref: GroupVersionKind | string) => ref.split(':').length === 3;
+export const isGroupVersionKind = (ref: GroupVersionKind | string) => ref.split('~').length === 3;
 
 export const groupVersionFor = (apiVersion: string) => ({
   group: apiVersion.split('/').length === 2 ? apiVersion.split('/')[0] : 'core',
@@ -16,31 +16,31 @@ export const groupVersionFor = (apiVersion: string) => ({
 });
 
 export const referenceFor = (obj: K8sResourceKind): GroupVersionKind => obj.kind && obj.apiVersion
-  ? `${groupVersionFor(obj.apiVersion).group}:${groupVersionFor(obj.apiVersion).version}:${obj.kind}`
+  ? `${groupVersionFor(obj.apiVersion).group}~${groupVersionFor(obj.apiVersion).version}~${obj.kind}`
   : '';
 
 export const referenceForCRD = (obj: CustomResourceDefinitionKind): GroupVersionKind => (
-  `${obj.spec.group}:${obj.spec.version}:${obj.spec.names.kind}`
+  `${obj.spec.group}~${obj.spec.version}~${obj.spec.names.kind}`
 );
 
 export const referenceForOwnerRef = (ownerRef: OwnerReference): GroupVersionKind => (
-  `${groupVersionFor(ownerRef.apiVersion).group}:${groupVersionFor(ownerRef.apiVersion).version}:${ownerRef.kind}`
+  `${groupVersionFor(ownerRef.apiVersion).group}~${groupVersionFor(ownerRef.apiVersion).version}~${ownerRef.kind}`
 );
 
 export const referenceForModel = (model: K8sKind): GroupVersionKind => (
-  `${model.apiGroup || 'core'}:${model.apiVersion}:${model.kind}`
+  `${model.apiGroup || 'core'}~${model.apiVersion}~${model.kind}`
 );
 
 export const kindForReference = (ref: K8sResourceKindReference) => isGroupVersionKind(ref)
-  ? ref.split(':')[2]
+  ? ref.split('~')[2]
   : ref;
 
-export const versionForReference = (ref: GroupVersionKind) => ref.split(':')[1];
+export const versionForReference = (ref: GroupVersionKind) => ref.split('~')[1];
 
 export const apiVersionForModel = (model: K8sKind) => _.isEmpty(model.apiGroup)
   ? model.apiVersion
   : `${model.apiGroup}/${model.apiVersion}`;
 
 export const apiVersionForReference = (ref: GroupVersionKind) => isGroupVersionKind(ref)
-  ? `${ref.split(':')[0]}/${ref.split(':')[1]}`
+  ? `${ref.split('~')[0]}/${ref.split('~')[1]}`
   : ref;


### PR DESCRIPTION
### Description

The current representation of a Kubernetes resource's `GroupVersionKind` uses colons as a delimiter (`operators.coreos.com:v1alpha1:ClusterServiceVersion`). However, this [does not work with React Router](https://github.com/ReactTraining/react-router/issues/1759), which uses colons to indicate a route parameter (claims its fixed, but I can't get it to work in a `<Switch>`). So we should use tildes instead!