### PR TITLE
Correct envFrom form field top alignment

### DIFF
--- a/frontend/public/components/utils/_value-from-pair.scss
+++ b/frontend/public/components/utils/_value-from-pair.scss
@@ -1,5 +1,4 @@
 .value-from {
-  padding-top: 5px;
   width: 100%;
 
   .value-from-pair {
@@ -24,4 +23,8 @@
     left: auto;
     right: 0;
   }
+}
+
+.value-from--key {
+  padding-top: 5px;
 }

--- a/frontend/public/components/utils/value-from-pair.jsx
+++ b/frontend/public/components/utils/value-from-pair.jsx
@@ -103,7 +103,7 @@ export const NameKeyDropdownPair = ({name, key, configMaps, secrets, onChange, k
     />{isKeyRef &&
     <Dropdown
       menuClassName="value-from__menu dropdown-menu--text-wrap"
-      className="value-from"
+      className="value-from value-from--key"
       autocompleteFilter={keyAutocompleteFilter}
       autocompletePlaceholder="Key"
       items={itemKeys}


### PR DESCRIPTION
Moved padding-top to specific `value-from--key` field to separate the stacked dropdowns for resource/key

<img width="785" alt="Screen Shot 2019-08-08 at 2 59 06 PM" src="https://user-images.githubusercontent.com/1874151/62730333-c0877000-b9ed-11e9-8b3a-e70ce0a3b0ad.png">

**Fixed**

---
<img width="797" alt="Screen Shot 2019-08-08 at 2 57 27 PM" src="https://user-images.githubusercontent.com/1874151/62730587-44415c80-b9ee-11e9-9cdc-be7412bfb51b.png">

