### PR TITLE
Bug 1741265: Prevent re-triggering the host operation

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/HostPowerStatusIcon.tsx
+++ b/frontend/packages/metal3-plugin/src/components/HostPowerStatusIcon.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { OnRunningIcon, OffIcon, InProgressIcon } from '@patternfly/react-icons';
+import { HOST_POWER_STATUS_POWERED_OFF, HOST_POWER_STATUS_POWERED_ON } from '../constants';
+
+type HostPowerStatusIconProps = {
+  powerStatus: string;
+};
+
+const HostPowerStatusIcon: React.FC<HostPowerStatusIconProps> = ({ powerStatus, ...iconProps }) => {
+  if (powerStatus === HOST_POWER_STATUS_POWERED_ON) return <OnRunningIcon {...iconProps} />;
+  if (powerStatus === HOST_POWER_STATUS_POWERED_OFF) return <OffIcon {...iconProps} />;
+  return <InProgressIcon {...iconProps} />;
+};
+
+export default HostPowerStatusIcon;

--- a/frontend/packages/metal3-plugin/src/components/host-detail.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host-detail.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { connect } from 'react-redux';
 import { Row, Col } from 'patternfly-react';
-import { OffIcon, OnRunningIcon } from '@patternfly/react-icons';
 import {
   referenceForModel,
   K8sResourceKind,
@@ -38,7 +37,7 @@ import {
   getHostRAMMiB,
   getHostTotalStorageCapacity,
   getHostMachineName,
-  isHostPoweredOn,
+  getHostPowerStatus,
   getHostVendorInfo,
   getHostMachine,
   findNodeMaintenance,
@@ -50,6 +49,7 @@ import BaremetalHostNICList from './host-nics';
 import BaremetalHostDiskList from './host-disks';
 import { HostDashboard } from './dashboard';
 import { menuActionsCreator } from './host-menu-actions';
+import HostPowerStatusIcon from './HostPowerStatusIcon';
 
 type BaremetalHostDetailPageProps = {
   namespace: string;
@@ -83,7 +83,7 @@ const BaremetalHostDetails: React.FC<BaremetalHostDetailsProps> = ({
   const RAMGB = humanizeDecimalBytes(getHostRAMMiB(host) * 2 ** 20).string;
   const totalStorageCapacity = humanizeDecimalBytes(getHostTotalStorageCapacity(host)).string;
   const description = getHostDescription(host);
-  const hostPoweredOn = isHostPoweredOn(host);
+  const powerStatus = getHostPowerStatus(host);
   const { count: CPUCount, model: CPUModel } = getHostCPU(host);
   const { manufacturer, productName, serialNumber } = getHostVendorInfo(host);
   const bios = getHostBios(host);
@@ -147,8 +147,8 @@ const BaremetalHostDetails: React.FC<BaremetalHostDetailsProps> = ({
             <dt>Power Status</dt>
             <dd>
               <StatusIconAndText
-                title={hostPoweredOn ? 'Running' : 'Powered Off'}
-                icon={hostPoweredOn ? <OnRunningIcon /> : <OffIcon />}
+                title={powerStatus}
+                icon={<HostPowerStatusIcon powerStatus={powerStatus} />}
               />
             </dd>
             {role && (

--- a/frontend/packages/metal3-plugin/src/components/host-menu-actions.tsx
+++ b/frontend/packages/metal3-plugin/src/components/host-menu-actions.tsx
@@ -14,10 +14,16 @@ import {
   findNodeMaintenance,
   getHostMachine,
   getNodeMaintenanceReason,
-  isHostPoweredOn,
+  getHostPowerStatus,
 } from '../selectors';
 import { BaremetalHostModel, NodeMaintenanceModel } from '../models';
 import { getHostStatus } from '../utils/host-status';
+import {
+  HOST_POWER_STATUS_POWERING_OFF,
+  HOST_POWER_STATUS_POWERED_ON,
+  HOST_POWER_STATUS_POWERING_ON,
+  HOST_POWER_STATUS_POWERED_OFF,
+} from '../constants';
 import { startNodeMaintenanceModal } from './modals/start-node-maintenance-modal';
 import { powerOffHostModal } from './modals/power-off-host-modal';
 
@@ -74,7 +80,9 @@ export const RemoveNodeMaintanance = (
 export const PowerOn = (kindObj: K8sKind, host: K8sResourceKind): KebabOption => {
   const title = 'Power on';
   return {
-    hidden: isHostPoweredOn(host),
+    hidden: [HOST_POWER_STATUS_POWERED_ON, HOST_POWER_STATUS_POWERING_ON].includes(
+      getHostPowerStatus(host),
+    ),
     label: title,
     callback: () => {
       k8sPatch(BaremetalHostModel, host, [{ op: 'replace', path: '/spec/online', value: true }]);
@@ -89,7 +97,9 @@ export const PowerOff = (
   resources: null,
   { hasNodeMaintenanceCapability, nodeName, status }: ActionArgs,
 ) => ({
-  hidden: !isHostPoweredOn(host),
+  hidden: [HOST_POWER_STATUS_POWERED_OFF, HOST_POWER_STATUS_POWERING_OFF].includes(
+    getHostPowerStatus(host),
+  ),
   label: 'Shut down',
   callback: () => powerOffHostModal({ hasNodeMaintenanceCapability, host, nodeName, status }),
   accessReview: host && asAccessReview(BaremetalHostModel, host, 'update'),

--- a/frontend/packages/metal3-plugin/src/constants.ts
+++ b/frontend/packages/metal3-plugin/src/constants.ts
@@ -20,6 +20,11 @@ export const HOST_STATUS_REGISTRATION_ERROR = 'registration error';
 export const HOST_STATUS_PROVISIONING_ERROR = 'provisioning error';
 export const HOST_STATUS_POWER_MANAGEMENT_ERROR = 'power management error';
 
+export const HOST_POWER_STATUS_POWERED_ON = 'Running';
+export const HOST_POWER_STATUS_POWERED_OFF = 'Powered off';
+export const HOST_POWER_STATUS_POWERING_OFF = 'Shutting down';
+export const HOST_POWER_STATUS_POWERING_ON = 'Powering on';
+
 export const HOST_STATUS_TITLES = {
   [HOST_STATUS_READY]: 'Ready',
   [HOST_STATUS_DISCOVERED]: 'Discovered',

--- a/frontend/packages/metal3-plugin/src/selectors/index.ts
+++ b/frontend/packages/metal3-plugin/src/selectors/index.ts
@@ -2,6 +2,12 @@ import * as _ from 'lodash';
 import { K8sResourceKind, MachineKind } from '@console/internal/module/k8s';
 import { getName } from '@console/shared/src/selectors';
 import { BaremetalHostDisk } from '../types';
+import {
+  HOST_POWER_STATUS_POWERED_ON,
+  HOST_POWER_STATUS_POWERING_OFF,
+  HOST_POWER_STATUS_POWERING_ON,
+  HOST_POWER_STATUS_POWERED_OFF,
+} from '../constants';
 
 export * from './node-maintanance';
 
@@ -11,14 +17,23 @@ export const getHostProvisioningState = (host: K8sResourceKind) =>
   _.get(host, 'status.provisioning.state');
 export const getHostMachineName = (host: K8sResourceKind) => _.get(host, 'spec.consumerRef.name');
 export const getHostBMCAddress = (host: K8sResourceKind) => _.get(host, 'spec.bmc.address');
-export const isHostOnline = (host: K8sResourceKind) => _.get(host, 'spec.online', false);
+export const isHostOnline = (host: K8sResourceKind): boolean => _.get(host, 'spec.online', false);
 export const getHostNICs = (host: K8sResourceKind) => _.get(host, 'status.hardware.nics', []);
 export const getHostStorage = (host: K8sResourceKind) => _.get(host, 'status.hardware.storage', []);
 export const getHostCPU = (host: K8sResourceKind) => _.get(host, 'status.hardware.cpu', {});
 export const getHostRAMMiB = (host: K8sResourceKind) => _.get(host, 'status.hardware.ramMebibytes');
 export const getHostErrorMessage = (host: K8sResourceKind) => _.get(host, 'status.errorMessage');
 export const getHostDescription = (host: K8sResourceKind) => _.get(host, 'spec.description', '');
-export const isHostPoweredOn = (host: K8sResourceKind) => _.get(host, 'status.poweredOn', false);
+export const isHostPoweredOn = (host: K8sResourceKind): boolean =>
+  _.get(host, 'status.poweredOn', false);
+export const getHostPowerStatus = (host: K8sResourceKind) => {
+  const isOnline = isHostOnline(host);
+  const isPoweredOn = isHostPoweredOn(host);
+  if (isOnline && isPoweredOn) return HOST_POWER_STATUS_POWERED_ON;
+  if (!isOnline && isPoweredOn) return HOST_POWER_STATUS_POWERING_OFF;
+  if (isOnline && !isPoweredOn) return HOST_POWER_STATUS_POWERING_ON;
+  return HOST_POWER_STATUS_POWERED_OFF;
+};
 export const getHostVendorInfo = (host: K8sResourceKind) =>
   _.get(host, 'status.hardware.systemVendor', {});
 export const getHostTotalStorageCapacity = (host: K8sResourceKind) =>


### PR DESCRIPTION
Power status is now calculated using combination of the trigger
(host.spec.online) and the result (host.status.poweredOn). This allows
to introduce power transition states and ability to prevent re-triggering
the power operation

https://bugzilla.redhat.com/show_bug.cgi?id=1741265