### PR TITLE
fix(topology-groups): Reset the application selector when selected application is deleted

### DIFF
--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -62,6 +62,7 @@ const Status: React.FC<StatusProps> = ({ status, title, children, iconOnly }) =>
     case 'Bound':
     case 'Complete':
     case 'Completed':
+    case 'Succeeded':
     case 'Enabled':
     case 'Ready':
     case 'Up to date':

--- a/frontend/packages/dev-console/src/components/dropdown/ResourceDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ResourceDropdown.tsx
@@ -117,10 +117,17 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
       });
 
     this.setState({ items: sortedList });
+    if (
+      (_.isEmpty(sortedList) || !sortedList[this.props.selectedKey]) &&
+      allSelectorItem &&
+      allSelectorItem.allSelectorKey !== this.props.selectedKey
+    ) {
+      this.onChange(allSelectorItem.allSelectorKey);
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    if (_.isEqual(this.state, nextState)) {
+    if (_.isEqual(this.state, nextState) && _.isEqual(this.props, nextProps)) {
       return false;
     }
     return true;


### PR DESCRIPTION
1. Resets the application selector when the selected group is deleted
2. Fixes Pipeline success status issue in pipeline ist component.

![screencast-localhost-9000-2019 07 30-00-14-24](https://user-images.githubusercontent.com/9964343/62073901-46255600-b25f-11e9-9231-2a671c7b71a2.gif)

fixes: https://jira.coreos.com/browse/ODC-1128