### PR TITLE
Adjustments to project status filters for improved display at responsive sizes and sidebar open.

### DIFF
--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -27,13 +27,4 @@
   &--logo {
     padding-top: ($grid-gutter-width / 2);
   }
-  &--overview {
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
-    @media (min-width: $screen-md-min) {
-      flex-direction: row;
-    }
-    justify-content: space-between;
-  }
 }

--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -1,14 +1,48 @@
+.co-m-nav-title--overview {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+
+  @media (max-width: $screen-sm-max) {
+    &.overview-filter-group {
+      flex-direction: column;
+    }
+  }
+
+  // Keep the flex child elements in a column, when <1200 && when the sidebar is open,
+  // so that the stacked filter group fields are displayed beneath the <h1>
+  @media (max-width: $screen-md-max) {
+    .overview--sidebar-shown & {
+      flex-direction: column;
+    }
+  }
+}
+
 .overview-toolbar {
   margin: 0 0 ($grid-gutter-width / 2) 0;
   min-width: 0;
   padding: 0;
-  @media (max-width: $screen-sm-max) {
-    // maintain single row alignment
-    .toolbar-pf-action-right {
-      align-items: flex-end;
-      display: flex;
-      float: none;
-      justify-content: space-between;
+
+  .toolbar-pf-actions {
+    margin: 0;
+  }
+
+  // Override pf and make toolbar a flex object to control positioning
+  .toolbar-pf-action-right {
+    align-items: flex-end;
+    display: flex;
+    float: none;
+
+    @media (min-width: $screen-sm-min) and (max-width: $screen-md-max) {
+      // switch to stacked fields when side open but still at desktop widths
+      .overview--sidebar-shown & {
+        align-items: initial;
+        display: flex;
+        flex-direction: column;
+        float: none;
+        min-width: 160px;
+        width: calc(100% - 535px);
+      }
     }
   }
 }
@@ -16,23 +50,41 @@
 .overview-toolbar__dropdown {
   display: inline-block;
   max-width: 100%; // enable text-overflow: ellipsis
+
   @media (max-width: $screen-sm-max) {
     min-width: 100%;
   }
-  .btn-dropdown {
-    max-width: 250px; // same at default .text-filter
-    width: 100%;
 
-    @media (min-width: $screen-xs-min) and (max-width: $screen-sm-max) {
-      max-width: 100%;
+  .overview--sidebar-shown & {
+    @media (max-width: $screen-md-max) {
+      min-width: 100%; // stack selections
     }
+  }
+
+  .btn-dropdown {
+    width: 100%;
+  }
+
+  .btn-link__titlePrefix {
+    color: lighten($btn-default-color, 15%);
+    font-weight: normal;
+    margin-right: 2px;
+  }
+
+  .dropdown-menu {
+    min-width: 250px;
   }
 }
 
 .overview-toolbar__form-group {
-  flex: 1 1 50%;
+  flex: 1 1 auto;
   min-width: 0; // enable truncation
   padding-right: 8px;
+
+  @media (max-width: $screen-sm-max) {
+    flex: 1 1 50%;
+  }
+
   @media (min-width: $screen-xs-min) {
     padding-right: 15px;
   }
@@ -41,6 +93,18 @@
     border-right: 0;
     margin-bottom: 0;
     padding-left: 0;
+
+    @media (max-width: $screen-md-max) {
+      .overview--sidebar-shown & {
+        padding-right: 0;
+      }
+    }
+
+    @media (min-width: $screen-lg-min) and (max-width: ($screen-lg-min + 200)) {
+      .overview--sidebar-shown & {
+        max-width: 250px; // prevents long group by select from pushing filter input behind sidebar
+      }
+    }
   }
 
   + .overview-toolbar__form-group {
@@ -49,6 +113,19 @@
     @media (min-width: $screen-xs-min) {
       padding-left: 15px;
     }
+
+    .overview--sidebar-shown & {
+      @media (max-width: $screen-md-max) {
+        border: 0;
+        padding-left: 0;
+        padding-top: 5px;
+      }
+
+    }
+  }
+
+  .co-actions-menu {
+    margin-left: 0;
   }
 }
 
@@ -64,16 +141,22 @@
 .overview-toolbar__label {
   margin: 0 10px 0 0;
   vertical-align: middle;
-  @media (max-width: $screen-sm-max) {
+  white-space: nowrap;
+  @media (max-width: $screen-md-max) {
     margin-bottom: 0;
     margin-right: 10px;
   }
 }
 
-@media (max-width: $screen-sm-max) {
-  .overview-toolbar__text-filter .text-filter {
-    min-width: 100%;
-    width: 100%;
+.overview-toolbar__text-filter .text-filter {
+  min-width: 100%;
+  width: 100%;
+
+  .overview--sidebar-shown & {
+    width: auto;
+  }
+  @media (min-width: $screen-md-min) {
+    width: 250px;
   }
 }
 
@@ -108,18 +191,18 @@
     z-index: 5;
   }
 
-    .overview__sidebar-appear {
-      opacity: 0;
-      transform: translateX(10%);
-    }
+  .overview__sidebar-appear {
+    opacity: 0;
+    transform: translateX(10%);
+  }
 
-    .overview__sidebar-appear-active {
-      opacity: 1;
-      transform: translateX(0);
-      transition:
-        opacity 175ms ease-out,
-        transform 225ms ease-out;
-    }
+  .overview__sidebar-appear-active {
+    opacity: 1;
+    transform: translateX(0);
+    transition:
+      opacity 175ms ease-out,
+      transform 225ms ease-out;
+  }
 
   &.overview--sidebar-shown {
     .overview__sidebar {
@@ -130,6 +213,7 @@
     @media(min-width: $screen-lg-min) {
       .overview__main-column {
         width: calc(100% - 535px);
+
         .co-m-pane__body {
           padding-right: 0;
         }
@@ -151,6 +235,7 @@
       // adjustments to increase click target and default color contrast because it's on a grey background
       opacity: .3;
       padding: 10px 15px;
+
       &:hover, &:focus {
         opacity: .6;
       }

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -285,7 +285,7 @@ const headingDispatchToProps = (dispatch): OverviewHeadingPropsFromDispatch => (
 });
 
 const OverviewHeading_: React.SFC<OverviewHeadingProps> = ({disabled, firstLabel = '', groupOptions, handleFilterChange = _.noop, handleGroupChange = _.noop, selectedGroup = '', selectView, selectedView, title, project}) => (
-  <div className="co-m-nav-title co-m-nav-title--overview">
+  <div className={classnames('co-m-nav-title co-m-nav-title--overview', { 'overview-filter-group': selectedView === View.Resources })}>
     {
       title &&
       <h1 className="co-m-pane__heading co-m-pane__heading--overview">
@@ -320,14 +320,13 @@ const OverviewHeading_: React.SFC<OverviewHeadingProps> = ({disabled, firstLabel
       <Toolbar.RightContent>
         {selectedView === View.Resources && <React.Fragment>
           <div className="form-group overview-toolbar__form-group">
-            <label className="overview-toolbar__label co-no-bold">
-              Group by
-            </label>
             <Dropdown
               className="overview-toolbar__dropdown"
+              menuClassName="dropdown-menu--text-wrap"
               disabled={disabled}
               items={groupOptions}
               onChange={handleGroupChange}
+              titlePrefix="Group by"
               title={groupOptions[selectedGroup]}
               spacerBefore={new Set([firstLabel])}
               headerBefore={{[firstLabel]: 'Label'}}
@@ -345,7 +344,7 @@ const OverviewHeading_: React.SFC<OverviewHeadingProps> = ({disabled, firstLabel
             </div>
           </div>
         </React.Fragment>}
-        {selectedView === View.Dashboard && !_.isEmpty(project) && <div className="form-group overview-toolbar__form-group">
+        {selectedView === View.Dashboard && !_.isEmpty(project) && <div className="form-group">
           <ActionsMenu actions={overviewMenuActions.map((a: KebabAction) => a(ProjectModel, project))} />
         </div>}
       </Toolbar.RightContent>

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -180,7 +180,7 @@ tags-input .autocomplete .suggestion-item em {
   }
 }
 
-@media (max-width: $screen-sm-max) {
+@media (max-width: $screen-md-max) {
   .toolbar-pf-actions {
     display: block;
     margin-bottom: 0;


### PR DESCRIPTION
The "Group by" text is included as a title prefix within the dropdown select field.
The filter group wraps beneath the page title and then the form fields stack when space constraints require.

Also fixes https://github.com/openshift/console/issues/847

https://jira.coreos.com/browse/CONSOLE-1053
https://docs.google.com/document/d/1jYfQgRG94GlEbUvDA9AOwxnvczghI692glzZhHP2xcA/edit?usp=sharing

<img width="1279" alt="screen shot 2018-12-03 at 5 28 04 pm" src="https://user-images.githubusercontent.com/1874151/49405584-d509bf00-f720-11e8-90d8-09e659378419.png">

<img width="1293" alt="screen shot 2018-12-03 at 5 20 40 pm" src="https://user-images.githubusercontent.com/1874151/49405613-e5ba3500-f720-11e8-8906-e1d46de4e776.png">

<img width="1051" alt="screen shot 2018-12-03 at 5 21 16 pm" src="https://user-images.githubusercontent.com/1874151/49405498-97a53180-f720-11e8-8819-b37a51899f62.png">
