### PR TITLE
Add support for dockerfile build strategy in git import flow

### DIFF
--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -28,8 +28,22 @@ const ODCEmptyState: React.FunctionComponent<Props> = ({ title, activeNamespace 
             <CardHeader>Import from Git</CardHeader>
             <CardBody>Import code from your git repository to be built and deployed </CardBody>
             <CardFooter>
-              <Link className="pf-c-button pf-m-secondary" to="/import">
+              <Link className="pf-c-button pf-m-secondary" to="/import?importType=git">
                 Import from Git
+              </Link>
+            </CardFooter>
+          </Card>
+        </GridItem>
+        <GridItem sm={6} md={6} lg={4}>
+          <Card className="odc-empty-state__card">
+            <CardHeader>Deploy Image</CardHeader>
+            <CardBody>Deploy an existing image from an image registry or image stream tag</CardBody>
+            <CardFooter>
+              <Link
+                className="pf-c-button pf-m-secondary"
+                to={`/deploy-image?preselected-ns=${activeNamespace}`}
+              >
+                Deploy Image
               </Link>
             </CardFooter>
           </Card>
@@ -47,14 +61,11 @@ const ODCEmptyState: React.FunctionComponent<Props> = ({ title, activeNamespace 
         </GridItem>
         <GridItem sm={6} md={6} lg={4}>
           <Card className="odc-empty-state__card">
-            <CardHeader>Deploy Image</CardHeader>
-            <CardBody>Deploy an existing image from an image registry or image stream tag</CardBody>
+            <CardHeader>Import from Dockerfile</CardHeader>
+            <CardBody>Import your Dockerfile from your git repo to be built & deployed</CardBody>
             <CardFooter>
-              <Link
-                className="pf-c-button pf-m-secondary"
-                to={`/deploy-image?preselected-ns=${activeNamespace}`}
-              >
-                Deploy Image
+              <Link className="pf-c-button pf-m-secondary" to="/import?importType=docker">
+                Import from Dockerfile
               </Link>
             </CardFooter>
           </Card>

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -68,6 +68,7 @@ const DeployImage: React.FC<DeployImageProps> = ({ namespace }) => {
         image: true,
         config: true,
       },
+      strategy: 'Source',
     },
     deployment: {
       env: [],

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -3,17 +3,13 @@ import * as _ from 'lodash';
 import { Form, Button } from 'patternfly-react';
 import { FormikProps, FormikValues } from 'formik';
 import { ButtonBar } from '@console/internal/components/utils';
-import { NormalizedBuilderImages } from '../../utils/imagestream-utils';
+import { GitImportFormProps } from './import-types';
 import GitSection from './git/GitSection';
 import BuilderSection from './builder/BuilderSection';
 import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
 import RouteCheckbox from './route/RouteCheckbox';
-
-export interface GitImportFormProps {
-  builderImages?: NormalizedBuilderImages;
-}
 
 const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = ({
   values,

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -42,7 +42,10 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       dir: '/',
       showGitType: false,
       secret: '',
+    },
+    docker: {
       dockerfilePath: 'Dockerfile',
+      containerPort: 8080,
     },
     image: {
       selected: '',

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -1,21 +1,18 @@
 import * as React from 'react';
 import * as plugins from '@console/internal/plugins';
 import { Formik } from 'formik';
-import { history } from '@console/internal/components/utils';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { history, AsyncComponent } from '@console/internal/components/utils';
 import { getActivePerspective } from '@console/internal/reducers/ui';
 import { RootState } from '@console/internal/redux';
 import { connect } from 'react-redux';
 import { NormalizedBuilderImages, normalizeBuilderImages } from '../../utils/imagestream-utils';
-import { GitImportFormData, FirehoseList } from './import-types';
+import { GitImportFormData, FirehoseList, ImportData } from './import-types';
 import { createResources } from './import-submit-utils';
 import { validationSchema } from './import-validation-utils';
-import GitImportForm from './GitImportForm';
-import SourceToImageForm from './SourceToImageForm';
 
 export interface ImportFormProps {
   namespace: string;
-  isS2I: boolean;
+  importData: ImportData;
   imageStreams?: FirehoseList;
 }
 
@@ -26,7 +23,7 @@ export interface StateProps {
 const ImportForm: React.FC<ImportFormProps & StateProps> = ({
   namespace,
   imageStreams,
-  isS2I,
+  importData,
   perspective,
 }) => {
   const initialValues: GitImportFormData = {
@@ -45,6 +42,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       dir: '/',
       showGitType: false,
       secret: '',
+      dockerfilePath: 'Dockerfile',
     },
     image: {
       selected: '',
@@ -84,6 +82,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
         image: true,
         config: true,
       },
+      strategy: importData.buildStrategy || 'Source',
     },
     deployment: {
       env: [],
@@ -121,18 +120,14 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
   };
 
   const handleSubmit = (values, actions) => {
-    const imageStream = builderImages[values.image.selected].obj;
+    const imageStream = builderImages && builderImages[values.image.selected].obj;
 
     const {
       project: { name: projectName },
     } = values;
 
-    const dryRunRequests: Promise<K8sResourceKind[]> = createResources(values, imageStream, true);
-    dryRunRequests
-      .then(() => {
-        const requests: Promise<K8sResourceKind[]> = createResources(values, imageStream);
-        return requests;
-      })
+    createResources(values, imageStream, true)
+      .then(() => createResources(values, imageStream))
       .then(() => {
         actions.setSubmitting(false);
         handleRedirect(projectName);
@@ -143,12 +138,9 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       });
   };
 
-  const renderForm = (props) => {
-    if (isS2I) {
-      return <SourceToImageForm {...props} builderImages={builderImages} />;
-    }
-    return <GitImportForm {...props} builderImages={builderImages} />;
-  };
+  const renderForm = (props) => (
+    <AsyncComponent {...props} builderImages={builderImages} loader={importData.loader} />
+  );
 
   return (
     <Formik

--- a/frontend/packages/dev-console/src/components/import/ImportPage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import { PageHeading, Firehose } from '@console/internal/components/utils';
+import { PageHeading, Firehose, FirehoseResource } from '@console/internal/components/utils';
 import { ImageStreamModel } from '@console/internal/models';
 import ImportForm from './ImportForm';
 import { ImportTypes, ImportData } from './import-types';
@@ -42,8 +42,8 @@ const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match, location 
   const preselectedNamespace = searchParams.get('preselected-ns');
   const importType = searchParams.get('importType');
 
-  let importData;
-  let resources;
+  let importData: ImportData;
+  let resources: FirehoseResource[];
   if (imageStreamName && imageStreamNamespace) {
     importData = ImportFlows.s2i;
     resources = [

--- a/frontend/packages/dev-console/src/components/import/ImportPage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportPage.tsx
@@ -4,8 +4,35 @@ import { Helmet } from 'react-helmet';
 import { PageHeading, Firehose } from '@console/internal/components/utils';
 import { ImageStreamModel } from '@console/internal/models';
 import ImportForm from './ImportForm';
+import { ImportTypes, ImportData } from './import-types';
 
 export type ImportPageProps = RouteComponentProps<{ ns?: string }>;
+
+const ImportFlows: { [name: string]: ImportData } = {
+  git: {
+    type: ImportTypes.git,
+    title: 'Import from git',
+    buildStrategy: 'Source',
+    loader: () =>
+      import('./GitImportForm' /* webpackChunkName: "git-import-form" */).then((m) => m.default),
+  },
+  docker: {
+    type: ImportTypes.docker,
+    title: 'Import from Dockerfile',
+    buildStrategy: 'Docker',
+    loader: () =>
+      import('./GitImportForm' /* webpackChunkName: "git-import-form" */).then((m) => m.default),
+  },
+  s2i: {
+    type: ImportTypes.s2i,
+    title: 'Create Source-to-Image Application',
+    buildStrategy: 'Source',
+    loader: () =>
+      import('./SourceToImageForm' /* webpackChunkName: "source-to-image-form" */).then(
+        (m) => m.default,
+      ),
+  },
+};
 
 const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match, location }) => {
   const namespace = match.params.ns;
@@ -13,26 +40,44 @@ const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match, location 
   const imageStreamName = searchParams.get('imagestream');
   const imageStreamNamespace = searchParams.get('imagestream-ns');
   const preselectedNamespace = searchParams.get('preselected-ns');
-  const isS2I = !!(imageStreamName && imageStreamNamespace);
-  const resources = [
-    {
-      kind: ImageStreamModel.kind,
-      prop: 'imageStreams',
-      isList: !isS2I,
-      ...(isS2I ? { name: imageStreamName, namespace: imageStreamNamespace } : {}),
-    },
-  ];
-  const title = isS2I ? 'Create Source-to-Image Application' : 'Git Import';
+  const importType = searchParams.get('importType');
+
+  let importData;
+  let resources;
+  if (imageStreamName && imageStreamNamespace) {
+    importData = ImportFlows.s2i;
+    resources = [
+      {
+        kind: ImageStreamModel.kind,
+        prop: 'imageStreams',
+        isList: false,
+        name: imageStreamName,
+        namespace: imageStreamNamespace,
+      },
+    ];
+  } else if (importType === ImportTypes.docker) {
+    importData = ImportFlows.docker;
+    resources = [];
+  } else {
+    importData = ImportFlows.git;
+    resources = [
+      {
+        kind: ImageStreamModel.kind,
+        prop: 'imageStreams',
+        isList: true,
+      },
+    ];
+  }
 
   return (
     <React.Fragment>
       <Helmet>
-        <title>{title}</title>
+        <title>{importData.title}</title>
       </Helmet>
-      <PageHeading title={title} />
+      <PageHeading title={importData.title} />
       <div className="co-m-pane__body">
         <Firehose resources={resources}>
-          <ImportForm namespace={namespace || preselectedNamespace} isS2I={isS2I} />
+          <ImportForm namespace={namespace || preselectedNamespace} importData={importData} />
         </Firehose>
       </div>
     </React.Fragment>

--- a/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
@@ -3,17 +3,13 @@ import * as _ from 'lodash';
 import { Form, Button } from 'patternfly-react';
 import { FormikProps, FormikValues } from 'formik';
 import { ButtonBar } from '@console/internal/components/utils';
-import { NormalizedBuilderImages } from '../../utils/imagestream-utils';
+import { SourceToImageFormProps } from './import-types';
 import GitSection from './git/GitSection';
 import BuilderSection from './builder/BuilderSection';
 import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
 import RouteCheckbox from './route/RouteCheckbox';
-
-export interface SourceToImageFormProps {
-  builderImages?: NormalizedBuilderImages;
-}
 
 const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormProps> = ({
   values,

--- a/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
@@ -17,6 +17,10 @@ export const mockFormData: GitImportFormData = {
     showGitType: false,
     secret: '',
   },
+  docker: {
+    dockerfilePath: 'Dockerfile',
+    containerPort: 8080,
+  },
   image: {
     selected: 'nodejs',
     recommended: '',

--- a/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
@@ -46,6 +46,7 @@ export const mockFormData: GitImportFormData = {
       image: true,
       config: true,
     },
+    strategy: 'Source',
   },
   deployment: {
     env: [],

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
@@ -107,5 +107,34 @@ describe('ValidationUtils', () => {
         expect(err.message).toBe('');
       });
     });
+
+    it('should throw an error if dockerfilePath is invalid', async () => {
+      const mockData = cloneDeep(mockFormData);
+      mockData.build.strategy = 'Docker';
+      mockData.docker.dockerfilePath = '/Dockerfile';
+      await validationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
+      await validationSchema.validate(mockData).catch((err) => {
+        expect(err.message).toBe('DockerfilePath must be a relative path');
+      });
+    });
+
+    it('should throw an error if containerPort is not an integer', async () => {
+      const mockData = cloneDeep(mockFormData);
+      mockData.build.strategy = 'Docker';
+      mockData.docker.containerPort = 808.5;
+      await validationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
+      await validationSchema.validate(mockData).catch((err) => {
+        expect(err.message).toBe('Container port should be an Integer');
+      });
+    });
+
+    it('should not disable create button when buildStrategy is docker and no builderImage is available', async () => {
+      const mockData = cloneDeep(mockFormData);
+      mockData.image.selected = '';
+      mockData.build.strategy = 'Docker';
+      await validationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(true));
+      mockData.build.strategy = 'Source';
+      await validationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
+    });
   });
 });

--- a/frontend/packages/dev-console/src/components/import/builder/BuilderSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderSection.tsx
@@ -11,6 +11,10 @@ export interface ImageSectionProps {
 }
 
 const BuilderSection: React.FC<ImageSectionProps> = ({ image, builderImages }) => {
+  if (!builderImages) {
+    return null;
+  }
+
   return (
     <FormSection title="Builder" divider>
       <BuilderImageSelector loadingImageStream={!builderImages} builderImages={builderImages} />

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -84,12 +84,20 @@ const GitSection: React.FC<GitSectionProps> = ({ project, showSample }) => {
         />
       </ExpandCollapse>
       {values.build.strategy === 'Docker' && (
-        <InputField
-          type="text"
-          name="git.dockerfilePath"
-          label="Dockerfile Path"
-          helpText="Allows the builds to use a different path to locate your Dockerfile, relative to the Context Dir field."
-        />
+        <React.Fragment>
+          <InputField
+            type="text"
+            name="docker.dockerfilePath"
+            label="Dockerfile Path"
+            helpText="Allows the builds to use a different path to locate your Dockerfile, relative to the Context Dir field."
+          />
+          <InputField
+            type="number"
+            name="docker.containerPort"
+            label="Container Port"
+            helpText="Port number the container exposes"
+          />
+        </React.Fragment>
       )}
     </FormSection>
   );

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -83,6 +83,14 @@ const GitSection: React.FC<GitSectionProps> = ({ project, showSample }) => {
           helpText="Secret with credentials for pulling your source code."
         />
       </ExpandCollapse>
+      {values.build.strategy === 'Docker' && (
+        <InputField
+          type="text"
+          name="git.dockerfilePath"
+          label="Dockerfile Path"
+          helpText="Allows the builds to use a different path to locate your Dockerfile, relative to the Context Dir field."
+        />
+      )}
     </FormSection>
   );
 };

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -1,5 +1,15 @@
 import { K8sResourceKind, ContainerPort } from '@console/internal/module/k8s';
+import { LazyLoader } from '@console/plugin-sdk/src/typings/types';
 import { NameValuePair, NameValueFromPair } from '../formik-fields/field-types';
+import { NormalizedBuilderImages } from '../../utils/imagestream-utils';
+
+export interface SourceToImageFormProps {
+  builderImages?: NormalizedBuilderImages;
+}
+
+export interface GitImportFormProps {
+  builderImages?: NormalizedBuilderImages;
+}
 
 export interface FirehoseList {
   data?: K8sResourceKind[];
@@ -68,6 +78,7 @@ export interface GitData {
   dir: string;
   showGitType: boolean;
   secret: string;
+  dockerfilePath?: string;
 }
 
 export interface RouteData {
@@ -95,6 +106,7 @@ export interface BuildData {
     config: boolean;
   };
   env: (NameValuePair | NameValueFromPair)[];
+  strategy: string;
 }
 
 export interface DeploymentData {
@@ -123,6 +135,19 @@ export enum GitTypes {
   github = 'GitHub',
   gitlab = 'GitLab',
   bitbucket = 'Bitbucket',
+}
+
+export enum ImportTypes {
+  git = 'git',
+  docker = 'docker',
+  s2i = 's2i',
+}
+
+export interface ImportData {
+  type: ImportTypes;
+  title: string;
+  buildStrategy: string;
+  loader: LazyLoader<GitImportFormProps | SourceToImageFormProps>;
 }
 
 export enum TerminationTypes {

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -37,6 +37,7 @@ export interface GitImportFormData {
   project: ProjectData;
   application: ApplicationData;
   git: GitData;
+  docker: DockerData;
   serverless?: ServerlessData;
   image: ImageData;
   route: RouteData;
@@ -78,7 +79,11 @@ export interface GitData {
   dir: string;
   showGitType: boolean;
   secret: string;
+}
+
+export interface DockerData {
   dockerfilePath?: string;
+  containerPort?: number;
 }
 
 export interface RouteData {

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -5,6 +5,7 @@ import { convertToBaseValue } from '@console/internal/components/utils';
 const urlRegex = /^(((ssh|git|https?):\/\/[\w]+)|(git@[\w]+.[\w]+:))([\w\-._~/?#[\]!$&'()*+,;=])+$/;
 const hostnameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 const pathRegex = /^\/.*$/;
+const relativePathRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\/.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
 
 export const validationSchema = yup.object().shape({
   name: yup.string().required('Required'),
@@ -32,6 +33,15 @@ export const validationSchema = yup.object().shape({
       then: yup.string().required('We failed to detect the git type. Please choose a git type.'),
     }),
     showGitType: yup.boolean(),
+  }),
+  docker: yup.object().when('build', {
+    is: (build) => build.strategy === 'Docker',
+    then: yup.object().shape({
+      dockerfilePath: yup
+        .string()
+        .matches(relativePathRegex, 'DockerfilePath must be a relative path'),
+      containerPort: yup.number().integer('Container port should be an Integer'),
+    }),
   }),
   deployment: yup.object().shape({
     replicas: yup

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -15,9 +15,12 @@ export const validationSchema = yup.object().shape({
     name: yup.string().required('Required'),
     selectedKey: yup.string().required('Required'),
   }),
-  image: yup.object().shape({
-    selected: yup.string().required('Required'),
-    tag: yup.string().required('Required'),
+  image: yup.object().when('build', {
+    is: (build) => build.strategy !== 'Docker',
+    then: yup.object().shape({
+      selected: yup.string().required('Required'),
+      tag: yup.string().required('Required'),
+    }),
   }),
   git: yup.object().shape({
     url: yup
@@ -172,6 +175,9 @@ export const validationSchema = yup.object().shape({
         }),
       limitUnit: yup.string('Unit must be Mi or Gi.'),
     }),
+  }),
+  build: yup.object().shape({
+    strategy: yup.string(),
   }),
 });
 

--- a/frontend/packages/dev-console/src/components/import/route/CreateRoute.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/CreateRoute.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FormGroup } from 'patternfly-react';
 import { useFormikContext, FormikValues } from 'formik';
+import * as _ from 'lodash';
 import { InputField, DropdownField } from '../../formik-fields';
 import { makePortName } from '../../../utils/imagestream-utils';
 
@@ -50,15 +51,17 @@ const CreateRoute: React.FC = () => {
         placeholder="/"
         helpText="Path that the router watches to route traffic to the service."
       />
-      <DropdownField
-        name="route.targetPort"
-        label="Target Port"
-        items={portOptions}
-        selectedKey={targetPort}
-        title={portOptions[targetPort] || 'Select target port'}
-        helpText="Target port for traffic."
-        fullWidth
-      />
+      {!_.isEmpty(ports) && (
+        <DropdownField
+          name="route.targetPort"
+          label="Target Port"
+          items={portOptions}
+          selectedKey={targetPort}
+          title={portOptions[targetPort] || 'Select target port'}
+          helpText="Target port for traffic."
+          fullWidth
+        />
+      )}
     </FormGroup>
   );
 };


### PR DESCRIPTION
Jira story - https://jira.coreos.com/browse/ODC-1154

This PR - 
- Adds support for dockerfile build strategy in git import flow.
- Adds a new card for `Import from dockerfile` in empty state and add page.
- Adds a new input field for `dockerfilePath` in git section.
- Adds support for passing `importType` as a search param in the route to `ImportPage`. importPage now has a `ImportFlows` object that has corresponding data for various import type `git`, `s2i` and `docker`.
- Instead of if else to render correct form component, now `AsyncComponent` is used in `ImportForm`.
- BuilderImage section now gets disabled if no builderimages are available in case of docker strategy.
- Updated submit utils to handle creation of resources based on `Source` as well as `Docker` strategy.

Note:
- In case of docker strategy there is no builder image to get the container ports from. Due to this service and routes are not created automatically. After discussion on #forum-ui channel we decided to add a input field for user to add container port until we have support for reading dockerfile and getting data using git source analysis. This is left to do now for this PR. We'll be updating any UX changes later on as a bug.

Screenshots

![Screenshot from 2019-07-19 05-12-00](https://user-images.githubusercontent.com/20724543/61499336-6d209400-a9e4-11e9-8162-8c031f260a0e.png)

![Screenshot from 2019-07-19 05-12-09](https://user-images.githubusercontent.com/20724543/61499345-77429280-a9e4-11e9-8f1b-7b219bca5346.png)

Update:
- Added container port field.
- Enabled creation of service and route.
- Updated validations to handle both cases for `buildStrategy`.
- Added validations for `dockerfilePath` anf `containerPort`
- Added tests for the validations.

![Screenshot from 2019-07-19 16-57-17](https://user-images.githubusercontent.com/20724543/61532056-50b54380-aa46-11e9-8295-7ea146667954.png)
