### PR TITLE
frontend/public/module/k8s/cluster-settings: "pre-release" -> "prerelease"

### DIFF
--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -19,7 +19,7 @@ export const getAvailableClusterUpdates = (cv: ClusterVersionKind): ClusterUpdat
   return _.get(cv, 'status.availableUpdates', []);
 };
 
-export const getAvailableClusterChannels = () => ({'nightly-4.1': 'nightly-4.1', 'pre-release-4.1': 'pre-release-4.1', 'stable-4.1': 'stable-4.1'});
+export const getAvailableClusterChannels = () => ({'nightly-4.1': 'nightly-4.1', 'prerelease-4.1': 'prerelease-4.1', 'stable-4.1': 'stable-4.1'});
 
 export const getDesiredClusterVersion = (cv: ClusterVersionKind): string => {
   return _.get(cv, 'status.desired.version');


### PR DESCRIPTION
@smarterclayton is tagging with the latter, so follow along :).  CC @spadgett (following up on #1419).