### PR TITLE
Fix bug where masthead dropdown items are incorrectly spaced

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -97,6 +97,16 @@ kbd {
   max-width: 100%;
 }
 
+// Temp fix to adjust dropdown item spacing until issue can be addressed upstream in PatternFly
+.pf-c-app-launcher {
+  &__group {
+    padding-top: 0 !important;
+  }
+  &__group-title {
+    padding-top: 8px !important;
+  }
+}
+
 .pf-c-button--align-right {
   margin-left: auto !important;
 }


### PR DESCRIPTION
This is a temp fix for https://jira.coreos.com/browse/CONSOLE-1645 until we can work with the upstream to figure out how to address there.

cc: @jeff-phillips-18 

After:
![Screen Shot 2019-07-25 at 9 19 34 AM](https://user-images.githubusercontent.com/895728/61877697-8c746100-aebd-11e9-80c9-f8c8a18a3407.png)
![Screen Shot 2019-07-25 at 9 19 43 AM](https://user-images.githubusercontent.com/895728/61877705-9302d880-aebd-11e9-93b4-6fa4ae72e77e.png)
![Screen Shot 2019-07-25 at 9 07 41 AM](https://user-images.githubusercontent.com/895728/61877713-98f8b980-aebd-11e9-8b6e-9334d0c5926c.png)
![Screen Shot 2019-07-25 at 9 07 45 AM](https://user-images.githubusercontent.com/895728/61877714-98f8b980-aebd-11e9-8376-931ebf508643.png)
