### PR TITLE
Add attach storage to daemon set and stateful set

### DIFF
--- a/frontend/public/components/daemon-set.jsx
+++ b/frontend/public/components/daemon-set.jsx
@@ -23,7 +23,7 @@ import {
   Selector,
 } from './utils';
 
-export const menuActions = [Kebab.factory.EditEnvironment, ...Kebab.factory.common];
+export const menuActions = [Kebab.factory.AddStorage, Kebab.factory.EditEnvironment, ...Kebab.factory.common];
 
 const DaemonSetHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-2 col-md-3 col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -17,8 +17,8 @@ import {
   navFactory,
 } from './utils';
 
-const { EditEnvironment, common } = Kebab.factory;
-export const menuActions = [EditEnvironment, ...common];
+const { AddStorage, EditEnvironment, common } = Kebab.factory;
+export const menuActions = [AddStorage, EditEnvironment, ...common];
 
 const kind = 'StatefulSet';
 const Row = props => <WorkloadListRow {...props} kind={kind} actions={menuActions} />;

--- a/frontend/public/components/storage/attach-storage.tsx
+++ b/frontend/public/components/storage/attach-storage.tsx
@@ -71,6 +71,8 @@ class AttachStorageForm extends React.Component<
       'DeploymentConfig',
       'ReplicaSet',
       'ReplicationController',
+      'StatefulSet',
+      'DaemonSet',
     ];
 
     if (!kindObj || !_.includes(supportedKinds, kindObj.kind)) {


### PR DESCRIPTION
Add attach storage to daemon set and stateful set. The "attach storage" page is accessible on many workload pages through the action menu.  We are simply adding it to stateful and daemon sets pages as well.