### PR TITLE
Monitoring: The "DeadMansSwitch" alert has been renamed to "Watchdog"

### DIFF
--- a/frontend/public/components/cluster-overview.jsx
+++ b/frontend/public/components/cluster-overview.jsx
@@ -170,7 +170,7 @@ const permissionedLoader = () => {
   }
 
   // Show events list if user lacks permission to view graphs.
-  const q = 'sum(ALERTS{alertstate="firing", alertname!="DeadMansSwitch"})';
+  const q = 'sum(ALERTS{alertstate="firing", alertname!="Watchdog"})';
   return coFetchJSON(`${prometheusBasePath}/api/v1/query?query=${encodeURIComponent(q)}`)
     .then(
       () => AllGraphs,

--- a/frontend/public/components/graphs/health.jsx
+++ b/frontend/public/components/graphs/health.jsx
@@ -30,7 +30,7 @@ const AlertsFiring = ({namespace}) => (
     title="Alerts Firing"
     name="Alerts"
     namespace={namespace}
-    query={`sum(ALERTS{alertstate="firing", alertname!="DeadMansSwitch" ${namespace ? `, namespace="${namespace}"` : ''}})`}
+    query={`sum(ALERTS{alertstate="firing", alertname!="Watchdog" ${namespace ? `, namespace="${namespace}"` : ''}})`}
     to="/monitoring"
   />
 );


### PR DESCRIPTION
This fixes the Cluster Status page's "Alerts Firing" count to exclude the Watchdog alert.

FYI @brancz