### PR TITLE
Add margin spacing so event info doesn't run together before truncating

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -102,6 +102,9 @@ $color-dark-border: #ddd;
   display: flex;
   justify-content: space-between;
   white-space: pre;
+  > *:not(:first-child) {
+    margin-left: 8px;
+  }
 }
 
 .co-sysevent__source {


### PR DESCRIPTION
Within `.co-sysevent__subheader` target 2nd resource and timestamp 

**before**
<img width="669" alt="a" src="https://user-images.githubusercontent.com/1874151/52304051-b792e480-295f-11e9-8136-58cae9ed9c6c.png">

**after**
<img width="654" alt="b" src="https://user-images.githubusercontent.com/1874151/52304046-b497f400-295f-11e9-8317-ab9deb2e793d.png">

**before**
<img width="616" alt="b1" src="https://user-images.githubusercontent.com/1874151/52304062-c083b600-295f-11e9-8f77-2610f174239c.png">

**after**
<img width="622" alt="a1" src="https://user-images.githubusercontent.com/1874151/52304065-c4173d00-295f-11e9-86a7-fbb4524cee79.png">

