### PR TITLE
Adjust modal height at landscape orientation so that buttons aren't beneath viewport on ios.

### DIFF
--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -82,8 +82,8 @@
   height: calc(100% - 20px); // subtract height margin-top 10px + margin-bottom 10px
   outline: 0;
 
-  @media(min-width: $screen-sm-min) {
-    height: calc(100% - 60px); // subtract height margin-top 30px + margin-bottom 30px
+  @media(min-width: $screen-sm-min), (max-width: $screen-xs-max) and (orientation: landscape) {
+    height: calc(100% - 60px); // At desktop, subtract margin-top 30px + margin-bottom 30px OR in the case of mobile landscape orientation, subtract the height of ios url control bar, since its height is not taken into account when the viewport height is calculated on initial page load. This causes the modal to extend below the viewport and hide modal-footer buttons.
   }
 }
 


### PR DESCRIPTION
Currently modal-footer buttons are off iOS mobile screens at landscape orientation. This is because of how the URL control bar* isn't taken into account when calculating viewport height. 

Even though this change prevents modals on Android from being full height of the viewport, it seems acceptable, in order to prevent annoying scroll issue on iOS and the scope is restricted to landscape orientation only.

Fixes https://jira.coreos.com/browse/CONSOLE-658
Notes on the problem
* https://github.com/bokand/URLBarSizing and https://medium.com/samsung-internet-dev/toolbars-keyboards-and-the-viewports-10abcc6c3769

**before**
<img width="538" alt="screen shot 2019-02-26 at 1 27 58 pm" src="https://user-images.githubusercontent.com/1874151/53438876-d3256400-39ce-11e9-9bd2-5e84dbf34b80.png">
<img width="538" alt="screen shot 2019-02-26 at 1 29 48 pm" src="https://user-images.githubusercontent.com/1874151/53438877-d3256400-39ce-11e9-9f8b-9097afc09d81.png">

**after**

<img width="523" alt="screen shot 2019-02-26 at 1 33 09 pm" src="https://user-images.githubusercontent.com/1874151/53439843-1f71a380-39d1-11e9-8d50-06d2f8cc15f9.png">
<img width="549" alt="screen shot 2019-02-26 at 1 34 24 pm" src="https://user-images.githubusercontent.com/1874151/53439844-1f71a380-39d1-11e9-9eb6-9286143ff997.png">

<img width="547" alt="screen shot 2019-02-26 at 2 15 31 pm" src="https://user-images.githubusercontent.com/1874151/53439801-049f2f00-39d1-11e9-891a-7d367c05525b.png">

