### PR TITLE
Fix bug where project workloads sidebar build status layout is broken

### DIFF
--- a/frontend/public/components/overview/_build-overview.scss
+++ b/frontend/public/components/overview/_build-overview.scss
@@ -20,6 +20,10 @@
   margin: 0;
 }
 
+.build-overview__status {
+  flex-wrap: wrap;
+}
+
 .build-overview__status-message {
   margin-bottom: 10px;
 }

--- a/frontend/public/components/overview/build-overview.tsx
+++ b/frontend/public/components/overview/build-overview.tsx
@@ -17,7 +17,7 @@ import {
 } from '../utils';
 
 import { BuildConfigOverviewItem } from '.';
-import { SyncIcon } from '@patternfly/react-icons';
+import { SyncAltIcon } from '@patternfly/react-icons';
 
 const conjugateBuildPhase = (phase: BuildPhase): string => {
   switch (phase) {
@@ -64,10 +64,13 @@ const BuildOverviewItem: React.SFC<BuildOverviewListItemProps> = ({build}) => {
 
   return <li className="list-group-item build-overview__item">
     <div className="build-overview__item-title">
-      <div>
-        {phase === 'Running'
-          ? <><StatusIconAndText icon={<SyncIcon />} title={phase} spin iconOnly /> {statusTitle}</>
-          : <><Status status={phase} iconOnly /> {statusTitle}</>}
+      <div className="build-overview__status co-icon-and-text">
+        <div className="co-icon-and-text__icon co-icon-flex-child">
+          {phase === 'Running'
+            ? <StatusIconAndText icon={<SyncAltIcon />} title={phase} spin iconOnly />
+            : <Status status={phase} iconOnly />}
+        </div>
+        {statusTitle}
       </div>
       <div>
         <BuildLogLink build={build} />


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1618

After:
![Screen Shot 2019-07-22 at 4 49 45 PM](https://user-images.githubusercontent.com/895728/61713669-176f2300-ad27-11e9-8818-7d2d39394cf6.png)

cc: @jtomasek 