### PR TITLE
Bug 1741119: Use `fieldSelector` to filter events

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -198,10 +198,11 @@ class EventStream extends React.Component {
   }
 
   wsInit(ns) {
-    const params = {
-      ns,
-      fieldSelector: this.props.fieldSelector,
-    };
+    const { fieldSelector } = this.props;
+    const params = { ns };
+    if (fieldSelector) {
+      params.queryParams = { fieldSelector: encodeURIComponent(fieldSelector) };
+    }
 
     this.ws = new WSFactory(`${ns || 'all'}-sysevents`, {
       host: 'auto',
@@ -433,7 +434,7 @@ EventStream.propTypes = {
 };
 
 
-export const ResourceEventStream = ({obj: {kind, metadata: {name, namespace}}}) =>
-  <EventStream filter={[obj => _.isMatch(obj, {name, kind})]} namespace={namespace} resourceEventStream />;
+export const ResourceEventStream = ({obj: {kind, metadata: {name, namespace, uid}}}) =>
+  <EventStream fieldSelector={`involvedObject.uid=${uid},involvedObject.name=${name},involvedObject.kind=${kind}`} namespace={namespace} resourceEventStream />;
 
 export const ResourcesEventStream = ({ filters, namespace }) => <EventStream filter={filters} resourceEventStream namespace={namespace} />;


### PR DESCRIPTION
Use a `fieldSelector` for `ResourceEventStream` rather than filtering on
the client. This is more efficient and avoids missing events for a
resource when there are more than 500.

/assign @rhamilto 