### PR TITLE
Initial frontend monorepo structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@
 /Godeps/_workspace/src/github.com/openshift/console
 /frontend/.cache-loader
 /frontend/__coverage__
+/frontend/**/node_modules
 /frontend/public/bower_components
-/frontend/node_modules
 /frontend/public/dist
 /frontend/npm-debug.log
 /frontend/yarn-error.log

--- a/clean-frontend.sh
+++ b/clean-frontend.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-rm -rf frontend/node_modules
+find frontend -type d -name 'node_modules' -prune -exec rm -rf {} \;
 rm -rf frontend/public/dist

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,3 +1,4 @@
+.yarn
 __coverage__
 public/dist
 *.min.js

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -3,5 +3,5 @@ __coverage__
 public/dist
 *.min.js
 public/lib
-node_modules
+**/node_modules
 Godeps

--- a/frontend/.yarnrc
+++ b/frontend/.yarnrc
@@ -1,0 +1,1 @@
+yarn-path ".yarn/releases/yarn-1.15.2.js"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,11 @@
   "repository": "https://github.com/openshift/console",
   "license": "Apache-2.0",
   "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
-    "dev": "rm -rf ./public/dist/ && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode development --watch --progress",
+    "dev": "rm -rf ./public/dist && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode development --watch --progress",
     "build": "rm -rf ./public/dist && NODE_ENV=production ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production",
     "coverage": "jest --coverage .",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --color .",
@@ -51,7 +54,9 @@
     ],
     "collectCoverageFrom": [
       "public/*.{js,jsx,ts,tsx}",
-      "public/{components,module,ui}/**/*.{js,jsx,ts,tsx}"
+      "public/{components,module,ui}/**/*.{js,jsx,ts,tsx}",
+      "packages/*/src/**/*.{js,jsx,ts,tsx}",
+      "!**/node_modules/**"
     ]
   },
   "dependencies": {

--- a/frontend/packages/.eslintrc
+++ b/frontend/packages/.eslintrc
@@ -1,0 +1,1 @@
+../public/.eslintrc

--- a/frontend/packages/console-app/package.json
+++ b/frontend/packages/console-app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@console/app",
+  "version": "0.0.0-fixed",
+  "description": "Console web application",
+  "private": true,
+  "main": "src/index.ts",
+  "dependencies": {
+    "@console/shared": "0.0.0-fixed"
+  }
+}

--- a/frontend/packages/console-app/src/index.ts
+++ b/frontend/packages/console-app/src/index.ts
@@ -1,0 +1,1 @@
+import '../../../public/components/app';

--- a/frontend/packages/console-shared/package.json
+++ b/frontend/packages/console-shared/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@console/shared",
+  "version": "0.0.0-fixed",
+  "description": "Console code shared between all packages",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "yarn --cwd ../.. run test packages/console-shared"
+  }
+}

--- a/frontend/packages/console-shared/src/index.ts
+++ b/frontend/packages/console-shared/src/index.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,7 +15,7 @@
   },
   "exclude": [
     ".yarn",
-    "node_modules",
+    "**/node_modules",
     "public/dist"
   ],
   "include": [

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,6 +14,7 @@
     "noUnusedLocals": true
   },
   "exclude": [
+    ".yarn",
     "node_modules",
     "public/dist"
   ],

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -15,7 +15,7 @@ const extractCSS = new MiniCssExtractPlugin({filename: 'app-bundle.css'});
 const config: webpack.Configuration = {
   entry: [
     './polyfills.js',
-    './public/components/app.jsx',
+    '@console/app',
   ],
   output: {
     path: path.resolve(__dirname, 'public/dist'),

--- a/link-check.sh
+++ b/link-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # We basically only check anchors that start with https:// to avoid false positives
-URLS=$(git grep 'href="https://[^"]*"' -- 'frontend/public/*' | grep -o 'https://[^"]*"' | sed s'/.$//' | sort | uniq)
+URLS=$(git grep 'href="https://[^"]*"' -- 'frontend/public/*' 'frontend/packages/*' | grep -o 'https://[^"]*"' | sed s'/.$//' | sort | uniq)
 
 for url in $URLS; do
   curl -f -o /dev/null --silent "$url"


### PR DESCRIPTION
## Frontend monorepo

This PR does two things:
- [x] address RFE #1363 for easier Yarn version management
- [x] add initial [monorepo](https://en.wikipedia.org/wiki/Monorepo) structure while keeping the `public` directory intact

Closes https://jira.coreos.com/browse/CONSOLE-1241
Closes #1363 

_Note: any file paths mentioned below are meant in context of the `frontend` directory._

### Yarn version management

`.yarnrc` is used to delegate execution to the local binary at `.yarn/releases/yarn-<version>.js` via the [`yarn-path` option](https://yarnpkg.com/lang/en/docs/yarnrc/#toc-yarn-path). This option is supported by Yarn >= 1.0 so there's no need to bump the global version installed on the system.

This causes the local Yarn binary to be used by both developers and automated systems such as CI/CD. Switching to a newer version of Yarn becomes super easy - put the new binary in `.yarn/releases` and update `.yarnrc` accordingly.

Developers can override this behavior by setting `yarn-path` to `false` if necessary.

### Monorepo support

The monorepo is powered by [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/), a feature introduced in [Yarn v0.28](https://github.com/yarnpkg/yarn/releases/tag/v0.28.4) (Jul 2017) and enabled by default since [Yarn v1.0.0](https://github.com/yarnpkg/yarn/releases/tag/v1.0.0) (Sep 2017).

> Yarn’s workspaces are the low-level primitives that tools like Lerna can (and [do](https://github.com/lerna/lerna/pull/899)!) use. They will never try to support the high-level feature that Lerna offers, but by implementing the core logic of the resolution and linking steps inside Yarn itself we hope to enable new usages and improve performance.

This PR avoids using [Lerna](https://github.com/lerna/lerna) since Yarn workspaces already covers all of our monorepo requirements:
* define packages using the `package.json` standard
* link packages using the `node_modules` file structure :star: 
* run a script on all the packages (Yarn v1.10 or better)

_:star: Hoisting of dependencies (moving them "up" into root `node_modules` directory) is an optimization to eliminate redundancy and improve performance. Yarn hoists by default but also supports the [`nohoist` option](https://yarnpkg.com/blog/2018/02/15/nohoist/#how-to-use-it) to circumvent potential issues. See also [Lerna docs on hoisting](https://github.com/lerna/lerna/blob/master/doc/hoist.md)._

### Packages

The `packages` directory is a flat list of all the frontend packages. The `console` prefix implies a core package owned by the Console team. This PR introduces two core packages:

```
packages/
|-- console-app
`-- console-shared
```

`@console/app` represents the Console web application itself.
* for now, `src/index.ts` module simply imports the React application code from `public` directory
* Console webpack entry is now defined as `['./polyfills.js', '@console/app']`

`@console/shared` represents the code shared between all packages.
* for now, `src/index.ts` module exports an empty object (placeholder for future updates)
* this package provides its own `test` script to scope Jest execution (test co-location preference)

### Dependencies

Existing core `dependencies` and `devDependencies` are kept in the monorepo root `package.json`. In general, having all external dependencies declared in one place makes it easier to maintain a coherent technology stack across all the packages and reduce potential of conflicts or duplicities.

Non-core packages can still declare specific dependencies, e.g. [`react-cosmos`](https://github.com/react-cosmos/react-cosmos) or [`@patternfly/react-console`](https://github.com/patternfly/patternfly-react/tree/master/packages/patternfly-3/react-console) for a potential [`kubevirt-components`](https://github.com/kubevirt/web-ui-components) package.

### Other changes

* all packages are currently [private](https://docs.npmjs.com/files/package.json#private) and use a fixed version (`0.0.0-fixed`)
* `packages/.eslintrc` is a symlink to `public/.eslintrc`

In future, we'll also need to ensure that ESLint [`import/no-extraneous-dependencies`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md) is applied to all the packages.

---

/cc @spadgett @jhadvig @christianvogt @priley86 @mareklibra @rawagner @jelkosz