### PR TITLE
Bug 1689980 - Don't request secrets and config maps when not enabled in editor

### DIFF
--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -259,8 +259,8 @@ export const EnvironmentPage = connect(stateToProps)(
     componentDidMount() {
       super.componentDidMount();
 
-      const {readOnly} = this.props;
-      if (readOnly) {
+      const {addConfigMapSecret, readOnly} = this.props;
+      if (!addConfigMapSecret || readOnly) {
         const configMaps = {}, secrets = {};
         this.setState({configMaps, secrets});
         return;


### PR DESCRIPTION
When `addConfigMapSecret` is false in the environment variable editor, skip the request for secrets and config maps.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1689980

/assign @jcaianirh 