### PR TITLE
Add Error Boundary for details pages

### DIFF
--- a/frontend/__tests__/components/factory/details.spec.tsx
+++ b/frontend/__tests__/components/factory/details.spec.tsx
@@ -14,7 +14,7 @@ describe(DetailsPage.displayName, () => {
   beforeEach(() => {
     const match = {params: {ns: 'default'}, isExact: true, path: '', url: ''};
 
-    wrapper = shallow(<DetailsPage match={match} name="test-name" namespace="default" kind={referenceForModel(PodModel)} pages={[]} />);
+    wrapper = shallow(<DetailsPage match={match} name="test-name" namespace="default" kind={referenceForModel(PodModel)} pages={[]} />).childAt(0).shallow();
   });
 
   it('renders a `Firehose` using the given props', () => {

--- a/frontend/public/components/error.tsx
+++ b/frontend/public/components/error.tsx
@@ -68,7 +68,7 @@ export const ErrorBoundaryFallback: React.SFC<ErrorBoundaryFallbackProps> = (pro
   <div className="co-m-pane__body">
     <h1 className="co-m-pane__heading co-m-pane__heading--center">Oh no! Something went wrong.</h1>
     <div className="row">
-      <ExpandCollapse textCollapsed="Show error details..." textExpanded="Hide error details..." bordered={false}>
+      <ExpandCollapse textCollapsed="Show Details" textExpanded="Hide Details" bordered={false}>
         <h3 className="co-section-heading-tertiary">{props.title}</h3>
         <div className="form-group">
           <label htmlFor="description">Description: </label>

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -6,6 +6,8 @@ import * as _ from 'lodash-es';
 
 import { Firehose, HorizontalNav, PageHeading } from '../utils';
 import { K8sResourceKindReference, K8sResourceKind } from '../../module/k8s';
+import { withFallback } from '../utils/error-boundary';
+import { ErrorBoundaryFallback } from '../error';
 
 export type FirehoseResource = {
   kind: K8sResourceKindReference;
@@ -18,7 +20,7 @@ export type FirehoseResource = {
   prop: string;
 };
 
-export const DetailsPage: React.SFC<DetailsPageProps> = (props) => <Firehose resources={[{
+export const DetailsPage = withFallback<DetailsPageProps>((props) => <Firehose resources={[{
   kind: props.kind,
   name: props.name,
   namespace: props.namespace,
@@ -40,7 +42,7 @@ export const DetailsPage: React.SFC<DetailsPageProps> = (props) => <Firehose res
     match={props.match}
     label={props.label || (props.kind as any).label}
     resourceKeys={_.map(props.resources, 'prop')} />
-</Firehose>;
+</Firehose>, ErrorBoundaryFallback);
 
 type Page = {
   href: string;


### PR DESCRIPTION
Addressing jira story: https://jira.coreos.com/browse/CONSOLE-536 

When a js issue occurs, prevent the white screen and use the new ErrorBoundaryFallback component to show an Oh no... message, the description of the error, and provide the available traces from the componentDidCatch Error Boundary class.

The details and the list pages now have error boundaries, and they will only provide an error component on the affected component lowest in the stack so that only error'd components will output the FallbackComponent, and components without issue will display properly if mixed on the same page. See the screenshot below. 

![screen shot 2018-11-13 at 5 26 27 pm](https://user-images.githubusercontent.com/35978579/48447714-b3916500-e76a-11e8-8b8f-e4faa1a1735a.png)

![screen shot 2018-11-13 at 5 26 46 pm](https://user-images.githubusercontent.com/35978579/48447717-b8561900-e76a-11e8-99dc-e5322516eb71.png)

![screen shot 2018-11-13 at 5 27 19 pm](https://user-images.githubusercontent.com/35978579/48447722-bbe9a000-e76a-11e8-841c-d4029d025c35.png)
