### PR TITLE
Improve API definition lookup for resources

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 
-import { getStoredSwagger, K8sKind, SwaggerDefinition, SwaggerDefinitions } from '../../module/k8s';
+import { getDefinitionKey, getStoredSwagger, K8sKind, SwaggerDefinition, SwaggerDefinitions } from '../../module/k8s';
 import { ResourceSidebarWrapper, sidebarScrollTop } from './resource-sidebar';
 import { CamelCaseWrap, LinkifyExternal } from '../utils';
 
@@ -29,9 +29,7 @@ export const ExploreTypeSidebar: React.FC<ExploreTypeSidebarProps> = (props) => 
   }
   const currentSelection = _.last(drilldownHistory);
   // Show the current selected property or the top-level definition for the kind.
-  const currentPath = currentSelection
-    ? currentSelection.path
-    : [Object.keys(allDefinitions).find(key => key.endsWith(`${kindObj.apiVersion.replace('/', '.')}.${kindObj.kind}`))];
+  const currentPath = currentSelection ? currentSelection.path : [getDefinitionKey(kindObj, allDefinitions)];
   const currentDefinition: SwaggerDefinition = _.get(allDefinitions, currentPath) || {};
 
   // Prefer the description saved in `currentSelection`. It won't always be defined in the definition itself.

--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -2,10 +2,20 @@ import * as _ from 'lodash-es';
 
 import { STORAGE_PREFIX } from '../../const';
 import { coFetchJSON } from '../../co-fetch';
-import { SwaggerDefinitions } from './';
+import { K8sKind, referenceForModel, SwaggerDefinitions } from './';
 
 const SWAGGER_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/swagger-definitions`;
 const SWAGGER_TIMESTAMP_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/swagger-last-updated`;
+
+export const getDefinitionKey = _.memoize((model: K8sKind, definitions: SwaggerDefinitions): string => {
+  return _.findKey(definitions, (def: SwaggerDefinition) => {
+    return _.some(def['x-kubernetes-group-version-kind'], ({group, version, kind}) => {
+      return (model.apiGroup || '') === (group || '') &&
+        model.apiVersion === version &&
+        model.kind === kind;
+    });
+  });
+}, referenceForModel);
 
 export const getStoredSwagger = (): SwaggerDefinitions => {
   const json = window.localStorage.getItem(SWAGGER_LOCAL_STORAGE_KEY);


### PR DESCRIPTION
Use `x-kubernetes-group-version-kind` instead of relying on a particular format of the API definition keys.

/assign @rhamilto 