### PR TITLE
Add logic to default storage class checking

### DIFF
--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -12,7 +12,11 @@ const { common } = Kebab.factory;
 const menuActions = [...common];
 
 const defaultClassAnnotation = 'storageclass.kubernetes.io/is-default-class';
-const isDefaultClass = (storageClass: K8sResourceKind) => _.get(storageClass, ['metadata', 'annotations', defaultClassAnnotation], 'false');
+const betaDefaultStorageClassAnnotation = 'storageclass.beta.kubernetes.io/is-default-class';
+export const isDefaultClass = (storageClass: K8sResourceKind) => {
+  const annotations = _.get(storageClass, 'metadata.annotations') || {};
+  return annotations[defaultClassAnnotation] === 'true' || annotations[betaDefaultStorageClassAnnotation] === 'true';
+};
 
 const StorageClassHeader = props => <ListHeader>
   <ColHead {...props} className="col-sm-4 col-xs-6" sortField="metadata.name">Name</ColHead>
@@ -33,7 +37,7 @@ const StorageClassRow: React.SFC<StorageClassRowProps> = ({obj}) => {
       {obj.reclaimPolicy || '-'}
     </div>
     <div className="col-sm-2 hidden-xs">
-      {isDefaultClass(obj)}
+      {isDefaultClass(obj).toString()}
     </div>
     <div className="dropdown-kebab-pf">
       <ResourceKebab actions={menuActions} kind={StorageClassReference} resource={obj} />

--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import * as fuzzy from 'fuzzysearch';
 
 import { Firehose, LoadingInline, Dropdown, ResourceName, ResourceIcon } from '.';
+import { isDefaultClass } from '../storage-class';
 
 /* Component StorageClassDropdown - creates a dropdown list of storage classes */
 
@@ -41,13 +42,13 @@ class StorageClassDropdown_ extends React.Component<StorageClassDropdownProps, S
       defaultClass: '',
     };
     const unorderedItems = {};
-    const noStorageClass = 'No storage class';
+    const noStorageClass = 'No default storage class';
     _.map(resources.StorageClass.data, resource => {
       unorderedItems[resource.metadata.name] = {
         kindLabel: 'StorageClass',
         name: resource.metadata.name,
         description: _.get(resource, 'metadata.annotations.description', ''),
-        default: _.get(resource, ['metadata', 'annotations', 'storageclass.kubernetes.io/is-default-class']) === 'true',
+        default: isDefaultClass(resource),
         accessMode:  _.get(resource, ['metadata', 'annotations', 'storage.alpha.openshift.io/access-mode'], ''),
         provisioner: resource.provisioner,
         type: _.get(resource, 'parameters.type', ''),


### PR DESCRIPTION
When a storageclass is created with annotation `storageclass.beta.kubernetes.io/is-default-class: 'true'`, it also should be considered as `Default` storage class

Changes made:

- Updated `isDefaultClass` login to include new annotation `storageclass.beta.kubernetes.io/is-default-class`

- Changed text from `No storage class` to `No default storage class` when no Default storage class is detected

@zherman0  @spadgett  Can you help review? Thanks