### PR TITLE
Bug 1704710: fix double memory accounting in top pods chart

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -188,7 +188,7 @@ export const TopPodsBarChart = ({ns}) => (
   <Bar
     title="Memory Usage by Pod (Top 10)"
     namespace={ns.metadata.name}
-    query={`sort(topk(10, sum by (pod_name)(container_memory_usage_bytes{pod_name!="", namespace="${ns.metadata.name}"})))`}
+    query={`sort(topk(10, sum by (pod_name)(container_memory_usage_bytes{container_name!="POD",container_name!="",pod_name!="", namespace="${ns.metadata.name}"})))`}
     humanize={humanizeMem}
     metric="pod_name" />
 );


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1704710

/assign @brancz 
/cc @kyoto 

Applies the same fix to console as https://github.com/coreos/prometheus-operator/pull/2528