### PR TITLE
Add Operator-Provided APIs to Uber Catalog

### DIFF
--- a/frontend/public/components/catalog/catalog-item-details.jsx
+++ b/frontend/public/components/catalog/catalog-item-details.jsx
@@ -51,7 +51,6 @@ export class CatalogTileDetails extends React.Component {
 
     const vendor = tileProvider ? `Provided by ${tileProvider}` : null;
     const iconClass = tileIconClass ? normalizeIconClass(tileIconClass) : null;
-    const createLabel = `Create ${kind === 'ImageStream' ? 'Application' : 'Service Instance'}`;
     const creationTimestamp = _.get(obj, 'metadata.creationTimestamp');
 
     const supportUrlLink = <a href={supportUrl} target="_blank" className="co-external-link" rel="noopener noreferrer">Get Support</a>;
@@ -72,7 +71,7 @@ export class CatalogTileDetails extends React.Component {
         <Modal.Body>
           <div className="co-catalog-page__overlay-body">
             <PropertiesSidePanel>
-              <Link className="btn btn-primary co-catalog-page__overlay-create" to={href} role="button">{createLabel}</Link>
+              <Link className="btn btn-primary co-catalog-page__overlay-create" to={href} role="button">{this.props.item.createLabel}</Link>
               {tileProvider && <PropertyItem label="Provider" value={tileProvider} />}
               {supportUrl && <PropertyItem label="Support" value={supportUrlLink} />}
               {creationTimestamp && <PropertyItem label="Created At" value={<Timestamp timestamp={creationTimestamp} />} />}

--- a/frontend/public/components/catalog/catalog-items.jsx
+++ b/frontend/public/components/catalog/catalog-items.jsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
-import {CatalogTile} from 'patternfly-react-extensions';
-import {Modal} from 'patternfly-react';
+import { CatalogTile } from 'patternfly-react-extensions';
+import { Modal } from 'patternfly-react';
 
-import {history} from '../utils/router';
-import {normalizeIconClass} from './catalog-item-icon';
-import {CatalogTileDetails} from './catalog-item-details';
-import {TileViewPage} from '../utils/tile-view-page';
+import { history } from '../utils/router';
+import { normalizeIconClass } from './catalog-item-icon';
+import { CatalogTileDetails } from './catalog-item-details';
+import { TileViewPage } from '../utils/tile-view-page';
 
 export const catalogCategories = {
   languages: {
@@ -187,6 +187,7 @@ export class CatalogTileViewPage extends React.Component {
           items={items}
           itemsSorter={itemsToSort => _.sortBy(itemsToSort, 'tileName')}
           getAvailableCategories={() => catalogCategories}
+          // TODO(alecmerdler): Dynamic filters for each Operator and its provided APIs
           getAvailableFilters={getAvailableFilters}
           filterGroups={filterGroups}
           filterGroupNameMap={filterGroupNameMap}

--- a/frontend/public/components/catalog/catalog-page.jsx
+++ b/frontend/public/components/catalog/catalog-page.jsx
@@ -4,7 +4,7 @@ import * as PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 
 import { CatalogTileViewPage } from './catalog-items';
-import { serviceClassDisplayName } from '../../module/k8s';
+import { serviceClassDisplayName, referenceForModel } from '../../module/k8s';
 import { withStartGuide } from '../start-guide';
 import { FLAGS, connectToFlags, flagPending } from '../../features';
 import { Firehose, PageHeading, StatusBox } from '../utils';
@@ -19,6 +19,9 @@ import {
   getServiceClassIcon,
   getServiceClassImage,
 } from './catalog-item-icon';
+import { ClusterServiceVersionModel } from '../../models';
+import { providedAPIsFor, referenceForProvidedAPI } from '../operator-lifecycle-manager';
+import * as operatorLogo from '../../imgs/operator.svg';
 
 export class CatalogListPage extends React.Component {
   constructor(props) {
@@ -39,8 +42,10 @@ export class CatalogListPage extends React.Component {
   }
 
   getItems() {
-    const {clusterserviceclasses, imagestreams, loaded} = this.props;
-    let clusterServiceClassItems = [], imageStreamsItems = [];
+    const {clusterserviceclasses, imagestreams, clusterServiceVersions, loaded} = this.props;
+    let clusterServiceClassItems = [];
+    let imageStreamsItems = [];
+    let operatorProvidedAPIs = [];
 
     if (!loaded) {
       return [];
@@ -54,7 +59,32 @@ export class CatalogListPage extends React.Component {
       imageStreamsItems = this.normalizeImagestreams(imagestreams.data, 'ImageStream');
     }
 
-    return _.sortBy([...clusterServiceClassItems, ...imageStreamsItems], 'tileName');
+    if (clusterServiceVersions) {
+      const imgFor = (desc) => _.get(desc.csv, 'spec.icon')
+        ? `data:${_.get(desc.csv, 'spec.icon', [])[0].mediatype};base64,${_.get(desc.csv, 'spec.icon', [])[0].base64data}`
+        : operatorLogo;
+
+      operatorProvidedAPIs = _.flatten(clusterServiceVersions.data.map(csv => providedAPIsFor(csv).map(desc => ({...desc, csv}))))
+        .reduce((all, cur) => all.find(v => referenceForProvidedAPI(v) === referenceForProvidedAPI(cur)) ? all : all.concat([cur]), [])
+        .map((desc, i) => ({
+          // NOTE: Faking a real k8s object to avoid fetching all CRDs
+          obj: {metadata: {uid: 1000000 + i, creationTimestamp: desc.csv.metadata.creationTimestamp}, ...desc},
+          kind: referenceForProvidedAPI(desc),
+          tileName: desc.displayName,
+          tileIconClass: null,
+          tileImgUrl: imgFor(desc),
+          tileDescription: desc.description,
+          tileProvider: desc.csv.spec.provider.name,
+          tags: desc.csv.spec.keywords,
+          createLabel: `Create ${desc.displayName}`,
+          href: `/ns/${this.props.namespace || desc.csv.metadata.namespace}/clusterserviceversions/${desc.csv.metadata.name}/${referenceForProvidedAPI(desc)}/new`,
+          supportUrl: null,
+          longDescription: `This resource is provided by ${desc.csv.spec.displayName}, a Kubernetes Operator enabled by the Operator Lifecycle Manager.`,
+          documentationUrl: _.get((desc.csv.spec.links || []).find(({name}) => name === 'Documentation'), 'url'),
+        }));
+    }
+
+    return _.sortBy([...clusterServiceClassItems, ...imageStreamsItems, ...operatorProvidedAPIs], 'tileName');
   }
 
   normalizeClusterServiceClasses(serviceClasses, kind) {
@@ -72,6 +102,7 @@ export class CatalogListPage extends React.Component {
       const tileDescription = _.get(serviceClass, 'spec.description');
       const tileProvider = _.get(serviceClass, 'spec.externalMetadata.providerDisplayName');
       const tags = _.get(serviceClass, 'spec.tags');
+      const createLabel = 'Create Service Instance';
       const href = `/catalog/create-service-instance?cluster-service-class=${serviceClass.metadata.name}&preselected-ns=${namespace}`;
       const supportUrl = _.get(serviceClass, 'spec.externalMetadata.supportUrl');
       const longDescription = _.get(serviceClass, 'spec.externalMetadata.longDescription');
@@ -86,6 +117,7 @@ export class CatalogListPage extends React.Component {
         tileDescription,
         tileProvider,
         tags,
+        createLabel,
         href,
         supportUrl,
         longDescription,
@@ -108,6 +140,7 @@ export class CatalogListPage extends React.Component {
       const tileIconClass = tileImgUrl ? null : iconClass;
       const tileDescription = _.get(tag, 'annotations.description');
       const tags = getAnnotationTags(tag);
+      const createLabel = 'Create Application';
       const tileProvider = _.get(tag, 'annotations.openshift.io/provider-display-name');
       const { name, namespace } = imageStream.metadata;
       const href = `/catalog/source-to-image?imagestream=${name}&imagestream-ns=${namespace}&preselected-ns=${currentNamespace}`;
@@ -121,6 +154,7 @@ export class CatalogListPage extends React.Component {
         tileImgUrl,
         tileDescription,
         tags,
+        createLabel,
         tileProvider,
         href,
         sampleRepo,
@@ -147,29 +181,33 @@ CatalogListPage.propTypes = {
 
 // eventually may use namespace
 // eslint-disable-next-line no-unused-vars
-export const Catalog = connectToFlags(FLAGS.OPENSHIFT, FLAGS.SERVICE_CATALOG)(({flags, mock, namespace}) => {
+export const Catalog = connectToFlags(FLAGS.OPENSHIFT, FLAGS.SERVICE_CATALOG, FLAGS.OPERATOR_LIFECYCLE_MANAGER)(({flags, mock, namespace}) => {
 
   if (flagPending(flags.OPENSHIFT) || flagPending(flags.SERVICE_CATALOG)) {
     return null;
   }
 
-  const resources = [];
-  if (flags.SERVICE_CATALOG) {
-    resources.push({
+  const resources = [
+    ...(flags.SERVICE_CATALOG ? [{
       isList: true,
       kind: 'ClusterServiceClass',
       namespaced: false,
       prop: 'clusterserviceclasses',
-    });
-  }
-  if (flags.OPENSHIFT) {
-    resources.push({
+    }] : []),
+    ...(flags.OPENSHIFT ? [{
       isList: true,
       kind: 'ImageStream',
       namespace: 'openshift',
       prop: 'imagestreams',
-    });
-  }
+    }] : []),
+    ...(flags.OPERATOR_LIFECYCLE_MANAGER ? [{
+      isList: true,
+      kind: referenceForModel(ClusterServiceVersionModel),
+      namespaced: true,
+      prop: 'clusterServiceVersions',
+    }] : []),
+  ];
+
   return <Firehose resources={mock ? [] : resources} className="co-catalog-connect">
     <CatalogListPage namespace={namespace} />
   </Firehose>;

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -23,6 +23,7 @@ import {
   referenceForProvidedAPI,
   APIServiceDefinition,
   CSVConditionReason,
+  providedAPIsFor,
 } from './index';
 import {
   Kebab,
@@ -39,10 +40,6 @@ import {
   ScrollToTopOnMount,
 } from '../utils';
 import { operatorGroupFor, operatorNamespaceFor } from './operator-group';
-
-type ProvidedAPIsFor = (csv: ClusterServiceVersionKind) => (CRDDescription | APIServiceDefinition)[];
-const providedAPIsFor: ProvidedAPIsFor = csv => _.get(csv.spec, 'customresourcedefinitions.owned', [])
-  .concat(_.get(csv.spec, 'apiservicedefinitions.owned', []));
 
 export const ClusterServiceVersionHeader: React.SFC = () => <ListHeader>
   <ColHead className="col-lg-3 col-md-4 col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -230,6 +230,10 @@ export const visibilityLabel = 'olm-visibility';
 
 export const isEnabled = (namespace: K8sResourceKind) => _.has(namespace, ['metadata', 'annotations', 'alm-manager']);
 
+type ProvidedAPIsFor = (csv: ClusterServiceVersionKind) => (CRDDescription | APIServiceDefinition)[];
+export const providedAPIsFor: ProvidedAPIsFor = csv => _.get(csv.spec, 'customresourcedefinitions.owned', [])
+  .concat(_.get(csv.spec, 'apiservicedefinitions.owned', []));
+
 export const referenceForProvidedAPI = (desc: CRDDescription | APIServiceDefinition): GroupVersionKind => _.get(desc, 'group')
   ? `${(desc as APIServiceDefinition).group}~${desc.version}~${desc.kind}`
   : `${(desc as CRDDescription).name.slice(desc.name.indexOf('.') + 1)}~${desc.version}~${desc.kind}`;


### PR DESCRIPTION
### Description

Adds CRDs/APIServices which are provided by `ClusterServiceVersions` to the main "Catalog" view.

### Screenshots

**Catalog view (w/ CRDs from etcd Operator):**
![screenshot_20181218_181504](https://user-images.githubusercontent.com/11700385/50188852-007bd480-02f1-11e9-9819-f06978368121.png)

**Create modal:**
![screenshot_20181219_123845](https://user-images.githubusercontent.com/11700385/50237513-1ccc4f80-038b-11e9-8660-fd1e24eec5da.png)

### Next Steps
- Dynamically created filters for each Operator's APIs
- Search by `displayName`

Addresses https://jira.coreos.com/browse/CONSOLE-915