### PR TITLE
Query Browser: Fix bug that caused graph to re-render when typing

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -217,12 +217,9 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   // interval relative to the graph's timespan, but not less than 5s.
   const delay = endTime ? null : Math.max(span / 120, 5000);
 
-  const queriesKey = JSON.stringify(queries);
-  const disabledSeriesKey = JSON.stringify(disabledSeries);
+  usePoll(tick, delay, endTime, queries, samples, span);
 
-  usePoll(tick, delay, endTime, queriesKey, samples, span);
-
-  React.useEffect(() => setUpdating(true), [endTime, queriesKey, samples, span]);
+  React.useEffect(() => setUpdating(true), [endTime, queries, samples, span]);
 
   const graphData: GraphDataPoint[][] = React.useMemo(() => _.flatten(
     _.map(results, (result, responseIndex) => {
@@ -237,8 +234,10 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
         return isIgnored ? [{x: null, y: null}] : formatSeriesValues(values, samples, span);
       });
     })
+  // Some of the hook dependencies are not included because we instead want those dependencies to trigger an Prometheus
+  // API call, which will update `results` and then trigger this hook
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  ), [disabledSeriesKey, filterLabels, results]);
+  ), [disabledSeries, filterLabels, results]);
 
   const onSpanChange = React.useCallback((newSpan: number) => {
     setDomain(undefined);


### PR DESCRIPTION
Move memoize logic up to the QueryBrowserPage component. This fixes a
bug where re-rendering the graph was triggered unnecessarily, including
when you typed into a query input.