### PR TITLE
Remove placeholder style from Events dropdown filter

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -171,6 +171,7 @@ export class EventsList extends React.Component {
             className="btn-group"
             items={categories}
             onChange={v => this.setState({category: v})}
+            selectedKey={this.state.category}
             title="All Categories"
           />
         </div>


### PR DESCRIPTION
Added selectedKey prop to the dropdown.

The dropdown filter on the right no longer uses the placeholder style:
<img width="1105" alt="Screen Shot 2019-04-03 at 1 58 31 PM" src="https://user-images.githubusercontent.com/7014965/55501526-96293e80-5618-11e9-962e-bca8eb371e34.png">

Fixes [CONSOLE-1347](https://jira.coreos.com/browse/CONSOLE-1347).