### PR TITLE
Tweak help message for storage classes

### DIFF
--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -136,7 +136,7 @@ class StorageClassDropdown_ extends React.Component<StorageClassDropdownProps, S
             menuClassName="dropdown-menu--text-wrap"
           />
           <p className="help-block" id={describedBy}>
-            Optional storage class for the new claim.
+            Storage class for the new claim.
           </p>
         </div>
       }


### PR DESCRIPTION
This simply changes the help message for the storage class dropdown to make it more generic for when a default class is already chosen for the user.