### PR TITLE
Query Browser: Ignore all Prometheus internal labels

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -13,7 +13,7 @@ import { PrometheusEndpoint } from '../graphs/helpers';
 import { getPrometheusExpressionBrowserURL } from '../graphs/prometheus-graph';
 import { ActionsMenu, Dropdown, ExternalLink, getURLSearchParams, Kebab, LoadingInline, useSafeFetch } from '../utils';
 import { withFallback } from '../utils/error-boundary';
-import { graphColors, Labels, PrometheusSeries, QueryBrowser } from './query-browser';
+import { graphColors, Labels, omitInternalLabels, PrometheusSeries, QueryBrowser } from './query-browser';
 
 const prometheusFunctions = [
   'abs()',
@@ -319,7 +319,7 @@ export const QueryBrowserPage = withFallback(() => {
   const onDataUpdate = (allQueries: PrometheusSeries[][]) => {
     const newQueries = _.map(allQueries, (querySeries, i) => {
       const allSeries = _.map(querySeries, s => ({
-        labels: _.omit(s.metric, '__name__'),
+        labels: omitInternalLabels(s.metric),
         value: parseFloat(_.last(s.values)[1]),
       }));
       return Object.assign({}, queries[i], {allSeries});

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -40,6 +40,9 @@ export const graphColors = [
   '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf',
 ];
 
+// Takes a Prometheus labels object and removes the internal labels (those beginning with "__")
+export const omitInternalLabels = labels => _.omitBy(labels, (v, k) => _.startsWith(k, '__'));
+
 const NoQueryMessage = () => <div className="text-center text-muted">Enter a query in the box below to explore the metrics gathered for this cluster</div>;
 
 const Error = ({error}) => <Alert isInline className="co-alert" variant="danger" title="An error occurred">{_.get(error, 'json.error', error.message)}</Alert>;
@@ -200,7 +203,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   const graphData: GraphDataPoint[][] = React.useMemo(() => _.flatten(
     _.map(results, (result, responseIndex) => {
       return _.map(result, ({metric, values}) => {
-        const labels = _.omit(metric, '__name__');
+        const labels = omitInternalLabels(metric);
 
         // If filterLabels is specified, ignore all series that don't match
         const isIgnored = filterLabels


### PR DESCRIPTION
We currently just have the internal label `__name__`, but there could be
more added so ignore all internal labels (those beginning with `__`).
See https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels