### PR TITLE
Fix scenario 'logs in via htpasswd identity provider' for username

### DIFF
--- a/frontend/integration-tests/tests/login.scenario.ts
+++ b/frontend/integration-tests/tests/login.scenario.ts
@@ -36,7 +36,7 @@ describe('Auth test', () => {
       it('logs in via htpasswd identity provider', async() => {
         await loginView.login(HTPASSWD_IDP, HTPASSWD_USERNAME, HTPASSWD_PASSWORD);
         expect(browser.getCurrentUrl()).toContain(appHost);
-        expect(loginView.userDropdown.getText()).toContain('test');
+        expect(loginView.userDropdown.getText()).toContain(HTPASSWD_USERNAME);
       });
 
       it('logs out htpasswd user', async() => {


### PR DESCRIPTION
@TheRealJon 
Since SSO page support multiple IDENTITIES login, use HTPASSWD_USERNAME for username instead of hard-coded name in test scenario. Because hard coding htpasswd user to match 'test' (expect(loginView.userDropdown.getText()).toContain('test');) will cause failure when HTPASSWD_USERNAME  is set to users other than "test*"

Could anyone help to review and merge please? Thanks!