### PR TITLE
Add alerts card

### DIFF
--- a/frontend/public/components/dashboard/health-card/alert-item.tsx
+++ b/frontend/public/components/dashboard/health-card/alert-item.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Icon } from 'patternfly-react';
+
+import { getAlertSeverity, getAlertMessage, getAlertDescription } from './';
+import { Alert } from '../../monitoring';
+
+const getSeverityIcon = (severity: string) => {
+  switch (severity) {
+    case 'critical':
+      return (
+        <Icon type="fa" name="exclamation-circle" className="co-health-card__alerts-icon co-health-card__alerts-icon--critical" />
+      );
+    case 'warning':
+    default:
+      return (
+        <Icon type="fa" name="exclamation-triangle" className="co-health-card__alerts-icon co-health-card__alerts-icon--warning" />
+      );
+  }
+};
+
+export const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
+  return (
+    <div className="co-health-card__alerts-item">
+      {getSeverityIcon(getAlertSeverity(alert))}
+      <div className="co-health-card__alerts-item-message">{getAlertDescription(alert) || getAlertMessage(alert)}</div>
+    </div>
+  );
+};
+
+type AlertItemProps = {
+  alert: Alert;
+};

--- a/frontend/public/components/dashboard/health-card/alerts-body.tsx
+++ b/frontend/public/components/dashboard/health-card/alerts-body.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export const AlertsBody: React.FC<AlertsBodyProps> = ({ children }) => (
+  <div className="co-health-card__alerts-body">{children}</div>
+);
+
+type AlertsBodyProps = {
+  children: React.ReactNode[];
+};

--- a/frontend/public/components/dashboard/health-card/health-card.scss
+++ b/frontend/public/components/dashboard/health-card/health-card.scss
@@ -1,3 +1,35 @@
+.co-health-card__alerts-body {
+  max-height: 10em;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.co-health-card__alerts-border {
+  border-top: 1px solid $pf-color-black-300;
+  padding-top: 1em;
+}
+
+.co-health-card__alerts-icon {
+  margin-right: 1.5em;
+}
+
+.co-health-card__alerts-icon--critical {
+  color: $pf-color-red-100;
+}
+
+.co-health-card__alerts-icon--warning {
+  color: $pf-color-gold-400;
+}
+
+.co-health-card__alerts-item {
+  display: table;
+  margin-bottom: 0.5em;
+}
+
+.co-health-card__alerts-item-message {
+  display: table-cell;
+}
+
 .co-health-card__body {
   min-height: 2.3em;
 }

--- a/frontend/public/components/dashboard/health-card/index.ts
+++ b/frontend/public/components/dashboard/health-card/index.ts
@@ -1,2 +1,5 @@
 export * from './health-body';
 export * from './health-item';
+export * from './alert-item';
+export * from './alerts-body';
+export * from './utils';

--- a/frontend/public/components/dashboard/health-card/utils.tsx
+++ b/frontend/public/components/dashboard/health-card/utils.tsx
@@ -1,0 +1,15 @@
+import * as _ from 'lodash-es';
+import { Alert } from '../../monitoring';
+import { ALERTS_KEY } from '../../../actions/dashboards';
+
+export const getAlertSeverity = (alert: Alert): string => _.get(alert, 'labels.severity');
+export const getAlertMessage = (alert: Alert): string => _.get(alert, 'annotations.message');
+export const getAlertDescription = (alert: Alert): string => _.get(alert, 'annotations.description');
+
+export const filterAlerts = (alerts: Alert[]): Alert[] =>
+  alerts.filter(alert => _.get(alert, 'labels.alertname') !== 'Watchdog');
+
+export const getAlerts = (alertsResults: any): Alert[] => {
+  const alertsResponse = alertsResults ? alertsResults.getIn([ALERTS_KEY, 'result'], []) : [];
+  return Array.isArray(alertsResponse) ? filterAlerts(alertsResponse) : [];
+};

--- a/frontend/public/components/dashboards-page/with-dashboard-resources.tsx
+++ b/frontend/public/components/dashboards-page/with-dashboard-resources.tsx
@@ -4,15 +4,20 @@ import { Map as ImmutableMap } from 'immutable';
 
 import { RESULTS_TYPE } from '../../reducers/dashboards';
 import {
-  watchURL,
-  stopWatchURL,
-  watchPrometheusQuery,
-  stopWatchPrometheusQuery,
+  ALERTS_KEY,
   Fetch,
-  WatchURLAction,
-  WatchPrometheusQueryAction,
-  StopWatchURLAction,
+  stopWatchAlerts,
+  StopWatchAlertsAction,
   StopWatchPrometheusAction,
+  stopWatchPrometheusQuery,
+  stopWatchURL,
+  StopWatchURLAction,
+  watchAlerts,
+  WatchAlertsAction,
+  watchPrometheusQuery,
+  WatchPrometheusQueryAction,
+  watchURL,
+  WatchURLAction,
 } from '../../actions/dashboards';
 import { RootState } from '../../redux';
 import { Firehose, FirehoseResource, FirehoseResult } from '../utils';
@@ -23,11 +28,14 @@ const mapDispatchToProps = dispatch => ({
   stopWatchURL: (url): StopWatchURL => dispatch(stopWatchURL(url)),
   watchPrometheusQuery: (query): WatchPrometheus => dispatch(watchPrometheusQuery(query)),
   stopWatchPrometheusQuery: (query): StopWatchPrometheus => dispatch(stopWatchPrometheusQuery(query)),
+  watchAlerts: (): WatchAlerts => dispatch(watchAlerts()),
+  stopWatchAlerts: (): StopWatchAlerts => dispatch(stopWatchAlerts()),
 });
 
 const mapStateToProps = (state: RootState) => ({
   [RESULTS_TYPE.URL]: state.dashboards.get(RESULTS_TYPE.URL),
   [RESULTS_TYPE.PROMETHEUS]: state.dashboards.get(RESULTS_TYPE.PROMETHEUS),
+  [RESULTS_TYPE.ALERTS]: state.dashboards.get(RESULTS_TYPE.ALERTS),
 });
 
 export const withDashboardResources = <P extends DashboardItemProps>(WrappedComponent: React.ComponentType<P>, additionalProps: any = {}) =>
@@ -50,32 +58,37 @@ export const withDashboardResources = <P extends DashboardItemProps>(WrappedComp
         const queryResultChanged = this.queries.some(query =>
           this.props[RESULTS_TYPE.PROMETHEUS].getIn([query, 'result']) !== nextProps[RESULTS_TYPE.PROMETHEUS].getIn([query, 'result'])
         );
+        const alertsResultChanged = this.props[RESULTS_TYPE.ALERTS].getIn([ALERTS_KEY, 'result']) !== nextProps[RESULTS_TYPE.PROMETHEUS].getIn([ALERTS_KEY, 'result']);
         const k8sResourcesChanged = this.state.k8sResources !== nextState.k8sResources;
 
-        return urlResultChanged || queryResultChanged || k8sResourcesChanged;
+        return urlResultChanged || queryResultChanged || alertsResultChanged || k8sResourcesChanged;
       }
 
       watchURL: WatchURL = (url, fetch) => {
         this.urls.push(url);
         this.props.watchURL(url, fetch);
-      }
+      };
 
       watchPrometheus: WatchPrometheus = query => {
         this.queries.push(query);
         this.props.watchPrometheusQuery(query);
-      }
+      };
+
+      watchAlerts: WatchAlerts = () => {
+        this.props.watchAlerts();
+      };
 
       watchK8sResource: WatchK8sResource = resource => {
         this.setState((state: WithDashboardResourcesState) => ({
           k8sResources: [...state.k8sResources, resource],
         }));
-      }
+      };
 
       stopWatchK8sResource: StopWatchK8sResource = resource => {
         this.setState((state: WithDashboardResourcesState) => ({
           k8sResources: state.k8sResources.filter(r => r.prop !== resource.prop),
         }));
-      }
+      };
 
       render() {
         return (
@@ -85,8 +98,11 @@ export const withDashboardResources = <P extends DashboardItemProps>(WrappedComp
               stopWatchURL={this.props.stopWatchURL}
               watchPrometheus={this.watchPrometheus}
               stopWatchPrometheusQuery={this.props.stopWatchPrometheusQuery}
+              watchAlerts={this.watchAlerts}
+              stopWatchAlerts={this.props.stopWatchAlerts}
               urlResults={this.props[RESULTS_TYPE.URL]}
               prometheusResults={this.props[RESULTS_TYPE.PROMETHEUS]}
+              alertsResults={this.props[RESULTS_TYPE.ALERTS]}
               watchK8sResource={this.watchK8sResource}
               stopWatchK8sResource={this.stopWatchK8sResource}
               {...additionalProps}
@@ -101,6 +117,8 @@ export type WatchURL = (url: string, fetch?: Fetch) => void;
 export type StopWatchURL = (url: string) => void;
 export type WatchPrometheus = (query: string) => void;
 export type StopWatchPrometheus = (query: string) => void;
+export type WatchAlerts = () => void;
+export type StopWatchAlerts = () => void;
 
 type WithDashboardResourcesState = {
   k8sResources: FirehoseResource[];
@@ -109,10 +127,13 @@ type WithDashboardResourcesState = {
 type WithDashboardResourcesProps = {
   watchURL: WatchURLAction;
   watchPrometheusQuery: WatchPrometheusQueryAction;
+  watchAlerts: WatchAlertsAction;
   stopWatchURL: StopWatchURLAction;
   stopWatchPrometheusQuery: StopWatchPrometheusAction;
+  stopWatchAlerts: StopWatchAlertsAction;
   [RESULTS_TYPE.PROMETHEUS]: ImmutableMap<string, any>;
   [RESULTS_TYPE.URL]: ImmutableMap<string, any>;
+  [RESULTS_TYPE.ALERTS]: ImmutableMap<string, any>;
 };
 
 export type WatchK8sResource = (resource: FirehoseResource) => void;
@@ -123,8 +144,11 @@ export type DashboardItemProps = {
   stopWatchURL: StopWatchURL;
   watchPrometheus: WatchPrometheus;
   stopWatchPrometheusQuery: StopWatchPrometheus;
+  watchAlerts: WatchAlerts;
+  stopWatchAlerts: StopWatchAlerts;
   urlResults: ImmutableMap<string, any>;
   prometheusResults: ImmutableMap<string, any>;
+  alertsResults: ImmutableMap<string, any>;
   watchK8sResource: WatchK8sResource;
   stopWatchK8sResource: StopWatchK8sResource;
   resources?: {

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1089,7 +1089,7 @@ type Silences = {
   loaded: boolean;
   loadError?: string;
 };
-type Alert = {
+export type Alert = {
   activeAt?: string;
   annotations: any;
   labels: {
@@ -1100,6 +1100,7 @@ type Alert = {
   silencedBy?: Silence[];
   state: AlertStates;
   value?: number;
+  fingerprint?: string;
 };
 type Rule = {
   alerts: Alert[];

--- a/frontend/public/reducers/dashboards.ts
+++ b/frontend/public/reducers/dashboards.ts
@@ -4,11 +4,13 @@ import { Map as ImmutableMap, fromJS } from 'immutable';
 export enum RESULTS_TYPE {
   PROMETHEUS = 'PROMETHEUS',
   URL = 'URL',
+  ALERTS = 'ALERTS',
 }
 
 export const defaults = {
   [RESULTS_TYPE.PROMETHEUS]: fromJS({}),
   [RESULTS_TYPE.URL]: fromJS({}),
+  [RESULTS_TYPE.ALERTS]: fromJS({}),
 };
 
 export type DashboardsState = ImmutableMap<string, any>;


### PR DESCRIPTION
This PR adds the alerts card to the dashboard overview page. The alerts card does not display if alert-manager is not available.

Loaded alerts card:
![Selection_567](https://user-images.githubusercontent.com/8544299/60591489-91396f80-9d6c-11e9-81f2-6b0ee418b05c.png)

Alerts card in loading state:
![Selection_568](https://user-images.githubusercontent.com/8544299/60591478-8b438e80-9d6c-11e9-96c5-99dde9849c8a.png)

@rawagner 
