### PR TITLE
Special case truncation class added to project list on the requester column...

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -92,7 +92,7 @@ const ProjectRow = ({obj: project}) => {
     <div className="col-md-3 col-sm-3 col-xs-4">
       <StatusIcon status={project.status.phase} />
     </div>
-    <div className="col-md-3 col-sm-3 hidden-xs">
+    <div className="col-md-3 col-sm-3 hidden-xs co-truncate">
       {requester || <span className="text-muted">No requester</span>}
     </div>
     <div className="col-md-3 hidden-sm hidden-xs">

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -2,7 +2,6 @@
 
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import { Tooltip } from './tooltip';
 
 import { annotationsModal, configureReplicaCountModal, labelsModal, podSelectorModal, deleteModal } from '../modals';
 import { DropdownMixin } from './dropdown';
@@ -81,7 +80,6 @@ export const ResourceKebab = connectToModel((props: ResourceKebabProps) => {
     options={actions.map(a => a(kindObj, resource))}
     key={resource.metadata.uid}
     isDisabled={isDisabled !== undefined ? isDisabled : _.get(resource.metadata, 'deletionTimestamp')}
-    id={`kebab-for-${resource.metadata.uid}`}
   />;
 });
 
@@ -104,24 +102,13 @@ export class Kebab extends DropdownMixin {
   }
 
   render() {
-    const {options, isDisabled, id} = this.props;
+    const {options, isDisabled} = this.props;
 
-    return <div id={id}>
-      { isDisabled ?
-        <Tooltip content="disabled">
-          <div ref={this.dropdownElement} className="co-kebab co-kebab--disabled" >
-            <span className="fa fa-ellipsis-v co-kebab__icon co-kebab__icon--disabled" aria-hidden="true"></span>
-            <span className="sr-only">Actions</span>
-          </div>
-        </Tooltip> :
-        <div ref={this.dropdownElement} className="co-kebab" >
-          <button type="button" aria-label="Actions" aria-haspopup="true" className="btn btn-link co-kebab__button" onClick={this.toggle}>
-            <span className="fa fa-ellipsis-v co-kebab__icon" aria-hidden="true"></span>
-          </button>
-          <span className="sr-only">Actions</span>
-          { this.state.active && <KebabItems options={options} onClick={this.onClick} /> }
-        </div>
-      }
+    return <div ref={this.dropdownElement} className="co-kebab">
+      <button type="button" aria-label="Actions" disabled={isDisabled} aria-haspopup="true" className="btn btn-link co-kebab__button" onClick={this.toggle}>
+        <span className="fa fa-ellipsis-v co-kebab__icon" aria-hidden="true"></span>
+      </button>
+      {(!isDisabled && this.state.active) && <KebabItems options={options} onClick={this.onClick} />}
     </div>;
   }
 }

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -554,28 +554,13 @@
 }
 
 .co-kebab {
-  position: relative;
   &__button {
+    border: 0; // remove so that dropdown-kebab-pf <button class="btn-link"> are aligned whether disabled or not
     padding: 0;
-    &:active,
-    &:focus,
-    &:hover {
-      .co-kebab__icon {
-        color: $color-pf-blue-400;
-      }
+
+    &[disabled] {
+      color: $color-pf-black-300 !important;
     }
-  }
-  &__dropdown {
-    margin-bottom: 10px;
-  }
-  &__icon {
-    color: $color-pf-black-700;
-    &--disabled {
-      color: $color-pf-black-300;
-    }
-  }
-  &--disabled {
-    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
to prevent long text string from overflowing with kebab icon. Other list views do not have this issue.

And add `.btn-link` class to disabled kebab, hooking into PatternFly rules, so the it gets the same size and positioning as the normal state.

_before_
<img width="583" alt="screen shot 2018-11-26 at 3 17 02 pm" src="https://user-images.githubusercontent.com/1874151/49039754-a9219300-f18e-11e8-8814-f3ed0a8b6fdd.png">


_after_
<img width="573" alt="screen shot 2018-11-26 at 3 17 50 pm" src="https://user-images.githubusercontent.com/1874151/49039759-acb51a00-f18e-11e8-8207-3594e6427337.png">
