### PR TITLE
[WIP] Change "Search" nav item to "Browse Resources"

### DIFF
--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -117,7 +117,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       perspective: 'dev',
       section: 'Advanced',
       componentProps: {
-        name: 'Search',
+        name: 'Browse Resources',
         href: '/search',
       },
     },

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -85,7 +85,7 @@ const AdminNav = () => (
   <React.Fragment>
     <NavSection title="Home">
       <ResourceClusterLink resource="projects" name="Projects" required={FLAGS.OPENSHIFT} />
-      <HrefLink href="/search" name="Search" startsWith={searchStartsWith} />
+      <HrefLink href="/search" name="Browse Resources" startsWith={searchStartsWith} />
       <ResourceNSLink resource="events" name="Events" />
     </NavSection>
 

--- a/frontend/public/components/search.jsx
+++ b/frontend/public/components/search.jsx
@@ -68,12 +68,13 @@ class SearchPage_ extends React.PureComponent {
     const validTags = _.reject(tags, tag => requirementFromString(tag) === undefined);
     const selector = selectorFromString(validTags.join(','));
     const labelClassName = `co-text-${_.toLower(kindForReference(kind))}`;
+    const title = 'Browse Resources';
 
     return <React.Fragment>
       <Helmet>
-        <title>Search</title>
+        <title>{title}</title>
       </Helmet>
-      <PageHeading detail={true} title="Search" >
+      <PageHeading detail={true} title={title}>
         <div className="co-search">
           <div className="input-group input-group-select">
             <div className="input-group-btn">


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-1557

Opening to get a discussion going on a better name. "Search" is not obvious. "All Resources" has also been proposed. I haven't renamed the component itself.

@smarterclayton @alimobrem @beanh66 @ncameronbritt @serenamarie125 @christianvogt 

I noticed dev console has search / events in a different nav order than admin console.

![Browse Resources · OKD 2019-06-27 15-27-00](https://user-images.githubusercontent.com/1167259/60294796-34fbc900-98f0-11e9-80be-622c3e114cf7.png)
