### PR TITLE
Dashboard Utilization card

### DIFF
--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -16,16 +16,18 @@ import {
   DashboardsOverviewHealthURLSubsystem,
   DashboardsCard,
   DashboardsTab,
-  DashboardsOverviewCapacityQuery,
   DashboardsOverviewInventoryItem,
   DashboardsInventoryItemGroup,
+  DashboardsOverviewQuery,
+  DashboardsOverviewUtilizationItem,
 } from '@console/plugin-sdk';
 
 // TODO(vojtech): internal code needed by plugins should be moved to console-shared package
 import { PodModel, RouteModel } from '@console/internal/models';
 import { FLAGS } from '@console/internal/const';
 import { GridPosition } from '@console/internal/components/dashboard/grid';
-import { CapacityQuery } from '@console/internal/components/dashboards-page/overview-dashboard/capacity-query-types';
+import { humanizeBinaryBytesWithoutB } from '@console/internal/components/utils/units';
+import { OverviewQuery } from '@console/internal/components/dashboards-page/overview-dashboard/queries';
 
 import { FooBarModel } from './models';
 import { yamlTemplates } from './yaml-templates';
@@ -48,9 +50,10 @@ type ConsumedExtensions =
   | DashboardsOverviewHealthURLSubsystem<any>
   | DashboardsTab
   | DashboardsCard
-  | DashboardsOverviewCapacityQuery
   | DashboardsOverviewInventoryItem
-  | DashboardsInventoryItemGroup;
+  | DashboardsInventoryItemGroup
+  | DashboardsOverviewQuery
+  | DashboardsOverviewUtilizationItem;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -198,16 +201,16 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'Dashboards/Overview/Capacity/Query',
+    type: 'Dashboards/Overview/Query',
     properties: {
-      queryKey: CapacityQuery.STORAGE_TOTAL,
+      queryKey: OverviewQuery.STORAGE_TOTAL,
       query: 'fooQuery',
     },
   },
   {
-    type: 'Dashboards/Overview/Capacity/Query',
+    type: 'Dashboards/Overview/Query',
     properties: {
-      queryKey: CapacityQuery.STORAGE_USED,
+      queryKey: OverviewQuery.STORAGE_UTILIZATION,
       query: 'barQuery',
     },
   },
@@ -228,6 +231,14 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'demo-inventory-group',
       icon: <DemoGroupIcon />,
+    },
+  },
+  {
+    type: 'Dashboards/Overview/Utilization/Item',
+    properties: {
+      title: 'Foo',
+      query: 'barQuery',
+      humanizeValue: humanizeBinaryBytesWithoutB,
     },
   },
 ];

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -14,9 +14,10 @@ import {
   isDashboardsOverviewHealthSubsystem,
   isDashboardsCard,
   isDashboardsTab,
-  isDashboardsOverviewCapacityQuery,
   isDashboardsOverviewInventoryItem,
   isDashboardsInventoryItemGroup,
+  isDashboardsOverviewQuery,
+  isDashboardsOverviewUtilizationItem,
 } from './typings';
 
 /**
@@ -73,8 +74,12 @@ export class ExtensionRegistry {
     return this.extensions.filter(isDashboardsCard);
   }
 
-  public getDashboardsOverviewCapacityQueries() {
-    return this.extensions.filter(isDashboardsOverviewCapacityQuery);
+  public getDashboardsOverviewQueries() {
+    return this.extensions.filter(isDashboardsOverviewQuery);
+  }
+
+  public getDashboardsOverviewUtilizationItems() {
+    return this.extensions.filter(isDashboardsOverviewUtilizationItem);
   }
 
   public getDashboardsOverviewInventoryItems() {

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -1,9 +1,9 @@
 import { SubsystemHealth } from '@console/internal/components/dashboards-page/overview-dashboard/health-card';
 import { GridPosition } from '@console/internal/components/dashboard/grid';
-import { CapacityQuery } from '@console/internal/components/dashboards-page/overview-dashboard/capacity-query-types';
-import { FirehoseResource } from '@console/internal/components/utils';
+import { FirehoseResource, Humanize } from '@console/internal/components/utils';
 import { K8sKind } from '@console/internal/module/k8s';
 import { StatusGroupMapper } from '@console/internal/components/dashboard/inventory-card/inventory-item';
+import { OverviewQuery } from '@console/internal/components/dashboards-page/overview-dashboard/queries';
 
 import { Extension } from './extension';
 import { LazyLoader } from './types';
@@ -58,9 +58,9 @@ namespace ExtensionProperties {
     loader: LazyLoader<any>;
   }
 
-  export interface DashboardsOverviewCapacityQuery {
+  export interface DashboardsOverviewQuery {
     /** The original Prometheus query key to replace */
-    queryKey: CapacityQuery;
+    queryKey: OverviewQuery;
 
     /** The Prometheus query */
     query: string;
@@ -89,6 +89,17 @@ namespace ExtensionProperties {
 
     /** React component representing status group icon. */
     icon: React.ReactElement;
+  }
+
+  export interface DashboardsOverviewUtilizationItem {
+    /** The utilization item title */
+    title: string;
+
+    /** The Prometheus utilization query */
+    query: string;
+
+    /** Function which will be used to format data from prometheus */
+    humanizeValue: Humanize;
   }
 }
 
@@ -134,14 +145,22 @@ export interface DashboardsCard extends Extension<ExtensionProperties.Dashboards
 export const isDashboardsCard = (e: Extension<any>): e is DashboardsCard =>
   e.type === 'Dashboards/Card';
 
-export interface DashboardsOverviewCapacityQuery
-  extends Extension<ExtensionProperties.DashboardsOverviewCapacityQuery> {
-  type: 'Dashboards/Overview/Capacity/Query';
+export interface DashboardsOverviewQuery
+  extends Extension<ExtensionProperties.DashboardsOverviewQuery> {
+  type: 'Dashboards/Overview/Query';
 }
 
-export const isDashboardsOverviewCapacityQuery = (
+export const isDashboardsOverviewQuery = (e: Extension<any>): e is DashboardsOverviewQuery =>
+  e.type === 'Dashboards/Overview/Query';
+
+export interface DashboardsOverviewUtilizationItem
+  extends Extension<ExtensionProperties.DashboardsOverviewUtilizationItem> {
+  type: 'Dashboards/Overview/Utilization/Item';
+}
+
+export const isDashboardsOverviewUtilizationItem = (
   e: Extension<any>,
-): e is DashboardsOverviewCapacityQuery => e.type === 'Dashboards/Overview/Capacity/Query';
+): e is DashboardsOverviewUtilizationItem => e.type === 'Dashboards/Overview/Utilization/Item';
 
 export interface DashboardsOverviewInventoryItem
   extends Extension<ExtensionProperties.DashboardsOverviewInventoryItem> {

--- a/frontend/public/components/dashboard/grid.tsx
+++ b/frontend/public/components/dashboard/grid.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
+import { global_breakpoint_lg as breakpointLG } from '@patternfly/react-tokens';
 
 import { useRefWidth } from '../utils/ref-width-hook';
-
-export const MEDIA_QUERY_LG = 992;
 
 export enum GridPosition {
   MAIN = 'MAIN',
@@ -18,7 +17,7 @@ const mapCardsToGrid = (cards: React.ComponentType<any>[], keyPrefix: string): R
 
 export const DashboardGrid: React.FC<DashboardGridProps> = ({ mainCards, leftCards = [], rightCards = [] }) => {
   const [containerRef, width] = useRefWidth();
-  const grid = width <= MEDIA_QUERY_LG ?
+  const grid = width <= parseInt(breakpointLG.value, 10) ?
     (
       <Grid className="co-dashboard-grid">
         <GridItem lg={12} md={12} sm={12}>

--- a/frontend/public/components/dashboard/utilization-card/index.ts
+++ b/frontend/public/components/dashboard/utilization-card/index.ts
@@ -1,0 +1,2 @@
+export * from './utilization-item';
+export * from './utilization-body';

--- a/frontend/public/components/dashboard/utilization-card/utilization-body.tsx
+++ b/frontend/public/components/dashboard/utilization-card/utilization-body.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { Row, Col } from 'patternfly-react';
+import { ChartAxis } from '@patternfly/react-charts';
+import { global_breakpoint_sm as breakpointSM } from '@patternfly/react-tokens';
+
+import { useRefWidth } from '../../utils';
+
+const formatDate = (date: Date): string => {
+  const minutes = `0${date.getMinutes()}`.slice(-2);
+  return `${date.getHours()}:${minutes}`;
+};
+
+const UtilizationAxis: React.FC<UtilizationAxisProps> = ({ timestamps, narrow = false }) => {
+  const [containerRef, width] = useRefWidth();
+  return (
+    <div ref={containerRef}>
+      <ChartAxis
+        scale={{ x: 'time' }}
+        tickValues={timestamps}
+        tickFormat={formatDate}
+        orientation="top"
+        height={15}
+        width={width}
+        padding={{ top: 25, bottom: 0, left: 70, right: narrow ? 45 : 30 }}
+        style={{
+          axis: {visibility: 'hidden'},
+        }}
+        fixLabelOverlap
+      />
+    </div>
+  );
+};
+
+export const UtilizationBody: React.FC<UtilizationBodyProps> = ({ timestamps, children }) => {
+  const [containerRef, width] = useRefWidth();
+
+  const axis = width < parseInt(breakpointSM.value, 10) ? (
+    <>
+      <Row>
+        <Col className="co-utilization-card__body-time-axis--narrow">
+          {timestamps.length > 0 && <UtilizationAxis timestamps={timestamps} narrow />}
+        </Col>
+      </Row>
+    </>
+  ) : (
+    <Row className="co-utilization-card__item">
+      <Col lg={5} md={5} sm={5} xs={5} />
+      <Col lg={7} md={7} sm={7} xs={7} className="co-utilization-card__body-time-axis--wide">
+        {timestamps.length > 0 && <UtilizationAxis timestamps={timestamps} />}
+      </Col>
+    </Row>
+  );
+  return (
+    <div ref={containerRef}>
+      {axis}
+      <div>{children}</div>
+    </div>
+  );
+};
+
+type UtilizationBodyProps = {
+  children: React.ReactNode;
+  timestamps: Date[];
+};
+
+type UtilizationAxisProps = {
+  timestamps: Date[];
+  narrow?: boolean;
+}

--- a/frontend/public/components/dashboard/utilization-card/utilization-card.scss
+++ b/frontend/public/components/dashboard/utilization-card/utilization-card.scss
@@ -1,0 +1,56 @@
+.co-utilization-card__body-time-axis--wide {
+  padding-left: 0;
+}
+
+.co-utilization-card__body-time-axis--narrow {
+  border-bottom: 1px solid $pf-color-black-300;
+  margin-right: 0.25em;
+}
+
+.co-utilization-card__item {
+  border-bottom: 1px solid $pf-color-black-300;
+  font-size: 1.333em;
+}
+
+.co-utilization-card__item-chart {
+  text-align: center;
+
+  svg {
+    overflow: visible;
+  }
+}
+
+.co-utilization-card__item-chart--narrow {
+  text-align: center;
+}
+
+.co-utilization-card__item-chart--wide {
+  border-left: 1px solid $pf-color-black-300;
+  padding-left: 0;
+}
+
+.co-utilization-card__item-current {
+  text-align: right;
+}
+
+.co-utilization-card__item-current--narrow {
+  font-size: 0.9em;
+}
+
+.co-utilization-card__item-row--narrow {
+  margin-right: 0.25em;
+}
+
+.co-utilization-card__item-title-row--narrow {
+  margin-bottom: 0.5em;
+  margin-top: 1em;
+}
+
+.co-utilization-card__item-title--narrow {
+  font-size: 0.875rem;
+}
+
+.co-utilization-card__item--wide {
+  align-items: center;
+  display: flex;
+}

--- a/frontend/public/components/dashboard/utilization-card/utilization-item.tsx
+++ b/frontend/public/components/dashboard/utilization-card/utilization-item.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { Col, Row } from 'patternfly-react';
+import { global_breakpoint_sm as breakpointSM } from '@patternfly/react-tokens';
+
+import { useRefWidth, LoadingInline, Humanize } from '../../utils';
+import { DataPoint } from '../../graphs';
+import { AreaChart } from '../../graphs/area';
+
+export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
+  ({ title, data, humanizeValue, isLoading = false, query }) => {
+    const [containerRef, width] = useRefWidth();
+
+    let current;
+    let chart;
+    if (isLoading) {
+      chart = <LoadingInline />;
+    } else {
+      if (data.length) {
+        const latestData = data[data.length - 1];
+        current = humanizeValue(latestData.y).string;
+      }
+
+      chart = (
+        <AreaChart
+          data={data}
+          query={query}
+          xAxis={false}
+          humanize={humanizeValue}
+          padding={{ top: 20, left: 70, bottom: 7, right: 30 }}
+          height={100}
+        />
+      );
+    }
+
+    const rows = width < parseInt(breakpointSM.value, 10) ? (
+      <div className="co-utilization-card__item">
+        <Row className="co-utilization-card__item-row--narrow co-utilization-card__item-title-row--narrow">
+          <Col lg={6} md={6} sm={6} xs={6} className="co-utilization-card__item-title--narrow">
+            {title}
+          </Col>
+          <Col className="co-utilization-card__item-current co-utilization-card__item-current--narrow" lg={6} md={6} sm={6} xs={6}>
+            {current}
+          </Col>
+        </Row>
+        <Row className="co-utilization-card__item-row--narrow">
+          <Col className="co-utilization-card__item-chart co-utilization-card__item-chart--narrow">{chart}</Col>
+        </Row>
+      </div>
+    ) : (
+      <Row className="co-utilization-card__item co-utilization-card__item--wide">
+        <Col lg={3} md={3} sm={3} xs={3}>
+          {title}
+        </Col>
+        <Col className="co-utilization-card__item-current" lg={2} md={2} sm={2} xs={2}>
+          {current}
+        </Col>
+        <Col
+          className="co-utilization-card__item-chart co-utilization-card__item-chart--wide"
+          lg={7}
+          md={7}
+          sm={7}
+          xs={7}
+        >
+          {chart}
+        </Col>
+      </Row>
+    );
+
+    return <div ref={containerRef}>{rows}</div>;
+  }
+);
+
+type UtilizationItemProps = {
+  title: string;
+  data?: DataPoint[];
+  isLoading: boolean,
+  humanizeValue: Humanize,
+  query: string,
+};

--- a/frontend/public/components/dashboards-page/overview-dashboard/capacity-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/capacity-card.tsx
@@ -12,17 +12,7 @@ import { CapacityBody, CapacityItem } from '../../dashboard/capacity-card';
 import { withDashboardResources, DashboardItemProps } from '../with-dashboard-resources';
 import { humanizePercentage, humanizeDecimalBytesPerSec, humanizeBinaryBytesWithoutB } from '../../utils';
 import { getInstantVectorStats, getRangeVectorStats, GetStats } from '../../graphs/utils';
-import { CapacityQuery } from './capacity-query-types';
-
-const defaultQueries = {
-  [CapacityQuery.CPU_USED]: '((sum(node:node_cpu_utilisation:avg1m) / count(node:node_cpu_utilisation:avg1m)) * 100)[60m:5m]',
-  [CapacityQuery.MEMORY_TOTAL]: 'sum(kube_node_status_capacity_memory_bytes)',
-  [CapacityQuery.MEMORY_USED]: '(sum(kube_node_status_capacity_memory_bytes) - sum(kube_node_status_allocatable_memory_bytes))[60m:5m]',
-  [CapacityQuery.STORAGE_TOTAL]: 'sum(node_filesystem_size_bytes)',
-  [CapacityQuery.STORAGE_USED]: '(sum(node_filesystem_size_bytes) - sum(node_filesystem_free_bytes))[60m:5m]',
-  [CapacityQuery.NETWORK_TOTAL]: 'sum(avg by(instance)(node_network_speed_bytes))',
-  [CapacityQuery.NETWORK_USED]: 'sum(node:node_net_utilisation:sum_irate)',
-};
+import { OverviewQuery, overviewQueries } from './queries';
 
 const getLastStats = (response, getStats: GetStats): React.ReactText => {
   const stats = getStats(response);
@@ -31,13 +21,13 @@ const getLastStats = (response, getStats: GetStats): React.ReactText => {
 
 const getQueries = () => {
   const pluginQueries = {};
-  plugins.registry.getDashboardsOverviewCapacityQueries().forEach(cq => {
-    const queryKey = cq.properties.queryKey;
+  plugins.registry.getDashboardsOverviewQueries().forEach(pluginQuery => {
+    const queryKey = pluginQuery.properties.queryKey;
     if (!pluginQueries[queryKey]) {
-      pluginQueries[queryKey] = cq.properties.query;
+      pluginQueries[queryKey] = pluginQuery.properties.query;
     }
   });
-  return _.defaults(pluginQueries, defaultQueries);
+  return _.defaults(pluginQueries, overviewQueries);
 };
 
 export const CapacityCard_: React.FC<DashboardItemProps> = ({
@@ -52,13 +42,13 @@ export const CapacityCard_: React.FC<DashboardItemProps> = ({
   }, [watchPrometheus, stopWatchPrometheusQuery]);
 
   const queries = getQueries();
-  const cpuUtilization = prometheusResults.getIn([queries[CapacityQuery.CPU_USED], 'result']);
-  const memoryUtilization = prometheusResults.getIn([queries[CapacityQuery.MEMORY_USED], 'result']);
-  const memoryTotal = prometheusResults.getIn([queries[CapacityQuery.MEMORY_TOTAL], 'result']);
-  const storageUsed = prometheusResults.getIn([queries[CapacityQuery.STORAGE_USED], 'result']);
-  const storageTotal = prometheusResults.getIn([queries[CapacityQuery.STORAGE_TOTAL], 'result']);
-  const networkUsed = prometheusResults.getIn([queries[CapacityQuery.NETWORK_USED], 'result']);
-  const networkTotal = prometheusResults.getIn([queries[CapacityQuery.NETWORK_TOTAL], 'result']);
+  const cpuUtilization = prometheusResults.getIn([queries[OverviewQuery.CPU_UTILIZATION], 'result']);
+  const memoryUtilization = prometheusResults.getIn([queries[OverviewQuery.MEMORY_UTILIZATION], 'result']);
+  const memoryTotal = prometheusResults.getIn([queries[OverviewQuery.MEMORY_TOTAL], 'result']);
+  const storageUsed = prometheusResults.getIn([queries[OverviewQuery.STORAGE_UTILIZATION], 'result']);
+  const storageTotal = prometheusResults.getIn([queries[OverviewQuery.STORAGE_TOTAL], 'result']);
+  const networkUsed = prometheusResults.getIn([queries[OverviewQuery.NETWORK_UTILIZATION], 'result']);
+  const networkTotal = prometheusResults.getIn([queries[OverviewQuery.NETWORK_TOTAL], 'result']);
 
   return (
     <DashboardCard>

--- a/frontend/public/components/dashboards-page/overview-dashboard/overview-dashboard.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/overview-dashboard.tsx
@@ -6,9 +6,10 @@ import { DetailsCard } from './details-card';
 import { CapacityCard } from './capacity-card';
 import { InventoryCard } from './inventory-card';
 import { EventsCard } from './events-card';
+import { UtilizationCard } from './utilization-card';
 
 export const OverviewDashboard: React.FC<{}> = () => {
-  const mainCards = [HealthCard, CapacityCard];
+  const mainCards = [HealthCard, CapacityCard, UtilizationCard];
   const leftCards = [DetailsCard, InventoryCard];
   const rightCards = [EventsCard];
 

--- a/frontend/public/components/dashboards-page/overview-dashboard/queries.ts
+++ b/frontend/public/components/dashboards-page/overview-dashboard/queries.ts
@@ -1,0 +1,25 @@
+export enum OverviewQuery {
+  MEMORY_TOTAL = 'MEMORY_TOTAL',
+  MEMORY_UTILIZATION = 'MEMORY_UTILIZATION',
+  NETWORK_TOTAL = 'NETWORK_TOTAL',
+  NETWORK_UTILIZATION = 'NETWORK_UTILIZATION',
+  CPU_UTILIZATION = 'CPU_UTILIZATION',
+  STORAGE_UTILIZATION = 'STORAGE_UTILIZATION',
+  STORAGE_TOTAL = 'STORAGE_TOTAL',
+}
+
+export const overviewQueries = {
+  [OverviewQuery.MEMORY_TOTAL]: 'sum(kube_node_status_capacity_memory_bytes)',
+  [OverviewQuery.MEMORY_UTILIZATION]: '(sum(kube_node_status_capacity_memory_bytes) - sum(kube_node_status_allocatable_memory_bytes))[60m:5m]',
+  [OverviewQuery.NETWORK_TOTAL]: 'sum(avg by(instance)(node_network_speed_bytes))',
+  [OverviewQuery.NETWORK_UTILIZATION]: 'sum(node:node_net_utilisation:sum_irate)',
+  [OverviewQuery.CPU_UTILIZATION]: '((sum(node:node_cpu_utilisation:avg1m) / count(node:node_cpu_utilisation:avg1m)) * 100)[60m:5m]',
+  [OverviewQuery.STORAGE_UTILIZATION]: '(sum(node_filesystem_size_bytes) - sum(node_filesystem_free_bytes))[60m:5m]',
+  [OverviewQuery.STORAGE_TOTAL]: 'sum(node_filesystem_size_bytes)',
+};
+
+export const utilizationQueries = {
+  [OverviewQuery.CPU_UTILIZATION]: overviewQueries[OverviewQuery.CPU_UTILIZATION],
+  [OverviewQuery.MEMORY_UTILIZATION]: overviewQueries[OverviewQuery.MEMORY_UTILIZATION],
+  [OverviewQuery.STORAGE_UTILIZATION]: overviewQueries[OverviewQuery.STORAGE_UTILIZATION],
+};

--- a/frontend/public/components/dashboards-page/overview-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/utilization-card.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import * as plugins from '../../../plugins';
+import {
+  DashboardCard,
+  DashboardCardBody,
+  DashboardCardHeader,
+  DashboardCardTitle,
+} from '../../dashboard/dashboard-card';
+import { UtilizationItem, UtilizationBody } from '../../dashboard/utilization-card';
+import { DashboardItemProps, withDashboardResources } from '../with-dashboard-resources';
+import { getRangeVectorStats } from '../../graphs/utils';
+import { humanizePercentage, humanizeBinaryBytesWithoutB } from '../../utils';
+import { OverviewQuery, utilizationQueries } from './queries';
+
+const getQueries = () => {
+  const pluginQueries = {};
+  plugins.registry.getDashboardsOverviewQueries().forEach(pluginQuery => {
+    const queryKey = pluginQuery.properties.queryKey;
+    if (!pluginQueries[queryKey]) {
+      pluginQueries[queryKey] = pluginQuery.properties.query;
+    }
+  });
+  return _.defaults(pluginQueries, utilizationQueries);
+};
+
+const UtilizationCard_: React.FC<DashboardItemProps> = ({
+  watchPrometheus,
+  stopWatchPrometheusQuery,
+  prometheusResults,
+}) => {
+  React.useEffect(() => {
+    const queries = getQueries();
+    Object.keys(queries).forEach(key => watchPrometheus(queries[key]));
+
+    const pluginItems = plugins.registry.getDashboardsOverviewUtilizationItems();
+    pluginItems.forEach(item => watchPrometheus(item.properties.query));
+    return () => {
+      Object.keys(queries).forEach(key => stopWatchPrometheusQuery(queries[key]));
+      pluginItems.forEach(item => stopWatchPrometheusQuery(item.properties.query));
+    };
+  }, [watchPrometheus, stopWatchPrometheusQuery]);
+
+  const queries = getQueries();
+  const cpuUtilization = prometheusResults.getIn([queries[OverviewQuery.CPU_UTILIZATION], 'result']);
+  const memoryUtilization = prometheusResults.getIn([queries[OverviewQuery.MEMORY_UTILIZATION], 'result']);
+  const storageUtilization = prometheusResults.getIn([queries[OverviewQuery.STORAGE_UTILIZATION], 'result']);
+
+  const cpuStats = getRangeVectorStats(cpuUtilization);
+  const memoryStats = getRangeVectorStats(memoryUtilization);
+  const storageStats = getRangeVectorStats(storageUtilization);
+
+  const pluginItems = plugins.registry.getDashboardsOverviewUtilizationItems();
+
+  return (
+    <DashboardCard>
+      <DashboardCardHeader>
+        <DashboardCardTitle>Cluster Utilization</DashboardCardTitle>
+      </DashboardCardHeader>
+      <DashboardCardBody>
+        <UtilizationBody timestamps={cpuStats.map(stat => stat.x as Date)}>
+          <UtilizationItem
+            title="CPU"
+            data={cpuStats}
+            isLoading={!cpuUtilization}
+            humanizeValue={humanizePercentage}
+            query={queries[OverviewQuery.CPU_UTILIZATION]}
+          />
+          <UtilizationItem
+            title="Memory"
+            data={memoryStats}
+            isLoading={!(memoryUtilization)}
+            humanizeValue={humanizeBinaryBytesWithoutB}
+            query={queries[OverviewQuery.MEMORY_UTILIZATION]}
+          />
+          <UtilizationItem
+            title="Disk Usage"
+            data={storageStats}
+            isLoading={!(storageUtilization)}
+            humanizeValue={humanizeBinaryBytesWithoutB}
+            query={queries[OverviewQuery.STORAGE_UTILIZATION]}
+          />
+          {pluginItems.map(({ properties }, index) => {
+            const utilization = prometheusResults.getIn([properties.query, 'result']);
+            const utilizationStats = getRangeVectorStats(utilization);
+            return (
+              <UtilizationItem
+                key={index}
+                title={properties.title}
+                data={utilizationStats}
+                isLoading={!utilization}
+                humanizeValue={properties.humanizeValue}
+                query={properties.query}
+              />
+            );
+          })}
+        </UtilizationBody>
+      </DashboardCardBody>
+    </DashboardCard>
+  );
+};
+
+export const UtilizationCard = withDashboardResources(UtilizationCard_);

--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -22,6 +22,7 @@ import { PrometheusEndpoint } from './helpers';
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
 import { usePrometheusPoll } from './prometheus-poll-hook';
 import { areaTheme } from './themes';
+import { DataPoint } from './';
 import { getRangeVectorStats } from './utils';
 
 const DEFAULT_HEIGHT = 180;
@@ -29,21 +30,59 @@ const DEFAULT_SAMPLES = 60;
 const DEFAULT_TICK_COUNT = 3;
 const DEFAULT_TIMESPAN = 60 * 60 * 1000; // 1 hour
 
-export const Area: React.FC<AreaProps> = ({
+export const AreaChart: React.FC<AreaChartProps> = ({
   className,
-  formatDate = twentyFourHourTime,
+  query,
+  title,
   height = DEFAULT_HEIGHT,
+  theme = getCustomTheme(ChartThemeColor.blue, ChartThemeVariant.light, areaTheme),
+  tickCount = DEFAULT_TICK_COUNT,
   humanize = humanizeNumber,
+  formatDate = twentyFourHourTime,
+  data,
+  xAxis = true,
+  yAxis = true,
+  padding,
+}) => {
+  const [containerRef, width] = useRefWidth();
+  const getLabel = ({x, y}) => `${humanize(y).string} at ${formatDate(x)}`;
+  const container = <ChartVoronoiContainer voronoiDimension="x" labels={getLabel} />;
+  return (
+    <PrometheusGraph ref={containerRef} className={className} title={title}>
+      {data.length ? (
+        <PrometheusGraphLink query={query}>
+          <Chart
+            containerComponent={container}
+            domainPadding={{y: 20}}
+            height={height}
+            width={width}
+            theme={theme}
+            scale={{x: 'time', y: 'linear'}}
+            padding={padding}
+          >
+            {xAxis && <ChartAxis tickCount={tickCount} tickFormat={formatDate} />}
+            {yAxis && <ChartAxis dependentAxis tickCount={tickCount} tickFormat={tick => humanize(tick).string} />}
+            <ChartArea data={data} />
+          </Chart>
+        </PrometheusGraphLink>
+      ) : (
+        <EmptyState className="graph-empty-state" variant={EmptyStateVariant.full}>
+          <EmptyStateIcon size="sm" icon={ChartAreaIcon} />
+          <Title size="sm">No Prometheus datapoints found.</Title>
+        </EmptyState>
+      )}
+    </PrometheusGraph>)
+  ;
+};
+
+export const Area: React.FC<AreaProps> = ({
   namespace,
   query,
   samples = DEFAULT_SAMPLES,
-  theme = getCustomTheme(ChartThemeColor.blue, ChartThemeVariant.light, areaTheme),
-  tickCount = DEFAULT_TICK_COUNT,
   timeout,
   timespan = DEFAULT_TIMESPAN,
-  title,
+  ...rest
 }) => {
-  const [containerRef, width] = useRefWidth();
   const [response] = usePrometheusPoll({
     endpoint: PrometheusEndpoint.QUERY_RANGE,
     namespace,
@@ -53,46 +92,30 @@ export const Area: React.FC<AreaProps> = ({
     timespan,
   });
   const data = getRangeVectorStats(response);
-  const getLabel = ({x, y}) => `${humanize(y).string} at ${formatDate(x)}`;
-  const container = <ChartVoronoiContainer voronoiDimension="x" labels={getLabel} />;
-  return <PrometheusGraph ref={containerRef} className={className} title={title}>
-    {
-      data.length ? (
-        <PrometheusGraphLink query={query}>
-          <Chart
-            containerComponent={container}
-            domainPadding={{y: 20}}
-            height={height}
-            width={width}
-            theme={theme}
-            scale={{x: 'time', y: 'linear'}}
-          >
-            <ChartAxis tickCount={tickCount} tickFormat={formatDate} />
-            <ChartAxis dependentAxis tickCount={tickCount} tickFormat={tick => humanize(tick).string} />
-            <ChartArea data={data} />
-          </Chart>
-        </PrometheusGraphLink>
-      ) : (
-        <EmptyState className="graph-empty-state" variant={EmptyStateVariant.full}>
-          <EmptyStateIcon size="sm" icon={ChartAreaIcon} />
-          <Title size="sm">No Prometheus datapoints found.</Title>
-        </EmptyState>
-      )
-    }
-  </PrometheusGraph>;
+  return (
+    <AreaChart data={data} query={query} {...rest} />
+  );
 };
 
-type AreaProps = {
+type AreaChartProps = {
   className?: string;
-  formatDate: (date: Date) => string;
-  humanize: Humanize;
+  formatDate?: (date: Date) => string;
+  humanize?: Humanize;
   height?: number,
+  query: string;
+  theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
+  tickCount?: number;
+  title?: string;
+  data?: DataPoint[];
+  xAxis?: boolean;
+  yAxis?: boolean;
+  padding?: object;
+}
+
+type AreaProps = AreaChartProps & {
   namespace?: string;
   query: string;
   samples?: number;
-  theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
-  tickCount?: number;
   timeout?: string;
   timespan?: number;
-  title?: string;
 }

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -101,5 +101,6 @@
 @import "components/dashboard/capacity-card/capacity-card";
 @import "components/dashboard/inventory-card/inventory-card";
 @import "components/dashboard/events-card/events-card";
+@import "components/dashboard/utilization-card/utilization-card";
 
 @import "components/nav/nav-header";


### PR DESCRIPTION
![utilization](https://user-images.githubusercontent.com/2078045/60270938-b3a53600-98f1-11e9-8785-7750d4bf512b.png)

@TheRealJon I've extracted Area chart component which is not using prometheus hook so it can be reused by Dashboard too. Same as I did in #1723 for Gauge.