### PR TITLE
Query browser: Better handle blank query and empty API response cases

### DIFF
--- a/frontend/public/components/graphs/query-browser.tsx
+++ b/frontend/public/components/graphs/query-browser.tsx
@@ -89,9 +89,9 @@ const Graph: React.FC<GraphProps> = ({colors, domain, data, onZoom, query}) => {
   </PrometheusGraph>;
 };
 
-export const QueryBrowser: React.FC<QueryBrowserProps> = ({colors, GraphLink, metric, onDataUpdate, query, samples, timeout, timespan}) => {
-  // For the default time span, use the first of the suggested span options that is at least as long as timespan
-  const defaultSpanText = spans.find(s => parsePrometheusDuration(s) >= timespan);
+export const QueryBrowser: React.FC<QueryBrowserProps> = ({colors, defaultTimespan, GraphLink, metric, onDataUpdate, query, samples, timeout}) => {
+  // For the default time span, use the first of the suggested span options that is at least as long as defaultTimespan
+  const defaultSpanText = spans.find(s => parsePrometheusDuration(s) >= defaultTimespan);
 
   const [domain, setDomain] = React.useState();
   const [graphData, setGraphData] = React.useState();
@@ -111,6 +111,8 @@ export const QueryBrowser: React.FC<QueryBrowserProps> = ({colors, GraphLink, me
     timeout,
     timespan: span,
   });
+
+  React.useEffect(() => setUpdating(true), [query, samples]);
 
   React.useEffect(() => {
     const result = _.get(data, 'data.result');
@@ -224,11 +226,11 @@ type GraphProps = {
 
 type QueryBrowserProps = {
   colors: string[];
+  defaultTimespan: number;
   GraphLink: React.ComponentType<any>;
   metric: string;
   onDataUpdate: (data: GraphDataMetric) => void;
   query: string;
   samples?: number;
   timeout?: number;
-  timespan: number;
 };

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -198,12 +198,12 @@ const Graph_ = ({hideGraphs, metric = undefined, samples, rule}) => {
 
   return <QueryBrowser
     colors={graphColors}
+    defaultTimespan={timespan}
     GraphLink={GraphLink}
     metric={metric}
     query={query}
     samples={samples}
     timeout="5s"
-    timespan={timespan}
   />;
 };
 const Graph = connect(graphStateToProps)(Graph_);
@@ -967,6 +967,7 @@ const QueryBrowserPage = () => {
         <div className="col-xs-12">
           <QueryBrowser
             colors={graphColors}
+            defaultTimespan={30 * 60 * 1000}
             onDataUpdate={data => setMetrics(_.map(data, d => ({
               labels: _.omitBy(d.metric, (v, k) => _.startsWith(k, '__')),
               value: _.get(_.last(d.values), 1),
@@ -974,7 +975,6 @@ const QueryBrowserPage = () => {
             query={query}
             samples={600}
             timeout="5s"
-            timespan={30 * 60 * 1000}
           />
           <form onSubmit={runQueries}>
             <div className="group">


### PR DESCRIPTION
- Add message for when no query has been entered
- Add message for when the API returns no data points
- Add a React hook to start the loading indicator when the query is changed
- Rename `timespan` to `defaultTimespan ` to better represent its function