### PR TITLE
remove unnecessary intermediate DOM nodes

### DIFF
--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -119,7 +119,7 @@ export const resourceTitle = $('#resource-title');
 
 export const nameFilter = $('.form-control.co-text-filter');
 export const messageLbl = $('.cos-status-box');
-export const modalAnnotationsLink = $('.loading-box__loaded').element(by.partialButtonText('Annotation'));
+export const modalAnnotationsLink = $('[data-test-id=resource-summary] [data-test-id=edit-annotations]');
 
 export const visitResource = async(resource: string, name: string) => {
   await browser.get(`${appHost}/k8s/ns/${testName}/${resource}/${name}`);

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -30,18 +30,6 @@ $co-modal-ignore-warning-icon-width: 30px;
   padding: 0 0 ($grid-gutter-width / 2);
 }
 
-.co-catalog-connect {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-
-  .loading-box {
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-  }
-}
-
 .co-catalog-item-details {
   display: flex;
   margin: 0 0 10px;

--- a/frontend/public/components/catalog/catalog-page.jsx
+++ b/frontend/public/components/catalog/catalog-page.jsx
@@ -250,7 +250,7 @@ export const Catalog = connectToFlags(FLAGS.OPENSHIFT, FLAGS.SERVICE_CATALOG, FL
     }] : []),
   ];
 
-  return <Firehose resources={mock ? [] : resources} className="co-catalog-connect">
+  return <Firehose resources={mock ? [] : resources}>
     <CatalogListPage namespace={namespace} />
   </Firehose>;
 });

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -31,7 +31,7 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, reso
     .map((o, i) => <ResourceLink key={i} kind={referenceForOwnerRef(o)} name={o.name} namespace={metadata.namespace} title={o.uid} />);
   const tolerations = showTolerations ? getTolerations(resource) : null;
 
-  return <dl className="co-m-pane__details">
+  return <dl data-test-id="resource-summary" className="co-m-pane__details">
     <dt>Name</dt>
     <dd>{metadata.name || '-'}</dd>
     { metadata.namespace ? <dt>Namespace</dt> : null }
@@ -47,7 +47,7 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, reso
     {showTolerations && <dt>Tolerations</dt>}
     {showTolerations && <dd><button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyTolerations(model, resource).callback}>{pluralize(_.size(tolerations), 'Toleration')}</button></dd>}
     {showAnnotations && <dt>Annotations</dt>}
-    {showAnnotations && <dd><button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyAnnotations(model, resource).callback}>{pluralize(_.size(metadata.annotations), 'Annotation')}</button></dd>}
+    {showAnnotations && <dd><button data-test-id="edit-annotations" type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyAnnotations(model, resource).callback}>{pluralize(_.size(metadata.annotations), 'Annotation')}</button></dd>}
     {children}
     <dt>Created At</dt>
     <dd><Timestamp timestamp={metadata.creationTimestamp} /></dd>

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -89,9 +89,9 @@ const ConnectToState = connect(({k8s}, {reduxes}) => {
   });
 }, null, null, {
   areStatesEqual: (next, prev) => (next.k8s === prev.k8s),
-})(props => <div className={props.className}>
-  {inject(props.children, _.omit(props, ['children', 'className', 'reduxes']))}
-</div>);
+})(props =>
+  inject(props.children, _.omit(props, ['children', 'className', 'reduxes']))
+);
 
 const stateToProps = ({k8s}, {resources}) => {
   const k8sModels = resources.reduce((models, {kind}) => models.set(kind, k8s.getIn(['RESOURCES', 'models', kind])), ImmutableMap());
@@ -180,12 +180,11 @@ export const Firehose = connect(
       const reduxes = this.firehoses.map(({id, prop, isList, filters, optional}) => ({reduxID: id, prop, isList, filters, optional}));
       const children = inject(this.props.children, _.omit(this.props, [
         'children',
-        'className',
         'resources',
       ]));
 
       return this.props.loaded || this.firehoses.length > 0
-        ? <ConnectToState reduxes={reduxes} className={this.props.className}> {children} </ConnectToState>
+        ? <ConnectToState reduxes={reduxes}>{children}</ConnectToState>
         : null;
     }
   }
@@ -208,7 +207,6 @@ Firehose.propTypes = {
     namespace: PropTypes.string,
     selector: PropTypes.object,
     fieldSelector: PropTypes.string,
-    className: PropTypes.string,
     isList: PropTypes.bool,
     optional: PropTypes.bool,
   })).isRequired,

--- a/frontend/public/components/utils/status-box.tsx
+++ b/frontend/public/components/utils/status-box.tsx
@@ -54,7 +54,12 @@ const Data: React.FC<DataProps> = ({EmptyMsg, label, data, children}) => {
       {EmptyMsg ? <EmptyMsg /> : <EmptyBox label={label} />}
     </div>;
   }
-  return <div className="loading-box loading-box__loaded">{children}</div>;
+  return (
+    <React.Fragment>
+      {children}
+      <div className="loading-box loading-box__loaded"></div>
+    </React.Fragment>
+  );
 };
 Data.displayName = 'Data';
 


### PR DESCRIPTION
This change removes unnecessary nodes introduced by `status-box` and `firehose` which affect the ability for pages to properly control their own layout.

Firehose should never introduce intermediate nodes as its purpose is to provide data.

I don't see a reason for the `status-box` to render the extra `div` instead of simply rendering the content directly.