### PR TITLE
Add the top consumers card to dashboard

### DIFF
--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -20,6 +20,7 @@ import {
   DashboardsInventoryItemGroup,
   DashboardsOverviewQuery,
   DashboardsOverviewUtilizationItem,
+  DashboardsOverviewTopConsumerItem,
 } from '@console/plugin-sdk';
 
 // TODO(vojtech): internal code needed by plugins should be moved to console-shared package
@@ -28,6 +29,7 @@ import { FLAGS } from '@console/internal/const';
 import { GridPosition } from '@console/internal/components/dashboard/grid';
 import { humanizeBinaryBytesWithoutB } from '@console/internal/components/utils/units';
 import { OverviewQuery } from '@console/internal/components/dashboards-page/overview-dashboard/queries';
+import { MetricType } from '@console/internal/components/dashboard/top-consumers-card/metric-type';
 
 import { FooBarModel } from './models';
 import { yamlTemplates } from './yaml-templates';
@@ -53,7 +55,8 @@ type ConsumedExtensions =
   | DashboardsOverviewInventoryItem
   | DashboardsInventoryItemGroup
   | DashboardsOverviewQuery
-  | DashboardsOverviewUtilizationItem;
+  | DashboardsOverviewUtilizationItem
+  | DashboardsOverviewTopConsumerItem;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -240,6 +243,19 @@ const plugin: Plugin<ConsumedExtensions> = [
       title: 'Foo',
       query: 'barQuery',
       humanizeValue: humanizeBinaryBytesWithoutB,
+    },
+  },
+  {
+    type: 'Dashboards/Overview/TopConsumers/Item',
+    properties: {
+      name: 'Prometheus',
+      metric: 'pod_name',
+      queries: {
+        [MetricType.CPU]:
+          'sort(topk(5, pod_name:container_cpu_usage:sum{pod_name=~"prometheus-.*"}))',
+      },
+      mutator: (data) =>
+        data.map((datum) => ({ ...datum, x: (datum.x as string).replace('prometheus-', '') })),
     },
   },
 ];

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -18,6 +18,7 @@ import {
   isDashboardsInventoryItemGroup,
   isDashboardsOverviewQuery,
   isDashboardsOverviewUtilizationItem,
+  isDashboardsOverviewTopConsumerItem,
   isOverviewResourceTab,
   isOverviewCRD,
 } from './typings';
@@ -90,6 +91,10 @@ export class ExtensionRegistry {
 
   public getDashboardsInventoryItemGroups() {
     return this.extensions.filter(isDashboardsInventoryItemGroup);
+  }
+
+  public getDashboardsOverviewTopConsumerItems() {
+    return this.extensions.filter(isDashboardsOverviewTopConsumerItem);
   }
 
   public getOverviewResourceTabs() {

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -4,6 +4,8 @@ import { FirehoseResource, Humanize } from '@console/internal/components/utils';
 import { K8sKind } from '@console/internal/module/k8s';
 import { StatusGroupMapper } from '@console/internal/components/dashboard/inventory-card/inventory-item';
 import { OverviewQuery } from '@console/internal/components/dashboards-page/overview-dashboard/queries';
+import { ConsumerMutator } from '@console/internal/components/dashboards-page/overview-dashboard/top-consumers-card';
+import { MetricType } from '@console/internal/components/dashboard/top-consumers-card/metric-type';
 
 import { Extension } from './extension';
 import { LazyLoader } from './types';
@@ -67,6 +69,20 @@ namespace ExtensionProperties {
 
     /** The Prometheus query */
     query: string;
+  }
+
+  export interface DashboardsOverviewTopConsumerItem {
+    /** The name of the top consumer item */
+    name: string;
+
+    /** The name of the metric */
+    metric: string;
+
+    /** The queries which will be used to query prometheus */
+    queries: { [key in MetricType]?: string };
+
+    /** Function which can mutate results of parsed prometheus data */
+    mutator?: ConsumerMutator;
   }
 
   export interface DashboardsOverviewInventoryItem {
@@ -182,5 +198,14 @@ export interface DashboardsInventoryItemGroup
 export const isDashboardsInventoryItemGroup = (
   e: Extension<any>,
 ): e is DashboardsInventoryItemGroup => e.type === 'Dashboards/Inventory/Item/Group';
+
+export interface DashboardsOverviewTopConsumerItem
+  extends Extension<ExtensionProperties.DashboardsOverviewTopConsumerItem> {
+  type: 'Dashboards/Overview/TopConsumers/Item';
+}
+
+export const isDashboardsOverviewTopConsumerItem = (
+  e: Extension<any>,
+): e is DashboardsOverviewTopConsumerItem => e.type === 'Dashboards/Overview/TopConsumers/Item';
 
 export type DashboardCardSpan = 4 | 6 | 12;

--- a/frontend/public/components/dashboard/top-consumers-card/consumers-body.tsx
+++ b/frontend/public/components/dashboard/top-consumers-card/consumers-body.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export const ConsumersBody: React.FC<ConsumersBodyProps> = React.memo(({ children }) => (
+  <div className="co-consumers-card__body">
+    {children}
+  </div>
+));
+
+type ConsumersBodyProps = {
+  children?: React.ReactNode;
+};

--- a/frontend/public/components/dashboard/top-consumers-card/consumers-filter.tsx
+++ b/frontend/public/components/dashboard/top-consumers-card/consumers-filter.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+
+import { CPU_DESC, MEMORY_DESC, STORAGE_DESC, NETWORK_DESC } from './strings';
+import { humanizeNumber, humanizeBinaryBytesWithoutB, humanizeDecimalBytesPerSec, Humanize } from '../../utils';
+import { MetricType } from './metric-type';
+
+export const metricTypeMap: MetricTypeMap = {
+  [MetricType.CPU]: {
+    description: CPU_DESC,
+    humanize: humanizeNumber,
+  },
+  [MetricType.MEMORY]: {
+    description: MEMORY_DESC,
+    humanize: humanizeBinaryBytesWithoutB,
+  },
+  [MetricType.STORAGE]: {
+    description: STORAGE_DESC,
+    humanize: humanizeNumber,
+  },
+  [MetricType.NETWORK]: {
+    description: NETWORK_DESC,
+    humanize: humanizeDecimalBytesPerSec,
+  },
+};
+
+export const ConsumersFilter: React.FC<ConsumersFilterProps> = ({ children }) =>
+  <div className="co-consumers-card__filters">{children}</div>;
+
+type ConsumersFilterProps = {
+  children: React.ReactNode;
+};
+
+type MetricTypeMap = {
+  [key: string]: {
+    description: string,
+    humanize: Humanize,
+  },
+};

--- a/frontend/public/components/dashboard/top-consumers-card/index.ts
+++ b/frontend/public/components/dashboard/top-consumers-card/index.ts
@@ -1,0 +1,2 @@
+export * from './consumers-filter';
+export * from './consumers-body';

--- a/frontend/public/components/dashboard/top-consumers-card/metric-type.ts
+++ b/frontend/public/components/dashboard/top-consumers-card/metric-type.ts
@@ -1,0 +1,6 @@
+export enum MetricType {
+  CPU = 'By CPU',
+  MEMORY = 'By Memory',
+  STORAGE = 'By Storage',
+  NETWORK = 'By Network',
+}

--- a/frontend/public/components/dashboard/top-consumers-card/strings.js
+++ b/frontend/public/components/dashboard/top-consumers-card/strings.js
@@ -1,0 +1,7 @@
+export const CPU_DESC = 'CPU time';
+export const MEMORY_DESC = 'Memory consumption';
+export const STORAGE_DESC = 'Filesystem IO time';
+export const NETWORK_DESC = 'Network consumption';
+
+export const PODS = 'Pods';
+export const NODES = 'Nodes';

--- a/frontend/public/components/dashboard/top-consumers-card/top-consumers-card.scss
+++ b/frontend/public/components/dashboard/top-consumers-card/top-consumers-card.scss
@@ -1,0 +1,9 @@
+.co-consumers-card__filters {
+  border-bottom: 1px solid $pf-color-black-300;
+  display: flex;
+  padding-bottom: 0.6em;
+}
+
+.co-consumers-card__body {
+  text-align: center;
+}

--- a/frontend/public/components/dashboards-page/overview-dashboard/capacity-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/capacity-card.tsx
@@ -12,7 +12,7 @@ import { CapacityBody, CapacityItem } from '../../dashboard/capacity-card';
 import { withDashboardResources, DashboardItemProps } from '../with-dashboard-resources';
 import { humanizePercentage, humanizeDecimalBytesPerSec, humanizeBinaryBytesWithoutB } from '../../utils';
 import { getInstantVectorStats, getRangeVectorStats, GetStats } from '../../graphs/utils';
-import { OverviewQuery, overviewQueries } from './queries';
+import { OverviewQuery, capacityQueries } from './queries';
 
 const getLastStats = (response, getStats: GetStats): React.ReactText => {
   const stats = getStats(response);
@@ -27,7 +27,7 @@ const getQueries = () => {
       pluginQueries[queryKey] = pluginQuery.properties.query;
     }
   });
-  return _.defaults(pluginQueries, overviewQueries);
+  return _.defaults(pluginQueries, capacityQueries);
 };
 
 export const CapacityCard_: React.FC<DashboardItemProps> = ({

--- a/frontend/public/components/dashboards-page/overview-dashboard/overview-dashboard.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/overview-dashboard.tsx
@@ -7,11 +7,12 @@ import { CapacityCard } from './capacity-card';
 import { InventoryCard } from './inventory-card';
 import { EventsCard } from './events-card';
 import { UtilizationCard } from './utilization-card';
+import { TopConsumersCard } from './top-consumers-card';
 
 export const OverviewDashboard: React.FC<{}> = () => {
   const mainCards = [{Card: HealthCard}, {Card: CapacityCard}, {Card: UtilizationCard}];
   const leftCards = [{Card: DetailsCard}, {Card: InventoryCard}];
-  const rightCards = [{Card: EventsCard}];
+  const rightCards = [{Card: EventsCard}, {Card: TopConsumersCard}];
 
   return (
     <Dashboard>

--- a/frontend/public/components/dashboards-page/overview-dashboard/queries.ts
+++ b/frontend/public/components/dashboards-page/overview-dashboard/queries.ts
@@ -6,9 +6,17 @@ export enum OverviewQuery {
   CPU_UTILIZATION = 'CPU_UTILIZATION',
   STORAGE_UTILIZATION = 'STORAGE_UTILIZATION',
   STORAGE_TOTAL = 'STORAGE_TOTAL',
+  PODS_BY_CPU = 'PODS_BY_CPU',
+  PODS_BY_MEMORY = 'PODS_BY_MEMORY',
+  PODS_BY_STORAGE = 'PODS_BY_STORAGE',
+  PODS_BY_NETWORK = 'PODS_BY_NETWORK',
+  NODES_BY_CPU = 'NODES_BY_CPU',
+  NODES_BY_MEMORY = 'NODES_BY_MEMORY',
+  NODES_BY_STORAGE = 'NODES_BY_STORAGE',
+  NODES_BY_NETWORK = 'NODES_BY_NETWORK',
 }
 
-export const overviewQueries = {
+const overviewQueries = {
   [OverviewQuery.MEMORY_TOTAL]: 'sum(kube_node_status_capacity_memory_bytes)',
   [OverviewQuery.MEMORY_UTILIZATION]: '(sum(kube_node_status_capacity_memory_bytes) - sum(kube_node_status_allocatable_memory_bytes))[60m:5m]',
   [OverviewQuery.NETWORK_TOTAL]: 'sum(avg by(instance)(node_network_speed_bytes))',
@@ -16,10 +24,40 @@ export const overviewQueries = {
   [OverviewQuery.CPU_UTILIZATION]: '((sum(node:node_cpu_utilisation:avg1m) / count(node:node_cpu_utilisation:avg1m)) * 100)[60m:5m]',
   [OverviewQuery.STORAGE_UTILIZATION]: '(sum(node_filesystem_size_bytes) - sum(node_filesystem_free_bytes))[60m:5m]',
   [OverviewQuery.STORAGE_TOTAL]: 'sum(node_filesystem_size_bytes)',
+  [OverviewQuery.PODS_BY_CPU]: 'sort(topk(5, pod_name:container_cpu_usage:sum))',
+  [OverviewQuery.PODS_BY_MEMORY]: 'sort(topk(5, pod_name:container_memory_usage_bytes:sum))',
+  [OverviewQuery.PODS_BY_STORAGE]: 'sort(topk(5, avg by (pod_name)(irate(container_fs_io_time_seconds_total{container_name="POD", pod_name!=""}[1m]))))',
+  [OverviewQuery.PODS_BY_NETWORK]: `sort(topk(5, sum by (pod_name)(irate(container_network_receive_bytes_total{container_name="POD", pod_name!=""}[1m]) + 
+irate(container_network_transmit_bytes_total{container_name="POD", pod_name!=""}[1m]))))`,
+  [OverviewQuery.NODES_BY_CPU]: 'sort(topk(5, node:node_cpu_utilisation:avg1m))',
+  [OverviewQuery.NODES_BY_MEMORY]: 'sort(topk(5, node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum))',
+  [OverviewQuery.NODES_BY_STORAGE]: 'sort(topk(5, node:node_disk_utilisation:avg_irate{cluster=""}))',
+  [OverviewQuery.NODES_BY_NETWORK]: 'sort(topk(5, node:node_net_utilisation:sum_irate{cluster=""}))',
+};
+
+export const capacityQueries = {
+  [OverviewQuery.MEMORY_TOTAL]: overviewQueries[OverviewQuery.MEMORY_TOTAL],
+  [OverviewQuery.MEMORY_UTILIZATION]: overviewQueries[OverviewQuery.MEMORY_UTILIZATION],
+  [OverviewQuery.NETWORK_TOTAL]: overviewQueries[OverviewQuery.NETWORK_TOTAL],
+  [OverviewQuery.NETWORK_UTILIZATION]: overviewQueries[OverviewQuery.NETWORK_UTILIZATION],
+  [OverviewQuery.CPU_UTILIZATION]: overviewQueries[OverviewQuery.CPU_UTILIZATION],
+  [OverviewQuery.STORAGE_UTILIZATION]: overviewQueries[OverviewQuery.STORAGE_UTILIZATION],
+  [OverviewQuery.STORAGE_TOTAL]: overviewQueries[OverviewQuery.STORAGE_TOTAL],
 };
 
 export const utilizationQueries = {
   [OverviewQuery.CPU_UTILIZATION]: overviewQueries[OverviewQuery.CPU_UTILIZATION],
   [OverviewQuery.MEMORY_UTILIZATION]: overviewQueries[OverviewQuery.MEMORY_UTILIZATION],
   [OverviewQuery.STORAGE_UTILIZATION]: overviewQueries[OverviewQuery.STORAGE_UTILIZATION],
+};
+
+export const topConsumersQueries = {
+  [OverviewQuery.PODS_BY_CPU]: overviewQueries[OverviewQuery.PODS_BY_CPU],
+  [OverviewQuery.PODS_BY_MEMORY]: overviewQueries[OverviewQuery.PODS_BY_MEMORY],
+  [OverviewQuery.PODS_BY_STORAGE]: overviewQueries [OverviewQuery.PODS_BY_STORAGE],
+  [OverviewQuery.PODS_BY_NETWORK]: overviewQueries[OverviewQuery.PODS_BY_NETWORK],
+  [OverviewQuery.NODES_BY_CPU]: overviewQueries[OverviewQuery.NODES_BY_CPU],
+  [OverviewQuery.NODES_BY_MEMORY]: overviewQueries[OverviewQuery.NODES_BY_MEMORY],
+  [OverviewQuery.NODES_BY_STORAGE]: overviewQueries[OverviewQuery.NODES_BY_STORAGE],
+  [OverviewQuery.NODES_BY_NETWORK]: overviewQueries[OverviewQuery.NODES_BY_NETWORK],
 };

--- a/frontend/public/components/dashboards-page/overview-dashboard/top-consumers-card.scss
+++ b/frontend/public/components/dashboards-page/overview-dashboard/top-consumers-card.scss
@@ -1,0 +1,11 @@
+.co-overview-consumers__dropdown {
+  width: 100%;
+}
+
+.co-overview-consumers__dropdown--left {
+  padding-left: 0.3em;
+}
+
+.co-overview-consumers__dropdown--right {
+  padding-right: 0.3em;
+}

--- a/frontend/public/components/dashboards-page/overview-dashboard/top-consumers-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/top-consumers-card.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import * as plugins from '../../../plugins';
+import {
+  DashboardCard,
+  DashboardCardBody,
+  DashboardCardHeader,
+  DashboardCardTitle,
+} from '../../dashboard/dashboard-card';
+import { ConsumersBody, ConsumersFilter, metricTypeMap } from '../../dashboard/top-consumers-card';
+import {
+  NODES,
+  PODS,
+} from '../../dashboard/top-consumers-card/strings';
+import { DashboardItemProps, withDashboardResources } from '../with-dashboard-resources';
+import { Dropdown } from '../../utils';
+import { OverviewQuery, topConsumersQueries } from './queries';
+import { getInstantVectorStats } from '../../graphs/utils';
+import { BarChart } from '../../graphs/bar';
+import { DataPoint } from '../../graphs';
+import { MetricType } from '../../dashboard/top-consumers-card/metric-type';
+
+const topConsumersQueryMap: TopConsumersMap = {
+  [PODS]: {
+    metric: 'pod_name',
+    queries: {
+      [MetricType.CPU]: topConsumersQueries[OverviewQuery.PODS_BY_CPU],
+      [MetricType.MEMORY]: topConsumersQueries[OverviewQuery.PODS_BY_MEMORY],
+      [MetricType.STORAGE]: topConsumersQueries[OverviewQuery.PODS_BY_STORAGE],
+    },
+  },
+  [NODES]: {
+    metric: 'node',
+    queries: {
+      [MetricType.CPU]: topConsumersQueries[OverviewQuery.NODES_BY_CPU],
+      [MetricType.MEMORY]: topConsumersQueries[OverviewQuery.NODES_BY_MEMORY],
+      [MetricType.STORAGE]: topConsumersQueries[OverviewQuery.NODES_BY_STORAGE],
+      [MetricType.NETWORK]: topConsumersQueries[OverviewQuery.NODES_BY_NETWORK],
+    },
+  },
+};
+
+const getTopConsumersQueries = (): TopConsumersMap => {
+  const topConsumers = {...topConsumersQueryMap};
+
+  plugins.registry.getDashboardsOverviewTopConsumerItems().forEach(pluginItem => {
+    if (!topConsumers[pluginItem.properties.name]) {
+      topConsumers[pluginItem.properties.name] = {
+        metric: pluginItem.properties.metric,
+        queries: pluginItem.properties.queries,
+        mutator: pluginItem.properties.mutator,
+      };
+    }
+  });
+  return topConsumers;
+};
+
+const TopConsumersCard_: React.FC<DashboardItemProps> = ({
+  watchPrometheus,
+  stopWatchPrometheusQuery,
+  prometheusResults,
+}) => {
+  const [type, setType] = React.useState(PODS);
+  const [sortOption, setSortOption] = React.useState(MetricType.CPU);
+
+  React.useEffect(() => {
+    const topConsumersMap = getTopConsumersQueries();
+    const currentQuery = topConsumersMap[type].queries[sortOption];
+    watchPrometheus(currentQuery);
+    return () => stopWatchPrometheusQuery(currentQuery);
+  }, [watchPrometheus, stopWatchPrometheusQuery, type, sortOption]);
+
+  const topConsumersMap = getTopConsumersQueries();
+  const topConsumersType = topConsumersMap[type];
+  const metricTypeSort = metricTypeMap[sortOption];
+  const currentQuery = topConsumersType.queries[sortOption];
+  const topConsumersResult = prometheusResults.getIn([currentQuery, 'result']);
+
+  const stats = getInstantVectorStats(topConsumersResult, topConsumersType.metric, metricTypeSort.humanize);
+
+  const data = topConsumersType.mutator ? topConsumersType.mutator(stats) : stats;
+
+  return (
+    <DashboardCard>
+      <DashboardCardHeader>
+        <DashboardCardTitle>Top Consumers</DashboardCardTitle>
+      </DashboardCardHeader>
+      <DashboardCardBody>
+        <ConsumersFilter>
+          <Dropdown
+            buttonClassName="co-overview-consumers__dropdown"
+            dropDownClassName="co-overview-consumers__dropdown"
+            className="btn-group co-overview-consumers__dropdown co-overview-consumers__dropdown--right"
+            items={_.mapValues(topConsumersMap, (v, key) => key)}
+            onChange={(v: string) => {
+              setType(v);
+              if (!topConsumersMap[v].queries[sortOption]) {
+                setSortOption(Object.keys(topConsumersMap[v].queries)[0] as MetricType);
+              }
+            }}
+            selectedKey={type}
+            title={type}
+          />
+          <Dropdown
+            className="btn-group co-overview-consumers__dropdown co-overview-consumers__dropdown--left"
+            buttonClassName="co-overview-consumers__dropdown"
+            dropDownClassName="co-overview-consumers__dropdown"
+            items={_.mapValues(topConsumersType.queries, (v, key) => key)}
+            onChange={(v: MetricType) => setSortOption(v)}
+            selectedKey={sortOption}
+            title={sortOption}
+          />
+        </ConsumersFilter>
+        <ConsumersBody>
+          <BarChart
+            data={data}
+            query={currentQuery}
+            title={`${type} by ${metricTypeSort.description}`}
+            loading={!topConsumersResult}
+          />
+        </ConsumersBody>
+      </DashboardCardBody>
+    </DashboardCard>
+  );
+};
+
+export const TopConsumersCard = withDashboardResources(TopConsumersCard_);
+
+export type ConsumerMutator = (data: DataPoint[]) => DataPoint[];
+
+type TopConsumersMap = {
+  [key: string]: {
+    metric: string,
+    queries: { [key in MetricType]?: string },
+    mutator?: ConsumerMutator,
+  },
+};

--- a/frontend/public/components/dashboards-page/with-dashboard-resources.tsx
+++ b/frontend/public/components/dashboards-page/with-dashboard-resources.tsx
@@ -43,6 +43,7 @@ export const withDashboardResources = <P extends DashboardItemProps>(WrappedComp
     class WithDashboardResources extends React.Component<WithDashboardResourcesProps, WithDashboardResourcesState> {
       private urls: Array<string> = [];
       private queries: Array<string> = [];
+      private watchingAlerts: boolean = false;
 
       constructor(props) {
         super(props);
@@ -61,7 +62,7 @@ export const withDashboardResources = <P extends DashboardItemProps>(WrappedComp
         const alertsResultChanged = this.props[RESULTS_TYPE.ALERTS].getIn([ALERTS_KEY, 'result']) !== nextProps[RESULTS_TYPE.PROMETHEUS].getIn([ALERTS_KEY, 'result']);
         const k8sResourcesChanged = this.state.k8sResources !== nextState.k8sResources;
 
-        return urlResultChanged || queryResultChanged || alertsResultChanged || k8sResourcesChanged;
+        return urlResultChanged || queryResultChanged || k8sResourcesChanged || (this.watchingAlerts && alertsResultChanged);
       }
 
       watchURL: WatchURL = (url, fetch) => {
@@ -75,7 +76,13 @@ export const withDashboardResources = <P extends DashboardItemProps>(WrappedComp
       };
 
       watchAlerts: WatchAlerts = () => {
+        this.watchingAlerts = true;
         this.props.watchAlerts();
+      };
+
+      stopWatchAlerts: StopWatchAlerts = () => {
+        this.watchingAlerts = false;
+        this.props.stopWatchAlerts();
       };
 
       watchK8sResource: WatchK8sResource = resource => {
@@ -99,7 +106,7 @@ export const withDashboardResources = <P extends DashboardItemProps>(WrappedComp
               watchPrometheus={this.watchPrometheus}
               stopWatchPrometheusQuery={this.props.stopWatchPrometheusQuery}
               watchAlerts={this.watchAlerts}
-              stopWatchAlerts={this.props.stopWatchAlerts}
+              stopWatchAlerts={this.stopWatchAlerts}
               urlResults={this.props[RESULTS_TYPE.URL]}
               prometheusResults={this.props[RESULTS_TYPE.PROMETHEUS]}
               alertsResults={this.props[RESULTS_TYPE.ALERTS]}

--- a/frontend/public/components/graphs/bar.tsx
+++ b/frontend/public/components/graphs/bar.tsx
@@ -17,7 +17,7 @@ import { PrometheusEndpoint } from './helpers';
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
 import { barTheme } from './themes';
 import { humanizeNumber, Humanize } from '../utils';
-import { DomainPadding } from '.';
+import { DomainPadding, DataPoint } from '.';
 import { getInstantVectorStats } from './utils';
 import { GraphEmpty } from './graph-empty';
 
@@ -27,19 +27,17 @@ const DEFAULT_BAR_WIDTH = 10;
 const DEFAULT_DOMAIN_PADDING: DomainPadding = { x: [20, 10] };
 const PADDING_RATIO = 1 / 3;
 
-export const Bar: React.FC<BarProps> = ({
+export const BarChart: React.FC<BarChartProps> = ({
   barWidth = DEFAULT_BAR_WIDTH,
-  domainPadding = DEFAULT_DOMAIN_PADDING,
-  humanize = humanizeNumber,
-  metric,
-  namespace,
-  query,
-  theme = getCustomTheme(ChartThemeColor.blue, ChartThemeVariant.light, barTheme),
   title,
+  query,
+  data = [],
+  domainPadding = DEFAULT_DOMAIN_PADDING,
+  theme = getCustomTheme(ChartThemeColor.blue, ChartThemeVariant.light, barTheme),
+  titleClassName,
+  loading = false,
 }) => {
   const [containerRef, width] = useRefWidth();
-  const [response,, loading] = usePrometheusPoll({ endpoint: PrometheusEndpoint.QUERY, namespace, query });
-  const data = getInstantVectorStats(response, metric, humanize);
 
   // Max space that horizontal padding should take up. By default, 2/3 of the horizontal space is always available for the actual bar graph.
   const maxHorizontalPadding = PADDING_RATIO * width;
@@ -57,44 +55,83 @@ export const Bar: React.FC<BarProps> = ({
     right: Math.min(100, maxHorizontalPadding),
     top: topPadding,
   };
+
   const tickLabelComponent = <ChartLabel x={0} verticalAnchor="start" transform={`translate(0, -${xAxisTickLabelHeight + BAR_LABEL_PADDING})`} />;
   const labelComponent = <ChartLabel x={width} />;
-
-  return <PrometheusGraph ref={containerRef} title={title}>
-    {
-      data.length ? (
-        <PrometheusGraphLink query={query}>
-          <Chart
-            domainPadding={domainPadding}
-            height={height}
-            theme={theme}
-            width={width}
-            padding={padding}
-          >
-            <ChartAxis tickLabelComponent={tickLabelComponent} />
-            <ChartBar
-              barWidth={barWidth}
-              data={data}
-              horizontal
-              labelComponent={labelComponent}
-            />
-          </Chart>
-        </PrometheusGraphLink>
-      ) : (
-        <GraphEmpty icon={ChartBarIcon} loading={loading} height={100} />
-      )
-    }
-  </PrometheusGraph>;
+  return (
+    <PrometheusGraph ref={containerRef} title={title} className={titleClassName} >
+      {
+        data.length ? (
+          <PrometheusGraphLink query={query}>
+            <Chart
+              domainPadding={domainPadding}
+              height={height}
+              theme={theme}
+              width={width}
+              padding={padding}
+            >
+              <ChartAxis tickLabelComponent={tickLabelComponent} />
+              <ChartBar
+                barWidth={barWidth}
+                data={data}
+                horizontal
+                labelComponent={labelComponent}
+              />
+            </Chart>
+          </PrometheusGraphLink>
+        ) : (
+          <GraphEmpty icon={ChartBarIcon} loading={loading} height={100} />
+        )
+      }
+    </PrometheusGraph>
+  );
 };
 
-type BarProps = {
+export const Bar: React.FC<BarProps> = ({
+  humanize = humanizeNumber,
+  metric,
+  namespace,
+  barWidth,
+  domainPadding,
+  theme,
+  query,
+  title,
+}) => {
+  const [response,, loading] = usePrometheusPoll({ endpoint: PrometheusEndpoint.QUERY, namespace, query });
+  const data = getInstantVectorStats(response, metric, humanize);
+
+  return (
+    <BarChart
+      title={title}
+      query={query}
+      data={data}
+      barWidth={barWidth}
+      domainPadding={domainPadding}
+      theme={theme}
+      loading={loading}
+    />
+  );
+};
+
+type BarChartProps = {
   barWidth?: number;
   domainPadding?: DomainPadding;
-  humanize?: Humanize;
-  metric: string;
-  namespace?: string;
   query: string;
   theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
   title?: string;
-  spacing?: number;
+  data?: DataPoint[];
+  titleClassName?: string;
+  loading?: boolean;
+}
+
+type BarProps = {
+  humanize?: Humanize;
+  metric: string;
+  namespace?: string;
+  barWidth?: number;
+  domainPadding?: DomainPadding;
+  query: string;
+  theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
+  title?: string;
+  titleClassName: string;
 }

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -101,5 +101,8 @@
 @import "components/dashboard/inventory-card/inventory-card";
 @import "components/dashboard/events-card/events-card";
 @import "components/dashboard/utilization-card/utilization-card";
+@import "components/dashboard/top-consumers-card/top-consumers-card";
+
+@import "components/dashboards-page/overview-dashboard/top-consumers-card";
 
 @import "components/nav/nav-header";


### PR DESCRIPTION
This PR adds the top consumers card to the overview dashboard.

Loaded card:
![OKD - Google Chrome_571](https://user-images.githubusercontent.com/8544299/60922630-28219280-a26b-11e9-97ab-8234578dd3c5.png)


