### PR TITLE
Append service account CA with trusted-ca-bundle

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -43,6 +43,9 @@ const (
 var (
 	log = capnslog.NewPackageLogger("github.com/openshift/console", "auth")
 
+	// Default PEM certificate used for getting HTTP client.
+	defaultIssuerCA = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
 	// Cache HTTP clients to avoid recreating them for each request to the
 	// OAuth server. The key is the ca.crt bytes cast to a string and the
 	// value is a pointer to the http.Client. Keep two maps: one that
@@ -120,12 +123,17 @@ type Config struct {
 }
 
 func newHTTPClient(issuerCA string, includeSystemRoots bool) (*http.Client, error) {
-	if issuerCA == "" {
-		return http.DefaultClient, nil
-	}
-	data, err := ioutil.ReadFile(issuerCA)
+	data, err := ioutil.ReadFile(defaultIssuerCA)
 	if err != nil {
-		return nil, fmt.Errorf("load issuer CA file %s: %v", issuerCA, err)
+		return nil, fmt.Errorf("load default issuer CA file %s: %v", issuerCA, err)
+	}
+
+	if issuerCA != "" {
+		issuerData, err := ioutil.ReadFile(issuerCA)
+		if err != nil {
+			return nil, fmt.Errorf("load issuer CA file %s: %v", issuerCA, err)
+		}
+		data = append(data, issuerData...)
 	}
 
 	caKey := string(data)

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -118,10 +118,6 @@ func addAuth(fs *flag.FlagSet, auth *Auth) {
 		fs.Set("user-auth-oidc-client-secret-file", auth.ClientSecretFile)
 	}
 
-	if auth.OAuthEndpointCAFile != "" {
-		fs.Set("user-auth-oidc-ca-file", auth.OAuthEndpointCAFile)
-	}
-
 	if auth.LogoutRedirect != "" {
 		fs.Set("user-auth-logout-redirect", auth.LogoutRedirect)
 	}


### PR DESCRIPTION
Fixing issue with starting a console server using the [trustedCA bundle change](https://github.com/openshift/console-operator/pull/265). 
This change will use the service-account ca by default. If `trusted-ca-bundle` is set, it will be merged with the `ca.crt` content.

/assign @spadgett 