### PR TITLE
Bug 1731480: Do not block "loaded" state on optional resources in Firehose

### DIFF
--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -118,6 +118,7 @@ const stateToProps = ({ k8s }, { resources }) => {
     ImmutableMap(),
   );
   const loaded = (r) =>
+    r.optional ||
     k8s.getIn([
       makeReduxID(
         k8sModels.get(r.kind),


### PR DESCRIPTION
Optional resources being loaded or errored to load should not block rendering
children in Firehose.

Issue: if an optional resource fails to load (i.e. HTTP 404),
the`loaded` property (stateToProps) is kept to `false` causing
the `props` to stay unchanged even if the k8sWatchObject produced
error (like HTTP 404).

With this fix, change to state by `ActionType.Errored` newly
results in React's re-rendering phase.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1731480