### PR TITLE
Use Text Filter in OLM E2E Tests

### DIFF
--- a/frontend/integration-tests/tests/olm/catalog.scenario.ts
+++ b/frontend/integration-tests/tests/olm/catalog.scenario.ts
@@ -28,8 +28,6 @@ describe('Installing a service from a Catalog Source', () => {
   it('displays Catalog Source with expected available packages', async() => {
     await sidenavView.clickNavLink(['Operators', 'Package Manifests']);
     await catalogView.isLoaded();
-    await catalogView.viewCatalogDetail('Red Hat Operators');
-    await catalogView.isLoaded();
 
     openCloudServices.forEach(name => {
       expect(catalogView.entryRowFor(name).isDisplayed()).toBe(true);
@@ -37,7 +35,7 @@ describe('Installing a service from a Catalog Source', () => {
   });
 
   it('displays YAML editor for creating a subscription to a service', async() => {
-    await catalogView.createSubscriptionFor('Prometheus Operator');
+    await catalogView.createSubscriptionFor('Prometheus');
     await browser.wait(until.presenceOf($('.ace_text-input')));
 
     expect($('.yaml-editor__header').getText()).toEqual('Create Subscription');

--- a/frontend/integration-tests/tests/olm/prometheus.scenario.ts
+++ b/frontend/integration-tests/tests/olm/prometheus.scenario.ts
@@ -31,7 +31,7 @@ describe('Interacting with the Prometheus OCS', () => {
   it('can be enabled from the Catalog Source', async() => {
     await sidenavView.clickNavLink(['Operators', 'Package Manifests']);
     await catalogView.isLoaded();
-    await catalogView.createSubscriptionFor('Prometheus Operator');
+    await catalogView.createSubscriptionFor('Prometheus');
     await browser.wait(until.presenceOf($('.ace_text-input')));
     const content = await yamlView.editorContent.getText();
     const newContent = defaultsDeep({}, {metadata: {generateName: `${testName}-prometheus-`, namespace: testName, labels: {[testLabel]: testName}}, spec: {channel: 'alpha', source: 'rh-operators', name: 'prometheus'}}, safeLoad(content));
@@ -41,7 +41,7 @@ describe('Interacting with the Prometheus OCS', () => {
     await sidenavView.clickNavLink(['Operators', 'Package Manifests']);
     await catalogView.isLoaded();
 
-    expect(catalogView.hasSubscription('Prometheus Operator')).toBe(true);
+    expect(catalogView.hasSubscription('Prometheus')).toBe(true);
   });
 
   it('creates Prometheus Operator `Deployment`', async() => {

--- a/frontend/integration-tests/views/olm-catalog.view.ts
+++ b/frontend/integration-tests/views/olm-catalog.view.ts
@@ -1,17 +1,12 @@
 /* eslint-disable no-undef, no-unused-vars */
 
-import { browser, $, $$, by, ExpectedConditions as until, ElementFinder } from 'protractor';
+import { browser, $, $$, by, ExpectedConditions as until } from 'protractor';
 
-const moveTo = (elem: ElementFinder) => browser.actions().mouseMove(elem).perform().then(() => elem);
-
-const withRetry = (action) => (args) => action(args)
-  .catch(() => action(args))
-  .catch(() => action(args))
-  .catch(() => action(args));
+import * as crudView from './crud.view';
 
 export const entryRows = $$('.co-resource-list__item');
 export const entryRowFor = (name: string) => entryRows.filter((row) => row.$('.co-clusterserviceversion-logo__name__clusterserviceversion').getText()
-  .then(text => text === name)).first();
+  .then(text => text === name || text.startsWith(name))).first();
 
 export const isLoaded = () => browser.wait(until.presenceOf($('.loading-box__loaded')), 10000).then(() => browser.sleep(500));
 
@@ -26,6 +21,5 @@ export const viewCatalogDetail = (name: string) => $$('.co-catalogsource-list__s
   .then(text => text === name)).first().element(by.linkText('View catalog details'))
   .click();
 
-export const createSubscriptionFor = withRetry((pkgName: string) => moveTo(
-  entryRowFor(pkgName).element(by.buttonText('Create Subscription'))
-).then(el => el.click()));
+export const createSubscriptionFor = (pkgName: string) => crudView.filterForName(pkgName)
+  .then(() => entryRowFor(pkgName).element(by.buttonText('Create Subscription')).click());


### PR DESCRIPTION
### Description

Reduces flakiness from `react-virtualized` and also tests the filtering on `PackageManifests`.