### PR TITLE
Redirect to project overview when creating a project

### DIFF
--- a/frontend/integration-tests/tests/base.scenario.ts
+++ b/frontend/integration-tests/tests/base.scenario.ts
@@ -39,7 +39,7 @@ describe('Basic console test', () => {
       await browser.wait(until.presenceOf($('.modal-body__field')));
       await $$('.modal-body__field').get(0).$('input').sendKeys(testName);
       await $('.modal-content').$('#confirm-action').click();
-      await browser.wait(until.urlContains(`/${resource}/${testName}`), BROWSER_TIMEOUT);
+      await browser.wait(until.urlContains(`/${testName}`), BROWSER_TIMEOUT);
     }
 
     expect(browser.getCurrentUrl()).toContain(appHost);


### PR DESCRIPTION
This also fixes a bug when creating a namespace with a network policy
where we were incorrectly redirecting to the network policy page.

/assign @rhamilto 