### PR TITLE
Added npm scripts to debug e2e and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ yarn run dev
 ```
 If changes aren't detected, you might need to increase `fs.inotify.max_user_watches`. See <https://webpack.js.org/configuration/watch/#not-enough-watchers>.
 
-### Tests
+### Unit Tests
 
 Run all unit tests:
 ```
@@ -171,6 +171,14 @@ Run frontend tests:
 ./test-frontend.sh
 ```
 
+#### Debugging Unit Tests
+
+1. `cd frontend; yarn run build`
+2. Add `debugger;` statements to any unit test
+3. `yarn debug-test route-pages`
+4. Chrome browser URL: 'chrome://inspect/#devices', click on the 'inspect' link in **Target (v10...)** section.
+5. Launches chrome-dev tools, click Resume button to continue
+6. Will break on any `debugger;` statements
 
 ### Integration Tests
 
@@ -221,6 +229,16 @@ $ ./test-gui.sh olm
 #### Hacking Integration Tests
 
 Remove the `--headless` flag to Chrome (chromeOptions) in [protractor.conf.ts](frontend/integration-tests/protractor.conf.ts) to see what the tests are actually doing.
+
+##### Debugging Integration Tests
+
+1. `cd frontend; yarn run build`
+2. Add `debugger;` statements to any e2e test
+3. `yarn run debug-test-suite --suite overview`
+4. Chrome browser URL: 'chrome://inspect/#devices', click on the 'inspect' link in **Target (v10...)** section.
+5. Launches chrome-dev tools, click Resume button to continue
+6. Will break on any `debugger;` statements
+7. Pauses browser when not using `--headless` argument!
 
 ### Dependency Management
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,11 +9,13 @@
     "coverage": "jest --coverage .",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --color .",
     "test": "jest",
+    "debug-test": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "webdriver-update": "webdriver-manager update --versions.chrome=2.38 --gecko=false",
     "test-gui-tap": "TAP=true yarn run test-gui",
     "test-gui-openshift": "yarn run test-suite --suite crud --params.openshift true",
     "test-gui": "yarn run test-suite --suite all",
     "test-suite": "ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/protractor integration-tests/protractor.conf.ts",
+    "debug-test-suite": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node -r ts-node/register --inspect-brk ./node_modules/.bin/protractor integration-tests/protractor.conf.ts",
     "analyze": "NODE_ENV=production ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production --profile --json | awk '{if(NR>2)print}' > public/dist/stats.json && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack-bundle-analyzer --mode static -r public/dist/report.html public/dist/stats.json"
   },
   "jest": {


### PR DESCRIPTION
### Debug e2e Tests

![image](https://user-images.githubusercontent.com/12733153/54764443-2f466700-4bce-11e9-8f77-c7aca9adb2ad.png)

Ex:
1. `cd frontend; yarn run build`
2. Add `debugger;` statements to any e2e test
3. `yarn run debug-test-suite --suite overview`
4. Chrome browser URL: 'chrome://inspect/#devices', click on '[inspect](url)' link in **Target (v10...)** section.
5. Launches chrome-dev tools, click Resume button to continue
6. Will break on any `debugger;` statements
7. Pauses browser when not using `--headless` argument!


[More info](https://github.com/angular/protractor/blob/master/docs/debugging.md#disabled-control-flow).

### Debug Unit Tests

![image](https://user-images.githubusercontent.com/12733153/54759547-b098fc00-4bc4-11e9-8270-9e9336ecbd59.png)

Ex:
1. `cd frontend; yarn run build`
2. Add `debugger;` statements to any unit test
3. `yarn debug-test route-pages`
4. Chrome browser URL: 'chrome://inspect/#devices', click on '[inspect](url)' link in **Target (v10...)** section.
5. Launches chrome-dev tools, click Resume button to continue
6. Will break on any `debugger;` statements

