### PR TITLE
Add basic API Explorer pages

### DIFF
--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import * as _ from 'lodash-es';
+import { Helmet } from 'react-helmet';
+import { Map as ImmutableMap } from 'immutable';
+import * as fuzzy from 'fuzzysearch';
+
+import { connectToModel } from '../kinds';
+import { K8sKind, K8sResourceKindReference, referenceForModel } from '../module/k8s';
+import { Table, TextFilter } from './factory';
+import { ExploreType } from './sidebars/explore-type-sidebar';
+import {
+  BreadCrumbs,
+  Loading,
+  ResourceIcon,
+  ScrollToTopOnMount,
+} from './utils';
+
+const APIResourceKind: React.FC<{model: K8sKind}> = ({model}) => <span className="co-resource-item">
+  <span className="co-resource-icon--fixed-width"><ResourceIcon kind={referenceForModel(model)} /></span>
+  <Link to={`/api-explorer/${referenceForModel(model)}`} className="co-resource-item__resource-name">{model.kind}</Link>
+</span>;
+
+const APIResourceHeader = () => [{
+  title: 'Kind',
+}, {
+  title: 'Group',
+}, {
+  title: 'Version',
+}];
+
+const APIResourceRows = ({componentProps: {data}}) => _.map(data, (model: K8sKind) => [{
+  title: <APIResourceKind model={model} />,
+}, {
+  title: model.apiGroup || '-',
+}, {
+  title: model.apiVersion,
+}]);
+
+const stateToProps = ({k8s}) => ({
+  models: k8s.getIn(['RESOURCES', 'models']),
+});
+
+const APIResourcesList = connect<APIResourcesListPropsFromState>(stateToProps)(({models}) => {
+  const [textFilter, setTextFilter] = React.useState('');
+  const filteredResources = textFilter
+    ? models.filter(({kind, apiGroup}) => {
+      const text = textFilter.toLowerCase();
+      return fuzzy(text, kind.toLowerCase()) || (apiGroup && fuzzy(text, apiGroup));
+    })
+    : models;
+  // Put models with no API group (core k8s resources) at the top.
+  const sortedResources = _.sortBy(filteredResources.toArray(), [({apiGroup}) => apiGroup || '1', 'apiVersion', 'kind']);
+  return <React.Fragment>
+    <div className="co-m-pane__filter-bar">
+      <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--filter">
+        <TextFilter
+          defaultValue={textFilter}
+          label="by kind or group"
+          onChange={(e) => setTextFilter(e.target.value)}
+        />
+      </div>
+    </div>
+    <div className="co-m-pane__body">
+      <Table
+        aria-label="API Resources"
+        data={sortedResources}
+        Header={APIResourceHeader}
+        Rows={APIResourceRows}
+        virtualize={false}
+        loaded={!_.isEmpty(sortedResources)} />
+    </div>
+  </React.Fragment>;
+});
+APIResourcesList.displayName = 'APIResourcesList';
+
+export const APIExplorerPage: React.FC<{}> = () => <React.Fragment>
+  <Helmet>
+    <title>API Explorer</title>
+  </Helmet>
+  <div className="co-m-nav-title">
+    <h1 className="co-m-pane__heading">API Explorer</h1>
+  </div>
+  <APIResourcesList />
+</React.Fragment>;
+APIExplorerPage.displayName = 'APIExplorerPage';
+
+export const APIResourcePage = connectToModel(({match, kindObj, kindsInFlight}: {match: any, kindObj: K8sKind, kindsInFlight: boolean}) => {
+  const exploreTypeRef = React.useRef(null);
+  const scrollTop = () => {
+    document.getElementById('content-scrollable').scrollTo(0, exploreTypeRef.current.offsetTop);
+  };
+
+  if (!kindObj) {
+    return kindsInFlight
+      ? <Loading />
+      : <div className="co-m-pane__body">
+        <h1 className="co-m-pane__heading co-m-pane__heading--center">404: Not Found</h1>
+      </div>;
+  }
+
+  const breadcrumbs = [{
+    name: 'API Explorer',
+    path: '/api-explorer',
+  }, {
+    name: `${kindObj.label} Details`,
+    path: match.url,
+  }];
+
+  return <React.Fragment>
+    <ScrollToTopOnMount />
+    <Helmet>
+      <title>{kindObj.label}</title>
+    </Helmet>
+    <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">
+      <BreadCrumbs breadcrumbs={breadcrumbs} />
+      <h1 className="co-m-pane__heading">{kindObj.label}</h1>
+    </div>
+    <div className="co-m-pane__body">
+      <h2 className="co-section-heading">Overview</h2>
+      <dl className="co-m-pane__details">
+        <dt>Kind</dt>
+        <dd>{kindObj.kind}</dd>
+        <dt>API Group</dt>
+        <dd>{kindObj.apiGroup || '-'}</dd>
+        <dt>API Version</dt>
+        <dd>{kindObj.apiVersion}</dd>
+      </dl>
+    </div>
+    <div className="co-m-pane__body" ref={exploreTypeRef}>
+      <h2 className="co-section-heading co-section-heading--breadcrumbs">Schema</h2>
+      <ExploreType kindObj={kindObj} scrollTop={scrollTop} />
+    </div>
+  </React.Fragment>;
+});
+APIResourcePage.displayName = 'APIResourcePage';
+
+type APIResourcesListPropsFromState = {
+  models: ImmutableMap<K8sResourceKindReference, K8sKind>;
+};

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -117,6 +117,8 @@ const AppContents = withRouter(React.memo(() => (
           <Redirect from="/overview/all-namespaces" to="/cluster-status" />
           <Redirect from="/overview/ns/:ns" to="/k8s/cluster/projects/:ns/workloads" />
           <Route path="/overview" exact component={NamespaceRedirect} />
+          <LazyRoute path="/api-explorer" exact loader={() => import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(m => m.APIExplorerPage)} />
+          <LazyRoute path="/api-explorer/:plural" loader={() => import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(m => m.APIResourcePage)} />
 
           <LazyRoute path="/start-guide" exact loader={() => import('./start-guide' /* webpackChunkName: "start-guide" */).then(m => m.StartGuidePage)} />
           <LazyRoute path="/command-line-tools" exact loader={() => import('./command-line-tools' /* webpackChunkName: "command-line-tools" */).then(m => m.CommandLineToolsPage)} />

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -188,6 +188,7 @@ const AdminNav = () => (
       <ResourceNSLink resource="resourcequotas" name="Resource Quotas" startsWith={quotaStartsWith} />
       <ResourceNSLink resource="limitranges" name="Limit Ranges" />
       <ResourceNSLink resource={referenceForModel(ChargebackReportModel)} name="Chargeback" required={FLAGS.CHARGEBACK} />
+      <HrefLink href="/api-explorer" name="API Explorer" />
       <ResourceClusterLink resource="customresourcedefinitions" name="Custom Resource Definitions" required={FLAGS.CAN_LIST_CRD} />
     </NavSection>
   </React.Fragment>

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 
 import { getDefinitionKey, getStoredSwagger, K8sKind, SwaggerDefinition, SwaggerDefinitions } from '../../module/k8s';
 import { ResourceSidebarWrapper, sidebarScrollTop } from './resource-sidebar';
-import { CamelCaseWrap, LinkifyExternal } from '../utils';
+import { CamelCaseWrap, EmptyBox, LinkifyExternal } from '../utils';
 
 const getRef = (definition: SwaggerDefinition): string => {
   const ref = definition.$ref || _.get(definition, 'items.$ref');
@@ -13,12 +13,12 @@ const getRef = (definition: SwaggerDefinition): string => {
   return ref && re.test(ref) ? ref.replace(re, '') : null;
 };
 
-export const ExploreTypeSidebar: React.FC<ExploreTypeSidebarProps> = (props) => {
+export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   // Track the previously selected items to build breadcrumbs. Each history
   // entry contains the name, description, and path to the definition in the
   // OpenAPI document.
   const [drilldownHistory, setDrilldownHistory] = React.useState([]);
-  const {kindObj, height} = props;
+  const {kindObj} = props;
   if (!kindObj) {
     return null;
   }
@@ -40,7 +40,9 @@ export const ExploreTypeSidebar: React.FC<ExploreTypeSidebarProps> = (props) => 
   const drilldown = (e: React.MouseEvent<HTMLButtonElement>, name: string, desc: string, path: string[]) => {
     e.preventDefault();
     setDrilldownHistory([...drilldownHistory, { name, description: desc, path }]);
-    sidebarScrollTop();
+    if (props.scrollTop) {
+      props.scrollTop();
+    }
   };
 
   const breadcrumbClicked = (e: React.MouseEvent<HTMLButtonElement>, i: number) => {
@@ -75,7 +77,7 @@ export const ExploreTypeSidebar: React.FC<ExploreTypeSidebarProps> = (props) => 
   const getTypeForRef = (ref: string): string => _.get(allDefinitions, [ref, 'format']) || _.get(allDefinitions, [ref, 'type']);
 
   return (
-    <ResourceSidebarWrapper label={kindObj.kind} linkLabel="View Schema" style={{height}}>
+    <React.Fragment>
       <ol className="breadcrumb">
         {breadcrumbs.map((crumb, i) => {
           const isLast = i === breadcrumbs.length - 1;
@@ -87,31 +89,44 @@ export const ExploreTypeSidebar: React.FC<ExploreTypeSidebarProps> = (props) => 
         })}
       </ol>
       {description && <p className="co-break-word co-pre-line"><LinkifyExternal>{description}</LinkifyExternal></p>}
-      <ul className="co-resource-sidebar-list">
-        {_.map(currentDefinition.properties, (definition: SwaggerDefinition, name: string) => {
-          const path = getDrilldownPath(definition, name);
-          const definitionType = definition.type || getTypeForRef(getRef(definition));
-          return (
-            <li key={name} className="co-resource-sidebar-item">
-              <h5 className="co-resource-sidebar-item__header co-break-word">
-                <CamelCaseWrap value={name} />
-                &nbsp;
-                <small>
-                  <span className="co-break-word">{definitionType}</span>
-                  {required.has(name) && <React.Fragment> &ndash; required</React.Fragment>}
-                </small>
-              </h5>
-              {definition.description && <p className="co-break-word co-pre-line"><LinkifyExternal>{definition.description}</LinkifyExternal></p>}
-              {path && <button type="button" className="btn btn-link btn-link--no-btn-default-values" onClick={e => drilldown(e, name, definition.description, path)}>View Details</button>}
-            </li>
-          );
-        })}
-      </ul>
-    </ResourceSidebarWrapper>
+      {_.isEmpty(currentDefinition.properties)
+        ? <EmptyBox label="Properties" />
+        : <ul className="co-resource-sidebar-list">
+          {_.map(currentDefinition.properties, (definition: SwaggerDefinition, name: string) => {
+            const path = getDrilldownPath(definition, name);
+            const definitionType = definition.type || getTypeForRef(getRef(definition));
+            return (
+              <li key={name} className="co-resource-sidebar-item">
+                <h5 className="co-resource-sidebar-item__header co-break-word">
+                  <CamelCaseWrap value={name} />
+                  &nbsp;
+                  <small>
+                    <span className="co-break-word">{definitionType}</span>
+                    {required.has(name) && <React.Fragment> &ndash; required</React.Fragment>}
+                  </small>
+                </h5>
+                {definition.description && <p className="co-break-word co-pre-line"><LinkifyExternal>{definition.description}</LinkifyExternal></p>}
+                {path && <button type="button" className="btn btn-link btn-link--no-btn-default-values" onClick={e => drilldown(e, name, definition.description, path)}>View Details</button>}
+              </li>
+            );
+          })}
+        </ul>
+      }
+    </React.Fragment>
   );
 };
 
-type ExploreTypeSidebarProps = {
+export const ExploreTypeSidebar: React.FC<ExploreTypeSidebarProps> = ({height, ...exploreTypeProps}) => (
+  <ResourceSidebarWrapper label={exploreTypeProps.kindObj.kind} linkLabel="View Schema" style={{height}}>
+    <ExploreType {...exploreTypeProps} scrollTop={sidebarScrollTop} />
+  </ResourceSidebarWrapper>
+);
+
+type ExploreTypeProps = {
   kindObj: K8sKind;
-  height: number;
+  scrollTop?: () => void;
 };
+
+type ExploreTypeSidebarProps = {
+  height: number;
+} & ExploreTypeProps;

--- a/frontend/public/components/utils/scroll-to-top-on-mount.jsx
+++ b/frontend/public/components/utils/scroll-to-top-on-mount.jsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 // back to the top of the navigated to page when pages share a resource.
 export class ScrollToTopOnMount extends React.Component {
   componentDidMount() {
-    window.scrollTo(0, 0);
+    document.getElementById('content-scrollable').scrollTo(0, 0);
   }
 
   render() {

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -122,6 +122,10 @@
   margin: 0 0 20px 0;
 }
 
+.co-section-heading--breadcrumbs {
+  margin-bottom: 0;
+}
+
 .co-section-heading__title {
   font-size: 18px;
   margin: 0 0 20px 0;


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-1517

There's a lot more we can do here, but I'd like to get something simple integrated and then iterate. Probably we want to add tabs to the details page and let users list instances. Would like your input @bmignano 

/assign @rhamilto 

![Screen Shot 2019-07-01 at 4 31 25 PM](https://user-images.githubusercontent.com/1167259/60464879-bc617900-9c1d-11e9-8ab3-e7e9665e9694.png)

![Screen Shot 2019-07-01 at 4 17 13 PM](https://user-images.githubusercontent.com/1167259/60464242-faf63400-9c1b-11e9-80af-0227e293ceb9.png)