### PR TITLE
add scale to zero status in non serverless applications

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
@@ -105,6 +105,24 @@ describe('TopologyUtils ', () => {
     );
   });
 
+  it('should return a Scaled to zero pod status in a non-serverless application', () => {
+    // simulate pod are scaled to zero in nodejs deployment.
+    const mockResources = { ...MockResources, pods: { data: [] } };
+    mockResources.deploymentConfigs.data[0].metadata.annotations = {
+      'idling.alpha.openshift.io/idled-at': '2019-04-22T11:58:33Z',
+    };
+    const transformTopologyData = new TransformTopologyData(mockResources);
+    transformTopologyData.transformDataBy('deploymentConfigs');
+    const result = transformTopologyData.getTopologyData();
+    const topologyTransformedData = result.topology;
+    const keys = Object.keys(topologyTransformedData);
+    const status = getPodStatus(
+      (topologyTransformedData[keys[0]].data as WorkloadData).donutStatus.pods[0],
+    );
+    expect(podStatus.includes(status)).toBe(true);
+    expect(status).toEqual('Scaled to 0');
+  });
+
   it('should return false for non knative resource', () => {
     const mockResources = { ...MockResources, pods: { data: [] } };
     const transformTopologyData = new TransformTopologyData(mockResources);

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -294,6 +294,18 @@ export class TransformTopologyData {
   }
 
   /**
+   * check if the deployment/deploymentconfig is idled.
+   * @param deploymentConfig
+   */
+  private isIdled(deploymentConfig: ResourceProps): boolean {
+    return !!_.get(
+      deploymentConfig,
+      "metadata.annotations['idling.alpha.openshift.io/idled-at']",
+      false,
+    );
+  }
+
+  /**
    * Get all the pods from a replication controller or a replicaset.
    * @param replicationController
    */
@@ -313,7 +325,8 @@ export class TransformTopologyData {
     if (
       dcPodsData &&
       !dcPodsData.length &&
-      this.isKnativeServing(replicationController, 'metadata.labels')
+      (this.isKnativeServing(replicationController, 'metadata.labels') ||
+        this.isIdled(deploymentConfig))
     ) {
       return [
         {


### PR DESCRIPTION
Show scale to zero on a nonserverless application in topology

![screencast-localhost-9000-2019 07 16-13-49-27](https://user-images.githubusercontent.com/9964343/61278412-c9f83080-a7d1-11e9-81b0-ef709925db33.gif)

Story: https://jira.coreos.com/browse/ODC-1151