### PR TITLE
Edit secret page returns to previous page when cancelling

### DIFF
--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -2,11 +2,9 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
-import { Link } from 'react-router-dom';
 
 import { k8sCreate, k8sUpdate, K8sResourceKind, referenceFor } from '../../module/k8s';
 import { ButtonBar, Firehose, history, StatusBox, LoadingBox, Dropdown, resourceObjPath } from '../utils';
-import { formatNamespacedRouteForResource } from '../../ui/ui-actions';
 import { AsyncComponent } from '../utils/async';
 import { SecretModel } from '../../models';
 import { WebHookSecretKey } from '../secret';
@@ -157,6 +155,7 @@ const withSecretForm = (SubForm) => class SecretFormComponent extends React.Comp
   }
   render() {
     const { secretTypeAbstraction } = this.state;
+    const { onCancel = history.goBack } = this.props;
     const title = `${this.props.titleVerb} ${secretDisplayType(secretTypeAbstraction)} Secret`;
     return <div className="co-m-pane__body">
       <Helmet>
@@ -191,7 +190,7 @@ const withSecretForm = (SubForm) => class SecretFormComponent extends React.Comp
         />
         <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress}>
           <button type="submit" disabled={this.state.disableForm} className="btn btn-primary" id="save-changes">{this.props.saveButtonText || 'Create'}</button>
-          <Link to={formatNamespacedRouteForResource('secrets')} className="btn btn-default" id="cancel">Cancel</Link>
+          <button type="button" className="btn btn-default" id="cancel" onClick={onCancel}>Cancel</button>
         </ButtonBar>
       </form>
     </div>;
@@ -930,6 +929,7 @@ export type BaseEditSecretProps_ = {
   secretTypeAbstraction?: SecretTypeAbstraction;
   saveButtonText?: string;
   explanation: string;
+  onCancel?: () => null;
 };
 
 export type BasicAuthSubformProps = {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1678159

Edit secret page "Cancel" button is no longer hardcoded to the secrets list page. The component now accepts an optional `onCancel` callback as a prop, which defaults to `history.goBack`.