### PR TITLE
Fix bug for infinite calls to get imagestream tag in git import

### DIFF
--- a/frontend/packages/dev-console/src/components/import/builder/BuilderImageTagSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderImageTagSelector.tsx
@@ -49,15 +49,9 @@ const BuilderImageTagSelector: React.FC<BuilderImageTagSelectorProps> = ({
         setFieldValue('image.ports', ports);
       })
       .catch((err) => setFieldError('image.ports', err.message));
-  }, [
-    selectedImageTag,
-    setFieldValue,
-    setFieldError,
-    imageName,
-    imageStreamNamespace,
-    imageTag,
-    k8sGet,
-  ]);
+    // Find a way to use useSafeK8s hooks without adding it to the deps array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedImageTag, setFieldValue, setFieldError, imageName, imageStreamNamespace, imageTag]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Fixes -  https://jira.coreos.com/browse/ODC-1499

- This PR fixes the bug that caused infinite calls to get imagestream tags when a builder image is selected in git import form. 
- It was caused by adding wrong dependency in `useEffect` hook which caused it to call the hook infinitely.