### PR TITLE
Test flake: Wait for overview list item to become clickable

### DIFF
--- a/frontend/integration-tests/tests/overview/overview.scenario.ts
+++ b/frontend/integration-tests/tests/overview/overview.scenario.ts
@@ -41,8 +41,10 @@ describe('Visiting Overview page', () => {
       });
 
       it(`shows ${kindModel.id} details sidebar when item is clicked`, async() => {
+        const overviewListItem = overviewView.getProjectOverviewListItem(kindModel, testName);
         await expect(overviewView.detailsSidebar.isPresent()).toBeFalsy();
-        await overviewView.getProjectOverviewListItem(kindModel, testName).click();
+        await browser.wait(until.elementToBeClickable(overviewListItem));
+        await overviewListItem.click();
         await overviewView.sidebarIsLoaded();
         await expect(overviewView.detailsSidebar.isDisplayed()).toBeTruthy();
         const title = await overviewView.detailsSidebarTitle.getText();


### PR DESCRIPTION
Issue: https://jira.coreos.com/browse/CONSOLE-1228

Since the tests are failing on the click step, we should make sure the list item is clickable.

/assign @spadgett

cc'ing @TheRealJon 