### PR TITLE
Design Fixes for ClusterServiceVersion Detail View

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -295,10 +295,10 @@ describe(ClusterServiceVersionsDetailsPage.displayName, () => {
     expect(detailsPage.props().pagesFor(testClusterServiceVersion)[0].name).toEqual('Overview');
     expect(detailsPage.props().pagesFor(testClusterServiceVersion)[0].href).toEqual('');
     expect(detailsPage.props().pagesFor(testClusterServiceVersion)[0].component).toEqual(ClusterServiceVersionDetails);
-    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[1].name).toEqual('Events');
-    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[1].href).toEqual('events');
-    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[2].name).toEqual('YAML');
-    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[2].href).toEqual('yaml');
+    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[1].name).toEqual('YAML');
+    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[1].href).toEqual('yaml');
+    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[2].name).toEqual('Events');
+    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[2].href).toEqual('events');
   });
 
   it('includes tab for each "owned" CRD', () => {

--- a/frontend/public/components/operator-lifecycle-manager/_operator-lifecycle-manager.scss
+++ b/frontend/public/components/operator-lifecycle-manager/_operator-lifecycle-manager.scss
@@ -57,7 +57,7 @@
   padding: 0 15px;
   max-width: 300px;
   min-width: 300px;
-  margin: 0 10px 20px 10px;
+  margin: 0 20px 20px 0;
 }
 
 .co-crd-card:hover {

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -187,9 +187,7 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
           <div className="col-sm-9">
             {status.phase !== ClusterServiceVersionPhase.CSVPhaseSucceeded && <Alert type="error"><strong>{status.phase}</strong>: {status.message}</Alert>}
             <SectionHeading text="Provided APIs" />
-            <div style={{width: '80%'}}>
-              <CRDCardRow csv={props.obj} crdDescs={spec.customresourcedefinitions.owned} />
-            </div>
+            <CRDCardRow csv={props.obj} crdDescs={spec.customresourcedefinitions.owned} />
             <SectionHeading text="Description" />
             <MarkdownView content={spec.description || 'Not available'} />
           </div>
@@ -246,8 +244,8 @@ export const ClusterServiceVersionsDetailsPage: React.StatelessComponent<Cluster
     name={props.match.params.name}
     pagesFor={(obj: ClusterServiceVersionKind) => [
       navFactory.details(ClusterServiceVersionDetails),
-      navFactory.events(ResourceEventStream),
       navFactory.editYaml(),
+      navFactory.events(ResourceEventStream),
       ...instancePagesFor(obj),
     ]}
     menuActions={menuActions} />;


### PR DESCRIPTION
### Description

Fixes some design styling for `ClusterServiceVersion` detail view.

Addresses https://github.com/openshift/console/pull/684#issuecomment-435551404