### PR TITLE
Query Browser: Fix handling of NaN values

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -342,7 +342,7 @@ export const QueryBrowserPage = withFallback(() => {
     const newQueries = _.map(allQueries, (querySeries, i) => {
       const allSeries = _.map(querySeries, s => ({
         labels: omitInternalLabels(s.metric),
-        value: parseFloat(_.last(s.values)[1]),
+        value: _.last(s.values)[1],
       }));
       return Object.assign({}, queries[i], {allSeries});
     });

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -41,7 +41,7 @@ export const graphColors = [
 ];
 
 // Takes a Prometheus labels object and removes the internal labels (those beginning with "__")
-export const omitInternalLabels = labels => _.omitBy(labels, (v, k) => _.startsWith(k, '__'));
+export const omitInternalLabels = (labels: Labels): Labels => _.omitBy(labels, (v, k) => _.startsWith(k, '__'));
 
 const NoQueryMessage = () => <div className="text-center text-muted">Enter a query in the box below to explore the metrics gathered for this cluster</div>;
 
@@ -115,10 +115,13 @@ const Graph: React.FC<GraphProps> = React.memo(({domain, data, onZoom, span}) =>
 });
 
 const formatSeriesValues = (values: PrometheusValue[], samples: number, span: number): GraphDataPoint[] => {
-  const newValues = _.map(values, v => ({
-    x: new Date(v[0] * 1000),
-    y: parseFloat(v[1]),
-  }));
+  const newValues = _.map(values, v => {
+    const y = Number(v[1]);
+    return ({
+      x: new Date(v[0] * 1000),
+      y: Number.isNaN(y) ? null : y,
+    });
+  });
 
   // The data may have missing values, so we fill those gaps with nulls so that the graph correctly shows the
   // missing values as gaps in the line


### PR DESCRIPTION
Convert NaN values to null for graph to prevent errors.
Remove unnecessary parseFloat() for values table.
Add type definition for omitInternalLabels().