### PR TITLE
Update Topology view to use @patternfly/react-topology components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "@patternfly/react-charts": "4.4.0",
     "@patternfly/react-core": "3.48.5",
     "@patternfly/react-table": "2.11.1",
+    "@patternfly/react-topology": "2.4.13",
     "@patternfly/react-virtualized-extension": "1.0.5",
     "abort-controller": "^3.0.0",
     "brace": "0.11.x",

--- a/frontend/packages/dev-console/src/components/topology/Graph.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Graph.tsx
@@ -3,7 +3,6 @@ import ReactMeasure from 'react-measure';
 import * as _ from 'lodash';
 import Renderer from './D3ForceDirectedRenderer';
 import {
-  GraphApi,
   EdgeProvider,
   NodeProvider,
   GraphModel,
@@ -17,7 +16,6 @@ interface State {
     width: number;
     height: number;
   };
-  graphApi?: GraphApi;
 }
 
 export interface GraphProps {
@@ -26,7 +24,6 @@ export interface GraphProps {
   groupProvider: GroupProvider;
   graph: GraphModel;
   topology: TopologyDataMap;
-  children?(GraphApi): React.ReactNode;
   selected?: string;
   onSelect?(string): void;
   graphApiRef?(GraphApi): void;
@@ -53,13 +50,11 @@ export default class Graph extends React.Component<GraphProps, State> {
 
   captureApiRef = (r) => {
     const { graphApiRef } = this.props;
-    this.setState({ graphApi: r ? r.api() : null });
     graphApiRef && graphApiRef(r ? r.api() : null);
   };
 
   renderMeasure = ({ measureRef }) => {
     const {
-      children,
       graph,
       nodeProvider,
       edgeProvider,
@@ -68,7 +63,7 @@ export default class Graph extends React.Component<GraphProps, State> {
       selected,
       topology,
     } = this.props;
-    const { dimensions, graphApi } = this.state;
+    const { dimensions } = this.state;
     return (
       <div ref={measureRef} className="odc-graph">
         {dimensions && (
@@ -86,7 +81,6 @@ export default class Graph extends React.Component<GraphProps, State> {
             selected={selected}
           />
         )}
-        {children && graphApi && children(graphApi)}
       </div>
     );
   };

--- a/frontend/packages/dev-console/src/components/topology/Graph.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Graph.tsx
@@ -29,6 +29,7 @@ export interface GraphProps {
   children?(GraphApi): React.ReactNode;
   selected?: string;
   onSelect?(string): void;
+  graphApiRef?(GraphApi): void;
 }
 
 export default class Graph extends React.Component<GraphProps, State> {
@@ -51,7 +52,9 @@ export default class Graph extends React.Component<GraphProps, State> {
   }, 100);
 
   captureApiRef = (r) => {
+    const { graphApiRef } = this.props;
     this.setState({ graphApi: r ? r.api() : null });
+    graphApiRef && graphApiRef(r ? r.api() : null);
   };
 
   renderMeasure = ({ measureRef }) => {

--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -1,14 +1,10 @@
 import * as React from 'react';
-import {
-  TopologyView,
-  TopologyControlBar,
-  createTopologyControlButtons,
-  defaultControlButtonsOptions,
-} from '@patternfly/react-topology';
+import { TopologyView } from '@patternfly/react-topology';
 
 import { nodeProvider, edgeProvider, groupProvider } from './shape-providers';
 import Graph from './Graph';
 import { GraphApi, TopologyDataModel } from './topology-types';
+import TopologyControlBar from './TopologyControlBar';
 import TopologySideBar from './TopologySideBar';
 
 type State = {
@@ -48,33 +44,11 @@ export default class Topology extends React.Component<TopologyProps, State> {
     this.setState({ graphApi: api });
   };
 
-  renderControlBar = () => {
-    const { graphApi } = this.state;
-    const controlButtons = createTopologyControlButtons({
-      ...defaultControlButtonsOptions,
-      zoomInCallback: () => {
-        graphApi && graphApi.zoomIn();
-      },
-      zoomOutCallback: () => {
-        graphApi && graphApi.zoomOut();
-      },
-      fitToScreenCallback: () => {
-        graphApi && graphApi.zoomFit();
-      },
-      resetViewCallback: () => {
-        graphApi && graphApi.resetLayout();
-      },
-      legend: false,
-    });
-
-    return <TopologyControlBar controlButtons={controlButtons} />;
-  };
-
   render() {
     const {
       data: { graph, topology },
     } = this.props;
-    const { selected } = this.state;
+    const { selected, graphApi } = this.state;
 
     const topologySideBar = (
       <TopologySideBar
@@ -86,7 +60,7 @@ export default class Topology extends React.Component<TopologyProps, State> {
 
     return (
       <TopologyView
-        controlBar={this.renderControlBar()}
+        controlBar={<TopologyControlBar graphApi={graphApi} />}
         sideBar={topologySideBar}
         sideBarOpen={!!selected}
       >

--- a/frontend/packages/dev-console/src/components/topology/TopologyControlBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyControlBar.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import {
+  TopologyControlBar as PFTopologyControlBar,
+  createTopologyControlButtons,
+  defaultControlButtonsOptions,
+} from '@patternfly/react-topology';
+
+import { GraphApi } from './topology-types';
+
+export interface TopologyControlBarProps {
+  graphApi?: GraphApi;
+}
+
+const TopologyControlBar: React.FC<TopologyControlBarProps> = ({ graphApi }) => {
+  const controlButtons = createTopologyControlButtons({
+    ...defaultControlButtonsOptions,
+    zoomInCallback: () => {
+      graphApi && graphApi.zoomIn();
+    },
+    zoomOutCallback: () => {
+      graphApi && graphApi.zoomOut();
+    },
+    fitToScreenCallback: () => {
+      graphApi && graphApi.zoomFit();
+    },
+    resetViewCallback: () => {
+      graphApi && graphApi.resetLayout();
+    },
+    legend: false,
+  });
+
+  return <PFTopologyControlBar controlButtons={controlButtons} />;
+};
+
+export default TopologyControlBar;

--- a/frontend/packages/dev-console/src/components/topology/TopologySideBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologySideBar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TopologySideBar as PfTopologySideBar } from '@patternfly/react-topology';
+import { TopologySideBar as PFTopologySideBar } from '@patternfly/react-topology';
 import { CloseButton } from '@console/internal/components/utils';
 import { ResourceOverviewPage } from '@console/internal/components/overview/resource-overview-page';
 import { TopologyDataObject } from './topology-types';
@@ -44,14 +44,14 @@ const TopologySideBar: React.FC<TopologySideBarProps> = ({ item, show, onClose }
   }
 
   return (
-    <PfTopologySideBar show={show}>
+    <PFTopologySideBar show={show}>
       <div className="odc-topology-sidebar__dismiss clearfix">
         <CloseButton onClick={onClose} data-test-id="sidebar-close-button" />
       </div>
       {itemtoShowOnSideBar ? (
         <ResourceOverviewPage item={itemtoShowOnSideBar} kind={itemtoShowOnSideBar.kind} />
       ) : null}
-    </PfTopologySideBar>
+    </PFTopologySideBar>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/topology/TopologySideBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologySideBar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ModelessOverlay } from 'patternfly-react';
+import { TopologySideBar as PfTopologySideBar } from '@patternfly/react-topology';
 import { CloseButton } from '@console/internal/components/utils';
 import { ResourceOverviewPage } from '@console/internal/components/overview/resource-overview-page';
 import { TopologyDataObject } from './topology-types';
@@ -44,14 +44,14 @@ const TopologySideBar: React.FC<TopologySideBarProps> = ({ item, show, onClose }
   }
 
   return (
-    <ModelessOverlay className="odc-topology-sidebar__overlay" show={show}>
+    <PfTopologySideBar show={show}>
       <div className="odc-topology-sidebar__dismiss clearfix">
         <CloseButton onClick={onClose} data-test-id="sidebar-close-button" />
       </div>
       {itemtoShowOnSideBar ? (
         <ResourceOverviewPage item={itemtoShowOnSideBar} kind={itemtoShowOnSideBar.kind} />
       ) : null}
-    </ModelessOverlay>
+    </PfTopologySideBar>
   );
 };
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -158,6 +158,9 @@ kbd {
     font-size: $font-size-base;
     height: auto;
   }
+  .pf-l-stack {
+    font-size: $font-size-base;
+  }
 }
 
 .pf-c-page__sidebar-body {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -239,10 +239,30 @@
     exenv "^1.2.2"
     focus-trap-react "^4.0.1"
 
+"@patternfly/react-core@^3.57.1":
+  version "3.57.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.57.1.tgz#4757e1798798daaf4f6a835f8d9256e27f908aa1"
+  integrity sha512-V9ET59Md62nDzNdbWMQGjFoyctkEw0bfRazV/8KZgMqWXVle0bt+TuIYHDtwxFlfTmnbEiDKoE+Fl1y3FC1Www==
+  dependencies:
+    "@patternfly/react-icons" "^3.10.6"
+    "@patternfly/react-styles" "^3.4.6"
+    "@patternfly/react-tokens" "^2.6.5"
+    "@tippy.js/react" "^2.2.1"
+    emotion "^9.2.9"
+    exenv "^1.2.2"
+    focus-trap-react "^4.0.1"
+
 "@patternfly/react-icons@^3.10.2":
   version "3.10.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.10.2.tgz#154c9d727e0d4f59212d463fe0790c3c71c78343"
   integrity sha512-n4NbSzqeROzpGsioQ6nvf/b2N4WzV0fuz5UXTuWD4PZCaY3D++eF1GLpIqEZHdA5uYN4NU6hzikPtyQqpX+bGA==
+  dependencies:
+    "@fortawesome/free-brands-svg-icons" "^5.8.1"
+
+"@patternfly/react-icons@^3.10.6":
+  version "3.10.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.10.6.tgz#f437cafe2f123e45a9a3456c85c27979b63ee765"
+  integrity sha512-zO14BaFuU/dZaEA+45Rh+eIb3c86l/ZPe6+UOyaD7s8GgqoiTFYYueoDCc9GEICdB+zb9kTLg20LIfsrnDsgnw==
   dependencies:
     "@fortawesome/free-brands-svg-icons" "^5.8.1"
 
@@ -291,6 +311,25 @@
     resolve-from "^4.0.0"
     typescript "3.4.5"
 
+"@patternfly/react-styles@^3.4.6":
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.4.6.tgz#03c645adfa3f6b8b7113232e90326547a39c6322"
+  integrity sha512-m9ynr85EMmBAxGhCguwRiGgpLDA9+YKtwF83ORK7ylHHsrK9JC/RFPvTj8d/80oUMmlzcL765ZwG7sT9qR3ybA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0-beta.48"
+    camel-case "^3.0.0"
+    css "^2.2.3"
+    cssom "^0.3.4"
+    cssstyle "^0.3.1"
+    emotion "^9.2.9"
+    emotion-server "^9.2.9"
+    fbjs-scripts "^0.8.3"
+    fs-extra "^6.0.1"
+    jsdom "^15.1.0"
+    relative "^3.0.2"
+    resolve-from "^4.0.0"
+    typescript "3.4.5"
+
 "@patternfly/react-table@2.11.1":
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-2.11.1.tgz#2bf52436797f2ef5a2f0aa49f75c680c50343bcf"
@@ -313,6 +352,20 @@
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.6.1.tgz#06b296dc14a2e30af026a61e544670da07bc28c4"
   integrity sha512-FoIY2uewqzxb6ScEn0G1lbfb1jLESDCqGo//zSXUx9dh83NWEsmkfKBKFEDhONyVYUGyFKcD7psByA94XLqnjw==
+
+"@patternfly/react-tokens@^2.6.5":
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.6.5.tgz#94907bbf1182855ceb69a44a0e351f7775842f19"
+  integrity sha512-HZ0LLAOugMmnD9n5T5Hp6vDnZ86ikm+MXu7kbfNqK9dTOVmEroPai0rUN6hnnPP4mCzFrLXmh4rzecDr2273yg==
+
+"@patternfly/react-topology@2.4.13":
+  version "2.4.13"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-topology/-/react-topology-2.4.13.tgz#318c8effba2806c9381a950b533d047c77d08dad"
+  integrity sha512-CaScmtQFr+++zr9z2dNxXl5Osihu30000af5TapkbBZABspnmcZ+AGO8dDj2VvLJ9e/qJaC2QP5tWc0W95s4hg==
+  dependencies:
+    "@patternfly/react-core" "^3.57.1"
+    "@patternfly/react-icons" "^3.10.6"
+    "@patternfly/react-styles" "^3.4.6"
 
 "@patternfly/react-virtualized-extension@1.0.5":
   version "1.0.5"
@@ -354,6 +407,14 @@
   dependencies:
     prop-types "^15.6.2"
     tippy.js "^3.2.0"
+
+"@tippy.js/react@^2.2.1":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@tippy.js/react/-/react-2.2.2.tgz#a0fbc646958cdb002d7d227f7b18dca346c76f2e"
+  integrity sha512-ex6IEy1cFC1a1MqbRaNZqo/MRK/GQOfa/VO5jydYeBrxnxJ3I/3gCX098dUHRLZmB6aFKVY39TwgnQRCbLUG4Q==
+  dependencies:
+    prop-types "^15.6.2"
+    tippy.js "^4.3.4"
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -10715,7 +10776,7 @@ popper.js@^1.14.1:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.4.tgz#8eec1d8ff02a5a3a152dd43414a15c7b79fd69b6"
 
-popper.js@^1.14.6:
+popper.js@^1.14.6, popper.js@^1.14.7:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
   integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==
@@ -13846,6 +13907,13 @@ tippy.js@^3.2.0:
   integrity sha512-ZiyGP9WZyCCcjxKM4G88cm4U1r1ytjeMDGa5FSKPaPzwc/3yZJVZsb1ffcmqUMCpryRp5LNxRNGKLzbs11sb/Q==
   dependencies:
     popper.js "^1.14.6"
+
+tippy.js@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-4.3.4.tgz#9a91fd5ce8c401f181b7adaa6b2c27f3d105f3ba"
+  integrity sha512-O2ukxHOJTLVYZ/TfHjNd8WgAWoefX9uk5QiWRdHfX2PR2lBpUU4BJQLl7U2Ykc8K7o16gTeHEElpuRfgD5b0aA==
+  dependencies:
+    popper.js "^1.14.7"
 
 tlds@^1.57.0:
   version "1.203.1"


### PR DESCRIPTION
This changes the topology view in developer mode to use the common topology view components in the @patternfly/react-topology package.

https://jira.coreos.com/browse/ODC-1002
https://jira.coreos.com/browse/ODC-1079

