### PR TITLE
Bug 1741119: Remove orphaned function call to fix console error

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -234,7 +234,6 @@ class EventStream extends React.Component {
           }
         });
         this.flushMessages();
-        this.resizeEvents();
       })
       .onopen(() => {
         this.messages = {};


### PR DESCRIPTION
Partially fixes https://bugzilla.redhat.com/show_bug.cgi?id=1741119

resizeEvents() was removed in https://github.com/openshift/console/pull/1895 and this call was orphaned in the process.