### PR TITLE
Add YAML template extension

### DIFF
--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -11,6 +11,7 @@ import {
   ResourceListPage,
   ResourceDetailPage,
   Perspective,
+  YAMLTemplate,
 } from '@console/plugin-sdk';
 
 // TODO(vojtech): internal code needed by plugins should be moved to console-shared package
@@ -18,6 +19,7 @@ import { PodModel } from '@console/internal/models';
 import { FLAGS } from '@console/internal/const';
 
 import * as models from './models';
+import { yamlTemplates } from './yaml-templates';
 
 type ConsumedExtensions =
   | ModelDefinition
@@ -27,7 +29,8 @@ type ConsumedExtensions =
   | ResourceClusterNavItem
   | ResourceListPage
   | ResourceDetailPage
-  | Perspective;
+  | Perspective
+  | YAMLTemplate;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -108,6 +111,13 @@ const plugin: Plugin<ConsumedExtensions> = [
         </svg>
       ),
       landingPageURL: '/search',
+    },
+  },
+  {
+    type: 'YAMLTemplate',
+    properties: {
+      model: models.FooBarModel,
+      template: yamlTemplates.getIn([models.FooBarModel, 'default']),
     },
   },
 ];

--- a/frontend/packages/console-demo-plugin/src/yaml-templates.ts
+++ b/frontend/packages/console-demo-plugin/src/yaml-templates.ts
@@ -1,0 +1,12 @@
+import { Map as ImmutableMap } from 'immutable';
+
+import { FooBarModel } from './models';
+
+export const yamlTemplates = ImmutableMap()
+  .setIn([FooBarModel, 'default'], `
+apiVersion: ${FooBarModel.apiVersion}
+kind: ${FooBarModel.kind}
+metadata:
+  name: example
+  namespace: default
+`);

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -8,6 +8,7 @@ import {
   isNavItem,
   isResourcePage,
   isPerspective,
+  isYAMLTemplate,
 } from './typings';
 
 /**
@@ -38,5 +39,9 @@ export class ExtensionRegistry {
 
   public getPerspectives() {
     return this.extensions.filter(isPerspective);
+  }
+
+  public getYAMLTemplates() {
+    return this.extensions.filter(isYAMLTemplate);
   }
 }

--- a/frontend/packages/console-plugin-sdk/src/typings/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/index.ts
@@ -75,3 +75,4 @@ export * from './models';
 export * from './nav';
 export * from './pages';
 export * from './perspective';
+export * from './yaml-templates';

--- a/frontend/packages/console-plugin-sdk/src/typings/yaml-templates.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/yaml-templates.ts
@@ -1,0 +1,18 @@
+import { Extension } from '.';
+import { K8sKind } from '@console/internal/module/k8s';
+
+namespace ExtensionProperties {
+  export interface YAMLTemplate {
+    model: K8sKind;
+    template: string;
+    templateName?: string;
+  }
+}
+
+export interface YAMLTemplate extends Extension<ExtensionProperties.YAMLTemplate> {
+  type: 'YAMLTemplate';
+}
+
+export function isYAMLTemplate(e: Extension<any>): e is YAMLTemplate {
+  return e.type === 'YAMLTemplate';
+}


### PR DESCRIPTION
This PR makes `yamlTemplates` in `public/models/yaml-templates.ts` extensible.

```ts
const plugin: Plugin<YAMLTemplate> = [
  {
    type: 'YAMLTemplate',
    properties: {
      model: FooBarModel,
      template: `
apiVersion: ${FooBarModel.apiVersion}
kind: ${FooBarModel.kind}
metadata:
  name: example
  namespace: default
`,
    },
  },
];
```

_Note: due to how [multi-line template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Multi-line_strings) work, leading whitespace within the template string should be removed._

It's also possible to pass a `templateName` (falls back to `default` if not specified):

```ts
const plugin: Plugin<YAMLTemplate> = [
  {
    type: 'YAMLTemplate',
    properties: {
      model: FooBarModel,
      template: '...',
      templateName: 'fb-compute',
    },
  },
];
```

Attempts to redefine existing templates (based on tuple key `[modelRef, templateName]`) will be logged and the conflicting templates will be discarded.

```ts
const plugin: Plugin<YAMLTemplate> = [
  {
    type: 'YAMLTemplate',
    properties: {
      model: PodModel,
      template: '...',
    },
  },
];
```

```
attempt to redefine YAML template default for model core~v1~Pod
```
