### PR TITLE
Allow Non-Virtualized Lists

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -70,6 +70,7 @@ export const PackageManifestList: React.SFC<PackageManifestListProps> = (props) 
           loaded={true}
           data={props.data.filter(pkg => pkg.status.catalogSource === catalog.name)}
           filters={props.filters}
+          virtualize={false}
           Header={PackageManifestHeader}
           Row={(rowProps: {obj: PackageManifestKind}) => <PackageManifestRow
             obj={rowProps.obj}


### PR DESCRIPTION
### Description

It appears that `react-virtualized` doesn't like having more than one virtual `List` present at a time. One solution is to pass `props.virtualized` to the `List` component (default `true`), which determines if the list should be virtualized. 

Using non-virtualized lists for `PackageManifests` view fixes a [known issue in `react-virtualized`](https://github.com/bvaughn/react-virtualized/issues/444). This list is quite small right now, so we shouldn't really be concerned about it not being virtualized. While it doesn't address the underlying issue, our engineering time shouldn't be spent fixing bugs in our dependencies.

Addresses https://jira.coreos.com/browse/CONSOLE-984