### PR TITLE
Monitoring: Remove left margin on list row descriptions

### DIFF
--- a/frontend/public/components/_monitoring.scss
+++ b/frontend/public/components/_monitoring.scss
@@ -15,8 +15,6 @@ $monitoring-line-height: 18px;
 }
 
 .monitoring-description {
-  margin-left: 16px;
-
   // Limit to $num-lines lines of text. Truncate with an ellipsis in WebKit. Just overflow hidden for other browsers.
   $num-lines: 2;
   display: -webkit-box;


### PR DESCRIPTION
This is no longer required because the cog menu has moved.