### PR TITLE
Installed Operators UI updates

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -60,7 +60,7 @@ describe(ClusterServiceVersionRow.displayName, () => {
 
     expect(col.find(ResourceKebab).props().resource).toEqual(testClusterServiceVersion);
     expect(col.find(ResourceKebab).props().kind).toEqual(referenceForModel(ClusterServiceVersionModel));
-    expect(col.find(ResourceKebab).props().actions.length).toEqual(2);
+    expect(col.find(ResourceKebab).props().actions.length).toEqual(1);
   });
 
   it('renders clickable column for app logo and name', () => {
@@ -88,7 +88,7 @@ describe(ClusterServiceVersionRow.displayName, () => {
   it('renders column for app status', () => {
     const col = wrapper.find('.row').childAt(3);
 
-    expect(col.childAt(0).text()).toEqual(` ${CSVConditionReason.CSVReasonInstallSuccessful}`);
+    expect(col.childAt(0).text()).toEqual(CSVConditionReason.CSVReasonInstallSuccessful);
   });
 
   it('renders "disabling" status if CSV has `deletionTimestamp`', () => {

--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -88,7 +88,7 @@ describe(ClusterServiceVersionRow.displayName, () => {
   it('renders column for app status', () => {
     const col = wrapper.find('.row').childAt(3);
 
-    expect(col.childAt(0).text()).toEqual(CSVConditionReason.CSVReasonInstallSuccessful);
+    expect(col.childAt(0).text()).toEqual(` ${CSVConditionReason.CSVReasonInstallSuccessful}`);
   });
 
   it('renders "disabling" status if CSV has `deletionTimestamp`', () => {

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -111,12 +111,6 @@ const listFilters = {
     }
     return filters.selected.has(resource.kind);
   },
-  'clusterserviceversion-status': (filters, csv) => {
-    if (!filters || !filters.selected || !filters.selected.size) {
-      return true;
-    }
-    return filters.selected.has(_.get(csv.status, 'reason')) || !_.includes(filters.all, _.get(csv.status, 'reason'));
-  },
 
   'packagemanifest-name': (filter, pkg) => fuzzyCaseInsensitive(filter, (pkg.status.defaultChannel
     ? pkg.status.channels.find(ch => ch.name === pkg.status.defaultChannel)

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -47,13 +47,14 @@ export const ClusterServiceVersionHeader: React.SFC = () => <ListHeader>
   <ColHead className="col-lg-3 col-md-3 hidden-sm hidden-xs">Provided APIs</ColHead>
 </ListHeader>;
 
-const menuActions = [Kebab.factory.Edit, Kebab.factory.Delete];
+const menuActions = [Kebab.factory.Edit];
 
 export const ClusterServiceVersionRow = withFallback<ClusterServiceVersionRowProps>(({obj}) => {
   const route = `/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${obj.metadata.name}`;
 
+  const statusString = _.get(obj, 'status.reason', ClusterServiceVersionPhase.CSVPhaseUnknown);
   const installStatus = obj.status && obj.status.phase !== ClusterServiceVersionPhase.CSVPhaseFailed
-    ? <span>{_.get(obj, 'status.reason', ClusterServiceVersionPhase.CSVPhaseUnknown)}</span>
+    ? <span>{(statusString === 'Copied' || statusString === 'InstallSucceeded') && <i aria-hidden="true" className="pficon pficon-ok" />} {statusString}</span>
     : <span className="co-error"><i className="fa fa-times-circle co-icon-space-r" /> Failed</span>;
 
   return <div className="row co-resource-list__item">
@@ -102,14 +103,6 @@ export const ClusterServiceVersionsPage = connect(stateToProps)((props: ClusterS
     Installed Operators are represented by Cluster Service Versions within this namespace. For more information, see the <ExternalLink href="https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/architecture.md" text="Operator Lifecycle Manager documentation" />. Or create an Operator and Cluster Service Version using the <ExternalLink href="https://github.com/operator-framework/operator-sdk" text="Operator SDK" />.
   </p>;
 
-  const allFilterValues = [CSVConditionReason.CSVReasonInstallSuccessful, CSVConditionReason.CSVReasonCopied];
-  const rowFilters = [{
-    type: 'clusterserviceversion-status',
-    selected: allFilterValues,
-    reducer: (csv: ClusterServiceVersionKind) => _.get(csv.status, 'reason'),
-    items: allFilterValues.map(status => ({id: status, title: status})),
-  }];
-
   return <React.Fragment>
     <PageHeading title="Installed Operators" />
     <ListPage
@@ -118,7 +111,6 @@ export const ClusterServiceVersionsPage = connect(stateToProps)((props: ClusterS
       kind={referenceForModel(ClusterServiceVersionModel)}
       ListComponent={ClusterServiceVersionList}
       helpText={helpText}
-      rowFilters={rowFilters}
       showTitle={false} />
   </React.Fragment>;
 });

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -3,6 +3,7 @@ import { Link, match as RouterMatch } from 'react-router-dom';
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';
 import { Alert } from 'patternfly-react';
+import * as classNames from 'classnames';
 
 import { ProvidedAPIsPage, ProvidedAPIPage } from './clusterserviceversion-resource';
 import { DetailsPage, ListHeader, ColHead, List, ListPage } from '../factory';
@@ -53,9 +54,10 @@ export const ClusterServiceVersionRow = withFallback<ClusterServiceVersionRowPro
   const route = `/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${obj.metadata.name}`;
 
   const statusString = _.get(obj, 'status.reason', ClusterServiceVersionPhase.CSVPhaseUnknown);
+  const showSuccessIcon = statusString === 'Copied' || statusString === 'InstallSucceeded';
   const installStatus = obj.status && obj.status.phase !== ClusterServiceVersionPhase.CSVPhaseFailed
-    ? <span>{(statusString === 'Copied' || statusString === 'InstallSucceeded') && <i aria-hidden="true" className="pficon pficon-ok" />} {statusString}</span>
-    : <span className="co-error"><i className="fa fa-times-circle co-icon-space-r" /> Failed</span>;
+    ? <span className={classNames(showSuccessIcon && 'co-icon-and-text')}>{showSuccessIcon && <i aria-hidden="true" className="pficon pficon-ok co-icon-and-text__icon" />}{statusString}</span>
+    : <span className="co-error co-icon-and-text"><i className="fa fa-times-circle co-icon-space-r co-icon-and-text__icon" /> Failed</span>;
 
   return <div className="row co-resource-list__item">
     <div className="col-lg-3 col-md-4 col-sm-4 col-xs-6" style={{display: 'flex', alignItems: 'center'}}>


### PR DESCRIPTION
I updated the actions in kebab menu, removed filtering, and added a success icon to the "Copied" and "InstallSucceeded" status states.

<img width="1055" alt="Screen Shot 2019-06-05 at 4 36 39 PM" src="https://user-images.githubusercontent.com/7014965/58988668-2a965580-87b0-11e9-8461-3853df8dbce8.png">

[I added a Jira issue](https://jira.coreos.com/browse/CONSOLE-1521) for adding "Edit Subscription" and "Uninstall Operator" to the kebab menu. We're going to have to do it as a follow-on since CSVs cannot currently link to Subscriptions. Per Alec, we can only link from Subscriptions to CSVs right now.

Fixes [CONSOLE-1462](https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-1462).
Fixes [OLM-903](https://jira.coreos.com/browse/OLM-903)

@openshift/team-ux-review, can you please review?