### PR TITLE
Bug 1685800: Monitoring: Disable Alerts Firing link if user can't access Monitoring

### DIFF
--- a/frontend/public/components/graphs/health.jsx
+++ b/frontend/public/components/graphs/health.jsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 
 import { Status, errorStatus } from './';
 import { coFetch, coFetchJSON } from '../../co-fetch';
+import { FLAGS, featureReducerName } from '../../features';
 import { k8sBasePath } from '../../module/k8s';
 
 // Use the shorter 'OpenShift Console' instead of 'OpenShift Container Platform Console' since the title appears in the chart.
@@ -25,15 +27,19 @@ export const KubernetesHealth = () => <Status title="Kubernetes API" fetch={fetc
 
 export const ConsoleHealth = () => <Status title={consoleName} fetch={fetchConsoleHealth} />;
 
-const AlertsFiring = ({namespace}) => (
-  <Status
+const alertsFiringStateToProps = (state) => ({canAccessMonitoring: !!state[featureReducerName].get(FLAGS.CAN_GET_NS)});
+
+const AlertsFiring_ = ({canAccessMonitoring, namespace}) => {
+  const toProp = canAccessMonitoring && !!window.SERVER_FLAGS.prometheusBaseURL ? {to: '/monitoring'} : {};
+  return <Status
+    {...toProp}
     title="Alerts Firing"
     name="Alerts"
     namespace={namespace}
     query={`sum(ALERTS{alertstate="firing", alertname!="Watchdog" ${namespace ? `, namespace="${namespace}"` : ''}})`}
-    to="/monitoring"
-  />
-);
+  />;
+};
+const AlertsFiring = connect(alertsFiringStateToProps)(AlertsFiring_);
 
 const CrashloopingPods = ({namespace}) => (
   <Status


### PR DESCRIPTION
"Alerts Firing" on the Status page links to the Monitoring UI "Alerts"
page, but not all users can access that page. This PR disables the link
for those who do not have access.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1685800