### PR TITLE
Use `tectonic-console-builder:v17` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/coreos/tectonic-console-builder:v16 AS build
+FROM quay.io/coreos/tectonic-console-builder:v17 AS build
 
 RUN mkdir -p /go/src/github.com/openshift/console/
 ADD . /go/src/github.com/openshift/console/


### PR DESCRIPTION
The builder was updated a while back to upgrade Chrome, but we didn't update the Dockerfile.

/assign @alecmerdler 