### PR TITLE
Fix list page row filter margins

### DIFF
--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -103,10 +103,7 @@ export class ListPageWrapper_ extends React.PureComponent {
     });
 
     return <div>
-      {!_.isEmpty(data) && <div className="row">
-        {RowsOfRowFilters}
-      </div>
-      }
+      {!_.isEmpty(data) && RowsOfRowFilters}
       <div className="row">
         <div className="col-xs-12">
           <ListComponent {...this.props} data={data} />

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -654,16 +654,14 @@ const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringListPage
         </div>
       </div>
       <div className="co-m-pane__body">
-        <div className="row">
-          <CheckBoxes
-            items={rowFilter.items}
-            itemCount={_.size(data)}
-            numbers={_.countBy(data, rowFilter.reducer)}
-            reduxIDs={[reduxID]}
-            selected={rowFilter.selected}
-            type={rowFilter.type}
-          />
-        </div>
+        <CheckBoxes
+          items={rowFilter.items}
+          itemCount={_.size(data)}
+          numbers={_.countBy(data, rowFilter.reducer)}
+          reduxIDs={[reduxID]}
+          selected={rowFilter.selected}
+          type={rowFilter.type}
+        />
         <div className="row">
           <div className="col-xs-12">
             <Table


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1619

The list row filter bars were jutting out into the vertical page gutters
on several pages due to them being double wrapped by `<div
className="row">`.

### Before
![before](https://user-images.githubusercontent.com/460802/62194094-1b98e180-b3b4-11e9-899a-5477000be214.png)

### After
![after](https://user-images.githubusercontent.com/460802/62194105-1fc4ff00-b3b4-11e9-8682-1ebf2ffaa358.png)
