### PR TITLE
Allow specialized views of already registered models

### DIFF
--- a/frontend/packages/console-demo-plugin/src/models.ts
+++ b/frontend/packages/console-demo-plugin/src/models.ts
@@ -13,3 +13,20 @@ export const FooBarModel: K8sKind = {
   id: 'foobar',
   crd: true,
 };
+
+export const MyTemplatesModel: K8sKind = {
+  label: 'My Specialized Template',
+  labelPlural: 'My Specialized Templates',
+  apiVersion: 'v1',
+  path: 'templates',
+  apiGroup: 'template.openshift.io',
+  plural: 'mytemplates',
+  namespaced: true,
+  abbr: 'MT',
+  kind: 'Template',
+  id: 'mytemplate',
+  specialized: true,
+  selector: {
+    matchLabels: { my: 'yes' },
+  },
+};

--- a/frontend/public/components/utils/resource-link.jsx
+++ b/frontend/public/components/utils/resource-link.jsx
@@ -12,7 +12,7 @@ import { FLAGS } from '../../const';
 const unknownKinds = new Set();
 
 export const resourcePathFromModel = (model, name, namespace) => {
-  const {path, plural, namespaced, crd, specialized} = model;
+  const {plural, namespaced, crd} = model;
 
   let url = '/k8s/';
 
@@ -26,10 +26,8 @@ export const resourcePathFromModel = (model, name, namespace) => {
 
   if (crd) {
     url += referenceForModel(model);
-  } else if (specialized) {
+  } else if (plural) {
     url += plural;
-  } else if (path) {
-    url += path;
   }
 
   if (name) {

--- a/frontend/public/components/utils/resource-link.jsx
+++ b/frontend/public/components/utils/resource-link.jsx
@@ -12,7 +12,7 @@ import { FLAGS } from '../../const';
 const unknownKinds = new Set();
 
 export const resourcePathFromModel = (model, name, namespace) => {
-  const {path, namespaced, crd} = model;
+  const {path, plural, namespaced, crd, specialized} = model;
 
   let url = '/k8s/';
 
@@ -26,6 +26,8 @@ export const resourcePathFromModel = (model, name, namespace) => {
 
   if (crd) {
     url += referenceForModel(model);
+  } else if (specialized) {
+    url += plural;
   } else if (path) {
     url += path;
   }

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -564,6 +564,7 @@ export type K8sKind = {
 
   id?: string;
   crd?: boolean;
+  specialized?: boolean;
   apiVersion: string;
   apiGroup?: string;
   namespaced?: boolean;

--- a/frontend/public/module/k8s/k8s-models.ts
+++ b/frontend/public/module/k8s/k8s-models.ts
@@ -33,7 +33,7 @@ k8sModels = k8sModels.withMutations(map => {
   const baseModelCount = map.size;
   const pluginModels = _.flatMap(plugins.registry.getModelDefinitions().map(md => md.properties.models));
 
-  const pluginModelsToAdd = pluginModels.filter(model => !hasModel(model));
+  const pluginModelsToAdd = pluginModels.filter(model => (model.specialized || !hasModel(model)));
   map.merge(modelsToMap(pluginModelsToAdd));
 
   _.difference(pluginModels, pluginModelsToAdd).forEach(model => {


### PR DESCRIPTION
**Allow specialized views of already registered models.**

Currently we do not allow for a template to register a new view of a model already existing.

Sometimes it is useful to have a specialized view of an already registered  model, for example, kubevirt use a view called "Virtual machine templates" to view openshift templates with specialized features. 

Currently the new view is rejected because it is falsely flagged as duplication of the regular template view. 

This PR allow for a plugin author to flag a plugin model as a `specialized` view, to bypass the check for duplication views.

Screenshot:
![Peek 2019-06-04 15-56](https://user-images.githubusercontent.com/2181522/58882934-21d94d00-86e6-11e9-8edf-6e7babee1dee.gif)
