### PR TITLE
Ensure empty Table/List filters for falsy rowFilters

### DIFF
--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -42,12 +42,12 @@ import {
 import { tableFilters } from './table-filters';
 
 const rowFiltersToFilterFuncs = (rowFilters) => {
-  return rowFilters
+  return (rowFilters || [])
     .filter(f => f.type && _.isFunction(f.filter))
     .reduce((acc, f) => ({ ...acc, [f.type]: f.filter }), {});
 };
 
-const getAllTableFilters = (rowFilters = []) => ({
+const getAllTableFilters = (rowFilters) => ({
   ...tableFilters,
   ...rowFiltersToFilterFuncs(rowFilters),
 });

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -42,12 +42,12 @@ import {
 import { tableFilters } from './table-filters';
 
 const rowFiltersToFilterFuncs = (rowFilters) => {
-  return rowFilters
+  return (rowFilters || [])
     .filter(f => f.type && _.isFunction(f.filter))
     .reduce((acc, f) => ({ ...acc, [f.type]: f.filter }), {});
 };
 
-const getAllTableFilters = (rowFilters = []) => ({
+const getAllTableFilters = (rowFilters) => ({
   ...tableFilters,
   ...rowFiltersToFilterFuncs(rowFilters),
 });


### PR DESCRIPTION
This should fix the e2e test failing after updating to `react-table`.

/cc @spadgett @priley86 