### PR TITLE
Fix different padding around utilization charts

### DIFF
--- a/frontend/public/components/dashboard/utilization-card/utilization-body.tsx
+++ b/frontend/public/components/dashboard/utilization-card/utilization-body.tsx
@@ -10,7 +10,7 @@ const formatDate = (date: Date): string => {
   return `${date.getHours()}:${minutes}`;
 };
 
-const UtilizationAxis: React.FC<UtilizationAxisProps> = ({ timestamps, narrow = false }) => {
+const UtilizationAxis: React.FC<UtilizationAxisProps> = ({ timestamps }) => {
   const [containerRef, width] = useRefWidth();
   return (
     <div ref={containerRef}>
@@ -21,7 +21,7 @@ const UtilizationAxis: React.FC<UtilizationAxisProps> = ({ timestamps, narrow = 
         orientation="top"
         height={15}
         width={width}
-        padding={{ top: 30, bottom: 0, left: 70, right: narrow ? 45 : 30 }}
+        padding={{ top: 30, bottom: 0, left: 70, right: 30 }}
         style={{
           axis: {visibility: 'hidden'},
         }}
@@ -34,22 +34,21 @@ const UtilizationAxis: React.FC<UtilizationAxisProps> = ({ timestamps, narrow = 
 export const UtilizationBody: React.FC<UtilizationBodyProps> = ({ timestamps, children }) => {
   const [containerRef, width] = useRefWidth();
 
-  const axis = width < parseInt(breakpointSM.value, 10) ? (
-    <>
-      <Row>
-        <Col className="co-utilization-card__body-time-axis--narrow">
-          {timestamps.length > 0 && <UtilizationAxis timestamps={timestamps} narrow />}
+  const axis = width < parseInt(breakpointSM.value, 10) ?
+    timestamps.length === 0 ? null : (
+      <Row className="co-utilization-card__item">
+        <Col>
+          <UtilizationAxis timestamps={timestamps} />
         </Col>
       </Row>
-    </>
-  ) : (
-    <Row className="co-utilization-card__item">
-      <Col lg={5} md={5} sm={5} xs={5} />
-      <Col lg={7} md={7} sm={7} xs={7} className="co-utilization-card__body-time-axis--wide">
-        {timestamps.length > 0 && <UtilizationAxis timestamps={timestamps} />}
-      </Col>
-    </Row>
-  );
+    ) : (
+      <Row className="co-utilization-card__item">
+        <Col lg={5} md={5} sm={5} xs={5} />
+        <Col lg={7} md={7} sm={7} xs={7}>
+          {timestamps.length > 0 && <UtilizationAxis timestamps={timestamps} />}
+        </Col>
+      </Row>
+    );
   return (
     <div ref={containerRef}>
       {axis}
@@ -65,5 +64,4 @@ type UtilizationBodyProps = {
 
 type UtilizationAxisProps = {
   timestamps: Date[];
-  narrow?: boolean;
 }

--- a/frontend/public/components/dashboard/utilization-card/utilization-card.scss
+++ b/frontend/public/components/dashboard/utilization-card/utilization-card.scss
@@ -1,15 +1,8 @@
-.co-utilization-card__body-time-axis--wide {
-  padding-left: 0;
-}
-
-.co-utilization-card__body-time-axis--narrow {
-  border-bottom: 1px solid $pf-color-black-300;
-  margin-right: 0.25em;
-}
-
 .co-utilization-card__item {
   border-bottom: 1px solid $pf-color-black-300;
   font-size: 1.333em;
+  margin: 0;
+  padding: 0;
 }
 
 .co-utilization-card__item-chart {
@@ -26,7 +19,6 @@
 
 .co-utilization-card__item-chart--wide {
   border-left: 1px solid $pf-color-black-300;
-  padding-left: 0;
 }
 
 .co-utilization-card__item-current {
@@ -38,7 +30,8 @@
 }
 
 .co-utilization-card__item-row--narrow {
-  margin-right: 0.25em;
+  margin: 0;
+  padding: 0;
 }
 
 .co-utilization-card__item-title-row--narrow {


### PR DESCRIPTION
Loaded charts
![screencapture-localhost-9000-dashboards-2019-07-23-15_36_24](https://user-images.githubusercontent.com/2078045/61716872-4ce43280-ad60-11e9-9fd9-03bbc8a65bcb.png)
![screencapture-localhost-9000-dashboards-2019-07-23-15_42_54](https://user-images.githubusercontent.com/2078045/61717058-a64c6180-ad60-11e9-8af6-b37cb75b254a.png)


errored charts
![utilization1](https://user-images.githubusercontent.com/2078045/61716886-553c6d80-ad60-11e9-9d68-14ea4d14da3c.png)
![screencapture-localhost-9000-dashboards-2019-07-23-15_35_40](https://user-images.githubusercontent.com/2078045/61716906-5bcae500-ad60-11e9-8d03-6338ffc6eddb.png)

