### PR TITLE
Kubernetes Marketplace - fix to only display operators in the openshift-marketplace namespace

### DIFF
--- a/frontend/public/components/marketplace/kubernetes-marketplace.jsx
+++ b/frontend/public/components/marketplace/kubernetes-marketplace.jsx
@@ -104,7 +104,7 @@ export const Marketplace = () => {
   resources.push({
     isList: true,
     kind: referenceForModel(PackageManifestModel),
-    namespace: undefined, // shows operators from all-namespaces - when backend is hooked up we will use 'marketplace'
+    namespace: 'openshift-marketplace',
     prop: 'packagemanifests',
   });
   return <Firehose resources={resources} className="co-catalog-connect">


### PR DESCRIPTION
### Description

As an admin, I want to only see operator offerings in the kubernetes marketplace tab instead of both offerings and operators that have already been deployed to the cluster. With the previous 'undefined' namespace, operators that are deployed to other namespaces would be visible as duplicates because of the packagemanifest re-use.

/cc @alecmerdler @spadgett 