### PR TITLE
Bug 1685409: Keep deleted projects from generating data

### DIFF
--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -866,9 +866,13 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
   }
 
   createOverviewData(): void {
-    const {loaded, updateResources} = this.props;
+    const {loaded, mock, updateResources} = this.props;
 
     if (!loaded) {
+      return;
+    }
+    // keeps deleted bookmarked projects from attempting to generate data
+    if (mock) {
       return;
     }
 


### PR DESCRIPTION
Removed noProjectsAvailable prop from disabled start guide wrappers to fix nonexistent project pages for non-cluster-admins.

If you navigated to a deleted bookmarked project as a non-cluster-admin with no active projects, you'd get a white screen of death with a console error.

Now you get this instead (matches behavior for when you have projects, plus getting started guide):
<img width="867" alt="Screen Shot 2019-03-15 at 10 46 57 AM" src="https://user-images.githubusercontent.com/7014965/54439741-c95e6900-470f-11e9-8949-70ab0eb2cc32.png">

The start guide seems to still work correctly with this change.

Fixes [#1685409](https://bugzilla.redhat.com/show_bug.cgi?id=1685409).