### PR TITLE
Improve catalog page skeleton

### DIFF
--- a/frontend/public/components/catalog/catalog-page.jsx
+++ b/frontend/public/components/catalog/catalog-page.jsx
@@ -8,7 +8,7 @@ import { CatalogTileViewPage } from './catalog-items';
 import { serviceClassDisplayName, referenceForModel } from '../../module/k8s';
 import { withStartGuide } from '../start-guide';
 import { connectToFlags, flagPending } from '../../reducers/features';
-import { Firehose, PageHeading, StatusBox } from '../utils';
+import { Firehose, PageHeading, skeletonCatalog, StatusBox } from '../utils';
 import {
   getAnnotationTags,
   getMostRecentBuilderTag,
@@ -24,18 +24,6 @@ import {
 import { ClusterServiceClassModel, ClusterServiceVersionModel } from '../../models';
 import { providedAPIsFor, referenceForProvidedAPI } from '../operator-lifecycle-manager';
 import * as operatorLogo from '../../imgs/operator.svg';
-
-export const skeletonCatalog = <div className="loading-skeleton--catalog">
-  <div className="skeleton-catalog--list" />
-  <div className="skeleton-catalog--grid">
-    <div className="skeleton-catalog--tile" />
-    <div className="skeleton-catalog--tile" />
-    <div className="skeleton-catalog--tile" />
-    <div className="skeleton-catalog--tile" />
-    <div className="skeleton-catalog--tile" />
-    <div className="skeleton-catalog--tile" />
-  </div>
-</div>;
 
 export class CatalogListPage extends React.Component {
   constructor(props) {

--- a/frontend/public/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-page.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import { match } from 'react-router';
 
-import { Firehose, PageHeading, StatusBox, MsgBox, ExternalLink, withFallback } from '../utils';
+import { Firehose, PageHeading, StatusBox, MsgBox, ExternalLink, skeletonCatalog, withFallback } from '../utils';
 import { ErrorBoundaryFallback } from '../error';
 import { referenceForModel } from '../../module/k8s';
 import { fromRequirements } from '../../module/k8s/selector';
@@ -13,7 +13,6 @@ import { OperatorHubTileView } from './operator-hub-items';
 import { PackageManifestKind, OperatorGroupKind, SubscriptionKind } from '../operator-lifecycle-manager';
 import { installedFor, subscriptionFor } from '../operator-lifecycle-manager/operator-group';
 import { OperatorHubItem, OperatorHubCSVAnnotations } from './index';
-import { skeletonCatalog } from '../catalog/catalog-page';
 
 import * as operatorImg from '../../imgs/operator.svg';
 

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -55,6 +55,7 @@ export * from './camel-case-wrap';
 export * from './truncate-middle';
 export * from './expand-collapse';
 export * from './volume-type';
+export * from './skeleton-catalog';
 
 /*
   Add the enum for NameValueEditorPair here and not in its namesake file because the editor should always be

--- a/frontend/public/components/utils/skeleton-catalog.tsx
+++ b/frontend/public/components/utils/skeleton-catalog.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+
+// 12 works well because it divides evenly for 2, 3, and 4 column layouts
+const skeletonTiles = Array.from({ length: 12 }, (_, k: number) => <div key={k} className="skeleton-catalog--tile" />);
+export const skeletonCatalog = <div className="loading-skeleton--catalog">
+  <div className="skeleton-catalog--list" />
+  <div className="skeleton-catalog--grid">{skeletonTiles}</div>
+</div>;


### PR DESCRIPTION
* Use 12 skeleton tiles (works well for 2, 3, and 4 column layouts)
* Remove dependency between OperatorHub and Developer Catalog bundles