### PR TITLE
Bug 1703954: Fix subscriptions link in catalog list

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/package-manifest.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/package-manifest.spec.tsx
@@ -7,7 +7,6 @@ import * as _ from 'lodash-es';
 
 import { PackageManifestHeader, PackageManifestHeaderProps, PackageManifestRow, PackageManifestRowProps, PackageManifestList, PackageManifestListProps } from '../../../public/components/operator-lifecycle-manager/package-manifest';
 import { ClusterServiceVersionLogo, PackageManifestKind } from '../../../public/components/operator-lifecycle-manager';
-import { SubscriptionModel } from '../../../public/models';
 import { ListHeader, ColHead, List, ListInnerProps } from '../../../public/components/factory';
 import { testPackageManifest, testCatalogSource, testSubscription } from '../../../__mocks__/k8sResourcesMocks';
 
@@ -54,7 +53,7 @@ describe(PackageManifestRow.displayName, () => {
   });
 
   it('renders column with link to subscriptions', () => {
-    expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).at(0).props().to).toEqual(`/operatormanagement/ns/default/${SubscriptionModel.plural}?name=${testSubscription.metadata.name}`);
+    expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).at(0).props().to).toEqual(`/operatormanagement/ns/default?name=${testSubscription.metadata.name}`);
     expect(wrapper.find('.co-resource-list__item').childAt(2).find(Link).at(0).childAt(0).text()).toEqual('View');
   });
 

--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -26,8 +26,8 @@ export const PackageManifestRow: React.SFC<PackageManifestRowProps> = (props) =>
   const {displayName, icon = [], version, provider} = channel.currentCSVDesc;
 
   const subscriptionLink = () => ns !== ALL_NAMESPACES_KEY
-    ? <Link to={`/operatormanagement/ns/${ns}/${SubscriptionModel.plural}?name=${subscription.metadata.name}`}>View<span className="visible-lg-inline"> subscription</span></Link>
-    : <Link to={`/operatormanagement/all-namespaces/${SubscriptionModel.plural}?name=${obj.metadata.name}`}>View<span className="visible-lg-inline"> subscriptions</span></Link>;
+    ? <Link to={`/operatormanagement/ns/${ns}?name=${subscription.metadata.name}`}>View<span className="visible-lg-inline"> subscription</span></Link>
+    : <Link to={`/operatormanagement/all-namespaces?name=${obj.metadata.name}`}>View<span className="visible-lg-inline"> subscriptions</span></Link>;
 
   const createSubscriptionLink = () => `/k8s/ns/${ns === ALL_NAMESPACES_KEY ? defaultNS : ns}/${SubscriptionModel.plural}/~new?pkg=${obj.metadata.name}&catalog=${catalogSourceName}&catalogNamespace=${catalogSourceNamespace}`;
 


### PR DESCRIPTION
This was a regression from #1421 where the URLs changed when the tab order changed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1703954

/cc @rhamilto @alecmerdler 