### PR TITLE
Bug 1720045: Switch to WHATWG abort controller polyfill

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,7 @@
     "@patternfly/react-core": "3.48.5",
     "@patternfly/react-table": "2.11.1",
     "@patternfly/react-virtualized-extension": "1.0.5",
-    "abortcontroller-polyfill": "^1.3.0",
+    "abort-controller": "^3.0.0",
     "brace": "0.11.x",
     "classnames": "2.x",
     "core-js": "2.x",

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -4,6 +4,8 @@ import { render } from 'react-dom';
 import { Helmet } from 'react-helmet';
 import { Provider } from 'react-redux';
 import { Route, Router } from 'react-router-dom';
+// AbortController is not supported in some older browser versions
+import 'abort-controller/polyfill';
 
 import store from '../redux';
 import { detectFeatures } from '../actions/features';

--- a/frontend/public/components/utils/safe-fetch-hook.ts
+++ b/frontend/public/components/utils/safe-fetch-hook.ts
@@ -1,6 +1,4 @@
 import { useEffect, useRef } from 'react';
-// AbortController is not supported in some older browser versions
-import { AbortController } from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 import { coFetchJSON } from '../../co-fetch';
 
 export const useSafeFetch = () => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -978,10 +978,12 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-abortcontroller-polyfill@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.3.0.tgz#de69af32ae926c210b7efbcc29bf644ee4838b00"
-  integrity sha512-lbWQgf+eRvku3va8poBlDBO12FigTQr9Zb7NIjXrePrhxWVKdCP2wbDl1tLDaYa18PWTom3UEWwdH13S46I+yA==
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
 
 abs-svg-path@^0.1.1, abs-svg-path@~0.1.1:
   version "0.1.1"
@@ -5302,6 +5304,11 @@ esutils@~1.0.0:
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 events@^1.0.0, events@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
Switch to https://github.com/mysticatea/abort-controller polyfill which is intended for use with `whatwg-fetch` (which is what we are using). 

Polyfill added by https://github.com/openshift/console/pull/1775 caused a regression because it was intended for use with `node-fetch`.

Tested against latest Chrome and Firefox to ensure native AbortController support isn't broken by polyfill. No runtime errors.

Tested against Firefox v56.0.2 to ensure polyfill works as expected. No runtime errors.