### PR TITLE
Ensure OLM CatalogSource View Requires OperatorGroup

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
@@ -22,7 +22,7 @@ describe(CatalogSourceDetails.displayName, () => {
   beforeEach(() => {
     obj = _.cloneDeep(testCatalogSource);
 
-    wrapper = shallow(<CatalogSourceDetails obj={obj} packageManifests={[testPackageManifest]} subscriptions={[]} />);
+    wrapper = shallow(<CatalogSourceDetails obj={obj} packageManifests={[testPackageManifest]} subscriptions={[]} operatorGroups={[]} />);
   });
 
   it('renders nothing if not all resources are loaded', () => {
@@ -59,6 +59,7 @@ describe(CatalogSourceDetailsPage.displayName, () => {
     expect(wrapper.find(DetailsPage).props().resources).toEqual([
       {kind: referenceForModel(PackageManifestModel), isList: true, namespace: match.params.ns, selector, prop: 'packageManifests'},
       {kind: referenceForModel(SubscriptionModel), isList: true, namespace: match.params.ns, prop: 'subscriptions'},
+      {kind: referenceForModel(OperatorGroupModel), isList: true, namespace: match.params.ns, prop: 'operatorGroups'},
     ]);
   });
 });

--- a/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
@@ -109,7 +109,7 @@ describe(InstallPlansList.displayName, () => {
     const msgWrapper = shallow(<EmptyMsg />);
 
     expect(msgWrapper.find(MsgBox).props().title).toEqual('No Install Plans Found');
-    expect(msgWrapper.find(MsgBox).props().detail).toEqual('Install Plans are created automatically by subscriptions or manually using kubectl.');
+    expect(msgWrapper.find(MsgBox).props().detail).toEqual('Install Plans are created automatically by subscriptions or manually using the CLI.');
   });
 });
 

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -52,5 +52,16 @@ const CRDRow = ({obj: crd}) => <div className="row co-resource-list__item">
   </div>
 </div>;
 
-export const CustomResourceDefinitionsList = props => <List {...props} Header={CRDHeader} Row={CRDRow} />;
-export const CustomResourceDefinitionsPage = props => <ListPage {...props} ListComponent={CustomResourceDefinitionsList} kind="CustomResourceDefinition" canCreate={true} filterLabel="CRDs by name" />;
+export const CustomResourceDefinitionsList: React.SFC<CustomResourceDefinitionsListProps> = props => <List {...props} Header={CRDHeader} Row={CRDRow} />;
+export const CustomResourceDefinitionsPage: React.SFC<CustomResourceDefinitionsPageProps> = props => <ListPage {...props} ListComponent={CustomResourceDefinitionsList} kind="CustomResourceDefinition" canCreate={true} filterLabel="CRDs by name" />;
+
+export type CustomResourceDefinitionsListProps = {
+
+};
+
+export type CustomResourceDefinitionsPageProps = {
+
+};
+
+CustomResourceDefinitionsList.displayName = 'CustomResourceDefinitionsList';
+CustomResourceDefinitionsPage.displayName = 'CustomResourceDefinitionsPage';

--- a/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
@@ -11,31 +11,35 @@ import { CatalogSourceKind, SubscriptionKind, PackageManifestKind, visibilityLab
 import { requireOperatorGroup } from './operator-group';
 import { PackageManifestList } from './package-manifest';
 import { SubscriptionModel, CatalogSourceModel, PackageManifestModel, OperatorGroupModel } from '../../models';
-import { referenceForModel } from '../../module/k8s';
+import { referenceForModel, K8sResourceKind } from '../../module/k8s';
 import { DetailsPage } from '../factory';
 
-export const CatalogSourceDetails: React.SFC<CatalogSourceDetailsProps> = ({obj, packageManifests, subscriptions}) => !_.isEmpty(obj)
-  ? <div className="co-catalog-details co-m-pane">
-    <div className="co-m-pane__body">
-      <div className="col-xs-4">
-        <dl className="co-m-pane__details">
-          <dt>Name</dt>
-          <dd>{obj.spec.displayName}</dd>
-        </dl>
+export const CatalogSourceDetails: React.SFC<CatalogSourceDetailsProps> = ({obj, packageManifests, subscriptions, operatorGroups}) => {
+  const toData = <T extends K8sResourceKind>(data: T[]) => ({loaded: true, data});
+
+  return !_.isEmpty(obj)
+    ? <div className="co-catalog-details co-m-pane">
+      <div className="co-m-pane__body">
+        <div className="col-xs-4">
+          <dl className="co-m-pane__details">
+            <dt>Name</dt>
+            <dd>{obj.spec.displayName}</dd>
+          </dl>
+        </div>
+        <div className="col-xs-4">
+          <dl className="co-m-pane__details">
+            <dt>Publisher</dt>
+            <dd>{obj.spec.publisher}</dd>
+          </dl>
+        </div>
       </div>
-      <div className="col-xs-4">
-        <dl className="co-m-pane__details">
-          <dt>Publisher</dt>
-          <dd>{obj.spec.publisher}</dd>
-        </dl>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Packages" />
+        <PackageManifestList loaded={true} data={packageManifests} operatorGroup={toData(operatorGroups)} subscription={toData(subscriptions)} />
       </div>
     </div>
-    <div className="co-m-pane__body">
-      <SectionHeading text="Packages" />
-      <PackageManifestList loaded={true} data={packageManifests} operatorGroup={null} subscription={{loaded: true, data: subscriptions}} />
-    </div>
-  </div>
-  : <div />;
+    : <div />;
+};
 
 export const CatalogSourceDetailsPage: React.SFC<CatalogSourceDetailsPageProps> = (props) => <DetailsPage
   {...props}
@@ -58,6 +62,11 @@ export const CatalogSourceDetailsPage: React.SFC<CatalogSourceDetailsPageProps> 
     isList: true,
     namespace: props.match.params.ns,
     prop: 'subscriptions',
+  }, {
+    kind: referenceForModel(OperatorGroupModel),
+    isList: true,
+    namespace: props.match.params.ns,
+    prop: 'operatorGroups',
   }]}
 />;
 
@@ -112,6 +121,7 @@ export type CatalogSourceDetailsProps = {
   obj: CatalogSourceKind;
   subscriptions: SubscriptionKind[];
   packageManifests: PackageManifestKind[];
+  operatorGroups: OperatorGroupKind[];
 };
 
 export type CatalogSourceDetailsPageProps = {

--- a/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
@@ -56,7 +56,7 @@ export const InstallPlanRow: React.SFC<InstallPlanRowProps> = (props) => {
   </ResourceRow>;
 };
 export const InstallPlansList = requireOperatorGroup((props: InstallPlansListProps) => {
-  const EmptyMsg = () => <MsgBox title="No Install Plans Found" detail="Install Plans are created automatically by subscriptions or manually using kubectl." />;
+  const EmptyMsg = () => <MsgBox title="No Install Plans Found" detail="Install Plans are created automatically by subscriptions or manually using the CLI." />;
   return <List {...props} Header={InstallPlanHeader} Row={InstallPlanRow} EmptyMsg={EmptyMsg} />;
 });
 

--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -68,11 +68,11 @@ export const PackageManifestList = requireOperatorGroup((props: PackageManifestL
           <h3>{catalog.displayName}</h3>
           <span className="text-muted">Packaged by {catalog.publisher}</span>
         </div>
-        <Link to={`/k8s/ns/${catalog.namespace}/${referenceForModel(CatalogSourceModel)}/${catalog.name}`}>View catalog details</Link>
+        {props.showDetailsLink && <Link to={`/k8s/ns/${catalog.namespace}/${referenceForModel(CatalogSourceModel)}/${catalog.name}`}>View catalog details</Link>}
       </div>
       <List
         loaded={true}
-        data={props.data.filter(pkg => pkg.status.catalogSource === catalog.name)}
+        data={(props.data || []).filter(pkg => pkg.status.catalogSource === catalog.name)}
         filters={props.filters}
         virtualize={false}
         Header={PackageManifestHeader}
@@ -80,8 +80,8 @@ export const PackageManifestList = requireOperatorGroup((props: PackageManifestL
           obj={rowProps.obj}
           catalogSourceName={catalog.name}
           catalogSourceNamespace={catalog.namespace}
-          subscription={props.subscription.data.find(sub => sub.spec.name === rowProps.obj.metadata.name)}
-          defaultNS={_.get(props.operatorGroup.data, '[0].metadata.namespace')} />}
+          subscription={(props.subscription.data || []).find(sub => sub.spec.name === rowProps.obj.metadata.name)}
+          defaultNS={_.get(props.operatorGroup, 'data[0].metadata.namespace')} />}
         label="Package Manifests"
         EmptyMsg={() => <MsgBox title="No PackageManifests Found" detail="The catalog author has not added any packages." />} />
     </div>) }
@@ -98,7 +98,7 @@ export const PackageManifestsPage: React.SFC<PackageManifestsPageProps> = (props
     title="Operator Catalog Sources"
     showTitle={true}
     helpText={HelpText}
-    ListComponent={PackageManifestList}
+    ListComponent={(listProps: PackageManifestListProps) => <PackageManifestList {...listProps} showDetailsLink={true} />}
     filterLabel="Packages by name"
     flatten={flatten}
     resources={[
@@ -120,6 +120,7 @@ export type PackageManifestListProps = {
   operatorGroup: {loaded: boolean, data?: OperatorGroupKind[]};
   loaded: boolean;
   loadError?: string | Object;
+  showDetailsLink?: boolean;
 };
 
 export type PackageManifestHeaderProps = {
@@ -134,6 +135,6 @@ export type PackageManifestRowProps = {
   defaultNS: string;
 };
 
-PackageManifestHeader.displayName = 'PackageHeader';
-PackageManifestRow.displayName = 'PackageRow';
-PackageManifestList.displayName = 'PackageList';
+PackageManifestHeader.displayName = 'PackageManifestHeader';
+PackageManifestRow.displayName = 'PackageManifestRow';
+PackageManifestList.displayName = 'PackageManifestList';


### PR DESCRIPTION
### Description

The detail view was not correctly receiving a list of `OperatorGroups` from its `<Firehose>` (yet another bug caused by https://jira.coreos.com/browse/CONSOLE-327).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1658077
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1654960
Addresses https://github.com/openshift/console/issues/919