### PR TITLE
fix(pipeline) Remove Pipeline Start Action

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -4,7 +4,7 @@ import { Kebab, navFactory } from '@console/internal/components/utils';
 import { viewYamlComponent } from '@console/internal/components//utils/horizontal-nav';
 import { k8sGet, k8sList } from '@console/internal/module/k8s';
 import { ErrorPage404 } from '@console/internal/components/error';
-import { triggerPipeline, rerunPipeline } from '../../utils/pipeline-actions';
+import { rerunPipeline } from '../../utils/pipeline-actions';
 import { getLatestRun } from '../../utils/pipeline-augment';
 import { PipelineRunModel, PipelineModel } from '../../models';
 import PipelinEnvironmentComponent from './PipelineEnvironment';
@@ -33,11 +33,6 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
             this.setState({
               menuActions: [
                 rerunPipeline(
-                  res,
-                  getLatestRun({ data: listres }, 'creationTimestamp'),
-                  'pipelines',
-                ),
-                triggerPipeline(
                   res,
                   getLatestRun({ data: listres }, 'creationTimestamp'),
                   'pipelines',

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineRow.tsx
@@ -7,7 +7,7 @@ import { pipelineFilterReducer } from '../../utils/pipeline-filter-reducer';
 import { Pipeline } from '../../utils/pipeline-augment';
 import { PipelineTaskStatus } from '../pipelineruns/PipelineTaskStatus';
 import { PipelineModel, PipelineRunModel } from '../../models';
-import { triggerPipeline, rerunPipeline } from '../../utils/pipeline-actions';
+import { rerunPipeline } from '../../utils/pipeline-actions';
 import { tableColumnClasses } from './pipeline-table';
 
 const pipelineReference = referenceForModel(PipelineModel);
@@ -21,11 +21,7 @@ interface PipelineRowProps {
 }
 
 const PipelineRow: React.FC<PipelineRowProps> = ({ obj, index, key, style }) => {
-  const menuActions = [
-    rerunPipeline(obj, obj.latestRun, ''),
-    triggerPipeline(obj, obj.latestRun, ''),
-    Kebab.factory.Delete,
-  ];
+  const menuActions = [rerunPipeline(obj, obj.latestRun, ''), Kebab.factory.Delete];
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>


### PR DESCRIPTION
This is bug fix for
https://jira.coreos.com/browse/ODC-1530

This PR  hides the `Start` action for a Pipeline, till the `Pipeline Start Modal` is not actually in place.
------------------------------------------------------------------
![Screenshot from 2019-08-05 16-19-29](https://user-images.githubusercontent.com/24852534/62459454-05689800-b79d-11e9-8696-7eb1883c2581.png)
-------------------------------------------------------------------
![Screenshot from 2019-08-05 16-21-29](https://user-images.githubusercontent.com/24852534/62459539-4365bc00-b79d-11e9-89d1-15ad189ea3ab.png)
