### PR TITLE
Conversion of buttons to pf4 button compontent (Group 1)

### DIFF
--- a/frontend/__tests__/components/environment.spec.tsx
+++ b/frontend/__tests__/components/environment.spec.tsx
@@ -76,7 +76,8 @@ describe(EnvironmentPage.name, () => {
     });
 
     it('renders save and reload buttons', () => {
-      expect(wrapper.find('.environment-buttons button').exists()).toEqual(true);
+      expect(wrapper.find({type: 'submit', variant: 'primary'}).shallow().text()).toEqual('Save');
+      expect(wrapper.find({type: 'button', variant: 'secondary'}).shallow().text()).toEqual('Reload');
     });
   });
 

--- a/frontend/__tests__/components/factory/list-page.spec.tsx
+++ b/frontend/__tests__/components/factory/list-page.spec.tsx
@@ -51,7 +51,7 @@ describe(FireMan_.displayName, () => {
     const createProps = {foo: 'bar'};
     const button = wrapper.setProps({canCreate: true, createProps, createButtonText: 'Create Me!'}).find('#yaml-create');
 
-    expect(wrapper.find('#yaml-create').text()).toEqual('Create Me!');
+    expect(wrapper.find('#yaml-create').shallow().text()).toEqual('Create Me!');
 
     Object.keys(createProps).forEach((key) => {
       expect(createProps[key] === button.props()[key]).toBe(true);

--- a/frontend/__tests__/components/operator-lifecycle-manager/create-operand.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/create-operand.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
 import Spy = jasmine.Spy;
-import { Alert } from '@patternfly/react-core';
+import { Alert, Button } from '@patternfly/react-core';
 
 import {
   CreateOperandForm,
@@ -37,7 +37,7 @@ describe(CreateOperand.displayName, () => {
   });
 
   it('renders YAML editor by default', () => {
-    expect(wrapper.find('button').text()).toEqual('Edit Form');
+    expect(wrapper.find(Button).shallow().text()).toEqual('Edit Form');
     expect(wrapper.find(CreateOperandYAML).exists()).toBe(true);
     expect(wrapper.find(CreateOperandForm).exists()).toBe(false);
   });
@@ -51,8 +51,8 @@ describe(CreateOperand.displayName, () => {
   });
 
   it('switches to form component when button is clicked', () => {
-    wrapper.find('button').simulate('click');
-    expect(wrapper.find('button').text()).toEqual('Edit YAML');
+    wrapper.find(Button).shallow().simulate('click');
+    expect(wrapper.find(Button).shallow().text()).toEqual('Edit YAML');
     expect(wrapper.find(CreateOperandYAML).exists()).toBe(false);
     expect(wrapper.find(CreateOperandForm).exists()).toBe(true);
   });
@@ -102,7 +102,7 @@ describe(CreateOperandForm.displayName, () => {
         done();
       });
 
-    wrapper.find('.btn-primary').simulate('click', new Event('click'));
+    wrapper.find({type: 'submit'}).shallow().simulate('click', new Event('click'));
   });
 
   it('displays errors if calling `k8sCreate` fails', (done) => {
@@ -114,7 +114,7 @@ describe(CreateOperandForm.displayName, () => {
         done();
       });
 
-    wrapper.find('.btn-primary').simulate('click', new Event('click'));
+    wrapper.find({type: 'submit'}).shallow().simulate('click', new Event('click'));
   });
 });
 

--- a/frontend/__tests__/components/utils/download-button.spec.tsx
+++ b/frontend/__tests__/components/utils/download-button.spec.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
-import { shallow, ShallowWrapper } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import Spy = jasmine.Spy;
 import * as fileSaver from 'file-saver';
+import { Button } from '@patternfly/react-core';
 
 import { DownloadButton, DownloadButtonProps } from '../../../public/components/utils/download-button';
 import * as coFetch from '../../../public/co-fetch';
 
 describe(DownloadButton.displayName, () => {
-  let wrapper: ShallowWrapper<DownloadButtonProps>;
+  let wrapper: ReactWrapper<DownloadButtonProps>;
   const url = 'http://google.com';
 
   const spyAndExpect = (spy: Spy) => (returnValue: any) => new Promise(resolve => spy.and.callFake((...args) => {
@@ -16,7 +17,7 @@ describe(DownloadButton.displayName, () => {
   }));
 
   beforeEach(() => {
-    wrapper = shallow(<DownloadButton url={url} />);
+    wrapper = mount(<DownloadButton url={url} />);
 
     spyOn(fileSaver, 'saveAs').and.returnValue(null);
   });
@@ -27,12 +28,12 @@ describe(DownloadButton.displayName, () => {
       done();
     });
 
-    wrapper.find('button').simulate('click');
+    wrapper.find(Button).simulate('click');
   });
 
   it('renders "Downloading..." if download is in flight', (done) => {
     spyAndExpect(spyOn(coFetch, 'coFetch'))(Promise.resolve()).then(() => {
-      expect(wrapper.find('button').text().trim()).toEqual('Downloading...');
+      expect(wrapper.find(Button).text().trim()).toEqual('Downloading...');
       done();
     });
 

--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -294,6 +294,7 @@ describe('Kubernetes resource CRUD operations', () => {
   describe('Editing labels', () => {
     const name = `${testName}-editlabels`;
     const plural = 'configmaps';
+    const kind = 'ConfigMap';
     const labelValue = 'appblah';
 
     beforeAll(async() => {
@@ -328,14 +329,7 @@ describe('Kubernetes resource CRUD operations', () => {
     });
 
     afterAll(async() => {
-      await browser.get(`${appHost}/k8s/ns/${testName}/${plural}/${name}`);
-      await browser.wait(until.presenceOf(crudView.actionsButton));
-      await crudView.actionsButton.click();
-      await browser.wait(until.presenceOf(crudView.actionsDropdownMenu), 1000);
-      await crudView.actionsDropdownMenu.element(by.partialLinkText('Delete ')).click();
-      await browser.wait(until.presenceOf($('#confirm-action')));
-      await $('.modal-footer #confirm-action').click();
-
+      await crudView.deleteResource(plural, kind, name);
       leakedResources.delete(JSON.stringify({name, plural, namespace: testName}));
     });
   });

--- a/frontend/integration-tests/views/environment.view.ts
+++ b/frontend/integration-tests/views/environment.view.ts
@@ -6,7 +6,7 @@ const inputs = $$('.pf-c-form-control');
 export const rowsKey = $('[placeholder="name"]');
 export const rowsValue = $('[placeholder="value"]');
 export const deleteBtn = $$('.pairs-list__delete-icon').first();
-export const saveBtn = element(by.cssContainingText('.btn.btn-primary', 'Save'));
+export const saveBtn = element(by.cssContainingText('.pf-m-primary', 'Save'));
 
 export const prefix = $('[data-test-id=env-prefix]');
 export const resources = $$('.co-resource-item__resource-name');

--- a/frontend/integration-tests/views/modal-annotations.view.ts
+++ b/frontend/integration-tests/views/modal-annotations.view.ts
@@ -2,7 +2,7 @@ import { $, $$, browser, ExpectedConditions as until } from 'protractor';
 
 const BROWSER_TIMEOUT = 15000;
 
-const addMoreBtn = $('.pairs-list__add-btn');
+const addMoreBtn = $('[data-test-id="pairs-list__add-btn"]');
 export const cancelBtn = $$('.btn-default').filter(link => link.getText().then(text => text.startsWith('Cancel'))).first();
 export const confirmActionBtn = $('#confirm-action');
 const annotationRows = $$('.pairs-list__row');

--- a/frontend/integration-tests/views/secrets.view.ts
+++ b/frontend/integration-tests/views/secrets.view.ts
@@ -27,7 +27,7 @@ export const createImageSecretLink = $('#image-link');
 export const createGenericSecretLink = $('#generic-link');
 
 export const addSecretEntryLink = $('.co-create-secret-form__link--add-entry');
-export const removeSecretEntryLink = $$('.co-create-secret-form__link--remove-entry .btn-link').first();
+export const removeSecretEntryLink = $$('.co-create-secret-form__link--remove-entry .pf-m-link').first();
 export const imageSecretForm = $$('.co-create-image-secret__form');
 export const genericSecretForm = $$('.co-create-generic-secret__form');
 

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -2,8 +2,8 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
+import { ActionGroup, Button } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import { ClusterRoleBindingModel } from '../../models';
 import { getQN, k8sCreate, k8sPatch, referenceFor } from '../../module/k8s';
@@ -446,8 +446,21 @@ const BaseEditRoleBinding = connect(null, {setActiveNamespace: UIActions.setActi
           <div className="co-form-section__separator"></div>
 
           <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress}>
-            <button type="submit" className="btn btn-primary" id="save-changes">{saveButtonText || 'Create'}</button>
-            <Link to={UIActions.formatNamespacedRouteForResource('rolebindings')} className="btn btn-default" id="cancel">Cancel</Link>
+            <ActionGroup className="pf-c-form">
+              <Button
+                type="submit"
+                id="save-changes"
+                variant="primary">
+                {saveButtonText || 'Create'}
+              </Button>
+              <Button
+                component="a"
+                to={UIActions.formatNamespacedRouteForResource('rolebindings')}
+                id="cancel"
+                variant="secondary">
+                Cancel
+              </Button>
+            </ActionGroup>
           </ButtonBar>
         </form>
       </div>;

--- a/frontend/public/components/cluster-settings/basicauth-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/basicauth-idp-form.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import * as _ from 'lodash-es';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { SecretModel, ConfigMapModel } from '../../models';
 import { IdentityProvider, k8sCreate, K8sResourceKind, OAuthKind } from '../../module/k8s';
@@ -186,8 +187,19 @@ export class AddBasicAuthPage extends PromiseComponent<{}, AddBasicAuthPageState
             inputFieldHelpText="PEM-encoded TLS private key for the client certificate. Required if Certificate is specified." />
         </div>
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
-          <button type="submit" className="btn btn-primary">Add</button>
-          <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary">
+              Add
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={history.goBack}>
+              Cancel
+            </Button>
+          </ActionGroup>
         </ButtonBar>
       </form>
     </div>;

--- a/frontend/public/components/cluster-settings/github-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/github-idp-form.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { SecretModel, ConfigMapModel } from '../../models';
 import { IdentityProvider, k8sCreate, K8sResourceKind, OAuthKind } from '../../module/k8s';
@@ -198,8 +199,19 @@ export class AddGitHubPage extends PromiseComponent<{}, AddGitHubPageState> {
         <p className="co-help-text">Optionally list teams. If specified, only GitHub users that are members of at least one of the listed teams will be allowed to log in. Cannot be used in combination with <strong>organizations</strong>.</p>
         <ListInput label="Team" onChange={this.teamsChanged} helpText="Restricts which teams are allowed to log in. The format is <org>/<team>." />
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
-          <button type="submit" className="btn btn-primary">Add</button>
-          <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary">
+              Add
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={history.goBack}>
+              Cancel
+            </Button>
+          </ActionGroup>
         </ButtonBar>
       </form>
     </div>;

--- a/frontend/public/components/cluster-settings/gitlab-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/gitlab-idp-form.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { SecretModel, ConfigMapModel } from '../../models';
 import { IdentityProvider, k8sCreate, K8sResourceKind, OAuthKind } from '../../module/k8s';
@@ -170,8 +171,19 @@ export class AddGitLabPage extends PromiseComponent<{}, AddGitLabPageState> {
         </div>
         <IDPCAFileInput value={caFileContent} onChange={this.caFileChanged} />
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
-          <button type="submit" className="btn btn-primary">Add</button>
-          <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary">
+                Add
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={history.goBack}>
+                Cancel
+            </Button>
+          </ActionGroup>
         </ButtonBar>
       </form>
     </div>;

--- a/frontend/public/components/cluster-settings/global-config.tsx
+++ b/frontend/public/components/cluster-settings/global-config.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
-import { Alert } from '@patternfly/react-core';
+import { Alert, Button } from '@patternfly/react-core';
 
 import { K8sKind, k8sList } from '../../module/k8s';
 import { resourcePathFromModel } from '../utils/resource-link';
@@ -16,10 +15,22 @@ const ItemRow = ({item}) => {
   const resourceLink = resourcePathFromModel(item.model, item.metadata.name, item.metadata.namespace);
   return <div className="row co-resource-list__item">
     <div className="col-sm-10 col-xs-12">
-      <Link to={resourceLink}>{item.kind}</Link>
+      <Button
+        className="pf-m-link--align-left"
+        component="a"
+        href={resourceLink}
+        variant="link">
+        {item.kind}
+      </Button>
     </div>
     <div className="col-sm-2 hidden-xs">
-      <Link to={`${resourceLink}/yaml`} className="btn btn-default pull-right">Edit YAML</Link>
+      <Button
+        className="pull-right"
+        component="a"
+        href={`${resourceLink}/yaml`}
+        variant="secondary">
+        Edit YAML
+      </Button>
     </div>
   </div>;
 };

--- a/frontend/public/components/cluster-settings/google-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/google-idp-form.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { SecretModel } from '../../models';
 import { IdentityProvider, k8sCreate, K8sResourceKind, OAuthKind } from '../../module/k8s';
@@ -130,8 +131,19 @@ export class AddGooglePage extends PromiseComponent<{}, AddGooglePageState> {
           </p>
         </div>
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
-          <button type="submit" className="btn btn-primary">Add</button>
-          <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary">
+              Add
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={history.goBack}>
+              Cancel
+            </Button>
+          </ActionGroup>
         </ButtonBar>
       </form>
     </div>;

--- a/frontend/public/components/cluster-settings/htpasswd-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/htpasswd-idp-form.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { SecretModel } from '../../models';
 import {
@@ -112,8 +113,19 @@ export class AddHTPasswdPage extends PromiseComponent<{}, AddHTPasswdPageState> 
             hideContents />
         </div>
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
-          <button type="submit" className="btn btn-primary">Add</button>
-          <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary">
+              Add
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={history.goBack}>
+              Cancel
+            </Button>
+          </ActionGroup>
         </ButtonBar>
       </form>
     </div>;

--- a/frontend/public/components/cluster-settings/keystone-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/keystone-idp-form.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import * as _ from 'lodash-es';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { SecretModel, ConfigMapModel } from '../../models';
 import { IdentityProvider, k8sCreate, K8sResourceKind, OAuthKind } from '../../module/k8s';
@@ -201,8 +202,19 @@ export class AddKeystonePage extends PromiseComponent<{}, AddKeystonePageState> 
             inputFieldHelpText="PEM-encoded TLS private key for the client certificate. Required if Certificate is specified." />
         </div>
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
-          <button type="submit" className="btn btn-primary">Add</button>
-          <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary">
+              Add
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={history.goBack}>
+              Cancel
+            </Button>
+          </ActionGroup>
         </ButtonBar>
       </form>
     </div>;

--- a/frontend/public/components/cluster-settings/ldap-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/ldap-idp-form.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { ConfigMapModel, SecretModel } from '../../models';
 import { IdentityProvider, k8sCreate, K8sResourceKind, OAuthKind } from '../../module/k8s';
@@ -227,8 +228,19 @@ export class AddLDAPPage extends PromiseComponent<{}, AddLDAPPageState> {
         <h3>More Options</h3>
         <IDPCAFileInput value={caFileContent} onChange={this.caFileChanged} />
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
-          <button type="submit" className="btn btn-primary">Add</button>
-          <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary">
+              Add
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={history.goBack}>
+              Cancel
+            </Button>
+          </ActionGroup>
         </ButtonBar>
       </form>
     </div>;

--- a/frontend/public/components/cluster-settings/openid-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/openid-idp-form.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { SecretModel, ConfigMapModel } from '../../models';
 import {
@@ -215,8 +216,19 @@ export class AddOpenIDPage extends PromiseComponent<{}, AddOpenIDIDPPageState> {
         <IDPCAFileInput value={caFileContent} onChange={this.caFileChanged} />
         <ListInput label="Extra Scopes" onChange={this.extraScopesChanged} helpText="Any scopes to request in addition to the standard openid scope." />
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
-          <button type="submit" className="btn btn-primary">Add</button>
-          <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary">
+              Add
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={history.goBack}>
+              Cancel
+            </Button>
+          </ActionGroup>
         </ButtonBar>
       </form>
     </div>;

--- a/frontend/public/components/cluster-settings/request-header-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/request-header-idp-form.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { ConfigMapModel } from '../../models';
 import { IdentityProvider, k8sCreate, K8sResourceKind, OAuthKind } from '../../module/k8s';
@@ -180,8 +181,19 @@ export class AddRequestHeaderPage extends PromiseComponent<{}, AddRequestHeaderP
         <ListInput label="Name Headers" onChange={this.nameHeadersChanged} helpText="The set of headers to check for the display name." />
         <ListInput label="Email Headers" onChange={this.emailHeadersChanged} helpText="The set of headers to check for the email address." />
         <ButtonBar errorMessage={this.state.errorMessage} inProgress={this.state.inProgress}>
-          <button type="submit" className="btn btn-primary">Add</button>
-          <button type="button" className="btn btn-default" onClick={history.goBack}>Cancel</button>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary">
+              Add
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={history.goBack}>
+              Cancel
+            </Button>
+          </ActionGroup>
         </ButtonBar>
       </form>
     </div>;

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -4,7 +4,8 @@ import * as classNames from 'classnames';
 import { safeLoad, safeDump } from 'js-yaml';
 import { saveAs } from 'file-saver';
 import { connect } from 'react-redux';
-import { Alert } from '@patternfly/react-core';
+import { ActionGroup, Alert, Button } from '@patternfly/react-core';
+import { DownloadIcon } from '@patternfly/react-icons';
 
 import * as ace from 'brace';
 import 'brace/ext/searchbox';
@@ -369,7 +370,7 @@ export const EditYAML = connect(stateToProps)(
           </div>}
           <div className="co-p-has-sidebar">
             <div className="co-p-has-sidebar__body">
-              <div className={classNames('yaml-editor', {'yaml-editor--readonly': readOnly})} ref={r => this.editor = r} style={{height: this.state.height}}>
+              <div className={classNames('pf-c-form yaml-editor', {'yaml-editor--readonly': readOnly})} ref={r => this.editor = r} style={{height: this.state.height}}>
                 <div className="absolute-zero">
                   <div className="full-width-and-height yaml-editor__flexbox">
                     <div id={this.id} key={this.id} className="yaml-editor__acebox" />
@@ -377,11 +378,13 @@ export const EditYAML = connect(stateToProps)(
                       {error && <Alert isInline className="co-alert co-alert--scrollable" variant="danger" title="An error occurred"><div className="co-pre-line">{error}</div></Alert>}
                       {success && <Alert isInline className="co-alert" variant="success" title={success} />}
                       {stale && <Alert isInline className="co-alert" variant="info" title="This object has been updated.">Click reload to see the new version.</Alert>}
-                      {create && <button type="submit" className="btn btn-primary" id="save-changes" onClick={() => this.save()}>Create</button>}
-                      {!create && !readOnly && <button type="submit" className="btn btn-primary" id="save-changes" onClick={() => this.save()}>Save</button>}
-                      {!create && <button type="submit" className="btn btn-default" id="reload-object" onClick={() => this.reload()}>Reload</button>}
-                      <button className="btn btn-default" id="cancel" onClick={() => this.onCancel()}>Cancel</button>
-                      {download && <button type="submit" className="btn btn-default pull-right hidden-sm hidden-xs" onClick={() => this.download()}><i className="fa fa-download"></i>&nbsp;Download</button>}
+                      <ActionGroup className="pf-c-form__group--no-top-margin">
+                        {create && <Button type="submit" variant="primary" id="save-changes" onClick={() => this.save()}>Create</Button>}
+                        {!create && !readOnly && <Button type="submit" variant="primary" id="save-changes" onClick={() => this.save()}>Save</Button>}
+                        {!create && <Button type="submit" variant="secondary" id="reload-object" onClick={() => this.reload()}>Reload</Button>}
+                        <Button variant="secondary" id="cancel" onClick={() => this.onCancel()}>Cancel</Button>
+                        {download && <Button type="submit" variant="secondary" className="pf-c-button--align-right hidden-sm hidden-xs" onClick={() => this.download()}><DownloadIcon /> Download</Button>}
+                      </ActionGroup>
                     </div>
                   </div>
                 </div>

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FieldLevelHelp } from 'patternfly-react';
-import { Alert } from '@patternfly/react-core';
+import { Alert, Button, ActionGroup } from '@patternfly/react-core';
 import * as classNames from 'classnames';
 
 import { k8sPatch, k8sGet, referenceFor, referenceForOwnerRef } from '../module/k8s';
@@ -508,13 +508,14 @@ export const EnvironmentPage = connect(stateToProps)(
       return <div className={classNames({'co-m-pane__body': !currentEnvVars.isCreate})}>
         {containerVars}
         { !currentEnvVars.isCreate && <div className="co-m-pane__body-group">
-          <div className="environment-buttons">
+          <div className="pf-c-form environment-buttons">
             {errorMessage && <Alert isInline className="co-alert" variant="danger" title={errorMessage} />}
             {stale && <Alert isInline className="co-alert" variant="info" title="The information on this page is no longer current.">Click Reload to update and lose edits, or Save Changes to overwrite.</Alert>}
             {success && <Alert isInline className="co-alert" variant="success" title={success} />}
-            {!readOnly &&
-            <button disabled={inProgress} type="submit" className="btn btn-primary" onClick={this.saveChanges}>Save</button>}
-            {!readOnly && <button disabled={inProgress} type="button" className="btn btn-default" onClick={this.reload}>Reload</button>}
+            {!readOnly && <ActionGroup>
+              <Button isDisabled={inProgress} type="submit" variant="primary" onClick={this.saveChanges}>Save</Button>
+              <Button isDisabled={inProgress} type="button" variant="secondary" onClick={this.reload}>Reload</Button>
+            </ActionGroup>}
           </div>
         </div> }
       </div>;

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -4,6 +4,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { Button } from '@patternfly/react-core';
 
 import { KEYBOARD_SHORTCUTS } from '../../const';
 import { filterList } from '../../actions/k8s';
@@ -210,7 +211,7 @@ export const FireMan_ = connect(null, {filterList})(
       if (canCreate) {
         if (createProps.to) {
           createLink = <Link className="co-m-primary-action" {...createProps}>
-            <button className="btn btn-primary" id="yaml-create">{createButtonText}</button>
+            <Button variant="primary" id="yaml-create">{createButtonText}</Button>
           </Link>;
         } else if (createProps.items) {
           createLink = <div className="co-m-primary-action">
@@ -225,7 +226,7 @@ export const FireMan_ = connect(null, {filterList})(
           </div>;
         } else {
           createLink = <div className="co-m-primary-action">
-            <button className="btn btn-primary" id="yaml-create" {...createProps}>{createButtonText}</button>
+            <Button variant="primary" id="yaml-create" {...createProps}>{createButtonText}</Button>
           </div>;
         }
         if (!_.isEmpty(createAccessReview)) {

--- a/frontend/public/components/modals/taints-modal.tsx
+++ b/frontend/public/components/modals/taints-modal.tsx
@@ -1,5 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 import { Dropdown, EmptyBox, PromiseComponent } from '../utils';
 import { K8sKind, k8sPatch, NodeKind, Taint } from '../../module/k8s';
@@ -109,9 +111,12 @@ class TaintsModal extends PromiseComponent<TaintsModalProps, TaintsModalState> {
               </div>
             )}
           </React.Fragment>}
-        <button type="button" className="btn btn-link" onClick={this._addRow}>
-          <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />Add More
-        </button>
+        <Button
+          onClick={this._addRow}
+          type="button"
+          variant="link">
+          <PlusCircleIcon data-test-id="pairs-list__add-icon" /> Add More
+        </Button>
       </ModalBody>
       <ModalSubmitFooter errorMessage={errorMessage} inProgress={inProgress} submitText="Save" cancel={this._cancel} />
     </form>;

--- a/frontend/public/components/modals/tolerations-modal.tsx
+++ b/frontend/public/components/modals/tolerations-modal.tsx
@@ -1,5 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 import { Dropdown, EmptyBox, PromiseComponent } from '../utils';
 import { K8sKind, k8sPatch, Toleration, TolerationOperator } from '../../module/k8s';
@@ -167,9 +169,13 @@ class TolerationsModal extends PromiseComponent<TolerationsModalProps, Toleratio
             })}
           </React.Fragment>
         }
-        <button type="button" className="btn btn-link" onClick={this._addRow}>
-          <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />Add More
-        </button>
+        <Button
+          className="btn btn-link"
+          onClick={this._addRow}
+          type="button"
+          variant="link">
+          <PlusCircleIcon data-test-id="pairs-list__add-icon" /> Add More
+        </Button>
       </ModalBody>
       <ModalSubmitFooter errorMessage={errorMessage} inProgress={inProgress} submitText="Save" cancel={this._cancel} />
     </form>;

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1,12 +1,13 @@
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { murmur3 } from 'murmurhash-js';
-import { Alert } from '@patternfly/react-core';
+import { Alert , ActionGroup, Button } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 import * as k8sActions from '../actions/k8s';
 import * as UIActions from '../actions/ui';
@@ -795,7 +796,7 @@ const silencesRowFilter = {
 };
 
 const CreateButton = () => <Link className="co-m-primary-action" to="/monitoring/silences/~new">
-  <button className="btn btn-primary">Create Silence</button>
+  <Button variant="primary">Create Silence</Button>
 </Link>;
 
 const SilencesPage_ = props => <MonitoringListPage
@@ -949,9 +950,12 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
               </button>
             </div>
           </div>)}
-          <button type="button" className="btn btn-link btn--silence-add-more" onClick={this.addMatcher}>
-            <i className="fa fa-plus-circle" aria-hidden="true" /> Add More
-          </button>
+          <Button
+            onClick={this.addMatcher}
+            type="button"
+            variant="link">
+            <PlusCircleIcon /> Add More
+          </Button>
         </div>
         <div className="co-form-section__separator"></div>
 
@@ -965,8 +969,19 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
         </div>
 
         <ButtonBar errorMessage={error} inProgress={inProgress}>
-          <button type="submit" className="btn btn-primary">{saveButtonText || 'Save'}</button>
-          <Link to={data.id ? `${SilenceResource.plural}/${data.id}` : SilenceResource.plural} className="btn btn-default">Cancel</Link>
+          <ActionGroup className="pf-c-form">
+            <Button
+              type="submit"
+              variant="primary">
+              {saveButtonText || 'Save'}
+            </Button>
+            <Button
+              component="a"
+              href={data.id ? `${SilenceResource.plural}/${data.id}` : SilenceResource.plural}
+              variant="secondary">
+              Cancel
+            </Button>
+          </ActionGroup>
         </ButtonBar>
       </form>
     </div>;

--- a/frontend/public/components/operator-lifecycle-manager/create-operand.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/create-operand.tsx
@@ -3,9 +3,8 @@ import { connect } from 'react-redux';
 import { match } from 'react-router';
 import { Helmet } from 'react-helmet';
 import { safeDump } from 'js-yaml';
-import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
-import { Alert } from '@patternfly/react-core';
+import { Alert, ActionGroup, Button } from '@patternfly/react-core';
 
 import {
   apiVersionForModel,
@@ -284,8 +283,20 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
         <Alert isInline className="co-alert co-break-word" variant="danger" title={error} />
       </div>}
       <div className="row">
-        <button className="btn btn-primary" type="submit" onClick={submit}>Create</button>
-        <Link className="btn btn-default" to={`/k8s/ns/${props.namespace}/clusterserviceversions/${props.clusterServiceVersion.metadata.name}/${referenceForModel(props.operandModel)}`}>Cancel</Link>
+        <ActionGroup className="pf-c-form">
+          <Button
+            onClick={submit}
+            type="submit"
+            variant="primary">
+            Create
+          </Button>
+          <Button
+            component="a"
+            href={`/k8s/ns/${props.namespace}/clusterserviceversions/${props.clusterServiceVersion.metadata.name}/${referenceForModel(props.operandModel)}`}
+            variant="secondary">
+            Cancel
+          </Button>
+        </ActionGroup>
       </div>
     </form>
     <div className="col-md-6">
@@ -327,8 +338,8 @@ export const CreateOperand: React.FC<CreateOperandProps> = (props) => {
           {name: `Create ${props.operandModel.label}`, path: window.location.pathname},
         ]} />
         <div style={{marginLeft: 'auto'}}>{
-          method === 'form' && <button className="btn btn-link" onClick={() => setMethod('yaml')}>Edit YAML</button> ||
-          method === 'yaml' && <button className="btn btn-link" onClick={() => setMethod('form')}>Edit Form</button>
+          method === 'form' && <Button variant="link" onClick={() => setMethod('yaml')}>Edit YAML</Button> ||
+          method === 'yaml' && <Button variant="link" onClick={() => setMethod('form')}>Edit Form</Button>
         }</div>
       </div>
       <h1 className="co-create-operand__header-text">{`Create ${props.operandModel.label}`}</h1>

--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -1,7 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Alert } from '@patternfly/react-core';
+import { Alert, ActionGroup, Button } from '@patternfly/react-core';
 
 import { ButtonBar, Dropdown, history, resourcePathFromModel, ResourceName } from '../utils';
 import { k8sCreate, k8sList, K8sResourceKind } from '../../module/k8s';
@@ -355,11 +355,21 @@ export class CreateRoute extends React.Component<null, CreateRouteState> {
             </React.Fragment>}
           </div> }
           <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress}>
-            <button type="submit"
-              disabled={(!this.state.name || !this.state.service || !this.state.targetPort || (this.state.secure && !this.state.termination))}
-              className="btn btn-primary"
-              id="save-changes">Create</button>
-            <Link to={formatNamespacedRouteForResource('routes')} className="btn btn-default" id="cancel">Cancel</Link>
+            <ActionGroup className="pf-c-form">
+              <Button type="submit"
+                isDisabled={(!this.state.name || !this.state.service || !this.state.targetPort || (this.state.secure && !this.state.termination))}
+                id="save-changes"
+                variant="primary">
+                Create
+              </Button>
+              <Button
+                component="a"
+                href={formatNamespacedRouteForResource('routes')}
+                id="cancel"
+                variant="secondary">
+                Cancel
+              </Button>
+            </ActionGroup>
           </ButtonBar>
         </form>
       </div>

--- a/frontend/public/components/secrets/_create-secret.scss
+++ b/frontend/public/components/secrets/_create-secret.scss
@@ -7,10 +7,6 @@
   position: relative;
 }
 
-.co-create-secret-form__link--add-entry {
-  padding: 0 0 15px 0;
-}
-
 .co-create-secret-form__link--remove-entry {
   display: flex;
   flex-flow: row-reverse;

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -2,6 +2,8 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { Base64 } from 'js-base64';
+import { ActionGroup, Button } from '@patternfly/react-core';
+import { PlusCircleIcon, TimesIcon } from '@patternfly/react-icons';
 
 import { k8sCreate, k8sUpdate, K8sResourceKind, referenceFor } from '../../module/k8s';
 import { ButtonBar, Firehose, history, StatusBox, LoadingBox, Dropdown, resourceObjPath } from '../utils';
@@ -227,17 +229,19 @@ export const withSecretForm = (SubForm, modal?: boolean) => class SecretFormComp
           <p className="co-m-pane__explanation">{this.props.explanation}</p>
           {this.renderBody()}
           <ButtonBar errorMessage={this.state.error} inProgress={this.state.inProgress}>
-            <button
-              type="submit"
-              disabled={this.state.disableForm}
-              className="btn btn-primary"
-              id="save-changes"
-            >
-              {this.props.saveButtonText || 'Create'}
-            </button>
-            <button type="button" className="btn btn-default" id="cancel" onClick={onCancel}>
-              Cancel
-            </button>
+            <ActionGroup className="pf-c-form">
+              <Button
+                type="submit"
+                isDisabled={this.state.disableForm}
+                variant="primary"
+                id="save-changes"
+              >
+                {this.props.saveButtonText || 'Create'}
+              </Button>
+              <Button type="button" variant="secondary" id="cancel" onClick={onCancel}>
+                Cancel
+              </Button>
+            </ActionGroup>
           </ButtonBar>
         </form>
       </div>
@@ -539,9 +543,12 @@ class CreateConfigSubform extends React.Component<CreateConfigSubformProps, Crea
     const secretEntriesList = _.map(this.state.secretEntriesArray, (entryData, index) => {
       return <div className="co-create-secret__form-entry-wrapper" key={entryData.uid}>
         {_.size(this.state.secretEntriesArray) > 1 && <div className="co-create-secret-form__link--remove-entry">
-          <button className="btn btn-link" type="button" onClick={() => this.removeEntry(index)}>
-            <i className="fa fa-minus-circle" aria-hidden="true" /> Remove Credentials
-          </button>
+          <Button
+            onClick={() => this.removeEntry(index)}
+            type="button"
+            variant="link">
+            <TimesIcon /> Remove Credentials
+          </Button>
         </div>}
         <ConfigEntryForm id={index} entry={entryData.entry} onChange={this.onDataChanged} />
       </div>;
@@ -549,9 +556,13 @@ class CreateConfigSubform extends React.Component<CreateConfigSubformProps, Crea
     return (
       <React.Fragment>
         {secretEntriesList}
-        <button className="btn btn-link co-create-secret-form__link--add-entry" type="button" onClick={() => this.addEntry()}>
-          <i className="fa fa-plus-circle" aria-hidden="true" /> Add Credentials
-        </button>
+        <Button
+          className="co-create-secret-form__link--add-entry pf-m-link--align-left"
+          onClick={() => this.addEntry()}
+          type="button"
+          variant="link">
+          <PlusCircleIcon /> Add Credentials
+        </Button>
       </React.Fragment>
     );
   }
@@ -854,9 +865,12 @@ class GenericSecretForm extends React.Component<GenericSecretFormProps, GenericS
     const secretEntriesList = _.map(this.state.secretEntriesArray, (entryData, index) => {
       return <div className="co-create-secret__form-entry-wrapper" key={entryData.uid}>
         {_.size(this.state.secretEntriesArray) > 1 && <div className="co-create-secret-form__link--remove-entry">
-          <button className="btn btn-link" type="button" onClick={() => this.removeEntry(index)}>
-            <i className="fa fa-minus-circle" aria-hidden="true" /> Remove Key/Value
-          </button>
+          <Button
+            type="button"
+            onClick={() => this.removeEntry(index)}
+            variant="link">
+            <TimesIcon /> Remove Key/Value
+          </Button>
         </div>}
         <KeyValueEntryForm id={index} entry={entryData.entry} onChange={this.onDataChanged} />
       </div>;
@@ -864,9 +878,13 @@ class GenericSecretForm extends React.Component<GenericSecretFormProps, GenericS
     return (
       <React.Fragment>
         {secretEntriesList}
-        <button className="btn btn-link co-create-secret-form__link--add-entry" type="button" onClick={() => this.addEntry()}>
+        <Button
+          className="co-create-secret-form__link--add-entry pf-m-link--align-left"
+          onClick={() => this.addEntry()}
+          type="button"
+          variant="link">
           <i className="fa fa-plus-circle" aria-hidden="true" /> Add Key/Value
-        </button>
+        </Button>
       </React.Fragment>
     );
   }

--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -5,7 +5,7 @@ import * as classNames from 'classnames';
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash-es';
 import { Form, FormControl, FormGroup, HelpBlock } from 'patternfly-react';
-
+import { ActionGroup, Button } from '@patternfly/react-core';
 import {
   AsyncComponent,
   ButtonBar,
@@ -857,21 +857,23 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
           </div>
 
           <ButtonBar errorMessage={this.state.error ? this.state.error.message : ''} inProgress={this.state.loading}>
-            <button
-              type="submit"
-              className="btn btn-primary"
-              id="save-changes"
-              disabled={!this.state.validationSuccessful}
-              onClick={this.createStorageClass}>
-              Create
-            </button>
-            <button
-              type="button"
-              className="btn btn-default"
-              id="cancel"
-              onClick={() => history.push('/k8s/cluster/storageclasses')}>
-              Cancel
-            </button>
+            <ActionGroup className="pf-c-form">
+              <Button
+                id="save-changes"
+                isDisabled={!this.state.validationSuccessful}
+                onClick={this.createStorageClass}
+                type="submit"
+                variant="primary">
+                Create
+              </Button>
+              <Button
+                id="cancel"
+                onClick={() => history.push('/k8s/cluster/storageclasses')}
+                type="button"
+                variant="secondary">
+                Cancel
+              </Button>
+            </ActionGroup>
           </ButtonBar>
         </Form>
       </div>

--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
 import { k8sCreate, K8sResourceKind, referenceFor } from '../../module/k8s';
 import {
@@ -267,12 +268,20 @@ class CreatePVCPage extends React.Component<CreatePVCPageProps, CreatePVCPageSta
         <form className="co-m-pane__body-group" onSubmit={this.save}>
           <CreatePVCForm onChange={this.onChange} namespace={namespace} />
           <ButtonBar errorMessage={error} inProgress={inProgress}>
-            <button type="submit" className="btn btn-primary" id="save-changes">
-              Create
-            </button>
-            <button type="button" className="btn btn-default" onClick={history.goBack}>
-              Cancel
-            </button>
+            <ActionGroup className="pf-c-form">
+              <Button
+                id="save-changes"
+                type="submit"
+                variant="primary">
+                Create
+              </Button>
+              <Button
+                onClick={history.goBack}
+                type="button"
+                variant="secondary">
+                Cancel
+              </Button>
+            </ActionGroup>
           </ButtonBar>
         </form>
       </div>

--- a/frontend/public/components/utils/_list-input.scss
+++ b/frontend/public/components/utils/_list-input.scss
@@ -1,7 +1,3 @@
-.co-list-input__add-btn {
-  padding-left: 0;
-}
-
 .co-list-input__help-block {
   margin-bottom: 10px
 }

--- a/frontend/public/components/utils/_name-value-editor.scss
+++ b/frontend/public/components/utils/_name-value-editor.scss
@@ -61,10 +61,6 @@ $drag-row-margin: 8px;
   cursor: move;
 }
 
-.pairs-list__add-icon {
-  margin-right: 6px;
-}
-
 .pairs-list__delete-icon {
   line-height: 35px;
 }

--- a/frontend/public/components/utils/download-button.tsx
+++ b/frontend/public/components/utils/download-button.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { saveAs } from 'file-saver';
-import { Alert } from '@patternfly/react-core';
+import { Alert, Button } from '@patternfly/react-core';
+import { DownloadIcon } from '@patternfly/react-icons';
 
 import { coFetch } from '../../co-fetch';
 
@@ -23,9 +24,9 @@ export const DownloadButton: React.FC<DownloadButtonProps> = (props) => {
   };
 
   return <React.Fragment>
-    <button className="btn btn-primary" style={{marginBottom: 10}} disabled={inFlight} type="button" onClick={() => download()}>
-      <i className="fa fa-fw fa-download" aria-hidden="true" />&nbsp;Download{inFlight && <React.Fragment>ing...</React.Fragment>}
-    </button>
+    <Button variant="primary" style={{marginBottom: 10}} isDisabled={inFlight} type="button" onClick={() => download()}>
+      <DownloadIcon /> Download{inFlight && <React.Fragment>ing...</React.Fragment>}
+    </Button>
     { error && <Alert isInline className="co-alert co-break-word" variant="danger" title={error.toString()} /> }
   </React.Fragment>;
 };

--- a/frontend/public/components/utils/list-input.tsx
+++ b/frontend/public/components/utils/list-input.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
+import { Button } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export class ListInput extends React.Component<ListInputProps, ListInputState> {
   private helpID: string = _.uniqueId('list-view-help-');
@@ -66,9 +68,13 @@ export class ListInput extends React.Component<ListInputProps, ListInputState> {
           </div>
         ))}
         {helpText && <div className="co-list-input__help-block help-block" id={this.helpID}>{helpText}</div>}
-        <button type="button" className="btn btn-link co-list-input__add-btn" onClick={() => this.addValue()}>
-          <i className="fa fa-plus-circle pairs-list__add-icon" aria-hidden="true" />Add More
-        </button>
+        <Button
+          className="pf-m-link--align-left"
+          onClick={() => this.addValue()}
+          type="button"
+          variant="link">
+          <PlusCircleIcon /> Add More
+        </Button>
       </div>
     );
   }

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -4,6 +4,8 @@ import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 import { DragSource, DropTarget } from 'react-dnd';
 import { DRAGGABLE_TYPE } from './draggable-item-types';
+import { Button } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 import { NameValueEditorPair, EnvFromPair, EnvType } from './index';
 import { ValueFromPair } from './value-from-pair';
@@ -78,16 +80,24 @@ export const NameValueEditor = withDragDropContext(class NameValueEditor extends
             readOnly ?
               null :
               <div className="co-toolbar__group co-toolbar__group--left">
-                <button type="button" className="btn btn-link pairs-list__add-btn" onClick={this._append}>
-                  <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />{addString}
-                </button>
+                <Button
+                  className="pf-m-link--align-left"
+                  data-test-id="pairs-list__add-btn"
+                  onClick={this._append}
+                  type="button"
+                  variant="link">
+                  <PlusCircleIcon data-test-id="pairs-list__add-icon" /> {addString}
+                </Button>
                 {
                   addConfigMapSecret &&
                     <React.Fragment>
                       <span aria-hidden="true" className="co-action-divider hidden-xs">|</span>
-                      <button type="button" className="btn btn-link" onClick={this._appendConfigMapOrSecret}>
-                        <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />Add from Config Map or Secret
-                      </button>
+                      <Button
+                        onClick={this._appendConfigMapOrSecret}
+                        type="button"
+                        variant="link">
+                        <PlusCircleIcon data-test-id="pairs-list__add-icon" /> Add from Config Map or Secret
+                      </Button>
                     </React.Fragment>
                 }
               </div>
@@ -189,9 +199,13 @@ export const EnvFromEditor = withDragDropContext(class EnvFromEditor extends Rea
         <div className="col-xs-12">
           {
             !readOnly &&
-            <button type="button" className="btn-link" onClick={this._append}>
-              <i aria-hidden="true" className="fa fa-plus-circle pairs-list__add-icon" />Add All From Config Map or Secret
-            </button>
+            <Button
+              className="pf-m-link--align-left"
+              onClick={this._append}
+              type="button"
+              variant="link">
+              <PlusCircleIcon /> Add All From Config Map or Secret
+            </Button>
           }
         </div>
       </div>

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -76,3 +76,7 @@
 .has-feedback .pf-c-form-control {
   padding-right: 25px;
 }
+
+.pf-c-form__group--no-top-margin {
+  margin-top: 0 !important;
+}

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -96,6 +96,14 @@ kbd {
   max-width: 100%;
 }
 
+.pf-c-button--align-right {
+  margin-left: auto !important;
+}
+
+.pf-c-button.pf-m-link--align-left {
+  padding-left: 0;
+}
+
 // PF components that calculate their correct height based on --pf-global--FontSize--md: 1rem
 .pf-c-modal-box,
 .pf-c-switch {

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -58,6 +58,7 @@
 @import "~@patternfly/patternfly/variables";
 @import "~@patternfly/patternfly/fonts";
 @import "~@patternfly/patternfly/base";
+@import "~@patternfly/patternfly/components/Form/form";
 @import "~@patternfly/patternfly/components/FormControl/form-control";
 @import "~@patternfly/patternfly/components/InputGroup/input-group";
 @import "~@patternfly/patternfly/patternfly-charts";


### PR DESCRIPTION
Includes:
- Buttons that are not within modals 
  - (excluding remove and reorder icon buttons)
  - (excluding "edit yaml" link buttons)
- "Add" field inline buttons
