### PR TITLE
Rename providerConfig to providerSpec

### DIFF
--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -37,7 +37,7 @@ const { common } = Kebab.factory;
 const menuActions = [editCountAction, ...common];
 const machineReference = referenceForModel(MachineModel);
 const machineSetReference = referenceForModel(MachineSetModel);
-const getAWSPlacement = (machineSet: MachineSetKind) => _.get(machineSet, 'spec.template.spec.providerConfig.value.placement') || {};
+const getAWSPlacement = (machineSet: MachineSetKind) => _.get(machineSet, 'spec.template.spec.providerSpec.value.placement') || {};
 
 // `spec.replicas` defaults to 1 if not specified. Make sure to differentiate between undefined and 0.
 const getDesiredReplicas = (machineSet: MachineSetKind) => {

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -21,15 +21,15 @@ import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 const { common } = Kebab.factory;
 const menuActions = [...common];
 const machineReference = referenceForModel(MachineModel);
-const getAWSPlacement = (machine: MachineKind) => _.get(machine, 'spec.providerConfig.value.placement') || {};
+const getAWSPlacement = (machine: MachineKind) => _.get(machine, 'spec.providerSpec.value.placement') || {};
 
 export const getMachineRole = (obj: MachineKind | MachineSetKind) => _.get(obj, ['metadata', 'labels', 'sigs.k8s.io/cluster-api-machine-role']);
 
 const MachineHeader = props => <ListHeader>
   <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
   <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.namespace">Namespace</ColHead>
-  <ColHead {...props} className="col-sm-2 hidden-xs" sortField="spec.providerConfig.value.placement.region">Region</ColHead>
-  <ColHead {...props} className="col-sm-2 hidden-xs" sortField="spec.providerConfig.value.placement.availabilityZone">Availability Zone</ColHead>
+  <ColHead {...props} className="col-sm-2 hidden-xs" sortField="spec.providerSpec.value.placement.region">Region</ColHead>
+  <ColHead {...props} className="col-sm-2 hidden-xs" sortField="spec.providerSpec.value.placement.availabilityZone">Availability Zone</ColHead>
 </ListHeader>;
 
 const MachineRow: React.SFC<MachineRowProps> = ({obj}: {obj: MachineKind}) => {

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -76,7 +76,7 @@ export type CustomResourceDefinitionKind = {
 } & K8sResourceKind;
 
 export type MachineSpec = {
-  providerConfig: {
+  providerSpec: {
     value: K8sResourceKind;
   };
   versions: {


### PR DESCRIPTION
The providerConfig field has been recently renamed to providerSpec.
Both aws actuator and installer has already migrated to use the new
field. The old providerConfig is about to be removed completely from
machine CRDS installed by machine API operator. So the field will no
longer be supported.