### PR TITLE
Add RBAC checks to create buttons and action menus

### DIFF
--- a/frontend/__tests__/components/factory/list-page.spec.tsx
+++ b/frontend/__tests__/components/factory/list-page.spec.tsx
@@ -32,7 +32,7 @@ describe(FireMan_.displayName, () => {
   let wrapper: ShallowWrapper<any>;
 
   beforeEach(() => {
-    const resources = [{kind: 'nodes'}];
+    const resources = [{kind: 'Node'}];
     wrapper = shallow(<FireMan_.WrappedComponent resources={resources} />);
   });
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
@@ -61,8 +61,8 @@ describe(SubscriptionRow.displayName, () => {
     expect(wrapper.find('.co-resource-list__item').find(ResourceKebab).props().kind).toEqual(referenceForModel(SubscriptionModel));
     expect(wrapper.find('.co-resource-list__item').find(ResourceKebab).props().resource).toEqual(subscription);
     expect(wrapper.find('.co-resource-list__item').find(ResourceKebab).props().actions[0]).toEqual(Kebab.factory.Edit);
-    expect(wrapper.find('.co-resource-list__item').find(ResourceKebab).props().actions[1]().label).toEqual('Remove Subscription...');
-    expect(wrapper.find('.co-resource-list__item').find(ResourceKebab).props().actions[1]().callback).toBeDefined();
+    expect(wrapper.find('.co-resource-list__item').find(ResourceKebab).props().actions[1](...menuArgs).label).toEqual('Remove Subscription...');
+    expect(wrapper.find('.co-resource-list__item').find(ResourceKebab).props().actions[1](...menuArgs).callback).toBeDefined();
     expect(wrapper.find('.co-resource-list__item').find(ResourceKebab).props().actions[2](...menuArgs).label).toEqual(`View ${ClusterServiceVersionModel.kind}...`);
     expect(wrapper.find('.co-resource-list__item').find(ResourceKebab).props().actions[2](...menuArgs).href).toEqual(`/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp.v1.0.0`);
   });

--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -118,8 +118,7 @@ describe('Kubernetes resource CRUD operations', () => {
       });
 
       it('displays detail view for new resource instance', async() => {
-        await browser.wait(until.presenceOf(crudView.actionsDropdown));
-
+        await browser.wait(until.presenceOf(crudView.resourceTitle));
         expect(browser.getCurrentUrl()).toContain(`/${name}`);
         expect(crudView.resourceTitle.getText()).toEqual(name);
       });
@@ -310,10 +309,7 @@ describe('Kubernetes resource CRUD operations', () => {
     });
 
     it('displays modal for editing resource instance labels', async() => {
-      await browser.wait(until.presenceOf(crudView.actionsDropdown));
-      await crudView.actionsDropdown.click();
-      await browser.wait(until.presenceOf(crudView.actionsDropdownMenu));
-      await crudView.actionsDropdownMenu.element(by.linkText('Edit Labels')).click();
+      await crudView.clickDetailsPageAction(crudView.actions.labels);
       await browser.wait(until.presenceOf($('.tags input')));
       await $('.tags input').sendKeys(labelValue, Key.ENTER);
       // This only works because there's only one label
@@ -335,8 +331,8 @@ describe('Kubernetes resource CRUD operations', () => {
 
     afterAll(async() => {
       await browser.get(`${appHost}/k8s/ns/${testName}/${plural}/${name}`);
-      await browser.wait(until.presenceOf(crudView.actionsDropdown));
-      await crudView.actionsDropdown.click();
+      await browser.wait(until.presenceOf(crudView.actionsButton));
+      await crudView.actionsButton.click();
       await browser.wait(until.presenceOf(crudView.actionsDropdownMenu), 1000);
       await crudView.actionsDropdownMenu.element(by.partialLinkText('Delete ')).click();
       await browser.wait(until.presenceOf($('#confirm-action')));

--- a/frontend/integration-tests/tests/deploy-image.scenario.ts
+++ b/frontend/integration-tests/tests/deploy-image.scenario.ts
@@ -39,7 +39,7 @@ describe('Deploy Image', () => {
       await browser.wait(until.presenceOf($('.overview')));
       expect($('.co-m-pane__name').getText()).toEqual('Project Status');
       await browser.get(`${appHost}/k8s/ns/${testName}/deploymentconfigs/${appName}`);
-      await browser.wait(until.presenceOf(crudView.actionsDropdown));
+      await browser.wait(until.presenceOf(crudView.actionsButton));
       expect(browser.getCurrentUrl()).toContain(`/${appName}`);
       expect(crudView.resourceTitle.getText()).toEqual(appName);
     });

--- a/frontend/integration-tests/tests/environment.scenario.ts
+++ b/frontend/integration-tests/tests/environment.scenario.ts
@@ -26,7 +26,7 @@ describe('Interacting with the environment variable editor', () => {
     await yamlView.setContent(safeDump(newContent));
     await crudView.saveChangesBtn.click();
     // Wait until the resource is created and the details page loads before continuing.
-    await browser.wait(until.presenceOf(crudView.actionsDropdown));
+    await browser.wait(until.presenceOf(crudView.actionsButton));
     checkLogs();
     checkErrors();
   });
@@ -41,7 +41,7 @@ describe('Interacting with the environment variable editor', () => {
     await crudView.isLoaded();
     await crudView.nameFilter.sendKeys(WORKLOAD_NAME);
     await browser.wait(until.elementToBeClickable(crudView.resourceRowNamesAndNs.first()), BROWSER_TIMEOUT);
-    await crudView.deleteRow('deployment')(WORKLOAD_NAME);
+    await crudView.deleteRow('Deployment')(WORKLOAD_NAME);
     checkLogs();
     checkErrors();
   });

--- a/frontend/integration-tests/tests/filter.scenario.ts
+++ b/frontend/integration-tests/tests/filter.scenario.ts
@@ -23,7 +23,7 @@ describe('Filtering', () => {
     await yamlView.setContent(safeDump(newContent));
     await crudView.saveChangesBtn.click();
     // Wait until the resource is created and the details page loads before continuing.
-    await browser.wait(until.presenceOf(crudView.actionsDropdown));
+    await browser.wait(until.presenceOf(crudView.actionsButton));
   });
 
   afterEach(() => {
@@ -36,7 +36,7 @@ describe('Filtering', () => {
     await crudView.isLoaded();
     await crudView.nameFilter.sendKeys(WORKLOAD_NAME);
     await browser.wait(until.elementToBeClickable(crudView.resourceRowNamesAndNs.first()), BROWSER_TIMEOUT);
-    await crudView.deleteRow('deployment')(WORKLOAD_NAME);
+    await crudView.deleteRow('Deployment')(WORKLOAD_NAME);
   });
 
   it('filters Pod from object detail', async() => {

--- a/frontend/integration-tests/tests/modal-annotations.scenario.ts
+++ b/frontend/integration-tests/tests/modal-annotations.scenario.ts
@@ -23,11 +23,11 @@ describe('Modal Annotations', () => {
     await crudView.createYAMLButton.click();
     await yamlView.isLoaded();
     const content = await yamlView.editorContent.getText();
-    const newContent = _.defaultsDeep({}, {metadata: {name: WORKLOAD_NAME, labels: {['lbl-modal']: testName}}}, safeLoad(content));
+    const newContent = _.defaultsDeep({}, {metadata: {name: WORKLOAD_NAME, labels: {'lbl-modal': testName}}}, safeLoad(content));
     await yamlView.setContent(safeDump(newContent));
     await crudView.saveChangesBtn.click();
     // Wait until the resource is created and the details page loads before continuing.
-    await browser.wait(until.presenceOf(crudView.actionsDropdown));
+    await browser.wait(until.presenceOf(crudView.resourceTitle));
     checkLogs();
     checkErrors();
   });
@@ -39,10 +39,9 @@ describe('Modal Annotations', () => {
 
   afterAll(async() => {
     await browser.get(`${appHost}/k8s/ns/${testName}/deployments`);
-    await crudView.isLoaded();
+    await crudView.resourceRowsPresent();
     await crudView.nameFilter.sendKeys(WORKLOAD_NAME);
-    await browser.wait(until.elementToBeClickable(crudView.resourceRowNamesAndNs.first()), BROWSER_TIMEOUT);
-    await crudView.deleteRow('deployment')(WORKLOAD_NAME);
+    await crudView.deleteRow('Deployment')(WORKLOAD_NAME);
     checkLogs();
     checkErrors();
   });
@@ -164,14 +163,14 @@ describe('Modal Annotations', () => {
 
     await browser.get(`${appHost}/k8s/ns/${testName}/deployments`);
     await crudView.isLoaded();
-    await crudView.selectOptionFromGear(WORKLOAD_NAME, crudView.gearOptions.annotations);
+    await crudView.clickKebabAction(WORKLOAD_NAME, crudView.actions.annotations);
     await modalAnnotationsView.isLoaded();
     await modalAnnotationsView.addAnnotation(annotationKey,annotationValue);
     await modalAnnotationsView.isLoaded();
     await modalAnnotationsView.confirmActionBtn.click();
     await browser.get(`${appHost}/k8s/ns/${testName}/deployments`);
     await crudView.isLoaded();
-    await crudView.selectOptionFromGear(WORKLOAD_NAME, crudView.gearOptions.annotations);
+    await crudView.clickKebabAction(WORKLOAD_NAME, crudView.actions.annotations);
     await modalAnnotationsView.isLoaded();
     await validateKeyAndValue(annotationKey, annotationValue, true);
     await browser.get(`${appHost}/k8s/ns/${testName}/deployments/${WORKLOAD_NAME}/yaml`);
@@ -289,13 +288,13 @@ describe('Modal Annotations', () => {
 
     await browser.get(`${appHost}/k8s/ns/${testName}/deployments`);
     await crudView.isLoaded();
-    await crudView.selectOptionFromGear(WORKLOAD_NAME, crudView.gearOptions.annotations);
+    await crudView.clickKebabAction(WORKLOAD_NAME, crudView.actions.annotations);
     await modalAnnotationsView.isLoaded();
     await modalAnnotationsView.addAnnotation(annotationKey, annotationValue);
     await modalAnnotationsView.isLoaded();
     await modalAnnotationsView.cancelBtn.click();
     await crudView.isLoaded();
-    await crudView.selectOptionFromGear(WORKLOAD_NAME, crudView.gearOptions.annotations);
+    await crudView.clickKebabAction(WORKLOAD_NAME, crudView.actions.annotations);
     await modalAnnotationsView.isLoaded();
     await validateKeyAndValue(annotationKey, annotationValue, false);
   });

--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -1,4 +1,4 @@
-import { by, ExpectedConditions as until } from 'protractor';
+import { ExpectedConditions as until } from 'protractor';
 
 import { checkLogs, checkErrors } from '../protractor.conf';
 import * as crudView from '../views/crud.view';
@@ -60,7 +60,7 @@ describe('Monitoring: Alerts', () => {
   });
 
   it('creates a new Silence from an existing alert', async() => {
-    await monitoringView.clickActionsMenuAction('Silence Alert');
+    await crudView.clickDetailsPageAction('Silence Alert');
     await monitoringView.wait(until.presenceOf(monitoringView.saveButton));
     await monitoringView.saveButton.click();
     expect(crudView.errorMessage.isPresent()).toBe(false);
@@ -91,7 +91,7 @@ describe('Monitoring: Alerts', () => {
   });
 
   it('expires the Silence', async() => {
-    await monitoringView.clickActionsMenuAction('Expire Silence');
+    await crudView.clickDetailsPageAction('Expire Silence');
     await monitoringView.wait(until.elementToBeClickable(monitoringView.modalConfirmButton));
     await monitoringView.modalConfirmButton.click();
     await monitoringView.wait(until.presenceOf(monitoringView.expiredSilenceIcon));
@@ -146,7 +146,7 @@ describe('Monitoring: Silences', () => {
   });
 
   it('edits the Silence', async() => {
-    await monitoringView.clickActionsMenuAction('Edit Silence');
+    await crudView.clickDetailsPageAction('Edit Silence');
     await monitoringView.wait(until.presenceOf(monitoringView.commentTextarea));
     await monitoringView.commentTextarea.sendKeys('Test Comment');
     await monitoringView.saveButton.click();
@@ -162,14 +162,9 @@ describe('Monitoring: Silences', () => {
     await sidenavView.clickNavLink(['Monitoring', 'Silences']);
     await crudView.isLoaded();
     await crudView.nameFilter.sendKeys(testAlertName);
-    await monitoringView.wait(until.elementToBeClickable(monitoringView.firstListLink));
-
     const row = crudView.rowForName(testAlertName);
     await monitoringView.wait(until.presenceOf(row));
-    const menuButton = monitoringView.rowMenuButton(row);
-    await monitoringView.wait(until.elementToBeClickable(menuButton));
-    await menuButton.click();
-    await row.element(by.linkText('Expire Silence')).click();
+    await crudView.clickKebabAction(testAlertName, 'Expire Silence');
     await monitoringView.wait(until.elementToBeClickable(monitoringView.modalConfirmButton));
     await monitoringView.modalConfirmButton.click();
     await monitoringView.wait(until.not(until.presenceOf(row)));

--- a/frontend/integration-tests/tests/olm/update-channel-approval.scenario.ts
+++ b/frontend/integration-tests/tests/olm/update-channel-approval.scenario.ts
@@ -58,7 +58,7 @@ describe('Manually approving an install plan', () => {
 
   it('does not create a cluster service version', async() => {
     await catalogView.entryRowFor(pkgName).element(by.linkText('View subscription')).click();
-    await crudView.selectOptionFromGear(subName, 'View ClusterServiceVersion');
+    await crudView.clickKebabAction(subName, 'View ClusterServiceVersion');
 
     expect($('.co-m-pane__body').getText()).toContain('404: Not Found');
   });

--- a/frontend/integration-tests/tests/performance.scenario.ts
+++ b/frontend/integration-tests/tests/performance.scenario.ts
@@ -66,7 +66,7 @@ describe('Performance test', () => {
     const initialChunks = await browser.executeScript<{name: string, size: number}[]>(() => performance.getEntriesByType('resource')
       .filter(({name}) => name.endsWith('.js')));
 
-    await crudView.selectOptionFromGear('console-config', 'Edit Config Map');
+    await crudView.clickKebabAction('console-config', 'Edit Config Map');
     await yamlView.isLoaded();
 
     const postChunks = await browser.executeScript<{name: string, size: number}[]>(() => performance.getEntriesByType('resource')

--- a/frontend/integration-tests/views/monitoring.view.ts
+++ b/frontend/integration-tests/views/monitoring.view.ts
@@ -1,6 +1,4 @@
-import { $, $$, browser, by, ExpectedConditions as until } from 'protractor';
-
-import * as crudView from '../views/crud.view';
+import { $, $$, browser } from 'protractor';
 
 export const wait = async(condition) => await browser.wait(condition, 15000);
 
@@ -8,7 +6,6 @@ export const wait = async(condition) => await browser.wait(condition, 15000);
 export const listPageHeading = $('.co-m-pane__heading');
 export const firstListLink = $$('.co-resource-list__item a.co-resource-item__resource-name').first();
 export const createButton = $('.co-m-pane__filter-bar-group button');
-export const rowMenuButton = row => row.$('.co-kebab__button');
 
 // Details pages
 export const detailsHeading = $('.co-m-nav-title .co-m-pane__name');
@@ -21,13 +18,6 @@ export const expiredSilenceIcon = $('.co-m-pane__details .fa-ban');
 export const ruleLink = $('.co-m-pane__details .co-resource-item__resource-name');
 export const silenceComment = $$('.co-m-pane__details dd').get(-2);
 export const firstAlertsListLink = $$('.co-resource-list__item a.co-resource-item').first();
-
-export const clickActionsMenuAction = async(actionText) => {
-  await wait(until.presenceOf(crudView.actionsDropdown));
-  await crudView.actionsDropdown.click();
-  await wait(until.presenceOf(crudView.actionsDropdownMenu));
-  await crudView.actionsDropdownMenu.element(by.linkText(actionText)).click();
-};
 
 // Silence form
 export const matcherNameInput = $('input[placeholder=Name]');

--- a/frontend/integration-tests/views/secrets.view.ts
+++ b/frontend/integration-tests/views/secrets.view.ts
@@ -86,9 +86,7 @@ export const checkSecret = async(ns: string, name: string, keyValuesToCheck: Obj
 };
 
 export const editSecret = async(ns: string, name: string, updateForm: Function) => {
-  await crudView.actionsDropdown.click();
-  await browser.wait(until.presenceOf(crudView.actionsDropdownMenu));
-  await crudView.actionsDropdownMenu.element(by.linkText('Edit Secret')).click();
+  await crudView.clickDetailsPageAction('Edit Secret');
   await browser.wait(until.urlContains(`/k8s/ns/${ns}/secrets/${name}/edit`));
   await browser.wait(until.and(crudView.untilNoLoadersPresent, until.presenceOf(secretNameInput)));
   await updateForm();

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -1,6 +1,7 @@
 $color-dropdown-hover: rgba(0, 0, 0, .05);
 $color-bookmarker--hover: #AAA;
 $color-bookmarker: #DDD;
+$dropdown-link-hover-border: 1px solid #bee1f4;
 
 .dropdown {
   position: relative;
@@ -85,13 +86,24 @@ $color-bookmarker: #DDD;
       cursor: pointer;
       flex-grow: 1;
       width: 100%;
+      &.disabled {
+        color: $dropdown-link-disabled-color;
+        cursor: not-allowed;
+        &:active,
+        &:focus,
+        &:hover {
+          background-color: inherit;
+          border-color: transparent;
+          color: $dropdown-link-disabled-color !important;
+        }
+      }
       &.next-to-bookmark {
         padding-left: 5px
       }
       &.hover {
         background-color: $dropdown-link-hover-bg;
-        border-top: 1px solid #bee1f4;
-        border-bottom: 1px solid #bee1f4;
+        border-top: $dropdown-link-hover-border;
+        border-bottom: $dropdown-link-hover-border;
         color: $dropdown-link-hover-color;
         position: relative;
         &:after,

--- a/frontend/public/components/_edit-yaml.scss
+++ b/frontend/public/components/_edit-yaml.scss
@@ -1,15 +1,14 @@
 .yaml-editor {
   position: relative;
-}
-
-.yaml-editor__acebox {
-  flex: 1;
-
-  &--readonly {
+  &--readonly .yaml-editor__acebox {
     background: $input-bg-disabled !important;
     color: $color-pf-black-700 !important;
     filter: grayscale(.55);
   }
+}
+
+.yaml-editor__acebox {
+  flex: 1;
 }
 
 .yaml-editor__buttons {

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -1,11 +1,25 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-import { K8sResourceKindReference, referenceFor } from '../module/k8s';
+import { K8sResourceKind, K8sResourceKindReference, referenceFor } from '../module/k8s';
 import { startBuild } from '../module/k8s/builds';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { errorModal } from './modals';
-import { BuildHooks, BuildStrategy, Kebab, SectionHeading, LabelList, history, navFactory, ResourceKebab, ResourceLink, resourceObjPath, ResourceSummary, WebhookTriggers } from './utils';
+import {
+  BuildHooks,
+  BuildStrategy,
+  history,
+  Kebab,
+  KebabAction,
+  LabelList,
+  navFactory,
+  ResourceKebab,
+  ResourceLink,
+  resourceObjPath,
+  ResourceSummary,
+  SectionHeading,
+  WebhookTriggers,
+} from './utils';
 import { BuildsPage, BuildEnvironmentComponent, BuildStrategyType } from './build';
 import { fromNow } from './utils/datetime';
 import { ResourceEventStream } from './events';
@@ -14,7 +28,7 @@ const BuildConfigsReference: K8sResourceKindReference = 'BuildConfig';
 
 const { EditEnvironment, common } = Kebab.factory;
 
-const startBuildAction = (kind, buildConfig) => ({
+const startBuildAction: KebabAction = (kind, buildConfig) => ({
   label: 'Start Build',
   callback: () => startBuild(buildConfig).then(build => {
     history.push(resourceObjPath(build, referenceFor(build)));
@@ -22,6 +36,14 @@ const startBuildAction = (kind, buildConfig) => ({
     const error = err.message;
     errorModal({error});
   }),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    subresource: 'instantiate',
+    name: buildConfig.metadata.name,
+    namespace: buildConfig.metadata.namespace,
+    verb: 'create',
+  },
 });
 
 const menuActions = [
@@ -46,7 +68,7 @@ export const BuildConfigsDetails: React.SFC<BuildConfigsDetailsProps> = ({obj: b
   <BuildHooks resource={buildConfig} />
 </React.Fragment>;
 
-const BuildsTabPage = ({obj: buildConfig}) => <BuildsPage namespace={buildConfig.metadata.namespace} showTitle={false} selector={{ 'openshift.io/build-config.name': buildConfig.metadata.name}} />;
+const BuildsTabPage = ({obj: buildConfig}) => <BuildsPage namespace={buildConfig.metadata.namespace} showTitle={false} selector={{'openshift.io/build-config.name': buildConfig.metadata.name}} />;
 
 const pages = [
   navFactory.details(BuildConfigsDetails),
@@ -89,7 +111,7 @@ const BuildConfigsRow: React.SFC<BuildConfigsRowProps> = ({obj}) => <div classNa
   </div>
 </div>;
 
-const buildStrategy = buildConfig => buildConfig.spec.strategy.type;
+const buildStrategy = (buildConfig: K8sResourceKind): BuildStrategyType => buildConfig.spec.strategy.type;
 
 const allStrategies = [BuildStrategyType.Docker, BuildStrategyType.JenkinsPipeline, BuildStrategyType.Source, BuildStrategyType.Custom];
 const filters = [{
@@ -117,17 +139,17 @@ export const BuildConfigsPage: React.SFC<BuildConfigsPageProps> = props =>
 BuildConfigsPage.displayName = 'BuildConfigsListPage';
 
 export type BuildConfigsRowProps = {
-  obj: any,
+  obj: any;
 };
 
 export type BuildConfigsDetailsProps = {
-  obj: any,
+  obj: any;
 };
 
 export type BuildConfigsPageProps = {
-  filterLabel: string,
+  filterLabel: string;
 };
 
 export type BuildConfigsDetailsPageProps = {
-  match: any,
+  match: any;
 };

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -7,7 +7,25 @@ import { K8sResourceKindReference, referenceFor, K8sResourceKind } from '../modu
 import { cloneBuild, formatBuildDuration, BuildPhase, getBuildNumber } from '../module/k8s/builds';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { errorModal } from './modals';
-import { BuildHooks, BuildStrategy, Kebab, SectionHeading, history, navFactory, ResourceKebab, ResourceLink, resourceObjPath, ResourceSummary, Timestamp, AsyncComponent, resourcePath, StatusIcon, humanizeDecimalBytes, humanizeCpuCores } from './utils';
+import {
+  AsyncComponent,
+  BuildHooks,
+  BuildStrategy,
+  history,
+  humanizeCpuCores,
+  humanizeDecimalBytes,
+  Kebab,
+  KebabAction,
+  navFactory,
+  ResourceKebab,
+  ResourceLink,
+  resourceObjPath,
+  resourcePath,
+  ResourceSummary,
+  SectionHeading,
+  StatusIcon,
+  Timestamp,
+} from './utils';
 import { BuildPipeline, BuildPipelineLogLink } from './build-pipeline';
 import { breadcrumbsForOwnerRefs } from './utils/breadcrumbs';
 import { fromNow } from './utils/datetime';
@@ -19,7 +37,7 @@ const BuildsReference: K8sResourceKindReference = 'Build';
 
 const { common, EditEnvironment } = Kebab.factory;
 
-const cloneBuildAction = (kind, build) => ({
+const cloneBuildAction: KebabAction = (kind, build) => ({
   label: 'Rebuild',
   callback: () => cloneBuild(build).then(clone => {
     history.push(resourceObjPath(clone, referenceFor(clone)));
@@ -27,6 +45,14 @@ const cloneBuildAction = (kind, build) => ({
     const error = err.message;
     errorModal({ error });
   }),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    subresource: 'instantiate',
+    name: build.metadata.name,
+    namespace: build.metadata.namespace,
+    verb: 'create',
+  },
 });
 
 const menuActions = [

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -53,16 +53,31 @@ const RolloutAction: KebabAction = (kind: K8sKind, obj: K8sResourceKind) => ({
     const error = err.message;
     errorModal({error});
   }),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    subresource: 'instantiate',
+    name: obj.metadata.name,
+    namespace: obj.metadata.namespace,
+    verb: 'create',
+  },
 });
 
-const PauseAction = (kind: K8sKind, obj: K8sResourceKind) => ({
+const PauseAction: KebabAction = (kind: K8sKind, obj: K8sResourceKind) => ({
   label: obj.spec.paused ? 'Resume Rollouts' : 'Pause Rollouts',
   callback: () => togglePaused(kind, obj).catch((err) => errorModal({error: err.message})),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    name: obj.metadata.name,
+    namespace: obj.metadata.namespace,
+    verb: 'patch',
+  },
 });
 
 const {ModifyCount, AddStorage, EditEnvironment, common} = Kebab.factory;
 
-export const menuActions = [
+export const menuActions: KebabAction[] = [
   RolloutAction,
   PauseAction,
   ModifyCount,

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -36,11 +36,25 @@ const {ModifyCount, AddStorage, EditEnvironment, common} = Kebab.factory;
 const UpdateStrategy: KebabAction = (kind: K8sKind, deployment: K8sResourceKind) => ({
   label: 'Edit Update Strategy',
   callback: () => configureUpdateStrategyModal({deployment}),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    name: deployment.metadata.name,
+    namespace: deployment.metadata.namespace,
+    verb: 'patch',
+  },
 });
 
 const PauseAction: KebabAction = (kind: K8sKind, obj: K8sResourceKind) => ({
   label: obj.spec.paused ? 'Resume Rollouts' : 'Pause Rollouts',
   callback: () => togglePaused(kind, obj).catch((err) => errorModal({error: err.message})),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    name: obj.metadata.name,
+    namespace: obj.metadata.namespace,
+    verb: 'patch',
+  },
 });
 
 export const menuActions = [

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -14,12 +14,13 @@ import { withFallback } from '../utils/error-boundary';
 import {
   Dropdown,
   Firehose,
-  makeReduxID,
-  makeQuery,
   history,
   inject,
   kindObj,
+  makeQuery,
+  makeReduxID,
   PageHeading,
+  RequireCreatePermission,
 } from '../utils';
 
 export const CompactExpandButtons = ({expand = false, onExpandChange = _.noop}) => <div className="btn-group btn-group-sm" data-toggle="buttons">
@@ -187,8 +188,9 @@ export const FireMan_ = connect(null, {filterList})(
         autoFocus,
         canCreate,
         canExpand,
+        createAccessReview,
         createButtonText,
-        createProps,
+        createProps = {},
         filterLabel,
         helpText,
         resources,
@@ -198,7 +200,7 @@ export const FireMan_ = connect(null, {filterList})(
       let createLink;
       if (canCreate) {
         if (createProps.to) {
-          createLink = <Link className="co-m-primary-action" {...createProps} tabIndex={-1}>
+          createLink = <Link className="co-m-primary-action" {...createProps}>
             <button className="btn btn-primary" id="yaml-create">{createButtonText}</button>
           </Link>;
         } else if (createProps.items) {
@@ -209,6 +211,9 @@ export const FireMan_ = connect(null, {filterList})(
           createLink = <div className="co-m-primary-action">
             <button className="btn btn-primary" id="yaml-create" {...createProps}>{createButtonText}</button>
           </div>;
+        }
+        if (!_.isEmpty(createAccessReview)) {
+          createLink = <RequireCreatePermission model={createAccessReview.model} namespace={createAccessReview.namespace}>{createLink}</RequireCreatePermission>;
         }
       }
 
@@ -252,6 +257,7 @@ FireMan_.defaultProps = {
 FireMan_.propTypes = {
   canCreate: PropTypes.bool,
   canExpand: PropTypes.bool,
+  createAccessReview: PropTypes.object,
   createButtonText: PropTypes.string,
   createProps: PropTypes.object,
   fieldSelector: PropTypes.string,
@@ -297,6 +303,7 @@ export const ListPage = withFallback(props => {
     namespace,
     selector,
     showTitle = true,
+    skipAccessReview,
     textFilter,
     match,
   } = props;
@@ -320,6 +327,7 @@ export const ListPage = withFallback(props => {
   }
 
   createProps = createProps || (createHandler ? {onClick: createHandler} : {to: href});
+  const createAccessReview = skipAccessReview ? null : { model: ko, namespace: usedNamespace };
   const resources = [{
     fieldSelector,
     filters,
@@ -341,6 +349,7 @@ export const ListPage = withFallback(props => {
     autoFocus={autoFocus}
     canCreate={canCreate}
     canExpand={canExpand}
+    createAccessReview={createAccessReview}
     createButtonText={createButtonText || `Create ${label}`}
     createProps={createProps}
     filterLabel={filterLabel || 'by name'}
@@ -367,6 +376,7 @@ export const MultiListPage = props => {
     autoFocus,
     canCreate,
     canExpand,
+    createAccessReview,
     createButtonText,
     createProps,
     filterLabel,
@@ -395,6 +405,7 @@ export const MultiListPage = props => {
     autoFocus={autoFocus}
     canCreate={canCreate}
     canExpand={canExpand}
+    createAccessReview={createAccessReview}
     createButtonText={createButtonText || 'Create'}
     createProps={createProps}
     filterLabel={filterLabel || 'by name'}

--- a/frontend/public/components/job.jsx
+++ b/frontend/public/components/job.jsx
@@ -13,6 +13,13 @@ const ModifyJobParallelism = (kind, obj) => ({
     resourceKind: kind,
     resource: obj,
   }),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    name: obj.metadata.name,
+    namespace: obj.metadata.namespace,
+    verb: 'patch',
+  },
 });
 const menuActions = [ModifyJobParallelism, ...Kebab.factory.common];
 

--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -21,6 +21,7 @@ import {
 } from './factory';
 import {
   Kebab,
+  KebabAction,
   navFactory,
   pluralize,
   ResourceKebab,
@@ -32,9 +33,15 @@ import {
   WorkloadPausedAlert,
 } from './utils';
 
-const pauseAction = (kind, obj) => ({
+const pauseAction: KebabAction = (kind, obj) => ({
   label: obj.spec.paused ? 'Resume Updates' : 'Pause Updates',
   callback: () => togglePaused(kind, obj).catch((err) => errorModal({error: err.message})),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    name: obj.metadata.name,
+    verb: 'patch',
+  },
 });
 
 const machineConfigPoolReference = referenceForModel(MachineConfigPoolModel);

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
 
-import { MachineModel, MachineSetModel } from '../models';
+import { MachineAutoscalerModel, MachineModel, MachineSetModel } from '../models';
 import { K8sKind, MachineDeploymentKind, MachineSetKind, referenceForModel } from '../module/k8s';
 import { getMachineRole, MachinePage } from './machine';
 import { configureMachineAutoscalerModal, configureReplicaCountModal } from './modals';
@@ -31,11 +31,24 @@ const machineReplicasModal = (resourceKind: K8sKind, resource: MachineSetKind | 
 export const editCountAction: KebabAction = (kind: K8sKind, resource: MachineSetKind | MachineDeploymentKind) => ({
   label: 'Edit Count',
   callback: () => machineReplicasModal(kind, resource),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    name: resource.metadata.name,
+    namespace: resource.metadata.namespace,
+    verb: 'patch',
+  },
 });
 
-const configureMachineAutoscaler = (kind: K8sKind, machineSet: MachineSetKind) => ({
+const configureMachineAutoscaler: KebabAction = (kind: K8sKind, machineSet: MachineSetKind) => ({
   label: 'Create Autoscaler',
   callback: () => configureMachineAutoscalerModal({machineSet, cancel: _.noop, close: _.noop}),
+  accessReview: {
+    group: MachineAutoscalerModel.apiGroup,
+    resource: MachineAutoscalerModel.path,
+    namespace: machineSet.metadata.namespace,
+    verb: 'create',
+  },
 });
 
 const { common } = Kebab.factory;

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -113,7 +113,7 @@ const silenceMenuActions = (silence) => silenceState(silence) === SilenceStates.
 
 const SilenceKebab = ({silence}) => <Kebab options={silenceMenuActions(silence)} />;
 
-const SilenceActionsMenu = ({silence}) => <div className="co-actions">
+const SilenceActionsMenu = ({silence}) => <div className="co-actions" data-test-id="details-actions">
   <ActionsMenu actions={silenceMenuActions(silence)} />
 </div>;
 
@@ -242,7 +242,7 @@ const AlertsDetailsPage = withFallback(connect(alertStateToProps)((props: Alerts
       <div className="co-m-nav-title co-m-nav-title--detail">
         <h1 className="co-m-pane__heading">
           <div className="co-m-pane__name co-resource-item"><MonitoringResourceIcon className="co-m-resource-icon--lg" resource={AlertResource} />{alertname}</div>
-          {(state === AlertStates.Firing || state === AlertStates.Pending) && <div className="co-actions">
+          {(state === AlertStates.Firing || state === AlertStates.Pending) && <div className="co-actions" data-test-id="details-actions">
             <ActionsMenu actions={[silenceAlert(alert)]} />
           </div>}
         </h1>

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -24,7 +24,7 @@ const getDisplayName = obj => _.get(obj, ['metadata', 'annotations', 'openshift.
 const getRequester = obj => _.get(obj, ['metadata', 'annotations', 'openshift.io/requester']);
 
 export const deleteModal = (kind, ns) => {
-  let {label, weight} = Kebab.factory.Delete(kind, ns);
+  let {label, weight, accessReview} = Kebab.factory.Delete(kind, ns);
   let callback = undefined;
   let tooltip;
 
@@ -40,7 +40,7 @@ export const deleteModal = (kind, ns) => {
       <Tooltip content={tooltip}>{label}</Tooltip>
     </div>;
   }
-  return {label, weight, callback};
+  return {label, weight, callback, accessReview};
 };
 
 const nsMenuActions = [Kebab.factory.ModifyLabels, Kebab.factory.ModifyAnnotations, Kebab.factory.Edit, deleteModal];
@@ -122,8 +122,10 @@ const ProjectList_ = props => {
 export const ProjectList = connect(createProjectMessageStateToProps)(ProjectList_);
 
 const ProjectsPage_ = props => {
-  const canCreate = props.flags.CAN_CREATE_PROJECT;
-  return <ListPage {...props} ListComponent={ProjectList} canCreate={canCreate} createHandler={() => createProjectModal({ blocking: true })} />;
+  const canCreate = props.flags[FLAGS.CAN_CREATE_PROJECT];
+  // Skip self-subject access review for projects since they use a special project request API.
+  // `FLAGS.CAN_CREATE_PROJECT` determines if the user can create projects.
+  return <ListPage {...props} ListComponent={ProjectList} canCreate={canCreate} skipAccessReview createHandler={() => createProjectModal({ blocking: true })} />;
 };
 export const ProjectsPage = connectToFlags(FLAGS.CAN_CREATE_PROJECT)(ProjectsPage_);
 

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -15,12 +15,26 @@ const MarkAsUnschedulable = (kind, obj) => ({
   label: 'Mark as Unschedulable',
   hidden: _.get(obj, 'spec.unschedulable'),
   callback: () => configureUnschedulableModal({resource: obj}),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    name: obj.metadata.name,
+    namespace: obj.metadata.namespace,
+    verb: 'patch',
+  },
 });
 
 const MarkAsSchedulable = (kind, obj) => ({
   label: 'Mark as Schedulable',
   hidden: !_.get(obj, 'spec.unschedulable', false),
   callback: () => makeNodeSchedulable(obj),
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.path,
+    name: obj.metadata.name,
+    namespace: obj.metadata.namespace,
+    verb: 'patch',
+  },
 });
 
 const { ModifyLabels, ModifyAnnotations, Edit } = Kebab.factory;

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
@@ -22,14 +22,29 @@ const actions = [
   (kind, obj) => ({
     label: `Edit ${kind.label}`,
     href: `/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${csvName()}/${referenceFor(obj)}/${obj.metadata.name}/yaml`,
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'update',
+    },
   }),
   (kind, obj) => ({
     label: `Delete ${kind.label}`,
     callback: () => deleteModal({
       kind,
       resource: obj,
+      namespace: obj.metadata.namespace,
       redirectTo: `/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${csvName()}/${referenceFor(obj)}`,
     }),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'delete',
+    },
   }),
 ] as KebabAction[];
 

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -35,6 +35,13 @@ const menuActions = [
   (kind, obj) => ({
     label: 'Remove Subscription...',
     callback: () => createDisableApplicationModal({k8sKill, k8sGet, k8sPatch, subscription: obj}),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'delete',
+    },
   }),
   (kind, obj) => {
     const installedCSV = _.get(obj, 'status.installedCSV');

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -30,6 +30,13 @@ const menuActions = [
   (kind, obj) => ({
     label: `Edit ${kind.label}`,
     href: `${resourceObjPath(obj, kind.kind)}/edit`,
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'update',
+    },
   }),
   Kebab.factory.Delete,
 ];

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -69,6 +69,12 @@ const KubeConfigify = (kind, sa) => ({
       errorModal({error});
     });
   },
+  accessReview: {
+    group: SecretModel.apiGroup,
+    resource: SecretModel.path,
+    namespace: sa.metadata.namespace,
+    verb: 'list',
+  },
 });
 const { common } = Kebab.factory;
 const menuActions = [KubeConfigify, ...common];

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -31,6 +31,12 @@ const createBinding = (kindObj, serviceInstance) => {
   return {
     callback: () => goToCreateBindingPage(serviceInstance),
     label: 'Create Service Binding',
+    accessReview: {
+      group: ServiceBindingModel.apiGroup,
+      resource: ServiceBindingModel.path,
+      namespace: serviceInstance.metadata.namespace,
+      verb: 'create',
+    },
   };
 };
 

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -58,7 +58,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
     { breadcrumbsFor && !_.isEmpty(data) && <BreadCrumbs breadcrumbs={breadcrumbsFor(data)} /> }
     <h1 className={classNames('co-m-pane__heading', {'co-m-pane__heading--logo': isCSV})}>
       { logo }
-      { showActions && <div className="co-actions">
+      { showActions && <div className="co-actions" data-test-id="details-actions">
         { hasButtonActions && <ActionButtons actionButtons={buttonActions.map(a => a(kindObj, data))} /> }
         { hasMenuActions && <ActionsMenu actions={menuActions.map(a => a(kindObj, data))} /> }
       </div> }

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -47,6 +47,7 @@ export * from './workload-pause';
 export * from './list-dropdown';
 export * from './status-icon';
 export * from './list-input';
+export * from './rbac';
 
 /*
   Add the enum for NameValueEditorPair here and not in its namesake file because the editor should always be

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -1,17 +1,49 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { connect } from 'react-redux';
 
 import { annotationsModal, configureReplicaCountModal, taintsModal, tolerationsModal, labelsModal, podSelectorModal, deleteModal, expandPVCModal } from '../modals';
 import { DropdownMixin } from './dropdown';
-import { history, resourceObjPath } from './index';
-import { referenceForModel, K8sResourceKind, K8sResourceKindReference, K8sKind } from '../../module/k8s';
+import { checkAccess, history, resourceObjPath, useAccessReview } from './index';
+import {
+  AccessReviewResourceAttributes,
+  K8sKind,
+  K8sResourceKind,
+  K8sResourceKindReference,
+  referenceForModel,
+} from '../../module/k8s';
+import { impersonateStateToProps } from '../../reducers/ui';
 import { connectToModel } from '../../kinds';
 
-const KebabItems: React.SFC<KebabItemsProps> = ({options, onClick}) => {
+const KebabItemEnabled: React.FC<KebabItemProps> = ({option, onClick}) => {
+  return <a href="#" onClick={(e) => onClick(e, option)} data-test-action={option.label}>{option.label}</a>;
+};
+
+const KebabItemDisabled: React.FC<{option: KebabOption}> = ({option}) => {
+  return <a className="disabled">{option.label}</a>;
+};
+
+const KebabItemAccessReview_ = (props: KebabItemProps & { impersonate: string }) => {
+  const { option, impersonate } = props;
+  const isAllowed = useAccessReview(option.accessReview, impersonate);
+  return isAllowed
+    ? <KebabItemEnabled {...props} />
+    : <KebabItemDisabled option={option} />;
+};
+const KebabItemAccessReview = connect(impersonateStateToProps)(KebabItemAccessReview_);
+
+const KebabItem: React.FC<KebabItemProps> = (props) => {
+  return props.option.accessReview
+    ? <KebabItemAccessReview {...props} />
+    : <KebabItemEnabled {...props} />;
+};
+
+export const KebabItems: React.SFC<KebabItemsProps> = ({options, onClick}) => {
   const visibleOptions = _.reject(options, o => _.get(o, 'hidden', false));
-  const lis = _.map(visibleOptions, (o, i) => <li key={i}><a href="#" onClick={e => onClick(e, o)}>{o.label}</a></li>);
-  return <ul className="dropdown-menu dropdown-menu-right dropdown-menu--block co-kebab__dropdown">
-    {lis}
+  return <ul className="dropdown-menu dropdown-menu-right dropdown-menu--block co-kebab__dropdown" data-test-id="action-items">
+    {_.map(visibleOptions, (o, i) => <li key={i}>
+      <KebabItem option={o} onClick={onClick} />
+    </li>)}
   </ul>;
 };
 
@@ -22,10 +54,25 @@ const kebabFactory: KebabFactory = {
       kind,
       resource: obj,
     }),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'delete',
+    },
   }),
   Edit: (kind, obj) => ({
     label: `Edit ${kind.label}`,
     href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/yaml`,
+    // TODO: Fallback to "View YAML"? We might want a similar fallback for annotations, labels, etc.
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'update',
+    },
   }),
   ModifyLabels: (kind, obj) => ({
     label: 'Edit Labels',
@@ -34,6 +81,13 @@ const kebabFactory: KebabFactory = {
       resource: obj,
       blocking: true,
     }),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'patch',
+    },
   }),
   ModifyPodSelector: (kind, obj) => ({
     label: 'Edit Pod Selector',
@@ -42,6 +96,13 @@ const kebabFactory: KebabFactory = {
       resource:  obj,
       blocking: true,
     }),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'patch',
+    },
   }),
   ModifyAnnotations: (kind, obj) => ({
     label: 'Edit Annotations',
@@ -50,6 +111,13 @@ const kebabFactory: KebabFactory = {
       resource: obj,
       blocking: true,
     }),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'patch',
+    },
   }),
   ModifyCount: (kind, obj) => ({
     label: 'Edit Count',
@@ -57,6 +125,13 @@ const kebabFactory: KebabFactory = {
       resourceKind: kind,
       resource: obj,
     }),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'patch',
+    },
   }),
   ModifyTaints: (kind, obj) => ({
     label: 'Edit Taints',
@@ -65,6 +140,13 @@ const kebabFactory: KebabFactory = {
       resource: obj,
       modalClassName: 'modal-lg',
     }),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'patch',
+    },
   }),
   ModifyTolerations: (kind, obj) => ({
     label: 'Edit Tolerations',
@@ -73,14 +155,35 @@ const kebabFactory: KebabFactory = {
       resource: obj,
       modalClassName: 'modal-lg',
     }),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'patch',
+    },
   }),
   EditEnvironment: (kind, obj) => ({
     label: `${kind.kind === 'Pod' ? 'View' : 'Edit'} Environment`,
     href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/environment`,
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'patch',
+    },
   }),
   AddStorage: (kind, obj) => ({
     label: 'Add Storage',
     href: `${resourceObjPath(obj, kind.crd ? referenceForModel(kind) : kind.kind)}/attach-storage`,
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'patch',
+    },
   }),
   ExpandPVC: (kind, obj) => ({
     label: 'Expand PVC',
@@ -88,6 +191,13 @@ const kebabFactory: KebabFactory = {
       kind,
       resource: obj,
     }),
+    accessReview: {
+      group: kind.apiGroup,
+      resource: kind.path,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'patch',
+    },
   }),
 };
 
@@ -110,9 +220,8 @@ export const ResourceKebab = connectToModel((props: ResourceKebabProps) => {
 
 export class Kebab extends DropdownMixin {
   static factory: KebabFactory = kebabFactory;
-  private onClick = this.onClick_.bind(this);
 
-  onClick_(event, option) {
+  onClick = (event, option: KebabOption) => {
     event.preventDefault();
 
     if (option.callback) {
@@ -124,13 +233,23 @@ export class Kebab extends DropdownMixin {
     }
 
     this.hide();
+  };
+
+  onHover = () => {
+    // Check access when hovering over a kebab to minimize flicker when opened.
+    // This depends on `checkAccess` being memoized.
+    _.each(this.props.options, (option: KebabOption) => {
+      if (option.accessReview) {
+        checkAccess(option.accessReview);
+      }
+    });
   }
 
   render() {
     const {options, isDisabled} = this.props;
 
-    return <div ref={this.dropdownElement} className="co-kebab">
-      <button type="button" aria-label="Actions" disabled={isDisabled} aria-haspopup="true" className="btn btn-link co-kebab__button" onClick={this.toggle}>
+    return <div ref={this.dropdownElement} className="co-kebab" onMouseEnter={this.onHover} onFocus={this.onHover}>
+      <button type="button" aria-label="Actions" disabled={isDisabled} aria-haspopup="true" className="btn btn-link co-kebab__button" onClick={this.toggle} data-test-id="kebab-button">
         <span className="fa fa-ellipsis-v co-kebab__icon" aria-hidden="true"></span>
       </button>
       {(!isDisabled && this.state.active) && <KebabItems options={options} onClick={this.onClick} />}
@@ -141,6 +260,7 @@ export class Kebab extends DropdownMixin {
 export type KebabOption = {
   label: string;
   href?: string, callback?: () => any;
+  accessReview?: AccessReviewResourceAttributes;
 };
 export type KebabAction = (kind: K8sKind, obj: K8sResourceKind) => KebabOption;
 
@@ -150,6 +270,11 @@ export type ResourceKebabProps = {
   kind: K8sResourceKindReference;
   resource: K8sResourceKind;
   isDisabled?: boolean;
+};
+
+type KebabItemProps = {
+  option: KebabOption;
+  onClick: (event: React.MouseEvent<{}>, option: KebabOption) => void;
 };
 
 export type KebabItemsProps = {

--- a/frontend/public/components/utils/rbac.tsx
+++ b/frontend/public/components/utils/rbac.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import * as _ from 'lodash-es';
+
+import store from '../../redux';
+import { impersonateStateToProps } from '../../reducers/ui';
+import { AccessReviewResourceAttributes, k8sCreate, K8sKind, K8sVerb, SelfSubjectAccessReviewKind } from '../../module/k8s';
+import { SelfSubjectAccessReviewModel } from '../../models';
+
+// Memoize the result so we only make the request once for each access review.
+// This does mean that the user will have to refresh the page to see updates.
+// Accept an `impersonateKey` parameter to include in the cache key even though
+// it's not used in the function body. (Impersonate headers are added
+// automatically by `k8sCreate`.) This function takes in the destructured
+// resource attributes so that the cache keys are stable. (`JSON.stringify` is
+// not guaranteed to give the same result for equivalent objects.)
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+const checkAccessInternal = _.memoize((group: string, resource: string, subresource: string, verb: K8sVerb, name: string, namespace: string, impersonateKey: string): Promise<SelfSubjectAccessReviewKind> => {
+  const ssar: SelfSubjectAccessReviewKind = {
+    apiVersion: 'authorization.k8s.io/v1',
+    kind: 'SelfSubjectAccessReview',
+    spec: {
+      resourceAttributes: { group, resource, subresource, verb, name, namespace },
+    },
+  };
+  return k8sCreate(SelfSubjectAccessReviewModel, ssar);
+}, (...args) => args.join('~'));
+
+const getImpersonateKey = (impersonate): string => {
+  impersonate = impersonate || store.getState().UI.get('impersonate');
+  return impersonate ? `${impersonate.kind}~{impersonate.user}` : '';
+};
+
+export const checkAccess = (resourceAttributes: AccessReviewResourceAttributes, impersonate?): Promise<SelfSubjectAccessReviewKind> => {
+  // Destructure the attributes with defaults so we can create a stable cache key.
+  const {group = '', resource = '', subresource = '', verb = '' as K8sVerb, name = '', namespace = ''} = (resourceAttributes || {});
+  return checkAccessInternal(group, resource, subresource, verb, name, namespace, getImpersonateKey(impersonate));
+};
+
+export const useAccessReview = (resourceAttributes: AccessReviewResourceAttributes, impersonate?): boolean => {
+  const [isAllowed, setAllowed] = React.useState(false);
+  // Destructure the attributes to pass them as dependencies to `useEffect`,
+  // which doesn't do deep comparison of object dependencies.
+  const {group = '', resource = '', subresource = '', verb = '' as K8sVerb, name = '', namespace = ''} = resourceAttributes;
+  const impersonateKey = getImpersonateKey(impersonate);
+  React.useEffect(() => {
+    checkAccessInternal(group, resource, subresource, verb, name, namespace, impersonateKey)
+      .then((result: SelfSubjectAccessReviewKind) => {
+        setAllowed(result.status.allowed);
+      })
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.warn('SelfSubjectAccessReview failed', e);
+        // Default to enabling the action if the access review fails so that we
+        // don't incorrectly block users from actions they can perform. The server
+        // still enforces access control.
+        setAllowed(true);
+      });
+  }, [group, resource, subresource, verb, name, namespace, impersonateKey]);
+
+  return isAllowed;
+};
+
+const RequireCreatePermission_: React.FC<RequireCreatePermissionProps> = ({model, namespace, impersonate, children}) => {
+  const isAllowed = useAccessReview({
+    group: model.apiGroup,
+    resource: model.path,
+    verb: 'create',
+    namespace,
+  }, impersonate);
+  return isAllowed ? <React.Fragment>{children}</React.Fragment> : null;
+};
+export const RequireCreatePermission = connect(impersonateStateToProps)(RequireCreatePermission_);
+RequireCreatePermission.displayName = 'RequireCreatePermission';
+
+type RequireCreatePermissionProps = {
+  model: K8sKind;
+  namespace?: string;
+  impersonate?: string;
+  children: React.ReactNode;
+};

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -80,7 +80,7 @@ export type Toleration = {
 export type K8sResourceKind = {
   apiVersion: string;
   kind: string;
-  metadata: ObjectMetadata;
+  metadata?: ObjectMetadata;
   spec?: {
     selector?: Selector;
     [key: string]: any
@@ -526,6 +526,29 @@ export type OAuthKind = {
       providerSelection: string;
       error: string;
     };
+  };
+} & K8sResourceKind;
+
+export type K8sVerb = 'create' | 'get' | 'list' | 'update' | 'patch' | 'delete' | 'deletecollection';
+
+export type AccessReviewResourceAttributes = {
+    group?: string;
+    resource?: string;
+    subresource?: string;
+    verb?: K8sVerb;
+    name?: string;
+    namespace?: string;
+};
+
+export type SelfSubjectAccessReviewKind = {
+  spec: {
+    resourceAttributes?: AccessReviewResourceAttributes;
+  };
+  status?: {
+    allowed: boolean;
+    denied?: boolean;
+    reason?: string;
+    evaluationError?: string;
   };
 } & K8sResourceKind;
 

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -159,3 +159,7 @@ export const createProjectMessageStateToProps = ({UI}: RootState) => {
 export const userStateToProps = ({UI}: RootState) => {
   return {user: UI.get('user')};
 };
+
+export const impersonateStateToProps = ({UI}: RootState) => {
+  return {impersonate: UI.get('impersonate')};
+};


### PR DESCRIPTION
Use `SelfSubjectAccessReview` requests to check access before displaying create buttons on list pages and actions in the action dropdowns. This change adds a `useAccessReview` hook for components to check access.

Defer checking permissions in action dropdowns until the dropdown is opened. This avoids firing off several SSAR requests for every table row at once, which isn't practical.

Memoize SSAR checks so that they only run once for specific `resourceAttributes`. Concurrent requests share a single promise. Impersonate user is included in the cache key, so impersonation works. As implemented, users will need to refresh the page if permissions change. (We already have this limitation for nav RBAC checks.)

This PR does not address modal links in the detail page itself, ~the YAML editor~, or create button on some pages that list multiple resources like Role Bindings.

We might want to change actions like "Edit Annotations" to "View Annotations" and open a read-only dialog.

TODO:

- [x] Avoid flicker when menu items go from disabled -> enabled when first opened
- [x] Make YAML editor read-only when no access
- [x] Update existing integration tests

Follow on work:

- [ ] Update other edit contexts like env var editor and modals
- [ ] Soften access denied error
- [ ] Integration tests specific to RBAC