### PR TITLE
Monitoring: Add PromQL query browser page

### DIFF
--- a/frontend/public/components/_monitoring.scss
+++ b/frontend/public/components/_monitoring.scss
@@ -51,3 +51,22 @@ $monitoring-line-height: 18px;
 .monitoring-state-icon--pending {
   color: $color-pf-black-700;
 }
+
+.group__body--query-browser {
+  padding-top: 20px;
+}
+
+.query-browser-metric__wrapper {
+  display: flex;
+}
+
+.query-browser-metric__color {
+  height: 20px;
+  margin: 2px 12px 2px 5px;
+  min-width: 20px;
+  width: 20px;
+}
+
+.query-browser-metric__labels {
+  word-break: break-word;
+}

--- a/frontend/public/components/graphs/query-browser.jsx
+++ b/frontend/public/components/graphs/query-browser.jsx
@@ -2,15 +2,14 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { addTraces, deleteTraces, relayout, restyle } from 'plotly.js/lib/core';
 
-import { connectToURLs, MonitoringRoutes } from '../../monitoring';
-import { Dropdown, ExternalLink, LoadingInline } from '../utils';
+import { Dropdown, LoadingInline } from '../utils';
 import { formatPrometheusDuration, parsePrometheusDuration } from '../utils/datetime';
 import { Line_ } from './line';
 
 const spans = ['5m', '15m', '30m', '1h', '2h', '6h', '12h', '1d', '2d', '1w', '2w'];
 const dropdownItems = _.zipObject(spans, spans);
 
-class QueryBrowser_ extends Line_ {
+export class QueryBrowser extends Line_ {
   constructor(props) {
     super(props);
 
@@ -29,6 +28,7 @@ class QueryBrowser_ extends Line_ {
     this.numTraces = 0;
 
     _.merge(this.layout, {
+      colorway: props.colors,
       dragmode: 'zoom',
       height: 200,
       hoverlabel: {
@@ -112,6 +112,16 @@ class QueryBrowser_ extends Line_ {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.query !== prevProps.query) {
+      this.setState({updating: true}, () => {
+        clearInterval(this.interval);
+        this.fetch();
+        this.relayout();
+      });
+    }
+  }
+
   updateGraph(data, error) {
     deleteTraces(this.node, _.range(this.numTraces));
     this.numTraces = 0;
@@ -167,13 +177,17 @@ class QueryBrowser_ extends Line_ {
         this.relayout({'xaxis.range': [start, end]});
       }
     }
+
+    if (_.isFunction(this.props.onDataUpdate)) {
+      this.props.onDataUpdate(this.data);
+    }
+
     this.setState({error, updating: false});
   }
 
   render() {
-    const {query, urls} = this.props;
+    const {GraphLink} = this.props;
     const {error, isSpanValid, spanText, updating} = this.state;
-    const baseUrl = urls[MonitoringRoutes.Prometheus];
 
     return <div className="query-browser__wrapper">
       <div className="query-browser__header">
@@ -200,7 +214,7 @@ class QueryBrowser_ extends Line_ {
           >Reset Zoom</button>
           {updating && <LoadingInline />}
         </div>
-        {baseUrl && query && <ExternalLink href={`${baseUrl}/graph?g0.expr=${encodeURIComponent(query)}&g0.tab=0`} text="View in Prometheus UI" />}
+        {GraphLink}
       </div>
       {error && <div className="alert alert-danger query-browser__error">
         <span className="pficon pficon-error-circle-o" aria-hidden="true"></span>{error.message}
@@ -209,4 +223,3 @@ class QueryBrowser_ extends Line_ {
     </div>;
   }
 }
-export const QueryBrowser = connectToURLs(MonitoringRoutes.Prometheus)(QueryBrowser_);

--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -301,6 +301,7 @@ const MonitoringNavSection_ = ({grafanaURL, canAccess, kibanaURL, prometheusURL}
     ? <NavSection title="Monitoring">
       {showAlerts && <HrefLink href="/monitoring/alerts" name="Alerts" startsWith={monitoringAlertsStartsWith} />}
       {showSilences && <HrefLink href="/monitoring/silences" name="Silences" />}
+      {showAlerts && <HrefLink href="/monitoring/query-browser" name="Query Browser" />}
       {showPrometheus && <ExternalLink href={prometheusURL} name="Metrics" />}
       {showGrafana && <ExternalLink href={grafanaURL} name="Dashboards" />}
       {kibanaURL && <ExternalLink href={kibanaURL} name="Logging" />}


### PR DESCRIPTION
Initial commit for the PromQL query browser page.

Displays a graph for any PromQL query. You can edit the query and the
graph will dynamically update.

You can zoom and drag the graph to view different time spans.

Shows the label keys and values for each time series plotted in the graph.

This PR aims to add the basic page functionality while minimizing conflicts with https://github.com/openshift/console/pull/1448. `QueryBrowser` will be reworked after that PR merges.

The styling in the PR is kept simple since the mocks are still being finalized.