### PR TITLE
copy ci test output files to artifacts dir on script exit

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -5,6 +5,13 @@ set -exuo pipefail
 ARTIFACT_DIR=/tmp/artifacts
 export ARTIFACT_DIR
 
+function copyArtifacts {
+  echo "Copying artifacts from $(pwd)..."
+  cp -rv ./gui_test_screenshots "${ARTIFACT_DIR}/gui_test_screenshots"
+}
+
+trap copyArtifacts EXIT
+
 ./build.sh
 
 oc login -u kubeadmin -p $(cat "${ARTIFACT_DIR}/installer/auth/kubeadmin-password")
@@ -14,6 +21,4 @@ source ./contrib/oc-environment.sh
 kubectl create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/okd/manifests/0.8.0/0000_30_06-rh-operators.configmap.yaml
 kubectl create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/okd/manifests/0.8.0/0000_30_09-rh-operators.catalogsource.yaml
 
-./test-gui.sh e2e
-
-cp -rv ./frontend/gui_test_screenshots "${ARTIFACT_DIR}/gui_test_screenshots"
+. ./test-gui.sh e2e

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -7,7 +7,7 @@ export ARTIFACT_DIR
 
 function copyArtifacts {
   echo "Copying artifacts from $(pwd)..."
-  cp -rv ./gui_test_screenshots "${ARTIFACT_DIR}/gui_test_screenshots"
+  cp -rv ./frontend/gui_test_screenshots "${ARTIFACT_DIR}/gui_test_screenshots"
 }
 
 trap copyArtifacts EXIT
@@ -21,4 +21,4 @@ source ./contrib/oc-environment.sh
 kubectl create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/okd/manifests/0.8.0/0000_30_06-rh-operators.configmap.yaml
 kubectl create -f https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/okd/manifests/0.8.0/0000_30_09-rh-operators.catalogsource.yaml
 
-. ./test-gui.sh e2e
+./test-gui.sh e2e


### PR DESCRIPTION
use trap to copy test files to artifacts dir on exit of script for e2e tests