### PR TITLE
shared: move lookup utils from kubevirt-plugin

### DIFF
--- a/frontend/packages/console-shared/src/index.ts
+++ b/frontend/packages/console-shared/src/index.ts
@@ -2,3 +2,4 @@ export * from './components';
 export * from './constants';
 export * from './selectors';
 export * from './types';
+export * from './utils';

--- a/frontend/packages/console-shared/src/selectors/common.ts
+++ b/frontend/packages/console-shared/src/selectors/common.ts
@@ -2,11 +2,11 @@ import * as _ from 'lodash';
 
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
-export const getName = (value: K8sResourceKind) =>
+export const getName = <A extends K8sResourceKind = K8sResourceKind>(value: A) =>
   _.get(value, 'metadata.name') as K8sResourceKind['metadata']['name'];
-export const getNamespace = (value: K8sResourceKind) =>
+export const getNamespace = <A extends K8sResourceKind = K8sResourceKind>(value: A) =>
   _.get(value, 'metadata.namespace') as K8sResourceKind['metadata']['namespace'];
-export const getUID = (value: K8sResourceKind) =>
+export const getUID = <A extends K8sResourceKind = K8sResourceKind>(value: A) =>
   _.get(value, 'metadata.uid') as K8sResourceKind['metadata']['uid'];
-export const getDeletetionTimestamp = (value: K8sResourceKind) =>
+export const getDeletetionTimestamp = <A extends K8sResourceKind = K8sResourceKind>(value: A) =>
   _.get(value, 'metadata.deletionTimestamp') as K8sResourceKind['metadata']['deletionTimestamp'];

--- a/frontend/packages/console-shared/src/utils/index.ts
+++ b/frontend/packages/console-shared/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/frontend/packages/console-shared/src/utils/utils.ts
+++ b/frontend/packages/console-shared/src/utils/utils.ts
@@ -1,0 +1,28 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { FirehoseResult } from '@console/internal/components/utils';
+import { getUID } from '../selectors';
+
+export type EntityMap<A> = { [propertyName: string]: A };
+export type K8sEntityMap<A extends K8sResourceKind> = EntityMap<A>;
+
+type KeyResolver<A> = (entity: A) => string;
+
+export const createBasicLookup = <A>(list: A[], getKey: KeyResolver<A>): EntityMap<A> => {
+  return (list || []).reduce((lookup, entity) => {
+    const key = getKey(entity);
+    if (key) {
+      lookup[key] = entity;
+    }
+    return lookup;
+  }, {});
+};
+
+export const createLookup = <A extends K8sResourceKind>(
+  loadingList: FirehoseResult<A[]>,
+  getKey?: KeyResolver<A>,
+): K8sEntityMap<A> => {
+  if (loadingList && loadingList.loaded) {
+    return createBasicLookup(loadingList.data, getKey || getUID);
+  }
+  return {};
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
@@ -1,4 +1,5 @@
-import { EntityMap, VMLikeEntityKind, VMKind } from '../../types';
+import { EntityMap } from '@console/shared';
+import { VMLikeEntityKind, VMKind } from '../../types';
 
 export enum StorageType {
   STORAGE_TYPE_VM = 'storage-type-vm',

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -7,7 +7,7 @@ import { Table } from '@console/internal/components/factory';
 import { PersistentVolumeClaimModel } from '@console/internal/models';
 import { Firehose, FirehoseResult, Kebab } from '@console/internal/components/utils';
 import { getResource } from 'kubevirt-web-ui-components';
-import { getNamespace, getName } from '@console/shared';
+import { getNamespace, getName, createBasicLookup, createLookup } from '@console/shared';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { sortable } from '@patternfly/react-table';
@@ -22,7 +22,6 @@ import {
   getVolumePersistentVolumeClaimName,
   getVolumes,
 } from '../../selectors/vm';
-import { createBasicLookup, createLookup } from '../../utils';
 import { DiskRow } from './disk-row';
 import { StorageBundle, StorageType, VMDiskRowProps } from './types';
 import { CreateDiskRowFirehose } from './create-disk-row';

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/types.ts
@@ -1,4 +1,5 @@
-import { EntityMap, VMKind, VMLikeEntityKind } from '../../types';
+import { EntityMap } from '@console/shared';
+import { VMKind, VMLikeEntityKind } from '../../types';
 
 export enum NetworkRowType {
   NETWORK_TYPE_VM = 'network-type-vm',

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
@@ -7,6 +7,7 @@ import { Table } from '@console/internal/components/factory';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 
 import { sortable } from '@patternfly/react-table';
+import { createBasicLookup } from '@console/shared';
 import { VMLikeEntityKind } from '../../types';
 import { asVm } from '../../selectors/selectors';
 import { getInterfaces, getNetworks, getVmPreferableNicBus } from '../../selectors/vm';
@@ -14,7 +15,6 @@ import { NicRow } from './nic-row';
 import { NetworkBundle, NetworkRowType, VMNicRowProps } from './types';
 import { CreateNicRowConnected } from './create-nic-row';
 import { dimensifyHeader } from '../../utils/table';
-import { createBasicLookup } from '../../utils';
 import { getInterfaceBinding, getNetworkName, nicTableColumnClasses } from './utils';
 import { VMLikeEntityTabProps } from '../vms/types';
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -11,7 +11,7 @@ import {
   // VM_SIMPLE_STATUS_TO_TEXT,
   //  DASHES,
 } from 'kubevirt-web-ui-components';
-import { getName, getNamespace, getUID } from '@console/shared';
+import { getName, getNamespace, getUID, createLookup, K8sEntityMap } from '@console/shared';
 
 import { NamespaceModel, PodModel } from '@console/internal/models';
 import { Table, MultiListPage, TableRow, TableData } from '@console/internal/components/factory';
@@ -24,12 +24,12 @@ import {
   VirtualMachineModel,
 } from '../../models';
 
-import { K8sEntityMap, VMIKind, VMKind } from '../../types';
+import { VMIKind, VMKind } from '../../types';
 import { menuActions } from './menu-actions';
-import { createLookup, getLookupId } from '../../utils';
 import { getMigrationVMIName, isMigrating } from '../../selectors/vmi-migration';
 import { vmStatusFilter } from './table-filters';
 import { dimensifyHeader, dimensifyRow } from '../../utils/table';
+import { getBasicID } from '../../utils';
 
 import { openCreateVmWizard } from '../modals';
 
@@ -77,10 +77,10 @@ const VMRow: React.FC<VMRowProps> = ({
   const namespace = getNamespace(vm);
   const uid = getUID(vm);
   const vmStatus = getVmStatus(vm, pods, migrations);
-  const lookupId = getLookupId(vm);
+  const lookupID = getBasicID(vm);
 
-  const migration = migrationLookup[lookupId];
-  const vmi = vmiLookup[lookupId];
+  const migration = migrationLookup[lookupID];
+  const vmi = vmiLookup[lookupID];
 
   return (
     <TableRow id={uid} index={index} trKey={key} style={style}>
@@ -121,7 +121,7 @@ const VMList: React.FC<React.ComponentProps<typeof Table> & VMListProps> = (prop
       customData={{
         pods: resources.pods.data || [],
         migrations: resources.migrations.data || [],
-        vmiLookup: createLookup(resources.vmis),
+        vmiLookup: createLookup(resources.vmis, getBasicID),
         migrationLookup: createLookup(
           resources.migrations,
           (m) => isMigrating(m) && `${getNamespace(m)}-${getMigrationVMIName(m)}`,

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vmi/migration.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vmi/migration.ts
@@ -3,9 +3,9 @@ import { k8sCreate } from '@console/internal/module/k8s';
 import { VMIKind } from '../../../types/vm';
 import { VirtualMachineInstanceMigrationModel } from '../../../models';
 import { Migration } from './objects/migration';
-import { prefixedId } from '../../../utils';
+import { prefixedID } from '../../../utils';
 
-export const getMigrationName = (vmi: VMIKind) => prefixedId(getName(vmi), 'migration');
+export const getMigrationName = (vmi: VMIKind) => prefixedID(getName(vmi), 'migration');
 
 export const startVMIMigration = (vmi: VMIKind) => {
   const migration = new Migration().setName(getMigrationName(vmi)).setVMI(vmi);

--- a/frontend/packages/kubevirt-plugin/src/models/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/index.ts
@@ -96,9 +96,9 @@ export const V2VVMwareModel: K8sKind = {
   id: 'v2vvmware',
 };
 
-export const NodeMaintenance: K8sKind = {
-  label: 'NodeMaintenance',
-  labelPlural: 'NodeMaintenances',
+export const NodeMaintenanceModel: K8sKind = {
+  label: 'Node Maintenance',
+  labelPlural: 'Node Maintenances',
   apiVersion: 'v1alpha1',
   apiGroup: 'kubevirt.io',
   plural: 'nodemaintenances',

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/combined.ts
@@ -4,7 +4,7 @@ import {
   VM_STATUS_V2V_CONVERSION_IN_PROGRESS,
 } from 'kubevirt-web-ui-components';
 
-import { getName } from '@console/shared';
+import { getName, createBasicLookup } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
 import { VMIKind, VMKind } from '../../types/vm';
@@ -12,7 +12,6 @@ import { getUsedNetworks, isVMRunning } from './selectors';
 import { VMMultiStatus } from '../../types';
 import { Network } from './types';
 import { NetworkType, POD_NETWORK } from '../../constants/vm';
-import { createBasicLookup } from '../../utils';
 
 const IMPORTING_STATUSES = new Set([VM_STATUS_IMPORTING, VM_STATUS_V2V_CONVERSION_IN_PROGRESS]);
 

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -1,10 +1,10 @@
 import * as _ from 'lodash';
+import { createBasicLookup } from '@console/shared';
 import { getDiskBus } from './disk';
 import { BUS_VIRTIO, NetworkType } from '../../constants/vm';
 import { VMKind } from '../../types';
 import { getNicBus } from './nic';
 import { Network } from './types';
-import { createBasicLookup } from '../../utils';
 
 export const getDisks = (vm: VMKind) => _.get(vm, 'spec.template.spec.domain.devices.disks', []);
 export const getInterfaces = (vm: VMKind) =>

--- a/frontend/packages/kubevirt-plugin/src/types/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/types.ts
@@ -1,10 +1,7 @@
-import { K8sResourceKind, PodKind, TemplateKind } from '@console/internal/module/k8s';
+import { PodKind, TemplateKind } from '@console/internal/module/k8s';
 import { VMKind } from './vm';
 
 export type VMLikeEntityKind = VMKind | TemplateKind;
-
-export type EntityMap<A> = { [propertyName: string]: A };
-export type K8sEntityMap<A extends K8sResourceKind> = EntityMap<A>;
 
 export type VMMultiStatus = {
   status: string;

--- a/frontend/packages/kubevirt-plugin/src/utils/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/index.ts
@@ -1,34 +1,11 @@
 import { FirehoseResult } from '@console/internal/components/utils';
-import { getName, getNamespace } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { EntityMap, K8sEntityMap } from '../types';
+import { getName, getNamespace } from '@console/shared';
 
-type KeyResolver<A> = (entity: A) => string;
-
-export const getLookupId = <A extends K8sResourceKind>(entity: A): string =>
+export const getBasicID = <A extends K8sResourceKind = K8sResourceKind>(entity: A): string =>
   `${getNamespace(entity)}-${getName(entity)}`;
 
-export const createBasicLookup = <A>(list: A[], getKey: KeyResolver<A>): EntityMap<A> => {
-  return (list || []).reduce((lookup, entity) => {
-    const key = getKey(entity);
-    if (key) {
-      lookup[key] = entity;
-    }
-    return lookup;
-  }, {});
-};
-
-export const createLookup = <A extends K8sResourceKind>(
-  loadingList: FirehoseResult<A[]>,
-  getKey?: KeyResolver<A>,
-): K8sEntityMap<A> => {
-  if (loadingList && loadingList.loaded) {
-    return createBasicLookup(loadingList.data, getKey || getLookupId);
-  }
-  return {};
-};
-
-export const prefixedId = (idPrefix: string, id: string): string =>
+export const prefixedID = (idPrefix: string, id: string): string =>
   idPrefix && id ? `${idPrefix}-${id}` : null;
 
 export const getLoadedData = (

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/vm/nic.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/vm/nic.ts
@@ -1,5 +1,5 @@
 import { validateDNS1123SubdomainValue, VALIDATION_ERROR_TYPE } from 'kubevirt-web-ui-components';
-import { EntityMap } from '../../../types';
+import { EntityMap } from '@console/shared';
 
 export const validateNicName = (name: string, interfaceLookup: EntityMap<any>) => {
   let validation = validateDNS1123SubdomainValue(name);


### PR DESCRIPTION
used by `kubevirt` and newly `metal3` (#1967)