### PR TITLE
Add ImageStream and ImageStream history timeline

### DIFF
--- a/frontend/public/components/_image-stream.scss
+++ b/frontend/public/components/_image-stream.scss
@@ -1,3 +1,53 @@
 .co-example-docker-command__popover {
   width: 600px;
 }
+
+.co-images-stream-tag-timeline {
+  font-size: 15px;
+  margin: 20px 30px;
+  padding-left: 0;
+  width: auto;
+  @media (max-width: $screen-xs-max) {
+    margin: 20px 10px;
+  }
+  li {
+    height: auto;
+    list-style: none;
+    position: relative;
+  }
+}
+
+.co-images-stream-tag-timeline__circle-icon,
+.co-images-stream-tag-timeline__square-icon {
+  color: $color-pf-black-300;
+  left: 10px;
+  position: relative;
+}
+
+.co-images-stream-tag-timeline__info {
+  background: $color-pf-black-150;
+  border-radius: 3px;
+  line-height: 30px;
+  margin: 8px 0 24px 40px;
+  padding: 20px;
+  width: 100%;
+  & > div:first-of-type {
+    font-size: var(--pf-global--FontSize--sm);
+    padding-bottom: 16px;
+  }
+}
+
+.co-images-stream-tag-timeline__item-row {
+  display: flex;
+  margin: 2px 0;
+}
+
+.co-images-stream-tag-timeline__line {
+  border: 2px solid $color-pf-black-300;
+  left: 14px;
+  position: relative;
+} 
+
+.co-images-stream-tag-timeline__timestamp {
+  margin-left: 35px;
+}

--- a/frontend/public/components/image-stream-timeline.tsx
+++ b/frontend/public/components/image-stream-timeline.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import { K8sResourceKindReference } from '../module/k8s';
+import { ResourceLink, Timestamp, EmptyBox } from './utils';
+import { getImageStreamTagName } from './image-stream';
+
+const ImageStreamTagsReference: K8sResourceKindReference = 'ImageStreamTag';
+
+const ImageStreamTimelineItem: React.FC<ImageStreamTimelineItemProps> = ({tag, imageStreamName, imageStreamNamespace, linkToTag}) => {
+  const referenceAndSHA = _.split(tag.dockerImageReference, '@');
+  return <React.Fragment>
+    <li>
+      <div className="co-images-stream-tag-timeline__item-row">
+        <span className="co-images-stream-tag-timeline__circle-icon"><i className="fa fa-circle" aria-hidden="true" /></span>
+        <div className="co-images-stream-tag-timeline__timestamp"><Timestamp timestamp={tag.created} simple={true} /></div>
+      </div>
+
+      <div className="co-images-stream-tag-timeline__item-row">
+        <span className="co-images-stream-tag-timeline__line"></span>
+        <div className="co-images-stream-tag-timeline__info">
+          <ResourceLink kind={ImageStreamTagsReference} name={getImageStreamTagName(imageStreamName, tag.tag)} namespace={imageStreamNamespace} title={tag.tag} linkTo={linkToTag} />
+          <div className="co-break-all">from {referenceAndSHA[0]}</div>
+          <div className="co-break-all">{referenceAndSHA[1]}</div>
+        </div>
+      </div>
+    </li>
+  </React.Fragment>;
+};
+
+// check is the compared tag version, is the latest version in a sorted array of all tag versions
+const isTagVersionLatest = (comparedTag: string, comparedTagPosition: number, orderedTagArray: TagMeta[]) => {
+  return comparedTagPosition === _.findIndex(orderedTagArray, (orderedTag: TagMeta) => orderedTag.tag === comparedTag);
+};
+
+export const ImageStreamTimeline: React.FC<ImageStreamTimelineProps> = ({ imageStreamTags, imageStreamName, imageStreamNamespace }) => {
+  if (!_.some(imageStreamTags, 'items')) {
+    return <EmptyBox label="Images" />;
+  }
+  const tagsArray: TagMeta[] = _.flatten(_.map(imageStreamTags, ({tag, items}) => {
+    return _.map(items, ({created, dockerImageReference}) => ({tag, created, dockerImageReference}));
+  }));
+  const orderedTagArray = _.orderBy(tagsArray, ['created'], ['desc']);
+  const timeline = _.map((orderedTagArray), (tag: TagMeta, i: number) => {
+    return <ImageStreamTimelineItem key={tag.dockerImageReference} tag={tag} imageStreamName={imageStreamName} imageStreamNamespace={imageStreamNamespace} linkToTag={isTagVersionLatest(tag.tag, i, orderedTagArray)} />;
+  });
+
+  return <React.Fragment>
+    <ul className="co-images-stream-tag-timeline">
+      {timeline}
+      <div>
+        <span className="co-images-stream-tag-timeline__square-icon"><i className="fa fa-square" aria-hidden="true" /></span>
+      </div>
+    </ul>
+  </React.Fragment>;
+};
+
+type ImageStreamTimelineItemProps = {
+  tag: TagMeta;
+  imageStreamName: string;
+  imageStreamNamespace: string;
+  linkToTag: boolean;
+}
+
+type TagMeta = {
+  created: string;
+  tag: string;
+  dockerImageReference: string;
+}
+
+type ImageStreamTimelineProps = {
+  imageStreamTags: any[];
+  imageStreamName: string;
+  imageStreamNamespace: string;
+}

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -9,12 +9,13 @@ import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
 import { CopyToClipboard, ExpandableAlert, ExternalLink, Kebab, SectionHeading, LabelList, navFactory, ResourceKebab, ResourceLink, ResourceSummary, history, Timestamp } from './utils';
+import { ImageStreamTimeline } from './image-stream-timeline';
 import { fromNow } from './utils/datetime';
 
 const ImageStreamsReference: K8sResourceKindReference = 'ImageStream';
 const ImageStreamTagsReference: K8sResourceKindReference = 'ImageStreamTag';
 
-const getImageStreamTagName = (imageStreamName: string, tag: string): string => `${imageStreamName}:${tag}`;
+export const getImageStreamTagName = (imageStreamName: string, tag: string): string => `${imageStreamName}:${tag}`;
 
 export const getAnnotationTags = (specTag: any) => _.get(specTag, 'annotations.tags', '').split(/\s*,\s*/);
 
@@ -202,7 +203,13 @@ export const ImageStreamsDetails: React.SFC<ImageStreamsDetailsProps> = ({obj: i
   </div>;
 };
 
-const pages = [navFactory.details(ImageStreamsDetails), navFactory.editYaml()];
+const ImageStreamHistory: React.FC<ImageStreamHistoryProps> = ({ obj: imageStream }) => {
+  const imageStreamStatusTags = _.get(imageStream, 'status.tags');
+  return <ImageStreamTimeline imageStreamTags={imageStreamStatusTags} imageStreamName={imageStream.metadata.name} imageStreamNamespace={imageStream.metadata.namespace} />;
+};
+ImageStreamHistory.displayName = 'ImageStreamHistory';
+
+const pages = [navFactory.details(ImageStreamsDetails), navFactory.editYaml(), navFactory.history(ImageStreamHistory)];
 export const ImageStreamsDetailsPage: React.SFC<ImageStreamsDetailsPageProps> = props =>
   <DetailsPage
     {...props}
@@ -294,6 +301,10 @@ type ImageStreamTagsRowProps = {
   specTag: any;
   statusTag: any;
 };
+
+type ImageStreamHistoryProps = {
+  obj: K8sResourceKind;
+}
 
 export type ImageStreamManipulationHelpProps = {
   imageStream: K8sResourceKind;

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -109,6 +109,11 @@ export const navFactory: NavFactory = {
     name: 'Workloads',
     component,
   }),
+  history: component => ({
+    href: 'history',
+    name: 'History',
+    component,
+  }),
 };
 
 export const NavBar: React.SFC<NavBarProps> = ({pages, basePath, hideDivider}) => {


### PR DESCRIPTION
Screens:
- ImageStream history tab
<img width="1152" alt="Screen Shot 2019-06-19 at 17 18 48" src="https://user-images.githubusercontent.com/1668218/59778437-c9de4100-92b6-11e9-80d3-2a1d580f6cc4.png">

- ImageStreamTag history tab
<img width="1168" alt="Screen Shot 2019-06-19 at 17 21 11" src="https://user-images.githubusercontent.com/1668218/59778451-cd71c800-92b6-11e9-81d2-fd67ee770a28.png">

- mobile
<img width="350" alt="Screen Shot 2019-06-19 at 17 21 33" src="https://user-images.githubusercontent.com/1668218/59778460-d1054f00-92b6-11e9-893a-638c98cb52fc.png">

The history timeline will render the tags from the newest to the oldest. Each timeline item will show timestamp, link to the tag, imageReference and sha of the image. The [design](https://docs.google.com/document/d/1ZMMWLleTVchiYIvuiSLPh73fC9ou-hzQ74Rh4HtO4Nw/edit#) contains the `from` reference that would be build from ImageStream Spec, as we do when building [ImageStreamTagsRow](https://github.com/openshift/console/blob/master/frontend/public/components/image-stream.tsx#L100-L102), but since the ImageStream Spec can be changed, the `from` reference can't be build from the spec. So showing the reference itself and SHA. 

@spadgett @rhamilto PTAL

@ncameronbritt fyi