### PR TITLE
set a max length of 2000 char for the git import URL

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -26,6 +26,7 @@ export const validationSchema = yup.object().shape({
   git: yup.object().shape({
     url: yup
       .string()
+      .max(2000, 'Please enter a URL that is less then 2000 characters.')
       .matches(urlRegex, 'Invalid Git URL.')
       .required('Required'),
     type: yup.string().when('showGitType', {


### PR DESCRIPTION
fixes https://jira.coreos.com/browse/ODC-764

The suggested safest max length for a URL is 2000. This will set the validation for the Import from Git form for the Git URL to 2000 characters.