### PR TITLE
fix(table): table overlapping issue

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -332,7 +332,7 @@ export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TablePro
       this._columnShift = props.onSelect ? 1 : 0; //shift indexes by 1 if select provided
       this._applySort = this._applySort.bind(this);
       this._onSort = this._onSort.bind(this);
-      this._handleResize = this._handleResize.bind(this);
+      this._handleResize = _.debounce(this._handleResize.bind(this), 100);
       this._bindBodyRef = this._bindBodyRef.bind(this);
       this._refreshGrid = this._refreshGrid.bind(this);
 


### PR DESCRIPTION
Fix [CONSOLE-1559](https://jira.coreos.com/browse/CONSOLE-1559).

Firing the `handleResize` event too quickly, or too often, can lead to false grid sizing as seen when resizing on the Role Bindings screen. We should throttle the window resize event to prevent this.