### PR TITLE
add Perspective extension and default admin perspective

### DIFF
--- a/frontend/__tests__/actions/ui.spec.ts
+++ b/frontend/__tests__/actions/ui.spec.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { ALL_NAMESPACES_KEY } from '../../public/const';
+import { ALL_NAMESPACES_KEY, LAST_PERSPECTIVE_LOCAL_STORAGE_KEY } from '../../public/const';
 
 import '../../__mocks__/localStorage';
 import store from '../../public/redux';
@@ -7,6 +7,7 @@ import * as UIActions from '../../public/actions/ui';
 import * as router from '../../public/components/utils/router';
 
 const setActiveNamespace = ns => store.dispatch(UIActions.setActiveNamespace(ns));
+const setActivePerspective = perspective => store.dispatch(UIActions.setActivePerspective(perspective));
 const getNamespacedRoute = path => UIActions.formatNamespaceRoute(UIActions.getActiveNamespace(), path);
 
 describe('ui-actions', () => {
@@ -103,6 +104,24 @@ describe('ui-actions', () => {
       setActiveNamespace(ALL_NAMESPACES_KEY);
       expect(getNamespacedRoute('/k8s/ns/foo/pods')).toEqual('/k8s/all-namespaces/pods');
       expect(getNamespacedRoute('/k8s/ns/foo/pods/WACKY_SUFFIX')).toEqual('/k8s/all-namespaces/pods');
+    });
+  });
+
+  describe('setActivePerspective', () => {
+    it('should create setActivePerspective action', () => {
+      expect(UIActions.setActivePerspective('test')).toEqual({
+        type: UIActions.ActionType.SetActivePerspective,
+        payload: {
+          perspective: 'test',
+        },
+        error: undefined,
+        meta: undefined,
+      });
+    });
+
+    it('sets active perspective in localStorage', () => {
+      setActivePerspective('test');
+      expect(localStorage.getItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY)).toEqual('test');
     });
   });
 });

--- a/frontend/__tests__/reducers/ui.spec.ts
+++ b/frontend/__tests__/reducers/ui.spec.ts
@@ -1,0 +1,52 @@
+import * as Immutable from 'immutable';
+import uiReducer, { getActivePerspective, getDefaultPerspective } from '../../public/reducers/ui';
+import { LAST_PERSPECTIVE_LOCAL_STORAGE_KEY } from '../../public/const';
+import * as UIActions from '../../public/actions/ui';
+import { RootState } from '@console/internal/redux';
+import * as plugins from '../../public/plugins';
+import '../../__mocks__/localStorage';
+
+describe('getDefaultPerspective', () => {
+  it('should default to undefined', () => {
+    expect(getDefaultPerspective()).toBeUndefined();
+  });
+
+  it('should default to undefined if perspective is not a valid extension', () => {
+    // no registry entry for perspective with id 'test'
+    localStorage.setItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY, 'test');
+    expect(getDefaultPerspective()).toBeUndefined();
+  });
+
+  it('should default to perspective extension marked default', () => {
+    // return Perspectives extension with one marked as the default
+    spyOn(plugins.registry, 'getPerspectives').and.returnValue([{
+      type: 'Perspective',
+      properties: {
+        id: 'admin',
+        default: true,
+      },
+    } as plugins.Perspective]);
+    expect(getDefaultPerspective()).toBe('admin');
+  });
+
+  it('should default to localStorage if perspective is a valid extension', () => {
+    // return Perspectives extension whose id matches that in the localStorage
+    spyOn(plugins.registry, 'getPerspectives').and.returnValue([{
+      type: 'Perspective',
+      properties: {
+        id: 'test',
+      },
+    } as plugins.Perspective]);
+    localStorage.setItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY, 'test');
+    expect(getDefaultPerspective()).toBe('test');
+  });
+});
+
+describe('getActivePerspective', () => {
+  it('should retrieve active perspective from state', () => {
+    const newState = {
+      UI: uiReducer(Immutable.Map({}), UIActions.setActivePerspective('test')),
+    } as RootState;
+    expect(getActivePerspective(newState)).toBe('test');
+  });
+});

--- a/frontend/packages/console-app/package.json
+++ b/frontend/packages/console-app/package.json
@@ -8,5 +8,8 @@
     "@console/internal": "0.0.0-fixed",
     "@console/plugin-sdk": "0.0.0-fixed",
     "@console/shared": "0.0.0-fixed"
+  },
+  "consolePlugin": {
+    "entry": "src/plugin.tsx"
   }
 }

--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { CogIcon } from '@patternfly/react-icons';
+import {
+  Plugin,
+  Perspective,
+} from '@console/plugin-sdk';
+
+type ConsumedExtensions =
+  | Perspective;
+
+const plugin: Plugin<ConsumedExtensions> = [
+  {
+    type: 'Perspective',
+    properties: {
+      id: 'admin',
+      name: 'Administrator',
+      icon: <CogIcon />,
+      landingPageURL: '/',
+      default: true,
+    },
+  },
+];
+
+export default plugin;

--- a/frontend/packages/console-demo-plugin/package.json
+++ b/frontend/packages/console-demo-plugin/package.json
@@ -8,6 +8,6 @@
     "@console/shared": "0.0.0-fixed"
   },
   "consolePlugin": {
-    "entry": "src/plugin.ts"
+    "entry": "src/plugin.tsx"
   }
 }

--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import * as _ from 'lodash-es';
 
 import {
@@ -9,6 +10,7 @@ import {
   ResourceClusterNavItem,
   ResourceListPage,
   ResourceDetailPage,
+  Perspective,
 } from '@console/plugin-sdk';
 
 // TODO(vojtech): internal code needed by plugins should be moved to console-shared package
@@ -24,7 +26,8 @@ type ConsumedExtensions =
   | ResourceNSNavItem
   | ResourceClusterNavItem
   | ResourceListPage
-  | ResourceDetailPage;
+  | ResourceDetailPage
+  | Perspective;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -85,6 +88,26 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       model: PodModel,
       loader: () => import('@console/internal/components/pod' /* webpackChunkName: "pod" */).then(m => m.PodsDetailsPage),
+    },
+  },
+  {
+    type: 'Perspective',
+    properties: {
+      id: 'test',
+      name: 'Test Perspective',
+      icon: (
+        <svg
+          style={{ verticalAlign: '-0.125em' }}
+          fill="currentColor"
+          height="1em"
+          width="1em"
+          viewBox="0 0 640 512"
+          role="img"
+        >
+          <path d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z" />
+        </svg>
+      ),
+      landingPageURL: '/search',
     },
   },
 ];

--- a/frontend/packages/console-plugin-sdk/src/codegen/__tests__/index.spec.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/__tests__/index.spec.ts
@@ -69,6 +69,17 @@ describe('codegen', () => {
         { ...pluginPackages[0] },
       ]);
     });
+
+    it('should include appPackage as a valid plugin package', () => {
+      const appPackage: PluginPackage = {
+        ...templatePackage,
+        name: 'app',
+        dependencies: {},
+        consolePlugin: { entry: 'plugin.ts' },
+      };
+
+      expect(getActivePluginPackages(appPackage, [appPackage])).toEqual([appPackage]);
+    });
   });
 
   describe('getActivePluginsModule', () => {

--- a/frontend/packages/console-plugin-sdk/src/codegen/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/index.ts
@@ -41,7 +41,8 @@ export const readPackages = (packageFiles: string[]) => {
  * Get the list of plugins to be used for the build.
  */
 export const getActivePluginPackages = (appPackage: Package, pluginPackages: PluginPackage[]) => {
-  return pluginPackages.filter(pkg => appPackage.dependencies[pkg.name] === pkg.version);
+  // active plugins include dependencies of the appPackage or the appPackage itself
+  return pluginPackages.filter(pkg => appPackage === pkg || appPackage.dependencies[pkg.name] === pkg.version);
 };
 
 /**

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -7,13 +7,13 @@ import {
   isFeatureFlag,
   isNavItem,
   isResourcePage,
+  isPerspective,
 } from './typings';
 
 /**
  * Registry used to query for Console extensions.
  */
 export class ExtensionRegistry {
-
   private readonly extensions: Extension<any>[];
 
   public constructor(plugins: ActivePlugin[]) {
@@ -36,4 +36,7 @@ export class ExtensionRegistry {
     return this.extensions.filter(isResourcePage);
   }
 
+  public getPerspectives() {
+    return this.extensions.filter(isPerspective);
+  }
 }

--- a/frontend/packages/console-plugin-sdk/src/typings/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/index.ts
@@ -74,3 +74,4 @@ export * from './features';
 export * from './models';
 export * from './nav';
 export * from './pages';
+export * from './perspective';

--- a/frontend/packages/console-plugin-sdk/src/typings/perspective.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/perspective.ts
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Extension } from '.';
+
+namespace ExtensionProperties {
+  export interface Perspective {
+    /* The perspective identifier. */
+    id: string;
+    /* The perspective display name. */
+    name: string;
+    /* The perspective display icon. */
+    icon: React.ReactElement;
+    /* The perspective landing page URL. */
+    landingPageURL: string;
+    /* Whether the perspective is the default. There can only be one default. */
+    default?: boolean;
+  }
+}
+
+export interface Perspective extends Extension<ExtensionProperties.Perspective> {
+  type: 'Perspective';
+}
+
+export function isPerspective(e: Extension<any>): e is Perspective {
+  return e.type === 'Perspective';
+}

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -4,7 +4,11 @@ import { action, ActionType as Action } from 'typesafe-actions';
 // FIXME(alecmerdler): Do not `import store`
 import store from '../redux';
 import { history } from '../components/utils/router';
-import { ALL_NAMESPACES_KEY, LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY } from '../const';
+import {
+  ALL_NAMESPACES_KEY,
+  LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
+  LAST_PERSPECTIVE_LOCAL_STORAGE_KEY,
+} from '../const';
 import { getNSPrefix } from '../components/utils/link';
 import { allModels } from '../module/k8s/k8s-models';
 import { detectFeatures } from './features';
@@ -17,6 +21,7 @@ export enum ActionType {
   SelectOverviewItem = 'selectOverviewItem',
   SelectOverviewView = 'selectOverviewView',
   SetActiveNamespace = 'setActiveNamespace',
+  SetActivePerspective = 'setActivePerspective',
   SetCreateProjectMessage = 'setCreateProjectMessage',
   SetCurrentLocation = 'setCurrentLocation',
   SetMonitoringData = 'setMonitoringData',
@@ -111,6 +116,14 @@ export const setActiveNamespace = (namespace: string = '') => {
 
   return action(ActionType.SetActiveNamespace, {namespace});
 };
+
+export const setActivePerspective = (perspective: string) => {
+  // remember the most recently-viewed perspective, which is automatically
+  // selected when returning to the console
+  localStorage.setItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY, perspective);
+  return action(ActionType.SetActivePerspective, {perspective});
+};
+
 export const beginImpersonate = (kind: string, name: string, subprotocols: string[]) => action(ActionType.BeginImpersonate, {kind, name, subprotocols});
 export const endImpersonate = () => action(ActionType.EndImpersonate);
 export const startImpersonate = (kind: string, name: string) => async(dispatch, getState) => {
@@ -188,6 +201,7 @@ export const monitoringToggleGraphs = () => action(ActionType.ToggleMonitoringGr
 const uiActions = {
   setCurrentLocation,
   setActiveNamespace,
+  setActivePerspective,
   beginImpersonate,
   endImpersonate,
   sortList,

--- a/frontend/public/const.ts
+++ b/frontend/public/const.ts
@@ -26,6 +26,7 @@ export const STORAGE_PREFIX = 'bridge';
 // This localStorage key predates the storage prefix.
 export const NAMESPACE_LOCAL_STORAGE_KEY = 'dropdown-storage-namespaces';
 export const LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-namespace-name`;
+export const LAST_PERSPECTIVE_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-perspective`;
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
 export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/community-providers-warning`;
 


### PR DESCRIPTION
Adds a new extension for contributing a `Perspective`. This is for supporting the developer perspective.
```
  export interface Perspective {
    id: string;
    name: string;
    icon: React.ReactElement;
    landingPageURL: string;
    default?: boolean;
  }
```

Changes includes:

- Contribution of default `Administrator` perspective.
- Ability to switch perspectives from the application launcher menu in the masthead as a temporary solution until PF4 and UX settle on a design for the mega-menu. Unless there are multiple perspectives registered, the actions will not show up in this menu. Therefore until we have the developer perspective merged into the repo, there won't be able visible UI related to perspectives.
- Adds redux actions, reducers, and selectors for working with perspectives.
- When the perspective is set, its ID is stored in localStorage such that a returning user will be in their last active perspective. This functionality is similar to active namespace.

fyi @rohitkrai03 