### PR TITLE
Bug 1741136: Use 1 decimal place for values < 100, 0 otherwise

### DIFF
--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -112,15 +112,7 @@ const convertValueWithUnitsToBaseValue = (value, unitArray, divisor) => {
   return { value, unit };
 };
 
-const getDefaultFractionDigits = value => {
-  if (value < 1) {
-    return 3;
-  }
-  if (value < 100) {
-    return 2;
-  }
-  return 1;
-};
+const getDefaultFractionDigits = value => value < 100 ? 1 : 0;
 
 const round = units.round = (value, options) => {
   const fractionDigits = getDefaultFractionDigits(value);


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1741136

as mentioned in https://docs.google.com/document/d/13QagwaaG_xp0JaiGgPnMqwiWA-BT3WOJItK_IVpPRlw/edit# we'd like to show 1 decimal place for values < 100, 0 otherwise

@spadgett WDYT? 
cc: @andybraren  