### PR TITLE
Enable gzip compression of static files

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"compress/gzip"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/openshift/console/auth"
 )
@@ -40,6 +43,37 @@ func authMiddlewareWithUser(a *auth.Authenticator, handlerFunc func(user *auth.U
 		}
 
 		handlerFunc(user, w, r)
+	})
+}
+
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+	sniffDone bool
+}
+
+func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	if !w.sniffDone {
+		if w.Header().Get("Content-Type") == "" {
+			w.Header().Set("Content-Type", http.DetectContentType(b))
+		}
+		w.sniffDone = true
+	}
+	return w.Writer.Write(b)
+}
+
+// gzipHandler wraps a http.Handler to support transparent gzip encoding.
+func gzipHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Vary", "Accept-Encoding")
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			h.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		h.ServeHTTP(&gzipResponseWriter{Writer: gz, ResponseWriter: w}, r)
 	})
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -173,7 +173,7 @@ func (s *Server) HTTPHandler() http.Handler {
 	handleFunc("/api/", notFoundHandler)
 
 	staticHandler := http.StripPrefix(proxy.SingleJoiningSlash(s.BaseURL.Path, "/static/"), http.FileServer(http.Dir(s.PublicDir)))
-	handle("/static/", securityHeadersMiddleware(staticHandler))
+	handle("/static/", gzipHandler(securityHeadersMiddleware(staticHandler)))
 
 	// Scope of Service Worker needs to be higher than the requests it is intercepting (https://stackoverflow.com/a/35780776/6909941)
 	handleFunc("/load-test.sw.js", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This reduces the size of our responses pretty dramatically.

/assign @alecmerdler 

@dgutride fyi

Before:

![screen shot 2018-12-18 at 12 35 41 pm](https://user-images.githubusercontent.com/1167259/50171816-79633800-02c1-11e9-9b8e-a40942b338fe.png)

After:

![screen shot 2018-12-18 at 12 30 20 pm](https://user-images.githubusercontent.com/1167259/50171536-b3800a00-02c0-11e9-8d8f-f99a859040ea.png)
