### PR TITLE
create single script for e2e tests for setup, launch, and teardown

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+ARTIFACT_DIR=/tmp/artifacts
+export ARTIFACT_DIR
+
+./build.sh
+
+oc login -u kubeadmin -p $(cat "${ARTIFACT_DIR}/installer/auth/kubeadmin-password")
+
+source ./contrib/oc-environment.sh
+
+kubectl create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/okd/manifests/0.8.0/0000_30_06-rh-operators.configmap.yaml
+kubectl create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/okd/manifests/0.8.0/0000_30_09-rh-operators.catalogsource.yaml
+
+./test-gui.sh e2e
+
+cp -rv ./frontend/gui_test_screenshots "${ARTIFACT_DIR}/gui_test_screenshots"


### PR DESCRIPTION
Add a script for e2e tests. Setup, launch, and then copy screenshots to the artifacts dir.