### PR TITLE
Align line-height for copy-to-clipboard to match height of copy button

### DIFF
--- a/frontend/public/components/utils/_copy-to-clipboard.scss
+++ b/frontend/public/components/utils/_copy-to-clipboard.scss
@@ -12,6 +12,7 @@
 }
 
 .co-copy-to-clipboard__text {
+  line-height: 1.4;
   padding-right: 50px;
 }
 


### PR DESCRIPTION
Just a small style adjustment but the line height was killing my feng-shui :shinto_shrine:

Before:
![1](https://user-images.githubusercontent.com/1668218/53496762-fd485600-3aa2-11e9-91c4-bb92ea8d7359.png)


After:
![2](https://user-images.githubusercontent.com/1668218/53496775-03d6cd80-3aa3-11e9-9b07-ac8e608bd188.png)

/assign @rhamilto 
