### PR TITLE
Bug 1739225: Timestamp component always shows dates in the future as relative dates

### DIFF
--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -13,11 +13,12 @@ const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean) => {
     return '-';
   }
 
-  const timeAgo = now.getTime() - mdate.getTime();
+  const timeDifference = now.getTime() - mdate.getTime();
   if (omitSuffix) {
     return dateTime.fromNow(mdate, undefined, {omitSuffix: true});
   }
-  if (timeAgo < 630000) { // 10.5 minutes
+  if (Math.sign(timeDifference) !== -1 && timeDifference < 630000) { // 10.5 minutes
+    // Show a relative time if within 10.5 minutes in the past from the current time.
     return dateTime.fromNow(mdate);
   }
 


### PR DESCRIPTION
Updated `Timestamp` component to only show dates 10.5 minutes in past as relative dates (ex: "2 minutes ago").  Future dates will never be displayed as relative dates, always as full dates.

**Before fix,** dates in the future always displayed as relative:

![image](https://user-images.githubusercontent.com/12733153/63051425-363a8280-beab-11e9-8ef4-6e496ca4ddd6.png)

**After fix**, future dates displayed as actual date (minus year if current year):

![image](https://user-images.githubusercontent.com/12733153/63051563-713cb600-beab-11e9-8c3f-3ffb8b6664f0.png)

https://bugzilla.redhat.com/show_bug.cgi