### PR TITLE
Fix timeout prop type for Prometheus API poller

### DIFF
--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -82,7 +82,7 @@ type AreaProps = {
   samples?: number;
   theme?: any;
   tickCount?: number;
-  timeout?: number;
+  timeout?: string;
   timespan?: number;
   title?: string;
 }

--- a/frontend/public/components/graphs/helpers.ts
+++ b/frontend/public/components/graphs/helpers.ts
@@ -36,6 +36,6 @@ type PrometheusURLProps = {
   namespace?: string;
   query: string;
   samples: number;
-  timeout?: number;
+  timeout?: string;
   timespan: number;
 };

--- a/frontend/public/components/graphs/prometheus-poll-hook.ts
+++ b/frontend/public/components/graphs/prometheus-poll-hook.ts
@@ -45,6 +45,6 @@ type PrometheusPollProps = {
   namespace?: string;
   query: string;
   samples?: number;
-  timeout?: number;
+  timeout?: string;
   timespan?: number;
 }

--- a/frontend/public/components/graphs/query-browser.tsx
+++ b/frontend/public/components/graphs/query-browser.tsx
@@ -89,7 +89,7 @@ const Graph: React.FC<GraphProps> = ({colors, domain, data, onZoom}) => {
   </div>;
 };
 
-const QueryBrowser_: React.FC<QueryBrowserProps> = ({colors, defaultTimespan, GraphLink, hideGraphs, metric, onDataUpdate, query, samples, timeout}) => {
+const QueryBrowser_: React.FC<QueryBrowserProps> = ({colors, defaultTimespan, GraphLink, hideGraphs, metric, onDataUpdate, query, samples}) => {
   // For the default time span, use the first of the suggested span options that is at least as long as defaultTimespan
   const defaultSpanText = spans.find(s => parsePrometheusDuration(s) >= defaultTimespan);
 
@@ -108,7 +108,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({colors, defaultTimespan, Gr
     endpoint: PrometheusEndpoint.QUERY_RANGE,
     query,
     samples,
-    timeout,
+    timeout: '5s',
     timespan: span,
   });
 
@@ -245,5 +245,4 @@ type QueryBrowserProps = {
   onDataUpdate: (data: GraphDataMetric) => void;
   query: string;
   samples?: number;
-  timeout?: number;
 };

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -203,7 +203,6 @@ const Graph_ = ({hideGraphs, metric = undefined, samples, rule}) => {
     metric={metric}
     query={query}
     samples={samples}
-    timeout="5s"
   />;
 };
 const Graph = connect(graphStateToProps)(Graph_);
@@ -975,7 +974,6 @@ const QueryBrowserPage = () => {
             })))}
             query={query}
             samples={600}
-            timeout="5s"
           />
           <form onSubmit={runQueries}>
             <div className="group">


### PR DESCRIPTION
The `timeout` parameter accepted by the Prometheus API is actually a
string with format `[0-9]+[smhdwy]`.

Set `timeout` directly in `QueryBrowser` instead of taking it as a prop.