### PR TITLE
Bug 1729876: Make the domain field required

### DIFF
--- a/frontend/public/components/cluster-settings/google-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/google-idp-form.tsx
@@ -117,15 +117,16 @@ export class AddGooglePage extends PromiseComponent<{}, AddGooglePageState> {
             required />
         </div>
         <div className="form-group">
-          <label className="control-label" htmlFor="hosted-domain">Hosted Domain</label>
+          <label className="control-label co-required" htmlFor="hosted-domain">Hosted Domain</label>
           <input className="pf-c-form-control"
             type="text"
             onChange={this.hostedDomainChanged}
             value={hostedDomain}
             id="hosted-domain"
-            aria-describedby="idp-hosted-domain-help" />
+            aria-describedby="idp-hosted-domain-help"
+            required />
           <p className="help-block" id="idp-hosted-domain-help">
-            Optionally restrict users to a Google App domain.
+            Restrict users to a Google App domain.
           </p>
         </div>
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>

--- a/frontend/public/components/cluster-settings/oauth.tsx
+++ b/frontend/public/components/cluster-settings/oauth.tsx
@@ -74,7 +74,7 @@ const OAuthDetails: React.SFC<OAuthDetailsProps> = ({obj}: {obj: OAuthKind}) => 
     <div className="co-m-pane__body">
       <SectionHeading text="Identity Providers" />
       <p className="co-m-pane__explanation co-m-pane__explanation--alt">
-        Identity providers determine how users log into the cluster. To specify how new identities are mapped to logged in users the mapping method is always set to the value: claim.
+        Identity providers determine how users log into the cluster.
       </p>
       <Dropdown
         className="co-m-pane__dropdown"

--- a/frontend/public/components/cluster-settings/oauth.tsx
+++ b/frontend/public/components/cluster-settings/oauth.tsx
@@ -74,7 +74,7 @@ const OAuthDetails: React.SFC<OAuthDetailsProps> = ({obj}: {obj: OAuthKind}) => 
     <div className="co-m-pane__body">
       <SectionHeading text="Identity Providers" />
       <p className="co-m-pane__explanation co-m-pane__explanation--alt">
-        Identity providers determine how users log into the cluster.
+        Identity providers determine how users log into the cluster. To specify how new identities are mapped to logged in users the mapping method is always set to the value: claim.
       </p>
       <Dropdown
         className="co-m-pane__dropdown"


### PR DESCRIPTION
Since we only support claim mapping method we need to make the Hosted Domain field required. The bug also notes that we should share with the user we are only supporting claim for mapping method so I introduced some text on the oath page.