### PR TITLE
Add "Application" and "Resource" overview groups

### DIFF
--- a/frontend/public/components/overview/project-overview.tsx
+++ b/frontend/public/components/overview/project-overview.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars, no-undef */
 import * as _ from 'lodash-es';
 import * as classnames from 'classnames';
 import * as React from 'react';
@@ -6,7 +7,6 @@ import { Link } from 'react-router-dom';
 import { ListView } from 'patternfly-react';
 
 import { Tooltip } from '../utils/tooltip';
-/* eslint-disable-next-line no-unused-vars */
 import { K8sResourceKind } from '../../module/k8s';
 import { UIActions } from '../../ui/ui-actions';
 import {
@@ -261,14 +261,12 @@ const ProjectOverviewList: React.SFC<ProjectOverviewListProps> = ({items, metric
 
 const ProjectOverviewGroup: React.SFC<ProjectOverviewGroupProps> = ({heading, items, metrics}) =>
   <div className="project-overview__group">
-    {heading && <h2 className="project-overview__group-heading">{heading}</h2>}
+    <h2 className="project-overview__group-heading">{heading}</h2>
     <ProjectOverviewList
       items={items}
       metrics={metrics}
     />
   </div>;
-
-
 
 export const ProjectOverview: React.SFC<ProjectOverviewProps> = ({groups, metrics}) =>
   <div className="project-overview">
@@ -282,7 +280,6 @@ export const ProjectOverview: React.SFC<ProjectOverviewProps> = ({groups, metric
     )}
   </div>;
 
-/* eslint-disable no-unused-vars, no-undef */
 type ControllerLinkProps = {
   controller: PodControllerOverviewItem;
 };
@@ -344,4 +341,3 @@ type ProjectOverviewProps = {
   groups: OverviewGroup[];
   metrics: any;
 };
-/* eslint-enable no-unused-vars, no-undef */


### PR DESCRIPTION
* Group by Application groups by either `app.kubernetes.io/part-of`, `app.kubernetes.io/name`, or `app` labels, depending what's set
* Group by Resource will group resources by their object kinds

Part of https://jira.coreos.com/browse/CONSOLE-913

/assign @TheRealJon 
@openshift/team-ux-review @sspeiche 

@TheRealJon I considered moving some of the overview components into separate modules, but I decided that would be better in a follow on.

![localhost_9000_overview_ns_brie-project 2](https://user-images.githubusercontent.com/1167259/48501280-e68b3580-e80a-11e8-9ba0-1e570ecc49b6.png)

![localhost_9000_overview_ns_brie-project](https://user-images.githubusercontent.com/1167259/48501288-ea1ebc80-e80a-11e8-882d-9405d3a73937.png)

![localhost_9000_overview_ns_brie-project 1](https://user-images.githubusercontent.com/1167259/48501313-facf3280-e80a-11e8-9489-5030255ab068.png)
