### PR TITLE
Add updates alert to about modal

### DIFF
--- a/frontend/public/components/_about-modal.scss
+++ b/frontend/public/components/_about-modal.scss
@@ -12,4 +12,10 @@
     color: var(--pf-global--color--100);
     margin-bottom: var(--pf-global--spacer--xl);
   }
+  .co-about-modal__alert {
+    margin-bottom: var(--pf-global--spacer--xl);
+  }
+  .co-about-modal__alert h4 {
+    line-height: var(--pf-global--LineHeight--md);
+  }
 }

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import { AboutModal as PfAboutModal, TextContent, TextList, TextListItem } from '@patternfly/react-core';
+import { Alert, AboutModal as PfAboutModal, TextContent, TextList, TextListItem } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
 
 import { FLAGS } from '../const';
 import { connectToFlags } from '../reducers/features';
@@ -9,8 +10,9 @@ import { Firehose } from './utils';
 import { ClusterVersionModel } from '../models';
 import { ClusterVersionKind, referenceForModel, UpdateHistory } from '../module/k8s';
 import { k8sVersion } from '../module/status';
+import { hasAvailableUpdates } from '../module/k8s/cluster-settings';
 
-const AboutModalItems: React.FC<AboutModalItemsProps> = ({cv}) => {
+const AboutModalItems: React.FC<AboutModalItemsProps> = ({closeAboutModal, cv}) => {
   const [kubernetesVersion, setKubernetesVersion] = React.useState('');
   React.useEffect(() => {
     k8sVersion()
@@ -21,32 +23,35 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({cv}) => {
   const channel: string = _.get(cv, 'data.spec.channel');
   const lastUpdate: UpdateHistory = _.get(cv, 'data.status.history[0]');
   return (
-    <TextContent>
-      <TextList component="dl">
-        {lastUpdate && (
-          <React.Fragment>
-            <TextListItem component="dt">OpenShift Version</TextListItem>
-            <TextListItem component="dd">{lastUpdate.state === 'Partial' ? `Updating to ${lastUpdate.version}` : lastUpdate.version}</TextListItem>
-          </React.Fragment>
-        )}
-        <TextListItem component="dt">Kubernetes Version</TextListItem>
-        <TextListItem component="dd">{kubernetesVersion}</TextListItem>
-        {channel && (
-          <React.Fragment>
-            <TextListItem component="dt">Channel</TextListItem>
-            <TextListItem component="dd">{channel}</TextListItem>
-          </React.Fragment>
-        )}
-        {clusterID && (
-          <React.Fragment>
-            <TextListItem component="dt">Cluster ID</TextListItem>
-            <TextListItem component="dd">{clusterID}</TextListItem>
-          </React.Fragment>
-        )}
-        <TextListItem component="dt">API Server</TextListItem>
-        <TextListItem component="dd">{window.SERVER_FLAGS.kubeAPIServerURL}</TextListItem>
-      </TextList>
-    </TextContent>
+    <React.Fragment>
+      {hasAvailableUpdates(cv.data) && <Alert className="co-about-modal__alert" variant="info" title={<React.Fragment>Update available. <Link to="/settings/cluster" onClick={closeAboutModal}>View Cluster Settings</Link></React.Fragment>} />}
+      <TextContent>
+        <TextList component="dl">
+          {lastUpdate && (
+            <React.Fragment>
+              <TextListItem component="dt">OpenShift Version</TextListItem>
+              <TextListItem component="dd">{lastUpdate.state === 'Partial' ? `Updating to ${lastUpdate.version}` : lastUpdate.version}</TextListItem>
+            </React.Fragment>
+          )}
+          <TextListItem component="dt">Kubernetes Version</TextListItem>
+          <TextListItem component="dd">{kubernetesVersion}</TextListItem>
+          {channel && (
+            <React.Fragment>
+              <TextListItem component="dt">Channel</TextListItem>
+              <TextListItem component="dd">{channel}</TextListItem>
+            </React.Fragment>
+          )}
+          {clusterID && (
+            <React.Fragment>
+              <TextListItem component="dt">Cluster ID</TextListItem>
+              <TextListItem component="dd">{clusterID}</TextListItem>
+            </React.Fragment>
+          )}
+          <TextListItem component="dt">API Server</TextListItem>
+          <TextListItem component="dd">{window.SERVER_FLAGS.kubeAPIServerURL}</TextListItem>
+        </TextList>
+      </TextContent>
+    </React.Fragment>
   );
 };
 AboutModalItems.displayName = 'AboutModalItems';
@@ -65,10 +70,10 @@ const AboutModal_: React.FC<AboutModalProps> = (props) => {
       productName=""
       brandImageSrc={details.logoImg}
       brandImageAlt={details.productName}
+      noAboutModalBoxContentContainer={true}
     >
       {!customBranding && <p>OpenShift is Red Hat&apos;s container application platform that allows developers to quickly develop, host,
         and scale applications in a cloud environment.</p>}
-      <br />
       <Firehose resources={resources}>
         <AboutModalItems {...props as any} />
       </Firehose>
@@ -79,6 +84,7 @@ export const AboutModal = connectToFlags(FLAGS.CLUSTER_VERSION)(AboutModal_);
 AboutModal.displayName = 'AboutModal';
 
 type AboutModalItemsProps = {
+  closeAboutModal: () => void;
   cv?: {
     data?: ClusterVersionKind;
   };


### PR DESCRIPTION
Added an alert to the about modal when updates are available. 

<img width="1348" alt="Screen Shot 2019-06-04 at 3 29 36 PM" src="https://user-images.githubusercontent.com/7014965/58908176-de7ae080-86dd-11e9-9cd0-5d6d84f923c0.png">

I had to override a line height style for the alert's h4 so it would conform to the usual PatternFly look.

Fixes [CONSOLE-1405](https://jira.coreos.com/browse/CONSOLE-1405).

@openshift/team-ux-review, can you please review?