### PR TITLE
Validate that OAuth URLs are absolute

### DIFF
--- a/auth/auth_openshift.go
+++ b/auth/auth_openshift.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -23,6 +24,19 @@ type openShiftConfig struct {
 	issuerURL     string
 	cookiePath    string
 	secureCookies bool
+}
+
+func validateAbsURL(value string) error {
+	ur, err := url.Parse(value)
+	if err != nil {
+		return err
+	}
+
+	if ur == nil || !ur.IsAbs() {
+		return fmt.Errorf("url is not absolute: %v", ur)
+	}
+
+	return nil
 }
 
 func newOpenShiftAuth(ctx context.Context, c *openShiftConfig) (oauth2.Endpoint, *openShiftAuth, error) {
@@ -54,6 +68,14 @@ func newOpenShiftAuth(ctx context.Context, c *openShiftConfig) (oauth2.Endpoint,
 	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
 		return oauth2.Endpoint{}, nil, fmt.Errorf("discovery through endpoint %s failed to decode body: %v",
 			wellKnownURL, err)
+	}
+
+	if err := validateAbsURL(metadata.Auth); err != nil {
+		return oauth2.Endpoint{}, nil, err
+	}
+
+	if err := validateAbsURL(metadata.Token); err != nil {
+		return oauth2.Endpoint{}, nil, err
 	}
 
 	return oauth2.Endpoint{


### PR DESCRIPTION
Check that we get an absolute URL back from the OAuth server metadata.
Treat relative URLs as errors. This fixes a problem where incorrect
endpoints are used when the console starts before the OAuth server.

/cc @benjaminapetersen @enj 

@jwforres fyi