### PR TITLE
Add Dev Catalog e2e tests to Jenkins CI

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -95,8 +95,7 @@ export const config: Config = {
     olm: ['tests/base.scenario.ts', 'tests/olm/descriptors.scenario.ts', 'tests/olm/catalog.scenario.ts', 'tests/olm/etcd.scenario.ts'],
     olmUpgrade: ['tests/base.scenario.ts', 'tests/olm/update-channel-approval.scenario.ts'],
     performance: ['tests/base.scenario.ts', 'tests/performance.scenario.ts'],
-    serviceCatalog: ['tests/base.scenario.ts', 'tests/service-catalog/service-catalog.scenario.ts', 'tests/service-catalog/service-broker.scenario.ts', 'tests/service-catalog/service-class.scenario.ts', 'tests/service-catalog/service-binding.scenario.ts'],
-    catalog: ['tests/base.scenario.ts', 'tests/catalog.scenario.ts'],
+    serviceCatalog: ['tests/base.scenario.ts', 'tests/service-catalog/service-catalog.scenario.ts', 'tests/service-catalog/service-broker.scenario.ts', 'tests/service-catalog/service-class.scenario.ts', 'tests/service-catalog/service-binding.scenario.ts', 'tests/developer-catalog.scenario.ts'],
     operatorHub: ['tests/base.scenario.ts', 'tests/operator-hub/operator-hub.scenario.ts'],
     overview: ['tests/base.scenario.ts', 'tests/overview/overview.scenario.ts'],
     e2e: ['tests/base.scenario.ts',
@@ -123,7 +122,7 @@ export const config: Config = {
       'tests/source-to-image.scenario.ts',
       'tests/deploy-image.scenario.ts',
       'tests/operator-hub/operator-hub.scenario.ts',
-      'tests/catalog.scenario.ts'],
+      'tests/developer-catalog.scenario.ts'],
   },
   params: {
     // Set to 'true' to enable OpenShift resources in the crud scenario.

--- a/frontend/integration-tests/tests/developer-catalog.scenario.ts
+++ b/frontend/integration-tests/tests/developer-catalog.scenario.ts
@@ -40,9 +40,9 @@ describe('Catalog', () => {
     expect(numLanguagesItems).toBeLessThan(origNumItems);
   });
 
-  it('displays ".NET Core" catalog tile when filter by name: "net"', async() => {
-    await catalogPageView.filterByKeyword('net');
-    expect(catalogPageView.catalogTileFor('.NET Core').isDisplayed()).toBe(true);
+  it('displays "Jenkins" catalog tile when filter by name: "jenkins"', async() => {
+    await catalogPageView.filterByKeyword('jenkins');
+    expect(catalogPageView.catalogTileFor('Jenkins').isDisplayed()).toBe(true);
   });
 
   it('displays "No Filter Results" page correctly', async() => {
@@ -60,28 +60,36 @@ describe('Catalog', () => {
     expect(catalogPageView.catalogTiles.isPresent()).toBe(true);
 
     const srvClassFilterCount = await catalogPageView.filterCheckboxCount('Service Class');
-    // '.NET Core' is source-to-image
-    expect(catalogPageView.catalogTileFor('.NET Core').isDisplayed()).toBe(true);
+
+    // 'Node.js' is source-to-image and should be shown initially
+    expect(catalogPageView.catalogTileFor('Node.js').isDisplayed()).toBe(true);
 
     await catalogPageView.clickFilterCheckbox('Service Class');
+    // 'Jenkins' is service-class and should be shown
+    expect(catalogPageView.catalogTileFor('Jenkins').isDisplayed()).toBe(true);
+    // 'Node.js' is s-2-i and should not be shown
+    expect(catalogPageView.catalogTileFor('Node.js').isPresent()).toBe(false);
+
     const numCatalogTiles = await catalogView.pageHeadingNumberOfItems();
-    // after checking '[X] Service Class (12)', the number of tiles should equal the 'Service Class' filter count
+    // after checking '[X] Service Class', the number of tiles should equal the 'Service Class' filter count
     expect(srvClassFilterCount).toEqual(numCatalogTiles);
-    // // '.NET Core' is s-t-i and should not be shown
-    expect(catalogPageView.catalogTileFor('.NET Core').isPresent()).toBe(false);
   });
 
   it('filters catalog tiles by \'Source-To-Image\' Type correctly', async() => {
     expect(catalogPageView.catalogTiles.isPresent()).toBe(true);
 
     const srvClassFilterCount = await catalogPageView.filterCheckboxCount('Source-To-Image');
-    // '.NET Core Example' is service class
-    expect(catalogPageView.catalogTileFor('.NET Core Example').isDisplayed()).toBe(true);
+
+    // 'Jenkins' is service class and should be shown initially
+    expect(catalogPageView.catalogTileFor('Jenkins').isDisplayed()).toBe(true);
 
     await catalogPageView.clickFilterCheckbox('Source-To-Image');
+    // 'Node.js' is s-2-i and should be shown
+    expect(catalogPageView.catalogTileFor('Node.js').isPresent()).toBe(true);
+    // 'Jenkins' is service-class and should not be shown
+    expect(catalogPageView.catalogTileFor('Jenkins').isPresent()).toBe(false);
+
     const numCatalogTiles = await catalogView.pageHeadingNumberOfItems();
     expect(srvClassFilterCount).toEqual(numCatalogTiles);
-    // // '.NET Core Example' is service-class and should not be shown
-    expect(catalogPageView.catalogTileFor('.NET Core Example').isPresent()).toBe(false);
   });
 });

--- a/frontend/public/components/catalog/catalog-page.jsx
+++ b/frontend/public/components/catalog/catalog-page.jsx
@@ -32,10 +32,11 @@ export class CatalogListPage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const {clusterserviceclasses, imagestreams, namespace} = this.props;
-    if (namespace !== prevProps.namespace ||
-      clusterserviceclasses !== prevProps.clusterserviceclasses ||
-      imagestreams !== prevProps.imagestreams) {
+    const {clusterserviceclasses, imagestreams, clusterServiceVersions, namespace} = this.props;
+    if (!_.isEqual(namespace, prevProps.namespace) ||
+      !_.isEqual(clusterserviceclasses, prevProps.clusterserviceclasses) ||
+      !_.isEqual(imagestreams, prevProps.imagestreams) ||
+      !_.isEqual(clusterServiceVersions, prevProps.clusterServiceVersions)) {
       const items = this.getItems();
       this.setState({items});
     }


### PR DESCRIPTION
- added test for when no service classes loaded in Dev Catalog
- updated `catalog-page` to update when `clusterServiceVersions` change
- renamed `catalog.scenario.ts` to `developer-catalog.scenario.ts` and added it to `serviceCatalog` test suite, which is run during Jenkins CI