### PR TITLE
Enable kubevirt-plugin by default

### DIFF
--- a/frontend/__mocks__/mutationObserver.js
+++ b/frontend/__mocks__/mutationObserver.js
@@ -1,0 +1,7 @@
+/* eslint-disable */
+
+global.MutationObserver = class {
+  constructor(callback) {}
+  disconnect() {}
+  observe(element, initObject) {}
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
       "./__mocks__/localStorage.ts",
       "./__mocks__/matchMedia.js",
       "./__mocks__/serverFlags.js",
+      "./__mocks__/mutationObserver.js",
       "./before-tests.js"
     ],
     "coverageDirectory": "__coverage__",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
       ".(ts|tsx|js|jsx)": "./node_modules/ts-jest/preprocessor.js"
     },
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!lodash-es|@console)"
+      "<rootDir>/node_modules/(?!(lodash-es|@console|@novnc|@spice-project)/.*)"
     ],
     "testRegex": "/__tests__/.*\\.spec\\.(ts|tsx|js|jsx)$",
     "testURL": "http://localhost",

--- a/frontend/packages/console-app/package.json
+++ b/frontend/packages/console-app/package.json
@@ -13,7 +13,8 @@
     "@console/knative-plugin": "0.0.0-fixed",
     "@console/metal3-plugin": "0.0.0-fixed",
     "@console/plugin-sdk": "0.0.0-fixed",
-    "@console/shared": "0.0.0-fixed"
+    "@console/shared": "0.0.0-fixed",
+    "@console/kubevirt-plugin": "0.0.0-fixed"
   },
   "consolePlugin": {
     "entry": "src/plugin.tsx"


### PR DESCRIPTION
We are close to expected feature-parity with the forked kubevirt/web-ui.