### PR TITLE
auth: use proxy from environment when connecting to OAuth server

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -151,6 +151,7 @@ func newHTTPClient(issuerCA string, includeSystemRoots bool) (*http.Client, erro
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs: certPool,
 			},


### PR DESCRIPTION
Fixes #1248 

https://jira.coreos.com/browse/CONSOLE-1440