### PR TITLE
Avoid unnecessary project lists for cluster readers

### DIFF
--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -19,7 +19,7 @@ const defaultDeny = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  setProjectsAvailable: () => setFlag(dispatch, FLAGS.PROJECTS_AVAILABLE, true),
+  hideStartGuide: () => setFlag(dispatch, FLAGS.SHOW_OPENSHIFT_START_GUIDE, false),
 });
 
 const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNamespaceModal extends PromiseComponent {
@@ -50,7 +50,7 @@ const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNames
   }
 
   createProject() {
-    const {setProjectsAvailable} = this.props;
+    const {hideStartGuide} = this.props;
     const {name, displayName, description} = this.state;
     const project = {
       metadata: {
@@ -60,8 +60,9 @@ const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNames
       description,
     };
     return k8sCreate(ProjectRequestModel, project).then(obj => {
-      // Immediately update the projects available flag to avoid the empty state message from displaying when projects watch is slow.
-      setProjectsAvailable();
+      // Immediately update the start guide flag to avoid the empty state
+      // message from displaying when projects watch is slow.
+      hideStartGuide();
       return obj;
     });
   }

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -248,8 +248,8 @@ class NamespaceBarDropdowns_ extends React.Component {
   componentDidUpdate() {
     const { namespace, dispatch } = this.props;
     if (namespace.loaded) {
-      const projectsAvailable = !_.isEmpty(namespace.data);
-      setFlag(dispatch, FLAGS.PROJECTS_AVAILABLE, projectsAvailable);
+      const noProjects = _.isEmpty(namespace.data);
+      setFlag(dispatch, FLAGS.SHOW_OPENSHIFT_START_GUIDE, noProjects);
     }
   }
 

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -414,7 +414,7 @@ export class Nav extends React.Component {
           <NavSection text="Storage" icon="pficon pficon-container-node">
             <ResourceClusterLink resource="persistentvolumes" name="Persistent Volumes" onClick={this.close} required={FLAGS.CAN_LIST_PV} />
             <ResourceNSLink resource="persistentvolumeclaims" name="Persistent Volume Claims" onClick={this.close} />
-            <ResourceClusterLink resource="storageclasses" name="Storage Classes" onClick={this.close} required={FLAGS.CAN_LIST_STORE} />
+            <ResourceClusterLink resource="storageclasses" name="Storage Classes" onClick={this.close} />
           </NavSection>
 
           <NavSection text="Builds" icon="pficon pficon-build" required={FLAGS.OPENSHIFT}>

--- a/frontend/public/components/search.jsx
+++ b/frontend/public/components/search.jsx
@@ -21,8 +21,8 @@ import {
   SelectorInput,
 } from './utils';
 
-const ResourceList = connectToModel(({kindObj, kindsInFlight, mock, namespace, selector}) => {
-  if (!kindObj && kindsInFlight) {
+const ResourceList = connectToModel(({kindObj, mock, namespace, selector}) => {
+  if (!kindObj) {
     return <LoadingBox />;
   }
 

--- a/frontend/public/components/start-guide.tsx
+++ b/frontend/public/components/start-guide.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import { createProjectMessageStateToProps } from '../ui/ui-reducers';
 import { SafetyFirst } from './safety-first';
 import { DocumentationSidebar, Disabled } from './utils';
-import { FLAGS, connectToFlags, flagPending } from '../features';
+import { FLAGS, connectToFlags } from '../features';
 import { ProjectModel, RoleModel, StorageClassModel } from '../models';
 
 const WHITELIST = [RoleModel.kind, StorageClassModel.kind];
@@ -70,7 +70,7 @@ export const OpenShiftGettingStarted = connect(createProjectMessageStateToProps)
 );
 
 export const withStartGuide = (WrappedComponent, doNotDisable: boolean = false) =>
-  connectToFlags(FLAGS.OPENSHIFT, FLAGS.PROJECTS_AVAILABLE)(
+  connectToFlags(FLAGS.SHOW_OPENSHIFT_START_GUIDE)(
     ({flags, ...rest}: any) => {
       const {kindObj} = rest;
       const kind = _.get(kindObj, 'kind', rest.kind);
@@ -80,11 +80,7 @@ export const withStartGuide = (WrappedComponent, doNotDisable: boolean = false) 
         return <WrappedComponent {...rest} />;
       }
 
-      if (flagPending(flags.OPENSHIFT) || flagPending(flags)) {
-        return null;
-      }
-
-      if (flags.OPENSHIFT && !flags.PROJECTS_AVAILABLE) {
+      if (flags.SHOW_OPENSHIFT_START_GUIDE) {
         return <React.Fragment>
           <StartGuide />
           {


### PR DESCRIPTION
If the user can list namespaces, avoid the expensive projects available flag check, which might return thousands of projects.

This also removes the `CAN_LIST_STORE` check because normal users can almost always list storage classes.

/assign @TheRealJon 