### PR TITLE
add custom resources to Kebap and PageHeading

### DIFF
--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -32,7 +32,8 @@ export const DetailsPage = withFallback<DetailsPageProps>((props) => <Firehose r
     menuActions={props.menuActions}
     buttonActions={props.buttonActions}
     kind={props.kind}
-    breadcrumbsFor={props.breadcrumbsFor} />
+    breadcrumbsFor={props.breadcrumbsFor}
+    resourceKeys={_.map(props.resources, 'prop')} />
   <HorizontalNav
     pages={props.pages}
     pagesFor={props.pagesFor}

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -38,7 +38,7 @@ const ActionButtons: React.SFC<ActionButtonsProps> = ({actionButtons}) => <div c
 </div>;
 
 export const PageHeading = connectToModel((props: PageHeadingProps) => {
-  const {kind, kindObj, detail, title, menuActions, buttonActions, obj, breadcrumbsFor, titleFunc, style} = props;
+  const {kind, kindObj, detail, title, menuActions, buttonActions, obj, breadcrumbsFor, titleFunc, style, resourceKeys} = props;
   const data = _.get(obj, 'data');
   const resourceTitle = (titleFunc && data) ? titleFunc(data) : title;
   const isCSV = kind === referenceForModel(ClusterServiceVersionModel);
@@ -53,13 +53,15 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
   const hasMenuActions = !_.isEmpty(menuActions);
   const showActions = (hasButtonActions || hasMenuActions) && !_.isEmpty(data) && !_.get(data, 'deletionTimestamp');
 
+  const extraResources = _.reduce(resourceKeys, (extraObjs, key) => ({...extraObjs, [key]: props[key].data}), {});
+
   return <div className={classNames('co-m-nav-title', {'co-m-nav-title--detail': detail}, {'co-m-nav-title--logo': isCSV}, {'co-m-nav-title--breadcrumbs': breadcrumbsFor && !_.isEmpty(data)})} style={style}>
     { breadcrumbsFor && !_.isEmpty(data) && <BreadCrumbs breadcrumbs={breadcrumbsFor(data)} /> }
     <h1 className={classNames('co-m-pane__heading', {'co-m-pane__heading--logo': isCSV})}>
       { logo }
       { showActions && <div className="co-actions">
-        { hasButtonActions && <ActionButtons actionButtons={buttonActions.map(a => a(kindObj, data))} /> }
-        { hasMenuActions && <ActionsMenu actions={menuActions.map(a => a(kindObj, data))} /> }
+        { hasButtonActions && <ActionButtons actionButtons={buttonActions.map(a => a(kindObj, data, extraResources))} /> }
+        { hasMenuActions && <ActionsMenu actions={menuActions.map(a => a(kindObj, data, extraResources))} /> }
       </div> }
     </h1>
     {props.children}
@@ -103,6 +105,7 @@ export type PageHeadingProps = {
   style?: object;
   title?: string | JSX.Element;
   titleFunc?: (obj: K8sResourceKind) => string | JSX.Element;
+  resourceKeys?: string[];
 };
 
 export type ResourceOverviewHeadingProps = {

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -8,6 +8,8 @@ import { DropdownMixin } from './dropdown';
 import { history, resourceObjPath } from './index';
 import { referenceForModel, K8sResourceKind, K8sResourceKindReference, K8sKind } from '../../module/k8s';
 import { connectToModel } from '../../kinds';
+import {FirehoseResource} from '../factory';
+import { Firehose } from './firehose';
 
 const KebabItems: React.SFC<KebabItemsProps> = ({options, onClick}) => {
   const visibleOptions = _.reject(options, o => _.get(o, 'hidden', false));
@@ -72,15 +74,28 @@ kebabFactory.common = [kebabFactory.ModifyLabels, kebabFactory.ModifyAnnotations
 
 export const ResourceKebab = connectToModel((props: ResourceKebabProps) => {
   const {actions, kindObj, resource, isDisabled} = props;
+  const resources = props.resources || [];
 
   if (!kindObj) {
     return null;
   }
-  return <Kebab
-    options={actions.map(a => a(kindObj, resource))}
-    key={resource.metadata.uid}
-    isDisabled={isDisabled !== undefined ? isDisabled : _.get(resource.metadata, 'deletionTimestamp')}
-  />;
+
+  const resourceKeys = _.map(resources, 'prop');
+
+  const Wrapper = (wrapperProps) => {
+    const extraResources = _.reduce(resourceKeys, (extraObjs, key) => ({...extraObjs, [key]: wrapperProps[key].data}), {});
+    return <Kebab
+      options={actions.map(a => a(kindObj, resource, extraResources))}
+      key={resource.metadata.uid}
+      isDisabled={isDisabled !== undefined ? isDisabled : _.get(resource.metadata, 'deletionTimestamp')}
+    />;
+  };
+
+  return (
+    <Firehose resources={resources}>
+      <Wrapper />
+    </Firehose>
+  );
 });
 
 export class Kebab extends DropdownMixin {
@@ -117,7 +132,7 @@ export type KebabOption = {
   label: string;
   href?: string, callback?: () => any;
 };
-export type KebabAction = (kind, obj: K8sResourceKind) => KebabOption;
+export type KebabAction = (kind, obj: K8sResourceKind, object?) => KebabOption;
 
 export type ResourceKebabProps = {
   kindObj: K8sKind;
@@ -125,6 +140,7 @@ export type ResourceKebabProps = {
   kind: K8sResourceKindReference;
   resource: K8sResourceKind;
   isDisabled?: boolean;
+  resources?: FirehoseResource[];
 };
 
 export type KebabItemsProps = {


### PR DESCRIPTION
This patch makes it possible for actions to have multiple custom resources. 

Example usage: https://github.com/kubevirt/web-ui/pull/142

I am not sure if I should extract the kebap usage into standalone component.