### PR TITLE
Fix position of loading indicator in LoadingBox component

### DIFF
--- a/frontend/public/components/utils/_status-box.scss
+++ b/frontend/public/components/utils/_status-box.scss
@@ -24,6 +24,15 @@
   }
 }
 
+.cos-status-box--loading {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  min-height: 50px;
+  width: 100%;
+}
+
 .co-m-loader--inline {
   display: inline-block;
   margin: 0;

--- a/frontend/public/components/utils/status-box.tsx
+++ b/frontend/public/components/utils/status-box.tsx
@@ -28,7 +28,7 @@ Loading.displayName = 'Loading';
 export const LoadingInline: React.FC<{}> = () => <Loading className="co-m-loader--inline" />;
 LoadingInline.displayName = 'LoadingInline';
 
-export const LoadingBox: React.FC<LoadingBoxProps> = ({className}) => <Box className={className}><Loading /></Box>;
+export const LoadingBox: React.FC<LoadingBoxProps> = ({className}) => <Box className={classNames('cos-status-box--loading', className)}><Loading /></Box>;
 LoadingBox.displayName = 'LoadingBox';
 
 export const EmptyBox: React.FC<EmptyBoxProps> = ({label}) => <Box>

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -489,25 +489,8 @@ $co-external-link-padding-right: 15px;
   background-color: $color-co-m-row-hover;
 }
 
-.co-m-inline-loader,
 .co-m-loader {
   min-width: 18px;
-}
-
-.co-m-inline-loader {
-  display: inline-block;
-  cursor: default;
-  &:hover {
-    text-decoration: none;
-  }
-}
-
-.co-m-loader {
-  display: block;
-  left: 50%;
-  margin: -11px 0 0 -13px;
-  position: absolute;
-  top: 50%;
 }
 
 .co-m-loader-dot__one,


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1648

Use flexbox instead of absolute positioning to center loading indicator in LoadingBox component.