### PR TITLE
Align Import Flows according to UX to fix inconsistencies

### DIFF
--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -8,7 +8,6 @@ import ImageSearchSection from './image-search/ImageSearchSection';
 import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
-import RouteCheckbox from './route/RouteCheckbox';
 
 export interface DeployImageFormProps {
   builderImages?: NormalizedBuilderImages;
@@ -27,7 +26,6 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
     <ImageSearchSection />
     <AppSection project={values.project} />
     <ServerlessSection />
-    <RouteCheckbox />
     <AdvancedSection values={values} />
     <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
       <ActionGroup className="pf-c-form">

--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -9,7 +9,6 @@ import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
 import RouteCheckbox from './route/RouteCheckbox';
-import FormSectionDivider from './section/FormSectionDivider';
 
 export interface DeployImageFormProps {
   builderImages?: NormalizedBuilderImages;
@@ -25,10 +24,8 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
   dirty,
 }) => (
   <Form className="co-deploy-image" onSubmit={handleSubmit}>
-    <AppSection project={values.project} />
-    <FormSectionDivider />
     <ImageSearchSection />
-    <FormSectionDivider />
+    <AppSection project={values.project} />
     <ServerlessSection />
     <RouteCheckbox />
     <AdvancedSection values={values} />

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -9,7 +9,6 @@ import BuilderSection from './builder/BuilderSection';
 import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
-import RouteCheckbox from './route/RouteCheckbox';
 import DockerSection from './git/DockerSection';
 
 const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = ({
@@ -28,7 +27,6 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
     <DockerSection buildStrategy={values.build.strategy} />
     <AppSection project={values.project} />
     <ServerlessSection />
-    <RouteCheckbox />
     <AdvancedSection values={values} />
     <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
       <ActionGroup className="pf-c-form">

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -11,7 +11,6 @@ import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
 import RouteCheckbox from './route/RouteCheckbox';
 import DockerSection from './git/DockerSection';
-import FormSectionDivider from './section/FormSectionDivider';
 
 const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = ({
   values,
@@ -25,12 +24,10 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
 }) => (
   <Form onSubmit={handleSubmit}>
     <GitSection />
-    <DockerSection buildStrategy={values.build.strategy} />
-    <FormSectionDivider />
-    <AppSection project={values.project} />
-    <FormSectionDivider />
-    <ServerlessSection />
     <BuilderSection image={values.image} builderImages={builderImages} />
+    <DockerSection buildStrategy={values.build.strategy} />
+    <AppSection project={values.project} />
+    <ServerlessSection />
     <RouteCheckbox />
     <AdvancedSection values={values} />
     <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>

--- a/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
@@ -10,7 +10,6 @@ import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
 import RouteCheckbox from './route/RouteCheckbox';
-import FormSectionDivider from './section/FormSectionDivider';
 
 const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormProps> = ({
   values,
@@ -23,12 +22,10 @@ const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormP
   dirty,
 }) => (
   <Form onSubmit={handleSubmit}>
-    <AppSection project={values.project} />
-    <FormSectionDivider />
-    <ServerlessSection />
     <BuilderSection image={values.image} builderImages={builderImages} />
     <GitSection showSample />
-    <FormSectionDivider />
+    <AppSection project={values.project} />
+    <ServerlessSection />
     <RouteCheckbox />
     <AdvancedSection values={values} />
     <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>

--- a/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
@@ -9,7 +9,6 @@ import BuilderSection from './builder/BuilderSection';
 import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
-import RouteCheckbox from './route/RouteCheckbox';
 
 const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormProps> = ({
   values,
@@ -26,7 +25,6 @@ const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormP
     <GitSection showSample />
     <AppSection project={values.project} />
     <ServerlessSection />
-    <RouteCheckbox />
     <AdvancedSection values={values} />
     <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
       <ActionGroup className="pf-c-form">

--- a/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
@@ -4,6 +4,8 @@ import ProgressiveList from '../../progressive-list/ProgressiveList';
 import ProgressiveListItem from '../../progressive-list/ProgressiveListItem';
 import RouteSection from '../route/RouteSection';
 import ServerlessRouteSection from '../serverless/ServerlessRouteSection';
+import FormSection from '../section/FormSection';
+import RouteCheckbox from '../route/RouteCheckbox';
 import LabelSection from './LabelSection';
 import ScalingSection from './ScalingSection';
 import ServerlessScalingSection from './ServerlessScalingSection';
@@ -22,40 +24,43 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({ values }) => {
   };
 
   return (
-    <ProgressiveList
-      text="Go to Advanced Options for"
-      visibleItems={visibleItems}
-      onVisibleItemChange={handleVisibleItemChange}
-    >
-      <ProgressiveListItem name="Routing">
-        {values.serverless.enabled ? (
-          <ServerlessRouteSection route={values.route} />
-        ) : (
-          <RouteSection route={values.route} />
+    <FormSection title="Advanced Options" fullWidth>
+      <RouteCheckbox />
+      <ProgressiveList
+        text="Click on the names to access advanced options for"
+        visibleItems={visibleItems}
+        onVisibleItemChange={handleVisibleItemChange}
+      >
+        <ProgressiveListItem name="Routing">
+          {values.serverless.enabled ? (
+            <ServerlessRouteSection route={values.route} />
+          ) : (
+            <RouteSection route={values.route} />
+          )}
+        </ProgressiveListItem>
+        {/* Hide Build for Deploy Image */}
+        {values.isi ? null : (
+          <ProgressiveListItem name="Build Configuration">
+            <BuildConfigSection namespace={values.project.name} />
+          </ProgressiveListItem>
         )}
-      </ProgressiveListItem>
-      {/* Hide Build for Deploy Image */}
-      {values.isi ? null : (
-        <ProgressiveListItem name="Build Configuration">
-          <BuildConfigSection namespace={values.project.name} />
+        {/* Hide Deployment for Serverless */}
+        {values.serverless.enabled ? null : (
+          <ProgressiveListItem name="Deployment Configuration">
+            <DeploymentConfigSection namespace={values.project.name} />
+          </ProgressiveListItem>
+        )}
+        <ProgressiveListItem name="Scaling">
+          {values.serverless.enabled ? <ServerlessScalingSection /> : <ScalingSection />}
         </ProgressiveListItem>
-      )}
-      {/* Hide Deployment for Serverless */}
-      {values.serverless.enabled ? null : (
-        <ProgressiveListItem name="Deployment Configuration">
-          <DeploymentConfigSection namespace={values.project.name} />
+        <ProgressiveListItem name="Resource Limits">
+          <ResourceLimitSection />
         </ProgressiveListItem>
-      )}
-      <ProgressiveListItem name="Scaling">
-        {values.serverless.enabled ? <ServerlessScalingSection /> : <ScalingSection />}
-      </ProgressiveListItem>
-      <ProgressiveListItem name="Resource Limits">
-        <ResourceLimitSection />
-      </ProgressiveListItem>
-      <ProgressiveListItem name="Labels">
-        <LabelSection />
-      </ProgressiveListItem>
-    </ProgressiveList>
+        <ProgressiveListItem name="Labels">
+          <LabelSection />
+        </ProgressiveListItem>
+      </ProgressiveList>
+    </FormSection>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/import/git/DockerSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/DockerSection.tsx
@@ -9,7 +9,7 @@ export interface DockerSectionProps {
 
 const DockerSection: React.FC<DockerSectionProps> = ({ buildStrategy }) =>
   buildStrategy === 'Docker' && (
-    <FormSection title="Docker">
+    <FormSection title="Dockerfile">
       <InputField
         type={TextInputTypes.text}
         name="docker.dockerfilePath"

--- a/frontend/packages/dev-console/src/components/import/serverless/ServerlessSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless/ServerlessSection.tsx
@@ -14,7 +14,7 @@ const ServerlessSection: React.FC<ServerlessSectionProps> = ({ flags }) => {
   if (flags[FLAG_KNATIVE_SERVING]) {
     const title = (
       <Split gutter="md">
-        <SplitItem>Serverless Options</SplitItem>
+        <SplitItem>Serverless</SplitItem>
         <SplitItem>
           <TechPreviewBadge />
         </SplitItem>

--- a/frontend/packages/dev-console/src/components/import/serverless/ServerlessSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless/ServerlessSection.tsx
@@ -14,7 +14,7 @@ const ServerlessSection: React.FC<ServerlessSectionProps> = ({ flags }) => {
   if (flags[FLAG_KNATIVE_SERVING]) {
     const title = (
       <Split gutter="md">
-        <SplitItem>Serverless</SplitItem>
+        <SplitItem className="odc-form-section__heading">Serverless</SplitItem>
         <SplitItem>
           <TechPreviewBadge />
         </SplitItem>

--- a/frontend/packages/dev-console/src/components/progressive-list/ProgressiveList.tsx
+++ b/frontend/packages/dev-console/src/components/progressive-list/ProgressiveList.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import FormSectionDivider from '../import/section/FormSectionDivider';
 import ProgressiveListFooter from './ProgressiveListFooter';
 import ProgressiveListItem from './ProgressiveListItem';
 import './ProgressiveList.scss';
@@ -28,10 +27,9 @@ const ProgressiveList: React.FC<ProgressiveListProps> = ({
   );
   return (
     <React.Fragment>
-      {visibleItems.map((item: string, index: number) => (
+      {visibleItems.map((item: string) => (
         <React.Fragment key={item}>
           {validChildren.find(({ props }: React.ReactElement) => item === props.name)}
-          {index !== validChildren.length - 1 && <FormSectionDivider />}
         </React.Fragment>
       ))}
       <ProgressiveListFooter text={text} items={items} onShowItem={onVisibleItemChange} />


### PR DESCRIPTION
Fixes Bugs -
- https://jira.coreos.com/browse/ODC-1554
- https://jira.coreos.com/browse/ODC-1555
- https://jira.coreos.com/browse/ODC-1556
- https://jira.coreos.com/browse/ODC-1557

This PR - 
- Changes the order of form sections in all the import flows based on the latest UX designs.
- Removes `options` word from titles of form sections.
- Makes advanced options list a form section with `Advanced` title.
- Move route checkbox into advanced form section.
- Remove all the form section dividers.

Screens - 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/6041994/63350679-81f19e00-c37b-11e9-8eca-7744153f1d18.gif)

cc: @serenamarie125 @parvathyvr 
