### PR TITLE
Bug 1714897 - Change deployment status checks

### DIFF
--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -136,7 +136,11 @@ export const DeploymentConfigsDetails: React.FC<{obj: K8sResourceKind}> = ({obj:
           <div className="col-sm-6">
             <ResourceSummary resource={dc} showPodSelector showNodeSelector showTolerations>
               <dt>Status</dt>
-              <dd>{dc.status.availableReplicas === dc.status.updatedReplicas ? <StatusIconAndText status="Active" /> : <StatusIconAndText status="Updating" />}</dd>
+              <dd>
+                {dc.status.availableReplicas === dc.status.updatedReplicas && dc.spec.replicas === dc.status.availableReplicas
+                  ? <StatusIconAndText status="Up to date" />
+                  : <StatusIconAndText status="Updating" />}
+              </dd>
             </ResourceSummary>
           </div>
           <div className="col-sm-6">

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -95,7 +95,11 @@ const DeploymentDetails: React.FC<DeploymentDetailsProps> = ({obj: deployment}) 
           <div className="col-sm-6">
             <ResourceSummary resource={deployment} showPodSelector showNodeSelector showTolerations>
               <dt>Status</dt>
-              <dd>{deployment.status.availableReplicas === deployment.status.updatedReplicas ? <StatusIconAndText status="Active" /> : <StatusIconAndText status="Updating" />}</dd>
+              <dd>
+                {deployment.status.availableReplicas === deployment.status.updatedReplicas && deployment.spec.replicas === deployment.status.availableReplicas
+                  ? <StatusIconAndText status="Up to date" />
+                  : <StatusIconAndText status="Updating" />}
+              </dd>
             </ResourceSummary>
           </div>
           <div className="col-sm-6">


### PR DESCRIPTION
* Change status from "Available" to "Up to date". This is more precise
  and makes sense for scaled down deployments. It also avoids confusion
  with the cluster operator available status since cluster operators are
  considered available as soon as any pods are ready.
* Only show "Up to date" when desired replicas matches actual replicas.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1714897

/assign @rhamilto 