### PR TITLE
remove unnecesary passing of resources in Firehose

### DIFF
--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -164,6 +164,7 @@ export const Firehose = connect(
       const children = inject(this.props.children, _.omit(this.props, [
         'children',
         'className',
+        'resources',
       ]));
 
       return this.props.loaded || this.firehoses.length > 0


### PR DESCRIPTION
This was causing PropTypes warning, because Firehose resources (`Array`) is passed to the children and immediately overridden by ConnectToState which is passing `Object`