### PR TITLE
Fix bug with masthead focus indicator

### DIFF
--- a/frontend/public/style/_base.scss
+++ b/frontend/public/style/_base.scss
@@ -5,9 +5,9 @@ button:focus,
 a:focus {
   outline-style: none;
 
-  // restore outline-style to buttons, a in .pf-l-page__header
+  // restore outline-style to buttons, a in .pf-c-page__header
   // so there is a visual indicator for keyboard users
-  .pf-l-page__header & {
+  .pf-c-page__header & {
     outline-style: auto;
   }
 }


### PR DESCRIPTION
PatternFly 4 renamed `pf-l-page` to `pf-c-page` in https://github.com/patternfly/patternfly-next/pull/1112, but this rule was overlooked in #989.