### PR TITLE
Add field level help for IDP mapping method

### DIFF
--- a/frontend/public/components/cluster-settings/mapping-method.tsx
+++ b/frontend/public/components/cluster-settings/mapping-method.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
+import { FieldLevelHelp } from 'patternfly-react';
 
 import { Dropdown } from '../utils';
 
@@ -14,11 +15,31 @@ export const MappingMethod: React.FC<MappingMethodProps> = ({value, onChange}) =
   };
   return (
     <div className="form-group">
-      <label className="control-label co-required" htmlFor="tag">Mapping Method</label>
+      <label className="control-label" htmlFor="tag">
+        Mapping Method
+        <FieldLevelHelp content={
+          <ul>
+            <li>
+              <strong>Claim</strong> maps users using the provider&apos;s preferred
+              username. Fails if a user with that name already exists for a
+              different identity provider.
+            </li>
+            <li>
+              <strong>Lookup</strong> requires administrators to manually
+              provision identities and users.
+            </li>
+            <li>
+              <strong>Add</strong> works like claim, but reuses existing users.
+              It should only be selected when you have multiple identity stores
+              that map to the same logical set of users.
+            </li>
+          </ul>
+        } />
+      </label>
       <Dropdown dropDownClassName="dropdown--full-width" items={mappingMethods} selectedKey={value} title={mappingMethods[value]} onChange={mappingMethodChanged} />
       <div className="help-block" id="mapping-method-description">
         { /* TODO: Add doc link when available in 4.0 docs. */ }
-        Specifies how new identities are mapped to users when they log in.
+        Specifies how new identities are mapped to users when they log in. Claim is recommended in most cases.
       </div>
     </div>
   );


### PR DESCRIPTION
Mapping method is confusing, so add field level help to explain the options. Encourage admins to select "Claim" if unsure. This is a common component reused on all IDP forms.

![Screen Shot 2019-03-29 at 9 42 39 AM](https://user-images.githubusercontent.com/1167259/55236852-3a6d4880-5207-11e9-8a66-d93e997dd822.png)

/cc @bmignano @jcaianirh @enj 
