### PR TITLE
Set .pf-c-dropdown__menu border to 0 and correct side padding

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -47,7 +47,7 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
 }
 
 .dropdown-menu__filter {
-  padding: 5px 10px 10px;
+  padding: 5px var(--pf-c-dropdown__menu-item--PaddingRight) 10px;
 }
 
 .dropdown-menu--text-wrap {
@@ -222,7 +222,7 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
       &.bookmarker {
         display: inline-block;
         padding-right: 5px;
-        padding-left: 12px;
+        padding-left: var(--pf-c-dropdown__menu-item--PaddingLeft);
         color: $color-bookmarker;
         flex: 0;
         &:hover {
@@ -252,6 +252,7 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
 }
 
 .pf-c-dropdown__menu {
+  border-width: 0 !important; // TEMP fix until https://github.com/patternfly/patternfly-next/issues/2019 is fixed upstream
   list-style: none;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
so that aligned edges of overlaid elements aren't shown.

Also correct side padding on dropdowns with filter.

<img width="371" alt="Screen Shot 2019-07-03 at 4 38 28 PM" src="https://user-images.githubusercontent.com/1874151/60623897-e186f080-9db1-11e9-8bb2-d6ac6cbc0b84.png">

<img width="205" alt="Screen Shot 2019-07-03 at 4 43 09 PM" src="https://user-images.githubusercontent.com/1874151/60623892-ddf36980-9db1-11e9-85d0-b2bd9263bf67.png">
