### PR TITLE
Normalize display of <ResourceIcon> across browsers, platforms

### DIFF
--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -1,29 +1,23 @@
-$height: 18px;
-
 .co-m-resource-icon {
   background-color: $color-container-dark;
-  border-radius: 10px;
+  border-radius: 20px;
   color: #fff;
   display: inline-block;
   font-size: $font-size-base - 1;
-  font-weight: normal;
-  height: $height;
-  line-height: $height;
+  font-weight: 300;
+  line-height: 16px;
   margin-right: 4px;
-  min-width: $height;
-  padding: 0 4px;
+  min-width: 18px;
+  padding: 2px 4px 1px;
   text-align: center;
+
   &--lg {
-    border-radius: 12px;
-    font-size: 16px;
-    height: 24px;
-    line-height: 24px;
-    margin-left: 0;
+    font-size: ($font-size-base + 1);
+    line-height: 21px;
     margin-right: 7px;
     min-width: 24px;
-    padding: 0 7px;
-    position: relative;
-    top: 2px;
+    padding-left: 7px;
+    padding-right: 7px;
   }
 }
 
@@ -104,18 +98,6 @@ $height: 18px;
 
 .co-m-resource-ingress {
   background-color: $color-ingress-dark;
-}
-
-.co-m-resource-icon--all {
-  background-color: black;
-}
-
-.co-m-resource-icon--align-left {
-  margin-left: 0;
-}
-
-.co-m-resource-icon--flex-child {
-  margin-right: 7px;
 }
 
 .co-resource-link {

--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -67,9 +67,6 @@ $color-dark-border: #ddd;
   display: flex;
   justify-content: flex-start;
   flex-wrap: wrap;
-  .co-m-resource-icon {
-    margin-left: 0;
-  }
 }
 
 .co-sysevent--transition {

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -26,7 +26,7 @@ const getTLSCert = (ingress) => {
   const certs = _.map(ingress.spec.tls, 'secretName');
 
   return <div>
-    <ResourceIcon kind="Secret" className="co-m-resource-icon--align-left" />
+    <ResourceIcon kind="Secret" />
     <span>{certs.join(', ')}</span>
   </div>;
 };

--- a/frontend/public/components/modals/configure-ns-pull-secret-modal.jsx
+++ b/frontend/public/components/modals/configure-ns-pull-secret-modal.jsx
@@ -183,7 +183,7 @@ class ConfigureNamespacePullSecret extends PromiseComponent {
             <label>Namespace</label>
           </div>
           <div className="col-xs-9">
-            <ResourceIcon kind="Namespace" className="co-m-resource-icon--align-left" /> &nbsp;{namespace.metadata.name}
+            <ResourceIcon kind="Namespace" /> &nbsp;{namespace.metadata.name}
           </div>
         </div>
 
@@ -193,7 +193,7 @@ class ConfigureNamespacePullSecret extends PromiseComponent {
           </div>
           { pullSecret ?
             <div className="col-xs-9">
-              <ResourceIcon kind="Secret" className="co-m-resource-icon--align-left" />
+              <ResourceIcon kind="Secret" />
                 &nbsp;{_.get(pullSecret, 'metadata.name')}
             </div> : <div className="col-xs-9">
               <input type="text" className="form-control" id="namespace-pull-secret-name" aria-describedby="namespace-pull-secret-name-help" required />


### PR DESCRIPTION
And remove orphaned or unnecessary rules.

Firefox MacOS before:
![screen shot 2019-02-21 at 2 41 34 pm](https://user-images.githubusercontent.com/895728/53196846-f8892b00-35e6-11e9-831a-848a9d767369.png)

Firefox MacOS after:
![screen shot 2019-02-21 at 2 42 16 pm](https://user-images.githubusercontent.com/895728/53196862-0048cf80-35e7-11e9-9d7e-07578521a179.png)

