### PR TITLE
Don't accept bin files in the yaml editor.

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -123,6 +123,9 @@ export const EditYAML = connect(stateToProps)(
       this.setState({stale});
       if (nextProps.error) {
         this.handleError(nextProps.error);
+      } else if (this.state.error) {
+        //clear stale error state
+        this.setState({error: ''});
       }
       if (nextProps.sampleObj) {
         this.loadYaml(!_.isEqual(this.state.sampleObj, nextProps.sampleObj), nextProps.sampleObj);


### PR DESCRIPTION
Fix for: https://jira.coreos.com/browse/CONSOLE-1519

Do not accept bin files in the yaml editor. If a yaml file is dropped, provide feedback to instruct the user to provide a text file.

cc: @jhadvig 