### PR TITLE
Remove 'zone' and 'zones' fields from aws-ebs storage class provisioner

### DIFF
--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -51,26 +51,6 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
           values: {io1: 'io1', gp2: 'gp2', sc1: 'sc1', st1: 'st1'},
           hintText: 'Select AWS Type'
         },
-        zone: {
-          name: 'Zone',
-          hintText: 'AWS zone',
-          validation: (params) => {
-            if (params.zone.value !== '' && _.get(params, 'zones.value', '') !== '') {
-              return 'Zone and zones parameters must not be used at the same time.';
-            }
-            return null;
-          }
-        },
-        zones: {
-          name: 'Zones',
-          hintText: 'AWS zones',
-          validation: (params) => {
-            if (params.zones.value !== '' && _.get(params, 'zone.value', '') !== '') {
-              return 'Zone and zones parameters must not be used at the same time.';
-            }
-            return null;
-          }
-        },
         iopsPerGB: {
           name: 'IOPS Per GiB',
           hintText: 'I/O operations per second per GiB',


### PR DESCRIPTION
This PR is to remove the 'zone' and 'zones' fields from the aws-ebs storage class provisioner in the storage class creation form, as they are deprecated as of kubernetes version 1.12.

See https://bugzilla.redhat.com/show_bug.cgi?id=1642352 