### PR TITLE
Fix bug where catalog isn't wide enough at mobile

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -25,7 +25,7 @@ $catalog-item-icon-size-sm: 24px;
   display: flex;
   flex-direction: column;
   min-height: 100%;
-  min-width: 465px; // in order to accommodate filters and tiles at mobile
+  min-width: 515px; // in order to accommodate filters and tiles at mobile
   padding: 0 0 ($grid-gutter-width / 2);
 }
 


### PR DESCRIPTION
This fixes the immediate bug, but I think the design [1] needs to be reconsidered.  With the wider filter column (previously 170px, now 220px), very little of the tile is visible at the smallest viewport resolution we support (320px).

[1] to rely on horizontal scrolling to view tiles

cc: @openshift/team-ux-review 

After:
![localhost_9000_k8s_cluster_clusterroles_-v1alpha1-admin_ iphone 5_se 1](https://user-images.githubusercontent.com/895728/51391973-9c237f00-1b01-11e9-84a1-f7d03458538d.png)
![localhost_9000_k8s_cluster_clusterroles_-v1alpha1-admin_ iphone 5_se](https://user-images.githubusercontent.com/895728/51391974-9c237f00-1b01-11e9-96aa-c86723b669e8.png)


