### PR TITLE
Fix bug where list style isn't turned off in `.pf-c-dropdown__menu`

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -224,6 +224,10 @@ tags-input .autocomplete .suggestion-item em {
 
 // PatternFly 4 overrides
 
+.pf-c-dropdown__menu {
+  list-style: none;
+}
+
 .pf-l-page {
   &__header {
     background-color: var(--pf-global--BackgroundColor--dark-200);


### PR DESCRIPTION
Before:
![screen shot 2019-01-04 at 11 48 07 am](https://user-images.githubusercontent.com/895728/50699788-d9bedd00-1016-11e9-9a88-5788dc5bd21b.png)

After:
![screen shot 2019-01-04 at 11 48 37 am](https://user-images.githubusercontent.com/895728/50699794-ddeafa80-1016-11e9-9036-9d1342062c59.png)

The bug occurs because `.pf-c-dropdown__menu` relies on PatternFly 4's disabling of list-style for all lists, and we don't include that in the console because of the backward compatibility issues it causes.