### PR TITLE
Add logging URL to console nav

### DIFF
--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -269,16 +269,18 @@ const monitoringAlertsStartsWith = ['monitoring/alerts', 'monitoring/alertrules'
 const MonitoringNavSection_ = ({ urls }) => {
   const prometheusURL = urls[MonitoringRoutes.Prometheus];
   const grafanaURL = urls[MonitoringRoutes.Grafana];
-  return window.SERVER_FLAGS.prometheusBaseURL || prometheusURL || grafanaURL
+  const kibanaURL = urls[MonitoringRoutes.Kibana];
+  return window.SERVER_FLAGS.prometheusBaseURL || prometheusURL || grafanaURL || kibanaURL
     ? <NavSection title="Monitoring">
       {window.SERVER_FLAGS.prometheusBaseURL && <HrefLink href="/monitoring/alerts" name="Alerts" startsWith={monitoringAlertsStartsWith} />}
       {window.SERVER_FLAGS.alertManagerBaseURL && <HrefLink href="/monitoring/silences" name="Silences" />}
       {prometheusURL && <ExternalLink href={prometheusURL} name="Metrics" />}
       {grafanaURL && <ExternalLink href={grafanaURL} name="Dashboards" />}
+      {kibanaURL && <ExternalLink href={kibanaURL} name="Logging" />}
     </NavSection>
     : null;
 };
-const MonitoringNavSection = connectToURLs(MonitoringRoutes.Prometheus, MonitoringRoutes.Grafana)(MonitoringNavSection_);
+const MonitoringNavSection = connectToURLs(MonitoringRoutes.Prometheus, MonitoringRoutes.Grafana, MonitoringRoutes.Kibana)(MonitoringNavSection_);
 
 export const Navigation = ({ isNavOpen, onNavSelect }) => {
   const PageNav = (

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -158,6 +158,22 @@ const detectMonitoringURLs = dispatch => coFetchJSON(monitoringConfigMapPath)
     },
   );
 
+const loggingConfigMapPath = `${k8sBasePath}/api/v1/namespaces/openshift-logging/configmaps/sharing-config`;
+const detectLoggingURL = dispatch => coFetchJSON(loggingConfigMapPath)
+  .then(
+    res => {
+      const {kibanaAppHost} = res.data;
+      if (!_.isEmpty(kibanaAppHost)) {
+        dispatch(setMonitoringURL(MonitoringRoutes.Kibana, kibanaAppHost));
+      }
+    },
+    err => {
+      if (!_.includes([401, 403, 404, 500], _.get(err, 'response.status'))) {
+        setTimeout(() => detectLoggingURL(dispatch), 15000);
+      }
+    },
+  );
+
 const detectUser = dispatch => coFetchJSON('api/kubernetes/apis/user.openshift.io/v1/users/~')
   .then(
     (user) => {
@@ -176,6 +192,7 @@ export const featureActions = [
   detectMonitoringURLs,
   detectClusterVersion,
   detectUser,
+  detectLoggingURL,
 ];
 
 const projectListPath = `${k8sBasePath}/apis/project.openshift.io/v1/projects?limit=1`;

--- a/frontend/public/monitoring.ts
+++ b/frontend/public/monitoring.ts
@@ -21,6 +21,7 @@ export enum MonitoringRoutes {
   Prometheus = 'prometheus-k8s',
   AlertManager = 'alertmanager-main',
   Grafana = 'grafana',
+  Kibana = 'kibana',
 }
 
 const SET_MONITORING_URL = 'setMonitoringURL';


### PR DESCRIPTION
The logging URL will show up in the nav if it's in the ConfigMap.

<img width="213" alt="screen shot 2018-12-12 at 1 31 19 pm" src="https://user-images.githubusercontent.com/7014965/49893143-b8ecd880-fe18-11e8-8052-b5fa8be8dec0.png">

Fixes [CONSOLE-972](https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-972).