### PR TITLE
Query Browser: UX fixes & small refactor

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -320,6 +320,8 @@ const Query: React.FC<QueryProps> = ({colorOffset, metrics, onBlur, onDelete, on
     breakPoint = 'grid2xl';
   }
 
+  const switchLabel = `${enabled ? 'Disable' : 'Enable'} query`;
+
   return <div className={classNames('query-browser__table', {'query-browser__table--expanded': expanded})}>
     <div className="query-browser__query-controls">
       <ExpandButton isExpanded={expanded} onClick={() => onUpdate({expanded: !expanded})} />
@@ -330,7 +332,9 @@ const Query: React.FC<QueryProps> = ({colorOffset, metrics, onBlur, onDelete, on
         onUpdate={v => onUpdate({text: v})}
         value={text}
       />
-      <Switch aria-label={`${enabled ? 'Disable' : 'Enable'} query`} isChecked={enabled} onChange={toggleEnabled} />
+      <div title={switchLabel}>
+        <Switch aria-label={switchLabel} isChecked={enabled} onChange={toggleEnabled} />
+      </div>
       <div className="dropdown-kebab-pf">
         <Kebab options={kebabOptions} />
       </div>

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -367,7 +367,6 @@ export const QueryBrowserPage = withFallback(() => {
   const [focusedQuery, setFocusedQuery] = React.useState();
   const [metrics, setMetrics] = React.useState();
   const [queries, setQueries] = React.useState(getParamsQueries());
-  const [restoreSelection, setRestoreSelection] = React.useState();
 
   const updateURLParams = () => {
     const newParams = {};
@@ -425,8 +424,8 @@ export const QueryBrowserPage = withFallback(() => {
       updateQuery(index, {text});
       target.focus();
 
-      // Restore the cursor position / currently selected text
-      setRestoreSelection([selection.start, selection.start + metric.length]);
+      // Restore the cursor position / currently selected text (use _.defer() to delay until after the input value is set)
+      _.defer(() => target.setSelectionRange(selection.start, selection.start + metric.length));
     } else {
       // No focused query, so add the metric to the end of the first query input
       updateQuery(0, {text: _.get(queries, [0, 'text']) + metric});
@@ -437,12 +436,6 @@ export const QueryBrowserPage = withFallback(() => {
     text: 'sum(sort_desc(sum_over_time(ALERTS{alertstate="firing"}[24h]))) by (alertname)',
     enabled: true,
   });
-
-  React.useEffect(() => {
-    if (focusedQuery && restoreSelection) {
-      focusedQuery.target.setSelectionRange(...restoreSelection);
-    }
-  }, [focusedQuery, restoreSelection]);
 
   let colorOffset = 0;
 

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -54,13 +54,16 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(({defaultSpanText, 
     setText(formatPrometheusDuration(span));
   }, [span]);
 
-  const setSpan = (newText: string) => {
+  const debouncedOnChange = React.useCallback(_.debounce(onChange, 400), [onChange]);
+
+  const setSpan = (newText: string, isDebounced = false) => {
     const newSpan = parsePrometheusDuration(newText);
     const newIsValid = (newSpan > 0);
     setIsValid(newIsValid);
     setText(newText);
     if (newIsValid && newSpan !== span) {
-      onChange(newSpan);
+      const fn = isDebounced ? debouncedOnChange : onChange;
+      fn(newSpan);
     }
   };
 
@@ -69,7 +72,7 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(({defaultSpanText, 
       aria-label="graph timespan"
       className="query-browser__span-text"
       isValid={isValid}
-      onChange={setSpan}
+      onChange={v => setSpan(v, true)}
       type="text"
       value={text}
     />
@@ -78,7 +81,7 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(({defaultSpanText, 
       items={dropdownItems}
       menuClassName="query-browser__span-dropdown-menu"
       noSelection={true}
-      onChange={setSpan}
+      onChange={v => setSpan(v)}
       title="&nbsp;"
     />
     <button


### PR DESCRIPTION
- Add `title` attribute for query `Switch`
  - Add to a wrapping `div` rather than to the `Switch` itself to cover the whole switch area.
- Debounce graph span text input
  - Avoids some unnecessary Prometheus API calls and graph re-renders while editing the span text.
- Refactor cursor position restore
  - Avoids the need to track the cursor position in state.