### PR TITLE
Fix error handling in storage class creation

### DIFF
--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -521,7 +521,9 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
     runValidation ? this.setState({newStorageClass: newParams}, this.validateForm) : this.setState({newStorageClass: newParams});
   };
 
-  createStorageClass = () => {
+  createStorageClass = (e: React.FormEvent<EventTarget>) => {
+    e.preventDefault();
+
     this.setState({
       loading: true,
     });
@@ -836,7 +838,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
               className="btn btn-primary"
               id="save-changes"
               disabled={!this.state.validationSuccessful}
-              onClick={() => this.createStorageClass()}>
+              onClick={this.createStorageClass}>
               Create
             </button>
             <button


### PR DESCRIPTION
**Problem:**
The storage class form page would clear and reload when attempting to create a storage class in Firefox. Any errors were only displayed for less than a second. In Chrome, the user was correctly redirected to the storage class list page when a storage class was successfully created. However, they were also redirected to the list page when creation failed and any errors were only displayed for less than a second, as well.

**Solution:**
Event handling in the creation method was causing the inconsistent behavior. Calling preventDefault() on the event corrects the issue.

**Bugzilla Ticket:** 
https://bugzilla.redhat.com/1642311