### PR TITLE
add extension to contribute arbitrary pages

### DIFF
--- a/frontend/__tests__/components/resource-pages.spec.tsx
+++ b/frontend/__tests__/components/resource-pages.spec.tsx
@@ -1,10 +1,10 @@
-import { resourceDetailPages, resourceListPages } from '../../public/components/resource-pages';
+import { resourceDetailsPages, resourceListPages } from '../../public/components/resource-pages';
 import { isGroupVersionKind } from '../../public/module/k8s';
 
-describe('resourceDetailPages', () => {
+describe('resourceDetailsPages', () => {
 
   it('contains a map of promises which resolve to every resource detail view component', (done) => {
-    resourceDetailPages.forEach((promise, name) => {
+    resourceDetailsPages.forEach((promise, name) => {
       expect(name.length > 0).toBe(true);
       expect(isGroupVersionKind(name)).toBe(true);
 

--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -9,9 +9,10 @@ import {
   ResourceNSNavItem,
   ResourceClusterNavItem,
   ResourceListPage,
-  ResourceDetailPage,
+  ResourceDetailsPage,
   Perspective,
   YAMLTemplate,
+  RoutePage,
 } from '@console/plugin-sdk';
 
 // TODO(vojtech): internal code needed by plugins should be moved to console-shared package
@@ -28,9 +29,10 @@ type ConsumedExtensions =
   | ResourceNSNavItem
   | ResourceClusterNavItem
   | ResourceListPage
-  | ResourceDetailPage
+  | ResourceDetailsPage
   | Perspective
-  | YAMLTemplate;
+  | YAMLTemplate
+  | RoutePage;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -80,7 +82,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'ResourcePage/List',
+    type: 'Page/Resource/List',
     properties: {
       model: PodModel,
       loader: () =>
@@ -90,7 +92,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'ResourcePage/Detail',
+    type: 'Page/Resource/Details',
     properties: {
       model: PodModel,
       loader: () =>
@@ -116,7 +118,7 @@ const plugin: Plugin<ConsumedExtensions> = [
           <path d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z" />
         </svg>
       ),
-      landingPageURL: '/search',
+      landingPageURL: '/test',
     },
   },
   {
@@ -131,8 +133,8 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       perspective: 'test',
       componentProps: {
-        name: 'Test Search',
-        href: '/search',
+        name: 'Test Home',
+        href: '/test',
       },
     },
   },
@@ -145,6 +147,14 @@ const plugin: Plugin<ConsumedExtensions> = [
         name: 'Test Projects',
         resource: 'projects',
       },
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: '/test',
+      render: () => <h1>Test Page</h1>,
     },
   },
 ];

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -6,9 +6,11 @@ import {
   isModelDefinition,
   isFeatureFlag,
   isNavItem,
-  isResourcePage,
+  isResourceListPage,
+  isResourceDetailsPage,
   isPerspective,
   isYAMLTemplate,
+  isRoutePage,
 } from './typings';
 
 /**
@@ -33,8 +35,16 @@ export class ExtensionRegistry {
     return this.extensions.filter(isNavItem);
   }
 
-  public getResourcePages() {
-    return this.extensions.filter(isResourcePage);
+  public getResourceListPages() {
+    return this.extensions.filter(isResourceListPage);
+  }
+
+  public getResourceDetailsPages() {
+    return this.extensions.filter(isResourceDetailsPage);
+  }
+
+  public getRoutePages() {
+    return this.extensions.filter(isRoutePage);
   }
 
   public getPerspectives() {

--- a/frontend/packages/console-plugin-sdk/src/typings/pages.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/pages.ts
@@ -1,34 +1,72 @@
 import * as React from 'react';
-import { K8sKind } from '@console/internal/module/k8s';
+import { RouteProps, RouteComponentProps } from 'react-router';
+import { K8sKind, K8sResourceKindReference } from '@console/internal/module/k8s';
 import { Extension } from './extension';
 
+type LazyLoader<T> = () => Promise<React.ComponentType<T>>;
+
 namespace ExtensionProperties {
-  export interface ResourcePage {
+  export interface ResourcePage<T> {
     /** Model associated with the resource page. */
     model: K8sKind;
     /** Loader for the corresponding React page component. */
-    loader: () => Promise<React.ComponentType<any>>;
+    loader: LazyLoader<T>;
   }
+
+  export type ResourceListPage = ResourcePage<{
+    /** See https://reacttraining.com/react-router/web/api/match */
+    match?: RouteComponentProps['match'];
+    /** The resource kind scope. */
+    kind?: K8sResourceKindReference;
+    /** Whether the page should assign focus when loaded. */
+    autoFocus?: boolean;
+    /** Whether the page should mock the UI empty state. */
+    mock?: boolean;
+    /** The namespace scope. */
+    namespace?: string;
+  }>;
+
+  export type ResourceDetailsPage = ResourcePage<{
+    /** See https://reacttraining.com/react-router/web/api/match */
+    match?: RouteComponentProps['match'];
+    /** The resource kind scope. */
+    kind?: K8sResourceKindReference;
+    /** The namespace scope. */
+    namespace?: string;
+    /** The page name. */
+    name?: string;
+  }>;
+
+  // Maps to react-router#https://reacttraining.com/react-router/web/api/Route
+  // See https://reacttraining.com/react-router/web/api/Route
+  export type RoutePage = Omit<RouteProps, 'location'> & {
+    /** Loader for the corresponding React page component. */
+    loader?: LazyLoader<RouteComponentProps>;
+    /** Any valid URL path or array of paths that path-to-regexp@^1.7.0 understands. */
+    path: string | string[];
+  };
 }
 
-export interface ResourceListPage extends Extension<ExtensionProperties.ResourcePage> {
-  type: 'ResourcePage/List';
+export interface ResourceListPage extends Extension<ExtensionProperties.ResourceListPage> {
+  type: 'Page/Resource/List';
 }
 
-export interface ResourceDetailPage extends Extension<ExtensionProperties.ResourcePage> {
-  type: 'ResourcePage/Detail';
+export interface ResourceDetailsPage extends Extension<ExtensionProperties.ResourceDetailsPage> {
+  type: 'Page/Resource/Details';
 }
 
-export type ResourcePage = ResourceListPage | ResourceDetailPage;
+export interface RoutePage extends Extension<ExtensionProperties.RoutePage> {
+  type: 'Page/Route';
+}
 
 export const isResourceListPage = (e: Extension<any>): e is ResourceListPage => {
-  return e.type === 'ResourcePage/List';
+  return e.type === 'Page/Resource/List';
 };
 
-export const isResourceDetailPage = (e: Extension<any>): e is ResourceDetailPage => {
-  return e.type === 'ResourcePage/Detail';
+export const isResourceDetailsPage = (e: Extension<any>): e is ResourceDetailsPage => {
+  return e.type === 'Page/Resource/Details';
 };
 
-export const isResourcePage = (e: Extension<any>): e is ResourcePage => {
-  return isResourceListPage(e) || isResourceDetailPage(e);
+export const isRoutePage = (e: Extension<any>): e is RoutePage => {
+  return e.type === 'Page/Route';
 };

--- a/frontend/public/components/resource-list.tsx
+++ b/frontend/public/components/resource-list.tsx
@@ -8,7 +8,7 @@ import { ErrorPage404 } from './error';
 import { withStartGuide } from './start-guide';
 import { AsyncComponent, LoadingBox } from './utils';
 import { DefaultPage, DefaultDetailsPage } from './default-resource';
-import { resourceListPages, resourceDetailPages } from './resource-pages';
+import { resourceListPages, resourceDetailsPages } from './resource-pages';
 import {
   apiVersionForReference,
   isGroupVersionKind,
@@ -64,7 +64,7 @@ export const ResourceDetailsPage = connectToPlural((props: ResourceDetailsPagePr
   const ref = props.match.path.indexOf('customresourcedefinitions') === -1 ? referenceForModel(kindObj) : null;
   const componentLoader = props.match.params.appName
     ? () => import('./operator-lifecycle-manager/clusterserviceversion-resource' /* webpackChunkName: "csv-resource" */).then(m => m.ClusterServiceVersionResourcesDetailsPage)
-    : resourceDetailPages.get(ref, () => Promise.resolve(DefaultDetailsPage));
+    : resourceDetailsPages.get(ref, () => Promise.resolve(DefaultDetailsPage));
 
   return <React.Fragment>
     <Helmet>

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -64,7 +64,7 @@ import {
 
 import * as plugins from '../plugins';
 
-export const resourceDetailPages = ImmutableMap<GroupVersionKind | string, () => Promise<React.ComponentType<any>>>()
+export const resourceDetailsPages = ImmutableMap<GroupVersionKind | string, () => Promise<React.ComponentType<any>>>()
   .set(referenceForModel(ClusterServiceClassModel), () => import('./cluster-service-class' /* webpackChunkName: "cluster-service-class" */).then(m => m.ClusterServiceClassDetailsPage))
   .set(referenceForModel(ClusterServiceBrokerModel), () => import('./cluster-service-broker' /* webpackChunkName: "cluster-service-broker" */).then(m => m.ClusterServiceBrokerDetailsPage))
   .set(referenceForModel(ClusterServicePlanModel), () => import('./cluster-service-plan' /* webpackChunkName: "cluster-service-plan" */).then(m => m.ClusterServicePlanDetailsPage))
@@ -121,7 +121,7 @@ export const resourceDetailPages = ImmutableMap<GroupVersionKind | string, () =>
   .set(referenceForModel(ClusterVersionModel), () => import('./cluster-settings/cluster-version' /* webpackChunkName: "cluster-version" */).then(m => m.ClusterVersionDetailsPage))
   .set(referenceForModel(OAuthModel), () => import('./cluster-settings/oauth' /* webpackChunkName: "oauth" */).then(m => m.OAuthDetailsPage))
   .withMutations(map => {
-    plugins.registry.getResourcePages().filter(plugins.isResourceDetailPage).forEach(page => {
+    plugins.registry.getResourceDetailsPages().forEach(page => {
       map.set(referenceForModel(page.properties.model), page.properties.loader);
     });
   });
@@ -181,7 +181,7 @@ export const resourceListPages = ImmutableMap<GroupVersionKind | string, () => P
   .set(referenceForModel(InstallPlanModel), () => import('./operator-lifecycle-manager/install-plan' /* webpackChunkName: "install-plan" */).then(m => m.InstallPlansPage))
   .set(referenceForModel(ClusterOperatorModel), () => import('./cluster-settings/cluster-operator' /* webpackChunkName: "cluster-operator" */).then(m => m.ClusterOperatorPage))
   .withMutations(map => {
-    plugins.registry.getResourcePages().filter(plugins.isResourceListPage).forEach(page => {
+    plugins.registry.getResourceListPages().forEach(page => {
       map.set(referenceForModel(page.properties.model), page.properties.loader);
     });
   });


### PR DESCRIPTION
Adds extension to allow plugins to contribute pages which render arbitrary react components. This is required by the dev console to render pages that are not based on a single resource and therefore cannot be contributed through the existing resource list / details page extensions.

### Changes
* Updated demo plugin to contribute new page linked to nav item
* renamed `resourceDetailPages` to `resourceDetailsPages`
* Updated typescript types for resource details / list page extensions to align with their counterpart in core
* Renamed `type` of existing extensions `ResourcePage/List` and `ResourcePage/Detail`
  * This would be a _breaking_ change for existing PRs
  * I wanted to align all page extensions to use the same prefix. Please comment.

/cc @vojtechszocs @spadgett 
fyi @jtomasek @rohitkrai03 