### PR TITLE
Update admin console nav

### DIFF
--- a/frontend/integration-tests/tests/login.scenario.ts
+++ b/frontend/integration-tests/tests/login.scenario.ts
@@ -48,8 +48,8 @@ describe('Auth test', () => {
     });
 
     it('does not show admin nav items in Catalog to htpasswd user', async() => {
-      await browser.wait(until.visibilityOf(sidenavView.navSectionFor('Catalog')));
-      expect(sidenavView.navSectionFor('Catalog')).not.toContain('OperatorHub');
+      await browser.wait(until.visibilityOf(sidenavView.navSectionFor('Operators')));
+      expect(sidenavView.navSectionFor('Operators')).not.toContain('OperatorHub');
     });
 
     it('does not show admin nav items in Storage to htpasswd user', async() => {

--- a/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/global-installmode.scenario.ts
@@ -44,8 +44,8 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Redis)', ()
     })());
 
     await browser.get(`${appHost}/status/ns/${testName}`);
-    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Catalog')));
-    await sidenavView.clickNavLink(['Catalog', 'OperatorHub']);
+    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Operators')));
+    await sidenavView.clickNavLink(['Operators', 'OperatorHub']);
     await crudView.isLoaded();
   });
 

--- a/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
+++ b/frontend/integration-tests/tests/olm/single-installmode.scenario.ts
@@ -39,8 +39,8 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     })());
 
     await browser.get(`${appHost}/status/ns/${testName}`);
-    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Catalog')));
-    await sidenavView.clickNavLink(['Catalog', 'OperatorHub']);
+    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Operators')));
+    await sidenavView.clickNavLink(['Operators', 'OperatorHub']);
     await crudView.isLoaded();
   });
 

--- a/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
+++ b/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
@@ -42,8 +42,8 @@ describe('Interacting with OperatorHub', () => {
 
   it('displays OperatorHub tile view with expected available Operators', async() => {
     await browser.get(`${appHost}/status/ns/${testName}`);
-    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Catalog')));
-    await sidenavView.clickNavLink(['Catalog', 'OperatorHub']);
+    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Operators')));
+    await sidenavView.clickNavLink(['Operators', 'OperatorHub']);
     await crudView.isLoaded();
 
     expect(catalogPageView.catalogTiles.count()).toBeGreaterThan(0);

--- a/frontend/integration-tests/tests/performance.scenario.ts
+++ b/frontend/integration-tests/tests/performance.scenario.ts
@@ -9,7 +9,7 @@ import * as crudView from '../views/crud.view';
 import * as yamlView from '../views/yaml.view';
 
 const chunkedRoutes = OrderedMap<string, {section: string, name: string}>()
-  .set('operator-management', {section: 'Catalog', name: 'Operator Management'})
+  .set('operator-management', {section: 'Operators', name: 'Operator Management'})
   .set('daemon-set', {section: 'Workloads', name: 'Daemon Sets'})
   .set('deployment', {section: 'Workloads', name: 'Deployments'})
   .set('deployment-config', {section: 'Workloads', name: 'Deployment Configs'})
@@ -30,8 +30,7 @@ const chunkedRoutes = OrderedMap<string, {section: string, name: string}>()
   .set('service-account', {section: 'Administration', name: 'Service Accounts'})
   .set('limit-range', {section: 'Administration', name: 'Limit Ranges'})
   .set('custom-resource-definition', {section: 'Administration', name: 'Custom Resource Definitions'})
-  .set('catalog', {section: 'Catalog', name: 'Developer Catalog'})
-  .set('operator-hub', {section: 'Catalog', name: 'OperatorHub'});
+  .set('operator-hub', {section: 'Operators', name: 'OperatorHub'});
 
 describe('Performance test', () => {
 
@@ -75,8 +74,8 @@ describe('Performance test', () => {
       await browser.get(`${appHost}/k8s/cluster/projects`);
       await browser.executeScript(() => performance.setResourceTimingBufferSize(1000));
       await browser.wait(until.presenceOf(crudView.resourceTitle));
-      // Avoid problems where the Catalog nav section appears where Workloads was at the moment the tests try to click.
-      await browser.wait(until.visibilityOf(sidenavView.navSectionFor('Catalog')));
+      // Avoid problems where the Operators nav section appears where Workloads was at the moment the tests try to click.
+      await browser.wait(until.visibilityOf(sidenavView.navSectionFor('Operators')));
       await sidenavView.clickNavLink([route.section, route.name]);
       await browser.wait(crudView.untilNoLoadersPresent);
 

--- a/frontend/integration-tests/tests/service-catalog/service-binding.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-binding.scenario.ts
@@ -19,7 +19,7 @@ describe('Test for Cluster Service Binding', () => {
   });
 
   it('creates a new binding for new service instance `mysql-persistent`', async() => {
-    await sidenavView.clickNavLink(['Catalog', 'Broker Management']);
+    await sidenavView.clickNavLink(['Service Catalog', 'Broker Management']);
     await crudView.isLoaded();
     await horizontalnavView.clickHorizontalTab('Service Classes');
 

--- a/frontend/integration-tests/tests/service-catalog/service-broker.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-broker.scenario.ts
@@ -17,7 +17,7 @@ describe('Test for Cluster Service Broker', () => {
   });
 
   it('displays `MariaDB` service class for `template-service-broker`', async() => {
-    await sidenavView.clickNavLink(['Catalog', 'Broker Management']);
+    await sidenavView.clickNavLink(['Service Catalog', 'Broker Management']);
     await crudView.isLoaded();
 
     await crudView.rowForName('template-service-broker').element(by.linkText('template-service-broker')).click();

--- a/frontend/integration-tests/tests/service-catalog/service-catalog.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-catalog.scenario.ts
@@ -6,7 +6,7 @@ import * as horizontalnavView from '../../views/horizontal-nav.view';
 import * as crudView from '../../views/crud.view';
 import * as srvCatalogView from '../../views/service-catalog.view';
 
-describe('Test for existence of Catalog nav items', () => {
+describe('Test for existence of Service Catalog nav items', () => {
   beforeAll(async() => {
     browser.get(`${appHost}/status/ns/${testName}`);
     await browser.wait(until.presenceOf($('.pf-c-nav')));
@@ -17,21 +17,21 @@ describe('Test for existence of Catalog nav items', () => {
     checkErrors();
   });
 
-  it('displays `Catalog` nav menu item in sidebar', async() => {
-    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Catalog')));
+  it('displays `Service Catalog` nav menu item in sidebar', async() => {
+    await browser.wait(until.presenceOf(sidenavView.navSectionFor('Service Catalog')));
 
-    expect(sidenavView.navSectionFor('Catalog').isDisplayed()).toBe(true);
+    expect(sidenavView.navSectionFor('Service Catalog').isDisplayed()).toBe(true);
   });
 
   it('displays `template-service-broker`', async() => {
-    await sidenavView.clickNavLink(['Catalog', 'Broker Management']);
+    await sidenavView.clickNavLink(['Service Catalog', 'Broker Management']);
     await crudView.isLoaded();
 
     expect(crudView.rowForName('template-service-broker').isDisplayed()).toBe(true);
   });
 
   it('displays `MariaDB` service class', async() => {
-    await sidenavView.clickNavLink(['Catalog', 'Broker Management']);
+    await sidenavView.clickNavLink(['Service Catalog', 'Broker Management']);
     await horizontalnavView.clickHorizontalTab('Service Classes');
     await crudView.isLoaded();
 
@@ -42,14 +42,14 @@ describe('Test for existence of Catalog nav items', () => {
   });
 
   it('initially displays no service instances', async() => {
-    await sidenavView.clickNavLink(['Catalog', 'Provisioned Services']);
+    await sidenavView.clickNavLink(['Service Catalog', 'Provisioned Services']);
     await crudView.isLoaded();
 
     expect(crudView.emptyState.getText()).toEqual('No Service Instances Found');
   });
 
   it('initially displays no service bindings', async() => {
-    await sidenavView.clickNavLink(['Catalog', 'Provisioned Services']);
+    await sidenavView.clickNavLink(['Service Catalog', 'Provisioned Services']);
     await horizontalnavView.clickHorizontalTab('Service Bindings');
     await crudView.isLoaded();
 

--- a/frontend/integration-tests/tests/service-catalog/service-class.scenario.ts
+++ b/frontend/integration-tests/tests/service-catalog/service-class.scenario.ts
@@ -19,7 +19,7 @@ describe('Test for Cluster Service Class', () => {
   });
 
   it('displays `default` service plan for service class `MariaDB`', async() => {
-    await sidenavView.clickNavLink(['Catalog', 'Broker Management']);
+    await sidenavView.clickNavLink(['Service Catalog', 'Broker Management']);
     await crudView.isLoaded();
     await horizontalnavView.clickHorizontalTab('Service Classes');
 
@@ -42,7 +42,7 @@ describe('Test for Cluster Service Class', () => {
   });
 
   it('creates a new instance for service class `MariaDB`', async() => {
-    await sidenavView.clickNavLink(['Catalog', 'Broker Management']);
+    await sidenavView.clickNavLink(['Service Catalog', 'Broker Management']);
     await crudView.isLoaded();
     await horizontalnavView.clickHorizontalTab('Service Classes');
 

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -89,41 +89,24 @@ const AdminNav = () => (
       <ResourceNSLink resource="events" name="Events" />
     </NavSection>
 
-    <NavSection title="Catalog">
-      <HrefLink href="/catalog" name="Developer Catalog" activePath="/catalog/" />
+    <NavSection title="Operators" required={FLAGS.OPERATOR_LIFECYCLE_MANAGER}>
       <HrefLink
-        href="/provisionedservices"
-        name="Provisioned Services"
-        activePath="/provisionedservices/"
-        startsWith={provisionedServicesStartsWith}
-        required={FLAGS.SERVICE_CATALOG}
-      />
-      <ResourceNSLink
-        model={ClusterServiceVersionModel}
-        resource={ClusterServiceVersionModel.plural}
-        required={[FLAGS.OPERATOR_LIFECYCLE_MANAGER, FLAGS.CAN_LIST_PACKAGE_MANIFEST]}
-        name="Installed Operators"
-      />
-      <Separator required={FLAGS.OPERATOR_LIFECYCLE_MANAGER} />
-      <HrefLink
-        required={[FLAGS.CAN_LIST_PACKAGE_MANIFEST, FLAGS.CAN_LIST_OPERATOR_GROUP, FLAGS.OPERATOR_LIFECYCLE_MANAGER]}
+        required={[FLAGS.CAN_LIST_PACKAGE_MANIFEST, FLAGS.CAN_LIST_OPERATOR_GROUP]}
         href="/operatorhub"
         name="OperatorHub"
         activePath="/operatorhub/"
       />
+      <ResourceNSLink
+        model={ClusterServiceVersionModel}
+        resource={ClusterServiceVersionModel.plural}
+        required={FLAGS.CAN_LIST_PACKAGE_MANIFEST}
+        name="Installed Operators"
+      />
       <HrefLink
         href="/operatormanagement"
         name="Operator Management"
-        required={[FLAGS.OPERATOR_LIFECYCLE_MANAGER]}
         activePath="/operatormanagement/"
         startsWith={operatorManagementStartsWith}
-      />
-      <HrefLink
-        href="/brokermanagement"
-        name="Broker Management"
-        activePath="/brokermanagement/"
-        startsWith={brokerManagementStartsWith}
-        required={FLAGS.SERVICE_CATALOG}
       />
     </NavSection>
 
@@ -164,6 +147,21 @@ const AdminNav = () => (
       <ResourceNSLink resource="buildconfigs" name={BuildConfigModel.labelPlural} />
       <ResourceNSLink resource="builds" name={BuildModel.labelPlural} />
       <ResourceNSLink resource="imagestreams" name={ImageStreamModel.labelPlural} startsWith={imagestreamsStartsWith} />
+    </NavSection>
+
+    <NavSection title="Service Catalog" required={FLAGS.SERVICE_CATALOG}>
+      <HrefLink
+        href="/provisionedservices"
+        name="Provisioned Services"
+        activePath="/provisionedservices/"
+        startsWith={provisionedServicesStartsWith}
+      />
+      <HrefLink
+        href="/brokermanagement"
+        name="Broker Management"
+        activePath="/brokermanagement/"
+        startsWith={brokerManagementStartsWith}
+      />
     </NavSection>
 
     <MonitoringNavSection />

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -187,11 +187,12 @@ export const NavSection = connect(navSectionStateToProps)(
 export type NavSectionTitle =
   | 'Administration'
   | 'Builds'
-  | 'Catalog'
   | 'Compute'
   | 'Home'
   | 'Monitoring'
   | 'Networking'
+  | 'Operators'
+  | 'Service Catalog'
   | 'Storage'
   | 'Workloads';
 


### PR DESCRIPTION
Related to https://jira.coreos.com/browse/CONSOLE-1462

* Create separate sections for Operators and Service Catalog
* Remove Developer Catalog (since it's part of the Developer perspective)

I've left "Operator Management" for now since I don't think we've done everything we need to remove the nave item.

/assign @alecmerdler 
cc @alimobrem @serenamarie125 @christianvogt @sspeiche @tlwu2013 

<img width="1027" alt="OperatorHub · OKD 2019-07-05 12-52-41" src="https://user-images.githubusercontent.com/1167259/60736116-e53a8480-9f23-11e9-9476-43e0c1a3f53b.png">