### PR TITLE
Fix StorageClass default status under cluster-console overview

### DIFF
--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -11,7 +11,7 @@ export const StorageClassReference: K8sResourceKindReference = 'StorageClass';
 const { common } = Kebab.factory;
 const menuActions = [...common];
 
-const defaultClassAnnotation = 'storageclass.beta.kubernetes.io/is-default-class';
+const defaultClassAnnotation = 'storageclass.kubernetes.io/is-default-class';
 const isDefaultClass = (storageClass: K8sResourceKind) => _.get(storageClass, ['metadata', 'annotations', defaultClassAnnotation], 'false');
 
 const StorageClassHeader = props => <ListHeader>


### PR DESCRIPTION
### Problem
The OpenShift Cluster Console shows the overview of StorageClasses under the Storage section. If a storage class is set as default (using the _storageclass.kubernetes.io/is-default-class = "true"_) the view does not update the status and keeps reporting "false".

### Cause
This issue happens because the file _frontend/public/components/storage-class.tsx_ defines the annotation key put in the variable **defaultClassAnnotation**. This annotation is defined here as _storageclass.beta.kubernetes.io/is-default-class._

### Extra Notes
The annotation _storageclass.kubernetes.io/is-default-class = "true"_ is set in the Ansible installation by the **openshift_storage_glusterfs** role.