### PR TITLE
Don't set new state when actionItem is clicked

### DIFF
--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -48,16 +48,20 @@ export class DropdownMixin extends React.PureComponent {
     e.preventDefault();
     e.stopPropagation();
 
-    const {onChange, noSelection, title} = this.props;
+    const { items, actionItem, onChange, noSelection, title } = this.props;
 
     if (onChange) {
       onChange(selectedKey, e);
     }
 
-    this.setState({
-      selectedKey,
-      title: noSelection ? title : this.props.items[selectedKey],
-    });
+    const newTitle = items[selectedKey];
+
+    if (!actionItem || (selectedKey !== actionItem.actionKey)) {
+      this.setState({
+        selectedKey,
+        title: noSelection ? title : newTitle,
+      });
+    }
 
     this.hide();
   }
@@ -421,8 +425,8 @@ export class Dropdown extends DropdownMixin {
 
 Dropdown.propTypes = {
   actionItem: PropTypes.shape({
-    key: PropTypes.string,
-    title: PropTypes.string,
+    actionKey: PropTypes.string,
+    actionTitle: PropTypes.string,
   }),
   autocompleteFilter: PropTypes.func,
   autocompletePlaceholder: PropTypes.string,


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-1126

This PR -
- Fixes the bug where action item title would disappear when clicked twice.
- The issue was due to onClick getting the title from `items` and not considering `actionItem` as a separate prop.

Update - 
- As it turns out for a few new use cases we didn't wanted to set `selectedKey` and 'title' when an  action item was clicked by user. For these cases we just call the onChange handler and let the parent decide if it wants to set any state or not.
- This feature is needed for 
  - https://github.com/openshift/console/pull/1811
  - https://github.com/openshift/console/pull/1787