### PR TITLE
Monitoring: Fix "Silenced" state not being shown in Active Alerts list

### DIFF
--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -78,6 +78,12 @@ export default (state, action) => {
           a.silencedBy = _.filter(_.get(silences, 'data'), s => isSilenced(a, s));
           if (a.silencedBy.length) {
             a.state = AlertStates.Silenced;
+            // Also set the state of Alerts in `rule.alerts`
+            _.each(a.rule.alerts, ruleAlert => {
+              if (_.some(a.silencedBy, s => isSilenced(ruleAlert, s))) {
+                ruleAlert.state = AlertStates.Silenced;
+              }
+            });
           }
         });
         state = state.setIn(['monitoring', 'alerts'], alerts);


### PR DESCRIPTION
The Active Alerts list (on the Rule details page) was showing "Silenced"
alerts as "Firing".