### PR TITLE
Improve project overview item selectors in overview integration tests

### DIFF
--- a/frontend/integration-tests/views/overview.view.ts
+++ b/frontend/integration-tests/views/overview.view.ts
@@ -1,4 +1,4 @@
-import { $, $$, browser, by, ExpectedConditions as until } from 'protractor';
+import { $, $$, browser, by, element, ExpectedConditions as until } from 'protractor';
 
 export const projectOverview = $('.project-overview');
 const projectOverviewItemSelector = '.project-overview__item';
@@ -13,15 +13,11 @@ export const itemsAreVisible = () => {
 };
 
 export const getProjectOverviewListItemsOfKind = (kindModel) => {
-  return projectOverviewListItems.filter(async(e) => {
-    return await e.element(by.className(`co-m-resource-${kindModel.id}`)).isPresent();
-  });
+  return $$(`.project-overview__item--${kindModel.kind}`);
 };
 
 export const getProjectOverviewListItem = (kindModel, name) => {
-  return getProjectOverviewListItemsOfKind(kindModel).filter(async(e) => {
-    return await e.element(by.linkText(name)).isPresent();
-  });
+  return element(by.cssContainingText(`.project-overview__item--${kindModel.kind}`, name));
 };
 
 export const sidebarIsLoaded = () => {

--- a/frontend/public/components/overview/project-overview.tsx
+++ b/frontend/public/components/overview/project-overview.tsx
@@ -215,7 +215,7 @@ const ProjectOverviewListItem = connect<ProjectOverviewListItemPropsFromState, P
     // Hide metrics when a selection is active.
     const hasSelection = !!selectedUID;
     const isSelected = uid === selectedUID;
-    const className = classnames('project-overview__item', {'project-overview__item--selected': isSelected});
+    const className = classnames(`project-overview__item project-overview__item--${kind}`, {'project-overview__item--selected': isSelected});
     const heading = <h3 className="project-overview__item-heading">
       <span className="co-resource-link co-resource-link-truncate">
         <ResourceIcon kind={kind} />


### PR DESCRIPTION
Added CSS class to project overview items which includes the resource kind. Use the new class as a selector in the overview integration tests to avoid usage of `filter` function.