### PR TITLE
Show "Evicted" instead of "Failed" for evicted pod status

### DIFF
--- a/frontend/public/module/k8s/pods.ts
+++ b/frontend/public/module/k8s/pods.ts
@@ -182,6 +182,10 @@ export const podPhase = (pod): PodPhase => {
     return 'Terminating';
   }
 
+  if (pod.status.reason === 'Evicted') {
+    return 'Evicted';
+  }
+
   let initializing = false;
   let phase = pod.status.phase || pod.status.reason;
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1694788