### PR TITLE
Fix minor issue & inconsistency with sidebar details panel

### DIFF
--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -164,7 +164,6 @@
     bottom: 0;
     box-shadow: var(--pf-global--BoxShadow--md);
     display: none;
-    padding-bottom: 30px;
     position: absolute;
     right: 0;
     top: 0;
@@ -271,6 +270,7 @@
 .resource-overview {
   height: 100%;
   min-height: 0;
+  padding-bottom: 30px;
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/frontend/public/components/overview/daemon-set-overview.tsx
+++ b/frontend/public/components/overview/daemon-set-overview.tsx
@@ -13,7 +13,7 @@ import { OverviewItem } from '.';
 import { ResourceOverviewDetails } from './resource-overview-details';
 
 const DaemonSetOverviewDetails: React.SFC<DaemonSetOverviewDetailsProps> = ({item}) =>
-  <div className="co-m-pane__body resource-overview__body">
+  <div className="overview__sidebar-pane-body resource-overview__body">
     <div className="resource-overview__summary">
       <ResourceSummary resource={item.obj} showPodSelector showNodeSelector showTolerations />
     </div>


### PR DESCRIPTION
Move sidebar bottom padding to scrollable div
<img width="576" alt="Screen Shot 2019-04-18 at 1 36 22 PM" src="https://user-images.githubusercontent.com/1874151/56380161-644ed500-61df-11e9-8364-eb0341cf8748.png">
<img width="575" alt="Screen Shot 2019-04-18 at 1 35 55 PM" src="https://user-images.githubusercontent.com/1874151/56380162-66b12f00-61df-11e9-86b5-7c4f406286a8.png">

----
Add correct class to `resource-overview__body` for correct padding and align content correctly
<img width="271" alt="Screen Shot 2019-04-18 at 10 54 03 AM" src="https://user-images.githubusercontent.com/1874151/56380308-dc1cff80-61df-11e9-839b-7a6e072a6daf.png">
<img width="256" alt="Screen Shot 2019-04-18 at 11 49 44 AM" src="https://user-images.githubusercontent.com/1874151/56380311-dde6c300-61df-11e9-837a-16f9ab06a3e4.png">

