### PR TITLE
fix(build): (ODC-1649)add data-test-id to Build items

### DIFF
--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -131,7 +131,7 @@ export const NavBar = withRouter<NavBarProps>(({pages, basePath, hideDivider}) =
   const secondaryTabs = <ul className="co-m-horizontal-nav__menu-secondary">{
     pages.slice(React.Children.count(primaryTabs.props.children) - 1).map(({name, href}) => {
       const klass = classNames('co-m-horizontal-nav__menu-item', {'co-m-horizontal-nav-item--active': location.pathname.replace(basePath, '/').endsWith(`/${href}`)});
-      return <li className={klass} key={name}><Link to={`${basePath}/${href}`}>{name}</Link></li>;
+      return <li className={klass} key={name} data-test-id={`horizontal-${name.toLowerCase()}-tab`}><Link to={`${basePath}/${href}`} >{name}</Link></li>;
     })}</ul>;
 
   return <div className="co-m-horizontal-nav__menu">

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -17,7 +17,7 @@ import { impersonateStateToProps } from '../../reducers/ui';
 import { connectToModel } from '../../kinds';
 
 const KebabItemEnabled: React.FC<KebabItemProps> = ({option, onClick}) => {
-  return <button className="pf-c-dropdown__menu-item" onClick={(e) => onClick(e, option)} data-test-action={option.label}>{option.label}</button>;
+  return <button className="pf-c-dropdown__menu-item" onClick={(e) => onClick(e, option)} data-test-action={option.label} data-test-id={option.label}>{option.label}</button>;
 };
 
 const KebabItemDisabled: React.FC<KebabItemDisabledProps> = ({option}) => {

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -337,7 +337,7 @@ const PairElement = DragSource(DRAGGABLE_TYPE.ENV_ROW, pairSource, collectSource
             </div>
           }
           <div className="col-xs-5 pairs-list__name-field">
-            <input type="text" className="pf-c-form-control" placeholder={nameString.toLowerCase()} value={pair[NameValueEditorPair.Name]} onChange={this._onChangeName} disabled={readOnly} />
+            <input type="text" className="pf-c-form-control" placeholder={nameString.toLowerCase()} value={pair[NameValueEditorPair.Name]} onChange={this._onChangeName} disabled={readOnly} data-test-id="nameValueEditorName" />
           </div>
           {
             _.isPlainObject(pair[NameValueEditorPair.Value]) ?
@@ -346,7 +346,7 @@ const PairElement = DragSource(DRAGGABLE_TYPE.ENV_ROW, pairSource, collectSource
               </div>
               :
               <div className="col-xs-5 pairs-list__value-field">
-                <input type="text" className="pf-c-form-control" placeholder={valueString.toLowerCase()} value={pair[NameValueEditorPair.Value] || ''} onChange={this._onChangeValue} disabled={readOnly} />
+                <input type="text" className="pf-c-form-control" placeholder={valueString.toLowerCase()} value={pair[NameValueEditorPair.Value] || ''} onChange={this._onChangeValue} disabled={readOnly} data-test-id="nameValueEditorValue" />
               </div>
           }
           {

--- a/frontend/public/components/utils/selector-input.jsx
+++ b/frontend/public/components/utils/selector-input.jsx
@@ -103,7 +103,7 @@ export class SelectorInput extends React.Component {
     };
 
     return <div className="co-search-input pf-c-form-control">
-      <tags-input>
+      <tags-input data-test-id="selector-input">
         <TagsInput ref={this.setRef} className="tags" value={tags} addKeys={addKeys} removeKeys={removeKeys} inputProps={inputProps} renderTag={renderTag} onChange={this.handleChange.bind(this)} addOnPaste addOnBlur />
       </tags-input>
     </div>;


### PR DESCRIPTION
Fixes issue -

- https://jira.coreos.com/browse/ODC-1649

This PR -  

- Applies data-test-id to dropdown menus and input fields for build tab automation.

Following are the places where data-test-id has been added -

    - Actions drop-down button
    - Action Menu Items in the Actions drop-down menu 
    - Builds tab on the build config page
    - Build config actions (The Kebab Menu Items)
    - Edit label input field
    - Edit Annotations input fields

Following items already have the data-test-id so no change required-

    - Builds tab on sidebar
    - Project drop-down menu