### PR TITLE
Remove CGO_ENABLED=0 from backend builds

### DIFF
--- a/build-backend.sh
+++ b/build-backend.sh
@@ -10,4 +10,4 @@ PROJECT_DIR=$(basename ${PWD})
 GIT_TAG=${SOURCE_GIT_TAG:-$(git describe --always --tags HEAD)}
 LD_FLAGS="-w -X github.com/openshift/console/pkg/version.Version=${GIT_TAG}"
 
-CGO_ENABLED=0 go build -ldflags "${LD_FLAGS}" -o bin/bridge github.com/openshift/console/cmd/bridge
+go build -ldflags "${LD_FLAGS}" -o bin/bridge github.com/openshift/console/cmd/bridge


### PR DESCRIPTION
When building the backend `CGO_ENABLED=0` was passed to `go build`. This
is most likely a leftover from time when image was based on alpine. As
this is no longer the case, this commit removes it.

The context of this change is a try to enable kuryr-kubernetes as SDN
for OpenShift clusters. To do so, DNS resolvers of pods running on the
cluster should support `use-vc` option in resolv.conf. `CGO_ENABLED=0`
forces usage of golang's internal implementation of a resolver that
doesn't support that option until golang 1.13. Removing it will make
console use libc resolver, which is honoring the option.