### PR TITLE
Monitoring: Fix alignment of Show / Hide Graph link

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -245,9 +245,8 @@ const AlertsDetailsPage = withFallback(connect(alertStateToProps)((props: Alerts
         </h1>
       </div>
       <div className="co-m-pane__body">
-        <SectionHeading text="Alert Overview">
-          {state !== AlertStates.NotFiring && <ToggleGraph />}
-        </SectionHeading>
+        {state !== AlertStates.NotFiring && <ToggleGraph />}
+        <SectionHeading text="Alert Overview" />
         <div className="co-m-pane__body-group">
           <div className="row">
             <div className="col-sm-12">
@@ -397,9 +396,8 @@ const AlertRulesDetailsPage = withFallback(connect(ruleStateToProps)((props: Ale
       </div>
       <div className="co-m-pane__body">
         <div className="co-m-pane__body-group">
-          <SectionHeading text="Active Alerts">
-            <ToggleGraph />
-          </SectionHeading>
+          <ToggleGraph />
+          <SectionHeading text="Active Alerts" />
           <div className="row">
             <div className="col-sm-12">
               <Graph rule={rule} />

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -1,3 +1,9 @@
+.query-browser__toggle-graph {
+  padding-right: 0;
+  margin-bottom: 8px;
+  float: right;
+}
+
 .graph-wrapper--query-browser {
   padding-left: 40px;
 }

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -119,9 +119,9 @@ const HeaderPrometheusLink = connectToURLs(MonitoringRoutes.Prometheus)(HeaderPr
 export const graphStateToProps = ({UI}) => ({hideGraphs: !!UI.getIn(['monitoring', 'hideGraphs'])});
 
 const ToggleGraph_ = ({hideGraphs, toggle}) => {
-  const icon = hideGraphs ? <ChartLineIcon className="co-icon-space-r" /> : <CompressIcon className="co-icon-space-r" />;
+  const icon = hideGraphs ? <ChartLineIcon /> : <CompressIcon />;
 
-  return <button type="button" className="btn btn-link" onClick={toggle}>
+  return <button type="button" className="btn btn-link query-browser__toggle-graph" onClick={toggle}>
     {hideGraphs ? 'Show' : 'Hide'} Graph {icon}
   </button>;
 };
@@ -469,7 +469,7 @@ export const QueryBrowserPage = withFallback(() => {
     </div>
     <div className="co-m-pane__body">
       <div className="row">
-        <div className="col-xs-12 text-right">
+        <div className="col-xs-12">
           <ToggleGraph />
         </div>
       </div>


### PR DESCRIPTION
Fix to align with the right edge of the graph and add a small margin
below the button link.

After
![screenshot](https://user-images.githubusercontent.com/460802/62264385-a46a5880-b45a-11e9-982d-4a0429ea49c1.png)

FYI @cshinn 