### PR TITLE
Query Browser: Switch from area chart to line chart

### DIFF
--- a/frontend/public/components/graphs/query-browser.tsx
+++ b/frontend/public/components/graphs/query-browser.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import {
   Chart,
-  ChartArea,
   ChartAxis,
   ChartGroup,
+  ChartLine,
   ChartThemeColor,
   ChartThemeVariant,
   getCustomTheme,
@@ -96,7 +96,7 @@ const Graph: React.FC<GraphProps> = ({domain, data, onZoom}) => {
         <ChartAxis tickCount={5} tickFormat={twentyFourHourTime} />
         <ChartAxis dependentAxis tickCount={5} tickFormat={humanizeNumber} />
         <ChartGroup colorScale={graphColors}>
-          {_.map(data, ({values}, i) => <ChartArea key={i} data={values} />)}
+          {_.map(data, ({values}, i) => <ChartLine key={i} data={values} />)}
         </ChartGroup>
       </Chart>
     </div>

--- a/frontend/public/components/graphs/query-browser.tsx
+++ b/frontend/public/components/graphs/query-browser.tsx
@@ -31,6 +31,12 @@ const spans = ['5m', '15m', '30m', '1h', '2h', '6h', '12h', '1d', '2d', '1w', '2
 const dropdownItems = _.zipObject(spans, spans);
 const theme = getCustomTheme(ChartThemeColor.multi, ChartThemeVariant.light, queryBrowserTheme);
 
+// Plotly default colors
+// TODO: Remove this once PatternFly's default colors are finalized
+export const graphColors = [
+  '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf',
+];
+
 const SpanControls = ({defaultSpanText, onChange, span}) => {
   const [isValid, setIsValid] = React.useState(true);
   const [text, setText] = React.useState(formatPrometheusDuration(span));
@@ -73,7 +79,7 @@ const SpanControls = ({defaultSpanText, onChange, span}) => {
   </React.Fragment>;
 };
 
-const Graph: React.FC<GraphProps> = ({colors, domain, data, onZoom}) => {
+const Graph: React.FC<GraphProps> = ({domain, data, onZoom}) => {
   const [containerRef, width] = useRefWidth();
 
   return <div className="graph-wrapper">
@@ -89,7 +95,7 @@ const Graph: React.FC<GraphProps> = ({colors, domain, data, onZoom}) => {
       >
         <ChartAxis tickCount={5} tickFormat={twentyFourHourTime} />
         <ChartAxis dependentAxis tickCount={5} tickFormat={humanizeNumber} />
-        <ChartGroup colorScale={colors}>
+        <ChartGroup colorScale={graphColors}>
           {_.map(data, ({values}, i) => <ChartArea key={i} data={values} />)}
         </ChartGroup>
       </Chart>
@@ -136,7 +142,6 @@ const handleResponses = (responses: PrometheusResponse[], metric: Labels, sample
 };
 
 const QueryBrowser_: React.FC<QueryBrowserProps> = ({
-  colors,
   defaultTimespan,
   GraphLink,
   hideGraphs,
@@ -226,7 +231,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
           <EmptyStateIcon size="sm" icon={ChartLineIcon} />
           <Title size="sm">No Prometheus datapoints found.</Title>
         </EmptyState>}
-        {!hideGraphs && !isEmptyState && <Graph colors={colors} data={graphData} domain={graphDomain} onZoom={onZoom} />}
+        {!hideGraphs && !isEmptyState && <Graph data={graphData} domain={graphDomain} onZoom={onZoom} />}
       </React.Fragment>}
   </div>;
 };
@@ -251,14 +256,12 @@ type GraphDataMetric = {
 };
 
 type GraphProps = {
-  colors: string[];
   data: GraphDataMetric[];
   domain: Domain;
   onZoom: (range: Domain) => void;
 };
 
 type QueryBrowserProps = {
-  colors: string[];
   defaultTimespan: number;
   GraphLink: React.ComponentType<{}>;
   hideGraphs: boolean;

--- a/frontend/public/components/graphs/query-browser.tsx
+++ b/frontend/public/components/graphs/query-browser.tsx
@@ -148,7 +148,6 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   metric,
   onDataUpdate,
   queries,
-  samples,
 }) => {
   // For the default time span, use the first of the suggested span options that is at least as long as defaultTimespan
   const defaultSpanText = spans.find(s => parsePrometheusDuration(s) >= defaultTimespan);
@@ -160,6 +159,9 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   const [updating, setUpdating] = React.useState(true);
 
   const endTime = _.get(domain, 'x[1]');
+
+  // Use more samples if we are only displaying a single metric
+  const samples = metric ? 600 : 300;
 
   const urls = _.map(queries, query => getPrometheusURL({
     endpoint: PrometheusEndpoint.QUERY_RANGE,
@@ -268,5 +270,4 @@ type QueryBrowserProps = {
   metric: Labels;
   onDataUpdate: (data: GraphDataMetric[]) => void;
   queries: string[];
-  samples?: number;
 };

--- a/frontend/public/components/graphs/themes.ts
+++ b/frontend/public/components/graphs/themes.ts
@@ -52,8 +52,15 @@ export const barTheme = {
 };
 
 export const queryBrowserTheme = {
-  ...areaTheme,
-  independentAxis: {
+  chart: {
+    padding: {
+      bottom: 0,
+      left: 40,
+      right: 0,
+      top: 0,
+    },
+  },
+  dependentAxis: {
     style: {
       grid: {stroke: '#EDEDED'},
     },

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -13,6 +13,7 @@ import { alertState, AlertStates, connectToURLs, MonitoringRoutes, silenceState,
 import store from '../redux';
 import { ColHead, List, ListHeader, ResourceRow, TextFilter } from './factory';
 import { QueryBrowser } from './graphs';
+import { graphColors } from './graphs/query-browser';
 import { getPrometheusExpressionBrowserURL } from './graphs/prometheus-graph';
 import { confirmModal } from './modals';
 import { CheckBoxes } from './row-filter';
@@ -179,11 +180,6 @@ const ToggleGraph_ = ({hideGraphs, toggle}) => {
 };
 const ToggleGraph = connect(graphStateToProps, {toggle: UIActions.monitoringToggleGraphs})(ToggleGraph_);
 
-// Plotly default colors:
-const graphColors = [
-  '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf',
-];
-
 const Graph_ = ({hideGraphs, metric = undefined, samples, rule}) => {
   if (hideGraphs) {
     return null;
@@ -198,7 +194,6 @@ const Graph_ = ({hideGraphs, metric = undefined, samples, rule}) => {
     : null;
 
   return <QueryBrowser
-    colors={graphColors}
     defaultTimespan={timespan}
     GraphLink={GraphLink}
     metric={metric}
@@ -991,7 +986,6 @@ const QueryBrowserPage = () => {
       <div className="row">
         <div className="col-xs-12">
           <QueryBrowser
-            colors={graphColors}
             defaultTimespan={30 * 60 * 1000}
             GraphLink={ToggleGraph}
             onDataUpdate={onDataUpdate}

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -180,7 +180,7 @@ const ToggleGraph_ = ({hideGraphs, toggle}) => {
 };
 const ToggleGraph = connect(graphStateToProps, {toggle: UIActions.monitoringToggleGraphs})(ToggleGraph_);
 
-const Graph_ = ({hideGraphs, metric = undefined, samples, rule}) => {
+const Graph_ = ({hideGraphs, metric = undefined, rule}) => {
   if (hideGraphs) {
     return null;
   }
@@ -198,7 +198,6 @@ const Graph_ = ({hideGraphs, metric = undefined, samples, rule}) => {
     GraphLink={GraphLink}
     metric={metric}
     queries={[query]}
-    samples={samples}
   />;
 };
 const Graph = connect(graphStateToProps)(Graph_);
@@ -249,7 +248,7 @@ const AlertsDetailsPage = withFallback(connect(alertStateToProps)((props: Alerts
         <div className="co-m-pane__body-group">
           <div className="row">
             <div className="col-sm-12">
-              {state !== AlertStates.NotFiring && <Graph metric={labels} rule={rule} samples={600} />}
+              {state !== AlertStates.NotFiring && <Graph metric={labels} rule={rule} />}
             </div>
           </div>
           <div className="row">
@@ -400,7 +399,7 @@ const AlertRulesDetailsPage = withFallback(connect(ruleStateToProps)((props: Ale
           </SectionHeading>
           <div className="row">
             <div className="col-sm-12">
-              <Graph rule={rule} samples={300} />
+              <Graph rule={rule} />
             </div>
           </div>
           <div className="row">
@@ -990,7 +989,6 @@ const QueryBrowserPage = () => {
             GraphLink={ToggleGraph}
             onDataUpdate={onDataUpdate}
             queries={validQueries}
-            samples={600}
           />
           <form onSubmit={runQueries}>
             <div className="group">


### PR DESCRIPTION
Also some code clean up to remove the `colors` prop and `samples` prop from `QueryBrowser`.