### PR TITLE
Bug fix - use functions not function calls in .then()

### DIFF
--- a/frontend/public/components/marketplace/marketplace-item-modal.jsx
+++ b/frontend/public/components/marketplace/marketplace-item-modal.jsx
@@ -54,10 +54,10 @@ class MarketplaceItemModal extends React.Component {
       },
     };
     if (!previousPackages){
-      k8sCreate(CatalogSourceConfigModel, catalogSourceConfig).then(close());
+      k8sCreate(CatalogSourceConfigModel, catalogSourceConfig).then(() => close());
       return;
     }
-    k8sKill(CatalogSourceConfigModel, catalogSourceConfig).then(k8sCreate(CatalogSourceConfigModel, catalogSourceConfig)).then(close()); // TODO: link to OLM subscription page
+    k8sKill(CatalogSourceConfigModel, catalogSourceConfig).then(() => k8sCreate(CatalogSourceConfigModel, catalogSourceConfig)).then(() => close()); // TODO: link to OLM subscription page
   }
 
   render() {


### PR DESCRIPTION
If you click the enable buttons quick enough you get strange behavior. This is because the `.then()` were not actually waiting till the previous command returned. This fixes that

/cc @alecmerdler 