### PR TITLE
Remove extra space above <th> to restore spacing above table to what …

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -511,6 +511,11 @@ kbd {
 
 // pf table overrides
 
+.pf-c-table .pf-c-table__sort .pf-c-button {
+  // remove padding-top on col heads to match what we had before
+  padding-top: 0 !important;
+}
+
 .pf-c-table tr > th {
   font-weight: var(--pf-global--FontWeight--bold);
 }


### PR DESCRIPTION
…it was

https://jira.coreos.com/browse/CONSOLE-1530?filter=-1

Before:
![Screen Shot 2019-06-20 at 4 14 36 PM](https://user-images.githubusercontent.com/895728/59878553-99f67280-9376-11e9-85e2-4b4d04990530.png)
![Screen Shot 2019-06-20 at 4 14 46 PM](https://user-images.githubusercontent.com/895728/59878554-99f67280-9376-11e9-8526-13acbcff2248.png)

Note this results in the focus ring not having equal top and bottom padding, but it looks ok IMO.

After:
![Screen Shot 2019-06-20 at 4 14 15 PM](https://user-images.githubusercontent.com/895728/59878564-9fec5380-9376-11e9-92f5-f5b9c6a3b0a9.png)
![Screen Shot 2019-06-20 at 4 15 05 PM](https://user-images.githubusercontent.com/895728/59878565-9fec5380-9376-11e9-9881-739ce10d1f10.png)
