### PR TITLE
Rich Preview for Operator InstallPlans

### DIFF
--- a/frontend/__mocks__/k8sResourcesMocks.ts
+++ b/frontend/__mocks__/k8sResourcesMocks.ts
@@ -9,7 +9,8 @@ import {
   CatalogSourceKind,
   InstallPlanApproval,
   PackageManifestKind,
-  OperatorGroupKind } from '../public/components/operator-lifecycle-manager';
+  OperatorGroupKind,
+  InstallPlanPhase } from '../public/components/operator-lifecycle-manager';
 import { StatusCapability, SpecCapability } from '../public/components/operator-lifecycle-manager/descriptors/types';
 import { CustomResourceDefinitionKind, K8sResourceKind, K8sKind } from '../public/module/k8s';
 /* eslint-enable no-unused-vars */
@@ -307,7 +308,7 @@ export const testInstallPlan: InstallPlanKind = {
     approval: InstallPlanApproval.Automatic,
   },
   status: {
-    phase: 'Complete',
+    phase: InstallPlanPhase.InstallPlanPhaseComplete,
     catalogSources: ['test-catalog'],
     plan: [],
   },

--- a/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
@@ -7,7 +7,7 @@ import * as _ from 'lodash';
 import { SubscriptionHeader, SubscriptionHeaderProps, SubscriptionRow, SubscriptionRowProps, SubscriptionsList, SubscriptionsListProps, SubscriptionsPage, SubscriptionsPageProps, SubscriptionDetails, SubscriptionDetailsPage, SubscriptionDetailsProps, SubscriptionUpdates, SubscriptionUpdatesProps, SubscriptionUpdatesState } from '../../../public/components/operator-lifecycle-manager/subscription';
 import { SubscriptionKind, SubscriptionState } from '../../../public/components/operator-lifecycle-manager';
 import { referenceForModel, referenceForModelCompatible } from '../../../public/module/k8s';
-import { SubscriptionModel, ClusterServiceVersionModel, PackageManifestModel, OperatorGroupModel } from '../../../public/models';
+import { SubscriptionModel, ClusterServiceVersionModel, PackageManifestModel, OperatorGroupModel, InstallPlanModel } from '../../../public/models';
 import { ListHeader, ColHead, List, MultiListPage, DetailsPage } from '../../../public/components/factory';
 import { ResourceKebab, ResourceLink, Kebab } from '../../../public/components/utils';
 import { testSubscription, testClusterServiceVersion, testPackageManifest } from '../../../__mocks__/k8sResourcesMocks';
@@ -215,6 +215,7 @@ describe(SubscriptionDetailsPage.displayName, () => {
 
     expect(wrapper.find(DetailsPage).props().resources).toEqual([
       {kind: referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'), namespace: 'default', isList: true, prop: 'packageManifests'},
+      {kind: referenceForModel(InstallPlanModel), isList: true, namespace: 'default', prop: 'installPlans'},
       {kind: referenceForModel(ClusterServiceVersionModel), namespace: 'default', isList: true, prop: 'clusterServiceVersions'},
     ]);
   });

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -65,3 +65,6 @@ export const taintsModal = (props) => import('./taints-modal' /* webpackChunkNam
 
 export const tolerationsModal = (props) => import('./tolerations-modal' /* webpackChunkName: "tolerations-modal" */)
   .then(m => m.tolerationsModal(props));
+
+export const installPlanPreviewModal = (props) => import('./installplan-preview-modal' /* webpackChunkName: "installplan-preview-modal" */)
+  .then(m => m.installPlanPreviewModal(props));

--- a/frontend/public/components/modals/installplan-preview-modal.tsx
+++ b/frontend/public/components/modals/installplan-preview-modal.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable no-undef, no-unused-vars */
+
+import * as React from 'react';
+import { safeDump } from 'js-yaml';
+
+import { createModalLauncher, ModalTitle, ModalBody, ModalFooter } from '../factory/modal';
+import { StepResource, referenceForStepResource } from '../operator-lifecycle-manager';
+import { ResourceLink, CopyToClipboard } from '../utils';
+
+export const installPlanPreviewModal = createModalLauncher<InstallPlanPreviewModalProps>(({cancel, stepResource}) => <div className="modal-content">
+  <ModalTitle>Install Plan Preview <ResourceLink linkTo={false} name={stepResource.name} kind={referenceForStepResource(stepResource)} /></ModalTitle>
+  <ModalBody>
+    <CopyToClipboard value={safeDump(JSON.parse(stepResource.manifest))} />
+  </ModalBody>
+  <ModalFooter inProgress={false}>
+    <button type="button" onClick={() => cancel()} className="btn btn-default">OK</button>
+  </ModalFooter>
+</div>);
+
+export type InstallPlanPreviewModalProps = {
+  stepResource: StepResource;
+  cancel: () => void;
+  close: () => void;
+};

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-import { K8sResourceKind, GroupVersionKind, OwnerReference, Selector } from '../../module/k8s';
+import { K8sResourceKind, GroupVersionKind, OwnerReference, Selector, referenceForGroupVersionKind } from '../../module/k8s';
 import { Descriptor } from './descriptors/types';
 export { ClusterServiceVersionsDetailsPage, ClusterServiceVersionsPage } from './clusterserviceversion';
 export { ClusterServiceVersionResourcesDetailsPage, ClusterServiceVersionResourceLink } from './clusterserviceversion-resource';
@@ -143,6 +143,15 @@ export type Step = {
   status: 'Unknown' | 'NotPresent' | 'Present' | 'Created';
 };
 
+export enum InstallPlanPhase {
+  InstallPlanPhaseNone = '',
+  InstallPlanPhasePlanning = 'Planning',
+  InstallPlanPhaseRequiresApproval = 'RequiresApproval',
+  InstallPlanPhaseInstalling = 'Installing',
+  InstallPlanPhaseComplete = 'Complete',
+  InstallPlanPhaseFailed = 'Failed',
+}
+
 export type InstallPlanKind = {
   spec: {
     clusterServiceVersionNames: string[];
@@ -150,7 +159,7 @@ export type InstallPlanKind = {
     approved?: boolean;
   };
   status?: {
-    phase: 'Planning' | 'RequiresApproval' | 'Installing' | 'Complete' | 'Failed';
+    phase: InstallPlanPhase;
     catalogSources: string[];
     plan: Step[];
   }
@@ -248,8 +257,10 @@ export const defaultChannelFor = (pkg: PackageManifestKind) => pkg.status.defaul
 export const installModesFor = (pkg: PackageManifestKind) => (channel: string) => pkg.status.channels.find(ch => ch.name === channel).currentCSVDesc.installModes;
 
 export const referenceForProvidedAPI = (desc: CRDDescription | APIServiceDefinition): GroupVersionKind => _.get(desc, 'group')
-  ? `${(desc as APIServiceDefinition).group}~${desc.version}~${desc.kind}`
-  : `${(desc as CRDDescription).name.slice(desc.name.indexOf('.') + 1)}~${desc.version}~${desc.kind}`;
+  ? referenceForGroupVersionKind((desc as APIServiceDefinition).group)(desc.version)(desc.kind)
+  : referenceForGroupVersionKind((desc as CRDDescription).name.slice(desc.name.indexOf('.') + 1))(desc.version)(desc.kind);
+
+export const referenceForStepResource = (resource: StepResource): GroupVersionKind => referenceForGroupVersionKind(resource.group || 'core')(resource.version)(resource.kind);
 
 export const ClusterServiceVersionLogo: React.SFC<ClusterServiceVersionLogoProps> = (props) => {
   const {icon, displayName, provider, version} = props;

--- a/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
@@ -6,12 +6,13 @@ import { match, Link } from 'react-router-dom';
 import { Map as ImmutableMap } from 'immutable';
 
 import { MultiListPage, List, ListHeader, ColHead, ResourceRow, DetailsPage } from '../factory';
-import { SectionHeading, MsgBox, ResourceLink, ResourceKebab, Kebab, ResourceIcon, navFactory, ResourceSummary } from '../utils';
-import { InstallPlanKind, InstallPlanApproval, olmNamespace, Step } from './index';
-import { referenceForModel, referenceForOwnerRef, k8sUpdate, referenceForModelCompatible } from '../../module/k8s';
+import { SectionHeading, MsgBox, ResourceLink, ResourceKebab, Kebab, ResourceIcon, navFactory, ResourceSummary, history } from '../utils';
+import { InstallPlanKind, InstallPlanApproval, olmNamespace, Step, referenceForStepResource } from './index';
+import { referenceForModel, referenceForOwnerRef, k8sUpdate, referenceForModelCompatible, apiVersionForReference } from '../../module/k8s';
 import { SubscriptionModel, ClusterServiceVersionModel, InstallPlanModel, CatalogSourceModel, OperatorGroupModel } from '../../models';
 import { breadcrumbsForOwnerRefs } from '../utils/breadcrumbs';
 import { requireOperatorGroup } from './operator-group';
+import { installPlanPreviewModal } from '../modals';
 
 export const InstallPlanHeader: React.SFC<InstallPlanHeaderProps> = (props) => <ListHeader>
   <ColHead {...props} className="col-xs-6 col-sm-4 col-md-3" sortField="metadata.name">Name</ColHead>
@@ -34,18 +35,20 @@ export const InstallPlanRow: React.SFC<InstallPlanRowProps> = (props) => {
       <ResourceLink kind="Namespace" name={props.obj.metadata.namespace} title={props.obj.metadata.namespace} displayName={props.obj.metadata.namespace} />
     </div>
     <div className="hidden-xs col-sm-4 col-md-3 col-lg-2">
-      {props.obj.spec.clusterServiceVersionNames.map((csvName, i) => <span key={i}>
-        { _.get(props, 'obj.status.phase') === 'Complete'
-          ? <ResourceLink kind={referenceForModel(ClusterServiceVersionModel)} name={csvName} namespace={props.obj.metadata.namespace} title={csvName} />
-          : <React.Fragment><ResourceIcon kind={referenceForModel(ClusterServiceVersionModel)} />{csvName}</React.Fragment> }
-      </span>) }
+      <ul className="list-unstyled">
+        { props.obj.spec.clusterServiceVersionNames.map((csvName, i) => <li key={i}>
+          { _.get(props, 'obj.status.phase') === 'Complete'
+            ? <ResourceLink kind={referenceForModel(ClusterServiceVersionModel)} name={csvName} namespace={props.obj.metadata.namespace} title={csvName} />
+            : <React.Fragment><ResourceIcon kind={referenceForModel(ClusterServiceVersionModel)} />{csvName}</React.Fragment> }
+        </li>) }
+      </ul>
     </div>
     <div className="hidden-xs hidden-sm col-md-3 col-lg-2">
       { (props.obj.metadata.ownerReferences || [])
         .filter(ref => referenceForOwnerRef(ref) === referenceForModel(SubscriptionModel))
-        .map(ref => <div key={ref.uid}>
-          <ResourceLink kind={referenceForModel(SubscriptionModel)} name={ref.name} namespace={props.obj.metadata.namespace} title={ref.uid} />
-        </div>) || <span className="text-muted">None</span> }
+        .map(ref => <ul key={ref.uid} className="list-unstyled">
+          <li><ResourceLink kind={referenceForModel(SubscriptionModel)} name={ref.name} namespace={props.obj.metadata.namespace} title={ref.uid} /></li>
+        </ul>) || <span className="text-muted">None</span> }
     </div>
     <div className="hidden-xs hidden-sm hidden-md col-lg-2">
       {phaseFor(_.get(props.obj.status, 'phase')) || 'Unknown'}
@@ -126,6 +129,7 @@ export class InstallPlanPreview extends React.Component<InstallPlanPreviewProps,
 
   render() {
     const {obj} = this.props;
+    const subscription = obj.metadata.ownerReferences.find(ref => referenceForOwnerRef(ref) === referenceForModel(SubscriptionModel));
 
     const plan = _.get(obj.status, 'plan') || [];
     const stepsByCSV = plan.reduce((acc, step) => acc.update(step.resolving, [], steps => steps.concat([step])), ImmutableMap<string, Step[]>()).toArray();
@@ -145,12 +149,18 @@ export class InstallPlanPreview extends React.Component<InstallPlanPreviewProps,
         { this.state.error && <div className="co-clusterserviceversion-detail__error-box">{this.state.error}</div> }
         { this.state.needsApproval && <div className="co-well">
           <h4>Review Manual Install Plan</h4>
-          <p>Once approved, the following resources will be created in order to satisfy the requirements for the components specified in the plan.</p>
+          <p>Once approved, the following resources will be created in order to satisfy the requirements for the components specified in the plan. Click the resource name to view the resource in detail.</p>
           <button
             className="btn btn-info"
             disabled={!this.state.needsApproval}
             onClick={() => approve()}>
             {this.state.needsApproval ? 'Approve' : 'Approved'}
+          </button>
+          <button
+            className="btn btn-default"
+            disabled={false}
+            onClick={() => history.push(`/k8s/ns/${obj.metadata.namespace}/${referenceForModel(SubscriptionModel)}/${subscription.name}?showDelete=true`)}>
+            Deny
           </button>
         </div> }
         { stepsByCSV.map((steps, i) => <div key={i} className="co-m-pane__body">
@@ -167,15 +177,20 @@ export class InstallPlanPreview extends React.Component<InstallPlanPreviewProps,
               </thead>
               <tbody>
                 { steps.map((step, key) => <tr key={key}>
-                  <td>{step.resource.name}</td>
-                  <td>
-                    <ResourceIcon kind={step.resource.kind === ClusterServiceVersionModel.kind ? referenceForModel(ClusterServiceVersionModel) : step.resource.kind} />
-                    {step.resource.kind}
+                  <td>{ ['Present', 'Created'].includes(step.status)
+                    ? <ResourceLink
+                      kind={referenceForStepResource(step.resource)}
+                      namespace={obj.metadata.namespace}
+                      name={step.resource.name}
+                      title={step.resource.name} />
+                    : <React.Fragment>
+                      <ResourceIcon kind={referenceForStepResource(step.resource)} />
+                      <button className="btn btn-link" onClick={() => installPlanPreviewModal({stepResource: step.resource})}>{step.resource.name}</button>
+                    </React.Fragment>}
                   </td>
-                  <td>{step.resource.group}/{step.resource.version}</td>
-                  <td>
-                    {stepStatus(step.status)}
-                  </td>
+                  <td>{step.resource.kind}</td>
+                  <td>{apiVersionForReference(referenceForStepResource(step.resource))}</td>
+                  <td>{stepStatus(step.status)}</td>
                 </tr>) }
               </tbody>
             </table>

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -8,7 +8,7 @@ import { List, ListHeader, ColHead, DetailsPage, MultiListPage } from '../factor
 import { requireOperatorGroup } from './operator-group';
 import { MsgBox, ResourceLink, ResourceKebab, navFactory, Kebab, ResourceSummary, LoadingInline, SectionHeading } from '../utils';
 import { removeQueryArgument } from '../utils/router';
-import { SubscriptionKind, SubscriptionState, PackageManifestKind, InstallPlanApproval, ClusterServiceVersionKind, olmNamespace, OperatorGroupKind } from './index';
+import { SubscriptionKind, SubscriptionState, PackageManifestKind, InstallPlanApproval, ClusterServiceVersionKind, olmNamespace, OperatorGroupKind, InstallPlanKind, InstallPlanPhase } from './index';
 import { referenceForModel, k8sKill, k8sUpdate, referenceForModelCompatible } from '../../module/k8s';
 import { SubscriptionModel, ClusterServiceVersionModel, CatalogSourceModel, InstallPlanModel, PackageManifestModel, OperatorGroupModel } from '../../models';
 import { createDisableApplicationModal } from '../modals/disable-application-modal';
@@ -106,7 +106,7 @@ export const SubscriptionDetails: React.SFC<SubscriptionDetailsProps> = (props) 
 
     <SectionHeading text="Subscription Overview" />
     <div className="co-m-pane__body-group">
-      <SubscriptionUpdates pkg={pkg} obj={obj} installedCSV={installedCSV} />
+      <SubscriptionUpdates pkg={pkg} obj={obj} installedCSV={installedCSV} installPlan={props.installPlan} />
     </div>
     <div className="co-m-pane__body-group">
       <div className="row">
@@ -159,6 +159,13 @@ export class SubscriptionUpdates extends React.Component<SubscriptionUpdatesProp
     const k8sUpdateAndWait = (...args) => k8sUpdate(...args).then(() => this.setState({waitingForUpdate: true}));
     const channelModal = () => createSubscriptionChannelModal({subscription: obj, pkg, k8sUpdate: k8sUpdateAndWait});
     const approvalModal = () => createInstallPlanApprovalModal({obj, k8sUpdate: k8sUpdateAndWait});
+    const installPlanPhase = (installPlan: InstallPlanKind) => {
+      switch (installPlan.status.phase) {
+        case InstallPlanPhase.InstallPlanPhaseRequiresApproval: return '1 requires approval';
+        case InstallPlanPhase.InstallPlanPhaseFailed: return '1 failed';
+        default: return '1 installing';
+      }
+    };
 
     return <div className="co-detail-table">
       <div className="co-detail-table__row row">
@@ -190,8 +197,10 @@ export class SubscriptionUpdates extends React.Component<SubscriptionUpdatesProp
             { _.get(obj.status, 'installedCSV') && installedCSV
               ? <Link to={`/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${_.get(obj.status, 'installedCSV')}`}>1 installed</Link>
               : <span>0 installed</span> }
-            { _.get(obj.status, 'state') === SubscriptionState.SubscriptionStateUpgradePending && _.get(obj.status, 'installplan')
-              ? <Link to={`/k8s/ns/${obj.metadata.namespace}/${InstallPlanModel.plural}/${_.get(obj.status, 'installplan.name')}`}>1 installing</Link>
+            { _.get(obj.status, 'state') === SubscriptionState.SubscriptionStateUpgradePending && _.get(obj.status, 'installplan') && this.props.installPlan
+              ? <Link to={`/k8s/ns/${obj.metadata.namespace}/${InstallPlanModel.plural}/${_.get(obj.status, 'installplan.name')}`}>
+                <span>{installPlanPhase(this.props.installPlan)}</span>
+              </Link>
               : <span>0 installing</span> }
           </div>
         </div>
@@ -210,6 +219,7 @@ export const SubscriptionDetailsPage: React.SFC<SubscriptionDetailsPageProps> = 
   type DetailsProps = {
     clusterServiceVersions?: ClusterServiceVersionKind[];
     packageManifests?: PackageManifestKind[];
+    installPlans?: InstallPlanKind[];
     obj: SubscriptionKind;
   };
 
@@ -224,12 +234,13 @@ export const SubscriptionDetailsPage: React.SFC<SubscriptionDetailsPageProps> = 
         pkg={pkgFor(detailsProps.packageManifests)(detailsProps.obj)}
         installedCSV={installedCSV(detailsProps.clusterServiceVersions)(detailsProps.obj)}
         showDelete={new URLSearchParams(window.location.search).has('showDelete')}
+        installPlan={(detailsProps.installPlans || []).find(ip => ip.metadata.name === _.get(detailsProps.obj.status, 'installplan.name'))}
       />),
       navFactory.editYaml(),
-      // TODO(alecmerdler): List install plans created by the subscription
     ]}
     resources={[
       {kind: referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'), isList: true, namespace: props.namespace, prop: 'packageManifests'},
+      {kind: referenceForModel(InstallPlanModel), isList: true, namespace: props.namespace, prop: 'installPlans'},
       {kind: referenceForModel(ClusterServiceVersionModel), namespace: props.namespace, isList: true, prop: 'clusterServiceVersions'},
     ]}
     menuActions={menuActions} />;
@@ -259,6 +270,7 @@ export type SubscriptionUpdatesProps = {
   obj: SubscriptionKind;
   pkg: PackageManifestKind;
   installedCSV?: ClusterServiceVersionKind;
+  installPlan?: InstallPlanKind;
 };
 
 export type SubscriptionUpdatesState = {
@@ -272,6 +284,7 @@ export type SubscriptionDetailsProps = {
   pkg: PackageManifestKind;
   installedCSV?: ClusterServiceVersionKind;
   showDelete?: boolean;
+  installPlan?: InstallPlanKind;
 };
 
 export type SubscriptionDetailsPageProps = {

--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -8,6 +8,9 @@ export const getQN: (obj: K8sResourceKind) => string = ({metadata: {name, namesp
 
 export const k8sBasePath = `${(window as any).SERVER_FLAGS.basePath}api/kubernetes`;
 
+// TODO(alecmerdler): Replace all manual string building with this function
+export const referenceForGroupVersionKind = (group: string) => (version: string) => (kind: string) => [group, version, kind].join('~');
+
 export const isGroupVersionKind = (ref: GroupVersionKind | string) => ref.split('~').length === 3;
 
 export const groupVersionFor = (apiVersion: string) => ({
@@ -16,20 +19,16 @@ export const groupVersionFor = (apiVersion: string) => ({
 });
 
 export const referenceFor = (obj: K8sResourceKind): GroupVersionKind => obj.kind && obj.apiVersion
-  ? `${groupVersionFor(obj.apiVersion).group}~${groupVersionFor(obj.apiVersion).version}~${obj.kind}`
+  ? referenceForGroupVersionKind(groupVersionFor(obj.apiVersion).group)(groupVersionFor(obj.apiVersion).version)(obj.kind)
   : '';
 
-export const referenceForCRD = (obj: CustomResourceDefinitionKind): GroupVersionKind => (
-  `${obj.spec.group}~${obj.spec.version}~${obj.spec.names.kind}`
-);
+export const referenceForCRD = (obj: CustomResourceDefinitionKind): GroupVersionKind => referenceForGroupVersionKind(obj.spec.group)(obj.spec.version)(obj.spec.names.kind);
 
-export const referenceForOwnerRef = (ownerRef: OwnerReference): GroupVersionKind => (
-  `${groupVersionFor(ownerRef.apiVersion).group}~${groupVersionFor(ownerRef.apiVersion).version}~${ownerRef.kind}`
-);
+export const referenceForOwnerRef = (ownerRef: OwnerReference): GroupVersionKind =>
+  referenceForGroupVersionKind(groupVersionFor(ownerRef.apiVersion).group)(groupVersionFor(ownerRef.apiVersion).version)(ownerRef.kind);
 
-export const referenceForModel = (model: K8sKind): GroupVersionKind => (
-  `${model.apiGroup || 'core'}~${model.apiVersion}~${model.kind}`
-);
+export const referenceForModel = (model: K8sKind): GroupVersionKind =>
+  referenceForGroupVersionKind(model.apiGroup || 'core')(model.apiVersion)(model.kind);
 
 export const kindForReference = (ref: K8sResourceKindReference) => isGroupVersionKind(ref)
   ? ref.split('~')[2]


### PR DESCRIPTION
### Description

Improves the UX of approving an `InstallPlan` by rendering details for each component that will be created as a result of executing the plan. If the plan has already been executed, show links to the created objects.

Also adds the ability to "deny" an `InstallPlan`, which will delete the associated `Subscription` as well.

### Screenshots

**`InstallPlan` list view:**
![Screenshot_20190326_143900](https://user-images.githubusercontent.com/11700385/55024353-0d395400-4fd5-11e9-9144-338e6b4e1e7d.png)

**`InstallPlan` detail view (w/ component preview modal):**
![Screenshot_20190326_162307](https://user-images.githubusercontent.com/11700385/55030867-ae2f0b80-4fe3-11e9-9103-eb56f2c113ea.png)

**`InstallPlan` detail view (approved):**
![Screenshot_20190326_162517](https://user-images.githubusercontent.com/11700385/55030935-d880c900-4fe3-11e9-85b7-8e422cc95ca2.png)

Addresses https://jira.coreos.com/browse/OLM-911
Addresses https://jira.coreos.com/browse/OLM-912