### PR TITLE
Fix OperatorHub Subscribe for SingleNamespace Mode

### DIFF
--- a/frontend/__tests__/components/modals/disable-application-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/disable-application-modal.spec.tsx
@@ -45,7 +45,7 @@ describe(DisableApplicationModal.name, () => {
 
   it('renders checkbox for setting cascading delete', () => {
     expect(wrapper.find('.co-delete-modal-checkbox-label').find('input').props().checked).toBe(true);
-    expect(wrapper.find('.co-delete-modal-checkbox-label').text()).toContain('Also completely remove the test-package Operator from the selected namespace.');
+    expect(wrapper.find('.co-delete-modal-checkbox-label').text()).toContain('Also completely remove the Operator from the selected namespace.');
   });
 
   it('calls `props.k8sKill` to delete the subscription when form is submitted', (done) => {

--- a/frontend/public/components/modals/disable-application-modal.tsx
+++ b/frontend/public/components/modals/disable-application-modal.tsx
@@ -56,7 +56,7 @@ export class DisableApplicationModal extends PromiseComponent {
         <div>
           <label className="co-delete-modal-checkbox-label">
             <input type="checkbox" checked={this.state.deleteCSV} onChange={() => this.setState({deleteCSV: !this.state.deleteCSV})} />
-            &nbsp;&nbsp; <strong>Also completely remove the <b>{name}</b> Operator from the selected namespace.</strong>
+            &nbsp;&nbsp; <strong>Also completely remove the Operator from the selected namespace.</strong>
           </label>
         </div>
       </ModalBody>

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -255,6 +255,7 @@ export const providedAPIsFor: ProvidedAPIsFor = csv => _.get(csv.spec, 'customre
 
 export const defaultChannelFor = (pkg: PackageManifestKind) => pkg.status.defaultChannel || pkg.status.channels[0].name;
 export const installModesFor = (pkg: PackageManifestKind) => (channel: string) => pkg.status.channels.find(ch => ch.name === channel).currentCSVDesc.installModes;
+export const supportedInstallModesFor = (pkg: PackageManifestKind) => (channel: string) => installModesFor(pkg)(channel).filter(({supported}) => supported);
 
 export const referenceForProvidedAPI = (desc: CRDDescription | APIServiceDefinition): GroupVersionKind => _.get(desc, 'group')
   ? referenceForGroupVersionKind((desc as APIServiceDefinition).group)(desc.version)(desc.kind)


### PR DESCRIPTION
### Description

Removes `getDerivedStateFromProps()` and simplifies the form state logic for `OperatorHubSubscribeForm`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1694571