### PR TITLE
Switch timestamp tooltips to PF4 to prevent overflow clipping

### DIFF
--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Tooltip } from './tooltip';
+import { Tooltip } from '@patternfly/react-core';
 import * as classNames from 'classnames';
 import { GlobeAmericasIcon } from '@patternfly/react-icons';
 
@@ -57,7 +57,7 @@ export const Timestamp = connect(nowStateToProps)((props: TimestampProps) => {
   return <div className={classNames('co-timestamp co-icon-and-text', props.className)}>
     <GlobeAmericasIcon className="co-icon-and-text__icon" />
     <Tooltip content={[<span className="co-nowrap" key="co-timestamp">{ mdate.toISOString() }</span>]}>
-      { timestamp }
+      <span>{ timestamp }</span>
     </Tooltip>
   </div>;
 });


### PR DESCRIPTION
Before:
<img width="1323" alt="Screen Shot 2019-08-16 at 2 06 44 PM" src="https://user-images.githubusercontent.com/895728/63188394-424f4d00-c02f-11e9-979c-302c66d507c2.png">

After:
<img width="1329" alt="Screen Shot 2019-08-16 at 2 06 55 PM" src="https://user-images.githubusercontent.com/895728/63188399-48452e00-c02f-11e9-9be3-3e20baa88f35.png">
