### PR TITLE
Move cmd/bridge/config.go into pkg

### DIFF
--- a/pkg/bridge/validate.go
+++ b/pkg/bridge/validate.go
@@ -1,0 +1,54 @@
+package bridge
+
+import (
+	"fmt"
+	"github.com/coreos/pkg/capnslog"
+	"net/url"
+)
+
+var (
+	plog = capnslog.NewPackageLogger("github.com/openshift/console", "bridge")
+)
+
+func ValidateFlagNotEmpty(name string, value string) string {
+	if value == "" {
+		FlagFatalf(name, "value is required")
+	}
+
+	return value
+}
+
+func ValidateFlagIsURL(name string, value string) *url.URL {
+	ValidateFlagNotEmpty(name, value)
+
+	ur, err := url.Parse(value)
+	if err != nil {
+		FlagFatalf(name, "%v", err)
+	}
+
+	if ur == nil || ur.String() == "" || ur.Scheme == "" || ur.Host == "" {
+		FlagFatalf(name, "malformed URL")
+	}
+
+	return ur
+}
+
+func ValidateFlagIs(name string, value string, expectedValues ...string) string {
+	if len(expectedValues) != 1 {
+		for _, v := range expectedValues {
+			if v == value {
+				return value
+			}
+		}
+		FlagFatalf(name, "value must be one of %s, not %s", expectedValues, value)
+	}
+	if value != expectedValues[0] {
+		FlagFatalf(name, "value must be %s, not %s", expectedValues[0], value)
+	}
+
+	return value
+}
+
+func FlagFatalf(name string, format string, a ...interface{}) {
+	plog.Fatalf("Invalid flag: %s, error: %s", name, fmt.Sprintf(format, a...))
+}

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -1,4 +1,4 @@
-package main
+package serverconfig
 
 import (
 	"errors"
@@ -8,61 +8,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 )
-
-// Config is the top-level console configuration.
-type Config struct {
-	APIVersion    string `yaml:"apiVersion"`
-	Kind          string `yaml:"kind"`
-	ServingInfo   `yaml:"servingInfo"`
-	ClusterInfo   `yaml:"clusterInfo"`
-	Auth          `yaml:"auth"`
-	Customization `yaml:"customization"`
-	Providers     `yaml:"providers"`
-}
-
-// ServingInfo holds configuration for serving HTTP.
-type ServingInfo struct {
-	BindAddress string `yaml:"bindAddress"`
-	CertFile    string `yaml:"certFile"`
-	KeyFile     string `yaml:"keyFile"`
-
-	// These fields are defined in `HTTPServingInfo`, but are not supported for console. Fail if any are specified.
-	// https://github.com/openshift/api/blob/0cb4131a7636e1ada6b2769edc9118f0fe6844c8/config/v1/types.go#L7-L38
-	BindNetwork           string        `yaml:"bindNetwork"`
-	ClientCA              string        `yaml:"clientCA"`
-	NamedCertificates     []interface{} `yaml:"namedCertificates"`
-	MinTLSVersion         string        `yaml:"minTLSVersion"`
-	CipherSuites          []string      `yaml:"cipherSuites"`
-	MaxRequestsInFlight   int64         `yaml:"maxRequestsInFlight"`
-	RequestTimeoutSeconds int64         `yaml:"requestTimeoutSeconds"`
-}
-
-// ClusterInfo holds information the about the cluster such as master public URL and console public URL.
-type ClusterInfo struct {
-	ConsoleBaseAddress string `yaml:"consoleBaseAddress"`
-	ConsoleBasePath    string `yaml:"consoleBasePath"`
-	MasterPublicURL    string `yaml:"masterPublicURL"`
-}
-
-// Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".
-type Auth struct {
-	ClientID            string `yaml:"clientID"`
-	ClientSecretFile    string `yaml:"clientSecretFile"`
-	OAuthEndpointCAFile string `yaml:"oauthEndpointCAFile"`
-	LogoutRedirect      string `yaml:"logoutRedirect"`
-}
-
-// Customization holds configuration such as what logo to use.
-type Customization struct {
-	Branding             string `yaml:"branding"`
-	DocumentationBaseURL string `yaml:"documentationBaseURL"`
-	CustomProductName    string `yaml:"customProductName"`
-	CustomLogoFile       string `yaml:"customLogoFile"`
-}
-
-type Providers struct {
-	StatuspageID string `yaml:"statuspageID"`
-}
 
 // SetFlagsFromConfig sets flag values based on a YAML config file.
 func SetFlagsFromConfig(fs *flag.FlagSet, filename string) (err error) {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -1,0 +1,61 @@
+package serverconfig
+
+
+// This file is a copy of the struct within the console operator:
+//   https://github.com/openshift/console-operator/blob/master/pkg/console/subresource/consoleserver/types.go
+// These structs need to remain in sync.
+
+// Config is the top-level console server cli configuration.
+type Config struct {
+	APIVersion    string `yaml:"apiVersion"`
+	Kind          string `yaml:"kind"`
+	ServingInfo   `yaml:"servingInfo"`
+	ClusterInfo   `yaml:"clusterInfo"`
+	Auth          `yaml:"auth"`
+	Customization `yaml:"customization"`
+	Providers     `yaml:"providers"`
+}
+
+// ServingInfo holds configuration for serving HTTP.
+type ServingInfo struct {
+	BindAddress string `yaml:"bindAddress,omitempty"`
+	CertFile    string `yaml:"certFile,omitempty"`
+	KeyFile     string `yaml:"keyFile,omitempty"`
+
+	// These fields are defined in `HTTPServingInfo`, but are not supported for console. Fail if any are specified.
+	// https://github.com/openshift/api/blob/0cb4131a7636e1ada6b2769edc9118f0fe6844c8/config/v1/types.go#L7-L38
+	BindNetwork           string        `yaml:"bindNetwork,omitempty"`
+	ClientCA              string        `yaml:"clientCA,omitempty"`
+	NamedCertificates     []interface{} `yaml:"namedCertificates,omitempty"`
+	MinTLSVersion         string        `yaml:"minTLSVersion,omitempty"`
+	CipherSuites          []string      `yaml:"cipherSuites,omitempty"`
+	MaxRequestsInFlight   int64         `yaml:"maxRequestsInFlight,omitempty"`
+	RequestTimeoutSeconds int64         `yaml:"requestTimeoutSeconds,omitempty"`
+}
+
+// ClusterInfo holds information the about the cluster such as master public URL and console public URL.
+type ClusterInfo struct {
+	ConsoleBaseAddress string `yaml:"consoleBaseAddress,omitempty"`
+	ConsoleBasePath    string `yaml:"consoleBasePath,omitempty"`
+	MasterPublicURL    string `yaml:"masterPublicURL,omitempty"`
+}
+
+// Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".
+type Auth struct {
+	ClientID            string `yaml:"clientID,omitempty"`
+	ClientSecretFile    string `yaml:"clientSecretFile,omitempty"`
+	OAuthEndpointCAFile string `yaml:"oauthEndpointCAFile,omitempty"`
+	LogoutRedirect      string `yaml:"logoutRedirect,omitempty"`
+}
+
+// Customization holds configuration such as what logo to use.
+type Customization struct {
+	Branding             string `yaml:"branding,omitempty"`
+	DocumentationBaseURL string `yaml:"documentationBaseURL,omitempty"`
+	CustomProductName    string `yaml:"customProductName,omitempty"`
+	CustomLogoFile       string `yaml:"customLogoFile,omitempty"`
+}
+
+type Providers struct {
+	StatuspageID string `yaml:"statuspageID,omitempty"`
+}


### PR DESCRIPTION
- Moves server config into /pkg/serverconfig instead of in /cmd/bridge
- Splits config into 2 files:
  - `types.go` is the set of structs, which is [shared with the operator](https://github.com/openshift/console-operator/blob/master/pkg/console/subresource/consoleserver/config.go).  We need to keep these in sync easily so splitting out just the types is helpful.
  - config.go is the helper funcs used by console only, not needed by
the operator
- Moves a few validation funcs into /pkg/bridge/validate.go

/assign @spadgett @jhadvig 