### PR TITLE
Use jsdom env. for testing and plugin-stats

### DIFF
--- a/frontend/__mocks__/localStorage.ts
+++ b/frontend/__mocks__/localStorage.ts
@@ -2,10 +2,10 @@ let _localStorage = {};
 
 (window as any).localStorage = (window as any).sessionStorage = {
   setItem(key, value) {
-    return Object.assign(_localStorage, {[key]: value});
+    Object.assign(_localStorage, { [key]: value} );
   },
   getItem(key) {
-    return _localStorage[key];
+    return _localStorage[key] || null;
   },
   clear() {
     _localStorage = {};

--- a/frontend/__mocks__/matchMedia.js
+++ b/frontend/__mocks__/matchMedia.js
@@ -1,1 +1,1 @@
-window.matchMedia = () => ({matches: true});
+window.matchMedia = () => ({ matches: true });

--- a/frontend/__mocks__/requestAnimationFrame.js
+++ b/frontend/__mocks__/requestAnimationFrame.js
@@ -1,4 +1,0 @@
-// https://github.com/facebook/jest/issues/4545
-window.requestAnimationFrame = (callback) => {
-  setTimeout(callback, 0);
-};

--- a/frontend/before-tests.js
+++ b/frontend/before-tests.js
@@ -3,11 +3,12 @@
 import { configure } from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
 
+import './setup-jsdom';
+import 'url-search-params-polyfill';
+
 // http://airbnb.io/enzyme/docs/installation/index.html#working-with-react-16
-configure({adapter: new Adapter()});
+configure({ adapter: new Adapter() });
 
 window.SERVER_FLAGS = {
   basePath: '/',
 };
-
-require('url-search-params-polyfill');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,8 +43,8 @@
       "<rootDir>/node_modules/(?!lodash-es|@console)"
     ],
     "testRegex": "/__tests__/.*\\.spec\\.(ts|tsx|js|jsx)$",
+    "testURL": "http://localhost",
     "setupFiles": [
-      "./__mocks__/requestAnimationFrame.js",
       "./__mocks__/localStorage.ts",
       "./__mocks__/matchMedia.js",
       "./before-tests.js"

--- a/frontend/packages/dev-console/src/components/topology/shapes/__tests__/BaseNode.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/__tests__/BaseNode.spec.tsx
@@ -38,7 +38,7 @@ describe('BaseNode', () => {
         .find('.odc-base-node__bg')
         .first()
         .props().filter,
-    ).toBe('url(blank#BaseNodeDropShadowFilterId)');
+    ).toBe('url(/#BaseNodeDropShadowFilterId)');
 
     wrapper.setState({ hover: true });
     expect(
@@ -46,7 +46,7 @@ describe('BaseNode', () => {
         .find('.odc-base-node__bg')
         .first()
         .props().filter,
-    ).toBe('url(blank#BaseNodeDropShadowFilterId--hover)');
+    ).toBe('url(/#BaseNodeDropShadowFilterId--hover)');
   });
 
   it('should show long labels when selected', () => {

--- a/frontend/plugin-stats.ts
+++ b/frontend/plugin-stats.ts
@@ -1,5 +1,8 @@
 /* eslint-env node */
 
+import './setup-jsdom';
+import './__mocks__/matchMedia';
+
 import {
   resolvePluginPackages,
   loadActivePlugins,

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -30,7 +30,7 @@ export function getDefaultPerspective() {
       activePerspective = defaultPerspective.properties.id;
     }
   }
-  return activePerspective;
+  return activePerspective || undefined;
 }
 
 export default (state: UIState, action: UIAction): UIState => {

--- a/frontend/setup-jsdom.js
+++ b/frontend/setup-jsdom.js
@@ -1,0 +1,27 @@
+/* eslint-env node */
+
+// https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md
+
+import { JSDOM } from 'jsdom';
+
+const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
+const { window } = jsdom;
+
+function copyProps(src, target) {
+  Object.defineProperties(target, {
+    ...Object.getOwnPropertyDescriptors(src),
+    ...Object.getOwnPropertyDescriptors(target),
+  });
+}
+
+global.window = window;
+global.document = window.document;
+global.navigator = {
+  userAgent: 'node.js',
+};
+global.requestAnimationFrame = (callback) => setTimeout(callback, 0);
+global.cancelAnimationFrame = (id) => {
+  clearTimeout(id);
+};
+
+copyProps(window, global);


### PR DESCRIPTION
This PR ensures that

- tests running through Jest / Enzyme
- the `plugin-stats` script

have access to relevant web APIs (notably DOM and HTML) provided via [jsdom](https://github.com/jsdom/jsdom) implementation.

This also fixes problems like Console plugin entry module directly or indirectly referencing such web APIs and `plugin-stats` (`ts-node`) failing on errors like `ReferenceError: Element is not defined`.

Notable changes:
- keep `__mocks__/localStorage.ts` since it's [not easy to mock jsdom's web storage](https://github.com/facebook/jest/issues/6798)
- keep `__mocks__/matchMedia.js` since it's not provided by jsdom
- remove `__mocks__/requestAnimationFrame.js` since it's already provided by jsdom

/cc @spadgett @alecmerdler @rawagner @christianvogt 