### PR TITLE
Fix bug 1703773 - show default class correctly on details

### DIFF
--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -59,7 +59,7 @@ const StorageClassDetails: React.SFC<StorageClassDetailsProps> = ({obj}) => <Rea
         <dt>Reclaim Policy</dt>
         <dd>{obj.reclaimPolicy || '-'}</dd>
         <dt>Default Class</dt>
-        <dd>{isDefaultClass(obj)}</dd>
+        <dd>{isDefaultClass(obj).toString()}</dd>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fix `Default Class` value on storage class details page, I'm sorry changes were missed in #1473 

