### PR TITLE
Fix for display issues in operator hub details

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -2,7 +2,7 @@ $catalog-item-icon-size-lg: 40px;
 $catalog-item-icon-size-sm: 24px;
 
 // Until Patternfly-React-Extensions is updated: https://github.com/patternfly/patternfly-react/issues/1146
-.catalog-tile-pf-title {
+.catalog-tile-pf-title, .properties-side-panel-pf-property-value {
   @include co-break-word;
 }
 

--- a/frontend/public/components/operator-lifecycle-manager/markdown-view.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/markdown-view.tsx
@@ -47,11 +47,17 @@ export class SyncMarkdownView extends React.Component<{content: string, outerScr
   }
 
   render() {
-    // Find the app's stylesheet and inject it into the frame to ensure consistent styling.
+    // Find the app's stylesheets and inject them into the frame to ensure consistent styling.
     const filteredLinks = Array.from(document.getElementsByTagName('link')).filter((l) => _.includes(l.href, 'app-bundle'));
 
+    const linkRefs = _.reduce(
+      filteredLinks,
+      (refs, link) => `${refs}
+        <link rel="stylesheet" href="${link.href}">`,
+      '');
+
     const contents = `
-      <link rel="stylesheet" href="${filteredLinks[0].href}">
+      ${linkRefs}
       <style type="text/css">
       body {
           color: ${this.props.content ? '#333' : '#999'};


### PR DESCRIPTION
Fixes text overrun in the left side properties on Firefox
Loads correct styles for the description markdown text

Fixes https://jira.coreos.com/browse/CONSOLE-1209