### PR TITLE
Change CRD link and update kebab/actions

### DIFF
--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -271,14 +271,16 @@ describe('Kubernetes resource CRUD operations', () => {
     it('displays YAML editor for creating a new custom resource instance', async() => {
       await browser.get(`${appHost}/k8s/cluster/customresourcedefinitions?name=${name}`);
       await crudView.isLoaded();
-      await crudView.resourceRows.first().element(by.linkText(crd.spec.names.kind)).click();
+      await crudView.resourceRows.$$('.co-kebab__button').click();
+      await browser.wait(until.elementToBeClickable($('.co-kebab__dropdown')));
+      await $('.co-kebab__dropdown').$$('a').filter(link => link.getText().then(text => text.startsWith('View Instances'))).first().click();
       await crudView.isLoaded();
       await crudView.createYAMLButton.click();
       await yamlView.isLoaded();
       expect(yamlView.editorContent.getText()).toContain(`kind: CRD${testName}`);
     });
 
-    xit('creates a new custom resource instance', async() => {
+    it('creates a new custom resource instance', async() => {
       leakedResources.add(JSON.stringify({name, plural: 'customresourcedefinitions'}));
       await yamlView.saveButton.click();
       expect(crudView.errorMessage.isPresent()).toBe(false);

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -107,6 +107,7 @@ export const resourceDetailPages = ImmutableMap<GroupVersionKind | string, () =>
   .set(ReportReference, () => import('./chargeback' /* webpackChunkName: "chargeback" */).then(m => m.ReportsDetailsPage))
   .set(ReportGenerationQueryReference, () => import('./chargeback' /* webpackChunkName: "chargeback" */).then(m => m.ReportGenerationQueriesDetailsPage))
   .set(referenceForModel(StorageClassModel), () => import('./storage-class' /* webpackChunkName: "storage-class" */).then(m => m.StorageClassDetailsPage))
+  .set(referenceForModel(CustomResourceDefinitionModel), () => import('./custom-resource-definition' /* webpackChunkName: "custom-resource-definition" */).then(m => m.CustomResourceDefinitionsDetailsPage))
   .set(referenceForModel(ClusterServiceVersionModel), () => import('./operator-lifecycle-manager/clusterserviceversion' /* webpackChunkName: "clusterserviceversion" */).then(m => m.ClusterServiceVersionsDetailsPage))
   .set(referenceForModel(CatalogSourceModel), () => import('./operator-lifecycle-manager/catalog-source' /* webpackChunkName: "catalog-source" */).then(m => m.CatalogSourceDetailsPage))
   .set(referenceForModel(SubscriptionModel), () => import('./operator-lifecycle-manager/subscription' /* webpackChunkName: "subscription" */).then(m => m.SubscriptionDetailsPage))


### PR DESCRIPTION
Changed the links for the CRD list page to go to the details page instead of the instances page. Updated the kebab and actions menu with a link to the instances page.

![screen shot 2019-02-26 at 11 42 38 am](https://user-images.githubusercontent.com/7014965/53430040-b92e5600-39bb-11e9-9715-dc8784399d8a.png)

![screen shot 2019-02-26 at 11 42 48 am](https://user-images.githubusercontent.com/7014965/53430050-bd5a7380-39bb-11e9-80f8-aff74dc0064f.png)

Fixes https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-1210