### PR TITLE
Query Browser: Allow disabling individual series in the graph

### DIFF
--- a/frontend/public/components/_monitoring.scss
+++ b/frontend/public/components/_monitoring.scss
@@ -65,6 +65,9 @@ $monitoring-line-height: 18px;
   margin: 2px 12px 2px 5px;
   min-width: 20px;
   width: 20px;
+  &--disabled {
+    border: 1px solid #888;
+  }
 }
 
 .query-browser-metric__labels {

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1051,7 +1051,9 @@ const MetricsDropdown = ({onChange}) => {
   />;
 };
 
-const MetricsList: React.FC<MetricsListProps> = ({allSeries, disabledSeries, onToggleSeries}) => (
+const getGraphColor = colorIndex => graphColors[colorIndex % graphColors.length];
+
+const MetricsList: React.FC<MetricsListProps> = ({allSeries, colorOffset, disabledSeries, onToggleSeries}) => (
   <div className="co-m-table-grid co-m-table-grid--bordered">
     <div className="row co-m-table-grid__head">
       <div className="col-xs-9 query-browser-metric__wrapper">
@@ -1063,8 +1065,7 @@ const MetricsList: React.FC<MetricsListProps> = ({allSeries, disabledSeries, onT
     <div className="co-m-table-grid__body">
       {_.map(allSeries, ({labels, value}, i) => {
         const isDisabled = _.some(disabledSeries, s => _.isEqual(s, labels));
-        const style = isDisabled ? undefined : {backgroundColor: graphColors[i % graphColors.length]};
-
+        const style = isDisabled ? undefined : {backgroundColor: getGraphColor(colorOffset + i)};
         return <div className="row" key={i}>
           <div className="col-xs-9 query-browser-metric__wrapper">
             <div
@@ -1199,6 +1200,8 @@ const QueryBrowserPage = withFallback(() => {
 
   const validQueries = _.reject(queries, q => _.isEmpty(q.query));
 
+  const getColorOffset = i => i > 0 ? _.sumBy(_.range(i), j => _.get(metrics, [j, 'length'])) : 0;
+
   return <React.Fragment>
     <div className="co-m-nav-title">
       <h1 className="co-m-pane__heading">
@@ -1266,6 +1269,7 @@ const QueryBrowserPage = withFallback(() => {
                 {q.expanded && <div className="group__body group__body--query-browser">
                   <MetricsList
                     allSeries={metrics[i]}
+                    colorOffset={getColorOffset(i)}
                     disabledSeries={queries[i].disabledSeries}
                     onToggleSeries={labels => toggleSeries(i, labels)}
                   />
@@ -1454,6 +1458,7 @@ export type ListPageProps = {
 };
 type MetricsListProps = {
   allSeries: {labels: Labels; value: number}[];
+  colorOffset: number;
   disabledSeries: Labels[];
   onToggleSeries: (labels: Labels) => void;
 };

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -18,7 +18,7 @@ import { ResourceRow, Table, TableData, TableRow, TextFilter } from './factory';
 import { PROMETHEUS_BASE_PATH, QueryBrowser } from './graphs';
 import { PrometheusEndpoint } from './graphs/helpers';
 import { getPrometheusExpressionBrowserURL } from './graphs/prometheus-graph';
-import { graphColors } from './graphs/query-browser';
+import { graphColors, Labels, PrometheusSeries } from './graphs/query-browser';
 import { confirmModal } from './modals';
 import { CheckBoxes } from './row-filter';
 import { formatPrometheusDuration } from './utils/datetime';
@@ -1051,28 +1051,39 @@ const MetricsDropdown = ({onChange}) => {
   />;
 };
 
-const MetricsList = ({metrics}) => <div className="co-m-table-grid co-m-table-grid--bordered">
-  <div className="row co-m-table-grid__head">
-    <div className="col-xs-9 query-browser-metric__wrapper">
-      <div className="query-browser-metric__color"></div>
-      Series
-    </div>
-    <div className="col-xs-3">Value</div>
-  </div>
-  <div className="co-m-table-grid__body">
-    {_.map(metrics, (m, i) => <div className="row" key={i}>
+const MetricsList: React.FC<MetricsListProps> = ({allSeries, disabledSeries, onToggleSeries}) => (
+  <div className="co-m-table-grid co-m-table-grid--bordered">
+    <div className="row co-m-table-grid__head">
       <div className="col-xs-9 query-browser-metric__wrapper">
-        <div className="query-browser-metric__color" style={{backgroundColor: graphColors[parseInt(i, 10) % graphColors.length]}}></div>
-        <div className="query-browser-metric__labels">
-          {_.isEmpty(m.labels)
-            ? <span className="text-muted">{'{}'}</span>
-            : _.map(m.labels, (v, k) => `${k}="${v}"`).join(',')}
-        </div>
+        <div className="query-browser-metric__color"></div>
+        Series
       </div>
-      <div className="col-xs-3">{m.value}</div>
-    </div>)}
+      <div className="col-xs-3">Value</div>
+    </div>
+    <div className="co-m-table-grid__body">
+      {_.map(allSeries, ({labels, value}, i) => {
+        const isDisabled = _.some(disabledSeries, s => _.isEqual(s, labels));
+        const style = isDisabled ? undefined : {backgroundColor: graphColors[i % graphColors.length]};
+
+        return <div className="row" key={i}>
+          <div className="col-xs-9 query-browser-metric__wrapper">
+            <div
+              className={classNames('query-browser-metric__color', {'query-browser-metric__color--disabled': isDisabled})}
+              onClick={() => onToggleSeries(labels)}
+              style={style}
+            ></div>
+            <div className="query-browser-metric__labels">
+              {_.isEmpty(labels)
+                ? <span className="text-muted">{'{}'}</span>
+                : _.map(labels, (v, k) => `${k}="${v}"`).join(',')}
+            </div>
+          </div>
+          <div className="col-xs-3">{value}</div>
+        </div>;
+      })}
+    </div>
   </div>
-</div>;
+);
 
 const QueryBrowserPage = withFallback(() => {
   const [focusedQuery, setFocusedQuery] = React.useState();
@@ -1082,9 +1093,15 @@ const QueryBrowserPage = withFallback(() => {
   const defaultQuery = getURLSearchParams().query || '';
 
   // `text` is the current string in the text input and `query` is the value displayed in the graph
-  const [queries, setQueries] = React.useState([{enabled: true, expanded: true, query: defaultQuery, text: defaultQuery}]);
+  const [queries, setQueries] = React.useState([{
+    disabledSeries: [],
+    enabled: true,
+    expanded: true,
+    query: defaultQuery,
+    text: defaultQuery,
+  }]);
 
-  const defaultQueryObj = {enabled: true, expanded: true, query: '', text: ''};
+  const defaultQueryObj = {disabledSeries: [], enabled: true, expanded: true, query: '', text: ''};
 
   const updateQuery = (i, obj) => setQueries(_.map(queries, (q, j) => i === j ? Object.assign({}, q, obj) : q));
 
@@ -1106,6 +1123,11 @@ const QueryBrowserPage = withFallback(() => {
     updateQuery(i, {enabled: !enabled, expanded: !enabled, query: enabled ? '' : text});
   };
 
+  const toggleSeries = (i: number, labels: Labels) => {
+    const disabledSeries = _.xorWith(queries[i].disabledSeries, [labels], _.isEqual);
+    updateQuery(i, {disabledSeries});
+  };
+
   const toggleExpanded = i => updateQuery(i, {expanded: !_.get(queries, [i, 'expanded'])});
 
   const isAllExpanded = _.every(queries, 'expanded');
@@ -1117,9 +1139,14 @@ const QueryBrowserPage = withFallback(() => {
     {label: 'Delete all queries', callback: deleteAllQueries},
   ];
 
-  const onDataUpdate = queriesData => setMetrics(_.map(queriesData,
-    data => _.map(data, ({labels, values}) => ({labels, value: _.get(_.last(values), 'y')}))
-  ));
+  const onDataUpdate = (allSeries: PrometheusSeries[][]) => {
+    return setMetrics(_.map(allSeries, series => {
+      return _.map(series, ({metric, values}) => ({
+        labels: _.omit(metric, '__name__'),
+        value: parseFloat(_.last(values)[1]),
+      }));
+    }));
+  };
 
   const onQueryBlur = (e, i) => {
     if (_.get(e, 'relatedTarget.id') === 'metrics-dropdown') {
@@ -1170,12 +1197,12 @@ const QueryBrowserPage = withFallback(() => {
     }
   }, [focusedQuery, restoreSelection]);
 
-  const validQueries = _.reject(_.map(queries, 'query'), _.isEmpty);
+  const validQueries = _.reject(queries, q => _.isEmpty(q.query));
 
   return <React.Fragment>
     <div className="co-m-nav-title">
       <h1 className="co-m-pane__heading">
-        <span>Metrics<HeaderPrometheusLink queries={validQueries} /></span>
+        <span>Metrics<HeaderPrometheusLink queries={_.map(validQueries, 'query')} /></span>
         <div className="co-actions">
           <ActionsMenu actions={actionsMenuActions} />
         </div>
@@ -1191,8 +1218,9 @@ const QueryBrowserPage = withFallback(() => {
         <div className="col-xs-12">
           <QueryBrowser
             defaultTimespan={30 * 60 * 1000}
+            disabledSeries={_.map(validQueries, 'disabledSeries')}
             onDataUpdate={onDataUpdate}
-            queries={validQueries}
+            queries={_.map(validQueries, 'query')}
           />
           <form onSubmit={runQueries}>
             <div className="query-browser__all-queries-controls">
@@ -1236,7 +1264,11 @@ const QueryBrowserPage = withFallback(() => {
                   </div>
                 </div>
                 {q.expanded && <div className="group__body group__body--query-browser">
-                  <MetricsList metrics={metrics[i]} />
+                  <MetricsList
+                    allSeries={metrics[i]}
+                    disabledSeries={queries[i].disabledSeries}
+                    onToggleSeries={labels => toggleSeries(i, labels)}
+                  />
                 </div>}
               </div>;
             })}
@@ -1360,7 +1392,7 @@ type Rule = {
   annotations: any;
   duration: number;
   id: string;
-  labels: {[key: string]: string};
+  labels: Labels;
   name: string;
   query: string;
 };
@@ -1419,4 +1451,9 @@ export type ListPageProps = {
   reduxID: string;
   Row: React.ComponentType<any>;
   rowFilter: {type: string, selected: string[], reducer: (any) => string, items: {id: string, title: string}[]};
+};
+type MetricsListProps = {
+  allSeries: {labels: Labels; value: number}[];
+  disabledSeries: Labels[];
+  onToggleSeries: (labels: Labels) => void;
 };


### PR DESCRIPTION
It was already possible to disable / enable each PromQL query
individual, but this adds the ability to disable / enable an individual
series (line on the graph) returned by a query.

Also fix the series colors in the table to match those of the graph lines.