### PR TITLE
Fix bug where recommended annotation for git url doesn't affect edit action in topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -218,7 +218,9 @@ export class TransformTopologyData {
         data: {
           url: !_.isEmpty(route.spec) ? getRouteWebURL(route) : this.getRouteData(ksroute),
           kind: targetDeploymentsKind,
-          editUrl: deploymentsAnnotations['app.openshift.io/edit-url'],
+          editUrl:
+            deploymentsAnnotations['app.openshift.io/edit-url'] ||
+            deploymentsAnnotations['app.openshift.io/vcs-uri'],
           builderImage: deploymentsLabels['app.kubernetes.io/name'],
           isKnativeResource: this.isKnativeServing(deploymentConfig, 'metadata.labels'),
           donutStatus: {


### PR DESCRIPTION
Jira issue - https://jira.coreos.com/browse/ODC-1441

Use annotation `app.openshift.io/vcs-uri` instead of `app.openshift.io/edit-url` for the edit button.
For reference - https://github.com/gorkem/app-labels/blob/master/labels-annotation-for-openshift.adoc