### PR TITLE
Bump screenfull to 4.0.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,7 +91,7 @@
     "redux-form": "7.x",
     "redux-thunk": "2.x",
     "sanitize-html": "1.x",
-    "screenfull": "^3.3.2",
+    "screenfull": "4.x",
     "semver": "^5.5.1",
     "showdown": "1.8.x",
     "text-encoding": "0.x",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10744,9 +10744,9 @@ scoped-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
 
-screenfull@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-3.3.2.tgz#a6adf3b3f5556da812725385880600f5b39fbf25"
+screenfull@4.x:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-4.0.0.tgz#86f3c26a2e516c8143884d8af16d07f0cb653394"
 
 scss-tokenizer@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
Fixes a runtime error in Chrome 67+.

/assign @dtaylor113 