### PR TITLE
Update create flow for pvc, routes, storage classes.

### DIFF
--- a/frontend/__tests__/components/storage-class-form.spec.tsx
+++ b/frontend/__tests__/components/storage-class-form.spec.tsx
@@ -31,7 +31,7 @@ describe(ConnectedStorageClassForm.displayName, () => {
   });
 
   it('renders the proper header', () => {
-    expect(wrapper.find('.co-m-pane__heading').text()).toEqual('Create Storage Class');
+    expect(wrapper.find('.co-m-pane__name').text()).toEqual('Create Storage Class');
   });
 
   it('renders a form', () => {

--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -94,6 +94,10 @@ describe('Kubernetes resource CRUD operations', () => {
         } else {
           await crudView.createYAMLButton.click();
         }
+        const formToYamlExists = await crudView.createYAMLLink.isPresent();
+        if (formToYamlExists) {
+          crudView.createYAMLLink.click();
+        }
         await yamlView.isLoaded();
 
         const content = await yamlView.editorContent.getText();

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -106,14 +106,8 @@ const filters = [{
 
 export const PersistentVolumeClaimsList = props => <List {...props} Header={Header} Row={Row} />;
 export const PersistentVolumeClaimsPage = props => {
-  const createItems = {
-    form: 'From Form',
-    yaml: 'From YAML',
-  };
   const createProps = {
-    items: createItems,
-    btnActionItemKey: 'form',
-    createLink: type => `/k8s/ns/${props.namespace}/persistentvolumeclaims/new/${type !== 'yaml' ? 'form' : ''}`,
+    to: `/k8s/ns/${props.namespace}/persistentvolumeclaims/new/form`,
   };
   return <ListPage {...props} ListComponent={PersistentVolumeClaimsList} kind={kind} canCreate={true} rowFilters={filters} createProps={createProps} />;
 };

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -310,21 +310,15 @@ const filters = [{
 }];
 
 export const RoutesPage: React.SFC<RoutesPageProps> = props => {
-  const createItems = {
-    form: 'From Form',
-    yaml: 'From YAML',
-  };
 
   const createProps = {
-    items: createItems,
-    createLink: (type) => `/k8s/ns/${props.namespace || 'default'}/routes/new/${type !== 'yaml' ? type : ''}`,
+    to: `/k8s/ns/${props.namespace || 'default'}/routes/new/form`,
   };
 
   return <ListPage
     ListComponent={RoutesList}
     kind={RoutesReference}
     canCreate={true}
-    createButtonText="Create"
     createProps={createProps}
     rowFilters={filters}
     {...props}

--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -227,7 +227,7 @@ export class CreateRoute extends React.Component<null, CreateRouteState> {
             {title}
           </div>
           <div className="co-m-pane__heading-link">
-            <Link to={`/k8s/ns/${this.state.namespace}/routes/new`}>From YAML</Link>
+            <Link to={`/k8s/ns/${this.state.namespace}/routes/new`} id="yaml-link" replace>Edit YAML</Link>
           </div>
         </h1>
       </div>

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash-es';
@@ -795,8 +796,14 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
     return (
       <div className="co-m-pane__body">
         <Form className="wizard-form">
-          <h1 className="co-m-pane__heading">Create Storage Class</h1>
-
+          <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
+            <div className="co-m-pane__name">
+              Create Storage Class
+            </div>
+            <div className="co-m-pane__heading-link">
+              <Link to="/k8s/cluster/storageclasses/new" id="yaml-link" replace>Edit YAML</Link>
+            </div>
+          </h1>
           <FormGroup controlId={'basic-settings-name'} validationState={fieldErrors.nameValidationMsg ? 'error': null}>
             <label className="control-label co-required" htmlFor="storage-class-name">Name</label>
             <FormControl

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -60,14 +60,8 @@ StorageClassList.displayName = 'StorageClassList';
 
 /* eslint-disable no-undef */
 export const StorageClassPage: React.SFC<StorageClassPageProps> = props => {
-  const createItems = {
-    form: 'From Form',
-    yaml: 'From YAML',
-  };
-
   const createProps = {
-    items: createItems,
-    createLink: (type) => `/k8s/cluster/storageclasses/new/${type !== 'yaml' ? type : ''}`,
+    to: '/k8s/cluster/storageclasses/new/form',
   };
 
   return <ListPage

--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -2,6 +2,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
 
 import { k8sCreate, K8sResourceKind, referenceFor } from '../../module/k8s';
 import { ButtonBar, history, ListDropdown, NameValueEditor, resourceObjPath, RequestSizeInput } from '../utils';
@@ -276,7 +277,14 @@ class CreatePVCPage extends React.Component<CreatePVCPageProps, CreatePVCPageSta
         <Helmet>
           <title>{title}</title>
         </Helmet>
-        <h1 className="co-m-pane__heading">{title}</h1>
+        <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
+          <div className="co-m-pane__name">
+            {title}
+          </div>
+          <div className="co-m-pane__heading-link">
+            <Link to={`/k8s/ns/${namespace}/persistentvolumeclaims/new`} id="yaml-link" replace>Edit YAML</Link>
+          </div>
+        </h1>
         <form className="co-m-pane__body-group " onSubmit={this.save}>
           <CreatePVCForm onChange={this.onChange} namespace={namespace} />
           <ButtonBar errorMessage={error} inProgress={inProgress}>


### PR DESCRIPTION
PR for jira card: https://jira.coreos.com/browse/CONSOLE-1047

Update create flow for pvc, routes, storage classes: to default to form editor:

- Add Edit YAML Link option in upper right corner. 

- Eliminate dropdown create buttons for these workloads. 

- OnCancel of YAML editor, route the user back to the list page.
