### PR TITLE
Bandaid fix OperatorHub tests for etcd operator

### DIFF
--- a/frontend/integration-tests/views/operator-hub.view.ts
+++ b/frontend/integration-tests/views/operator-hub.view.ts
@@ -16,6 +16,13 @@ export const createSubscriptionFormTitle = element(by.cssContainingText('h1', 'C
 export const createSubscriptionFormBtn = element(by.buttonText('Subscribe'));
 export const createSubscriptionFormInstallMode = element(by.cssContainingText('label', 'Installation Mode'));
 
+export const installNamespaceDropdown = $('.dropdown--full-width');
+export const installNamespaceDropdownBtn = installNamespaceDropdown.$('.dropdown-toggle');
+export const installNamespaceDropdownFilter = (filter: string) => installNamespaceDropdown
+  .$('.dropdown-menu__filter').$('input').sendKeys(filter);
+export const installNamespaceDropdownSelect = (namespace: string) => installNamespaceDropdown
+  .$(`#${namespace}-Project-link`);
+
 export const communityWarningModal = $('.co-modal-ignore-warning');
 export const operatorCommunityWarningIsLoaded = () => browser.wait(until.presenceOf(communityWarningModal), 1000)
   .then(() => browser.sleep(500));


### PR DESCRIPTION
- Changed OperatorHub test to check for OwnNamespace installmode
  rather than AllNamespaces
- Updated namespace to "default" to match the new install namespace

The etcd operator in community-operators changed late last week,
replacing AllNamespaces functionality with SingleNamespace.
This puts a bandaid on the issue.
Operators in community-operators can change frequently, and
because of this OperatorHub tests will be unstable when relying on
external content.

/cc @galletti94 @jeff-phillips-18 @spadgett @dtaylor113 

This will help tests pass for now, but it's not a long-term solution. I suggest we either use a separate quay namespace with stable operator bundles and add that as a "Custom" OperatorSource during this test, or possibly figure out installmodes on the fly.