### PR TITLE
fix(dev-console): update the order and wording of the advanced options

### DIFF
--- a/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
@@ -26,23 +26,29 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({ values }) => {
       visibleItems={visibleItems}
       onVisibleItemChange={handleVisibleItemChange}
     >
-      <ProgressiveListItem name="Route">
+      <ProgressiveListItem name="Routing">
         <RouteSection route={values.route} />
+      </ProgressiveListItem>
+      {/* Hide Build for Deploy Image */}
+      {values.isi ? null : (
+        <ProgressiveListItem name="Build Configuration">
+          <BuildConfigSection namespace={values.project.name} />
+        </ProgressiveListItem>
+      )}
+      {/* Hide Deployment for Serverless */}
+      {values.serverless.trigger ? null : (
+        <ProgressiveListItem name="Deployment Configuration">
+          <DeploymentConfigSection namespace={values.project.name} />
+        </ProgressiveListItem>
+      )}
+      <ProgressiveListItem name="Scaling">
+        {values.serverless.trigger ? <ServerlessScalingSection /> : <ScalingSection />}
+      </ProgressiveListItem>
+      <ProgressiveListItem name="Resource Limits">
+        <ResourceLimitSection />
       </ProgressiveListItem>
       <ProgressiveListItem name="Labels">
         <LabelSection />
-      </ProgressiveListItem>
-      <ProgressiveListItem name="Scale">
-        {values.serverless.trigger ? <ServerlessScalingSection /> : <ScalingSection />}
-      </ProgressiveListItem>
-      <ProgressiveListItem name="Build Config">
-        <BuildConfigSection namespace={values.project.name} />
-      </ProgressiveListItem>
-      <ProgressiveListItem name="Deployment Config">
-        <DeploymentConfigSection namespace={values.project.name} />
-      </ProgressiveListItem>
-      <ProgressiveListItem name="Resource Limit">
-        <ResourceLimitSection />
       </ProgressiveListItem>
     </ProgressiveList>
   );


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/ODC-1344
Fixes https://jira.coreos.com/browse/ODC-1345

Changes the order and wording of the advanced options in the forms.
Hides some options based on Serverless and Deploy Image form usage.

![advanced-options](https://user-images.githubusercontent.com/1184371/61658905-6029cc00-ac94-11e9-8e25-cdf32633f858.png)

