### PR TITLE
Use resource name for all the resources in topology view

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
@@ -429,7 +429,7 @@ Object {
         "url": "http://analytics.io",
       },
       "id": "5ca9ae28-680d-11e9-8c69-5254003f9382",
-      "name": "analytics",
+      "name": "analytics-deployment",
       "pods": Array [
         Object {
           "id": "5cec460e-680d-11e9-8c69-5254003f9382",
@@ -880,7 +880,7 @@ Object {
         "url": "http://wit.io",
       },
       "id": "60a9b423-680d-11e9-8c69-5254003f9382",
-      "name": "wit",
+      "name": "wit-deployment",
       "pods": Array [
         Object {
           "id": "610c7d95-680d-11e9-8c69-5254003f9382",

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -204,8 +204,8 @@ export class TransformTopologyData {
       this.topologyData.topology[dcUID] = {
         id: dcUID,
         name:
-          deploymentsLabels['app.kubernetes.io/instance'] ||
-          _.get(deploymentConfig, 'metadata.name'),
+          _.get(deploymentConfig, 'metadata.name') ||
+          deploymentsLabels['app.kubernetes.io/instance'],
 
         type: 'workload',
         resources: _.map(nodeResources, (resource) => {


### PR DESCRIPTION
bug: https://jira.coreos.com/browse/ODC-1471
This PR adds:
Use the resource name for all resources over `app.kubernetes.io/instance` label

![Screenshot from 2019-07-25 21-25-53](https://user-images.githubusercontent.com/9278015/61890443-1572b300-af25-11e9-944a-95ad60655bd9.png)
