### PR TITLE
Only show project status toolbar for valid projects

### DIFF
--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -330,7 +330,7 @@ const OverviewHeading_: React.SFC<OverviewHeadingProps> = ({disabled, firstLabel
         <div className="co-m-pane__name co-m-pane__name--overview">{title}</div>
       </h1>
     }
-    <div className={classnames('overview-view-selector', {'selected-view__resources': selectedView === View.Resources })}>
+    {!_.isEmpty(project) && <div className={classnames('overview-view-selector', {'selected-view__resources': selectedView === View.Resources })}>
       <div className="form-group btn-group">
         <button
           type="button"
@@ -362,7 +362,6 @@ const OverviewHeading_: React.SFC<OverviewHeadingProps> = ({disabled, firstLabel
               <Dropdown
                 className="overview-toolbar__dropdown"
                 menuClassName="dropdown-menu--text-wrap"
-                disabled={disabled}
                 items={groupOptions}
                 onChange={handleGroupChange}
                 titlePrefix="Group by"
@@ -376,7 +375,6 @@ const OverviewHeading_: React.SFC<OverviewHeadingProps> = ({disabled, firstLabel
                 <TextFilter
                   autoFocus={!disabled}
                   defaultValue={''}
-                  disabled={disabled}
                   label="by name"
                   onChange={handleFilterChange}
                 />
@@ -388,7 +386,7 @@ const OverviewHeading_: React.SFC<OverviewHeadingProps> = ({disabled, firstLabel
           </div>}
         </Toolbar.RightContent>
       </Toolbar>
-    </div>
+    </div>}
   </div>
 );
 


### PR DESCRIPTION
Toolbar options don't make sense if the project isn't valid because there is no project data.

Before: 
![screen shot 2019-01-04 at 1 59 11 pm](https://user-images.githubusercontent.com/895728/50705477-f9f79780-1028-11e9-91b5-832709e4f306.png)

After:
![screen shot 2019-01-04 at 1 59 23 pm](https://user-images.githubusercontent.com/895728/50705490-febc4b80-1028-11e9-9dd1-f121b11ea626.png)
