### PR TITLE
Query Browser: Fix zoom `x2` value

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -196,17 +196,17 @@ $tooltip-background-color: #151515;
   width: 100%;
 }
 
+.query-browser__zoom {
+  cursor: ew-resize;
+  position: relative;
+}
+
 .query-browser__zoom-overlay {
   background-color: rgba(0, 0, 0, 0.2);
   bottom: 0;
   position: absolute;
   top: 0;
   z-index: $zindex-modal;
-}
-
-.query-browser__zoom {
-  cursor: ew-resize;
-  position: relative;
 }
 
 .co-alert-manager-yaml__explanation {

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -262,7 +262,9 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   const onMouseDown = (e) => {
     if (!isZooming) {
       setIsZooming(true);
-      setX1(e.clientX - e.currentTarget.getBoundingClientRect().left);
+      const x = e.clientX - e.currentTarget.getBoundingClientRect().left;
+      setX1(x);
+      setX2(x);
     }
   };
 


### PR DESCRIPTION
Without this fix, the selected zoom region can momentarily appear to
expand from the left edge of the graph to the current cursor position.

Also fix CSS rule ordering to be alphabetical.