### PR TITLE
Query Browser: Fix some styles to better match mocks & clean up CSS

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -2,12 +2,6 @@
   padding-top: 20px;
 }
 
-.query-browser__all-queries-controls {
-  display: flex;
-  justify-content: space-between;
-  margin: 15px 0;
-}
-
 .query-browser__dropdown--subtitle {
   padding: 1px 10px;
 }
@@ -23,16 +17,21 @@
   font-weight: 600;
 }
 
-.query-browser__external-link {
-  margin-left: auto;
-}
-
-.query-browser__header {
-  align-items: center;
+.query-browser__controls {
   display: flex;
   flex-wrap: wrap-reverse;
+  justify-content: space-between;
   margin-bottom: 15px;
   width: 100%;
+}
+
+.query-browser__controls--left {
+  display: flex;
+}
+
+.query-browser__controls--right {
+  display: flex;
+  margin-left: auto;
 }
 
 .query-browser__inline-control {
@@ -41,7 +40,8 @@
 }
 
 .query-browser__loading {
-  width: 20px;
+  margin: auto 0;
+  min-width: 20px;
 }
 
 .query-browser__metrics-dropdown-button {
@@ -85,28 +85,24 @@
   }
 }
 
-.query-browser__span-dropdown {
-  .query-browser__span-dropdown-button {
-    height: 29px;
-    min-width: 30px;
-    width: 30px;
-  }
-  .query-browser__span-dropdown-menu {
-    min-width: 110px;
-    right: 0;
-  }
+.query-browser__span-dropdown-button {
+  margin-left: -1px;
+  width: 44px;
+}
+
+.query-browser__span-dropdown-menu {
+  right: 0;
+  width: 130px;
 }
 
 .query-browser__span-text {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-  width: 80px;
+  max-width: 87px;
 }
 
 .query-browser__wrapper {
   border: 1px solid $color-grey-background-border;
-  margin: 0 0 15px 0;
+  margin: 0 0 20px 0;
   overflow: visible;
-  padding: 20px;
+  padding: 10px;
   width: 100%;
 }

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -186,7 +186,7 @@ const QueryInput: React.FC<QueryInputProps> = ({metrics = [], onBlur, onSubmit, 
 
   return <div className="query-browser__query query-browser__inline-control pf-c-dropdown">
     <textarea
-      autoFocus={true}
+      autoFocus
       className="form-control query-browser__query-input"
       onBlur={onTextareaBlur}
       onChange={onChange}
@@ -243,7 +243,7 @@ const Query: React.FC<QueryProps> = ({colorOffset, metrics, onBlur, onDelete, on
     {expanded && <div className="group__body group__body--query-browser">
       <div className="co-m-table-grid co-m-table-grid--bordered">
         <div className="row co-m-table-grid__head">
-          <div className="col-xs-9 query-browser-metric__wrapper">
+          <div className="col-xs-9">
             <div className="query-browser-metric__color"></div>
             Series
           </div>
@@ -373,9 +373,11 @@ export const QueryBrowserPage = withFallback(() => {
             queries={_.map(queries, 'query')}
           />
           <form onSubmit={onSubmit}>
-            <div className="query-browser__all-queries-controls">
-              <MetricsDropdown onChange={onMetricChange} onLoad={setMetrics} />
-              <div>
+            <div className="query-browser__controls">
+              <div className="query-browser__controls--left">
+                <MetricsDropdown onChange={onMetricChange} onLoad={setMetrics} />
+              </div>
+              <div className="query-browser__controls--right">
                 <button type="button" className="btn btn-default query-browser__inline-control" onClick={addQuery}>Add Query</button>
                 <button type="submit" className="btn btn-primary">Run Queries</button>
               </div>

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -14,6 +14,7 @@ import {
   EmptyState,
   EmptyStateIcon,
   EmptyStateVariant,
+  TextInput,
   Title,
 } from '@patternfly/react-core';
 import { ChartLineIcon } from '@patternfly/react-icons';
@@ -62,17 +63,16 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(({defaultSpanText, 
   };
 
   return <React.Fragment>
-    <div className={isValid ? '' : 'has-error'}>
-      <input
-        className="form-control query-browser__span-text"
-        onChange={e => setSpan(e.target.value)}
-        type="text"
-        value={text}
-      />
-    </div>
+    <TextInput
+      aria-label="graph timespan"
+      className="query-browser__span-text"
+      isValid={isValid}
+      onChange={setSpan}
+      type="text"
+      value={text}
+    />
     <Dropdown
       buttonClassName="query-browser__span-dropdown-button"
-      className="query-browser__span-dropdown"
       items={dropdownItems}
       menuClassName="query-browser__span-dropdown-menu"
       noSelection={true}
@@ -235,12 +235,14 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   }
 
   return <div className="query-browser__wrapper">
-    <div className="query-browser__header">
-      <SpanControls defaultSpanText={defaultSpanText} onChange={onSpanChange} span={span} />
-      <div className="query-browser__loading">
-        {updating && <LoadingInline />}
+    <div className="query-browser__controls">
+      <div className="query-browser__controls--left">
+        <SpanControls defaultSpanText={defaultSpanText} onChange={onSpanChange} span={span} />
+        <div className="query-browser__loading">
+          {updating && <LoadingInline />}
+        </div>
       </div>
-      {GraphLink && <div className="query-browser__external-link">
+      {GraphLink && <div className="query-browser__controls--right">
         <GraphLink />
       </div>}
     </div>


### PR DESCRIPTION
Convert timespan text input to a PatternFly `TextInput`.
Adjust some margins, padding, etc.
Clean up CSS a bit including removing the remaining use of nested SCSS.