### PR TITLE
tests: get URL from the console config status

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -20,6 +20,6 @@ export BRIDGE_AUTH_USERNAME=kubeadmin
 set +x
 export BRIDGE_AUTH_PASSWORD="$(cat "${INSTALLER_DIR}/auth/kubeadmin-password")"
 set -x
-export BRIDGE_BASE_ADDRESS="https://$(oc get route console -n openshift-console -o jsonpath='{.spec.host}')"
+export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
 
 ./test-gui.sh ${1:-e2e}


### PR DESCRIPTION
/assign @benjaminapetersen 

I'm hoping this fixes the flake here:

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_console/1287/pull-ci-openshift-console-master-e2e-aws-console-olm/10

But it's probably the correct thing to do anyway.