### PR TITLE
Fix the Cluster Status page's Health links to use Link

### DIFF
--- a/frontend/public/components/graphs/health.jsx
+++ b/frontend/public/components/graphs/health.jsx
@@ -30,7 +30,7 @@ const AlertsFiring = ({namespace}) => (
     title="Alerts Firing"
     name="Alerts"
     query={`sum(ALERTS{alertstate="firing", alertname!="DeadMansSwitch" ${namespace ? `, namespace="${namespace}"` : ''}})`}
-    href="/monitoring"
+    to="/monitoring"
   />
 );
 
@@ -39,7 +39,7 @@ const CrashloopingPods = ({namespace}) => (
     title="Crashlooping Pods"
     name="Pods"
     query={`count(increase(kube_pod_container_status_restarts_total${namespace ? `{namespace="${namespace}"}` : ''}[1h]) > 5 )`}
-    href={`/k8s/${namespace ? `ns/${namespace}` : 'all-namespaces'}/pods?rowFilter-pod-status=CrashLoopBackOff`}
+    to={`/k8s/${namespace ? `ns/${namespace}` : 'all-namespaces'}/pods?rowFilter-pod-status=CrashLoopBackOff`}
   />
 );
 

--- a/frontend/public/components/graphs/status.jsx
+++ b/frontend/public/components/graphs/status.jsx
@@ -1,5 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 
 import { SafetyFirst } from '../safety-first';
 import { coFetchJSON } from '../../co-fetch';
@@ -117,10 +118,10 @@ export class Status extends SafetyFirst {
         <div className="text-muted" style={{fontSize: 14, lineHeight: 1.3}}>{long}</div>
       </div>
     </div>;
-    const props = _.pick(this.props, ['href', 'rel', 'target']);
+    const props = _.pick(this.props, ['rel', 'target', 'to']);
     if (_.isEmpty(props)) {
       return statusElem;
     }
-    return <a {...props} style={{textDecoration: 'none'}}>{statusElem}</a>;
+    return <Link {...props} style={{textDecoration: 'none'}}>{statusElem}</Link>;
   }
 }


### PR DESCRIPTION
This change is necessary for the links to work when the `-base-path`
option is used.

This also prevents the UI reloading when you click these links.

This does mean that only internal `href`s will be handled, but currently we're only using `Status` in these 2 places anyway.

/cc @spadgett 