### PR TITLE
Remove the namespace parameter from cephClusterResource in details card

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/details-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/details-card.tsx
@@ -16,7 +16,6 @@ import { K8sResourceKind } from '@console/internal/module/k8s/index';
 import { getName } from '@console/shared/src/selectors/common';
 import { referenceForModel } from '@console/internal/module/k8s/k8s';
 import { CephClusterModel } from '../../../models';
-import { CEPH_STORAGE_NAMESPACE } from '../../../constants/index';
 
 const getInfrastructurePlatform = (infrastructure: K8sResourceKind): string =>
   _.get(infrastructure, 'status.platform');
@@ -34,8 +33,6 @@ const infrastructureResource: FirehoseResource = {
 
 const cephClusterResource: FirehoseResource = {
   kind: referenceForModel(CephClusterModel),
-  namespaced: true,
-  namespace: CEPH_STORAGE_NAMESPACE,
   isList: true,
   prop: 'ceph',
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/details-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/details-card.tsx
@@ -33,6 +33,7 @@ const infrastructureResource: FirehoseResource = {
 
 const cephClusterResource: FirehoseResource = {
   kind: referenceForModel(CephClusterModel),
+  namespaced: false,
   isList: true,
   prop: 'ceph',
 };


### PR DESCRIPTION
/assign @cloudbehl 
This PR removes hard-coded namespace from Storage details since rook doesn't care about the namespace.