### PR TITLE
Reduce .co-namespace-selector__menu.dropdown-menu max-height...

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -1,9 +1,6 @@
-$co-namespace-selector-desktop: 47px;
-$co-namespace-selector-mobile: 35px;
 $color-dropdown-hover: rgba(0, 0, 0, .05);
 $color-bookmarker--hover: #AAA;
 $color-bookmarker: #DDD;
-$masthead-height: 76px;
 
 .dropdown {
   position: relative;
@@ -185,14 +182,13 @@ $masthead-height: 76px;
 }
 
 .co-namespace-selector__menu.dropdown-menu {
-  max-height: calc(100vh - (#{$masthead-height} + #{$co-namespace-selector-mobile}));
+  max-height: 60vh;
   max-width: 100%;
   min-width: 210px;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 
   @media (min-width: $grid-float-breakpoint) {
-    max-height: calc(100vh - (#{$masthead-height} + #{$co-namespace-selector-desktop}));
     min-width: 250px;
   }
 


### PR DESCRIPTION
to fix double scrollbar issue when a global notification is present.  Note:  at the smallest viewport heights, the double scrollbar issue can still exist when multiple notifications are present.  Given this is an unlikely scenario, it seems plausible to let it stand.

![localhost_9000_catalog_all-namespaces 1](https://user-images.githubusercontent.com/895728/51054597-633c5500-15ab-11e9-8101-a3eb0cc39b72.png)
![localhost_9000_catalog_all-namespaces](https://user-images.githubusercontent.com/895728/51054598-63d4eb80-15ab-11e9-8be3-6370a47c2886.png)
![localhost_9000_catalog_all-namespaces ipad 1](https://user-images.githubusercontent.com/895728/51054600-63d4eb80-15ab-11e9-8156-b57352f290f1.png)
![localhost_9000_catalog_all-namespaces ipad 2](https://user-images.githubusercontent.com/895728/51054601-63d4eb80-15ab-11e9-899c-c4c4ff5b2e3f.png)
![localhost_9000_catalog_all-namespaces iphone 5_se 1](https://user-images.githubusercontent.com/895728/51054602-63d4eb80-15ab-11e9-8ec6-484863657fbd.png)
![localhost_9000_catalog_all-namespaces iphone 5_se](https://user-images.githubusercontent.com/895728/51054603-63d4eb80-15ab-11e9-97b3-d853e417b526.png)
![localhost_9000_catalog_all-namespaces iphone 6_7_8 1](https://user-images.githubusercontent.com/895728/51054604-63d4eb80-15ab-11e9-991f-cad5a35cd989.png)
![localhost_9000_catalog_all-namespaces iphone 6_7_8](https://user-images.githubusercontent.com/895728/51054605-63d4eb80-15ab-11e9-8104-5dd47b3844e9.png)
