### PR TITLE
clicking on build decorator navigates to associated build

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
@@ -10,7 +10,7 @@ import { Status, calculateRadius, PodStatus, GreenCheckCircleIcon } from '@conso
 import { TooltipPosition } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { resourcePathFromModel } from '@console/internal/components/utils';
-import { BuildConfigModel } from '@console/internal/models';
+import { BuildModel } from '@console/internal/models';
 import { detectGitType } from '../../import/import-validation-utils';
 import { NodeProps, WorkloadData } from '../topology-types';
 import Decorator from './Decorator';
@@ -94,11 +94,7 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
         build && (
           <Link
             key="build"
-            to={resourcePathFromModel(
-              BuildConfigModel,
-              build.metadata.ownerReferences[0].name,
-              build.metadata.namespace,
-            )}
+            to={resourcePathFromModel(BuildModel, build.metadata.name, build.metadata.namespace)}
             className="odc-decorator__link"
           >
             <Decorator


### PR DESCRIPTION
ODC-bug: https://jira.coreos.com/browse/ODC-1611

Currently, Clicking on the build decorator navigates to associated buildconfig. This Pr changes that to associated build instead of buildconfig.
