### PR TITLE
Bug 1734601 - The statefulset created with default yaml will get error in page after add storage to it

### DIFF
--- a/frontend/public/components/modals/remove-volume-modal.tsx
+++ b/frontend/public/components/modals/remove-volume-modal.tsx
@@ -32,8 +32,10 @@ export const RemoveVolumeModal: React.FC<RemoveVolumeModalProps> = (props) => {
     // Either way, we cannot give the cmd to remove it
     if (allowRemoveVolume) {
       const volumes: Volume[] = _.get(resource, 'spec.template.spec.volumes', []);
-      const volumeIndex = volumes.findIndex((v: Volume) => v.name === rowVolumeData.volumeDetail.name);
-      patches.push({op: 'remove', path: `/spec/template/spec/volumes/${volumeIndex}`});
+      const volumeIndex = volumes.findIndex((v: Volume) => v.name === rowVolumeData.name);
+      if (volumeIndex > -1) {
+        patches.push({op: 'remove', path: `/spec/template/spec/volumes/${volumeIndex}`});
+      }
     }
     return patches;
   };
@@ -60,8 +62,8 @@ export const RemoveVolumeModal: React.FC<RemoveVolumeModalProps> = (props) => {
       <div className="co-delete-modal">
         <YellowExclamationTriangleIcon className="co-delete-modal__icon" />
         <div>
-          <p className="lead">Remove volume <span className="co-break-word">{volume.volumeDetail.name}</span>?</p>
-          <div>Are you sure you want to remove volume <strong className="co-break-word">{volume.volumeDetail.name}</strong>
+          <p className="lead">Remove volume <span className="co-break-word">{volume.name}</span>?</p>
+          <div>Are you sure you want to remove volume <strong className="co-break-word">{volume.name}</strong>
             <span> from <strong>{ kind.label }</strong>: <strong>{ resource.metadata.name }</strong>?</span>
           </div>
           {type && <div>

--- a/frontend/public/components/utils/volume-type.tsx
+++ b/frontend/public/components/utils/volume-type.tsx
@@ -6,16 +6,18 @@ import { getVolumeLocation, getVolumeType } from '../../module/k8s/pods';
 import { ResourceLink } from './';
 
 export const VolumeType: React.FC<VolumeTypeProps> = ({volume, namespace}) => {
-  if (volume.secret) {
-    return <ResourceLink kind="Secret" name={volume.secret.secretName} namespace={namespace} />;
-  }
+  if (volume) {
+    if (volume.secret) {
+      return <ResourceLink kind="Secret" name={volume.secret.secretName} namespace={namespace} />;
+    }
 
-  if (volume.configMap) {
-    return <ResourceLink kind="ConfigMap" name={volume.configMap.name} namespace={namespace} />;
-  }
+    if (volume.configMap) {
+      return <ResourceLink kind="ConfigMap" name={volume.configMap.name} namespace={namespace} />;
+    }
 
-  if (volume.persistentVolumeClaim) {
-    return <ResourceLink kind="PersistentVolumeClaim" name={volume.persistentVolumeClaim.claimName} namespace={namespace} />;
+    if (volume.persistentVolumeClaim) {
+      return <ResourceLink kind="PersistentVolumeClaim" name={volume.persistentVolumeClaim.claimName} namespace={namespace} />;
+    }
   }
 
   const type = getVolumeType(volume);

--- a/frontend/public/components/volumes-table.tsx
+++ b/frontend/public/components/volumes-table.tsx
@@ -37,9 +37,13 @@ const getPodTemplate = (resource: K8sResourceKind): PodTemplate => {
   return resource.kind === 'Pod' ? resource as PodKind : resource.spec.template;
 };
 
+const anyContainerWithVolumeMounts = (containers: ContainerSpec[]) => {
+  return !!_.findKey(containers, 'volumeMounts');
+};
+
 const getRowVolumeData = (resource: K8sResourceKind): RowVolumeData[] => {
   const pod: PodTemplate = getPodTemplate(resource);
-  if (!pod || !pod.spec || !pod.spec.volumes) {
+  if (_.isEmpty(pod.spec.volumes) && !anyContainerWithVolumeMounts(pod.spec.containers)) {
     return [];
   }
 
@@ -139,7 +143,7 @@ export const VolumesTable = props => {
   const pod: PodTemplate = getPodTemplate(resource);
   return <React.Fragment>
     {props.heading && <SectionHeading text={props.heading} />}
-    {_.isEmpty(pod.spec.volumes)
+    {_.isEmpty(pod.spec.volumes) && !anyContainerWithVolumeMounts(pod.spec.containers)
       ? <EmptyBox label="Volumes" />
       : (
         <Table {...tableProps} aria-label="Volumes" loaded={true} label={props.heading} data={data} Header={VolumesTableHeader} Row={VolumesTableRow} virtualize />


### PR DESCRIPTION
Don't show any `VolumeType` reference if the  container has `volumeMount` defined, but it's not part of the spec's `volumes`
eg:
```
kind: StatefulSet
...
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: nginx
    spec:
      volumes:
        - name: www-example-0
          persistentVolumeClaim:
            claimName: www-example-0
      containers:
        - name: nginx
          image: 'gcr.io/google_containers/nginx-slim:0.8'
          ports:
            - name: web
              containerPort: 80
              protocol: TCP
          resources: {}
          volumeMounts:
            - name: www
              mountPath: /usr/share/nginx/html
            - name: www-example-0
              mountPath: /data1
...
```

Screen:
<img width="1150" alt="Screen Shot 2019-07-31 at 17 04 45" src="https://user-images.githubusercontent.com/1668218/62223538-65ce9280-b3b5-11e9-93dd-0ed25c82455f.png">

/assign @zherman0 

ccíng @rhamilto 