### PR TITLE
Fix pvc to only have storageClass property if not null

### DIFF
--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -117,7 +117,6 @@ export class CreatePVCForm extends React.Component<CreatePVCFormProps, CreatePVC
       },
       spec: {
         accessModes: [accessMode],
-        storageClassName: storageClass,
         resources: {
           requests: {
             storage: `${requestSizeValue}${requestSizeUnit}`,
@@ -130,6 +129,10 @@ export class CreatePVCForm extends React.Component<CreatePVCFormProps, CreatePVC
     const selector = this.getSelector();
     if (selector) {
       obj.spec.selector = selector;
+    }
+
+    if (storageClass) {
+      obj.spec.storageClassName = storageClass;
     }
 
     return obj;


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1647283
This code leaves the storageClasName property out of the definition for a new pvc if the value is null.  Prior, we left the property in there with a null value which prevented the default storage class from being applied.