### PR TITLE
Improve OperatorHub Scenarios

### DIFF
--- a/frontend/__mocks__/k8sResourcesMocks.ts
+++ b/frontend/__mocks__/k8sResourcesMocks.ts
@@ -231,7 +231,7 @@ export const testOwnedResourceInstance: ClusterServiceVersionResourceKind = {
 };
 
 export const testOperatorGroup: OperatorGroupKind = {
-  apiVersion: 'operators.coreos.com/v1alpha2',
+  apiVersion: 'operators.coreos.com/v1',
   kind: 'OperatorGroup',
   metadata: {
     name: 'test-operatorgroup',

--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -116,24 +116,21 @@ export const config: Config = {
     olm: suite([
       'tests/olm/descriptors.scenario.ts',
       'tests/olm/catalog.scenario.ts',
-      'tests/olm/single-installmode.scenario.ts',
       'tests/olm/global-installmode.scenario.ts',
+      'tests/olm/single-installmode.scenario.ts',
     ]),
     olmUpgrade: suite([
       'tests/olm/update-channel-approval.scenario.ts',
     ]),
-    operatorHub: [
-      'tests/login.scenario.ts',
-      'tests/base.scenario.ts',
+    operatorHub: suite([
       'tests/operator-hub/operator-hub.scenario.ts',
-    ],
-    // OLM and OperatorHub
+    ]),
     olmFull: suite([
       'tests/operator-hub/operator-hub.scenario.ts',
       'tests/olm/descriptors.scenario.ts',
       'tests/olm/catalog.scenario.ts',
-      'tests/olm/single-installmode.scenario.ts',
       'tests/olm/global-installmode.scenario.ts',
+      'tests/olm/single-installmode.scenario.ts',
     ]),
     performance: suite([
       'tests/performance.scenario.ts',

--- a/frontend/integration-tests/tests/olm/catalog.scenario.ts
+++ b/frontend/integration-tests/tests/olm/catalog.scenario.ts
@@ -5,7 +5,7 @@ import { appHost, checkLogs, checkErrors, testName } from '../../protractor.conf
 import * as catalogView from '../../views/olm-catalog.view';
 import * as sidenavView from '../../views/sidenav.view';
 
-describe('Installing a service from a Catalog Source', () => {
+describe('Installing an Operator from a Catalog Source', () => {
   const openCloudServices = new Set(['etcd', 'Prometheus Operator']);
   const operatorGroupName = 'test-operatorgroup';
 
@@ -32,7 +32,7 @@ describe('Installing a service from a Catalog Source', () => {
     })());
 
     const operatorGroup = {
-      apiVersion: 'operators.coreos.com/v1alpha2',
+      apiVersion: 'operators.coreos.com/v1',
       kind: 'OperatorGroup',
       metadata: {name: operatorGroupName},
       spec: {targetNamespaces: [testName]},
@@ -60,7 +60,7 @@ describe('Installing a service from a Catalog Source', () => {
 
   it('displays Catalog Source with expected available packages', async() => {
     await sidenavView.clickNavLink(['Catalog', 'Operator Management']);
-    await catalogView.clickCatalogsTab();
+    await catalogView.clickTab('Operator Catalogs');
     await catalogView.isLoaded();
 
     openCloudServices.forEach(name => {
@@ -68,7 +68,7 @@ describe('Installing a service from a Catalog Source', () => {
     });
   });
 
-  it('displays YAML editor for creating a subscription to a service', async() => {
+  it('displays YAML editor for creating a subscription to an Operator', async() => {
     await catalogView.createSubscriptionFor('Prometheus');
     await browser.wait(until.presenceOf($('.ace_text-input')));
 

--- a/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
@@ -19,7 +19,7 @@ describe('Interacting with the Redis Operator (all-namespaces install mode)', ()
 
   beforeAll(async() => {
     const operatorGroup = {
-      apiVersion: 'operators.coreos.com/v1alpha2',
+      apiVersion: 'operators.coreos.com/v1',
       kind: 'OperatorGroup',
       metadata: {name: operatorGroupName},
     };
@@ -42,7 +42,7 @@ describe('Interacting with the Redis Operator (all-namespaces install mode)', ()
 
   it('can be enabled from the Catalog Source', async() => {
     await sidenavView.clickNavLink(['Catalog', 'Operator Management']);
-    await catalogView.clickCatalogsTab();
+    await catalogView.clickTab('Operator Catalogs');
     await catalogView.isLoaded();
     await catalogView.createSubscriptionFor('Redis Enterprise');
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -52,7 +52,7 @@ describe('Interacting with the Redis Operator (all-namespaces install mode)', ()
     await $('#save-changes').click();
     await crudView.isLoaded();
     await sidenavView.clickNavLink(['Catalog', 'Operator Management']);
-    await catalogView.clickCatalogsTab();
+    await catalogView.clickTab('Operator Catalogs');
     await catalogView.isLoaded();
 
     expect(catalogView.hasSubscription('Redis Enterprise')).toBe(true);

--- a/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
@@ -20,7 +20,7 @@ describe('Interacting with the Prometheus Operator (single-namespace install mod
 
   beforeAll(async() => {
     const operatorGroup = {
-      apiVersion: 'operators.coreos.com/v1alpha2',
+      apiVersion: 'operators.coreos.com/v1',
       kind: 'OperatorGroup',
       metadata: {name: operatorGroupName},
       spec: {targetNamespaces: [testName]},
@@ -44,7 +44,7 @@ describe('Interacting with the Prometheus Operator (single-namespace install mod
 
   it('can be enabled from the Catalog Source', async() => {
     await sidenavView.clickNavLink(['Catalog', 'Operator Management']);
-    await catalogView.clickCatalogsTab();
+    await catalogView.clickTab('Operator Catalogs');
     await catalogView.isLoaded();
     await catalogView.createSubscriptionFor('Prometheus');
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -54,7 +54,7 @@ describe('Interacting with the Prometheus Operator (single-namespace install mod
     await $('#save-changes').click();
     await crudView.isLoaded();
     await sidenavView.clickNavLink(['Catalog', 'Operator Management']);
-    await catalogView.clickCatalogsTab();
+    await catalogView.clickTab('Operator Catalogs');
     await catalogView.isLoaded();
 
     expect(catalogView.hasSubscription('Prometheus')).toBe(true);

--- a/frontend/integration-tests/tests/olm/update-channel-approval.scenario.ts
+++ b/frontend/integration-tests/tests/olm/update-channel-approval.scenario.ts
@@ -26,7 +26,7 @@ describe('Manually approving an install plan', () => {
 
   it('removes existing subscription if necessary', async() => {
     await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
-    await catalogView.clickCatalogsTab();
+    await catalogView.clickTab('Operator Catalogs');
     await catalogView.isLoaded();
 
     if (await catalogView.hasSubscription(pkgName)) {
@@ -40,7 +40,7 @@ describe('Manually approving an install plan', () => {
 
   it('creates a subscription with a `startingCSV` that is not latest and manual approval strategy', async() => {
     await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
-    await catalogView.clickCatalogsTab();
+    await catalogView.clickTab('Operator Catalogs');
     await catalogView.isLoaded();
     await catalogView.entryRowFor(pkgName).element(by.buttonText('Create Subscription')).click();
     await browser.wait(until.presenceOf($('.ace_text-input')));
@@ -50,7 +50,7 @@ describe('Manually approving an install plan', () => {
     await $('#save-changes').click();
     await crudView.isLoaded();
     await sidenavView.clickNavLink(['Operators', 'Catalog Sources']);
-    await catalogView.clickCatalogsTab();
+    await catalogView.clickTab('Operator Catalogs');
     await catalogView.isLoaded();
 
     expect(catalogView.hasSubscription(pkgName)).toBe(true);

--- a/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
+++ b/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
@@ -8,10 +8,7 @@ import * as catalogPageView from '../../views/catalog-page.view';
 import * as operatorHubView from '../../views/operator-hub.view';
 
 describe('Subscribing to an Operator from OperatorHub', () => {
-  const openCloudServices = new Set([
-    {id: 'amq-streams-openshift-marketplace', name: 'AMQ Streams'},
-    {id: 'mongodb-enterprise-openshift-marketplace', name: 'MongoDB'},
-  ]);
+  let installedOperator: string;
 
   afterAll(() => {
     execSync(`kubectl delete subscription -n ${testName} --all`);
@@ -24,44 +21,34 @@ describe('Subscribing to an Operator from OperatorHub', () => {
     checkErrors();
   });
 
-  it('displays OperatorHub with expected available operators', async() => {
+  it('displays OperatorHub tile view with expected available Operators', async() => {
     await browser.get(`${appHost}/operatorhub/ns/${testName}`);
     await crudView.isLoaded();
 
-    openCloudServices.forEach(operator => {
-      expect(catalogPageView.catalogTileById(operator.id).isDisplayed()).toBe(true);
-    });
+    expect(catalogPageView.catalogTiles.count()).toBeGreaterThan(0);
   });
 
-  it('displays Couchbase Operator operator when filter "Couchbase" is active', async() => {
-    await catalogPageView.showMoreFilters('provider').click();
-    await catalogPageView.clickFilterCheckbox('provider-couchbase');
-    await browser.wait(until.visibilityOf(catalogPageView.catalogTileById('couchbase-enterprise-certified-openshift-marketplace')));
+  it('filters Operators by "Provider"', async() => {
+    await catalogPageView.filterSectionFor('provider').$$('.filter-panel-pf-category-item').get(0).$('input').click();
+    const filteredOperator = await catalogPageView.catalogTiles.first().$('.catalog-tile-pf-title').getText();
 
-    expect(catalogPageView.catalogTiles.count()).toEqual(1);
+    await catalogPageView.filterSectionFor('provider').$$('.filter-panel-pf-category-item').get(0).$('input').click();
+    await catalogPageView.filterSectionFor('provider').$$('.filter-panel-pf-category-item').get(1).$('input').click();
 
-    await catalogPageView.clickFilterCheckbox('provider-couchbase');
+    expect(catalogPageView.catalogTiles.count()).toBeGreaterThan(0);
+    expect(catalogPageView.catalogTiles.first().$('.catalog-tile-pf-title').getText()).not.toEqual(filteredOperator);
   });
 
-  it('does not display Couchbase Operator operator when filter "Red Hat" is active', async() => {
-    await catalogPageView.clickFilterCheckbox('provider-red-hat');
-    await browser.wait(until.invisibilityOf(catalogPageView.catalogTileById('couchbase-enterprise-certified-openshift-marketplace')));
+  it('filters Operators by name', async() => {
+    await catalogPageView.filterSectionFor('provider').$$('.filter-panel-pf-category-item').get(1).$('input').click();
+    const filteredOperator = await catalogPageView.catalogTiles.first().$('.catalog-tile-pf-title').getText();
+    await catalogPageView.filterByKeyword(filteredOperator);
 
-    expect(catalogPageView.catalogTiles.count()).toBeGreaterThan(1);
-
-    await catalogPageView.clickFilterCheckbox('provider-red-hat');
+    expect(catalogPageView.catalogTiles.count()).toBeGreaterThan(0);
+    expect(catalogPageView.catalogTiles.first().$('.catalog-tile-pf-title').getText()).toEqual(filteredOperator);
   });
 
-  it('displays "AMQ Streams" as an operator when using the filter "stre"', async() => {
-    await catalogPageView.filterByKeyword('stre');
-
-    expect(catalogPageView.catalogTileById('amq-streams-openshift-marketplace').isDisplayed()).toBe(true);
-
-    await catalogPageView.filterByKeyword('');
-  });
-
-  it('displays "Clear All Filters" text when filters remove all operators from display', async() => {
-    await catalogPageView.clickFilterCheckbox('provider-red-hat');
+  it('displays "Clear All Filters" text when filters remove all Operators from display', async() => {
     await catalogPageView.filterByKeyword('NoOperatorsTest');
 
     expect(catalogPageView.catalogTiles.count()).toBe(0);
@@ -69,114 +56,93 @@ describe('Subscribing to an Operator from OperatorHub', () => {
   });
 
   it('clears all filters when "Clear All Filters" text is clicked', async() => {
-    await catalogPageView.filterByKeyword('NoOperatorsTest');
-    expect(catalogPageView.filterCheckboxFor('provider-red-hat').isSelected()).toBe(true);
     await catalogPageView.clearFiltersText.click();
 
     expect(catalogPageView.filterTextbox.getAttribute('value')).toEqual('');
-    expect(catalogPageView.filterCheckboxFor('provider-red-hat').isSelected()).toBe(false);
-
-    openCloudServices.forEach(operator => {
-      expect(catalogPageView.catalogTileById(operator.id).isDisplayed()).toBe(true);
-    });
+    expect(catalogPageView.catalogTiles.count()).toBeGreaterThan(0);
   });
 
-  openCloudServices.forEach(operator => {
-    it(`displays OperatorHubModalOverlay with correct content when ${operator.name} operator is clicked`, async() => {
-      await catalogPageView.catalogTileById(operator.id).click();
-      await operatorHubView.operatorModalIsLoaded();
-
-      expect(operatorHubView.operatorModal.isDisplayed()).toBe(true);
-      expect(operatorHubView.operatorModalTitle.getText()).toEqual(operator.name);
-
-      await operatorHubView.closeOperatorModal();
-      await operatorHubView.operatorModalIsClosed();
-    });
-  });
-
-  it('shows the warning dialog when a community operator is clicked', async() => {
-    await(catalogPageView.catalogTileById('etcd-openshift-marketplace').click());
+  it('shows the warning dialog when a community Operator is clicked', async() => {
+    await catalogPageView.clickFilterCheckbox('providerType-community');
+    await catalogPageView.catalogTiles.first().click();
     await operatorHubView.operatorCommunityWarningIsLoaded();
     await operatorHubView.closeCommunityWarningModal();
     await operatorHubView.operatorCommunityWarningIsClosed();
   });
 
-  it('shows the community operator when "Show Community Operators" is accepted', async() => {
-    await(catalogPageView.catalogTileById('etcd-openshift-marketplace').click());
+  it('shows the community Operator details when "Show Community Operators" is accepted', async() => {
+    const operatorTile = catalogPageView.catalogTiles.first();
+    await operatorTile.click();
     await operatorHubView.operatorCommunityWarningIsLoaded();
-    await operatorHubView.acceptCommunityWarningModal();
+    await operatorHubView.acceptForeverCommunityWarningModal();
     await operatorHubView.operatorCommunityWarningIsClosed();
 
     expect(operatorHubView.operatorModal.isDisplayed()).toBe(true);
-    expect(operatorHubView.operatorModalTitle.getText()).toEqual('etcd');
-
-    await operatorHubView.closeOperatorModal();
-    await operatorHubView.operatorModalIsClosed();
+    expect(operatorHubView.operatorModalTitle.getText()).toEqual(operatorTile.$('.catalog-tile-pf-title').getText());
   });
 
-  it('filters OperatorHub tiles by Category', async() => {
-    expect(catalogPageView.catalogTiles.isPresent()).toBe(true);
-    expect(catalogView.categoryTabs.isPresent()).toBe(true);
+  it('filters Operators by catagory', async() => {
+    await operatorHubView.closeOperatorModal();
+    await operatorHubView.operatorModalIsClosed();
+    await catalogView.categoryTabs.get(1).click();
+
+    expect(catalogPageView.catalogTiles.count()).toBeGreaterThan(0);
   });
 
   it('displays subscription creation form for selected Operator', async() => {
-    await catalogPageView.catalogTileById('etcd-openshift-marketplace').click();
-    await operatorHubView.operatorCommunityWarningIsLoaded();
-    await operatorHubView.acceptCommunityWarningModal();
-    await operatorHubView.operatorModalIsLoaded();
+    await catalogView.categoryTabs.get(0).click();
+    installedOperator = await catalogPageView.catalogTiles.first().$('.catalog-tile-pf-title').getText();
+    await catalogPageView.catalogTileFor(installedOperator).click();
+    await browser.wait(until.visibilityOf(operatorHubView.operatorModal));
     await operatorHubView.operatorModalInstallBtn.click();
+    await operatorHubView.createSubscriptionFormLoaded();
 
-    expect(browser.getCurrentUrl()).toContain('/operatorhub/subscribe?pkg=etcd&catalog=community-operators&catalogNamespace=openshift-marketplace&targetNamespace=');
-    expect(operatorHubView.createSubscriptionFormTitle.isDisplayed()).toBe(true);
+    expect(operatorHubView.createSubscriptionFormName.getText()).toEqual(installedOperator);
   });
 
   it('selects target namespace for Operator subscription', async() => {
     await browser.wait(until.visibilityOf(operatorHubView.createSubscriptionFormInstallMode));
-    await $('input[value="singlenamespace-alpha"]').click();
 
-    expect($('input[value="SingleNamespace"]').getAttribute('disabled')).toBe(null);
+    if (operatorHubView.singleNamespaceInstallMode.getAttribute('disabled') !== null) {
+      await operatorHubView.singleNamespaceInstallMode.click();
+      await browser.wait(until.visibilityOf(operatorHubView.installNamespaceDropdownBtn));
+      await operatorHubView.installNamespaceDropdownBtn.click();
+      await operatorHubView.installNamespaceDropdownFilter(testName);
+      await operatorHubView.installNamespaceDropdownSelect(testName).click();
+    }
+
+    expect(operatorHubView.createSubscriptionError.isPresent()).toBe(false);
+    expect(operatorHubView.createSubscriptionFormBtn.getAttribute('disabled')).toEqual(null);
   });
 
   it('displays Operator as subscribed in OperatorHub', async() => {
-    await $('input[value="SingleNamespace"]').click();
-    await browser.wait(until.visibilityOf(operatorHubView.installNamespaceDropdownBtn));
-    await operatorHubView.installNamespaceDropdownBtn.click();
-    await operatorHubView.installNamespaceDropdownFilter(testName);
-    await operatorHubView.installNamespaceDropdownSelect(testName).click();
-
     await operatorHubView.createSubscriptionFormBtn.click();
     await crudView.isLoaded();
     await browser.get(`${appHost}/operatorhub/ns/${testName}`);
     await crudView.isLoaded();
     await catalogPageView.clickFilterCheckbox('installState-installed');
 
-    expect(catalogPageView.catalogTileById('etcd-openshift-marketplace').$('.catalog-tile-pf-footer').getText()).toContain('Installed');
+    expect(catalogPageView.catalogTileFor(installedOperator).isDisplayed()).toBe(true);
   });
 
   it(`displays Operator in "Cluster Service Versions" view for "${testName}" namespace`, async() => {
-    await browser.get(`${appHost}/operatorhub/ns/${testName}`);
-    await crudView.isLoaded();
-    await catalogPageView.catalogTileById('etcd-openshift-marketplace').click();
-    await operatorHubView.operatorCommunityWarningIsLoaded();
-    await operatorHubView.acceptCommunityWarningModal();
+    await catalogPageView.catalogTileFor(installedOperator).click();
     await operatorHubView.operatorModalIsLoaded();
     await operatorHubView.viewInstalledOperator();
     await crudView.isLoaded();
 
-    await browser.wait(until.visibilityOf(crudView.rowForOperator('etcd')), 30000);
+    await browser.wait(until.visibilityOf(crudView.rowForOperator(installedOperator)), 30000);
   });
 
   it('displays button to uninstall the Operator', async() => {
     await browser.get(`${appHost}/operatorhub/ns/${testName}`);
     await crudView.isLoaded();
     await catalogPageView.clickFilterCheckbox('installState-installed');
-    await catalogPageView.catalogTileFor('etcd').click();
-    await operatorHubView.operatorCommunityWarningIsLoaded();
-    await operatorHubView.acceptCommunityWarningModal();
+    await catalogPageView.catalogTileFor(installedOperator).click();
     await operatorHubView.operatorModalIsLoaded();
     await operatorHubView.operatorModalUninstallBtn.click();
 
-    expect(browser.getCurrentUrl()).toContain(`/ns/${testName}/subscriptions/etcd?showDelete=true`);
+    expect(browser.getCurrentUrl()).toContain(`/ns/${testName}/subscriptions/`);
   });
 
   it('uninstalls Operator from the cluster', async() => {
@@ -184,6 +150,6 @@ describe('Subscribing to an Operator from OperatorHub', () => {
     await element(by.cssContainingText('#confirm-action', 'Remove')).click();
     await crudView.isLoaded();
 
-    expect(crudView.rowForName('etcd').isPresent()).toBe(false);
+    expect(crudView.rowForOperator(installedOperator).isPresent()).toBe(false);
   });
 });

--- a/frontend/integration-tests/views/catalog-page.view.ts
+++ b/frontend/integration-tests/views/catalog-page.view.ts
@@ -5,11 +5,12 @@ export const catalogTileFor = (name: string) => element(by.cssContainingText('.c
 export const catalogTileById = (id: string) => $(`[data-test=${id}]`);
 
 // FilterSidePanel views
+export const filterSectionFor = (group: string) => $(`[data-test-group-name=${group}]`);
 export const showMoreFilters = (group: string) => $(`[data-test-group-name=${group}] .btn-link`);
 export const filterCheckboxFor = (id: string) => $(`input[data-test=${id}]`);
 export const clickFilterCheckbox = (id: string) => filterCheckboxFor(id).click();
 export const filterCheckboxCount = (id: string) => filterCheckboxFor(id).$('.item-count').getText()
   .then(text => parseInt(text.substring(1, text.indexOf(')')), 10));
 export const filterTextbox = $$('.filter-panel-pf-category').first().$('input');
-export const filterByKeyword = (filter: string) => filterTextbox.sendKeys(filter);
+export const filterByKeyword = (filter: string) => filterTextbox.clear().then(() => filterTextbox.sendKeys(filter));
 export const clearFiltersText = $('.co-catalog-page__no-filter-results').$('.blank-slate-pf-helpLink').$('button');

--- a/frontend/integration-tests/views/olm-catalog.view.ts
+++ b/frontend/integration-tests/views/olm-catalog.view.ts
@@ -8,7 +8,7 @@ export const entryRowFor = (name: string) => element(by.cssContainingText(rowSel
 
 export const isLoaded = () => browser.wait(until.presenceOf($('.loading-box__loaded')), 10000).then(() => browser.sleep(500));
 
-export const clickCatalogsTab = () => crudView.clickTab('Operator Catalogs');
+export const clickTab = (tab: string) => crudView.clickTab(tab);
 
 export const hasSubscription = (name: string) => browser.getCurrentUrl().then(url => {
   if (url.indexOf('all-namespaces') > -1) {

--- a/frontend/integration-tests/views/operator-hub.view.ts
+++ b/frontend/integration-tests/views/operator-hub.view.ts
@@ -12,8 +12,13 @@ export const operatorModalIsClosed = () => browser.wait(until.not(until.presence
 export const viewInstalledOperator = () => $('.hint-block-pf').element(by.linkText('View it here.')).click();
 
 export const createSubscriptionFormTitle = element(by.cssContainingText('h1', 'Create Operator Subscription'));
+export const createSubscriptionFormName = $('.co-clusterserviceversion-logo__name__clusterserviceversion');
 export const createSubscriptionFormBtn = element(by.buttonText('Subscribe'));
+export const createSubscriptionFormLoaded = () => browser.wait(until.visibilityOf(createSubscriptionFormBtn));
 export const createSubscriptionFormInstallMode = element(by.cssContainingText('label', 'Installation Mode'));
+export const allNamespacesInstallMode = $('input[value="AllNamespaces"]');
+export const singleNamespaceInstallMode = $('input[value="SingleNamespace"]');
+export const createSubscriptionError = $('.alert-danger');
 
 export const installNamespaceDropdown = $('.dropdown--full-width');
 export const installNamespaceDropdownBtn = installNamespaceDropdown.$('.dropdown-toggle');
@@ -29,3 +34,5 @@ export const operatorCommunityWarningIsClosed = () => browser.wait(until.not(unt
   .then(() => browser.sleep(500));
 export const closeCommunityWarningModal = () => communityWarningModal.$('.btn-default').click();
 export const acceptCommunityWarningModal = () => communityWarningModal.$('.btn-primary').click();
+export const acceptForeverCommunityWarningModal = () => $('.co-modal-ignore-warning__checkbox').$('input').click()
+  .then(() => acceptCommunityWarningModal());

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -230,7 +230,7 @@ export type PackageManifestKind = {
 } & K8sResourceKind;
 
 export type OperatorGroupKind = {
-  apiVersion: 'operators.coreos.com/v1alpha2';
+  apiVersion: 'operators.coreos.com/v1';
   kind: 'OperatorGroup';
   spec?: {
     selector?: Selector;


### PR DESCRIPTION
### Description

Reduce flakes by removing dependence on specific Operators being present in OperatorHub and focusing solely on the _functionality_ of OperatorHub, rather than testing the _content_.

### Future Work

- Once **Operator Catalogs** view is unified with **OperatorHub** (local `CatalogSources` visible in tile view), we will only need a single test suite for subscription flow. We can also use the static testing `CatalogSource` so we know the Operators contained there will not change
