### PR TITLE
Show Failed Subscriptions in Installed Operator List View

### DIFF
--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -27,8 +27,8 @@ import {
   CSVConditionReason,
   copiedLabelKey,
 } from '../../../public/components/operator-lifecycle-manager';
-import { DetailsPage, ListPage, TableInnerProps, Table, TableRow } from '../../../public/components/factory';
-import { testClusterServiceVersion } from '../../../__mocks__/k8sResourcesMocks';
+import { DetailsPage, TableInnerProps, Table, TableRow, MultiListPage } from '../../../public/components/factory';
+import { testClusterServiceVersion, testSubscription } from '../../../__mocks__/k8sResourcesMocks';
 import {
   Timestamp,
   ResourceLink,
@@ -37,6 +37,7 @@ import {
   ScrollToTopOnMount,
   SectionHeading,
   Firehose,
+  resourceObjPath,
 } from '../../../public/components/utils';
 import { referenceForModel } from '../../../public/module/k8s';
 import { ClusterServiceVersionModel, SubscriptionModel, PackageManifestModel } from '../../../public/models';
@@ -53,11 +54,11 @@ describe(ClusterServiceVersionTableRow.displayName, () => {
   let wrapper: ShallowWrapper<ClusterServiceVersionTableRowProps>;
 
   beforeEach(() => {
-    wrapper = shallow(<ClusterServiceVersionTableRow obj={testClusterServiceVersion} index={0} style={{}} />).childAt(0).shallow();
+    wrapper = shallow(<ClusterServiceVersionTableRow obj={testClusterServiceVersion} subscription={testSubscription} index={0} style={{}} />).childAt(0).shallow();
   });
 
   it('renders a component wrapped in an `ErrorBoundary', () => {
-    wrapper = shallow(<ClusterServiceVersionTableRow obj={testClusterServiceVersion} index={0} style={{}} />);
+    wrapper = shallow(<ClusterServiceVersionTableRow obj={testClusterServiceVersion} subscription={testSubscription} index={0} style={{}} />);
 
     expect(wrapper.find(ErrorBoundary).exists()).toBe(true);
   });
@@ -67,13 +68,13 @@ describe(ClusterServiceVersionTableRow.displayName, () => {
 
     expect(col.find(ResourceKebab).props().resource).toEqual(testClusterServiceVersion);
     expect(col.find(ResourceKebab).props().kind).toEqual(referenceForModel(ClusterServiceVersionModel));
-    expect(col.find(ResourceKebab).props().actions.length).toEqual(1);
+    expect(col.find(ResourceKebab).props().actions.length).toEqual(3);
   });
 
   it('renders clickable column for app logo and name', () => {
     const col = wrapper.find(TableRow).childAt(0);
 
-    expect(col.find(Link).props().to).toEqual(`/k8s/ns/${testClusterServiceVersion.metadata.namespace}/${ClusterServiceVersionModel.plural}/${testClusterServiceVersion.metadata.name}`);
+    expect(col.find(Link).props().to).toEqual(resourceObjPath(testClusterServiceVersion, referenceForModel(ClusterServiceVersionModel)));
     expect(col.find(Link).find(ClusterServiceVersionLogo).exists()).toBe(true);
   });
 
@@ -110,7 +111,7 @@ describe(ClusterServiceVersionTableRow.displayName, () => {
     const col = wrapper.find(TableRow).childAt(4);
     testClusterServiceVersion.spec.customresourcedefinitions.owned.forEach((desc, i) => {
       expect(col.find(Link).at(i).props().title).toEqual(desc.name);
-      expect(col.find(Link).at(i).props().to).toEqual(`/k8s/ns/default/clusterserviceversions/testapp/${referenceForProvidedAPI(desc)}`);
+      expect(col.find(Link).at(i).props().to).toEqual(`${resourceObjPath(testClusterServiceVersion, referenceForModel(ClusterServiceVersionModel))}/${referenceForProvidedAPI(desc)}`);
     });
   });
 });
@@ -145,8 +146,8 @@ describe(ClusterServiceVersionLogo.displayName, () => {
 describe(ClusterServiceVersionList.displayName, () => {
 
   it('renders `List` with correct props', () => {
-    const wrapper = shallow(<ClusterServiceVersionList data={[]} loaded={true} />);
-    expect(wrapper.find<TableInnerProps>(Table).props().Row).toEqual(ClusterServiceVersionTableRow);
+    const wrapper = shallow(<ClusterServiceVersionList data={[]} subscription={{loaded: true, data: [testSubscription], loadError: null}} loaded={true} />);
+
     expect(wrapper.find<TableInnerProps>(Table).props().Header).toEqual(ClusterServiceVersionTableHeader);
   });
 });
@@ -158,10 +159,13 @@ describe(ClusterServiceVersionsPage.displayName, () => {
     wrapper = shallow(<ClusterServiceVersionsPage kind={referenceForModel(ClusterServiceVersionModel)} resourceDescriptions={[]} namespace="foo" />);
   });
 
-  it('renders a `ListPage` with correct props', () => {
-    const listPage = wrapper.find(ListPage);
+  it('renders a `MultiListPage` with correct props', () => {
+    const listPage = wrapper.find(MultiListPage);
 
-    expect(listPage.props().kind).toEqual(referenceForModel(ClusterServiceVersionModel));
+    expect(listPage.props().resources).toEqual([
+      {kind: referenceForModel(ClusterServiceVersionModel), namespace: 'foo', prop: 'clusterServiceVersion'},
+      {kind: referenceForModel(SubscriptionModel), prop: 'subscription'},
+    ]);
     expect(listPage.props().ListComponent).toEqual(ClusterServiceVersionList);
     expect(listPage.props().showTitle).toBe(false);
   });

--- a/frontend/integration-tests/tests/login.scenario.ts
+++ b/frontend/integration-tests/tests/login.scenario.ts
@@ -47,9 +47,8 @@ describe('Auth test', () => {
       expect(sidenavView.navSectionFor('Administration')).not.toContain('Custom Resource Definitions');
     });
 
-    it('does not show admin nav items in Catalog to htpasswd user', async() => {
-      await browser.wait(until.visibilityOf(sidenavView.navSectionFor('Operators')));
-      expect(sidenavView.navSectionFor('Operators')).not.toContain('OperatorHub');
+    it('does not show admin nav items in Operators to htpasswd user', async() => {
+      expect(sidenavView.navSectionFor('Operators').isPresent()).toBe(false);
     });
 
     it('does not show admin nav items in Storage to htpasswd user', async() => {

--- a/frontend/integration-tests/tests/performance.scenario.ts
+++ b/frontend/integration-tests/tests/performance.scenario.ts
@@ -9,7 +9,6 @@ import * as crudView from '../views/crud.view';
 import * as yamlView from '../views/yaml.view';
 
 const chunkedRoutes = OrderedMap<string, {section: string, name: string}>()
-  .set('operator-management', {section: 'Operators', name: 'Operator Management'})
   .set('daemon-set', {section: 'Workloads', name: 'Daemon Sets'})
   .set('deployment', {section: 'Workloads', name: 'Deployments'})
   .set('deployment-config', {section: 'Workloads', name: 'Deployment Configs'})

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -190,7 +190,13 @@ export const menuActions = [
   Kebab.factory.Delete,
 ];
 
-export const menuActionsCreator = (kindObj: K8sKind, vm: VMKind, { vmi, pods, migrations }) => {
+type ExtraResources = { vmi: VMIKind; pods: K8sResourceKind[]; migrations: K8sResourceKind[] };
+
+export const menuActionsCreator = (
+  kindObj: K8sKind,
+  vm: VMKind,
+  { vmi, pods, migrations }: ExtraResources,
+) => {
   const vmStatus = getVmStatus(vm, pods, migrations);
   const migration = findVMIMigration(migrations, vmi);
 

--- a/frontend/packages/metal3-plugin/src/components/host-menu-actions.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host-menu-actions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { asAccessReview, KebabOption } from '@console/internal/components/utils';
-import { k8sKill, K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { k8sKill, K8sKind, K8sResourceKind, MachineKind } from '@console/internal/module/k8s';
 import { getMachineNodeName, getName } from '@console/shared';
 import { confirmModal } from '@console/internal/components/modals';
 import { findNodeMaintenance, getHostMachine, getNodeMaintenanceReason } from '../selectors';
@@ -58,10 +58,12 @@ export const RemoveNodeMaintanance = (
 
 export const menuActions = [SetNodeMaintanance, RemoveNodeMaintanance];
 
+type ExtraResources = { machines: MachineKind[]; nodeMaintenances: K8sResourceKind[] };
+
 export const menuActionsCreator = (
   kindObj: K8sKind,
   host: K8sResourceKind,
-  { machines, nodeMaintenances },
+  { machines, nodeMaintenances }: ExtraResources,
   { hasNodeMaintenanceCapability },
 ) => {
   const machine = getHostMachine(host, machines);

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -143,10 +143,6 @@ const AppContents = connect((state: RootState) => ({
           <LazyRoute path="/provisionedservices/ns/:ns" loader={() => import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(m => m.ProvisionedServicesPage)} />
           <Route path="/provisionedservices" component={NamespaceRedirect} />
 
-          <LazyRoute path="/operatormanagement/all-namespaces" loader={() => import('./operator-management' /* webpackChunkName: "operator-management" */).then(m => m.OperatorManagementPage)} />
-          <LazyRoute path="/operatormanagement/ns/:ns" loader={() => import('./operator-management' /* webpackChunkName: "operator-management" */).then(m => m.OperatorManagementPage)} />
-          <Route path="/operatormanagement" component={NamespaceRedirect} />
-
           <LazyRoute path="/brokermanagement" loader={() => import('./broker-management' /* webpackChunkName: "brokermanagment" */).then(m => m.BrokerManagementPage)} />
 
           <LazyRoute path={`/k8s/ns/:ns/${SubscriptionModel.plural}/~new`} exact loader={() => import('./operator-lifecycle-manager' /* webpackChunkName: "create-subscription-yaml" */).then(m => NamespaceFromURL(m.CreateSubscriptionYAML))} />

--- a/frontend/public/components/modals/disable-application-modal.tsx
+++ b/frontend/public/components/modals/disable-application-modal.tsx
@@ -6,6 +6,7 @@ import { history, resourceListPathFromModel, withHandlePromise } from '../utils'
 import { ClusterServiceVersionKind, SubscriptionKind } from '../operator-lifecycle-manager';
 import { K8sKind, K8sResourceKind } from '../../module/k8s';
 import { ClusterServiceVersionModel, SubscriptionModel } from '../../models';
+import { getActiveNamespace } from '../../actions/ui';
 
 export const DisableApplicationModal = withHandlePromise((props: DisableApplicationModalProps) => {
   const [deleteCSV, setDeleteCSV] = React.useState(true);
@@ -23,8 +24,9 @@ export const DisableApplicationModal = withHandlePromise((props: DisableApplicat
     props.handlePromise(Promise.all(promises)).then(() => {
       props.close();
 
-      if (new RegExp(`/${subscription.metadata.name}(/|$)`).test(window.location.pathname)) {
-        history.push(resourceListPathFromModel(SubscriptionModel, subscription.metadata.namespace));
+      if (window.location.pathname.split('/').includes(subscription.metadata.name)
+        || window.location.pathname.split('/').includes(subscription.status.installedCSV)) {
+        history.push(resourceListPathFromModel(ClusterServiceVersionModel, getActiveNamespace()));
       }
     });
   };

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -9,19 +9,15 @@ import { monitoringReducerName, MonitoringRoutes } from '../../reducers/monitori
 import {
   BuildConfigModel,
   BuildModel,
-  CatalogSourceModel,
   ChargebackReportModel,
   ClusterServiceVersionModel,
   DeploymentConfigModel,
   ImageStreamModel,
-  InstallPlanModel,
   MachineAutoscalerModel,
   MachineConfigModel,
   MachineConfigPoolModel,
   MachineModel,
   MachineSetModel,
-  PackageManifestModel,
-  SubscriptionModel,
 } from '../../models';
 
 import { referenceForModel } from '../../module/k8s';
@@ -35,18 +31,6 @@ type SeparatorProps = {
 const Separator: React.FC<SeparatorProps> = () => <NavItemSeparator />;
 
 const searchStartsWith = ['search'];
-const operatorManagementStartsWith = [
-  referenceForModel(PackageManifestModel),
-  PackageManifestModel.plural,
-  // FIXME(alecmerdler): Needed for backwards-compatibility with new API groups
-  'packages.apps.redhat.com~v1alpha1~PackageManifest',
-  referenceForModel(SubscriptionModel),
-  SubscriptionModel.plural,
-  referenceForModel(InstallPlanModel),
-  InstallPlanModel.plural,
-  referenceForModel(CatalogSourceModel),
-  CatalogSourceModel.plural,
-];
 const provisionedServicesStartsWith = ['serviceinstances', 'servicebindings'];
 const brokerManagementStartsWith = ['clusterservicebrokers', 'clusterserviceclasses'];
 const rolesStartsWith = ['roles', 'clusterroles'];
@@ -102,12 +86,6 @@ const AdminNav = () => (
         resource={ClusterServiceVersionModel.plural}
         required={FLAGS.CAN_LIST_PACKAGE_MANIFEST}
         name="Installed Operators"
-      />
-      <HrefLink
-        href="/operatormanagement"
-        name="Operator Management"
-        activePath="/operatormanagement/"
-        startsWith={operatorManagementStartsWith}
       />
     </NavSection>
 

--- a/frontend/public/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-subscribe.tsx
@@ -4,9 +4,9 @@ import { Helmet } from 'react-helmet';
 import { match } from 'react-router';
 import { Alert } from '@patternfly/react-core';
 
-import { Firehose, history, NsDropdown, resourcePathFromModel, BreadCrumbs, StatusBox } from '../utils';
+import { Firehose, history, NsDropdown, BreadCrumbs, StatusBox, resourceListPathFromModel } from '../utils';
 import { referenceForModel, k8sCreate, apiVersionForModel, kindForReference, apiVersionForReference, k8sListPartialMetadata } from '../../module/k8s';
-import { SubscriptionModel, OperatorGroupModel, PackageManifestModel } from '../../models';
+import { SubscriptionModel, OperatorGroupModel, PackageManifestModel, ClusterServiceVersionModel } from '../../models';
 import {
   OperatorGroupKind,
   PackageManifestKind,
@@ -125,7 +125,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
       ? Promise.resolve()
       : k8sCreate(OperatorGroupModel, operatorGroup))
       .then(() => k8sCreate(SubscriptionModel, subscription))
-      .then(() => history.push(resourcePathFromModel(SubscriptionModel, packageName, subscription.metadata.namespace)));
+      .then(() => history.push(resourceListPathFromModel(ClusterServiceVersionModel, targetNamespace || props.targetNamespace || selectedTargetNamespace)));
   };
 
   const formValid = () => [selectedUpdateChannel, selectedInstallMode, selectedTargetNamespace, selectedApproval].some(v => _.isNil(v) || _.isEmpty(v))

--- a/frontend/public/components/operator-lifecycle-manager/_operator-lifecycle-manager.scss
+++ b/frontend/public/components/operator-lifecycle-manager/_operator-lifecycle-manager.scss
@@ -111,11 +111,9 @@
   margin-bottom: 20px;
 }
 
-.co-clusterserviceversion-list__disabled-icon {
-  margin: 10px;
-  width: 100px;
-  height: 100px;
-  filter: grayscale(100%);
+.co-clusterserviceversion-row__status {
+  display: flex;
+  flex-direction: column;
 }
 
 .co-spec-descriptor--resource-requirements {

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -7,14 +7,15 @@ import { sortable } from '@patternfly/react-table';
 import { Helmet } from 'react-helmet';
 import { Alert } from '@patternfly/react-core';
 
-import { SuccessStatus, ErrorStatus } from '@console/shared';
+import { SuccessStatus, ErrorStatus, ProgressStatus } from '@console/shared';
 import { ProvidedAPIsPage, ProvidedAPIPage } from './operand';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from '../factory';
+import { DetailsPage, Table, TableRow, TableData, MultiListPage } from '../factory';
 import { withFallback } from '../utils/error-boundary';
-import { referenceForModel, referenceFor, GroupVersionKind, K8sKind } from '../../module/k8s';
+import { referenceForModel, referenceFor, GroupVersionKind, K8sKind, k8sKill, k8sPatch, k8sGet } from '../../module/k8s';
 import { ClusterServiceVersionModel, SubscriptionModel, PackageManifestModel } from '../../models';
 import { ResourceEventStream } from '../events';
 import { Conditions } from '../conditions';
+import { createDisableApplicationModal } from '../modals/disable-application-modal';
 import {
   ClusterServiceVersionKind,
   ClusterServiceVersionLogo,
@@ -27,6 +28,7 @@ import {
   SubscriptionKind,
   PackageManifestKind,
   copiedLabelKey,
+  SubscriptionState,
 } from './index';
 import {
   Kebab,
@@ -45,6 +47,9 @@ import {
   FirehoseResult,
   StatusBox,
   Page,
+  resourcePathFromModel,
+  KebabOption,
+  resourceObjPath,
 } from '../utils';
 import { operatorGroupFor, operatorNamespaceFor } from './operator-group';
 import { SubscriptionDetails } from './subscription';
@@ -81,20 +86,50 @@ export const ClusterServiceVersionTableHeader = () => {
     },
   ];
 };
-ClusterServiceVersionTableHeader.displayName = 'ClusterServiceVersionTableHeader';
 
-const menuActions = [Kebab.factory.Edit];
+const editSubscription = (sub: SubscriptionKind) => !_.isNil(sub)
+  ? ({
+    label: 'Edit Subscription',
+    href: `${resourcePathFromModel(SubscriptionModel, sub.metadata.name, sub.metadata.namespace)}/yaml`,
+  }) as KebabOption
+  : null;
+const uninstall = (sub: SubscriptionKind) => !_.isNil(sub)
+  ? ({
+    label: 'Uninstall Operator',
+    callback: () => createDisableApplicationModal({k8sKill, k8sGet, k8sPatch, subscription: sub}),
+    accessReview: {
+      group: SubscriptionModel.apiGroup,
+      resource: SubscriptionModel.plural,
+      name: sub.metadata.name,
+      namespace: sub.metadata.namespace,
+      verb: 'delete',
+    },
+  }) as KebabOption
+  : null;
 
-export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionTableRowProps>(({obj, index, key, style}) => {
-  const route = `/k8s/ns/${obj.metadata.namespace}/${ClusterServiceVersionModel.plural}/${obj.metadata.name}`;
+export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionTableRowProps>((props) => {
+  const {obj, index, key, style, subscription} = props;
 
+  const route = resourceObjPath(obj, referenceForModel(ClusterServiceVersionModel));
   const statusString = _.get(obj, 'status.reason', ClusterServiceVersionPhase.CSVPhaseUnknown);
   const showSuccessIcon = statusString === 'Copied' || statusString === 'InstallSucceeded';
+  const subscriptionState = (state: SubscriptionState) => {
+    switch (state) {
+      case SubscriptionState.SubscriptionStateUpgradeAvailable: return 'Upgrade available';
+      case SubscriptionState.SubscriptionStateUpgradePending: return 'Upgrading';
+      case SubscriptionState.SubscriptionStateAtLatest: return 'Up to date';
+      default: return '';
+    }
+  };
   const installStatus = obj.status && obj.status.phase !== ClusterServiceVersionPhase.CSVPhaseFailed
-    ? <span className={classNames(showSuccessIcon && 'co-icon-and-text')}>{showSuccessIcon &&
+    ? <span className={classNames({'co-icon-and-text': showSuccessIcon})}>{showSuccessIcon &&
         <SuccessStatus title={statusString} />}
     </span>
     : <span className="co-error co-icon-and-text"><ErrorStatus title="Failed" /></span>;
+  const menuActions = [Kebab.factory.Edit].concat(!_.isNil(subscription)
+    ? [() => editSubscription(subscription), () => uninstall(subscription)]
+    : []);
+
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -109,7 +144,10 @@ export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionT
         <ResourceLink kind="Deployment" name={obj.spec.install.spec.deployments[0].name} namespace={operatorNamespaceFor(obj)} title={obj.spec.install.spec.deployments[0].name} />
       </TableData>
       <TableData className={tableColumnClasses[3]}>
-        {obj.metadata.deletionTimestamp ? 'Disabling' : installStatus}
+        <div className="co-clusterserviceversion-row__status">
+          { obj.metadata.deletionTimestamp ? 'Disabling' : installStatus }
+          { subscription && <span className="text-muted">{subscriptionState(_.get(subscription.status, 'state'))}</span> }
+        </div>
       </TableData>
       <TableData className={tableColumnClasses[4]}>
         { _.take(providedAPIsFor(obj), 4).map((desc, i) => <div key={i}>
@@ -124,10 +162,58 @@ export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionT
   );
 });
 
+export const FailedSubscriptionTableRow: React.FC<FailedSubscriptionTableRowProps> = (props) => {
+  const {obj, index, key, style} = props;
+
+  const route = resourceObjPath(obj, referenceForModel(SubscriptionModel));
+  const menuActions = [Kebab.factory.Edit, () => uninstall(obj)];
+  const subscriptionState = _.get(obj.status, 'state', 'Unknown');
+
+  return <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+    <TableData className={tableColumnClasses[0]}>
+      <Link to={route}>
+        <ClusterServiceVersionLogo icon={null} displayName={obj.spec.name} version={null} provider={null} />
+      </Link>
+    </TableData>
+    <TableData className={tableColumnClasses[1]}>
+      <ResourceLink kind="Namespace" title={obj.metadata.namespace} name={obj.metadata.namespace} />
+    </TableData>
+    <TableData className={tableColumnClasses[2]}>
+      <span className="text-muted">None</span>
+    </TableData>
+    <TableData className={tableColumnClasses[3]}>
+      { ['Unknown', SubscriptionState.SubscriptionStateFailed].includes(subscriptionState) && <span className="co-icon-and-text co-error">
+        <ErrorStatus title={subscriptionState} />
+      </span> }
+      { subscriptionState === SubscriptionState.SubscriptionStateUpgradePending && <span className="co-icon-and-text">
+        <ProgressStatus title={subscriptionState} />
+      </span>}
+    </TableData>
+    <TableData className={tableColumnClasses[4]}>
+      <span className="text-muted">None</span>
+    </TableData>
+    <TableData className={tableColumnClasses[5]}>
+      <ResourceKebab resource={obj} kind={referenceFor(obj)} actions={menuActions} />
+    </TableData>
+  </TableRow>;
+};
+
+const subscriptionFor = (csv: ClusterServiceVersionKind) => (subs: SubscriptionKind[]) => subs.find(sub => {
+  return sub.metadata.namespace === csv.metadata.annotations['olm.operatorNamespace'] && _.get(sub.status, 'installedCSV') === csv.metadata.name;
+});
+
 export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps> = (props) => {
   const EmptyMsg = () => <MsgBox title="No Cluster Service Versions Found" detail="" />;
 
-  return <Table {...props} aria-label="Installed Operators" Header={ClusterServiceVersionTableHeader} Row={ClusterServiceVersionTableRow} EmptyMsg={EmptyMsg} virtualize />;
+  return <Table
+    {...props}
+    aria-label="Installed Operators"
+    Header={ClusterServiceVersionTableHeader}
+    Row={(rowProps) => referenceFor(rowProps.obj) === referenceForModel(ClusterServiceVersionModel)
+      ? <ClusterServiceVersionTableRow {...rowProps} subscription={subscriptionFor(rowProps.obj)(_.get(props.subscription, 'data', []))} />
+      : <FailedSubscriptionTableRow {...rowProps} />}
+    EmptyMsg={EmptyMsg}
+    virtualize />;
 };
 
 export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProps> = (props) => {
@@ -141,10 +227,17 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
       <title>{title}</title>
     </Helmet>
     <PageHeading title={title} />
-    <ListPage
+    <MultiListPage
       {...props}
+      resources={[
+        {kind: referenceForModel(ClusterServiceVersionModel), namespace: props.namespace, prop: 'clusterServiceVersion'},
+        {kind: referenceForModel(SubscriptionModel), prop: 'subscription'},
+      ]}
+      flatten={({clusterServiceVersion, subscription}) => _.get(clusterServiceVersion, 'data', [] as ClusterServiceVersionKind[])
+        .concat(_.get(subscription, 'data', [] as SubscriptionKind[])
+          .filter(sub => ['', sub.metadata.namespace].includes(props.namespace) && _.isNil(_.get((sub as SubscriptionKind).status, 'installedCSV'))))
+      }
       namespace={props.namespace}
-      kind={referenceForModel(ClusterServiceVersionModel)}
       ListComponent={ClusterServiceVersionList}
       helpText={helpText}
       showTitle={false} />
@@ -310,6 +403,10 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
         component: React.memo(() => <ProvidedAPIPage csv={obj} kind={referenceForProvidedAPI(desc)} namespace={obj.metadata.namespace} />, (_.isEqual)),
       })));
   };
+  type ExtraResources = {subscription: SubscriptionKind[]};
+  const menuActions = (model, obj: ClusterServiceVersionKind, {subscription}: ExtraResources) => [Kebab.factory.Edit(model, obj)].concat(!_.isNil(subscriptionFor(obj)(subscription))
+    ? [editSubscription(subscriptionFor(obj)(subscription)), uninstall(subscriptionFor(obj)(subscription))]
+    : []);
 
   const pagesFor = React.useCallback((obj: ClusterServiceVersionKind) => _.compact([
     navFactory.details(ClusterServiceVersionDetails),
@@ -329,6 +426,7 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
       {name: 'Installed Operators', path: `/k8s/ns/${props.match.params.ns}/${props.match.params.plural}`},
       {name: 'Operator Details', path: props.match.url},
     ]}
+    resources={[{kind: referenceForModel(SubscriptionModel), isList: true, prop: 'subscription'}]}
     namespace={props.match.params.ns}
     kind={referenceForModel(ClusterServiceVersionModel)}
     name={props.match.params.name}
@@ -346,6 +444,7 @@ export type ClusterServiceVersionListProps = {
   loaded: boolean;
   loadError?: string;
   data: ClusterServiceVersionKind[];
+  subscription: FirehoseResult<SubscriptionKind[]>
 };
 
 export type CRDCardProps = {
@@ -374,6 +473,14 @@ export type ClusterServiceVersionDetailsProps = {
 
 export type ClusterServiceVersionTableRowProps = {
   obj: ClusterServiceVersionKind;
+  subscription: SubscriptionKind;
+  index: number;
+  key?: string;
+  style: object;
+};
+
+export type FailedSubscriptionTableRowProps = {
+  obj: SubscriptionKind;
   index: number;
   key?: string;
   style: object;
@@ -386,6 +493,8 @@ export type CSVSubscriptionProps = {
 // TODO(alecmerdler): Find Webpack loader/plugin to add `displayName` to React components automagically
 ClusterServiceVersionList.displayName = 'ClusterServiceVersionList';
 ClusterServiceVersionsPage.displayName = 'ClusterServiceVersionsPage';
+ClusterServiceVersionTableRow.displayName = 'ClusterServiceVersionTableRow';
+ClusterServiceVersionTableHeader.displayName = 'ClusterServiceVersionTableHeader';
 CRDCard.displayName = 'CRDCard';
 ClusterServiceVersionsDetailsPage.displayName = 'ClusterServiceVersionsDetailsPage';
 ClusterServiceVersionDetails.displayName = 'ClusterServiceVersionDetails';

--- a/frontend/public/components/operator-lifecycle-manager/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/index.tsx
@@ -52,6 +52,7 @@ export enum InstallPlanApproval {
 
 export enum SubscriptionState {
   SubscriptionStateNone = '',
+  SubscriptionStateFailed = 'UpgradeFailed',
   SubscriptionStateUpgradeAvailable = 'UpgradeAvailable',
   SubscriptionStateUpgradePending = 'UpgradePending',
   SubscriptionStateAtLatest = 'AtLatestKnown',

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -98,7 +98,12 @@ export type BreadCrumbsProps = {
   breadcrumbs: {name: string, path: string}[];
 };
 
-export type KebabOptionsCreator = (...args: Parameters<KebabAction>) => KebabOption[];
+export type KebabOptionsCreator = (
+  kindObj: K8sKind,
+  data: K8sResourceKind,
+  extraResources?: {[prop: string]: K8sResourceKind | K8sResourceKind[]},
+  customData?: any
+) => KebabOption[];
 
 export type PageHeadingProps = {
   breadcrumbsFor?: (obj: K8sResourceKind) => {name: string, path: string}[];

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -4,14 +4,14 @@ import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 
 import { ResourceIcon } from './index';
-import { modelFor, referenceForModel } from '../../module/k8s';
+import { modelFor, referenceForModel, K8sKind, K8sResourceKindReference, K8sResourceKind } from '../../module/k8s';
 import { connectToModel } from '../../kinds';
 import { connectToFlags } from '../../reducers/features';
 import { FLAGS } from '../../const';
 
 const unknownKinds = new Set();
 
-export const resourcePathFromModel = (model, name, namespace) => {
+export const resourcePathFromModel = (model: K8sKind, name?: string, namespace?: string) => {
   const {plural, namespaced, crd} = model;
 
   let url = '/k8s/';
@@ -37,12 +37,12 @@ export const resourcePathFromModel = (model, name, namespace) => {
   return url;
 };
 
-export const resourceListPathFromModel = (model, namespace) => resourcePathFromModel(model, null, namespace);
+export const resourceListPathFromModel = (model: K8sKind, namespace: string) => resourcePathFromModel(model, null, namespace);
 
 /**
  * NOTE: This will not work for runtime-defined resources. Use a `connect`-ed component like `ResourceLink` instead.
  */
-export const resourcePath = (kind, name, namespace) => {
+export const resourcePath = (kind: K8sResourceKindReference, name: string, namespace: string) => {
   const model = modelFor(kind);
   if (!model) {
     if (!unknownKinds.has(kind)) {
@@ -56,7 +56,7 @@ export const resourcePath = (kind, name, namespace) => {
   return resourcePathFromModel(model, name, namespace);
 };
 
-export const resourceObjPath = (obj, kind) => resourcePath(kind, _.get(obj, 'metadata.name'), _.get(obj, 'metadata.namespace'));
+export const resourceObjPath = (obj: K8sResourceKind, kind: K8sResourceKindReference) => resourcePath(kind, _.get(obj, 'metadata.name'), _.get(obj, 'metadata.namespace'));
 
 export const ResourceLink = connectToModel(
   ({className, displayName, inline = false, kind, linkTo = true, name, namespace, hideIcon, title, children}) => {
@@ -74,9 +74,7 @@ export const ResourceLink = connectToModel(
     </span>;
   });
 
-ResourceLink.displayName = 'ResourceLink';
-
-const NodeLink_ = (props) => {
+const NodeLink_: React.FC<NodeLinkProps> = (props) => {
   const {name, flags} = props;
   if (!name) {
     return <React.Fragment>-</React.Fragment>;
@@ -86,4 +84,11 @@ const NodeLink_ = (props) => {
     : <React.Fragment>{name}</React.Fragment>;
 };
 
-export const NodeLink = connectToFlags(FLAGS.CAN_LIST_NODE)(NodeLink_);
+export const NodeLink = connectToFlags<NodeLinkProps>(FLAGS.CAN_LIST_NODE)(NodeLink_);
+
+type NodeLinkProps = {
+  name: string;
+  flags: {[key: string]: boolean};
+};
+
+ResourceLink.displayName = 'ResourceLink';


### PR DESCRIPTION
### Description

Combine `ClusterServiceVersions` with `Subscriptions` in the **Installed Operators** list view. If a `Subscription` fails in some way, there won't be an associated `ClusterServiceVersion` object to view, yet the admin should be aware of the Operator's failed status. Previously, this was done using the **Operator Management** tab, but UX wants this section removed in favor of "unified" list/detail views.

### Changes

- [x] Removes **Operator Management** navbar tab
- [x] Combines `ClusterServiceVersions` and failed `Subscriptions` into **Installed Operators** list view
- [x] Updates "Create Operator Subscription" flow to redirect to **Installed Operators**
- [x] Adds "Edit Subscription" and "Uninstall Operator" to menu/kebab actions

### Screenshots

**Installed Operators list view (failed `Subscriptions`):**
![Screenshot_20190718_161553](https://user-images.githubusercontent.com/11700385/61488888-5859e700-a977-11e9-84af-a35bb741b2b6.png)

**Installed Operators list view (in-progress `Subscription`):**
![Screenshot_20190719_130524](https://user-images.githubusercontent.com/11700385/61552487-f4dac280-aa25-11e9-8e0b-70a6981d30cb.png)

**Kebab actions (successfully installed):**
![Screenshot_20190719_125936](https://user-images.githubusercontent.com/11700385/61552177-16877a00-aa25-11e9-8af8-9f53b3307b13.png)

Addresses https://jira.coreos.com/browse/CONSOLE-1521