### PR TITLE
Improve display of Operator > PackageManifests table

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
@@ -18,12 +18,12 @@ import { kindForReference, K8sResourceKind, OwnerReference, K8sKind, referenceFo
 import { ClusterServiceVersionModel } from '../../models';
 
 export const ClusterServiceVersionResourceHeader: React.SFC<ClusterServiceVersionResourceHeaderProps> = (props) => <ListHeader>
-  <ColHead {...props} className="col-xs-2" sortField="metadata.name">Name</ColHead>
-  <ColHead {...props} className="col-xs-2" sortField="metadata.labels">Labels</ColHead>
-  <ColHead {...props} className="col-xs-2" sortField="kind">Type</ColHead>
-  <ColHead {...props} className="col-xs-2">Status</ColHead>
-  <ColHead {...props} className="col-xs-2">Version</ColHead>
-  <ColHead {...props} className="col-xs-2">Last Updated</ColHead>
+  <ColHead {...props} className="col-xs-6 col-sm-4 col-md-3 col-lg-2" sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className="col-xs-6 col-sm-4 col-md-3 col-lg-2" sortField="metadata.labels">Labels</ColHead>
+  <ColHead {...props} className="hidden-xs col-sm-4 col-md-3 col-lg-2" sortField="kind">Type</ColHead>
+  <ColHead {...props} className="hidden-xs hidden-sm col-md-3 col-lg-2">Status</ColHead>
+  <ColHead {...props} className="hidden-xs hidden-sm hidden-md col-lg-2">Version</ColHead>
+  <ColHead {...props} className="hidden-xs hidden-sm hidden-md col-lg-2">Last Updated</ColHead>
 </ListHeader>;
 
 export const ClusterServiceVersionResourceLink: React.SFC<ClusterServiceVersionResourceLinkProps> = (props) => {
@@ -41,22 +41,22 @@ export const ClusterServiceVersionResourceRow: React.SFC<ClusterServiceVersionRe
   const {obj} = props;
 
   return <div className="row co-resource-list__item">
-    <div className="col-xs-2">
+    <div className="col-xs-6 col-sm-4 col-md-3 col-lg-2">
       <ClusterServiceVersionResourceLink obj={obj} />
     </div>
-    <div className="col-xs-2">
+    <div className="col-xs-6 col-sm-4 col-md-3 col-lg-2">
       <LabelList kind={obj.kind} labels={obj.metadata.labels} />
     </div>
-    <div className="col-xs-2">
+    <div className="hidden-xs col-sm-4 col-md-3 col-lg-2 co-break-word">
       {obj.kind}
     </div>
-    <div className="col-xs-2">
+    <div className="hidden-xs hidden-sm col-md-3 col-lg-2">
       {_.get(obj.status, 'phase') || <div className="text-muted">Unknown</div>}
     </div>
-    <div className="col-xs-2">
+    <div className="hidden-xs hidden-sm hidden-md col-lg-2">
       {_.get(obj.spec, 'version') || <div className="text-muted">Unknown</div>}
     </div>
-    <div className="col-xs-2">
+    <div className="hidden-xs hidden-sm hidden-md col-lg-2">
       <Timestamp timestamp={obj.metadata.creationTimestamp} />
     </div>
     <div className="dropdown-kebab-pf">


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1220

After:
![localhost_9000_k8s_ns_openshift-operator-lifecycle-manager_clusterserviceversions_packageserver v0 8 0_packages apps redhat com_v1alpha1_packagemanifest iphone 5_se](https://user-images.githubusercontent.com/895728/51395939-06412180-1b0c-11e9-93de-25ff4a455747.png)
![localhost_9000_k8s_ns_openshift-operator-lifecycle-manager_clusterserviceversions_packageserver v0 8 0_packages apps redhat com_v1alpha1_packagemanifest ipad](https://user-images.githubusercontent.com/895728/51395945-080ae500-1b0c-11e9-9d11-74e6466bda8b.png)
![localhost_9000_k8s_ns_openshift-operator-lifecycle-manager_clusterserviceversions_packageserver v0 8 0_packages apps redhat com_v1alpha1_packagemanifest 1](https://user-images.githubusercontent.com/895728/51395987-1eb13c00-1b0c-11e9-953f-33ab267aafb8.png)
![localhost_9000_k8s_ns_openshift-operator-lifecycle-manager_clusterserviceversions_packageserver v0 8 0_packages apps redhat com_v1alpha1_packagemanifest](https://user-images.githubusercontent.com/895728/51395948-09d4a880-1b0c-11e9-9480-3e73fcea59bd.png)
