### PR TITLE
Do not show pod selector by default in Summary Page

### DIFF
--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -36,7 +36,7 @@ export const BuildConfigsDetails: React.SFC<BuildConfigsDetailsProps> = ({obj: b
     <SectionHeading text="Build Config Overview" />
     <div className="row">
       <div className="col-sm-6">
-        <ResourceSummary resource={buildConfig} showPodSelector={false} showNodeSelector={false} />
+        <ResourceSummary resource={buildConfig} showNodeSelector={false} />
       </div>
       <div className="col-sm-6">
         <BuildStrategy resource={buildConfig} />

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -36,7 +36,7 @@ export const BuildConfigsDetails: React.SFC<BuildConfigsDetailsProps> = ({obj: b
     <SectionHeading text="Build Config Overview" />
     <div className="row">
       <div className="col-sm-6">
-        <ResourceSummary resource={buildConfig} showNodeSelector={false} />
+        <ResourceSummary resource={buildConfig} />
       </div>
       <div className="col-sm-6">
         <BuildStrategy resource={buildConfig} />

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -123,7 +123,7 @@ export const BuildsDetails: React.SFC<BuildsDetailsProps> = ({ obj: build }) => 
       </div>}
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={build} showPodSelector={false} showNodeSelector={false}>
+          <ResourceSummary resource={build} showNodeSelector={false}>
             {triggeredBy && <dt>Triggered By</dt>}
             {triggeredBy && <dd>{triggeredBy}</dd>}
             {startTimestamp && <dt>Started</dt>}

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -123,7 +123,7 @@ export const BuildsDetails: React.SFC<BuildsDetailsProps> = ({ obj: build }) => 
       </div>}
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={build} showNodeSelector={false}>
+          <ResourceSummary resource={build}>
             {triggeredBy && <dt>Triggered By</dt>}
             {triggeredBy && <dd>{triggeredBy}</dd>}
             {startTimestamp && <dt>Started</dt>}

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -101,7 +101,7 @@ class ReportsDetails extends React.Component<ReportsDetailsProps> {
         <SectionHeading text="Report Overview" />
         <div className="row">
           <div className="col-sm-6 col-xs-12">
-            <ResourceSummary resource={obj} showNodeSelector={false} showPodSelector={false} showAnnotations={true} />
+            <ResourceSummary resource={obj} showNodeSelector={false} showAnnotations={true} />
           </div>
           <div className="col-sm-6 col-xs-12">
             <dl className="co-m-pane__details">
@@ -439,7 +439,7 @@ const ReportGenerationQueriesDetails: React.SFC<ReportGenerationQueriesDetailsPr
   return <div>
     <div className="co-m-pane__body">
       <SectionHeading text="Chargeback Report Generation Query" />
-      <ResourceSummary resource={obj} showNodeSelector={false} showPodSelector={false} showAnnotations={true}>
+      <ResourceSummary resource={obj} showNodeSelector={false} showAnnotations={true}>
         <dt>Query</dt>
         <dd><pre><code>{_.get(obj, ['spec', 'query'])}</code></pre></dd>
         <div className="row">

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -101,7 +101,7 @@ class ReportsDetails extends React.Component<ReportsDetailsProps> {
         <SectionHeading text="Report Overview" />
         <div className="row">
           <div className="col-sm-6 col-xs-12">
-            <ResourceSummary resource={obj} showAnnotations={true} />
+            <ResourceSummary resource={obj} />
           </div>
           <div className="col-sm-6 col-xs-12">
             <dl className="co-m-pane__details">
@@ -439,7 +439,7 @@ const ReportGenerationQueriesDetails: React.SFC<ReportGenerationQueriesDetailsPr
   return <div>
     <div className="co-m-pane__body">
       <SectionHeading text="Chargeback Report Generation Query" />
-      <ResourceSummary resource={obj} showNodeSelector={false} showAnnotations={true}>
+      <ResourceSummary resource={obj}>
         <dt>Query</dt>
         <dd><pre><code>{_.get(obj, ['spec', 'query'])}</code></pre></dd>
         <div className="row">

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -101,7 +101,7 @@ class ReportsDetails extends React.Component<ReportsDetailsProps> {
         <SectionHeading text="Report Overview" />
         <div className="row">
           <div className="col-sm-6 col-xs-12">
-            <ResourceSummary resource={obj} showNodeSelector={false} showAnnotations={true} />
+            <ResourceSummary resource={obj} showAnnotations={true} />
           </div>
           <div className="col-sm-6 col-xs-12">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/cluster-service-broker.tsx
+++ b/frontend/public/components/cluster-service-broker.tsx
@@ -42,7 +42,7 @@ const ClusterServiceBrokerDetails: React.SFC<ClusterServiceBrokerDetailsProps> =
       <SectionHeading text="Service Broker Overview" />
       <div className="row">
         <div className="col-md-6">
-          <ResourceSummary resource={serviceBroker} showNodeSelector={false} />
+          <ResourceSummary resource={serviceBroker} />
           <dt>Last Catalog Retrieval Time</dt>
           <dd><Timestamp timestamp={serviceBroker.status.lastCatalogRetrievalTime} /></dd>
           {serviceBroker.spec.insecureSkipTLSVerify && <dt>Insecure Skip TLS Verify</dt>}

--- a/frontend/public/components/cluster-service-broker.tsx
+++ b/frontend/public/components/cluster-service-broker.tsx
@@ -42,7 +42,7 @@ const ClusterServiceBrokerDetails: React.SFC<ClusterServiceBrokerDetailsProps> =
       <SectionHeading text="Service Broker Overview" />
       <div className="row">
         <div className="col-md-6">
-          <ResourceSummary resource={serviceBroker} showPodSelector={false} showNodeSelector={false} />
+          <ResourceSummary resource={serviceBroker} showNodeSelector={false} />
           <dt>Last Catalog Retrieval Time</dt>
           <dd><Timestamp timestamp={serviceBroker.status.lastCatalogRetrievalTime} /></dd>
           {serviceBroker.spec.insecureSkipTLSVerify && <dt>Insecure Skip TLS Verify</dt>}

--- a/frontend/public/components/cluster-service-class.tsx
+++ b/frontend/public/components/cluster-service-class.tsx
@@ -59,7 +59,7 @@ const ClusterServiceClassDetails: React.SFC<ClusterServiceClassDetailsProps> = (
     </div>
     <div className="col-md-5 col-md-pull-7">
       <SectionHeading text="Service Class Overview" />
-      <ResourceSummary resource={serviceClass} showNodeSelector={false}>
+      <ResourceSummary resource={serviceClass}>
         <dt>External Name</dt>
         <dd>{serviceClass.spec.externalName || '-'}</dd>
       </ResourceSummary>

--- a/frontend/public/components/cluster-service-class.tsx
+++ b/frontend/public/components/cluster-service-class.tsx
@@ -59,7 +59,7 @@ const ClusterServiceClassDetails: React.SFC<ClusterServiceClassDetailsProps> = (
     </div>
     <div className="col-md-5 col-md-pull-7">
       <SectionHeading text="Service Class Overview" />
-      <ResourceSummary resource={serviceClass} showPodSelector={false} showNodeSelector={false}>
+      <ResourceSummary resource={serviceClass} showNodeSelector={false}>
         <dt>External Name</dt>
         <dd>{serviceClass.spec.externalName || '-'}</dd>
       </ResourceSummary>

--- a/frontend/public/components/cluster-service-plan.tsx
+++ b/frontend/public/components/cluster-service-plan.tsx
@@ -32,7 +32,7 @@ const ClusterServicePlanDetails: React.SFC<ClusterServicePlanDetailsProps> = ({o
     <SectionHeading text="Service Plan Overview" />
     <div className="row">
       <div className="col-md-6">
-        <ResourceSummary resource={servicePlan} showPodSelector={false} showNodeSelector={false} />
+        <ResourceSummary resource={servicePlan} showNodeSelector={false} />
       </div>
       <div className="col-md-6">
         <dl className="co-m-pane__details">

--- a/frontend/public/components/cluster-service-plan.tsx
+++ b/frontend/public/components/cluster-service-plan.tsx
@@ -32,7 +32,7 @@ const ClusterServicePlanDetails: React.SFC<ClusterServicePlanDetailsProps> = ({o
     <SectionHeading text="Service Plan Overview" />
     <div className="row">
       <div className="col-md-6">
-        <ResourceSummary resource={servicePlan} showNodeSelector={false} />
+        <ResourceSummary resource={servicePlan} />
       </div>
       <div className="col-md-6">
         <dl className="co-m-pane__details">

--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -131,7 +131,7 @@ const ClusterOperatorDetails: React.SFC<ClusterOperatorDetailsProps> = ({obj}) =
     <React.Fragment>
       <div className="co-m-pane__body">
         <SectionHeading text="Cluster Operator Overview" />
-        <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
+        <ResourceSummary resource={obj}>
           <dt>Status</dt>
           <dd><OperatorStatusIconAndLabel status={status} /></dd>
           <dt>Message</dt>

--- a/frontend/public/components/cluster-settings/oauth.tsx
+++ b/frontend/public/components/cluster-settings/oauth.tsx
@@ -59,7 +59,7 @@ const OAuthDetails: React.SFC<OAuthDetailsProps> = ({obj}: {obj: K8sResourceKind
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="OAuth Overview" />
-      <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
+      <ResourceSummary resource={obj} showNodeSelector={false}>
         <dt>Access Token Max Age</dt>
         <dd>{tokenDuration(tokenConfig.accessTokenMaxAgeSeconds)}</dd>
       </ResourceSummary>

--- a/frontend/public/components/cluster-settings/oauth.tsx
+++ b/frontend/public/components/cluster-settings/oauth.tsx
@@ -59,7 +59,7 @@ const OAuthDetails: React.SFC<OAuthDetailsProps> = ({obj}: {obj: K8sResourceKind
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="OAuth Overview" />
-      <ResourceSummary resource={obj} showNodeSelector={false}>
+      <ResourceSummary resource={obj}>
         <dt>Access Token Max Age</dt>
         <dd>{tokenDuration(tokenConfig.accessTokenMaxAgeSeconds)}</dd>
       </ResourceSummary>

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -33,7 +33,7 @@ const ConfigMapDetails = ({obj: configMap}) => {
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="Config Map Overview" />
-      <ResourceSummary resource={configMap} showPodSelector={false} showNodeSelector={false} />
+      <ResourceSummary resource={configMap} showNodeSelector={false} />
     </div>
     <div className="co-m-pane__body">
       <SectionHeading text="Data" />

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -33,7 +33,7 @@ const ConfigMapDetails = ({obj: configMap}) => {
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="Config Map Overview" />
-      <ResourceSummary resource={configMap} showNodeSelector={false} />
+      <ResourceSummary resource={configMap} />
     </div>
     <div className="co-m-pane__body">
       <SectionHeading text="Data" />

--- a/frontend/public/components/cron-job.jsx
+++ b/frontend/public/components/cron-job.jsx
@@ -45,7 +45,7 @@ const Details = ({obj: cronjob}) => {
       <div className="row">
         <div className="col-md-6">
           <SectionHeading text="CronJob Overview" />
-          <ResourceSummary resource={cronjob} showNodeSelector={false} showAnnotations={false}>
+          <ResourceSummary resource={cronjob} showAnnotations={false}>
             <dt>Schedule</dt>
             <dd>{cronjob.spec.schedule}</dd>
             <dt>Concurrency Policy</dt>

--- a/frontend/public/components/cron-job.jsx
+++ b/frontend/public/components/cron-job.jsx
@@ -45,7 +45,7 @@ const Details = ({obj: cronjob}) => {
       <div className="row">
         <div className="col-md-6">
           <SectionHeading text="CronJob Overview" />
-          <ResourceSummary resource={cronjob} showNodeSelector={false} showPodSelector={false} showAnnotations={false}>
+          <ResourceSummary resource={cronjob} showNodeSelector={false} showAnnotations={false}>
             <dt>Schedule</dt>
             <dd>{cronjob.spec.schedule}</dd>
             <dt>Concurrency Policy</dt>

--- a/frontend/public/components/cron-job.jsx
+++ b/frontend/public/components/cron-job.jsx
@@ -45,7 +45,7 @@ const Details = ({obj: cronjob}) => {
       <div className="row">
         <div className="col-md-6">
           <SectionHeading text="CronJob Overview" />
-          <ResourceSummary resource={cronjob} showAnnotations={false}>
+          <ResourceSummary resource={cronjob}>
             <dt>Schedule</dt>
             <dd>{cronjob.spec.schedule}</dd>
             <dt>Concurrency Policy</dt>

--- a/frontend/public/components/daemon-set.jsx
+++ b/frontend/public/components/daemon-set.jsx
@@ -70,7 +70,7 @@ const Details = ({obj: daemonset}) => <React.Fragment>
     <SectionHeading text="Daemon Set Overview" />
     <div className="row">
       <div className="col-lg-6">
-        <ResourceSummary resource={daemonset} />
+        <ResourceSummary resource={daemonset} showPodSelector={true} />
       </div>
       <div className="col-lg-6">
         <DaemonSetDetailsList ds={daemonset} />

--- a/frontend/public/components/daemon-set.jsx
+++ b/frontend/public/components/daemon-set.jsx
@@ -70,7 +70,7 @@ const Details = ({obj: daemonset}) => <React.Fragment>
     <SectionHeading text="Daemon Set Overview" />
     <div className="row">
       <div className="col-lg-6">
-        <ResourceSummary resource={daemonset} showPodSelector={true} showNodeSelector={true} />
+        <ResourceSummary resource={daemonset} showPodSelector showNodeSelector />
       </div>
       <div className="col-lg-6">
         <DaemonSetDetailsList ds={daemonset} />

--- a/frontend/public/components/daemon-set.jsx
+++ b/frontend/public/components/daemon-set.jsx
@@ -70,7 +70,7 @@ const Details = ({obj: daemonset}) => <React.Fragment>
     <SectionHeading text="Daemon Set Overview" />
     <div className="row">
       <div className="col-lg-6">
-        <ResourceSummary resource={daemonset} showPodSelector={true} />
+        <ResourceSummary resource={daemonset} showPodSelector={true} showNodeSelector={true} />
       </div>
       <div className="col-lg-6">
         <DaemonSetDetailsList ds={daemonset} />

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -110,7 +110,7 @@ export const DeploymentConfigsDetails: React.SFC<{obj: any}> = ({obj: dc}) => {
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
-            <ResourceSummary resource={dc}>
+            <ResourceSummary resource={dc} showPodSelector={true}>
               <dt>Status</dt>
               <dd>{dc.status.availableReplicas === dc.status.updatedReplicas ? <StatusIcon status="Active" /> : <StatusIcon status="Updating" />}</dd>
             </ResourceSummary>

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -110,7 +110,7 @@ export const DeploymentConfigsDetails: React.SFC<{obj: any}> = ({obj: dc}) => {
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
-            <ResourceSummary resource={dc} showPodSelector={true}>
+            <ResourceSummary resource={dc} showPodSelector={true} showNodeSelector={true}>
               <dt>Status</dt>
               <dd>{dc.status.availableReplicas === dc.status.updatedReplicas ? <StatusIcon status="Active" /> : <StatusIcon status="Updating" />}</dd>
             </ResourceSummary>

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -110,7 +110,7 @@ export const DeploymentConfigsDetails: React.SFC<{obj: any}> = ({obj: dc}) => {
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
-            <ResourceSummary resource={dc} showPodSelector={true} showNodeSelector={true}>
+            <ResourceSummary resource={dc} showPodSelector showNodeSelector>
               <dt>Status</dt>
               <dd>{dc.status.availableReplicas === dc.status.updatedReplicas ? <StatusIcon status="Active" /> : <StatusIcon status="Updating" />}</dd>
             </ResourceSummary>

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -74,7 +74,7 @@ const DeploymentDetails = ({obj: deployment}) => {
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
-            <ResourceSummary resource={deployment} showPodSelector={true} showNodeSelector={true}>
+            <ResourceSummary resource={deployment} showPodSelector showNodeSelector>
               <dt>Status</dt>
               <dd>{deployment.status.availableReplicas === deployment.status.updatedReplicas ? <StatusIcon status="Active" /> : <StatusIcon status="Updating" />}</dd>
             </ResourceSummary>

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -74,7 +74,7 @@ const DeploymentDetails = ({obj: deployment}) => {
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
-            <ResourceSummary resource={deployment} showPodSelector={true}>
+            <ResourceSummary resource={deployment} showPodSelector={true} showNodeSelector={true}>
               <dt>Status</dt>
               <dd>{deployment.status.availableReplicas === deployment.status.updatedReplicas ? <StatusIcon status="Active" /> : <StatusIcon status="Updating" />}</dd>
             </ResourceSummary>

--- a/frontend/public/components/deployment.jsx
+++ b/frontend/public/components/deployment.jsx
@@ -74,7 +74,7 @@ const DeploymentDetails = ({obj: deployment}) => {
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
-            <ResourceSummary resource={deployment}>
+            <ResourceSummary resource={deployment} showPodSelector={true}>
               <dt>Status</dt>
               <dd>{deployment.status.availableReplicas === deployment.status.updatedReplicas ? <StatusIcon status="Active" /> : <StatusIcon status="Updating" />}</dd>
             </ResourceSummary>

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -131,7 +131,7 @@ export const HorizontalPodAutoscalersDetails: React.SFC<HorizontalPodAutoscalers
     <SectionHeading text="Horizontal Pod Autoscaler Overview" />
     <div className="row">
       <div className="col-sm-6">
-        <ResourceSummary resource={hpa} showNodeSelector={false} />
+        <ResourceSummary resource={hpa} />
       </div>
       <div className="col-sm-6">
         <dl className="co-m-pane__details">

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -131,7 +131,7 @@ export const HorizontalPodAutoscalersDetails: React.SFC<HorizontalPodAutoscalers
     <SectionHeading text="Horizontal Pod Autoscaler Overview" />
     <div className="row">
       <div className="col-sm-6">
-        <ResourceSummary resource={hpa} showPodSelector={false} showNodeSelector={false} />
+        <ResourceSummary resource={hpa} showNodeSelector={false} />
       </div>
       <div className="col-sm-6">
         <dl className="co-m-pane__details">

--- a/frontend/public/components/image-stream-tag.tsx
+++ b/frontend/public/components/image-stream-tag.tsx
@@ -47,7 +47,7 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
       <div className="row">
         <div className="col-md-6 col-sm-12">
           <SectionHeading text="Image Overview" />
-          <ResourceSummary resource={imageStreamTag} showPodSelector={false} showNodeSelector={false}>
+          <ResourceSummary resource={imageStreamTag} showNodeSelector={false}>
             {labels.name && <dt>Image Name</dt>}
             {labels.name && <dd>{labels.name}</dd>}
             {labels.summary && <dt>Summary</dt>}

--- a/frontend/public/components/image-stream-tag.tsx
+++ b/frontend/public/components/image-stream-tag.tsx
@@ -47,7 +47,7 @@ export const ImageStreamTagsDetails: React.SFC<ImageStreamTagsDetailsProps> = ({
       <div className="row">
         <div className="col-md-6 col-sm-12">
           <SectionHeading text="Image Overview" />
-          <ResourceSummary resource={imageStreamTag} showNodeSelector={false}>
+          <ResourceSummary resource={imageStreamTag}>
             {labels.name && <dt>Image Name</dt>}
             {labels.name && <dd>{labels.name}</dd>}
             {labels.summary && <dt>Summary</dt>}

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -116,7 +116,7 @@ export const ImageStreamsDetails: React.SFC<ImageStreamsDetailsProps> = ({obj: i
   return <div>
     <div className="co-m-pane__body">
       <SectionHeading text="Image Stream Overview" />
-      <ResourceSummary resource={imageStream} showNodeSelector={false}>
+      <ResourceSummary resource={imageStream}>
         {imageRepository && <dt>Image Repository</dt>}
         {imageRepository && <dd>{imageRepository}</dd>}
         {publicImageRepository && <dt>Public Image Repository</dt>}

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -116,7 +116,7 @@ export const ImageStreamsDetails: React.SFC<ImageStreamsDetailsProps> = ({obj: i
   return <div>
     <div className="co-m-pane__body">
       <SectionHeading text="Image Stream Overview" />
-      <ResourceSummary resource={imageStream} showPodSelector={false} showNodeSelector={false}>
+      <ResourceSummary resource={imageStream} showNodeSelector={false}>
         {imageRepository && <dt>Image Repository</dt>}
         {imageRepository && <dd>{imageRepository}</dd>}
         {publicImageRepository && <dt>Public Image Repository</dt>}

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -118,7 +118,7 @@ const RulesRows = (props) => {
 const Details = ({obj: ingress}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="Ingress Overview" />
-    <ResourceSummary resource={ingress} showPodSelector={false} showNodeSelector={false}>
+    <ResourceSummary resource={ingress} showNodeSelector={false}>
       <dt>TLS Certificate</dt>
       <dd>{getTLSCert(ingress)}</dd>
     </ResourceSummary>

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -118,7 +118,7 @@ const RulesRows = (props) => {
 const Details = ({obj: ingress}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="Ingress Overview" />
-    <ResourceSummary resource={ingress} showNodeSelector={false}>
+    <ResourceSummary resource={ingress}>
       <dt>TLS Certificate</dt>
       <dd>{getTLSCert(ingress)}</dd>
     </ResourceSummary>

--- a/frontend/public/components/job.jsx
+++ b/frontend/public/components/job.jsx
@@ -57,7 +57,7 @@ const Details = ({obj: job}) => <React.Fragment>
     <div className="row">
       <div className="col-md-6">
         <SectionHeading text="Job Overview" />
-        <ResourceSummary resource={job} showNodeSelector={false}>
+        <ResourceSummary resource={job} showNodeSelector={false} showPodSelector={true}>
           <dt>Desired Completions</dt>
           <dd>{job.spec.completions || '-'}</dd>
           <dt>Parallelism</dt>

--- a/frontend/public/components/job.jsx
+++ b/frontend/public/components/job.jsx
@@ -57,7 +57,7 @@ const Details = ({obj: job}) => <React.Fragment>
     <div className="row">
       <div className="col-md-6">
         <SectionHeading text="Job Overview" />
-        <ResourceSummary resource={job} showNodeSelector={false} showPodSelector={true}>
+        <ResourceSummary resource={job} showPodSelector={true}>
           <dt>Desired Completions</dt>
           <dd>{job.spec.completions || '-'}</dd>
           <dt>Parallelism</dt>

--- a/frontend/public/components/job.jsx
+++ b/frontend/public/components/job.jsx
@@ -57,7 +57,7 @@ const Details = ({obj: job}) => <React.Fragment>
     <div className="row">
       <div className="col-md-6">
         <SectionHeading text="Job Overview" />
-        <ResourceSummary resource={job} showPodSelector={true}>
+        <ResourceSummary resource={job} showPodSelector>
           <dt>Desired Completions</dt>
           <dd>{job.spec.completions || '-'}</dd>
           <dt>Parallelism</dt>

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -101,7 +101,7 @@ export const LimitRangeDetailsList = (resource) => {
 const Details = ({obj: rq}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="Limit Range Overview" />
-    <ResourceSummary resource={rq} showPodSelector={false} showNodeSelector={false} />
+    <ResourceSummary resource={rq} showNodeSelector={false} />
   </div>
   <LimitRangeDetailsList resource={rq} />
 </React.Fragment>;

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -101,7 +101,7 @@ export const LimitRangeDetailsList = (resource) => {
 const Details = ({obj: rq}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="Limit Range Overview" />
-    <ResourceSummary resource={rq} showNodeSelector={false} />
+    <ResourceSummary resource={rq} />
   </div>
   <LimitRangeDetailsList resource={rq} />
 </React.Fragment>;

--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -131,7 +131,7 @@ const MachineConfigPoolCounts: React.SFC<MachineConfigPoolCountsProps> = ({obj})
 const MachineConfigPoolSummary: React.SFC<MachineConfigPoolSummaryProps> = ({obj}) => {
   const machineConfigSelector = _.get(obj, 'spec.machineConfigSelector');
   const machineSelector = _.get(obj, 'spec.machineSelector');
-  return <ResourceSummary resource={obj} showNodeSelector={false}>
+  return <ResourceSummary resource={obj}>
     <dt>Machine Config Selector</dt>
     <dd>
       <Selector

--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -131,7 +131,7 @@ const MachineConfigPoolCounts: React.SFC<MachineConfigPoolCountsProps> = ({obj})
 const MachineConfigPoolSummary: React.SFC<MachineConfigPoolSummaryProps> = ({obj}) => {
   const machineConfigSelector = _.get(obj, 'spec.machineConfigSelector');
   const machineSelector = _.get(obj, 'spec.machineSelector');
-  return <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
+  return <ResourceSummary resource={obj} showNodeSelector={false}>
     <dt>Machine Config Selector</dt>
     <dd>
       <Selector

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -26,7 +26,7 @@ export const machineConfigReference = referenceForModel(MachineConfigModel);
 const machineConfigMenuActions = [...Kebab.factory.common];
 
 const MachineConfigSummary: React.SFC<MachineConfigSummaryProps> = ({obj}) => (
-  <ResourceSummary resource={obj} showNodeSelector={false}>
+  <ResourceSummary resource={obj}>
     <dt>OS Image URL</dt>
     <dd>{obj.spec.osImageURL || '-'}</dd>
   </ResourceSummary>

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -26,7 +26,7 @@ export const machineConfigReference = referenceForModel(MachineConfigModel);
 const machineConfigMenuActions = [...Kebab.factory.common];
 
 const MachineConfigSummary: React.SFC<MachineConfigSummaryProps> = ({obj}) => (
-  <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
+  <ResourceSummary resource={obj} showNodeSelector={false}>
     <dt>OS Image URL</dt>
     <dd>{obj.spec.osImageURL || '-'}</dd>
   </ResourceSummary>

--- a/frontend/public/components/machine-deployment.tsx
+++ b/frontend/public/components/machine-deployment.tsx
@@ -67,7 +67,7 @@ const MachineDeploymentDetails: React.SFC<MachineDeploymentDetailsProps> = ({obj
       <MachineCounts resourceKind={MachineDeploymentModel} resource={obj} />
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
+          <ResourceSummary resource={obj} showNodeSelector={false}>
             <dt>Selector</dt>
             <dd>
               <Selector

--- a/frontend/public/components/machine-deployment.tsx
+++ b/frontend/public/components/machine-deployment.tsx
@@ -67,7 +67,7 @@ const MachineDeploymentDetails: React.SFC<MachineDeploymentDetailsProps> = ({obj
       <MachineCounts resourceKind={MachineDeploymentModel} resource={obj} />
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={obj} showNodeSelector={false}>
+          <ResourceSummary resource={obj}>
             <dt>Selector</dt>
             <dd>
               <Selector

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -142,7 +142,7 @@ const MachineSetDetails: React.SFC<MachineSetDetailsProps> = ({obj}) => {
     <div className="co-m-pane__body">
       <SectionHeading text="Machine Set Overview" />
       <MachineCounts resourceKind={MachineSetModel} resource={obj} />
-      <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
+      <ResourceSummary resource={obj} showNodeSelector={false}>
         <dt>Selector</dt>
         <dd>
           <Selector

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -142,7 +142,7 @@ const MachineSetDetails: React.SFC<MachineSetDetailsProps> = ({obj}) => {
     <div className="co-m-pane__body">
       <SectionHeading text="Machine Set Overview" />
       <MachineCounts resourceKind={MachineSetModel} resource={obj} />
-      <ResourceSummary resource={obj} showNodeSelector={false}>
+      <ResourceSummary resource={obj}>
         <dt>Selector</dt>
         <dd>
           <Selector

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -60,7 +60,7 @@ const MachineDetails: React.SFC<MachineDetailsProps> = ({obj}: {obj: MachineKind
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="Machine Overview" />
-      <ResourceSummary resource={obj} showNodeSelector={false}>
+      <ResourceSummary resource={obj}>
         {nodeName && <React.Fragment>
           <dt>Node</dt>
           <dd><NodeLink name={nodeName} /></dd>

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -60,7 +60,7 @@ const MachineDetails: React.SFC<MachineDetailsProps> = ({obj}: {obj: MachineKind
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="Machine Overview" />
-      <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
+      <ResourceSummary resource={obj} showNodeSelector={false}>
         {nodeName && <React.Fragment>
           <dt>Node</dt>
           <dd><NodeLink name={nodeName} /></dd>

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -201,7 +201,7 @@ export const NamespaceSummary = ({ns}) => {
   const requester = getRequester(ns);
   return <div className="row">
     <div className="col-sm-6 col-xs-12">
-      <ResourceSummary resource={ns} showPodSelector={false} showNodeSelector={false}>
+      <ResourceSummary resource={ns} showNodeSelector={false}>
         {displayName && <dt>Display Name</dt>}
         {displayName && <dd>{displayName}</dd>}
         {requester && <dt>Requester</dt>}

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -201,7 +201,7 @@ export const NamespaceSummary = ({ns}) => {
   const requester = getRequester(ns);
   return <div className="row">
     <div className="col-sm-6 col-xs-12">
-      <ResourceSummary resource={ns} showNodeSelector={false}>
+      <ResourceSummary resource={ns}>
         {displayName && <dt>Display Name</dt>}
         {displayName && <dd>{displayName}</dd>}
         {requester && <dt>Requester</dt>}

--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -97,7 +97,7 @@ const Details_ = ({obj: np}) => {
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="Namespace Overview" />
-      <ResourceSummary resource={np} podSelector={'spec.podSelector'} showNodeSelector={false} showPodSelector={true} />
+      <ResourceSummary resource={np} podSelector={'spec.podSelector'} showPodSelector={true} />
     </div>
     <div className="co-m-pane__body">
       <SectionHeading text="Ingress Rules" />

--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -97,7 +97,7 @@ const Details_ = ({obj: np}) => {
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="Namespace Overview" />
-      <ResourceSummary resource={np} podSelector={'spec.podSelector'} showPodSelector={true} />
+      <ResourceSummary resource={np} podSelector={'spec.podSelector'} showPodSelector />
     </div>
     <div className="co-m-pane__body">
       <SectionHeading text="Ingress Rules" />

--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -97,7 +97,7 @@ const Details_ = ({obj: np}) => {
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="Namespace Overview" />
-      <ResourceSummary resource={np} podSelector={'spec.podSelector'} showNodeSelector={false} />
+      <ResourceSummary resource={np} podSelector={'spec.podSelector'} showNodeSelector={false} showPodSelector={true} />
     </div>
     <div className="co-m-pane__body">
       <SectionHeading text="Ingress Rules" />

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
@@ -191,7 +191,7 @@ export const ClusterServiceVersionResourceDetails = connectToModel(
             <div className="row">
               <div className="col-xs-6">
                 { this.state.expanded
-                  ? <ResourceSummary resource={this.props.obj} showPodSelector={false} />
+                  ? <ResourceSummary resource={this.props.obj} />
                   : <dl className="co-m-pane__details">
                     <dt>Name</dt>
                     <dd>{metadata.name}</dd>

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -214,7 +214,7 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
-            <ResourceSummary resource={props.obj} showNodeSelector={false} showPodSelector={false} />
+            <ResourceSummary resource={props.obj} showNodeSelector={false} />
           </div>
           <div className="col-sm-6">
             <dt>Status</dt>

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -214,7 +214,7 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
-            <ResourceSummary resource={props.obj} showNodeSelector={false} />
+            <ResourceSummary resource={props.obj} />
           </div>
           <div className="col-sm-6">
             <dt>Status</dt>

--- a/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
@@ -94,7 +94,7 @@ export const InstallPlanDetails: React.SFC<InstallPlanDetailsProps> = ({obj}) =>
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
-            <ResourceSummary resource={obj} showNodeSelector={false} showPodSelector={false} showAnnotations={false} />
+            <ResourceSummary resource={obj} showNodeSelector={false} showAnnotations={false} />
           </div>
           <div className="col-sm-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
@@ -94,7 +94,7 @@ export const InstallPlanDetails: React.SFC<InstallPlanDetailsProps> = ({obj}) =>
       <div className="co-m-pane__body-group">
         <div className="row">
           <div className="col-sm-6">
-            <ResourceSummary resource={obj} showNodeSelector={false} showAnnotations={false} />
+            <ResourceSummary resource={obj} showAnnotations={false} />
           </div>
           <div className="col-sm-6">
             <dl className="co-m-pane__details">

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -103,7 +103,7 @@ export const SubscriptionDetails: React.SFC<SubscriptionDetailsProps> = (props) 
     <div className="co-m-pane__body-group">
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={obj} showNodeSelector={false} showPodSelector={false} showAnnotations={false} />
+          <ResourceSummary resource={obj} showNodeSelector={false} showAnnotations={false} />
         </div>
         <div className="col-sm-6">
           <dl className="co-m-pane__details">

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -103,7 +103,7 @@ export const SubscriptionDetails: React.SFC<SubscriptionDetailsProps> = (props) 
     <div className="co-m-pane__body-group">
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={obj} showNodeSelector={false} showAnnotations={false} />
+          <ResourceSummary resource={obj} showAnnotations={false} />
         </div>
         <div className="col-sm-6">
           <dl className="co-m-pane__details">

--- a/frontend/public/components/overview/daemon-set-overview.tsx
+++ b/frontend/public/components/overview/daemon-set-overview.tsx
@@ -15,7 +15,7 @@ import { ResourceOverviewDetails } from './resource-overview-details';
 const DaemonSetOverviewDetails: React.SFC<DaemonSetOverviewDetailsProps> = ({item}) =>
   <div className="co-m-pane__body resource-overview__body">
     <div className="resource-overview__summary">
-      <ResourceSummary resource={item.obj} showPodSelector={true} />
+      <ResourceSummary resource={item.obj} showPodSelector={true} showNodeSelector={true} />
     </div>
     <div className="resource-overview__details">
       <DaemonSetDetailsList ds={item.obj} />

--- a/frontend/public/components/overview/daemon-set-overview.tsx
+++ b/frontend/public/components/overview/daemon-set-overview.tsx
@@ -15,7 +15,7 @@ import { ResourceOverviewDetails } from './resource-overview-details';
 const DaemonSetOverviewDetails: React.SFC<DaemonSetOverviewDetailsProps> = ({item}) =>
   <div className="co-m-pane__body resource-overview__body">
     <div className="resource-overview__summary">
-      <ResourceSummary resource={item.obj} />
+      <ResourceSummary resource={item.obj} showPodSelector={true} />
     </div>
     <div className="resource-overview__details">
       <DaemonSetDetailsList ds={item.obj} />

--- a/frontend/public/components/overview/daemon-set-overview.tsx
+++ b/frontend/public/components/overview/daemon-set-overview.tsx
@@ -15,7 +15,7 @@ import { ResourceOverviewDetails } from './resource-overview-details';
 const DaemonSetOverviewDetails: React.SFC<DaemonSetOverviewDetailsProps> = ({item}) =>
   <div className="co-m-pane__body resource-overview__body">
     <div className="resource-overview__summary">
-      <ResourceSummary resource={item.obj} showPodSelector={true} showNodeSelector={true} />
+      <ResourceSummary resource={item.obj} showPodSelector showNodeSelector />
     </div>
     <div className="resource-overview__details">
       <DaemonSetDetailsList ds={item.obj} />

--- a/frontend/public/components/overview/deployment-config-overview.tsx
+++ b/frontend/public/components/overview/deployment-config-overview.tsx
@@ -23,7 +23,7 @@ const DeploymentConfigOverviewDetails: React.SFC<DeploymentConfigOverviewDetails
       <DeploymentPodCounts resource={dc} resourceKind={DeploymentConfigModel} />
     </div>
     <div className="resource-overview__summary">
-      <ResourceSummary resource={dc}>
+      <ResourceSummary resource={dc} showPodSelector={true}>
         <dt>Status</dt>
         <dd>
           {

--- a/frontend/public/components/overview/deployment-config-overview.tsx
+++ b/frontend/public/components/overview/deployment-config-overview.tsx
@@ -23,7 +23,7 @@ const DeploymentConfigOverviewDetails: React.SFC<DeploymentConfigOverviewDetails
       <DeploymentPodCounts resource={dc} resourceKind={DeploymentConfigModel} />
     </div>
     <div className="resource-overview__summary">
-      <ResourceSummary resource={dc} showPodSelector={true}>
+      <ResourceSummary resource={dc} showPodSelector={true} showNodeSelector={true}>
         <dt>Status</dt>
         <dd>
           {

--- a/frontend/public/components/overview/deployment-config-overview.tsx
+++ b/frontend/public/components/overview/deployment-config-overview.tsx
@@ -23,7 +23,7 @@ const DeploymentConfigOverviewDetails: React.SFC<DeploymentConfigOverviewDetails
       <DeploymentPodCounts resource={dc} resourceKind={DeploymentConfigModel} />
     </div>
     <div className="resource-overview__summary">
-      <ResourceSummary resource={dc} showPodSelector={true} showNodeSelector={true}>
+      <ResourceSummary resource={dc} showPodSelector showNodeSelector>
         <dt>Status</dt>
         <dd>
           {

--- a/frontend/public/components/overview/deployment-overview.tsx
+++ b/frontend/public/components/overview/deployment-overview.tsx
@@ -23,7 +23,7 @@ const DeploymentOverviewDetails: React.SFC<DeploymentOverviewDetailsProps> = ({i
       <DeploymentPodCounts resource={item.obj} resourceKind={DeploymentModel} />
     </div>
     <div className="resource-overview__summary">
-      <ResourceSummary resource={item.obj}>
+      <ResourceSummary resource={item.obj} showPodSelector={true}>
         <dt>Status</dt>
         <dd>
           {

--- a/frontend/public/components/overview/deployment-overview.tsx
+++ b/frontend/public/components/overview/deployment-overview.tsx
@@ -23,7 +23,7 @@ const DeploymentOverviewDetails: React.SFC<DeploymentOverviewDetailsProps> = ({i
       <DeploymentPodCounts resource={item.obj} resourceKind={DeploymentModel} />
     </div>
     <div className="resource-overview__summary">
-      <ResourceSummary resource={item.obj} showPodSelector={true} showNodeSelector={true}>
+      <ResourceSummary resource={item.obj} showPodSelector showNodeSelector>
         <dt>Status</dt>
         <dd>
           {

--- a/frontend/public/components/overview/deployment-overview.tsx
+++ b/frontend/public/components/overview/deployment-overview.tsx
@@ -23,7 +23,7 @@ const DeploymentOverviewDetails: React.SFC<DeploymentOverviewDetailsProps> = ({i
       <DeploymentPodCounts resource={item.obj} resourceKind={DeploymentModel} />
     </div>
     <div className="resource-overview__summary">
-      <ResourceSummary resource={item.obj} showPodSelector={true}>
+      <ResourceSummary resource={item.obj} showPodSelector={true} showNodeSelector={true}>
         <dt>Status</dt>
         <dd>
           {

--- a/frontend/public/components/overview/stateful-set-overview.tsx
+++ b/frontend/public/components/overview/stateful-set-overview.tsx
@@ -10,7 +10,7 @@ import { ResourceOverviewDetails } from './resource-overview-details';
 
 const StatefulSetOverviewDetails: React.SFC<StatefulSetOverviewDetailsProps> = ({item}) =>
   <div className="overview__sidebar-pane-body resource-overview__body">
-    <ResourceSummary resource={item.obj} />
+    <ResourceSummary resource={item.obj} showPodSelector={true} />
   </div>;
 
 const tabs = [

--- a/frontend/public/components/overview/stateful-set-overview.tsx
+++ b/frontend/public/components/overview/stateful-set-overview.tsx
@@ -10,7 +10,7 @@ import { ResourceOverviewDetails } from './resource-overview-details';
 
 const StatefulSetOverviewDetails: React.SFC<StatefulSetOverviewDetailsProps> = ({item}) =>
   <div className="overview__sidebar-pane-body resource-overview__body">
-    <ResourceSummary resource={item.obj} showPodSelector={true} />
+    <ResourceSummary resource={item.obj} showPodSelector showNodeSelector />
   </div>;
 
 const tabs = [

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -50,7 +50,7 @@ const Details_ = ({flags, obj: pvc}) => {
     <SectionHeading text="PersistentVolumeClaim Overview" />
     <div className="row">
       <div className="col-sm-6">
-        <ResourceSummary resource={pvc} showPodSelector={false} showNodeSelector={false}>
+        <ResourceSummary resource={pvc} showNodeSelector={false}>
           <dt>Label Selector</dt>
           <dd><Selector selector={labelSelector} /></dd>
         </ResourceSummary>

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -50,7 +50,7 @@ const Details_ = ({flags, obj: pvc}) => {
     <SectionHeading text="PersistentVolumeClaim Overview" />
     <div className="row">
       <div className="col-sm-6">
-        <ResourceSummary resource={pvc} showNodeSelector={false}>
+        <ResourceSummary resource={pvc}>
           <dt>Label Selector</dt>
           <dd><Selector selector={labelSelector} /></dd>
         </ResourceSummary>

--- a/frontend/public/components/persistent-volume.jsx
+++ b/frontend/public/components/persistent-volume.jsx
@@ -31,7 +31,7 @@ const Row = ({obj}) => <div className="row co-resource-list__item">
 const Details = ({obj}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="PersistentVolume Overview" />
-    <ResourceSummary resource={obj} podSelector="spec.podSelector" showNodeSelector={false} showPodSelector={true} />
+    <ResourceSummary resource={obj} podSelector="spec.podSelector" showNodeSelector={false} showPodSelector />
   </div>
 </React.Fragment>;
 

--- a/frontend/public/components/persistent-volume.jsx
+++ b/frontend/public/components/persistent-volume.jsx
@@ -31,7 +31,7 @@ const Row = ({obj}) => <div className="row co-resource-list__item">
 const Details = ({obj}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="PersistentVolume Overview" />
-    <ResourceSummary resource={obj} podSelector="spec.podSelector" showNodeSelector={false} />
+    <ResourceSummary resource={obj} podSelector="spec.podSelector" showNodeSelector={false} showPodSelector={true} />
   </div>
 </React.Fragment>;
 

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -189,7 +189,7 @@ export const PodDetailsList = ({pod}) => {
 };
 
 export const PodResourceSummary = ({pod}) => (
-  <ResourceSummary resource={pod} showNodeSelector={false}>
+  <ResourceSummary resource={pod}>
     <dt>Node Selector</dt>
     <dd><Selector kind="Node" selector={pod.spec.nodeSelector} /></dd>
   </ResourceSummary>

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -189,7 +189,7 @@ export const PodDetailsList = ({pod}) => {
 };
 
 export const PodResourceSummary = ({pod}) => (
-  <ResourceSummary resource={pod}>
+  <ResourceSummary resource={pod} showNodeSelector>
     <dt>Node Selector</dt>
     <dd><Selector kind="Node" selector={pod.spec.nodeSelector} /></dd>
   </ResourceSummary>

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -189,7 +189,7 @@ export const PodDetailsList = ({pod}) => {
 };
 
 export const PodResourceSummary = ({pod}) => (
-  <ResourceSummary resource={pod} showPodSelector={false} showNodeSelector={false}>
+  <ResourceSummary resource={pod} showNodeSelector={false}>
     <dt>Node Selector</dt>
     <dd><Selector kind="Node" selector={pod.spec.nodeSelector} /></dd>
   </ResourceSummary>

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -19,7 +19,7 @@ const Details = ({obj: replicaSet}) => {
       <SectionHeading text="Replica Set Overview" />
       <div className="row">
         <div className="col-md-6">
-          <ResourceSummary resource={replicaSet}>
+          <ResourceSummary resource={replicaSet} showPodSelector={true}>
             {revision && <React.Fragment>
               <dt>Deployment Revision</dt>
               <dd>{revision}</dd>

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -19,7 +19,7 @@ const Details = ({obj: replicaSet}) => {
       <SectionHeading text="Replica Set Overview" />
       <div className="row">
         <div className="col-md-6">
-          <ResourceSummary resource={replicaSet} showPodSelector={true}>
+          <ResourceSummary resource={replicaSet} showPodSelector={true} showNodeSelector={true}>
             {revision && <React.Fragment>
               <dt>Deployment Revision</dt>
               <dd>{revision}</dd>

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -19,7 +19,7 @@ const Details = ({obj: replicaSet}) => {
       <SectionHeading text="Replica Set Overview" />
       <div className="row">
         <div className="col-md-6">
-          <ResourceSummary resource={replicaSet} showPodSelector={true} showNodeSelector={true}>
+          <ResourceSummary resource={replicaSet} showPodSelector showNodeSelector>
             {revision && <React.Fragment>
               <dt>Deployment Revision</dt>
               <dd>{revision}</dd>

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -14,7 +14,7 @@ const Details = ({obj: replicationController}) => {
       <SectionHeading text="Replication Controller Overview" />
       <div className="row">
         <div className="col-md-6">
-          <ResourceSummary resource={replicationController}>
+          <ResourceSummary resource={replicationController} showPodSelector={true}>
             {revision && <React.Fragment>
               <dt>Deployment Revision</dt>
               <dd>{revision}</dd>

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -14,7 +14,7 @@ const Details = ({obj: replicationController}) => {
       <SectionHeading text="Replication Controller Overview" />
       <div className="row">
         <div className="col-md-6">
-          <ResourceSummary resource={replicationController} showPodSelector={true}>
+          <ResourceSummary resource={replicationController} showPodSelector={true} showNodeSelector={true}>
             {revision && <React.Fragment>
               <dt>Deployment Revision</dt>
               <dd>{revision}</dd>

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -14,7 +14,7 @@ const Details = ({obj: replicationController}) => {
       <SectionHeading text="Replication Controller Overview" />
       <div className="row">
         <div className="col-md-6">
-          <ResourceSummary resource={replicationController} showPodSelector={true} showNodeSelector={true}>
+          <ResourceSummary resource={replicationController} showPodSelector showNodeSelector>
             {revision && <React.Fragment>
               <dt>Deployment Revision</dt>
               <dd>{revision}</dd>

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -166,7 +166,7 @@ const Details = ({obj: rq}) => {
       {showChartRow && <QuotaGaugeCharts quota={rq} resourceTypes={resourceTypes} />}
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={rq} showPodSelector={false} showNodeSelector={false} />
+          <ResourceSummary resource={rq} showNodeSelector={false} />
         </div>
         {scopes && <div className="col-sm-6">
           <dl className="co-m-pane__details">

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -166,7 +166,7 @@ const Details = ({obj: rq}) => {
       {showChartRow && <QuotaGaugeCharts quota={rq} resourceTypes={resourceTypes} />}
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={rq} showNodeSelector={false} />
+          <ResourceSummary resource={rq} />
         </div>
         {scopes && <div className="col-sm-6">
           <dl className="co-m-pane__details">

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -213,7 +213,7 @@ const RouteDetails: React.SFC<RoutesDetailsProps> = ({obj: route}) => <React.Fra
     <SectionHeading text="Route Overview" />
     <div className="row">
       <div className="col-sm-6">
-        <ResourceSummary resource={route} showPodSelector={false} showNodeSelector={false}>
+        <ResourceSummary resource={route} showNodeSelector={false}>
           <dt>{route.spec.to.kind}</dt>
           <dd><ResourceLink kind={route.spec.to.kind} name={route.spec.to.name} namespace={route.metadata.namespace}
             title={route.spec.to.name} />

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -213,7 +213,7 @@ const RouteDetails: React.SFC<RoutesDetailsProps> = ({obj: route}) => <React.Fra
     <SectionHeading text="Route Overview" />
     <div className="row">
       <div className="col-sm-6">
-        <ResourceSummary resource={route} showNodeSelector={false}>
+        <ResourceSummary resource={route}>
           <dt>{route.spec.to.kind}</dt>
           <dd><ResourceLink kind={route.spec.to.kind} name={route.spec.to.name} namespace={route.metadata.namespace}
             title={route.spec.to.name} />

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -66,7 +66,7 @@ const SecretDetails = ({obj: secret}) => {
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="Secret Overview" />
-      <ResourceSummary resource={secret} showPodSelector={false} showNodeSelector={false} />
+      <ResourceSummary resource={secret} showNodeSelector={false} />
     </div>
     <div className="co-m-pane__body">
       <SecretData data={secret.data} type={secret.type} />

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -66,7 +66,7 @@ const SecretDetails = ({obj: secret}) => {
   return <React.Fragment>
     <div className="co-m-pane__body">
       <SectionHeading text="Secret Overview" />
-      <ResourceSummary resource={secret} showNodeSelector={false} />
+      <ResourceSummary resource={secret} />
     </div>
     <div className="co-m-pane__body">
       <SecretData data={secret.data} type={secret.type} />

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -112,7 +112,7 @@ const Details = ({obj: serviceaccount}) => {
     <React.Fragment>
       <div className="co-m-pane__body">
         <SectionHeading text="Service Account Overview" />
-        <ResourceSummary resource={serviceaccount} showNodeSelector={false} />
+        <ResourceSummary resource={serviceaccount} />
       </div>
       <div className="co-m-pane__body co-m-pane__body--alt">
         <SectionHeading text="Secrets" style={{marginBottom: '-20px'}} />

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -112,7 +112,7 @@ const Details = ({obj: serviceaccount}) => {
     <React.Fragment>
       <div className="co-m-pane__body">
         <SectionHeading text="Service Account Overview" />
-        <ResourceSummary resource={serviceaccount} showPodSelector={false} showNodeSelector={false} />
+        <ResourceSummary resource={serviceaccount} showNodeSelector={false} />
       </div>
       <div className="co-m-pane__body co-m-pane__body--alt">
         <SectionHeading text="Secrets" style={{marginBottom: '-20px'}} />

--- a/frontend/public/components/service-binding.tsx
+++ b/frontend/public/components/service-binding.tsx
@@ -38,7 +38,7 @@ const ServiceBindingDetails: React.SFC<ServiceBindingDetailsProps> = ({obj: sb})
       <SectionHeading text="Service Binding Overview" />
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={sb} showNodeSelector={false} />
+          <ResourceSummary resource={sb} />
         </div>
         <div className="col-sm-6">
           <dl className="co-m-pane__details">

--- a/frontend/public/components/service-binding.tsx
+++ b/frontend/public/components/service-binding.tsx
@@ -38,7 +38,7 @@ const ServiceBindingDetails: React.SFC<ServiceBindingDetailsProps> = ({obj: sb})
       <SectionHeading text="Service Binding Overview" />
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={sb} showPodSelector={false} showNodeSelector={false} />
+          <ResourceSummary resource={sb} showNodeSelector={false} />
         </div>
         <div className="col-sm-6">
           <dl className="co-m-pane__details">

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -117,7 +117,7 @@ const ServiceInstanceDetails: React.SFC<ServiceInstanceDetailsProps> = ({obj: si
       <SectionHeading text="Service Instance Overview" />
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={si} showPodSelector={false} showNodeSelector={false} />
+          <ResourceSummary resource={si} showNodeSelector={false} />
         </div>
         <div className="col-sm-6">
           <dl className="co-m-pane__details">

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -117,7 +117,7 @@ const ServiceInstanceDetails: React.SFC<ServiceInstanceDetailsProps> = ({obj: si
       <SectionHeading text="Service Instance Overview" />
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={si} showNodeSelector={false} />
+          <ResourceSummary resource={si} />
         </div>
         <div className="col-sm-6">
           <dl className="co-m-pane__details">

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -115,7 +115,7 @@ const Details = ({obj: s}) => <div className="co-m-pane__body">
   <div className="row">
     <div className="col-sm-6">
       <SectionHeading text="Service Overview" />
-      <ResourceSummary resource={s} showNodeSelector={false} showPodSelector={true}>
+      <ResourceSummary resource={s} showPodSelector={true}>
         <dt>Session Affinity</dt>
         <dd>{s.spec.sessionAffinity || '-'}</dd>
       </ResourceSummary>

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -115,7 +115,7 @@ const Details = ({obj: s}) => <div className="co-m-pane__body">
   <div className="row">
     <div className="col-sm-6">
       <SectionHeading text="Service Overview" />
-      <ResourceSummary resource={s} showPodSelector={true}>
+      <ResourceSummary resource={s} showPodSelector>
         <dt>Session Affinity</dt>
         <dd>{s.spec.sessionAffinity || '-'}</dd>
       </ResourceSummary>

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -115,7 +115,7 @@ const Details = ({obj: s}) => <div className="co-m-pane__body">
   <div className="row">
     <div className="col-sm-6">
       <SectionHeading text="Service Overview" />
-      <ResourceSummary resource={s} showNodeSelector={false}>
+      <ResourceSummary resource={s} showNodeSelector={false} showPodSelector={true}>
         <dt>Session Affinity</dt>
         <dd>{s.spec.sessionAffinity || '-'}</dd>
       </ResourceSummary>

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -26,7 +26,7 @@ const Row = props => <WorkloadListRow {...props} kind={kind} actions={menuAction
 const Details = ({obj: ss}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="StatefulSet Overview" />
-    <ResourceSummary resource={ss} showNodeSelector={false} />
+    <ResourceSummary resource={ss} showNodeSelector={false} showPodSelector={true} />
   </div>
   <div className="co-m-pane__body">
     <SectionHeading text="Containers" />

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -26,7 +26,7 @@ const Row = props => <WorkloadListRow {...props} kind={kind} actions={menuAction
 const Details = ({obj: ss}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="StatefulSet Overview" />
-    <ResourceSummary resource={ss} showPodSelector={true} />
+    <ResourceSummary resource={ss} showPodSelector showNodeSelector />
   </div>
   <div className="co-m-pane__body">
     <SectionHeading text="Containers" />

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -26,7 +26,7 @@ const Row = props => <WorkloadListRow {...props} kind={kind} actions={menuAction
 const Details = ({obj: ss}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="StatefulSet Overview" />
-    <ResourceSummary resource={ss} showNodeSelector={false} showPodSelector={true} />
+    <ResourceSummary resource={ss} showPodSelector={true} />
   </div>
   <div className="co-m-pane__body">
     <SectionHeading text="Containers" />

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -44,7 +44,7 @@ const StorageClassRow: React.SFC<StorageClassRowProps> = ({obj}) => {
 const StorageClassDetails: React.SFC<StorageClassDetailsProps> = ({obj}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="StorageClass Overview" />
-    <ResourceSummary resource={obj} showNodeSelector={false}>
+    <ResourceSummary resource={obj}>
       <dt>Provisioner</dt>
       <dd>{obj.provisioner || '-'}</dd>
       <dt>Reclaim Policy</dt>

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -44,7 +44,7 @@ const StorageClassRow: React.SFC<StorageClassRowProps> = ({obj}) => {
 const StorageClassDetails: React.SFC<StorageClassDetailsProps> = ({obj}) => <React.Fragment>
   <div className="co-m-pane__body">
     <SectionHeading text="StorageClass Overview" />
-    <ResourceSummary resource={obj} showNodeSelector={false} showPodSelector={false}>
+    <ResourceSummary resource={obj} showNodeSelector={false}>
       <dt>Provisioner</dt>
       <dd>{obj.provisioner || '-'}</dd>
       <dt>Reclaim Policy</dt>

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -15,7 +15,7 @@ export const detailsPage = <T extends {}>(Component: React.ComponentType<T>) => 
   return <Component {...props} />;
 };
 
-export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, resource, showPodSelector = false, showNodeSelector = true, showAnnotations = true, podSelector = 'spec.selector'}) => {
+export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, resource, showPodSelector = false, showNodeSelector = false, showAnnotations = true, podSelector = 'spec.selector'}) => {
   const { metadata, type } = resource;
   const reference = referenceFor(resource);
   const model = modelFor(reference);

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -15,7 +15,7 @@ export const detailsPage = <T extends {}>(Component: React.ComponentType<T>) => 
   return <Component {...props} />;
 };
 
-export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, resource, showPodSelector = true, showNodeSelector = true, showAnnotations = true, podSelector = 'spec.selector'}) => {
+export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, resource, showPodSelector = false, showNodeSelector = true, showAnnotations = true, podSelector = 'spec.selector'}) => {
   const { metadata, type } = resource;
   const reference = referenceFor(resource);
   const model = modelFor(reference);


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1289

Change Summary Page showPodSelector property to default to false (to not show the pod selector).
Update components referencing the ResourceSummary to account for the change.