### PR TITLE
Add namespace to events

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -93,6 +93,7 @@ $color-dark-border: #ddd;
 
 .co-sysevent__resourcelink {
   display: block;
+  flex: 2 0 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -109,6 +110,11 @@ $color-dark-border: #ddd;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.co-sysevent__timestamp {
+  flex: 1 0 0;
+  justify-content: flex-end;
 }
 
 .co-sysevent__message {

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -70,7 +70,12 @@ const Inner = connectToFlags(FLAGS.CAN_LIST_NODE)(class Inner extends React.Pure
               name={obj.name}
               title={obj.uid}
             />
-            <Timestamp timestamp={lastTimestamp} />
+            {obj.namespace && <ResourceLink
+              className="co-sysevent__resourcelink hidden-xs"
+              kind="Namespace"
+              name={obj.namespace}
+            />}
+            <Timestamp className="co-sysevent__timestamp" timestamp={lastTimestamp} />
           </div>
           <div className="co-sysevent__details">
             <small className="co-sysevent__source">

--- a/frontend/public/components/utils/timestamp.jsx
+++ b/frontend/public/components/utils/timestamp.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Tooltip } from './tooltip';
+import * as classNames from 'classnames';
 
 import {SafetyFirst} from '../safety-first';
 import * as dateTime from './datetime';
@@ -119,6 +120,7 @@ export class Timestamp extends SafetyFirst {
 
   render() {
     const { mdate, timestamp } = this.state;
+    const { className } = this.props;
 
     if (!dateTime.isValid(mdate)) {
       return <div className="co-timestamp">-</div>;
@@ -128,7 +130,7 @@ export class Timestamp extends SafetyFirst {
       return timestamp;
     }
 
-    return <div className="co-timestamp co-icon-and-text">
+    return <div className={classNames('co-timestamp co-icon-and-text', className)}>
       <i className="fa fa-globe co-icon-and-text__icon" aria-hidden="true" />
       <Tooltip content={[<span className="co-nowrap" key="co-timestamp">{ mdate.toISOString() }</span>]}>
         { timestamp }


### PR DESCRIPTION
Added namespace links to events. Shows "all" for cluster resource events
since they don't have a defined namespace.

<img width="983" alt="screen shot 2019-01-16 at 5 35 07 pm" src="https://user-images.githubusercontent.com/7014965/51283136-388c3b00-19b5-11e9-98d5-b46031d61878.png">

Cluster vs. non-cluster:
<img width="972" alt="screen shot 2019-01-16 at 5 35 38 pm" src="https://user-images.githubusercontent.com/7014965/51283148-3fb34900-19b5-11e9-8f66-9e3766c5da72.png">

Fixes [CONSOLE-784](https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-784).

@openshift/team-ux-review, could you please review?