### PR TITLE
Installed Operator Subscription Tab

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -3,13 +3,45 @@ import { shallow, ShallowWrapper, mount, ReactWrapper } from 'enzyme';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
 
-import { ClusterServiceVersionsDetailsPage, ClusterServiceVersionsDetailsPageProps, ClusterServiceVersionDetails, ClusterServiceVersionDetailsProps, ClusterServiceVersionsPage, ClusterServiceVersionsPageProps, ClusterServiceVersionList, ClusterServiceVersionTableHeader, ClusterServiceVersionTableRow, ClusterServiceVersionTableRowProps, CRDCard, CRDCardRow } from '../../../public/components/operator-lifecycle-manager/clusterserviceversion';
-import { ClusterServiceVersionKind, ClusterServiceVersionLogo, ClusterServiceVersionLogoProps, referenceForProvidedAPI, CSVConditionReason } from '../../../public/components/operator-lifecycle-manager';
+import {
+  ClusterServiceVersionsDetailsPage,
+  ClusterServiceVersionsDetailsPageProps,
+  ClusterServiceVersionDetails,
+  ClusterServiceVersionDetailsProps,
+  ClusterServiceVersionsPage,
+  ClusterServiceVersionsPageProps,
+  ClusterServiceVersionList,
+  ClusterServiceVersionTableHeader,
+  ClusterServiceVersionTableRow,
+  ClusterServiceVersionTableRowProps,
+  CRDCard,
+  CRDCardRow,
+  CSVSubscription,
+  CSVSubscriptionProps,
+} from '../../../public/components/operator-lifecycle-manager/clusterserviceversion';
+import {
+  ClusterServiceVersionKind,
+  ClusterServiceVersionLogo,
+  ClusterServiceVersionLogoProps,
+  referenceForProvidedAPI,
+  CSVConditionReason,
+  copiedLabelKey,
+} from '../../../public/components/operator-lifecycle-manager';
 import { DetailsPage, ListPage, TableInnerProps, Table, TableRow } from '../../../public/components/factory';
 import { testClusterServiceVersion } from '../../../__mocks__/k8sResourcesMocks';
-import { Timestamp, MsgBox, ResourceLink, ResourceKebab, ErrorBoundary, LoadingBox, ScrollToTopOnMount, SectionHeading } from '../../../public/components/utils';
+import {
+  Timestamp,
+  MsgBox,
+  ResourceLink,
+  ResourceKebab,
+  ErrorBoundary,
+  LoadingBox,
+  ScrollToTopOnMount,
+  SectionHeading,
+  Firehose,
+} from '../../../public/components/utils';
 import { referenceForModel } from '../../../public/module/k8s';
-import { ClusterServiceVersionModel } from '../../../public/models';
+import { ClusterServiceVersionModel, SubscriptionModel, PackageManifestModel } from '../../../public/models';
 
 import * as operatorLogo from '../../../public/imgs/operator.svg';
 
@@ -238,6 +270,28 @@ describe(ClusterServiceVersionDetails.displayName, () => {
   });
 });
 
+describe(CSVSubscription.displayName, () => {
+  let wrapper: ShallowWrapper<CSVSubscriptionProps>;
+
+  it('renders `Firehose` for PackageManifest and Subscription', () => {
+    let obj = _.cloneDeep(testClusterServiceVersion);
+    obj = _.set(obj, 'metadata.annotations', {[copiedLabelKey]: 'operators'});
+    wrapper = shallow(<CSVSubscription obj={obj} />);
+
+    expect(wrapper.find(Firehose).props().resources).toEqual([{
+      kind: referenceForModel(SubscriptionModel),
+      namespace: obj.metadata.annotations[copiedLabelKey],
+      isList: true,
+      prop: 'subscription',
+    }, {
+      kind: referenceForModel(PackageManifestModel),
+      namespace: obj.metadata.namespace,
+      isList: true,
+      prop: 'packageManifest',
+    }]);
+  });
+});
+
 describe(ClusterServiceVersionsDetailsPage.displayName, () => {
   let wrapper: ShallowWrapper<ClusterServiceVersionsDetailsPageProps>;
   const name = 'example';
@@ -263,8 +317,10 @@ describe(ClusterServiceVersionsDetailsPage.displayName, () => {
     expect(detailsPage.props().pagesFor(testClusterServiceVersion)[0].component).toEqual(ClusterServiceVersionDetails);
     expect(detailsPage.props().pagesFor(testClusterServiceVersion)[1].name).toEqual('YAML');
     expect(detailsPage.props().pagesFor(testClusterServiceVersion)[1].href).toEqual('yaml');
-    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[2].name).toEqual('Events');
-    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[2].href).toEqual('events');
+    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[2].name).toEqual('Subscription');
+    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[2].href).toEqual('subscription');
+    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[3].name).toEqual('Events');
+    expect(detailsPage.props().pagesFor(testClusterServiceVersion)[3].href).toEqual('events');
   });
 
   it('includes tab for each "owned" CRD', () => {
@@ -273,11 +329,11 @@ describe(ClusterServiceVersionsDetailsPage.displayName, () => {
     const csv = _.cloneDeep(testClusterServiceVersion);
     csv.spec.customresourcedefinitions.owned = csv.spec.customresourcedefinitions.owned.concat([{name: 'e.example.com', kind: 'E', version: 'v1', displayName: 'E'}]);
 
-    expect(detailsPage.props().pagesFor(csv)[3].name).toEqual('All Instances');
-    expect(detailsPage.props().pagesFor(csv)[3].href).toEqual('instances');
+    expect(detailsPage.props().pagesFor(csv)[4].name).toEqual('All Instances');
+    expect(detailsPage.props().pagesFor(csv)[4].href).toEqual('instances');
     csv.spec.customresourcedefinitions.owned.forEach((desc, i) => {
-      expect(detailsPage.props().pagesFor(csv)[4 + i].name).toEqual(desc.displayName);
-      expect(detailsPage.props().pagesFor(csv)[4 + i].href).toEqual(referenceForProvidedAPI(desc));
+      expect(detailsPage.props().pagesFor(csv)[5 + i].name).toEqual(desc.displayName);
+      expect(detailsPage.props().pagesFor(csv)[5 + i].href).toEqual(referenceForProvidedAPI(desc));
     });
   });
 

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -101,7 +101,7 @@ const AdminNav = () => (
       <ResourceNSLink
         model={ClusterServiceVersionModel}
         resource={ClusterServiceVersionModel.plural}
-        required={[FLAGS.OPERATOR_LIFECYCLE_MANAGER]}
+        required={[FLAGS.OPERATOR_LIFECYCLE_MANAGER, FLAGS.CAN_LIST_PACKAGE_MANIFEST]}
         name="Installed Operators"
       />
       <Separator required={FLAGS.OPERATOR_LIFECYCLE_MANAGER} />

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -11,7 +11,8 @@ export { SubscriptionsPage } from './subscription';
 import * as operatorLogo from '../../imgs/operator.svg';
 import { InstallModeType } from './operator-group';
 
-export const appCatalogLabel = 'alm-catalog';
+export const copiedLabelKey = 'olm.copiedFrom';
+
 export enum AppCatalog {
   rhOperators = 'rh-operators',
 }

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -146,14 +146,13 @@ export const SubscriptionDetails: React.SFC<SubscriptionDetailsProps> = (props) 
   const {obj, installedCSV, pkg} = props;
   const catalogNS = obj.spec.sourceNamespace || olmNamespace;
 
-  const Effect: React.SFC<{promise: () => Promise<any>}> = ({promise}) => {
-    promise();
-    return null;
-  };
+  React.useEffect(() => {
+    if (props.showDelete) {
+      createDisableApplicationModal({k8sKill, k8sGet, k8sPatch, subscription: obj}).result.then(() => removeQueryArgument('showDelete'));
+    }
+  }, [obj, props.showDelete]);
 
   return <div className="co-m-pane__body">
-    <Effect promise={props.showDelete ? () => createDisableApplicationModal({k8sKill, k8sGet, k8sPatch, subscription: obj}).result.then(() => removeQueryArgument('showDelete')) : () => null} />
-
     <SectionHeading text="Subscription Overview" />
     <div className="co-m-pane__body-group">
       <SubscriptionUpdates pkg={pkg} obj={obj} installedCSV={installedCSV} installPlan={props.installPlan} />
@@ -177,6 +176,11 @@ export const SubscriptionDetails: React.SFC<SubscriptionDetailsProps> = (props) 
             <dd>
               <ResourceLink kind={referenceForModel(CatalogSourceModel)} name={obj.spec.source} namespace={catalogNS} title={obj.spec.source} />
             </dd>
+            <dt>Install Plan</dt>
+            <dd>{_.get(obj.status, 'installplan.name')
+              ? <ResourceLink kind={referenceForModel(InstallPlanModel)} name={obj.status.installplan.name} namespace={obj.metadata.namespace} title={obj.status.installplan.name} />
+              : 'None'
+            }</dd>
           </dl>
         </div>
       </div>


### PR DESCRIPTION
### Description

Adds **Subscription** tab to the `ClusterServiceVersion` detail view so that cluster admins can manage updates to their installed Operators. Works for `OwnNamespace` install modes (`Subscription` lives in same namespace as `ClusterServiceVersion`) and `AllNamespaces` install mode (`Subscription` lives in a single namespace, and [`ClusterServiceVersions` are "copied" to all namespaces](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/operatorgroups.md#copied-csvs) for users to discover.

### Screenshots

**Subscription tab (`OwnNamespace` install mode):**
![Screenshot_20190625_152329](https://user-images.githubusercontent.com/11700385/60127012-38128000-975d-11e9-8ef0-643774e298a1.png)

**Subscription tab (`AllNamespaces` install mode in a "copied" namespace):**
![Screenshot_20190626_134006](https://user-images.githubusercontent.com/11700385/60202204-11fde600-9818-11e9-9e4b-c631be3ba5b2.png)

Addresses https://jira.coreos.com/browse/CONSOLE-1460