### PR TITLE
Disable `gecko` for webdriver update to avoid Github rate limit errors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "coverage": "jest --coverage .",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --color .",
     "test": "jest",
-    "webdriver-update": "webdriver-manager update --versions.chrome=2.38",
+    "webdriver-update": "webdriver-manager update --versions.chrome=2.38 --gecko=false",
     "test-gui-tap": "TAP=true yarn run test-gui",
     "test-gui-openshift": "yarn run test-suite --suite crud --params.openshift true",
     "test-gui": "yarn run test-suite --suite all",


### PR DESCRIPTION
Github will rate limit unauthenticated requests run as part of
`webdriver-manager update`, which causes it to fail sometimes. Since we
only use Chrome in our e2e tests, disable gecko, which avoids the problem.

/assign @alecmerdler 