### PR TITLE
Fix bug where Operator Hub empty state background did not fill viewport

### DIFF
--- a/frontend/public/components/utils/error-boundary.tsx
+++ b/frontend/public/components/utils/error-boundary.tsx
@@ -37,7 +37,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
     const FallbackComponent = this.props.FallbackComponent || DefaultFallback;
     return hasError
       ? <FallbackComponent title={error.name} componentStack={errorInfo.componentStack} errorMessage={error.message} stack={error.stack} />
-      : <div>{this.props.children}</div>;
+      : <React.Fragment>{this.props.children}</React.Fragment>;
   }
 }
 


### PR DESCRIPTION
Before:
![localhost_9000_operatorhub_all-namespaces](https://user-images.githubusercontent.com/895728/53820924-c8bd1a00-3f3a-11e9-8334-2028de248297.png)

After:
![localhost_9000_operatorhub_all-namespaces 1](https://user-images.githubusercontent.com/895728/53820988-e4282500-3f3a-11e9-9027-f6c3fdc498be.png)
