### PR TITLE
show starting guide on build config page when there are no projects

### DIFF
--- a/frontend/packages/dev-console/src/components/BuildConfigPage.tsx
+++ b/frontend/packages/dev-console/src/components/BuildConfigPage.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { match as RMatch } from 'react-router';
+import * as _ from 'lodash';
 import { BuildConfigsPage } from '@console/internal/components/build-config';
+import { withStartGuide } from '../../../../public/components/start-guide';
 import DefaultPage from './DefaultPage';
 
 export interface BuildConfigPageProps {
@@ -9,15 +11,17 @@ export interface BuildConfigPageProps {
     ns?: string;
   }>;
 }
-const BuildConfigPage: React.FC<BuildConfigPageProps> = (props) => {
-  const namespace = props.match.params.ns;
+const allParams = (props) => Object.assign({}, _.get(props, 'match.params'), props);
+
+const BuildConfigPage = withStartGuide((props: BuildConfigPageProps) => {
+  const { noProjectsAvailable, ns } = allParams(props);
   return (
     <React.Fragment>
       <Helmet>
         <title>Builds</title>
       </Helmet>
-      {namespace ? (
-        <BuildConfigsPage {...props} />
+      {ns ? (
+        <BuildConfigsPage {...props} mock={noProjectsAvailable} />
       ) : (
         <DefaultPage title="Build Configs">
           Select a project to view the list of build configs
@@ -25,6 +29,6 @@ const BuildConfigPage: React.FC<BuildConfigPageProps> = (props) => {
       )}
     </React.Fragment>
   );
-};
+});
 
 export default BuildConfigPage;

--- a/frontend/packages/dev-console/src/components/BuildConfigPage.tsx
+++ b/frontend/packages/dev-console/src/components/BuildConfigPage.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { match as RMatch } from 'react-router';
-import * as _ from 'lodash';
 import { BuildConfigsPage } from '@console/internal/components/build-config';
 import { withStartGuide } from '../../../../public/components/start-guide';
 import DefaultPage from './DefaultPage';
@@ -10,17 +9,17 @@ export interface BuildConfigPageProps {
   match: RMatch<{
     ns?: string;
   }>;
+  noProjectsAvailable?: boolean;
 }
-const allParams = (props) => Object.assign({}, _.get(props, 'match.params'), props);
 
-const BuildConfigPage = withStartGuide((props: BuildConfigPageProps) => {
-  const { noProjectsAvailable, ns } = allParams(props);
+const BuildConfigPage: React.FC<BuildConfigPageProps> = ({ noProjectsAvailable, ...props }) => {
+  const namespace = props.match.params.ns;
   return (
     <React.Fragment>
       <Helmet>
         <title>Builds</title>
       </Helmet>
-      {ns ? (
+      {namespace ? (
         <BuildConfigsPage {...props} mock={noProjectsAvailable} />
       ) : (
         <DefaultPage title="Build Configs">
@@ -29,6 +28,6 @@ const BuildConfigPage = withStartGuide((props: BuildConfigPageProps) => {
       )}
     </React.Fragment>
   );
-});
+};
 
-export default BuildConfigPage;
+export default withStartGuide(BuildConfigPage);

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -180,6 +180,7 @@ export type BuildConfigsDetailsProps = {
 
 export type BuildConfigsPageProps = {
   filterLabel?: string;
+  mock?: any;
 };
 
 export type BuildConfigsDetailsPageProps = {

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -180,7 +180,7 @@ export type BuildConfigsDetailsProps = {
 
 export type BuildConfigsPageProps = {
   filterLabel?: string;
-  mock?: any;
+  mock?: boolean;
 };
 
 export type BuildConfigsDetailsPageProps = {


### PR DESCRIPTION
Fixes the bug : https://jira.coreos.com/browse/ODC-1389

![Build-config-page](https://user-images.githubusercontent.com/22490998/62009069-8c53ba00-b178-11e9-8cb7-ecf0fb0664d4.gif)
