### PR TITLE
Query Browser: Add graph tooltip

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -130,6 +130,33 @@
   padding-right: 0;
 }
 
+.query-browser__tooltip {
+  background-color: #151515;
+  color: #eee;
+  overflow: scroll;
+  padding: 15px;
+  z-index: 999999;
+}
+
+.query-browser__tooltip-group {
+  display: flex;
+  margin-bottom: 15px;
+}
+
+.query-browser__tooltip-label-key {
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.query-browser__tooltip-time, .query-browser__tooltip-value {
+  margin-left: auto;
+  padding-left: 15px;
+};
+
+.query-browser__tooltip-value {
+  font-weight: 600;
+}
+
 .query-browser__wrapper {
   border: 1px solid $color-grey-background-border;
   margin: 0 0 20px 0;

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -356,13 +356,16 @@ const getParamsQueries = () => {
     const query = searchParams[`query${i}`];
     queries.push({disabledSeries: [], enabled: true, expanded: true, query, text: query});
   }
-  return queries;
+  return _.isEmpty(queries) ? undefined : queries;
 };
 
 export const QueryBrowserPage = withFallback(() => {
+  // `text` is the current string in the text input and `query` is the value displayed in the graph
+  const defaultQueryObj = {disabledSeries: [], enabled: true, expanded: true, query: '', text: ''};
+
   const [focusedQuery, setFocusedQuery] = React.useState();
   const [metrics, setMetrics] = React.useState();
-  const [queries, setQueries] = React.useState(getParamsQueries());
+  const [queries, setQueries] = React.useState(getParamsQueries() || [defaultQueryObj]);
   const [restoreSelection, setRestoreSelection] = React.useState();
 
   const updateURLParams = () => {
@@ -370,9 +373,6 @@ export const QueryBrowserPage = withFallback(() => {
     _.each(queries, (q, i) => newParams[`query${i}`] = q.text);
     setAllQueryArguments(newParams);
   };
-
-  // `text` is the current string in the text input and `query` is the value displayed in the graph
-  const defaultQueryObj = {disabledSeries: [], enabled: true, expanded: true, query: '', text: ''};
 
   const updateQuery = (i: number, patch: PrometheusQuery) => {
     setQueries(_.map(queries, (q, j) => i === j ? Object.assign({}, q, patch) : q));


### PR DESCRIPTION
Customize the tooltip layout using a SVG `<foreignObject>`.

Some styling is left for a follow up PR, including adding a tooltip arrow.

Also includes a bug fix for displaying a single query input by default.

![screenshot](https://user-images.githubusercontent.com/460802/61392286-6cf79a00-a8f9-11e9-9669-dc95d708a966.png)
