### PR TITLE
Monitoring: Change some state icons

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -135,7 +135,7 @@ const AlertState: React.SFC<AlertStateProps> = ({state}) => {
   const stateToIconClassName = {
     firing: 'fa fa-bell alert-firing',
     silenced: 'fa fa-bell-slash text-muted',
-    pending: 'fa fa-exclamation-triangle alert-pending',
+    pending: 'fa fa-bell-o alert-pending',
   };
   const klass = stateToIconClassName[state];
   return klass ? <React.Fragment><i className={klass} aria-hidden="true"></i> {_.startCase(state)}</React.Fragment> : null;
@@ -146,7 +146,7 @@ const SilenceState = ({silence}) => {
   const stateToIconClassName = {
     active: 'fa fa-check-circle-o silence-active',
     pending: 'fa fa-hourglass-half silence-pending',
-    expired: 'fa fa-times-circle-o text-muted',
+    expired: 'fa fa-ban text-muted',
   };
   const klass = stateToIconClassName[state];
   return klass ? <React.Fragment><i className={klass} aria-hidden="true"></i> {_.startCase(state)}</React.Fragment> : null;

--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -27,7 +27,10 @@
   color: $color-pf-red;
 }
 
-.alert-pending,
-.silence-pending {
+.alert-pending {
   color: $color-pf-orange-300;
+}
+
+.silence-pending {
+  color: $color-pf-black-700;
 }


### PR DESCRIPTION
Change Alert pending, Silence pending and Silence expired icons.

FYI @cshinn 

| &nbsp; | Before | After |
|--|--|--|
| Alerts | ![screenshot-3](https://user-images.githubusercontent.com/460802/47900514-90d89400-dec0-11e8-92bb-2c98c43c4c93.png) | ![screenshot-4](https://user-images.githubusercontent.com/460802/47900728-4277c500-dec1-11e8-8141-ce337b48c9fe.png) |
Silences | ![screenshot-2](https://user-images.githubusercontent.com/460802/47900688-2116d900-dec1-11e8-8f62-66101123435c.png) | ![screenshot-1](https://user-images.githubusercontent.com/460802/48040057-c4fece00-e1ba-11e8-8a59-83059613f35b.png) |
