### PR TITLE
Query Browser: Convert results list into table

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -1,7 +1,3 @@
-.group__body--query-browser {
-  padding-top: 20px;
-}
-
 .query-browser__clear-icon {
   color: $color-pf-black-600;
   font-size: 18px;
@@ -16,14 +12,17 @@
 }
 
 .query-browser__expand-button {
+  border: none;
+  height: 30px;
   padding: 0;
-  width: 38px;
+  width: 30px;
 }
 
 .query-browser__expand-icon {
   color: $color-pf-black-600;
   font-size: 30px;
   font-weight: 600;
+  vertical-align: middle;
 }
 
 .query-browser__controls {
@@ -31,7 +30,12 @@
   flex-wrap: wrap-reverse;
   justify-content: space-between;
   margin-bottom: 15px;
+  padding: 0 20px;
   width: 100%;
+
+  &--graph {
+    padding: 0;
+  }
 }
 
 .query-browser__controls--left {
@@ -67,31 +71,28 @@
   }
 }
 
-.query-browser-metric__labels {
-  word-break: break-word;
-}
-
-.query-browser-metric__wrapper {
-  display: flex;
-}
-
 .query-browser__query {
+  margin-left: 10px;
+  margin-right: 15px;
   width: 100%;
+}
+
+.query-browser__query-controls {
+  align-items: center;
+  border: solid $color-grey-background-border;
+  border-width: 1px 0;
+  display: flex;
+  padding: 10px 20px 10px 30px;
 }
 
 .query-browser__query-input {
   resize: vertical;
 }
 
-.query-browser__query-switch {
-  margin-right: 15px;
-}
-
 .query-browser__series-btn {
   border: none;
   height: 20px;
-  margin: 2px 12px 2px 5px;
-  min-width: 20px;
+  padding: 5px;
   width: 20px;
   &--disabled {
     border: 1px solid #888;
@@ -110,6 +111,23 @@
 
 .query-browser__span-text {
   max-width: 87px;
+}
+
+.query-browser__table {
+  border-left: 3px solid transparent;
+  margin-bottom: 25px;
+
+  &--expanded {
+    border-left-color: var(--pf-global--active-color--100);
+  }
+
+  tr > :first-child {
+    width: 40px;
+  }
+}
+
+.query-browser__table-cell {
+  padding-right: 0;
 }
 
 .query-browser__wrapper {

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -241,7 +241,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   }
 
   return <div className="query-browser__wrapper">
-    <div className="query-browser__controls">
+    <div className="query-browser__controls query-browser__controls--graph">
       <div className="query-browser__controls--left">
         <SpanControls defaultSpanText={defaultSpanText} onChange={onSpanChange} span={span} />
         <div className="query-browser__loading">


### PR DESCRIPTION
Display the query results in a table with one column for each label plus
a column for the series value.
Allow sorting the table by any column.
Use PatternFly's `Table` components.
Style changes to better match mocks.

![screenshot](https://user-images.githubusercontent.com/460802/60896626-a305a000-a2a1-11e9-80dc-e26fdef6dd39.png)
