### PR TITLE
Bug 1685802 - Fix when no externalMetadata for displayName when Creat…

### DIFF
--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -134,7 +134,7 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
       return <div className="radio co-create-service-instance__plan" key={plan.spec.externalName}>
         <label>
           <input type="radio" name="plan" id="plan" value={plan.spec.externalName} checked={selectedPlanName === plan.spec.externalName} onChange={this.onPlanChange} />
-          {plan.spec.externalMetadata.displayName || plan.spec.externalName}
+          {_.get(plan.spec, ['externalMetadata', 'displayName']) || plan.spec.externalName}
           {plan.spec.description && <div className="text-muted">{plan.spec.description}</div>}
         </label>
       </div>;


### PR DESCRIPTION
…ing Service Instance

Previously, console browser crashed with blank screen.  With fix, it now continues to the Create Instance form:
![image](https://user-images.githubusercontent.com/12733153/53894757-ad1b4780-3ffe-11e9-812b-f562e1f71bd2.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1685802