### PR TITLE
Fix bug where modal dropdowns are clipped

### DIFF
--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -60,11 +60,19 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  position: relative;
   @media(min-width: $screen-sm-min) {
     // Desktop only responsive max-height allows modal to adjust to content height and enable scroll shadows if needed.
     max-height: calc(100vh - 60px);
+    // Dropdown workaround:  use when modal content can expand (taints, tolerations)
+    &--accommodate-dropdown .modal-body-inner-shadow-covers {
+      padding-bottom: 100px;
+    }
+    // Dropdown workaround: use when modal content is short and cannot expand
+    &--no-inner-scroll .modal-body {
+      overflow-y: visible ;
+    }
   }
-  position: relative;
 }
 
 // setting a height on modal-dialog enables flex child height to shrink and become scrollable

--- a/frontend/public/components/modals/cluster-channel-modal.tsx
+++ b/frontend/public/components/modals/cluster-channel-modal.tsx
@@ -43,12 +43,9 @@ class ClusterChannelModal extends PromiseComponent {
   render() {
     const {cv} = this.props;
     const availableChannels = getAvailableClusterChannels();
-    return <form onSubmit={this._submit} name="form" className="modal-content modal-content--small">
+    return <form onSubmit={this._submit} name="form" className="modal-content modal-content--no-inner-scroll">
       <ModalTitle>Update Channel</ModalTitle>
       <ModalBody>
-        {/* <p>
-          // TODO: Determine what content goes here.
-        </p> */}
         <div className="form-group">
           <label htmlFor="channel_dropdown">Channel</label>
           <Dropdown

--- a/frontend/public/components/modals/cluster-update-modal.tsx
+++ b/frontend/public/components/modals/cluster-update-modal.tsx
@@ -49,7 +49,7 @@ class ClusterUpdateModal extends PromiseComponent {
     const availableUpdates = getAvailableClusterUpdates(cv);
     const currentVersion = getDesiredClusterVersion(cv);
     const dropdownItems = _.map(availableUpdates, 'version');
-    return <form onSubmit={this._submit} name="form" className="modal-content">
+    return <form onSubmit={this._submit} name="form" className="modal-content modal-content--no-inner-scroll">
       <ModalTitle>Update Cluster</ModalTitle>
       <ModalBody>
         {/* <p>

--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -101,7 +101,7 @@ const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNames
       [allow]: 'No restrictions (default)',
       [deny]: 'Deny all inbound traffic',
     };
-    return <form onSubmit={this._submit.bind(this)} name="form" className="modal-content co-p-new-user-modal">
+    return <form onSubmit={this._submit.bind(this)} name="form" className="modal-content modal-content--no-inner-scroll co-p-new-user-modal">
       <ModalTitle>Create {label}</ModalTitle>
       <ModalBody>
         <div className="form-group">

--- a/frontend/public/components/modals/taints-modal.tsx
+++ b/frontend/public/components/modals/taints-modal.tsx
@@ -70,7 +70,7 @@ class TaintsModal extends PromiseComponent {
       'NoExecute': 'NoExecute',
     };
     const { taints, errorMessage, inProgress } = this.state;
-    return <form onSubmit={this._submit} name="form" className="modal-content taint-modal">
+    return <form onSubmit={this._submit} name="form" className="modal-content modal-content--accommodate-dropdown taint-modal">
       <ModalTitle>Edit Taints</ModalTitle>
       <ModalBody>
         {_.isEmpty(taints)

--- a/frontend/public/components/modals/tolerations-modal.tsx
+++ b/frontend/public/components/modals/tolerations-modal.tsx
@@ -104,7 +104,7 @@ class TolerationsModal extends PromiseComponent {
       'NoExecute': 'NoExecute',
     };
     const { tolerations, errorMessage, inProgress } = this.state;
-    return <form onSubmit={this._submit} name="form" className="modal-content toleration-modal">
+    return <form onSubmit={this._submit} name="form" className="modal-content modal-content--accommodate-dropdown toleration-modal">
       <ModalTitle>Edit Tolerations</ModalTitle>
       <ModalBody>
         {_.isEmpty(tolerations)


### PR DESCRIPTION
These fixes aren't ideal, but they resolve the bug with low risk.

Fixes https://jira.coreos.com/browse/CONSOLE-1360

If the modal contents can be expanded, add padding to the bottom of the modal so the dropdown is visible when open:
<img width="930" alt="Screen Shot 2019-04-11 at 10 18 47 AM" src="https://user-images.githubusercontent.com/895728/55965360-71e6e680-5c44-11e9-9bc5-8c921154c9bd.png">
<img width="931" alt="Screen Shot 2019-04-11 at 10 16 51 AM" src="https://user-images.githubusercontent.com/895728/55965361-71e6e680-5c44-11e9-87a4-0f44513a324f.png">

If the modal contents cannot be expanded, turn off overflow so the dropdown isn't clipped:
<img width="619" alt="Screen Shot 2019-04-11 at 10 17 12 AM" src="https://user-images.githubusercontent.com/895728/55965362-71e6e680-5c44-11e9-95ab-091aa862331d.png">
<img width="629" alt="Screen Shot 2019-04-11 at 10 17 19 AM" src="https://user-images.githubusercontent.com/895728/55965363-71e6e680-5c44-11e9-9000-8be5c9158fdb.png">
<img width="620" alt="Screen Shot 2019-04-11 at 10 17 54 AM" src="https://user-images.githubusercontent.com/895728/55965364-71e6e680-5c44-11e9-81e0-9f101a18bfdc.png">
