### PR TITLE
Don't automatically reload YAML in YAML editor

### DIFF
--- a/frontend/public/components/droppable-edit-yaml.tsx
+++ b/frontend/public/components/droppable-edit-yaml.tsx
@@ -28,11 +28,12 @@ export const DroppableEditYAML = withDragDropContext(class DroppableEditYAML ext
   constructor(props) {
     super(props);
     this.state = {
-      obj: this.props.obj || '',
+      fileUpload: '',
       error: '',
     };
     this.handleFileDrop = this.handleFileDrop.bind(this);
   }
+
   handleFileDrop(item, monitor) {
     if (!monitor) {
       return;
@@ -44,7 +45,7 @@ export const DroppableEditYAML = withDragDropContext(class DroppableEditYAML ext
       reader.onload = () => {
         const input = reader.result;
         this.setState({
-          obj: input,
+          fileUpload: input,
         });
       };
       reader.readAsText(file, 'UTF-8');
@@ -53,13 +54,16 @@ export const DroppableEditYAML = withDragDropContext(class DroppableEditYAML ext
         error: fileSizeErrorMsg,
       });
     }
-
   }
+
   render() {
+    const { obj } = this.props;
+    const { fileUpload, error } = this.state;
     return <EditYAMLComponent
       {...this.props}
-      obj={this.state.obj}
-      error={this.state.error}
+      obj={obj}
+      fileUpload={fileUpload}
+      error={error}
       onDrop={this.handleFileDrop} />;
   }
 });
@@ -69,6 +73,6 @@ export type DroppableEditYAMLProps = {
   obj: string,
 };
 export type DroppableEditYAMLState = {
-  obj: string,
+  fileUpload: string,
   error: string,
 };

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -54,6 +54,7 @@ export const EditYAML = connect(stateToProps)(
         initialized: false,
         stale: false,
         sampleObj: props.sampleObj,
+        fileUpload: props.fileUpload,
       };
       this.id = `edit-yaml-${++id}`;
       this.ace = null;
@@ -133,8 +134,10 @@ export const EditYAML = connect(stateToProps)(
       }
       if (nextProps.sampleObj) {
         this.loadYaml(!_.isEqual(this.state.sampleObj, nextProps.sampleObj), nextProps.sampleObj);
+      } else if (nextProps.fileUpload) {
+        this.loadYaml(!_.isEqual(this.state.fileUpload, nextProps.fileUpload), nextProps.fileUpload);
       } else {
-        this.loadYaml(true, nextProps.obj);
+        this.loadYaml();
       }
     }
 


### PR DESCRIPTION
Don't automatically replace the YAML when the resource changes. This was
an accidental regression when adding drag and drop support.

https://bugzilla.redhat.com/show_bug.cgi?id=1666175

/assign @jhadvig 