### PR TITLE
[WIP] Temporarily disable failing OLM tests

### DIFF
--- a/frontend/integration-tests/tests/olm/etcd.scenario.ts
+++ b/frontend/integration-tests/tests/olm/etcd.scenario.ts
@@ -11,7 +11,7 @@ import * as catalogView from '../../views/olm-catalog.view';
 import * as sidenavView from '../../views/sidenav.view';
 import * as yamlView from '../../views/yaml.view';
 
-describe('Interacting with the etcd Operator (all-namespaces install mode)', () => {
+xdescribe('Interacting with the etcd Operator (all-namespaces install mode)', () => {
   const etcdClusterResources = new Set(['Service', 'Pod']);
   const deleteRecoveryTime = 60000;
   const etcdOperatorName = 'etcd-operator';

--- a/frontend/integration-tests/tests/olm/prometheus.scenario.ts
+++ b/frontend/integration-tests/tests/olm/prometheus.scenario.ts
@@ -11,7 +11,7 @@ import * as catalogView from '../../views/olm-catalog.view';
 import * as sidenavView from '../../views/sidenav.view';
 import * as yamlView from '../../views/yaml.view';
 
-describe('Interacting with the Prometheus Operator (single-namespace install mode)', () => {
+xdescribe('Interacting with the Prometheus Operator (single-namespace install mode)', () => {
   const prometheusResources = new Set(['StatefulSet', 'Pod']);
   const alertmanagerResources = new Set(['StatefulSet', 'Pod']);
   const serviceMonitorResources = new Set(['Pod']);

--- a/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
+++ b/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
@@ -111,7 +111,7 @@ describe('Subscribing to an Operator from Operator Hub', () => {
     await operatorHubView.operatorModalInstallBtn.click();
 
     expect(browser.getCurrentUrl()).toContain('/operatorhub/subscribe?pkg=etcd&catalog=community-operators&catalogNamespace=openshift-marketplace&targetNamespace=');
-    expect(operatorHubView.createSubscriptionFormTitle.isDisplayed()).toBe(true);
+    await operatorHubView.createSubscriptionFormTitleIsPresent();
   });
 
   it('selects target namespace for Operator subscription', async() => {
@@ -128,7 +128,7 @@ describe('Subscribing to an Operator from Operator Hub', () => {
     expect(catalogPageView.catalogTileFor('etcd').$('.catalog-tile-pf-footer').getText()).toContain('Installed');
   });
 
-  it('displays Operator in "Cluster Service Versions" view for "default" namespace', async() => {
+  xit('displays Operator in "Cluster Service Versions" view for "default" namespace', async() => {
     await browser.get(`${appHost}/operatorhub/ns/${testName}`);
     await crudView.isLoaded();
     await operatorHubView.showCommunityOperators();

--- a/frontend/integration-tests/views/operator-hub.view.ts
+++ b/frontend/integration-tests/views/operator-hub.view.ts
@@ -22,3 +22,5 @@ export const showCommunityOperators = async() => {
   await $('.co-modal-ignore-warning').$('.btn-primary').click();
   await browser.wait(until.not(until.presenceOf($('.co-modal-ignore-warning'))), 1000).then(() => browser.sleep(500));
 };
+
+export const createSubscriptionFormTitleIsPresent = () => browser.wait(until.presenceOf(createSubscriptionFormTitle));


### PR DESCRIPTION
It looks like #1172 reenabled some failing OLM tests. Best I can tell, this is not a problem in console or with the tests themselves, but legitimate failures in OLM. I haven't seen the OLM tests pass since the PR merged, and I can reproduce the problems locally on a fresh install.

Here's the error I'm seeing in the install plan:

```yaml
status:
  catalogSources:
    - installed-community-openshift-operators
  conditions:
    - lastTransitionTime: '2019-02-23T19:39:52Z'
      lastUpdateTime: '2019-02-23T19:39:52Z'
      message: >-
        error creating csv etcdoperator.v0.9.2: an error on the server ("This
        request caused apiserver to panic. Look in the logs for details.") has
        prevented the request from succeeding (post
        clusterserviceversions.operators.coreos.com)
      reason: InstallComponentFailed
      status: 'False'
      type: Installed
phase: Failed
```

Since two dozen approved console PRs are blocked on this, I'd like to consider disabling the tests for now (and putting `/hold` on any OLM-related PRs) to unblock the queue.

@alecmerdler @jwforres 