### PR TITLE
Use PF4 popover to gain ability to switch position

### DIFF
--- a/frontend/public/components/dashboard/dashboard-card/card-link.tsx
+++ b/frontend/public/components/dashboard/dashboard-card/card-link.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Button, OverlayTrigger, Popover } from 'patternfly-react';
+import { Button } from 'patternfly-react';
+import { Popover, PopoverPosition } from '@patternfly/react-core';
 
 const DashboardCardButtonLink: React.FC<DashboardCardButtonLinkProps> = React.memo(({ children, ...rest }) => (
   <Button bsStyle="link" className="co-dashboard-card__button-link" {...rest}>{children}</Button>
@@ -17,15 +18,16 @@ export const DashboardCardPopupLink: React.FC<DashboardCardPopupLinkProps> = Rea
     if (React.Children.count(children) === 0) {
       return null;
     }
-    const overlay = (
-      <Popover id="popover" title={popupTitle}>
-        {children}
-      </Popover>
-    );
+
     return (
-      <OverlayTrigger overlay={overlay} placement="right" trigger={['click']} rootClose>
+      <Popover
+        position={PopoverPosition.right}
+        headerContent={popupTitle}
+        bodyContent={children}
+        enableFlip
+      >
         <DashboardCardButtonLink>{linkTitle}</DashboardCardButtonLink>
-      </OverlayTrigger>
+      </Popover>
     );
   }
 );


### PR DESCRIPTION
fixes Subsystem Health popover positioning on smaller screens https://jira.coreos.com/browse/CONSOLE-1635

![popover](https://user-images.githubusercontent.com/2078045/61695933-a8003000-ad34-11e9-9d92-c4ca32698c1e.png)

flipped position if popover should render outside of window
![popover1](https://user-images.githubusercontent.com/2078045/61695937-a9c9f380-ad34-11e9-8fc1-2850aa1ecdc3.png)
![popover2](https://user-images.githubusercontent.com/2078045/61695938-aafb2080-ad34-11e9-8fee-0294fdbcae70.png)
