### PR TITLE
wire up the routing to the serverless resource

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -233,6 +233,7 @@ export const createResources = async (
     isi: { ports },
     serverless: { scaling },
     limits,
+    route,
   } = formData;
 
   const requests: Promise<K8sResourceKind>[] = [];
@@ -255,6 +256,7 @@ export const createResources = async (
         projectName,
         scaling,
         limits,
+        route,
         imageStreamResponse.status.dockerImageRepository,
       ),
     );

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -318,6 +318,7 @@ export const createResources = async (
     build: { strategy: buildStrategy },
     limits,
     serverless: { scaling },
+    route,
   } = formData;
 
   const requests: Promise<K8sResourceKind>[] = [
@@ -338,6 +339,7 @@ export const createResources = async (
         projectName,
         scaling,
         limits,
+        route,
         imageStreamResponse.status.dockerImageRepository,
       ),
     ]);

--- a/frontend/packages/dev-console/src/components/import/route/RouteSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/RouteSection.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useFormikContext, FormikValues } from 'formik';
 import FormSection from '../section/FormSection';
 import { RouteData } from '../import-types';
 import CreateRoute from './CreateRoute';
@@ -9,12 +10,17 @@ interface RouteSectionProps {
 }
 
 const RouteSection: React.FC<RouteSectionProps> = ({ route }) => {
+  const {
+    values: {
+      serverless: { trigger: serverlessTrigger },
+    },
+  } = useFormikContext<FormikValues>();
   return (
     <FormSection title="Routing">
       {route.create && (
         <React.Fragment>
           <CreateRoute />
-          <SecureRoute />
+          {!serverlessTrigger && <SecureRoute />}
         </React.Fragment>
       )}
     </FormSection>

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -31,9 +31,11 @@ export const createKnativeService = (
   namespace: string,
   scaling: ServerlessScaling,
   limits: LimitsData,
+  { targetPort },
   imageStreamName: string,
   imageStreamTag?: string,
 ): Promise<K8sResourceKind> => {
+  const contTargetPort: number = parseInt(targetPort, 10);
   const { concurrencylimit, concurrencytarget, minpods, maxpods } = scaling;
   const {
     cpu: {
@@ -71,6 +73,13 @@ export const createKnativeService = (
           ...(concurrencylimit && { containerConcurrency: concurrencylimit }),
           container: {
             image: `${imageStreamName}${imageStreamTag ? `:${imageStreamTag}` : ''}`,
+            ...(contTargetPort && {
+              ports: [
+                {
+                  containerPort: contTargetPort,
+                },
+              ],
+            }),
             resources: {
               ...((cpuLimit || memoryLimit) && {
                 limits: {


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/ODC-1363

This adds the `containerPort` to the serverless resource when it gets built. Then the route form can pass the port to it.
Turns off the secure route for serverless.