### PR TITLE
[metal3] Remove fans and psus from intenvory card

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/dashboard/inventory-card.tsx
+++ b/frontend/packages/metal3-plugin/src/components/dashboard/inventory-card.tsx
@@ -5,11 +5,7 @@ import { DashboardCard } from '@console/internal/components/dashboard/dashboard-
 import { DashboardCardBody } from '@console/internal/components/dashboard/dashboard-card/card-body';
 import { DashboardCardHeader } from '@console/internal/components/dashboard/dashboard-card/card-header';
 import { DashboardCardTitle } from '@console/internal/components/dashboard/dashboard-card/card-title';
-import {
-  InventoryItem,
-  Status,
-} from '@console/internal/components/dashboard/inventory-card/inventory-item';
-import { InventoryStatusGroup } from '@console/internal/components/dashboard/inventory-card/status-group';
+import { InventoryItem } from '@console/internal/components/dashboard/inventory-card/inventory-item';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { FirehoseResource } from '@console/internal/components/utils';
 import { MachineModel } from '@console/internal/models';
@@ -70,18 +66,6 @@ export const InventoryCard: React.FC<InventoryCardProps> = ({
   const podError = getHostQueryResultError(podResult);
   const podCount = _.get(podResult, 'data.result', []).length;
 
-  const fanResult = prometheusResults.getIn([queries[HostQuery.NUMBER_OF_FANS], 'result']);
-  const fanError = getHostQueryResultError(fanResult);
-  const fans = _.get(fanResult, 'data.result', []);
-  const fanCount = fans.length;
-  const fanNotOkCount = fans.filter((el) => el.metric.status !== 'ok').length;
-
-  const psuResult = prometheusResults.getIn([queries[HostQuery.NUMBER_OF_PSUS], 'result']);
-  const psuError = getHostQueryResultError(psuResult);
-  const psus = _.get(psuResult, 'data.result', []);
-  const psuCount = psus.length;
-  const psuNotOkCount = psus.filter((el) => el.metric.status !== 'ok').length;
-
   return (
     <DashboardCard>
       <DashboardCardHeader>
@@ -118,28 +102,6 @@ export const InventoryCard: React.FC<InventoryCardProps> = ({
           count={cpuCount}
           error={null}
         />
-
-        <InventoryItem
-          isLoading={!fanResult}
-          singularTitle="Fan"
-          pluralTitle="Fans"
-          count={fanCount}
-          error={fanError}
-        >
-          <Status groupID={InventoryStatusGroup.OK} count={fanCount - fanNotOkCount} />
-          <Status groupID={InventoryStatusGroup.ERROR} count={fanNotOkCount} />
-        </InventoryItem>
-
-        <InventoryItem
-          isLoading={!psuResult}
-          singularTitle="PSU"
-          pluralTitle="PSUs"
-          count={psuCount}
-          error={psuError}
-        >
-          <Status groupID={InventoryStatusGroup.OK} count={psuCount - psuNotOkCount} />
-          <Status groupID={InventoryStatusGroup.ERROR} count={psuNotOkCount} />
-        </InventoryItem>
       </DashboardCardBody>
     </DashboardCard>
   );


### PR DESCRIPTION
The data needed for these two inventory items won't be available in 4.2 so we're hiding it for now.  This commit can be reverted once ironic-exporter is available.