### PR TITLE
Query Browser: Move queries state to redux

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -25,6 +25,15 @@ export enum ActionType {
   SetCurrentLocation = 'setCurrentLocation',
   SetMonitoringData = 'setMonitoringData',
   ToggleMonitoringGraphs = 'monitoringToggleGraphs',
+  QueryBrowserAddQuery = 'queryBrowserAddQuery',
+  QueryBrowserDeleteAllQueries = 'queryBrowserDeleteAllQueries',
+  QueryBrowserDeleteQuery = 'queryBrowserDeleteQuery',
+  QueryBrowserInsertText = 'queryBrowserInsertText',
+  QueryBrowserPatchQuery = 'queryBrowserPatchQuery',
+  QueryBrowserRunQueries = 'queryBrowserRunQueries',
+  QueryBrowserSetAllExpanded = 'queryBrowserSetAllExpanded',
+  QueryBrowserSetMetrics = 'queryBrowserSetMetrics',
+  QueryBrowserToggleIsEnabled = 'queryBrowserToggleIsEnabled',
   SetUser = 'setUser',
   SortList = 'sortList',
   BeginImpersonate = 'beginImpersonate',
@@ -202,6 +211,21 @@ export const monitoringLoading = (key: 'alerts' | 'silences') => action(ActionTy
 export const monitoringLoaded = (key: 'alerts' | 'silences', data: any) => action(ActionType.SetMonitoringData, {key, data: {loaded: true, loadError: null, data}});
 export const monitoringErrored = (key: 'alerts' | 'silences', loadError: any) => action(ActionType.SetMonitoringData, {key, data: {loaded: true, loadError, data: null}});
 export const monitoringToggleGraphs = () => action(ActionType.ToggleMonitoringGraphs);
+export const queryBrowserAddQuery = () => action(ActionType.QueryBrowserAddQuery);
+export const queryBrowserDeleteAllQueries = () => action(ActionType.QueryBrowserDeleteAllQueries);
+export const queryBrowserDeleteQuery = (index: number) => action(ActionType.QueryBrowserDeleteQuery, {index});
+export const queryBrowserInsertText = (index: number, newText: string, replaceFrom: number, replaceTo: number) => {
+  return action(ActionType.QueryBrowserInsertText, {index, newText, replaceFrom, replaceTo});
+};
+export const queryBrowserPatchQuery = (index: number, patch: {[key: string]: unknown}) => {
+  return action(ActionType.QueryBrowserPatchQuery, {index, patch});
+};
+export const queryBrowserRunQueries = () => action(ActionType.QueryBrowserRunQueries);
+export const queryBrowserSetAllExpanded = (isExpanded: boolean) => {
+  return action(ActionType.QueryBrowserSetAllExpanded, {isExpanded});
+};
+export const queryBrowserSetMetrics = (metrics: string[]) => action(ActionType.QueryBrowserSetMetrics, {metrics});
+export const queryBrowserToggleIsEnabled = (index: number) => action(ActionType.QueryBrowserToggleIsEnabled, {index});
 export const setConsoleLinks = (consoleLinks: string[]) => action(ActionType.SetConsoleLinks, {consoleLinks});
 
 // TODO(alecmerdler): Implement all actions using `typesafe-actions` and add them to this export
@@ -228,6 +252,15 @@ const uiActions = {
   monitoringLoaded,
   monitoringErrored,
   monitoringToggleGraphs,
+  queryBrowserAddQuery,
+  queryBrowserDeleteAllQueries,
+  queryBrowserDeleteQuery,
+  queryBrowserInsertText,
+  queryBrowserPatchQuery,
+  queryBrowserRunQueries,
+  queryBrowserSetAllExpanded,
+  queryBrowserSetMetrics,
+  queryBrowserToggleIsEnabled,
   setConsoleLinks,
 };
 

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -78,11 +78,6 @@
   }
 }
 
-.query-browser__no-data-warning {
-  border-bottom: solid 1px $color-grey-background-border;
-  padding: 10px 20px;
-}
-
 .query-browser__query {
   line-height: 1;
   margin: 0 15px;
@@ -151,6 +146,11 @@
 .query-browser__table-cell {
   @include co-break-word;
   padding-right: 0 !important;
+}
+
+.query-browser__table-message {
+  border-bottom: solid 1px $color-grey-background-border;
+  padding: 10px 20px;
 }
 
 $tooltip-background-color: #151515;


### PR DESCRIPTION
Move the queries data from component state to redux.

Fixes: https://jira.coreos.com/browse/MON-746

Also improves performance of a number of actions by eliminating
re-renders of intermediate components when only the child component has
actually changed. Some components were broken into smaller components to
better take advantage of this.