### PR TITLE
Correctly set default alignment of css grid elements within project-overview__additional-info

### DIFF
--- a/frontend/public/components/overview/_project-overview.scss
+++ b/frontend/public/components/overview/_project-overview.scss
@@ -1,7 +1,7 @@
 // Nesting increases specificity so that pf list styles are always overridden
 .project-overview {
   .project-overview__additional-info {
-    align-items: baseline;
+    align-items: center;
     display: grid;
     grid-column-gap: 3%;
     grid-row-gap: 10px;


### PR DESCRIPTION
…
Fixes https://jira.coreos.com/browse/CONSOLE-1049

![align-items](https://user-images.githubusercontent.com/1874151/49304337-091f7e80-f49a-11e8-856a-f491ede65a20.gif)
