### PR TITLE
Add css to truncated container image name to communicate to the user that the entire string can be selected and copied.

### DIFF
--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -101,7 +101,7 @@ export const ContainerRow = ({pod, container}) => {
     <div className="col-lg-2 col-md-3 col-sm-4 col-xs-5">
       <ContainerLink pod={pod} name={container.name} />
     </div>
-    <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7 co-truncate co-nowrap">{container.image || '-'}</div>
+    <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7 co-truncate co-nowrap co-select-to-copy">{container.image || '-'}</div>
     <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs"><StatusIcon status={cstate.label} /></div>
     <div className="col-lg-1 col-md-2 hidden-sm hidden-xs">{_.get(cstatus, 'restartCount', '0')}</div>
     <div className="col-lg-2 col-md-2 hidden-sm hidden-xs"><Timestamp timestamp={startedAt} /></div>

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -375,6 +375,11 @@
   text-overflow: ellipsis;
 }
 
+.co-select-to-copy {
+  cursor: copy;
+  user-select: all;
+}
+
 .co-nowrap {
   white-space: nowrap;
 }


### PR DESCRIPTION
- adds `user-select: all` and `cursor: copy`

Related request: https://github.com/openshift/console/pull/1214#issuecomment-470808101

**Before (three click to select entire name)**
![copyW3EErHMKKw](https://user-images.githubusercontent.com/1874151/54308645-cbf07f80-45a4-11e9-97f5-de86349921c7.gif)


**After (single click selects entire name)**
![copy-new0vybfmTjvN](https://user-images.githubusercontent.com/1874151/54308656-d14dca00-45a4-11e9-917b-b9baad8957c8.gif)

