### PR TITLE
Update patternfly-next to v1.0.109, About Modal updates

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,8 +53,8 @@
     ]
   },
   "dependencies": {
-    "@patternfly/patternfly-next": "^1.0.101",
-    "@patternfly/react-core": "^1.40.0",
+    "@patternfly/patternfly-next": "^1.0.109",
+    "@patternfly/react-core": "^1.43.5",
     "brace": "0.11.x",
     "classnames": "2.x",
     "core-js": "2.x",

--- a/frontend/public/components/_about-modal.scss
+++ b/frontend/public/components/_about-modal.scss
@@ -6,9 +6,4 @@
   p {
     color: var(--pf-global--Color--dark-200);
   }
-  // hide trademark and logo-image as they are not optional, but should be
-  .pf-c-about-modal-box__header-strapline,
-  .pf-c-about-modal-box__logo-image {
-    display:none;
-  }
 }

--- a/frontend/public/components/about-modal.jsx
+++ b/frontend/public/components/about-modal.jsx
@@ -32,7 +32,6 @@ export class AboutModal extends React.Component {
         isOpen={isOpen}
         onClose={closeAboutModal}
         productName={details.productTitle}
-        trademark=""
         brandImageSrc={details.logoImg}
         brandImageAlt={details.logoAlt}
         logoImageSrc={details.logoImg}

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -3,7 +3,7 @@ body,
 #app,
 #content,
 #content-scrollable,
-.pf-l-page__main-section {
+.pf-c-page__main-section {
   height: 100%; // so .co-p-has-sidebar, .yaml-editor are full height
 }
 
@@ -19,7 +19,7 @@ body,
   -webkit-overflow-scrolling: touch;
 }
 
-.pf-l-page__main-section {
+.pf-c-page__main-section {
   --pf-global--FontSize--md: #{$font-size-base};
 }
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -228,7 +228,7 @@ tags-input .autocomplete .suggestion-item em {
   list-style: none;
 }
 
-.pf-l-page {
+.pf-c-page {
   &__header {
     background-color: var(--pf-global--BackgroundColor--dark-200);
     background-image: url("../imgs/pfbg_2000.jpg");
@@ -238,27 +238,27 @@ tags-input .autocomplete .suggestion-item em {
 
   &__main {
     // `z-index: auto` is required for fullscreen terminal
-    --pf-l-page__main--ZIndex: auto;
+    --pf-c-page__main--ZIndex: auto;
   }
 
-  // `.pf-l-page` specificity required
-  .pf-l-page__main-section {
-    --pf-l-page__main-section--Padding: 0;
+  // `.pf-c-page` specificity required
+  .pf-c-page__main-section {
+    --pf-c-page__main-section--Padding: 0;
 
     @media screen and (min-width: $grid-float-breakpoint) {
-      --pf-l-page__main-section--Padding: 0;
+      --pf-c-page__main-section--Padding: 0;
     }
   }
 }
 
-.pf-l-page__sidebar {
-  --pf-l-page__sidebar--BackgroundColor: #{$color-pf-black-900};
-  --pf-l-page__sidebar--PaddingBottom: 0;
-  --pf-l-page__sidebar--PaddingTop: 0;
+.pf-c-page__sidebar {
+  --pf-c-page__sidebar--BackgroundColor: #{$color-pf-black-900};
+  --pf-c-page__sidebar--PaddingBottom: 0;
+  --pf-c-page__sidebar--PaddingTop: 0;
   position: relative; // fix z-index bug in Edge
 
   @media screen and (min-width: $grid-float-breakpoint) {
-    --pf-l-page__sidebar--BoxShadow: none;
+    --pf-c-page__sidebar--BoxShadow: none;
   }
 
   .pf-c-nav {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -86,24 +86,25 @@
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
 
-"@patternfly/patternfly-next@^1.0.101":
-  version "1.0.101"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.101.tgz#1017ca79437811d48540f0a5ab0afb997db4f074"
+"@patternfly/patternfly-next@^1.0.109":
+  version "1.0.109"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.109.tgz#5c1a8ca29ca48d030324d3d588af9954e2f36cea"
 
-"@patternfly/react-core@^1.40.0":
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-1.40.0.tgz#1fbbd395ba41e7bd0adc48ec62309adbca1eb30e"
+"@patternfly/react-core@^1.43.5":
+  version "1.43.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-1.43.5.tgz#b66e8915785aecde621663b1c719cf965d9d5bd4"
   dependencies:
-    "@patternfly/react-icons" "^2.9.3"
+    "@patternfly/react-icons" "^2.9.5"
     "@patternfly/react-styles" "^2.3.0"
+    "@tippy.js/react" "^1.1.1"
     exenv "^1.2.2"
     focus-trap-react "^4.0.1"
   optionalDependencies:
     "@patternfly/react-tokens" "^1.0.0"
 
-"@patternfly/react-icons@^2.9.3":
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-2.9.3.tgz#39f29c4084daeb681ceaea6ad530baae83dd62e2"
+"@patternfly/react-icons@^2.9.5":
+  version "2.9.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-2.9.5.tgz#abccb6b151f965cb1370a1e0210bc650e202ce97"
 
 "@patternfly/react-styles@^2.3.0":
   version "2.3.0"
@@ -137,6 +138,13 @@
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+
+"@tippy.js/react@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@tippy.js/react/-/react-1.1.1.tgz#91476726529e31d4c9f9074d995d0fa31f3b6e2d"
+  dependencies:
+    prop-types "^15.6.2"
+    tippy.js "^3.2.0"
 
 "@types/c3@^0.6.0":
   version "0.6.2"
@@ -9080,6 +9088,10 @@ popper.js@^1.14.1:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.4.tgz#8eec1d8ff02a5a3a152dd43414a15c7b79fd69b6"
 
+popper.js@^1.14.6:
+  version "1.14.6"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.6.tgz#ab20dd4edf9288b8b3b6531c47c361107b60b4b0"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -11690,6 +11702,12 @@ tiny-sdf@^1.0.2:
 tinycolor2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
+
+tippy.js@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-3.3.0.tgz#90d4f90be9c80fdc0d0025f49378e3d9f60508d3"
+  dependencies:
+    popper.js "^1.14.6"
 
 tmp@0.0.30:
   version "0.0.30"


### PR DESCRIPTION
To incorporate changes upstream in the About Modal.  `trademark` no longer required in `<PfAboutModal />`.  Updated `_overrides.scss`. 

![image](https://user-images.githubusercontent.com/12733153/50309304-588b1600-046c-11e9-9aa8-8831e6db1802.png)

Related PRs:
https://github.com/openshift/console/pull/936#discussion_r241780200
