### PR TITLE
Adding the missing Y-axis labels to NooBaa-dashboard's Data Consumption card

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.tsx
@@ -19,10 +19,7 @@ import {
   DashboardItemProps,
   withDashboardResources,
 } from '@console/internal/components/dashboards-page/with-dashboard-resources';
-import {
-  humanizeDecimalBytes,
-  humanizeBinaryBytesWithoutB,
-} from '@console/internal/components/utils';
+import { humanizeBinaryBytes, humanizeNumber } from '@console/internal/components/utils';
 import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import { DATA_CONSUMPTION_QUERIES, ObjectServiceDashboardQuery } from '../../constants/queries';
 import {
@@ -32,12 +29,14 @@ import {
   BY_PHYSICAL_VS_LOGICAL_USAGE,
   BY_EGRESS,
   PROVIDERS,
+  CHART_LABELS,
 } from '../../constants';
 import { DataConsumptionDropdown } from './data-consumption-card-dropdown';
 import {
   BarChartData,
   metricsChartDataMap,
   metricsChartLegendDataMap,
+  numberInWords,
 } from './data-consumption-card-utils';
 import './data-consumption-card.scss';
 
@@ -80,26 +79,33 @@ const DataConsumptionCard: React.FC<DashboardItemProps> = ({
     'result',
   ]);
 
-  let maxUnit: string;
   let maxVal: number;
   let chartData = [];
   let legendData = [];
+  let suffixLabel = '';
   const result = _.get(dataConsumptionQueryResult, 'data.result', []);
   if (result.length) {
     let maxData: BarChartData | any = {
       x: '',
       y: 0,
       name: '',
+      yOriginal: 0,
+      unit: '',
     };
     chartData = metricsChartDataMap[metricType][sortByKpi](result);
     legendData = metricsChartLegendDataMap[metricType][sortByKpi](chartData);
-    maxData = _.maxBy(chartData.map((data) => _.maxBy(data, 'y')), 'y');
-    maxVal = maxData.y;
-    maxUnit =
-      (sortByKpi === BY_IOPS || sortByKpi === BY_PHYSICAL_VS_LOGICAL_USAGE) &&
-      chartData.length === 2
-        ? humanizeDecimalBytes(maxVal).unit
-        : humanizeBinaryBytesWithoutB(maxVal).unit;
+    maxData = _.maxBy(chartData.map((data) => _.maxBy(data, 'yOriginal')), 'yOriginal');
+    const maxDataV = Number(maxData.yOriginal);
+    const maxDataVStr = maxDataV.toFixed(1);
+    let maxDataH = humanizeBinaryBytes(maxDataVStr);
+    suffixLabel = maxDataH.unit;
+    if (sortByKpi === BY_IOPS) {
+      suffixLabel = numberInWords(maxDataV);
+      maxDataH = humanizeNumber(maxDataVStr);
+    }
+    // if suffixLabel is a non-empty string, show it in expected form
+    if (suffixLabel) suffixLabel = `(in ${suffixLabel})`;
+    maxVal = Number(maxDataH.value);
   }
 
   const yTickValues = [
@@ -130,18 +136,20 @@ const DataConsumptionCard: React.FC<DashboardItemProps> = ({
       <DashboardCardBody isLoading={!dataConsumptionQueryResult}>
         {chartData.length > 0 ? (
           <div>
+            <span className="text-secondary">
+              {CHART_LABELS[sortByKpi]} {suffixLabel}
+            </span>
             <Chart
               themeColor={ChartThemeColor.purple}
               domain={{ y: [0, maxVal] }}
               domainPadding={{ x: [15, 20], y: [10, 10] }}
-              padding={{ top: 20, bottom: 40, left: 40, right: 17 }}
+              padding={{ top: 20, bottom: 40, left: 50, right: 17 }}
               height={280}
             >
               <ChartAxis style={{ tickLabels: { padding: 5, fontSize: 10 } }} />
               <ChartAxis
                 dependentAxis
                 tickValues={yTickValues}
-                tickFormat={(t) => `${t}${maxUnit}`}
                 style={{
                   tickLabels: { padding: 5, fontSize: 8, fontWeight: 500 },
                   grid: { stroke: '#4d525840' },
@@ -158,6 +166,7 @@ const DataConsumptionCard: React.FC<DashboardItemProps> = ({
               data={legendData}
               orientation="horizontal"
               height={40}
+              width={500}
               style={{ labels: { fontSize: 10 } }}
             />
           </div>

--- a/frontend/packages/noobaa-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/index.ts
@@ -4,3 +4,10 @@ export const BY_IOPS = 'I/O Operations';
 export const BY_LOGICAL_USAGE = 'Logical Used Capacity';
 export const BY_PHYSICAL_VS_LOGICAL_USAGE = 'Physical Vs Logical Usage';
 export const BY_EGRESS = 'Egress';
+
+export const CHART_LABELS = {
+  [BY_LOGICAL_USAGE]: 'Logical used capacity per account',
+  [BY_PHYSICAL_VS_LOGICAL_USAGE]: 'Physical vs. Logical used capacity',
+  [BY_EGRESS]: 'Egress Per Provider',
+  [BY_IOPS]: 'I/O Operations count',
+};


### PR DESCRIPTION
This PR adds the missing y-axis labels in data consumption (of NooBaa dashboard)

Fix: https://github.com/openshift/console/issues/2252

Signed-off-by: aruniiird <arun.iiird@gmail.com>