### PR TITLE
Enable sysevent__message to be scrollable if msg content exceeds 150px

### DIFF
--- a/frontend/public/components/_sysevent-stream.scss
+++ b/frontend/public/components/_sysevent-stream.scss
@@ -118,7 +118,11 @@ $color-dark-border: #ddd;
 
 .co-sysevent__message {
   @include co-break-word;
+  margin-right: -11px; // align with edge if scrollable area is visible (sysevent_box padding + border)
   margin-top: 10px;
+  max-height: 150px;
+  overflow-y: auto;
+  padding-right: 11px;
   position: relative;
 }
 


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-1346

In the cases where event messages are long, set a `max-height` and make scrollable

<img width="899" alt="Screen Shot 2019-04-17 at 11 06 03 AM" src="https://user-images.githubusercontent.com/1874151/56300016-25e3e800-6103-11e9-8d6f-4fee0a58643d.png">

<img width="340" alt="Screen Shot 2019-04-17 at 11 03 15 AM" src="https://user-images.githubusercontent.com/1874151/56300025-28ded880-6103-11e9-90ad-596cc7dfd921.png">
