### PR TITLE
Bug 1693180 - MachineSet and Machine pages need Event page for resources page consistency

### DIFF
--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -33,6 +33,7 @@ import {
   togglePaused,
   WorkloadPausedAlert,
 } from './utils';
+import { ResourceEventStream } from './events';
 
 const pauseAction: KebabAction = (kind, obj) => ({
   label: obj.spec.paused ? 'Resume Updates' : 'Pause Updates',
@@ -187,6 +188,7 @@ const pages = [
   navFactory.details(MachineConfigPoolDetails),
   navFactory.editYaml(),
   navFactory.machineConfigs(MachineConfigList),
+  navFactory.events(ResourceEventStream),
 ];
 
 export const MachineConfigPoolDetailsPage: React.SFC<any> = props => (

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -20,6 +20,7 @@ import {
   ResourceSummary,
   SectionHeading,
 } from './utils';
+import { ResourceEventStream } from './events';
 
 
 export const machineConfigReference = referenceForModel(MachineConfigModel);
@@ -46,6 +47,7 @@ const MachineConfigDetails: React.SFC<MachineConfigDetailsProps> = ({obj}) => (
 const pages = [
   navFactory.details(MachineConfigDetails),
   navFactory.editYaml(),
+  navFactory.events(ResourceEventStream),
 ];
 
 export const MachineConfigDetailsPage: React.SFC<any> = props => {

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -23,6 +23,7 @@ import {
   useAccessReview,
 } from './utils';
 import { Tooltip } from './utils/tooltip';
+import { ResourceEventStream } from './events';
 
 const machineReplicasModal = (resourceKind: K8sKind, resource: MachineSetKind | MachineDeploymentKind) => configureReplicaCountModal({
   resourceKind,
@@ -247,6 +248,7 @@ export const MachineSetDetailsPage: React.SFC<MachineSetDetailsPageProps> = prop
     navFactory.details(MachineSetDetails),
     navFactory.editYaml(),
     navFactory.machines(MachineTabPage),
+    navFactory.events(ResourceEventStream),
   ]}
 />;
 

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -17,6 +17,7 @@ import {
   SectionHeading,
   navFactory,
 } from './utils';
+import { ResourceEventStream } from './events';
 
 const { common } = Kebab.factory;
 const menuActions = [...common];
@@ -144,7 +145,11 @@ export const MachineDetailsPage: React.SFC<MachineDetailsPageProps> = props =>
     {...props}
     kind={machineReference}
     menuActions={menuActions}
-    pages={[navFactory.details(MachineDetails), navFactory.editYaml()]}
+    pages={[
+      navFactory.details(MachineDetails),
+      navFactory.editYaml(),
+      navFactory.events(ResourceEventStream),
+    ]}
   />;
 
 export type MachineDetailsProps = {


### PR DESCRIPTION
/assign @spadgett 

The bug is referring only to `Machine` and `MachineSet` resources but other `Compute` resource have been missing the `Events` tab so adding as well.
I know this is 4.1 bug but lets add it here to the master as well and cherrypick to 4.1 branch.

PTAL