### PR TITLE
Add labels list to Alert details and Silence details pages

### DIFF
--- a/frontend/public/components/_monitoring.scss
+++ b/frontend/public/components/_monitoring.scss
@@ -9,7 +9,7 @@
 
 $monitoring-line-height: 18px;
 
-.monitoring-description, .monitoring-timestamp {
+.monitoring-description, .monitoring-label-list, .monitoring-timestamp {
   line-height: $monitoring-line-height;
   margin-top: 4px;
 }

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -149,6 +149,16 @@ const Annotation = ({children, title}) => _.isNil(children)
   ? null
   : <React.Fragment><dt>{title}</dt><dd>{children}</dd></React.Fragment>;
 
+const Label = ({k, v}) => <div className="co-m-label co-m-label--expand" key={k}>
+  <span className="co-m-label__key">{k}</span>
+  <span className="co-m-label__eq">=</span>
+  <span className="co-m-label__value">{v}</span>
+</div>;
+
+const SilenceMatchersList = ({silence}) => <div className={`co-text-${SilenceResource.kind.toLowerCase()}`}>
+  {_.map(silence.matchers, ({name, isRegex, value}) => <Label key={name} k={name} v={isRegex ? `~${value}` : value} />)}
+</div>;
+
 class MonitoringPageWrapper extends SafetyFirst<AlertsPageWrapperProps, null> {
   componentDidMount () {
     super.componentDidMount();
@@ -271,6 +281,13 @@ const AlertsDetailsPage_ = connect(alertStateToProps)((props: AlertsDetailsPageP
               <dl className="co-m-pane__details">
                 <dt>Name</dt>
                 <dd>{alertname}</dd>
+                <dt>Labels</dt>
+                <dd>{_.isEmpty(labels)
+                  ? <div className="text-muted">No labels</div>
+                  : <div className={`co-text-${AlertResource.kind.toLowerCase()}`}>
+                    {_.map(labels, (v, k) => <Label key={k} k={k} v={v} />)}
+                  </div>
+                }</dd>
                 {severity && <React.Fragment>
                   <dt>Severity</dt>
                   <dd>{_.startCase(severity)}</dd>
@@ -497,6 +514,11 @@ const SilencesDetailsPage_ = connect(silenceParamToProps)((props: SilencesDetail
                   <dt>Name</dt>
                   <dd>{silence.name}</dd>
                 </React.Fragment>}
+                <dt>Matchers</dt>
+                <dd>{_.isEmpty(silence.matchers)
+                  ? <div className="text-muted">No matchers</div>
+                  : <SilenceMatchersList silence={silence} />
+                }</dd>
                 <dt>State</dt>
                 <dd><SilenceState silence={silence} /></dd>
                 <dt>Last Updated At</dt>
@@ -719,6 +741,9 @@ const SilenceRow = ({obj}) => {
           <MonitoringResourceIcon resource={SilenceResource} />
           <Link className="co-resource-link__resource-name" title={obj.id} to={`${SilenceResource.path}/${obj.id}`}>{obj.name}</Link>
         </div>
+      </div>
+      <div className="monitoring-label-list">
+        <SilenceMatchersList silence={obj} />
       </div>
     </div>
     <div className="col-xs-3">

--- a/frontend/public/style/_text.scss
+++ b/frontend/public/style/_text.scss
@@ -17,6 +17,7 @@ $kinds: (
   service: $color-service-dark,
   serviceaccount: $color-serviceaccount-dark,
   servicemonitor: $color-service-dark,
+  silence: $color-alert-dark,
   alertmanager: $color-alertmanager-dark,
 );
 


### PR DESCRIPTION
Unlike most Console labels, these labels don't link to the Search page
because there is no Search page for Alerts or Silences.

Doesn't use the existing `LabelList` component because that creates labels
that link to the Search page.

Will conflict with #715 

FYI @cshinn 

<img width="1199" alt="screenshot-1" src="https://user-images.githubusercontent.com/460802/47764659-7ad4a300-dd09-11e8-808f-ea4fdf3bc91a.png">

![screenshot-2](https://user-images.githubusercontent.com/460802/47764673-8758fb80-dd09-11e8-9af4-e1cabdc5695e.png)

<img width="1300" alt="screenshot-1" src="https://user-images.githubusercontent.com/460802/47830475-53480e00-ddcf-11e8-8f8a-730db19969a8.png">
