### PR TITLE
Bug 1602331: Enable blocking on certain modals with forms to prevent accidental data loss. Must click cancel to close.

### DIFF
--- a/frontend/public/components/modals/add-secret-to-workload.tsx
+++ b/frontend/public/components/modals/add-secret-to-workload.tsx
@@ -227,6 +227,7 @@ export type AddSecretToWorkloadModalProps = {
   close: () => void;
   secretName: string;
   namespace: string;
+  blocking?: boolean;
 };
 
 export type AddSecretToWorkloadModalState = {

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -67,7 +67,7 @@ const NamespaceRow = ({obj: ns}) => <ResourceRow obj={ns}>
 </ResourceRow>;
 
 export const NamespacesList = props => <List {...props} Header={NamespaceHeader} Row={NamespaceRow} />;
-export const NamespacesPage = props => <ListPage {...props} ListComponent={NamespacesList} canCreate={true} createHandler={() => createNamespaceModal({})} />;
+export const NamespacesPage = props => <ListPage {...props} ListComponent={NamespacesList} canCreate={true} createHandler={() => createNamespaceModal({blocking: true})} />;
 
 const projectMenuActions = [Kebab.factory.Edit, deleteModal];
 

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -15,7 +15,7 @@ export const addSecretToWorkload = (kindObj, secret) => {
 
   return {
     btnClass: 'btn-primary',
-    callback: () => configureAddSecretToWorkloadModal({secretName, namespace}),
+    callback: () => configureAddSecretToWorkloadModal({secretName, namespace, blocking: true}),
     label: 'Add Secret to Workload',
   };
 };

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -34,6 +34,7 @@ const kebabFactory: KebabFactory = {
     callback: () => labelsModal({
       kind,
       resource: obj,
+      blocking: true,
     }),
   }),
   ModifyPodSelector: (kind, obj) => ({
@@ -41,6 +42,7 @@ const kebabFactory: KebabFactory = {
     callback: () => podSelectorModal({
       kind,
       resource:  obj,
+      blocking: true,
     }),
   }),
   ModifyAnnotations: (kind, obj) => ({
@@ -48,6 +50,7 @@ const kebabFactory: KebabFactory = {
     callback: () => annotationsModal({
       kind,
       resource: obj,
+      blocking: true,
     }),
   }),
   ModifyCount: (kind, obj) => ({


### PR DESCRIPTION
Edit forms effected: Labels, Annotations, Add Secret, Pod Selector

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1602331
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1688956