### PR TITLE
Bug 1741144: Update styles for dashboard cards

### DIFF
--- a/frontend/__tests__/components/graphs/graph-empty.spec.tsx
+++ b/frontend/__tests__/components/graphs/graph-empty.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { ChartAreaIcon, ChartBarIcon } from '@patternfly/react-icons';
-import { EmptyState, EmptyStateIcon } from '@patternfly/react-core';
+import { EmptyState, Title } from '@patternfly/react-core';
 
 import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import { LoadingBox } from '@console/internal/components/utils';
@@ -14,12 +13,7 @@ describe('<GraphEmpty />', () => {
 
   it('should render an empty state', () => {
     const wrapper = shallow(<GraphEmpty />);
-    let icon = wrapper.find(EmptyStateIcon);
     expect(wrapper.find(EmptyState).exists()).toBe(true);
-    expect(icon.exists()).toBe(true);
-    expect(icon.props().icon).toBe(ChartAreaIcon);
-    wrapper.setProps({icon: ChartBarIcon});
-    icon = wrapper.find(EmptyStateIcon);
-    expect(icon.props().icon).toBe(ChartBarIcon);
+    expect(wrapper.find(Title).exists()).toBe(true);
   });
 });

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/data-resiliency/data-resiliency.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/data-resiliency/data-resiliency.scss
@@ -8,12 +8,6 @@
   text-align: center;
 }
 
-.ceph-data-resiliency__icon-error {
-  color: $pf-color-black-600;
-  font-size: 5rem;
-  margin-top: 1.6rem;
-}
-
 .ceph-data-resiliency__icon-ok {
   font-size: 60px;
 }

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/data-resiliency/data-resiliency.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/data-resiliency/data-resiliency.tsx
@@ -11,7 +11,7 @@ import {
   DashboardItemProps,
   withDashboardResources,
 } from '@console/internal/components/dashboards-page/with-dashboard-resources';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import { DATA_RESILIENCY_QUERIES } from '../../../../constants/queries';
 import './data-resiliency.scss';
 
@@ -28,12 +28,7 @@ const DataResiliencyStatusBody: React.FC<DataResiliencyStatusBody> = ({ error })
       </div>
     </>
   ) : (
-    <>
-      <div className="ceph-data-resiliency__icon-error">
-        <ExclamationTriangleIcon />
-      </div>
-      <div>Not available</div>
-    </>
+    <GraphEmpty height="100%" />
   );
 
 const DataResiliencyBuildBody: React.FC<DataResiliencyBuildBody> = ({ progressPercentage }) => (

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/inventory-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/inventory-card.tsx
@@ -21,6 +21,7 @@ import {
   PersistentVolumeModel,
   StorageClassModel,
 } from '@console/internal/models';
+import { InventoryBody } from '@console/internal/components/dashboard/inventory-card/inventory-body';
 import { ResourceInventoryItem } from '@console/internal/components/dashboard/inventory-card/inventory-item';
 import { getCephNodes, getCephPVs, getCephPVCs, getCephSC } from '../../../selectors';
 
@@ -81,32 +82,34 @@ const InventoryCard: React.FC<DashboardItemProps> = ({
         <DashboardCardTitle>Inventory</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
-        <ResourceInventoryItem
-          isLoading={!nodesLoaded}
-          error={!!nodesLoadError}
-          kind={NodeModel}
-          resources={getCephNodes(nodesData)}
-          mapper={getNodeStatusGroups}
-          showLink={false}
-        />
-        <ResourceInventoryItem
-          isLoading={!pvcsLoaded}
-          error={!!pvcsLoadError}
-          kind={PersistentVolumeClaimModel}
-          useAbbr
-          resources={getCephPVCs(filteredSCNames, pvcsData)}
-          mapper={getPVCStatusGroups}
-          showLink={false}
-        />
-        <ResourceInventoryItem
-          isLoading={!pvsLoaded}
-          error={!!pvsLoadError}
-          kind={PersistentVolumeModel}
-          useAbbr
-          resources={getCephPVs(pvsData)}
-          mapper={getPVStatusGroups}
-          showLink={false}
-        />
+        <InventoryBody>
+          <ResourceInventoryItem
+            isLoading={!nodesLoaded}
+            error={!!nodesLoadError}
+            kind={NodeModel}
+            resources={getCephNodes(nodesData)}
+            mapper={getNodeStatusGroups}
+            showLink={false}
+          />
+          <ResourceInventoryItem
+            isLoading={!pvcsLoaded}
+            error={!!pvcsLoadError}
+            kind={PersistentVolumeClaimModel}
+            useAbbr
+            resources={getCephPVCs(filteredSCNames, pvcsData)}
+            mapper={getPVCStatusGroups}
+            showLink={false}
+          />
+          <ResourceInventoryItem
+            isLoading={!pvsLoaded}
+            error={!!pvsLoadError}
+            kind={PersistentVolumeModel}
+            useAbbr
+            resources={getCephPVs(pvsData)}
+            mapper={getPVStatusGroups}
+            showLink={false}
+          />
+        </InventoryBody>
       </DashboardCardBody>
     </DashboardCard>
   );

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/top-consumers-card/top-consumers-card-body.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/top-consumers-card/top-consumers-card-body.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { ChartLineIcon } from '@patternfly/react-icons';
 import {
   Chart,
   ChartAxis,
@@ -96,7 +95,7 @@ export const TopConsumersBody: React.FC<TopConsumerBodyProps> = React.memo(
         </>
       );
     }
-    return <GraphEmpty icon={ChartLineIcon} />;
+    return <GraphEmpty />;
   },
 );
 

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/top-consumers-card/top-consumers-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/top-consumers-card/top-consumers-card.tsx
@@ -82,7 +82,7 @@ const TopConsumerCard: React.FC<DashboardItemProps> = ({
           />
         </div>
       </DashboardCardHeader>
-      <DashboardCardBody>
+      <DashboardCardBody className="co-dashboard-card__body--top-margin">
         <TopConsumersBody
           topConsumerStats={topConsumerStats}
           metricType={TopConsumerResourceValueMapping[metricType]}

--- a/frontend/packages/metal3-plugin/src/components/dashboard/inventory-card.tsx
+++ b/frontend/packages/metal3-plugin/src/components/dashboard/inventory-card.tsx
@@ -8,6 +8,7 @@ import { DashboardCard } from '@console/internal/components/dashboard/dashboard-
 import { DashboardCardBody } from '@console/internal/components/dashboard/dashboard-card/card-body';
 import { DashboardCardHeader } from '@console/internal/components/dashboard/dashboard-card/card-header';
 import { DashboardCardTitle } from '@console/internal/components/dashboard/dashboard-card/card-title';
+import { InventoryBody } from '@console/internal/components/dashboard/inventory-card/inventory-body';
 import { InventoryItem } from '@console/internal/components/dashboard/inventory-card/inventory-item';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { FirehoseResource } from '@console/internal/components/utils';
@@ -73,13 +74,15 @@ const InventoryCard: React.FC<InventoryCardProps> = ({
         <DashboardCardTitle>Inventory</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
-        <InventoryItem
-          isLoading={!podResult}
-          singularTitle="Pod"
-          pluralTitle="Pods"
-          count={podCount}
-          error={podError || !podStats.length}
-        />
+        <InventoryBody>
+          <InventoryItem
+            isLoading={!podResult}
+            singularTitle="Pod"
+            pluralTitle="Pods"
+            count={podCount}
+            error={podError || !podStats.length}
+          />
+        </InventoryBody>
       </DashboardCardBody>
     </DashboardCard>
   );

--- a/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card-item.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card-item.tsx
@@ -11,11 +11,11 @@ const formatCount = (count: number) => {
 const BucketsRowStatus: React.FC<BucketsRowStatusProps> = React.memo(({ status, link }) => (
   <div className="nb-buckets-card__row-status-item">
     {_.isNil(status) ? (
-      <span className="nb-buckets-card__row-subtitle">Unavailable</span>
+      <span className="co-dashboard-text--small nb-buckets-card__row-subtitle">Unavailable</span>
     ) : Number(status) > 0 ? (
       <React.Fragment>
         <a href={link} style={{ textDecoration: 'none' }}>
-          <RedExclamationCircleIcon className="nb-bucket-card__status-icon" />
+          <RedExclamationCircleIcon className="co-dashboard-icon nb-bucket-card__status-icon" />
           <span className="nb-buckets-card__row-status-item-text">{status}</span>
         </a>
       </React.Fragment>
@@ -29,7 +29,7 @@ const BucketsRow: React.FC<BucketsRowProps> = React.memo(
     return (
       <div className="nb-buckets-card__row-title">
         <div>{_.isNil(bucketsCount) ? title : pluralize(Number(bucketsCount), title)}</div>
-        <div className="nb-buckets-card__row-subtitle">{subtitle}</div>
+        <div className="co-dashboard-text--small nb-buckets-card__row-subtitle">{subtitle}</div>
       </div>
     );
   },
@@ -40,7 +40,7 @@ export const BucketsItem: React.FC<BucketsItemProps> = React.memo(
     isLoading ? (
       <LoadingInline />
     ) : (
-      <div className="nb-buckets-card__row">
+      <div className="co-inventory-card__item">
         <BucketsRow title={title} bucketsCount={bucketsCount} objectsCount={objectsCount} />
         <BucketsRowStatus status={unhealthyCount} link={link} />
       </div>

--- a/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card.scss
+++ b/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card.scss
@@ -1,13 +1,5 @@
 @import '~@patternfly/patternfly/sass-utilities/colors';
 
-.nb-buckets-card__row {
-  border-bottom: 1px solid $pf-color-black-300;
-  display: flex;
-  font-size: 1rem;
-  justify-content: space-between;
-  padding: 1em 0;
-}
-
 .nb-buckets-card__row-status {
   align-items: center;
   display: flex;
@@ -33,7 +25,6 @@
 
 .nb-buckets-card__row-subtitle {
   color: $pf-color-black-500;
-  font-size: 0.875rem;
 }
 
 .nb-buckets-card__row-title {

--- a/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card.tsx
@@ -89,8 +89,10 @@ const ObjectDashboardBucketsCard: React.FC<DashboardItemProps> = ({
         <DashboardCardTitle>Buckets</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
-        <BucketsItem title="ObjectBucket" {...bucketProps} link={link} />
-        <BucketsItem title="ObjectBucketClaim" {...bucketClaimProps} link={link} />
+        <div className="co-dashboard-card__body--no-padding">
+          <BucketsItem title="ObjectBucket" {...bucketProps} link={link} />
+          <BucketsItem title="ObjectBucketClaim" {...bucketClaimProps} link={link} />
+        </div>
       </DashboardCardBody>
     </DashboardCard>
   );

--- a/frontend/packages/noobaa-storage-plugin/src/components/capacity-card/capacity-card-body.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/capacity-card/capacity-card-body.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { ChartDonut, ChartThemeVariant, ChartThemeColor } from '@patternfly/react-charts';
-import { ChartPieIcon } from '@patternfly/react-icons';
 import { DataPoint } from '@console/internal/components/graphs';
 import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import {
@@ -8,7 +7,7 @@ import {
   humanizePercentage,
   humanizeBinaryBytes,
 } from '@console/internal/components/utils';
-import './capacity-card-body.scss';
+import './capacity-card.scss';
 
 type LegendDataType = {
   name: string;
@@ -50,11 +49,11 @@ export const CapacityCardBody: React.FC<CapacityCardBodyProps> = ({
   }
   const { metricData, metricLegend } = getLegendAndChartData(metricsData, totalUsage);
   if (!metricData.length) {
-    return <GraphEmpty icon={ChartPieIcon} />;
+    return <GraphEmpty />;
   }
   const totalHumanized = humanizeBinaryBytes(totalUsage, null, totalUsage ? null : 'MiB');
   return (
-    <div className="nb-capacity-card__chart-body">
+    <div className="nb-capacity-card__body-chart">
       <div className="noobaa-capacity-card__item">
         <ChartDonut
           width={275}

--- a/frontend/packages/noobaa-storage-plugin/src/components/capacity-card/capacity-card.scss
+++ b/frontend/packages/noobaa-storage-plugin/src/components/capacity-card/capacity-card.scss
@@ -1,4 +1,4 @@
-.nb-capacity-card__chart-body {
+.nb-capacity-card__body-chart {
   display: flex;
   flex-direction: column;
 }

--- a/frontend/packages/noobaa-storage-plugin/src/components/capacity-card/capacity-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/capacity-card/capacity-card.tsx
@@ -15,6 +15,8 @@ import { getInstantVectorStats } from '@console/internal/components/graphs/utils
 import { ObjectDashboardQuery, ObjectCapacityQueries } from '../../queries';
 import { CapacityCardBody } from './capacity-card-body';
 
+import './capacity-card.scss';
+
 const CapacityDropdownType = {
   [ObjectDashboardQuery.CAPACITY_USAGE_PROJECT_QUERY]: 'Projects',
   [ObjectDashboardQuery.CAPACITY_USAGE_BUCKET_CLASS_QUERY]: 'Bucket Class',
@@ -70,13 +72,12 @@ const ObjectDashboardCapacityCard: React.FC<DashboardItemProps> = ({
       <DashboardCardHeader>
         <DashboardCardTitle>Capacity Breakdown</DashboardCardTitle>
         <Dropdown
-          className="nb-capacity-card__dropdown-item"
           items={CapacityDropdownType}
           onChange={setCapacityUsageType}
           selectedKey={[capacityUsageType]}
         />
       </DashboardCardHeader>
-      <DashboardCardBody>
+      <DashboardCardBody className="co-dashboard-card__body--top-margin">
         <CapacityCardBody
           isLoading={!capacityUsageTop6AndOthers || !capacityUsageTotalResult}
           metricsData={capacityUsageVectorStats}

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.tsx
@@ -8,7 +8,6 @@ import {
   ChartLegend,
   ChartThemeColor,
 } from '@patternfly/react-charts';
-import { ChartBarIcon } from '@patternfly/react-icons';
 import {
   DashboardCard,
   DashboardCardBody,
@@ -127,7 +126,10 @@ const DataConsumptionCard: React.FC<DashboardItemProps> = ({
           setKpi={setsortByKpi}
         />
       </DashboardCardHeader>
-      <DashboardCardBody isLoading={!dataConsumptionQueryResult}>
+      <DashboardCardBody
+        className="co-dashboard-card__body--top-margin"
+        isLoading={!dataConsumptionQueryResult}
+      >
         {chartData.length > 0 ? (
           <div>
             <Chart
@@ -162,7 +164,7 @@ const DataConsumptionCard: React.FC<DashboardItemProps> = ({
             />
           </div>
         ) : (
-          <GraphEmpty icon={ChartBarIcon} />
+          <GraphEmpty />
         )}
       </DashboardCardBody>
     </DashboardCard>

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-resiliency-card/data-resiliency-card.scss
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-resiliency-card/data-resiliency-card.scss
@@ -12,11 +12,6 @@
   align-self: flex-start;
 }
 
-.nb-data-resiliency__icon--error {
-  color: $pf-color-black-600;
-  font-size: 5rem;
-}
-
 .nb-data-resiliency__icon--ok {
   font-size: 60px;
 }

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-resiliency-card/data-resiliency-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-resiliency-card/data-resiliency-card.tsx
@@ -13,7 +13,7 @@ import {
   DashboardItemProps,
   withDashboardResources,
 } from '@console/internal/components/dashboards-page/with-dashboard-resources';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import { DATA_RESILIENCE_QUERIES } from '../../queries';
 import { getPropsData } from '../../utils';
 import './data-resiliency-card.scss';
@@ -37,12 +37,7 @@ const DataResiliencyStatusBody: React.FC<DataResiliencyStatusBody> = ({ isResili
       </div>
     </>
   ) : (
-    <>
-      <div className="nb-data-resiliency__icon--error">
-        <ExclamationTriangleIcon />
-      </div>
-      <div>Not available</div>
-    </>
+    <GraphEmpty height="100%" />
   );
 
 const DataResiliencyBuildBody: React.FC<DataResiliencyBuildBody> = React.memo(

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card-item.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card-item.tsx
@@ -8,7 +8,7 @@ import {
 } from '@console/internal/components/utils';
 
 const ItemBody: React.FC<ItemBodyProps> = React.memo(({ title, children }) => (
-  <div className="nb-object-data-reduction-card__row">
+  <div className="co-inventory-card__item">
     <div className="nb-object-data-reduction-card__row-title">{title}</div>
     {children}
   </div>
@@ -16,7 +16,11 @@ const ItemBody: React.FC<ItemBodyProps> = React.memo(({ title, children }) => (
 
 export const EfficiencyItem: React.FC<EfficiencyItemProps> = React.memo(
   ({ efficiency, isLoading }) => {
-    let text = <span className="nb-object-data-reduction-card__row-subtitle">Unavailable</span>;
+    let text = (
+      <span className="co-dashboard-text--small nb-object-data-reduction-card__row-subtitle">
+        Unavailable
+      </span>
+    );
     const infoText =
       'Efficiency ratio refers to the deduplication and compression process effectiveness.';
 
@@ -42,7 +46,11 @@ export const EfficiencyItem: React.FC<EfficiencyItemProps> = React.memo(
 
 export const SavingsItem: React.FC<SavingsItemProps> = React.memo(
   ({ savings, logicalSize, isLoading }) => {
-    let text = <span className="nb-object-data-reduction-card__row-subtitle">Unavailable</span>;
+    let text = (
+      <span className="co-dashboard-text--small nb-object-data-reduction-card__row-subtitle">
+        Unavailable
+      </span>
+    );
     const infoText =
       'Savings shows the uncompressed and non-deduped data that would have been stored without those techniques';
 

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card.scss
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card.scss
@@ -1,14 +1,5 @@
 @import '~@patternfly/patternfly/sass-utilities/colors';
 
-.nb-object-data-reduction-card__row {
-  align-items: center;
-  border-bottom: 1px solid $pf-color-black-300;
-  display: flex;
-  font-size: 1rem;
-  justify-content: space-between;
-  padding: 1em 0;
-}
-
 .nb-object-data-reduction-card__row-status {
   align-items: center;
   display: flex;
@@ -30,7 +21,6 @@
 
 .nb-object-data-reduction-card__row-subtitle {
   color: $pf-color-black-500;
-  font-size: 0.875rem;
 }
 
 .nb-object-data-reduction-card__row-title {

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card.tsx
@@ -63,8 +63,10 @@ const DataReductionCard: React.FC<DashboardItemProps> = ({
         <DashboardCardTitle>Object Data Reduction</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
-        <EfficiencyItem {...efficiencyProps} />
-        <SavingsItem {...savingsProps} />
+        <div className="co-dashboard-card__body--no-padding">
+          <EfficiencyItem {...efficiencyProps} />
+          <SavingsItem {...savingsProps} />
+        </div>
       </DashboardCardBody>
     </DashboardCard>
   );

--- a/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card-body.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card-body.tsx
@@ -6,13 +6,16 @@ export const ResourceProvidersBody: React.FC<ResourceProvidersBodyProps> = ({
   hasProviders,
   children,
 }) => {
+  let body;
   if (isLoading) {
-    return <LoadingInline />;
+    body = <LoadingInline />;
   }
   if (!hasProviders) {
-    return <div className="text-secondary">Unavailable</div>;
+    body = (
+      <div className="nb-resource-providers-card__not-available text-secondary">Unavailable</div>
+    );
   }
-  return <div>{children}</div>;
+  return <div className="co-dashboard-card__body--no-padding">{body || children}</div>;
 };
 
 type ResourceProvidersBodyProps = {

--- a/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card-item.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card-item.tsx
@@ -7,7 +7,7 @@ const ResourceProvidersItemStatus: React.FC<ResourceProvidersRowStatusProps> = R
     <div className="nb-resource-providers-card__row-status">
       <div className="nb-resource-providers-card__row-status-item">
         <a href={link} style={{ textDecoration: 'none' }}>
-          <RedExclamationCircleIcon className="nb-resource-provider-card__status-icon" />
+          <RedExclamationCircleIcon className="co-dashboard-icon nb-resource-providers-card__status-icon" />
           <span className="nb-resource-providers-card__row-status-item-text">{status}</span>
         </a>
       </div>
@@ -17,7 +17,7 @@ const ResourceProvidersItemStatus: React.FC<ResourceProvidersRowStatusProps> = R
 
 export const ResourceProvidersItem: React.FC<ResourceProvidersRowProps> = React.memo(
   ({ title, count, unhealthyProviders, link }) => (
-    <div className="nb-resource-providers-card__row">
+    <div className="co-inventory-card__item">
       <div className="nb-resource-providers-card__row-title">{`${count} ${title}`}</div>
       {!_.isNil(unhealthyProviders[title]) && unhealthyProviders[title] > 0 ? (
         <ResourceProvidersItemStatus status={unhealthyProviders[title]} link={link} />

--- a/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card.scss
+++ b/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card.scss
@@ -1,12 +1,10 @@
 @import '~@patternfly/patternfly/sass-utilities/colors';
 
-.nb-resource-providers-card__row {
-  align-items: center;
-  border-bottom: 1px solid $pf-color-black-300;
+.nb-resource-providers-card__not-available {
   display: flex;
-  font-size: 1rem;
-  justify-content: space-between;
-  padding: 1em 0;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
 }
 
 .nb-resource-providers-card__row-status {
@@ -16,10 +14,6 @@
   :last-child {
     margin-right: 0;
   }
-}
-
-.nb-resource-provider-card__status-icon {
-  color: $pf-color-black-700;
 }
 
 .nb-resource-providers-card__row-status-item {
@@ -36,4 +30,8 @@
 
 .nb-resource-providers-card__row-title {
   margin-right: 0.5em;
+}
+
+.nb-resource-providers-card__status-icon {
+  color: $pf-color-black-700;
 }

--- a/frontend/public/components/dashboard/capacity-card/capacity-card.scss
+++ b/frontend/public/components/dashboard/capacity-card/capacity-card.scss
@@ -9,11 +9,15 @@
   flex: 0 1 120px;
   flex-direction: column;
   justify-content: space-between;
+  margin-top: 1.5em;
   text-align: center;
 }
 
+.co-capacity-card__item-chart {
+  margin-bottom: 0;
+}
+
 .co-capacity-card__item-description {
-  font-size: 0.875rem;
   font-weight: normal;
   line-height: 1.5;
   margin-bottom: 0;

--- a/frontend/public/components/dashboard/capacity-card/capacity-item.tsx
+++ b/frontend/public/components/dashboard/capacity-card/capacity-item.tsx
@@ -18,16 +18,17 @@ export const CapacityItem: React.FC<CapacityItemProps> = React.memo(({ title, us
   };
   const description = error ? NOT_AVAILABLE : (
     <>
-      <span className="co-capacity-card__item-description-value">{available.string}</span>
+      <span className="co-dashboard-text--small co-capacity-card__item-description-value">{available.string}</span>
       {' available out of '}
-      <span className="co-capacity-card__item-description-value">{totalFormatted.string}</span>
+      <span className="co-dashboard-text--small co-capacity-card__item-description-value">{totalFormatted.string}</span>
     </>
   );
   return (
     <div className="co-capacity-card__item">
       <div className="co-capacity-card__item-title">{title}</div>
-      <h6 className="co-capacity-card__item-description">{isLoading ? <LoadingInline /> : description}</h6>
+      <h6 className="co-dashboard-text--small co-capacity-card__item-description">{isLoading ? <LoadingInline /> : description}</h6>
       <GaugeChart
+        className="co-capacity-card__item-chart"
         data={data}
         label={`${percentageUsed.toString()}%`}
         loading={isLoading}

--- a/frontend/public/components/dashboard/dashboard-card/card-help.tsx
+++ b/frontend/public/components/dashboard/dashboard-card/card-help.tsx
@@ -10,7 +10,7 @@ export const DashboardCardHelp: React.FC<DashboardCardTitleHelpProps> = React.me
   return (
     <OverlayTrigger overlay={overlay} placement="top" trigger={['click']} rootClose>
       <Button bsStyle="link">
-        <InfoCircleIcon className="co-dashboard-header__icon" />
+        <InfoCircleIcon className="co-dashboard-icon co-dashboard-header__icon" />
       </Button>
     </OverlayTrigger>
   );

--- a/frontend/public/components/dashboard/dashboard-card/card.scss
+++ b/frontend/public/components/dashboard/dashboard-card/card.scss
@@ -2,8 +2,14 @@
   margin: 0;
 }
 
-.co-dashboard-card__body {
-  margin-top: 1.5em;
+.co-dashboard-card__body--no-padding {
+  margin-bottom: calc(-1 * var(--pf-c-card--child--PaddingBottom));
+  margin-left: calc(-1 * var(--pf-c-card--child--PaddingLeft));
+  margin-right: calc(-1 * var(--pf-c-card--child--PaddingRight));
+}
+
+.co-dashboard-card__body--top-margin {
+  margin-top: 1.5rem;
 }
 
 .co-dashboard-card__button-link {
@@ -30,6 +36,14 @@
 }
 
 .co-dashboard-header__icon {
-  font-size: 1.125rem;
   margin-right: -10px;
+}
+
+.co-dashboard-icon {
+  font-size: 1.2rem;
+  margin-top: 0.2rem;
+}
+
+.co-dashboard-text--small {
+  font-size: 0.875rem;
 }

--- a/frontend/public/components/dashboard/details-card/details-body.tsx
+++ b/frontend/public/components/dashboard/details-card/details-body.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export const DetailsBody: React.FC<DetailsBodyProps> = ({ children }) => (
-  <dl className="co-details-card__body">{children}</dl>
+  <dl className="co-dashboard-card__body--top-margin co-details-card__body co-dashboard-text--small">{children}</dl>
 );
 
 type DetailsBodyProps = {

--- a/frontend/public/components/dashboard/details-card/details-card.scss
+++ b/frontend/public/components/dashboard/details-card/details-card.scss
@@ -5,12 +5,10 @@
 
 .co-details-card__item-title {
   flex-basis: 100%;
-  font-size: 0.875rem;
   text-transform: capitalize;
 }
 
 .co-details-card__item-value {
   flex-basis: 100%;
-  font-size: 0.875rem;
   margin-bottom: 8px;
 }

--- a/frontend/public/components/dashboard/events-card/event-item.tsx
+++ b/frontend/public/components/dashboard/events-card/event-item.tsx
@@ -23,7 +23,7 @@ export const EventItem: React.FC<EventComponentProps> = React.memo(({ event }) =
           title={obj.uid}
         />
       </div>
-      <div className="co-events-card__item-message text-secondary">
+      <div className="co-dashboard-text--small co-events-card__item-message text-secondary">
         {message}
       </div>
     </div>

--- a/frontend/public/components/dashboard/events-card/events-body.tsx
+++ b/frontend/public/components/dashboard/events-card/events-body.tsx
@@ -23,7 +23,7 @@ export const EventsBody: React.FC<EventsBodyProps> = ({ events, filter }) => {
     );
   }
   return (
-    <div className="co-events-card__body" id="events-body">
+    <div className="co-dashboard-card__body--no-padding co-events-card__body" id="events-body">
       <div className="co-events-card__body-stream">
         {eventsBody}
       </div>

--- a/frontend/public/components/dashboard/events-card/events-card.scss
+++ b/frontend/public/components/dashboard/events-card/events-card.scss
@@ -1,5 +1,4 @@
 .co-events-card__body {
-  margin: -1.5em;
   max-height: 30em;
   min-height: 10em;
   overflow-x: hidden;
@@ -27,7 +26,6 @@
 }
 
 .co-events-card__item-message {
-  font-size: 0.875rem;
   margin-top: 0.5em;
   @include co-line-clamp(5);
 }

--- a/frontend/public/components/dashboard/health-card/alert-item.tsx
+++ b/frontend/public/components/dashboard/health-card/alert-item.tsx
@@ -14,7 +14,7 @@ const getSeverityIcon = (severity: string) => {
     default:
       icon = <YellowExclamationTriangleIcon />;
   }
-  return <div className="co-health-card__alerts-icon">{icon}</div>;
+  return <div className="co-dashboard-icon co-health-card__icon">{icon}</div>;
 };
 
 export const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {

--- a/frontend/public/components/dashboard/health-card/alerts-body.tsx
+++ b/frontend/public/components/dashboard/health-card/alerts-body.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export const AlertsBody: React.FC<AlertsBodyProps> = ({ children }) => (
-  <div className="co-health-card__alerts-body">{children}</div>
+  <div className="co-dashboard-card__body--no-padding co-health-card__alerts-body">{children}</div>
 );
 
 type AlertsBodyProps = {

--- a/frontend/public/components/dashboard/health-card/health-body.tsx
+++ b/frontend/public/components/dashboard/health-card/health-body.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 export const HealthBody: React.FC<HealthBodyProps> = React.memo(({ children, className }) => (
-  <div className={classNames('co-health-card__body', className)}>{children}</div>
+  <div className={classNames('co-dashboard-card__body--top-margin co-health-card__body', className)}>{children}</div>
 ));
 
 type HealthBodyProps = {

--- a/frontend/public/components/dashboard/health-card/health-card.scss
+++ b/frontend/public/components/dashboard/health-card/health-card.scss
@@ -8,24 +8,24 @@
   border-top: 1px solid $pf-color-black-300;
 }
 
-.co-health-card__alerts-icon {
-  font-size: 1.2rem;
-  margin-right: 1rem;
-  margin-top: 0.2rem;
-}
-
 .co-health-card__alerts-item {
   align-items: center;
   display: flex;
-  margin-bottom: 0.5em;
+  padding-bottom: 0.5em;
+  padding-left: var(--pf-c-card--child--PaddingLeft);
+  padding-right: var(--pf-c-card--child--PaddingRight);
+}
+
+.co-health-card__alerts-item:first-of-type {
+  padding-top: var(--pf-c-card--first-child--PaddingTop);
+}
+
+.co-health-card__alerts-item:last-of-type {
+  padding-bottom: var(--pf-c-card--child--PaddingBottom);
 }
 
 .co-health-card__body {
   min-height: 2.3em;
-}
-
-.co-health-card__icon {
-  font-size: 1.5rem;
 }
 
 .co-health-card__item {
@@ -45,7 +45,6 @@
 
 .co-health-card__text {
   display: block;
-  font-size: 0.875rem;
   margin-left: 1rem;
 }
 

--- a/frontend/public/components/dashboard/health-card/health-item.tsx
+++ b/frontend/public/components/dashboard/health-card/health-item.tsx
@@ -22,7 +22,7 @@ const HealthItemIcon: React.FC<HealthItemIconProps> = ({ state }) => {
     default:
       icon = <YellowExclamationTriangleIcon />;
   }
-  return <div className="co-health-card__icon">{icon}</div>;
+  return <div className="co-dashboard-icon">{icon}</div>;
 };
 
 export const HealthItem: React.FC<HealthItemProps> = React.memo(
@@ -30,8 +30,8 @@ export const HealthItem: React.FC<HealthItemProps> = React.memo(
     <div className={classNames('co-health-card__item', className)}>
       {state === HealthState.LOADING ? <LoadingInline /> : <HealthItemIcon state={state} />}
       <div>
-        {message && <span className="co-health-card__text">{message}</span>}
-        {details && <div className="co-health-card__text co-health-card__subtitle">{details}</div>}
+        {message && <span className="co-dashboard-text--small co-health-card__text">{message}</span>}
+        {details && <div className="co-dashboard-text--small co-health-card__text co-health-card__subtitle">{details}</div>}
       </div>
     </div>
   ),

--- a/frontend/public/components/dashboard/inventory-card/inventory-body.tsx
+++ b/frontend/public/components/dashboard/inventory-card/inventory-body.tsx
@@ -1,0 +1,3 @@
+import * as React from 'react';
+
+export const InventoryBody = ({ children }) => <div className="co-dashboard-card__body--no-padding">{children}</div>;

--- a/frontend/public/components/dashboard/inventory-card/inventory-card.scss
+++ b/frontend/public/components/dashboard/inventory-card/inventory-card.scss
@@ -4,7 +4,7 @@
   display: flex;
   font-size: 1rem;
   justify-content: space-between;
-  padding: 1em 0;
+  padding: 1em var(--pf-c-card--child--PaddingRight) 1em var(--pf-c-card--child--PaddingLeft);
 }
 
 .co-inventory-card__item-status {
@@ -26,10 +26,6 @@
   display: flex;
   flex-shrink: 0;
   margin-right: 0.5em;
-}
-
-.co-inventory-card__status-icon {
-  font-size: 1.125rem;
 }
 
 .co-inventory-card__status-icon--question {

--- a/frontend/public/components/dashboard/inventory-card/inventory-item.tsx
+++ b/frontend/public/components/dashboard/inventory-card/inventory-item.tsx
@@ -49,7 +49,7 @@ export const InventoryItem: React.FC<InventoryItemProps> = React.memo(
     const title = count !== 1 ? pluralTitle : singularTitle;
     let status: React.ReactNode;
     if (error) {
-      status = <div className="text-secondary">Unavailable</div>;
+      status = <div className="co-dashboard-text--small text-secondary">Unavailable</div>;
     } else if (isLoading) {
       status = <LoadingInline />;
     } else {
@@ -69,7 +69,7 @@ export const Status: React.FC<StatusProps> = React.memo(({ groupID, count, flags
   const groupIcon = statusGroupIcons[groupID] || statusGroupIcons[InventoryStatusGroup.NOT_MAPPED];
   return (
     <div className="co-inventory-card__status">
-      <span className="co-inventory-card__status-icon">{groupIcon}</span>
+      <span className="co-dashboard-icon">{groupIcon}</span>
       <span className="co-inventory-card__status-text">{count}</span>
     </div>
   );
@@ -85,7 +85,7 @@ const StatusLink: React.FC<StatusLinkProps> = React.memo(
     return (
       <div className="co-inventory-card__status">
         <Link to={to} style={{textDecoration: 'none'}}>
-          <span className="co-inventory-card__status-icon">{groupIcon}</span>
+          <span className="co-dashboard-icon">{groupIcon}</span>
           <span className="co-inventory-card__status-text">{count}</span>
         </Link>
       </div>

--- a/frontend/public/components/dashboard/top-consumers-card/consumers-filter.tsx
+++ b/frontend/public/components/dashboard/top-consumers-card/consumers-filter.tsx
@@ -24,7 +24,7 @@ export const metricTypeMap: MetricTypeMap = {
 };
 
 export const ConsumersFilter: React.FC<ConsumersFilterProps> = ({ children }) =>
-  <div className="co-consumers-card__filters">{children}</div>;
+  <div className="co-dashboard-card__body--top-margin co-consumers-card__filters">{children}</div>;
 
 type ConsumersFilterProps = {
   children: React.ReactNode;

--- a/frontend/public/components/dashboard/top-consumers-card/top-consumers-card.scss
+++ b/frontend/public/components/dashboard/top-consumers-card/top-consumers-card.scss
@@ -1,7 +1,11 @@
 .co-consumers-card__filters {
   border-bottom: 1px solid $pf-color-black-300;
   display: flex;
-  padding-bottom: 0.6em;
+  margin-left: calc(-1 * var(--pf-c-card--child--PaddingLeft));
+  margin-right: calc(-1 * var(--pf-c-card--child--PaddingRight));
+  padding-bottom: var(--pf-c-card--child--PaddingBottom);
+  padding-left: var(--pf-c-card--child--PaddingLeft);
+  padding-right: var(--pf-c-card--child--PaddingRight);
 }
 
 .co-consumers-card__body {

--- a/frontend/public/components/dashboard/utilization-card/utilization-body.tsx
+++ b/frontend/public/components/dashboard/utilization-card/utilization-body.tsx
@@ -21,7 +21,7 @@ const UtilizationAxis: React.FC<UtilizationAxisProps> = ({ timestamps }) => {
         orientation="top"
         height={15}
         width={width}
-        padding={{ top: 30, bottom: 0, left: 70, right: 30 }}
+        padding={{ top: 30, bottom: 0, left: 70, right: 0 }}
         style={{
           axis: {visibility: 'hidden'},
         }}
@@ -37,20 +37,23 @@ export const UtilizationBody: React.FC<UtilizationBodyProps> = ({ timestamps, ch
   const axis = width < parseInt(breakpointSM.value, 10) ?
     timestamps.length === 0 ? null : (
       <Row className="co-utilization-card__item">
-        <Col>
+        <Col className="co-utilization-card__axis">
           <UtilizationAxis timestamps={timestamps} />
         </Col>
       </Row>
     ) : (
       <Row className="co-utilization-card__item">
         <Col lg={5} md={5} sm={5} xs={5} />
-        <Col lg={7} md={7} sm={7} xs={7}>
+        <Col lg={7} md={7} sm={7} xs={7} className="co-utilization-card__axis">
           {timestamps.length > 0 && <UtilizationAxis timestamps={timestamps} />}
         </Col>
       </Row>
     );
   return (
-    <div ref={containerRef}>
+    <div
+      className="co-dashboard-card__body--top-margin co-dashboard-card__body--no-padding co-utilization-card__body"
+      ref={containerRef}
+    >
       {axis}
       <div>{children}</div>
     </div>

--- a/frontend/public/components/dashboard/utilization-card/utilization-card.scss
+++ b/frontend/public/components/dashboard/utilization-card/utilization-card.scss
@@ -1,3 +1,12 @@
+.co-utilization-card__area-chart {
+  margin: 0;
+  padding: 0;
+}
+
+.co-utilization-card__axis {
+  padding: 0 0.5rem;
+}
+
 .co-utilization-card__item {
   border-bottom: 1px solid $pf-color-black-300;
   font-size: 1.333em;
@@ -6,11 +15,8 @@
 }
 
 .co-utilization-card__item-chart {
+  padding: 0 0.5rem;
   text-align: center;
-
-  svg {
-    overflow: visible;
-  }
 }
 
 .co-utilization-card__item-chart--narrow {
@@ -22,11 +28,8 @@
 }
 
 .co-utilization-card__item-current {
+  padding-right: var(--pf-c-card--child--PaddingRight);
   text-align: right;
-}
-
-.co-utilization-card__item-current--narrow {
-  font-size: 0.875rem;
 }
 
 .co-utilization-card__item-row--narrow {
@@ -35,12 +38,11 @@
 }
 
 .co-utilization-card__item-title-row--narrow {
-  margin-bottom: 0.5em;
   margin-top: 1em;
 }
 
-.co-utilization-card__item-title--narrow {
-  font-size: 0.875rem;
+.co-utilization-card__item-title {
+  padding-left: var(--pf-c-card--child--PaddingLeft);
 }
 
 .co-utilization-card__item--wide {

--- a/frontend/public/components/dashboard/utilization-card/utilization-item.tsx
+++ b/frontend/public/components/dashboard/utilization-card/utilization-item.tsx
@@ -23,18 +23,19 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
         query={query}
         xAxis={false}
         humanize={humanizeValue}
-        padding={{ top: 20, left: 70, bottom: 7, right: 30 }}
-        height={100}
+        padding={{ top: 13, left: 70, bottom: 0, right: 0 }}
+        height={80}
+        className="co-utilization-card__area-chart"
       />
     );
 
     const rows = width < parseInt(breakpointSM.value, 10) ? (
       <div className="co-utilization-card__item">
         <Row className="co-utilization-card__item-row--narrow co-utilization-card__item-title-row--narrow">
-          <Col lg={6} md={6} sm={6} xs={6} className="co-utilization-card__item-title--narrow">
+          <Col lg={6} md={6} sm={6} xs={6} className="co-utilization-card__item-title co-dashboard-text--small">
             {title}
           </Col>
-          <Col className="co-utilization-card__item-current co-utilization-card__item-current--narrow" lg={6} md={6} sm={6} xs={6}>
+          <Col className="co-utilization-card__item-current co-dashboard-text--small" lg={6} md={6} sm={6} xs={6}>
             {current}
           </Col>
         </Row>
@@ -44,7 +45,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
       </div>
     ) : (
       <Row className="co-utilization-card__item co-utilization-card__item--wide">
-        <Col lg={3} md={3} sm={3} xs={3}>
+        <Col className="co-utilization-card__item-title" lg={3} md={3} sm={3} xs={3}>
           {title}
         </Col>
         <Col className="co-utilization-card__item-current" lg={2} md={2} sm={2} xs={2}>

--- a/frontend/public/components/dashboards-page/overview-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/inventory-card.tsx
@@ -17,6 +17,7 @@ import { FirehoseResource } from '../../utils';
 import { connectToFlags, FlagsObject, WithFlagsProps } from '../../../reducers/features';
 import { getFlagsForExtensions } from '../utils';
 import { uniqueResource } from './utils';
+import { InventoryBody } from '../../dashboard/inventory-card/inventory-body';
 
 const k8sResources: FirehoseResource[] = [
   {
@@ -87,41 +88,43 @@ const InventoryCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
         <DashboardCardTitle>Cluster Inventory</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
-        <ResourceInventoryItem isLoading={!nodesLoaded} error={!!nodesLoadError} kind={NodeModel} resources={nodesData} mapper={getNodeStatusGroups} />
-        <ResourceInventoryItem isLoading={!podsLoaded} error={!!podsLoadError} kind={PodModel} resources={podsData} mapper={getPodStatusGroups} />
-        <ResourceInventoryItem isLoading={!pvcsLoaded} error={!!pvcsLoadError} kind={PersistentVolumeClaimModel} useAbbr resources={pvcsData} mapper={getPVCStatusGroups} />
-        {pluginItems.map((item, index) => {
-          const resource = _.get(resources, uniqueResource(item.properties.resource, index).prop);
-          const resourceLoaded = _.get(resource, 'loaded');
-          const resourceLoadError = _.get(resource, 'loadError');
-          const resourceData = _.get(resource, 'data', []) as K8sResourceKind[];
+        <InventoryBody>
+          <ResourceInventoryItem isLoading={!nodesLoaded} error={!!nodesLoadError} kind={NodeModel} resources={nodesData} mapper={getNodeStatusGroups} />
+          <ResourceInventoryItem isLoading={!podsLoaded} error={!!podsLoadError} kind={PodModel} resources={podsData} mapper={getPodStatusGroups} />
+          <ResourceInventoryItem isLoading={!pvcsLoaded} error={!!pvcsLoadError} kind={PersistentVolumeClaimModel} useAbbr resources={pvcsData} mapper={getPVCStatusGroups} />
+          {pluginItems.map((item, index) => {
+            const resource = _.get(resources, uniqueResource(item.properties.resource, index).prop);
+            const resourceLoaded = _.get(resource, 'loaded');
+            const resourceLoadError = _.get(resource, 'loadError');
+            const resourceData = _.get(resource, 'data', []) as K8sResourceKind[];
 
-          const additionalResources = {};
-          if (item.properties.additionalResources) {
-            item.properties.additionalResources.forEach(ar => {
-              additionalResources[ar.prop] = _.get(resources, uniqueResource(ar, index).prop);
-            });
-          }
-          const additionalResourcesLoaded = Object.keys(additionalResources).every(key =>
-            !additionalResources[key] || additionalResources[key].loaded || additionalResources[key].loadError
-          );
-          const additionalResourcesData = {};
+            const additionalResources = {};
+            if (item.properties.additionalResources) {
+              item.properties.additionalResources.forEach(ar => {
+                additionalResources[ar.prop] = _.get(resources, uniqueResource(ar, index).prop);
+              });
+            }
+            const additionalResourcesLoaded = Object.keys(additionalResources).every(key =>
+              !additionalResources[key] || additionalResources[key].loaded || additionalResources[key].loadError
+            );
+            const additionalResourcesData = {};
 
-          Object.keys(additionalResources).forEach(key => additionalResourcesData[key] = _.get(additionalResources[key], 'data', []));
+            Object.keys(additionalResources).forEach(key => additionalResourcesData[key] = _.get(additionalResources[key], 'data', []));
 
-          return (
-            <ResourceInventoryItem
-              key={index}
-              isLoading={!resourceLoaded || !additionalResourcesLoaded}
-              error={!!resourceLoadError}
-              kind={item.properties.model}
-              resources={resourceData}
-              additionalResources={additionalResourcesData}
-              mapper={item.properties.mapper}
-              useAbbr={item.properties.useAbbr}
-            />
-          );
-        })}
+            return (
+              <ResourceInventoryItem
+                key={index}
+                isLoading={!resourceLoaded || !additionalResourcesLoaded}
+                error={!!resourceLoadError}
+                kind={item.properties.model}
+                resources={resourceData}
+                additionalResources={additionalResourcesData}
+                mapper={item.properties.mapper}
+                useAbbr={item.properties.useAbbr}
+              />
+            );
+          })}
+        </InventoryBody>
       </DashboardCardBody>
     </DashboardCard>
   );

--- a/frontend/public/components/dashboards-page/overview-dashboard/top-consumers-card.scss
+++ b/frontend/public/components/dashboards-page/overview-dashboard/top-consumers-card.scss
@@ -10,6 +10,10 @@
   padding-right: 0.3em;
 }
 
+.co-overview-consumers__chart {
+  margin-bottom: 0;
+}
+
 .co-overview-consumers__view-more {
   text-align: left;
 }

--- a/frontend/public/components/dashboards-page/overview-dashboard/top-consumers-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/top-consumers-card.tsx
@@ -170,6 +170,7 @@ const TopConsumersCard_ = connectToURLs(MonitoringRoutes.Prometheus)(({
         <ConsumersBody>
           <BarChart
             data={top5Data}
+            titleClassName="co-overview-consumers__chart"
             title={`${type} by ${metricTypeSort.description}`}
             loading={!consumersLoadError && !(topConsumersResult && consumersLoaded)}
             LabelComponent={({ title, metric }) => (

--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -9,8 +9,8 @@
   white-space: nowrap; 
 }
 
-.graph-empty-state {
-  background: #f5f5f5;
+.graph-empty-state__title {
+  font-size: 0.875rem;
 }
 
 .graph-wrapper {

--- a/frontend/public/components/graphs/bar.tsx
+++ b/frontend/public/components/graphs/bar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ChartBarIcon } from '@patternfly/react-icons';
 import {
   ChartBar,
   ChartLabel,
@@ -70,7 +69,7 @@ export const BarChart: React.FC<BarChartProps> = ({
             ))}
           </PrometheusGraphLink>
         ) : (
-          <GraphEmpty icon={ChartBarIcon} loading={loading} height={100} />
+          <GraphEmpty loading={loading} />
         )
       }
     </PrometheusGraph>

--- a/frontend/public/components/graphs/gauge.tsx
+++ b/frontend/public/components/graphs/gauge.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts';
+import classNames from 'classnames';
 
 import { PrometheusGraph, PrometheusGraphLink } from './prometheus-graph';
 import { usePrometheusPoll } from './prometheus-poll-hook';
@@ -22,36 +23,42 @@ export const GaugeChart: React.FC<GaugeChartProps> = ({
   thresholds = DEFAULT_THRESHOLDS,
   title,
   usedLabel = 'used',
-
   // Don't sort, Uses previously declared props
   label = data ? humanize(data.y).string : 'No Data',
   secondaryTitle = usedLabel,
+  className,
 }) => {
   const [ref, width] = useRefWidth();
   const ready = !error && !loading;
   const status = loading ? 'Loading' : error;
   const labels = (d) => d.x ? `${d.x} ${usedLabel}` : `${d.y} ${remainderLabel}`;
-  return <PrometheusGraph className="graph-wrapper--title-center graph-wrapper--gauge" ref={ref} title={title}>
-    <PrometheusGraphLink query={query}>
-      <ChartDonutThreshold
-        data={thresholds}
-        height={width} // Changes the scale of the graph, not actual width and height
-        y="value"
-        width={width}
-      >
-        <ChartDonutUtilization
-          labels={labels}
-          data={ready ? data : { y: 0 }}
-          invert={invert}
-          subTitle={ready ? secondaryTitle : ''}
-          themeColor={ChartThemeColor.green}
-          thresholds={thresholds}
-          title={status || label}
-          theme={theme}
-        />
-      </ChartDonutThreshold>
-    </PrometheusGraphLink>
-  </PrometheusGraph>;
+  return (
+    <PrometheusGraph
+      className={classNames('graph-wrapper--title-center graph-wrapper--gauge', className)}
+      ref={ref}
+      title={title}
+    >
+      <PrometheusGraphLink query={query}>
+        <ChartDonutThreshold
+          data={thresholds}
+          height={width} // Changes the scale of the graph, not actual width and height
+          y="value"
+          width={width}
+        >
+          <ChartDonutUtilization
+            labels={labels}
+            data={ready ? data : { y: 0 }}
+            invert={invert}
+            subTitle={ready ? secondaryTitle : ''}
+            themeColor={ChartThemeColor.green}
+            thresholds={thresholds}
+            title={status || label}
+            theme={theme}
+          />
+        </ChartDonutThreshold>
+      </PrometheusGraphLink>
+    </PrometheusGraph>
+  );
 };
 
 export const Gauge: React.FC<GaugeProps> = ({
@@ -112,6 +119,7 @@ type GaugeChartProps = {
   }[];
   title?: string;
   usedLabel?: string;
+  className?: string;
 }
 
 type GaugeProps = {

--- a/frontend/public/components/graphs/graph-empty.tsx
+++ b/frontend/public/components/graphs/graph-empty.tsx
@@ -1,21 +1,21 @@
 import * as React from 'react';
-import { ChartAreaIcon } from '@patternfly/react-icons';
-import { EmptyStateIcon, EmptyState, EmptyStateVariant, Title } from '@patternfly/react-core';
+import { EmptyState, EmptyStateVariant, Title } from '@patternfly/react-core';
 import { LoadingBox } from '../utils';
 
-export const GraphEmpty: React.FC<GraphEmptyProps> = ({height = 180, icon = ChartAreaIcon, loading = false}) => <div style={{minHeight:height, width: '100%'}} >
-  {
-    loading ? <LoadingBox /> : (
-      <EmptyState className="graph-empty-state" variant={EmptyStateVariant.full}>
-        <EmptyStateIcon size="sm" icon={icon} />
-        <Title size="sm">No datapoints found.</Title>
+export const GraphEmpty: React.FC<GraphEmptyProps> = ({ height = 180, loading = false }) => (
+  <div style={{height, width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center'}} >
+    {loading ? (
+      <LoadingBox />
+    ) : (
+      <EmptyState variant={EmptyStateVariant.full} >
+        <Title className="graph-empty-state__title text-secondary" size="sm">No datapoints found.</Title>
       </EmptyState>
     )
-  }
-</div>;
+    }
+  </div>
+);
 
 type GraphEmptyProps = {
-  icon?: React.SFC<any>;
-  height?: number;
+  height?: number | string;
   loading?: boolean;
 }

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -428,7 +428,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
       </div>}
     </div>
     {error && <Error error={error} />}
-    {(_.isEmpty(graphData) && !updating) && <GraphEmpty icon={ChartLineIcon} />}
+    {(_.isEmpty(graphData) && !updating) && <GraphEmpty />}
     {!_.isEmpty(graphData) && <React.Fragment>
       {samples < maxSamples && <Alert
         isInline


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1741144

notable changes: 
- Dashboard card body has padding set to 0
- all lines (inventory, utilization, top consumers) are full body width (thanks to the change above)
- if padding is required, it needs to be specified case by case, Im using PF's `--pf-c-card--child--Padding*` variables
- I've added custom style to utilization chart empty state to have consistent height of row for empty and loaded charts

@andybraren can you please take a look at let me know if I need to fix anything else ?
![screencapture-localhost-9000-dashboards-2019-08-15-12_28_39](https://user-images.githubusercontent.com/2078045/63089606-afdc7a00-bf58-11e9-8d59-feab330613e5.png)

![screencapture-localhost-9000-dashboards-2019-08-15-12_39_06](https://user-images.githubusercontent.com/2078045/63089901-c6370580-bf59-11e9-8481-ccd6a8b110bd.png)


@cloudbehl can you also check storage and noobaa with loaded data ? I've checked error states of those dashboards and it looks fine.

