### PR TITLE
Fix bug where `pf-c-form-control` styles weren't loading in prod

### DIFF
--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -60,3 +60,4 @@
 @import "~@patternfly/patternfly/_variables";
 @import "~@patternfly/patternfly/_fonts";
 @import "~@patternfly/patternfly/_base";
+@import "~@patternfly/patternfly/components/FormControl/form-control";


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1588

IMPORTANT:  this bug occured because tree shaking only applies to production and not dev.  In other words, all PF4 CSS is included in dev, but in prod tree shaking removes any CSS for PF4 components that are not in use. Going forward, any time PF4 react component styles are being used without the component itself, we need to explicitly include the relevant SCSS file as done in this PR.