### PR TITLE
Adding Florian back to metal3-plugin OWNERS file

### DIFF
--- a/frontend/packages/metal3-plugin/OWNERS
+++ b/frontend/packages/metal3-plugin/OWNERS
@@ -2,8 +2,10 @@ reviewers:
   - jtomasek
   - honza
   - knowncitizen
+  - flofuchs
 approvers:
   - jtomasek
   - honza
+  - flofuchs
 labels:
   - component/metal3


### PR DESCRIPTION
Florian is now part of the org, so he can be added back.
(removed by https://github.com/openshift/console/pull/2175)