### PR TITLE
Fix bug where expanded terminal is unusable on iOS

### DIFF
--- a/frontend/public/components/_terminal.scss
+++ b/frontend/public/components/_terminal.scss
@@ -29,3 +29,7 @@ $console-collapse-link-z-index: $console-z-index + 20;
   top: 4px;
   z-index: $console-collapse-link-z-index;  // in fullscreen mode, to get above console's z-index
 }
+
+.default-overflow {
+  overflow: visible !important;
+}

--- a/frontend/public/components/terminal.jsx
+++ b/frontend/public/components/terminal.jsx
@@ -36,11 +36,24 @@ export class Terminal extends React.Component {
     this.terminal && this.terminal.focus();
   }
 
+  enableiOSFix() {
+    document.getElementsByClassName('pf-c-page__main')[0].classList.add('default-overflow');
+    document.getElementById('content-scrollable').classList.add('default-overflow');
+  }
+
+  disableiOSFix() {
+    document.getElementsByClassName('pf-c-page__main')[0].classList.remove('default-overflow');
+    document.getElementById('content-scrollable').classList.remove('default-overflow');
+  }
+
   setFullscreen( fullscreen ) {
     this.terminal.toggleFullScreen(fullscreen);
     this.isFullscreen = fullscreen;
     this.focus();
     this.onResize();
+    // fix iOS bug where masthead overlays fullscreen terminal
+    // see https://bugs.webkit.org/show_bug.cgi?id=160953
+    fullscreen ? this.enableiOSFix() : this.disableiOSFix();
   }
 
   onConnectionClosed(reason) {


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1364

After:
![Screen Shot 2019-04-23 at 9 09 31 AM](https://user-images.githubusercontent.com/895728/56583435-8e214680-65a7-11e9-8c35-132c6f371ec9.png)

This is a bit hack-y, but I couldn't find a more robust way to work around the bug without more significant and riskier changes.