### PR TITLE
Convert co-m-modal-link from <a> to <button>

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/spec/index.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/spec/index.spec.tsx
@@ -35,7 +35,7 @@ describe(SpecDescriptor.name, () => {
     descriptor['x-descriptors'] = [SpecCapability.podCount];
     wrapper = wrapper.setProps({descriptor, value});
 
-    expect(wrapper.find('dd').childAt(0).shallow().find('a.co-m-modal-link').text()).toEqual(`${value} pods`);
+    expect(wrapper.find('dd').childAt(0).shallow().find('button.co-modal-btn-link').text()).toEqual(`${value} pods`);
 
     spyOn(configureSize, 'configureSizeModal').and.callFake((props) => {
       expect(props).toEqual({
@@ -46,7 +46,7 @@ describe(SpecDescriptor.name, () => {
       });
       done();
     });
-    wrapper.find('dd').childAt(0).shallow().find('a.co-m-modal-link').props().onClick(null);
+    wrapper.find('dd').childAt(0).shallow().find('button.co-modal-btn-link').props().onClick(null);
   });
 
   it('renders an endpoints list', () => {

--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/spec/resource-requirements.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/spec/resource-requirements.spec.tsx
@@ -51,29 +51,29 @@ describe(ResourceRequirementsModalLink.displayName, () => {
     wrapper = shallow(<ResourceRequirementsModalLink obj={obj} type="limits" path="resources" />);
   });
 
-  it('renders a link with the resource requests limits', () => {
+  it('renders a button link with the resource requests limits', () => {
     const {memory, cpu} = obj.spec.resources.limits;
     wrapper = wrapper.setProps({type: 'requests'});
 
-    expect(wrapper.find('a').text()).toEqual(`CPU: ${cpu}, Memory: ${memory}`);
+    expect(wrapper.find('button').text()).toEqual(`CPU: ${cpu}, Memory: ${memory}`);
   });
 
-  it('renders a link with the resource limits', () => {
+  it('renders a button link with the resource limits', () => {
     const {memory, cpu} = obj.spec.resources.requests;
-    expect(wrapper.find('a').text()).toEqual(`CPU: ${cpu}, Memory: ${memory}`);
+    expect(wrapper.find('button').text()).toEqual(`CPU: ${cpu}, Memory: ${memory}`);
   });
 
   it('renders default values if undefined', () => {
     obj.spec.resources = undefined;
     wrapper.setProps({obj});
 
-    expect(wrapper.find('a').text()).toEqual('CPU: none, Memory: none');
+    expect(wrapper.find('button').text()).toEqual('CPU: none, Memory: none');
   });
 
   it('opens resource requirements modal when clicked', () => {
     const modalSpy = jasmine.createSpy('modalSpy');
     spyOn(modal, 'createModalLauncher').and.returnValue(modalSpy);
-    wrapper.find('a').simulate('click');
+    wrapper.find('button').simulate('click');
 
     expect(modalSpy.calls.count()).toEqual(1);
     expect(modalSpy.calls.argsFor(0)[0].title).toEqual(`${obj.kind} Resource Limits`);

--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -114,7 +114,7 @@ export const resourceTitle = $('#resource-title');
 
 export const nameFilter = $('.form-control.text-filter');
 export const messageLbl = $('.cos-status-box');
-export const modalAnnotationsLink = $('.loading-box__loaded').element(by.partialLinkText('Annotation'));
+export const modalAnnotationsLink = $('.loading-box__loaded').element(by.partialButtonText('Annotation'));
 
 export const visitResource = async(resource: string, name: string) => {
   await browser.get(`${appHost}/k8s/ns/${testName}/${resource}/${name}`);

--- a/frontend/public/components/alert-manager.tsx
+++ b/frontend/public/components/alert-manager.tsx
@@ -39,7 +39,7 @@ const Details: React.SFC<DetailsProps> = (props) => {
             <dd>{spec.version}</dd>
             <dt>Replicas</dt>
             <dd>
-              <a className="co-m-modal-link" href="#" onClick={openReplicaCountModal}>{pluralize(spec.replicas, 'pod')}</a>
+              <button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={openReplicaCountModal}>{pluralize(spec.replicas, 'pod')}</button>
             </dd>
             {_.get(spec, 'resources.requests.memory') && <React.Fragment>
               <dt>Resource Request</dt>

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -38,7 +38,7 @@ import {
 
 const clusterAutoscalerReference = referenceForModel(ClusterAutoscalerModel);
 
-const CurrentChannel: React.SFC<CurrentChannelProps> = ({cv}) => <button className="btn btn-link co-m-modal-link" onClick={() => (clusterChannelModal({cv}))}>
+const CurrentChannel: React.SFC<CurrentChannelProps> = ({cv}) => <button className="btn btn-link co-modal-btn-link" onClick={() => (clusterChannelModal({cv}))}>
   {cv.spec.channel || '-'}
 </button>;
 
@@ -84,7 +84,7 @@ const UpdatesAvailableAlert: React.SFC<UpdatesAvailableAlertProps> = ({cv}) => {
     <strong>
       {titleText}
     </strong>
-    <Button bsStyle="link" className="co-m-modal-link" onClick={()=> (clusterUpdateModal({cv}))}>
+    <Button bsStyle="link" className="btn btn-link co-modal-btn-link co-modal-btn-link--inline" onClick={()=> (clusterUpdateModal({cv}))}>
       {buttonText}
     </Button>
   </div>;
@@ -97,7 +97,7 @@ const UpdateStatus: React.SFC<UpdateStatusProps> = ({cv}) => {
   return <React.Fragment>
     {
       status === ClusterUpdateStatus.UpdatesAvailable
-        ? <Button bsStyle="link" className="co-m-modal-link" onClick={() => (clusterUpdateModal({cv}))}>
+        ? <Button bsStyle="link" className="btn btn-link co-modal-btn-link" onClick={() => (clusterUpdateModal({cv}))}>
           <i className={iconClass} aria-hidden={true}></i>
           &nbsp;
           {status}
@@ -134,19 +134,19 @@ const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = (
         { updatesAvailable && <UpdatesAvailableAlert cv={cv} /> }
         <div className="co-detail-table">
           <div className="co-detail-table__row row">
-            <div className="co-detail-table__section">
+            <div className="co-detail-table__section col-sm-4">
               <dl className="co-m-pane__details">
                 <dt className="co-detail-table__section-header">Channel</dt>
                 <dd><CurrentChannel cv={cv} /></dd>
               </dl>
             </div>
-            <div className="co-detail-table__section">
+            <div className="co-detail-table__section col-sm-4">
               <dl className="co-m-pane__details">
                 <dt className="co-detail-table__section-header">Update Status</dt>
                 <dd><UpdateStatus cv={cv} /></dd>
               </dl>
             </div>
-            <div className="co-detail-table__section">
+            <div className="co-detail-table__section col-sm-4">
               <dl className="co-m-pane__details">
                 <dt className="co-detail-table__section-header">Desired Version</dt>
                 <dd><DesiredVersion cv={cv} /></dd>

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -91,7 +91,7 @@ export const MachineCounts: React.SFC<MachineCountsProps> = ({resourceKind, reso
           <dl className="co-m-pane__details">
             <dt className="co-detail-table__section-header">Desired Count</dt>
             <dd>
-              <button type="button" className="btn btn-link co-m-modal-link" onClick={editReplicas}>
+              <button type="button" className="btn btn-link co-modal-btn-link" onClick={editReplicas}>
                 {pluralize(desiredReplicas, 'machine')}
               </button>
             </dd>

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -161,7 +161,7 @@ class PullSecret extends SafetyFirst {
       return <LoadingInline />;
     }
     const modal = () => configureNamespacePullSecretModal({namespace: this.props.namespace, pullSecret: this.state.data});
-    return <a className="co-m-modal-link" onClick={modal}>{_.get(this.state.data, 'metadata.name') || 'Not Configured'}</a>;
+    return <button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={modal}>{_.get(this.state.data, 'metadata.name') || 'Not Configured'}</button>;
   }
 }
 

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -144,9 +144,9 @@ const Details = ({obj: node}) => {
             <dt>Node Labels</dt>
             <dd><LabelList kind="Node" labels={node.metadata.labels} /></dd>
             <dt>Taints</dt>
-            <dd><a className="co-m-modal-link" onClick={Kebab.factory.ModifyTaints(NodeModel, node).callback}>{pluralize(_.size(node.spec.taints), 'Taint')}</a></dd>
+            <dd><button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyTaints(NodeModel, node).callback}>{pluralize(_.size(node.spec.taints), 'Taint')}</button></dd>
             <dt>Annotations</dt>
-            <dd><a className="co-m-modal-link" onClick={Kebab.factory.ModifyAnnotations(NodeModel, node).callback}>{pluralize(_.size(node.metadata.annotations), 'Annotation')}</a></dd>
+            <dd><button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyAnnotations(NodeModel, node).callback}>{pluralize(_.size(node.metadata.annotations), 'Annotation')}</button></dd>
             {machine && <React.Fragment>
               <dt>Machine</dt>
               <dd><ResourceLink kind={referenceForModel(MachineModel)} name={machine.name} namespace={machine.namespace} /></dd>

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
@@ -22,7 +22,7 @@ const Default: React.SFC<SpecCapabilityProps> = ({value}) => {
 };
 
 const PodCount: React.SFC<SpecCapabilityProps> = ({model, obj, descriptor, value}) =>
-  <a onClick={() => configureSizeModal({kindObj: model, resource: obj, specDescriptor: descriptor, specValue: value})} className="co-m-modal-link">{value} pods</a>;
+  <button type="button" className="btn btn-link co-modal-btn-link" onClick={() => configureSizeModal({kindObj: model, resource: obj, specDescriptor: descriptor, specValue: value})}>{value} pods</button>;
 
 const Endpoints: React.SFC<SpecCapabilityProps> = ({value}) => <EndpointList endpoints={value} />;
 

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/resource-requirements.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/resource-requirements.tsx
@@ -66,7 +66,7 @@ export const ResourceRequirementsModalLink: React.SFC<ResourceRequirementsModalL
     return modal({title, description, obj, Form, type, path});
   };
 
-  return <a className="co-m-modal-link" onClick={onClick}>{`CPU: ${cpu || 'none'}, Memory: ${memory || 'none'}`}</a>;
+  return <button type="button" className="btn btn-link co-modal-btn-link" onClick={onClick}>{`CPU: ${cpu || 'none'}, Memory: ${memory || 'none'}`}</button>;
 };
 
 export type ResourceRequirementsModalProps = {

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -178,7 +178,7 @@ export class SubscriptionUpdates extends React.Component<SubscriptionUpdatesProp
             <dt className="co-detail-table__section-header">Channel</dt>
             <dd>{ this.state.waitingForUpdate
               ? <LoadingInline />
-              : <a className="co-m-modal-link" onClick={() => channelModal()}>{obj.spec.channel || 'default'}</a>
+              : <button type="button" className="btn btn-link co-modal-btn-link" onClick={() => channelModal()}>{obj.spec.channel || 'default'}</button>
             }</dd>
           </dl>
         </div>
@@ -187,7 +187,7 @@ export class SubscriptionUpdates extends React.Component<SubscriptionUpdatesProp
             <dt className="co-detail-table__section-header">Approval</dt>
             <dd>{ this.state.waitingForUpdate
               ? <LoadingInline />
-              : <a className="co-m-modal-link" onClick={() => approvalModal()}>{obj.spec.installPlanApproval || 'Automatic'}</a>
+              : <button type="button" className="btn btn-link co-modal-btn-link" onClick={() => approvalModal()}>{obj.spec.installPlanApproval || 'Automatic'}</button>
             }</dd>
           </dl>
         </div>

--- a/frontend/public/components/utils/deployment-pod-counts.tsx
+++ b/frontend/public/components/utils/deployment-pod-counts.tsx
@@ -66,19 +66,19 @@ export class DeploymentPodCounts extends SafetyFirst<DPCProps, DPCState> {
     return <div className="co-m-pane__body-group">
       <div className="co-detail-table">
         <div className="co-detail-table__row row">
-          <div className="co-detail-table__section">
+          <div className="co-detail-table__section col-sm-3">
             <dl className="co-m-pane__details">
               <dt className="co-detail-table__section-header">Desired Count</dt>
               <dd>
                 {
                   this.state.waitingForUpdate
                     ? <LoadingInline />
-                    : <a className="co-m-modal-link" href="#" onClick={this.openReplicaCountModal}>{ pluralize(spec.replicas, 'pod') }</a>
+                    : <button type="button" className="btn btn-link co-modal-btn-link" onClick={this.openReplicaCountModal}>{ pluralize(spec.replicas, 'pod') }</button>
                 }
               </dd>
             </dl>
           </div>
-          <div className="co-detail-table__section">
+          <div className="co-detail-table__section col-sm-3">
             <dl className="co-m-pane__details">
               <dt className="co-detail-table__section-header">Up-to-date Count</dt>
               <dd>
@@ -88,7 +88,7 @@ export class DeploymentPodCounts extends SafetyFirst<DPCProps, DPCState> {
               </dd>
             </dl>
           </div>
-          <div className="co-detail-table__section co-detail-table__section--last">
+          <div className="co-detail-table__section co-detail-table__section--last col-sm-6">
             <dl className="co-m-pane__details">
               <dt className="co-detail-table__section-header">Matching Pods</dt>
               <dd>

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -47,9 +47,9 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, reso
     {showNodeSelector && <dt>Node Selector</dt>}
     {showNodeSelector && <dd><Selector kind="Node" selector={_.get(resource, 'spec.template.spec.nodeSelector')} /></dd>}
     {showTolerations && <dt>Tolerations</dt>}
-    {showTolerations && <dd><a className="co-m-modal-link" onClick={Kebab.factory.ModifyTolerations(model, resource).callback}>{pluralize(_.size(tolerations), 'Toleration')}</a></dd>}
+    {showTolerations && <dd><button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyTolerations(model, resource).callback}>{pluralize(_.size(tolerations), 'Toleration')}</button></dd>}
     {showAnnotations && <dt>Annotations</dt>}
-    {showAnnotations && <dd><a className="co-m-modal-link" onClick={Kebab.factory.ModifyAnnotations(model, resource).callback}>{pluralize(_.size(metadata.annotations), 'Annotation')}</a></dd>}
+    {showAnnotations && <dd><button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyAnnotations(model, resource).callback}>{pluralize(_.size(metadata.annotations), 'Annotation')}</button></dd>}
     {children}
     <dt>Created At</dt>
     <dd><Timestamp timestamp={metadata.creationTimestamp} /></dd>

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -151,6 +151,8 @@
 .co-m-pane__details {
   // TODO: refactor so <dl>s have margin-bottom by default
   margin-bottom: 20px;
+  min-width: 0; // enable break-word
+  white-space: normal; // override inheritence from co-detail-table
   .co-detail-table__row & {
     margin-bottom: 0;
   }
@@ -403,27 +405,37 @@
   max-width: 600px;
 }
 
-.co-m-modal-link {
-  cursor: pointer;
+// Enable word-break and append pficon-var-edit icon ::after so that it doesn't wrap without text
+.co-modal-btn-link {
   outline: none;
-  padding-right:  20px;
-  position: relative;
+  padding: 0 20px 0 0;
+  white-space: normal;
+  word-break: break-all; // Firefox
+  word-break: break-word;
   &::after {
     color: $color-pf-black-600;
     content: $pficon-var-edit;
+    display: inline-block;
     font-family: $icon-font-name-pf;
     line-height: 1;
+    margin-left: 5px;
+    margin-right: -20px; // width + margin-left
     pointer-events: none;
-    position: absolute;
+    position: relative;
     right: 0;
-    top: 0;
-  }
-  &.btn-link::after {
-    top: 5px;
+    width: 15px;
   }
   &:hover::after {
     color: $color-pf-black-700;
   }
+}
+
+.co-modal-btn-link--inline {
+  margin: 0 8px;
+}
+
+.co-modal-btn-link--left {
+  text-align: left;
 }
 
 .co-m-pane__body-group {


### PR DESCRIPTION
- Improve accessibility
- Enable wrapping of long strings
- Keep appended edit icon from wrapping without end text (same as `co-external-link`)
- add ` col-sm-4` to cluster settings `co-detail-table` so it has an explicit width to enable wrapping

fixes: https://jira.coreos.com/browse/CONSOLE-1357

<img width="645" alt="Screen Shot 2019-04-08 at 1 32 13 PM" src="https://user-images.githubusercontent.com/1874151/55745415-285c8880-5a05-11e9-9518-8f3865e13976.png">
<img width="674" alt="Screen Shot 2019-04-08 at 1 49 01 PM" src="https://user-images.githubusercontent.com/1874151/55745416-285c8880-5a05-11e9-97f0-a478cf6ec486.png">
