### PR TITLE
Add help and aria described by to list input component

### DIFF
--- a/frontend/public/components/cluster-settings/github-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/github-idp-form.tsx
@@ -192,11 +192,11 @@ export class AddGitHubPage extends PromiseComponent<{}, AddGitHubPageState> {
         <div className="co-form-section__separator"></div>
         <h3>Organizations</h3>
         <p className="co-help-text">Optionally list organizations. If specified, only GitHub users that are members of at least one of the listed organizations will be allowed to log in. Cannot be used in combination with <strong>teams</strong>.</p>
-        <ListInput label="Organization" onChange={this.organizationChanged} />
+        <ListInput label="Organization" onChange={this.organizationChanged} helpText="Restricts which organizations are allowed to log in." />
         <div className="co-form-section__separator"></div>
         <h3>Teams</h3>
         <p className="co-help-text">Optionally list teams. If specified, only GitHub users that are members of at least one of the listed teams will be allowed to log in. Cannot be used in combination with <strong>organizations</strong>.</p>
-        <ListInput label="Team" onChange={this.teamChanged} />
+        <ListInput label="Team" onChange={this.teamChanged} helpText="Restricts which teams are allowed to log in. The format is <org>/<team>." />
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
           <button type="submit" className="btn btn-primary">Add</button>
           <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>

--- a/frontend/public/components/cluster-settings/ldap-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/ldap-idp-form.tsx
@@ -219,10 +219,10 @@ export class AddLDAPPage extends PromiseComponent<{}, AddLDAPPageState> {
         <div className="co-form-section__separator"></div>
         <h3>Attributes</h3>
         <p className="co-help-text">Attributes map LDAP attributes to identities.</p>
-        <ListInput label="ID" required initialValues={attributesID} onChange={this.attributesIDChanged} />
-        <ListInput label="Preferred Username" initialValues={attributesPreferredUsername} onChange={this.attributesPreferredUsernameChanged} />
-        <ListInput label="Name" initialValues={attributesName} onChange={this.attributesNameChanged} />
-        <ListInput label="Email" onChange={this.attributesEmailChanged} />
+        <ListInput label="ID" required initialValues={attributesID} onChange={this.attributesIDChanged} helpText="The list of attributes whose values should be used as the user ID." />
+        <ListInput label="Preferred Username" initialValues={attributesPreferredUsername} onChange={this.attributesPreferredUsernameChanged} helpText="The list of attributes whose values should be used as the preferred username." />
+        <ListInput label="Name" initialValues={attributesName} onChange={this.attributesNameChanged} helpText="The list of attributes whose values should be used as the display name." />
+        <ListInput label="Email" onChange={this.attributesEmailChanged} helpText="The list of attributes whose values should be used as the email address." />
         <div className="co-form-section__separator"></div>
         <h3>More Options</h3>
         <IDPCAFileInput value={caFileContent} onChange={this.caFileChanged} />

--- a/frontend/public/components/cluster-settings/openid-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/openid-idp-form.tsx
@@ -207,13 +207,13 @@ export class AddOpenIDPage extends PromiseComponent<{}, AddOpenIDIDPPageState> {
         <div className="co-form-section__separator"></div>
         <h3>Claims</h3>
         <p className="co-help-text">Claims map metadata from the OpenID provider to an OpenShift user. The first non-empty claim is used.</p>
-        <ListInput label="Preferred Username" initialValues={claimPreferredUsernames} onChange={this.claimPreferredUsernamesChanged} />
-        <ListInput label="Name" initialValues={claimNames} onChange={this.claimNamesChanged} />
-        <ListInput label="Email" initialValues={claimEmails} onChange={this.claimEmailsChanged} />
+        <ListInput label="Preferred Username" initialValues={claimPreferredUsernames} onChange={this.claimPreferredUsernamesChanged} helpText="Any scopes to request in addition to the standard openid scope." />
+        <ListInput label="Name" initialValues={claimNames} onChange={this.claimNamesChanged} helpText="The list of claims whose values should be used as the display name." />
+        <ListInput label="Email" initialValues={claimEmails} onChange={this.claimEmailsChanged} helpText="The list of claims whose values should be used as the email address." />
         <div className="co-form-section__separator"></div>
         <h3>More Options</h3>
         <IDPCAFileInput value={caFileContent} onChange={this.caFileChanged} />
-        <ListInput label="Extra Scopes" onChange={this.extraScopesChanged} />
+        <ListInput label="Extra Scopes" onChange={this.extraScopesChanged} helpText="Any scopes to request in addition to the standard openid scope." />
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
           <button type="submit" className="btn btn-primary">Add</button>
           <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>

--- a/frontend/public/components/cluster-settings/request-header-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/request-header-idp-form.tsx
@@ -174,11 +174,11 @@ export class AddRequestHeaderPage extends PromiseComponent<{}, AddRequestHeaderP
         <div className="co-form-section__separator" />
         <h3>More Options</h3>
         <IDPCAFileInput value={caFileContent} onChange={this.caFileChanged} isRequired />
-        <ListInput label="Client Common Names" onChange={this.clientCommonNamesChanged} />
-        <ListInput label="Headers" onChange={this.headersChanged} required />
-        <ListInput label="Preferred Username Headers" onChange={this.preferredUsernameHeadersChanged} />
-        <ListInput label="Name Headers" onChange={this.nameHeadersChanged} />
-        <ListInput label="Email Headers" onChange={this.emailHeadersChanged} />
+        <ListInput label="Client Common Names" onChange={this.clientCommonNamesChanged} helpText="The set of common names to require a match from." />
+        <ListInput label="Headers" onChange={this.headersChanged} helpText="The set of headers to check for identity information." required />
+        <ListInput label="Preferred Username Headers" onChange={this.preferredUsernameHeadersChanged} helpText="The set of headers to check for the preferred username." />
+        <ListInput label="Name Headers" onChange={this.nameHeadersChanged} helpText="The set of headers to check for the display name." />
+        <ListInput label="Email Headers" onChange={this.emailHeadersChanged} helpText="The set of headers to check for the email address." />
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
           <button type="submit" className="btn btn-primary">Add</button>
           <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>

--- a/frontend/public/components/utils/_list-input.scss
+++ b/frontend/public/components/utils/_list-input.scss
@@ -2,6 +2,10 @@
   padding-left: 0;
 }
 
+.co-list-input__help-block {
+  margin-bottom: 10px
+}
+
 .co-list-input__remove-btn {
   margin-left: 5px;
   margin-top: -6px;

--- a/frontend/public/components/utils/list-input.tsx
+++ b/frontend/public/components/utils/list-input.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 
 export class ListInput extends React.Component<ListInputProps, ListInputState> {
+  private helpID: string = _.uniqueId('list-view-help-');
   constructor(props: ListInputProps) {
     super(props);
     this.state = {
@@ -40,7 +41,7 @@ export class ListInput extends React.Component<ListInputProps, ListInputState> {
   }
 
   render() {
-    const { label, required } = this.props;
+    const { label, required, helpText } = this.props;
     const { values } = this.state;
     const missingValues = required && (_.isEmpty(values) || _.every(values, v => !v));
     return (
@@ -54,7 +55,8 @@ export class ListInput extends React.Component<ListInputProps, ListInputState> {
                 type="text"
                 value={v}
                 onChange={(e: React.FormEvent<HTMLInputElement>) => this.valueChanged(i, e.currentTarget.value)}
-                required={missingValues && i === 0} />
+                required={missingValues && i === 0}
+                aria-describedby={helpText ? this.helpID : undefined} />
             </div>
             <div className="co-list-input__remove-btn">
               <button type="button" className="btn btn-link btn-link--inherit-color" onClick={() => this.removeValue(i)} aria-label="Remove">
@@ -63,6 +65,7 @@ export class ListInput extends React.Component<ListInputProps, ListInputState> {
             </div>
           </div>
         ))}
+        {helpText && <div className="co-list-input__help-block help-block" id={this.helpID}>{helpText}</div>}
         <button type="button" className="btn btn-link co-list-input__add-btn" onClick={() => this.addValue()}>
           <i className="fa fa-plus-circle pairs-list__add-icon" aria-hidden="true" />Add More
         </button>
@@ -81,5 +84,6 @@ type ListInputProps = {
   label: string;
   initialValues?: string[];
   onChange: ChangeCallback;
+  helpText?: string;
   required?: boolean;
 };


### PR DESCRIPTION
And add help text and aria-describedby for all idp pages using the list input component.

<img width="716" alt="Screen Shot 2019-05-18 at 3 03 09 PM" src="https://user-images.githubusercontent.com/35978579/57973914-3abfcf80-797e-11e9-8746-88fe8b975f04.png">

after margin change:

![Screen Shot 2019-05-20 at 11 54 38 AM](https://user-images.githubusercontent.com/35978579/58035435-c2304e80-7af6-11e9-9468-5bb48062881e.png)
