### PR TITLE
Add new separate suite for release prow job

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -150,6 +150,18 @@ export const config: Config = {
       'tests/monitoring.scenario.ts',
       'tests/crd-extensions.scenario.ts',
     ]),
+    release: suite([
+      'tests/crud.scenario.ts',
+      'tests/secrets.scenario.ts',
+      'tests/filter.scenario.ts',
+      'tests/environment.scenario.ts',
+      'tests/overview/overview.scenario.ts',
+      'tests/source-to-image.scenario.ts',
+      'tests/deploy-image.scenario.ts',
+      'tests/performance.scenario.ts',
+      'tests/monitoring.scenario.ts',
+      'tests/crd-extensions.scenario.ts',
+    ]),
     all: suite([
       'tests/crud.scenario.ts',
       'tests/overview/overview.scenareio.ts',


### PR DESCRIPTION
@spadgett I removed only annotation tests out of full e2e test suite since I am not very sure which kind of test else is more flaky. Please let me know if any other test you think it should  be remove as well. PTAL, thanks.