### PR TITLE
apiExplorer: add spacing between dropdown components

### DIFF
--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -224,6 +224,7 @@ const APIResourcesList = compose(withRouter, connect<APIResourcesListPropsFromSt
           selectedKey={groupFilter}
           spacerBefore={groupSpacer}
           title={groupOptions[groupFilter]}
+          className="btn-group"
         />
         <Dropdown
           items={versionOptions}
@@ -231,6 +232,7 @@ const APIResourcesList = compose(withRouter, connect<APIResourcesListPropsFromSt
           selectedKey={versionFilter}
           spacerBefore={versionSpacer}
           title={versionOptions[versionFilter]}
+          className="btn-group"
         />
       </div>
       <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--filter">


### PR DESCRIPTION
Fix: https://github.com/openshift/console/issues/2384

<img width="297" alt="Screen Shot 2019-08-17 at 5 24 33 PM" src="https://user-images.githubusercontent.com/35978579/63217393-ea3e4680-c113-11e9-970a-58ca56e5216e.png">
