### PR TITLE
Add dashboards page with health card

### DIFF
--- a/frontend/__tests__/actions/dashboards.spec.ts
+++ b/frontend/__tests__/actions/dashboards.spec.ts
@@ -1,0 +1,106 @@
+import { Map as ImmutableMap } from 'immutable';
+
+import { watchURL, ActionType, stopWatchURL, stopWatchPrometheusQuery, watchPrometheusQuery } from '../../public/actions/dashboards';
+import { RESULTS_TYPE, defaults } from '../../public/reducers/dashboards';
+
+const testStopWatch = (stopAction, type: RESULTS_TYPE, key: string) => {
+  expect(stopAction(key)).toEqual({
+    payload: {
+      key,
+      type,
+    },
+    type: ActionType.StopWatch,
+  });
+};
+
+const testStartWatch = (watchAction, type: RESULTS_TYPE, key: string) => {
+  const getState = jasmine.createSpy('getState').and.returnValues(
+    {dashboards: ImmutableMap(defaults)},
+    {dashboards: ImmutableMap(defaults).setIn([type, key, 'active'], 1)},
+  );
+  const dispatch = jasmine.createSpy('dispatch');
+
+  watchAction(key)(dispatch, getState);
+  expect(dispatch).toHaveBeenCalledTimes(2);
+  expect(dispatch.calls.all()[0].args[0]).toEqual({
+    payload: {
+      key,
+      type,
+    },
+    type: ActionType.ActivateWatch,
+  });
+  expect(dispatch.calls.all()[1].args[0]).toEqual({
+    payload: {
+      key,
+      type,
+      inFlight: true,
+    },
+    type: ActionType.UpdateWatchInFlight,
+  });
+};
+
+const testIncrementActiveWatch = (watchAction, type, key) => {
+  const getState = jasmine.createSpy('getState').and.returnValue(
+    {dashboards: ImmutableMap(defaults).setIn([type, key, 'active'], 1)},
+  );
+  const dispatch = jasmine.createSpy('dispatch');
+
+  watchAction(key)(dispatch, getState);
+  expect(dispatch).toHaveBeenCalledTimes(1);
+  expect(dispatch.calls.all()[0].args[0]).toEqual({
+    payload: {
+      key,
+      type,
+    },
+    type: ActionType.ActivateWatch,
+  });
+};
+
+describe('dashboards-actions', () => {
+  afterEach(function() {
+    window.SERVER_FLAGS.prometheusBaseURL = undefined;
+  });
+
+  it('watchURL starts watching URL', () =>
+    testStartWatch(watchURL, RESULTS_TYPE.URL, 'fooURL')
+  );
+
+  it('watchPrometheusQuery starts watching Query', () => {
+    window.SERVER_FLAGS.prometheusBaseURL = 'prometheusBaseURL';
+    testStartWatch(watchPrometheusQuery, RESULTS_TYPE.PROMETHEUS, 'fooQuery');
+  });
+
+  it('watchPrometheusQuery sets empty result if base url is not available', () => {
+    const getState = jasmine.createSpy('getState').and.returnValue(
+      {dashboards: ImmutableMap(defaults)}
+    );
+    const dispatch = jasmine.createSpy('dispatch');
+
+    watchPrometheusQuery('fooQuery')(dispatch, getState);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch.calls.all()[1].args[0]).toEqual({
+      payload: {
+        key: 'fooQuery',
+        type: RESULTS_TYPE.PROMETHEUS,
+        result: {},
+      },
+      type: ActionType.UpdateResult,
+    });
+  });
+
+  it('watchURL increments active count for active watch', () =>
+    testIncrementActiveWatch(watchURL, RESULTS_TYPE.URL, 'fooURL')
+  );
+
+  it('watchPrometheusQuery increments active count for active watch', () =>
+    testIncrementActiveWatch(watchPrometheusQuery, RESULTS_TYPE.PROMETHEUS, 'fooQuery')
+  );
+
+  it('stopWatchURL stops watching URL', () =>
+    testStopWatch(stopWatchURL, RESULTS_TYPE.URL, 'fooURL')
+  );
+
+  it('stopWatchPrometheusQuery stops watching Prometheus', () =>
+    testStopWatch(stopWatchPrometheusQuery, RESULTS_TYPE.PROMETHEUS, 'fooQuery')
+  );
+});

--- a/frontend/__tests__/reducers/dashboards.spec.ts
+++ b/frontend/__tests__/reducers/dashboards.spec.ts
@@ -1,0 +1,82 @@
+import * as Immutable from 'immutable';
+import { noop } from 'lodash-es';
+
+import { dashboardsReducer, defaults, RESULTS_TYPE } from '../../public/reducers/dashboards';
+import { activateWatch, updateWatchTimeout, updateWatchInFlight, stopWatch, updateResult } from '../../public/actions/dashboards';
+
+describe('dashboardsReducer', () => {
+  it('returns default values if state is uninitialized', () => {
+    const newState = dashboardsReducer(null, null);
+
+    expect(newState).toEqual(Immutable.Map(defaults));
+  });
+
+  it('activates new watch', () => {
+    const action = activateWatch(RESULTS_TYPE.URL, 'fooUrl');
+    const initialState = Immutable.Map(defaults);
+    const newState = dashboardsReducer(initialState, action);
+
+    expect(newState).toEqual(initialState.setIn([RESULTS_TYPE.URL, 'fooUrl', 'active'], 1));
+  });
+
+  it('increments watch active prop', () => {
+    const action = activateWatch(RESULTS_TYPE.URL, 'fooUrl');
+    const initialState = Immutable.Map(defaults).setIn([RESULTS_TYPE.URL, 'fooUrl', 'active'], 1);
+
+    const newState = dashboardsReducer(initialState, action);
+    expect(newState).toEqual(initialState.setIn([RESULTS_TYPE.URL, 'fooUrl', 'active'], 2));
+  });
+
+  it('updates watch timeout reference', () => {
+    const timeout = {ref: noop, unref: noop};
+    const action = updateWatchTimeout(RESULTS_TYPE.URL, 'fooUrl', timeout);
+    const initialState = Immutable.Map(defaults);
+    const stateWithTimeout = dashboardsReducer(initialState, action);
+
+    expect(stateWithTimeout).toEqual(initialState.setIn([RESULTS_TYPE.URL, 'fooUrl', 'timeout'], timeout));
+
+    const nextTimeout = {ref: noop, unref: noop};
+    const nextAction = updateWatchTimeout(RESULTS_TYPE.URL, 'fooUrl', nextTimeout);
+
+    const nextState = dashboardsReducer(stateWithTimeout, nextAction);
+
+    expect(nextState).toEqual(stateWithTimeout.setIn([RESULTS_TYPE.URL, 'fooUrl', 'timeout'], nextTimeout));
+  });
+
+  it('updates in flight resource', () => {
+    const action = updateWatchInFlight(RESULTS_TYPE.URL, 'fooUrl', true);
+    const initialState = Immutable.Map(defaults);
+    const stateInFlight = dashboardsReducer(initialState, action);
+
+    expect(stateInFlight).toEqual(initialState.setIn([RESULTS_TYPE.URL, 'fooUrl', 'inFlight'], true));
+
+    const nextAction = updateWatchInFlight(RESULTS_TYPE.URL, 'fooUrl', false);
+    const nextState = dashboardsReducer(stateInFlight, nextAction);
+
+    expect(nextState).toEqual(stateInFlight.setIn([RESULTS_TYPE.URL, 'fooUrl', 'inFlight'], false));
+  });
+
+  it('stops watch', () => {
+    const timeout = {ref: noop, unref: noop};
+    const action = stopWatch(RESULTS_TYPE.URL, 'fooUrl');
+    const initialState = Immutable.Map(defaults).merge({[RESULTS_TYPE.URL]: {fooUrl: {active: 2, timeout}}});
+    const newState = dashboardsReducer(initialState, action);
+
+    expect(newState).toEqual(initialState.setIn([RESULTS_TYPE.URL, 'fooUrl', 'active'], 1));
+
+    const nextState = dashboardsReducer(newState, action);
+    expect(nextState).toEqual(newState.setIn([RESULTS_TYPE.URL, 'fooUrl', 'active'], 0));
+  });
+
+  it('updates result', () => {
+    const action = updateResult(RESULTS_TYPE.URL, 'fooUrl', 'result');
+    const initialState = Immutable.Map(defaults);
+    const newState = dashboardsReducer(initialState, action);
+
+    expect(newState).toEqual(initialState.setIn([RESULTS_TYPE.URL, 'fooUrl', 'result'], 'result'));
+
+    const nextAction = updateResult(RESULTS_TYPE.URL, 'fooUrl', 'newResult');
+    const nextState = dashboardsReducer(newState, nextAction);
+    expect(nextState).toEqual(newState.setIn([RESULTS_TYPE.URL, 'fooUrl', 'result'], 'newResult'));
+  });
+});

--- a/frontend/packages/console-demo-plugin/src/dashboards/health.ts
+++ b/frontend/packages/console-demo-plugin/src/dashboards/health.ts
@@ -1,0 +1,12 @@
+import { HealthState } from '@console/internal/components/dashboard/health-card/states';
+import { SubsystemHealth } from '@console/internal/components/dashboards-page/overview-dashboard/health-card';
+
+export const getFooHealthState = (): SubsystemHealth => ({
+  message: 'Foo is healthy',
+  state: HealthState.OK,
+});
+
+export const getBarHealthState = (): SubsystemHealth => ({
+  message: 'Bar is in an error state',
+  state: HealthState.ERROR,
+});

--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -13,6 +13,8 @@ import {
   Perspective,
   YAMLTemplate,
   RoutePage,
+  DashboardsOverviewHealthPrometheusSubsystem,
+  DashboardsOverviewHealthURLSubsystem,
 } from '@console/plugin-sdk';
 
 // TODO(vojtech): internal code needed by plugins should be moved to console-shared package
@@ -21,6 +23,7 @@ import { FLAGS } from '@console/internal/const';
 
 import * as models from './models';
 import { yamlTemplates } from './yaml-templates';
+import { getFooHealthState, getBarHealthState } from './dashboards/health';
 
 type ConsumedExtensions =
   | ModelDefinition
@@ -32,7 +35,9 @@ type ConsumedExtensions =
   | ResourceDetailsPage
   | Perspective
   | YAMLTemplate
-  | RoutePage;
+  | RoutePage
+  | DashboardsOverviewHealthPrometheusSubsystem
+  | DashboardsOverviewHealthURLSubsystem<any>;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -126,6 +131,22 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       model: models.FooBarModel,
       template: yamlTemplates.getIn([models.FooBarModel, 'default']),
+    },
+  },
+  {
+    type: 'Dashboards/Overview/Health/URL',
+    properties: {
+      title: 'Foo system',
+      url: 'fooUrl',
+      healthHandler: getFooHealthState,
+    },
+  },
+  {
+    type: 'Dashboards/Overview/Health/Prometheus',
+    properties: {
+      title: 'Bar system',
+      query: 'barQuery',
+      healthHandler: getBarHealthState,
     },
   },
   {

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -11,6 +11,7 @@ import {
   isPerspective,
   isYAMLTemplate,
   isRoutePage,
+  isDashboardsOverviewHealthSubsystem,
 } from './typings';
 
 /**
@@ -53,5 +54,9 @@ export class ExtensionRegistry {
 
   public getYAMLTemplates() {
     return this.extensions.filter(isYAMLTemplate);
+  }
+
+  public getDashboardsOverviewHealthSubsystems() {
+    return this.extensions.filter(isDashboardsOverviewHealthSubsystem);
   }
 }

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -1,0 +1,62 @@
+import { SubsystemHealth } from '@console/internal/components/dashboards-page/overview-dashboard/health-card';
+import { Extension } from './extension';
+
+namespace ExtensionProperties {
+  interface DashboardsOverviewHealthSubsystem<R> {
+    /** The subsystem's display name */
+    title: string;
+
+    /** Resolve the subsystem's health */
+    healthHandler: (response: R) => SubsystemHealth;
+  }
+
+  export interface DashboardsOverviewHealthURLSubsystem<R>
+    extends DashboardsOverviewHealthSubsystem<R> {
+    /**
+     * The URL to fetch data from. It will be prefixed with base k8s URL.
+     * For example: `healthz` will result in `<k8sBasePath>/healthz`
+     */
+    url: string;
+
+    /**
+     * Custom function to fetch data from the URL.
+     * If none is specified, default one (`coFetchJson`) will be used.
+     * Response is then parsed by `healthHandler`.
+     */
+    fetch?: (url: string) => Promise<R>;
+  }
+
+  export interface DashboardsOverviewHealthPrometheusSubsystem
+    extends DashboardsOverviewHealthSubsystem<any> {
+    /** The Prometheus query */
+    query: string;
+  }
+}
+
+export interface DashboardsOverviewHealthURLSubsystem<R>
+  extends Extension<ExtensionProperties.DashboardsOverviewHealthURLSubsystem<R>> {
+  type: 'Dashboards/Overview/Health/URL';
+}
+
+export const isDashboardsOverviewHealthURLSubsystem = (
+  e: Extension<any>,
+): e is DashboardsOverviewHealthURLSubsystem<any> => e.type === 'Dashboards/Overview/Health/URL';
+
+export interface DashboardsOverviewHealthPrometheusSubsystem
+  extends Extension<ExtensionProperties.DashboardsOverviewHealthPrometheusSubsystem> {
+  type: 'Dashboards/Overview/Health/Prometheus';
+}
+
+export const isDashboardsOverviewHealthPrometheusSubsystem = (
+  e: Extension<any>,
+): e is DashboardsOverviewHealthPrometheusSubsystem =>
+  e.type === 'Dashboards/Overview/Health/Prometheus';
+
+export type DashboardsOverviewHealthSubsystem =
+  | DashboardsOverviewHealthURLSubsystem<any>
+  | DashboardsOverviewHealthPrometheusSubsystem;
+
+export const isDashboardsOverviewHealthSubsystem = (
+  e: Extension<any>,
+): e is DashboardsOverviewHealthSubsystem =>
+  isDashboardsOverviewHealthURLSubsystem(e) || isDashboardsOverviewHealthPrometheusSubsystem(e);

--- a/frontend/packages/console-plugin-sdk/src/typings/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/index.ts
@@ -2,6 +2,7 @@ export * from './extension';
 
 // TODO(vojtech): internal code needed by plugin SDK should be moved to console-shared package
 
+export * from './dashboards';
 export * from './features';
 export * from './models';
 export * from './nav';

--- a/frontend/public/actions/dashboards.ts
+++ b/frontend/public/actions/dashboards.ts
@@ -1,0 +1,89 @@
+import { ActionType as Action, action } from 'typesafe-actions';
+import { Dispatch } from 'react-redux';
+
+import { coFetchJSON } from '../co-fetch';
+import { k8sBasePath } from '../module/k8s/k8s';
+import { RESULTS_TYPE, isWatchActive } from '../reducers/dashboards';
+import { RootState } from '../redux';
+
+export enum ActionType {
+  StopWatch = 'stopWatch',
+  UpdateResult = 'updateResult',
+  ActivateWatch = 'activateWatch',
+  UpdateWatchTimeout = 'updateWatchTimeout',
+  UpdateWatchInFlight = 'updateWatchInFlight',
+}
+
+const REFRESH_TIMEOUT = 5000;
+
+export const stopWatch = (type: RESULTS_TYPE, key: string) => action(ActionType.StopWatch, { type, key });
+export const updateResult = (type: RESULTS_TYPE, key: string, result) => action(ActionType.UpdateResult, { type, key, result });
+export const activateWatch = (type: RESULTS_TYPE, key: string) => action(ActionType.ActivateWatch, { type, key });
+export const updateWatchTimeout = (type: RESULTS_TYPE, key: string, timeout: NodeJS.Timer) => action(ActionType.UpdateWatchTimeout, { type, key, timeout});
+export const updateWatchInFlight = (type: RESULTS_TYPE, key: string, inFlight: boolean) => action(ActionType.UpdateWatchInFlight, { type, key, inFlight });
+
+const dashboardsActions = {
+  stopWatch,
+  updateResult,
+  activateWatch,
+  updateWatchTimeout,
+  updateWatchInFlight,
+};
+
+const fetchPeriodically: FetchPeriodically = async(dispatch, type, key, url, getState, fetch) => {
+  if (!isWatchActive(getState().dashboards, type, key)) {
+    return;
+  }
+  let result;
+  try {
+    dispatch(updateWatchInFlight(type, key, true));
+    result = await fetch(url);
+  } catch (error) {
+    result = error;
+  } finally {
+    dispatch(updateWatchInFlight(type, key, false));
+    dispatch(updateResult(type, key, result));
+    const timeout = setTimeout(() => fetchPeriodically(dispatch, type, key, url, getState, fetch), REFRESH_TIMEOUT);
+    dispatch(updateWatchTimeout(type, key, timeout));
+  }
+};
+
+export const watchPrometheusQuery: WatchPrometheusQueryAction = query => (dispatch, getState) => {
+  const isActive = isWatchActive(getState().dashboards, RESULTS_TYPE.PROMETHEUS, query);
+  dispatch(activateWatch(RESULTS_TYPE.PROMETHEUS, query));
+  if (!isActive) {
+    const prometheusBaseURL = window.SERVER_FLAGS.prometheusBaseURL;
+    if (!prometheusBaseURL) {
+      dispatch(updateResult(RESULTS_TYPE.PROMETHEUS, query, {}));
+    } else {
+      const url = `${prometheusBaseURL}/api/v1/query?query=${encodeURIComponent(query)}`;
+      fetchPeriodically(dispatch, RESULTS_TYPE.PROMETHEUS, query, url, getState, coFetchJSON);
+    }
+  }
+};
+
+export const watchURL: WatchURLAction = (url, fetch = coFetchJSON) => (dispatch, getState) => {
+  const isActive = isWatchActive(getState().dashboards, RESULTS_TYPE.URL, url);
+  dispatch(activateWatch(RESULTS_TYPE.URL, url));
+  if (!isActive) {
+    const k8sURL = `${k8sBasePath}/${url}`;
+    fetchPeriodically(dispatch, RESULTS_TYPE.URL, url, k8sURL, getState, fetch);
+  }
+};
+
+export const stopWatchPrometheusQuery = (query: string) => stopWatch(RESULTS_TYPE.PROMETHEUS, query);
+export const stopWatchURL = (url: string) => stopWatch(RESULTS_TYPE.URL, url);
+
+type ThunkAction = (dispatch: Dispatch, getState: () => RootState) => void;
+
+export type WatchURLAction = (url: string, fetch?: Fetch) => ThunkAction;
+export type WatchPrometheusQueryAction = (query: string) => ThunkAction;
+export type StopWatchURLAction = (url: string) => void;
+export type StopWatchPrometheusAction = (query: string) => void;
+
+export type Fetch = (url: string) => Promise<any>;
+
+type FetchPeriodically =
+  (dispatch: Dispatch, type: RESULTS_TYPE, key: string, url: string, getState: () => RootState, fetch: Fetch) => void;
+
+export type DashboardsAction = Action<typeof dashboardsActions>;

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -98,6 +98,7 @@ const AppContents = withRouter(React.memo(() => (
 
           <Route path={['/all-namespaces', '/ns/:ns']} component={RedirectComponent} />
 
+          <LazyRoute path="/dashboards" exact loader={() => import('./dashboards-page/dashboards' /* webpackChunkName: "dashboards" */).then(m => m.DashboardsPage)} />
           <LazyRoute path="/cluster-status" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
           <LazyRoute path="/overview/all-namespaces" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
           <LazyRoute path="/overview/ns/:ns" exact loader={() => import('./overview' /* webpackChunkName: "overview" */).then(m => m.OverviewPage)} />

--- a/frontend/public/components/dashboard/dashboard-card/card-body.tsx
+++ b/frontend/public/components/dashboard/dashboard-card/card-body.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { CardBody, CardBodyProps } from '@patternfly/react-core';
+
+import { LoadingInline } from '../../utils';
+
+export const DashboardCardBody: React.FC<DashboardCardBodyProps> = React.memo(({ isLoading, classname, children, ...props }) => (
+  <CardBody className={classNames('co-dashboard-card__body', classname)} {...props}>
+    {isLoading ? <LoadingInline /> : children}
+  </CardBody>
+));
+
+type DashboardCardBodyProps = CardBodyProps & {
+  classname?: string;
+  children: React.ReactNode;
+  isLoading?: boolean;
+};

--- a/frontend/public/components/dashboard/dashboard-card/card-header.tsx
+++ b/frontend/public/components/dashboard/dashboard-card/card-header.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { CardHeader, CardHeaderProps } from '@patternfly/react-core';
+
+export const DashboardCardHeader: React.FC<DashboardCardHeaderProps> = React.memo(({ className, children, ...props }) => (
+  <CardHeader {...props} className={classNames('co-dashboard-card__header', className)}>
+    {children}
+  </CardHeader>
+));
+
+type DashboardCardHeaderProps = CardHeaderProps & {
+  className?: string;
+  children: React.ReactNode;
+};

--- a/frontend/public/components/dashboard/dashboard-card/card-help.tsx
+++ b/frontend/public/components/dashboard/dashboard-card/card-help.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { Button, Icon, OverlayTrigger, Popover } from 'patternfly-react';
+
+export const DashboardCardHelp: React.FC<DashboardCardTitleHelpProps> = React.memo(({ children }) => {
+  if (React.Children.count(children) === 0) {
+    return null;
+  }
+  const overlay = <Popover id="popover">{children}</Popover>;
+  return (
+    <OverlayTrigger overlay={overlay} placement="top" trigger={['click']} rootClose>
+      <Button bsStyle="link">
+        <Icon
+          type="fa"
+          name="info-circle"
+          className="co-dashboard-header__icon"
+        />
+      </Button>
+    </OverlayTrigger>
+  );
+});
+
+type DashboardCardTitleHelpProps = {
+  children: React.ReactNode;
+}

--- a/frontend/public/components/dashboard/dashboard-card/card-see-all.tsx
+++ b/frontend/public/components/dashboard/dashboard-card/card-see-all.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Button, OverlayTrigger, Popover } from 'patternfly-react';
+
+const SEE_ALL = 'See all';
+
+export const DashboardCardSeeAll: React.FC<DashboardCardTitleSeeAllProps> = React.memo(({ title, children }) => {
+  if (React.Children.count(children) === 0) {
+    return null;
+  }
+  const overlay = (
+    <Popover id="popover" title={title}>
+      {children}
+    </Popover>
+  );
+  return (
+    <OverlayTrigger overlay={overlay} placement="right" trigger={['click']} rootClose>
+      <Button bsStyle="link">{SEE_ALL}</Button>
+    </OverlayTrigger>
+  );
+});
+
+type DashboardCardTitleSeeAllProps = {
+  children?: React.ReactNode;
+  title: string;
+}

--- a/frontend/public/components/dashboard/dashboard-card/card-title.tsx
+++ b/frontend/public/components/dashboard/dashboard-card/card-title.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+export const DashboardCardTitle: React.FC<DashboardCardTitleProps> = React.memo(({ className, children }) => (
+  <h2 className={classNames('co-dashboard-card__title', className)}>
+    {children}
+  </h2>
+));
+
+type DashboardCardTitleProps = {
+  className?: string;
+  children: React.ReactNode;
+}

--- a/frontend/public/components/dashboard/dashboard-card/card.scss
+++ b/frontend/public/components/dashboard/dashboard-card/card.scss
@@ -1,0 +1,24 @@
+.co-dashboard-card {
+  margin: 0;
+}
+
+.co-dashboard-card__body {
+  margin-top: 1.5em;
+}
+
+.co-dashboard-card__header {
+  align-items: center;
+  border-bottom: 1px solid $pf-color-black-300;
+  display: flex;
+  justify-content: space-between;
+}
+
+.co-dashboard-card__title {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.co-dashboard-header__icon {
+  font-size: 1.125rem;
+  margin-right: -10px;
+}

--- a/frontend/public/components/dashboard/dashboard-card/card.tsx
+++ b/frontend/public/components/dashboard/dashboard-card/card.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { Card, CardProps } from '@patternfly/react-core';
+
+export const DashboardCard: React.FC<DashboardCardProps> = React.memo(({ className, children, ...props }) => (
+  <Card {...props} className={classNames('co-dashboard-card', className)}>
+    {children}
+  </Card>
+));
+
+type DashboardCardProps = CardProps & {
+  className?: string;
+  children: React.ReactNode;
+};

--- a/frontend/public/components/dashboard/dashboard-card/index.ts
+++ b/frontend/public/components/dashboard/dashboard-card/index.ts
@@ -1,0 +1,6 @@
+export * from './card';
+export * from './card-body';
+export * from './card-header';
+export * from './card-title';
+export * from './card-help';
+export * from './card-see-all';

--- a/frontend/public/components/dashboard/dashboard.scss
+++ b/frontend/public/components/dashboard/dashboard.scss
@@ -1,0 +1,8 @@
+.co-dashboard-body {
+  background-color: $pf-color-black-200;
+  padding: 1rem;
+}
+
+.co-dashboard-grid {
+  grid-gap: 1rem;
+}

--- a/frontend/public/components/dashboard/dashboard.tsx
+++ b/frontend/public/components/dashboard/dashboard.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+export const Dashboard: React.FC<DashboardProps> = ({ className, children }) => (
+  <div className={classNames('co-dashboard-body', className)}>{children}</div>
+);
+
+type DashboardProps = {
+  className?: string;
+  children: React.ReactNode;
+};

--- a/frontend/public/components/dashboard/grid.tsx
+++ b/frontend/public/components/dashboard/grid.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { Grid, GridItem } from '@patternfly/react-core';
+
+import { useRefWidth } from '../utils';
+
+export const MEDIA_QUERY_LG = 992;
+
+export const DashboardGrid: React.FC<DashboardGridProps> = ({ mainCards, leftCards, rightCards }) => {
+  const [containerRef, width] = useRefWidth();
+  const grid = width <= MEDIA_QUERY_LG ?
+    (
+      <Grid className="co-dashboard-grid">
+        <GridItem lg={12} md={12} sm={12}>
+          {mainCards}
+        </GridItem>
+        <GridItem key="left" lg={12} md={12} sm={12}>
+          {leftCards}
+        </GridItem>
+        <GridItem key="right" lg={12} md={12} sm={12}>
+          {rightCards}
+        </GridItem>
+      </Grid>
+    ) : (
+      <Grid className="co-dashboard-grid">
+        <GridItem key="left" lg={3} md={3} sm={3}>
+          {leftCards}
+        </GridItem>
+        <GridItem lg={6} md={6} sm={6}>
+          {mainCards}
+        </GridItem>
+        <GridItem key="right" lg={3} md={3} sm={3}>
+          {rightCards}
+        </GridItem>
+      </Grid>
+    );
+
+  return <div ref={containerRef}>{grid}</div>;
+};
+
+type DashboardGridProps = {
+  mainCards: React.ReactNode,
+  leftCards?: React.ReactNode,
+  rightCards?: React.ReactNode,
+};

--- a/frontend/public/components/dashboard/health-card/health-body.tsx
+++ b/frontend/public/components/dashboard/health-card/health-body.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+export const HealthBody: React.FC<HealthBodyProps> = React.memo(({ children, className }) => (
+  <div className={classNames('co-health-card__body', className)}>{children}</div>
+));
+
+type HealthBodyProps = {
+  className?: string;
+  children: React.ReactNode;
+};

--- a/frontend/public/components/dashboard/health-card/health-card.scss
+++ b/frontend/public/components/dashboard/health-card/health-card.scss
@@ -1,0 +1,47 @@
+.co-health-card__body {
+  min-height: 2.3em;
+}
+
+.co-health-card__icon {
+  font-size: 1.5rem;
+}
+
+.co-health-card__icon--error {
+  color: $pf-color-red-100;
+}
+
+.co-health-card__icon--ok {
+  color: $pf-color-light-green-400;
+}
+
+.co-health-card__icon--warning {
+  color: $pf-color-gold-400;
+}
+
+.co-health-card__item {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.co-health-card__separator {
+  border-bottom: 1px solid $pf-color-black-200;
+}
+
+.co-health-card__subsystem-item {
+  padding-top: 5px;
+}
+
+.co-health-card__subtitle {
+  color: $pf-color-black-500;
+  font-size: 0.7rem;
+}
+
+.co-health-card__text {
+  font-size: 0.875rem;
+  margin-left: 1rem;
+}
+
+.co-health-card__title {
+  padding-left: 0.6rem;
+}

--- a/frontend/public/components/dashboard/health-card/health-item.tsx
+++ b/frontend/public/components/dashboard/health-card/health-item.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Icon } from 'patternfly-react';
+import classNames from 'classnames';
+
+import { HealthState } from './states';
+import { LoadingInline } from '../../utils';
+
+const HealthItemIcon: React.FC<HealthItemIconProps> = ({ state }) => {
+  let icon;
+  let iconClassModifier;
+  switch (state) {
+    case HealthState.OK:
+      icon = 'check-circle';
+      iconClassModifier = 'ok';
+      break;
+    case HealthState.ERROR:
+      icon = 'exclamation-circle';
+      iconClassModifier = 'error';
+      break;
+    case HealthState.WARNING:
+    default:
+      icon = 'exclamation-triangle';
+      iconClassModifier = 'warning';
+  }
+  return (
+    <div className={`co-health-card__icon co-health-card__icon--${iconClassModifier}`}>
+      <Icon type="fa" name={icon} />
+    </div>
+  );
+};
+
+export const HealthItem: React.FC<HealthItemProps> = React.memo(({ className, state, message, details }) => (
+  <div className={classNames('co-health-card__item', className)}>
+    {state === HealthState.LOADING ? <LoadingInline /> : <HealthItemIcon state={state} />}
+    <div>
+      {message && <span className="co-health-card__text">{message}</span>}
+      {details && <div className="co-health-card__text co-health-card__subtitle">{details}</div>}
+    </div>
+  </div>
+));
+
+type HealthItemProps = {
+  className?: string;
+  message?: string;
+  details?: string;
+  state?: HealthState;
+};
+
+type HealthItemIconProps = {
+  state?: HealthState;
+}

--- a/frontend/public/components/dashboard/health-card/index.ts
+++ b/frontend/public/components/dashboard/health-card/index.ts
@@ -1,0 +1,2 @@
+export * from './health-body';
+export * from './health-item';

--- a/frontend/public/components/dashboard/health-card/states.ts
+++ b/frontend/public/components/dashboard/health-card/states.ts
@@ -1,0 +1,6 @@
+export enum HealthState {
+  OK = 'OK',
+  ERROR = 'ERROR',
+  WARNING = 'WARNING',
+  LOADING = 'LOADING',
+}

--- a/frontend/public/components/dashboard/index.ts
+++ b/frontend/public/components/dashboard/index.ts
@@ -1,0 +1,2 @@
+export * from './dashboard';
+export * from './grid';

--- a/frontend/public/components/dashboards-page/dashboards.tsx
+++ b/frontend/public/components/dashboards-page/dashboards.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+
+import { OverviewDashboard } from './overview-dashboard/overview-dashboard';
+import { HorizontalNav, PageHeading } from '../utils';
+
+const tabs = [
+  {
+    href: '',
+    name: 'Overview',
+    component: OverviewDashboard,
+  },
+];
+
+export const DashboardsPage: React.FC<RouteComponentProps> = ({ match }) => (
+  <React.Fragment>
+    <PageHeading title="Dashboards" detail={true} />
+    <HorizontalNav match={match} pages={tabs} noStatusBox />
+  </React.Fragment>
+);

--- a/frontend/public/components/dashboards-page/overview-dashboard/health-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/health-card.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+
+import * as plugins from '../../../plugins';
+import {
+  DashboardCard,
+  DashboardCardBody,
+  DashboardCardHeader,
+  DashboardCardTitle,
+  DashboardCardSeeAll,
+} from '../../dashboard/dashboard-card';
+import { HealthBody, HealthItem } from '../../dashboard/health-card';
+import { HealthState } from '../../dashboard/health-card/states';
+import { coFetch } from '../../../co-fetch';
+import { featureReducerName, flagPending } from '../../../reducers/features';
+import { FLAGS } from '../../../const';
+import { withDashboardResources, DashboardItemProps } from '../with-dashboard-resources';
+import { RootState } from '../../../redux';
+import { getBrandingDetails } from '../../masthead';
+
+export const HEALTHY = 'is healthy';
+export const ERROR = 'is in an error state';
+
+const getClusterHealth = (subsystemStates: Array<SubsystemHealth>): ClusterHealth => {
+  let healthState: ClusterHealth = { state: HealthState.OK, message: 'Cluster is healthy' };
+  const subsystemBySeverity = {
+    error: subsystemStates.filter(subsystem => subsystem.state === HealthState.ERROR),
+    warning: subsystemStates.filter(subsystem => subsystem.state === HealthState.WARNING),
+    loading: subsystemStates.filter(subsystem => subsystem.state === HealthState.LOADING),
+  };
+
+  if (subsystemBySeverity.loading.length > 0) {
+    healthState = { state: HealthState.LOADING, message: null };
+  } else if (subsystemBySeverity.error.length > 0) {
+    healthState =
+      subsystemBySeverity.error.length === 1
+        ? subsystemBySeverity.error[0]
+        : { state: HealthState.ERROR, message: 'Multiple errors', details: 'Cluster health is degraded' };
+  } else if (subsystemBySeverity.warning.length > 0) {
+    healthState =
+      subsystemBySeverity.warning.length === 1
+        ? subsystemBySeverity.warning[0]
+        : { state: HealthState.WARNING, message: 'Multiple warnings', details: 'Cluster health is degraded' };
+  }
+
+  return healthState;
+};
+
+const getName = (openShiftFlag: boolean): string => openShiftFlag ? getBrandingDetails().productName : 'Kubernetes';
+
+const getK8sHealthState = (openShiftFlag: boolean, k8sHealth: any): SubsystemHealth => {
+  if (!k8sHealth) {
+    return { state: HealthState.LOADING };
+  }
+  return k8sHealth === 'ok'
+    ? { message: `${getName(openShiftFlag)} ${HEALTHY}`, state: HealthState.OK }
+    : { message: `${getName(openShiftFlag)} ${ERROR}`, state: HealthState.ERROR };
+};
+
+const mapStateToProps = (state: RootState) => ({
+  openShiftFlag: state[featureReducerName].get(FLAGS.OPENSHIFT),
+});
+
+const fetchK8sHealth = async(url) => {
+  const response = await coFetch(url);
+  return response.text();
+};
+
+const _HealthCard: React.FC<HealthProps> = ({
+  watchURL,
+  stopWatchURL,
+  watchPrometheus,
+  stopWatchPrometheusQuery,
+  urlResults,
+  prometheusResults,
+  openShiftFlag,
+}) => {
+  React.useEffect(() => {
+    const subsystems = plugins.registry.getDashboardsOverviewHealthSubsystems();
+    watchURL('healthz', fetchK8sHealth);
+
+    subsystems.filter(plugins.isDashboardsOverviewHealthURLSubsystem).forEach(subsystem => {
+      const { url, fetch } = subsystem.properties;
+      watchURL(url, fetch);
+    });
+    subsystems.filter(plugins.isDashboardsOverviewHealthPrometheusSubsystem).forEach(subsystem => {
+      const { query } = subsystem.properties;
+      watchPrometheus(query);
+    });
+    return () => {
+      stopWatchURL('healthz');
+
+      subsystems.filter(plugins.isDashboardsOverviewHealthURLSubsystem).forEach(subsystem =>
+        stopWatchURL(subsystem.properties.url)
+      );
+      subsystems.filter(plugins.isDashboardsOverviewHealthPrometheusSubsystem).forEach(subsystem =>
+        stopWatchPrometheusQuery(subsystem.properties.query)
+      );
+    };
+  }, [watchURL, stopWatchURL, watchPrometheus, stopWatchPrometheusQuery]);
+
+  const subsystems = plugins.registry.getDashboardsOverviewHealthSubsystems();
+  const k8sHealth = urlResults.getIn(['healthz', 'result']);
+  const k8sHealthState = getK8sHealthState(openShiftFlag, k8sHealth);
+
+  const subsystemsHealths = subsystems.map(subsystem => {
+    let result;
+    if (plugins.isDashboardsOverviewHealthPrometheusSubsystem(subsystem)) {
+      result = prometheusResults.getIn([subsystem.properties.query, 'result']);
+    } else {
+      result = urlResults.getIn([subsystem.properties.url, 'result']);
+    }
+    return subsystem.properties.healthHandler(result);
+  });
+
+  const healthState = getClusterHealth([k8sHealthState, ...subsystemsHealths]);
+
+  return (
+    <DashboardCard>
+      <DashboardCardHeader>
+        <DashboardCardTitle>Cluster Health</DashboardCardTitle>
+        {subsystems.length > 0 && !flagPending(openShiftFlag) && (
+          <DashboardCardSeeAll title="Subsystem health">
+            <HealthItem
+              message={getName(openShiftFlag)}
+              details={k8sHealthState.message}
+              state={k8sHealthState.state}
+            />
+            {subsystemsHealths.map((subsystem, index) => (
+              <div key={index}>
+                <div className="co-health-card__separator" />
+                <HealthItem
+                  className="co-health-card__subsystem-item"
+                  message={subsystems[index].properties.title}
+                  details={subsystem.message}
+                  state={subsystem.state}
+                />
+              </div>
+            ))}
+          </DashboardCardSeeAll>
+        )}
+      </DashboardCardHeader>
+      <DashboardCardBody isLoading={flagPending(openShiftFlag)}>
+        <HealthBody>
+          <HealthItem
+            state={healthState.state}
+            message={healthState.message}
+            details={healthState.details}
+          />
+        </HealthBody>
+      </DashboardCardBody>
+    </DashboardCard>
+  );
+};
+
+export const HealthCard = withDashboardResources(connect(mapStateToProps)(_HealthCard));
+
+type ClusterHealth = {
+  state: HealthState;
+  message?: string;
+  details?: string,
+};
+
+export type SubsystemHealth = {
+  message?: string;
+  state: HealthState;
+};
+
+type HealthProps = DashboardItemProps & {
+  openShiftFlag: boolean;
+};

--- a/frontend/public/components/dashboards-page/overview-dashboard/overview-dashboard.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/overview-dashboard.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+import { Dashboard, DashboardGrid } from '../../dashboard';
+import { HealthCard } from './health-card';
+
+export const OverviewDashboard: React.FC<{}> = () => {
+  const mainCards = [
+    <HealthCard key="health" />,
+  ];
+
+  return (
+    <Dashboard>
+      <DashboardGrid mainCards={mainCards} />
+    </Dashboard>
+  );
+};

--- a/frontend/public/components/dashboards-page/with-dashboard-resources.tsx
+++ b/frontend/public/components/dashboards-page/with-dashboard-resources.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { Map as ImmutableMap } from 'immutable';
+
+import { RESULTS_TYPE } from '../../reducers/dashboards';
+import {
+  watchURL,
+  stopWatchURL,
+  watchPrometheusQuery,
+  stopWatchPrometheusQuery,
+  Fetch,
+  WatchURLAction,
+  WatchPrometheusQueryAction,
+  StopWatchURLAction,
+  StopWatchPrometheusAction,
+} from '../../actions/dashboards';
+import { RootState } from '../../redux';
+
+const mapDispatchToProps = dispatch => ({
+  watchURL: (url, fetch): WatchURL => dispatch(watchURL(url, fetch)),
+  stopWatchURL: (url): StopWatchURL => dispatch(stopWatchURL(url)),
+  watchPrometheusQuery: (query): WatchPrometheus => dispatch(watchPrometheusQuery(query)),
+  stopWatchPrometheusQuery: (query): StopWatchPrometheus => dispatch(stopWatchPrometheusQuery(query)),
+});
+
+const mapStateToProps = (state: RootState) => ({
+  [RESULTS_TYPE.URL]: state.dashboards.get(RESULTS_TYPE.URL),
+  [RESULTS_TYPE.PROMETHEUS]: state.dashboards.get(RESULTS_TYPE.PROMETHEUS),
+});
+
+const WithDashboardResources = (WrappedComponent: React.ComponentType<DashboardItemProps>) =>
+  class WithDashboardResources_ extends React.Component<WithDashboardResourcesProps> {
+    private urls: Array<string> = [];
+    private queries: Array<string> = [];
+
+    shouldComponentUpdate(nextProps: WithDashboardResourcesProps) {
+      const urlResultChanged = this.urls.some(urlKey =>
+        this.props[RESULTS_TYPE.URL].getIn([urlKey, 'result']) !== nextProps[RESULTS_TYPE.URL].getIn([urlKey, 'result'])
+      );
+      const queryResultChanged = this.queries.some(query =>
+        this.props[RESULTS_TYPE.PROMETHEUS].getIn([query, 'result']) !== nextProps[RESULTS_TYPE.PROMETHEUS].getIn([query, 'result'])
+      );
+      return urlResultChanged || queryResultChanged;
+    }
+
+    watchURL: WatchURL = (url, fetch) => {
+      this.urls.push(url);
+      this.props.watchURL(url, fetch);
+    }
+
+    watchPrometheus: WatchPrometheus = query => {
+      this.queries.push(query);
+      this.props.watchPrometheusQuery(query);
+    }
+
+    render() {
+      return (
+        <WrappedComponent
+          watchURL={this.watchURL}
+          stopWatchURL={this.props.stopWatchURL}
+          watchPrometheus={this.watchPrometheus}
+          stopWatchPrometheusQuery={this.props.stopWatchPrometheusQuery}
+          urlResults={this.props[RESULTS_TYPE.URL]}
+          prometheusResults={this.props[RESULTS_TYPE.URL]}
+        />
+      );
+    }
+  };
+
+export const withDashboardResources = compose(connect(mapStateToProps, mapDispatchToProps), WithDashboardResources);
+
+export type WatchURL = (url: string, fetch?: Fetch) => void;
+export type StopWatchURL = (url: string) => void;
+export type WatchPrometheus = (query: string) => void;
+export type StopWatchPrometheus = (query: string) => void;
+
+type WithDashboardResourcesProps = {
+  watchURL: WatchURLAction;
+  watchPrometheusQuery: WatchPrometheusQueryAction;
+  stopWatchURL: StopWatchURLAction;
+  stopWatchPrometheusQuery: StopWatchPrometheusAction;
+  [RESULTS_TYPE.PROMETHEUS]: ImmutableMap<string, any>;
+  [RESULTS_TYPE.URL]: ImmutableMap<string, any>;
+};
+
+export type DashboardItemProps = {
+  watchURL: WatchURL,
+  stopWatchURL: StopWatchURL,
+  watchPrometheus: WatchPrometheus,
+  stopWatchPrometheusQuery: StopWatchPrometheus,
+  urlResults: ImmutableMap<string, any>,
+  prometheusResults: ImmutableMap<string, any>,
+}

--- a/frontend/public/reducers/dashboards.ts
+++ b/frontend/public/reducers/dashboards.ts
@@ -1,0 +1,45 @@
+import { ActionType, DashboardsAction } from '../actions/dashboards';
+import { Map as ImmutableMap, fromJS } from 'immutable';
+
+export enum RESULTS_TYPE {
+  PROMETHEUS = 'PROMETHEUS',
+  URL = 'URL',
+}
+
+export const defaults = {
+  [RESULTS_TYPE.PROMETHEUS]: fromJS({}),
+  [RESULTS_TYPE.URL]: fromJS({}),
+};
+
+export type DashboardsState = ImmutableMap<string, any>;
+
+export const isWatchActive = (state: DashboardsState, type: string, key: string): boolean => state.getIn([type, key, 'active']) > 0 || state.getIn([type, key, 'inFlight']);
+
+export const dashboardsReducer = (state: DashboardsState, action: DashboardsAction): DashboardsState => {
+  if (!state) {
+    return ImmutableMap(defaults);
+  }
+  switch (action.type) {
+    case ActionType.ActivateWatch: {
+      const activePath = [action.payload.type, action.payload.key, 'active'];
+      const active = state.hasIn(activePath) ? state.getIn(activePath) : 0;
+      return state.setIn(activePath, active + 1);
+    }
+    case ActionType.UpdateWatchTimeout:
+      return state.setIn([action.payload.type, action.payload.key, 'timeout'], action.payload.timeout);
+    case ActionType.UpdateWatchInFlight:
+      return state.setIn([action.payload.type, action.payload.key, 'inFlight'], action.payload.inFlight);
+    case ActionType.StopWatch: {
+      const active = state.getIn([action.payload.type, action.payload.key, 'active']);
+      const newState = state.setIn([action.payload.type, action.payload.key, 'active'], active - 1);
+      if (active === 1) {
+        clearTimeout(state.getIn([action.payload.type, action.payload.key, 'timeout']));
+      }
+      return newState;
+    }
+    case ActionType.UpdateResult:
+      return state.setIn([action.payload.type, action.payload.key, 'result'], action.payload.result);
+    default:
+      return state;
+  }
+};

--- a/frontend/public/redux.ts
+++ b/frontend/public/redux.ts
@@ -4,6 +4,7 @@ import { featureReducer, featureReducerName, FeatureState } from './reducers/fea
 import { monitoringReducer, monitoringReducerName, MonitoringState } from './reducers/monitoring';
 import k8sReducers, { K8sState } from './reducers/k8s';
 import UIReducers, { UIState } from './reducers/ui';
+import { dashboardsReducer, DashboardsState } from './reducers/dashboards';
 
 const composeEnhancers =
   // eslint-disable-next-line no-undef
@@ -31,6 +32,7 @@ export type RootState = {
   UI: UIState;
   [featureReducerName]: FeatureState;
   [monitoringReducerName]: MonitoringState;
+  dashboards: DashboardsState;
 };
 
 const reducers = combineReducers<RootState>({
@@ -38,6 +40,7 @@ const reducers = combineReducers<RootState>({
   UI: UIReducers,
   [featureReducerName]: featureReducer,
   [monitoringReducerName]: monitoringReducer,
+  dashboards: dashboardsReducer,
 });
 
 const store = createStore(reducers, {}, composeEnhancers(applyMiddleware(thunk)));

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -1,4 +1,5 @@
 // Config
+// pf3 color variables
 @import '~patternfly/dist/sass/patternfly/color-variables';
 @import "style/vars";
 
@@ -10,6 +11,11 @@
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/variables";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins";
 @import "~font-awesome-sass/assets/stylesheets/font-awesome/variables";
+
+// pf4 color variables
+// these vars have slightly different names to pf3 ones (imported above)
+// ie $color-pf-black-100 (pf3) vs $pf-color-black-100 (pf4)
+@import '~@patternfly/patternfly/sass-utilities/colors';
 
 @import "style/base";
 
@@ -95,3 +101,7 @@
 @import "components/storage-class-form";
 @import "components/quota";
 @import "components/cluster-settings/cluster-settings";
+
+@import "components/dashboard/dashboard";
+@import "components/dashboard/dashboard-card/card";
+@import "components/dashboard/health-card/health-card";


### PR DESCRIPTION
This PR introduces dashboards page as designed in https://docs.google.com/document/d/1q0DIcUKgFhvNbtGt-SMl35Z2jHA_QO2r7aaBuFmwE2U/edit#heading=h.koix4vo7e16v

Dashboards page has its own redux store to be able to share resources (prometheus queries results, various url requests and in the future also k8s resources) between various dashboard cards and also dashboard tabs.

Dashboards page currently contains only one tab (Overview) - plan is to be able to contribute other tabs via static extension mechanism. Overview tab contains only one card - Health which can be extended via static plugin mechanism to show healths for other subsystems (ie KubeVirt or Storage).
Other cards will follow in separate PRs.

Dashboard page is not included in navigation yet, but can be accessed directly via `/dashboards` route.

Dashboards page - Overview tab
![dashboard](https://user-images.githubusercontent.com/2078045/58089864-2837d700-7bc6-11e9-8502-3c93984f732e.png)

Dashboards page - Overview tab with demo-plugin enabled
![Screenshot from 2019-05-21 12-43-58](https://user-images.githubusercontent.com/2078045/58089912-3f76c480-7bc6-11e9-9b80-99cb0b7b5284.png)


@vojtechszocs @cloudbehl 