### PR TITLE
Bug 1707631: Monitoring: Fix graph controls layout on mobile

### DIFF
--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -24,20 +24,17 @@
 }
 
 .query-browser__header {
-  display: inline-flex;
-  justify-content: space-between;
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap-reverse;
   padding: 10px;
   width: 100%;
-}
-
-.query-browser__controls {
-  display: inline-flex;
 }
 
 .query-browser__span-text {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
-  width: 100px;
+  width: 80px;
 }
 
 .query-browser__span-dropdown {
@@ -52,11 +49,19 @@
 }
 
 .query-browser__span-dropdown-menu {
-  min-width: 130px;
+  min-width: 110px;
 }
 
-.query-browser__span-reset {
-  margin: 0 20px;
+.query-browser__span-dropdown, .query-browser__span-dropdown-menu, .query-browser__span-reset {
+  margin-right: 20px;
+}
+
+.query-browser__loading {
+  width: 20px;
+}
+
+.query-browser__external-link {
+  margin-left: auto;
 }
 
 .query-browser__error {

--- a/frontend/public/components/graphs/query-browser.jsx
+++ b/frontend/public/components/graphs/query-browser.jsx
@@ -177,30 +177,32 @@ class QueryBrowser_ extends Line_ {
 
     return <div className="query-browser__wrapper">
       <div className="query-browser__header">
-        <div className="query-browser__controls">
-          <div className={isSpanValid ? '' : 'has-error'}>
-            <input
-              className="form-control query-browser__span-text"
-              onChange={this.onSpanTextChange}
-              type="text"
-              value={spanText}
-            />
-          </div>
-          <Dropdown
-            buttonClassName="btn-default form-control query-browser__span-dropdown"
-            items={dropdownItems}
-            menuClassName="dropdown-menu-right query-browser__span-dropdown-menu"
-            noSelection={true}
-            onChange={v => this.showLatest(parsePrometheusDuration(v))}
+        <div className={isSpanValid ? '' : 'has-error'}>
+          <input
+            className="form-control query-browser__span-text"
+            onChange={this.onSpanTextChange}
+            type="text"
+            value={spanText}
           />
-          <button
-            className="btn btn-default query-browser__span-reset"
-            onClick={() => this.showLatest(this.defaultSpan)}
-            type="button"
-          >Reset Zoom</button>
+        </div>
+        <Dropdown
+          buttonClassName="btn-default form-control query-browser__span-dropdown"
+          items={dropdownItems}
+          menuClassName="dropdown-menu-right query-browser__span-dropdown-menu"
+          noSelection={true}
+          onChange={v => this.showLatest(parsePrometheusDuration(v))}
+        />
+        <button
+          className="btn btn-default query-browser__span-reset"
+          onClick={() => this.showLatest(this.defaultSpan)}
+          type="button"
+        >Reset Zoom</button>
+        <div className="query-browser__loading">
           {updating && <LoadingInline />}
         </div>
-        {baseUrl && query && <ExternalLink href={`${baseUrl}/graph?g0.expr=${encodeURIComponent(query)}&g0.tab=0`} text="View in Prometheus UI" />}
+        <div className="query-browser__external-link">
+          {baseUrl && query && <ExternalLink href={`${baseUrl}/graph?g0.expr=${encodeURIComponent(query)}&g0.tab=0`} text="View in Prometheus UI" />}
+        </div>
       </div>
       {error && <div className="alert alert-danger query-browser__error">
         <span className="pficon pficon-error-circle-o" aria-hidden="true"></span>{error.message}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1707631

Stop the graph controls getting pushed outside the graph frame.

Make sure enough space is reserved for the loading indicator so that
when it appears, it doesn't push the Prometheus UI link aside.

Reduce the width of the dropdown by 20px.

CC @cshinn 

Before | After
---|---
![before](https://user-images.githubusercontent.com/460802/57372406-89c47280-71d0-11e9-9e03-dce4d91b1bc1.png) | ![after](https://user-images.githubusercontent.com/460802/57372412-92b54400-71d0-11e9-8e48-457e07e9a6eb.png)