### PR TITLE
Improve consistency of remove buttons

### DIFF
--- a/frontend/public/components/modals/tolerations-modal.tsx
+++ b/frontend/public/components/modals/tolerations-modal.tsx
@@ -168,7 +168,7 @@ class TolerationsModal extends PromiseComponent {
                 </div>
                 <div className="col-md-1">
                   {this._isEditable(t) && (
-                    <button type="button" className="btn btn-link toleration-modal__delete-icon" onClick={() => this._remove(i)} aria-label="Delete">
+                    <button type="button" className="btn btn-link btn-link--inherit-color toleration-modal__delete-icon" onClick={() => this._remove(i)} aria-label="Delete">
                       <i className="fa fa-minus-circle pairs-list__side-btn pairs-list__delete-icon" aria-hidden="true" />
                     </button>
                   )}

--- a/frontend/public/components/utils/_list-input.scss
+++ b/frontend/public/components/utils/_list-input.scss
@@ -3,11 +3,13 @@
 }
 
 .co-list-input__remove-btn {
+  margin-left: 5px;
   margin-top: -6px;
 }
 
 .co-list-input__row {
   display: flex;
+  margin-bottom: 5px;
 }
 
 .co-list-input__value {

--- a/frontend/public/components/utils/list-input.tsx
+++ b/frontend/public/components/utils/list-input.tsx
@@ -49,7 +49,7 @@ export class ListInput extends React.Component<ListInputProps, ListInputState> {
               <input className="form-control" type="text" value={v} onChange={(e: React.FormEvent<HTMLInputElement>) => this.valueChanged(i, e.currentTarget.value)} />
             </div>
             <div className="co-list-input__remove-btn">
-              <button type="button" className="btn btn-link" onClick={() => this.removeValue(i)} aria-label="Remove">
+              <button type="button" className="btn btn-link btn-link--inherit-color" onClick={() => this.removeValue(i)} aria-label="Remove">
                 <i className="fa fa-minus-circle pairs-list__side-btn pairs-list__delete-icon" aria-hidden="true" />
               </button>
             </div>

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -189,7 +189,7 @@ export const EnvFromEditor = withDragDropContext(class EnvFromEditor extends Rea
         <div className="col-xs-12">
           {
             !readOnly &&
-            <button type="button" className="btn-link pairs-list__btn" onClick={this._append}>
+            <button type="button" className="btn-link" onClick={this._append}>
               <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />Add All From Config Map or Secret
             </button>
           }


### PR DESCRIPTION
* Make all remove button links the same color (`btn-link--inherit-color`). This is consistent with the name-value editor.
* Add a little extra margin to list-input controls

Before:

<img width="677" alt="Add Identity Provider: OpenID Connect · OKD 2019-03-27 19-23-54" src="https://user-images.githubusercontent.com/1167259/55118784-e4dd5280-50c5-11e9-9500-500ddf891bf3.png">

After:

<img width="691" alt="Add Identity Provider: OpenID Connect · OKD 2019-03-27 19-19-55" src="https://user-images.githubusercontent.com/1167259/55118729-b8293b00-50c5-11e9-9e93-019b406314d6.png">

/assign @rhamilto 