### PR TITLE
Remove unnecessary padding in alerts title, fix icon/text position

### DIFF
--- a/frontend/public/components/dashboard/health-card/alert-item.tsx
+++ b/frontend/public/components/dashboard/health-card/alert-item.tsx
@@ -5,24 +5,23 @@ import { getAlertSeverity, getAlertMessage, getAlertDescription } from './';
 import { Alert } from '../../monitoring';
 
 const getSeverityIcon = (severity: string) => {
+  let icon;
   switch (severity) {
     case 'critical':
-      return (
-        <RedExclamationCircleIcon className="co-health-card__alerts-icon" />
-      );
+      icon = <RedExclamationCircleIcon />;
+      break;
     case 'warning':
     default:
-      return (
-        <YellowExclamationTriangleIcon className="co-health-card__alerts-icon" />
-      );
+      icon = <YellowExclamationTriangleIcon />;
   }
+  return <div className="co-health-card__alerts-icon">{icon}</div>;
 };
 
 export const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
   return (
     <div className="co-health-card__alerts-item">
       {getSeverityIcon(getAlertSeverity(alert))}
-      <div className="co-health-card__alerts-item-message">{getAlertDescription(alert) || getAlertMessage(alert)}</div>
+      {getAlertDescription(alert) || getAlertMessage(alert)}
     </div>
   );
 };

--- a/frontend/public/components/dashboard/health-card/health-card.scss
+++ b/frontend/public/components/dashboard/health-card/health-card.scss
@@ -6,21 +6,18 @@
 
 .co-health-card__alerts-border {
   border-top: 1px solid $pf-color-black-300;
-  padding-top: 1em;
 }
 
 .co-health-card__alerts-icon {
-  font-size: 20px;
+  font-size: 1.2rem;
   margin-right: 1rem;
+  margin-top: 0.2rem;
 }
 
 .co-health-card__alerts-item {
-  display: table;
+  align-items: center;
+  display: flex;
   margin-bottom: 0.5em;
-}
-
-.co-health-card__alerts-item-message {
-  display: table-cell;
 }
 
 .co-health-card__body {


### PR DESCRIPTION
before:
![alerts_padding](https://user-images.githubusercontent.com/2078045/62859979-1d8d6980-bcff-11e9-8678-bfa6c98a3058.png)

after:
![alerts_padding1](https://user-images.githubusercontent.com/2078045/62859983-1ebe9680-bcff-11e9-9ece-5c5db0c05884.png)
