### PR TITLE
Fix incorrect height of See All

### DIFF
--- a/frontend/public/components/dashboard/dashboard-card/card-see-all.tsx
+++ b/frontend/public/components/dashboard/dashboard-card/card-see-all.tsx
@@ -14,7 +14,7 @@ export const DashboardCardSeeAll: React.FC<DashboardCardTitleSeeAllProps> = Reac
   );
   return (
     <OverlayTrigger overlay={overlay} placement="right" trigger={['click']} rootClose>
-      <Button bsStyle="link">{SEE_ALL}</Button>
+      <Button bsStyle="link" className="co-dashboard-card__see-all">{SEE_ALL}</Button>
     </OverlayTrigger>
   );
 });

--- a/frontend/public/components/dashboard/dashboard-card/card.scss
+++ b/frontend/public/components/dashboard/dashboard-card/card.scss
@@ -13,6 +13,11 @@
   justify-content: space-between;
 }
 
+.co-dashboard-card__see-all {
+  line-height: 1;
+  padding: 0;
+}
+
 .co-dashboard-card__title {
   font-size: 1rem;
   margin: 0;


### PR DESCRIPTION
Before with demo-plugin enabled (adds subsystem which enables See All link). Note the incorrect Details Card header height
![see-all-before](https://user-images.githubusercontent.com/2078045/60206101-1abfdd80-9853-11e9-812e-2172a27be05e.png)

After
![see-all-after](https://user-images.githubusercontent.com/2078045/60206107-1bf10a80-9853-11e9-87e8-5a03a2563c10.png)
