### PR TITLE
Improve nav item extensions

### DIFF
--- a/frontend/packages/console-demo-plugin/src/plugin.ts
+++ b/frontend/packages/console-demo-plugin/src/plugin.ts
@@ -1,23 +1,33 @@
 import {
   Plugin,
+  ModelFeatureFlag,
   HrefNavItem,
   ResourceNSNavItem,
+  ResourceClusterNavItem,
   ResourceListPage,
   ResourceDetailPage,
-  ModelFeatureFlag,
 } from '@console/plugin-sdk';
 
 // TODO(vojtech): internal code needed by plugins should be moved to console-shared package
 import { PodModel } from '@console/internal/models';
+import { FLAGS } from '@console/internal/const';
 
 type ConsumedExtensions =
+  | ModelFeatureFlag
   | HrefNavItem
   | ResourceNSNavItem
+  | ResourceClusterNavItem
   | ResourceListPage
-  | ResourceDetailPage
-  | ModelFeatureFlag;
+  | ResourceDetailPage;
 
 const plugin: Plugin<ConsumedExtensions> = [
+  {
+    type: 'FeatureFlag/Model',
+    properties: {
+      model: PodModel,
+      flag: 'TEST_MODEL_FLAG',
+    },
+  },
   {
     type: 'NavItem/Href',
     properties: {
@@ -32,11 +42,22 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceNS',
     properties: {
-      section: 'Workloads',
+      section: 'Home',
       componentProps: {
         name: 'Test ResourceNS Link',
         resource: 'pods',
         required: 'TEST_MODEL_FLAG',
+      },
+    },
+  },
+  {
+    type: 'NavItem/ResourceCluster',
+    properties: {
+      section: 'Home',
+      componentProps: {
+        name: 'Test ResourceCluster Link',
+        resource: 'projects',
+        required: [FLAGS.OPENSHIFT, 'TEST_MODEL_FLAG'],
       },
     },
   },
@@ -52,13 +73,6 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       model: PodModel,
       loader: () => import('@console/internal/components/pod' /* webpackChunkName: "pod" */).then(m => m.PodsDetailsPage),
-    },
-  },
-  {
-    type: 'FeatureFlag/Model',
-    properties: {
-      model: PodModel,
-      flag: 'TEST_MODEL_FLAG',
     },
   },
 ];

--- a/frontend/packages/console-plugin-sdk/src/typings/nav.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/nav.ts
@@ -1,30 +1,29 @@
 import { Extension } from '.';
-import { K8sKind } from '@console/internal/module/k8s';
+import { NavSectionTitle } from '@console/internal/components/nav/section';
+
+import {
+  NavLinkProps,
+  HrefLinkProps,
+  ResourceNSLinkProps,
+  ResourceClusterLinkProps,
+} from '@console/internal/components/nav/items';
 
 namespace ExtensionProperties {
   interface NavItem {
-    // TODO(vojtech): link to existing nav sections by value
-    section: 'Home' | 'Workloads';
-    componentProps: {
-      name: string;
-      required?: string;
-      disallowed?: string;
-      startsWith?: string[];
-    }
+    section: NavSectionTitle;
+    componentProps: Pick<NavLinkProps, 'name' | 'required' | 'disallowed' | 'startsWith'>;
   }
 
   export interface HrefNavItem extends NavItem {
-    componentProps: NavItem['componentProps'] & {
-      href: string;
-      activePath?: string;
-    }
+    componentProps: NavItem['componentProps'] & Pick<HrefLinkProps, 'href' | 'activePath'>;
   }
 
   export interface ResourceNSNavItem extends NavItem {
-    componentProps: NavItem['componentProps'] & {
-      resource: string;
-      model?: K8sKind;
-    }
+    componentProps: NavItem['componentProps'] & Pick<ResourceNSLinkProps, 'resource' | 'model'>;
+  }
+
+  export interface ResourceClusterNavItem extends NavItem {
+    componentProps: NavItem['componentProps'] & Pick<ResourceClusterLinkProps, 'resource' | 'model'>;
   }
 }
 
@@ -36,8 +35,11 @@ export interface ResourceNSNavItem extends Extension<ExtensionProperties.Resourc
   type: 'NavItem/ResourceNS';
 }
 
-// TODO(vojtech): add ResourceClusterNavItem
-export type NavItem = HrefNavItem | ResourceNSNavItem;
+export interface ResourceClusterNavItem extends Extension<ExtensionProperties.ResourceClusterNavItem> {
+  type: 'NavItem/ResourceCluster';
+}
+
+export type NavItem = HrefNavItem | ResourceNSNavItem | ResourceClusterNavItem;
 
 export function isHrefNavItem(e: Extension<any>): e is HrefNavItem {
   return e.type === 'NavItem/Href';
@@ -47,6 +49,10 @@ export function isResourceNSNavItem(e: Extension<any>): e is ResourceNSNavItem {
   return e.type === 'NavItem/ResourceNS';
 }
 
+export function isResourceClusterNavItem(e: Extension<any>): e is ResourceClusterNavItem {
+  return e.type === 'NavItem/ResourceCluster';
+}
+
 export function isNavItem(e: Extension<any>): e is NavItem {
-  return isHrefNavItem(e) || isResourceNSNavItem(e);
+  return isHrefNavItem(e) || isResourceNSNavItem(e) || isResourceClusterNavItem(e);
 }

--- a/frontend/public/components/nav/items.tsx
+++ b/frontend/public/components/nav/items.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import * as _ from 'lodash-es';
+import { NavItem } from '@patternfly/react-core';
+
+import { formatNamespacedRouteForResource } from '../../actions/ui';
+import { referenceForModel, K8sKind } from '../../module/k8s';
+import { stripBasePath } from '../utils';
+
+export const matchesPath = (resourcePath, prefix) => resourcePath === prefix || _.startsWith(resourcePath, `${prefix}/`);
+export const matchesModel = (resourcePath, model) => model && matchesPath(resourcePath, referenceForModel(model));
+
+export const stripNS = href => {
+  href = stripBasePath(href);
+  return href.replace(/^\/?k8s\//, '').replace(/^\/?(cluster|all-namespaces|ns\/[^/]*)/, '').replace(/^\//, '');
+};
+
+export const ExternalLink = ({href, name}) => <NavItem isActive={false}>
+  <a className="pf-c-nav__link" href={href} target="_blank" rel="noopener noreferrer">{name}<span className="co-external-link"></span></a>
+</NavItem>;
+
+class NavLink<P extends NavLinkProps> extends React.PureComponent<P> {
+  static defaultProps = {
+    required: '',
+    disallowed: '',
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+  static isActive(...args): boolean {
+    throw new Error('not implemented');
+  }
+
+  get to(): string {
+    throw new Error('not implemented');
+  }
+
+  static startsWith(resourcePath: string, ...someStrings: string[]) {
+    return _.some(someStrings, s => resourcePath.startsWith(s));
+  }
+
+  render() {
+    const { isActive, id, name, onClick } = this.props;
+
+    // onClick is now handled globally by the Nav's onSelect,
+    // however onClick can still be passed if desired in certain cases
+
+    return (
+      <NavItem isActive={isActive}>
+        <Link
+          id={id}
+          to={this.to}
+          onClick={onClick}
+        >
+          {name}
+        </Link>
+      </NavItem>
+    );
+  }
+}
+
+export class ResourceNSLink extends NavLink<ResourceNSLinkProps> {
+  static isActive(props, resourcePath, activeNamespace) {
+    const href = stripNS(formatNamespacedRouteForResource(props.resource, activeNamespace));
+    return matchesPath(resourcePath, href) || matchesModel(resourcePath, props.model);
+  }
+
+  get to() {
+    const { resource, activeNamespace } = this.props;
+    return formatNamespacedRouteForResource(resource, activeNamespace);
+  }
+}
+
+export class ResourceClusterLink extends NavLink<ResourceClusterLinkProps> {
+  static isActive(props, resourcePath) {
+    return resourcePath === props.resource || _.startsWith(resourcePath, `${props.resource}/`) || matchesModel(resourcePath, props.model);
+  }
+
+  get to() {
+    return `/k8s/cluster/${this.props.resource}`;
+  }
+}
+
+export class HrefLink extends NavLink<HrefLinkProps> {
+  static isActive(props, resourcePath) {
+    const noNSHref = stripNS(props.href);
+    return resourcePath === noNSHref || _.startsWith(resourcePath, `${noNSHref}/`);
+  }
+
+  get to() {
+    return this.props.href;
+  }
+}
+
+export type NavLinkProps = {
+  name: string;
+  id?: LinkProps['id'];
+  onClick?: LinkProps['onClick'];
+  isActive?: boolean;
+  required?: string | string[];
+  disallowed?: string;
+  startsWith?: string[];
+  activePath?: string;
+};
+
+export type ResourceNSLinkProps = NavLinkProps & {
+  resource: string;
+  model?: K8sKind;
+  activeNamespace?: string;
+};
+
+export type ResourceClusterLinkProps = NavLinkProps & {
+  resource: string;
+  model?: K8sKind;
+};
+
+export type HrefLinkProps = NavLinkProps & {
+  href: string;
+};

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import * as _ from 'lodash-es';
+import memoize from 'memoize-one';
+import { NavExpandable } from '@patternfly/react-core';
+
+import { RootState } from '../../redux';
+import { featureReducerName, flagPending, FeatureState } from '../../reducers/features';
+import { stripBasePath } from '../utils';
+import * as plugins from '../../plugins';
+import { HrefLink, ResourceNSLink, ResourceClusterLink, stripNS } from './items';
+
+const navSectionStateToProps = (state: RootState, {required}) => {
+  const flags = state[featureReducerName];
+  const canRender = required ? flags.get(required) : true;
+
+  return {
+    flags, canRender,
+    activeNamespace: state.UI.get('activeNamespace'),
+    location: state.UI.get('location'),
+  };
+};
+
+export const NavSection = connect(navSectionStateToProps)(
+  class NavSection extends React.Component<NavSectionProps, NavSectionState> {
+    public state: NavSectionState;
+
+    constructor(props) {
+      super(props);
+      this.state = { isOpen: false, activeChild: null };
+
+      const activeChild = this.getActiveChild();
+      if (activeChild) {
+        this.state.activeChild = activeChild;
+        this.state.isOpen = true;
+      }
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+      const { isOpen } = this.state;
+
+      if (isOpen !== nextProps.isOpen) {
+        return true;
+      }
+
+      if (!isOpen && !nextState.isOpen) {
+        return false;
+      }
+
+      return nextProps.location !== this.props.location || nextProps.flags !== this.props.flags;
+    }
+
+    getActiveChild() {
+      const { activeNamespace, location, children } = this.props;
+
+      if (!children) {
+        return stripBasePath(location).startsWith(this.props.activePath);
+      }
+
+      const resourcePath = location ? stripNS(location) : '';
+
+      //current bug? - we should be checking if children is a single item or .filter is undefined
+      return (children as any[]).filter(c => {
+        if (!c) {
+          return false;
+        }
+        if (c.props.startsWith) {
+          const active = c.type.startsWith(resourcePath, c.props.startsWith, activeNamespace);
+          if (active || !c.props.activePath) {
+            return active;
+          }
+        }
+        return c.type.isActive && c.type.isActive(c.props, resourcePath, activeNamespace);
+      }).map(c => c.props.name)[0];
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+      if (prevProps.location === this.props.location) {
+        return;
+      }
+
+      const activeChild = this.getActiveChild();
+      const state: Partial<NavSectionState> = {activeChild};
+      if (activeChild && !prevState.activeChild) {
+        state.isOpen = true;
+      }
+      this.setState(state as NavSectionState);
+    }
+
+    toggle = (e, expandState) => {
+      this.setState({isOpen: expandState});
+    }
+
+    getPluginNavItems = memoize(
+      (section) => plugins.registry.getNavItems(section)
+    );
+
+    render() {
+      if (!this.props.canRender) {
+        return null;
+      }
+
+      const { title, children, activeNamespace, flags } = this.props;
+      const { isOpen, activeChild } = this.state;
+      const isActive = !!activeChild;
+
+      const mapChild = (c) => {
+        if (!c) {
+          return null;
+        }
+        const {name, required, disallowed} = c.props;
+        const requiredArray = required ? _.castArray(required) : [];
+        const requirementMissing = _.some(requiredArray, flag => (
+          flag && (flagPending(flags.get(flag)) || !flags.get(flag))
+        ));
+        if (requirementMissing) {
+          return null;
+        }
+        if (disallowed && (flagPending(flags.get(disallowed)) || flags.get(disallowed))) {
+          return null;
+        }
+        return React.cloneElement(c, {
+          key: name,
+          isActive: name === this.state.activeChild,
+          activeNamespace,
+          flags,
+        });
+      };
+
+      const Children = React.Children.map(children, mapChild);
+
+      const PluginChildren = _.compact(this.getPluginNavItems(title).map((item, index) => {
+        if (plugins.isHrefNavItem(item)) {
+          return <HrefLink key={index} {...item.properties.componentProps} />;
+        }
+        if (plugins.isResourceNSNavItem(item)) {
+          return <ResourceNSLink key={index} {...item.properties.componentProps} />;
+        }
+        if (plugins.isResourceClusterNavItem(item)) {
+          return <ResourceClusterLink key={index} {...item.properties.componentProps} />;
+        }
+      })).map(mapChild);
+
+      return (Children || PluginChildren.length > 0) ? (
+        <NavExpandable title={title} isActive={isActive} isExpanded={isOpen} onExpand={this.toggle}>
+          {Children}
+          {PluginChildren}
+        </NavExpandable>
+      ) : null;
+    }
+  }
+);
+
+export type NavSectionTitle =
+  | 'Administration'
+  | 'Builds'
+  | 'Catalog'
+  | 'Compute'
+  | 'Home'
+  | 'Monitoring'
+  | 'Networking'
+  | 'Storage'
+  | 'Workloads';
+
+type NavSectionProps = {
+  flags?: FeatureState;
+  title: NavSectionTitle;
+  canRender?: boolean;
+  activeNamespace?: string;
+  activePath?: string;
+  location?: string;
+};
+
+type NavSectionState = {
+  isOpen: boolean;
+  activeChild: React.ReactNode;
+};

--- a/frontend/public/declarations.d.ts
+++ b/frontend/public/declarations.d.ts
@@ -34,6 +34,7 @@ declare interface Window {
     statuspageID: string;
   };
   windowError?: boolean;
+  __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;
 }
 
 // From https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html

--- a/frontend/public/redux.ts
+++ b/frontend/public/redux.ts
@@ -7,9 +7,7 @@ import UIReducers, { UIState } from './reducers/ui';
 
 const composeEnhancers =
   // eslint-disable-next-line no-undef
-  (process.env.NODE_ENV !== 'production' &&
-    (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) ||
-  compose;
+  (process.env.NODE_ENV !== 'production' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
 
 /**
  * This is the entirety of the `redux-thunk` library.


### PR DESCRIPTION
Follow-up to PR #1528.

From plugin perspective:
- [x] nav item extension's `section` now links to all known sections
- [x] nav item extension's `componentProps` now links to corresponding React component props
- [x] add `ResourceClusterNavItem` extension

From Console perspective:
- [x] refactor `public/components/nav/index.jsx` into smaller parts that use TypeScript
- [x] add `__REDUX_DEVTOOLS_EXTENSION_COMPOSE__` to global `Window` declaration
