### PR TITLE
Changes for project status toolbar

### DIFF
--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -1,27 +1,20 @@
 .co-m-nav-title--overview {
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
   justify-content: space-between;
-
-  @media (max-width: $screen-sm-max) {
-    &.overview-filter-group {
-      flex-direction: column;
-    }
-  }
-
-  // Keep the flex child elements in a column, when <1200 && when the sidebar is open,
-  // so that the stacked filter group fields are displayed beneath the <h1>
-  @media (max-width: $screen-md-max) {
-    .overview--sidebar-shown & {
-      flex-direction: column;
-    }
-  }
 }
 
 .overview-toolbar {
   margin: 0 0 ($grid-gutter-width / 2) 0;
   min-width: 0;
   padding: 0;
+  @media (max-width: $screen-xs-max) {
+    // Stack toggle buttons above resource filter options at mobile
+    .selected-view__resources & {
+      width: 100%;
+    }
+  }
 
   .toolbar-pf-actions {
     margin: 0;
@@ -79,11 +72,6 @@
 .overview-toolbar__form-group {
   flex: 1 1 auto;
   min-width: 0; // enable truncation
-  padding-right: 8px;
-
-  @media (max-width: $screen-sm-max) {
-    flex: 1 1 50%;
-  }
 
   @media (min-width: $screen-xs-min) {
     padding-right: 15px;
@@ -93,6 +81,7 @@
     border-right: 0;
     margin-bottom: 0;
     padding-left: 0;
+    padding-right: 10px;
 
     @media (max-width: $screen-md-max) {
       .overview--sidebar-shown & {
@@ -102,17 +91,14 @@
 
     @media (min-width: $screen-lg-min) and (max-width: ($screen-lg-min + 200)) {
       .overview--sidebar-shown & {
-        max-width: 250px; // prevents long group by select from pushing filter input behind sidebar
+        max-width: 200px; // prevents group by select from pushing filter input behind the sidebar
       }
     }
   }
 
   + .overview-toolbar__form-group {
     border-left: 1px solid $color-pf-black-300;
-    padding-left: 8px;
-    @media (min-width: $screen-xs-min) {
-      padding-left: 15px;
-    }
+    padding-left: 10px;
 
     .overview--sidebar-shown & {
       @media (max-width: $screen-md-max) {
@@ -155,9 +141,6 @@
   .overview--sidebar-shown & {
     width: auto;
   }
-  @media (min-width: $screen-md-min) {
-    width: 250px;
-  }
 }
 
 .overview {
@@ -179,8 +162,9 @@
   .overview__sidebar {
     background: #fff;
     bottom: 0;
-    box-shadow: var(--pf-global--BoxShadow--lg-left);
+    box-shadow: var(--pf-global--BoxShadow--md);
     display: none;
+    padding-bottom: 30px;
     position: absolute;
     right: 0;
     top: 0;
@@ -260,6 +244,27 @@
 
   .co-actions-menu {
     margin-top: -3px;
+  }
+}
+
+.overview-view-selector {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+
+  @media (max-width: $screen-md-max) {
+    .overview--sidebar-shown & {
+      flex-direction: column;
+    }
+  }
+
+  .btn-group {
+    button+button {
+      margin-left: 0;
+    }
+    i.fa {
+      margin-right: 6px;
+    }
   }
 }
 

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -328,65 +328,67 @@ const OverviewHeading_: React.SFC<OverviewHeadingProps> = ({disabled, firstLabel
       title &&
       <h1 className="co-m-pane__heading co-m-pane__heading--overview">
         <div className="co-m-pane__name co-m-pane__name--overview">{title}</div>
-        <div className="toolbar-pf">
-          <div className="form-group toolbar-pf-view-selector overview-view-selector">
-            <button
-              type="button"
-              className={classnames('btn btn-link', { active: selectedView === View.Resources })}
-              aria-label="Resources"
-              title="Resources"
-              disabled={disabled}
-              onClick={() => selectView(View.Resources)}
-            >
-              <i className="fa fa-list-ul" aria-hidden="true" />
-            </button>
-            <button
-              type="button"
-              className={classnames('btn btn-link', { active: selectedView === View.Dashboard })}
-              aria-label="Dashboard"
-              title="Dashboard"
-              disabled={disabled}
-              onClick={() => selectView(View.Dashboard)}
-            >
-              <i className="fa fa-dashboard" aria-hidden="true" />
-            </button>
-          </div>
-        </div>
       </h1>
     }
-    <Toolbar className="overview-toolbar">
-      <Toolbar.RightContent>
-        {selectedView === View.Resources && <React.Fragment>
-          <div className="form-group overview-toolbar__form-group">
-            <Dropdown
-              className="overview-toolbar__dropdown"
-              menuClassName="dropdown-menu--text-wrap"
-              disabled={disabled}
-              items={groupOptions}
-              onChange={handleGroupChange}
-              titlePrefix="Group by"
-              title={groupOptions[selectedGroup]}
-              spacerBefore={new Set([firstLabel])}
-              headerBefore={{[firstLabel]: 'Label'}}
-            />
-          </div>
-          <div className="form-group overview-toolbar__form-group">
-            <div className="overview-toolbar__text-filter">
-              <TextFilter
-                autoFocus={!disabled}
-                defaultValue={''}
+    <div className={classnames('overview-view-selector', {'selected-view__resources': selectedView === View.Resources })}>
+      <div className="form-group btn-group">
+        <button
+          type="button"
+          className={classnames('btn btn-default', { 'btn-primary': selectedView === View.Resources })}
+          aria-label="Resources"
+          title="Resources"
+          disabled={disabled}
+          onClick={() => selectView(View.Resources)}
+        >
+          <i className="fa fa-list-ul" aria-hidden="true" />
+          Resources
+        </button>
+        <button
+          type="button"
+          className={classnames('btn btn-default', { 'btn-primary': selectedView === View.Dashboard })}
+          aria-label="Dashboard"
+          title="Dashboard"
+          disabled={disabled}
+          onClick={() => selectView(View.Dashboard)}
+        >
+          <i className="fa fa-dashboard" aria-hidden="true" />
+          Dashboard
+        </button>
+      </div>
+      <Toolbar className="overview-toolbar">
+        <Toolbar.RightContent>
+          {selectedView === View.Resources && <React.Fragment>
+            <div className="form-group overview-toolbar__form-group">
+              <Dropdown
+                className="overview-toolbar__dropdown"
+                menuClassName="dropdown-menu--text-wrap"
                 disabled={disabled}
-                label="Resources by name"
-                onChange={handleFilterChange}
+                items={groupOptions}
+                onChange={handleGroupChange}
+                titlePrefix="Group by"
+                title={groupOptions[selectedGroup]}
+                spacerBefore={new Set([firstLabel])}
+                headerBefore={{[firstLabel]: 'Label'}}
               />
             </div>
-          </div>
-        </React.Fragment>}
-        {selectedView === View.Dashboard && !_.isEmpty(project) && <div className="form-group">
-          <ActionsMenu actions={overviewMenuActions.map((a: KebabAction) => a(ProjectModel, project))} />
-        </div>}
-      </Toolbar.RightContent>
-    </Toolbar>
+            <div className="form-group overview-toolbar__form-group">
+              <div className="overview-toolbar__text-filter">
+                <TextFilter
+                  autoFocus={!disabled}
+                  defaultValue={''}
+                  disabled={disabled}
+                  label="by name"
+                  onChange={handleFilterChange}
+                />
+              </div>
+            </div>
+          </React.Fragment>}
+          {selectedView === View.Dashboard && !_.isEmpty(project) && <div className="form-group">
+            <ActionsMenu actions={overviewMenuActions.map((a: KebabAction) => a(ProjectModel, project))} />
+          </div>}
+        </Toolbar.RightContent>
+      </Toolbar>
+    </div>
   </div>
 );
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -173,10 +173,6 @@ tags-input .autocomplete .suggestion-item em {
   box-shadow: none;
   min-width: 0; // enable text-overflow: ellipsis
   padding-top: 0;
-
-  .overview-view-selector {
-    padding: 0 0 0 15px;
-  }
 }
 
 @media (max-width: $screen-md-max) {


### PR DESCRIPTION
- make toggle icons into buttons w/ icons
- move toggle buttons and filter options to own row beneath title
- switch sidebar boxshadow to md from lg-left for sharper edge contrast
- add bottom padding for increase space between sidebar panel bottom and text

design doc https://redhat.invisionapp.com/share/7UPKM9TME8A#/screens/337462744

![status-page-1300](https://user-images.githubusercontent.com/1874151/50712504-c8d69180-103f-11e9-9b38-433f8275d68f.png)
![status-page-1300-sidebar](https://user-images.githubusercontent.com/1874151/50712503-c8d69180-103f-11e9-9921-61cfa10ba6f1.png)
---
![status-page-850](https://user-images.githubusercontent.com/1874151/50712505-c8d69180-103f-11e9-8dc7-a5494ec20e2b.png)
![status-page-1150-sidebar](https://user-images.githubusercontent.com/1874151/50712506-c8d69180-103f-11e9-9463-536cbb7d3f91.png)
![status-page-1150](https://user-images.githubusercontent.com/1874151/50712507-c8d69180-103f-11e9-82fd-f56c6fd603e5.png)

---
![status-page-320](https://user-images.githubusercontent.com/1874151/50712482-b6f4ee80-103f-11e9-9dae-35b8ef955ae5.png)
![status-page-786](https://user-images.githubusercontent.com/1874151/50712483-b6f4ee80-103f-11e9-9ea2-6ac6c0cce2c4.png)
![status-page-768](https://user-images.githubusercontent.com/1874151/50712484-b78d8500-103f-11e9-8e78-c9dee6c5b211.png)

---

<img width="380" alt="dashboard-mobile" src="https://user-images.githubusercontent.com/1874151/50712455-a0e72e00-103f-11e9-9cdb-f8be48364452.png">
---
Padding added
<img width="620" alt="sidebar-bottom-padding" src="https://user-images.githubusercontent.com/1874151/50712470-a80e3c00-103f-11e9-8d31-8e88df655b2e.png">
