### PR TITLE
frontend/public/cluster-settings: fix current version from clusterversion

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -42,7 +42,7 @@ export const getAvailableClusterUpdates = (cv) => {
 };
 
 export const getCurrentClusterVersion = (cv) => {
-  return _.get(cv, 'status.current.version');
+  return _.get(cv, 'status.desired.version');
 };
 
 


### PR DESCRIPTION
https://github.com/openshift/api/pull/153 moved the field for the current version as reported by the cluster version operator.