### PR TITLE
(apiExplorer): add override to align vertically to top

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -397,6 +397,10 @@ kbd {
   vertical-align: top;
 }
 
+.pf-c-table.pf-m-compact tr > td {
+  vertical-align: top;
+}
+
 .pf-c-table.pf-c-virtualized tr.vertical-align-middle > td {
   vertical-align: middle;
 }

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -393,12 +393,11 @@ kbd {
 }
 
 // override .co-m-table-grid [class*='col-'], .co-m-table-grid .row
-.pf-c-table.pf-c-virtualized tr > td {
-  vertical-align: top;
-}
-
-.pf-c-table.pf-m-compact tr > td {
-  vertical-align: top;
+.pf-c-table.pf-m-compact,
+.pf-c-table.pf-c-virtualized {
+  tr > td {
+    vertical-align: top;
+  }
 }
 
 .pf-c-table.pf-c-virtualized tr.vertical-align-middle > td {


### PR DESCRIPTION
Fix issue: https://github.com/openshift/console/issues/2386

<img width="885" alt="Screen Shot 2019-08-17 at 6 11 33 PM" src="https://user-images.githubusercontent.com/35978579/63217783-7eaba780-c11a-11e9-9e9a-262007f5981d.png">
