### PR TITLE
Make overview sidebar resource name a link

### DIFF
--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -16,8 +16,7 @@
     line-height: 21px;
     margin-right: 7px;
     min-width: 24px;
-    padding-left: 7px;
-    padding-right: 7px;
+    padding: 0 7px;
   }
 }
 

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -201,7 +201,7 @@ const AlertsDetailsPage = withFallback(connect(alertStateToProps)((props: Alerts
     <StatusBox data={alert} label={AlertResource.label} loaded={loaded} loadError={loadError}>
       <div className="co-m-nav-title co-m-nav-title--detail">
         <h1 className="co-m-pane__heading">
-          <div className="co-m-pane__name"><MonitoringResourceIcon className="co-m-resource-icon--lg pull-left" resource={AlertResource} />{alertname}</div>
+          <div className="co-m-pane__name"><MonitoringResourceIcon className="co-m-resource-icon--lg" resource={AlertResource} />{alertname}</div>
           {(state === AlertStates.Firing || state === AlertStates.Pending) && <div className="co-actions">
             <ActionsMenu actions={[silenceAlert(alert)]} />
           </div>}
@@ -323,7 +323,7 @@ const AlertRulesDetailsPage = withFallback(connect(ruleStateToProps)((props: Ale
     <StatusBox data={rule} label={AlertRuleResource.label} loaded={loaded} loadError={loadError}>
       <div className="co-m-nav-title co-m-nav-title--detail">
         <h1 className="co-m-pane__heading">
-          <div className="co-m-pane__name"><MonitoringResourceIcon className="co-m-resource-icon--lg pull-left" resource={AlertRuleResource} />{name}</div>
+          <div className="co-m-pane__name"><MonitoringResourceIcon className="co-m-resource-icon--lg" resource={AlertRuleResource} />{name}</div>
         </h1>
       </div>
       <div className="co-m-pane__body">
@@ -412,7 +412,7 @@ const SilencesDetailsPage = withFallback(connect(silenceParamToProps)((props: Si
     <StatusBox data={silence} label={SilenceResource.label} loaded={loaded} loadError={loadError}>
       <div className="co-m-nav-title co-m-nav-title--detail">
         <h1 className="co-m-pane__heading">
-          <div className="co-m-pane__name"><MonitoringResourceIcon className="co-m-resource-icon--lg pull-left" resource={SilenceResource} />{name}</div>
+          <div className="co-m-pane__name"><MonitoringResourceIcon className="co-m-resource-icon--lg" resource={SilenceResource} />{name}</div>
           <SilenceActionsMenu silence={silence} />
         </h1>
       </div>

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -3,7 +3,7 @@ import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
 
-import { ActionsMenu, ResourceIcon, KebabAction } from './index';
+import { ActionsMenu, ResourceIcon, KebabAction, resourcePath } from './index';
 import { ClusterServiceVersionLogo } from '../operator-lifecycle-manager';
 import { connectToModel } from '../../kinds';
 import { ClusterServiceVersionModel } from '../../models';
@@ -48,7 +48,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
 
   const logo = isCSV
     ? csvLogo()
-    : <div className="co-m-pane__name">{ kind && <ResourceIcon kind={kind} className="co-m-resource-icon--lg pull-left" /> } <span id="resource-title">{resourceTitle}</span></div>;
+    : <div className="co-m-pane__name">{ kind && <ResourceIcon kind={kind} className="co-m-resource-icon--lg" /> } <span id="resource-title">{resourceTitle}</span></div>;
   const hasButtonActions = !_.isEmpty(buttonActions);
   const hasMenuActions = !_.isEmpty(menuActions);
   const showActions = (hasButtonActions || hasMenuActions) && !_.isEmpty(data) && !_.get(data, 'deletionTimestamp');
@@ -73,8 +73,10 @@ export const SidebarSectionHeading: React.SFC<SidebarSectionHeadingProps> = ({te
 export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = ({kindObj, actions, resource}) => <div className="overview__sidebar-pane-head resource-overview__heading">
   <h1 className="co-m-pane__heading">
     <div className="co-m-pane__name">
-      <ResourceIcon className="co-m-resource-icon--lg pull-left" kind={kindObj.kind} />
-      {resource.metadata.name}
+      <ResourceIcon className="co-m-resource-icon--lg" kind={kindObj.kind} />
+      <Link to={resourcePath(resource.kind, resource.metadata.name, resource.metadata.namespace)} className="co-resource-link__resource-name">
+        {resource.metadata.name}
+      </Link>
     </div>
     <div className="co-actions">
       <ActionsMenu actions={actions.map(a => a(kindObj, resource))} />

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -101,6 +101,8 @@
 
 .co-m-pane__name {
   @include co-break-word;
+  align-items: baseline;
+  display: flex;
   flex: 1;
   margin-right: 10px;
   min-width: 0; // necessary for wrapping since its a flex child


### PR DESCRIPTION
- css adjustments to parent node `.co-m-pane__name` and `.co-m-resource-icon--lg` so that .pull-left class isn't needed.

Issue: https://jira.coreos.com/browse/CONSOLE-1271

Screenshot
<img width="1138" alt="screen shot 2019-02-28 at 10 54 15 am" src="https://user-images.githubusercontent.com/1874151/53579251-3afeba80-3b47-11e9-8a98-33cc479a74ca.png">

cc @serenamarie125 