### PR TITLE
Correct the sidebar tab alignment with edge of content

### DIFF
--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -78,7 +78,10 @@ $co-m-horizontal-nav__menu-item-link-padding-lr-mobile: 15px;
 
 .overview__sidebar {
   .co-m-horizontal-nav__menu {
-    padding: 0 20px;
+    padding: 0 5px;
+    @media (min-width: $grid-float-breakpoint) {
+      padding: 0 20px;
+    }
   }
   .co-m-horizontal-nav__menu-item {
     font-size: 16px;


### PR DESCRIPTION
**before**
<img width="227" alt="tabs-before" src="https://user-images.githubusercontent.com/1874151/47858438-73250500-ddc2-11e8-9a6b-87282f658fe9.png">



**after**
<img width="227" alt="tabs-after" src="https://user-images.githubusercontent.com/1874151/47858443-75875f00-ddc2-11e8-91c0-1d4206d29258.png">
