### PR TITLE
temporarily disable formatOnSave vscode

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,16 +1,17 @@
 {
-  "[javascript]": {
-    "editor.formatOnSave": true
-  },
-  "[javascriptreact]": {
-    "editor.formatOnSave": true
-  },
-  "[typescript]": {
-    "editor.formatOnSave": true
-  },
-  "[typescriptreact]": {
-    "editor.formatOnSave": true
-  },
+  // TODO uncomment once we enable new eslint & prettier support across the entire project
+  // "[javascript]": {
+  //   "editor.formatOnSave": true
+  // },
+  // "[javascriptreact]": {
+  //   "editor.formatOnSave": true
+  // },
+  // "[typescript]": {
+  //   "editor.formatOnSave": true
+  // },
+  // "[typescriptreact]": {
+  //   "editor.formatOnSave": true
+  // },
 
   "eslint.validate": [
     "javascript",


### PR DESCRIPTION
The vscode settings were part of my eslint PR.
We do want to enable `formatOnSave` however this may be a bit early until we format the entire project with prettier. Currently there are 13k+ formatting errors if we enable prettier on the `public` dir. Most files in `public` dir will result in larger changes with `formatOnSave` enabled as people continue to develop with the old eslint settings.

/cc @vojtechszocs @spadgett 