### PR TITLE
Don't open overview sidebar when clicking link inside list

### DIFF
--- a/frontend/public/components/overview/project-overview.tsx
+++ b/frontend/public/components/overview/project-overview.tsx
@@ -237,8 +237,22 @@ const ProjectOverviewListItem = connect<ProjectOverviewListItemPropsFromState, P
       <Status item={item} />
     </div>;
 
+    const onClick = (e: Event) => {
+      // Don't toggle details if clicking on a link inside the row.
+      const target = e.target as HTMLElement;
+      if (target.tagName.toLowerCase() === 'a') {
+        return;
+      }
+
+      if (isSelected) {
+        dismissDetails();
+      } else {
+        selectItem(uid);
+      }
+    };
+
     return <ListView.Item
-      onClick={() => (isSelected ? dismissDetails() : selectItem(uid))}
+      onClick={onClick}
       className={className}
       heading={heading}
       additionalInfo={[additionalInfo]}


### PR DESCRIPTION
Fixes a bug where clicking on a overview link, then clicking back, returns with the details sidebar in a different state.