### PR TITLE
Kubevirt: vm template: create wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -23,6 +23,7 @@ import { TemplateKind } from '@console/internal/module/k8s';
 import { match } from 'react-router';
 import { dimensifyHeader, dimensifyRow } from '../../utils/table';
 import { VMTemplateLink } from './vm-template-link';
+import { openCreateVmWizard } from '../modals';
 import { VM_TEMPLATE_LABEL_PLURAL } from '../../constants/vm-templates';
 
 const vmTemplateEditAction = (kind, obj) => ({
@@ -141,9 +142,11 @@ const VirtualMachineTemplates: React.FC<React.ComponentProps<typeof Table>> = (p
 
 const getCreateProps = (namespace: string) => ({
   items: {
+    wizard: 'Create with Wizard',
     yaml: 'Create from YAML',
   },
   createLink: () => `/k8s/ns/${namespace || 'default'}/vmtemplates/~new/`,
+  action: (itemName) => (itemName === 'wizard' ? () => openCreateVmWizard(namespace, true) : null),
 });
 
 const VirtualMachineTemplatesPage: React.FC<


### PR DESCRIPTION
Depends on: https://github.com/openshift/console/pull/1822

vm/vm-template wizard is integrated in #1822, this PR add that wizard to the action menu of vm-templates, the `true` in `openCreateVmWizard(namespace, true)` indecate vm-template wizard.

![OKD](https://user-images.githubusercontent.com/2181522/60866217-76657000-a230-11e9-834c-533523c1c4dc.png)

![Peek 2019-07-09 13-21](https://user-images.githubusercontent.com/2181522/60880583-999e1880-a24c-11e9-93ac-9fb4593b44f0.gif)

![OKD(1)](https://user-images.githubusercontent.com/2181522/60866229-7b2a2400-a230-11e9-8823-b2a820736485.png)

