### PR TITLE
Disable OLM tests in 3.11 branch

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -108,7 +108,6 @@ set +e
 builder_run 'Build' 0 1 ./build.sh
 builder_run 'Tests' 0 1 ./test.sh
 builder_run 'GUI-Tests' 1 1 ./test-gui.sh crud
-builder_run 'GUI-Tests-OLM' 1 0 ./test-gui.sh olm
 
 status 'Performance' 'pending'
 if DOCKER_ENV="KUBECONFIG" ./builder-run.sh ./test-gui.sh performance


### PR DESCRIPTION
These test always fail since the shared cluster is running the latest OLM version, which is not API compatible. Disable the tests for now to unblock merges.

Needed to unblock #777

@alecmerdler Let me know if you object. I'm not sure how else to address this in the short term.

/assign @alecmerdler 
@petr-muller  @sosiouxme fyi