### PR TITLE
Persisting Catalog category and filter selections in url

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -95,6 +95,7 @@ export const config: Config = {
     olmUpgrade: ['tests/base.scenario.ts', 'tests/olm/update-channel-approval.scenario.ts'],
     performance: ['tests/base.scenario.ts', 'tests/performance.scenario.ts'],
     serviceCatalog: ['tests/base.scenario.ts', 'tests/service-catalog/service-catalog.scenario.ts', 'tests/service-catalog/service-broker.scenario.ts', 'tests/service-catalog/service-class.scenario.ts', 'tests/service-catalog/service-binding.scenario.ts'],
+    catalog: ['tests/base.scenario.ts', 'tests/catalog.scenario.ts'],
     all: ['tests/base.scenario.ts',
       'tests/crud.scenario.ts',
       'tests/secrets.scenario.ts',
@@ -103,8 +104,8 @@ export const config: Config = {
       'tests/filter.scenario.ts',
       'tests/modal-annotations.scenario.ts',
       'tests/source-to-image.scenario.ts',
-      'tests/deploy-image.scenario.ts'],
-    catalog: ['tests/base.scenario.ts', 'tests/catalog.scenario.ts'],
+      'tests/deploy-image.scenario.ts',
+      'tests/catalog.scenario.ts'],
   },
   params: {
     // Set to 'true' to enable OpenShift resources in the crud scenario.

--- a/frontend/integration-tests/tests/catalog.scenario.ts
+++ b/frontend/integration-tests/tests/catalog.scenario.ts
@@ -18,12 +18,12 @@ describe('Catalog', () => {
     checkErrors();
   });
 
-  it('has clickable Catalog Tiles', async() => {
+  it('clicking on Catalog Tile opens details modal', async() => {
     expect(catalogPageView.catalogTiles.isPresent()).toBe(true);
 
     await catalogPageView.catalogTiles.first().click();
-    await catalogView.createCatalogItemPageIsLoaded();
-    expect($('.co-catalog-item-details__name').isPresent()).toBe(true);
+    await catalogView.catalogDetailsLoaded();
+    expect($('.co-catalog-page__overlay-body').isPresent()).toBe(true);
   });
 
   it('filters catalog tiles by Category', async() => {

--- a/frontend/integration-tests/views/catalog.view.ts
+++ b/frontend/integration-tests/views/catalog.view.ts
@@ -6,4 +6,4 @@ export const pageNumberItemsHeading = $('.co-catalog-page__num-items');
 export const pageHeadingNumberOfItems = () => pageNumberItemsHeading.getText()
   .then(text => parseInt(text.substring(0, text.indexOf(' items')), 10));
 export const categoryViewAllLinks = $$('.catalog-tile-view-pf-category-view-all');
-export const createCatalogItemPageIsLoaded = () => browser.wait(until.presenceOf($('.co-catalog-item-info')), 10000).then(() => browser.sleep(1000));
+export const catalogDetailsLoaded = () => browser.wait(until.presenceOf($('.modal-content')), 10000).then(() => browser.sleep(1000));

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,7 +68,7 @@
     "openshift-logos-icon": "1.7.1",
     "patternfly": "^3.54.8",
     "patternfly-react": "^2.22.0",
-    "patternfly-react-extensions": "2.11.1",
+    "patternfly-react-extensions": "2.12.8",
     "plotly.js": "1.28.x",
     "prop-types": "15.6.x",
     "react": "16.x",

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -105,6 +105,20 @@ class App extends React.PureComponent {
   }
 
   render() {
+    // Needed so we don't pull in the Catalog pages and its dependencies until the user navigates to the page
+    let catalogPageLoader = () =>
+      import('./catalog/catalog-page' /* webpackChunkName: "catalog" */).then(m => {
+        this.CatalogPage = m.CatalogPage;
+        return m.CatalogPage;
+      });
+
+    let renderCatalogRoute = (path) => {
+      if (this.CatalogPage) {
+        return <Route path={path} exact component={this.CatalogPage} />;
+      }
+      return <LazyRoute path={path} exact loader={catalogPageLoader} />;
+    };
+
     return <React.Fragment>
       <Helmet titleTemplate={`%s · ${productName}`} defaultTitle={productName} />
       <Masthead />
@@ -120,8 +134,8 @@ class App extends React.PureComponent {
             <LazyRoute path="/overview/all-namespaces" exact loader={() => import('./overview' /* webpackChunkName: "overview" */).then(m => m.OverviewPage)} />
             <Route path="/overview" exact component={NamespaceRedirect} />
 
-            <LazyRoute path="/catalog/all-namespaces" exact loader={() => import('./catalog/catalog-page' /* webpackChunkName: "catalog" */).then(m => m.CatalogPage)} />
-            <LazyRoute path="/catalog/ns/:ns" exact loader={() => import('./catalog/catalog-page' /* webpackChunkName: "catalog" */).then(m => m.CatalogPage)} />
+            {renderCatalogRoute('/catalog/all-namespaces')}
+            {renderCatalogRoute('/catalog/ns/:ns')}
             <Route path="/catalog" exact component={NamespaceRedirect} />
 
             <LazyRoute path="/status/all-namespaces" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />

--- a/frontend/public/components/catalog/catalog-items.jsx
+++ b/frontend/public/components/catalog/catalog-items.jsx
@@ -12,101 +12,157 @@ import {Modal} from 'patternfly-react/dist/js/components/Modal';
 import {normalizeIconClass} from './catalog-item-icon';
 import {categorizeItems, recategorizeItems} from '../utils/categorize-catalog-items';
 import {CatalogTileDetails} from './catalog-item-details';
+import {history} from '../utils';
+
+const CATEGORY_URL_PARAM = 'category';
+const KEYWORD_URL_PARAM = 'keyword';
+const TYPE_URL_PARAM = 'by-type';
+
+const defaultFilters = {
+  byKeyword: {
+    value: '',
+    active: false,
+  },
+  byType: {
+    clusterServiceClass: {
+      label: 'Service Class',
+      value: 'ClusterServiceClass',
+      active: false,
+    },
+    imageStream: {
+      label: 'Source-to-Image',
+      value: 'ImageStream',
+      active: false,
+    },
+  },
+};
+
+const defaultFilterCounts = {
+  byType: {
+    clusterServiceClasses: 0,
+    imageStreams: 0,
+  },
+};
 
 export class CatalogTileViewPage extends React.Component {
   constructor(props) {
     super(props);
 
-    const categories = categorizeItems(props.items);
-    const activeTabs = ['all']; // array of tabs [main category, sub-category]
-    const filters = {
-      byKeyword: {
-        value: '',
-        active: false,
-      },
-      byType: {
-        clusterServiceClass: {
-          label: 'Service Class',
-          value: 'ClusterServiceClass',
-          active: false,
-        },
-        imageStream: {
-          label: 'Source-to-Image',
-          value: 'ImageStream',
-          active: false,
-        },
-      },
+    /* saving in state
+      {
+        categories: set of categories and subcategories based on passed in items.  Initially, empty categories are
+          removed. Subsequent filtering may result in empty categories.
+        currentCategories: categories/subcategories to list in the right hand CatalogTileView
+        selectedCategory: category selected from left hand tabs or from url
+        showAllItemsForCategory: flag to show all items/tiles for selected category
+        filters: active filters from left side panel or url
+        filterCounts: number of items that match each filter type
+        numItems: displayed in title above CatalogTileView
+      }
+    */
+    this.state = {
+      categories: categorizeItems(props.items),
+      currentCategories: null,
+      selectedCategory: null,
+      showAllItemsForCategory: false,
+      filters: defaultFilters,
+      filterCounts: defaultFilterCounts,
+      numItems: 0,
     };
-
-    let filterCounts = {
-      byType: {
-        clusterServiceClasses: 0,
-        imageStreams: 0,
-      },
-    };
-
-    this.state = this.getCategoryState(activeTabs, categories);
-    filterCounts = this.getFilterCounts(activeTabs, filters, filterCounts, categories);
-
-    _.assign(this.state, {
-      showAllItemsForCategory: null,
-      activeTabs,
-      filters,
-      filterCounts,
-      showOverlay: false,
-    });
 
     this.openOverlay = this.openOverlay.bind(this);
     this.closeOverlay = this.closeOverlay.bind(this);
+    this.unmounted = false;
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    const { filters, filterCounts, activeTabs, categories } = this.state;
+  componentDidMount() {
+    this.setState(this.getUpdatedStateFromURLParams(window.location.search));
+  }
+
+  componentWillUnmount() {
+    this.unmounted = true;
+  }
+
+  componentDidUpdate(prevProps) {
+    const { filters, selectedCategory } = this.state;
     const { items } = this.props;
 
     if (items !== prevProps.items) {
-      const newCategories = categorizeItems(items);
-      this.setState(this.getCategoryState(activeTabs, newCategories));
-      if (this.hasActiveFilters(filters)) {
-        const filteredItems = this.filterItems(items);
-        const filteredCategories = recategorizeItems(filteredItems, newCategories);
-        this.setState(this.getCategoryState(activeTabs, filteredCategories));
-      }
-      this.setState(this.getFilterCounts(activeTabs, filters, filterCounts, newCategories));
-    }
-
-    if (filters !== prevState.filters) {
-      const filteredItems = this.filterItems(items);
-      const newCategories = recategorizeItems(filteredItems, categories);
-      this.setState(this.getCategoryState(activeTabs, newCategories));
-    }
-
-    if (activeTabs !== prevState.activeTabs) {
-      this.setState(this.getCategoryState(activeTabs, categories));
-    }
-
-    // filter counts are updated when new Category tab is selected or filter by name changed
-    if (activeTabs !== prevState.activeTabs || prevState.filters.byKeyword !== filters.byKeyword ) {
-      this.setState(this.getFilterCounts(activeTabs, filters, filterCounts, categories));
+      const categories = categorizeItems(items);
+      this.setState(this.getUpdatedState(categories, selectedCategory, filters));
     }
   }
 
-  hasActiveFilters(filters) {
+  getUpdatedState(categories, selectedCategory, filters) {
+    const { items } = this.props;
+    const { filterCounts } = this.state || {};
+
+    if (!items) {
+      return;
+    }
+
+    const updateFilterCounts = filterCounts ||
+      {
+        byType: {
+          clusterServiceClasses: 0,
+          imageStreams: 0,
+        },
+      };
+
+    const filteredItems = this.filterItems(items, filters);
+
+    const newCategories = recategorizeItems(filteredItems, categories);
+
+    return {
+      filters,
+      ...CatalogTileViewPage.getCategoryState(selectedCategory, newCategories),
+      filterCounts: this.getFilterCounts(selectedCategory, filters, updateFilterCounts, newCategories),
+    };
+  }
+
+  getUpdatedStateFromURLParams(paramsString) {
+    const { categories } = this.state;
+    const searchParams = new URLSearchParams(paramsString);
+    const categoryParam = searchParams.get(CATEGORY_URL_PARAM);
+    const keywordParam = searchParams.get(KEYWORD_URL_PARAM);
+    const byTypeParam = searchParams.get(TYPE_URL_PARAM);
+    try {
+      const typeFilters = byTypeParam ? JSON.parse(byTypeParam) : [];
+      const curCategory = categoryParam ? JSON.parse(categoryParam) : ['all'];
+      const filters = CatalogTileViewPage.getFilterState(keywordParam, typeFilters, defaultFilters);
+      return this.getUpdatedState(categories, curCategory, filters);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('could not update state from url params: could not parse search params');
+    }
+  }
+
+  static hasActiveFilters(filters) {
     const { byKeyword, byType } = filters;
     return byType.clusterServiceClass.active || byType.imageStream.active || byKeyword.active;
   }
 
-  getActiveCategories(activeTabs, categories) {
-    const mainCategory = _.find(categories, { id: _.first(activeTabs) });
-    const subCategory = activeTabs.length < 2 ? null : _.find(mainCategory.subcategories, { id: _.last(activeTabs) });
+  static getActiveCategories(selectedCategory, categories) {
+    const mainCategory = _.find(categories, { id: _.first(selectedCategory) });
+    const subCategory = selectedCategory.length < 2 ? null : _.find(mainCategory.subcategories, { id: _.last(selectedCategory) });
     return [mainCategory, subCategory];
   }
 
-  getFilterCounts(activeTabs, filters, filterCounts, categories) {
+  static getFilterState(keyword, byType, filters) {
+    const newFilters = _.cloneDeep(filters);
+    const active = !!keyword;
+    newFilters.byKeyword = { active, value: keyword || '' };
+    newFilters.byType.clusterServiceClass.active = _.includes(byType, 'clusterServiceClass');
+    newFilters.byType.imageStream.active = _.includes(byType, 'imageStream');
+
+    return newFilters;
+  }
+
+  getFilterCounts(selectedCategory, filters, filterCounts, categories) {
     const filteredItems = this.filterItemsForCounts(filters);
     const categoriesForCounts = recategorizeItems(filteredItems, categories);
 
-    const [ mainCategory, subCategory ] = this.getActiveCategories(activeTabs, categoriesForCounts);
+    const [ mainCategory, subCategory ] = CatalogTileViewPage.getActiveCategories(selectedCategory, categoriesForCounts);
     const items = subCategory ? subCategory.items : mainCategory.items;
 
     const count = _.countBy(items, 'kind');
@@ -117,50 +173,49 @@ export class CatalogTileViewPage extends React.Component {
     return newFilterCounts;
   }
 
-  getCategoryState(activeTabs, categories) {
-    const [ mainCategory, subCategory ] = this.getActiveCategories(activeTabs, categories);
+  static getCategoryState(selectedCategory, categories) {
+    const [ mainCategory, subCategory ] = CatalogTileViewPage.getActiveCategories(selectedCategory, categories);
     const currentCategories = mainCategory.subcategories || categories;
     const numItems = subCategory ? subCategory.numItems : mainCategory.numItems;
+    // showAllItemsForCategory if main category doesn't contain subcategories and not showing 'all categories' (ie. 'Other') OR subcategory has been selected
+    const showAllItemsForCategory = (_.isEmpty(mainCategory.subcategories) && _.first(selectedCategory) !== 'all') || subCategory !== null ? _.last(selectedCategory) : null;
 
     return {
       categories,
+      selectedCategory,
       currentCategories,
       numItems: numItems || 0,
+      showAllItemsForCategory,
     };
   }
 
-  isAllTabActive() {
-    const { activeTabs } = this.state;
-    return _.first(activeTabs) === 'all';
-  }
-
   activeTabIsSubCategory(subcategories) {
-    const { activeTabs } = this.state;
-    if (activeTabs.length < 2) {
+    const { selectedCategory } = this.state;
+    if (_.size(selectedCategory) < 2) {
       return false;
     }
 
-    const activeID = _.last(activeTabs);
+    const activeID = _.last(selectedCategory);
     return _.some(subcategories, { id: activeID });
   }
 
   isActiveTab(categoryID) {
-    const { activeTabs } = this.state;
-    const activeID = _.last(activeTabs);
+    const { selectedCategory } = this.state;
+    const activeID = _.last(selectedCategory);
     return activeID === categoryID;
   }
 
   hasActiveDescendant(categoryID) {
-    const { activeTabs } = this.state;
-    return _.first(activeTabs) === categoryID;
+    const { selectedCategory } = this.state;
+    return _.first(selectedCategory) === categoryID;
   }
 
   renderTabs(category, parentID = null){
     const { id, label, subcategories } = category;
     const active = this.isActiveTab(id);
     const onActivate = () => {
-      const tabs = parentID ? [parentID, id] : [id];
-      this.onActivateTab(tabs);
+      const selectedCategory = parentID ? [parentID, id] : [id];
+      this.selectCategory(selectedCategory);
     };
     const hasActiveDescendant = this.hasActiveDescendant(id);
     const shown = id === 'all';
@@ -185,50 +240,8 @@ export class CatalogTileViewPage extends React.Component {
     </VerticalTabs>;
   }
 
-  syncTabsAndTiles(category, parentCategory) {
-    const { categories } = this.state;
-    if (!parentCategory && category === 'all') {
-      this.setState({
-        activeTabs: [category],
-        currentCategories: categories,
-        numItems: _.first(categories).numItems,
-        showAllItemsForCategory: null,
-      });
-      return;
-    }
-
-    const { currentCategories } = this.state;
-    const tmpCategories = parentCategory ? currentCategories : categories;
-    const activeCategory = _.find(tmpCategories, { id: category });
-    if (!activeCategory) {
-      return;
-    }
-
-    const { numItems, subcategories } = activeCategory;
-    const state = {
-      activeTabs: parentCategory ? [parentCategory, category] : [category],
-      numItems: numItems || 0,
-    };
-    if (_.isEmpty(subcategories)) {
-      // no sub-categories, show all items for selected category
-      _.assign(state, {
-        currentCategories: categories,
-        showAllItemsForCategory: category,
-      });
-    } else {
-      // show list of sub-categories
-      _.assign(state, {
-        currentCategories: subcategories,
-        showAllItemsForCategory: null,
-      });
-    }
-    this.setState(state);
-  }
-
-  onActivateTab(tabs) {
-    const category = _.last(tabs);
-    const parent = tabs.length > 1 ? _.first(tabs) : null;
-    this.syncTabsAndTiles(category, parent);
+  selectCategory(selectedCategory) {
+    this.updateURL(CATEGORY_URL_PARAM, selectedCategory);
   }
 
   openOverlay(item) {
@@ -248,6 +261,8 @@ export class CatalogTileViewPage extends React.Component {
   renderCategoryTiles(category) {
     const { showAllItemsForCategory } = this.state;
     const { id, label, parentCategory, items } = category;
+    const selectedCategory = parentCategory ? [parentCategory, id] : [id];
+
     if (showAllItemsForCategory && id !== showAllItemsForCategory) {
       return null;
     }
@@ -257,7 +272,7 @@ export class CatalogTileViewPage extends React.Component {
       title={label}
       totalItems={items && category.items.length}
       viewAll={showAllItemsForCategory === id}
-      onViewAll={() => this.syncTabsAndTiles(id, parentCategory)}>
+      onViewAll={() => this.selectCategory(selectedCategory)}>
       {_.map(items, ((item) => {
         const { obj, tileName, tileImgUrl, tileIconClass, tileProvider, tileDescription } = item;
         const uid = obj.metadata.uid;
@@ -280,25 +295,24 @@ export class CatalogTileViewPage extends React.Component {
 
   getCategoryLabel(categoryID) {
     const { categories } = this.state;
+    if (!categoryID || !categories) {
+      return '';
+    }
+
     return _.find(categories, { id: categoryID }).label;
   }
 
-  filterByKeyword(items) {
-    const { filters } = this.state;
-    const { byKeyword } = filters;
-
-    const filterString = byKeyword.value.toLowerCase();
+  filterByKeyword(keyword, items) {
+    const filterString = keyword.toLowerCase();
     return _.filter(items, item => item.tileName.toLowerCase().includes(filterString) ||
       item.tileDescription.toLowerCase().includes(filterString) ||
       item.tags.includes(filterString));
   }
 
-  filterItems() {
-    const { filters } = this.state;
+  filterItems(items, filters) {
     const { byKeyword, byType } = filters;
-    const { items } = this.props;
 
-    if (!this.hasActiveFilters(filters) ) {
+    if (!CatalogTileViewPage.hasActiveFilters(filters) ) {
       return items;
     }
 
@@ -313,7 +327,7 @@ export class CatalogTileViewPage extends React.Component {
     }
 
     if (byKeyword.active) {
-      return this.filterByKeyword(byType.clusterServiceClass.active || byType.imageStream.active ? filteredItems : items);
+      return this.filterByKeyword(filters.byKeyword.value, byType.clusterServiceClass.active || byType.imageStream.active ? filteredItems : items);
     }
 
     return filteredItems;
@@ -324,37 +338,70 @@ export class CatalogTileViewPage extends React.Component {
     const { items } = this.props;
 
     if (byKeyword.active) {
-      return this.filterByKeyword(items);
+      return this.filterByKeyword(byKeyword.value, items);
     }
 
     return items;
   }
 
   clearFilters() {
-    const filters = _.cloneDeep(this.state.filters);
-    filters.byKeyword.active = filters.byType.clusterServiceClass.active = filters.byType.imageStream.active = false;
-    filters.byKeyword.value = '';
+    const params = new URLSearchParams(window.location.search);
+    params.delete(KEYWORD_URL_PARAM);
+    params.delete(TYPE_URL_PARAM);
+    const url = new URL(window.location);
+    const searchParams = `?${params.toString()}${url.hash}`;
+    history.replace(`${url.pathname}${searchParams}`);
+    if (this.unmounted) {
+      return;
+    }
+    this.setState(this.getUpdatedStateFromURLParams(searchParams));
     this.filterByKeywordInput.focus();
-    this.setState({filters});
+  }
+
+  updateURL(filterName, value) {
+    const params = new URLSearchParams(window.location.search);
+    if (value) {
+      params.set(filterName, Array.isArray(value) ? JSON.stringify(value) : value);
+    } else {
+      params.delete(filterName);
+    }
+    const url = new URL(window.location);
+    const searchParams = `?${params.toString()}${url.hash}`;
+    history.replace(`${url.pathname}${searchParams}`);
+    // do not set state if unmounted, case for when history.replace taking too much time
+    // and causes component to remount.  Noticeable in Safari
+    if (this.unmounted) {
+      return;
+    }
+    this.setState(this.getUpdatedStateFromURLParams(searchParams));
   }
 
   onFilterChange(filterType, id, value) {
-    const filters = _.cloneDeep(this.state.filters);
+    const { filters } = this.state;
+    const { byType } = filters;
+    let byTypeValues = [];
+
     if (filterType === 'byKeyword') {
-      const active = !!value;
-      filters[filterType] = { active, value };
+      this.updateURL(KEYWORD_URL_PARAM, value);
     } else {
-      filters[filterType][id].active = value;
+      if (value) {
+        byTypeValues.push(id);
+      }
+      _.forOwn(byType, (typeKeyValue, typeKey) => {
+        if (typeKey !== id && byType[typeKey].active) {
+          byTypeValues.push(typeKey);
+        }
+      });
+      this.updateURL(TYPE_URL_PARAM, _.isEmpty(byTypeValues) ? false : byTypeValues);
     }
-    this.setState({filters});
   }
 
   render() {
-    const { activeTabs, showAllItemsForCategory, currentCategories, numItems, filters, filterCounts, showOverlay, item } = this.state;
+    const { selectedCategory, showAllItemsForCategory, currentCategories, numItems, filters, filterCounts, showOverlay, item } = this.state;
     const { clusterServiceClass, imageStream } = filters.byType;
     const { clusterServiceClasses, imageStreams } = filterCounts.byType;
     const activeCategory = showAllItemsForCategory ? _.find(currentCategories, { id: showAllItemsForCategory }) : null;
-    const heading = activeCategory ? activeCategory.label : this.getCategoryLabel(_.first(activeTabs));
+    const heading = activeCategory ? activeCategory.label : this.getCategoryLabel(_.first(selectedCategory));
 
     return (
       <div className="co-catalog-page">

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8148,15 +8148,15 @@ patternfly-bootstrap-treeview@~2.1.0:
     bootstrap "3.3.x"
     jquery ">= 2.1.x"
 
-patternfly-react-extensions@2.11.1:
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/patternfly-react-extensions/-/patternfly-react-extensions-2.11.1.tgz#d2ed49b728b66a3afcf38940deb9697d11c2fa76"
+patternfly-react-extensions@2.12.8:
+  version "2.12.8"
+  resolved "https://registry.yarnpkg.com/patternfly-react-extensions/-/patternfly-react-extensions-2.12.8.tgz#268674846e3600517a07b8a0d80f2cf7305e39a5"
   dependencies:
     breakjs "^1.0.0"
     classnames "^2.2.5"
     css-element-queries "^1.0.1"
     patternfly "^3.52.1"
-    patternfly-react "^2.22.1"
+    patternfly-react "^2.23.0"
     react-virtualized "9.x"
 
 patternfly-react@^2.22.0:
@@ -8182,9 +8182,9 @@ patternfly-react@^2.22.0:
     sortabular "^1.5.1"
     table-resolver "^3.2.0"
 
-patternfly-react@^2.22.1:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.22.1.tgz#68c3661e806a7406ee8b30dc1a96c00eff502349"
+patternfly-react@^2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.23.0.tgz#da0e4d2f37dfab1ebce3a7a377052d2446c9d28c"
   dependencies:
     bootstrap-slider-without-jquery "^10.0.0"
     breakjs "^1.0.0"

--- a/sources
+++ b/sources
@@ -1,2 +1,2 @@
 401aa1438604b8e32306fa2bd4f8e211  node-v8.9.4-headers.tar.gz
-5a31a2c68718575bd3b1d239e9b2c103  yarn-offline.tar
+f616e2f2c2d078384c84ae06d15b9efc  yarn-offline.tar


### PR DESCRIPTION
Catalog category and filter selections are now being persisted in the url.

Ex (using JSON.stringify/JSON.parse for search params):
http://0.0.0.0:9001/catalog/ns/default?category=%5B%22languages%22%2C%22dotnet%22%5D&by-type=%5B%22clusterServiceClass%22%2C%22imageStream%22%5D&keyword=ex

In general, not happy with hardcoded category levels (2) and filtering by known types (service-class and imagestream).  Hopefully, when #643 merges we can start working on shared catalog utils and support any number of category/subcategory levels, and dynamic filtering categories (ex. by vendor, where vendor filter values are dynamic, gathered from passed in items).