### PR TITLE
Add console-scripts package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@console/root",
   "description": "OpenShift Web Console",
   "repository": "https://github.com/openshift/console",
   "license": "Apache-2.0",
@@ -38,7 +39,7 @@
     "transformIgnorePatterns": [
       "<rootDir>/node_modules/(?!lodash-es/.*)"
     ],
-    "testRegex": "/__tests__/.*\\.(ts|tsx|js|jsx)$",
+    "testRegex": "(/__tests__/.*|\\.test)\\.(ts|tsx|js|jsx)$",
     "setupFiles": [
       "./__mocks__/requestAnimationFrame.js",
       "./__mocks__/localStorage.ts",

--- a/frontend/packages/console-scripts/.eslintrc
+++ b/frontend/packages/console-scripts/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../integration-tests/.eslintrc"
+  ]
+}

--- a/frontend/packages/console-scripts/bin/test.js
+++ b/frontend/packages/console-scripts/bin/test.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const readPkgUp = require('read-pkg-up');
+const spawn = require('cross-spawn');
+const utils = require('../src/utils');
+
+const scriptName = path.basename(process.argv[1]);
+const callerDir = process.cwd();
+
+const { pkg: rootPkg = {}, path: rootPkgPath } = readPkgUp.sync({ cwd: path.dirname(callerDir) });
+
+if (rootPkg.name !== '@console/root') {
+  console.error(
+    `The script ${scriptName} was called on a package outside the Console monorepo structure.`
+  );
+  process.exit(1);
+}
+
+const rootDir = path.dirname(rootPkgPath);
+const callerRelativePath = path.relative(rootDir, callerDir);
+
+utils.handleSpawnResult(
+  spawn.sync('yarn', ['test', callerRelativePath], { stdio: 'inherit', cwd: rootDir })
+);

--- a/frontend/packages/console-scripts/package.json
+++ b/frontend/packages/console-scripts/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@console/scripts",
+  "version": "0.0.0-fixed",
+  "description": "Console scripts available to all packages",
+  "private": true,
+  "bin": {
+    "console-test": "./bin/test.js"
+  },
+  "dependencies": {
+    "cross-spawn": "^6.0.5",
+    "read-pkg-up": "^5.0.0"
+  }
+}

--- a/frontend/packages/console-scripts/src/utils.js
+++ b/frontend/packages/console-scripts/src/utils.js
@@ -1,0 +1,20 @@
+function handleSpawnResult(result) {
+  if (result.signal === 'SIGKILL') {
+    console.error(
+      'The build failed because the process exited too early. ' +
+        'This probably means the system ran out of memory or someone called ' +
+        '`kill -9` on the process.',
+    );
+  } else if (result.signal === 'SIGTERM') {
+    console.error(
+      'The build failed because the process exited too early. ' +
+        'Someone might have called `kill` or `killall`, or the system could ' +
+        'be shutting down.',
+    );
+  }
+  process.exitCode = result.signal ? 1 : result.status;
+}
+
+module.exports = {
+  handleSpawnResult,
+};

--- a/frontend/packages/console-shared/package.json
+++ b/frontend/packages/console-shared/package.json
@@ -5,6 +5,9 @@
   "private": true,
   "main": "src/index.ts",
   "scripts": {
-    "test": "yarn --cwd ../.. run test packages/console-shared"
+    "test": "console-test"
+  },
+  "dependencies": {
+    "@console/scripts": "0.0.0-fixed"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3200,6 +3200,7 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
   dependencies:
     nice-try "^1.0.4"
     path-key "^2.0.1"
@@ -4752,6 +4753,13 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
 
 findup@^0.1.5:
   version "0.1.5"
@@ -7543,6 +7551,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash-es@4.x, lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.7"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.7.tgz#db240a3252c3dd8360201ac9feef91ac977ea856"
@@ -8922,11 +8938,25 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-map@^1.1.1:
   version "1.2.0"
@@ -8951,6 +8981,11 @@ p-timeout@^2.0.1:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 pad-left@^1.0.2:
   version "1.0.2"
@@ -10363,6 +10398,14 @@ read-pkg-up@^3.0.0:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
 
+read-pkg-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-5.0.0.tgz#b6a6741cb144ed3610554f40162aa07a6db621b8"
+  integrity sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==
+  dependencies:
+    find-up "^3.0.0"
+    read-pkg "^5.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -10386,6 +10429,14 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+read-pkg@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.0.0.tgz#75449907ece8dfb89cbc76adcba2665316e32b94"
+  integrity sha512-OWufaRc67oJjcgrxckW/qO9q22iYzyiONh8h+GMcnOvSHAmhV1Dr3x+gyRjP+Qxc5jKupkSfoCQLS/98rDPh9A==
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"


### PR DESCRIPTION
This PR adds new `console-scripts` package containing common scripts available to all packages.

This is conceptually similar to [fabric8-ui `scripts` package](https://github.com/fabric8-ui/fabric8-ui/tree/master/packages/scripts). Reusing scripts across packages allows for aligning common workflows such as testing, linting, etc. and therefore improve monorepo cohesiveness.

```diff
"scripts": {
-  "test": "yarn --cwd ../.. run test packages/console-shared"
+  "test": "console-test"
}
```

Here's what happens when you run the `console-test` script:
- check if the script was called from within the Console monorepo
- execute `yarn test packages/<caller-pkg>` in the monorepo root directory

_Note: [Jest `testRegex` option](https://jestjs.io/docs/en/configuration.html#testregex-string-array-string) was modified to allow future test co-location._

I've tested this by adding a temporary `packages/console-shared/src/index.test.js` file and running `yarn test` in the monorepo root and then in the `packages/console-shared` directory. Both global and package-specific `test` workflow works as expected.