### PR TITLE
Address filter bar usability issues

### DIFF
--- a/frontend/public/components/_row-filter.scss
+++ b/frontend/public/components/_row-filter.scss
@@ -1,8 +1,28 @@
 $color-row-filter-border: $color-pf-black-300;
 $color-row-filter-border--active: $color-pf-blue-300;
 
+.co-m-row-filter__controls {
+  display: flex;
+  flex: 1;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+}
+
+.co-m-row-filter__items {
+  font-weight: bold;
+  padding: 7px 10px;
+  white-space: nowrap;
+}
+
+.co-m-row-filter__selector {
+  padding: 7px 10px;
+  white-space: nowrap;
+}
+
 .row-filter {
   background-color: $color-pf-black-150;
+  display: flex;
+  flex-wrap: wrap;
   margin-bottom: 30px;
   margin-top: 3px;
   outline: 1px solid $color-row-filter-border;

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -75,6 +75,7 @@ export class ListPageWrapper_ extends React.PureComponent {
         key={i}
         applyFilter={this.props.applyFilter}
         items={_.isFunction(items) ? items(_.pick(this.props, kinds)) : items}
+        itemCount={_.size(data)}
         numbers={count || _.countBy(data, reducer)}
         selected={selected}
         type={type}

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -574,6 +574,7 @@ const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringListPage
         <div className="row">
           <CheckBoxes
             items={rowFilter.items}
+            itemCount={_.size(data)}
             numbers={_.countBy(data, rowFilter.reducer)}
             reduxIDs={[reduxID]}
             selected={rowFilter.selected}
@@ -1018,6 +1019,7 @@ export type ListPageProps = {
   data: Rule[] | Silence[];
   filters: {[key: string]: any};
   Header: React.ComponentType<any>;
+  itemCount: number;
   kindPlural: string;
   loaded: boolean;
   loadError?: string;


### PR DESCRIPTION
Added a "Selected All Filters" link and item count. The existing classes didn't seem to be using BEM; let me know if I should swap them out.

Many items (not all selected):
<img width="1064" alt="screen shot 2018-11-29 at 10 26 11 am" src="https://user-images.githubusercontent.com/7014965/49232595-40226100-f3c2-11e8-88d8-103ec5fc2bf0.png">

Many items (all selected):
<img width="1066" alt="screen shot 2018-11-29 at 10 26 25 am" src="https://user-images.githubusercontent.com/7014965/49232609-44e71500-f3c2-11e8-8a87-d189f78a2ffa.png">

Fewer items (not all selected):
<img width="1065" alt="screen shot 2018-11-29 at 10 27 51 am" src="https://user-images.githubusercontent.com/7014965/49232622-4a445f80-f3c2-11e8-9f29-a47b0ce36fb1.png">

Fewer items (all selected):
<img width="1060" alt="screen shot 2018-11-29 at 10 28 00 am" src="https://user-images.githubusercontent.com/7014965/49232633-4f091380-f3c2-11e8-90cd-7d595ca7d622.png">

Edge case with an entire row of filters:
<img width="1171" alt="screen shot 2018-11-29 at 10 49 08 am" src="https://user-images.githubusercontent.com/7014965/49233665-7365ef80-f3c4-11e8-8356-b18a18290352.png">

Fixes [CONSOLE-762](https://jira.coreos.com/browse/CONSOLE-762).

@openshift/team-ux-review, could you please review? Thanks!



