### PR TITLE
[bug-1663861] Add paused alert to deployments/deployment configs on status page

### DIFF
--- a/frontend/public/components/overview/deployment-config-overview.tsx
+++ b/frontend/public/components/overview/deployment-config-overview.tsx
@@ -9,6 +9,7 @@ import {
   DeploymentPodCounts,
   LoadingInline,
   ResourceSummary,
+  WorkloadPausedAlert,
 } from '../utils';
 
 import { OverviewDetailsResourcesTab } from './resource-overview-page';
@@ -17,6 +18,7 @@ import { ResourceOverviewDetails } from './resource-overview-details';
 
 const DeploymentConfigOverviewDetails: React.SFC<DeploymentConfigOverviewDetailsProps> = ({item: {obj: dc}}) => {
   return <div className="overview__sidebar-pane-body resource-overview__body">
+    {dc.spec.paused && <WorkloadPausedAlert obj={dc} model={DeploymentConfigModel} />}
     <div className="resource-overview__pod-counts">
       <DeploymentPodCounts resource={dc} resourceKind={DeploymentConfigModel} />
     </div>

--- a/frontend/public/components/overview/deployment-overview.tsx
+++ b/frontend/public/components/overview/deployment-overview.tsx
@@ -9,6 +9,7 @@ import {
   DeploymentPodCounts,
   LoadingInline,
   ResourceSummary,
+  WorkloadPausedAlert,
 } from '../utils';
 
 import { OverviewDetailsResourcesTab } from './resource-overview-page';
@@ -17,6 +18,7 @@ import { ResourceOverviewDetails } from './resource-overview-details';
 
 const DeploymentOverviewDetails: React.SFC<DeploymentOverviewDetailsProps> = ({item}) => {
   return <div className="overview__sidebar-pane-body resource-overview__body">
+    {item.obj.spec.paused && <WorkloadPausedAlert obj={item.obj} model={DeploymentModel} />}
     <div className="resource-overview__pod-counts">
       <DeploymentPodCounts resource={item.obj} resourceKind={DeploymentModel} />
     </div>

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -152,7 +152,7 @@ const podAlertKey = (alert: any, pod: K8sResourceKind, containerName: string = '
   return `${alert}--${id}--${containerName}`;
 };
 
-const getPodAlerts = (pod: K8sResourceKind): any => {
+const getPodAlerts = (pod: K8sResourceKind): OverviewItemAlerts => {
   const alerts = {};
   const statuses = [
     ..._.get(pod, 'status.initContainerStatuses', []),
@@ -182,12 +182,12 @@ const getPodAlerts = (pod: K8sResourceKind): any => {
   return alerts;
 };
 
-const combinePodAlerts = (pods: K8sResourceKind[]): any => _.reduce(pods, (acc, pod) => ({
+const combinePodAlerts = (pods: K8sResourceKind[]): OverviewItemAlerts => _.reduce(pods, (acc, pod) => ({
   ...acc,
   ...getPodAlerts(pod),
 }), {});
 
-const getReplicationControllerAlerts = (rc: K8sResourceKind): any => {
+const getReplicationControllerAlerts = (rc: K8sResourceKind): OverviewItemAlerts => {
   const phase = getDeploymentPhase(rc);
   const version = getDeploymentConfigVersion(rc);
   const label = _.isFinite(version) ? `#${version}` : rc.metadata.name;
@@ -210,6 +210,18 @@ const getReplicationControllerAlerts = (rc: K8sResourceKind): any => {
     default:
       return {};
   }
+};
+
+const getResourcePausedAlert = (resource): OverviewItemAlerts => {
+  if (!resource.spec.paused) {
+    return {};
+  }
+  return {
+    [`${resource.metadata.uid}--Paused`]: {
+      severity: 'info',
+      message: `${resource.metadata.name} is paused.`,
+    },
+  };
 };
 
 const getOwnedResources = ({metadata:{uid}}: K8sResourceKind, resources: K8sResourceKind[]): K8sResourceKind[] => {
@@ -706,6 +718,7 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
   createDeploymentItems(): OverviewItem[] {
     const {deployments} = this.props;
     return _.map(deployments.data, d => {
+      const alerts = getResourcePausedAlert(d);
       const replicaSets = this.getReplicaSetsForResource(d);
       const current = _.head(replicaSets);
       const previous = _.nth(replicaSets, 1);
@@ -727,6 +740,7 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
         />;
 
       return {
+        alerts,
         buildConfigs,
         current,
         isRollingOut,
@@ -742,6 +756,7 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
   createDeploymentConfigItems(): OverviewItem[] {
     const {deploymentConfigs} = this.props;
     return _.map(deploymentConfigs.data, dc => {
+      const alerts = getResourcePausedAlert(dc);
       const replicationControllers = this.getReplicationControllersForResource(dc);
       const current = _.head(replicationControllers);
       const previous = _.nth(replicationControllers, 1);
@@ -763,6 +778,7 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
           ready={dc.status.replicas}
         />;
       return {
+        alerts,
         buildConfigs,
         current,
         isRollingOut,


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1663861
Adds an alert on the overview list item and an info alert to the sidebar details when a deployment or deployment config is paused.

![image](https://user-images.githubusercontent.com/22625502/51059987-0a28ed00-15bc-11e9-94a7-42320cbda3ed.png)

@openshift/team-ux-review 