### PR TITLE
Remove user input for Volume Name and auto generate instead

### DIFF
--- a/frontend/public/components/storage/attach-storage.tsx
+++ b/frontend/public/components/storage/attach-storage.tsx
@@ -187,6 +187,7 @@ class AttachStorageForm extends React.Component<
 
   onPVCChange = newPVCObj => {
     this.setState({ newPVCObj });
+    this.updateVolumeName(_.get(newPVCObj, 'metadata.name', ''));
   };
 
   isContainerSelected = ({ name }) => {
@@ -220,8 +221,6 @@ class AttachStorageForm extends React.Component<
     const { kindObj, name, namespace } = this.props;
     const {
       claimName,
-      volumeName,
-      volumeAlreadyMounted,
       mountPath,
       subPath,
       inProgress,
@@ -240,13 +239,7 @@ class AttachStorageForm extends React.Component<
           <h1 className="co-m-pane__heading">{title}</h1>
           {kindObj && (
             <div className="co-m-pane__explanation">
-              Add a persistent volume claim to&nbsp;
-              <ResourceLink
-                kind={kindObj.kind}
-                name={name}
-                namespace={namespace}
-              />
-              .
+              Add a persistent volume claim to <ResourceLink inline kind={kindObj.kind} name={name} namespace={namespace} />
             </div>
           )}
           <label className="control-label co-required" >
@@ -288,28 +281,6 @@ class AttachStorageForm extends React.Component<
 
           {this.state.showCreatePVC === 'new' && <div className="co-form-subsection"><CreatePVCForm onChange={this.onPVCChange} namespace={this.props.namespace} /></div>}
 
-          <div className="form-group">
-            <label className="control-label co-required" htmlFor="volume-name">
-              Volume Name
-            </label>
-            <div>
-              <input
-                className="form-control"
-                type="text"
-                onChange={this.handleChange}
-                aria-describedby="volume-name-help"
-                id="volume-name"
-                name="volumeName"
-                value={volumeName}
-                pattern="[a-z0-9](?:[-a-z0-9]*[a-z0-9])?"
-                readOnly={volumeAlreadyMounted}
-                required
-              />
-              <p className="help-block" id="volume-name-help">
-                Unique name to identify this volume.
-              </p>
-            </div>
-          </div>
           <div className="form-group">
             <label className="control-label co-required" htmlFor="mount-path">
               Mount Path


### PR DESCRIPTION
Based on feedback, we have decided to remove the input of volume name from the user and auto generate the volume based on the pvc name.  Also, the mount path was required but there are some cases where a volume needs to be added even if there is not a volume mount.
UPDATE: Moved the required mount path change out of this PR and opened new ticket to track investigation.
![remove-volume-name-existingpvc](https://user-images.githubusercontent.com/18728857/48627126-fe7cc980-e970-11e8-8ae2-1e3bfd96e8ed.png)
![remove-volumename-newpvc](https://user-images.githubusercontent.com/18728857/48627114-f7ee5200-e970-11e8-99ac-0eb56c8b5cc0.png)
