### PR TITLE
Fix broken ClusterServiceVersion instance links

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -249,8 +249,8 @@ export const olmNamespace = 'operator-lifecycle-manager';
 export const visibilityLabel = 'olm-visibility';
 
 type ProvidedAPIsFor = (csv: ClusterServiceVersionKind) => (CRDDescription | APIServiceDefinition)[];
-export const providedAPIsFor: ProvidedAPIsFor = csv => _.get(csv.spec, 'customresourcedefinitions.owned', [])
-  .concat(_.get(csv.spec, 'apiservicedefinitions.owned', []));
+export const providedAPIsFor: ProvidedAPIsFor = csv => _.get(csv, 'spec.customresourcedefinitions.owned', [])
+  .concat(_.get(csv, 'spec.apiservicedefinitions.owned', []));
 
 export const referenceForProvidedAPI = (desc: CRDDescription | APIServiceDefinition): GroupVersionKind => _.get(desc, 'group')
   ? referenceForGroupVersionKind((desc as APIServiceDefinition).group)(desc.version)(desc.kind)


### PR DESCRIPTION
`apiVersion` and `kind` weren't properly injected into the object, and depending on the URL, the `ClusterServiceVersion` resource name wasn't found.

/assign @alecmerdler 

Fixes https://jira.coreos.com/browse/CONSOLE-1371

Fixes this error:

```
TypeError: Cannot read property 'spec' of undefined
    at k (https://console-openshift-console.apps.spadgett.devcluster.openshift.com/static/main-chunk-6a98277096e45f27a91f.min.js:1:231596)
    at https://console-openshift-console.apps.spadgett.devcluster.openshift.com/static/main-chunk-6a98277096e45f27a91f.min.js:1:311262
    at Object.pagesFor (https://console-openshift-console.apps.spadgett.devcluster.openshift.com/static/main-chunk-6a98277096e45f27a91f.min.js:1:311608)
    at t.render (https://console-openshift-console.apps.spadgett.devcluster.openshift.com/static/main-chunk-6a98277096e45f27a91f.min.js:1:488296)
    at ki (https://console-openshift-console.apps.spadgett.devcluster.openshift.com/static/vendors~main-chunk-27caafc464533938778b.min.js:104:63002)
    at Di (https://console-openshift-console.apps.spadgett.devcluster.openshift.com/static/vendors~main-chunk-27caafc464533938778b.min.js:104:62797)
    at Ri (https://console-openshift-console.apps.spadgett.devcluster.openshift.com/static/vendors~main-chunk-27caafc464533938778b.min.js:104:66631)
    at qa (https://console-openshift-console.apps.spadgett.devcluster.openshift.com/static/vendors~main-chunk-27caafc464533938778b.min.js:104:90675)
    at Ka (https://console-openshift-console.apps.spadgett.devcluster.openshift.com/static/vendors~main-chunk-27caafc464533938778b.min.js:104:91059)
    at ks (https://console-openshift-console.apps.spadgett.devcluster.openshift.com/static/vendors~main-chunk-27caafc464533938778b.min.js:104:97946)
```