### PR TITLE
[WIP] Add ConsoleNotification CRD that can appear above or below the page

### DIFF
--- a/extensions/console-notification.crd.yaml
+++ b/extensions/console-notification.crd.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consolenotifications.console.openshift.io
+  annotations:
+    displayName: ConsoleNotification
+    description: Extension for configuring openshift web console notifications.
+spec:
+  group: console.openshift.io
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  scope: Cluster
+  names:
+    plural: consolenotifications
+    singular: consolenotification
+    kind: ConsoleNotification
+    listKind: ConsoleNotificationList
+  additionalPrinterColumns:
+  - name: Text
+    type: string
+    JSONPath: .spec.notification.text
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Represents console notification spec
+          required:
+          - notification
+          properties:
+            notification:
+              type: object
+              description: Object that holds notification extension
+              required:
+                - text
+                - position
+              properties:
+                text:
+                  type: string
+                  description: Text of the notification
+                position:
+                  type: string
+                  description: The location of the notification (top, bottom, topBottom)
+                  pattern: '\btop\b|\bbottom\b|\btopBottom\b'
+                link:
+                  type: object
+                  description: Object that holds notification link details
+                  required:
+                    - href
+                  properties:
+                    text:
+                      type: string
+                      description: Text of the link
+                    href:
+                      type: string
+                      description: Absolute URL for the link
+                      pattern: '^((https?):\/\/)?(www.)?[a-z0-9]+\.[a-z]+(\/[a-zA-Z0-9#]+\/?)*$'
+                    opensNewWindow:
+                      type: boolean
+                      description: Determines whether the link opens in a new window
+                backgroundColor:
+                  type: string
+                  description: The background color for the notification
+                color:
+                  type: string
+                  description: The color of the text for the notification

--- a/frontend/public/components/_global-notification.scss
+++ b/frontend/public/components/_global-notification.scss
@@ -3,7 +3,6 @@ $global-notification-text: $color-pf-white;
 .co-global-notification {
   background-color: $color-pf-blue-400;
   color: $global-notification-text;
-  font-weight: 300;
   padding: 4px ($grid-gutter-width / 2);
   text-align: center;
 
@@ -11,20 +10,19 @@ $global-notification-text: $color-pf-white;
     padding: 6px $grid-gutter-width;
   }
 
+  + .co-global-notification {
+    margin-top: 1px;
+  }
+
   a {
     color: $global-notification-text;
     cursor: pointer;
     text-decoration: underline;
   }
-
-  +  .co-global-notification {
-    box-shadow: inset 0 10px 10px -10px rgba(0,34,53,0.7);
-  }
 }
 
 .co-global-notification__text {
   margin: 0;
-  padding: 5px 10px;
 }
 
 .co-global-notification__impersonate-name {

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -12,6 +12,7 @@ import { ALL_NAMESPACES_KEY } from '../const';
 import { connectToFlags, featureActions, flagPending, FLAGS } from '../features';
 import { analyticsSvc } from '../module/analytics';
 import { GlobalNotifications } from './global-notifications';
+import { ConsoleNotifier } from './console-notifier';
 import { Masthead } from './masthead';
 import { NamespaceBar } from './namespace';
 import { Navigation } from './nav';
@@ -169,6 +170,7 @@ class App extends React.PureComponent {
           titleTemplate={`%s · ${productName}`}
           defaultTitle={productName}
         />
+        <ConsoleNotifier position="top" />
         <Page
           header={<Masthead onNavToggle={this._onNavToggle} />}
           sidebar={<Navigation isNavOpen={isNavOpen} onNavSelect={this._onNavSelect} />}
@@ -288,6 +290,7 @@ class App extends React.PureComponent {
             </div>
           </PageSection>
         </Page>
+        <ConsoleNotifier position="bottom" />
       </React.Fragment>
     );
   }

--- a/frontend/public/components/console-notifier.tsx
+++ b/frontend/public/components/console-notifier.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable no-undef */
+
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import { Firehose } from './utils';
+import { referenceForModel } from '../module/k8s';
+import { ConsoleNotificationModel } from '../models/index';
+
+const ConsoleNotifier_ = ({ obj: {data}, position }) => <React.Fragment>
+  {!_.isEmpty(data)
+    ? _.map(data, n => (n.spec.notification.position === position || n.spec.notification.position === 'topBottom')
+      ? <div key={n.metadata.uid}
+        className="co-global-notification"
+        style={{
+          backgroundColor: n.spec.notification.backgroundColor,
+          color: n.spec.notification.color,
+        }}>
+        <div className="co-global-notification__content">
+          <p className="co-global-notification__text">
+            {n.spec.notification.text} {_.get(n.spec.notification, ['link', 'href'])
+              && <a href={n.spec.notification.link.href}
+                target={n.spec.notification.link.opensNewWindow ? '_blank' : null}
+                className={n.spec.notification.link.opensNewWindow ? 'co-external-link' : null}
+                style={{color: n.spec.notification.color}}>{n.spec.notification.link.text || 'More info'}</a>}
+          </p>
+        </div>
+      </div>
+      : null)
+    : null}
+</React.Fragment>;
+
+export const ConsoleNotifier: React.SFC<ConsoleNotifierProps> = props => {
+  const consoleNotificationResources = [
+    {
+      kind: referenceForModel(ConsoleNotificationModel),
+      isList: true,
+      prop: 'obj',
+    },
+  ];
+  return <Firehose resources={consoleNotificationResources}>
+    <ConsoleNotifier_ {...props} />
+  </Firehose>;
+};
+
+export type ConsoleNotifierProps = {
+  obj: any,
+  position: string,
+};

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -152,7 +152,8 @@ export const EditYAML = connect(stateToProps)(
 
     get height() {
       return Math.floor(
-        document.body.getBoundingClientRect().bottom - this.editor.getBoundingClientRect().top
+        // notifications can appear above and below .pf-c-page, so calculate height using the bottom of .pf-c-page
+        document.getElementsByClassName('pf-c-page')[0].getBoundingClientRect().bottom - this.editor.getBoundingClientRect().top
       );
     }
 

--- a/frontend/public/components/terminal.jsx
+++ b/frontend/public/components/terminal.jsx
@@ -74,13 +74,14 @@ export class Terminal extends React.Component {
       return;
     }
 
+    const pageRect = document.getElementsByClassName('pf-c-page')[0].getBoundingClientRect();
     const bodyRect = document.body.getBoundingClientRect();
     const nodeRect = node.getBoundingClientRect();
 
     const { padding } = this.props;
 
     // This assumes we want to fill everything below and to the right.  In full-screen, fill entire viewport
-    const height = Math.floor(bodyRect.bottom - (this.isFullscreen ? 0 : nodeRect.top) - padding);
+    const height = Math.floor(pageRect.bottom - (this.isFullscreen ? 0 : nodeRect.top) - padding);
     const width = Math.floor(bodyRect.width - (this.isFullscreen ? 0 : nodeRect.left) - (this.isFullscreen ? 10 : padding));
 
     if (height === this.state.height && width === this.state.width) {

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -946,3 +946,17 @@ export const OAuthModel: K8sKind = {
   id: 'oauth',
   crd: true,
 };
+
+export const ConsoleNotificationModel: K8sKind = {
+  label: 'Console Notification',
+  labelPlural: 'Console Notifications',
+  apiVersion: 'v1',
+  path: 'consolenotifications',
+  apiGroup: 'console.openshift.io',
+  plural: 'consolenotifications',
+  abbr: 'CN',
+  namespaced: false,
+  kind: 'ConsoleNotification',
+  id: 'consolenotification',
+  crd: true,
+};

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -797,4 +797,19 @@ spec:
   machineSelector:
     matchLabels:
       node-role.kubernetes.io/master: ""
+`).setIn([referenceForModel(k8sModels.ConsoleNotificationModel), 'default'], `
+apiVersion: console.openshift.io/v1
+kind: ConsoleNotification
+metadata:
+  name: example
+spec:
+  notification:
+    text: This is an example notification message with an optional link.
+    position: top
+    link:
+      href: 'http://www.example.com'
+      text: Optional link text
+      opensNewWindow: false
+    color: '#fff'
+    backgroundColor: '#0088ce'
 `);

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -7,9 +7,13 @@ body,
   height: 100%; // so .co-p-has-sidebar, .yaml-editor are full height
 }
 
+#app,
 #content {
   display: flex;
   flex-direction: column;
+}
+
+#content {
   font-size: $font-size-base; // so PatternFly 4's PatternFly 3 shield rules don't override
 }
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -276,6 +276,8 @@ tags-input .autocomplete .suggestion-item em {
 }
 
 .pf-c-page {
+  overflow: hidden;
+
   &__header {
     background-color: var(--pf-global--BackgroundColor--dark-200);
     background-image: url("../imgs/pfbg_2000.jpg");


### PR DESCRIPTION
Option to replace https://github.com/openshift/console/pull/1284

Differs from https://github.com/openshift/console/pull/1284
- reduces padding in notifications so they consume less vertical space
- positioning of notifications (top, bottom, topBottom)
- option to set notification background color
- option to set notification text color
- link
  - href must now be an absolute url
  - option to open link in new window with new window indicator icon

![localhost_9000_k8s_cluster_console openshift io_v1_ConsoleNotification_example_yaml](https://user-images.githubusercontent.com/895728/54844505-77888680-4cad-11e9-8470-f61840a3adb8.png)


