### PR TITLE
Bug 1697176 - Monitoring: Use Plotly's default Y axis label format

### DIFF
--- a/frontend/public/components/graphs/query-browser.jsx
+++ b/frontend/public/components/graphs/query-browser.jsx
@@ -41,6 +41,7 @@ class QueryBrowser_ extends Line_ {
       },
       yaxis: {
         fixedrange: false,
+        tickformat: null, // Use Plotly's default value format
       },
     });
 


### PR DESCRIPTION
So that decimals will be rendered as e.g. "0.5" rather than "500m".

Overrides the change introduced by #1323, but only for the monitoring alert graphs.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1697176

FYI @juzhao, @cshinn 

### Before
![before](https://user-images.githubusercontent.com/460802/55701637-dc164600-5a0e-11e9-9655-0ba7f6752938.png)

### After
![after](https://user-images.githubusercontent.com/460802/55701643-e2a4bd80-5a0e-11e9-925f-027cbda52455.png)
