### PR TITLE
deploying new version (rolling, recreate) visualization for topology

### DIFF
--- a/frontend/packages/console-shared/src/constants/resource.ts
+++ b/frontend/packages/console-shared/src/constants/resource.ts
@@ -24,3 +24,16 @@ export const METRICS_POLL_INTERVAL = 30 * 1000;
 
 // Annotation key for image triggers
 export const TRIGGERS_ANNOTATION = 'image.openshift.io/triggers';
+
+export enum DEPLOYMENT_STRATEGY {
+  rolling = 'Rolling',
+  recreate = 'Recreate',
+}
+
+export enum DEPLOYMENT_PHASE {
+  running = 'Running',
+  pending = 'Pending',
+  complete = 'Complete',
+  failed = 'Failed',
+  cancelled = 'Cancelled',
+}

--- a/frontend/packages/console-shared/src/types/pod.ts
+++ b/frontend/packages/console-shared/src/types/pod.ts
@@ -50,3 +50,13 @@ export interface PodRingData {
     pods: Pod[];
   };
 }
+
+export interface PodData {
+  current: Pod[];
+  previous: Pod[];
+  strategy: string;
+  totalReplicas: number;
+  currentRCPhase: string;
+  currentReplicas: number;
+  currentAvailableReplicas: number;
+}

--- a/frontend/packages/console-shared/src/types/pod.ts
+++ b/frontend/packages/console-shared/src/types/pod.ts
@@ -50,13 +50,3 @@ export interface PodRingData {
     pods: Pod[];
   };
 }
-
-export interface PodData {
-  current: Pod[];
-  previous: Pod[];
-  strategy: string;
-  totalReplicas: number;
-  currentRCPhase: string;
-  currentReplicas: number;
-  currentAvailableReplicas: number;
-}

--- a/frontend/packages/console-shared/src/utils/pod-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-utils.ts
@@ -158,7 +158,7 @@ export const getPodData = (
   const currentDeploymentphase = current && current.phase;
   const currentPods = current && current.pods;
   const previousPods = previous && previous.pods;
-
+  console.log('###########3', current, isRollingOut);
   // DaemonSets and StatefulSets
   if (!strategy) return { inProgressDeploymentData: null, completedDeploymentData: pods };
 

--- a/frontend/packages/console-shared/src/utils/pod-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-utils.ts
@@ -158,7 +158,6 @@ export const getPodData = (
   const currentDeploymentphase = current && current.phase;
   const currentPods = current && current.pods;
   const previousPods = previous && previous.pods;
-  console.log('###########3', current, isRollingOut);
   // DaemonSets and StatefulSets
   if (!strategy) return { inProgressDeploymentData: null, completedDeploymentData: pods };
 

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -389,7 +389,7 @@ const getRolloutStatus = (
       phase !== DEPLOYMENT_PHASE.complete
     );
   }
-  return notFailedOrCancelled && !!previous;
+  return notFailedOrCancelled && previous && previous.pods.length > 0;
 };
 
 export class TransformResourceData {

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -30,6 +30,8 @@ import {
   TRIGGERS_ANNOTATION,
   DEPLOYMENT_PHASE_ANNOTATION,
   CONTAINER_WAITING_STATE_ERROR_REASONS,
+  DEPLOYMENT_STRATEGY,
+  DEPLOYMENT_PHASE,
 } from '../constants';
 import { resourceStatus, podStatus } from './ResourceStatus';
 import { isKnativeServing, isIdled } from './pod-utils';
@@ -370,6 +372,26 @@ const getIdledStatus = (
   return rc;
 };
 
+const getRolloutStatus = (
+  dc: K8sResourceKind,
+  current: PodControllerOverviewItem,
+  previous: PodControllerOverviewItem,
+): boolean => {
+  const strategy = _.get(dc, ['spec', 'strategy', 'type']);
+  const phase = current && current.phase;
+  const currentRC = current && current.obj;
+  const notFailedOrCancelled =
+    current && phase !== DEPLOYMENT_PHASE.cancelled && phase !== DEPLOYMENT_PHASE.failed;
+  if (strategy === DEPLOYMENT_STRATEGY.recreate) {
+    return (
+      notFailedOrCancelled &&
+      getDeploymentConfigVersion(currentRC) > 1 &&
+      phase !== DEPLOYMENT_PHASE.complete
+    );
+  }
+  return notFailedOrCancelled && !!previous;
+};
+
 export class TransformResourceData {
   private resources: any;
 
@@ -410,7 +432,7 @@ export class TransformResourceData {
     const ownedRC = getOwnedResources(resource, replicationControllers.data);
     return _.filter(
       ownedRC,
-      (rc) => _.get(rc, 'status.replicas') || getDeploymentConfigVersion(rc) === currentVersion,
+      (rc) => _.get(rc, 'status.replicas') || getDeploymentConfigVersion(rc) >= currentVersion - 1,
     );
   };
 
@@ -553,8 +575,7 @@ export class TransformResourceData {
       };
       const replicationControllers = this.getReplicationControllersForResource(obj);
       const [current, previous] = replicationControllers;
-      const isRollingOut =
-        current && previous && current.phase !== 'Cancelled' && current.phase !== 'Failed';
+      const isRollingOut = getRolloutStatus(obj, current, previous);
       const buildConfigs = this.getBuildConfigsForResource(obj);
       const services = this.getServicesForResource(obj);
       const routes = this.getRoutesForServices(services);

--- a/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
@@ -45,6 +45,85 @@ Object {
         "builderImage": "test-file-stub",
         "donutStatus": Object {
           "build": undefined,
+          "current": Object {
+            "kind": "ReplicationController",
+            "metadata": Object {
+              "annotations": Object {
+                "openshift.io/deployer-pod.completed-at": "2019-04-26 10:36:10 +0000 UTC",
+                "openshift.io/deployment-config.name": "nodejs",
+                "openshift.io/deployment.phase": "Complete",
+              },
+              "creationTimestamp": "2019-04-26T10:36:06Z",
+              "generation": 2,
+              "labels": Object {
+                "app": "nodejs",
+                "openshift.io/deployment-config.name": "nodejs",
+              },
+              "name": "nodejs-1",
+              "namespace": "testproject3",
+              "ownerReferences": Array [
+                Object {
+                  "apiVersion": "apps.openshift.io/v1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "DeploymentConfig",
+                  "name": "nodejs",
+                  "uid": "02f680df-680f-11e9-b69e-5254003f9382",
+                },
+              ],
+              "resourceVersion": "1161189",
+              "selfLink": "/api/v1/namespaces/testproject3/replicationcontrollers/nodejs-1",
+              "uid": "18c94ccd-680f-11e9-8c69-5254003f9382",
+            },
+            "spec": Object {},
+            "status": Object {
+              "availableReplicas": 1,
+              "fullyLabeledReplicas": 1,
+              "observedGeneration": 2,
+              "readyReplicas": 1,
+              "replicas": 1,
+            },
+          },
+          "dc": Object {
+            "apiVersion": "apps/v1",
+            "kind": "DeploymentConfig",
+            "metadata": Object {
+              "annotations": Object {
+                "app.openshift.io/vcs-ref": "master",
+                "app.openshift.io/vcs-uri": "https://github.com/redhat-developer/topology-example",
+              },
+              "creationTimestamp": "2019-04-22T11:58:33Z",
+              "generation": 2,
+              "labels": Object {
+                "app": "nodejs",
+              },
+              "name": "nodejs",
+              "namespace": "testproject1",
+              "resourceVersion": "732186",
+              "selfLink": "/apis/apps.openshift.io/v1/namespaces/testproject1/deploymentconfigs/nodejs",
+              "uid": "02f680df-680f-11e9-b69e-5254003f9382",
+            },
+            "spec": Object {
+              "template": Object {
+                "metadata": Object {
+                  "creationTimestamp": null,
+                  "labels": Object {
+                    "app": "nodejs",
+                    "deploymentconfig": "nodejs",
+                  },
+                },
+                "spec": Object {},
+              },
+            },
+            "status": Object {
+              "availableReplicas": 1,
+              "latestVersion": 1,
+              "readyReplicas": 1,
+              "replicas": 1,
+              "unavailableReplicas": 0,
+              "updatedReplicas": 1,
+            },
+          },
           "pods": Array [
             Object {
               "kind": "Pod",
@@ -86,6 +165,7 @@ Object {
               },
             },
           ],
+          "previous": undefined,
         },
         "editUrl": "https://github.com/redhat-developer/topology-example",
         "isKnativeResource": false,
@@ -414,6 +494,109 @@ Object {
         "builderImage": "test-file-stub",
         "donutStatus": Object {
           "build": undefined,
+          "current": Object {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "metadata": Object {
+              "annotations": Object {
+                "app.openshift.io/connects-to": "[\\"wit\\"]",
+                "deployment.kubernetes.io/desired-replicas": "3",
+                "deployment.kubernetes.io/max-replicas": "4",
+                "deployment.kubernetes.io/revision": "1",
+                "deployment.kubernetes.io/revision-history": "1,1,1",
+              },
+              "creationTimestamp": "2019-04-26T10:23:41Z",
+              "generation": 3,
+              "labels": Object {
+                "app.kubernetes.io/component": "backend",
+                "app.kubernetes.io/instance": "analytics",
+                "app.kubernetes.io/name": "python",
+                "app.kubernetes.io/part-of": "application-1",
+                "app.kubernetes.io/version": "1.0",
+                "pod-template-hash": "1588370380",
+              },
+              "name": "analytics-deployment-59dd7c47d4",
+              "namespace": "testproject3",
+              "ownerReferences": Array [
+                Object {
+                  "apiVersion": "apps/v1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "Deployment",
+                  "name": "analytics-deployment",
+                  "uid": "5ca9ae28-680d-11e9-8c69-5254003f9382",
+                },
+              ],
+              "resourceVersion": "1398999",
+              "selfLink": "/apis/apps/v1/namespaces/testproject3/replicasets/analytics-deployment-59dd7c47d4",
+              "uid": "5cad37cb-680d-11e9-8c69-5254003f9382",
+            },
+            "spec": Object {},
+            "status": Object {
+              "fullyLabeledReplicas": 3,
+              "observedGeneration": 3,
+              "replicas": 3,
+            },
+          },
+          "dc": Object {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": Object {
+              "annotations": Object {
+                "app.openshift.io/connects-to": "[\\"wit\\"]",
+              },
+              "creationTimestamp": "2019-04-22T11:35:37Z",
+              "generation": 5,
+              "labels": Object {
+                "app.kubernetes.io/component": "backend",
+                "app.kubernetes.io/instance": "analytics",
+                "app.kubernetes.io/name": "python",
+                "app.kubernetes.io/part-of": "application-1",
+                "app.kubernetes.io/version": "1.0",
+              },
+              "name": "analytics-deployment",
+              "namespace": "testproject1",
+              "resourceVersion": "753748",
+              "selfLink": "/apis/apps/v1/namespaces/testproject1/deployments/analytics-deployment",
+              "uid": "5ca9ae28-680d-11e9-8c69-5254003f9382",
+            },
+            "name": "analytics-deployment",
+            "spec": Object {
+              "progressDeadlineSeconds": 600,
+              "replicas": 3,
+              "revisionHistoryLimit": 10,
+              "selector": Object {
+                "matchLabels": Object {
+                  "app.kubernetes.io/component": "backend",
+                  "app.kubernetes.io/instance": "analytics",
+                  "app.kubernetes.io/name": "python",
+                  "app.kubernetes.io/part-of": "application-1",
+                  "app.kubernetes.io/version": "1.0",
+                },
+              },
+              "strategy": Object {
+                "rollingUpdate": Object {
+                  "maxSurge": "25%",
+                  "maxUnavailable": "25%",
+                },
+                "type": "RollingUpdate",
+              },
+              "template": Object {
+                "metadata": Object {
+                  "creationTimestamp": null,
+                  "labels": Object {
+                    "app.kubernetes.io/component": "backend",
+                    "app.kubernetes.io/instance": "analytics",
+                    "app.kubernetes.io/name": "python",
+                    "app.kubernetes.io/part-of": "application-1",
+                    "app.kubernetes.io/version": "1.0",
+                  },
+                },
+                "spec": Object {},
+              },
+            },
+            "status": Object {},
+          },
           "pods": Array [
             Object {
               "kind": "Pod",
@@ -533,6 +716,7 @@ Object {
               },
             },
           ],
+          "previous": undefined,
         },
         "editUrl": undefined,
         "isKnativeResource": false,
@@ -1137,6 +1321,105 @@ Object {
         "builderImage": "test-file-stub",
         "donutStatus": Object {
           "build": undefined,
+          "current": Object {
+            "kind": "ReplicaSet",
+            "metadata": Object {
+              "annotations": Object {
+                "deployment.kubernetes.io/desired-replicas": "3",
+                "deployment.kubernetes.io/max-replicas": "4",
+                "deployment.kubernetes.io/revision": "1",
+              },
+              "creationTimestamp": "2019-04-26T10:23:47Z",
+              "generation": 1,
+              "labels": Object {
+                "app.kubernetes.io/component": "backend",
+                "app.kubernetes.io/instance": "wit",
+                "app.kubernetes.io/name": "nodejs",
+                "app.kubernetes.io/part-of": "application-1",
+                "app.kubernetes.io/version": "1.0",
+                "pod-template-hash": "2127746025",
+              },
+              "name": "wit-deployment-656cc8b469",
+              "namespace": "testproject3",
+              "ownerReferences": Array [
+                Object {
+                  "apiVersion": "apps/v1",
+                  "blockOwnerDeletion": true,
+                  "controller": true,
+                  "kind": "Deployment",
+                  "name": "wit-deployment",
+                  "uid": "60a9b423-680d-11e9-8c69-5254003f9382",
+                },
+              ],
+              "resourceVersion": "1389053",
+              "selfLink": "/apis/apps/v1/namespaces/testproject3/replicasets/wit-deployment-656cc8b469",
+              "uid": "60a9b423-680d-11e9-8c69-5254003f9382",
+            },
+            "spec": Object {},
+            "status": Object {
+              "fullyLabeledReplicas": 3,
+              "observedGeneration": 1,
+              "replicas": 3,
+            },
+          },
+          "dc": Object {
+            "kind": "Deployment",
+            "metadata": Object {
+              "annotations": Object {
+                "deployment.kubernetes.io/revision": "1",
+              },
+              "creationTimestamp": "2019-04-22T11:35:43Z",
+              "generation": 2,
+              "labels": Object {
+                "app.kubernetes.io/component": "backend",
+                "app.kubernetes.io/instance": "wit",
+                "app.kubernetes.io/name": "nodejs",
+                "app.kubernetes.io/part-of": "application-1",
+                "app.kubernetes.io/version": "1.0",
+              },
+              "name": "wit-deployment",
+              "namespace": "testproject1",
+              "resourceVersion": "726179",
+              "selfLink": "/apis/apps/v1/namespaces/testproject1/deployments/wit-deployment",
+              "uid": "60a9b423-680d-11e9-8c69-5254003f9382",
+            },
+            "name": "wit-deployment",
+            "spec": Object {
+              "progressDeadlineSeconds": 600,
+              "replicas": 3,
+              "revisionHistoryLimit": 10,
+              "selector": Object {
+                "matchLabels": Object {
+                  "app.kubernetes.io/component": "backend",
+                  "app.kubernetes.io/instance": "wit",
+                  "app.kubernetes.io/name": "nodejs",
+                  "app.kubernetes.io/part-of": "application-1",
+                  "app.kubernetes.io/version": "1.0",
+                },
+              },
+              "strategy": Object {
+                "rollingUpdate": Object {
+                  "maxSurge": "25%",
+                  "maxUnavailable": "25%",
+                },
+                "type": "RollingUpdate",
+              },
+              "template": Object {
+                "metadata": Object {
+                  "creationTimestamp": null,
+                  "labels": Object {
+                    "app.kubernetes.io/component": "backend",
+                    "app.kubernetes.io/instance": "wit",
+                    "app.kubernetes.io/name": "nodejs",
+                    "app.kubernetes.io/part-of": "application-1",
+                    "app.kubernetes.io/version": "1.0",
+                  },
+                },
+                "spec": Object {},
+              },
+            },
+            "status": Object {},
+          },
           "pods": Array [
             Object {
               "kind": "Pod",
@@ -1250,6 +1533,7 @@ Object {
               },
             },
           ],
+          "previous": undefined,
         },
         "editUrl": undefined,
         "isKnativeResource": false,

--- a/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
@@ -42,50 +42,97 @@ Object {
   "topology": Object {
     "02f680df-680f-11e9-b69e-5254003f9382": Object {
       "data": Object {
+        "build": undefined,
         "builderImage": "test-file-stub",
         "donutStatus": Object {
-          "build": undefined,
           "current": Object {
-            "kind": "ReplicationController",
-            "metadata": Object {
-              "annotations": Object {
-                "openshift.io/deployer-pod.completed-at": "2019-04-26 10:36:10 +0000 UTC",
-                "openshift.io/deployment-config.name": "nodejs",
-                "openshift.io/deployment.phase": "Complete",
-              },
-              "creationTimestamp": "2019-04-26T10:36:06Z",
-              "generation": 2,
-              "labels": Object {
-                "app": "nodejs",
-                "openshift.io/deployment-config.name": "nodejs",
-              },
-              "name": "nodejs-1",
-              "namespace": "testproject3",
-              "ownerReferences": Array [
-                Object {
-                  "apiVersion": "apps.openshift.io/v1",
-                  "blockOwnerDeletion": true,
-                  "controller": true,
-                  "kind": "DeploymentConfig",
-                  "name": "nodejs",
-                  "uid": "02f680df-680f-11e9-b69e-5254003f9382",
+            "alerts": Object {},
+            "obj": Object {
+              "apiVersion": "v1",
+              "kind": "ReplicationController",
+              "metadata": Object {
+                "annotations": Object {
+                  "openshift.io/deployer-pod.completed-at": "2019-04-26 10:36:10 +0000 UTC",
+                  "openshift.io/deployment-config.name": "nodejs",
+                  "openshift.io/deployment.phase": "Complete",
                 },
-              ],
-              "resourceVersion": "1161189",
-              "selfLink": "/api/v1/namespaces/testproject3/replicationcontrollers/nodejs-1",
-              "uid": "18c94ccd-680f-11e9-8c69-5254003f9382",
+                "creationTimestamp": "2019-04-26T10:36:06Z",
+                "generation": 2,
+                "labels": Object {
+                  "app": "nodejs",
+                  "openshift.io/deployment-config.name": "nodejs",
+                },
+                "name": "nodejs-1",
+                "namespace": "testproject3",
+                "ownerReferences": Array [
+                  Object {
+                    "apiVersion": "apps.openshift.io/v1",
+                    "blockOwnerDeletion": true,
+                    "controller": true,
+                    "kind": "DeploymentConfig",
+                    "name": "nodejs",
+                    "uid": "02f680df-680f-11e9-b69e-5254003f9382",
+                  },
+                ],
+                "resourceVersion": "1161189",
+                "selfLink": "/api/v1/namespaces/testproject3/replicationcontrollers/nodejs-1",
+                "uid": "18c94ccd-680f-11e9-8c69-5254003f9382",
+              },
+              "spec": Object {},
+              "status": Object {
+                "availableReplicas": 1,
+                "fullyLabeledReplicas": 1,
+                "observedGeneration": 2,
+                "readyReplicas": 1,
+                "replicas": 1,
+              },
             },
-            "spec": Object {},
-            "status": Object {
-              "availableReplicas": 1,
-              "fullyLabeledReplicas": 1,
-              "observedGeneration": 2,
-              "readyReplicas": 1,
-              "replicas": 1,
-            },
+            "phase": "Complete",
+            "pods": Array [
+              Object {
+                "kind": "Pod",
+                "metadata": Object {
+                  "annotations": Object {
+                    "openshift.io/deployment-config.latest-version": "1",
+                    "openshift.io/deployment-config.name": "nodejs",
+                    "openshift.io/deployment.name": "nodejs-1",
+                    "openshift.io/scc": "restricted",
+                  },
+                  "creationTimestamp": "2019-04-26T10:36:07Z",
+                  "generateName": "nodejs-1-",
+                  "labels": Object {
+                    "app": "nodejs",
+                    "deployment": "nodejs-1",
+                    "deploymentconfig": "nodejs",
+                  },
+                  "name": "nodejs-1-2v82p",
+                  "namespace": "testproject3",
+                  "ownerReferences": Array [
+                    Object {
+                      "apiVersion": "v1",
+                      "blockOwnerDeletion": true,
+                      "controller": true,
+                      "kind": "ReplicationController",
+                      "name": "nodejs-1",
+                      "uid": "18c94ccd-680f-11e9-8c69-5254003f9382",
+                    },
+                  ],
+                  "resourceVersion": "1161178",
+                  "selfLink": "/api/v1/namespaces/testproject3/pods/nodejs-1-2v82p",
+                  "uid": "19e6c6a5-680f-11e9-8c69-5254003f9382",
+                },
+                "spec": Object {
+                  "containers": Array [],
+                },
+                "status": Object {
+                  "phase": "Running",
+                },
+              },
+            ],
+            "revision": undefined,
           },
           "dc": Object {
-            "apiVersion": "apps/v1",
+            "apiVersion": "apps.openshift.io/v1",
             "kind": "DeploymentConfig",
             "metadata": Object {
               "annotations": Object {
@@ -124,6 +171,7 @@ Object {
               "updatedReplicas": 1,
             },
           },
+          "isRollingOut": undefined,
           "pods": Array [
             Object {
               "kind": "Pod",
@@ -491,52 +539,175 @@ Object {
     },
     "5ca9ae28-680d-11e9-8c69-5254003f9382": Object {
       "data": Object {
+        "build": undefined,
         "builderImage": "test-file-stub",
         "donutStatus": Object {
-          "build": undefined,
           "current": Object {
-            "apiVersion": "apps/v1",
-            "kind": "ReplicaSet",
-            "metadata": Object {
-              "annotations": Object {
-                "app.openshift.io/connects-to": "[\\"wit\\"]",
-                "deployment.kubernetes.io/desired-replicas": "3",
-                "deployment.kubernetes.io/max-replicas": "4",
-                "deployment.kubernetes.io/revision": "1",
-                "deployment.kubernetes.io/revision-history": "1,1,1",
-              },
-              "creationTimestamp": "2019-04-26T10:23:41Z",
-              "generation": 3,
-              "labels": Object {
-                "app.kubernetes.io/component": "backend",
-                "app.kubernetes.io/instance": "analytics",
-                "app.kubernetes.io/name": "python",
-                "app.kubernetes.io/part-of": "application-1",
-                "app.kubernetes.io/version": "1.0",
-                "pod-template-hash": "1588370380",
-              },
-              "name": "analytics-deployment-59dd7c47d4",
-              "namespace": "testproject3",
-              "ownerReferences": Array [
-                Object {
-                  "apiVersion": "apps/v1",
-                  "blockOwnerDeletion": true,
-                  "controller": true,
-                  "kind": "Deployment",
-                  "name": "analytics-deployment",
-                  "uid": "5ca9ae28-680d-11e9-8c69-5254003f9382",
+            "alerts": Object {},
+            "obj": Object {
+              "apiVersion": "apps/v1",
+              "kind": "ReplicaSet",
+              "metadata": Object {
+                "annotations": Object {
+                  "app.openshift.io/connects-to": "[\\"wit\\"]",
+                  "deployment.kubernetes.io/desired-replicas": "3",
+                  "deployment.kubernetes.io/max-replicas": "4",
+                  "deployment.kubernetes.io/revision": "1",
+                  "deployment.kubernetes.io/revision-history": "1,1,1",
                 },
-              ],
-              "resourceVersion": "1398999",
-              "selfLink": "/apis/apps/v1/namespaces/testproject3/replicasets/analytics-deployment-59dd7c47d4",
-              "uid": "5cad37cb-680d-11e9-8c69-5254003f9382",
+                "creationTimestamp": "2019-04-26T10:23:41Z",
+                "generation": 3,
+                "labels": Object {
+                  "app.kubernetes.io/component": "backend",
+                  "app.kubernetes.io/instance": "analytics",
+                  "app.kubernetes.io/name": "python",
+                  "app.kubernetes.io/part-of": "application-1",
+                  "app.kubernetes.io/version": "1.0",
+                  "pod-template-hash": "1588370380",
+                },
+                "name": "analytics-deployment-59dd7c47d4",
+                "namespace": "testproject3",
+                "ownerReferences": Array [
+                  Object {
+                    "apiVersion": "apps/v1",
+                    "blockOwnerDeletion": true,
+                    "controller": true,
+                    "kind": "Deployment",
+                    "name": "analytics-deployment",
+                    "uid": "5ca9ae28-680d-11e9-8c69-5254003f9382",
+                  },
+                ],
+                "resourceVersion": "1398999",
+                "selfLink": "/apis/apps/v1/namespaces/testproject3/replicasets/analytics-deployment-59dd7c47d4",
+                "uid": "5cad37cb-680d-11e9-8c69-5254003f9382",
+              },
+              "spec": Object {},
+              "status": Object {
+                "fullyLabeledReplicas": 3,
+                "observedGeneration": 3,
+                "replicas": 3,
+              },
             },
-            "spec": Object {},
-            "status": Object {
-              "fullyLabeledReplicas": 3,
-              "observedGeneration": 3,
-              "replicas": 3,
-            },
+            "pods": Array [
+              Object {
+                "kind": "Pod",
+                "metadata": Object {
+                  "annotations": Object {
+                    "openshift.io/scc": "restricted",
+                  },
+                  "creationTimestamp": "2019-04-26T10:23:41Z",
+                  "generateName": "analytics-deployment-59dd7c47d4-",
+                  "labels": Object {
+                    "app.kubernetes.io/component": "backend",
+                    "app.kubernetes.io/instance": "analytics",
+                    "app.kubernetes.io/name": "python",
+                    "app.kubernetes.io/part-of": "application-1",
+                    "app.kubernetes.io/version": "1.0",
+                    "pod-template-hash": "1588370380",
+                  },
+                  "name": "analytics-deployment-59dd7c47d4-2jp7t",
+                  "namespace": "testproject3",
+                  "ownerReferences": Array [
+                    Object {
+                      "apiVersion": "apps/v1",
+                      "blockOwnerDeletion": true,
+                      "controller": true,
+                      "kind": "ReplicaSet",
+                      "name": "analytics-deployment-59dd7c47d4",
+                      "uid": "5cad37cb-680d-11e9-8c69-5254003f9382",
+                    },
+                  ],
+                  "resourceVersion": "1395096",
+                  "selfLink": "/api/v1/namespaces/testproject3/pods/analytics-deployment-59dd7c47d4-2jp7t",
+                  "uid": "5cec460e-680d-11e9-8c69-5254003f9382",
+                },
+                "spec": Object {
+                  "containers": Array [],
+                },
+                "status": Object {
+                  "phase": "Running",
+                },
+              },
+              Object {
+                "kind": "Pod",
+                "metadata": Object {
+                  "annotations": Object {
+                    "openshift.io/scc": "restricted",
+                  },
+                  "creationTimestamp": "2019-04-26T16:03:01Z",
+                  "generateName": "analytics-deployment-59dd7c47d4-",
+                  "labels": Object {
+                    "app.kubernetes.io/component": "backend",
+                    "app.kubernetes.io/instance": "analytics",
+                    "app.kubernetes.io/name": "python",
+                    "app.kubernetes.io/part-of": "application-1",
+                    "app.kubernetes.io/version": "1.0",
+                    "pod-template-hash": "1588370380",
+                  },
+                  "name": "analytics-deployment-59dd7c47d4-6btjb",
+                  "namespace": "testproject3",
+                  "ownerReferences": Array [
+                    Object {
+                      "apiVersion": "apps/v1",
+                      "blockOwnerDeletion": true,
+                      "controller": true,
+                      "kind": "ReplicaSet",
+                      "name": "analytics-deployment-59dd7c47d4",
+                      "uid": "5cad37cb-680d-11e9-8c69-5254003f9382",
+                    },
+                  ],
+                  "resourceVersion": "1394896",
+                  "selfLink": "/api/v1/namespaces/testproject3/pods/analytics-deployment-59dd7c47d4-6btjb",
+                  "uid": "c4592a49-683c-11e9-8c69-5254003f9382",
+                },
+                "spec": Object {
+                  "constainers": Array [],
+                },
+                "status": Object {
+                  "phase": "Running",
+                },
+              },
+              Object {
+                "kind": "Pod",
+                "metadata": Object {
+                  "annotations": Object {
+                    "openshift.io/scc": "restricted",
+                  },
+                  "creationTimestamp": "2019-04-26T10:23:41Z",
+                  "generateName": "analytics-deployment-59dd7c47d4-",
+                  "labels": Object {
+                    "app.kubernetes.io/component": "backend",
+                    "app.kubernetes.io/instance": "analytics",
+                    "app.kubernetes.io/name": "python",
+                    "app.kubernetes.io/part-of": "application-1",
+                    "app.kubernetes.io/version": "1.0",
+                    "pod-template-hash": "1588370380",
+                  },
+                  "name": "analytics-deployment-59dd7c47d4-n4zrh",
+                  "namespace": "testproject3",
+                  "ownerReferences": Array [
+                    Object {
+                      "apiVersion": "apps/v1",
+                      "blockOwnerDeletion": true,
+                      "controller": true,
+                      "kind": "ReplicaSet",
+                      "name": "analytics-deployment-59dd7c47d4",
+                      "uid": "5cad37cb-680d-11e9-8c69-5254003f9382",
+                    },
+                  ],
+                  "resourceVersion": "1394826",
+                  "selfLink": "/api/v1/namespaces/testproject3/pods/analytics-deployment-59dd7c47d4-n4zrh",
+                  "uid": "5cec1049-680d-11e9-8c69-5254003f9382",
+                },
+                "spec": Object {
+                  "constainers": Array [],
+                },
+                "status": Object {
+                  "phase": "Running",
+                },
+              },
+            ],
+            "revision": 1,
           },
           "dc": Object {
             "apiVersion": "apps/v1",
@@ -597,6 +768,7 @@ Object {
             },
             "status": Object {},
           },
+          "isRollingOut": false,
           "pods": Array [
             Object {
               "kind": "Pod",
@@ -1318,51 +1490,170 @@ Object {
     },
     "60a9b423-680d-11e9-8c69-5254003f9382": Object {
       "data": Object {
+        "build": undefined,
         "builderImage": "test-file-stub",
         "donutStatus": Object {
-          "build": undefined,
           "current": Object {
-            "kind": "ReplicaSet",
-            "metadata": Object {
-              "annotations": Object {
-                "deployment.kubernetes.io/desired-replicas": "3",
-                "deployment.kubernetes.io/max-replicas": "4",
-                "deployment.kubernetes.io/revision": "1",
-              },
-              "creationTimestamp": "2019-04-26T10:23:47Z",
-              "generation": 1,
-              "labels": Object {
-                "app.kubernetes.io/component": "backend",
-                "app.kubernetes.io/instance": "wit",
-                "app.kubernetes.io/name": "nodejs",
-                "app.kubernetes.io/part-of": "application-1",
-                "app.kubernetes.io/version": "1.0",
-                "pod-template-hash": "2127746025",
-              },
-              "name": "wit-deployment-656cc8b469",
-              "namespace": "testproject3",
-              "ownerReferences": Array [
-                Object {
-                  "apiVersion": "apps/v1",
-                  "blockOwnerDeletion": true,
-                  "controller": true,
-                  "kind": "Deployment",
-                  "name": "wit-deployment",
-                  "uid": "60a9b423-680d-11e9-8c69-5254003f9382",
+            "alerts": Object {},
+            "obj": Object {
+              "apiVersion": "apps/v1",
+              "kind": "ReplicaSet",
+              "metadata": Object {
+                "annotations": Object {
+                  "deployment.kubernetes.io/desired-replicas": "3",
+                  "deployment.kubernetes.io/max-replicas": "4",
+                  "deployment.kubernetes.io/revision": "1",
                 },
-              ],
-              "resourceVersion": "1389053",
-              "selfLink": "/apis/apps/v1/namespaces/testproject3/replicasets/wit-deployment-656cc8b469",
-              "uid": "60a9b423-680d-11e9-8c69-5254003f9382",
+                "creationTimestamp": "2019-04-26T10:23:47Z",
+                "generation": 1,
+                "labels": Object {
+                  "app.kubernetes.io/component": "backend",
+                  "app.kubernetes.io/instance": "wit",
+                  "app.kubernetes.io/name": "nodejs",
+                  "app.kubernetes.io/part-of": "application-1",
+                  "app.kubernetes.io/version": "1.0",
+                  "pod-template-hash": "2127746025",
+                },
+                "name": "wit-deployment-656cc8b469",
+                "namespace": "testproject3",
+                "ownerReferences": Array [
+                  Object {
+                    "apiVersion": "apps/v1",
+                    "blockOwnerDeletion": true,
+                    "controller": true,
+                    "kind": "Deployment",
+                    "name": "wit-deployment",
+                    "uid": "60a9b423-680d-11e9-8c69-5254003f9382",
+                  },
+                ],
+                "resourceVersion": "1389053",
+                "selfLink": "/apis/apps/v1/namespaces/testproject3/replicasets/wit-deployment-656cc8b469",
+                "uid": "60a9b423-680d-11e9-8c69-5254003f9382",
+              },
+              "spec": Object {},
+              "status": Object {
+                "fullyLabeledReplicas": 3,
+                "observedGeneration": 1,
+                "replicas": 3,
+              },
             },
-            "spec": Object {},
-            "status": Object {
-              "fullyLabeledReplicas": 3,
-              "observedGeneration": 1,
-              "replicas": 3,
-            },
+            "pods": Array [
+              Object {
+                "kind": "Pod",
+                "metadata": Object {
+                  "annotations": Object {
+                    "openshift.io/scc": "restricted",
+                  },
+                  "creationTimestamp": "2019-04-26T10:23:48Z",
+                  "generateName": "wit-deployment-656cc8b469-",
+                  "labels": Object {
+                    "app.kubernetes.io/component": "backend",
+                    "app.kubernetes.io/instance": "wit",
+                    "app.kubernetes.io/name": "nodejs",
+                    "app.kubernetes.io/part-of": "application-1",
+                    "app.kubernetes.io/version": "1.0",
+                    "pod-template-hash": "2127746025",
+                  },
+                  "name": "wit-deployment-656cc8b469-2n6nl",
+                  "namespace": "testproject3",
+                  "ownerReferences": Array [
+                    Object {
+                      "apiVersion": "apps/v1",
+                      "blockOwnerDeletion": true,
+                      "controller": true,
+                      "kind": "ReplicaSet",
+                      "name": "wit-deployment-656cc8b469",
+                      "uid": "60a9b423-680d-11e9-8c69-5254003f9382",
+                    },
+                  ],
+                  "resourceVersion": "1394776",
+                  "selfLink": "/api/v1/namespaces/testproject3/pods/wit-deployment-656cc8b469-2n6nl",
+                  "uid": "610c7d95-680d-11e9-8c69-5254003f9382",
+                },
+                "spec": Object {},
+                "status": Object {
+                  "phase": "Running",
+                },
+              },
+              Object {
+                "kind": "Pod",
+                "metadata": Object {
+                  "annotations": Object {
+                    "openshift.io/scc": "restricted",
+                  },
+                  "creationTimestamp": "2019-04-26T10:23:48Z",
+                  "generateName": "wit-deployment-656cc8b469-",
+                  "labels": Object {
+                    "app.kubernetes.io/component": "backend",
+                    "app.kubernetes.io/instance": "wit",
+                    "app.kubernetes.io/name": "nodejs",
+                    "app.kubernetes.io/part-of": "application-1",
+                    "app.kubernetes.io/version": "1.0",
+                    "pod-template-hash": "2127746025",
+                  },
+                  "name": "wit-deployment-656cc8b469-kzh9c",
+                  "namespace": "testproject3",
+                  "ownerReferences": Array [
+                    Object {
+                      "apiVersion": "apps/v1",
+                      "blockOwnerDeletion": true,
+                      "controller": true,
+                      "kind": "ReplicaSet",
+                      "name": "wit-deployment-656cc8b469",
+                      "uid": "60a9b423-680d-11e9-8c69-5254003f9382",
+                    },
+                  ],
+                  "resourceVersion": "1394914",
+                  "selfLink": "/api/v1/namespaces/testproject3/pods/wit-deployment-656cc8b469-kzh9c",
+                  "uid": "60dbfd78-680d-11e9-8c69-5254003f9382",
+                },
+                "spec": Object {},
+                "status": Object {
+                  "phase": "Running",
+                },
+              },
+              Object {
+                "kind": "Pod",
+                "metadata": Object {
+                  "annotations": Object {
+                    "openshift.io/scc": "restricted",
+                  },
+                  "creationTimestamp": "2019-04-26T10:23:48Z",
+                  "generateName": "wit-deployment-656cc8b469-",
+                  "labels": Object {
+                    "app.kubernetes.io/component": "backend",
+                    "app.kubernetes.io/instance": "wit",
+                    "app.kubernetes.io/name": "nodejs",
+                    "app.kubernetes.io/part-of": "application-1",
+                    "app.kubernetes.io/version": "1.0",
+                    "pod-template-hash": "2127746025",
+                  },
+                  "name": "wit-deployment-656cc8b469-r5nlj",
+                  "namespace": "testproject3",
+                  "ownerReferences": Array [
+                    Object {
+                      "apiVersion": "apps/v1",
+                      "blockOwnerDeletion": true,
+                      "controller": true,
+                      "kind": "ReplicaSet",
+                      "name": "wit-deployment-656cc8b469",
+                      "uid": "60a9b423-680d-11e9-8c69-5254003f9382",
+                    },
+                  ],
+                  "resourceVersion": "1395115",
+                  "selfLink": "/api/v1/namespaces/testproject3/pods/wit-deployment-656cc8b469-r5nlj",
+                  "uid": "610bbd96-680d-11e9-8c69-5254003f9382",
+                },
+                "spec": Object {},
+                "status": Object {
+                  "phase": "Running",
+                },
+              },
+            ],
+            "revision": 1,
           },
           "dc": Object {
+            "apiVersion": "apps/v1",
             "kind": "Deployment",
             "metadata": Object {
               "annotations": Object {
@@ -1420,6 +1711,7 @@ Object {
             },
             "status": Object {},
           },
+          "isRollingOut": false,
           "pods": Array [
             Object {
               "kind": "Pod",

--- a/frontend/packages/dev-console/src/components/topology/shapes/PodSet.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/PodSet.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { PodStatus, calculateRadius, getDataBasedOnCurrentAndPreviousRC } from '@console/shared';
+import { DonutStatusData } from '../topology-types';
+
+interface PodSetProps {
+  size: number;
+  data: DonutStatusData;
+}
+
+interface InnerPodStatusRadius {
+  innerPodStatusOuterRadius: number;
+  innerPodStatusInnerRadius: number;
+}
+
+const calculateInnerPodStatusRadius = (
+  outerPodStatusInnerRadius: number,
+  outerPodStatusWidth: number,
+): InnerPodStatusRadius => {
+  const innerPodStatusWidth = outerPodStatusWidth * 0.6;
+  const spaceBwOuterAndInnerPodStatus = 3;
+  const innerPodStatusOuterRadius = outerPodStatusInnerRadius - spaceBwOuterAndInnerPodStatus;
+  const innerPodStatusInnerRadius = innerPodStatusOuterRadius - innerPodStatusWidth;
+
+  return { innerPodStatusOuterRadius, innerPodStatusInnerRadius };
+};
+
+const PodSet: React.FC<PodSetProps> = ({ size, data }) => {
+  const { podStatusOuterRadius, podStatusInnerRadius, podStatusStrokeWidth } = calculateRadius(
+    size,
+  );
+  const { innerPodStatusOuterRadius, innerPodStatusInnerRadius } = calculateInnerPodStatusRadius(
+    podStatusInnerRadius,
+    podStatusStrokeWidth,
+  );
+  const { inProgressDeploymentData, completedDeploymentData } = getDataBasedOnCurrentAndPreviousRC(
+    data.dc,
+    data.current,
+    data.previous,
+    data.pods,
+  );
+  return (
+    <React.Fragment>
+      <PodStatus
+        key={inProgressDeploymentData ? 'deploy' : 'notDeploy'}
+        x={-size / 2}
+        y={-size / 2}
+        innerRadius={podStatusInnerRadius}
+        outerRadius={podStatusOuterRadius}
+        data={completedDeploymentData}
+        size={size}
+      />
+      {inProgressDeploymentData && (
+        <PodStatus
+          x={-size / 2}
+          y={-size / 2}
+          innerRadius={innerPodStatusInnerRadius}
+          outerRadius={innerPodStatusOuterRadius}
+          data={inProgressDeploymentData}
+          size={size}
+        />
+      )}
+    </React.Fragment>
+  );
+};
+
+export default PodSet;

--- a/frontend/packages/dev-console/src/components/topology/shapes/PodSet.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/PodSet.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PodStatus, calculateRadius, getDataBasedOnCurrentAndPreviousRC } from '@console/shared';
+import { PodStatus, calculateRadius, getPodData } from '@console/shared';
 import { DonutStatusData } from '../topology-types';
 
 interface PodSetProps {
@@ -32,11 +32,12 @@ const PodSet: React.FC<PodSetProps> = ({ size, data }) => {
     podStatusInnerRadius,
     podStatusStrokeWidth,
   );
-  const { inProgressDeploymentData, completedDeploymentData } = getDataBasedOnCurrentAndPreviousRC(
+  const { inProgressDeploymentData, completedDeploymentData } = getPodData(
     data.dc,
+    data.pods,
     data.current,
     data.previous,
-    data.pods,
+    data.isRollingOut,
   );
   return (
     <React.Fragment>

--- a/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
@@ -21,9 +21,7 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
 }) => {
   const { radius, decoratorRadius } = calculateRadius(size);
   const {
-    data: {
-      donutStatus: { build },
-    },
+    data: { build },
   } = workload;
   const repoIcon = routeDecoratorIcon(workload.data.editUrl, decoratorRadius);
 
@@ -32,7 +30,7 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
       x={x}
       y={y}
       outerRadius={radius}
-      innerRadius={radius * 0.55}
+      innerRadius={radius * 0.45}
       icon={workload.data.builderImage}
       label={workload.name}
       kind={workload.data.kind}

--- a/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { Status, calculateRadius, PodStatus } from '@console/shared';
+import { Status, calculateRadius } from '@console/shared';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { resourcePathFromModel } from '@console/internal/components/utils';
@@ -10,6 +10,7 @@ import { NodeProps, WorkloadData } from '../topology-types';
 import Decorator from './Decorator';
 import BaseNode from './BaseNode';
 import KnativeIcon from './KnativeIcon';
+import PodSet from './PodSet';
 
 const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
   data: workload,
@@ -18,9 +19,7 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
   size,
   ...others
 }) => {
-  const { radius, podStatusOuterRadius, podStatusInnerRadius, decoratorRadius } = calculateRadius(
-    size,
-  );
+  const { radius, decoratorRadius } = calculateRadius(size);
   const {
     data: {
       donutStatus: { build },
@@ -103,14 +102,7 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
         ),
       ]}
     >
-      <PodStatus
-        x={-size / 2}
-        y={-size / 2}
-        innerRadius={podStatusInnerRadius}
-        outerRadius={podStatusOuterRadius}
-        data={workload.data.donutStatus.pods}
-        size={size}
-      />
+      <PodSet size={size} data={workload.data.donutStatus} />
       {workload.data.isKnativeResource && (
         <KnativeIcon
           x={-radius * 0.15}

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -78,10 +78,15 @@ export interface WorkloadData {
   builderImage?: string;
   kind?: string;
   isKnativeResource?: boolean;
-  donutStatus: {
-    pods: Pod[];
-    build: K8sResourceKind;
-  };
+  donutStatus: DonutStatusData;
+}
+
+export interface DonutStatusData {
+  pods: Pod[];
+  current: ResourceProps;
+  previous: ResourceProps;
+  dc: ResourceProps;
+  build: ResourceProps;
 }
 
 export interface GraphApi {

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -1,6 +1,6 @@
 import { ComponentType } from 'react';
 import { KebabOption } from '@console/internal/components/utils';
-import { Pod, Resource, OverviewItem } from '@console/shared';
+import { Pod, Resource, OverviewItem, PodControllerOverviewItem } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { Point } from '../../utils/svg-utils';
 
@@ -78,15 +78,16 @@ export interface WorkloadData {
   builderImage?: string;
   kind?: string;
   isKnativeResource?: boolean;
+  build: K8sResourceKind;
   donutStatus: DonutStatusData;
 }
 
 export interface DonutStatusData {
   pods: Pod[];
-  current: ResourceProps;
-  previous: ResourceProps;
-  dc: ResourceProps;
-  build: ResourceProps;
+  current: PodControllerOverviewItem;
+  previous: PodControllerOverviewItem;
+  dc: K8sResourceKind;
+  isRollingOut: boolean;
 }
 
 export interface GraphApi {

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -88,7 +88,7 @@ const createInstanceForResource = (resources: TopologyDataResources, utils?: Fun
  * @param cheURL che link
  */
 const createTopologyNodeData = (dc: OverviewItem, cheURL?: string): TopologyDataObject => {
-  const { obj: deploymentConfig } = dc;
+  const { obj: deploymentConfig, current, previous, isRollingOut } = dc;
   const dcUID = _.get(deploymentConfig, 'metadata.uid');
   const deploymentsLabels = _.get(deploymentConfig, 'metadata.labels', {});
   const deploymentsAnnotations = _.get(deploymentConfig, 'metadata.annotations', {});
@@ -111,9 +111,13 @@ const createTopologyNodeData = (dc: OverviewItem, cheURL?: string): TopologyData
         getImageForIconClass(`icon-${deploymentsLabels['app.kubernetes.io/name']}`) ||
         getImageForIconClass(`icon-openshift`),
       isKnativeResource: isKnativeServing(deploymentConfig, 'metadata.labels'),
+      build: _.get(buildConfigs[0], 'builds[0]'),
       donutStatus: {
         pods: dc.pods,
-        build: _.get(buildConfigs[0], 'builds[0]'),
+        current,
+        previous,
+        isRollingOut,
+        dc: deploymentConfig,
       },
     },
   };

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -47,10 +47,11 @@ const rollout = (dc: K8sResourceKind): Promise<K8sResourceKind> => {
 
 const RolloutAction: KebabAction = (kind: K8sKind, obj: K8sResourceKind) => ({
   label: 'Start Rollout',
-  callback: () => rollout(obj).catch(err => {
-    const error = err.message;
-    errorModal({error});
-  }),
+  callback: () =>
+    rollout(obj).catch((err) => {
+      const error = err.message;
+      errorModal({ error });
+    }),
   accessReview: {
     group: kind.apiGroup,
     resource: kind.plural,

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -11,14 +11,12 @@ import { VolumesTable } from './volumes-table';
 import { DetailsPage, ListPage, Table } from './factory';
 import {
   AsyncComponent,
-  history,
   Kebab,
   KebabAction,
   ContainerTable,
   navFactory,
   pluralize,
   ResourceSummary,
-  resourcePath,
   SectionHeading,
   togglePaused,
   WorkloadPausedAlert,
@@ -47,27 +45,12 @@ const rollout = (dc: K8sResourceKind): Promise<K8sResourceKind> => {
   return k8sCreate(DeploymentConfigModel, req, opts);
 };
 
-const determineReplicationControllerName = (dc: K8sResourceKind): string => {
-  return `${dc.metadata.name}-${dc.status.latestVersion}`;
-};
-
 const RolloutAction: KebabAction = (kind: K8sKind, obj: K8sResourceKind) => ({
   label: 'Start Rollout',
-  callback: () =>
-    rollout(obj)
-      .then((deployment) => {
-        history.push(
-          resourcePath(
-            'ReplicationController',
-            determineReplicationControllerName(deployment),
-            deployment.metadata.namespace,
-          ),
-        );
-      })
-      .catch((err) => {
-        const error = err.message;
-        errorModal({ error });
-      }),
+  callback: () => rollout(obj).catch(err => {
+    const error = err.message;
+    errorModal({error});
+  }),
   accessReview: {
     group: kind.apiGroup,
     resource: kind.plural,


### PR DESCRIPTION
Story: https://jira.coreos.com/browse/ODC-842

This PR adds the Rolling and Recreate strategy visualization for deployments.

rolling:
![rolling-topology](https://user-images.githubusercontent.com/9278015/63522393-dfb9ed80-c515-11e9-801a-ac22fa703e64.gif)
recreate:
![recreate-topology](https://user-images.githubusercontent.com/9278015/63522633-62db4380-c516-11e9-9865-38ed955f77d3.gif)

