### PR TITLE
Move QuestionCircleIcon component in front of the help text

### DIFF
--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -234,7 +234,7 @@ const CustomRouteHelp: React.SFC<CustomRouteHelpProps> = ({host, routerCanonical
         as the alias.</p>
       </div>
     }>
-    <button className="btn btn-link btn-link--no-btn-default-values" type="button">Do you need to set up custom DNS? <QuestionCircleIcon /></button>
+    <button className="btn btn-link btn-link--no-btn-default-values" type="button"><QuestionCircleIcon /> Do you need to set up custom DNS?</button>
   </Popover>;
 
 const RouteIngressStatus: React.SFC<RouteIngressStatusProps> = ({ingresses, annotations}) =>


### PR DESCRIPTION
While working on "Image Stream Podman Commands" story I've noticed that in the designs the question mark icon is in front of the text, which makes more sense since the text ends with the question mark anyway.

Before:
![Screen Shot 2019-04-25 at 11 06 45](https://user-images.githubusercontent.com/1668218/56724314-0b38f100-674b-11e9-875a-e51ef135275d.png)

After:
![Screen Shot 2019-04-25 at 11 06 35](https://user-images.githubusercontent.com/1668218/56724315-0bd18780-674b-11e9-8228-62807733a239.png)


/assign @spadgett @dtaylor113 