### PR TITLE
Correctly virtualize list rows

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -42,6 +42,9 @@ export const config: Config = {
         '--disable-background-timer-throttling',
         '--disable-renderer-backgrounding',
         '--disable-raf-throttling',
+        // Avoid crashes when running in a container due to small /dev/shm size
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=715363
+        '--disable-dev-shm-usage',
       ],
       prefs: {
         'profile.password_manager_enabled': false,

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -366,7 +366,7 @@ VirtualRows.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object),
   expand: PropTypes.bool,
   Row: PropTypes.func.isRequired,
-  kindObj: PropTypes.any.isRequired,
+  kindObj: PropTypes.any,
   label: PropTypes.string,
   mock: PropTypes.bool,
 };
@@ -453,9 +453,9 @@ export const List = connect(stateToProps, {sortList: UIActions.sortList})(
     };
 
     render() {
-      const {currentSortField, currentSortFunc, currentSortOrder, expand, Header, label, listId, mock, Row, sortList} = this.props;
+      const {currentSortField, currentSortFunc, currentSortOrder, expand, Header, label, listId, mock, Row, sortList, virtualize = true} = this.props;
       const componentProps: any = _.pick(this.props, ['data', 'filters', 'selected', 'match', 'kindObj']);
-      const ListRows = this.props.virtualize ? VirtualRows : Rows;
+      const ListRows = virtualize ? VirtualRows : Rows;
       const children = <React.Fragment>
         <Header
           {...componentProps}


### PR DESCRIPTION
When we added the `virtualize` prop, we didn't default it to true, so the tables are not using virtual scrolling.

/assign @alecmerdler 
/cc @priley86 