### PR TITLE
Display binary data

### DIFF
--- a/frontend/public/components/configmap-and-secret-data.tsx
+++ b/frontend/public/components/configmap-and-secret-data.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Base64 } from 'js-base64';
+import { saveAs } from 'file-saver';
 
 import { CopyToClipboard, EmptyBox, SectionHeading } from './utils';
 
@@ -8,14 +9,36 @@ export const MaskedData: React.FC<{}> = () => <React.Fragment>
   <span aria-hidden="true">&bull;&bull;&bull;&bull;&bull;</span>
 </React.Fragment>;
 
-export const ConfigMapData: React.FC<ConfigMapDataProps> = ({data}) => {
+const downloadBinary = (key, value) => {
+  const rawBinary = window.atob(value);
+  const rawBinaryLength = rawBinary.length;
+  const array = new Uint8Array(new ArrayBuffer(rawBinaryLength));
+  for (let i = 0; i < rawBinaryLength; i++) {
+    array[i] = rawBinary.charCodeAt(i);
+  }
+  const blob = new Blob([array], {type: 'data:application/octet-stream;'});
+  saveAs(blob, key);
+};
+
+export const ConfigMapBinaryData: React.FC<DownloadValueProps> = ({data}) => {
+  const dl = [];
+  Object.keys(data || {}).sort().forEach(k => {
+    const value = data[k];
+    dl.push(<dt key={`${k}-k`}>{k}</dt>);
+    dl.push(<dd key={`${k}-v`}><button className="btn btn-link btn-link--no-btn-default-values" type="button" onClick={() => downloadBinary(k, value)}>Save File</button></dd>);
+  });
+  return dl.length ? <dl>{dl}</dl> : <EmptyBox label="Binary Data" />;
+};
+ConfigMapBinaryData.displayName = 'ConfigMapBinaryData';
+
+export const ConfigMapData: React.FC<ConfigMapDataProps> = ({data, label}) => {
   const dl = [];
   Object.keys(data || {}).sort().forEach(k => {
     const value = data[k];
     dl.push(<dt key={`${k}-k`}>{k}</dt>);
     dl.push(<dd key={`${k}-v`}><CopyToClipboard value={value} /></dd>);
   });
-  return dl.length ? <dl>{dl}</dl> : <EmptyBox label="Data" />;
+  return dl.length ? <dl>{dl}</dl> : <EmptyBox label={label} />;
 };
 ConfigMapData.displayName = 'ConfigMapData';
 
@@ -61,6 +84,11 @@ type KeyValueData = {
 };
 
 type ConfigMapDataProps = {
+  data: KeyValueData;
+  label: string;
+};
+
+type DownloadValueProps = {
   data: KeyValueData;
 };
 

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { ColHead, DetailsPage, List, ListHeader, ListPage, ResourceRow } from './factory';
-import { ConfigMapData } from './configmap-and-secret-data';
+import { ConfigMapData, ConfigMapBinaryData } from './configmap-and-secret-data';
 import { Kebab, SectionHeading, navFactory, ResourceKebab, ResourceLink, ResourceSummary } from './utils';
 import { fromNow } from './utils/datetime';
 
@@ -37,7 +37,11 @@ const ConfigMapDetails = ({obj: configMap}) => {
     </div>
     <div className="co-m-pane__body">
       <SectionHeading text="Data" />
-      <ConfigMapData data={configMap.data} />
+      <ConfigMapData data={configMap.data} label="Data" />
+    </div>
+    <div className="co-m-pane__body">
+      <SectionHeading text="Binary Data" />
+      <ConfigMapBinaryData data={configMap.binaryData} />
     </div>
   </React.Fragment>;
 };


### PR DESCRIPTION
Not sure if showing them in a `CopyToClipboard` component is the right way, but we are doing it in the origin-web-console as well, but opened for discussion.

Screen:
<img width="1164" alt="Screen Shot 2019-06-07 at 17 59 57" src="https://user-images.githubusercontent.com/1668218/59117756-dd9cb580-894e-11e9-8af8-47b04cc414cb.png">


@openshift/team-ux-review @spadgett PTAL