### PR TITLE
Bug 1666231 - Fix current payload on cluster settings page

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -187,7 +187,7 @@ const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = (
         <dt>Cluster ID</dt>
         <dd className="co-break-all">{cv.spec.clusterID}</dd>
         <dt>Current Payload</dt>
-        <dd className="co-break-all">{_.get(cv, 'status.current.payload')}</dd>
+        <dd className="co-break-all">{_.get(cv, 'status.desired.payload') || '-'}</dd>
         <dt>Cluster Autoscaler</dt>
         <dd>
           {_.isEmpty(autoscalers)


### PR DESCRIPTION
The API has changed slightly. It's now `status.desired.payload`.

https://bugzilla.redhat.com/show_bug.cgi?id=1666231

/assign @rhamilto 