### PR TITLE
Update global configuration table

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -175,9 +175,9 @@ const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = (
     <div className="co-m-pane__body-group">
       <dl className="co-m-pane__details">
         <dt>Cluster ID</dt>
-        <dd>{cv.spec.clusterID}</dd>
+        <dd className="co-break-all">{cv.spec.clusterID}</dd>
         <dt>Current Payload</dt>
-        <dd>{_.get(cv, 'status.current.payload')}</dd>
+        <dd className="co-break-all">{_.get(cv, 'status.current.payload')}</dd>
         <dt>Cluster Autoscaler</dt>
         <dd>
           {_.isEmpty(autoscalers)
@@ -199,7 +199,7 @@ const pages = [{
   component: ClusterVersionDetailsTable,
 }, {
   href: 'globalconfig',
-  name: 'Global Config',
+  name: 'Global Configuration',
   component: GlobalConfigPage,
 }, {
   href: 'clusteroperators',

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -271,6 +271,7 @@ const rolebindingsStartsWith = ['rolebindings', 'clusterrolebindings'];
 const quotaStartsWith = ['resourcequotas', 'clusterresourcequotas'];
 const imagestreamsStartsWith = ['imagestreams', 'imagestreamtags'];
 const monitoringAlertsStartsWith = ['monitoring/alerts', 'monitoring/alertrules'];
+const clusterSettingsStartsWith = ['settings/cluster', 'config.openshift.io'];
 
 const MonitoringNavSection_ = ({ urls }) => {
   const prometheusURL = urls[MonitoringRoutes.Prometheus];
@@ -371,7 +372,7 @@ export const Navigation = ({ isNavOpen, onNavSelect }) => {
           <ResourceClusterLink resource="nodes" name="Nodes" required={FLAGS.CAN_LIST_NODE} />
           <ResourceNSLink resource={referenceForModel(MachineSetModel)} name="Machine Sets" required={FLAGS.CLUSTER_API} />
           <ResourceNSLink resource={referenceForModel(MachineModel)} name="Machines" required={FLAGS.CLUSTER_API} />
-          <HrefLink href="/settings/cluster" activePath="/settings/cluster/" name="Cluster Settings" required={FLAGS.CLUSTER_VERSION} />
+          <HrefLink href="/settings/cluster" activePath="/settings/cluster/" name="Cluster Settings" required={FLAGS.CLUSTER_VERSION} startsWith={clusterSettingsStartsWith} />
           <ResourceNSLink resource="serviceaccounts" name="Service Accounts" />
           <ResourceNSLink resource="roles" name="Roles" startsWith={rolesStartsWith} />
           <ResourceNSLink resource="rolebindings" name="Role Bindings" startsWith={rolebindingsStartsWith} />

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -283,6 +283,12 @@
   @include co-break-word;
 }
 
+// Prefer `co-break-word` in most cases. `co-break-all` should generally be reserved for URLs and long,
+// unbroken identifiers.
+.co-break-all {
+  word-break: break-all;
+}
+
 // append external-link icon to <a> so that it doesn't wrap without text
 // there must be no white space between the text and the closing </a> tag holding the pseudo element
 .co-external-link:after {


### PR DESCRIPTION
Since the various configuration resources are all named "cluster," update the table to just show the resource kind like "Authentication" and "DNS."

Highlight the "Cluster Settings" nav item when a resource in the `config.openshift.io` API group is selected. This includes global config resources and `ClusterOperators`.

See https://github.com/openshift/openshift-origin-design/pull/137

<img width="1287" alt="screen shot 2019-01-07 at 9 46 02 pm" src="https://user-images.githubusercontent.com/1167259/50807092-30524280-12c7-11e9-8e1d-2ae7e67270d9.png">

/assign @rhamilto 
@openshift/team-ux-review 