### PR TITLE
allow dot and underscore in docker file path

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
@@ -119,16 +119,6 @@ describe('ValidationUtils', () => {
       });
     });
 
-    it('should throw an error if dockerfilePath is invalid', async () => {
-      const mockData = cloneDeep(mockFormData);
-      mockData.build.strategy = 'Docker';
-      mockData.docker.dockerfilePath = '/Dockerfile';
-      await validationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
-      await validationSchema.validate(mockData).catch((err) => {
-        expect(err.message).toBe('DockerfilePath must be a relative path');
-      });
-    });
-
     it('should throw an error if containerPort is not an integer', async () => {
       const mockData = cloneDeep(mockFormData);
       mockData.build.strategy = 'Docker';

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -6,7 +6,6 @@ import { isInteger } from '../../utils/yup-validation-util';
 const urlRegex = /^(((ssh|git|https?):\/\/[\w]+)|(git@[\w]+.[\w]+:))([\w\-._~/?#[\]!$&'()*+,;=])+$/;
 const hostnameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 const pathRegex = /^\/.*$/;
-const relativePathRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\/.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/;
 const nameRegex = /^([a-z]([-a-z0-9]*[a-z0-9])?)*$/;
 
 export const validationSchema = yup.object().shape({
@@ -48,9 +47,6 @@ export const validationSchema = yup.object().shape({
   docker: yup.object().when('build', {
     is: (build) => build.strategy === 'Docker',
     then: yup.object().shape({
-      dockerfilePath: yup
-        .string()
-        .matches(relativePathRegex, 'DockerfilePath must be a relative path'),
       containerPort: yup.number().test(isInteger('Container port should be an Integer')),
     }),
   }),


### PR DESCRIPTION
ODC Bug: https://jira.coreos.com/browse/ODC-1617

This Pr fixes the regex to accept dot and underscore in dockerfile path

![Screenshot from 2019-08-16 13-02-30](https://user-images.githubusercontent.com/9278015/63151288-ca7d2480-c026-11e9-8ded-150112dc7451.png)
![Screenshot from 2019-08-16 13-02-39](https://user-images.githubusercontent.com/9278015/63151289-ca7d2480-c026-11e9-8ffe-504d6d4101f0.png)
![Screenshot from 2019-08-16 13-07-05](https://user-images.githubusercontent.com/9278015/63151290-cb15bb00-c026-11e9-8cd2-6fdb29a66aac.png)
