### PR TITLE
Bug 1720045: Add polyfill for AbortController

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,6 +66,7 @@
     "@patternfly/react-core": "3.38.1",
     "@patternfly/react-table": "2.11.1",
     "@patternfly/react-virtualized-extension": "1.0.5",
+    "abortcontroller-polyfill": "^1.3.0",
     "brace": "0.11.x",
     "classnames": "2.x",
     "core-js": "2.x",

--- a/frontend/public/components/utils/safe-fetch-hook.ts
+++ b/frontend/public/components/utils/safe-fetch-hook.ts
@@ -1,4 +1,6 @@
 import { useEffect, useRef } from 'react';
+// AbortController is not supported in some older browser versions
+import { AbortController } from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 import { coFetchJSON } from '../../co-fetch';
 
 export const useSafeFetch = () => {
@@ -8,5 +10,5 @@ export const useSafeFetch = () => {
     return () => controller.current.abort();
   }, []);
 
-  return (url) => coFetchJSON(url, 'get', {signal: controller.current.signal});
+  return (url) => coFetchJSON(url, 'get', {signal: controller.current.signal as AbortSignal});
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -924,6 +924,11 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
+abortcontroller-polyfill@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.3.0.tgz#de69af32ae926c210b7efbcc29bf644ee4838b00"
+  integrity sha512-lbWQgf+eRvku3va8poBlDBO12FigTQr9Zb7NIjXrePrhxWVKdCP2wbDl1tLDaYa18PWTom3UEWwdH13S46I+yA==
+
 abs-svg-path@^0.1.1, abs-svg-path@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/abs-svg-path/-/abs-svg-path-0.1.1.tgz#df601c8e8d2ba10d4a76d625e236a9a39c2723bf"


### PR DESCRIPTION
AbortController/AbortSignal is not supported in some older browser versions. Added a polyfill which prevents a runtime error where AbortController is undefined in those browsers. When AbortController is unsupported, the polyfill will cause in-flight fetch promises to reject when the abort signal is triggered.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1720045