### PR TITLE
Fix bug with Deploy Image environment var editor loading indicator

### DIFF
--- a/frontend/public/components/deploy-image.tsx
+++ b/frontend/public/components/deploy-image.tsx
@@ -406,7 +406,8 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
                     envPath={['spec','template','spec','containers']}
                     readOnly={false}
                     onChange={this.onEnvironmentChange}
-                    addConfigMapSecret={false} />
+                    addConfigMapSecret={false}
+                    useLoadingInline={true} />
                 </div>
               </div>
             </React.Fragment>}

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -6,7 +6,7 @@ import { FieldLevelHelp, Alert } from 'patternfly-react';
 import * as classNames from 'classnames';
 
 import { k8sPatch, k8sGet, referenceFor, referenceForOwnerRef } from '../module/k8s';
-import { PromiseComponent, NameValueEditorPair, EnvType, EnvFromPair, LoadingBox, AsyncComponent, ContainerDropdown, ResourceLink } from './utils';
+import { PromiseComponent, NameValueEditorPair, EnvType, EnvFromPair, LoadingInline, LoadingBox, AsyncComponent, ContainerDropdown, ResourceLink } from './utils';
 import { ConfigMapModel, SecretModel } from '../models';
 
 /**
@@ -83,7 +83,7 @@ const getContainersObjectForDropdown = (containerArray) => {
   }, {});
 };
 
-/** @type {(state: any, props: {obj?: object, rawEnvData?: any, readOnly: boolean, envPath: any, onChange?: (env: any) => void, addConfigMapSecret?: boolean}) => {model: K8sKind}} */
+/** @type {(state: any, props: {obj?: object, rawEnvData?: any, readOnly: boolean, envPath: any, onChange?: (env: any) => void, addConfigMapSecret?: boolean, useLoadingInline?: boolean}) => {model: K8sKind}} */
 const stateToProps = ({k8s}, {obj}) => ({
   model: k8s.getIn(['RESOURCES', 'models', referenceFor(obj)]) || k8s.getIn(['RESOURCES', 'models', obj.kind]),
 });
@@ -404,9 +404,12 @@ export const EnvironmentPage = connect(stateToProps)(
 
     render() {
       const {errorMessage, success, inProgress, currentEnvVars, stale, configMaps, secrets, containerIndex, containerType} = this.state;
-      const {rawEnvData, readOnly, obj, addConfigMapSecret} = this.props;
+      const {rawEnvData, readOnly, obj, addConfigMapSecret, useLoadingInline} = this.props;
 
       if (!configMaps || !currentEnvVars || !secrets) {
+        if (useLoadingInline) {
+          return <LoadingInline />;
+        }
         return <LoadingBox />;
       }
 
@@ -479,6 +482,7 @@ EnvironmentPage.propTypes = {
   readOnly: PropTypes.bool.isRequired,
   onChange: PropTypes.func,
   addConfigMapSecret: PropTypes.bool,
+  useLoadingInline: PropTypes.bool,
 };
 EnvironmentPage.defaultProps = {
   obj: {},


### PR DESCRIPTION
On the Deploy Image page, the Environment Var editor can take a few seconds to load.  By default, `<LoadingBox />` is displayed while loading occurs.  The layout of `<LoadingBox />` is problematic for the Deploy Image page because the Env Var editor is not the only thing on the page (like it is elsewhere).  Adding an option prop to use `<LoadingInline />` instead of `<LoadingBox />` fixes the bug.

Before:
http://recordit.co/LLjBAHFTIe
![screen shot 2019-01-10 at 2 25 31 pm](https://user-images.githubusercontent.com/895728/50991894-be0a7980-14e3-11e9-9c00-d9789078ecb1.png)

After:
http://recordit.co/J6iZLkq6PE
![screen shot 2019-01-10 at 2 26 10 pm](https://user-images.githubusercontent.com/895728/50991905-c2369700-14e3-11e9-96ee-f0dfc5e8b5f4.png)


cc: @jwforres, @jcaianirh  