### PR TITLE
Optional env variable for running integration tests without headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,11 @@ $ ./test-gui.sh olm
 
 #### Hacking Integration Tests
 
-Remove the `--headless` flag to Chrome (chromeOptions) in [protractor.conf.ts](frontend/integration-tests/protractor.conf.ts) to see what the tests are actually doing.
+To see what the tests are actually doing, it is posible to run in none `headless` mode by setting the `NO_HEADLESS` enviorment variable:
+
+```
+$ NO_HEADLESS=true ./test-gui.sh olm
+```
 
 ##### Debugging Integration Tests
 

--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -35,8 +35,8 @@ export const config: Config = {
     acceptInsecureCerts: true,
     chromeOptions: {
       args: [
+        ...(process.env.NO_HEADLESS ? [] : ['--headless']),
         '--disable-gpu',
-        '--headless',
         '--no-sandbox',
         '--window-size=1920,1200',
         '--disable-background-timer-throttling',


### PR DESCRIPTION
When debugging integration tests it's convenient to run with browser open ( e.g. without `--headless` cli arg)

This PR adds an optional ENV arg `NO_HEADLESS` to run the tests with no `--headless` arg.

Example:
```
NO_HEADLESS=true ./test-gui.sh overview
```