### PR TITLE
Fix: builds are not updated in resource details tab of topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -91,6 +91,12 @@ const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
       namespace,
       prop: 'buildconfigs',
     },
+    {
+      isList: true,
+      kind: 'Build',
+      namespace,
+      prop: 'builds',
+    },
   ];
   return (
     <Firehose resources={resources} forceUpdate>

--- a/frontend/packages/dev-console/src/components/topology/TopologySideBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologySideBar.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { ModelessOverlay } from 'patternfly-react';
-import { some } from 'lodash';
 import { CloseButton } from '@console/internal/components/utils';
 import { ResourceOverviewPage } from '@console/internal/components/overview/resource-overview-page';
 import { TopologyDataObject, ResourceProps } from './topology-types';
@@ -33,20 +32,7 @@ const TopologySideBar: React.FC<TopologySideBarProps> = ({ item, show, onClose }
     );
     const routes = metadataUIDCheck(item.resources.filter((o) => o.kind === 'Route'));
     const services = metadataUIDCheck(item.resources.filter((o) => o.kind === 'Service'));
-    const builds = metadataUIDCheck(item.resources.filter((o) => o.kind === 'Builds'));
-    const buildConfigs = metadataUIDCheck(
-      item.resources.filter((o) => o.kind === 'BuildConfig'),
-    ).map((bc) => {
-      const {
-        metadata: { uid },
-      } = bc;
-      return {
-        builds: builds.filter(({ metadata: { ownerReferences } }: ResourceProps) =>
-          some(ownerReferences, { uid }),
-        ),
-        ...bc,
-      };
-    });
+    const buildConfigs = metadataUIDCheck(item.resources.filter((o) => o.kind === 'BuildConfig'));
     itemtoShowOnSideBar = {
       obj: { apiVersion: 'apps.openshift.io/v1', ...dc[0] },
       kind: dc[0].kind,

--- a/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
@@ -224,6 +224,7 @@ Object {
           "status": Object {},
         },
         Object {
+          "builds": Array [],
           "kind": "BuildConfig",
           "metadata": Object {},
           "name": undefined,
@@ -536,6 +537,7 @@ Object {
           "status": Object {},
         },
         Object {
+          "builds": Array [],
           "kind": "BuildConfig",
           "metadata": Object {},
           "name": undefined,
@@ -841,6 +843,7 @@ Object {
           "status": Object {},
         },
         Object {
+          "builds": Array [],
           "kind": "BuildConfig",
           "metadata": Object {
             "annotations": Object {

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
@@ -133,6 +133,10 @@ const sampleKnativeBuildConfigs: Resource = {
   data: [],
 };
 
+const sampleKnativeBuilds: Resource = {
+  data: [],
+};
+
 export const sampleKnativeServices: Resource = {
   data: [
     {
@@ -221,4 +225,5 @@ export const MockKnativeResources: TopologyDataResources = {
   services: sampleKnativeServices,
   routes: sampleKnativeRoutes,
   buildconfigs: sampleKnativeBuildConfigs,
+  builds: sampleKnativeBuilds,
 };

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -9,6 +9,7 @@ export const resources: TopologyDataResources = {
   deployments: { data: [] },
   replicasets: { data: [] },
   buildconfigs: { data: [] },
+  builds: { data: [] },
 };
 
 export const topologyData: TopologyDataModel = {
@@ -889,6 +890,102 @@ const sampleBuildConfigs: Resource = {
   ],
 };
 
+const sampleBuilds: Resource = {
+  data: [
+    {
+      kind: 'Builds',
+      metadata: {
+        annotations: {
+          'openshift.io/build-config.name': 'analytics-build',
+          'openshift.io/build.number': '1',
+        },
+        selfLink: '/apis/build.openshift.io/v1/namespaces/testproject3/builds/analytics-build-1',
+        resourceVersion: '358822',
+        name: 'analytics-build-1',
+        uid: '58d6b528-9c89-11e9-80f4-0a580a82001a',
+        creationTimestamp: '2019-07-02T05:22:12Z',
+        namespace: 'testproject3',
+        ownerReferences: [
+          {
+            apiVersion: 'build.openshift.io/v1',
+            kind: 'BuildConfig',
+            name: 'analytics-build',
+            uid: '5ca46c49-680d-11e9-b69e-5254003f9382',
+            controller: true,
+          },
+        ],
+        labels: {
+          app: 'analytics-build',
+          'app.kubernetes.io/component': 'analytics-build',
+          'app.kubernetes.io/instance': 'analytics-build',
+          'app.kubernetes.io/name': 'nodejs',
+          'app.kubernetes.io/part-of': 'myapp',
+          buildconfig: 'analytics-build',
+          'openshift.io/build-config.name': 'analytics-build',
+          'openshift.io/build.start-policy': 'Serial',
+        },
+      },
+      spec: {
+        serviceAccount: 'builder',
+        source: {
+          type: 'Git',
+          git: {
+            uri: 'https://github.com/fabric8-ui/fabric8-ui',
+          },
+          contextDir: '/',
+        },
+        strategy: {
+          type: 'Source',
+          sourceStrategy: {
+            from: {
+              kind: 'DockerImage',
+              name:
+                'image-registry.openshift-image-registry.svc:5000/openshift/nodejs@sha256:0ad231dc2d1c34ed3fb29fb304821171155e0a1a23f0e0490b2cd8ca60915517',
+            },
+            pullSecret: {
+              name: 'builder-dockercfg-tx6qx',
+            },
+          },
+        },
+        output: {
+          to: {
+            kind: 'ImageStreamTag',
+            name: 'analytics-build:latest',
+          },
+        },
+        resources: {},
+        postCommit: {},
+        nodeSelector: null,
+        triggeredBy: [
+          {
+            message: 'Image change',
+            imageChangeBuild: {
+              imageID:
+                'image-registry.openshift-image-registry.svc:5000/openshift/nodejs@sha256:0ad231dc2d1c34ed3fb29fb304821171155e0a1a23f0e0490b2cd8ca60915517',
+              fromRef: {
+                kind: 'ImageStreamTag',
+                namespace: 'openshift',
+                name: 'nodejs:10',
+              },
+            },
+          },
+        ],
+      },
+      status: {
+        phase: 'New',
+        reason: 'CannotCreateBuildPod',
+        message: 'Failed creating build pod.',
+        config: {
+          kind: 'BuildConfig',
+          namespace: 'testproject3',
+          name: 'analytics-build',
+        },
+        output: {},
+      },
+    },
+  ],
+};
+
 export const MockResources: TopologyDataResources = {
   deployments: sampleDeployments,
   deploymentConfigs: sampleDeploymentConfigs,
@@ -898,4 +995,5 @@ export const MockResources: TopologyDataResources = {
   services: sampleServices,
   routes: sampleRoutes,
   buildconfigs: sampleBuildConfigs,
+  builds: sampleBuilds,
 };

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -24,6 +24,7 @@ export interface TopologyDataResources {
   deployments: Resource;
   replicasets: Resource;
   buildconfigs: Resource;
+  builds: Resource;
 }
 
 export interface Node {


### PR DESCRIPTION
ODC-Bug: https://jira.coreos.com/browse/ODC-1145

Builds were not showing in Resource Details for topology view. This PR fixes that.

![Screenshot from 2019-07-02 11-41-37](https://user-images.githubusercontent.com/9278015/60488332-5299ab80-9cbf-11e9-9470-ebee9d6308a2.png)
