### PR TITLE
Fix lint warning in crud integration test scenario

### DIFF
--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -273,7 +273,7 @@ describe('Kubernetes resource CRUD operations', () => {
       await crudView.isLoaded();
       await crudView.resourceRows.$$('.co-kebab__button').click();
       await browser.wait(until.elementToBeClickable($('.co-kebab__dropdown')));
-      await $('.co-kebab__dropdown').$$('a').filter(link => link.getText().then(text => text.startsWith('View Instances'))).first().click();
+      await element(by.cssContainingText('.co-kebab__dropdown a', 'View Instances')).click();
       await crudView.isLoaded();
       await crudView.createYAMLButton.click();
       await yamlView.isLoaded();


### PR DESCRIPTION
Fixes this lint warning:

```sh
./frontend/integration-tests/tests/crud.scenario.ts
  276:81  warning  Too many nested callbacks (5). Maximum allowed is 4  max-nested-callbacks
```