### PR TITLE
Update width if ref width changes

### DIFF
--- a/frontend/public/components/utils/ref-width-hook.ts
+++ b/frontend/public/components/utils/ref-width-hook.ts
@@ -4,17 +4,21 @@ export const useRefWidth = () => {
   const ref = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
 
+  const clientWidth = ref && ref.current && ref.current.clientWidth;
+
   useEffect(() => {
     const handleResize = () => setWidth(ref && ref.current && ref.current.clientWidth);
     window.addEventListener('resize', handleResize);
     window.addEventListener('nav_toggle', handleResize);
-    handleResize();
-
     return () => {
       window.removeEventListener('resize', handleResize);
       window.removeEventListener('nav_toggle', handleResize);
     };
   }, []);
+
+  useEffect(() => {
+    setWidth(clientWidth);
+  }, [clientWidth]);
 
   return [ref, width] as [React.MutableRefObject<HTMLDivElement>, number];
 };


### PR DESCRIPTION
ref width hook reacts only on `resize` and `nav_toggle` events which in some cases may not be enough - component may get rerendered with different size but non of the mentioned events happened.

Actual scenario where this is causing issues is in Grid component https://github.com/openshift/console/blob/master/frontend/public/components/dashboard/grid.tsx#L21 which on the first render renders narrow grid as width is 0 in the beginning. We have various charts as grid items and they compute their width/height also with `ref-width-hook`. Second render of `grid` renders wide grid (width from `width-ref-hook` is populated with actual value) which changes the size of cards (thus size of charts) but charts are not updated with new width because their width didnt change due to `resize` or `nav_toggle`