### PR TITLE
Bug 1737756: Add virtualize prop to baremetal host table

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/host.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host.tsx
@@ -124,15 +124,27 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({
   );
 };
 
-const HostList: React.FC<HostListProps> = (props) => (
-  <Table {...props} aria-label="Baremetal Hosts" Header={HostsTableHeader} Row={HostsTableRow} />
-);
-
 type HostListProps = React.ComponentProps<typeof Table> & {
   data: HostRowBundle[];
   customData: {
     hasNodeMaintenanceCapability: boolean;
   };
+};
+
+const HostList: React.FC<HostListProps> = (props) => (
+  <Table
+    {...props}
+    defaultSortField="host.metadata.name"
+    aria-label="Baremetal Hosts"
+    Header={HostsTableHeader}
+    Row={HostsTableRow}
+    virtualize
+  />
+);
+
+type BaremetalHostsPageProps = {
+  namespace: string;
+  hasNodeMaintenanceCapability: boolean;
 };
 
 const BaremetalHostsPage: React.FC<BaremetalHostsPageProps> = ({
@@ -183,19 +195,23 @@ const BaremetalHostsPage: React.FC<BaremetalHostsPageProps> = ({
     if (loaded) {
       const nodeMaintenanceLookup = createLookup(nodeMaintenances, getNodeMaintenanceNodeName);
 
-      return hostsData.map((host) => {
-        const machine = getHostMachine(host, machinesData);
-        const node = getMachineNode(machine, nodesData);
-        const nodeMaintenance = nodeMaintenanceLookup[getName(node)];
-        return {
-          ...host,
-          host,
-          machine,
-          node,
-          nodeMaintenance,
-          status: getHostStatus({ host, machine, node, nodeMaintenance }),
-        };
-      });
+      return hostsData.map(
+        (host): HostRowBundle => {
+          const machine = getHostMachine(host, machinesData);
+          const node = getMachineNode(machine, nodesData);
+          const nodeMaintenance = nodeMaintenanceLookup[getName(node)];
+          return {
+            // TODO(jtomasek): this is needed to make 'name' textFilter work.
+            // Remove this when it is possible to pass custom textFilter as a function
+            metadata: { name: host.metadata.name },
+            host,
+            machine,
+            node,
+            nodeMaintenance,
+            status: getHostStatus({ host, machine, node, nodeMaintenance }),
+          };
+        },
+      );
     }
     return [];
   };
@@ -213,11 +229,6 @@ const BaremetalHostsPage: React.FC<BaremetalHostsPageProps> = ({
       customData={{ hasNodeMaintenanceCapability }}
     />
   );
-};
-
-type BaremetalHostsPageProps = {
-  namespace: string;
-  hasNodeMaintenanceCapability: boolean;
 };
 
 const hostsPageStateToProps = ({ k8s }) => ({

--- a/frontend/packages/metal3-plugin/src/components/types.ts
+++ b/frontend/packages/metal3-plugin/src/components/types.ts
@@ -1,7 +1,8 @@
 import { K8sResourceKind, MachineKind, NodeKind } from '@console/internal/module/k8s';
 import { HostMultiStatus } from '../utils/host-status';
 
-export type HostRowBundle = K8sResourceKind & {
+export type HostRowBundle = {
+  metadata?: { name: string };
   machine: MachineKind;
   node: NodeKind;
   host: K8sResourceKind;


### PR DESCRIPTION
This adds missing virtualize prop to Table component rendered by HostList.
This ensures that a table rows are correctly updated when the data changes.
This also fixes filtering and sorting issues on HostList

https://bugzilla.redhat.com/show_bug.cgi?id=1737756
https://bugzilla.redhat.com/show_bug.cgi?id=1737466