### PR TITLE
Bug 1720161: Avoid overlapping text in machine config list

### DIFF
--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -64,7 +64,7 @@ const MachineConfigRow: React.SFC<MachineConfigRowProps> = ({obj}) => <div class
   <div className="col-xs-6  col-sm-4  col-md-3  col-lg-2">
     <ResourceLink kind={machineConfigReference} name={obj.metadata.name} title={obj.metadata.name} />
   </div>
-  <div className="hidden-xs col-sm-6  col-md-4  col-lg-3">
+  <div className="hidden-xs col-sm-6  col-md-4  col-lg-3 co-break-word">
     { _.get(obj, ['metadata', 'annotations', 'machineconfiguration.openshift.io/generated-by-controller-version'], '-')}
   </div>
   <div className="hidden-xs hidden-sm col-md-3  col-lg-3">


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1720161

This is fixed in 4.2 by #1666.

/assign @rhamilto 
/hold

![Machine Configs · OKD 2019-06-13 08-27-32](https://user-images.githubusercontent.com/1167259/59432351-1b696600-8db5-11e9-882a-809774b5cb0d.png)
