### PR TITLE
Query Browser style fixes and allow passing buttonClassName and menuClassName to <Dropdown />

### DIFF
--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -65,11 +65,13 @@
 }
 
 .query-browser__metrics-dropdown {
-  width: 200px;
-}
-.query-browser__metrics-dropdown-menu {
-  max-height: 25vh;
-  overflow: scroll;
+  .query-browser__metrics-dropdown-button {
+    width: 200px;
+  }
+  .query-browser__metrics-dropdown-menu {
+    max-height: 25vh;
+    overflow: scroll;
+  }
 }
 
 .query-browser__query, .query-browser__query-switch {
@@ -78,22 +80,19 @@
 }
 
 .query-browser__span-dropdown {
-  border-bottom-left-radius: 0;
-  border-left: none;
-  border-top-left-radius: 0;
-  width: 30px;
-  .caret {
-    margin-left: 0;
-    margin-right: 1px;
+  .query-browser__span-dropdown-button {
+    height: 29px;
+    min-width: 30px;
+    width: 30px;
+  }
+  .query-browser__span-dropdown-menu {
+    min-width: 110px;
+    right: 0;
   }
 }
 
-.query-browser__span-dropdown, .query-browser__span-dropdown-menu, .query-browser__span-reset {
+.query-browser__span-dropdown, .query-browser__span-reset {
   margin-right: 20px;
-}
-
-.query-browser__span-dropdown-menu {
-  min-width: 110px;
 }
 
 .query-browser__span-text {

--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -56,10 +56,6 @@
   width: 100%;
 }
 
-.query-browser__kebab {
-  position: relative;
-}
-
 .query-browser__loading {
   width: 20px;
 }
@@ -74,8 +70,7 @@
   }
 }
 
-.query-browser__query, .query-browser__query-switch {
-  margin-right: 15px;
+.query-browser__query {
   resize: vertical;
 }
 
@@ -91,8 +86,9 @@
   }
 }
 
-.query-browser__span-dropdown, .query-browser__span-reset {
-  margin-right: 20px;
+.query-browser__inline-control {
+  margin-left: 10px;
+  margin-right: 10px;
 }
 
 .query-browser__span-text {

--- a/frontend/public/components/graphs/query-browser.tsx
+++ b/frontend/public/components/graphs/query-browser.tsx
@@ -71,11 +71,13 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(({defaultSpanText, 
       />
     </div>
     <Dropdown
-      buttonClassName="query-browser__span-dropdown"
+      buttonClassName="query-browser__span-dropdown-button"
+      className="query-browser__span-dropdown"
       items={dropdownItems}
-      menuClassName="pf-c-dropdown__menu dropdown-menu-right query-browser__span-dropdown-menu"
-      onChange={setSpan}
+      menuClassName="query-browser__span-dropdown-menu"
       noSelection={true}
+      onChange={setSpan}
+      title="&nbsp;"
     />
     <button
       className="btn btn-default query-browser__span-reset"

--- a/frontend/public/components/graphs/query-browser.tsx
+++ b/frontend/public/components/graphs/query-browser.tsx
@@ -80,7 +80,7 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(({defaultSpanText, 
       title="&nbsp;"
     />
     <button
-      className="btn btn-default query-browser__span-reset"
+      className="btn btn-default query-browser__inline-control"
       onClick={() => setSpan(defaultSpanText)}
       type="button"
     >Reset Zoom</button>

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1093,17 +1093,17 @@ const Query: React.FC<QueryProps> = ({colorOffset, onBlur, onDelete, onSubmit, o
       </button>
       <textarea
         autoFocus={true}
-        className="form-control query-browser__query"
+        className="form-control query-browser__inline-control query-browser__query"
         onBlur={onBlur}
         onChange={e => onUpdate({text: e.target.value})}
         onKeyDown={onKeyDown}
         placeholder="Expression (press Shift+Enter for newlines)"
         value={text}
       />
-      <div className="query-browser__query-switch">
+      <div className="query-browser__inline-control">
         <Switch aria-label={`${enabled ? 'Disable' : 'Enable'} query`} isChecked={enabled} onChange={toggleEnabled} />
       </div>
-      <div className="dropdown-kebab-pf query-browser__kebab">
+      <div className="dropdown-kebab-pf">
         <Kebab options={kebabOptions} />
       </div>
     </div>
@@ -1240,7 +1240,7 @@ const QueryBrowserPage = withFallback(() => {
             <div className="query-browser__all-queries-controls">
               <MetricsDropdown onChange={onMetricChange} />
               <div>
-                <button type="button" className="btn" onClick={addQuery}>Add Query</button>
+                <button type="button" className="btn btn-default query-browser__inline-control" onClick={addQuery}>Add Query</button>
                 <button type="submit" className="btn btn-primary">Run Queries</button>
               </div>
             </div>

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1039,7 +1039,8 @@ const MetricsDropdown = ({onChange}) => {
 
   return <Dropdown
     autocompleteFilter={fuzzy}
-    buttonClassName="btn-default query-browser__metrics-dropdown"
+    buttonClassName="query-browser__metrics-dropdown-button"
+    className="query-browser__metrics-dropdown"
     id="metrics-dropdown"
     items={items}
     menuClassName="query-browser__metrics-dropdown-menu"

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -360,10 +360,10 @@ export class Dropdown extends DropdownMixin {
     _.each(items, (v, k) => addItem(k, v));
 
     //render PF4 dropdown markup if this is not the autocomplete filter
-    if (autocompleteFilter){
-      return <div className={classNames(className)} ref={this.dropdownElement} style={this.props.style}>
+    if (autocompleteFilter) {
+      return <div className={className} ref={this.dropdownElement} style={this.props.style}>
         <div className={classNames('dropdown pf-c-dropdown', {'pf-m-expanded': this.state.active}, dropDownClassName)}>
-          <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('pf-c-dropdown__toggle', buttonClassName ? buttonClassName : '')} id={this.props.id} aria-describedby={describedBy} disabled={disabled} >
+          <button aria-haspopup="true" onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" className={classNames('pf-c-dropdown__toggle', buttonClassName)} id={this.props.id} aria-describedby={describedBy} disabled={disabled} >
             <div className="btn-dropdown__content-wrap">
               <span className="pf-c-dropdown__toggle-text">
                 {titlePrefix && <span className="btn-link__titlePrefix">{titlePrefix}: </span>}
@@ -398,10 +398,11 @@ export class Dropdown extends DropdownMixin {
         </div>
       </div>;
     }
+
     //pf4 markup
-    return (<div className={classNames(className)} ref={this.dropdownElement} style={this.props.style}>
+    return (<div className={className} ref={this.dropdownElement} style={this.props.style}>
       <div className={classNames({'dropdown pf-c-dropdown': true, 'pf-m-expanded': this.state.active})}>
-        <button aria-haspopup="true" aria-expanded={this.state.active} className={classNames('pf-c-dropdown__toggle')} onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" id={this.props.id} aria-describedby={describedBy} >
+        <button aria-haspopup="true" aria-expanded={this.state.active} className={classNames('pf-c-dropdown__toggle', buttonClassName)} onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" id={this.props.id} aria-describedby={describedBy} >
           <span className="pf-c-dropdown__toggle-text">
             {titlePrefix && <span className="btn-link__titlePrefix">{titlePrefix}: </span>}
             {title}
@@ -409,13 +410,12 @@ export class Dropdown extends DropdownMixin {
           <CaretDownIcon className="pf-c-dropdown__toggle-icon" />
         </button>
         {
-          active && <ul ref={this.dropdownList} className="pf-c-dropdown__menu">
+          active && <ul ref={this.dropdownList} className={classNames('pf-c-dropdown__menu', menuClassName)}>
             {rows}
           </ul>
         }
       </div>
     </div>);
-
   }
 }
 


### PR DESCRIPTION
Fix dropdown style issues introduced by switching to PF4 dropdowns. Required allowing `buttonClassName` and `menuClassName` to be passed to `Dropdown`.

Several other Query Browser style tweaks.

FYI @sg00dwin 