### PR TITLE
Fix bug where .co-m-horizontal-nav__menu__secondary does not scroll i…

### DIFF
--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -25,12 +25,7 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: 15px;
   overflow-y: hidden;
   padding: 0;
   -webkit-overflow-scrolling: touch;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
 }
-
 
 .co-m-horizontal-nav__menu-item {
   font-size: 18px;


### PR DESCRIPTION
…n Chrome 70 Windows

Fixes https://jira.coreos.com/browse/CONSOLE-1048

It turns out in Windows that if the scrollbar isn't allowed to render, scrolling cannot occur.  

cc: @alecmerdler 