### PR TITLE
Add "Copy Login Command" modal

### DIFF
--- a/auth/auth_oidc.go
+++ b/auth/auth_oidc.go
@@ -74,7 +74,7 @@ func (o *oidcAuth) login(w http.ResponseWriter, token *oauth2.Token) (*loginStat
 		Name:     openshiftSessionCookieName,
 		Value:    ls.sessionToken,
 		MaxAge:   maxAge(ls.exp, time.Now()),
-		HttpOnly: true,
+		HttpOnly: false,
 		Path:     o.cookiePath,
 		Secure:   o.secureCookies,
 	}
@@ -94,7 +94,7 @@ func (o *oidcAuth) logout(w http.ResponseWriter, r *http.Request) {
 		Name:     openshiftSessionCookieName,
 		Value:    "",
 		MaxAge:   0,
-		HttpOnly: true,
+		HttpOnly: false,
 		Path:     o.cookiePath,
 		Secure:   o.secureCookies,
 	}

--- a/auth/auth_openshift.go
+++ b/auth/auth_openshift.go
@@ -134,7 +134,7 @@ func (o *openShiftAuth) login(w http.ResponseWriter, token *oauth2.Token) (*logi
 		Name:     openshiftSessionCookieName,
 		Value:    ls.rawToken,
 		MaxAge:   int(expiresIn),
-		HttpOnly: true,
+		HttpOnly: false,
 		Path:     o.cookiePath,
 		Secure:   o.secureCookies,
 	}
@@ -150,8 +150,8 @@ func (o *openShiftAuth) logout(w http.ResponseWriter, r *http.Request) {
 	cookie := http.Cookie{
 		Name:     openshiftSessionCookieName,
 		Value:    "",
+		HttpOnly: false,
 		MaxAge:   0,
-		HttpOnly: true,
 		Path:     o.cookiePath,
 		Secure:   o.secureCookies,
 	}

--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -84,11 +84,13 @@ export class TimeoutError extends Error {
   }
 }
 
-const cookiePrefix = 'csrf-token=';
-export const getCSRFToken = () => document && document.cookie && document.cookie.split(';')
+export const getCookie = cookiePrefix => document && document.cookie && document.cookie.split(';')
   .map(c => _.trim(c))
   .filter(c => c.startsWith(cookiePrefix))
   .map(c => c.slice(cookiePrefix.length)).pop();
+
+const csrfCookiePrefix = 'csrf-token=';
+export const getCSRFToken = () => getCookie(csrfCookiePrefix);
 
 export const coFetch = (url, options = {}, timeout=20000) => {
   const allOptions = _.defaultsDeep({}, initDefaults, options);

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -10,6 +10,9 @@ import { history, Firehose } from './utils';
 import { openshiftHelpBase } from './utils/documentation';
 import { AboutModal } from './about-modal';
 import { getAvailableClusterUpdates, clusterVersionReference } from '../module/k8s/cluster-settings';
+import { CopyLoginCommandModal } from './modals/copy-login-command-modal';
+
+const apiServerURL = window.SERVER_FLAGS.kubeAPIServerURL;
 
 const UpdatesAvailableButton = ({obj, onClick}) => {
   const updatesAvailable = !_.isEmpty(getAvailableClusterUpdates(obj.data));
@@ -32,6 +35,7 @@ class MastheadToolbar_ extends React.Component {
       username: null,
       isKubeAdmin: false,
       showAboutModal: false,
+      showCopyLoginCommand: false,
     };
 
     this._updateUser = this._updateUser.bind(this);
@@ -48,6 +52,8 @@ class MastheadToolbar_ extends React.Component {
     this._onHelpDropdownToggle = this._onHelpDropdownToggle.bind(this);
     this._onAboutModal = this._onAboutModal.bind(this);
     this._closeAboutModal = this._closeAboutModal.bind(this);
+    this._onCopyLoginCommand = this._onCopyLoginCommand.bind(this);
+    this._closeCopyLoginCommand = this._closeCopyLoginCommand.bind(this);
   }
 
   componentDidMount() {
@@ -138,6 +144,15 @@ class MastheadToolbar_ extends React.Component {
     this.setState({ showAboutModal: false });
   }
 
+  _onCopyLoginCommand(e) {
+    e.preventDefault();
+    this.setState({ showCopyLoginCommand: true });
+  }
+
+  _closeCopyLoginCommand() {
+    this.setState({ showCopyLoginCommand: false });
+  }
+
   _onDocumentation(e) {
     e.preventDefault();
     window.open(openshiftHelpBase, '_blank').opener = null;
@@ -168,6 +183,13 @@ class MastheadToolbar_ extends React.Component {
           authSvc.logout();
         }
       };
+
+      if (flags[FLAGS.OPENSHIFT] && apiServerURL) {
+        actions.push({
+          label: 'Copy Login Command',
+          callback: this._onCopyLoginCommand,
+        });
+      }
 
       if (mobile) {
         actions.push({
@@ -228,7 +250,7 @@ class MastheadToolbar_ extends React.Component {
   }
 
   render() {
-    const { isApplicationLauncherDropdownOpen, isHelpDropdownOpen, showAboutModal } = this.state;
+    const { isApplicationLauncherDropdownOpen, isHelpDropdownOpen, showAboutModal, showCopyLoginCommand, username } = this.state;
     const { flags } = this.props;
     const resources = [{
       kind: clusterVersionReference,
@@ -291,6 +313,7 @@ class MastheadToolbar_ extends React.Component {
           </ToolbarGroup>
         </Toolbar>
         {showAboutModal && <AboutModal isOpen={showAboutModal} closeAboutModal={this._closeAboutModal} />}
+        {showCopyLoginCommand && <CopyLoginCommandModal isOpen={showCopyLoginCommand} closeCopyLoginCommand={this._closeCopyLoginCommand} username={username} />}
       </React.Fragment>
     );
   }

--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -7,6 +7,19 @@
   margin-right: 15px;
 }
 
+.co-copy-login-command-modal {
+  padding: 5px;
+  p {
+    margin-top: 10px;
+    margin-bottom: 20px;
+  }
+}
+
+.co-copy-login-command-modal__icon {
+  vertical-align: top;
+  font-size: 18px;
+}
+
 .co-overlay {
   background: rgba(0, 0, 0, 0.5);
   bottom: 0;

--- a/frontend/public/components/modals/copy-login-command-modal.tsx
+++ b/frontend/public/components/modals/copy-login-command-modal.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable no-undef, no-unused-vars */
+import * as _ from 'lodash-es';
+import * as React from 'react';
+import * as Modal from 'react-modal';
+
+import { ModalTitle, ModalBody, ModalFooter } from '../factory/modal';
+import { CopyToClipboard } from '../utils/copy-to-clipboard';
+
+type CopyModalProps = {
+  isOpen: boolean,
+  closeCopyLoginCommand: Function,
+  username: string,
+};
+
+type CopyModalState = {
+  token: string,
+};
+
+const apiServerURL = (window as any).SERVER_FLAGS.kubeAPIServerURL;
+const tokenCookiePrefix = 'openshift-session-token=';
+
+export class CopyLoginCommandModal extends React.Component <CopyModalProps, CopyModalState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      token: null,
+    };
+    this.handleToken = this.handleToken.bind(this);
+  }
+  handleToken() {
+    const iframe = window.document.getElementById('apiIframe');
+    const cookies = (iframe as any).contentDocument.cookie;
+    const openshiftToken = cookies.split(';')
+      .map(c => _.trim(c))
+      .filter(c => c.startsWith(tokenCookiePrefix))
+      .map(c => c.slice(tokenCookiePrefix.length)).pop();
+    this.setState({ token: openshiftToken });
+  }
+  render() {
+    const {isOpen, closeCopyLoginCommand, username } = this.props;
+    const loginCommand = `oc login ${apiServerURL} ${this.state.token ? `--token=${this.state.token}` : ''}`;
+    const obfuscatedLoginCommand = `oc login ${apiServerURL} --token=<hidden>`;
+    const modalContainer = document.getElementById('modal-container');
+    const iframeSrc = `${window.location.origin}/api`;
+    const onCloseClick = e => {
+      e.stopPropagation();
+      closeCopyLoginCommand(e);
+    };
+    Modal.setAppElement(modalContainer);
+    return (
+      <Modal
+        isOpen={isOpen}
+        contentLabel="Modal"
+        onRequestClose={closeCopyLoginCommand}
+        className="modal-dialog"
+        overlayClassName="co-overlay"
+        shouldCloseOnOverlayClick={true}>
+        <div className="modal-content">
+          <ModalTitle>Copy Login Command</ModalTitle>
+          <ModalBody className="modal-body">
+            <div className="co-copy-login-command-modal">
+              <p>
+                <span aria-hidden="true" className="co-copy-login-command-modal__icon pficon pficon-warning-triangle-o"></span>&nbsp;
+                A token is a form of a password. Do not share your API Token.
+              </p>
+              <p>
+                Copy the following command and appended token to login as user <b>{`${username}`}</b> through the CLI.
+              </p>
+              <iframe id="apiIframe" onLoad={this.handleToken} style={{display:'none'}} src={`${iframeSrc}`} ></iframe>
+              <CopyToClipboard value={loginCommand} visibleValue={obfuscatedLoginCommand} />
+            </div>
+          </ModalBody>
+          <ModalFooter inProgress={false} errorMessage=""><button type="button" onClick={onCloseClick} className="btn btn-default btn-primary">Close</button></ModalFooter>
+        </div>
+      </Modal>
+    );
+  }
+}

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -84,7 +84,7 @@ func securityHeadersMiddleware(hdlr http.Handler) http.HandlerFunc {
 		// Ancient weak protection against reflected XSS (equivalent to CSP no unsafe-inline)
 		w.Header().Set("X-XSS-Protection", "1; mode=block")
 		// Prevent clickjacking attacks involving iframes
-		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 		// Less information leakage about what domains we link to
 		w.Header().Set("X-DNS-Prefetch-Control", "off")
 		// Less information leakage about what domains we link to


### PR DESCRIPTION
Adding "Copy Login Command" modal for user to login into the `oc` client with token. Was a bit tricky cause had to set the `X-Frame-Options` header to `SAMEORIGIN` to be able to use `iframe` from which we read the token.
Additional comments in code.

/assign @spadgett 
cc'ing @openshift/team-ux-review for design review

screen:
<img width="1386" alt="screen shot 2019-03-05 at 19 29 18" src="https://user-images.githubusercontent.com/1668218/53828855-122f5880-3f7f-11e9-893e-00e53bf484d8.png">

Story: https://jira.coreos.com/browse/CONSOLE-1039