### PR TITLE
fix(pipeline-actions): Align Pipeline Actions with latest UX

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunRow.tsx
@@ -20,7 +20,7 @@ interface PipelineRunRowProps {
 }
 
 const PipelineRunRow: React.FC<PipelineRunRowProps> = ({ obj, index, key, style }) => {
-  const menuActions = [reRunPipelineRun(obj), stopPipelineRun(obj), ...Kebab.factory.common];
+  const menuActions = [reRunPipelineRun(obj), stopPipelineRun(obj), Kebab.factory.Delete];
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -32,17 +32,17 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
           .then((listres) => {
             this.setState({
               menuActions: [
-                triggerPipeline(
-                  res,
-                  getLatestRun({ data: listres }, 'creationTimestamp'),
-                  'pipelines',
-                ),
                 rerunPipeline(
                   res,
                   getLatestRun({ data: listres }, 'creationTimestamp'),
                   'pipelines',
                 ),
-                ...Kebab.factory.common,
+                triggerPipeline(
+                  res,
+                  getLatestRun({ data: listres }, 'creationTimestamp'),
+                  'pipelines',
+                ),
+                Kebab.factory.Delete,
               ],
             });
           })

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineRow.tsx
@@ -22,9 +22,9 @@ interface PipelineRowProps {
 
 const PipelineRow: React.FC<PipelineRowProps> = ({ obj, index, key, style }) => {
   const menuActions = [
-    triggerPipeline(obj, obj.latestRun, ''),
     rerunPipeline(obj, obj.latestRun, ''),
-    ...Kebab.factory.common,
+    triggerPipeline(obj, obj.latestRun, ''),
+    Kebab.factory.Delete,
   ];
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
@@ -31,31 +31,31 @@ export const actionPipelineRuns: PipelineRun[] = [
 ];
 
 describe('PipelineAction testing rerunPipeline create correct labels and callbacks', () => {
-  it('expect label to be "Trigger Last Run" when latestRun is available', () => {
+  it('expect label to be "Start Last Run" when latestRun is available', () => {
     const rerunAction = rerunPipeline(actionPipelines[0], actionPipelineRuns[0]);
     const rerunResult = rerunAction(PipelineModel, actionPipelines[1]);
-    expect(rerunResult.label).toBe('Trigger Last Run');
+    expect(rerunResult.label).toBe('Start Last Run');
     expect(rerunResult.callback).not.toBeNull();
   });
-  it('expect label not to be "Trigger" when latestRun is unavailable', () => {
+  it('expect label not to be "Start Last Run" when latestRun is unavailable', () => {
     const rerunAction = rerunPipeline(actionPipelines[1], null);
     const rerunResult = rerunAction(PipelineModel, actionPipelines[1]);
-    expect(rerunResult.label).not.toBe('Trigger Last Run');
+    expect(rerunResult.label).not.toBe('Start Last Run');
     expect(rerunResult.callback).toBeNull();
   });
 });
 
 describe('PipelineAction testing stopPipelineRun create correct labels and callbacks', () => {
-  it('expect label to be "Stop Pipeline Run" when latest Run is running', () => {
+  it('expect label to be "Stop" when latest Run is running', () => {
     const stopAction = stopPipelineRun(actionPipelineRuns[1]);
     const stopResult = stopAction(PipelineRunModel, actionPipelineRuns[1]);
-    expect(stopResult.label).toBe('Stop Pipeline Run');
+    expect(stopResult.label).toBe('Stop');
     expect(stopResult.callback).not.toBeNull();
   });
-  it('expect label not to be "Stop Pipeline Run" when latestRun is not running', () => {
+  it('expect label not to be "Stop" when latestRun is not running', () => {
     const stopAction = stopPipelineRun(actionPipelineRuns[0]);
     const stopResult = stopAction(PipelineRunModel, actionPipelineRuns[0]);
-    expect(stopResult.label).not.toBe('Stop Pipeline Run');
+    expect(stopResult.label).not.toBe('Stop');
     expect(stopResult.callback).toBeNull();
   });
 });

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -115,7 +115,7 @@ export const triggerPipeline = (
 ): ActionFunction => {
   // The returned function will be called using the 'kind' and 'obj' in Kebab Actions
   return (): Action => ({
-    label: 'Trigger',
+    label: 'Start',
     callback: () => {
       k8sCreate(PipelineRunModel, newPipelineRun(pipeline, latestRun))
         .then(() => {
@@ -170,13 +170,13 @@ export const rerunPipeline = (
   if (!latestRun || !latestRun.metadata) {
     // The returned function will be called using the 'kind' and 'obj' in Kebab Actions
     return (): Action => ({
-      label: <div className="dropdown__disabled">Trigger Last Run</div>,
+      label: <div className="dropdown__disabled">Start Last Run</div>,
       callback: null,
     });
   }
   // The returned function will be called using the 'kind' and 'obj' in Kebab Actions
   return (): Action => ({
-    label: 'Trigger Last Run',
+    label: 'Start Last Run',
     callback: () => {
       k8sCreate(PipelineRunModel, newPipelineRun(pipeline, latestRun))
         .then(() => {
@@ -193,13 +193,13 @@ export const stopPipelineRun = (pipelineRun: PipelineRun): ActionFunction => {
   if (!pipelineRun || pipelineRunFilterReducer(pipelineRun) !== 'Running') {
     // The returned function will be called using the 'kind' and 'obj' in Kebab Actions
     return (): Action => ({
-      label: <div className="dropdown__disabled">Stop Pipeline Run</div>,
+      label: <div className="dropdown__disabled">Stop</div>,
       callback: null,
     });
   }
   // The returned function will be called using the 'kind' and 'obj' in Kebab Actions
   return (): Action => ({
-    label: 'Stop Pipeline Run',
+    label: 'Stop',
     callback: () => {
       k8sUpdate(PipelineRunModel, pipelineRun, {
         spec: { ...pipelineRun.spec, status: 'PipelineRunCancelled' },


### PR DESCRIPTION
This covers bugs, 
https://jira.coreos.com/browse/ODC-1348 - removing common resource actions
https://jira.coreos.com/browse/ODC-1245 - aligning Pipeline action terminology with latest UX

-----------------------------------------------------------------------------------------------------------------------------
Post Fix: Pipeline Actions will appear as follows:
------------------------------------------------------------------------------------------------------------------------------
Pipeline List

![Screenshot from 2019-07-25 15-38-59](https://user-images.githubusercontent.com/24852534/61867435-db89b880-aef4-11e9-9cc2-93b7e0978e1d.png)

---------------------------------------------------------------------------------------------------------------------------
Pipeline Details Page

![Screenshot from 2019-07-25 15-38-44](https://user-images.githubusercontent.com/24852534/61867475-f2c8a600-aef4-11e9-8999-8ca2c46b3bcd.png)

--------------------------------------------------------------------------------------------------------------------------
Pipeline Run List

![Screenshot from 2019-07-25 15-38-35](https://user-images.githubusercontent.com/24852534/61867533-0c69ed80-aef5-11e9-9eda-c15d833c776d.png)
