### PR TITLE
Fix oauth htpasswd template for integration test

### DIFF
--- a/frontend/integration-tests/data/htpasswd-idp.yaml
+++ b/frontend/integration-tests/data/htpasswd-idp.yaml
@@ -17,8 +17,6 @@ metadata:
 spec:
   identityProviders:
   - name: test
-    challenge: true
-    login: true
     mappingMethod: claim
     type: HTPasswd
     htpasswd:


### PR DESCRIPTION
Now since 'challenge' and 'login' are removed from identityProviders, update the test template for integration test.
```
oauthConfig:
  ...
  identityProviders:
  - name: "my_ldap_provider" 
    challenge: true 
    login: true
```
@spadgett Could you help to review please? Thanks!