### PR TITLE
Filter Marketplace CatalogSources from OLM View

### DIFF
--- a/frontend/public/components/marketplace/kubernetes-marketplace.jsx
+++ b/frontend/public/components/marketplace/kubernetes-marketplace.jsx
@@ -9,6 +9,8 @@ import {PackageManifestModel} from '../../models';
 import {MarketplaceTileViewPage} from './kubernetes-marketplace-items';
 import * as operatorImg from '../../imgs/operator.svg';
 
+export const marketplaceLabel = 'openshift-marketplace';
+
 const normalizePackageManifests = (packageManifests, kind) => {
   const activePackageManifests = _.filter(packageManifests, packageManifest => {
     return !packageManifest.status.removedFromBrokerCatalog;

--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import { referenceForModel, K8sResourceKind } from '../../module/k8s';
 import { requireOperatorGroup } from './operator-group';
 import { PackageManifestKind, SubscriptionKind, ClusterServiceVersionLogo, visibilityLabel, OperatorGroupKind } from './index';
+import { marketplaceLabel } from '../marketplace/kubernetes-marketplace';
 import { PackageManifestModel, SubscriptionModel, CatalogSourceModel, OperatorGroupModel } from '../../models';
 import { StatusBox, MsgBox } from '../utils';
 import { List, ListHeader, ColHead, MultiListPage } from '../factory';
@@ -102,7 +103,7 @@ export const PackageManifestsPage: React.SFC<PackageManifestsPageProps> = (props
     filterLabel="Packages by name"
     flatten={flatten}
     resources={[
-      {kind: referenceForModel(PackageManifestModel), isList: true, namespaced: true, prop: 'packageManifest', selector: {matchExpressions: [{key: visibilityLabel, operator: 'DoesNotExist'}]}},
+      {kind: referenceForModel(PackageManifestModel), isList: true, namespaced: true, prop: 'packageManifest', selector: {matchExpressions: [{key: visibilityLabel, operator: 'DoesNotExist'}, {key: marketplaceLabel, operator: 'DoesNotExist'}]}},
       {kind: referenceForModel(CatalogSourceModel), isList: true, namespaced: true, prop: 'catalogSource'},
       {kind: referenceForModel(SubscriptionModel), isList: true, namespaced: true, prop: 'subscription'},
       {kind: referenceForModel(OperatorGroupModel), isList: true, namespaced: true, prop: 'operatorGroup'},


### PR DESCRIPTION
### Description

Ensures that there are two unique sets of `PackageManifests` for the "Kubernetes Marketplace"/"Package Manifest" views.

Addresses https://jira.coreos.com/browse/ALM-838