### PR TITLE
Bug 1706868: Add node's status to node's details page

### DIFF
--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -147,6 +147,8 @@ const Details = ({obj: node}) => {
           <dl className="co-m-pane__details">
             <dt>Node Name</dt>
             <dd>{node.metadata.name || '-'}</dd>
+            <dt>Status</dt>
+            <dd><NodeStatus node={node} /></dd>
             <dt>External ID</dt>
             <dd>{_.get(node, 'spec.externalID', '-')}</dd>
             <dt>Node Addresses</dt>


### PR DESCRIPTION
/assign @spadgett 

Screen:
<img width="1093" alt="Screen Shot 2019-05-16 at 11 10 42" src="https://user-images.githubusercontent.com/1668218/57842089-1e7c3100-77cc-11e9-9c50-f343ef316ae9.png">
