### PR TITLE
Fix bug where probe URLs may lack `/`

### DIFF
--- a/frontend/public/module/k8s/probe.js
+++ b/frontend/public/module/k8s/probe.js
@@ -86,7 +86,11 @@ const flatteners = {
     }
 
     if (cmd.path) {
-      c += cmd.path;
+      if (cmd.path.startsWith('/')) {
+        c += cmd.path;
+      } else {
+        c += `/${cmd.path}`;
+      }
     }
     return c;
   },


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1131

After:
<img width="316" alt="screen shot 2018-12-10 at 6 30 15 pm" src="https://user-images.githubusercontent.com/895728/49768262-c2a3fe00-fca9-11e8-8226-a43adbd52448.png">
<img width="371" alt="screen shot 2018-12-10 at 6 30 46 pm" src="https://user-images.githubusercontent.com/895728/49768263-c2a3fe00-fca9-11e8-9e4e-a3723740f6e5.png">

