### PR TITLE
Add space around YAML editor at desktop

### DIFF
--- a/frontend/public/components/_edit-yaml.scss
+++ b/frontend/public/components/_edit-yaml.scss
@@ -1,5 +1,11 @@
 .yaml-editor {
   position: relative;
+  @media (min-width: $grid-float-breakpoint) {
+    // changing these values requires changes to the editorHeight() and width() calculations in edit-yaml.jsx
+    margin-left: $grid-gutter-width;
+    margin-right: $grid-gutter-width;
+    padding-top: $grid-gutter-width;
+  }
 }
 
 .yaml-editor__buttons {
@@ -9,8 +15,8 @@
   margin-top: auto;
   z-index: 10;
   @media (min-width: $grid-float-breakpoint) {
-    padding-left: $grid-gutter-width;
-    padding-right: $grid-gutter-width;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -58,6 +58,9 @@ const stateToProps = ({k8s, UI}) => ({
   models: k8s.getIn(['RESOURCES', 'models']),
 });
 
+const isDesktop = () => window.innerWidth > 767;
+const desktopGutter = 30;
+
 /**
  * This component loads the entire Monaco editor library with it.
  * Consider using `AsyncComponent` to dynamically load this component when needed.
@@ -159,7 +162,11 @@ export const EditYAML = connect(stateToProps)(
     }
 
     get editorHeight() {
-      return Math.floor(this.height - this.buttons.getBoundingClientRect().height);
+      const buttonsHeight = this.buttons.getBoundingClientRect().height;
+      // if viewport width is > 767, also subtract top padding on .yaml-editor
+      return isDesktop()
+        ? Math.floor(this.height - buttonsHeight - desktopGutter)
+        : Math.floor(this.height - buttonsHeight);
     }
 
     get height() {
@@ -170,11 +177,15 @@ export const EditYAML = connect(stateToProps)(
     }
 
     get width() {
-      const sidebar = _.first(document.getElementsByClassName('co-p-has-sidebar__sidebar'));
-      const pageWidth = document.getElementById('content-scrollable').getBoundingClientRect().width;
-      return sidebar
-        ? pageWidth - sidebar.getBoundingClientRect().width
-        : pageWidth;
+      const hasSidebarSidebar = _.first(document.getElementsByClassName('co-p-has-sidebar__sidebar'));
+      const contentScrollableWidth = document.getElementById('content-scrollable').getBoundingClientRect().width;
+      // if viewport width is > 767, also subtract left and right margins on .yaml-editor
+      const hasSidebarBodyWidth = isDesktop()
+        ? contentScrollableWidth - (desktopGutter * 2)
+        : contentScrollableWidth;
+      return hasSidebarSidebar
+        ? hasSidebarBodyWidth - hasSidebarSidebar.getBoundingClientRect().width
+        : hasSidebarBodyWidth;
     }
 
     reload() {

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -59,8 +59,8 @@ body,
 
   &__sidebar--hidden {
     position: absolute;
-    right: 13px;
-    top: -35px;
+    right: 23px;
+    top: 1px;
     z-index: 1;
   }
 }


### PR DESCRIPTION
Resolves https://jira.coreos.com/browse/CONSOLE-1693

![localhost_9000_k8s_ns_robb_pods_etcd-operator-5dfbc9d746-m6jf9_yaml (1)](https://user-images.githubusercontent.com/895728/63552826-c2315780-c506-11e9-8720-5bb216083eda.png)
![localhost_9000_k8s_ns_robb_pods_etcd-operator-5dfbc9d746-m6jf9_yaml (2)](https://user-images.githubusercontent.com/895728/63552827-c2315780-c506-11e9-8af9-69dd8ea051e0.png)
![localhost_9000_k8s_ns_robb_pods_etcd-operator-5dfbc9d746-m6jf9_yaml (3)](https://user-images.githubusercontent.com/895728/63552829-c2315780-c506-11e9-86fc-4dbf3782f4c8.png)
![localhost_9000_k8s_ns_robb_pods_etcd-operator-5dfbc9d746-m6jf9_yaml](https://user-images.githubusercontent.com/895728/63552831-c2315780-c506-11e9-868d-8634c92690c6.png)
I opted to keep the bleed at mobile since space is so limited.
![localhost_9000_k8s_ns_robb_pods_etcd-operator-5dfbc9d746-m6jf9_yaml (4)](https://user-images.githubusercontent.com/895728/63552830-c2315780-c506-11e9-8de2-28243fcef09e.png)

