### PR TITLE
Show only necessary columns for NetworkPolicy and LimitRange lists on mobile

### DIFF
--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -13,13 +13,13 @@ const LimitRangeReference: K8sResourceKindReference = 'LimitRange';
 
 const LimitRangeRow: React.SFC<LimitRangeProps> = ({obj}) =>
   <div className="row co-resource-list__item">
-    <div className="col-xs-4">
+    <div className="col-sm-4 col-xs-6">
       <ResourceLink kind={LimitRangeReference} name={obj.metadata.name} namespace={obj.metadata.namespace} />
     </div>
-    <div className="col-xs-4">
+    <div className="col-sm-4 col-xs-6">
       <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
     </div>
-    <div className="col-xs-4">
+    <div className="col-sm-4 hidden-xs">
       <Timestamp timestamp={obj.metadata.creationTimestamp} />
     </div>
     <div className="dropdown-kebab-pf">
@@ -29,9 +29,9 @@ const LimitRangeRow: React.SFC<LimitRangeProps> = ({obj}) =>
 
 const LimitRangeHeader: React.SFC<LimitRangeHeaderProps> = props =>
   <ListHeader>
-    <ColHead {...props} className="col-xs-4" sortField="metadata.name">Name</ColHead>
-    <ColHead {...props} className="col-xs-4" sortField="metadata.namespace">Namespace</ColHead>
-    <ColHead {...props} className="col-xs-4" sortField="metadata.creationTimestamp">Created</ColHead>
+    <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
+    <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
+    <ColHead {...props} className="col-sm-4 hidden-xs" sortField="metadata.creationTimestamp">Created</ColHead>
   </ListHeader>;
 
 export const LimitRangeList: React.SFC = props =>

--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -10,21 +10,21 @@ const { common } = Kebab.factory;
 const menuActions = [...common];
 
 const Header = props => <ListHeader>
-  <ColHead {...props} className="col-xs-4" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-xs-3" sortField="metadata.namespace">Namespace</ColHead>
-  <ColHead {...props} className="col-xs-5" sortField="spec.podSelector">Pod Selector</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
+  <ColHead {...props} className="col-sm-4 hidden-xs" sortField="spec.podSelector">Pod Selector</ColHead>
 </ListHeader>;
 
 const kind = 'NetworkPolicy';
 const Row = ({obj: np}) => <div className="row co-resource-list__item">
-  <div className="col-xs-4">
+  <div className="col-sm-4 col-xs-6">
     <ResourceLink kind={kind} name={np.metadata.name} namespace={np.metadata.namespace} title={np.metadata.name} />
   </div>
-  <div className="col-xs-3 co-break-word">
+  <div className="col-sm-4 col-xs-6 co-break-word">
     <ResourceLink kind={'Namespace'} name={np.metadata.namespace} title={np.metadata.namespace} />
   </div>
 
-  <div className="col-xs-5 co-break-word">
+  <div className="col-sm-4 hidden-xs co-break-word">
     {
       _.isEmpty(np.spec.podSelector) ?
         <Link to={`/search/ns/${np.metadata.namespace}?kind=Pod`}>{`All pods within ${np.metadata.namespace}`}</Link> :


### PR DESCRIPTION
Noticed that these two list pages show more columns then needed. Other list pages should be fine.
@spadgett PTAL