### PR TITLE
The .co-actions-menu button within the <h1 co-resource-item> loads la…

### DIFF
--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -17,11 +17,16 @@
     padding-left: $grid-gutter-width;
     padding-right: $grid-gutter-width;
   }
-  &--breadcrumbs {
-    padding-top: 0;
-  }
   &--detail {
     border-bottom: 1px solid $color-grey-background-border;
+    // Set min-height to prevent shifting of page content when actions btn is rendered after page content
+    min-height: 90px; // h1 text + top & bottom margin + bottom border (29 + 30 + 30 + 1)
+  }
+  // Positioned after --detail to take precedence, since they will be a siblings
+  &--breadcrumbs {
+    // Set min-height to prevent shifting of page content when actions btn is rendered after page content
+    min-height: 118px; // breadcrumb text + top & bottom padding + h1 text + bottom margin + bottom border +  (21 + 25 + 12 + 29 + 30 + 1)
+    padding-top: 0;
   }
   &--logo {
     padding-top: ($grid-gutter-width / 2);


### PR DESCRIPTION
The `.co-actions-menu` button within the `<h1 co-resource-item>` loads last on the page and is slightly taller than the heading, so it causes the nav menu and detail content beneath it, to bump down when it loads. Applying a `min-height` to the parent `.co-m-nav-title `alleviates this behavior.

**bug** 
![button-page-jump2](https://user-images.githubusercontent.com/1874151/58579552-58f8bb80-8219-11e9-9bfd-840cceed6af8.gif)


**Fix**
![button-page-jump2-fix](https://user-images.githubusercontent.com/1874151/58579558-5bf3ac00-8219-11e9-9707-2276b38027e1.gif)

___________

with breadcrumbs
**bug**
![button-page-jump](https://user-images.githubusercontent.com/1874151/58579843-dae8e480-8219-11e9-8a4f-015e24f2ba10.gif)


**Fix**
![button-page-jump-fix](https://user-images.githubusercontent.com/1874151/58579617-775eb700-8219-11e9-86bb-7feca993989d.gif)



