### PR TITLE
Bug 1703891: Avoid runtime errors when no kind is passed to `ResourceLink`

### DIFF
--- a/frontend/public/components/utils/resource-link.jsx
+++ b/frontend/public/components/utils/resource-link.jsx
@@ -58,8 +58,8 @@ export const resourcePath = (kind, name, namespace) => {
 export const resourceObjPath = (obj, kind) => resourcePath(kind, _.get(obj, 'metadata.name'), _.get(obj, 'metadata.namespace'));
 
 export const ResourceLink = connectToModel(
-  ({className, displayName, inline = false, kind, kindsInFlight, linkTo = true, name, namespace, hideIcon, title}) => {
-    if (!kind && kindsInFlight) {
+  ({className, displayName, inline = false, kind, linkTo = true, name, namespace, hideIcon, title}) => {
+    if (!kind) {
       return null;
     }
     const path = resourcePath(kind, name, namespace);


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1703891

/assign @jhadvig 