### PR TITLE
Refactor .co-m-pane__body styles so border is correctly added

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -464,7 +464,7 @@ class EventStream extends React.Component {
     });
     const messageCount = count < maxMessages ? `Showing ${pluralize(count, 'event')}` : `Showing ${count} of ${allCount}+ events`;
 
-    return <div className="co-m-pane__body co-m-pane__body--alt">
+    return <div className="co-m-pane__body">
       <div className="co-sysevent-stream">
         <div className="co-sysevent-stream__status">
           <div className="co-sysevent-stream__timeline__btn-text">

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -148,8 +148,8 @@ const Details = ({obj: serviceaccount}) => {
         <SectionHeading text="Service Account Overview" />
         <ResourceSummary resource={serviceaccount} />
       </div>
-      <div className="co-m-pane__body co-m-pane__body--alt">
-        <SectionHeading text="Secrets" style={{marginBottom: '-20px'}} />
+      <div className="co-m-pane__body co-m-pane__body--section-heading">
+        <SectionHeading text="Secrets" />
       </div>
       <SecretsPage kind="Secret" canCreate={false} namespace={namespace} filters={filters} autoFocus={false} showTitle={false} />
     </React.Fragment>

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -8,22 +8,22 @@
 }
 
 .co-m-pane__body {
-  border-bottom: 1px solid $color-grey-background-border;
   margin: $grid-gutter-width 0 0;
   padding: 0 ($grid-gutter-width / 2) $grid-gutter-width;
   @media (min-width: $screen-sm-min) {
     padding-left: $grid-gutter-width;
     padding-right: $grid-gutter-width;
   }
-  &--alt {
-    border-bottom: 0;
-    padding-bottom: 0;
-  }
   &--no-top-margin {
     margin-top: 0;
   }
-  &:last-child {
-    border-bottom: 0;
+  &--section-heading {
+    padding-bottom: 0;
+  }
+  + .co-m-pane__body {
+    border-top: 1px solid $color-grey-background-border;
+    margin-top: 0;
+    padding-top: $grid-gutter-width;
   }
 }
 


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1533

This should provide a more predictable result with regard to when a border is rendered.  IMO, the adjacent sibling selector is a more robust fix and will prevent situations where we have unwanted borders being rendered like the one in the bug.