### PR TITLE
Improve layout of workload tables

### DIFF
--- a/frontend/public/components/mounted-vol.tsx
+++ b/frontend/public/components/mounted-vol.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
+import * as classNames from 'classnames';
 
 import {
   getVolumeType,
@@ -30,8 +31,10 @@ const Volume = ({volumeMounts, pod}) => {
     {volumeMounts.mounts.map((m, i) => <React.Fragment key={i}>
       <div className="row">
         <div className="col-lg-2 col-md-3 col-sm-4 col-xs-5">{name}</div>
-        <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7 co-break-word">{_.get(m, 'mountPath', '-')} </div>
-        <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs co-break-word">{_.get(m, 'subPath', '-')} </div>
+        <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7 co-break-all co-select-to-copy">{_.get(m, 'mountPath', '-')} </div>
+        <div className={classNames('col-lg-2 col-md-2 col-sm-3 hidden-xs co-break-all', { 'co-select-to-copy': _.get(m, 'subPath') })}>
+          {_.get(m, 'subPath', '-')}
+        </div>
         <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">
           <VolumeIcon kind={kind} />
           <span className="co-break-word">{loc && ` (${loc})`}</span>

--- a/frontend/public/components/utils/container-table.tsx
+++ b/frontend/public/components/utils/container-table.tsx
@@ -7,21 +7,21 @@ const ContainerRow: React.SFC<ContainerRowProps> = ({container}) => {
   const resourceLimits = _.get(container, 'resources.limits');
   const ports = _.get(container, 'ports');
   return <div className="row">
-    <div className="col-xs-6 col-sm-4 col-md-3 co-break-word">
+    <div className="col-xs-5 col-sm-4 col-md-3 co-break-word">
       {container.name}
     </div>
-    <div className="col-xs-6 col-sm-4 col-md-3 co-break-all">{container.image || '-'}</div>
-    <div className="col-sm-4 col-md-3 hidden-xs">{_.map(resourceLimits, (v, k) => `${k}: ${v}`).join(', ') || '-'}</div>
-    <div className="col-md-3 hidden-xs hidden-sm co-break-word">{_.map(ports, port => `${port.containerPort}/${port.protocol}`).join(', ') || '-'}</div>
+    <div className="col-xs-7 col-sm-5 co-break-all co-select-to-copy">{container.image || '-'}</div>
+    <div className="col-sm-3 col-md-2 hidden-xs">{_.map(resourceLimits, (v, k) => `${k}: ${v}`).join(', ') || '-'}</div>
+    <div className="col-md-2 hidden-xs hidden-sm co-break-word">{_.map(ports, port => `${port.containerPort}/${port.protocol}`).join(', ') || '-'}</div>
   </div>;
 };
 
 export const ContainerTable: React.SFC<ContainerTableProps> = ({containers}) => <div className="co-m-table-grid co-m-table-grid--bordered">
   <div className="row co-m-table-grid__head">
-    <div className="col-xs-6 col-sm-4 col-md-3">Name</div>
-    <div className="col-xs-6 col-sm-4 col-md-3">Image</div>
-    <div className="col-sm-4 col-md-3 hidden-xs">Resource Limits</div>
-    <div className="col-md-3 hidden-xs hidden-sm">Ports</div>
+    <div className="col-xs-5 col-sm-4 col-md-3">Name</div>
+    <div className="col-xs-7 col-sm-5">Image</div>
+    <div className="col-sm-3 col-md-2 hidden-xs">Resource Limits</div>
+    <div className="col-md-2 hidden-xs hidden-sm">Ports</div>
   </div>
   <div className="co-m-table-grid__body">
     {_.map(containers, (c, i) => <ContainerRow key={i} container={c} />)}

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -378,6 +378,8 @@
 .co-select-to-copy {
   cursor: copy;
   user-select: all;
+  -moz-user-select: all;
+  -webkit-user-select: all;
 }
 
 .co-nowrap {


### PR DESCRIPTION
Give the image column more space, add `co-break-all` (since we don't care where long identifiers are broken), and add `co-select-to-copy` to the image and some volume columns.

Adds the `-moz` prefix to `co-select-to-copy` so it works on Firefox.

/assign @sg00dwin 

![Screen Shot 2019-03-18 at 3 53 02 PM](https://user-images.githubusercontent.com/1167259/54559316-23706000-4996-11e9-823d-d3886fbb760b.png)
