### PR TITLE
Add Events Card/Extract VirtualList from events.

### DIFF
--- a/frontend/public/components/dashboard/events-card/event-item.tsx
+++ b/frontend/public/components/dashboard/events-card/event-item.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Icon } from 'patternfly-react';
+import { Link } from 'react-router-dom';
+
+import { connectToFlags } from '../../../reducers/features';
+import { FLAGS } from '../../../const';
+import { Timestamp, ResourceLink, resourcePathFromModel } from '../../utils';
+import { NodeModel } from '../../../models';
+import { EventComponentProps } from '../../utils/event-stream';
+import { categoryFilter } from '../../events';
+
+const EventItem_: React.FC<EventItemProps> = ({ event, flags }) => {
+  const { count, firstTimestamp, lastTimestamp, involvedObject: obj, source, message } = event;
+  const isError = categoryFilter('error', event);
+  return (
+    <div className="co-events-card__item">
+      <small>
+        <Timestamp simple className="co-events-card__item-timestamp text-secondary" timestamp={lastTimestamp} />
+        {count > 1 && <div className="text-secondary co-events-card__item-timestamp">
+          &nbsp;- {count} times in the last <Timestamp timestamp={firstTimestamp} simple={true} omitSuffix={true} />
+        </div>}
+      </small>
+      <div className="co-events-card__item-subheader">
+        {isError && <Icon type="fa" name="exclamation-circle" className="co-events-card__item-icon--error" />}
+        <ResourceLink
+          className="co-events-card__item-resourcelink"
+          kind={obj.kind}
+          namespace={obj.namespace}
+          name={obj.name}
+          title={obj.uid}
+        />
+      </div>
+      <small className="co-events-card__item-source">
+        Generated from <span>{source.component}</span>
+        {source.component === 'kubelet' && <span> on {flags[FLAGS.CAN_LIST_NODE]
+          ? <Link to={resourcePathFromModel(NodeModel, source.host)}>{source.host}</Link>
+          : <React.Fragment>{source.host}</React.Fragment>}
+        </span>}
+      </small>
+
+      <div className="co-events-card__item-message text-secondary">
+        {message}
+      </div>
+    </div>
+  );
+};
+
+export const EventItem = React.memo(connectToFlags(FLAGS.CAN_LIST_NODE)(EventItem_));
+
+type EventItemProps = EventComponentProps & {
+  flags: {[FLAGS.CAN_LIST_NODE]: boolean};
+};

--- a/frontend/public/components/dashboard/events-card/events-body.tsx
+++ b/frontend/public/components/dashboard/events-card/events-body.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import { EventStreamList } from '../../utils/event-stream';
+import { EventItem } from './event-item';
+import { NoEvents, ErrorLoadingEvents } from '../../events';
+import { LoadingInline, FirehoseResult } from '../../utils';
+import { EventKind } from '../../../module/k8s';
+
+export const EventsBody: React.FC<EventsBodyProps> = ({ events, filter }) => {
+  let eventsBody;
+  if (!(events && events.loaded)) {
+    eventsBody = <div className="co-events-card__body-loading"><LoadingInline /></div>;
+  } else if (events.loadError) {
+    eventsBody = <ErrorLoadingEvents />;
+  } else {
+    const filteredEvents = filter ? events.data.filter(filter) : events.data;
+    const sortedEvents = _.orderBy(filteredEvents, ['lastTimestamp', 'name'], ['desc', 'asc']);
+    eventsBody = filteredEvents.length === 0 ? (
+      <NoEvents />
+    ) : (
+      <EventStreamList events={sortedEvents} EventComponent={EventItem} scrollableElementId="events-body" />
+    );
+  }
+  return (
+    <div className="co-events-card__body" id="events-body">
+      <div className="co-events-card__body-stream">
+        {eventsBody}
+      </div>
+    </div>
+  );
+};
+
+type EventsBodyProps = {
+  events: FirehoseResult<EventKind[]>;
+  filter?: (event: EventKind) => boolean;
+};

--- a/frontend/public/components/dashboard/events-card/events-card.scss
+++ b/frontend/public/components/dashboard/events-card/events-card.scss
@@ -1,0 +1,57 @@
+.co-events-card__body {
+  margin: -1.5em;
+  max-height: 30em;
+  min-height: 10em;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.co-events-card__body-loading {
+  text-align: center;
+}
+
+.co-events-card__body-stream {
+  margin-top: 1.5em;
+}
+
+.co-events-card__item {
+  border-bottom: solid 1px $pf-color-black-200;
+  padding: 0 1.5em;
+}
+
+.co-events-card__item-icon--error {
+  align-items: center;
+  color: $pf-color-red-100;
+  display: flex;
+  font-size: 1.2rem;
+  margin-right: 0.3em;
+}
+
+.co-events-card__item-message {
+  font-size: 0.875rem;
+  margin-top: 0.5em;
+}
+
+.co-events-card__item-resourcelink {
+  display: block;
+  flex: 2 0 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.co-events-card__item-source {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.co-events-card__item-subheader {
+  display: flex;
+  justify-content: space-between;
+  white-space: pre;
+}
+
+.co-events-card__item-timestamp {
+  display: inline-block;
+}

--- a/frontend/public/components/dashboards-page/overview-dashboard/events-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/events-card.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import { DashboardCard, DashboardCardHeader, DashboardCardBody, DashboardCardTitle } from '../../dashboard/dashboard-card';
+import { EventsBody } from '../../dashboard/events-card/events-body';
+import { DashboardItemProps, withDashboardResources } from '../with-dashboard-resources';
+import { EventModel } from '../../../models';
+import { FirehoseResource, FirehoseResult } from '../../utils';
+import { EventKind } from '../../../module/k8s';
+
+const eventsResource: FirehoseResource = {isList: true, kind: EventModel.kind, prop: 'events'};
+
+const EventsCard_: React.FC<DashboardItemProps> = ({ watchK8sResource, stopWatchK8sResource, resources }) => {
+  React.useEffect(() => {
+    watchK8sResource(eventsResource);
+    return () => stopWatchK8sResource(eventsResource);
+  }, [watchK8sResource, stopWatchK8sResource]);
+  return (
+    <DashboardCard>
+      <DashboardCardHeader>
+        <DashboardCardTitle>Events</DashboardCardTitle>
+      </DashboardCardHeader>
+      <DashboardCardBody>
+        <EventsBody events={resources.events as FirehoseResult<EventKind[]>} />
+      </DashboardCardBody>
+    </DashboardCard>
+  );
+};
+
+export const EventsCard = withDashboardResources(EventsCard_);

--- a/frontend/public/components/dashboards-page/overview-dashboard/overview-dashboard.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/overview-dashboard.tsx
@@ -5,14 +5,16 @@ import { HealthCard } from './health-card';
 import { DetailsCard } from './details-card';
 import { CapacityCard } from './capacity-card';
 import { InventoryCard } from './inventory-card';
+import { EventsCard } from './events-card';
 
 export const OverviewDashboard: React.FC<{}> = () => {
   const mainCards = [HealthCard, CapacityCard];
   const leftCards = [DetailsCard, InventoryCard];
+  const rightCards = [EventsCard];
 
   return (
     <Dashboard>
-      <DashboardGrid mainCards={mainCards} leftCards={leftCards} />
+      <DashboardGrid mainCards={mainCards} leftCards={leftCards} rightCards={rightCards} />
     </Dashboard>
   );
 };

--- a/frontend/public/components/utils/event-stream.tsx
+++ b/frontend/public/components/utils/event-stream.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import {
+  AutoSizer,
+  List as VirtualList,
+  WindowScroller,
+  CellMeasurer,
+  CellMeasurerCache,
+} from 'react-virtualized';
+import { CSSTransition } from 'react-transition-group';
+
+import { EventKind } from '../../module/k8s';
+
+// Keep track of seen events so we only animate new ones.
+const seen = new Set();
+const timeout = {enter: 150};
+
+const measurementCache = new CellMeasurerCache({
+  fixedWidth: true,
+  minHeight: 109, /* height of event with a one-line event message on desktop */
+});
+
+class SysEvent extends React.Component<SysEventProps> {
+  shouldComponentUpdate(nextProps: SysEventProps) {
+    if (this.props.event.lastTimestamp !== nextProps.event.lastTimestamp) {
+      // Timestamps can be modified because events can be combined.
+      return true;
+    }
+    if (_.isEqual(this.props.style, nextProps.style)) {
+      return false;
+    }
+    return true;
+  }
+
+  componentWillUnmount() {
+    // TODO (kans): this is not correct, but don't memory leak :-/
+    seen.delete(this.props.event.metadata.uid);
+  }
+
+  render() {
+    const { EventComponent, index, style, event} = this.props;
+
+    let shouldAnimate: boolean;
+    const key = event.metadata.uid;
+    // Only animate events if they're at the start of the list (first 6) and we haven't seen them before.
+    if (!seen.has(key) && index < 6) {
+      seen.add(key);
+      shouldAnimate = true;
+    }
+
+    return <div className="co-sysevent--transition" style={style}>
+      <CSSTransition mountOnEnter={true} appear={shouldAnimate} in exit={false} timeout={timeout} classNames="slide">
+        {status => <div className={`slide-${status}`}><EventComponent event={event} /></div>}
+      </CSSTransition>
+    </div>;
+  }
+}
+
+export class EventStreamList extends React.Component<EventStreamListProps> {
+  private rowRenderer;
+  private list: VirtualList;
+
+  constructor(props: EventStreamListProps) {
+    super(props);
+    this.rowRenderer = (events, index, style, key, parent) => (
+      <CellMeasurer
+        cache={measurementCache}
+        columnIndex={0}
+        key={key}
+        rowIndex={index}
+        parent={parent}>
+        {({ measure }) =>
+          <SysEvent event={events[index]} EventComponent={props.EventComponent} onLoad={measure} onEntered={print} key={key} style={style} index={index} />
+        }
+      </CellMeasurer>
+    );
+  }
+
+  componentDidUpdate(prevProps: EventStreamListProps) {
+    if (prevProps.events !== this.props.events) {
+      this.onResize();
+      if (this.list) {
+        this.list.recomputeRowHeights();
+      }
+    }
+  }
+
+  onResize() {
+    measurementCache.clearAll();
+  }
+
+  /* Default `height` to 0 to avoid console errors from https://github.com/bvaughn/react-virtualized/issues/1158 */
+  render() {
+    const { events, scrollableElementId = 'content-scrollable'} = this.props;
+    return events.length > 0 &&
+    <WindowScroller scrollElement={document.getElementById(scrollableElementId)}>
+      {({height, isScrolling, registerChild, onChildScroll, scrollTop}) =>
+        <AutoSizer disableHeight onResize={this.onResize}>
+          {({width}) => <div ref={registerChild}>
+            <VirtualList
+              autoHeight
+              data={events}
+              deferredMeasurementCache={measurementCache}
+              height={height || 0}
+              isScrolling={isScrolling}
+              onScroll={onChildScroll}
+              ref={virtualList => this.list = virtualList}
+              rowCount={events.length}
+              rowHeight={measurementCache.rowHeight}
+              rowRenderer={({index, style, key, parent}) => this.rowRenderer(events, index, style, key, parent)}
+              scrollTop={scrollTop}
+              tabIndex={null}
+              width={width}
+            />
+          </div>}
+        </AutoSizer>}
+    </WindowScroller>;
+  }
+}
+
+type EventStreamListProps = {
+  scrollableElementId?: string;
+  events: EventKind[];
+  EventComponent: React.ComponentType<EventComponentProps>;
+}
+
+export type EventComponentProps = {
+  event: EventKind;
+}
+
+type SysEventProps = {
+  EventComponent: React.ComponentType<EventComponentProps>;
+  event: EventKind;
+  onLoad: () => void;
+  onEntered: () => void;
+  style: React.CSSProperties;
+  index: number;
+}

--- a/frontend/public/module/k8s/event.ts
+++ b/frontend/public/module/k8s/event.ts
@@ -1,0 +1,6 @@
+export type EventInvolvedObject = {
+  kind: string;
+  name: string;
+  uid: string;
+  namespace?: string;
+};

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -1,4 +1,5 @@
 import { JSONSchema6 } from 'json-schema';
+import { EventInvolvedObject } from './event';
 
 export * from './job';
 export * from './k8s';
@@ -14,6 +15,7 @@ export * from './cluster-operator';
 export * from './cluster-settings';
 export * from './template';
 export * from './swagger';
+export * from './event';
 
 export type OwnerReference = {
   name: string;
@@ -617,3 +619,17 @@ export type GroupVersionKind = string;
  * Maintains backwards-compatibility with references using the `kind` string field.
  */
 export type K8sResourceKindReference = GroupVersionKind | string;
+
+export type EventKind = K8sResourceKind & {
+  count: number;
+  type: string;
+  involvedObject: EventInvolvedObject;
+  message: string;
+  lastTimestamp: string;
+  firstTimestamp: string;
+  reason: string;
+  source: {
+    component: string;
+    host?: string;
+  }
+};

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -100,5 +100,6 @@
 @import "components/dashboard/details-card/details-card";
 @import "components/dashboard/capacity-card/capacity-card";
 @import "components/dashboard/inventory-card/inventory-card";
+@import "components/dashboard/events-card/events-card";
 
 @import "components/nav/nav-header";


### PR DESCRIPTION
This PR replaces https://github.com/openshift/console/pull/1818

![events](https://user-images.githubusercontent.com/2078045/60164706-5a100f00-97fe-11e9-8ee2-2d927aaf744a.png)

In this case Im using `Firehose` to fetch events as suggested by @spadgett . I still did some changes to existing `events.jsx` - I've extracted Event's `VirtualList` which is reused in Events dashboard card.