### PR TITLE
Remove Backwards Compatibility Hack for Marketplace APIs

### DIFF
--- a/frontend/__tests__/components/modals/disable-application-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/disable-application-modal.spec.tsx
@@ -9,22 +9,32 @@ import { DisableApplicationModal, DisableApplicationModalProps, DisableApplicati
 import { ModalTitle, ModalSubmitFooter } from '../../../public/components/factory/modal';
 import { testSubscription } from '../../../__mocks__/k8sResourcesMocks';
 import { SubscriptionKind } from '../../../public/components/operator-lifecycle-manager/index';
-import { ClusterServiceVersionModel, SubscriptionModel } from '../../../public/models';
+import { ClusterServiceVersionModel, SubscriptionModel, CatalogSourceConfigModel } from '../../../public/models';
+import { apiVersionForModel } from '../../../public/module/k8s';
 
 describe(DisableApplicationModal.name, () => {
   let wrapper: ShallowWrapper<DisableApplicationModalProps, DisableApplicationModalState>;
   let k8sKill: Spy;
+  let k8sGet: Spy;
+  let k8sPatch: Spy;
   let close: Spy;
   let cancel: Spy;
   let subscription: SubscriptionKind;
 
+  const spyAndExpect = (spy: Spy) => (returnValue: any) => new Promise(resolve => spy.and.callFake((...args) => {
+    resolve(args);
+    return returnValue;
+  }));
+
   beforeEach(() => {
     k8sKill = jasmine.createSpy('k8sKill').and.returnValue(Promise.resolve());
+    k8sGet = jasmine.createSpy('k8sGet').and.returnValue(Promise.resolve());
+    k8sPatch = jasmine.createSpy('k8sPatch').and.returnValue(Promise.resolve());
     close = jasmine.createSpy('close');
     cancel = jasmine.createSpy('cancel');
     subscription = {..._.cloneDeep(testSubscription), status: {installedCSV: 'testapp.v1.0.0'}};
 
-    wrapper = shallow(<DisableApplicationModal subscription={subscription} k8sKill={k8sKill} close={close} cancel={cancel} />);
+    wrapper = shallow(<DisableApplicationModal subscription={subscription} k8sKill={k8sKill} k8sGet={k8sGet} k8sPatch={k8sPatch} close={close} cancel={cancel} />);
   });
 
   it('renders a modal form', () => {
@@ -39,7 +49,7 @@ describe(DisableApplicationModal.name, () => {
   });
 
   it('calls `props.k8sKill` to delete the subscription when form is submitted', (done) => {
-    close.and.callFake(() => {
+    spyAndExpect(close)(null).then(() => {
       expect(k8sKill.calls.argsFor(0)[0]).toEqual(SubscriptionModel);
       expect(k8sKill.calls.argsFor(0)[1]).toEqual(subscription);
       expect(k8sKill.calls.argsFor(0)[2]).toEqual({});
@@ -51,7 +61,7 @@ describe(DisableApplicationModal.name, () => {
   });
 
   it('calls `props.k8sKill` to delete the `ClusterServiceVersion` from the subscription namespace when form is submitted', (done) => {
-    close.and.callFake(() => {
+    spyAndExpect(close)(null).then(() => {
       expect(k8sKill.calls.argsFor(1)[0]).toEqual(ClusterServiceVersionModel);
       expect(k8sKill.calls.argsFor(1)[1].metadata.namespace).toEqual(testSubscription.metadata.namespace);
       expect(k8sKill.calls.argsFor(1)[1].metadata.name).toEqual('testapp.v1.0.0');
@@ -66,7 +76,7 @@ describe(DisableApplicationModal.name, () => {
   it('does not call `props.k8sKill` to delete `ClusterServiceVersion` if `status.installedCSV` field missing from subscription', (done) => {
     wrapper = wrapper.setProps({subscription: testSubscription});
 
-    close.and.callFake(() => {
+    spyAndExpect(close)(null).then(() => {
       expect(k8sKill.calls.count()).toEqual(1);
       done();
     });
@@ -78,7 +88,7 @@ describe(DisableApplicationModal.name, () => {
     wrapper = wrapper.setState({deleteCSV: false});
     wrapper = wrapper.setProps({subscription: testSubscription});
 
-    close.and.callFake(() => {
+    spyAndExpect(close)(null).then(() => {
       expect(k8sKill.calls.count()).toEqual(1);
       done();
     });
@@ -89,7 +99,7 @@ describe(DisableApplicationModal.name, () => {
   it('adds delete options with `propagationPolicy` if cascading delete checkbox is checked', (done) => {
     wrapper = wrapper.setState({deleteCSV: true});
 
-    close.and.callFake(() => {
+    spyAndExpect(close)(null).then(() => {
       expect(k8sKill.calls.argsFor(0)[3]).toEqual({kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy: 'Foreground'});
       expect(k8sKill.calls.argsFor(1)[3]).toEqual({kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy: 'Foreground'});
       done();
@@ -98,8 +108,56 @@ describe(DisableApplicationModal.name, () => {
     wrapper.find('form').simulate('submit', new Event('submit'));
   });
 
+  it('calls `props.k8sKill` to update `CatalogSourceConfig` if subscription contains appropriate labels', (done) => {
+    subscription.metadata.labels = {
+      'csc-owner-name': 'test-csc',
+      'csc-owner-namespace': 'default',
+    };
+    wrapper = wrapper.setProps({subscription});
+
+    const catalogSourceConfig = {
+      apiVersion: apiVersionForModel(CatalogSourceConfigModel),
+      kind: CatalogSourceConfigModel.kind,
+      spec: {packages: [subscription.spec.name].join(',')},
+    };
+    k8sGet.and.returnValue(Promise.resolve(catalogSourceConfig));
+
+    spyAndExpect(close)(null).then(() => {
+      expect(k8sGet.calls.count()).toEqual(1);
+      expect(k8sKill.calls.argsFor(2)[1]).toEqual(catalogSourceConfig);
+      done();
+    });
+
+    wrapper.find('form').simulate('submit', new Event('submit'));
+  });
+
+  it('calls `props.k8sKill` to delete `CatalogSourceConfig` if subscription contains appropriate labels and is the last entry in `spec.packages`', (done) => {
+    subscription.metadata.labels = {
+      'csc-owner-name': 'test-csc',
+      'csc-owner-namespace': 'default',
+    };
+    wrapper = wrapper.setProps({subscription});
+
+    const catalogSourceConfig = {
+      apiVersion: apiVersionForModel(CatalogSourceConfigModel),
+      kind: CatalogSourceConfigModel.kind,
+      spec: {packages: [subscription.spec.name, 'other-package'].join(',')},
+    };
+    k8sGet.and.returnValue(Promise.resolve(catalogSourceConfig));
+
+    spyAndExpect(close)(null).then(() => {
+      expect(k8sGet.calls.count()).toEqual(1);
+      expect(k8sKill.calls.count()).toEqual(2);
+      expect(k8sPatch.calls.argsFor(0)[1]).toEqual(catalogSourceConfig);
+      expect(k8sPatch.calls.argsFor(0)[2]).toEqual([{op: 'replace', path: '/spec/packages', value: 'other-package'}]);
+      done();
+    });
+
+    wrapper.find('form').simulate('submit', new Event('submit'));
+  });
+
   it('calls `props.close` after successful submit', (done) => {
-    close.and.callFake(() => {
+    spyAndExpect(close)(null).then(() => {
       done();
     });
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
@@ -8,7 +8,7 @@ import { safeLoad } from 'js-yaml';
 import { CatalogSourceDetails, CatalogSourceDetailsProps, CatalogSourceDetailsPage, CatalogSourceDetailsPageProps, CreateSubscriptionYAML, CreateSubscriptionYAMLProps } from '../../../public/components/operator-lifecycle-manager/catalog-source';
 import { PackageManifestList } from '../../../public/components/operator-lifecycle-manager/package-manifest';
 import { visibilityLabel } from '../../../public/components/operator-lifecycle-manager';
-import { referenceForModel, referenceForModelCompatible } from '../../../public/module/k8s';
+import { referenceForModel } from '../../../public/module/k8s';
 import { SubscriptionModel, CatalogSourceModel, PackageManifestModel, OperatorGroupModel } from '../../../public/models';
 import { DetailsPage } from '../../../public/components/factory';
 import { Firehose, LoadingBox, ErrorBoundary } from '../../../public/components/utils';
@@ -57,9 +57,9 @@ describe(CatalogSourceDetailsPage.displayName, () => {
     expect(wrapper.find(DetailsPage).props().pages.map(p => p.name)).toEqual(['Overview', 'YAML']);
     expect(wrapper.find(DetailsPage).props().pages[0].component).toEqual(CatalogSourceDetails);
     expect(wrapper.find(DetailsPage).props().resources).toEqual([
-      {kind: referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'), isList: true, namespace: match.params.ns, selector, prop: 'packageManifests'},
+      {kind: referenceForModel(PackageManifestModel), isList: true, namespace: match.params.ns, selector, prop: 'packageManifests'},
       {kind: referenceForModel(SubscriptionModel), isList: true, namespace: match.params.ns, prop: 'subscriptions'},
-      {kind: referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2~OperatorGroup'), isList: true, namespace: match.params.ns, prop: 'operatorGroups'},
+      {kind: referenceForModel(OperatorGroupModel), isList: true, namespace: match.params.ns, prop: 'operatorGroups'},
     ]);
   });
 });
@@ -76,13 +76,13 @@ describe(CreateSubscriptionYAML.displayName, () => {
 
   it('renders a `Firehose` for the `PackageManfest` specified in the URL', () => {
     expect(wrapper.find<any>(Firehose).props().resources).toEqual([{
-      kind: referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'),
+      kind: referenceForModel(PackageManifestModel),
       name: testPackageManifest.metadata.name,
       namespace: 'default',
       isList: false,
       prop: 'packageManifest',
     }, {
-      kind: referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2~OperatorGroup'),
+      kind: referenceForModel(OperatorGroupModel),
       isList: true,
       namespace: 'default',
       prop: 'operatorGroup',

--- a/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
@@ -135,7 +135,7 @@ describe(InstallPlansPage.displayName, () => {
     expect(wrapper.find(MultiListPage).props().filterLabel).toEqual('Install Plans by name');
     expect(wrapper.find(MultiListPage).props().resources).toEqual([
       {kind: k8s.referenceForModel(InstallPlanModel), namespace: 'default', namespaced: true, prop: 'installPlan'},
-      {kind: k8s.referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2~OperatorGroup'), namespace: 'default', namespaced: true, prop: 'operatorGroup'},
+      {kind: k8s.referenceForModel(OperatorGroupModel), namespace: 'default', namespaced: true, prop: 'operatorGroup'},
     ]);
   });
 });

--- a/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 
 import { SubscriptionHeader, SubscriptionHeaderProps, SubscriptionRow, SubscriptionRowProps, SubscriptionsList, SubscriptionsListProps, SubscriptionsPage, SubscriptionsPageProps, SubscriptionDetails, SubscriptionDetailsPage, SubscriptionDetailsProps, SubscriptionUpdates, SubscriptionUpdatesProps, SubscriptionUpdatesState } from '../../../public/components/operator-lifecycle-manager/subscription';
 import { SubscriptionKind, SubscriptionState } from '../../../public/components/operator-lifecycle-manager';
-import { referenceForModel, referenceForModelCompatible } from '../../../public/module/k8s';
+import { referenceForModel } from '../../../public/module/k8s';
 import { SubscriptionModel, ClusterServiceVersionModel, PackageManifestModel, OperatorGroupModel, InstallPlanModel } from '../../../public/models';
 import { ListHeader, ColHead, List, MultiListPage, DetailsPage } from '../../../public/components/factory';
 import { ResourceKebab, ResourceLink, Kebab } from '../../../public/components/utils';
@@ -141,7 +141,7 @@ describe(SubscriptionsPage.displayName, () => {
     expect(wrapper.find(MultiListPage).props().filterLabel).toEqual('Subscriptions by package');
     expect(wrapper.find(MultiListPage).props().resources).toEqual([
       {kind: referenceForModel(SubscriptionModel), namespace: 'default', namespaced: true, prop: 'subscription'},
-      {kind: referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2~OperatorGroup'), namespace: 'default', namespaced: true, prop: 'operatorGroup'},
+      {kind: referenceForModel(OperatorGroupModel), namespace: 'default', namespaced: true, prop: 'operatorGroup'},
     ]);
   });
 });
@@ -214,7 +214,7 @@ describe(SubscriptionDetailsPage.displayName, () => {
     const wrapper = shallow(<SubscriptionDetailsPage match={match} namespace="default" />);
 
     expect(wrapper.find(DetailsPage).props().resources).toEqual([
-      {kind: referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'), namespace: 'default', isList: true, prop: 'packageManifests'},
+      {kind: referenceForModel(PackageManifestModel), namespace: 'default', isList: true, prop: 'packageManifests'},
       {kind: referenceForModel(InstallPlanModel), isList: true, namespace: 'default', prop: 'installPlans'},
       {kind: referenceForModel(ClusterServiceVersionModel), namespace: 'default', isList: true, prop: 'clusterServiceVersions'},
     ]);

--- a/frontend/public/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-page.tsx
@@ -7,7 +7,7 @@ import { match } from 'react-router';
 
 import { Firehose, PageHeading, StatusBox, MsgBox, ExternalLink, withFallback } from '../utils';
 import { ErrorBoundaryFallback } from '../error';
-import { referenceForModel, K8sResourceKind, referenceForModelCompatible } from '../../module/k8s';
+import { referenceForModel, K8sResourceKind } from '../../module/k8s';
 import { PackageManifestModel, OperatorGroupModel, CatalogSourceConfigModel, SubscriptionModel } from '../../models';
 import { getOperatorProviderType } from './operator-hub-utils';
 import { OperatorHubTileView } from './operator-hub-items';
@@ -80,16 +80,16 @@ export const OperatorHubPage = withFallback((props: OperatorHubPageProps) => <Re
     <div className="co-catalog-connect">
       <Firehose resources={[{
         isList: true,
-        kind: referenceForModelCompatible(CatalogSourceConfigModel)('marketplace.redhat.com~v1alpha1~CatalogSourceConfig'),
+        kind: referenceForModel(CatalogSourceConfigModel),
         namespace: 'openshift-marketplace',
         prop: 'catalogSourceConfig',
       }, {
         isList: true,
-        kind: referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2~OperatorGroup'),
+        kind: referenceForModel(OperatorGroupModel),
         prop: 'operatorGroup',
       }, {
         isList: true,
-        kind: referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'),
+        kind: referenceForModel(PackageManifestModel),
         namespace: 'openshift-marketplace',
         prop: 'packageManifest',
         selector: {matchLabels: {'openshift-marketplace': 'true'}},

--- a/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
@@ -11,7 +11,7 @@ import { CatalogSourceKind, SubscriptionKind, PackageManifestKind, visibilityLab
 import { requireOperatorGroup } from './operator-group';
 import { PackageManifestList } from './package-manifest';
 import { SubscriptionModel, CatalogSourceModel, PackageManifestModel, OperatorGroupModel } from '../../models';
-import { referenceForModel, K8sResourceKind, referenceForModelCompatible } from '../../module/k8s';
+import { referenceForModel, K8sResourceKind } from '../../module/k8s';
 import { DetailsPage } from '../factory';
 
 export const CatalogSourceDetails: React.SFC<CatalogSourceDetailsProps> = ({obj, packageManifests, subscriptions, operatorGroups}) => {
@@ -52,7 +52,7 @@ export const CatalogSourceDetailsPage: React.SFC<CatalogSourceDetailsPageProps> 
   ]}
   menuActions={Kebab.factory.common}
   resources={[{
-    kind: referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'),
+    kind: referenceForModel(PackageManifestModel),
     isList: true,
     namespace: props.match.params.ns,
     selector: {matchLabels: {catalog: props.match.params.name}, matchExpressions: [{key: visibilityLabel, operator: 'DoesNotExist'}]},
@@ -63,7 +63,7 @@ export const CatalogSourceDetailsPage: React.SFC<CatalogSourceDetailsPageProps> 
     namespace: props.match.params.ns,
     prop: 'subscriptions',
   }, {
-    kind: referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2~OperatorGroup'),
+    kind: referenceForModel(OperatorGroupModel),
     isList: true,
     namespace: props.match.params.ns,
     prop: 'operatorGroups',
@@ -101,13 +101,13 @@ export const CreateSubscriptionYAML: React.SFC<CreateSubscriptionYAMLProps> = (p
   );
 
   return <Firehose resources={[{
-    kind: referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'),
+    kind: referenceForModel(PackageManifestModel),
     isList: false,
     name: new URLSearchParams(props.location.search).get('pkg'),
     namespace: new URLSearchParams(props.location.search).get('catalogNamespace'),
     prop: 'packageManifest',
   }, {
-    kind: referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2~OperatorGroup'),
+    kind: referenceForModel(OperatorGroupModel),
     isList: true,
     namespace: props.match.params.ns,
     prop: 'operatorGroup',

--- a/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
@@ -8,7 +8,7 @@ import { Map as ImmutableMap } from 'immutable';
 import { MultiListPage, List, ListHeader, ColHead, ResourceRow, DetailsPage } from '../factory';
 import { SectionHeading, MsgBox, ResourceLink, ResourceKebab, Kebab, ResourceIcon, navFactory, ResourceSummary, history } from '../utils';
 import { InstallPlanKind, InstallPlanApproval, olmNamespace, Step, referenceForStepResource } from './index';
-import { referenceForModel, referenceForOwnerRef, k8sUpdate, referenceForModelCompatible, apiVersionForReference } from '../../module/k8s';
+import { referenceForModel, referenceForOwnerRef, k8sUpdate, apiVersionForReference } from '../../module/k8s';
 import { SubscriptionModel, ClusterServiceVersionModel, InstallPlanModel, CatalogSourceModel, OperatorGroupModel } from '../../models';
 import { breadcrumbsForOwnerRefs } from '../utils/breadcrumbs';
 import { requireOperatorGroup } from './operator-group';
@@ -71,7 +71,7 @@ export const InstallPlansPage: React.SFC<InstallPlansPageProps> = (props) => {
       namespace={namespace}
       resources={[
         {kind: referenceForModel(InstallPlanModel), namespace, namespaced: true, prop: 'installPlan'},
-        {kind: referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2~OperatorGroup'), namespace, namespaced: true, prop: 'operatorGroup'},
+        {kind: referenceForModel(OperatorGroupModel), namespace, namespaced: true, prop: 'operatorGroup'},
       ]}
       flatten={resources => _.get(resources.installPlan, 'data', [])}
       title="Install Plans"

--- a/frontend/public/components/operator-lifecycle-manager/operator-group.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/operator-group.tsx
@@ -5,7 +5,7 @@ import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
 
 import { MsgBox } from '../utils/status-box';
-import { K8sResourceKind, GroupVersionKind, referenceForModelCompatible } from '../../module/k8s';
+import { K8sResourceKind, GroupVersionKind, referenceForModel } from '../../module/k8s';
 import { OperatorGroupKind, SubscriptionKind } from './index';
 import { AsyncComponent } from '../utils/async';
 import { OperatorGroupModel } from '../../models';
@@ -17,7 +17,7 @@ export const operatorGroupFor = (obj: K8sResourceKind) => _.get(obj, ['metadata'
 
 export const NoOperatorGroupMsg: React.SFC = () => <MsgBox
   title="Namespace Not Enabled"
-  detail={<p>The Operator Lifecycle Manager will not watch this namespace because it is not configured with an OperatorGroup. <Link to={`/ns/${getActiveNamespace()}/${referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2')}/new`}>Create one here.</Link></p>} />;
+  detail={<p>The Operator Lifecycle Manager will not watch this namespace because it is not configured with an OperatorGroup. <Link to={`/ns/${getActiveNamespace()}/${referenceForModel(OperatorGroupModel)}/new`}>Create one here.</Link></p>} />;
 
 type RequireOperatorGroupProps = {
   operatorGroup: {loaded: boolean, data?: OperatorGroupKind[]};
@@ -30,9 +30,9 @@ export const OperatorGroupSelector: React.SFC<OperatorGroupSelectorProps> = (pro
   }}
   desc="Operator Groups"
   placeholder="Select Operator Group"
-  selectedKeyKind={referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2')}
+  selectedKeyKind={referenceForModel(OperatorGroupModel)}
   dataFilter={props.dataFilter}
-  resources={[{kind: referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2'), fieldSelector: `metadata.name!=${props.excludeName}`}]} />;
+  resources={[{kind: referenceForModel(OperatorGroupModel), fieldSelector: `metadata.name!=${props.excludeName}`}]} />;
 
 export const requireOperatorGroup = <P extends RequireOperatorGroupProps>(Component: React.ComponentType<P>) => {
   return class RequireOperatorGroup extends React.Component<P> {

--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link, match } from 'react-router-dom';
 
-import { referenceForModel, K8sResourceKind, referenceForModelCompatible } from '../../module/k8s';
+import { referenceForModel, K8sResourceKind } from '../../module/k8s';
 import { requireOperatorGroup, installedFor, supports } from './operator-group';
 import { PackageManifestKind, SubscriptionKind, ClusterServiceVersionLogo, visibilityLabel, OperatorGroupKind, installModesFor, defaultChannelFor } from './index';
 import { PackageManifestModel, SubscriptionModel, CatalogSourceModel, OperatorGroupModel } from '../../models';
@@ -109,10 +109,10 @@ export const PackageManifestsPage: React.SFC<PackageManifestsPageProps> = (props
     textFilter="packagemanifest-name"
     flatten={flatten}
     resources={[
-      {kind: referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'), isList: true, namespaced: true, prop: 'packageManifest', selector: {matchExpressions: [{key: visibilityLabel, operator: 'DoesNotExist'}, {key: OPERATOR_HUB_LABEL, operator: 'DoesNotExist'}]}},
+      {kind: referenceForModel(PackageManifestModel), isList: true, namespaced: true, prop: 'packageManifest', selector: {matchExpressions: [{key: visibilityLabel, operator: 'DoesNotExist'}, {key: OPERATOR_HUB_LABEL, operator: 'DoesNotExist'}]}},
       {kind: referenceForModel(CatalogSourceModel), isList: true, namespaced: true, prop: 'catalogSource'},
       {kind: referenceForModel(SubscriptionModel), isList: true, prop: 'subscription'},
-      {kind: referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2~OperatorGroup'), isList: true, prop: 'operatorGroup'},
+      {kind: referenceForModel(OperatorGroupModel), isList: true, prop: 'operatorGroup'},
     ]} />;
 };
 

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -9,7 +9,7 @@ import { requireOperatorGroup } from './operator-group';
 import { MsgBox, ResourceLink, ResourceKebab, navFactory, Kebab, ResourceSummary, LoadingInline, SectionHeading } from '../utils';
 import { removeQueryArgument } from '../utils/router';
 import { SubscriptionKind, SubscriptionState, PackageManifestKind, InstallPlanApproval, ClusterServiceVersionKind, olmNamespace, OperatorGroupKind, InstallPlanKind, InstallPlanPhase } from './index';
-import { referenceForModel, k8sKill, k8sUpdate, referenceForModelCompatible } from '../../module/k8s';
+import { referenceForModel, k8sGet, k8sPatch, k8sKill, k8sUpdate } from '../../module/k8s';
 import { SubscriptionModel, ClusterServiceVersionModel, CatalogSourceModel, InstallPlanModel, PackageManifestModel, OperatorGroupModel } from '../../models';
 import { createDisableApplicationModal } from '../modals/disable-application-modal';
 import { createSubscriptionChannelModal } from '../modals/subscription-channel-modal';
@@ -36,7 +36,7 @@ const menuActions = [
   Kebab.factory.Edit,
   (kind, obj) => ({
     label: 'Remove Subscription...',
-    callback: () => createDisableApplicationModal({k8sKill, subscription: obj}),
+    callback: () => createDisableApplicationModal({k8sKill, k8sGet, k8sPatch, subscription: obj}),
   }),
   (kind, obj) => ({
     label: `View ${ClusterServiceVersionModel.kind}...`,
@@ -80,7 +80,7 @@ export const SubscriptionsPage: React.SFC<SubscriptionsPageProps> = (props) => {
     namespace={namespace}
     resources={[
       {kind: referenceForModel(SubscriptionModel), namespace, namespaced: true, prop: 'subscription'},
-      {kind: referenceForModelCompatible(OperatorGroupModel)('operators.coreos.com~v1alpha2~OperatorGroup'), namespace, namespaced: true, prop: 'operatorGroup'},
+      {kind: referenceForModel(OperatorGroupModel), namespace, namespaced: true, prop: 'operatorGroup'},
     ]}
     flatten={resources => _.get(resources.subscription, 'data', [])}
     title="Subscriptions"
@@ -102,7 +102,7 @@ export const SubscriptionDetails: React.SFC<SubscriptionDetailsProps> = (props) 
   };
 
   return <div className="co-m-pane__body">
-    <Effect promise={props.showDelete ? () => createDisableApplicationModal({k8sKill, subscription: obj}).result.then(() => removeQueryArgument('showDelete')) : () => null} />
+    <Effect promise={props.showDelete ? () => createDisableApplicationModal({k8sKill, k8sGet, k8sPatch, subscription: obj}).result.then(() => removeQueryArgument('showDelete')) : () => null} />
 
     <SectionHeading text="Subscription Overview" />
     <div className="co-m-pane__body-group">
@@ -239,7 +239,7 @@ export const SubscriptionDetailsPage: React.SFC<SubscriptionDetailsPageProps> = 
       navFactory.editYaml(),
     ]}
     resources={[
-      {kind: referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'), isList: true, namespace: props.namespace, prop: 'packageManifests'},
+      {kind: referenceForModel(PackageManifestModel), isList: true, namespace: props.namespace, prop: 'packageManifests'},
       {kind: referenceForModel(InstallPlanModel), isList: true, namespace: props.namespace, prop: 'installPlans'},
       {kind: referenceForModel(ClusterServiceVersionModel), namespace: props.namespace, isList: true, prop: 'clusterServiceVersions'},
     ]}

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -3,7 +3,7 @@
 import { Map as ImmutableMap } from 'immutable';
 
 import { ReportReference, ReportGenerationQueryReference } from './chargeback';
-import { referenceForModel, GroupVersionKind, referenceForModelCompatible } from '../module/k8s';
+import { referenceForModel, GroupVersionKind } from '../module/k8s';
 import {
   AlertmanagerModel,
   BuildConfigModel,
@@ -163,7 +163,7 @@ export const resourceListPages = ImmutableMap<GroupVersionKind | string, () => P
   .set(referenceForModel(StorageClassModel), () => import('./storage-class' /* webpackChunkName: "storage-class" */).then(m => m.StorageClassPage))
   .set(referenceForModel(CustomResourceDefinitionModel), () => import('./custom-resource-definition' /* webpackChunkName: "custom-resource-definition" */).then(m => m.CustomResourceDefinitionsPage))
   .set(referenceForModel(ClusterServiceVersionModel), () => import('./operator-lifecycle-manager/clusterserviceversion' /* webpackChunkName: "clusterserviceversion" */).then(m => m.ClusterServiceVersionsPage))
-  .set(referenceForModelCompatible(PackageManifestModel)('packages.apps.redhat.com~v1alpha1~PackageManifest'), () => import('./operator-lifecycle-manager/package-manifest' /* webpackChunkName: "package-manifest" */).then(m => m.PackageManifestsPage))
+  .set(referenceForModel(PackageManifestModel), () => import('./operator-lifecycle-manager/package-manifest' /* webpackChunkName: "package-manifest" */).then(m => m.PackageManifestsPage))
   .set(referenceForModel(SubscriptionModel), () => import('./operator-lifecycle-manager/subscription' /* webpackChunkName: "subscription" */).then(m => m.SubscriptionsPage))
   .set(referenceForModel(InstallPlanModel), () => import('./operator-lifecycle-manager/install-plan' /* webpackChunkName: "install-plan" */).then(m => m.InstallPlansPage))
   .set(referenceForModel(ClusterOperatorModel), () => import('./cluster-settings/cluster-operator' /* webpackChunkName: "cluster-operator" */).then(m => m.ClusterOperatorPage));

--- a/frontend/public/module/k8s/k8s-models.ts
+++ b/frontend/public/module/k8s/k8s-models.ts
@@ -2,9 +2,9 @@ import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';
 
 // eslint-disable-next-line no-unused-vars
-import { K8sResourceKindReference, K8sKind, GroupVersionKind } from './index';
+import { K8sResourceKindReference, K8sKind } from './index';
 import * as staticModels from '../../models';
-import { referenceForModel, kindForReference, apiVersionForModel, apiVersionForReference } from './k8s';
+import { referenceForModel, kindForReference } from './k8s';
 import store from '../../redux';
 
 /**
@@ -51,36 +51,3 @@ export const modelFor = (ref: K8sResourceKindReference) => {
  */
 export const allModels = () => k8sModels;
 
-/**
- * FIXME(alecmerdler): Hack (should not access `store` directly) to add backwards-compatibility support for APIs.
- * This should not be the client's responsibility.
- */
-export const referenceForModelCompatible = (model: K8sKind) => (fallbackGVK: GroupVersionKind): GroupVersionKind => {
-  if (store.getState().k8s.hasIn(['RESOURCES', 'models', referenceForModel(model)])) {
-    return referenceForModel(model);
-  }
-  return fallbackGVK;
-};
-
-/**
- * FIXME(alecmerdler): Hack (should not access `store` directly) to add backwards-compatibility support for APIs.
- * This should not be the client's responsibility.
- */
-export const apiVersionForModelCompatible = (model: K8sKind) => (fallbackGVK: GroupVersionKind) => {
-  if (store.getState().k8s.hasIn(['RESOURCES', 'models', referenceForModel(model)])) {
-    return apiVersionForModel(model);
-  }
-  return apiVersionForReference(fallbackGVK);
-};
-
-/**
- * FIXME(alecmerdler): Hack (should not access `store` directly) to add backwards-compatibility support for APIs.
- * This should not be the client's responsibility.
- */
-export const modelForCompatible = (gvk: GroupVersionKind) => (fallbackGVK: GroupVersionKind) => {
-  const model = store.getState().k8s.getIn(['RESOURCES', 'models', gvk]);
-  if (_.isEmpty(model)) {
-    return store.getState().k8s.getIn(['RESOURCES', 'models', fallbackGVK]);
-  }
-  return model;
-};


### PR DESCRIPTION
### Description

Removes client backwards-compatibility [hack for Marketplace APIs](https://github.com/openshift/console/pull/1327).

Addresses https://jira.coreos.com/browse/CONSOLE-1350