### PR TITLE
Add View Schema to creating new resources from YAML

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -17,6 +17,7 @@ import { k8sCreate, k8sUpdate, referenceFor, groupVersionFor, referenceForModel 
 import { checkAccess, history, Loading, resourceObjPath } from './utils';
 import { ExploreTypeSidebar } from './sidebars/explore-type-sidebar';
 import { ResourceSidebar } from './sidebars/resource-sidebar';
+import { resourceSidebars } from './sidebars/resource-sidebars';
 import { yamlTemplates } from '../models/yaml-templates';
 
 import { getStoredSwagger } from '../module/k8s/swagger';
@@ -515,10 +516,13 @@ export const EditYAML = connect(stateToProps)(
       const klass = classNames('co-file-dropzone-container', {'co-file-dropzone--drop-over': isOver});
 
       const {error, success, stale, yaml, height} = this.state;
-      const {create, obj, download = true, header} = this.props;
+      const {create, obj, download = true, header, kind} = this.props;
       const readOnly = this.props.readOnly || this.state.notAllowed;
       const options = { readOnly, scrollBeyondLastLine: false };
       const model = this.getModel(obj);
+      const sideBar = (create && resourceSidebars.get(kind))
+        ? <ResourceSidebar isCreateMode={create} kindObj={model} height={height} loadSampleYaml={this.loadSampleYaml_} downloadSampleYaml={this.downloadSampleYaml_} />
+        : <ExploreTypeSidebar isCreateMode={create} kindObj={model} height={this.state.height} />;
       const editYamlComponent = <div className="co-file-dropzone">
         { canDrop && <div className={klass}><p className="co-file-dropzone__drop-text">Drop file here</p></div> }
 
@@ -554,8 +558,7 @@ export const EditYAML = connect(stateToProps)(
                   </div>
                 </div>
               </div>
-              {create && <ResourceSidebar isCreateMode={create} kindObj={model} height={height} loadSampleYaml={this.loadSampleYaml_} downloadSampleYaml={this.downloadSampleYaml_} />}
-              {!create && <ExploreTypeSidebar kindObj={model} height={this.state.height} />}
+              {sideBar}
             </div>
           </div>
         </div>

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -116,8 +116,8 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   );
 };
 
-export const ExploreTypeSidebar: React.FC<ExploreTypeSidebarProps> = ({height, ...exploreTypeProps}) => (
-  <ResourceSidebarWrapper label={exploreTypeProps.kindObj.kind} linkLabel="View Schema" style={{height}} startHidden>
+export const ExploreTypeSidebar: React.FC<ExploreTypeSidebarProps> = ({height, isCreateMode, ...exploreTypeProps}) => (
+  <ResourceSidebarWrapper label={exploreTypeProps.kindObj.kind} linkLabel="View Schema" style={{height}} isCreateMode={isCreateMode} startHidden>
     <ExploreType {...exploreTypeProps} scrollTop={sidebarScrollTop} />
   </ResourceSidebarWrapper>
 );
@@ -129,4 +129,5 @@ type ExploreTypeProps = {
 
 type ExploreTypeSidebarProps = {
   height: number;
+  isCreateMode?: boolean;
 } & ExploreTypeProps;

--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -28,12 +28,12 @@ export class ResourceSidebarWrapper extends React.Component {
   }
 
   render() {
-    const {style, label, linkLabel, children} = this.props;
+    const {style, label, linkLabel, children, isCreateMode} = this.props;
     const {height} = style;
     const {showSidebar} = this.state;
 
     if (!showSidebar) {
-      return <div className="co-p-has-sidebar__sidebar--hidden hidden-sm hidden-xs">
+      return <div className={`co-p-has-sidebar__sidebar--hidden hidden-sm hidden-xs ${isCreateMode && 'co-p-has-sidebar__new-mode'}`}>
         <button className="btn btn-link" onClick={this.toggleSidebar}>
           <InfoCircleIcon className="co-icon-space-r co-p-has-sidebar__sidebar-link-icon" />{linkLabel}
         </button>
@@ -74,7 +74,7 @@ export const SampleYaml = ({sample, loadSampleYaml, downloadSampleYaml}) => {
 };
 
 export const ResourceSidebar = props => {
-  const {kindObj, height} = props;
+  const {kindObj, height, isCreateMode} = props;
   if (!kindObj || !props.isCreateMode) {
     return null;
   }
@@ -82,7 +82,7 @@ export const ResourceSidebar = props => {
   const {kind, label} = kindObj;
   const SidebarComponent = resourceSidebars.get(kind);
   if (SidebarComponent) {
-    return <ResourceSidebarWrapper label={`${label} Samples`} linkLabel="View Samples" style={{height}}>
+    return <ResourceSidebarWrapper label={`${label} Samples`} linkLabel="View Samples" style={{height}} isCreateMode={isCreateMode}>
       <SidebarComponent {...props} />
     </ResourceSidebarWrapper>;
   }

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -63,4 +63,8 @@ body,
     top: -35px;
     z-index: 1;
   }
+
+  &__new-mode {
+    top: -45px;
+  }
 }


### PR DESCRIPTION
Fixes [CONSOLE-1671](https://jira.coreos.com/browse/CONSOLE-1671)

In the cases where the create resource from yaml page already had a 'View Samples' sidebar such as Build Config which let you Build from Docker, use S2I build, etc... it does not display the 'View schema' sidebar. It displays the same 'View Samples' sidebar as before.

![Screen Shot 2019-08-07 at 4 19 43 PM](https://user-images.githubusercontent.com/26305082/62712428-ccad0680-b9c8-11e9-8d92-427fe13662fb.png)
