### PR TITLE
Migrate copy to clipboard tooltip to PF4

### DIFF
--- a/frontend/__tests__/components/utils/copy-to-clipboard.spec.tsx
+++ b/frontend/__tests__/components/utils/copy-to-clipboard.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
-import { Tooltip } from 'react-lightweight-tooltip';
+import { Tooltip } from '@patternfly/react-core';
 import { CopyToClipboard as CTC } from 'react-copy-to-clipboard';
 
 import { CopyToClipboard, CopyToClipboardProps } from '../../../public/components/utils/copy-to-clipboard';

--- a/frontend/public/components/utils/copy-to-clipboard.tsx
+++ b/frontend/public/components/utils/copy-to-clipboard.tsx
@@ -1,49 +1,10 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { CopyToClipboard as CTC } from 'react-copy-to-clipboard';
-import { Tooltip } from 'react-lightweight-tooltip';
+import { Tooltip } from '@patternfly/react-core';
 import { PasteIcon } from '@patternfly/react-icons';
 
 export const CopyToClipboard: React.FC<CopyToClipboardProps> = React.memo((props) => {
-  const overrides = Object.freeze({
-    wrapper: {
-      position: 'absolute',
-      right: '0',
-      top: '0',
-      height: '42px',
-      padding: '0',
-    } as React.CSSProperties,
-    tooltip: {
-      position: 'absolute',
-      right: '55px',
-      bottom: '-6px',
-      left: 'auto',
-      maxWidth: '170px',
-      minWidth: 'auto',
-      padding: '0',
-      textAlign: 'center',
-      width: 'auto',
-      transform: 'translateX(0px)',
-    } as React.CSSProperties,
-    content: {
-      display: 'block',
-      fontFamily: '"Open Sans",Helvetica,Arial,sans-serif',
-      fontSize: '12px',
-      padding: '7px 12px',
-      whiteSpace: 'normal',
-    } as React.CSSProperties,
-    arrow: {
-      position: 'absolute',
-      bottom: '8px',
-      right: '-13px',
-      left: 'auto',
-      borderTop: '8px solid transparent',
-      borderBottom: '8px solid transparent',
-      borderLeft: '8px solid #000',
-    } as React.CSSProperties,
-    gap: {},
-  });
-
   const [copied, setCopied] = React.useState(false);
 
   const tooltipText = copied ? 'Copied' : 'Copy to Clipboard';
@@ -54,7 +15,7 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = React.memo((props
 
   return <div className="co-copy-to-clipboard">
     <pre className="co-pre-wrap co-copy-to-clipboard__text">{visibleValue}</pre>
-    <Tooltip content={tooltipContent} styles={overrides}>
+    <Tooltip content={tooltipContent} trigger="click mouseenter focus" exitDelay={1250}>
       <CTC text={props.value} onCopy={() => setCopied(true)}>
         <button onMouseEnter={() => setCopied(false)} className="btn btn-default co-copy-to-clipboard__btn fix" type="button">
           <PasteIcon />


### PR DESCRIPTION
Partially fixes https://jira.coreos.com/browse/CONSOLE-1011

Note the behavior of the tooltip differs slightly as a result of this update.  After clicking the copy button, the tooltip fades out after 1250ms (see screenshot below).  Before the tooltip persisted after clicking the copy button.

![DYHyz58SRb](https://user-images.githubusercontent.com/895728/63273822-aa3ea700-c26c-11e9-8dea-8c88e813db93.gif)
