### PR TITLE
Fix CRD links where kind matches a different static model

### DIFF
--- a/frontend/public/module/k8s/k8s-models.ts
+++ b/frontend/public/module/k8s/k8s-models.ts
@@ -30,12 +30,12 @@ export const modelFor = (ref: K8sResourceKindReference) => {
   if (m) {
     return m;
   }
-  m = k8sModels.get(kindForReference(ref));
+  // FIXME: Remove synchronous `store.getState()` call here, should be using `connectToModels` instead, only here for backwards-compatibility
+  m = store.getState().k8s.getIn(['RESOURCES', 'models']).get(ref);
   if (m) {
     return m;
   }
-  // FIXME: Remove synchronous `store.getState()` call here, should be using `connectToModels` instead, only here for backwards-compatibility
-  m = store.getState().k8s.getIn(['RESOURCES', 'models']).get(ref);
+  m = k8sModels.get(kindForReference(ref));
   if (m) {
     return m;
   }


### PR DESCRIPTION
Make sure we first check the specific `GroupVersionKind` reference before using `kindForReference`. This prevents getting the wrong model when a CRD kind is the same as another static resource. In OpenShift, this is specifically a problem for `ingresses.config.openshift.io`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1659962

/assign @alecmerdler 
/cc @rhamilto 