### PR TITLE
Improve active plugin list override

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/codegen/plugin-resolver.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/plugin-resolver.ts
@@ -74,10 +74,16 @@ export const resolvePluginPackages = (
 
   // provide the ability to override the active plugin list
   if (_.isString(process.env[consolePluginOverrideEnvVar])) {
-    const pluginPackageNames = process.env[consolePluginOverrideEnvVar].split(',');
+    const pkgNames = process.env[consolePluginOverrideEnvVar]
+      .split(',')
+      .map((name) => (!name.startsWith('@') ? `@console/${name}` : name));
+
     return sortPluginPackages(
       appPackage,
-      pluginPackages.filter((pkg) => pluginPackageNames.includes(pkg.name)),
+      _.uniq([
+        ...((isPluginPackage(appPackage) && [appPackage]) || []),
+        ...pluginPackages.filter((pkg) => pkgNames.includes(pkg.name)),
+      ]),
     );
   }
 


### PR DESCRIPTION
This PR addresses https://github.com/openshift/console/pull/1875#issuecomment-507793333

#### 1) if package scope isn't specified, use `@console`

Following commands are equivalent:

```sh
CONSOLE_PLUGINS=dev-console,metal3-plugin yarn dev
CONSOLE_PLUGINS=@console/dev-console,@console/metal3-plugin yarn dev
```

#### 2) ensure `@console/app` is always in the package list

Following commands are equivalent:

```sh
CONSOLE_PLUGINS=dev-console yarn dev
CONSOLE_PLUGINS=app,dev-console yarn dev
```

@alecmerdler For development without any additional plugins, you can use any of the following:

```sh
CONSOLE_PLUGINS= yarn dev
CONSOLE_PLUGINS=app yarn dev
```
