### PR TITLE
Fix bug where position of .co-m-modal-link icon differed across browsers

### DIFF
--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -396,18 +396,17 @@
   outline: none;
   padding-right:  20px;
   position: relative;
-  &:after {
+  &::after {
     color: $color-pf-black-600;
     content: $pficon-var-edit;
     font-family: $icon-font-name-pf;
+    line-height: 1;
     pointer-events: none;
     position: absolute;
     right: 0;
+    top: 0;
   }
-  &:focus {
-    outline: none;
-  }
-  &:hover:after {
+  &:hover::after {
     color: $color-pf-black-700;
   }
 }


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1311

MacOS Chrome and Firefox
![screen shot 2019-03-05 at 9 58 37 am](https://user-images.githubusercontent.com/895728/53814451-a244b200-3f2d-11e9-9ee2-da854c47cb43.png)

Windows 10 Firefox, Edge, Chrome
![screen shot 2019-03-05 at 9 57 35 am](https://user-images.githubusercontent.com/895728/53814493-b5f01880-3f2d-11e9-8a38-f78a712f7009.png)
