### PR TITLE
Lightly Expose OLM Operator Groups

### DIFF
--- a/frontend/__mocks__/k8sResourcesMocks.ts
+++ b/frontend/__mocks__/k8sResourcesMocks.ts
@@ -1,5 +1,15 @@
 /* eslint-disable no-unused-vars */
-import { ClusterServiceVersionKind, ClusterServiceVersionResourceKind, InstallPlanKind, ClusterServiceVersionPhase, CSVConditionReason, SubscriptionKind, CatalogSourceKind, InstallPlanApproval, PackageManifestKind } from '../public/components/operator-lifecycle-manager';
+import {
+  ClusterServiceVersionKind,
+  ClusterServiceVersionResourceKind,
+  InstallPlanKind,
+  ClusterServiceVersionPhase,
+  CSVConditionReason,
+  SubscriptionKind,
+  CatalogSourceKind,
+  InstallPlanApproval,
+  PackageManifestKind,
+  OperatorGroupKind } from '../public/components/operator-lifecycle-manager';
 import { StatusCapability, SpecCapability } from '../public/components/operator-lifecycle-manager/descriptors/types';
 import { CustomResourceDefinitionKind, K8sResourceKind, K8sKind } from '../public/module/k8s';
 /* eslint-enable no-unused-vars */
@@ -216,6 +226,18 @@ export const testOwnedResourceInstance: ClusterServiceVersionResourceKind = {
   spec: {},
   status: {
     'some-filled-path': 'this is filled!',
+  },
+};
+
+export const testOperatorGroup: OperatorGroupKind = {
+  apiVersion: 'operators.coreos.com/v1alpha2',
+  kind: 'OperatorGroup',
+  metadata: {
+    name: 'test-operatorgroup',
+    namespace: 'default',
+  },
+  spec: {
+    selector: {},
   },
 };
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
 
 import { ClusterServiceVersionsDetailsPage, ClusterServiceVersionsDetailsPageProps, ClusterServiceVersionDetails, ClusterServiceVersionDetailsProps, ClusterServiceVersionsPage, ClusterServiceVersionsPageProps, ClusterServiceVersionList, ClusterServiceVersionHeader, ClusterServiceVersionRow, ClusterServiceVersionRowProps, CRDCard, CRDCardRow } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion';
-import { ClusterServiceVersionKind, ClusterServiceVersionLogo, ClusterServiceVersionLogoProps, referenceForProvidedAPI } from '../../../public/components/operator-lifecycle-manager';
+import { ClusterServiceVersionKind, ClusterServiceVersionLogo, ClusterServiceVersionLogoProps, referenceForProvidedAPI, CSVConditionReason } from '../../../public/components/operator-lifecycle-manager';
 import { DetailsPage, ListPage, ListHeader, ColHead, List, ListInnerProps } from '../../../public/components/factory';
 import { testClusterServiceVersion } from '../../../__mocks__/k8sResourcesMocks';
 import { Timestamp, OverflowLink, MsgBox, ResourceLink, ResourceKebab, ErrorBoundary, LoadingBox, ScrollToTopOnMount, SectionHeading } from '../../../public/components/utils';
@@ -90,7 +90,7 @@ describe(ClusterServiceVersionRow.displayName, () => {
   it('renders column for app status', () => {
     const col = wrapper.find('.row').childAt(3);
 
-    expect(col.childAt(0).text()).toEqual('Enabled');
+    expect(col.childAt(0).text()).toEqual(CSVConditionReason.CSVReasonInstallSuccessful);
   });
 
   it('renders "disabling" status if CSV has `deletionTimestamp`', () => {

--- a/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
@@ -7,10 +7,10 @@ import { Link } from 'react-router-dom';
 
 import { InstallPlanHeader, InstallPlanHeaderProps, InstallPlanRow, InstallPlanRowProps, InstallPlansList, InstallPlansListProps, InstallPlansPage, InstallPlansPageProps, InstallPlanDetailsPage, InstallPlanPreview, InstallPlanPreviewProps, InstallPlanPreviewState, InstallPlanDetailsPageProps, InstallPlanDetails, InstallPlanDetailsProps } from '../../../public/components/operator-lifecycle-manager/install-plan';
 import { InstallPlanKind, InstallPlanApproval } from '../../../public/components/operator-lifecycle-manager';
-import { ListHeader, ColHead, ResourceRow, List, ListPage, DetailsPage } from '../../../public/components/factory';
+import { ListHeader, ColHead, ResourceRow, List, MultiListPage, DetailsPage } from '../../../public/components/factory';
 import { ResourceKebab, ResourceLink, ResourceIcon, Kebab, MsgBox } from '../../../public/components/utils';
 import { testInstallPlan } from '../../../__mocks__/k8sResourcesMocks';
-import { InstallPlanModel, ClusterServiceVersionModel } from '../../../public/models';
+import { InstallPlanModel, ClusterServiceVersionModel, OperatorGroupModel } from '../../../public/models';
 import * as k8s from '../../../public/module/k8s';
 
 describe(InstallPlanHeader.displayName, () => {
@@ -96,7 +96,7 @@ describe(InstallPlansList.displayName, () => {
   let wrapper: ShallowWrapper<InstallPlansListProps>;
 
   beforeEach(() => {
-    wrapper = shallow(<InstallPlansList />);
+    wrapper = shallow(<InstallPlansList.WrappedComponent operatorGroup={null} />);
   });
 
   it('renders a `List` component with the correct props', () => {
@@ -117,15 +117,18 @@ describe(InstallPlansPage.displayName, () => {
   let wrapper: ShallowWrapper<InstallPlansPageProps>;
 
   beforeEach(() => {
-    wrapper = shallow(<InstallPlansPage />);
+    wrapper = shallow(<InstallPlansPage namespace="default" />);
   });
 
-  it('renders a `ListPage` with the correct props', () => {
-    expect(wrapper.find(ListPage).props().title).toEqual('Install Plans');
-    expect(wrapper.find(ListPage).props().showTitle).toBe(true);
-    expect(wrapper.find(ListPage).props().ListComponent).toEqual(InstallPlansList);
-    expect(wrapper.find(ListPage).props().filterLabel).toEqual('Install Plans by name');
-    expect(wrapper.find(ListPage).props().kind).toEqual(k8s.referenceForModel(InstallPlanModel));
+  it('renders a `MultiListPage` with the correct props', () => {
+    expect(wrapper.find(MultiListPage).props().title).toEqual('Install Plans');
+    expect(wrapper.find(MultiListPage).props().showTitle).toBe(true);
+    expect(wrapper.find(MultiListPage).props().ListComponent).toEqual(InstallPlansList);
+    expect(wrapper.find(MultiListPage).props().filterLabel).toEqual('Install Plans by name');
+    expect(wrapper.find(MultiListPage).props().resources).toEqual([
+      {kind: k8s.referenceForModel(InstallPlanModel), namespace: 'default', namespaced: true, prop: 'installPlan'},
+      {kind: k8s.referenceForModel(OperatorGroupModel), namespace: 'default', namespaced: true, prop: 'operatorGroup'},
+    ]);
   });
 });
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/operator-group.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/operator-group.spec.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import { requireOperatorGroup, NoOperatorGroupMsg } from '../../../public/components/operator-lifecycle-manager/operator-group';
+import { testOperatorGroup } from '../../../__mocks__/k8sResourcesMocks';
+
+describe('requireOperatorGroup', () => {
+  const SomeComponent = () => <div>Requires OperatorGroup</div>;
+
+  it('renders given component if `OperatorGroups` has not loaded yet', () => {
+    const WrappedComponent = requireOperatorGroup(SomeComponent);
+    const wrapper = shallow(<WrappedComponent operatorGroup={{loaded: false}} />);
+
+    expect(wrapper.find(SomeComponent).exists()).toBe(true);
+    expect(wrapper.find(NoOperatorGroupMsg).exists()).toBe(false);
+  });
+
+  it('renders message if no `OperatorGroups` loaded', () => {
+    const WrappedComponent = requireOperatorGroup(SomeComponent);
+    const wrapper = shallow(<WrappedComponent operatorGroup={{loaded: true, data: []}} />);
+
+    expect(wrapper.find(NoOperatorGroupMsg).exists()).toBe(true);
+    expect(wrapper.find(SomeComponent).exists()).toBe(false);
+  });
+
+  it('renders given component if `OperatorGroups` loaded and present', () => {
+    const WrappedComponent = requireOperatorGroup(SomeComponent);
+    const wrapper = shallow(<WrappedComponent operatorGroup={{loaded: true, data: [testOperatorGroup]}} />);
+
+    expect(wrapper.find(SomeComponent).exists()).toBe(true);
+    expect(wrapper.find(NoOperatorGroupMsg).exists()).toBe(false);
+  });
+});

--- a/frontend/__tests__/components/operator-lifecycle-manager/package-manifest.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/package-manifest.spec.tsx
@@ -35,7 +35,7 @@ describe(PackageManifestRow.displayName, () => {
   let wrapper: ShallowWrapper<PackageManifestRowProps>;
 
   beforeEach(() => {
-    wrapper = shallow(<PackageManifestRow obj={testPackageManifest} catalogSourceNamespace={testCatalogSource.metadata.namespace} catalogSourceName={testCatalogSource.metadata.name} subscription={testSubscription} />);
+    wrapper = shallow(<PackageManifestRow obj={testPackageManifest} catalogSourceNamespace={testCatalogSource.metadata.namespace} catalogSourceName={testCatalogSource.metadata.name} subscription={testSubscription} defaultNS="default" />);
   });
 
   it('renders column for package name and logo', () => {
@@ -76,7 +76,7 @@ describe(PackageManifestList.displayName, () => {
     otherPackageManifest.status.catalogSourcePublisher = 'Some Publisher';
     packages = [testPackageManifest, otherPackageManifest];
 
-    wrapper = shallow(<PackageManifestList loaded={true} data={packages} catalogSource={{}} subscription={{}} />);
+    wrapper = shallow(<PackageManifestList.WrappedComponent loaded={true} data={packages} operatorGroup={null} subscription={null} />);
   });
 
   it('renders a section for each unique `CatalogSource` for the given packages', () => {

--- a/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
@@ -7,8 +7,8 @@ import * as _ from 'lodash';
 import { SubscriptionHeader, SubscriptionHeaderProps, SubscriptionRow, SubscriptionRowProps, SubscriptionsList, SubscriptionsListProps, SubscriptionsPage, SubscriptionsPageProps, SubscriptionDetails, SubscriptionDetailsPage, SubscriptionDetailsProps, SubscriptionUpdates, SubscriptionUpdatesProps, SubscriptionUpdatesState } from '../../../public/components/operator-lifecycle-manager/subscription';
 import { SubscriptionKind, SubscriptionState } from '../../../public/components/operator-lifecycle-manager';
 import { referenceForModel } from '../../../public/module/k8s';
-import { SubscriptionModel, ClusterServiceVersionModel, PackageManifestModel } from '../../../public/models';
-import { ListHeader, ColHead, List, ListPage, DetailsPage } from '../../../public/components/factory';
+import { SubscriptionModel, ClusterServiceVersionModel, PackageManifestModel, OperatorGroupModel } from '../../../public/models';
+import { ListHeader, ColHead, List, MultiListPage, DetailsPage } from '../../../public/components/factory';
 import { ResourceKebab, ResourceLink, Kebab } from '../../../public/components/utils';
 import { testSubscription, testClusterServiceVersion, testPackageManifest } from '../../../__mocks__/k8sResourcesMocks';
 
@@ -114,7 +114,7 @@ describe(SubscriptionsList.displayName, () => {
   let wrapper: ShallowWrapper<SubscriptionsListProps>;
 
   beforeEach(() => {
-    wrapper = shallow(<SubscriptionsList data={[]} loaded={true} {...{[referenceForModel(ClusterServiceVersionModel)]: {data: []}}} />);
+    wrapper = shallow(<SubscriptionsList.WrappedComponent data={[]} loaded={true} {...{[referenceForModel(ClusterServiceVersionModel)]: {data: []}}} operatorGroup={null} />);
   });
 
   it('renders a `List` component with correct props', () => {
@@ -131,15 +131,18 @@ describe(SubscriptionsPage.displayName, () => {
     wrapper = shallow(<SubscriptionsPage match={match} namespace="default" />);
   });
 
-  it('renders a `ListPage` component with the correct props', () => {
-    expect(wrapper.find(ListPage).props().ListComponent).toEqual(SubscriptionsList);
-    expect(wrapper.find(ListPage).props().title).toEqual('Subscriptions');
-    expect(wrapper.find(ListPage).props().showTitle).toBe(true);
-    expect(wrapper.find(ListPage).props().canCreate).toBe(true);
-    expect(wrapper.find(ListPage).props().createProps).toEqual({to: `/k8s/ns/default/${referenceForModel(PackageManifestModel)}`});
-    expect(wrapper.find(ListPage).props().createButtonText).toEqual('Create Subscription');
-    expect(wrapper.find(ListPage).props().filterLabel).toEqual('Subscriptions by package');
-    expect(wrapper.find(ListPage).props().kind).toEqual(referenceForModel(SubscriptionModel));
+  it('renders a `MultiListPage` component with the correct props', () => {
+    expect(wrapper.find(MultiListPage).props().ListComponent).toEqual(SubscriptionsList);
+    expect(wrapper.find(MultiListPage).props().title).toEqual('Subscriptions');
+    expect(wrapper.find(MultiListPage).props().showTitle).toBe(true);
+    expect(wrapper.find(MultiListPage).props().canCreate).toBe(true);
+    expect(wrapper.find(MultiListPage).props().createProps).toEqual({to: `/k8s/ns/default/${referenceForModel(PackageManifestModel)}`});
+    expect(wrapper.find(MultiListPage).props().createButtonText).toEqual('Create Subscription');
+    expect(wrapper.find(MultiListPage).props().filterLabel).toEqual('Subscriptions by package');
+    expect(wrapper.find(MultiListPage).props().resources).toEqual([
+      {kind: referenceForModel(SubscriptionModel), namespace: 'default', namespaced: true, prop: 'subscription'},
+      {kind: referenceForModel(OperatorGroupModel), namespace: 'default', namespaced: true, prop: 'operatorGroup'},
+    ]);
   });
 });
 
@@ -186,7 +189,7 @@ describe(SubscriptionDetails.displayName, () => {
   });
 
   it('renders link to catalog source', () => {
-    const link = wrapper.findWhere(node => node.equals(<dt>Catalog</dt>)).parents().at(0).find('dd').find(ResourceLink).at(0);
+    const link = wrapper.findWhere(node => node.equals(<dt>Catalog Source</dt>)).parents().at(0).find('dd').find(ResourceLink).at(0);
 
     expect(link.props().name).toEqual(testSubscription.spec.source);
   });

--- a/frontend/integration-tests/tests/base.scenario.ts
+++ b/frontend/integration-tests/tests/base.scenario.ts
@@ -38,6 +38,7 @@ describe('Basic console test', () => {
       await crudView.createYAMLButton.click();
       await browser.wait(until.presenceOf($('.modal-body__field')));
       await $$('.modal-body__field').get(0).$('input').sendKeys(testName);
+      await $$('.modal-body__field').get(1).$('input').sendKeys(`test-name=${testName}`);
       await $('.modal-content').$('#confirm-action').click();
       await browser.wait(until.urlContains(`/${testName}`), BROWSER_TIMEOUT);
     }

--- a/frontend/integration-tests/tests/olm/catalog.scenario.ts
+++ b/frontend/integration-tests/tests/olm/catalog.scenario.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef, no-unused-vars */
 
+import { execSync } from 'child_process';
 import { browser, $, ExpectedConditions as until } from 'protractor';
 
 import { appHost, checkLogs, checkErrors, testName } from '../../protractor.conf';
@@ -7,9 +8,17 @@ import * as catalogView from '../../views/olm-catalog.view';
 import * as sidenavView from '../../views/sidenav.view';
 
 describe('Installing a service from a Catalog Source', () => {
-  const openCloudServices = new Set(['etcd', 'Prometheus Operator']);
+  const openCloudServices = new Set(['etcd', 'Prometheus Operator', 'AMQ Streams', 'Service Catalog', 'FederationV2']);
 
   beforeAll(async() => {
+    const operatorGroup = {
+      apiVersion: 'operators.coreos.com/v1alpha2',
+      kind: 'OperatorGroup',
+      metadata: {name: 'test-operatorgroup'},
+      spec: {selector: {matchLabels: {'test-name': testName}}},
+    };
+    execSync(`echo '${JSON.stringify(operatorGroup)}' | kubectl create -n ${testName} -f -`);
+
     browser.get(`${appHost}/status/ns/${testName}`);
     await browser.wait(until.presenceOf($('#sidebar')));
   });

--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -5,7 +5,7 @@ import { Timestamp } from './utils';
 import { CamelCaseWrap } from './utils/camel-case-wrap';
 
 export const Conditions: React.SFC<ConditionsProps> = ({conditions}) => {
-  const rows = _.map(conditions, condition => <div className="row" key={JSON.stringify(condition)}>
+  const rows = _.map(conditions, (condition, i) => <div className="row" key={i}>
     <div className="col-xs-4 col-sm-2 col-md-2">
       <CamelCaseWrap value={condition.type} />
     </div>

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -3,14 +3,14 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-import { K8sResourceKind, GroupVersionKind, OwnerReference } from '../../module/k8s';
+import { K8sResourceKind, GroupVersionKind, OwnerReference, Selector } from '../../module/k8s';
 import { Descriptor } from './descriptors/types';
-import * as operatorLogo from '../../imgs/operator.svg';
-
 export { ClusterServiceVersionsDetailsPage, ClusterServiceVersionsPage } from './clusterserviceversion';
 export { ClusterServiceVersionResourcesDetailsPage, ClusterServiceVersionResourceLink } from './clusterserviceversion-resource';
 export { CatalogSourceDetailsPage, CreateSubscriptionYAML } from './catalog-source';
 export { SubscriptionsPage } from './subscription';
+
+import * as operatorLogo from '../../imgs/operator.svg';
 
 export const appCatalogLabel = 'alm-catalog';
 export enum AppCatalog {
@@ -42,6 +42,7 @@ export enum CSVConditionReason {
   CSVReasonComponentUnhealthy = 'ComponentUnhealthy',
   CSVReasonBeingReplaced = 'BeingReplaced',
   CSVReasonReplaced = 'Replaced',
+  CSVReasonCopied = 'Copied',
 }
 
 export enum InstallPlanApproval {
@@ -214,6 +215,13 @@ export type PackageManifestKind = {
     }[];
     defaultChannel: string;
   };
+} & K8sResourceKind;
+
+export type OperatorGroupKind = {
+  apiVersion: 'operators.coreos.com/v1alpha2';
+  kind: 'OperatorGroup';
+  spec: {selector: Selector};
+  status?: {namespaces: K8sResourceKind[]};
 } & K8sResourceKind;
 
 // TODO(alecmerdler): Shouldn't be needed anymore

--- a/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
@@ -5,12 +5,13 @@ import * as _ from 'lodash-es';
 import { match, Link } from 'react-router-dom';
 import { Map as ImmutableMap } from 'immutable';
 
-import { ListPage, List, ListHeader, ColHead, ResourceRow, DetailsPage } from '../factory';
+import { MultiListPage, List, ListHeader, ColHead, ResourceRow, DetailsPage } from '../factory';
 import { SectionHeading, MsgBox, ResourceLink, ResourceKebab, Kebab, ResourceIcon, navFactory, ResourceSummary } from '../utils';
 import { InstallPlanKind, InstallPlanApproval, olmNamespace, Step } from './index';
 import { referenceForModel, referenceForOwnerRef, k8sUpdate } from '../../module/k8s';
-import { SubscriptionModel, ClusterServiceVersionModel, InstallPlanModel, CatalogSourceModel } from '../../models';
+import { SubscriptionModel, ClusterServiceVersionModel, InstallPlanModel, CatalogSourceModel, OperatorGroupModel } from '../../models';
 import { breadcrumbsForOwnerRefs } from '../utils/breadcrumbs';
+import { requireOperatorGroup } from './operator-group';
 
 export const InstallPlanHeader: React.SFC<InstallPlanHeaderProps> = (props) => <ListHeader>
   <ColHead {...props} className="col-xs-6 col-sm-4 col-md-3" sortField="metadata.name">Name</ColHead>
@@ -54,18 +55,22 @@ export const InstallPlanRow: React.SFC<InstallPlanRowProps> = (props) => {
     </div>
   </ResourceRow>;
 };
-export const InstallPlansList: React.SFC<InstallPlansListProps> = (props) => {
+export const InstallPlansList = requireOperatorGroup((props: InstallPlansListProps) => {
   const EmptyMsg = () => <MsgBox title="No Install Plans Found" detail="Install Plans are created automatically by subscriptions or manually using kubectl." />;
   return <List {...props} Header={InstallPlanHeader} Row={InstallPlanRow} EmptyMsg={EmptyMsg} />;
-};
+});
 
-export const InstallPlansPage: React.SFC<InstallPlansPageProps> = (props) => <ListPage
+export const InstallPlansPage: React.SFC<InstallPlansPageProps> = (props) => <MultiListPage
   {...props}
+  resources={[
+    {kind: referenceForModel(InstallPlanModel), namespace: props.namespace, namespaced: true, prop: 'installPlan'},
+    {kind: referenceForModel(OperatorGroupModel), namespace: props.namespace, namespaced: true, prop: 'operatorGroup'},
+  ]}
+  flatten={resources => _.get(resources.subscription, 'data', [])}
   title="Install Plans"
   showTitle={true}
   ListComponent={InstallPlansList}
-  filterLabel="Install Plans by name"
-  kind={referenceForModel(InstallPlanModel)} />;
+  filterLabel="Install Plans by name" />;
 
 export const InstallPlanDetails: React.SFC<InstallPlanDetailsProps> = ({obj}) => {
   const needsApproval = obj.spec.approval === InstallPlanApproval.Manual && obj.spec.approved === false;
@@ -206,7 +211,7 @@ export type InstallPlansListProps = {
 };
 
 export type InstallPlansPageProps = {
-
+  namespace?: string;
 };
 
 export type InstallPlanDetailsProps = {

--- a/frontend/public/components/operator-lifecycle-manager/operator-group.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/operator-group.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import { MsgBox } from '../utils/status-box';
+import { K8sResourceKind } from '../../module/k8s';
+import { OperatorGroupKind } from './index';
+
+export const targetNamespacesFor = (obj: K8sResourceKind) => _.get(obj, ['metadata', 'annotations', 'olm.targetNamespaces']);
+export const operatorNamespaceFor = (obj: K8sResourceKind) => _.get(obj, ['metadata', 'annotations', 'olm.operatorNamespace']);
+export const operatorGroupFor = (obj: K8sResourceKind) => _.get(obj, ['metadata', 'annotations', 'olm.operatorGroup']);
+
+export const NoOperatorGroupMsg: React.SFC = () => <MsgBox
+  title="Namespace Not Enabled"
+  // TODO(alecmerdler): Better description + link to docs
+  detail="The Operator Lifecycle Manager will not watch this namespace because it is not configured with an OperatorGroup." />;
+
+type RequireOperatorGroupProps = {
+  operatorGroup: {loaded: boolean, data?: OperatorGroupKind[]};
+};
+
+export const requireOperatorGroup = <P extends RequireOperatorGroupProps>(Component: React.ComponentType<P>) => {
+  return class RequireOperatorGroup extends React.Component<P> {
+    static WrappedComponent = Component;
+
+    render() {
+      const namespaceEnabled = !_.get(this.props.operatorGroup, 'loaded') || !_.isEmpty(this.props.operatorGroup.data);
+
+      return namespaceEnabled
+        ? <Component {...this.props} />
+        : <NoOperatorGroupMsg />;
+    }
+  } as React.ComponentClass<P> & {WrappedComponent: React.ComponentType<P>};
+};
+
+NoOperatorGroupMsg.displayName = 'NoOperatorGroupMsg';

--- a/frontend/public/components/utils/status-box.jsx
+++ b/frontend/public/components/utils/status-box.jsx
@@ -54,6 +54,7 @@ const Data = ({EmptyMsg, label, data, children}) => {
   return <div className="loading-box loading-box__loaded">{children}</div>;
 };
 
+/** @type {React.SFC<{label?: string, loadError?: string | Object, loaded?: boolean, data?: any, EmptyMsg?: React.ComponentType}>} */
 export const StatusBox = props => {
   const {label, loadError, loaded} = props;
 

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -67,18 +67,17 @@ export const SubscriptionModel: K8sKind = {
   plural: 'subscriptions',
 };
 
-export const EtcdClusterModel: K8sKind = {
-  kind: 'EtcdCluster',
-  label: 'etcd Cluster',
-  labelPlural: 'Etcd Clusters',
-  apiGroup: 'etcd.database.coreos.com',
-  apiVersion: 'v1beta2',
-  path: 'etcdclusters',
-  abbr: 'EC',
+export const OperatorGroupModel: K8sKind = {
+  kind: 'OperatorGroup',
+  label: 'OperatorGroup',
+  labelPlural: 'OperatorGroups',
+  apiGroup: 'operators.coreos.com',
+  apiVersion: 'v1alpha2',
+  path: 'operatorgroups',
+  abbr: 'OG',
   namespaced: true,
   crd: true,
-  plural: 'etcdclusters',
-  propagationPolicy : 'Foreground',
+  plural: 'operatorgroups',
 };
 
 export const PrometheusModel: K8sKind = {


### PR DESCRIPTION
### Description

The `OperatorGroup` resource establishes [minimum multi-tenancy support for Operators using OLM](https://github.com/operator-framework/operator-lifecycle-manager/pull/573). Each `ClusterServiceVersion` must belong to an `OperatorGroup` (signified by an annotation), which is determined by its namespace.

```
OperatorGroup ---[selects]---> Namespace ---[contains]---> ClusterServiceVersion
```

### Screenshots

**Package Manifest list view (no `OperatorGroup`):**
![screenshot_20181129_145918](https://user-images.githubusercontent.com/11700385/49248336-77efcf80-f3e7-11e8-8ab3-ccfd72c8bc46.png)

**Subscription list view (no `OperatorGroup`):**
![screenshot_20181129_150032](https://user-images.githubusercontent.com/11700385/49248392-96ee6180-f3e7-11e8-9def-97af497e5027.png)

**Install Plan list view (no `OperatorGroup`):**
![screenshot_20181129_150042](https://user-images.githubusercontent.com/11700385/49248400-9b1a7f00-f3e7-11e8-9ede-44730441bb0a.png)

Blocked by https://github.com/operator-framework/operator-lifecycle-manager/pull/589
Addresses https://jira.coreos.com/browse/ALM-794
Addresses https://jira.coreos.com/browse/CONSOLE-1093
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1655927