### PR TITLE
Tidy up table CSS post-PF4 table integration

### DIFF
--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -36,7 +36,7 @@ const StorageClassTableHeader = () => {
       props: { className: tableColumnClasses[1] },
     },
     {
-      title: <React.Fragment>Reclaim <span className="pf-u-display-none-on-md pf-u-display-inline-block-on-lg">Policy</span></React.Fragment>,
+      title: <React.Fragment>Reclaim <span className="hidden-sm">Policy</span></React.Fragment>,
       sortField: 'reclaimPolicy', transforms: [sortable],
       props: { className: tableColumnClasses[2] },
     },

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -1,8 +1,4 @@
 // Config
-// pf3 color variables
-@import '~patternfly/dist/sass/patternfly/color-variables';
-@import '~@patternfly/patternfly/sass-utilities/all';
-@import "~@patternfly/patternfly/_variables";
 @import "style/vars";
 
 // External dependency variables or mixins that are required/extended by our custom styles (tilde tells Webpack not to use relative path)
@@ -13,11 +9,6 @@
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/variables";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/mixins";
 @import "~font-awesome-sass/assets/stylesheets/font-awesome/variables";
-
-// pf4 color variables
-// these vars have slightly different names to pf3 ones (imported above)
-// ie $color-pf-black-100 (pf3) vs $pf-color-black-100 (pf4)
-@import '~@patternfly/patternfly/sass-utilities/colors';
 
 @import "style/base";
 

--- a/frontend/public/style/_base.scss
+++ b/frontend/public/style/_base.scss
@@ -10,9 +10,7 @@ dl {
 
 // match pf4 styling / table col head styling
 dt {
-  color: $color-text-primary;
-  font-weight: var(--pf-global--FontWeight--bold);
-  font-size: $font-size-base; }
+  font-weight: var(--pf-global--FontWeight--bold); }
 
 dd {
   margin-bottom: 20px; }

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -151,15 +151,6 @@
 .co-table-container {
   overflow: auto;
   margin-bottom: 30px;
-  table {
-    thead {
-      th {
-        color: $color-text-primary;
-        font-weight: var(--pf-global--FontWeight--bold);
-        font-size: $font-size-base;
-      }
-    }
-  }
 }
 
 .co-m-pane__details {
@@ -478,9 +469,7 @@
     }
   }
   &__head {
-    color: $color-text-primary;
     font-weight: var(--pf-global--FontWeight--bold);
-    font-size: $font-size-base;
     padding: 0 20px 10px 0; // right padding to maintain alignment with __body .row
     a {
       cursor: pointer;

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -202,9 +202,8 @@ tags-input .autocomplete .suggestion-item em {
     vertical-align: middle !important;
   }
   th {
-    padding-top: 0 !important;
-    color: $color-text-primary;
     font-weight: var(--pf-global--FontWeight--bold);
+    padding-top: 0 !important;
   }
   thead > tr > th {
     border-bottom: 0;
@@ -513,7 +512,6 @@ kbd {
 // pf table overrides
 
 .pf-c-table tr > th {
-  color: $color-text-primary;
   font-weight: var(--pf-global--FontWeight--bold);
 }
 

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -4,6 +4,14 @@
 $consoleWebDistPath: './';
 $consoleWebFontPath: $consoleWebDistPath + 'fonts';
 
+// PatternFly color variables -- imported here so they can be used throughout
+// PF3 color variables
+@import '~patternfly/dist/sass/patternfly/color-variables';
+// PF4 color variables
+// Note these vars have slightly different names to PF3 ones (imported above)
+// i.e., $color-pf-black-100 (PF3) vs $pf-color-black-100 (PF4)
+@import '~@patternfly/patternfly/sass-utilities/colors';
+
 
 // == Overrides of external dependency variables
 
@@ -36,27 +44,24 @@ $co-m-label-line-height: 19px;
 
 // == Colors
 
-$color-error: $color-pf-red-100;
-$color-primary: $color-pf-blue-300;
-// TODO (jon) review color usage throughout app and consolidate common colors into this file
-
 $color-alertmanager-dark: $color-pf-orange-500;
 $color-co-m-row-hover: #fafafa;
 $color-configmap-dark: $color-pf-purple-600;
 $color-container-dark: $color-pf-light-blue-400;
+$color-error: $color-pf-red-100;
 $color-grey-background-border: #ccc;
 $color-ingress-dark: $color-pf-purple-700;
 $color-namespace-dark: $color-pf-green-500;
 $color-node-dark: $color-pf-purple-400;
 $color-pod-dark: $color-pf-cyan-400;
 $color-pod-overlord: $color-pf-blue-600;
+$color-primary: $color-pf-blue-300;
 $color-rbac-binding-dark: $color-pf-cyan-500;
 $color-rbac-role-dark: $color-pf-orange-600;
 $color-secret-dark: $color-pf-orange-400;
 $color-service-dark: $color-pf-light-green-500;
 $color-text-muted: $color-pf-black-600;
-$color-text-primary: $pf-global--Color--100;
-$color-text-secondary: $pf-global--Color--200;
+$color-text-secondary: $color-pf-black-600;
 // -- Depend on color vars defined above
 $color-alert-dark: $color-container-dark;
 $color-alertrule-dark: $color-configmap-dark;

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -1,7 +1,4 @@
 // Config
-@import '~patternfly/dist/sass/patternfly/color-variables';
-@import '~@patternfly/patternfly/sass-utilities/all';
-@import "~@patternfly/patternfly/_variables";
 @import "style/vars";
 
 // External dependencies (tilde tells Webpack not to use relative path). Seperate SCSS entrypoint here because some modules break sourcemaps.
@@ -59,8 +56,7 @@
 @import '~patternfly-react-extensions/dist/sass/filter-side-panel';
 @import '~patternfly-react-extensions/dist/sass/properties-side-panel';
 @import '~patternfly-react-extensions/dist/sass/vertical-tabs';
-
-// Note: PF Sass load order is important and can cause issues if changed
+@import '~@patternfly/patternfly/sass-utilities/all';
+@import "~@patternfly/patternfly/_variables";
 @import "~@patternfly/patternfly/_fonts";
 @import "~@patternfly/patternfly/_base";
-@import '~@patternfly/patternfly/utilities/Display/display';


### PR DESCRIPTION
* Restores PF4 imports to the way they were before so we can use SCSS overrides on PF4
* Removes PF4 display utilities as there is no need to add those when PF3 offers an equivalent that already exists
* Removes unnecessary table style declarations