### PR TITLE
Monitoring: Change sort by state to sort logically instead of alphabetically

### DIFF
--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -191,7 +191,7 @@ const filterPropType = (props, propName, componentName) => {
 };
 
 const sorts = {
-  alertState,
+  alertStateOrder: alert => ['firing', 'silenced', 'pending', 'not-firing'].indexOf(alertState(alert)),
   daemonsetNumScheduled: daemonset => _.toInteger(_.get(daemonset, 'status.currentNumberScheduled')),
   dataSize: resource => _.size(_.get(resource, 'data')),
   ingressValidHosts,
@@ -209,6 +209,7 @@ const sorts = {
   podPhase,
   podReadiness,
   serviceClassDisplayName,
+  silenceStateOrder: silence => ['active', 'pending', 'expired'].indexOf(silenceState(silence)),
   string: val => JSON.stringify(val),
 };
 

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -14,6 +14,7 @@ import {
   WindowScroller,
 } from 'react-virtualized';
 
+import { AlertStates, SilenceStates } from '../../monitoring';
 import { UIActions } from '../../ui/ui-actions';
 import { ingressValidHosts } from '../ingress';
 import { alertState, silenceState } from '../monitoring';
@@ -191,7 +192,7 @@ const filterPropType = (props, propName, componentName) => {
 };
 
 const sorts = {
-  alertStateOrder: alert => ['firing', 'silenced', 'pending', 'not-firing'].indexOf(alertState(alert)),
+  alertStateOrder: alert => [AlertStates.Firing, AlertStates.Silenced, AlertStates.Pending, AlertStates.NotFiring].indexOf(alertState(alert)),
   daemonsetNumScheduled: daemonset => _.toInteger(_.get(daemonset, 'status.currentNumberScheduled')),
   dataSize: resource => _.size(_.get(resource, 'data')),
   ingressValidHosts,
@@ -209,7 +210,7 @@ const sorts = {
   podPhase,
   podReadiness,
   serviceClassDisplayName,
-  silenceStateOrder: silence => ['active', 'pending', 'expired'].indexOf(silenceState(silence)),
+  silenceStateOrder: silence => [SilenceStates.Active, SilenceStates.Pending, SilenceStates.Expired].indexOf(silenceState(silence)),
   string: val => JSON.stringify(val),
 };
 

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -490,7 +490,7 @@ const AlertRow = ({obj}) => {
 
 const AlertHeader = props => <ListHeader>
   <ColHead {...props} className="col-xs-7" sortField="labels.alertname">Name</ColHead>
-  <ColHead {...props} className="col-xs-3" sortFunc="alertState">State</ColHead>
+  <ColHead {...props} className="col-xs-3" sortFunc="alertStateOrder">State</ColHead>
   <ColHead {...props} className="col-xs-2" sortField="labels.severity">Severity</ColHead>
 </ListHeader>;
 
@@ -622,7 +622,7 @@ const AlertsPage = withFallback(connect(monitoringRulesToProps)(AlertsPage_));
 
 const SilenceHeader = props => <ListHeader>
   <ColHead {...props} className="col-xs-7" sortField="name">Name</ColHead>
-  <ColHead {...props} className="col-xs-3" sortField="status.state">State</ColHead>
+  <ColHead {...props} className="col-xs-3" sortFunc="silenceStateOrder">State</ColHead>
   <ColHead {...props} className="col-xs-2">Silenced Alerts</ColHead>
 </ListHeader>;
 

--- a/frontend/public/monitoring.ts
+++ b/frontend/public/monitoring.ts
@@ -7,6 +7,19 @@ import * as _ from 'lodash-es';
 import { k8sBasePath } from './module/k8s/k8s';
 import { coFetchJSON } from './co-fetch';
 
+export const enum AlertStates {
+  Firing = 'firing',
+  Silenced = 'silenced',
+  Pending = 'pending',
+  NotFiring = 'not-firing',
+}
+
+export const enum SilenceStates {
+  Active = 'active',
+  Pending = 'pending',
+  Expired = 'expired',
+}
+
 export enum MonitoringRoutes {
   Prometheus = 'prometheus-k8s',
   AlertManager = 'alertmanager-main',
@@ -62,7 +75,7 @@ const stateToProps = (desiredURLs: string[], state) => {
 export const connectToURLs = (...urls) => connect(state => stateToProps(urls, state));
 
 // Determine if an Alert is silenced by a Silence (if all of the Silence's matchers match one of the Alert's labels)
-export const isSilenced = (alert, silence) => _.get(silence, 'status.state') === 'active' &&
+export const isSilenced = (alert, silence) => _.get(silence, 'status.state') === SilenceStates.Active &&
   _.every(silence.matchers, m => {
     const alertValue = _.get(alert.labels, m.name);
     return alertValue !== undefined &&

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -3,7 +3,7 @@ import { Map as ImmutableMap } from 'immutable';
 
 import { types } from './ui-actions';
 import { ALL_NAMESPACES_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, NAMESPACE_LOCAL_STORAGE_KEY } from '../const';
-import { isSilenced } from '../monitoring';
+import { AlertStates, isSilenced } from '../monitoring';
 import { legalNamePattern, getNamespace } from '../components/utils/link';
 
 export default (state, action) => {
@@ -72,8 +72,8 @@ export default (state, action) => {
         const silences = state.getIn(['monitoring', 'silences'], {}).data;
 
         _.each(_.get(alerts, 'data.asAlerts'), a => {
-          if (a.state === 'firing' && _.some(silences, s => isSilenced(a, s))) {
-            a.state = 'silenced';
+          if (a.state === AlertStates.Firing && _.some(silences, s => isSilenced(a, s))) {
+            a.state = AlertStates.Silenced;
           }
         });
         state = state.setIn(['monitoring', 'rules'], alerts);


### PR DESCRIPTION
Clicking the list page STATE column heading was sorting the column alphabetically. This changes it to sort logically:
  - Firing > Silenced > Pending > Not Firing for Alerts
  - Active > Pending > Expired for Silences

Also refactor by adding `AlertStates` and `SilenceStates` `enums`.