### PR TITLE
Bug 1676786: Align kubeconfig output with CLI

### DIFF
--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -6,7 +6,7 @@ import { Base64 } from 'js-base64';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { Kebab, SectionHeading, navFactory, ResourceKebab, ResourceLink, ResourceSummary } from './utils';
 import { fromNow } from './utils/datetime';
-import { k8sGet } from '../module/k8s';
+import { k8sList } from '../module/k8s';
 import { SecretModel } from '../models';
 import { SecretsPage } from './secret';
 import { saveAs } from 'file-saver';
@@ -16,37 +16,44 @@ const KubeConfigify = (kind, sa) => ({
   label: 'Download kubeconfig file',
   weight: 200,
   callback: () => {
-    const name = _.get(sa, 'secrets[0].name');
+    const name = sa.metadata.name;
     const namespace = sa.metadata.namespace;
 
-    k8sGet(SecretModel, name, namespace).then(({data}) => {
+    k8sList(SecretModel, {ns: namespace}).then((secrets) => {
       const server = window.SERVER_FLAGS.kubeAPIServerURL;
       const url = new URL(server);
-      const clusterName = url.host;
+      const clusterName = url.host.replace(/\./g, '-');
 
-      const token = Base64.decode(data.token);
-      const cert = data['ca.crt'];
+      // Find the secret that is the service account token.
+      const saSecretsByName = _.keyBy(sa.secrets, 'name');
+      const secret = _.find(secrets, s => saSecretsByName[s.metadata.name] && s.type === 'kubernetes.io/service-account-token');
+      if (!secret) {
+        errorModal({error: 'Unable to get service account token.'});
+        return;
+      }
+      const token = Base64.decode(secret.data.token);
+      const cert = secret.data['ca.crt'];
 
       const config = {
         apiVersion: 'v1',
-        'current-context': name,
-        kind: 'Config',
-        preferences: {},
         clusters: [{
-          name: clusterName,
           cluster: {
             'certificate-authority-data': cert,
             server,
           },
+          name: clusterName,
         }],
         contexts: [{
-          name,
           context: {
             cluster: clusterName,
             namespace,
             user: name,
           },
+          name,
         }],
+        'current-context': name,
+        kind: 'Config',
+        preferences: {},
         'users': [{
           name,
           user: {


### PR DESCRIPTION
And fixes bug where token secret may not be found if it is not the first secret.  See https://github.com/openshift/console/pull/1262#discussion_r263529839

Follow on to https://bugzilla.redhat.com/show_bug.cgi?id=1676786.

Note there are still some yaml formatting differences resulting from js-yam'sl default output (list indentation, chomping indicator, use of single quotes around strings), but those are strictly presentational.