### PR TITLE
Add initial cluster settings page for OpenShift

### DIFF
--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -69,12 +69,15 @@
   &__modal--version {
     margin: 0;
   }
+  &__updates,
   &__user {
     display: none;
     @media (min-width: $grid-float-breakpoint) {
       align-items: baseline;
       display: flex;
     }
+  }
+  &__user {
     .btn-dropdown__item {
       align-items: baseline;
       display: flex; // so .co-masthead__username truncates

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -12,6 +12,7 @@ import { ALL_NAMESPACES_KEY } from '../const';
 import { connectToFlags, featureActions, flagPending, FLAGS } from '../features';
 import { analyticsSvc } from '../module/analytics';
 import { MonitoringUI } from './monitoring';
+import { ClusterSettingsPage } from './cluster-settings/cluster-settings';
 import { GlobalNotifications } from './global-notifications';
 import { Masthead } from './masthead';
 import { NamespaceBar } from './namespace';
@@ -188,6 +189,8 @@ class App extends React.PureComponent {
             <LazyRoute path="/k8s/ns/:ns/persistentvolumeclaims/new/form" exact kind="PersistentVolumeClaim" loader={() => import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(m => m.CreatePVC)} />
 
             <Route path="/monitoring" component={MonitoringUI} />
+
+            <Route path="/settings/cluster" component={ClusterSettingsPage} />
 
             <LazyRoute path={'/k8s/cluster/storageclasses/new/form'} exact loader={() => import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(m => m.StorageClassForm)} />
 

--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -1,0 +1,157 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import { K8sResourceKind, K8sResourceKindReference, referenceForModel } from '../../module/k8s';
+import { ClusterOperatorModel } from '../../models';
+import { ColHead, DetailsPage, List, ListHeader, ListPage } from '../factory';
+import {
+  ResourceLink,
+  ResourceSummary,
+  SectionHeading,
+  navFactory,
+} from '../utils';
+
+enum OperatorStatus {
+  Available = 'Available',
+  Updating = 'Updating',
+  Failing = 'Failing',
+  Unknown = 'Unknown',
+}
+
+export const clusterOperatorReference: K8sResourceKindReference = referenceForModel(ClusterOperatorModel);
+
+const getStatusAndMessage = (operator: K8sResourceKind) => {
+  const conditions = _.get(operator, 'status.conditions');
+  const failing: any = _.find(conditions, { type: 'Failing', status: 'True' });
+  if (failing) {
+    return { status: OperatorStatus.Failing, message: failing.message };
+  }
+
+  const progressing: any = _.find(conditions, { type: 'Progressing', status: 'True' });
+  if (progressing) {
+    return { status: OperatorStatus.Updating, message: progressing.message };
+  }
+
+  const available: any = _.find(conditions, { type: 'Available', status: 'True' });
+  if (available) {
+    return { status: OperatorStatus.Available, message: available.message };
+  }
+
+  return { status: OperatorStatus.Unknown, message: '' };
+};
+
+export const getClusterOperatorStatus = (operator: K8sResourceKind) => {
+  const { status } = getStatusAndMessage(operator);
+  return status;
+};
+
+const getIconClass = (status: OperatorStatus) => {
+  return {
+    [OperatorStatus.Available]: 'pficon pficon-ok text-success',
+    [OperatorStatus.Updating]: 'pficon pficon-in-progress',
+    [OperatorStatus.Failing]: 'pficon pficon-error-circle-o text-danger',
+  }[status];
+};
+
+const OperatorStatusIconAndLabel: React.SFC<OperatorStatusIconAndLabelProps> = ({status}) => {
+  const iconClass = getIconClass(status);
+  return status === OperatorStatus.Unknown
+    ? <span className="text-muted">Unknown</span>
+    : <React.Fragment><i className={iconClass} aria-hidden="true" /> {status}</React.Fragment>;
+};
+
+const ClusterOperatorHeader = props => <ListHeader>
+  <ColHead {...props} className="col-md-3 col-sm-3 col-xs-6" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-md-2 col-sm-3 col-xs-6" sortFunc="getClusterOperatorStatus">Status</ColHead>
+  <ColHead {...props} className="col-md-4 col-sm-3 hidden-xs">Message</ColHead>
+  <ColHead {...props} className="col-md-3 col-sm-3 hidden-xs" sortField="status.version">Version</ColHead>
+</ListHeader>;
+
+const ClusterOperatorRow: React.SFC<ClusterOperatorRowProps> = ({obj}) => {
+  const { status, message } = getStatusAndMessage(obj);
+  return <div className="row co-resource-list__item">
+    <div className="col-md-3 col-sm-3 col-xs-6">
+      <ResourceLink kind={clusterOperatorReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
+    </div>
+    <div className="col-md-2 col-sm-3 col-xs-6">
+      <OperatorStatusIconAndLabel status={status} />
+    </div>
+    <div className="col-md-4 col-sm-3 hidden-xs">
+      {message ? _.truncate(message, { length: 256, separator: ' ' }) : '-'}
+    </div>
+    <div className="col-md-3 col-sm-3 hidden-xs">
+      {obj.status.version || <span className="text-muted">Unknown</span>}
+    </div>
+  </div>;
+};
+
+export const ClusterOperatorList: React.SFC = props => <List {...props} Header={ClusterOperatorHeader} Row={ClusterOperatorRow} />;
+
+const allStatuses = [
+  OperatorStatus.Available,
+  OperatorStatus.Updating,
+  OperatorStatus.Failing,
+  OperatorStatus.Unknown,
+];
+
+const filters = [{
+  type: 'cluster-operator-status',
+  selected: allStatuses,
+  reducer: getClusterOperatorStatus,
+  items: _.map(allStatuses, phase => ({
+    id: phase,
+    title: phase,
+  })),
+}];
+
+export const ClusterOperatorPage: React.SFC<ClusterOperatorPageProps> = props =>
+  <ListPage
+    {...props}
+    title="Cluster Operators"
+    kind={clusterOperatorReference}
+    ListComponent={ClusterOperatorList}
+    canCreate={false}
+    rowFilters={filters}
+  />;
+
+const ClusterOperatorDetails: React.SFC<ClusterOperatorDetailsProps> = ({obj}) => {
+  const { status, message } = getStatusAndMessage(obj);
+  return <div className="co-m-pane__body">
+    <SectionHeading text="Cluster Operator Overview" />
+    <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
+      <dt>Status</dt>
+      <dd><OperatorStatusIconAndLabel status={status} /></dd>
+      <dt>Message</dt>
+      <dd>{message || '-'}</dd>
+    </ResourceSummary>
+  </div>;
+};
+
+export const ClusterOperatorDetailsPage: React.SFC<ClusterOperatorDetailsPageProps> = props =>
+  <DetailsPage
+    {...props}
+    kind={clusterOperatorReference}
+    pages={[navFactory.details(ClusterOperatorDetails), navFactory.editYaml()]}
+  />;
+
+type OperatorStatusIconAndLabelProps = {
+  status: OperatorStatus;
+};
+
+type ClusterOperatorRowProps = {
+  obj: K8sResourceKind;
+};
+
+type ClusterOperatorPageProps = {
+  autoFocus?: boolean;
+  showTitle?: boolean;
+};
+
+type ClusterOperatorDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type ClusterOperatorDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -1,0 +1,157 @@
+/* eslint-disable no-unused-vars, no-undef */
+
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import { Helmet } from 'react-helmet';
+
+import { Firehose, HorizontalNav } from '../utils';
+import { K8sResourceKind, referenceForModel } from '../../module/k8s';
+import { ClusterVersionModel } from '../../models';
+import { ClusterOperatorPage } from './cluster-operator';
+
+enum ClusterUpdateStatus {
+  UpToDate = 'Up to Date',
+  UpdatesAvailable = 'Updates Available',
+  Updating = 'Updating',
+  Failing = 'Failing',
+  ErrorRetrieving = 'Error Retrieving',
+}
+
+const clusterVersionReference = referenceForModel(ClusterVersionModel);
+
+const FailedConditionAlert = ({message, condition}) => <div className="alert alert-danger">
+  <i className="pficon pficon-error-circle-o" aria-hidden="true" /> <strong>{message}</strong> {condition.message}
+</div>;
+
+const getClusterUpdateStatus = (cv: K8sResourceKind): ClusterUpdateStatus => {
+  const conditions = _.get(cv, 'status.conditions', []);
+  const isFailingCondition = _.find(conditions, { type: 'Failing', status: 'True' });
+  if (isFailingCondition) {
+    return ClusterUpdateStatus.Failing;
+  }
+
+  const retrievedUpdatesFailedCondition = _.find(conditions, { type: 'RetrievedUpdates', status: 'False' });
+  if (retrievedUpdatesFailedCondition) {
+    return ClusterUpdateStatus.ErrorRetrieving;
+  }
+
+  const isProgressingCondition = _.find(conditions, { type: 'Progressing', status: 'True' });
+  if (isProgressingCondition) {
+    return ClusterUpdateStatus.Updating;
+  }
+
+  const updates = _.get(cv, 'status.availableUpdates');
+  return _.isEmpty(updates) ? ClusterUpdateStatus.UpToDate : ClusterUpdateStatus.UpdatesAvailable;
+};
+
+const getIconClass = (status: ClusterUpdateStatus) => {
+  return {
+    [ClusterUpdateStatus.UpToDate]: 'pficon pficon-ok text-success',
+    [ClusterUpdateStatus.UpdatesAvailable]: 'fa fa-arrow-circle-up text-success',
+    [ClusterUpdateStatus.Updating]: 'pficon pficon-in-progress',
+    [ClusterUpdateStatus.Failing]: 'pficon pficon-error-circle-o text-danger',
+    [ClusterUpdateStatus.ErrorRetrieving]: 'pficon pficon-error-circle-o text-danger',
+  }[status];
+};
+
+const UpdateStatus: React.SFC<UpdateStatusProps> = ({cv}) => {
+  const status = getClusterUpdateStatus(cv);
+  const iconClass = getIconClass(status);
+  return <React.Fragment>
+    <i className={iconClass} aria-hidden="true" />&nbsp;{status}
+  </React.Fragment>;
+};
+
+const CurrentVersion: React.SFC<CurrentVersionProps> = ({cv}) => {
+  const currentVersion = _.get(cv, 'status.current.version');
+  return currentVersion || <React.Fragment><i className="pficon pficon-warning-triangle-o" aria-hidden="true" />&nbsp;Unknown</React.Fragment>;
+};
+
+const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = ({obj: cv}) => {
+  const conditions = _.get(cv, 'status.conditions', []);
+  const retrievedUpdatesFailedCondition = _.find(conditions, { type: 'RetrievedUpdates', status: 'False' });
+  const isFailingCondition = _.find(conditions, { type: 'Failing', status: 'True' });
+  const payload = _.get(cv, 'status.current.payload');
+  return <div className="co-m-pane__body">
+    <div className="co-m-pane__body-group">
+      {isFailingCondition && <FailedConditionAlert message="Upgrade is failing." condition={isFailingCondition} />}
+      {retrievedUpdatesFailedCondition && <FailedConditionAlert message="Could not retrieve updates." condition={retrievedUpdatesFailedCondition} />}
+      <div className="co-detail-table">
+        <div className="co-detail-table__row row">
+          <div className="co-detail-table__section">
+            <dl className="co-m-pane__details">
+              <dt className="co-detail-table__section-header">Channel</dt>
+              <dd>{cv.spec.channel}</dd>
+            </dl>
+          </div>
+          <div className="co-detail-table__section">
+            <dl className="co-m-pane__details">
+              <dt className="co-detail-table__section-header">Update Status</dt>
+              <dd><UpdateStatus cv={cv} /></dd>
+            </dl>
+          </div>
+          <div className="co-detail-table__section">
+            <dl className="co-m-pane__details">
+              <dt className="co-detail-table__section-header">Current Version</dt>
+              <dd><CurrentVersion cv={cv} /></dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div className="co-m-pane__body-group">
+      <dl className="co-m-pane__details">
+        <dt>Cluster ID</dt>
+        <dd>{cv.spec.clusterID}</dd>
+        <dt>Current Payload</dt>
+        <dd>{payload}</dd>
+      </dl>
+    </div>
+  </div>;
+};
+
+const ClusterOperatorTabPage: React.SFC = () => <ClusterOperatorPage autoFocus={false} showTitle={false} />;
+
+const pages = [{
+  href: '',
+  name: 'Overview',
+  component: ClusterVersionDetailsTable,
+}, {
+  href: 'clusteroperators',
+  name: 'Cluster Operators',
+  component: ClusterOperatorTabPage,
+}];
+
+export const ClusterSettingsPage: React.SFC<ClusterSettingsPageProps> = ({match}) => {
+  const title = 'Cluster Settings';
+  const resources = [
+    {kind: clusterVersionReference, name: 'version', isList: false, prop: 'obj'},
+  ];
+  return <React.Fragment>
+    <Helmet>
+      <title>{title}</title>
+    </Helmet>
+    <div className="co-m-nav-title">
+      <h1 className="co-m-pane__heading">{title}</h1>
+    </div>
+    <Firehose resources={resources}>
+      <HorizontalNav pages={pages} match={match} hideDivider />;
+    </Firehose>
+  </React.Fragment>;
+};
+
+type UpdateStatusProps = {
+  cv: K8sResourceKind;
+};
+
+type CurrentVersionProps = {
+  cv: K8sResourceKind;
+};
+
+type ClusterVersionDetailsTableProps = {
+  obj: K8sResourceKind;
+};
+
+type ClusterSettingsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -19,6 +19,7 @@ import { UIActions } from '../../ui/ui-actions';
 import { ingressValidHosts } from '../ingress';
 import { alertState, silenceState } from '../monitoring';
 import { routeStatus } from '../routes';
+import { getClusterOperatorStatus } from '../cluster-settings/cluster-operator';
 import { secretTypeFilterReducer } from '../secret';
 import { bindingType, roleType } from '../RBAC';
 import {
@@ -161,6 +162,14 @@ const listFilters = {
     return fuzzyCaseInsensitive(str, displayName);
   },
 
+  'cluster-operator-status': (statuses, operator) => {
+    if (!statuses || !statuses.selected || !statuses.selected.size) {
+      return true;
+    }
+
+    const status = getClusterOperatorStatus(operator);
+    return statuses.selected.has(status) || !_.includes(statuses.all, status);
+  },
 };
 
 const getFilteredRows = (_filters, objects) => {

--- a/frontend/public/components/masthead.tsx
+++ b/frontend/public/components/masthead.tsx
@@ -160,12 +160,18 @@ export const LogoImage = () => {
   </div>;
 };
 
-export const Masthead = () => <header role="banner" className="navbar navbar-pf-vertical co-masthead">
+const Masthead_ = ({ flags }) => <header role="banner" className="navbar navbar-pf-vertical co-masthead">
   <div className="navbar-header">
     <LogoImage />
   </div>
   <div className="nav navbar-nav navbar-right navbar-iconic navbar-utility">
     <div className="co-masthead__dropdowns">
+      {flags[FLAGS.CLUSTER_UPDATES_AVAILABLE] && <div className="co-masthead__updates">
+        <Link to="/settings/cluster" title="Cluster Updates Available" className="nav-item-iconic">
+          <i className="fa fa-arrow-circle-up" aria-hidden="true" />
+          <span className="sr-only">Cluster Updates Available</span>
+        </Link>
+      </div>}
       <div className="co-masthead__help">
         <HelpMenu />
       </div>
@@ -175,6 +181,7 @@ export const Masthead = () => <header role="banner" className="navbar navbar-pf-
     </div>
   </div>
 </header>;
+export const Masthead = connectToFlags(FLAGS.CLUSTER_UPDATES_AVAILABLE)(Masthead_);
 
 /* eslint-disable no-undef */
 export type FlagsProps = {

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -435,6 +435,7 @@ export class Nav extends React.Component {
             <ResourceClusterLink resource="nodes" name="Nodes" onClick={this.close} required={FLAGS.CAN_LIST_NODE} />
             <ResourceNSLink resource={referenceForModel(MachineSetModel)} name="Machine Sets" onClick={this.close} required={FLAGS.CLUSTER_API} />
             <ResourceNSLink resource={referenceForModel(MachineModel)} name="Machines" onClick={this.close} required={FLAGS.CLUSTER_API} />
+            <HrefLink href="/settings/cluster" activePath="/settings/cluster/" name="Cluster Settings" onClick={this.close} required={FLAGS.CLUSTER_VERSION} />
             <ResourceNSLink resource="serviceaccounts" name="Service Accounts" onClick={this.close} />
             <ResourceNSLink resource="roles" name="Roles" startsWith={rolesStartsWith} onClick={this.close} />
             <ResourceNSLink resource="rolebindings" name="Role Bindings" onClick={this.close} startsWith={rolebindingsStartsWith} />

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -9,6 +9,7 @@ import {
   BuildConfigModel,
   BuildModel,
   CatalogSourceModel,
+  ClusterOperatorModel,
   ClusterRoleModel,
   ClusterServiceBrokerModel,
   ClusterServiceClassModel,
@@ -102,7 +103,8 @@ export const resourceDetailPages = ImmutableMap<GroupVersionKind | string, () =>
   .set(referenceForModel(ClusterServiceVersionModel), () => import('./operator-lifecycle-manager/clusterserviceversion' /* webpackChunkName: "clusterserviceversion" */).then(m => m.ClusterServiceVersionsDetailsPage))
   .set(referenceForModel(CatalogSourceModel), () => import('./operator-lifecycle-manager/catalog-source' /* webpackChunkName: "catalog-source" */).then(m => m.CatalogSourceDetailsPage))
   .set(referenceForModel(SubscriptionModel), () => import('./operator-lifecycle-manager/subscription' /* webpackChunkName: "subscription" */).then(m => m.SubscriptionDetailsPage))
-  .set(referenceForModel(InstallPlanModel), () => import('./operator-lifecycle-manager/install-plan' /* webpackChunkName: "install-plan" */).then(m => m.InstallPlanDetailsPage));
+  .set(referenceForModel(InstallPlanModel), () => import('./operator-lifecycle-manager/install-plan' /* webpackChunkName: "install-plan" */).then(m => m.InstallPlanDetailsPage))
+  .set(referenceForModel(ClusterOperatorModel), () => import('./cluster-settings/cluster-operator' /* webpackChunkName: "cluster-operator" */).then(m => m.ClusterOperatorDetailsPage));
 
 export const resourceListPages = ImmutableMap<GroupVersionKind | string, () => Promise<React.ComponentType<any>>>()
   .set(referenceForModel(ClusterServiceClassModel), () => import('./cluster-service-class' /* webpackChunkName: "cluster-service-class" */).then(m => m.ClusterServiceClassPage))
@@ -151,4 +153,5 @@ export const resourceListPages = ImmutableMap<GroupVersionKind | string, () => P
   .set(referenceForModel(ClusterServiceVersionModel), () => import('./operator-lifecycle-manager/clusterserviceversion' /* webpackChunkName: "clusterserviceversion" */).then(m => m.ClusterServiceVersionsPage))
   .set(referenceForModel(PackageManifestModel), () => import('./operator-lifecycle-manager/package-manifest' /* webpackChunkName: "package-manifest" */).then(m => m.PackageManifestsPage))
   .set(referenceForModel(SubscriptionModel), () => import('./operator-lifecycle-manager/subscription' /* webpackChunkName: "subscription" */).then(m => m.SubscriptionsPage))
-  .set(referenceForModel(InstallPlanModel), () => import('./operator-lifecycle-manager/install-plan' /* webpackChunkName: "install-plan" */).then(m => m.InstallPlansPage));
+  .set(referenceForModel(InstallPlanModel), () => import('./operator-lifecycle-manager/install-plan' /* webpackChunkName: "install-plan" */).then(m => m.InstallPlansPage))
+  .set(referenceForModel(ClusterOperatorModel), () => import('./cluster-settings/cluster-operator' /* webpackChunkName: "cluster-operator" */).then(m => m.ClusterOperatorPage));

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -74,22 +74,27 @@ export const navFactory: NavFactory = {
   envEditor: (component) => ({
     href: 'environment',
     name: 'Environment',
-    component: component,
+    component,
   }),
   clusterServiceClasses: component => ({
     href: 'serviceclasses',
     name: 'Service Classes',
-    component: component,
+    component,
   }),
   clusterServicePlans: component => ({
     href: 'serviceplans',
     name: 'Service Plans',
-    component: component,
+    component,
   }),
   serviceBindings: component => ({
     href: 'servicebindings',
     name: 'Service Bindings',
-    component: component,
+    component,
+  }),
+  clusterOperators: component => ({
+    href: 'clusteroperators',
+    name: 'Cluster Operators',
+    component,
   }),
   machines: component => ({
     href: 'machines',
@@ -98,7 +103,7 @@ export const navFactory: NavFactory = {
   }),
 };
 
-export const NavBar: React.SFC<NavBarProps> = ({pages, basePath}) => {
+export const NavBar: React.SFC<NavBarProps> = ({pages, basePath, hideDivider}) => {
   // These tabs go before the divider
   const before = ['', 'edit', 'yaml'];
   const divider = <li className="co-m-horizontal-nav__menu-item co-m-horizontal-nav__menu-item--divider" key="_divider" />;
@@ -108,7 +113,7 @@ export const NavBar: React.SFC<NavBarProps> = ({pages, basePath}) => {
     pages.filter(({href}, i, all) => before.includes(href) || before.includes(_.get(all[i + 1], 'href'))).map(({name, href}) => {
       const klass = classNames('co-m-horizontal-nav__menu-item', {'co-m-horizontal-nav-item--active': location.pathname.replace(basePath, '/').endsWith(`/${href}`)});
       return <li className={klass} key={name}><Link to={`${basePath}/${href}`}>{name}</Link></li>;
-    })}{divider}</ul>;
+    })}{!hideDivider && divider}</ul>;
 
   const secondaryTabs = <ul className="co-m-horizontal-nav__menu-secondary">{
     pages.slice(React.Children.count(primaryTabs.props.children) - 1).map(({name, href}) => {
@@ -133,6 +138,7 @@ export class HorizontalNav extends React.PureComponent<HorizontalNavProps> {
     pagesFor: PropTypes.func,
     className: PropTypes.string,
     hideNav: PropTypes.bool,
+    hideDivider: PropTypes.bool,
     match: PropTypes.shape({
       path: PropTypes.string,
     }),
@@ -155,7 +161,7 @@ export class HorizontalNav extends React.PureComponent<HorizontalNavProps> {
 
     return <div className={props.className}>
       <div className="co-m-horizontal-nav">
-        {!props.hideNav && <NavBar pages={pages} basePath={props.match.url} />}
+        {!props.hideNav && <NavBar pages={pages} basePath={props.match.url} hideDivider={props.hideDivider} />}
         <StatusBox {...props.obj} EmptyMsg={props.EmptyMsg} label={props.label}>
           <Switch> {routes} </Switch>
         </StatusBox>
@@ -171,6 +177,7 @@ export type PodsComponentProps = {
 export type NavBarProps = {
   pages: Page[];
   basePath: string;
+  hideDivider?: boolean;
 };
 
 export type HorizontalNavProps = {
@@ -182,5 +189,6 @@ export type HorizontalNavProps = {
   match: any;
   resourceKeys?: string[];
   hideNav?: boolean;
+  hideDivider?: boolean;
   EmptyMsg?: React.ComponentType<any>;
 };

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -816,3 +816,32 @@ export const MachineModel: K8sKind = {
   id: 'machine',
   crd: true,
 };
+
+// Openshift cluster resources
+export const ClusterOperatorModel: K8sKind = {
+  label: 'Cluster Operator',
+  labelPlural: 'Cluster Operators',
+  apiVersion: 'v1',
+  path: 'clusteroperators',
+  apiGroup: 'config.openshift.io',
+  plural: 'clusteroperators',
+  abbr: 'CO',
+  namespaced: false,
+  kind: 'ClusterOperator',
+  id: 'clusteroperator',
+  crd: true,
+};
+
+export const ClusterVersionModel: K8sKind = {
+  label: 'Cluster Version',
+  labelPlural: 'Cluster Versions',
+  apiVersion: 'v1',
+  path: 'clusterversions',
+  apiGroup: 'config.openshift.io',
+  plural: 'clusterversions',
+  abbr: 'CV',
+  namespaced: false,
+  kind: 'ClusterVersion',
+  id: 'clusterversion',
+  crd: true,
+};


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-868

Show channel, update status, and current version for the cluster as well as cluster operator status.

This PR does not yet let you change channels or start an upgrade. It also doesn't change the about dialog to avoid conflicting more with the in flight PF4 changes.

Cluster updates icon in masthead:

![cluster settings okd 2018-11-27 16-34-40](https://user-images.githubusercontent.com/1167259/49113027-6a5d0d00-f262-11e8-9092-65f50f456a1e.png)

Cluster settings overview (showing an error here because I have no current version set):

![cluster settings okd 2018-11-27 16-35-33](https://user-images.githubusercontent.com/1167259/49113052-7a74ec80-f262-11e8-9d91-cc6116bcbbbc.png)

Cluster operator status:

![cluster settings okd 2018-11-27 16-35-53](https://user-images.githubusercontent.com/1167259/49113077-8bbdf900-f262-11e8-93ca-46a25180849f.png)
