### PR TITLE
NavSection: allow plugins to define their position

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/nav.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/nav.ts
@@ -12,6 +12,7 @@ namespace ExtensionProperties {
   interface NavItem {
     section: NavSectionTitle;
     componentProps: Pick<NavLinkProps, 'name' | 'required' | 'disallowed' | 'startsWith'>;
+    mergeAfter?: string;
   }
 
   export interface HrefNavItem extends NavItem {


### PR DESCRIPTION
Within NavSection, a plugin can provide `mergeAfter` optional string property
to denote after which element will be rendered.

If `mergeAfter` is omitted or not-matching, the item is appended at the end.

First use-case: `Virtual Machines` of the `kubevirt-plugin` will be positioned after `Pods` as requested by UXD.