### PR TITLE
Making the unhealthy icon consistent throughout all cards

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card-item.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card-item.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { ArrowCircleDownIcon } from '@patternfly/react-icons';
 import { LoadingInline, pluralize } from '@console/internal/components/utils';
+import { RedExclamationCircleIcon } from '@console/shared';
 
 const pluralizeWithNotation = (i: number, suffix: string, singular: string) =>
   `${i}${suffix} ${i === 1 ? singular : `${singular}s`}`;
@@ -19,7 +19,7 @@ const BucketsRowStatus: React.FC<BucketsRowStatusProps> = React.memo(({ status }
     ) : Number(status) > 0 ? (
       <React.Fragment>
         <div>
-          <ArrowCircleDownIcon />
+          <RedExclamationCircleIcon />
         </div>
         <div className="nb-buckets-card__row-status-item-text">{status}</div>
       </React.Fragment>

--- a/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card-item.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card-item.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { ArrowCircleDownIcon } from '@patternfly/react-icons';
+import { RedExclamationCircleIcon } from '@console/shared';
 
 const ResourceProvidersItemStatus: React.FC<ResourceProvidersRowStatusProps> = React.memo(
   ({ status }) => (
     <div className="nb-resource-providers-card__row-status">
       <div className="nb-resource-providers-card__row-status-item">
         <div>
-          <ArrowCircleDownIcon />
+          <RedExclamationCircleIcon />
         </div>
         <div className="nb-resource-providers-card__row-status-item-text">{status}</div>
       </div>


### PR DESCRIPTION
Changes submitted for,
for bucket and resource-provider card
- displaying the red-circle-exclamation icon for unhealthy buckets

for bucket-card
- made the logic for showing object-counts-text simpler and scalable

Fixes: https://github.com/openshift/console/issues/2309

Signed-off-by: aruniiird <arun.iiird@gmail.com>