### PR TITLE
Bug 1732678: Fix text overflow in  bar chart

### DIFF
--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -1,3 +1,10 @@
+.graph-bar__label {
+  text-align: left;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap; 
+}
+
 .graph-empty-state {
   background: #f5f5f5;
 }

--- a/frontend/public/components/graphs/bar.tsx
+++ b/frontend/public/components/graphs/bar.tsx
@@ -1,9 +1,6 @@
-import * as _ from 'lodash-es';
 import * as React from 'react';
 import { ChartBarIcon } from '@patternfly/react-icons';
 import {
-  Chart,
-  ChartAxis,
   ChartBar,
   ChartLabel,
   ChartThemeColor,
@@ -17,14 +14,11 @@ import { PrometheusEndpoint } from './helpers';
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
 import { barTheme } from './themes';
 import { humanizeNumber, Humanize } from '../utils';
-import { DomainPadding, DataPoint } from '.';
+import { DataPoint } from '.';
 import { getInstantVectorStats } from './utils';
 import { GraphEmpty } from './graph-empty';
 
-const BAR_PADDING = 8; // Space between each bar (top and bottom)
-const BAR_LABEL_PADDING = 8;
 const DEFAULT_BAR_WIDTH = 10;
-const DEFAULT_DOMAIN_PADDING: DomainPadding = { x: [20, 10] };
 const PADDING_RATIO = 1 / 3;
 
 export const BarChart: React.FC<BarChartProps> = ({
@@ -32,7 +26,6 @@ export const BarChart: React.FC<BarChartProps> = ({
   title,
   query,
   data = [],
-  domainPadding = DEFAULT_DOMAIN_PADDING,
   theme = getCustomTheme(ChartThemeColor.blue, ChartThemeVariant.light, barTheme),
   titleClassName,
   loading = false,
@@ -42,42 +35,36 @@ export const BarChart: React.FC<BarChartProps> = ({
   // Max space that horizontal padding should take up. By default, 2/3 of the horizontal space is always available for the actual bar graph.
   const maxHorizontalPadding = PADDING_RATIO * width;
 
-  // SVG text element is slightly taller than font size
-  const xAxisTickLabelHeight = _.get(theme, 'independentAxis.style.tickLabels.fontSize') || _.get(theme, 'axis.style.tickLabels.fontSize', 14) * 1.25;
-  const barFootprint = barWidth + xAxisTickLabelHeight + BAR_PADDING + BAR_LABEL_PADDING;
-  const topPadding = xAxisTickLabelHeight + BAR_LABEL_PADDING; // Moving the label above the bar
-
-  // Calculate total graph height, accounting for domain padding.
-  const height = barFootprint * data.length + topPadding;
   const padding = {
-    bottom: 0,
+    bottom: 15,
     left: 0,
     right: Math.min(100, maxHorizontalPadding),
-    top: topPadding,
+    top: 0,
   };
 
-  const tickLabelComponent = <ChartLabel x={0} verticalAnchor="start" transform={`translate(0, -${xAxisTickLabelHeight + BAR_LABEL_PADDING})`} />;
-  const labelComponent = <ChartLabel x={width} />;
+  const sortedData = data.sort((a, b) => b.y - a.y);
+
   return (
     <PrometheusGraph ref={containerRef} title={title} className={titleClassName} >
       {
-        data.length ? (
+        sortedData.length ? (
           <PrometheusGraphLink query={query}>
-            <Chart
-              domainPadding={domainPadding}
-              height={height}
-              theme={theme}
-              width={width}
-              padding={padding}
-            >
-              <ChartAxis tickLabelComponent={tickLabelComponent} />
-              <ChartBar
-                barWidth={barWidth}
-                data={data}
-                horizontal
-                labelComponent={labelComponent}
-              />
-            </Chart>
+            {sortedData.map((datum, index) => (
+              <React.Fragment key={index}>
+                <div className="graph-bar__label">{datum.x}</div>
+                <ChartBar
+                  barWidth={barWidth}
+                  data={[datum]}
+                  horizontal
+                  labelComponent={<ChartLabel x={width} />}
+                  theme={theme}
+                  height={barWidth + padding.bottom}
+                  width={width}
+                  domain={{y: [0, sortedData[0].y]}}
+                  padding={padding}
+                />
+              </React.Fragment>
+            ))}
           </PrometheusGraphLink>
         ) : (
           <GraphEmpty icon={ChartBarIcon} loading={loading} height={100} />
@@ -92,7 +79,6 @@ export const Bar: React.FC<BarProps> = ({
   metric,
   namespace,
   barWidth,
-  domainPadding,
   theme,
   query,
   title,
@@ -106,7 +92,6 @@ export const Bar: React.FC<BarProps> = ({
       query={query}
       data={data}
       barWidth={barWidth}
-      domainPadding={domainPadding}
       theme={theme}
       loading={loading}
     />
@@ -115,7 +100,6 @@ export const Bar: React.FC<BarProps> = ({
 
 type BarChartProps = {
   barWidth?: number;
-  domainPadding?: DomainPadding;
   query: string;
   theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
   title?: string;
@@ -129,7 +113,6 @@ type BarProps = {
   metric: string;
   namespace?: string;
   barWidth?: number;
-  domainPadding?: DomainPadding;
   query: string;
   theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
   title?: string;

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -22,7 +22,7 @@ export const PrometheusGraphLink = connectToURLs(MonitoringRoutes.Prometheus)(
   ({children, query, urls}: React.PropsWithChildren<PrometheusGraphLinkProps>) => {
     const url = getPrometheusExpressionBrowserURL(urls, [query]);
     return query
-      ? <a href={url} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }}>{children}</a>
+      ? <a href={url} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>{children}</a>
       : <React.Fragment>{children}</React.Fragment>;
   }
 );

--- a/frontend/public/components/graphs/utils.ts
+++ b/frontend/public/components/graphs/utils.ts
@@ -14,7 +14,7 @@ export const getRangeVectorStats: GetStats = response => {
 export const getInstantVectorStats: GetStats = (response, metric, humanize) => {
   const results = _.get(response, 'data.result', []);
   return results.map(r => {
-    const y = _.get(r, 'value[1]');
+    const y = parseFloat(_.get(r, 'value[1]'));
     return {
       label: humanize ? humanize(y).string : null,
       x: _.get(r, ['metric', metric], ''),


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1732678

![top_consumers_wrap](https://user-images.githubusercontent.com/2078045/62045231-2103f980-b205-11e9-8422-f308162b9b2e.png)

Overflown text is now truncated with ellipsis. According to https://docs.google.com/document/d/1oT2n1S7m9wR9Fg8MmQogvLXyRiBgUS_yNFhE0bszMVw/edit?disco=AAAADPNd5BE we will also want to make these titles clickable.

@spadgett do we want to make titles in bar chart clickable for 4.2 ? If not, I should probably wrap the titles instead of truncating.

@andybraren @TheRealJon 
