### PR TITLE
More Reliable Element Locators for OLM E2E Tests

### DIFF
--- a/frontend/integration-tests/tests/olm/descriptors.scenario.ts
+++ b/frontend/integration-tests/tests/olm/descriptors.scenario.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef, no-unused-vars */
 
 import { execSync } from 'child_process';
-import { browser, $$ } from 'protractor';
+import { browser, element, by } from 'protractor';
 import { safeDump } from 'js-yaml';
 
 import { appHost, testName, checkLogs, checkErrors } from '../../protractor.conf';
@@ -180,17 +180,17 @@ describe('Using OLM descriptor components', () => {
   });
 
   testCSV.spec.customresourcedefinitions.owned[0].specDescriptors.forEach(descriptor => {
-    const label = $$('dt').filter(dt => dt.getText().then(text => text.toLowerCase() === descriptor.displayName.toLowerCase())).first();
+    const label = element(by.cssContainingText('.olm-descriptor__title', descriptor.displayName));
 
-    it(`displays spec descriptor for ${descriptor.displayName}`, () => {
+    it(`displays spec descriptor for ${descriptor.displayName}`, async() => {
       expect(label.isDisplayed()).toBe(true);
     });
   });
 
   testCSV.spec.customresourcedefinitions.owned[0].statusDescriptors.forEach(descriptor => {
-    const label = $$('dt').filter(dt => dt.getText().then(text => text.toLowerCase() === descriptor.displayName.toLowerCase())).first();
+    const label = element(by.cssContainingText('.olm-descriptor__title', descriptor.displayName));
 
-    it(`displays status descriptor for ${descriptor.displayName}`, () => {
+    it(`displays status descriptor for ${descriptor.displayName}`, async() => {
       expect(label.isDisplayed()).toBe(true);
     });
   });

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
@@ -104,13 +104,13 @@ export const SpecDescriptor: React.SFC<DescriptorProps> = (props) => {
   const capability = _.get(descriptor, ['x-descriptors', 0], null) as SpecCapability;
   const Capability = capabilityFor(capability);
 
-  return <dl>
+  return <dl className="olm-descriptor">
     <div style={{width: 'max-content'}}>
       <Tooltip content={descriptor.description}>
-        <dt>{descriptor.displayName}</dt>
+        <dt className="olm-descriptor__title">{descriptor.displayName}</dt>
       </Tooltip>
     </div>
-    <dd><Capability descriptor={descriptor} capability={capability} value={value} namespace={namespace} model={model} obj={obj} /></dd>
+    <dd className="olm-descriptor__value"><Capability descriptor={descriptor} capability={capability} value={value} namespace={namespace} model={model} obj={obj} /></dd>
   </dl>;
 };
 

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/status/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/status/index.tsx
@@ -73,13 +73,13 @@ export const StatusDescriptor: React.SFC<DescriptorProps> = (props) => {
   const capability = _.get(descriptor, ['x-descriptors', 0], null) as StatusCapability;
   const Capability = capabilityFor(capability);
 
-  return <dl>
+  return <dl className="olm-descriptor">
     <div style={{width: 'max-content'}}>
       <Tooltip content={descriptor.description}>
-        <dt>{descriptor.displayName}</dt>
+        <dt className="olm-descriptor__title">{descriptor.displayName}</dt>
       </Tooltip>
     </div>
-    <dd><Capability descriptor={descriptor} capability={capability} value={value} namespace={namespace} /></dd>
+    <dd className="olm-descriptor__value"><Capability descriptor={descriptor} capability={capability} value={value} namespace={namespace} /></dd>
   </dl>;
 };
 


### PR DESCRIPTION
### Description

Adds CSS classes to the descriptor labels and values and uses those to locate the elements in the Protractor tests.

Fixes https://jira.coreos.com/browse/CONSOLE-1214