### PR TITLE
Fix bug where builds are shown in the wrong order in resources tab of topoplogy view

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import { K8sResourceKind, LabelSelector } from '@console/internal/module/k8s';
 import { getRouteWebURL } from '@console/internal/components/routes';
 import { KNATIVE_SERVING_LABEL } from '@console/knative-plugin';
+import { sortBuilds } from '@console/internal/components/overview';
 import { TopologyDataResources, ResourceProps, TopologyDataModel } from './topology-types';
 
 export const podColor = {
@@ -345,10 +346,10 @@ export class TransformTopologyData {
 
   private getBuildConfigs(
     deploymentConfig: ResourceProps,
-  ): ResourceProps & { builds: ResourceProps[] } {
+  ): ResourceProps & { builds: K8sResourceKind[] } {
     const buildConfig = {
       kind: 'BuildConfig',
-      builds: [] as ResourceProps[],
+      builds: [] as K8sResourceKind[],
       metadata: {},
       status: {},
       spec: {},
@@ -360,7 +361,7 @@ export class TransformTopologyData {
     ]);
     if (bconfig) {
       const bc = _.merge(buildConfig, bconfig);
-      const builds = this.getBuilds(bc);
+      const builds = sortBuilds(this.getBuilds(bc));
       return { ...bc, builds };
     }
     return buildConfig;

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -306,7 +306,7 @@ const sortReplicationControllersByRevision = (replicationControllers: K8sResourc
   return sortByRevision(replicationControllers, getDeploymentConfigVersion);
 };
 
-const sortBuilds = (builds: K8sResourceKind[]): K8sResourceKind[] => {
+export const sortBuilds = (builds: K8sResourceKind[]): K8sResourceKind[] => {
 
   const byCreationTime = (left, right) => {
     const leftCreationTime = new Date(_.get(left, 'metadata.creationTimestamp', Date.now()));


### PR DESCRIPTION
Bug: https://jira.coreos.com/browse/ODC-1394

In this PR `sortBuilds` is used to sort the builds so that the latest build is shown first.

![Screenshot from 2019-07-22 17-10-46](https://user-images.githubusercontent.com/20724543/61629840-acc8d380-aca3-11e9-8bde-c5c45a9af8a3.png)
