### PR TITLE
Indicate external links in masthead dropdowns and switch direction of…

### DIFF
--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -153,6 +153,7 @@ class MastheadToolbar_ extends React.Component {
     return [{
       label: 'Multi-Cluster Manager',
       callback: this._onClusterManager,
+      externalLink: true,
     }];
   }
 
@@ -160,10 +161,12 @@ class MastheadToolbar_ extends React.Component {
     return [{
       label: 'Documentation',
       callback: this._onDocumentation,
+      externalLink: true,
     }, {
       label: 'CLI Download',
       callback: this._onCLIDownload,
-    }, {
+      externalLink: true,
+    },{
       label: 'About',
       callback: this._onAboutModal,
     }];
@@ -172,7 +175,9 @@ class MastheadToolbar_ extends React.Component {
   _renderMenuItems(actions) {
     return actions.map((action, i) => action.separator
       ? <DropdownSeparator key={i} />
-      : <DropdownItem key={i} onClick={action.callback}>{action.label}</DropdownItem>
+      : <DropdownItem key={i} onClick={action.callback}>
+        {action.label}{action.externalLink && <span className="co-external-link"></span>}
+      </DropdownItem>
     );
   }
 
@@ -282,6 +287,7 @@ class MastheadToolbar_ extends React.Component {
             <ToolbarItem>
               <Dropdown
                 isPlain
+                position="right"
                 onSelect={this._onHelpDropdownSelect}
                 toggle={
                   <DropdownToggle aria-label="Help" iconComponent={null} onToggle={this._onHelpDropdownToggle}>

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -275,9 +275,13 @@
   margin-right: -15px; // width + margin-left
   top:0;
   width: 12px;
-
+  .pf-c-dropdown__menu-item & {
+    color: $color-pf-black-600;
+    margin-left: 5px;
+  }
   .pf-c-nav__link & {
     color: $color-pf-black-500;
+    margin-left: 4px;
   }
 }
 .co-external-link {


### PR DESCRIPTION
… help dropdown

![Screen Shot 2019-04-10 at 3 08 40 PM](https://user-images.githubusercontent.com/895728/55906612-a73af800-5ba2-11e9-902d-0c904ddc93c3.png)
<img width="354" alt="Screen Shot 2019-04-11 at 10 40 00 AM" src="https://user-images.githubusercontent.com/895728/55966360-3b11d000-5c46-11e9-8ddb-f8ce025683a6.png">
<img width="252" alt="Screen Shot 2019-04-11 at 10 39 51 AM" src="https://user-images.githubusercontent.com/895728/55966361-3b11d000-5c46-11e9-85fa-0e35bf947137.png">


Bonus:  slightly increase spacing between text label and external link icon in nav external links
![Screen Shot 2019-04-10 at 3 09 05 PM](https://user-images.githubusercontent.com/895728/55906616-a73af800-5ba2-11e9-825e-f7566657f33f.png)
