### PR TITLE
Fix envFrom e2e test script

### DIFF
--- a/frontend/integration-tests/views/environment.view.ts
+++ b/frontend/integration-tests/views/environment.view.ts
@@ -31,8 +31,8 @@ export const addVariableFrom = async(resourceName: string, resourcePrefix: strin
   await dropDownBtn.first().click();
   await textFilter.sendKeys(resourceName);
   await option.first().click();
-  await inputs.get(2).clear();
-  await inputs.get(2).sendKeys(resourcePrefix);
+  await prefix.clear();
+  await prefix.sendKeys(resourcePrefix);
   await browser.wait(until.elementToBeClickable(saveBtn), BROWSER_TIMEOUT);
   await saveBtn.click();
 };


### PR DESCRIPTION
Fix clear prefix failed when adding the second value. such as this error: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_console/1597/pull-ci-openshift-console-master-e2e-aws-console/1507

@spadgett  This update should be more stable, pls review it, thanks.