### PR TITLE
Break long words in cluster operator messages

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -66,7 +66,7 @@ const ClusterOperatorRow: React.SFC<ClusterOperatorRowProps> = ({obj}) => {
     <div className="col-md-3 col-sm-3 hidden-xs">
       {operatorVersion || '-'}
     </div>
-    <div className="col-md-4 col-sm-3 hidden-xs">
+    <div className="col-md-4 col-sm-3 hidden-xs co-break-word co-pre-line">
       {message ? _.truncate(message, { length: 256, separator: ' ' }) : '-'}
     </div>
   </div>;


### PR DESCRIPTION
/assign @rhamilto @sg00dwin 

Before:

![Screen Shot 2019-04-25 at 11 50 00 AM](https://user-images.githubusercontent.com/1167259/56750026-e0ea3200-6750-11e9-9262-b63dd961aa8a.png)

After:

![Screen Shot 2019-04-25 at 11 55 13 AM](https://user-images.githubusercontent.com/1167259/56750077-0414e180-6751-11e9-8693-8193709df22d.png)


