### PR TITLE
Do not render ResourceIcon contents if kind does not exist

### DIFF
--- a/frontend/public/components/utils/resource-icon.tsx
+++ b/frontend/public/components/utils/resource-icon.tsx
@@ -9,6 +9,10 @@ import { kindToAbbr } from '../../module/k8s/get-resources';
 const MEMO = {};
 
 export const ResourceIcon: React.SFC<ResourceIconProps> = ({className, kind}) => {
+  // if no kind, return null so an empty icon isn't rendered
+  if (!kind) {
+    return null;
+  }
   const memoKey = className ? `${kind}/${className}` : kind;
   if (MEMO[memoKey]) {
     return MEMO[memoKey];


### PR DESCRIPTION
We've seen this issue before, but corrected for it by ensuring `kind` is passed.  IMO, it's better to not output anything if `kind` is missing since the icon isn't essential.

Before:
Note the blue bar to the left of "packageserver" in the list.
![Screen Shot 2019-04-09 at 11 42 40 AM](https://user-images.githubusercontent.com/895728/55814485-aa5bb880-5abc-11e9-8e27-c1c19faa8b93.png)

After
![Screen Shot 2019-04-09 at 11 42 51 AM](https://user-images.githubusercontent.com/895728/55814495-afb90300-5abc-11e9-9a8e-1e0b4d1dad5d.png)
