### PR TITLE
Change Cluster Resource Quota namespaces to "None"

### DIFF
--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -50,7 +50,7 @@ const Row = ({obj: rq}) => <div className="row co-resource-list__item">
     <ResourceLink kind={quotaKind(rq)} name={rq.metadata.name} namespace={rq.metadata.namespace} className="co-resource-link__resource-name" />
   </div>
   <div className="col-md-7 col-xs-6 co-break-word">
-    {rq.metadata.namespace ? <ResourceLink kind="Namespace" name={rq.metadata.namespace} title={rq.metadata.namespace} /> : 'all'}
+    {rq.metadata.namespace ? <ResourceLink kind="Namespace" name={rq.metadata.namespace} title={rq.metadata.namespace} /> : 'None'}
   </div>
   <div className="dropdown-kebab-pf">
     <ResourceKebab actions={menuActions} kind={quotaKind(rq)} resource={rq} />


### PR DESCRIPTION
Updated Resource Quotas page to display a namespace of "None" instead of "all" for Cluster Resource Quotas.

<img width="1029" alt="screen shot 2019-01-18 at 3 06 44 pm" src="https://user-images.githubusercontent.com/7014965/51410568-099bd380-1b33-11e9-86f5-02132300661f.png">

Fixes [CONSOLE-1225](https://jira.coreos.com/browse/CONSOLE-1225).