### PR TITLE
Add OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+  - alecmerdler
+  - benjaminapetersen
+  - jhadvig
+  - rhamilto
+  - spadgett
+approvers:
+  - benjaminapetersen
+  - bparees
+  - rhamilto
+  - spadgett

--- a/auth/OWNERS
+++ b/auth/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - benjaminapetersen
+  - enj
+  - spadgett
+approvers:
+  - benjaminapetersen
+  - bparees
+  - enj
+  - spadgett

--- a/frontend/OWNERS
+++ b/frontend/OWNERS
@@ -1,0 +1,20 @@
+reviewers:
+  - alecmerdler
+  - benjaminapetersen
+  - dtaylor113
+  - jcaianirh
+  - jeff-phillips-18
+  - jhadvig
+  - kyoto
+  - rhamilto
+  - spadgett
+  - TheRealJon
+  - zherman0
+approvers:
+  - alecmerdler
+  - benjaminapetersen
+  - bparees
+  - jhadvig
+  - kyoto
+  - rhamilto
+  - spadgett

--- a/frontend/public/components/operator-hub/OWNERS
+++ b/frontend/public/components/operator-hub/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - alecmerdler
+  - galletti94
+  - jeff-phillips-18
+  - SamiSousa
+  - spadgett
+approvers:
+  - alecmerdler
+  - jeff-phillips-18
+  - spadgett

--- a/frontend/public/components/operator-lifecycle-manager/OWNERS
+++ b/frontend/public/components/operator-lifecycle-manager/OWNERS
@@ -3,3 +3,5 @@ reviewers:
   - josephschorr
 approvers:
   - alecmerdler
+  - ecordell
+  - spadgett

--- a/frontend/public/style/OWNERS
+++ b/frontend/public/style/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - rhamilto
+  - sg00dwin
+approvers:
+  - rhamilto
+  - sg00dwin
+  - spadgett


### PR DESCRIPTION
Here is a first pass at adding some OWNERS files. I'm open to changing who is listed here. Just trying to get something set up.

Note that "reviewers" only controls who the bot suggests as a reviewer. Anyone in the OpenShift org can `/lgtm` a PR if an approver has approved.

https://jira.coreos.com/browse/CONSOLE-1315

/assign @rhamilto @benjaminapetersen @alecmerdler 
@pweil- @bparees fyi

/hold
for feedback