### PR TITLE
Allow Inventory items without status groups

### DIFF
--- a/frontend/public/components/dashboard/inventory-card/inventory-item.tsx
+++ b/frontend/public/components/dashboard/inventory-card/inventory-item.tsx
@@ -7,15 +7,7 @@ import { LoadingInline } from '../../utils';
 import { K8sResourceKind, K8sKind } from '../../../module/k8s';
 import { InventoryStatusGroup } from './status-group';
 
-const getPluginStatusGroupIcons = () => {
-  const pluginGroups = {};
-  plugins.registry.getDashboardsInventoryItemGroups().forEach(group => {
-    pluginGroups[group.properties.id] = group.properties.icon;
-  });
-  return pluginGroups;
-};
-
-const statusGroupIcons = {
+const defaultStatusGroupIcons = {
   [InventoryStatusGroup.OK]: (
     <Icon
       type="fa"
@@ -51,13 +43,37 @@ const statusGroupIcons = {
       className="co-inventory-card__status-icon co-inventory-card__status-icon--question"
     />
   ),
-  ...getPluginStatusGroupIcons(),
+};
+
+const getStatusGroupIcons = () => {
+  const groupStatusIcons = {...defaultStatusGroupIcons};
+  plugins.registry.getDashboardsInventoryItemGroups().forEach(group => {
+    if (!groupStatusIcons[group.properties.id]) {
+      groupStatusIcons[group.properties.id] = group.properties.icon;
+    }
+  });
+  return groupStatusIcons;
+};
+
+export const InventoryItem: React.FC<InventoryItemProps> = ({ isLoading, singularTitle, pluralTitle, count, children }) => {
+  const title = count !== 1 ? pluralTitle : singularTitle;
+  return (
+    <div className="co-inventory-card__item">
+      <div className="co-inventory-card__item-title">{isLoading ? title : `${count} ${title}`}</div>
+      {isLoading ? <LoadingInline /> : (
+        <div className="co-inventory-card__item-status">
+          {children}
+        </div>
+      )}
+    </div>
+  );
 };
 
 const Status: React.FC<StatusProps> = React.memo(({ groupID, count, statusIDs, kind, namespace, filterType}) => {
   const statusItems = encodeURIComponent(statusIDs.join(','));
   const namespacePath = namespace ? `ns/${namespace}` : 'all-namespaces';
   const to = filterType && statusItems.length > 0 ? `/k8s/${namespacePath}/${kind.plural}?rowFilter-${filterType}=${statusItems}` : `/k8s/${namespacePath}/${kind.plural}`;
+  const statusGroupIcons = getStatusGroupIcons();
   const groupIcon = statusGroupIcons[groupID] || statusGroupIcons[InventoryStatusGroup.NOT_MAPPED];
   return (
     <div className="co-inventory-card__status">
@@ -69,37 +85,40 @@ const Status: React.FC<StatusProps> = React.memo(({ groupID, count, statusIDs, k
   );
 });
 
-export const InventoryItem: React.FC<InventoryItemProps> = React.memo(({ kind, useAbbr, resources, additionalResources, isLoading, mapper, namespace }) => {
+export const ResourceInventoryItem: React.FC<ResourceInventoryItemProps> = React.memo(({ kind, useAbbr, resources, additionalResources, isLoading, mapper, namespace }) => {
   const groups = mapper(resources, additionalResources);
-  let title: string;
-  if (useAbbr) {
-    title = resources.length !== 1 ? `${kind.abbr}s` : kind.abbr;
-  } else {
-    title = resources.length !== 1 ? kind.labelPlural : kind.label;
-  }
+  const [singularTitle, pluralTitle] = useAbbr ? [kind.abbr, `${kind.abbr}s`] : [kind.label, kind.labelPlural];
   return (
-    <div className="co-inventory-card__item">
-      <div className="co-inventory-card__item-title">{isLoading ? title : `${resources.length} ${title}`}</div>
-      {isLoading ? <LoadingInline /> : (
-        <div className="co-inventory-card__item-status">
-          {Object.keys(groups).filter(key => groups[key].count > 0).map((key, index) => (
-            <Status
-              key={index}
-              kind={kind}
-              namespace={namespace}
-              groupID={key}
-              count={groups[key].count}
-              statusIDs={groups[key].statusIDs}
-              filterType={groups[key].filterType}
-            />
-          ))}
-        </div>
-      )}
-    </div>
+    <InventoryItem
+      isLoading={isLoading}
+      singularTitle={singularTitle}
+      pluralTitle={pluralTitle}
+      count={resources.length}
+    >
+      {Object.keys(groups).filter(key => groups[key].count > 0).map(key => (
+        <Status
+          key={key}
+          kind={kind}
+          namespace={namespace}
+          groupID={key}
+          count={groups[key].count}
+          statusIDs={groups[key].statusIDs}
+          filterType={groups[key].filterType}
+        />
+      ))}
+    </InventoryItem>
   );
 });
 
 export type StatusGroupMapper = (resources: K8sResourceKind[], additionalResources?: {[key: string]: K8sResourceKind[]}) => {[key in InventoryStatusGroup | string]: {filterType?: string, statusIDs: string[], count: number}};
+
+type InventoryItemProps = {
+  isLoading: boolean,
+  singularTitle: string,
+  pluralTitle: string,
+  count: number,
+  children?: React.ReactChild[],
+};
 
 type StatusProps = {
   groupID: InventoryStatusGroup | string;
@@ -110,7 +129,7 @@ type StatusProps = {
   filterType?: string;
 }
 
-type InventoryItemProps = {
+type ResourceInventoryItemProps = {
   resources: K8sResourceKind[];
   additionalResources?: {[key: string]: K8sResourceKind[]};
   mapper: StatusGroupMapper;

--- a/frontend/public/components/dashboards-page/overview-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/inventory-card.tsx
@@ -8,7 +8,7 @@ import {
   DashboardCardHeader,
   DashboardCardTitle,
 } from '../../dashboard/dashboard-card';
-import { InventoryItem } from '../../dashboard/inventory-card/inventory-item';
+import { ResourceInventoryItem } from '../../dashboard/inventory-card/inventory-item';
 import { DashboardItemProps, withDashboardResources } from '../with-dashboard-resources';
 import { PodModel, NodeModel, PersistentVolumeClaimModel } from '../../../models';
 import { K8sResourceKind, PodKind } from '../../../module/k8s';
@@ -78,9 +78,9 @@ const InventoryCard_: React.FC<DashboardItemProps> = ({ watchK8sResource, stopWa
         <DashboardCardTitle>Cluster inventory</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
-        <InventoryItem isLoading={!nodesLoaded} kind={NodeModel} resources={nodesData} mapper={getNodeStatusGroups} />
-        <InventoryItem isLoading={!podsLoaded} kind={PodModel} resources={podsData} mapper={getPodStatusGroups} />
-        <InventoryItem isLoading={!pvcsLoaded} kind={PersistentVolumeClaimModel} useAbbr resources={pvcsData} mapper={getPVCStatusGroups} />
+        <ResourceInventoryItem isLoading={!nodesLoaded} kind={NodeModel} resources={nodesData} mapper={getNodeStatusGroups} />
+        <ResourceInventoryItem isLoading={!podsLoaded} kind={PodModel} resources={podsData} mapper={getPodStatusGroups} />
+        <ResourceInventoryItem isLoading={!pvcsLoaded} kind={PersistentVolumeClaimModel} useAbbr resources={pvcsData} mapper={getPVCStatusGroups} />
         {pluginItems.map((item, index) => {
           const resource = _.get(resources, uniqueResource(item.properties.resource, index).prop);
           const resourceLoaded = _.get(resource, 'loaded');
@@ -98,7 +98,7 @@ const InventoryCard_: React.FC<DashboardItemProps> = ({ watchK8sResource, stopWa
           Object.keys(additionalResources).forEach(key => additionalResourcesData[key] = _.get(additionalResources[key], 'data', []));
 
           return (
-            <InventoryItem
+            <ResourceInventoryItem
               key={index}
               isLoading={!resourceLoaded || !additionalResourcesLoaded}
               kind={item.properties.model}


### PR DESCRIPTION
Baremetal dashboard has a case where inventory item is not a k8s resource nor it does have status. `InventoryItem` is now generic item which is not tied to k8s resource and does not necessarily has statuses. New `ResourceInventoryItem` component has the same functionality as `InventoryItem` used to have before this change.

@honza let me know if this change satisfies your needs