### PR TITLE
Restored breadcrumbs back to Pod from Container details page

### DIFF
--- a/frontend/public/components/container.jsx
+++ b/frontend/public/components/container.jsx
@@ -19,6 +19,7 @@ import {
   StatusIcon,
   Timestamp,
 } from './utils';
+import { resourcePath } from './utils/resource-link';
 
 const formatComputeResources = resources => _.map(resources, (v, k) => `${k}: ${v}`).join(', ');
 
@@ -251,14 +252,6 @@ const Details = (props) => {
 };
 
 export const ContainersDetailsPage = (props) => <div>
-  <PageHeading
-    detail={true}
-    title={props.match.params.name}
-    kind="Container"
-    breadcrumbsFor={() => [
-      {name: props.match.params.podName, path: `${props.match.url.split('/').filter((v, i) => i <= props.match.path.split('/').indexOf(':podName')).join('/')}`},
-      {name: 'Container Details', path: `${props.match.url}`},
-    ]} />
   <Firehose resources={[{
     name: props.match.params.podName,
     namespace: props.match.params.ns,
@@ -266,6 +259,14 @@ export const ContainersDetailsPage = (props) => <div>
     isList: false,
     prop: 'obj',
   }]}>
+    <PageHeading
+      detail={true}
+      title={props.match.params.name}
+      kind="Container"
+      breadcrumbsFor={() => [
+        {name: props.match.params.podName, path: resourcePath('Pod', props.match.params.podName, props.match.params.ns)},
+        {name: 'Container Details', path: `${props.match.url}`},
+      ]} />
     <HorizontalNav hideNav={true} pages={[{name: 'container', href: '', component: Details}]} match={props.match} />
   </Firehose>
 </div>;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12733153/51269789-62336b00-1991-11e9-94ec-862416cdcc5b.png)

<img src="https://user-images.githubusercontent.com/12733153/51269909-99098100-1991-11e9-9914-c7a88d0f0b33.png" width="50px" />

![image](https://user-images.githubusercontent.com/12733153/51269808-6a8ba600-1991-11e9-9f7e-12c92459306f.png)
![image](https://user-images.githubusercontent.com/12733153/51269816-6e1f2d00-1991-11e9-9651-d5fcef68e9a3.png)

<img src="https://user-images.githubusercontent.com/12733153/51269909-99098100-1991-11e9-9914-c7a88d0f0b33.png" width="50px" />

![image](https://user-images.githubusercontent.com/12733153/51270177-45e3fe00-1992-11e9-93a1-56a551be075e.png)

Fix for: https://jira.coreos.com/browse/CONSOLE-1204