### PR TITLE
Bug 1690799: Remove output ImageStreamTag from BuildConfig YAML template

### DIFF
--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -135,10 +135,6 @@ kind: BuildConfig
 metadata:
   name: example
 spec:
-  output:
-    to:
-      kind: ImageStreamTag
-      name: example:latest
   source:
     git:
       ref: master


### PR DESCRIPTION
Now that we have the sidebar with examples that push to image streams, we can probably remove the output image stream from the default YAML template. The build will run successfully, although it won't push the image anywhere. But that is probably better than a failing build.

Unfortunately, we can't add a comment explaining since it's stripped out when we update the YAML to include the current namespace.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1690799
Fixes https://jira.coreos.com/browse/CONSOLE-580
Fixes #403

/assign @rhamilto 