### PR TITLE
Fix console memory leak

### DIFF
--- a/auth/auth_openshift.go
+++ b/auth/auth_openshift.go
@@ -159,7 +159,7 @@ func (o *openShiftAuth) logout(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (o *openShiftAuth) authenticate(r *http.Request) (*User, error) {
+func getOpenShiftUser(r *http.Request) (*User, error) {
 	// TODO: This doesn't do any validation of the cookie with the assumption that the
 	// API server will reject tokens it doesn't recognize. If we want to keep some backend
 	// state we should sign this cookie. If not there's not much we can do.


### PR DESCRIPTION
* Don't create a new HTTP client for every request to the API
* Only create the OIDC loginMethod once since it is stateful

/assign @enj 