### PR TITLE
metal3: add node maintenance actions

### DIFF
--- a/frontend/packages/console-shared/src/index.ts
+++ b/frontend/packages/console-shared/src/index.ts
@@ -2,3 +2,4 @@ export * from './components';
 export * from './constants';
 export * from './selectors';
 export * from './types';
+export * from './utils';

--- a/frontend/packages/console-shared/src/selectors/common.ts
+++ b/frontend/packages/console-shared/src/selectors/common.ts
@@ -2,11 +2,11 @@ import * as _ from 'lodash';
 
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
-export const getName = (value: K8sResourceKind) =>
+export const getName = <A extends K8sResourceKind = K8sResourceKind>(value: A) =>
   _.get(value, 'metadata.name') as K8sResourceKind['metadata']['name'];
-export const getNamespace = (value: K8sResourceKind) =>
+export const getNamespace = <A extends K8sResourceKind = K8sResourceKind>(value: A) =>
   _.get(value, 'metadata.namespace') as K8sResourceKind['metadata']['namespace'];
-export const getUID = (value: K8sResourceKind) =>
+export const getUID = <A extends K8sResourceKind = K8sResourceKind>(value: A) =>
   _.get(value, 'metadata.uid') as K8sResourceKind['metadata']['uid'];
-export const getDeletetionTimestamp = (value: K8sResourceKind) =>
+export const getDeletetionTimestamp = <A extends K8sResourceKind = K8sResourceKind>(value: A) =>
   _.get(value, 'metadata.deletionTimestamp') as K8sResourceKind['metadata']['deletionTimestamp'];

--- a/frontend/packages/console-shared/src/utils/index.ts
+++ b/frontend/packages/console-shared/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/frontend/packages/console-shared/src/utils/utils.ts
+++ b/frontend/packages/console-shared/src/utils/utils.ts
@@ -1,0 +1,28 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { FirehoseResult } from '@console/internal/components/utils';
+import { getUID } from '../selectors';
+
+export type EntityMap<A> = { [propertyName: string]: A };
+export type K8sEntityMap<A extends K8sResourceKind> = EntityMap<A>;
+
+type KeyResolver<A> = (entity: A) => string;
+
+export const createBasicLookup = <A>(list: A[], getKey: KeyResolver<A>): EntityMap<A> => {
+  return (list || []).reduce((lookup, entity) => {
+    const key = getKey(entity);
+    if (key) {
+      lookup[key] = entity;
+    }
+    return lookup;
+  }, {});
+};
+
+export const createLookup = <A extends K8sResourceKind>(
+  loadingList: FirehoseResult<A[]>,
+  getKey?: KeyResolver<A>,
+): K8sEntityMap<A> => {
+  if (loadingList && loadingList.loaded) {
+    return createBasicLookup(loadingList.data, getKey || getUID);
+  }
+  return {};
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
@@ -1,4 +1,5 @@
-import { EntityMap, VMLikeEntityKind, VMKind } from '../../types';
+import { EntityMap } from '@console/shared';
+import { VMLikeEntityKind, VMKind } from '../../types';
 
 export enum StorageType {
   STORAGE_TYPE_VM = 'storage-type-vm',

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -7,7 +7,7 @@ import { Table } from '@console/internal/components/factory';
 import { PersistentVolumeClaimModel } from '@console/internal/models';
 import { Firehose, FirehoseResult, Kebab } from '@console/internal/components/utils';
 import { getResource } from 'kubevirt-web-ui-components';
-import { getNamespace, getName } from '@console/shared';
+import { getNamespace, getName, createBasicLookup, createLookup } from '@console/shared';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { sortable } from '@patternfly/react-table';
@@ -22,7 +22,6 @@ import {
   getVolumePersistentVolumeClaimName,
   getVolumes,
 } from '../../selectors/vm';
-import { createBasicLookup, createLookup } from '../../utils';
 import { DiskRow } from './disk-row';
 import { StorageBundle, StorageType, VMDiskRowProps } from './types';
 import { CreateDiskRowFirehose } from './create-disk-row';

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/types.ts
@@ -1,4 +1,5 @@
-import { EntityMap, VMKind, VMLikeEntityKind } from '../../types';
+import { EntityMap } from '@console/shared';
+import { VMKind, VMLikeEntityKind } from '../../types';
 
 export enum NetworkRowType {
   NETWORK_TYPE_VM = 'network-type-vm',

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
@@ -7,6 +7,7 @@ import { Table } from '@console/internal/components/factory';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 
 import { sortable } from '@patternfly/react-table';
+import { createBasicLookup } from '@console/shared';
 import { VMLikeEntityKind } from '../../types';
 import { asVm } from '../../selectors/selectors';
 import { getInterfaces, getNetworks, getVmPreferableNicBus } from '../../selectors/vm';
@@ -14,7 +15,6 @@ import { NicRow } from './nic-row';
 import { NetworkBundle, NetworkRowType, VMNicRowProps } from './types';
 import { CreateNicRowConnected } from './create-nic-row';
 import { dimensifyHeader } from '../../utils/table';
-import { createBasicLookup } from '../../utils';
 import { getInterfaceBinding, getNetworkName, nicTableColumnClasses } from './utils';
 import { VMLikeEntityTabProps } from '../vms/types';
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -11,7 +11,7 @@ import {
   // VM_SIMPLE_STATUS_TO_TEXT,
   //  DASHES,
 } from 'kubevirt-web-ui-components';
-import { getName, getNamespace, getUID } from '@console/shared';
+import { getName, getNamespace, getUID, createLookup, K8sEntityMap } from '@console/shared';
 
 import { NamespaceModel, PodModel } from '@console/internal/models';
 import { Table, MultiListPage, TableRow, TableData } from '@console/internal/components/factory';
@@ -24,12 +24,12 @@ import {
   VirtualMachineModel,
 } from '../../models';
 
-import { K8sEntityMap, VMIKind, VMKind } from '../../types';
+import { VMIKind, VMKind } from '../../types';
 import { menuActions } from './menu-actions';
-import { createLookup, getLookupId } from '../../utils';
 import { getMigrationVMIName, isMigrating } from '../../selectors/vmi-migration';
 import { vmStatusFilter } from './table-filters';
 import { dimensifyHeader, dimensifyRow } from '../../utils/table';
+import { getBasicID } from '../../utils';
 
 import { openCreateVmWizard } from '../modals';
 
@@ -77,10 +77,10 @@ const VMRow: React.FC<VMRowProps> = ({
   const namespace = getNamespace(vm);
   const uid = getUID(vm);
   const vmStatus = getVmStatus(vm, pods, migrations);
-  const lookupId = getLookupId(vm);
+  const lookupID = getBasicID(vm);
 
-  const migration = migrationLookup[lookupId];
-  const vmi = vmiLookup[lookupId];
+  const migration = migrationLookup[lookupID];
+  const vmi = vmiLookup[lookupID];
 
   return (
     <TableRow id={uid} index={index} trKey={key} style={style}>
@@ -121,7 +121,7 @@ const VMList: React.FC<React.ComponentProps<typeof Table> & VMListProps> = (prop
       customData={{
         pods: resources.pods.data || [],
         migrations: resources.migrations.data || [],
-        vmiLookup: createLookup(resources.vmis),
+        vmiLookup: createLookup(resources.vmis, getBasicID),
         migrationLookup: createLookup(
           resources.migrations,
           (m) => isMigrating(m) && `${getNamespace(m)}-${getMigrationVMIName(m)}`,

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vmi/migration.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vmi/migration.ts
@@ -3,9 +3,9 @@ import { k8sCreate } from '@console/internal/module/k8s';
 import { VMIKind } from '../../../types/vm';
 import { VirtualMachineInstanceMigrationModel } from '../../../models';
 import { Migration } from './objects/migration';
-import { prefixedId } from '../../../utils';
+import { prefixedID } from '../../../utils';
 
-export const getMigrationName = (vmi: VMIKind) => prefixedId(getName(vmi), 'migration');
+export const getMigrationName = (vmi: VMIKind) => prefixedID(getName(vmi), 'migration');
 
 export const startVMIMigration = (vmi: VMIKind) => {
   const migration = new Migration().setName(getMigrationName(vmi)).setVMI(vmi);

--- a/frontend/packages/kubevirt-plugin/src/models/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/index.ts
@@ -95,15 +95,3 @@ export const V2VVMwareModel: K8sKind = {
   kind: 'V2VVmware',
   id: 'v2vvmware',
 };
-
-export const NodeMaintenanceModel: K8sKind = {
-  label: 'Node Maintenance',
-  labelPlural: 'Node Maintenances',
-  apiVersion: 'v1alpha1',
-  apiGroup: 'kubevirt.io',
-  plural: 'nodemaintenances',
-  abbr: 'NM',
-  namespaced: false,
-  kind: 'NodeMaintenance',
-  id: 'nodemaintenance',
-};

--- a/frontend/packages/kubevirt-plugin/src/models/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/index.ts
@@ -96,9 +96,9 @@ export const V2VVMwareModel: K8sKind = {
   id: 'v2vvmware',
 };
 
-export const NodeMaintenance: K8sKind = {
-  label: 'NodeMaintenance',
-  labelPlural: 'NodeMaintenances',
+export const NodeMaintenanceModel: K8sKind = {
+  label: 'Node Maintenance',
+  labelPlural: 'Node Maintenances',
   apiVersion: 'v1alpha1',
   apiGroup: 'kubevirt.io',
   plural: 'nodemaintenances',

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/combined.ts
@@ -4,7 +4,7 @@ import {
   VM_STATUS_V2V_CONVERSION_IN_PROGRESS,
 } from 'kubevirt-web-ui-components';
 
-import { getName } from '@console/shared';
+import { getName, createBasicLookup } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
 import { VMIKind, VMKind } from '../../types/vm';
@@ -12,7 +12,6 @@ import { getUsedNetworks, isVMRunning } from './selectors';
 import { VMMultiStatus } from '../../types';
 import { Network } from './types';
 import { NetworkType, POD_NETWORK } from '../../constants/vm';
-import { createBasicLookup } from '../../utils';
 
 const IMPORTING_STATUSES = new Set([VM_STATUS_IMPORTING, VM_STATUS_V2V_CONVERSION_IN_PROGRESS]);
 

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -1,10 +1,10 @@
 import * as _ from 'lodash';
+import { createBasicLookup } from '@console/shared';
 import { getDiskBus } from './disk';
 import { BUS_VIRTIO, NetworkType } from '../../constants/vm';
 import { VMKind } from '../../types';
 import { getNicBus } from './nic';
 import { Network } from './types';
-import { createBasicLookup } from '../../utils';
 
 export const getDisks = (vm: VMKind) => _.get(vm, 'spec.template.spec.domain.devices.disks', []);
 export const getInterfaces = (vm: VMKind) =>

--- a/frontend/packages/kubevirt-plugin/src/types/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/types.ts
@@ -1,10 +1,7 @@
-import { K8sResourceKind, PodKind, TemplateKind } from '@console/internal/module/k8s';
+import { PodKind, TemplateKind } from '@console/internal/module/k8s';
 import { VMKind } from './vm';
 
 export type VMLikeEntityKind = VMKind | TemplateKind;
-
-export type EntityMap<A> = { [propertyName: string]: A };
-export type K8sEntityMap<A extends K8sResourceKind> = EntityMap<A>;
 
 export type VMMultiStatus = {
   status: string;

--- a/frontend/packages/kubevirt-plugin/src/utils/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/index.ts
@@ -1,34 +1,11 @@
 import { FirehoseResult } from '@console/internal/components/utils';
-import { getName, getNamespace } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { EntityMap, K8sEntityMap } from '../types';
+import { getName, getNamespace } from '@console/shared';
 
-type KeyResolver<A> = (entity: A) => string;
-
-export const getLookupId = <A extends K8sResourceKind>(entity: A): string =>
+export const getBasicID = <A extends K8sResourceKind = K8sResourceKind>(entity: A): string =>
   `${getNamespace(entity)}-${getName(entity)}`;
 
-export const createBasicLookup = <A>(list: A[], getKey: KeyResolver<A>): EntityMap<A> => {
-  return (list || []).reduce((lookup, entity) => {
-    const key = getKey(entity);
-    if (key) {
-      lookup[key] = entity;
-    }
-    return lookup;
-  }, {});
-};
-
-export const createLookup = <A extends K8sResourceKind>(
-  loadingList: FirehoseResult<A[]>,
-  getKey?: KeyResolver<A>,
-): K8sEntityMap<A> => {
-  if (loadingList && loadingList.loaded) {
-    return createBasicLookup(loadingList.data, getKey || getLookupId);
-  }
-  return {};
-};
-
-export const prefixedId = (idPrefix: string, id: string): string =>
+export const prefixedID = (idPrefix: string, id: string): string =>
   idPrefix && id ? `${idPrefix}-${id}` : null;
 
 export const getLoadedData = (

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/vm/nic.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/vm/nic.ts
@@ -1,5 +1,5 @@
 import { validateDNS1123SubdomainValue, VALIDATION_ERROR_TYPE } from 'kubevirt-web-ui-components';
-import { EntityMap } from '../../../types';
+import { EntityMap } from '@console/shared';
 
 export const validateNicName = (name: string, interfaceLookup: EntityMap<any>) => {
   let validation = validateDNS1123SubdomainValue(name);

--- a/frontend/packages/metal3-plugin/src/components/host-menu-actions.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host-menu-actions.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+
+import { asAccessReview, KebabOption } from '@console/internal/components/utils';
+import { k8sKill, K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { getMachineNodeName, getName } from '@console/shared';
+import { confirmModal } from '@console/internal/components/modals';
+
+import { findNodeMaintenance, getHostMachine, getNodeMaintenanceReason } from '../selectors';
+import { startNodeMaintenanceModal } from './modals/start-node-maintenance-modal';
+import { NodeMaintenanceModel } from '../models';
+
+type ActionArgs = {
+  nodeName?: string;
+  nodeMaintenance?: K8sResourceKind;
+  hasNodeMaintenanceCapability: boolean;
+};
+
+export const SetNodeMaintanance = (
+  kindObj: K8sKind,
+  host: K8sResourceKind,
+  resources: {},
+  { hasNodeMaintenanceCapability, nodeMaintenance, nodeName }: ActionArgs,
+): KebabOption => ({
+  hidden: !nodeName || !hasNodeMaintenanceCapability || !!nodeMaintenance,
+  label: 'Start Maintenance',
+  callback: () => startNodeMaintenanceModal({ nodeName }),
+});
+
+export const RemoveNodeMaintanance = (
+  kindObj: K8sKind,
+  host: K8sResourceKind,
+  resources: {},
+  { hasNodeMaintenanceCapability, nodeMaintenance, nodeName }: ActionArgs,
+): KebabOption => {
+  const title = 'Stop Maintenance';
+  const reason = getNodeMaintenanceReason(nodeMaintenance);
+  return {
+    hidden: !nodeName || !hasNodeMaintenanceCapability || !nodeMaintenance,
+    label: title,
+    callback: () =>
+      confirmModal({
+        title,
+        message: (
+          <>
+            Are you sure you want to stop maintenance{' '}
+            <strong>
+              {getName(nodeMaintenance)}
+              {reason ? ` (${reason})` : ''}
+            </strong>{' '}
+            on node <strong>{nodeName}</strong>?
+          </>
+        ),
+        btnText: title,
+        executeFn: () => k8sKill(NodeMaintenanceModel, nodeMaintenance),
+      }),
+    accessReview:
+      nodeMaintenance && asAccessReview(NodeMaintenanceModel, nodeMaintenance, 'delete'),
+  };
+};
+
+export const menuActions = [SetNodeMaintanance, RemoveNodeMaintanance];
+
+export const menuActionsCreator = (
+  kindObj: K8sKind,
+  host: K8sResourceKind,
+  { machines, nodeMaintenances },
+  { hasNodeMaintenanceCapability },
+) => {
+  const machine = getHostMachine(host, machines);
+  const nodeName = getMachineNodeName(machine);
+  const nodeMaintenance = findNodeMaintenance(nodeMaintenances, nodeName);
+
+  return menuActions.map((action) => {
+    return action(kindObj, host, null, { hasNodeMaintenanceCapability, nodeMaintenance, nodeName });
+  });
+};

--- a/frontend/packages/metal3-plugin/src/components/host-status.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host-status.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from 'patternfly-react';
-import { AddCircleOIcon, SyncAltIcon, UnknownIcon } from '@patternfly/react-icons';
+import { AddCircleOIcon, SyncAltIcon, UnknownIcon, MaintenanceIcon } from '@patternfly/react-icons';
 
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import {
@@ -9,13 +9,14 @@ import {
   RedExclamationCircleIcon,
 } from '@console/internal/components/utils/status-icon';
 import { RequireCreatePermission } from '@console/internal/components/utils';
-import { getHostStatus } from '../utils/host-status';
+import { HostMultiStatus } from '../utils/host-status';
 
 import {
   HOST_STATUS_DISCOVERED,
   HOST_PROGRESS_STATES,
   HOST_ERROR_STATES,
   HOST_SUCCESS_STATES,
+  HOST_STATUS_UNDER_MAINTENANCE,
 } from '../constants';
 import { BaremetalHostModel } from '../models';
 
@@ -38,26 +39,26 @@ export const AddDiscoveredHostButton: React.FC<{ host: K8sResourceKind }> = (
 };
 
 type BaremetalHostStatusProps = {
-  host: K8sResourceKind;
-  machine?: K8sResourceKind;
-  node?: K8sResourceKind;
+  host?: K8sResourceKind;
+  status: HostMultiStatus;
 };
 
-const BaremetalHostStatus = ({ host }: BaremetalHostStatusProps) => {
-  const hostStatus = getHostStatus(host);
-  const { status, title } = hostStatus;
+const BaremetalHostStatus = ({ host, status: { status, title } }: BaremetalHostStatusProps) => {
+  const statusTitle = title || status;
 
   switch (true) {
     case status === HOST_STATUS_DISCOVERED:
       return <AddDiscoveredHostButton host={host} />;
+    case status === HOST_STATUS_UNDER_MAINTENANCE:
+      return <StatusIconAndText status={statusTitle} icon={<MaintenanceIcon />} />;
     case HOST_PROGRESS_STATES.includes(status):
-      return <StatusIconAndText status={title} icon={<SyncAltIcon />} />;
+      return <StatusIconAndText status={statusTitle} icon={<SyncAltIcon />} />;
     case HOST_SUCCESS_STATES.includes(status):
-      return <StatusIconAndText status={title} icon={<GreenCheckCircleIcon />} />;
+      return <StatusIconAndText status={statusTitle} icon={<GreenCheckCircleIcon />} />;
     case HOST_ERROR_STATES.includes(status):
-      return <StatusIconAndText status={title} icon={<RedExclamationCircleIcon />} />;
+      return <StatusIconAndText status={statusTitle} icon={<RedExclamationCircleIcon />} />;
     default:
-      return <StatusIconAndText status={title} icon={<UnknownIcon />} />;
+      return <StatusIconAndText status={statusTitle} icon={<UnknownIcon />} />;
   }
 };
 

--- a/frontend/packages/metal3-plugin/src/components/host.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host.tsx
@@ -1,26 +1,24 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import { connect } from 'react-redux';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
-import { getName, getNamespace, getUID, getMachineNode } from '@console/shared';
+import { getName, getNamespace, getUID, getMachineNode, createLookup } from '@console/shared';
 import { MachineModel, NodeModel } from '@console/internal/models';
-
 import { MultiListPage, Table, TableRow, TableData } from '@console/internal/components/factory';
-import { FirehoseResult, Kebab, ResourceLink } from '@console/internal/components/utils';
-import {
-  referenceForModel,
-  K8sResourceKind,
-  MachineKind,
-  NodeKind,
-} from '@console/internal/module/k8s';
+import { Kebab, ResourceLink, FirehoseResource } from '@console/internal/components/utils';
+import { referenceForModel } from '@console/internal/module/k8s';
 
-import { BaremetalHostModel } from '../models';
-import { getHostBMCAddress, getHostMachine } from '../selectors';
+import { BaremetalHostModel, NodeMaintenanceModel } from '../models';
+import { getHostBMCAddress, getHostMachine, getNodeMaintenanceNodeName } from '../selectors';
 import { BaremetalHostRole } from './host-role';
 import MachineCell from './machine-cell';
 import BaremetalHostStatus from './host-status';
 import { hostStatusFilter } from './table-filters';
+import { menuActions } from './host-menu-actions';
+import { getHostStatus } from '../utils/host-status';
+import { HostRowBundle } from './types';
 
 const tableColumnClasses = [
   classNames('col-lg-3', 'col-md-4', 'col-sm-12', 'col-xs-12'),
@@ -34,20 +32,19 @@ const tableColumnClasses = [
 const HostsTableHeader = () => [
   {
     title: 'Name',
-    sortField: 'metadata.name',
+    sortField: 'host.metadata.name',
     transforms: [sortable],
     props: { className: tableColumnClasses[0] },
   },
   {
     title: 'Status',
-    // TODO(jtomasek): enable this once it is possible to pass sort function
-    // sortFunc: getSimpleHostStatus,
-    // transforms: [sortable],
+    sortField: 'status.status',
+    transforms: [sortable],
     props: { className: tableColumnClasses[1] },
   },
   {
     title: 'Machine',
-    sortField: 'spec.consumerRef.name',
+    sortField: 'host.spec.consumerRef.name',
     transforms: [sortable],
     props: { className: tableColumnClasses[2] },
   },
@@ -59,21 +56,20 @@ const HostsTableHeader = () => [
   },
   {
     title: 'Management Address',
-    sortField: 'spec.consumerRef.name',
+    sortField: 'host.spec.bmc.address',
     transforms: [sortable],
     props: { className: tableColumnClasses[4] },
   },
-  // {
-  //   title: '',
-  //   props: { className: tableColumnClasses[5] },
-  // },
+  {
+    title: '',
+    props: { className: tableColumnClasses[5] },
+  },
 ];
 
 type HostsTableRowProps = {
-  obj: K8sResourceKind;
+  obj: HostRowBundle;
   customData: {
-    machines: MachineKind[];
-    nodes: NodeKind[];
+    hasNodeMaintenanceCapability: boolean;
   };
   index: number;
   key?: string;
@@ -81,38 +77,17 @@ type HostsTableRowProps = {
 };
 
 const HostsTableRow: React.FC<HostsTableRowProps> = ({
-  obj: host,
-  customData: { machines, nodes },
+  obj: { host, node, nodeMaintenance, machine, status },
+  customData: { hasNodeMaintenanceCapability },
   index,
   key,
   style,
 }) => {
   const name = getName(host);
   const namespace = getNamespace(host);
-  // const machineName = getHostMachineName(host);
   const address = getHostBMCAddress(host);
   const uid = getUID(host);
-  const machine = getHostMachine(host, machines);
-  const node = getMachineNode(machine, nodes);
-
-  // TODO(jtomasek): other resource references will be updated as a subsequent change
-  // const machineResource = {
-  //   kind: referenceForModel(MachineModel),
-  //   name: machineName,
-  //   namespaced: true,
-  //   namespace,
-  //   isList: false,
-  //   prop: 'machine',
-  // };
-
-  // const hostResourceMap = {
-  //   machine: {
-  //     resource: machineResource,
-  //   },
-  //   nodes: {
-  //     resource: getResource(NodeModel, { namespaced: false }),
-  //   },
-  // };
+  const nodeName = getName(node);
 
   return (
     <TableRow id={uid} index={index} trKey={key} style={style}>
@@ -124,81 +99,106 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({
         />
       </TableData>
       <TableData className={tableColumnClasses[1]}>
-        <BaremetalHostStatus host={host} machine={machine} node={node} />
+        <BaremetalHostStatus host={host} status={status} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
-        <MachineCell host={host} />
+        <MachineCell host={host} status={status} />
       </TableData>
       <TableData className={tableColumnClasses[3]}>
         <BaremetalHostRole machine={machine} />
       </TableData>
       <TableData className={tableColumnClasses[4]}>{address}</TableData>
-      {/* <TableData className={tableColumnClasses[5]}>
-        TODO(jtomasek): Add host actions here
-      </TableData> */}
+      <TableData className={tableColumnClasses[5]}>
+        <Kebab
+          options={menuActions.map((action) =>
+            action(BaremetalHostModel, host, null, {
+              nodeMaintenance,
+              nodeName,
+              hasNodeMaintenanceCapability,
+            }),
+          )}
+          key={`kebab-for-${uid}`}
+          id={`kebab-for-${uid}`}
+        />
+      </TableData>
     </TableRow>
   );
 };
 
-type HostListProps = {
-  data: K8sResourceKind[];
-  resources: {
-    machines: FirehoseResult<MachineKind[]>;
-    nodes: FirehoseResult<NodeKind[]>;
-  };
-} & React.ComponentProps<typeof Table>;
+const HostList: React.FC<HostListProps> = (props) => (
+  <Table {...props} aria-label="Baremetal Hosts" Header={HostsTableHeader} Row={HostsTableRow} />
+);
 
-const HostList: React.FC<HostListProps> = (props) => {
-  const {
-    resources: { machines, nodes },
-    ...tableProps
-  } = props;
-  return (
-    <Table
-      {...tableProps}
-      aria-label="Baremetal Hosts"
-      Header={HostsTableHeader}
-      Row={HostsTableRow}
-      customData={{
-        machines: machines.data || [],
-        nodes: nodes.data || [],
-      }}
-    />
-  );
+type HostListProps = React.ComponentProps<typeof Table> & {
+  data: HostRowBundle[];
+  customData: {
+    hasNodeMaintenanceCapability: boolean;
+  };
 };
 
-type BaremetalHostsPageProps = {
-  namespace: string;
-};
+const BaremetalHostsPage: React.FC<BaremetalHostsPageProps> = ({
+  hasNodeMaintenanceCapability,
+  ...props
+}) => {
+  const resources: FirehoseResource[] = [
+    {
+      kind: referenceForModel(BaremetalHostModel),
+      namespaced: true,
+      prop: 'hosts',
+    },
+    {
+      kind: referenceForModel(MachineModel),
+      namespaced: true,
+      prop: 'machines',
+    },
+    {
+      kind: NodeModel.kind,
+      namespaced: false,
+      prop: 'nodes',
+    },
+  ];
 
-export const BaremetalHostsPage: React.FC<BaremetalHostsPageProps> = (props) => {
-  const hostsResource = {
-    kind: referenceForModel(BaremetalHostModel),
-    namespaced: true,
-    prop: 'hosts',
-  };
-  const machinesResource = {
-    kind: referenceForModel(MachineModel),
-    namespaced: true,
-    prop: 'machines',
-  };
-  const nodesResource = {
-    kind: NodeModel.kind,
-    namespaced: false,
-    prop: 'nodes',
-  };
+  if (hasNodeMaintenanceCapability) {
+    resources.push({
+      kind: referenceForModel(NodeMaintenanceModel),
+      namespaced: false,
+      isList: true,
+      prop: 'nodeMaintenances',
+      optional: true,
+    });
+  }
 
-  const flatten = (resources) => {
+  const flatten = (fResources) => {
     // TODO(jtomasek): Remove loaded check once ListPageWrapper_ is updated to call flatten only
     // when resources are loaded
-    const loaded = _.every(resources, (resource) =>
+    const loaded = _.every(fResources, (resource) =>
       resource.optional ? resource.loaded || !_.isEmpty(resource.loadError) : resource.loaded,
     );
     const {
       hosts: { data: hostsData },
-    } = resources;
+      machines: { data: machinesData },
+      nodes: { data: nodesData },
+      nodeMaintenances,
+    } = fResources;
 
-    return loaded ? hostsData : [];
+    if (loaded) {
+      const nodeMaintenanceLookup = createLookup(nodeMaintenances, getNodeMaintenanceNodeName);
+
+      return hostsData.map((host) => {
+        const machine = getHostMachine(host, machinesData);
+        const node = getMachineNode(machine, nodesData);
+        const nodeMaintenance = nodeMaintenanceLookup[getName(node)];
+        return {
+          ...host,
+          host,
+          machine,
+          node,
+          nodeMaintenance,
+          status: getHostStatus({ host, machine, node, nodeMaintenance }),
+        };
+      });
+    }
+    return [];
   };
 
   return (
@@ -208,9 +208,25 @@ export const BaremetalHostsPage: React.FC<BaremetalHostsPageProps> = (props) => 
       rowFilters={[hostStatusFilter]}
       createButtonText="Add Host"
       namespace={props.namespace}
-      resources={[hostsResource, machinesResource, nodesResource]}
+      resources={resources}
       flatten={flatten}
       ListComponent={HostList}
+      customData={{ hasNodeMaintenanceCapability }}
     />
   );
 };
+
+type BaremetalHostsPageProps = {
+  namespace: string;
+  hasNodeMaintenanceCapability: boolean;
+};
+
+const hostsPageStateToProps = ({ k8s }) => ({
+  hasNodeMaintenanceCapability: !!k8s.getIn([
+    'RESOURCES',
+    'models',
+    referenceForModel(NodeMaintenanceModel),
+  ]),
+});
+
+export const BaremetalHostsPageConnected = connect(hostsPageStateToProps)(BaremetalHostsPage);

--- a/frontend/packages/metal3-plugin/src/components/machine-cell.tsx
+++ b/frontend/packages/metal3-plugin/src/components/machine-cell.tsx
@@ -12,13 +12,14 @@ import {
 import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
 
 import { getHostMachineName } from '../selectors';
-import { canHostAddMachine } from '../utils/host-status';
+import { canHostAddMachine, HostMultiStatus } from '../utils/host-status';
 
 interface MachineCellProps {
   host: K8sResourceKind;
+  status: HostMultiStatus;
 }
 
-const MachineCell: React.FC<MachineCellProps> = ({ host }) => {
+const MachineCell: React.FC<MachineCellProps> = ({ host, status }) => {
   const machineName = getHostMachineName(host);
 
   const {
@@ -35,7 +36,7 @@ const MachineCell: React.FC<MachineCellProps> = ({ host }) => {
       />
     );
   }
-  if (canHostAddMachine(host)) {
+  if (canHostAddMachine(status.status)) {
     const ns = namespace || 'default';
     const href = `/k8s/ns/${ns}/${referenceForModel(MachineModel)}/~new`;
     return (

--- a/frontend/packages/metal3-plugin/src/components/modals/start-node-maintenance-modal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/start-node-maintenance-modal.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+
+import { FormControl } from 'patternfly-react';
+
+import { withHandlePromise } from '@console/internal/components/utils';
+import {
+  createModalLauncher,
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+} from '@console/internal/components/factory';
+
+import { startNodeMaintenance } from '../../k8s/requests/node-maintenance';
+
+const StartNodeMaintenanceModal = withHandlePromise((props: NodeMaintenanceModalProps) => {
+  const { nodeName, inProgress, errorMessage, handlePromise, close, cancel } = props;
+
+  const [reason, setReason] = React.useState('');
+
+  const submit = (event) => {
+    event.preventDefault();
+    const promise = startNodeMaintenance(nodeName, reason);
+    return handlePromise(promise).then(close);
+  };
+
+  const action = 'Start Maintenance';
+  return (
+    <form onSubmit={submit} name="form" className="modal-content">
+      <ModalTitle>{action}</ModalTitle>
+      <ModalBody>
+        <p>
+          All managed workloads will be moved off of this host. New workloads and data will not be
+          added to this host until maintenance is stopped.
+        </p>
+        <p>
+          If the host does not exit maintenance within <strong>30 minutes</strong>, the cluster will
+          automatically rebuild the host&apos;s data using replicated copies
+        </p>
+        <div className="form-group">
+          <label htmlFor="node-maintenance-reason">Reason</label>
+          <FormControl
+            type="text"
+            id="node-maintenance-reason"
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+          />
+        </div>
+      </ModalBody>
+      <ModalSubmitFooter
+        errorMessage={errorMessage}
+        inProgress={inProgress}
+        submitText={action}
+        cancel={cancel}
+      />
+    </form>
+  );
+});
+
+export type NodeMaintenanceModalProps = {
+  nodeName: string;
+  handlePromise: <T>(promise: Promise<T>) => Promise<T>;
+  inProgress: boolean;
+  errorMessage: string;
+  cancel: () => void;
+  close: () => void;
+};
+
+export const startNodeMaintenanceModal = createModalLauncher(StartNodeMaintenanceModal);

--- a/frontend/packages/metal3-plugin/src/components/table-filters.ts
+++ b/frontend/packages/metal3-plugin/src/components/table-filters.ts
@@ -1,8 +1,6 @@
 import * as _ from 'lodash';
 
 import { Filter } from '@console/shared';
-import { K8sResourceKind } from '@console/internal/module/k8s';
-import { getSimpleHostStatus } from '../utils/host-status';
 import {
   HOST_REGISTERING_STATES,
   HOST_PROVISIONING_STATES,
@@ -11,6 +9,7 @@ import {
   HOST_STATUS_TITLES,
   HOST_STATUS_PROVISIONED,
 } from '../constants';
+import { HostRowBundle } from './types';
 
 const hostStatesToFilterMap = Object.freeze({
   registering: {
@@ -39,9 +38,8 @@ const hostStatesToFilterMap = Object.freeze({
   },
 });
 
-const getHostFilterStatus = (host: K8sResourceKind): string => {
-  const status = getSimpleHostStatus(host);
-  return _.findKey(hostStatesToFilterMap, ({ states }) => states.includes(status));
+const getHostFilterStatus = (bundle: HostRowBundle): string => {
+  return _.findKey(hostStatesToFilterMap, ({ states }) => states.includes(bundle.status.status));
 };
 
 export const hostStatusFilter: Filter = {
@@ -49,8 +47,8 @@ export const hostStatusFilter: Filter = {
   selected: Object.keys(hostStatesToFilterMap),
   reducer: getHostFilterStatus,
   items: _.map(hostStatesToFilterMap, ({ title }, id) => ({ id, title })),
-  filter: (groups, host: K8sResourceKind) => {
-    const status = getHostFilterStatus(host);
+  filter: (groups, bundle: HostRowBundle) => {
+    const status = getHostFilterStatus(bundle);
     return groups.selected.has(status) || !_.includes(groups.all, status);
   },
 };

--- a/frontend/packages/metal3-plugin/src/components/types.ts
+++ b/frontend/packages/metal3-plugin/src/components/types.ts
@@ -1,0 +1,10 @@
+import { K8sResourceKind, MachineKind, NodeKind } from '@console/internal/module/k8s';
+import { HostMultiStatus } from '../utils/host-status';
+
+export type HostRowBundle = K8sResourceKind & {
+  machine: MachineKind;
+  node: NodeKind;
+  host: K8sResourceKind;
+  nodeMaintenance: K8sResourceKind;
+  status: HostMultiStatus;
+};

--- a/frontend/packages/metal3-plugin/src/constants.ts
+++ b/frontend/packages/metal3-plugin/src/constants.ts
@@ -13,8 +13,8 @@ export const HOST_STATUS_DEPROVISIONING = 'deprovisioning';
 export const HOST_STATUS_MAKING_HOST_AVAILABLE = 'making host available';
 export const HOST_STATUS_MATCH_PROFILE = 'match profile';
 export const HOST_STATUS_STARTING_MAINTENANCE = 'starting maintenance';
+export const HOST_STATUS_UNDER_MAINTENANCE = 'under maintenance';
 export const HOST_STATUS_STOPPING_MAINTENANCE = 'stopping maintenance';
-export const HOST_STATUS_MAINTENANCE = 'maintenance';
 export const HOST_STATUS_VALIDATION_ERROR = 'validation error';
 export const HOST_STATUS_REGISTRATION_ERROR = 'registration error';
 export const HOST_STATUS_PROVISIONING_ERROR = 'provisioning error';
@@ -38,8 +38,8 @@ export const HOST_STATUS_TITLES = {
   [HOST_STATUS_PROVISIONING_ERROR]: 'Provisioning Error',
   [HOST_STATUS_POWER_MANAGEMENT_ERROR]: 'Power Management Error',
   [HOST_STATUS_STARTING_MAINTENANCE]: 'Starting maintenance',
+  [HOST_STATUS_UNDER_MAINTENANCE]: 'Under maintenance',
   [HOST_STATUS_STOPPING_MAINTENANCE]: 'Stopping maintenance',
-  [HOST_STATUS_MAINTENANCE]: 'Maintenance',
   [HOST_STATUS_MATCH_PROFILE]: 'Matching profile',
 };
 

--- a/frontend/packages/metal3-plugin/src/k8s/objects/node-maintenance/index.ts
+++ b/frontend/packages/metal3-plugin/src/k8s/objects/node-maintenance/index.ts
@@ -1,0 +1,22 @@
+import { apiVersionForModel } from '@console/internal/module/k8s';
+import { NodeMaintenanceModel } from '../../../models';
+
+export const buildNodeMaintenance = ({
+  generateName,
+  nodeName,
+  reason,
+}: {
+  nodeName: string;
+  generateName?: string;
+  reason?: string;
+}) => ({
+  apiVersion: apiVersionForModel(NodeMaintenanceModel),
+  kind: NodeMaintenanceModel.kind,
+  metadata: {
+    generateName: `${generateName || 'nm'}-`,
+  },
+  spec: {
+    nodeName,
+    reason,
+  },
+});

--- a/frontend/packages/metal3-plugin/src/k8s/requests/node-maintenance/index.ts
+++ b/frontend/packages/metal3-plugin/src/k8s/requests/node-maintenance/index.ts
@@ -1,0 +1,7 @@
+import { k8sCreate } from '@console/internal/module/k8s';
+import { buildNodeMaintenance } from '../../objects/node-maintenance';
+import { NodeMaintenanceModel } from '../../../models';
+
+export const startNodeMaintenance = (nodeName: string, reason: string) => {
+  return k8sCreate(NodeMaintenanceModel, buildNodeMaintenance({ nodeName, reason }));
+};

--- a/frontend/packages/metal3-plugin/src/models.ts
+++ b/frontend/packages/metal3-plugin/src/models.ts
@@ -12,3 +12,15 @@ export const BaremetalHostModel: K8sKind = {
   id: 'baremetalhost',
   crd: true,
 };
+
+export const NodeMaintenanceModel: K8sKind = {
+  label: 'Node Maintenance',
+  labelPlural: 'Node Maintenances',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'kubevirt.io',
+  plural: 'nodemaintenances',
+  abbr: 'NM',
+  namespaced: false,
+  kind: 'NodeMaintenance',
+  id: 'nodemaintenance',
+};

--- a/frontend/packages/metal3-plugin/src/plugin.ts
+++ b/frontend/packages/metal3-plugin/src/plugin.ts
@@ -50,7 +50,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       model: BaremetalHostModel,
       loader: () =>
         import('./components/host' /* webpackChunkName: "metal3-baremetalhost" */).then(
-          (m) => m.BaremetalHostsPage,
+          (m) => m.BaremetalHostsPageConnected,
         ),
     },
   },
@@ -60,7 +60,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       model: BaremetalHostModel,
       loader: () =>
         import('./components/host-detail' /* webpackChunkName: "metal3-baremetalhost" */).then(
-          (m) => m.BaremetalHostDetailPage,
+          (m) => m.BaremetalHostDetailPageConnected,
         ),
     },
   },

--- a/frontend/packages/metal3-plugin/src/selectors/index.ts
+++ b/frontend/packages/metal3-plugin/src/selectors/index.ts
@@ -4,6 +4,8 @@ import { K8sResourceKind, MachineKind } from '@console/internal/module/k8s';
 import { getName } from '@console/shared';
 import { BaremetalHostDisk } from '../types';
 
+export * from './node-maintanance';
+
 export const getHostOperationalStatus = (host: K8sResourceKind) =>
   _.get(host, 'status.operationalStatus');
 export const getHostProvisioningState = (host: K8sResourceKind) =>
@@ -22,5 +24,6 @@ export const getHostVendorInfo = (host: K8sResourceKind) =>
   _.get(host, 'status.hardware.systemVendor', {});
 export const getHostTotalStorageCapacity = (host: K8sResourceKind) =>
   _.reduce(getHostStorage(host), (sum: number, disk: BaremetalHostDisk) => sum + disk.sizeBytes, 0);
-export const getHostMachine = (host: K8sResourceKind, machines: MachineKind[]) =>
+
+export const getHostMachine = (host: K8sResourceKind, machines: MachineKind[] = []) =>
   machines.find((machine: MachineKind) => getHostMachineName(host) === getName(machine));

--- a/frontend/packages/metal3-plugin/src/selectors/node-maintanance.ts
+++ b/frontend/packages/metal3-plugin/src/selectors/node-maintanance.ts
@@ -1,0 +1,14 @@
+import * as _ from 'lodash';
+
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export const getNodeMaintenanceNodeName = (nodeMaintenance: K8sResourceKind): string =>
+  _.get(nodeMaintenance, 'spec.nodeName');
+
+export const getNodeMaintenanceReason = (nodeMaintenance: K8sResourceKind): string =>
+  _.get(nodeMaintenance, 'spec.reason');
+
+export const findNodeMaintenance = (nodeMaintenances: K8sResourceKind[], nodeName: string) =>
+  (nodeMaintenances || []).find(
+    (nodeMaintenance) => getNodeMaintenanceNodeName(nodeMaintenance) === nodeName,
+  );

--- a/frontend/packages/metal3-plugin/src/utils/host-status.ts
+++ b/frontend/packages/metal3-plugin/src/utils/host-status.ts
@@ -1,29 +1,40 @@
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, MachineKind, NodeKind } from '@console/internal/module/k8s';
 
+import { getDeletetionTimestamp } from '@console/shared';
 import {
   getHostOperationalStatus,
   getHostProvisioningState,
   getHostErrorMessage,
-  // isNodeUnschedulable,
 } from '../selectors';
 
 import {
   HOST_STATUS_TITLES,
+  HOST_STATUS_UNDER_MAINTENANCE,
+  HOST_STATUS_STOPPING_MAINTENANCE,
   HOST_STATUS_READY,
-  // HOST_STATUS_STARTING_MAINTENANCE,
 } from '../constants';
 
-// import { NOT_HANDLED } from '../common';
+const isUnderMaintanance = (maintenance) => {
+  if (maintenance && !getDeletetionTimestamp(maintenance)) {
+    return {
+      status: HOST_STATUS_UNDER_MAINTENANCE,
+      title: HOST_STATUS_TITLES[HOST_STATUS_UNDER_MAINTENANCE],
+      maintenance,
+    };
+  }
+  return null;
+};
 
-// const isStartingMaintenance = (node) => {
-//   if (isNodeUnschedulable(node)) {
-//     return {
-//       status: HOST_STATUS_STARTING_MAINTENANCE,
-//       text: HOST_STATUS_TITLES[HOST_STATUS_STARTING_MAINTENANCE],
-//     };
-//   }
-//   return NOT_HANDLED;
-// };
+const isStoppingMaintanance = (maintenance) => {
+  if (maintenance && getDeletetionTimestamp(maintenance)) {
+    return {
+      status: HOST_STATUS_STOPPING_MAINTENANCE,
+      title: HOST_STATUS_TITLES[HOST_STATUS_STOPPING_MAINTENANCE],
+      maintenance,
+    };
+  }
+  return null;
+};
 
 const getBaremetalHostStatus = (host: K8sResourceKind) => {
   const operationalStatus = getHostOperationalStatus(host);
@@ -37,23 +48,26 @@ const getBaremetalHostStatus = (host: K8sResourceKind) => {
   };
 };
 
-export const getHostStatus = (
-  host: K8sResourceKind,
-  // machine?: MachineKind,
-  // node?: NodeKind,
-) => {
-  // TODO(jtomasek): make this more robust by including node/machine status
-  // return isStartingMaintenance(node) || getBaremetalHostStatus(host);
-  return getBaremetalHostStatus(host);
+export type HostMultiStatus = {
+  status: string;
+  title: string;
+  errorMessage?: string;
 };
 
-export const getSimpleHostStatus = (
-  host: K8sResourceKind,
-  // machine?: MachineKind,
-  // node?: NodeKind,
-): string => getHostStatus(host).status;
+export const getHostStatus = ({ host, nodeMaintenance }: HostStatusProps): HostMultiStatus => {
+  // TODO(jtomasek): make this more robust by including node/machine status
+  return (
+    isUnderMaintanance(nodeMaintenance) ||
+    isStoppingMaintanance(nodeMaintenance) ||
+    getBaremetalHostStatus(host)
+  );
+};
 
-export const canHostAddMachine = (host: K8sResourceKind): boolean =>
-  [HOST_STATUS_READY].includes(getSimpleHostStatus(host));
-// export const canHostStartMaintenance = (hostNode: NodeKind) => hostNode && !isNodeUnschedulable(hostNode);
-// export const canHostStopMaintenance = (hostNode: NodeKind) => isNodeUnschedulable(hostNode);
+type HostStatusProps = {
+  host: K8sResourceKind;
+  machine?: MachineKind;
+  node?: NodeKind;
+  nodeMaintenance?: K8sResourceKind;
+};
+
+export const canHostAddMachine = (status: string): boolean => [HOST_STATUS_READY].includes(status);


### PR DESCRIPTION
- detect availability according to NodeMaintenance CRD
- start maintenance dialog
- enhance & refactor status
- small refactoring
- reverted the old flatten pattern to support status filtering and to
prevent duplicate resource lookup

depends on
~- [] #1964~ 
- [x] #1965
- [ ] #1966
- [x] #2029

@jtomasek @honza  