### PR TITLE
build-backend.sh: use SOURCE_GIT_TAG if available

### DIFF
--- a/build-backend.sh
+++ b/build-backend.sh
@@ -7,7 +7,7 @@ set -e
 
 PROJECT_DIR=$(basename ${PWD})
 
-GIT_TAG=`git describe --always --tags HEAD`
+GIT_TAG=${SOURCE_GIT_TAG:-$(git describe --always --tags HEAD)}
 LD_FLAGS="-w -X github.com/openshift/console/version.Version=${GIT_TAG}"
 
 CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o bin/bridge github.com/openshift/console/cmd/bridge


### PR DESCRIPTION
This will be supplied in downstream builds to relay the tag from the source git repo.