### PR TITLE
Improve area and bar chart readability

### DIFF
--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -117,7 +117,7 @@ const BuildGraphs = requirePrometheus(({build}) => {
 
   return <React.Fragment>
     <div className="row">
-      <div className="col-md-4">
+      <div className="col-md-12 col-lg-4">
         <Area
           title="Memory Usage"
           formatY={humanizeDecimalBytes}
@@ -125,7 +125,7 @@ const BuildGraphs = requirePrometheus(({build}) => {
           query={`pod_name:container_memory_usage_bytes:sum{pod_name='${podName}',container_name='',namespace='${namespace}'}`}
         />
       </div>
-      <div className="col-md-4">
+      <div className="col-md-12 col-lg-4">
         <Area
           title="CPU Usage"
           formatY={humanizeCpuCores}
@@ -133,7 +133,7 @@ const BuildGraphs = requirePrometheus(({build}) => {
           query={`pod_name:container_cpu_usage:sum{pod_name='${podName}',container_name='',namespace='${namespace}'}`}
         />
       </div>
-      <div className="col-md-4">
+      <div className="col-md-12 col-lg-4">
         <Area
           title="Filesystem"
           formatY={humanizeDecimalBytes}

--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -11,7 +11,6 @@ import {
   Chart,
   ChartArea,
   ChartAxis,
-  ChartGroup,
   ChartThemeColor,
   ChartThemeVariant,
   ChartVoronoiContainer,
@@ -26,7 +25,7 @@ import { usePrometheusPoll } from './prometheus-poll-hook';
 import { areaTheme } from './themes';
 import { DataPoint, MutatorFunction, PrometheusResponse } from './';
 
-const DEFAULT_HEIGHT = 100;
+const DEFAULT_HEIGHT = 180;
 const DEFAULT_SAMPLES = 60;
 const DEFAULT_TICK_COUNT = 3;
 const DEFAULT_TIMESPAN = 60 * 60 * 1000; // 1 hour
@@ -63,7 +62,7 @@ export const Area: React.FC<AreaProps> = ({
     timespan,
   });
   const data = formatResponse(response);
-  const getLabel = ({y}) => formatY(y);
+  const getLabel = ({x, y}) => `${formatY(y)} at ${formatX(x)}`;
   const container = <ChartVoronoiContainer voronoiDimension="x" labels={getLabel} />;
   return <PrometheusGraph ref={containerRef} className={className} query={query} title={title}>
     {
@@ -78,9 +77,7 @@ export const Area: React.FC<AreaProps> = ({
         >
           <ChartAxis tickCount={tickCount} tickFormat={formatX} />
           <ChartAxis dependentAxis tickCount={tickCount} tickFormat={formatY} />
-          <ChartGroup>
-            <ChartArea data={data} />
-          </ChartGroup>
+          <ChartArea data={data} />
         </Chart>
         : <EmptyState className="graph-empty-state" variant={EmptyStateVariant.full}>
           <EmptyStateIcon size="sm" icon={ChartAreaIcon} />

--- a/frontend/public/components/graphs/themes.ts
+++ b/frontend/public/components/graphs/themes.ts
@@ -10,7 +10,7 @@ export const areaTheme = {
     padding: {
       bottom: 30,
       left: 60,
-      right: 0,
+      right: 10,
       top: 0,
     },
   },

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -217,7 +217,7 @@ export const PullSecret = (props) => {
 };
 
 export const NamespaceLineCharts = ({ns}) => <div className="row">
-  <div className="col-sm-6 col-xs-12">
+  <div className="col-md-6 col-sm-12">
     <Area
       title="CPU Usage"
       formatY={humanizeCpuCores}
@@ -225,7 +225,7 @@ export const NamespaceLineCharts = ({ns}) => <div className="row">
       query={`namespace:container_cpu_usage:sum{namespace='${ns.metadata.name}'}`}
     />
   </div>
-  <div className="col-sm-6 col-xs-12">
+  <div className="col-md-6 col-sm-12">
     <Area
       title="Memory Usage"
       formatY={humanizeDecimalBytes}

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -147,41 +147,41 @@ const NodeGraphs = requirePrometheus(({node}) => {
 
   return <React.Fragment>
     <div className="row">
-      <div className="col-md-4">
+      <div className="col-md-12 col-lg-4">
         <Area
           title="Memory Usage"
           formatY={humanizeDecimalBytes}
           query={ipQuery && `node_memory_Active_bytes${ipQuery}`}
         />
       </div>
-      <div className="col-md-4">
+      <div className="col-md-12 col-lg-4">
         <Area
           title="CPU Usage"
           formatY={humanizeCpuCores}
           query={ipQuery && `instance:node_cpu:rate:sum${ipQuery}`}
         />
       </div>
-      <div className="col-md-4">
+      <div className="col-md-12 col-lg-4">
         <Area
           title="Number of Pods"
           query={ipQuery && `kubelet_running_pod_count${ipQuery}`}
         />
       </div>
-      <div className="col-md-4">
+      <div className="col-md-12 col-lg-4">
         <Area
           title="Network In"
           formatY={humanizeDecimalBytes}
           query={ipQuery && `instance:node_network_receive_bytes:rate:sum${ipQuery}`}
         />
       </div>
-      <div className="col-md-4">
+      <div className="col-md-12 col-lg-4">
         <Area
           title="Network Out"
           formatY={humanizeDecimalBytes}
           query={ipQuery && `instance:node_network_transmit_bytes:rate:sum${ipQuery}`}
         />
       </div>
-      <div className="col-md-4">
+      <div className="col-md-12 col-lg-4">
         <Area
           title="Filesystem"
           formatY={humanizeDecimalBytes}

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -178,7 +178,7 @@ export const PodContainerTable: React.FC<PodContainerTableProps> = ({heading, co
 
 const PodGraphs = requirePrometheus(({pod}) => <React.Fragment>
   <div className="row">
-    <div className="col-md-4">
+    <div className="col-md-12 col-lg-4">
       <Area
         title="Memory Usage"
         formatY={humanizeDecimalBytes}
@@ -186,7 +186,7 @@ const PodGraphs = requirePrometheus(({pod}) => <React.Fragment>
         query={`pod_name:container_memory_usage_bytes:sum{pod_name='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}`}
       />
     </div>
-    <div className="col-md-4">
+    <div className="col-md-12 col-lg-4">
       <Area
         title="CPU Usage"
         formatY={humanizeCpuCores}
@@ -194,7 +194,7 @@ const PodGraphs = requirePrometheus(({pod}) => <React.Fragment>
         query={`pod_name:container_cpu_usage:sum{pod_name='${pod.metadata.name}',namespace='${pod.metadata.namespace}'}`}
       />
     </div>
-    <div className="col-md-4">
+    <div className="col-md-12 col-lg-4">
       <Area
         title="Filesystem"
         formatY={humanizeDecimalBytes}


### PR DESCRIPTION
- Move bar chart labels above bar so that full label is readable
- Add time to area chart tooltip
- Increase default height of area charts
- Adjust breakpoints for area charts on build, namespace, node, and pod detail pages.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1719481

![image](https://user-images.githubusercontent.com/22625502/59538337-64114400-8ec7-11e9-9ed5-2ee7c7c568f5.png)
