### PR TITLE
Remove orphaned yaml editor styles

### DIFF
--- a/frontend/public/components/_edit-yaml.scss
+++ b/frontend/public/components/_edit-yaml.scss
@@ -1,14 +1,5 @@
 .yaml-editor {
   position: relative;
-  &--readonly .yaml-editor__acebox {
-    background: $input-bg-disabled !important;
-    color: $color-pf-black-700 !important;
-    filter: grayscale(.55);
-  }
-}
-
-.yaml-editor__acebox {
-  flex: 1;
 }
 
 .yaml-editor__buttons {
@@ -21,11 +12,6 @@
     padding-left: $grid-gutter-width;
     padding-right: $grid-gutter-width;
   }
-}
-
-.yaml-editor__flexbox {
-  display: flex;
-  flex-direction: column;
 }
 
 .yaml-editor__header {

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -535,7 +535,7 @@ export const EditYAML = connect(stateToProps)(
           <div className="pf-c-form">
             <div className="co-p-has-sidebar">
               <div className="co-p-has-sidebar__body">
-                <div className={classNames('yaml-editor', {'yaml-editor--readonly': readOnly})} ref={r => this.editor = r}>
+                <div className="yaml-editor" ref={r => this.editor = r}>
                   <MonacoEditor
                     ref={this.monacoRef}
                     language="yaml"


### PR DESCRIPTION
These styles were specific to the old Ace-based implementation.