### PR TITLE
Make row keys more unique

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -48,7 +48,7 @@ export const flatten = resources => _.flatMap(resources, resource => {
       ret.push(Object.assign({}, binding, {
         subject,
         subjectIndex,
-        rowKey: `${getQN(binding)}|${subject.kind}|${subject.name}`,
+        rowKey: `${getQN(binding)}|${subject.kind}|${subject.name}${subject.namespace ? `|${subject.namespace}` : ''}`,
       }));
     });
   });


### PR DESCRIPTION
Added namespace (when it's not undefined) to row keys to avoid key conflicts. Fixes filtering issues @serenamarie125 noticed.

Fixed filtering:
![role-binding-unique](https://user-images.githubusercontent.com/7014965/51063308-672aa000-15c8-11e9-8952-8a3126a6f7f6.gif)



Fixes [CONSOLE-1171](https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-1171).