### PR TITLE
Monitoring: Fix the initial time range rendered by graphs

### DIFF
--- a/frontend/public/components/graphs/query-browser.jsx
+++ b/frontend/public/components/graphs/query-browser.jsx
@@ -16,6 +16,7 @@ class QueryBrowser_ extends Line_ {
 
     // For the default time span, use the first of the suggested span options that is at least as long as props.timeSpan
     this.defaultSpan = spans.map(parsePrometheusDuration).find(s => s >= props.timeSpan);
+    this.timeSpan = this.defaultSpan;
 
     _.assign(this.state, {
       isSpanValid: true,


### PR DESCRIPTION
Fix `this.timeSpan` to have the correct initial value. Fixes a bug where
time range `props.timeSpan` was plotted instead of `this.defaultSpan`.