### PR TITLE
convert dropdown markup to pf4

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -296,7 +296,7 @@ class NamespaceBarDropdowns_ extends React.Component {
       },
     ];
 
-    return <div className="co-namespace-bar__dropdowns">
+    return <div className="co-namespace-bar__dropdowns pf-l-flex pf-m-justify-content-space-between pf-m-align-items-center">
       <Dropdown
         className="co-namespace-selector"
         menuClassName="co-namespace-selector__menu"

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
-
+import { Button } from '@patternfly/react-core';
 import { ActionsMenu, ResourceIcon, KebabAction, resourcePath } from './index';
 import { ClusterServiceVersionLogo } from '../operator-lifecycle-manager';
 import { connectToModel } from '../../kinds';
@@ -30,13 +30,14 @@ export const BreadCrumbs: React.SFC<BreadCrumbsProps> = ({breadcrumbs}) => (
     }) }
   </ol>);
 
-const ActionButtons: React.SFC<ActionButtonsProps> = ({actionButtons}) => <div className="co-action-buttons">
+const ActionButtons: React.SFC<ActionButtonsProps> = ({actionButtons}) => <React.Fragment>
   {_.map(actionButtons, (actionButton, i) => {
     if (!_.isEmpty(actionButton)) {
-      return <button className={`btn ${actionButton.btnClass} co-action-buttons__btn`} onClick={actionButton.callback} key={i}>{actionButton.label}</button>;
+      return <Button variant="primary" onClick={actionButton.callback} key={i}>{actionButton.label}</Button>;
+      {/* return <button className={`btn ${actionButton.btnClass} co-action-buttons__btn`} onClick={actionButton.callback} key={i}>{actionButton.label}</button>; */}
     }
   })}
-</div>;
+</React.Fragment>;
 
 export const PageHeading = connectToModel((props: PageHeadingProps) => {
   const {kind, kindObj, detail, title, menuActions, buttonActions, obj, breadcrumbsFor, titleFunc, style} = props;
@@ -58,7 +59,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
     { breadcrumbsFor && !_.isEmpty(data) && <BreadCrumbs breadcrumbs={breadcrumbsFor(data)} /> }
     <h1 className={classNames('co-m-pane__heading', {'co-m-pane__heading--logo': isCSV})}>
       { logo }
-      { showActions && <div className="co-actions" data-test-id="details-actions">
+      { showActions && <div className="pf-l-flex pf-m-space-items-sm" data-test-id="details-actions">
         { hasButtonActions && <ActionButtons actionButtons={buttonActions.map(a => a(kindObj, data))} /> }
         { hasMenuActions && <ActionsMenu actions={menuActions.map(a => a(kindObj, data))} /> }
       </div> }
@@ -82,7 +83,7 @@ export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = 
         </Link>
         {isDeleting && <ResourceItemDeleting />}
       </div>
-      {!isDeleting && <div className="co-actions">
+      {!isDeleting && <div className="pf-l-flex pf-m-space-items-sm">
         <ActionsMenu actions={actions.map(a => a(kindObj, resource))} />
       </div>}
     </h1>

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -1,7 +1,8 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import * as classNames from 'classnames';
 import { connect } from 'react-redux';
-
+import { EllipsisVIcon } from '@patternfly/react-icons';
 import { annotationsModal, configureReplicaCountModal, taintsModal, tolerationsModal, labelsModal, podSelectorModal, deleteModal, expandPVCModal } from '../modals';
 import { DropdownMixin } from './dropdown';
 import { checkAccess, history, resourceObjPath, useAccessReview } from './index';
@@ -16,11 +17,11 @@ import { impersonateStateToProps } from '../../reducers/ui';
 import { connectToModel } from '../../kinds';
 
 const KebabItemEnabled: React.FC<KebabItemProps> = ({option, onClick}) => {
-  return <a href="#" onClick={(e) => onClick(e, option)} data-test-action={option.label}>{option.label}</a>;
+  return <button className="pf-c-dropdown__menu-item" onClick={(e) => onClick(e, option)} data-test-action={option.label}>{option.label}</button>;
 };
 
 const KebabItemDisabled: React.FC<{option: KebabOption}> = ({option}) => {
-  return <a className="disabled">{option.label}</a>;
+  return <button className="pf-c-dropdown__menu-item pf-m-disabled">{option.label}</button>;
 };
 
 const KebabItemAccessReview_ = (props: KebabItemProps & { impersonate: string }) => {
@@ -40,7 +41,7 @@ const KebabItem: React.FC<KebabItemProps> = (props) => {
 
 export const KebabItems: React.SFC<KebabItemsProps> = ({options, onClick}) => {
   const visibleOptions = _.reject(options, o => _.get(o, 'hidden', false));
-  return <ul className="dropdown-menu dropdown-menu-right dropdown-menu--block co-kebab__dropdown" data-test-id="action-items">
+  return <ul className="pf-c-dropdown__menu pf-m-align-right" data-test-id="action-items">
     {_.map(visibleOptions, (o, i) => <li key={i}>
       <KebabItem option={o} onClick={onClick} />
     </li>)}
@@ -248,9 +249,9 @@ export class Kebab extends DropdownMixin {
   render() {
     const {options, isDisabled} = this.props;
 
-    return <div ref={this.dropdownElement} className="co-kebab" onMouseEnter={this.onHover} onFocus={this.onHover}>
-      <button type="button" aria-label="Actions" disabled={isDisabled} aria-haspopup="true" className="btn btn-link co-kebab__button" onClick={this.toggle} data-test-id="kebab-button">
-        <span className="fa fa-ellipsis-v co-kebab__icon" aria-hidden="true"></span>
+    return <div ref={this.dropdownElement} className={classNames({'pf-c-dropdown': true, 'pf-m-expanded': this.state.active})} onFocus={this.onHover}>
+      <button type="button" aria-label="Actions" aria-expanded={this.state.active} disabled={isDisabled} aria-haspopup="true" className="pf-c-dropdown__toggle pf-m-plain" onClick={this.toggle} data-test-id="kebab-button">
+        <EllipsisVIcon />
       </button>
       {(!isDisabled && this.state.active) && <KebabItems options={options} onClick={this.onClick} />}
     </div>;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -300,6 +300,8 @@ kbd {
   &:hover {
     color: var(--pf-global--Color--dark-100);
   }
+  font-size: $font-size-base;
+  --pf-c-dropdown__menu-item--FontSize: 14px;
 }
 
 .pf-c-dropdown__toggle .pf-c-dropdown__toggle-icon {

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -57,7 +57,14 @@
 @import '~patternfly-react-extensions/dist/sass/filter-side-panel';
 @import '~patternfly-react-extensions/dist/sass/properties-side-panel';
 @import '~patternfly-react-extensions/dist/sass/vertical-tabs';
+
+// Note: PF Sass load order is important and can cause issues if changed
 @import '~@patternfly/patternfly/sass-utilities/all';
 @import "~@patternfly/patternfly/_variables";
 @import "~@patternfly/patternfly/_fonts";
 @import "~@patternfly/patternfly/_base";
+@import '~@patternfly/patternfly/layouts/Flex/flex';
+@import '~@patternfly/patternfly/utilities/Display/display';
+@import '~@patternfly/patternfly/utilities/Flex/flex';
+
+


### PR DESCRIPTION
PR to convert existing dropdowns over to PF4 HTML/CSS. Conversions to PF-React JS would come later...

**Actions Detail Dropdown**
Note: if the "Add Secret to Workload" button remains unchanged and uses Bootstrap styles, it will not match PF4 Dropdown styles. Should we extend the scope of this to include PF4 Button conversion globally? That should not be terrible, even though we have a lot of BS3 `<button>`'s still.
<img width="1423" alt="actions-dropdown" src="https://user-images.githubusercontent.com/4237045/58587461-7767b280-822b-11e9-8349-0995dde5d789.png">

_Update_: An alternative which may work for now and allow us to avoid restyling all Button's now is just updating the `co-action-button` styles to be `height: 100%; `. This would limit the scope of this to just Dropdown's.

<img width="1432" alt="Screen Shot 2019-05-30 at 9 26 43 AM" src="https://user-images.githubusercontent.com/4237045/58635994-4768ef80-82bd-11e9-8da9-8cbb344a875f.png">

Without this, we have differently sized Buttons.
<img width="1432" alt="Screen Shot 2019-05-30 at 9 26 54 AM" src="https://user-images.githubusercontent.com/4237045/58636025-59e32900-82bd-11e9-95fe-315dc4c3e6ad.png">

**Projects Dropdown**
This one remains unchanged. It is an exception and does not follow the norm of the other Dropdowns, even though some code is shared. This is a better fit for the [PF4 Context Selector](https://pf4.patternfly.org/components/ContextSelector/examples/) i.m.h.o.
<img width="1421" alt="projects-dropdown" src="https://user-images.githubusercontent.com/4237045/58587658-ee9d4680-822b-11e9-9814-c854561a04d3.png">

**Add Dropdown**
<img width="1423" alt="add-dropdown" src="https://user-images.githubusercontent.com/4237045/58587674-ff4dbc80-822b-11e9-8d9a-7b76cf7e1d94.png">

**Kebab Dropdown**
This is how it looks with the table as it is today. With the PF4 Table, see [this comment](https://github.com/openshift/console/pull/1465#discussion_r288746643)

<img width="1423" alt="kebab-dropdown" src="https://user-images.githubusercontent.com/4237045/58587712-155b7d00-822c-11e9-8408-f459eacdda25.png">

**Create Dropdown**

<img width="1425" alt="create-dropdown" src="https://user-images.githubusercontent.com/4237045/58587787-3ae88680-822c-11e9-9dbf-b9797b0ba129.png">


**Masthead Dropdown**
Made fonts 14px globally for menu items to match our interim font size standard. These would be affected too.
<img width="1423" alt="masthead-dropdown" src="https://user-images.githubusercontent.com/4237045/58587589-be55a800-822b-11e9-8b97-23edc63cd2c6.png">

cc: @spadgett 