### PR TITLE
Chargeback: updated to v2 table api which returns display columns and units

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -178,14 +178,14 @@ export const stopImpersonate = () => (dispatch) => {
   dispatch(detectFeatures());
   history.push(window.SERVER_FLAGS.basePath);
 };
-export const sortList = (listId: string, field: string, func: any, orderBy: string, column: string) => {
+export const sortList = (listId: string, field: string, func: string, sortAsNumber: boolean, orderBy: string, column: string) => {
   const url = new URL(window.location.href);
   const sp = new URLSearchParams(window.location.search);
   sp.set('orderBy', orderBy);
   sp.set('sortBy', column);
   history.replace(`${url.pathname}?${sp.toString()}${url.hash}`);
 
-  return action(ActionType.SortList, {listId, field, func, orderBy});
+  return action(ActionType.SortList, {listId, field, func, sortAsNumber, orderBy});
 };
 export const setCreateProjectMessage = (message: string) => action(ActionType.SetCreateProjectMessage, {message});
 export const setUser = (user: any) => action(ActionType.SetUser, {user});

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -632,7 +632,7 @@ const MonitoringListPage = connect(filtersToProps)(class InnerMonitoringListPage
 
     if (!params.get('sortBy')) {
       // Sort by rule name by default
-      store.dispatch(UIActions.sortList(reduxID, 'name', undefined, 'asc', 'Name'));
+      store.dispatch(UIActions.sortList(reduxID, 'name', undefined, false, 'asc', 'Name'));
     }
   }
 

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -99,7 +99,7 @@ export default (state: UIState, action: UIAction): UIState => {
       return state.delete('impersonate');
 
     case ActionType.SortList:
-      return state.mergeIn(['listSorts', action.payload.listId], _.pick(action.payload, ['field', 'func', 'orderBy']));
+      return state.mergeIn(['listSorts', action.payload.listId], _.pick(action.payload, ['field', 'func', 'sortAsNumber', 'orderBy']));
 
     case ActionType.SetCreateProjectMessage:
       return state.set('createProjectMessage', action.payload.message);


### PR DESCRIPTION
Using units to format dates and sort numeric columns.

![image](https://user-images.githubusercontent.com/12733153/63054532-06db4400-beb2-11e9-8a18-b5caa75226bb.png)

ToDo:
- [ ] When ready, need to test to see if new code works with 4.2 OLM Metering installation
      Merged:  [PR: Update OLM/Marketplace 4.2 package](https://github.com/operator-framework/operator-metering/pull/868) 
     @chancez "...4.2 stuff comes out with 4.2. this relates to RCM/ART publishing our stuff, which they arent doing for 4.2 yet.  ill be working on making it so you can semi-test using 4.2 via OLM, but the manual install should be similar enough to do anything you need also"

JIRA: Chargeback Reports: Use v2 report results API to show field units and which should be shown/hidden - https://jira.coreos.com/browse/CONSOLE-1445

cc @chancez  