### PR TITLE
Bug 1739380: Query Browser: Fix table values

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -78,6 +78,11 @@
   }
 }
 
+.query-browser__no-data-warning {
+  border-bottom: solid 1px $color-grey-background-border;
+  padding: 10px 20px;
+}
+
 .query-browser__query {
   line-height: 1;
   margin: 0 15px;
@@ -144,7 +149,8 @@
 }
 
 .query-browser__table-cell {
-  padding-right: 0;
+  @include co-break-word;
+  padding-right: 0 !important;
 }
 
 $tooltip-background-color: #151515;


### PR DESCRIPTION
The table values were displaying the last value of each series, but that
is not actually correct since a series may not continue until the
current time. Instead we need to get the latest values from the
Prometheus API's `query` endpoint.

Also fixes a bug where the results table was not cleared after the query
input was cleared. A "No datapoints found" message is now shown instead.

![screenshot](https://user-images.githubusercontent.com/460802/62823631-f08d6980-bbcd-11e9-81e7-2a8590b03e56.png)

Also fixes a bug where the table data was being truncated in Firefox.

Fixes: https://jira.coreos.com/browse/MON-744
Fixes: https://jira.coreos.com/browse/MON-734
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1739380

FYI @cshinn, @juzhao 