### PR TITLE
Fix hot-loop issue with prometheus poll and ref width effects

### DIFF
--- a/frontend/public/components/graphs/use-prometheus-poll.ts
+++ b/frontend/public/components/graphs/use-prometheus-poll.ts
@@ -1,12 +1,13 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import * as _ from 'lodash-es';
 import { useEffect, useRef } from 'react';
 import { prometheusTenancyBasePath, prometheusBasePath } from '.';
 import { coFetchJSON } from '../../co-fetch';
 import { useSafetyFirst } from '../safety-first';
 
-// TODO This effect only handles polling prometheus data range queries. For now,
+// TODO This effect only handles prometheus matrix data. For now,
 // area charts are the only component using this, so that's okay, but will need
-// to be expanded to handle singular vector queries as well.
+// to be expanded to handle vector data as well.
 export const usePrometheusPoll = ({
   basePath,
   defaultQueryName = '',
@@ -18,7 +19,6 @@ export const usePrometheusPoll = ({
 }: PrometheusPollProps ) => {
   const [data, setData] = useSafetyFirst([]);
   const interval = useRef(null);
-
   useEffect(() => {
     const fetch = () => {
       const end = Date.now();
@@ -55,7 +55,7 @@ export const usePrometheusPoll = ({
     return () => {
       clearInterval(interval.current);
     };
-  }, [basePath, defaultQueryName, namespace, numSamples, query, timeout, timeSpan, setData]);
+  }, [basePath, defaultQueryName, namespace, numSamples, query, timeout, timeSpan]);
 
   return [data] as [GraphDataPoint[][]];
 };

--- a/frontend/public/components/utils/use-ref-width.ts
+++ b/frontend/public/components/utils/use-ref-width.ts
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import * as React from 'react';
 import { useSafetyFirst } from '../safety-first';
 
@@ -15,7 +16,7 @@ export const useRefWidth = () => {
       window.removeEventListener('resize', handleResize);
       window.removeEventListener('nav_toggle', handleResize);
     };
-  }, [setWidth]);
+  }, []);
 
   return [ref, width] as [React.Ref<HTMLDivElement>, number];
 };


### PR DESCRIPTION
Our lint rules were adding the state hook update functions to effect hook dependency lists in these two effects, which was causing them to run on every render. Removed those functions from dependencies, and disabled the `react-hooks/exhaustive-deps` rule in those files. 