### PR TITLE
Bug 1726597: Improve alert styles

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -369,7 +369,7 @@ export const EditYAML = connect(stateToProps)(
                   <div className="full-width-and-height yaml-editor__flexbox">
                     <div id={this.id} key={this.id} className="yaml-editor__acebox" />
                     <div className="yaml-editor__buttons">
-                      {error && <Alert isInline className="co-alert co-scrollable-alert" variant="danger" title="An error occurred">{error}</Alert>}
+                      {error && <Alert isInline className="co-alert co-alert--scrollable" variant="danger" title="An error occurred"><div className="co-pre-line">{error}</div></Alert>}
                       {success && <Alert isInline className="co-alert" variant="success" title={success} />}
                       {stale && <Alert isInline className="co-alert" variant="info" title="This object has been updated.">Click reload to see the new version.</Alert>}
                       {create && <button type="submit" className="btn btn-primary" id="save-changes" onClick={() => this.save()}>Create</button>}

--- a/frontend/public/components/utils/_alerts.scss
+++ b/frontend/public/components/utils/_alerts.scss
@@ -1,16 +1,13 @@
 .co-alert {
   margin-bottom: var(--pf-global--spacer--lg);
+  text-align: left;
   // overrides Bootstrap-related line-height issue that causes the title and icon to go out of alignment
   h4 {
     line-height: var(--pf-global--LineHeight--md);
   }
 }
 
-.co-expandable-alert {
-  margin-bottom: var(--pf-global--spacer--xl);
-}
-
-.co-scrollable-alert .pf-c-alert__description {
+.co-alert--scrollable .pf-c-alert__description {
   max-height: 100px;
   overflow-x: hidden;
   overflow-y: auto;

--- a/frontend/public/components/utils/alerts.tsx
+++ b/frontend/public/components/utils/alerts.tsx
@@ -10,7 +10,7 @@ export const ExpandableAlert: React.FC<CustomAlertProps> = ({alerts, variant}) =
   return <Alert
     isInline
     variant={variant}
-    className="co-expandable-alert"
+    className="co-alert"
     title={<React.Fragment>{`There are ${alertCount} ${variant} alerts.`}<button type="button" className="btn btn-link" onClick={() => setExpanded(!expanded)}>{expanded ? 'Hide' : 'Show'} Details</button></React.Fragment>}
   >
     {expanded && alertContent}

--- a/frontend/public/components/utils/button-bar.jsx
+++ b/frontend/public/components/utils/button-bar.jsx
@@ -16,8 +16,12 @@ const injectDisabled = (children, disabled) => {
   });
 };
 
-const ErrorMessage = ({message}) => <Alert isInline className="co-alert co-scrollable-alert" variant="danger" title="An error occurred">{message}</Alert>;
-const InfoMessage = ({message}) => <Alert isInline className="co-alert co-scrollable-alert" variant="info" title={message} />;
+const ErrorMessage = ({message}) => (
+  <Alert isInline className="co-alert co-alert--scrollable" variant="danger" title="An error occurred">
+    <div className="co-pre-line">{message}</div>
+  </Alert>
+);
+const InfoMessage = ({message}) => <Alert isInline className="co-alert" variant="info" title={message} />;
 
 // NOTE: DO NOT use <a> elements within a ButtonBar.
 // They don't support the disabled attribute, and therefore


### PR DESCRIPTION
* Make sure alert text is left-aligned when parentd has a different `text-align` value
* Use `co-pre-line` when appropriate
* Use BEM naming

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1726597

/assign @rhamilto 