### PR TITLE
Set 'user-auth-oidc-ca-file' flag with the TrustedCA file

### DIFF
--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -35,8 +35,15 @@ func SetFlagsFromConfig(fs *flag.FlagSet, filename string) (err error) {
 	addAuth(fs, &config.Auth)
 	addCustomization(fs, &config.Customization)
 	addProviders(fs, &config.Providers)
+	addTrustedCAFile(fs, &config.Proxy)
 
 	return nil
+}
+
+func addTrustedCAFile(fs *flag.FlagSet, proxy *Proxy) {
+	if proxy.TrustedCAFile != "" {
+		fs.Set("user-auth-oidc-ca-file", proxy.TrustedCAFile)
+	}
 }
 
 func addServingInfo(fs *flag.FlagSet, servingInfo *ServingInfo) (err error) {

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -1,6 +1,5 @@
 package serverconfig
 
-
 // This file is a copy of the struct within the console operator:
 //   https://github.com/openshift/console-operator/blob/master/pkg/console/subresource/consoleserver/types.go
 // These structs need to remain in sync.
@@ -14,6 +13,7 @@ type Config struct {
 	Auth          `yaml:"auth"`
 	Customization `yaml:"customization"`
 	Providers     `yaml:"providers"`
+	Proxy         `yaml:"proxy"`
 }
 
 // ServingInfo holds configuration for serving HTTP.
@@ -58,4 +58,9 @@ type Customization struct {
 
 type Providers struct {
 	StatuspageID string `yaml:"statuspageID,omitempty"`
+}
+
+// Proxy holds proxy configuration
+type Proxy struct {
+	TrustedCAFile string `yaml:"trustedCAFile,omitempty"`
 }


### PR DESCRIPTION
Console side of story https://jira.coreos.com/browse/CONSOLE-1669

The path of the TrustedCA file will be read from the `console-config` configMap upon starting the console server and passed to the `ca-file` flag.

/assign @spadgett @benjaminapetersen 