### PR TITLE
Add CRD Instances to Horizontal Nav Details Page

### DIFF
--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -5,7 +5,7 @@ import { sortable } from '@patternfly/react-table';
 
 import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
 import { AsyncComponent, Kebab, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from './utils';
-import { K8sResourceKind, referenceForCRD } from '../module/k8s';
+import {K8sResourceKind, referenceForCRD, CustomResourceDefinitionKind} from '../module/k8s';
 import { resourceListPages } from './resource-pages';
 import { DefaultPage } from './default-resource';
 
@@ -111,21 +111,26 @@ const Details = ({obj: crd}) => {
   </div>;
 };
 
-const Instances = ({obj, namespace}) => {
+const Instances:React.FC<InstancesProps> = ({obj, namespace}) => {
   const crdKind = referenceForCRD(obj);
   const componentLoader = resourceListPages.get(crdKind, () => Promise.resolve(DefaultPage));
   return <AsyncComponent loader={componentLoader} namespace={namespace ? namespace : undefined} kind={crdKind} showTitle={false} autoFocus={false} />;
 };
 
-export const CustomResourceDefinitionsList: React.SFC<CustomResourceDefinitionsListProps> = props => <Table {...props} aria-label="Custom Resource Definitions" Header={CRDTableHeader} Row={CRDTableRow} defaultSortField="spec.names.kind" virtualize />;
+export const CustomResourceDefinitionsList: React.FC<CustomResourceDefinitionsListProps> = props => <Table {...props} aria-label="Custom Resource Definitions" Header={CRDTableHeader} Row={CRDTableRow} defaultSortField="spec.names.kind" virtualize />;
 
-export const CustomResourceDefinitionsPage: React.SFC<CustomResourceDefinitionsPageProps> = props => <ListPage {...props} ListComponent={CustomResourceDefinitionsList} kind="CustomResourceDefinition" canCreate={true} />;
+export const CustomResourceDefinitionsPage: React.FC<CustomResourceDefinitionsPageProps> = props => <ListPage {...props} ListComponent={CustomResourceDefinitionsList} kind="CustomResourceDefinition" canCreate={true} />;
 export const CustomResourceDefinitionsDetailsPage = props => <DetailsPage {...props} menuActions={menuActions} pages={[navFactory.details(Details), navFactory.editYaml(), {name: 'Instances', href: 'instances', component: Instances}]} />;
 
 export type CustomResourceDefinitionsListProps = {
 };
 
 export type CustomResourceDefinitionsPageProps = {
+};
+
+type InstancesProps = {
+  obj: CustomResourceDefinitionKind;
+  namespace: string;
 };
 
 CustomResourceDefinitionsList.displayName = 'CustomResourceDefinitionsList';

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -5,7 +5,7 @@ import { sortable } from '@patternfly/react-table';
 
 import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
 import { AsyncComponent, Kebab, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from './utils';
-import {K8sResourceKind, referenceForCRD, CustomResourceDefinitionKind} from '../module/k8s';
+import { K8sResourceKind, referenceForCRD, CustomResourceDefinitionKind } from '../module/k8s';
 import { resourceListPages } from './resource-pages';
 import { DefaultPage } from './default-resource';
 
@@ -111,7 +111,7 @@ const Details = ({obj: crd}) => {
   </div>;
 };
 
-const Instances:React.FC<InstancesProps> = ({obj, namespace}) => {
+const Instances: React.FC<InstancesProps> = ({obj, namespace}) => {
   const crdKind = referenceForCRD(obj);
   const componentLoader = resourceListPages.get(crdKind, () => Promise.resolve(DefaultPage));
   return <AsyncComponent loader={componentLoader} namespace={namespace ? namespace : undefined} kind={crdKind} showTitle={false} autoFocus={false} />;

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -11,7 +11,16 @@ import { DefaultPage } from './default-resource';
 
 const { common } = Kebab.factory;
 
-const menuActions = [...common];
+const crdInstancesPath = crd => _.get(crd, 'spec.scope') === 'Namespaced'
+  ? `/k8s/all-namespaces/${referenceForCRD(crd)}`
+  : `/k8s/cluster/${referenceForCRD(crd)}`;
+
+const instances = (kind, obj) => ({
+  label: 'View Instances',
+  href: crdInstancesPath(obj),
+});
+
+const menuActions = [instances, ...common];
 
 const tableColumnClasses = [
   classNames('col-lg-3', 'col-md-4', 'col-sm-4', 'col-xs-6'),

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -5,6 +5,7 @@ import { sortable } from '@patternfly/react-table';
 import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
 import { Kebab, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from './utils';
 import { K8sResourceKind, referenceForCRD } from '../module/k8s';
+import { ResourceListPage } from './resource-list';
 
 const { common } = Kebab.factory;
 
@@ -111,7 +112,8 @@ const Details = ({obj: crd}) => {
 export const CustomResourceDefinitionsList: React.SFC<CustomResourceDefinitionsListProps> = props => <Table {...props} aria-label="Custom Resource Definitions" Header={CRDTableHeader} Row={CRDTableRow} defaultSortField="spec.names.kind" virtualize />;
 
 export const CustomResourceDefinitionsPage: React.SFC<CustomResourceDefinitionsPageProps> = props => <ListPage {...props} ListComponent={CustomResourceDefinitionsList} kind="CustomResourceDefinition" canCreate={true} />;
-export const CustomResourceDefinitionsDetailsPage = props => <DetailsPage {...props} menuActions={menuActions} pages={[navFactory.details(Details), navFactory.editYaml()]} />;
+export const CustomResourceDefinitionsDetailsPage = props => <DetailsPage {...props} menuActions={menuActions} pages={[navFactory.details(Details), navFactory.editYaml(),
+  {name: 'Instances', href: 'instances', component: (instanceProps) => <ResourceListPage {...instanceProps} modelRef={referenceForCRD(instanceProps.obj)} />}]} />;
 
 export type CustomResourceDefinitionsListProps = {
 };


### PR DESCRIPTION
Address Jira Story: https://jira.coreos.com/browse/CONSOLE-1488
Instead of using the action menu to navigate to the instances page, add a tabbed page in the horizontal nav of the CRD details page to show instances.

cc: @jhadvig, @spadgett 