### PR TITLE
Address issue of resource name on details page doesn't wrap and causes resource icon to break

### DIFF
--- a/frontend/integration-tests/views/create-role-binding.view.ts
+++ b/frontend/integration-tests/views/create-role-binding.view.ts
@@ -10,7 +10,7 @@ const selectFromDropdown = async(dropdownButton, text) => {
 
 export const selectNamespace = (namespace) => selectFromDropdown($('#ns-dropdown'), namespace);
 export const selectRole = (role) => selectFromDropdown($('#role-dropdown'), role);
-export const getSelectedNamespace = () => $('#ns-dropdown .co-resource-link__resource-name').getText();
-export const getSelectedRole = () => $('#role-dropdown .co-resource-link__resource-name').getText();
+export const getSelectedNamespace = () => $('#ns-dropdown .co-resource-item__resource-name').getText();
+export const getSelectedRole = () => $('#role-dropdown .co-resource-item__resource-name').getText();
 export const inputName = (name) => $('#role-binding-name').sendKeys(name);
 export const inputSubject = (subject) => $('#subject-name').sendKeys(subject);

--- a/frontend/integration-tests/views/monitoring.view.ts
+++ b/frontend/integration-tests/views/monitoring.view.ts
@@ -6,7 +6,7 @@ export const wait = async(condition) => await browser.wait(condition, 15000);
 
 // List pages
 export const listPageHeading = $('.co-m-pane__heading');
-export const firstListLink = $$('.co-resource-list__item a.co-resource-link__resource-name').first();
+export const firstListLink = $$('.co-resource-list__item a.co-resource-item__resource-name').first();
 export const createButton = $('.co-m-pane__filter-bar-group button');
 export const rowMenuButton = row => row.$('.co-kebab__button');
 
@@ -18,9 +18,9 @@ export const detailsHeadingSilenceIcon = $('.co-m-nav-title .co-m-resource-silen
 export const detailsSubHeadings = $$('.co-m-pane__body h2');
 export const labels = $$('.co-m-label');
 export const expiredSilenceIcon = $('.co-m-pane__details .fa-ban');
-export const ruleLink = $('.co-m-pane__details .co-resource-link__resource-name');
+export const ruleLink = $('.co-m-pane__details .co-resource-item__resource-name');
 export const silenceComment = $$('.co-m-pane__details dd').get(-2);
-export const firstAlertsListLink = $$('.co-resource-list__item a.co-resource-link').first();
+export const firstAlertsListLink = $$('.co-resource-list__item a.co-resource-item').first();
 
 export const clickActionsMenuAction = async(actionText) => {
   await wait(until.presenceOf(crudView.actionsDropdown));

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -97,7 +97,7 @@ const Header = props => <ListHeader>
 </ListHeader>;
 
 export const BindingName = ({binding}) => {
-  <ResourceLink kind={bindingKind(binding)} name={binding.metadata.name} namespace={binding.metadata.namespace} className="co-resource-link__resource-name" />;
+  <ResourceLink kind={bindingKind(binding)} name={binding.metadata.name} namespace={binding.metadata.namespace} className="co-resource-item__resource-name" />;
 };
 
 export const BindingKebab = connect(null, {startImpersonate: UIActions.startImpersonate})(
@@ -114,7 +114,7 @@ export const RoleLink = ({binding}) => {
 
 const Row = ({obj: binding}) => <ResourceRow obj={binding}>
   <div className="col-md-3 col-sm-4 col-xs-6">
-    <ResourceLink kind={bindingKind(binding)} name={binding.metadata.name} namespace={binding.metadata.namespace} className="co-resource-link__resource-name" />
+    <ResourceLink kind={bindingKind(binding)} name={binding.metadata.name} namespace={binding.metadata.namespace} className="co-resource-item__resource-name" />
   </div>
   <div className="col-md-3 col-sm-4 hidden-xs co-break-word">
     <RoleLink binding={binding} />

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -279,7 +279,7 @@ $color-bookmarker: #DDD;
   overflow: hidden;
   text-align: left;
   text-overflow: ellipsis;
-  .co-resource-link__resource-name {
+  .co-resource-item__resource-name {
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -6,9 +6,9 @@
   }
 }
 
-.co-action-buttons__btn,
+.co-action-buttons__btn, // btn along with drowdown actions
 .co-actions-menu {
-  margin-left: 3px;
+  margin-left: 10px;
 }
 
 .co-m-nav-title {

--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -19,7 +19,7 @@
     .active a,
     .active a:focus,
     .active a:hover {
-      .co-resource-link__resource-api {
+      .co-resource-item__resource-api {
         color: $dropdown-link-active-color;
       }
     }

--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -3,6 +3,7 @@
   border-radius: 20px;
   color: #fff;
   display: inline-block;
+  flex-shrink: 0;
   font-size: $font-size-base - 1;
   font-weight: 300;
   line-height: 16px;
@@ -10,7 +11,6 @@
   min-width: 18px;
   padding: 2px 4px 1px;
   text-align: center;
-
   &--lg {
     font-size: ($font-size-base + 1);
     line-height: 21px;
@@ -99,7 +99,7 @@
   background-color: $color-ingress-dark;
 }
 
-.co-resource-link {
+.co-resource-item {
   align-items: baseline;
   display: flex;
   min-width: 0; // required so co-break-word works
@@ -111,16 +111,14 @@
   &__resource-name {
     min-width: 0; // required so co-break-word works
   }
-  .co-m-resource-icon {
-    flex-shrink: 0;
-  }
 }
 
-.co-resource-link-truncate {
+.co-resource-item--truncate {
   white-space: nowrap;
-  .co-resource-link__resource-name {
+  .co-resource-item__resource-name {
     line-height: normal;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 }
+

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -35,7 +35,7 @@ const namespaced = crd => crd.spec.scope === 'Namespaced';
 
 const CRDRow = ({obj: crd}) => <div className="row co-resource-list__item">
   <div className="col-lg-3 col-md-4 col-sm-4 col-xs-6">
-    <span className="co-resource-link">
+    <span className="co-resource-item">
       <ResourceLink kind="CustomResourceDefinition" name={crd.metadata.name} namespace={crd.metadata.namespace} displayName={_.get(crd, 'spec.names.kind')} />
     </span>
   </div>

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -211,7 +211,7 @@ const AlertsDetailsPage = withFallback(connect(alertStateToProps)((props: Alerts
     <StatusBox data={alert} label={AlertResource.label} loaded={loaded} loadError={loadError}>
       <div className="co-m-nav-title co-m-nav-title--detail">
         <h1 className="co-m-pane__heading">
-          <div className="co-m-pane__name"><MonitoringResourceIcon className="co-m-resource-icon--lg" resource={AlertResource} />{alertname}</div>
+          <div className="co-m-pane__name co-resource-item"><MonitoringResourceIcon className="co-m-resource-icon--lg" resource={AlertResource} />{alertname}</div>
           {(state === AlertStates.Firing || state === AlertStates.Pending) && <div className="co-actions">
             <ActionsMenu actions={[silenceAlert(alert)]} />
           </div>}
@@ -248,9 +248,9 @@ const AlertsDetailsPage = withFallback(connect(alertStateToProps)((props: Alerts
                 </dd>
                 <dt>Alerting Rule</dt>
                 <dd>
-                  <div className="co-resource-link">
+                  <div className="co-resource-item">
                     <MonitoringResourceIcon resource={AlertRuleResource} />
-                    <Link to={ruleURL(rule)} className="co-resource-link__resource-name">{_.get(rule, 'name')}</Link>
+                    <Link to={ruleURL(rule)} className="co-resource-item__resource-name">{_.get(rule, 'name')}</Link>
                   </div>
                 </dd>
               </dl>
@@ -298,7 +298,7 @@ const ActiveAlerts = ({alerts, ruleID}) => <div className="co-m-table-grid co-m-
   <div className="co-m-table-grid__body">
     {_.sortBy(alerts, alertDescription).map((a, i) => <ResourceRow key={i} obj={a}>
       <div className="col-xs-6">
-        <Link className="co-resource-link" to={alertURL(a, ruleID)}>{alertDescription(a)}</Link>
+        <Link className="co-resource-item" to={alertURL(a, ruleID)}>{alertDescription(a)}</Link>
       </div>
       <div className="col-sm-2 hidden-xs"><Timestamp timestamp={a.activeAt} /></div>
       <div className="col-sm-2 col-xs-3"><AlertState state={a.state} /></div>
@@ -327,7 +327,7 @@ const AlertRulesDetailsPage = withFallback(connect(ruleStateToProps)((props: Ale
     <StatusBox data={rule} label={AlertRuleResource.label} loaded={loaded} loadError={loadError}>
       <div className="co-m-nav-title co-m-nav-title--detail">
         <h1 className="co-m-pane__heading">
-          <div className="co-m-pane__name"><MonitoringResourceIcon className="co-m-resource-icon--lg" resource={AlertRuleResource} />{name}</div>
+          <div className="co-m-pane__name co-resource-item"><MonitoringResourceIcon className="co-m-resource-icon--lg" resource={AlertRuleResource} />{name}</div>
         </h1>
       </div>
       <div className="co-m-pane__body">
@@ -391,7 +391,7 @@ const SilencedAlertsList = ({alerts}) => _.isEmpty(alerts)
     <div className="co-m-table-grid__body">
       {_.sortBy(alerts, alertDescription).map((a, i) => <div className="row co-resource-list__item" key={i}>
         <div className="col-xs-9">
-          <Link className="co-resource-link" to={alertURL(a, a.rule.id)}>{a.labels.alertname}</Link>
+          <Link className="co-resource-item" to={alertURL(a, a.rule.id)}>{a.labels.alertname}</Link>
           <div className="monitoring-description">{alertDescription(a)}</div>
         </div>
         <div className="col-xs-3">{a.labels.severity || '-'}</div>
@@ -420,7 +420,7 @@ const SilencesDetailsPage = withFallback(connect(silenceParamToProps)((props: Si
     <StatusBox data={silence} label={SilenceResource.label} loaded={loaded} loadError={loadError}>
       <div className="co-m-nav-title co-m-nav-title--detail">
         <h1 className="co-m-pane__heading">
-          <div className="co-m-pane__name"><MonitoringResourceIcon className="co-m-resource-icon--lg" resource={SilenceResource} />{name}</div>
+          <div className="co-m-pane__name co-resource-item"><MonitoringResourceIcon className="co-m-resource-icon--lg" resource={SilenceResource} />{name}</div>
           <SilenceActionsMenu silence={silence} />
         </h1>
       </div>
@@ -482,9 +482,9 @@ const AlertRow = ({obj}) => {
 
   return <ResourceRow obj={obj}>
     <div className="col-sm-7 col-xs-8">
-      <div className="co-resource-link">
+      <div className="co-resource-item">
         <MonitoringResourceIcon resource={AlertResource} />
-        <Link to={alertURL(obj, obj.rule.id)} className="co-resource-link__resource-name">{labels.alertname}</Link>
+        <Link to={alertURL(obj, obj.rule.id)} className="co-resource-item__resource-name">{labels.alertname}</Link>
       </div>
       <div className="monitoring-description">{annotations.description || annotations.message}</div>
     </div>
@@ -583,7 +583,7 @@ const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringListPage
       </Helmet>
       <div className="co-m-nav-title">
         <h1 className="co-m-pane__heading">
-          <div className="co-m-pane__name">
+          <div className="co-m-pane__name co-resource-item">
             {kindPlural}
             <HeaderAlertmanagerLink path={alertmanagerLinkPath} />
           </div>
@@ -650,9 +650,9 @@ const SilenceRow = ({obj}) => {
 
   return <ResourceRow obj={obj}>
     <div className="col-sm-7 col-xs-8">
-      <div className="co-resource-link">
+      <div className="co-resource-item">
         <MonitoringResourceIcon resource={SilenceResource} />
-        <Link className="co-resource-link__resource-name" title={obj.id} to={`${SilenceResource.path}/${obj.id}`}>{obj.name}</Link>
+        <Link className="co-resource-item__resource-name" title={obj.id} to={`${SilenceResource.path}/${obj.id}`}>{obj.name}</Link>
       </div>
       <div className="monitoring-label-list">
         <SilenceMatchersList silence={obj} />

--- a/frontend/public/components/mounted-vol.tsx
+++ b/frontend/public/components/mounted-vol.tsx
@@ -16,7 +16,7 @@ import {
   SectionHeading,
 } from './utils';
 
-const ContainerLink = ({name, pod}) => <span className="co-resource-link co-resource-link--inline">
+const ContainerLink = ({name, pod}) => <span className="co-resource-item co-resource-item--inline">
   <ResourceIcon kind="Container" />
   <Link to={`/k8s/ns/${pod.metadata.namespace}/pods/${pod.metadata.name}/containers/${name}`}>{name}</Link>
 </span>;

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -84,9 +84,9 @@ const ProjectRow = ({obj: project}) => {
   const requester = getRequester(project);
   return <ResourceRow obj={project}>
     <div className="col-md-3 col-sm-6 col-xs-8">
-      <span className="co-resource-link">
+      <span className="co-resource-item">
         <ResourceIcon kind="Project" />
-        <Link to={`/overview/ns/${name}`} title={displayName} className="co-resource-link__resource-name">{project.metadata.name}</Link>
+        <Link to={`/overview/ns/${name}`} title={displayName} className="co-resource-item__resource-name">{project.metadata.name}</Link>
       </span>
     </div>
     <div className="col-md-3 col-sm-3 col-xs-4">

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
@@ -31,9 +31,9 @@ export const ClusterServiceVersionResourceLink: React.SFC<ClusterServiceVersionR
   // FIXME(alecmerdler): Grab `ClusterServiceVersion` name from Redux instead
   const appName = location.pathname.split('/').slice(-2, -1);
 
-  return <span className="co-resource-link">
+  return <span className="co-resource-item">
     <ResourceIcon kind={referenceFor(props.obj)} />
-    <Link to={`/k8s/ns/${namespace}/${ClusterServiceVersionModel.plural}/${appName}/${referenceFor(props.obj)}/${name}`} className="co-resource-link__resource-name">{name}</Link>
+    <Link to={`/k8s/ns/${namespace}/${ClusterServiceVersionModel.plural}/${appName}/${referenceFor(props.obj)}/${name}`} className="co-resource-item__resource-name">{name}</Link>
   </span>;
 };
 

--- a/frontend/public/components/overview/namespace-overview.tsx
+++ b/frontend/public/components/overview/namespace-overview.tsx
@@ -51,7 +51,7 @@ const ResourceQuotaCharts = ({quota, resourceTypes}) => {
   return <div className="group">
     <div className="group__title">
       <h2 className="h3">
-        <ResourceLink kind="ResourceQuota" name={quota.metadata.name} className="co-resource-link-truncate"
+        <ResourceLink kind="ResourceQuota" name={quota.metadata.name} className="co-resource-item--truncate"
           namespace={quota.metadata.namespace} inline="true" title={quota.metadata.name} />
         {scopes && <QuotaScopesInline className="co-resource-quota-dashboard-scopes" scopes={scopes} />}
       </h2>

--- a/frontend/public/components/overview/project-overview.tsx
+++ b/frontend/public/components/overview/project-overview.tsx
@@ -217,9 +217,9 @@ const ProjectOverviewListItem = connect<ProjectOverviewListItemPropsFromState, P
     const isSelected = uid === selectedUID;
     const className = classnames(`project-overview__item project-overview__item--${kind}`, {'project-overview__item--selected': isSelected});
     const heading = <h3 className="project-overview__item-heading">
-      <span className="co-resource-link co-resource-link-truncate">
+      <span className="co-resource-item co-resource-item--truncate">
         <ResourceIcon kind={kind} />
-        <Link to={resourcePath(kind, name, namespace)} className="co-resource-link__resource-name">
+        <Link to={resourcePath(kind, name, namespace)} className="co-resource-item__resource-name">
           {name}
         </Link>
         {current && <React.Fragment>,&nbsp;<ControllerLink controller={current} /></React.Fragment>}

--- a/frontend/public/components/pod.jsx
+++ b/frontend/public/components/pod.jsx
@@ -85,7 +85,7 @@ const PodHeader = props => <ListHeader>
   <ColHead {...props} className="col-lg-2 hidden-md hidden-sm hidden-xs" sortFunc="podReadiness">Readiness</ColHead>
 </ListHeader>;
 
-const ContainerLink = ({pod, name}) => <span className="co-resource-link co-resource-link--inline">
+const ContainerLink = ({pod, name}) => <span className="co-resource-item co-resource-item--inline">
   <ResourceIcon kind="Container" />
   <Link to={`/k8s/ns/${pod.metadata.namespace}/pods/${pod.metadata.name}/containers/${name}`}>{name}</Link>
 </span>;

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -40,13 +40,13 @@ const blacklistResources = ImmutableSet([
 ]);
 
 const DropdownItem: React.SFC<DropdownItemProps> = ({model, showGroup}) => <React.Fragment>
-  <span className="co-resource-link">
+  <span className="co-resource-item">
     <span className="co-resource-icon--fixed-width">
       <ResourceIcon kind={model.kind} />
     </span>
-    <span className="co-resource-link__resource-name">
+    <span className="co-resource-item__resource-name">
       {model.kind}
-      {showGroup && <React.Fragment>&nbsp;<div className="co-resource-link__resource-api text-muted co-truncate show co-nowrap small">{model.apiGroup || 'core'}/{model.apiVersion}</div></React.Fragment>}
+      {showGroup && <React.Fragment>&nbsp;<div className="co-resource-item__resource-api text-muted co-truncate show co-nowrap small">{model.apiGroup || 'core'}/{model.apiVersion}</div></React.Fragment>}
     </span>
   </span>
 </React.Fragment>;
@@ -85,11 +85,11 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = props => {
   // Add an "All" item to the top if `showAll`.
   const allItems = (showAll
     ? OrderedMap({all: <React.Fragment>
-      <span className="co-resource-link">
+      <span className="co-resource-item">
         <span className="co-resource-icon--fixed-width">
           <ResourceIcon kind="All" />
         </span>
-        <span className="co-resource-link__resource-name">All Types</span>
+        <span className="co-resource-item__resource-name">All Types</span>
       </span>
       {/* <ResourceIcon kind="All" /> */}
     </React.Fragment>}).concat(items)

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -48,7 +48,7 @@ const Header = props => <ListHeader>
 
 const Row = ({obj: rq}) => <div className="row co-resource-list__item">
   <div className="col-md-5 col-xs-6">
-    <ResourceLink kind={quotaKind(rq)} name={rq.metadata.name} namespace={rq.metadata.namespace} className="co-resource-link__resource-name" />
+    <ResourceLink kind={quotaKind(rq)} name={rq.metadata.name} namespace={rq.metadata.namespace} className="co-resource-item__resource-name" />
   </div>
   <div className="col-md-7 col-xs-6 co-break-word">
     {rq.metadata.namespace ? <ResourceLink kind="Namespace" name={rq.metadata.namespace} title={rq.metadata.namespace} /> : 'None'}

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -48,7 +48,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
 
   const logo = isCSV
     ? csvLogo()
-    : <div className="co-m-pane__name">{ kind && <ResourceIcon kind={kind} className="co-m-resource-icon--lg" /> } <span id="resource-title">{resourceTitle}</span></div>;
+    : <div className="co-m-pane__name co-resource-item">{ kind && <ResourceIcon kind={kind} className="co-m-resource-icon--lg" /> } <span id="resource-title" className="co-resource-item__resource-name">{resourceTitle}</span></div>;
   const hasButtonActions = !_.isEmpty(buttonActions);
   const hasMenuActions = !_.isEmpty(menuActions);
   const showActions = (hasButtonActions || hasMenuActions) && !_.isEmpty(data) && !_.get(data, 'deletionTimestamp');
@@ -72,9 +72,9 @@ export const SidebarSectionHeading: React.SFC<SidebarSectionHeadingProps> = ({te
 
 export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = ({kindObj, actions, resource}) => <div className="overview__sidebar-pane-head resource-overview__heading">
   <h1 className="co-m-pane__heading">
-    <div className="co-m-pane__name">
+    <div className="co-m-pane__name co-resource-item">
       <ResourceIcon className="co-m-resource-icon--lg" kind={kindObj.kind} />
-      <Link to={resourcePath(resource.kind, resource.metadata.name, resource.metadata.namespace)} className="co-resource-link__resource-name">
+      <Link to={resourcePath(resource.kind, resource.metadata.name, resource.metadata.namespace)} className="co-resource-item__resource-name">
         {resource.metadata.name}
       </Link>
     </div>

--- a/frontend/public/components/utils/resource-icon.tsx
+++ b/frontend/public/components/utils/resource-icon.tsx
@@ -41,6 +41,6 @@ export type ResourceNameProps = {
 };
 /* eslint-enable no-undef */
 
-export const ResourceName: React.SFC<ResourceNameProps> = (props) => <span className="co-resource-link"><ResourceIcon kind={props.kind} /> <span className="co-resource-link__resource-name">{props.name}</span></span>;
+export const ResourceName: React.SFC<ResourceNameProps> = (props) => <span className="co-resource-item"><ResourceIcon kind={props.kind} /> <span className="co-resource-item__resource-name">{props.name}</span></span>;
 
 ResourceName.displayName = 'ResourceName';

--- a/frontend/public/components/utils/resource-link.jsx
+++ b/frontend/public/components/utils/resource-link.jsx
@@ -64,11 +64,11 @@ export const ResourceLink = connectToModel(
     }
     const path = resourcePath(kind, name, namespace);
     const value = displayName ? displayName : name;
-    const classes = classNames('co-resource-link', className, {'co-resource-link--inline': inline});
+    const classes = classNames('co-resource-item', className, {'co-resource-item--inline': inline});
 
     return <span className={classes}>
       { !hideIcon && <ResourceIcon kind={kind} /> }
-      {(path && linkTo) ? <Link to={path} title={title} className="co-resource-link__resource-name">{value}</Link> : <span className="co-resource-link__resource-name">{value}</span>}
+      {(path && linkTo) ? <Link to={path} title={title} className="co-resource-item__resource-name">{value}</Link> : <span className="co-resource-item__resource-name">{value}</span>}
     </span>;
   });
 

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -99,15 +99,6 @@
   font-weight: normal;
 }
 
-.co-m-pane__name {
-  @include co-break-word;
-  align-items: baseline;
-  display: flex;
-  flex: 1;
-  margin-right: 10px;
-  min-width: 0; // necessary for wrapping since its a flex child
-}
-
 .co-inline-block {
   display: inline-block;
 }


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-1337

Includes:
Combine `co-resource-link` and `co-m-pane__name` into single wrapping class `co-resource-item` for resources.

**before**
<img width="500" alt="Screen Shot 2019-03-27 at 1 44 04 PM" src="https://user-images.githubusercontent.com/1874151/55107601-1515f880-50a8-11e9-87ef-655cad2356cb.png">


**after**

<img width="487" alt="Screen Shot 2019-03-27 at 1 43 53 PM" src="https://user-images.githubusercontent.com/1874151/55107608-1b0bd980-50a8-11e9-92b7-579588eaa2d5.png">


Since changes where apart of `<ResourceLink>` I've included several other places that use it.

<img width="293" alt="Screen Shot 2019-03-27 at 1 47 39 PM" src="https://user-images.githubusercontent.com/1874151/55107707-5a3a2a80-50a8-11e9-9435-c50b729688ea.png">
<img width="482" alt="Screen Shot 2019-03-27 at 1 49 24 PM" src="https://user-images.githubusercontent.com/1874151/55107724-61f9cf00-50a8-11e9-9a7b-f8acd7388dbf.png">
<img width="459" alt="Screen Shot 2019-03-27 at 1 49 36 PM" src="https://user-images.githubusercontent.com/1874151/55107731-658d5600-50a8-11e9-8e19-c981bc341176.png">
<img width="281" alt="Screen Shot 2019-03-27 at 3 54 09 PM" src="https://user-images.githubusercontent.com/1874151/55107816-98cfe500-50a8-11e9-98a0-39dbbd8cf6d4.png">
