### PR TITLE
Monitoring: Add show / hide toggle button for the graphs

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -169,7 +169,20 @@ const Label = ({k, v}) => <div className="co-m-label co-m-label--expand" key={k}
   <span className="co-m-label__value">{v}</span>
 </div>;
 
-const Graph = ({metric = undefined, numSamples, rule}) => {
+const graphStateToProps = ({UI}) => ({hideGraphs: !!UI.getIn(['monitoring', 'hideGraphs'])});
+
+const ToggleGraph_ = ({hideGraphs, toggle}) => {
+  const iconClass = `fa fa-${hideGraphs ? 'line-chart' : 'compress'}`;
+  return <button type="button" className="btn btn-link" onClick={toggle}>
+    {hideGraphs ? 'Show' : 'Hide'} Graph <i className={iconClass} aria-hidden="true" />
+  </button>;
+};
+const ToggleGraph = connect(graphStateToProps, {toggle: UIActions.toggleMonitoringGraphs})(ToggleGraph_);
+
+const Graph_ = ({hideGraphs, metric = undefined, numSamples, rule}) => {
+  if (hideGraphs) {
+    return null;
+  }
   const {duration = 0, query = ''} = rule || {};
 
   // 3 times the rule's duration, but not less than 30 minutes
@@ -177,6 +190,7 @@ const Graph = ({metric = undefined, numSamples, rule}) => {
 
   return <QueryBrowser metric={metric} numSamples={numSamples} query={query} timeSpan={timeSpan} timeout="5s" />;
 };
+const Graph = connect(graphStateToProps)(Graph_);
 
 const SilenceMatchersList = ({silence}) => <div className={`co-text-${SilenceResource.kind.toLowerCase()}`}>
   {_.map(silence.matchers, ({name, isRegex, value}, i) => <Label key={i} k={name} v={isRegex ? `~${value}` : value} />)}
@@ -218,7 +232,9 @@ const AlertsDetailsPage = withFallback(connect(alertStateToProps)((props: Alerts
         </h1>
       </div>
       <div className="co-m-pane__body">
-        <SectionHeading text="Alert Overview" />
+        <SectionHeading text="Alert Overview">
+          {state !== AlertStates.NotFiring && <ToggleGraph />}
+        </SectionHeading>
         <div className="co-m-pane__body-group">
           <div className="row">
             <div className="col-sm-12">
@@ -364,7 +380,9 @@ const AlertRulesDetailsPage = withFallback(connect(ruleStateToProps)((props: Ale
       </div>
       <div className="co-m-pane__body">
         <div className="co-m-pane__body-group">
-          <SectionHeading text="Active Alerts" />
+          <SectionHeading text="Active Alerts">
+            <ToggleGraph />
+          </SectionHeading>
           <div className="row">
             <div className="col-sm-12">
               <Graph numSamples={300} rule={rule} />

--- a/frontend/public/ui/ui-actions.js
+++ b/frontend/public/ui/ui-actions.js
@@ -76,6 +76,7 @@ export const types = {
   setClusterID: 'setClusterID',
   setCurrentLocation: 'setCurrentLocation',
   setMonitoringData: 'setMonitoringData',
+  toggleMonitoringGraphs: 'toggleMonitoringGraphs',
   setUser: 'setUser',
   sortList: 'sortList',
   startImpersonate: 'startImpersonate',
@@ -188,4 +189,6 @@ export const UIActions = {
   monitoringLoaded: (key, data) => ({type: types.setMonitoringData, key, data: {loaded: true, loadError: null, data}}),
 
   monitoringErrored: (key, loadError) => ({type: types.setMonitoringData, key, data: {loaded: true, loadError, data: null}}),
+
+  [types.toggleMonitoringGraphs]: () => ({type: types.toggleMonitoringGraphs}),
 };

--- a/frontend/public/ui/ui-reducers.js
+++ b/frontend/public/ui/ui-reducers.js
@@ -98,6 +98,9 @@ export default (state, action) => {
       });
       return state.setIn(['monitoring', 'silences'], silences);
     }
+    case types.toggleMonitoringGraphs:
+      return state.setIn(['monitoring', 'hideGraphs'], !state.getIn(['monitoring', 'hideGraphs']));
+
     case types.selectOverviewView:
       return state.setIn(['overview', 'selectedView'], action.view);
 


### PR DESCRIPTION
Uses redux to store a `hideGraphs` flag, which applies to all monitoring
UI pages. So, for example, hiding the graph on the alert details page
will also hide it on the alerting rule details page.

### Graph Shown
![screenshot-1](https://user-images.githubusercontent.com/460802/55077590-7c996b80-50db-11e9-8d91-b7a39b10f540.png)

### Graph Hidden
![screenshot-2](https://user-images.githubusercontent.com/460802/55077612-858a3d00-50db-11e9-8189-cc089321e79e.png)

FYI @cshinn 