### PR TITLE
Move `Import YAML` to masthead

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -65,10 +65,6 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
   color: gold;
 }
 
-.co-add-actions-selector__icon {
-  margin: 0 5px 0 0;
-}
-
 .co-namespace-bar {
   border-bottom: 1px solid $color-grey-background-border;
   padding: 0 15px;
@@ -79,14 +75,9 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
     padding-right: 30px;
   }
 
-  &__import {
-    color: inherit;
-  }
-
   &__items {
     align-items: center;
     display: flex;
-    justify-content: space-between;
 
     .pf-m-plain {
       color: inherit;
@@ -106,6 +97,7 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
 }
 
 .co-namespace-selector {
+  margin-right: 20px;
   max-width: 60%;
 
   .pf-c-dropdown__toggle.pf-m-plain {

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -13,6 +13,7 @@ import {
   global_BackgroundColor_dark_100 as editorBackground,
 } from '@patternfly/react-tokens';
 
+import { ALL_NAMESPACES_KEY } from '../const';
 import { k8sCreate, k8sUpdate, referenceFor, groupVersionFor, referenceForModel } from '../module/k8s';
 import { checkAccess, history, Loading, resourceObjPath } from './utils';
 import { ExploreTypeSidebar } from './sidebars/explore-type-sidebar';
@@ -265,6 +266,10 @@ export const EditYAML = connect(stateToProps)(
 
       // If this is a namesapced resource, default to the active namespace when none is specified in the YAML.
       if (!obj.metadata.namespace && model.namespaced) {
+        if (this.props.activeNamespace === ALL_NAMESPACES_KEY) {
+          this.handleError('No "metadata.namespace" field found in YAML.');
+          return;
+        }
         obj.metadata.namespace = this.props.activeNamespace;
       }
 

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -7,7 +7,6 @@ import { Tooltip } from './utils/tooltip';
 import { Link } from 'react-router-dom';
 import * as fuzzy from 'fuzzysearch';
 import { Status } from '@console/shared';
-import { PlusCircleIcon } from '@patternfly/react-icons';
 
 import { NamespaceModel, ProjectModel, SecretModel } from '../models';
 import { k8sGet } from '../module/k8s';
@@ -410,7 +409,6 @@ class NamespaceBarDropdowns_ extends React.Component {
         storageKey={NAMESPACE_LOCAL_STORAGE_KEY}
         shortCut={KEYBOARD_SHORTCUTS.focusNamespaceDropdown} />
       { children }
-      <Link to={UIActions.formatNamespacedRouteForResource('import', activeNamespace)} className="co-namespace-bar__import"><PlusCircleIcon className="co-add-actions-selector__icon" />Import YAML</Link>
     </div>;
   }
 }


### PR DESCRIPTION
Resolves https://jira.coreos.com/browse/CONSOLE-1647

Note per discussion with @beanh66, the tooltip did not get added to the `Import YAML` icon as it would make it an outlier with the other icons present in the masthead.  Additionally, the addition of another icon required optionally hiding the system update icon at viewport widths 768px - 991px **if** the systems status icon is also present (note there are 5 icons possible in the header now, but we only have room to display 4 at these sizes).

![localhost_9000_import-yaml](https://user-images.githubusercontent.com/895728/62161945-381a1880-b2e5-11e9-881d-d4e4cdb7803f.png)

![localhost_9000_topology_ns_robb](https://user-images.githubusercontent.com/895728/62388163-9a178f80-b52a-11e9-818a-1382a68804b0.png)
