### PR TITLE
Monitoring: Improve sort by state column on list pages

### DIFF
--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -14,7 +14,7 @@ import {
   WindowScroller,
 } from 'react-virtualized';
 
-import { alertState, AlertStates, silenceState, SilenceStates } from '../../monitoring';
+import { alertState, alertStateOrder, silenceState, silenceStateOrder } from '../../monitoring';
 import { UIActions } from '../../ui/ui-actions';
 import { ingressValidHosts } from '../ingress';
 import { routeStatus } from '../routes';
@@ -200,7 +200,7 @@ const filterPropType = (props, propName, componentName) => {
 };
 
 const sorts = {
-  alertStateOrder: alert => [AlertStates.Firing, AlertStates.Silenced, AlertStates.Pending, AlertStates.NotFiring].indexOf(alertState(alert)),
+  alertStateOrder,
   daemonsetNumScheduled: daemonset => _.toInteger(_.get(daemonset, 'status.currentNumberScheduled')),
   dataSize: resource => _.size(_.get(resource, 'data')),
   ingressValidHosts,
@@ -218,7 +218,7 @@ const sorts = {
   podPhase,
   podReadiness,
   serviceClassDisplayName,
-  silenceStateOrder: silence => [SilenceStates.Active, SilenceStates.Pending, SilenceStates.Expired].indexOf(silenceState(silence)),
+  silenceStateOrder,
   string: val => JSON.stringify(val),
 };
 

--- a/frontend/public/monitoring.ts
+++ b/frontend/public/monitoring.ts
@@ -53,6 +53,16 @@ export const connectToURLs = (...urls) => connect(state => stateToProps(urls, st
 export const alertState = a => _.get(a, 'state', AlertStates.NotFiring);
 export const silenceState = s => _.get(s, 'status.state');
 
+// Sort alerts and silences by their state (sort first by the state itself, then by the timestamp relevant to the state)
+export const alertStateOrder = alert => [
+  [AlertStates.Firing, AlertStates.Silenced, AlertStates.Pending, AlertStates.NotFiring].indexOf(alertState(alert)),
+  alertState(alert) === AlertStates.Silenced ? _.max(_.map(alert.silencedBy, 'endsAt')) : _.get(alert, 'activeAt'),
+];
+export const silenceStateOrder = silence => [
+  [SilenceStates.Active, SilenceStates.Pending, SilenceStates.Expired].indexOf(silenceState(silence)),
+  _.get(silence, silenceState(silence) === SilenceStates.Pending ? 'startsAt' : 'endsAt'),
+];
+
 // Determine if an Alert is silenced by a Silence (if all of the Silence's matchers match one of the Alert's labels)
 export const isSilenced = (alert, silence) => [AlertStates.Firing, AlertStates.Silenced].includes(alert.state) &&
   _.every(silence.matchers, m => {


### PR DESCRIPTION
Sort first by the state itself, then by the timestamp relevant to the state.

This helps with navigating through larger numbers of alerts and also makes the sort order predictable within alerts of the same state.

e.g. In the screenshot below, sort first by state (Firing above Not Firing), then by timestamp (earlier times near the top).

![screenshot](https://user-images.githubusercontent.com/460802/50055035-c85b8100-018c-11e9-9af6-1bc0e4fc9a92.png)