### PR TITLE
frontend: use Memory instead of RAM

### DIFF
--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -90,7 +90,7 @@ const BuildGraphs = requirePrometheus(({build}) => {
   return <React.Fragment>
     <div className="row">
       <div className="col-md-4">
-        <Line title="RAM" query={`pod_name:container_memory_usage_bytes:sum{pod_name='${podName}',container_name='',namespace='${build.metadata.namespace}'}`} />
+        <Line title="Memory Usage" query={`pod_name:container_memory_usage_bytes:sum{pod_name='${podName}',container_name='',namespace='${build.metadata.namespace}'}`} />
       </div>
       <div className="col-md-4">
         <Line title="CPU Usage" query={`pod_name:container_cpu_usage:sum{pod_name='${podName}',container_name='',namespace='${build.metadata.namespace}'} * 1000`} />

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -172,7 +172,7 @@ export const NamespaceLineCharts = ({ns}) => <div className="row">
     ]} />
   </div>
   <div className="col-sm-6 col-xs-12">
-    <Line title="RAM" query={[
+    <Line title="Memory Usage" query={[
       {
         name: 'Used',
         query: `namespace:container_memory_usage_bytes:sum{namespace='${ns.metadata.name}'}`,

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -146,10 +146,10 @@ const NodeGraphs = requirePrometheus(({node}) => {
   return <React.Fragment>
     <div className="row">
       <div className="col-md-4">
-        <Line title="RAM" query={ipQuery && `node_memory_Active${ipQuery}`} units="binaryBytes" limit={memoryLimit} />
+        <Line title="Memory Usage" query={ipQuery && `node_memory_Active${ipQuery}`} units="binaryBytes" limit={memoryLimit} />
       </div>
       <div className="col-md-4">
-        <Line title="CPU" query={ipQuery && `instance:node_cpu:rate:sum${ipQuery}`} units="numeric" limit={integerLimit(node.status.allocatable.cpu)} />
+        <Line title="CPU Usage" query={ipQuery && `instance:node_cpu:rate:sum${ipQuery}`} units="numeric" limit={integerLimit(node.status.allocatable.cpu)} />
       </div>
       <div className="col-md-4">
         <Line title="Number of Pods" query={ipQuery && `kubelet_running_pod_count${ipQuery}`} units="numeric" limit={integerLimit(node.status.allocatable.pods)} />
@@ -161,7 +161,7 @@ const NodeGraphs = requirePrometheus(({node}) => {
         <Line title="Network Out" query={ipQuery && `instance:node_network_transmit_bytes:rate:sum${ipQuery}`} units="decimalBytes" />
       </div>
       <div className="col-md-4">
-        <Line title="Filesystem" query={ipQuery && `instance:node_filesystem_usage:sum${ipQuery}`} units="decimalBytes" />
+        <Line title="Filesystem (bytes)" query={ipQuery && `instance:node_filesystem_usage:sum${ipQuery}`} units="decimalBytes" />
       </div>
     </div>
 

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -133,7 +133,7 @@ export const PodContainerTable = ({heading, containers, pod}) => <React.Fragment
 const PodGraphs = requirePrometheus(({pod}) => <React.Fragment>
   <div className="row">
     <div className="col-md-4">
-      <Line title="RAM" query={`pod_name:container_memory_usage_bytes:sum{pod_name='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}`} />
+      <Line title="Memory Usage" query={`pod_name:container_memory_usage_bytes:sum{pod_name='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}`} />
     </div>
     <div className="col-md-4">
       <Line title="CPU Usage" query={`pod_name:container_cpu_usage:sum{pod_name='${pod.metadata.name}',namespace='${pod.metadata.namespace}'} * 1000`} />


### PR DESCRIPTION
@spadgett 

The resource is named "Memory" in the pod resources and add "Usage" to align with "CPU Usage"