### PR TITLE
Add break-word to the conditions reason column.

### DIFF
--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -15,7 +15,7 @@ export const Conditions: React.SFC<ConditionsProps> = ({conditions}) => {
     <div className="hidden-xs hidden-sm col-md-2">
       <Timestamp timestamp={condition.lastUpdateTime || condition.lastTransitionTime} />
     </div>
-    <div className="col-xs-4 col-sm-3 col-md-2">
+    <div className="col-xs-4 col-sm-3 col-md-2 co-break-word">
       <CamelCaseWrap value={condition.reason} />
     </div>
     {/* remove initial newline which appears in route messages */}


### PR DESCRIPTION

**before**
<img width="1044" alt="Screen Shot 2019-03-20 at 10 20 57 AM" src="https://user-images.githubusercontent.com/1874151/54717788-6285e900-4b2f-11e9-83ee-f35e43b6f59d.png">

**after**

<img width="1037" alt="Screen Shot 2019-03-20 at 10 20 36 AM" src="https://user-images.githubusercontent.com/1874151/54717798-674a9d00-4b2f-11e9-8913-21da1cefd235.png">
