### PR TITLE
feat(dropdown-actionitem): add create action to the project dropdown

### DIFF
--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -70,7 +70,7 @@ const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNames
 
   _submit(event) {
     event.preventDefault();
-    const { createProject, close } = this.props;
+    const { createProject, close, onSubmit } = this.props;
 
     let promise = createProject ? this.createProject() : this.createNamespace();
     if (this.state.np === deny) {
@@ -83,7 +83,11 @@ const CreateNamespaceModal = connect(null, mapDispatchToProps)(class CreateNames
 
     this.handlePromise(promise).then(obj => {
       close();
-      history.push(resourceObjPath(obj, referenceFor(obj)));
+      if (onSubmit) {
+        onSubmit(obj);
+      } else {
+        history.push(resourceObjPath(obj, referenceFor(obj)));
+      }
     });
   }
 

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -26,6 +26,7 @@ import { OverviewNamespaceDashboard } from './overview/namespace-overview';
 const getModel = useProjects => useProjects ? ProjectModel : NamespaceModel;
 const getDisplayName = obj => _.get(obj, ['metadata', 'annotations', 'openshift.io/display-name']);
 const getRequester = obj => _.get(obj, ['metadata', 'annotations', 'openshift.io/requester']);
+const CREATE_NEW_RESOURCE = '#CREATE_RESOURCE_ACTION#';
 
 export const deleteModal = (kind, ns) => {
   let {label, weight, accessReview} = Kebab.factory.Delete(kind, ns);
@@ -344,8 +345,21 @@ class NamespaceBarDropdowns_ extends React.Component {
       // If the currently active namespace is not found in the list of all namespaces, put it in anyway
       items[title] = title;
     }
+    const defaultActionItem = {
+      actionTitle: `Create ${model.label}`,
+      actionKey: CREATE_NEW_RESOURCE,
+    };
 
-    const onChange = newNamespace => dispatch(UIActions.setActiveNamespace(newNamespace));
+    const onChange = (newNamespace) => {
+      if (newNamespace === CREATE_NEW_RESOURCE) {
+        createProjectModal({
+          blocking: true,
+          onSubmit: (newProject) => dispatch(UIActions.setActiveNamespace(newProject.metadata.name)),
+        });
+      } else {
+        dispatch(UIActions.setActiveNamespace(newNamespace));
+      }
+    };
 
     return <div className="co-namespace-bar__items" data-test-id="namespace-bar-dropdown">
       <Dropdown
@@ -354,6 +368,7 @@ class NamespaceBarDropdowns_ extends React.Component {
         buttonClassName="pf-m-plain"
         canFavorite
         items={items}
+        actionItem={defaultActionItem}
         titlePrefix={model.label}
         title={<span className="btn-link__title">{title}</span>}
         onChange={onChange}


### PR DESCRIPTION
Add `create new project` action item to the project dropdown in `Add` and `Topology` page in the dev console.

* modified the namespace component to get the `onchange` and `actionItem` props from the parent component.
* modified the create namespace modal component to have an onSubmit handler.
* add actionItem to namespace dropdown

![screencast-localhost-9000-2019 06 25-13-26-19](https://user-images.githubusercontent.com/9964343/60082276-07c4e480-9751-11e9-9e63-f8b82edbd5ab.gif)

Story: https://jira.coreos.com/browse/ODC-1023