### PR TITLE
move route checkbox out of advanced

### DIFF
--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -8,6 +8,7 @@ import ImageSearchSection from './image-search/ImageSearchSection';
 import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
+import RouteCheckbox from './route/RouteCheckbox';
 
 export interface DeployImageFormProps {
   builderImages?: NormalizedBuilderImages;
@@ -36,6 +37,7 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
       <AppSection project={values.project} />
       <ImageSearchSection />
       <ServerlessSection />
+      <RouteCheckbox />
       <AdvancedSection values={values} />
     </div>
     <br />

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -9,6 +9,7 @@ import BuilderSection from './builder/BuilderSection';
 import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
+import RouteCheckbox from './route/RouteCheckbox';
 
 export interface GitImportFormProps {
   builderImages?: NormalizedBuilderImages;
@@ -30,6 +31,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
       <AppSection project={values.project} />
       <ServerlessSection />
       <BuilderSection image={values.image} builderImages={builderImages} />
+      <RouteCheckbox />
       <AdvancedSection values={values} />
     </div>
     <br />

--- a/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
@@ -9,6 +9,7 @@ import BuilderSection from './builder/BuilderSection';
 import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
+import RouteCheckbox from './route/RouteCheckbox';
 
 export interface SourceToImageFormProps {
   builderImages?: NormalizedBuilderImages;
@@ -30,6 +31,7 @@ const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormP
       <ServerlessSection />
       <BuilderSection image={values.image} builderImages={builderImages} />
       <GitSection project={values.project} showSample />
+      <RouteCheckbox />
       <AdvancedSection values={values} />
     </div>
     <br />

--- a/frontend/packages/dev-console/src/components/import/route/RouteCheckbox.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/RouteCheckbox.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { CheckboxField } from '../../formik-fields';
+
+const RouteCheckbox: React.FC = () => {
+  return (
+    <CheckboxField
+      type="checkbox"
+      name="route.create"
+      label="Create a route to the application"
+      helpText="Exposes your application at a public URL"
+    />
+  );
+};
+
+export default RouteCheckbox;

--- a/frontend/packages/dev-console/src/components/import/route/RouteSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/RouteSection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { CheckboxField } from '../../formik-fields';
 import FormSection from '../section/FormSection';
 import CreateRoute from './CreateRoute';
 import SecureRoute from './SecureRoute';
@@ -12,11 +11,6 @@ interface RouteSectionProps {
 const RouteSection: React.FC<RouteSectionProps> = ({ route }) => {
   return (
     <FormSection title="Routing">
-      <CheckboxField
-        type="checkbox"
-        name="route.create"
-        label="Create a route to the application"
-      />
       {route.create && (
         <React.Fragment>
           <CreateRoute />


### PR DESCRIPTION
The route checkbox is always defaulted to on. It was therefore moved out of the hidden advanced section. https://jira.coreos.com/browse/ODC-1358
To make it easier to share, I made it into a component.


![route-checkbox](https://user-images.githubusercontent.com/1184371/61409572-87f1ec00-a8b0-11e9-8ede-ee4a2414fbb8.png)
