### PR TITLE
align all print width lint rules

### DIFF
--- a/frontend/packages/eslint-plugin-console/lib/config/prettier.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/prettier.js
@@ -14,7 +14,7 @@ module.exports = {
         bracketSpacing: true,
         jsxBracketSameLine: false,
         arrowParens: 'always',
-        printWidth: 120,
+        printWidth: 100,
         semi: true,
         useTabs: false,
       },

--- a/frontend/packages/eslint-plugin-console/lib/config/react.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/react.js
@@ -15,7 +15,11 @@ module.exports = {
 
   plugins: ['react-hooks'],
 
-  rules: merge(require('./rules/react'), require('./rules/react-hooks'), require('./rules/airbnb-base-overrides')),
+  rules: merge(
+    require('./rules/react'),
+    require('./rules/react-hooks'),
+    require('./rules/airbnb-base-overrides'),
+  ),
 
   overrides: [
     {

--- a/frontend/packages/eslint-plugin-console/lib/config/rules/airbnb-base-overrides.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/rules/airbnb-base-overrides.js
@@ -5,9 +5,6 @@ module.exports = {
   // Require or disallow named function expressions
   'func-names': 'off',
 
-  // max line length
-  'max-len': ['error', { code: 120, comments: 100, ignoreUrls: true }],
-
   // Disallow nested ternary expressions
   'no-nested-ternary': 'off',
 


### PR DESCRIPTION
Sets the prettier `printWidth` to 100.

This only affects a single file in the `packages` dir

/cc @vojtechszocs @spadgett 
fyi @jtomasek 