### PR TITLE
[WIP] Add form to configure HTPasswd IDP

### DIFF
--- a/frontend/public/components/_global-notification.scss
+++ b/frontend/public/components/_global-notification.scss
@@ -11,7 +11,7 @@ $global-notification-text: $color-pf-white;
     padding: 6px $grid-gutter-width;
   }
 
-  a {
+  a, .btn-link {
     color: $global-notification-text;
     cursor: pointer;
     text-decoration: underline;

--- a/frontend/public/components/kube-admin-notifier.jsx
+++ b/frontend/public/components/kube-admin-notifier.jsx
@@ -4,6 +4,12 @@ import { connect } from 'react-redux';
 
 import { userStateToProps } from '../ui/ui-reducers';
 import { KUBE_ADMIN_USERNAME } from '../const';
+import { addIDPModal } from './modals';
+
+const addIDP = (e) => {
+  e.preventDefault();
+  addIDPModal({});
+};
 
 export const KubeAdminNotifier = connect(userStateToProps)(({user}) => {
   const username = _.get(user, 'metadata.name');
@@ -11,7 +17,9 @@ export const KubeAdminNotifier = connect(userStateToProps)(({user}) => {
     ? <div className="co-global-notification">
       <div className="co-global-notification__content">
         <p className="co-global-notification__text">
-          You are logged in as a temporary administrative user. Set up an identity provider to allow others to log in.
+          You are logged in as a temporary administrative user.
+          Add an identity provider to allow others to log in.
+          <button className="btn btn-link" type="button" onClick={addIDP}>Add Identity Provider</button>
         </p>
       </div>
     </div>

--- a/frontend/public/components/modals/add-idp-modal.tsx
+++ b/frontend/public/components/modals/add-idp-modal.tsx
@@ -1,0 +1,125 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
+import { AsyncComponent, ExternalLink, helpLink, HELP_TOPICS, history, PromiseComponent, resourceObjPath } from '../utils';
+import { OAuthModel, SecretModel } from '../../models';
+import { k8sCreate, k8sGet, k8sPatch, K8sResourceKind, referenceFor } from '../../module/k8s';
+
+// The name of the cluster-scoped OAuth configuration resource.
+const oauthResourceName = 'cluster';
+
+const DroppableFileInput = (props) => <AsyncComponent loader={() => import('../utils/file-input').then(c => c.DroppableFileInput)} {...props} />;
+
+class AddIDPModal extends PromiseComponent {
+  readonly state: AddIDPModalState = {
+    htpasswdFileContent: '',
+    inProgress: false,
+    errorMessage: '',
+  }
+
+  getOAuthResource(): Promise<K8sResourceKind> {
+    return this.handlePromise(k8sGet(OAuthModel, oauthResourceName));
+  }
+
+  createHTPasswdSecret(): Promise<K8sResourceKind> {
+    const secret = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        generateName: 'htpasswd-',
+        namespace: 'openshift-config',
+      },
+      stringData: {
+        htpasswd: this.state.htpasswdFileContent,
+      },
+    };
+
+    return this.handlePromise(k8sCreate(SecretModel, secret));
+  }
+
+  addHTPasswdIDP(oauth: K8sResourceKind, secretName: string): Promise<K8sResourceKind> {
+    const htpasswd = {
+      name: 'htpasswd',
+      type: 'HTPasswd',
+      challenge: true,
+      login: true,
+      htpasswd: {
+        fileData: {
+          name: secretName,
+        },
+      },
+    };
+
+    const patch = _.isEmpty(oauth.spec.identityProviders)
+      ? { op: 'add', path: '/spec/identityProviders', value: [htpasswd] }
+      : { op: 'add', path: '/spec/identityProviders/-', value: htpasswd };
+    return this.handlePromise(k8sPatch(OAuthModel, oauth, [patch]));
+  }
+
+  submit = (e) => {
+    e.preventDefault();
+    if (!this.state.htpasswdFileContent) {
+      this.setState({errorMessage: 'You must specify an HTPasswd file.'});
+      return;
+    }
+
+    // Clear any previous errors.
+    this.setState({errorMessage: ''});
+    this.getOAuthResource().then((oauth: K8sResourceKind) => {
+      return this.createHTPasswdSecret()
+        .then((secret: K8sResourceKind) => this.addHTPasswdIDP(oauth, secret.metadata.name))
+        .then(() => {
+          this.props.close();
+          history.push(resourceObjPath(oauth, referenceFor(oauth)));
+        });
+    });
+  }
+
+  cancel = () => {
+    this.props.close();
+  }
+
+  htpasswdFileChanged = (htpasswdFileContent: string) => {
+    this.setState({htpasswdFileContent});
+  }
+
+  render() {
+    const { htpasswdFileContent } = this.state;
+    return <form onSubmit={this.submit} name="form">
+      <ModalTitle>Add Identity Provider</ModalTitle>
+      <ModalBody>
+        <p>
+          Identity providers determine how users log into the cluster.
+          &nbsp;
+          <ExternalLink href={helpLink(HELP_TOPICS.CONFIGURING_AUTHENTICATION)} text="Learn More" />
+        </p>
+        <div className="form-group">
+          <label>Type</label>
+          <p className="form-control-static">HTPasswd</p>
+        </div>
+        <div className="form-group">
+          <DroppableFileInput
+            onChange={this.htpasswdFileChanged}
+            inputFileData={htpasswdFileContent}
+            id="htpasswd-file"
+            label="HTPasswd File"
+            inputFieldHelpText="Upload an HTPasswd file created using the htpasswd command. This is a flat file that contains each user's username and encrypted password."
+            isRequired
+            hideContents />
+        </div>
+      </ModalBody>
+      <ModalSubmitFooter errorMessage={this.state.errorMessage} inProgress={this.state.inProgress} submitText="Add" cancel={this.cancel} />
+    </form>;
+  }
+}
+
+export const addIDPModal = createModalLauncher(AddIDPModal);
+
+type AddIDPModalState = {
+  htpasswdFileContent: string;
+  inProgress: boolean;
+  errorMessage: string;
+};

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -57,3 +57,6 @@ export const deleteModal = (props) => import('./delete-modal' /* webpackChunkNam
 
 export const clusterUpdateModal = (props) => import('./cluster-update-modal' /* webpackChunkName: "cluster-update-modal" */)
   .then(m => m.clusterUpdateModal(props));
+
+export const addIDPModal = (props) => import('./add-idp-modal' /* webpackChunkName: "add-idp-modal" */)
+  .then(m => m.addIDPModal(props));

--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -8,14 +8,16 @@ export const openshiftHelpBase = (window as any).SERVER_FLAGS.documentationBaseU
 
 /* global
   HELP_TOPICS: false,
+  COMPUTE_RESOURCES_QUOTA: false,
+  CONFIGURING_AUTHENTICATION: false,
   GET_STARTED_CLI: false,
   NETWORK_POLICY_GUIDE: false,
-  COMPUTE_RESOURCES_QUOTA: false,
  */
 export enum HELP_TOPICS {
+  COMPUTE_RESOURCES_QUOTA = 'dev_guide/compute_resources.html#dev-compute-resources',
+  CONFIGURING_AUTHENTICATION = 'install_config/configuring_authentication.html',
   GET_STARTED_CLI = 'cli_reference/get_started_cli.html',
   NETWORK_POLICY_GUIDE = 'admin_guide/managing_networking.html#admin-guide-networking-networkpolicy',
-  COMPUTE_RESOURCES_QUOTA = 'dev_guide/compute_resources.html#dev-compute-resources',
 }
 
 export const helpLink = (topic: HELP_TOPICS) => `${openshiftHelpBase}${topic}`;

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -1,7 +1,8 @@
+/* eslint-disable no-undef, no-unused-vars */
+
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { NativeTypes } from 'react-dnd-html5-backend';
-// eslint-disable-next-line no-unused-vars
 import { DropTarget, ConnectDropTarget, DropTargetMonitor } from 'react-dnd';
 import withDragDropContext from './drag-drop-context';
 
@@ -41,7 +42,7 @@ export class FileInput extends React.Component<FileInputProps, FileInputState> {
     this.readFile(event.target.files[0]);
   }
   render() {
-    const { connectDropTarget, isOver, canDrop, id, isRequired } = this.props;
+    const { connectDropTarget, errorMessage, hideContents, isOver, canDrop, id, isRequired } = this.props;
     const klass = classNames('co-file-dropzone-container', {'co-file-dropzone--drop-over': isOver});
     return (
       connectDropTarget(
@@ -66,14 +67,14 @@ export class FileInput extends React.Component<FileInputProps, FileInputState> {
                 </span>
               </div>
               <p className="help-block" id={`${id}-help`}>{this.props.inputFieldHelpText}</p>
-              <textarea className="form-control co-file-dropzone__textarea"
+              {!hideContents && <textarea className="form-control co-file-dropzone__textarea"
                 onChange={this.onDataChange}
                 value={this.props.inputFileData}
                 aria-describedby={`${id}-textarea-help`}
                 required={isRequired}>
-              </textarea>
+              </textarea>}
               <p className="help-block" id={`${id}-textarea-help`}>{this.props.textareaFieldHelpText}</p>
-              { this.props.errorMessage && <div className="text-danger">{this.props.errorMessage}</div> }
+              { errorMessage && <div className="text-danger">{errorMessage}</div> }
             </div>
           </div>
         </div>
@@ -148,38 +149,42 @@ export const DroppableFileInput = withDragDropContext(class DroppableFileInput e
       inputFileName={this.state.inputFileName} />;
   }
 });
-/* eslint-disable no-undef */
+
 export type DroppableFileInputProps = {
-  inputFileData: string,
-  onChange: Function,
-  label: string,
-  id: string,
-  inputFieldHelpText: string,
-  textareaFieldHelpText: string,
-  isRequired: boolean,
+  inputFileData: string;
+  onChange: Function;
+  label: string;
+  id: string;
+  inputFieldHelpText: string;
+  textareaFieldHelpText: string;
+  isRequired: boolean;
+  hideContents?: boolean;
 };
+
 export type DroppableFileInputState = {
-  inputFileData: string,
-  inputFileName: string,
-  errorMessage?: any,
+  inputFileData: string;
+  inputFileName: string;
+  errorMessage?: any;
 };
+
 export type FileInputState = {
-  inputFileData: string,
-  inputFileName: string,
+  inputFileData: string;
+  inputFileName: string;
 };
+
 export type FileInputProps = {
-  errorMessage: string,
-  connectDropTarget?: ConnectDropTarget,
-  isOver?: boolean,
-  canDrop?: boolean,
-  onDrop: (props: FileInputProps, monitor: DropTargetMonitor) => void,
-  inputFileData: string,
-  inputFileName: string,
-  onChange: Function,
-  label: string,
-  id: string,
-  inputFieldHelpText: string,
-  textareaFieldHelpText: string,
-  isRequired: boolean,
+  errorMessage: string;
+  connectDropTarget?: ConnectDropTarget;
+  isOver?: boolean;
+  canDrop?: boolean;
+  onDrop: (props: FileInputProps, monitor: DropTargetMonitor) => void;
+  inputFileData: string;
+  inputFileName: string;
+  onChange: Function;
+  label: string;
+  id: string;
+  inputFieldHelpText: string;
+  textareaFieldHelpText: string;
+  isRequired: boolean;
+  hideContents?: boolean;
 };
-/* eslint-enable no-undef */

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -884,3 +884,17 @@ export const ClusterAutoscalerModel: K8sKind = {
   id: 'clusterautoscaler',
   crd: true,
 };
+
+export const OAuthModel: K8sKind = {
+  label: 'OAuth',
+  labelPlural: 'OAuths',
+  apiVersion: 'v1',
+  path: 'oauths',
+  apiGroup: 'config.openshift.io',
+  plural: 'oauths',
+  abbr: 'OA',
+  namespaced: false,
+  kind: 'OAuth',
+  id: 'oauth',
+  crd: true,
+};


### PR DESCRIPTION
This lets the admin add an HTPasswd IDP with other types to follow. It requires backend changes to work that are not yet in place.

We can switch this to a full page form at some point, but I wanted to get something simple working.

![projects openshift 2019-01-04 13-58-55](https://user-images.githubusercontent.com/1167259/50705465-ee0bd580-1028-11e9-9851-d99e7252e7cc.png)

![secrets openshift 2019-01-04 14-08-13](https://user-images.githubusercontent.com/1167259/50705884-2fe94b80-102a-11e9-8d63-940f7bf99d2c.png)

cc @enj @alimobrem @openshift/team-ux-review 

Closes #916