### PR TITLE
apply application labels to serverless resources

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -233,6 +233,7 @@ export const createResources = async (
     project: { name: projectName },
     isi: { ports },
     serverless: { scaling },
+    labels: userLabels,
     limits,
     route,
   } = formData;
@@ -258,6 +259,7 @@ export const createResources = async (
         scaling,
         limits,
         route,
+        userLabels,
         imageStreamResponse.status.dockerImageRepository,
       ),
     );

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -227,15 +227,15 @@ export const createResources = async (
   dryRun: boolean = false,
 ): Promise<K8sResourceKind[]> => {
   const {
+    name,
+    application: { name: applicationName },
     route: { create: canCreateRoute },
     project: { name: projectName },
-    name,
     isi: { ports },
     serverless: { scaling },
     limits,
     route,
   } = formData;
-
   const requests: Promise<K8sResourceKind>[] = [];
   requests.push(createImageStream(formData, dryRun));
   if (!formData.serverless.trigger) {
@@ -253,6 +253,7 @@ export const createResources = async (
     requests.push(
       createKnativeService(
         name,
+        applicationName,
         projectName,
         scaling,
         limits,

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -311,6 +311,7 @@ export const createResources = async (
   dryRun: boolean = false,
 ): Promise<K8sResourceKind[]> => {
   const {
+    name,
     application: { name: applicationName },
     project: { name: projectName },
     route: { create: canCreateRoute },
@@ -320,6 +321,7 @@ export const createResources = async (
     serverless: { scaling },
     route,
   } = formData;
+  const imageStreamName = imageStream && imageStream.metadata.name;
 
   const requests: Promise<K8sResourceKind>[] = [
     createImageStream(formData, imageStream, dryRun),
@@ -335,12 +337,14 @@ export const createResources = async (
     const [imageStreamResponse] = await Promise.all(requests);
     return Promise.all([
       createKnativeService(
+        name,
         applicationName,
         projectName,
         scaling,
         limits,
         route,
         imageStreamResponse.status.dockerImageRepository,
+        imageStreamName,
       ),
     ]);
   }

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -317,11 +317,12 @@ export const createResources = async (
     route: { create: canCreateRoute },
     image: { ports },
     build: { strategy: buildStrategy },
+    labels: userLabels,
     limits,
     serverless: { scaling },
     route,
   } = formData;
-  const imageStreamName = imageStream && imageStream.metadata.name;
+  const imageStreamName = _.get(imageStream, 'metadata.name');
 
   const requests: Promise<K8sResourceKind>[] = [
     createImageStream(formData, imageStream, dryRun),
@@ -343,6 +344,7 @@ export const createResources = async (
         scaling,
         limits,
         route,
+        userLabels,
         imageStreamResponse.status.dockerImageRepository,
         imageStreamName,
       ),

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -6,6 +6,7 @@ import {
   ConfigurationModel,
   RouteModel,
 } from '@console/knative-plugin';
+import { getAppLabels } from '@console/dev-console/src/utils/resource-label-utils';
 
 interface ServerlessScaling {
   minpods: number;
@@ -33,6 +34,7 @@ export const createKnativeService = (
   scaling: ServerlessScaling,
   limits: LimitsData,
   { targetPort },
+  labels,
   imageStreamUrl: string,
   imageStreamName?: string,
 ): Promise<K8sResourceKind> => {
@@ -52,6 +54,8 @@ export const createKnativeService = (
       limitUnit: memoryLimitUnit,
     },
   } = limits;
+  const defaultLabel = getAppLabels(name, applicationName, imageStreamName);
+  delete defaultLabel.app;
   const knativeDeployResource: K8sResourceKind = {
     kind: 'Service',
     apiVersion: 'serving.knative.dev/v1alpha1',
@@ -63,10 +67,8 @@ export const createKnativeService = (
       template: {
         metadata: {
           labels: {
-            'app.kubernetes.io/part-of': applicationName,
-            'app.kubernetes.io/component': name,
-            'app.kubernetes.io/instance': name,
-            'app.kubernetes.io/name': imageStreamName,
+            ...defaultLabel,
+            ...labels,
           },
           annotations: {
             ...(concurrencytarget && {


### PR DESCRIPTION
Bugs: 
https://jira.coreos.com/browse/ODC-1390, (application labels are missing from serverless resources)
 https://jira.coreos.com/browse/ODC-1367 (application Names are missing from application list)

- We have been passing the application name as the resource name while creating the Knative service for `import from git` flow. This PR fixes that.
- these labels are added to the serverless now
```
'app.kubernetes.io/part-of,
 'app.kubernetes.io/component',
 'app.kubernetes.io/instance',
 'app.kubernetes.io/name',
```
# Screenshots

application labels are missing from serverless resources
![Screenshot from 2019-07-23 20-53-56](https://user-images.githubusercontent.com/9278015/61731105-643f1200-ad98-11e9-9a51-8aec1b488f50.png)
![Screenshot from 2019-07-23 22-23-46](https://user-images.githubusercontent.com/9278015/61731190-9486b080-ad98-11e9-9e09-6574525dff7a.png)

application Names are missing from application list

![Screenshot from 2019-07-23 22-24-35](https://user-images.githubusercontent.com/9278015/61731263-b7b16000-ad98-11e9-8e25-c917957a87ac.png)



