### PR TITLE
Query Browser: Make the Hide Graph button also hide the graph controls

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1081,10 +1081,14 @@ const QueryBrowserPage = () => {
     </div>
     <div className="co-m-pane__body">
       <div className="row">
+        <div className="col-xs-12 text-right">
+          <ToggleGraph />
+        </div>
+      </div>
+      <div className="row">
         <div className="col-xs-12">
           <QueryBrowser
             defaultTimespan={30 * 60 * 1000}
-            GraphLink={ToggleGraph}
             onDataUpdate={onDataUpdate}
             queries={validQueries}
           />


### PR DESCRIPTION
Move the "Hide Graph" / "Show Graph" button outside of the graph area
and change it to also hide the graph controls, not just the graph
itself.