### PR TITLE
Use customData prop to pass machines and nodes to HostTableRow

### DIFF
--- a/frontend/packages/console-shared/src/selectors/common.ts
+++ b/frontend/packages/console-shared/src/selectors/common.ts
@@ -6,7 +6,7 @@ export const getName = (value: K8sResourceKind) =>
   _.get(value, 'metadata.name') as K8sResourceKind['metadata']['name'];
 export const getNamespace = (value: K8sResourceKind) =>
   _.get(value, 'metadata.namespace') as K8sResourceKind['metadata']['namespace'];
-export const getUid = (value: K8sResourceKind) =>
+export const getUID = (value: K8sResourceKind) =>
   _.get(value, 'metadata.uid') as K8sResourceKind['metadata']['uid'];
 export const getDeletetionTimestamp = (value: K8sResourceKind) =>
   _.get(value, 'metadata.deletionTimestamp') as K8sResourceKind['metadata']['deletionTimestamp'];

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import { ResourceIcon } from '@console/internal/components/utils';
-import { getName, getNamespace, getUid } from '@console/shared';
+import { getName, getNamespace, getUID } from '@console/shared';
 import { TemplateModel } from '@console/internal/models';
 import { TemplateKind } from '@console/internal/module/k8s';
 
@@ -15,7 +15,7 @@ export const VMTemplateLink: React.FC<VMTemplateLinkProps> = ({ template }) => {
       <ResourceIcon kind={TemplateModel.kind} />
       <Link
         to={`/k8s/ns/${namespace}/vmtemplates/${name}`}
-        title={getUid(template)}
+        title={getUID(template)}
         className="co-resource-item__resource-name"
       >
         {name}

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -11,7 +11,7 @@ import {
   // VM_SIMPLE_STATUS_TO_TEXT,
   //  DASHES,
 } from 'kubevirt-web-ui-components';
-import { getName, getNamespace, getUid } from '@console/shared';
+import { getName, getNamespace, getUID } from '@console/shared';
 
 import { NamespaceModel, PodModel } from '@console/internal/models';
 import { Table, MultiListPage, TableRow, TableData } from '@console/internal/components/factory';
@@ -74,7 +74,7 @@ const VMRow: React.FC<VMRowProps> = ({
 }) => {
   const name = getName(vm);
   const namespace = getNamespace(vm);
-  const uid = getUid(vm);
+  const uid = getUID(vm);
   const vmStatus = getVmStatus(vm, pods, migrations);
   const dimensify = dimensifyRow(tableColumnClasses);
 

--- a/frontend/packages/metal3-plugin/src/components/host.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host.tsx
@@ -3,11 +3,11 @@ import * as _ from 'lodash';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
-import { getName, getNamespace, getMachineNode } from '@console/shared';
+import { getName, getNamespace, getUid, getMachineNode } from '@console/shared';
 import { MachineModel, NodeModel } from '@console/internal/models';
 
 import { MultiListPage, Table, TableRow, TableData } from '@console/internal/components/factory';
-import { ResourceLink, Kebab } from '@console/internal/components/utils';
+import { FirehoseResult, Kebab, ResourceLink } from '@console/internal/components/utils';
 import {
   referenceForModel,
   K8sResourceKind,
@@ -70,18 +70,30 @@ const HostsTableHeader = () => [
 ];
 
 type HostsTableRowProps = {
-  obj: K8sResourceKind & { machine: MachineKind; node: NodeKind };
+  obj: K8sResourceKind;
+  customData: {
+    machines: MachineKind[];
+    nodes: NodeKind[];
+  };
   index: number;
   key?: string;
   style: React.StyleHTMLAttributes<any>;
 };
 
-const HostsTableRow: React.FC<HostsTableRowProps> = ({ obj: host, index, key, style }) => {
+const HostsTableRow: React.FC<HostsTableRowProps> = ({
+  obj: host,
+  customData: { machines, nodes },
+  index,
+  key,
+  style,
+}) => {
   const name = getName(host);
   const namespace = getNamespace(host);
   // const machineName = getHostMachineName(host);
   const address = getHostBMCAddress(host);
-  const { machine, node } = host;
+  const uid = getUid(host);
+  const machine = getHostMachine(host, machines);
+  const node = getMachineNode(machine, nodes);
 
   // TODO(jtomasek): other resource references will be updated as a subsequent change
   // const machineResource = {
@@ -103,7 +115,7 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({ obj: host, index, key, st
   // };
 
   return (
-    <TableRow id={host.metadata.uid} index={index} trKey={key} style={style}>
+    <TableRow id={uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
         <ResourceLink
           kind={referenceForModel(BaremetalHostModel)}
@@ -128,9 +140,32 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({ obj: host, index, key, st
   );
 };
 
-const HostList: React.FC<React.ComponentProps<typeof Table>> = (props) => (
-  <Table {...props} aria-label="Baremetal Hosts" Header={HostsTableHeader} Row={HostsTableRow} />
-);
+type HostListProps = {
+  data: K8sResourceKind[];
+  resources: {
+    machines: FirehoseResult<MachineKind[]>;
+    nodes: FirehoseResult<NodeKind[]>;
+  };
+} & React.ComponentProps<typeof Table>;
+
+const HostList: React.FC<HostListProps> = (props) => {
+  const {
+    resources: { machines, nodes },
+    ...tableProps
+  } = props;
+  return (
+    <Table
+      {...tableProps}
+      aria-label="Baremetal Hosts"
+      Header={HostsTableHeader}
+      Row={HostsTableRow}
+      customData={{
+        machines: machines.data || [],
+        nodes: nodes.data || [],
+      }}
+    />
+  );
+};
 
 type BaremetalHostsPageProps = {
   namespace: string;
@@ -161,18 +196,9 @@ export const BaremetalHostsPage: React.FC<BaremetalHostsPageProps> = (props) => 
     );
     const {
       hosts: { data: hostsData },
-      machines: { data: machinesData },
-      nodes: { data: nodesData },
     } = resources;
 
-    if (loaded) {
-      return hostsData.map((host) => {
-        const machine = getHostMachine(host, machinesData);
-        const node = getMachineNode(machine, nodesData);
-        return { ...host, machine, node };
-      });
-    }
-    return [];
+    return loaded ? hostsData : [];
   };
 
   return (

--- a/frontend/packages/metal3-plugin/src/components/host.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
-import { getName, getNamespace, getUid, getMachineNode } from '@console/shared';
+import { getName, getNamespace, getUID, getMachineNode } from '@console/shared';
 import { MachineModel, NodeModel } from '@console/internal/models';
 
 import { MultiListPage, Table, TableRow, TableData } from '@console/internal/components/factory';
@@ -91,7 +91,7 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({
   const namespace = getNamespace(host);
   // const machineName = getHostMachineName(host);
   const address = getHostBMCAddress(host);
-  const uid = getUid(host);
+  const uid = getUID(host);
   const machine = getHostMachine(host, machines);
   const node = getMachineNode(machine, nodes);
 


### PR DESCRIPTION
This replaces current practise where host resource object was expanded
with 'machines' and 'nodes' objects to pass the data to the row.

Instead customData prop is used to pass machines and nodes data.