### PR TITLE
Monitoring: Store which Silences affect which Alerts in Redux

### DIFF
--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -206,6 +206,7 @@ const sorts = {
   },
   nodeUpdateStatus: node => _.get(containerLinuxUpdateOperator.getUpdateStatus(node), 'text'),
   numReplicas: resource => _.toInteger(_.get(resource, 'status.replicas')),
+  numSilencedAlerts: silence => silence.silencedAlerts.length,
   planExternalName,
   podPhase,
   podReadiness,


### PR DESCRIPTION
This is more efficient because it means we only need to scan through the
Alerts and Silences to find matches when the data is updated, instead of
on each component render.

This also fixes the Silence list page's "SILENCED ALERTS" column to be
sortable.