### PR TITLE
Capitalize Inventory card's title

### DIFF
--- a/frontend/public/components/dashboards-page/overview-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/inventory-card.tsx
@@ -75,7 +75,7 @@ const InventoryCard_: React.FC<DashboardItemProps> = ({ watchK8sResource, stopWa
   return (
     <DashboardCard>
       <DashboardCardHeader>
-        <DashboardCardTitle>Cluster inventory</DashboardCardTitle>
+        <DashboardCardTitle>Cluster Inventory</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
         <ResourceInventoryItem isLoading={!nodesLoaded} error={!!nodesLoadError} kind={NodeModel} resources={nodesData} mapper={getNodeStatusGroups} />


### PR DESCRIPTION
> Cluster inventory -> Cluster Inventory

This aligns with the capitalization of all other dashboard cards. Resolves [CONSOLE-1638](https://jira.coreos.com/browse/CONSOLE-1638).

![image](https://user-images.githubusercontent.com/9122899/61674450-ea3c5980-acc1-11e9-9790-0c5ef6ed85c1.png)