### PR TITLE
Fix bug where long usernames in user dropdown do not truncate

### DIFF
--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -1,5 +1,5 @@
 .co-username {
-  max-width: 230px; // PF4 does not limit username length (upstream bug)
+  max-width: 225px !important; // PF4 does not limit username length (upstream bug)
   overflow-x: hidden;
   padding: 0 8px; // so sizing is consistent with .pf-c-dropdown__toggle
   text-overflow: ellipsis;

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -243,7 +243,7 @@ class MastheadToolbar_ extends React.Component {
         position="right"
         onSelect={this._onUserDropdownSelect}
         isOpen={isUserDropdownOpen}
-        toggle={<DropdownToggle onToggle={this._onUserDropdownToggle}>{username}</DropdownToggle>}
+        toggle={<DropdownToggle className="co-username" onToggle={this._onUserDropdownToggle}>{username}</DropdownToggle>}
         dropdownItems={this._renderMenuItems(actions)}
       />
     );


### PR DESCRIPTION
Before:
![Screen Shot 2019-04-30 at 10 42 19 AM](https://user-images.githubusercontent.com/895728/56970275-ca6b1e80-6b34-11e9-862c-40c2fa01ccca.png)

After:
![Screen Shot 2019-04-30 at 10 39 23 AM](https://user-images.githubusercontent.com/895728/56970286-d060ff80-6b34-11e9-9281-52d2c0f6c8f3.png)
