### PR TITLE
fix loading of builder-image for non-admin

### DIFF
--- a/frontend/packages/dev-console/src/components/import/ImportPage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportPage.tsx
@@ -65,6 +65,7 @@ const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match, location 
         kind: ImageStreamModel.kind,
         prop: 'imageStreams',
         isList: true,
+        namespace: 'openshift',
       },
     ];
   }


### PR DESCRIPTION
This PR fixes: https://jira.coreos.com/browse/ODC-1388

![Screenshot from 2019-08-21 14-47-20](https://user-images.githubusercontent.com/22490998/63419521-9b99f080-c422-11e9-9e9e-20f03114d6a7.png)
