### PR TITLE
fix: build image selector overflows text

### DIFF
--- a/frontend/packages/dev-console/src/components/import/builder/BuilderImageCard.scss
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderImageCard.scss
@@ -1,7 +1,7 @@
 .odc-builder-image-card {
   position: relative;
-  height: 112px;
   width: 136px;
+  min-height: 118px;
   margin: 4px;
   align-items: center;
   border: 0;
@@ -16,6 +16,10 @@
     font-size: var(--pf-global--FontSize--sm);
     font-weight: var(--pf-global--FontWeight--bold);
     line-height: var(--pf-global--LineHeight--sm);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 
   &__recommended {


### PR DESCRIPTION
Bug fix - https://jira.coreos.com/browse/ODC-1184

Before:
![Screenshot from 2019-07-02 17-35-01](https://user-images.githubusercontent.com/2561818/60511551-e08d8a80-9cef-11e9-9f1c-4ca826f4657e.png)

After:
![Screenshot from 2019-07-03 11-26-06](https://user-images.githubusercontent.com/2561818/60566739-6e678500-9d85-11e9-8dac-5b148a5641b6.png)
