### PR TITLE
Add a basic details page for cluster OAuth configuration

### DIFF
--- a/frontend/public/components/cluster-settings/oauth.tsx
+++ b/frontend/public/components/cluster-settings/oauth.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable no-undef, no-unused-vars */
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import { OAuthModel } from '../../models';
+import { K8sResourceKind, referenceForModel } from '../../module/k8s';
+import { DetailsPage } from '../factory';
+import {
+  EmptyBox,
+  Kebab,
+  navFactory,
+  SectionHeading,
+  ResourceSummary,
+} from '../utils';
+import { formatDuration } from '../utils/datetime';
+
+const { common } = Kebab.factory;
+const menuActions = [...common];
+
+const oAuthReference = referenceForModel(OAuthModel);
+
+// Convert to ms for formatDuration
+const tokenDuration = (seconds: number) => _.isNil(seconds * 1000) ? '-' : formatDuration(seconds);
+
+const IdentityProviders: React.SFC<IdentityProvidersProps> = ({identityProviders}) => {
+  return _.isEmpty(identityProviders)
+    ? <EmptyBox label="Identity Providers" />
+    : <div className="co-table-container">
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Challenge</th>
+            <th>Login</th>
+          </tr>
+        </thead>
+        <tbody>
+          {_.map(identityProviders, idp => (
+            <tr key={idp.name}>
+              <td>{idp.name}</td>
+              <td>{idp.type}</td>
+              <td>{idp.challenge ? 'true' : 'false'}</td>
+              <td>{idp.login ? 'true' : 'false'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>;
+};
+
+const OAuthDetails: React.SFC<OAuthDetailsProps> = ({obj}: {obj: K8sResourceKind}) => {
+  const { identityProviders, tokenConfig = {} } = obj.spec;
+  const { accessTokenMaxAgeSeconds, authorizeTokenMaxAgeSeconds } = tokenConfig;
+  return <React.Fragment>
+    <div className="co-m-pane__body">
+      <SectionHeading text="OAuth Overview" />
+      <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
+        <dt>Max Age: Access Token</dt>
+        <dd>{tokenDuration(accessTokenMaxAgeSeconds)}</dd>
+        <dt>Max Age: Authorize Token</dt>
+        <dd>{tokenDuration(authorizeTokenMaxAgeSeconds)}</dd>
+      </ResourceSummary>
+    </div>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Identity Providers" />
+      <p className="co-m-pane__explanation">
+        Identity providers determine how users log into the cluster.
+      </p>
+      <IdentityProviders identityProviders={identityProviders} />
+    </div>
+  </React.Fragment>;
+};
+
+export const OAuthDetailsPage: React.SFC<OAuthDetailsPageProps> = props => (
+  <DetailsPage
+    {...props}
+    kind={oAuthReference}
+    menuActions={menuActions}
+    pages={[navFactory.details(OAuthDetails), navFactory.editYaml()]}
+  />
+);
+
+type IdentityProvidersProps = {
+  identityProviders: any[];
+};
+
+type OAuthDetailsProps = {
+  obj: K8sResourceKind;
+};
+
+type OAuthDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/kube-admin-notifier.jsx
+++ b/frontend/public/components/kube-admin-notifier.jsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
-import * as _ from 'lodash-es';
+// import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
+import * as _ from 'lodash-es';
 
+// import { OAuthModel } from '../models';
 import { userStateToProps } from '../ui/ui-reducers';
 import { KUBE_ADMIN_USERNAME } from '../const';
+// import { resourcePathFromModel } from './utils/resource-link';
+
+// const oAuthResourcePath = resourcePathFromModel(OAuthModel, 'cluster');
 
 export const KubeAdminNotifier = connect(userStateToProps)(({user}) => {
   const username = _.get(user, 'metadata.name');
@@ -11,7 +16,9 @@ export const KubeAdminNotifier = connect(userStateToProps)(({user}) => {
     ? <div className="co-global-notification">
       <div className="co-global-notification__content">
         <p className="co-global-notification__text">
-          You are logged in as a temporary administrative user. Set up an identity provider to allow others to log in.
+          You are logged in as a temporary administrative user.
+          {/* Temporarily disable the link since it's not yet possible to add identity providers. */}
+          {/* Update the <Link to={oAuthResourcePath}>cluster OAuth configuration</Link> to allow others to log in. */}
         </p>
       </div>
     </div>

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -35,6 +35,7 @@ import {
   NamespaceModel,
   NetworkPolicyModel,
   NodeModel,
+  OAuthModel,
   PersistentVolumeClaimModel,
   PersistentVolumeModel,
   PodModel,
@@ -106,7 +107,8 @@ export const resourceDetailPages = ImmutableMap<GroupVersionKind | string, () =>
   .set(referenceForModel(CatalogSourceModel), () => import('./operator-lifecycle-manager/catalog-source' /* webpackChunkName: "catalog-source" */).then(m => m.CatalogSourceDetailsPage))
   .set(referenceForModel(SubscriptionModel), () => import('./operator-lifecycle-manager/subscription' /* webpackChunkName: "subscription" */).then(m => m.SubscriptionDetailsPage))
   .set(referenceForModel(InstallPlanModel), () => import('./operator-lifecycle-manager/install-plan' /* webpackChunkName: "install-plan" */).then(m => m.InstallPlanDetailsPage))
-  .set(referenceForModel(ClusterOperatorModel), () => import('./cluster-settings/cluster-operator' /* webpackChunkName: "cluster-operator" */).then(m => m.ClusterOperatorDetailsPage));
+  .set(referenceForModel(ClusterOperatorModel), () => import('./cluster-settings/cluster-operator' /* webpackChunkName: "cluster-operator" */).then(m => m.ClusterOperatorDetailsPage))
+  .set(referenceForModel(OAuthModel), () => import('./cluster-settings/oauth' /* webpackChunkName: "oauth" */).then(m => m.OAuthDetailsPage));
 
 export const resourceListPages = ImmutableMap<GroupVersionKind | string, () => Promise<React.ComponentType<any>>>()
   .set(referenceForModel(ClusterServiceClassModel), () => import('./cluster-service-class' /* webpackChunkName: "cluster-service-class" */).then(m => m.ClusterServiceClassPage))

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -861,7 +861,7 @@ export const MachineDeploymentModel: K8sKind = {
   crd: true,
 };
 
-// Openshift cluster resources
+// OpenShift cluster resources
 export const ClusterOperatorModel: K8sKind = {
   label: 'Cluster Operator',
   labelPlural: 'Cluster Operators',
@@ -901,5 +901,20 @@ export const ClusterAutoscalerModel: K8sKind = {
   namespaced: false,
   kind: 'ClusterAutoscaler',
   id: 'clusterautoscaler',
+  crd: true,
+};
+
+// OpenShift global configuration
+export const OAuthModel: K8sKind = {
+  label: 'OAuth',
+  labelPlural: 'OAuths',
+  apiVersion: 'v1',
+  path: 'oauths',
+  apiGroup: 'config.openshift.io',
+  plural: 'oauths',
+  abbr: 'OA',
+  namespaced: false,
+  kind: 'OAuth',
+  id: 'oauth',
   crd: true,
 };


### PR DESCRIPTION
Related to #1010. Show basic details about the OAuth configuration. For now, show identity providers in a table, although we eventually want to show additional detail for each kind of IDP.

/assign @TheRealJon 
@enj fyi

Closes #916

![screen shot 2019-01-10 at 9 07 15 pm](https://user-images.githubusercontent.com/1167259/51009029-5d4b6300-151c-11e9-93cc-648960a7dd1d.png)
