### PR TITLE
Fix Bug to disable project selector in git import form when a project is in the context

### DIFF
--- a/frontend/integration-tests/tests/deploy-image.scenario.ts
+++ b/frontend/integration-tests/tests/deploy-image.scenario.ts
@@ -12,14 +12,27 @@ describe('Deploy Image', () => {
   const imageName = 'mysql';
 
   describe('Deploy Image page', () => {
-    it('should auto-fill the namespace/project', async() => {
+    it('should render project/namespace dropdown when all-namespace is selected', async() => {
       // Navigate to the deploy-image page
-      await browser.get(`${appHost}/deploy-image/ns/${testName}?preselected-ns=${testName}`);
+      await browser.get(`${appHost}/deploy-image/all-namespaces`);
 
-      const nsSpan = '#namespace-dropdown-project-name-field .btn-dropdown__content-wrap .co-resource-item__resource-name';
+      const nsSpan =
+        '#namespace-dropdown-project-name-field .btn-dropdown__content-wrap .pf-c-dropdown__toggle-text .pf-c-dropdown__toggle-text--placeholder';
       // Wait for the Project field to appear
       await browser.wait(until.presenceOf(element(by.css(nsSpan))));
       // Confirm that the project field has the right text
+      expect(element(by.css(nsSpan)).getText()).toEqual('Select namespace');
+    });
+
+    it('should render project/namespace dropdown disabled when in a project context', async() => {
+      // Navigate to the deploy-image page
+      await browser.get(`${appHost}/deploy-image/ns/${testName}?preselected-ns=${testName}`);
+
+      const nsSpan =
+        '#namespace-dropdown-project-name-field .btn-dropdown__content-wrap .pf-c-dropdown__toggle-text .co-resource-item .co-resource-item__resource-name';
+      // Wait for the Project field to appear
+      await browser.wait(until.presenceOf(element(by.css(nsSpan))));
+      // Confirm that the project field does not exist
       expect(element(by.css(nsSpan)).getText()).toEqual(testName);
     });
 
@@ -38,12 +51,16 @@ describe('Deploy Image', () => {
 
     it('should fill in the application', async() => {
       // Set the application name
+      // Wait for the Application Dropdown field to appear
+      await browser.wait(
+        until.elementToBeClickable(element(by.id('application-form-app-dropdown'))),
+      );
       // Click on the dropdown
       await element(by.id('application-form-app-dropdown')).click();
       // Wait for the Create Application button to appear
-      await browser.wait(until.presenceOf(element(by.id('create-application-key-link'))));
+      await browser.wait(until.presenceOf(element(by.id('#CREATE_APPLICATION_KEY#-link'))));
       // Click on the Create New Application button
-      await element(by.id('create-application-key-link')).click();
+      await element(by.id('#CREATE_APPLICATION_KEY#-link')).click();
       // Wait for the Application Name field to appear
       await browser.wait(until.presenceOf(element(by.id('form-input-application-name-field'))));
       // Enter the new Application name

--- a/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
@@ -18,6 +18,7 @@ export interface DropdownFieldProps extends InputFieldProps {
   selectedKey?: string;
   title?: React.ReactNode;
   fullWidth?: boolean;
+  disabled?: boolean;
 }
 
 export interface EnvironmentFieldProps extends InputFieldProps {

--- a/frontend/packages/dev-console/src/components/import/app/AppSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/app/AppSection.tsx
@@ -15,7 +15,7 @@ const AppSection: React.FC<AppSectionProps> = ({ project }) => {
         data-test-id="application-form-namespace-dropdown"
         name="project.name"
         label="Project"
-        selectedKey={project.name}
+        disabled={!!project.name}
         fullWidth
         required
       />

--- a/frontend/packages/dev-console/src/components/import/app/ApplicationSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/app/ApplicationSelector.tsx
@@ -5,7 +5,7 @@ import { InputField } from '../../formik-fields';
 import { getValidationState } from '../../formik-fields/field-utils';
 import ApplicationDropdown from '../../dropdown/ApplicationDropdown';
 
-export const CREATE_APPLICATION_KEY = 'create-application-key';
+export const CREATE_APPLICATION_KEY = '#CREATE_APPLICATION_KEY#';
 
 export interface ApplicationSelectorProps {
   namespace?: string;

--- a/frontend/public/components/utils/list-dropdown.jsx
+++ b/frontend/public/components/utils/list-dropdown.jsx
@@ -95,7 +95,7 @@ class ListDropdown_ extends React.Component {
   }
 
   render() {
-    const {desc, fixed, placeholder, id, loaded} = this.props;
+    const {desc, fixed, placeholder, id, loaded, disabled} = this.props;
     const items = {};
 
     _.keys(this.state.items).forEach(key => {
@@ -116,7 +116,8 @@ class ListDropdown_ extends React.Component {
         onChange={this.onChange}
         id={id}
         dropDownClassName="dropdown--full-width"
-        menuClassName="dropdown-menu--text-wrap" />;
+        menuClassName="dropdown-menu--text-wrap"
+        disabled={disabled} />;
 
     return <div>
       { Component }


### PR DESCRIPTION
Fixes - https://jira.coreos.com/browse/ODC-689

- Now project selector is hidden in Git Import form if a project is already selected in context.
- Makes `CREATE_APPLICATION_KEY` unique.
- Fixes e2e test for deploy image based on above changes.

Screenshot - 
<img width="719" alt="Screenshot 2019-07-29 at 6 00 53 PM" src="https://user-images.githubusercontent.com/6041994/62048679-207e5980-b22b-11e9-8b6e-86077bfb305d.png">

<img width="741" alt="Screenshot 2019-07-29 at 6 01 12 PM" src="https://user-images.githubusercontent.com/6041994/62048685-22e0b380-b22b-11e9-96c5-b74196b12397.png">



