### PR TITLE
Bug 1691282: Relax RBAC checks for Operator Management nav

### DIFF
--- a/frontend/public/components/nav.jsx
+++ b/frontend/public/components/nav.jsx
@@ -351,7 +351,6 @@ export const Navigation = ({ isNavOpen, onNavSelect }) => {
             activePath="/operatorhub/"
           />
           <HrefLink
-            required={[FLAGS.CAN_LIST_PACKAGE_MANIFEST, FLAGS.CAN_LIST_OPERATOR_GROUP]}
             href="/operatormanagement"
             name="Operator Management"
             activePath="/operatormanagement/"

--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -111,8 +111,8 @@ export const PackageManifestsPage: React.SFC<PackageManifestsPageProps> = (props
     resources={[
       {kind: referenceForModel(PackageManifestModel), isList: true, namespaced: true, prop: 'packageManifest', selector: {matchExpressions: [{key: visibilityLabel, operator: 'DoesNotExist'}, {key: OPERATOR_HUB_LABEL, operator: 'DoesNotExist'}]}},
       {kind: referenceForModel(CatalogSourceModel), isList: true, namespaced: true, prop: 'catalogSource'},
-      {kind: referenceForModel(SubscriptionModel), isList: true, prop: 'subscription'},
-      {kind: referenceForModel(OperatorGroupModel), isList: true, prop: 'operatorGroup'},
+      {kind: referenceForModel(SubscriptionModel), isList: true, namespaced: true, prop: 'subscription'},
+      {kind: referenceForModel(OperatorGroupModel), isList: true, namespaced: true, prop: 'operatorGroup'},
     ]} />;
 };
 


### PR DESCRIPTION
* Don't require users to be able to list package manifests and operator groups at the cluster scope to view these pages
* Restrict Firehose queries to current namespace on the Operator Catalogs tab

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1691282

/assign @alecmerdler @ecordell 