### PR TITLE
Bug 1689837 - Should not list cluster scope service bindings when vis…

### DIFF
--- a/frontend/public/components/service-binding.tsx
+++ b/frontend/public/components/service-binding.tsx
@@ -106,7 +106,7 @@ ServiceBindingsList.displayName = 'ServiceBindingsList';
 export const ServiceBindingsPage: React.SFC<ServiceBindingsPageProps> = props =>
   <ListPage
     {...props}
-    namespace={_.get(props.match, 'params.ns')}
+    namespace={props.namespace ||_.get(props.match, 'params.ns')}
     showTitle={false}
     kind={referenceForModel(ServiceBindingModel)}
     ListComponent={ServiceBindingsList}


### PR DESCRIPTION
…it service binding tab on service instance page

https://bugzilla.redhat.com/show_bug.cgi?id=1689837

`namespace` was not being applied when coming from Catalog -> Provisioned Services -> Service Instances -> Service Instance details page -> Service Bindings (sub-tab)

**Previous URL** which resulted in "servicebindings.servicecatalog.k8s.io is forbidden..." error message
http://0.0.0.0:9000/provisionedservices/ns/test-proj/servicebindings

**Correct URL** when `namespace` applied:
http://0.0.0.0:9000/k8s/ns/test-proj/servicecatalog.k8s.io~v1beta1~ServiceInstance/user-provided-service/servicebindings