### PR TITLE
Change the behaviour of card help from click to hover

### DIFF
--- a/build-backend.sh
+++ b/build-backend.sh
@@ -10,4 +10,4 @@ PROJECT_DIR=$(basename ${PWD})
 GIT_TAG=${SOURCE_GIT_TAG:-$(git describe --always --tags HEAD)}
 LD_FLAGS="-w -X github.com/openshift/console/pkg/version.Version=${GIT_TAG}"
 
-CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o bin/bridge github.com/openshift/console/cmd/bridge
+go build -ldflags "${LD_FLAGS}" -o bin/bridge github.com/openshift/console/cmd/bridge


### PR DESCRIPTION
This fix  changes the trigger of the help-card from click to hover(With click functionality still retained for touch screens; this issue still persists on touch screens). To avoid the issue seen in the picture below. On scroll the tool tip sticks to the viewport rather than scrolling with the parent component. This should suffice until patternfly fixes this issue.

![bugpic](https://user-images.githubusercontent.com/54092533/63014637-9f6ec580-beac-11e9-8223-934e1eef0a7e.png)
