### PR TITLE
Add full width class to the Storage Class Dropdown

### DIFF
--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -25,6 +25,7 @@ const StorageClassDropdown: React.SFC<StorageClassDropdownProps> = props => {
   return (
     <ListDropdown
       {...props}
+      dropDownClassName="dropdown--full-width"
       desc="Storage Classes"
       resources={resources}
       selectedKeyKind={kind}

--- a/frontend/public/components/utils/list-dropdown.jsx
+++ b/frontend/public/components/utils/list-dropdown.jsx
@@ -86,7 +86,7 @@ class ListDropdown_ extends React.Component {
   }
 
   render() {
-    const {desc, fixed, placeholder, id, loaded} = this.props;
+    const {desc, fixed, placeholder, id, loaded, dropDownClassName} = this.props;
     const items = {};
     const sortedItems = _.keys(this.state.items).sort();
 
@@ -105,7 +105,8 @@ class ListDropdown_ extends React.Component {
         title={this.state.title}
         onChange={this.onChange}
         id={id}
-        menuClassName="dropdown-menu--text-wrap" />;
+        menuClassName="dropdown-menu--text-wrap"
+        dropDownClassName={dropDownClassName} />;
 
     return <div>
       { Component }


### PR DESCRIPTION
Noticed that the Create Storage form's Dropdown does not have full width, even though the alert under the dropdown does have it.
Before:
![1](https://user-images.githubusercontent.com/1668218/49592082-7f2b5600-f970-11e8-8ef1-60a8c26f5e37.png)

After:
![2](https://user-images.githubusercontent.com/1668218/49592086-82264680-f970-11e8-965d-30e34e20c492.png)

@spadgett PTAL
@zherman0 fyi