### PR TITLE
Query Browser: Ignore Prometheus API AbortError errors

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -207,8 +207,10 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
       setError(undefined);
     })
     .catch(err => {
-      setError(err);
-      setUpdating(false);
+      if (err.name !== 'AbortError') {
+        setError(err);
+        setUpdating(false);
+      }
     });
 
   // If an end time was set, stop polling since we are no longer displaying the latest data. Otherwise use a polling


### PR DESCRIPTION
When the Query Browser is unmounted, the Prometheus API poller is
aborted, resulting in an `AbortError` error in the fetch `catch`. We
should ignore these errors.

This fixes a JS error resulting from trying to set the state of an
unmounted component (trying to store the error information in state).