### PR TITLE
Revert "Use ContextReplacementPlugin to avoid webpack warnings with monaco"

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -131,11 +131,6 @@ const config: webpack.Configuration = {
     }),
     new webpack.IgnorePlugin(/prettier/),
     extractCSS,
-    // https://github.com/microsoft/monaco-editor-webpack-plugin/issues/13
-    new webpack.ContextReplacementPlugin(
-      /monaco-editor-core\/esm\/vs\/editor\/common\/services/,
-      __dirname
-    ),
   ],
   devtool: 'cheap-module-source-map',
   stats: 'minimal',


### PR DESCRIPTION
Reverts openshift/console#2129

The original fix causes problems for `yarn run dev`. Revert for now. I've confirmed that removing `ContextReplacementPlugin` has no effect on the bundle size.

/cc @rhamilto @alecmerdler 