### PR TITLE
Add new alert class to have a max-height and enable overflow-y to be scrollable

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -352,7 +352,7 @@ export const EditYAML = connect(stateToProps)(
                   <div className="full-width-and-height yaml-editor__flexbox">
                     <div id={this.id} key={this.id} className={classNames('yaml-editor__acebox', {'yaml-editor__acebox--readonly': readOnly})} />
                     <div className="yaml-editor__buttons">
-                      {error && <p className="alert alert-danger"><span className="pficon pficon-error-circle-o"></span>{error}</p>}
+                      {error && <p className="alert alert-danger co-alert"><span className="pficon pficon-error-circle-o"></span>{error}</p>}
                       {success && <p className="alert alert-success"><span className="pficon pficon-ok"></span>{success}</p>}
                       {stale && <p className="alert alert-info">
                         <span className="pficon pficon-info"></span>This object has been updated. Click reload to see the new version.

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -1,3 +1,12 @@
+.co-alert {
+  max-height: 75px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  @media (min-height: $screen-sm-min) {
+    max-height: 150px;
+  }
+}
+
 .co-m-pane__body {
   border-bottom: 1px solid $color-grey-background-border;
   margin: $grid-gutter-width 0 0;


### PR DESCRIPTION
Prevents long error messages from rendering yaml editor unusable

https://jira.coreos.com/browse/CONSOLE-1348

<img width="644" alt="Screen Shot 2019-04-16 at 3 49 16 PM" src="https://user-images.githubusercontent.com/1874151/56244138-31370500-606a-11e9-9ca8-a223df798469.png">
