### PR TITLE
Reduce tile view pages chunk size, fix minor display issues

### DIFF
--- a/frontend/integration-tests/tests/performance.scenario.ts
+++ b/frontend/integration-tests/tests/performance.scenario.ts
@@ -96,7 +96,7 @@ describe('Performance test', () => {
       expect(routeChunk).not.toBeNull();
       // FIXME: Really need to address this chunk size
       if (routeName === 'catalog' || routeName === 'marketplace') {
-        expect((routeChunk as any).decodedBodySize).toBeLessThan(200000);
+        expect((routeChunk as any).decodedBodySize).toBeLessThan(100000);
       } else {
         expect((routeChunk as any).decodedBodySize).toBeLessThan(chunkLimit);
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,7 +68,7 @@
     "openshift-logos-icon": "1.7.1",
     "patternfly": "^3.54.8",
     "patternfly-react": "^2.22.0",
-    "patternfly-react-extensions": "2.12.8",
+    "patternfly-react-extensions": "2.13.11",
     "plotly.js": "1.28.x",
     "prop-types": "15.6.x",
     "react": "16.6.3",

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -19,9 +19,23 @@ $catalog-item-icon-size-sm: 24px;
 
 .co-catalog {
   background: $color-pf-black-150;
+  display: flex;
+  flex-direction: column;
   min-height: 100%;
   min-width: 465px; // in order to accommodate filters and tiles at mobile
   padding: 0 0 ($grid-gutter-width / 2);
+}
+
+.co-catalog-connect {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+
+  .loading-box {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+  }
 }
 
 .co-catalog-item-details {
@@ -84,15 +98,15 @@ $catalog-item-icon-size-sm: 24px;
 }
 
 .co-catalog-page {
-  background: #fff;
+  background: $color-pf-white;
   box-shadow: 0 0.0625rem 0.125rem 0 rgba(3,3,3,.2);
   display: flex;
+  flex:1;
   margin: 0 ($grid-gutter-width / 2);
   padding: ($grid-gutter-width / 2) 0 0;
 
   &__content {
     flex: 1 1 auto;
-    margin: 0 ($grid-gutter-width / 2);
   }
 
   &__heading {

--- a/frontend/public/components/catalog/catalog-page.jsx
+++ b/frontend/public/components/catalog/catalog-page.jsx
@@ -170,7 +170,7 @@ export const Catalog = connectToFlags(FLAGS.OPENSHIFT, FLAGS.SERVICE_CATALOG)(({
       prop: 'imagestreams',
     });
   }
-  return <Firehose resources={mock ? [] : resources}>
+  return <Firehose resources={mock ? [] : resources} className="co-catalog-connect">
     <CatalogListPage namespace={namespace} />
   </Firehose>;
 });

--- a/frontend/public/components/marketplace/kubernetes-marketplace.jsx
+++ b/frontend/public/components/marketplace/kubernetes-marketplace.jsx
@@ -106,7 +106,7 @@ export const Marketplace = () => {
     namespace: undefined, // shows operators from all-namespaces - when backend is hooked up we will use 'marketplace'
     prop: 'packagemanifests',
   });
-  return <Firehose resources={resources}>
+  return <Firehose resources={resources} className="co-catalog-connect">
     <MarketplaceListPage />
   </Firehose>;
 };

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -167,7 +167,7 @@ export const Firehose = connect(
       ]));
 
       return this.props.loaded || this.firehoses.length > 0
-        ? <ConnectToState reduxes={reduxes}> {children} </ConnectToState>
+        ? <ConnectToState reduxes={reduxes} className={this.props.className}> {children} </ConnectToState>
         : null;
     }
   }

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -187,14 +187,6 @@ tags-input .autocomplete .suggestion-item em {
   }
 }
 
-// Catalog tile adjustments for fade out overflow text, due to different base font size
-.catalog-tile-pf {
-  padding-bottom: 17px;
-}
-.catalog-tile-pf-body .catalog-tile-pf-description::after {
-  bottom: 15px;
-}
-
 .table {
   margin-bottom: 0;
   td {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8213,15 +8213,16 @@ patternfly-bootstrap-treeview@~2.1.0:
     bootstrap "3.3.x"
     jquery ">= 2.1.x"
 
-patternfly-react-extensions@2.12.8:
-  version "2.12.8"
-  resolved "https://registry.yarnpkg.com/patternfly-react-extensions/-/patternfly-react-extensions-2.12.8.tgz#268674846e3600517a07b8a0d80f2cf7305e39a5"
+patternfly-react-extensions@2.13.11:
+  version "2.13.11"
+  resolved "https://registry.yarnpkg.com/patternfly-react-extensions/-/patternfly-react-extensions-2.13.11.tgz#9c45c5e79dc08b9583c87f08eaf0f5d6b8675d17"
   dependencies:
     breakjs "^1.0.0"
     classnames "^2.2.5"
     css-element-queries "^1.0.1"
-    patternfly "^3.52.1"
-    patternfly-react "^2.23.0"
+    patternfly "^3.58.0"
+    patternfly-react "^2.25.1"
+    react-bootstrap "^0.32.1"
     react-virtualized "9.x"
 
 patternfly-react@^2.22.0:
@@ -8247,15 +8248,15 @@ patternfly-react@^2.22.0:
     sortabular "^1.5.1"
     table-resolver "^3.2.0"
 
-patternfly-react@^2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.23.0.tgz#da0e4d2f37dfab1ebce3a7a377052d2446c9d28c"
+patternfly-react@^2.25.1:
+  version "2.25.1"
+  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.25.1.tgz#0a05830317219e4c7e27fcb5c703c9e19077fab4"
   dependencies:
     bootstrap-slider-without-jquery "^10.0.0"
     breakjs "^1.0.0"
     classnames "^2.2.5"
     css-element-queries "^1.0.1"
-    patternfly "^3.52.4"
+    patternfly "^3.58.0"
     react-bootstrap "^0.32.1"
     react-bootstrap-switch "^15.5.3"
     react-bootstrap-typeahead "^3.1.3"
@@ -8270,9 +8271,40 @@ patternfly-react@^2.23.0:
     sortabular "^1.5.1"
     table-resolver "^3.2.0"
 
-patternfly@^3.52.1, patternfly@^3.52.4, patternfly@^3.54.8:
+patternfly@^3.52.4, patternfly@^3.54.8:
   version "3.54.8"
   resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.54.8.tgz#fd6c69714dc460575d2534c9f29017a58b442a83"
+  dependencies:
+    bootstrap "~3.3.7"
+    font-awesome "^4.7.0"
+    jquery "~3.2.1"
+  optionalDependencies:
+    "@types/c3" "^0.6.0"
+    bootstrap-datepicker "^1.7.1"
+    bootstrap-sass "^3.3.7"
+    bootstrap-select "1.12.2"
+    bootstrap-slider "^9.9.0"
+    bootstrap-switch "~3.3.4"
+    bootstrap-touchspin "~3.1.1"
+    c3 "~0.4.11"
+    d3 "~3.5.17"
+    datatables.net "^1.10.15"
+    datatables.net-colreorder "^1.4.1"
+    datatables.net-colreorder-bs "~1.3.2"
+    datatables.net-select "~1.2.0"
+    drmonty-datatables-colvis "~1.1.2"
+    eonasdan-bootstrap-datetimepicker "^4.17.47"
+    font-awesome-sass "^4.7.0"
+    google-code-prettify "~1.0.5"
+    jquery-match-height "^0.7.2"
+    moment "^2.19.1"
+    moment-timezone "^0.4.1"
+    patternfly-bootstrap-combobox "~1.1.7"
+    patternfly-bootstrap-treeview "~2.1.0"
+
+patternfly@^3.58.0:
+  version "3.58.0"
+  resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.58.0.tgz#c94516a9fbf2b645b63a53e58fcf39c45bf66a8b"
   dependencies:
     bootstrap "~3.3.7"
     font-awesome "^4.7.0"


### PR DESCRIPTION
Reduces the chunk size be eliminating the use of _.intersection in the tile views (was adding about 80k) and updating to latest patternfly-react-extensions which contains some dependency fixes.

Removed overrides for the tile description fader as this was fixed in patternfly-react-extensions.

Updated the tile view pages to always be full page rather than jumping when filtering.

Bumps patternfly-react-extensions to 2.13.11

Fixes:  https://bugzilla.redhat.com/show_bug.cgi?id=1640054

Fixes #869 

@sosiouxme fyi
