### PR TITLE
Migrate Service Catalog forms to PF4 form components

### DIFF
--- a/frontend/public/components/service-catalog/create-binding.tsx
+++ b/frontend/public/components/service-catalog/create-binding.tsx
@@ -135,7 +135,7 @@ class CreateBindingForm extends React.Component<CreateBindingProps, CreateBindin
             <form className="co-create-service-binding co-m-pane__form">
               <div className="form-group co-create-service-binding__name">
                 <label className="control-label co-required" htmlFor="name">Service Binding Name</label>
-                <input className="form-control"
+                <input className="pf-c-form-control"
                   type="text"
                   onChange={this.onNameChange}
                   value={name}

--- a/frontend/public/components/service-catalog/create-instance.tsx
+++ b/frontend/public/components/service-catalog/create-instance.tsx
@@ -157,7 +157,7 @@ class CreateInstance extends React.Component<CreateInstanceProps, CreateInstance
                 </div>
                 <div className="form-group co-create-service-instance__name">
                   <label className="control-label co-required" htmlFor="name">Service Instance Name</label>
-                  <input className="form-control"
+                  <input className="pf-c-form-control"
                     type="text"
                     onChange={this.onNameChange}
                     value={this.state.name}

--- a/frontend/public/components/service-catalog/schema-form.tsx
+++ b/frontend/public/components/service-catalog/schema-form.tsx
@@ -126,7 +126,7 @@ const CustomBaseInput = (props) => {
 
   return (
     <input
-      className="form-control"
+      className="pf-c-form-control"
       readOnly={readonly}
       disabled={disabled}
       autoFocus={autofocus}


### PR DESCRIPTION
Supports https://jira.coreos.com/browse/CONSOLE-1564

NOTE:  these changes are untested, but I am confident they are ok.