### PR TITLE
Adding 'OCS' prefix to storage dashboard cards

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/details-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/details-card.tsx
@@ -65,7 +65,7 @@ const DetailsCard: React.FC<DashboardItemProps> = ({
   return (
     <DashboardCard>
       <DashboardCardHeader>
-        <DashboardCardTitle>Details</DashboardCardTitle>
+        <DashboardCardTitle>OCS Details</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
         <DetailsBody>

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/health-card/health-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/health-card/health-card.tsx
@@ -47,7 +47,7 @@ const HealthCard: React.FC<DashboardItemProps> = ({
   return (
     <DashboardCard>
       <DashboardCardHeader>
-        <DashboardCardTitle>Health</DashboardCardTitle>
+        <DashboardCardTitle>OCS Health</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody isLoading={cephHealthState.state === HealthState.LOADING}>
         <HealthBody>

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/inventory-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/inventory-card.tsx
@@ -83,7 +83,7 @@ const InventoryCard: React.FC<DashboardItemProps> = ({
   return (
     <DashboardCard>
       <DashboardCardHeader>
-        <DashboardCardTitle>Inventory</DashboardCardTitle>
+        <DashboardCardTitle>OCS Inventory</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
         <ResourceInventoryItem


### PR DESCRIPTION
Health, Details and Inventory cards are prefixed with 'OCS' string...

Fixes: https://github.com/openshift/console/issues/2301

Signed-off-by: aruniiird <arun.iiird@gmail.com>