### PR TITLE
Bug 1708235: Monitoring: Fix graph controls layout on mobile

### DIFF
--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -32,20 +32,17 @@
 }
 
 .query-browser__header {
-  display: inline-flex;
-  justify-content: space-between;
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap-reverse;
   padding: 10px;
   width: 100%;
-}
-
-.query-browser__controls {
-  display: inline-flex;
 }
 
 .query-browser__span-text {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
-  width: 100px;
+  width: 80px;
 }
 
 .query-browser__span-dropdown {
@@ -60,11 +57,19 @@
 }
 
 .query-browser__span-dropdown-menu {
-  min-width: 130px;
+  min-width: 110px;
 }
 
-.query-browser__span-reset {
-  margin: 0 20px;
+.query-browser__span-dropdown, .query-browser__span-dropdown-menu, .query-browser__span-reset {
+  margin-right: 20px;
+}
+
+.query-browser__loading {
+  width: 20px;
+}
+
+.query-browser__external-link {
+  margin-left: auto;
 }
 
 .query-browser__error {

--- a/frontend/public/components/graphs/query-browser.jsx
+++ b/frontend/public/components/graphs/query-browser.jsx
@@ -191,30 +191,32 @@ export class QueryBrowser extends Line_ {
 
     return <div className="query-browser__wrapper">
       <div className="query-browser__header">
-        <div className="query-browser__controls">
-          <div className={isSpanValid ? '' : 'has-error'}>
-            <input
-              className="form-control query-browser__span-text"
-              onChange={this.onSpanTextChange}
-              type="text"
-              value={spanText}
-            />
-          </div>
-          <Dropdown
-            buttonClassName="btn-default form-control query-browser__span-dropdown"
-            items={dropdownItems}
-            menuClassName="dropdown-menu-right query-browser__span-dropdown-menu"
-            noSelection={true}
-            onChange={v => this.showLatest(parsePrometheusDuration(v))}
+        <div className={isSpanValid ? '' : 'has-error'}>
+          <input
+            className="form-control query-browser__span-text"
+            onChange={this.onSpanTextChange}
+            type="text"
+            value={spanText}
           />
-          <button
-            className="btn btn-default query-browser__span-reset"
-            onClick={() => this.showLatest(this.defaultSpan)}
-            type="button"
-          >Reset Zoom</button>
+        </div>
+        <Dropdown
+          buttonClassName="btn-default form-control query-browser__span-dropdown"
+          items={dropdownItems}
+          menuClassName="dropdown-menu-right query-browser__span-dropdown-menu"
+          noSelection={true}
+          onChange={v => this.showLatest(parsePrometheusDuration(v))}
+        />
+        <button
+          className="btn btn-default query-browser__span-reset"
+          onClick={() => this.showLatest(this.defaultSpan)}
+          type="button"
+        >Reset Zoom</button>
+        <div className="query-browser__loading">
           {updating && <LoadingInline />}
         </div>
-        {GraphLink}
+        <div className="query-browser__external-link">
+          {GraphLink}
+        </div>
       </div>
       {error && <div className="alert alert-danger query-browser__error">
         <span className="pficon pficon-error-circle-o" aria-hidden="true"></span>{error.message}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1708235

Stop the graph controls getting pushed outside the graph frame.

Make sure enough space is reserved for the loading indicator so that
when it appears, it doesn't push the Prometheus UI link aside.

Reduce the width of the dropdown by 20px.