### PR TITLE
Fix overlapping text in Machine Configs table

### DIFF
--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -60,19 +60,19 @@ const MachineConfigHeader: React.SFC<any> = props => <ListHeader>
 </ListHeader>;
 
 const MachineConfigRow: React.SFC<MachineConfigRowProps> = ({obj}) => <div className="row co-resource-list__item">
-  <div className="col-xs-6  col-sm-4  col-md-3  col-lg-2">
+  <div className="col-xs-6 col-sm-4 col-md-3 col-lg-2">
     <ResourceLink kind={machineConfigReference} name={obj.metadata.name} title={obj.metadata.name} />
   </div>
-  <div className="hidden-xs col-sm-6  col-md-4  col-lg-3">
+  <div className="hidden-xs col-sm-6 col-md-4 col-lg-3 co-break-word">
     { _.get(obj, ['metadata', 'annotations', 'machineconfiguration.openshift.io/generated-by-controller-version'], '-')}
   </div>
-  <div className="hidden-xs hidden-sm col-md-3  col-lg-3">
+  <div className="hidden-xs hidden-sm col-md-3 col-lg-3">
     {_.get(obj, 'spec.config.ignition.version') || '-'}
   </div>
   <div className="hidden-xs hidden-sm hidden-md col-lg-2 co-break-word">
     {_.get(obj, 'spec.osImageURL') || '-'}
   </div>
-  <div className="col-xs-6  col-sm-2  col-md-2  col-lg-2">
+  <div className="col-xs-6 col-sm-2 col-md-2 col-lg-2">
     {fromNow(obj.metadata.creationTimestamp)}
   </div>
   <div className="dropdown-kebab-pf">


### PR DESCRIPTION
After: 
![Screen Shot 2019-06-04 at 1 42 10 PM](https://user-images.githubusercontent.com/895728/58901712-b71d1700-86cf-11e9-8e2a-d7b2b55b2c8d.png)
 
Figured I'd fix this in master in spite of the pending table changes so this fix could go in the z stream.