### PR TITLE
Monitoring: Use LazyRoute for all monitoring pages

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -11,7 +11,6 @@ import { productName } from '../branding';
 import { ALL_NAMESPACES_KEY } from '../const';
 import { connectToFlags, featureActions, flagPending, FLAGS } from '../features';
 import { analyticsSvc } from '../module/analytics';
-import { MonitoringUI } from './monitoring';
 import { ClusterSettingsPage } from './cluster-settings/cluster-settings';
 import { GlobalNotifications } from './global-notifications';
 import { Masthead } from './masthead';
@@ -185,7 +184,7 @@ class App extends React.PureComponent {
 
             <LazyRoute path="/k8s/ns/:ns/persistentvolumeclaims/new/form" exact kind="PersistentVolumeClaim" loader={() => import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(m => m.CreatePVC)} />
 
-            <Route path="/monitoring" component={MonitoringUI} />
+            <LazyRoute path="/monitoring" loader={() => import('./monitoring' /* webpackChunkName: "monitoring" */).then(m => m.MonitoringUI)} />
 
             <Route path="/settings/cluster" component={ClusterSettingsPage} />
 

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -14,10 +14,9 @@ import {
   WindowScroller,
 } from 'react-virtualized';
 
-import { AlertStates, SilenceStates } from '../../monitoring';
+import { alertState, AlertStates, silenceState, SilenceStates } from '../../monitoring';
 import { UIActions } from '../../ui/ui-actions';
 import { ingressValidHosts } from '../ingress';
-import { alertState, silenceState } from '../monitoring';
 import { routeStatus } from '../routes';
 import { getClusterOperatorStatus } from '../cluster-settings/cluster-operator';
 import { secretTypeFilterReducer } from '../secret';

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -8,7 +8,7 @@ import { Link, Redirect, Route, Switch } from 'react-router-dom';
 
 import { coFetchJSON } from '../co-fetch';
 import k8sActions from '../module/k8s/k8s-actions';
-import { AlertStates, connectToURLs, MonitoringRoutes, SilenceStates } from '../monitoring';
+import { alertState, AlertStates, connectToURLs, MonitoringRoutes, silenceState, SilenceStates } from '../monitoring';
 import store from '../redux';
 import { UIActions } from '../ui/ui-actions';
 import { ColHead, List, ListHeader, ResourceRow, TextFilter } from './factory';
@@ -57,14 +57,10 @@ const labelsToParams = labels => _.map(labels, (v, k) => `${encodeURIComponent(k
 const alertURL = (alert, ruleID) => `${AlertResource.path}/${ruleID}?${labelsToParams(alert.labels)}`;
 const ruleURL = rule => `${AlertRuleResource.path}/${_.get(rule, 'id')}`;
 
-export const alertState = a => _.get(a, 'state', AlertStates.NotFiring);
-
 const alertDescription = alert => {
   const {annotations = {}, labels = {}} = alert;
   return annotations.description || annotations.message || labels.alertname;
 };
-
-export const silenceState = s => _.get(s, 'status.state');
 
 const alertsToProps = ({UI}) => UI.getIn(['monitoring', 'alerts']) || {};
 const silencesToProps = ({UI}) => UI.getIn(['monitoring', 'silences']) || {};

--- a/frontend/public/monitoring.ts
+++ b/frontend/public/monitoring.ts
@@ -50,6 +50,9 @@ const stateToProps = (desiredURLs: string[], state) => {
 
 export const connectToURLs = (...urls) => connect(state => stateToProps(urls, state));
 
+export const alertState = a => _.get(a, 'state', AlertStates.NotFiring);
+export const silenceState = s => _.get(s, 'status.state');
+
 // Determine if an Alert is silenced by a Silence (if all of the Silence's matchers match one of the Alert's labels)
 export const isSilenced = (alert, silence) => [AlertStates.Firing, AlertStates.Silenced].includes(alert.state) &&
   _.every(silence.matchers, m => {


### PR DESCRIPTION
Also moved the `alertState()` and `silenceState()` helpers out of
`monitoring.tsx` to avoid needing to import that file.

The problems I was having with this before, seem to have been resolved by https://github.com/openshift/console/pull/864.

/cc @alecmerdler 

FYI @spadgett 