### PR TITLE
Add cluster operator start guide

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 
 import { ClusterOperatorModel } from '../../models';
+import { StartGuide } from '../start-guide';
 import {
   ColHead,
   DetailsPage,
@@ -28,6 +29,7 @@ import {
   ResourceSummary,
   SectionHeading,
 } from '../utils';
+import { STORAGE_PREFIX } from '../../const';
 
 export const clusterOperatorReference: K8sResourceKindReference = referenceForModel(ClusterOperatorModel);
 
@@ -90,15 +92,26 @@ const filters = [{
   })),
 }];
 
+export const ClusterOperatorStartGuide: React.SFC<{}> = () =>
+  <React.Fragment>
+    <h4>What are Cluster Operators?</h4>
+    <p>
+      An Operator is a method of packaging, deploying, and managing a Kubernetes application. Cluster Operators implement and automate updates of OpenShift and Kubernetes at the cluster level. During an update, the latest versions of the OpenShift and Kubernetes components are downloaded. A rolling update will occur to install the latest versions.
+    </p>
+  </React.Fragment>;
+
 export const ClusterOperatorPage: React.SFC<ClusterOperatorPageProps> = props =>
-  <ListPage
-    {...props}
-    title="Cluster Operators"
-    kind={clusterOperatorReference}
-    ListComponent={ClusterOperatorList}
-    canCreate={false}
-    rowFilters={filters}
-  />;
+  <React.Fragment>
+    <StartGuide dismissKey={`${STORAGE_PREFIX}/seen-cluster-operator-guide`} startGuide={<ClusterOperatorStartGuide />} />
+    <ListPage
+      {...props}
+      title="Cluster Operators"
+      kind={clusterOperatorReference}
+      ListComponent={ClusterOperatorList}
+      canCreate={false}
+      rowFilters={filters}
+    />
+  </React.Fragment>;
 
 const OperandVersions: React.SFC<OperandVersionsProps> = ({versions}) => {
   return _.isEmpty(versions)

--- a/frontend/public/const.js
+++ b/frontend/public/const.js
@@ -19,7 +19,7 @@ export const EVENTS = {
 export const ALL_NAMESPACES_KEY = '#ALL_NS#';
 
 // Prefix our localStorage items to avoid conflicts if another app ever runs on the same domain.
-const STORAGE_PREFIX = 'bridge';
+export const STORAGE_PREFIX = 'bridge';
 
 // This localStorage key predates the storage prefix.
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -238,6 +238,18 @@
   @media (min-width: $screen-sm-min) {
     margin: $grid-gutter-width;
   }
+
+  .co-well__close-button {
+    float: right;
+  }
+
+  .co-well__close-button {
+    color: $color-pf-blue-600;
+  }
+
+  .co-well__close-button:hover, .co-well__close-button:active {
+    color: $color-pf-blue-400;
+  }
 }
 
 // Prevent iOS phones from zooming on form inputs


### PR DESCRIPTION
Added start guide per UX's design.

<img width="1096" alt="Screen Shot 2019-04-24 at 2 19 58 PM" src="https://user-images.githubusercontent.com/7014965/56684459-ca36d300-669d-11e9-943d-0980ad76400c.png">

Fixes [CONSOLE-1404](https://jira.coreos.com/browse/CONSOLE-1404).

@openshift/team-ux-review, can you please review? Thanks!