### PR TITLE
feat(virtual-table): split virtualized table, cluster settings table

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -27,7 +27,7 @@ import {
   CSVConditionReason,
   copiedLabelKey,
 } from '../../../public/components/operator-lifecycle-manager';
-import { DetailsPage, ListPage, TableInnerProps, Table, TableRow } from '../../../public/components/factory';
+import { DetailsPage, ListPage, VirtualTableInnerProps, VirtualTable, VirtualTableRow } from '../../../public/components/factory';
 import { testClusterServiceVersion } from '../../../__mocks__/k8sResourcesMocks';
 import {
   Timestamp,
@@ -63,7 +63,7 @@ describe(ClusterServiceVersionTableRow.displayName, () => {
   });
 
   it('renders `ResourceKebab` with actions', () => {
-    const col = wrapper.find(TableRow);
+    const col = wrapper.find(VirtualTableRow);
 
     expect(col.find(ResourceKebab).props().resource).toEqual(testClusterServiceVersion);
     expect(col.find(ResourceKebab).props().kind).toEqual(referenceForModel(ClusterServiceVersionModel));
@@ -71,14 +71,14 @@ describe(ClusterServiceVersionTableRow.displayName, () => {
   });
 
   it('renders clickable column for app logo and name', () => {
-    const col = wrapper.find(TableRow).childAt(0);
+    const col = wrapper.find(VirtualTableRow).childAt(0);
 
     expect(col.find(Link).props().to).toEqual(`/k8s/ns/${testClusterServiceVersion.metadata.namespace}/${ClusterServiceVersionModel.plural}/${testClusterServiceVersion.metadata.name}`);
     expect(col.find(Link).find(ClusterServiceVersionLogo).exists()).toBe(true);
   });
 
   it('renders column for app namespace link', () => {
-    const link = wrapper.find(TableRow).childAt(1).find(ResourceLink);
+    const link = wrapper.find(VirtualTableRow).childAt(1).find(ResourceLink);
 
     expect(link.props().kind).toEqual('Namespace');
     expect(link.props().title).toEqual(testClusterServiceVersion.metadata.namespace);
@@ -86,14 +86,14 @@ describe(ClusterServiceVersionTableRow.displayName, () => {
   });
 
   it('renders column with link to Operator deployment', () => {
-    const col = wrapper.find(TableRow).childAt(2);
+    const col = wrapper.find(VirtualTableRow).childAt(2);
 
     expect(col.find(ResourceLink).props().kind).toEqual('Deployment');
     expect(col.find(ResourceLink).props().name).toEqual(testClusterServiceVersion.spec.install.spec.deployments[0].name);
   });
 
   it('renders column for app status', () => {
-    const col = wrapper.find(TableRow).childAt(3);
+    const col = wrapper.find(VirtualTableRow).childAt(3);
     const statusComponent = col.childAt(0).find('SuccessStatus');
     expect(statusComponent.exists()).toBeTruthy();
     expect(statusComponent.prop('title')).toEqual(CSVConditionReason.CSVReasonInstallSuccessful);
@@ -101,13 +101,13 @@ describe(ClusterServiceVersionTableRow.displayName, () => {
 
   it('renders "disabling" status if CSV has `deletionTimestamp`', () => {
     wrapper = wrapper.setProps({obj: _.cloneDeepWith(testClusterServiceVersion, (v, k) => k === 'metadata' ? {...v, deletionTimestamp: Date.now()} : undefined)});
-    const col = wrapper.find(TableRow).childAt(3);
+    const col = wrapper.find(VirtualTableRow).childAt(3);
 
     expect(col.childAt(0).text()).toEqual('Disabling');
   });
 
   it('renders column with each CRD provided by the Operator', () => {
-    const col = wrapper.find(TableRow).childAt(4);
+    const col = wrapper.find(VirtualTableRow).childAt(4);
     testClusterServiceVersion.spec.customresourcedefinitions.owned.forEach((desc, i) => {
       expect(col.find(Link).at(i).props().title).toEqual(desc.name);
       expect(col.find(Link).at(i).props().to).toEqual(`/k8s/ns/default/clusterserviceversions/testapp/${referenceForProvidedAPI(desc)}`);
@@ -146,8 +146,8 @@ describe(ClusterServiceVersionList.displayName, () => {
 
   it('renders `List` with correct props', () => {
     const wrapper = shallow(<ClusterServiceVersionList data={[]} loaded={true} />);
-    expect(wrapper.find<TableInnerProps>(Table).props().Row).toEqual(ClusterServiceVersionTableRow);
-    expect(wrapper.find<TableInnerProps>(Table).props().Header).toEqual(ClusterServiceVersionTableHeader);
+    expect(wrapper.find<VirtualTableInnerProps>(VirtualTable).props().Row).toEqual(ClusterServiceVersionTableRow);
+    expect(wrapper.find<VirtualTableInnerProps>(VirtualTable).props().Header).toEqual(ClusterServiceVersionTableHeader);
   });
 });
 

--- a/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/install-plan.spec.tsx
@@ -6,7 +6,7 @@ import Spy = jasmine.Spy;
 
 import { InstallPlanTableHeader, InstallPlanTableRow, InstallPlanTableRowProps, InstallPlansList, InstallPlansListProps, InstallPlansPage, InstallPlansPageProps, InstallPlanDetailsPage, InstallPlanPreview, InstallPlanPreviewProps, InstallPlanPreviewState, InstallPlanDetailsPageProps, InstallPlanDetails, InstallPlanDetailsProps } from '../../../public/components/operator-lifecycle-manager/install-plan';
 import { InstallPlanKind, InstallPlanApproval, referenceForStepResource } from '../../../public/components/operator-lifecycle-manager';
-import { Table, TableRow, MultiListPage, DetailsPage } from '../../../public/components/factory';
+import { VirtualTable, VirtualTableRow, MultiListPage, DetailsPage } from '../../../public/components/factory';
 import { ResourceKebab, ResourceLink, ResourceIcon, Kebab, MsgBox } from '../../../public/components/utils';
 import { testInstallPlan } from '../../../__mocks__/k8sResourcesMocks';
 import { InstallPlanModel, ClusterServiceVersionModel, OperatorGroupModel, CustomResourceDefinitionModel } from '../../../public/models';
@@ -27,43 +27,43 @@ describe(InstallPlanTableRow.displayName, () => {
   });
 
   it('renders resource kebab for performing common actions', () => {
-    expect(wrapper.find(TableRow).find(ResourceKebab).props().actions).toEqual(Kebab.factory.common);
+    expect(wrapper.find(VirtualTableRow).find(ResourceKebab).props().actions).toEqual(Kebab.factory.common);
   });
 
   it('renders column for install plan name', () => {
-    expect(wrapper.find(TableRow).childAt(0).find(ResourceLink).props().kind).toEqual(k8s.referenceForModel(InstallPlanModel));
-    expect(wrapper.find(TableRow).childAt(0).find(ResourceLink).props().namespace).toEqual(testInstallPlan.metadata.namespace);
-    expect(wrapper.find(TableRow).childAt(0).find(ResourceLink).props().name).toEqual(testInstallPlan.metadata.name);
-    expect(wrapper.find(TableRow).childAt(0).find(ResourceLink).props().title).toEqual(testInstallPlan.metadata.uid);
+    expect(wrapper.find(VirtualTableRow).childAt(0).find(ResourceLink).props().kind).toEqual(k8s.referenceForModel(InstallPlanModel));
+    expect(wrapper.find(VirtualTableRow).childAt(0).find(ResourceLink).props().namespace).toEqual(testInstallPlan.metadata.namespace);
+    expect(wrapper.find(VirtualTableRow).childAt(0).find(ResourceLink).props().name).toEqual(testInstallPlan.metadata.name);
+    expect(wrapper.find(VirtualTableRow).childAt(0).find(ResourceLink).props().title).toEqual(testInstallPlan.metadata.uid);
   });
 
   it('renders column for install plan namespace', () => {
-    expect(wrapper.find(TableRow).childAt(1).find(ResourceLink).props().kind).toEqual('Namespace');
-    expect(wrapper.find(TableRow).childAt(1).find(ResourceLink).props().title).toEqual(testInstallPlan.metadata.namespace);
-    expect(wrapper.find(TableRow).childAt(1).find(ResourceLink).props().displayName).toEqual(testInstallPlan.metadata.namespace);
+    expect(wrapper.find(VirtualTableRow).childAt(1).find(ResourceLink).props().kind).toEqual('Namespace');
+    expect(wrapper.find(VirtualTableRow).childAt(1).find(ResourceLink).props().title).toEqual(testInstallPlan.metadata.namespace);
+    expect(wrapper.find(VirtualTableRow).childAt(1).find(ResourceLink).props().displayName).toEqual(testInstallPlan.metadata.namespace);
   });
 
   it('render column for install plan components list', () => {
-    expect(wrapper.find(TableRow).childAt(2).find(ResourceLink).props().kind).toEqual(k8s.referenceForModel(ClusterServiceVersionModel));
-    expect(wrapper.find(TableRow).childAt(2).find(ResourceLink).props().name).toEqual(testInstallPlan.spec.clusterServiceVersionNames.toString());
-    expect(wrapper.find(TableRow).childAt(2).find(ResourceLink).props().namespace).toEqual(testInstallPlan.metadata.namespace);
+    expect(wrapper.find(VirtualTableRow).childAt(2).find(ResourceLink).props().kind).toEqual(k8s.referenceForModel(ClusterServiceVersionModel));
+    expect(wrapper.find(VirtualTableRow).childAt(2).find(ResourceLink).props().name).toEqual(testInstallPlan.spec.clusterServiceVersionNames.toString());
+    expect(wrapper.find(VirtualTableRow).childAt(2).find(ResourceLink).props().namespace).toEqual(testInstallPlan.metadata.namespace);
   });
 
   it('renders column for parent subscription(s) determined by `metadata.ownerReferences`', () => {
-    expect(wrapper.find(TableRow).childAt(3).find(ResourceLink).length).toEqual(1);
+    expect(wrapper.find(VirtualTableRow).childAt(3).find(ResourceLink).length).toEqual(1);
   });
 
   it('renders column for install plan status', () => {
-    expect(wrapper.find(TableRow).childAt(4).shallow().text()).toEqual(testInstallPlan.status.phase);
+    expect(wrapper.find(VirtualTableRow).childAt(4).shallow().text()).toEqual(testInstallPlan.status.phase);
   });
 
   it('renders column with fallback status if `status.phase` is undefined', () => {
     const obj = {..._.cloneDeep(testInstallPlan), status: null};
     wrapper = wrapper.setProps({obj});
 
-    expect(wrapper.find(TableRow).childAt(4).shallow().text()).toEqual('Unknown');
-    expect(wrapper.find(TableRow).childAt(2).find(ResourceIcon).length).toEqual(1);
-    expect(wrapper.find(TableRow).childAt(2).find(ResourceIcon).at(0).props().kind).toEqual(k8s.referenceForModel(ClusterServiceVersionModel));
+    expect(wrapper.find(VirtualTableRow).childAt(4).shallow().text()).toEqual('Unknown');
+    expect(wrapper.find(VirtualTableRow).childAt(2).find(ResourceIcon).length).toEqual(1);
+    expect(wrapper.find(VirtualTableRow).childAt(2).find(ResourceIcon).at(0).props().kind).toEqual(k8s.referenceForModel(ClusterServiceVersionModel));
   });
 });
 
@@ -75,12 +75,12 @@ describe(InstallPlansList.displayName, () => {
   });
 
   it('renders a `Table` component with the correct props', () => {
-    expect(wrapper.find<any>(Table).props().Header).toEqual(InstallPlanTableHeader);
-    expect(wrapper.find<any>(Table).props().Row).toEqual(InstallPlanTableRow);
+    expect(wrapper.find<any>(VirtualTable).props().Header).toEqual(InstallPlanTableHeader);
+    expect(wrapper.find<any>(VirtualTable).props().Row).toEqual(InstallPlanTableRow);
   });
 
   it('passes custom empty message for table', () => {
-    const EmptyMsg = wrapper.find<any>(Table).props().EmptyMsg;
+    const EmptyMsg = wrapper.find<any>(VirtualTable).props().EmptyMsg;
     const msgWrapper = shallow(<EmptyMsg />);
 
     expect(msgWrapper.find(MsgBox).props().title).toEqual('No Install Plans Found');

--- a/frontend/__tests__/components/operator-lifecycle-manager/operand.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/operand.spec.tsx
@@ -22,7 +22,7 @@ import { referenceForProvidedAPI } from '../../../public/components/operator-lif
 import { StatusDescriptor } from '../../../public/components/operator-lifecycle-manager/descriptors/status';
 import { SpecDescriptor } from '../../../public/components/operator-lifecycle-manager/descriptors/spec';
 import { testCRD, testResourceInstance, testClusterServiceVersion, testOwnedResourceInstance, testModel } from '../../../__mocks__/k8sResourcesMocks';
-import { Table, DetailsPage, MultiListPage, ListPage } from '../../../public/components/factory';
+import { VirtualTable, DetailsPage, MultiListPage, ListPage } from '../../../public/components/factory';
 import { Timestamp, LabelList, StatusBox, ResourceKebab } from '../../../public/components/utils';
 import { referenceFor, referenceForModel , K8sResourceKind } from '../../../public/module/k8s';
 import { ClusterServiceVersionModel } from '../../../public/models';
@@ -109,8 +109,8 @@ describe(OperandList.displayName, () => {
     wrapper = shallow(<OperandList loaded={true} data={resources} filters={{}} />);
   });
 
-  it('renders a `Table` of the custom resource instances of the given kind', () => {
-    const table: ShallowWrapper<any> = wrapper.find(Table);
+  it('renders a `VirtualTable` of the custom resource instances of the given kind', () => {
+    const table: ShallowWrapper<any> = wrapper.find(VirtualTable);
     expect(Object.keys(wrapper.props()).reduce((k, prop) => table.prop(prop) === wrapper.prop(prop), false)).toBe(true);
     expect(table.props().Header).toEqual(OperandTableHeader);
     expect(table.props().Row).toEqual(OperandTableRow);

--- a/frontend/__tests__/components/operator-lifecycle-manager/package-manifest.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/package-manifest.spec.tsx
@@ -5,7 +5,7 @@ import * as _ from 'lodash-es';
 
 import { PackageManifestTableHeader, PackageManifestTableRow, PackageManifestTableRowProps, PackageManifestList, PackageManifestListProps } from '../../../public/components/operator-lifecycle-manager/package-manifest';
 import { ClusterServiceVersionLogo, PackageManifestKind } from '../../../public/components/operator-lifecycle-manager';
-import { Table, TableRow } from '../../../public/components/factory';
+import { VirtualTable, VirtualTableRow } from '../../../public/components/factory';
 import { testPackageManifest, testCatalogSource, testSubscription } from '../../../__mocks__/k8sResourcesMocks';
 
 describe(PackageManifestTableHeader.displayName, () => {
@@ -31,33 +31,33 @@ describe(PackageManifestTableRow.displayName, () => {
   });
 
   it('renders column for package name and logo', () => {
-    expect(wrapper.find(TableRow).childAt(0).dive().find(ClusterServiceVersionLogo).props().displayName).toEqual(testPackageManifest.status.channels[0].currentCSVDesc.displayName);
+    expect(wrapper.find(VirtualTableRow).childAt(0).dive().find(ClusterServiceVersionLogo).props().displayName).toEqual(testPackageManifest.status.channels[0].currentCSVDesc.displayName);
   });
 
   it('renders column for latest CSV version for package in catalog', () => {
     const {name, currentCSVDesc: {version}} = testPackageManifest.status.channels[0];
-    expect(wrapper.find(TableRow).childAt(1).dive().text()).toEqual(`${version} (${name})`);
+    expect(wrapper.find(VirtualTableRow).childAt(1).dive().text()).toEqual(`${version} (${name})`);
   });
 
   it('does not render link if no subscriptions exist in the current namespace', () => {
     wrapper = wrapper.setProps({subscription: null});
 
-    expect(wrapper.find(TableRow).childAt(2).dive().text()).toContain('None');
+    expect(wrapper.find(VirtualTableRow).childAt(2).dive().text()).toContain('None');
   });
 
   it('renders column with link to subscriptions', () => {
-    expect(wrapper.find(TableRow).childAt(2).dive().find(Link).at(0).props().to).toEqual(`/operatormanagement/ns/default?name=${testSubscription.metadata.name}`);
-    expect(wrapper.find(TableRow).childAt(2).dive().find(Link).at(0).childAt(0).text()).toEqual('View');
+    expect(wrapper.find(VirtualTableRow).childAt(2).dive().find(Link).at(0).props().to).toEqual(`/operatormanagement/ns/default?name=${testSubscription.metadata.name}`);
+    expect(wrapper.find(VirtualTableRow).childAt(2).dive().find(Link).at(0).childAt(0).text()).toEqual('View');
   });
 
   it('renders button to create new subscription if `canSubscribe` is true', () => {
-    expect(wrapper.find(TableRow).childAt(2).dive().find('button').text()).toEqual('Create Subscription');
+    expect(wrapper.find(VirtualTableRow).childAt(2).dive().find('button').text()).toEqual('Create Subscription');
   });
 
   it('does not render button to create new subscription if `canSubscribe` is false', () => {
     wrapper = wrapper.setProps({canSubscribe: false});
 
-    expect(wrapper.find(TableRow).childAt(2).dive().find('button').exists()).toBe(false);
+    expect(wrapper.find(VirtualTableRow).childAt(2).dive().find('button').exists()).toBe(false);
   });
 });
 
@@ -82,11 +82,11 @@ describe(PackageManifestList.displayName, () => {
     });
   });
 
-  it('renders `Table` component with correct props for each section', () => {
-    expect(wrapper.find(Table).length).toEqual(2);
+  it('renders `VirtualTable` component with correct props for each section', () => {
+    expect(wrapper.find(VirtualTable).length).toEqual(2);
     packages.forEach((pkg, i) => {
-      expect(wrapper.find('.co-catalogsource-list__section').at(i).find(Table).props().Header).toEqual(PackageManifestTableHeader);
-      expect(wrapper.find('.co-catalogsource-list__section').at(i).find(Table).props().data.length).toEqual(1);
+      expect(wrapper.find('.co-catalogsource-list__section').at(i).find(VirtualTable).props().Header).toEqual(PackageManifestTableHeader);
+      expect(wrapper.find('.co-catalogsource-list__section').at(i).find(VirtualTable).props().data.length).toEqual(1);
     });
   });
 });

--- a/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/subscription.spec.tsx
@@ -6,7 +6,7 @@ import { SubscriptionTableHeader, SubscriptionTableRow, SubscriptionTableRowProp
 import { SubscriptionKind, SubscriptionState } from '../../../public/components/operator-lifecycle-manager';
 import { referenceForModel } from '../../../public/module/k8s';
 import { SubscriptionModel, ClusterServiceVersionModel, PackageManifestModel, OperatorGroupModel, InstallPlanModel } from '../../../public/models';
-import { Table, TableRow, MultiListPage, DetailsPage } from '../../../public/components/factory';
+import { VirtualTable, VirtualTableRow, MultiListPage, DetailsPage } from '../../../public/components/factory';
 import { ResourceKebab, ResourceLink, Kebab } from '../../../public/components/utils';
 import { testSubscription, testClusterServiceVersion, testPackageManifest } from '../../../__mocks__/k8sResourcesMocks';
 
@@ -26,61 +26,61 @@ describe(SubscriptionTableRow.displayName, () => {
   });
 
   it('renders column for subscription name', () => {
-    expect(wrapper.find(TableRow).childAt(0).shallow().find(ResourceLink).props().name).toEqual(subscription.metadata.name);
-    expect(wrapper.find(TableRow).childAt(0).shallow().find(ResourceLink).props().title).toEqual(subscription.metadata.name);
-    expect(wrapper.find(TableRow).childAt(0).shallow().find(ResourceLink).props().namespace).toEqual(subscription.metadata.namespace);
-    expect(wrapper.find(TableRow).childAt(0).shallow().find(ResourceLink).props().kind).toEqual(referenceForModel(SubscriptionModel));
+    expect(wrapper.find(VirtualTableRow).childAt(0).shallow().find(ResourceLink).props().name).toEqual(subscription.metadata.name);
+    expect(wrapper.find(VirtualTableRow).childAt(0).shallow().find(ResourceLink).props().title).toEqual(subscription.metadata.name);
+    expect(wrapper.find(VirtualTableRow).childAt(0).shallow().find(ResourceLink).props().namespace).toEqual(subscription.metadata.namespace);
+    expect(wrapper.find(VirtualTableRow).childAt(0).shallow().find(ResourceLink).props().kind).toEqual(referenceForModel(SubscriptionModel));
   });
 
   it('renders actions kebab', () => {
     const menuArgs = [ClusterServiceVersionModel, subscription];
-    expect(wrapper.find(TableRow).find(ResourceKebab).props().kind).toEqual(referenceForModel(SubscriptionModel));
-    expect(wrapper.find(TableRow).find(ResourceKebab).props().resource).toEqual(subscription);
-    expect(wrapper.find(TableRow).find(ResourceKebab).props().actions[0]).toEqual(Kebab.factory.Edit);
-    expect(wrapper.find(TableRow).find(ResourceKebab).props().actions[1](...menuArgs).label).toEqual('Remove Subscription...');
-    expect(wrapper.find(TableRow).find(ResourceKebab).props().actions[1](...menuArgs).callback).toBeDefined();
-    expect(wrapper.find(TableRow).find(ResourceKebab).props().actions[2](...menuArgs).label).toEqual(`View ${ClusterServiceVersionModel.kind}...`);
-    expect(wrapper.find(TableRow).find(ResourceKebab).props().actions[2](...menuArgs).href).toEqual(`/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp.v1.0.0`);
+    expect(wrapper.find(VirtualTableRow).find(ResourceKebab).props().kind).toEqual(referenceForModel(SubscriptionModel));
+    expect(wrapper.find(VirtualTableRow).find(ResourceKebab).props().resource).toEqual(subscription);
+    expect(wrapper.find(VirtualTableRow).find(ResourceKebab).props().actions[0]).toEqual(Kebab.factory.Edit);
+    expect(wrapper.find(VirtualTableRow).find(ResourceKebab).props().actions[1](...menuArgs).label).toEqual('Remove Subscription...');
+    expect(wrapper.find(VirtualTableRow).find(ResourceKebab).props().actions[1](...menuArgs).callback).toBeDefined();
+    expect(wrapper.find(VirtualTableRow).find(ResourceKebab).props().actions[2](...menuArgs).label).toEqual(`View ${ClusterServiceVersionModel.kind}...`);
+    expect(wrapper.find(VirtualTableRow).find(ResourceKebab).props().actions[2](...menuArgs).href).toEqual(`/k8s/ns/default/${ClusterServiceVersionModel.plural}/testapp.v1.0.0`);
   });
 
   it('renders column for namespace name', () => {
-    expect(wrapper.find(TableRow).childAt(1).shallow().find(ResourceLink).props().name).toEqual(subscription.metadata.namespace);
-    expect(wrapper.find(TableRow).childAt(1).shallow().find(ResourceLink).props().title).toEqual(subscription.metadata.namespace);
-    expect(wrapper.find(TableRow).childAt(1).shallow().find(ResourceLink).props().displayName).toEqual(subscription.metadata.namespace);
-    expect(wrapper.find(TableRow).childAt(1).shallow().find(ResourceLink).props().kind).toEqual('Namespace');
+    expect(wrapper.find(VirtualTableRow).childAt(1).shallow().find(ResourceLink).props().name).toEqual(subscription.metadata.namespace);
+    expect(wrapper.find(VirtualTableRow).childAt(1).shallow().find(ResourceLink).props().title).toEqual(subscription.metadata.namespace);
+    expect(wrapper.find(VirtualTableRow).childAt(1).shallow().find(ResourceLink).props().displayName).toEqual(subscription.metadata.namespace);
+    expect(wrapper.find(VirtualTableRow).childAt(1).shallow().find(ResourceLink).props().kind).toEqual('Namespace');
   });
 
   it('renders column for subscription state when update available', () => {
     subscription.status.state = SubscriptionState.SubscriptionStateUpgradeAvailable;
     wrapper = wrapper.setProps({obj: subscription});
 
-    expect(wrapper.find(TableRow).childAt(2).shallow().text()).toContain('Upgrade available');
+    expect(wrapper.find(VirtualTableRow).childAt(2).shallow().text()).toContain('Upgrade available');
   });
 
   it('renders column for subscription state when unknown state', () => {
-    expect(wrapper.find(TableRow).childAt(2).shallow().text()).toEqual('Unknown');
+    expect(wrapper.find(VirtualTableRow).childAt(2).shallow().text()).toEqual('Unknown');
   });
 
   it('renders column for subscription state when update in progress', () => {
     subscription.status.state = SubscriptionState.SubscriptionStateUpgradePending;
     wrapper = wrapper.setProps({obj: subscription});
 
-    expect(wrapper.find(TableRow).childAt(2).shallow().text()).toContain('Upgrading');
+    expect(wrapper.find(VirtualTableRow).childAt(2).shallow().text()).toContain('Upgrading');
   });
 
   it('renders column for subscription state when no updates available', () => {
     subscription.status.state = SubscriptionState.SubscriptionStateAtLatest;
     wrapper = wrapper.setProps({obj: subscription});
 
-    expect(wrapper.find(TableRow).childAt(2).shallow().text()).toContain('Up to date');
+    expect(wrapper.find(VirtualTableRow).childAt(2).shallow().text()).toContain('Up to date');
   });
 
   it('renders column for current subscription channel', () => {
-    expect(wrapper.find(TableRow).childAt(3).shallow().text()).toEqual(subscription.spec.channel);
+    expect(wrapper.find(VirtualTableRow).childAt(3).shallow().text()).toEqual(subscription.spec.channel);
   });
 
   it('renders column for approval strategy', () => {
-    expect(wrapper.find(TableRow).childAt(4).shallow().text()).toEqual('Automatic');
+    expect(wrapper.find(VirtualTableRow).childAt(4).shallow().text()).toEqual('Automatic');
   });
 });
 
@@ -91,9 +91,9 @@ describe(SubscriptionsList.displayName, () => {
     wrapper = shallow(<SubscriptionsList.WrappedComponent data={[]} loaded={true} {...{[referenceForModel(ClusterServiceVersionModel)]: {data: []}}} operatorGroup={null} />);
   });
 
-  it('renders a `Table` component with correct props', () => {
-    expect(wrapper.find<any>(Table).props().Header).toEqual(SubscriptionTableHeader);
-    expect(wrapper.find<any>(Table).props().Row).toEqual(SubscriptionTableRow);
+  it('renders a `VirtualTable` component with correct props', () => {
+    expect(wrapper.find<any>(VirtualTable).props().Header).toEqual(SubscriptionTableHeader);
+    expect(wrapper.find<any>(VirtualTable).props().Row).toEqual(SubscriptionTableRow);
   });
 });
 

--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunList.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
-import { Table } from '@console/internal/components/factory';
+import { VirtualTable } from '@console/internal/components/factory';
 import PipelineRunHeader from './PipelineRunHeader';
 import PipelineRunRow from './PipelineRunRow';
 import { PipelineRunModel } from '../../models';
 
 export const PipelineRunList: React.FC = (props) => (
-  <Table
+  <VirtualTable
     {...props}
     aria-label={PipelineRunModel.labelPlural}
     Header={PipelineRunHeader}
     Row={PipelineRunRow}
-    virtualize
   />
 );
 

--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Status } from '@console/shared';
-import { TableRow, TableData } from '@console/internal/components/factory';
+import { VirtualTableRow, VirtualTableData } from '@console/internal/components/factory';
 import { Kebab, ResourceLink, Timestamp, ResourceKebab } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { pipelineRunFilterReducer } from '../../utils/pipeline-filter-reducer';
@@ -23,32 +23,32 @@ interface PipelineRunRowProps {
 const PipelineRunRow: React.FC<PipelineRunRowProps> = ({ obj, index, key, style }) => {
   const menuActions = [reRunPipelineRun(obj), stopPipelineRun(obj), ...Kebab.factory.common];
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink
           kind={pipelinerunReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
           title={obj.metadata.name}
         />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <Timestamp timestamp={obj.status && obj.status.startTime} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <Status status={pipelineRunFilterReducer(obj)} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <PipelineTaskStatus pipelinerun={obj} />
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>-</TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>-</VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         {obj.spec && obj.spec.trigger && obj.spec.trigger.type ? obj.spec.trigger.type : '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[6]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[6]}>
         <ResourceKebab actions={menuActions} kind={pipelinerunReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineAugmentRuns.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineAugmentRuns.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Table } from '@console/internal/components/factory';
+import { VirtualTable } from '@console/internal/components/factory';
 import PipelineHeader from './PipelineHeader';
 import PipelineRow from './PipelineRow';
 import { augmentRunsToData, PropPipelineData, KeyedRuns } from '../../utils/pipeline-augment';
@@ -16,13 +16,12 @@ const PipelineAugmentRuns: React.FC<PipelineAugmentRunsProps> = ({
   propsReferenceForRuns,
   ...props
 }) => (
-  <Table
+  <VirtualTable
     {...props}
     data={augmentRunsToData(data, propsReferenceForRuns, props as KeyedRuns)}
     aria-label={PipelineModel.labelPlural}
     Header={PipelineHeader}
     Row={PipelineRow}
-    virtualize
   />
 );
 

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Firehose } from '@console/internal/components/utils';
-import { Table } from '@console/internal/components/factory';
+import { VirtualTable } from '@console/internal/components/factory';
 import PipelineHeader from './PipelineHeader';
 import PipelineRow from './PipelineRow';
 import PipelineAugmentRuns from './PipelineAugmentRuns';
@@ -18,12 +18,11 @@ const PipelineList: React.FC<PipelineListProps> = (props) => {
       <PipelineAugmentRuns {...props} propsReferenceForRuns={propsReferenceForRuns} />
     </Firehose>
   ) : (
-    <Table
+    <VirtualTable
       {...props}
       aria-label={PipelineModel.labelPlural}
       Header={PipelineHeader}
       Row={PipelineRow}
-      virtualize
     />
   );
 };

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Status } from '@console/shared';
-import { TableRow, TableData } from '@console/internal/components/factory';
+import { VirtualTableRow, VirtualTableData } from '@console/internal/components/factory';
 import { Kebab, ResourceLink, Timestamp, ResourceKebab } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { pipelineFilterReducer } from '../../utils/pipeline-filter-reducer';
@@ -28,16 +28,16 @@ const PipelineRow: React.FC<PipelineRowProps> = ({ obj, index, key, style }) => 
     ...Kebab.factory.common,
   ];
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink
           kind={pipelineReference}
           name={obj.metadata.name}
           namespace={obj.metadata.namespace}
           title={obj.metadata.name}
         />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         {obj.latestRun && obj.latestRun.metadata && obj.latestRun.metadata.name ? (
           <ResourceLink
             kind={pipelinerunReference}
@@ -47,24 +47,24 @@ const PipelineRow: React.FC<PipelineRowProps> = ({ obj, index, key, style }) => 
         ) : (
           '-'
         )}
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <Status status={pipelineFilterReducer(obj)} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {(obj.latestRun && <PipelineTaskStatus pipeline={obj} pipelinerun={obj.latestRun} />) ||
           '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {(obj.latestRun && obj.latestRun.status && obj.latestRun.status.completionTime && (
           <Timestamp timestamp={obj.latestRun.status.completionTime} />
         )) ||
           '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={pipelineReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/create-disk-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/create-disk-row.tsx
@@ -9,7 +9,7 @@ import {
   getResource,
 } from 'kubevirt-web-ui-components';
 
-import { TableData, TableRow } from '@console/internal/components/factory';
+import { VirtualTableData, VirtualTableRow } from '@console/internal/components/factory';
 import { Firehose, FirehoseResult, LoadingInline } from '@console/internal/components/utils';
 import { HelpBlock, FormGroup } from 'patternfly-react';
 import { StorageClassModel, TemplateModel } from '@console/internal/models';
@@ -92,8 +92,8 @@ export const CreateDiskRow: React.FC<CreateDiskRowProps> = ({
 
   const bus = getVmPreferableDiskBus(vm);
   return (
-    <TableRow id={id} index={index} trKey={id} style={style}>
-      <TableData>
+    <VirtualTableRow id={id} index={index} trKey={id} style={style}>
+      <VirtualTableData>
         <FormGroup
           className="kubevirt-vm-create-device-row__cell--no_bottom"
           validationState={
@@ -107,8 +107,8 @@ export const CreateDiskRow: React.FC<CreateDiskRowProps> = ({
             {nameError && !nameError.isEmptyError && nameError.message}
           </HelpBlock>
         </FormGroup>
-      </TableData>
-      <TableData>
+      </VirtualTableData>
+      <VirtualTableData>
         <Integer
           id="disk-size"
           positive
@@ -118,17 +118,17 @@ export const CreateDiskRow: React.FC<CreateDiskRowProps> = ({
           onChange={setSize}
         />
         <span className="kubevirt-vm-create-device-row__cell_addendum">Gi</span>
-      </TableData>
-      <TableData id="disk-bus">{bus}</TableData>
-      <TableData>
+      </VirtualTableData>
+      <VirtualTableData id="disk-bus">{bus}</VirtualTableData>
+      <VirtualTableData>
         <StorageClassColumn
           storageClass={storageClass}
           onChange={setStorageClass}
           storageClasses={storageClasses}
           creating={creating}
         />
-      </TableData>
-      <TableData className="kubevirt-vm-create-device-row__confirmation-buttons">
+      </VirtualTableData>
+      <VirtualTableData className="kubevirt-vm-create-device-row__confirmation-buttons">
         <CancelAcceptButtons
           onCancel={onCreateRowDismiss}
           onAccept={() => {
@@ -142,8 +142,8 @@ export const CreateDiskRow: React.FC<CreateDiskRowProps> = ({
           }}
           disabled={!isValid}
         />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { TableData, TableRow } from '@console/internal/components/factory';
+import { VirtualTableData, VirtualTableRow } from '@console/internal/components/factory';
 import {
   asAccessReview,
   Kebab,
@@ -49,19 +49,19 @@ export const DiskRow: React.FC<VMDiskRowProps> = ({
   const storageColumn = storageClass === undefined ? <LoadingInline /> : storageClass;
 
   return (
-    <TableRow id={diskName} index={index} trKey={diskName} style={style}>
-      <TableData>{diskName}</TableData>
-      <TableData>{sizeColumn || DASH}</TableData>
-      <TableData>{getDiskBus(disk, BUS_VIRTIO)}</TableData>
-      <TableData>{storageColumn || DASH}</TableData>
-      <TableData className={Kebab.columnClass}>
+    <VirtualTableRow id={diskName} index={index} trKey={diskName} style={style}>
+      <VirtualTableData>{diskName}</VirtualTableData>
+      <VirtualTableData>{sizeColumn || DASH}</VirtualTableData>
+      <VirtualTableData>{getDiskBus(disk, BUS_VIRTIO)}</VirtualTableData>
+      <VirtualTableData>{storageColumn || DASH}</VirtualTableData>
+      <VirtualTableData className={Kebab.columnClass}>
         <Kebab
           options={getActions(vmLikeEntity, disk)}
           key={`kebab-for--${diskName}`}
           isDisabled={getDeletetionTimestamp(vmLikeEntity)}
           id={`kebab-for-${diskName}`}
         />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Button } from 'patternfly-react';
 import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
 
-import { Table } from '@console/internal/components/factory';
+import { VirtualTable } from '@console/internal/components/factory';
 import { PersistentVolumeClaimModel } from '@console/internal/models';
 import { Firehose, FirehoseResult, Kebab } from '@console/internal/components/utils';
 import { getResource } from 'kubevirt-web-ui-components';
@@ -136,7 +136,7 @@ export const VMDisks: React.FC<VMDisksProps> = ({ vmLikeEntity, pvcs, datavolume
             action={<AlertActionCloseButton onClose={() => setCreateError(null)} />}
           />
         )}
-        <Table
+        <VirtualTable
           aria-label="VM Disks List"
           data={getStoragesData(
             {

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/create-nic-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/create-nic-row.tsx
@@ -10,7 +10,7 @@ import {
 } from 'kubevirt-web-ui-components';
 import { connect } from 'react-redux';
 
-import { TableData, TableRow } from '@console/internal/components/factory';
+import { VirtualTableData, VirtualTableRow } from '@console/internal/components/factory';
 import { Firehose, FirehoseResult, LoadingInline } from '@console/internal/components/utils';
 import { FormGroup, HelpBlock } from 'patternfly-react';
 import { TemplateModel } from '@console/internal/models';
@@ -114,8 +114,8 @@ export const CreateNicRow: React.FC<CreateNicRowProps> = ({
   const isValid = !nameError && network && binding;
 
   return (
-    <TableRow id={id} index={index} trKey={id} style={style}>
-      <TableData className={dimensify()}>
+    <VirtualTableRow id={id} index={index} trKey={id} style={style}>
+      <VirtualTableData className={dimensify()}>
         <FormGroup
           className="kubevirt-vm-create-device-row__cell--no_bottom"
           validationState={
@@ -129,11 +129,11 @@ export const CreateNicRow: React.FC<CreateNicRowProps> = ({
             {nameError && !nameError.isEmptyError && nameError.message}
           </HelpBlock>
         </FormGroup>
-      </TableData>
-      <TableData id="nic-model" className={dimensify()}>
+      </VirtualTableData>
+      <VirtualTableData id="nic-model" className={dimensify()}>
         {model}
-      </TableData>
-      <TableData id="nic-binding" className={dimensify()}>
+      </VirtualTableData>
+      <VirtualTableData id="nic-binding" className={dimensify()}>
         <NetworkColumn
           network={network}
           onChange={(net) => {
@@ -153,8 +153,8 @@ export const CreateNicRow: React.FC<CreateNicRowProps> = ({
           vm={vm}
           creating={creating}
         />
-      </TableData>
-      <TableData className={dimensify()}>
+      </VirtualTableData>
+      <VirtualTableData className={dimensify()}>
         <Dropdown
           id="nic-binding"
           choices={getNetworkBindings(networkType)}
@@ -162,16 +162,16 @@ export const CreateNicRow: React.FC<CreateNicRowProps> = ({
           onChange={setBinding}
           disabled={creating}
         />
-      </TableData>
-      <TableData className={dimensify()}>
+      </VirtualTableData>
+      <VirtualTableData className={dimensify()}>
         <Text
           id="nic-mac-address"
           onChange={setMacAddress}
           value={macAddress}
           disabled={creating || networkType === NetworkType.POD}
         />
-      </TableData>
-      <TableData className="kubevirt-vm-create-device-row__confirmation-buttons">
+      </VirtualTableData>
+      <VirtualTableData className="kubevirt-vm-create-device-row__confirmation-buttons">
         <CancelAcceptButtons
           onCancel={onCreateRowDismiss}
           onAccept={() => {
@@ -185,8 +185,8 @@ export const CreateNicRow: React.FC<CreateNicRowProps> = ({
           }}
           disabled={!isValid}
         />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/nic-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/nic-row.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { TableData, TableRow } from '@console/internal/components/factory';
+import { VirtualTableData, VirtualTableRow } from '@console/internal/components/factory';
 import { asAccessReview, Kebab, KebabOption } from '@console/internal/components/utils';
 import { getDeletetionTimestamp, DASH } from '@console/shared';
 
@@ -44,20 +44,20 @@ export const NicRow: React.FC<VMNicRowProps> = ({
   const dimensify = dimensifyRow(nicTableColumnClasses);
 
   return (
-    <TableRow id={nicName} index={index} trKey={nicName} style={style}>
-      <TableData className={dimensify()}>{nicName}</TableData>
-      <TableData className={dimensify()}>{nic.model || BUS_VIRTIO}</TableData>
-      <TableData className={dimensify()}>{networkName}</TableData>
-      <TableData className={dimensify()}>{binding || DASH}</TableData>
-      <TableData className={dimensify()}>{nic.macAddress || DASH}</TableData>
-      <TableData className={dimensify(true)}>
+    <VirtualTableRow id={nicName} index={index} trKey={nicName} style={style}>
+      <VirtualTableData className={dimensify()}>{nicName}</VirtualTableData>
+      <VirtualTableData className={dimensify()}>{nic.model || BUS_VIRTIO}</VirtualTableData>
+      <VirtualTableData className={dimensify()}>{networkName}</VirtualTableData>
+      <VirtualTableData className={dimensify()}>{binding || DASH}</VirtualTableData>
+      <VirtualTableData className={dimensify()}>{nic.macAddress || DASH}</VirtualTableData>
+      <VirtualTableData className={dimensify(true)}>
         <Kebab
           options={getActions(vmLikeEntity, nic)}
           key={`kebab-for--${nicName}`}
           isDisabled={getDeletetionTimestamp(vmLikeEntity)}
           id={`kebab-for-${nicName}`}
         />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
@@ -3,7 +3,7 @@ import { Button } from 'patternfly-react';
 import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
 import * as _ from 'lodash';
 
-import { Table } from '@console/internal/components/factory';
+import { VirtualTable } from '@console/internal/components/factory';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 
 import { sortable } from '@patternfly/react-table';
@@ -76,7 +76,7 @@ export const VMNics: React.FC<VMLikeEntityTabProps> = ({ obj: vmLikeEntity }) =>
             action={<AlertActionCloseButton onClose={() => setCreateError(null)} />}
           />
         )}
-        <Table
+        <VirtualTable
           aria-label="VM Nics List"
           data={getStoragesData(vmLikeEntity, isCreating)}
           Header={() =>

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -10,7 +10,12 @@ import {
   TEMPLATE_TYPE_LABEL,
 } from 'kubevirt-web-ui-components';
 
-import { ListPage, Table, TableRow, TableData } from '@console/internal/components/factory';
+import {
+  ListPage,
+  VirtualTable,
+  VirtualTableRow,
+  VirtualTableData,
+} from '@console/internal/components/factory';
 import {
   Kebab,
   ResourceLink,
@@ -102,36 +107,38 @@ const VMTemplateTableRow: React.FC<VMTemplateTableRowProps> = ({
   const os = getTemplateOperatingSystems([template])[0];
 
   return (
-    <TableRow id={template.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={dimensify()}>
+    <VirtualTableRow id={template.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={dimensify()}>
         <VMTemplateLink template={template} />
-      </TableData>
-      <TableData className={dimensify()}>
+      </VirtualTableData>
+      <VirtualTableData className={dimensify()}>
         <ResourceLink
           kind="Namespace"
           name={getNamespace(template)}
           title={getNamespace(template)}
         />
-      </TableData>
-      <TableData className={dimensify()}>
+      </VirtualTableData>
+      <VirtualTableData className={dimensify()}>
         {_.get(template.metadata, 'annotations.description', DASH)}
-      </TableData>
-      <TableData className={dimensify()}>
+      </VirtualTableData>
+      <VirtualTableData className={dimensify()}>
         <TemplateSource template={template} />
-      </TableData>
-      <TableData className={dimensify()}>{os ? os.name || os.id : DASH}</TableData>
-      <TableData className={dimensify()}>{getTemplateFlavors([template])[0]}</TableData>
-      <TableData className={dimensify(true)}>
+      </VirtualTableData>
+      <VirtualTableData className={dimensify()}>{os ? os.name || os.id : DASH}</VirtualTableData>
+      <VirtualTableData className={dimensify()}>
+        {getTemplateFlavors([template])[0]}
+      </VirtualTableData>
+      <VirtualTableData className={dimensify(true)}>
         <ResourceKebab actions={menuActions} kind={kind} resource={template} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 VMTemplateTableRow.displayName = 'VmTemplateTableRow';
 
-const VirtualMachineTemplates: React.FC<React.ComponentProps<typeof Table>> = (props) => {
+const VirtualMachineTemplates: React.FC<React.ComponentProps<typeof VirtualTable>> = (props) => {
   return (
-    <Table
+    <VirtualTable
       {...props}
       aria-label={VM_TEMPLATE_LABEL_PLURAL}
       Header={VMTemplateTableHeader}

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -14,7 +14,12 @@ import {
 import { getName, getNamespace, getUID, createLookup, K8sEntityMap } from '@console/shared';
 
 import { NamespaceModel, PodModel } from '@console/internal/models';
-import { Table, MultiListPage, TableRow, TableData } from '@console/internal/components/factory';
+import {
+  VirtualTable,
+  MultiListPage,
+  VirtualTableRow,
+  VirtualTableData,
+} from '@console/internal/components/factory';
 import { FirehoseResult, Kebab, ResourceLink } from '@console/internal/components/utils';
 import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
 
@@ -83,17 +88,17 @@ const VMRow: React.FC<VMRowProps> = ({
   const vmi = vmiLookup[lookupID];
 
   return (
-    <TableRow id={uid} index={index} trKey={key} style={style}>
-      <TableData className={dimensify()}>
+    <VirtualTableRow id={uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={dimensify()}>
         <ResourceLink kind={VirtualMachineModel.kind} name={name} namespace={namespace} />
-      </TableData>
-      <TableData className={dimensify()}>
+      </VirtualTableData>
+      <VirtualTableData className={dimensify()}>
         <ResourceLink kind={NamespaceModel.kind} name={namespace} title={namespace} />
-      </TableData>
-      <TableData className={dimensify()}>
+      </VirtualTableData>
+      <VirtualTableData className={dimensify()}>
         <VmStatus vm={vm} pods={pods} migrations={migrations} />
-      </TableData>
-      <TableData className={dimensify(true)}>
+      </VirtualTableData>
+      <VirtualTableData className={dimensify(true)}>
         <Kebab
           options={menuActions.map((action) => {
             return action(VirtualMachineModel, vm, {
@@ -105,15 +110,15 @@ const VMRow: React.FC<VMRowProps> = ({
           key={`kebab-for-${uid}`}
           id={`kebab-for-${uid}`}
         />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 
-const VMList: React.FC<React.ComponentProps<typeof Table> & VMListProps> = (props) => {
+const VMList: React.FC<React.ComponentProps<typeof VirtualTable> & VMListProps> = (props) => {
   const { resources } = props;
   return (
-    <Table
+    <VirtualTable
       {...props}
       aria-label={VirtualMachineModel.labelPlural}
       Header={VMHeader}

--- a/frontend/packages/metal3-plugin/src/components/host-disks.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host-disks.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
 
-import { Table, TableRow, TableData } from '@console/internal/components/factory';
+import {
+  VirtualTable,
+  VirtualTableRow,
+  VirtualTableData,
+} from '@console/internal/components/factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { humanizeDecimalBytes } from '@console/internal/components/utils';
 import { getHostStorage } from '../selectors';
@@ -28,15 +32,15 @@ const DisksTableRow: React.FC<DisksTableRowProps> = ({ obj, index, key, style })
   const { hctl, model, name, rotational, serialNumber, sizeBytes, vendor } = obj;
   const { string: size } = humanizeDecimalBytes(sizeBytes);
   return (
-    <TableRow id={name} index={index} trKey={key} style={style}>
-      <TableData>{name}</TableData>
-      <TableData>{size}</TableData>
-      <TableData>{rotational ? 'Rotational' : 'SSD'}</TableData>
-      <TableData>{model}</TableData>
-      <TableData>{serialNumber}</TableData>
-      <TableData>{vendor}</TableData>
-      <TableData>{hctl}</TableData>
-    </TableRow>
+    <VirtualTableRow id={name} index={index} trKey={key} style={style}>
+      <VirtualTableData>{name}</VirtualTableData>
+      <VirtualTableData>{size}</VirtualTableData>
+      <VirtualTableData>{rotational ? 'Rotational' : 'SSD'}</VirtualTableData>
+      <VirtualTableData>{model}</VirtualTableData>
+      <VirtualTableData>{serialNumber}</VirtualTableData>
+      <VirtualTableData>{vendor}</VirtualTableData>
+      <VirtualTableData>{hctl}</VirtualTableData>
+    </VirtualTableRow>
   );
 };
 
@@ -49,7 +53,7 @@ const BaremetalHostDiskList: React.FC<BaremetalHostNICListProps> = ({ obj: host 
   return (
     <div className="co-m-list">
       <div className="co-m-pane__body">
-        <Table
+        <VirtualTable
           data={disks}
           aria-label="Baremetal Host NICs"
           Header={DisksTableHeader}

--- a/frontend/packages/metal3-plugin/src/components/host-nics.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host-nics.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { OutlinedCheckSquareIcon, OutlinedSquareIcon } from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';
 
-import { Table, TableRow, TableData } from '@console/internal/components/factory';
+import {
+  VirtualTable,
+  VirtualTableRow,
+  VirtualTableData,
+} from '@console/internal/components/factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getHostNICs } from '../selectors';
 import { BaremetalHostNIC } from '../types';
@@ -27,15 +31,17 @@ type NICsTableRowProps = {
 const NICsTableRow: React.FC<NICsTableRowProps> = ({ obj: nic, index, key, style }) => {
   const { ip, mac, model, name, pxe, speedGbps, vlanId } = nic;
   return (
-    <TableRow id={ip} index={index} trKey={key} style={style}>
-      <TableData>{name}</TableData>
-      <TableData>{model}</TableData>
-      <TableData>{pxe ? <OutlinedCheckSquareIcon /> : <OutlinedSquareIcon />}</TableData>
-      <TableData>{ip}</TableData>
-      <TableData>{speedGbps} Gbps</TableData>
-      <TableData>{mac}</TableData>
-      <TableData>{vlanId}</TableData>
-    </TableRow>
+    <VirtualTableRow id={ip} index={index} trKey={key} style={style}>
+      <VirtualTableData>{name}</VirtualTableData>
+      <VirtualTableData>{model}</VirtualTableData>
+      <VirtualTableData>
+        {pxe ? <OutlinedCheckSquareIcon /> : <OutlinedSquareIcon />}
+      </VirtualTableData>
+      <VirtualTableData>{ip}</VirtualTableData>
+      <VirtualTableData>{speedGbps} Gbps</VirtualTableData>
+      <VirtualTableData>{mac}</VirtualTableData>
+      <VirtualTableData>{vlanId}</VirtualTableData>
+    </VirtualTableRow>
   );
 };
 
@@ -48,7 +54,7 @@ const BaremetalHostNICList: React.FC<BaremetalHostNICListProps> = ({ obj: host }
   return (
     <div className="co-m-list">
       <div className="co-m-pane__body">
-        <Table
+        <VirtualTable
           data={nics}
           aria-label="Baremetal Host NICs"
           Header={NICsTableHeader}

--- a/frontend/packages/metal3-plugin/src/components/host.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host.tsx
@@ -6,7 +6,12 @@ import { sortable } from '@patternfly/react-table';
 
 import { getName, getNamespace, getUID, getMachineNode, createLookup } from '@console/shared';
 import { MachineModel, NodeModel } from '@console/internal/models';
-import { MultiListPage, Table, TableRow, TableData } from '@console/internal/components/factory';
+import {
+  MultiListPage,
+  VirtualTable,
+  VirtualTableRow,
+  VirtualTableData,
+} from '@console/internal/components/factory';
 import { Kebab, ResourceLink, FirehoseResource } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 
@@ -90,25 +95,25 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({
   const nodeName = getName(node);
 
   return (
-    <TableRow id={uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink
           kind={referenceForModel(BaremetalHostModel)}
           name={name}
           namespace={namespace}
         />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <BaremetalHostStatus host={host} status={status} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <MachineCell host={host} status={status} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <BaremetalHostRole machine={machine} />
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>{address}</TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>{address}</VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <Kebab
           options={menuActions.map((action) =>
             action(BaremetalHostModel, host, null, {
@@ -120,16 +125,21 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({
           key={`kebab-for-${uid}`}
           id={`kebab-for-${uid}`}
         />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 
 const HostList: React.FC<HostListProps> = (props) => (
-  <Table {...props} aria-label="Baremetal Hosts" Header={HostsTableHeader} Row={HostsTableRow} />
+  <VirtualTable
+    {...props}
+    aria-label="Baremetal Hosts"
+    Header={HostsTableHeader}
+    Row={HostsTableRow}
+  />
 );
 
-type HostListProps = React.ComponentProps<typeof Table> & {
+type HostListProps = React.ComponentProps<typeof VirtualTable> & {
   data: HostRowBundle[];
   customData: {
     hasNodeMaintenanceCapability: boolean;

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -8,7 +8,7 @@ import { sortable } from '@patternfly/react-table';
 import { ClusterRoleBindingModel } from '../../models';
 import { getQN, k8sCreate, k8sPatch, referenceFor } from '../../module/k8s';
 import * as UIActions from '../../actions/ui';
-import { MultiListPage, Table, TableRow, TableData } from '../factory';
+import { MultiListPage, VirtualTable, VirtualTableRow, VirtualTableData } from '../factory';
 import { RadioGroup } from '../radio';
 import { confirmModal } from '../modals';
 import {
@@ -164,33 +164,33 @@ export const RoleLink = ({binding}) => {
 
 const RoleBindingsTableRow = ({obj: binding, index, key, style}) => {
   return (
-    <TableRow id={binding.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={binding.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={bindingKind(binding)} name={binding.metadata.name} namespace={binding.metadata.namespace} className="co-resource-item__resource-name" />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <RoleLink binding={binding} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         {binding.subject.kind}
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[3], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[3], 'co-break-word')}>
         {binding.subject.name}
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[4], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[4], 'co-break-word')}>
         {binding.metadata.namespace ? <ResourceLink kind="Namespace" name={binding.metadata.namespace} /> : 'all'}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <BindingKebab binding={binding} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 RoleBindingsTableRow.displayName = 'RoleBindingsTableRow';
 
 const EmptyMsg = () => <MsgBox title="No Role Bindings Found" detail="Roles grant access to types of objects in the cluster. Roles are applied to a group or user via a Role Binding." />;
 
-export const BindingsList = props => <Table {...props} aria-label="Role Bindings" EmptyMsg={EmptyMsg} Header={RoleBindingsTableHeader} Row={RoleBindingsTableRow} virtualize />;
+export const BindingsList = props => <VirtualTable {...props} aria-label="Role Bindings" EmptyMsg={EmptyMsg} Header={RoleBindingsTableHeader} Row={RoleBindingsTableRow} />;
 
 export const bindingType = binding => {
   if (!binding) {

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -7,7 +7,7 @@ import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { flatten as bindingsFlatten } from './bindings';
 import { BindingName, BindingsList, RulesList } from './index';
-import { DetailsPage, MultiListPage, TextFilter, Table, TableRow, TableData } from '../factory';
+import { DetailsPage, MultiListPage, TextFilter, VirtualTable, VirtualTableRow, VirtualTableData } from '../factory';
 import { Kebab, SectionHeading, MsgBox, navFactory, ResourceKebab, ResourceLink, Timestamp } from '../utils';
 
 export const isSystemRole = role => _.startsWith(role.metadata.name, 'system:');
@@ -54,17 +54,17 @@ RolesTableHeader.displayName = 'RolesTableHeader';
 
 const RolesTableRow = ({obj: role, index, key, style}) => {
   return (
-    <TableRow id={role.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={roleColumnClasses[0]}>
+    <VirtualTableRow id={role.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={roleColumnClasses[0]}>
         <ResourceLink kind={roleKind(role)} name={role.metadata.name} namespace={role.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(roleColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(roleColumnClasses[1], 'co-break-word')}>
         {role.metadata.namespace ? <ResourceLink kind="Namespace" name={role.metadata.namespace} /> : 'all'}
-      </TableData>
-      <TableData className={roleColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={roleColumnClasses[2]}>
         <ResourceKebab actions={menuActions} kind={roleKind(role)} resource={role} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 RolesTableRow.displayName = 'RolesTableRow';
@@ -160,20 +160,20 @@ BindingsTableHeader.displayName = 'BindingsTableHeader';
 
 const BindingsTableRow = ({obj: binding, index, key, style}) => {
   return (
-    <TableRow id={binding.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={bindingsColumnClasses[0]}>
+    <VirtualTableRow id={binding.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={bindingsColumnClasses[0]}>
         <BindingName binding={binding} />
-      </TableData>
-      <TableData className={bindingsColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={bindingsColumnClasses[1]}>
         {binding.subject.kind}
-      </TableData>
-      <TableData className={bindingsColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={bindingsColumnClasses[2]}>
         {binding.subject.name}
-      </TableData>
-      <TableData className={bindingsColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={bindingsColumnClasses[3]}>
         {binding.namespace || 'all'}
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 BindingsTableRow.displayName = 'BindingsTableRow';
@@ -208,7 +208,7 @@ export const ClusterRolesDetailsPage = RolesDetailsPage;
 
 const EmptyMsg = () => <MsgBox title="No Roles Found" detail="Roles grant access to types of objects in the cluster. Roles are applied to a team or user via a Role Binding." />;
 
-const RolesList = props => <Table {...props} aria-label="Roles" EmptyMsg={EmptyMsg} Header={RolesTableHeader} Row={RolesTableRow} virtualize />;
+const RolesList = props => <VirtualTable {...props} aria-label="Roles" EmptyMsg={EmptyMsg} Header={RolesTableHeader} Row={RolesTableRow} />;
 
 export const roleType = role => {
   if (!role) {

--- a/frontend/public/components/alert-manager.tsx
+++ b/frontend/public/components/alert-manager.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { referenceForModel, K8sResourceKind } from '../module/k8s';
-import { ListPage, DetailsPage, Table, TableRow, TableData } from './factory';
+import { ListPage, DetailsPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { SectionHeading, LabelList, navFactory, ResourceLink, Selector, Firehose, LoadingInline, pluralize } from './utils';
 import { configureReplicaCountModal } from './modals';
 import { AlertmanagerModel } from '../models';
@@ -95,23 +95,23 @@ const tableColumnClasses = [
 const AlertManagerTableRow: React.FC<AlertManagerTableRowProps> = ({obj: alertManager, index, key, style}) => {
   const {metadata, spec} = alertManager;
   return (
-    <TableRow id={alertManager.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={alertManager.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={referenceForModel(AlertmanagerModel)} name={metadata.name} namespace={metadata.namespace} title={metadata.uid} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <ResourceLink kind="Namespace" name={metadata.namespace} title={metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={AlertmanagerModel.kind} labels={metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {spec.version}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <Selector selector={spec.nodeSelector} kind="Node" />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 AlertManagerTableRow.displayName = 'AlertManagerTableRow';
@@ -148,7 +148,7 @@ const AlertManagerTableHeader = () => {
 };
 AlertManagerTableHeader.displayName = 'AlertManagerTableHeader';
 
-export const AlertManagersList = props => <Table {...props} aria-label="Alert Managers" Header={AlertManagerTableHeader} Row={AlertManagerTableRow} virtualize />;
+export const AlertManagersList = props => <VirtualTable {...props} aria-label="Alert Managers" Header={AlertManagerTableHeader} Row={AlertManagerTableRow} />;
 
 export const AlertManagersPage = props => <ListPage {...props} ListComponent={AlertManagersList} canCreate={false} kind={referenceForModel(AlertmanagerModel)} />;
 

--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -203,7 +203,6 @@ const APIResourcesList = connect<APIResourcesListPropsFromState>(stateToProps)((
         aria-label="API Resources"
         data={sortedResources}
         loaded={!!models.size}
-        virtualize={false}
       />
     </div>
   </>;
@@ -420,7 +419,6 @@ const APIResourceAccessReview: React.FC<APIResourceTabProps> = ({kindObj, namesp
           aria-label="API Resources"
           data={sortedData}
           loaded
-          virtualize={false}
         />
       </div>
     </>

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { K8sResourceKind, K8sResourceKindReference, referenceFor } from '../module/k8s';
 import { startBuild } from '../module/k8s/builds';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { errorModal } from './modals';
 import {
   BuildHooks,
@@ -119,23 +119,23 @@ BuildConfigsTableHeader.displayName = 'BuildConfigsTableHeader';
 
 const BuildConfigsTableRow: React.FC<BuildConfigsTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={BuildConfigsReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={BuildConfigsReference} labels={obj.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         { fromNow(obj.metadata.creationTimestamp) }
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <ResourceKebab actions={menuActions} kind={BuildConfigsReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 BuildConfigsTableRow.displayName = 'BuildConfigsTableRow';
@@ -159,7 +159,7 @@ const filters = [{
   })),
 }];
 
-export const BuildConfigsList: React.SFC = props => <Table {...props} aria-label="Build Configs" Header={BuildConfigsTableHeader} Row={BuildConfigsTableRow} virtualize />;
+export const BuildConfigsList: React.SFC = props => <VirtualTable {...props} aria-label="Build Configs" Header={BuildConfigsTableHeader} Row={BuildConfigsTableRow} />;
 
 BuildConfigsList.displayName = 'BuildConfigsList';
 

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -7,7 +7,7 @@ import { sortable } from '@patternfly/react-table';
 import { Status } from '@console/shared';
 import { K8sResourceKindReference, referenceFor, K8sResourceKind, k8sPatch, K8sKind } from '../module/k8s';
 import { cloneBuild, formatBuildDuration, getBuildNumber } from '../module/k8s/builds';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { errorModal, confirmModal } from './modals';
 import {
   AsyncComponent,
@@ -279,23 +279,23 @@ BuildsTableHeader.displayName = 'BuildsTableHeader';
 
 const BuildsTableRow: React.FC<BuildsTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={BuildsReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <Status status={obj.status.phase} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {fromNow(obj.metadata.creationTimestamp)}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <ResourceKebab actions={menuActions} kind={BuildsReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 BuildsTableRow.displayName = 'BuildsTableRow';
@@ -306,7 +306,7 @@ type BuildsTableRowProps = {
   style: object;
 };
 
-export const BuildsList: React.SFC = props => <Table {...props} aria-label="Builds" Header={BuildsTableHeader} Row={BuildsTableRow} virtualize />;
+export const BuildsList: React.SFC = props => <VirtualTable {...props} aria-label="Builds" Header={BuildsTableHeader} Row={BuildsTableRow} />;
 
 BuildsList.displayName = 'BuildsList';
 

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -5,7 +5,7 @@ import { sortable } from '@patternfly/react-table';
 import { connectToFlags, flagPending } from '../reducers/features';
 import { FLAGS } from '../const';
 import { Conditions } from './conditions';
-import { ColHead, DetailsPage, ListHeader, ListPage, Table, TableRow, TableData } from './factory';
+import { ColHead, DetailsPage, ListHeader, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { getQueryArgument, setQueryArgument } from './utils/router';
 import { coFetchJSON } from '../co-fetch';
 import { ChargebackReportModel } from '../models';
@@ -95,26 +95,26 @@ ReportsTableHeader.displayName = 'ReportsTableHeader';
 
 const ReportsTableRow: React.FC<ReportsTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={ReportReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} namespace={undefined} title={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <ResourceLink kind={ReportGenerationQueryReference} name={_.get(obj, ['spec', 'query'])} namespace={obj.metadata.namespace} title={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <Timestamp timestamp={_.get(obj, ['spec', 'reportingStart'])} />
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <Timestamp timestamp={_.get(obj, ['spec', 'reportingEnd'])} />
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={ReportReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ReportsTableRow.displayName = 'ReportsTableRow';
@@ -322,7 +322,7 @@ const reportsPages = [
 
 const EmptyMsg = () => <MsgBox title="No reports have been generated" detail="Reports allow resource usage and cost to be tracked per namespace, pod, and more." />;
 
-export const ReportsList: React.SFC = props => <Table {...props} aria-label="Reports" Header={ReportsTableHeader} Row={ReportsTableRow} EmptyMsg={EmptyMsg} />;
+export const ReportsList: React.SFC = props => <VirtualTable {...props} aria-label="Reports" Header={ReportsTableHeader} Row={ReportsTableRow} EmptyMsg={EmptyMsg} />;
 
 const ReportsPage_: React.SFC<ReportsPageProps> = props => {
   if (flagPending(props.flags[FLAGS.CHARGEBACK])) {
@@ -395,23 +395,23 @@ ReportGenerationQueriesTableHeader.displayName = 'ReportGenerationQueriesTableHe
 
 const ReportGenerationQueriesTableRow: React.FC<ReportGenerationQueriesTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={reportsGenerationColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={reportsGenerationColumnClasses[0]}>
         <ResourceLink kind={ReportGenerationQueryReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={reportsGenerationColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={reportsGenerationColumnClasses[1]}>
         <ResourceLink kind="Namespace" namespace={undefined} name={obj.metadata.namespace} title={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={reportsGenerationColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={reportsGenerationColumnClasses[2]}>
         <LabelList kind={ReportGenerationQueryReference} labels={_.get(obj, ['metadata', 'labels'])} />
-      </TableData>
-      <TableData className={reportsGenerationColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={reportsGenerationColumnClasses[3]}>
         <Timestamp timestamp={_.get(obj, ['metadata', 'creationTimestamp'])} />
-      </TableData>
-      <TableData className={reportsGenerationColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={reportsGenerationColumnClasses[4]}>
         <ResourceKebab actions={menuActions} kind={ReportGenerationQueryReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ReportGenerationQueriesTableRow.displayName = 'ReportGenerationQueriesTableRow';
@@ -457,7 +457,7 @@ const ReportGenerationQueriesDetails: React.SFC<ReportGenerationQueriesDetailsPr
   </div>;
 };
 
-export const ReportGenerationQueriesList: React.SFC = props => <Table aria-label="Chargeback Queries List" {...props} Header={ReportGenerationQueriesTableHeader} Row={ReportGenerationQueriesTableRow} />;
+export const ReportGenerationQueriesList: React.SFC = props => <VirtualTable aria-label="Chargeback Queries List" {...props} Header={ReportGenerationQueriesTableHeader} Row={ReportGenerationQueriesTableRow} />;
 
 export const ReportGenerationQueriesPage: React.SFC<ReportGenerationQueriesPageProps> = props => <div>
   <ChargebackNavBar match={props.match} />

--- a/frontend/public/components/cluster-service-broker.tsx
+++ b/frontend/public/components/cluster-service-broker.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, SectionHeading, detailsPage, navFactory, ResourceLink, ResourceKebab, ResourceSummary, StatusWithIcon, Timestamp, ExternalLink } from './utils';
 import { K8sResourceKind, referenceForModel } from '../module/k8s';
 import { ClusterServiceBrokerModel } from '../models';
@@ -45,23 +45,23 @@ ClusterServiceBrokerTableHeader.displayName = 'ClusterServiceBrokerTableHeader';
 
 const ClusterServiceBrokerTableRow: React.FC<ClusterServiceBrokerTableRowProps> = ({obj: serviceBroker, index, key, style}) => {
   return (
-    <TableRow id={serviceBroker.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={serviceBroker.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={referenceForModel(ClusterServiceBrokerModel)} name={serviceBroker.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <StatusWithIcon obj={serviceBroker} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {serviceBroker.spec.relistBehavior}
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <Timestamp timestamp={serviceBroker.status.lastCatalogRetrievalTime} />
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <ResourceKebab actions={menuActions} kind={referenceForModel(ClusterServiceBrokerModel)} resource={serviceBroker} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ClusterServiceBrokerTableRow.displayName = 'ClusterServiceBrokerTableRow';
@@ -120,7 +120,7 @@ export const ClusterServiceBrokerDetailsPage: React.SFC<ClusterServiceBrokerDeta
     navFactory.clusterServiceClasses(ServiceClassTabPage),
   ]}
 />;
-export const ClusterServiceBrokerList: React.SFC = props => <Table {...props} aria-label="Cluster Service Brokers" Header={ClusterServiceBrokerTableHeader} Row={ClusterServiceBrokerTableRow} virtualize />;
+export const ClusterServiceBrokerList: React.SFC = props => <VirtualTable {...props} aria-label="Cluster Service Brokers" Header={ClusterServiceBrokerTableHeader} Row={ClusterServiceBrokerTableRow} />;
 
 export const ClusterServiceBrokerPage: React.SFC<ClusterServiceBrokerPageProps> = props =>
   <ListPage

--- a/frontend/public/components/cluster-service-class.tsx
+++ b/frontend/public/components/cluster-service-class.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { history, SectionHeading, detailsPage, navFactory, ResourceSummary, resourcePathFromModel, ResourceLink } from './utils';
 import { viewYamlComponent } from './utils/horizontal-nav';
 import { ClusterServiceClassModel, ClusterServiceBrokerModel } from '../models';
@@ -55,18 +55,18 @@ ClusterServiceClassTableHeader.displayName = 'ClusterServiceClassTableHeader';
 const ClusterServiceClassTableRow: React.FC<ClusterServiceClassTableRowProps> = ({obj: serviceClass, index, key, style}) => {
   const path = resourcePathFromModel(ClusterServiceClassModel, serviceClass.metadata.name);
   return (
-    <TableRow id={serviceClass.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={serviceClass.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ClusterServiceClassIcon serviceClass={serviceClass} />
         <Link className="co-cluster-service-class-link" to={path}>{serviceClassDisplayName(serviceClass)}</Link>
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         {serviceClass.spec.externalName}
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         <ResourceLink kind={referenceForModel(ClusterServiceBrokerModel)} name={serviceClass.spec.clusterServiceBrokerName} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ClusterServiceClassTableRow.displayName = 'ClusterServiceClassTableRow';
@@ -108,7 +108,7 @@ export const ClusterServiceClassDetailsPage: React.SFC<ClusterServiceClassDetail
       fieldSelector={`spec.clusterServiceClassRef.name=${obj.metadata.name}`} />)]}
 />;
 
-export const ClusterServiceClassList: React.SFC = props => <Table {...props} aria-label="Cluster Service Classes" Header={ClusterServiceClassTableHeader} Row={ClusterServiceClassTableRow} defaultSortFunc="serviceClassDisplayName" virtualize />;
+export const ClusterServiceClassList: React.SFC = props => <VirtualTable {...props} aria-label="Cluster Service Classes" Header={ClusterServiceClassTableHeader} Row={ClusterServiceClassTableRow} defaultSortFunc="serviceClassDisplayName" />;
 
 export const ClusterServiceClassPage: React.SFC<ClusterServiceClassPageProps> = props =>
   <ListPage

--- a/frontend/public/components/cluster-service-plan.tsx
+++ b/frontend/public/components/cluster-service-plan.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { SectionHeading, detailsPage, navFactory, ResourceLink, ResourceSummary } from './utils';
 import { K8sResourceKind, referenceForModel, servicePlanDisplayName } from '../module/k8s';
 import { ClusterServicePlanModel, ClusterServiceBrokerModel, ClusterServiceClassModel } from '../models';
@@ -33,17 +33,17 @@ ClusterServicePlanTableHeader.displayName = 'ClusterServicePlanTableHeader';
 
 const ClusterServicePlanTableRow: React.FC<ClusterServicePlanTableRowProps> = ({obj: servicePlan, index, key, style}) => {
   return (
-    <TableRow id={servicePlan.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={servicePlan.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={referenceForModel(ClusterServicePlanModel)} name={servicePlan.metadata.name} displayName={servicePlan.spec.externalName} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         {servicePlan.spec.externalName}
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         <ResourceLink kind={referenceForModel(ClusterServiceBrokerModel)} name={servicePlan.spec.clusterServiceBrokerName} title={servicePlan.spec.clusterServiceBrokerName} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ClusterServicePlanTableRow.displayName = 'ClusterServicePlanTableRow';
@@ -89,7 +89,7 @@ export const ClusterServicePlanDetailsPage: React.SFC<ClusterServicePlanDetailsP
   ]}
 />;
 
-export const ClusterServicePlanList: React.SFC = props => <Table {...props} aria-label="Cluster Service Plans" Header={ClusterServicePlanTableHeader} Row={ClusterServicePlanTableRow} virtualize />;
+export const ClusterServicePlanList: React.SFC = props => <VirtualTable {...props} aria-label="Cluster Service Plans" Header={ClusterServicePlanTableHeader} Row={ClusterServicePlanTableRow} />;
 
 export const ClusterServicePlanPage: React.SFC<ClusterServicePlanPageProps> = props =>
   <ListPage

--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -7,10 +7,11 @@ import { Alert } from '@patternfly/react-core';
 import { ClusterOperatorModel } from '../../models';
 import {
   DetailsPage,
-  ListPage,
   Table,
-  TableRow,
-  TableData,
+  ListPage,
+  VirtualTable,
+  VirtualTableRow,
+  VirtualTableData,
 } from '../factory';
 import { Conditions } from '../conditions';
 import {
@@ -85,20 +86,20 @@ const ClusterOperatorTableRow: React.FC<ClusterOperatorTableRowProps> = ({obj, i
   const { status, message } = getStatusAndMessage(obj);
   const operatorVersion = getClusterOperatorVersion(obj);
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={clusterOperatorReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <OperatorStatusIconAndLabel status={status} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {operatorVersion || '-'}
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[3], 'co-break-word', 'co-pre-line')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[3], 'co-break-word', 'co-pre-line')}>
         {message ? _.truncate(message, { length: 256, separator: ' ' }) : '-'}
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ClusterOperatorTableRow.displayName = 'ClusterOperatorTableRow';
@@ -109,7 +110,7 @@ type ClusterOperatorTableRowProps = {
   style: object;
 };
 
-export const ClusterOperatorList: React.SFC = props => <Table {...props} aria-label="Cluster Operators" Header={ClusterOperatorTableHeader} Row={ClusterOperatorTableRow} virtualize />;
+export const ClusterOperatorList: React.SFC = props => <VirtualTable {...props} aria-label="Cluster Operators" Header={ClusterOperatorTableHeader} Row={ClusterOperatorTableRow} />;
 
 const allStatuses = [
   OperatorStatus.Available,
@@ -157,25 +158,29 @@ export const ClusterOperatorPage: React.SFC<ClusterOperatorPageProps> = props =>
   </React.Fragment>;
 
 const OperandVersions: React.SFC<OperandVersionsProps> = ({versions}) => {
+  const OperandVersionsHeader = () => {
+    return [
+      { title: 'Name' },
+      { title: 'Version' },
+    ];
+  };
+  const OperandVersionsRows = ({componentProps}) => {
+    return _.map(componentProps.data, ({name, version}) => {
+      return [
+        { title: name },
+        { title: version },
+      ];
+    });
+  };
   return _.isEmpty(versions)
     ? <EmptyBox label="Versions" />
     : <div className="co-table-container">
-      <table className="table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Version</th>
-          </tr>
-        </thead>
-        <tbody>
-          {_.map(versions, ({name, version}, i) => (
-            <tr key={i}>
-              <td>{name}</td>
-              <td>{version}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <Table
+        aria-label="Versions"
+        data={versions}
+        Header={OperandVersionsHeader}
+        Rows={OperandVersionsRows}
+        loaded={true} />
     </div>;
 };
 

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import { Button } from 'patternfly-react';
 import { Link } from 'react-router-dom';
-
+import { Table } from '../factory';
 import { ClusterOperatorPage } from './cluster-operator';
 import { clusterChannelModal, clusterUpdateModal, errorModal } from '../modals';
 import { GlobalConfigPage } from './global-config';
@@ -146,6 +146,26 @@ const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = (
   // Split image on `@` to emphasize the digest.
   const imageParts = desiredImage.split('@');
 
+  const HistoryHeader = () => {
+    return [
+      { title: 'Version' },
+      { title: 'State' },
+      { title: 'Started' },
+      { title: 'Completed' },
+    ];
+  };
+
+  const HistoryRows = ({componentProps}) => {
+    return _.map(componentProps.data, (update) => {
+      return [
+        { title: update.version || '-' },
+        { title: update.state || '-' },
+        { title: <Timestamp timestamp={update.startedTime} /> },
+        { title: update.completionTime ? <Timestamp timestamp={update.completionTime} /> : '-' },
+      ];
+    });
+  };
+
   return <React.Fragment>
     <div className="co-m-pane__body">
       <div className="co-m-pane__body-group">
@@ -205,24 +225,12 @@ const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTableProps> = (
       {_.isEmpty(history)
         ? <EmptyBox label="History" />
         : <div className="co-table-container">
-          <table className="table">
-            <thead>
-              <tr>
-                <th>Version</th>
-                <th>State</th>
-                <th>Started</th>
-                <th>Completed</th>
-              </tr>
-            </thead>
-            <tbody>
-              {_.map(history, (update, i) => <tr key={i}>
-                <td className="co-break-all co-select-to-copy">{update.version || '-'}</td>
-                <td>{update.state || '-'}</td>
-                <td><Timestamp timestamp={update.startedTime} /></td>
-                <td>{update.completionTime ? <Timestamp timestamp={update.completionTime} /> : '-'}</td>
-              </tr>)}
-            </tbody>
-          </table>
+          <Table
+            aria-label="Update History"
+            data={history}
+            Header={HistoryHeader}
+            Rows={HistoryRows}
+            loaded={true} />
         </div>
       }
     </div>

--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -1,43 +1,51 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-
+import { Table } from './factory';
 import { Timestamp } from './utils';
 import { CamelCaseWrap } from './utils/camel-case-wrap';
 
 export const Conditions: React.SFC<ConditionsProps> = ({conditions}) => {
-  const rows = _.map(conditions, (condition, i) => <div className="row" key={i}>
-    <div className="col-xs-4 col-sm-2 col-md-2">
-      <CamelCaseWrap value={condition.type} />
-    </div>
-    <div className="col-xs-4 col-sm-2 col-md-2">
-      {condition.status}
-    </div>
-    <div className="hidden-xs hidden-sm col-md-2">
-      <Timestamp timestamp={condition.lastUpdateTime || condition.lastTransitionTime} />
-    </div>
-    <div className="col-xs-4 col-sm-3 col-md-2">
-      <CamelCaseWrap value={condition.reason} />
-    </div>
-    {/* remove initial newline which appears in route messages */}
-    <div className="hidden-xs col-sm-5 col-md-4 co-break-word co-pre-line">
-      {_.trim(condition.message) || '-'}
-    </div>
-  </div>);
+  const ConditionsTableHeader = () => {
+    return [
+      {
+        title: 'Type',
+      },
+      {
+        title: 'Status',
+      },
+      {
+        title: 'Updated',
+      },
+      {
+        title: 'Reason',
+      },
+      {
+        title: 'Message',
+      },
+    ];
+  };
+
+  const ConditionsTableRows = ({componentProps}) => {
+    return _.map(componentProps.data, (condition) => {
+      return [
+        { title: <CamelCaseWrap value={condition.type} /> },
+        { title: condition.status },
+        { title: <Timestamp timestamp={condition.lastUpdateTime || condition.lastTransitionTime} /> },
+        { title: <CamelCaseWrap value={condition.reason} /> },
+        /* remove initial newline which appears in route messages */
+        { title: _.trim(condition.message) || '-', props: { className: 'co-pre-line' } },
+      ];
+    });
+  };
 
   return <React.Fragment>
     {conditions
-      ? <div className="co-m-table-grid co-m-table-grid--bordered">
-        <div className="row co-m-table-grid__head">
-          <div className="col-xs-4 col-sm-2 col-md-2">Type</div>
-          <div className="col-xs-4 col-sm-2 col-md-2">Status</div>
-          <div className="hidden-xs hidden-sm col-md-2">Updated</div>
-          <div className="col-xs-4 col-sm-3 col-md-2">Reason</div>
-          <div className="hidden-xs col-sm-5 col-md-4">Message</div>
-        </div>
-        <div className="co-m-table-grid__body">
-          {rows}
-        </div>
-      </div>
+      ? <Table
+        aria-label="Conditions"
+        data={conditions}
+        Header={ConditionsTableHeader}
+        Rows={ConditionsTableRows}
+        loaded={true} />
       : <div className="cos-status-box">
         <div className="text-center">No Conditions Found</div>
       </div>}

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { ConfigMapData, ConfigMapBinaryData } from './configmap-and-secret-data';
 import { Kebab, SectionHeading, navFactory, ResourceKebab, ResourceLink, ResourceSummary } from './utils';
 import { fromNow } from './utils/datetime';
@@ -46,23 +46,23 @@ ConfigMapTableHeader.displayName = 'ConfigMapTableHeader';
 
 const ConfigMapTableRow = ({obj: configMap, index, key, style}) => {
   return (
-    <TableRow id={configMap.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={configMap.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind="ConfigMap" name={configMap.metadata.name} namespace={configMap.metadata.namespace} title={configMap.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={configMap.metadata.namespace} title={configMap.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {_.size(configMap.data)}
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {fromNow(configMap.metadata.creationTimestamp)}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={configMap} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ConfigMapTableRow.displayName = 'ConfigMapTableRow';
@@ -85,7 +85,7 @@ const ConfigMapDetails = ({obj: configMap}) => {
   </React.Fragment>;
 };
 
-const ConfigMaps = props => <Table {...props} aria-label="Config Maps" Header={ConfigMapTableHeader} Row={ConfigMapTableRow} virtualize />;
+const ConfigMaps = props => <VirtualTable {...props} aria-label="Config Maps" Header={ConfigMapTableHeader} Row={ConfigMapTableRow} />;
 
 const ConfigMapsPage = props => <ListPage ListComponent={ConfigMaps} canCreate={true} {...props} />;
 const ConfigMapsDetailsPage = props => <DetailsPage

--- a/frontend/public/components/cron-job.jsx
+++ b/frontend/public/components/cron-job.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, ContainerTable, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary, Timestamp } from './utils';
 import { ResourceEventStream } from './events';
 
@@ -51,26 +51,26 @@ CronJobTableHeader.displayName = 'CronJobTableHeader';
 
 const CronJobTableRow = ({obj: cronjob, index, key, style}) => {
   return (
-    <TableRow id={cronjob.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={cronjob.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={cronjob.metadata.name} title={cronjob.metadata.name} namespace={cronjob.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={cronjob.metadata.namespace} title={cronjob.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {cronjob.spec.schedule}
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {_.get(cronjob.spec, 'concurrencyPolicy', '-')}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {_.get(cronjob.spec, 'startingDeadlineSeconds', '-')}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={cronjob} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 CronJobTableRow.displayName = 'CronJobTableRow';
@@ -113,7 +113,7 @@ const Details = ({obj: cronjob}) => {
   </React.Fragment>;
 };
 
-export const CronJobsList = props => <Table {...props} aria-label="Cron Jobs" Header={CronJobTableHeader} Row={CronJobTableRow} virtualize />;
+export const CronJobsList = props => <VirtualTable {...props} aria-label="Cron Jobs" Header={CronJobTableHeader} Row={CronJobTableRow} />;
 
 export const CronJobsPage = props => <ListPage {...props} ListComponent={CronJobsList} kind={kind} canCreate={true} />;
 

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { AsyncComponent, Kebab, navFactory, ResourceKebab, ResourceLink, ResourceSummary, SectionHeading } from './utils';
 import { K8sResourceKind, referenceForCRD, CustomResourceDefinitionKind } from '../module/k8s';
 import { resourceListPages } from './resource-pages';
@@ -68,32 +68,32 @@ const namespaced = crd => crd.spec.scope === 'Namespaced';
 
 const CRDTableRow: React.FC<CRDTableRowProps> = ({obj: crd, index, key, style}) => {
   return (
-    <TableRow id={crd.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={crd.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <span className="co-resource-item">
           <ResourceLink kind="CustomResourceDefinition" name={crd.metadata.name} namespace={crd.metadata.namespace} displayName={_.get(crd, 'spec.names.kind')} />
         </span>
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         { crd.spec.group }
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         { crd.spec.version }
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         { namespaced(crd) ? 'Yes' : 'No' }
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {
           isEstablished(crd.status.conditions)
             ? <span><i className="pficon pficon-ok" aria-hidden="true"></i></span>
             : <span><i className="fa fa-ban" aria-hidden="true"></i></span>
         }
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind="CustomResourceDefinition" resource={crd} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 CRDTableRow.displayName = 'CRDTableRow';
@@ -117,7 +117,7 @@ const Instances: React.FC<InstancesProps> = ({obj, namespace}) => {
   return <AsyncComponent loader={componentLoader} namespace={namespace ? namespace : undefined} kind={crdKind} showTitle={false} autoFocus={false} />;
 };
 
-export const CustomResourceDefinitionsList: React.FC<CustomResourceDefinitionsListProps> = props => <Table {...props} aria-label="Custom Resource Definitions" Header={CRDTableHeader} Row={CRDTableRow} defaultSortField="spec.names.kind" virtualize />;
+export const CustomResourceDefinitionsList: React.FC<CustomResourceDefinitionsListProps> = props => <VirtualTable {...props} aria-label="Custom Resource Definitions" Header={CRDTableHeader} Row={CRDTableRow} defaultSortField="spec.names.kind" />;
 
 export const CustomResourceDefinitionsPage: React.FC<CustomResourceDefinitionsPageProps> = props => <ListPage {...props} ListComponent={CustomResourceDefinitionsList} kind="CustomResourceDefinition" canCreate={true} />;
 export const CustomResourceDefinitionsDetailsPage = props => <DetailsPage {...props} menuActions={menuActions} pages={[navFactory.details(Details), navFactory.editYaml(), {name: 'Instances', href: 'instances', component: Instances}]} />;

--- a/frontend/public/components/daemon-set.jsx
+++ b/frontend/public/components/daemon-set.jsx
@@ -5,9 +5,9 @@ import { sortable } from '@patternfly/react-table';
 import {
   DetailsPage,
   ListPage,
-  Table,
-  TableRow,
-  TableData,
+  VirtualTable,
+  VirtualTableRow,
+  VirtualTableData,
 } from './factory';
 import {
   AsyncComponent,
@@ -69,28 +69,28 @@ DaemonSetTableHeader.displayName = 'DaemonSetTableHeader';
 
 const DaemonSetTableRow = ({obj: daemonset, index, key, style}) => {
   return (
-    <TableRow id={daemonset.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={daemonset.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={daemonset.metadata.name} namespace={daemonset.metadata.namespace} title={daemonset.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={daemonset.metadata.namespace} title={daemonset.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={daemonset.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <Link to={`/k8s/ns/${daemonset.metadata.namespace}/daemonsets/${daemonset.metadata.name}/pods`} title="pods">
           {daemonset.status.currentNumberScheduled} of {daemonset.status.desiredNumberScheduled} pods
         </Link>
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <Selector selector={daemonset.spec.selector} namespace={daemonset .metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={daemonset} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 DaemonSetTableRow.displayName = 'DaemonSetTableRow';
@@ -134,7 +134,7 @@ const environmentComponent = (props) => <EnvironmentPage
   readOnly={false}
 />;
 const {details, pods, editYaml, envEditor, events} = navFactory;
-const DaemonSets = props => <Table {...props} aria-label="Daemon Sets" Header={DaemonSetTableHeader} Row={DaemonSetTableRow} virtualize />;
+const DaemonSets = props => <VirtualTable {...props} aria-label="Daemon Sets" Header={DaemonSetTableHeader} Row={DaemonSetTableRow} />;
 
 const DaemonSetsPage = props => <ListPage canCreate={true} ListComponent={DaemonSets} {...props} />;
 const DaemonSetsDetailsPage = props => <DetailsPage

--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { fromNow } from './utils/datetime';
 import { referenceFor, kindForReference } from '../module/k8s';
 import {
@@ -48,23 +48,23 @@ TableHeader.displayName = 'TableHeader';
 
 const TableRowForKind = ({obj, index, key, style, customData}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={customData.kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         { obj.metadata.namespace
           ? <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
           : 'None'
         }
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         { fromNow(obj.metadata.creationTimestamp) }
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <ResourceKebab actions={menuActions} kind={referenceFor(obj) || customData.kind} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 TableRowForKind.displayName = 'TableRowForKind';
@@ -81,13 +81,12 @@ const DetailsForKind = kind => function DetailsForKind_({obj}) {
 export const DefaultList = props => {
   const { kinds } = props;
 
-  return <Table {...props}
+  return <VirtualTable {...props}
     aria-label="Default Resource"
     kinds={[kinds[0]]}
     customData={{kind: kinds[0]}}
     Header={TableHeader}
-    Row={TableRowForKind}
-    virtualize />;
+    Row={TableRowForKind} />;
 };
 DefaultList.displayName = DefaultList;
 

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -11,7 +11,7 @@ import { VolumesTable } from './volumes-table';
 import {
   DetailsPage,
   ListPage,
-  Table,
+  VirtualTable,
 } from './factory';
 import {
   AsyncComponent,
@@ -208,7 +208,7 @@ const DeploymentConfigTableHeader = () => {
 };
 DeploymentConfigTableHeader.displayName = 'DeploymentConfigTableHeader';
 
-export const DeploymentConfigsList: React.FC = props => <Table {...props} aria-label="Deployment Configs" Header={DeploymentConfigTableHeader} Row={DeploymentConfigTableRow} virtualize />;
+export const DeploymentConfigsList: React.FC = props => <VirtualTable {...props} aria-label="Deployment Configs" Header={DeploymentConfigTableHeader} Row={DeploymentConfigTableRow} />;
 DeploymentConfigsList.displayName = 'DeploymentConfigsList';
 
 export const DeploymentConfigsPage: React.FC<DeploymentConfigsPageProps> = props => {

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -12,7 +12,7 @@ import { VolumesTable } from './volumes-table';
 import {
   DetailsPage,
   ListPage,
-  Table,
+  VirtualTable,
 } from './factory';
 import {
   AsyncComponent,
@@ -172,7 +172,7 @@ const DeploymentTableHeader = () => {
 };
 DeploymentTableHeader.displayName = 'DeploymentTableHeader';
 
-export const DeploymentsList: React.FC = props => <Table {...props} aria-label="Deployments" Header={DeploymentTableHeader} Row={DeploymentTableRow} virtualize />;
+export const DeploymentsList: React.FC = props => <VirtualTable {...props} aria-label="Deployments" Header={DeploymentTableHeader} Row={DeploymentTableRow} />;
 DeploymentsList.displayName = 'DeploymentsList';
 
 export const DeploymentsPage: React.FC<DeploymentsPageProps> = props => <ListPage kind={deploymentsReference} canCreate={true} ListComponent={DeploymentsList} {...props} />;

--- a/frontend/public/components/factory/index.tsx
+++ b/frontend/public/components/factory/index.tsx
@@ -2,4 +2,5 @@ export * from './details';
 export * from './list-page';
 export * from './list';
 export * from './modal';
+export * from './virtual-table';
 export * from './table';

--- a/frontend/public/components/factory/table-sorts.tsx
+++ b/frontend/public/components/factory/table-sorts.tsx
@@ -1,0 +1,81 @@
+import * as _ from 'lodash-es';
+import { alertStateOrder, silenceStateOrder } from '../../reducers/monitoring';
+import { ingressValidHosts } from '../ingress';
+import {
+  getJobTypeAndCompletions,
+  K8sResourceKind,
+  planExternalName,
+  podPhase,
+  podReadiness,
+  serviceCatalogStatus,
+  serviceClassDisplayName,
+  getClusterOperatorStatus,
+  getClusterOperatorVersion,
+  getTemplateInstanceStatus,
+  getNodeRoles,
+} from '../../module/k8s';
+
+import { SortByDirection } from '@patternfly/react-table';
+import { getFilteredRows } from './table-filters';
+
+export const tableSorts = {
+  alertStateOrder,
+  daemonsetNumScheduled: daemonset => _.toInteger(_.get(daemonset, 'status.currentNumberScheduled')),
+  dataSize: resource => _.size(_.get(resource, 'data')),
+  ingressValidHosts,
+  serviceCatalogStatus,
+  jobCompletions: job => getJobTypeAndCompletions(job).completions,
+  jobType: job => getJobTypeAndCompletions(job).type,
+  nodeReadiness: node => {
+    let readiness = _.get(node, 'status.conditions');
+    readiness = _.find(readiness, {type: 'Ready'});
+    return _.get(readiness, 'status');
+  },
+  numReplicas: resource => _.toInteger(_.get(resource, 'status.replicas')),
+  planExternalName,
+  podPhase,
+  podReadiness,
+  serviceClassDisplayName,
+  silenceStateOrder,
+  string: val => JSON.stringify(val),
+  getClusterOperatorStatus,
+  getClusterOperatorVersion,
+  getTemplateInstanceStatus,
+  nodeRoles: (node: K8sResourceKind): string => {
+    const roles = getNodeRoles(node);
+    return roles.sort().join(', ');
+  },
+};
+
+export const tableStateToProps = ({UI}, {data = [], defaultSortField = 'metadata.name', defaultSortFunc = undefined, filters = {}, loaded = false, reduxID = null, reduxIDs = null, staticFilters = [{}], rowFilters = []}) => {
+  const allFilters = staticFilters ? Object.assign({}, filters, ...staticFilters) : filters;
+  let newData = getFilteredRows(allFilters, rowFilters, data);
+
+  const listId = reduxIDs ? reduxIDs.join(',') : reduxID;
+  // Only default to 'metadata.name' if no `defaultSortFunc`
+  const currentSortField = UI.getIn(['listSorts', listId, 'field'], defaultSortFunc ? undefined : defaultSortField);
+  const currentSortFunc = UI.getIn(['listSorts', listId, 'func'], defaultSortFunc);
+  const currentSortOrder = UI.getIn(['listSorts', listId, 'orderBy'], SortByDirection.asc);
+
+  if (loaded) {
+    let sortBy: string | Function = 'metadata.name';
+    if (currentSortField) {
+      // Sort resources by one of their fields as a string
+      sortBy = resource => tableSorts.string(_.get(resource, currentSortField, ''));
+    } else if (currentSortFunc && tableSorts[currentSortFunc]) {
+      // Sort resources by a function in the 'tableSorts' object
+      sortBy = tableSorts[currentSortFunc];
+    }
+
+    // Always set the secondary sort criteria to ascending by name
+    newData = _.orderBy(newData, [sortBy, 'metadata.name'], [currentSortOrder, SortByDirection.asc]);
+  }
+
+  return {
+    currentSortField,
+    currentSortFunc,
+    currentSortOrder,
+    data: newData,
+    listId,
+  };
+};

--- a/frontend/public/components/factory/virtual-table.tsx
+++ b/frontend/public/components/factory/virtual-table.tsx
@@ -1,0 +1,367 @@
+import * as _ from 'lodash-es';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+import { connect } from 'react-redux';
+
+import * as UIActions from '../../actions/ui';
+import { EmptyBox, StatusBox } from '../utils';
+
+import {
+  IRowData, // eslint-disable-line no-unused-vars
+  IExtraData, // eslint-disable-line no-unused-vars
+  Table as PfTable,
+  TableHeader,
+  TableGridBreakpoint,
+  SortByDirection,
+} from '@patternfly/react-table';
+
+import { CellMeasurerCache, CellMeasurer} from 'react-virtualized';
+
+import {
+  AutoSizer,
+  VirtualTableBody,
+  WindowScroller,
+} from '@patternfly/react-virtualized-extension';
+
+import { filterPropType } from './table-filters';
+import { tableStateToProps } from './table-sorts';
+
+// Common table row/columns helper SFCs for implementing accessible data grid
+export const VirtualTableRow: React.SFC<VirtualTableRowProps> = ({id, index, trKey, style, className, ...props}) => {
+  return (
+    <tr {...props} data-id={id} data-index={index} data-test-rows="resource-row" data-key={trKey} style={style} className={className} role="row" />
+  );
+};
+VirtualTableRow.displayName = 'VirtualTableRow';
+export type VirtualTableRowProps = {
+  id: any;
+  index: number;
+  trKey: string;
+  style: object;
+  className?: string;
+}
+
+export const VirtualTableData: React.SFC<VirtualTableDataProps> = ({className, ...props}) => {
+  return (
+    <td {...props} className={className} role="gridcell" />
+  );
+};
+VirtualTableData.displayName = 'VirtualTableData';
+export type VirtualTableDataProps = {
+  id?: string;
+  className?: string;
+}
+
+const VirtualTableWrapper: React.SFC<VirtualTableWrapperProps> = ({ariaLabel, ariaRowCount, ...props}) => {
+  return <div {...props} role="grid" aria-label={ariaLabel} aria-rowcount={ariaRowCount} />;
+};
+export type VirtualTableWrapperProps = {
+  ariaLabel: string;
+  ariaRowCount: number | undefined;
+}
+
+const VirtualBody: React.SFC<VirtualBodyProps> = (props) => {
+  const { bindBodyRef, cellMeasurementCache, customData, Row, height, isScrolling, onChildScroll, data, columns, scrollTop, width } = props;
+
+  const rowRenderer = ({index, isScrolling: scrolling, key, style, parent}) => {
+    const rowArgs = {obj: data[index], index, columns, isScrolling: scrolling, key, style, customData};
+    const row = (Row as RowFunction)(rowArgs as RowFunctionArgs);
+
+    return <CellMeasurer
+      cache={cellMeasurementCache}
+      columnIndex={0}
+      key={key}
+      parent={parent}
+      rowIndex={index}>{row}</CellMeasurer>;
+  };
+
+  return (
+    <VirtualTableBody
+      ref={bindBodyRef}
+      autoHeight
+      className="pf-c-table pf-m-compact pf-m-border-rows pf-c-virtualized pf-c-window-scroller"
+      deferredMeasurementCache={cellMeasurementCache}
+      rowHeight={cellMeasurementCache.rowHeight}
+      height={height || 0}
+      isScrolling={isScrolling}
+      isScrollingOptOut={true}
+      onScroll={onChildScroll}
+      columnCount={1}
+      rows={data}
+      rowCount={data.length}
+      rowRenderer={rowRenderer}
+      scrollTop={scrollTop}
+      width={width}
+    />
+  );
+};
+
+export type RowFunctionArgs = {obj: object, index: number, columns: [], isScrolling: boolean, key: string, style: object, customData?: object};
+export type RowFunction = (args: RowFunctionArgs) => JSX.Element;
+
+export type VirtualBodyProps = {
+  bindBodyRef: Function;
+  cellMeasurementCache: any;
+  customData?: object;
+  Row: RowFunction | React.ComponentClass<any, any> | React.ComponentType<any>;
+  height: number;
+  isScrolling: boolean;
+  onChildScroll: (...args) => any;
+  data: any[];
+  columns: any[];
+  scrollTop: number;
+  width: number;
+  expand: boolean;
+}
+
+type VirtualTableOwnProps = {
+  customData?: object;
+  data?: any[];
+  defaultSortFunc?: string;
+  defaultSortField?: string;
+  filters?: {[key: string]: any};
+  Header: (...args) => any[];
+  loadError?: string | Object;
+  Row?: RowFunction | React.ComponentClass<any, any> | React.ComponentType<any>;
+  'aria-label': string;
+  virtualize?: boolean;
+  EmptyMsg?: React.ComponentType<{}>;
+  loaded?: boolean;
+  reduxID?: string;
+  reduxIDs?: string[];
+}
+
+type VirtualTablePropsFromState = {};
+
+type VirtualTablePropsFromDispatch = {};
+
+type VirtualTableOptionProps = {
+  UI: any;
+}
+
+/**
+ * Important: All Table documentation follows the @patternfly/react-virtualized-extension APIs
+ * Documentation here: https://patternfly-react.surge.sh/patternfly-4/virtual%20scroll/virtualized/
+ */
+
+export const VirtualTable = connect<VirtualTablePropsFromState,VirtualTablePropsFromDispatch,VirtualTableOwnProps,VirtualTableOptionProps>(
+  tableStateToProps,
+  {sortList: UIActions.sortList},
+  null,
+  {areStatesEqual: ({UI: next}, {UI: prev}) => next.get('listSorts') === prev.get('listSorts')}
+)(
+  class VirtualTableInner extends React.Component<VirtualTableInnerProps, VirtualTableInnerState> {
+    static propTypes = {
+      customData: PropTypes.object,
+      data: PropTypes.array,
+      EmptyMsg: PropTypes.func,
+      expand: PropTypes.bool,
+      fieldSelector: PropTypes.string,
+      filters: filterPropType,
+      Header: PropTypes.func.isRequired,
+      Row: PropTypes.func,
+      loaded: PropTypes.bool,
+      loadError: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+      mock: PropTypes.bool,
+      namespace: PropTypes.string,
+      reduxID: PropTypes.string,
+      reduxIDs: PropTypes.array,
+      selector: PropTypes.object,
+      staticFilters: PropTypes.array,
+      virtualize: PropTypes.bool,
+      currentSortField: PropTypes.string,
+      currentSortFunc: PropTypes.string,
+      currentSortOrder: PropTypes.any,
+      defaultSortField: PropTypes.string,
+      defaultSortFunc: PropTypes.string,
+      label: PropTypes.string,
+      listId: PropTypes.string,
+      sortList: PropTypes.func,
+      onSelect: PropTypes.func,
+    };
+    _columnShift: number;
+    _cellMeasurementCache: any;
+    _bodyRef: any;
+
+    constructor(props){
+      super(props);
+      const componentProps: any = _.pick(props, ['data', 'filters', 'selected', 'match', 'kindObj']);
+      const columns = props.Header(componentProps);
+      //sort by first column
+      this.state = {
+        columns,
+        sortBy: {},
+      };
+      this._applySort = this._applySort.bind(this);
+      this._onSort = this._onSort.bind(this);
+      this._handleResize = this._handleResize.bind(this);
+      this._bindBodyRef = this._bindBodyRef.bind(this);
+      this._refreshGrid = this._refreshGrid.bind(this);
+      this._columnShift = props.onSelect ? 1 : 0; //shift indexes by 1 if select provided
+
+      this._cellMeasurementCache = new CellMeasurerCache({
+        fixedWidth: true,
+        minHeight: 44,
+        keyMapper: rowIndex => {
+          const uid = _.get(props.data[rowIndex], 'metadata.uid', rowIndex);
+          return uid;
+        },
+      });
+    }
+
+    componentDidMount(){
+      const {columns} = this.state;
+      const sp = new URLSearchParams(window.location.search);
+      const columnIndex = _.findIndex(columns, {title: sp.get('sortBy')});
+
+      if (columnIndex > -1){
+        const sortOrder = sp.get('orderBy') || SortByDirection.asc;
+        const column = columns[columnIndex];
+        this._applySort(column.sortField, column.sortFunc, sortOrder, column.title);
+        this.setState({
+          sortBy: {
+            index: columnIndex + this._columnShift,
+            direction: sortOrder,
+          },
+        });
+      }
+
+      // re-render after resize
+      window.addEventListener('resize', this._handleResize);
+    }
+
+    componentDidUpdate(prevProps){
+      const {data} = this.props;
+      if (this._bodyRef && !_.isEqual(prevProps.data, data)){
+        // force react-virtualized to update after data changes with `isScrollingOptOut` set true
+        this._refreshGrid();
+      }
+    }
+
+    componentWillUnmount(){
+      window.removeEventListener('resize', this._handleResize);
+    }
+
+    _refreshGrid() {
+      this._cellMeasurementCache.clearAll();
+      this._bodyRef.recomputeVirtualGridSize();
+    }
+
+    _handleResize() {
+      if (this._bodyRef){
+        this._refreshGrid();
+      }
+    }
+
+    _bindBodyRef(ref) {
+      this._bodyRef = ref;
+    }
+
+    _applySort(sortField, sortFunc, direction, columnTitle){
+      const {sortList, listId, currentSortFunc} = this.props;
+      const applySort = _.partial(sortList, listId);
+      applySort(sortField, sortFunc || currentSortFunc, direction, columnTitle);
+    }
+
+    _onSort(_event, index, direction){
+      const sortColumn = this.state.columns[index - this._columnShift];
+      this._applySort(sortColumn.sortField, sortColumn.sortFunc, direction, sortColumn.title);
+      this.setState({
+        sortBy: {
+          index,
+          direction,
+        },
+      });
+    }
+
+    render() {
+      const {Row, expand, label, mock, onSelect, 'aria-label': ariaLabel, customData} = this.props;
+      const {sortBy, columns} = this.state;
+      const componentProps: any = _.pick(this.props, ['data', 'filters', 'selected', 'match', 'kindObj']);
+      const ariaRowCount = componentProps.data && componentProps.data.length;
+
+      const children = mock ? <EmptyBox label={label} /> : (
+        <VirtualTableWrapper ariaLabel={ariaLabel} ariaRowCount={ariaRowCount}>
+          <PfTable
+            cells={columns}
+            rows={[]}
+            gridBreakPoint={TableGridBreakpoint.none}
+            onSort={this._onSort}
+            onSelect={onSelect}
+            sortBy={sortBy}
+            className="pf-m-compact pf-m-border-rows"
+            role={'presentation'}
+            aria-label={null}
+          >
+            <TableHeader />
+          </PfTable>
+          <WindowScroller scrollElement={document.getElementById('content-scrollable')}>
+            {({height, isScrolling, registerChild, onChildScroll, scrollTop}) => (
+              <AutoSizer disableHeight>
+                {({width}) => (
+                  <div ref={registerChild}>
+                    <VirtualBody
+                      bindBodyRef={this._bindBodyRef}
+                      cellMeasurementCache={this._cellMeasurementCache}
+                      Row={Row}
+                      customData={customData}
+                      height={height}
+                      isScrolling={isScrolling}
+                      onChildScroll={onChildScroll}
+                      data={componentProps.data}
+                      columns={columns}
+                      scrollTop={scrollTop}
+                      width={width}
+                      expand={expand}
+                    />
+                  </div>
+                )}
+              </AutoSizer>
+            )}
+          </WindowScroller>
+        </VirtualTableWrapper>
+      );
+      return <div className="co-m-table-grid co-m-table-grid--bordered">
+        { mock
+          ? children
+          : <StatusBox skeleton={<div className="loading-skeleton--table" />} {...this.props}>{children}</StatusBox> }
+      </div>;
+    }
+  });
+
+
+export type VirtualTableInnerProps = {
+  'aria-label': string;
+  customData?: object;
+  currentSortField?: string;
+  currentSortFunc?: string;
+  currentSortOrder?: any;
+  data?: any[];
+  defaultSortField?: string;
+  defaultSortFunc?: string;
+  EmptyMsg?: React.ComponentType<{}>;
+  expand?: boolean;
+  fieldSelector?: string;
+  filters?: {[name: string]: any};
+  Header: (...args) => any[];
+  label?: string;
+  listId?: string;
+  loaded?: boolean;
+  loadError?: string | Object;
+  mock?: boolean;
+  namespace?: string;
+  reduxID?: string;
+  reduxIDs?: string[];
+  Row?: RowFunction | React.ComponentClass<any, any> | React.ComponentType<any>;
+  selector?: Object;
+  sortList?: (listId: string, field: string, func: any, orderBy: string, column: string) => any;
+  onSelect?: (event: React.MouseEvent, isSelected: boolean, rowIndex: number, rowData: IRowData, extraData: IExtraData) => void;
+  staticFilters?: any[];
+  rowFilters?: any[];
+  virtualize?: boolean;
+};
+
+export type VirtualTableInnerState = {
+  columns?: any[];
+  sortBy: object;
+};

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { Conditions } from './conditions';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, SectionHeading, LabelList, navFactory, ResourceKebab, ResourceLink, ResourceSummary, Timestamp } from './utils';
 import { ResourceEventStream } from './events';
 
@@ -218,29 +218,29 @@ HorizontalPodAutoscalersTableHeader.displayName = 'HorizontalPodAutoscalersTable
 
 const HorizontalPodAutoscalersTableRow: React.FC<HorizontalPodAutoscalersTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={HorizontalPodAutoscalersReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={obj.metadata.labels} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[3], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[3], 'co-break-word')}>
         <ResourceLink kind={obj.spec.scaleTargetRef.kind} name={obj.spec.scaleTargetRef.name} namespace={obj.metadata.namespace} title={obj.spec.scaleTargetRef.name} />
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {obj.spec.minReplicas}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         {obj.spec.maxReplicas}
-      </TableData>
-      <TableData className={tableColumnClasses[6]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[6]}>
         <ResourceKebab actions={menuActions} kind={HorizontalPodAutoscalersReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 HorizontalPodAutoscalersTableRow.displayName = 'HorizontalPodAutoscalersTableRow';
@@ -251,7 +251,7 @@ type HorizontalPodAutoscalersTableRowProps = {
   style: object;
 };
 
-const HorizontalPodAutoscalersList: React.SFC = props => <Table {...props} aria-label="Horizontal Pod Auto Scalers" Header={HorizontalPodAutoscalersTableHeader} Row={HorizontalPodAutoscalersTableRow} virtualize />;
+const HorizontalPodAutoscalersList: React.SFC = props => <VirtualTable {...props} aria-label="Horizontal Pod Auto Scalers" Header={HorizontalPodAutoscalersTableHeader} Row={HorizontalPodAutoscalersTableRow} />;
 HorizontalPodAutoscalersList.displayName = 'HorizontalPodAutoscalersList';
 
 export const HorizontalPodAutoscalersPage: React.SFC<HorizontalPodAutoscalersPageProps> = props =>

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -7,7 +7,7 @@ import { AlertVariant, Popover } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { CopyToClipboard, ExpandableAlert, ExternalLink, Kebab, SectionHeading, LabelList, navFactory, ResourceKebab, ResourceLink, ResourceSummary, history, Timestamp } from './utils';
 import { ImageStreamTimeline } from './image-stream-timeline';
 import { fromNow } from './utils/datetime';
@@ -254,23 +254,23 @@ ImageStreamsTableHeader.displayName = 'ImageStreamsTableHeader';
 
 const ImageStreamsTableRow: React.FC<ImageStreamsTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={ImageStreamsReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={ImageStreamsReference} labels={obj.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {fromNow(obj.metadata.creationTimestamp)}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <ResourceKebab actions={menuActions} kind={ImageStreamsReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ImageStreamsTableRow.displayName = 'ImageStreamsTableRow';
@@ -281,7 +281,7 @@ type ImageStreamsTableRowProps = {
   style: object;
 };
 
-export const ImageStreamsList: React.SFC = props => <Table {...props} aria-label="Image Streams" Header={ImageStreamsTableHeader} Row={ImageStreamsTableRow} virtualize />;
+export const ImageStreamsList: React.SFC = props => <VirtualTable {...props} aria-label="Image Streams" Header={ImageStreamsTableHeader} Row={ImageStreamsTableRow} />;
 ImageStreamsList.displayName = 'ImageStreamsList';
 
 export const buildPhase = build => build.status.phase;

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, SectionHeading, LabelList, ResourceKebab, ResourceIcon, detailsPage, EmptyBox, navFactory, ResourceLink, ResourceSummary } from './utils';
 
 const menuActions = Kebab.factory.common;
@@ -70,24 +70,24 @@ IngressTableHeader.displayName = 'IngressTableHeader';
 
 const IngressTableRow = ({obj: ingress, index, key, style}) => {
   return (
-    <TableRow id={ingress.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={ingress.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={ingress.metadata.name}
           namespace={ingress.metadata.namespace} title={ingress.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={ingress.metadata.namespace} title={ingress.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={ingress.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {getHosts(ingress)}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={ingress} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 IngressTableRow.displayName = 'IngressTableRow';
@@ -175,7 +175,7 @@ const IngressesDetailsPage = props => <DetailsPage
   menuActions={menuActions}
   pages={[navFactory.details(detailsPage(Details)), navFactory.editYaml()]}
 />;
-const IngressesList = props => <Table {...props} aria-label="Ingresses" Header={IngressTableHeader} Row={IngressTableRow} virtualize />;
+const IngressesList = props => <VirtualTable {...props} aria-label="Ingresses" Header={IngressTableHeader} Row={IngressTableRow} />;
 
 const IngressesPage = props => <ListPage ListComponent={IngressesList} canCreate={true} {...props} />;
 

--- a/frontend/public/components/job.jsx
+++ b/frontend/public/components/job.jsx
@@ -5,7 +5,7 @@ import { sortable } from '@patternfly/react-table';
 
 import { Status } from '@console/shared';
 import { getJobTypeAndCompletions } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { configureJobParallelismModal } from './modals';
 import { Kebab, ContainerTable, SectionHeading, LabelList, ResourceKebab, ResourceLink, ResourceSummary, Timestamp, navFactory } from './utils';
 import { ResourceEventStream } from './events';
@@ -69,26 +69,26 @@ JobTableHeader.displayName = 'JobTableHeader';
 const JobTableRow = ({obj: job, index, key, style}) => {
   const {type, completions} = getJobTypeAndCompletions(job);
   return (
-    <TableRow id={job.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={job.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={job.metadata.name} namespace={job.metadata.namespace} title={job.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={job.metadata.namespace} title={job.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={job.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <Link to={`/k8s/ns/${job.metadata.namespace}/jobs/${job.metadata.name}/pods`} title="pods">
           {job.status.succeeded || 0} of {completions}
         </Link>
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>{type}</TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>{type}</VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind="Job" resource={job} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 JobTableRow.displayName = 'JobTableRow';
@@ -138,7 +138,7 @@ const JobsDetailsPage = props => <DetailsPage
   menuActions={menuActions}
   pages={[details(Details), editYaml(), pods(), events(ResourceEventStream)]}
 />;
-const JobsList = props => <Table {...props} aria-label="Jobs" Header={JobTableHeader} Row={JobTableRow} virtualize />;
+const JobsList = props => <VirtualTable {...props} aria-label="Jobs" Header={JobTableHeader} Row={JobTableRow} />;
 
 const JobsPage = props => <ListPage ListComponent={JobsList} canCreate={true} {...props} />;
 export {JobsList, JobsPage, JobsDetailsPage};

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import {K8sResourceKindReference, K8sResourceKind} from '../module/k8s';
-import {DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import {DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import {Kebab, navFactory, SectionHeading, ResourceKebab, ResourceLink, ResourceSummary, Timestamp} from './utils';
 
 const { common } = Kebab.factory;
@@ -20,20 +20,20 @@ const tableColumnClasses = [
 
 export const LimitRangeTableRow: React.FC<LimitRangeTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={LimitRangeReference} name={obj.metadata.name} namespace={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <ResourceKebab actions={menuActions} kind={LimitRangeReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 LimitRangeTableRow.displayName = 'LimitRangeTableRow';
@@ -65,7 +65,7 @@ export const LimitRangeTableHeader = () => {
 };
 LimitRangeTableHeader.displayName = 'LimitRangeTableHeader';
 
-export const LimitRangeList: React.SFC = props => <Table {...props} aria-label="Limit Ranges" Header={LimitRangeTableHeader} Row={LimitRangeTableRow} virtualize />;
+export const LimitRangeList: React.SFC = props => <VirtualTable {...props} aria-label="Limit Ranges" Header={LimitRangeTableHeader} Row={LimitRangeTableRow} />;
 
 export const LimitRangeListPage: React.SFC<LimitRangeListPageProps> = props =>
   <ListPage

--- a/frontend/public/components/machine-autoscaler.tsx
+++ b/frontend/public/components/machine-autoscaler.tsx
@@ -4,7 +4,7 @@ import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
 import { MachineAutoscalerModel } from '../models';
 import { groupVersionFor, K8sResourceKind, referenceForGroupVersionKind, referenceForModel } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import {
   Kebab,
   navFactory,
@@ -71,26 +71,26 @@ MachineAutoscalerTableHeader.displayName = 'MachineAutoscalerTableHeader';
 
 const MachineAutoscalerTableRow: React.FC<MachineAutoscalerTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={machineAutoscalerReference} name={obj.metadata.name} namespace={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         <MachineAutoscalerTargetLink obj={obj} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {_.get(obj, 'spec.minReplicas') || '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {_.get(obj, 'spec.maxReplicas') || '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={machineAutoscalerReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 MachineAutoscalerTableRow.displayName = 'MachineAutoscalerTableRow';
@@ -101,12 +101,11 @@ type MachineAutoscalerTableRowProps = {
   style: object;
 };
 
-const MachineAutoscalerList: React.FC = props => <Table
+const MachineAutoscalerList: React.FC = props => <VirtualTable
   {...props}
   aria-label="Machine Autoscalers"
   Header={MachineAutoscalerTableHeader}
-  Row={MachineAutoscalerTableRow}
-  virtualize />;
+  Row={MachineAutoscalerTableRow} />;
 
 const MachineAutoscalerDetails: React.FC<MachineAutoscalerDetailsProps> = ({obj}) => {
   return <React.Fragment>

--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -16,9 +16,9 @@ import {
 import {
   DetailsPage,
   ListPage,
-  Table,
-  TableRow,
-  TableData,
+  VirtualTable,
+  VirtualTableRow,
+  VirtualTableData,
 } from './factory';
 import {
   Kebab,
@@ -237,26 +237,26 @@ MachineConfigPoolTableHeader.displayName = 'MachineConfigPoolTableHeader';
 
 const MachineConfigPoolTableRow: React.FC<MachineConfigPoolTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={classNames(tableColumnClasses[0], 'co-break-word')}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={classNames(tableColumnClasses[0], 'co-break-word')}>
         <ResourceLink kind={machineConfigPoolReference} name={obj.metadata.name} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         {_.get(obj, 'status.configuration.name') ? <ResourceLink kind={machineConfigReference} name={obj.status.configuration.name} title={obj.status.configuration.name} /> : '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {getConditionStatus(obj, MachineConfigPoolConditionType.Updated)}
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {getConditionStatus(obj, MachineConfigPoolConditionType.Updating)}
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[4], 'co-truncate')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[4], 'co-truncate')}>
         {getConditionStatus(obj, MachineConfigPoolConditionType.Degraded)}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={machineConfigPoolMenuActions} kind={machineConfigPoolReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 MachineConfigPoolTableRow.displayName = 'MachineConfigPoolTableRow';
@@ -267,12 +267,11 @@ type MachineConfigPoolTableRowProps = {
   style: object;
 };
 
-const MachineConfigPoolList: React.SFC<any> = props => <Table
+const MachineConfigPoolList: React.SFC<any> = props => <VirtualTable
   {...props}
   aria-label="Machine Config Pools"
   Header={MachineConfigPoolTableHeader}
-  Row={MachineConfigPoolTableRow}
-  virtualize />;
+  Row={MachineConfigPoolTableRow} />;
 
 export const MachineConfigPoolPage: React.SFC<any> = props => (
   <ListPage

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -8,9 +8,9 @@ import { fromNow } from './utils/datetime';
 import {
   DetailsPage,
   ListPage,
-  Table,
-  TableRow,
-  TableData,
+  VirtualTable,
+  VirtualTableRow,
+  VirtualTableData,
 } from './factory';
 import {
   Kebab,
@@ -95,26 +95,26 @@ MachineConfigTableHeader.displayName = 'MachineConfigTableHeader';
 
 const MachineConfigTableRow: React.FC<MachineConfigTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={machineConfigReference} name={obj.metadata.name} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         { _.get(obj, ['metadata', 'annotations', 'machineconfiguration.openshift.io/generated-by-controller-version'], '-')}
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {_.get(obj, 'spec.config.ignition.version') || '-'}
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[3], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[3], 'co-break-word')}>
         {_.get(obj, 'spec.osImageURL') || '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {fromNow(obj.metadata.creationTimestamp)}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={machineConfigMenuActions} kind={machineConfigReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 MachineConfigTableRow.displayName = 'MachineConfigTableRow';
@@ -125,12 +125,11 @@ type MachineConfigTableRowProps = {
   style: object;
 };
 
-const MachineConfigList: React.SFC<any> = props => <Table
+const MachineConfigList: React.SFC<any> = props => <VirtualTable
   {...props}
   aria-label="Machine Configs"
   Header={MachineConfigTableHeader}
-  Row={MachineConfigTableRow}
-  virtualize />;
+  Row={MachineConfigTableRow} />;
 
 export const MachineConfigPage: React.SFC<any> = ({canCreate = true, ...rest}) => (
   <ListPage

--- a/frontend/public/components/machine-deployment.tsx
+++ b/frontend/public/components/machine-deployment.tsx
@@ -14,7 +14,7 @@ import {
   MachineCounts,
   MachineTabPage,
 } from './machine-set';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import {
   Kebab,
   ResourceKebab,
@@ -63,22 +63,22 @@ MachineDeploymentTableHeader.displayName = 'MachineDeploymentTableHeader';
 
 const MachineDeploymentTableRow: React.FC<MachineDeploymentTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={machineDeploymentReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <Link to={`${resourcePath(machineDeploymentReference, obj.metadata.name, obj.metadata.namespace)}/machines`}>
           {getReadyReplicas(obj)} of {getDesiredReplicas(obj)} machines
         </Link>
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <ResourceKebab actions={menuActions} kind={machineDeploymentReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 MachineDeploymentTableRow.displayName = 'MachineDeploymentTableRow';
@@ -144,12 +144,11 @@ const MachineDeploymentDetails: React.SFC<MachineDeploymentDetailsProps> = ({obj
   </React.Fragment>;
 };
 
-export const MachineDeploymentList: React.SFC = props => <Table
+export const MachineDeploymentList: React.SFC = props => <VirtualTable
   {...props}
   aria-label="Machine Deployments"
   Header={MachineDeploymentTableHeader}
-  Row={MachineDeploymentTableRow}
-  virtualize />;
+  Row={MachineDeploymentTableRow} />;
 
 export const MachineDeploymentPage: React.SFC<MachineDeploymentPageProps> = props =>
   <ListPage

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -8,7 +8,7 @@ import { MachineAutoscalerModel, MachineModel, MachineSetModel } from '../models
 import { K8sKind, MachineDeploymentKind, MachineSetKind, referenceForModel } from '../module/k8s';
 import { MachinePage } from './machine';
 import { configureMachineAutoscalerModal, configureReplicaCountModal } from './modals';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import {
   Kebab,
   KebabAction,
@@ -100,22 +100,22 @@ MachineSetTableHeader.displayName = 'MachineSetTableHeader';
 
 const MachineSetTableRow: React.FC<MachineSetTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={machineSetReference} name={obj.metadata.name} namespace={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <Link to={`${resourcePath(machineSetReference, obj.metadata.name, obj.metadata.namespace)}/machines`}>
           {getReadyReplicas(obj)} of {getDesiredReplicas(obj)} machines
         </Link>
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <ResourceKebab actions={menuActions} kind={machineSetReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 MachineSetTableRow.displayName = 'MachineSetTableRow';
@@ -230,7 +230,7 @@ const MachineSetDetails: React.SFC<MachineSetDetailsProps> = ({obj}) => {
   </React.Fragment>;
 };
 
-export const MachineSetList: React.SFC = props => <Table {...props} aria-label="Machine Sets" Header={MachineSetTableHeader} Row={MachineSetTableRow} virtualize />;
+export const MachineSetList: React.SFC = props => <VirtualTable {...props} aria-label="Machine Sets" Header={MachineSetTableHeader} Row={MachineSetTableRow} />;
 
 export const MachineSetPage: React.SFC<MachineSetPageProps> = props =>
   <ListPage

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -7,7 +7,7 @@ import { MachineModel } from '../models';
 import { MachineKind, referenceForModel } from '../module/k8s';
 import { Conditions } from './conditions';
 import { NodeIPList } from './node';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import {
   Kebab,
   NodeLink,
@@ -65,26 +65,26 @@ const MachineTableRow: React.FC<MachineTableRowProps> = ({obj, index, key, style
   const { availabilityZone, region } = getMachineAWSPlacement(obj);
   const nodeName = getMachineNodeName(obj);
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={classNames(tableColumnClasses[0], 'co-break-word')}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={classNames(tableColumnClasses[0], 'co-break-word')}>
         <ResourceLink kind={machineReference} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {nodeName ? <NodeLink name={nodeName} /> : '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {region || '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {availabilityZone || '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={machineReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 MachineTableRow.displayName = 'MachineTableRow';
@@ -130,7 +130,7 @@ const MachineDetails: React.SFC<MachineDetailsProps> = ({obj}: {obj: MachineKind
   </React.Fragment>;
 };
 
-export const MachineList: React.SFC = props => <Table {...props} aria-label="Machines" Header={MachineTableHeader} Row={MachineTableRow} virtualize />;
+export const MachineList: React.SFC = props => <VirtualTable {...props} aria-label="Machines" Header={MachineTableHeader} Row={MachineTableRow} />;
 
 export const MachinePage: React.SFC<MachinePageProps> = props =>
   <ListPage

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -13,7 +13,7 @@ import * as UIActions from '../actions/ui';
 import { coFetchJSON } from '../co-fetch';
 import { alertState, AlertStates, connectToURLs, MonitoringRoutes, silenceState, SilenceStates } from '../reducers/monitoring';
 import store from '../redux';
-import { ResourceRow, Table, TableData, TableRow, TextFilter } from './factory';
+import { ResourceRow, VirtualTable, VirtualTableData, VirtualTableRow, TextFilter } from './factory';
 import { confirmModal } from './modals';
 import { graphStateToProps, QueryBrowserPage, ToggleGraph } from './monitoring/metrics';
 import { Labels, QueryBrowser } from './monitoring/query-browser';
@@ -510,25 +510,25 @@ const AlertTableRow: React.FC<AlertTableRowProps> = ({obj, index, key, style}) =
   const {annotations = {}, labels} = obj;
   const state = alertState(obj);
   return (
-    <TableRow id={obj.rule.id} index={index} trKey={key} style={style}>
-      <TableData className={tableAlertClasses[0]}>
+    <VirtualTableRow id={obj.rule.id} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableAlertClasses[0]}>
         <div className="co-resource-item">
           <MonitoringResourceIcon resource={AlertResource} />
           <Link to={alertURL(obj, obj.rule.id)} data-test-id="alert-resource-link" className="co-resource-item__resource-name">{labels && labels.alertname}</Link>
         </div>
         <div className="monitoring-description">{annotations.description || annotations.message}</div>
-      </TableData>
-      <TableData className={tableAlertClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableAlertClasses[1]}>
         <AlertState state={state} />
         <AlertStateDescription alert={obj} />
-      </TableData>
-      <TableData className={classNames(tableAlertClasses[2], 'co-truncate')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableAlertClasses[2], 'co-truncate')}>
         {_.startCase(_.get(labels, 'severity')) || '-'}
-      </TableData>
-      <TableData className={tableAlertClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableAlertClasses[3]}>
         <Kebab options={state === AlertStates.Firing || state === AlertStates.Pending ? [silenceAlert(obj), viewAlertRule(obj)] : [viewAlertRule(obj)]} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 AlertTableRow.displayName = 'AlertTableRow';
@@ -660,7 +660,7 @@ const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringListPage
         </div>
         <div className="row">
           <div className="col-xs-12">
-            <Table
+            <VirtualTable
               aria-label={kindPlural}
               data={data}
               filters={filters}
@@ -669,7 +669,6 @@ const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringListPage
               loadError={loadError}
               reduxID={reduxID}
               Row={Row}
-              virtualize
             />
           </div>
         </div>
@@ -746,8 +745,8 @@ const SilenceRow = ({obj}) => {
 const SilenceTableRow: React.FC<SilenceTableRowProps> = ({obj, index, key, style}) => {
   const state = silenceState(obj);
   return (
-    <TableRow id={obj.id} index={index} trKey={key} style={style}>
-      <TableData className={tableSilenceClasses[0]}>
+    <VirtualTableRow id={obj.id} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableSilenceClasses[0]}>
         <div className="co-resource-item">
           <MonitoringResourceIcon resource={SilenceResource} />
           <Link className="co-resource-item__resource-name" data-test-id="silence-resource-link" title={obj.id} to={`${SilenceResource.plural}/${obj.id}`}>{obj.name}</Link>
@@ -755,20 +754,20 @@ const SilenceTableRow: React.FC<SilenceTableRowProps> = ({obj, index, key, style
         <div className="monitoring-label-list">
           <SilenceMatchersList silence={obj} />
         </div>
-      </TableData>
-      <TableData className={classNames(tableSilenceClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableSilenceClasses[1], 'co-break-word')}>
         <SilenceState silence={obj} />
         {state === SilenceStates.Pending && <StateTimestamp text="Starts" timestamp={obj.startsAt} />}
         {state === SilenceStates.Active && <StateTimestamp text="Ends" timestamp={obj.endsAt} />}
         {state === SilenceStates.Expired && <StateTimestamp text="Expired" timestamp={obj.endsAt} />}
-      </TableData>
-      <TableData className={tableSilenceClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableSilenceClasses[2]}>
         {obj.firingAlerts.length}
-      </TableData>
-      <TableData className={tableSilenceClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableSilenceClasses[3]}>
         <SilenceKebab silence={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 SilenceTableRow.displayName = 'SilenceTableRow';

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -11,7 +11,7 @@ import { Status } from '@console/shared';
 import { NamespaceModel, ProjectModel, SecretModel } from '../models';
 import { k8sGet } from '../module/k8s';
 import * as UIActions from '../actions/ui';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, Dropdown, Firehose, LabelList, LoadingInline, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceIcon, ResourceSummary, MsgBox, ExternalLink, humanizeCpuCores, humanizeDecimalBytes, useAccessReview } from './utils';
 import { createNamespaceModal, createProjectModal, deleteNamespaceModal, configureNamespacePullSecretModal } from './modals';
 import { RoleBindingsPage } from './RBAC';
@@ -81,25 +81,25 @@ NamespacesTableHeader.displayName = 'NamespacesTableHeader';
 
 const NamespacesTableRow = ({obj: ns, index, key, style}) => {
   return (
-    <TableRow id={ns.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={namespacesColumnClasses[0]}>
+    <VirtualTableRow id={ns.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={namespacesColumnClasses[0]}>
         <ResourceLink kind="Namespace" name={ns.metadata.name} title={ns.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(namespacesColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(namespacesColumnClasses[1], 'co-break-word')}>
         <Status status={ns.status.phase} />
-      </TableData>
-      <TableData className={namespacesColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={namespacesColumnClasses[2]}>
         <LabelList kind="Namespace" labels={ns.metadata.labels} />
-      </TableData>
-      <TableData className={namespacesColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={namespacesColumnClasses[3]}>
         <ResourceKebab actions={nsMenuActions} kind="Namespace" resource={ns} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 NamespacesTableRow.displayName = 'NamespacesTableRow';
 
-export const NamespacesList = props => <Table {...props} aria-label="Namespaces" Header={NamespacesTableHeader} Row={NamespacesTableRow} virtualize />;
+export const NamespacesList = props => <VirtualTable {...props} aria-label="Namespaces" Header={NamespacesTableHeader} Row={NamespacesTableRow} />;
 
 export const NamespacesPage = props => <ListPage {...props} ListComponent={NamespacesList} canCreate={true} createHandler={() => createNamespaceModal({blocking: true})} />;
 
@@ -160,8 +160,8 @@ const ProjectTableRow = ({obj: project, index, key, style, customData = {}}) => 
   const requester = getRequester(project);
   const { ProjectLinkComponent, actionsEnabled = true } = customData;
   return (
-    <TableRow id={project.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={projectColumnClasses[0]}>
+    <VirtualTableRow id={project.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={projectColumnClasses[0]}>
         {customData && ProjectLinkComponent ? (
           <ProjectLinkComponent project={project} />
         ) : (
@@ -169,29 +169,29 @@ const ProjectTableRow = ({obj: project, index, key, style, customData = {}}) => 
             <ResourceLink kind="Project" name={project.metadata.name} title={project.metadata.uid} />
           </span>
         )}
-      </TableData>
-      <TableData className={projectColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={projectColumnClasses[1]}>
         <Status status={project.status.phase} />
-      </TableData>
-      <TableData className={classNames(projectColumnClasses[2], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(projectColumnClasses[2], 'co-break-word')}>
         {requester || <span className="text-muted">No requester</span>}
-      </TableData>
-      <TableData className={projectColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={projectColumnClasses[3]}>
         <LabelList kind="Project" labels={project.metadata.labels} />
-      </TableData>
+      </VirtualTableData>
       {
         actionsEnabled && (
-          <TableData className={projectColumnClasses[4]}>
+          <VirtualTableData className={projectColumnClasses[4]}>
             <ResourceKebab actions={projectMenuActions} kind="Project" resource={project} />
-          </TableData>
+          </VirtualTableData>
         )
       }
-    </TableRow>
+    </VirtualTableRow>
   );
 };
 ProjectTableRow.displayName = 'ProjectTableRow';
 
-export const ProjectsTable = props => <Table {...props} aria-label="Projects" Header={projectHeaderWithoutActions} Row={ProjectTableRow} customData={{ProjectLinkComponent: ProjectLink, actionsEnabled: false}} virtualize />;
+export const ProjectsTable = props => <VirtualTable {...props} aria-label="Projects" Header={projectHeaderWithoutActions} Row={ProjectTableRow} customData={{ProjectLinkComponent: ProjectLink, actionsEnabled: false}} />;
 
 const ProjectList_ = props => {
   const ProjectEmptyMessageDetail = <React.Fragment>
@@ -206,7 +206,7 @@ const ProjectList_ = props => {
     </p>
   </React.Fragment>;
   const ProjectEmptyMessage = () => <MsgBox title="Welcome to OpenShift" detail={ProjectEmptyMessageDetail} />;
-  return <Table {...props} aria-label="Projects" Header={ProjectTableHeader} Row={ProjectTableRow} EmptyMsg={ProjectEmptyMessage} virtualize />;
+  return <VirtualTable {...props} aria-label="Projects" Header={ProjectTableHeader} Row={ProjectTableRow} EmptyMsg={ProjectEmptyMessage} />;
 };
 export const ProjectList = connect(createProjectMessageStateToProps)(ProjectList_);
 

--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -5,7 +5,7 @@ import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
 import { connectToFlags } from '../reducers/features';
 import { FLAGS } from '../const';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary, Selector, ExternalLink } from './utils';
 
 const { common } = Kebab.factory;
@@ -43,29 +43,29 @@ const kind = 'NetworkPolicy';
 
 const NetworkPolicyTableRow = ({obj: np, index, key, style}) => {
   return (
-    <TableRow id={np.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={np.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={np.metadata.name} namespace={np.metadata.namespace} title={np.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind={'Namespace'} name={np.metadata.namespace} title={np.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         {
           _.isEmpty(np.spec.podSelector) ?
             <Link to={`/search/ns/${np.metadata.namespace}?kind=Pod`}>{`All pods within ${np.metadata.namespace}`}</Link> :
             <Selector selector={np.spec.podSelector} namespace={np.metadata.namespace} />
         }
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={np} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 NetworkPolicyTableRow.displayName = 'NetworkPolicyTableRow';
 
-const NetworkPoliciesList = props => <Table {...props} aria-label="Network Policies" Header={NetworkPolicyTableHeader} Row={NetworkPolicyTableRow} virtualize />;
+const NetworkPoliciesList = props => <VirtualTable {...props} aria-label="Network Policies" Header={NetworkPolicyTableHeader} Row={NetworkPolicyTableRow} />;
 
 export const NetworkPoliciesPage = props => <ListPage {...props} ListComponent={NetworkPoliciesList} kind={kind} canCreate={true} />;
 

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -6,7 +6,7 @@ import { sortable } from '@patternfly/react-table';
 import { Status } from '@console/shared';
 import { getNodeRoles, nodeStatus, makeNodeSchedulable, K8sResourceKind, referenceForModel } from '../module/k8s';
 import { ResourceEventStream } from './events';
-import { Table, TableRow, TableData, DetailsPage, ListPage } from './factory';
+import { VirtualTable, VirtualTableRow, VirtualTableData, DetailsPage, ListPage } from './factory';
 import { configureUnschedulableModal } from './modals';
 import { PodsPage } from './pod';
 import { Kebab, navFactory, LabelList, ResourceKebab, SectionHeading, ResourceLink, Timestamp, units, cloudProviderNames, cloudProviderID, pluralize, humanizeDecimalBytes, humanizeCpuCores, useAccessReview, humanizeDecimalBytesPerSec } from './utils';
@@ -103,23 +103,23 @@ const NodeTableRow: React.FC<NodeTableRowProps> = ({obj: node, index, key, style
   const machine = getMachine(node);
   const roles = getNodeRoles(node).sort();
   return (
-    <TableRow id={node.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={node.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind="Node" name={node.metadata.name} title={node.metadata.uid} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <NodeStatus node={node} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {roles.length ? roles.join(', ') : '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {machine && <ResourceLink kind={referenceForModel(MachineModel)} name={machine.name} namespace={machine.namespace} />}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <NodeKebab node={node} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 NodeTableRow.displayName = 'NodeTableRow';
@@ -130,7 +130,7 @@ type NodeTableRowProps = {
   style: object;
 };
 
-const NodesList = props => <Table {...props} aria-label="Nodes" Header={NodeTableHeader} Row={NodeTableRow} virtualize />;
+const NodesList = props => <VirtualTable {...props} aria-label="Nodes" Header={NodeTableHeader} Row={NodeTableRow} />;
 
 const filters = [{
   type: 'node-status',

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -9,7 +9,7 @@ import { Alert } from '@patternfly/react-core';
 
 import { SuccessStatus, ErrorStatus } from '@console/shared';
 import { ProvidedAPIsPage, ProvidedAPIPage } from './operand';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from '../factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from '../factory';
 import { withFallback } from '../utils/error-boundary';
 import { referenceForModel, referenceFor, GroupVersionKind, K8sKind } from '../../module/k8s';
 import { ClusterServiceVersionModel, SubscriptionModel, PackageManifestModel } from '../../models';
@@ -96,38 +96,38 @@ export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionT
     </span>
     : <span className="co-error co-icon-and-text"><ErrorStatus title="Failed" /></span>;
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <Link to={route}>
           <ClusterServiceVersionLogo icon={_.get(obj, 'spec.icon', [])[0]} displayName={obj.spec.displayName} version={obj.spec.version} provider={obj.spec.provider} />
         </Link>
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <ResourceLink kind="Namespace" title={obj.metadata.namespace} name={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <ResourceLink kind="Deployment" name={obj.spec.install.spec.deployments[0].name} namespace={operatorNamespaceFor(obj)} title={obj.spec.install.spec.deployments[0].name} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {obj.metadata.deletionTimestamp ? 'Disabling' : installStatus}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         { _.take(providedAPIsFor(obj), 4).map((desc, i) => <div key={i}>
           <Link to={`${route}/${referenceForProvidedAPI(desc)}`} title={desc.name}>{desc.displayName}</Link>
         </div>)}
         { providedAPIsFor(obj).length > 4 && <Link to={`${route}/instances`} title={`View ${providedAPIsFor(obj).length - 4} more...`}>{`View ${providedAPIsFor(obj).length - 4} more...`}</Link>}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab resource={obj} kind={referenceFor(obj)} actions={menuActions} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 });
 
 export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps> = (props) => {
   const EmptyMsg = () => <MsgBox title="No Cluster Service Versions Found" detail="" />;
 
-  return <Table {...props} aria-label="Installed Operators" Header={ClusterServiceVersionTableHeader} Row={ClusterServiceVersionTableRow} EmptyMsg={EmptyMsg} virtualize />;
+  return <VirtualTable {...props} aria-label="Installed Operators" Header={ClusterServiceVersionTableHeader} Row={ClusterServiceVersionTableRow} EmptyMsg={EmptyMsg} />;
 };
 
 export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProps> = (props) => {

--- a/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/install-plan.tsx
@@ -4,7 +4,7 @@ import { match, Link } from 'react-router-dom';
 import { Map as ImmutableMap } from 'immutable';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
-import { MultiListPage, DetailsPage, Table, TableRow, TableData } from '../factory';
+import { MultiListPage, DetailsPage, VirtualTable, VirtualTableRow, VirtualTableData } from '../factory';
 import { SectionHeading, MsgBox, ResourceLink, ResourceKebab, Kebab, ResourceIcon, navFactory, ResourceSummary, history } from '../utils';
 import { InstallPlanKind, InstallPlanApproval, olmNamespace, Step, referenceForStepResource } from './index';
 import { K8sResourceKind, referenceForModel, referenceForOwnerRef, k8sUpdate, apiVersionForReference } from '../../module/k8s';
@@ -53,14 +53,14 @@ export const InstallPlanTableRow: React.FC<InstallPlanTableRowProps> = ({obj, in
     ? <React.Fragment><i className="fa fa-exclamation-triangle text-warning" aria-hidden="true" /> {phase}</React.Fragment>
     : phase;
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={referenceForModel(InstallPlanModel)} namespace={obj.metadata.namespace} name={obj.metadata.name} title={obj.metadata.uid} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} displayName={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <ul className="list-unstyled">
           { obj.spec.clusterServiceVersionNames.map((csvName, i) => <li key={i}>
             { _.get(obj, 'status.phase') === 'Complete'
@@ -68,21 +68,21 @@ export const InstallPlanTableRow: React.FC<InstallPlanTableRowProps> = ({obj, in
               : <React.Fragment><ResourceIcon kind={referenceForModel(ClusterServiceVersionModel)} />{csvName}</React.Fragment> }
           </li>) }
         </ul>
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         { (obj.metadata.ownerReferences || [])
           .filter(ref => referenceForOwnerRef(ref) === referenceForModel(SubscriptionModel))
           .map(ref => <ul key={ref.uid} className="list-unstyled">
             <li><ResourceLink kind={referenceForModel(SubscriptionModel)} name={ref.name} namespace={obj.metadata.namespace} title={ref.uid} /></li>
           </ul>) || <span className="text-muted">None</span> }
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {phaseFor(_.get(obj.status, 'phase')) || 'Unknown'}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={Kebab.factory.common} kind={referenceForModel(InstallPlanModel)} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 InstallPlanTableRow.displayName = 'InstallPlanTableRow';
@@ -95,7 +95,7 @@ export type InstallPlanTableRowProps = {
 
 export const InstallPlansList = requireOperatorGroup((props: InstallPlansListProps) => {
   const EmptyMsg = () => <MsgBox title="No Install Plans Found" detail="Install Plans are created automatically by subscriptions or manually using the CLI." />;
-  return <Table {...props} aria-label="Install Plans" Header={InstallPlanTableHeader} Row={InstallPlanTableRow} EmptyMsg={EmptyMsg} />;
+  return <VirtualTable {...props} aria-label="Install Plans" Header={InstallPlanTableHeader} Row={InstallPlanTableRow} EmptyMsg={EmptyMsg} />;
 });
 
 export const InstallPlansPage: React.SFC<InstallPlansPageProps> = (props) => {

--- a/frontend/public/components/operator-lifecycle-manager/k8s-resource.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/k8s-resource.tsx
@@ -7,7 +7,7 @@ import { match } from 'react-router';
 import { CRDDescription, ClusterServiceVersionKind, referenceForProvidedAPI, providedAPIsFor } from './index';
 import { OperandLink } from './operand';
 import { ResourceLink, Timestamp, MsgBox, FirehoseResource } from '../utils';
-import { MultiListPage, Table, TableRow, TableData } from '../factory';
+import { MultiListPage, VirtualTable, VirtualTableRow, VirtualTableData } from '../factory';
 import { K8sResourceKind, GroupVersionKind, kindForReference } from '../../module/k8s';
 
 const tableColumnClasses = [
@@ -36,28 +36,27 @@ export const ResourceTableHeader = () => [
   },
 ];
 
-export const ResourceTableRow: React.FC<ResourceTableRowProps> = ({obj, index, key, style, linkFor}) => <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-  <TableData className={tableColumnClasses[0]}>
+export const ResourceTableRow: React.FC<ResourceTableRowProps> = ({obj, index, key, style, linkFor}) => <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+  <VirtualTableData className={tableColumnClasses[0]}>
     {linkFor(obj)}
-  </TableData>
-  <TableData className={tableColumnClasses[1]}>
+  </VirtualTableData>
+  <VirtualTableData className={tableColumnClasses[1]}>
     {obj.kind}
-  </TableData>
-  <TableData className={tableColumnClasses[2]}>
+  </VirtualTableData>
+  <VirtualTableData className={tableColumnClasses[2]}>
     {_.get(obj.status, 'phase', 'Created')}
-  </TableData>
-  <TableData className={tableColumnClasses[3]}>
+  </VirtualTableData>
+  <VirtualTableData className={tableColumnClasses[3]}>
     <Timestamp timestamp={obj.metadata.creationTimestamp} />
-  </TableData>
-</TableRow>;
+  </VirtualTableData>
+</VirtualTableRow>;
 
-export const ResourceTable: React.FC<ResourceTableProps> = (props) => <Table
+export const ResourceTable: React.FC<ResourceTableProps> = (props) => <VirtualTable
   {...props}
   aria-label="Operand Resources"
   Header={ResourceTableHeader}
   Row={rowProps => <ResourceTableRow {...rowProps} linkFor={props.linkFor} />}
-  EmptyMsg={() => <MsgBox title="No Resources Found" detail="There are no Kubernetes resources used by this operand." />}
-  virtualize />;
+  EmptyMsg={() => <MsgBox title="No Resources Found" detail="There are no Kubernetes resources used by this operand." />} />;
 
 export const Resources: React.FC<ResourcesProps> = (props) => {
   const providedAPI = providedAPIsFor(props.clusterServiceVersion).find(desc => referenceForProvidedAPI(desc) === props.match.params.plural);

--- a/frontend/public/components/operator-lifecycle-manager/operand.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/operand.tsx
@@ -13,7 +13,7 @@ import { SpecDescriptor } from './descriptors/spec';
 import { StatusCapability, Descriptor } from './descriptors/types';
 import { Resources } from './k8s-resource';
 import { ErrorPage404 } from '../error';
-import { MultiListPage, ListPage, DetailsPage, Table, TableRow, TableData } from '../factory';
+import { MultiListPage, ListPage, DetailsPage, VirtualTable, VirtualTableRow, VirtualTableData } from '../factory';
 import { ResourceSummary, StatusBox, navFactory, Timestamp, LabelList, ResourceIcon, MsgBox, ResourceKebab, Kebab, KebabAction, LoadingBox } from '../utils';
 import { connectToModel } from '../../kinds';
 import { apiVersionForReference, kindForReference, K8sResourceKind, OwnerReference, K8sKind, referenceFor, GroupVersionKind, referenceForModel } from '../../module/k8s';
@@ -101,32 +101,32 @@ export const OperandLink: React.SFC<OperandLinkProps> = (props) => {
 export const OperandTableRow: React.FC<OperandTableRowProps> = ({obj, index, key, style}) => {
   const status = _.get(obj.status, 'phase');
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <OperandLink obj={obj} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <LabelList kind={obj.kind} labels={obj.metadata.labels} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         {obj.kind}
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {_.isEmpty(status) ?
           <div className="text-muted">Unknown</div> :
           <>{status === 'Running' ? <SuccessStatus title={status} /> : <Status status={status} />}</>
         }
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {_.get(obj.spec, 'version') || <div className="text-muted">Unknown</div>}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
-      </TableData>
-      <TableData className={tableColumnClasses[6]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[6]}>
         <ResourceKebab actions={actions} kind={referenceFor(obj)} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 
@@ -144,13 +144,12 @@ export const OperandList: React.SFC<OperandListProps> = (props) => {
   });
   const EmptyMsg = () => <MsgBox title="No Operands Found" detail="Operands are declarative components used to define the behavior of the application." />;
 
-  return <Table {...props}
+  return <VirtualTable {...props}
     data={ensureKind(props.data)}
     EmptyMsg={EmptyMsg}
     aria-label="Operands"
     Header={OperandTableHeader}
-    Row={OperandTableRow}
-    virtualize />;
+    Row={OperandTableRow} />;
 };
 
 const inFlightStateToProps = ({k8s}: RootState) => ({inFlight: k8s.getIn(['RESOURCES', 'inFlight'])});

--- a/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/package-manifest.tsx
@@ -8,7 +8,7 @@ import { requireOperatorGroup, installedFor, supports } from './operator-group';
 import { PackageManifestKind, SubscriptionKind, ClusterServiceVersionLogo, visibilityLabel, OperatorGroupKind, installModesFor, defaultChannelFor } from './index';
 import { PackageManifestModel, SubscriptionModel, CatalogSourceModel, OperatorGroupModel } from '../../models';
 import { StatusBox, MsgBox } from '../utils';
-import { MultiListPage, Table, TableRow, TableData } from '../factory';
+import { MultiListPage, VirtualTable, VirtualTableRow, VirtualTableData } from '../factory';
 import { getActiveNamespace } from '../../actions/ui';
 import { ALL_NAMESPACES_KEY, OPERATOR_HUB_LABEL } from '../../const';
 
@@ -38,21 +38,21 @@ export const PackageManifestTableRow: React.SFC<PackageManifestTableRowProps> = 
 
   const createSubscriptionLink = () => `/k8s/ns/${ns === ALL_NAMESPACES_KEY ? defaultNS : ns}/${SubscriptionModel.plural}/~new?pkg=${obj.metadata.name}&catalog=${catalogSourceName}&catalogNamespace=${catalogSourceNamespace}`;
 
-  return <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-    <TableData className={tableColumnClasses[0]}>
+  return <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+    <VirtualTableData className={tableColumnClasses[0]}>
       <ClusterServiceVersionLogo displayName={displayName} icon={_.get(icon, '[0]')} provider={provider.name} />
-    </TableData>
-    <TableData className={tableColumnClasses[1]}>
+    </VirtualTableData>
+    <VirtualTableData className={tableColumnClasses[1]}>
       {version} ({channel.name})
-    </TableData>
-    <TableData className={tableColumnClasses[2]}>{ subscription
+    </VirtualTableData>
+    <VirtualTableData className={tableColumnClasses[2]}>{ subscription
       ? subscriptionLink()
       : <span className="text-muted">None</span> }
     { canSubscribe && <Link to={createSubscriptionLink()}>
       <button className="btn btn-primary">Create<span className="visible-lg-inline"> Subscription</span></button>
     </Link> }
-    </TableData>
-  </TableRow>;
+    </VirtualTableData>
+  </VirtualTableRow>;
 };
 
 export const PackageManifestList = requireOperatorGroup((props: PackageManifestListProps) => {
@@ -78,7 +78,7 @@ export const PackageManifestList = requireOperatorGroup((props: PackageManifestL
         </div>
         {props.showDetailsLink && <Link to={`/k8s/ns/${catalog.namespace}/${referenceForModel(CatalogSourceModel)}/${catalog.name}`}>View catalog details</Link>}
       </div>
-      <Table
+      <VirtualTable
         aria-label="Package Manifests"
         loaded={true}
         data={(props.data || []).filter(pkg => pkg.status.catalogSource === catalog.name)}
@@ -99,8 +99,7 @@ export const PackageManifestList = requireOperatorGroup((props: PackageManifestL
               .filter(og => _.isEmpty(props.namespace) || og.metadata.namespace === props.namespace)
               .some(og => supports(installModesFor(rowProps.obj)(defaultChannelFor(rowProps.obj)))(og))}
           defaultNS={_.get(props.operatorGroup, 'data[0].metadata.namespace')} />}
-        EmptyMsg={() => <MsgBox title="No PackageManifests Found" detail="The catalog author has not added any packages." />}
-        virtualize />
+        EmptyMsg={() => <MsgBox title="No PackageManifests Found" detail="The catalog author has not added any packages." />} />
     </div>) }
   </StatusBox>;
 });

--- a/frontend/public/components/operator-lifecycle-manager/subscription.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/subscription.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { match, Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
-import { DetailsPage, MultiListPage, Table, TableRow, TableData } from '../factory';
+import { DetailsPage, MultiListPage, VirtualTable, VirtualTableRow, VirtualTableData } from '../factory';
 import { requireOperatorGroup } from './operator-group';
 import { MsgBox, ResourceLink, ResourceKebab, navFactory, Kebab, ResourceSummary, LoadingInline, SectionHeading } from '../utils';
 import { removeQueryArgument } from '../utils/router';
@@ -83,26 +83,26 @@ const menuActions = [
 
 export const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={referenceForModel(SubscriptionModel)} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} displayName={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {subscriptionState(_.get(obj.status, 'state'))}
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[3], 'co-truncate', 'co-select-to-copy')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[3], 'co-truncate', 'co-select-to-copy')}>
         {obj.spec.channel || 'default'}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {obj.spec.installPlanApproval || 'Automatic'}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={referenceForModel(SubscriptionModel)} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 SubscriptionTableRow.displayName = 'SubscriptionTableRow';
@@ -114,12 +114,11 @@ export type SubscriptionTableRowProps = {
 };
 
 export const SubscriptionsList = requireOperatorGroup((props: SubscriptionsListProps) =>
-  <Table {...props}
+  <VirtualTable {...props}
     aria-label="Operator Subscriptions"
     Header={SubscriptionTableHeader}
     Row={SubscriptionTableRow}
-    EmptyMsg={() => <MsgBox title="No Subscriptions Found" detail="Each namespace can subscribe to a single channel of a package for automatic updates." />}
-    virtualize />
+    EmptyMsg={() => <MsgBox title="No Subscriptions Found" detail="Each namespace can subscribe to a single channel of a package for automatic updates." />} />
 );
 
 export const SubscriptionsPage: React.SFC<SubscriptionsPageProps> = (props) => {

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -7,7 +7,7 @@ import { Status } from '@console/shared';
 import { connectToFlags } from '../reducers/features';
 import { Conditions } from './conditions';
 import { FLAGS } from '../const';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary, Selector } from './utils';
 import { ResourceEventStream } from './events';
 
@@ -63,29 +63,29 @@ const kind = 'PersistentVolumeClaim';
 
 const PVCTableRow = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <PVCStatus pvc={obj} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         { _.get(obj, 'spec.volumeName') ?
           <ResourceLink kind="PersistentVolume" name={obj.spec.volumeName} title={obj.spec.volumeName} />:
           <div className="text-muted">No Persistent Volume</div>
         }
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {_.get(obj, 'spec.resources.requests.storage', '-')}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 PVCTableRow.displayName = 'PVCTableRow';
@@ -153,7 +153,7 @@ const filters = [{
 }];
 
 
-export const PersistentVolumeClaimsList = props => <Table {...props} aria-label="Persistent Volume Claims" Header={PVCTableHeader} Row={PVCTableRow} virtualize />;
+export const PersistentVolumeClaimsList = props => <VirtualTable {...props} aria-label="Persistent Volume Claims" Header={PVCTableHeader} Row={PVCTableRow} />;
 export const PersistentVolumeClaimsPage = props => {
   const createProps = {
     to: `/k8s/ns/${props.namespace || 'default'}/persistentvolumeclaims/~new/form`,

--- a/frontend/public/components/persistent-volume.jsx
+++ b/frontend/public/components/persistent-volume.jsx
@@ -4,7 +4,7 @@ import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
 
 import { Status } from '@console/shared';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, LabelList, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary, Timestamp } from './utils';
 
 const { common } = Kebab.factory;
@@ -59,33 +59,33 @@ const kind = 'PersistentVolume';
 
 const PVTableRow = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <PVStatus pv={obj} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {_.get(obj,'spec.claimRef.name') ?
           <ResourceLink kind="PersistentVolumeClaim" name={obj.spec.claimRef.name} namespace={obj.spec.claimRef.namespace} title={obj.spec.claimRef.name} />
           :
           <div className="text-muted">No Claim</div>
         }
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {_.get(obj, 'spec.capacity.storage', '-')}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <LabelList kind={kind} labels={obj.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
-      </TableData>
-      <TableData className={tableColumnClasses[6]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[6]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 PVTableRow.displayName = 'PVTableRow';
@@ -97,7 +97,7 @@ const Details = ({obj}) => <React.Fragment>
   </div>
 </React.Fragment>;
 
-export const PersistentVolumesList = props => <Table {...props} aria-label="Persistent Volumes" Header={PVTableHeader} Row={PVTableRow} virtualize />;
+export const PersistentVolumesList = props => <VirtualTable {...props} aria-label="Persistent Volumes" Header={PVTableHeader} Row={PVTableRow} />;
 export const PersistentVolumesPage = props => <ListPage {...props} ListComponent={PersistentVolumesList} kind={kind} canCreate={true} />;
 export const PersistentVolumesDetailsPage = props => <DetailsPage
   {...props}

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -9,7 +9,7 @@ import { ContainerSpec, K8sResourceKindReference, PodKind } from '../module/k8s'
 import { getRestartPolicyLabel, podPhase, podPhaseFilterReducer, podReadiness } from '../module/k8s/pods';
 import { getContainerState, getContainerStatus } from '../module/k8s/container';
 import { ResourceEventStream } from './events';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import {
   AsyncComponent,
   Kebab,
@@ -66,29 +66,29 @@ const kind = 'Pod';
 const PodTableRow: React.FC<PodTableRowProps> = ({obj: pod, index, key, style}) => {
   const phase = podPhase(pod);
   return (
-    <TableRow id={pod.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={pod.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={pod.metadata.name} namespace={pod.metadata.namespace} title={pod.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={pod.metadata.namespace} title={pod.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={pod.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <NodeLink name={pod.spec.nodeName} />
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <Status status={phase} />
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <Readiness pod={pod} />
-      </TableData>
-      <TableData className={tableColumnClasses[6]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[6]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={pod} isDisabled={phase === 'Terminating'} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 PodTableRow.displayName = 'PodTableRow';
@@ -317,7 +317,7 @@ export const PodsDetailsPage: React.FC<PodDetailsPageProps> = props => <DetailsP
 />;
 PodsDetailsPage.displayName = 'PodsDetailsPage';
 
-export const PodList: React.FC = props => <Table {...props} aria-label="Pods" Header={PodTableHeader} Row={PodTableRow} virtualize />;
+export const PodList: React.FC = props => <VirtualTable {...props} aria-label="Pods" Header={PodTableHeader} Row={PodTableRow} />;
 PodList.displayName = 'PodList';
 
 const filters = [{

--- a/frontend/public/components/prometheus.jsx
+++ b/frontend/public/components/prometheus.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { ListPage, Table, TableRow, TableData } from './factory';
+import { ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, LabelList, ResourceKebab, ResourceLink, Selector } from './utils';
 import { PrometheusModel } from '../models';
 import { referenceForModel } from '../module/k8s';
@@ -21,26 +21,26 @@ const tableColumnClasses = [
 const PrometheusTableRow = ({obj: instance, index, key, style}) => {
   const {metadata, spec} = instance;
   return (
-    <TableRow id={instance.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={instance.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={referenceForModel(PrometheusModel)} name={metadata.name} namespace={metadata.namespace} title={metadata.uid} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <ResourceLink kind="Namespace" name={metadata.namespace} title={metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={PrometheusModel.kind} labels={metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {spec.version}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <Selector selector={spec.serviceMonitorSelector} kind="ServiceMonitor" namespace={metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={referenceForModel(PrometheusModel)} resource={instance} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 PrometheusTableRow.displayName = 'PrometheusTableRow';
@@ -74,6 +74,6 @@ const PrometheusTableHeader = () => {
 };
 PrometheusTableHeader.displayName = 'PrometheusTableHeader';
 
-export const PrometheusInstancesList = props => <Table {...props} aria-label="Promethesuses" Header={PrometheusTableHeader} Row={PrometheusTableRow} virtualize />;
+export const PrometheusInstancesList = props => <VirtualTable {...props} aria-label="Promethesuses" Header={PrometheusTableHeader} Row={PrometheusTableRow} />;
 
 export const PrometheusInstancesPage = props => <ListPage {...props} ListComponent={PrometheusInstancesList} canCreate={true} kind={referenceForModel(PrometheusModel)} />;

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 
-import { DetailsPage, ListPage, Table } from './factory';
+import { DetailsPage, ListPage, VirtualTable } from './factory';
 import {
   Kebab,
   ContainerTable,
@@ -87,7 +87,7 @@ const ReplicaSetTableHeader = () => {
 };
 ReplicaSetTableHeader.displayName = 'ReplicaSetTableHeader';
 
-const ReplicaSetsList = props => <Table {...props} aria-label="Replicate Sets" Header={ReplicaSetTableHeader} Row={ReplicaSetTableRow} virtualize />;
+const ReplicaSetsList = props => <VirtualTable {...props} aria-label="Replicate Sets" Header={ReplicaSetTableHeader} Row={ReplicaSetTableRow} />;
 const ReplicaSetsPage = props => <ListPage canCreate={true} ListComponent={ReplicaSetsList} {...props} />;
 
 export {ReplicaSetsList, ReplicaSetsPage, ReplicaSetsDetailsPage};

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -5,7 +5,7 @@ import * as classNames from 'classnames';
 import { Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import { ResourceEventStream } from './events';
-import { DetailsPage, ListPage, Table, TableData, TableRow } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableData, VirtualTableRow } from './factory';
 import { replicaSetMenuActions } from './replicaset';
 import {
   ContainerTable,
@@ -120,31 +120,31 @@ const ReplicationControllerTableRow = ({obj, index, key, style}) => {
   const phase = _.get(obj, ['metadata', 'annotations', 'openshift.io/deployment.phase']);
 
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={obj.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <Link to={`${resourcePath(kind, obj.metadata.name, obj.metadata.namespace)}/pods`} title="pods">
           {obj.status.replicas || 0} of {obj.spec.replicas} pods
         </Link>
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         {phase}
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <Selector selector={obj.spec.selector} namespace={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[6]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[6]}>
         <ResourceKebab actions={replicaSetMenuActions} kind={kind} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ReplicationControllerTableRow.displayName = 'ReplicationControllerTableRow';
@@ -183,6 +183,6 @@ const ReplicationControllerTableHeader = () => {
 };
 ReplicationControllerTableHeader.displayName = 'ReplicationControllerTableHeader';
 
-export const ReplicationControllersList = props => <Table {...props} aria-label="Replication Controllers" Header={ReplicationControllerTableHeader} Row={ReplicationControllerTableRow} virtualize />;
+export const ReplicationControllersList = props => <VirtualTable {...props} aria-label="Replication Controllers" Header={ReplicationControllerTableHeader} Row={ReplicationControllerTableRow} />;
 
 export const ReplicationControllersPage = props => <ListPage canCreate={true} ListComponent={ReplicationControllersList} {...props} />;

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { FieldLevelHelp } from 'patternfly-react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, MultiListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, MultiListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, SectionHeading, navFactory, ResourceKebab, ResourceLink, ResourceSummary, convertToBaseValue } from './utils';
 import { connectToFlags, flagPending } from '../reducers/features';
 import { FLAGS } from '../const';
@@ -66,17 +66,17 @@ ResourceQuotaTableHeader.displayName = 'ResourceQuotaTableHeader';
 
 export const ResourceQuotaTableRow = ({obj: rq, index, key, style}) => {
   return (
-    <TableRow id={rq.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={rq.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={quotaKind(rq)} name={rq.metadata.name} namespace={rq.metadata.namespace} className="co-resource-item__resource-name" />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         {rq.metadata.namespace ? <ResourceLink kind="Namespace" name={rq.metadata.namespace} title={rq.metadata.namespace} /> : 'None'}
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <ResourceKebab actions={menuActions} kind={quotaKind(rq)} resource={rq} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ResourceQuotaTableRow.displayName = 'ResourceQuotaTableRow';
@@ -243,7 +243,7 @@ const Details = ({obj: rq}) => {
   </React.Fragment>;
 };
 
-export const ResourceQuotasList = props => <Table {...props} aria-label="Resource Quoates" Header={ResourceQuotaTableHeader} Row={ResourceQuotaTableRow} virtualize />;
+export const ResourceQuotasList = props => <VirtualTable {...props} aria-label="Resource Quoates" Header={ResourceQuotaTableHeader} Row={ResourceQuotaTableRow} />;
 
 export const quotaType = quota => {
   if (!quota) {

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -6,7 +6,7 @@ import { sortable } from '@patternfly/react-table';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 
 import { Status } from '@console/shared';
-import { DetailsPage,ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage,ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, CopyToClipboard, SectionHeading, ResourceKebab, detailsPage, navFactory, ResourceLink, ResourceSummary, ExternalLink } from './utils';
 import { MaskedData } from './configmap-and-secret-data';
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
@@ -152,27 +152,27 @@ RouteTableHeader.displayName = 'RouteTableHeader';
 
 const RouteTableRow: React.FC<RouteTableRowProps> = ({obj: route, index, key, style}) => {
   return (
-    <TableRow id={route.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={route.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={route.metadata.name}
           namespace={route.metadata.namespace} title={route.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={route.metadata.namespace} title={route.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         <RouteLocation obj={route} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <ResourceLink kind="Service" name={route.spec.to.name} namespace={route.metadata.namespace} title={route.spec.to.name} />
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <RouteStatus obj={route} />
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={route} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 RouteTableRow.displayName = 'RouteTableRow';
@@ -386,7 +386,7 @@ export const RoutesDetailsPage: React.SFC<RoutesDetailsPageProps> = props => <De
   menuActions={menuActions}
   pages={[navFactory.details(detailsPage(RouteDetails)), navFactory.editYaml()]}
 />;
-export const RoutesList: React.SFC = props => <Table {...props} aria-label="Routes" Header={RouteTableHeader} Row={RouteTableRow} virtualize />;
+export const RoutesList: React.SFC = props => <VirtualTable {...props} aria-label="Routes" Header={RouteTableHeader} Row={RouteTableRow} />;
 
 const filters = [{
   type: 'route-status',

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { SecretData } from './configmap-and-secret-data';
 import { Kebab, SectionHeading, ResourceKebab, ResourceLink, ResourceSummary, detailsPage, navFactory, resourceObjPath } from './utils';
 import { fromNow } from './utils/datetime';
@@ -86,20 +86,20 @@ const SecretTableRow = ({obj: secret, index, key, style}) => {
   const data = _.size(secret.data);
   const age = fromNow(secret.metadata.creationTimestamp);
   return (
-    <TableRow id={secret.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={secret.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind="Secret" name={secret.metadata.name} namespace={secret.metadata.namespace} title={secret.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={secret.metadata.namespace} title={secret.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>{secret.type}</TableData>
-      <TableData className={tableColumnClasses[3]}>{data}</TableData>
-      <TableData className={tableColumnClasses[4]}>{age}</TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[2], 'co-break-word')}>{secret.type}</VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>{data}</VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>{age}</VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={secret} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 SecretTableRow.displayName = 'SecretTableRow';
@@ -116,7 +116,7 @@ const SecretDetails = ({obj: secret}) => {
   </React.Fragment>;
 };
 
-const SecretsList = props => <Table {...props} aria-label="Secrets" Header={SecretTableHeader} Row={SecretTableRow} virtualize />;
+const SecretsList = props => <VirtualTable {...props} aria-label="Secrets" Header={SecretTableHeader} Row={SecretTableRow} />;
 SecretsList.displayName = 'SecretsList';
 
 const IMAGE_FILTER_VALUE = 'Image';

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -4,7 +4,7 @@ import { safeDump } from 'js-yaml';
 import { Base64 } from 'js-base64';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, SectionHeading, navFactory, ResourceKebab, ResourceLink, ResourceSummary } from './utils';
 import { fromNow } from './utils/datetime';
 import { k8sList } from '../module/k8s';
@@ -117,23 +117,23 @@ ServiceAccountTableHeader.displayName = 'ServiceAccountTableHeader';
 const ServiceAccountTableRow = ({obj: serviceaccount, index, key, style}) => {
   const {metadata: {name, namespace, uid, creationTimestamp}, secrets} = serviceaccount;
   return (
-    <TableRow id={serviceaccount.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={serviceaccount.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={name} namespace={namespace} title={uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={namespace} title={namespace} /> {}
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {secrets ? secrets.length : 0}
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         {fromNow(creationTimestamp)}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={serviceaccount} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ServiceAccountTableRow.displayName = 'ServiceAccountTableRow';
@@ -161,6 +161,6 @@ const ServiceAccountsDetailsPage = props => <DetailsPage
   menuActions={menuActions}
   pages={[navFactory.details(Details), navFactory.editYaml()]}
 />;
-const ServiceAccountsList = props => <Table {...props} aria-label="Service Accounts" Header={ServiceAccountTableHeader} Row={ServiceAccountTableRow} virtualize />;
+const ServiceAccountsList = props => <VirtualTable {...props} aria-label="Service Accounts" Header={ServiceAccountTableHeader} Row={ServiceAccountTableRow} />;
 const ServiceAccountsPage = props => <ListPage ListComponent={ServiceAccountsList} {...props} canCreate={true} />;
 export {ServiceAccountsList, ServiceAccountsPage, ServiceAccountsDetailsPage};

--- a/frontend/public/components/service-binding.tsx
+++ b/frontend/public/components/service-binding.tsx
@@ -6,7 +6,7 @@ import * as classNames from 'classnames';
 import { Alert } from '@patternfly/react-core';
 
 import { serviceCatalogStatus, referenceForModel, K8sResourceKind } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, SectionHeading, navFactory, ResourceKebab, ResourceLink, ResourceSummary, StatusWithIcon } from './utils';
 import { ResourceEventStream } from './events';
 import { Conditions } from './conditions';
@@ -110,26 +110,26 @@ ServiceBindingsTableHeader.displayName = 'ServiceBindingsTableHeader';
 
 const ServiceBindingsTableRow: React.FC<ServiceBindingsTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={referenceForModel(ServiceBindingModel)} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         <ResourceLink kind={referenceForModel(ServiceInstanceModel)} name={obj.spec.instanceRef.name} title={obj.spec.instanceRef.name} namespace={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[3], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[3], 'co-break-word')}>
         { secretLink(obj) }
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[4], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[4], 'co-break-word')}>
         <StatusWithIcon obj={obj} />
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={referenceForModel(ServiceBindingModel)} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ServiceBindingsTableRow.displayName = 'ServiceBindingsTableRow';
@@ -141,7 +141,7 @@ type ServiceBindingsTableRowProps = {
 };
 
 
-const ServiceBindingsList: React.SFC = props => <Table {...props} aria-label="Service Bindings" Header={ServiceBindingsTableHeader} Row={ServiceBindingsTableRow} virtualize />;
+const ServiceBindingsList: React.SFC = props => <VirtualTable {...props} aria-label="Service Bindings" Header={ServiceBindingsTableHeader} Row={ServiceBindingsTableRow} />;
 ServiceBindingsList.displayName = 'ServiceBindingsList';
 
 export const ServiceBindingsPage: React.SFC<ServiceBindingsPageProps> = props =>

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -6,7 +6,7 @@ import * as classNames from 'classnames';
 import { Alert } from '@patternfly/react-core';
 
 import { k8sList, K8sResourceKind, planExternalName, serviceCatalogStatus, referenceForModel } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import {
   ExternalLink,
   Kebab,
@@ -224,31 +224,31 @@ ServiceInstancesTableHeader.displayName = 'ServiceInstancesTableHeader';
 const ServiceInstancesTableRow: React.FC<ServiceInstancesTableRowProps> = ({obj, index, key, style}) => {
   const clusterServiceClassRefName = _.get(obj, 'spec.clusterServiceClassRef.name');
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={referenceForModel(ServiceInstanceModel)} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.name} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[2], 'co-break-word')}>
         {clusterServiceClassRefName
           ? <ResourceLink kind={referenceForModel(ClusterServiceClassModel)} displayName={obj.spec.clusterServiceClassExternalName} title={obj.spec.clusterServiceClassExternalName} name={obj.spec.clusterServiceClassRef.name} />
           : obj.spec.clusterServiceClassExternalName }
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <StatusWithIcon obj={obj} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[4], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[4], 'co-break-word')}>
         {planExternalName(obj) || '-'}
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[5], 'co-truncate')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[5], 'co-truncate')}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
-      </TableData>
-      <TableData className={tableColumnClasses[6]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[6]}>
         <ResourceKebab actions={menuActions} kind={referenceForModel(ServiceInstanceModel)} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ServiceInstancesTableRow.displayName = 'ServiceInstancesTableRow';
@@ -259,7 +259,7 @@ type ServiceInstancesTableRowProps = {
   style: object;
 };
 
-const ServiceInstancesList: React.SFC = props => <Table {...props} aria-label="Service Instances" Header={ServiceInstancesTableHeader} Row={ServiceInstancesTableRow} virtualize />;
+const ServiceInstancesList: React.SFC = props => <VirtualTable {...props} aria-label="Service Instances" Header={ServiceInstancesTableHeader} Row={ServiceInstancesTableRow} />;
 ServiceInstancesList.displayName = 'ServiceInstancesList';
 
 const filters = [{

--- a/frontend/public/components/service-monitor.jsx
+++ b/frontend/public/components/service-monitor.jsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
-import { ListPage, Table, TableRow, TableData } from './factory';
+import { ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, ResourceKebab, ResourceLink, Selector } from './utils';
 import { ServiceMonitorModel } from '../models';
 import { referenceForModel } from '../module/k8s';
@@ -37,25 +37,25 @@ const tableColumnClasses = [
 const ServiceMonitorTableRow = ({obj: sm, index, key, style}) => {
   const {metadata} = sm;
   return (
-    <TableRow id={sm.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={sm.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={referenceForModel(ServiceMonitorModel)} name={metadata.name} namespace={metadata.namespace} title={metadata.uid} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[1]}>
         <ResourceLink kind="Namespace" name={metadata.namespace} title={metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         { serviceSelectorLinks(sm) }
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <p>
           { namespaceSelectorLinks(sm) }
         </p>
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <ResourceKebab actions={menuActions} kind={referenceForModel(ServiceMonitorModel)} resource={sm} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ServiceMonitorTableRow.displayName = 'ServiceMonitorTableRow';
@@ -85,7 +85,7 @@ const ServiceMonitorTableHeader = () => {
 };
 ServiceMonitorTableHeader.displayName = 'ServiceMonitorTableHeader';
 
-export const ServiceMonitorsList = props => <Table {...props} aria-label="Service Monitors" Header={ServiceMonitorTableHeader} Row={ServiceMonitorTableRow} virtualize />;
+export const ServiceMonitorsList = props => <VirtualTable {...props} aria-label="Service Monitors" Header={ServiceMonitorTableHeader} Row={ServiceMonitorTableRow} />;
 
 export const ServiceMonitorsPage = props => <ListPage
   {...props}

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, navFactory, LabelList, ResourceKebab, SectionHeading, ResourceIcon, ResourceLink, ResourceSummary, Selector } from './utils';
 
 const menuActions = [Kebab.factory.ModifyPodSelector, ...Kebab.factory.common];
@@ -57,26 +57,26 @@ ServiceTableHeader.displayName = 'ServiceTableHeader';
 
 const ServiceTableRow = ({obj: s, index, key, style}) => {
   return (
-    <TableRow id={s.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={s.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={s.metadata.name} namespace={s.metadata.namespace} title={s.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={s.metadata.namespace} title={s.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={s.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <Selector selector={s.spec.selector} namespace={s.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <ServiceIP s={s} />
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={s} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 ServiceTableRow.displayName = 'ServiceTableRow';
@@ -180,7 +180,7 @@ const ServicesDetailsPage = props => <DetailsPage
   pages={[details(Details), editYaml(), pods()]}
 />;
 
-const ServicesList = props => <Table {...props} aria-label="Services" Header={ServiceTableHeader} Row={ServiceTableRow} virtualize />;
+const ServicesList = props => <VirtualTable {...props} aria-label="Services" Header={ServiceTableHeader} Row={ServiceTableRow} />;
 const ServicesPage = props => <ListPage canCreate={true} ListComponent={ServicesList} {...props} />;
 
 export {ServicesList, ServicesPage, ServicesDetailsPage};

--- a/frontend/public/components/stateful-set.jsx
+++ b/frontend/public/components/stateful-set.jsx
@@ -4,7 +4,7 @@ import { ResourceEventStream } from './events';
 import {
   DetailsPage,
   ListPage,
-  Table,
+  VirtualTable,
 } from './factory';
 
 import {
@@ -64,7 +64,7 @@ const environmentComponent = (props) => <EnvironmentPage
   readOnly={false}
 />;
 
-export const StatefulSetsList = props => <Table {...props} aria-label="Stateful Sets" Header={StatefulSetTableHeader} Row={StatefulSetTableRow} virtualize />;
+export const StatefulSetsList = props => <VirtualTable {...props} aria-label="Stateful Sets" Header={StatefulSetTableHeader} Row={StatefulSetTableRow} />;
 export const StatefulSetsPage = props => <ListPage {...props} ListComponent={StatefulSetsList} kind={kind} canCreate={true} />;
 
 const pages = [

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, VirtualTable, VirtualTableRow, VirtualTableData } from './factory';
 import { Kebab, detailsPage, navFactory, ResourceKebab, SectionHeading, ResourceLink, ResourceSummary } from './utils';
 import { StorageClassResourceKind, K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 
@@ -49,22 +49,22 @@ StorageClassTableHeader.displayName = 'StorageClassTableHeader';
 
 const StorageClassTableRow: React.SFC<StorageClassTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={classNames(tableColumnClasses[0], 'co-break-word')}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={classNames(tableColumnClasses[0], 'co-break-word')}>
         <ResourceLink kind={StorageClassReference} name={obj.metadata.name}>
           { isDefaultClass(obj) && <span className="small text-muted co-resource-item__help-text">&ndash; Default</span> }
         </ResourceLink>
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         {obj.provisioner}
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         {obj.reclaimPolicy || '-'}
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <ResourceKebab actions={menuActions} kind={StorageClassReference} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 StorageClassTableRow.displayName = 'StorageClassTableRow';
@@ -95,7 +95,7 @@ const StorageClassDetails: React.SFC<StorageClassDetailsProps> = ({obj}) => <Rea
   </div>
 </React.Fragment>;
 
-export const StorageClassList: React.SFC = props => <Table {...props} aria-label="Storage Classes" Header={StorageClassTableHeader} Row={StorageClassTableRow} virtualize />;
+export const StorageClassList: React.SFC = props => <VirtualTable {...props} aria-label="Storage Classes" Header={StorageClassTableHeader} Row={StorageClassTableRow} />;
 StorageClassList.displayName = 'StorageClassList';
 
 export const StorageClassPage: React.SFC<StorageClassPageProps> = props => {

--- a/frontend/public/components/template-instance.tsx
+++ b/frontend/public/components/template-instance.tsx
@@ -7,9 +7,9 @@ import { Status } from '@console/shared';
 import {
   DetailsPage,
   ListPage,
-  Table,
-  TableRow,
-  TableData,
+  VirtualTable,
+  VirtualTableRow,
+  VirtualTableData,
 } from './factory';
 import { Conditions } from './conditions';
 import { getTemplateInstanceStatus, referenceFor, TemplateInstanceKind } from '../module/k8s';
@@ -55,20 +55,20 @@ TemplateInstanceTableHeader.displayName = 'TemplateInstanceTableHeader';
 
 const TemplateInstanceTableRow: React.FC<TemplateInstanceTableRowProps> = ({obj, index, key, style}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={classNames(tableColumnClasses[0], 'co-break-word')}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={classNames(tableColumnClasses[0], 'co-break-word')}>
         <ResourceLink kind="TemplateInstance" name={obj.metadata.name} namespace={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <Status status={getTemplateInstanceStatus(obj)} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <ResourceKebab actions={menuActions} kind="TemplateInstance" resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 TemplateInstanceTableRow.displayName = 'TemplateInstanceTableRow';
@@ -79,7 +79,7 @@ type TemplateInstanceTableRowProps = {
   style: object;
 };
 
-export const TemplateInstanceList: React.SFC = props => <Table {...props} aria-label="Template Instances" Header={TemplateInstanceTableHeader} Row={TemplateInstanceTableRow} virtualize />;
+export const TemplateInstanceList: React.SFC = props => <VirtualTable {...props} aria-label="Template Instances" Header={TemplateInstanceTableHeader} Row={TemplateInstanceTableRow} />;
 
 const allStatuses = ['Ready', 'Not Ready', 'Failed'];
 

--- a/frontend/public/components/workload-table.tsx
+++ b/frontend/public/components/workload-table.tsx
@@ -4,8 +4,8 @@ import { sortable } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 import { K8sResourceKind } from '../module/k8s';
 import {
-  TableRow,
-  TableData,
+  VirtualTableRow,
+  VirtualTableData,
 } from './factory';
 
 import {
@@ -29,28 +29,28 @@ const tableColumnClasses = [
 
 export const WorkloadTableRow: React.FC<WorkloadTableRowProps> = ({obj, index, key, style, kind, menuActions}) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+    <VirtualTableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <VirtualTableData className={tableColumnClasses[0]}>
         <ResourceLink kind={kind} name={obj.metadata.name} namespace={obj.metadata.namespace} title={obj.metadata.uid} />
-      </TableData>
-      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+      </VirtualTableData>
+      <VirtualTableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} title={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[2]}>
         <LabelList kind={kind} labels={obj.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[3]}>
         <Link to={`${resourcePath(kind, obj.metadata.name, obj.metadata.namespace)}/pods`} title="pods">
           {obj.status.replicas || 0} of {obj.spec.replicas} pods
         </Link>
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[4]}>
         <Selector selector={obj.spec.selector} namespace={obj.metadata.namespace} />
-      </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      </VirtualTableData>
+      <VirtualTableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={menuActions} kind={kind} resource={obj} />
-      </TableData>
-    </TableRow>
+      </VirtualTableData>
+    </VirtualTableRow>
   );
 };
 WorkloadTableRow.displayName = 'WorkloadTableRow';

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -374,7 +374,7 @@ kbd {
   }
 }
 
-.pf-c-table tbody > tr > :first-child::before {
+.pf-c-table.pf-c-virtualized tbody > tr > :first-child::before {
   content: none;
   width: 0 !important;
 }
@@ -434,6 +434,7 @@ kbd {
     border-bottom: 1px solid $table-border-color;
   }
 }
+
 
 .text-secondary {
   color: $color-text-secondary;


### PR DESCRIPTION
start detail table conversion in #1986 for all detail tables in Cluster Settings.

* split out detail table into a new component. Virtualized table "@patternfly/react-virtualized-extension" and "@patternfly/react-table" have different APIs due to the nature of virtualized table body. Their row definitions are different, as well as the expected markup/jsx. Also, checking `virtualized` everywhere in the current `Table` abstraction just seems wrong. This was never my original intent... had previously called the rows `Vr` and `Vd` (virtual row), but I still think this component should be split out into two components.

Table:
https://patternfly-react.surge.sh/patternfly-4/components/table/
Virtual Table:
https://patternfly-react.surge.sh/patternfly-4/virtual%20scroll/virtualized/

cc: @TheRealJon @jcaianirh @spadgett 

~also, filed [2045](https://github.com/patternfly/patternfly-next/issues/2045) upstream in pf-next today. Currently, the CSS is here in overrides for this.~ Fixed by rescoping the following styles to `virtualized` tables only:
```
.pf-c-table.pf-c-virtualized tbody > tr > :first-child::before {
  content: none;
  width: 0 !important;
}
```
Codepen: https://codepen.io/priley86-the-sans/pen/JQgNrW