### PR TITLE
Generate icon based on model reference

### DIFF
--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -42,7 +42,7 @@ const blacklistResources = ImmutableSet([
 const DropdownItem: React.SFC<DropdownItemProps> = ({model, showGroup}) => <React.Fragment>
   <span className="co-resource-item">
     <span className="co-resource-icon--fixed-width">
-      <ResourceIcon kind={model.kind} />
+      <ResourceIcon kind={referenceForModel(model)} />
     </span>
     <span className="co-resource-item__resource-name">
       {model.kind}


### PR DESCRIPTION
Fixed differing icons between list view and search select dropdown.

Alertmanager:
<img width="1119" alt="Screen Shot 2019-04-23 at 1 51 39 PM" src="https://user-images.githubusercontent.com/7014965/56604004-fb949d80-65ce-11e9-8c4d-ca2c107b99dd.png">

OperatorSource:
<img width="1119" alt="Screen Shot 2019-04-23 at 1 51 48 PM" src="https://user-images.githubusercontent.com/7014965/56604011-00595180-65cf-11e9-8ffe-842d6b37a961.png">

Fixes [CONSOLE-1352](https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-1352).