### PR TITLE
add background box to topology labels

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/shapes/BaseNode.scss
+++ b/frontend/packages/dev-console/src/components/topology/shapes/BaseNode.scss
@@ -10,7 +10,10 @@
 
   &__label {
     pointer-events: none;
-    fill: var(--pf-global--Color--300);
+    fill: var(--pf-global--Color--light-100);
     font-size: var(--pf-global--FontSize--sm);
+    text {
+      fill: var(--pf-global--Color--300);
+    }
   }
 }

--- a/frontend/packages/dev-console/src/components/topology/shapes/BaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/BaseNode.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import SvgDropShadowFilter from '../../svg/SvgDropShadowFilter';
 import { createSvgIdUrl } from '../../../utils/svg-utils';
+import SvgBoxedText from '../../svg/SvgBoxedText';
 
 import './BaseNode.scss';
 
@@ -88,15 +89,15 @@ export default class BaseNode extends React.Component<BaseNodeProps, State> {
             }
           />
           {label != null && (
-            <text
+            <SvgBoxedText
               className="odc-base-node__label"
-              textAnchor="middle"
-              y={outerRadius + 10}
+              y={outerRadius + 20}
               x={0}
-              dy="0.6em"
+              paddingX={8}
+              paddingY={4}
             >
               {selected || hover ? label : truncateEnd(label)}
-            </text>
+            </SvgBoxedText>
           )}
           {selected && (
             <circle

--- a/frontend/packages/dev-console/src/components/topology/shapes/__tests__/BaseNode.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/__tests__/BaseNode.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { mount, shallow } from 'enzyme';
 import BaseNode, { BaseNodeProps, State } from '../BaseNode';
+import SvgBoxedText from '../../../svg/SvgBoxedText';
 
 jest.mock('../../../svg/SvgDefs');
 jest.mock('@console/internal/components/catalog/catalog-item-icon', () => ({
@@ -15,12 +16,24 @@ describe('BaseNode', () => {
 
   it('should not truncate labels <= 16 characters', () => {
     const wrapper = shallow(<BaseNode outerRadius={100} label="1234567890abcdef" />);
-    expect(wrapper.find('text').text()).toBe('1234567890abcdef');
+    expect(
+      wrapper
+        .find(SvgBoxedText)
+        .shallow()
+        .find('text')
+        .text(),
+    ).toBe('1234567890abcdef');
   });
 
   it('should truncate labels > 16 characters', () => {
     const wrapper = shallow(<BaseNode outerRadius={100} label="1234567890abcdefgh" />);
-    expect(wrapper.find('text').text()).toBe('1234567890abcde…');
+    expect(
+      wrapper
+        .find(SvgBoxedText)
+        .shallow()
+        .find('text')
+        .text(),
+    ).toBe('1234567890abcde…');
   });
 
   it('should show long labels on hover', () => {
@@ -28,7 +41,13 @@ describe('BaseNode', () => {
       <BaseNode outerRadius={100} label="1234567890abcdefgh" />,
     );
     wrapper.setState({ hover: true });
-    expect(wrapper.find('text').text()).toBe('1234567890abcdefgh');
+    expect(
+      wrapper
+        .find(SvgBoxedText)
+        .shallow()
+        .find('text')
+        .text(),
+    ).toBe('1234567890abcdefgh');
   });
 
   it('should show different drop shadow on hover', () => {
@@ -51,7 +70,13 @@ describe('BaseNode', () => {
 
   it('should show long labels when selected', () => {
     const wrapper = shallow(<BaseNode outerRadius={100} selected label="1234567890abcdefgh" />);
-    expect(wrapper.find('text').text()).toBe('1234567890abcdefgh');
+    expect(
+      wrapper
+        .find(SvgBoxedText)
+        .shallow()
+        .find('text')
+        .text(),
+    ).toBe('1234567890abcdefgh');
   });
 
   it('should render selection', () => {


### PR DESCRIPTION
ODC-story: https://jira.coreos.com/browse/ODC-1147

This Pr adds background box to the node labels in topology

![Screenshot from 2019-07-02 15-33-26](https://user-images.githubusercontent.com/9278015/60504574-7836ad00-9cdf-11e9-8f4c-082e730efca7.png)
![Screenshot from 2019-07-02 15-33-36](https://user-images.githubusercontent.com/9278015/60504577-7836ad00-9cdf-11e9-82c7-96a7faffbfbd.png)
