### PR TITLE
Bug 1739351: Filter externally provisioned hosts as provisioned hosts

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/table-filters.ts
+++ b/frontend/packages/metal3-plugin/src/components/table-filters.ts
@@ -7,6 +7,7 @@ import {
   HOST_ERROR_STATES,
   HOST_STATUS_TITLES,
   HOST_STATUS_PROVISIONED,
+  HOST_STATUS_EXTERNALLY_PROVISIONED,
 } from '../constants';
 import { HostRowBundle } from './types';
 
@@ -25,7 +26,7 @@ const hostStatesToFilterMap = Object.freeze({
   },
   provisioned: {
     title: 'Provisioned',
-    states: [HOST_STATUS_PROVISIONED],
+    states: [HOST_STATUS_PROVISIONED, HOST_STATUS_EXTERNALLY_PROVISIONED],
   },
   error: {
     title: 'Error',


### PR DESCRIPTION
This ensures that externally provisioned bare metal hosts are treated as provisioned ones in filtering and dashboard status reporting

https://bugzilla.redhat.com/show_bug.cgi?id=1739351