### PR TITLE
kubevirt: Add Status column to VmList 

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/table-filters.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/table-filters.ts
@@ -1,0 +1,22 @@
+import * as _ from 'lodash';
+
+import {
+  getSimpleVmStatus,
+  VM_SIMPLE_STATUS_ALL,
+  VM_SIMPLE_STATUS_TO_TEXT,
+} from 'kubevirt-web-ui-components';
+import { Filter } from '@console/shared';
+
+export const vmStatusFilter: Filter = {
+  type: 'vm-status',
+  selected: VM_SIMPLE_STATUS_ALL,
+  reducer: getSimpleVmStatus,
+  items: VM_SIMPLE_STATUS_ALL.map((status) => ({
+    id: status,
+    title: VM_SIMPLE_STATUS_TO_TEXT[status],
+  })),
+  filter: (statuses, vm) => {
+    const status = getSimpleVmStatus(vm);
+    return statuses.selected.has(status) || !_.includes(statuses.all, status);
+  },
+};


### PR DESCRIPTION
The `State` column is added into `VmList` page.

Depends on:
- [x] #1682
- [x] #1693 
- [x] #1735 
- [ ] #1839 
- [x] #1761

TODO:
- [x] extension point for filters - wip #1693, #1735
- [x] VM Status filters

---

![vmStatus](https://user-images.githubusercontent.com/17194943/60249079-48913a80-98c4-11e9-94e4-c570d6024476.png)

