### PR TITLE
Fix Cluster Settings > Cluster Operators sort by status

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -2,49 +2,30 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-import { K8sResourceKind, K8sResourceKindReference, referenceForModel } from '../../module/k8s';
 import { ClusterOperatorModel } from '../../models';
-import { ColHead, DetailsPage, List, ListHeader, ListPage } from '../factory';
 import {
+  ColHead,
+  DetailsPage,
+  List,
+  ListHeader,
+  ListPage,
+} from '../factory';
+import {
+  getClusterOperatorStatus,
+  getStatusAndMessage,
+  K8sResourceKind,
+  K8sResourceKindReference,
+  OperatorStatus,
+  referenceForModel,
+} from '../../module/k8s';
+import {
+  navFactory,
   ResourceLink,
   ResourceSummary,
   SectionHeading,
-  navFactory,
 } from '../utils';
 
-enum OperatorStatus {
-  Available = 'Available',
-  Updating = 'Updating',
-  Failing = 'Failing',
-  Unknown = 'Unknown',
-}
-
 export const clusterOperatorReference: K8sResourceKindReference = referenceForModel(ClusterOperatorModel);
-
-const getStatusAndMessage = (operator: K8sResourceKind) => {
-  const conditions = _.get(operator, 'status.conditions');
-  const failing: any = _.find(conditions, { type: 'Failing', status: 'True' });
-  if (failing) {
-    return { status: OperatorStatus.Failing, message: failing.message };
-  }
-
-  const progressing: any = _.find(conditions, { type: 'Progressing', status: 'True' });
-  if (progressing) {
-    return { status: OperatorStatus.Updating, message: progressing.message };
-  }
-
-  const available: any = _.find(conditions, { type: 'Available', status: 'True' });
-  if (available) {
-    return { status: OperatorStatus.Available, message: available.message };
-  }
-
-  return { status: OperatorStatus.Unknown, message: '' };
-};
-
-export const getClusterOperatorStatus = (operator: K8sResourceKind) => {
-  const { status } = getStatusAndMessage(operator);
-  return status;
-};
 
 const getIconClass = (status: OperatorStatus) => {
   return {

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -14,13 +14,17 @@ import {
   WindowScroller,
 } from 'react-virtualized';
 
-import { alertState, alertStateOrder, silenceState, silenceStateOrder } from '../../monitoring';
 import { UIActions } from '../../ui/ui-actions';
 import { ingressValidHosts } from '../ingress';
 import { routeStatus } from '../routes';
-import { getClusterOperatorStatus } from '../cluster-settings/cluster-operator';
 import { secretTypeFilterReducer } from '../secret';
 import { bindingType, roleType } from '../RBAC';
+import {
+  alertState,
+  alertStateOrder,
+  silenceState,
+  silenceStateOrder,
+} from '../../monitoring';
 import {
   containerLinuxUpdateOperator,
   EmptyBox,
@@ -43,6 +47,7 @@ import {
   podReadiness,
   serviceCatalogStatus,
   serviceClassDisplayName,
+  getClusterOperatorStatus,
 } from '../../module/k8s';
 
 const fuzzyCaseInsensitive = (a, b) => fuzzy(_.toLower(a), _.toLower(b));
@@ -230,6 +235,7 @@ const sorts = {
   serviceClassDisplayName,
   silenceStateOrder,
   string: val => JSON.stringify(val),
+  getClusterOperatorStatus,
 };
 
 export class ColHead extends React.Component<ColHeadProps> {
@@ -443,9 +449,7 @@ export const List = connect(stateToProps, {sortList: UIActions.sortList})(
     render() {
       const {currentSortField, currentSortFunc, currentSortOrder, expand, Header, label, listId, mock, Row, sortList} = this.props;
       const componentProps: any = _.pick(this.props, ['data', 'filters', 'selected', 'match', 'kindObj']);
-
       const ListRows = this.props.virtualize ? VirtualRows : Rows;
-
       const children = <React.Fragment>
         <Header
           {...componentProps}

--- a/frontend/public/module/k8s/cluster-operator.ts
+++ b/frontend/public/module/k8s/cluster-operator.ts
@@ -1,0 +1,35 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as _ from 'lodash-es';
+import { K8sResourceKind } from '.';
+
+export enum OperatorStatus {
+  Available = 'Available',
+  Updating = 'Updating',
+  Failing = 'Failing',
+  Unknown = 'Unknown',
+}
+
+export const getStatusAndMessage = (operator: K8sResourceKind) => {
+  const conditions = _.get(operator, 'status.conditions');
+  const failing: any = _.find(conditions, { type: 'Failing', status: 'True' });
+  if (failing) {
+    return { status: OperatorStatus.Failing, message: failing.message };
+  }
+
+  const progressing: any = _.find(conditions, { type: 'Progressing', status: 'True' });
+  if (progressing) {
+    return { status: OperatorStatus.Updating, message: progressing.message };
+  }
+
+  const available: any = _.find(conditions, { type: 'Available', status: 'True' });
+  if (available) {
+    return { status: OperatorStatus.Available, message: available.message };
+  }
+
+  return { status: OperatorStatus.Unknown, message: '' };
+};
+
+export const getClusterOperatorStatus = (operator: K8sResourceKind) => {
+  const { status } = getStatusAndMessage(operator);
+  return status;
+};

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -10,6 +10,7 @@ export * from './autocomplete';
 export * from './get-resources';
 export * from './k8s-models';
 export * from './label-selector';
+export * from './cluster-operator';
 
 export type OwnerReference = {
   name: string;


### PR DESCRIPTION
Fix a bug which caused the sort functionality not to work for the status column on the Cluster Operators tab of the Cluster Settings page.

Fixes https://jira.coreos.com/browse/CONSOLE-1263