### PR TITLE
Kubernetes Marketplace - disable marketplace nav and route

### DIFF
--- a/frontend/integration-tests/tests/performance.scenario.ts
+++ b/frontend/integration-tests/tests/performance.scenario.ts
@@ -31,8 +31,8 @@ const chunkedRoutes = OrderedMap<string, {section: string, name: string}>()
   .set('resource-quota', {section: 'Administration', name: 'Resource Quotas'})
   .set('limit-range', {section: 'Administration', name: 'Limit Ranges'})
   .set('custom-resource-definition', {section: 'Administration', name: 'CRDs'})
-  .set('catalog', {section: 'Home', name: 'Catalog'})
-  .set('marketplace', {section: 'Operators', name: 'Kubernetes Marketplace'});
+  .set('catalog', {section: 'Home', name: 'Catalog'});
+// .set('marketplace', {section: 'Operators', name: 'Kubernetes Marketplace'});
 
 describe('Performance test', () => {
 

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -131,7 +131,9 @@ class App extends React.PureComponent {
             <LazyRoute path="/cluster-health" exact loader={() => import('./cluster-health' /* webpackChunkName: "cluster-health" */).then(m => m.ClusterHealth)} />
             <LazyRoute path="/start-guide" exact loader={() => import('./start-guide' /* webpackChunkName: "start-guide" */).then(m => m.StartGuidePage)} />
 
-            <LazyRoute path="/marketplace" exact loader={() => import('./marketplace/kubernetes-marketplace' /* webpackChunkName: "marketplace" */).then(m => m.MarketplacePage)} />
+            {
+              // <LazyRoute path="/marketplace" exact loader={() => import('./marketplace/kubernetes-marketplace' /* webpackChunkName: "marketplace" */).then(m => m.MarketplacePage)} />
+            }
 
             <LazyRoute path={`/k8s/ns/:ns/${SubscriptionModel.plural}/new`} exact loader={() => import('./operator-lifecycle-manager' /* webpackChunkName: "create-subscription-yaml" */).then(m => NamespaceFromURL(m.CreateSubscriptionYAML))} />
 

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -378,7 +378,9 @@ export class Nav extends React.Component {
           </NavSection>
 
           <NavSection required={FLAGS.OPERATOR_LIFECYCLE_MANAGER} text="Operators" img={operatorImg} activeImg={operatorActiveImg} >
-            <HrefLink required={FLAGS.KUBERNETES_MARKETPLACE} href="/marketplace" name="Kubernetes Marketplace" activePath="/marketplace/" onClick={this.close} />
+            {
+              // <HrefLink required={FLAGS.KUBERNETES_MARKETPLACE} href="/marketplace" name="Kubernetes Marketplace" activePath="/marketplace/" onClick={this.close} />
+            }
             <ResourceNSLink model={ClusterServiceVersionModel} resource={ClusterServiceVersionModel.plural} name="Cluster Service Versions" onClick={this.close} />
             <Sep />
             <ResourceNSLink model={PackageManifestModel} resource={PackageManifestModel.plural} name="Package Manifests" onClick={this.close} />


### PR DESCRIPTION
### Description

As a side effect of certain packagemanifests (specifically those in the openshift-operator-lifecycle-manager namespace) being "global", these operators will be present in the marketplace UI. The subscribe functionality is still in progress and we don't want users being able to see operators that are already on cluster as this would be confusing to the purpose of marketplace. Until these two issues are resolved, we need to temporarily disable the marketplace nav item and route.