### PR TITLE
[WIP] Created extension for OCS operator workflow for IPI

### DIFF
--- a/frontend/packages/ceph-storage-plugin/package.json
+++ b/frontend/packages/ceph-storage-plugin/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "dependencies": {
     "@console/plugin-sdk": "0.0.0-fixed",
-    "@console/shared": "0.0.0-fixed"
+    "@console/shared": "0.0.0-fixed",
+    "@console/internal": "0.0.0-fixed"
   },
   "consolePlugin": {
     "entry": "src/plugin.ts"

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ipi-deployment-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ipi-deployment-modal.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+import {
+  createModalLauncher,
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+} from '@console/internal/components/factory/modal';
+import {
+  PromiseComponent,
+  PromiseComponentState,
+} from '@console/internal/components/utils/promise-component';
+
+class IPIDeployementModal extends PromiseComponent<ipiModalProps, PromiseComponentState> {
+  state = {
+    inProgress: false,
+    errorMessage: '',
+  };
+
+  submit = (event: React.FormEvent<EventTarget>) => {
+    event.preventDefault();
+
+    this.setState({ inProgress: true, errorMessage: '' });
+    // TODO: Call the API, once decided
+    // this.handlePromise().then(this.props.close);
+  };
+
+  render() {
+    return (
+      <form
+        onSubmit={this.submit}
+        name="form"
+        className="modal-content modal-content--no-inner-scroll"
+      >
+        <ModalTitle>Create OCS Service</ModalTitle>
+        <ModalBody>
+          3 new nodes and a AWS bucket will be created in order to create the OCS Service.
+        </ModalBody>
+        <ModalSubmitFooter
+          errorMessage={this.state.errorMessage}
+          inProgress={this.state.inProgress}
+          submitText="Create"
+          cancel={this.props.cancel}
+          cancelText="Cancel"
+        />
+      </form>
+    );
+  }
+}
+
+export const ipiDeployementModal = createModalLauncher<ipiModalProps>(IPIDeployementModal);
+
+export type ipiModalProps = {
+  cancel: (e: Event) => void;
+  close: () => void;
+};


### PR DESCRIPTION
After implementing, the IPI modal looks like - 

![ipi-modal](https://user-images.githubusercontent.com/5517376/60069808-45c10900-974f-11e9-93ed-232741058fee.png)


@spadgett @vojtechszocs This is the initial PR of OCS operator workflow for IPI. Please review.