### PR TITLE
Monitoring: Improve graph hover labels to only show those that differ

### DIFF
--- a/frontend/public/components/graphs/query-browser.jsx
+++ b/frontend/public/components/graphs/query-browser.jsx
@@ -96,6 +96,12 @@ class QueryBrowser_ extends Line_ {
     if (!_.isEmpty(newData)) {
       this.data = newData;
       let traceIndex = 0;
+
+      // Work out which labels have different values for different metrics
+      const allLabels = _.map(newData, 'metric');
+      const allLabelKeys = _.uniq(_.flatMap(allLabels, _.keys));
+      const differingLabelKeys = _.filter(allLabelKeys, k => _.uniqBy(allLabels, k).length > 1);
+
       _.each(newData, ({metric, values}) => {
         // If props.metric is specified, ignore all other metrics
         const labels = _.omit(metric, '__name__');
@@ -114,11 +120,14 @@ class QueryBrowser_ extends Line_ {
           }
         });
 
+        // Just show labels that differ between metrics to keep the name shorter
+        const name = _.map(_.pick(labels, differingLabelKeys), (v, k) => `${k}="${v}"`).join(',');
+
         const update = {
           line: {
             width: 1,
           },
-          name: _.map(labels, (v, k) => `${k}=${v}`).join(','),
+          name,
           x: [values.map(v => new Date(v[0] * 1000))],
           y: [values.map(v => v[1])],
         };


### PR DESCRIPTION
The list of labels is often too long to display. Filtering out those
that are actually the same for all graph traces helps.

FYI @cshinn 

### Before
![hover-labels-before](https://user-images.githubusercontent.com/460802/54828696-1639d500-4cf8-11e9-932d-314a9a6342c4.png)

### After
![hover-labels-after](https://user-images.githubusercontent.com/460802/54828691-133ee480-4cf8-11e9-936e-e0ce93d11064.png)