### PR TITLE
Monitoring: Get monitoring UI URLs from ConfigMap

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -10,7 +10,6 @@ import store from '../redux';
 import { productName } from '../branding';
 import { ALL_NAMESPACES_KEY } from '../const';
 import { connectToFlags, featureActions, flagPending, FLAGS } from '../features';
-import { detectMonitoringURLs } from '../monitoring';
 import { analyticsSvc } from '../module/analytics';
 import { MonitoringUI } from './monitoring';
 import { GlobalNotifications } from './global-notifications';
@@ -226,7 +225,6 @@ getCachedResources().then(resources => {
 }).catch(startDiscovery);
 
 _.each(featureActions, store.dispatch);
-store.dispatch(detectMonitoringURLs);
 
 analyticsSvc.push({tier: 'tectonic'});
 

--- a/frontend/public/monitoring.ts
+++ b/frontend/public/monitoring.ts
@@ -4,9 +4,6 @@ import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';
 
-import { k8sBasePath } from './module/k8s/k8s';
-import { coFetchJSON } from './co-fetch';
-
 export const enum AlertStates {
   Firing = 'firing',
   Silenced = 'silenced',
@@ -29,28 +26,7 @@ export enum MonitoringRoutes {
 const SET_MONITORING_URL = 'setMonitoringURL';
 const DEFAULTS = _.mapValues(MonitoringRoutes, undefined);
 
-const monitoringRoutes = `${k8sBasePath}/apis/route.openshift.io/v1/namespaces/openshift-monitoring/routes/`;
-export const detectMonitoringURLs = dispatch => coFetchJSON(monitoringRoutes).then(res => {
-  const byName = _.keyBy(res.items, 'metadata.name');
-  _.each(MonitoringRoutes, name => {
-    const route = byName[name];
-    if (!route) {
-      return;
-    }
-    const scheme = _.get(route, 'spec.tls.termination') ? 'https' : 'http';
-    const url = `${scheme}://${route.spec.host}`;
-    // eslint-disable-next-line no-console
-    console.log(`${name} detected at ${url}`);
-    dispatch({ name, url, type: SET_MONITORING_URL });
-  });
-}).catch(res => {
-  const status = _.get(res, 'response.status');
-  // eslint-disable-next-line no-console
-  console.log('Could not get openshift-monitoring routes, status:', status);
-  if (!_.includes([401, 403, 404, 500], status)) {
-    setTimeout(() => detectMonitoringURLs(dispatch), 15000);
-  }
-});
+export const setMonitoringURL = (name, url) => ({name, url, type: SET_MONITORING_URL});
 
 export const monitoringReducer = (state: ImmutableMap<string, any>, action) => {
   if (!state) {


### PR DESCRIPTION
Get the Alertmanager, Grafana and Prometheus UI URLs from a ConfigMap
named `sharing-config` in the `monitoring` namespace.

@spadgett Can we go ahead and merge this change even though it won't work until the ConfigMap is added? (Since the current approach is broken anyway.)