### PR TITLE
Disable no-underscore-dangle rule

### DIFF
--- a/frontend/packages/.eslintrc.js
+++ b/frontend/packages/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
     ],
     // TODO fix for monorepo support
     'import/no-extraneous-dependencies': 'off',
+    'no-underscore-dangle': 'off',
   },
 };


### PR DESCRIPTION
The rule does not allow underscore in plugin components but is widely used in console. I'd like to disable it to allow plugin components use the same convention as rest of console's code.

See https://github.com/openshift/console/pull/1803#discussion_r297365651

@vojtechszocs @spadgett @christianvogt any objections ?

