### PR TITLE
Bug 1722879, 1722880: Update operand table

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/operand.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/operand.tsx
@@ -64,25 +64,22 @@ const tableColumnClasses = [
 export const OperandTableHeader = () => {
   return [
     {
-      title: 'Name', sortField: 'metadata.name', transforms: [sortable],
-      props: { className: tableColumnClasses[0] },
+      title: 'Name', sortField: 'metadata.name', transforms: [sortable], props: { className: tableColumnClasses[0] },
     },
     {
-      title: 'Labels', sortField: 'metadata.labels', transforms: [sortable],
-      props: { className: tableColumnClasses[1] },
+      title: 'Labels', sortField: 'metadata.labels', transforms: [sortable], props: { className: tableColumnClasses[1] },
     },
     {
-      title: 'Type', sortField: 'kind', transforms: [sortable],
-      props: { className: tableColumnClasses[2] },
+      title: 'Kind', sortField: 'kind', transforms: [sortable], props: { className: tableColumnClasses[2] },
     },
     {
-      title: 'Status', props: { className: tableColumnClasses[3] },
+      title: 'Status', sortField: 'status.phase', transforms: [sortable], props: { className: tableColumnClasses[3] },
     },
     {
-      title: 'Version', props: { className: tableColumnClasses[4] },
+      title: 'Version', sortField: 'spec.version', transforms: [sortable], props: { className: tableColumnClasses[4] },
     },
     {
-      title: 'Last Updated', props: { className: tableColumnClasses[5] },
+      title: 'Last Updated', sortField: 'metadata.creationTimestamp', transforms: [sortable], props: { className: tableColumnClasses[5] },
     },
     {
       title: '', props: { className: tableColumnClasses[6] },


### PR DESCRIPTION
* Use `Kind` instead of `Type` in column header to align with k8s terms
* Allow sorting on all columns

https://bugzilla.redhat.com/show_bug.cgi?id=1722879
https://bugzilla.redhat.com/show_bug.cgi?id=1722880

/assign @alecmerdler 

(We have a separate JIRA issue tracking the broken create button styles.)

<img width="1050" alt="etcdoperator v0 9 4 · Details · OKD 2019-07-03 13-41-41" src="https://user-images.githubusercontent.com/1167259/60613169-54836d80-9d98-11e9-9af2-19250308da6a.png">

