### PR TITLE
Changes from UX for attach-storage

### DIFF
--- a/frontend/public/components/_storage-class-form.scss
+++ b/frontend/public/components/_storage-class-form.scss
@@ -1,7 +1,3 @@
-.create-storage-class-form__subsection {
-  margin-left: 20px;
-}
-
 .create-storage-class-form__checkbox {
   width: inherit;
 }

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -826,7 +826,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
             <HelpBlock>Determines what volume plugin is used for provisioning persistent volumes.</HelpBlock>
           </FormGroup>
 
-          <div className="create-storage-class-form__subsection">
+          <div className="co-form-subsection">
             {newStorageClass.type !== null ? this.getProvisionerElements() : null}
           </div>
 

--- a/frontend/public/components/storage/attach-storage.tsx
+++ b/frontend/public/components/storage/attach-storage.tsx
@@ -62,16 +62,6 @@ class AttachStorageForm extends React.Component<
     error: '',
     showCreatePVC: 'existing',
     newPVCObj: null,
-    existingOrNewRadios: [
-      {
-        value: 'existing',
-        title: 'Use existing claim',
-      },
-      {
-        value: 'new',
-        title: 'Create new claim',
-      },
-    ],
   };
 
   componentDidMount() {
@@ -259,31 +249,22 @@ class AttachStorageForm extends React.Component<
               .
             </div>
           )}
+          <label className="control-label co-required" >
+            Persistent Volume Claim
+          </label>
           <div className="form-group">
-            {this.state.existingOrNewRadios.map(radio => {
-              const checked = radio.value === this.state.showCreatePVC;
-              return (
-                <RadioInput
-                  {...radio}
-                  key={radio.value}
-                  onChange={this.handleChange}
-                  checked={checked}
-                  aria-describedby="show-create-pvc-help"
-                  inline={true}
-                  name="showCreatePVC"
-                />
-              );
-            })}
-            <p className="help-block" id="show-create-pvc-help">
-              Choose to use existing claim or create a new one.
-            </p>
+            <RadioInput
+              title="Use existing claim"
+              value="existing"
+              key="existing"
+              onChange={this.handleChange}
+              checked={this.state.showCreatePVC === 'existing'}
+              name="showCreatePVC"
+            />
           </div>
 
           {this.state.showCreatePVC === 'existing' &&
-            <div className="form-group">
-              <label className="control-label co-required" htmlFor="volume-name">
-                Persistent Volume Claim
-              </label>
+            <div className="form-group co-form-subsection">
               <PVCDropdown
                 namespace={namespace}
                 onChange={this.handlePVCChange}
@@ -294,8 +275,18 @@ class AttachStorageForm extends React.Component<
               />
             </div>
           }
+          <div className="form-group">
+            <RadioInput
+              title="Create new claim"
+              value="new"
+              key="new"
+              onChange={this.handleChange}
+              checked={this.state.showCreatePVC === 'new'}
+              name="showCreatePVC"
+            />
+          </div>
 
-          {this.state.showCreatePVC === 'new' && <CreatePVCForm onChange={this.onPVCChange} namespace={this.props.namespace} />}
+          {this.state.showCreatePVC === 'new' && <div className="co-form-subsection"><CreatePVCForm onChange={this.onPVCChange} namespace={this.props.namespace} /></div>}
 
           <div className="form-group">
             <label className="control-label co-required" htmlFor="volume-name">
@@ -421,7 +412,6 @@ export type AttachStorageFormState = {
   volumeAlreadyMounted: boolean;
   showCreatePVC: string;
   newPVCObj: K8sResourceKind;
-  existingOrNewRadios: { value: string, title: string }[];
 };
 
 export type AttachStorageFormProps = {

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -6,3 +6,7 @@
   content: '*';
   padding-left: 3px;
 }
+
+.co-form-subsection {
+  margin-left: 20px;
+}


### PR DESCRIPTION
UXD asked for a change from the current attach storage page.  Here are those changes:
![existing-indent](https://user-images.githubusercontent.com/18728857/48159075-8425b880-e291-11e8-9322-3bd44d13656c.png)
![new-indent](https://user-images.githubusercontent.com/18728857/48159084-88ea6c80-e291-11e8-9d88-53cb96fe17a5.png)




Here are the existing shots:
![attach-storage-with-pvc1](https://user-images.githubusercontent.com/18728857/48153331-35712200-e283-11e8-80a3-09e977c7feea.png)
![attach-storage-with-pvc-active](https://user-images.githubusercontent.com/18728857/48153343-3b670300-e283-11e8-89aa-2a4ee91e5111.png)

What do we think? @erinboyd @cshinn @spadgett 
