### PR TITLE
Error Handling for Creating Operator Custom Resources with Invalid Templates

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/create-crd-yaml.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/create-crd-yaml.spec.tsx
@@ -41,6 +41,16 @@ describe(CreateCRDYAML.displayName, () => {
     expect(createYAML.props().template).toEqual(safeDump(testResourceInstance));
   });
 
+  it('handles invalid JSON example object on annotation', () => {
+    const data = _.cloneDeep(testClusterServiceVersion);
+    data.metadata.annotations = {'alm-examples': 'invalid === true'};
+    wrapper = wrapper.setProps({ClusterServiceVersion: {loaded: true, data}} as any);
+
+    const createYAML = wrapper.find(Firehose).childAt(0).dive<CreateYAMLProps, {}>();
+
+    expect(createYAML.props().template).toEqual(null);
+  });
+
   it('does not render YAML editor component if ClusterServiceVersion has not loaded yet', () => {
     wrapper = wrapper.setProps({ClusterServiceVersion: {loaded: false}} as any);
 

--- a/frontend/public/components/operator-lifecycle-manager/create-crd-yaml.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/create-crd-yaml.tsx
@@ -19,10 +19,12 @@ export const CreateCRDYAML: React.SFC<CreateCRDYAMLProps> = (props) => {
 
   const Create = (createProps: {ClusterServiceVersion: {loaded: boolean, data: ClusterServiceVersionKind}}) => {
     if (createProps.ClusterServiceVersion.loaded && createProps.ClusterServiceVersion.data) {
-      const templates = _.get(createProps.ClusterServiceVersion.data.metadata.annotations, annotationKey, '[]');
-      const templateObj = (JSON.parse(templates) as K8sResourceKind[])
-        .find(obj => referenceFor(obj) === props.match.params.plural);
-      const template = templateObj ? _.attempt(() => safeDump(templateObj)) : null;
+      const templatesJSON = _.get(createProps.ClusterServiceVersion.data.metadata.annotations, annotationKey, '[]');
+      const template = _.attempt(() => safeDump((JSON.parse(templatesJSON) as K8sResourceKind[]).find(obj => referenceFor(obj) === props.match.params.plural)));
+      if (_.isError(template)) {
+        // eslint-disable-next-line no-console
+        console.error('Error parsing example JSON from annotation. Falling back to default.');
+      }
 
       return <CreateYAML {...props as any} template={!_.isError(template) ? template : null} />;
     }


### PR DESCRIPTION
### Description

Wraps `JSON.parse()` in error handling and passes `null` for the template if the annotation is invalid.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1671125