### PR TITLE
Bug 1683755: Switch icon for updating clusters

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -30,7 +30,7 @@ export const clusterOperatorReference: K8sResourceKindReference = referenceForMo
 const getIconClass = (status: OperatorStatus) => {
   return {
     [OperatorStatus.Available]: 'pficon pficon-ok text-success',
-    [OperatorStatus.Updating]: 'pficon pficon-in-progress',
+    [OperatorStatus.Updating]: 'fa fa-refresh',
     [OperatorStatus.Failing]: 'pficon pficon-error-circle-o text-danger',
   }[status];
 };

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -77,7 +77,7 @@ const getIconClass = (status: ClusterUpdateStatus) => {
   return {
     [ClusterUpdateStatus.UpToDate]: 'pficon pficon-ok',
     [ClusterUpdateStatus.UpdatesAvailable]: 'fa fa-arrow-circle-o-up',
-    [ClusterUpdateStatus.Updating]: 'fa-spin pficon pficon-in-progress',
+    [ClusterUpdateStatus.Updating]: 'fa-spin fa fa-refresh',
     [ClusterUpdateStatus.Failing]: 'pficon pficon-error-circle-o',
     [ClusterUpdateStatus.ErrorRetrieving]: 'pficon pficon-error-circle-o',
   }[status];

--- a/frontend/public/components/utils/status-icon.tsx
+++ b/frontend/public/components/utils/status-icon.tsx
@@ -9,27 +9,29 @@ export const StatusIcon: React.FunctionComponent<StatusIconProps> = ({status}) =
   }
 
   switch (status) {
+    case 'New':
+      return <span className="co-icon-and-text"><Icon type="fa" name="hourglass-1" className="co-icon-and-text__icon" /><CamelCaseWrap value={status} /></span>;
 
     case 'Pending':
       return <span className="co-icon-and-text"><Icon type="fa" name="hourglass-half" className="co-icon-and-text__icon" /><CamelCaseWrap value={status} /></span>;
 
-    case 'Expired':
+    case 'ContainerCreating':
+      return <span className="co-icon-and-text"><Icon type="pf" name="in-progress" className="co-icon-and-text__icon" /><CamelCaseWrap value={status} /></span>;
+
+    case 'In Progress':
+    case 'Running':
+    case 'Updating':
+    case 'Upgrading':
+      return <span className="co-icon-and-text"><Icon type="fa" name="refresh" className="co-icon-and-text__icon" /><CamelCaseWrap value={status} /></span>;
+
     case 'Cancelled':
+    case 'Expired':
     case 'Not Ready':
     case 'Terminating':
       return <span className="co-icon-and-text"><Icon type="fa" name="ban" className="co-icon-and-text__icon" /><CamelCaseWrap value={status} /></span>;
 
     case 'Warning':
       return <span className="co-icon-and-text"><Icon type="pf" name="warning-triangle-o" className="co-icon-and-text__icon" /><CamelCaseWrap value={status} /></span>;
-
-    case 'Running':
-      return <span className="co-icon-and-text"><Icon type="fa" name="refresh" className="co-icon-and-text__icon" /><CamelCaseWrap value={status} /></span>;
-
-    case 'ContainerCreating':
-    case 'Updating':
-    case 'Upgrading':
-    case 'In Progress':
-      return <span className="co-icon-and-text"><Icon type="pf" name="in-progress" className="co-icon-and-text__icon" /><CamelCaseWrap value={status} /></span>;
 
     case 'ContainerCannotRun':
     case 'CrashLoopBackOff':
@@ -53,9 +55,6 @@ export const StatusIcon: React.FunctionComponent<StatusIconProps> = ({status}) =
 
     case 'Unknown':
       return <span className="co-icon-and-text"><Icon type="pf" name="unknown" className="co-icon-and-text__icon" /><CamelCaseWrap value={status} /></span>;
-
-    case 'New':
-      return <span className="co-icon-and-text"><Icon type="fa" name="hourglass-1" className="co-icon-and-text__icon" /><CamelCaseWrap value={status} /></span>;
 
     default:
       return <span><CamelCaseWrap value={status} /></span>;


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1683755

We've gotten feedback that `pficon-in-progress` doesn't convey "updating" well on the cluster settings page when it's not animated. If we spin the icon in the cluster operator table, however, the animation is distracting since there are so many moving icons and they can get out of phase.

Note that  we use `pficon-in-progress` for pending pods and `fa-refresh` for running pods. I'd argue that an updating cluster operator is closer to a running pod than a pending pod since pending a waiting state.

This PR changes the icon to `fa-refresh` for updating cluster operators.

@openshift/team-ux-review Thoughts?

cc @tracyrankin @jwforres @pweil-

![cluster settings openshift 2019-02-28 13-17-12](https://user-images.githubusercontent.com/1167259/53588561-33e1a780-3b5b-11e9-941f-07f28f1b8fb0.png)