### PR TITLE
Fix bug where mobile dropdown menu items were missing

### DIFF
--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -131,13 +131,14 @@ class MastheadToolbar_ extends React.Component {
     }
 
     if (mobile) {
-      actions.push([{
+      actions.push({
         label: 'Documentation',
         callback: this._onDocumentation,
       },{
         label: 'About',
         callback: this._onAboutModal,
-      }]);
+      });
+
       return (
         <Dropdown
           isPlain


### PR DESCRIPTION
Before:
![screen shot 2018-12-18 at 2 34 47 pm](https://user-images.githubusercontent.com/895728/50178667-25614f00-02d3-11e9-9480-f700bdf087f4.png)

After:
![screen shot 2018-12-18 at 2 42 47 pm](https://user-images.githubusercontent.com/895728/50178699-3611c500-02d3-11e9-9c98-7bb9de927995.png)
