### PR TITLE
Allow non-beta version for Console config

### DIFF
--- a/cmd/bridge/config.go
+++ b/cmd/bridge/config.go
@@ -70,8 +70,8 @@ func SetFlagsFromConfig(fs *flag.FlagSet, filename string) (err error) {
 		return err
 	}
 
-	if config.APIVersion != "console.openshift.io/v1beta1" || config.Kind != "ConsoleConfig" {
-		return fmt.Errorf("unsupported version (apiVersion: %s, kind: %s), only console.openshift.io/v1beta1 ConsoleConfig is supported", config.APIVersion, config.Kind)
+	if !(config.APIVersion == "console.openshift.io/v1beta1" || config.APIVersion == "console.openshift.io/v1") || config.Kind != "ConsoleConfig" {
+		return fmt.Errorf("unsupported version (apiVersion: %s, kind: %s), only console.openshift.io/v1 ConsoleConfig is supported", config.APIVersion, config.Kind)
 	}
 
 	err = addServingInfo(fs, &config.ServingInfo)


### PR DESCRIPTION
Current console is coded to only allow for console.openshift.io/v1beta1  && Kind = "ConsoleConfig".  Adding config.openshift.io/v1 && Kind = "Console" to help for future configurations.