### PR TITLE
eslint: no-multiple-empty-lines

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -35,6 +35,7 @@
     "default-case": [2],
     "dot-notation": [2],
     "eol-last": [2, "unix"],
+    "no-multiple-empty-lines": [2, {"max": 2, "maxEOF": 0}],
     "eqeqeq": [2, "allow-null"],
     "guard-for-in": 2,
     "import/no-unresolved": ["error"],

--- a/frontend/__tests__/components/namespace.spec.tsx
+++ b/frontend/__tests__/components/namespace.spec.tsx
@@ -38,4 +38,3 @@ describe(PullSecret.displayName, () => {
     expect(wrapper.find(LoadingInline).exists()).toBe(true);
   });
 });
-

--- a/frontend/__tests__/components/utils/download-button.spec.tsx
+++ b/frontend/__tests__/components/utils/download-button.spec.tsx
@@ -40,4 +40,3 @@ describe(DownloadButton.displayName, () => {
     wrapper.find('button').simulate('click');
   });
 });
-

--- a/frontend/public/components/error.tsx
+++ b/frontend/public/components/error.tsx
@@ -96,4 +96,3 @@ export type ErrorComponentProps = {
 
 export type ErrorPageProps = {};
 export type ErrorPage404Props = Omit<ErrorComponentProps, 'title'>;
-

--- a/frontend/public/components/utils/cloud-provider.js
+++ b/frontend/public/components/utils/cloud-provider.js
@@ -10,4 +10,3 @@ export const cloudProviderNames = (providerNames) => {
   return '';
 
 };
-

--- a/frontend/public/components/volumes-table.tsx
+++ b/frontend/public/components/volumes-table.tsx
@@ -187,4 +187,3 @@ type ContainerLinkProps = {
   pod: PodKind;
   name: string;
 };
-

--- a/frontend/public/module/k8s/service-catalog.ts
+++ b/frontend/public/module/k8s/service-catalog.ts
@@ -33,4 +33,3 @@ export const serviceCatalogStatus = (obj: K8sResourceKind) => {
 
   return 'Not Ready';
 };
-


### PR DESCRIPTION
Enforce no extra empty line at the end of a file.

Motivation for this PR is nit-pick in https://github.com/openshift/console/pull/1997#discussion_r303996926 .