### PR TITLE
Monitoring: Fix node detail page's Memory Usage graph

### DIFF
--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -118,7 +118,7 @@ const NodeGraphs = requirePrometheus(({node}) => {
   return <React.Fragment>
     <div className="row">
       <div className="col-md-4">
-        <Line title="Memory Usage" query={ipQuery && `node_memory_Active${ipQuery}`} units="binaryBytes" limit={memoryLimit} />
+        <Line title="Memory Usage" query={ipQuery && `node_memory_Active_bytes${ipQuery}`} units="binaryBytes" limit={memoryLimit} />
       </div>
       <div className="col-md-4">
         <Line title="CPU Usage" query={ipQuery && `instance:node_cpu:rate:sum${ipQuery}`} units="numeric" limit={integerLimit(node.status.allocatable.cpu)} />


### PR DESCRIPTION
This graph was not populated with any data because it was using the
wrong metric name. `node_memory_Active_bytes` appears to be the correct
metric.

FYI @juzhao, @mxinden 

### Before 
![screenshot-2](https://user-images.githubusercontent.com/460802/52831464-17d01600-3118-11e9-81b0-3fa37d9d1327.png)

### After
![screenshot-1](https://user-images.githubusercontent.com/460802/52831467-1acb0680-3118-11e9-9c96-b97bad1d6b13.png)
