### PR TITLE
Keep sidebar dropshadow at mobile

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -237,9 +237,12 @@ tags-input .autocomplete .suggestion-item em {
 
 .pf-l-page__sidebar {
   --pf-l-page__sidebar--BackgroundColor: #{$color-pf-black-900};
-  --pf-l-page__sidebar--BoxShadow: none;
   --pf-l-page__sidebar--PaddingBottom: 0;
   --pf-l-page__sidebar--PaddingTop: 0;
+
+  @media screen and (min-width: $grid-float-breakpoint) {
+    --pf-l-page__sidebar--BoxShadow: none;
+  }
 
   .pf-c-nav {
     // List link


### PR DESCRIPTION
It's subtle, but I think it helps differentiate the mobile nav as an overlay.

Before:
![localhost_9000_k8s_ns_robb_packagemanifests iphone 6_7_8 plus 1](https://user-images.githubusercontent.com/895728/50177231-70796300-02cf-11e9-9c78-895f3e77d509.png)

After:
![localhost_9000_k8s_ns_robb_packagemanifests iphone 6_7_8 plus](https://user-images.githubusercontent.com/895728/50177240-75d6ad80-02cf-11e9-87c8-d66290c99991.png)
