### PR TITLE
Add wrapping class to so that resource icon and link wrapping behavior is the same as <ResourceLink>

### DIFF
--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -26,8 +26,10 @@ const namespaced = crd => crd.spec.scope === 'Namespaced';
 
 const CRDRow = ({obj: crd}) => <div className="row co-resource-list__item">
   <div className="col-lg-4 col-md-4 col-sm-4 col-xs-6">
-    <ResourceIcon kind="CustomResourceDefinition" />
-    <Link className="co-resource-link__resource-name" to={`/k8s/all-namespaces/customresourcedefinitions/${referenceForCRD(crd)}`}>{_.get(crd, 'spec.names.kind', crd.metadata.name)}</Link>
+    <span className="co-resource-link">
+      <ResourceIcon kind="CustomResourceDefinition" />
+      <Link className="co-resource-link__resource-name" to={`/k8s/all-namespaces/customresourcedefinitions/${referenceForCRD(crd)}`}>{_.get(crd, 'spec.names.kind', crd.metadata.name)}</Link>
+    </span>
   </div>
   <div className="col-lg-3 col-md-4 col-sm-4 col-xs-6 co-break-word">
     { crd.spec.group }

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -84,8 +84,10 @@ const ProjectRow = ({obj: project}) => {
   const requester = getRequester(project);
   return <ResourceRow obj={project}>
     <div className="col-md-3 col-sm-6 col-xs-8">
-      <ResourceIcon kind="Project" />
-      <Link to={`/overview/ns/${name}`} title={displayName} className="co-resource-link__resource-name">{project.metadata.name}</Link>
+      <span className="co-resource-link">
+        <ResourceIcon kind="Project" />
+        <Link to={`/overview/ns/${name}`} title={displayName} className="co-resource-link__resource-name">{project.metadata.name}</Link>
+      </span>
     </div>
     <div className="col-md-3 col-sm-3 col-xs-4">
       {project.status.phase}


### PR DESCRIPTION
Adds `.co-resource-link` parent