### PR TITLE
Add support for custom table filters

### DIFF
--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -1,5 +1,4 @@
 import * as _ from 'lodash-es';
-import * as fuzzy from 'fuzzysearch';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -14,15 +13,7 @@ import {
 
 import * as UIActions from '../../actions/ui';
 import { ingressValidHosts } from '../ingress';
-import { routeStatus } from '../routes';
-import { secretTypeFilterReducer } from '../secret';
-import { bindingType, roleType } from '../RBAC';
-import {
-  alertState,
-  alertStateOrder,
-  silenceState,
-  silenceStateOrder,
-} from '../../reducers/monitoring';
+import { alertStateOrder, silenceStateOrder } from '../../reducers/monitoring';
 import {
   EmptyBox,
   LabelList,
@@ -34,13 +25,11 @@ import {
 } from '../utils';
 import {
   getJobTypeAndCompletions,
-  nodeStatus,
   K8sKind,
   K8sResourceKind,
   K8sResourceKindReference,
   planExternalName,
   podPhase,
-  podPhaseFilterReducer,
   podReadiness,
   serviceCatalogStatus,
   serviceClassDisplayName,
@@ -50,156 +39,15 @@ import {
   getNodeRoles,
 } from '../../module/k8s';
 
-const fuzzyCaseInsensitive = (a, b) => fuzzy(_.toLower(a), _.toLower(b));
+import { tableFilters, TableFilterMap } from './table-filters';
 
-// TODO: Having list filters here is undocumented, stringly-typed, and non-obvious. We can change that
-const listFilters = {
-  'name': (filter, obj) => fuzzyCaseInsensitive(filter, obj.metadata.name),
-
-  'alert-name': (filter, alert) => fuzzyCaseInsensitive(filter, _.get(alert, 'labels.alertname')),
-
-  'alert-state': (filter, alert) => filter.selected.has(alertState(alert)),
-
-  'silence-name': (filter, silence) => fuzzyCaseInsensitive(filter, silence.name),
-
-  'silence-state': (filter, silence) => filter.selected.has(silenceState(silence)),
-
-  // Filter role by role kind
-  'role-kind': (filter, role) => filter.selected.has(roleType(role)),
-
-  // Filter role bindings by role kind
-  'role-binding-kind': (filter, binding) => filter.selected.has(bindingType(binding)),
-
-  // Filter role bindings by text match
-  'role-binding': (str, {metadata, roleRef, subject}) => {
-    const isMatch = val => fuzzyCaseInsensitive(str, val);
-    return [metadata.name, roleRef.name, subject.kind, subject.name].some(isMatch);
-  },
-
-  // Filter role bindings by roleRef name
-  'role-binding-roleRef': (roleRef, binding) => binding.roleRef.name === roleRef,
-
-  'selector': (selector, obj) => {
-    if (!selector || !selector.values || !selector.values.size) {
-      return true;
-    }
-    return selector.values.has(_.get(obj, selector.field));
-  },
-
-  'pod-status': (phases, pod) => {
-    if (!phases || !phases.selected || !phases.selected.size) {
-      return true;
-    }
-
-    const phase = podPhaseFilterReducer(pod);
-    return phases.selected.has(phase) || !_.includes(phases.all, phase);
-  },
-
-  'node-status': (statuses, node) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
-
-    const status = nodeStatus(node);
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
-
-  'clusterserviceversion-resource-kind': (filters, resource) => {
-    if (!filters || !filters.selected || !filters.selected.size) {
-      return true;
-    }
-    return filters.selected.has(resource.kind);
-  },
-
-  'packagemanifest-name': (filter, pkg) => fuzzyCaseInsensitive(filter, (pkg.status.defaultChannel
-    ? pkg.status.channels.find(ch => ch.name === pkg.status.defaultChannel)
-    : pkg.status.channels[0]).currentCSVDesc.displayName),
-
-  'build-status': (phases, build) => {
-    if (!phases || !phases.selected || !phases.selected.size) {
-      return true;
-    }
-
-    const phase = build.status.phase;
-    return phases.selected.has(phase) || !_.includes(phases.all, phase);
-  },
-
-  'build-strategy': (strategies, buildConfig) => {
-    if (!strategies || !strategies.selected || !strategies.selected.size) {
-      return true;
-    }
-
-    const strategy = buildConfig.spec.strategy.type;
-    return strategies.selected.has(strategy) || !_.includes(strategies.all, strategy);
-  },
-
-  'route-status': (statuses, route) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
-
-    const status = routeStatus(route);
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
-
-  'catalog-status': (statuses, catalog) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
-
-    const status = serviceCatalogStatus(catalog);
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
-
-  'secret-type': (types, secret) => {
-    if (!types || !types.selected || !types.selected.size) {
-      return true;
-    }
-    const type = secretTypeFilterReducer(secret);
-    return types.selected.has(type) || !_.includes(types.all, type);
-  },
-
-  'pvc-status': (phases, pvc) => {
-    if (!phases || !phases.selected || !phases.selected.size) {
-      return true;
-    }
-
-    const phase = pvc.status.phase;
-    return phases.selected.has(phase) || !_.includes(phases.all, phase);
-  },
-
-  // Filter service classes by text match
-  'service-class': (str, serviceClass) => {
-    const displayName = serviceClassDisplayName(serviceClass);
-    return fuzzyCaseInsensitive(str, displayName);
-  },
-
-  'cluster-operator-status': (statuses, operator) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
-
-    const status = getClusterOperatorStatus(operator);
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
-
-  'template-instance-status': (statuses, instance) => {
-    if (!statuses || !statuses.selected || !statuses.selected.size) {
-      return true;
-    }
-
-    const status = getTemplateInstanceStatus(instance);
-    return statuses.selected.has(status) || !_.includes(statuses.all, status);
-  },
-};
-
-const getFilteredRows = (_filters, objects) => {
+const getFilteredRows = (_filters, customFilterFuncs: TableFilterMap, objects) => {
   if (_.isEmpty(_filters)) {
     return objects;
   }
 
   _.each(_filters, (value, name) => {
-    const filter = listFilters[name];
+    const filter = tableFilters[name] || customFilterFuncs[name];
     if (_.isFunction(filter)) {
       objects = _.filter(objects, o => filter(value, o));
     }
@@ -214,7 +62,7 @@ const filterPropType = (props, propName, componentName) => {
   }
 
   for (const key of _.keys(props[propName])) {
-    if (key in listFilters || key === 'loadTest') {
+    if (key in tableFilters || key in props.customFilterFuncs || key === 'loadTest') {
       continue;
     }
     return new Error(`Invalid prop '${propName}' in '${componentName}'. '${key}' is not a valid filter type!`);
@@ -398,9 +246,9 @@ Rows.propTypes = {
 
 const skeletonTable = <div className="loading-skeleton--table" />;
 
-const stateToProps = ({UI}, {data = [], defaultSortField = 'metadata.name', defaultSortFunc = undefined, filters = {}, loaded = false, reduxID = null, reduxIDs = null, staticFilters = [{}]}) => {
+const stateToProps = ({UI}, {data = [], defaultSortField = 'metadata.name', defaultSortFunc = undefined, filters = {}, loaded = false, reduxID = null, reduxIDs = null, staticFilters = [{}], customFilterFuncs = {}}) => {
   const allFilters = staticFilters ? Object.assign({}, filters, ...staticFilters) : filters;
-  let newData = getFilteredRows(allFilters, data);
+  let newData = getFilteredRows(allFilters, customFilterFuncs, data);
 
   const listId = reduxIDs ? reduxIDs.join(',') : reduxID;
   // Only default to 'metadata.name' if no `defaultSortFunc`
@@ -576,6 +424,7 @@ export type ListInnerProps = {
   sortList?: (...args) => any;
   staticFilters?: any[];
   virtualize?: boolean;
+  customFilterFuncs?: TableFilterMap;
 };
 
 export type ResourceRowProps = {

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -47,7 +47,7 @@ const rowFiltersToFilterFuncs = (rowFilters) => {
     .reduce((acc, f) => ({ ...acc, [f.type]: f.filter }), {});
 };
 
-const getAllTableFilters = (rowFilters) => ({
+const getAllTableFilters = (rowFilters = []) => ({
   ...rowFiltersToFilterFuncs(rowFilters),
   ...tableFilters,
 });

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -48,8 +48,8 @@ const rowFiltersToFilterFuncs = (rowFilters) => {
 };
 
 const getAllTableFilters = (rowFilters = []) => ({
-  ...rowFiltersToFilterFuncs(rowFilters),
   ...tableFilters,
+  ...rowFiltersToFilterFuncs(rowFilters),
 });
 
 const getFilteredRows = (_filters, rowFilters, objects) => {

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -12,7 +12,6 @@ import {
   serviceClassDisplayName,
   getClusterOperatorStatus,
   getTemplateInstanceStatus,
-  K8sResourceKind,
 } from '../../module/k8s';
 
 import {
@@ -163,15 +162,15 @@ export const tableFilters: TableFilterMap = {
   },
 };
 
-interface FilterGroups {
+interface TableFilterGroups {
   selected: Set<string>;
   all: string[];
   values: Set<string>;
   field: string;
 }
 
-type TableFilter<T extends K8sResourceKind> = (filters: FilterGroups, obj: T) => boolean;
+export type TableFilter = (groups: TableFilterGroups, obj: any) => boolean;
 
-export type TableFilterMap = {
-  [key: string]: TableFilter<any>;
+type TableFilterMap = {
+  [key: string]: TableFilter;
 }

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -1,0 +1,177 @@
+import * as _ from 'lodash-es';
+import * as fuzzy from 'fuzzysearch';
+
+import { routeStatus } from '../routes';
+import { secretTypeFilterReducer } from '../secret';
+import { bindingType, roleType } from '../RBAC';
+
+import {
+  nodeStatus,
+  podPhaseFilterReducer,
+  serviceCatalogStatus,
+  serviceClassDisplayName,
+  getClusterOperatorStatus,
+  getTemplateInstanceStatus,
+  K8sResourceKind,
+} from '../../module/k8s';
+
+import {
+  alertState,
+  silenceState,
+} from '../../reducers/monitoring';
+
+const fuzzyCaseInsensitive = (a, b) => fuzzy(_.toLower(a), _.toLower(b));
+
+// TODO: Table filters are undocumented, stringly-typed, and non-obvious. We can change that.
+export const tableFilters: TableFilterMap = {
+  'name': (filter, obj) => fuzzyCaseInsensitive(filter, obj.metadata.name),
+
+  'alert-name': (filter, alert) => fuzzyCaseInsensitive(filter, _.get(alert, 'labels.alertname')),
+
+  'alert-state': (filter, alert) => filter.selected.has(alertState(alert)),
+
+  'silence-name': (filter, silence) => fuzzyCaseInsensitive(filter, silence.name),
+
+  'silence-state': (filter, silence) => filter.selected.has(silenceState(silence)),
+
+  // Filter role by role kind
+  'role-kind': (filter, role) => filter.selected.has(roleType(role)),
+
+  // Filter role bindings by role kind
+  'role-binding-kind': (filter, binding) => filter.selected.has(bindingType(binding)),
+
+  // Filter role bindings by text match
+  'role-binding': (str, {metadata, roleRef, subject}) => {
+    const isMatch = val => fuzzyCaseInsensitive(str, val);
+    return [metadata.name, roleRef.name, subject.kind, subject.name].some(isMatch);
+  },
+
+  // Filter role bindings by roleRef name
+  'role-binding-roleRef': (roleRef, binding) => binding.roleRef.name === roleRef,
+
+  'selector': (selector, obj) => {
+    if (!selector || !selector.values || !selector.values.size) {
+      return true;
+    }
+    return selector.values.has(_.get(obj, selector.field));
+  },
+
+  'pod-status': (phases, pod) => {
+    if (!phases || !phases.selected || !phases.selected.size) {
+      return true;
+    }
+
+    const phase = podPhaseFilterReducer(pod);
+    return phases.selected.has(phase) || !_.includes(phases.all, phase);
+  },
+
+  'node-status': (statuses, node) => {
+    if (!statuses || !statuses.selected || !statuses.selected.size) {
+      return true;
+    }
+
+    const status = nodeStatus(node);
+    return statuses.selected.has(status) || !_.includes(statuses.all, status);
+  },
+
+  'clusterserviceversion-resource-kind': (filters, resource) => {
+    if (!filters || !filters.selected || !filters.selected.size) {
+      return true;
+    }
+    return filters.selected.has(resource.kind);
+  },
+
+  'packagemanifest-name': (filter, pkg) => fuzzyCaseInsensitive(filter, (pkg.status.defaultChannel
+    ? pkg.status.channels.find(ch => ch.name === pkg.status.defaultChannel)
+    : pkg.status.channels[0]).currentCSVDesc.displayName),
+
+  'build-status': (phases, build) => {
+    if (!phases || !phases.selected || !phases.selected.size) {
+      return true;
+    }
+
+    const phase = build.status.phase;
+    return phases.selected.has(phase) || !_.includes(phases.all, phase);
+  },
+
+  'build-strategy': (strategies, buildConfig) => {
+    if (!strategies || !strategies.selected || !strategies.selected.size) {
+      return true;
+    }
+
+    const strategy = buildConfig.spec.strategy.type;
+    return strategies.selected.has(strategy) || !_.includes(strategies.all, strategy);
+  },
+
+  'route-status': (statuses, route) => {
+    if (!statuses || !statuses.selected || !statuses.selected.size) {
+      return true;
+    }
+
+    const status = routeStatus(route);
+    return statuses.selected.has(status) || !_.includes(statuses.all, status);
+  },
+
+  'catalog-status': (statuses, catalog) => {
+    if (!statuses || !statuses.selected || !statuses.selected.size) {
+      return true;
+    }
+
+    const status = serviceCatalogStatus(catalog);
+    return statuses.selected.has(status) || !_.includes(statuses.all, status);
+  },
+
+  'secret-type': (types, secret) => {
+    if (!types || !types.selected || !types.selected.size) {
+      return true;
+    }
+    const type = secretTypeFilterReducer(secret);
+    return types.selected.has(type) || !_.includes(types.all, type);
+  },
+
+  'pvc-status': (phases, pvc) => {
+    if (!phases || !phases.selected || !phases.selected.size) {
+      return true;
+    }
+
+    const phase = pvc.status.phase;
+    return phases.selected.has(phase) || !_.includes(phases.all, phase);
+  },
+
+  // Filter service classes by text match
+  'service-class': (str, serviceClass) => {
+    const displayName = serviceClassDisplayName(serviceClass);
+    return fuzzyCaseInsensitive(str, displayName);
+  },
+
+  'cluster-operator-status': (statuses, operator) => {
+    if (!statuses || !statuses.selected || !statuses.selected.size) {
+      return true;
+    }
+
+    const status = getClusterOperatorStatus(operator);
+    return statuses.selected.has(status) || !_.includes(statuses.all, status);
+  },
+
+  'template-instance-status': (statuses, instance) => {
+    if (!statuses || !statuses.selected || !statuses.selected.size) {
+      return true;
+    }
+
+    const status = getTemplateInstanceStatus(instance);
+    return statuses.selected.has(status) || !_.includes(statuses.all, status);
+  },
+};
+
+interface FilterGroups {
+  selected: Set<string>;
+  all: string[];
+  values: Set<string>;
+  field: string;
+}
+
+type TableFilter<T extends K8sResourceKind> = (filters: FilterGroups, obj: T) => boolean;
+
+export type TableFilterMap = {
+  [key: string]: TableFilter<any>;
+}

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -47,7 +47,7 @@ const rowFiltersToFilterFuncs = (rowFilters) => {
     .reduce((acc, f) => ({ ...acc, [f.type]: f.filter }), {});
 };
 
-const getAllTableFilters = (rowFilters) => ({
+const getAllTableFilters = (rowFilters = []) => ({
   ...rowFiltersToFilterFuncs(rowFilters),
   ...tableFilters,
 });

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -39,15 +39,27 @@ import {
   WindowScroller,
 } from '@patternfly/react-virtualized-extension';
 
-import { tableFilters, TableFilterMap } from './table-filters';
+import { tableFilters } from './table-filters';
 
-const getFilteredRows = (_filters, customFilterFuncs: TableFilterMap, objects) => {
+const rowFiltersToFilterFuncs = (rowFilters) => {
+  return rowFilters
+    .filter(f => f.type && _.isFunction(f.filter))
+    .reduce((acc, f) => ({ ...acc, [f.type]: f.filter }), {});
+};
+
+const getAllTableFilters = (rowFilters) => ({
+  ...rowFiltersToFilterFuncs(rowFilters),
+  ...tableFilters,
+});
+
+const getFilteredRows = (_filters, rowFilters, objects) => {
   if (_.isEmpty(_filters)) {
     return objects;
   }
 
+  const allTableFilters = getAllTableFilters(rowFilters);
   _.each(_filters, (value, name) => {
-    const filter = tableFilters[name] || customFilterFuncs[name];
+    const filter = allTableFilters[name];
     if (_.isFunction(filter)) {
       objects = _.filter(objects, o => filter(value, o));
     }
@@ -61,8 +73,9 @@ const filterPropType = (props, propName, componentName) => {
     return;
   }
 
+  const allTableFilters = getAllTableFilters(props.rowFilters);
   for (const key of _.keys(props[propName])) {
-    if (key in tableFilters || key in props.customFilterFuncs || key === 'loadTest') {
+    if (key in allTableFilters || key === 'loadTest') {
       continue;
     }
     return new Error(`Invalid prop '${propName}' in '${componentName}'. '${key}' is not a valid filter type!`);
@@ -98,9 +111,9 @@ const sorts = {
   },
 };
 
-const stateToProps = ({UI}, {data = [], defaultSortField = 'metadata.name', defaultSortFunc = undefined, filters = {}, loaded = false, reduxID = null, reduxIDs = null, staticFilters = [{}], customFilterFuncs = {}}) => {
+const stateToProps = ({UI}, {data = [], defaultSortField = 'metadata.name', defaultSortFunc = undefined, filters = {}, loaded = false, reduxID = null, reduxIDs = null, staticFilters = [{}]}, rowFilters = []) => {
   const allFilters = staticFilters ? Object.assign({}, filters, ...staticFilters) : filters;
-  let newData = getFilteredRows(allFilters, customFilterFuncs, data);
+  let newData = getFilteredRows(allFilters, rowFilters, data);
 
   const listId = reduxIDs ? reduxIDs.join(',') : reduxID;
   // Only default to 'metadata.name' if no `defaultSortFunc`
@@ -446,8 +459,8 @@ export type TableInnerProps = {
   selectedResourcesForKind?: string[];
   onSelect?: (event: React.MouseEvent, isSelected: boolean, rowIndex: number, rowData: IRowData, extraData: IExtraData) => void;
   staticFilters?: any[];
+  rowFilters?: any[];
   virtualize?: boolean;
-  customFilterFuncs?: TableFilterMap;
 };
 
 export type TableInnerState = {

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -48,8 +48,8 @@ const rowFiltersToFilterFuncs = (rowFilters) => {
 };
 
 const getAllTableFilters = (rowFilters = []) => ({
-  ...rowFiltersToFilterFuncs(rowFilters),
   ...tableFilters,
+  ...rowFiltersToFilterFuncs(rowFilters),
 });
 
 const getFilteredRows = (_filters, rowFilters, objects) => {


### PR DESCRIPTION
`Table` and `List` components now support custom filter functions via existing `ListPage.rowFilters` prop pass-through.

For example:

```ts
// packages/kubevirt-plugin/src/components/table-filters.ts

import { TableFilter } from '@console/internal/components/factory/table-filters';

export const kubevirtTableFilters: TableFilters = {
  VmStatus: {
    type: 'vm-status',
    filter: (statuses, vm) => {
      const status = getSimpleVmStatus(vm);
      return statuses.selected.has(status) || !_.includes(statuses.all, status);
    },
  },
};

type TableFilters = {
  [name: string]: {
    type: string;
    filter: TableFilter;
  };
};
```

```tsx
// packages/kubevirt-plugin/src/components/vm.tsx

import { kubevirtTableFilters } from './table-filters';

const filters = [{
  type: kubevirtTableFilters.VmStatus.type, // change here
  selected: VM_SIMPLE_STATUS_ALL,
  reducer: getSimpleVmStatus,
  items: VM_SIMPLE_STATUS_ALL.map((status) => ({
    id: status,
    title: VM_SIMPLE_STATUS_TO_TEXT[status],
  })),
  filter: kubevirtTableFilters.VmStatus.filter, // change here
}];

// declare VirtualMachinesPage as usual, passing rowFilters={filters}
```

Additionally, `Table` vs. `List` filter map inconsistency was removed by using the same `tableFilters` implementation.

---

/cc @spadgett @christianvogt @mareklibra @jtomasek 