### PR TITLE
Make environment delete button accessible

### DIFF
--- a/frontend/public/components/utils/_name-value-editor.scss
+++ b/frontend/public/components/utils/_name-value-editor.scss
@@ -1,5 +1,11 @@
 .co-empty__header {
-  width: auto;
+  padding: 0;
+  width: 28px;
+}
+
+.pairs-list__action {
+  padding: 0;
+  width: 28px;
 }
 
 .pairs-list__row {
@@ -43,11 +49,11 @@
 
 .pairs-list__side-btn {
   cursor: pointer;
-  padding-right: 8px;
 }
 
 .pairs-list__action-icon {
-  padding-right: 0;
+  color: $color-pf-black-900;
+  margin-left: 8px;
   width: auto;
 }
 
@@ -65,5 +71,7 @@
 }
 
 .pairs-list__span-btns {
+  color: $color-pf-black-900;
+  margin-left: -8px;
   white-space: pre;
 }

--- a/frontend/public/components/utils/_name-value-editor.scss
+++ b/frontend/public/components/utils/_name-value-editor.scss
@@ -1,11 +1,14 @@
+$drag-column-width: 28px;
+$drag-row-margin: 8px;
+
 .co-empty__header {
   padding: 0;
-  width: 28px;
+  width: $drag-column-width;
 }
 
 .pairs-list__action {
   padding: 0;
-  width: 28px;
+  width: $drag-column-width;
 }
 
 .pairs-list__row {
@@ -53,7 +56,7 @@
 
 .pairs-list__action-icon {
   color: $color-pf-black-900;
-  margin-left: 8px;
+  margin-left: $drag-row-margin;
   width: auto;
 }
 
@@ -72,6 +75,6 @@
 
 .pairs-list__span-btns {
   color: $color-pf-black-900;
-  margin-left: -8px;
+  margin-left: -$drag-row-margin;
   white-space: pre;
 }

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -67,8 +67,8 @@ export const NameValueEditor = withDragDropContext(class NameValueEditor extends
     return <React.Fragment>
       <div className="row">
         {!readOnly && allowSorting && <div className="col-xs-1 co-empty__header"></div>}
-        <div className="col-xs-5 text-secondary text-uppercase co-full__header">{nameString}</div>
-        <div className="col-xs-5 text-secondary text-uppercase co-full__header">{valueString}</div>
+        <div className="col-xs-5 text-secondary text-uppercase">{nameString}</div>
+        <div className="col-xs-5 text-secondary text-uppercase">{valueString}</div>
         <div className="col-xs-1 co-empty__header"></div>
       </div>
       {pairElems}
@@ -180,8 +180,8 @@ export const EnvFromEditor = withDragDropContext(class EnvFromEditor extends Rea
     return <React.Fragment>
       <div className="row">
         {!readOnly && <div className="col-xs-1 co-empty__header"></div>}
-        <div className="col-xs-5 text-secondary text-uppercase co-full__header">Config Map/Secret</div>
-        <div className="col-xs-5 text-secondary text-uppercase co-full__header">Prefix (Optional)</div>
+        <div className="col-xs-5 text-secondary text-uppercase">Config Map/Secret</div>
+        <div className="col-xs-5 text-secondary text-uppercase">Prefix (Optional)</div>
         <div className="col-xs-1 co-empty__header"></div>
       </div>
       {pairElems}

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -67,8 +67,8 @@ export const NameValueEditor = withDragDropContext(class NameValueEditor extends
     return <React.Fragment>
       <div className="row">
         {!readOnly && allowSorting && <div className="col-xs-1 co-empty__header"></div>}
-        <div className="col-xs-5 text-secondary text-uppercase">{nameString}</div>
-        <div className="col-xs-5 text-secondary text-uppercase">{valueString}</div>
+        <div className="col-xs-5 text-secondary text-uppercase co-full__header">{nameString}</div>
+        <div className="col-xs-5 text-secondary text-uppercase co-full__header">{valueString}</div>
         <div className="col-xs-1 co-empty__header"></div>
       </div>
       {pairElems}
@@ -180,8 +180,8 @@ export const EnvFromEditor = withDragDropContext(class EnvFromEditor extends Rea
     return <React.Fragment>
       <div className="row">
         {!readOnly && <div className="col-xs-1 co-empty__header"></div>}
-        <div className="col-xs-5 text-secondary text-uppercase">Config Map/Secret</div>
-        <div className="col-xs-5 text-secondary text-uppercase">Prefix (Optional)</div>
+        <div className="col-xs-5 text-secondary text-uppercase co-full__header">Config Map/Secret</div>
+        <div className="col-xs-5 text-secondary text-uppercase co-full__header">Prefix (Optional)</div>
         <div className="col-xs-1 co-empty__header"></div>
       </div>
       {pairElems}
@@ -310,14 +310,16 @@ const PairElement = DragSource(DRAGGABLE_TYPE.ENV_ROW, pairSource, collectSource
 
   render() {
     const {isDragging, connectDragSource, connectDragPreview, connectDropTarget, nameString, valueString, allowSorting, readOnly, pair, configMaps, secrets} = this.props;
-    const deleteButton = <React.Fragment><i className="fa fa-minus-circle pairs-list__side-btn pairs-list__delete-icon" aria-hidden="true" onClick={this._onRemove}></i><span className="sr-only">Delete</span></React.Fragment>;
+    const deleteButton = <React.Fragment><i className="fa fa-minus-circle pairs-list__side-btn pairs-list__delete-icon" aria-hidden="true"></i><span className="sr-only">Delete</span></React.Fragment>;
 
     return connectDropTarget(
       connectDragPreview(
         <div className={classNames('row', isDragging ? 'pairs-list__row-dragging' : 'pairs-list__row')} ref={node => this.node = node}>
           {allowSorting && !readOnly &&
-            <div className="col-xs-1 pairs-list__action-icon">
-              {connectDragSource(<i className="pficon pficon-drag-drop pairs-list__action-icon--reorder" />)}
+            <div className="col-xs-1 pairs-list__action">
+              {connectDragSource(<button type="button" className="btn btn-link pairs-list__action-icon" tabIndex="-1">
+                <i className="pficon pficon-drag-drop pairs-list__action-icon--reorder" />
+              </button>)}
             </div>
           }
           <div className="col-xs-5 pairs-list__name-field">
@@ -336,9 +338,9 @@ const PairElement = DragSource(DRAGGABLE_TYPE.ENV_ROW, pairSource, collectSource
           {
             !readOnly &&
               <div className="col-xs-1">
-                <span className={classNames(allowSorting ? 'pairs-list__span-btns' : null)}>
+                <button type="button" className={classNames('btn', 'btn-link', {'pairs-list__span-btns': allowSorting})} onClick={this._onRemove}>
                   {deleteButton}
-                </span>
+                </button>
               </div>
           }
         </div>)
@@ -392,14 +394,16 @@ const EnvFromPairElement = DragSource(DRAGGABLE_TYPE.ENV_FROM_ROW, pairSource, c
 
   render() {
     const {isDragging, connectDragSource, connectDragPreview, connectDropTarget, valueString, readOnly, pair, configMaps, secrets} = this.props;
-    const deleteButton = <React.Fragment><i className="fa fa-minus-circle pairs-list__side-btn pairs-list__delete-icon" aria-hidden="true" onClick={this._onRemove}></i><span className="sr-only">Delete</span></React.Fragment>;
+    const deleteButton = <React.Fragment><i className="fa fa-minus-circle pairs-list__side-btn pairs-list__delete-icon" aria-hidden="true"></i><span className="sr-only">Delete</span></React.Fragment>;
 
     return connectDropTarget(
       connectDragPreview(
         <div className={classNames('row', isDragging ? 'pairs-list__row-dragging' : 'pairs-list__row')} ref={node => this.node = node}>
           { !readOnly &&
-            <div className="col-xs-1 pairs-list__action-icon">
-              {connectDragSource(<i className="pficon pficon-drag-drop pairs-list__action-icon--reorder" />)}
+            <div className="col-xs-1 pairs-list__action">
+              {connectDragSource(<button type="button" className="btn btn-link pairs-list__action-icon" tabIndex="-1">
+                <i className="pficon pficon-drag-drop pairs-list__action-icon--reorder" />
+              </button>)}
             </div>
           }
           <div className="col-xs-5 pairs-list__value-pair-field">
@@ -411,9 +415,9 @@ const EnvFromPairElement = DragSource(DRAGGABLE_TYPE.ENV_FROM_ROW, pairSource, c
           {
             readOnly ? null :
               <div className="col-xs-1">
-                <span className="pairs-list__span-btns">
+                <button type="button" className="btn btn-link pairs-list__span-btns" onClick={this._onRemove}>
                   {deleteButton}
-                </span>
+                </button>
               </div>
           }
         </div>)


### PR DESCRIPTION
Made the environment delete button into a real button so it's in the tab flow and can be triggered by hitting return on the keyboard. Made the drag and drop button into a button as well so the styling would be consistent, but it's not in the tab flow since you can't drag and drop with the keyboard. (Let me know if you want it in the tab flow.)

Both now have a blue hover/focus state and blue focus ring since they're buttons.

Tabbing in action:
![env-accessibility](https://user-images.githubusercontent.com/7014965/50712294-f40cb100-103e-11e9-9476-ab5a8379ca41.gif)

I had to make some changes to the padding, etc. since the switch from spans to buttons threw them off.

Fixes [CONSOLE-1079](https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-1079).

@openshift/team-ux-review, could you please review? Let me know if you want the drag and drop button in the tab flow even though you can't use it with the keyboard.