### PR TITLE
Better OLM E2E Cleanup

### DIFF
--- a/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
@@ -51,8 +51,8 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Redis)', ()
 
   afterAll(() => {
     execSync(`kubectl delete catalogsource -n ${catalogNamespace} ${catalogSource.metadata.name}`);
-    execSync(`kubectl delete subscription -n ${globalOperatorsNamespace} --field-selector metadata.name=redis-enterprise`);
-    execSync(`kubectl delete clusterserviceversion -n ${globalOperatorsNamespace} --field-selector metadata.name=redis-enterprise-operator.v0.0.1`);
+    execSync(`kubectl delete subscription -n ${globalOperatorsNamespace} redis-enterprise`);
+    execSync(`kubectl delete clusterserviceversion -n ${globalOperatorsNamespace} redis-enterprise-operator.v0.0.1`);
   });
 
   afterEach(() => {

--- a/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
@@ -45,8 +45,8 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
 
   afterAll(() => {
     execSync(`kubectl delete catalogsource -n ${testName} ${catalogSource.metadata.name}`);
-    execSync(`kubectl delete subscription -n ${testName} --field-selector metadata.name=prometheus`);
-    execSync(`kubectl delete clusterserviceversion -n ${testName} --field-selector metadata.name=prometheusoperator.0.27.0`);
+    execSync(`kubectl delete subscription -n ${testName} prometheus`);
+    execSync(`kubectl delete clusterserviceversion -n ${testName} prometheusoperator.0.27.0`);
   });
 
   afterEach(() => {


### PR DESCRIPTION
### Description

Just delete test objects using `metadata.name` instead of `--field-selector` flag.

Fixes https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_console/1725/pull-ci-openshift-console-master-e2e-aws-console-olm/1947