### PR TITLE
Switch from height to minHeight for empty state to prevent overflow issue

### DIFF
--- a/frontend/public/components/graphs/graph-empty.tsx
+++ b/frontend/public/components/graphs/graph-empty.tsx
@@ -3,7 +3,7 @@ import { ChartAreaIcon } from '@patternfly/react-icons';
 import { EmptyStateIcon, EmptyState, EmptyStateVariant, Title } from '@patternfly/react-core';
 import { LoadingBox } from '../utils';
 
-export const GraphEmpty: React.FC<GraphEmptyProps> = ({height = 180, icon = ChartAreaIcon, loading = false}) => <div style={{height, width: '100%'}} >
+export const GraphEmpty: React.FC<GraphEmptyProps> = ({height = 180, icon = ChartAreaIcon, loading = false}) => <div style={{minHeight:height, width: '100%'}} >
   {
     loading ? <LoadingBox /> : (
       <EmptyState className="graph-empty-state" variant={EmptyStateVariant.full}>


### PR DESCRIPTION
The explicit height was preventing the container to grow if necessary. 

Fixes
https://jira.coreos.com/browse/CONSOLE-1689 and
https://jira.coreos.com/browse/CONSOLE-1690

<img width="1666" alt="Screen Shot 2019-08-20 at 10 59 03 AM" src="https://user-images.githubusercontent.com/1874151/63359673-230c3480-c33b-11e9-98a0-bef44af7de68.png">
