### PR TITLE
Correctly show cluster operator operand versions

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -12,14 +12,17 @@ import {
 } from '../factory';
 import {
   getClusterOperatorStatus,
+  getClusterOperatorVersion,
   getStatusAndMessage,
-  K8sResourceKind,
+  ClusterOperator,
   K8sResourceKindReference,
+  OperandVersion,
   OperatorStatus,
   referenceForModel,
 } from '../../module/k8s';
 import {
   navFactory,
+  EmptyBox,
   ResourceLink,
   ResourceSummary,
   SectionHeading,
@@ -46,11 +49,12 @@ const ClusterOperatorHeader = props => <ListHeader>
   <ColHead {...props} className="col-md-3 col-sm-3 col-xs-6" sortField="metadata.name">Name</ColHead>
   <ColHead {...props} className="col-md-2 col-sm-3 col-xs-6" sortFunc="getClusterOperatorStatus">Status</ColHead>
   <ColHead {...props} className="col-md-4 col-sm-3 hidden-xs">Message</ColHead>
-  <ColHead {...props} className="col-md-3 col-sm-3 hidden-xs" sortField="status.version">Version</ColHead>
+  <ColHead {...props} className="col-md-3 col-sm-3 hidden-xs" sortFunc="getClusterOperatorVersion">Version</ColHead>
 </ListHeader>;
 
 const ClusterOperatorRow: React.SFC<ClusterOperatorRowProps> = ({obj}) => {
   const { status, message } = getStatusAndMessage(obj);
+  const operatorVersion = getClusterOperatorVersion(obj);
   return <div className="row co-resource-list__item">
     <div className="col-md-3 col-sm-3 col-xs-6">
       <ResourceLink kind={clusterOperatorReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
@@ -62,7 +66,7 @@ const ClusterOperatorRow: React.SFC<ClusterOperatorRowProps> = ({obj}) => {
       {message ? _.truncate(message, { length: 256, separator: ' ' }) : '-'}
     </div>
     <div className="col-md-3 col-sm-3 hidden-xs">
-      {_.get(obj, 'status.version') || <span className="text-muted">Unknown</span>}
+      {operatorVersion || '-'}
     </div>
   </div>;
 };
@@ -96,17 +100,50 @@ export const ClusterOperatorPage: React.SFC<ClusterOperatorPageProps> = props =>
     rowFilters={filters}
   />;
 
+const OperandVersions: React.SFC<OperandVersionsProps> = ({versions}) => {
+  return _.isEmpty(versions)
+    ? <EmptyBox label="Versions" />
+    : <div className="co-table-container">
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Version</th>
+          </tr>
+        </thead>
+        <tbody>
+          {_.map(versions, ({name, version}, i) => (
+            <tr key={i}>
+              <td>{name}</td>
+              <td>{version}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>;
+};
+
+
 const ClusterOperatorDetails: React.SFC<ClusterOperatorDetailsProps> = ({obj}) => {
   const { status, message } = getStatusAndMessage(obj);
-  return <div className="co-m-pane__body">
-    <SectionHeading text="Cluster Operator Overview" />
-    <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
-      <dt>Status</dt>
-      <dd><OperatorStatusIconAndLabel status={status} /></dd>
-      <dt>Message</dt>
-      <dd>{message || '-'}</dd>
-    </ResourceSummary>
-  </div>;
+  const versions: OperandVersion[] = _.get(obj, 'status.versions', []);
+  return (
+    <React.Fragment>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Cluster Operator Overview" />
+        <ResourceSummary resource={obj} showPodSelector={false} showNodeSelector={false}>
+          <dt>Status</dt>
+          <dd><OperatorStatusIconAndLabel status={status} /></dd>
+          <dt>Message</dt>
+          <dd className="co-pre-line">{message || '-'}</dd>
+        </ResourceSummary>
+      </div>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Operand Versions" />
+        <OperandVersions versions={versions} />
+      </div>
+    </React.Fragment>
+  );
 };
 
 export const ClusterOperatorDetailsPage: React.SFC<ClusterOperatorDetailsPageProps> = props =>
@@ -121,7 +158,7 @@ type OperatorStatusIconAndLabelProps = {
 };
 
 type ClusterOperatorRowProps = {
-  obj: K8sResourceKind;
+  obj: ClusterOperator;
 };
 
 type ClusterOperatorPageProps = {
@@ -129,8 +166,12 @@ type ClusterOperatorPageProps = {
   showTitle?: boolean;
 };
 
+type OperandVersionsProps = {
+  versions: OperandVersion[];
+};
+
 type ClusterOperatorDetailsProps = {
-  obj: K8sResourceKind;
+  obj: ClusterOperator;
 };
 
 type ClusterOperatorDetailsPageProps = {

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -48,6 +48,7 @@ import {
   serviceCatalogStatus,
   serviceClassDisplayName,
   getClusterOperatorStatus,
+  getClusterOperatorVersion,
 } from '../../module/k8s';
 
 const fuzzyCaseInsensitive = (a, b) => fuzzy(_.toLower(a), _.toLower(b));
@@ -236,6 +237,7 @@ const sorts = {
   silenceStateOrder,
   string: val => JSON.stringify(val),
   getClusterOperatorStatus,
+  getClusterOperatorVersion,
 };
 
 export class ColHead extends React.Component<ColHeadProps> {

--- a/frontend/public/module/k8s/cluster-operator.ts
+++ b/frontend/public/module/k8s/cluster-operator.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars, no-undef */
 import * as _ from 'lodash-es';
-import { K8sResourceKind } from '.';
+import { ClusterOperator, OperandVersion } from '.';
 
 export enum OperatorStatus {
   Available = 'Available',
@@ -9,7 +9,7 @@ export enum OperatorStatus {
   Unknown = 'Unknown',
 }
 
-export const getStatusAndMessage = (operator: K8sResourceKind) => {
+export const getStatusAndMessage = (operator: ClusterOperator) => {
   const conditions = _.get(operator, 'status.conditions');
   const failing: any = _.find(conditions, { type: 'Failing', status: 'True' });
   if (failing) {
@@ -29,7 +29,13 @@ export const getStatusAndMessage = (operator: K8sResourceKind) => {
   return { status: OperatorStatus.Unknown, message: '' };
 };
 
-export const getClusterOperatorStatus = (operator: K8sResourceKind) => {
+export const getClusterOperatorStatus = (operator: ClusterOperator) => {
   const { status } = getStatusAndMessage(operator);
   return status;
+};
+
+export const getClusterOperatorVersion = (operator: ClusterOperator) => {
+  const versions: OperandVersion[] = _.get(operator, 'status.versions', []);
+  const operatorVersion = _.find(versions, v => v.name === 'operator');
+  return operatorVersion ? operatorVersion.version : '';
 };

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -242,6 +242,27 @@ export type ClusterVersionKind = {
   };
 } & K8sResourceKind;
 
+export type OperandVersion = {
+  name: string;
+  version: string;
+};
+
+type ClusterOperatorObjectReference = {
+  group: string;
+  resource: string;
+  namespace?: string;
+  name: string;
+};
+
+export type ClusterOperator = {
+  spec: {};
+  status: {
+    conditions?: any[];
+    versions?: OperandVersion[];
+    relatedObjects?: ClusterOperatorObjectReference[];
+  };
+} & K8sResourceKind;
+
 export type K8sKind = {
   abbr: string;
   kind: string;


### PR DESCRIPTION
The cluster operator no longer has a single version field. It has a list
of versions instead. Remove the version from the cluster operator table
since it's too much data for a table column and show the operand
versions on the details page instead.

/assign @TheRealJon 

![screen shot 2019-02-28 at 10 10 05 am](https://user-images.githubusercontent.com/1167259/53576433-9cbc2600-3b41-11e9-9569-2619a9c29204.png)

![screen shot 2019-02-28 at 10 10 18 am](https://user-images.githubusercontent.com/1167259/53576437-9e85e980-3b41-11e9-9718-3d817d70d4e8.png)
