### PR TITLE
Prevent long unbroken resource names to cause horizontal scroll on modals that display resource name

### DIFF
--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -42,8 +42,8 @@ export const createModalLauncher: CreateModalLauncher = (Component) => (props) =
 
 export const ModalTitle: React.SFC<ModalTitleProps> = ({children, className = 'modal-header'}) => <div className={className}><h4 className="modal-title">{children}</h4></div>;
 
-export const ModalBody: React.SFC<ModalBodyProps> = ({children, className= 'modal-body'}) => (
-  <div className={className}>
+export const ModalBody: React.SFC<ModalBodyProps> = ({children}) => (
+  <div className="modal-body">
     <div className="modal-body-content">
       <div className="modal-body-inner-shadow-covers">{children}</div>
     </div>

--- a/frontend/public/components/modals/command-line-tools-modal.tsx
+++ b/frontend/public/components/modals/command-line-tools-modal.tsx
@@ -7,7 +7,7 @@ import { ExternalLink } from '../utils';
 export const commandLineToolsModal = createModalLauncher(
   ({cancel}) => <div className="modal-content">
     <ModalTitle>Command Line Tools</ModalTitle>
-    <ModalBody className="modal-body">
+    <ModalBody>
       <h5>oc - OpenShift Command Line Interface (CLI)</h5>
       <p>With the OpenShift command line interface, you can create applications and manage OpenShift projects from a terminal.</p>
       <p>The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features.</p>

--- a/frontend/public/components/modals/delete-modal.jsx
+++ b/frontend/public/components/modals/delete-modal.jsx
@@ -52,8 +52,8 @@ class DeleteModal extends PromiseComponent {
         <div className="co-delete-modal">
           <span aria-hidden="true" className="co-delete-modal__icon pficon pficon-warning-triangle-o"></span>
           <div>
-            <p className="lead">Delete {resource.metadata.name}?</p>
-            <div>Are you sure you want to delete <strong>{resource.metadata.name}</strong>
+            <p className="lead">Delete <span className="co-break-word">{resource.metadata.name}</span>?</p>
+            <div>Are you sure you want to delete <strong className="co-break-word">{resource.metadata.name}</strong>
               {_.has(resource.metadata, 'namespace') && <span> in namespace <strong>{ resource.metadata.namespace }</strong>?</span>}
               {_.has(kind, 'propagationPolicy') && <div className="checkbox">
                 <label className="control-label">

--- a/frontend/public/components/modals/delete-namespace-modal.jsx
+++ b/frontend/public/components/modals/delete-namespace-modal.jsx
@@ -30,12 +30,12 @@ class DeleteNamespaceModal extends PromiseComponent {
   render() {
     return <form onSubmit={this._submit} name="form" className="modal-content ">
       <ModalTitle>Delete {this.props.kind.label}</ModalTitle>
-      <ModalBody className="modal-body">
+      <ModalBody>
         <div className="co-delete-modal">
           <span aria-hidden="true" className="co-delete-modal__icon pficon pficon-warning-triangle-o"></span>
           <div>
             <p>This action cannot be undone. It will destroy all pods, services and other objects in the deleted namespace.</p>
-            <p>Confirm deletion by typing <strong>{this.props.resource.metadata.name}</strong> below:</p>
+            <p>Confirm deletion by typing <strong className="co-break-word">{this.props.resource.metadata.name}</strong> below:</p>
             <input type="text" className="form-control" onKeyUp={this._matchTypedNamespace} placeholder="Enter name" autoFocus={true} />
           </div>
         </div>

--- a/frontend/public/components/modals/expand-pvc-modal.jsx
+++ b/frontend/public/components/modals/expand-pvc-modal.jsx
@@ -44,8 +44,8 @@ class ExpandPVCModal extends PromiseComponent {
     const { requestSizeUnit, requestSizeValue } =this.state;
     return <form onSubmit={this._submit} name="form" className="modal-content modal-content--no-inner-scroll">
       <ModalTitle>Expand {kind.label}</ModalTitle>
-      <ModalBody className="modal-body">
-        <p>Increase the capacity of claim <strong>{resource.metadata.name}.</strong> This can be a time-consuming process.</p>
+      <ModalBody>
+        <p>Increase the capacity of claim <strong className="co-break-word">{resource.metadata.name}.</strong> This can be a time-consuming process.</p>
         <label className="control-label co-required">Size</label>
         <RequestSizeInput
           name="requestSize"

--- a/frontend/public/components/operator-hub/operator-hub-community-provider-modal.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-community-provider-modal.tsx
@@ -29,7 +29,7 @@ export class OperatorHubCommunityProviderModal extends React.Component<OperatorH
     const submitButtonContent = <React.Fragment>Continue</React.Fragment>;
     return <form onSubmit={this.submit} className="modal-content co-modal-ignore-warning">
       <ModalTitle>Show Community Operator</ModalTitle>
-      <ModalBody className="modal-body">
+      <ModalBody>
         <div className="co-modal-ignore-warning__content">
           <div className="co-modal-ignore-warning__icon">
             <Icon type="pf" name="info" />

--- a/frontend/public/style/mixin/_break-word.scss
+++ b/frontend/public/style/mixin/_break-word.scss
@@ -1,6 +1,12 @@
-// Generic mixin for break-word. Note if element is a flex child then min-width: 0% is necessary for it to wrap.
+// Generic mixin for break-word.
+// DESCRIPTION: Breaks long non-breaking strings within a div or flex container
+// An unbreakable "word" may be broken at an arbitrary point if there are no otherwise-acceptable break points in the line.
+// (1) https://bugzilla.mozilla.org/show_bug.cgi?id=1136818#c2
+// USAGE:
+// - DO choose to use this over `word-break: break-all` if at all possible, since break-all can break normal words in awkward places.
 
 @mixin co-break-word() {
+  min-width: 0; // required by FF and Edge
   overflow-wrap: break-word; // new name as per the CSS3 spec
-  word-wrap: break-word; // IE 11, Edge 16/17 requires legacy name "word-wrap" rather than "overflow-wrap".
+  word-break: break-word; // required by FF and Edge
 }


### PR DESCRIPTION
Add .co-break-word mixin
- includes word-break: break-word and min-width: 0 to mixin (for Edge and Firefox)
Move `modal-body` class to `<ModalBody>` since it is always needed. 

<img width="770" alt="Screen Shot 2019-06-20 at 4 31 48 PM" src="https://user-images.githubusercontent.com/1874151/59941140-81479480-942a-11e9-8106-4d4a4a45ce20.png">
<img width="701" alt="Screen Shot 2019-06-20 at 4 37 52 PM" src="https://user-images.githubusercontent.com/1874151/59941141-81479480-942a-11e9-86ca-7c12f46a9eff.png">
<img width="725" alt="Screen Shot 2019-06-20 at 4 47 03 PM" src="https://user-images.githubusercontent.com/1874151/59941142-81479480-942a-11e9-9ada-19a6aa873500.png">
<img width="800" alt="Screen Shot 2019-06-20 at 4 49 50 PM" src="https://user-images.githubusercontent.com/1874151/59941143-81479480-942a-11e9-9a69-1e0936cec78b.png">
