### PR TITLE
Add readOnly styles for Ace editor

### DIFF
--- a/frontend/public/components/_edit-yaml.scss
+++ b/frontend/public/components/_edit-yaml.scss
@@ -4,6 +4,12 @@
 
 .yaml-editor__acebox {
   flex: 1;
+
+  &--readonly {
+    background: $input-bg-disabled !important;
+    color: $color-pf-black-700 !important;
+    filter: grayscale(.55);
+  }
 }
 
 .yaml-editor__buttons {

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -350,7 +350,7 @@ export const EditYAML = connect(stateToProps)(
               <div className="yaml-editor" ref={r => this.editor = r} style={{height: this.state.height}}>
                 <div className="absolute-zero">
                   <div className="full-width-and-height yaml-editor__flexbox">
-                    <div id={this.id} key={this.id} className="yaml-editor__acebox" />
+                    <div id={this.id} key={this.id} className={classNames('yaml-editor__acebox', {'yaml-editor__acebox--readonly': readOnly})} />
                     <div className="yaml-editor__buttons">
                       {error && <p className="alert alert-danger"><span className="pficon pficon-error-circle-o"></span>{error}</p>}
                       {success && <p className="alert alert-success"><span className="pficon pficon-ok"></span>{success}</p>}


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-45

The idea is to follow the readOnly style cues set by PatternFly and apply them to the Ace editor.  

Notes:   
* This only changes the presentation of the content in the editor (it does not change the existing readOnly functionality of Ace editor).
* I think the only places we're currently setting the Ace editor to read only mode is on [ClusterServiceClassDetailsPage](https://github.com/openshift/console/blob/master/frontend/public/components/cluster-service-class.tsx#L80) and [ClusterServicePlanDetailsPage](https://github.com/openshift/console/blob/master/frontend/public/components/cluster-service-plan.tsx#L6), both of which are to be deprecated.  

editable (existing)
![localhost_9000_k8s_ns_ansible-service-broker_pods_automation-broker-operator-79d4bf86bb-ksmhh_yaml (2)](https://user-images.githubusercontent.com/895728/54150860-e6452480-440f-11e9-844c-f84053ce7da3.png)

readOnly (new)
![localhost_9000_k8s_ns_ansible-service-broker_pods_automation-broker-operator-79d4bf86bb-ksmhh_yaml (1)](https://user-images.githubusercontent.com/895728/54150202-3e7b2700-440e-11e9-86a5-0f80ab507474.png)