### PR TITLE
fix(serverless): Adv Search for knative resources throws error

### DIFF
--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionsPage.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react';
-import { match as RMatch } from 'react-router-dom';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { RevisionModel } from '../../models';
 import RevisionList from './RevisionList';
 
 export interface RevisionsPageProps {
-  match: RMatch<{
-    ns?: string;
-  }>;
+  namespace: string;
 }
 
-const RevisionsPage: React.FC<RevisionsPageProps> = ({ match }) => (
+const RevisionsPage: React.FC<RevisionsPageProps> = ({ namespace }) => (
   <ListPage
-    namespace={match.params.ns}
+    namespace={namespace}
     canCreate={false}
     kind={referenceForModel(RevisionModel)}
     ListComponent={RevisionList}

--- a/frontend/packages/knative-plugin/src/components/routes/RoutesPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RoutesPage.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react';
-import { match as RMatch } from 'react-router-dom';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { RouteModel } from '../../models';
 import RouteList from './RouteList';
 
 export interface RoutesPageProps {
-  match: RMatch<{
-    ns?: string;
-  }>;
+  namespace: string;
 }
 
-const RoutesPage: React.FC<RoutesPageProps> = ({ match }) => (
+const RoutesPage: React.FC<RoutesPageProps> = ({ namespace }) => (
   <ListPage
-    namespace={match.params.ns}
+    namespace={namespace}
     canCreate={false}
     kind={referenceForModel(RouteModel)}
     ListComponent={RouteList}

--- a/frontend/packages/knative-plugin/src/components/services/ServicesPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServicesPage.tsx
@@ -1,19 +1,16 @@
 import * as React from 'react';
-import { match as RMatch } from 'react-router-dom';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { ServiceModel } from '../../models';
 import ServiceList from './ServiceList';
 
 export interface ServicesPageProps {
-  match: RMatch<{
-    ns?: string;
-  }>;
+  namespace: string;
 }
 
-const ServicesPage: React.FC<ServicesPageProps> = ({ match }) => (
+const ServicesPage: React.FC<ServicesPageProps> = ({ namespace }) => (
   <ListPage
-    namespace={match.params.ns}
+    namespace={namespace}
     canCreate
     kind={referenceForModel(ServiceModel)}
     ListComponent={ServiceList}


### PR DESCRIPTION
Adv Search for knative resources i.e services/routes/revisions throws an error

Tracks: https://jira.coreos.com/browse/ODC-1540

GIF:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/5129024/62670150-d2e2b900-b9af-11e9-90b9-3867bf2ad8e5.gif)
