### PR TITLE
Tweak cluster settings page

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import { ClusterOperatorPage } from './cluster-operator';
 import { clusterChannelModal, clusterUpdateModal } from '../modals';
 import { GlobalConfigPage } from './global-config';
-import { ClusterAutoscalerModel } from '../../models';
+import { ClusterAutoscalerModel, ClusterVersionModel } from '../../models';
 import {
   ClusterUpdateStatus,
   ClusterVersionCondition,
@@ -124,6 +124,9 @@ const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = (
   const isFailingCondition = getClusterVersionCondition(cv, ClusterVersionConditionType.Failing, K8sResourceConditionStatus.True);
   const updatingCondition = getClusterVersionCondition(cv, ClusterVersionConditionType.Progressing, K8sResourceConditionStatus.True);
   const updatesAvailable = !_.isEmpty(getAvailableClusterUpdates(cv));
+  const desiredImage: string = _.get(cv, 'status.desired.image') || '';
+  // Split image on `@` to emphasize the digest.
+  const imageParts = desiredImage.split('@');
 
   return <React.Fragment>
     <div className="co-m-pane__body">
@@ -160,7 +163,15 @@ const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = (
           <dt>Cluster ID</dt>
           <dd className="co-break-all">{cv.spec.clusterID}</dd>
           <dt>Desired Release Image</dt>
-          <dd className="co-break-all">{_.get(cv, 'status.desired.image') || '-'}</dd>
+          <dd>
+            {imageParts.length === 2
+              ? <React.Fragment><span className="text-muted">{imageParts[0]}@</span>{imageParts[1]}</React.Fragment>
+              : desiredImage || '-'}
+          </dd>
+          <dt>Cluster Version Configuration</dt>
+          <dd>
+            <ResourceLink kind={referenceForModel(ClusterVersionModel)} name={cv.metadata.name} />
+          </dd>
           <dt>Cluster Autoscaler</dt>
           <dd>
             {_.isEmpty(autoscalers)

--- a/frontend/public/components/cluster-settings/cluster-version.tsx
+++ b/frontend/public/components/cluster-settings/cluster-version.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable no-unused-vars, no-undef */
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import { ClusterVersionModel } from '../../models';
+import { DetailsPage } from '../factory';
+import { Conditions } from '../conditions';
+import {
+  ClusterVersionKind,
+  K8sResourceKindReference,
+  referenceForModel,
+} from '../../module/k8s';
+import {
+  navFactory,
+  ResourceSummary,
+  SectionHeading,
+} from '../utils';
+
+const clusterVersionReference: K8sResourceKindReference = referenceForModel(ClusterVersionModel);
+
+const ClusterVersionDetails: React.SFC<ClusterVersionDetailsProps> = ({obj}) => {
+  const conditions = _.get(obj, 'status.conditions', []);
+  return (
+    <React.Fragment>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Cluster Version Overview" />
+        <ResourceSummary resource={obj} />
+      </div>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Conditions" />
+        <Conditions conditions={conditions} />
+      </div>
+    </React.Fragment>
+  );
+};
+
+export const ClusterVersionDetailsPage: React.SFC<ClusterVersionDetailsPageProps> = props =>
+  <DetailsPage
+    {...props}
+    kind={clusterVersionReference}
+    pages={[navFactory.details(ClusterVersionDetails), navFactory.editYaml()]}
+  />;
+
+type ClusterVersionDetailsProps = {
+  obj: ClusterVersionKind;
+};
+
+type ClusterVersionDetailsPageProps = {
+  match: any;
+};

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -15,6 +15,7 @@ import {
   ClusterServiceClassModel,
   ClusterServicePlanModel,
   ClusterServiceVersionModel,
+  ClusterVersionModel,
   ConfigMapModel,
   ContainerModel,
   CronJobModel,
@@ -113,6 +114,7 @@ export const resourceDetailPages = ImmutableMap<GroupVersionKind | string, () =>
   .set(referenceForModel(SubscriptionModel), () => import('./operator-lifecycle-manager/subscription' /* webpackChunkName: "subscription" */).then(m => m.SubscriptionDetailsPage))
   .set(referenceForModel(InstallPlanModel), () => import('./operator-lifecycle-manager/install-plan' /* webpackChunkName: "install-plan" */).then(m => m.InstallPlanDetailsPage))
   .set(referenceForModel(ClusterOperatorModel), () => import('./cluster-settings/cluster-operator' /* webpackChunkName: "cluster-operator" */).then(m => m.ClusterOperatorDetailsPage))
+  .set(referenceForModel(ClusterVersionModel), () => import('./cluster-settings/cluster-version' /* webpackChunkName: "cluster-version" */).then(m => m.ClusterVersionDetailsPage))
   .set(referenceForModel(OAuthModel), () => import('./cluster-settings/oauth' /* webpackChunkName: "oauth" */).then(m => m.OAuthDetailsPage));
 
 export const resourceListPages = ImmutableMap<GroupVersionKind | string, () => Promise<React.ComponentType<any>>>()


### PR DESCRIPTION
* Deemphasize image pull spec except for the image digest
* Link directly to `ClusterVersion` details
* Add conditions to `ClusterVersion` page

Feedback from @smarterclayton 
/assign @rhamilto 

<img width="1183" alt="Cluster Settings · OKD 2019-04-30 13-14-20" src="https://user-images.githubusercontent.com/1167259/56980268-e6c58600-6b49-11e9-867b-11f151264206.png">

<img width="1401" alt="version · Details · OKD 2019-04-30 13-15-02" src="https://user-images.githubusercontent.com/1167259/56980299-0066cd80-6b4a-11e9-83cb-3ac348861bc6.png">
