### PR TITLE
Accept any node for ActionsMenu label

### DIFF
--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -403,7 +403,7 @@ export const ActionsMenu = (props) => {
 ActionsMenu.propTypes = {
   actions: PropTypes.arrayOf(
     PropTypes.shape({
-      label: PropTypes.string.isRequired,
+      label: PropTypes.node.isRequired,
       href: PropTypes.string,
       callback: PropTypes.func,
     })).isRequired,


### PR DESCRIPTION
Namespace `default` adds a disabled menu item, which causes prop types errors since the label prop type is a string.

/assign @TheRealJon 