### PR TITLE
Monitoring: State icon style fixes

### DIFF
--- a/frontend/public/components/_monitoring.scss
+++ b/frontend/public/components/_monitoring.scss
@@ -47,3 +47,7 @@ $monitoring-line-height: 18px;
 .btn--silence-add-more {
   padding: 0;
 }
+
+.monitoring-state-icon--pending {
+  color: $color-pf-black-700;
+}

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -120,9 +120,9 @@ const AlertState: React.SFC<AlertStateProps> = ({state}) => {
     return <span className="text-muted">Not Firing</span>;
   }
   const klass = {
-    [AlertStates.Firing]: 'fa fa-bell alert-firing',
-    [AlertStates.Silenced]: 'fa fa-bell-slash text-muted',
-    [AlertStates.Pending]: 'fa fa-bell-o alert-pending',
+    [AlertStates.Firing]: 'fa fa-fw fa-bell alert-firing',
+    [AlertStates.Silenced]: 'fa fa-fw fa-bell-slash text-muted',
+    [AlertStates.Pending]: 'fa fa-fw fa-bell-o alert-pending',
   }[state];
   return klass ? <React.Fragment><i className={klass} aria-hidden="true"></i> {_.startCase(state)}</React.Fragment> : null;
 };
@@ -130,9 +130,9 @@ const AlertState: React.SFC<AlertStateProps> = ({state}) => {
 const SilenceState = ({silence}) => {
   const state = silenceState(silence);
   const klass = {
-    [SilenceStates.Active]: 'pficon pficon-ok',
-    [SilenceStates.Pending]: 'fa fa-hourglass-half',
-    [SilenceStates.Expired]: 'fa fa-ban text-muted',
+    [SilenceStates.Active]: 'pficon pficon-ok fa-fw',
+    [SilenceStates.Pending]: 'fa fa-fw fa-hourglass-half monitoring-state-icon--pending',
+    [SilenceStates.Expired]: 'fa fa-fw fa-ban text-muted',
   }[state];
   return klass ? <React.Fragment><i className={klass} aria-hidden="true"></i> {_.startCase(state)}</React.Fragment> : null;
 };


### PR DESCRIPTION
The state icons have different widths, so set a consistent width so that
the state text is aligned.

Also revert the pending Silence state icon color to as it was before PR
#870 merged.

FYI @cshinn 

| Alerts | Silences |
| --- | --- |
| ![alerts](https://user-images.githubusercontent.com/460802/50332818-32f91d80-04fb-11e9-955c-0ae2b6219882.png) | ![silences](https://user-images.githubusercontent.com/460802/50332823-3b515880-04fb-11e9-8c62-9bdb9909d412.png) |