### PR TITLE
Fix Crash on Search View for ClusterServiceVersion

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -154,7 +154,7 @@ describe(ClusterServiceVersionsPage.displayName, () => {
   let wrapper: ShallowWrapper<ClusterServiceVersionsPageProps>;
 
   beforeEach(() => {
-    wrapper = shallow(<ClusterServiceVersionsPage.WrappedComponent kind={referenceForModel(ClusterServiceVersionModel)} resourceDescriptions={[]} match={{params: {ns: 'foo'}, isExact: true, path: '', url: ''}} />);
+    wrapper = shallow(<ClusterServiceVersionsPage.WrappedComponent kind={referenceForModel(ClusterServiceVersionModel)} resourceDescriptions={[]} namespace="foo" />);
   });
 
   it('renders a `ListPage` with correct props', () => {

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -110,7 +110,7 @@ export const ClusterServiceVersionsPage = connect(stateToProps)((props: ClusterS
     <PageHeading title="Cluster Service Versions" />
     <ListPage
       {...props}
-      namespace={props.match.params.ns}
+      namespace={props.namespace}
       kind={referenceForModel(ClusterServiceVersionModel)}
       ListComponent={ClusterServiceVersionList}
       helpText={helpText}
@@ -253,7 +253,7 @@ export const ClusterServiceVersionsDetailsPage: React.StatelessComponent<Cluster
 export type ClusterServiceVersionsPageProps = {
   kind: string;
   loading?: boolean;
-  match: RouterMatch<{ns?: string}>;
+  namespace: string;
   resourceDescriptions: CRDDescription[];
 };
 


### PR DESCRIPTION
### Description

Switch from expecting `props.match` to `props.namespace`.

Addresses https://jira.coreos.com/browse/CONSOLE-1095