### PR TITLE
Monitoring: Use correct text for rule link

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -227,7 +227,7 @@ const AlertsDetailsPage = withFallback(connect(alertStateToProps)((props: Alerts
                 <dd>
                   <div className="co-resource-link">
                     <MonitoringResourceIcon resource={AlertRuleResource} />
-                    <Link to={ruleURL(rule)} className="co-resource-link__resource-name">{alertname}</Link>
+                    <Link to={ruleURL(rule)} className="co-resource-link__resource-name">{_.get(rule, 'name')}</Link>
                   </div>
                 </dd>
               </dl>


### PR DESCRIPTION
Actually `alertname` and `rule.name` are the same text here, but we want
the rule name, so using `rule.name` is correct.