### PR TITLE
Add null check for file in DroppableEditYAML component

### DIFF
--- a/frontend/public/components/droppable-edit-yaml.tsx
+++ b/frontend/public/components/droppable-edit-yaml.tsx
@@ -47,7 +47,13 @@ export const DroppableEditYAML = withDragDropContext(class DroppableEditYAML ext
     if (!monitor) {
       return;
     }
-    const file = monitor.getItem().files[0];
+    const [file] = monitor.getItem().files;
+
+    // If unsupported file type is dropped into drop zone, file will be undefined
+    if (!file) {
+      return;
+    }
+
     // limit size size uploading to 1 mb
     if (file.size <= maxFileUploadSize) {
       const reader = new FileReader();


### PR DESCRIPTION
Fix runtime error when an image is dragged from the browser into the file drop zone in the YAML editor.

Fixes https://jira.coreos.com/browse/CONSOLE-1518