### PR TITLE
[WIP] Operator Hub - Landing page is blank when packageserver is not running

### DIFF
--- a/frontend/public/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-page.tsx
@@ -92,7 +92,7 @@ export class OperatorHubList extends React.Component<OperatorHubListProps, Opera
 
     if (loaded && !prevProps.loaded ||
       !_.isEqual(subscription.data, prevProps.subscription.data) ||
-      !_.isEqual(packageManifest.data, prevProps.packageManifest.data)) {
+      !_.isEqual(_.get(packageManifest, 'data'), _.get(prevProps.packageManifest, 'data'))) {
       const items = _.sortBy(normalizePackageManifests(_.get(packageManifest, 'data'), subscription.data), 'name');
       this.setState({items});
     }


### PR DESCRIPTION
Fixes [Bugzilla 1667227](https://bugzilla.redhat.com/show_bug.cgi?id=1667227)

/cc @jeff-phillips-18 @spadgett @alecmerdler 