### PR TITLE
Bug 1722811: Use kind name for label

### DIFF
--- a/frontend/integration-tests/tests/crd-extensions.scenario.ts
+++ b/frontend/integration-tests/tests/crd-extensions.scenario.ts
@@ -64,7 +64,7 @@ describe('CRD extensions', () => {
       await crudView.clickKebabAction(crd, 'View Instances');
       await crudView.resourceRowsPresent();
       // cannot use `await crudView.deleteRow(crd)(name)` because ConsoleCLIDownload is humanized as 'Console C L I Download';
-      await crudView.clickKebabAction(name, 'Delete Console CLIDownload');
+      await crudView.clickKebabAction(name, 'Delete Console CLI Download');
       await browser.wait(until.presenceOf($('#confirm-action')));
       await $('#confirm-action').click();
     });

--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -91,16 +91,16 @@ const getResources_ = () => coFetchJSON('api/kubernetes/apis')
 
         const defineModels = (list: APIResourceList): K8sKind[] => list.resources.filter(({name}) => !name.includes('/'))
           .map(({name, singularName, namespaced, kind, verbs, shortNames}) => {
-            const label = kind.replace(/([A-Z]+)/g, ' $1').slice(1);
             const groupVersion = list.groupVersion.split('/').length === 2 ? list.groupVersion : `core/${list.groupVersion}`;
 
             return {
-              kind, namespaced, label, verbs, shortNames,
+              kind, namespaced, verbs, shortNames,
+              label: kind,
               plural: name,
               apiVersion: groupVersion.split('/')[1],
               abbr: kindToAbbr(kind),
               apiGroup: groupVersion.split('/')[0],
-              labelPlural: `${label}${label.endsWith('s') ? 'es' : 's'}`,
+              labelPlural: `${kind}${kind.endsWith('s') ? 'es' : 's'}`,
               path: name,
               id: singularName,
               crd: true,

--- a/frontend/public/reducers/k8s.ts
+++ b/frontend/public/reducers/k8s.ts
@@ -97,7 +97,7 @@ export default (state: K8sState, action: K8sAction): K8sState => {
         })
         .reduce((prevState, newModel) => {
           // FIXME: Need to use `kind` as model reference for legacy components accessing k8s primitives
-          const [modelRef, model] = allModels().findEntry(staticModel => !staticModel.crd && referenceForModel(staticModel) === referenceForModel(newModel))
+          const [modelRef, model] = allModels().findEntry(staticModel => referenceForModel(staticModel) === referenceForModel(newModel))
             || [referenceForModel(newModel), newModel];
           // Verbs and short names are not part of the static model definitions, so use the values found during discovery.
           return prevState.updateIn(['RESOURCES', 'models'], models => models.set(modelRef, {...model, verbs: newModel.verbs, shortNames: newModel.shortNames}));


### PR DESCRIPTION
Bug 1722811: Use kind name for label if the kind is not in our known set of models.

This changes many labels other than the `HyperConvered` mentioned in the bug.  However, any resource defined in our models will have a proper label so there should be no undesired results. Hopefully. 

