### PR TITLE
Fix when cluster-settings history is undefined

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -132,7 +132,7 @@ const DesiredVersion: React.SFC<DesiredVersionProps> = ({cv}) => {
 };
 
 const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = ({obj: cv, autoscalers}) => {
-  const { history, conditions } = cv.status;
+  const { history = [], conditions = [] } = cv.status;
   const status = getClusterUpdateStatus(cv);
   const retrievedUpdatesFailedCondition = _.find(conditions, { type: 'RetrievedUpdates', status: 'False' });
   const isFailingCondition = _.find(conditions, { type: 'Failing', status: 'True' });
@@ -186,27 +186,29 @@ const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = (
     </div>
     <div className="co-m-pane__body">
       <SectionHeading text="Update History" />
-      <div className="co-table-container">
-        <table className="table">
-          <thead>
-            <tr>
-              <th>Version</th>
-              <th>State</th>
-              <th>Started</th>
-              <th>Completed</th>
-            </tr>
-          </thead>
-          <tbody>
-            {_.isEmpty(history) && <EmptyBox label="History" />}
-            {history.map((update, i) => <tr key={i}>
-              <td className="co-break-all">{update.version || '-'}</td>
-              <td>{update.state || '-'}</td>
-              <td><Timestamp timestamp={update.startedTime} /></td>
-              <td>{update.completionTime ? <Timestamp timestamp={update.completionTime} /> : '-'}</td>
-            </tr>)}
-          </tbody>
-        </table>
-      </div>
+      {_.isEmpty(history)
+        ? <EmptyBox label="History" />
+        : <div className="co-table-container">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Version</th>
+                <th>State</th>
+                <th>Started</th>
+                <th>Completed</th>
+              </tr>
+            </thead>
+            <tbody>
+              {_.map(history, (update, i) => <tr key={i}>
+                <td className="co-break-all">{update.version || '-'}</td>
+                <td>{update.state || '-'}</td>
+                <td><Timestamp timestamp={update.startedTime} /></td>
+                <td>{update.completionTime ? <Timestamp timestamp={update.completionTime} /> : '-'}</td>
+              </tr>)}
+            </tbody>
+          </table>
+        </div>
+      }
     </div>
   </React.Fragment>;
 };


### PR DESCRIPTION
In the latest master found an issue when the cluster-version status is not containing `history` field. In that case it will be destructed as `undefined`. So adding default value for both destructed status fields.

```
cluster-settings.tsx:201 Uncaught TypeError: Cannot read property 'map' of undefined
    at ClusterVersionDetailsTable (cluster-settings.tsx:201)
    at mountIndeterminateComponent (react-dom.development.js:8562)
```

After fixing that found another issue where the `<tbody>` tag can't contain `<div>` tag inside it, which is part of the `EmptyBox` component so I've restructured it:
```
warning.js:33 Warning: validateDOMNesting(...): <div> cannot appear as a child of <tbody>.
    in div (created by Box)
    in Box (created by EmptyBox)
    in EmptyBox (created by ClusterVersionDetailsTable)
    in tbody (created by ClusterVersionDetailsTable)
    ...
```

/assign @TheRealJon 