### PR TITLE
Select Copied filter by default in CSV list

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -104,11 +104,12 @@ export const ClusterServiceVersionsPage = connect(stateToProps)((props: ClusterS
     Installed Operators are represented by Cluster Service Versions within this namespace. For more information, see the <ExternalLink href="https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/architecture.md" text="Operator Lifecycle Manager documentation" />. Or create an Operator and Cluster Service Version using the <ExternalLink href="https://github.com/operator-framework/operator-sdk" text="Operator SDK" />.
   </p>;
 
+  const allFilterValues = [CSVConditionReason.CSVReasonInstallSuccessful, CSVConditionReason.CSVReasonCopied];
   const rowFilters = [{
     type: 'clusterserviceversion-status',
-    selected: [CSVConditionReason.CSVReasonInstallSuccessful],
+    selected: allFilterValues,
     reducer: (csv: ClusterServiceVersionKind) => _.get(csv.status, 'reason'),
-    items: [CSVConditionReason.CSVReasonInstallSuccessful, CSVConditionReason.CSVReasonCopied].map(status => ({id: status, title: status})),
+    items: allFilterValues.map(status => ({id: status, title: status})),
   }];
 
   return <React.Fragment>


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1254

Unfortunately, there's no good default filter for both individual namespaces and all projects. I'd rather err on the side of not hiding the CSV when looking at things in a namespace, however. Copied items can still be filtered out easily enough when in all projects.

/assign @alecmerdler 
/cc @jwforres @robszumski 