### PR TITLE
Bug 1656730 - Remove `customresourcedefinitions` from CRD paths

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -156,11 +156,6 @@ class App extends React.PureComponent {
             <LazyRoute path="/k8s/all-namespaces/import" exact loader={() => import('./import-yaml' /* webpackChunkName: "import-yaml" */).then(m => NamespaceFromURL(m.ImportYamlPage))} />
             <LazyRoute path="/k8s/ns/:ns/import/" exact loader={() => import('./import-yaml' /* webpackChunkName: "import-yaml" */).then(m => NamespaceFromURL(m.ImportYamlPage))} />
 
-            <Route path="/k8s/ns/:ns/customresourcedefinitions/:plural" exact component={ResourceListPage} />
-            <Route path="/k8s/ns/:ns/customresourcedefinitions/:plural/:name" component={ResourceDetailsPage} />
-            <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural" exact component={ResourceListPage} />
-            <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural/:name" component={ResourceDetailsPage} />
-
             {
               // These pages are temporarily disabled. We need to update the safe resources list.
               // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -28,7 +28,7 @@ const CRDRow = ({obj: crd}) => <div className="row co-resource-list__item">
   <div className="col-lg-4 col-md-4 col-sm-4 col-xs-6">
     <span className="co-resource-link">
       <ResourceIcon kind="CustomResourceDefinition" />
-      <Link className="co-resource-link__resource-name" to={`/k8s/all-namespaces/customresourcedefinitions/${referenceForCRD(crd)}`}>{_.get(crd, 'spec.names.kind', crd.metadata.name)}</Link>
+      <Link className="co-resource-link__resource-name" to={`/k8s/all-namespaces/${referenceForCRD(crd)}`}>{_.get(crd, 'spec.names.kind', crd.metadata.name)}</Link>
     </span>
   </div>
   <div className="col-lg-3 col-md-4 col-sm-4 col-xs-6 co-break-word">

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -32,7 +32,7 @@ export const ResourceListPage = connectToPlural(withStartGuide(
       const missingType = isGroupVersionKind(plural) ? `"${kindForReference(plural)}" in "${apiVersionForReference(plural)}"` : `"${plural}"`;
       return <ErrorPage404 message={`The server doesn't have a resource type ${missingType}. Try refreshing the page if it was recently added.`} />;
     }
-    const ref = props.match.path.indexOf('customresourcedefinitions') === -1 ? referenceForModel(kindObj) : null;
+    const ref = referenceForModel(kindObj);
     const componentLoader = resourceListPages.get(ref, () => Promise.resolve(DefaultPage));
 
     return <div className="co-m-list">


### PR DESCRIPTION
The original change was put in place to keep the CRDs nav item
highlighted, but I'm not sure the new behavior is better.

* It introduced some problems switching between projects when a CRD is
  selected.
* It created two different URL patterns to the same resource list. You
  might get one or the other depending on how you get to the list in the
  UI. The CRDs nav item is highlighted or not depending on where you
  came from.
* It prevented you from seeing the custom list columns when viewing a
  resource. This was originally listed as a benefit, but I'd argue in
  most cases you want the custom columns. I personally prefer having
  one consistent view of the resource no matter where it shows up
  (search view, CRDs page, or another page).

This change does have the drawback of not highlighting the CRDs nav item. I
think the behavior is fine though since you're no longer looking at the
CRDs themselves.

https://bugzilla.redhat.com/show_bug.cgi?id=1656730