### PR TITLE
Monitoring: Display Prometheus API error if graph data fetch fails

### DIFF
--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -58,3 +58,7 @@
 .query-browser__span-reset {
   margin: 0 20px;
 }
+
+.query-browser__error {
+  margin: 10px 10px 20px 10px;
+}

--- a/frontend/public/components/graphs/query-browser.jsx
+++ b/frontend/public/components/graphs/query-browser.jsx
@@ -94,7 +94,7 @@ class QueryBrowser_ extends Line_ {
     };
   }
 
-  updateGraph(data) {
+  updateGraph(data, error) {
     const newData = _.get(data, '[0].data.result');
     if (!_.isEmpty(newData)) {
       this.data = newData;
@@ -151,12 +151,12 @@ class QueryBrowser_ extends Line_ {
         this.relayout({'xaxis.range': [start, end]});
       }
     }
-    this.setState({updating: false});
+    this.setState({error, updating: false});
   }
 
   render() {
     const {query, urls} = this.props;
-    const {spanText, isSpanValid, updating} = this.state;
+    const {error, isSpanValid, spanText, updating} = this.state;
     const baseUrl = urls[MonitoringRoutes.Prometheus];
 
     return <div className="query-browser__wrapper">
@@ -186,6 +186,9 @@ class QueryBrowser_ extends Line_ {
         </div>
         {baseUrl && query && <ExternalLink href={`${baseUrl}/graph?g0.expr=${encodeURIComponent(query)}&g0.tab=0`} text="View in Prometheus UI" />}
       </div>
+      {error && <div className="alert alert-danger query-browser__error">
+        <span className="pficon pficon-error-circle-o" aria-hidden="true"></span>{error.message}
+      </div>}
       <div ref={this.setNode} style={{width: '100%'}} />
     </div>;
   }


### PR DESCRIPTION
Fix the Monitoring UI graphs to display the error message if the call to fetch the graph data fails.

![screenshot](https://user-images.githubusercontent.com/460802/55694002-00f9c180-59ed-11e9-835c-90eee39c51d2.png)