### PR TITLE
Add copy login command link to request token page

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -68,6 +68,13 @@ type Authenticator struct {
 	secureCookies bool
 }
 
+type SpecialAuthURLs struct {
+	// RequestToken is a special page in the OpenShift integrated OAuth server for requesting a token.
+	RequestToken string
+	// KubeAdminLogout is the logout URL for the special kube:admin user in OpenShift.
+	KubeAdminLogout string
+}
+
 // loginMethod is used to handle OAuth2 responses and associate bearer tokens
 // with a user.
 //
@@ -79,9 +86,7 @@ type loginMethod interface {
 	login(http.ResponseWriter, *oauth2.Token) (*loginState, error)
 	// logout deletes any cookies associated with the user.
 	logout(http.ResponseWriter, *http.Request)
-	// getKubeAdminLogoutURL returns the logout URL for the special
-	// kube:admin user in OpenShift
-	getKubeAdminLogoutURL() string
+	getSpecialURLs() SpecialAuthURLs
 }
 
 // AuthSource allows callers to switch between Tectonic and OpenShift login support.
@@ -336,8 +341,8 @@ func (a *Authenticator) LogoutFunc(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetKubeAdminLogoutURL returns the logout URL for the special kube:admin user in OpenShift
-func (a *Authenticator) GetKubeAdminLogoutURL() string {
-	return a.getLoginMethod().getKubeAdminLogoutURL()
+func (a *Authenticator) GetSpecialURLs() SpecialAuthURLs {
+	return a.getLoginMethod().getSpecialURLs()
 }
 
 // CallbackFunc handles OAuth2 callbacks and code/token exchange.

--- a/auth/auth_oidc.go
+++ b/auth/auth_oidc.go
@@ -132,6 +132,6 @@ func (o *oidcAuth) authenticate(r *http.Request) (*User, error) {
 	}, nil
 }
 
-func (o *oidcAuth) getKubeAdminLogoutURL() string {
-	return ""
+func (o *oidcAuth) getSpecialURLs() SpecialAuthURLs {
+	return SpecialAuthURLs{}
 }

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -149,6 +149,11 @@ class MastheadToolbar_ extends React.Component {
     commandLineToolsModal({});
   }
 
+  _copyLoginCommand(e) {
+    e.preventDefault();
+    window.open(window.SERVER_FLAGS.requestTokenURL, '_blank').opener = null;
+  }
+
   _launchActions() {
     return [{
       label: 'Multi-Cluster Manager',
@@ -204,6 +209,14 @@ class MastheadToolbar_ extends React.Component {
       if (mobile) {
         actions.push({
           separator: true,
+        });
+      }
+
+      if (window.SERVER_FLAGS.requestTokenURL) {
+        actions.push({
+          label: 'Copy Login Command',
+          callback: this._copyLoginCommand,
+          externalLink: true,
         });
       }
 

--- a/frontend/public/components/modals/command-line-tools-modal.tsx
+++ b/frontend/public/components/modals/command-line-tools-modal.tsx
@@ -11,7 +11,15 @@ export const commandLineToolsModal = createModalLauncher(
       <h5>oc - OpenShift Command Line Interface (CLI)</h5>
       <p>With the OpenShift command line interface, you can create applications and manage OpenShift projects from a terminal.</p>
       <p>The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features.</p>
-      <p><ExternalLink href={OC_DOWNLOAD_LINK} text="Download oc" /></p>
+      <p>
+        <ExternalLink href={OC_DOWNLOAD_LINK} text="Download oc" />
+        {(window as any).SERVER_FLAGS.requestTokenURL && (
+          <React.Fragment>
+            &nbsp;<span className="co-action-divider" aria-hidden="true">|</span>
+            &nbsp;<ExternalLink href={(window as any).SERVER_FLAGS.requestTokenURL} text="Copy Login Command" />
+          </React.Fragment>
+        )}
+      </p>
       <hr />
       <h5>odo - Developer-focused CLI for OpenShift</h5>
       <p><span className="label label-warning">Tech Preview</span></p>

--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,7 @@ type jsGlobals struct {
 	LoginErrorURL            string `json:"loginErrorURL"`
 	LogoutURL                string `json:"logoutURL"`
 	LogoutRedirect           string `json:"logoutRedirect"`
+	RequestTokenURL          string `json:"requestTokenURL"`
 	KubeAdminLogoutURL       string `json:"kubeAdminLogoutURL"`
 	KubeAPIServerURL         string `json:"kubeAPIServerURL"`
 	PrometheusBaseURL        string `json:"prometheusBaseURL"`
@@ -260,7 +261,9 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !s.authDisabled() {
-		jsg.KubeAdminLogoutURL = s.Auther.GetKubeAdminLogoutURL()
+		specialAuthURLs := s.Auther.GetSpecialURLs()
+		jsg.RequestTokenURL = specialAuthURLs.RequestToken
+		jsg.KubeAdminLogoutURL = specialAuthURLs.KubeAdminLogout
 	}
 
 	if s.prometheusProxyEnabled() {


### PR DESCRIPTION
Link to the integrated OAuth server request token page until we can provide a better experience.

/cc @rhamilto @jhadvig @enj 
@alimobrem fyi

![apiservice-cabundle-injector · Details · OKD 2019-05-02 13-02-56](https://user-images.githubusercontent.com/1167259/57092947-a0536100-6cda-11e9-849f-ff3cc3c47232.png)

![apiservice-cabundle-injector · Details · OKD 2019-05-02 13-03-21](https://user-images.githubusercontent.com/1167259/57092974-af3a1380-6cda-11e9-8d65-d009af5aef6b.png)
