### PR TITLE
Fix OLM E2E Test Cleanup

### DIFF
--- a/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
@@ -50,9 +50,11 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Redis)', ()
   });
 
   afterAll(() => {
-    execSync(`kubectl delete catalogsource -n ${catalogNamespace} ${catalogSource.metadata.name}`);
-    execSync(`kubectl delete subscription -n ${globalOperatorsNamespace} redis-enterprise`);
-    execSync(`kubectl delete clusterserviceversion -n ${globalOperatorsNamespace} redis-enterprise-operator.v0.0.1`);
+    [
+      `kubectl delete catalogsource -n ${catalogNamespace} ${catalogSource.metadata.name}`,
+      `kubectl delete subscription -n ${globalOperatorsNamespace} redis-enterprise`,
+      `kubectl delete clusterserviceversion -n ${globalOperatorsNamespace} redis-enterprise-operator.v0.0.1`,
+    ].forEach(cmd => _.attempt(() => execSync(cmd)));
   });
 
   afterEach(() => {

--- a/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
@@ -1,5 +1,6 @@
 import { browser, $, $$, element, ExpectedConditions as until, by } from 'protractor';
 import { execSync } from 'child_process';
+import * as _ from 'lodash';
 
 import { appHost, testName, checkLogs, checkErrors } from '../../protractor.conf';
 import * as crudView from '../../views/crud.view';
@@ -44,9 +45,11 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
   });
 
   afterAll(() => {
-    execSync(`kubectl delete catalogsource -n ${testName} ${catalogSource.metadata.name}`);
-    execSync(`kubectl delete subscription -n ${testName} prometheus`);
-    execSync(`kubectl delete clusterserviceversion -n ${testName} prometheusoperator.0.27.0`);
+    [
+      `kubectl delete catalogsource -n ${testName} ${catalogSource.metadata.name}`,
+      `kubectl delete subscription -n ${testName} prometheus`,
+      `kubectl delete clusterserviceversion -n ${testName} prometheusoperator.0.27.0`,
+    ].forEach(cmd => _.attempt(() => execSync(cmd)));
   });
 
   afterEach(() => {


### PR DESCRIPTION
### Description

Wrap cleanup `kubectl` calls with `_.attempt()` (when tests are successful, cleanup not needed).