### PR TITLE
Fix bug where overview alerts can abut one another

### DIFF
--- a/frontend/public/components/overview/_project-overview.scss
+++ b/frontend/public/components/overview/_project-overview.scss
@@ -160,6 +160,14 @@
   }
 }
 
+.project-overview__status .co-icon-and-text {
+  margin-right: 12px;
+
+  .project-overview__builds & {
+    margin-right: 4px;
+  }
+}
+
 @media (min-width: $screen-md-min) {
   // Metrics are hidden when the sidebar is open. Adjust list row styles.
   .overview--sidebar-shown .project-overview {

--- a/frontend/public/components/overview/project-overview.tsx
+++ b/frontend/public/components/overview/project-overview.tsx
@@ -151,7 +151,7 @@ const AlertTooltip = ({alerts, severity, noSeverityLabel=false}) => {
   // Disable the tooltip on mobile since a touch also opens the sidebar, which
   // immediately covers the tooltip content.
   return <Tooltip content={content} styles={overviewTooltipStyles} disableOnMobile>
-    <TooltipStatus status={severity} title={noSeverityLabel ? String(count) : pluralize(count, label)} />
+    <span className="project-overview__status"><TooltipStatus status={severity} title={noSeverityLabel ? String(count) : pluralize(count, label)} /></span>
   </Tooltip>;
 };
 
@@ -173,7 +173,7 @@ const Alerts: React.SFC<AlertsProps> = ({item}) => {
     {error && <AlertTooltip severity="Error" alerts={error} />}
     {warning && <AlertTooltip severity="Warning" alerts={warning} />}
     {info && <AlertTooltip severity="Info" alerts={info} />}
-    {(buildNew || buildPending || buildRunning || buildFailed || buildError) && <div>
+    {(buildNew || buildPending || buildRunning || buildFailed || buildError) && <div className="project-overview__builds">
       Builds {buildNew && <AlertTooltip severity="New" alerts={buildNew} noSeverityLabel />} {buildPending && <AlertTooltip severity="Pending" alerts={buildPending} noSeverityLabel />} {buildRunning && <AlertTooltip severity="Running" alerts={buildRunning} noSeverityLabel />} {buildFailed && <AlertTooltip severity="Failed" alerts={buildFailed} noSeverityLabel />} {buildError && <AlertTooltip severity="Error" alerts={buildError} noSeverityLabel />}
     </div>}
   </div>;


### PR DESCRIPTION
Before:
![Screen Shot 2019-08-15 at 8 54 32 AM](https://user-images.githubusercontent.com/895728/63096109-00dd7580-bf3b-11e9-9ea8-d851d3e46e4f.png)
![Screen Shot 2019-08-15 at 8 54 45 AM](https://user-images.githubusercontent.com/895728/63096110-00dd7580-bf3b-11e9-9fb3-67881b79b202.png)

After:
![Screen Shot 2019-08-15 at 4 30 41 PM](https://user-images.githubusercontent.com/895728/63124862-44a39f80-bf7a-11e9-91ba-72ba400672e4.png)

