### PR TITLE
More Safety Around Accessing InstallPlan Status

### DIFF
--- a/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
+++ b/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
@@ -37,16 +37,18 @@ describe('Subscribing to an Operator from OperatorHub', () => {
 
   it('displays Couchbase Operator operator when filter "Couchbase" is active', async() => {
     await catalogPageView.clickFilterCheckbox('provider-couchbase');
+    await browser.wait(until.visibilityOf(catalogPageView.catalogTileById('couchbase-enterprise-certified-openshift-marketplace')));
 
-    expect(catalogPageView.catalogTileById('couchbase-enterprise-openshift-marketplace').isDisplayed()).toBe(true);
+    expect(catalogPageView.catalogTiles.count()).toEqual(1);
 
     await catalogPageView.clickFilterCheckbox('provider-couchbase');
   });
 
   it('does not display Couchbase Operator operator when filter "Red Hat" is active', async() => {
     await catalogPageView.clickFilterCheckbox('provider-red-hat');
+    await browser.wait(until.invisibilityOf(catalogPageView.catalogTileById('couchbase-enterprise-certified-openshift-marketplace')));
 
-    expect(catalogPageView.catalogTileById('couchbase-enterprise-openshift-marketplace').isPresent()).toBe(false);
+    expect(catalogPageView.catalogTiles.count()).toBeGreaterThan(1);
 
     await catalogPageView.clickFilterCheckbox('provider-red-hat');
   });

--- a/frontend/integration-tests/views/catalog-page.view.ts
+++ b/frontend/integration-tests/views/catalog-page.view.ts
@@ -1,8 +1,7 @@
-import { $, $$ } from 'protractor';
+import { $, $$, element, by } from 'protractor';
 
 export const catalogTiles = $$('.catalog-tile-pf');
-export const catalogTileFor = (name: string) => catalogTiles.filter((tile) => tile.$('.catalog-tile-pf-title').getText()
-  .then(text => text === name)).first();
+export const catalogTileFor = (name: string) => element(by.cssContainingText('.catalog-tile-pf-title', name));
 export const catalogTileById = (id: string) => $(`[data-test=${id}]`);
 
 // FilterSidePanel views

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -164,7 +164,7 @@ export class SubscriptionUpdates extends React.Component<SubscriptionUpdatesProp
     const channelModal = () => createSubscriptionChannelModal({subscription: obj, pkg, k8sUpdate: k8sUpdateAndWait});
     const approvalModal = () => createInstallPlanApprovalModal({obj, k8sUpdate: k8sUpdateAndWait});
     const installPlanPhase = (installPlan: InstallPlanKind) => {
-      switch (installPlan.status.phase) {
+      switch (_.get(installPlan, 'status.phase') as InstallPlanPhase) {
         case InstallPlanPhase.InstallPlanPhaseRequiresApproval: return '1 requires approval';
         case InstallPlanPhase.InstallPlanPhaseFailed: return '1 failed';
         default: return '1 installing';


### PR DESCRIPTION
### Description

It's possible for the `status` of an `InstallPlan` to not exist yet.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1696074