### PR TITLE
Kubevirt: reorder routes for new vmtemplate

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/plugin.ts
+++ b/frontend/packages/kubevirt-plugin/src/plugin.ts
@@ -120,22 +120,22 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Page/Route',
     properties: {
-      path: `/k8s/ns/:ns/vmtemplates/:name`,
-      loader: () =>
-        import(
-          './components/vm-templates/vm-template-details-page' /* webpackChunkName: "kubevirt-virtual-machine-details" */
-        ).then((m) => m.VMTemplateDetailsPage),
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
       exact: true,
       path: ['/k8s/ns/:ns/vmtemplates/~new'],
       loader: () =>
         import(
           './components/vm-templates/vm-template-create-yaml' /* webpackChunkName: "kubevirt-vmtemplates-create-yaml" */
         ).then((m) => m.CreateVMTemplateYAML),
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      path: `/k8s/ns/:ns/vmtemplates/:name`,
+      loader: () =>
+        import(
+          './components/vm-templates/vm-template-details-page' /* webpackChunkName: "kubevirt-virtual-machine-details" */
+        ).then((m) => m.VMTemplateDetailsPage),
     },
   },
   {


### PR DESCRIPTION
Register `vmtemplates/~new` route before the `vmtemplate/:name` route.

before:
![OKD](https://user-images.githubusercontent.com/2181522/60667320-eca15580-9e71-11e9-9500-9424b5dc78bf.png)

after:
![OKD(1)](https://user-images.githubusercontent.com/2181522/60667334-f88d1780-9e71-11e9-9d77-ce0837185efc.png)

