### PR TITLE
Support models declared by plugins

### DIFF
--- a/frontend/__tests__/module/k8s/k8s-models.spec.ts
+++ b/frontend/__tests__/module/k8s/k8s-models.spec.ts
@@ -1,6 +1,6 @@
-import { referenceFor, referenceForCRD, referenceForOwnerRef, referenceForModel, kindForReference, versionForReference } from '../../../public/module/k8s';
+import { referenceFor, referenceForCRD, referenceForOwnerRef, referenceForModel, kindForReference, versionForReference, modelsToMap } from '../../../public/module/k8s';
 import { testNamespace, testClusterServiceVersion, testCRD, testOwnedResourceInstance } from '../../../__mocks__/k8sResourcesMocks';
-import { PodModel, DeploymentModel } from '../../../public/models';
+import { PodModel, DeploymentModel, SubscriptionModel, PrometheusModel } from '../../../public/models';
 
 describe('referenceFor', () => {
 
@@ -54,5 +54,22 @@ describe('versionForReference', () => {
 
   it('returns the API version for a given reference', () => {
     expect(versionForReference(referenceFor(testClusterServiceVersion))).toEqual('v1alpha1');
+  });
+});
+
+describe('modelsToMap', () => {
+
+  it('returns a map with keys based on model.kind for models with crd:false', () => {
+    expect(modelsToMap([ PodModel, DeploymentModel ]).toObject()).toEqual({
+      [PodModel.kind]: PodModel,
+      [DeploymentModel.kind]: DeploymentModel,
+    });
+  });
+
+  it('returns a map with keys based on referenceForModel for models with crd:true', () => {
+    expect(modelsToMap([ SubscriptionModel, PrometheusModel ]).toObject()).toEqual({
+      [referenceForModel(SubscriptionModel)]: SubscriptionModel,
+      [referenceForModel(PrometheusModel)]: PrometheusModel,
+    });
   });
 });

--- a/frontend/packages/console-demo-plugin/src/models.ts
+++ b/frontend/packages/console-demo-plugin/src/models.ts
@@ -1,0 +1,15 @@
+import { K8sKind } from '@console/internal/module/k8s';
+
+export const FooBarModel: K8sKind = {
+  apiGroup: 'test.io',
+  apiVersion: 'v1alpha1',
+  kind: 'FooBar',
+  label: 'Foo Bar',
+  labelPlural: 'Foo Bars',
+  path: 'foobars',
+  plural: 'foobars',
+  abbr: 'FOOBAR',
+  namespaced: true,
+  id: 'foobar',
+  crd: true,
+};

--- a/frontend/packages/console-demo-plugin/src/plugin.ts
+++ b/frontend/packages/console-demo-plugin/src/plugin.ts
@@ -1,5 +1,8 @@
+import * as _ from 'lodash-es';
+
 import {
   Plugin,
+  ModelDefinition,
   ModelFeatureFlag,
   HrefNavItem,
   ResourceNSNavItem,
@@ -12,7 +15,10 @@ import {
 import { PodModel } from '@console/internal/models';
 import { FLAGS } from '@console/internal/const';
 
+import * as models from './models';
+
 type ConsumedExtensions =
+  | ModelDefinition
   | ModelFeatureFlag
   | HrefNavItem
   | ResourceNSNavItem
@@ -21,6 +27,12 @@ type ConsumedExtensions =
   | ResourceDetailPage;
 
 const plugin: Plugin<ConsumedExtensions> = [
+  {
+    type: 'ModelDefinition',
+    properties: {
+      models: _.values(models),
+    },
+  },
   {
     type: 'FeatureFlag/Model',
     properties: {

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -1,5 +1,13 @@
 import * as _ from 'lodash-es';
-import { Extension, PluginList, isNavItem, isResourcePage, isFeatureFlag } from './typings';
+
+import {
+  Extension,
+  ActivePlugin,
+  isModelDefinition,
+  isFeatureFlag,
+  isNavItem,
+  isResourcePage,
+} from './typings';
 
 /**
  * Registry used to query for Console extensions.
@@ -8,8 +16,16 @@ export class ExtensionRegistry {
 
   private readonly extensions: Extension<any>[];
 
-  public constructor(plugins: PluginList) {
-    this.extensions = _.flatMap(plugins);
+  public constructor(plugins: ActivePlugin[]) {
+    this.extensions = _.flatMap(plugins.map(p => p.extensions));
+  }
+
+  public getModelDefinitions() {
+    return this.extensions.filter(isModelDefinition);
+  }
+
+  public getFeatureFlags() {
+    return this.extensions.filter(isFeatureFlag);
   }
 
   public getNavItems(section: string) {
@@ -18,10 +34,6 @@ export class ExtensionRegistry {
 
   public getResourcePages() {
     return this.extensions.filter(isResourcePage);
-  }
-
-  public getFeatureFlags() {
-    return this.extensions.filter(isFeatureFlag);
   }
 
 }

--- a/frontend/packages/console-plugin-sdk/src/typings/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/index.ts
@@ -1,21 +1,25 @@
 /**
- * An extension of the Console web application.
+ * An extension of the Console application.
  *
  * Each extension is a realization (instance) of an extension `type` using the
  * parameters provided via the `properties` object.
  *
- * Core extension types should follow `Category` or `Category/Specialization`
- * format, e.g. `NavItem/Href`.
+ * The value of extension `type` should be formatted in a way that describes
+ * the broader category as well as any specialization(s), for example:
  *
- * @todo(vojtech) write ESLint rule to guard against extension type duplicity
+ * - `ModelDefinition`
+ * - `NavItem/Href`
+ * - `Dashboards/Overview/Utilization`
+ *
+ * TODO(vojtech): write ESLint rule to guard against extension type duplicity
  */
-export interface Extension<P> {
+export type Extension<P> = {
   type: string;
   properties: P;
-}
+};
 
 /**
- * A plugin is simply a list of extensions.
+ * From plugin author perspective, a plugin is simply a list of extensions.
  *
  * Plugin metadata is stored in the `package.json` file of the corresponding
  * monorepo package. The `consolePlugin.entry` path should point to a module
@@ -56,12 +60,17 @@ export interface Extension<P> {
 export type Plugin<E extends Extension<any>> = E[];
 
 /**
- * A list of arbitrary plugins.
+ * From Console application perspective, a plugin is a list of extensions
+ * enhanced with additional data.
  */
-export type PluginList = Plugin<Extension<any>>[];
+export type ActivePlugin = {
+  name: string;
+  extensions: Extension<any>[];
+};
 
 // TODO(vojtech): internal code needed by plugin SDK should be moved to console-shared package
 
 export * from './features';
+export * from './models';
 export * from './nav';
 export * from './pages';

--- a/frontend/packages/console-plugin-sdk/src/typings/models.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/models.ts
@@ -1,0 +1,16 @@
+import { Extension } from '.';
+import { K8sKind } from '@console/internal/module/k8s';
+
+namespace ExtensionProperties {
+  export interface ModelDefinition {
+    models: K8sKind[];
+  }
+}
+
+export interface ModelDefinition extends Extension<ExtensionProperties.ModelDefinition> {
+  type: 'ModelDefinition';
+}
+
+export function isModelDefinition(e: Extension<any>): e is ModelDefinition {
+  return e.type === 'ModelDefinition';
+}

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -1,16 +1,16 @@
 /* eslint-disable no-undef */
 
-import { PluginList, ExtensionRegistry } from '@console/plugin-sdk';
+import { ActivePlugin, ExtensionRegistry } from '@console/plugin-sdk';
 export * from '@console/plugin-sdk';
 
 // the '@console/active-plugins' module is generated during webpack build
 const activePlugins = (process.env.NODE_ENV !== 'test')
-  ? require('@console/active-plugins').default as PluginList
+  ? require('@console/active-plugins').default as ActivePlugin[]
   : [];
 
 export const registry = new ExtensionRegistry(activePlugins);
 
 if (process.env.NODE_ENV !== 'test') {
   // eslint-disable-next-line no-console
-  console.info(`${activePlugins.length} plugins active`);
+  console.info(`Active plugins: [${activePlugins.map(p => p.name).join(', ')}]`);
 }

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -8,7 +8,7 @@ import * as ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import * as MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import * as VirtualModulesPlugin from 'webpack-virtual-modules';
 
-import { readPackages, resolveActivePlugins, getActivePluginsModule } from '@console/plugin-sdk/src/codegen';
+import { readPackages, getActivePluginPackages, getActivePluginsModule } from '@console/plugin-sdk/src/codegen';
 
 const NODE_ENV = process.env.NODE_ENV;
 
@@ -134,7 +134,7 @@ if (NODE_ENV === 'production') {
 /* Console plugin support */
 const packageFiles = glob.sync('packages/*/package.json', { absolute: true });
 const { appPackage, pluginPackages } = readPackages(packageFiles);
-const activePluginPackages = appPackage ? resolveActivePlugins(appPackage, pluginPackages) : [];
+const activePluginPackages = appPackage ? getActivePluginPackages(appPackage, pluginPackages) : [];
 
 config.plugins.push(
   new VirtualModulesPlugin({


### PR DESCRIPTION
This PR ensures that Console is aware of any additional static models declared by plugins.

### Overview

Plugins are encouraged to keep all of their model definitions in a single module, e.g. `models.ts` placed next to `plugin.ts`.

```ts
// models.ts

import { K8sKind } from '@console/internal/module/k8s';

export const FooBarModel: K8sKind = {
  apiGroup: 'test.io',
  apiVersion: 'v1alpha1',
  kind: 'FooBar',
  label: 'Foo Bar',
  labelPlural: 'Foo Bars',
  path: 'foobars',
  plural: 'foobars',
  abbr: 'FOOBAR',
  namespaced: true,
  id: 'foobar',
  crd: true,
};
```

To add these models, use the new `ModelDefinition` extension:

```ts
// plugin.ts

import * as _ from 'lodash-es';
import { Plugin, ModelDefinition } from '@console/plugin-sdk';
import * as models from './models';

type ConsumedExtensions = ModelDefinition /* | OtherExtension | ... */;

const plugin: Plugin<ConsumedExtensions> = [
  {
    type: 'ModelDefinition',
    properties: {
      models: _.values(models),
    },
  },
];
```

Browser console log:

```
Active plugins: [@console/demo-plugin]
1 new models added by plugins
```

The `@console/active-plugins` module codegen has been modified to export `ActivePlugin[]`, i.e. the list of extensions enhanced with additional data:

```ts
export type ActivePlugin = {
  name: string;                 // = pkg.name
  extensions: Extension<any>[]; // = pkg.consolePlugin.entry
};
```

Any future metadata (e.g. plugin order) can be part of the `ActivePlugin` representation.

_Note: from plugin author perspective, a plugin remains to be a list of `Extension` objects._

### Handling model conflicts

A plugin cannot redefine existing models, this includes both Console base models and models declared previously by other plugins.

```ts
// models.ts

import { K8sKind } from '@console/internal/module/k8s';

export const FooBarModel: K8sKind = {
  apiGroup: 'test.io',
  apiVersion: 'v1alpha1',
  kind: 'FooBar',
  label: 'Foo Bar',
  labelPlural: 'Foo Bars',
  path: 'foobars',
  plural: 'foobars',
  abbr: 'FOOBAR',
  namespaced: true,
  id: 'foobar',
  crd: true,
};

// this model is conflicting with existing Console declaration:
// referenceForModel(baseModel) === referenceForModel(thisModel)
export const PrometheusModel: K8sKind = {
  kind: 'Prometheus',
  label: 'Prometheus',
  labelPlural: 'Prometheuses',
  apiGroup: 'monitoring.coreos.com',
  apiVersion: 'v1',
  path: 'prometheusi', // <-- change here
  abbr: 'PI',
  namespaced: true,
  crd: true,
  plural: 'prometheuses',
  propagationPolicy : 'Foreground',
};
```

The conflicting models will be reported in browser console log:

```
Active plugins: [@console/demo-plugin]
attempt to redefine model monitoring.coreos.com~v1~Prometheus
1 new models added by plugins
```

---

@mareklibra @jtomasek YAML template extension will be done in a separate PR.
