### PR TITLE
Monitoring: Allow single digit months, days and hours in Silence times

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -702,15 +702,15 @@ const toISODate = (dateStr: string): string => {
 
 const Text = props => <input {...props} type="text" className="form-control form-control--silence-text" />;
 
-const Datetime = props => <div>
-  <Tooltip content={[<span className="co-nowrap" key="co-timestamp">{toISODate(props.value)}</span>]}>
-    <Text
-      {...props}
-      pattern="\d{4}/(0[1-9]|1[012])/(0[1-9]|[12][0-9]|3[01]) ([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?"
-      placeholder="YYYY/MM/DD hh:mm:ss"
-    />
-  </Tooltip>
-</div>;
+const Datetime = props => {
+  const pattern = '\\d{4}/(0?[1-9]|1[012])/(0?[1-9]|[12]\\d|3[01]) (0?\\d|1\\d|2[0-3]):[0-5]\\d(:[0-5]\\d)?';
+  const tooltip = (new RegExp(`^${pattern}$`)).test(props.value) ? toISODate(props.value) : 'Invalid date / time';
+  return <div>
+    <Tooltip content={[<span className="co-nowrap" key="co-timestamp">{tooltip}</span>]}>
+      <Text {...props} pattern={pattern} placeholder="YYYY/MM/DD hh:mm:ss" />
+    </Tooltip>
+  </div>;
+};
 
 class SilenceForm_ extends SafetyFirst<SilenceFormProps, SilenceFormState> {
   constructor(props) {


### PR DESCRIPTION
Loosen up the Silence start time and end time inputs a little to allow
single digit months, days and hours. Also improve the ISO format tooltip
to show the text `Invalid date / time` if the datetime has the wrong
format instead of showing a blank tooltip.

FYI @cshinn 

![screenshot-1](https://user-images.githubusercontent.com/460802/49721067-bc5f5300-fca4-11e8-9b8d-bac658e6a832.png) ![screenshot-2](https://user-images.githubusercontent.com/460802/49721074-bf5a4380-fca4-11e8-81a1-519b6a26ce5d.png)
