### PR TITLE
Add Type Definition for Global `window` 

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -225,7 +225,7 @@ export const checkLogs = async() => (await browser.manage().logs().get('browser'
   });
 
 function hasError() {
-  return (window as any).windowError;
+  return window.windowError;
 }
 export const checkErrors = async() => await browser.executeScript(hasError).then(err => {
   if (err) {

--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -30,7 +30,7 @@ export enum ActionType {
 }
 
 export const defaults = _.mapValues(FLAGS, flag => flag === FLAGS.AUTH_ENABLED
-  ? !(window as any).SERVER_FLAGS.authDisabled
+  ? !window.SERVER_FLAGS.authDisabled
   : undefined
 );
 

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -63,7 +63,7 @@ export const formatNamespaceRoute = (activeNamespace, originalPath, location?) =
     return originalPath;
   }
 
-  originalPath = originalPath.substr(prefix.length + (window as any).SERVER_FLAGS.basePath.length);
+  originalPath = originalPath.substr(prefix.length + window.SERVER_FLAGS.basePath.length);
 
   let parts = originalPath.split('/').filter(p => p);
   let previousNS = '';
@@ -153,12 +153,12 @@ export const startImpersonate = (kind: string, name: string) => async(dispatch, 
 
   dispatch(beginImpersonate(kind, name, subprotocols));
   dispatch(detectFeatures());
-  history.push((window as any).SERVER_FLAGS.basePath);
+  history.push(window.SERVER_FLAGS.basePath);
 };
 export const stopImpersonate = () => (dispatch) => {
   dispatch(endImpersonate());
   dispatch(detectFeatures());
-  history.push((window as any).SERVER_FLAGS.basePath);
+  history.push(window.SERVER_FLAGS.basePath);
 };
 export const sortList = (listId: string, field: string, func: any, orderBy: string, column: string) => {
   const url = new URL(window.location.href);

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -16,7 +16,7 @@ const AboutModal_: React.FC<AboutModalProps> = ({isOpen, closeAboutModal, cluste
   }, []);
 
   const details = getBrandingDetails();
-  const customBranding = (window as any).SERVER_FLAGS.customLogoURL || (window as any).SERVER_FLAGS.customProductName;
+  const customBranding = window.SERVER_FLAGS.customLogoURL || window.SERVER_FLAGS.customProductName;
 
   return (
     <PfAboutModal

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -26,7 +26,7 @@ export const createModalLauncher: CreateModalLauncher = (Component) => (props) =
     };
     Modal.setAppElement(modalContainer);
     ReactDOM.render(<Provider store={store}>
-      <Router {...{history, basename: (window as any).SERVER_FLAGS.basePath}}>
+      <Router {...{history, basename: window.SERVER_FLAGS.basePath}}>
         <Modal
           isOpen={true}
           contentLabel="Modal"

--- a/frontend/public/components/modals/command-line-tools-modal.tsx
+++ b/frontend/public/components/modals/command-line-tools-modal.tsx
@@ -13,10 +13,10 @@ export const commandLineToolsModal = createModalLauncher(
       <p>The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features.</p>
       <p>
         <ExternalLink href={OC_DOWNLOAD_LINK} text="Download oc" />
-        {(window as any).SERVER_FLAGS.requestTokenURL && (
+        {window.SERVER_FLAGS.requestTokenURL && (
           <React.Fragment>
             &nbsp;<span className="co-action-divider" aria-hidden="true">|</span>
-            &nbsp;<ExternalLink href={(window as any).SERVER_FLAGS.requestTokenURL} text="Copy Login Command" />
+            &nbsp;<ExternalLink href={window.SERVER_FLAGS.requestTokenURL} text="Copy Login Command" />
           </React.Fragment>
         )}
       </p>

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -102,7 +102,7 @@ const cancelSilence = (silence) => ({
     title: 'Expire Silence',
     message: 'Are you sure you want to expire this silence?',
     btnText: 'Expire Silence',
-    executeFn: () => coFetchJSON.delete(`${(window as any).SERVER_FLAGS.alertManagerBaseURL}/api/v1/silence/${silence.id}`)
+    executeFn: () => coFetchJSON.delete(`${window.SERVER_FLAGS.alertManagerBaseURL}/api/v1/silence/${silence.id}`)
       .then(() => refreshPoller('silences')),
   }),
 });
@@ -809,7 +809,7 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
   onSubmit = (e): void => {
     e.preventDefault();
 
-    const {alertManagerBaseURL} = (window as any).SERVER_FLAGS;
+    const {alertManagerBaseURL} = window.SERVER_FLAGS;
     if (!alertManagerBaseURL) {
       this.setState({error: 'Alertmanager URL not set'});
       return;
@@ -1006,7 +1006,7 @@ export class MonitoringUI extends React.Component<null, null> {
       poller();
     };
 
-    const {alertManagerBaseURL, prometheusBaseURL} = (window as any).SERVER_FLAGS;
+    const {alertManagerBaseURL, prometheusBaseURL} = window.SERVER_FLAGS;
 
     if (prometheusBaseURL) {
       poll(`${prometheusBaseURL}/api/v1/rules`, 'alerts', data => {

--- a/frontend/public/components/utils/documentation.tsx
+++ b/frontend/public/components/utils/documentation.tsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash-es';
 import { ExternalLink } from '../utils';
 
 // Prefer the documentation base URL passed as a flag, but fall back to the latest docs if none was specified.
-export const openshiftHelpBase = (window as any).SERVER_FLAGS.documentationBaseURL || 'https://docs.okd.io/latest/';
+export const openshiftHelpBase = window.SERVER_FLAGS.documentationBaseURL || 'https://docs.okd.io/latest/';
 
 /* eslint-disable react/jsx-no-target-blank */
 export const DocumentationLinks = () => <dl className="co-documentation-links">

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -16,7 +16,7 @@ import { ALL_NAMESPACES_KEY } from '../../const';
 
 export const legalNamePattern = /[a-z0-9](?:[-a-z0-9]*[a-z0-9])?/;
 
-const basePathPattern = new RegExp(`^/?${(window as any).SERVER_FLAGS.basePath}`);
+const basePathPattern = new RegExp(`^/?${window.SERVER_FLAGS.basePath}`);
 
 export const namespacedPrefixes = ['/search', '/status', '/k8s', '/overview', '/catalog', '/provisionedservices', '/operators', '/operatormanagement', '/operatorhub'];
 

--- a/frontend/public/components/utils/router.ts
+++ b/frontend/public/components/utils/router.ts
@@ -17,10 +17,10 @@ try {
   createHistory = createBrowserHistory;
 }
 
-export const history = createHistory({basename: (window as any).SERVER_FLAGS.basePath});
+export const history = createHistory({basename: window.SERVER_FLAGS.basePath});
 
-const removeBasePath = (url = '/') => _.startsWith(url, (window as any).SERVER_FLAGS.basePath)
-  ? url.slice((window as any).SERVER_FLAGS.basePath.length - 1)
+const removeBasePath = (url = '/') => _.startsWith(url, window.SERVER_FLAGS.basePath)
+  ? url.slice(window.SERVER_FLAGS.basePath.length - 1)
   : url;
 
 // Monkey patch history to slice off the base path

--- a/frontend/public/components/utils/webhooks.tsx
+++ b/frontend/public/components/utils/webhooks.tsx
@@ -6,7 +6,7 @@ import * as _ from 'lodash-es';
 import { K8sResourceKind } from '../../module/k8s';
 import { SectionHeading, ResourceLink } from '.';
 
-const kubeAPIServerURL = (window as any).SERVER_FLAGS.kubeAPIServerURL || 'https://<api-server>';
+const kubeAPIServerURL = window.SERVER_FLAGS.kubeAPIServerURL || 'https://<api-server>';
 enum TriggerTypes {
   Bitbucket ='Bitbucket',
   ConfigChange = 'ConfigChange',

--- a/frontend/public/const.ts
+++ b/frontend/public/const.ts
@@ -28,7 +28,7 @@ export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
 export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-namespace-name`;
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
 export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/community-providers-warning`;
-export const SWAGGER_SESSION_STORAGE_KEY = `${STORAGE_PREFIX}/${(window as any).SERVER_FLAGS.consoleVersion}/swagger-definitions`;
+export const SWAGGER_SESSION_STORAGE_KEY = `${STORAGE_PREFIX}/${window.SERVER_FLAGS.consoleVersion}/swagger-definitions`;
 
 // Bootstrap user for OpenShift 4.0 clusters
 export const KUBE_ADMIN_USERNAME = 'kube:admin';

--- a/frontend/public/declarations.d.ts
+++ b/frontend/public/declarations.d.ts
@@ -8,6 +8,34 @@ declare module '*.png' {
   export = value;
 }
 
+declare interface Window {
+  SERVER_FLAGS: {
+    alertManagerBaseURL: string;
+    authDisabled: boolean;
+    basePath: string;
+    branding: string;
+    consoleVersion: string;
+    customLogoURL: string;
+    customProductName: string;
+    documentationBaseURL: string;
+    googleTagManagerID: string;
+    kubeAPIServerURL: string;
+    kubeAdminLogoutURL: string;
+    kubectlClientID: string;
+    loadTestFactor: number
+    loginErrorURL: string;
+    loginSuccessURL: string;
+    loginURL: string;
+    logoutRedirect: string;
+    logoutURL: string;
+    prometheusBaseURL: string;
+    prometheusTenancyBaseURL: string;
+    requestTokenURL: string;
+    statuspageID: string;
+  };
+  windowError?: boolean;
+}
+
 // From https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 declare type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 declare type Diff<T, K> = Omit<T, keyof K>;

--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -15,7 +15,7 @@ export const kindToAbbr = kind => (kind.replace(/[^A-Z]/g, '') || kind.toUpperCa
 export const cacheResources = (resources) => new Promise<void>((resolve, reject) => {
   try {
     // Add the console version. We invalidate the cache when console version changes.
-    const { consoleVersion } = (window as any).SERVER_FLAGS;
+    const { consoleVersion } = window.SERVER_FLAGS;
     const versionedResources = _.assign({}, resources, { consoleVersion });
     localStorage.setItem(API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY, JSON.stringify(versionedResources));
     resolve();
@@ -38,7 +38,7 @@ export const getCachedResources = () => new Promise<any>((resolve, reject) => {
 
     if (resourcesJSON) {
       const resources = JSON.parse(resourcesJSON);
-      const { consoleVersion: currentVersion } = (window as any).SERVER_FLAGS;
+      const { consoleVersion: currentVersion } = window.SERVER_FLAGS;
       const { consoleVersion: cachedVersion } = resources;
       if (cachedVersion !== currentVersion) {
         // eslint-disable-next-line no-console

--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -6,7 +6,7 @@ import { K8sResourceKindReference, GroupVersionKind, CustomResourceDefinitionKin
 
 export const getQN: (obj: K8sResourceKind) => string = ({metadata: {name, namespace}}) => (namespace ? `(${namespace})-` : '') + name;
 
-export const k8sBasePath = `${(window as any).SERVER_FLAGS.basePath}api/kubernetes`;
+export const k8sBasePath = `${window.SERVER_FLAGS.basePath}api/kubernetes`;
 
 // TODO(alecmerdler): Replace all manual string building with this function
 export const referenceForGroupVersionKind = (group: string) => (version: string) => (kind: string) => [group, version, kind].join('~');

--- a/frontend/public/reducers/features.ts
+++ b/frontend/public/reducers/features.ts
@@ -19,7 +19,7 @@ import { FeatureAction, ActionType } from '../actions/features';
 import { FLAGS } from '../const';
 
 export const defaults = _.mapValues(FLAGS, flag => flag === FLAGS.AUTH_ENABLED
-  ? !(window as any).SERVER_FLAGS.authDisabled
+  ? !window.SERVER_FLAGS.authDisabled
   : undefined
 );
 


### PR DESCRIPTION
### Description

Removes the need for `(window as any)` by defining what our global `window` looks like (includes `SERVER_FLAGS`).

