### PR TITLE
Monitoring: Always show not firing alerts with status "Not Firing"

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -179,14 +179,7 @@ const alertStateToProps = (state, {match}): AlertsDetailsPageProps => {
   let alert = _.find(alerts, a => _.isEqual(a.labels, labels));
   if (rule && !alert) {
     // No Alert with the exact label set was found, so display a "fake" Alert based on the Rule
-    const alertStates = _.map(alerts, alertState);
-    alert = {
-      annotations: rule.annotations,
-      labels,
-      rule,
-      // Set the state to the most significant state of all the Rule's Alerts
-      state: _.find([AlertStates.Firing, AlertStates.Silenced, AlertStates.Pending], s => alertStates.includes(s)) || AlertStates.NotFiring,
-    };
+    alert = {annotations: rule.annotations, labels, rule, state: AlertStates.NotFiring};
   }
   return {alert, loaded, loadError, rule, silencesLoaded};
 };


### PR DESCRIPTION
This behavior was trying to be helpful by indicating that a different
alert generated by the same rule was Firing / Pending. However, it was
actually very confusing because that Firing / Pending alert will have
different labels from those currently visible in the UI. Better to just
show the alert as Not Firing.