### PR TITLE
Warn when logged in as temporary admin user

### DIFF
--- a/frontend/public/components/_global-notification.scss
+++ b/frontend/public/components/_global-notification.scss
@@ -12,8 +12,13 @@ $global-notification-text: #fff;
   }
 }
 
+.co-global-notification + .co-global-notification {
+  border-top: 1px solid #00659c;
+}
+
 .co-global-notification__text {
   margin: 0;
+  padding: 5px 10px;
 }
 
 .co-global-notification__impersonate-name {

--- a/frontend/public/components/global-notifications.jsx
+++ b/frontend/public/components/global-notifications.jsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
 import { ImpersonateNotifier } from './impersonate-notifier';
+import { KubeAdminNotifier } from './kube-admin-notifier';
 
 export const GlobalNotifications = () => <div className="co-global-notifications">
+  <KubeAdminNotifier />
   <ImpersonateNotifier />
 </div>;

--- a/frontend/public/components/kube-admin-notifier.jsx
+++ b/frontend/public/components/kube-admin-notifier.jsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import { connect } from 'react-redux';
+
+import { userStateToProps } from '../ui/ui-reducers';
+import { KUBE_ADMIN_USERNAME } from '../const';
+
+export const KubeAdminNotifier = connect(userStateToProps)(({user}) => {
+  const username = _.get(user, 'metadata.name');
+  return username === KUBE_ADMIN_USERNAME
+    ? <div className="co-global-notification">
+      <div className="co-global-notification__content">
+        <p className="co-global-notification__text">
+          You are logged in as temporary administrative user. Set up an identity provider to allow others to log in.
+        </p>
+      </div>
+    </div>
+    : null;
+});

--- a/frontend/public/const.js
+++ b/frontend/public/const.js
@@ -25,3 +25,6 @@ const STORAGE_PREFIX = 'bridge';
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
 export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-namespace-name`;
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
+
+// Bootstrap user for OpenShift 4.0 clusters
+export const KUBE_ADMIN_USERNAME = 'kube:admin';

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -155,11 +155,24 @@ const detectMonitoringURLs = dispatch => coFetchJSON(monitoringConfigMapPath)
     },
   );
 
+const detectUser = dispatch => coFetchJSON('api/kubernetes/apis/user.openshift.io/v1/users/~')
+  .then(
+    (user) => {
+      dispatch(UIActions.setUser(user));
+    },
+    err => {
+      if (!_.includes([401, 403, 404, 500], _.get(err, 'response.status'))) {
+        setTimeout(() => detectUser(dispatch), 15000);
+      }
+    },
+  );
+
 export const featureActions = [
   detectOpenShift,
   detectCanCreateProject,
   detectMonitoringURLs,
   detectClusterVersion,
+  detectUser,
 ];
 
 const projectListPath = `${k8sBasePath}/apis/project.openshift.io/v1/projects?limit=1`;

--- a/frontend/public/ui/ui-actions.js
+++ b/frontend/public/ui/ui-actions.js
@@ -73,6 +73,7 @@ export const types = {
   setCreateProjectMessage: 'setCreateProjectMessage',
   setCurrentLocation: 'setCurrentLocation',
   setMonitoringData: 'setMonitoringData',
+  setUser: 'setUser',
   sortList: 'sortList',
   startImpersonate: 'startImpersonate',
   stopImpersonate: 'stopImpersonate',
@@ -162,6 +163,8 @@ export const UIActions = {
   },
 
   [types.setCreateProjectMessage]: message => ({type: types.setCreateProjectMessage, message}),
+
+  [types.setUser]: user => ({type: types.setUser, user}),
 
   [types.selectOverviewView]: view => ({type: types.selectOverviewView, view}),
 

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -20,7 +20,6 @@ export default (state, action) => {
       }
     }
 
-
     return ImmutableMap({
       activeNavSectionId: 'workloads',
       location: pathname,
@@ -33,6 +32,7 @@ export default (state, action) => {
         selectedUID: '',
         selectedView: 'resources',
       }),
+      user: {},
     });
   }
 
@@ -64,6 +64,9 @@ export default (state, action) => {
 
     case types.setCreateProjectMessage:
       return state.set('createProjectMessage', action.message);
+
+    case types.setUser:
+      return state.set('user', action.user);
 
     case types.setMonitoringData:
       state = state.setIn(['monitoring', action.key], action.data);
@@ -124,4 +127,8 @@ export default (state, action) => {
 
 export const createProjectMessageStateToProps = ({UI}) => {
   return {createProjectMessage: UI.get('createProjectMessage')};
+};
+
+export const userStateToProps = ({UI}) => {
+  return {user: UI.get('user')};
 };


### PR DESCRIPTION
Added banner and redux stuff for getting the username in the store. Also
modified the masthead to pull the username from the store for the user menu.

The banner shows only if the user is "kube:admin." So I can actually take a screenshot, here it is when the banner is set to show to "admin" ("admin" in bold would be "kube-admin"):
<img width="1424" alt="screen shot 2018-12-04 at 10 13 37 am" src="https://user-images.githubusercontent.com/7014965/49451509-527b1100-f7ad-11e8-8a11-94d48b91e77e.png">

Fixes [CONSOLE-1071](https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-1071).

@openshift/team-ux-review, could you please review? Let me know if you want the language, etc. changed. We don't have a link yet for configuring the identity provider.