### PR TITLE
Code fixups

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/features.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/features.ts
@@ -3,7 +3,9 @@ import { K8sKind } from '@console/internal/module/k8s';
 
 namespace ExtensionProperties {
   export interface ModelFeatureFlag {
+    /** If a CRD for this model exists, the feature will be enabled. */
     model: K8sKind;
+    /** The name of the feature flag. */
     flag: string;
   }
 }
@@ -15,10 +17,10 @@ export interface ModelFeatureFlag extends Extension<ExtensionProperties.ModelFea
 // TODO(vojtech): add ActionFeatureFlag
 export type FeatureFlag = ModelFeatureFlag;
 
-export function isModelFeatureFlag(e: Extension<any>): e is ModelFeatureFlag {
+export const isModelFeatureFlag = (e: Extension<any>): e is ModelFeatureFlag => {
   return e.type === 'FeatureFlag/Model';
-}
+};
 
-export function isFeatureFlag(e: Extension<any>): e is FeatureFlag {
+export const isFeatureFlag = (e: Extension<any>): e is FeatureFlag => {
   return isModelFeatureFlag(e);
-}
+};

--- a/frontend/packages/console-plugin-sdk/src/typings/models.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/models.ts
@@ -3,6 +3,7 @@ import { K8sKind } from '@console/internal/module/k8s';
 
 namespace ExtensionProperties {
   export interface ModelDefinition {
+    /** Additional Kubernetes model definitions to register with Console. */
     models: K8sKind[];
   }
 }
@@ -11,6 +12,6 @@ export interface ModelDefinition extends Extension<ExtensionProperties.ModelDefi
   type: 'ModelDefinition';
 }
 
-export function isModelDefinition(e: Extension<any>): e is ModelDefinition {
+export const isModelDefinition = (e: Extension<any>): e is ModelDefinition => {
   return e.type === 'ModelDefinition';
-}
+};

--- a/frontend/packages/console-plugin-sdk/src/typings/nav.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/nav.ts
@@ -10,8 +10,11 @@ import {
 
 namespace ExtensionProperties {
   interface NavItem {
+    /** Nav section to which this item belongs to. */
     section: NavSectionTitle;
+    /** Props to pass to the corresponding `NavLink` component. */
     componentProps: Pick<NavLinkProps, 'name' | 'required' | 'disallowed' | 'startsWith'>;
+    /** Nav item after which this item should be placed. */
     mergeAfter?: string;
   }
 
@@ -42,18 +45,18 @@ export interface ResourceClusterNavItem extends Extension<ExtensionProperties.Re
 
 export type NavItem = HrefNavItem | ResourceNSNavItem | ResourceClusterNavItem;
 
-export function isHrefNavItem(e: Extension<any>): e is HrefNavItem {
+export const isHrefNavItem = (e: Extension<any>): e is HrefNavItem => {
   return e.type === 'NavItem/Href';
-}
+};
 
-export function isResourceNSNavItem(e: Extension<any>): e is ResourceNSNavItem {
+export const isResourceNSNavItem = (e: Extension<any>): e is ResourceNSNavItem => {
   return e.type === 'NavItem/ResourceNS';
-}
+};
 
-export function isResourceClusterNavItem(e: Extension<any>): e is ResourceClusterNavItem {
+export const isResourceClusterNavItem = (e: Extension<any>): e is ResourceClusterNavItem => {
   return e.type === 'NavItem/ResourceCluster';
-}
+};
 
-export function isNavItem(e: Extension<any>): e is NavItem {
+export const isNavItem = (e: Extension<any>): e is NavItem => {
   return isHrefNavItem(e) || isResourceNSNavItem(e) || isResourceClusterNavItem(e);
-}
+};

--- a/frontend/packages/console-plugin-sdk/src/typings/pages.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/pages.ts
@@ -4,7 +4,9 @@ import { K8sKind } from '@console/internal/module/k8s';
 
 namespace ExtensionProperties {
   export interface ResourcePage {
+    /** Model associated with the resource page. */
     model: K8sKind;
+    /** Loader for the corresponding React page component. */
     loader: () => Promise<React.ComponentType<any>>;
   }
 }
@@ -19,14 +21,14 @@ export interface ResourceDetailPage extends Extension<ExtensionProperties.Resour
 
 export type ResourcePage = ResourceListPage | ResourceDetailPage;
 
-export function isResourceListPage(e: Extension<any>): e is ResourceListPage {
+export const isResourceListPage = (e: Extension<any>): e is ResourceListPage => {
   return e.type === 'ResourcePage/List';
-}
+};
 
-export function isResourceDetailPage(e: Extension<any>): e is ResourceDetailPage {
+export const isResourceDetailPage = (e: Extension<any>): e is ResourceDetailPage => {
   return e.type === 'ResourcePage/Detail';
-}
+};
 
-export function isResourcePage(e: Extension<any>): e is ResourcePage {
+export const isResourcePage = (e: Extension<any>): e is ResourcePage => {
   return isResourceListPage(e) || isResourceDetailPage(e);
-}
+};

--- a/frontend/packages/console-plugin-sdk/src/typings/perspective.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/perspective.ts
@@ -3,15 +3,15 @@ import { Extension } from '.';
 
 namespace ExtensionProperties {
   export interface Perspective {
-    /* The perspective identifier. */
+    /** The perspective identifier. */
     id: string;
-    /* The perspective display name. */
+    /** The perspective display name. */
     name: string;
-    /* The perspective display icon. */
+    /** The perspective display icon. */
     icon: React.ReactElement;
-    /* The perspective landing page URL. */
+    /** The perspective landing page URL. */
     landingPageURL: string;
-    /* Whether the perspective is the default. There can only be one default. */
+    /** Whether the perspective is the default. There can only be one default. */
     default?: boolean;
   }
 }
@@ -20,6 +20,6 @@ export interface Perspective extends Extension<ExtensionProperties.Perspective> 
   type: 'Perspective';
 }
 
-export function isPerspective(e: Extension<any>): e is Perspective {
+export const isPerspective = (e: Extension<any>): e is Perspective => {
   return e.type === 'Perspective';
-}
+};

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -30,7 +30,7 @@ const mergePluginChild = (Children: React.ReactElement[], pluginChild: React.Rea
   }
 };
 
-const getNavLinkFromItem = (item: plugins.NavItem, key: number): React.ReactElement | null => {
+const getNavLinkFromItem = (item: plugins.NavItem, key: number) => {
   if (plugins.isHrefNavItem(item)) {
     return <HrefLink key={key} {...item.properties.componentProps} />;
   }
@@ -117,7 +117,7 @@ export const NavSection = connect(navSectionStateToProps)(
       (section) => plugins.registry.getNavItems(section)
     );
 
-    mapChild = (c: React.ReactElement): React.ReactElement | null => {
+    mapChild = (c: React.ReactElement) => {
       if (!c) {
         return null;
       }
@@ -154,7 +154,7 @@ export const NavSection = connect(navSectionStateToProps)(
       const { isOpen, activeChild } = this.state;
       const isActive = !!activeChild;
 
-      const Children: React.ReactElement[] | null = React.Children.map(children, this.mapChild) || [];
+      const Children = React.Children.map(children, this.mapChild) || [];
 
       this.getPluginNavItems(title).forEach((item, index) => {
         const pluginChild = this.mapChild(getNavLinkFromItem(item, index));


### PR DESCRIPTION
- document properties of all Console extensions
- use `fn = () => {}` form for function declarations
- remove redundant type annotations in nav section module