### PR TITLE
Allow any decimal number in request size input component

### DIFF
--- a/frontend/public/components/utils/request-size-input.tsx
+++ b/frontend/public/components/utils/request-size-input.tsx
@@ -28,6 +28,7 @@ export class RequestSizeInput extends React.Component<RequestSizeInputProps> {
           <input
             className="form-control"
             type="number"
+            step="any"
             onChange={this.onValueChange}
             placeholder={this.props.placeholder}
             aria-describedby={describedBy}


### PR DESCRIPTION
This addresses bug https://bugzilla.redhat.com/show_bug.cgi?id=1646791
While there are other questions regarding what options we should present to the user or what freedom we should give the input, this at least allows the user to enter any value they want using a decimal value.