### PR TITLE
kubevirt: link to vm template overview

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import { ResourceIcon } from '@console/internal/components/utils';
+import { getName, getNamespace, getUid } from '@console/shared';
+import { TemplateModel } from '@console/internal/models';
+import { TemplateKind } from '@console/internal/module/k8s';
+
+export const VMTemplateLink: React.FC<VMTemplateLinkProps> = ({ template }) => {
+  const name = getName(template);
+  const namespace = getNamespace(template);
+
+  return (
+    <>
+      <ResourceIcon kind={TemplateModel.kind} />
+      <Link
+        to={`/k8s/ns/${namespace}/vmtemplates/${name}`}
+        title={getUid(template)}
+        className="co-resource-item__resource-name"
+      >
+        {name}
+      </Link>
+    </>
+  );
+};
+
+type VMTemplateLinkProps = {
+  template: TemplateKind;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -15,7 +15,7 @@ import {
 import { ResourceSummary } from '@console/internal/components/utils';
 import { DASH } from '@console/shared';
 import { TemplateKind, K8sResourceKind } from '@console/internal/module/k8s';
-import { VMTemplateLink } from './vm-template';
+import { VMTemplateLink } from './vm-template-link';
 
 export const VMTemplateResourceSummary: React.FC<VMTemplateResourceSummaryProps> = ({
   template,

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -6,7 +6,6 @@ import {
   getOperatingSystem,
   getWorkloadProfile,
   getVmTemplate,
-  getTemplateDisplayName,
   getFlavor,
   BootOrder,
   getBootableDevicesInOrder,
@@ -16,12 +15,12 @@ import {
 import { ResourceSummary } from '@console/internal/components/utils';
 import { DASH } from '@console/shared';
 import { TemplateKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { VMTemplateLink } from './vm-template';
 
 export const VMTemplateResourceSummary: React.FC<VMTemplateResourceSummaryProps> = ({
   template,
 }) => {
   const base = getVmTemplate(template);
-  const baseLink = base && getTemplateDisplayName(base); // TODO(mlibra): link to a template detail, once implemented
 
   return (
     <ResourceSummary resource={template}>
@@ -32,7 +31,7 @@ export const VMTemplateResourceSummary: React.FC<VMTemplateResourceSummaryProps>
       <dt>Workload Profile</dt>
       <dd>{getWorkloadProfile(template) || DASH}</dd>
       <dt>Base Template</dt>
-      <dd>{baseLink || DASH}</dd>
+      <dd>{base ? <VMTemplateLink template={base} /> : DASH}</dd>
     </ResourceSummary>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -11,18 +11,13 @@ import {
 } from 'kubevirt-web-ui-components';
 
 import { ListPage, Table, TableRow, TableData } from '@console/internal/components/factory';
-import {
-  Kebab,
-  ResourceLink,
-  ResourceKebab,
-  ResourceIcon,
-} from '@console/internal/components/utils';
-import { getName, getNamespace, DASH, getUid } from '@console/shared';
+import { Kebab, ResourceLink, ResourceKebab } from '@console/internal/components/utils';
+import { getNamespace, DASH } from '@console/shared';
 import { TemplateModel } from '@console/internal/models';
-import { Link } from 'react-router-dom';
 import { TemplateKind } from '@console/internal/module/k8s';
 import { match } from 'react-router';
 import { dimensifyHeader, dimensifyRow } from '../../utils/table';
+import { VMTemplateLink } from './vm-template-link';
 
 export const menuActions = Kebab.factory.common;
 
@@ -161,26 +156,4 @@ type VirtualMachineTemplatesPageProps = {
   match: match<{ ns?: string }>;
 };
 
-const VMTemplateLink: React.FC<VMTemplateLinkProps> = ({ template }) => {
-  const name = getName(template);
-  const namespace = getNamespace(template);
-
-  return (
-    <>
-      <ResourceIcon kind={kind} />
-      <Link
-        to={`/k8s/ns/${namespace}/vmtemplates/${name}`}
-        title={getUid(template)}
-        className="co-resource-item__resource-name"
-      >
-        {name}
-      </Link>
-    </>
-  );
-};
-
-type VMTemplateLinkProps = {
-  template: TemplateKind;
-};
-
-export { VMTemplateLink, VirtualMachineTemplatesPage };
+export { VirtualMachineTemplatesPage };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -81,23 +81,19 @@ const VMTemplateTableHeader = () =>
 
 VMTemplateTableHeader.displayName = 'VMTemplateTableHeader';
 
-const VMTemplateTableRow = ({ obj: template, index, key, style }: VMTemplateTableRowProps) => {
+const VMTemplateTableRow: React.FC<VMTemplateTableRowProps> = ({
+  obj: template,
+  index,
+  key,
+  style,
+}) => {
   const dimensify = dimensifyRow(tableColumnClasses);
   const os = getTemplateOperatingSystems([template])[0];
-  const name = getName(template);
-  const namespace = getNamespace(template);
 
   return (
     <TableRow id={template.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={dimensify()}>
-        <ResourceIcon kind={kind} />
-        <Link
-          to={`/k8s/ns/${namespace}/vmtemplates/${name}`}
-          title={getUid(template)}
-          className="co-resource-item__resource-name"
-        >
-          {name}
-        </Link>
+        <VMTemplateLink template={template} />
       </TableData>
       <TableData className={dimensify()}>
         <ResourceLink
@@ -122,7 +118,7 @@ const VMTemplateTableRow = ({ obj: template, index, key, style }: VMTemplateTabl
 };
 VMTemplateTableRow.displayName = 'VmTemplateTableRow';
 
-const VirtualMachineTemplates = (props: React.ComponentProps<typeof Table>) => {
+const VirtualMachineTemplates: React.FC<React.ComponentProps<typeof Table>> = (props) => {
   return (
     <Table
       {...props}
@@ -140,9 +136,9 @@ const getCreateProps = (namespace: string) => ({
   createLink: () => `/k8s/ns/${namespace || 'default'}/vmtemplates/~new/`,
 });
 
-const VirtualMachineTemplatesPage = (
-  props: VirtualMachineTemplatesPageProps & React.ComponentProps<typeof ListPage>,
-) => (
+const VirtualMachineTemplatesPage: React.FC<
+  VirtualMachineTemplatesPageProps & React.ComponentProps<typeof ListPage>
+> = (props) => (
   <ListPage
     {...props}
     title={labelPlural}
@@ -165,4 +161,26 @@ type VirtualMachineTemplatesPageProps = {
   match: match<{ ns?: string }>;
 };
 
-export { VirtualMachineTemplatesPage };
+const VMTemplateLink: React.FC<VMTemplateLinkProps> = ({ template }) => {
+  const name = getName(template);
+  const namespace = getNamespace(template);
+
+  return (
+    <>
+      <ResourceIcon kind={kind} />
+      <Link
+        to={`/k8s/ns/${namespace}/vmtemplates/${name}`}
+        title={getUid(template)}
+        className="co-resource-item__resource-name"
+      >
+        {name}
+      </Link>
+    </>
+  );
+};
+
+type VMTemplateLinkProps = {
+  template: TemplateKind;
+};
+
+export { VMTemplateLink, VirtualMachineTemplatesPage };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -8,7 +8,6 @@ import {
   getVmiIpAddresses,
   getWorkloadProfile,
   getVmTemplate,
-  getTemplateDisplayName,
   getNodeName,
   getFlavor,
   VmStatuses,
@@ -23,10 +22,10 @@ import { getName, getNamespace, DASH } from '@console/shared';
 import { PodModel } from '@console/internal/models';
 
 import { VMKind, VMIKind } from '../../types';
+import { VMTemplateLink } from '../vm-templates/vm-template';
 
 export const VMResourceSummary = ({ vm }: VMResourceSummaryProps) => {
   const template = getVmTemplate(vm);
-  const templateLink = template && getTemplateDisplayName(template); // TODO(mlibra): link to a template detail, once implemented
 
   return (
     <ResourceSummary resource={vm}>
@@ -35,7 +34,7 @@ export const VMResourceSummary = ({ vm }: VMResourceSummaryProps) => {
       <dt>Operating System</dt>
       <dd>{getOperatingSystemName(vm) || getOperatingSystem(vm) || DASH}</dd>
       <dt>Template</dt>
-      <dd>{templateLink || DASH}</dd>
+      <dd>{template ? <VMTemplateLink template={template} /> : DASH}</dd>
     </ResourceSummary>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -22,7 +22,7 @@ import { getName, getNamespace, DASH } from '@console/shared';
 import { PodModel } from '@console/internal/models';
 
 import { VMKind, VMIKind } from '../../types';
-import { VMTemplateLink } from '../vm-templates/vm-template';
+import { VMTemplateLink } from '../vm-templates/vm-template-link';
 
 export const VMResourceSummary = ({ vm }: VMResourceSummaryProps) => {
   const template = getVmTemplate(vm);


### PR DESCRIPTION
Follow-up to #1843, adding links to the vm template overview page.

Ref:
https://github.com/openshift/console/pull/1843#discussion_r299598509