### PR TITLE
Monitoring: Fix identifying Alerts that are silenced by regex matchers

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -8,7 +8,7 @@ import { Link, Redirect, Route, Switch } from 'react-router-dom';
 
 import { coFetchJSON } from '../co-fetch';
 import k8sActions from '../module/k8s/k8s-actions';
-import { connectToURLs, MonitoringRoutes } from '../monitoring';
+import { connectToURLs, isSilenced, MonitoringRoutes } from '../monitoring';
 import store from '../redux';
 import { UIActions } from '../ui/ui-actions';
 import { monitoringRulesToProps, monitoringSilencesToProps } from '../ui/ui-reducers';
@@ -67,11 +67,6 @@ const alertDescription = alert => {
 };
 
 export const silenceState = s => _.get(s, 'status.state');
-
-// Determine if an Alert is silenced by a Silence (if all of the Silence's matchers match one of the Alert's labels)
-const isSilenced = (alert, silence) => alertState(alert) === 'silenced' &&
-  _.get(silence, 'status.state') === 'active' &&
-  _.every(silence.matchers, m => _.get(alert.labels, m.name) === m.value);
 
 const pollers = {};
 const pollerTimeouts = {};
@@ -371,7 +366,7 @@ const AlertRulesDetailsPage = withFallback(connect(ruleStateToProps)((props: Ale
 }));
 
 const silencedAlertsToProps = (state, {silence}) => ({
-  alerts: _.filter(_.get(monitoringRulesToProps(state), 'data.asAlerts'), a => isSilenced(a, silence)),
+  alerts: _.filter(_.get(monitoringRulesToProps(state), 'data.asAlerts'), a => alertState(a) === 'silenced' && isSilenced(a, silence)),
 });
 
 const SilencedAlertsList = connect(silencedAlertsToProps)(

--- a/frontend/public/monitoring.ts
+++ b/frontend/public/monitoring.ts
@@ -60,3 +60,11 @@ const stateToProps = (desiredURLs: string[], state) => {
 };
 
 export const connectToURLs = (...urls) => connect(state => stateToProps(urls, state));
+
+// Determine if an Alert is silenced by a Silence (if all of the Silence's matchers match one of the Alert's labels)
+export const isSilenced = (alert, silence) => _.get(silence, 'status.state') === 'active' &&
+  _.every(silence.matchers, m => {
+    const alertValue = _.get(alert.labels, m.name);
+    return alertValue !== undefined &&
+      (m.isRegex ? (new RegExp(`^${m.value}$`)).test(alertValue) : alertValue === m.value);
+  });


### PR DESCRIPTION
`isSilenced()` was only testing for non-regex matchers.