### PR TITLE
Monitoring: Fix Pending / Silenced state display in Active Alerts list

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -169,7 +169,7 @@ const SilenceMatchersList = ({silence}) => <div className={`co-text-${SilenceRes
 </div>;
 
 const alertStateToProps = (state, {match}): AlertsDetailsPageProps => {
-  const {data, loaded, loadError}: Rules = alertsToProps(state);
+  const {data, loaded, loadError}: Alerts = alertsToProps(state);
   const ruleID = _.get(match, 'params.ruleID');
   const labels = getURLSearchParams();
   const alerts = _.filter(data, a => a.rule.id === ruleID);
@@ -302,7 +302,7 @@ const ActiveAlerts = ({alerts, ruleID}) => <div className="co-m-table-grid co-m-
 </div>;
 
 const ruleStateToProps = (state, {match}): AlertRulesDetailsPageProps => {
-  const {data, loaded, loadError}: Rules = alertsToProps(state);
+  const {data, loaded, loadError}: Alerts = alertsToProps(state);
   const id = _.get(match, 'params.id');
   const alert = _.find(data, a => a.rule.id === id);
   return {loaded, loadError, rule: _.get(alert, 'rule')};
@@ -989,7 +989,7 @@ type Rule = {
   name: string;
   query: string;
 };
-type Rules = {
+type Alerts = {
   data: Alert[];
   loaded: boolean;
   loadError?: string;

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -68,39 +68,36 @@ export default (state, action) => {
     case types.setUser:
       return state.set('user', action.user);
 
-    case types.setMonitoringData:
+    case types.setMonitoringData: {
       state = state.setIn(['monitoring', action.key], action.data);
 
       const isFiring = alert => [AlertStates.Firing, AlertStates.Silenced].includes(alert.state);
 
-      if (action.key === 'alerts' || action.key === 'silences') {
-        const alerts = state.getIn(['monitoring', 'alerts']);
-        const firingAlerts = _.filter(_.get(alerts, 'data'), isFiring);
-        const silences = state.getIn(['monitoring', 'silences']);
+      const alerts = state.getIn(['monitoring', 'alerts']);
+      const firingAlerts = _.filter(_.get(alerts, 'data'), isFiring);
+      const silences = state.getIn(['monitoring', 'silences']);
 
-        // For each Alert, store a list of the Silences that are silencing it and set its state to show it is silenced
-        _.each(firingAlerts, a => {
-          a.silencedBy = _.filter(_.get(silences, 'data'), s => isSilenced(a, s));
-          if (a.silencedBy.length) {
-            a.state = AlertStates.Silenced;
-            // Also set the state of Alerts in `rule.alerts`
-            _.each(a.rule.alerts, ruleAlert => {
-              if (_.some(a.silencedBy, s => isFiring(ruleAlert) && isSilenced(ruleAlert, s))) {
-                ruleAlert.state = AlertStates.Silenced;
-              }
-            });
-          }
-        });
-        state = state.setIn(['monitoring', 'alerts'], alerts);
+      // For each Alert, store a list of the Silences that are silencing it and set its state to show it is silenced
+      _.each(firingAlerts, a => {
+        a.silencedBy = _.filter(_.get(silences, 'data'), s => isSilenced(a, s));
+        if (a.silencedBy.length) {
+          a.state = AlertStates.Silenced;
+          // Also set the state of Alerts in `rule.alerts`
+          _.each(a.rule.alerts, ruleAlert => {
+            if (_.some(a.silencedBy, s => isFiring(ruleAlert) && isSilenced(ruleAlert, s))) {
+              ruleAlert.state = AlertStates.Silenced;
+            }
+          });
+        }
+      });
+      state = state.setIn(['monitoring', 'alerts'], alerts);
 
-        // For each Silence, store a list of the Alerts it is silencing
-        _.each(_.get(silences, 'data'), s => {
-          s.silencedAlerts = _.filter(firingAlerts, a => a.silencedBy.includes(s));
-        });
-        state = state.setIn(['monitoring', 'silences'], silences);
-      }
-      return state;
-
+      // For each Silence, store a list of the Alerts it is silencing
+      _.each(_.get(silences, 'data'), s => {
+        s.silencedAlerts = _.filter(firingAlerts, a => a.silencedBy.includes(s));
+      });
+      return state.setIn(['monitoring', 'silences'], silences);
+    }
     case types.selectOverviewView:
       return state.setIn(['overview', 'selectedView'], action.view);
 


### PR DESCRIPTION
Fix pending alerts in Active Alerts list to have the state "Pending" even if they match a silence.

Also some minor refactoring:
- Remove redundant `action.key === 'alerts' || action.key === 'silences'` condition in Redux reducer because those are now the only two keys.
- Rename `Rules` type to `Alerts` because it represents an alert, not an alert rule.