### PR TITLE
Monitoring: Wrap PromQL <pre> to fix page layout in Firefox

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -353,7 +353,7 @@ const AlertRulesDetailsPage = withFallback(connect(ruleStateToProps)((props: Ale
                   <dd>{formatDuration(duration * 1000)}</dd>
                 </React.Fragment>}
                 <dt>Expression</dt>
-                <dd><pre className="monitoring-query">{query}</pre></dd>
+                <dd><pre className="co-pre-wrap monitoring-query">{query}</pre></dd>
               </dl>
             </div>
           </div>


### PR DESCRIPTION
The query `<pre>` was not wrapping in Firefox, which forced the page width
out. A solution is to allow the query text to wrap, which is perhaps
better anyway since it then shows the full query.

/cc @cshinn Are you happy with this approach?

### Before
![before](https://user-images.githubusercontent.com/460802/51435975-ebff7300-1cc6-11e9-81fc-daabde3b5e62.png)

### After
![after](https://user-images.githubusercontent.com/460802/51435976-edc93680-1cc6-11e9-922f-fee44795e5d9.png)
