### PR TITLE
Use ContextReplacementPlugin to avoid webpack warnings with monaco

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -130,6 +130,11 @@ const config: webpack.Configuration = {
       languages: ['yaml'],
     }),
     extractCSS,
+    // https://github.com/microsoft/monaco-editor-webpack-plugin/issues/13
+    new webpack.ContextReplacementPlugin(
+      /monaco-editor-core\/esm\/vs\/editor\/common\/services/,
+      __dirname
+    ),
   ],
   devtool: 'cheap-module-source-map',
   stats: 'minimal',


### PR DESCRIPTION
Partial fix for https://jira.coreos.com/browse/CONSOLE-1641
Addresses this warning specifically:

```
WARNING in ./node_modules/monaco-editor-core/esm/vs/editor/common/services/editorSimpleWorker.js 374:12-383:17
Critical dependency: the request of a dependency is an expression
```

The prettier warnings will require an update to yaml-language-server that bumps the prettier version.

/assign @alecmerdler 
@JPinkney 