### PR TITLE
Bug 1726055: Query Browser: Always start Y-axis from zero

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -118,12 +118,13 @@ const Graph: React.FC<GraphProps> = React.memo(({containerComponent, domain, dat
       containerComponent={containerComponent}
       domain={domain || {x: [Date.now() - span, Date.now()], y: undefined}}
       height={200}
+      minDomain={{y: 0}}
       scale={{x: 'time', y: 'linear'}}
       theme={chartTheme}
       width={width}
     >
       <ChartAxis tickCount={5} tickFormat={twentyFourHourTime} />
-      <ChartAxis dependentAxis tickCount={6} tickFormat={value => humanizeNumber(value).string} />
+      <ChartAxis crossAxis={false} dependentAxis tickCount={6} tickFormat={value => humanizeNumber(value).string} />
       <ChartGroup>
         {_.map(data, (values, i) => <ChartLine key={i} data={values} />)}
       </ChartGroup>


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1726055

This restores the Y-axis behavior to be the same as 4.1.

Use the `ChartAxis` `crossAxis` prop to ensure that a `0` axis label is
always shown.

![screenshot](https://user-images.githubusercontent.com/460802/62453837-2a193b80-b7ae-11e9-9b74-260750ba8bca.png)

FYI @cshinn 