### PR TITLE
Bug 1741147: Add units to top consumers cpu and storage results.

### DIFF
--- a/frontend/public/components/dashboard/top-consumers-card/consumers-filter.tsx
+++ b/frontend/public/components/dashboard/top-consumers-card/consumers-filter.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
 import { CPU_DESC, MEMORY_DESC, STORAGE_DESC, NETWORK_DESC } from './strings';
-import { humanizeNumber, humanizeBinaryBytesWithoutB, humanizeDecimalBytesPerSec, Humanize } from '../../utils';
+import { Humanize, humanizeBinaryBytesWithoutB, humanizeDecimalBytesPerSec, humanizeSeconds } from '../../utils';
 import { MetricType } from './metric-type';
 
 export const metricTypeMap: MetricTypeMap = {
   [MetricType.CPU]: {
     description: CPU_DESC,
-    humanize: humanizeNumber,
+    humanize: humanizeSeconds,
   },
   [MetricType.MEMORY]: {
     description: MEMORY_DESC,
@@ -15,7 +15,7 @@ export const metricTypeMap: MetricTypeMap = {
   },
   [MetricType.STORAGE]: {
     description: STORAGE_DESC,
-    humanize: humanizeNumber,
+    humanize: humanizeSeconds,
   },
   [MetricType.NETWORK]: {
     description: NETWORK_DESC,

--- a/frontend/public/components/dashboard/top-consumers-card/strings.js
+++ b/frontend/public/components/dashboard/top-consumers-card/strings.js
@@ -1,6 +1,6 @@
 export const CPU_DESC = 'CPU time';
 export const MEMORY_DESC = 'Memory consumption';
-export const STORAGE_DESC = 'Filesystem IO time';
+export const STORAGE_DESC = 'Average I/O time';
 export const NETWORK_DESC = 'Network consumption';
 
 export const PODS = 'Pods';

--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -39,6 +39,11 @@ const TYPES = {
     space: true,
     divisor: 1000,
   },
+  seconds: {
+    units: ['ns', 'μs', 'ms', 's'],
+    space: true,
+    divisor: 1000,
+  },
 };
 
 const getType = (name) => {
@@ -171,6 +176,7 @@ export const humanizeBinaryBytes = (v, initialUnit, preferredUnit) => humanize(v
 export const humanizeDecimalBytes = (v, initialUnit, preferredUnit) => humanize(v, 'decimalBytes', true, initialUnit, preferredUnit);
 export const humanizeDecimalBytesPerSec = (v, initialUnit, preferredUnit) => humanize(v, 'decimalBytesPerSec', true, initialUnit, preferredUnit);
 export const humanizeNumber = (v, initialUnit, preferredUnit) => humanize(v, 'numeric', true, initialUnit, preferredUnit);
+export const humanizeSeconds = (v, initialUnit, preferredUnit) => humanize(v, 'seconds', true, initialUnit, preferredUnit);
 export const humanizeCpuCores = v => {
   const value = v < 1 ? round(v*1000) : v;
   const unit = v < 1 ? 'm' : '';


### PR DESCRIPTION
Change storage description to 'by Average I/O time'

https://bugzilla.redhat.com/show_bug.cgi?id=1741147
https://bugzilla.redhat.com/show_bug.cgi?id=1741149