### PR TITLE
HEAD <token_endpoint>/implicit as health check

### DIFF
--- a/auth/auth_openshift.go
+++ b/auth/auth_openshift.go
@@ -88,7 +88,7 @@ func newOpenShiftAuth(ctx context.Context, c *openShiftConfig) (oauth2.Endpoint,
 	}
 
 	// Make sure we can talk to the token endpoint.
-	req, err = http.NewRequest(http.MethodHead, metadata.Token, nil)
+	req, err = http.NewRequest(http.MethodHead, metadata.Token + "/implicit", nil)
 	if err != nil {
 		return oauth2.Endpoint{}, nil, err
 	}


### PR DESCRIPTION
The token_endpoint only supports GET and POST requests.  This mimics the behavior of oc.