### PR TITLE
Monitoring: Fix key attribute for Silence matchers

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -163,7 +163,7 @@ const Label = ({k, v}) => <div className="co-m-label co-m-label--expand" key={k}
 </div>;
 
 const SilenceMatchersList = ({silence}) => <div className={`co-text-${SilenceResource.kind.toLowerCase()}`}>
-  {_.map(silence.matchers, ({name, isRegex, value}) => <Label key={name} k={name} v={isRegex ? `~${value}` : value} />)}
+  {_.map(silence.matchers, ({name, isRegex, value}, i) => <Label key={i} k={name} v={isRegex ? `~${value}` : value} />)}
 </div>;
 
 const alertStateToProps = (state): AlertsDetailsPageProps => {


### PR DESCRIPTION
It is possible for two matchers to have the same name, so we can't use
this as the key. Alertmanager actually allows two matchers to have both
the same name and the same value, so even a combination of both would
not be sufficient.