### PR TITLE
fix the pipeline run task status color mismatch

### DIFF
--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -172,12 +172,13 @@ export enum runStatus {
   Succeeded = 'Succeeded',
   Failed = 'Failed',
   Running = 'Running',
-  'In progress' = 'In Progress',
+  'In Progress' = 'In Progress',
   Pending = 'Pending',
   FailedToStart = 'FailedToStart',
   PipelineNotStarted = 'PipelineNotStarted',
   Skipped = 'Skipped',
   Cancelled = 'Cancelled',
+  Idle = 'Idle',
 }
 
 export const getRunStatusColor = (status: string): StatusMessage => {
@@ -190,6 +191,7 @@ export const getRunStatusColor = (status: string): StatusMessage => {
       return { message: 'Running', pftoken: runningColor };
     case runStatus['In Progress']:
       return { message: 'Running', pftoken: runningColor };
+    case runStatus.Idle:
     case runStatus.Pending:
       return { message: 'Not Started Yet', pftoken: pendingColor };
     case runStatus.FailedToStart:


### PR DESCRIPTION
change the Inprogess status color and Idle status color in the pipeline run visualization.

![screenshot-localhost-9000-2019 07 10-16-50-53](https://user-images.githubusercontent.com/9964343/60965438-7732fa80-a333-11e9-8089-d4ba963497fa.png)


Fixes Issue:  https://jira.coreos.com/browse/ODC-1298