### PR TITLE
Add common component for idp mapping method dropdown

### DIFF
--- a/frontend/public/components/cluster-settings/htpasswd-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/htpasswd-idp-form.tsx
@@ -9,11 +9,11 @@ import { k8sCreate, k8sGet, k8sPatch, K8sResourceKind, referenceFor } from '../.
 import {
   AsyncComponent,
   ButtonBar,
-  Dropdown,
   PromiseComponent,
   history,
   resourceObjPath,
 } from '../utils';
+import { MappingMethod, MappingMethodType } from './mapping-method';
 
 // The name of the cluster-scoped OAuth configuration resource.
 const oauthResourceName = 'cluster';
@@ -101,11 +101,7 @@ export class AddHTPasswdPage extends PromiseComponent {
   render() {
     const { name, mappingMethod, htpasswdFileContent } = this.state;
     const title = 'Add Identity Provider: HTPasswd';
-    const mappingMethods = {
-      'claim': 'Claim',
-      'lookup': 'Lookup',
-      'add': 'Add',
-    };
+
     return <div className="co-m-pane__body">
       <Helmet>
         <title>{title}</title>
@@ -128,14 +124,7 @@ export class AddHTPasswdPage extends PromiseComponent {
             Unique name of the new identity provider. This cannot be changed later.
           </p>
         </div>
-        <div className="form-group">
-          <label className="control-label co-required" htmlFor="tag">Mapping Method</label>
-          <Dropdown dropDownClassName="dropdown--full-width" items={mappingMethods} selectedKey={mappingMethod} title={mappingMethods[mappingMethod]} onChange={this.mappingMethodChanged} />
-          <div className="help-block" id="mapping-method-description">
-            { /* TODO: Add doc link when available in 4.0 docs. */ }
-            Specifies how new identities are mapped to users when they log in.
-          </div>
-        </div>
+        <MappingMethod value={mappingMethod} onChange={this.mappingMethodChanged} />
         <div className="form-group">
           <DroppableFileInput
             onChange={this.htpasswdFileChanged}
@@ -157,7 +146,7 @@ export class AddHTPasswdPage extends PromiseComponent {
 
 type AddHTPasswdPageState = {
   name: string;
-  mappingMethod: string;
+  mappingMethod: MappingMethodType;
   htpasswdFileContent: string;
   inProgress: boolean;
   errorMessage: string;

--- a/frontend/public/components/cluster-settings/mapping-method.tsx
+++ b/frontend/public/components/cluster-settings/mapping-method.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable no-undef, no-unused-vars */
+import * as React from 'react';
+
+import { Dropdown } from '../utils';
+
+export const MappingMethod: React.FC<MappingMethodProps> = ({value, onChange}) => {
+  const mappingMethodChanged = (mappingMethod: MappingMethodType) => {
+    onChange(mappingMethod);
+  };
+  const mappingMethods = {
+    'claim': 'Claim',
+    'lookup': 'Lookup',
+    'add': 'Add',
+  };
+  return (
+    <div className="form-group">
+      <label className="control-label co-required" htmlFor="tag">Mapping Method</label>
+      <Dropdown dropDownClassName="dropdown--full-width" items={mappingMethods} selectedKey={value} title={mappingMethods[value]} onChange={mappingMethodChanged} />
+      <div className="help-block" id="mapping-method-description">
+        { /* TODO: Add doc link when available in 4.0 docs. */ }
+        Specifies how new identities are mapped to users when they log in.
+      </div>
+    </div>
+  );
+};
+
+export type MappingMethodType = 'claim' | 'lookup' | 'add';
+
+type MappingMethodProps = {
+  value: MappingMethodType;
+  onChange: (value: MappingMethodType) => void;
+};

--- a/frontend/public/components/cluster-settings/openid-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/openid-idp-form.tsx
@@ -9,12 +9,12 @@ import { k8sCreate, k8sGet, k8sPatch, K8sResourceKind, referenceFor } from '../.
 import {
   AsyncComponent,
   ButtonBar,
-  Dropdown,
   ListInput,
   PromiseComponent,
   history,
   resourceObjPath,
 } from '../utils';
+import { MappingMethod, MappingMethodType } from './mapping-method';
 
 // The name of the cluster-scoped OAuth configuration resource.
 const oauthResourceName = 'cluster';
@@ -178,11 +178,6 @@ export class AddOpenIDPage extends PromiseComponent {
   render() {
     const { name, mappingMethod, clientID, clientSecretFileContent, issuer, caFileContent } = this.state;
     const title = 'Add Identity Provider: OpenID Connect';
-    const mappingMethods = {
-      'claim': 'Claim',
-      'lookup': 'Lookup',
-      'add': 'Add',
-    };
     return <div className="co-m-pane__body">
       <Helmet>
         <title>{title}</title>
@@ -205,14 +200,7 @@ export class AddOpenIDPage extends PromiseComponent {
             Unique name of the new identity provider. This cannot be changed later.
           </p>
         </div>
-        <div className="form-group">
-          <label className="control-label co-required" htmlFor="tag">Mapping Method</label>
-          <Dropdown dropDownClassName="dropdown--full-width" items={mappingMethods} selectedKey={mappingMethod} title={mappingMethods[mappingMethod]} onChange={this.mappingMethodChanged} />
-          <div className="help-block" id="mapping-method-description">
-            { /* TODO: Add doc link when available in 4.0 docs. */ }
-            Specifies how new identities are mapped to users when they log in.
-          </div>
-        </div>
+        <MappingMethod value={mappingMethod} onChange={this.mappingMethodChanged} />
         <div className="form-group">
           <label className="control-label co-required" htmlFor="clientID">ClientID</label>
           <input className="form-control"
@@ -268,7 +256,7 @@ export class AddOpenIDPage extends PromiseComponent {
 
 type AddOpenIDIDPPageState = {
   name: string;
-  mappingMethod: 'claim' | 'lookup' | 'add';
+  mappingMethod: MappingMethodType;
   clientID: string;
   clientSecretFileContent: string;
   claimPreferredUsernames: string[];


### PR DESCRIPTION
Add common component for idp mapping method dropdown to new cluster-settings-utils file and use the common component in htpasswd and openid forms.