### PR TITLE
Remove TypeScript `eslint-disable` Pragmas

### DIFF
--- a/frontend/__mocks__/k8sResourcesMocks.ts
+++ b/frontend/__mocks__/k8sResourcesMocks.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import {
   ClusterServiceVersionKind,
   ClusterServiceVersionResourceKind,
@@ -13,7 +12,6 @@ import {
   InstallPlanPhase } from '../public/components/operator-lifecycle-manager';
 import { StatusCapability, SpecCapability } from '../public/components/operator-lifecycle-manager/descriptors/types';
 import { CustomResourceDefinitionKind, K8sResourceKind, K8sKind } from '../public/module/k8s';
-/* eslint-enable no-unused-vars */
 
 export const testNamespace: K8sResourceKind = {
   apiVersion: 'v1',

--- a/frontend/__mocks__/operatorHubItemsMocks.ts
+++ b/frontend/__mocks__/operatorHubItemsMocks.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
-
 import { PackageManifestKind } from '../public/components/operator-lifecycle-manager';
 import { OperatorHubItem } from '../public/components/operator-hub';
 

--- a/frontend/__tests__/actions/k8s.spec.ts
+++ b/frontend/__tests__/actions/k8s.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import Spy = jasmine.Spy;
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';

--- a/frontend/__tests__/components/create-yaml.spec.tsx
+++ b/frontend/__tests__/components/create-yaml.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { safeLoad, safeDump } from 'js-yaml';

--- a/frontend/__tests__/components/factory/details.spec.tsx
+++ b/frontend/__tests__/components/factory/details.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 

--- a/frontend/__tests__/components/factory/list-page.spec.tsx
+++ b/frontend/__tests__/components/factory/list-page.spec.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line no-unused-vars
 import { shallow, ShallowWrapper } from 'enzyme';
 
 import { TextFilter, ListPageWrapper_, FireMan_, MultiListPage } from '../../../public/components/factory/list-page';

--- a/frontend/__tests__/components/modals/disable-application-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/disable-application-modal.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
 import Spy = jasmine.Spy;

--- a/frontend/__tests__/components/modals/installplan-approval-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/installplan-approval-modal.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
 import Spy = jasmine.Spy;

--- a/frontend/__tests__/components/modals/subscription-channel-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/subscription-channel-modal.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
 import Spy = jasmine.Spy;

--- a/frontend/__tests__/components/namespace.spec.tsx
+++ b/frontend/__tests__/components/namespace.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import Spy = jasmine.Spy;

--- a/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/catalog-source.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';

--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion-resource.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { match as RouterMatch } from 'react-router-dom';
 import { shallow, ShallowWrapper } from 'enzyme';

--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper, mount, ReactWrapper } from 'enzyme';
 import { Link } from 'react-router-dom';

--- a/frontend/__tests__/components/operator-lifecycle-manager/create-crd-yaml.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/create-crd-yaml.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash-es';

--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/spec/index.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/spec/index.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/spec/resource-requirements.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/spec/resource-requirements.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { shallow, mount, ShallowWrapper, ReactWrapper } from 'enzyme';

--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/index.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/index.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/phase.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/phase.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/pods.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/descriptors/status/pods.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
-
 import * as React from 'react';
 import * as _ from 'lodash';
 import { shallow, ShallowWrapper } from 'enzyme';

--- a/frontend/__tests__/components/operator-lifecycle-manager/operator-group.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/operator-group.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { shallow } from 'enzyme';

--- a/frontend/__tests__/components/operator-lifecycle-manager/package-manifest.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/package-manifest.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { shallow, ShallowWrapper } from 'enzyme';

--- a/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';

--- a/frontend/__tests__/components/pod.spec.tsx
+++ b/frontend/__tests__/components/pod.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 

--- a/frontend/__tests__/components/route-pages.spec.tsx
+++ b/frontend/__tests__/components/route-pages.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as React from 'react';
 import { shallow, mount } from 'enzyme';
 

--- a/frontend/__tests__/components/safety-first.spec.tsx
+++ b/frontend/__tests__/components/safety-first.spec.tsx
@@ -1,5 +1,5 @@
 
-/* eslint-disable no-undef, no-unused-vars */
+/* eslint-env node */
 
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';

--- a/frontend/__tests__/components/storage-class-form.spec.tsx
+++ b/frontend/__tests__/components/storage-class-form.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
 import Spy = jasmine.Spy;

--- a/frontend/__tests__/components/utils/copy-to-clipboard.spec.tsx
+++ b/frontend/__tests__/components/utils/copy-to-clipboard.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { Tooltip } from 'react-lightweight-tooltip';

--- a/frontend/__tests__/components/utils/download-button.spec.tsx
+++ b/frontend/__tests__/components/utils/download-button.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import Spy = jasmine.Spy;

--- a/frontend/__tests__/components/utils/error-boundary.spec.tsx
+++ b/frontend/__tests__/components/utils/error-boundary.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 

--- a/frontend/__tests__/components/utils/firehose.spec.tsx
+++ b/frontend/__tests__/components/utils/firehose.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { ShallowWrapper, shallow } from 'enzyme';
 import { Map as ImmutableMap } from 'immutable';

--- a/frontend/__tests__/components/utils/page-heading.spec.tsx
+++ b/frontend/__tests__/components/utils/page-heading.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { shallow, ShallowWrapper } from 'enzyme';

--- a/frontend/__tests__/components/utils/promise-component.spec.tsx
+++ b/frontend/__tests__/components/utils/promise-component.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { shallow } from 'enzyme';
 

--- a/frontend/__tests__/module/k8s/autocomplete.spec.ts
+++ b/frontend/__tests__/module/k8s/autocomplete.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import { Editor, IEditSession, Position } from 'brace';
 
 import { getCompletions } from '../../../public/module/k8s/autocomplete';

--- a/frontend/__tests__/reducers/features.spec.tsx
+++ b/frontend/__tests__/reducers/features.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as Immutable from 'immutable';
 

--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { Config, browser, logging } from 'protractor';
 import { execSync } from 'child_process';
 import * as HtmlScreenshotReporter from 'protractor-jasmine2-screenshot-reporter';

--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef, no-unused-vars, no-console */
+/* eslint-disable no-console */
 
 import { browser, $, $$, by, ExpectedConditions as until, Key, element } from 'protractor';
 import { safeLoad, safeDump } from 'js-yaml';

--- a/frontend/integration-tests/tests/deploy-image.scenario.ts
+++ b/frontend/integration-tests/tests/deploy-image.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { browser, $, element, by, ExpectedConditions as until, Key } from 'protractor';
 import * as _ from 'lodash';
 

--- a/frontend/integration-tests/tests/developer-catalog.scenario.ts
+++ b/frontend/integration-tests/tests/developer-catalog.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { browser, $, $$, ExpectedConditions as until } from 'protractor';
 import { execSync } from 'child_process';
 

--- a/frontend/integration-tests/tests/olm/catalog.scenario.ts
+++ b/frontend/integration-tests/tests/olm/catalog.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { execSync } from 'child_process';
 import { browser, $, ExpectedConditions as until } from 'protractor';
 

--- a/frontend/integration-tests/tests/olm/descriptors.scenario.ts
+++ b/frontend/integration-tests/tests/olm/descriptors.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { execSync } from 'child_process';
 import { browser, element, by } from 'protractor';
 import { safeDump } from 'js-yaml';

--- a/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { browser, $, element, ExpectedConditions as until, by } from 'protractor';
 import { safeDump, safeLoad } from 'js-yaml';
 import { defaultsDeep } from 'lodash';

--- a/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { browser, $, $$, element, ExpectedConditions as until, by } from 'protractor';
 import { defaultsDeep } from 'lodash';
 import { safeDump, safeLoad } from 'js-yaml';

--- a/frontend/integration-tests/tests/olm/update-channel-approval.scenario.ts
+++ b/frontend/integration-tests/tests/olm/update-channel-approval.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { browser, ExpectedConditions as until, $, by, element } from 'protractor';
 import { defaultsDeep } from 'lodash';
 import { safeDump, safeLoad } from 'js-yaml';

--- a/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
+++ b/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { browser, $, ExpectedConditions as until, element, by } from 'protractor';
 import { execSync } from 'child_process';
 

--- a/frontend/integration-tests/tests/service-catalog/service-binding.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-binding.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import {execSync} from 'child_process';
 import {browser, $, $$, ExpectedConditions as until} from 'protractor';
 

--- a/frontend/integration-tests/tests/service-catalog/service-broker.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-broker.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import {browser, $, ExpectedConditions as until, by} from 'protractor';
 
 import { appHost, checkLogs, checkErrors, testName } from '../../protractor.conf';

--- a/frontend/integration-tests/tests/service-catalog/service-catalog.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-catalog.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import {browser, $, ExpectedConditions as until} from 'protractor';
 
 import { appHost, checkLogs, checkErrors, testName } from '../../protractor.conf';

--- a/frontend/integration-tests/tests/service-catalog/service-class.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-class.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import {browser, $, $$, ExpectedConditions as until, by} from 'protractor';
 
 import { appHost, checkLogs, checkErrors, testName } from '../../protractor.conf';

--- a/frontend/integration-tests/tests/source-to-image.scenario.ts
+++ b/frontend/integration-tests/tests/source-to-image.scenario.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { $, browser, ExpectedConditions as until } from 'protractor';
 import * as _ from 'lodash';
 

--- a/frontend/integration-tests/views/horizontal-nav.view.ts
+++ b/frontend/integration-tests/views/horizontal-nav.view.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { $$, by, browser, element, ExpectedConditions as until } from 'protractor';
 
 export const horizontalTabFor = (name: string) => element(by.cssContainingText('.co-m-horizontal-nav__menu-item', name));

--- a/frontend/integration-tests/views/login.view.ts
+++ b/frontend/integration-tests/views/login.view.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { $, browser, ExpectedConditions as until, by, element } from 'protractor';
 import { appHost } from '../protractor.conf';
 

--- a/frontend/integration-tests/views/olm-catalog.view.ts
+++ b/frontend/integration-tests/views/olm-catalog.view.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { browser, $, $$, by, element, ExpectedConditions as until } from 'protractor';
 
 import * as crudView from './crud.view';

--- a/frontend/integration-tests/views/operator-hub.view.ts
+++ b/frontend/integration-tests/views/operator-hub.view.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { browser, $, ExpectedConditions as until, by, element } from 'protractor';
 
 export const operatorModal = $('.modal-content');

--- a/frontend/integration-tests/views/secrets.view.ts
+++ b/frontend/integration-tests/views/secrets.view.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import { $, $$, browser, by, ExpectedConditions as until, element, ElementFinder } from 'protractor';
 import { Base64 } from 'js-base64';
 import { execSync } from 'child_process';

--- a/frontend/integration-tests/views/service-catalog.view.ts
+++ b/frontend/integration-tests/views/service-catalog.view.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import {browser, $, ExpectedConditions as until, by, element} from 'protractor';
 
 export const linkForCSC = (name: string) => element(by.linkText(name));

--- a/frontend/integration-tests/views/sidenav.view.ts
+++ b/frontend/integration-tests/views/sidenav.view.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { $$, by, browser, element, ExpectedConditions as until } from 'protractor';
 
 export const navSectionFor = (name: string) => element(by.cssContainingText('.pf-c-nav > .pf-c-nav__list > .pf-c-nav__item', name));

--- a/frontend/integration-tests/views/yaml.view.ts
+++ b/frontend/integration-tests/views/yaml.view.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import { $, $$, by, Key, browser, ExpectedConditions as until } from 'protractor';
 import { waitForNone } from '../protractor.conf';
 

--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { Dispatch } from 'react-redux';
 import * as _ from 'lodash-es';
 import { ActionType as Action, action } from 'typesafe-actions';

--- a/frontend/public/actions/k8s.ts
+++ b/frontend/public/actions/k8s.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
-
 import * as _ from 'lodash-es';
 import { Dispatch } from 'react-redux';
 import { ActionType as Action, action } from 'typesafe-actions';

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { AboutModal as PfAboutModal, TextContent, TextList, TextListItem } from '@patternfly/react-core';

--- a/frontend/public/components/alert-manager.tsx
+++ b/frontend/public/components/alert-manager.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as _ from 'lodash-es';
 import * as React from 'react';
 

--- a/frontend/public/components/broker-management.tsx
+++ b/frontend/public/components/broker-management.tsx
@@ -19,7 +19,6 @@ export const BrokerManagementPage: React.SFC<BrokerManagementPageProps> = ({matc
     <HorizontalNav pages={pages} match={match} hideDivider noStatusBox={true} />
   </React.Fragment>;
 
-/* eslint-disable no-undef */
 export type BrokerManagementPageProps = {
   match: any;
 };

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKindReference, referenceFor } from '../module/k8s';
 import { startBuild } from '../module/k8s/builds';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
@@ -117,7 +116,6 @@ export const BuildConfigsPage: React.SFC<BuildConfigsPageProps> = props =>
     rowFilters={filters} />;
 BuildConfigsPage.displayName = 'BuildConfigsListPage';
 
-/* eslint-disable no-undef */
 export type BuildConfigsRowProps = {
   obj: any,
 };
@@ -133,4 +131,3 @@ export type BuildConfigsPageProps = {
 export type BuildConfigsDetailsPageProps = {
   match: any,
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/build-pipeline.tsx
+++ b/frontend/public/components/build-pipeline.tsx
@@ -126,7 +126,6 @@ export const BuildPipeline: React.SFC<BuildPipelineProps> = ({ obj }) => {
   </div>;
 };
 
-/* eslint-disable no-undef */
 export type BuildPipelineProps = {
   obj: K8sResourceKind;
 };
@@ -173,4 +172,3 @@ export type JenkinsInputUrlProps = {
   obj: K8sResourceKind;
   stage: any;
 };
-/* eslint-disable no-undef */

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -1,10 +1,8 @@
-/* eslint-disable no-undef */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Icon } from 'patternfly-react';
 import { Link } from 'react-router-dom';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKindReference, referenceFor, K8sResourceKind } from '../module/k8s';
 import { cloneBuild, formatBuildDuration, BuildPhase, getBuildNumber } from '../module/k8s/builds';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
@@ -281,4 +279,3 @@ export type BuildsDetailsPageProps = {
 export type BuildPhaseIconProps = {
   build: K8sResourceKind
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/catalog/catalog-item-details.jsx
+++ b/frontend/public/components/catalog/catalog-item-details.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';

--- a/frontend/public/components/catalog/catalog-item-icon.tsx
+++ b/frontend/public/components/catalog/catalog-item-icon.tsx
@@ -1,10 +1,7 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, TemplateKind } from '../../module/k8s';
 import * as threeScaleImg from '../../imgs/logos/3scale.svg';
 import * as aerogearImg from '../../imgs/logos/aerogear.svg';
@@ -233,4 +230,3 @@ export type ImageStreamIconProps = {
   tag: any;
   iconSize?: string;
 };
-

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -15,7 +15,6 @@ import {
   MsgBox,
 } from './utils/status-box';
 import {
-  // eslint-disable-next-line no-unused-vars
   GroupVersionKind,
   modelFor,
   referenceForModel,
@@ -476,8 +475,6 @@ export const ReportGenerationQueriesDetailsPage: React.SFC<ReportGenerationQueri
   return <DetailsPage {...props} kind={ReportGenerationQueryReference} menuActions={menuActions} pages={reportGenerationQueryPages} />;
 };
 
-
-/* eslint-disable no-undef */
 export type ReportsRowProps = {
   obj: any,
 };
@@ -538,7 +535,6 @@ export type ReportGenerationQueriesPageProps = {
 export type ReportGenerationQueriesDetailsPageProps = {
   match: any,
 };
-/* eslint-enable no-undef */
 
 ReportsRow.displayName = 'ReportsRow';
 ReportsList.displayName = 'ReportsList';

--- a/frontend/public/components/checkbox.tsx
+++ b/frontend/public/components/checkbox.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 
 export const Checkbox: React.SFC<CheckboxProps> = ({name, label, checked, onChange}) => (

--- a/frontend/public/components/cluster-service-broker.tsx
+++ b/frontend/public/components/cluster-service-broker.tsx
@@ -1,9 +1,6 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { Kebab, SectionHeading, detailsPage, navFactory, ResourceLink, ResourceKebab, ResourceSummary, StatusWithIcon, Timestamp, ExternalLink } from './utils';
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, referenceForModel } from '../module/k8s';
 import { ClusterServiceBrokerModel } from '../models';
 import { Conditions } from './conditions';

--- a/frontend/public/components/cluster-service-class-info.tsx
+++ b/frontend/public/components/cluster-service-class-info.tsx
@@ -1,9 +1,6 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, serviceClassDisplayName } from '../module/k8s';
 import { ClusterServiceClassIcon } from './catalog/catalog-item-icon';
 import { ExternalLink } from './utils';

--- a/frontend/public/components/cluster-service-class.tsx
+++ b/frontend/public/components/cluster-service-class.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
@@ -8,7 +6,6 @@ import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from '.
 import { history, SectionHeading, detailsPage, navFactory, ResourceSummary, resourcePathFromModel, ResourceLink } from './utils';
 import { viewYamlComponent } from './utils/horizontal-nav';
 import { ClusterServiceClassModel, ClusterServiceBrokerModel } from '../models';
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, referenceForModel, serviceClassDisplayName } from '../module/k8s';
 import { ClusterServiceClassIcon } from './catalog/catalog-item-icon';
 import { ClusterServicePlanPage } from './cluster-service-plan';

--- a/frontend/public/components/cluster-service-plan.tsx
+++ b/frontend/public/components/cluster-service-plan.tsx
@@ -1,10 +1,7 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { SectionHeading, detailsPage, navFactory, ResourceLink, ResourceSummary } from './utils';
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, referenceForModel, servicePlanDisplayName } from '../module/k8s';
 import { ClusterServicePlanModel, ClusterServiceBrokerModel, ClusterServiceClassModel } from '../models';
 import { viewYamlComponent } from './utils/horizontal-nav';

--- a/frontend/public/components/cluster-settings/basicauth-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/basicauth-idp-form.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import * as _ from 'lodash-es';

--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/components/cluster-settings/cluster-version.tsx
+++ b/frontend/public/components/cluster-settings/cluster-version.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/cluster-settings/github-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/github-idp-form.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 

--- a/frontend/public/components/cluster-settings/gitlab-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/gitlab-idp-form.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 

--- a/frontend/public/components/cluster-settings/global-config.tsx
+++ b/frontend/public/components/cluster-settings/global-config.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';

--- a/frontend/public/components/cluster-settings/google-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/google-idp-form.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 

--- a/frontend/public/components/cluster-settings/htpasswd-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/htpasswd-idp-form.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 

--- a/frontend/public/components/cluster-settings/idp-cafile-input.tsx
+++ b/frontend/public/components/cluster-settings/idp-cafile-input.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 import { AsyncComponent } from '../utils';
 

--- a/frontend/public/components/cluster-settings/idp-name-input.tsx
+++ b/frontend/public/components/cluster-settings/idp-name-input.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 
 export const IDPNameInput: React.FC<IDPNameInputProps> = ({value, onChange}) => (

--- a/frontend/public/components/cluster-settings/index.ts
+++ b/frontend/public/components/cluster-settings/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as _ from 'lodash-es';
 
 import { OAuthModel } from '../../models';

--- a/frontend/public/components/cluster-settings/ldap-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/ldap-idp-form.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/components/cluster-settings/oauth.tsx
+++ b/frontend/public/components/cluster-settings/oauth.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/cluster-settings/openid-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/openid-idp-form.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 

--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -44,7 +44,6 @@ export const Conditions: React.SFC<ConditionsProps> = ({conditions}) => {
   </React.Fragment>;
 };
 
-/* eslint-disable no-undef */
 export type conditionProps = {
   type: string;
   status: string;
@@ -59,4 +58,3 @@ export type ConditionsProps = {
   title?: string;
   subTitle?: string;
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/configmap-and-secret-data.tsx
+++ b/frontend/public/components/configmap-and-secret-data.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import { Base64 } from 'js-base64';
 

--- a/frontend/public/components/container.tsx
+++ b/frontend/public/components/container.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/create-yaml.tsx
+++ b/frontend/public/components/create-yaml.tsx
@@ -49,7 +49,6 @@ export const EditYAMLPage: React.SFC<EditYAMLPageProps> = (props) => {
   </Firehose>;
 };
 
-/* eslint-disable no-undef */
 export type CreateYAMLProps = {
   match: RouterMatch<{ns: string, plural: string, appName?: string}>;
   kindsInFlight: boolean;
@@ -63,6 +62,5 @@ export type EditYAMLPageProps = {
   match: RouterMatch<{ns: string, name: string}>;
   kind: string;
 };
-/* eslint-enable no-undef */
 
 EditYAMLPage.displayName = 'EditYAMLPage';

--- a/frontend/public/components/deploy-image.tsx
+++ b/frontend/public/components/deploy-image.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/components/droppable-edit-yaml.tsx
+++ b/frontend/public/components/droppable-edit-yaml.tsx
@@ -2,7 +2,6 @@ import withDragDropContext from './utils/drag-drop-context';
 import * as React from 'react';
 import {EditYAML} from './edit-yaml';
 import { NativeTypes } from 'react-dnd-html5-backend';
-// eslint-disable-next-line no-unused-vars
 import { DropTarget } from 'react-dnd';
 
 // Maximal file size, in bytes, that user can upload
@@ -68,10 +67,10 @@ export const DroppableEditYAML = withDragDropContext(class DroppableEditYAML ext
   }
 });
 
-/* eslint-disable no-undef */
 export type DroppableEditYAMLProps = {
   obj: string,
 };
+
 export type DroppableEditYAMLState = {
   fileUpload: string | ArrayBuffer,
   error: string,

--- a/frontend/public/components/error.tsx
+++ b/frontend/public/components/error.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { ExpandCollapse } from 'patternfly-react';

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { match } from 'react-router-dom';
 import * as _ from 'lodash-es';

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 import * as fuzzy from 'fuzzysearch';

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKindReference } from '../module/k8s';
 import { Conditions } from './conditions';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
@@ -216,7 +215,6 @@ export const HorizontalPodAutoscalersPage: React.SFC<HorizontalPodAutoscalersPag
   />;
 HorizontalPodAutoscalersPage.displayName = 'HorizontalPodAutoscalersListPage';
 
-/* eslint-disable no-undef */
 export type HorizontalPodAutoscalersRowProps = {
   obj: any,
 };
@@ -244,4 +242,3 @@ export type MetricsRowProps = {
   current: any,
   target: any,
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/image-stream-tag.tsx
+++ b/frontend/public/components/image-stream-tag.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { DetailsPage } from './factory';
 import { Kebab, SectionHeading, navFactory, ResourceSummary } from './utils';
@@ -147,7 +146,6 @@ export const ImageStreamTagsDetailsPage: React.SFC<ImageStreamTagsDetailsPagePro
     pages={pages} />;
 ImageStreamTagsDetailsPage.displayName = 'ImageStreamTagsDetailsPage';
 
-/* eslint-disable no-undef */
 export type ImageStreamTagsDetailsProps = {
   obj: any,
 };
@@ -155,4 +153,3 @@ export type ImageStreamTagsDetailsProps = {
 export type ImageStreamTagsDetailsPageProps = {
   match: any,
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -4,7 +4,6 @@ import * as semver from 'semver';
 import { Popover } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { CopyToClipboard, ExternalLink, Kebab, SectionHeading, LabelList, navFactory, ResourceKebab, ResourceLink, ResourceSummary, history, Timestamp } from './utils';
@@ -236,7 +235,6 @@ export const ImageStreamsPage: React.SFC<ImageStreamsPageProps> = props =>
   />;
 ImageStreamsPage.displayName = 'ImageStreamsListPage';
 
-/*  eslint-disable no-undef, no-unused-vars  */
 type ImageStreamTagsRowProps = {
   imageStream: K8sResourceKind;
   specTag: any;
@@ -262,4 +260,3 @@ export type ImageStreamsPageProps = {
 export type ImageStreamsDetailsPageProps = {
   match: any;
 };
-/* eslint-enable no-undef, no-unused-vars */

--- a/frontend/public/components/instantiate-template.tsx
+++ b/frontend/public/components/instantiate-template.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-// eslint-disable-next-line no-unused-vars
 import {K8sResourceKindReference} from '../module/k8s';
 import {ColHead, DetailsPage, List, ListHeader, ListPage} from './factory';
 import {Kebab, navFactory, SectionHeading, ResourceKebab, ResourceLink, ResourceSummary, Timestamp} from './utils';
@@ -112,7 +111,6 @@ export const LimitRangeDetailsPage = props => <DetailsPage
   pages={[navFactory.details(Details), navFactory.editYaml()]}
 />;
 
-/*  eslint-disable no-undef, no-unused-vars  */
 export type LimitRangeProps = {
   obj: any,
 };

--- a/frontend/public/components/machine-autoscaler.tsx
+++ b/frontend/public/components/machine-autoscaler.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as _ from 'lodash-es';
 import * as React from 'react';
 

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as _ from 'lodash-es';
 import * as React from 'react';
 

--- a/frontend/public/components/machine-deployment.tsx
+++ b/frontend/public/components/machine-deployment.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/modals/add-secret-to-workload.tsx
+++ b/frontend/public/components/modals/add-secret-to-workload.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as fuzzy from 'fuzzysearch';

--- a/frontend/public/components/modals/cluster-channel-modal.tsx
+++ b/frontend/public/components/modals/cluster-channel-modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 
 import { ClusterVersionModel } from '../../models';

--- a/frontend/public/components/modals/cluster-update-modal.tsx
+++ b/frontend/public/components/modals/cluster-update-modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as _ from 'lodash-es';
 import * as React from 'react';
 

--- a/frontend/public/components/modals/configure-machine-autoscaler-modal.tsx
+++ b/frontend/public/components/modals/configure-machine-autoscaler-modal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/modals/disable-application-modal.tsx
+++ b/frontend/public/components/modals/disable-application-modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/modals/installplan-approval-modal.tsx
+++ b/frontend/public/components/modals/installplan-approval-modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/modals/installplan-preview-modal.tsx
+++ b/frontend/public/components/modals/installplan-preview-modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { safeDump } from 'js-yaml';
 

--- a/frontend/public/components/modals/subscription-channel-modal.tsx
+++ b/frontend/public/components/modals/subscription-channel-modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/modals/taints-modal.tsx
+++ b/frontend/public/components/modals/taints-modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as _ from 'lodash-es';
 import * as React from 'react';
 

--- a/frontend/public/components/modals/tolerations-modal.tsx
+++ b/frontend/public/components/modals/tolerations-modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as _ from 'lodash-es';
 import * as React from 'react';
 

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -573,10 +573,8 @@ const filtersToProps = ({k8s}, {reduxID}) => {
 };
 
 const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringListPage extends React.Component<ListPageProps> {
-  /* eslint-disable no-undef */
   props: ListPageProps;
   defaultNameFilter: string;
-  /* eslint-enable no-undef */
 
   constructor(props) {
     super(props);
@@ -777,7 +775,6 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
     }
   }
 
-  /* eslint-disable no-undef */
   setField = (path: string, v: any): void => {
     const data = Object.assign({}, this.state.data);
     _.set(data, path, v);
@@ -830,7 +827,6 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
       .catch(err => this.setState({error: _.get(err, 'json.error') || err.message || 'Error saving Silence'}))
       .then(() => this.setState({inProgress: false}));
   }
-  /* eslint-enable no-undef */
 
   render() {
     const {Info, saveButtonText, title} = this.props;
@@ -1069,7 +1065,6 @@ export class MonitoringUI extends React.Component<null, null> {
   }
 }
 
-/* eslint-disable no-undef, no-unused-vars */
 type Silence = {
   comment: string;
   createdBy: string;

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as _ from 'lodash-es';
 import * as React from 'react';
 

--- a/frontend/public/components/operator-hub/index.ts
+++ b/frontend/public/components/operator-hub/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { PackageManifestKind, SubscriptionKind } from '../operator-lifecycle-manager';
 
 export const OPERATOR_HUB_CSC_BASE = 'marketplace-enabled-operators';

--- a/frontend/public/components/operator-hub/operator-hub-community-provider-modal.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-community-provider-modal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Checkbox, Icon } from 'patternfly-react';

--- a/frontend/public/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-item-details.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Button, HintBlock, Modal } from 'patternfly-react';
 import { CatalogItemHeader, PropertiesSidePanel, PropertyItem } from 'patternfly-react-extensions';

--- a/frontend/public/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-items.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';

--- a/frontend/public/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-page.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-subscribe.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { match } from 'react-router-dom';

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion-resource.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Link, match } from 'react-router-dom';
 import * as _ from 'lodash-es';

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { Link, match as RouterMatch } from 'react-router-dom';
 import * as _ from 'lodash-es';
@@ -271,7 +269,6 @@ export const ClusterServiceVersionsDetailsPage: React.StatelessComponent<Cluster
     menuActions={menuActions} />;
 };
 
-/* eslint-disable no-undef */
 export type ClusterServiceVersionsPageProps = {
   kind: string;
   loading?: boolean;
@@ -312,7 +309,6 @@ export type ClusterServiceVersionDetailsProps = {
 export type ClusterServiceVersionRowProps = {
   obj: ClusterServiceVersionKind;
 };
-/* eslint-enable no-undef */
 
 // TODO(alecmerdler): Find Webpack loader/plugin to add `displayName` to React components automagically
 ClusterServiceVersionList.displayName = 'ClusterServiceVersionList';

--- a/frontend/public/components/operator-lifecycle-manager/create-crd-yaml.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/create-crd-yaml.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import { safeDump } from 'js-yaml';
 import { match } from 'react-router-dom';

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/configure-size.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/configure-size.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { configureCountModal } from '../../../modals';
 import { K8sResourceKind, K8sKind } from '../../../../module/k8s';
 import { Descriptor } from '../types';

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/endpoint.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/endpoint.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Map as ImmutableMap } from 'immutable';

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/resource-requirements.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/resource-requirements.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/status/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/status/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Map as ImmutableMap } from 'immutable';

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/status/phase.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/status/phase.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 
 export const Phase: React.SFC<PhaseProps> = ({status}) => <span className={status === 'Failed' ? 'co-error' : ''}>

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/status/pods.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/status/pods.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 
 import { Donut } from '../../../graphs';

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/types.ts
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/types.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { K8sKind, K8sResourceKind } from '../../../module/k8s';
 
 export enum SpecCapability {

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { match, Link } from 'react-router-dom';

--- a/frontend/public/components/operator-lifecycle-manager/k8s-resource.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/k8s-resource.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/operator-lifecycle-manager/markdown-view.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/markdown-view.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Converter } from 'showdown';

--- a/frontend/public/components/operator-lifecycle-manager/operator-group.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/operator-group.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';

--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link, match } from 'react-router-dom';

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { match, Link } from 'react-router-dom';

--- a/frontend/public/components/operator-management.tsx
+++ b/frontend/public/components/operator-management.tsx
@@ -24,7 +24,6 @@ export const OperatorManagementPage: React.SFC<OperatorManagementPageProps> = ({
     <HorizontalNav pages={pages} match={match} hideDivider noStatusBox={true} />
   </React.Fragment>;
 
-/* eslint-disable no-undef */
 export type OperatorManagementPageProps = {
   match: any;
 };

--- a/frontend/public/components/overview/build-overview.tsx
+++ b/frontend/public/components/overview/build-overview.tsx
@@ -110,7 +110,6 @@ export const BuildOverview: React.SFC<BuildConfigsOverviewProps> = ({buildConfig
   }
 </div>;
 
-/* eslint-disable no-unused-vars, no-undef */
 type BuildOverviewListItemProps = {
   build: K8sResourceKind;
 };
@@ -122,4 +121,3 @@ type BuildOverviewListProps = {
 type BuildConfigsOverviewProps = {
   buildConfigs: BuildConfigOverviewItem[];
 };
-/* eslint-enable no-unused-vars, no-undef */

--- a/frontend/public/components/overview/constants.ts
+++ b/frontend/public/components/overview/constants.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 // Keys for special 'group by' options
 // Should not be valid label keys to avoid conflicts. https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 export enum OverviewSpecialGroup {

--- a/frontend/public/components/overview/daemon-set-overview.tsx
+++ b/frontend/public/components/overview/daemon-set-overview.tsx
@@ -41,7 +41,6 @@ export const DaemonSetOverview: React.SFC<DaemonSetOverviewProps> = ({item}) =>
     tabs={tabs}
   />;
 
-/* eslint-disable no-unused-vars, no-undef */
 type DaemonSetOverviewDetailsProps = {
   item: OverviewItem;
 };
@@ -49,4 +48,3 @@ type DaemonSetOverviewDetailsProps = {
 type DaemonSetOverviewProps = {
   item: OverviewItem;
 };
-/* eslint-enable no-unused-vars, no-undef */

--- a/frontend/public/components/overview/deployment-config-overview.tsx
+++ b/frontend/public/components/overview/deployment-config-overview.tsx
@@ -61,7 +61,6 @@ export const DeploymentConfigOverviewPage: React.SFC<DeploymentConfigOverviewPro
     tabs={tabs}
   />;
 
-/* eslint-disable no-unused-vars, no-undef */
 type DeploymentConfigOverviewDetailsProps = {
   item: OverviewItem;
 };
@@ -69,4 +68,3 @@ type DeploymentConfigOverviewDetailsProps = {
 type DeploymentConfigOverviewProps = {
   item: OverviewItem;
 };
-/* eslint-enable no-unused-vars, no-undef */

--- a/frontend/public/components/overview/deployment-overview.tsx
+++ b/frontend/public/components/overview/deployment-overview.tsx
@@ -61,7 +61,6 @@ export const DeploymentOverviewPage: React.SFC<DeploymentOverviewProps> = ({item
     tabs={tabs}
   />;
 
-/* eslint-disable no-unused-vars, no-undef */
 type DeploymentOverviewDetailsProps = {
   item: OverviewItem;
 };
@@ -69,4 +68,3 @@ type DeploymentOverviewDetailsProps = {
 type DeploymentOverviewProps = {
   item: OverviewItem;
 };
-/* eslint-enable no-unused-vars, no-undef */

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as _ from 'lodash-es';
 import * as classnames from 'classnames';
 import * as fuzzy from 'fuzzysearch';

--- a/frontend/public/components/overview/namespace-overview.tsx
+++ b/frontend/public/components/overview/namespace-overview.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/overview/networking-overview.tsx
+++ b/frontend/public/components/overview/networking-overview.tsx
@@ -66,7 +66,6 @@ export const NetworkingOverview: React.SFC<NetworkingOverviewProps> = ({routes, 
   </React.Fragment>;
 };
 
-/* eslint-disable no-unused-vars, no-undef */
 type RoutesOverviewListProps = {
   routes: K8sResourceKind[];
 };
@@ -91,4 +90,3 @@ type ServiceOverviewListProps = {
 type ServiceOverviewListItemProps = {
   service: K8sResourceKind;
 };
-/* eslint-enable no-unused-vars, no-undef */

--- a/frontend/public/components/overview/pod-overview.tsx
+++ b/frontend/public/components/overview/pod-overview.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import { PodOverviewItem } from '.';
 import { PodResourceSummary, PodDetailsList, menuActions } from '../pod';

--- a/frontend/public/components/overview/project-overview.tsx
+++ b/frontend/public/components/overview/project-overview.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as _ from 'lodash-es';
 import * as classnames from 'classnames';
 import * as React from 'react';

--- a/frontend/public/components/overview/resource-overview-details.tsx
+++ b/frontend/public/components/overview/resource-overview-details.tsx
@@ -36,7 +36,6 @@ export const ResourceOverviewDetails = connect<PropsFromState, PropsFromDispatch
     </div>
 );
 
-/* eslint-disable no-unused-vars, no-undef */
 type PropsFromState = {
   selectedDetailsTab: any
 };
@@ -56,4 +55,3 @@ type OwnProps = {
 };
 
 type ResourceOverviewDetailsProps = PropsFromState & PropsFromDispatch & OwnProps;
-/* eslint-enable no-unused-vars, no-undef */

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 
 import { connectToModel } from '../../kinds';

--- a/frontend/public/components/overview/resource-overview-pages.tsx
+++ b/frontend/public/components/overview/resource-overview-pages.tsx
@@ -1,7 +1,6 @@
 import { Map as ImmutableMap } from 'immutable';
 
 import {
-  /* eslint-disable-next-line no-unused-vars */
   GroupVersionKind,
   referenceForModel,
 } from '../../module/k8s';

--- a/frontend/public/components/overview/stateful-set-overview.tsx
+++ b/frontend/public/components/overview/stateful-set-overview.tsx
@@ -32,7 +32,6 @@ export const StatefulSetOverview: React.SFC<StatefulSetOverviewProps> = ({item})
     tabs={tabs}
   />;
 
-/* eslint-disable no-unused-vars, no-undef */
 type StatefulSetOverviewDetailsProps = {
   item: OverviewItem;
 };
@@ -40,4 +39,3 @@ type StatefulSetOverviewDetailsProps = {
 type StatefulSetOverviewProps = {
   item: OverviewItem;
 };
-/* eslint-enable no-unused-vars, no-undef */

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';

--- a/frontend/public/components/provisioned-services.tsx
+++ b/frontend/public/components/provisioned-services.tsx
@@ -19,7 +19,6 @@ export const ProvisionedServicesPage: React.SFC<ProvisionedServicesPageProps> = 
     <HorizontalNav pages={pages} match={match} hideDivider noStatusBox={true} />
   </React.Fragment>;
 
-/* eslint-disable no-undef */
 export type ProvisionedServicesPageProps = {
   match: any;
 };

--- a/frontend/public/components/radio.tsx
+++ b/frontend/public/components/radio.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -74,7 +74,6 @@ export const ResourceDetailsPage = connectToPlural((props: ResourceDetailsPagePr
   </React.Fragment>;
 });
 
-/* eslint-disable no-undef, no-unused-vars */
 export type ResourceListPageProps = {
   flags: any,
   kindObj: K8sKind;
@@ -89,8 +88,6 @@ export type ResourceDetailsPageProps = {
   match: match<any>;
   modelRef: K8sResourceKindReference;
 };
-/* eslint-enable no-undef, no-unused-vars */
-
 
 ResourceListPage.displayName = 'ResourceListPage';
 ResourceDetailsPage.displayName = 'ResourceDetailsPage';

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import { Map as ImmutableMap } from 'immutable';
 
 import { ReportReference, ReportGenerationQueryReference } from './chargeback';

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -6,14 +6,12 @@ import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
 import { Kebab, CopyToClipboard, SectionHeading, ResourceKebab, detailsPage, navFactory, ResourceLink, ResourceSummary, StatusIcon, ExternalLink } from './utils';
 import { MaskedData } from './configmap-and-secret-data';
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { Conditions, conditionProps } from './conditions';
 
 const RoutesReference: K8sResourceKindReference = 'Route';
 const menuActions = Kebab.factory.common;
 
-/* eslint-disable no-undef */
 export type IngressStatusProps = {
   host: string;
   routerName: string;
@@ -21,7 +19,6 @@ export type IngressStatusProps = {
   wildcardPolicy: string;
   routerCanonicalHostname: string;
 };
-/* eslint-enable no-undef */
 
 const getRouteHost = (route, onlyAdmitted) => {
   let oldestAdmittedIngress = null;
@@ -370,7 +367,6 @@ export const RoutesPage: React.SFC<RoutesPageProps> = props => {
   />;
 };
 
-/* eslint-disable no-undef */
 export type RouteHostnameProps = {
   obj: K8sResourceKind;
 };
@@ -417,4 +413,3 @@ export type CustomRouteHelpProps = {
   host: string;
   routerCanonicalHostname: string;
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Link } from 'react-router-dom';

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/components/service-binding.tsx
+++ b/frontend/public/components/service-binding.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { match } from 'react-router-dom';
 
-// eslint-disable-next-line no-unused-vars
 import { serviceCatalogStatus, referenceForModel, K8sResourceKind } from '../module/k8s';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { Kebab, SectionHeading, navFactory, ResourceKebab, ResourceLink, ResourceSummary, StatusWithIcon } from './utils';
@@ -112,7 +111,6 @@ export const ServiceBindingsPage: React.SFC<ServiceBindingsPageProps> = props =>
     ListComponent={ServiceBindingsList}
   />;
 
-/* eslint-disable no-undef */
 export type ServiceBindingsRowProps = {
   obj: K8sResourceKind,
 };
@@ -135,6 +133,5 @@ export type ServiceBindingsPageProps = {
 export type ServiceBindingDetailsPageProps = {
   match: any,
 };
-/* eslint-enable no-undef */
 
 ServiceBindingsPage.displayName = 'ServiceBindingsListPage';

--- a/frontend/public/components/service-catalog-parameters.tsx
+++ b/frontend/public/components/service-catalog-parameters.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind } from '../module/k8s';
 import { SectionHeading, ResourceLink } from './utils';
 import { MaskedData } from './configmap-and-secret-data';
@@ -42,7 +41,6 @@ export const ServiceCatalogParameters: React.SFC<ServiceCatalogParametersProps> 
   </dl>
 </div>;
 
-/* eslint-disable no-undef */
 export type ServiceCatalogParametersSecretsProps = {
   obj: K8sResourceKind,
 };
@@ -52,4 +50,3 @@ export type ServiceCatalogParametersProps = {
     [key: string]: string
   }
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/service-catalog/create-binding.tsx
+++ b/frontend/public/components/service-catalog/create-binding.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/components/service-catalog/schema-form.tsx
+++ b/frontend/public/components/service-catalog/schema-form.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Link, withRouter, RouteComponentProps, match } from 'react-router-dom';

--- a/frontend/public/components/source-to-image.tsx
+++ b/frontend/public/components/source-to-image.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/components/start-guide.tsx
+++ b/frontend/public/components/start-guide.tsx
@@ -86,7 +86,6 @@ export const withStartGuide = (WrappedComponent, doNotDisable: boolean = false) 
     }
   );
 
-/* eslint-disable no-unused-vars, no-undef */
 type StartGuideProps = {
   dismissKey?: string;
   startGuide: React.ReactNode;
@@ -95,4 +94,3 @@ type StartGuideProps = {
 export type WithStartGuideProps = {
   noProjectsAvailable?: boolean;
 };
-/* eslint-enable no-unused-vars, no-undef */

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -36,7 +36,6 @@ const defaultState = {
   fieldErrors: {parameters: {}},
 };
 
-/*eslint-disable no-undef*/
 export class StorageClassForm_ extends React.Component<StorageClassFormProps, StorageClassFormState> {
 
   resources: Resources;
@@ -938,7 +937,5 @@ export const StorageClassForm = props => {
     </Firehose>
   );
 };
+
 ConnectedStorageClassForm.displayName='StorageClassForm';
-
-
-/* eslint-enable no-undef */

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -3,7 +3,6 @@ import * as _ from 'lodash-es';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { Kebab, detailsPage, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary } from './utils';
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 
 export const StorageClassReference: K8sResourceKindReference = 'StorageClass';
@@ -68,7 +67,6 @@ const StorageClassDetails: React.SFC<StorageClassDetailsProps> = ({obj}) => <Rea
 export const StorageClassList: React.SFC = props => <List {...props} Header={StorageClassHeader} Row={StorageClassRow} />;
 StorageClassList.displayName = 'StorageClassList';
 
-/* eslint-disable no-undef */
 export const StorageClassPage: React.SFC<StorageClassPageProps> = props => {
   const createProps = {
     to: '/k8s/cluster/storageclasses/~new/form',
@@ -108,4 +106,3 @@ export type StorageClassPageProps = {
 export type StorageClassDetailsPageProps = {
   match: any,
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/storage/attach-storage.tsx
+++ b/frontend/public/components/storage/attach-storage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';

--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
@@ -324,4 +323,3 @@ export type CreatePVCPageState = {
   title: string;
   pvcObj: K8sResourceKind;
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/template-instance.tsx
+++ b/frontend/public/components/template-instance.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/utils/async.tsx
+++ b/frontend/public/components/utils/async.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/utils/breadcrumbs.ts
+++ b/frontend/public/components/utils/breadcrumbs.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash-es';
 
-// eslint-disable-next-line no-unused-vars
 import { modelFor, referenceForOwnerRef, K8sResourceKind } from '../../module/k8s';
 import { resourcePathFromModel } from './resource-link';
 

--- a/frontend/public/components/utils/build-hooks.tsx
+++ b/frontend/public/components/utils/build-hooks.tsx
@@ -24,10 +24,8 @@ export const BuildHooks: React.SFC<BuildHooksProps> = ({ resource }) => {
     : null;
 };
 
-/* eslint-disable no-undef */
 export type BuildHooksProps = {
   resource: K8sResourceKind;
 };
-/* eslint-enable no-undef */
 
 BuildHooks.displayName = 'BuildHooks';

--- a/frontend/public/components/utils/build-strategy.tsx
+++ b/frontend/public/components/utils/build-strategy.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, K8sResourceKindReference } from '../../module/k8s';
 import { ResourceLink } from './';
 import { getStrategyType } from '../build';
@@ -67,11 +66,9 @@ export const BuildStrategy: React.SFC<BuildStrategyProps> = ({ resource, childre
   </dl>;
 };
 
-/* eslint-disable no-undef */
 export type BuildStrategyProps = {
   resource: K8sResourceKind;
   children?: JSX.Element[];
 };
-/* eslint-enable no-undef */
 
 BuildStrategy.displayName = 'BuildStrategy';

--- a/frontend/public/components/utils/camel-case-wrap.tsx
+++ b/frontend/public/components/utils/camel-case-wrap.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 
 const MEMO = {};

--- a/frontend/public/components/utils/container-table.tsx
+++ b/frontend/public/components/utils/container-table.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/utils/copy-to-clipboard.tsx
+++ b/frontend/public/components/utils/copy-to-clipboard.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { CopyToClipboard as CTC } from 'react-copy-to-clipboard';

--- a/frontend/public/components/utils/deployment-pod-counts.tsx
+++ b/frontend/public/components/utils/deployment-pod-counts.tsx
@@ -7,7 +7,6 @@ import { configureReplicaCountModal } from '../modals';
 import { LoadingInline, pluralize } from './';
 
 
-/* eslint-disable no-undef, no-unused-vars */
 type DPCProps = {
   resource: K8sResourceKind;
   resourceKind: K8sKind;
@@ -17,13 +16,10 @@ type DPCState = {
   desiredCount: number,
   waitingForUpdate: boolean,
 };
-/* eslint-enable no-undef, no-unused-vars */
 
 // Common representation of desired / up-to-date / matching pods for Deployment like things
 export class DeploymentPodCounts extends React.Component<DPCProps, DPCState> {
-  /* eslint-disable no-undef, no-unused-vars */
   openReplicaCountModal: any;
-  /* eslint-enable no-undef, no-unused-vars */
 
   constructor(props) {
     super(props);

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/utils/download-button.tsx
+++ b/frontend/public/components/utils/download-button.tsx
@@ -40,7 +40,6 @@ export const DownloadButton: React.FC<DownloadButtonProps> = (props) => {
   </div>;
 };
 
-/* eslint-disable no-undef */
 export type DownloadButtonProps = {
   url: string,
   filename?: string,
@@ -51,6 +50,5 @@ export type DownloadButtonState = {
   inFlight: boolean,
   error: any,
 };
-/* eslint-enable no-undef */
 
 DownloadButton.displayName = 'DownloadButton';

--- a/frontend/public/components/utils/error-boundary.tsx
+++ b/frontend/public/components/utils/error-boundary.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-unused-vars, no-undef, react/display-name */
+/* eslint-disable react/display-name */
 
 import * as React from 'react';
 

--- a/frontend/public/components/utils/file-input.tsx
+++ b/frontend/public/components/utils/file-input.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { NativeTypes } from 'react-dnd-html5-backend';

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -89,7 +89,6 @@ export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = 
   </div>;
 };
 
-/* eslint-disable no-undef */
 export type ActionButtonsProps = {
   actionButtons: any[];
 };
@@ -129,7 +128,6 @@ export type SidebarSectionHeadingProps = {
   style?: any;
   text: string;
 };
-/* eslint-enable no-undef */
 
 BreadCrumbs.displayName = 'BreadCrumbs';
 PageHeading.displayName = 'PageHeading';

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -53,7 +53,6 @@ export * from './list-input';
   loaded asynchronously in order not to bloat the vendor file. The enum reference into the editor
   will cause it not to load asynchronously.
  */
-/* eslint-disable no-undef */
 export const enum NameValueEditorPair {
   Name = 0,
   Value,

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 import * as _ from 'lodash-es';
 import * as React from 'react';
 

--- a/frontend/public/components/utils/label-list.tsx
+++ b/frontend/public/components/utils/label-list.tsx
@@ -36,7 +36,6 @@ export class LabelList extends React.Component<LabelListProps> {
   }
 }
 
-/* eslint-disable no-undef */
 export type LabelProps = {
   kind: K8sResourceKindReference;
   name: string;
@@ -49,4 +48,3 @@ export type LabelListProps = {
   kind: K8sResourceKindReference;
   expand?: boolean;
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/utils/line-buffer.ts
+++ b/frontend/public/components/utils/line-buffer.ts
@@ -2,11 +2,9 @@ export const LINE_PATTERN = /^.*(\n|$)/gm;
 
 export class LineBuffer {
 
-  /* eslint-disable no-undef */
   private _maxSize: number
   private _buffer: string[]
   private _tail: string
-  /* eslint-enable no-undef */
 
   constructor(maxSize) {
     this._maxSize = maxSize;

--- a/frontend/public/components/utils/list-input.tsx
+++ b/frontend/public/components/utils/list-input.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';

--- a/frontend/public/components/utils/number-spinner.tsx
+++ b/frontend/public/components/utils/number-spinner.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';

--- a/frontend/public/components/utils/promise-component.tsx
+++ b/frontend/public/components/utils/promise-component.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
-
 import * as React from 'react';
 
 export const withHandlePromise: WithHandlePromise = (Component) => (props) => {

--- a/frontend/public/components/utils/request-size-input.tsx
+++ b/frontend/public/components/utils/request-size-input.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
 import * as React from 'react';
 import { Dropdown } from '.';
 

--- a/frontend/public/components/utils/resource-icon.tsx
+++ b/frontend/public/components/utils/resource-icon.tsx
@@ -33,7 +33,6 @@ export const ResourceIcon: React.SFC<ResourceIconProps> = ({className, kind}) =>
   return rendered;
 };
 
-/* eslint-disable no-undef */
 export type ResourceIconProps = {
   className?: string;
   kind: K8sResourceKindReference;
@@ -43,7 +42,6 @@ export type ResourceNameProps = {
   kind: K8sResourceKindReference;
   name: string;
 };
-/* eslint-enable no-undef */
 
 export const ResourceName: React.SFC<ResourceNameProps> = (props) => <span className="co-resource-item"><ResourceIcon kind={props.kind} /> <span className="co-resource-item__resource-name">{props.name}</span></span>;
 

--- a/frontend/public/components/utils/router.ts
+++ b/frontend/public/components/utils/router.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as _ from 'lodash-es';
 import { createBrowserHistory, createMemoryHistory } from 'history';
 

--- a/frontend/public/components/utils/service-catalog-status.tsx
+++ b/frontend/public/components/utils/service-catalog-status.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKind, serviceCatalogStatus } from '../../module/k8s';
 import { StatusIcon } from '../utils';
 
@@ -9,8 +8,6 @@ export const StatusWithIcon: React.SFC<StatusWithIconProps> = ({obj}) => {
   return <StatusIcon status={objStatus} />;
 };
 
-/* eslint-disable no-undef */
 export type StatusWithIconProps = {
   obj: K8sResourceKind
 };
-/* eslint-enable no-undef */

--- a/frontend/public/components/utils/simple-tab-nav.tsx
+++ b/frontend/public/components/utils/simple-tab-nav.tsx
@@ -62,7 +62,6 @@ export class SimpleTabNav extends React.Component<SimpleTabNavProps, SimpleTabNa
   }
 }
 
-/* eslint-disable no-unused-vars, no-undef */
 type SimpleTabNavProps = {
   onClickTab?: (name: string) => void;
   selectedTab?: string,
@@ -82,4 +81,3 @@ type SimpleTabProps = {
   onClick: (title: string) => void;
   title: string;
 };
-/* eslint-enable no-unused-vars, no-undef */

--- a/frontend/public/components/utils/status-icon.tsx
+++ b/frontend/public/components/utils/status-icon.tsx
@@ -61,7 +61,6 @@ export const StatusIcon: React.FunctionComponent<StatusIconProps> = ({status}) =
   }
 };
 
-/* eslint-disable no-undef */
 export type StatusIconProps = {
   status?: string;
 };

--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef, no-unused-vars */
+
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as fuzzy from 'fuzzysearch';

--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
-
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Tooltip } from './tooltip';

--- a/frontend/public/components/utils/tooltip.tsx
+++ b/frontend/public/components/utils/tooltip.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Tooltip as RLT } from 'react-lightweight-tooltip';

--- a/frontend/public/components/utils/webhooks.tsx
+++ b/frontend/public/components/utils/webhooks.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 import * as React from 'react';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/utils/workload-pause.tsx
+++ b/frontend/public/components/utils/workload-pause.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-// eslint-disable-next-line no-unused-vars
-import { K8sKind, k8sPatch, K8sResourceKind} from '../../module/k8s/index';
+import { K8sKind, k8sPatch, K8sResourceKind } from '../../module/k8s/index';
 import { errorModal } from '../modals/index';
 
 export const togglePaused = (model: K8sKind, obj: K8sResourceKind) => {

--- a/frontend/public/components/volumes-table.tsx
+++ b/frontend/public/components/volumes-table.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';

--- a/frontend/public/kinds.ts
+++ b/frontend/public/kinds.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
-
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-unused-vars
 import { K8sKind } from '../module/k8s';
 
 export const CatalogSourceConfigModel: K8sKind = {

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import { Map as ImmutableMap } from 'immutable';
 
 import { GroupVersionKind, referenceForModel } from '../module/k8s';

--- a/frontend/public/module/k8s/autocomplete.ts
+++ b/frontend/public/module/k8s/autocomplete.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { IEditSession, Editor, Position } from 'brace';
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';

--- a/frontend/public/module/k8s/builds.ts
+++ b/frontend/public/module/k8s/builds.ts
@@ -6,7 +6,6 @@ import { formatDuration } from '../../components/utils/datetime';
 
 const BUILD_NUMBER_ANNOTATION = 'openshift.io/build.number';
 
-/* eslint-disable no-undef */
 export enum BuildPhase {
   Cancelled = 'Cancelled',
   Complete = 'Complete',
@@ -16,7 +15,6 @@ export enum BuildPhase {
   Pending ='Pending',
   Running = 'Running',
 }
-/* eslint-enable no-undef */
 
 const createBuildRequest = (obj, model, subresource) => {
   const req = {

--- a/frontend/public/module/k8s/cluster-operator.ts
+++ b/frontend/public/module/k8s/cluster-operator.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as _ from 'lodash-es';
 import { ClusterOperator, OperandVersion } from '.';
 

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as _ from 'lodash-es';
 
 import { ClusterVersionModel } from '../../models';

--- a/frontend/public/module/k8s/container.ts
+++ b/frontend/public/module/k8s/container.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import * as _ from 'lodash-es';
 
 import { ContainerSpec, ContainerStatus, PodKind } from './';

--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
-
 import * as _ from 'lodash-es';
 
 import { coFetchJSON } from '../../co-fetch';

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 export * from './job';
 export * from './k8s';
 export * from './node';

--- a/frontend/public/module/k8s/k8s-models.ts
+++ b/frontend/public/module/k8s/k8s-models.ts
@@ -1,7 +1,6 @@
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';
 
-// eslint-disable-next-line no-unused-vars
 import { K8sResourceKindReference, K8sKind } from './index';
 import * as staticModels from '../../models';
 import { referenceForModel, kindForReference } from './k8s';

--- a/frontend/public/module/k8s/k8s.ts
+++ b/frontend/public/module/k8s/k8s.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as _ from 'lodash-es';
 
 import { K8sResourceKindReference, GroupVersionKind, CustomResourceDefinitionKind, K8sResourceKind, K8sKind, OwnerReference } from './index';

--- a/frontend/public/module/k8s/node.ts
+++ b/frontend/public/module/k8s/node.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as _ from 'lodash-es';
 
 import { k8sPatch } from './resource';

--- a/frontend/public/module/k8s/pods.ts
+++ b/frontend/public/module/k8s/pods.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import * as _ from 'lodash-es';
 
 import { ContainerSpec, PodKind, Volume, VolumeMount } from './';
@@ -136,10 +135,8 @@ export const getVolumeLocation = (volume: Volume) => {
 
 export const getRestartPolicyLabel = (pod: PodKind) => _.get(getRestartPolicy(pod), 'label', '');
 
-/* eslint-disable no-undef */
 export type PodReadiness = string;
 export type PodPhase = string;
-/* eslint-enable no-undef */
 
 export const getVolumeMountPermissions = (v: VolumeMount) => {
   if (!v) {

--- a/frontend/public/module/k8s/probe.ts
+++ b/frontend/public/module/k8s/probe.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import * as _ from 'lodash-es';
 
 import {

--- a/frontend/public/module/k8s/selector.ts
+++ b/frontend/public/module/k8s/selector.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { createEquals, requirementFromString, requirementToString } from './selector-requirement';
 import { Selector, MatchExpression } from './index';
 

--- a/frontend/public/module/k8s/service-catalog.ts
+++ b/frontend/public/module/k8s/service-catalog.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import * as _ from 'lodash-es';
 
 import { K8sResourceKind } from '../../module/k8s';

--- a/frontend/public/module/k8s/template.ts
+++ b/frontend/public/module/k8s/template.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars, no-undef */
 import * as _ from 'lodash-es';
 
 import { TemplateInstanceKind } from '../../module/k8s';

--- a/frontend/public/reducers/features.ts
+++ b/frontend/public/reducers/features.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, no-unused-vars */
-
 import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';

--- a/frontend/public/reducers/k8s.ts
+++ b/frontend/public/reducers/k8s.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import * as _ from 'lodash-es';
 import { Map as ImmutableMap, fromJS } from 'immutable';
 

--- a/frontend/public/reducers/monitoring.ts
+++ b/frontend/public/reducers/monitoring.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -1,6 +1,4 @@
 /* eslint-env node */
-/* eslint-disable no-unused-vars, no-undef */
-
 import * as webpack from 'webpack';
 import * as path from 'path';
 import * as glob from 'glob';


### PR DESCRIPTION
### Description

Removes all the times we `eslint-disable` the rules `no-undef` or `no-unused-vars` because they are handled by the current version of `@typescript-eslint/eslint-plugin`.

Sorry for this touching ALL the `.ts` files...