### PR TITLE
table: default virtualize to true

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -352,7 +352,7 @@ export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TableOwn
     }
 
     componentDidUpdate(prevProps){
-      const {data, virtualize} = this.props;
+      const { data, virtualize = true } = this.props;
       if (virtualize && this._bodyRef && !_.isEqual(prevProps.data, data)){
         // force react-virtualized to update after data changes with `isScrollingOptOut` set true
         this._refreshGrid();


### PR DESCRIPTION
Fixes rendering when virtualized is not specified and is expected to be true as a default

rant: this is a bad pattern of setting default values
- causes mistakes
- is not visible from outside and does not behave as an interface (cannot be depended upon)