### PR TITLE
Apply table--layout-fixed to images table...

### DIFF
--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -234,7 +234,11 @@ const Details = ({obj: node}) => {
     <div className="co-m-pane__body">
       <SectionHeading text="Images" />
       <div className="co-table-container">
-        <table className="table">
+        <table className="table table--layout-fixed">
+          <colgroup>
+            <col className="col-sm-10 col-xs-9"></col>
+            <col className="col-sm-2 col-xs-3"></col>
+          </colgroup>
           <thead>
             <tr>
               <th>Name</th>
@@ -243,7 +247,7 @@ const Details = ({obj: node}) => {
           </thead>
           <tbody>
             {_.map(images, (image, i) => <tr key={i}>
-              <td>{image.names.find(name => !name.includes('@')) || image.names[0]}</td>
+              <td className="co-break-all">{image.names.find(name => !name.includes('@')) || image.names[0]}</td>
               <td>{units.humanize(image.sizeBytes, 'decimalBytes', true).string || '-'}</td>
             </tr>)}
           </tbody>


### PR DESCRIPTION
… and `.co-break-all` to the name column to prevent long string issues 

**before**
<img width="504" alt="screen shot 2019-02-21 at 5 03 39 pm" src="https://user-images.githubusercontent.com/1874151/53204872-be298900-35fa-11e9-818d-fc48a9094d20.png">


**after**
<img width="525" alt="screen shot 2019-02-21 at 5 19 54 pm" src="https://user-images.githubusercontent.com/1874151/53205763-4741bf80-35fd-11e9-89b0-acef9769c637.png">


