### PR TITLE
Fix bug where catalog overlay is still open when canceling create

### DIFF
--- a/frontend/public/components/catalog/catalog-item-details.jsx
+++ b/frontend/public/components/catalog/catalog-item-details.jsx
@@ -71,7 +71,7 @@ export class CatalogTileDetails extends React.Component {
         <Modal.Body>
           <div className="co-catalog-page__overlay-body">
             <PropertiesSidePanel>
-              <Link className="btn btn-primary co-catalog-page__overlay-create" to={href} role="button" title={this.props.item.createLabel}>{this.props.item.createLabel}</Link>
+              <Link className="btn btn-primary co-catalog-page__overlay-create" to={href} role="button" title={this.props.item.createLabel} onClick={closeOverlay}>{this.props.item.createLabel}</Link>
               {tileProvider && <PropertyItem label="Provider" value={tileProvider} />}
               {supportUrl && <PropertyItem label="Support" value={supportUrlLink} />}
               {creationTimestamp && <PropertyItem label="Created At" value={<Timestamp timestamp={creationTimestamp} />} />}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1670698

Calling closeOverlay here preserves the other query string parameters, thus maintaining any filters the user may have set on the catalog.

![lcaipxguub](https://user-images.githubusercontent.com/895728/51990236-a127ed00-2476-11e9-926f-fbe75fb225ee.gif)
