### PR TITLE
Bug RHSTOR-495: Fixed the title,height and migration of pf3 to pf4 icons

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/data-resiliency/data-resiliency.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/data-resiliency/data-resiliency.scss
@@ -1,10 +1,8 @@
-@import '~@patternfly/patternfly/sass-utilities/colors';
-
 .ceph-data-resiliency__dashboard-body {
   display: flex;
   flex-direction: column;
   height: 18.6em;
-  justify-content: center;
+  margin-top: 1.5em;
   text-align: center;
 }
 
@@ -16,6 +14,11 @@
   font-size: 60px;
 }
 
+.ceph-data-resiliency__progress-bar {
+  text-align: left;
+  grid-gap: 0rem;
+}
+
 .ceph-data-resiliency__status-title-error {
   margin-top: 1.5625em;
 }
@@ -25,12 +28,8 @@
 }
 
 .ceph-data-resiliency__title {
-  margin-bottom: 6em;
+  margin-bottom: 7em;
   text-align: center;
-}
-
-.ceph-data-resiliency__utilization-bar {
-  text-align: left;
 }
 
 .ceph-data-resiliency__dashboard-card {

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/data-resiliency/data-resiliency.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/data-resiliency/data-resiliency.tsx
@@ -39,7 +39,7 @@ const DataResiliencyBuildBody: React.FC<DataResiliencyBuildBody> = ({ progressPe
   <>
     <div className="ceph-data-resiliency__title">Rebuilding data resiliency</div>
     <Progress
-      className="ceph-data-resiliency__utilization-bar"
+      className="ceph-data-resiliency__progress-bar"
       value={progressPercentage}
       title="Rebuilding in Progress"
       label={`${progressPercentage}%`}

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-resiliency-card/data-resiliency-card.scss
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-resiliency-card/data-resiliency-card.scss
@@ -1,10 +1,8 @@
-@import '~@patternfly/patternfly/sass-utilities/colors';
-
 .nb-data-resiliency__dashboard-body {
   display: flex;
   flex-direction: column;
-  height: 15.9em;
   justify-content: center;
+  margin-top: 1.5em;
   text-align: center;
 }
 
@@ -13,27 +11,24 @@
 }
 
 .nb-data-resiliency__icon--error {
-  color: $pf-color-red-100;
+  font-size: 60px;
 }
 
 .nb-data-resiliency__icon--ok {
-  color: $pf-color-light-green-400;
+  font-size: 60px;
+}
+
+.nb-data-resiliency__progress-bar {
+  text-align: left;
+  grid-gap: 0rem;
 }
 
 .nb-data-resiliency__status-title--error {
   margin-top: 1.5625em;
 }
 
-.nb-data-resiliency__status-title--ok {
-  margin-bottom: 3.5em;
-}
-
 .nb-data-resiliency__title {
-  margin-bottom: 6em;
-  text-align: center;
+  font-size: 1rem;
+  margin-top: 0;
+  margin-bottom: 3em;
 }
-
-.nb-data-resiliency__utilization-bar {
-  text-align: left;
-}
-

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-resiliency-card/data-resiliency-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-resiliency-card/data-resiliency-card.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { Icon } from 'patternfly-react';
 import { pluralize, Progress } from '@patternfly/react-core';
+import { GreenCheckCircleIcon, RedExclamationCircleIcon } from '@console/shared';
 import {
   DashboardCard,
   DashboardCardBody,
@@ -30,15 +30,15 @@ const getFormattedEta = (eta: number): string => {
 const DataResiliencyStatusBody: React.FC<DataResiliencyStatusBody> = ({ isResilient }) =>
   isResilient ? (
     <>
-      <div className="nb-data-resiliency__status-title--ok">Your Data is Resilient</div>
+      <div className="nb-data-resiliency__title">Your data is resilient</div>
       <div className="nb-data-resiliency__icon--ok">
-        <Icon type="fa" name="check-circle" size="5x" />
+        <GreenCheckCircleIcon />
       </div>
     </>
   ) : (
     <>
       <div className="nb-data-resiliency__icon--error">
-        <Icon type="fa" name="exclamation-triangle" size="5x" />
+        <RedExclamationCircleIcon />
       </div>
       <div className="nb-data-resiliency__status-title--error">No data available</div>
     </>
@@ -50,7 +50,7 @@ const DataResiliencyBuildBody: React.FC<DataResiliencyBuildBody> = React.memo(
       <>
         <div className="nb-data-resiliency__title">Rebuilding data</div>
         <Progress
-          className="nb-data-resiliency__utilization-bar"
+          className="nb-data-resiliency__progress-bar"
           value={progressPercentage}
           title="Rebuilding in Progress"
           label={`${progressPercentage}%`}


### PR DESCRIPTION
![datares1](https://user-images.githubusercontent.com/25664409/62415200-827ffa00-b643-11e9-960c-d82465572c05.png)
![dr2](https://user-images.githubusercontent.com/25664409/62453012-085c8c00-b78f-11e9-8c2f-4f2fa48284a2.png)
![dr1](https://user-images.githubusercontent.com/25664409/62453030-18746b80-b78f-11e9-8171-f247cfa2c310.png)

* Removed the gap between progress bar title and progress bar
* Fixed the height and title of data resiliency card in object service dashboard
* Migration from pf3 to pf4 icons
