### PR TITLE
Update engine check to allow node 11

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -153,6 +153,6 @@
     "webpack-cli": "^2.0.12"
   },
   "engines": {
-    "node": ">=8.x <=10.x"
+    "node": ">=8.x"
   }
 }


### PR DESCRIPTION
Just a small detail on the README.
a bit of background...: was installing node on new HW and installed version 11. When I was installing *glide* the installment shouted on me that I need version 10.

@spadgett PTAL