### PR TITLE
Fix OLM Create Subscription Namespace

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/catalog-source.tsx
@@ -86,7 +86,7 @@ export const CreateSubscriptionYAML: React.SFC<CreateSubscriptionYAMLProps> = (p
             namespace: default
           spec:
             source: ${new URLSearchParams(props.location.search).get('catalog')}
-            sourceNamespace: ${pkg.status.catalogSourceNamespace}
+            sourceNamespace: ${new URLSearchParams(props.location.search).get('catalogNamespace')}
             name: ${pkg.metadata.name}
             startingCSV: ${channel.currentCSV}
             channel: ${channel.name}


### PR DESCRIPTION
### Description

It's possible to create a `Subscription` which will not resolve (mainly affects end-to-end tests, since no one is creating custom `CatalogSources` right now). Will only be needed until https://github.com/openshift/console/pull/1627 is merged which removes this UI completely.

Unblocks https://github.com/operator-framework/operator-lifecycle-manager/pull/890