### PR TITLE
Query Browser: Fix display of range vector queries in results table

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -34,6 +34,7 @@ export enum ActionType {
   QueryBrowserSetAllExpanded = 'queryBrowserSetAllExpanded',
   QueryBrowserSetMetrics = 'queryBrowserSetMetrics',
   QueryBrowserToggleIsEnabled = 'queryBrowserToggleIsEnabled',
+  QueryBrowserToggleSeries = 'queryBrowserToggleSeries',
   SetUser = 'setUser',
   SortList = 'sortList',
   BeginImpersonate = 'beginImpersonate',
@@ -226,6 +227,9 @@ export const queryBrowserSetAllExpanded = (isExpanded: boolean) => {
 };
 export const queryBrowserSetMetrics = (metrics: string[]) => action(ActionType.QueryBrowserSetMetrics, {metrics});
 export const queryBrowserToggleIsEnabled = (index: number) => action(ActionType.QueryBrowserToggleIsEnabled, {index});
+export const queryBrowserToggleSeries = (index: number, labels: {[key: string]: unknown}) => {
+  return action(ActionType.QueryBrowserToggleSeries, {index, labels});
+};
 export const setConsoleLinks = (consoleLinks: string[]) => action(ActionType.SetConsoleLinks, {consoleLinks});
 
 // TODO(alecmerdler): Implement all actions using `typesafe-actions` and add them to this export
@@ -261,6 +265,7 @@ const uiActions = {
   queryBrowserSetAllExpanded,
   queryBrowserSetMetrics,
   queryBrowserToggleIsEnabled,
+  queryBrowserToggleSeries,
   setConsoleLinks,
 };
 

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -195,6 +195,12 @@ export default (state: UIState, action: UIAction): UIState => {
         query.merge({isEnabled, isExpanded: isEnabled, query: isEnabled ? query.get('text') : ''})
       );
     }
+    case ActionType.QueryBrowserToggleSeries:
+      return state.updateIn(
+        ['queryBrowser', 'queries', action.payload.index, 'disabledSeries'],
+        v => _.xorWith(v, [action.payload.labels], _.isEqual)
+      );
+
     case ActionType.SelectOverviewItem:
       return state.setIn(['overview', 'selectedUID'], action.payload.uid);
 


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/MON-753

Instead of starting with the `query_range` API result and augmenting it
with the `query` API result, start with the `query` result and augment
with the `query_range` results.

Change to display `query` API error messages, not just `query_range`
error messages.

Add missing `aria-label` to `Table` and remove `key` from `TableBody`,
which forced re-renders.