### PR TITLE
customize resource tables for knative Services, Routes, and Revisions

### DIFF
--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionHeader.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionHeader.tsx
@@ -1,0 +1,49 @@
+import { sortable } from '@patternfly/react-table';
+import { tableColumnClasses } from './revision-table';
+
+const RevisionHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortField: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Service',
+      sortField: 'obj.metadata.labels["serving.knative.dev/service"]',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: 'Age',
+      sortField: 'obj.metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[3] },
+    },
+    {
+      title: 'Conditions',
+      props: { className: tableColumnClasses[4] },
+    },
+    {
+      title: 'Ready',
+      props: { className: tableColumnClasses[5] },
+    },
+    {
+      title: 'Reason',
+      props: { className: tableColumnClasses[6] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[7] },
+    },
+  ];
+};
+
+export default RevisionHeader;

--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionList.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionList.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Table, TableProps } from '@console/internal/components/factory';
+import { RevisionModel } from '../../models';
+import RevisionHeader from './RevisionHeader';
+import RevisionRow from './RevisionRow';
+
+const RevisionList: React.FC<TableProps> = (props) => (
+  <Table
+    {...props}
+    aria-label={RevisionModel.labelPlural}
+    Header={RevisionHeader}
+    Row={RevisionRow}
+    virtualize
+  />
+);
+
+export default RevisionList;

--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionRow.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import * as cx from 'classnames';
+import { TableRow, TableData } from '@console/internal/components/factory';
+import { Kebab, ResourceLink, ResourceKebab, Timestamp } from '@console/internal/components/utils';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { RevisionModel, ServiceModel } from '../../models';
+import { getConditionString, getCondition } from '../../utils/condition-utils';
+import { RevisionKind, ConditionTypes } from '../../types';
+import { tableColumnClasses } from './revision-table';
+
+const revisionReference = referenceForModel(RevisionModel);
+const serviceReference = referenceForModel(ServiceModel);
+
+export interface RevisionRowProps {
+  obj: RevisionKind;
+  index: number;
+  key?: string;
+  style: object;
+}
+
+const RevisionRow: React.FC<RevisionRowProps> = ({ obj, index, key, style }) => {
+  const readyCondition = obj.status
+    ? getCondition(obj.status.conditions, ConditionTypes.Ready)
+    : null;
+  return (
+    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink
+          kind={revisionReference}
+          name={obj.metadata.name}
+          namespace={obj.metadata.namespace}
+          title={obj.metadata.uid}
+        />
+      </TableData>
+      <TableData className={cx(tableColumnClasses[1], 'co-break-word')}>
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
+      </TableData>
+      <TableData className={cx(tableColumnClasses[2], 'co-break-word')}>
+        <ResourceLink
+          kind={serviceReference}
+          name={obj.metadata.labels['serving.knative.dev/service']}
+          namespace={obj.metadata.namespace}
+          title={obj.metadata.labels['serving.knative.dev/service']}
+        />
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <Timestamp timestamp={obj.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[4]}>
+        {obj.status ? getConditionString(obj.status.conditions) : '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[5]}>
+        {(readyCondition && readyCondition.status) || '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[6]}>
+        {(readyCondition && readyCondition.message) || '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[7]}>
+        <ResourceKebab actions={Kebab.factory.common} kind={revisionReference} resource={obj} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+export default RevisionRow;

--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionsPage.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { match as RMatch } from 'react-router-dom';
+import { ListPage } from '@console/internal/components/factory';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { RevisionModel } from '../../models';
+import RevisionList from './RevisionList';
+
+export interface RevisionsPageProps {
+  match: RMatch<{
+    ns?: string;
+  }>;
+}
+
+const RevisionsPage: React.FC<RevisionsPageProps> = ({ match }) => (
+  <ListPage
+    namespace={match.params.ns}
+    canCreate
+    kind={referenceForModel(RevisionModel)}
+    ListComponent={RevisionList}
+  />
+);
+
+export default RevisionsPage;

--- a/frontend/packages/knative-plugin/src/components/revisions/revision-table.ts
+++ b/frontend/packages/knative-plugin/src/components/revisions/revision-table.ts
@@ -1,0 +1,12 @@
+import { Kebab } from '@console/internal/components/utils';
+
+export const tableColumnClasses = [
+  'col-lg-2 col-md-2 col-sm-4 col-xs-6',
+  'col-lg-2 col-md-2 col-sm-4 col-xs-6',
+  'col-lg-2 col-md-2 col-sm-4 hidden-xs',
+  'col-lg-2 col-md-2 hidden-sm hidden-xs',
+  'col-lg-1 col-md-2 hidden-sm hidden-xs',
+  'col-lg-1 col-md-2 hidden-sm hidden-xs',
+  'col-lg-2 col-md-2 hidden-sm hidden-xs',
+  Kebab.columnClass,
+];

--- a/frontend/packages/knative-plugin/src/components/routes/RouteHeader.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RouteHeader.tsx
@@ -1,0 +1,47 @@
+import { sortable } from '@patternfly/react-table';
+import { tableColumnClasses } from './route-table';
+
+const RouteHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortField: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'URL',
+      sortField: 'status.url',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: 'Age',
+      sortField: 'age',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[3] },
+    },
+    {
+      title: 'Conditions',
+      sortField: 'conditions',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[4] },
+    },
+    {
+      title: 'Traffic',
+      props: { className: tableColumnClasses[5] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[6] },
+    },
+  ];
+};
+
+export default RouteHeader;

--- a/frontend/packages/knative-plugin/src/components/routes/RouteList.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RouteList.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Table, TableProps } from '@console/internal/components/factory';
+import { RouteModel } from '../../models';
+import RouteHeader from './RouteHeader';
+import RouteRow from './RouteRow';
+
+const RouteList: React.FC<TableProps> = (props) => (
+  <Table
+    {...props}
+    aria-label={RouteModel.labelPlural}
+    Header={RouteHeader}
+    Row={RouteRow}
+    virtualize
+  />
+);
+
+export default RouteList;

--- a/frontend/packages/knative-plugin/src/components/routes/RouteRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RouteRow.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import * as cx from 'classnames';
+import { TableRow, TableData } from '@console/internal/components/factory';
+import {
+  Kebab,
+  ResourceLink,
+  ResourceKebab,
+  Timestamp,
+  ExternalLink,
+} from '@console/internal/components/utils';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { RevisionModel, RouteModel } from '../../models';
+import { getConditionString } from '../../utils/condition-utils';
+import { RouteKind, ConfigurationKind } from '../../types';
+import { tableColumnClasses } from './route-table';
+
+const routeReference = referenceForModel(RouteModel);
+const revisionReference = referenceForModel(RevisionModel);
+
+export interface RouteRowProps {
+  obj: RouteKind;
+  index: number;
+  key?: string;
+  style: object;
+  customData: {
+    configurationsByName: {
+      [key: string]: ConfigurationKind;
+    };
+  };
+}
+
+const RouteRow: React.FC<RouteRowProps> = ({ obj, index, key, style }) => (
+  <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+    <TableData className={tableColumnClasses[0]}>
+      <ResourceLink
+        kind={routeReference}
+        name={obj.metadata.name}
+        namespace={obj.metadata.namespace}
+        title={obj.metadata.uid}
+      />
+    </TableData>
+    <TableData className={cx(tableColumnClasses[1], 'co-break-word')}>
+      <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
+    </TableData>
+    <TableData className={tableColumnClasses[2]}>
+      {(obj.status && obj.status.url && (
+        <ExternalLink href={obj.status.url} text={obj.status.url} />
+      )) ||
+        '-'}
+    </TableData>
+    <TableData className={tableColumnClasses[3]}>
+      <Timestamp timestamp={obj.metadata.creationTimestamp} />
+    </TableData>
+    <TableData className={tableColumnClasses[4]}>
+      {obj.status ? getConditionString(obj.status.conditions) : '-'}
+    </TableData>
+    <TableData className={tableColumnClasses[5]}>
+      {obj.status && obj.status.traffic
+        ? obj.status.traffic.map((t, i) => (
+            <React.Fragment key={t.revisionName}>
+              {i > 0 ? ', ' : ''}
+              {`${t.percent}% → `}
+              <ResourceLink
+                namespace={obj.metadata.namespace}
+                kind={revisionReference}
+                name={t.revisionName}
+                inline
+                hideIcon
+              />
+            </React.Fragment>
+          ))
+        : '-'}
+    </TableData>
+    <TableData className={tableColumnClasses[6]}>
+      <ResourceKebab actions={Kebab.factory.common} kind={routeReference} resource={obj} />
+    </TableData>
+  </TableRow>
+);
+
+export default RouteRow;

--- a/frontend/packages/knative-plugin/src/components/routes/RoutesPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RoutesPage.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { match as RMatch } from 'react-router-dom';
+import { ListPage } from '@console/internal/components/factory';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { RouteModel } from '../../models';
+import RouteList from './RouteList';
+
+export interface RoutesPageProps {
+  match: RMatch<{
+    ns?: string;
+  }>;
+}
+
+const RoutesPage: React.FC<RoutesPageProps> = ({ match }) => (
+  <ListPage
+    namespace={match.params.ns}
+    canCreate
+    kind={referenceForModel(RouteModel)}
+    ListComponent={RouteList}
+  />
+);
+
+export default RoutesPage;

--- a/frontend/packages/knative-plugin/src/components/routes/route-table.ts
+++ b/frontend/packages/knative-plugin/src/components/routes/route-table.ts
@@ -1,0 +1,11 @@
+import { Kebab } from '@console/internal/components/utils';
+
+export const tableColumnClasses = [
+  'col-lg-2 col-md-2 col-sm-4 col-xs-6',
+  'col-lg-2 col-md-2 col-sm-4 col-xs-6',
+  'col-lg-3 col-md-2 col-sm-4 hidden-xs',
+  'col-lg-2 col-md-2 hidden-sm hidden-xs',
+  'col-lg-1 col-md-2 hidden-sm hidden-xs',
+  'col-lg-2 col-md-2 hidden-sm hidden-xs',
+  Kebab.columnClass,
+];

--- a/frontend/packages/knative-plugin/src/components/services/ServiceHeader.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceHeader.tsx
@@ -1,0 +1,55 @@
+import { sortable } from '@patternfly/react-table';
+import { tableColumnClasses } from './service-table';
+
+const ServiceHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortField: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Domain',
+      sortField: 'domain',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: 'Generation',
+      sortField: 'obj.metadata.generation',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[3] },
+    },
+    {
+      title: 'Age',
+      sortField: 'obj.metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[4] },
+    },
+    {
+      title: 'Conditions',
+      props: { className: tableColumnClasses[5] },
+    },
+    {
+      title: 'Ready',
+      props: { className: tableColumnClasses[6] },
+    },
+    {
+      title: 'Reason',
+      props: { className: tableColumnClasses[7] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[8] },
+    },
+  ];
+};
+
+export default ServiceHeader;

--- a/frontend/packages/knative-plugin/src/components/services/ServiceList.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceList.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Table, TableProps } from '@console/internal/components/factory';
+import { ServiceModel } from '../../models';
+import ServiceHeader from './ServiceHeader';
+import ServiceRow from './ServiceRow';
+
+const ServiceList: React.FC<TableProps> = (props) => (
+  <Table
+    {...props}
+    aria-label={ServiceModel.labelPlural}
+    Header={ServiceHeader}
+    Row={ServiceRow}
+    virtualize
+  />
+);
+
+export default ServiceList;

--- a/frontend/packages/knative-plugin/src/components/services/ServiceRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceRow.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import * as cx from 'classnames';
+import { TableRow, TableData } from '@console/internal/components/factory';
+import { Kebab, ResourceLink, ResourceKebab, Timestamp } from '@console/internal/components/utils';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ServiceModel } from '../../models';
+import { getConditionString, getCondition } from '../../utils/condition-utils';
+import { ServiceKind, ConditionTypes } from '../../types';
+import { tableColumnClasses } from './service-table';
+
+const serviceReference = referenceForModel(ServiceModel);
+
+export interface ServiceRowProps {
+  obj: ServiceKind;
+  index: number;
+  key?: string;
+  style: object;
+}
+
+const ServiceRow: React.FC<ServiceRowProps> = ({ obj, index, key, style }) => {
+  const readyCondition = obj.status
+    ? getCondition(obj.status.conditions, ConditionTypes.Ready)
+    : null;
+  return (
+    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink
+          kind={serviceReference}
+          name={obj.metadata.name}
+          namespace={obj.metadata.namespace}
+          title={obj.metadata.uid}
+        />
+      </TableData>
+      <TableData className={cx(tableColumnClasses[1], 'co-break-word')}>
+        <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
+      </TableData>
+      <TableData className={cx(tableColumnClasses[2], 'co-break-word')}>
+        {obj.metadata.domain || '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>{obj.metadata.generation || '-'}</TableData>
+      <TableData className={tableColumnClasses[4]}>
+        <Timestamp timestamp={obj.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={tableColumnClasses[5]}>
+        {obj.status ? getConditionString(obj.status.conditions) : '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[6]}>
+        {(readyCondition && readyCondition.status) || '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[7]}>
+        {(readyCondition && readyCondition.message) || '-'}
+      </TableData>
+      <TableData className={tableColumnClasses[8]}>
+        <ResourceKebab actions={Kebab.factory.common} kind={serviceReference} resource={obj} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+export default ServiceRow;

--- a/frontend/packages/knative-plugin/src/components/services/ServicesPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServicesPage.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { match as RMatch } from 'react-router-dom';
+import { ListPage } from '@console/internal/components/factory';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ServiceModel } from '../../models';
+import ServiceList from './ServiceList';
+
+export interface ServicesPageProps {
+  match: RMatch<{
+    ns?: string;
+  }>;
+}
+
+const ServicesPage: React.FC<ServicesPageProps> = ({ match }) => (
+  <ListPage
+    namespace={match.params.ns}
+    canCreate
+    kind={referenceForModel(ServiceModel)}
+    ListComponent={ServiceList}
+  />
+);
+
+export default ServicesPage;

--- a/frontend/packages/knative-plugin/src/components/services/service-table.ts
+++ b/frontend/packages/knative-plugin/src/components/services/service-table.ts
@@ -1,0 +1,13 @@
+import { Kebab } from '@console/internal/components/utils';
+
+export const tableColumnClasses = [
+  'col-lg-2 col-md-2 col-sm-4 col-xs-6',
+  'col-lg-2 col-md-2 col-sm-4 col-xs-6',
+  'col-lg-2 col-md-2 col-sm-4 hidden-xs',
+  'col-lg-1 col-md-2 hidden-sm hidden-xs',
+  'col-lg-2 hidden-md hidden-sm hidden-xs',
+  'col-lg-1 col-md-2 hidden-sm hidden-xs',
+  'col-lg-1 col-md-2 hidden-sm hidden-xs',
+  'col-lg-2 hidden-md hidden-sm hidden-xs',
+  Kebab.columnClass,
+];

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -6,6 +6,7 @@ import {
   ModelDefinition,
   OverviewResourceTab,
   OverviewCRD,
+  ResourceListPage,
 } from '@console/plugin-sdk';
 import { referenceForModel } from '@console/internal/module/k8s';
 import * as models from './models';
@@ -18,7 +19,8 @@ type ConsumedExtensions =
   | ModelFeatureFlag
   | ModelDefinition
   | OverviewResourceTab
-  | OverviewCRD;
+  | OverviewCRD
+  | ResourceListPage;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -61,8 +63,8 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       section: 'Serverless',
       componentProps: {
-        name: models.ConfigurationModel.labelPlural,
-        resource: referenceForModel(models.ConfigurationModel),
+        name: models.RouteModel.labelPlural,
+        resource: referenceForModel(models.RouteModel),
         required: FLAG_KNATIVE_SERVING,
       },
     },
@@ -84,6 +86,36 @@ const plugin: Plugin<ConsumedExtensions> = [
       resources: knativeServingResources,
       required: FLAG_KNATIVE_SERVING,
       utils: getKnativeServingResources,
+    },
+  },
+  {
+    type: 'Page/Resource/List',
+    properties: {
+      model: models.RevisionModel,
+      loader: async () =>
+        (await import(
+          './components/revisions/RevisionsPage' /* webpackChunkName: "knative-revisions-page" */
+        )).default,
+    },
+  },
+  {
+    type: 'Page/Resource/List',
+    properties: {
+      model: models.ServiceModel,
+      loader: async () =>
+        (await import(
+          './components/services/ServicesPage' /* webpackChunkName: "knative-services-page" */
+        )).default,
+    },
+  },
+  {
+    type: 'Page/Resource/List',
+    properties: {
+      model: models.RouteModel,
+      loader: async () =>
+        (await import(
+          './components/routes/RoutesPage' /* webpackChunkName: "knative-routes-page" */
+        )).default,
     },
   },
 ];

--- a/frontend/packages/knative-plugin/src/types.ts
+++ b/frontend/packages/knative-plugin/src/types.ts
@@ -1,0 +1,32 @@
+import { K8sResourceKind, K8sResourceCondition } from '@console/internal/module/k8s';
+
+export type ConfigurationKind = K8sResourceKind;
+
+export type RevisionKind = {
+  status: {
+    conditions: K8sResourceCondition<ConditionTypes>[];
+  };
+} & K8sResourceKind;
+
+export type ServiceKind = K8sResourceKind & {
+  metadata?: {
+    generation?: number;
+    domain?: string;
+  };
+};
+
+export type RouteKind = {
+  status: {
+    url: string;
+    traffic: Traffic[];
+  };
+} & K8sResourceKind;
+
+export enum ConditionTypes {
+  Ready = 'Ready',
+}
+
+export type Traffic = {
+  revisionName: string;
+  percent: number;
+};

--- a/frontend/packages/knative-plugin/src/utils/__tests__/condition-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/condition-utils.spec.ts
@@ -1,0 +1,71 @@
+import { K8sResourceCondition, K8sResourceConditionStatus } from '@console/internal/module/k8s';
+import { getConditionOKCount, getConditionString, getCondition } from '../condition-utils';
+
+const createCondition = (status: K8sResourceConditionStatus): K8sResourceCondition<any> => ({
+  status,
+  type: '',
+  lastTransitionTime: null,
+  reason: '',
+  message: '',
+});
+
+const createConditionOfType = (type: string): K8sResourceCondition<any> => ({
+  status: K8sResourceConditionStatus.Unknown,
+  type,
+  lastTransitionTime: null,
+  reason: '',
+  message: '',
+});
+
+describe('condition-utils', () => {
+  describe('getConditionOKCount', () => {
+    it(`should count the number of conditions with status === 'True'`, () => {
+      expect(getConditionOKCount(undefined)).toBe(0);
+      expect(
+        getConditionOKCount([
+          createCondition(K8sResourceConditionStatus.False),
+          createCondition(K8sResourceConditionStatus.False),
+        ]),
+      ).toBe(0);
+      expect(
+        getConditionOKCount([
+          createCondition(K8sResourceConditionStatus.True),
+          createCondition(K8sResourceConditionStatus.False),
+          createCondition(K8sResourceConditionStatus.True),
+        ]),
+      ).toBe(2);
+    });
+  });
+
+  describe('getConditionString', () => {
+    it('should return a condition string with OK and total condition counts', () => {
+      expect(getConditionString(undefined)).toBe('0 OK / 0');
+      expect(
+        getConditionString([
+          createCondition(K8sResourceConditionStatus.False),
+          createCondition(K8sResourceConditionStatus.False),
+        ]),
+      ).toBe('0 OK / 2');
+      expect(
+        getConditionString([
+          createCondition(K8sResourceConditionStatus.True),
+          createCondition(K8sResourceConditionStatus.False),
+          createCondition(K8sResourceConditionStatus.True),
+        ]),
+      ).toBe('2 OK / 3');
+    });
+  });
+
+  describe('getCondition', () => {
+    it('should return the condition with matching type', () => {
+      expect(getCondition(undefined, 'test')).toBe(undefined);
+      const condition = createConditionOfType('test');
+      expect(
+        getCondition(
+          [createConditionOfType('error'), condition, createConditionOfType('ready')],
+          'test',
+        ),
+      ).toBe(condition);
+    });
+  });
+});

--- a/frontend/packages/knative-plugin/src/utils/condition-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/condition-utils.ts
@@ -1,0 +1,13 @@
+import * as _ from 'lodash';
+import { K8sResourceCondition, K8sResourceConditionStatus } from '@console/internal/module/k8s';
+
+export const getConditionOKCount = (conditions: K8sResourceCondition<any>[]): number =>
+  _.sumBy<any>(conditions, (c) => Number(c.status === K8sResourceConditionStatus.True));
+
+export const getConditionString = (conditions: K8sResourceCondition<any>[]): string =>
+  `${getConditionOKCount(conditions)} OK / ${_.size(conditions)}`;
+
+export const getCondition = <T>(
+  conditions: K8sResourceCondition<any>[],
+  type: T,
+): K8sResourceCondition<T> | undefined => _.find(conditions, (c) => c.type === type);

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -238,7 +238,7 @@ export type VirtualBodyProps = {
   expand: boolean;
 }
 
-type TableOwnProps = {
+export type TableProps = {
   customData?: object;
   data?: any[];
   defaultSortFunc?: string;
@@ -264,7 +264,7 @@ type TableOptionProps = {
   UI: any;
 }
 
-export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TableOwnProps,TableOptionProps>(
+export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TableProps,TableOptionProps>(
   stateToProps,
   {sortList: UIActions.sortList},
   null,


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/CONSOLE-1555

Adds custom tables for severless resources such that the display columns match the `kn` command line utility:

Services:
![image](https://user-images.githubusercontent.com/14068621/61249516-6f080000-a723-11e9-869a-5fdacf4008ad.png)

Revisions:
![image](https://user-images.githubusercontent.com/14068621/61249527-78916800-a723-11e9-85be-23f4974bab20.png)

Routes:
![image](https://user-images.githubusercontent.com/14068621/61249544-82b36680-a723-11e9-99cf-ed64a4745cc0.png)

cc @invincibleJai @joshuawilson @gijohn @alimobrem 