### PR TITLE
Improve Service Catalog UX with OLM

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
@@ -5,13 +5,13 @@ import { match as RouterMatch } from 'react-router-dom';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash-es';
 
-import { ClusterServiceVersionResourceList, ClusterServiceVersionResourceListProps, ProvidedAPIsPage, ProvidedAPIsPageProps, ClusterServiceVersionResourceHeaderProps, ClusterServiceVersionResourcesDetailsState, ClusterServiceVersionResourceRowProps, ClusterServiceVersionResourceHeader, ClusterServiceVersionResourceRow, ClusterServiceVersionResourceDetails, ClusterServiceVersionResourcesDetailsPageProps, ClusterServiceVersionResourcesDetailsProps, ClusterServiceVersionResourcesDetailsPage, ClusterServiceVersionResourceLink } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion-resource';
+import { ClusterServiceVersionResourceList, ClusterServiceVersionResourceListProps, ProvidedAPIsPage, ProvidedAPIsPageProps, ClusterServiceVersionResourceHeaderProps, ClusterServiceVersionResourcesDetailsState, ClusterServiceVersionResourceRowProps, ClusterServiceVersionResourceHeader, ClusterServiceVersionResourceRow, ClusterServiceVersionResourceDetails, ClusterServiceVersionResourcesDetailsPageProps, ClusterServiceVersionResourcesDetailsProps, ClusterServiceVersionResourcesDetailsPage, ClusterServiceVersionResourceLink, ProvidedAPIPage, ProvidedAPIPageProps } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion-resource';
 import { Resources } from '../../../public/components/operator-lifecycle-manager/k8s-resource';
 import { ClusterServiceVersionResourceKind, referenceForProvidedAPI } from '../../../public/components/operator-lifecycle-manager';
 import { StatusDescriptor } from '../../../public/components/operator-lifecycle-manager/descriptors/status';
 import { SpecDescriptor } from '../../../public/components/operator-lifecycle-manager/descriptors/spec';
-import { testCRD, testResourceInstance, testClusterServiceVersion, testOwnedResourceInstance } from '../../../__mocks__/k8sResourcesMocks';
-import { List, ColHead, ListHeader, DetailsPage, MultiListPage } from '../../../public/components/factory';
+import { testCRD, testResourceInstance, testClusterServiceVersion, testOwnedResourceInstance, testModel } from '../../../__mocks__/k8sResourcesMocks';
+import { List, ColHead, ListHeader, DetailsPage, MultiListPage, ListPage } from '../../../public/components/factory';
 import { Timestamp, LabelList, ResourceSummary, StatusBox, ResourceKebab, Kebab } from '../../../public/components/utils';
 import { referenceFor, K8sKind, referenceForModel } from '../../../public/module/k8s';
 import { ClusterServiceVersionModel } from '../../../public/models';
@@ -412,5 +412,17 @@ describe(ProvidedAPIsPage.displayName, () => {
     const data = flatten(resources);
 
     expect(data.length).toEqual(2);
+  });
+});
+
+describe(ProvidedAPIPage.displayName, () => {
+  let wrapper: ShallowWrapper<ProvidedAPIPageProps>;
+
+  it('does not allow creation if "create" not included in the verbs for the model', () => {
+    const readonlyModel = _.cloneDeep(testModel);
+    readonlyModel.verbs = ['get'];
+    wrapper = shallow(<ProvidedAPIPage.WrappedComponent kindObj={readonlyModel} kind={referenceForModel(readonlyModel)} csv={testClusterServiceVersion} />);
+
+    expect(wrapper.find(ListPage).props().canCreate).toBe(false);
   });
 });

--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -8,7 +8,7 @@ import * as _ from 'lodash-es';
 import { ClusterServiceVersionsDetailsPage, ClusterServiceVersionsDetailsPageProps, ClusterServiceVersionDetails, ClusterServiceVersionDetailsProps, ClusterServiceVersionsPage, ClusterServiceVersionsPageProps, ClusterServiceVersionList, ClusterServiceVersionHeader, ClusterServiceVersionRow, ClusterServiceVersionRowProps, CRDCard, CRDCardRow } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion';
 import { ClusterServiceVersionKind, ClusterServiceVersionLogo, ClusterServiceVersionLogoProps, referenceForProvidedAPI, CSVConditionReason } from '../../../public/components/operator-lifecycle-manager';
 import { DetailsPage, ListPage, ListHeader, ColHead, List, ListInnerProps } from '../../../public/components/factory';
-import { testClusterServiceVersion } from '../../../__mocks__/k8sResourcesMocks';
+import { testClusterServiceVersion, testModel } from '../../../__mocks__/k8sResourcesMocks';
 import { Timestamp, OverflowLink, MsgBox, ResourceLink, ResourceKebab, ErrorBoundary, LoadingBox, ScrollToTopOnMount, SectionHeading } from '../../../public/components/utils';
 import { referenceForModel } from '../../../public/module/k8s';
 import { ClusterServiceVersionModel } from '../../../public/models';
@@ -181,7 +181,7 @@ describe(CRDCard.displayName, () => {
   const crd = testClusterServiceVersion.spec.customresourcedefinitions.owned[0];
 
   it('renders a card with title, body, and footer', () => {
-    const wrapper = shallow(<CRDCard crd={crd} csv={testClusterServiceVersion} />);
+    const wrapper = shallow(<CRDCard.WrappedComponent crd={crd} csv={testClusterServiceVersion} kindObj={testModel} />);
 
     expect(wrapper.find('.co-crd-card__title').exists()).toBe(true);
     expect(wrapper.find('.co-crd-card__body').exists()).toBe(true);
@@ -189,9 +189,16 @@ describe(CRDCard.displayName, () => {
   });
 
   it('renders a link to create a new instance', () => {
-    const wrapper = shallow(<CRDCard crd={crd} csv={testClusterServiceVersion} />);
+    const kindObj = _.cloneDeep({...testModel, verbs: ['create']});
+    const wrapper = shallow(<CRDCard.WrappedComponent crd={crd} csv={testClusterServiceVersion} kindObj={kindObj} />);
 
     expect(wrapper.find('.co-crd-card__footer').find(Link).props().to).toEqual(`/k8s/ns/${testClusterServiceVersion.metadata.namespace}/${ClusterServiceVersionModel.plural}/${testClusterServiceVersion.metadata.name}/${referenceForProvidedAPI(crd)}/new`);
+  });
+
+  it('does not render link to create new instance if "create" not included in verbs for the model', () => {
+    const wrapper = shallow(<CRDCard.WrappedComponent crd={crd} csv={testClusterServiceVersion} kindObj={testModel} />);
+
+    expect(wrapper.find('.co-crd-card__footer').find(Link).exists()).toBe(false);
   });
 });
 

--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -43,7 +43,7 @@ describe('Kubernetes resource CRUD operations', () => {
     .set('imagestreams', {kind: 'ImageStream'})
     .set('routes', {kind: 'Route'});
   const serviceCatalogObjs = OrderedMap<string, {kind: string, namespaced?: boolean}>()
-    .set('clusterservicebrokers', {kind: 'ClusterServiceBroker', namespaced: false});
+    .set('clusterservicebrokers', {kind: 'servicecatalog.k8s.io~v1beta1~ClusterServiceBroker', namespaced: false});
   let testObjs = browser.params.openshift === 'true' ? k8sObjs.merge(openshiftObjs) : k8sObjs;
   testObjs = browser.params.servicecatalog === 'true' ? testObjs.merge(serviceCatalogObjs) : testObjs;
 

--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -40,8 +40,12 @@ export const filterForName = async(name: string) => {
   await textFilter.sendKeys(name);
 };
 
-export const editHumanizedKind = (kind) => {
-  const humanizedKind = kind.split(/(?=[A-Z])/).join(' ');
+export const editHumanizedKind = (kind: string) => {
+  const humanizedKind = (kind.includes('~')
+    ? kind.split('~')[2]
+    : kind
+  ).split(/(?=[A-Z])/).join(' ');
+
   return `Edit ${humanizedKind}`;
 };
 

--- a/frontend/public/components/cluster-service-broker.tsx
+++ b/frontend/public/components/cluster-service-broker.tsx
@@ -4,11 +4,11 @@ import * as React from 'react';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { Kebab, SectionHeading, detailsPage, navFactory, ResourceLink, ResourceKebab, ResourceSummary, StatusWithIcon, Timestamp } from './utils';
 // eslint-disable-next-line no-unused-vars
-import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
+import { K8sResourceKind, referenceForModel } from '../module/k8s';
+import { ClusterServiceBrokerModel } from '../models';
 import { Conditions } from './conditions';
 import { ClusterServiceClassPage } from './cluster-service-class';
 
-const ClusterServiceBrokerReference: K8sResourceKindReference = 'ClusterServiceBroker';
 const menuActions = Kebab.factory.common;
 
 const ClusterServiceBrokerHeader: React.SFC<ClusterServiceBrokerHeaderProps> = props => <ListHeader>
@@ -20,7 +20,7 @@ const ClusterServiceBrokerHeader: React.SFC<ClusterServiceBrokerHeaderProps> = p
 
 const ClusterServiceBrokerListRow: React.SFC<ClusterServiceBrokerRowProps> = ({obj: serviceBroker}) => <ResourceRow obj={serviceBroker}>
   <div className="col-sm-3 col-xs-6">
-    <ResourceLink kind="ClusterServiceBroker" name={serviceBroker.metadata.name} />
+    <ResourceLink kind={referenceForModel(ClusterServiceBrokerModel)} name={serviceBroker.metadata.name} />
   </div>
   <div className="col-sm-3 col-xs-6 co-break-word">
     <StatusWithIcon obj={serviceBroker} />
@@ -32,7 +32,7 @@ const ClusterServiceBrokerListRow: React.SFC<ClusterServiceBrokerRowProps> = ({o
     <Timestamp timestamp={serviceBroker.status.lastCatalogRetrievalTime} />
   </div>
   <div className="dropdown-kebab-pf">
-    <ResourceKebab actions={menuActions} kind="ClusterServiceBroker" resource={serviceBroker} />
+    <ResourceKebab actions={menuActions} kind={referenceForModel(ClusterServiceBrokerModel)} resource={serviceBroker} />
   </div>
 </ResourceRow>;
 
@@ -76,7 +76,7 @@ const ClusterServiceBrokerDetails: React.SFC<ClusterServiceBrokerDetailsProps> =
 const ServiceClassTabPage = ({obj}) => <ClusterServiceClassPage showTitle={false} fieldSelector={`spec.clusterServiceBrokerName=${obj.metadata.name}`} />;
 export const ClusterServiceBrokerDetailsPage: React.SFC<ClusterServiceBrokerDetailsPageProps> = props => <DetailsPage
   {...props}
-  kind={ClusterServiceBrokerReference}
+  kind={referenceForModel(ClusterServiceBrokerModel)}
   menuActions={menuActions}
   pages={[
     navFactory.details(detailsPage(ClusterServiceBrokerDetails)),
@@ -88,11 +88,11 @@ export const ClusterServiceBrokerList: React.SFC = props => <List {...props} Hea
 
 export const ClusterServiceBrokerPage: React.SFC<ClusterServiceBrokerPageProps> = props =>
   <ListPage
+    {...props}
     ListComponent={ClusterServiceBrokerList}
-    kind={ClusterServiceBrokerReference}
+    kind={referenceForModel(ClusterServiceBrokerModel)}
     canCreate={true}
     showTitle={false}
-    {...props}
   />;
 
 export type ClusterServiceBrokerRowProps = {

--- a/frontend/public/components/cluster-service-class.tsx
+++ b/frontend/public/components/cluster-service-class.tsx
@@ -7,14 +7,12 @@ import * as _ from 'lodash-es';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { history, SectionHeading, detailsPage, navFactory, ResourceSummary, resourcePathFromModel, ResourceLink } from './utils';
 import { viewYamlComponent } from './utils/horizontal-nav';
-import { ClusterServiceClassModel } from '../models';
+import { ClusterServiceClassModel, ClusterServiceBrokerModel } from '../models';
 // eslint-disable-next-line no-unused-vars
-import { K8sResourceKind, K8sResourceKindReference, serviceClassDisplayName } from '../module/k8s';
+import { K8sResourceKind, referenceForModel, serviceClassDisplayName } from '../module/k8s';
 import { ClusterServiceClassIcon } from './catalog/catalog-item-icon';
 import { ClusterServicePlanPage } from './cluster-service-plan';
 import { ClusterServiceClassInfo } from './cluster-service-class-info';
-
-const ClusterServiceClassReference: K8sResourceKindReference = 'ClusterServiceClass';
 
 const createInstance = (kindObj, serviceClass) => {
   if (!_.get(serviceClass, 'status.removedFromBrokerCatalog')) {
@@ -49,7 +47,7 @@ const ClusterServiceClassListRow: React.SFC<ClusterServiceClassRowProps> = ({obj
       {serviceClass.spec.externalName}
     </div>
     <div className="col-sm-3 hidden-xs co-break-word">
-      <ResourceLink kind="ClusterServiceBroker" name={serviceClass.spec.clusterServiceBrokerName} />
+      <ResourceLink kind={referenceForModel(ClusterServiceBrokerModel)} name={serviceClass.spec.clusterServiceBrokerName} />
     </div>
   </ResourceRow>;
 };
@@ -77,7 +75,7 @@ export const ClusterServiceClassDetailsPage: React.SFC<ClusterServiceClassDetail
   {...props}
   buttonActions={actionButtons}
   titleFunc={serviceClassDisplayName}
-  kind={ClusterServiceClassReference}
+  kind={referenceForModel(ClusterServiceClassModel)}
   pages={[navFactory.details(detailsPage(ClusterServiceClassDetails)),
     navFactory.editYaml(viewYamlComponent),
     navFactory.clusterServicePlans(({obj}) => <ClusterServicePlanPage showTitle={false}
@@ -88,13 +86,13 @@ export const ClusterServiceClassList: React.SFC = props => <List {...props} Head
 
 export const ClusterServiceClassPage: React.SFC<ClusterServiceClassPageProps> = props =>
   <ListPage
+    {...props}
     showTitle={false}
     ListComponent={ClusterServiceClassList}
-    kind={ClusterServiceClassReference}
+    kind={referenceForModel(ClusterServiceClassModel)}
     filterLabel="Service Classes by display name"
     textFilter="service-class"
     canCreate={false}
-    {...props}
   />;
 
 export type ClusterServiceClassRowProps = {

--- a/frontend/public/components/cluster-service-plan.tsx
+++ b/frontend/public/components/cluster-service-plan.tsx
@@ -5,10 +5,9 @@ import * as React from 'react';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { SectionHeading, detailsPage, navFactory, ResourceLink, ResourceSummary } from './utils';
 // eslint-disable-next-line no-unused-vars
-import { K8sResourceKind, K8sResourceKindReference, servicePlanDisplayName } from '../module/k8s';
+import { K8sResourceKind, referenceForModel, servicePlanDisplayName } from '../module/k8s';
+import { ClusterServicePlanModel, ClusterServiceBrokerModel, ClusterServiceClassModel } from '../models';
 import { viewYamlComponent } from './utils/horizontal-nav';
-
-const ClusterServicePlanReference: K8sResourceKindReference = 'ClusterServicePlan';
 
 const ClusterServicePlanHeader: React.SFC<ClusterServicePlanHeaderProps> = props => <ListHeader>
   <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
@@ -18,13 +17,13 @@ const ClusterServicePlanHeader: React.SFC<ClusterServicePlanHeaderProps> = props
 
 const ClusterServicePlanListRow: React.SFC<ClusterServicePlanRowProps> = ({obj: servicePlan}) => <ResourceRow obj={servicePlan}>
   <div className="col-sm-4 col-xs-6">
-    <ResourceLink kind="ClusterServicePlan" name={servicePlan.metadata.name} displayName={servicePlan.spec.externalName} />
+    <ResourceLink kind={referenceForModel(ClusterServicePlanModel)} name={servicePlan.metadata.name} displayName={servicePlan.spec.externalName} />
   </div>
   <div className="col-sm-4 col-xs-6">
     {servicePlan.spec.externalName}
   </div>
   <div className="col-sm-4 hidden-xs co-break-word">
-    <ResourceLink kind="ClusterServiceBroker" name={servicePlan.spec.clusterServiceBrokerName} title={servicePlan.spec.clusterServiceBrokerName} />
+    <ResourceLink kind={referenceForModel(ClusterServiceBrokerModel)} name={servicePlan.spec.clusterServiceBrokerName} title={servicePlan.spec.clusterServiceBrokerName} />
   </div>
 </ResourceRow>;
 
@@ -40,9 +39,9 @@ const ClusterServicePlanDetails: React.SFC<ClusterServicePlanDetailsProps> = ({o
           <dt>Description</dt>
           <dd>{servicePlan.spec.description}</dd>
           <dt>Broker</dt>
-          <dd><ResourceLink kind="ClusterServiceBroker" name={servicePlan.spec.clusterServiceBrokerName} /></dd>
+          <dd><ResourceLink kind={referenceForModel(ClusterServiceBrokerModel)} name={servicePlan.spec.clusterServiceBrokerName} /></dd>
           <dt>Service Class</dt>
-          <dd><ResourceLink kind="ClusterServiceClass" name={servicePlan.spec.clusterServiceClassRef.name} /></dd>
+          <dd><ResourceLink kind={referenceForModel(ClusterServiceClassModel)} name={servicePlan.spec.clusterServiceClassRef.name} /></dd>
           {servicePlan.status.removedFromBrokerCatalog && <React.Fragment>
             <dt>Removed From Catalog</dt>
             <dd>{servicePlan.status.removedFromBrokerCatalog}</dd>
@@ -56,7 +55,7 @@ const ClusterServicePlanDetails: React.SFC<ClusterServicePlanDetailsProps> = ({o
 export const ClusterServicePlanDetailsPage: React.SFC<ClusterServicePlanDetailsPageProps> = props => <DetailsPage
   {...props}
   titleFunc={servicePlanDisplayName}
-  kind={ClusterServicePlanReference}
+  kind={referenceForModel(ClusterServicePlanModel)}
   pages={[
     navFactory.details(detailsPage(ClusterServicePlanDetails)),
     navFactory.editYaml(viewYamlComponent),
@@ -66,10 +65,10 @@ export const ClusterServicePlanList: React.SFC = props => <List {...props} Heade
 
 export const ClusterServicePlanPage: React.SFC<ClusterServicePlanPageProps> = props =>
   <ListPage
-    ListComponent={ClusterServicePlanList}
-    kind={ClusterServicePlanReference}
-    canCreate={false}
     {...props}
+    ListComponent={ClusterServicePlanList}
+    kind={referenceForModel(ClusterServicePlanModel)}
+    canCreate={false}
   />;
 
 export type ClusterServicePlanRowProps = {

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -104,7 +104,7 @@ ResourceNSLink.propTypes = {
 
 class ResourceClusterLink extends NavLink {
   static isActive(props, resourcePath) {
-    return resourcePath === props.resource || _.startsWith(resourcePath, `${props.resource}/`);
+    return resourcePath === props.resource || _.startsWith(resourcePath, `${props.resource}/`) || matchesModel(resourcePath, props.model);
   }
 
   get to() {
@@ -116,6 +116,7 @@ ResourceClusterLink.propTypes = {
   name: PropTypes.string.isRequired,
   startsWith: PropTypes.arrayOf(PropTypes.string),
   resource: PropTypes.string.isRequired,
+  model: PropTypes.object,
 };
 
 class HrefLink extends NavLink {

--- a/frontend/public/components/service-binding.tsx
+++ b/frontend/public/components/service-binding.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { match } from 'react-router-dom';
 
 // eslint-disable-next-line no-unused-vars
-import { K8sResourceKindReference, serviceCatalogStatus } from '../module/k8s';
+import { serviceCatalogStatus, referenceForModel, K8sResourceKind } from '../module/k8s';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { Kebab, SectionHeading, navFactory, ResourceKebab, ResourceLink, ResourceSummary, StatusWithIcon } from './utils';
 import { ResourceEventStream } from './events';
@@ -11,8 +11,7 @@ import { Conditions } from './conditions';
 import { ServiceCatalogParameters, ServiceCatalogParametersSecrets } from './service-catalog-parameters';
 import { ServiceBindingDescription } from './service-instance';
 import { addSecretToWorkload } from './secret';
-
-const ServiceBindingsReference: K8sResourceKindReference = 'ServiceBinding';
+import { ServiceBindingModel, ServiceInstanceModel } from '../models';
 
 const actionButtons = [
   addSecretToWorkload,
@@ -44,7 +43,7 @@ const ServiceBindingDetails: React.SFC<ServiceBindingDetailsProps> = ({obj: sb})
         <div className="col-sm-6">
           <dl className="co-m-pane__details">
             <dt>Service Instance</dt>
-            <dd><ResourceLink kind="ServiceInstance" name={sb.spec.instanceRef.name} namespace={sb.metadata.namespace} /></dd>
+            <dd><ResourceLink kind={referenceForModel(ServiceInstanceModel)} name={sb.spec.instanceRef.name} namespace={sb.metadata.namespace} /></dd>
             <dt>Secret</dt>
             <dd>{ secretLink(sb) }</dd>
             <dt>Status</dt>
@@ -66,7 +65,7 @@ const pages = [navFactory.details(ServiceBindingDetails), navFactory.editYaml(),
 export const ServiceBindingDetailsPage: React.SFC<ServiceBindingDetailsPageProps> = props =>
   <DetailsPage
     {...props}
-    kind={ServiceBindingsReference}
+    kind={referenceForModel(ServiceBindingModel)}
     buttonActions={actionButtons}
     menuActions={menuActions}
     pages={pages} />;
@@ -82,13 +81,13 @@ const ServiceBindingsHeader = props => <ListHeader>
 
 const ServiceBindingsRow: React.SFC<ServiceBindingsRowProps> = ({obj}) => <div className="row co-resource-list__item">
   <div className="col-md-3 col-sm-4 col-xs-6">
-    <ResourceLink kind={ServiceBindingsReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
+    <ResourceLink kind={referenceForModel(ServiceBindingModel)} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
   </div>
   <div className="col-md-2 col-sm-4 col-xs-6 co-break-word">
     <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
   </div>
   <div className="col-md-2 col-sm-4 hidden-xs co-break-word">
-    <ResourceLink kind="ServiceInstance" name={obj.spec.instanceRef.name} title={obj.spec.instanceRef.name} namespace={obj.metadata.namespace} />
+    <ResourceLink kind={referenceForModel(ServiceInstanceModel)} name={obj.spec.instanceRef.name} title={obj.spec.instanceRef.name} namespace={obj.metadata.namespace} />
   </div>
   <div className="col-md-3 hidden-sm hidden-xs co-break-word">
     { secretLink(obj) }
@@ -97,7 +96,7 @@ const ServiceBindingsRow: React.SFC<ServiceBindingsRowProps> = ({obj}) => <div c
     <StatusWithIcon obj={obj} />
   </div>
   <div className="dropdown-kebab-pf">
-    <ResourceKebab actions={menuActions} kind={ServiceBindingsReference} resource={obj} />
+    <ResourceKebab actions={menuActions} kind={referenceForModel(ServiceBindingModel)} resource={obj} />
   </div>
 </div>;
 
@@ -109,19 +108,18 @@ export const ServiceBindingsPage: React.SFC<ServiceBindingsPageProps> = props =>
     {...props}
     namespace={_.get(props.match, 'params.ns')}
     showTitle={false}
-    kind={ServiceBindingsReference}
+    kind={referenceForModel(ServiceBindingModel)}
     ListComponent={ServiceBindingsList}
     filterLabel="Service Bindings by name"
   />;
-ServiceBindingsPage.displayName = 'ServiceBindingsListPage';
 
 /* eslint-disable no-undef */
 export type ServiceBindingsRowProps = {
-  obj: any,
+  obj: K8sResourceKind,
 };
 
 export type ServiceBindingDetailsProps = {
-  obj: any,
+  obj: K8sResourceKind,
 };
 
 export type ServiceBindingsPageProps = {
@@ -139,3 +137,5 @@ export type ServiceBindingDetailsPageProps = {
   match: any,
 };
 /* eslint-enable no-undef */
+
+ServiceBindingsPage.displayName = 'ServiceBindingsListPage';

--- a/frontend/public/components/service-catalog/create-binding.tsx
+++ b/frontend/public/components/service-catalog/create-binding.tsx
@@ -8,8 +8,8 @@ import { IChangeEvent, ISubmitEvent } from 'react-jsonschema-form';
 import { JSONSchema6 } from 'json-schema';
 
 import { LoadingBox } from '../utils/status-box';
-import { ServiceInstanceModel, ServiceBindingModel } from '../../models';
-import { k8sCreate, K8sResourceKind } from '../../module/k8s';
+import { ServiceInstanceModel, ServiceBindingModel, ClusterServicePlanModel } from '../../models';
+import { k8sCreate, K8sResourceKind, referenceForModel } from '../../module/k8s';
 import { ButtonBar } from '../utils/button-bar';
 import {
   createParametersSecret,
@@ -45,7 +45,7 @@ const BindingParameters: React.SFC<BindingParametersProps> = props => {
   }
 
   const resources = [
-    {kind: 'ClusterServicePlan', name: planName, prop: 'plan'},
+    {kind: referenceForModel(ClusterServicePlanModel), name: planName, prop: 'plan'},
   ];
   return <Firehose resources={resources}>
     <BindingParametersForm {...props as any} />
@@ -160,7 +160,7 @@ class CreateBindingForm extends React.Component<CreateBindingProps, CreateBindin
 
 export const CreateBindingPage: React.SFC<CreateBindingPageProps> = (props) => {
   const resources = [
-    {kind: 'ServiceInstance', name: props.match.params.name, namespace: props.match.params.ns, isList: false, prop: 'obj'},
+    {kind: referenceForModel(ServiceInstanceModel), name: props.match.params.name, namespace: props.match.params.ns, isList: false, prop: 'obj'},
   ];
   return <Firehose resources={resources}>
     <CreateBindingForm {...props as any} />

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -6,12 +6,13 @@ import { Helmet } from 'react-helmet';
 import { IChangeEvent, ISubmitEvent } from 'react-jsonschema-form';
 
 import { LoadingBox } from '../utils/status-box';
-import { ServiceInstanceModel } from '../../models';
+import { ServiceInstanceModel, ClusterServiceClassModel, ClusterServicePlanModel } from '../../models';
 import { ClusterServiceClassInfo } from '../cluster-service-class-info';
 import { ButtonBar } from '../utils/button-bar';
 import {
   k8sCreate,
   K8sResourceKind,
+  referenceForModel,
 } from '../../module/k8s';
 import {
   createParametersSecret,
@@ -192,8 +193,8 @@ export const CreateInstancePage = (props) => {
   const name = searchParams.get('cluster-service-class');
   const preselectedNamespace = searchParams.get('preselected-ns');
   const resources = [
-    {kind: 'ClusterServiceClass', name, isList: false, prop: 'obj'},
-    {kind: 'ClusterServicePlan', isList: true, prop: 'plans', fieldSelector: `spec.clusterServiceClassRef.name=${name}`},
+    {kind: referenceForModel(ClusterServiceClassModel), name, isList: false, prop: 'obj'},
+    {kind: referenceForModel(ClusterServicePlanModel), isList: true, prop: 'plans', fieldSelector: `spec.clusterServiceClassRef.name=${name}`},
   ];
   return <Firehose resources={resources}>
     <CreateInstance preselectedNamespace={preselectedNamespace} {...props as any} />

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -3,16 +3,14 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link, withRouter, RouteComponentProps, match } from 'react-router-dom';
 
-import { k8sList, K8sResourceKind, K8sResourceKindReference, planExternalName, serviceCatalogStatus } from '../module/k8s';
+import { k8sList, K8sResourceKind, planExternalName, serviceCatalogStatus, referenceForModel } from '../module/k8s';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { Kebab, history, navFactory, ResourceKebab, ResourceIcon, ResourceLink, ResourceSummary, SectionHeading, StatusWithIcon, Timestamp } from './utils';
 import { ResourceEventStream } from './events';
 import { Conditions } from './conditions';
 import { ServiceCatalogParameters, ServiceCatalogParametersSecrets } from './service-catalog-parameters';
 import { ServiceBindingsPage } from './service-binding';
-import { ServiceBindingModel } from '../models';
-
-const ServiceInstancesReference: K8sResourceKindReference = 'ServiceInstance';
+import { ServiceBindingModel, ServiceInstanceModel, ClusterServiceClassModel } from '../models';
 
 const goToCreateBindingPage = (serviceInstance: K8sResourceKind) => {
   history.push(`/k8s/ns/${serviceInstance.metadata.namespace}/serviceinstances/${serviceInstance.metadata.name}/create-binding`);
@@ -33,7 +31,7 @@ const menuActions = [
 ];
 
 export const ServiceBindingDescription: React.SFC<ServiceBindingDescriptionProps> = ({instanceName, className}) => <p className={className}>
-  Service bindings create a secret containing the necessary information for a workload to use <ResourceIcon kind="ServiceInstance" />{instanceName}.
+  Service bindings create a secret containing the necessary information for a workload to use <ResourceIcon kind={referenceForModel(ServiceInstanceModel)} />{instanceName}.
   Once the binding is ready, add the secret to your workload&apos;s environment variables or volumes.
 </p>;
 
@@ -113,7 +111,7 @@ const ServiceInstanceDetails: React.SFC<ServiceInstanceDetailsProps> = ({obj: si
             <dt>Service Class</dt>
             <dd>
               {clusterServiceClassName
-                ? <ResourceLink kind="ClusterServiceClass" displayName={classDisplayName} title={classDisplayName} name={clusterServiceClassName} />
+                ? <ResourceLink kind={referenceForModel(ClusterServiceClassModel)} displayName={classDisplayName} title={classDisplayName} name={clusterServiceClassName} />
                 : classDisplayName}
             </dd>
             <dt>Status</dt>
@@ -149,7 +147,7 @@ const pages = [
 export const ServiceInstanceDetailsPage: React.SFC<ServiceInstanceDetailsPageProps> = props =>
   <DetailsPage
     {...props}
-    kind={ServiceInstancesReference}
+    kind={referenceForModel(ServiceInstanceModel)}
     menuActions={menuActions}
     pages={pages} />;
 ServiceInstanceDetailsPage.displayName = 'ServiceInstanceDetailsPage';
@@ -168,14 +166,14 @@ const ServiceInstancesRow: React.SFC<ServiceInstancesRowProps> = ({obj}) => {
 
   return <div className="row co-resource-list__item">
     <div className="col-md-2 col-sm-4 col-xs-6">
-      <ResourceLink kind={ServiceInstancesReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
+      <ResourceLink kind={referenceForModel(ServiceInstanceModel)} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
     </div>
     <div className="col-md-2 col-sm-3 col-xs-6 co-break-word">
       <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
     </div>
     <div className="col-md-2 col-sm-3 hidden-xs co-break-word">
       {clusterServiceClassRefName
-        ? <ResourceLink kind="ClusterServiceClass" displayName={obj.spec.clusterServiceClassExternalName} title={obj.spec.clusterServiceClassExternalName} name={obj.spec.clusterServiceClassRef.name} />
+        ? <ResourceLink kind={referenceForModel(ClusterServiceClassModel)} displayName={obj.spec.clusterServiceClassExternalName} title={obj.spec.clusterServiceClassExternalName} name={obj.spec.clusterServiceClassRef.name} />
         : obj.spec.clusterServiceClassExternalName }
     </div>
     <div className="col-md-2 col-sm-2 hidden-xs">
@@ -188,7 +186,7 @@ const ServiceInstancesRow: React.SFC<ServiceInstancesRowProps> = ({obj}) => {
       <Timestamp timestamp={obj.metadata.creationTimestamp} />
     </div>
     <div className="dropdown-kebab-pf">
-      <ResourceKebab actions={menuActions} kind={ServiceInstancesReference} resource={obj} />
+      <ResourceKebab actions={menuActions} kind={referenceForModel(ServiceInstanceModel)} resource={obj} />
     </div>
   </div>;
 };
@@ -211,7 +209,7 @@ export const ServiceInstancesPage: React.SFC<ServiceInstancesPageProps> = props 
   <ListPage
     {...props}
     namespace={_.get(props.match, 'params.ns')}
-    kind={ServiceInstancesReference}
+    kind={referenceForModel(ServiceInstanceModel)}
     ListComponent={ServiceInstancesList}
     filterLabel="Service Instances by name"
     rowFilters={filters}

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -732,6 +732,7 @@ export const ClusterServiceBrokerModel: K8sKind = {
   namespaced: false,
   kind: 'ClusterServiceBroker',
   id: 'clusterservicebroker',
+  crd: true,
 };
 
 export const ClusterServiceClassModel: K8sKind = {
@@ -745,6 +746,7 @@ export const ClusterServiceClassModel: K8sKind = {
   namespaced: false,
   kind: 'ClusterServiceClass',
   id: 'clusterserviceclass',
+  crd: true,
 };
 
 export const ClusterServicePlanModel: K8sKind = {
@@ -758,6 +760,7 @@ export const ClusterServicePlanModel: K8sKind = {
   namespaced: false,
   kind: 'ClusterServicePlan',
   id: 'clusterserviceplan',
+  crd: true,
 };
 
 export const ServiceInstanceModel: K8sKind = {
@@ -771,6 +774,7 @@ export const ServiceInstanceModel: K8sKind = {
   namespaced: true,
   kind: 'ServiceInstance',
   id: 'serviceinstance',
+  crd: true,
 };
 
 export const ServiceBindingModel: K8sKind = {
@@ -784,6 +788,7 @@ export const ServiceBindingModel: K8sKind = {
   namespaced: true,
   kind: 'ServiceBinding',
   id: 'servicebinding',
+  crd: true,
 };
 
 export const LimitRangeModel: K8sKind = {


### PR DESCRIPTION
### Description

Fixes some bugs when using the OLM UI to interact with Service Catalog. Updates references to Service Catalog models to use `GroupVersionKind`. Uses `verbs` from API discovery to determine if resources can be created and show "Create" button accordingly. 

### Screenshots

**`ClusterServiceVersion` detail view:**
![screenshot_20181219_150738](https://user-images.githubusercontent.com/11700385/50245212-e220e200-039f-11e9-9fd0-84ebc0b7ddf0.png)

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1659894
Fixes https://jira.coreos.com/browse/CONSOLE-1164