### PR TITLE
Bug 1741132: Add "B" to the end of binary unit labels

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-card/capacity-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-card/capacity-card.tsx
@@ -11,11 +11,7 @@ import {
   DashboardItemProps,
   withDashboardResources,
 } from '@console/internal/components/dashboard/with-dashboard-resources';
-import {
-  Dropdown,
-  FieldLevelHelp,
-  humanizeBinaryBytesWithoutB,
-} from '@console/internal/components/utils';
+import { Dropdown, FieldLevelHelp, humanizeBinaryBytes } from '@console/internal/components/utils';
 import { getInstantVectorStats, GetStats } from '@console/internal/components/graphs/utils';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import {
@@ -130,7 +126,7 @@ export const CapacityCard: React.FC<DashboardItemProps & WithFlagsProps> = ({
             used={statUsed}
             total={statTotal}
             error={storageTotalError || storageUsedError}
-            formatValue={humanizeBinaryBytesWithoutB}
+            formatValue={humanizeBinaryBytes}
             isLoading={!(storageUsed && storageTotal)}
           />
         </CapacityBody>

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/top-consumers-card/top-consumers-card-body.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/top-consumers-card/top-consumers-card-body.tsx
@@ -11,7 +11,7 @@ import {
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
 import { DataPoint, PrometheusResponse } from '@console/internal/components/graphs';
-import { humanizeBinaryBytesWithoutB, LoadingInline } from '@console/internal/components/utils';
+import { humanizeBinaryBytes, LoadingInline } from '@console/internal/components/utils';
 import { twentyFourHourTime } from '@console/internal/components/utils/datetime';
 import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import { getGraphVectorStats, getMetricType, sortResources } from './utils';
@@ -31,7 +31,7 @@ const chartLegendPropsValue = {
 const getMaxCapacity = (topConsumerStatsResult: PrometheusResponse['data']['result']) => {
   const resourceValues = _.flatMap(topConsumerStatsResult, (resource) => resource.values);
   const maxCapacity = _.maxBy(resourceValues, (value) => Number(value[1]));
-  return humanizeBinaryBytesWithoutB(Number(maxCapacity[1]));
+  return humanizeBinaryBytes(Number(maxCapacity[1]));
 };
 
 export const TopConsumersBody: React.FC<TopConsumerBodyProps> = React.memo(

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/top-consumers-card/utils.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/top-consumers-card/utils.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { humanizeBinaryBytesWithoutB } from '@console/internal/components/utils';
+import { humanizeBinaryBytes } from '@console/internal/components/utils';
 import { PrometheusResponse, DataPoint } from '@console/internal/components/graphs';
 
 export const getMetricType: GetMetricType = (resource, metricType) =>
@@ -12,7 +12,7 @@ export const getGraphVectorStats: GetStats = (response, metricType, unit) => {
     return r.values.map((arr) => ({
       name: truncatedName,
       x: new Date(arr[0] * 1000),
-      y: Number(humanizeBinaryBytesWithoutB(arr[1], null, unit).value),
+      y: Number(humanizeBinaryBytes(arr[1], null, unit).value),
     }));
   });
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utilization-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utilization-card.tsx
@@ -11,7 +11,7 @@ import {
 } from '@console/internal/components/dashboard/with-dashboard-resources';
 import { getRangeVectorStats } from '@console/internal/components/graphs/utils';
 import {
-  humanizeBinaryBytesWithoutB,
+  humanizeBinaryBytes,
   humanizeDecimalBytesPerSec,
 } from '@console/internal/components/utils';
 import UtilizationBody from '@console/shared/src/components/dashboard/utilization-card/UtilizationBody';
@@ -130,7 +130,7 @@ const UtilizationCard: React.FC<DashboardItemProps> = ({
           <UtilizationItem
             title="Used Capacity"
             data={capacityStats}
-            humanizeValue={humanizeBinaryBytesWithoutB}
+            humanizeValue={humanizeBinaryBytes}
             query={
               UTILIZATION_QUERY[StorageDashboardQuery.CEPH_CAPACITY_USED] +
               UTILIZATION_QUERY_HOUR_MAP[duration]

--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -28,7 +28,7 @@ import {
 import { PodModel, RouteModel, NodeModel } from '@console/internal/models';
 import { FLAGS } from '@console/internal/const';
 import { GridPosition } from '@console/shared/src/components/dashboard/DashboardGrid';
-import { humanizeBinaryBytesWithoutB } from '@console/internal/components/utils/units';
+import { humanizeBinaryBytes } from '@console/internal/components/utils/units';
 import { OverviewQuery } from '@console/internal/components/dashboard/dashboards-page/overview-dashboard/queries';
 import { MetricType } from '@console/shared/src/components/dashboard/top-consumers-card/metric-type';
 import { FooBarModel } from './models';
@@ -264,7 +264,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       title: 'Foo',
       query: 'barQuery',
-      humanizeValue: humanizeBinaryBytesWithoutB,
+      humanizeValue: humanizeBinaryBytes,
       required: 'TEST_MODEL_FLAG',
     },
   },

--- a/frontend/packages/console-shared/src/components/dashboard/top-consumers-card/ConsumersFilter.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/top-consumers-card/ConsumersFilter.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
   humanizeSeconds,
-  humanizeBinaryBytesWithoutB,
+  humanizeBinaryBytes,
   humanizeDecimalBytesPerSec,
 } from '@console/internal/components/utils/units';
 import { Humanize } from '@console/internal/components/utils/types';
@@ -21,7 +21,7 @@ export const metricTypeMap: MetricTypeMap = {
   },
   [MetricType.MEMORY]: {
     description: MEMORY_DESC,
-    humanize: humanizeBinaryBytesWithoutB,
+    humanize: humanizeBinaryBytes,
   },
   [MetricType.STORAGE]: {
     description: STORAGE_DESC,

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card-utils.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card-utils.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import {
   Humanize,
-  humanizeBinaryBytesWithoutB,
+  humanizeBinaryBytes,
   humanizeNumber,
   HumanizeResult,
 } from '@console/internal/components/utils';
@@ -100,12 +100,12 @@ export const getDataConsumptionChartData: GetDataConsumptionChartData = (
       ];
       break;
     case 'ACCOUNTS_BY_LOGICAL_USAGE':
-      max = getMaxVal(result.logicalUsage, humanizeBinaryBytesWithoutB);
+      max = getMaxVal(result.logicalUsage, humanizeBinaryBytes);
       chartData = [
         getChartData(
           result.logicalUsage,
           metric,
-          humanizeBinaryBytesWithoutB,
+          humanizeBinaryBytes,
           max.unit,
           'Total Logical Used Capacity',
         ),
@@ -114,27 +114,27 @@ export const getDataConsumptionChartData: GetDataConsumptionChartData = (
         {
           name: `Total Logical Used Capacity ${getLegendData(
             result.totalLogicalUsage,
-            humanizeBinaryBytesWithoutB,
+            humanizeBinaryBytes,
           )}`,
         },
       ];
       break;
     case 'PROVIDERS_BY_PHYSICAL_VS_LOGICAL_USAGE':
-      firstBarMax = getMaxVal(result.physicalUsage, humanizeBinaryBytesWithoutB);
-      secondBarMax = getMaxVal(result.logicalUsage, humanizeBinaryBytesWithoutB);
+      firstBarMax = getMaxVal(result.physicalUsage, humanizeBinaryBytes);
+      secondBarMax = getMaxVal(result.logicalUsage, humanizeBinaryBytes);
       max = firstBarMax.value > secondBarMax.value ? firstBarMax : secondBarMax;
       chartData = [
         getChartData(
           result.physicalUsage,
           metric,
-          humanizeBinaryBytesWithoutB,
+          humanizeBinaryBytes,
           max.unit,
           'Total Logical Used Capacity',
         ),
         getChartData(
           result.logicalUsage,
           metric,
-          humanizeBinaryBytesWithoutB,
+          humanizeBinaryBytes,
           max.unit,
           'Total Physical Used Capacity',
         ),
@@ -143,20 +143,20 @@ export const getDataConsumptionChartData: GetDataConsumptionChartData = (
         {
           name: `Total Logical Used Capacity ${getLegendData(
             result.totalPhysicalUsage,
-            humanizeBinaryBytesWithoutB,
+            humanizeBinaryBytes,
           )}`,
         },
         {
           name: `Total Physical Used Capacity ${getLegendData(
             result.totalLogicalUsage,
-            humanizeBinaryBytesWithoutB,
+            humanizeBinaryBytes,
           )}`,
         },
       ];
       break;
     case 'PROVIDERS_BY_EGRESS':
-      max = getMaxVal(result.egress, humanizeBinaryBytesWithoutB);
-      chartData = [getChartData(result.egress, metric, humanizeBinaryBytesWithoutB, max.unit)];
+      max = getMaxVal(result.egress, humanizeBinaryBytes);
+      chartData = [getChartData(result.egress, metric, humanizeBinaryBytes, max.unit)];
       legendData = chartData[0].map((dataPoint) => ({
         name: `${dataPoint.x} ${dataPoint.y} ${max.unit}`,
       }));

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card-item.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card-item.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import {
   FieldLevelHelp,
-  humanizeBinaryBytesWithoutB,
+  humanizeBinaryBytes,
   humanizePercentage,
   LoadingInline,
 } from '@console/internal/components/utils';
@@ -57,7 +57,7 @@ export const SavingsItem: React.FC<SavingsItemProps> = React.memo(
       const savingsPercentage = logicalSize
         ? `(${humanizePercentage((100 * Number(savings)) / logicalSize).string})`
         : '';
-      stats = `${humanizeBinaryBytesWithoutB(savings).string} ${savingsPercentage}`;
+      stats = `${humanizeBinaryBytes(savings).string} ${savingsPercentage}`;
     }
     return (
       <ItemBody

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/capacity-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/capacity-card.tsx
@@ -13,7 +13,7 @@ import { withDashboardResources, DashboardItemProps } from '../../with-dashboard
 import {
   humanizePercentage,
   humanizeDecimalBytesPerSec,
-  humanizeBinaryBytesWithoutB,
+  humanizeBinaryBytes,
   useRefWidth,
 } from '../../../utils';
 import { getInstantVectorStats, getRangeVectorStats, GetStats } from '../../../graphs/utils';
@@ -111,7 +111,7 @@ export const CapacityCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
       title="Memory"
       used={getLastStats(memoryUtilization, getInstantVectorStats)}
       total={getLastStats(memoryTotal, getInstantVectorStats)}
-      formatValue={humanizeBinaryBytesWithoutB}
+      formatValue={humanizeBinaryBytes}
       isLoading={!(memoryUtilization && memoryTotal)}
       error={memoryUtilizationError || memoryTotalError}
     />
@@ -122,7 +122,7 @@ export const CapacityCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
       title="Storage"
       used={getLastStats(storageUsed, getRangeVectorStats)}
       total={getLastStats(storageTotal, getInstantVectorStats)}
-      formatValue={humanizeBinaryBytesWithoutB}
+      formatValue={humanizeBinaryBytes}
       isLoading={!(storageUsed && storageTotal)}
       error={storageUsedError || storageTotalError}
     />

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/utilization-card.tsx
@@ -17,7 +17,7 @@ import { metricTypeMap } from '@console/shared/src/components/dashboard/top-cons
 import { MetricType } from '@console/shared/src/components/dashboard/top-consumers-card/metric-type';
 import { DashboardItemProps, withDashboardResources } from '../../with-dashboard-resources';
 import { getRangeVectorStats } from '../../../graphs/utils';
-import { humanizePercentage, humanizeBinaryBytesWithoutB } from '../../../utils';
+import { humanizePercentage, humanizeBinaryBytes } from '../../../utils';
 import { Dropdown } from '../../../utils/dropdown';
 import { OverviewQuery, utilizationQueries, top25ConsumerQueries } from './queries';
 import { connectToFlags, FlagsObject, WithFlagsProps } from '../../../../reducers/features';
@@ -188,9 +188,9 @@ const UtilizationCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
           data={memoryStats}
           error={memoryUtilizationError}
           isLoading={!memoryUtilization}
-          humanizeValue={humanizeBinaryBytesWithoutB}
+          humanizeValue={humanizeBinaryBytes}
           query={queries[OverviewQuery.MEMORY_UTILIZATION]}
-          byteDataType={ByteDataTypes.BinaryBytesWithoutB}
+          byteDataType={ByteDataTypes.BinaryBytes}
           TopConsumerPopover={memPopover}
         />
         <UtilizationItem
@@ -198,9 +198,9 @@ const UtilizationCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
           data={storageStats}
           error={storageUtilizationError}
           isLoading={!storageUtilization}
-          humanizeValue={humanizeBinaryBytesWithoutB}
+          humanizeValue={humanizeBinaryBytes}
           query={queries[OverviewQuery.STORAGE_UTILIZATION]}
-          byteDataType={ByteDataTypes.BinaryBytesWithoutB}
+          byteDataType={ByteDataTypes.BinaryBytes}
           TopConsumerPopover={storagePopover}
         />
         {pluginItems.map(({ properties }, index) => {

--- a/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
@@ -14,7 +14,7 @@ import {
   UTILIZATION_QUERY_HOUR_MAP,
 } from '@console/shared/src/components/dashboard/utilization-card/dropdown-value';
 import { Dropdown } from '../../utils/dropdown';
-import { humanizeCpuCores, humanizeDecimalBytes, humanizeNumber } from '../../utils';
+import { humanizeCpuCores, humanizeBinaryBytes, humanizeNumber } from '../../utils';
 import { getRangeVectorStats } from '../../graphs/utils';
 import { PrometheusResponse } from '../../graphs';
 import { ProjectDashboardContext } from './project-dashboard-context';
@@ -90,7 +90,7 @@ export const UtilizationCard = withDashboardResources(
               title="Memory"
               data={memoryStats}
               isLoading={!projectName || !memoryUtilization}
-              humanizeValue={humanizeDecimalBytes}
+              humanizeValue={humanizeBinaryBytes}
               query={queries[ProjectQueries.MEMORY_USAGE]}
               error={memoryError}
             />

--- a/frontend/public/components/modals/expand-pvc-modal.jsx
+++ b/frontend/public/components/modals/expand-pvc-modal.jsx
@@ -43,9 +43,9 @@ class ExpandPVCModal extends PromiseComponent {
   render() {
     const { kind, resource } = this.props;
     const dropdownUnits = {
-      Mi: 'Mi',
-      Gi: 'Gi',
-      Ti: 'Ti',
+      Mi: 'MiB',
+      Gi: 'GiB',
+      Ti: 'TiB',
     };
     const { requestSizeUnit, requestSizeValue } = this.state;
     return (

--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -70,9 +70,9 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
     },
   ];
   const dropdownUnits = {
-    Mi: 'Mi',
-    Gi: 'Gi',
-    Ti: 'Ti',
+    Mi: 'MiB',
+    Gi: 'GiB',
+    Ti: 'TiB',
   };
   const { namespace, onChange } = props;
 


### PR DESCRIPTION
This PR:
1. Converts the unit labels of all dashboard cards from `Mi/Gi/Ti` to `MiB/GiB/TiB` by changing `humanizeBinaryBytesWithoutB` to `humanizeBinaryBytes`.
2. Adds a `B` to the dropdown labels of the PVC create form and expand modal
3. <s>Updates the Node Details page charts and table to use `humanizeBinaryBytes` (except for Network-related metrics, for reasons described [here](https://github.com/openshift/console/pull/2161#issuecomment-515045779)).</s>

The reasoning for this change was [discussed back in June](https://docs.google.com/presentation/d/1DeNa43v6J7s5TtYjpmFBAzAIfE0QFiNp4vMWzM7j4Dc/edit#slide=id.g595e80c6d6_0_137) and IIRC the plan was to switch over whenever dashboards were introduced, which emphasize these unit labels quite a bit. With dashboards now here, should we make the switch?

Here are the remaining places in the Console that use `Mi/Gi/Ti` that I could find. I think they pull the value and label directly from the YAML, so I'm not quite sure how to address that.

- PVC table and details: `spec.resources.requests.storage`
- PV table and details: `spec.capacity.storage`
- Limit Range details (Limits table): `resource.resource.spec.limits`
- Resource Quota details ("Max" in table): `unsure`

FYI @rawagner @julienlim

(Also @rawagner, should this PR switch to using `decimalBitsPerSec` for the Node Details charts even though it depends on your #2161?)

Fixes [Bugzilla 1741132](https://bugzilla.redhat.com/show_bug.cgi?id=1741132)