### PR TITLE
Query Browser: Performance fix

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -238,7 +238,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
       });
     })
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  ), [disabledSeriesKey, filterLabels, results, samples, span]);
+  ), [disabledSeriesKey, filterLabels, results]);
 
   const onSpanChange = React.useCallback((newSpan: number) => {
     setDomain(undefined);


### PR DESCRIPTION
Fix a serious performance bug that caused `graphData` to be recalculated
every time `span` changed. This could be extremely slow if `span` was
changed from a large value to a small value. The correct behaviour is
for changing `span` to trigger a call to the Prometheus API, and when
that call returns new data, `graphData` is recalculated.