### PR TITLE
Fix position of co-m-modal-link icon when also btn-link

### DIFF
--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -406,6 +406,9 @@
     right: 0;
     top: 0;
   }
+  &.btn-link::after {
+    top: 5px;
+  }
   &:hover::after {
     color: $color-pf-black-700;
   }


### PR DESCRIPTION
I caused this bug with https://github.com/openshift/console/pull/1251.  SMH

Before:

![Screen Shot 2019-03-08 at 3 30 02 PM](https://user-images.githubusercontent.com/895728/54054060-2cec1200-41b7-11e9-8035-1c74d2be5d0a.png)

After:

![Screen Shot 2019-03-08 at 3 28 48 PM](https://user-images.githubusercontent.com/895728/54054068-31b0c600-41b7-11e9-8e9c-9e847ee8b6ca.png)
