### PR TITLE
Minor updates to OLM and OperatorHub pages

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
@@ -136,7 +136,7 @@ describe(SubscriptionsPage.displayName, () => {
     expect(wrapper.find(MultiListPage).props().title).toEqual('Subscriptions');
     expect(wrapper.find(MultiListPage).props().showTitle).toBe(false);
     expect(wrapper.find(MultiListPage).props().canCreate).toBe(true);
-    expect(wrapper.find(MultiListPage).props().createProps).toEqual({to: '/operatormanagement/ns/default'});
+    expect(wrapper.find(MultiListPage).props().createProps).toEqual({to: '/operatormanagement/ns/default/catalogsources'});
     expect(wrapper.find(MultiListPage).props().createButtonText).toEqual('Create Subscription');
     expect(wrapper.find(MultiListPage).props().filterLabel).toEqual('Subscriptions by package');
     expect(wrapper.find(MultiListPage).props().resources).toEqual([

--- a/frontend/integration-tests/tests/olm/catalog.scenario.ts
+++ b/frontend/integration-tests/tests/olm/catalog.scenario.ts
@@ -62,6 +62,7 @@ describe('Installing a service from a Catalog Source', () => {
 
   it('displays Catalog Source with expected available packages', async() => {
     await sidenavView.clickNavLink(['Catalog', 'Operator Management']);
+    await catalogView.clickCatalogsTab();
     await catalogView.isLoaded();
 
     openCloudServices.forEach(name => {

--- a/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
@@ -44,6 +44,7 @@ describe('Interacting with the Redis Operator (all-namespaces install mode)', ()
 
   it('can be enabled from the Catalog Source', async() => {
     await sidenavView.clickNavLink(['Catalog', 'Operator Management']);
+    await catalogView.clickCatalogsTab();
     await catalogView.isLoaded();
     await catalogView.createSubscriptionFor('Redis Enterprise');
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -53,6 +54,7 @@ describe('Interacting with the Redis Operator (all-namespaces install mode)', ()
     await $('#save-changes').click();
     await crudView.isLoaded();
     await sidenavView.clickNavLink(['Catalog', 'Operator Management']);
+    await catalogView.clickCatalogsTab();
     await catalogView.isLoaded();
 
     expect(catalogView.hasSubscription('Redis Enterprise')).toBe(true);

--- a/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
@@ -46,6 +46,7 @@ describe('Interacting with the Prometheus Operator (single-namespace install mod
 
   it('can be enabled from the Catalog Source', async() => {
     await sidenavView.clickNavLink(['Catalog', 'Operator Management']);
+    await catalogView.clickCatalogsTab();
     await catalogView.isLoaded();
     await catalogView.createSubscriptionFor('Prometheus');
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -55,6 +56,7 @@ describe('Interacting with the Prometheus Operator (single-namespace install mod
     await $('#save-changes').click();
     await crudView.isLoaded();
     await sidenavView.clickNavLink(['Catalog', 'Operator Management']);
+    await catalogView.clickCatalogsTab();
     await catalogView.isLoaded();
 
     expect(catalogView.hasSubscription('Prometheus')).toBe(true);

--- a/frontend/integration-tests/tests/olm/update-channel-approval.scenario.ts
+++ b/frontend/integration-tests/tests/olm/update-channel-approval.scenario.ts
@@ -28,6 +28,7 @@ describe('Manually approving an install plan', () => {
 
   it('removes existing subscription if necessary', async() => {
     await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
+    await catalogView.clickCatalogsTab();
     await catalogView.isLoaded();
 
     if (await catalogView.hasSubscription(pkgName)) {
@@ -41,6 +42,7 @@ describe('Manually approving an install plan', () => {
 
   it('creates a subscription with a `startingCSV` that is not latest and manual approval strategy', async() => {
     await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
+    await catalogView.clickCatalogsTab();
     await catalogView.isLoaded();
     await catalogView.entryRowFor(pkgName).element(by.buttonText('Create Subscription')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -50,6 +52,7 @@ describe('Manually approving an install plan', () => {
     await $('#save-changes').click();
     await crudView.isLoaded();
     await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
+    await catalogView.clickCatalogsTab();
     await catalogView.isLoaded();
 
     expect(catalogView.hasSubscription(pkgName)).toBe(true);

--- a/frontend/integration-tests/tests/performance.scenario.ts
+++ b/frontend/integration-tests/tests/performance.scenario.ts
@@ -90,7 +90,7 @@ describe('Performance test', () => {
       // Avoid problems where the Catalog nav section appears where Workloads was at the moment the tests try to click.
       await browser.wait(until.visibilityOf(sidenavView.navSectionFor('Catalog')));
       await sidenavView.clickNavLink([route.section, route.name]);
-      await crudView.isLoaded();
+      await browser.wait(crudView.untilNoLoadersPresent);
 
       const routeChunk = await browser.executeScript<PerformanceEntry>(routeChunkFor, routeName);
 

--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -25,8 +25,15 @@ export const resourceRows = $$('.co-resource-list__item');
 export const resourceRowNamesAndNs = $$('.co-m-resource-icon + a');
 export const rowForName = (name: string) => resourceRows.filter((row) => row.$$('.co-m-resource-icon + a').first().getText().then(text => text === name)).first();
 export const rowForOperator = (name: string) => resourceRows.filter((row) => row.$('.co-clusterserviceversion-logo__name__clusterserviceversion').getText().then(text => text === name)).first();
-export const navTabs = $$('.co-m-horizontal-nav__menu-item > a');
-export const navTabFor = (name: string) => navTabs.filter((tab) => tab.getText().then(text => text === name)).first();
+
+const navMenu = $('.co-m-horizontal-nav__menu');
+const isNavLoaded = () => browser.wait(until.presenceOf(navMenu));
+export const navTabFor = (name: string) => navMenu.element(by.linkText(name));
+export const clickTab = async(name: string) => {
+  await isNavLoaded();
+  await navTabFor(name).click();
+};
+
 
 export const labelsForRow = (name: string) => rowForName(name).$$('.co-m-label');
 export const textFilter = $('.co-m-pane__filter-bar-group--filter input');

--- a/frontend/integration-tests/views/olm-catalog.view.ts
+++ b/frontend/integration-tests/views/olm-catalog.view.ts
@@ -10,6 +10,8 @@ export const entryRowFor = (name: string) => element(by.cssContainingText(rowSel
 
 export const isLoaded = () => browser.wait(until.presenceOf($('.loading-box__loaded')), 10000).then(() => browser.sleep(500));
 
+export const clickCatalogsTab = () => crudView.clickTab('Operator Catalogs');
+
 export const hasSubscription = (name: string) => browser.getCurrentUrl().then(url => {
   if (url.indexOf('all-namespaces') > -1) {
     throw new Error('Cannot call `hasSubscription` for all namespaces');

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -197,8 +197,10 @@ export const FireMan_ = connect(null, {filterList: k8sActions.filterList})(
       const {title} = this.props;
       return <React.Fragment>
         {title && <PageHeading title={title} />}
-        <div className={classNames('co-m-pane__filter-bar', {'co-m-pane__filter-bar--with-help-text': helpText})}>
-          {helpText && <div className={classNames('co-m-pane__filter-bar-group', {'co-m-pane__filter-bar-group--help-text': helpText})}>
+        {/* Show help text above the filter bar if there's a create button. */}
+        {helpText && createLink && <p className="co-m-pane__help-text co-help-text">{helpText}</p>}
+        <div className={classNames('co-m-pane__filter-bar', {'co-m-pane__filter-bar--with-help-text': helpText && !createLink})}>
+          {helpText && !createLink && <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--help-text">
             {helpText}
           </div>}
           {createLink && <div className="co-m-pane__filter-bar-group">

--- a/frontend/public/components/modals/disable-application-modal.tsx
+++ b/frontend/public/components/modals/disable-application-modal.tsx
@@ -46,7 +46,7 @@ export class DisableApplicationModal extends PromiseComponent {
     const {name} = this.props.subscription.spec;
 
     return <form onSubmit={this.submit.bind(this)} name="form" className="modal-content co-catalog-install-modal">
-      <ModalTitle className="modal-header">Remove Subscription</ModalTitle>
+      <ModalTitle className="modal-header">Remove Operator Subscription</ModalTitle>
       <ModalBody>
         <div>
           <p>

--- a/frontend/public/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-subscribe.tsx
@@ -246,7 +246,9 @@ export const OperatorHubSubscribePage: React.SFC<OperatorHubSubscribePageProps> 
   </Helmet>
   <div>
     <h1>Create Operator Subscription</h1>
-    <p className="co-help-text">Keep your service up to date by subscribing to a channel and update strategy from which to pull updates.</p>
+    <p className="co-help-text">
+      Keep your service up to date by selecting a channel and approval strategy. The strategy determines either manual or automatic updates.
+    </p>
   </div>
   <Firehose resources={[{
     isList: true,

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -88,9 +88,10 @@ export const SubscriptionsPage: React.SFC<SubscriptionsPageProps> = (props) => {
     ]}
     flatten={resources => _.get(resources.subscription, 'data', [])}
     title="Subscriptions"
+    helpText="Operator Subscriptions keep your services up to date by tracking a channel in a package. The approval strategy determines either manual or automatic updates."
     showTitle={false}
     canCreate={true}
-    createProps={{to: namespace ? `/operatormanagement/ns/${namespace}` : '/operatormanagement/all-namespaces'}}
+    createProps={{to: namespace ? `/operatormanagement/ns/${namespace}/catalogsources` : '/operatormanagement/all-namespaces/catalogsources'}}
     createButtonText="Create Subscription"
     ListComponent={SubscriptionsList}
     filterLabel="Subscriptions by package" />;

--- a/frontend/public/components/operator-management.tsx
+++ b/frontend/public/components/operator-management.tsx
@@ -6,12 +6,12 @@ import {InstallPlansPage} from './operator-lifecycle-manager/install-plan';
 
 const pages = [{
   href: '',
-  name: 'Operator Catalogs',
-  component: PackageManifestsPage,
-}, {
-  href: 'subscriptions',
   name: 'Operator Subscriptions',
   component: SubscriptionsPage,
+}, {
+  href: 'catalogsources',
+  name: 'Operator Catalogs',
+  component: PackageManifestsPage,
 }, {
   href: 'installplans',
   name: 'Install Plans',

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -22,12 +22,6 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  margin: 20px ($grid-gutter-width / 2);
-  @media (min-width: $grid-float-breakpoint) {
-    margin-left: $grid-gutter-width;
-    margin-right: $grid-gutter-width;
-    margin-top: $grid-gutter-width;
-  }
   &--alt {
     margin-left: 0;
     margin-right: 0;
@@ -51,6 +45,16 @@
   .btn-group {
     margin-right: 10px;
     min-width: 0; // enables truncation of selected item, if needed
+  }
+}
+
+.co-m-pane__filter-bar,
+.co-m-pane__help-text {
+  margin: 20px ($grid-gutter-width / 2);
+  @media (min-width: $grid-float-breakpoint) {
+    margin-left: $grid-gutter-width;
+    margin-right: $grid-gutter-width;
+    margin-top: $grid-gutter-width;
   }
 }
 


### PR DESCRIPTION
* Make Subscriptions first tab under Operator Management
* Add help text to top of Subscriptions page
* Change modal title to "Remove Operator Subscription"
* Update help text on Create Operator Subscription page

/assign @rhamilto 
cc @alecmerdler @tlwu2013 @jwforres 

![localhost_9000_](https://user-images.githubusercontent.com/1167259/56038026-de262080-5cfe-11e9-96fd-0ff15a01e261.png)

![localhost_9000_ (1)](https://user-images.githubusercontent.com/1167259/56038032-e1b9a780-5cfe-11e9-9264-d1f70754ad28.png)

![localhost_9000_ (2)](https://user-images.githubusercontent.com/1167259/56038037-e67e5b80-5cfe-11e9-8bd5-eb2eb88d7406.png)


