### PR TITLE
Remove misleading route hostname message

### DIFF
--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -255,9 +255,7 @@ export class CreateRoute extends React.Component<null, CreateRouteState> {
               name="hostname"
               aria-describedby="hostname-help" />
             <div className="help-block" id="hostname-help">
-              <p>Public hostname for the route.  If not specified, a hostname is generated.</p>
-              <p>The hostname cannot be changed after the route is created.</p>
-              {/* TODO:  add additional wildcard help text from https://github.com/openshift/origin-web-console/blob/master/app/views/directives/osc-routing.html#L65-L67 */}
+              Public hostname for the route. If not specified, a hostname is generated.
             </div>
           </div>
           <div className="form-group co-create-route__path">


### PR DESCRIPTION
The create route form says a route hostname can't be changed. This is
not always the case and depends on the user's permissions. Remove the
message.

/assign @rhamilto 