### PR TITLE
Align prettier printWidth configuration for .js and .ts files

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "arrowParens": "always",
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/frontend/packages/eslint-plugin-console/lib/config/prettier.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/prettier.js
@@ -6,43 +6,14 @@ module.exports = {
   plugins: ['prettier'],
 
   rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        singleQuote: true,
-        trailingComma: 'all',
-        bracketSpacing: true,
-        jsxBracketSameLine: false,
-        arrowParens: 'always',
-        printWidth: 120,
-        semi: true,
-        useTabs: false,
-      },
-      {
-        usePrettierrc: false,
-      },
-    ],
+    'prettier/prettier': 'error',
   },
 
   overrides: [
     {
       files: ['*.ts', '*.tsx'],
       rules: merge(require('./rules/prettier-typescript'), {
-        'prettier/prettier': [
-          'error',
-          {
-            parser: 'typescript',
-            singleQuote: true,
-            trailingComma: 'all',
-            bracketSpacing: true,
-            jsxBracketSameLine: false,
-            arrowParens: 'always',
-            printWidth: 100,
-          },
-          {
-            usePrettierrc: false,
-          },
-        ],
+        'prettier/prettier': 'error',
       }),
     },
   ],

--- a/frontend/packages/eslint-plugin-console/lib/config/react.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/react.js
@@ -15,7 +15,11 @@ module.exports = {
 
   plugins: ['react-hooks'],
 
-  rules: merge(require('./rules/react'), require('./rules/react-hooks'), require('./rules/airbnb-base-overrides')),
+  rules: merge(
+    require('./rules/react'),
+    require('./rules/react-hooks'),
+    require('./rules/airbnb-base-overrides'),
+  ),
 
   overrides: [
     {

--- a/frontend/packages/eslint-plugin-console/lib/config/rules/airbnb-base-overrides.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/rules/airbnb-base-overrides.js
@@ -5,9 +5,6 @@ module.exports = {
   // Require or disallow named function expressions
   'func-names': 'off',
 
-  // max line length
-  'max-len': ['error', { code: 120, comments: 100, ignoreUrls: true }],
-
   // Disallow nested ternary expressions
   'no-nested-ternary': 'off',
 


### PR DESCRIPTION
And introduce .prettierrc file to enable support for editor formatters which depend on it