### PR TITLE
Temp fix to restore About modal opening

### DIFF
--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -369,7 +369,7 @@ class MastheadToolbar_ extends React.Component {
             <ToolbarItem className="hidden-xs">{this._renderMenu(false)}</ToolbarItem>
           </ToolbarGroup>
         </Toolbar>
-        {showAboutModal && <AboutModal isOpen={showAboutModal} closeAboutModal={this._closeAboutModal} />}
+        <AboutModal isOpen={showAboutModal} closeAboutModal={this._closeAboutModal} />
       </React.Fragment>
     );
   }


### PR DESCRIPTION
Temporarily remove the boolean surrounding `<AboutModal>` so the about modal works until https://github.com/patternfly/patternfly-react/pull/2153 lands and we're able to bump @patternfly/react-core.  I believe this was working before because we had unnecessary state changes resulting in re-rendering.  https://github.com/openshift/console/commit/4199a8d65c2c61baf243ce80c3300d7e2aae8393#diff-ad1a22990eba749c0aeabdc5a78fe485 removed those unnecessary state changes.