### PR TITLE
Fix bug where right gutter is missing from `.co-catalog-page__num-items`

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -116,7 +116,7 @@ $catalog-item-icon-size-sm: 24px;
   &__num-items {
     border-bottom: 1px solid $color-pf-black-200;
     font-weight: 700;
-    margin: 0 0 $grid-gutter-width 0;
+    margin: 0 ($grid-gutter-width / 2) $grid-gutter-width 0;
     padding: 0 0 20px;
   }
 


### PR DESCRIPTION
Before:
![screen shot 2019-01-09 at 9 27 04 am](https://user-images.githubusercontent.com/895728/50905408-c5048f80-13f0-11e9-97bc-3691f6833a00.png)

After:
![screen shot 2019-01-09 at 9 24 04 am](https://user-images.githubusercontent.com/895728/50905422-cafa7080-13f0-11e9-812e-83ccde1aa422.png)
