### PR TITLE
Monitoring: Show matching alerts for all silences & improve UX when API calls have not all completed

### DIFF
--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -215,7 +215,6 @@ const sorts = {
   },
   nodeUpdateStatus: node => _.get(containerLinuxUpdateOperator.getUpdateStatus(node), 'text'),
   numReplicas: resource => _.toInteger(_.get(resource, 'status.replicas')),
-  numSilencedAlerts: silence => silence.silencedAlerts.length,
   planExternalName,
   podPhase,
   podReadiness,

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -399,7 +399,7 @@ const silenceParamToProps = (state, {match}) => {
 
 const SilencesDetailsPage = withFallback(connect(silenceParamToProps)((props: SilencesDetailsPageProps) => {
   const {loaded, loadError, silence} = props;
-  const {createdBy = '', comment = '', endsAt = '', matchers = {}, name = '', silencedAlerts = [], startsAt = '', updatedAt = ''} = silence || {};
+  const {createdBy = '', comment = '', endsAt = '', firingAlerts = [], matchers = {}, name = '', startsAt = '', updatedAt = ''} = silence || {};
 
   return <React.Fragment>
     <Helmet>
@@ -443,8 +443,8 @@ const SilencesDetailsPage = withFallback(connect(silenceParamToProps)((props: Si
                 <dd>{createdBy || '-'}</dd>
                 <dt>Comments</dt>
                 <dd>{comment || '-'}</dd>
-                <dt>Silenced Alerts</dt>
-                <dd>{silencedAlerts.length}</dd>
+                <dt>Firing Alerts</dt>
+                <dd>{firingAlerts.length}</dd>
               </dl>
             </div>
           </div>
@@ -452,10 +452,10 @@ const SilencesDetailsPage = withFallback(connect(silenceParamToProps)((props: Si
       </div>
       <div className="co-m-pane__body">
         <div className="co-m-pane__body-group">
-          <SectionHeading text="Silenced Alerts" />
+          <SectionHeading text="Firing Alerts" />
           <div className="row">
             <div className="col-xs-12">
-              <SilencedAlertsList alerts={silencedAlerts} />
+              <SilencedAlertsList alerts={firingAlerts} />
             </div>
           </div>
         </div>
@@ -630,7 +630,7 @@ const AlertsPage = withFallback(connect(alertsToProps)(AlertsPage_));
 const SilenceHeader = props => <ListHeader>
   <ColHead {...props} className="col-xs-7" sortField="name">Name</ColHead>
   <ColHead {...props} className="col-xs-3" sortFunc="silenceStateOrder">State</ColHead>
-  <ColHead {...props} className="col-xs-2" sortFunc="numSilencedAlerts">Silenced Alerts</ColHead>
+  <ColHead {...props} className="col-xs-2" sortField="firingAlerts.length">Firing Alerts</ColHead>
 </ListHeader>;
 
 const SilenceRow = ({obj}) => {
@@ -652,7 +652,7 @@ const SilenceRow = ({obj}) => {
       {state === SilenceStates.Active && <StateTimestamp text="Ends" timestamp={obj.endsAt} />}
       {state === SilenceStates.Expired && <StateTimestamp text="Expired" timestamp={obj.endsAt} />}
     </div>
-    <div className="col-xs-2">{obj.silencedAlerts.length}</div>
+    <div className="col-xs-2">{obj.firingAlerts.length}</div>
     <div className="dropdown-kebab-pf">
       <SilenceKebab silence={obj} />
     </div>
@@ -957,13 +957,13 @@ type Silence = {
   comment: string;
   createdBy: string;
   endsAt: string;
+  // eslint-disable-next-line no-use-before-define
+  firingAlerts: Alert[];
   id?: string;
   matchers: {name: string, value: string, isRegex: boolean}[];
   name?: string;
   startsAt: string;
   status?: {state: SilenceStates};
-  // eslint-disable-next-line no-use-before-define
-  silencedAlerts: Alert[];
   updatedAt?: string;
 };
 type Silences = {

--- a/frontend/public/monitoring.ts
+++ b/frontend/public/monitoring.ts
@@ -51,7 +51,7 @@ const stateToProps = (desiredURLs: string[], state) => {
 export const connectToURLs = (...urls) => connect(state => stateToProps(urls, state));
 
 // Determine if an Alert is silenced by a Silence (if all of the Silence's matchers match one of the Alert's labels)
-export const isSilenced = (alert, silence) => _.get(silence, 'status.state') === SilenceStates.Active &&
+export const isSilenced = (alert, silence) => [AlertStates.Firing, AlertStates.Silenced].includes(alert.state) &&
   _.every(silence.matchers, m => {
     const alertValue = _.get(alert.labels, m.name);
     return alertValue !== undefined &&


### PR DESCRIPTION
Instead of showing the silenced alerts only for active silences, show
them regardless of the silence's state. Also change the label from
"Silenced Alerts" to "Firing Alerts".

Improve the silence details page to better handle the case where the
silence has loaded, but the alerts data is still loading.
Similarly, improve the alert details page to better handle the case
where the alert has loaded, but the silences data is still loading.