### PR TITLE
Remove documentation links

### DIFF
--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 import { FLAGS, connectToFlags } from '../features';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
-import { Kebab, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary, Selector, helpLink, HELP_TOPICS, ExternalLink } from './utils';
+import { Kebab, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary, Selector, ExternalLink } from './utils';
 
 const { common } = Kebab.factory;
 const menuActions = [...common];
@@ -92,10 +92,8 @@ const IngressRow = ({ingress, namespace, podSelector}) => {
   </div>;
 };
 
-const Details_ = ({flags, obj: np}) => {
-  const networkPolicyDocs = flags[FLAGS.OPENSHIFT]
-    ? helpLink(HELP_TOPICS.NETWORK_POLICY_GUIDE)
-    : 'https://kubernetes.io/docs/concepts/services-networking/network-policies/';
+const Details_ = ({obj: np}) => {
+  const networkPolicyDocs = 'https://kubernetes.io/docs/concepts/services-networking/network-policies/';
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="Namespace Overview" />

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import { FieldLevelHelp } from 'patternfly-react';
 
 import { ColHead, DetailsPage, List, ListHeader, MultiListPage } from './factory';
-import { Kebab, SectionHeading, navFactory, ResourceKebab, ResourceLink, ResourceSummary, convertToBaseValue, helpLink, HELP_TOPICS, ExternalLink } from './utils';
+import { Kebab, SectionHeading, navFactory, ResourceKebab, ResourceLink, ResourceSummary, convertToBaseValue } from './utils';
 import { FLAGS, connectToFlags, flagPending } from '../features';
 import { Gauge } from './graphs';
 import { LoadingBox } from './utils/status-box';
@@ -152,7 +152,7 @@ const Details = ({obj: rq}) => {
           <div>
             <p>Requests are the amount of resources you expect to use. These are used when establishing if the cluster can fulfill your Request.</p>
             <p>Limits are a maximum amount of a resource you can consume. Applications consuming more than the Limit may be terminated.</p>
-            <p>A cluster administrator can establish limits on both the amount you can Request and your Limits with a <ExternalLink href={helpLink(HELP_TOPICS.COMPUTE_RESOURCES_QUOTA)} text="Resource Quota" />.</p>
+            <p>A cluster administrator can establish limits on both the amount you can Request and your Limits with a Resource Quota.</p>
           </div>
         } />
       </SectionHeading>

--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -1,25 +1,10 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-import { productName } from '../../branding';
 import { ExternalLink } from '../utils';
 
 // Prefer the documentation base URL passed as a flag, but fall back to the latest docs if none was specified.
 export const openshiftHelpBase = (window as any).SERVER_FLAGS.documentationBaseURL || 'https://docs.okd.io/latest/';
-
-/* global
-  HELP_TOPICS: false,
-  GET_STARTED_CLI: false,
-  NETWORK_POLICY_GUIDE: false,
-  COMPUTE_RESOURCES_QUOTA: false,
- */
-export enum HELP_TOPICS {
-  GET_STARTED_CLI = 'cli_reference/get_started_cli.html',
-  NETWORK_POLICY_GUIDE = 'admin_guide/managing_networking.html#admin-guide-networking-networkpolicy',
-  COMPUTE_RESOURCES_QUOTA = 'dev_guide/compute_resources.html#dev-compute-resources',
-}
-
-export const helpLink = (topic: HELP_TOPICS) => `${openshiftHelpBase}${topic}`;
 
 /* eslint-disable react/jsx-no-target-blank */
 export const DocumentationLinks = () => <dl className="co-documentation-links">
@@ -27,11 +12,6 @@ export const DocumentationLinks = () => <dl className="co-documentation-links">
   <dd className="co-documentation-links__description">
     From getting started with creating your first application, to trying out more advanced build and deployment techniques, these resources
     provide what you need to set up and manage your environment as a cluster administrator or an application developer.
-  </dd>
-  <dt className="co-documentation-links__title"><ExternalLink href={helpLink(HELP_TOPICS.GET_STARTED_CLI)} text="Get Started with the CLI" /></dt>
-  <dd className="co-documentation-links__description">
-    With the {productName} command line interface (CLI), you can create applications and manage projects from a terminal. Learn how to install
-    and use the oc client tool.
   </dd>
 </dl>;
 


### PR DESCRIPTION
The 4.0 docs are being restructured, so I removed the links we generate based on the base URL. We can add them back in once the docs are finalized.

Fixes [CONSOLE-1244](https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-1244).