### PR TITLE
Removing duplicate k8s-watcher

### DIFF
--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -8,11 +8,12 @@ import { Link } from 'react-router-dom';
 import k8sActions from '../../module/k8s/k8s-actions';
 import { CheckBoxes, storagePrefix } from '../row-filter';
 import { ErrorPage404 } from '../error';
-import { makeReduxID, makeQuery } from '../utils/k8s-watcher';
 import { referenceForModel } from '../../module/k8s';
 import {
   Dropdown,
   Firehose,
+  makeReduxID,
+  makeQuery,
   history,
   inject,
   kindObj,

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -4,43 +4,8 @@ import * as PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 
-import { inject } from './index';
+import { inject, makeReduxID, makeQuery } from './index';
 import actions from '../../module/k8s/k8s-actions';
-
-export const makeReduxID = (k8sKind = {}, query) => {
-  let qs = '';
-  if (!_.isEmpty(query)) {
-    qs = `---${JSON.stringify(query)}`;
-  }
-
-  return `${k8sKind.plural}${qs}`;
-};
-
-/** @type {(namespace: string, labelSelector?: any, fieldSelector?: any, name?: string) => {[key: string]: string}} */
-export const makeQuery = (namespace, labelSelector, fieldSelector, name, limit) => {
-  const query = {};
-
-  if (!_.isEmpty(labelSelector)) {
-    query.labelSelector = labelSelector;
-  }
-
-  if (!_.isEmpty(namespace)) {
-    query.ns = namespace;
-  }
-
-  if (!_.isEmpty(name)) {
-    query.name = name;
-  }
-
-  if (fieldSelector) {
-    query.fieldSelector = fieldSelector;
-  }
-
-  if (limit) {
-    query.limit = limit;
-  }
-  return query;
-};
 
 const processReduxId = ({k8s}, props) => {
   const {reduxID, isList, filters} = props;

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -46,6 +46,7 @@ export * from './container-table';
 export * from './simple-tab-nav';
 export * from './request-size-input';
 export * from './name-value-editor';
+export * from './k8s-watcher';
 
 /*
   Add the enum for NameValueEditorPair here and not in its namesake file because the editor should always be

--- a/frontend/public/components/utils/k8s-watcher.js
+++ b/frontend/public/components/utils/k8s-watcher.js
@@ -1,6 +1,6 @@
 import * as _ from 'lodash-es';
 
-export const makeReduxID = (k8sKind, query) => {
+export const makeReduxID = (k8sKind = {}, query) => {
   let qs = '';
   if (!_.isEmpty(query)) {
     qs = `---${JSON.stringify(query)}`;
@@ -9,7 +9,8 @@ export const makeReduxID = (k8sKind, query) => {
   return `${k8sKind.plural}${qs}`;
 };
 
-export const makeQuery = (namespace, labelSelector, fieldSelector, name) => {
+/** @type {(namespace: string, labelSelector?: any, fieldSelector?: any, name?: string) => {[key: string]: string}} */
+export const makeQuery = (namespace, labelSelector, fieldSelector, name, limit) => {
   const query = {};
 
   if (!_.isEmpty(labelSelector)) {
@@ -26,6 +27,10 @@ export const makeQuery = (namespace, labelSelector, fieldSelector, name) => {
 
   if (fieldSelector) {
     query.fieldSelector = fieldSelector;
+  }
+
+  if (limit) {
+    query.limit = limit;
   }
   return query;
 };


### PR DESCRIPTION
While working on https://github.com/openshift/console/pull/682 I've found this duplicate code. Not sure what was the purpose but a I guess the k8s-watcher should be replaced by the one in [firehose.jsx](https://github.com/openshift/console/blob/c89885586f29ecdd203343b2411c1005babe5f9d/frontend/public/components/utils/firehose.jsx#L10-L43)

/assign @spadgett