### PR TITLE
Alertmanager Configuration

### DIFF
--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -5,6 +5,7 @@ import * as crudView from '../views/crud.view';
 import * as monitoringView from '../views/monitoring.view';
 import * as namespaceView from '../views/namespace.view';
 import * as sidenavView from '../views/sidenav.view';
+import * as horizontalnavView from '../views/horizontal-nav.view';
 
 const testAlertName = 'Watchdog';
 
@@ -23,9 +24,9 @@ describe('Monitoring: Alerts', () => {
   });
 
   it('displays the Alerts list page', async() => {
-    await sidenavView.clickNavLink(['Monitoring', 'Alerts']);
+    await sidenavView.clickNavLink(['Monitoring', 'Alerting']);
     await crudView.isLoaded();
-    expect(monitoringView.listPageHeading.getText()).toContain('Alerts');
+    expect(monitoringView.listPageHeading.getText()).toContain('Alerting');
   });
 
   it('does not have a namespace dropdown', async() => {
@@ -105,9 +106,10 @@ describe('Monitoring: Silences', () => {
   });
 
   it('displays the Silences list page', async() => {
-    await sidenavView.clickNavLink(['Monitoring', 'Silences']);
+    await sidenavView.clickNavLink(['Monitoring', 'Alerting']);
     await crudView.isLoaded();
-    expect(monitoringView.listPageHeading.getText()).toContain('Silences');
+    await horizontalnavView.clickHorizontalTab('Silences');
+    expect(monitoringView.helpText.getText()).toContain('Silences temporarily mute alerts based on a set of conditions');
   });
 
   it('does not have a namespace dropdown', async() => {
@@ -130,8 +132,9 @@ describe('Monitoring: Silences', () => {
   });
 
   it('filters Silences by name', async() => {
-    await sidenavView.clickNavLink(['Monitoring', 'Silences']);
+    await sidenavView.clickNavLink(['Monitoring', 'Alerting']);
     await crudView.isLoaded();
+    await horizontalnavView.clickHorizontalTab('Silences');
     await monitoringView.wait(until.elementToBeClickable(crudView.nameFilter));
     await crudView.nameFilter.sendKeys(testAlertName);
     expect(monitoringView.firstListLinkById('silence-resource-link').getText()).toContain(testAlertName);
@@ -159,8 +162,9 @@ describe('Monitoring: Silences', () => {
   });
 
   it('expires the Silence', async() => {
-    await sidenavView.clickNavLink(['Monitoring', 'Silences']);
+    await sidenavView.clickNavLink(['Monitoring', 'Alerting']);
     await crudView.isLoaded();
+    await horizontalnavView.clickHorizontalTab('Silences');
     await crudView.nameFilter.sendKeys(testAlertName);
     const row = crudView.rowForName(testAlertName);
     await monitoringView.wait(until.presenceOf(row));
@@ -168,5 +172,27 @@ describe('Monitoring: Silences', () => {
     await monitoringView.wait(until.elementToBeClickable(monitoringView.modalConfirmButton));
     await monitoringView.modalConfirmButton.click();
     await monitoringView.wait(until.not(until.presenceOf(row)));
+  });
+});
+
+describe('Monitoring: YAML', () => {
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+
+  it('displays the YAML page', async() => {
+    await sidenavView.clickNavLink(['Monitoring', 'Alerting']);
+    await crudView.isLoaded();
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await crudView.isLoaded();
+    expect(monitoringView.alertManagerYamlForm.isPresent()).toBe(true);
+  });
+
+  it('saves alert-manager.yaml', async() => {
+    expect(monitoringView.successAlert.isPresent()).toBe(false);
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+    expect(monitoringView.successAlert.isPresent()).toBe(true);
   });
 });

--- a/frontend/integration-tests/views/monitoring.view.ts
+++ b/frontend/integration-tests/views/monitoring.view.ts
@@ -27,3 +27,8 @@ export const saveButton = $('button[type=submit]');
 
 // Modal
 export const modalConfirmButton = $('#confirm-action');
+
+// YAML form
+export const alertManagerYamlForm = $('.co-alert-manager-yaml__form');
+export const successAlert = $('.pf-m-success');
+export const helpText = $('.co-help-text');

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -197,7 +197,11 @@ const AppContents = connect((state: RootState) => ({
 
           <LazyRoute path="/k8s/ns/:ns/persistentvolumeclaims/~new/form" exact kind="PersistentVolumeClaim" loader={() => import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(m => m.CreatePVC)} />
 
+          <LazyRoute path="/monitoring/alerts" exact loader={() => import('./monitoring' /* webpackChunkName: "monitoring" */).then(m => m.MonitoringUI)} />
+          <LazyRoute path="/monitoring/silences" exact loader={() => import('./monitoring' /* webpackChunkName: "monitoring" */).then(m => m.MonitoringUI)} />
+          <LazyRoute path="/monitoring/alertmanageryaml" exact loader={() => import('./monitoring' /* webpackChunkName: "monitoring" */).then(m => m.MonitoringUI)} />
           <LazyRoute path="/monitoring" loader={() => import('./monitoring' /* webpackChunkName: "monitoring" */).then(m => m.MonitoringUI)} />
+
           <LazyRoute path="/settings/idp/github" exact loader={() => import('./cluster-settings/github-idp-form' /* webpackChunkName: "github-idp-form" */).then(m => m.AddGitHubPage)} />
           <LazyRoute path="/settings/idp/gitlab" exact loader={() => import('./cluster-settings/gitlab-idp-form' /* webpackChunkName: "gitlab-idp-form" */).then(m => m.AddGitLabPage)} />
           <LazyRoute path="/settings/idp/google" exact loader={() => import('./cluster-settings/google-idp-form' /* webpackChunkName: "google-idp-form" */).then(m => m.AddGooglePage)} />

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -138,3 +138,15 @@
   padding: 10px;
   width: 100%;
 }
+
+.co-alert-manager-yaml__explanation {
+  margin-bottom: 0;
+}
+
+.co-alert-manager-yaml__form-entry-wrapper {
+  position: relative;
+}
+
+.co-alert-manager-yaml__form co-file-dropzone__textarea {
+  min-height: 400px;
+}

--- a/frontend/public/components/monitoring/alert-manager-yaml-editor.tsx
+++ b/frontend/public/components/monitoring/alert-manager-yaml-editor.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+
+import {Base64} from 'js-base64';
+import {k8sPatch, K8sResourceKind} from '../../module/k8s';
+import {SecretModel} from '../../models';
+import {ButtonBar, history, LoadingBox, StatusBox} from '../utils';
+import {AsyncComponent} from '../utils/async';
+
+const DroppableFileInput = (props) => <AsyncComponent loader={() => import('../utils/file-input').then(c => c.DroppableFileInput)} {...props} />;
+
+const AlertManagerYAMLEditor: React.FC<AlertManagerYAMLEditorProps> = ({obj, onCancel=history.goBack}) => {
+  const secret:K8sResourceKind = obj;
+  const alertManagerYaml = _.get(secret, ['data', 'alertmanager.yaml']);
+  const initErrorMsg = _.isEmpty(alertManagerYaml) ? 'Error: alertmanager.yaml not found in Secret "alertmanager-main", in namespace "openshift-monitoring"' : null;
+
+  const [errorMsg, setErrorMsg] = React.useState(initErrorMsg);
+  const [successMsg, setSuccessMsg] = React.useState();
+  const [inProgress, setInProgress] = React.useState(false);
+  const [yamlStringData, setYamlStringData] = React.useState(!_.isEmpty(alertManagerYaml) ? Base64.decode(alertManagerYaml): '');
+
+  const save = e => {
+    e.preventDefault();
+    setInProgress(true);
+    const patch = [{ op: 'replace', path: '/data/alertmanager.yaml', value:  Base64.encode(yamlStringData)}];
+    k8sPatch(SecretModel, secret, patch)
+      .then(newSecret => {
+        setSuccessMsg(`${newSecret.metadata.name} has been updated to version ${newSecret.metadata.resourceVersion}`);
+        setErrorMsg('');
+        setInProgress(false);
+      }, err => {
+        setErrorMsg(err.message);
+        setSuccessMsg('');
+        setInProgress(false);
+      });
+  };
+
+  return <div className="co-m-pane__body">
+    <form
+      className="co-m-pane__body-group co-alert-manager-yaml-form co-m-pane__form"
+      onSubmit={save}
+    >
+      <p className="co-alert-manager-yaml__explanation">
+        Update this YAML to configure Routes, Receivers, Groupings and other Alert Manager settings
+      </p>
+      {!_.isEmpty(yamlStringData) && <div className="co-alert-manager-yaml__form-entry-wrapper">
+        <div className="co-alert-manager-yaml__form">
+          <div className="form-group">
+            <DroppableFileInput
+              onChange={setYamlStringData}
+              inputFileData={yamlStringData}
+              inputFieldHelpText="Drag and drop file with your value here or browse to upload it." />
+          </div>
+        </div>
+      </div>
+      }
+      <ButtonBar errorMessage={errorMsg} successMessage={successMsg} inProgress={inProgress}>
+        {!_.isEmpty(yamlStringData) && <button type="submit" className="btn btn-primary" id="save-changes">
+          Save
+        </button> }
+        <button type="button" className="btn btn-default" id="cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </ButtonBar>
+    </form>
+  </div>;
+};
+
+export const AlertManagerYAMLEditorWrapper: React.FC<AlertManagerYAMLEditorWrapperProps> = React.memo(({obj, ...props}) => {
+  const [inProgress, setInProgress] = React.useState(true);
+
+  React.useEffect(() => {
+    if (inProgress && !_.isEmpty(obj.data)) {
+      setInProgress(false);
+    }
+  }, [inProgress, obj.data]);
+
+  if (inProgress) {
+    return <LoadingBox />;
+  }
+
+  return <StatusBox {...obj}>
+    <AlertManagerYAMLEditor {...props} obj={obj.data} />
+  </StatusBox>;
+});
+
+type AlertManagerYAMLEditorWrapperProps = {
+  obj?: {
+    data?: K8sResourceKind;
+    [key: string]: any;
+  };
+};
+
+type AlertManagerYAMLEditorProps = {
+  obj?: K8sResourceKind;
+  onCancel?: () => void;
+};

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -53,7 +53,7 @@ const rolesStartsWith = ['roles', 'clusterroles'];
 const rolebindingsStartsWith = ['rolebindings', 'clusterrolebindings'];
 const quotaStartsWith = ['resourcequotas', 'clusterresourcequotas'];
 const imagestreamsStartsWith = ['imagestreams', 'imagestreamtags'];
-const monitoringAlertsStartsWith = ['monitoring/alerts', 'monitoring/alertrules'];
+const monitoringAlertsStartsWith = ['monitoring/alerts', 'monitoring/alertrules', 'monitoring/silences', 'monitoring/alertmanageryaml'];
 const clusterSettingsStartsWith = ['settings/cluster', 'settings/idp', 'config.openshift.io'];
 const apiExplorerStartsWith = ['api-explorer', 'api-resource'];
 
@@ -71,8 +71,7 @@ const MonitoringNavSection_ = ({grafanaURL, canAccess, kibanaURL, prometheusURL}
   const showGrafana = canAccess && !!grafanaURL;
   return showAlerts || showSilences || showPrometheus || showGrafana || kibanaURL
     ? <NavSection title="Monitoring">
-      {showAlerts && <HrefLink href="/monitoring/alerts" name="Alerts" startsWith={monitoringAlertsStartsWith} />}
-      {showSilences && <HrefLink href="/monitoring/silences" name="Silences" />}
+      {showAlerts && <HrefLink href="/monitoring/alerts" name="Alerting" startsWith={monitoringAlertsStartsWith} />}
       {showAlerts && <HrefLink href="/monitoring/query-browser" name="Query Browser" />}
       {showPrometheus && <ExternalLink href={prometheusURL} name="Metrics" />}
       {showGrafana && <ExternalLink href={grafanaURL} name="Dashboards" />}

--- a/frontend/public/components/utils/button-bar.jsx
+++ b/frontend/public/components/utils/button-bar.jsx
@@ -22,13 +22,15 @@ const ErrorMessage = ({message}) => (
   </Alert>
 );
 const InfoMessage = ({message}) => <Alert isInline className="co-alert" variant="info" title={message} />;
+const SuccessMessage = ({message}) => <Alert isInline className="co-alert" variant="success" title={message} />;
 
 // NOTE: DO NOT use <a> elements within a ButtonBar.
 // They don't support the disabled attribute, and therefore
 // can't be disabled during a pending promise/request.
-/** @type {React.SFC<{children: any, className?: string, errorMessage?: string, infoMessage?: string, inProgress: boolean}}>} */
-export const ButtonBar = ({children, className, errorMessage, infoMessage, inProgress}) => {
+/** @type {React.SFC<{children: any, className?: string, errorMessage?: string, infoMessage?: string, successMessage?: string, inProgress: boolean}}>} */
+export const ButtonBar = ({children, className, errorMessage, infoMessage, successMessage, inProgress}) => {
   return <div className={classNames(className, 'co-m-btn-bar')}>
+    {successMessage && <SuccessMessage message={successMessage} />}
     {errorMessage && <ErrorMessage message={errorMessage} />}
     {injectDisabled(children, inProgress)}
     {inProgress && <LoadingInline />}
@@ -38,6 +40,7 @@ export const ButtonBar = ({children, className, errorMessage, infoMessage, inPro
 
 ButtonBar.propTypes = {
   children: PropTypes.node.isRequired,
+  successMessage: PropTypes.string,
   errorMessage: PropTypes.string,
   infoMessage: PropTypes.string,
   inProgress: PropTypes.bool.isRequired,


### PR DESCRIPTION
TODO:
- [X] Update Monitoring Alerts & Silences integration tests, add YAML tests

[Design Doc](http://openshift.github.io/openshift-origin-design/web-console/monitoring/alertmanager-config/alertmanager-config) 

**Initial implementation of Monitoring > Alerting**
https://jira.coreos.com/browse/CONSOLE-1577

**Demo at:**
https://console-openshift-console.apps.taylorseven.devcluster.openshift.com 
_IM me for username/password_

**Move 'Alerts' and 'Silences' from nav menu to Alerting page tabs**
![image](https://user-images.githubusercontent.com/12733153/60836901-d3abe380-a194-11e9-8044-4e3f5c878459.png)

**Implement YAML tab**
![image](https://user-images.githubusercontent.com/12733153/60836974-0e158080-a195-11e9-84f9-f9a625434a59.png)

