### PR TITLE
Fix bug where DefaultPage loading indicator is mis-positioned

### DIFF
--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -9,7 +9,7 @@ import { GlobalNotifications } from './global-notifications';
 import { NamespaceBar } from './namespace';
 import { SearchPage } from './search';
 import { ResourceDetailsPage, ResourceListPage } from './resource-list';
-import { AsyncComponent, Loading } from './utils';
+import { AsyncComponent, LoadingBox } from './utils';
 import { namespacedPrefixes } from './utils/link';
 import { ClusterServiceVersionModel, SubscriptionModel, AlertmanagerModel } from '../models';
 import { referenceForModel } from '../module/k8s';
@@ -56,7 +56,7 @@ type DefaultPageProps = {
 // The default page component lets us connect to flags without connecting the entire App.
 const DefaultPage_: React.FC<DefaultPageProps> = ({ flags, activePerspective }) => {
   if (Object.keys(flags).some(key => flagPending(flags[key]))) {
-    return <Loading />;
+    return <LoadingBox />;
   }
   // support redirecting to perspective landing page
   return flags[FLAGS.OPENSHIFT] ? (


### PR DESCRIPTION
Before:
![Screen Shot 2019-08-15 at 2 50 07 PM](https://user-images.githubusercontent.com/895728/63118869-c260ae80-bf6c-11e9-8ae8-08084efc4e17.png)

After:
![Screen Shot 2019-08-15 at 3 01 18 PM](https://user-images.githubusercontent.com/895728/63119191-95f96200-bf6d-11e9-8c83-0f8ed44ec9d1.png)


cc: @TheRealJon 