### PR TITLE
separate the serverless route form so that it can maintain state

### DIFF
--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -61,6 +61,9 @@ const DeployImage: React.FC<DeployImageProps> = ({ namespace }) => {
         privateKey: '',
       },
     },
+    serverlessRoute: {
+      targetPort: '',
+    },
     build: {
       env: [],
       triggers: {

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -69,6 +69,9 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
         privateKey: '',
       },
     },
+    serverlessRoute: {
+      targetPort: '',
+    },
     serverless: {
       enabled: false,
       scaling: {

--- a/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
@@ -3,6 +3,7 @@ import { FormikValues } from 'formik';
 import ProgressiveList from '../../progressive-list/ProgressiveList';
 import ProgressiveListItem from '../../progressive-list/ProgressiveListItem';
 import RouteSection from '../route/RouteSection';
+import ServerlessRouteSection from '../serverless/ServerlessRouteSection';
 import LabelSection from './LabelSection';
 import ScalingSection from './ScalingSection';
 import ServerlessScalingSection from './ServerlessScalingSection';
@@ -27,7 +28,11 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({ values }) => {
       onVisibleItemChange={handleVisibleItemChange}
     >
       <ProgressiveListItem name="Routing">
-        <RouteSection route={values.route} />
+        {values.serverless.enabled ? (
+          <ServerlessRouteSection route={values.route} />
+        ) : (
+          <RouteSection route={values.route} />
+        )}
       </ProgressiveListItem>
       {/* Hide Build for Deploy Image */}
       {values.isi ? null : (

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -28,6 +28,7 @@ export interface DeployImageFormData {
   labels: { [name: string]: string };
   env: { [name: string]: string };
   route: RouteData;
+  serverlessRoute?: ServerlessRouteData;
   build: BuildData;
   deployment: DeploymentData;
   limits: LimitsData;
@@ -42,6 +43,7 @@ export interface GitImportFormData {
   serverless?: ServerlessData;
   image: ImageData;
   route: RouteData;
+  serverlessRoute?: ServerlessRouteData;
   build: BuildData;
   deployment: DeploymentData;
   labels: { [name: string]: string };
@@ -94,6 +96,10 @@ export interface RouteData {
   hostname: string;
   secure: boolean;
   tls: TLSData;
+}
+
+export interface ServerlessRouteData {
+  targetPort: string;
 }
 
 export interface TLSData {

--- a/frontend/packages/dev-console/src/components/import/route/CreateRoute.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/CreateRoute.tsx
@@ -10,7 +10,6 @@ const CreateRoute: React.FC = () => {
     values: {
       image: { ports },
       route: { targetPort },
-      serverless: { enabled: serverlessEnabled },
     },
   } = useFormikContext<FormikValues>();
   const portOptions = ports.reduce((acc, port) => {
@@ -23,17 +22,6 @@ const CreateRoute: React.FC = () => {
     return acc;
   }, {});
 
-  if (serverlessEnabled) {
-    return (
-      <InputField
-        type={TextInputTypes.text}
-        name="route.targetPort"
-        label="Target Port"
-        placeholder="8080"
-        helpText="Target port for traffic."
-      />
-    );
-  }
   return (
     <React.Fragment>
       <InputField

--- a/frontend/packages/dev-console/src/components/import/route/RouteSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/RouteSection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useFormikContext, FormikValues } from 'formik';
 import FormSection from '../section/FormSection';
 import { RouteData } from '../import-types';
 import CreateRoute from './CreateRoute';
@@ -10,17 +9,12 @@ interface RouteSectionProps {
 }
 
 const RouteSection: React.FC<RouteSectionProps> = ({ route }) => {
-  const {
-    values: {
-      serverless: { enabled: serverlessEnabled },
-    },
-  } = useFormikContext<FormikValues>();
   return (
     <FormSection title="Routing">
       {route.create && (
         <React.Fragment>
           <CreateRoute />
-          {!serverlessEnabled && <SecureRoute />}
+          <SecureRoute />
         </React.Fragment>
       )}
     </FormSection>

--- a/frontend/packages/dev-console/src/components/import/serverless/ServerlessRouteSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless/ServerlessRouteSection.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { TextInputTypes } from '@patternfly/react-core';
+import FormSection from '../section/FormSection';
+import { RouteData } from '../import-types';
+import { InputField } from '../../formik-fields';
+
+export interface ServerlessRouteSectionProps {
+  route: RouteData;
+}
+
+const ServerlessRouteSection: React.FC<ServerlessRouteSectionProps> = ({ route }) => {
+  return (
+    <FormSection title="Routing">
+      {route.create && (
+        <InputField
+          type={TextInputTypes.text}
+          name="serverlessRoute.targetPort"
+          label="Target Port"
+          placeholder="8080"
+          helpText="Target port for traffic."
+        />
+      )}
+    </FormSection>
+  );
+};
+
+export default ServerlessRouteSection;


### PR DESCRIPTION
Fixes bug https://jira.coreos.com/browse/ODC-1375

Previously, if you were to change to/from Serverless in the dev console Import/Deploy forms you would lose any Route data since they shared the form. This fix separates the forms.