### PR TITLE
Bug 1677545 - Correctly handle last chunk on incremental load

### DIFF
--- a/frontend/__tests__/module/k8s/k8s-actions.spec.ts
+++ b/frontend/__tests__/module/k8s/k8s-actions.spec.ts
@@ -2,10 +2,11 @@
 
 import Spy = jasmine.Spy;
 import { Map as ImmutableMap } from 'immutable';
+import * as _ from 'lodash-es';
 
 import k8sActions, { types } from '../../../public/module/k8s/k8s-actions';
 import * as k8sResource from '../../../public/module/k8s/resource';
-import { K8sResourceKind } from '../../../public/module/k8s';
+import { K8sResourceKind, K8sKind } from '../../../public/module/k8s';
 import { PodModel, APIServiceModel } from '../../../public/models';
 import { testResourceInstance } from '../../../__mocks__/k8sResourcesMocks';
 import * as coFetch from '../../../public/co-fetch';
@@ -13,11 +14,31 @@ import * as coFetch from '../../../public/co-fetch';
 describe('watchAPIServices', () => {
   const {watchAPIServices} = k8sActions;
 
-  it('does nothing if already watching `APIServices`', () => {
+  const spyAndExpect = (spy: Spy) => (returnValue: any) => new Promise(resolve => spy.and.callFake((...args) => {
+    resolve(args);
+    return returnValue;
+  }));
+
+  it('does nothing if already watching `APIServices`', (done) => {
     const getState = jasmine.createSpy('getState').and.returnValue({k8s: ImmutableMap().set('apiservices', [])});
-    const dispatch = jasmine.createSpy('dispatch').and.callFake(() => {
-      fail('Should not call `dispatch`');
+    const dispatch = jasmine.createSpy('dispatch').and.callFake((action) => {
+      fail(`Should not dispatch action: ${JSON.stringify(action)}`);
     });
+
+    watchAPIServices()(dispatch, getState);
+    done();
+  });
+
+  it('dispatches `getResourcesInFlight` action before listing `APIServices`', (done) => {
+    const getState = jasmine.createSpy('getState').and.returnValue({k8s: ImmutableMap()});
+    const dispatch = jasmine.createSpy('dispatch');
+    spyOn(k8sActions, 'watchK8sList').and.returnValue({});
+
+    spyAndExpect(spyOn(k8sResource, 'k8sList'))(Promise.resolve({}))
+      .then(() => {
+        expect(dispatch.calls.argsFor(0)[0].type).toEqual(types.getResourcesInFlight);
+        done();
+      });
 
     watchAPIServices()(dispatch, getState);
   });
@@ -25,12 +46,13 @@ describe('watchAPIServices', () => {
   it('attempts to list `APIServices`', (done) => {
     const getState = jasmine.createSpy('getState').and.returnValue({k8s: ImmutableMap()});
     const dispatch = jasmine.createSpy('dispatch');
-    spyOn(k8sActions, 'watchK8sList').and.returnValue({});
+    spyOn(k8sActions, 'watchK8sList');
 
-    spyOn(k8sResource, 'k8sList').and.callFake((model) => new Promise(() => {
-      expect(model).toEqual(APIServiceModel);
-      done();
-    }));
+    spyAndExpect(spyOn(k8sResource, 'k8sList'))(Promise.resolve({}))
+      .then(([model]) => {
+        expect(model).toEqual(APIServiceModel);
+        done();
+      });
 
     watchAPIServices()(dispatch, getState);
   });
@@ -38,12 +60,13 @@ describe('watchAPIServices', () => {
   it('falls back to polling Kubernetes `/apis` endpoint if cannot list `APIServices`', (done) => {
     const getState = jasmine.createSpy('getState').and.returnValue({k8s: ImmutableMap()});
     const dispatch = jasmine.createSpy('dispatch');
-    spyOn(k8sActions, 'watchK8sList').and.returnValue({});
     spyOn(k8sResource, 'k8sList').and.returnValue(Promise.reject());
-    spyOn(coFetch, 'coFetchJSON').and.callFake((path) => {
-      expect(path).toEqual('api/kubernetes/apis');
-      done();
-    });
+
+    spyAndExpect(spyOn(coFetch, 'coFetchJSON'))(Promise.resolve({groups: []}))
+      .then(([path]) => {
+        expect(path).toEqual('api/kubernetes/apis');
+        done();
+      });
 
     watchAPIServices()(dispatch, getState);
   });
@@ -51,67 +74,71 @@ describe('watchAPIServices', () => {
 
 describe(types.watchK8sList, () => {
   const {watchK8sList} = k8sActions;
-  const id = 'some-redux-id';
-  let k8sList: Spy;
-  let websocket: {[method: string]: Spy};
+  let getState: Spy;
   let resourceList: {items: K8sResourceKind[], metadata: {resourceVersion: string, continue?: string}, kind: string, apiVersion: string};
+  let model: K8sKind;
 
   beforeEach(() => {
-    websocket = {
-      onclose: jasmine.createSpy('onclose'),
-      ondestroy: jasmine.createSpy('ondestroy'),
-      onbulkmessage: jasmine.createSpy('onbulkmessage'),
-    };
-    websocket.onclose.and.returnValue(websocket);
-    websocket.ondestroy.and.returnValue(websocket);
-    websocket.onbulkmessage.and.returnValue(websocket);
-
+    getState = jasmine.createSpy('getState').and.returnValue({UI: ImmutableMap()});
+    model = _.cloneDeep({...PodModel, verbs: ['list', 'get']});
     resourceList = {
       apiVersion: testResourceInstance.apiVersion,
       kind: `${testResourceInstance.kind}List`,
       items: new Array(300).fill(testResourceInstance),
-      metadata: {resourceVersion: '10000000'},
+      metadata: {resourceVersion: '0'},
     };
-
-    k8sList = spyOn(k8sResource, 'k8sList').and.returnValue(Promise.resolve({}));
-    spyOn(k8sResource, 'k8sWatch').and.returnValue(websocket);
   });
 
-  it('incrementally fetches lists until `continue` token is no longer returned in response', (done) => {
-    k8sList.and.callFake((k8sKind, params, raw) => {
+  it('dispatches `loaded` action only once after first data is received', (done) => {
+    const k8sList = spyOn(k8sResource, 'k8sList').and.returnValue(Promise.resolve({...resourceList, items: new Array(10).fill(testResourceInstance)}));
+
+    const dispatch = jasmine.createSpy('dispatch').and.callFake((action) => {
+      if (action.type === types.loaded) {
+        expect(k8sList.calls.count()).toEqual(1);
+        done();
+      } else if (action.type !== types.watchK8sList) {
+        fail(`Action other than 'loaded' was dispatched: ${JSON.stringify(action)}`);
+      }
+    });
+
+    watchK8sList('some-redux-id', {}, model)(dispatch, getState);
+  });
+
+  it('incrementally fetches list until `continue` token is no longer returned in response', (done) => {
+    const k8sList = spyOn(k8sResource, 'k8sList').and.callFake((k8sKind, params, raw) => {
       expect(params.limit).toEqual(250);
-      if (k8sList.calls.count() > 1) {
+
+      if (k8sList.calls.count() === 1 || k8sList.calls.count() === 11) {
+        expect(params.continue).toBeUndefined();
+      } else {
         expect(params.continue).toEqual('toNextPage');
       }
-
       resourceList.metadata.resourceVersion = (parseInt(resourceList.metadata.resourceVersion, 10) + 1).toString();
-      resourceList.metadata.continue = parseInt(resourceList.metadata.resourceVersion, 10) > 10000005 ? null : 'toNextPage';
+      resourceList.metadata.continue = parseInt(resourceList.metadata.resourceVersion, 10) < 10 ? 'toNextPage' : undefined;
+
       return resourceList;
     });
 
+    let returnedItems = 0;
     const dispatch = jasmine.createSpy('dispatch').and.callFake((action) => {
-      switch (action.type) {
-        case types.watchK8sList:
-          expect(action.id).toEqual(id);
-          expect(action.query).toEqual({});
-          break;
-        case types.bulkAddToList:
-          expect(action.k8sObjects).toEqual(resourceList.items);
-          expect(dispatch.calls.allArgs().filter(args => args[0].type === types.bulkAddToList).length).toEqual(k8sList.calls.count());
-          break;
-        case types.errored:
-          fail(action.k8sObjects);
-          break;
-        case types.loaded:
-          expect(k8sList.calls.count()).toEqual(1);
+      if (action.type === types.bulkAddToList) {
+        const bulkAddToListCalls = dispatch.calls.allArgs().filter(args => args[0].type === types.bulkAddToList);
+
+        expect(action.k8sObjects).toEqual(resourceList.items);
+        expect(bulkAddToListCalls.length).toEqual(k8sList.calls.count() - 1);
+
+        returnedItems = returnedItems + action.k8sObjects.length;
+
+        if (bulkAddToListCalls.length === 9) {
+          expect(returnedItems).toEqual(resourceList.items.length * bulkAddToListCalls.length);
           done();
-          break;
-        default:
-          break;
+        }
+      } else if (action.type === types.errored) {
+        fail(action.k8sObjects);
       }
     });
 
-    watchK8sList(id, {}, PodModel)(dispatch, jasmine.createSpy('getState'));
+    watchK8sList('another-redux-id', {}, model)(dispatch, getState);
   });
 
   xit('stops incrementally fetching if `stopK8sWatch` action is dispatched', () => {

--- a/frontend/public/module/k8s/k8s-actions.ts
+++ b/frontend/public/module/k8s/k8s-actions.ts
@@ -57,9 +57,9 @@ const actions = {
 
     k8sList(APIServiceModel, {})
       .then(() => dispatch(actions.watchK8sList(makeReduxID(APIServiceModel, {}), {}, APIServiceModel, actions.getResources)))
-      .catch(() => {
+      .catch((e) => {
         const poller = () => coFetchJSON('api/kubernetes/apis').then(d => {
-          if (d.length !== getState().k8s.getIn(['RESOURCES', apiGroups], 0)) {
+          if (d.groups.length !== getState().k8s.getIn(['RESOURCES', apiGroups], 0)) {
             dispatch(actions.getResources());
           }
           dispatch({type: types.setAPIGroups, value: d.groups.length});

--- a/frontend/public/module/k8s/k8s-actions.ts
+++ b/frontend/public/module/k8s/k8s-actions.ts
@@ -165,10 +165,11 @@ const actions = {
 
       if (!continueToken) {
         [actions.loaded, extraAction].forEach(f => f && dispatch(f(id, response.items)));
+      } else {
+        dispatch(actions.bulkAddToList(id, response.items));
       }
 
       if (response.metadata.continue) {
-        dispatch(actions.bulkAddToList(id, response.items));
         return incrementallyLoad(response.metadata.continue);
       }
       return response.metadata.resourceVersion;


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1677545

We weren't calling `bulkAddToList` on the last chunk of data since `response.metadata.continue` wasn't defined.

@alecmerdler Let me know if this looks right. I'd your input on how to change k8s-actions-spec.ts to check this.

/cc @alecmerdler @rhamilto 