### PR TITLE
Adding Basic Implementation for expand PVC 

### DIFF
--- a/frontend/public/components/modals/expand-pvc-modal.jsx
+++ b/frontend/public/components/modals/expand-pvc-modal.jsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+
+import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
+import { PromiseComponent, RequestSizeInput } from '../utils';
+import { k8sPatch } from '../../module/k8s/';
+
+// Modal for expanding persistent volume claims
+class ExpandPVCModal extends PromiseComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      inProgress: false,
+      errorMessage: '',
+      requestSizeValue: '',
+      requestSizeUnit: 'Gi',
+    };
+    this._handleRequestSizeInputChange = this._handleRequestSizeInputChange.bind(this);
+    this._cancel = this.props.cancel.bind(this);
+    this._submit = this._submit.bind(this);
+  }
+
+  _handleRequestSizeInputChange(obj) {
+    this.setState({ requestSizeValue: obj.value, requestSizeUnit: obj.unit });
+  }
+
+  _submit(e) {
+    e.preventDefault();
+    const { requestSizeUnit, requestSizeValue } =this.state;
+    const patch = [{op: 'replace', path: '/spec/resources/requests', value: {storage: `${requestSizeValue}${requestSizeUnit}`}}];
+    this.handlePromise(k8sPatch(this.props.kind, this.props.resource, patch))
+      .then(this.props.close);
+  }
+
+  render() {
+    const {kind, resource} = this.props;
+    const dropdownUnits = {
+      Mi: 'Mi',
+      Gi: 'Gi',
+      Ti: 'Ti',
+    };
+    const { requestSizeUnit, requestSizeValue } =this.state;
+    return <form onSubmit={this._submit} name="form" className="modal-content modal-content--no-inner-scroll">
+      <ModalTitle>Expand {kind.label}</ModalTitle>
+      <ModalBody className="modal-body">
+        <p>Increase the capacity of claim <strong>{resource.metadata.name}.</strong> This can be a time-consuming process.</p>
+        <label className="control-label co-required">Size</label>
+        <RequestSizeInput
+          name="requestSize"
+          required
+          onChange={this._handleRequestSizeInputChange}
+          defaultRequestSizeUnit={requestSizeUnit}
+          defaultRequestSizeValue={requestSizeValue}
+          dropdownUnits={dropdownUnits}
+        />
+      </ModalBody>
+      <ModalSubmitFooter errorMessage={this.state.errorMessage} inProgress={this.state.inProgress} submitButtonClass="btn-primary" submitText="Expand" cancel={this._cancel} />
+    </form>;
+  }
+}
+
+export const expandPVCModal = createModalLauncher(ExpandPVCModal);

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -62,3 +62,6 @@ export const installPlanPreviewModal = (props) => import('./installplan-preview-
 
 export const commandLineToolsModal = (props) => import('./command-line-tools-modal' /* webpackChunkName: "command-line-tools-modal" */)
   .then(m => m.commandLineToolsModal(props));
+
+export const expandPVCModal = (props) => import('./expand-pvc-modal' /* webpackChunkName: "expand-pvc-modal" */)
+  .then(m => m.expandPVCModal(props));

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -8,8 +8,8 @@ import { ResourceEventStream } from './events';
 
 const pvcPhase = pvc => pvc.status.phase;
 
-const { common } = Kebab.factory;
-const menuActions = [...common];
+const { common, ExpandPVC } = Kebab.factory;
+const menuActions = [ExpandPVC, ...common];
 
 const PVCStatus = ({pvc}) => {
   const phase = pvcPhase(pvc);

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -3,7 +3,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 
-import { annotationsModal, configureReplicaCountModal, taintsModal, tolerationsModal, labelsModal, podSelectorModal, deleteModal } from '../modals';
+import { annotationsModal, configureReplicaCountModal, taintsModal, tolerationsModal, labelsModal, podSelectorModal, deleteModal, expandPVCModal } from '../modals';
 import { DropdownMixin } from './dropdown';
 import { history, resourceObjPath } from './index';
 import { referenceForModel, K8sResourceKind, K8sResourceKindReference, K8sKind } from '../../module/k8s';
@@ -83,6 +83,13 @@ const kebabFactory: KebabFactory = {
   AddStorage: (kind, obj) => ({
     label: 'Add Storage',
     href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/attach-storage`,
+  }),
+  ExpandPVC: (kind, obj) => ({
+    label: 'Expand PVC',
+    callback: () => expandPVCModal({
+      kind,
+      resource: obj,
+    }),
   }),
 };
 


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-1339

Re-implemented the [OCP 3.x Expand PVC Design](http://openshift.github.io/openshift-origin-design/web-console/old/project-details/pvc-expand.html) in OCP4 (React) following latest PF4 styling.

* Added the option for Expand PVC in the dropdown under Actions menu and Kebab menu
* Implemented the modal for Expand PVC that support expansion functionality
 
**Screenshots**
![p1](https://user-images.githubusercontent.com/25664409/57329859-369be280-7132-11e9-9416-f5824d21d417.png)
![pv](https://user-images.githubusercontent.com/25664409/57330315-44059c80-7133-11e9-8f11-d5798807ac17.png)
![p2](https://user-images.githubusercontent.com/25664409/57329861-37347900-7132-11e9-911b-7622449e5d68.png)
![p3](https://user-images.githubusercontent.com/25664409/57329863-37347900-7132-11e9-88a2-40b22e738cb7.png)
![p5](https://user-images.githubusercontent.com/25664409/57329872-3d2a5a00-7132-11e9-973d-0a55bf9567c0.png)

