### PR TITLE
Fix bug where mobile Logout nav section had expand indicator

### DIFF
--- a/frontend/public/components/masthead.tsx
+++ b/frontend/public/components/masthead.tsx
@@ -124,11 +124,6 @@ const UserMenuWrapper = connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.OPENSHIFT)((pro
     return <OSUserMenu actions={actions} />;
   }
 
-  actions.unshift({
-    label: 'My Account',
-    href: '/settings/profile',
-  });
-
   return authSvc.userID() ? <UserMenu actions={actions} username={authSvc.name()} /> : null;
 });
 

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -248,7 +248,7 @@ const NavSection = connect(navSectionStateToProps)(
               : <Link className="navigation-container__section__title__link" to={href} onClick={this.open}>{text}</Link>
             }
           </div>
-          <i className={classNames('icon fa fa-angle-right', isOpen ? 'navigation-container__section--open' : '')} aria-hidden="true" />
+          {children && <i className={classNames('icon fa fa-angle-right', isOpen ? 'navigation-container__section--open' : '')} aria-hidden="true" />}
         </div>
         {Children && <ul className={classNames('navigation-container__list', {'navigation-container__list--open': isOpen})} style={{maxHeight}}>{Children}</ul>}
       </div>;
@@ -280,7 +280,7 @@ const MonitoringNavSection_ = ({urls, closeMenu}) => {
 };
 const MonitoringNavSection = connectToURLs(MonitoringRoutes.Prometheus, MonitoringRoutes.Grafana)(MonitoringNavSection_);
 
-const UserNavSection = connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.OPENSHIFT)(({flags, closeMenu}) => {
+const UserNavSection = connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.OPENSHIFT)(({flags}) => {
   if (!flags[FLAGS.AUTH_ENABLED] || flagPending(flags[FLAGS.OPENSHIFT])) {
     return null;
   }
@@ -294,14 +294,7 @@ const UserNavSection = connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.OPENSHIFT)(({fla
     }
   };
 
-  if (flags[FLAGS.OPENSHIFT]) {
-    return <NavSection text="Logout" icon="pficon pficon-user" klass="visible-xs-block" onClick={logout} />;
-  }
-
-  return <NavSection text="User" icon="pficon pficon-user" klass="visible-xs-block">
-    <HrefLink href="/settings/profile" name="My Account" onClick={closeMenu} key="myAccount" />
-    <HrefLink href="#" name="Logout" onClick={logout} key="logout" />
-  </NavSection>;
+  return <NavSection text="Logout" icon="pficon pficon-user" klass="visible-xs-block" onClick={logout} />;
 });
 
 export class Nav extends React.Component {


### PR DESCRIPTION
And remove orphaned links to /settings/profile.

Before:
![screen shot 2018-11-20 at 2 12 42 pm](https://user-images.githubusercontent.com/895728/48798296-53eb0a80-ecd2-11e8-9909-1ff51c6ab82e.png)

After:
![screen shot 2018-11-20 at 2 44 12 pm](https://user-images.githubusercontent.com/895728/48798499-c65bea80-ecd2-11e8-9aaa-753afebab755.png)

