### PR TITLE
More generic error message upon Terminal close

### DIFF
--- a/frontend/public/components/pod-exec.jsx
+++ b/frontend/public/components/pod-exec.jsx
@@ -96,7 +96,7 @@ export const PodExec = connectToFlags(FLAGS.OPENSHIFT)(class PodExec extends Rea
         if (!evt || evt.wasClean === true) {
           return;
         }
-        const error = evt.reason || 'Connection did not close cleanly.';
+        const error = evt.reason || 'The terminal connection has closed.';
         this.setState({error});
         this.terminal.current && this.terminal.current.onConnectionClosed(error);
         this.ws.destroy();


### PR DESCRIPTION
Previously the Terminal says connection didn't close cleanly when entering an "exit" command.   Error message changed to more generic error message since we can't determine between Terminal exiting with problem .vs exiting via 'exit' command.

Error msg updated to: "The terminal connection has closed".

https://jira.coreos.com/browse/CONSOLE-1203