### PR TITLE
Bug 1741386: Fix area chart domain and handle single data points better

### DIFF
--- a/frontend/public/components/graphs/index.tsx
+++ b/frontend/public/components/graphs/index.tsx
@@ -41,3 +41,8 @@ export type DomainPadding = number | {
   x?: number | [number, number];
   y?: number | [number, number];
 }
+
+export type DomainPropType = {
+  x: [number, number];
+  y?: [number, number];
+};


### PR DESCRIPTION
Make the following improvements to the AreaChart component:
- Display a scatter plot rather than an area chart when only one data point exists
- When a timespan prop is provided, force area chart x-domain to cover the entire timespan
- Force y-domain to show meaningful values when all data values are zero. Previously, all y-axis tick labels would be zero in this case.
- When only one data point exists, force the y-domain upper bound to be twice the data value so that the point will fall near the vertical center of the graph. Previously it would always be at the very top which made it harder to see.

![image](https://user-images.githubusercontent.com/22625502/63519423-e9fdcc80-c4c0-11e9-83a1-0b42a8a0306c.png)

