### PR TITLE
Hide the restart VM menu option during migration

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -67,11 +67,11 @@ const menuActionStop = (kindObj: K8sKind, vm: VMKind): KebabOption => {
 const menuActionRestart = (
   kindObj: K8sKind,
   vm: VMKind,
-  { vmStatus, vmi }: ActionArgs,
+  { vmStatus, vmi, migration }: ActionArgs,
 ): KebabOption => {
   const title = 'Restart Virtual Machine';
   return {
-    hidden: isVMImporting(vmStatus) || !isVMRunningWithVMI({ vm, vmi }),
+    hidden: isVMImporting(vmStatus) || !isVMRunningWithVMI({ vm, vmi }) || isMigrating(migration),
     label: title,
     callback: () =>
       confirmModal({


### PR DESCRIPTION
This PR hides the restart option in the kebab and actions menu when a VM is being migrated.

Bug: https://bugzilla.redhat.com/1712736