### PR TITLE
Query Browser: Add back 1px top padding

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -117,6 +117,7 @@ const Graph: React.FC<GraphProps> = React.memo(({containerComponent, domain, dat
     {width > 0 && <Chart
       containerComponent={containerComponent}
       domain={domain || {x: [Date.now() - span, Date.now()], y: undefined}}
+      domainPadding={{y: 1}}
       height={200}
       minDomain={{y: 0}}
       scale={{x: 'time', y: 'linear'}}


### PR DESCRIPTION
We actually need a tiny bit of padding at the top of the graph.
Otherwise 1px of the highest point on the line is cut off.