### PR TITLE
Align secrets createItems with deploymentConfig's

### DIFF
--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -127,7 +127,7 @@ const SecretsPage = props => {
     image: 'Image Pull Secret',
     source: 'Source Secret',
     webhook: 'Webhook Secret',
-    yaml: 'Secret from YAML',
+    yaml: 'From YAML',
   };
 
   const createProps = {


### PR DESCRIPTION
Noticed that we have slightly different naming in the `createItems` for secrets and [deploymentConfig](https://github.com/openshift/console/blob/master/frontend/public/components/deployment-config.tsx#L171).