### PR TITLE
Adjust placement of contextDir in buildConfig

### DIFF
--- a/frontend/public/components/source-to-image.tsx
+++ b/frontend/public/components/source-to-image.tsx
@@ -219,10 +219,10 @@ class BuildSource extends React.Component<BuildSourceProps, BuildSourceState> {
           },
         },
         source: {
+          contextDir,
           git: {
             uri: repository,
             ref,
-            contextDir,
             type: 'Git',
           },
         },


### PR DESCRIPTION
Moved contextDir from under git to source. ContextDir now shows up in the BuildConfig YAML.

Fixes [bug 1669974](https://bugzilla.redhat.com/show_bug.cgi?id=1669974).