### PR TITLE
Make tags-input full width so that clicking anywhere inside container sets cursor.

### DIFF
--- a/frontend/public/components/utils/_label.scss
+++ b/frontend/public/components/utils/_label.scss
@@ -22,6 +22,10 @@
   }
 }
 
+tags-input {
+  min-width: 100%;
+}
+
 tags-input:focus,
 tags-input .host:focus {
   outline: none;


### PR DESCRIPTION
… 
before
<img width="611" alt="Screen Shot 2019-07-23 at 10 22 17 AM" src="https://user-images.githubusercontent.com/1874151/61720079-28726100-ad34-11e9-9db4-20e2ae94941d.png">


after
<img width="617" alt="Screen Shot 2019-07-23 at 10 22 27 AM" src="https://user-images.githubusercontent.com/1874151/61720085-2c9e7e80-ad34-11e9-8bda-80af58526a85.png">
