### PR TITLE
Investigate adding ErrorBoundry to ListView

### DIFF
--- a/frontend/public/components/error.tsx
+++ b/frontend/public/components/error.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { ExpandCollapse } from 'patternfly-react';
 import { Helmet } from 'react-helmet';
 
 import { getQueryArgument, PageHeading } from './utils';
@@ -62,6 +63,26 @@ export const ErrorPage404: React.SFC<ErrorPage404Props> = (props) => <div>
   <ErrorComponent title="404: Page Not Found" message={props.message} errMessage={props.errMessage} />
 </div>;
 
+export const ErrorBoundaryFallbackComponent: React.SFC<ErrorBoundaryFallbackComponentProps> = (props) =>
+  <div className="co-m-pane__body">
+    <h1 className="co-m-pane__heading co-m-pane__heading--center">Oh no! Something went wrong.</h1>
+    <ExpandCollapse textCollapsed="Show error details..." textExpanded="Hide error details..." bordered={false}>
+      <h3 className="co-section-heading-tertiary">{props.title}</h3>
+      <div>
+        <strong>Description: </strong>
+        {props.errorMessage}
+      </div>
+      <div className="text-muted">
+        <strong>Component Trace: </strong>
+        {props.componentStack}
+      </div>
+      <div className="text-muted">
+        <strong>Stack Trace: </strong>
+        {props.stack}
+      </div>
+    </ExpandCollapse>
+  </div>;
+
 export type ErrorComponentProps = {
   title: string;
   message?: string;
@@ -70,3 +91,9 @@ export type ErrorComponentProps = {
 
 export type ErrorPageProps = {};
 export type ErrorPage404Props = Omit<ErrorComponentProps, 'title'>;
+export type ErrorBoundaryFallbackComponentProps = {
+  errorMessage: string;
+  componentStack: string;
+  stack: string;
+  title: string;
+};

--- a/frontend/public/components/error.tsx
+++ b/frontend/public/components/error.tsx
@@ -77,7 +77,7 @@ export const ErrorBoundaryFallback: React.SFC<ErrorBoundaryFallbackProps> = (pro
         <div className="form-group">
           <label htmlFor="componentTrace">Component Trace: </label>
           <div className="co-copy-to-clipboard__stacktrace-width-height">
-            <CopyToClipboard value={props.componentStack.trim()} className="co-copy-to-clipboard__stacktrace-height" />
+            <CopyToClipboard value={props.componentStack.trim()} />
           </div>
         </div>
         <div className="form-group">

--- a/frontend/public/components/error.tsx
+++ b/frontend/public/components/error.tsx
@@ -4,7 +4,8 @@ import * as React from 'react';
 import { ExpandCollapse } from 'patternfly-react';
 import { Helmet } from 'react-helmet';
 
-import { getQueryArgument, PageHeading } from './utils';
+import {CopyToClipboard, getQueryArgument, PageHeading} from './utils';
+import {ErrorBoundaryFallbackProps} from './utils/error-boundary';
 
 // User messages for error_types returned in auth.go
 const messages = {
@@ -63,24 +64,30 @@ export const ErrorPage404: React.SFC<ErrorPage404Props> = (props) => <div>
   <ErrorComponent title="404: Page Not Found" message={props.message} errMessage={props.errMessage} />
 </div>;
 
-export const ErrorBoundaryFallbackComponent: React.SFC<ErrorBoundaryFallbackComponentProps> = (props) =>
+export const ErrorBoundaryFallback: React.SFC<ErrorBoundaryFallbackProps> = (props) =>
   <div className="co-m-pane__body">
     <h1 className="co-m-pane__heading co-m-pane__heading--center">Oh no! Something went wrong.</h1>
-    <ExpandCollapse textCollapsed="Show error details..." textExpanded="Hide error details..." bordered={false}>
-      <h3 className="co-section-heading-tertiary">{props.title}</h3>
-      <div>
-        <strong>Description: </strong>
-        {props.errorMessage}
-      </div>
-      <div className="text-muted">
-        <strong>Component Trace: </strong>
-        {props.componentStack}
-      </div>
-      <div className="text-muted">
-        <strong>Stack Trace: </strong>
-        {props.stack}
-      </div>
-    </ExpandCollapse>
+    <div className="row">
+      <ExpandCollapse textCollapsed="Show error details..." textExpanded="Hide error details..." bordered={false}>
+        <h3 className="co-section-heading-tertiary">{props.title}</h3>
+        <div className="form-group">
+          <label htmlFor="description">Description: </label>
+          <p>{props.errorMessage}</p>
+        </div>
+        <div className="form-group">
+          <label htmlFor="componentTrace">Component Trace: </label>
+          <div className="co-copy-to-clipboard__stacktrace-width-height">
+            <CopyToClipboard value={props.componentStack.trim()} className="co-copy-to-clipboard__stacktrace-height" />
+          </div>
+        </div>
+        <div className="form-group">
+          <label htmlFor="stackTrace">Stack Trace: </label>
+          <div className="co-copy-to-clipboard__stacktrace-width-height">
+            <CopyToClipboard value={props.stack.trim()} />
+          </div>
+        </div>
+      </ExpandCollapse>
+    </div>
   </div>;
 
 export type ErrorComponentProps = {
@@ -91,9 +98,4 @@ export type ErrorComponentProps = {
 
 export type ErrorPageProps = {};
 export type ErrorPage404Props = Omit<ErrorComponentProps, 'title'>;
-export type ErrorBoundaryFallbackComponentProps = {
-  errorMessage: string;
-  componentStack: string;
-  stack: string;
-  title: string;
-};
+

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 
 import k8sActions from '../../module/k8s/k8s-actions';
 import { CheckBoxes, storagePrefix } from '../row-filter';
-import { ErrorPage404 } from '../error';
+import { ErrorPage404, ErrorBoundaryFallbackComponent } from '../error';
 import { referenceForModel } from '../../module/k8s';
 import {
   Dropdown,
@@ -18,6 +18,7 @@ import {
   inject,
   kindObj,
   PageHeading,
+  withFallback,
 } from '../utils';
 
 export const CompactExpandButtons = ({expand = false, onExpandChange = _.noop}) => <div className="btn-group btn-group-sm" data-toggle="buttons">
@@ -268,6 +269,8 @@ FireMan_.propTypes = {
   title: PropTypes.string,
 };
 
+export const listPageWithFallback = Page => withFallback(props => <ListPage {...props} Page={Page} />, ErrorBoundaryFallbackComponent);
+
 /** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, helpText?: any, namespace?: string, filterLabel?: string, textFilter?: string, title?: string, showTitle?: boolean, dropdownFilters?: any[], rowFilters?: any[], selector?: any, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, mock?: boolean}>} */
 export const ListPage = props => {
   const {
@@ -350,6 +353,7 @@ export const ListPage = props => {
 };
 
 ListPage.displayName = 'ListPage';
+export const ListPageWrapper = listPageWithFallback(ListPage);
 
 /** @type {React.SFC<{canCreate?: boolean, createButtonText?: string, createProps?: any, flatten?: Function, title?: string, showTitle?: boolean, helpText?: any, dropdownFilters?: any[], filterLabel?: string, rowFilters?: any[], resources: any[], ListComponent: React.ComponentType<any>, namespace?: string}>} */
 export const MultiListPage = props => {

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -9,6 +9,7 @@ import k8sActions from '../../module/k8s/k8s-actions';
 import { CheckBoxes, storagePrefix } from '../row-filter';
 import { ErrorPage404, ErrorBoundaryFallbackComponent } from '../error';
 import { referenceForModel } from '../../module/k8s';
+import { withFallback } from '../utils/error-boundary';
 import {
   Dropdown,
   Firehose,
@@ -18,7 +19,6 @@ import {
   inject,
   kindObj,
   PageHeading,
-  withFallback,
 } from '../utils';
 
 export const CompactExpandButtons = ({expand = false, onExpandChange = _.noop}) => <div className="btn-group btn-group-sm" data-toggle="buttons">

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 
 import k8sActions from '../../module/k8s/k8s-actions';
 import { CheckBoxes, storagePrefix } from '../row-filter';
-import { ErrorPage404, ErrorBoundaryFallbackComponent } from '../error';
+import { ErrorPage404, ErrorBoundaryFallback } from '../error';
 import { referenceForModel } from '../../module/k8s';
 import { withFallback } from '../utils/error-boundary';
 import {
@@ -269,10 +269,8 @@ FireMan_.propTypes = {
   title: PropTypes.string,
 };
 
-export const listPageWithFallback = Page => withFallback(props => <ListPage {...props} Page={Page} />, ErrorBoundaryFallbackComponent);
-
 /** @type {React.SFC<{ListComponent: React.ComponentType<any>, kind: string, helpText?: any, namespace?: string, filterLabel?: string, textFilter?: string, title?: string, showTitle?: boolean, dropdownFilters?: any[], rowFilters?: any[], selector?: any, fieldSelector?: string, canCreate?: boolean, createButtonText?: string, createProps?: any, mock?: boolean}>} */
-export const ListPage = props => {
+export const ListPage = withFallback(props => {
   const {
     autoFocus,
     canCreate,
@@ -350,10 +348,9 @@ export const ListPage = props => {
     textFilter={textFilter}
     title={title}
   />;
-};
+}, ErrorBoundaryFallback);
 
 ListPage.displayName = 'ListPage';
-export const ListPageWrapper = listPageWithFallback(ListPage);
 
 /** @type {React.SFC<{canCreate?: boolean, createButtonText?: string, createProps?: any, flatten?: Function, title?: string, showTitle?: boolean, helpText?: any, dropdownFilters?: any[], filterLabel?: string, rowFilters?: any[], resources: any[], ListComponent: React.ComponentType<any>, namespace?: string}>} */
 export const MultiListPage = props => {

--- a/frontend/public/components/utils/_copy-to-clipboard.scss
+++ b/frontend/public/components/utils/_copy-to-clipboard.scss
@@ -14,3 +14,13 @@
 .co-copy-to-clipboard__text {
   padding-right: 50px;
 }
+
+.co-copy-to-clipboard__stacktrace-width-height {
+  display: flex;
+  .co-copy-to-clipboard {
+    width: 100%;
+  }
+  .co-copy-to-clipboard__text {
+    max-height: 25vh;
+  }
+}

--- a/frontend/public/components/utils/error-boundary.tsx
+++ b/frontend/public/components/utils/error-boundary.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars, no-undef, react/display-name */
 
 import * as React from 'react';
+import {ErrorBoundaryFallbackComponentProps} from '../error';
 
 class DefaultFallback extends React.Component {
   render() {
@@ -11,17 +12,32 @@ class DefaultFallback extends React.Component {
 export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props) {
     super(props);
-    this.state = {hasError: false};
+    this.state = {
+      hasError: false,
+      error: {
+        message: '',
+        stack: '',
+        name: ''
+      },
+      errorInfo: {
+        componentStack: ''
+      }
+    };
   }
 
-  componentDidCatch(error) {
-    this.setState({hasError: true});
+  componentDidCatch(error, errorInfo) {
+    this.setState({
+      hasError: true,
+      error,
+      errorInfo
+    });
   }
 
   render() {
+    const {hasError, error, errorInfo} = this.state;
     const FallbackComponent = this.props.FallbackComponent || DefaultFallback;
-    return this.state.hasError
-      ? <FallbackComponent />
+    return hasError
+      ? <FallbackComponent title={error.name} componentStack={errorInfo.componentStack} errorMessage={error.message} stack={error.stack} />
       : <div>{this.props.children}</div>;
   }
 }
@@ -30,12 +46,14 @@ export const withFallback: WithFallback = (Component, FallbackComponent) => (pro
   <Component {...props} />
 </ErrorBoundary>;
 
-export type WithFallback = <P = {}>(Component: React.ComponentType<P>, FallbackComponent?: React.ComponentType) => React.ComponentType<P>;
+export type WithFallback = <P = {}>(Component: React.ComponentType<P>, FallbackComponent?: React.ComponentType<ErrorBoundaryFallbackComponentProps>) => React.ComponentType<P>;
 
 export type ErrorBoundaryProps = {
-  FallbackComponent?: React.ComponentType;
+  FallbackComponent?: React.ComponentType<ErrorBoundaryFallbackComponentProps>;
 };
 
 export type ErrorBoundaryState = {
   hasError: boolean;
+  error: {message: string, stack: string, name: string};
+  errorInfo: {componentStack: string};
 };

--- a/frontend/public/components/utils/error-boundary.tsx
+++ b/frontend/public/components/utils/error-boundary.tsx
@@ -46,7 +46,7 @@ export const withFallback: WithFallback = (Component, FallbackComponent) => (pro
   <Component {...props} />
 </ErrorBoundary>;
 
-export type WithFallback = <P = {}>(Component: React.ComponentType<P>, FallbackComponent?: React.ComponentType<ErrorBoundaryFallbackComponentProps>) => React.ComponentType<P>;
+export type WithFallback = <P = {}>(Component: React.ComponentType<P>, FallbackComponent?: React.ComponentType<any>) => React.ComponentType<P>;
 
 export type ErrorBoundaryProps = {
   FallbackComponent?: React.ComponentType<ErrorBoundaryFallbackComponentProps>;

--- a/frontend/public/components/utils/error-boundary.tsx
+++ b/frontend/public/components/utils/error-boundary.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-unused-vars, no-undef, react/display-name */
 
 import * as React from 'react';
-import {ErrorBoundaryFallbackComponentProps} from '../error';
 
 class DefaultFallback extends React.Component {
   render() {
@@ -17,11 +16,11 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
       error: {
         message: '',
         stack: '',
-        name: ''
+        name: '',
       },
       errorInfo: {
-        componentStack: ''
-      }
+        componentStack: '',
+      },
     };
   }
 
@@ -29,7 +28,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
     this.setState({
       hasError: true,
       error,
-      errorInfo
+      errorInfo,
     });
   }
 
@@ -48,8 +47,15 @@ export const withFallback: WithFallback = (Component, FallbackComponent) => (pro
 
 export type WithFallback = <P = {}>(Component: React.ComponentType<P>, FallbackComponent?: React.ComponentType<any>) => React.ComponentType<P>;
 
+export type ErrorBoundaryFallbackProps = {
+  errorMessage: string;
+  componentStack: string;
+  stack: string;
+  title: string;
+};
+
 export type ErrorBoundaryProps = {
-  FallbackComponent?: React.ComponentType<ErrorBoundaryFallbackComponentProps>;
+  FallbackComponent?: React.ComponentType<ErrorBoundaryFallbackProps>;
 };
 
 export type ErrorBoundaryState = {

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -51,6 +51,7 @@
 @import "~xterm/dist/addons/fullscreen/fullscreen";
 @import "~patternfly-react/dist/sass/field-level-help";
 @import "~patternfly-react/dist/sass/modeless-overlay";
+@import "~patternfly-react/dist/sass/expand-collapse";
 @import '~patternfly-react-extensions/dist/sass/variables';
 @import '~patternfly-react-extensions/dist/sass/catalog-item';
 @import '~patternfly-react-extensions/dist/sass/catalog-tile';


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-536

When a js issue occurs, prevent the white screen and provide an Oh no... message as well as output showing the output to the issue with the page along with available traces from the componentDidCatch Error Boundary class.

The component as of now is simple enough to work as a full page error, or an error that is part of other page content (see figures below) such as a list in a details view.

Spoke briefly with @bmignano and @spadgett about design, and figured we could discuss here for a more detailed dialog.

@openshift/team-ux-review 

![screen shot 2018-11-06 at 2 12 22 pm](https://user-images.githubusercontent.com/35978579/48092430-a4df0700-e1da-11e8-9e10-6921abb90f69.png)

![screen shot 2018-11-06 at 2 13 07 pm](https://user-images.githubusercontent.com/35978579/48092437-ac061500-e1da-11e8-82f5-8f211d3fc973.png)

![screen shot 2018-11-06 at 3 20 58 pm](https://user-images.githubusercontent.com/35978579/48092447-b4f6e680-e1da-11e8-8b47-2ab52424a7dc.png)

![screen shot 2018-11-06 at 3 21 17 pm](https://user-images.githubusercontent.com/35978579/48092451-b9230400-e1da-11e8-8499-323566a664fa.png)

**Updated 11/13**
![screen shot 2018-11-13 at 10 59 34 am](https://user-images.githubusercontent.com/35978579/48425677-4c0bf300-e733-11e8-97ed-1b9694d48001.png)
