### PR TITLE
Improve e2e test reliability

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -158,3 +158,10 @@ export const waitForCount = (elementArrayFinder, expectedCount) => {
     return expectedCount >= actualCount;
   };
 };
+
+export const waitForNone = (elementArrayFinder) => {
+  return async() => {
+    const count = await elementArrayFinder.count();
+    return count === 0;
+  };
+};

--- a/frontend/integration-tests/tests/overview/overview.scenario.ts
+++ b/frontend/integration-tests/tests/overview/overview.scenario.ts
@@ -26,26 +26,25 @@ describe('Visiting Overview page', () => {
 
   overviewResources.forEach((kindModel) => {
     describe(kindModel.labelPlural, () => {
+      const resourceName = `${testName}-${kindModel.kind.toLowerCase()}`;
       beforeAll(async()=>{
-        await crudView.createNamespacedTestResource(kindModel);
+        await crudView.createNamespacedTestResource(kindModel, resourceName);
       });
 
       it(`displays a ${kindModel.id} in the project overview list`, async() => {
         await browser.wait(until.presenceOf(overviewView.projectOverview));
         await overviewView.itemsAreVisible();
-        await expect(overviewView.getProjectOverviewListItem(kindModel, testName).isPresent()).toBeTruthy();
+        await expect(overviewView.getProjectOverviewListItem(kindModel, resourceName).isPresent()).toBeTruthy();
       });
 
       it(`shows ${kindModel.id} details sidebar when item is clicked`, async() => {
-        const overviewListItem = overviewView.getProjectOverviewListItem(kindModel, testName);
+        const overviewListItem = overviewView.getProjectOverviewListItem(kindModel, resourceName);
         await expect(overviewView.detailsSidebar.isPresent()).toBeFalsy();
         await browser.wait(until.elementToBeClickable(overviewListItem));
         await overviewListItem.click();
         await overviewView.sidebarIsLoaded();
         await expect(overviewView.detailsSidebar.isDisplayed()).toBeTruthy();
-        const title = await overviewView.detailsSidebarTitle.getText();
-        await expect(title).toContain(kindModel.kind);
-        await expect(title).toContain(testName);
+        await expect(overviewView.detailsSidebarTitle.getText()).toContain(resourceName);
       });
     });
   });

--- a/frontend/integration-tests/tests/secrets.scenario.ts
+++ b/frontend/integration-tests/tests/secrets.scenario.ts
@@ -169,7 +169,7 @@ describe('Interacting with the create secret forms', () => {
 
     it('creates registry credentials image secret', async() => {
       await secretsView.createSecret(secretsView.createImageSecretLink, testName, credentialsImageSecretName, async() => {
-        await browser.wait(until.presenceOf(secretsView.addSecretEntryLink));
+        await browser.wait(until.and(crudView.untilNoLoadersPresent, until.presenceOf(secretsView.addSecretEntryLink)));
         await secretsView.addSecretEntryLink.click();
         await secretsView.imageSecretForm.each(async(el, index) => {
           await el.$('input[name=address]').sendKeys(address + index);
@@ -256,7 +256,7 @@ describe('Interacting with the create secret forms', () => {
 
     it('creates Key/Value secret', async() => {
       await secretsView.createSecret(secretsView.createGenericSecretLink, testName, keyValueSecretName, async() => {
-        await browser.wait(until.presenceOf(secretsView.addSecretEntryLink));
+        await browser.wait(until.and(crudView.untilNoLoadersPresent, until.presenceOf(secretsView.addSecretEntryLink)));
         await secretsView.addSecretEntryLink.click();
         await browser.wait(waitForCount($$('.co-file-dropzone__textarea'), 2));
         await secretsView.genericSecretForm.each(async(el, index) => {

--- a/frontend/integration-tests/views/create-role-binding.view.ts
+++ b/frontend/integration-tests/views/create-role-binding.view.ts
@@ -1,0 +1,16 @@
+import { $, browser, ExpectedConditions as until, element, by } from 'protractor';
+
+const selectFromDropdown = async(dropdownButton, text) => {
+  await dropdownButton.click();
+  await browser.wait(until.presenceOf($('.dropdown--text-filter')));
+  await browser.actions().sendKeys(text).perform();
+  await element(by.cssContainingText('li[role=option] a', text)).click();
+  await browser.wait(until.not(until.visibilityOf($('.dropdown-menu'))));
+};
+
+export const selectNamespace = (namespace) => selectFromDropdown($('#ns-dropdown'), namespace);
+export const selectRole = (role) => selectFromDropdown($('#role-dropdown'), role);
+export const getSelectedNamespace = () => $('#ns-dropdown .co-resource-link__resource-name').getText();
+export const getSelectedRole = () => $('#role-dropdown .co-resource-link__resource-name').getText();
+export const inputName = (name) => $('#role-binding-name').sendKeys(name);
+export const inputSubject = (subject) => $('#subject-name').sendKeys(subject);

--- a/frontend/integration-tests/views/environment.view.ts
+++ b/frontend/integration-tests/views/environment.view.ts
@@ -1,12 +1,12 @@
-import { $, $$, browser, ExpectedConditions as until } from 'protractor';
+import { $, $$, browser, ExpectedConditions as until, by, element } from 'protractor';
 
 const BROWSER_TIMEOUT = 15000;
 
 const inputs = $$('.form-control');
 export const rowsKey = $('[placeholder="name"]');
 export const rowsValue = $('[placeholder="value"]');
-export const deleteBtn = $('.pairs-list__delete-icon');
-export const saveBtn = $$('.btn-primary').filter(link => link.getText().then(text => text.startsWith('Save'))).first();
+export const deleteBtn = $$('.pairs-list__delete-icon').first();
+export const saveBtn = element(by.cssContainingText('.btn.btn-primary', 'Save'));
 
 export const isLoaded = () => browser.wait(until.presenceOf(inputs.first()), BROWSER_TIMEOUT);
 

--- a/frontend/integration-tests/views/namespace.view.ts
+++ b/frontend/integration-tests/views/namespace.view.ts
@@ -1,5 +1,5 @@
-import { $$ } from 'protractor';
+import { $, $$ } from 'protractor';
 
-export const namespaceSelector = $$('.co-namespace-selector');
-
+export const namespaceBar = $('.co-namespace-bar');
+export const namespaceSelector = $('.co-namespace-selector');
 export const selectedNamespace = $$('.co-namespace-selector .dropdown .btn-link .btn-link__title').first();

--- a/frontend/integration-tests/views/search.view.ts
+++ b/frontend/integration-tests/views/search.view.ts
@@ -1,11 +1,11 @@
-import { $, $$, browser, by, element, ExpectedConditions as until } from 'protractor';
+import { $, $$, browser, ExpectedConditions as until } from 'protractor';
 
 const BROWSER_TIMEOUT = 15000;
 
 export const dropdown = $('.co-type-selector .btn-dropdown');
 export const dropdownLinks = $$('.dropdown-menu a');
 export const labelFilter = $('.co-m-selector-input input');
-export const linkForType = type => element(by.partialLinkText(type));
+export const linkForType = type => $(`#${type}-link`);
 
 export const selectSearchType = async(objectType: string) => {
   const isPresent = await dropdownLinks.isPresent();

--- a/frontend/integration-tests/views/secrets.view.ts
+++ b/frontend/integration-tests/views/secrets.view.ts
@@ -26,7 +26,7 @@ export const createImageSecretLink = $('#image-link');
 export const createGenericSecretLink = $('#generic-link');
 
 export const addSecretEntryLink = $('.co-create-secret-form__link--add-entry');
-export const removeSecretEntryLink = $('.co-create-secret-form__link--remove-entry .btn-link');
+export const removeSecretEntryLink = $$('.co-create-secret-form__link--remove-entry .btn-link').first();
 export const imageSecretForm = $$('.co-create-image-secret__form');
 export const genericSecretForm = $$('.co-create-generic-secret__form');
 
@@ -69,10 +69,10 @@ export const checkSecret = async(ns: string, name: string, keyValuesToCheck: Obj
 
 export const editSecret = async(ns: string, name: string, updateForm: Function) => {
   await crudView.actionsDropdown.click();
-  await browser.wait(until.presenceOf(crudView.actionsDropdownMenu), 500);
+  await browser.wait(until.presenceOf(crudView.actionsDropdownMenu));
   await crudView.actionsDropdownMenu.element(by.linkText('Edit Secret')).click();
   await browser.wait(until.urlContains(`/k8s/ns/${ns}/secrets/${name}/edit`));
-  await browser.wait(until.presenceOf(secretNameInput));
+  await browser.wait(until.and(crudView.untilNoLoadersPresent, until.presenceOf(secretNameInput)));
   await updateForm();
   await saveButton.click();
   expect(crudView.errorMessage.isPresent()).toBe(false);

--- a/frontend/integration-tests/views/sidenav.view.ts
+++ b/frontend/integration-tests/views/sidenav.view.ts
@@ -2,7 +2,7 @@
 
 import { $$, by, browser, element, ExpectedConditions as until } from 'protractor';
 
-export const navSectionFor = (name: string) => element(by.cssContainingText('.pf-c-nav__item', name));
+export const navSectionFor = (name: string) => element(by.cssContainingText('.pf-c-nav > .pf-c-nav__list > .pf-c-nav__item', name));
 
 export const clickNavLink = (path: [string, string]) => browser.wait(until.visibilityOf(navSectionFor(path[0])))
   .then(() => navSectionFor(path[0]).click())

--- a/frontend/integration-tests/views/source-to-image.view.ts
+++ b/frontend/integration-tests/views/source-to-image.view.ts
@@ -1,10 +1,10 @@
-import { browser, $, element, by, ExpectedConditions as until, Key } from 'protractor';
+import { browser, $, element, by, ExpectedConditions as until } from 'protractor';
 
 import { appHost, testName } from '../protractor.conf';
 import * as crudView from './crud.view';
 
 export const createApplicationButton = element(by.buttonText('Create Application'));
-export const isLoaded = () => browser.wait(until.presenceOf($('.co-source-to-image-form')));
+export const isLoaded = () => browser.wait(until.and(crudView.untilNoLoadersPresent, until.presenceOf($('.co-source-to-image-form'))));
 export const nsDropdown = $('#namespace');
 export const nameInput = $('#name');
 export const trySampleButton = element(by.partialButtonText('Try Sample'));
@@ -17,5 +17,8 @@ export const visitOpenShiftImageStream = async(name: string) => {
 };
 
 export const selectTestProject = async() => {
-  await nsDropdown.click().then(() => browser.actions().sendKeys(testName, Key.ARROW_DOWN, Key.ENTER).perform());
+  await nsDropdown.click();
+  await browser.wait(until.visibilityOf($('.dropdown-menu')));
+  await element(by.cssContainingText('li[role=option] a', testName)).click();
+  await browser.wait(until.not(until.visibilityOf($('.dropdown-menu'))));
 };

--- a/frontend/integration-tests/views/yaml.view.ts
+++ b/frontend/integration-tests/views/yaml.view.ts
@@ -1,16 +1,21 @@
 /* eslint-disable no-undef, no-unused-vars */
-
 import { $, $$, by, Key, browser, ExpectedConditions as until } from 'protractor';
+import { waitForNone } from '../protractor.conf';
 
 export const saveButton = $('.yaml-editor__buttons').$('#save-changes');
 export const cancelButton = $('.yaml-editor__buttons').element(by.buttonText('Cancel'));
-
-export const isLoaded = () => browser.wait(until.visibilityOf(saveButton));
-
-export const editorInput = $$('textarea.ace_text-input').get(0);
+export const editorInput = $('textarea.ace_text-input');
 export const editorContent = $('div.ace_content');
+export const isLoaded = () => browser.wait(until.and(waitForNone($$('.co-m-loader')), until.visibilityOf(saveButton)));
+const insertLine = (line) => editorInput.sendKeys(line, Key.ENTER, Key.HOME);
+export const setContent = async(text: string) => {
+  const lines = text.split(/\n/g);
+  await editorContent.click();
+  await editorInput.sendKeys(Key.chord(Key.CONTROL, 'a'), Key.BACK_SPACE);
+  await editorInput.sendKeys(Key.chord(Key.COMMAND, 'a'), Key.BACK_SPACE); // For those OSX users...
 
-export const setContent = (text: string) => editorContent.click()
-  .then(() => editorInput.sendKeys(Key.chord(Key.CONTROL, 'a'), Key.BACK_SPACE))
-  .then(() => editorInput.sendKeys(Key.chord(Key.COMMAND, 'a'), Key.BACK_SPACE)) // For those OSX users...
-  .then(() => text.split(/\n/g).map(line => editorInput.sendKeys(line, Key.ENTER, Key.HOME)));
+  // Lines should be inserted sychronously and sequentially
+  for (const line of lines) {
+    await insertLine(line);
+  }
+};


### PR DESCRIPTION
Improves reliability of e2e tests. 

- Increase specificity on a few ambiguous element locators. 
- Add a condition to check for `.co-m-loader` elements on a page so that we can wait until they are all gone before proceeding.
- Fix a few possible async race conditions
- Use better names for created resources so that they can be more easily selected