### PR TITLE
Fix bug where masthead status icon size and positioning are off

### DIFF
--- a/frontend/public/components/_masthead.scss
+++ b/frontend/public/components/_masthead.scss
@@ -1,8 +1,5 @@
 .co-system-status-icon {
-  margin-top: 3px;
-  .visible-xs-block & {
-    margin-top: 5px;
-  }
+  font-size: $pf-header-icon-fontsize;
 }
 
 .co-username {


### PR DESCRIPTION
Before (too small and too low):

![Screen Shot 2019-07-24 at 11 28 17 AM](https://user-images.githubusercontent.com/895728/61806698-2c6eb380-ae06-11e9-9914-d1294c96225c.png)
![Screen Shot 2019-07-24 at 11 28 25 AM](https://user-images.githubusercontent.com/895728/61806699-2c6eb380-ae06-11e9-8caf-10d4976d2486.png)

After:
![Screen Shot 2019-07-24 at 11 23 42 AM](https://user-images.githubusercontent.com/895728/61806464-bc602d80-ae05-11e9-9300-cd2f234d04db.png)
![Screen Shot 2019-07-24 at 11 23 34 AM](https://user-images.githubusercontent.com/895728/61806465-bc602d80-ae05-11e9-8efa-c54ba8b296ba.png)
