### PR TITLE
Add missing css class to vm template table

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -25,8 +25,8 @@ const selector = {
   matchLabels: { [TEMPLATE_TYPE_LABEL]: 'vm' },
 };
 
-const tableColumnClass = classNames('col-lg-2', 'col-sm-4', 'col-xs-4');
-const tableColumnClassHiddenOnSmall = classNames('col-lg-2', 'hidden-sm', 'hidden-xs');
+const tableColumnClass = classNames('col-lg-2', 'col-md-2', 'col-sm-4', 'col-xs-4');
+const tableColumnClassHiddenOnSmall = classNames('col-lg-2', 'col-md-2', 'hidden-sm', 'hidden-xs');
 
 const tableColumnClasses = [
   tableColumnClass,


### PR DESCRIPTION
The VM Template table is missing the `-md-` class.

Before:
![OKD](https://user-images.githubusercontent.com/2181522/61792569-bd08bc00-ae25-11e9-9762-1673cf45d498.png)

After:
![OKD(1)](https://user-images.githubusercontent.com/2181522/61792719-078a3880-ae26-11e9-9a38-d201b28a3d17.png)
