### PR TITLE
Migrate Deploy Image form to PF4 form components

### DIFF
--- a/frontend/integration-tests/tests/deploy-image.scenario.ts
+++ b/frontend/integration-tests/tests/deploy-image.scenario.ts
@@ -29,7 +29,7 @@ describe('Deploy Image', () => {
   describe('Deploy Image page', () => {
     it('can be used to search for an image', async() => {
       await $('#image-name').sendKeys(appName);
-      await $('.input-group-btn .btn-default').click();
+      await $('[data-test-id=image-search]').click();
       await browser.wait(until.presenceOf($('.co-image-name-results__details')));
       expect((element(by.cssContainingText('.co-image-name-results__heading', appName))).isPresent()).toBe(true);
     });

--- a/frontend/public/components/_deploy-image.scss
+++ b/frontend/public/components/_deploy-image.scss
@@ -12,7 +12,6 @@
 .co-image-name-results {
   border-bottom: 1px solid $color-pf-black-200;
   border-top: 1px solid $color-pf-black-200;
-  margin: 30px 0;
   padding: 30px 0;
 
   &__heading {

--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -15,7 +15,8 @@
   align-items: center;
   display: flex;
   height: auto; // allow tags to wrap
-  padding: 3px 0;
+  min-height: 33px; // maintain height of .pf-c-form-controls
+  padding-left: 0;
   width: 100%;
 }
 

--- a/frontend/public/components/deploy-image.tsx
+++ b/frontend/public/components/deploy-image.tsx
@@ -2,7 +2,14 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-import { Alert } from '@patternfly/react-core';
+import {
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  InputGroup,
+  TextInput,
+} from '@patternfly/react-core';
 
 import { FieldLevelHelp } from 'patternfly-react';
 import { getPorts } from './source-to-image';
@@ -73,8 +80,8 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
     this.setState({namespace});
   };
 
-  onImageNameChange: React.ReactEventHandler<HTMLInputElement> = event => {
-    this.setState({imageName: event.currentTarget.value});
+  onImageNameChange = value => {
+    this.setState({imageName: value});
   };
 
   onKeyPress = event => {
@@ -87,8 +94,8 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
     this.env = env;
   };
 
-  onNameChange: React.ReactEventHandler<HTMLInputElement> = event => {
-    this.setState({name: event.currentTarget.value});
+  onNameChange = value => {
+    this.setState({name: value});
   };
 
   onLabelsChange = (labels: string[]) => {
@@ -320,34 +327,42 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
       </Helmet>
       <PageHeading title={title} />
       <div className="co-m-pane__body">
-        <form onSubmit={this.save} className="co-deploy-image co-m-pane__form">
-          <div className="form-group co-deploy-image__namespace">
-            <label className="control-label co-required" htmlFor="dropdown-selectbox">Namespace</label>
+        <Form onSubmit={this.save} className="co-deploy-image">
+          <FormGroup
+            className="co-deploy-image__namespace"
+            label="Namespace"
+            isRequired
+            fieldId="dropdown-selectbox">
             <NsDropdown selectedKey={this.state.namespace} onChange={this.onNamespaceChange} id="dropdown-selectbox" />
-          </div>
-          <p>Deploy an existing image from an {/*image stream tag or */} image registry.</p>
-          <div className="form-group co-deploy-image__image-name">
-            <label className="control-label co-required" htmlFor="image-name">Image Name</label>
-            <div className="input-group">
-              <input className="form-control"
+          </FormGroup>
+          <FormGroup fieldId="co-deploy-image__instructions">
+            <p style={{margin: 0}}>Deploy an existing image from an {/*image stream tag or */} image registry.</p>
+          </FormGroup>
+          <FormGroup
+            className="co-deploy-image__image-name"
+            label="Image Name"
+            isRequired
+            fieldId="image-name"
+            helperText={<React.Fragment>To deploy an image from a private repository, you must <Link to={`/k8s/ns/${this.state.namespace || 'default'}/secrets/~new/image`}>create an image pull secret</Link> with your image registry credentials.</React.Fragment>}>
+            <InputGroup>
+              <TextInput
+                name="imageName"
+                id="image-name"
                 type="search"
                 onChange={this.onImageNameChange}
                 onKeyDown={this.onKeyPress}
                 value={this.state.imageName}
-                id="image-name"
-                name="imageName"
-                aria-describedby="image-name-help" />
-              <span className="input-group-btn">
-                <button type="button" className="btn btn-default" onClick={this.search} disabled={!this.state.imageName}>
-                  <i className="fa fa-search" aria-hidden="true"></i>
-                  <span className="sr-only">Find</span>
-                </button>
-              </span>
-            </div>
-            <div className="help-block" id="image-name-help">
-              To deploy an image from a private repository, you must <Link to={`/k8s/ns/${this.state.namespace || 'default'}/secrets/~new/image`}>create an image pull secret</Link> with your image registry credentials.
-            </div>
-          </div>
+                aria-describedby="image-name-helper" />
+              <Button
+                variant="tertiary"
+                aria-label="Find"
+                onClick={this.search}
+                isDisabled={!this.state.imageName}
+                data-test-id="image-search">
+                <i className="fa fa-search" aria-hidden="true"></i>
+              </Button>
+            </InputGroup>
+          </FormGroup>
           <div className="co-image-name-results">
             {!isi && <div className="co-image-name-results__loading">
               {loading && <Loading className="co-m-loader--inline" />}
@@ -389,37 +404,44 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
                     </p>}
                   </div>
                 </div>
-                <div className="form-group co-deploy-image__name">
-                  <label htmlFor="name" className="control-label co-required">Name</label>
-                  <input className="form-control"
+              </div>
+              <div className="pf-c-form">
+                <FormGroup
+                  className="co-deploy-image__image-name"
+                  label="Name"
+                  isRequired
+                  fieldId="name"
+                  helperText="Identifies the resources created for this image.">
+                  <TextInput
+                    name="name"
+                    id="name"
                     type="text"
                     onChange={this.onNameChange}
                     value={name}
-                    id="name"
-                    name="name"
-                    required />
-                  <div className="help-block">Identifies the resources created for this image.</div>
-                </div>
-              </div>
-              <div className="form-group co-deploy-image__labels">
-                <label htmlFor="tags-input" className="control-label">Labels</label>
-                <SelectorInput labelClassName="co-text-deploymentconfig" onChange={this.onLabelsChange} tags={labels} />
-                <div className="help-block" id="labels-help">
-                  If no labels are specified, app={name || '<name>'} will be added.
-                </div>
-              </div>
-              <div>
-                <label>Environment Variables</label>
-                <FieldLevelHelp content={
-                  <div>Define environment variables as key-value pairs to store configuration settings. Drag and drop environment variables to change the order in which they are run. A variable can reference any other variables that come before it in the list, for example <code>FULLDOMAIN = $(SUBDOMAIN).example.com</code>.</div>} />
-                <div>
-                  <EnvironmentPage
-                    envPath={['spec','template','spec','containers']}
-                    readOnly={false}
-                    onChange={this.onEnvironmentChange}
-                    addConfigMapSecret={false}
-                    useLoadingInline={true} />
-                </div>
+                    aria-describedby="name-helper"/>
+                </FormGroup>
+                <FormGroup
+                  className="co-deploy-image__labels"
+                  label="Labels"
+                  isRequired
+                  fieldId="tags-input"
+                  helperText={<React.Fragment>If no labels are specified, app={name || '<name>'} will be added.</React.Fragment>}>
+                  <SelectorInput labelClassName="co-text-deploymentconfig" onChange={this.onLabelsChange} tags={labels} />
+                </FormGroup>
+                <FormGroup
+                  fieldId="co-deploy-image__env-vars">
+                  <label>Environment Variables</label>
+                  <FieldLevelHelp content={
+                    <div>Define environment variables as key-value pairs to store configuration settings. Drag and drop environment variables to change the order in which they are run. A variable can reference any other variables that come before it in the list, for example <code>FULLDOMAIN = $(SUBDOMAIN).example.com</code>.</div>} />
+                  <div>
+                    <EnvironmentPage
+                      envPath={['spec','template','spec','containers']}
+                      readOnly={false}
+                      onChange={this.onEnvironmentChange}
+                      addConfigMapSecret={false}
+                      useLoadingInline={true} />
+                  </div>
+                </FormGroup>
               </div>
             </React.Fragment>}
           </div>
@@ -427,7 +449,7 @@ export class DeployImage extends React.Component<DeployImageProps, DeployImageSt
             <button type="submit" className="btn btn-primary" disabled={!this.state.namespace || !this.state.imageName || !this.state.name}>Deploy</button>
             <Link to={formatNamespacedRouteForResource('deploymentconfigs')} className="btn btn-default">Cancel</Link>
           </ButtonBar>
-        </form>
+        </Form>
       </div>
     </React.Fragment>;
   }

--- a/frontend/public/components/utils/_label.scss
+++ b/frontend/public/components/utils/_label.scss
@@ -42,6 +42,7 @@ tags-input .tags {
   color: $input-color;
   cursor: text;
   line-height: $co-m-label-line-height;
+  margin: -2px 0;
   padding: 0 $padding-base-horizontal;
 }
 

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -34,7 +34,8 @@
 
 
 // Restrict form widths
-.co-m-pane__form {
+.co-m-pane__form,
+.pf-c-form {
   @media (min-width: 769px) {
     max-width: 650px;
   }

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -96,6 +96,15 @@ kbd {
   max-width: 100%;
 }
 
+.pf-c-form {
+  .pf-c-form__helper-text {
+    --pf-c-form__helper-text--FontSize: #{$font-size-base};
+  }
+  .pf-c-form__label {
+    --pf-c-form__label--FontSize: #{$font-size-base};
+  }
+}
+
 // PF components that calculate their correct height based on --pf-global--FontSize--md: 1rem
 .pf-c-modal-box,
 .pf-c-switch {


### PR DESCRIPTION
![localhost_9000_deploy-image_preselected-ns=robb](https://user-images.githubusercontent.com/895728/60983793-99fbe980-a308-11e9-9a8f-151e7df3d4d2.png)

Supports https://jira.coreos.com/browse/CONSOLE-1564

PF4 forms are significantly different from PF3 forms such that there is not an easy migration path (e.g., swapping existing classes). 

Note:  PF4's `<Form>` is used to control the spacing between groupings, which is problematic when groupings are not direct descendants of `<Form>` (this seems like a design flaw in PF4 forms).  The workaround is to add a [`<div className="pf-c-form">`](https://github.com/openshift/console/compare/master...rhamilto:form-deploy-image?expand=1#diff-a446ce5f1da338fec4ae2846acd42785R408) around the non-direct descendant groupings. 