### PR TITLE
Row filter receives name-filtered data

### DIFF
--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -59,6 +59,10 @@ TextFilter.displayName = 'TextFilter';
 // TODO (jon) make this into "withListPageFilters" HOC
 /** @augments {React.PureComponent<{ListComponent: React.ComponentType<any>, kinds: string[], flatten?: function, data?: any[], rowFilters?: any[]}>} */
 export class ListPageWrapper_ extends React.PureComponent {
+  getFilteredRows(filter, objects) {
+    return _.filter(objects, o => o.metadata.name.includes(filter));
+  }
+
   render() {
     const {
       flatten,
@@ -68,6 +72,8 @@ export class ListPageWrapper_ extends React.PureComponent {
       rowFilters,
     } = this.props;
     const data = flatten ? flatten(this.props.resources) : [];
+    const filteredData = this.getFilteredRows(this.props.filters.name, data);
+    const intersection = _.intersection(data, filteredData);
 
     const RowsOfRowFilters = rowFilters && _.map(rowFilters, ({items, reducer, selected, type, numbers}, i) => {
       const count = _.isFunction(numbers) ? numbers(data) : undefined;
@@ -75,8 +81,8 @@ export class ListPageWrapper_ extends React.PureComponent {
         key={i}
         applyFilter={this.props.applyFilter}
         items={_.isFunction(items) ? items(_.pick(this.props, kinds)) : items}
-        itemCount={_.size(data)}
-        numbers={count || _.countBy(data, reducer)}
+        itemCount={_.size(filteredData) > 0 ? _.size(intersection) : _.size(data)}
+        numbers={count || _.size(filteredData) > 0 ? _.countBy(intersection, reducer) : _.countBy(data, reducer)}
         selected={selected}
         type={type}
         reduxIDs={reduxIDs}


### PR DESCRIPTION
Row filters now handle rows filtered by the "filter by name" text input. The numbers in the filters and the item count adjust when content is added to the input field.

Unfiltered:
<img width="1203" alt="screen shot 2018-12-14 at 4 02 25 pm" src="https://user-images.githubusercontent.com/7014965/50027301-c2fa0d00-ffb9-11e8-9f34-5f72e85b052c.png">

Filtered:
<img width="1206" alt="screen shot 2018-12-14 at 4 02 41 pm" src="https://user-images.githubusercontent.com/7014965/50027310-cab9b180-ffb9-11e8-92f2-7ceed90f9f39.png">

Fixes [bug 1656709](https://bugzilla.redhat.com/show_bug.cgi?id=1656709).

Heads up for @openshift/team-ux-review.