### PR TITLE
Kubernetes Marketplace - Fix default logo to match OLM

### DIFF
--- a/frontend/public/components/marketplace/kubernetes-marketplace.jsx
+++ b/frontend/public/components/marketplace/kubernetes-marketplace.jsx
@@ -8,6 +8,7 @@ import {referenceForModel} from '../../module/k8s';
 import {PackageManifestModel} from '../../models';
 import {MarketplaceItemModal} from './marketplace-item-modal';
 import {MarketplaceTileViewPage} from './kubernetes-marketplace-items';
+import * as operatorImg from '../../imgs/operator.svg';
 
 const normalizePackageManifests = (packageManifests, kind) => {
   const activePackageManifests = _.filter(packageManifests, packageManifest => {
@@ -18,7 +19,7 @@ const normalizePackageManifests = (packageManifests, kind) => {
     const uid = `${name}/${packageManifest.status.catalogSourceNamespace}`;
     const defaultIconClass = 'fa fa-clone'; // TODO: get this info from the packagemanifest
     const iconObj = _.get(packageManifest, 'status.channels[0].currentCSVDesc.icon[0]');
-    const imgUrl = iconObj && `data:${iconObj.mediatype};base64,${iconObj.base64data}`;
+    const imgUrl = iconObj ? `data:${iconObj.mediatype};base64,${iconObj.base64data}` : operatorImg;
     const iconClass = imgUrl ? null : defaultIconClass;
     const provider = _.get(packageManifest, 'metadata.labels.provider');
     const tags = packageManifest.metadata.tags;


### PR DESCRIPTION
Changes the default icon shown in marketplace when the data is missing from the CSV to match the logo displayed in OLM - this is a small patch for consistency.

Previous:

![screenshot from 2018-11-06 10-59-47](https://user-images.githubusercontent.com/20077170/48076429-27ec6700-e1b3-11e8-9c4f-2b9c152f000f.png)
![screenshot from 2018-11-06 11-00-00](https://user-images.githubusercontent.com/20077170/48076430-27ec6700-e1b3-11e8-8c83-a3e64aac4915.png)

Current:

![screenshot from 2018-11-06 11-00-52](https://user-images.githubusercontent.com/20077170/48076487-43f00880-e1b3-11e8-95b1-1070b517e11b.png)
