### PR TITLE
Add missing <noscript>, remove product name from tokener.html

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -52,6 +52,7 @@
   </head>
 
   <body>
+    <noscript>JavaScript must be enabled.</noscript>
     <div id="modal-container"></div>
     [[ if .GoogleTagManagerID ]]
     <% if (htmlWebpackPlugin.options.production) { %>

--- a/frontend/public/tokener.html
+++ b/frontend/public/tokener.html
@@ -51,7 +51,7 @@
       } catch (e) {
         error = e;
         console.error(e);
-        document.body.append('localStorage must be enabled to use OpenShift Console:');
+        document.body.append('localStorage must be enabled:');
         document.body.append(e.message || e.toString());
       }
       if (!error) {
@@ -71,6 +71,6 @@
     </script>
   </head>
   <body>
-    <noscript>JavaScript must be enabled to use OpenShift Console.</noscript>
+    <noscript>JavaScript must be enabled.</noscript>
   </body>
 </html>


### PR DESCRIPTION
If JavaScript is not enabled, a blank white page is seen in the browser.  Adding the missing `<noscript>` puts a message on the page indicating JavaScript is required.