### PR TITLE
init overview state on mount to ensure resource lists are rendered

### DIFF
--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -449,7 +449,8 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
     filteredItems: [],
     groupedItems: [],
     firstLabel: '',
-  };
+    ...this.createOverviewData(),
+  }
 
   componentDidMount(): void {
     this.fetchMetrics();
@@ -491,7 +492,7 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
       || !_.isEqual(routes, prevProps.routes)
       || !_.isEqual(services, prevProps.services)
       || !_.isEqual(statefulSets, prevProps.statefulSets)) {
-      this.createOverviewData();
+      this.setState(this.createOverviewData());
     } else if (filterValue !== prevProps.filterValue) {
       const filteredItems = this.filterItems(this.state.items);
       this.setState({
@@ -503,7 +504,6 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
         groupedItems: groupItems(this.state.filteredItems, selectedGroup),
       });
     }
-
     // Fetch new metrics when the namespace changes.
     if (namespace !== prevProps.namespace) {
       clearInterval(this.metricsInterval);
@@ -872,7 +872,7 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
     }, []);
   }
 
-  createOverviewData(): void {
+  createOverviewData(): OverviewMainContentState {
     const {loaded, mock, selectedGroup, updateGroupOptions, updateSelectedGroup, updateResources} = this.props;
 
     if (!loaded) {
@@ -901,12 +901,12 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
 
     updateGroupOptions(groupOptions);
     const groupedItems = groupItems(filteredItems, selectedGroup);
-    this.setState({
+    return {
       filteredItems,
       groupedItems,
       firstLabel,
       items,
-    });
+    };
   }
 
   render() {


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/CONSOLE-1469

The recent changes to reduce unnecessary rendering caused by firehose exposed a bug in `OverviewMainContent` where it is doing `state` updates on `componentDidUpdate` but not on component init. The `OverviewMainContent` component never properly setup its internal state on first mount and therefore failed to render the data. It relied on firehose to do multiple updates after mounting in order to update the internal `state`.

The fix is to init the component `state` properly with the overview data.

![resource-load](https://user-images.githubusercontent.com/14068621/57882558-facbe180-77f1-11e9-87d6-68be37f7b8d9.gif)
