### PR TITLE
Add: Remove volume feature

### DIFF
--- a/frontend/public/components/daemon-set.jsx
+++ b/frontend/public/components/daemon-set.jsx
@@ -120,7 +120,7 @@ const Details = ({obj: daemonset}) => <React.Fragment>
     <ContainerTable containers={daemonset.spec.template.spec.containers} />
   </div>
   <div className="co-m-pane__body">
-    <VolumesTable podTemplate={daemonset.spec.template} heading="Volumes" />
+    <VolumesTable resource={daemonset} heading="Volumes" />
   </div>
 </React.Fragment>;
 

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -155,7 +155,7 @@ export const DeploymentConfigsDetails: React.FC<{obj: K8sResourceKind}> = ({obj:
       <ContainerTable containers={dc.spec.template.spec.containers} />
     </div>
     <div className="co-m-pane__body">
-      <VolumesTable podTemplate={dc.spec.template} heading="Volumes" />
+      <VolumesTable resource={dc} heading="Volumes" />
     </div>
     <div className="co-m-pane__body">
       <SectionHeading text="Conditions" />

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -114,7 +114,7 @@ const DeploymentDetails: React.FC<DeploymentDetailsProps> = ({obj: deployment}) 
       <ContainerTable containers={deployment.spec.template.spec.containers} />
     </div>
     <div className="co-m-pane__body">
-      <VolumesTable podTemplate={deployment.spec.template} heading="Volumes" />
+      <VolumesTable resource={deployment} heading="Volumes" />
     </div>
     <div className="co-m-pane__body">
       <SectionHeading text="Conditions" />

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -63,5 +63,8 @@ export const installPlanPreviewModal = (props) => import('./installplan-preview-
 export const expandPVCModal = (props) => import('./expand-pvc-modal' /* webpackChunkName: "expand-pvc-modal" */)
   .then(m => m.expandPVCModal(props));
 
+export const removeVolumeModal = (props) => import('./remove-volume-modal' /* webpackChunkName: "remove-volume-modal" */)
+  .then(m => m.removeVolumeModal(props));
+
 export const configureMachineAutoscalerModal = (props) => import('./configure-machine-autoscaler-modal' /* webpackChunkName: "configure-machine-autoscaler-modal" */)
   .then(m => m.configureMachineAutoscalerModal(props));

--- a/frontend/public/components/modals/remove-volume-modal.tsx
+++ b/frontend/public/components/modals/remove-volume-modal.tsx
@@ -1,0 +1,86 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+
+import { createModalLauncher, ModalTitle, ModalBody, ModalSubmitFooter } from '../factory';
+import { ContainerSpec, getVolumeType, K8sKind, k8sPatch, K8sResourceKind, Volume, VolumeMount } from '../../module/k8s/';
+import { RowVolumeData } from '../volumes-table';
+
+export const RemoveVolumeModal: React.FC<RemoveVolumeModalProps> = (props) => {
+  const [inProgress, setInProgress] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState('');
+
+  const getRemoveVolumePatch = (resource: K8sResourceKind, rowVolumeData: RowVolumeData) => {
+    const containers: ContainerSpec[] = _.get(resource, 'spec.template.spec.containers', []);
+    const patches = [];
+    let allowRemoveVolume = true;
+    containers.forEach((container: ContainerSpec, i: number) => {
+      const mounts: VolumeMount[] = _.get(container, 'volumeMounts', []);
+      mounts.forEach((mount: VolumeMount, j: number) => {
+        if (mount.name !== rowVolumeData.name) {
+          return;
+        }
+        if (mount.mountPath === rowVolumeData.mountPath) {
+          patches.push({op: 'remove', path: `/spec/template/spec/containers/${i}/volumeMounts/${j}`});
+        } else {
+          allowRemoveVolume = false;
+        }
+      });
+    });
+
+    // if the mountCount is greater than zero, then the volume is still being used at a different mount point or in a different container
+    // Either way, we cannot give the cmd to remove it
+    if (allowRemoveVolume) {
+      const volumes: Volume[] = _.get(resource, 'spec.template.spec.volumes', []);
+      const volumeIndex = volumes.findIndex((v: Volume) => v.name === rowVolumeData.volumeDetail.name);
+      patches.push({op: 'remove', path: `/spec/template/spec/volumes/${volumeIndex}`});
+    }
+    return patches;
+  };
+
+  const submit = (event: React.FormEvent<EventTarget>) => {
+    event.preventDefault();
+    setErrorMessage('');
+    setInProgress(true);
+    const { kind, resource, volume } = props;
+    k8sPatch(kind, resource, getRemoveVolumePatch(resource, volume)).then(() => {
+      setInProgress(false);
+      props.close();
+    }).catch(({message: errMessage}) => {
+      setErrorMessage(errMessage);
+      setInProgress(false);
+    });
+  };
+
+  const {kind, resource, volume} = props;
+  const type: string = _.get(getVolumeType(volume.volumeDetail), 'id', '');
+  return <form onSubmit={submit} className="modal-content">
+    <ModalTitle>Remove Volume</ModalTitle>
+    <ModalBody className="modal-body">
+      <div className="co-delete-modal">
+        <span aria-hidden="true" className="co-delete-modal__icon pficon pficon-warning-triangle-o" />
+        <div>
+          <p className="lead">Remove volume <span className="co-break-word">{volume.volumeDetail.name}</span>?</p>
+          <div>Are you sure you want to remove volume <strong className="co-break-word">{volume.volumeDetail.name}</strong>
+            <span> from <strong>{ kind.label }</strong>: <strong>{ resource.metadata.name }</strong>?</span>
+          </div>
+          {type && <div>
+            <label className="control-label">
+              Note: This will not remove the underlying { type }.
+            </label>
+          </div>}
+        </div>
+      </div>
+    </ModalBody>
+    <ModalSubmitFooter errorMessage={errorMessage} inProgress={inProgress} submitButtonClass="btn-danger" submitText="Remove Volume" cancel={props.cancel} />
+  </form>;
+};
+
+export const removeVolumeModal = createModalLauncher(RemoveVolumeModal);
+
+export type RemoveVolumeModalProps = {
+  cancel: (e: Event) => void;
+  close: () => void;
+  volume: RowVolumeData;
+  kind: K8sKind;
+  resource: K8sResourceKind;
+};

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -276,7 +276,7 @@ const Details: React.FC<PodDetailsProps> = ({obj: pod}) => {
       <PodContainerTable key="containerTable" heading="Containers" containers={pod.spec.containers} pod={pod} />
     </div>
     <div className="co-m-pane__body">
-      <VolumesTable podTemplate={pod} heading="Volumes" />
+      <VolumesTable resource={pod} heading="Volumes" />
     </div>
   </React.Fragment>;
 };

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -50,7 +50,7 @@ const Details = ({obj: replicaSet}) => {
       <ContainerTable containers={replicaSet.spec.template.spec.containers} />
     </div>
     <div className="co-m-pane__body">
-      <VolumesTable podTemplate={replicaSet.spec.template} heading="Volumes" />
+      <VolumesTable resource={replicaSet} heading="Volumes" />
     </div>
   </React.Fragment>;
 };

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -44,7 +44,7 @@ const Details = ({obj: replicationController}) => {
       <ContainerTable containers={replicationController.spec.template.spec.containers} />
     </div>
     <div className="co-m-pane__body">
-      <VolumesTable podTemplate={replicationController.spec.template} heading="Volumes" />
+      <VolumesTable resource={replicationController} heading="Volumes" />
     </div>
   </React.Fragment>;
 };

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -50,7 +50,7 @@ const Details = ({obj: ss}) => <React.Fragment>
     <ContainerTable containers={ss.spec.template.spec.containers} />
   </div>
   <div className="co-m-pane__body">
-    <VolumesTable podTemplate={ss.spec.template} heading="Volumes" />
+    <VolumesTable resource={ss} heading="Volumes" />
   </div>
 </React.Fragment>;
 

--- a/frontend/public/components/volumes-table.tsx
+++ b/frontend/public/components/volumes-table.tsx
@@ -5,28 +5,47 @@ import * as classNames from 'classnames';
 
 import {
   ContainerSpec,
+  getVolumeType,
+  getVolumeLocation,
+  K8sKind,
+  K8sResourceKind,
+  K8sResourceKindReference,
   PodKind,
   PodTemplate,
   Volume,
   VolumeMount,
 } from '../module/k8s';
-import {
-  getVolumeType,
-  getVolumeLocation,
-} from '../module/k8s/pods';
-import {
-  VolumeIcon,
-  ResourceIcon,
-  EmptyBox,
-  SectionHeading,
-} from './utils';
+import { asAccessReview, EmptyBox, Kebab, KebabOption, VolumeIcon, ResourceIcon, SectionHeading } from './utils';
+import { Table, TableData, TableRow } from './factory';
+import { sortable } from '@patternfly/react-table';
+import { removeVolumeModal } from './modals';
+import {connectToModel} from '../kinds';
 
-const getVolumeMountsByPermissions = (pod: PodTemplate): VolumeData[] => {
+const removeVolume = (kind: K8sKind, obj: K8sResourceKind, volume: RowVolumeData): KebabOption => {
+  return {
+    label: 'Remove Volume',
+    callback: () => removeVolumeModal({
+      kind,
+      resource: obj,
+      volume,
+    }),
+    accessReview: asAccessReview(kind, obj, 'patch'),
+  };
+};
+
+const menuActions = [removeVolume];
+
+const getPodTemplate = (resource: K8sResourceKind): PodTemplate => {
+  return resource.kind === 'Pod' ? resource as PodKind : resource.spec.template;
+};
+
+const getRowVolumeData = (resource: K8sResourceKind): RowVolumeData[] => {
+  const pod: PodTemplate = getPodTemplate(resource);
   if (!pod || !pod.spec || !pod.spec.volumes) {
     return [];
   }
-  const m = {};
 
+  const m = {};
   const volumes = (pod.spec.volumes || []).reduce((p, v: Volume) => {
     p[v.name] = v;
     return p;
@@ -34,15 +53,12 @@ const getVolumeMountsByPermissions = (pod: PodTemplate): VolumeData[] => {
 
   _.forEach(pod.spec.containers, (c: ContainerSpec) => {
     _.forEach(c.volumeMounts, (v: VolumeMount) => {
-      const k = `${v.name}_${v.readOnly ? 'ro' : 'rw'}`;
+      const k = `${v.name}_${v.readOnly ? 'ro' : 'rw'}_${v.mountPath}`;
       const mount = {container: c.name, mountPath: v.mountPath, subPath: v.subPath};
-      if (k in m) {
-        return m[k].mounts.push(mount);
-      }
-      m[k] = {mounts: [mount], name: v.name, readOnly: !!v.readOnly, volume: volumes[v.name]};
+      m[k] = {name: v.name, readOnly: !!v.readOnly, volumeDetail: volumes[v.name],
+        container: mount.container, mountPath: mount.mountPath, subPath: mount.subPath,resource};
     });
   });
-
   return _.values(m);
 };
 
@@ -52,70 +68,125 @@ const ContainerLink: React.FC<ContainerLinkProps> = ({name, pod}) => <span class
 </span>;
 ContainerLink.displayName = 'ContainerLink';
 
-const VolumeRow: React.FC<VolumeRowProps> = ({value, pod}) => {
-  const kind = _.get(getVolumeType(value.volume), 'id', '');
-  const loc = getVolumeLocation(value.volume);
-  const name = value.name;
-  const permission = value.readOnly ? 'Read-only' : 'Read/Write';
+const volumeRoColumnClasses = [
+  classNames('col-lg-2', 'col-md-3', 'col-sm-4', 'col-xs-5'),
+  classNames('col-lg-2', 'col-md-3', 'col-sm-4', 'col-xs-7'),
+  classNames('col-lg-2', 'col-md-2', 'col-sm-4', 'hidden-xs'),
+  classNames('col-lg-2', 'col-md-2', 'hidden-sm', 'hidden-xs'),
+  classNames('col-lg-2', 'col-md-2', 'hidden-sm', 'hidden-xs'),
+  classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
+  Kebab.columnClass,
+];
 
-  return <div>
-    {value.mounts.map((m: Mount, i: number) => <React.Fragment key={i}>
-      <div className="row">
-        <div className="col-lg-2 col-md-3 col-sm-4 col-xs-5">{name}</div>
-        <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7 co-break-all co-select-to-copy">{_.get(m, 'mountPath', '-')} </div>
-        <div className={classNames('col-lg-2 col-md-2 col-sm-3 hidden-xs co-break-all', { 'co-select-to-copy': _.get(m, 'subPath') })}>
-          {_.get(m, 'subPath', '-')}
-        </div>
-        <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">
-          <VolumeIcon kind={kind} />
-          <span className="co-break-word">{loc && ` (${loc})`}</span>
-        </div>
-        <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">{permission}</div>
-        <div className="col-lg-2 hidden-md hidden-sm hidden-xs">
-          { _.get(pod, 'kind') === 'Pod'
-            ? <ContainerLink name={m.container} pod={pod as PodKind} />
-            : <div>{m.container}</div>
-          }
-        </div>
-      </div>
-    </React.Fragment>)}
-  </div>;
+const VolumesTableHeader = () => {
+  return [
+    {
+      title: 'Name', sortField: 'name', transforms: [sortable],
+      props: { className: volumeRoColumnClasses[0]},
+    },
+    {
+      title: 'Mount Path', sortField: 'mountPath', transforms: [sortable],
+      props: { className: volumeRoColumnClasses[1]},
+    },
+    {
+      title: 'SubPath', sortField: 'subPath', transforms: [sortable],
+      props: { className: volumeRoColumnClasses[2]},
+    },
+    {
+      title: 'Type',
+      props: { className: volumeRoColumnClasses[3]},
+    },
+    {
+      title: 'Permissions', sortField: 'readOnly', transforms: [sortable],
+      props: { className: volumeRoColumnClasses[4]},
+    },
+    {
+      title: 'Utilized By', sortField: 'container', transforms: [sortable],
+      props: { className: volumeRoColumnClasses[5]},
+    },
+    {
+      title: '',
+      props: { className: volumeRoColumnClasses[6]},
+    },
+  ];
 };
-VolumeRow.displayName = 'VolumeRow';
+VolumesTableHeader.displayName = 'VolumesTableHeader';
 
-export const VolumesTable: React.FC<VolumesTableProps> = ({podTemplate, heading}) => (
-  <React.Fragment>
-    {heading && <SectionHeading text={heading} />}
-    {_.isEmpty(podTemplate.spec.volumes)
+const VolumesTableRow = ({obj: volume, index, key, style}) => {
+  const type = _.get(getVolumeType(volume.volumeDetail), 'id', '');
+  const loc = getVolumeLocation(volume.volumeDetail);
+  const name = volume.name;
+  const permission = volume.readOnly ? 'Read-only' : 'Read/Write';
+  const { resource } = volume;
+  const pod: PodTemplate = getPodTemplate(resource);
+
+  return (
+    <TableRow id={`${name}-${volume.mountPath}`} index={index} trKey={key} style={style}>
+      <TableData className={volumeRoColumnClasses[0]}>{name}</TableData>
+      <TableData className={classNames(volumeRoColumnClasses[1], 'co-break-word')}>{volume.mountPath}</TableData>
+      <TableData className={volumeRoColumnClasses[2]}>{volume.subPath}</TableData>
+      <TableData className={volumeRoColumnClasses[3]}>
+        <VolumeIcon kind={type} />
+        <span className="co-break-word">{loc && ` (${loc})`}</span>
+      </TableData>
+      <TableData className={volumeRoColumnClasses[4]}>{permission}</TableData>
+      <TableData className={volumeRoColumnClasses[5]}>
+        {_.get(pod, 'kind') === 'Pod' ? <ContainerLink name={volume.container} pod={pod as PodKind} /> : <div>{volume.container}</div>}
+      </TableData>
+      <TableData className={volumeRoColumnClasses[6]}>
+        <VolumeKebab actions={menuActions} kind={resource.kind} resource={resource} rowVolumeData={volume} />
+      </TableData>
+    </TableRow>
+  );
+};
+VolumesTableRow.displayName = 'VolumesTableRow';
+
+export const VolumesTable = props => {
+  const { resource, ...tableProps } = props;
+  const data: RowVolumeData[] = getRowVolumeData(resource);
+  const pod: PodTemplate = getPodTemplate(resource);
+  return <React.Fragment>
+    {props.heading && <SectionHeading text={props.heading} />}
+    {_.isEmpty(pod.spec.volumes)
       ? <EmptyBox label="Volumes" />
       : (
-        <div className="co-m-table-grid co-m-table-grid--bordered">
-          <div className="row co-m-table-grid__head">
-            <div className="col-lg-2 col-md-3 col-sm-4 col-xs-5">Name</div>
-            <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7">Mount Path</div>
-            <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs">SubPath</div>
-            <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">Type</div>
-            <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">Permissions</div>
-            <div className="col-lg-2 hidden-md hidden-sm hidden-xs">Utilized By</div>
-          </div>
-          <div className="co-m-table-grid__body">
-            {getVolumeMountsByPermissions(podTemplate).map((v, i) => <VolumeRow key={i} value={v} pod={podTemplate} />)}
-          </div>
-        </div>
+        <Table {...tableProps} aria-label="Volumes" loaded={true} label={props.heading} data={data} Header={VolumesTableHeader} Row={VolumesTableRow} virtualize />
       )}
-  </React.Fragment>
-);
+  </React.Fragment>;
+};
+
 VolumesTable.displayName = 'VolumesTable';
 
-type Mount = {
-  container: string;
-} & VolumeMount;
+const VolumeKebab = connectToModel((props: VolumeKebabProps) => {
+  const {actions, kindObj, resource, isDisabled, rowVolumeData} = props;
+  if (!kindObj || kindObj.kind === 'Pod') {
+    return null;
+  }
+  const options = actions.map(b => b(kindObj, resource, rowVolumeData));
+  return <Kebab
+    options={options}
+    isDisabled={isDisabled !== undefined ? isDisabled : _.get(resource.metadata, 'deletionTimestamp')}
+  />;
+});
 
-type VolumeData = {
+type VolumeKebabAction = (kind: K8sKind, obj: K8sResourceKind, rowVolumeData: RowVolumeData) => KebabOption;
+type VolumeKebabProps = {
+  kindObj: K8sKind;
+  actions: VolumeKebabAction[];
+  kind: K8sResourceKindReference;
+  resource: K8sResourceKind;
+  isDisabled?: boolean;
+  rowVolumeData: RowVolumeData;
+};
+
+export type RowVolumeData = {
   name: string;
   readOnly: boolean;
-  volume: Volume;
-  mounts: Mount[];
+  volumeDetail: Volume;
+  container: string;
+  mountPath: string;
+  subPath?: string;
+  resource: K8sResourceKind;
 };
 
 type ContainerLinkProps = {
@@ -123,12 +194,3 @@ type ContainerLinkProps = {
   name: string;
 };
 
-type VolumeRowProps = {
-  pod: PodKind | PodTemplate;
-  value: VolumeData;
-};
-
-type VolumesTableProps = {
-  podTemplate: PodKind | PodTemplate;
-  heading?: string;
-};


### PR DESCRIPTION
Add a kebab with option of `Remove Volume` on all volumes in order to remove said volume from a resource.

This also entails a slight refactor for the `VolumesTable` component which currently takes a podTemplate but must now take a full resource so that I can remove the volumes from said resource.

Original:
![volume-table-no-kebab](https://user-images.githubusercontent.com/18728857/60542153-7d403000-9cd0-11e9-8f65-285b5d1545b2.png)

With Kebab:
![volume-table-with-kebab](https://user-images.githubusercontent.com/18728857/60542174-85986b00-9cd0-11e9-8568-f999228478e7.png)

With Kebab Open:
![volume-table-with-kebab-open](https://user-images.githubusercontent.com/18728857/60542188-90eb9680-9cd0-11e9-9430-816563086831.png)

Confirmation Screen:
![remove-volume-modal](https://user-images.githubusercontent.com/18728857/60542213-9cd75880-9cd0-11e9-99d0-c1cd55beb2f5.png)


