### PR TITLE
add labels to OWNERS files

### DIFF
--- a/frontend/packages/ceph-storage-plugin/OWNERS
+++ b/frontend/packages/ceph-storage-plugin/OWNERS
@@ -1,13 +1,8 @@
 reviewers:
   - mareklibra
   - rawagner
-  - cloudbehl
-  - gnehapk
-  - afreen23
 approvers:
   - mareklibra
   - rawagner
-  - cloudbehl
-  - gnehapk
 labels:
   - component/ceph

--- a/frontend/packages/ceph-storage-plugin/OWNERS
+++ b/frontend/packages/ceph-storage-plugin/OWNERS
@@ -9,3 +9,5 @@ approvers:
   - rawagner
   - cloudbehl
   - gnehapk
+labels:
+  - component/ceph

--- a/frontend/packages/console-app/OWNERS
+++ b/frontend/packages/console-app/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - component/core

--- a/frontend/packages/console-plugin-sdk/OWNERS
+++ b/frontend/packages/console-plugin-sdk/OWNERS
@@ -6,3 +6,5 @@ approvers:
   - christianvogt
   - spadgett
   - vojtechszocs
+labels:
+  - component/sdk

--- a/frontend/packages/console-shared/OWNERS
+++ b/frontend/packages/console-shared/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - component/shared

--- a/frontend/packages/dev-console/OWNERS
+++ b/frontend/packages/dev-console/OWNERS
@@ -7,6 +7,7 @@ reviewers:
   - joshuawilson
   - invincibleJai
   - karthikjeeyar
+  - nemesis09
   - rohitkrai03
   - sahil143
   - vikram-raj
@@ -14,3 +15,5 @@ approvers:
   - christianvogt
   - joshuawilson
   - rohitkrai03
+labels:
+  - component/dev-console

--- a/frontend/packages/knative-plugin/OWNERS
+++ b/frontend/packages/knative-plugin/OWNERS
@@ -3,9 +3,11 @@ reviewers:
   - debsmita1
   - divyanshiGupta
   - christianvogt
+  - gijohn
   - joshuawilson
   - invincibleJai
   - karthikjeeyar
+  - nemesis09
   - rohitkrai03
   - sahil143
   - vikram-raj
@@ -13,3 +15,5 @@ approvers:
   - christianvogt
   - joshuawilson
   - rohitkrai03
+labels:
+  - component/knative

--- a/frontend/packages/kubevirt-plugin/OWNERS
+++ b/frontend/packages/kubevirt-plugin/OWNERS
@@ -10,3 +10,5 @@ approvers:
   - rawagner
   - suomiy
   - jelkosz
+labels:
+  - component/kubevirt

--- a/frontend/packages/metal3-plugin/OWNERS
+++ b/frontend/packages/metal3-plugin/OWNERS
@@ -1,12 +1,9 @@
 reviewers:
   - jtomasek
   - honza
-  - flofuchs
   - knowncitizen
-  - dantrainor
 approvers:
   - jtomasek
   - honza
-  - flofuchs
 labels:
   - component/metal3

--- a/frontend/packages/metal3-plugin/OWNERS
+++ b/frontend/packages/metal3-plugin/OWNERS
@@ -8,3 +8,5 @@ approvers:
   - jtomasek
   - honza
   - flofuchs
+labels:
+  - component/metal3

--- a/frontend/packages/noobaa-storage-plugin/OWNERS
+++ b/frontend/packages/noobaa-storage-plugin/OWNERS
@@ -9,3 +9,5 @@ approvers:
   - rawagner
   - cloudbehl
   - gnehapk
+labels:
+  - component/noobaa

--- a/frontend/packages/noobaa-storage-plugin/OWNERS
+++ b/frontend/packages/noobaa-storage-plugin/OWNERS
@@ -1,13 +1,8 @@
 reviewers:
   - mareklibra
   - rawagner
-  - cloudbehl
-  - gnehapk
-  - afreen23
 approvers:
   - mareklibra
   - rawagner
-  - cloudbehl
-  - gnehapk
 labels:
   - component/noobaa

--- a/frontend/public/OWNERS
+++ b/frontend/public/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - component/core

--- a/frontend/public/components/operator-lifecycle-manager/OWNERS
+++ b/frontend/public/components/operator-lifecycle-manager/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - alecmerdler
   - ecordell
   - spadgett
+labels:
+  - component/olm

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - component/backend


### PR DESCRIPTION
Adds `labels` to owners files for prow `owners-labels` plugin to automatically apply labels.

Requires: https://github.com/openshift/release/pull/4526

cc @spadgett 