### PR TITLE
Bug 1661099 - Fix fullscreen terminal

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -232,6 +232,11 @@ tags-input .autocomplete .suggestion-item em {
     background-size: cover;
   }
 
+  &__main {
+    // `z-index: auto` is required for fullscreen terminal
+    --pf-l-page__main--ZIndex: auto;
+  }
+
   // `.pf-l-page` specificity required
   .pf-l-page__main-section {
     --pf-l-page__main-section--Padding: 0;


### PR DESCRIPTION
The explicit `z-index: 100` on the main content prevented the fullscreen terminal from sitting on top of the nav/masthead. I couldn't find any bad effects using `auto` instead.

https://bugzilla.redhat.com/show_bug.cgi?id=1661099

/cc @alecmerdler 