### PR TITLE
Remove LoadingInline from namespace details private ResourceQuotas component

### DIFF
--- a/frontend/public/components/overview/namespace-overview.tsx
+++ b/frontend/public/components/overview/namespace-overview.tsx
@@ -4,7 +4,7 @@ import * as _ from 'lodash-es';
 import { requirePrometheus } from '../graphs';
 import { Health } from '../graphs/health';
 import { deleteModal, NamespaceLineCharts, NamespaceSummary, TopPodsBarChart } from '../namespace';
-import { Firehose, LoadingInline, ResourceLink, resourceListPathFromModel, StatusBox } from '../utils';
+import { Firehose, ResourceLink, resourceListPathFromModel, StatusBox } from '../utils';
 import { RoleBindingModel } from '../../models';
 import { K8sResourceKind } from '../../module/k8s';
 import { getQuotaResourceTypes, hasComputeResources, QuotaGaugeCharts, QuotaScopesInline } from '../resource-quota';
@@ -64,7 +64,7 @@ const ResourceQuotas: React.SFC<QuotaBoxesProps> = ({resourceQuotas}) => {
   const { loaded, loadError, data: quotas } = resourceQuotas;
 
   if (!loaded) {
-    return <LoadingInline />;
+    return null;
   }
   if (loadError) {
     <StatusBox loadError={loadError} />;


### PR DESCRIPTION
Resource quota section on the namespace details page should not render anything until the Firehose is not in a 'loading' state. Fixes https://jira.coreos.com/browse/CONSOLE-1659