### PR TITLE
Showing pvc expansion status under conditions and Redirection to Details Page

### DIFF
--- a/frontend/public/components/modals/expand-pvc-modal.jsx
+++ b/frontend/public/components/modals/expand-pvc-modal.jsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
-import { PromiseComponent, RequestSizeInput } from '../utils';
-import { k8sPatch } from '../../module/k8s/';
+import { PromiseComponent, RequestSizeInput, resourceObjPath, history } from '../utils';
+import { k8sPatch, referenceFor } from '../../module/k8s/';
 
 // Modal for expanding persistent volume claims
 class ExpandPVCModal extends PromiseComponent {
@@ -27,8 +27,11 @@ class ExpandPVCModal extends PromiseComponent {
     e.preventDefault();
     const { requestSizeUnit, requestSizeValue } =this.state;
     const patch = [{op: 'replace', path: '/spec/resources/requests', value: {storage: `${requestSizeValue}${requestSizeUnit}`}}];
-    this.handlePromise(k8sPatch(this.props.kind, this.props.resource, patch))
-      .then(this.props.close);
+    this.handlePromise(k8sPatch(this.props.kind, this.props.resource, patch)).then((resource) => {
+      this.props.close();
+      // redirected to the details page for persitent volume claim
+      history.push(resourceObjPath(resource, referenceFor(resource)));
+    });
   }
 
   render() {

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 
 import { connectToFlags } from '../reducers/features';
+import { Conditions } from './conditions';
 import { FLAGS } from '../const';
 import { ColHead, DetailsPage, List, ListHeader, ListPage } from './factory';
 import { Kebab, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary, Selector, StatusIcon } from './utils';
@@ -47,35 +48,42 @@ const Details_ = ({flags, obj: pvc}) => {
   const requestedStorage = _.get(pvc, 'spec.resources.requests.storage');
   const storage = _.get(pvc, 'status.capacity.storage');
   const accessModes = _.get(pvc, 'status.accessModes');
-  return <div className="co-m-pane__body">
-    <SectionHeading text="PersistentVolumeClaim Overview" />
-    <div className="row">
-      <div className="col-sm-6">
-        <ResourceSummary resource={pvc}>
-          <dt>Label Selector</dt>
-          <dd><Selector selector={labelSelector} kind="PersistentVolume" /></dd>
-        </ResourceSummary>
-      </div>
-      <div className="col-sm-6">
-        <dl>
-          <dt>Status</dt>
-          <dd><PVCStatus pvc={pvc} /></dd>
-          <dt>Storage Class</dt>
-          <dd>
-            {storageClassName ? <ResourceLink kind="StorageClass" name={storageClassName} /> : '-'}
-          </dd>
-          {volumeName && canListPV && <React.Fragment>
-            <dt>Persistent Volume</dt>
-            <dd><ResourceLink kind="PersistentVolume" name={volumeName} /></dd>
-          </React.Fragment>}
-          <dt>Requested</dt>
-          <dd>{requestedStorage || '-'}</dd>
-          {storage && <React.Fragment><dt>Size</dt><dd>{storage}</dd></React.Fragment>}
-          {!_.isEmpty(accessModes) && <React.Fragment><dt>Access Modes</dt><dd>{accessModes.join(', ')}</dd></React.Fragment>}
-        </dl>
+  const conditions = _.get(pvc, 'status.conditions');
+  return <React.Fragment>
+    <div className="co-m-pane__body">
+      <SectionHeading text="PersistentVolumeClaim Overview" />
+      <div className="row">
+        <div className="col-sm-6">
+          <ResourceSummary resource={pvc}>
+            <dt>Label Selector</dt>
+            <dd><Selector selector={labelSelector} kind="PersistentVolume" /></dd>
+          </ResourceSummary>
+        </div>
+        <div className="col-sm-6">
+          <dl>
+            <dt>Status</dt>
+            <dd><PVCStatus pvc={pvc} /></dd>
+            <dt>Storage Class</dt>
+            <dd>
+              {storageClassName ? <ResourceLink kind="StorageClass" name={storageClassName} /> : '-'}
+            </dd>
+            {volumeName && canListPV && <React.Fragment>
+              <dt>Persistent Volume</dt>
+              <dd><ResourceLink kind="PersistentVolume" name={volumeName} /></dd>
+            </React.Fragment>}
+            <dt>Requested</dt>
+            <dd>{requestedStorage || '-'}</dd>
+            {storage && <React.Fragment><dt>Size</dt><dd>{storage}</dd></React.Fragment>}
+            {!_.isEmpty(accessModes) && <React.Fragment><dt>Access Modes</dt><dd>{accessModes.join(', ')}</dd></React.Fragment>}
+          </dl>
+        </div>
       </div>
     </div>
-  </div>;
+    <div className="co-m-pane__body">
+      <SectionHeading text="Conditions" />
+      <Conditions conditions={conditions} />
+    </div>
+  </React.Fragment>;
 };
 
 const Details = connectToFlags(FLAGS.CAN_LIST_PV)(Details_);


### PR DESCRIPTION
This patch implements following: 
* Showing the PVC Expansion Status appropriately under **Conditions** as it expands 
   https://jira.coreos.com/browse/RHSTOR-13
* When PVC is expanded from the PVC List page nothing is reflected in UI hence redirecting it to overview page 
![Screenshot from 2019-05-20 09-35-31](https://user-images.githubusercontent.com/25664409/57996698-8ee5c380-7ae6-11e9-80d1-a0bd5c59da09.png)

![Screenshot from 2019-05-20 09-36-56 (1)](https://user-images.githubusercontent.com/25664409/57996647-3d3d3900-7ae6-11e9-9299-0748146812ea.png)


