### PR TITLE
Introduce kubevirt

### DIFF
--- a/frontend/packages/kubevirt-plugin/OWNERS
+++ b/frontend/packages/kubevirt-plugin/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+  - mareklibra
+  - rawagner
+  - suomiy
+  - vojtechszocs
+  - pcbailey
+  - jelkosz
+approvers:
+  - mareklibra
+  - rawagner
+  - suomiy
+  - jelkosz

--- a/frontend/packages/kubevirt-plugin/package.json
+++ b/frontend/packages/kubevirt-plugin/package.json
@@ -13,4 +13,3 @@
     "entry": "src/plugin.ts"
   }
 }
-

--- a/frontend/packages/kubevirt-plugin/package.json
+++ b/frontend/packages/kubevirt-plugin/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@console/kubevirt-plugin",
+  "version": "0.0.0-fixed",
+  "description": "Kubevirt - Virtual machines addon for Kubernetes",
+  "private": true,
+  "dependencies": {
+    "@console/internal": "0.0.0-fixed",
+    "@console/plugin-sdk": "0.0.0-fixed",
+    "@console/shared": "0.0.0-fixed"
+  },
+  "consolePlugin": {
+    "entry": "src/plugin.ts"
+  }
+}
+

--- a/frontend/packages/kubevirt-plugin/package.json
+++ b/frontend/packages/kubevirt-plugin/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@console/internal": "0.0.0-fixed",
     "@console/plugin-sdk": "0.0.0-fixed",
-    "@console/shared": "0.0.0-fixed"
+    "@console/shared": "0.0.0-fixed",
+    "kubevirt-web-ui-components": "^0.1.34-4"
   },
   "consolePlugin": {
     "entry": "src/plugin.ts"

--- a/frontend/packages/kubevirt-plugin/src/components/__tests__/vm.spec.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/__tests__/vm.spec.tsx
@@ -1,0 +1,1 @@
+// TODO(mlibra)

--- a/frontend/packages/kubevirt-plugin/src/components/__tests__/vm.spec.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/__tests__/vm.spec.tsx
@@ -1,1 +1,0 @@
-// TODO(mlibra)

--- a/frontend/packages/kubevirt-plugin/src/components/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash-es';
 
 import {
   getName,
@@ -95,43 +94,35 @@ const filters = [{
 }];
 */
 
-const createItems = {
-  wizard: 'Create with Wizard',
-  yaml: 'Create from YAML',
-};
-
 export type VirtualMachinesPageProps = {
   namespace: string;
 };
 
-export class VirtualMachinesPage extends React.Component<VirtualMachinesPageProps> {
-  createProps = {
-    items: createItems,
-    createLink: (type) => {
-      switch (type) {
-        case 'wizard':
-          return () => {
-            window.console.log('TODO: start wizard'); // TODO(mlibra)
-          };
-          // return () => openCreateVmWizard(this.props.namespace);
-        default:
-          return `/k8s/ns/${this.props.namespace || 'default'}/virtualmachines/~new/`; // TODO
-      }
-    },
-  };
+const getCreateProps = ({ namespace }) => ({
+  items: {
+    wizard: 'Create with Wizard',
+    yaml: 'Create from YAML',
+  },
+  createLink: type => {
+    switch (type) {
+      case 'wizard':
+        return () => {
+          window.console.log('TODO: start wizard'); // TODO(mlibra)
+        };
+      // return () => openCreateVmWizard(this.props.namespace);
+      default:
+        return `/k8s/ns/${namespace || 'default'}/virtualmachines/~new/`;
+    }
+  },
+});
 
-  shouldComponentUpdate(nextProps: VirtualMachinesPageProps) {
-    return !_.isEqual(nextProps, this.props);
-  }
-
-  render() {
-    return <ListPage
-      {...this.props}
-      canCreate={true}
-      kind={VirtualMachineModel.kind}
-      ListComponent={VMList}
-      createProps={this.createProps}
-      rowFilters={filters}
-    />;
-  }
-}
+export const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = props => (
+  <ListPage
+    {...props}
+    canCreate={true}
+    kind={VirtualMachineModel.kind}
+    ListComponent={VMList}
+    createProps={getCreateProps(props)}
+    rowFilters={filters}
+  />
+);

--- a/frontend/packages/kubevirt-plugin/src/components/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import {
+  getName,
+  getNamespace,
+  getUid,
+  // VmStatus,
+  getSimpleVmStatus,
+  VM_SIMPLE_STATUS_ALL,
+  VM_SIMPLE_STATUS_TO_TEXT,
+//  getResource,
+//  DASHES,
+} from 'kubevirt-web-ui-components';
+
+import { NamespaceModel } from '@console/internal/models';
+import { ListHeader, ColHead, List, ListPage, ResourceRow } from '@console/internal/components/factory';
+import { ResourceLink } from '@console/internal/components/utils';
+// import { actions } from '../../module/okdk8s';
+
+import {
+  VirtualMachineModel,
+  // VirtualMachineInstanceModel,
+  // VirtualMachineInstanceMigrationModel,
+} from '../models';
+
+// import { openCreateVmWizard } from '../modals/create-vm-modal';
+// import { menuActions } from './menu-actions';
+// import { WithResources } from '../utils/withResources';
+
+const mainRowSize = 'col-lg-4 col-md-4 col-sm-6 col-xs-6';
+const otherRowSize = 'col-lg-4 col-md-4 hidden-sm hidden-xs';
+
+const VMHeader = props => <ListHeader>
+  <ColHead {...props} className={mainRowSize} sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className={otherRowSize} sortField="metadata.namespace">Namespace</ColHead>
+  <ColHead {...props} className={mainRowSize} sortField="spec.running">State</ColHead>
+</ListHeader>;
+
+const VMRow = ({ obj: vm }) => {
+  const name = getName(vm);
+  const namespace = getNamespace(vm);
+  const uid = getUid(vm);
+
+  /*
+  TODO(mlibra) To keep recent PR minimal, relations to other objects will be migrated as a next step.
+               Keeping the code here for reference.
+  const migrationResources = getResource(VirtualMachineInstanceMigrationModel, {namespace});
+  const resourceMap = {
+    pods: {
+      resource: getResource(PodModel, { namespace }),
+    },
+    migrations: {
+      resource: migrationResources,
+    },
+  };
+  */
+
+  return <ResourceRow obj={vm}>
+    <div className={mainRowSize}>
+      <ResourceLink kind={VirtualMachineModel.kind} name={name} namespace={namespace} title={uid} />
+    </div>
+    <div className={otherRowSize}>
+      <ResourceLink kind={NamespaceModel.kind} name={namespace} title={namespace} />
+    </div>
+    <div className={mainRowSize}>
+      {/*
+        <WithResources resourceMap={resourceMap} loaderComponent={() => DASHES}>
+          <VmStatus vm={vm}/>
+        </WithResources>
+      */}
+    </div>
+    <div className="dropdown-kebab-pf">
+      {/*
+      <ResourceKebab actions={menuActions} kind={VirtualMachineModel.kind} resource={vm} resources={[
+        getResource(VirtualMachineInstanceModel, { name, namespace, isList: false }),
+        getResource(VirtualMachineInstanceMigrationModel, {namespace}),
+        getResource(PodModel, {namespace}),
+      ]} />
+      */}
+    </div>
+  </ResourceRow>;
+};
+
+const VMList: React.FC = props => <List {...props} Header={VMHeader} Row={VMRow} />;
+VMList.displayName = 'VMList';
+
+const filters = [{
+  type: 'vm-status',
+  selected: VM_SIMPLE_STATUS_ALL,
+  reducer: getSimpleVmStatus,
+  items: VM_SIMPLE_STATUS_ALL.map(status => ({ id: status, title: VM_SIMPLE_STATUS_TO_TEXT[status] }) ),
+}];
+
+const createItems = {
+  wizard: 'Create with Wizard',
+  yaml: 'Create from YAML',
+};
+
+export type VirtualMachinesPageProps = {
+  namespace: string;
+};
+
+export class VirtualMachinesPage extends React.Component<VirtualMachinesPageProps> {
+  createProps = {
+    items: createItems,
+    createLink: (type) => {
+      switch (type) {
+        case 'wizard':
+          return () => {
+            window.console.log('TODO: start wizard'); // TODO(mlibra)
+          };
+          // return () => openCreateVmWizard(this.props.namespace);
+        default:
+          return `/k8s/ns/${this.props.namespace || 'default'}/virtualmachines/~new/`; // TODO
+      }
+    },
+  };
+
+  shouldComponentUpdate(nextProps: VirtualMachinesPageProps) {
+    return !_.isEqual(nextProps, this.props);
+  }
+
+  render() {
+    return <ListPage
+      {...this.props}
+      canCreate={true}
+      kind={VirtualMachineModel.kind}
+      ListComponent={VMList}
+      createProps={this.createProps}
+      rowFilters={filters}
+    />;
+  }
+}

--- a/frontend/packages/kubevirt-plugin/src/components/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm.tsx
@@ -6,11 +6,11 @@ import {
   getNamespace,
   getUid,
   // VmStatus,
-  getSimpleVmStatus,
-  VM_SIMPLE_STATUS_ALL,
-  VM_SIMPLE_STATUS_TO_TEXT,
-//  getResource,
-//  DASHES,
+  // getSimpleVmStatus,
+  // VM_SIMPLE_STATUS_ALL,
+  // VM_SIMPLE_STATUS_TO_TEXT,
+  //  getResource,
+  //  DASHES,
 } from 'kubevirt-web-ui-components';
 
 import { NamespaceModel } from '@console/internal/models';
@@ -85,12 +85,15 @@ const VMRow = ({ obj: vm }) => {
 const VMList: React.FC = props => <List {...props} Header={VMHeader} Row={VMRow} />;
 VMList.displayName = 'VMList';
 
+const filters = undefined;
+/* TODO(mlibra): introduce extension point for list.tsx and reenable here then
 const filters = [{
   type: 'vm-status',
   selected: VM_SIMPLE_STATUS_ALL,
   reducer: getSimpleVmStatus,
   items: VM_SIMPLE_STATUS_ALL.map(status => ({ id: status, title: VM_SIMPLE_STATUS_TO_TEXT[status] }) ),
 }];
+*/
 
 const createItems = {
   wizard: 'Create with Wizard',

--- a/frontend/packages/kubevirt-plugin/src/models.ts
+++ b/frontend/packages/kubevirt-plugin/src/models.ts
@@ -1,0 +1,162 @@
+import { K8sKind } from '@console/internal/module/k8s';
+
+export const VirtualMachineModel: K8sKind = {
+  label: 'Virtual Machine',
+  labelPlural: 'Virtual Machines',
+  apiVersion: 'v1alpha3',
+  path: 'virtualmachines',
+  apiGroup: 'kubevirt.io',
+  plural: 'virtualmachines',
+  abbr: 'VM',
+  namespaced: true,
+  kind: 'VirtualMachine',
+  id: 'virtualmachine',
+};
+
+export const VirtualMachineInstanceModel: K8sKind = {
+  label: 'Virtual Machine Instance',
+  labelPlural: 'Virtual Machine Instances',
+  apiVersion: 'v1alpha3',
+  path: 'virtualmachineinstances',
+  apiGroup: 'kubevirt.io',
+  plural: 'virtualmachineinstances',
+  abbr: 'VMI',
+  namespaced: true,
+  kind: 'VirtualMachineInstance',
+  id: 'virtualmachineinstance',
+};
+
+export const VirtualMachineInstancePresetModel: K8sKind = {
+  label: 'Virtual Machine Instance Preset',
+  labelPlural: 'Virtual Machine Instance Presets',
+  apiVersion: 'v1alpha3',
+  path: 'virtualmachineinstancepresets',
+  apiGroup: 'kubevirt.io',
+  plural: 'virtualmachineinstancepresets',
+  abbr: 'VMIP',
+  namespaced: true,
+  kind: 'VirtualMachineInstancePreset',
+  id: 'virtualmachineinstancepreset',
+};
+
+export const VirtualMachineInstanceReplicaSetModel: K8sKind = {
+  label: 'Virtual Machine Instance Replica Set',
+  labelPlural: 'Virtual Machine Instance Replica Sets',
+  apiVersion: 'v1alpha3',
+  path: 'virtualmachineinstancereplicaset',
+  apiGroup: 'kubevirt.io',
+  plural: 'virtualmachineinstancereplicasets',
+  abbr: 'VMIRS',
+  namespaced: true,
+  kind: 'VirtualMachineInstanceReplicaSet',
+  id: 'virtualmachineinstancereplicaset',
+};
+
+export const TemplateModel: K8sKind = {
+  label: 'Template',
+  labelPlural: 'Templates',
+  apiVersion: 'v1',
+  path: 'templates',
+  apiGroup: 'template.openshift.io',
+  plural: 'templates',
+  namespaced: true,
+  abbr: 'Template',
+  kind: 'Template',
+  id: 'template',
+};
+
+/* TODO(mlibra): migrate templates
+export const VmTemplateModel: K8sKind = {
+  label: 'Template',
+  labelPlural: 'Templates',
+  apiVersion: 'v1',
+  path: 'templates',
+  apiGroup: 'template.openshift.io',
+  plural: 'vmtemplates',
+  namespaced: true,
+  abbr: 'VMT',
+  kind: 'Template',
+  id: 'vmtemplate',
+  selector: {
+    matchLabels: {[TEMPLATE_TYPE_LABEL]: 'vm'},
+  },
+};
+*/
+
+export const NetworkAttachmentDefinitionModel: K8sKind = {
+  label: 'Network Attachment Definition',
+  labelPlural: 'Network Attachment Definitions',
+  apiVersion: 'v1',
+  path: 'network-attachment-definitions',
+  apiGroup: 'k8s.cni.cncf.io',
+  plural: 'network-attachment-definitions',
+  namespaced: true,
+  abbr: 'NAD',
+  kind: 'NetworkAttachmentDefinition',
+  id: 'network-attachment-definition',
+};
+
+export const VirtualMachineInstanceMigrationModel: K8sKind = {
+  label: 'Virtual Machine Instance Migration',
+  labelPlural: 'Virtual Machine Instance Migrations',
+  apiVersion: 'v1alpha3',
+  path: 'virtualmachineinstancemigrations',
+  apiGroup: 'kubevirt.io',
+  plural: 'virtualmachineinstancemigrations',
+  abbr: 'VMIM',
+  namespaced: true,
+  kind: 'VirtualMachineInstanceMigration',
+  id: 'virtualmachineinstancemigration',
+};
+
+export const DataVolumeModel: K8sKind = {
+  label: 'Data Volume',
+  labelPlural: 'Data Volumes',
+  apiVersion: 'v1alpha1',
+  path: 'datavolumes',
+  apiGroup: 'cdi.kubevirt.io',
+  plural: 'datavolumes',
+  abbr: 'DV',
+  namespaced: true,
+  kind: 'DataVolume',
+  id: 'datavolume',
+};
+
+export const V2VVMwareModel: K8sKind = {
+  label: 'V2V VMWare Provider',
+  labelPlural: 'V2V VMWare Providers',
+  apiVersion: 'v1alpha1',
+  path: 'v2vvmwares',
+  apiGroup: 'kubevirt.io',
+  plural: 'v2vvmwares',
+  abbr: 'v2vVmw',
+  namespaced: true,
+  kind: 'V2VVmware',
+  id: 'v2vvmware',
+};
+
+export const InfrastructureModel: K8sKind = {
+  label: 'Infrastructure',
+  labelPlural: 'Infrastructures',
+  apiVersion: 'v1',
+  path: 'infrastructures',
+  apiGroup: 'config.openshift.io',
+  plural: 'infrastructures',
+  abbr: 'infra',
+  namespaced: false,
+  kind: 'Infrastructure',
+  id: 'infrastructure',
+};
+
+export const NodeMaintenance: K8sKind = {
+  label: 'NodeMaintenance',
+  labelPlural: 'NodeMaintenances',
+  apiVersion: 'v1alpha1',
+  path: 'nodemaintenances',
+  apiGroup: 'kubevirt.io',
+  plural: 'nodemaintenances',
+  abbr: 'nm',
+  namespaced: false,
+  kind: 'NodeMaintenance',
+  id: 'nodemaintenance',
+};

--- a/frontend/packages/kubevirt-plugin/src/models.ts
+++ b/frontend/packages/kubevirt-plugin/src/models.ts
@@ -46,23 +46,10 @@ export const VirtualMachineInstanceReplicaSetModel: K8sKind = {
   path: 'virtualmachineinstancereplicaset',
   apiGroup: 'kubevirt.io',
   plural: 'virtualmachineinstancereplicasets',
-  abbr: 'VMIRS',
+  abbr: 'VMIR',
   namespaced: true,
   kind: 'VirtualMachineInstanceReplicaSet',
   id: 'virtualmachineinstancereplicaset',
-};
-
-export const TemplateModel: K8sKind = {
-  label: 'Template',
-  labelPlural: 'Templates',
-  apiVersion: 'v1',
-  path: 'templates',
-  apiGroup: 'template.openshift.io',
-  plural: 'templates',
-  namespaced: true,
-  abbr: 'Template',
-  kind: 'Template',
-  id: 'template',
 };
 
 /* TODO(mlibra): migrate templates
@@ -129,23 +116,10 @@ export const V2VVMwareModel: K8sKind = {
   path: 'v2vvmwares',
   apiGroup: 'kubevirt.io',
   plural: 'v2vvmwares',
-  abbr: 'v2vVmw',
+  abbr: 'VVW',
   namespaced: true,
   kind: 'V2VVmware',
   id: 'v2vvmware',
-};
-
-export const InfrastructureModel: K8sKind = {
-  label: 'Infrastructure',
-  labelPlural: 'Infrastructures',
-  apiVersion: 'v1',
-  path: 'infrastructures',
-  apiGroup: 'config.openshift.io',
-  plural: 'infrastructures',
-  abbr: 'infra',
-  namespaced: false,
-  kind: 'Infrastructure',
-  id: 'infrastructure',
 };
 
 export const NodeMaintenance: K8sKind = {
@@ -155,7 +129,7 @@ export const NodeMaintenance: K8sKind = {
   path: 'nodemaintenances',
   apiGroup: 'kubevirt.io',
   plural: 'nodemaintenances',
-  abbr: 'nm',
+  abbr: 'NM',
   namespaced: false,
   kind: 'NodeMaintenance',
   id: 'nodemaintenance',

--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -52,7 +52,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'ResourcePage/List',
     properties: {
       model: models.VirtualMachineModel,
-      loader: () => import('./components/vm' /* webpackChunkName: "virtual-machines" */).then(m => m.VirtualMachinesPage),
+      loader: () => import('./components/vm' /* webpackChunkName: "kubevirt-virtual-machines" */).then(m => m.VirtualMachinesPage),
     },
   },
   {
@@ -66,7 +66,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   //   type: 'ResourcePage/Detail',
   //   properties: {
   //     model: VirtualMachineModel,
-  //     loader: () => import('./components/vm-detail' /* webpackChunkName: "virtual-machines" */).then(m => m.VirtualMachinesDetailsPage),
+  //     loader: () => import('./components/vm-detail' /* webpackChunkName: "kubevirt-virtual-machines" */).then(m => m.VirtualMachinesDetailsPage),
   //   },
   // },
 ];

--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -1,17 +1,24 @@
-import { Plugin, ResourceNSNavItem, ResourceListPage, ResourceDetailPage, ModelFeatureFlag, YamlTemplate } from '@console/plugin-sdk';
+import * as _ from 'lodash-es';
+import { Plugin, ResourceNSNavItem, ResourceListPage, ResourceDetailPage, ModelFeatureFlag, YamlTemplate, ModelDefinition } from '@console/plugin-sdk';
 
-import { VirtualMachineModel } from './models';
+import * as models from './models';
 import { vmYamlTemplate } from './yaml-templates';
 
-type ConsumedExtensions = ResourceNSNavItem | ResourceListPage | ResourceDetailPage | ModelFeatureFlag | YamlTemplate;
+type ConsumedExtensions = ResourceNSNavItem | ResourceListPage | ResourceDetailPage | ModelFeatureFlag | YamlTemplate | ModelDefinition;
 
 const FLAG_KUBEVIRT = 'KUBEVIRT';
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
+    type: 'ModelDefinition',
+    properties: {
+      models: _.values(models),
+    },
+  },
+  {
     type: 'FeatureFlag/Model',
     properties: {
-      model: VirtualMachineModel,
+      model: models.VirtualMachineModel,
       flag: FLAG_KUBEVIRT,
     },
   },
@@ -21,7 +28,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       section: 'Workloads',
       componentProps: {
         name: 'Virtual Machines',
-        resource: VirtualMachineModel.plural,
+        resource: models.VirtualMachineModel.plural,
         required: FLAG_KUBEVIRT,
       },
       mergeAfter: 'Pods', // rendered name of the resource navigation link in the left-side menu
@@ -30,14 +37,14 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'ResourcePage/List',
     properties: {
-      model: VirtualMachineModel,
+      model: models.VirtualMachineModel,
       loader: () => import('./components/vm' /* webpackChunkName: "virtual-machines" */).then(m => m.VirtualMachinesPage),
     },
   },
   {
     type: 'YamlTemplate',
     properties: {
-      model: VirtualMachineModel,
+      model: models.VirtualMachineModel,
       template: vmYamlTemplate,
     },
   },

--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -1,10 +1,24 @@
 import * as _ from 'lodash-es';
-import { Plugin, ResourceNSNavItem, ResourceListPage, ResourceDetailPage, ModelFeatureFlag, YamlTemplate, ModelDefinition } from '@console/plugin-sdk';
+import {
+  Plugin,
+  ResourceNSNavItem,
+  ResourceListPage,
+  ResourceDetailPage,
+  ModelFeatureFlag,
+  YAMLTemplate,
+  ModelDefinition,
+} from '@console/plugin-sdk';
 
 import * as models from './models';
-import { vmYamlTemplate } from './yaml-templates';
+import { yamlTemplates } from './yaml-templates';
 
-type ConsumedExtensions = ResourceNSNavItem | ResourceListPage | ResourceDetailPage | ModelFeatureFlag | YamlTemplate | ModelDefinition;
+type ConsumedExtensions =
+  | ResourceNSNavItem
+  | ResourceListPage
+  | ResourceDetailPage
+  | ModelFeatureFlag
+  | YAMLTemplate
+  | ModelDefinition;
 
 const FLAG_KUBEVIRT = 'KUBEVIRT';
 
@@ -31,7 +45,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         resource: models.VirtualMachineModel.plural,
         required: FLAG_KUBEVIRT,
       },
-      mergeAfter: 'Pods', // rendered name of the resource navigation link in the left-side menu
+      mergeAfter: 'Pods',
     },
   },
   {
@@ -42,10 +56,10 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'YamlTemplate',
+    type: 'YAMLTemplate',
     properties: {
       model: models.VirtualMachineModel,
-      template: vmYamlTemplate,
+      template: yamlTemplates.getIn([models.VirtualMachineModel, 'default']),
     },
   },
   // {

--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -17,13 +17,14 @@ const plugin: Plugin<ConsumedExtensions> = [
   },
   {
     type: 'NavItem/ResourceNS',
-    properties: { // TODO(mlibra): set order, see section.tsx
+    properties: {
       section: 'Workloads',
       componentProps: {
         name: 'Virtual Machines',
         resource: VirtualMachineModel.plural,
         required: FLAG_KUBEVIRT,
       },
+      mergeAfter: 'Pods', // rendered name of the resource navigation link in the left-side menu
     },
   },
   {

--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -3,22 +3,24 @@ import { VirtualMachineModel } from './models';
 
 type ConsumedExtensions = ResourceNSNavItem | ResourceListPage | ResourceDetailPage | ModelFeatureFlag;
 
+const FLAG_KUBEVIRT = 'KUBEVIRT';
+
 const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'FeatureFlag/Model',
     properties: {
       model: VirtualMachineModel,
-      flag: 'KUBEVIRT',
+      flag: FLAG_KUBEVIRT,
     },
   },
   {
     type: 'NavItem/ResourceNS',
-    properties: { // TODO: set order, see section.tsx
+    properties: { // TODO(mlibra): set order, see section.tsx
       section: 'Workloads',
       componentProps: {
         name: 'Virtual Machines',
-        resource: 'virtualmachines',
-        required: 'KUBEVIRT',
+        resource: VirtualMachineModel.plural,
+        required: FLAG_KUBEVIRT,
       },
     },
   },
@@ -29,6 +31,13 @@ const plugin: Plugin<ConsumedExtensions> = [
       loader: () => import('./components/vm' /* webpackChunkName: "virtual-machines" */).then(m => m.VirtualMachinesPage),
     },
   },
+  // {
+  //   type: 'ResourcePage/Detail',
+  //   properties: {
+  //     model: VirtualMachineModel,
+  //     loader: () => import('./components/vm-detail' /* webpackChunkName: "virtual-machines" */).then(m => m.VirtualMachinesDetailsPage),
+  //   },
+  // },
 ];
 
 export default plugin;

--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -1,7 +1,34 @@
-import { Plugin, HrefNavItem, ResourceNSNavItem } from '@console/plugin-sdk';
+import { Plugin, ResourceNSNavItem, ResourceListPage, ResourceDetailPage, ModelFeatureFlag } from '@console/plugin-sdk';
+import { VirtualMachineModel } from './models';
 
-type ConsumedExtensions = HrefNavItem | ResourceNSNavItem;
+type ConsumedExtensions = ResourceNSNavItem | ResourceListPage | ResourceDetailPage | ModelFeatureFlag;
 
-const plugin: Plugin<ConsumedExtensions> = [];
+const plugin: Plugin<ConsumedExtensions> = [
+  {
+    type: 'FeatureFlag/Model',
+    properties: {
+      model: VirtualMachineModel,
+      flag: 'KUBEVIRT',
+    },
+  },
+  {
+    type: 'NavItem/ResourceNS',
+    properties: { // TODO: set order, see section.tsx
+      section: 'Workloads',
+      componentProps: {
+        name: 'Virtual Machines',
+        resource: 'virtualmachines',
+        required: 'KUBEVIRT',
+      },
+    },
+  },
+  {
+    type: 'ResourcePage/List',
+    properties: {
+      model: VirtualMachineModel,
+      loader: () => import('./components/vm' /* webpackChunkName: "virtual-machines" */).then(m => m.VirtualMachinesPage),
+    },
+  },
+];
 
 export default plugin;

--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -3,7 +3,7 @@ import {
   Plugin,
   ResourceNSNavItem,
   ResourceListPage,
-  ResourceDetailPage,
+  ResourceDetailsPage,
   ModelFeatureFlag,
   YAMLTemplate,
   ModelDefinition,
@@ -15,7 +15,7 @@ import { yamlTemplates } from './yaml-templates';
 type ConsumedExtensions =
   | ResourceNSNavItem
   | ResourceListPage
-  | ResourceDetailPage
+  | ResourceDetailsPage
   | ModelFeatureFlag
   | YAMLTemplate
   | ModelDefinition;
@@ -49,7 +49,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'ResourcePage/List',
+    type: 'Page/Resource/List',
     properties: {
       model: models.VirtualMachineModel,
       loader: () =>
@@ -66,7 +66,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   // {
-  //   type: 'ResourcePage/Detail',
+  //   type: 'Page/Resource/Details',
   //   properties: {
   //     model: VirtualMachineModel,
   //     loader: () => import('./components/vm-detail' /* webpackChunkName: "kubevirt-virtual-machines" */).then(m => m.VirtualMachinesDetailsPage),

--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -52,7 +52,10 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'ResourcePage/List',
     properties: {
       model: models.VirtualMachineModel,
-      loader: () => import('./components/vm' /* webpackChunkName: "kubevirt-virtual-machines" */).then(m => m.VirtualMachinesPage),
+      loader: () =>
+        import('./components/vm' /* webpackChunkName: "kubevirt-virtual-machines" */).then(
+          (m) => m.VirtualMachinesPage,
+        ),
     },
   },
   {

--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -1,7 +1,9 @@
-import { Plugin, ResourceNSNavItem, ResourceListPage, ResourceDetailPage, ModelFeatureFlag } from '@console/plugin-sdk';
-import { VirtualMachineModel } from './models';
+import { Plugin, ResourceNSNavItem, ResourceListPage, ResourceDetailPage, ModelFeatureFlag, YamlTemplate } from '@console/plugin-sdk';
 
-type ConsumedExtensions = ResourceNSNavItem | ResourceListPage | ResourceDetailPage | ModelFeatureFlag;
+import { VirtualMachineModel } from './models';
+import { vmYamlTemplate } from './yaml-templates';
+
+type ConsumedExtensions = ResourceNSNavItem | ResourceListPage | ResourceDetailPage | ModelFeatureFlag | YamlTemplate;
 
 const FLAG_KUBEVIRT = 'KUBEVIRT';
 
@@ -29,6 +31,13 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       model: VirtualMachineModel,
       loader: () => import('./components/vm' /* webpackChunkName: "virtual-machines" */).then(m => m.VirtualMachinesPage),
+    },
+  },
+  {
+    type: 'YamlTemplate',
+    properties: {
+      model: VirtualMachineModel,
+      template: vmYamlTemplate,
     },
   },
   // {

--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -1,0 +1,7 @@
+import { Plugin, HrefNavItem, ResourceNSNavItem } from '@console/plugin-sdk';
+
+type ConsumedExtensions = HrefNavItem | ResourceNSNavItem;
+
+const plugin: Plugin<ConsumedExtensions> = [];
+
+export default plugin;

--- a/frontend/packages/kubevirt-plugin/src/yaml-templates.ts
+++ b/frontend/packages/kubevirt-plugin/src/yaml-templates.ts
@@ -2,8 +2,9 @@ import { Map as ImmutableMap } from 'immutable';
 
 import { VirtualMachineModel } from './models';
 
-export const yamlTemplates = ImmutableMap()
-  .setIn([VirtualMachineModel, 'default'], `
+export const yamlTemplates = ImmutableMap().setIn(
+  [VirtualMachineModel, 'default'],
+  `
 apiVersion: ${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}
 kind: ${VirtualMachineModel.kind}
 metadata:
@@ -37,4 +38,5 @@ spec:
         - name: cloudinitdisk
           cloudInitNoCloud:
             userDataBase64: SGkuXG4=
-`);
+`,
+);

--- a/frontend/packages/kubevirt-plugin/src/yaml-templates.ts
+++ b/frontend/packages/kubevirt-plugin/src/yaml-templates.ts
@@ -1,0 +1,37 @@
+import { VirtualMachineModel } from './models';
+
+export const vmYamlTemplate = `
+  apiVersion: ${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}
+  kind: VirtualMachine
+  metadata:
+    name: example
+  spec:
+    running: false
+    template:
+      spec:
+        domain:
+          devices:
+            disks:
+              - name: containerdisk
+                disk:
+                  bus: virtio
+              - name: cloudinitdisk
+                disk:
+                  bus: virtio
+            interfaces:
+            - name: default
+              bridge: {}
+          resources:
+            requests:
+              memory: 64M
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+          - name: containerdisk
+            containerDisk:
+              image: kubevirt/cirros-registry-disk-demo
+          - name: cloudinitdisk
+            cloudInitNoCloud:
+              userDataBase64: SGkuXG4=
+`;

--- a/frontend/packages/kubevirt-plugin/src/yaml-templates.ts
+++ b/frontend/packages/kubevirt-plugin/src/yaml-templates.ts
@@ -1,37 +1,40 @@
+import { Map as ImmutableMap } from 'immutable';
+
 import { VirtualMachineModel } from './models';
 
-export const vmYamlTemplate = `
-  apiVersion: ${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}
-  kind: VirtualMachine
-  metadata:
-    name: example
-  spec:
-    running: false
-    template:
-      spec:
-        domain:
-          devices:
-            disks:
-              - name: containerdisk
-                disk:
-                  bus: virtio
-              - name: cloudinitdisk
-                disk:
-                  bus: virtio
-            interfaces:
-            - name: default
-              bridge: {}
-          resources:
-            requests:
-              memory: 64M
-        networks:
-        - name: default
-          pod: {}
-        volumes:
-          - name: containerdisk
-            containerDisk:
-              image: kubevirt/cirros-registry-disk-demo
-          - name: cloudinitdisk
-            cloudInitNoCloud:
-              userDataBase64: SGkuXG4=
-`;
+export const yamlTemplates = ImmutableMap()
+  .setIn([VirtualMachineModel, 'default'], `
+apiVersion: ${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}
+kind: ${VirtualMachineModel.kind}
+metadata:
+  name: example
+spec:
+  running: false
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+          - name: default
+            bridge: {}
+        resources:
+          requests:
+            memory: 64M
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: kubevirt/cirros-registry-disk-demo
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userDataBase64: SGkuXG4=
+`);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -43,6 +43,13 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.2.0":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/types@^7.0.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.3.tgz#3a767004567060c2f40fca49a304712c525ee37d"
@@ -147,6 +154,11 @@
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
 
+"@novnc/novnc@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@novnc/novnc/-/novnc-1.1.0.tgz#3827b623e9e201ee1e1c8a61d107c51cbfaeb871"
+  integrity sha512-W90Q79EuCYT++39aT/VKGyk7hUt2gPN3rN+ifPUvY4rdjgZlfwdCg9q7yzj04hke/zgdHsbXFfyFijBvrRuU5A==
+
 "@patternfly/patternfly@2.8.2":
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.8.2.tgz#8362795b17a73be76dd9408b3c0d370e8a030d77"
@@ -165,6 +177,18 @@
     victory "^32.2.3"
     victory-core "^32.2.3"
     victory-legend "^32.2.3"
+
+"@patternfly/react-console@1.x":
+  version "1.10.50"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-console/-/react-console-1.10.50.tgz#a9e270b5acd95572909df89bdb8d469d91626102"
+  integrity sha512-yAjtXFP3wzYCz1xA/MTzzgS9Z5113u/7OZ1VpPwP5OGVOPo2C2MykmGDKkBC0B7SXmtkYlrAL3TRHeiNUjsu0w==
+  dependencies:
+    "@novnc/novnc" "^1.0.0"
+    "@spice-project/spice-html5" "^0.2.1"
+    blob-polyfill "^3.0.20180112"
+    classnames "^2.2.5"
+    file-saver "^1.3.8"
+    xterm "^3.3.0"
 
 "@patternfly/react-core@3.33.1":
   version "3.33.1"
@@ -220,6 +244,11 @@
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+
+"@spice-project/spice-html5@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@spice-project/spice-html5/-/spice-html5-0.2.1.tgz#9452fc7435a8b1c67937d86ea3b6d6d7e0616725"
+  integrity sha512-NY86i+x/0ldKK89enXghsXCzWwfb5DQ91hQFu9hbyLcAfCVn+ZKoYsw7xUWX6/HQBRrdu/4F1id7SdOwNqpG9g==
 
 "@tippy.js/react@^1.1.1":
   version "1.1.1"
@@ -1355,6 +1384,11 @@ atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
 
+autobind-decorator@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-2.4.0.tgz#ea9e1c98708cf3b5b356f7cf9f10f265ff18239c"
+  integrity sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw==
+
 autoprefixer@^6.3.1:
   version "6.7.7"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
@@ -2234,6 +2268,11 @@ bl@^1.0.0:
   dependencies:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
+
+blob-polyfill@^3.0.20180112:
+  version "3.0.20180112"
+  resolved "https://registry.yarnpkg.com/blob-polyfill/-/blob-polyfill-3.0.20180112.tgz#7f7c3e235ae298867f8c22b429d33aa9a7cc65b5"
+  integrity sha512-DX/47MXO+hNuEhuZRW9/yykNoCe7E/ywcPKtPVqGPRwLlowN811xi/3yVMQkE2fhTGHfrH8O9BMuhM7IdcRyew==
 
 block-stream@*:
   version "0.0.9"
@@ -3514,6 +3553,11 @@ css-loader@0.28.x:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
+css-mediaquery@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
+  integrity sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=
+
 css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -4086,6 +4130,16 @@ dnd-core@^2.6.0:
     invariant "^2.0.0"
     lodash "^4.2.0"
     redux "^3.7.1"
+
+dnd-core@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-4.0.5.tgz#3b83d138d0d5e265c73ec978dec5e1ed441dc665"
+  integrity sha1-O4PRONDV4mXHPsl43sXh7UQdxmU=
+  dependencies:
+    asap "^2.0.6"
+    invariant "^2.2.4"
+    lodash "^4.17.10"
+    redux "^4.0.0"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -5195,7 +5249,7 @@ file-loader@1.x:
     loader-utils "^1.0.2"
     schema-utils "^0.4.5"
 
-file-saver@1.3.x:
+file-saver@1.3.x, file-saver@^1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.8.tgz#e68a30c7cb044e2fb362b428469feb291c2e09d8"
 
@@ -5616,6 +5670,11 @@ get-caller-file@^1.0.1:
 get-canvas-context@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-canvas-context/-/get-canvas-context-1.0.2.tgz#d6e7b50bc4e4c86357cd39f22647a84b73601e93"
+
+get-node-dimensions@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz#fb7b4bb57060fb4247dd51c9d690dfbec56b0823"
+  integrity sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ==
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -6743,6 +6802,11 @@ https-proxy-agent@^2.2.1:
   dependencies:
     agent-base "^4.1.0"
     debug "^3.1.0"
+
+hyphenate-style-name@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
+  integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
 iconv-lite@0.4.19, iconv-lite@^0.4.17:
   version "0.4.19"
@@ -8023,6 +8087,21 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+kubevirt-web-ui-components@^0.1.34-4:
+  version "0.1.34-7"
+  resolved "https://registry.yarnpkg.com/kubevirt-web-ui-components/-/kubevirt-web-ui-components-0.1.34-7.tgz#d63ef14fad42cc1b197275f52f48429c568dac6d"
+  integrity sha512-q7UQqRdRz80x5SG1entoOWurHKIAmt7XWh6OaCoTSE8YJwjhLny4TgjwW441eFOp+OUTqc0p5vNpBxiQc27QKw==
+  dependencies:
+    "@patternfly/react-console" "1.x"
+    classnames "2.x"
+    js-yaml "3.x"
+    lodash "4.x"
+    react-dnd "2.6.x"
+    react-dnd-html5-backend "5.0.x"
+    react-measure "2.x"
+    react-responsive "6.1.x"
+    reactabular-dnd "8.16.x"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -8348,13 +8427,13 @@ lodash@3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.0.tgz#93d51c672828a4416a12af57220ba8a8737e2fbb"
 
+lodash@4.x, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.4:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.3, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.4:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 lodash@^4.2.0:
   version "4.17.10"
@@ -8551,6 +8630,13 @@ mat4-recompose@^1.0.3:
   resolved "https://registry.yarnpkg.com/mat4-recompose/-/mat4-recompose-1.0.4.tgz#3953c230ff2473dc772ee014a52c925cf81b0e4d"
   dependencies:
     gl-mat4 "^1.0.1"
+
+matchmediaquery@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.3.0.tgz#6f672bcdbc44de16825c6917fbcdcfb9b82607b1"
+  integrity sha512-u0dlv+VENJ+3YepvwSPBieuvnA6DWfaYa/ctwysAR13y4XLJNyt7bEVKzNj/Nvjo+50d88Pj+xL9xaSo6JmX/w==
+  dependencies:
+    css-mediaquery "^0.1.2"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -10907,13 +10993,23 @@ react-diff-view@^1.8.1:
     lodash.mapvalues "^4.6.0"
     warning "^4.0.1"
 
+react-dnd-html5-backend@5.0.x:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-5.0.1.tgz#0b578d79c5c01317c70414c8d717f632b919d4f1"
+  integrity sha1-C1eNecXAExfHBBTI1xf2MrkZ1PE=
+  dependencies:
+    autobind-decorator "^2.1.0"
+    dnd-core "^4.0.5"
+    lodash "^4.17.10"
+    shallowequal "^1.0.2"
+
 react-dnd-html5-backend@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-2.6.0.tgz#590cd1cca78441bb274edd571fef4c0b16ddcf8e"
   dependencies:
     lodash "^4.2.0"
 
-react-dnd@^2.6.0:
+react-dnd@2.6.x, react-dnd@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-2.6.0.tgz#7fa25676cf827d58a891293e3c1ab59da002545a"
   dependencies:
@@ -11002,6 +11098,16 @@ react-linkify@^0.2.2:
     prop-types "^15.5.8"
     tlds "^1.57.0"
 
+react-measure@2.x:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-measure/-/react-measure-2.3.0.tgz#75835d39abec9ae13517f35a819c160997a7a44e"
+  integrity sha512-dwAvmiOeblj5Dvpnk8Jm7Q8B4THF/f1l1HtKVi0XDecsG6LXwGvzV5R1H32kq3TW6RW64OAf5aoQxpIgLa4z8A==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    get-node-dimensions "^1.2.1"
+    prop-types "^15.6.2"
+    resize-observer-polyfill "^1.5.0"
+
 react-modal@3.x:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.3.2.tgz#b13da9490653a7c76bc0e9600323eb1079c620e7"
@@ -11056,6 +11162,15 @@ react-redux@5.x:
     lodash-es "^4.17.5"
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
+
+react-responsive@6.1.x:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-6.1.2.tgz#b9b9cc3ee35f37e80cb036f1c9038ef73aec920b"
+  integrity sha512-AXentVC/kN3KED9zhzJv2pu4vZ0i6cSHdTtbCScVV1MT6F5KXaG2qs5D7WLmhdaOvmiMX8UfmS4ZSO+WPwDt4g==
+  dependencies:
+    hyphenate-style-name "^1.0.0"
+    matchmediaquery "^0.3.0"
+    prop-types "^15.6.1"
 
 react-router-dom@4.x:
   version "4.2.2"
@@ -11140,6 +11255,11 @@ react@16.8.6:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
+
+reactabular-dnd@8.16.x:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/reactabular-dnd/-/reactabular-dnd-8.16.0.tgz#c66df1cfa08615978aa4eeb885747a1634dfc54a"
+  integrity sha512-gU2j9A90+0phiQ4SJkNxBc7tht/St5uzIxAlb2ELVtpB6C5UsZ25uoeiasv/zi6LuBwaUiIeLWe092nYx0loBA==
 
 reactabular-table@^8.14.0:
   version "8.14.0"
@@ -11392,6 +11512,11 @@ regenerator-runtime@^0.11.0:
 regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -11743,6 +11868,11 @@ requireindex@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
   integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -12260,6 +12390,11 @@ shallow-copy@0.0.1, shallow-copy@~0.0.1:
 shallowequal@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
+
+shallowequal@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 sharkdown@^0.1.0:
   version "0.1.0"
@@ -14637,6 +14772,11 @@ xterm@^3.12.2:
   version "3.12.2"
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.12.2.tgz#ec8563857c7b098973bab4dbf537f1a7c6a790c8"
   integrity sha512-FSXovDdsqIKqoayC6+zFzhaHi+A3NSceM5rgTW88DH7sS96HdwMToB2p1rW+FyNsSqfAgFwlXDRQk+fh/aHvPQ==
+
+xterm@^3.3.0:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.14.2.tgz#f1285288bdc7df7056ef4bde64311900748c3e5d"
+  integrity sha512-L50XMhfAC953/3EzmL+lq8jyD6CQ3SZ83UDrxalpKzE3d7Wo5JqehSd4yOrHYZYrijOT3pX6kBsZEI9uuZ1lmQ==
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Initial effort of merging https://github.com/kubevirt/web-ui fork features back to upstream.

New `kubevirt-plugin` is created with bare minimum functionality in terms of listing Virtual Machines.
Additional features will be moved within follow-ups.

---
Depends on:
- ~~#1584~~
- ~~https://github.com/openshift/console/pull/1586~~
- ~~https://github.com/openshift/console/pull/1600~~
- ~~#1609~~
- ~~#1613~~
- ~~#1668~~

---
TODO:
- [x] introduce support for ordering items within left-side menu (for Resource Nav Item) - wip #1609 
- [x] introduce new extension point for yaml templates (initially for Create VM from Yaml) - wip #1613 
- [x] OWNERS file
---
Some of immediate follow-ups:
- VM-status with fetching of related objects
- VM Detail page
- VM templates (list, detail)
- Create VM Wizard
