### PR TITLE
Firehose resources are considered loaded only once all optional resources have either loaded or errored.

### DIFF
--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -404,7 +404,6 @@ export const MultiListPage = props => {
         kinds={_.map(resources, 'kind')}
         label={label}
         ListComponent={ListComponent}
-        mock={mock}
         rowFilters={rowFilters}
         staticFilters={staticFilters}
       />

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -67,7 +67,7 @@ const ConnectToState = connect(({k8s}, {reduxes}) => {
   });
 
   const required = _.filter(resources, r => !r.optional);
-  const loaded = _.every(required, 'loaded');
+  const loaded = _.every(resources, resource => (resource.optional ? resource.loaded || !_.isEmpty(resource.loadError) : resource.loaded));
   const loadError = worstError(_.map(required, 'loadError').filter(Boolean));
 
   return Object.assign({}, resources, {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650464

Cause:
Resources loaded through the ConnectToState component (in firehose.jsx) were considered collectively loaded if the `loaded` state of all required resources was true. Optional resources' `loaded` state was not being checked. This means that the `loaded` prop set by this component could be true before optional resources were finished loading.

Consequence:
When optional resources are passed to FIrehose, and no required resources exist, an empty state might be displayed momentarily before optional resources have a chance to finish loading.

Fix:
The logic for setting the 'loaded' prop created in ConnectToState is now as follows:
 - Optional resources are considered loaded if and only if either their `loaded` state is true or their `loadError` state is not empty.
- Required resources are considered loaded if and only if their `loaded` state is true
- If all optional and required resources are considered loaded by the above logic, the `loaded` prop will be true.

Result:
An empty state is no longer displayed before optional components are finished loading.

