### PR TITLE
Fix OLM InstallMode Logic

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/operator-group.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/operator-group.spec.tsx
@@ -149,12 +149,26 @@ describe('supports', () => {
   it('correctly returns for an Operator that can only run in its own namespace', () => {
     set = [
       {type: InstallModeType.InstallModeTypeOwnNamespace, supported: true},
-      {type: InstallModeType.InstallModeTypeSingleNamespace, supported: true},
+      {type: InstallModeType.InstallModeTypeSingleNamespace, supported: false},
       {type: InstallModeType.InstallModeTypeMultiNamespace, supported: false},
       {type: InstallModeType.InstallModeTypeAllNamespaces, supported: false},
     ];
 
     expect(supports(set)(ownNamespaceGroup)).toBe(true);
+    expect(supports(set)(singleNamespaceGroup)).toBe(false);
+    expect(supports(set)(multiNamespaceGroup)).toBe(false);
+    expect(supports(set)(allNamespacesGroup)).toBe(false);
+  });
+
+  it('correctly returns for an Operator that can only run in a single namespace', () => {
+    set = [
+      {type: InstallModeType.InstallModeTypeOwnNamespace, supported: false},
+      {type: InstallModeType.InstallModeTypeSingleNamespace, supported: true},
+      {type: InstallModeType.InstallModeTypeMultiNamespace, supported: false},
+      {type: InstallModeType.InstallModeTypeAllNamespaces, supported: false},
+    ];
+
+    expect(supports(set)(ownNamespaceGroup)).toBe(false);
     expect(supports(set)(singleNamespaceGroup)).toBe(true);
     expect(supports(set)(multiNamespaceGroup)).toBe(false);
     expect(supports(set)(allNamespacesGroup)).toBe(false);
@@ -176,7 +190,7 @@ describe('supports', () => {
 
   it('correctly returns for an Operator which can only run in all namespaces', () => {
     set = [
-      {type: InstallModeType.InstallModeTypeOwnNamespace, supported: true},
+      {type: InstallModeType.InstallModeTypeOwnNamespace, supported: false},
       {type: InstallModeType.InstallModeTypeSingleNamespace, supported: false},
       {type: InstallModeType.InstallModeTypeMultiNamespace, supported: false},
       {type: InstallModeType.InstallModeTypeAllNamespaces, supported: true},

--- a/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
@@ -8,7 +8,7 @@ import * as catalogPageView from '../../views/catalog-page.view';
 import * as operatorHubView from '../../views/operator-hub.view';
 import * as sidenavView from '../../views/sidenav.view';
 
-describe('Interacting with a `SingleNamespace` install mode Operator (Prometheus)', () => {
+describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)', () => {
   const prometheusResources = new Set(['StatefulSet', 'Pod']);
   const alertmanagerResources = new Set(['StatefulSet', 'Pod']);
   const serviceMonitorResources = new Set(['Pod']);
@@ -67,7 +67,7 @@ describe('Interacting with a `SingleNamespace` install mode Operator (Prometheus
 
   it('selects target namespace for Operator subscription', async() => {
     await browser.wait(until.visibilityOf(operatorHubView.createSubscriptionFormInstallMode));
-    await operatorHubView.singleNamespaceInstallMode.click();
+    await operatorHubView.ownNamespaceInstallMode.click();
     await browser.wait(until.visibilityOf(operatorHubView.installNamespaceDropdownBtn));
     await operatorHubView.installNamespaceDropdownBtn.click();
     await operatorHubView.installNamespaceDropdownFilter(testName);

--- a/frontend/integration-tests/views/operator-hub.view.ts
+++ b/frontend/integration-tests/views/operator-hub.view.ts
@@ -17,7 +17,7 @@ export const createSubscriptionFormBtn = element(by.buttonText('Subscribe'));
 export const createSubscriptionFormLoaded = () => browser.wait(until.visibilityOf(createSubscriptionFormBtn));
 export const createSubscriptionFormInstallMode = element(by.cssContainingText('label', 'Installation Mode'));
 export const allNamespacesInstallMode = $('input[value="AllNamespaces"]');
-export const singleNamespaceInstallMode = $('input[value="SingleNamespace"]');
+export const ownNamespaceInstallMode = $('input[value="OwnNamespace"]');
 export const createSubscriptionError = $('.alert-danger');
 
 export const installNamespaceDropdown = $('.dropdown--full-width');

--- a/frontend/public/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-subscribe.tsx
@@ -38,7 +38,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
   const selectedInstallMode = installMode || supportedInstallModesFor(props.packageManifest.data[0])(selectedUpdateChannel)
     .reduce((preferredInstallMode, mode) => mode.type === InstallModeType.InstallModeTypeAllNamespaces
       ? InstallModeType.InstallModeTypeAllNamespaces
-      : preferredInstallMode, InstallModeType.InstallModeTypeSingleNamespace);
+      : preferredInstallMode, InstallModeType.InstallModeTypeOwnNamespace);
   let selectedTargetNamespace = targetNamespace || props.targetNamespace;
   if (selectedInstallMode === InstallModeType.InstallModeTypeAllNamespaces) {
     selectedTargetNamespace = _.get(props.operatorGroup, 'data', [] as OperatorGroupKind[]).find(og => og.metadata.name === 'global-operators').metadata.namespace;
@@ -60,13 +60,13 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
   }, [catalogSource, catalogSourceNamespace, pkgName, props.packageManifest.data, selectedTargetNamespace]);
 
   const installModes = channels.find(ch => ch.name === selectedUpdateChannel).currentCSVDesc.installModes;
-  const supportsSingle = installModes.find(m => m.type === InstallModeType.InstallModeTypeSingleNamespace).supported;
+  const supportsSingle = installModes.find(m => m.type === InstallModeType.InstallModeTypeOwnNamespace).supported;
   const supportsGlobal = installModes.find(m => m.type === InstallModeType.InstallModeTypeAllNamespaces).supported;
   const descFor = (mode: InstallModeType) => {
     if (mode === InstallModeType.InstallModeTypeAllNamespaces && supportsGlobal) {
       return 'Operator will be available in all namespaces.';
     }
-    if (mode === InstallModeType.InstallModeTypeSingleNamespace && supportsSingle) {
+    if (mode === InstallModeType.InstallModeTypeOwnNamespace && supportsSingle) {
       return 'Operator will be available in a single namespace only.';
     }
     return 'This mode is not supported by this Operator';
@@ -169,21 +169,21 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
             </Tooltip>
           </div>
           <div>
-            <Tooltip content={descFor(InstallModeType.InstallModeTypeSingleNamespace)} hidden={!supportsSingle}>
+            <Tooltip content={descFor(InstallModeType.InstallModeTypeOwnNamespace)} hidden={!supportsSingle}>
               <RadioInput
                 onChange={e => {
                   setInstallMode(e.target.value);
                   setTargetNamespace(null);
                   setCannotResolve(false);
                 }}
-                value={InstallModeType.InstallModeTypeSingleNamespace}
-                checked={selectedInstallMode === InstallModeType.InstallModeTypeSingleNamespace}
+                value={InstallModeType.InstallModeTypeOwnNamespace}
+                checked={selectedInstallMode === InstallModeType.InstallModeTypeOwnNamespace}
                 disabled={!supportsSingle}
                 title="A specific namespace on the cluster">
                 <div className="co-m-radio-desc">
-                  <p className="text-muted">{descFor(InstallModeType.InstallModeTypeSingleNamespace)}</p>
+                  <p className="text-muted">{descFor(InstallModeType.InstallModeTypeOwnNamespace)}</p>
                 </div>
-                { selectedInstallMode === InstallModeType.InstallModeTypeSingleNamespace && <div style={{marginLeft: '20px'}}>
+                { selectedInstallMode === InstallModeType.InstallModeTypeOwnNamespace && <div style={{marginLeft: '20px'}}>
                   <NsDropdown
                     id="dropdown-selectbox"
                     selectedKey={selectedTargetNamespace}


### PR DESCRIPTION
### Description

Update `installMode` check to match [logic in Operator Lifecycle Manager](match Operator Lifecycle Manager) and allow installing `OwnNamespace` Operators.

Addresses https://jira.coreos.com/browse/OLM-1112