### PR TITLE
Add optional span property for dashboard card

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -56,6 +56,9 @@ namespace ExtensionProperties {
 
     /** Loader for the corresponding dashboard card component. */
     loader: LazyLoader<any>;
+
+    /** Card's vertical span in the column. Ignored for small screens, defaults to 12. */
+    span?: DashboardCardSpan;
   }
 
   export interface DashboardsOverviewQuery {
@@ -179,3 +182,5 @@ export interface DashboardsInventoryItemGroup
 export const isDashboardsInventoryItemGroup = (
   e: Extension<any>,
 ): e is DashboardsInventoryItemGroup => e.type === 'Dashboards/Inventory/Item/Group';
+
+export type DashboardCardSpan = 4 | 6 | 12;

--- a/frontend/packages/metal3-plugin/src/components/dashboard/index.tsx
+++ b/frontend/packages/metal3-plugin/src/components/dashboard/index.tsx
@@ -14,7 +14,7 @@ export const HostDashboard: React.FC<{ obj: K8sResourceKind }> = ({ obj }) => {
     obj,
   });
 
-  const mainCards = [ConnectedHealthCard, ConnectedUtilizationCard];
+  const mainCards = [{ Card: ConnectedHealthCard }, { Card: ConnectedUtilizationCard }];
   const leftCards = [];
 
   return (

--- a/frontend/public/components/dashboard/grid.tsx
+++ b/frontend/public/components/dashboard/grid.tsx
@@ -3,6 +3,7 @@ import { Grid, GridItem } from '@patternfly/react-core';
 import { global_breakpoint_lg as breakpointLG } from '@patternfly/react-tokens';
 
 import { useRefWidth } from '../utils/ref-width-hook';
+import { DashboardCardSpan } from '@console/plugin-sdk';
 
 export enum GridPosition {
   MAIN = 'MAIN',
@@ -10,9 +11,9 @@ export enum GridPosition {
   RIGHT = 'RIGHT',
 }
 
-const mapCardsToGrid = (cards: React.ComponentType<any>[], keyPrefix: string): React.ReactNode[] =>
-  cards.map((Card, index) => (
-    <GridItem key={`${keyPrefix}-${index}`} span={12}><Card /></GridItem>
+const mapCardsToGrid = (cards: GridDashboardCard[], keyPrefix: string, ignoreCardSpan: boolean = false): React.ReactNode[] =>
+  cards.map(({Card, span = 12}, index) => (
+    <GridItem key={`${keyPrefix}-${index}`} span={ignoreCardSpan ? 12 : span}><Card /></GridItem>
   ));
 
 export const DashboardGrid: React.FC<DashboardGridProps> = ({ mainCards, leftCards = [], rightCards = [] }) => {
@@ -22,17 +23,17 @@ export const DashboardGrid: React.FC<DashboardGridProps> = ({ mainCards, leftCar
       <Grid className="co-dashboard-grid">
         <GridItem lg={12} md={12} sm={12}>
           <Grid className="co-dashboard-grid">
-            {mapCardsToGrid(mainCards, 'main')}
+            {mapCardsToGrid(mainCards, 'main', true)}
           </Grid>
         </GridItem>
         <GridItem key="left" lg={12} md={12} sm={12}>
           <Grid className="co-dashboard-grid">
-            {mapCardsToGrid(leftCards, 'left')}
+            {mapCardsToGrid(leftCards, 'left', true)}
           </Grid>
         </GridItem>
         <GridItem key="right" lg={12} md={12} sm={12}>
           <Grid className="co-dashboard-grid">
-            {mapCardsToGrid(rightCards, 'right')}
+            {mapCardsToGrid(rightCards, 'right', true)}
           </Grid>
         </GridItem>
       </Grid>
@@ -59,8 +60,13 @@ export const DashboardGrid: React.FC<DashboardGridProps> = ({ mainCards, leftCar
   return <div ref={containerRef}>{grid}</div>;
 };
 
+export type GridDashboardCard = {
+  Card: React.ComponentType<any>;
+  span?: DashboardCardSpan;
+}
+
 type DashboardGridProps = {
-  mainCards: React.ComponentType<any>[],
-  leftCards?: React.ComponentType<any>[],
-  rightCards?: React.ComponentType<any>[],
+  mainCards: GridDashboardCard[],
+  leftCards?: GridDashboardCard[],
+  rightCards?: GridDashboardCard[],
 };

--- a/frontend/public/components/dashboards-page/dashboards.tsx
+++ b/frontend/public/components/dashboards-page/dashboards.tsx
@@ -7,11 +7,14 @@ import * as plugins from '../../plugins';
 import { OverviewDashboard } from './overview-dashboard/overview-dashboard';
 import { HorizontalNav, PageHeading, LoadingBox, Page, AsyncComponent } from '../utils';
 import { Dashboard } from '../dashboard/dashboard';
-import { DashboardGrid, GridPosition } from '../dashboard/grid';
+import { DashboardGrid, GridPosition, GridDashboardCard } from '../dashboard/grid';
 import { DashboardsCard } from '@console/plugin-sdk';
 
-const getCardsOnPosition = (cards: DashboardsCard[], position: GridPosition): React.ComponentType<any>[] =>
-  cards.filter(c => c.properties.position === position).map(c => () => <AsyncComponent loader={c.properties.loader} />);
+const getCardsOnPosition = (cards: DashboardsCard[], position: GridPosition): GridDashboardCard[] =>
+  cards.filter(c => c.properties.position === position).map(c => ({
+    Card: () => <AsyncComponent loader={c.properties.loader} />,
+    span: c.properties.span,
+  }));
 
 const getPluginTabPages = (): Page[] => {
   const cards = plugins.registry.getDashboardsCards();

--- a/frontend/public/components/dashboards-page/overview-dashboard/overview-dashboard.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/overview-dashboard.tsx
@@ -9,9 +9,9 @@ import { EventsCard } from './events-card';
 import { UtilizationCard } from './utilization-card';
 
 export const OverviewDashboard: React.FC<{}> = () => {
-  const mainCards = [HealthCard, CapacityCard, UtilizationCard];
-  const leftCards = [DetailsCard, InventoryCard];
-  const rightCards = [EventsCard];
+  const mainCards = [{Card: HealthCard}, {Card: CapacityCard}, {Card: UtilizationCard}];
+  const leftCards = [{Card: DetailsCard}, {Card: InventoryCard}];
+  const rightCards = [{Card: EventsCard}];
 
   return (
     <Dashboard>


### PR DESCRIPTION
Allows adding more cards in one line.
![grid-span](https://user-images.githubusercontent.com/2078045/60329974-ba838580-9991-11e9-8d88-b74d7687f1f9.png)

@cloudbehl 