### PR TITLE
Fix errors due to Lodash module replacement

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -105,10 +105,7 @@ const config: webpack.Configuration = {
     runtimeChunk: true,
   },
   plugins: [
-    // replace 'lodash' and 'lodash/*' imports with a lodash-es equivalent
-    new webpack.NormalModuleReplacementPlugin(/^lodash($|\/.*$)/, (resource) => {
-      resource.request = resource.request.replace(/^lodash/, 'lodash-es');
-    }),
+    new webpack.NormalModuleReplacementPlugin(/^lodash$/, 'lodash-es'),
     new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true }),
     new HtmlWebpackPlugin({
       filename: './tokener.html',


### PR DESCRIPTION
This PR fixes a problem with Lodash module replacement during webpack build.

The standard Lodash import style used in Console is

```ts
import * as _ from 'lodash';
import * as _ from 'lodash-es'; // should go away as part of #1724
```

with both `_` objects having an equivalent structure.

**Problem 1,** is structural difference between `lodash/foo` vs. `lodash-es/foo` imports
```ts
var memoize = require('lodash/memoize');    // memoize is function
var memoize = require('lodash-es/memoize'); // memoize is Module => memoize.default is function
```

**Problem 2,** is the weird-looking `lodash.foo` form used by some vendor libraries
```ts
var cloneDeep = require('lodash.clonedeep');    // cloneDeep is function
var cloneDeep = require('lodash-es.clonedeep'); // error, no such module available
```

Therefore, the replacement RegExp is changed to `/^lodash$/`.

This also means that parts of `lodash` (technically a separate library) will make it into webpack-generated chunks, due to vendor libraries using either `lodash/foo` or `lodash.foo`. I don't think we can do anything about this.

**Note:** from webpack compilation perspective, using

```ts
import * as _ from 'lodash-es';
```
in source code vs. using
```ts
import * as _ from 'lodash';
```
in source code together with `/^lodash$/` => `lodash-es` replacement should yield the same results.

/cc @spadgett @mareklibra 