### PR TITLE
Add ability to include dropDownClassName="dropdown--full-width" 

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -20,6 +20,7 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
 .dropdown--full-width {
   &,
   .pf-c-dropdown__toggle {
+    justify-content: space-between;
     width: 100%;
   }
 }

--- a/frontend/public/components/source-to-image.tsx
+++ b/frontend/public/components/source-to-image.tsx
@@ -431,7 +431,13 @@ class BuildSource extends React.Component<BuildSourceProps, BuildSourceState> {
           </div>
           <div className="form-group">
             <label className="control-label co-required" htmlFor="tag">Version</label>
-            <Dropdown items={tagOptions} selectedKey={selectedTag} title={tagOptions[selectedTag]} onChange={this.onTagChange} id="tag" />
+            <Dropdown
+              dropDownClassName="dropdown--full-width"
+              items={tagOptions}
+              selectedKey={selectedTag}
+              title={tagOptions[selectedTag]}
+              onChange={this.onTagChange}
+              id="tag" />
           </div>
           <div className="form-group">
             <label className="control-label co-required" htmlFor="name">Name</label>

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -401,7 +401,7 @@ export class Dropdown extends DropdownMixin {
 
     //pf4 markup
     return (<div className={className} ref={this.dropdownElement} style={this.props.style}>
-      <div className={classNames({'dropdown pf-c-dropdown': true, 'pf-m-expanded': this.state.active})}>
+      <div className={classNames({'dropdown pf-c-dropdown': true, 'pf-m-expanded': this.state.active}, dropDownClassName)}>
         <button aria-haspopup="true" aria-expanded={this.state.active} className={classNames('pf-c-dropdown__toggle', buttonClassName)} onClick={this.toggle} onKeyDown={this.onKeyDown} type="button" id={this.props.id} aria-describedby={describedBy} >
           <span className="pf-c-dropdown__toggle-text">
             {titlePrefix && <span className="btn-link__titlePrefix">{titlePrefix}: </span>}


### PR DESCRIPTION
to dropdowns that doesn't include autocomplete.
- Make source-to-image "Version" dropdown full width.

![Screen Shot 2019-07-01 at 1 29 44 PM](https://user-images.githubusercontent.com/1874151/60455489-7ea42680-9c04-11e9-9959-cbe065bad99e.png)
