### PR TITLE
eslint: disallow lodash imports (use lodash-es instead)

### DIFF
--- a/frontend/public/.eslintrc
+++ b/frontend/public/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "extends": [
+    "../.eslintrc"
+  ],
+  "rules": {
+    "no-restricted-imports": ["error", {
+      "name": "lodash",
+      "message": "Use lodash-es instead.",
+    }],
+  }
+}


### PR DESCRIPTION
https://eslint.org/docs/rules/no-restricted-imports

```
$ eslint --ext .js,.jsx,.ts,.tsx --color .

/Users/sam/go/src/github.com/openshift/console/frontend/public/components/storage-class-form.tsx
  5:1  error  'lodash' import is restricted from being used. Use lodash-es instead  no-restricted-imports

✖ 1 problem (1 error, 0 warnings)
```

/cc @alecmerdler @jeff-phillips-18 