### PR TITLE
CreateVmWizard: rendered Import provision type conditionally

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/create-vm-wizard.tsx
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { connect } from 'react-redux';
 import {
   CreateVmWizard,
   getResource,
@@ -19,8 +20,18 @@ import {
   VirtualMachineModel,
   NetworkAttachmentDefinitionModel,
   DataVolumeModel,
+  V2VVMwareModel,
 } from '../../models';
 import { createModalResourceLauncher } from './modal-resource-launcher';
+
+const mapStateToProps = ({ k8s }) => {
+  const kindsInFlight = k8s.getIn(['RESOURCES', 'inFlight']);
+  const k8sModels = k8s.getIn(['RESOURCES', 'models']);
+
+  return { isV2vVmwareCrd: !kindsInFlight && !!k8sModels.get(V2VVMwareModel.kind) };
+};
+
+const CreateVmWizardDecorated = connect(mapStateToProps)(CreateVmWizard);
 
 export const openCreateVmWizard = (activeNamespace, createTemplate = false) => {
   const resources = [
@@ -79,7 +90,11 @@ export const openCreateVmWizard = (activeNamespace, createTemplate = false) => {
     };
   };
 
-  const launcher = createModalResourceLauncher(CreateVmWizard, resources, resourcesToProps);
+  const launcher = createModalResourceLauncher(
+    CreateVmWizardDecorated,
+    resources,
+    resourcesToProps,
+  );
 
   // TODO(mlibra): The CreateVmWizard will be refactored later when being moved from web-ui-components to openshift/console, so following props will not be needed. So far we need to meet contract to keep backward compatibility.
   launcher({


### PR DESCRIPTION
The `Import` provision type is newly rendered if related V2VVMware CRD
is present in the cluster only.

With this patch, check for presence of the CRD is passed down to the wizard.

The CRD is expected to be deployed by a not-yet-implemented specialized v2v operator.
This patch is a workaround for the case that other team will not make it till release.