### PR TITLE
Add ExpandableAlert component

### DIFF
--- a/frontend/public/components/utils/_alerts.scss
+++ b/frontend/public/components/utils/_alerts.scss
@@ -1,0 +1,3 @@
+.co-expandable-alert {
+  margin-bottom: var(--pf-global--spacer--xl);
+}

--- a/frontend/public/components/utils/alerts.tsx
+++ b/frontend/public/components/utils/alerts.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import { Alert, AlertVariant, List, ListItem } from '@patternfly/react-core';
+
+export const ExpandableAlert: React.FC<CustomAlertProps> = ({alerts, variant}) => {
+  const alertCount = alerts.length;
+  const [expanded, setExpanded] = React.useState(false);
+  const alertContent = alertCount > 1 ? <List>{_.map(alerts, (error, i) => <ListItem key={i}>{error}</ListItem>)}</List> : alerts;
+
+  return <Alert
+    isInline
+    variant={variant}
+    className="co-expandable-alert"
+    title={<React.Fragment>{`There are ${alertCount} ${variant} alerts.`}<button type="button" className="btn btn-link" onClick={() => setExpanded(!expanded)}>{expanded ? 'Hide' : 'Show'} Details</button></React.Fragment>}
+  >
+    {expanded && alertContent}
+  </Alert>;
+};
+
+type CustomAlertProps = {
+  alerts: React.ReactNode[];
+  variant: AlertVariant;
+};

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -29,6 +29,7 @@ export * from './documentation';
 export * from './router';
 export * from './operator-states';
 export * from './link';
+export * from './alerts';
 export * from './async';
 export * from './download-button';
 export * from './error-boundary';

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -33,6 +33,7 @@
 @import "style/storage-class";
 
 // React Components
+@import "components/utils/alerts";
 @import "components/utils/copy-to-clipboard";
 @import "components/utils/disabled";
 @import "components/utils/file-input";


### PR DESCRIPTION
First work done on https://jira.coreos.com/browse/CONSOLE-1450 based on designs from @ncameronbritt which is adding `ExpandableAlert` component that is used for display related alerts, which user can show or hide.

Demo:
![alerts](https://user-images.githubusercontent.com/1668218/59354083-a77f7d00-8d24-11e9-9d74-51d4e8dbda89.gif)

@spadgett PTAL