### PR TITLE
Monitoring: Fix Silence form JS warning and button alignment

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -949,10 +949,7 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
               </button>
             </div>
           </div>)}
-          <Button
-            onClick={this.addMatcher}
-            type="button"
-            variant="link">
+          <Button className="pf-m-link--align-left" onClick={this.addMatcher} type="button" variant="link">
             <PlusCircleIcon className="co-icon-space-r" />Add More
           </Button>
         </div>

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -841,11 +841,10 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
     const startsAt = formatDate(now);
     const endsAt = formatDate(new Date(now.setHours(now.getHours() + 2)));
     const data = _.defaults(props.defaults, {startsAt, endsAt, matchers: [], createdBy: '', comment: ''});
-    this.state = {data, error: undefined, inProgress: false};
-
     if (_.isEmpty(data.matchers)) {
-      this.addMatcher();
+      data.matchers.push({name: '', value: '', isRegex: false});
     }
+    this.state = {data, error: undefined, inProgress: false};
   }
 
   setField = (path: string, v: any): void => {


### PR DESCRIPTION
1. Fix `Can't call setState on a component that is not yet mounted` JS warning
2. Fix "Add More" button to align with left edge of page