### PR TITLE
Make ux updates to cluster settings pages

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
+import { Alert } from '@patternfly/react-core';
+
 import { ClusterOperatorModel } from '../../models';
-import { StartGuide } from '../start-guide';
 import {
   DetailsPage,
   ListPage,
@@ -15,8 +16,12 @@ import { Conditions } from '../conditions';
 import {
   getClusterOperatorStatus,
   getClusterOperatorVersion,
+  getClusterVersionCondition,
   getStatusAndMessage,
   ClusterOperator,
+  ClusterVersionConditionType,
+  ClusterVersionKind,
+  K8sResourceConditionStatus,
   K8sResourceKindReference,
   OperandVersion,
   OperatorStatus,
@@ -30,7 +35,6 @@ import {
   ResourceSummary,
   SectionHeading,
 } from '../utils';
-import { STORAGE_PREFIX } from '../../const';
 
 export const clusterOperatorReference: K8sResourceKindReference = referenceForModel(ClusterOperatorModel);
 
@@ -124,17 +128,24 @@ const filters = [{
   })),
 }];
 
-export const ClusterOperatorStartGuide: React.SFC<{}> = () =>
-  <React.Fragment>
-    <h4>What are Cluster Operators?</h4>
-    <p>
-      An Operator is a method of packaging, deploying, and managing a Kubernetes application. Cluster Operators implement and automate updates of OpenShift and Kubernetes at the cluster level. During an update, the latest versions of the OpenShift and Kubernetes components are downloaded. A rolling update will occur to install the latest versions.
-    </p>
-  </React.Fragment>;
+const UpdateInProgressAlert: React.SFC<UpdateInProgressAlertProps> = ({cv}) => {
+  const updateCondition = getClusterVersionCondition(cv, ClusterVersionConditionType.Progressing, K8sResourceConditionStatus.True);
+  return (
+    <React.Fragment>
+      { updateCondition &&
+        <div className="co-m-pane__body co-m-pane__body--section-heading">
+          <Alert isInline className="co-alert" variant="info" title="Cluster update in progress.">
+            {updateCondition.message}
+          </Alert>
+        </div>
+      }
+    </React.Fragment>
+  );
+};
 
 export const ClusterOperatorPage: React.SFC<ClusterOperatorPageProps> = props =>
   <React.Fragment>
-    <StartGuide dismissKey={`${STORAGE_PREFIX}/seen-cluster-operator-guide`} startGuide={<ClusterOperatorStartGuide />} />
+    <UpdateInProgressAlert cv={props.cv} />
     <ListPage
       {...props}
       title="Cluster Operators"
@@ -223,6 +234,7 @@ type OperatorStatusIconAndLabelProps = {
 };
 
 type ClusterOperatorPageProps = {
+  cv: ClusterVersionKind;
   autoFocus?: boolean;
   showTitle?: boolean;
 };
@@ -237,4 +249,8 @@ type ClusterOperatorDetailsProps = {
 
 type ClusterOperatorDetailsPageProps = {
   match: any;
+};
+
+type UpdateInProgressAlertProps = {
+  cv: ClusterVersionKind;
 };

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -229,20 +229,20 @@ const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = (
   </React.Fragment>;
 };
 
-const ClusterOperatorTabPage: React.SFC = () => <ClusterOperatorPage autoFocus={false} showTitle={false} />;
+const ClusterOperatorTabPage: React.SFC<ClusterOperatorTabPageProps> = ({obj: cv}) => <ClusterOperatorPage cv={cv} autoFocus={false} showTitle={false} />;
 
 const pages = [{
   href: '',
   name: 'Overview',
   component: ClusterVersionDetailsTable,
 }, {
-  href: 'globalconfig',
-  name: 'Global Configuration',
-  component: GlobalConfigPage,
-}, {
   href: 'clusteroperators',
   name: 'Cluster Operators',
   component: ClusterOperatorTabPage,
+}, {
+  href: 'globalconfig',
+  name: 'Global Configuration',
+  component: GlobalConfigPage,
 }];
 
 export const ClusterSettingsPage: React.SFC<ClusterSettingsPageProps> = ({match}) => {
@@ -288,4 +288,8 @@ type ClusterVersionDetailsTableProps = {
 
 type ClusterSettingsPageProps = {
   match: any;
+};
+
+type ClusterOperatorTabPageProps = {
+  obj: ClusterVersionKind;
 };


### PR DESCRIPTION
For Jira story: https://jira.coreos.com/browse/CONSOLE-1514

- remove blue hint block
- move cluster operators next to overview
- add inline notification to the cluster operators tab only when an update is in progress
- overview tab remains unchanged

![Screen Shot 2019-06-24 at 1 56 30 PM](https://user-images.githubusercontent.com/35978579/60111581-36849000-973c-11e9-9bf8-082e609d4b16.png)
