### PR TITLE
Only store swagger.json definitions

### DIFF
--- a/frontend/__tests__/module/k8s/autocomplete.spec.ts
+++ b/frontend/__tests__/module/k8s/autocomplete.spec.ts
@@ -85,22 +85,20 @@ describe('getCompletions', () => {
   });
 
   it('invokes callback with appropriate completions for properties', (done) => {
-    const swagger = {
-      definitions: {
-        'io.k8s.api.apps.v1.Deployment': {},
-        'io.k8s.api.apps.v1.DeploymentSpec': {
-          properties: {
-            minReadySeconds: {
-              description: 'Dummy property',
-              type: 'integer',
-              format: 'int32',
-            },
+    const definitions = {
+      'io.k8s.api.apps.v1.Deployment': {},
+      'io.k8s.api.apps.v1.DeploymentSpec': {
+        properties: {
+          minReadySeconds: {
+            description: 'Dummy property',
+            type: 'integer',
+            format: 'int32',
           },
         },
       },
     };
     sessionMock.getLines = jasmine.createSpy('getLinesSpy').and.returnValue(['kind: Deployment', 'apiVersion: apps/v1']);
-    spyOn(window.localStorage, 'getItem').and.returnValue(JSON.stringify(swagger));
+    spyOn(window.sessionStorage, 'getItem').and.returnValue(JSON.stringify(definitions));
 
     getCompletions(editorMock, sessionMock, position, '', (error, results) => {
       expect(results.length).toEqual(1);
@@ -116,7 +114,7 @@ describe('getCompletions', () => {
 
   it('does not provide completion for properties if k8s API spec cannot be retrieved', (done) => {
     sessionMock.getLines = jasmine.createSpy('getLinesSpy').and.returnValue(['kind: Deployment', 'apiVersion: apps/v1']);
-    spyOn(window.localStorage, 'getItem').and.returnValue(null);
+    spyOn(window.sessionStorage, 'getItem').and.returnValue(null);
 
     getCompletions(editorMock, sessionMock, position, '', (error, results) => {
       fail('Should not have been called');

--- a/frontend/public/const.js
+++ b/frontend/public/const.js
@@ -26,6 +26,7 @@ export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
 export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-namespace-name`;
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
 export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/community-providers-warning`;
+export const SWAGGER_SESSION_STORAGE_KEY = `${STORAGE_PREFIX}/${window.SERVER_FLAGS.consoleVersion}/swagger-definitions`;
 
 // Bootstrap user for OpenShift 4.0 clusters
 export const KUBE_ADMIN_USERNAME = 'kube:admin';


### PR DESCRIPTION
sessionStorage has limited space. Only store what we're using for the YAML editor.