### PR TITLE
fix(pipeline-service-account) copy Service account while rerunning Pipelines

### DIFF
--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -104,6 +104,12 @@ export const newPipelineRun = (pipeline: Pipeline, latestRun: PipelineRun): Pipe
       trigger: {
         type: 'manual',
       },
+      serviceAccount:
+        latestRun && latestRun.spec && latestRun.spec.serviceAccount
+          ? latestRun.spec.serviceAccount
+          : pipeline && pipeline.spec && pipeline.spec.serviceAccount
+          ? pipeline.spec.serviceAccount
+          : '',
     },
   };
 };

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -43,6 +43,7 @@ export const newPipelineRun = (pipeline: Pipeline, latestRun: PipelineRun): Pipe
     );
     return null;
   }
+  // TODO: Add serviceAccount for start scenario by fetching details from user
   return {
     apiVersion: `${PipelineRunModel.apiGroup}/${PipelineRunModel.apiVersion}`,
     kind: PipelineRunModel.kind,
@@ -107,9 +108,7 @@ export const newPipelineRun = (pipeline: Pipeline, latestRun: PipelineRun): Pipe
       serviceAccount:
         latestRun && latestRun.spec && latestRun.spec.serviceAccount
           ? latestRun.spec.serviceAccount
-          : pipeline && pipeline.spec && pipeline.spec.serviceAccount
-          ? pipeline.spec.serviceAccount
-          : '',
+          : 'pipeline',
     },
   };
 };

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -58,6 +58,7 @@ export interface Pipeline extends K8sResourceKind {
     params: Param[];
     resources: PipelineResource[];
     tasks: K8sResourceKind[];
+    serviceAccount?: string;
   };
 }
 
@@ -69,6 +70,7 @@ export interface PipelineRun extends K8sResourceKind {
       type: string;
     };
     resources: PipelineResource[];
+    serviceAccount?: string;
   };
   status?: {
     succeededCondition?: string;

--- a/frontend/packages/dev-console/yamls/pipelines/pipeline.yaml
+++ b/frontend/packages/dev-console/yamls/pipelines/pipeline.yaml
@@ -16,6 +16,7 @@ spec:
     - name: hello-world-2
       taskRef:
         name: hello-world-2
+  serviceAccount: pipeline
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Pipeline
@@ -32,12 +33,14 @@ spec:
     - name: hello-world-3
       taskRef:
         name: hello-world-3
+  serviceAccount: pipeline
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Pipeline
 metadata:
   name: mapit-deploy-pipeline
 spec:
+  serviceAccount: pipeline
   resources:
   - name: mapit-git
     type: git
@@ -100,6 +103,7 @@ kind: Pipeline
 metadata:
   name: mapit-build-pipeline
 spec:
+  serviceAccount: pipeline
   resources:
   - name: mapit-git
     type: git


### PR DESCRIPTION
Addresses issue:
https://jira.coreos.com/browse/ODC-1501
--------------------------------------------------------------------------
POST-FIX
--------------------------------------------------------------------------
rerunning pipeline
![Screenshot from 2019-07-31 18-46-18](https://user-images.githubusercontent.com/24852534/62215249-34a98e80-b3c4-11e9-83c5-38b19868cf44.png)
-------------------------------------------------------------------------
pipelinerun running
![Screenshot from 2019-07-31 18-46-30](https://user-images.githubusercontent.com/24852534/62215250-34a98e80-b3c4-11e9-982e-7729405202ef.png)
-------------------------------------------------------------------------
pipelinerun successful
![Screenshot from 2019-07-31 18-46-46](https://user-images.githubusercontent.com/24852534/62215251-34a98e80-b3c4-11e9-860c-d2593ca6d75a.png)
-------------------------------------------------------------------------
serviceAccount of pipelineRun
![Screenshot from 2019-07-31 18-47-02](https://user-images.githubusercontent.com/24852534/62215252-35422500-b3c4-11e9-9495-3f074bac6400.png)
--------------------------------------------------------------------------
