### PR TITLE
Add script for plugin stats & simplify webpack config

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,8 +8,9 @@
     "public"
   ],
   "scripts": {
-    "dev": "rm -rf ./public/dist && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode development --watch --progress",
-    "build": "rm -rf ./public/dist && NODE_ENV=production ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production",
+    "clean": "rm -rf ./public/dist",
+    "dev": "yarn clean && yarn plugin-stats && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode development --watch --progress",
+    "build": "yarn clean && yarn plugin-stats && NODE_ENV=production ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production",
     "coverage": "jest --coverage .",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx --color .",
     "test": "jest",
@@ -20,7 +21,8 @@
     "test-gui": "yarn run test-suite --suite all",
     "test-suite": "ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/protractor integration-tests/protractor.conf.ts",
     "debug-test-suite": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node -r ts-node/register --inspect-brk ./node_modules/.bin/protractor integration-tests/protractor.conf.ts",
-    "analyze": "NODE_ENV=production ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production --profile --json | awk '{if(NR>2)print}' > public/dist/stats.json && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack-bundle-analyzer --mode static -r public/dist/report.html public/dist/stats.json"
+    "analyze": "NODE_ENV=production ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack --mode=production --profile --json | awk '{if(NR>2)print}' > public/dist/stats.json && ts-node -O '{\"module\":\"commonjs\"}' ./node_modules/.bin/webpack-bundle-analyzer --mode static -r public/dist/report.html public/dist/stats.json",
+    "plugin-stats": "ts-node -O '{\"module\":\"commonjs\"}' ./plugin-stats.ts"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/frontend/plugin-stats.ts
+++ b/frontend/plugin-stats.ts
@@ -1,0 +1,15 @@
+/* eslint-env node */
+
+import {
+  resolvePluginPackages,
+  loadActivePlugins,
+  printPluginStats,
+} from '@console/plugin-sdk/src/codegen';
+
+// Prevent ts-node from processing additional assets such as stylesheets.
+// https://github.com/TypeStrong/ts-node/issues/175#issuecomment-455429261
+['.css', '.scss'].forEach(ext => {
+  require.extensions[ext] = () => undefined;
+});
+
+printPluginStats(loadActivePlugins(resolvePluginPackages()));

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -6,12 +6,7 @@ import * as ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import * as MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import * as VirtualModulesPlugin from 'webpack-virtual-modules';
 
-import {
-  resolvePluginPackages,
-  loadActivePlugins,
-  getActivePluginsModule,
-  printPluginStats,
-} from '@console/plugin-sdk/src/codegen';
+import { resolvePluginPackages, getActivePluginsModule } from '@console/plugin-sdk/src/codegen';
 
 const NODE_ENV = process.env.NODE_ENV;
 
@@ -139,12 +134,9 @@ if (NODE_ENV === 'production') {
 }
 
 /* Console plugin support */
-const pluginPackages = resolvePluginPackages();
-printPluginStats(loadActivePlugins(pluginPackages));
-
 config.plugins.push(
   new VirtualModulesPlugin({
-    'node_modules/@console/active-plugins.js': getActivePluginsModule(pluginPackages),
+    'node_modules/@console/active-plugins.js': getActivePluginsModule(resolvePluginPackages()),
   }),
 );
 


### PR DESCRIPTION
This PR fixes an issue where `ts-node` tries to load a stylesheet and fails due to TS parse errors.

For example, adding `packages/dev-console/src/style.scss` and updating DevConsole `plugin.tsx` to import `./style.scss` causes the following error:

```
/home/vszocs/go/src/github.com/openshift/console/frontend/node_modules/ts-node/src/index.ts:257
      throw new TSError(formatDiagnostics(diagnosticList, cwd, ts, lineOffset))
            ^
TSError: ⨯ Unable to compile TypeScript
packages/dev-console/src/style.scss: Declaration or statement expected. (1128)
packages/dev-console/src/style.scss (1,6): ';' expected. (1005)
```

To fix that, we simplify the webpack config by moving the `loadActivePlugins` invocation into a separate script, along with the `require.extensions` hack necessary to make it work.

See TypeStrong/ts-node#175 for more details.

/cc @spadgett @mareklibra @christianvogt 