### PR TITLE
Add units utilities for comparing resource quota values

### DIFF
--- a/frontend/public/components/cluster-health.jsx
+++ b/frontend/public/components/cluster-health.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 
-import { humanizeCPU, humanizeMem, PageHeading } from './utils';
+import { humanizeMem, humanizeNumber, PageHeading } from './utils';
 import { Bar, Gauge, Line, Scalar } from './graphs';
 
 const multiLoadQueries = [
@@ -65,7 +65,7 @@ export const ClusterHealth = () => <div>
         <Line title="Cluster Load Average" query={multiLoadQueries} />
       </div>
       <div className="col-lg-3 col-md-6">
-        <Bar title="CPU Usage by Namespace" query={'sort(topk(10, sum by (namespace) (namespace:container_cpu_usage:sum)))'} humanize={humanizeCPU} metric="namespace" />
+        <Bar title="CPU Usage by Namespace" query={'sort(topk(10, sum by (namespace) (namespace:container_cpu_usage:sum)))'} humanize={humanizeNumber} metric="namespace" />
       </div>
     </div>
     <div className="row">
@@ -130,10 +130,10 @@ export const ClusterHealth = () => <div>
     </div>
     <div className="row">
       <div className="col-lg-9">
-        <Bar title="API Writes Req/sec (Top 10 Clients)" query={'sort(topk(10, sum by (client)(rate(apiserver_request_count{verb!="GET", verb!="LIST", verb!="WATCH"}[5m]))))'} humanize={humanizeCPU} metric="client" />
+        <Bar title="API Writes Req/sec (Top 10 Clients)" query={'sort(topk(10, sum by (client)(rate(apiserver_request_count{verb!="GET", verb!="LIST", verb!="WATCH"}[5m]))))'} humanize={humanizeNumber} metric="client" />
       </div>
       <div className="col-lg-9">
-        <Bar title="API Reads Req/sec (Top 10 Clients)" query={'sort(topk(10, sum by (client)(rate(apiserver_request_count{verb!="POST", verb!="PUT", verb!="PATCH"}[5m]))))'} humanize={humanizeCPU} metric="client" />
+        <Bar title="API Reads Req/sec (Top 10 Clients)" query={'sort(topk(10, sum by (client)(rate(apiserver_request_count{verb!="POST", verb!="PUT", verb!="PATCH"}[5m]))))'} humanize={humanizeNumber} metric="client" />
       </div>
       <div className="col-lg-9">
         <Bar title="Top 10 Pod Memory" query={'sort(topk(10, sum by (pod_name) (container_memory_usage_bytes{pod_name!=""})))'} humanize={humanizeMem} metric="pod_name" />

--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -19,6 +19,11 @@ const TYPES = {
     space: true,
     divisor: 1000,
   },
+  decimalBytesWithoutB: {
+    units: ['', 'k', 'M', 'G', 'T', 'P', 'E'],
+    space: true,
+    divisor: 1000,
+  },
   binaryBytes: {
     units: ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'],
     space: true,
@@ -138,7 +143,6 @@ const humanize = units.humanize = (value, typeName, useRound = false) => {
 };
 
 export const humanizeMem = v => humanize(v, 'binaryBytes', true).string;
-export const humanizeCPU = v => humanize(v, 'numeric', true).string;
 export const humanizeNumber = v => humanize(v, 'numeric', true).string;
 
 units.dehumanize = (value, typeName) => {
@@ -176,7 +180,7 @@ const validateNumber = (float='') => {
     return 'must be a number';
   }
 };
-const validCPUUnits = new Set(['p', 'm', 'c', 'd', 'n', 'K', 'M', 'G']);
+const validCPUUnits = new Set(['m', '']);
 const validateCPUUnit = (value='') => {
   if (validCPUUnits.has(value)) {
     return;
@@ -254,4 +258,40 @@ validate.memory = (value='') => {
   return validateNumber(number) || validateMemUnit(unit);
 };
 
+// Convert k8s compute resources values to a base value for comparison.
+// If the value has no unit, it just returns the number, so this function
+// can be used for any quota resource (resource counts). `units.dehumanize`
+// is problematic for comparing quota resources because you need to know
+// what unit you're dealing with already (e.g. decimal vs binary). Returns
+// null if value isn't recognized as valid.
+export const convertToBaseValue = (value) => {
+  if (!_.isString(value)) {
+    return null;
+  }
 
+  const [number, unit] = validate.split(value);
+  const validationError = validateNumber(number);
+  if (validationError) {
+    return null;
+  }
+
+  if (!unit) {
+    return number;
+  }
+
+  // Handle CPU millicores specifically.
+  if (unit === 'm') {
+    return number / 1000;
+  }
+
+  if (TYPES.binaryBytesWithoutB.units.includes(unit)) {
+    return units.dehumanize(value, 'binaryBytesWithoutB').value;
+  }
+
+  if (TYPES.decimalBytesWithoutB.units.includes(unit)) {
+    return units.dehumanize(value, 'decimalBytesWithoutB').value;
+  }
+
+  // Unrecognized unit.
+  return null;
+};


### PR DESCRIPTION
/assign @dtaylor113 

@dtaylor113 You should be able to use this for comparing quota usage without needing to know the unit type. This should also correctly handle CPU values.