### PR TITLE
Fix bug where monaco-aria-container is sometimes visible in Firefox

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -72,6 +72,12 @@ kbd {
   font-size: $font-size-base;
 }
 
+// fix bug where monaco-aria-container is visible in Firefox but shouldn't be
+// bug occurs only if the suggestions overlay has been enabled
+.monaco-aria-container {
+  top: -999em;
+}
+
 // PatternFly 4 overrides
 
 .pf-c-about-modal-box {


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1661

Before:
![Screen Shot 2019-08-12 at 2 15 29 PM](https://user-images.githubusercontent.com/895728/62887806-0012cc80-bd0c-11e9-9aea-761c955912f9.png)

After:
![Screen Shot 2019-08-12 at 2 15 42 PM](https://user-images.githubusercontent.com/895728/62887822-06a14400-bd0c-11e9-8b19-04893b43ba29.png)
