### PR TITLE
Fix bug where itemIconClass wasn't passed to <CatalogItemHeader>

### DIFF
--- a/frontend/public/components/marketplace/marketplace-item-modal.jsx
+++ b/frontend/public/components/marketplace/marketplace-item-modal.jsx
@@ -7,7 +7,7 @@ import {PropertiesSidePanel, PropertyItem} from 'patternfly-react-extensions/dis
 
 const MarketplaceItemModal = (props) => {
   const { item, close /* openSubscribe */ } = props;
-  const { itemName, itemImgUrl, provider, description, version, certifiedLevel, healthIndex, repository, containerImage, createdAt, support } = item;
+  const { itemName, itemIconClass, itemImgUrl, provider, description, version, certifiedLevel, healthIndex, repository, containerImage, createdAt, support } = item;
   const notAvailable = <span className="properties-side-panel-pf-property-label">N/A</span>;
   const MarketplaceProperty = ({label, value}) => {
     return <PropertyItem label={label} value={value || notAvailable} />;
@@ -17,6 +17,7 @@ const MarketplaceItemModal = (props) => {
       <Modal.Header>
         <CatalogItemHeader
           className="co-marketplace-modal__item-header"
+          iconClass={itemIconClass}
           iconImg={itemImgUrl}
           title={itemName}
           vendor={<span> {provider}</span>}


### PR DESCRIPTION
Before:
![screen shot 2018-11-01 at 10 19 01 am](https://user-images.githubusercontent.com/895728/47857285-9dc18e80-ddbf-11e8-9be3-61faef3d8cf9.PNG)

After:
![screen shot 2018-11-01 at 10 19 06 am](https://user-images.githubusercontent.com/895728/47857289-a2864280-ddbf-11e8-8250-e86b835fb91c.PNG)

cc: @galletti94 