### PR TITLE
Fix bug where update link lacked modal decorator

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -99,7 +99,7 @@ const UpdateInProgressAlert = () => <div className="alert alert-info">
 const UpdatesAvailableAlert = ({cv}) => <div className="alert alert-info">
   <i className="pficon pficon-info" aria-hidden={true} />
   Cluster update is available.
-  <Button bsStyle="link" onClick={()=> (launchUpdateModal(cv))}>
+  <Button bsStyle="link" className="co-m-modal-link" onClick={()=> (launchUpdateModal(cv))}>
     Update Now
   </Button>
 </div>;
@@ -110,7 +110,7 @@ const UpdateStatus: React.SFC<UpdateStatusProps> = ({cv}) => {
   return <React.Fragment>
     {
       status === ClusterUpdateStatus.UpdatesAvailable
-        ? <Button bsStyle="link" onClick={() => (launchUpdateModal(cv))}>
+        ? <Button bsStyle="link" className="co-m-modal-link" onClick={() => (launchUpdateModal(cv))}>
           <i className={iconClass} aria-hidden={true}></i>
           &nbsp;
           {status}


### PR DESCRIPTION
Before:
<img width="659" alt="screen shot 2019-03-07 at 3 44 34 pm" src="https://user-images.githubusercontent.com/895728/53987778-f3040880-40ef-11e9-84a5-db90176c86cc.png">

After:
<img width="675" alt="screen shot 2019-03-07 at 3 42 33 pm" src="https://user-images.githubusercontent.com/895728/53987786-f8615300-40ef-11e9-8b6e-fae72ede3a59.png">
