### PR TITLE
Fix ref type in width hook

### DIFF
--- a/frontend/public/components/utils/ref-width-hook.ts
+++ b/frontend/public/components/utils/ref-width-hook.ts
@@ -16,5 +16,5 @@ export const useRefWidth = () => {
     };
   }, []);
 
-  return [ref, width] as [React.Ref<HTMLDivElement>, number];
+  return [ref, width] as [React.MutableRefObject<HTMLDivElement>, number];
 };


### PR DESCRIPTION
`useRef` function returns `MutableRefObject<T>`