### PR TITLE
[Do Not Merge] Remove await from overview test assertions

### DIFF
--- a/frontend/integration-tests/tests/overview/overview.scenario.ts
+++ b/frontend/integration-tests/tests/overview/overview.scenario.ts
@@ -34,17 +34,17 @@ describe('Visiting Overview page', () => {
       it(`displays a ${kindModel.id} in the project overview list`, async() => {
         await browser.wait(until.presenceOf(overviewView.projectOverview));
         await overviewView.itemsAreVisible();
-        await expect(overviewView.getProjectOverviewListItem(kindModel, resourceName).isPresent()).toBeTruthy();
+        expect(overviewView.getProjectOverviewListItem(kindModel, resourceName).isPresent()).toBeTruthy();
       });
 
       it(`shows ${kindModel.id} details sidebar when item is clicked`, async() => {
         const overviewListItem = overviewView.getProjectOverviewListItem(kindModel, resourceName);
-        await expect(overviewView.detailsSidebar.isPresent()).toBeFalsy();
+        expect(overviewView.detailsSidebar.isPresent()).toBeFalsy();
         await browser.wait(until.elementToBeClickable(overviewListItem));
         await overviewListItem.click();
         await overviewView.sidebarIsLoaded();
-        await expect(overviewView.detailsSidebar.isDisplayed()).toBeTruthy();
-        await expect(overviewView.detailsSidebarTitle.getText()).toContain(resourceName);
+        expect(overviewView.detailsSidebar.isDisplayed()).toBeTruthy();
+        expect(overviewView.detailsSidebarTitle.getText()).toContain(resourceName);
       });
     });
   });


### PR DESCRIPTION
Troubleshoot test flakes that cannot be reproduced locally. Hoping to reproduce overview test flake and get a little more insight from stack traces/screenshots when `await` is removed from the assertions.