### PR TITLE
Remove cluster hostname from sidebar

### DIFF
--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Title, Text, TextVariants } from '@patternfly/react-core';
+import { Title } from '@patternfly/react-core';
 import { getActivePerspective } from '../../reducers/ui';
 import * as plugins from '../../plugins';
 import { RootState } from '../../redux';
@@ -14,23 +14,11 @@ export const NavHeader: React.FC<StateProps> = ({ activePerspective }) => {
     .getPerspectives()
     .find((p) => p.properties.id === activePerspective).properties;
 
-  let clusterName: string;
-  const server = window.SERVER_FLAGS.kubeAPIServerURL;
-  if (server) {
-    // add zero-width space after each `.` to improve readability when breaking up the string for wrapping
-    clusterName = new URL(server).host.replace(/\./g, `.${String.fromCharCode(8203)}`);
-  }
-
   return (
     <div className="oc-nav-header">
       <Title className="oc-nav-header__title" size="md">
         {icon} {name}
       </Title>
-      {clusterName && (
-        <Text className="oc-nav-header__description co-break-word" component={TextVariants.small}>
-          Cluster: {clusterName}
-        </Text>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
This PR fixes: https://jira.coreos.com/browse/ODC-1185

![RemovedClusterName](https://user-images.githubusercontent.com/22490998/60290039-7bbfe200-9935-11e9-836f-09b2e9990fa2.png)
