### PR TITLE
Remove Status and move view to Projects > Workloads

### DIFF
--- a/frontend/integration-tests/tests/deploy-image.scenario.ts
+++ b/frontend/integration-tests/tests/deploy-image.scenario.ts
@@ -37,7 +37,7 @@ describe('Deploy Image', () => {
     it('can be used to create an app based on an image', async() => {
       await $('.co-m-btn-bar .btn-primary').click();
       await browser.wait(until.presenceOf($('.overview')));
-      expect($('.co-m-pane__name').getText()).toEqual('Project Status');
+      expect($('.project-overview').isPresent());
       await browser.get(`${appHost}/k8s/ns/${testName}/deploymentconfigs/${appName}`);
       await browser.wait(until.presenceOf(crudView.actionsButton));
       expect(browser.getCurrentUrl()).toContain(`/${appName}`);

--- a/frontend/integration-tests/tests/overview/overview.scenario.ts
+++ b/frontend/integration-tests/tests/overview/overview.scenario.ts
@@ -20,7 +20,7 @@ describe('Visiting Overview page', () => {
   });
 
   beforeAll(async() => {
-    await browser.get(`${appHost}/overview/ns/${testName}`);
+    await browser.get(`${appHost}/k8s/cluster/projects/${testName}/workloads`);
     await crudView.isLoaded();
   });
 

--- a/frontend/integration-tests/tests/performance.scenario.ts
+++ b/frontend/integration-tests/tests/performance.scenario.ts
@@ -28,7 +28,6 @@ const chunkedRoutes = OrderedMap<string, {section: string, name: string}>()
   .set('image-stream', {section: 'Builds', name: 'Image Streams'})
   .set('node', {section: 'Compute', name: 'Nodes'})
   .set('service-account', {section: 'Administration', name: 'Service Accounts'})
-  .set('resource-quota', {section: 'Administration', name: 'Resource Quotas'})
   .set('limit-range', {section: 'Administration', name: 'Limit Ranges'})
   .set('custom-resource-definition', {section: 'Administration', name: 'Custom Resource Definitions'})
   .set('catalog', {section: 'Catalog', name: 'Developer Catalog'})
@@ -46,17 +45,6 @@ describe('Performance test', () => {
     writeFileSync(path.resolve(__dirname, '../../gui_test_screenshots/bundle-analysis.txt'), resources);
 
     expect(resources.length).not.toEqual(0);
-  });
-
-  it('downloads new bundle for "Overview" route', async() => {
-    await browser.get(`${appHost}/status/all-namespaces`);
-    await browser.wait(until.presenceOf(crudView.resourceTitle));
-
-    const overviewChunk = await browser.executeScript<any>(() => performance.getEntriesByType('resource')
-      .find(({name}) => name.endsWith('.js') && name.indexOf('cluster-overview') > -1));
-
-    expect(overviewChunk).not.toBeNull();
-    expect(overviewChunk.decodedBodySize).toBeLessThan(100000);
   });
 
   it('downloads new bundle for YAML editor route', async() => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,7 @@
     "react-linkify": "^0.2.2",
     "react-modal": "3.x",
     "react-redux": "5.x",
-    "react-router-dom": "4.x",
+    "react-router-dom": "4.3.x",
     "react-tagsinput": "3.19.x",
     "react-transition-group": "2.3.x",
     "react-virtualized": "9.x",

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -19,7 +19,6 @@ export enum ActionType {
   DismissOverviewDetails = 'dismissOverviewDetails',
   SelectOverviewDetailsTab = 'selectOverviewDetailsTab',
   SelectOverviewItem = 'selectOverviewItem',
-  SelectOverviewView = 'selectOverviewView',
   SetActiveNamespace = 'setActiveNamespace',
   SetActivePerspective = 'setActivePerspective',
   SetCreateProjectMessage = 'setCreateProjectMessage',
@@ -182,7 +181,6 @@ export const sortList = (listId: string, field: string, func: any, orderBy: stri
 };
 export const setCreateProjectMessage = (message: string) => action(ActionType.SetCreateProjectMessage, {message});
 export const setUser = (user: any) => action(ActionType.SetUser, {user});
-export const selectOverviewView = (view: string) => action(ActionType.SelectOverviewView, {view});
 export const selectOverviewItem = (uid: string) => action(ActionType.SelectOverviewItem, {uid});
 export const selectOverviewDetailsTab = (tab: string) => action(ActionType.SelectOverviewDetailsTab, {tab});
 export const updateOverviewMetrics = (metrics: any) => action(ActionType.UpdateOverviewMetrics, {metrics});
@@ -207,7 +205,6 @@ const uiActions = {
   sortList,
   setCreateProjectMessage,
   setUser,
-  selectOverviewView,
   selectOverviewItem,
   selectOverviewDetailsTab,
   updateOverviewMetrics,

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -100,13 +100,9 @@ const AppContents = withRouter(React.memo(() => (
 
           <LazyRoute path="/dashboards" exact loader={() => import('./dashboards-page/dashboards' /* webpackChunkName: "dashboards" */).then(m => m.DashboardsPage)} />
           <LazyRoute path="/cluster-status" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
-          <LazyRoute path="/overview/all-namespaces" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
-          <LazyRoute path="/overview/ns/:ns" exact loader={() => import('./overview' /* webpackChunkName: "overview" */).then(m => m.OverviewPage)} />
+          <Redirect from="/overview/all-namespaces" to="/cluster-status" />
+          <Redirect from="/overview/ns/:ns" to="/k8s/cluster/projects/:ns/workloads" />
           <Route path="/overview" exact component={NamespaceRedirect} />
-
-          <LazyRoute path="/status/all-namespaces" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
-          <LazyRoute path="/status/ns/:ns" exact loader={() => import('./cluster-overview' /* webpackChunkName: "cluster-overview" */).then(m => m.ClusterOverviewPage)} />
-          <Route path="/status" exact component={NamespaceRedirect} />
 
           <LazyRoute path="/start-guide" exact loader={() => import('./start-guide' /* webpackChunkName: "start-guide" */).then(m => m.StartGuidePage)} />
 

--- a/frontend/public/components/deploy-image.tsx
+++ b/frontend/public/components/deploy-image.tsx
@@ -303,7 +303,7 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
       .then(() => {
         this.setState({inProgress: false});
         if (!this.state.error) {
-          history.push(`/overview/ns/${this.state.namespace}`);
+          history.push(`/k8s/cluster/projects/${this.state.namespace}/workloads`);
         }
       });
   };

--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -83,12 +83,7 @@ const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNames
 
     this.handlePromise(promise).then(obj => {
       close();
-      if (createProject) {
-        // Redirect to the overview instead of the project details page.
-        history.push(`/overview/ns/${obj.metadata.name}`);
-      } else {
-        history.push(resourceObjPath(obj, referenceFor(obj)));
-      }
+      history.push(resourceObjPath(obj, referenceFor(obj)));
     });
   }
 

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -11,7 +11,7 @@ import { NamespaceModel, ProjectModel, SecretModel } from '../models';
 import { k8sGet } from '../module/k8s';
 import * as UIActions from '../actions/ui';
 import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
-import { Kebab, Dropdown, Firehose, LabelList, LoadingInline, navFactory, ResourceKebab, SectionHeading, ResourceIcon, ResourceLink, ResourceSummary, MsgBox, StatusIconAndText, ExternalLink, humanizeCpuCores, humanizeDecimalBytes } from './utils';
+import { Kebab, Dropdown, Firehose, LabelList, LoadingInline, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary, MsgBox, StatusIconAndText, ExternalLink, humanizeCpuCores, humanizeDecimalBytes } from './utils';
 import { createNamespaceModal, createProjectModal, deleteNamespaceModal, configureNamespacePullSecretModal } from './modals';
 import { RoleBindingsPage } from './RBAC';
 import { Bar, Area, requirePrometheus } from './graphs';
@@ -20,6 +20,8 @@ import { featureReducerName, flagPending, connectToFlags } from '../reducers/fea
 import { setFlag } from '../actions/features';
 import { openshiftHelpBase } from './utils/documentation';
 import { createProjectMessageStateToProps } from '../reducers/ui';
+import { Overview } from './overview';
+import { OverviewNamespaceDashboard } from './overview/namespace-overview';
 
 const getModel = useProjects => useProjects ? ProjectModel : NamespaceModel;
 const getDisplayName = obj => _.get(obj, ['metadata', 'annotations', 'openshift.io/display-name']);
@@ -134,17 +136,13 @@ const ProjectTableHeader = () => {
 };
 ProjectTableHeader.displayName = 'ProjectTableHeader';
 
-
 const ProjectTableRow = ({obj: project, index, key, style}) => {
-  const name = project.metadata.name;
-  const displayName = getDisplayName(project);
   const requester = getRequester(project);
   return (
     <TableRow id={project.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={projectColumnClasses[0]}>
         <span className="co-resource-item">
-          <ResourceIcon kind="Project" />
-          <Link to={`/overview/ns/${name}`} title={displayName} className="co-resource-item__resource-name">{project.metadata.name}</Link>
+          <ResourceLink kind="Project" name={project.metadata.name} title={project.metadata.uid} />
         </span>
       </TableData>
       <TableData className={projectColumnClasses[1]}>
@@ -390,5 +388,5 @@ export const NamespacesDetailsPage = props => <DetailsPage
 export const ProjectsDetailsPage = props => <DetailsPage
   {...props}
   menuActions={projectMenuActions}
-  pages={[navFactory.details(Details), navFactory.editYaml(), navFactory.roles(RolesPage)]}
+  pages={[navFactory.details(OverviewNamespaceDashboard), navFactory.editYaml(), navFactory.workloads(Overview), navFactory.roles(RolesPage)]}
 />;

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -85,12 +85,6 @@ const AdminNav = () => (
   <React.Fragment>
     <NavSection title="Home">
       <ResourceClusterLink resource="projects" name="Projects" required={FLAGS.OPENSHIFT} />
-      {
-        // Show different status pages based on OpenShift vs native Kubernetes.
-        // TODO: Make Overview work on native Kubernetes. It currently assumes OpenShift resources.
-      }
-      <HrefLink href="/overview" name="Status" activePath="/overview/" required={FLAGS.OPENSHIFT} />
-      <HrefLink href="/status" name="Status" activePath="/status/" disallowed={FLAGS.OPENSHIFT} />
       <HrefLink href="/search" name="Search" startsWith={searchStartsWith} />
       <ResourceNSLink resource="events" name="Events" />
     </NavSection>

--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -1,162 +1,12 @@
-.co-m-nav-title--overview {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  min-height: 113px; // Positions skeleton screen at appropriate height since .overview-view-selector elements are loaded afterwards
-}
-
-.overview-toolbar {
-  margin: 0 0 ($grid-gutter-width / 2) 0;
-  min-width: 0;
-  padding: 0;
-  @media (max-width: $screen-xs-max) {
-    // Stack toggle buttons above resource filter options at mobile
-    .selected-view__resources & {
-      width: 100%;
-    }
-  }
-
-  .toolbar-pf-actions {
-    margin: 0;
-  }
-
-  // Override pf and make toolbar a flex object to control positioning
-  .toolbar-pf-action-right {
-    align-items: flex-end;
-    display: flex;
-    float: none;
-
-    @media (min-width: $screen-sm-min) and (max-width: $screen-md-max) {
-      // switch to stacked fields when side open but still at desktop widths
-      .overview--sidebar-shown & {
-        align-items: initial;
-        display: flex;
-        flex-direction: column;
-        float: none;
-        min-width: 160px;
-        width: calc(100% - 535px);
-      }
-    }
-  }
-}
-
-.overview-toolbar__dropdown {
-  display: inline-block;
-  max-width: 100%; // enable text-overflow: ellipsis
-
-  @media (max-width: $screen-sm-max) {
-    min-width: 100%;
-  }
-
-  .overview--sidebar-shown & {
-    @media (max-width: $screen-md-max) {
-      min-width: 100%; // stack selections
-    }
-  }
-
-  .btn-dropdown {
-    width: 100%;
-  }
-
-  .btn-link__titlePrefix {
-    color: lighten($btn-default-color, 15%);
-    font-weight: normal;
-    margin-right: 2px;
-  }
-
-  .dropdown-menu {
-    min-width: 250px;
-  }
-}
-
-.overview-toolbar__form-group {
-  flex: 1 1 auto;
-  min-width: 0; // enable truncation
-
-  @media (min-width: $screen-xs-min) {
-    padding-right: 15px;
-  }
-
-  &:first-child {
-    border-right: 0;
-    margin-bottom: 0;
-    padding-left: 0;
-    padding-right: 10px;
-
-    @media (max-width: $screen-md-max) {
-      .overview--sidebar-shown & {
-        padding-right: 0;
-      }
-    }
-
-    @media (min-width: $screen-lg-min) and (max-width: ($screen-lg-min + 200)) {
-      .overview--sidebar-shown & {
-        max-width: 200px; // prevents group by select from pushing filter input behind the sidebar
-      }
-    }
-  }
-
-  + .overview-toolbar__form-group {
-    border-left: 1px solid $color-pf-black-300;
-    padding-left: 10px;
-
-    .overview--sidebar-shown & {
-      @media (max-width: $screen-md-max) {
-        border: 0;
-        padding-left: 0;
-        padding-top: 5px;
-      }
-
-    }
-  }
-
-  .co-actions-menu {
-    margin-left: 0;
-  }
-}
-
-.co-m-pane__heading--overview {
-  justify-content: flex-start;
-  margin: 0 20px ($grid-gutter-width / 2) 0;
-}
-
-.co-m-pane__name--overview {
-  flex: 0 1 auto;
-}
-
-.overview-toolbar__label {
-  margin: 0 10px 0 0;
-  vertical-align: middle;
-  white-space: nowrap;
-  @media (max-width: $screen-md-max) {
-    margin-bottom: 0;
-    margin-right: 10px;
-  }
-}
-
-.overview-toolbar__text-filter .co-text-filter {
-  min-width: 100%;
-  width: 100%;
-
-  .overview--sidebar-shown & {
-    width: auto;
-  }
-}
+$overview-sidebar-width: 550px;
 
 .overview {
-  bottom: 0;
-  display: flex;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
+  overflow: hidden; // hide .overview__sidebar box-shadow at top
+  position: relative;
 
   .overview__main-column {
-    height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
-    width: 100%;
     -webkit-overflow-scrolling: touch;
   }
 
@@ -169,10 +19,10 @@
     right: 0;
     top: 0;
     width: calc(100% - 15px);
-    @media(min-width: $screen-sm-min) {
-      max-width: 550px;
-    }
     z-index: 5;
+    @media(min-width: $screen-sm-min) {
+      max-width: $overview-sidebar-width;
+    }
   }
 
   .overview__sidebar-appear {
@@ -196,16 +46,7 @@
 
     @media(min-width: $screen-lg-min) {
       .overview__main-column {
-        width: calc(100% - 500px);
-
-        .co-m-pane__body {
-          padding-right: 0;
-        }
-      }
-
-      .overview__sidebar {
-        min-height: 0;
-        overflow: hidden;
+        margin-right: $overview-sidebar-width;
       }
     }
   }
@@ -244,27 +85,6 @@
 
   .co-actions-menu {
     margin-top: -3px;
-  }
-}
-
-.overview-view-selector {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-
-  @media (max-width: $screen-md-max) {
-    .overview--sidebar-shown & {
-      flex-direction: column;
-    }
-  }
-
-  .btn-group {
-    button+button {
-      margin-left: 0;
-    }
-    i.fa {
-      margin-right: 6px;
-    }
   }
 }
 

--- a/frontend/public/components/overview/_project-overview.scss
+++ b/frontend/public/components/overview/_project-overview.scss
@@ -48,11 +48,29 @@
 
   .project-overview__item {
     min-height: 71px;
+
+    &.list-group-item {
+      background-clip: initial;
+      border-bottom: 1px solid $color-pf-black-200;
+      border-left: 0;
+      border-right: 0;
+      border-top: 1px solid $color-pf-black-200;
+      cursor: pointer;
+      position: relative;
+    }
   }
 
-  .project-overview__item--selected,
-  .project-overview__item.project-overview__item--selected:hover, {
-    background-color: $color-pf-blue-100;
+  .project-overview__item--selected {
+    background-color: $color-pf-blue-100 !important;
+
+    &::after {
+      align-self: center;
+      content: $fa-var-chevron-right;
+      display: block;
+      font-family: 'FontAwesome';
+      position: absolute;
+      right: 30px;
+    }
   }
 
   .project-overview__item .project-overview__item-chevron {
@@ -84,35 +102,6 @@
     padding: 5px 0;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .project-overview__item.list-group-item {
-    background-clip: initial;
-    border-bottom: 1px solid $color-pf-black-200;
-    border-left: 0;
-    border-right: 0;
-    border-top: 1px solid $color-pf-black-200;
-    cursor: pointer;
-    position: relative;
-    &::after {
-      align-self: center;
-      content: $fa-var-chevron-right;
-      display: none;
-      font-family: 'FontAwesome';
-      position: absolute;
-      right: 30px;
-    }
-
-    &--selected::after,
-    &:hover::after {
-      display: block;
-    }
-
-    &--selected,
-    &--selected:hover {
-      background-color: $color-pf-blue-100;
-      border-color: $color-pf-blue-100;
-    }
   }
 
   .project-overview__list {

--- a/frontend/public/components/overview/constants.ts
+++ b/frontend/public/components/overview/constants.ts
@@ -4,9 +4,3 @@ export enum OverviewSpecialGroup {
   GROUP_BY_APPLICATION = '#GROUP_BY_APPLICATION#',
   GROUP_BY_RESOURCE = '#GROUP_BY_RESOURCE#',
 }
-
-// View options for overview page
-export enum OverviewViewOption {
-  RESOURCES = 'resources',
-  DASHBOARD = 'dashboard',
-}

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -4,9 +4,7 @@ import * as fuzzy from 'fuzzysearch';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { CSSTransition } from 'react-transition-group';
-import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-import { Toolbar, EmptyState } from 'patternfly-react';
 
 import { coFetchJSON } from '../../co-fetch';
 import { getBuildNumber } from '../../module/k8s/builds';
@@ -22,23 +20,16 @@ import {
   PodTemplate,
 } from '../../module/k8s';
 import {
-  withStartGuide,
-  WithStartGuideProps,
-} from '../start-guide';
-import {
   DaemonSetModel,
   DeploymentModel,
   DeploymentConfigModel,
   PodModel,
-  ProjectModel,
   ReplicationControllerModel,
   ReplicaSetModel,
   StatefulSetModel,
 } from '../../models';
 import {
-  ActionsMenu,
   CloseButton,
-  KebabAction,
   Dropdown,
   Firehose,
   StatusBox,
@@ -46,10 +37,9 @@ import {
   resourceObjPath,
 } from '../utils';
 
-import { overviewMenuActions, OverviewNamespaceDashboard } from './namespace-overview';
 import { ProjectOverview } from './project-overview';
 import { ResourceOverviewPage } from './resource-overview-page';
-import { OverviewViewOption, OverviewSpecialGroup } from './constants';
+import { OverviewSpecialGroup } from './constants';
 
 
 // List of container status waiting reason values that we should call out as errors in project status rows.
@@ -70,9 +60,6 @@ const DEFAULT_GROUP_NAME = 'other resources';
 
 // Interval at which metrics are retrieved and updated
 const METRICS_POLL_INTERVAL = 30 * 1000;
-
-// Namespace prefixes that are reserved and should not have calls to action on empty state
-const RESERVED_NS_PREFIXES = ['openshift-', 'kube-', 'kubernetes-'];
 
 // Annotation key for image triggers
 const TRIGGERS_ANNOTATION = 'image.openshift.io/triggers';
@@ -336,8 +323,6 @@ const sortBuilds = (builds: K8sResourceKind[]): K8sResourceKind[] => {
   return builds.sort(byBuildNumber);
 };
 
-const isReservedNamespace = (ns: string) => ns === 'default' || ns === 'openshift' || RESERVED_NS_PREFIXES.some(prefix => _.startsWith(ns, prefix));
-
 const OverviewItemReadiness: React.SFC<OverviewItemReadinessProps> = ({desired = 0, ready = 0, resource}) => {
   const href = `${resourceObjPath(resource, resource.kind)}/pods`;
   return <Link to={href}>
@@ -345,46 +330,14 @@ const OverviewItemReadiness: React.SFC<OverviewItemReadinessProps> = ({desired =
   </Link>;
 };
 
-const overviewEmptyStateToProps = ({UI}) => ({
-  activeNamespace: UI.get('activeNamespace'),
-  resources: UI.getIn(['overview', 'resources']),
-});
-
-const OverviewEmptyState = connect(overviewEmptyStateToProps)(({activeNamespace, resources}) => {
-  // Don't encourage users to add content to system namespaces.
-  if (resources.isEmpty() && !isReservedNamespace(activeNamespace)) {
-    return <EmptyState>
-      <EmptyState.Title>
-        Get started with your project.
-      </EmptyState.Title>
-      <EmptyState.Info>
-        Add content to your project from the catalog of web frameworks, databases, and other components. You may also deploy an existing image or create resources using YAML definitions.
-      </EmptyState.Info>
-      <EmptyState.Action>
-        <Link to="/catalog" className="btn btn-primary">
-          Browse Catalog
-        </Link>
-      </EmptyState.Action>
-      <EmptyState.Action secondary>
-        <Link className="btn btn-default" to={`/deploy-image?preselected-ns=${activeNamespace}`}>
-          Deploy Image
-        </Link>
-        <Link className="btn btn-default" to={UIActions.formatNamespacedRouteForResource('import', activeNamespace)}>
-          Import YAML
-        </Link>
-      </EmptyState.Action>
-    </EmptyState>;
-  }
-  return <EmptyBox label="Resources" />;
-});
+const OverviewEmptyState = () => <EmptyBox label="Workloads" />;
 
 const headingStateToProps = ({UI}): OverviewHeadingPropsFromState => {
-  const {selectedView, selectedGroup, groupOptions, filterValue} = UI.get('overview').toJS();
-  return {groupOptions, selectedGroup, selectedView, filterValue};
+  const {selectedGroup, groupOptions, filterValue} = UI.get('overview').toJS();
+  return {groupOptions, selectedGroup, filterValue};
 };
 
 const headingDispatchToProps = (dispatch): OverviewHeadingPropsFromDispatch => ({
-  selectView: (view: OverviewViewOption) => dispatch(UIActions.selectOverviewView(view)),
   selectGroup: (group: OverviewSpecialGroup) => dispatch(UIActions.updateOverviewSelectedGroup(group)),
   changeFilter: (value: string) => dispatch(UIActions.updateOverviewFilterValue(value)),
 });
@@ -396,70 +349,27 @@ class OverviewHeading_ extends React.Component<OverviewHeadingProps> {
   }
 
   render() {
-    const {changeFilter, disabled, filterValue, firstLabel = '', groupOptions, selectGroup, selectedGroup, selectView, selectedView, title, project} = this.props;
-    return <div className={classnames('co-m-nav-title co-m-nav-title--overview', { 'overview-filter-group': selectedView === OverviewViewOption.RESOURCES })}>
-      {
-        title &&
-        <h1 className="co-m-pane__heading co-m-pane__heading--overview">
-          <div className="co-m-pane__name co-m-pane__name--overview">{title}</div>
-        </h1>
-      }
-      {!_.isEmpty(project) && <div className={classnames('overview-view-selector', {'selected-view__resources': selectedView === OverviewViewOption.RESOURCES })}>
-        <div className="form-group btn-group">
-          <button
-            type="button"
-            className={classnames('btn btn-default', { 'btn-primary': selectedView === OverviewViewOption.RESOURCES })}
-            aria-label="Resources"
-            title="Resources"
-            disabled={disabled}
-            onClick={() => selectView(OverviewViewOption.RESOURCES)}
-          >
-            <i className="fa fa-list-ul" aria-hidden="true" />
-            Resources
-          </button>
-          <button
-            type="button"
-            className={classnames('btn btn-default', { 'btn-primary': selectedView === OverviewViewOption.DASHBOARD })}
-            aria-label="Dashboard"
-            title="Dashboard"
-            disabled={disabled}
-            onClick={() => selectView(OverviewViewOption.DASHBOARD)}
-          >
-            <i className="fa fa-dashboard" aria-hidden="true" />
-            Dashboard
-          </button>
-        </div>
-        <Toolbar className="overview-toolbar" preventSubmit>
-          <Toolbar.RightContent>
-            {selectedView === OverviewViewOption.RESOURCES && <React.Fragment>
-              <div className="form-group overview-toolbar__form-group">
-                <Dropdown
-                  className="overview-toolbar__dropdown"
-                  menuClassName="dropdown-menu--text-wrap"
-                  items={groupOptions}
-                  onChange={selectGroup}
-                  titlePrefix="Group by"
-                  title={groupOptions[selectedGroup] || 'Select Category'}
-                  spacerBefore={new Set([firstLabel])}
-                  headerBefore={{[firstLabel]: 'Label'}}
-                />
-              </div>
-              <div className="form-group overview-toolbar__form-group">
-                <div className="overview-toolbar__text-filter">
-                  <TextFilter
-                    defaultValue={filterValue}
-                    label="by name"
-                    onChange={(e) => changeFilter(e.target.value)}
-                  />
-                </div>
-              </div>
-            </React.Fragment>}
-            {selectedView === OverviewViewOption.DASHBOARD && !_.isEmpty(project) && <div className="form-group">
-              <ActionsMenu actions={overviewMenuActions.map((a: KebabAction) => a(ProjectModel, project))} />
-            </div>}
-          </Toolbar.RightContent>
-        </Toolbar>
-      </div>}
+    const {changeFilter, filterValue, firstLabel = '', groupOptions, selectGroup, selectedGroup} = this.props;
+    return <div className="co-m-pane__filter-bar">
+      <div className="co-m-pane__filter-bar-group">
+        <Dropdown
+          className="btn-group"
+          menuClassName="dropdown-menu--text-wrap"
+          items={groupOptions}
+          onChange={selectGroup}
+          titlePrefix="Group by"
+          title={groupOptions[selectedGroup] || 'Select Category'}
+          spacerBefore={new Set([firstLabel])}
+          headerBefore={{[firstLabel]: 'Label'}}
+        />
+      </div>
+      <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--filter">
+        <TextFilter
+          defaultValue={filterValue}
+          label="by name"
+          onChange={(e) => changeFilter(e.target.value)}
+        />
+      </div>
     </div>;
   }
 }
@@ -467,8 +377,8 @@ class OverviewHeading_ extends React.Component<OverviewHeadingProps> {
 const OverviewHeading = connect<OverviewHeadingPropsFromState, OverviewHeadingPropsFromDispatch, OverviewHeadingOwnProps>(headingStateToProps, headingDispatchToProps)(OverviewHeading_);
 
 const mainContentStateToProps = ({UI}): OverviewMainContentPropsFromState => {
-  const {filterValue, metrics, selectedView, selectedGroup, groupOptions} = UI.get('overview').toJS();
-  return {filterValue, groupOptions, metrics, selectedGroup, selectedView};
+  const {filterValue, metrics, selectedGroup, groupOptions} = UI.get('overview').toJS();
+  return {filterValue, groupOptions, metrics, selectedGroup};
 };
 
 const mainContentDispatchToProps = (dispatch): OverviewMainContentPropsFromDispatch => ({
@@ -978,7 +888,7 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
   }
 
   render() {
-    const {loaded, loadError, mock, title, project = {}, selectedView} = this.props;
+    const {loaded, loadError, project = {}} = this.props;
     const {filteredItems, groupedItems, firstLabel} = this.state;
 
     const skeletonOverview = <div className="skeleton-overview">
@@ -990,22 +900,19 @@ class OverviewMainContent_ extends React.Component<OverviewMainContentProps, Ove
 
     return <div className="co-m-pane">
       <OverviewHeading
-        disabled={mock}
         firstLabel={firstLabel}
-        title={title}
         project={project.data}
       />
       <div className="co-m-pane__body co-m-pane__body--no-top-margin">
         <StatusBox
           skeleton={skeletonOverview}
-          data={selectedView === OverviewViewOption.RESOURCES ? filteredItems : project}
+          data={filteredItems}
           label="Resources"
           loaded={loaded}
           loadError={loadError}
           EmptyMsg={OverviewEmptyState}
         >
-          {selectedView === OverviewViewOption.RESOURCES && <ProjectOverview groups={groupedItems} />}
-          {selectedView === OverviewViewOption.DASHBOARD && <OverviewNamespaceDashboard obj={project.data} />}
+          <ProjectOverview groups={groupedItems} />
         </StatusBox>
       </div>
     </div>;
@@ -1018,8 +925,8 @@ const overviewStateToProps = ({UI}): OverviewPropsFromState => {
   const selectedUID = UI.getIn(['overview', 'selectedUID']);
   const resources = UI.getIn(['overview', 'resources']);
   const selectedItem = !!resources && resources.get(selectedUID);
-  const selectedView = UI.getIn(['overview', 'selectedView'], OverviewViewOption.RESOURCES);
-  return { selectedItem, selectedView };
+  return { selectedItem };
+
 };
 
 const overviewDispatchToProps = (dispatch): OverviewPropsFromDispatch => {
@@ -1028,9 +935,24 @@ const overviewDispatchToProps = (dispatch): OverviewPropsFromDispatch => {
   };
 };
 
-const Overview_: React.SFC<OverviewProps> = ({mock, namespace, selectedItem, selectedView, title, dismissDetails}) => {
-  const sidebarOpen = !_.isEmpty(selectedItem) && selectedView !== OverviewViewOption.DASHBOARD;
+const Overview_: React.SFC<OverviewProps> = ({mock, match, selectedItem, title, dismissDetails}) => {
+  const namespace = _.get(match, 'params.name');
+  const sidebarOpen = !_.isEmpty(selectedItem);
   const className = classnames('overview', {'overview--sidebar-shown': sidebarOpen});
+  const ref = React.useRef();
+  const [height, setHeight] = React.useState(500);
+  const calcHeight = (node) => {
+    setHeight(document.getElementsByClassName('pf-c-page')[0].getBoundingClientRect().bottom - node.current.getBoundingClientRect().top);
+  };
+  React.useLayoutEffect(() => {
+    calcHeight(ref);
+    const handleResize = () => calcHeight(ref);
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  });
+
   // TODO: Update resources for native Kubernetes clusters.
   const resources = [
     {
@@ -1108,7 +1030,7 @@ const Overview_: React.SFC<OverviewProps> = ({mock, namespace, selectedItem, sel
   ];
 
   return <div className={className}>
-    <div className="overview__main-column">
+    <div className="overview__main-column" ref={ref} style={{height}}>
       <div className="overview__main-column-section">
         <Firehose resources={mock ? [] : resources} forceUpdate>
           <OverviewMainContent
@@ -1139,23 +1061,6 @@ const Overview_: React.SFC<OverviewProps> = ({mock, namespace, selectedItem, sel
 };
 
 export const Overview = connect<OverviewPropsFromState, OverviewPropsFromDispatch, OverviewOwnProps>(overviewStateToProps, overviewDispatchToProps)(Overview_);
-
-export const OverviewPage = withStartGuide(
-  ({match, noProjectsAvailable}: OverviewPageProps & WithStartGuideProps) => {
-    const namespace = _.get(match, 'params.ns');
-    const title = 'Project Status';
-    return <React.Fragment>
-      <Helmet>
-        <title>{title}</title>
-      </Helmet>
-      <Overview
-        mock={noProjectsAvailable}
-        namespace={namespace}
-        title={title}
-      />
-    </React.Fragment>;
-  }
-);
 
 type FirehoseItem = {
   data?: K8sResourceKind;
@@ -1227,19 +1132,15 @@ type OverviewHeadingPropsFromState = {
   filterValue: string;
   groupOptions: {[key: string]: string};
   selectedGroup: string;
-  selectedView: OverviewViewOption;
 };
 
 type OverviewHeadingPropsFromDispatch = {
-  selectView: (view: OverviewViewOption) => void;
   selectGroup: (selectedLabel: OverviewSpecialGroup) => void;
   changeFilter: (value: string) => void;
 };
 
 type OverviewHeadingOwnProps = {
-  disabled?: boolean;
   firstLabel?: string;
-  title: string;
   project: K8sResourceKind;
 };
 
@@ -1250,7 +1151,6 @@ type OverviewMainContentPropsFromState = {
   groupOptions: {[key: string]: string};
   metrics: OverviewMetrics;
   selectedGroup: string;
-  selectedView: OverviewViewOption;
 };
 
 type OverviewMainContentPropsFromDispatch = {
@@ -1292,7 +1192,6 @@ type OverviewMainContentState = {
 
 type OverviewPropsFromState = {
   selectedItem: any;
-  selectedView: OverviewViewOption;
 };
 
 type OverviewPropsFromDispatch = {
@@ -1301,12 +1200,8 @@ type OverviewPropsFromDispatch = {
 
 type OverviewOwnProps = {
   mock: boolean;
-  namespace: string;
+  match: any;
   title: string;
 };
 
 type OverviewProps = OverviewPropsFromState & OverviewPropsFromDispatch & OverviewOwnProps;
-
-type OverviewPageProps = {
-  match: any;
-};

--- a/frontend/public/components/overview/namespace-overview.tsx
+++ b/frontend/public/components/overview/namespace-overview.tsx
@@ -96,12 +96,12 @@ const OverviewResourceQuotas = ({ns}) => {
   </Firehose>;
 };
 
-export const OverviewNamespaceDashboard = ({obj: ns}) => <React.Fragment>
+export const OverviewNamespaceDashboard = ({obj: ns}) => <div className="co-m-pane__body">
   <OverviewHealth ns={ns} />
   <OverviewResourceQuotas ns={ns} />
   <OverviewResourceUsage ns={ns} />
   <OverviewNamespaceSummary ns={ns} />
-</React.Fragment>;
+</div>;
 
 export type QuotaBoxesProps = {
   resourceQuotas?: {loaded: boolean, loadError: string, data: K8sResourceKind};

--- a/frontend/public/components/overview/project-overview.tsx
+++ b/frontend/public/components/overview/project-overview.tsx
@@ -364,8 +364,7 @@ class ProjectOverview_ extends React.Component<ProjectOverviewProps> {
         />
       )}
       <p className="small text-center hidden-xs">
-        <kbd>&uarr;</kbd> and <kbd>&darr;</kbd> selects items, <kbd>{KEYBOARD_SHORTCUTS.focusFilterInput}</kbd> filters items,
-        and <kbd>{KEYBOARD_SHORTCUTS.focusNamespaceDropdown}</kbd> selects projects.
+        <kbd>&uarr;</kbd> and <kbd>&darr;</kbd> selects items, and <kbd>{KEYBOARD_SHORTCUTS.focusFilterInput}</kbd> filters items.
       </p>
     </div>;
   }

--- a/frontend/public/components/source-to-image.tsx
+++ b/frontend/public/components/source-to-image.tsx
@@ -392,7 +392,7 @@ class BuildSource extends React.Component<BuildSourceProps, BuildSourceState> {
     Promise.all(requests).then(() => {
       this.setState({inProgress: false});
       if (!this.state.error) {
-        history.push(`/overview/ns/${this.state.namespace}`);
+        history.push(`/k8s/cluster/projects/${this.state.namespace}/workloads`);
       }
     }).catch(() => this.setState({inProgress: false}));
   };

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -104,6 +104,11 @@ export const navFactory: NavFactory = {
     name: 'Machines',
     component,
   }),
+  workloads: component => ({
+    href: 'workloads',
+    name: 'Workloads',
+    component,
+  }),
 };
 
 export const NavBar: React.SFC<NavBarProps> = ({pages, basePath, hideDivider}) => {

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -57,7 +57,6 @@ export default (state: UIState, action: UIAction): UIState => {
         resources: ImmutableMap({}),
         selectedDetailsTab: '',
         selectedUID: '',
-        selectedView: 'resources',
         selectedGroup: OverviewSpecialGroup.GROUP_BY_APPLICATION,
         groupOptions: ImmutableMap(),
         filterValue: '',
@@ -129,9 +128,6 @@ export default (state: UIState, action: UIAction): UIState => {
     }
     case ActionType.ToggleMonitoringGraphs:
       return state.setIn(['monitoring', 'hideGraphs'], !state.getIn(['monitoring', 'hideGraphs']));
-
-    case ActionType.SelectOverviewView:
-      return state.setIn(['overview', 'selectedView'], action.payload.view);
 
     case ActionType.SelectOverviewItem:
       return state.setIn(['overview', 'selectedUID'], action.payload.uid);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6814,7 +6814,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@^2.1.0, hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.1.0, hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -11400,28 +11400,30 @@ react-responsive@6.1.x:
     matchmediaquery "^0.3.0"
     prop-types "^15.6.1"
 
-react-router-dom@4.x:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.2.2.tgz#c8a81df3adc58bba8a76782e946cbd4eae649b8d"
+react-router-dom@4.3.x:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.3.1.tgz#4c2619fc24c4fa87c9fd18f4fb4a43fe63fbd5c6"
+  integrity sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==
   dependencies:
     history "^4.7.2"
-    invariant "^2.2.2"
+    invariant "^2.2.4"
     loose-envify "^1.3.1"
-    prop-types "^15.5.4"
-    react-router "^4.2.0"
-    warning "^3.0.0"
+    prop-types "^15.6.1"
+    react-router "^4.3.1"
+    warning "^4.0.1"
 
-react-router@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"
+react-router@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
+  integrity sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==
   dependencies:
     history "^4.7.2"
-    hoist-non-react-statics "^2.3.0"
-    invariant "^2.2.2"
+    hoist-non-react-statics "^2.5.0"
+    invariant "^2.2.4"
     loose-envify "^1.3.1"
     path-to-regexp "^1.7.0"
-    prop-types "^15.5.4"
-    warning "^3.0.0"
+    prop-types "^15.6.1"
+    warning "^4.0.1"
 
 react-side-effect@^1.1.0:
   version "1.1.5"


### PR DESCRIPTION
Resolves https://jira.coreos.com/browse/CONSOLE-1477

Note this PR deviates from [the design](http://openshift.github.io/openshift-origin-design/web-console/future-openshift/dashboards/dashboards) in a few ways:

* Does not add the project picker bar to the project details view since the project picker is a filter (filtering a project by another project isn't tenable).
* Does not disable the project actions when the workloads sidebar is open as that creates a confusing interaction as it is not clear why the project actions are no longer available.

Follow on PR todos:
- [x] Update the "+Add" dropdown everywhere to be just a link to "+Import YAML". https://github.com/openshift/console/pull/1706
- [X] Update the Actions dropdown everywhere to remove actions that simply jump to tabs. https://github.com/openshift/console/pull/1718
- [ ] Add standard breadcrumbs to all details pages and change existing owner ref breadcrumbs to standard ones.
- [ ] Determine how to best address multiple Actions buttons when the overview sidebar is open.

![localhost_9000_k8s_cluster_projects_robb](https://user-images.githubusercontent.com/895728/59275498-699e2e00-8c2a-11e9-9a72-03332d91b3dc.png)
![localhost_9000_k8s_cluster_projects_robb_ (0)](https://user-images.githubusercontent.com/895728/59275505-6c008800-8c2a-11e9-878d-2e8592c374f1.png)
![localhost_9000_k8s_cluster_projects_robb_ (1)](https://user-images.githubusercontent.com/895728/59275506-6c991e80-8c2a-11e9-8d0b-9125e8247e6f.png)
![localhost_9000_k8s_cluster_projects_robb_ (2)](https://user-images.githubusercontent.com/895728/59275510-6d31b500-8c2a-11e9-9823-009e28405c05.png)
![localhost_9000_k8s_cluster_projects_robb-empty_workloads](https://user-images.githubusercontent.com/895728/59365718-0504d100-8d07-11e9-8e62-2a0ee2b6c191.png)