### PR TITLE
Kubevirt: Fix vm tempalte breadcrumbs

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
@@ -8,6 +8,7 @@ import { TemplateModel } from '@console/internal/models';
 import { VMDisksFirehose } from '../vm-disks';
 import { VMTemplateDetailsConnected } from './vm-template-details';
 import { VMNics } from '../vm-nics';
+import { labelPlural } from './vm-template';
 
 export const VMTemplateDetailsPage: React.FC<VMTemplateDetailsPageProps> = (props) => {
   const nicsPage = {
@@ -31,6 +32,11 @@ export const VMTemplateDetailsPage: React.FC<VMTemplateDetailsPageProps> = (prop
 
   const menuActions = undefined; // TODO(mlibra): menuActions
 
+  const breadcrumbsForVMTemplatePage = (match: any) => () => [
+    { name: labelPlural, path: `/k8s/ns/${match.params.ns || 'default'}/vmtemplates` },
+    { name: `${match.params.name} details`, path: `${match.url}` },
+  ];
+
   return (
     <DetailsPage
       {...props}
@@ -40,6 +46,7 @@ export const VMTemplateDetailsPage: React.FC<VMTemplateDetailsPageProps> = (prop
       namespace={props.match.params.ns}
       menuActions={menuActions}
       pages={pages}
+      breadcrumbsFor={breadcrumbsForVMTemplatePage(props.match)}
     />
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
@@ -8,7 +8,7 @@ import { TemplateModel } from '@console/internal/models';
 import { VMDisksFirehose } from '../vm-disks';
 import { VMTemplateDetailsConnected } from './vm-template-details';
 import { VMNics } from '../vm-nics';
-import { labelPlural } from './vm-template';
+import { VM_TEMPLATE_LABEL_PLURAL } from '../../constants/vm-templates';
 
 export const VMTemplateDetailsPage: React.FC<VMTemplateDetailsPageProps> = (props) => {
   const nicsPage = {
@@ -33,7 +33,7 @@ export const VMTemplateDetailsPage: React.FC<VMTemplateDetailsPageProps> = (prop
   const menuActions = undefined; // TODO(mlibra): menuActions
 
   const breadcrumbsForVMTemplatePage = (match: any) => () => [
-    { name: labelPlural, path: `/k8s/ns/${match.params.ns || 'default'}/vmtemplates` },
+    { name: VM_TEMPLATE_LABEL_PLURAL, path: `/k8s/ns/${match.params.ns || 'default'}/vmtemplates` },
     { name: `${match.params.name} Details`, path: `${match.url}` },
   ];
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
@@ -34,7 +34,7 @@ export const VMTemplateDetailsPage: React.FC<VMTemplateDetailsPageProps> = (prop
 
   const breadcrumbsForVMTemplatePage = (match: any) => () => [
     { name: labelPlural, path: `/k8s/ns/${match.params.ns || 'default'}/vmtemplates` },
-    { name: `${match.params.name} details`, path: `${match.url}` },
+    { name: `${match.params.name} Details`, path: `${match.url}` },
   ];
 
   return (

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -18,6 +18,7 @@ import { TemplateKind } from '@console/internal/module/k8s';
 import { match } from 'react-router';
 import { dimensifyHeader, dimensifyRow } from '../../utils/table';
 import { VMTemplateLink } from './vm-template-link';
+import { VM_TEMPLATE_LABEL_PLURAL } from '../../constants/vm-templates';
 
 export const menuActions = Kebab.factory.common;
 
@@ -25,7 +26,6 @@ const { kind } = TemplateModel;
 const selector = {
   matchLabels: { [TEMPLATE_TYPE_LABEL]: 'vm' },
 };
-const labelPlural = 'Virtual Machine Templates';
 
 const tableColumnClass = classNames('col-lg-2', 'col-sm-4', 'col-xs-4');
 const tableColumnClassHiddenOnSmall = classNames('col-lg-2', 'hidden-sm', 'hidden-xs');
@@ -117,7 +117,7 @@ const VirtualMachineTemplates: React.FC<React.ComponentProps<typeof Table>> = (p
   return (
     <Table
       {...props}
-      aria-label={labelPlural}
+      aria-label={VM_TEMPLATE_LABEL_PLURAL}
       Header={VMTemplateTableHeader}
       Row={VMTemplateTableRow}
     />
@@ -136,7 +136,7 @@ const VirtualMachineTemplatesPage: React.FC<
 > = (props) => (
   <ListPage
     {...props}
-    title={labelPlural}
+    title={VM_TEMPLATE_LABEL_PLURAL}
     ListComponent={VirtualMachineTemplates}
     kind={kind}
     selector={selector}
@@ -156,4 +156,4 @@ type VirtualMachineTemplatesPageProps = {
   match: match<{ ns?: string }>;
 };
 
-export { labelPlural, VirtualMachineTemplatesPage };
+export { VirtualMachineTemplatesPage };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -156,4 +156,4 @@ type VirtualMachineTemplatesPageProps = {
   match: match<{ ns?: string }>;
 };
 
-export { VirtualMachineTemplatesPage };
+export { labelPlural, VirtualMachineTemplatesPage };

--- a/frontend/packages/kubevirt-plugin/src/constants/vm-templates/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm-templates/constants.ts
@@ -1,0 +1,1 @@
+export const VM_TEMPLATE_LABEL_PLURAL = 'Virtual Machine Templates';

--- a/frontend/packages/kubevirt-plugin/src/constants/vm-templates/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm-templates/index.ts
@@ -1,0 +1,1 @@
+export * from './constants';


### PR DESCRIPTION
Follow-up to #1843, fix breadcrumbs label and link.

Ref:
https://github.com/openshift/console/pull/1843#issuecomment-508179319

Before (link to vm template list is broken):
![OKD(2)](https://user-images.githubusercontent.com/2181522/60809197-c68df500-a192-11e9-94c9-d82ebb495c48.png)

After:
![OKD(1)](https://user-images.githubusercontent.com/2181522/60809204-c8f04f00-a192-11e9-879c-3f3b1e98dd69.png)

