### PR TITLE
Monitoring: Add Prometheus API timeout option

### DIFF
--- a/frontend/public/components/graphs/base.jsx
+++ b/frontend/public/components/graphs/base.jsx
@@ -47,11 +47,12 @@ export class BaseGraph extends SafetyFirst {
     const basePath = this.props.basePath || (this.props.namespace ? prometheusTenancyBasePath : prometheusBasePath);
     const pollInterval = timeSpan ? Math.max(timeSpan / 120, 5000) : 15000;
     const stepSize = (timeSpan && this.props.numSamples ? timeSpan / this.props.numSamples : pollInterval) / 1000;
+    const timeoutParam = this.props.timeout ? `&timeout=${encodeURIComponent(this.props.timeout)}` : '';
     const promises = queries.map(q => {
       const nsParam = this.props.namespace ? `&namespace=${encodeURIComponent(this.props.namespace)}` : '';
       const url = this.timeSpan
-        ? `${basePath}/api/v1/query_range?query=${encodeURIComponent(q.query)}&start=${start / 1000}&end=${end / 1000}&step=${stepSize}${nsParam}`
-        : `${basePath}/api/v1/query?query=${encodeURIComponent(q.query)}${nsParam}`;
+        ? `${basePath}/api/v1/query_range?query=${encodeURIComponent(q.query)}&start=${start / 1000}&end=${end / 1000}&step=${stepSize}${nsParam}${timeoutParam}`
+        : `${basePath}/api/v1/query?query=${encodeURIComponent(q.query)}${nsParam}${timeoutParam}`;
       return coFetchJSON(url);
     });
     Promise.all(promises)

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -175,7 +175,7 @@ const Graph = ({metric = undefined, numSamples, rule}) => {
   // 3 times the rule's duration, but not less than 30 minutes
   const timeSpan = Math.max(3 * duration, 30 * 60) * 1000;
 
-  return <QueryBrowser metric={metric} numSamples={numSamples} query={query} timeSpan={timeSpan} />;
+  return <QueryBrowser metric={metric} numSamples={numSamples} query={query} timeSpan={timeSpan} timeout="5s" />;
 };
 
 const SilenceMatchersList = ({silence}) => <div className={`co-text-${SilenceResource.kind.toLowerCase()}`}>


### PR DESCRIPTION
Allow graphs to set a timeout for the Prometheus API call that fetches
the data. This limits the potential load caused by heavy queries.

Set a timeout of `5s` for the Monitoring UI graphs.