### PR TITLE
Revisions to overview-sidebar transition

### DIFF
--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -53,23 +53,21 @@
     @media(min-width: $screen-sm-min) {
       width: 550px;
     }
-    transition:
-      transform 125ms ease-out,
-      opacity 175ms linear;
     z-index: 5;
   }
 
-  @media(max-width: $screen-xs-max) {
     .overview__sidebar-appear {
-      transform: translateX(7px);
-      opacity: .75;
+      opacity: 0;
+      transform: translateX(10%);
     }
 
     .overview__sidebar-appear-active {
-      transform: translateX(0);
       opacity: 1;
+      transform: translateX(0);
+      transition:
+        opacity 175ms ease-out,
+        transform 225ms ease-out;
     }
-  }
 
   &.overview--sidebar-shown {
     .overview__sidebar {

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -852,7 +852,8 @@ export const Overview = connect<OverviewPropsFromState, {}, OverviewOwnProps>(ov
     </div>
     {
       !_.isEmpty(selectedItem) &&
-      <CSSTransition in appear timeout={1} classNames="overview__sidebar">
+      <CSSTransition
+        appear={true} in timeout={225} classNames="overview__sidebar">
         <div className="overview__sidebar">
           <div className="overview__sidebar-dismiss clearfix">
             <CloseButton onClick={() => store.dispatch(UIActions.selectOverviewItem(''))} />


### PR DESCRIPTION
Moves the `transition` property to the `overview__sidebar-appear-active` className that's added by react-transition-group. Make `timeout` same as transition-duration. 
Improves smoothness of transition by adjusting duration, offset distance and opacity. This effect aligns more closely with the "add from catalog" modal transition. Also enable behavior at desktop widths.

cc @alecmerdler 


![sidbar-transition-mobile](https://user-images.githubusercontent.com/1874151/48089711-1dda6080-e1d3-11e8-80b8-ea811efdf508.gif)


![sidbar-transition](https://user-images.githubusercontent.com/1874151/48089716-216de780-e1d3-11e8-8142-5613092c379b.gif)
