### PR TITLE
[WIP] Add CLI download link

### DIFF
--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { ArrowCircleUpIcon, QuestionCircleIcon, ThIcon } from '@patternfly/react-icons';
 import { Button, Dropdown, DropdownToggle, DropdownSeparator, DropdownItem, KebabToggle, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 
+import { CLI_DOWNLOAD_LINK } from '../const';
 import { FLAGS, stateToProps as flagStateToProps, flagPending } from '../features';
 import { authSvc } from '../module/auth';
 import { history, Firehose } from './utils';
@@ -143,6 +144,11 @@ class MastheadToolbar_ extends React.Component {
     window.open(openshiftHelpBase, '_blank').opener = null;
   }
 
+  _onCLIDownload(e) {
+    e.preventDefault();
+    window.open(CLI_DOWNLOAD_LINK, '_blank').opener = null;
+  }
+
   _renderMenuItems(actions) {
     return actions.map((action, i) => action.separator
       ? <DropdownSeparator key={i} />
@@ -185,7 +191,10 @@ class MastheadToolbar_ extends React.Component {
       actions.unshift({
         label: 'Documentation',
         callback: this._onDocumentation,
-      },{
+      }, {
+        label: 'CLI Download',
+        callback: this._onCLIDownload,
+      }, {
         label: 'About',
         callback: this._onAboutModal,
       });
@@ -275,6 +284,9 @@ class MastheadToolbar_ extends React.Component {
                 dropdownItems={[
                   <DropdownItem key="documentation" onClick={this._onDocumentation}>
                     Documentation
+                  </DropdownItem>,
+                  <DropdownItem key="cli" onClick={this._onCLIDownload}>
+                    CLI Download
                   </DropdownItem>,
                   <DropdownItem key="about" onClick={this._onAboutModal}>
                     About

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -14,7 +14,7 @@ import { ActionsMenu, Kebab, Dropdown, Firehose, LabelList, LoadingInline, navFa
 import { createNamespaceModal, createProjectModal, deleteNamespaceModal, configureNamespacePullSecretModal } from './modals';
 import { RoleBindingsPage } from './RBAC';
 import { Bar, Line, requirePrometheus } from './graphs';
-import { NAMESPACE_LOCAL_STORAGE_KEY, ALL_NAMESPACES_KEY } from '../const';
+import { CLI_DOWNLOAD_LINK, ALL_NAMESPACES_KEY, NAMESPACE_LOCAL_STORAGE_KEY } from '../const';
 import { FLAGS, featureReducerName, flagPending, setFlag, connectToFlags } from '../features';
 import { openshiftHelpBase } from './utils/documentation';
 import { createProjectMessageStateToProps } from '../ui/ui-reducers';
@@ -111,6 +111,9 @@ const ProjectList_ = props => {
     </p>
     <p>
       To learn more, visit the OpenShift <ExternalLink href={openshiftHelpBase} text="documentation" />.
+    </p>
+    <p>
+      Download the command-line tools <ExternalLink href={CLI_DOWNLOAD_LINK} text="here" />.
     </p>
   </React.Fragment>;
   const ProjectEmptyMessage = () => <MsgBox title="Welcome to OpenShift" detail={ProjectEmptyMessageDetail} />;

--- a/frontend/public/const.js
+++ b/frontend/public/const.js
@@ -36,3 +36,5 @@ export const RH_OPERATOR_SUPPORT_POLICY_LINK = 'https://access.redhat.com/third-
 
 // Package manifests for the Operator Hub use this label.
 export const OPERATOR_HUB_LABEL = 'openshift-marketplace';
+
+export const CLI_DOWNLOAD_LINK = 'https://mirror.openshift.com/pub/openshift-v3/clients/';


### PR DESCRIPTION
Opening this to get feedback. It adds a CLI download link to the UI. It uses this link:

https://mirror.openshift.com/pub/openshift-v3/clients/

The biggest problem is that it's not a direct link to the version that the cluster is running. The user will have to pick the correct version. I think this is better than having no link at all, however.

We could add an option to the console config to make this customizable, but then it would be up to the cluster admin to set the right value.

Related issue: https://bugzilla.redhat.com/show_bug.cgi?id=1666573

cc @nstielau @bparees @oourfali @jwforres @brenton 

![screen shot 2019-03-01 at 3 01 50 pm](https://user-images.githubusercontent.com/1167259/53663162-0c5e0e00-3c33-11e9-9805-547ca9df9a7e.png)
