### PR TITLE
Don't automatically add an empty row to taints and tolerations dialogs

### DIFF
--- a/frontend/public/components/modals/taints-modal.tsx
+++ b/frontend/public/components/modals/taints-modal.tsx
@@ -13,7 +13,7 @@ class TaintsModal extends PromiseComponent {
   constructor(public props: TaintsModalProps) {
     super(props);
     // Add an empty row for editing if no taints exist.
-    this.state.taints = this._defaultFirstRow(this.props.resource.spec.taints);
+    this.state.taints = this.props.resource.spec.taints;
   }
 
   _submit = (e: React.FormEvent<EventTarget>) => {
@@ -52,12 +52,6 @@ class TaintsModal extends PromiseComponent {
       return { taints };
     });
   };
-
-  _defaultFirstRow(taints: Taint[]): Taint[] {
-    return _.isEmpty(taints)
-      ? [this._newTaint()]
-      : taints;
-  }
 
   _newTaint(): Taint {
     return {key: '', value: '', effect: 'NoSchedule'};

--- a/frontend/public/components/modals/tolerations-modal.tsx
+++ b/frontend/public/components/modals/tolerations-modal.tsx
@@ -12,9 +12,7 @@ class TolerationsModal extends PromiseComponent {
 
   constructor(public props: TolerationsModalProps) {
     super(props);
-    const tolerations = this._getTolerationsFromResource();
-    // Add an empty row for editing if no tolerations exist.
-    this.state.tolerations = this._defaultFirstRow(tolerations);
+    this.state.tolerations = this._getTolerationsFromResource() || [];
   }
 
   _getTolerationsFromResource = (): Toleration[] => {
@@ -82,12 +80,6 @@ class TolerationsModal extends PromiseComponent {
 
   _newToleration(): TolerationModalItem {
     return {key: '', operator: 'Exists', value: '', effect: '', isNew: true};
-  }
-
-  _defaultFirstRow(tolerations: TolerationModalItem[]): TolerationModalItem[] {
-    return _.isEmpty(tolerations)
-      ? [this._newToleration()]
-      : tolerations;
   }
 
   _addRow = () => {


### PR DESCRIPTION
This is confusing for these dialogs since it's not obvious it's a new
empty value. This is particularly true for tolerations where the default
row we add is actually a valid toleration.

/assign @nicolethoen 