### PR TITLE
Monitoring: Use formatPrometheusDuration() for alerting rule's `for`

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -16,7 +16,7 @@ import { QueryBrowser } from './graphs';
 import { confirmModal } from './modals';
 import { CheckBoxes } from './row-filter';
 import { SafetyFirst } from './safety-first';
-import { formatDuration } from './utils/datetime';
+import { formatPrometheusDuration } from './utils/datetime';
 import { withFallback } from './utils/error-boundary';
 import { Tooltip } from './utils/tooltip';
 import {
@@ -353,7 +353,7 @@ const AlertRulesDetailsPage = withFallback(connect(ruleStateToProps)((props: Ale
               <dl className="co-m-pane__details">
                 {_.isInteger(duration) && <React.Fragment>
                   <dt>For</dt>
-                  <dd>{formatDuration(duration * 1000)}</dd>
+                  <dd>{formatPrometheusDuration(duration * 1000)}</dd>
                 </React.Fragment>}
                 <dt>Expression</dt>
                 <dd><pre className="co-pre-wrap monitoring-query">{query}</pre></dd>


### PR DESCRIPTION
This makes the duration formatting consistent with Prometheus. For example, 15 minutes will now be correctly shown as `15m` instead of `15m 0s`.

Not addressed in this PR: Several other places use `formatDuration()` and maybe should also be changed to use `formatPrometheusDuration()`.