### PR TITLE
Remove noButton option from dropdown to fix accessibility issue

### DIFF
--- a/frontend/integration-tests/views/namespace.view.ts
+++ b/frontend/integration-tests/views/namespace.view.ts
@@ -2,4 +2,4 @@ import { $$ } from 'protractor';
 
 export const namespaceSelector = $$('.co-namespace-selector');
 
-export const selectedNamespace = $$('.co-namespace-selector .dropdown .dropdown__not-btn .dropdown__not-btn__title').first();
+export const selectedNamespace = $$('.co-namespace-selector .dropdown .btn-link .btn-link__title').first();

--- a/frontend/integration-tests/views/search.view.ts
+++ b/frontend/integration-tests/views/search.view.ts
@@ -2,7 +2,7 @@ import { $, $$, browser, by, element, ExpectedConditions as until } from 'protra
 
 const BROWSER_TIMEOUT = 15000;
 
-export const dropdown = $('.btn-dropdown__content-wrap');
+export const dropdown = $('.co-type-selector .btn-dropdown');
 export const dropdownLinks = $$('.dropdown-menu a');
 export const labelFilter = $('.co-m-selector-input input');
 export const linkForType = type => element(by.partialLinkText(type));

--- a/frontend/public/components/_cluster-picker.scss
+++ b/frontend/public/components/_cluster-picker.scss
@@ -1,26 +1,28 @@
 .cluster-picker {
   background-color: $color-os-nav-active;
   border-radius: 1px;
-  color: $color-os-nav-title;
   margin: 7px 10px;
-  padding: 2px 0 2px 10px;
 
   .dropdown {
-    .dropdown__not-btn {
-      white-space: nowrap;
-      text-overflow: ellipsis;
+    .btn-link {
+      color: $color-os-nav-title;
       overflow: hidden;
-      padding-right: 20px;
+      padding: 2px 20px 2px 10px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      width: 100%;
+      &:focus,
+      &:hover {
+        text-decoration: none;
+      }
       .caret {
         position: absolute;
         right: 9px;
-        top: 6px;
+        top: 9px;
       }
     }
     ul.dropdown-menu {
       box-shadow: 0 2px 4px rgba(0,0,0,0.175);
-      margin-left: -10px;
-      margin-top: 2px;
       min-width: 200px;
       @media(max-width: $grid-float-breakpoint-max) {
         width: 200px;
@@ -39,6 +41,7 @@
           }
           &:hover {
             background-color: $color-os-nav-hover;
+            border-color: $color-os-nav-hover;
           }
         }
       }

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -23,10 +23,6 @@ $color-bookmarker: #DDD;
   cursor: not-allowed;
 }
 
-.dropdown__not-btn {
-  cursor: pointer;
-}
-
 .dropdown-menu__divider {
   height: 1px;
   margin: 9px 0;
@@ -139,9 +135,8 @@ $color-bookmarker: #DDD;
 
 .co-namespace-bar {
   background-color: #292E34;
-  color: $color-os-nav-title;
   height: $co-namespace-selector-mobile;
-  padding-right: 15px;
+  padding: 0 15px;
   white-space: nowrap;
 
   @media (min-width: $grid-float-breakpoint) {
@@ -150,42 +145,40 @@ $color-bookmarker: #DDD;
   }
 
   &__dropdowns {
-    align-items: baseline;
     display: flex;
     justify-content: space-between;
+
+    .btn-link {
+      padding: 4px 0 2px !important;
+
+      @media(min-width: $grid-float-breakpoint) {
+        padding-bottom: 7px !important;
+        padding-top: 12px !important;
+      }
+    }
   }
 }
 
 .co-namespace-selector {
-  font-size: ($font-size-base + 1);
-  max-width: 80%;
+  max-width: 75%;
 
-  @media (min-width: $grid-float-breakpoint) {
-    font-size: ($font-size-base + 3);
-  }
-
-  .dropdown__not-btn {
-    align-items: baseline;
-    display: flex;
-    padding: 2px 15px;
+  .btn-link {
+    font-size: ($font-size-base + 1);
+    padding: 2px 0 !important;
 
     @media (min-width: $grid-float-breakpoint) {
-      padding: 7px 15px;
+      font-size: ($font-size-base + 3);
+      padding-bottom: 7px !important;
+      padding-top: 7px !important;
     }
 
-    &__title {
-      flex: 0 1 auto;
-      margin-left: 10px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+    &__titlePrefix {
+      margin-right: 6px;
     }
   }
 }
 
 .co-namespace-selector__menu.dropdown-menu {
-  left: 15px;
-  margin-top: 0;
   max-height: calc(100vh - (#{$masthead-height-mobile} + #{$co-namespace-selector-mobile}));
   max-width: 100%;
   min-width: 210px;
@@ -290,7 +283,7 @@ $color-bookmarker: #DDD;
 }
 
 .btn-dropdown__content-wrap {
-  align-items: center;
+  align-items: baseline;
   display: flex;
   flex: 1 1 auto;
   justify-content: space-between;

--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -33,9 +33,6 @@
       display: block;
     }
   }
-  &__help-icon {
-    margin: 0 2px 0 5px;
-  }
   &__logo {
     align-items: center;
     display: flex;
@@ -81,12 +78,8 @@
       align-items: baseline;
       display: flex;
     }
-    .dropdown__not-btn,
-    .dropdown__not-btn__title {
-      align-items: baseline;
-      display: flex;
-    }
     .no-dropdown {
+      cursor: default !important; // override pf style
       line-height: normal !important; // override pf style
       &:hover,
       &:focus {
@@ -114,6 +107,20 @@
   .co-actions-menu {
     padding: 0;
     margin: 0;
+  }
+}
+
+.co-masthead,
+.co-namespace-bar {
+  .btn-link {
+    border: 0;
+    color: $color-os-nav-title;
+    padding: 0;
+
+    &:focus,
+    &:hover {
+      text-decoration: none;
+    }
   }
 }
 

--- a/frontend/public/components/cluster-picker.tsx
+++ b/frontend/public/components/cluster-picker.tsx
@@ -40,7 +40,7 @@ const FirehoseToDropdown: React.SFC<FirehoseToDropdownProps> = ({clusters}) => {
   const spacerBefore = new Set([masterURL]);
   items[masterURL] = <div>Manage Cluster Directory…</div>;
 
-  return <Dropdown title="Clusters" items={items} selectedKey={selected} noButton={true} className="cluster-picker" menuClassName="dropdown--dark" onChange={url => window.location.href = url} spacerBefore={spacerBefore} />;
+  return <Dropdown title="Clusters" items={items} selectedKey={selected} className="cluster-picker" buttonClassName="btn-link" menuClassName="dropdown--dark" onChange={url => window.location.href = url} spacerBefore={spacerBefore} />;
 };
 
 const resources = [{

--- a/frontend/public/components/masthead.tsx
+++ b/frontend/public/components/masthead.tsx
@@ -80,8 +80,7 @@ class HelpMenu extends React.Component<{}, {}> {
         actions={[
           {label: 'Documentation', callback: this.openDocumentation},
           {label: 'About', callback: launchAboutModal}]}
-        buttonClassName="nav-item-iconic"
-        noButton
+        buttonClassName="btn-link nav-item-iconic"
         noCaret
         title={<i className="fa fa-question-circle-o co-masthead__help-icon" />} />
     </React.Fragment>;
@@ -98,9 +97,8 @@ const UserMenu: React.StatelessComponent<UserMenuProps> = ({username, actions}) 
   }
 
   return <ActionsMenu actions={actions}
-    buttonClassName="nav-item-iconic"
     title={title}
-    noButton={true} />;
+    buttonClassName="btn-link nav-item-iconic" />;
 };
 
 const UserMenuWrapper = connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.OPENSHIFT)((props: FlagsProps) => {

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -298,11 +298,11 @@ class NamespaceBarDropdowns_ extends React.Component {
       <Dropdown
         className="co-namespace-selector"
         menuClassName="co-namespace-selector__menu"
-        noButton
+        buttonClassName="btn-link"
         canFavorite
         items={items}
         titlePrefix={model.label}
-        title={title}
+        title={<span className="btn-link__title">{title}</span>}
         onChange={onChange}
         selectedKey={activeNamespace || ALL_NAMESPACES_KEY}
         autocompleteFilter={autocompleteFilter}
@@ -312,7 +312,7 @@ class NamespaceBarDropdowns_ extends React.Component {
         shortCut="n" />
       <ActionsMenu actions={addActions}
         title={<React.Fragment><span className="pficon pficon-add-circle-o co-add-actions-selector__icon" aria-hidden="true"></span> Add</React.Fragment>}
-        noButton={true}
+        buttonClassName="btn-link"
         menuClassName="co-add-actions-selector__menu dropdown-menu--right" />
     </div>;
   }

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -290,7 +290,7 @@ export class Dropdown extends DropdownMixin {
 
   render() {
     const {active, autocompleteText, selectedKey, items, title, bookmarks, keyboardHoverKey, favoriteKey} = this.state;
-    const {autocompleteFilter, autocompletePlaceholder, noButton, className, buttonClassName, menuClassName, storageKey, canFavorite, dropDownClassName, titlePrefix, describedBy, noCaret} = this.props;
+    const {autocompleteFilter, autocompletePlaceholder, className, buttonClassName, menuClassName, storageKey, canFavorite, dropDownClassName, titlePrefix, describedBy, noCaret} = this.props;
 
     const spacerBefore = this.props.spacerBefore || new Set();
     const headerBefore = this.props.headerBefore || {};
@@ -320,23 +320,15 @@ export class Dropdown extends DropdownMixin {
     //Adding `dropDownClassName` specifically to use patternfly's context selector component, which expects `bootstrap-select` class on the dropdown. We can remove this additional property if that changes in upcoming patternfly versions.
     return <div className={classNames(className)} ref={this.dropdownElement} style={this.props.style}>
       <div className={classNames('dropdown', dropDownClassName, {'open': active})}>
-        {
-          noButton
-            ? <div role="button" tabIndex="0" onClick={this.toggle} onKeyDown={this.onKeyDown} className={classNames('dropdown__not-btn', buttonClassName)} id={this.props.id}>
-              {titlePrefix && `${titlePrefix}: `}
-              <span className="dropdown__not-btn__title">{title}</span>&nbsp;
-              {noCaret ? null : <Caret />}
-            </div>
-            : <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('btn', 'btn-dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id} aria-describedby={describedBy} >
-              <div className="btn-dropdown__content-wrap">
-                <span className="btn-dropdown__item">
-                  {titlePrefix && `${titlePrefix}: `}
-                  {title}
-                </span>
-                {noCaret ? null : <Caret />}
-              </div>
-            </button>
-        }
+        <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('btn', 'btn-dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id} aria-describedby={describedBy} >
+          <div className="btn-dropdown__content-wrap">
+            <span className="btn-dropdown__item">
+              {titlePrefix && <span className="btn-link__titlePrefix">{titlePrefix}: </span>}
+              {title}
+            </span>
+            {noCaret ? null : <Caret />}
+          </div>
+        </button>
         {
           active && <ul role="listbox" ref={this.dropdownList} className={classNames('dropdown-menu', 'dropdown-menu--block', menuClassName)}>
             {
@@ -375,7 +367,7 @@ Dropdown.propTypes = {
   headerBefore: PropTypes.objectOf(PropTypes.string),
   items: PropTypes.object.isRequired,
   menuClassName: PropTypes.string,
-  noButton: PropTypes.bool,
+  buttonClassName: PropTypes.string,
   noSelection: PropTypes.bool,
   storageKey: PropTypes.string,
   spacerBefore: PropTypes.instanceOf(Set),
@@ -384,7 +376,7 @@ Dropdown.propTypes = {
 };
 
 export const ActionsMenu = (props) => {
-  const {actions, buttonClassName, title = undefined, menuClassName = undefined, noButton, noCaret = false} = props;
+  const {actions, title = undefined, menuClassName = undefined, buttonClassName = undefined, noCaret = false} = props;
   const shownActions = _.reject(actions, o => _.get(o, 'hidden', false));
   const items = _.fromPairs(_.map(shownActions, (v, k) => [k, v.label]));
   const btnTitle = title || <span id="action-dropdown">Actions</span>;
@@ -405,7 +397,6 @@ export const ActionsMenu = (props) => {
     title={btnTitle}
     onChange={onChange}
     noSelection={true}
-    noButton={noButton}
     noCaret={noCaret} />;
 };
 
@@ -417,9 +408,8 @@ ActionsMenu.propTypes = {
       callback: PropTypes.func,
     })).isRequired,
   menuClassName: PropTypes.string,
-  noButton: PropTypes.bool,
-  noCaret: PropTypes.bool,
   title: PropTypes.node,
+  noCaret: PropTypes.bool,
 };
 
 const containerLabel = (container) =>


### PR DESCRIPTION
Fixes bug where dropdowns without buttons (e.g., namespace picker) do not open on press of Enter key.