### PR TITLE
Remove invalid, orphaned CSS partial

### DIFF
--- a/frontend/public/components/_users.scss
+++ b/frontend/public/components/_users.scss
@@ -1,3 +1,0 @@
-.co-m-pane__body:last {
-  padding-bottom: 30px;
-}

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -67,7 +67,6 @@
 @import "components/sysevent-stream";
 @import "components/icon-and-text";
 @import "components/toggle-play";
-@import "components/users";
 @import "components/volume-icon";
 @import "components/horizontal-nav";
 @import "components/edit-yaml";


### PR DESCRIPTION
`:last` is not a valid [CSS pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes), so this rule is invalid and orphaned.