### PR TITLE
Remove undesirable border at bottom of events page

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -465,7 +465,7 @@ class EventStream extends SafetyFirst {
     });
     const messageCount = count < maxMessages ? `Showing ${pluralize(count, 'event')}` : `Showing ${count} of ${allCount}+ events`;
 
-    return <div className="co-m-pane__body">
+    return <div className="co-m-pane__body co-m-pane__body--alt">
       <div className="co-sysevent-stream">
         <div className="co-sysevent-stream__status">
           <div className="co-sysevent-stream__timeline__btn-text">


### PR DESCRIPTION
Before:
![screen shot 2019-01-24 at 2 19 44 pm](https://user-images.githubusercontent.com/895728/51703033-507e4300-1fe3-11e9-8e47-d0d50c8c96fc.png)

After:
![screen shot 2019-01-24 at 2 19 54 pm](https://user-images.githubusercontent.com/895728/51703034-507e4300-1fe3-11e9-8240-de408356b6df.png)
