### PR TITLE
Bug 1732299: Volume table does not show all volumes

### DIFF
--- a/frontend/public/components/modals/remove-volume-modal.tsx
+++ b/frontend/public/components/modals/remove-volume-modal.tsx
@@ -19,7 +19,7 @@ export const RemoveVolumeModal: React.FC<RemoveVolumeModalProps> = (props) => {
         if (mount.name !== rowVolumeData.name) {
           return;
         }
-        if (mount.mountPath === rowVolumeData.mountPath) {
+        if (mount.mountPath === rowVolumeData.mountPath && container.name === rowVolumeData.container) {
           patches.push({op: 'remove', path: `/spec/template/spec/containers/${i}/volumeMounts/${j}`});
         } else {
           allowRemoveVolume = false;

--- a/frontend/public/components/volumes-table.tsx
+++ b/frontend/public/components/volumes-table.tsx
@@ -43,7 +43,7 @@ const getRowVolumeData = (resource: K8sResourceKind): RowVolumeData[] => {
     return [];
   }
 
-  const m = {};
+  const data: RowVolumeData[] = [];
   const volumes = (pod.spec.volumes || []).reduce((p, v: Volume) => {
     p[v.name] = v;
     return p;
@@ -51,13 +51,11 @@ const getRowVolumeData = (resource: K8sResourceKind): RowVolumeData[] => {
 
   _.forEach(pod.spec.containers, (c: ContainerSpec) => {
     _.forEach(c.volumeMounts, (v: VolumeMount) => {
-      const k = `${v.name}_${v.readOnly ? 'ro' : 'rw'}_${v.mountPath}`;
-      const mount = {container: c.name, mountPath: v.mountPath, subPath: v.subPath};
-      m[k] = {name: v.name, readOnly: !!v.readOnly, volumeDetail: volumes[v.name],
-        container: mount.container, mountPath: mount.mountPath, subPath: mount.subPath, resource};
+      data.push({name: v.name, readOnly: !!v.readOnly, volumeDetail: volumes[v.name],
+        container: c.name, mountPath: v.mountPath, subPath: v.subPath, resource});
     });
   });
-  return _.values(m);
+  return data;
 };
 
 const ContainerLink: React.FC<ContainerLinkProps> = ({name, pod}) => <span className="co-resource-item co-resource-item--inline">


### PR DESCRIPTION
Volume table does not show all values.  The new volume tables switch to PF4 included flattening the data passed into each row.  The string used for the keys in that data used `volumeName_readOnly_mntPath` however that did not worked for individually selected containers (which merged in parallel) with the exact same values and the keys would be overwritten.
Since all values are unique in the flatten table now, no key value is needed and the values are simply pushed onto an array.
Additionally, the remove volume modal component had to be updated to check that the proper container was selected for removal.