### PR TITLE
Remove checks for empty list in overview e2e tests

### DIFF
--- a/frontend/integration-tests/tests/overview/overview.scenario.ts
+++ b/frontend/integration-tests/tests/overview/overview.scenario.ts
@@ -19,24 +19,20 @@ describe('Visiting Overview page', () => {
     checkLogs();
   });
 
-  it('shows an emtpy list when no resources exist', async() => {
+  beforeAll(async() => {
     await browser.get(`${appHost}/overview/ns/${testName}`);
     await crudView.isLoaded();
-    await expect(overviewView.projectOverviewListItems.count()).toEqual(0);
   });
 
   overviewResources.forEach((kindModel) => {
     describe(kindModel.labelPlural, () => {
       beforeAll(async()=>{
-        await expect(overviewView.getProjectOverviewListItemsOfKind(kindModel).count()).toEqual(0);
-        await expect(overviewView.getProjectOverviewListItem(kindModel, testName).isPresent()).toBeFalsy();
         await crudView.createNamespacedTestResource(kindModel);
       });
 
       it(`displays a ${kindModel.id} in the project overview list`, async() => {
         await browser.wait(until.presenceOf(overviewView.projectOverview));
         await overviewView.itemsAreVisible();
-        await expect(overviewView.getProjectOverviewListItemsOfKind(kindModel).count()).toEqual(1);
         await expect(overviewView.getProjectOverviewListItem(kindModel, testName).isPresent()).toBeTruthy();
       });
 


### PR DESCRIPTION
Previously run GUI tests could pollute the test namespace and cause the status view to display resources which were not created by the overview test suite. This will cause the overview test suite to fail because the first test case checks that the status view is empty. We also check that after a resource is created, it is the only one of its kind shown in the status view. Removing these checks since they aren't necessary to confirm the expected overview behavior and can cause false failures.