### PR TITLE
Adjustments needed to spacing of the .co-external-link since base font was changed to Overpass

### DIFF
--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -292,10 +292,10 @@
   font-size: 75%;
   height: 16px;
   position:relative;
-  margin-left: 5px;
-  margin-right: -25px; // width + margin-left
+  margin-left: 3px;
+  margin-right: -15px; // width + margin-left
   top:0;
-  width: 20px;
+  width: 12px;
 
   .pf-c-nav__link & {
     color: $color-pf-black-500;
@@ -303,7 +303,7 @@
 }
 .co-external-link {
   display: inline-block;
-  padding-right: 25px;
+  padding-right: 15px;
 }
 // Enable break word within co-m-table-grid
 .co-external-link--block {


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1174

<img width="717" alt="screen shot 2019-01-07 at 10 41 30 am" src="https://user-images.githubusercontent.com/1874151/50777182-e89cce00-1268-11e9-848f-06ace249abb7.png">
