### PR TITLE
Monitoring: Remove unnecessary check for Silence state "inactive"

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -133,9 +133,6 @@ const AlertState: React.SFC<StateProps> = ({state}) => {
 
 const SilenceState = ({silence}) => {
   const state = silenceState(silence);
-  if (state === 'inactive') {
-    return <span className="text-muted">{_.startCase(state)}</span>;
-  }
   const stateToIconClassName = {
     active: 'fa fa-check-circle-o silence-active',
     pending: 'fa fa-hourglass-half silence-pending',


### PR DESCRIPTION
Silences never have the state "inactive", so this check was redundant.