### PR TITLE
Adding co-resource-link__resource-api class and rules so that active …

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -4,7 +4,7 @@
   .btn-dropdown .show {
     display: inline !important;
     &::before {
-      content: " - "
+      content: "- "
     }
   }
   .dropdown-menu {
@@ -14,6 +14,14 @@
     overflow-y: auto;
     a {
       padding: 4px 20px 4px 6px;
+    }
+    &:active,
+    .active a,
+    .active a:focus,
+    .active a:hover {
+      .co-resource-link__resource-api {
+        color: $dropdown-link-active-color;
+      }
     }
   }
 }

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -46,7 +46,7 @@ const DropdownItem: React.SFC<DropdownItemProps> = ({model, showGroup}) => <Reac
     </span>
     <span className="co-resource-link__resource-name">
       {model.kind}
-      {showGroup && <React.Fragment>&nbsp;<div className="text-muted co-truncate show co-nowrap small">{model.apiGroup || 'core'}/{model.apiVersion}</div></React.Fragment>}
+      {showGroup && <React.Fragment>&nbsp;<div className="co-resource-link__resource-api text-muted co-truncate show co-nowrap small">{model.apiGroup || 'core'}/{model.apiVersion}</div></React.Fragment>}
     </span>
   </span>
 </React.Fragment>;


### PR DESCRIPTION
…and pseudo class states get appropriate color.
Also remove extra space before ` - ` when inline

related: https://jira.coreos.com/browse/CONSOLE-1333

<img width="382" alt="Screen Shot 2019-03-22 at 2 10 50 PM (2)" src="https://user-images.githubusercontent.com/1874151/54845943-1c589300-4cb1-11e9-9a53-5ea79c764314.png">
