### PR TITLE
Update status icons & labels as specified by Patternfly recommendations

### DIFF
--- a/frontend/__tests__/components/route-pages.spec.tsx
+++ b/frontend/__tests__/components/route-pages.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import { RouteLocation, RouteStatus } from '../../public/components/routes';
 import { K8sResourceKind } from '../../public/module/k8s';
@@ -196,9 +196,9 @@ describe(RouteStatus.displayName, () => {
       },
     };
 
-    const wrapper = shallow(<RouteStatus obj={route} />);
-    expect(wrapper.find('.fa-check').exists()).toBe(true);
-    expect(wrapper.text()).toEqual('Accepted');
+    const wrapper = mount(<RouteStatus obj={route} />);
+    expect(wrapper.find('.pficon-ok').exists()).toBe(true);
+    expect(wrapper.text()).toEqual(' Accepted');
   });
 
   it('renders Rejected status', () => {
@@ -223,9 +223,9 @@ describe(RouteStatus.displayName, () => {
       },
     };
 
-    const wrapper = shallow(<RouteStatus obj={route} />);
-    expect(wrapper.find('.fa-times-circle').exists()).toBe(true);
-    expect(wrapper.text()).toEqual('Rejected');
+    const wrapper = mount(<RouteStatus obj={route} />);
+    expect(wrapper.find('.pficon-error-circle-o').exists()).toBe(true);
+    expect(wrapper.text()).toEqual(' Rejected');
   });
 
   it('renders Pending status', () => {
@@ -237,8 +237,8 @@ describe(RouteStatus.displayName, () => {
       },
     };
 
-    const wrapper = shallow(<RouteStatus obj={route} />);
+    const wrapper = mount(<RouteStatus obj={route} />);
     expect(wrapper.find('.fa-hourglass-half').exists()).toBe(true);
-    expect(wrapper.text()).toEqual('Pending');
+    expect(wrapper.text()).toEqual(' Pending');
   });
 });

--- a/frontend/public/components/build-pipeline.tsx
+++ b/frontend/public/components/build-pipeline.tsx
@@ -23,19 +23,19 @@ export const getJenkinsBuildURL = (resource: K8sResourceKind): string => _.get(r
 const BuildSummaryStatusIcon: React.SFC<BuildSummaryStatusIconProps> = ({ status }) => {
   const statusClass = _.lowerCase(status);
   const icon = ({
-    new: 'fa-hourglass-o',
-    pending: 'fa-hourglass-half',
-    running: 'fa-refresh fa-spin',
-    complete: 'fa-check-circle',
-    failed: 'fa-times-circle',
+    new: '',
+    pending: 'pficon pficon-pending',
+    running: 'fa fa-refresh fa-fw',
+    complete: 'pficon pficon-ok',
+    failed: 'pficon pficon-error-circle-o',
   })[statusClass];
 
   return icon
     ? <span className={`build-pipeline__status-icon build-pipeline__status-icon--${statusClass}`}>
-      <span className={`fa ${icon} fa-fw`} aria-hidden="true"></span>
+      <span className={icon} aria-hidden="true"></span>
     </span>
     : <span className="build-pipeline__status-icon">
-      <span className="fa fa-refresh fa-spin" aria-hidden="true"></span>
+      <span className="fa fa-refresh" aria-hidden="true"></span>
     </span>;
 };
 

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -9,7 +9,7 @@ import { K8sResourceKindReference, referenceFor, K8sResourceKind } from '../modu
 import { cloneBuild, formatBuildDuration, BuildPhase, getBuildNumber } from '../module/k8s/builds';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { errorModal } from './modals';
-import { BuildHooks, BuildStrategy, Kebab, SectionHeading, history, navFactory, ResourceKebab, ResourceLink, resourceObjPath, ResourceSummary, Timestamp, AsyncComponent, resourcePath } from './utils';
+import { BuildHooks, BuildStrategy, Kebab, SectionHeading, history, navFactory, ResourceKebab, ResourceLink, resourceObjPath, ResourceSummary, Timestamp, AsyncComponent, resourcePath, StatusIcon } from './utils';
 import { BuildPipeline, BuildPipelineLogLink } from './build-pipeline';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { fromNow } from './utils/datetime';
@@ -221,7 +221,7 @@ const BuildsRow: React.SFC<BuildsRowProps> = ({ obj }) => <div className="row co
     <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
   </div>
   <div className="col-sm-3 hidden-xs">
-    {obj.status.phase}
+    <StatusIcon status={obj.status.phase} />
   </div>
   <div className="col-sm-3 hidden-xs">
     {fromNow(obj.metadata.creationTimestamp)}

--- a/frontend/public/components/container.jsx
+++ b/frontend/public/components/container.jsx
@@ -16,6 +16,7 @@ import {
   ResourceLink,
   ScrollToTopOnMount,
   SectionHeading,
+  StatusIcon,
   Timestamp,
 } from './utils';
 
@@ -171,7 +172,7 @@ const Details = (props) => {
         <SectionHeading text="Container Overview" />
         <dl className="co-m-pane__details">
           <dt>State</dt>
-          <dd>{stateValue}</dd>
+          <dd><StatusIcon status={stateValue} /></dd>
           <dt>ID</dt>
           <dd><Overflow value={status.containerID} /></dd>
           <dt>Restarts</dt>

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -43,8 +43,8 @@ const CRDRow = ({obj: crd}) => <div className="row co-resource-list__item">
   <div className="col-lg-1 hidden-md hidden-sm hidden-xs">
     {
       isEstablished(crd.status.conditions)
-        ? <span className="node-ready"><i className="fa fa-check-circle"></i></span>
-        : <span className="node-not-ready"><i className="fa fa-minus-circle"></i></span>
+        ? <span><i className="pficon pficon-ok" aria-hidden="true"></i></span>
+        : <span><i className="fa fa-ban" aria-hidden="true"></i></span>
     }
   </div>
   <div className="dropdown-kebab-pf">

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -19,13 +19,13 @@ import {
   Kebab,
   ContainerTable,
   DeploymentPodCounts,
-  LoadingInline,
   navFactory,
   pluralize,
   ResourceSummary,
   SectionHeading,
   togglePaused,
   WorkloadPausedAlert,
+  StatusIcon,
 } from './utils';
 
 const DeploymentConfigsReference: K8sResourceKindReference = 'DeploymentConfig';
@@ -112,7 +112,7 @@ export const DeploymentConfigsDetails: React.SFC<{obj: any}> = ({obj: dc}) => {
           <div className="col-sm-6">
             <ResourceSummary resource={dc}>
               <dt>Status</dt>
-              <dd>{dc.status.availableReplicas === dc.status.updatedReplicas ? <span>Active</span> : <div><span className="co-icon-space-r"><LoadingInline /></span> Updating</div>}</dd>
+              <dd>{dc.status.availableReplicas === dc.status.updatedReplicas ? <StatusIcon status="Active" /> : <StatusIcon status="Updating" />}</dd>
             </ResourceSummary>
           </div>
           <div className="col-sm-6">

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -18,11 +18,11 @@ import {
   Kebab,
   ContainerTable,
   DeploymentPodCounts,
-  LoadingInline,
   navFactory,
   pluralize,
   ResourceSummary,
   SectionHeading,
+  StatusIcon,
   togglePaused,
   WorkloadPausedAlert,
 } from './utils';
@@ -76,7 +76,7 @@ const DeploymentDetails = ({obj: deployment}) => {
           <div className="col-sm-6">
             <ResourceSummary resource={deployment}>
               <dt>Status</dt>
-              <dd>{deployment.status.availableReplicas === deployment.status.updatedReplicas ? <span>Active</span> : <div><span className="co-icon-space-r"><LoadingInline /></span> Updating</div>}</dd>
+              <dd>{deployment.status.availableReplicas === deployment.status.updatedReplicas ? <StatusIcon status="Active" /> : <StatusIcon status="Updating" />}</dd>
             </ResourceSummary>
           </div>
           <div className="col-sm-6">

--- a/frontend/public/components/job.jsx
+++ b/frontend/public/components/job.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { getJobTypeAndCompletions } from '../module/k8s';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { configureJobParallelismModal } from './modals';
-import { Kebab, ContainerTable, SectionHeading, LabelList, ResourceKebab, ResourceLink, ResourceSummary, Timestamp, navFactory } from './utils';
+import { Kebab, ContainerTable, SectionHeading, LabelList, ResourceKebab, ResourceLink, ResourceSummary, Timestamp, navFactory, StatusIcon } from './utils';
 import { ResourceEventStream } from './events';
 
 const ModifyJobParallelism = (kind, obj) => ({
@@ -70,7 +70,7 @@ const Details = ({obj: job}) => <React.Fragment>
         <SectionHeading text="Job Status" />
         <dl className="co-m-pane__details">
           <dt>Status</dt>
-          <dd>{job.status.conditions ? job.status.conditions[0].type : 'In Progress'}</dd>
+          <dd>{job.status.conditions ? <StatusIcon status={job.status.conditions[0].type} /> : <StatusIcon status="In Progress" />}</dd>
           <dt>Start Time</dt>
           <dd><Timestamp timestamp={job.status.startTime} /></dd>
           <dt>Completion Time</dt>

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -131,8 +131,8 @@ const AlertState: React.SFC<AlertStateProps> = ({state}) => {
 const SilenceState = ({silence}) => {
   const state = silenceState(silence);
   const klass = {
-    [SilenceStates.Active]: 'fa fa-check-circle-o silence-active',
-    [SilenceStates.Pending]: 'fa fa-hourglass-half silence-pending',
+    [SilenceStates.Active]: 'pficon pficon-ok',
+    [SilenceStates.Pending]: 'fa fa-hourglass-half',
     [SilenceStates.Expired]: 'fa fa-ban text-muted',
   }[state];
   return klass ? <React.Fragment><i className={klass} aria-hidden="true"></i> {_.startCase(state)}</React.Fragment> : null;

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -10,7 +10,7 @@ import { k8sGet } from '../module/k8s';
 import { formatNamespacedRouteForResource, UIActions } from '../ui/ui-actions';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { SafetyFirst } from './safety-first';
-import { ActionsMenu, Kebab, Dropdown, Firehose, LabelList, LoadingInline, navFactory, ResourceKebab, SectionHeading, ResourceIcon, ResourceLink, ResourceSummary, humanizeMem, MsgBox } from './utils';
+import { ActionsMenu, Kebab, Dropdown, Firehose, LabelList, LoadingInline, navFactory, ResourceKebab, SectionHeading, ResourceIcon, ResourceLink, ResourceSummary, humanizeMem, MsgBox, StatusIcon } from './utils';
 import { createNamespaceModal, createProjectModal, deleteNamespaceModal, configureNamespacePullSecretModal } from './modals';
 import { RoleBindingsPage } from './RBAC';
 import { Bar, Line, requirePrometheus } from './graphs';
@@ -56,7 +56,7 @@ const NamespaceRow = ({obj: ns}) => <ResourceRow obj={ns}>
     <ResourceLink kind="Namespace" name={ns.metadata.name} title={ns.metadata.uid} />
   </div>
   <div className="col-sm-4 col-xs-6 co-break-word">
-    {ns.status.phase}
+    <StatusIcon status={ns.status.phase} />
   </div>
   <div className="col-sm-4 hidden-xs">
     <LabelList kind="Namespace" labels={ns.metadata.labels} />
@@ -90,7 +90,7 @@ const ProjectRow = ({obj: project}) => {
       </span>
     </div>
     <div className="col-md-3 col-sm-3 col-xs-4">
-      {project.status.phase}
+      <StatusIcon status={project.status.phase} />
     </div>
     <div className="col-md-3 col-sm-3 hidden-xs">
       {requester || <span className="text-muted">No requester</span>}
@@ -210,7 +210,7 @@ export const NamespaceSummary = ({ns}) => {
     <div className="col-sm-6 col-xs-12">
       <dl className="co-m-pane__details">
         <dt>Status</dt>
-        <dd>{ns.status.phase}</dd>
+        <dd><StatusIcon status={ns.status.phase} /></dd>
         <dt>Default Pull Secret</dt>
         <dd><PullSecret namespace={ns} /></dd>
         <dt>Network Policies</dt>

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -8,7 +8,7 @@ import { ResourceEventStream } from './events';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { configureUnschedulableModal } from './modals';
 import { PodsPage } from './pod';
-import { Kebab, navFactory, LabelList, ResourceKebab, SectionHeading, ResourceLink, Timestamp, units, cloudProviderNames, cloudProviderID, pluralize, containerLinuxUpdateOperator } from './utils';
+import { Kebab, navFactory, LabelList, ResourceKebab, SectionHeading, ResourceLink, Timestamp, units, cloudProviderNames, cloudProviderID, pluralize, containerLinuxUpdateOperator, StatusIcon } from './utils';
 import { Line, requirePrometheus } from './graphs';
 import { K8sResourceKind, referenceForModel } from '../module/k8s';
 import { MachineModel, NodeModel } from '../models';
@@ -59,7 +59,7 @@ const HeaderSearch = props => <ListHeader>
   <ColHead {...props} className="col-md-2 col-sm-3 hidden-xs" sortField="status.addresses">Node Addresses</ColHead>
 </ListHeader>;
 
-const NodeStatus = ({node}) => isNodeReady(node) ? <span className="node-ready"><i className="fa fa-check"></i> Ready</span> : <span className="node-not-ready"><i className="fa fa-minus-circle"></i> Not Ready</span>;
+const NodeStatus = ({node}) => isNodeReady(node) ? <StatusIcon status="Ready" /> : <StatusIcon status="Not Ready" />;
 
 const NodeCLUpdateStatus = ({node}) => {
   const updateStatus = containerLinuxUpdateOperator.getUpdateStatus(node);

--- a/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
@@ -124,8 +124,8 @@ export class InstallPlanPreview extends React.Component<InstallPlanPreviewProps,
       .catch((error) => this.setState({error}));
 
     const stepStatus = (status: Step['status']) => <React.Fragment>
-      {status === 'Present' && <i className="fa fa-check-circle co-icon-space-r" aria-hidden="true" />}
-      {status === 'Created' && <i className="fa fa-plus-circle co-icon-space-r" aria-hidden="true" />}
+      {status === 'Present' && <i className="pficon pficon-ok co-icon-space-r" aria-hidden="true" />}
+      {status === 'Created' && <i className="pficon pficon-add-circle-o co-icon-space-r" aria-hidden="true" />}
       {status}
     </React.Fragment>;
 

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -23,9 +23,9 @@ export const SubscriptionHeader: React.SFC<SubscriptionHeaderProps> = (props) =>
 
 const subscriptionState = (state: SubscriptionState) => {
   switch (state) {
-    case SubscriptionState.SubscriptionStateUpgradeAvailable: return <span><i className="fa fa-exclamation-triangle text-warning" /> Upgrade available</span>;
-    case SubscriptionState.SubscriptionStateUpgradePending: return <span><i className="fa fa-spin fa-circle-o-notch text-primary" /> Upgrading</span>;
-    case SubscriptionState.SubscriptionStateAtLatest: return <span><i className="fa fa-check-circle co-m-status--ok" /> Up to date</span>;
+    case SubscriptionState.SubscriptionStateUpgradeAvailable: return <span><i className="pficon pficon-warning-triangle-o text-warning" /> Upgrade available</span>;
+    case SubscriptionState.SubscriptionStateUpgradePending: return <span><i className="pficon pficon-in-progress text-primary" /> Upgrading</span>;
+    case SubscriptionState.SubscriptionStateAtLatest: return <span><i className="pficon pficon-ok co-m-status--ok" /> Up to date</span>;
     default: return <span className={_.isEmpty(state) && 'text-muted'}>{state || 'Unknown'}</span>;
   }
 };

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 
 import { FLAGS, connectToFlags } from '../features';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Kebab, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary, Selector } from './utils';
+import { Kebab, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary, Selector, StatusIcon } from './utils';
 import { ResourceEventStream } from './events';
 
 const pvcPhase = pvc => pvc.status.phase;
@@ -13,20 +13,7 @@ const menuActions = [...common];
 
 const PVCStatus = ({pvc}) => {
   const phase = pvcPhase(pvc);
-  if (!phase) {
-    return '-';
-  }
-
-  switch (phase) {
-    case 'Pending':
-      return <span className="text-muted"><i className="fa fa-hourglass-half" aria-hidden="true"></i> Pending</span>;
-    case 'Bound':
-      return <span className="pvc-bound"><i className="fa fa-check" aria-hidden="true"></i> Bound</span>;
-    case 'Lost':
-      return <span className="pvc-lost"><i className="fa fa-minus-circle" aria-hidden="true"></i> Lost</span>;
-    default:
-      return phase;
-  }
+  return <StatusIcon status={phase} />;
 };
 
 const Header = props => <ListHeader>

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import { Kebab, CopyToClipboard, SectionHeading, ResourceKebab, detailsPage, navFactory, ResourceLink, ResourceSummary } from './utils';
+import { Kebab, CopyToClipboard, SectionHeading, ResourceKebab, detailsPage, navFactory, ResourceLink, ResourceSummary, StatusIcon } from './utils';
 import { MaskedData } from './configmap-and-secret-data';
 // eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
@@ -94,26 +94,7 @@ export const routeStatus = (route) => {
 
 export const RouteStatus: React.SFC<RouteStatusProps> = ({obj: route}) => {
   const status: string = routeStatus(route);
-
-  switch (status) {
-    case 'Pending':
-      return <span>
-        <span className="fa fa-hourglass-half co-status-icon" aria-hidden="true"></span>
-        Pending
-      </span>;
-    case 'Accepted':
-      return <span className="route-accepted">
-        <span className="fa fa-check co-status-icon" aria-hidden="true"></span>
-        Accepted
-      </span>;
-    case 'Rejected':
-      return <span className="route-rejected">
-        <span className="fa fa-times-circle co-status-icon" aria-hidden="true"></span>
-        Rejected
-      </span>;
-    default:
-      break;
-  }
+  return <StatusIcon status={status} />;
 };
 RouteStatus.displayName = 'RouteStatus';
 

--- a/frontend/public/components/software-details.jsx
+++ b/frontend/public/components/software-details.jsx
@@ -11,14 +11,14 @@ import { FLAGS, connectToFlags, flagPending } from '../features';
 
 const StatusIconRow = ({state, text}) => {
   const iconClasses = {
-    ok: 'fa-check',
-    warning: 'fa-warning',
-    critical: 'fa-warning',
-    unknown: 'fa-question-circle',
+    ok: 'pficon-ok',
+    warning: 'pficon-warning-triangle-o',
+    critical: 'pficon-error-circle-o',
+    unknown: 'pficon-unknown',
     'access-denied': 'fa-ban',
   };
   return <div className={classNames('co-m-status', [`co-m-status--${state}`])}>
-    <i className={classNames('co-m-status__icon', 'fa', iconClasses[state])}></i>
+    <i className={classNames('co-m-status__icon', 'pficon', iconClasses[state])}></i>
     <span className="co-m-status__text">{text}</span>
   </div>;
 };

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -49,6 +49,7 @@ export * from './name-value-editor';
 export * from './k8s-watcher';
 export * from './workload-pause';
 export * from './list-dropdown';
+export * from './status-icon';
 
 /*
   Add the enum for NameValueEditorPair here and not in its namesake file because the editor should always be

--- a/frontend/public/components/utils/service-catalog-status.tsx
+++ b/frontend/public/components/utils/service-catalog-status.tsx
@@ -2,29 +2,11 @@ import * as React from 'react';
 
 // eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, serviceCatalogStatus } from '../../module/k8s';
+import { StatusIcon } from '../utils';
 
 export const StatusWithIcon: React.SFC<StatusWithIconProps> = ({obj}) => {
   const objStatus: string = serviceCatalogStatus(obj);
-
-  switch (objStatus) {
-    case 'Not Ready':
-      return <span className="status-not-ready">
-        <span className="fa fa-hourglass-half co-status-icon" aria-hidden="true"></span>
-        Not Ready
-      </span>;
-    case 'Failed':
-      return <span className="status-failed">
-        <span className="fa fa-times co-status-icon" aria-hidden="true"></span>
-        Failed
-      </span>;
-    case 'Ready':
-      return <span className="status-ready">
-        <span className="fa fa-check co-status-icon" aria-hidden="true"></span>
-        Ready
-      </span>;
-    default:
-      return <span className="status-unknown">-</span>;
-  }
+  return <StatusIcon status={objStatus} />;
 };
 
 /* eslint-disable no-undef */

--- a/frontend/public/components/utils/status-icon.tsx
+++ b/frontend/public/components/utils/status-icon.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Icon } from 'patternfly-react';
+import {CamelCaseWrap} from './camel-case-wrap';
+
+export const StatusIcon: React.FunctionComponent<StatusIconProps> = ({status}) => {
+
+  if (!status){
+    return <span>-</span>;
+  }
+
+  switch (status) {
+
+    case 'Pending':
+      return <span><Icon type="fa" name="hourglass-half" /> <CamelCaseWrap value={status} /></span>;
+
+    case 'Expired':
+    case 'Cancelled':
+    case 'Not Ready':
+    case 'Terminating':
+      return <span><Icon type="fa" name="ban" /> <CamelCaseWrap value={status} /></span>;
+
+    case 'Warning':
+      return <span><Icon type="pf" name="warning-triangle-o" /> <CamelCaseWrap value={status} /></span>;
+
+    case 'Running':
+      return <span><Icon type="fa" name="refresh" /> <CamelCaseWrap value={status} /></span>;
+
+    case 'ContainerCreating':
+    case 'Updating':
+    case 'Upgrading':
+    case 'In Progress':
+      return <span><Icon type="pf" name="in-progress" /> <CamelCaseWrap value={status} /></span>;
+
+    case 'ContainerCannotRun':
+    case 'CrashLoopBackOff':
+    case 'Critical':
+    case 'Error':
+    case 'Failed':
+    case 'InstallCheckFailed':
+    case 'Lost':
+    case 'Rejected':
+      return <span><Icon type="pf" name="error-circle-o" /> <CamelCaseWrap value={status} /></span>;
+
+    case 'Accepted':
+    case 'Active':
+    case 'Bound':
+    case 'Complete':
+    case 'Completed':
+    case 'Enabled':
+    case 'Ready':
+    case 'Up to date':
+      return <span><Icon type="pf" name="ok" /> <CamelCaseWrap value={status} /></span>;
+
+    case 'Unknown':
+      return <span><Icon type="pf" name="unknown" /> <CamelCaseWrap value={status} /></span>;
+
+    case 'New':
+      return <span><Icon type="fa" name="hourglass-1" /> <CamelCaseWrap value={status} /></span>;
+
+    default:
+      return <span><CamelCaseWrap value={status} /></span>;
+  }
+};
+
+/* eslint-disable no-undef */
+export type StatusIconProps = {
+  status?: string;
+};

--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -11,26 +11,10 @@
   width: 16px;
 }
 
-.node-ready,
-.pvc-bound,
-.route-accepted,
-.status-ready,
-.silence-active {
-  color: $color-pf-green-400;
-}
-
-.alert-firing,
-.node-not-ready,
-.pvc-lost,
-.route-rejected,
-.status-failed {
+.alert-firing {
   color: $color-pf-red;
 }
 
 .alert-pending {
   color: $color-pf-orange-300;
-}
-
-.silence-pending {
-  color: $color-pf-black-700;
 }


### PR DESCRIPTION
[CONSOLE-986](https://jira.coreos.com/browse/CONSOLE-986)

Make status icons & labels match [design](https://github.com/openshift/openshift-origin-design/blob/master/web-console/4.0-designs/status/status.md)

![screen shot 2018-11-27 at 4 14 26 pm](https://user-images.githubusercontent.com/26305082/49112030-b3f82880-f25f-11e8-84e4-207ba7d6f79b.png)
![screen shot 2018-11-27 at 4 06 06 pm](https://user-images.githubusercontent.com/26305082/49112034-b65a8280-f25f-11e8-880c-915d91e887db.png)
![screen shot 2018-11-27 at 4 06 31 pm](https://user-images.githubusercontent.com/26305082/49112042-b9557300-f25f-11e8-90f7-41b33a8b2a79.png)
![screen shot 2018-11-27 at 4 13 03 pm](https://user-images.githubusercontent.com/26305082/49112053-bce8fa00-f25f-11e8-9a84-1d054a99b254.png)
![screen shot 2018-11-27 at 4 08 16 pm](https://user-images.githubusercontent.com/26305082/49112124-f1f54c80-f25f-11e8-98f1-40e15ed4b32a.png)
