### PR TITLE
Fix bug to show an application selected by default in import flows

### DIFF
--- a/frontend/packages/dev-console/src/components/dropdown/ApplicationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ApplicationDropdown.tsx
@@ -23,6 +23,7 @@ interface ApplicationDropdownProps {
     actionKey: string;
   };
   selectedKey: string;
+  autoSelect?: boolean;
   onChange?: (key: string, name?: string) => void;
 }
 

--- a/frontend/packages/dev-console/src/components/dropdown/ResourceDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ResourceDropdown.tsx
@@ -39,6 +39,7 @@ interface ResourceDropdownProps {
   placeholder?: string;
   resources?: FirehoseList[];
   selectedKey: string;
+  autoSelect?: boolean;
   resourceFilter?: (resource: any) => boolean;
   onChange?: (key: string, name?: string) => void;
 }
@@ -66,13 +67,19 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
       resourceFilter,
       dataSelector,
       selectedKey,
+      autoSelect,
     } = nextProps;
 
     if (!loaded) {
       this.setState({ title: <LoadingInline /> });
       return;
     }
-    if (!this.props.loaded || !selectedKey) {
+
+    // If autoSelect is true only then have an item pre-selected based on selectedKey.
+    if (autoSelect) {
+      const selectedItemKey = !selectedKey ? _.get(_.keys(this.state.items), 0) : selectedKey;
+      this.onChange(selectedItemKey);
+    } else if (!this.props.loaded || !selectedKey) {
       this.setState({
         title: <span className="btn-dropdown__item--placeholder">{placeholder}</span>,
       });
@@ -137,8 +144,10 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
     const name = this.state.items[key];
     const { actionItem, onChange } = this.props;
     const title = actionItem && key === actionItem.actionKey ? actionItem.actionTitle : name;
-    onChange && this.props.onChange(key, name);
-    this.setState({ title });
+    if (title !== this.state.title) {
+      onChange && this.props.onChange(key, name);
+      this.setState({ title });
+    }
   };
 
   render() {

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import * as plugins from '@console/internal/plugins';
 import { Formik } from 'formik';
 import { history, AsyncComponent } from '@console/internal/components/utils';
-import { getActivePerspective } from '@console/internal/reducers/ui';
+import { getActivePerspective, getActiveApplication } from '@console/internal/reducers/ui';
 import { RootState } from '@console/internal/redux';
 import { connect } from 'react-redux';
+import { ALL_APPLICATIONS_KEY } from '@console/internal/const';
 import { NormalizedBuilderImages, normalizeBuilderImages } from '../../utils/imagestream-utils';
 import { GitImportFormData, FirehoseList, ImportData } from './import-types';
 import { createResources } from './import-submit-utils';
@@ -18,6 +19,7 @@ export interface ImportFormProps {
 
 export interface StateProps {
   perspective: string;
+  activeApplication: string;
 }
 
 const ImportForm: React.FC<ImportFormProps & StateProps> = ({
@@ -25,6 +27,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
   imageStreams,
   importData,
   perspective,
+  activeApplication,
 }) => {
   const initialValues: GitImportFormData = {
     name: '',
@@ -32,8 +35,8 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       name: namespace || '',
     },
     application: {
-      name: '',
-      selectedKey: '',
+      name: activeApplication,
+      selectedKey: activeApplication,
     },
     git: {
       url: '',
@@ -160,8 +163,11 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
 };
 
 const mapStateToProps = (state: RootState): StateProps => {
+  const perspective = getActivePerspective(state);
+  const activeApplication = getActiveApplication(state);
   return {
-    perspective: getActivePerspective(state),
+    perspective,
+    activeApplication: activeApplication !== ALL_APPLICATIONS_KEY ? activeApplication : '',
   };
 };
 

--- a/frontend/packages/dev-console/src/components/import/app/ApplicationSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/app/ApplicationSelector.tsx
@@ -48,6 +48,7 @@ const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({ namespace }) 
             actionTitle: 'Create New Application',
             actionKey: CREATE_APPLICATION_KEY,
           }}
+          autoSelect
           selectedKey={selectedKey.value}
           onChange={onDropdownChange}
         />


### PR DESCRIPTION
Jira Issue - https://jira.coreos.com/browse/ODC-1392

- If `all applications` is selected in the secondary mast-head, default to first application in the app dropdown.
- If `activeApplication` is present, select that from the app dropdown.

![default-app](https://user-images.githubusercontent.com/20724543/62048391-67b81a80-b22a-11e9-8271-a1a167f029d4.gif)
