### PR TITLE
errorModal: refactor to use React Component

### DIFF
--- a/frontend/public/components/modals/error-modal.jsx
+++ b/frontend/public/components/modals/error-modal.jsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 
 import {createModalLauncher, ModalTitle, ModalBody, ModalFooter} from '../factory/modal';
 
-export const errorModal = createModalLauncher(
-  ({error, cancel}) => {
-    return (
-      <div className="modal-content">
-        <ModalTitle>Error</ModalTitle>
-        <ModalBody>{error}</ModalBody>
-        <ModalFooter inProgress={false} errorMessage=""><button type="button" onClick={(e) => cancel(e)} className="btn btn-default">OK</button></ModalFooter>
-      </div>
-    );
-  }
-);
+export const ModalErrorContent = ({ error, title = 'Error', cancel }) => (
+  <div className="modal-content">
+    <ModalTitle>{title}</ModalTitle>
+    <ModalBody>{error}</ModalBody>
+    <ModalFooter inProgress={false} errorMessage="">
+      <button type="button" onClick={cancel} className="btn btn-default">OK</button>
+    </ModalFooter>
+  </div>);
+
+export const errorModal = createModalLauncher(ModalErrorContent);


### PR DESCRIPTION
No API or functional change.

The component is intended to be reused by other commits.