### PR TITLE
Kubevirt: vm template details: Fix base template link and label

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
@@ -7,8 +7,8 @@ import { TemplateModel } from '@console/internal/models';
 import { TemplateKind } from '@console/internal/module/k8s';
 
 export const VMTemplateLink: React.FC<VMTemplateLinkProps> = ({ template }) => {
-  const name = getName(template);
-  const namespace = getNamespace(template);
+  const name = template.name || getName(template);
+  const namespace = template.namespace || getNamespace(template);
 
   return (
     <>
@@ -25,5 +25,5 @@ export const VMTemplateLink: React.FC<VMTemplateLinkProps> = ({ template }) => {
 };
 
 type VMTemplateLinkProps = {
-  template: TemplateKind;
+  template: TemplateKind & { name: string, namespace: string };
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
@@ -25,5 +25,5 @@ export const VMTemplateLink: React.FC<VMTemplateLinkProps> = ({ template }) => {
 };
 
 type VMTemplateLinkProps = {
-  template: TemplateKind & { name?: string, namespace?: string };
+  template: TemplateKind & { name?: string; namespace?: string };
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
@@ -7,8 +7,8 @@ import { TemplateModel } from '@console/internal/models';
 import { TemplateKind } from '@console/internal/module/k8s';
 
 export const VMTemplateLink: React.FC<VMTemplateLinkProps> = ({ template }) => {
-  const name = template.name || getName(template);
-  const namespace = template.namespace || getNamespace(template);
+  const name = (template && template.name) || getName(template);
+  const namespace = (template && template.namespace) || getNamespace(template);
 
   return (
     <>
@@ -25,5 +25,5 @@ export const VMTemplateLink: React.FC<VMTemplateLinkProps> = ({ template }) => {
 };
 
 type VMTemplateLinkProps = {
-  template: TemplateKind & { name: string, namespace: string };
+  template: TemplateKind & { name?: string, namespace?: string };
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-link.tsx
@@ -7,8 +7,8 @@ import { TemplateModel } from '@console/internal/models';
 import { TemplateKind } from '@console/internal/module/k8s';
 
 export const VMTemplateLink: React.FC<VMTemplateLinkProps> = ({ template }) => {
-  const name = (template && template.name) || getName(template);
-  const namespace = (template && template.namespace) || getNamespace(template);
+  const name = template && (template.name || getName(template));
+  const namespace = template && (template.namespace || getNamespace(template));
 
   return (
     <>


### PR DESCRIPTION
In `VMTemplateLink` the `template` prop may not be a `TemplateKind` , if called for `base template`  it may be an object with fields `name` and `namespace`.

Before:
![OKD(1)](https://user-images.githubusercontent.com/2181522/60885843-349cef80-a259-11e9-86c3-3dc010d1dde7.png)

After:
![OKD](https://user-images.githubusercontent.com/2181522/60885860-3cf52a80-a259-11e9-8ef6-6e5eea6979be.png)

