### PR TITLE
fix(pipeline-list): Add Succeeded to Status List

### DIFF
--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -63,6 +63,7 @@ const Status: React.FC<StatusProps> = ({ status, title, children, iconOnly }) =>
     case 'Complete':
     case 'Completed':
     case 'Enabled':
+    case 'Succeeded':
     case 'Ready':
     case 'Up to date':
       return <SuccessStatus {...statusProps} />;


### PR DESCRIPTION
This fixes bug https://jira.coreos.com/browse/ODC-1472
The succeeded icon doesn't show up in Pipeline List.

![Screenshot from 2019-07-25 14-34-09](https://user-images.githubusercontent.com/24852534/61866940-c06a7900-aef3-11e9-89de-e97c2bd76964.png)

----------------------------------------------------------------------------------------------------------------
Post Fix: The succeeded icon will show up as follows:

![Screenshot from 2019-07-25 15-48-15](https://user-images.githubusercontent.com/24852534/61867000-e1cb6500-aef3-11e9-9b10-194e88ce3ec6.png)
