### PR TITLE
Remove PF3 alerts and convert remaining instances to PF4 alerts

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/create-operand.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/create-operand.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
 import Spy = jasmine.Spy;
+import { Alert } from '@patternfly/react-core';
 
 import {
   CreateOperandForm,
@@ -109,7 +110,7 @@ describe(CreateOperandForm.displayName, () => {
     spyAndExpect(spyOn(k8s, 'k8sCreate'))(Promise.reject(error))
       .then(() => new Promise(resolve => setTimeout(() => resolve(), 10)))
       .then(() => {
-        expect(wrapper.find('.co-alert').text()).toEqual(error.message);
+        expect(wrapper.find(Alert).props().title).toEqual(error.message);
         done();
       });
 

--- a/frontend/integration-tests/views/operator-hub.view.ts
+++ b/frontend/integration-tests/views/operator-hub.view.ts
@@ -18,7 +18,7 @@ export const createSubscriptionFormLoaded = () => browser.wait(until.visibilityO
 export const createSubscriptionFormInstallMode = element(by.cssContainingText('label', 'Installation Mode'));
 export const allNamespacesInstallMode = $('input[value="AllNamespaces"]');
 export const ownNamespaceInstallMode = $('input[value="OwnNamespace"]');
-export const createSubscriptionError = $('.alert-danger');
+export const createSubscriptionError = $('.pf-c-alert.pf-m-danger');
 
 export const installNamespaceDropdown = $('.dropdown--full-width');
 export const installNamespaceDropdownBtn = installNamespaceDropdown.$('.pf-c-dropdown__toggle');

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import { Alert, Button } from 'patternfly-react';
+import { Button } from 'patternfly-react';
+import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
 
 import { Table } from '@console/internal/components/factory';
 import { PersistentVolumeClaimModel } from '@console/internal/models';
@@ -71,7 +72,13 @@ export const VMDisks: React.FC<VMDisksProps> = ({ vmLikeEntity, pvcs, datavolume
         </div>
       </div>
       <div className="co-m-pane__body">
-        {createError && <Alert onDismiss={() => setCreateError(null)}>{createError}</Alert>}
+        {createError && (
+          <Alert
+            variant="danger"
+            action={<AlertActionCloseButton onClose={() => setCreateError(null)} />}
+            title={createError}
+          />
+        )}
         <Table
           aria-label="VM Disks List"
           data={getStoragesData(vmLikeEntity, isCreating)}

--- a/frontend/public/components/operator-lifecycle-manager/create-operand.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/create-operand.tsx
@@ -5,6 +5,7 @@ import { Helmet } from 'react-helmet';
 import { safeDump } from 'js-yaml';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
+import { Alert } from '@patternfly/react-core';
 
 import {
   K8sResourceKindReference,
@@ -136,9 +137,9 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
           { field.description && <span className="help-block text-muted">{field.description}</span> }
         </div>
       </div>)}
-      <div className="row">
-        {error && <p className="alert alert-danger co-alert"><span className="pficon pficon-error-circle-o"></span>{error}</p>}
-      </div>
+      {error && <div className="row">
+        <Alert isInline className="co-alert co-break-word" variant="danger" title={error} />
+      </div>}
       <div className="row">
         <button className="btn btn-primary" type="submit" onClick={submit}>Create</button>
         <Link className="btn btn-default" to={`/k8s/ns/${props.namespace}/clusterserviceversions/${props.clusterServiceVersion.metadata.name}/${referenceForModel(props.operandModel)}`}>Cancel</Link>

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -22,7 +22,6 @@
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/input-groups";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/breadcrumbs";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/labels";
-@import "~bootstrap-sass/assets/stylesheets/bootstrap/alerts";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/list-group";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/close";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/modals";
@@ -38,7 +37,6 @@
 @import '~patternfly/dist/sass/patternfly/breadcrumbs';
 @import '~patternfly/dist/sass/patternfly/hint-block';
 @import '~patternfly/dist/sass/patternfly/modals';
-@import '~patternfly/dist/sass/patternfly/alerts';
 @import '~patternfly/dist/sass/patternfly/toolbar';
 @import '~patternfly/dist/sass/patternfly/blank-slate';
 @import '~patternfly/dist/sass/patternfly/list-view';


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1594

![Screen Shot 2019-07-03 at 1 44 24 PM](https://user-images.githubusercontent.com/895728/60615041-37509e00-9d9c-11e9-84d0-03769fa7cbc8.png)

Note:  I was unable to test the vm-disk instance, but believe it should be fine based on the JSX changes alone.