### PR TITLE
Add Label Selector for "Hiding" Certain OLM Packages

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
@@ -7,6 +7,7 @@ import { safeLoad } from 'js-yaml';
 
 import { CatalogSourceDetails, CatalogSourceDetailsProps, CatalogSourceDetailsPage, CatalogSourceDetailsPageProps, CreateSubscriptionYAML, CreateSubscriptionYAMLProps } from '../../../public/components/operator-lifecycle-manager/catalog-source';
 import { PackageManifestList } from '../../../public/components/operator-lifecycle-manager/package-manifest';
+import { visibilityLabel } from '../../../public/components/operator-lifecycle-manager';
 import { referenceForModel } from '../../../public/module/k8s';
 import { SubscriptionModel, CatalogSourceModel, PackageManifestModel } from '../../../public/models';
 import { DetailsPage } from '../../../public/components/factory';
@@ -51,7 +52,7 @@ describe(CatalogSourceDetailsPage.displayName, () => {
   });
 
   it('renders `DetailsPage` with correct props', () => {
-    const selector = {matchLabels: {catalog: match.params.name}};
+    const selector = {matchLabels: {catalog: match.params.name}, matchExpressions: [{key: visibilityLabel, operator: 'DoesNotExist'}]};
 
     expect(wrapper.find(DetailsPage).props().kind).toEqual(referenceForModel(CatalogSourceModel));
     expect(wrapper.find(DetailsPage).props().pages.map(p => p.name)).toEqual(['Overview', 'YAML']);

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -5,7 +5,7 @@ import { match } from 'react-router-dom';
 import * as _ from 'lodash-es';
 
 import { Firehose, HorizontalNav, PageHeading } from '../utils';
-import { K8sResourceKindReference, K8sResourceKind } from '../../module/k8s';
+import { K8sResourceKindReference, K8sResourceKind, Selector } from '../../module/k8s';
 import { withFallback } from '../utils/error-boundary';
 import { ErrorBoundaryFallback } from '../error';
 
@@ -14,9 +14,7 @@ export type FirehoseResource = {
   name?: string;
   namespace: string;
   isList?: boolean;
-  selector?: {
-    matchLabels?: {[label: string]: string};
-  };
+  selector?: Selector;
   prop: string;
 };
 

--- a/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
@@ -7,7 +7,7 @@ import { match } from 'react-router-dom';
 import { SectionHeading, Firehose, MsgBox, LoadingBox, Kebab, navFactory } from '../utils';
 import { withFallback } from '../utils/error-boundary';
 import { CreateYAML } from '../create-yaml';
-import { CatalogSourceKind, SubscriptionKind, PackageManifestKind } from './index';
+import { CatalogSourceKind, SubscriptionKind, PackageManifestKind, visibilityLabel } from './index';
 import { PackageManifestList } from './package-manifest';
 import { SubscriptionModel, CatalogSourceModel, PackageManifestModel } from '../../models';
 import { referenceForModel } from '../../module/k8s';
@@ -50,7 +50,7 @@ export const CatalogSourceDetailsPage: React.SFC<CatalogSourceDetailsPageProps> 
     kind: referenceForModel(PackageManifestModel),
     isList: true,
     namespace: props.match.params.ns,
-    selector: {matchLabels: {catalog: props.match.params.name}},
+    selector: {matchLabels: {catalog: props.match.params.name}, matchExpressions: [{key: visibilityLabel, operator: 'DoesNotExist'}]},
     prop: 'packageManifests',
   }, {
     kind: referenceForModel(SubscriptionModel),

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -199,6 +199,7 @@ export type PackageManifestKind = {
 
 // TODO(alecmerdler): Shouldn't be needed anymore
 export const olmNamespace = 'operator-lifecycle-manager';
+export const visibilityLabel = 'olm-visibility';
 
 export const isEnabled = (namespace: K8sResourceKind) => _.has(namespace, ['metadata', 'annotations', 'alm-manager']);
 

--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -5,7 +5,7 @@ import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
 
 import { referenceForModel, K8sResourceKind } from '../../module/k8s';
-import { PackageManifestKind, SubscriptionKind, CatalogSourceKind, ClusterServiceVersionLogo } from './index';
+import { PackageManifestKind, SubscriptionKind, CatalogSourceKind, ClusterServiceVersionLogo, visibilityLabel } from './index';
 import { PackageManifestModel, SubscriptionModel, CatalogSourceModel } from '../../models';
 import { StatusBox, MsgBox } from '../utils';
 import { List, ListHeader, ColHead, MultiListPage } from '../factory';
@@ -98,7 +98,7 @@ export const PackageManifestsPage: React.SFC<PackageManifestsPageProps> = (props
     filterLabel="Packages by name"
     flatten={flatten}
     resources={[
-      {kind: referenceForModel(PackageManifestModel), isList: true, namespaced: true, prop: 'packageManifest'},
+      {kind: referenceForModel(PackageManifestModel), isList: true, namespaced: true, prop: 'packageManifest', selector: {matchExpressions: [{key: visibilityLabel, operator: 'DoesNotExist'}]}},
       {kind: referenceForModel(CatalogSourceModel), isList: true, namespaced: true, prop: 'catalogSource'},
       {kind: referenceForModel(SubscriptionModel), isList: true, namespaced: true, prop: 'subscription'},
     ]} />;

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -27,14 +27,19 @@ export type ObjectMetadata = {
   [key: string]: any,
 };
 
+export type MatchExpression = {key: string, operator: 'Exists' | 'DoesNotExist'} | {key: string, operator: 'In' | 'NotIn' | 'Equals' | 'NotEquals', values: string[]};
+
+export type Selector = {
+  matchLabels?: {[key: string]: string};
+  matchExpressions?: MatchExpression[];
+};
+
 export type K8sResourceKind = {
   apiVersion: string;
   kind: string;
   metadata: ObjectMetadata;
   spec?: {
-    selector?: {
-      matchLabels?: {[key: string]: any},
-    },
+    selector?: Selector;
     [key: string]: any
   };
   status?: {[key: string]: any};
@@ -130,7 +135,7 @@ export type K8sKind = {
   apiVersion: string;
   apiGroup?: string;
   namespaced?: boolean;
-  selector?: {matchLabels?: {[key: string]: string}};
+  selector?: Selector;
   labels?: {[key: string]: string};
   annotations?: {[key: string]: string};
   verbs?: string[];

--- a/frontend/public/module/k8s/selector.ts
+++ b/frontend/public/module/k8s/selector.ts
@@ -1,8 +1,13 @@
-import {createEquals, requirementFromString, requirementToString} from './selector-requirement';
+/* eslint-disable no-undef, no-unused-vars */
 
-const isOldFormat = selector => !selector.matchLabels && !selector.matchExpressions;
+import { createEquals, requirementFromString, requirementToString } from './selector-requirement';
+import { Selector, MatchExpression } from './index';
 
-export const fromRequirements = (requirements, options) => {
+const isOldFormat = (selector: Selector) => !selector.matchLabels && !selector.matchExpressions;
+
+type Options = {undefinedWhenEmpty?: boolean, basic?: boolean};
+
+export const fromRequirements = (requirements: MatchExpression[], options = {} as Options) => {
   options = options || {};
   const selector = {
     matchLabels:      {},
@@ -13,7 +18,7 @@ export const fromRequirements = (requirements, options) => {
     return;
   }
 
-  requirements.forEach(function(r) {
+  requirements.forEach((r) => {
     if (r.operator === 'Equals') {
       selector.matchLabels[r.key] = r.values[0];
     } else {
@@ -29,10 +34,9 @@ export const fromRequirements = (requirements, options) => {
   return selector;
 };
 
-export const split = string => string.trim() ? string.split(/,(?![^(]*\))/) : []; // [''] -> []
+export const split = (str: string) => str.trim() ? str.split(/,(?![^(]*\))/) : []; // [''] -> []
 
-export const toRequirements = selector => {
-  selector = selector || {};
+export const toRequirements = (selector: Selector = {}) => {
   const requirements = [];
   const matchLabels = isOldFormat(selector) ? selector : selector.matchLabels;
   const matchExpressions = selector.matchExpressions;
@@ -48,12 +52,12 @@ export const toRequirements = selector => {
   return requirements;
 };
 
-export const selectorFromString = string => {
-  const requirements = split(string || '').map(requirementFromString);
+export const selectorFromString = (str: string) => {
+  const requirements = split(str || '').map(requirementFromString) as MatchExpression[];
   return fromRequirements(requirements);
 };
 
-export const selectorToString = selector => {
+export const selectorToString = (selector: Selector) => {
   const requirements = toRequirements(selector);
   return requirements.map(requirementToString).join(',');
 };


### PR DESCRIPTION
### Description

Utilizes [Kubernetes label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) to "hide" certain Operator `PackageManifests` which contain the label `olm-visibility`.

Addresses https://jira.coreos.com/browse/ALM-813