### PR TITLE
Reset specific PF components that need --pf-global--FontSize--md: 1rem

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -96,6 +96,12 @@ kbd {
   max-width: 100%;
 }
 
+// PF components that calculate their correct height based on --pf-global--FontSize--md: 1rem
+.pf-c-modal-box,
+.pf-c-switch {
+  --pf-global--FontSize--md: 1rem;
+}
+
 .pf-c-page {
   display: block !important;
   position: relative;


### PR DESCRIPTION
... so that their height is calculated correctly.
cc @kyoto 

https://github.com/openshift/console/pull/1894#issuecomment-508370909

<img width="583" alt="Screen Shot 2019-07-05 at 4 47 19 PM" src="https://user-images.githubusercontent.com/1874151/60744741-47f04800-9f45-11e9-9ab3-60f7d1e48339.png">
