### PR TITLE
Query Browser: Fix graph padding so that labels fit in the border

### DIFF
--- a/frontend/public/components/graphs/themes.ts
+++ b/frontend/public/components/graphs/themes.ts
@@ -62,7 +62,27 @@ export const queryBrowserTheme = {
   },
   dependentAxis: {
     style: {
-      grid: {stroke: '#EDEDED'},
+      axis: {
+        stroke: 'none',
+      },
+      grid: {
+        stroke: '#EDEDED',
+      },
+      tickLabels: {
+        padding: 0,
+      },
+    },
+  },
+  independentAxis: {
+    style: {
+      tickLabels: {
+        padding: 2,
+      },
+      ticks: {
+        size: 5,
+        strokeWidth: 1,
+        stroke: '#d2d2d2',
+      },
     },
   },
 };

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -1,5 +1,6 @@
 .graph-wrapper--query-browser {
   padding-left: 40px;
+  padding-right: 10px;
 }
 
 .query-browser__clear-icon {

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -117,14 +117,13 @@ const Graph: React.FC<GraphProps> = React.memo(({containerComponent, domain, dat
     {width && <Chart
       containerComponent={containerComponent}
       domain={domain || {x: [Date.now() - span, Date.now()], y: undefined}}
-      domainPadding={{y: 20}}
       height={200}
       scale={{x: 'time', y: 'linear'}}
       theme={chartTheme}
       width={width}
     >
       <ChartAxis tickCount={5} tickFormat={twentyFourHourTime} />
-      <ChartAxis dependentAxis tickCount={5} tickFormat={value => humanizeNumber(value).string} />
+      <ChartAxis dependentAxis tickCount={6} tickFormat={value => humanizeNumber(value).string} />
       <ChartGroup>
         {_.map(data, (values, i) => <ChartLine key={i} data={values} />)}
       </ChartGroup>
@@ -313,9 +312,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
     </div>
     {error && <Error error={error} />}
     {(_.isEmpty(graphData) && !updating) && <GraphEmpty icon={ChartLineIcon} />}
-    {!_.isEmpty(graphData) && <div
-      className="graph-wrapper graph-wrapper--query-browser"
-    >
+    {!_.isEmpty(graphData) && <div className="graph-wrapper graph-wrapper--query-browser">
       <div className="query-browser__zoom" onMouseDown={onMouseDown} onMouseMove={onMouseMove} onMouseUp={onMouseUp}>
         {isZooming && <div className="query-browser__zoom-overlay" style={{left: Math.min(x1, x2), width: Math.abs(x1 - x2)}}></div>}
         <Graph


### PR DESCRIPTION
Reduce padding between the axis labels and the graph to save some space
and prevent the labels from sometimes overflowing outside the border.

Also tweak some styles to make better use of the space available and to
better match the mocks.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1734364

### Before
![before](https://user-images.githubusercontent.com/460802/62440905-13aeb800-b78d-11e9-8582-b7102f881822.png)

### After
![screenshot](https://user-images.githubusercontent.com/460802/62440853-d518fd80-b78c-11e9-9fb2-48c2762c36f3.png)

FYI @cshinn 