### PR TITLE
Removing overflow-y: hidden from events list so that tooltips aren't clipped.

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -1,7 +1,6 @@
 $color-dark-border: #ddd;
 
 .co-sysevent-stream {
-  overflow-y: hidden;
   padding: 60px 0 50px 0;
   position: relative;
 }


### PR DESCRIPTION


…
fixes 
<img width="382" alt="screen shot 2019-01-24 at 10 55 09 am" src="https://user-images.githubusercontent.com/1874151/51690737-4ea68680-1fc7-11e9-96a9-d27ff2aed68d.png">

<img width="335" alt="screen shot 2019-01-24 at 11 21 12 am" src="https://user-images.githubusercontent.com/1874151/51692107-34ba7300-1fca-11e9-98af-6fb203f0b400.png">

