### PR TITLE
Adjust Installed Operator details page layout

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow, ShallowWrapper, mount, ReactWrapper } from 'enzyme';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
+import { CardHeader, CardBody, CardFooter } from '@patternfly/react-core';
 
 import {
   ClusterServiceVersionsDetailsPage,
@@ -172,21 +173,21 @@ describe(CRDCard.displayName, () => {
   it('renders a card with title, body, and footer', () => {
     const wrapper = shallow(<CRDCard canCreate={true} crd={crd} csv={testClusterServiceVersion} />);
 
-    expect(wrapper.find('.co-crd-card__title').exists()).toBe(true);
-    expect(wrapper.find('.co-crd-card__body').exists()).toBe(true);
-    expect(wrapper.find('.co-crd-card__footer').exists()).toBe(true);
+    expect(wrapper.find(CardHeader).exists()).toBe(true);
+    expect(wrapper.find(CardBody).exists()).toBe(true);
+    expect(wrapper.find(CardFooter).exists()).toBe(true);
   });
 
   it('renders a link to create a new instance', () => {
     const wrapper = shallow(<CRDCard canCreate={true} crd={crd} csv={testClusterServiceVersion} />);
 
-    expect(wrapper.find('.co-crd-card__footer').find(Link).props().to).toEqual(`/k8s/ns/${testClusterServiceVersion.metadata.namespace}/${ClusterServiceVersionModel.plural}/${testClusterServiceVersion.metadata.name}/${referenceForProvidedAPI(crd)}/~new`);
+    expect(wrapper.find(CardFooter).find(Link).props().to).toEqual(`/k8s/ns/${testClusterServiceVersion.metadata.namespace}/${ClusterServiceVersionModel.plural}/${testClusterServiceVersion.metadata.name}/${referenceForProvidedAPI(crd)}/~new`);
   });
 
   it('does not render link to create new instance if `props.canCreate` is false', () => {
     const wrapper = shallow(<CRDCard canCreate={false} crd={crd} csv={testClusterServiceVersion} />);
 
-    expect(wrapper.find('.co-crd-card__footer').find(Link).exists()).toBe(false);
+    expect(wrapper.find(CardFooter).find(Link).exists()).toBe(false);
   });
 });
 

--- a/frontend/public/components/operator-lifecycle-manager/_operator-lifecycle-manager.scss
+++ b/frontend/public/components/operator-lifecycle-manager/_operator-lifecycle-manager.scss
@@ -46,39 +46,15 @@
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 15px;
+
+  .pf-c-card {
+    width: 300px;
+    margin-right: 20px;
+    margin-bottom: 20px;
+  }
 }
 
-.co-crd-card {
-  border: 1px solid rgba(209,209,209,0.75);
-  box-shadow: 0 1px 1px rgba(3,3,3,0.175);
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: 0 15px;
-  max-width: 300px;
-  min-width: 300px;
-  margin: 0 20px 20px 0;
-}
 
-.co-crd-card:hover {
-  box-shadow: 0 1px 10px rgba(3,3,3,0.175);
-}
-
-.co-crd-card__title {
-  margin: 15px 0;
-  padding: 0;
-}
-
-.co-crd-card__body {
-  padding: 0 0 15px;
-}
-
-.co-crd-card__footer {
-  background-color: $color-pf-black-100;
-  border-top: 1px solid $color-pf-black-300;
-  margin: 0 -15px !important;
-  padding: 7.5px 15px;
-}
 
 .co-operand-details__compact-expand {
   display: flex;

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -5,7 +5,8 @@ import { connect } from 'react-redux';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { Helmet } from 'react-helmet';
-import { Alert } from '@patternfly/react-core';
+import { AddCircleOIcon } from '@patternfly/react-icons';
+import { Alert, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react-core';
 
 import { ProvidedAPIsPage, ProvidedAPIPage } from './operand';
 import { DetailsPage, ListPage, Table, TableRow, TableData } from '../factory';
@@ -159,21 +160,19 @@ export const CRDCard: React.SFC<CRDCardProps> = (props) => {
   const {csv, crd, canCreate} = props;
   const createRoute = () => `/k8s/ns/${csv.metadata.namespace}/${ClusterServiceVersionModel.plural}/${csv.metadata.name}/${referenceForProvidedAPI(crd)}/~new`;
 
-  return <div className="co-crd-card">
-    <div className="co-crd-card__title">
-      <div style={{display: 'flex', alignItems: 'center', fontWeight: 600}}>
-        <ResourceLink kind={referenceForProvidedAPI(crd)} title={crd.name} linkTo={false} displayName={crd.displayName} />
-      </div>
-    </div>
-    <div className="co-crd-card__body" style={{margin: '0'}}>
+  return <Card>
+    <CardHeader>
+      <ResourceLink kind={referenceForProvidedAPI(crd)} title={crd.name} linkTo={false} displayName={crd.displayName} />
+    </CardHeader>
+    <CardBody>
       <p>{crd.description}</p>
-    </div>
-    { canCreate && <div className="co-crd-card__footer">
-      <Link className="co-crd-card__link" to={createRoute()}>
-        <span className="pficon pficon-add-circle-o" aria-hidden="true"></span> Create New
+    </CardBody>
+    { canCreate && <CardFooter>
+      <Link to={createRoute()}>
+        <AddCircleOIcon /> Create Instance
       </Link>
-    </div> }
-  </div>;
+    </CardFooter> }
+  </Card>;
 };
 
 const crdCardRowStateToProps = ({k8s}, {crdDescs}) => {
@@ -201,6 +200,13 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
     <div className="co-m-pane__body">
       <div className="co-m-pane__body-group">
         <div className="row">
+          <div className="col-sm-9">
+            {status.phase === ClusterServiceVersionPhase.CSVPhaseFailed && <Alert isInline className="co-alert" variant="danger" title={`${status.phase}: ${status.message}`} />}
+            <SectionHeading text="Provided APIs" />
+            <CRDCardRow csv={props.obj} crdDescs={providedAPIsFor(props.obj)} />
+            <SectionHeading text="Description" />
+            <MarkdownView content={spec.description || 'Not available'} />
+          </div>
           <div className="col-sm-3">
             <dl className="co-clusterserviceversion-details__field">
               <dt>Provider</dt>
@@ -224,13 +230,6 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
                 </dd>)
                 : <dd>Not available</dd> }
             </dl>
-          </div>
-          <div className="col-sm-9">
-            {status.phase === ClusterServiceVersionPhase.CSVPhaseFailed && <Alert isInline className="co-alert" variant="danger" title={`${status.phase}: ${status.message}`} />}
-            <SectionHeading text="Provided APIs" />
-            <CRDCardRow csv={props.obj} crdDescs={providedAPIsFor(props.obj)} />
-            <SectionHeading text="Description" />
-            <MarkdownView content={spec.description || 'Not available'} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Changes to Installed Operators > Operator Details page layout and CRD Card according to https://jira.coreos.com/browse/CONSOLE-1461
**Current**
![image](https://user-images.githubusercontent.com/22625502/61405589-2cbbfb80-a8a8-11e9-8aef-0a43018e954d.png)

**Proposed Changes**
![image](https://user-images.githubusercontent.com/22625502/61404999-c2568b80-a8a6-11e9-983e-8fa8f7dc38bf.png)

After further discussion of the design with @alecmerdler and @tlwu2013, the following adjustments were made to the original design:
- Use standard PF4 card instead of the gray background in the design
- Wording of create link in CRD cards was changed to 'Create Instance'
- Don't add the gray background to the metadata details pane
- Do not change the nav items
- Do not add the 'Edit YAML' link in the 'Cluster Service Version' section

**Implemented Changes**
![image](https://user-images.githubusercontent.com/22625502/61404952-a05d0900-a8a6-11e9-936d-f7fa025de8b1.png)

@openshift/team-ux-review 
