### PR TITLE
Allow user to select container to mount volume

### DIFF
--- a/frontend/public/components/container-selector.tsx
+++ b/frontend/public/components/container-selector.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+import { ContainerSpec } from '../module/k8s';
+import { Checkbox } from '@patternfly/react-core';
+
+export const ContainerSelector: React.FC<ContainerSelectorProps> = ({ containers, onChange, selected }) => <div>
+  {containers.map((container: ContainerSpec) => <Checkbox
+    key={container.name}
+    label={`${container.name} from image ${container.image}`}
+    id={container.name}
+    isChecked={selected.includes(container.name)}
+    onChange={onChange}
+  />)}
+</div>;
+
+export type ContainerSelectorProps = {
+  containers: ContainerSpec[];
+  onChange: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;
+  selected: string[];
+};


### PR DESCRIPTION
Allow users to select which container they wish to mount a volume to.

Converted the `AttachStorage` to a functional component and to use hooks.
Also created new component ContainerSelector.
![selectcontain-thur1](https://user-images.githubusercontent.com/18728857/61082389-9ccd0c00-a3e6-11e9-8965-72a830eedad8.png)
![containerselector-mon](https://user-images.githubusercontent.com/18728857/61240408-66510300-a6fe-11e9-815a-82ac9bf18678.png)




 