### PR TITLE
Improve Subsystem Health popover text flow and spacing

### DIFF
--- a/frontend/public/components/dashboard/health-card/health-card.scss
+++ b/frontend/public/components/dashboard/health-card/health-card.scss
@@ -34,15 +34,11 @@
 .co-health-card__item {
   align-items: center;
   display: flex;
-  flex-wrap: wrap;
 }
 
 .co-health-card__separator {
   border-bottom: 1px solid $pf-color-black-200;
-}
-
-.co-health-card__subsystem-item {
-  padding-top: 5px;
+  margin: 10px -14px;
 }
 
 .co-health-card__subtitle {
@@ -51,6 +47,7 @@
 }
 
 .co-health-card__text {
+  display: block;
   font-size: 0.875rem;
   margin-left: 1rem;
 }

--- a/frontend/public/components/dashboards-page/overview-dashboard/health-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/health-card.tsx
@@ -129,7 +129,7 @@ const HealthCard_ = connect(mapStateToProps)(({
       <DashboardCardHeader>
         <DashboardCardTitle>Cluster Health</DashboardCardTitle>
         {subsystems.length > 0 && !flagPending(openshiftFlag) && (
-          <DashboardCardPopupLink linkTitle="See all" popupTitle="Subsystem health">
+          <DashboardCardPopupLink linkTitle="See all" popupTitle="Subsystem Health">
             <HealthItem
               message={getName(openshiftFlag)}
               details={k8sHealthState.message}
@@ -139,7 +139,6 @@ const HealthCard_ = connect(mapStateToProps)(({
               <div key={index}>
                 <div className="co-health-card__separator" />
                 <HealthItem
-                  className="co-health-card__subsystem-item"
                   message={subsystems[index].properties.title}
                   details={subsystem.message}
                   state={subsystem.state}


### PR DESCRIPTION
Resolves the text wrapping problems noted in [CONSOLE-1635](https://jira.coreos.com/browse/CONSOLE-1635).

Also:
- Improves the spacing between subsystem items
- Prevents odd-looking span wrapping behavior at certain screen sizes
- Capitalizes "health" in "Subsystem health"
- Removes the no-longer-needed `.co-health-card__subsystem-item`
- Extends line separators to the edges of the popover

Before:

<img width="397" alt="2019-07-22 22 09 02" src="https://user-images.githubusercontent.com/9122899/61677368-60928900-accd-11e9-9c53-36f7e7021dfc.png">

After:

<img width="396" alt="2019-07-22 21 57 11" src="https://user-images.githubusercontent.com/9122899/61677374-64bea680-accd-11e9-86a9-0f7f231193a3.png">