### PR TITLE
Monitoring: Enable y axis zoom for alert and alerting rule graphs

### DIFF
--- a/frontend/public/components/graphs/query-browser.jsx
+++ b/frontend/public/components/graphs/query-browser.jsx
@@ -37,6 +37,9 @@ class QueryBrowser_ extends Line_ {
         tickformat: null, // Use Plotly's default datetime labels
         type: 'date',
       },
+      yaxis: {
+        fixedrange: false,
+      },
     });
 
     this.onPlotlyRelayout = e => {


### PR DESCRIPTION
Allows zooming the x axis, the y axis or both.

![screenshot](https://user-images.githubusercontent.com/460802/54890860-a3df1580-4eee-11e9-980d-4e5ca75a9391.png)

FYI @cshinn 