### PR TITLE
Fix preselected items in ListDropdown

### DIFF
--- a/frontend/public/components/utils/list-dropdown.jsx
+++ b/frontend/public/components/utils/list-dropdown.jsx
@@ -49,7 +49,7 @@ class ListDropdown_ extends React.Component {
       return;
     }
     const state = {};
-    const { resources, dataFilter, selectedKey } = nextProps;
+    const { resources, dataFilter } = nextProps;
 
     state.items = {};
     _.each(resources, ({data}, kindLabel) => {
@@ -61,8 +61,9 @@ class ListDropdown_ extends React.Component {
       }, state.items);
     });
 
+    const { selectedKey } = this.state;
     // did we switch from !loaded -> loaded ?
-    if (!this.props.loaded || !selectedKey) {
+    if (!this.props.loaded && !selectedKey) {
       state.title = <span className="text-muted">{nextProps.placeholder}</span>;
     }
 


### PR DESCRIPTION
@zherman0 FYI, the change in #654 broke the dropdown in some places. I'm reverting that for now.

This will break the "Clear Selection" link in the Create PVC form, but I know you were going to move away from `ListDropdown`, correct? If not, we should add a clear option directly as a prop to `ListDropdown` so it can manage its own state and we handle it consistently everywhere.

/cc @zherman0 @rhamilto 