### PR TITLE
Don't use AsyncComponent PF3 Switch

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/create-operand.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/create-operand.tsx
@@ -6,6 +6,7 @@ import { safeDump } from 'js-yaml';
 import * as _ from 'lodash-es';
 import { PropertyPath } from 'lodash';
 import * as classNames from 'classnames';
+import { Switch } from 'patternfly-react';
 import { Alert, ActionGroup, Button } from '@patternfly/react-core';
 import { JSONSchema6TypeName } from 'json-schema';
 
@@ -27,7 +28,7 @@ import {
 import { ClusterServiceVersionKind, referenceForProvidedAPI, providedAPIsFor, CRDDescription, ClusterServiceVersionLogo, APIServiceDefinition } from './index';
 import { ClusterServiceVersionModel, CustomResourceDefinitionModel } from '../../models';
 import { Firehose } from '../utils/firehose';
-import { NumberSpinner, StatusBox, BreadCrumbs, history, SelectorInput, ListDropdown, AsyncComponent, resourcePathFromModel, FirehoseResult, useScrollToTopOnMount } from '../utils';
+import { NumberSpinner, StatusBox, BreadCrumbs, history, SelectorInput, ListDropdown, resourcePathFromModel, FirehoseResult, useScrollToTopOnMount } from '../utils';
 import { SpecCapability, StatusCapability, Descriptor } from './descriptors/types';
 import { ResourceRequirements } from './descriptors/spec/resource-requirements';
 import { RootState } from '../../redux';
@@ -330,8 +331,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
         onChange={({currentTarget}) => setFormValues(values => ({...values, [field.path]: currentTarget.checked}))} />;
     }
     if (field.capabilities.includes(SpecCapability.booleanSwitch)) {
-      return <AsyncComponent
-        loader={() => import('patternfly-react').then(m => m.Switch)}
+      return <Switch
         value={formValues[field.path]}
         onChange={(el, val) => setFormValues(values => ({...values, [field.path]: val}))}
         onText="True"

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
@@ -2,12 +2,13 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Map as ImmutableMap } from 'immutable';
 import { Tooltip } from '@patternfly/react-core';
+import { Switch } from 'patternfly-react';
 
 import { SpecCapability, DescriptorProps, CapabilityProps } from '../types';
 import { ResourceRequirementsModalLink } from './resource-requirements';
 import { EndpointList } from './endpoint';
 import { configureSizeModal } from './configure-size';
-import { Selector, ResourceLink, LoadingInline, AsyncComponent } from '../../../utils';
+import { Selector, ResourceLink, LoadingInline } from '../../../utils';
 import { k8sPatch } from '../../../../module/k8s';
 import { YellowExclamationTriangleIcon } from '@console/shared';
 
@@ -55,8 +56,7 @@ const BooleanSwitch: React.FC<SpecCapabilityProps> = (props) => {
   };
 
   return <div className="co-spec-descriptor--switch">
-    <AsyncComponent
-      loader={() => import('patternfly-react').then(m => m.Switch)}
+    <Switch
       value={value}
       onChange={(el, val) => {
         setValue(val);


### PR DESCRIPTION
This creates a separate bundle with all of PF3 and breaks tree-shaking.
Removing the AsyncComponent doesn't increase the main vendor bundle size.

Here is the PF3 chunk that this change removes:

<img width="381" alt="Screen Shot 2019-08-17 at 10 12 30 AM" src="https://user-images.githubusercontent.com/1167259/63213748-12ab4e00-c0de-11e9-90e6-e42a3502bc6b.png">

Credit to @redallen for tracking this down!

/cc @alecmerdler @redallen