### PR TITLE
Only add 'open' to .dropdown className if 'nav-item-iconic'

### DIFF
--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -319,7 +319,7 @@ export class Dropdown extends DropdownMixin {
 
     //Adding `dropDownClassName` specifically to use patternfly's context selector component, which expects `bootstrap-select` class on the dropdown. We can remove this additional property if that changes in upcoming patternfly versions.
     return <div className={classNames(className)} ref={this.dropdownElement} style={this.props.style}>
-      <div className={classNames('dropdown', dropDownClassName, {'open': active})}>
+      <div className={classNames('dropdown', dropDownClassName, {'open': active && _.includes(buttonClassName, 'nav-item-iconic')})}>
         <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('btn', 'btn-dropdown', 'dropdown-toggle', buttonClassName ? buttonClassName : 'btn-default')} id={this.props.id} aria-describedby={describedBy} >
           <div className="btn-dropdown__content-wrap">
             <span className="btn-dropdown__item">


### PR DESCRIPTION
#722 added `open` to dropdowns when they are active in order to get the correct styling of the masthead dropdown toggles.  However, this resulted in a bug where non-masthead dropdown toggles have the incorrect background color when the dropdown is open.

Before:
![screen shot 2018-11-19 at 4 42 05 pm](https://user-images.githubusercontent.com/895728/48736875-89ccb800-ec1a-11e8-87d9-ede03c67a6d9.png)

After:
![screen shot 2018-11-19 at 4 42 11 pm](https://user-images.githubusercontent.com/895728/48736884-8e916c00-ec1a-11e8-8005-df88186af0e7.png)

FYI @rebeccaalpert 