### PR TITLE
Auth test updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ CI runs the [test-prow-e2e.sh](test-prow-e2e.sh) script, which uses the `e2e` su
 You can simulate an e2e run against an existing 4.0 cluster with the following commands (replace `/path/to/install-dir` with your OpenShift 4.0 install directory):
 
 ```
-$ export BRIDGE_AUTH_USERNAME=kubeadmin
-$ export BRIDGE_BASE_ADDRESS="https://$(oc get route console -n openshift-console -o jsonpath='{.spec.host}')"
-$ export BRIDGE_AUTH_PASSWORD=$(cat "/path/to/install-dir/auth/kubeadmin-password")
+$ oc apply -f ./frontend/integration-tests/data/htpasswd-idp.yaml
+$ export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
+$ export BRIDGE_KUBEADMIN_PASSWORD=$(cat "/path/to/install-dir/auth/kubeadmin-password")
 $ ./test-gui.sh e2e
 ```
 

--- a/frontend/integration-tests/data/htpasswd-idp.yaml
+++ b/frontend/integration-tests/data/htpasswd-idp.yaml
@@ -17,8 +17,6 @@ metadata:
 spec:
   identityProviders:
   - name: test
-    challenge: true
-    login: true
     mappingMethod: claim
     type: HTPasswd
     htpasswd:

--- a/frontend/integration-tests/tests/login.scenario.ts
+++ b/frontend/integration-tests/tests/login.scenario.ts
@@ -9,10 +9,10 @@ const JASMINE_EXTENDED_TIMEOUT_INTERVAL = 1000 * 60 * 3;
 const KUBEADMIN_IDP = 'kube:admin';
 const KUBEADMIN_USERNAME = 'kubeadmin';
 const {
-  HTPASSWD_IDP = 'test',
-  HTPASSWD_USERNAME = 'test',
-  HTPASSWD_PASSWORD = 'test',
-  KUBEADMIN_PASSWORD,
+  BRIDGE_HTPASSWD_IDP = 'test',
+  BRIDGE_HTPASSWD_USERNAME = 'test',
+  BRIDGE_HTPASSWD_PASSWORD = 'test',
+  BRIDGE_KUBEADMIN_PASSWORD,
 } = process.env;
 
 describe('Auth test', () => {
@@ -21,7 +21,7 @@ describe('Auth test', () => {
     await browser.sleep(3000); // Wait long enough for the login redirect to complete
   });
 
-  if (KUBEADMIN_PASSWORD) {
+  if (BRIDGE_KUBEADMIN_PASSWORD) {
     describe('Login test', async() => {
       beforeAll(() => {
         // Extend the default jasmine timeout interval just in case it takes a while for the htpasswd idp to be ready
@@ -34,9 +34,9 @@ describe('Auth test', () => {
       });
 
       it('logs in via htpasswd identity provider', async() => {
-        await loginView.login(HTPASSWD_IDP, HTPASSWD_USERNAME, HTPASSWD_PASSWORD);
+        await loginView.login(BRIDGE_HTPASSWD_IDP, BRIDGE_HTPASSWD_USERNAME, BRIDGE_HTPASSWD_PASSWORD);
         expect(browser.getCurrentUrl()).toContain(appHost);
-        expect(loginView.userDropdown.getText()).toContain(HTPASSWD_USERNAME);
+        expect(loginView.userDropdown.getText()).toContain(BRIDGE_HTPASSWD_USERNAME);
       });
 
       it('logs out htpasswd user', async() => {
@@ -46,7 +46,7 @@ describe('Auth test', () => {
       });
 
       it('logs in as kubeadmin user', async() => {
-        await loginView.login(KUBEADMIN_IDP, KUBEADMIN_USERNAME, KUBEADMIN_PASSWORD);
+        await loginView.login(KUBEADMIN_IDP, KUBEADMIN_USERNAME, BRIDGE_KUBEADMIN_PASSWORD);
         expect(browser.getCurrentUrl()).toContain(appHost);
         expect(loginView.userDropdown.getText()).toContain('kube:admin');
         await browser.wait(until.presenceOf($('.co-global-notification')));
@@ -59,7 +59,7 @@ describe('Auth test', () => {
         expect($('.login-pf').isPresent()).toBeTruthy();
 
         // Log back in so that remaining tests can be run
-        await loginView.login(KUBEADMIN_IDP, KUBEADMIN_USERNAME, KUBEADMIN_PASSWORD);
+        await loginView.login(KUBEADMIN_IDP, KUBEADMIN_USERNAME, BRIDGE_KUBEADMIN_PASSWORD);
         expect(loginView.userDropdown.getText()).toContain('kube:admin');
       });
     });

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -17,7 +17,7 @@ trap copyArtifacts EXIT
 
 # don't log kubeadmin-password
 set +x
-export KUBEADMIN_PASSWORD="$(cat "${INSTALLER_DIR}/auth/kubeadmin-password")"
+export BRIDGE_KUBEADMIN_PASSWORD="$(cat "${INSTALLER_DIR}/auth/kubeadmin-password")"
 set -x
 export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
 


### PR DESCRIPTION
* `login` and `challenge` are no longer in the API
* Prefix test env vars with `BRIDGE`
* Update README for recent changes

/cc @enj @TheRealJon 

@xiaocwan fyi