### PR TITLE
Add skeleton for the network attachment definition plugin

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/OWNERS
+++ b/frontend/packages/network-attachment-definition-plugin/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - pcbailey
+  - mareklibra
+  - rawagner
+approvers:
+  - pcbailey
+  - mareklibra
+  - rawagner
+labels:
+  - component/network-attachment-definition

--- a/frontend/packages/network-attachment-definition-plugin/package.json
+++ b/frontend/packages/network-attachment-definition-plugin/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@console/network-attachment-definition-plugin",
+  "version": "0.0.0-fixed",
+  "description": "Network attachment definition add-on",
+  "private": true,
+  "dependencies": {
+    "@console/plugin-sdk": "0.0.0-fixed",
+    "@console/shared": "0.0.0-fixed",
+    "@console/internal": "0.0.0-fixed"
+  },
+  "consolePlugin": {
+    "entry": "src/plugin.ts"
+  }
+}


### PR DESCRIPTION
This PR adds the skeleton for the network attachment definition plugin.

@spadgett Could you please review?