### PR TITLE
Convert inline icon (delete and move) and add more buttons to pf4 styles

### DIFF
--- a/frontend/integration-tests/views/environment.view.ts
+++ b/frontend/integration-tests/views/environment.view.ts
@@ -5,7 +5,7 @@ const BROWSER_TIMEOUT = 15000;
 const inputs = $$('.pf-c-form-control');
 export const rowsKey = $('[placeholder="name"]');
 export const rowsValue = $('[placeholder="value"]');
-export const deleteBtn = $$('.pairs-list__delete-icon').first();
+export const deleteBtn = $$('[data-test-id="pairs-list__delete-btn"]').first();
 export const saveBtn = element(by.cssContainingText('.pf-m-primary', 'Save'));
 
 export const prefix = $('[data-test-id=env-prefix]');

--- a/frontend/integration-tests/views/modal-annotations.view.ts
+++ b/frontend/integration-tests/views/modal-annotations.view.ts
@@ -8,7 +8,7 @@ export const confirmActionBtn = $('#confirm-action');
 const annotationRows = $$('.pairs-list__row');
 export const annotationRowsKey = $$('[placeholder="key"]');
 export const annotationRowsValue = $$('[placeholder="value"]');
-export const annotationRowsDelete = $$('.pairs-list__delete-icon');
+export const annotationRowsDelete = $$('[data-test-id="pairs-list__delete-btn"]');
 export const annotationDialogOverlay = $('.co-overlay');
 
 export const isLoaded = () => browser.wait(until.presenceOf(addMoreBtn), BROWSER_TIMEOUT);

--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -94,16 +94,22 @@
 }
 
 .toleration-modal__field, .taint-modal__field  {
-  padding-top: 5px;
   padding-right: 0;
 }
 
+.toleration-modal__field, .taint-modal__input {
+  margin-bottom: 5px;
+  @media(max-width: $screen-sm-max) {
+    margin-bottom: 10px;
+  }
+}
+
 .toleration-modal__heading, .taint-modal__heading {
-  margin-bottom: 0;
+  margin-bottom: 5px;
 }
 
 .toleration-modal__row, .taint-modal__row {
-  margin-bottom: 16px;
+  margin-bottom: 15px;
   @media(max-width: $screen-sm-max) {
     margin-bottom: 24px;
   }

--- a/frontend/public/components/modals/taints-modal.tsx
+++ b/frontend/public/components/modals/taints-modal.tsx
@@ -84,17 +84,17 @@ class TaintsModal extends PromiseComponent<TaintsModalProps, TaintsModalState> {
             </div>
             {_.map(taints, (c, i) =>
               <div className="row taint-modal__row" key={i}>
-                <div className="col-md-4 col-sm-6 col-xs-6 taint-modal__field">
-                  <div className="hidden-md hidden-lg text-secondary text-uppercase">Key</div>
-                  <input type="text" className="pf-c-form-control" value={c.key} onChange={(e) => this._change(e, i, 'key')} required />
+                <div className="col-md-4 col-xs-5 taint-modal__field">
+                  <div className="taint-modal__heading hidden-md hidden-lg text-secondary text-uppercase">Key</div>
+                  <input type="text" className="pf-c-form-control taint-modal__input" value={c.key} onChange={(e) => this._change(e, i, 'key')} required />
                 </div>
-                <div className="col-md-3 col-sm-5 col-xs-5 taint-modal__field">
-                  <div className="hidden-md hidden-lg text-secondary text-uppercase">Value</div>
-                  <input type="text" className="pf-c-form-control" value={c.value} onChange={(e) => this._change(e, i, 'value')} />
+                <div className="col-md-3 col-xs-5 taint-modal__field">
+                  <div className="taint-modal__heading hidden-md hidden-lg text-secondary text-uppercase">Value</div>
+                  <input type="text" className="pf-c-form-control taint-modal__input" value={c.value} onChange={(e) => this._change(e, i, 'value')} />
                 </div>
                 <div className="clearfix visible-sm visible-xs"></div>
-                <div className="col-md-4 col-sm-6 col-xs-6 taint-modal__field">
-                  <div className="hidden-md hidden-lg text-secondary text-uppercase">Effect</div>
+                <div className="col-md-4 col-xs-5 taint-modal__field">
+                  <div className="taint-modal__heading hidden-md hidden-lg text-secondary text-uppercase">Effect</div>
                   <Dropdown
                     className="taint-modal__dropdown"
                     dropDownClassName="dropdown--full-width"
@@ -103,8 +103,8 @@ class TaintsModal extends PromiseComponent<TaintsModalProps, TaintsModalState> {
                     selectedKey={c.effect}
                     title={effects[c.effect]} />
                 </div>
-                <div className="col-md-1 col-md-offset-0 col-sm-offset-11 col-xs-offset-11">
-                  <button type="button" className="btn btn-link btn-link--inherit-color taint-modal__delete-icon" onClick={() => this._remove(i)} aria-label="Delete">
+                <div className="col-md-1 col-md-offset-0 col-sm-offset-10 col-xs-offset-10">
+                  <button type="button" className="pf-c-button pf-m-plain btn-link--inherit-color taint-modal__delete-icon" onClick={() => this._remove(i)} aria-label="Delete">
                     <MinusCircleIcon className="pairs-list__side-btn pairs-list__delete-icon" />
                   </button>
                 </div>
@@ -112,6 +112,7 @@ class TaintsModal extends PromiseComponent<TaintsModalProps, TaintsModalState> {
             )}
           </React.Fragment>}
         <Button
+          className="pf-m-link--align-left"
           onClick={this._addRow}
           type="button"
           variant="link">

--- a/frontend/public/components/modals/tolerations-modal.tsx
+++ b/frontend/public/components/modals/tolerations-modal.tsx
@@ -121,11 +121,11 @@ class TolerationsModal extends PromiseComponent<TolerationsModalProps, Toleratio
               const { key, operator, value, effect = '' } = t;
               return <div className="row toleration-modal__row" key={i}>
                 <div className="col-md-4 col-sm-5 col-xs-5 toleration-modal__field">
-                  <div className="hidden-md hidden-lg text-secondary text-uppercase">Key</div>
+                  <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">Key</div>
                   <input type="text" className="pf-c-form-control" value={key} onChange={(e) => this._change(e, i, 'key')} readOnly={!this._isEditable(t)} />
                 </div>
                 <div className="col-md-2 col-sm-5 col-xs-5 toleration-modal__field">
-                  <div className="hidden-md hidden-lg text-secondary text-uppercase">Operator</div>
+                  <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">Operator</div>
                   { this._isEditable(t)
                     ? <Dropdown
                       className="toleration-modal__dropdown"
@@ -138,7 +138,7 @@ class TolerationsModal extends PromiseComponent<TolerationsModalProps, Toleratio
                 </div>
                 <div className="clearfix visible-sm visible-xs"></div>
                 <div className="col-md-3 col-sm-5 col-xs-5 toleration-modal__field">
-                  <div className="hidden-md hidden-lg text-secondary text-uppercase">Value</div>
+                  <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">Value</div>
                   <input
                     type="text"
                     className="pf-c-form-control"
@@ -147,7 +147,7 @@ class TolerationsModal extends PromiseComponent<TolerationsModalProps, Toleratio
                     readOnly={!this._isEditable(t) || operator === 'Exists'} />
                 </div>
                 <div className="col-md-2 col-sm-5 col-xs-5 toleration-modal__field">
-                  <div className="hidden-md hidden-lg text-secondary text-uppercase">Effect</div>
+                  <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">Effect</div>
                   { this._isEditable(t)
                     ? <Dropdown
                       className="toleration-modal__dropdown"
@@ -160,7 +160,7 @@ class TolerationsModal extends PromiseComponent<TolerationsModalProps, Toleratio
                 </div>
                 <div className="col-md-1 col-sm-2 col-xs-2">
                   {this._isEditable(t) && (
-                    <button type="button" className="btn btn-link btn-link--inherit-color toleration-modal__delete-icon" onClick={() => this._remove(i)} aria-label="Delete">
+                    <button type="button" className="pf-c-button pf-m-plain btn-link--inherit-color toleration-modal__delete-icon" onClick={() => this._remove(i)} aria-label="Delete">
                       <MinusCircleIcon className="pairs-list__side-btn pairs-list__delete-icon" />
                     </button>
                   )}
@@ -170,7 +170,7 @@ class TolerationsModal extends PromiseComponent<TolerationsModalProps, Toleratio
           </React.Fragment>
         }
         <Button
-          className="btn btn-link"
+          className="pf-m-link--align-left"
           onClick={this._addRow}
           type="button"
           variant="link">

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/match-expressions.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/match-expressions.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import { Button } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import { MatchExpression } from '../../../../module/k8s';
@@ -21,7 +22,7 @@ export const MatchExpressions: React.FC<MatchExpressionsProps> = (props) => {
     </div>
     { props.matchExpressions.map((expression, i) => <div className="row toleration-modal__row" key={i}>
       <div className="col-md-4 col-sm-5 col-xs-5 toleration-modal__field">
-        <div className="hidden-md hidden-lg text-secondary text-uppercase">Key</div>
+        <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">Key</div>
         <input
           type="text"
           className="form-control"
@@ -29,7 +30,7 @@ export const MatchExpressions: React.FC<MatchExpressionsProps> = (props) => {
           onChange={e => changeKey(e.target.value, i)} />
       </div>
       <div className="col-md-2 col-sm-5 col-xs-5 toleration-modal__field">
-        <div className="hidden-md hidden-lg text-secondary text-uppercase">Operator</div>
+        <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">Operator</div>
         <Dropdown
           className="toleration-modal__dropdown"
           dropDownClassName="dropdown--full-width"
@@ -40,7 +41,7 @@ export const MatchExpressions: React.FC<MatchExpressionsProps> = (props) => {
       </div>
       <div className="clearfix visible-sm visible-xs"></div>
       <div className="col-md-3 col-sm-5 col-xs-5 toleration-modal__field">
-        <div className="hidden-md hidden-lg text-secondary text-uppercase">Value</div>
+        <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">Value</div>
         <input
           type="text"
           className="form-control"
@@ -51,7 +52,7 @@ export const MatchExpressions: React.FC<MatchExpressionsProps> = (props) => {
       <div className="col-md-1 col-sm-2 col-xs-2">
         <button
           type="button"
-          className="btn btn-link btn-link--inherit-color toleration-modal__delete-icon"
+          className="pf-c-button pf-m-plain btn-link--inherit-color toleration-modal__delete-icon"
           onClick={() => props.onChangeMatchExpressions(props.matchExpressions.filter((e, index) => index !== i))}
           aria-label="Delete">
           <MinusCircleIcon className="pairs-list__side-btn pairs-list__delete-icon" />
@@ -59,13 +60,14 @@ export const MatchExpressions: React.FC<MatchExpressionsProps> = (props) => {
       </div>
     </div>) }
     <div className="row">
-      <button
+      <Button
+        className="pf-m-link--align-left"
         type="button"
-        className="btn btn-link"
         style={{marginLeft: '10px'}}
-        onClick={() => onChangeMatchExpressions(matchExpressions.concat({key: '', operator: 'Exists'}))}>
+        onClick={() => onChangeMatchExpressions(matchExpressions.concat({key: '', operator: 'Exists'}))}
+        variant="link">
         <PlusCircleIcon className="co-icon-space-r" />Add More
-      </button>
+      </Button>
     </div>
   </React.Fragment>;
 };

--- a/frontend/public/components/utils/_name-value-editor.scss
+++ b/frontend/public/components/utils/_name-value-editor.scss
@@ -1,6 +1,4 @@
 $drag-column-width: 28px;
-$drag-row-margin-left: 8px;
-$drag-row-margin-top: 6px;
 
 .co-empty__header {
   padding: 0;
@@ -12,7 +10,24 @@ $drag-row-margin-top: 6px;
   width: $drag-column-width;
 }
 
+.pairs-list__action-icon {
+  background: transparent;
+  border: 0;
+  display: flex;
+  padding-left: $grid-gutter-width / 2 !important;
+}
+
+.pairs-list__action-icon--reorder {
+  cursor: move;
+}
+
+.pairs-list__heading {
+  margin-bottom: 5px;
+}
+
 .pairs-list__row {
+  align-items: center;
+  display: flex;
   padding-bottom: 15px;
 }
 
@@ -33,7 +48,6 @@ $drag-row-margin-top: 6px;
 
 .pairs-list__value-field,
 .pairs-list__name-field {
-  padding-top: 5px;
   padding-right: 0;
 }
 
@@ -52,22 +66,7 @@ $drag-row-margin-top: 6px;
   cursor: pointer;
 }
 
-.pairs-list__action-icon {
-  margin-left: $drag-row-margin-left;
-  margin-top: $drag-row-margin-top;
-  width: auto;
-}
-
-.pairs-list__action-icon--reorder {
-  cursor: move;
-}
-
-.pairs-list__delete-icon {
-  line-height: 35px;
-}
-
 .pairs-list__span-btns {
-  margin-left: -$drag-row-margin-left;
-  margin-top: $drag-row-margin-top;
-  white-space: pre;
+  border: 0;
+  display: flex;
 }

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -67,7 +67,7 @@ export const NameValueEditor = withDragDropContext(class NameValueEditor extends
       return <PairElement onChange={this._change} index={i} nameString={nameString} valueString={valueString} allowSorting={allowSorting} readOnly={readOnly} pair={pair} key={key} onRemove={this._remove} onMove={this._move} rowSourceId={nameValueId} configMaps={configMaps} secrets={secrets} />;
     });
     return <React.Fragment>
-      <div className="row">
+      <div className="row pairs-list__heading">
         {!readOnly && allowSorting && <div className="col-xs-1 co-empty__header"></div>}
         <div className="col-xs-5 text-secondary text-uppercase">{nameString}</div>
         <div className="col-xs-5 text-secondary text-uppercase">{valueString}</div>
@@ -90,15 +90,15 @@ export const NameValueEditor = withDragDropContext(class NameValueEditor extends
                 </Button>
                 {
                   addConfigMapSecret &&
-                    <React.Fragment>
-                      <span aria-hidden="true" className="co-action-divider hidden-xs">|</span>
-                      <Button
-                        onClick={this._appendConfigMapOrSecret}
-                        type="button"
-                        variant="link">
-                        <PlusCircleIcon data-test-id="pairs-list__add-icon" className="co-icon-space-r" />Add from Config Map or Secret
-                      </Button>
-                    </React.Fragment>
+                  <React.Fragment>
+                    <Button
+                      className="pf-m-link--align-left"
+                      onClick={this._appendConfigMapOrSecret}
+                      type="button"
+                      variant="link">
+                      <PlusCircleIcon data-test-id="pairs-list__add-icon" className="co-icon-space-r" />Add from Config Map or Secret
+                    </Button>
+                  </React.Fragment>
                 }
               </div>
           }
@@ -188,7 +188,7 @@ export const EnvFromEditor = withDragDropContext(class EnvFromEditor extends Rea
     });
 
     return <React.Fragment>
-      <div className="row">
+      <div className="row pairs-list__heading">
         {!readOnly && <div className="col-xs-1 co-empty__header"></div>}
         <div className="col-xs-5 text-secondary text-uppercase">Config Map/Secret</div>
         <div className="col-xs-5 text-secondary text-uppercase">Prefix (Optional)</div>
@@ -324,14 +324,14 @@ const PairElement = DragSource(DRAGGABLE_TYPE.ENV_ROW, pairSource, collectSource
 
   render() {
     const {isDragging, connectDragSource, connectDragPreview, connectDropTarget, nameString, valueString, allowSorting, readOnly, pair, configMaps, secrets} = this.props;
-    const deleteButton = <React.Fragment><MinusCircleIcon className="pairs-list__side-btn pairs-list__delete-icon" /><span className="sr-only">Delete</span></React.Fragment>;
+    const deleteIcon = <React.Fragment><MinusCircleIcon className="pairs-list__side-btn pairs-list__delete-icon" /><span className="sr-only">Delete</span></React.Fragment>;
 
     return connectDropTarget(
       connectDragPreview(
         <div className={classNames('row', isDragging ? 'pairs-list__row-dragging' : 'pairs-list__row')} ref={node => this.node = node}>
           {allowSorting && !readOnly &&
             <div className="col-xs-1 pairs-list__action">
-              {connectDragSource(<button type="button" className="btn btn-link btn-link--inherit-color pairs-list__action-icon" tabIndex="-1">
+              {connectDragSource(<button type="button" className="pf-c-button pf-m-plain btn-link--inherit-color pairs-list__action-icon" tabIndex="-1">
                 <PficonDragdropIcon className="pairs-list__action-icon--reorder" />
               </button>)}
             </div>
@@ -351,9 +351,9 @@ const PairElement = DragSource(DRAGGABLE_TYPE.ENV_ROW, pairSource, collectSource
           }
           {
             !readOnly &&
-              <div className="col-xs-1">
-                <button type="button" className={classNames('btn', 'btn-link', 'btn-link--inherit-color', {'pairs-list__span-btns': allowSorting})} onClick={this._onRemove}>
-                  {deleteButton}
+              <div className="col-xs-1 pairs-list__action">
+                <button type="button" data-test-id="pairs-list__delete-btn" className={classNames('pf-c-button', 'pf-m-plain', 'btn-link--inherit-color', {'pairs-list__span-btns': allowSorting})} onClick={this._onRemove}>
+                  {deleteIcon}
                 </button>
               </div>
           }
@@ -415,7 +415,7 @@ const EnvFromPairElement = DragSource(DRAGGABLE_TYPE.ENV_FROM_ROW, pairSource, c
         <div className={classNames('row', isDragging ? 'pairs-list__row-dragging' : 'pairs-list__row')} ref={node => this.node = node}>
           { !readOnly &&
             <div className="col-xs-1 pairs-list__action">
-              {connectDragSource(<button type="button" className="btn btn-link btn-link--inherit-color pairs-list__action-icon" tabIndex="-1">
+              {connectDragSource(<button type="button" className="pf-c-button pf-m-plain btn-link--inherit-color pairs-list__action-icon" tabIndex="-1">
                 <PficonDragdropIcon className="pairs-list__action-icon--reorder" />
               </button>)}
             </div>
@@ -428,8 +428,8 @@ const EnvFromPairElement = DragSource(DRAGGABLE_TYPE.ENV_FROM_ROW, pairSource, c
           </div>
           {
             readOnly ? null :
-              <div className="col-xs-1">
-                <button type="button" className="btn btn-link btn-link--inherit-color pairs-list__span-btns" onClick={this._onRemove}>
+              <div className="col-xs-1 pairs-list__action">
+                <button type="button" className="pf-c-button pf-m-plain btn-link--inherit-color pairs-list__span-btns" onClick={this._onRemove}>
                   {deleteButton}
                 </button>
               </div>


### PR DESCRIPTION
- correct vertical alignment of remove icon 
- restructure css for inline form input rows so that the taints/tolerations and environment variables key value editable forms are visually consistent.
- correct hover state to match pf4

https://jira.coreos.com/browse/CONSOLE-1525

**Before and after**
<img width="931" alt="Screen Shot 2019-07-30 at 2 04 35 PM" src="https://user-images.githubusercontent.com/1874151/62549028-c63a5580-b835-11e9-92ae-f52a3b64a521.png">
<img width="915" alt="tolerations-desktop" src="https://user-images.githubusercontent.com/1874151/62549557-b40ce700-b836-11e9-9539-81a9bce1d818.png">

----
**Before and after**
<img width="619" alt="Screen Shot 2019-07-30 at 2 04 44 PM" src="https://user-images.githubusercontent.com/1874151/62549257-2b8e4680-b836-11e9-8d6d-d31f64dde364.png">
<img width="623" alt="pairs-list" src="https://user-images.githubusercontent.com/1874151/62549583-c424c680-b836-11e9-9cad-7e3ae879aa62.png">

------
**Before and after**
<img width="701" alt="Screen Shot 2019-07-30 at 2 05 43 PM" src="https://user-images.githubusercontent.com/1874151/62549299-38ab3580-b836-11e9-949a-f53911ae92ff.png">
<img width="871" alt="envars" src="https://user-images.githubusercontent.com/1874151/62549646-df8fd180-b836-11e9-84cc-907fa63dfc3f.png">


-----

Icon hover state changed to match pf4
![reorder-and-hover-state](https://user-images.githubusercontent.com/1874151/62550110-ab68e080-b837-11e9-81a1-f011d3e1a263.gif)
