### PR TITLE
eslint: enforce trailing commas (comma-dangle)

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -25,6 +25,7 @@
   "rules": {
     "brace-style": 2,
     "camelcase": 2,
+    "comma-dangle": ["error", "always-multiline"],
     "consistent-return": 0,
     "consistent-this": [1, "that"],
     "curly": [2, "all"],
@@ -42,7 +43,6 @@
     "max-nested-callbacks": [1, 4],
     "no-alert": 2,
     "no-caller": 2,
-    "no-comma-dangle": 0,
     "no-console": 2,
     "no-constant-condition": 2,
     "no-debugger": 2,

--- a/frontend/__mocks__/catalogItemsMocks.ts
+++ b/frontend/__mocks__/catalogItemsMocks.ts
@@ -10,7 +10,7 @@ export const catalogListPageProps = {
         'spec': {
           'tags': [
             'database',
-            'mongodb'
+            'mongodb',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-mongodb',
@@ -20,8 +20,8 @@ export const catalogListPageProps = {
           'description': 'MongoDB database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mongodb-container/blob/master/3.2/README.md.\n\nNOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
+          'removedFromBrokerCatalog': false,
+        },
       },
       {
         'metadata': {
@@ -31,7 +31,7 @@ export const catalogListPageProps = {
         'spec': {
           'tags': [
             'instant-app',
-            'jenkins'
+            'jenkins',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-jenkins',
@@ -41,8 +41,8 @@ export const catalogListPageProps = {
           'description': 'Jenkins service, with persistent storage.\n\nNOTE: You must have persistent volumes available in your cluster to use this template.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
+          'removedFromBrokerCatalog': false,
+        },
       },
       {
         'metadata': {
@@ -53,7 +53,7 @@ export const catalogListPageProps = {
           'tags': [
             'quickstart',
             'php',
-            'cakephp'
+            'cakephp',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-php',
@@ -63,8 +63,8 @@ export const catalogListPageProps = {
           'description': 'An example CakePHP application with a MySQL database. For more information about using this template, including OpenShift considerations, see https://github.com/openshift/cakephp-ex/blob/master/README.md.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
+          'removedFromBrokerCatalog': false,
+        },
       },
       {
         'metadata': {
@@ -75,7 +75,7 @@ export const catalogListPageProps = {
           'tags': [
             'quickstart',
             'ruby',
-            'rails'
+            'rails',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-ruby',
@@ -85,8 +85,8 @@ export const catalogListPageProps = {
           'description': 'An example Rails application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/openshift/rails-ex/blob/master/README.md.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
+          'removedFromBrokerCatalog': false,
+        },
       },
       {
         'metadata': {
@@ -97,7 +97,7 @@ export const catalogListPageProps = {
           'tags': [
             'quickstart',
             'python',
-            'django'
+            'django',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-python',
@@ -107,8 +107,8 @@ export const catalogListPageProps = {
           'description': 'An example Django application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/openshift/django-ex/blob/master/README.md.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
+          'removedFromBrokerCatalog': false,
+        },
       },
       {
         'metadata': {
@@ -118,7 +118,7 @@ export const catalogListPageProps = {
         'spec': {
           'tags': [
             'database',
-            'postgresql'
+            'postgresql',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-postgresql',
@@ -128,8 +128,8 @@ export const catalogListPageProps = {
           'description': 'PostgreSQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.\n\nNOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
+          'removedFromBrokerCatalog': false,
+        },
       },
       {
         'metadata': {
@@ -139,7 +139,7 @@ export const catalogListPageProps = {
         'spec': {
           'tags': [
             'database',
-            'mariadb'
+            'mariadb',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-mariadb',
@@ -149,8 +149,8 @@ export const catalogListPageProps = {
           'description': 'MariaDB database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mariadb-container/blob/master/10.2/root/usr/share/container-scripts/mysql/README.md.\n\nNOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
+          'removedFromBrokerCatalog': false,
+        },
       },
       {
         'metadata': {
@@ -160,7 +160,7 @@ export const catalogListPageProps = {
         'spec': {
           'tags': [
             'database',
-            'mysql'
+            'mysql',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-mysql-database',
@@ -170,8 +170,8 @@ export const catalogListPageProps = {
           'description': 'MySQL database service, with persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/mysql-container/blob/master/5.7/root/usr/share/container-scripts/mysql/README.md.\n\nNOTE: Scaling to more than one replica is not supported. You must have persistent volumes available in your cluster to use this template.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
+          'removedFromBrokerCatalog': false,
+        },
       },
       {
         'metadata': {
@@ -181,17 +181,17 @@ export const catalogListPageProps = {
         'spec': {
           'tags': [
             'instant-app',
-            'jenkins'
+            'jenkins',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-jenkins',
-            'displayName': 'Pipeline Build Example'
+            'displayName': 'Pipeline Build Example',
           },
           'description': 'This example showcases the new Jenkins Pipeline integration in OpenShift,\nwhich performs continuous integration and deployment right on the platform.\nThe template contains a Jenkinsfile - a definition of a multi-stage CI/CD process - that\nleverages the underlying OpenShift platform for dynamic and scalable\nbuilds. OpenShift integrates the status of your pipeline builds into the web\nconsole allowing you to see your entire application lifecycle in a single view.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
+          'removedFromBrokerCatalog': false,
+        },
       },
       {
         'metadata': {
@@ -202,7 +202,7 @@ export const catalogListPageProps = {
           'tags': [
             'quickstart',
             'perl',
-            'dancer'
+            'dancer',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-perl',
@@ -212,8 +212,8 @@ export const catalogListPageProps = {
           'description': 'An example Dancer application with a MySQL database. For more information about using this template, including OpenShift considerations, see https://github.com/openshift/dancer-ex/blob/master/README.md.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
+          'removedFromBrokerCatalog': false,
+        },
       },
       {
         'metadata': {
@@ -223,7 +223,7 @@ export const catalogListPageProps = {
         'spec': {
           'tags': [
             'quickstart',
-            'nodejs'
+            'nodejs',
           ],
           'externalMetadata': {
             'console.openshift.io/iconClass': 'icon-nodejs',
@@ -233,14 +233,14 @@ export const catalogListPageProps = {
           'description': 'An example Node.js application with a MongoDB database. For more information about using this template, including OpenShift considerations, see https://github.com/openshift/nodejs-ex/blob/master/README.md.',
         },
         'status': {
-          'removedFromBrokerCatalog': false
-        }
-      }
+          'removedFromBrokerCatalog': false,
+        },
+      },
     ],
     'filters': {},
     'loadError': '',
     'loaded': true,
-    'selected': null
+    'selected': null,
   },
   'imagestreams': {
     'data': [
@@ -251,17 +251,17 @@ export const catalogListPageProps = {
               'name': '10.2',
               'annotations': {
                 'tags': 'database,mariadb',
-              }
-            }
-          ]
+              },
+            },
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '10.2',
-            }
-          ]
-        }
+            },
+          ],
+        },
       },
       {
         'metadata': {
@@ -269,8 +269,8 @@ export const catalogListPageProps = {
           'uid': 'c00bec39-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'Perl',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:38Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:38Z',
+          },
         },
         'spec': {
           'tags': [
@@ -282,17 +282,17 @@ export const catalogListPageProps = {
                 'openshift.io/display-name': 'Perl 5.24',
                 'openshift.io/provider-display-name': 'Red Hat, Inc.',
                 'tags': 'builder,perl',
-              }
-            }
-          ]
+              },
+            },
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '5.24',
-            }
-          ]
-        }
+            },
+          ],
+        },
       },
       {
         'metadata': {
@@ -300,8 +300,8 @@ export const catalogListPageProps = {
           'uid': 'c00c829d-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'PHP',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:38Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:38Z',
+          },
         },
         'spec': {
           'tags': [
@@ -313,9 +313,9 @@ export const catalogListPageProps = {
                 'openshift.io/display-name': 'PHP 7.1',
                 'openshift.io/provider-display-name': 'Red Hat, Inc.',
                 'tags': 'builder,php',
-              }
-            }
-          ]
+              },
+            },
+          ],
         },
         'status': {
           'dockerImageRepository': '172.30.1.1:5000/openshift/php',
@@ -323,8 +323,8 @@ export const catalogListPageProps = {
             {
               'tag': '7.1',
             },
-          ]
-        }
+          ],
+        },
       },
       {
         'metadata': {
@@ -332,8 +332,8 @@ export const catalogListPageProps = {
           'uid': 'c00e6500-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'Nginx HTTP server and a reverse proxy (nginx)',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:37Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:37Z',
+          },
         },
         'spec': {
           'tags': [
@@ -345,17 +345,17 @@ export const catalogListPageProps = {
                 'openshift.io/display-name': 'Nginx HTTP server and a reverse proxy 1.12',
                 'openshift.io/provider-display-name': 'Red Hat, Inc.',
                 'tags': 'builder,nginx',
-              }
-            }
-          ]
+              },
+            },
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '1.12',
-            }
-          ]
-        }
+            },
+          ],
+        },
       },
       {
         'metadata': {
@@ -363,8 +363,8 @@ export const catalogListPageProps = {
           'uid': 'c0119342-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'Redis',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:38Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:38Z',
+          },
         },
         'spec': {
           'tags': [
@@ -376,17 +376,17 @@ export const catalogListPageProps = {
                 'openshift.io/display-name': 'Redis 3.2',
                 'openshift.io/provider-display-name': 'Red Hat, Inc.',
                 'tags': 'redis',
-              }
-            }
-          ]
+              },
+            },
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '3.2',
-            }
-          ]
-        }
+            },
+          ],
+        },
       },
       {
         'metadata': {
@@ -394,8 +394,8 @@ export const catalogListPageProps = {
           'uid': 'c00f890f-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'PostgreSQL',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:38Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:38Z',
+          },
         },
         'spec': {
           'tags': [
@@ -407,17 +407,17 @@ export const catalogListPageProps = {
                 'openshift.io/display-name': 'PostgreSQL 9.6',
                 'openshift.io/provider-display-name': 'Red Hat, Inc.',
                 'tags': 'database,postgresql',
-              }
-            }
-          ]
+              },
+            },
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '9.6',
-            }
-          ]
-        }
+            },
+          ],
+        },
       },
       {
         'metadata': {
@@ -425,8 +425,8 @@ export const catalogListPageProps = {
           'uid': 'c00aa68e-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'Apache HTTP Server (httpd)',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:36Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:36Z',
+          },
         },
         'spec': {
           'tags': [
@@ -438,17 +438,17 @@ export const catalogListPageProps = {
                 'openshift.io/display-name': 'Apache HTTP Server 2.4',
                 'openshift.io/provider-display-name': 'Red Hat, Inc.',
                 'tags': 'builder,httpd',
-              }
-            }
-          ]
+              },
+            },
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '2.4',
-            }
-          ]
-        }
+            },
+          ],
+        },
       },
       {
         'metadata': {
@@ -456,8 +456,8 @@ export const catalogListPageProps = {
           'uid': 'c01320a0-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': '.NET Core Builder Images',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:36Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:36Z',
+          },
         },
         'spec': {
           'tags': [
@@ -467,18 +467,18 @@ export const catalogListPageProps = {
                 'openshift.io/display-name': '.NET Core 2.0',
                 'tags': 'builder,.net,dotnet,dotnetcore,rh-dotnet20',
                 'description': 'Build and run .NET Core 2.0 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/redhat-developer/s2i-dotnetcore/tree/master/2.0/build/README.md.',
-                'iconClass': 'icon-dotnet'
-              }
-            }
-          ]
+                'iconClass': 'icon-dotnet',
+              },
+            },
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '2.0',
-            }
-          ]
-        }
+            },
+          ],
+        },
       },
       {
         'metadata': {
@@ -486,8 +486,8 @@ export const catalogListPageProps = {
           'uid': 'c00b0711-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'Ruby',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:40Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:40Z',
+          },
         },
         'spec': {
           'tags': [
@@ -499,17 +499,17 @@ export const catalogListPageProps = {
                 'openshift.io/display-name': 'Ruby 2.4',
                 'openshift.io/provider-display-name': 'Red Hat, Inc.',
                 'tags': 'builder,ruby',
-              }
-            }
-          ]
+              },
+            },
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '2.4',
-            }
-          ]
-        }
+            },
+          ],
+        },
       },
       {
         'metadata': {
@@ -517,8 +517,8 @@ export const catalogListPageProps = {
           'uid': 'c00e1bc4-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'MySQL',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:37Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:37Z',
+          },
         },
         'spec': {
           'tags': [
@@ -532,15 +532,15 @@ export const catalogListPageProps = {
                 'tags': 'mysql',
               },
             },
-          ]
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '5.7',
             },
-          ]
-        }
+          ],
+        },
       },
       {
         'metadata': {
@@ -548,8 +548,8 @@ export const catalogListPageProps = {
           'uid': 'c00d0c6b-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'Python',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:39Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:39Z',
+          },
         },
         'spec': {
           'tags': [
@@ -563,15 +563,15 @@ export const catalogListPageProps = {
                 'tags': 'builder,python',
               },
             },
-          ]
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '3.6',
             },
-          ]
-        }
+          ],
+        },
       },
       {
         'metadata': {
@@ -579,8 +579,8 @@ export const catalogListPageProps = {
           'uid': 'c013e3d7-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': '.NET Core Runtime Images',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:36Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:36Z',
+          },
         },
         'spec': {
           'tags': [
@@ -593,15 +593,15 @@ export const catalogListPageProps = {
                 'tags': 'runtime,.net-runtime,dotnet-runtime,dotnetcore-runtime',
               },
             },
-          ]
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '2.0',
             },
-          ]
-        }
+          ],
+        },
       },
       {
         'metadata': {
@@ -609,8 +609,8 @@ export const catalogListPageProps = {
           'uid': 'c00d954a-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'WildFly',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:39Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:39Z',
+          },
         },
         'spec': {
           'tags': [
@@ -624,15 +624,15 @@ export const catalogListPageProps = {
                 'tags': 'builder,wildfly,java',
               },
             },
-          ]
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '10.1',
             },
-          ]
-        }
+          ],
+        },
       },
       {
         'metadata': {
@@ -640,8 +640,8 @@ export const catalogListPageProps = {
           'uid': 'c00fd59d-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'MongoDB',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:37Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:37Z',
+          },
         },
         'spec': {
           'tags': [
@@ -655,15 +655,15 @@ export const catalogListPageProps = {
                 'tags': 'database,mongodb',
               },
             },
-          ]
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '3.4',
             },
-          ]
-        }
+          ],
+        },
       },
       {
         'metadata': {
@@ -671,8 +671,8 @@ export const catalogListPageProps = {
           'uid': 'c00b594d-c641-11e8-be32-54e1ad486c15',
           'annotations': {
             'openshift.io/display-name': 'Node.js',
-            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:38Z'
-          }
+            'openshift.io/image.dockerRepositoryCheck': '2018-10-02T12:50:38Z',
+          },
         },
         'spec': {
           'tags': [
@@ -686,23 +686,23 @@ export const catalogListPageProps = {
                 'tags': 'builder,nodejs',
               },
             },
-          ]
+          ],
         },
         'status': {
           'tags': [
             {
               'tag': '8',
             },
-          ]
-        }
-      }
+          ],
+        },
+      },
     ],
     'filters': {},
     'loadError': '',
     'loaded': true,
-    'selected': null
+    'selected': null,
   },
-  'loaded': true
+  'loaded': true,
 };
 
 export const catalogItems = [
@@ -712,213 +712,213 @@ export const catalogItems = [
       '.net',
       'dotnet',
       'dotnetcore',
-      'rh-dotnet20'
-    ]
+      'rh-dotnet20',
+    ],
   },
   {
     'tags': [
       'builder',
-      'httpd'
-    ]
+      'httpd',
+    ],
   },
   {
     'tags': [
       'quickstart',
       'php',
-      'cakephp'
-    ]
+      'cakephp',
+    ],
   },
   {
     'tags': [
       'quickstart',
       'perl',
-      'dancer'
-    ]
+      'dancer',
+    ],
   },
   {
     'tags': [
       'quickstart',
       'python',
-      'django'
-    ]
+      'django',
+    ],
   },
   {
     'tags': [
       'instant-app',
-      'jenkins'
-    ]
+      'jenkins',
+    ],
   },
   {
     'tags': [
       'database',
-      'mariadb'
-    ]
+      'mariadb',
+    ],
   },
   {
     'tags': [
       'database',
-      'mongodb'
-    ]
+      'mongodb',
+    ],
   },
   {
     'tags': [
       'database',
-      'mysql'
-    ]
+      'mysql',
+    ],
   },
   {
     'tags': [
       'builder',
-      'nginx'
-    ]
+      'nginx',
+    ],
   },
   {
     'tags': [
       'builder',
-      'nodejs'
-    ]
+      'nodejs',
+    ],
   },
   {
     'tags': [
       'quickstart',
-      'nodejs'
-    ]
+      'nodejs',
+    ],
   },
   {
     'tags': [
       'builder',
-      'php'
-    ]
+      'php',
+    ],
   },
   {
     'tags': [
       'builder',
-      'perl'
-    ]
+      'perl',
+    ],
   },
   {
     'tags': [
       'instant-app',
-      'jenkins'
-    ]
+      'jenkins',
+    ],
   },
   {
     'tags': [
       'database',
-      'postgresql'
-    ]
+      'postgresql',
+    ],
   },
   {
     'tags': [
       'builder',
-      'python'
-    ]
+      'python',
+    ],
   },
   {
     'tags': [
       'quickstart',
       'ruby',
-      'rails'
-    ]
+      'rails',
+    ],
   },
   {
     'tags': [
       'builder',
-      'ruby'
-    ]
+      'ruby',
+    ],
   },
   {
     'tags': [
       'builder',
       'wildfly',
-      'java'
-    ]
-  }
+      'java',
+    ],
+  },
 ];
 
 export const catalogCategories = [
   {
     'id': 'all',
-    'numItems': 20
+    'numItems': 20,
   },
   {
     'id': 'languages',
     'subcategories': [
       {
         'id': 'java',
-        'numItems': 1
+        'numItems': 1,
       },
       {
         'id': 'javascript',
-        'numItems': 2
+        'numItems': 2,
       },
       {
         'id': 'dotnet',
-        'numItems': 1
+        'numItems': 1,
       },
       {
         'id': 'perl',
-        'numItems': 2
+        'numItems': 2,
       },
       {
         'id': 'ruby',
-        'numItems': 2
+        'numItems': 2,
       },
       {
         'id': 'php',
-        'numItems': 2
+        'numItems': 2,
       },
       {
         'id': 'python',
-        'numItems': 2
-      }
+        'numItems': 2,
+      },
     ],
-    'numItems': 12
+    'numItems': 12,
   },
   {
     'id': 'databases',
     'subcategories': [
       {
         'id': 'mongodb',
-        'numItems': 1
+        'numItems': 1,
       },
       {
         'id': 'mysql',
-        'numItems': 1
+        'numItems': 1,
       },
       {
         'id': 'postgresql',
-        'numItems': 1
+        'numItems': 1,
       },
       {
         'id': 'mariadb',
-        'numItems': 1
-      }
+        'numItems': 1,
+      },
     ],
-    'numItems': 4
+    'numItems': 4,
   },
   {
     'id': 'middleware',
     'subcategories': [
       {
         'id': 'runtimes',
-        'numItems': 1
-      }
+        'numItems': 1,
+      },
     ],
-    'numItems': 1
+    'numItems': 1,
   },
   {
     'id': 'cicd',
     'subcategories': [
       {
         'id': 'jenkins',
-        'numItems': 2
-      }
+        'numItems': 2,
+      },
     ],
-    'numItems': 2
+    'numItems': 2,
   },
   {
     'id': 'other',
-    'numItems': 1
-  }
+    'numItems': 1,
+  },
 ];

--- a/frontend/__mocks__/k8sResourcesMocks.ts
+++ b/frontend/__mocks__/k8sResourcesMocks.ts
@@ -10,7 +10,7 @@ export const testNamespace: K8sResourceKind = {
   metadata: {
     name: 'default',
     annotations: {'alm-manager': 'tectonic-system.alm-operator'},
-  }
+  },
 };
 
 export const testClusterServiceVersion: ClusterServiceVersionKind = {
@@ -37,7 +37,7 @@ export const testClusterServiceVersion: ClusterServiceVersionKind = {
       {name: 'John Doe', email: 'johndoe@example.com'},
     ],
     icon: [
-      {base64data: '', mediatype: 'image/png',}
+      {base64data: '', mediatype: 'image/png'},
     ],
     labels: {
       'alm-owner-testapp': 'testapp.clusterserviceversions.operators.coreos.com.v1alpha1',
@@ -45,15 +45,15 @@ export const testClusterServiceVersion: ClusterServiceVersionKind = {
     },
     selector: {
       matchLabels: {
-        'alm-owner-testapp': 'testapp.clusterserviceversions.operators.coreos.com.v1alpha1'
-      }
+        'alm-owner-testapp': 'testapp.clusterserviceversions.operators.coreos.com.v1alpha1',
+      },
     },
     install: {
       strategy: 'Deployment',
       spec: {
         permissions: [{serviceAccountName: 'testapp-operator', rules: [{apiGroups: ['testapp.coreos.com'], resources: ['testresource'], verbs: ['*']}]}],
         deployments: [{name: 'testapp-operator', spec: {}}],
-      }
+      },
     },
     customresourcedefinitions: {
       owned: [{
@@ -89,9 +89,9 @@ export const testClusterServiceVersion: ClusterServiceVersionKind = {
           displayName: 'Some Status',
           description: 'This status is filled',
           'x-descriptors': [StatusCapability.text],
-        }]
+        }],
       }],
-    }
+    },
   },
   status: {
     phase: ClusterServiceVersionPhase.CSVPhaseSucceeded,
@@ -116,15 +116,15 @@ export const localClusterServiceVersion: ClusterServiceVersionKind = {
     },
     selector: {
       matchLabels: {
-        'alm-owner-local-testapp': 'local-testapp.clusterserviceversions.operators.coreos.com.v1alpha1'
-      }
+        'alm-owner-local-testapp': 'local-testapp.clusterserviceversions.operators.coreos.com.v1alpha1',
+      },
     },
     install: {
       strategy: 'Deployment',
       spec: {
         permissions: [{serviceAccountName: 'local-operator', rules: [{apiGroups: ['testapp.coreos.com'], resources: ['testresource'], verbs: ['*']}]}],
         deployments: [{name: 'testapp-operator', spec: {}}],
-      }
+      },
     },
     customresourcedefinitions: {
       owned: [{
@@ -139,7 +139,7 @@ export const localClusterServiceVersion: ClusterServiceVersionKind = {
   status: {
     phase: ClusterServiceVersionPhase.CSVPhaseSucceeded,
     reason: CSVConditionReason.CSVReasonInstallSuccessful,
-  }
+  },
 };
 
 export const testCRD: CustomResourceDefinitionKind = {
@@ -153,7 +153,7 @@ export const testCRD: CustomResourceDefinitionKind = {
     annotations: {
       displayName: 'Dashboard',
       description: 'Test Dashboard',
-    }
+    },
   },
   spec: {
     group: 'testapp.coreos.com',
@@ -164,7 +164,7 @@ export const testCRD: CustomResourceDefinitionKind = {
       singular: 'testresource',
       listKind: 'TestResourceList',
     },
-  }
+  },
 };
 
 export const testModel: K8sKind = {
@@ -211,7 +211,7 @@ export const testOwnedResourceInstance: ClusterServiceVersionResourceKind = {
       kind: 'TestResource',
       apiVersion: testResourceInstance.apiVersion,
       uid: testResourceInstance.metadata.uid,
-    }]
+    }],
   },
   spec: {},
   status: {
@@ -246,7 +246,7 @@ export const testPackageManifest: PackageManifestKind = {
         provider: {
           name: 'CoreOS, Inc',
         },
-      }
+      },
     }],
     defaultChannel: 'alpha',
   },
@@ -298,12 +298,12 @@ export const testOperatorDeployment: K8sResourceKind = {
       name: testClusterServiceVersion.metadata.name,
       uid: testClusterServiceVersion.metadata.uid,
       kind: testClusterServiceVersion.kind,
-      apiVersion: testClusterServiceVersion.apiVersion
+      apiVersion: testClusterServiceVersion.apiVersion,
     }],
     spec: {
 
-    }
-  }
+    },
+  },
 };
 
 export const testSubscription: SubscriptionKind = {
@@ -318,5 +318,5 @@ export const testSubscription: SubscriptionKind = {
     source: 'ocs',
     name: 'test-package',
     channel: 'stable',
-  }
+  },
 };

--- a/frontend/__mocks__/localStorage.ts
+++ b/frontend/__mocks__/localStorage.ts
@@ -9,5 +9,5 @@ let _localStorage = {};
   },
   clear() {
     _localStorage = {};
-  }
+  },
 };

--- a/frontend/__tests__/components/factory/list-page.spec.tsx
+++ b/frontend/__tests__/components/factory/list-page.spec.tsx
@@ -112,8 +112,8 @@ describe(ListPageWrapper_.displayName, () => {
       reducer: (item) => item.kind,
       items: [
         {id: 'database', title: 'Databases'},
-        {id: 'loadbalancer', title: 'Load Balancers'}
-      ]
+        {id: 'loadbalancer', title: 'Load Balancers'},
+      ],
     }];
     wrapper.setProps({rowFilters: rowFilters});
     const checkboxes = wrapper.find(CheckBoxes) as any;

--- a/frontend/__tests__/components/modals/subscription-channel-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/subscription-channel-modal.spec.tsx
@@ -37,7 +37,7 @@ describe(SubscriptionChannelModal.name, () => {
         provider: {
           name: 'CoreOS, Inc',
         },
-      }
+      },
     }, {
       name: 'nightly',
       currentCSV: 'testapp-nightly',
@@ -48,7 +48,7 @@ describe(SubscriptionChannelModal.name, () => {
         provider: {
           name: 'CoreOS, Inc',
         },
-      }
+      },
     }];
 
     wrapper = shallow(<SubscriptionChannelModal subscription={subscription} pkg={pkg} k8sUpdate={k8sUpdate} close={close} cancel={cancel} />);

--- a/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
@@ -79,7 +79,7 @@ describe(CreateSubscriptionYAML.displayName, () => {
       name: testPackageManifest.metadata.name,
       namespace: 'default',
       isList: false,
-      prop: 'packageManifest'
+      prop: 'packageManifest',
     }]);
   });
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
@@ -283,7 +283,7 @@ describe(ClusterServiceVersionResourcesDetailsPage.displayName, () => {
 
   it('renders a `DetailsPage` which also watches the parent CSV', () => {
     expect(wrapper.find(DetailsPage).props().resources).toEqual([
-      {kind: referenceForModel(ClusterServiceVersionModel), name: match.params.appName, namespace: match.params.ns, isList: false, prop: 'csv'}
+      {kind: referenceForModel(ClusterServiceVersionModel), name: match.params.appName, namespace: match.params.ns, isList: false, prop: 'csv'},
     ]);
   });
 
@@ -316,15 +316,15 @@ describe(ClusterServiceVersionResourcesDetailsPage.displayName, () => {
       kind: 'Pod',
       metadata: {
         uid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
-        ownerReferences: [{uid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'}]
-      }
+        ownerReferences: [{uid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'}],
+      },
     };
     const deployment = {
       kind: 'Deployment',
       metadata: {
         uid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        ownerReferences: [{uid: testResourceInstance.metadata.uid}]
-      }
+        ownerReferences: [{uid: testResourceInstance.metadata.uid}],
+      },
     };
     const secret = {
       kind: 'Secret',

--- a/frontend/__tests__/components/operator-lifecycle-manager/create-crd-yaml.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/create-crd-yaml.spec.tsx
@@ -21,7 +21,7 @@ describe(CreateCRDYAML.displayName, () => {
 
   it('renders a `Firehose` for the ClusterServiceVersion', () => {
     expect(wrapper.find<any>(Firehose).props().resources).toEqual([
-      {kind: referenceForModel(ClusterServiceVersionModel), name: 'example', namespace: 'default', isList: false, prop: 'ClusterServiceVersion'}
+      {kind: referenceForModel(ClusterServiceVersionModel), name: 'example', namespace: 'default', isList: false, prop: 'ClusterServiceVersion'},
     ]);
   });
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/spec/index.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/spec/index.spec.tsx
@@ -20,7 +20,7 @@ describe(SpecDescriptor.name, () => {
       'path': '',
       'displayName': 'Some Spec Control',
       'description': '',
-      'x-descriptors': []
+      'x-descriptors': [],
     };
     wrapper = shallow(<SpecDescriptor model={testModel} obj={testResourceInstance} namespace="foo" descriptor={descriptor} value={null} />);
   });

--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/index.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/index.spec.tsx
@@ -18,7 +18,7 @@ describe(StatusDescriptor.displayName, () => {
       path: '',
       displayName: 'Some Thing',
       description: '',
-      'x-descriptors': []
+      'x-descriptors': [],
     };
     wrapper = shallow(<StatusDescriptor descriptor={descriptor} value={null} obj={null} model={testModel} namespace="foo" />);
   });

--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/pods.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/pods.spec.tsx
@@ -16,7 +16,7 @@ describe(PodStatusChart.displayName, () => {
       'path': 'size',
       'displayName': 'Size',
       'description': 'The desired number of member Pods for the etcd cluster.',
-      'x-descriptors': [SpecCapability.podCount]
+      'x-descriptors': [SpecCapability.podCount],
     };
     wrapper = shallow(<PodStatusChart statusDescriptor={descriptor} fetcher={() => null} />);
   });

--- a/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
@@ -145,7 +145,7 @@ describe(InstallPlanPreview.name, () => {
           kind: ClusterServiceVersionModel.kind,
           name: 'testoperator.v1.0.0',
           manifest: '',
-        }
+        },
       },
     ];
 

--- a/frontend/__tests__/components/pod.spec.tsx
+++ b/frontend/__tests__/components/pod.spec.tsx
@@ -16,7 +16,7 @@ describe('Readiness', () => {
       status: {
         phase: 'Running',
         conditions: [],
-      }
+      },
     };
   });
 

--- a/frontend/__tests__/components/route-pages.spec.tsx
+++ b/frontend/__tests__/components/route-pages.spec.tsx
@@ -17,9 +17,9 @@ describe(RouteLocation.displayName, () => {
       'spec': {
         'host': 'www.example.com',
         'tls': {
-          'termination': 'edge'
+          'termination': 'edge',
         },
-        'wildcardPolicy': 'None'
+        'wildcardPolicy': 'None',
       },
       'status': {
         'ingress': [
@@ -29,12 +29,12 @@ describe(RouteLocation.displayName, () => {
               {
                 'type': 'Admitted',
                 'status': 'True',
-                'lastTransitionTime': '2018-04-30T16:55:48Z'
-              }
-            ]
-          }
-        ]
-      }
+                'lastTransitionTime': '2018-04-30T16:55:48Z',
+              },
+            ],
+          },
+        ],
+      },
     };
 
     const wrapper = shallow(<RouteLocation obj={route} />);
@@ -51,7 +51,7 @@ describe(RouteLocation.displayName, () => {
       },
       'spec': {
         'host': 'www.example.com',
-        'wildcardPolicy': 'None'
+        'wildcardPolicy': 'None',
       },
       'status': {
         'ingress': [
@@ -61,12 +61,12 @@ describe(RouteLocation.displayName, () => {
               {
                 'type': 'Admitted',
                 'status': 'True',
-                'lastTransitionTime': '2018-04-30T16:55:48Z'
-              }
-            ]
-          }
-        ]
-      }
+                'lastTransitionTime': '2018-04-30T16:55:48Z',
+              },
+            ],
+          },
+        ],
+      },
     };
 
     const wrapper = shallow(<RouteLocation obj={route} />);
@@ -84,7 +84,7 @@ describe(RouteLocation.displayName, () => {
       'spec': {
         'host': 'www.example.com',
         'path': '\\mypath',
-        'wildcardPolicy': 'None'
+        'wildcardPolicy': 'None',
       },
       'status': {
         'ingress': [
@@ -94,12 +94,12 @@ describe(RouteLocation.displayName, () => {
               {
                 'type': 'Admitted',
                 'status': 'True',
-                'lastTransitionTime': '2018-04-30T16:55:48Z'
-              }
-            ]
-          }
-        ]
-      }
+                'lastTransitionTime': '2018-04-30T16:55:48Z',
+              },
+            ],
+          },
+        ],
+      },
     };
 
     const wrapper = shallow(<RouteLocation obj={route} />);
@@ -116,7 +116,7 @@ describe(RouteLocation.displayName, () => {
       },
       'spec': {
         'host': 'www.example.com',
-        'wildcardPolicy': 'Subdomain'
+        'wildcardPolicy': 'Subdomain',
       },
       'status': {
         'ingress': [
@@ -126,12 +126,12 @@ describe(RouteLocation.displayName, () => {
               {
                 'type': 'Admitted',
                 'status': 'True',
-                'lastTransitionTime': '2018-04-30T16:55:48Z'
-              }
-            ]
-          }
-        ]
-      }
+                'lastTransitionTime': '2018-04-30T16:55:48Z',
+              },
+            ],
+          },
+        ],
+      },
     };
 
     const wrapper = shallow(<RouteLocation obj={route} />);
@@ -148,7 +148,7 @@ describe(RouteLocation.displayName, () => {
       },
       'spec': {
         'host': 'www.example.com',
-        'wildcardPolicy': 'None'
+        'wildcardPolicy': 'None',
       },
       'status': {
         'ingress': [
@@ -158,12 +158,12 @@ describe(RouteLocation.displayName, () => {
               {
                 'type': 'Admitted',
                 'status': 'False',
-                'lastTransitionTime': '2018-04-30T16:55:48Z'
-              }
-            ]
-          }
-        ]
-      }
+                'lastTransitionTime': '2018-04-30T16:55:48Z',
+              },
+            ],
+          },
+        ],
+      },
     };
 
     const wrapper = shallow(<RouteLocation obj={route} />);
@@ -188,12 +188,12 @@ describe(RouteStatus.displayName, () => {
               {
                 'type': 'Admitted',
                 'status': 'True',
-                'lastTransitionTime': '2018-04-30T16:55:48Z'
-              }
-            ]
-          }
-        ]
-      }
+                'lastTransitionTime': '2018-04-30T16:55:48Z',
+              },
+            ],
+          },
+        ],
+      },
     };
 
     const wrapper = shallow(<RouteStatus obj={route} />);
@@ -215,12 +215,12 @@ describe(RouteStatus.displayName, () => {
               {
                 'type': 'Admitted',
                 'status': 'False',
-                'lastTransitionTime': '2018-04-30T16:55:48Z'
-              }
-            ]
-          }
-        ]
-      }
+                'lastTransitionTime': '2018-04-30T16:55:48Z',
+              },
+            ],
+          },
+        ],
+      },
     };
 
     const wrapper = shallow(<RouteStatus obj={route} />);
@@ -234,7 +234,7 @@ describe(RouteStatus.displayName, () => {
       'kind': 'Route',
       'metadata': {
         name: 'example',
-      }
+      },
     };
 
     const wrapper = shallow(<RouteStatus obj={route} />);

--- a/frontend/__tests__/components/storage-class-form.spec.tsx
+++ b/frontend/__tests__/components/storage-class-form.spec.tsx
@@ -51,8 +51,8 @@ describe(ConnectedStorageClassForm.displayName, () => {
     wrapper.setState({
       newStorageClass: {
         ...wrapper.state().newStorageClass,
-        type: 'aws'
-      }
+        type: 'aws',
+      },
     });
     expect(wrapper.find({title: 'Select AWS Type'}).exists()).toBe(true);
   });

--- a/frontend/__tests__/docker.js
+++ b/frontend/__tests__/docker.js
@@ -10,9 +10,9 @@ describe('k8sDocker', () => {
             containerStatuses: [
               {name: 'ACAEB740-01D1-4D43-BB7B-68EBFD484701'},
               {name: '06DB4D15-3A24-482B-82B1-A46337D8C2DD'},
-              {name: '7AE75BB5-B562-4D5A-B880-F529797CAD5F'}
-            ]
-          }
+              {name: '7AE75BB5-B562-4D5A-B880-F529797CAD5F'},
+            ],
+          },
         },
 
         // container name
@@ -28,9 +28,9 @@ describe('k8sDocker', () => {
             containerStatuses: [
               {name: 'ACAEB740-01D1-4D43-BB7B-68EBFD484701'},
               {name: '9242B9F6-A50A-4330-8C0E-B18EA4672A89', status: 'running'},
-              {name: '7AE75BB5-B562-4D5A-B880-F529797CAD5F'}
-            ]
-          }
+              {name: '7AE75BB5-B562-4D5A-B880-F529797CAD5F'},
+            ],
+          },
         },
 
         // container name

--- a/frontend/__tests__/module/k8s/autocomplete.spec.ts
+++ b/frontend/__tests__/module/k8s/autocomplete.spec.ts
@@ -93,11 +93,11 @@ describe('getCompletions', () => {
             minReadySeconds: {
               description: 'Dummy property',
               type: 'integer',
-              format: 'int32'
-            }
-          }
-        }
-      }
+              format: 'int32',
+            },
+          },
+        },
+      },
     };
     sessionMock.getLines = jasmine.createSpy('getLinesSpy').and.returnValue(['kind: Deployment', 'apiVersion: apps/v1']);
     spyOn(window.localStorage, 'getItem').and.returnValue(JSON.stringify(swagger));

--- a/frontend/__tests__/module/k8s/k8s-actions.spec.ts
+++ b/frontend/__tests__/module/k8s/k8s-actions.spec.ts
@@ -60,7 +60,7 @@ describe(types.watchK8sList, () => {
     websocket = {
       onclose: jasmine.createSpy('onclose'),
       ondestroy: jasmine.createSpy('ondestroy'),
-      onbulkmessage: jasmine.createSpy('onbulkmessage')
+      onbulkmessage: jasmine.createSpy('onbulkmessage'),
     };
     websocket.onclose.and.returnValue(websocket);
     websocket.ondestroy.and.returnValue(websocket);

--- a/frontend/__tests__/module/k8s/pods.spec.ts
+++ b/frontend/__tests__/module/k8s/pods.spec.ts
@@ -66,8 +66,8 @@ describe('podReadiness', () => {
         phase: 'Running',
         conditions: [
           {type: 'Ready', status: 'True'},
-        ]
-      }
+        ],
+      },
     };
   });
 

--- a/frontend/__tests__/selector-requirement.js
+++ b/frontend/__tests__/selector-requirement.js
@@ -5,43 +5,43 @@ describe('k8sSelectorRequirement', () => {
     [
       {
         requirement: {key: 'key1', operator: 'Equals', values: ['value1']},
-        string:      'key1=value1'
+        string:      'key1=value1',
       },
 
       {
         requirement: {key: 'key1', operator: 'NotEquals', values: ['value1']},
-        string:      'key1!=value1'
+        string:      'key1!=value1',
       },
 
       {
         requirement: {key: 'key1', operator: 'Exists', values: []},
-        string:      'key1'
+        string:      'key1',
       },
 
       {
         requirement: {key: 'key1', operator: 'DoesNotExist', values: []},
-        string:      '!key1'
+        string:      '!key1',
       },
 
       {
         requirement: {key: 'key1', operator: 'In', values: ['value1', 'value2']},
-        string:      'key1 in (value1,value2)'
+        string:      'key1 in (value1,value2)',
       },
 
       {
         requirement: {key: 'key1', operator: 'NotIn', values: ['value1', 'value2']},
-        string:      'key1 notin (value1,value2)'
+        string:      'key1 notin (value1,value2)',
       },
 
       {
         requirement: {key: 'key1', operator: 'GreaterThan', values: ['666.999']},
-        string:      'key1 > 666.999'
+        string:      'key1 > 666.999',
       },
 
       {
         requirement: {key: 'key1', operator: 'LessThan', values: ['666.999']},
-        string:      'key1 < 666.999'
-      }
+        string:      'key1 < 666.999',
+      },
     ].forEach(t => {
       it('...', () => expect(requirementFromString(t.string)).toEqual(t.requirement));
     });
@@ -70,7 +70,7 @@ describe('k8sSelectorRequirement', () => {
       'key1>one_two_three',
       'key1<',
       'key1<=',
-      'key1<one_two_three'
+      'key1<one_two_three',
     ].forEach(s => {
       it(`returns falsy for unknown/malformed string: ${s}`, () => expect(requirementFromString(s)).toBeFalsy());
     });
@@ -80,43 +80,43 @@ describe('k8sSelectorRequirement', () => {
     [
       {
         requirement: {key: 'key1', operator: 'Equals', values: ['value1', 'value2']},
-        string:      'key1=value1'
+        string:      'key1=value1',
       },
 
       {
         requirement: {key: 'key1', operator: 'NotEquals', values: ['value1', 'value2']},
-        string:      'key1!=value1'
+        string:      'key1!=value1',
       },
 
       {
         requirement: {key: 'key1', operator: 'Exists', values: ['value1']},
-        string:      'key1'
+        string:      'key1',
       },
 
       {
         requirement: {key: 'key1', operator: 'DoesNotExist', values: ['value1']},
-        string:      '!key1'
+        string:      '!key1',
       },
 
       {
         requirement: {key: 'key1', operator: 'In', values: ['value1', 'value2']},
-        string:      'key1 in (value1,value2)'
+        string:      'key1 in (value1,value2)',
       },
 
       {
         requirement: {key: 'key1', operator: 'NotIn', values: ['value1', 'value2']},
-        string:      'key1 notin (value1,value2)'
+        string:      'key1 notin (value1,value2)',
       },
 
       {
         requirement: {key: 'key1', operator: 'GreaterThan', values: ['666.999']},
-        string:      'key1 > 666.999'
+        string:      'key1 > 666.999',
       },
 
       {
         requirement: {key: 'key1', operator: 'LessThan', values: ['666.999']},
-        string:      'key1 < 666.999'
-      }
+        string:      'key1 < 666.999',
+      },
     ].forEach(t => {
       it(`returns string for ${JSON.stringify(t.requirement)} requirement`, () => {
         expect(requirementToString(t.requirement)).toEqual(t.string);
@@ -133,7 +133,7 @@ describe('k8sSelectorRequirement', () => {
       expect(createEquals('Key', 'Value')).toEqual({
         key:      'Key',
         operator: 'Equals',
-        values:   ['Value']
+        values:   ['Value'],
       });
     });
   });

--- a/frontend/__tests__/selector.js
+++ b/frontend/__tests__/selector.js
@@ -5,7 +5,7 @@ describe('k8sSelector', () => {
     it('works for nullable', () => {
       expect(selectorFromString(null)).toEqual({
         matchLabels:      {},
-        matchExpressions: []
+        matchExpressions: [],
       });
     });
 
@@ -13,46 +13,46 @@ describe('k8sSelector', () => {
       expect(selectorFromString('key1=value1,key2=value2,key3,!key4,key5 in (value5),key6 in (value6.1,value6.2),key7 notin (value7),key8 notin (value8.1,value8.2)')).toEqual({
         matchLabels: {
           key1: 'value1',
-          key2: 'value2'
+          key2: 'value2',
         },
 
         matchExpressions: [
           {
             key:      'key3',
             operator: 'Exists',
-            values:   []
+            values:   [],
           },
 
           {
             key:      'key4',
             operator: 'DoesNotExist',
-            values:   []
+            values:   [],
           },
 
           {
             key:      'key5',
             operator: 'In',
-            values:   ['value5']
+            values:   ['value5'],
           },
 
           {
             key:      'key6',
             operator: 'In',
-            values:   ['value6.1', 'value6.2']
+            values:   ['value6.1', 'value6.2'],
           },
 
           {
             key:      'key7',
             operator: 'NotIn',
-            values:   ['value7']
+            values:   ['value7'],
           },
 
           {
             key:      'key8',
             operator: 'NotIn',
-            values:   ['value8.1', 'value8.2']
-          }
-        ]
+            values:   ['value8.1', 'value8.2'],
+          },
+        ],
       });
     });
   });
@@ -74,51 +74,51 @@ describe('k8sSelector', () => {
       expect(selectorToString({
         matchLabels: {
           key1: 'value1',
-          key2: 'value2'
+          key2: 'value2',
         },
 
         matchExpressions: [
           {
             key:      'key3',
-            operator: 'Exists'
+            operator: 'Exists',
           },
 
           {
             key:      'key4',
-            operator: 'DoesNotExist'
+            operator: 'DoesNotExist',
           },
 
           {
             key:      'key5',
             operator: 'In',
-            values:   'value5'
+            values:   'value5',
           },
 
           {
             key:      'key6',
             operator: 'In',
-            values:   ['value6.1', 'value6.2']
+            values:   ['value6.1', 'value6.2'],
           },
 
           {
             key:      'key7',
             operator: 'NotIn',
-            values:   'value7'
+            values:   'value7',
           },
 
           {
             key:      'key8',
             operator: 'NotIn',
-            values:   ['value8.1', 'value8.2']
-          }
-        ]
+            values:   ['value8.1', 'value8.2'],
+          },
+        ],
       })).toEqual('key1=value1,key2=value2,key3,!key4,key5 in (value5),key6 in (value6.1,value6.2),key7 notin (value7),key8 notin (value8.1,value8.2)');
     });
 
     it('works when V1 selector is given', () => {
       expect(selectorToString({
         key1: 'value1',
-        key2: 'value2'
+        key2: 'value2',
       })).toEqual('key1=value1,key2=value2');
     });
   });

--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -36,14 +36,14 @@ export const config: Config = {
         '--window-size=1920,1200',
         '--disable-background-timer-throttling',
         '--disable-renderer-backgrounding',
-        '--disable-raf-throttling'
+        '--disable-raf-throttling',
       ],
       prefs: {
         'profile.password_manager_enabled': false,
         'credentials_enable_service': false,
-        'password_manager_enabled': false
-      }
-    }
+        'password_manager_enabled': false,
+      },
+    },
   },
   beforeLaunch: () => new Promise(resolve => htmlReporter.beforeLaunch(resolve)),
   onPrepare: () => {
@@ -112,8 +112,8 @@ export const config: Config = {
     // $ yarn run test-gui --params.openshift true
     openshift: 'false',
     // Set to 'true' to enable Service Catalog resources in the crud scenario.
-    servicecatalog: 'false'
-  }
+    servicecatalog: 'false',
+  },
 };
 
 export const checkLogs = async() => (await browser.manage().logs().get('browser'))

--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -226,7 +226,7 @@ describe('Kubernetes resource CRUD operations', () => {
       kind: 'CustomResourceDefinition',
       metadata: {
         name,
-        labels: {[testLabel]: testName}
+        labels: {[testLabel]: testName},
       },
       spec: {
         group,
@@ -236,8 +236,8 @@ describe('Kubernetes resource CRUD operations', () => {
           singular: `crd${testName}`,
           kind: `CRD${testName}`,
           shortNames: [testName],
-        }
-      }
+        },
+      },
     };
 
     it('displays `CustomResourceDefinitions` list view', async() => {

--- a/frontend/integration-tests/tests/olm/descriptors.scenario.ts
+++ b/frontend/integration-tests/tests/olm/descriptors.scenario.ts
@@ -21,7 +21,7 @@ const defaultValueFor = <C extends SpecCapability | StatusCapability>(capability
     case StatusCapability.podCount: return 3;
     case StatusCapability.w3Link: return 'https://google.com';
     case StatusCapability.conditions: return [
-      {type: 'Available', status: 'True', lastUpdateTime: '2018-08-22T23:27:55Z', lastTransitionTime: '2018-08-22T23:27:55Z', reason: 'AppReady', message: 'App is ready.'}
+      {type: 'Available', status: 'True', lastUpdateTime: '2018-08-22T23:27:55Z', lastTransitionTime: '2018-08-22T23:27:55Z', reason: 'AppReady', message: 'App is ready.'},
     ];
     case StatusCapability.text: return 'Some text';
     case StatusCapability.prometheusEndpoint: return 'my-svc.my-namespace.svc.cluster.local';
@@ -51,8 +51,8 @@ describe('Using OLM descriptor components', () => {
         singular: 'app',
         kind: 'App',
         listKind: 'Apps',
-      }
-    }
+      },
+    },
   };
   const testCR = {
     apiVersion: `${testCRD.spec.group}/${testCRD.spec.version}`,
@@ -64,12 +64,12 @@ describe('Using OLM descriptor components', () => {
     },
     spec: {
       ...Object.keys(SpecCapability).filter(c => !prefixedCapabilities.has(SpecCapability[c])).reduce((acc, cur) => ({
-        ...acc, [cur]: defaultValueFor(SpecCapability[cur])
+        ...acc, [cur]: defaultValueFor(SpecCapability[cur]),
       }), {}),
     },
     status: {
       ...Object.keys(StatusCapability).filter(c => !prefixedCapabilities.has(StatusCapability[c])).reduce((acc, cur) => ({
-        ...acc, [cur]: defaultValueFor(StatusCapability[cur])
+        ...acc, [cur]: defaultValueFor(StatusCapability[cur]),
       }), {}),
     },
   };
@@ -93,27 +93,27 @@ describe('Using OLM descriptor components', () => {
               replicas: 1,
               selector: {
                 matchLabels: {
-                  name: 'test-operator-alm-owned'
-                }
+                  name: 'test-operator-alm-owned',
+                },
               },
               template: {
                 metadata: {
                   name: 'test-operator-alm-owned',
                   labels: {
-                    name: 'test-operator-alm-owned'
-                  }
+                    name: 'test-operator-alm-owned',
+                  },
                 },
                 spec: {
                   serviceAccountName: 'test-operator',
                   containers: [{
                     name: 'test-operator',
                     image: 'nginx',
-                  }]
-                }
-              }
-            }
-          }]
-        }
+                  }],
+                },
+              },
+            },
+          }],
+        },
       },
       customresourcedefinitions: {
         owned: [
@@ -136,10 +136,10 @@ describe('Using OLM descriptor components', () => {
               path: capability,
               'x-descriptors': [StatusCapability[capability]],
             })),
-          }
-        ]
-      }
-    }
+          },
+        ],
+      },
+    },
   };
 
   beforeAll(async() => {

--- a/frontend/integration-tests/tests/secrets.scenario.ts
+++ b/frontend/integration-tests/tests/secrets.scenario.ts
@@ -141,16 +141,16 @@ describe('Interacting with the create secret forms', () => {
             username: username0,
             password: password0,
             auth: secretsView.encode(username0, password0),
-            email: 'test@secret.com0'
+            email: 'test@secret.com0',
           },
           'https://index.openshift.io/v1':{
             username: username1,
             password: password1,
             auth: secretsView.encode(username1, password1),
-            email: 'test@secret.com1'
-          }
-        }
-      }
+            email: 'test@secret.com1',
+          },
+        },
+      },
     };
     const updatedCredentialsToCheck = {
       '.dockerconfigjson': {
@@ -159,10 +159,10 @@ describe('Interacting with the create secret forms', () => {
             username: usernameUpdated,
             password: passwordUpdated,
             auth: secretsView.encode(usernameUpdated, passwordUpdated),
-            email: 'testUpdated@secret.com'
-          }
-        }
-      }
+            email: 'testUpdated@secret.com',
+          },
+        },
+      },
     };
 
     beforeAll(async() => secretsView.visitSecretsPage(appHost, testName));
@@ -217,9 +217,9 @@ describe('Interacting with the create secret forms', () => {
           username: username,
           password: password,
           auth: secretsView.encode(username, password),
-          email: 'test@secret.com'
-        }
-      }
+          email: 'test@secret.com',
+        },
+      },
     };
 
     beforeAll(async() => secretsView.visitSecretsPage(appHost, testName));

--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -111,7 +111,7 @@ export const coFetch = (url, options = {}, timeout=20000) => {
 const parseJson = (response) => response.json();
 
 export const coFetchUtils = {
-  parseJson
+  parseJson,
 };
 
 export const coFetchJSON = (url, method = 'GET', options = {}) => {

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -208,7 +208,7 @@ class ListDropdown_ extends React.Component {
 
     if (loadError) {
       this.setState({
-        title: <div className="cos-error-title">Error Loading {nextProps.desc}</div>
+        title: <div className="cos-error-title">Error Loading {nextProps.desc}</div>,
       });
       return;
     }

--- a/frontend/public/components/RBAC/rules.jsx
+++ b/frontend/public/components/RBAC/rules.jsx
@@ -98,7 +98,7 @@ const DeleteRule = (name, namespace, i) => ({
         op: 'remove', path: `/rules/${i}`,
       }]);
     },
-  })
+  }),
 });
 
 // This page is temporarily disabled until we update the safe resources list.

--- a/frontend/public/components/alert-manager.jsx
+++ b/frontend/public/components/alert-manager.jsx
@@ -13,14 +13,14 @@ class Details extends SafetyFirst {
   constructor(props) {
     super(props);
     this.state = {
-      desiredCountOutdated: false
+      desiredCountOutdated: false,
     };
     this._openReplicaCountModal = this._openReplicaCountModal.bind(this);
   }
 
   componentWillReceiveProps() {
     this.setState({
-      desiredCountOutdated: false
+      desiredCountOutdated: false,
     });
   }
 
@@ -32,9 +32,9 @@ class Details extends SafetyFirst {
       resource: this.props.obj,
       invalidateState: (isInvalid) => {
         this.setState({
-          desiredCountOutdated: isInvalid
+          desiredCountOutdated: isInvalid,
         });
-      }
+      },
     });
   }
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -114,7 +114,7 @@ class App extends React.PureComponent {
         <GlobalNotifications />
         <div id="content-scrollable">
           <Switch>
-            <Route path={['/all-namespaces', '/ns/:ns',]} component={RedirectComponent} />
+            <Route path={['/all-namespaces', '/ns/:ns']} component={RedirectComponent} />
 
             <LazyRoute path="/overview/ns/:ns" exact loader={() => import('./overview' /* webpackChunkName: "overview" */).then(m => m.OverviewPage)} />
             <LazyRoute path="/overview/all-namespaces" exact loader={() => import('./overview' /* webpackChunkName: "overview" */).then(m => m.OverviewPage)} />

--- a/frontend/public/components/build-logs.jsx
+++ b/frontend/public/components/build-logs.jsx
@@ -39,7 +39,7 @@ export class BuildLogs extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      status: LOG_SOURCE_WAITING
+      status: LOG_SOURCE_WAITING,
     };
   }
 

--- a/frontend/public/components/build-pipeline.tsx
+++ b/frontend/public/components/build-pipeline.tsx
@@ -27,7 +27,7 @@ const BuildSummaryStatusIcon: React.SFC<BuildSummaryStatusIconProps> = ({ status
     pending: 'fa-hourglass-half',
     running: 'fa-refresh fa-spin',
     complete: 'fa-check-circle',
-    failed: 'fa-times-circle'
+    failed: 'fa-times-circle',
   })[statusClass];
 
   return icon

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -169,7 +169,7 @@ const pages = [
   navFactory.editYaml(),
   navFactory.envEditor(BuildEnvironmentComponent),
   navFactory.logs(BuildLogs),
-  navFactory.events(ResourceEventStream)
+  navFactory.events(ResourceEventStream),
 ];
 
 export const BuildsDetailsPage: React.SFC<BuildsDetailsPageProps> = props =>

--- a/frontend/public/components/catalog/catalog-item-details.jsx
+++ b/frontend/public/components/catalog/catalog-item-details.jsx
@@ -29,7 +29,7 @@ export class CatalogTileDetails extends React.Component {
     k8sGet(ClusterServicePlanModel, null, null, {queryParams: { fieldSelector: `spec.clusterServiceClassRef.name=${obj.metadata.name}`} })
       .then(({items: plans}) => {
         this.setState({
-          plans: _.orderBy(plans, ['spec.externalMetadata.displayName', 'metadata.name'])
+          plans: _.orderBy(plans, ['spec.externalMetadata.displayName', 'metadata.name']),
         });
       });
   }

--- a/frontend/public/components/catalog/catalog-items.jsx
+++ b/frontend/public/components/catalog/catalog-items.jsx
@@ -35,7 +35,7 @@ export class CatalogTileViewPage extends React.Component {
           value: 'ImageStream',
           active: false,
         },
-      }
+      },
     };
 
     let filterCounts = {

--- a/frontend/public/components/catalog/catalog-page.jsx
+++ b/frontend/public/components/catalog/catalog-page.jsx
@@ -11,7 +11,7 @@ import { Firehose, PageHeading, StatusBox } from '../utils';
 import {
   getAnnotationTags,
   getMostRecentBuilderTag,
-  isBuilder
+  isBuilder,
 } from '../image-stream';
 import {
   getImageForIconClass,
@@ -159,7 +159,7 @@ export const Catalog = connectToFlags(FLAGS.OPENSHIFT, FLAGS.SERVICE_CATALOG)(({
       isList: true,
       kind: 'ClusterServiceClass',
       namespaced: false,
-      prop: 'clusterserviceclasses'
+      prop: 'clusterserviceclasses',
     });
   }
   if (flags.OPENSHIFT) {
@@ -167,7 +167,7 @@ export const Catalog = connectToFlags(FLAGS.OPENSHIFT, FLAGS.SERVICE_CATALOG)(({
       isList: true,
       kind: 'ImageStream',
       namespace: 'openshift',
-      prop: 'imagestreams'
+      prop: 'imagestreams',
     });
   }
   return <Firehose resources={mock ? [] : resources}>

--- a/frontend/public/components/channel-operators/app-version.jsx
+++ b/frontend/public/components/channel-operators/app-version.jsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 
 import {LoadingInline, taskStatuses, operatorStates, calculateChannelState, determineOperatorState, orderedTaskStatuses} from '../utils';
-import {configureOperatorStrategyModal, configureOperatorChannelModal,} from '../modals';
+import {configureOperatorStrategyModal, configureOperatorChannelModal} from '../modals';
 import {DetailConfig} from './detail-config';
 import {DetailStatus} from './detail-status';
 
@@ -22,7 +22,7 @@ const groupTaskStatuses = tss => {
     reason: '',
     state: '',
     type: 'operator',
-    statuses: []
+    statuses: [],
   };
 
   const appVersionTaskStatuses = {
@@ -30,7 +30,7 @@ const groupTaskStatuses = tss => {
     reason: '',
     state: '',
     type: 'appversion',
-    statuses: []
+    statuses: [],
   };
 
   const groupedTaskStatuses = [operatorTaskStatuses, appVersionTaskStatuses];
@@ -63,7 +63,7 @@ const DetailWrapper = ({title, children}) => <div className="col-xs-6 col-sm-4 c
 
 DetailWrapper.propTypes = {
   title: PropTypes.node,
-  children: PropTypes.node
+  children: PropTypes.node,
 };
 
 const Details = ({config, channelState, tcAppVersion}) => {
@@ -223,7 +223,7 @@ class TaskStatus extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      isErrorMsgVisible: false
+      isErrorMsgVisible: false,
     };
   }
 

--- a/frontend/public/components/channel-operators/detail-config.jsx
+++ b/frontend/public/components/channel-operators/detail-config.jsx
@@ -14,7 +14,7 @@ export class DetailConfig extends SafetyFirst {
   constructor(props) {
     super(props);
     this.state = {
-      outdated: false
+      outdated: false,
     };
     this._openModal = this._openModal.bind(this);
   }
@@ -27,14 +27,14 @@ export class DetailConfig extends SafetyFirst {
     this.props.modal(_.defaults({}, this.props.modalData, {
       config: this.props.config,
       callbacks: {
-        invalidateState: this._updateOutdated.bind(this)
-      }
+        invalidateState: this._updateOutdated.bind(this),
+      },
     }));
   }
 
   _updateOutdated(outdated) {
     this.setState({
-      outdated
+      outdated,
     });
   }
 
@@ -55,5 +55,5 @@ DetailConfig.propTypes = {
   displayFunction: PropTypes.func,
   modal: PropTypes.func,
   modalData: PropTypes.object,
-  field: PropTypes.string.isRequired
+  field: PropTypes.string.isRequired,
 };

--- a/frontend/public/components/channel-operators/detail-status.jsx
+++ b/frontend/public/components/channel-operators/detail-status.jsx
@@ -10,19 +10,19 @@ export class DetailStatus extends SafetyFirst {
   constructor(props) {
     super(props);
     this.state = {
-      outdated: false
+      outdated: false,
     };
   }
 
   componentWillReceiveProps() {
     this.setState({
-      outdated: false
+      outdated: false,
     });
   }
 
   _doAction(kind, field, value) {
     this.setState({
-      outdated: true
+      outdated: true,
     });
 
     let k8skind, resource;
@@ -38,7 +38,7 @@ export class DetailStatus extends SafetyFirst {
     k8sPatch(k8skind, resource, patch)
       .catch((error) => {
         this.setState({
-          outdated: false
+          outdated: false,
         });
         throw error;
       });

--- a/frontend/public/components/channel-operators/tectonic-channel.jsx
+++ b/frontend/public/components/channel-operators/tectonic-channel.jsx
@@ -10,14 +10,14 @@ const componentNames = {
   'kubernetes': 'Kubernetes',
   'tectonic-cluster': 'Tectonic',
   'tectonic-etcd': 'tectonic-etcd',
-  'tectonic-monitoring': 'tectonic-monitoring'
+  'tectonic-monitoring': 'tectonic-monitoring',
 };
 
 const podNames = {
   'kubernetes': 'kube-version-operator',
   'tectonic-cluster': 'tectonic-channel-operator',
   'tectonic-etcd': 'etcd-operator',
-  'tectonic-monitoring': 'tectonic-prometheus-operator'
+  'tectonic-monitoring': 'tectonic-prometheus-operator',
 };
 
 export const clusterAppVersionName = 'tectonic-cluster';
@@ -44,7 +44,7 @@ const generateComponents = (components, pods) => {
         taskStatuses: component.taskStatuses,
         failureStatus: component.failureStatus,
         state,
-        logsUrl
+        logsUrl,
       };
     }
     return finalComponents;
@@ -66,27 +66,27 @@ export class TectonicChannel extends SafetyFirst {
         kind: 'ChannelOperatorConfig',
         namespace: 'tectonic-system',
         isList: true,
-        prop: 'configs'
+        prop: 'configs',
       },
       {
         kind: 'TectonicVersion',
         namespace: 'tectonic-system',
         isList: true,
-        prop: 'tectonicVersions'
+        prop: 'tectonicVersions',
       },
       {
         kind: 'AppVersion',
         namespace: 'tectonic-system',
         isList: true,
-        prop: 'appVersions'
+        prop: 'appVersions',
       },
       {
         kind: 'Pod',
         namespace: 'tectonic-system',
         isList: true,
         prop: 'pods',
-        selector: selector
-      }
+        selector: selector,
+      },
 
     ];
   }
@@ -106,7 +106,7 @@ class TectonicChannelWithData extends React.Component {
 
     if (configs.loadError) {
       return {
-        loadError : configs.loadError
+        loadError : configs.loadError,
       };
     }
 
@@ -120,7 +120,7 @@ class TectonicChannelWithData extends React.Component {
 
     if (versions.loadError) {
       return {
-        loadError : versions.loadError
+        loadError : versions.loadError,
       };
     }
 
@@ -146,7 +146,7 @@ class TectonicChannelWithData extends React.Component {
       pausedSpec: _.get(spec, 'paused'),
       pausedStatus: _.get(status, 'paused'),
       failureStatus: _.get(status, 'failureStatus', null),
-      taskStatuses: _.get(status, 'taskStatuses', [])
+      taskStatuses: _.get(status, 'taskStatuses', []),
     };
 
     return components;

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -12,14 +12,14 @@ import {
   LoadError,
   LoadingBox,
   LoadingInline,
-  MsgBox
+  MsgBox,
 } from './utils/status-box';
 import {
   // eslint-disable-next-line no-unused-vars
   GroupVersionKind,
   modelFor,
   referenceForModel,
-  resourceURL
+  resourceURL,
 } from '../module/k8s';
 import {
   Cog,
@@ -32,7 +32,7 @@ import {
   ResourceLink,
   ResourceSummary,
   SectionHeading,
-  Timestamp
+  Timestamp,
 } from './utils';
 
 export const ReportReference: GroupVersionKind = referenceForModel(ChargebackReportModel);

--- a/frontend/public/components/client-tokens.jsx
+++ b/frontend/public/components/client-tokens.jsx
@@ -12,7 +12,7 @@ export class ClientTokensContainer extends SafetyFirst {
     this.state = {
       clients : null,
       resourceLoaded: false,
-      loadingError: false
+      loadingError: false,
     };
     this._getClients = this._getClients.bind(this);
   }
@@ -51,11 +51,11 @@ const RevokeToken = (id, onTokenRevocation) => ({
       data.append('clientId', id);
       const promise = coFetch('api/tectonic/revoke-token', {
         method: 'POST',
-        body: data
+        body: data,
       }).then(onTokenRevocation);
       return promise;
     },
-  })
+  }),
 });
 
 const ClientRow = ({client, onTokenRevocation}) => {

--- a/frontend/public/components/cluster-overview.jsx
+++ b/frontend/public/components/cluster-overview.jsx
@@ -202,7 +202,7 @@ const GraphsPage = connectToFlags(FLAGS.OPENSHIFT)(({flags, mock, limited, names
     kind: openShiftFlag ? 'Project' : 'Namespace',
     name: namespace,
     isList: false,
-    prop: 'data'
+    prop: 'data',
   }];
 
   return <Firehose resources={resources}>

--- a/frontend/public/components/cluster-service-class.tsx
+++ b/frontend/public/components/cluster-service-class.tsx
@@ -29,7 +29,7 @@ const createInstance = (kindObj, serviceClass) => {
 };
 
 const actionButtons = [
-  createInstance
+  createInstance,
 ];
 
 const ClusterServiceClassHeader: React.SFC<ClusterServiceClassHeaderProps> = props => <ListHeader>

--- a/frontend/public/components/cluster-service-plan.tsx
+++ b/frontend/public/components/cluster-service-plan.tsx
@@ -59,7 +59,7 @@ export const ClusterServicePlanDetailsPage: React.SFC<ClusterServicePlanDetailsP
   kind={ClusterServicePlanReference}
   pages={[
     navFactory.details(detailsPage(ClusterServicePlanDetails)),
-    navFactory.editYaml(viewYamlComponent)
+    navFactory.editYaml(viewYamlComponent),
   ]}
 />;
 export const ClusterServicePlanList: React.SFC = props => <List {...props} Header={ClusterServicePlanHeader} Row={ClusterServicePlanListRow} />;

--- a/frontend/public/components/cluster-settings/certs-info.jsx
+++ b/frontend/public/components/cluster-settings/certs-info.jsx
@@ -10,7 +10,7 @@ export class CertsInfoContainer extends SafetyFirst {
   constructor(props){
     super(props);
     this.state = {
-      info : null
+      info : null,
     };
   }
 

--- a/frontend/public/components/cluster-settings/cluster-monitoring.jsx
+++ b/frontend/public/components/cluster-settings/cluster-monitoring.jsx
@@ -114,7 +114,7 @@ const renderField = ({
   meta: {
     // touched,
     error,
-    warning }
+    warning },
 }) => <div>
   <input className={classNames('form-control', {'form-control--invalid': !!error})} style={fieldStyle} {...input} type={type} autoFocus={autoFocus} placeholder={placeholder} />
   {
@@ -216,8 +216,8 @@ const MemCPUModalLink = ({section, type, config, obj}) => {
           limits: {
             [type]: formData.limit,
           },
-        }
-      }
+        },
+      },
     });
 
     return modal({title, description, config, obj, reduxFormWrapper, FormBody, getNewConfig});

--- a/frontend/public/components/cluster-settings/ldap.jsx
+++ b/frontend/public/components/cluster-settings/ldap.jsx
@@ -9,7 +9,7 @@ import {
   Field,
   reduxForm,
   formValueSelector,
-  getFormValues
+  getFormValues,
 } from 'redux-form';
 
 import store from '../../redux';
@@ -20,12 +20,12 @@ import { coFetchJSON } from '../../co-fetch';
 import {
   LoadingInline,
   LoadError,
-  PageHeading
+  PageHeading,
 } from '../utils';
 import {
   SettingsContent,
   SettingsLabel,
-  SettingsRow
+  SettingsRow,
 } from './cluster-settings';
 
 export const LDAPSetting = () => <SettingsRow>
@@ -86,7 +86,7 @@ const Fields = {
     {
       name: Password,
       label: 'Password',
-      type: 'password'
+      type: 'password',
     },
   ],
   ServiceAccount: [

--- a/frontend/public/components/cluster-settings/settings-modal-link.jsx
+++ b/frontend/public/components/cluster-settings/settings-modal-link.jsx
@@ -18,5 +18,5 @@ export const SettingsModalLink = ({onClick, outdated, children}) => {
 SettingsModalLink.propTypes = {
   children: PropTypes.node,
   onClick: PropTypes.func,
-  outdated: PropTypes.bool
+  outdated: PropTypes.bool,
 };

--- a/frontend/public/components/configmap-and-secret-data.jsx
+++ b/frontend/public/components/configmap-and-secret-data.jsx
@@ -65,9 +65,9 @@ export class SecretData extends React.PureComponent {
 }
 
 SecretData.propTypes = {
-  data: PropTypes.object
+  data: PropTypes.object,
 };
 
 SecretData.defaultProps = {
-  data: {}
+  data: {},
 };

--- a/frontend/public/components/container-linux-update-operator/container-linux-updates.jsx
+++ b/frontend/public/components/container-linux-update-operator/container-linux-updates.jsx
@@ -8,13 +8,13 @@ const firehoseResources = [
   {
     kind: 'Node',
     isList: true,
-    prop: 'nodes'
+    prop: 'nodes',
   },
   {
     kind: 'ConfigMap',
     namespace: 'tectonic-system',
     name: 'tectonic-config',
-    prop: 'configMap'
+    prop: 'configMap',
 
   },
 ];

--- a/frontend/public/components/container.jsx
+++ b/frontend/public/components/container.jsx
@@ -5,7 +5,7 @@ import * as k8sProbe from '../module/k8s/probe';
 import {
   getContainerState,
   getContainerStatus,
-  getPullPolicyLabel
+  getPullPolicyLabel,
 } from '../module/k8s/docker';
 import {
   Firehose,

--- a/frontend/public/components/daemon-set.jsx
+++ b/frontend/public/components/daemon-set.jsx
@@ -7,7 +7,7 @@ import {
   List,
   ListHeader,
   ListPage,
-  ResourceRow
+  ResourceRow,
 } from './factory';
 import {
   AsyncComponent,
@@ -20,7 +20,7 @@ import {
   ResourceLink,
   ResourceSummary,
   SectionHeading,
-  Selector
+  Selector,
 } from './utils';
 
 export const menuActions = [Cog.factory.EditEnvironment, ...Cog.factory.common];

--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -11,7 +11,7 @@ import {
   ResourceCog,
   ResourceLink,
   ResourceSummary,
-  SectionHeading
+  SectionHeading,
 } from './utils';
 
 const { common } = Cog.factory;

--- a/frontend/public/components/deploy-image.tsx
+++ b/frontend/public/components/deploy-image.tsx
@@ -17,13 +17,13 @@ import {
   Loading,
   PageHeading,
   Timestamp,
-  units
+  units,
 } from './utils';
 import {
   DeploymentConfigModel,
   ImageStreamModel,
   ImageStreamImportsModel,
-  ServiceModel
+  ServiceModel,
 } from '../models';
 
 const getSuggestedName = name => {
@@ -99,18 +99,18 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
       apiVersion: 'image.openshift.io/v1',
       metadata: {
         name: 'newapp',
-        namespace
+        namespace,
       },
       spec: {
         import: false,
         images: [{
           from: {
             kind: 'DockerImage',
-            name: _.trim(imageName)
-          }
-        }]
+            name: _.trim(imageName),
+          },
+        }],
       },
-      status: {}
+      status: {},
     };
 
     this.setState({
@@ -134,7 +134,7 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
               name,
               image,
               tag,
-              status
+              status,
             },
             name: getSuggestedName(name),
           });
@@ -155,13 +155,13 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
 
     this.setState({
       inProgress: true,
-      error: null
+      error: null,
     });
 
     const { name, namespace, isi } = this.state;
 
     const annotations = {
-      'openshift.io/generated-by': 'OpenShiftWebConsole'
+      'openshift.io/generated-by': 'OpenShiftWebConsole',
     };
 
     const volumes = [], volumeMounts = [];
@@ -171,11 +171,11 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
       const volumeName = `${name}-${volumeNumber}`;
       volumes.push({
         name: volumeName,
-        emptyDir: {}
+        emptyDir: {},
       });
       volumeMounts.push({
         name: volumeName,
-        mountPath: path
+        mountPath: path,
       });
     });
 
@@ -200,31 +200,31 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
         name,
         namespace,
         labels,
-        annotations
+        annotations,
       },
       spec: {
         triggers: [{
-          type: 'ConfigChange'
+          type: 'ConfigChange',
         }, {
           type: 'ImageChange',
           imageChangeParams: {
             automatic: true,
             containerNames: [
-              name
+              name,
             ],
             from: {
               kind: 'ImageStreamTag',
               name: `${name}:${isi.tag}`,
-              namespace
-            }
-          }
+              namespace,
+            },
+          },
         }],
         replicas: 1,
         selector: labels,
         template: {
           metadata: {
             labels,
-            annotations
+            annotations,
           },
           spec: {
             volumes,
@@ -233,10 +233,10 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
               image: isi.image.dockerImageMetadata.Config.Image,
               ports,
               volumeMounts,
-              env: this.env
+              env: this.env,
             }],
-          }
-        }
+          },
+        },
       },
     };
 
@@ -250,11 +250,11 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
           name,
           namespace,
           labels,
-          annotations
+          annotations,
         },
         spec: {
           selector: {
-            deploymentconfig: name
+            deploymentconfig: name,
           },
           ports: _.map(ports, port => ({
             port: port.containerPort,
@@ -262,7 +262,7 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
             protocol: port.protocol,
             // Use the same naming convention as CLI new-app.
             name: `${port.containerPort}-${port.protocol}`.toLowerCase(),
-          }))
+          })),
         },
       };
 
@@ -275,22 +275,22 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
       metadata: {
         name,
         namespace,
-        labels
+        labels,
       },
       spec: {
         tags: [{
           name: isi.tag,
           annotations: {
             ...annotations,
-            'openshift.io/imported-from': isi.name
+            'openshift.io/imported-from': isi.name,
           },
           from: {
             kind: 'DockerImage',
-            name: isi.name
+            name: isi.name,
           },
-          importPolicy: {}
-        }]
-      }
+          importPolicy: {},
+        }],
+      },
     };
 
     createResource(ImageStreamModel, imageStream);

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -12,7 +12,7 @@ import {
   List,
   ListPage,
   WorkloadListHeader,
-  WorkloadListRow
+  WorkloadListRow,
 } from './factory';
 import {
   AsyncComponent,
@@ -23,7 +23,7 @@ import {
   navFactory,
   pluralize,
   ResourceSummary,
-  SectionHeading
+  SectionHeading,
 } from './utils';
 
 const DeploymentConfigsReference: K8sResourceKindReference = 'DeploymentConfig';
@@ -138,7 +138,7 @@ const pages = [
   navFactory.editYaml(),
   navFactory.pods(),
   navFactory.envEditor(environmentComponent),
-  navFactory.events(ResourceEventStream)
+  navFactory.events(ResourceEventStream),
 ];
 
 export const DeploymentConfigsDetailsPage: React.SFC<DeploymentConfigsDetailsPageProps> = props => {
@@ -162,7 +162,7 @@ export const DeploymentConfigsPage: React.SFC<DeploymentConfigsPageProps> = prop
     items: createItems,
     createLink: type => type === 'image'
       ? `/deploy-image${props.namespace ? `?preselected-ns=${props.namespace}` : ''}`
-      : `/k8s/ns/${props.namespace || 'default'}/deploymentconfigs/new`
+      : `/k8s/ns/${props.namespace || 'default'}/deploymentconfigs/new`,
   };
   return <ListPage {...props} title="Deployment Configs" kind={DeploymentConfigsReference} ListComponent={DeploymentConfigsList} canCreate={true} createButtonText="Create" createProps={createProps} filterLabel={props.filterLabel} />;
 };

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -11,7 +11,7 @@ import {
   List,
   ListPage,
   WorkloadListHeader,
-  WorkloadListRow
+  WorkloadListRow,
 } from './factory';
 import {
   AsyncComponent,
@@ -22,7 +22,7 @@ import {
   navFactory,
   pluralize,
   ResourceSummary,
-  SectionHeading
+  SectionHeading,
 } from './utils';
 
 const {ModifyCount, AddStorage, EditEnvironment, common} = Cog.factory;

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -274,7 +274,7 @@ export const EnvironmentPage = connect(stateToProps)(
             this.setState({errorMessage});
           }
           return {
-            configMaps: {}
+            configMaps: {},
           };
         }),
         k8sGet(SecretModel, null, envNamespace).catch((err) => {
@@ -283,9 +283,9 @@ export const EnvironmentPage = connect(stateToProps)(
             this.setState({errorMessage});
           }
           return {
-            secrets: {}
+            secrets: {},
           };
-        })
+        }),
       ])
         .then(_.spread((configMaps, secrets) => this.setState({configMaps, secrets})));
     }
@@ -349,7 +349,7 @@ export const EnvironmentPage = connect(stateToProps)(
         return null;
       }
       return readOnly ? {
-        currentEnvVars
+        currentEnvVars,
       } : {stale: true, success: null};
     }
 

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -456,7 +456,7 @@ class EventStream extends SafetyFirst {
     }
 
     const klass = classNames('co-sysevent-stream__timeline', {
-      'co-sysevent-stream__timeline--empty': !allCount || !count
+      'co-sysevent-stream__timeline--empty': !allCount || !count,
     });
     const messageCount = count < maxMessages ? `Showing ${pluralize(count, 'event')}` : `Showing ${count} of ${allCount}+ events`;
 

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -17,7 +17,7 @@ import {
   history,
   inject,
   kindObj,
-  PageHeading
+  PageHeading,
 } from '../utils';
 
 export const CompactExpandButtons = ({expand = false, onExpandChange = _.noop}) => <div className="btn-group btn-group-sm" data-toggle="buttons">

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -41,7 +41,7 @@ import {
   podPhaseFilterReducer,
   podReadiness,
   serviceCatalogStatus,
-  serviceClassDisplayName
+  serviceClassDisplayName,
 } from '../../module/k8s';
 
 const fuzzyCaseInsensitive = (a, b) => fuzzy(_.toLower(a), _.toLower(b));
@@ -243,7 +243,7 @@ export class ColHead extends React.Component<ColHeadProps> {
       currentSortFunc,
       currentSortOrder,
       sortField,
-      sortFunc
+      sortFunc,
     } = this.props;
     const className = classNames(this.props.className, 'text-nowrap');
     if (!sortField && !sortFunc) {
@@ -360,7 +360,7 @@ const stateToProps = ({UI}, {data = [], defaultSortField = 'metadata.name', defa
     currentSortFunc,
     currentSortOrder,
     data: newData,
-    listId
+    listId,
   };
 };
 

--- a/frontend/public/components/graphs/bar.jsx
+++ b/frontend/public/components/graphs/bar.jsx
@@ -60,7 +60,7 @@ export class Bar extends BaseGraph {
         align: 'left',
         font: {
           size: 12,
-          color: 'black'
+          color: 'black',
         },
       }, {
         x: 0,
@@ -73,7 +73,7 @@ export class Bar extends BaseGraph {
         align: 'right',
         font: {
           size: 12,
-          color: 'black'
+          color: 'black',
         },
       });
     });

--- a/frontend/public/components/graphs/donut.jsx
+++ b/frontend/public/components/graphs/donut.jsx
@@ -36,12 +36,12 @@ export class Donut extends SafetyFirst {
       annotations: [
         {
           font: {
-            size: 11
+            size: 11,
           },
           showarrow: false,
           text: '',
           x: 0.5,
-          y: 0.5
+          y: 0.5,
         },
       ],
     };

--- a/frontend/public/components/graphs/gauge.jsx
+++ b/frontend/public/components/graphs/gauge.jsx
@@ -56,7 +56,7 @@ class Gauge_ extends BaseGraph {
         align: 'center',
         font: {
           size: 20,
-          color: '#333'
+          color: '#333',
         },
       }],
     };
@@ -81,7 +81,7 @@ class Gauge_ extends BaseGraph {
           colors.clear,
           colors.ok,
           colors.gray,
-        ]
+        ],
       },
       textinfo: 'none',
       hole: .65,

--- a/frontend/public/components/graphs/line.jsx
+++ b/frontend/public/components/graphs/line.jsx
@@ -44,7 +44,7 @@ export class Line_ extends BaseGraph {
         x: 0, y: 1,
         bgcolor: 'rgba(255, 255, 255, 0.5)',
         size: '12px',
-        orientation: 'h'
+        orientation: 'h',
       },
       margin: {
         l: 30,

--- a/frontend/public/components/marketplace/kubernetes-marketplace.jsx
+++ b/frontend/public/components/marketplace/kubernetes-marketplace.jsx
@@ -61,7 +61,7 @@ class MarketplaceListPage extends React.Component {
   constructor() {
     super();
     this.state = {
-      selectedItem: null
+      selectedItem: null,
     };
   }
 
@@ -75,13 +75,13 @@ class MarketplaceListPage extends React.Component {
 
   openOverlay(item) {
     this.setState({
-      selectedItem : item
+      selectedItem : item,
     });
   }
 
   closeOverlay() {
     this.setState({
-      selectedItem : null
+      selectedItem : null,
     });
   }
 
@@ -106,7 +106,7 @@ export const Marketplace = () => {
     isList: true,
     kind: referenceForModel(PackageManifestModel),
     namespace: undefined, // shows operators from all-namespaces - when backend is hooked up we will use 'marketplace'
-    prop: 'packagemanifests'
+    prop: 'packagemanifests',
   });
   return <Firehose resources={resources}>
     <MarketplaceListPage />

--- a/frontend/public/components/marketplace/marketplace-item-modal.jsx
+++ b/frontend/public/components/marketplace/marketplace-item-modal.jsx
@@ -47,9 +47,9 @@ const MarketplaceItemModal = (props) => {
   );
 };
 MarketplaceItemModal.propTypes = {
-  size: PropTypes.string
+  size: PropTypes.string,
 };
 MarketplaceItemModal.defaultProps = {
-  size: 'default'
+  size: 'default',
 };
 export { MarketplaceItemModal };

--- a/frontend/public/components/masthead.tsx
+++ b/frontend/public/components/masthead.tsx
@@ -46,7 +46,7 @@ const UserMenuWrapper = connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.OPENSHIFT)((pro
     };
     actions.push({
       label: 'Logout',
-      callback: logout
+      callback: logout,
     });
   }
 
@@ -56,7 +56,7 @@ const UserMenuWrapper = connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.OPENSHIFT)((pro
 
   actions.unshift({
     label: 'My Account',
-    href: '/settings/profile'
+    href: '/settings/profile',
   });
 
   return authSvc.userID() ? <UserMenu actions={actions} username={authSvc.name()} /> : null;
@@ -66,7 +66,7 @@ export class OSUserMenu extends SafetyFirst<OSUserMenuProps, OSUserMenuState> {
   constructor(props) {
     super(props);
     this.state = {
-      username: undefined
+      username: undefined,
     };
   }
 
@@ -92,7 +92,7 @@ const ContextSwitcher = () => {
   const items = {
     [`${developerConsoleURL}catalog`]: 'Service Catalog',
     [`${developerConsoleURL}projects`]: 'Application Console',
-    [(window as any).SERVER_FLAGS.basePath]: 'Cluster Console'
+    [(window as any).SERVER_FLAGS.basePath]: 'Cluster Console',
   };
 
   return <div className="contextselector-pf">

--- a/frontend/public/components/modals/add-secret-to-workload.tsx
+++ b/frontend/public/components/modals/add-secret-to-workload.tsx
@@ -61,7 +61,7 @@ export class AddSecretToWorkloadModal extends React.Component<AddSecretToWorkloa
   handleChange: React.ReactEventHandler<HTMLInputElement> = event => {
     const { name, value } = event.currentTarget;
     this.setState({
-      [name]: value
+      [name]: value,
     } as any);
   }
 

--- a/frontend/public/components/modals/configure-count-modal.jsx
+++ b/frontend/public/components/modals/configure-count-modal.jsx
@@ -12,7 +12,7 @@ class ConfigureCountModal extends PromiseComponent {
 
     const getPath = this.props.path.substring(1).replace('/', '.');
     this.state = Object.assign(this.state, {
-      value: _.get(this.props.resource, getPath) || this.props.defaultValue
+      value: _.get(this.props.resource, getPath) || this.props.defaultValue,
     });
 
     this._change = this._change.bind(this);
@@ -28,7 +28,7 @@ class ConfigureCountModal extends PromiseComponent {
 
   _changeValueBy(operation) {
     this.setState({
-      value: _.toInteger(this.state.value) + operation
+      value: _.toInteger(this.state.value) + operation,
     });
   }
 
@@ -73,7 +73,7 @@ ConfigureCountModal.propTypes = {
   path: PropTypes.string.isRequired,
   resource: PropTypes.object.isRequired,
   resourceKind: PropTypes.object.isRequired,
-  title: PropTypes.node.isRequired
+  title: PropTypes.node.isRequired,
 };
 
 export const configureCountModal = createModalLauncher(ConfigureCountModal);
@@ -84,7 +84,7 @@ export const configureReplicaCountModal = (props) => {
     title: 'Edit Count',
     message: `${props.resourceKind.labelPlural} maintain the desired number of healthy pods.`,
     path: '/spec/replicas',
-    buttonText: 'Save'
+    buttonText: 'Save',
   }, props));
 };
 
@@ -94,7 +94,7 @@ export const configureJobParallelismModal = (props) => {
     title: 'Edit Parallelism',
     message: `${props.resourceKind.labelPlural} create one or more pods and ensure that a specified number of them successfully terminate. When the specified number of completions is successfully reached, the job is complete.`,
     path: '/spec/parallelism',
-    buttonText: 'Save'
+    buttonText: 'Save',
   }, props));
 };
 
@@ -104,6 +104,6 @@ export const configureClusterSizeModal = (props) => {
     title: 'Edit Cluster Size',
     message: `${props.resourceKind.labelPlural} maintain the desired number of healthy pods.`,
     path: '/spec/size',
-    buttonText: 'Save'
+    buttonText: 'Save',
   }, props));
 };

--- a/frontend/public/components/modals/configure-ns-pull-secret-modal.jsx
+++ b/frontend/public/components/modals/configure-ns-pull-secret-modal.jsx
@@ -57,7 +57,7 @@ const parseExisitingPullSecret = (pullSecret) => {
 
 const generateSecretData = (formData) => {
   const config = {
-    auths: {}
+    auths: {},
   };
 
   let authParts = [];
@@ -69,7 +69,7 @@ const generateSecretData = (formData) => {
 
   config.auths[formData.address] = {
     auth:  window.btoa(authParts.join(':')),
-    email: formData.email
+    email: formData.email,
   };
 
   return window.btoa(JSON.stringify(config));
@@ -88,7 +88,7 @@ class ConfigureNamespacePullSecret extends PromiseComponent {
     this.state = Object.assign(this.state, {
       method: 'form',
       fileData: null,
-      invalidJson: false
+      invalidJson: false,
     });
   }
 
@@ -143,7 +143,7 @@ class ConfigureNamespacePullSecret extends PromiseComponent {
       const patch = [{
         op: 'replace',
         path: `/data/${CONST.PULL_SECRET_DATA}`,
-        value: secretData
+        value: secretData,
       }];
       promise = k8sPatch(SecretModel, pullSecret, patch);
     } else {
@@ -153,10 +153,10 @@ class ConfigureNamespacePullSecret extends PromiseComponent {
       const secret = {
         metadata: {
           name: event.target.elements['namespace-pull-secret-name'].value,
-          namespace: namespace.metadata.name
+          namespace: namespace.metadata.name,
         },
         data: data,
-        type: CONST.PULL_SECRET_TYPE
+        type: CONST.PULL_SECRET_TYPE,
       };
       promise = k8sCreate(SecretModel, secret);
     }
@@ -293,7 +293,7 @@ class ConfigureNamespacePullSecret extends PromiseComponent {
 
 ConfigureNamespacePullSecret.propTypes = {
   namespace: PropTypes.object.isRequired,
-  pullSecret: PropTypes.object
+  pullSecret: PropTypes.object,
 };
 
 export const configureNamespacePullSecretModal = createModalLauncher(ConfigureNamespacePullSecret);

--- a/frontend/public/components/modals/configure-operator-channel-modal.jsx
+++ b/frontend/public/components/modals/configure-operator-channel-modal.jsx
@@ -12,7 +12,7 @@ class ConfigureOperatorChannel extends PromiseComponent {
     super(props);
 
     this.state = Object.assign(this.state, {
-      value: _.get(this.props.config, 'channel').toString()
+      value: _.get(this.props.config, 'channel').toString(),
     });
 
     this._change = this._change.bind(this);
@@ -66,7 +66,7 @@ ConfigureOperatorChannel.propTypes = {
   close: PropTypes.func.isRequired,
   config: PropTypes.object.isRequired,
   callbacks: PropTypes.object.isRequired,
-  valueType: PropTypes.string
+  valueType: PropTypes.string,
 };
 
 export const configureOperatorChannelModal = createModalLauncher(ConfigureOperatorChannel);

--- a/frontend/public/components/modals/configure-operator-modal.jsx
+++ b/frontend/public/components/modals/configure-operator-modal.jsx
@@ -14,7 +14,7 @@ class ConfigureOperatorModal extends PromiseComponent {
 
     const getPath = this.props.path.replace('/', '.').substr(1);
     this.state = Object.assign(this.state, {
-      value: _.get(this.props.config, getPath).toString()
+      value: _.get(this.props.config, getPath).toString(),
     });
 
     this._change = this._change.bind(this);
@@ -66,7 +66,7 @@ ConfigureOperatorModal.propTypes = {
   close: PropTypes.func.isRequired,
   config: PropTypes.object.isRequired,
   callbacks: PropTypes.object.isRequired,
-  valueType: PropTypes.string
+  valueType: PropTypes.string,
 };
 
 const configureOperatorModal = createModalLauncher(ConfigureOperatorModal);
@@ -80,15 +80,15 @@ export const configureOperatorStrategyModal = (props) => {
       {
         value: 'true',
         title: <span>Automatic <span className="co-no-bold">(recommended)</span></span>,
-        desc: 'Stay up to date with the latest version automatically.'
+        desc: 'Stay up to date with the latest version automatically.',
       },
       {
         value: 'false',
         title: 'Admin Approval',
-        desc: 'All updates must be approved by an admin. Important security patches may be missed.'
-      }
+        desc: 'All updates must be approved by an admin. Important security patches may be missed.',
+      },
     ],
     title: 'Update Strategy',
-    valueType: 'bool'
+    valueType: 'bool',
   }, props));
 };

--- a/frontend/public/components/modals/configure-update-strategy-modal.jsx
+++ b/frontend/public/components/modals/configure-update-strategy-modal.jsx
@@ -29,7 +29,7 @@ class ConfigureUpdateStrategyModal extends PromiseComponent {
     this._cancel = this.props.cancel.bind(this);
 
     this.state = Object.assign({
-      strategyType: _.get(this.deployment.spec, 'strategy.type')
+      strategyType: _.get(this.deployment.spec, 'strategy.type'),
     }, this.state);
   }
 
@@ -45,7 +45,7 @@ class ConfigureUpdateStrategyModal extends PromiseComponent {
     if (type === 'RollingUpdate') {
       patch.value = {
         maxUnavailable: getNumberOrPercent(event.target.elements['input-max-unavailable'].value || '25%'),
-        maxSurge: getNumberOrPercent(event.target.elements['input-max-surge'].value || '25%')
+        maxSurge: getNumberOrPercent(event.target.elements['input-max-surge'].value || '25%'),
       };
       patch.op = 'add';
     } else {
@@ -157,7 +157,7 @@ class ConfigureUpdateStrategyModal extends PromiseComponent {
 }
 
 ConfigureUpdateStrategyModal.propTypes = {
-  deployment: PropTypes.object
+  deployment: PropTypes.object,
 };
 
 export const configureUpdateStrategyModal = createModalLauncher(ConfigureUpdateStrategyModal);

--- a/frontend/public/components/modals/confirm-modal.jsx
+++ b/frontend/public/components/modals/confirm-modal.jsx
@@ -16,7 +16,7 @@ class ConfirmModal extends PromiseComponent {
 
     this.handlePromise(
       this.props.executeFn(null, {
-        supressNotifications: true
+        supressNotifications: true,
       })
     ).then(this.props.close);
   }
@@ -35,7 +35,7 @@ ConfirmModal.propTypes = {
   close: PropTypes.func.isRequired,
   executeFn: PropTypes.func.isRequired,
   message: PropTypes.node,
-  title: PropTypes.node.isRequired
+  title: PropTypes.node.isRequired,
 };
 
 export const confirmModal = createModalLauncher(ConfirmModal);

--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -14,12 +14,12 @@ const defaultDeny = {
   'apiVersion': 'networking.k8s.io/v1',
   'kind': 'NetworkPolicy',
   'spec': {
-    'podSelector': null
-  }
+    'podSelector': null,
+  },
 };
 
 const mapDispatchToProps = dispatch => ({
-  setProjectsAvailable: () => setFlag(dispatch, FLAGS.PROJECTS_AVAILABLE, true)
+  setProjectsAvailable: () => setFlag(dispatch, FLAGS.PROJECTS_AVAILABLE, true),
 });
 
 const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNamespaceModal extends PromiseComponent {
@@ -34,7 +34,7 @@ const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNames
     const name = e.target.name;
     const value = e.target.value;
     this.setState({
-      [name]: value
+      [name]: value,
     });
   }
 

--- a/frontend/public/components/modals/delete-modal.jsx
+++ b/frontend/public/components/modals/delete-modal.jsx
@@ -12,7 +12,7 @@ class DeleteModal extends PromiseComponent {
     this._submit = this._submit.bind(this);
     this._cancel = this.props.cancel.bind(this);
     this.state = Object.assign(this.state, {
-      isChecked: true
+      isChecked: true,
     });
   }
 

--- a/frontend/public/components/modals/kubectl-config.jsx
+++ b/frontend/public/components/modals/kubectl-config.jsx
@@ -16,7 +16,7 @@ const getConfiguration = code => {
     method: 'POST',
     body: `code=${encodeURIComponent(code)}`,
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/x-www-form-urlencoded',
     },
   }).then(res => res.text());
 };
@@ -29,7 +29,7 @@ const downloadConfiguration = config => {
 const steps = {
   GET_VERIFICATION_CODE: 1,
   VERIFY_CODE: 2,
-  DOWNLOAD_CONFIGURATION: 3
+  DOWNLOAD_CONFIGURATION: 3,
 };
 
 class KubectlConfigModal extends PromiseComponent {
@@ -42,7 +42,7 @@ class KubectlConfigModal extends PromiseComponent {
       verificationCode: null,
       kubectlLinuxUrl: null,
       kubectlMacUrl: null,
-      kubectlWinUrl: null
+      kubectlWinUrl: null,
     });
 
     this._updateCode = this._updateCode.bind(this);
@@ -62,7 +62,7 @@ class KubectlConfigModal extends PromiseComponent {
 
     getVerificationCode();
     this.setState({
-      step: steps.VERIFY_CODE
+      step: steps.VERIFY_CODE,
     });
   }
 
@@ -78,7 +78,7 @@ class KubectlConfigModal extends PromiseComponent {
     ).then((configuration) => {
       this.setState({
         step: steps.DOWNLOAD_CONFIGURATION,
-        configuration
+        configuration,
       });
       this.props.callback();
     });
@@ -86,7 +86,7 @@ class KubectlConfigModal extends PromiseComponent {
 
   _updateCode(event) {
     this.setState({
-      verificationCode: event.target.value
+      verificationCode: event.target.value,
     });
   }
 
@@ -103,7 +103,7 @@ class KubectlConfigModal extends PromiseComponent {
         this.setState({
           kubectlMacUrl: `${prefix}/bin/darwin${postfix}`,
           kubectlLinuxUrl: `${prefix}/bin/linux${postfix}`,
-          kubectlWinUrl: `${prefix}/bin/windows${postfix}.exe`
+          kubectlWinUrl: `${prefix}/bin/windows${postfix}.exe`,
         });
       });
   }

--- a/frontend/public/components/modals/tags.jsx
+++ b/frontend/public/components/modals/tags.jsx
@@ -28,7 +28,7 @@ class TagsModal extends PromiseComponent {
 
   _updateTags(tags) {
     this.setState({
-      tags: tags.nameValuePairs
+      tags: tags.nameValuePairs,
     });
   }
 

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -270,12 +270,12 @@ class NamespaceBarDropdowns_ extends React.Component {
       },
       {
         label: 'Deploy Image',
-        href: `/deploy-image?preselected-ns=${activeNamespace}`
+        href: `/deploy-image?preselected-ns=${activeNamespace}`,
       },
       {
         label: 'Import YAML',
         href: formatNamespacedRouteForResource('import', activeNamespace),
-      }
+      },
     ];
 
     return <div className="co-namespace-bar__dropdowns">
@@ -315,7 +315,7 @@ const NamespaceBar_ = ({useProjects}) => {
 const namespaceBarStateToProps = ({k8s}) => {
   const useProjects = k8s.hasIn(['RESOURCES', 'models', ProjectModel.kind]);
   return {
-    useProjects
+    useProjects,
   };
 };
 

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -52,12 +52,12 @@ class NavLink extends React.PureComponent {
 
 NavLink.defaultProps = {
   required: '',
-  disallowed: ''
+  disallowed: '',
 };
 
 NavLink.propTypes = {
   required: PropTypes.string,
-  disallowed: PropTypes.string
+  disallowed: PropTypes.string,
 };
 
 

--- a/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
@@ -51,7 +51,7 @@ export const CatalogSourceDetailsPage: React.SFC<CatalogSourceDetailsPageProps> 
     isList: true,
     namespace: props.match.params.ns,
     selector: {matchLabels: {catalog: props.match.params.name}},
-    prop: 'packageManifests'
+    prop: 'packageManifests',
   }, {
     kind: referenceForModel(SubscriptionModel),
     isList: true,

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -20,7 +20,7 @@ import {
   ClusterServiceVersionLogo,
   ClusterServiceVersionPhase,
   CRDDescription,
-  referenceForCRDDesc
+  referenceForCRDDesc,
 } from './index';
 import {
   Cog,
@@ -92,7 +92,7 @@ export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps
 };
 
 const stateToProps = ({k8s, FLAGS}, {match}) => ({
-  loading: FLAGS.get(featureFlags.OPENSHIFT) === undefined || !k8s.getIn([FLAGS.get(featureFlags.OPENSHIFT) ? 'projects' : 'namespaces', 'loaded'])
+  loading: FLAGS.get(featureFlags.OPENSHIFT) === undefined || !k8s.getIn([FLAGS.get(featureFlags.OPENSHIFT) ? 'projects' : 'namespaces', 'loaded']),
 });
 
 export const ClusterServiceVersionsPage = connect(stateToProps)((props: ClusterServiceVersionsPageProps) => {

--- a/frontend/public/components/operator-lifecycle-manager/create-crd-yaml.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/create-crd-yaml.tsx
@@ -35,7 +35,7 @@ export const CreateCRDYAML: React.SFC<CreateCRDYAMLProps> = (props) => {
     name: props.match.params.appName,
     namespace: props.match.params.ns,
     isList: false,
-    prop: 'ClusterServiceVersion'
+    prop: 'ClusterServiceVersion',
   }]}>
     <Create {...props as any} />
   </Firehose>;

--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -52,7 +52,7 @@ export const PackageManifestList: React.SFC<PackageManifestListProps> = (props) 
     displayName: status.catalogSourceDisplayName,
     name: status.catalogSource,
     publisher: status.catalogSourcePublisher,
-    namespace: status.catalogSourceNamespace
+    namespace: status.catalogSourceNamespace,
   }), new Map<string, CatalogSourceInfo>());
 
   return props.loaded

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -39,7 +39,7 @@ const menuActions = [
   (kind, obj) => ({
     label: `View ${ClusterServiceVersionModel.kind}...`,
     href: `/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${_.get(obj.status, 'installedCSV')}`,
-  })
+  }),
 ];
 
 export const SubscriptionRow: React.SFC<SubscriptionRowProps> = (props) => {

--- a/frontend/public/components/overview/build-configs-overview.tsx
+++ b/frontend/public/components/overview/build-configs-overview.tsx
@@ -11,7 +11,7 @@ import { startBuild, getBuildNumber } from '../../module/k8s/builds';
 import {
   ResourceLink,
   resourcePath,
-  SidebarSectionHeading
+  SidebarSectionHeading,
 } from '../utils';
 
 import { BuildConfigOverviewItem } from '.';

--- a/frontend/public/components/overview/daemon-set-overview.tsx
+++ b/frontend/public/components/overview/daemon-set-overview.tsx
@@ -4,7 +4,7 @@ import { DaemonSetModel } from '../../models';
 import { ResourceSummary } from '../utils';
 import {
   menuActions,
-  DaemonSetDetailsList
+  DaemonSetDetailsList,
 } from '../daemon-set';
 
 
@@ -25,12 +25,12 @@ const DaemonSetOverviewDetails: React.SFC<DaemonSetOverviewDetailsProps> = ({ite
 const tabs = [
   {
     name: 'Overview',
-    component: DaemonSetOverviewDetails
+    component: DaemonSetOverviewDetails,
   },
   {
     name: 'Resources',
-    component: OverviewDetailsResourcesTab
-  }
+    component: OverviewDetailsResourcesTab,
+  },
 ];
 
 export const DaemonSetOverview: React.SFC<DaemonSetOverviewProps> = ({item}) =>

--- a/frontend/public/components/overview/deployment-config-overview.tsx
+++ b/frontend/public/components/overview/deployment-config-overview.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { DeploymentConfigModel } from '../../models';
 import {
   DeploymentConfigDetailsList,
-  menuActions
+  menuActions,
 } from '../deployment-config';
 import {
   DeploymentPodCounts,
@@ -43,12 +43,12 @@ const DeploymentConfigOverviewDetails: React.SFC<DeploymentConfigOverviewDetails
 const tabs = [
   {
     name: 'Overview',
-    component: DeploymentConfigOverviewDetails
+    component: DeploymentConfigOverviewDetails,
   },
   {
     name: 'Resources',
-    component: OverviewDetailsResourcesTab
-  }
+    component: OverviewDetailsResourcesTab,
+  },
 ];
 
 export const DeploymentConfigOverviewPage: React.SFC<DeploymentConfigOverviewProps> = ({item}) =>

--- a/frontend/public/components/overview/deployment-overview.tsx
+++ b/frontend/public/components/overview/deployment-overview.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { DeploymentModel } from '../../models';
 import {
   DeploymentDetailsList,
-  menuActions
+  menuActions,
 } from '../deployment';
 import {
   DeploymentPodCounts,
@@ -43,12 +43,12 @@ const DeploymentOverviewDetails: React.SFC<DeploymentOverviewDetailsProps> = ({i
 const tabs = [
   {
     name: 'Overview',
-    component: DeploymentOverviewDetails
+    component: DeploymentOverviewDetails,
   },
   {
     name: 'Resources',
-    component: OverviewDetailsResourcesTab
-  }
+    component: OverviewDetailsResourcesTab,
+  },
 ];
 
 export const DeploymentOverviewPage: React.SFC<DeploymentOverviewProps> = ({item}) =>

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -24,7 +24,7 @@ import {
 import {
   withStartGuide,
   /* eslint-disable-next-line no-unused-vars */
-  WithStartGuideProps
+  WithStartGuideProps,
 } from '../start-guide';
 import {
   DaemonSetModel,
@@ -32,7 +32,7 @@ import {
   DeploymentConfigModel,
   ReplicationControllerModel,
   ReplicaSetModel,
-  StatefulSetModel
+  StatefulSetModel,
 } from '../../models';
 import {
   CloseButton,
@@ -155,7 +155,7 @@ const getOwnedResources = ({metadata:{uid}}: K8sResourceKind, resources: K8sReso
   return _.filter(resources, ({metadata:{ownerReferences}}) => {
     return _.some(ownerReferences, {
       uid,
-      controller: true
+      controller: true,
     });
   });
 };
@@ -304,7 +304,7 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
       replicationControllers,
       routes,
       services,
-      statefulSets
+      statefulSets,
     } = this.props;
     const {filterValue, selectedGroupLabel} = this.state;
 
@@ -326,11 +326,11 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
       const filteredItems = this.filterItems(this.state.items);
       this.setState({
         filteredItems,
-        groupedItems: this.groupItems(filteredItems, selectedGroupLabel)
+        groupedItems: this.groupItems(filteredItems, selectedGroupLabel),
       });
     } else if (selectedGroupLabel !== prevState.selectedGroupLabel) {
       this.setState({
-        groupedItems: this.groupItems(this.state.filteredItems, selectedGroupLabel)
+        groupedItems: this.groupItems(this.state.filteredItems, selectedGroupLabel),
       });
     }
   }
@@ -409,7 +409,7 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
     return _.map(groups, (group: OverviewItem[], name: string) => {
       return {
         name,
-        items: group
+        items: group,
       };
     }).sort(compareGroups);
   }
@@ -423,7 +423,7 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
       }
       return {
         ...accumulator,
-        [key]: key
+        [key]: key,
       };
     }, groupOptions);
   }
@@ -454,13 +454,13 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
     const pods = this.getPodsForResource(rc);
     const alerts = {
       ...combinePodAlerts(pods),
-      ...getReplicationControllerAlerts(rc)
+      ...getReplicationControllerAlerts(rc),
     };
     const phase = getDeploymentPhase(rc);
     const revision = getDeploymentConfigVersion(rc);
     const obj = {
       ...rc,
-      kind: ReplicationControllerModel.kind
+      kind: ReplicationControllerModel.kind,
     };
     return {
       alerts,
@@ -537,8 +537,8 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
             ...acc,
             {
               ...buildConfig,
-              builds: sortBuilds(builds)
-            }
+              builds: sortBuilds(builds),
+            },
           ];
         }
         return acc;
@@ -556,11 +556,11 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
       const alerts = combinePodAlerts(pods);
       const obj = {
         ...ds,
-        kind: DaemonSetModel.kind
+        kind: DaemonSetModel.kind,
       };
       const readiness = {
         desired: ds.status.desiredNumberScheduled || 0,
-        ready: ds.status.currentNumberScheduled || 0
+        ready: ds.status.currentNumberScheduled || 0,
       };
 
       return {
@@ -570,7 +570,7 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
         pods,
         readiness,
         routes,
-        services
+        services,
       };
     });
   }
@@ -587,11 +587,11 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
       const routes = this.getRoutesForServices(services);
       const obj = {
         ...d,
-        kind: DeploymentModel.kind
+        kind: DeploymentModel.kind,
       };
       const readiness = {
         desired: d.spec.replicas || 0,
-        ready: d.status.replicas || 0
+        ready: d.status.replicas || 0,
       };
 
       return {
@@ -619,11 +619,11 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
       const routes = this.getRoutesForServices(services);
       const obj = {
         ...dc,
-        kind: DeploymentConfigModel.kind
+        kind: DeploymentConfigModel.kind,
       };
       const readiness = {
         desired: dc.spec.replicas || 0,
-        ready: dc.status.replicas || 0
+        ready: dc.status.replicas || 0,
       };
 
       return {
@@ -645,11 +645,11 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
       const buildConfigs = this.getBuildConfigsForResource(ss);
       const obj = {
         ...ss,
-        kind: StatefulSetModel.kind
+        kind: StatefulSetModel.kind,
       };
       const readiness = {
         desired: ss.spec.replicas || 0,
-        ready: ss.status.replicas || 0
+        ready: ss.status.replicas || 0,
       };
       const pods = this.getPodsForResource(ss);
       const alerts = combinePodAlerts(pods);
@@ -678,7 +678,7 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
       ...this.createDaemonSetItems(),
       ...this.createDeploymentItems(),
       ...this.createDeploymentConfigItems(),
-      ...this.createStatefulSetItems()
+      ...this.createStatefulSetItems(),
     ];
 
     store.dispatch(UIActions.updateOverviewResources(items));
@@ -692,7 +692,7 @@ class OverviewDetails extends SafetyFirst<OverviewDetailsProps, OverviewDetailsS
       groupedItems,
       groupOptions,
       items,
-      selectedGroupLabel
+      selectedGroupLabel,
     });
   }
 
@@ -738,7 +738,7 @@ const overviewStateToProps = ({UI}): OverviewPropsFromState => {
   const selectedUID = UI.getIn(['overview', 'selectedUID'], '');
   const resources = UI.getIn(['overview', 'resources']);
   return {
-    selectedItem: !!resources && resources.get(selectedUID)
+    selectedItem: !!resources && resources.get(selectedUID),
   };
 };
 
@@ -756,68 +756,68 @@ export const Overview = connect<OverviewPropsFromState, OverviewPropsFromDispatc
         isList: true,
         kind: 'Build',
         namespace,
-        prop: 'builds'
+        prop: 'builds',
       },
       {
         isList: true,
         kind: 'BuildConfig',
         namespace,
-        prop: 'buildConfigs'
+        prop: 'buildConfigs',
       },
       {
         isList: true,
         kind: 'DaemonSet',
         namespace,
-        prop: 'daemonSets'
+        prop: 'daemonSets',
       },
       {
         isList: true,
         kind: 'Deployment',
         namespace,
-        prop: 'deployments'
+        prop: 'deployments',
       },
       {
         isList: true,
         kind: 'DeploymentConfig',
         namespace,
-        prop: 'deploymentConfigs'
+        prop: 'deploymentConfigs',
       },
       {
         isList: true,
         kind: 'Pod',
         namespace,
-        prop: 'pods'
+        prop: 'pods',
       },
       {
         isList: true,
         kind: 'ReplicaSet',
         namespace,
-        prop: 'replicaSets'
+        prop: 'replicaSets',
       },
       {
         isList: true,
         kind: 'ReplicationController',
         namespace,
-        prop: 'replicationControllers'
+        prop: 'replicationControllers',
       },
       {
         isList: true,
         kind: 'Route',
         namespace,
-        prop: 'routes'
+        prop: 'routes',
       },
       {
         isList: true,
         kind: 'StatefulSet',
         namespace,
-        prop: 'statefulSets'
+        prop: 'statefulSets',
       },
       {
         isList: true,
         kind: 'Service',
         namespace,
-        prop: 'services'
-      }
+        prop: 'services',
+      },
     ];
 
     if (_.isEmpty(namespace) || namespace === ALL_NAMESPACES_KEY) {

--- a/frontend/public/components/overview/project-overview.tsx
+++ b/frontend/public/components/overview/project-overview.tsx
@@ -13,13 +13,13 @@ import {
   pluralize,
   ResourceIcon,
   resourceObjPath,
-  resourcePath
+  resourcePath,
 } from '../utils';
 
 import {
   OverviewGroup,
   OverviewItem,
-  PodControllerOverviewItem
+  PodControllerOverviewItem,
 } from '.';
 
 const formatToFractionalDigits = (value: number, digits: number): string => Intl.NumberFormat(undefined, { minimumFractionDigits: digits, maximumFractionDigits: digits }).format(value);
@@ -204,7 +204,7 @@ const Alerts: React.SFC<AlertsProps> = ({item}) => {
 };
 
 const projectOverviewListItemStateToProps = ({UI}): ProjectOverviewListItemPropsFromState => ({
-  selectedUID: UI.getIn(['overview', 'selectedUID'])
+  selectedUID: UI.getIn(['overview', 'selectedUID']),
 });
 
 const projectOverviewListItemDispatchToProps = (dispatch): ProjectOverviewListItemPropsFromDispatch => ({

--- a/frontend/public/components/overview/resource-overview-details.tsx
+++ b/frontend/public/components/overview/resource-overview-details.tsx
@@ -12,11 +12,11 @@ import {
 import { OverviewItem } from '.';
 
 const stateToProps = ({UI}): PropsFromState => ({
-  selectedDetailsTab: UI.getIn(['overview', 'selectedDetailsTab'])
+  selectedDetailsTab: UI.getIn(['overview', 'selectedDetailsTab']),
 });
 
 const dispatchToProps = (dispatch): PropsFromDispatch => ({
-  onClickTab: (name) => dispatch(UIActions.selectOverviewDetailsTab(name))
+  onClickTab: (name) => dispatch(UIActions.selectOverviewDetailsTab(name)),
 });
 
 export const ResourceOverviewDetails = connect<PropsFromState, PropsFromDispatch, OwnProps>(stateToProps, dispatchToProps)(

--- a/frontend/public/components/overview/resource-overview-pages.tsx
+++ b/frontend/public/components/overview/resource-overview-pages.tsx
@@ -9,7 +9,7 @@ import {
   DaemonSetModel,
   DeploymentModel,
   DeploymentConfigModel,
-  StatefulSetModel
+  StatefulSetModel,
 } from '../../models';
 
 export const resourceOverviewPages = ImmutableMap<GroupVersionKind | string, () => Promise<React.ComponentType<any>>>()

--- a/frontend/public/components/overview/stateful-set-overview.tsx
+++ b/frontend/public/components/overview/stateful-set-overview.tsx
@@ -16,12 +16,12 @@ const StatefulSetOverviewDetails: React.SFC<StatefulSetOverviewDetailsProps> = (
 const tabs = [
   {
     name: 'Overview',
-    component: StatefulSetOverviewDetails
+    component: StatefulSetOverviewDetails,
   },
   {
     name: 'Resources',
-    component: OverviewDetailsResourcesTab
-  }
+    component: OverviewDetailsResourcesTab,
+  },
 ];
 
 export const StatefulSetOverview: React.SFC<StatefulSetOverviewProps> = ({item}) =>

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -100,7 +100,7 @@ const filters = [{
   items: _.map(allPhases, phase => ({
     id: phase,
     title: phase,
-  }))
+  })),
 }];
 
 

--- a/frontend/public/components/pod-logs.jsx
+++ b/frontend/public/components/pod-logs.jsx
@@ -9,7 +9,7 @@ const containersToStatuses = ({ status }, containers) => {
     if (containerStatus) {
       return {
         ...accumulator,
-        [name]: { ...containerStatus, order }
+        [name]: { ...containerStatus, order },
       };
     }
     return accumulator;

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -155,7 +155,7 @@ const PodGraphs = requirePrometheus(({pod}) => <React.Fragment>
 const Details = ({obj: pod}) => {
   const limits = {
     cpu: null,
-    memory: null
+    memory: null,
   };
   limits.cpu = _.reduce(pod.spec.containers, (sum, container) => {
     const value = units.dehumanize(_.get(container, 'resources.limits.cpu', 0), 'numeric').value;
@@ -286,8 +286,8 @@ const filters = [{
     // The pod phase is "Succeeded," but the container state is "Completed."
     { id: 'Succeeded', title: 'Completed' },
     { id: 'Failed', title: 'Failed' },
-    { id: 'Unknown', title: 'Unknown '}
-  ]
+    { id: 'Unknown', title: 'Unknown '},
+  ],
 }];
 
 export class PodsPage extends React.Component {

--- a/frontend/public/components/profile.jsx
+++ b/frontend/public/components/profile.jsx
@@ -11,7 +11,7 @@ export class ProfilePage extends SafetyFirst {
   constructor(props) {
     super(props);
     this.state = {
-      isKubeCtlDownloaded: false
+      isKubeCtlDownloaded: false,
     };
     this._onKubeCtlDownloaded = this._onKubeCtlDownloaded.bind(this);
   }

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -66,7 +66,7 @@ export const ResourceQuotasPage = connectToFlags(FLAGS.OPENSHIFT)(({namespace, f
       items: [
         {id: 'cluster', title: 'Cluster-wide Resource Quotas'},
         {id: 'namespace', title: 'Namespace Resource Quotas'},
-      ]
+      ],
     }];
   }
   return <MultiListPage

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -305,7 +305,7 @@ const filters = [{
   items: [
     {id: 'Accepted', title: 'Accepted'},
     {id: 'Rejected', title: 'Rejected'},
-    {id: 'Pending', title: 'Pending'}
+    {id: 'Pending', title: 'Pending'},
   ],
 }];
 
@@ -317,7 +317,7 @@ export const RoutesPage: React.SFC<RoutesPageProps> = props => {
 
   const createProps = {
     items: createItems,
-    createLink: (type) => `/k8s/ns/${props.namespace || 'default'}/routes/new/${type !== 'yaml' ? type : ''}`
+    createLink: (type) => `/k8s/ns/${props.namespace || 'default'}/routes/new/${type !== 'yaml' ? type : ''}`,
   };
 
   return <ListPage

--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -58,14 +58,14 @@ export class CreateRoute extends React.Component<null, CreateRouteState> {
         loaded: true,
       }))
       .catch(err => this.setState({
-        error: err.message
+        error: err.message,
       }));
   }
 
   handleChange: React.ReactEventHandler<HTMLInputElement> = event => {
     const { name, value } = event.currentTarget;
     this.setState({
-      [name]: value
+      [name]: value,
     } as any);
   }
 
@@ -87,7 +87,7 @@ export class CreateRoute extends React.Component<null, CreateRouteState> {
   toggleSection: React.ReactEventHandler<HTMLInputElement> = event => {
     const { name, checked } = event.currentTarget;
     this.setState({
-      [name]: checked
+      [name]: checked,
     } as any);
   }
 
@@ -182,8 +182,8 @@ export class CreateRoute extends React.Component<null, CreateRouteState> {
         path,
         port: {
           targetPort,
-        }
-      }
+        },
+      },
     };
 
     this.setState({ inProgress: true });
@@ -193,7 +193,7 @@ export class CreateRoute extends React.Component<null, CreateRouteState> {
         history.push(resourcePathFromModel(RouteModel, name, namespace));
       }, err => this.setState({
         error: err.message,
-        inProgress: false
+        inProgress: false,
       }));
   }
 

--- a/frontend/public/components/search.jsx
+++ b/frontend/public/components/search.jsx
@@ -94,5 +94,5 @@ export const SearchPage = withStartGuide(SearchPage_);
 SearchPage.propTypes = {
   location: PropTypes.object.isRequired,
   namespace: namespaceProptype,
-  noProjectsAvailable: PropTypes.bool
+  noProjectsAvailable: PropTypes.bool,
 };

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -88,7 +88,7 @@ const secretTypeFilterValues = [
   SOURCE_FILTER_VALUE,
   TLS_FILTER_VALUE,
   SA_TOKEN_FILTER_VALUE,
-  OPAQUE_FILTER_VALUE
+  OPAQUE_FILTER_VALUE,
 ];
 
 export const secretTypeFilterReducer = secret => {
@@ -132,7 +132,7 @@ const SecretsPage = props => {
 
   const createProps = {
     items: createItems,
-    createLink: (type) => `/k8s/ns/${props.namespace || 'default'}/secrets/new/${type !== 'yaml' ? type : ''}`
+    createLink: (type) => `/k8s/ns/${props.namespace || 'default'}/secrets/new/${type !== 'yaml' ? type : ''}`,
   };
 
   return <ListPage ListComponent={SecretsList} canCreate={true} rowFilters={filters} createButtonText="Create" createProps={createProps} {...props} />;

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -127,7 +127,7 @@ const withSecretForm = (SubForm) => class SecretFormComponent extends React.Comp
   onError (err) {
     this.setState({
       error: err,
-      inProgress: false
+      inProgress: false,
     });
   }
   onNameChanged (event) {
@@ -242,7 +242,7 @@ class ImageSecretForm extends React.Component<ImageSecretFormProps, ImageSecretF
   onDataChanged (secretData) {
     const dataKey = secretData[AUTHS_KEY] ? '.dockerconfigjson' : '.dockercfg';
     this.setState({
-      stringData: {[dataKey]: secretData}
+      stringData: {[dataKey]: secretData},
     }, () => this.props.onChange({
       stringData: _.mapValues(this.state.stringData, JSON.stringify),
       type: getImageSecretType(dataKey),
@@ -259,7 +259,7 @@ class ImageSecretForm extends React.Component<ImageSecretFormProps, ImageSecretF
   render () {
     const authTypes = {
       'credentials': 'Image Registry Credentials',
-      'config-file': 'Upload Configuration File'
+      'config-file': 'Upload Configuration File',
     };
     const data = _.get(this.state.stringData, this.state.dataKey);
     return <React.Fragment>
@@ -315,10 +315,10 @@ class ConfigEntryForm extends React.Component<ConfigEntryFormProps, ConfigEntryF
   changeData(event) {
     const { name, value } = event.target;
     this.setState({
-      [name]: value
+      [name]: value,
     } as ConfigEntryFormState, () => {
       this.setState({
-        auth: this.updateAuth(name)
+        auth: this.updateAuth(name),
       } as ConfigEntryFormState, () => this.props.onChange(this.state, this.props.id));
     });
   }
@@ -464,14 +464,14 @@ class CreateConfigSubform extends React.Component<CreateConfigSubformProps, Crea
     const updatedSecretEntriesArray = [...this.state.secretEntriesArray];
     updatedSecretEntriesArray.splice(entryID, 1);
     this.setState({
-      secretEntriesArray: updatedSecretEntriesArray
+      secretEntriesArray: updatedSecretEntriesArray,
     }, () => {
       this.propagateEntryChange(this.state.secretEntriesArray);
     });
   }
   addEntry(){
     this.setState({
-      secretEntriesArray: _.concat(this.state.secretEntriesArray, this.newImageSecretEntry())
+      secretEntriesArray: _.concat(this.state.secretEntriesArray, this.newImageSecretEntry()),
     }, () => {
       this.propagateEntryChange(this.state.secretEntriesArray);
     });
@@ -542,19 +542,19 @@ class WebHookSecretForm extends React.Component<WebHookSecretFormProps, WebHookS
   constructor(props) {
     super(props);
     this.state = {
-      stringData: {WebHookSecretKey: this.props.stringData.WebHookSecretKey || ''}
+      stringData: {WebHookSecretKey: this.props.stringData.WebHookSecretKey || ''},
     };
     this.changeWebHookSecretkey = this.changeWebHookSecretkey.bind(this);
     this.generateWebHookSecret = this.generateWebHookSecret.bind(this);
   }
   changeWebHookSecretkey(event) {
     this.setState({
-      stringData: { WebHookSecretKey: event.target.value }
+      stringData: { WebHookSecretKey: event.target.value },
     }, () => this.props.onChange(this.state));
   }
   generateWebHookSecret() {
     this.setState({
-      stringData: { WebHookSecretKey: generateSecret() }
+      stringData: { WebHookSecretKey: generateSecret() },
     }, () => this.props.onChange(this.state));
   }
   render () {
@@ -632,7 +632,7 @@ export class BasicAuthSubform extends React.Component<BasicAuthSubformProps, Bas
   }
   changeData(event) {
     this.setState({
-      [event.target.name]: event.target.value
+      [event.target.name]: event.target.value,
     } as BasicAuthSubformState, () => this.props.onChange(this.state));
   }
   render() {
@@ -681,12 +681,12 @@ class SSHAuthSubform extends React.Component<SSHAuthSubformProps, SSHAuthSubform
   }
   changeData(event) {
     this.setState({
-      'ssh-privatekey': event.target.value
+      'ssh-privatekey': event.target.value,
     }, () => this.props.onChange(this.state));
   }
   onFileChange(fileData) {
     this.setState({
-      'ssh-privatekey': fileData
+      'ssh-privatekey': fileData,
     }, () => this.props.onChange(this.state));
   }
   render() {
@@ -778,7 +778,7 @@ class GenericSecretForm extends React.Component<GenericSecretFormProps, GenericS
     const updatedSecretEntriesArray = [...this.state.secretEntriesArray];
     updatedSecretEntriesArray.splice(entryID, 1);
     this.setState({
-      secretEntriesArray: updatedSecretEntriesArray
+      secretEntriesArray: updatedSecretEntriesArray,
     }, () => this.props.onChange({
       stringData: this.genericSecretArrayToObject(this.state.secretEntriesArray),
       type: SecretType.opaque,
@@ -786,7 +786,7 @@ class GenericSecretForm extends React.Component<GenericSecretFormProps, GenericS
   }
   addEntry(){
     this.setState({
-      secretEntriesArray: _.concat(this.state.secretEntriesArray, this.newGenericSecretEntry())
+      secretEntriesArray: _.concat(this.state.secretEntriesArray, this.newGenericSecretEntry()),
     }, () => this.props.onChange({
       stringData: this.genericSecretArrayToObject(this.state.secretEntriesArray),
       type: SecretType.opaque,

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -35,7 +35,7 @@ const KubeConfigify = (kind, sa) => ({
           cluster: {
             'certificate-authority-data': cert,
             server,
-          }
+          },
         }],
         contexts: [{
           name,
@@ -43,14 +43,14 @@ const KubeConfigify = (kind, sa) => ({
             cluster: clusterName,
             namespace,
             user: name,
-          }
+          },
         }],
         'users': [{
           name,
           user: {
             token: token,
-          }
-        }]
+          },
+        }],
       };
       const dump = safeDump(config);
       const blob = new Blob([dump], { type: 'text/yaml;charset=utf-8' });

--- a/frontend/public/components/service-catalog/create-binding.tsx
+++ b/frontend/public/components/service-catalog/create-binding.tsx
@@ -16,13 +16,13 @@ import {
   getBindingCreateSchema,
   getBindingParametersForm,
   getUISchema,
-  ServiceCatalogParametersForm
+  ServiceCatalogParametersForm,
 } from './schema-form';
 import {
   Firehose,
   history,
   PageHeading,
-  resourcePathFromModel
+  resourcePathFromModel,
 } from '../utils';
 
 const PARAMETERS_SECRET_KEY = 'parameters';
@@ -126,7 +126,7 @@ class CreateBindingForm extends React.Component<CreateBindingProps, CreateBindin
         obj={obj}
         breadcrumbsFor={() => [
           {name: serviceInstance.metadata.name, path: resourcePathFromModel(ServiceInstanceModel, serviceInstance.metadata.name, serviceInstance.metadata.namespace)},
-          {name: `${title}`, path: `${match.url}`}
+          {name: `${title}`, path: `${match.url}`},
         ]}
       />
       <div className="co-m-pane__body">

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -12,20 +12,20 @@ import { ClusterServiceClassInfo } from '../cluster-service-class-info';
 import { ButtonBar } from '../utils/button-bar';
 import {
   k8sCreate,
-  K8sResourceKind
+  K8sResourceKind,
 } from '../../module/k8s';
 import {
   createParametersSecret,
   getInstanceCreateParametersForm,
   getInstanceCreateSchema,
   getUISchema,
-  ServiceCatalogParametersForm
+  ServiceCatalogParametersForm,
 } from './schema-form';
 import {
   Firehose,
   history,
   PageHeading,
-  resourcePathFromModel
+  resourcePathFromModel,
 } from '../utils';
 
 const PARAMETERS_SECRET_KEY = 'parameters';
@@ -101,7 +101,7 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
         clusterServiceClassExternalName: _.get(this.props.obj, 'data.spec.externalName'),
         clusterServicePlanExternalName: this.state.plan,
         parametersFrom,
-      }
+      },
     };
 
     return k8sCreate(ServiceInstanceModel, serviceInstance);

--- a/frontend/public/components/service-catalog/schema-form.tsx
+++ b/frontend/public/components/service-catalog/schema-form.tsx
@@ -81,7 +81,7 @@ export const createParametersSecret = (secretName: string, key: string, paramete
         name: owner.metadata.name,
         uid: owner.metadata.uid,
         controller: false,
-        blockOwnerDeletion: false
+        blockOwnerDeletion: false,
       }],
     },
     stringData: {

--- a/frontend/public/components/service-catalog/shema-form.tsx
+++ b/frontend/public/components/service-catalog/shema-form.tsx
@@ -23,7 +23,7 @@ export const createParametersSecret = (secretName: string, key: string, paramete
         name: owner.metadata.name,
         uid: owner.metadata.uid,
         controller: false,
-        blockOwnerDeletion: false
+        blockOwnerDeletion: false,
       }],
     },
     stringData: {

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -143,7 +143,7 @@ const pages = [
   navFactory.details(ServiceInstanceDetails),
   navFactory.editYaml(),
   navFactory.events(ResourceEventStream),
-  navFactory.serviceBindings(ServiceBindingsDetails)
+  navFactory.serviceBindings(ServiceBindingsDetails),
 ];
 
 export const ServiceInstanceDetailsPage: React.SFC<ServiceInstanceDetailsPageProps> = props =>
@@ -203,7 +203,7 @@ const filters = [{
   items: [
     {id: 'Ready', title: 'Ready'},
     {id: 'Not Ready', title: 'Not Ready'},
-    {id: 'Failed', title: 'Failed'}
+    {id: 'Failed', title: 'Failed'},
   ],
 }];
 

--- a/frontend/public/components/sidebars/build-config-sidebar.jsx
+++ b/frontend/public/components/sidebars/build-config-sidebar.jsx
@@ -23,7 +23,7 @@ const samples = [
     details: 'The Pipeline build strategy allows developers to define a Jenkins pipeline for execution by the Jenkins pipeline plugin. The build can be started, monitored, and managed in the same way as any other build type.',
     templateName: 'pipeline-build',
     kind: referenceForModel(BuildConfigModel),
-  }
+  },
 ];
 
 export const BuildConfigSidebar = ({loadSampleYaml, downloadSampleYaml}) => {

--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -6,7 +6,7 @@ export class ResourceSidebarWrapper extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      showSidebar: true
+      showSidebar: true,
     };
   }
 

--- a/frontend/public/components/software-details.jsx
+++ b/frontend/public/components/software-details.jsx
@@ -15,7 +15,7 @@ const StatusIconRow = ({state, text}) => {
     warning: 'fa-warning',
     critical: 'fa-warning',
     unknown: 'fa-question-circle',
-    'access-denied': 'fa-ban'
+    'access-denied': 'fa-ban',
   };
   return <div className={classNames('co-m-status', [`co-m-status--${state}`])}>
     <i className={classNames('co-m-status__icon', 'fa', iconClasses[state])}></i>

--- a/frontend/public/components/start-guide.tsx
+++ b/frontend/public/components/start-guide.tsx
@@ -28,7 +28,7 @@ export class StartGuide extends SafetyFirst<StartGuideProps, StartGuideState> {
       // ignored
     }
     this.state = {
-      visible
+      visible,
     };
   }
 

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -6,7 +6,7 @@ import {
   List,
   ListPage,
   WorkloadListHeader,
-  WorkloadListRow
+  WorkloadListRow,
 } from './factory';
 import {
   AsyncComponent,
@@ -14,7 +14,7 @@ import {
   ContainerTable,
   ResourceSummary,
   SectionHeading,
-  navFactory
+  navFactory,
 } from './utils';
 
 const { EditEnvironment, common } = Cog.factory;
@@ -52,7 +52,7 @@ const pages = [
   navFactory.editYaml(),
   navFactory.pods(),
   navFactory.envEditor(environmentComponent),
-  navFactory.events(ResourceEventStream)
+  navFactory.events(ResourceEventStream),
 ];
 
 export const StatefulSetsDetailsPage = props => <DetailsPage

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -18,13 +18,13 @@ const defaultState = {
     description: '',
     type: null,
     parameters: {},
-    reclaim: null
+    reclaim: null,
   },
   customParams: [['', '']],
   validationSuccessful: false,
   loading: false,
   error: null,
-  fieldErrors: {parameters: {}}
+  fieldErrors: {parameters: {}},
 };
 
 /*eslint-disable no-undef*/
@@ -49,7 +49,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
         type: {
           name: 'Type',
           values: {io1: 'io1', gp2: 'gp2', sc1: 'sc1', st1: 'st1'},
-          hintText: 'Select AWS Type'
+          hintText: 'Select AWS Type',
         },
         iopsPerGB: {
           name: 'IOPS Per GiB',
@@ -60,23 +60,23 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
             }
             return null;
           },
-          visible: (params) => _.get(params, 'type.value') === 'io1'
+          visible: (params) => _.get(params, 'type.value') === 'io1',
         },
         fsType: {
           name: 'Filesystem Type',
-          hintText: 'Filesystem to Be Laid Out'
+          hintText: 'Filesystem to Be Laid Out',
         },
         encrypted: {
           name: 'Encrypted',
           type: 'checkbox',
-          format: (value) => value.toString()
+          format: (value) => value.toString(),
         },
         kmsKeyId: {
           name: 'KMS Key ID',
           hintText: 'The full Amazon Resource Name of the key to use when encrypting the volume',
-          visible: (params) => _.get(params, 'encrypted.value', false)
-        }
-      }
+          visible: (params) => _.get(params, 'encrypted.value', false),
+        },
+      },
     },
     'gce-pd': {
       title: 'GCE PD',
@@ -86,7 +86,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
         type: {
           name: 'Type',
           values: {'pd-standard': 'pd-standard', 'pd-ssd': 'pd-ssd'},
-          hintText: 'Select GCE type'
+          hintText: 'Select GCE type',
         },
         zone: {
           name: 'Zone',
@@ -95,7 +95,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
               return 'Zone and zones parameters must not be used at the same time';
             }
             return null;
-          }
+          },
         },
         zones: {
           name: 'Zones',
@@ -104,7 +104,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
               return 'Zone and zones parameters must not be used at the same time';
             }
             return null;
-          }
+          },
         },
         'replication-type': {
           name: 'Replication Type',
@@ -115,9 +115,9 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
               return 'Zone cannot be specified when Replication Type regional-pd is chosen, use zones instead';
             }
             return null;
-          }
-        }
-      }
+          },
+        },
+      },
     },
     glusterfs: {
       title: 'Glusterfs',
@@ -126,19 +126,19 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
       parameters: {
         resturl: {
           name: 'Gluster REST/Heketi URL',
-          required: true
+          required: true,
         },
         restuser: {
-          name: 'Gluster REST/Heketi user'
+          name: 'Gluster REST/Heketi user',
         },
         secretNamespace: {
-          name: 'Secret Namespace'
+          name: 'Secret Namespace',
         },
         secretName: {
-          name: 'Secret Name'
+          name: 'Secret Name',
         },
         clusterid: {
-          name: 'Cluster ID'
+          name: 'Cluster ID',
         },
         gidMin: {
           name: 'GID Min',
@@ -156,12 +156,12 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
               return 'GID Max must be number';
             }
             return null;
-          }
+          },
         },
         volumetype: {
-          name: 'Volume Type'
-        }
-      }
+          name: 'Volume Type',
+        },
+      },
     },
     openstackCinder: {
       title: 'OpenStack Cinder',
@@ -169,12 +169,12 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
       documentationLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/#openstack-cinder',
       parameters: {
         type: {
-          name: 'Volume Type'
+          name: 'Volume Type',
         },
         availability:{
-          name: 'Availability Zone'
-        }
-      }
+          name: 'Availability Zone',
+        },
+      },
     },
     azureFile: {
       title: 'Azure File',
@@ -183,17 +183,17 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
       parameters: {
         skuName: {
           name: 'SKU Name',
-          hintText: 'Azure storage account SKU tier'
+          hintText: 'Azure storage account SKU tier',
         },
         location: {
           name: 'Location',
-          hintText: 'Azure storage account location'
+          hintText: 'Azure storage account location',
         },
         storageAccount: {
           name: 'Azure Storage Account Name',
-          hintText: 'Azure Storage Account Name'
-        }
-      }
+          hintText: 'Azure Storage Account Name',
+        },
+      },
     },
     azureDisk: {
       title: 'Azure Disk',
@@ -202,14 +202,14 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
       parameters: {
         storageaccounttype: {
           name: 'Storage Account Type',
-          hintText: 'Storage Account Type'
+          hintText: 'Storage Account Type',
         },
         kind: {
           name: 'Account Kind',
           values: {shared: 'shared', dedicated: 'dedicated', managed: 'managed'},
-          hintText: 'Select Account Kind'
-        }
-      }
+          hintText: 'Select Account Kind',
+        },
+      },
     },
     quobyte: {
       title: 'Quobyte',
@@ -218,37 +218,37 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
       parameters: {
         quobyteAPIServer: {
           name: 'Quobyte API Server',
-          hintText: 'Quobyte API Server'
+          hintText: 'Quobyte API Server',
         },
         registry: {
           name: 'Registry Address(es)',
-          hintText: 'Registry Address(es)'
+          hintText: 'Registry Address(es)',
         },
         adminSecretName: {
           name: 'Admin Secret Name',
-          hintText: 'Admin Secret Name'
+          hintText: 'Admin Secret Name',
         },
         adminSecretNamespace: {
           name: 'Admin Secret Namespace',
-          hintText: 'Admin Secret Namespace'
+          hintText: 'Admin Secret Namespace',
         },
         user: {
           name: 'User',
-          hintText: 'User'
+          hintText: 'User',
         },
         group: {
           name: 'Group',
-          hintText: 'Group'
+          hintText: 'Group',
         },
         quobyteConfig: {
           name: 'Quobyte Configuration',
-          hintText: 'Quobyte Configuration'
+          hintText: 'Quobyte Configuration',
         },
         quobyteTenant: {
           name: 'Quobyte Tenant',
-          hintText: 'Quobyte tenant ID used to create/delete the volume'
-        }
-      }
+          hintText: 'Quobyte tenant ID used to create/delete the volume',
+        },
+      },
     },
     cephRbd: {
       title: 'Ceph RBD',
@@ -258,53 +258,53 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
         monitors: {
           name: 'Monitors',
           required: true,
-          hintText: 'Monitors'
+          hintText: 'Monitors',
         },
         adminId: {
           name: 'Admin Client ID',
-          hintText: 'Admin Client ID'
+          hintText: 'Admin Client ID',
         },
         adminSecretName: {
           name: 'Admin Secret Name',
           required: true,
-          hintText: 'Admin Secret Name'
+          hintText: 'Admin Secret Name',
         },
         adminSecretNamespace: {
           name: 'Admin Secret Namespace',
-          hintText: 'Admin Secret Namespace'
+          hintText: 'Admin Secret Namespace',
         },
         pool: {
           name: 'Pool',
-          hintText: 'Pool'
+          hintText: 'Pool',
         },
         userId: {
           name: 'User Client ID',
-          hintText: 'Ceph client ID used to map the RBD image'
+          hintText: 'Ceph client ID used to map the RBD image',
         },
         userSecretName: {
           name: 'User Secret Name',
           required: true,
-          hintText: 'User Secret Name'
+          hintText: 'User Secret Name',
         },
         userSecretNamespace: {
           name: 'User Secret Namespace',
-          hintText: 'User Secret Namespace'
+          hintText: 'User Secret Namespace',
         },
         fsType: {
           name: 'Filesystem Type',
-          hintText: 'Filesystem Type'
+          hintText: 'Filesystem Type',
         },
         imageFormat: {
           name: 'Image Format',
           values: {1: '1', 2: '2'},
-          hintText: 'Select Image Format'
+          hintText: 'Select Image Format',
         },
         imageFeatures: {
           name: 'Image Features',
           hintText: 'Image Features',
-          visible: (params) => _.get(params, 'imageFormat.value') === '2'
-        }
-      }
+          visible: (params) => _.get(params, 'imageFormat.value') === '2',
+        },
+      },
     },
     vSphereVolume: {
       title: 'vSphere Volume',
@@ -314,13 +314,13 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
         diskformat: {
           name: 'Disk Format',
           values: {thin: 'thin', zeroedthick: 'zeroed thick', eagerzeroedthick: 'eager zeroed thick'},
-          hintText: 'Select Disk Format'
+          hintText: 'Select Disk Format',
         },
         datastore: {
           name: 'Datastore',
-          hintText: 'Datastore'
-        }
-      }
+          hintText: 'Datastore',
+        },
+      },
     },
     portworxVolume: {
       title: 'Portworx Volume',
@@ -330,7 +330,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
         fs: {
           name: 'Filesystem',
           values: {none: 'none', xfs: 'xfs', ext4: 'ext4'},
-          hintText: 'Select Filesystem'
+          hintText: 'Select Filesystem',
         },
         block_size: { // eslint-disable-line camelcase
           name: 'Block Size',
@@ -350,12 +350,12 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
               return 'Number of replicas must be a number';
             }
             return null;
-          }
+          },
         },
         io_priority: { // eslint-disable-line camelcase
           name: 'I/O Priority',
           values: {high: 'high', medium: 'medium', low: 'low'},
-          hintText: 'I/O Priority'
+          hintText: 'I/O Priority',
         },
         snap_interval: { // eslint-disable-line camelcase
           name: 'Snapshot Interval',
@@ -366,7 +366,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
             }
             return null;
           },
-          format: (value) => value.toString()
+          format: (value) => value.toString(),
         },
         aggregation_level: { // eslint-disable-line camelcase
           name: 'Aggregation Level',
@@ -377,14 +377,14 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
             }
             return null;
           },
-          format: (value) => value.toString()
+          format: (value) => value.toString(),
         },
         ephemeral: {
           name: 'Ephemeral',
           type: 'checkbox',
-          format: (value) => value.toString()
-        }
-      }
+          format: (value) => value.toString(),
+        },
+      },
     },
     scaleIo: {
       title: 'ScaleIO',
@@ -394,42 +394,42 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
         gateway: {
           name: 'API Gateway',
           required: true,
-          hintText: 'ScaleIO API gateway address'
+          hintText: 'ScaleIO API gateway address',
         },
         system: {
           name: 'System Name',
           required: true,
-          hintText: 'Name of the ScaleIO system'
+          hintText: 'Name of the ScaleIO system',
         },
         protectionDomain: {
           name: 'Protection Domain',
           required: true,
-          hintText: 'Name of the ScaleIO protection domain'
+          hintText: 'Name of the ScaleIO protection domain',
         },
         storagePool: {
           name: 'Storage Pool',
           required: true,
-          hintText: 'Name of the volume storage pool'
+          hintText: 'Name of the volume storage pool',
         },
         storageMode: {
           name: 'Storage Mode',
           values: {thinProvisioned: 'ThinProvisioned', thickProvisioned: 'ThickProvisioned'},
-          hintText: 'Select Storage Provision Mode'
+          hintText: 'Select Storage Provision Mode',
         },
         secretRef: {
           name: 'Secret Reference',
           required: true,
-          hintText: 'Reference to a configured Secret object'
+          hintText: 'Reference to a configured Secret object',
         },
         readOnly: {
           name: 'Read Only',
-          type: 'checkbox'
+          type: 'checkbox',
         },
         fsType: {
           name: 'Filesystem Type',
-          hintText: 'Filesystem to use for the volume'
-        }
-      }
+          hintText: 'Filesystem to use for the volume',
+        },
+      },
     },
     storageOs: {
       title: 'StorageOS',
@@ -438,19 +438,19 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
       parameters: {
         pool: {
           name: 'Pool',
-          hintText: 'Name of the StorageOS distributed capacity pool from which to provision the volume'
+          hintText: 'Name of the StorageOS distributed capacity pool from which to provision the volume',
         },
         description: {
           name: 'Description',
-          hintText: 'Description to assign to volumes that were created dynamically'
+          hintText: 'Description to assign to volumes that were created dynamically',
         },
         fsType: {
           name: 'Filesystem Type',
-          hintText: 'Default filesystem type to request'
+          hintText: 'Default filesystem type to request',
         },
         adminSecretName: {
           name: 'Admin Secret Name',
-          hintText: 'Name of the secret to use for obtaining the StorageOS API credentials'
+          hintText: 'Name of the secret to use for obtaining the StorageOS API credentials',
         },
         adminSecretNamespace: {
           name: 'Admin Secret Namespace',
@@ -460,13 +460,13 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
             return adminSecretName !== null && adminSecretName !== '';
           },
         },
-      }
-    }
+      },
+    },
   });
 
   reclaimPolicies = {
     Retain: 'Retain',
-    Delete: 'Delete'
+    Delete: 'Delete',
   };
 
   componentDidUpdate(prevProps) {
@@ -515,7 +515,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
   updateNewStorage = (param, value, runValidation) => {
     const newParams = {
       ...this.state.newStorageClass,
-      [param]: value
+      [param]: value,
     };
 
     runValidation ? this.setState({newStorageClass: newParams}, this.validateForm) : this.setState({newStorageClass: newParams});
@@ -523,7 +523,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
 
   createStorageClass = () => {
     this.setState({
-      loading: true
+      loading: true,
     });
 
     const type = this.state.newStorageClass.type;
@@ -532,7 +532,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
     let data : StorageClass = {
       metadata: {
         name: this.state.newStorageClass.name,
-        annotations: {description: this.state.newStorageClass.description}
+        annotations: {description: this.state.newStorageClass.description},
       },
       provisioner: this.storageTypes[type].provisioner,
       parameters: dataParameters,
@@ -585,7 +585,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
 
   updateCustomParams = (customParams) => {
     this.setState({
-      customParams: customParams.nameValuePairs
+      customParams: customParams.nameValuePairs,
     });
   };
 
@@ -620,7 +620,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
     const nameUpdated = updatedName !== this.previousName;
     const returnVal = {
       error: null,
-      nameIsValid: true
+      nameIsValid: true,
     };
 
     if (nameUpdated) {
@@ -855,12 +855,12 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
 
 const mapStateToProps = ({k8s}, {onClose}) => ({
   k8s: k8s,
-  onClose: onClose
+  onClose: onClose,
 });
 
 const mapDispatchToProps = () => ({
   stopK8sWatch: actions.stopK8sWatch,
-  watchK8sList: actions.watchK8sList
+  watchK8sList: actions.watchK8sList,
 });
 
 export type StorageClassFormProps = {

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -67,7 +67,7 @@ export const StorageClassPage: React.SFC<StorageClassPageProps> = props => {
 
   const createProps = {
     items: createItems,
-    createLink: (type) => `/k8s/cluster/storageclasses/new/${type !== 'yaml' ? type : ''}`
+    createLink: (type) => `/k8s/cluster/storageclasses/new/${type !== 'yaml' ? type : ''}`,
   };
 
   return <ListPage

--- a/frontend/public/components/terminal.jsx
+++ b/frontend/public/components/terminal.jsx
@@ -126,5 +126,5 @@ Terminal.defaultProps = {
     cursorBlink: false,
     cols: 80,
     rows: 25,
-  }
+  },
 };

--- a/frontend/public/components/utils/container-linux-update-operator.js
+++ b/frontend/public/components/utils/container-linux-update-operator.js
@@ -142,5 +142,5 @@ export const containerLinuxUpdateOperator = {
   getNewVersion,
   getLastCheckedTime,
   getDownloadCompletedIconClass,
-  getUpdateCompletedIconClass
+  getUpdateCompletedIconClass,
 };

--- a/frontend/public/components/utils/copy-to-clipboard.jsx
+++ b/frontend/public/components/utils/copy-to-clipboard.jsx
@@ -57,7 +57,7 @@ export class CopyToClipboard extends React.PureComponent {
         borderTop: '8px solid transparent',
         borderBottom: '8px solid transparent',
         borderLeft: '8px solid #000',
-      }
+      },
     });
 
     const tooltipText = this.state.copied ? 'Copied' : 'Copy to Clipboard';

--- a/frontend/public/components/utils/deployment-pod-counts.tsx
+++ b/frontend/public/components/utils/deployment-pod-counts.tsx
@@ -31,7 +31,7 @@ export class DeploymentPodCounts extends SafetyFirst<DPCProps, DPCState> {
 
     this.state = {
       desiredCount: -1,
-      waitingForUpdate: false
+      waitingForUpdate: false,
     };
 
     this.openReplicaCountModal = event => {

--- a/frontend/public/components/utils/draggable-item-types.js
+++ b/frontend/public/components/utils/draggable-item-types.js
@@ -1,4 +1,4 @@
 export const DRAGGABLE_TYPE = {
   ENV_ROW: 'env_row',
-  ENV_FROM_ROW: 'env_from_row'
+  ENV_FROM_ROW: 'env_from_row',
 };

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -54,7 +54,7 @@ export class DropdownMixin extends React.PureComponent {
 
     this.setState({
       selectedKey: selectedKey,
-      title: noSelection ? title : this.props.items[selectedKey]
+      title: noSelection ? title : this.props.items[selectedKey],
     });
 
     this.hide();
@@ -430,7 +430,7 @@ export class ContainerDropdown extends React.PureComponent {
   getHeaders(container, initContainer) {
     return initContainer ? {
       [container.name]: 'Containers',
-      [initContainer.name]: 'Init Containers'
+      [initContainer.name]: 'Init Containers',
     } : {};
   }
 
@@ -460,10 +460,10 @@ ContainerDropdown.propTypes = {
   containers: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
   currentKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   initContainers: PropTypes.object,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
 };
 
 ContainerDropdown.defaultProps = {
   currentKey: '',
-  initContainers: {}
+  initContainers: {},
 };

--- a/frontend/public/components/utils/entitlements.ts
+++ b/frontend/public/components/utils/entitlements.ts
@@ -4,18 +4,18 @@ export const entitlementTitles = {
   nodes: {
     uppercase: 'Node',
     lowercase: 'node',
-    inPairs: false
+    inPairs: false,
   },
   vCPUs: {
     uppercase: 'vCPU',
     lowercase: 'vCPU',
-    inPairs: true
+    inPairs: true,
   },
   sockets: {
     uppercase: 'Socket',
     lowercase: 'socket',
-    inPairs: true
-  }
+    inPairs: true,
+  },
 };
 
 export const entitlementTitle = (name, count) => {

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -17,7 +17,7 @@ export class FileInput extends React.Component<FileInputProps, FileInputState> {
   }
   onDataChange(event) {
     this.props.onChange({
-      fileData: event.target.value
+      fileData: event.target.value,
     });
   }
   readFile(file) {
@@ -93,7 +93,7 @@ const boxTarget = {
 const FileInputComponent = DropTarget(NativeTypes.FILE, boxTarget, (connect, monitor) => ({
   connectDropTarget: connect.dropTarget(),
   isOver: monitor.isOver(),
-  canDrop: monitor.canDrop()
+  canDrop: monitor.canDrop(),
 }))(FileInput);
 
 export const DroppableFileInput = withDragDropContext(class DroppableFileInput extends React.Component<DroppableFileInputProps, DroppableFileInputState>{

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -11,7 +11,7 @@ import {
   K8sKind,
   K8sResourceKind,
   K8sResourceKindReference,
-  referenceForModel
+  referenceForModel,
 } from '../../module/k8s';
 
 export const BreadCrumbs: React.SFC<BreadCrumbsProps> = ({breadcrumbs}) => (

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -90,7 +90,7 @@ export const navFactory: NavFactory = {
     href: 'servicebindings',
     name: 'Service Bindings',
     component: component,
-  })
+  }),
 };
 
 export const NavBar: React.SFC<NavBarProps> = ({pages, basePath}) => {

--- a/frontend/public/components/utils/log-window.jsx
+++ b/frontend/public/components/utils/log-window.jsx
@@ -19,7 +19,7 @@ export class LogWindow extends React.PureComponent {
     this._setLogContents = (element) => this.logContents = element;
     this.state = {
       content: '',
-      height: ''
+      height: '',
     };
   }
 
@@ -74,7 +74,7 @@ export class LogWindow extends React.PureComponent {
     const targetHeight = Math.floor(window.innerHeight - this.scrollPane.getBoundingClientRect().top -
       (this.props.isFullscreen ? FULLSCREEN_FUDGE_FACTOR : FUDGE_FACTOR));
     this.setState({
-      height: targetHeight
+      height: targetHeight,
     });
   }
 
@@ -132,5 +132,5 @@ LogWindow.propTypes = {
   lines: PropTypes.array.isRequired,
   linesBehind: PropTypes.number.isRequired,
   status: PropTypes.string.isRequired,
-  updateStatus: PropTypes.func.isRequired
+  updateStatus: PropTypes.func.isRequired,
 };

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -210,11 +210,11 @@ EnvFromEditor.propTypes = {
   ).isRequired,
   updateParentData: PropTypes.func.isRequired,
   configMaps: PropTypes.object,
-  secrets: PropTypes.object
+  secrets: PropTypes.object,
 };
 EnvFromEditor.defaultProps = {
   readOnly: false,
-  nameValueId: 0
+  nameValueId: 0,
 };
 
 
@@ -222,9 +222,9 @@ const pairSource = {
   beginDrag(props) {
     return {
       index: props.index,
-      rowSourceId: props.rowSourceId
+      rowSourceId: props.rowSourceId,
     };
-  }
+  },
 };
 
 const itemTarget = {
@@ -271,13 +271,13 @@ const itemTarget = {
     // but it's good here for the sake of performance
     // to avoid expensive index searches.
     monitor.getItem().index = hoverIndex;
-  }
+  },
 };
 
 const collectSourcePair = (connect, monitor) => ({
   connectDragSource: connect.dragSource(),
   connectDragPreview: connect.dragPreview(),
-  isDragging: monitor.isDragging()
+  isDragging: monitor.isDragging(),
 });
 
 const collectTargetPair = (connect) => ({
@@ -363,7 +363,7 @@ PairElement.propTypes = {
   onMove: PropTypes.func.isRequired,
   rowSourceId: PropTypes.number.isRequired,
   configMaps: PropTypes.object,
-  secrets: PropTypes.object
+  secrets: PropTypes.object,
 };
 
 const EnvFromPairElement = DragSource(DRAGGABLE_TYPE.ENV_FROM_ROW, pairSource, collectSourcePair)(DropTarget(DRAGGABLE_TYPE.ENV_FROM_ROW, itemTarget, collectTargetPair)(class EnvFromPairElement extends React.Component {
@@ -436,5 +436,5 @@ EnvFromPairElement.propTypes = {
   onMove: PropTypes.func.isRequired,
   rowSourceId: PropTypes.number.isRequired,
   configMaps: PropTypes.object,
-  secrets: PropTypes.object
+  secrets: PropTypes.object,
 };

--- a/frontend/public/components/utils/number-spinner.jsx
+++ b/frontend/public/components/utils/number-spinner.jsx
@@ -15,5 +15,5 @@ export const NumberSpinner = (props) => {
 };
 NumberSpinner.propTypes = {
   // function that increments/decrements the existing value
-  changeValueBy: PropTypes.func.isRequired
+  changeValueBy: PropTypes.func.isRequired,
 };

--- a/frontend/public/components/utils/operator-states.jsx
+++ b/frontend/public/components/utils/operator-states.jsx
@@ -7,12 +7,12 @@ export const operatorStates = {
   Complete: {
     suffix: 'complete',
     icon: 'fa-check-circle',
-    statusText: 'Completed'
+    statusText: 'Completed',
   },
   Failed: {
     suffix: 'failed',
     icon: 'fa-ban',
-    statusText: 'Software update failed'
+    statusText: 'Software update failed',
   },
   Loading: {
     suffix: 'loading',
@@ -20,66 +20,66 @@ export const operatorStates = {
   NeedsAttention: {
     suffix: 'needs-attention',
     icon: 'fa-exclamation-triangle',
-    statusText: 'Update Needs Attention'
+    statusText: 'Update Needs Attention',
   },
   Paused: {
     suffix: 'paused',
     icon: 'fa-pause-circle-o',
-    statusText: 'Paused...'
+    statusText: 'Paused...',
   },
   Pausing: {
     suffix: 'pausing',
     icon: 'fa-pause-circle-o',
-    statusText: 'Pausing...'
+    statusText: 'Pausing...',
 
   },
   Requested: {
     suffix: 'requested',
     icon: 'fa-ban',
-    statusText: 'Update Requested...'
+    statusText: 'Update Requested...',
   },
   UpdateAvailable: {
     suffix: 'update-available',
     icon: 'fa-arrow-circle-down',
-    statusText: ' is available'
+    statusText: ' is available',
   },
   Updating: {
     suffix: 'updating',
     icon: 'fa-circle-o-notch fa-spin',
-    statusText: 'Updating'
+    statusText: 'Updating',
   },
   Pending: {
     suffix: 'pending',
     icon: 'fa-circle-o',
-    statusText: 'Updating'
+    statusText: 'Updating',
   },
   UpToDate: {
     suffix: 'up-to-date',
-    statusText: 'Up to date'
-  }
+    statusText: 'Up to date',
+  },
 };
 
 export const taskStatuses = {
   BackOff: {
     suffix:'backoff',
-    icon: 'fa-ban'
+    icon: 'fa-ban',
   },
   Completed: {
     suffix:'completed',
-    icon: 'fa-check-circle'
+    icon: 'fa-check-circle',
   },
   Failed: {
     suffix: 'failed',
-    icon: 'fa-ban'
+    icon: 'fa-ban',
   },
   NotStarted: {
     suffix: 'notstarted',
-    icon: 'fa-circle-o'
+    icon: 'fa-circle-o',
   },
   Running: {
     suffix: 'running',
-    icon: 'fa-circle-o-notch fa-spin'
-  }
+    icon: 'fa-circle-o-notch fa-spin',
+  },
 };
 
 export const orderedTaskStatuses = ['Running', 'Failed', 'BackOff', 'NotStarted', 'Completed'];

--- a/frontend/public/components/utils/promise-component.jsx
+++ b/frontend/public/components/utils/promise-component.jsx
@@ -14,7 +14,7 @@ export class PromiseComponent extends SafetyFirst {
 
   handlePromise(promise) {
     this.setState({
-      inProgress: true
+      inProgress: true,
     });
     return promise.then(
       res => this._then(res),

--- a/frontend/public/components/utils/resource-log.jsx
+++ b/frontend/public/components/utils/resource-log.jsx
@@ -26,7 +26,7 @@ const streamStatusMessages = {
   [STREAM_EOF]: 'Log stream ended.',
   [STREAM_LOADING]: 'Loading log...',
   [STREAM_PAUSED]: 'Log stream paused.',
-  [STREAM_ACTIVE]: 'Log streaming...'
+  [STREAM_ACTIVE]: 'Log streaming...',
 };
 
 // Component for log stream controls
@@ -78,7 +78,7 @@ export class ResourceLog extends SafetyFirst {
       resourceStatus: LOG_SOURCE_WAITING,
       stale: false,
       status: STREAM_LOADING,
-      isFullscreen: false
+      isFullscreen: false,
     };
   }
 
@@ -144,7 +144,7 @@ export class ResourceLog extends SafetyFirst {
   // Handler for websocket onerror event
   _onError(){
     this.setState({
-      error: true
+      error: true,
     });
   }
 
@@ -156,7 +156,7 @@ export class ResourceLog extends SafetyFirst {
       const linesAdded = this._buffer.ingest(text);
       this.setState({
         linesBehind: status === STREAM_PAUSED ? linesBehind + linesAdded : linesBehind,
-        lines: this._buffer.getLines()
+        lines: this._buffer.getLines(),
       });
     }
   }
@@ -174,7 +174,7 @@ export class ResourceLog extends SafetyFirst {
       lines: [],
       linesBehind: 0,
       stale: false,
-      status: STREAM_LOADING
+      status: STREAM_LOADING,
     }, () => {
       this._wsDestroy();
       this._wsInit(this.props);
@@ -226,14 +226,14 @@ export class ResourceLog extends SafetyFirst {
         queryParams: {
           container: containerName || '',
           follow: 'true',
-          tailLines: bufferSize
-        }
+          tailLines: bufferSize,
+        },
       };
       const watchURL = resourceURL(modelFor(kind), urlOpts);
       const wsOpts = {
         host: 'auto',
         path: watchURL,
-        subprotocols: ['base64.binary.k8s.io']
+        subprotocols: ['base64.binary.k8s.io'],
       };
 
       this.ws = new WSFactory(watchURL, wsOpts)
@@ -286,7 +286,7 @@ export class ResourceLog extends SafetyFirst {
 }
 
 ResourceLog.defaultProps = {
-  bufferSize: 1000
+  bufferSize: 1000,
 };
 
 ResourceLog.propTypes = {

--- a/frontend/public/components/utils/simple-tab-nav.tsx
+++ b/frontend/public/components/utils/simple-tab-nav.tsx
@@ -33,7 +33,7 @@ export class SimpleTabNav extends React.Component<SimpleTabNavProps, SimpleTabNa
     const {tabs} = this.props;
     this.props.onClickTab(name);
     this.setState({
-      'selectedTab': _.find(tabs, {name})
+      'selectedTab': _.find(tabs, {name}),
     });
   }
 

--- a/frontend/public/components/utils/toggle-play.jsx
+++ b/frontend/public/components/utils/toggle-play.jsx
@@ -15,5 +15,5 @@ export class TogglePlay extends React.Component {
 TogglePlay.propTypes = {
   active: PropTypes.bool.isRequired,
   className: PropTypes.string,
-  onClick: PropTypes.func.isRequired
+  onClick: PropTypes.func.isRequired,
 };

--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -7,32 +7,32 @@ const TYPES = {
   numeric: {
     units: ['', 'k', 'm', 'b'],
     space: false,
-    divisor: 1000
+    divisor: 1000,
   },
   percentage: {
     units: ['%'],
     space: false,
-    divisor: 1000
+    divisor: 1000,
   },
   decimalBytes: {
     units: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'],
     space: true,
-    divisor: 1000
+    divisor: 1000,
   },
   binaryBytes: {
     units: ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'],
     space: true,
-    divisor: 1024
+    divisor: 1024,
   },
   binaryBytesWithoutB: {
     units: ['i', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei'],
     space: true,
-    divisor: 1024
+    divisor: 1024,
   },
   SI: {
     units: ['', 'K', 'M', 'G', 'T', 'P', 'E'],
     space: false,
-    divisor: 1000
+    divisor: 1000,
   },
 };
 
@@ -42,7 +42,7 @@ const getType = (name) => {
     return {
       units: [],
       space: false,
-      divisor: 1000
+      divisor: 1000,
     };
   }
   return type;
@@ -133,7 +133,7 @@ const humanize = units.humanize = (value, typeName, useRound = false) => {
   return {
     string: converted.value + converted.unit,
     value: converted.value,
-    unit: converted.unit
+    unit: converted.unit,
   };
 };
 

--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -41,7 +41,7 @@ const getHeaders = (configMap, secret) => {
   }
   return {
     [configMap]: 'Config Maps',
-    [secret]: 'Secrets'
+    [secret]: 'Secrets',
   };
 };
 
@@ -97,7 +97,7 @@ export const NameKeyDropdownPair = ({name, key, configMaps, secrets, onChange, k
         const keyValuePair = _.split(val, ':');
         onChange({
           [keyValuePair[1]]:
-            isKeyRef ? {'name': keyValuePair[0], 'key': ''} : {'name': keyValuePair[0]}
+            isKeyRef ? {'name': keyValuePair[0], 'key': ''} : {'name': keyValuePair[0]},
         });
       }}
     />{isKeyRef &&
@@ -169,28 +169,28 @@ const keyStringToComponent = {
   },
   secretKeyRef: {
     component: ConfigMapSecretKeyRef,
-    kind: 'Secret'
+    kind: 'Secret',
   },
   configMapKeyRef: {
     component: ConfigMapSecretKeyRef,
-    kind: 'ConfigMap'
+    kind: 'ConfigMap',
   },
   configMapSecretKeyRef: {
-    component: ConfigMapSecretKeyRef
+    component: ConfigMapSecretKeyRef,
   },
   resourceFieldRef: {
     component: ResourceFieldRef,
   },
   configMapRef: {
     component: ConfigMapSecretRef,
-    kind: 'ConfigMap'
+    kind: 'ConfigMap',
   },
   secretRef: {
     component: ConfigMapSecretRef,
-    kind: 'Secret'
+    kind: 'Secret',
   },
   configMapSecretRef: {
-    component: ConfigMapSecretRef
+    component: ConfigMapSecretRef,
   },
 };
 
@@ -221,5 +221,5 @@ ValueFromPair.propTypes = {
   configMaps: PropTypes.object,
   secrets: PropTypes.object,
   onChange: PropTypes.func,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
 };

--- a/frontend/public/components/utils/volume-icon.jsx
+++ b/frontend/public/components/utils/volume-icon.jsx
@@ -7,7 +7,7 @@ export const VolumeIcon = ({kind}) => {
   const faClasses = _.fromPairs([
     [VolumeSource.emptyDir.id, 'fa-folder-open-o'],
     [VolumeSource.hostPath.id, 'fa-files-o'],
-    [VolumeSource.secret.id, 'fa-lock']
+    [VolumeSource.secret.id, 'fa-lock'],
   ]);
   const faClass = faClasses[kind];
 

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -127,7 +127,7 @@ export let featureActions = [
   detectCalicoFlags,
   detectOpenShift,
   detectProjectsAvailable,
-  detectCanCreateProject
+  detectCanCreateProject,
 ];
 
 // generate additional featureActions
@@ -139,7 +139,7 @@ export let featureActions = [
   [FLAGS.CAN_LIST_CRD, { group: 'apiextensions.k8s.io', resource: 'customresourcedefinitions', verb: 'list' }],
 ].forEach(_.spread((FLAG, resourceAttributes) => {
   const req = {
-    spec: { resourceAttributes }
+    spec: { resourceAttributes },
   };
   const fn = (dispatch) => {
     return k8sCreate(SelfSubjectAccessReviewModel, req)

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -158,7 +158,7 @@ export const ServiceModel: K8sKind = {
   namespaced: true,
   kind: 'Service',
   id: 'service',
-  labelPlural: 'Services'
+  labelPlural: 'Services',
 };
 
 export const PodModel: K8sKind = {
@@ -170,7 +170,7 @@ export const PodModel: K8sKind = {
   namespaced: true,
   kind: 'Pod',
   id: 'pod',
-  labelPlural: 'Pods'
+  labelPlural: 'Pods',
 };
 
 export const ContainerModel: K8sKind = {
@@ -181,7 +181,7 @@ export const ContainerModel: K8sKind = {
   abbr: 'C',
   kind: 'Container',
   id: 'container',
-  labelPlural: 'Containers'
+  labelPlural: 'Containers',
 };
 
 export const DaemonSetModel: K8sKind = {
@@ -195,7 +195,7 @@ export const DaemonSetModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'DaemonSet',
   id: 'daemonset',
-  labelPlural: 'Daemon Sets'
+  labelPlural: 'Daemon Sets',
 };
 
 export const ReplicationControllerModel: K8sKind = {
@@ -208,7 +208,7 @@ export const ReplicationControllerModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'ReplicationController',
   id: 'replicationcontroller',
-  labelPlural: 'Replication Controllers'
+  labelPlural: 'Replication Controllers',
 };
 
 export const HorizontalPodAutoscalerModel: K8sKind = {
@@ -221,7 +221,7 @@ export const HorizontalPodAutoscalerModel: K8sKind = {
   namespaced: true,
   kind: 'HorizontalPodAutoscaler',
   id: 'horizontalpodautoscaler',
-  labelPlural: 'Horizontal Pod Autoscalers'
+  labelPlural: 'Horizontal Pod Autoscalers',
 };
 
 export const ServiceAccountModel: K8sKind = {
@@ -233,7 +233,7 @@ export const ServiceAccountModel: K8sKind = {
   namespaced: true,
   kind: 'ServiceAccount',
   id: 'serviceaccount',
-  labelPlural: 'Service Accounts'
+  labelPlural: 'Service Accounts',
 };
 
 export const ReplicaSetModel: K8sKind = {
@@ -247,7 +247,7 @@ export const ReplicaSetModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'ReplicaSet',
   id: 'replicaset',
-  labelPlural: 'Replica Sets'
+  labelPlural: 'Replica Sets',
 };
 
 export const DeploymentModel: K8sKind = {
@@ -261,7 +261,7 @@ export const DeploymentModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'Deployment',
   id: 'deployment',
-  labelPlural: 'Deployments'
+  labelPlural: 'Deployments',
 };
 
 export const DeploymentConfigModel: K8sKind = {
@@ -275,7 +275,7 @@ export const DeploymentConfigModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'DeploymentConfig',
   id: 'deploymentconfig',
-  labelPlural: 'Deployment Configs'
+  labelPlural: 'Deployment Configs',
 };
 
 export const BuildConfigModel: K8sKind = {
@@ -289,7 +289,7 @@ export const BuildConfigModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'BuildConfig',
   id: 'buildconfig',
-  labelPlural: 'Build Configs'
+  labelPlural: 'Build Configs',
 };
 
 export const BuildModel: K8sKind = {
@@ -303,7 +303,7 @@ export const BuildModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'Build',
   id: 'build',
-  labelPlural: 'Builds'
+  labelPlural: 'Builds',
 };
 
 export const ImageStreamModel: K8sKind = {
@@ -317,7 +317,7 @@ export const ImageStreamModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'ImageStream',
   id: 'imagestream',
-  labelPlural: 'Image Streams'
+  labelPlural: 'Image Streams',
 };
 
 export const ImageStreamTagModel: K8sKind = {
@@ -331,7 +331,7 @@ export const ImageStreamTagModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'ImageStreamTag',
   id: 'imagestreamtag',
-  labelPlural: 'Image Stream Tags'
+  labelPlural: 'Image Stream Tags',
 };
 
 export const ImageStreamImportsModel: K8sKind = {
@@ -344,7 +344,7 @@ export const ImageStreamImportsModel: K8sKind = {
   namespaced: true,
   kind: 'ImageStreamImport',
   id: 'imagestreamimport',
-  labelPlural: 'Image Stream Imports'
+  labelPlural: 'Image Stream Imports',
 };
 
 export const JobModel: K8sKind = {
@@ -358,7 +358,7 @@ export const JobModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'Job',
   id: 'job',
-  labelPlural: 'Jobs'
+  labelPlural: 'Jobs',
 };
 
 export const NodeModel: K8sKind = {
@@ -369,7 +369,7 @@ export const NodeModel: K8sKind = {
   abbr: 'N',
   kind: 'Node',
   id: 'node',
-  labelPlural: 'Nodes'
+  labelPlural: 'Nodes',
 };
 
 export const EventModel: K8sKind = {
@@ -381,7 +381,7 @@ export const EventModel: K8sKind = {
   namespaced: true,
   kind: 'Event',
   id: 'event',
-  labelPlural: 'Events'
+  labelPlural: 'Events',
 };
 
 export const ComponentStatusModel: K8sKind = {
@@ -392,7 +392,7 @@ export const ComponentStatusModel: K8sKind = {
   plural: 'componentstatuses',
   abbr: 'CS',
   kind: 'ComponentStatus',
-  id: 'componentstatus'
+  id: 'componentstatus',
 };
 
 export const NamespaceModel: K8sKind = {
@@ -403,7 +403,7 @@ export const NamespaceModel: K8sKind = {
   abbr: 'NS',
   kind: 'Namespace',
   id: 'namespace',
-  labelPlural: 'Namespaces'
+  labelPlural: 'Namespaces',
 };
 
 export const ProjectModel: K8sKind = {
@@ -415,7 +415,7 @@ export const ProjectModel: K8sKind = {
   abbr: 'PR',
   kind: 'Project',
   id: 'project',
-  labelPlural: 'Projects'
+  labelPlural: 'Projects',
 };
 
 export const ProjectRequestModel: K8sKind = {
@@ -427,7 +427,7 @@ export const ProjectRequestModel: K8sKind = {
   abbr: '',
   kind: 'ProjectRequest',
   id: 'projectrequest',
-  labelPlural: 'Project Requests'
+  labelPlural: 'Project Requests',
 };
 
 export const IngressModel: K8sKind = {
@@ -440,7 +440,7 @@ export const IngressModel: K8sKind = {
   abbr: 'I',
   namespaced: true,
   kind: 'Ingress',
-  id: 'ingress'
+  id: 'ingress',
 };
 
 export const RouteModel: K8sKind = {
@@ -453,7 +453,7 @@ export const RouteModel: K8sKind = {
   abbr: 'RT',
   namespaced: true,
   kind: 'Route',
-  id: 'route'
+  id: 'route',
 };
 
 export const ConfigMapModel: K8sKind = {
@@ -465,7 +465,7 @@ export const ConfigMapModel: K8sKind = {
   namespaced: true,
   kind: 'ConfigMap',
   id: 'configmap',
-  labelPlural: 'Config Maps'
+  labelPlural: 'Config Maps',
 };
 
 export const SecretModel: K8sKind = {
@@ -477,7 +477,7 @@ export const SecretModel: K8sKind = {
   namespaced: true,
   kind: 'Secret',
   id: 'secret',
-  labelPlural: 'Secrets'
+  labelPlural: 'Secrets',
 };
 
 export const ClusterRoleBindingModel: K8sKind = {
@@ -489,7 +489,7 @@ export const ClusterRoleBindingModel: K8sKind = {
   abbr: 'CRB',
   kind: 'ClusterRoleBinding',
   id: 'clusterrolebinding',
-  labelPlural: 'Cluster Role Bindings'
+  labelPlural: 'Cluster Role Bindings',
 };
 
 export const ClusterRoleModel: K8sKind = {
@@ -501,7 +501,7 @@ export const ClusterRoleModel: K8sKind = {
   abbr: 'CR',
   kind: 'ClusterRole',
   id: 'clusterrole',
-  labelPlural: 'Cluster Roles'
+  labelPlural: 'Cluster Roles',
 };
 
 export const RoleBindingModel: K8sKind = {
@@ -514,7 +514,7 @@ export const RoleBindingModel: K8sKind = {
   namespaced: true,
   kind: 'RoleBinding',
   id: 'rolebinding',
-  labelPlural: 'Role Bindings'
+  labelPlural: 'Role Bindings',
 };
 
 export const RoleModel: K8sKind = {
@@ -527,7 +527,7 @@ export const RoleModel: K8sKind = {
   namespaced: true,
   kind: 'Role',
   id: 'role',
-  labelPlural: 'Roles'
+  labelPlural: 'Roles',
 };
 
 export const SelfSubjectAccessReviewModel: K8sKind = {
@@ -540,7 +540,7 @@ export const SelfSubjectAccessReviewModel: K8sKind = {
   namespaced: true,
   kind: 'SelfSubjectAccessReview',
   id: 'selfsubjectaccessreview',
-  labelPlural: 'Self Subject Access Reviews'
+  labelPlural: 'Self Subject Access Reviews',
 };
 
 export const TectonicVersionModel: K8sKind = {
@@ -553,7 +553,7 @@ export const TectonicVersionModel: K8sKind = {
   namespaced: true,
   kind: 'TectonicVersion',
   id: 'tectonicversion',
-  labelPlural: 'Tectonic Versions'
+  labelPlural: 'Tectonic Versions',
 };
 
 export const ChannelOperatorConfigModel: K8sKind = {
@@ -566,7 +566,7 @@ export const ChannelOperatorConfigModel: K8sKind = {
   namespaced: true,
   kind: 'ChannelOperatorConfig',
   id: 'channeloperatorconfig',
-  labelPlural: 'Channel Operator Configs'
+  labelPlural: 'Channel Operator Configs',
 };
 
 export const AppVersionModel: K8sKind = {
@@ -579,7 +579,7 @@ export const AppVersionModel: K8sKind = {
   namespaced: true,
   kind: 'AppVersion',
   id: 'appversion',
-  labelPlural: 'AppVersions'
+  labelPlural: 'AppVersions',
 };
 
 export const PersistentVolumeModel: K8sKind = {
@@ -590,7 +590,7 @@ export const PersistentVolumeModel: K8sKind = {
   abbr: 'PV',
   kind: 'PersistentVolume',
   id: 'persistentvolume',
-  labelPlural: 'Persistent Volumes'
+  labelPlural: 'Persistent Volumes',
 };
 
 export const PersistentVolumeClaimModel: K8sKind = {
@@ -602,7 +602,7 @@ export const PersistentVolumeClaimModel: K8sKind = {
   namespaced: true,
   kind: 'PersistentVolumeClaim',
   id: 'persistentvolumeclaim',
-  labelPlural: 'Persistent Volume Claims'
+  labelPlural: 'Persistent Volume Claims',
 };
 
 export const PetsetModel: K8sKind = {
@@ -614,7 +614,7 @@ export const PetsetModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'Petset',
   id: 'petset',
-  labelPlural: 'Petsets'
+  labelPlural: 'Petsets',
 };
 
 export const StatefulSetModel: K8sKind = {
@@ -628,7 +628,7 @@ export const StatefulSetModel: K8sKind = {
   propagationPolicy: 'Foreground',
   kind: 'StatefulSet',
   id: 'statefulset',
-  labelPlural: 'Stateful Sets'
+  labelPlural: 'Stateful Sets',
 };
 
 export const ResourceQuotaModel: K8sKind = {
@@ -640,7 +640,7 @@ export const ResourceQuotaModel: K8sKind = {
   namespaced: true,
   kind: 'ResourceQuota',
   id: 'resourcequota',
-  labelPlural: 'Resource Quotas'
+  labelPlural: 'Resource Quotas',
 };
 
 export const ClusterResourceQuotaModel: K8sKind = {
@@ -653,7 +653,7 @@ export const ClusterResourceQuotaModel: K8sKind = {
   namespaced: false,
   kind: 'ClusterResourceQuota',
   id: 'clusterresourcequota',
-  labelPlural: 'Cluster Resource Quotas'
+  labelPlural: 'Cluster Resource Quotas',
 };
 
 export const NetworkPolicyModel: K8sKind = {
@@ -666,7 +666,7 @@ export const NetworkPolicyModel: K8sKind = {
   abbr: 'NP',
   namespaced: true,
   kind: 'NetworkPolicy',
-  id: 'networkpolicy'
+  id: 'networkpolicy',
 };
 
 export const CustomResourceDefinitionModel: K8sKind = {
@@ -679,7 +679,7 @@ export const CustomResourceDefinitionModel: K8sKind = {
   plural: 'customresourcedefinitions',
   kind: 'CustomResourceDefinition',
   id: 'customresourcedefinition',
-  labelPlural: 'Custom Resource Definitions'
+  labelPlural: 'Custom Resource Definitions',
 };
 
 export const CronJobModel: K8sKind = {
@@ -706,7 +706,7 @@ export const StorageClassModel: K8sKind = {
   abbr: 'SC',
   namespaced: false,
   kind: 'StorageClass',
-  id: 'storageclass'
+  id: 'storageclass',
 };
 
 export const ClusterServiceBrokerModel: K8sKind = {
@@ -719,7 +719,7 @@ export const ClusterServiceBrokerModel: K8sKind = {
   abbr: 'CSB',
   namespaced: false,
   kind: 'ClusterServiceBroker',
-  id: 'clusterservicebroker'
+  id: 'clusterservicebroker',
 };
 
 export const ClusterServiceClassModel: K8sKind = {
@@ -732,7 +732,7 @@ export const ClusterServiceClassModel: K8sKind = {
   abbr: 'CSC',
   namespaced: false,
   kind: 'ClusterServiceClass',
-  id: 'clusterserviceclass'
+  id: 'clusterserviceclass',
 };
 
 export const ClusterServicePlanModel: K8sKind = {
@@ -745,7 +745,7 @@ export const ClusterServicePlanModel: K8sKind = {
   abbr: 'CSP',
   namespaced: false,
   kind: 'ClusterServicePlan',
-  id: 'clusterserviceplan'
+  id: 'clusterserviceplan',
 };
 
 export const ServiceInstanceModel: K8sKind = {
@@ -758,7 +758,7 @@ export const ServiceInstanceModel: K8sKind = {
   abbr: 'SI',
   namespaced: true,
   kind: 'ServiceInstance',
-  id: 'serviceinstance'
+  id: 'serviceinstance',
 };
 
 export const ServiceBindingModel: K8sKind = {
@@ -771,7 +771,7 @@ export const ServiceBindingModel: K8sKind = {
   abbr: 'SB',
   namespaced: true,
   kind: 'ServiceBinding',
-  id: 'servicebinding'
+  id: 'servicebinding',
 };
 
 export const LimitRangeModel: K8sKind = {
@@ -783,7 +783,7 @@ export const LimitRangeModel: K8sKind = {
   namespaced: true,
   kind: 'LimitRange',
   id: 'limitrange',
-  labelPlural: 'Limit Ranges'
+  labelPlural: 'Limit Ranges',
 };
 
 export const APIServiceModel: K8sKind = {

--- a/frontend/public/module/analytics.js
+++ b/frontend/public/module/analytics.js
@@ -30,7 +30,7 @@ export const analyticsSvc = {
       event: 'tectonicRouteChange',
       attributes: {
         route: route,
-      }
+      },
     });
   },
 };

--- a/frontend/public/module/auth.js
+++ b/frontend/public/module/auth.js
@@ -52,7 +52,7 @@ export const authSvc = {
       }
     });
 
-    coFetch(window.SERVER_FLAGS.logoutURL, { method: 'POST', })
+    coFetch(window.SERVER_FLAGS.logoutURL, { method: 'POST' })
       // eslint-disable-next-line no-console
       .catch(e => console.error('Error logging out', e))
       .then(() => {

--- a/frontend/public/module/k8s/k8s-reducers.ts
+++ b/frontend/public/module/k8s/k8s-reducers.ts
@@ -167,7 +167,7 @@ export default (state: ImmutableMap<string, any>, action) => {
       // eslint-disable-next-line no-console
       console.info(`loaded ${id}`);
       state = state.mergeDeep({
-        [id]: {loaded: true, loadError: ''}
+        [id]: {loaded: true, loadError: ''},
       });
       newList = loadList(list, k8sObjects);
       break;

--- a/frontend/public/module/k8s/label-selector.js
+++ b/frontend/public/module/k8s/label-selector.js
@@ -26,13 +26,13 @@ export class LabelSelector {
       'In': 'in',
       'NotIn': 'not in',
       'Exists': 'exists',
-      'DoesNotExist': 'does not exist'
+      'DoesNotExist': 'does not exist',
     };
     this._REVERSE_OPERATOR_MAP = {
       'in': 'In',
       'not in': 'NotIn',
       'exists': 'Exists',
-      'does not exist': 'DoesNotExist'
+      'does not exist': 'DoesNotExist',
     };
     if (selector) {
       if (selector.matchLabels || selector.matchExpressions) {
@@ -58,7 +58,7 @@ export class LabelSelector {
     let conjunct = {
       key: key,
       operator: operator,
-      values: values
+      values: values,
     };
     const id = this._getIdForConjunct(conjunct);
     this._conjuncts[id] = conjunct;
@@ -151,7 +151,7 @@ export class LabelSelector {
   findConjunctsMatching(operator, key) {
     return _.pickBy(this._conjuncts, _.matches({
       operator: operator,
-      key: key
+      key: key,
     }));
   }
   // Test whether this label selector covers the given selector
@@ -203,14 +203,14 @@ export class LabelSelector {
   // Exports the labelSelector as a string in the API format, exports as matchExpressions
   exportJSON() {
     let result = {
-      matchExpressions: []
+      matchExpressions: [],
     };
     for (let id in this._conjuncts) {
       const conjunct = this._conjuncts[id];
       const expression = {
         key: conjunct.key,
         operator: this._REVERSE_OPERATOR_MAP[conjunct.operator],
-        values: conjunct.values
+        values: conjunct.values,
       };
       result.matchExpressions.push(expression);
     }

--- a/frontend/public/module/k8s/selector-requirement.js
+++ b/frontend/public/module/k8s/selector-requirement.js
@@ -5,7 +5,7 @@ const toArray = value => Array.isArray(value) ? value : [value];
 export const createEquals = (key, value) => ({
   key:      key,
   operator: 'Equals',
-  values:   [value]
+  values:   [value],
 });
 
 export const requirementFromString = string => {
@@ -16,7 +16,7 @@ export const requirementFromString = string => {
     return {
       key:      string,
       operator: 'Exists',
-      values:   []
+      values:   [],
     };
   }
 
@@ -25,7 +25,7 @@ export const requirementFromString = string => {
     return {
       key:      string.split(/!\s*/)[1],
       operator: 'DoesNotExist',
-      values:   []
+      values:   [],
     };
   }
 
@@ -42,7 +42,7 @@ export const requirementFromString = string => {
     return {
       key:      string.split(/\s*!=\s*/)[0],
       operator: 'NotEquals',
-      values:   [string.split(/\s*!=\s*/)[1]]
+      values:   [string.split(/\s*!=\s*/)[1]],
     };
   }
 
@@ -55,7 +55,7 @@ export const requirementFromString = string => {
     return {
       key:      key,
       operator: 'In',
-      values:   values
+      values:   values,
     };
   }
 
@@ -68,7 +68,7 @@ export const requirementFromString = string => {
     return {
       key:      key,
       operator: 'NotIn',
-      values:   values
+      values:   values,
     };
   }
 
@@ -81,7 +81,7 @@ export const requirementFromString = string => {
     return {
       key:      key,
       operator: 'GreaterThan',
-      values:   [value]
+      values:   [value],
     };
   }
 
@@ -94,7 +94,7 @@ export const requirementFromString = string => {
     return {
       key:      key,
       operator: 'LessThan',
-      values:   [value]
+      values:   [value],
     };
   }
 

--- a/frontend/public/module/k8s/selector.js
+++ b/frontend/public/module/k8s/selector.js
@@ -6,7 +6,7 @@ export const fromRequirements = (requirements, options) => {
   options = options || {};
   const selector = {
     matchLabels:      {},
-    matchExpressions: []
+    matchExpressions: [],
   };
 
   if (options.undefinedWhenEmpty && requirements.length === 0) {

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -30,7 +30,7 @@ export default (state, action) => {
         resources: new ImmutableMap({}),
         selectedDetailsTab: '',
         selectedUID: '',
-      })
+      }),
     });
   }
 

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -42,14 +42,14 @@ let config: webpack.Configuration = {
             options: {
               // Leave one core spare for fork-ts-checker-webpack-plugin
               workers: require('os').cpus().length - 1,
-            }
+            },
           },
           {
             loader: 'ts-loader',
             options: {
               happyPackMode: true, // This implicitly enables transpileOnly! No type checking!
               transpileOnly: true, // fork-ts-checker-webpack-plugin takes care of type checking
-            }
+            },
           },
         ],
       },
@@ -60,8 +60,8 @@ let config: webpack.Configuration = {
           {
             loader: MiniCssExtractPlugin.loader,
             options: {
-              publicPath: './'
-            }
+              publicPath: './',
+            },
           },
           { loader: 'cache-loader' },
           { loader: 'thread-loader' },
@@ -69,20 +69,20 @@ let config: webpack.Configuration = {
             loader: 'css-loader',
             options: {
               sourceMap: true,
-            }
+            },
           },
           {
             loader: 'resolve-url-loader',
             options: {
               sourceMap: true,
-            }
+            },
           },
           {
             loader: 'sass-loader',
             options: {
               sourceMap: true,
               outputStyle: 'compressed',
-            }
+            },
           },
         ],
       },
@@ -93,7 +93,7 @@ let config: webpack.Configuration = {
           name: 'assets/[name].[ext]',
         },
       },
-    ]
+    ],
   },
   optimization: {
     splitChunks: {


### PR DESCRIPTION
Justification:

1. It makes it easier to add or remove items from arrays and objects
2. It reduces noise in diffs when items are added or removed (helps with reviews)

https://eslint.org/docs/rules/comma-dangle#require-or-disallow-trailing-commas-comma-dangle

We have enough contributors to console now that I think it makes sense to start enforcing a style using eslint, particularly since errors can be easily fixed with `yarn run lint --fix`.

/hold
for feedback

/cc @alecmerdler @benjaminapetersen @TheRealJon @rhamilto 
and anyone else :)