### PR TITLE
Bug 1741470: Correctly order overview groups

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -32,7 +32,7 @@ export enum ActionType {
   UpdateOverviewMetrics = 'updateOverviewMetrics',
   UpdateOverviewResources = 'updateOverviewResources',
   UpdateOverviewSelectedGroup = 'updateOverviewSelectedGroup',
-  UpdateOverviewGroupOptions = 'updateOverviewGroupOptions',
+  UpdateOverviewLabels = 'updateOverviewLabels',
   UpdateOverviewFilterValue = 'updateOverviewFilterValue',
   UpdateTimestamps = 'updateTimestamps',
   SetConsoleLinks = 'setConsoleLinks',
@@ -195,8 +195,8 @@ export const updateOverviewMetrics = (metrics: any) => action(ActionType.UpdateO
 export const updateOverviewResources = (resources: OverviewItem[]) => action(ActionType.UpdateOverviewResources, {resources});
 export const updateTimestamps = (lastTick: number) => action(ActionType.UpdateTimestamps, {lastTick});
 export const dismissOverviewDetails = () => action(ActionType.DismissOverviewDetails);
-export const updateOverviewSelectedGroup = (group: OverviewSpecialGroup) => action(ActionType.UpdateOverviewSelectedGroup, {group});
-export const updateOverviewGroupOptions = (groups: {[label: string]: string}) => action(ActionType.UpdateOverviewGroupOptions, {groups});
+export const updateOverviewSelectedGroup = (group: OverviewSpecialGroup | string) => action(ActionType.UpdateOverviewSelectedGroup, {group});
+export const updateOverviewLabels = (labels: string[]) => action(ActionType.UpdateOverviewLabels, {labels});
 export const updateOverviewFilterValue = (value: string) => action(ActionType.UpdateOverviewFilterValue, {value});
 export const monitoringLoading = (key: 'alerts' | 'silences') => action(ActionType.SetMonitoringData, {key, data: {loaded: false, loadError: null, data: null}});
 export const monitoringLoaded = (key: 'alerts' | 'silences', data: any) => action(ActionType.SetMonitoringData, {key, data: {loaded: true, loadError: null, data}});
@@ -222,7 +222,7 @@ const uiActions = {
   updateTimestamps,
   dismissOverviewDetails,
   updateOverviewSelectedGroup,
-  updateOverviewGroupOptions,
+  updateOverviewLabels,
   updateOverviewFilterValue,
   monitoringLoading,
   monitoringLoaded,

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -157,8 +157,8 @@ export default (state: UIState, action: UIAction): UIState => {
       return state.setIn(['overview', 'selectedGroup'], action.payload.group);
     }
 
-    case ActionType.UpdateOverviewGroupOptions: {
-      return state.setIn(['overview', 'groupOptions'], ImmutableMap(action.payload.groups));
+    case ActionType.UpdateOverviewLabels: {
+      return state.setIn(['overview', 'labels'], action.payload.labels);
     }
 
     case ActionType.UpdateOverviewFilterValue: {


### PR DESCRIPTION
We were losing the key insertion order for the group options when
storing them as an object in Redux. Instead, store the label keys an an
array, then add the special groups in `OverviewHeading`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1741470

/assign @TheRealJon 