### PR TITLE
Add missing Helmet component + encapsulate Helmet used on the list pages into the PageHeading component

### DIFF
--- a/frontend/public/components/catalog/catalog-page.jsx
+++ b/frontend/public/components/catalog/catalog-page.jsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
-import { Helmet } from 'react-helmet';
 
 import { CatalogTileViewPage } from './catalog-items';
 import { serviceClassDisplayName, referenceForModel } from '../../module/k8s';
@@ -222,9 +221,6 @@ Catalog.propTypes = {
 export const CatalogPage = withStartGuide(({match, noProjectsAvailable}) => {
   const namespace = _.get(match, 'params.ns');
   return <React.Fragment>
-    <Helmet>
-      <title>Developer Catalog</title>
-    </Helmet>
     <div className="co-catalog">
       <PageHeading title="Developer Catalog" />
       <Catalog namespace={namespace} mock={noProjectsAvailable} />

--- a/frontend/public/components/cluster-health.jsx
+++ b/frontend/public/components/cluster-health.jsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Helmet } from 'react-helmet';
 
 import { humanizeMem, humanizeNumber, PageHeading } from './utils';
 import { Bar, Gauge, Line, Scalar } from './graphs';
@@ -42,10 +41,6 @@ const diskQueries = [
 ];
 
 export const ClusterHealth = () => <div>
-  <Helmet>
-    <title>Cluster Health</title>
-  </Helmet>
-
   <PageHeading title="Cluster Health" />
 
   <div className="cluster-overview-cell container-fluid">

--- a/frontend/public/components/cluster-overview.jsx
+++ b/frontend/public/components/cluster-overview.jsx
@@ -1,7 +1,6 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 
 import { EventsList } from './events';
@@ -194,9 +193,6 @@ export const ClusterOverviewPage = withStartGuide(({match, noProjectsAvailable})
   const namespace = _.get(match, 'params.ns');
   const title = namespace ? `Status of ${ namespace }` : 'Cluster Status';
   return <React.Fragment>
-    <Helmet>
-      <title>{noProjectsAvailable ? 'Overview' : title}</title>
-    </Helmet>
     <PageHeading title={noProjectsAvailable ? 'Overview' : title} />
     <div className="cluster-overview-cell container-fluid">
       <AsyncComponent namespace={namespace} loader={permissionedLoader} mock={noProjectsAvailable} />

--- a/frontend/public/components/deploy-image.tsx
+++ b/frontend/public/components/deploy-image.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 
 import { FieldLevelHelp } from 'patternfly-react';
@@ -310,9 +309,6 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
     const ports = getPorts(isi);
 
     return <React.Fragment>
-      <Helmet>
-        <title>{title}</title>
-      </Helmet>
       <PageHeading title={title} />
       <div className="co-m-pane__body">
         <form onSubmit={this.save} className="co-deploy-image co-m-pane__form">

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { safeLoad, safeDump } from 'js-yaml';
 import { saveAs } from 'file-saver';
+import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 
 import * as ace from 'brace';
@@ -324,11 +325,15 @@ export const EditYAML = connect(stateToProps)(
       const {error, success, stale} = this.state;
       const {create, obj, download = true, readOnly, header} = this.props;
       const model = this.getModel(obj);
+      const title = create ? header : `Edit ${_.get(model, 'label')}`;
 
       const editYamlComponent = <div className="co-file-dropzone">
         { canDrop && <div className={klass}><p className="co-file-dropzone__drop-text">Drop file here</p></div> }
 
         <div>
+          <Helmet>
+            <title>{title}</title>
+          </Helmet>
           {create && <div className="yaml-editor__header">
             <h1 className="yaml-editor__header-text">{header}</h1>
             <p className="help-block">Create by manually entering YAML or JSON definitions, or by dragging and dropping a file into the editor.</p>

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -4,7 +4,6 @@ import * as classNames from 'classnames';
 import * as PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
 import { Link } from 'react-router-dom';
-import { Helmet } from 'react-helmet';
 import {
   AutoSizer,
   List as VirtualList,
@@ -190,9 +189,6 @@ export class EventsList extends React.Component {
 
 export const EventStreamPage = withStartGuide(({noProjectsAvailable, ...rest}) =>
   <React.Fragment>
-    <Helmet>
-      <title>Events</title>
-    </Helmet>
     <PageHeading title="Events" />
     <EventsList {...rest} autoFocus={!noProjectsAvailable} mock={noProjectsAvailable} />
   </React.Fragment>

--- a/frontend/public/components/import-yaml.tsx
+++ b/frontend/public/components/import-yaml.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { AsyncComponent } from './utils';
 
 export const ImportYamlPage = () => {
-
   return <React.Fragment>
     <AsyncComponent loader={() => import('./droppable-edit-yaml').then(c => c.DroppableEditYAML)} create={true} download={false} header="Import YAML" />
   </React.Fragment>;

--- a/frontend/public/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-page.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import {Helmet} from 'react-helmet';
 
 import { Firehose, PageHeading, StatusBox, MsgBox } from '../utils';
 import { referenceForModel, K8sResourceKind } from '../../module/k8s';
@@ -128,9 +127,6 @@ export class OperatorHubList extends React.Component<OperatorHubListProps, Opera
 
 export const OperatorHubPage: React.SFC<OperatorHubPageProps> = (props) => {
   return <React.Fragment>
-    <Helmet>
-      <title>Operator Hub</title>
-    </Helmet>
     <div className="co-catalog">
       <PageHeading title="Operator Hub" />
       <div className="co-catalog-connect">

--- a/frontend/public/components/profile.jsx
+++ b/frontend/public/components/profile.jsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Helmet } from 'react-helmet';
 
 import { authSvc } from '../module/auth';
 import { kubectlConfigModal } from './modals';
@@ -22,9 +21,6 @@ export class ProfilePage extends SafetyFirst {
 
   render() {
     return <div className="co-p-profile">
-      <Helmet>
-        <title>Profile</title>
-      </Helmet>
       <PageHeading detail={true} title="Profile" />
       <div className="co-m-pane__body">
         <dl className="co-m-pane__details">

--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 
 import { ButtonBar, Dropdown, history, resourcePathFromModel, ResourceName } from '../utils';
@@ -218,6 +219,9 @@ export class CreateRoute extends React.Component<null, CreateRouteState> {
 
     return <React.Fragment>
       <div className="co-m-pane__body co-m-pane__form">
+        <Helmet>
+          <title>{title}</title>
+        </Helmet>
         <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
           <div className="co-m-pane__name">
             {title}

--- a/frontend/public/components/search.jsx
+++ b/frontend/public/components/search.jsx
@@ -2,7 +2,6 @@ import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Helmet } from 'react-helmet';
 
 import { AsyncComponent } from './utils/async';
 import { connectToModel } from '../kinds';
@@ -71,9 +70,6 @@ class SearchPage_ extends React.PureComponent {
     const labelClassName = `co-text-${_.toLower(kindForReference(kind))}`;
 
     return <React.Fragment>
-      <Helmet>
-        <title>Search</title>
-      </Helmet>
       <PageHeading detail={true} title="Search" >
         <div className="co-search">
           <div className="input-group input-group-select">

--- a/frontend/public/components/service-catalog/create-binding.tsx
+++ b/frontend/public/components/service-catalog/create-binding.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { IChangeEvent, ISubmitEvent } from 'react-jsonschema-form';
 import { JSONSchema6 } from 'json-schema';
@@ -118,9 +117,6 @@ class CreateBindingForm extends React.Component<CreateBindingProps, CreateBindin
     }
 
     return <React.Fragment>
-      <Helmet>
-        <title>{title}</title>
-      </Helmet>
       <PageHeading
         title={title}
         obj={obj}

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import { Helmet } from 'react-helmet';
 import { IChangeEvent, ISubmitEvent } from 'react-jsonschema-form';
 
 import { ServiceInstanceModel, ClusterServiceClassModel, ClusterServicePlanModel } from '../../models';
@@ -141,9 +140,6 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
     });
 
     return <React.Fragment>
-      <Helmet>
-        <title>{title}</title>
-      </Helmet>
       <StatusBox data={serviceClass} loaded={loaded} loadError={loadError} label="Service Class">
         <PageHeading title={title} />
         <div className="co-m-pane__body co-create-service-instance">

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
@@ -798,12 +799,16 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
   render() {
     const { newStorageClass, fieldErrors } = this.state;
     const reclaimPolicyKey = newStorageClass.reclaim === null ? this.reclaimPolicies.Delete : newStorageClass.reclaim;
+    const title = 'Create Storage Class';
 
     return (
       <div className="co-m-pane__body co-m-pane__form">
+        <Helmet>
+          <title>{title}</title>
+        </Helmet>
         <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
           <div className="co-m-pane__name">
-            Create Storage Class
+            {title}
           </div>
           <div className="co-m-pane__heading-link">
             <Link to="/k8s/cluster/storageclasses/new" id="yaml-link" replace>Edit YAML</Link>

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
+import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 
 import { ActionsMenu, ResourceIcon, KebabAction } from './index';
@@ -54,6 +55,9 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
   const showActions = (hasButtonActions || hasMenuActions) && !_.isEmpty(data) && !_.get(data, 'deletionTimestamp');
 
   return <div className={classNames('co-m-nav-title', {'co-m-nav-title--detail': detail}, {'co-m-nav-title--logo': isCSV}, {'co-m-nav-title--breadcrumbs': breadcrumbsFor && !_.isEmpty(data)})} style={style}>
+    <Helmet>
+      <title>{title}</title>
+    </Helmet>
     { breadcrumbsFor && !_.isEmpty(data) && <BreadCrumbs breadcrumbs={breadcrumbsFor(data)} /> }
     <h1 className={classNames('co-m-pane__heading', {'co-m-pane__heading--logo': isCSV})}>
       { logo }


### PR DESCRIPTION
On couple of pages we have been missing Helmet component for setting `title` for the page `head`.
For list and browse pages we are use PageHeading component into which I've encapsulated the Helmet component.
For create forms we are not using the PageHeading component, so I've added the Helmet component into those forms that have been missing it.
Also "Import YAML" && "Edit YAML" have been missing Helmet.

Went through all our routes so we dont miss the title on any page. 

/assign @spadgett 