### PR TITLE
Fix selector for disabled kebab in crud tests

### DIFF
--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -79,7 +79,7 @@ export const deleteRow = (kind: string) => (name: string) => rowForName(name).$$
 
     await $('#confirm-action').click();
 
-    const kebabIsDisabled = until.presenceOf(rowForName(name).$('.co-kebab--disabled'));
+    const kebabIsDisabled = until.not(until.elementToBeClickable(rowForName(name).$('.co-kebab__button')));
     const listIsEmpty = until.textToBePresentInElement($('.cos-status-box > .text-center'), 'No ');
     const rowIsGone = until.not(until.presenceOf(rowForName(name).$('.co-kebab')));
     return browser.wait(until.or(kebabIsDisabled, until.or(listIsEmpty, rowIsGone)));


### PR DESCRIPTION
Fixes flaky crud tests. Since the disabled kebab selector was incorrect, the test was waiting for items to disappear from the list view to confirm deletion. This caused timeout failures, mainly for deployment configs because they take longer to delete.