### PR TITLE
Fix cluster update modal

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -60,7 +60,7 @@ const UpdatesAvailableMessage: React.SFC<CVStatusMessageProps> = ({cv}) => <Reac
     <i className="fa fa-arrow-circle-o-up update-pending" aria-hidden={true} /> Update available
   </div>
   <div>
-    <Button bsStyle="primary" onClick={() => clusterUpdateModal(cv)}>
+    <Button bsStyle="primary" onClick={() => clusterUpdateModal({cv})}>
       Update now
     </Button>
   </div>


### PR DESCRIPTION
The `cv` prop is not passed correctly to the cluster update modal

/assign @rhamilto 