### PR TITLE
Cluster Settings updates

### DIFF
--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -4,3 +4,7 @@
   padding: 0 8px; // so sizing is consistent with .pf-c-dropdown__toggle
   text-overflow: ellipsis;
 }
+
+.co-update-icon svg {
+  color: $color-pf-blue-400;
+}

--- a/frontend/public/components/cluster-settings/_cluster-settings.scss
+++ b/frontend/public/components/cluster-settings/_cluster-settings.scss
@@ -5,3 +5,7 @@
     width: 100%;
   }
 }
+
+.co-update-status {
+  padding-bottom: 5px;
+}

--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -35,14 +35,13 @@ const getIconClass = (status: OperatorStatus) => {
     [OperatorStatus.Available]: 'pficon pficon-ok text-success',
     [OperatorStatus.Updating]: 'fa fa-refresh',
     [OperatorStatus.Failing]: 'pficon pficon-error-circle-o text-danger',
+    [OperatorStatus.Unknown]: 'pficon pficon-unknown',
   }[status];
 };
 
 const OperatorStatusIconAndLabel: React.SFC<OperatorStatusIconAndLabelProps> = ({status}) => {
   const iconClass = getIconClass(status);
-  return status === OperatorStatus.Unknown
-    ? <span className="text-muted">Unknown</span>
-    : <React.Fragment><i className={iconClass} aria-hidden="true" /> {status}</React.Fragment>;
+  return <React.Fragment><i className={iconClass} aria-hidden="true" /> {status}</React.Fragment>;
 };
 
 const ClusterOperatorHeader = props => <ListHeader>

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -16,7 +16,7 @@ const UpdatesAvailableButton = ({obj, onClick}) => {
   const updatesAvailable = !_.isEmpty(getAvailableClusterUpdates(obj.data));
   return updatesAvailable
     ? <ToolbarItem>
-      <Button variant="plain" aria-label="Cluster Updates Available" onClick={onClick}>
+      <Button className="co-update-icon" variant="plain" aria-label="Cluster Updates Available" onClick={onClick}>
         <ArrowCircleUpIcon />
       </Button>
     </ToolbarItem>

--- a/frontend/public/components/modals/cluster-channel-modal.tsx
+++ b/frontend/public/components/modals/cluster-channel-modal.tsx
@@ -46,8 +46,11 @@ class ClusterChannelModal extends PromiseComponent {
     return <form onSubmit={this._submit} name="form" className="modal-content modal-content--no-inner-scroll">
       <ModalTitle>Update Channel</ModalTitle>
       <ModalBody>
+        <p>
+          Select a channel that reflects your desired version. Critical security updates will be delivered to any vulnerable channels.
+        </p>
         <div className="form-group">
-          <label htmlFor="channel_dropdown">Channel</label>
+          <label htmlFor="channel_dropdown">Select Channel</label>
           <Dropdown
             className="cluster-channel-modal__dropdown"
             id="channel_dropdown"
@@ -58,7 +61,7 @@ class ClusterChannelModal extends PromiseComponent {
           />
         </div>
       </ModalBody>
-      <ModalSubmitFooter errorMessage={this.state.errorMessage} inProgress={this.state.inProgress} submitText="Update" cancel={this._cancel} />
+      <ModalSubmitFooter errorMessage={this.state.errorMessage} inProgress={this.state.inProgress} submitText="Save" cancel={this._cancel} />
     </form>;
   }
 }

--- a/frontend/public/components/modals/cluster-update-modal.tsx
+++ b/frontend/public/components/modals/cluster-update-modal.tsx
@@ -46,6 +46,7 @@ class ClusterUpdateModal extends PromiseComponent {
 
   render() {
     const {cv} = this.props;
+    const {selectedVersion} = this.state;
     const availableUpdates = getAvailableClusterUpdates(cv);
     const currentVersion = getDesiredClusterVersion(cv);
     const dropdownItems = _.map(availableUpdates, 'version');
@@ -60,12 +61,13 @@ class ClusterUpdateModal extends PromiseComponent {
           <p>{currentVersion}</p>
         </div>
         <div className="form-group">
-          <label htmlFor="version_dropdown">New Version</label>
+          <label htmlFor="version_dropdown">Select New Version</label>
           <Dropdown
             className="cluster-update-modal__dropdown"
             id="version_dropdown"
             items={dropdownItems}
             onChange={this._change}
+            selectedKey={selectedVersion}
             title="Select Version"
           />
         </div>

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 
 import { ClusterVersionModel } from '../../models';
 import { referenceForModel } from './k8s';
-import { ClusterVersionKind, ClusterUpdate, ClusterVersionConditionType, K8sResourceConditionStatus, ClusterVersionCondition } from '.';
+import { ClusterVersionKind, ClusterUpdate, ClusterVersionConditionType, K8sResourceConditionStatus, ClusterVersionCondition, UpdateHistory } from '.';
 
 export enum ClusterUpdateStatus {
   UpToDate = 'Up to Date',
@@ -23,6 +23,12 @@ export const getAvailableClusterChannels = () => ({'nightly-4.1': 'nightly-4.1',
 
 export const getDesiredClusterVersion = (cv: ClusterVersionKind): string => {
   return _.get(cv, 'status.desired.version');
+};
+
+export const getLastCompletedUpdate = (cv: ClusterVersionKind): string => {
+  const history: UpdateHistory[] = _.get(cv, 'status.history', []);
+  const lastCompleted: UpdateHistory = history.find(update => update.state === 'Completed');
+  return lastCompleted && lastCompleted.version;
 };
 
 export const getClusterVersionCondition = (cv: ClusterVersionKind, type: ClusterVersionConditionType, status: K8sResourceConditionStatus = undefined): ClusterVersionCondition => {

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -242,7 +242,7 @@ export type ClusterUpdate = {
   version: string;
 };
 
-type UpdateHistory = {
+export type UpdateHistory = {
   state: 'Completed' | 'Partial';
   startedTime: string;
   completionTime: string;

--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -18,3 +18,7 @@
 .alert-pending {
   color: $color-pf-orange-300;
 }
+
+.update-pending {
+  color: $color-pf-blue-400;
+}


### PR DESCRIPTION
Initial round of visual changes.

Hint for first-time users and About Modal updates will be added in separate PRs.

Fixes part of [CONSOLE-1343](https://jira.coreos.com/browse/CONSOLE-1343).

**Message fades out on line 2:**
<img width="1074" alt="Screen Shot 2019-04-12 at 3 14 03 PM" src="https://user-images.githubusercontent.com/7014965/56060719-a4244100-5d35-11e9-8776-742150d4a121.png">

**Up to Date:**
<img width="657" alt="Screen Shot 2019-04-12 at 4 43 49 PM" src="https://user-images.githubusercontent.com/7014965/56065200-2e72a200-5d42-11e9-8360-6f020aca7549.png">

**Update Available:**
<img width="661" alt="Screen Shot 2019-04-12 at 4 36 03 PM" src="https://user-images.githubusercontent.com/7014965/56064814-1e0df780-5d41-11e9-9c42-9a90596b54bb.png">

**Updating:**
Used junk data for message in this screenshot since I can't simulate an update. It should show the real updating message instead.

<img width="646" alt="Screen Shot 2019-04-12 at 4 25 36 PM" src="https://user-images.githubusercontent.com/7014965/56064300-b4411e00-5d3f-11e9-8fb7-d38ea67f6a3a.png">

**Error Retrieving:**
<img width="651" alt="Screen Shot 2019-04-12 at 4 41 05 PM" src="https://user-images.githubusercontent.com/7014965/56065066-ccb23800-5d41-11e9-9cde-f627e7d9dc6b.png">

**Failing:**
<img width="654" alt="Screen Shot 2019-04-12 at 4 59 25 PM" src="https://user-images.githubusercontent.com/7014965/56065968-5ebb4000-5d44-11e9-995e-399e1120a623.png">

**Edit Channel Modal:**
<img width="623" alt="Screen Shot 2019-04-12 at 3 22 33 PM" src="https://user-images.githubusercontent.com/7014965/56061225-d2eee700-5d36-11e9-82fd-3b5dbc5f6921.png">

**Update Cluster Modal:**
I filled in junk/test data for this screenshot so the dropdown is populated. We don't have release notes yet, so we have to leave out the description in the modal for now.

<img width="630" alt="Screen Shot 2019-04-12 at 4 14 46 PM" src="https://user-images.githubusercontent.com/7014965/56063748-2284e100-5d3e-11e9-815c-f8c8238ae363.png">

**Navbar when updates are available:**
Icons were already this style (different from design guide). Happy to swap out for the other style, but I think we'd need to switch out all the circle icons for that.

<img width="1359" alt="Screen Shot 2019-04-12 at 2 34 22 PM" src="https://user-images.githubusercontent.com/7014965/56061601-dfc00a80-5d37-11e9-9a10-cfd9e6bc9031.png">