### PR TITLE
Monitoring nav fixes

### DIFF
--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -280,9 +280,9 @@ const ClusterPickerNavSection = connectToFlags(FLAGS.OPENSHIFT)(({flags}) => {
 const MonitoringNavSection_ = ({urls, closeMenu}) => {
   const prometheusURL = urls[MonitoringRoutes.Prometheus];
   const grafanaURL = urls[MonitoringRoutes.Grafana];
-  return prometheusURL || grafanaURL
+  return window.SERVER_FLAGS.prometheusBaseURL || prometheusURL || grafanaURL
     ? <NavSection text="Monitoring" icon="pficon pficon-screen">
-      {prometheusURL && <HrefLink href="/monitoring" name="Alerts" onClick={closeMenu} />}
+      {window.SERVER_FLAGS.prometheusBaseURL && <HrefLink href="/monitoring" name="Alerts" onClick={closeMenu} />}
       {prometheusURL && <HrefLink href={prometheusURL} target="_blank" name="Metrics" onClick={closeMenu} isExternal={true} />}
       {grafanaURL && <HrefLink href={grafanaURL} target="_blank" name="Dashboards" onClick={closeMenu} isExternal={true} />}
     </NavSection>

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -288,7 +288,7 @@ const MonitoringNavSection_ = ({urls, closeMenu}) => {
     </NavSection>
     : null;
 };
-const MonitoringNavSection = connectToURLs(MonitoringRoutes.Prometheus, MonitoringRoutes.AlertManager, MonitoringRoutes.Grafana)(MonitoringNavSection_);
+const MonitoringNavSection = connectToURLs(MonitoringRoutes.Prometheus, MonitoringRoutes.Grafana)(MonitoringNavSection_);
 
 const UserNavSection = connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.OPENSHIFT)(({flags, closeMenu}) => {
   if (!flags[FLAGS.AUTH_ENABLED] || flagPending(flags[FLAGS.OPENSHIFT])) {


### PR DESCRIPTION
Use the existence of `SERVER_FLAGS.prometheusBaseURL` to determine whether
to show the Monitoring UI. This is the URL of the Prometheus API, which
provides the data for the Monitoring UI. The `MonitoringRoutes.Prometheus`
URL just provides the Prometheus UI URL, which is not essential for
displaying the Monitoring UI.

Also remove redundant Redux connect to `MonitoringRoutes.AlertManager` URL.