### PR TITLE
Monitoring: Fix graph zoom & tooltips

### DIFF
--- a/frontend/public/components/graphs/themes.ts
+++ b/frontend/public/components/graphs/themes.ts
@@ -55,7 +55,7 @@ export const queryBrowserTheme = {
   chart: {
     padding: {
       bottom: 0,
-      left: 40,
+      left: 0,
       right: 0,
       top: 0,
     },

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -1,3 +1,7 @@
+.graph-wrapper--query-browser {
+  padding-left: 40px;
+}
+
 .query-browser__clear-icon {
   color: $color-pf-black-600;
   font-size: 18px;
@@ -190,6 +194,19 @@ $tooltip-background-color: #151515;
   overflow: visible;
   padding: 10px;
   width: 100%;
+}
+
+.query-browser__zoom-overlay {
+  background-color: rgba(0, 0, 0, 0.2);
+  bottom: 0;
+  position: absolute;
+  top: 0;
+  z-index: $zindex-modal;
+}
+
+.query-browser__zoom {
+  cursor: ew-resize;
+  position: relative;
 }
 
 .co-alert-manager-yaml__explanation {


### PR DESCRIPTION
Fix several related problems with graph zooming and tooltips.

The interaction between graph zooming and tooltips caused several bugs.
This fixes them by implementing our own zoom.

Removes the need to use Victory Chart's `VictorySelectionContainer` and
`createContainer()`.

Fixes
  - Bug where tooltip stopped displaying after graph data was updated
  - Improve laggy UI when selecting an area of the graph
  - Allow zooming on a region of the graph with no data points
  - Prevent zooming down to a time span so small that the Prometheus API
    returns an error
  - Prevent some unnecessary re-renders of the graph by replacing
    `Graph`'s `metadata` and `onZoom` props with a single
    `containerComponent` prop, which is memoized
  - Hide tooltips when zooming because they can get in the way when
    selecting the zoom region

Limits the zoom feature to only zooming the X-axis. This is preferable
to the previous behaviour of only being able to select a rectangular
region of the graph. Y-axis zooming may be brought back in a future PR.

Change cursor to `ew-resize` to give a visual indication that the graph
can be zoomed.

Fixes
  - https://bugzilla.redhat.com/show_bug.cgi?id=1733123
  - https://bugzilla.redhat.com/show_bug.cgi?id=1732649
  - https://bugzilla.redhat.com/show_bug.cgi?id=1731322
  - https://bugzilla.redhat.com/show_bug.cgi?id=1731319
  - https://jira.coreos.com/browse/MON-727
  - https://jira.coreos.com/browse/MON-728