### PR TITLE
fix(serverless): Add valid default YAML for serverless objects

### DIFF
--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionsPage.tsx
@@ -14,7 +14,7 @@ export interface RevisionsPageProps {
 const RevisionsPage: React.FC<RevisionsPageProps> = ({ match }) => (
   <ListPage
     namespace={match.params.ns}
-    canCreate
+    canCreate={false}
     kind={referenceForModel(RevisionModel)}
     ListComponent={RevisionList}
   />

--- a/frontend/packages/knative-plugin/src/components/routes/RoutesPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RoutesPage.tsx
@@ -14,7 +14,7 @@ export interface RoutesPageProps {
 const RoutesPage: React.FC<RoutesPageProps> = ({ match }) => (
   <ListPage
     namespace={match.params.ns}
-    canCreate
+    canCreate={false}
     kind={referenceForModel(RouteModel)}
     ListComponent={RouteList}
   />

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -8,9 +8,11 @@ import {
   OverviewCRD,
   ResourceListPage,
   GlobalConfig,
+  YAMLTemplate,
 } from '@console/plugin-sdk';
 import { referenceForModel } from '@console/internal/module/k8s';
 import * as models from './models';
+import { yamlTemplates } from './yaml-templates';
 import { FLAG_KNATIVE_SERVING } from './const';
 import { knativeServingResources } from './utils/create-knative-utils';
 import { getKnativeServingResources } from './utils/get-knative-resources';
@@ -22,7 +24,8 @@ type ConsumedExtensions =
   | GlobalConfig
   | OverviewResourceTab
   | OverviewCRD
-  | ResourceListPage;
+  | ResourceListPage
+  | YAMLTemplate;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -129,6 +132,13 @@ const plugin: Plugin<ConsumedExtensions> = [
         (await import(
           './components/routes/RoutesPage' /* webpackChunkName: "knative-routes-page" */
         )).default,
+    },
+  },
+  {
+    type: 'YAMLTemplate',
+    properties: {
+      model: models.ServiceModel,
+      template: yamlTemplates.getIn([models.ServiceModel, 'default']),
     },
   },
 ];

--- a/frontend/packages/knative-plugin/src/yaml-templates.ts
+++ b/frontend/packages/knative-plugin/src/yaml-templates.ts
@@ -1,0 +1,20 @@
+import { Map as ImmutableMap } from 'immutable';
+import { ServiceModel } from './models';
+
+export const yamlTemplates = ImmutableMap().setIn(
+  [ServiceModel, 'default'],
+  `
+apiVersion: ${ServiceModel.apiGroup}/${ServiceModel.apiVersion}
+kind: ${ServiceModel.kind}
+metadata:
+  name: sample
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: openshift/hello-openshift
+`,
+);


### PR DESCRIPTION
Add valid default YAML for serverless Service creation objects
Removes create option for Revisions/Routes

Tracks : https://jira.coreos.com/browse/ODC-1411

<img width="1668" alt="Screenshot 2019-08-05 at 7 53 25 PM" src="https://user-images.githubusercontent.com/5129024/62471640-b6316000-b7ba-11e9-86e3-663383fc36eb.png">
