### PR TITLE
Query Browser: Allow queries to contain newlines

### DIFF
--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -64,6 +64,7 @@
 
 .query-browser__query, .query-browser__query-switch {
   margin-right: 15px;
+  resize: vertical;
 }
 
 .query-browser__span-dropdown {

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1217,6 +1217,7 @@ const QueryBrowserPage = withFallback(() => {
                     />
                   </button>
                   <textarea
+                    autoFocus={true}
                     className="form-control query-browser__query"
                     onBlur={e => onQueryBlur(e, i)}
                     onChange={e => onQueryChange(e, i)}

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1033,7 +1033,7 @@ const MetricsDropdown = ({onChange}) => {
       .catch(() => setIsError(true));
   }, [safeFetch]);
 
-  let title: string | React.ReactNode = 'Insert Metric at Cursor';
+  let title: React.ReactNode = 'Insert Metric at Cursor';
   if (isError) {
     title = 'Failed to load metrics list';
   } else if (_.isEmpty(items)) {
@@ -1139,6 +1139,14 @@ const QueryBrowserPage = withFallback(() => {
     }
   };
 
+  const onQueryKeyDown = e => {
+    // Enter+Shift inserts newlines, Enter alone runs the query
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      runQueries(e);
+    }
+  };
+
   const onMetricChange = metric => {
     if (focusedQuery) {
       // Replace the currently selected text with the metric
@@ -1208,12 +1216,12 @@ const QueryBrowserPage = withFallback(() => {
                       className={`fa fa-angle-${q.expanded ? 'down' : 'right'} query-browser__table-toggle-icon`}
                     />
                   </button>
-                  <input
+                  <textarea
                     className="form-control query-browser__query"
                     onBlur={e => onQueryBlur(e, i)}
                     onChange={e => onQueryChange(e, i)}
+                    onKeyDown={onQueryKeyDown}
                     placeholder="Expression (press Shift+Enter for newlines)"
-                    type="text"
                     value={q.text}
                   />
                   <div className="query-browser__query-switch">


### PR DESCRIPTION
Change the query input to a `<textarea>` and allow inserting newlines by
pressing Enter+Shift.

Also auto-focus the query input when the page loads and also focus new query
inputs when the "Add Query" button is clicked.