### PR TITLE
Add Explore Type sidebar to YAML editor

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,6 +91,7 @@
     "react-helmet": "5.x",
     "react-jsonschema-form": "^1.0.4",
     "react-lightweight-tooltip": "1.x",
+    "react-linkify": "^0.2.2",
     "react-modal": "3.x",
     "react-redux": "5.x",
     "react-router-dom": "4.x",

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -14,7 +14,7 @@ import { getBrandingDetails, Masthead } from './masthead';
 import { Navigation } from './nav';
 import { history } from './utils';
 import * as UIActions from '../actions/ui';
-import { getCachedResources } from '../module/k8s';
+import { fetchSwagger, getCachedResources } from '../module/k8s';
 import { ActionType, watchAPIServices } from '../actions/k8s';
 import '../vendor.scss';
 import '../style.scss';
@@ -140,6 +140,9 @@ store.dispatch(detectFeatures());
 
 // Global timer to ensure all <Timestamp> components update in sync
 setInterval(() => store.dispatch(UIActions.updateTimestamps(Date.now())), 10000);
+
+// Fetch swagger on load if it's stale.
+fetchSwagger();
 
 // Used by GUI tests to check for unhandled exceptions
 window.windowError = false;

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -14,10 +14,9 @@ import 'brace/snippets/yaml';
 
 import { k8sCreate, k8sUpdate, referenceFor, getCompletions, groupVersionFor, snippets, referenceForModel } from '../module/k8s';
 import { checkAccess, history, Loading, resourceObjPath } from './utils';
-import { coFetchJSON } from '../co-fetch';
+import { ExploreTypeSidebar } from './sidebars/explore-type-sidebar';
 import { ResourceSidebar } from './sidebars/resource-sidebar';
 import { yamlTemplates } from '../models/yaml-templates';
-import { SWAGGER_SESSION_STORAGE_KEY } from '../const';
 
 const { snippetManager } = ace.acequire('ace/snippets');
 snippetManager.register([...snippets.values()], 'yaml');
@@ -70,20 +69,6 @@ export const EditYAML = connect(stateToProps)(
 
       if (this.props.error) {
         this.handleError(this.props.error);
-      }
-
-      // Retrieve k8s API spec for autocompletion
-      if (!window.sessionStorage.getItem(SWAGGER_SESSION_STORAGE_KEY)) {
-        coFetchJSON('api/kubernetes/openapi/v2').then(swagger => {
-          // Only store definitions to reduce the document size.
-          const json = JSON.stringify(swagger.definitions || {});
-          try {
-            window.sessionStorage.setItem(SWAGGER_SESSION_STORAGE_KEY, json);
-          } catch (e) {
-            // eslint-disable-next-line no-console
-            console.error('Could not store swagger.json', e);
-          }
-        });
       }
     }
 
@@ -394,7 +379,8 @@ export const EditYAML = connect(stateToProps)(
                 </div>
               </div>
             </div>
-            <ResourceSidebar isCreateMode={create} kindObj={model} height={this.state.height} loadSampleYaml={this.loadSampleYaml_} downloadSampleYaml={this.downloadSampleYaml_} />
+            {create && <ResourceSidebar isCreateMode={create} kindObj={model} height={this.state.height} loadSampleYaml={this.loadSampleYaml_} downloadSampleYaml={this.downloadSampleYaml_} />}
+            {!create && <ExploreTypeSidebar kindObj={model} height={this.state.height} />}
           </div>
         </div>
       </div>;

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import * as classNames from 'classnames';
+
+import { getStoredSwagger, K8sKind, SwaggerDefinition, SwaggerDefinitions } from '../../module/k8s';
+import { ResourceSidebarWrapper, sidebarScrollTop } from './resource-sidebar';
+import { CamelCaseWrap, LinkifyExternal } from '../utils';
+
+const getRef = (definition: SwaggerDefinition): string => {
+  const ref = definition.$ref || _.get(definition, 'items.$ref');
+  const re = /^#\/definitions\//;
+  // Only follow JSON pointers, not external URI references.
+  return ref && re.test(ref) ? ref.replace(re, '') : null;
+};
+
+export const ExploreTypeSidebar: React.FC<ExploreTypeSidebarProps> = (props) => {
+  // Track the previously selected items to build breadcrumbs. Each history
+  // entry contains the name, description, and path to the definition in the
+  // OpenAPI document.
+  const [drilldownHistory, setDrilldownHistory] = React.useState([]);
+  const {kindObj, height} = props;
+  if (!kindObj) {
+    return null;
+  }
+
+  const allDefinitions: SwaggerDefinitions = getStoredSwagger();
+  if (!allDefinitions) {
+    return null;
+  }
+  const currentSelection = _.last(drilldownHistory);
+  // Show the current selected property or the top-level definition for the kind.
+  const currentPath = currentSelection
+    ? currentSelection.path
+    : [Object.keys(allDefinitions).find(key => key.endsWith(`${kindObj.apiVersion.replace('/', '.')}.${kindObj.kind}`))];
+  const currentDefinition: SwaggerDefinition = _.get(allDefinitions, currentPath) || {};
+
+  // Prefer the description saved in `currentSelection`. It won't always be defined in the definition itself.
+  const description = currentSelection ? currentSelection.description : currentDefinition.description;
+  const required = new Set(currentDefinition.required || []);
+  const breadcrumbs = drilldownHistory.length ? [kindObj.kind, ..._.map(drilldownHistory, 'name')] : [];
+
+  const drilldown = (e: React.MouseEvent<HTMLButtonElement>, name: string, desc: string, path: string[]) => {
+    e.preventDefault();
+    setDrilldownHistory([...drilldownHistory, { name, description: desc, path }]);
+    sidebarScrollTop();
+  };
+
+  const breadcrumbClicked = (e: React.MouseEvent<HTMLButtonElement>, i: number) => {
+    e.preventDefault();
+    setDrilldownHistory(_.take(drilldownHistory, i));
+  };
+
+  // Get the path in the swagger document to additional property details for drilldown.
+  // This can be
+  // - A reference to another top-level definition
+  // - Inline property declartions
+  // - Inline property declartions for array items
+  const getDrilldownPath = (definition: SwaggerDefinition, name: string): string[] => {
+    const ref = getRef(definition);
+    // Only allow drilldown if the reference has additional properties to explore.
+    if (ref && (_.get(allDefinitions, [ref, 'properties']) || _.get(allDefinitions, [ref, 'items']))) {
+      return [ref];
+    }
+
+    if (definition.properties) {
+      return [...currentPath, 'properties', name];
+    }
+
+    if (_.get(definition, 'items.properties')) {
+      return [...currentPath, 'properties', name, 'items'];
+    }
+
+    return null;
+  };
+
+  // Get the type to display for a property reference.
+  const getTypeForRef = (ref: string): string => _.get(allDefinitions, [ref, 'format']) || _.get(allDefinitions, [ref, 'type']);
+
+  return (
+    <ResourceSidebarWrapper label={kindObj.kind} linkLabel="View Schema" style={{height}}>
+      <ol className="breadcrumb">
+        {breadcrumbs.map((crumb, i) => {
+          const isLast = i === breadcrumbs.length - 1;
+          return <li key={i} className={classNames({'active': isLast})}>
+            {isLast
+              ? crumb
+              : <button type="button" className="btn btn-link btn-link--no-btn-default-values" onClick={e => breadcrumbClicked(e, i)}>{crumb}</button>}
+          </li>;
+        })}
+      </ol>
+      {description && <p className="co-break-word co-pre-line"><LinkifyExternal>{description}</LinkifyExternal></p>}
+      <ul className="co-resource-sidebar-list">
+        {_.map(currentDefinition.properties, (definition: SwaggerDefinition, name: string) => {
+          const path = getDrilldownPath(definition, name);
+          const definitionType = definition.type || getTypeForRef(getRef(definition));
+          return (
+            <li key={name} className="co-resource-sidebar-item">
+              <h5 className="co-resource-sidebar-item__header co-break-word">
+                <CamelCaseWrap value={name} />
+                &nbsp;
+                <small>
+                  <span className="co-break-word">{definitionType}</span>
+                  {required.has(name) && <React.Fragment> &ndash; required</React.Fragment>}
+                </small>
+              </h5>
+              {definition.description && <p className="co-break-word co-pre-line"><LinkifyExternal>{definition.description}</LinkifyExternal></p>}
+              {path && <button type="button" className="btn btn-link btn-link--no-btn-default-values" onClick={e => drilldown(e, name, definition.description, path)}>View Details</button>}
+            </li>
+          );
+        })}
+      </ul>
+    </ResourceSidebarWrapper>
+  );
+};
+
+type ExploreTypeSidebarProps = {
+  kindObj: K8sKind;
+  height: number;
+};

--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 
 import { resourceSidebars } from './resource-sidebars';
 
+export const sidebarScrollTop = () => {
+  document.getElementsByClassName('co-p-has-sidebar__sidebar')[0].scrollTop = 0;
+};
+
 export class ResourceSidebarWrapper extends React.Component {
   constructor(props) {
     super(props);
@@ -11,27 +15,27 @@ export class ResourceSidebarWrapper extends React.Component {
   }
 
   render() {
-    const {style, label} = this.props;
+    const {style, label, linkLabel, children} = this.props;
     const {height} = style;
     const {showSidebar} = this.state;
 
     if (!showSidebar) {
       return <div className="co-p-has-sidebar__sidebar--hidden hidden-sm">
         <button className="btn btn-link" onClick={() => this.setState({showSidebar: !showSidebar})}>
-          <span className="fa fa-fw fa-info-circle co-p-has-sidebar__sidebar-link-icon"></span>View samples
+          <i className="fa fa-fw fa-info-circle co-p-has-sidebar__sidebar-link-icon" aria-hidden="true" />{linkLabel}
         </button>
       </div>;
     }
 
     return <div className="co-p-has-sidebar__sidebar co-p-has-sidebar__sidebar--bordered hidden-sm" style={{height}}>
       <div className="co-m-pane__body">
-        <button type="button" className="close" aria-hidden="true" aria-label="Close" onClick={() => this.setState({showSidebar: !showSidebar})}>
-          <span className="pficon pficon-close"></span>
+        <button type="button" className="close" aria-label="Close" onClick={() => this.setState({showSidebar: !showSidebar})}>
+          <i className="pficon pficon-close" aria-hidden="true" />
         </button>
         <h1 className="co-p-has-sidebar__sidebar-heading co-resource-sidebar-header text-capitalize">
-          {label} samples
+          {label}
         </h1>
-        { this.props.children }
+        {children}
       </div>
     </div>;
   }
@@ -65,7 +69,7 @@ export const ResourceSidebar = props => {
   const {kind, label} = kindObj;
   const SidebarComponent = resourceSidebars.get(kind);
   if (SidebarComponent) {
-    return <ResourceSidebarWrapper label={label} style={{height}}>
+    return <ResourceSidebarWrapper label={`${label} Samples`} linkLabel="View Samples" style={{height}}>
       <SidebarComponent {...props} />
     </ResourceSidebarWrapper>;
   }

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -51,6 +51,7 @@ export * from './rbac';
 export * from './poll-hook';
 export * from './ref-width-hook';
 export * from './safe-fetch-hook';
+export * from './camel-case-wrap';
 
 /*
   Add the enum for NameValueEditorPair here and not in its namesake file because the editor should always be

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
+import Linkify from 'react-linkify';
 
 import { ALL_NAMESPACES_KEY } from '../../const';
 
@@ -60,6 +61,10 @@ export const getURLSearchParams = () => {
 };
 
 export const ExternalLink: React.FC<ExternalLinkProps> = ({href, text, additionalClassName=''}) => <a className={classNames('co-external-link', additionalClassName)} href={href} target="_blank" rel="noopener noreferrer">{text}</a>;
+
+// Open links in a new window and set noopener/noreferrer.
+export const LinkifyExternal: React.FC<{children: React.ReactNode}> = ({children}) => <Linkify properties={{target: '_blank', rel: 'noopener noreferrer'}}>{children}</Linkify>;
+LinkifyExternal.displayName = 'LinkifyExternal';
 
 type ExternalLinkProps = {
   href: string;

--- a/frontend/public/const.ts
+++ b/frontend/public/const.ts
@@ -28,7 +28,6 @@ export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
 export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-namespace-name`;
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
 export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/community-providers-warning`;
-export const SWAGGER_SESSION_STORAGE_KEY = `${STORAGE_PREFIX}/${window.SERVER_FLAGS.consoleVersion}/swagger-definitions`;
 
 // Bootstrap user for OpenShift 4.0 clusters
 export const KUBE_ADMIN_USERNAME = 'kube:admin';

--- a/frontend/public/module/k8s/autocomplete.ts
+++ b/frontend/public/module/k8s/autocomplete.ts
@@ -3,10 +3,9 @@ import { Map as ImmutableMap } from 'immutable';
 import * as _ from 'lodash-es';
 
 import { ServiceAccountModel, SecretModel, ServiceModel, ConfigMapModel, AlertmanagerModel } from '../../models';
-import { K8sKind, K8sResourceKind } from '../../module/k8s';
+import { getStoredSwagger, K8sKind, K8sResourceKind, SwaggerDefinitions } from '../../module/k8s';
 import { k8sListPartialMetadata } from '../../module/k8s/resource';
 import { getActiveNamespace } from '../../actions/ui';
-import { SWAGGER_SESSION_STORAGE_KEY } from '../../const';
 
 export type AceSnippet = {
   content: string;
@@ -138,7 +137,7 @@ export const getPropertyCompletions = async(state: Editor, session: IEditSession
 
   const kind = valueFor('kind');
   const apiVersion = valueFor('apiVersion');
-  const swaggerDefinitions: SwaggerDefinitions = JSON.parse(window.sessionStorage.getItem(SWAGGER_SESSION_STORAGE_KEY));
+  const swaggerDefinitions: SwaggerDefinitions = getStoredSwagger();
 
   if (kind.length && apiVersion.length && swaggerDefinitions) {
     const defKey = Object.keys(swaggerDefinitions).find(key => key.endsWith(`${apiVersion.replace('/', '.')}.${kind}`));
@@ -202,20 +201,6 @@ export const getCompletions: Completer['getCompletions'] = (editor, session, pos
   } else {
     getPropertyCompletions(editor, session, pos, prefix, callback);
   }
-};
-
-export type SwaggerDefinitions = {
-  [name: string]: {
-    description: string;
-    properties: {[prop: string]: {description: string, type: string}};
-  }
-};
-
-export type SwaggerAPISpec = {
-  swagger: string;
-  info: {title: string, version: string};
-  paths: {[path: string]: any};
-  definitions: SwaggerDefinitions;
 };
 
 // TODO: Remove once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25337 is merged

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -11,6 +11,7 @@ export * from './label-selector';
 export * from './cluster-operator';
 export * from './cluster-settings';
 export * from './template';
+export * from './swagger';
 
 export type OwnerReference = {
   name: string;

--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -1,0 +1,80 @@
+import * as _ from 'lodash-es';
+
+import { STORAGE_PREFIX } from '../../const';
+import { coFetchJSON } from '../../co-fetch';
+import { SwaggerDefinitions } from './';
+
+const SWAGGER_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/swagger-definitions`;
+const SWAGGER_TIMESTAMP_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/swagger-last-updated`;
+
+export const getStoredSwagger = (): SwaggerDefinitions => {
+  const json = window.localStorage.getItem(SWAGGER_LOCAL_STORAGE_KEY);
+  if (!json) {
+    return null;
+  }
+  try {
+    return JSON.parse(json);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Could not parse swagger JSON.', e);
+    return null;
+  }
+};
+
+const isSwaggerStale = () => {
+  // Avoid refreshing the entire document on cellular connections.
+  const connection = (navigator as any).connection || (navigator as any).mozConnection || (navigator as any).webkitConnection;
+  if (connection && connection.effectiveType === 'cellular') {
+    return false;
+  }
+  // Store the swagger definitions in localStorage, but refresh once per day.
+  // This document is large, so avoid reloading it too often.
+  const lastUpdated = Number(window.localStorage.getItem(SWAGGER_TIMESTAMP_LOCAL_STORAGE_KEY));
+  return !_.isFinite(lastUpdated) || lastUpdated < (Date.now() - (1000 * 60 * 60 * 24));
+};
+
+const storeSwagger = (swagger: SwaggerAPISpec) => {
+  // Only store definitions to reduce the document size.
+  const json = JSON.stringify(swagger.definitions || {});
+  window.localStorage.setItem(SWAGGER_LOCAL_STORAGE_KEY, json);
+  window.localStorage.setItem(SWAGGER_TIMESTAMP_LOCAL_STORAGE_KEY, `${Date.now()}`);
+};
+
+export const fetchSwagger = async(): Promise<SwaggerDefinitions> => {
+  try {
+    const storedSwagger = getStoredSwagger();
+    if (storedSwagger && !isSwaggerStale()) {
+      return storedSwagger;
+    }
+
+    const swagger: SwaggerAPISpec = await coFetchJSON('api/kubernetes/openapi/v2');
+    storeSwagger(swagger);
+    return swagger.definitions;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Could not get OpenAPI definitions', e);
+    return null;
+  }
+};
+
+export type SwaggerDefinition = {
+  description?: string;
+  type?: string;
+  $ref?: string;
+  items?: SwaggerDefinition;
+  required?: string[];
+  properties?: {
+    [prop: string]: SwaggerDefinition;
+  };
+};
+
+export type SwaggerDefinitions = {
+  [name: string]: SwaggerDefinition;
+};
+
+export type SwaggerAPISpec = {
+  swagger: string;
+  info: {title: string, version: string};
+  paths: {[path: string]: any};
+  definitions: SwaggerDefinitions;
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7878,6 +7878,13 @@ lie@~3.1.0:
   dependencies:
     immediate "~3.0.5"
 
+linkify-it@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.1.0.tgz#c4caf38a6cd7ac2212ef3c7d2bde30a91561f9db"
+  integrity sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==
+  dependencies:
+    uc.micro "^1.0.1"
+
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
@@ -10789,6 +10796,15 @@ react-lightweight-tooltip@1.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-lightweight-tooltip/-/react-lightweight-tooltip-1.0.0.tgz#1fb96831b88de21a4d73d02148aae3d8d0aea9bc"
 
+react-linkify@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/react-linkify/-/react-linkify-0.2.2.tgz#55b99b1cc7244446a0f9bdebbe13b2c30f789e65"
+  integrity sha512-0S8cvUNtEgfJpIGDPKklyrnrTffJ63WuJAc4KaYLBihl5TjgH5cHUmYD+AXLpsV+CVmfoo/56SUNfrZcY4zYMQ==
+  dependencies:
+    linkify-it "^2.0.3"
+    prop-types "^15.5.8"
+    tlds "^1.57.0"
+
 react-modal@3.x:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.3.2.tgz#b13da9490653a7c76bc0e9600323eb1079c620e7"
@@ -12989,6 +13005,11 @@ tippy.js@^3.2.0:
   dependencies:
     popper.js "^1.14.6"
 
+tlds@^1.57.0:
+  version "1.203.1"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.203.1.tgz#4dc9b02f53de3315bc98b80665e13de3edfc1dfc"
+  integrity sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw==
+
 tmp@0.0.30:
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz#72419d4a8be7d6ce75148fd8b324e593a711c2ed"
@@ -13281,6 +13302,11 @@ typescript@3.4.4:
 ua-parser-js@^0.7.18:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
+
+uc.micro@^1.0.1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@3.3.x:
   version "3.3.16"


### PR DESCRIPTION
This adds a type explorer sidebar to the YAML editor using the OpenAPI schema, similar to `oc explain`. You can drill down into different properties for more detail and go back using breadcrumbs.

cc @smarterclayton @alecmerdler @alimobrem @robszumski @beanh66 

![Screen Shot 2019-05-22 at 5 08 14 PM](https://user-images.githubusercontent.com/1167259/58209059-39f7a800-7cb4-11e9-9ebe-7ad772137ea2.png)
