### PR TITLE
Add object-shorthand to linter

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -25,6 +25,5 @@
 ## JavaScript
 
 - Run the linter and follow all rules defined in .eslintrc
-- Prefer ES6 `const` over `let` or `var` when values do not change.
 - Never use absolute paths in code. The app should be able to run behind a proxy under an arbitrary path.
 - TESTS: Should follow a similar "test tables" convention as used in Go where applicable.

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -56,6 +56,7 @@
     "no-unused-vars": ["error", {"varsIgnorePattern": "React"}],
     "no-use-before-define": 2,
     "no-var": 2,
+    "object-shorthand": ["error", "properties"],
     "prefer-const": ["error", {"destructuring": "all"}],
     "prefer-template": 2,
     "quotes": [2, "single"],

--- a/frontend/__tests__/components/factory/list-page.spec.tsx
+++ b/frontend/__tests__/components/factory/list-page.spec.tsx
@@ -115,7 +115,7 @@ describe(ListPageWrapper_.displayName, () => {
         {id: 'loadbalancer', title: 'Load Balancers'},
       ],
     }];
-    wrapper.setProps({rowFilters: rowFilters});
+    wrapper.setProps({rowFilters});
     const checkboxes = wrapper.find(CheckBoxes) as any;
 
     expect(checkboxes.length).toEqual(rowFilters.length);

--- a/frontend/integration-tests/tests/secrets.scenario.ts
+++ b/frontend/integration-tests/tests/secrets.scenario.ts
@@ -214,8 +214,8 @@ describe('Interacting with the create secret forms', () => {
     const configFile = {
       auths:{
         'https://index.openshift.io/v1':{
-          username: username,
-          password: password,
+          username,
+          password,
           auth: secretsView.encode(username, password),
           email: 'test@secret.com',
         },

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -431,10 +431,10 @@ const BindingLoadingWrapper = props => {
   </StatusBox>;
 };
 
-export const EditRoleBinding = ({match: {params}, kind}) => <Firehose resources={[{kind: kind, name: params.name, namespace: params.ns, isList: false, prop: 'obj'}]}>
+export const EditRoleBinding = ({match: {params}, kind}) => <Firehose resources={[{kind, name: params.name, namespace: params.ns, isList: false, prop: 'obj'}]}>
   <BindingLoadingWrapper fixedKeys={['kind', 'metadata', 'roleRef']} subjectIndex={getSubjectIndex()} titleVerb="Edit" saveButtonText="Save" />
 </Firehose>;
 
-export const CopyRoleBinding = ({match: {params}, kind}) => <Firehose resources={[{kind: kind, name: params.name, namespace: params.ns, isList: false, prop: 'obj'}]}>
+export const CopyRoleBinding = ({match: {params}, kind}) => <Firehose resources={[{kind, name: params.name, namespace: params.ns, isList: false, prop: 'obj'}]}>
   <BindingLoadingWrapper isCreate={true} subjectIndex={getSubjectIndex()} titleVerb="Duplicate" />
 </Firehose>;

--- a/frontend/public/components/channel-operators/app-version.jsx
+++ b/frontend/public/components/channel-operators/app-version.jsx
@@ -141,7 +141,7 @@ const TectonicClusterAppVersion = ({tcAppVersion, secondaryAppVersions, tectonic
   const headerText = currentVersion === desiredVersion ? <span>{name} {currentVersion}</span> :
     <span className="co-cluster-updates__operator-subheader">{name} {currentVersion} &#10141; {desiredVersion || targetVersion}</span>;
 
-  const state = determineOperatorState(_.defaults({desiredVersion: desiredVersion}, tcAppVersion));
+  const state = determineOperatorState(_.defaults({desiredVersion}, tcAppVersion));
   const groupedTaskStatuses = groupTaskStatuses(tcAppVersion.taskStatuses);
 
   return <div className="row"><div className="co-cluster-updates__operator-component col-xs-12">
@@ -179,7 +179,7 @@ const SecondaryAppVersion = ({appVersion, tcAppVersion, tectonicVersions}) => {
     }
   }
 
-  const state = determineOperatorState(_.defaults({desiredVersion: desiredVersion}, appVersion));
+  const state = determineOperatorState(_.defaults({desiredVersion}, appVersion));
 
   return <div className="co-cluster-updates__operator-component">
     <div className="co-cluster-updates__operator-step">

--- a/frontend/public/components/channel-operators/detail-status.jsx
+++ b/frontend/public/components/channel-operators/detail-status.jsx
@@ -34,7 +34,7 @@ export class DetailStatus extends SafetyFirst {
       resource = { metadata: { namespace: 'tectonic-system', name: 'tectonic-cluster' } };
     }
 
-    const patch = [{ op: 'replace', path: `/${field}`, value: value }];
+    const patch = [{ op: 'replace', path: `/${field}`, value }];
     k8sPatch(k8skind, resource, patch)
       .catch((error) => {
         this.setState({

--- a/frontend/public/components/channel-operators/tectonic-channel.jsx
+++ b/frontend/public/components/channel-operators/tectonic-channel.jsx
@@ -85,7 +85,7 @@ export class TectonicChannel extends SafetyFirst {
         namespace: 'tectonic-system',
         isList: true,
         prop: 'pods',
-        selector: selector,
+        selector,
       },
 
     ];

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -119,7 +119,7 @@ export const EditYAML = connect(stateToProps)(
     componentWillReceiveProps(nextProps) {
       const newVersion = _.get(nextProps.obj, 'metadata.resourceVersion');
       const stale = this.displayedVersion !== newVersion;
-      this.setState({stale: stale });
+      this.setState({stale});
       if (nextProps.sampleObj) {
         this.loadYaml(!_.isEqual(this.state.sampleObj, nextProps.sampleObj), nextProps.sampleObj);
       } else {

--- a/frontend/public/components/modals/configure-ns-pull-secret-modal.jsx
+++ b/frontend/public/components/modals/configure-ns-pull-secret-modal.jsx
@@ -155,7 +155,7 @@ class ConfigureNamespacePullSecret extends PromiseComponent {
           name: event.target.elements['namespace-pull-secret-name'].value,
           namespace: namespace.metadata.name,
         },
-        data: data,
+        data,
         type: CONST.PULL_SECRET_TYPE,
       };
       promise = k8sCreate(SecretModel, secret);

--- a/frontend/public/components/modals/configure-operator-modal.jsx
+++ b/frontend/public/components/modals/configure-operator-modal.jsx
@@ -35,7 +35,7 @@ class ConfigureOperatorModal extends PromiseComponent {
       value = value === 'true';
     }
 
-    const patch = [{ op: 'replace', path: this.props.path, value: value }];
+    const patch = [{ op: 'replace', path: this.props.path, value }];
 
     this.handlePromise(
       k8sPatch(ChannelOperatorConfigModel, this.props.config, patch)

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/configure-size.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/configure-size.tsx
@@ -7,7 +7,7 @@ import { Descriptor } from '../types';
 export const configureSizeModal = ({kindObj, resource, specDescriptor, specValue}: ConfigureSizeModalProps) => {
   return configureCountModal({
     resourceKind: kindObj,
-    resource: resource,
+    resource,
     defaultValue: specValue || 0,
     title: `Modify ${specDescriptor.displayName}`,
     message: specDescriptor.description,

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -104,7 +104,7 @@ const withSecretForm = (SubForm) => class SecretFormComponent extends React.Comp
 
     this.state = {
       secretTypeAbstraction: this.props.secretTypeAbstraction,
-      secret: secret,
+      secret,
       inProgress: false,
       type: defaultSecretType,
       stringData: _.mapValues(_.get(props.obj, 'data'), (value) => {
@@ -250,7 +250,7 @@ class ImageSecretForm extends React.Component<ImageSecretFormProps, ImageSecretF
   }
   changeFormType(authType) {
     this.setState({
-      authType: authType,
+      authType,
     });
   }
   onFormDisable(disable) {
@@ -591,7 +591,7 @@ class SourceSecretForm extends React.Component<SourceSecretFormProps, SourceSecr
   }
   changeAuthenticationType(type: SecretType) {
     this.setState({
-      type: type,
+      type,
     }, () => this.props.onChange(this.state));
   }
   onDataChanged(secretsData) {
@@ -753,8 +753,8 @@ class GenericSecretForm extends React.Component<GenericSecretFormProps, GenericS
     return _.map(genericSecretObject, (value, key) => ({
       uid: _.uniqueId(),
       entry: {
-        key: key,
-        value: value,
+        key,
+        value,
       },
     }));
   }
@@ -903,7 +903,7 @@ export const CreateSecret = ({match: {params}}) => {
   />;
 };
 
-export const EditSecret = ({match: {params}, kind}) => <Firehose resources={[{kind: kind, name: params.name, namespace: params.ns, isList: false, prop: 'obj'}]}>
+export const EditSecret = ({match: {params}, kind}) => <Firehose resources={[{kind, name: params.name, namespace: params.ns, isList: false, prop: 'obj'}]}>
   <SecretLoadingWrapper fixedKeys={['kind', 'metadata']} titleVerb="Edit" saveButtonText="Save" />
 </Firehose>;
 

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -48,7 +48,7 @@ const KubeConfigify = (kind, sa) => ({
         'users': [{
           name,
           user: {
-            token: token,
+            token,
           },
         }],
       };

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -65,7 +65,7 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
   }
 
   onNamespaceChange = (namespace: string) => {
-    this.setState({namespace: namespace});
+    this.setState({namespace});
   }
 
   onNameChange: React.ReactEventHandler<HTMLInputElement> = event => {

--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -65,7 +65,7 @@ export const ResourceSidebar = props => {
   const {kind, label} = kindObj;
   const SidebarComponent = resourceSidebars.get(kind);
   if (SidebarComponent) {
-    return <ResourceSidebarWrapper label={label} style={{height: height}}>
+    return <ResourceSidebarWrapper label={label} style={{height}}>
       <SidebarComponent {...props} />
     </ResourceSidebarWrapper>;
   }

--- a/frontend/public/components/source-to-image.tsx
+++ b/frontend/public/components/source-to-image.tsx
@@ -269,7 +269,7 @@ class BuildSource extends React.Component<BuildSourceProps, BuildSourceState> {
           },
           spec: {
             containers: [{
-              name: name,
+              name,
               image: `${name}:latest`,
               ports,
               env: [],

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -493,7 +493,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
         this.resources = {
           data: data && data.toArray().map(p => p.toJSON()),
           loadError: this.props.k8s.getIn([StorageClassModel.plural, 'loadError']),
-          loaded: loaded,
+          loaded,
         };
 
         this.validateForm();
@@ -569,7 +569,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
         this.setState({loading: false});
         history.push('/k8s/cluster/storageclasses');
       })
-      .catch(error => this.setState({loading: false, error: error}));
+      .catch(error => this.setState({loading: false, error}));
   };
 
   getFormParams = () => {
@@ -885,8 +885,8 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
 }
 
 const mapStateToProps = ({k8s}, {onClose}) => ({
-  k8s: k8s,
-  onClose: onClose,
+  k8s,
+  onClose,
 });
 
 const mapDispatchToProps = () => ({

--- a/frontend/public/components/storage/attach-storage.tsx
+++ b/frontend/public/components/storage/attach-storage.tsx
@@ -95,7 +95,7 @@ class AttachStorageForm extends React.Component<
     const volumes = _.get(resourceObj, 'spec.template.spec.volumes');
     const volume = _.find(volumes, {
       persistentVolumeClaim: {
-        claimName: claimName,
+        claimName,
       },
     }) as any;
 

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -53,7 +53,7 @@ export class DropdownMixin extends React.PureComponent {
     }
 
     this.setState({
-      selectedKey: selectedKey,
+      selectedKey,
       title: noSelection ? title : this.props.items[selectedKey],
     });
 

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -54,7 +54,7 @@ export const navFactory: NavFactory = {
   editYaml: (component = editYamlComponent) => ({
     href: 'yaml',
     name: 'YAML',
-    component: component,
+    component,
   }),
   pods: component => ({
     href: 'pods',
@@ -99,7 +99,7 @@ export const navFactory: NavFactory = {
   machines: component => ({
     href: 'machines',
     name: 'Machines',
-    component: component,
+    component,
   }),
 };
 

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -22,7 +22,7 @@ const kebabFactory: KebabFactory = {
   Delete: (kind, obj) => ({
     label: `Delete ${kind.label}`,
     callback: () => deleteModal({
-      kind: kind,
+      kind,
       resource: obj,
     }),
   }),
@@ -33,21 +33,21 @@ const kebabFactory: KebabFactory = {
   ModifyLabels: (kind, obj) => ({
     label: 'Edit Labels',
     callback: () => labelsModal({
-      kind: kind,
+      kind,
       resource: obj,
     }),
   }),
   ModifyPodSelector: (kind, obj) => ({
     label: 'Edit Pod Selector',
     callback: () => podSelectorModal({
-      kind: kind,
+      kind,
       resource:  obj,
     }),
   }),
   ModifyAnnotations: (kind, obj) => ({
     label: 'Edit Annotations',
     callback: () => annotationsModal({
-      kind: kind,
+      kind,
       resource: obj,
     }),
   }),

--- a/frontend/public/components/utils/log-window.jsx
+++ b/frontend/public/components/utils/log-window.jsx
@@ -111,7 +111,7 @@ export class LogWindow extends React.PureComponent {
       </div>
       <div className="log-window__body">
         <div className="log-window__scroll-pane" ref={this._setScrollPane}>
-          <div className="log-window__contents" ref={this._setLogContents} style={{ height: height }}>
+          <div className="log-window__contents" ref={this._setLogContents} style={{ height }}>
             <div className="log-window__contents__text">
               {content}
             </div>

--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -109,7 +109,7 @@ export const NameKeyDropdownPair = ({name, key, configMaps, secrets, onChange, k
       items={itemKeys}
       selectedKey={key}
       title={keyTitle}
-      onChange={val => onChange({[refProperty]:{'name': name, 'key': val}})}
+      onChange={val => onChange({[refProperty]:{name, 'key': val}})}
     />}
   </React.Fragment>;
 };

--- a/frontend/public/module/analytics.js
+++ b/frontend/public/module/analytics.js
@@ -29,7 +29,7 @@ export const analyticsSvc = {
     analyticsSvc.push({
       event: 'tectonicRouteChange',
       attributes: {
-        route: route,
+        route,
       },
     });
   },

--- a/frontend/public/module/k8s/label-selector.js
+++ b/frontend/public/module/k8s/label-selector.js
@@ -56,9 +56,9 @@ export class LabelSelector {
 
   addConjunct(key, operator, values) {
     const conjunct = {
-      key: key,
-      operator: operator,
-      values: values,
+      key,
+      operator,
+      values,
     };
     const id = this._getIdForConjunct(conjunct);
     this._conjuncts[id] = conjunct;
@@ -150,8 +150,8 @@ export class LabelSelector {
   }
   findConjunctsMatching(operator, key) {
     return _.pickBy(this._conjuncts, _.matches({
-      operator: operator,
-      key: key,
+      operator,
+      key,
     }));
   }
   // Test whether this label selector covers the given selector

--- a/frontend/public/module/k8s/probe.js
+++ b/frontend/public/module/k8s/probe.js
@@ -48,7 +48,7 @@ const parsers = {
     }
     return {
       host: [scheme, '://', hostname].join(''),
-      path: path,
+      path,
       port: parseInt(port, 10) || port,
     };
   },

--- a/frontend/public/module/k8s/selector-requirement.js
+++ b/frontend/public/module/k8s/selector-requirement.js
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 const toArray = value => Array.isArray(value) ? value : [value];
 
 export const createEquals = (key, value) => ({
-  key:      key,
+  key,
   operator: 'Equals',
   values:   [value],
 });
@@ -53,9 +53,9 @@ export const requirementFromString = string => {
     const values = parts[1].slice(1, -1).split(',').map(_.trim);
 
     return {
-      key:      key,
+      key,
       operator: 'In',
-      values:   values,
+      values,
     };
   }
 
@@ -66,9 +66,9 @@ export const requirementFromString = string => {
     const values = parts[1].slice(1, -1).split(',').map(_.trim);
 
     return {
-      key:      key,
+      key,
       operator: 'NotIn',
-      values:   values,
+      values,
     };
   }
 
@@ -79,7 +79,7 @@ export const requirementFromString = string => {
     const value = parts[1];
 
     return {
-      key:      key,
+      key,
       operator: 'GreaterThan',
       values:   [value],
     };
@@ -92,7 +92,7 @@ export const requirementFromString = string => {
     const value = parts[1];
 
     return {
-      key:      key,
+      key,
       operator: 'LessThan',
       values:   [value],
     };

--- a/frontend/public/module/k8s/service-catalog.ts
+++ b/frontend/public/module/k8s/service-catalog.ts
@@ -14,7 +14,7 @@ export const planExternalName = (serviceInstance: K8sResourceKind): string =>
   _.get(serviceInstance, 'spec.clusterServicePlanExternalName') || _.get(serviceInstance, 'spec.servicePlanExternalName');
 
 const statusCondition = (obj: K8sResourceKind, type: string) => {
-  return _.find(_.get(obj, 'status.conditions'), {type: type});
+  return _.find(_.get(obj, 'status.conditions'), {type});
 };
 
 const isStatusReady = (obj: K8sResourceKind) => {


### PR DESCRIPTION
Require object literal shorthand syntax on properties. Fixed up the files that the linter complained about.