### PR TITLE
Bug 1727772:  Fix layout bugs with DownloadButton component

### DIFF
--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -307,17 +307,13 @@ class ReportData extends React.Component<ReportDataProps, ReportDataState> {
           applySort={(sb, func, ob) => this.applySort(sb, func, ob)} />;
       }
     }
-    const name = _.get(obj, ['metadata', 'name']);
     const format = 'csv';
     const downloadURL = dataURL(obj, format);
 
-    return <div>
-      <div className="co-m-pane__body">
-        <SectionHeading text="Usage Report">
-          <DownloadButton className="pull-right" url={downloadURL} filename={`${name}.${format}`} />
-        </SectionHeading>
-        { dataElem }
-      </div>
+    return <div className="co-m-pane__body">
+      <SectionHeading text="Usage Report" />
+      <DownloadButton url={downloadURL} />
+      { dataElem }
     </div>;
   }
 }

--- a/frontend/public/components/utils/download-button.tsx
+++ b/frontend/public/components/utils/download-button.tsx
@@ -22,23 +22,12 @@ export const DownloadButton: React.FC<DownloadButtonProps> = (props) => {
       .then(() => setInFlight(false));
   };
 
-  const { className, filename } = props;
-  const spanStyle = {
-    position: 'absolute' as 'absolute',
-    left: 0,
-  };
-  // The position styling and always-hidden filename are so the button doesn't resize when its content changes.
-  return <div className={className}>
+  return <React.Fragment>
     <button className="btn btn-primary" style={{marginBottom: 10}} disabled={inFlight} type="button" onClick={() => download()}>
-      <i className="fa fa-fw fa-download" />&nbsp;Download
-      <span style={{position: 'relative'}}>
-        { inFlight && <span style={spanStyle}>ing...</span> }
-        <span style={Object.assign({}, spanStyle, {visibility: inFlight ? 'hidden' : 'visible'})}>&nbsp;{filename}</span>
-      </span>
-      <span style={{visibility: 'hidden'}}>&nbsp;{filename}</span>
+      <i className="fa fa-fw fa-download" aria-hidden="true" />&nbsp;Download{inFlight && <React.Fragment>ing...</React.Fragment>}
     </button>
-    { error && <Alert isInline className="co-alert co-break-word" variant="danger" title="An error occurred">{error.toString()}</Alert> }
-  </div>;
+    { error && <Alert isInline className="co-alert co-break-word" variant="danger" title={error.toString()} /> }
+  </React.Fragment>;
 };
 
 export type DownloadButtonProps = {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1727772

After discussing it with @spadgett, we determined including the filename in the button isn't really necessary, can be problematic with long filenames, and we can avoid the bug entirely by removing it.  

Additionally, this PR addresses a couple of other issues:
* Error text is too big
* Placing `<DownloadButton>` inside `<SectionHeading>` could result in an undesirable layout if error message is long.  By moving `<DownloadButton>` below `<SectionHeading>`, the error message has room to grow, and the primary action is in a consistent location with list view pages.  Further, this provides flexibility in where `<DownloadButton>` can be used because it makes no assumptions about its parent.

Before:
Button is wide, but label can be short.
![csqTnagJit](https://user-images.githubusercontent.com/895728/60843733-7a987b80-a1a5-11e9-860d-42650b9b29b8.gif)
Error text is too big and layout could be problematic.
![8D0mhqVP53](https://user-images.githubusercontent.com/895728/60843782-9734b380-a1a5-11e9-8d22-f08189f4b14e.gif)

After:
Button gets wider, but feels more natural
![W27X0e0L9x](https://user-images.githubusercontent.com/895728/60843811-ab78b080-a1a5-11e9-92de-18bf351f6e4c.gif)
Error message is correct font size has plenty of room to grow if needed
![whVhuF8n5y](https://user-images.githubusercontent.com/895728/60843847-c21f0780-a1a5-11e9-967f-80962ee12436.gif)


