### PR TITLE
Monitoring: Hide kebab menu for silenced alerts in Active Alerts list

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -287,7 +287,7 @@ const ActiveAlerts = ({alerts, ruleID}) => <div className="co-m-table-grid co-m-
       <div className="col-sm-2 hidden-xs"><Timestamp timestamp={a.activeAt} /></div>
       <div className="col-sm-2 col-xs-3"><AlertState state={a.state} /></div>
       <div className="col-sm-2 col-xs-3 co-break-word">{a.value}</div>
-      <div className="dropdown-kebab-pf"><Kebab options={[silenceAlert(a)]} /></div>
+      {a.state !== AlertStates.Silenced && <div className="dropdown-kebab-pf"><Kebab options={[silenceAlert(a)]} /></div>}
     </ResourceRow>)}
   </div>
 </div>;


### PR DESCRIPTION
In the Active Alerts list (on the Rule details page), the only kebab
menu action is "Silence Alert". However, we don't want to show that
action for alerts that are already silenced, so remove the menu
completely in this case.

This does mean that some rows will have the menu and some won't, but I think this is acceptable now that we have switched to a right aligned menu.

/cc @cshinn WDYT?

![screenshot](https://user-images.githubusercontent.com/460802/50071012-9fca9a00-0213-11e9-86df-3a30f1267c7b.png)
