### PR TITLE
Ensure Developer Catalog Only Lists ClusterServiceVersions from Current Namespace

### DIFF
--- a/frontend/public/components/catalog/catalog-page.jsx
+++ b/frontend/public/components/catalog/catalog-page.jsx
@@ -204,6 +204,7 @@ export const Catalog = connectToFlags(FLAGS.OPENSHIFT, FLAGS.SERVICE_CATALOG, FL
       isList: true,
       kind: referenceForModel(ClusterServiceVersionModel),
       namespaced: true,
+      namespace,
       prop: 'clusterServiceVersions',
     }] : []),
   ];
@@ -231,3 +232,5 @@ export const CatalogPage = withStartGuide(({match, noProjectsAvailable}) => {
     </div>
   </React.Fragment>;
 });
+
+CatalogPage.displayName = 'CatalogPage';


### PR DESCRIPTION
### Description

The `<Firehose>` was missing the `namespace` prop, which made it fetch from `all-namespaces`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1663815