### PR TITLE
revert changes to status-box loading-box__loaded

### DIFF
--- a/frontend/public/components/utils/status-box.tsx
+++ b/frontend/public/components/utils/status-box.tsx
@@ -55,10 +55,9 @@ const Data: React.FC<DataProps> = ({EmptyMsg, label, data, children}) => {
     </div>;
   }
   return (
-    <React.Fragment>
+    <div className="loading-box loading-box__loaded">
       {children}
-      <div className="loading-box loading-box__loaded"></div>
-    </React.Fragment>
+    </div>
   );
 };
 Data.displayName = 'Data';


### PR DESCRIPTION
Revert's the change which moved the `loading-box loading-box__loaded` DOM node in `status-box` outside of the hierarchy as it's affected by a CSS rule related to `co-m-pane__body`.

https://github.com/openshift/console/commit/5854e7290a2700a4632f1a9adbce80ea08033d49#r33749840

CSS rule:
https://github.com/openshift/console/blob/6e13331966d52fb767524f4aa8d4535feb171975/frontend/public/style/_common.scss#L25-L27

IMO the use of the `:last-child` pseudo selector for `co-m-pane__body` is problematic pattern when not properly scoped within a single component. As shown here this rule can be easily broken when components return root nodes containing `co-m-pane__body` or multiple nodes within a `React.Fragment`. Reverting for now until more time can be dedicated to looking into an alternative.

/cc @rhamilto 