### PR TITLE
Query Browser: Align controls with left & right edges of graph & table

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -30,12 +30,7 @@
   flex-wrap: wrap-reverse;
   justify-content: space-between;
   margin-bottom: 15px;
-  padding: 0 20px;
   width: 100%;
-
-  &--graph {
-    padding: 0;
-  }
 }
 
 .query-browser__controls--left {

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -224,7 +224,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   }
 
   return <div className={classNames('query-browser__wrapper', {'graph-empty-state': _.isEmpty(graphData)})}>
-    <div className="query-browser__controls query-browser__controls--graph">
+    <div className="query-browser__controls">
       <div className="query-browser__controls--left">
         <SpanControls defaultSpanText={defaultSpanText} onChange={onSpanChange} span={span} />
         {updating && <div className="query-browser__loading">


### PR DESCRIPTION
Aligns the metrics dropdown on the left and aligns the "Run Queries" button on the right.

![screenshot](https://user-images.githubusercontent.com/460802/61507005-066c9c00-aa1f-11e9-8c75-1c7f1dc4cf32.png)

FYI @cshinn 