### PR TITLE
Fix Delete Subscription Redirect

### DIFF
--- a/frontend/__tests__/components/modals/disable-application-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/disable-application-modal.spec.tsx
@@ -3,14 +3,14 @@ import { ShallowWrapper, shallow } from 'enzyme';
 import Spy = jasmine.Spy;
 import * as _ from 'lodash-es';
 
-import { DisableApplicationModal, DisableApplicationModalProps, DisableApplicationModalState } from '../../../public/components/modals/disable-application-modal';
+import { DisableApplicationModal, DisableApplicationModalProps } from '../../../public/components/modals/disable-application-modal';
 import { ModalTitle, ModalSubmitFooter } from '../../../public/components/factory/modal';
 import { testSubscription } from '../../../__mocks__/k8sResourcesMocks';
 import { SubscriptionKind } from '../../../public/components/operator-lifecycle-manager/index';
 import { ClusterServiceVersionModel, SubscriptionModel } from '../../../public/models';
 
 describe(DisableApplicationModal.name, () => {
-  let wrapper: ShallowWrapper<DisableApplicationModalProps, DisableApplicationModalState>;
+  let wrapper: ShallowWrapper<DisableApplicationModalProps>;
   let k8sKill: Spy;
   let k8sGet: Spy;
   let k8sPatch: Spy;
@@ -31,7 +31,7 @@ describe(DisableApplicationModal.name, () => {
     cancel = jasmine.createSpy('cancel');
     subscription = {..._.cloneDeep(testSubscription), status: {installedCSV: 'testapp.v1.0.0'}};
 
-    wrapper = shallow(<DisableApplicationModal subscription={subscription} k8sKill={k8sKill} k8sGet={k8sGet} k8sPatch={k8sPatch} close={close} cancel={cancel} />);
+    wrapper = shallow(<DisableApplicationModal subscription={subscription} k8sKill={k8sKill} k8sGet={k8sGet} k8sPatch={k8sPatch} close={close} cancel={cancel} />).dive();
   });
 
   it('renders a modal form', () => {
@@ -82,7 +82,7 @@ describe(DisableApplicationModal.name, () => {
   });
 
   it('does not call `props.k8sKill` to delete `ClusterServiceVersion` if `state.deleteCSV` is false', (done) => {
-    wrapper = wrapper.setState({deleteCSV: false});
+    wrapper.find('input').simulate('click');
     wrapper = wrapper.setProps({subscription: testSubscription});
 
     spyAndExpect(close)(null).then(() => {
@@ -94,8 +94,6 @@ describe(DisableApplicationModal.name, () => {
   });
 
   it('adds delete options with `propagationPolicy` if cascading delete checkbox is checked', (done) => {
-    wrapper = wrapper.setState({deleteCSV: true});
-
     spyAndExpect(close)(null).then(() => {
       expect(k8sKill.calls.argsFor(0)[3]).toEqual({kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy: 'Foreground'});
       expect(k8sKill.calls.argsFor(1)[3]).toEqual({kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy: 'Foreground'});

--- a/frontend/public/components/modals/disable-application-modal.tsx
+++ b/frontend/public/components/modals/disable-application-modal.tsx
@@ -2,62 +2,59 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 
 import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory/modal';
-import { PromiseComponent, history, resourceListPathFromModel } from '../utils';
+import { history, resourceListPathFromModel, withHandlePromise } from '../utils';
 import { ClusterServiceVersionKind, SubscriptionKind } from '../operator-lifecycle-manager';
 import { K8sKind, K8sResourceKind } from '../../module/k8s';
 import { ClusterServiceVersionModel, SubscriptionModel } from '../../models';
 
-export class DisableApplicationModal extends PromiseComponent<DisableApplicationModalProps, DisableApplicationModalState> {
-  public state: DisableApplicationModalState;
+export const DisableApplicationModal = withHandlePromise((props: DisableApplicationModalProps) => {
+  const [deleteCSV, setDeleteCSV] = React.useState(true);
 
-  constructor(public props: DisableApplicationModalProps) {
-    super(props);
-    this.state.deleteCSV = true;
-  }
-
-  private submit(event): void {
+  const submit = (event) => {
     event.preventDefault();
 
-    const {subscription, k8sKill} = this.props;
+    const {subscription, k8sKill} = props;
     const deleteOptions = {kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy: 'Foreground'};
     const promises = [k8sKill(SubscriptionModel, subscription, {}, deleteOptions)]
-      .concat(_.get(this.props.subscription, 'status.installedCSV') && this.state.deleteCSV
+      .concat(_.get(subscription, 'status.installedCSV') && deleteCSV
         ? k8sKill(ClusterServiceVersionModel, {metadata: {name: subscription.status.installedCSV, namespace: subscription.metadata.namespace}} as ClusterServiceVersionKind, {}, deleteOptions).catch(() => Promise.resolve())
         : []);
 
-    this.handlePromise(Promise.all(promises)).then(() => {
-      this.props.close();
-      history.push(resourceListPathFromModel(SubscriptionModel, subscription.metadata.namespace));
+    props.handlePromise(Promise.all(promises)).then(() => {
+      props.close();
+
+      if (new RegExp(`/${subscription.metadata.name}(/|$)`).test(window.location.pathname)) {
+        history.push(resourceListPathFromModel(SubscriptionModel, subscription.metadata.namespace));
+      }
     });
-  }
+  };
 
-  render() {
-    const {name} = this.props.subscription.spec;
+  return <form onSubmit={submit} name="form" className="modal-content co-catalog-install-modal">
+    <ModalTitle className="modal-header">Remove Operator Subscription</ModalTitle>
+    <ModalBody>
+      <div>
+        <p>
+          This will remove the <b>{name}</b> subscription from <i>{props.subscription.metadata.namespace}</i> and the Operator will no longer receive updates.
+        </p>
+      </div>
+      <div>
+        <label className="co-delete-modal-checkbox-label">
+          <input type="checkbox" checked={deleteCSV} onChange={() => setDeleteCSV(!deleteCSV)} />
+          &nbsp;&nbsp; <strong>Also completely remove the Operator from the selected namespace.</strong>
+        </label>
+      </div>
+    </ModalBody>
+    <ModalSubmitFooter inProgress={props.inProgress} errorMessage={props.errorMessage} cancel={props.cancel} submitText="Remove" />
+  </form>;
+});
 
-    return <form onSubmit={this.submit.bind(this)} name="form" className="modal-content co-catalog-install-modal">
-      <ModalTitle className="modal-header">Remove Operator Subscription</ModalTitle>
-      <ModalBody>
-        <div>
-          <p>
-            This will remove the <b>{name}</b> subscription from <i>{this.props.subscription.metadata.namespace}</i> and the Operator will no longer receive updates.
-          </p>
-        </div>
-        <div>
-          <label className="co-delete-modal-checkbox-label">
-            <input type="checkbox" checked={this.state.deleteCSV} onChange={() => this.setState({deleteCSV: !this.state.deleteCSV})} />
-            &nbsp;&nbsp; <strong>Also completely remove the Operator from the selected namespace.</strong>
-          </label>
-        </div>
-      </ModalBody>
-      <ModalSubmitFooter inProgress={this.state.inProgress} errorMessage={this.state.errorMessage} cancel={this.props.cancel.bind(this)} submitText="Remove" />
-    </form>;
-  }
-}
-
-export const createDisableApplicationModal = createModalLauncher<DisableApplicationModalProps>(DisableApplicationModal);
+export const createDisableApplicationModal = createModalLauncher(DisableApplicationModal);
 
 export type DisableApplicationModalProps = {
-  cancel: (e: Event) => void;
+  handlePromise: <T>(promise: Promise<T>) => Promise<T>;
+  inProgress: boolean;
+  errorMessage: string;
+  cancel: (error: any) => void;
   close: () => void;
   k8sKill: (kind: K8sKind, resource: K8sResourceKind, options: any, json: any) => Promise<any>;
   k8sGet: (kind: K8sKind, name: string, namespace: string) => Promise<K8sResourceKind>;
@@ -65,8 +62,4 @@ export type DisableApplicationModalProps = {
   subscription: SubscriptionKind;
 };
 
-export type DisableApplicationModalState = {
-  inProgress: boolean;
-  errorMessage: string;
-  deleteCSV: boolean;
-};
+DisableApplicationModal.displayName = 'DisableApplicationModal';

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/resource-requirements.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/resource-requirements.tsx
@@ -78,11 +78,6 @@ export type ResourceRequirementsModalProps = {
   close: () => void;
 };
 
-export type ResourceRequirementsModalState = {
-  inProgress: boolean;
-  errorMessage: string;
-};
-
 export type ResourceRequirementsModalLinkProps = {
   obj: ClusterServiceVersionResourceKind;
   model: K8sKind;


### PR DESCRIPTION
### Description

Use the active namespace instead of the namespace of the deleted `Subscription`. Also refactor `DisableApplicationModal` to functional component using `withHandlePromise` HOC.

Addresses https://jira.coreos.com/browse/OLM-1105