### PR TITLE
Bug 1739831: Fix wrapping issue with node details graphs

### DIFF
--- a/frontend/public/components/graphs/graph-empty.tsx
+++ b/frontend/public/components/graphs/graph-empty.tsx
@@ -3,16 +3,16 @@ import { ChartAreaIcon } from '@patternfly/react-icons';
 import { EmptyStateIcon, EmptyState, EmptyStateVariant, Title } from '@patternfly/react-core';
 import { LoadingBox } from '../utils';
 
-export const GraphEmpty: React.FC<GraphEmptyProps> = ({height = 180, icon = ChartAreaIcon, loading = false}) => loading ? (
-  <div style={{height, width: '100%'}} >
-    <LoadingBox />
-  </div>
-) : (
-  <EmptyState className="graph-empty-state" variant={EmptyStateVariant.full} >
-    <EmptyStateIcon size="sm" icon={icon} />
-    <Title size="sm">No datapoints found.</Title>
-  </EmptyState>
-);
+export const GraphEmpty: React.FC<GraphEmptyProps> = ({height = 180, icon = ChartAreaIcon, loading = false}) => <div style={{height, width: '100%'}} >
+  {
+    loading ? <LoadingBox /> : (
+      <EmptyState className="graph-empty-state" variant={EmptyStateVariant.full}>
+        <EmptyStateIcon size="sm" icon={icon} />
+        <Title size="sm">No datapoints found.</Title>
+      </EmptyState>
+    )
+  }
+</div>;
 
 type GraphEmptyProps = {
   icon?: React.SFC<any>;

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -170,6 +170,8 @@ const NodeGraphs = requirePrometheus(({node}) => {
           query={ipQuery && `kubelet_running_pod_count${ipQuery}`}
         />
       </div>
+    </div>
+    <div className="row">
       <div className="col-md-12 col-lg-4">
         <Area
           title="Network In"
@@ -192,7 +194,6 @@ const NodeGraphs = requirePrometheus(({node}) => {
         />
       </div>
     </div>
-    <br />
   </React.Fragment>;
 });
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1739831

Separate graphs into two Bootstrap rows to ensure that unexpected wrapping doesn't occur.