### PR TITLE
Monitoring: After expiring a Silence, immediately refresh Silence data

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -103,7 +103,8 @@ const cancelSilence = (silence, urls) => ({
     title: 'Expire Silence',
     message: 'Are you sure you want to expire this silence?',
     btnText: 'Expire Silence',
-    executeFn: () => coFetchJSON.delete(`${urls[MonitoringRoutes.AlertManager]}/api/v1/silence/${silence.id}`),
+    executeFn: () => coFetchJSON.delete(`${urls[MonitoringRoutes.AlertManager]}/api/v1/silence/${silence.id}`)
+      .then(() => refreshPoller('silences')),
   }),
 });
 


### PR DESCRIPTION
So that the changes to the expired Silence are quickly reflected in the
UI instead of waiting for the next poll interval.