### PR TITLE
kubevirt: use correct path in dashboard URL

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -150,7 +150,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Dashboards/Overview/Health/URL',
     properties: {
       title: 'Virtualization',
-      url: `/apis/subresources.${models.VirtualMachineModel.apiGroup}/${
+      url: `apis/subresources.${models.VirtualMachineModel.apiGroup}/${
         models.VirtualMachineModel.apiVersion
       }/healthz`,
       healthHandler: getKubevirtHealthState,


### PR DESCRIPTION
The leading slash causes an extra `/` in the final URL.

/assign @rawagner 