### PR TITLE
Monitoring: Change list header areas to better match non-Monitoring list pages

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -653,7 +653,7 @@ const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringListPage
       <Helmet>
         <title>Monitoring Alerts</title>
       </Helmet>
-      <div className="co-m-nav-title co-m-nav-title--detail">
+      <div className="co-m-nav-title">
         <h1 className="co-m-pane__heading">
           <div className="co-m-pane__name">
             Monitoring Alerts &nbsp;<span className="monitoring-header-link"><AlertmanagerLink text="Alertmanager UI" /></span>

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -647,7 +647,7 @@ const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringListPage
   }
 
   render () {
-    const {CreateButton, data, filters, Header, loaded, loadError, match, PageDescription, reduxID, Row, rowFilter, textFilterLabel} = this.props;
+    const {CreateButton, data, filters, Header, loaded, loadError, PageDescription, reduxID, Row, rowFilter, textFilterLabel} = this.props;
 
     return <React.Fragment>
       <Helmet>
@@ -660,15 +660,6 @@ const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringListPage
           </div>
         </h1>
       </div>
-      <ul className="co-m-horizontal-nav__menu">
-        <li className={classNames('co-m-horizontal-nav__menu-item', {'co-m-horizontal-nav-item--active': match.path === AlertResource.path})}>
-          <Link to={AlertResource.path}>Alerts</Link>
-        </li>
-        <li className={classNames('co-m-horizontal-nav__menu-item', {'co-m-horizontal-nav-item--active': match.path === SilenceResource.path})}>
-          <Link to={SilenceResource.path}>Silences</Link>
-        </li>
-        <li className="co-m-horizontal-nav__menu-item co-m-horizontal-nav__menu-item--divider"></li>
-      </ul>
       <div className="co-m-pane__filter-bar co-m-pane__filter-bar--with-help-text">
         {PageDescription && <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--help-text">
           <PageDescription />


### PR DESCRIPTION
Remove list page tabs.
Both Alerts and Silences are now listed in the sidebar, so we don't need
the tabs and removing them makes the style more consistent with other
list pages.

Remove "co-m-nav-title--detail" class from the Monitoring list page
headings to match the style of non-Monitoring list pages.

FYI @cshinn 

## Before
![screenshot-1](https://user-images.githubusercontent.com/460802/47898657-19a00180-deba-11e8-8b87-043bb9663e38.png)

## After
![screenshot-2](https://user-images.githubusercontent.com/460802/47898661-1f95e280-deba-11e8-9f6c-da0b2b3538a8.png)
