### PR TITLE
Add option to set e2e testing chrome browser binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ To see what the tests are actually doing, it is posible to run in none `headless
 $ NO_HEADLESS=true ./test-gui.sh olm
 ```
 
+To use a specific binary version of chrome, it is posible to set the `CHROME_BINARY_PATH` enviorment variable:
+
+```
+$ CHROME_BINARY_PATH="/usr/bin/chromium-browser" ./test-gui.sh olm
+```
+
 ##### Debugging Integration Tests
 
 1. `cd frontend; yarn run build`

--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -34,6 +34,8 @@ export const config: Config = {
     browserName: 'chrome',
     acceptInsecureCerts: true,
     chromeOptions: {
+      // A path to chrome binary, if undefined will use system chrome browser.
+      binary: process.env.CHROME_BINARY_PATH,
       args: [
         ...(process.env.NO_HEADLESS ? [] : ['--headless']),
         '--disable-gpu',


### PR DESCRIPTION
**Motivation**

It is nice to have the option to set the chrome binary used for testing.

a - Chrome browser is not always installed on the testing system, users may download a binary [1] and run it from local user directory.
b - The system Chrome browser may be too old or new for the `chromedriver` used [2].

**Example of problem**

For example on Fedora 30 the system Chrome is currently `76.0.3809.87`, testign with current `chromedriver` version will result in failed test:
```
[09:08:50] E/launcher - session not created: Chrome version must be between 71 and 75
  (Driver info: chromedriver=2.46.628388 (4a34a70827ac54148e092aafb70504c4ea7ae926),platform=Linux 5.1.19-300.fc30.x86_64 x86_64)
[09:08:50] E/launcher - SessionNotCreatedError: session not created: Chrome version must be between 71 and 75
  (Driver info: chromedriver=2.46.628388 (4a34a70827ac54148e092aafb70504c4ea7ae926),platform=Linux 5.1.19-300.fc30.x86_64 x86_64)
```

**Example of use**

```
CHROME_BINARY_PATH="/usr/bin/chromium-browser" ./test-gui.sh
```

[1] https://www.chromium.org/getting-involved/download-chromium
[2] https://github.com/openshift/console/blob/master/frontend/package.json#L154