### PR TITLE
Bug 1665010: Add button link co copy webhook URL with secret to the clipboard

### DIFF
--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -175,7 +175,7 @@ export const BuildConfigsPage: React.SFC<BuildConfigsPageProps> = props =>
 BuildConfigsPage.displayName = 'BuildConfigsListPage';
 
 export type BuildConfigsDetailsProps = {
-  obj: any;
+  obj: K8sResourceKind;
 };
 
 export type BuildConfigsPageProps = {

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -95,6 +95,7 @@ export type K8sResourceKind = {
   };
   status?: {[key: string]: any};
   type?: {[key: string]: any};
+  data?: {[key: string]: any};
 };
 
 export type VolumeMount = {


### PR DESCRIPTION
If user got permissions to Get Secrets the `Copy URL with Secret` link button will appear in the Webhook table. 

Screens:
- desktop <img width="1403" alt="Screen Shot 2019-07-30 at 11 54 01" src="https://user-images.githubusercontent.com/1668218/62121516-0d6b9800-b2c4-11e9-92c9-bc71aabdf032.png">
- tablet <img width="826" alt="Screen Shot 2019-07-30 at 11 55 47" src="https://user-images.githubusercontent.com/1668218/62121554-1f4d3b00-b2c4-11e9-88fb-8ebc51c67885.png">
- mobile <img width="398" alt="Screen Shot 2019-07-30 at 11 54 55" src="https://user-images.githubusercontent.com/1668218/62121553-1f4d3b00-b2c4-11e9-812b-fc950ec25178.png">


In case use doesnt have permissions the Get the secret the table wont contain the link button to copy the webhookURL.

The secret for a particular webhook is get on demand, after clicking on the link.
After that the webhookURL is constructed and copied into the clipboard.

@bmignano PTAL

/assign @spadgett @dgoodwin 