### PR TITLE
Fix bug where .co-m-overflow__gradient is the wrong color

### DIFF
--- a/frontend/public/components/_overflow.scss
+++ b/frontend/public/components/_overflow.scss
@@ -11,6 +11,10 @@ $width: 35px;
     top: 0;
     pointer-events: none;
     width: $width;
+
+    .co-m-row:hover & {
+      background: linear-gradient(to left, $color-co-m-row-hover 0%, $color-co-m-row-hover 31%,rgba(255,255,255,0) 100%);
+    }
   }
 
   &__input:active ~ &__gradient, &__input:focus ~ &__gradient {

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -490,7 +490,7 @@
 }
 
 .co-m-row:hover {
-  background-color: #fafafa;
+  background-color: $color-co-m-row-hover;
 }
 
 .co-m-inline-loader,

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -39,6 +39,7 @@ $color-primary: $color-pf-blue-300;
 // TODO (jon) review color usage throughout app and consolidate common colors into this file
 
 $color-alertmanager-dark: $color-pf-orange-500;
+$color-co-m-row-hover: #fafafa;
 $color-configmap-dark: $color-pf-purple-600;
 $color-container-dark: $color-pf-light-blue-400;
 $color-grey-background-border: #ccc;


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1054

After:
<img width="799" alt="screen shot 2018-12-10 at 4 26 51 pm" src="https://user-images.githubusercontent.com/895728/49762667-6be1f880-fc98-11e8-8d93-88ee8a0e56d4.png">
