### PR TITLE
Remove temp scrolling fix as it's no longer needed

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -263,8 +263,6 @@ tags-input .autocomplete .suggestion-item em {
   --pf-c-page__sidebar--PaddingBottom: 0;
   --pf-c-page__sidebar--PaddingTop: 0;
   position: relative; // fix z-index bug in Edge
-  // TEMP fix until https://github.com/patternfly/patternfly-next/issues/1175 is fixed upstream
-  -webkit-overflow-scrolling: touch;
 
   @media screen and (min-width: $grid-float-breakpoint) {
     --pf-c-page__sidebar--BoxShadow: none;


### PR DESCRIPTION
https://github.com/openshift/console/pull/989 switched from the PatternFly layout (`.pf-l-page*`) to component (`.pf-c-page*`) which includes this fix.