### PR TITLE
 Persistent storage dashboard : Added changes to set correct ceph cluster name in health card

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/health-card/health-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/health-card/health-card.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import {
   AlertsBody,
   AlertItem,
@@ -15,9 +16,21 @@ import {
 import { HealthBody } from '@console/internal/components/dashboard/health-card/health-body';
 import { HealthItem } from '@console/internal/components/dashboard/health-card/health-item';
 import { HealthState } from '@console/internal/components/dashboard/health-card/states';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { FirehoseResource } from '@console/internal/components/utils';
+import { CephClusterModel } from '../../../../models';
+import { CEPH_STORAGE_NAMESPACE } from '../../../../constants/index';
 import { STORAGE_HEALTH_QUERIES, StorageDashboardQuery } from '../../../../constants/queries';
 import { filterCephAlerts } from '../../../../selectors';
 import { getCephHealthState } from './utils';
+
+const cephClusterResource: FirehoseResource = {
+  kind: referenceForModel(CephClusterModel),
+  namespaced: true,
+  namespace: CEPH_STORAGE_NAMESPACE,
+  isList: true,
+  prop: 'ceph',
+};
 
 const HealthCard: React.FC<DashboardItemProps> = ({
   watchPrometheus,
@@ -26,22 +39,36 @@ const HealthCard: React.FC<DashboardItemProps> = ({
   watchAlerts,
   stopWatchAlerts,
   alertsResults,
+  resources,
+  watchK8sResource,
+  stopWatchK8sResource,
 }) => {
   React.useEffect(() => {
     watchAlerts();
+    watchK8sResource(cephClusterResource);
     watchPrometheus(STORAGE_HEALTH_QUERIES[StorageDashboardQuery.CEPH_STATUS_QUERY]);
     return () => {
       stopWatchAlerts();
+      stopWatchK8sResource(cephClusterResource);
       stopWatchPrometheusQuery(STORAGE_HEALTH_QUERIES[StorageDashboardQuery.CEPH_STATUS_QUERY]);
     };
-  }, [watchPrometheus, stopWatchPrometheusQuery, watchAlerts, stopWatchAlerts]);
+  }, [
+    watchK8sResource,
+    stopWatchK8sResource,
+    watchPrometheus,
+    stopWatchPrometheusQuery,
+    watchAlerts,
+    stopWatchAlerts,
+  ]);
 
   const queryResult = prometheusResults.getIn([
     STORAGE_HEALTH_QUERIES[StorageDashboardQuery.CEPH_STATUS_QUERY],
     'result',
   ]);
 
-  const cephHealthState = getCephHealthState(queryResult);
+  const cephCluster = _.get(resources, 'ceph');
+  const cephHealthState = getCephHealthState(queryResult, cephCluster);
+
   const alerts = filterCephAlerts(getAlerts(alertsResults));
 
   return (

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/health-card/health-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/health-card/health-card.tsx
@@ -16,21 +16,10 @@ import {
 import { HealthBody } from '@console/internal/components/dashboard/health-card/health-body';
 import { HealthItem } from '@console/internal/components/dashboard/health-card/health-item';
 import { HealthState } from '@console/internal/components/dashboard/health-card/states';
-import { referenceForModel } from '@console/internal/module/k8s';
-import { FirehoseResource } from '@console/internal/components/utils';
-import { CephClusterModel } from '../../../../models';
-import { CEPH_STORAGE_NAMESPACE } from '../../../../constants/index';
 import { STORAGE_HEALTH_QUERIES, StorageDashboardQuery } from '../../../../constants/queries';
 import { filterCephAlerts } from '../../../../selectors';
+import { cephClusterResource } from '../../../../constants/resources';
 import { getCephHealthState } from './utils';
-
-const cephClusterResource: FirehoseResource = {
-  kind: referenceForModel(CephClusterModel),
-  namespaced: true,
-  namespace: CEPH_STORAGE_NAMESPACE,
-  isList: true,
-  prop: 'ceph',
-};
 
 const HealthCard: React.FC<DashboardItemProps> = ({
   watchPrometheus,

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/health-card/utils.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/health-card/utils.ts
@@ -24,7 +24,7 @@ const CephHealthStatus = [
 ];
 
 export const getCephHealthState = (ocsResponse, cephCluster): CephHealth => {
-  if (!ocsResponse) {
+  if (!ocsResponse || !_.get(cephCluster, 'loaded')) {
     return { state: HealthState.LOADING };
   }
   const value = _.get(ocsResponse, 'data.result[0].value[1]');

--- a/frontend/packages/ceph-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/index.ts
@@ -1,7 +1,7 @@
-export const CEPH_HEALTHY = 'Ceph is healthy';
-export const CEPH_DEGRADED = 'Ceph health is degraded';
-export const CEPH_ERROR = 'Ceph health is in error state';
-export const CEPH_UNKNOWN = 'Ceph is not available';
+export const CEPH_HEALTHY = 'is healthy';
+export const CEPH_DEGRADED = 'health is degraded';
+export const CEPH_ERROR = 'health is in error state';
+export const CEPH_UNKNOWN = 'is not available';
 export const CEPH_STORAGE_NAMESPACE = 'openshift-storage';
 export const ONE_HR = '1 Hour';
 export const SIX_HR = '6 Hours';

--- a/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
@@ -1,12 +1,10 @@
 import { FirehoseResource } from '@console/internal/components/utils/index';
 import { referenceForModel } from '@console/internal/module/k8s/k8s';
 import { CephClusterModel } from '../models';
-import { CEPH_STORAGE_NAMESPACE } from './index';
 
-const cephClusterResource: FirehoseResource = {
+export const cephClusterResource: FirehoseResource = {
   kind: referenceForModel(CephClusterModel),
-  namespaced: true,
-  namespace: CEPH_STORAGE_NAMESPACE,
+  namespaced: false,
   isList: true,
   prop: 'ceph',
 };

--- a/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
@@ -1,0 +1,19 @@
+import { FirehoseResource } from '@console/internal/components/utils/index';
+import { referenceForModel } from '@console/internal/module/k8s/k8s';
+import { CephClusterModel } from '../models';
+import { CEPH_STORAGE_NAMESPACE } from './index';
+
+const cephClusterResource: FirehoseResource = {
+  kind: referenceForModel(CephClusterModel),
+  namespaced: true,
+  namespace: CEPH_STORAGE_NAMESPACE,
+  isList: true,
+  prop: 'ceph',
+};
+export enum StorageDashboardResource {
+  CEPH_CLUSTER_RESOURCE = 'CEPH_CLUSTER_RESOURCE',
+}
+
+export const STORAGE_HEALTH_RESOURCES = {
+  [StorageDashboardResource.CEPH_CLUSTER_RESOURCE]: cephClusterResource,
+};

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -16,6 +16,7 @@ import {
   StorageDashboardQuery,
   STORAGE_HEALTH_QUERIES,
 } from './constants/queries';
+import { STORAGE_HEALTH_RESOURCES, StorageDashboardResource } from './constants/resources';
 import { getCephHealthState } from './components/dashboard-page/storage-dashboard/health-card/utils';
 
 type ConsumedExtensions =
@@ -156,6 +157,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       title: 'Storage',
       query: STORAGE_HEALTH_QUERIES[StorageDashboardQuery.CEPH_STATUS_QUERY],
+      resource: STORAGE_HEALTH_RESOURCES[StorageDashboardResource.CEPH_CLUSTER_RESOURCE],
       healthHandler: getCephHealthState,
       required: CEPH_FLAG,
     },


### PR DESCRIPTION
Signed-off-by: Anmol Sachan <anmol13694@gmail.com>

**When both cluster name and cluster health status are available:**
![Screenshot from 2019-08-21 00-25-42](https://user-images.githubusercontent.com/8753636/63379687-7077b880-c3b2-11e9-9227-bc0f91ca6114.png)

**When cluster name is available but health status is not available:**
![Screenshot from 2019-08-21 00-20-56](https://user-images.githubusercontent.com/8753636/63379716-82595b80-c3b2-11e9-892f-cc54002aa2e2.png)

**When both cluster name and health status are unavailable:**
![Screenshot from 2019-08-21 00-20-37](https://user-images.githubusercontent.com/8753636/63379740-91400e00-c3b2-11e9-9bf2-6661594b6d7c.png)
