### PR TITLE
Fix use of eslint-disable for dependency array in useEffect for ProgressiveListItem

### DIFF
--- a/frontend/packages/dev-console/src/components/progressive-list/ProgressiveListItem.tsx
+++ b/frontend/packages/dev-console/src/components/progressive-list/ProgressiveListItem.tsx
@@ -5,12 +5,9 @@ export interface ProgressiveListItemProps {
 }
 
 const ProgressiveListItem: React.FC<ProgressiveListItemProps> = ({ children }) => {
-  const element = React.createRef<HTMLDivElement>();
+  const element = React.useRef<HTMLDivElement>();
   React.useEffect(() => {
     element.current.scrollIntoView({ behavior: 'smooth' });
-    // this effect needs to run only on first render that why dependency array is kept empty
-    // Error: React Hook React.useEffect has a missing dependency: 'element'. Either include it or remove the dependency array.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return <div ref={element}>{children}</div>;
 };


### PR DESCRIPTION
- This PR removes the use of `eslint-disable` in `useEffect` hook of `ProgressiveListItem`.