### PR TITLE
Bug 1742952: Handle ClusterResourceQuota as a CRD

### DIFF
--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -272,7 +272,7 @@ export const ResourceQuotasPage = connectToFlags(FLAGS.OPENSHIFT)(({namespace, f
     return <LoadingBox />;
   }
   if (flags[FLAGS.OPENSHIFT]) {
-    resources.push({kind: 'ClusterResourceQuota', namespaced: false, optional: true});
+    resources.push({kind: referenceForModel(ClusterResourceQuotaModel), namespaced: false, optional: true});
     rowFilters = [{
       type: 'role-kind',
       selected: ['cluster', 'namespace'],

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -626,6 +626,7 @@ export const ClusterResourceQuotaModel: K8sKind = {
   kind: 'ClusterResourceQuota',
   id: 'clusterresourcequota',
   labelPlural: 'Cluster Resource Quotas',
+  crd: true,
 };
 
 export const NetworkPolicyModel: K8sKind = {


### PR DESCRIPTION
`ClusterResourceQuota` was converted to a CRD sometime after the initial console implementation was added.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1742952

/assign @alecmerdler 