### PR TITLE
Filter Bar for ClusterServiceVersion List View

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -8,7 +8,7 @@ import * as _ from 'lodash-es';
 import { ClusterServiceVersionsDetailsPage, ClusterServiceVersionsDetailsPageProps, ClusterServiceVersionDetails, ClusterServiceVersionDetailsProps, ClusterServiceVersionsPage, ClusterServiceVersionsPageProps, ClusterServiceVersionList, ClusterServiceVersionHeader, ClusterServiceVersionRow, ClusterServiceVersionRowProps, CRDCard, CRDCardRow } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion';
 import { ClusterServiceVersionKind, ClusterServiceVersionLogo, ClusterServiceVersionLogoProps, referenceForProvidedAPI, CSVConditionReason } from '../../../public/components/operator-lifecycle-manager';
 import { DetailsPage, ListPage, ListHeader, ColHead, List, ListInnerProps } from '../../../public/components/factory';
-import { testClusterServiceVersion, testModel } from '../../../__mocks__/k8sResourcesMocks';
+import { testClusterServiceVersion } from '../../../__mocks__/k8sResourcesMocks';
 import { Timestamp, MsgBox, ResourceLink, ResourceKebab, ErrorBoundary, LoadingBox, ScrollToTopOnMount, SectionHeading } from '../../../public/components/utils';
 import { referenceForModel } from '../../../public/module/k8s';
 import { ClusterServiceVersionModel } from '../../../public/models';
@@ -177,7 +177,7 @@ describe(CRDCard.displayName, () => {
   const crd = testClusterServiceVersion.spec.customresourcedefinitions.owned[0];
 
   it('renders a card with title, body, and footer', () => {
-    const wrapper = shallow(<CRDCard.WrappedComponent crd={crd} csv={testClusterServiceVersion} kindObj={testModel} />);
+    const wrapper = shallow(<CRDCard canCreate={true} crd={crd} csv={testClusterServiceVersion} />);
 
     expect(wrapper.find('.co-crd-card__title').exists()).toBe(true);
     expect(wrapper.find('.co-crd-card__body').exists()).toBe(true);
@@ -185,14 +185,13 @@ describe(CRDCard.displayName, () => {
   });
 
   it('renders a link to create a new instance', () => {
-    const kindObj = _.cloneDeep({...testModel, verbs: ['create']});
-    const wrapper = shallow(<CRDCard.WrappedComponent crd={crd} csv={testClusterServiceVersion} kindObj={kindObj} />);
+    const wrapper = shallow(<CRDCard canCreate={true} crd={crd} csv={testClusterServiceVersion} />);
 
     expect(wrapper.find('.co-crd-card__footer').find(Link).props().to).toEqual(`/k8s/ns/${testClusterServiceVersion.metadata.namespace}/${ClusterServiceVersionModel.plural}/${testClusterServiceVersion.metadata.name}/${referenceForProvidedAPI(crd)}/new`);
   });
 
-  it('does not render link to create new instance if "create" not included in verbs for the model', () => {
-    const wrapper = shallow(<CRDCard.WrappedComponent crd={crd} csv={testClusterServiceVersion} kindObj={testModel} />);
+  it('does not render link to create new instance if `props.canCreate` is false', () => {
+    const wrapper = shallow(<CRDCard canCreate={false} crd={crd} csv={testClusterServiceVersion} />);
 
     expect(wrapper.find('.co-crd-card__footer').find(Link).exists()).toBe(false);
   });

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -105,6 +105,12 @@ const listFilters = {
     }
     return filters.selected.has(resource.kind);
   },
+  'clusterserviceversion-status': (filters, csv) => {
+    if (!filters || !filters.selected || !filters.selected.size) {
+      return true;
+    }
+    return filters.selected.has(_.get(csv.status, 'reason')) || !_.includes(filters.all, _.get(csv.status, 'reason'));
+  },
 
   'build-status': (phases, build) => {
     if (!phases || !phases.selected || !phases.selected.size) {

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -48,7 +48,6 @@ export enum CSVConditionReason {
 export enum InstallPlanApproval {
   Automatic = 'Automatic',
   Manual = 'Manual',
-  UpdateOnly = 'Update-Only',
 }
 
 export enum SubscriptionState {


### PR DESCRIPTION
### Description

The `OperatorGroups` feature of OLM allows a single Operator to be installed into a single namespace and have its APIs provided to many other namespaces. To improve usability, the `ClusterServiceVersion` is "copied" into those target namespaces (but no `Deployment` is created). Adding a simple filter bar to the list view makes it easier to find "real" `ClusterServiceVersion` vs "copied" ones. 

Also adds RBAC check for Operator-provided APIs and fixes `PackageManifest` rows with no channels.

### Screenshots

**`ClusterServiceVersion` list view (unfiltered):**
![screenshot_20190130_105850](https://user-images.githubusercontent.com/11700385/51994133-2793fd00-247e-11e9-9bb2-405922baebfe.png)

**`ClusterServiceVersion` list view (filtered):**
![screenshot_20190130_105934](https://user-images.githubusercontent.com/11700385/51994155-311d6500-247e-11e9-9356-ca78bc6746c8.png)

Addresses https://jira.coreos.com/browse/ALM-880
Addresses https://jira.coreos.com/browse/ALM-8887
Addresses https://jira.coreos.com/browse/ALM-861