### PR TITLE
Bug 1732836: Converted Chargeback Report Usage tables to pf4 Tables

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -112,7 +112,16 @@ const sorts = {
   },
 };
 
-const stateToProps = ({UI}, {data = [], defaultSortField = 'metadata.name', defaultSortFunc = undefined, filters = {}, loaded = false, reduxID = null, reduxIDs = null, staticFilters = [{}], rowFilters = []}) => {
+const stateToProps = ({UI}, {
+  data = [],
+  defaultSortField = 'metadata.name',
+  defaultSortFunc = undefined,
+  filters = {},
+  loaded = false,
+  reduxID = null,
+  reduxIDs = null,
+  staticFilters = [{}],
+  rowFilters = []}) => {
   const allFilters = staticFilters ? Object.assign({}, filters, ...staticFilters) : filters;
   let newData = getFilteredRows(allFilters, rowFilters, data);
 


### PR DESCRIPTION
ToDo
- [x] numeric fields are sorting by alphanumeric, need to determine way to apply numeric filter func dynamically to just numeric columns.

![image](https://user-images.githubusercontent.com/12733153/61817042-9cd3ff80-ae1b-11e9-9ca1-79894f77b870.png)


**Addresses:** 
Remove orphaned componets from list.tsx
https://jira.coreos.com/browse/CONSOLE-1636

**Fixes:** 
Sorting not working in Chargeback Reports listing table
https://bugzilla.redhat.com/show_bug.cgi?id=1732836

Usage Report table overlaps when view on smaller screen size
https://bugzilla.redhat.com/show_bug.cgi?id=1729437

_At Mobile:_
![image](https://user-images.githubusercontent.com/12733153/61816702-e96b0b00-ae1a-11e9-8ea2-7689829572d2.png)

