### PR TITLE
kubevirt: do not pre-request kubevirt's SC config

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/create-vm-wizard.tsx
@@ -12,7 +12,6 @@ import {
   TemplateModel,
   PersistentVolumeClaimModel,
   StorageClassModel,
-  ConfigMapModel,
 } from '@console/internal/models';
 import { getName } from '@console/shared';
 import { units, Firehose } from '@console/internal/components/utils';
@@ -23,7 +22,6 @@ import {
   DataVolumeModel,
   V2VVMwareModel,
 } from '../../models';
-import { STORAGE_CLASS_CONFIG_MAP_NAMESPACE, STORAGE_CLASS_CONFIG_MAP_NAME } from '../../constants';
 import { createModalResourceLauncher } from './modal-resource-launcher';
 
 const mapStateToProps = ({ k8s }) => {
@@ -59,13 +57,6 @@ export const openCreateVmWizard = (activeNamespace, createTemplate = false) => {
       prop: 'persistentVolumeClaims',
     }),
     getResource(DataVolumeModel, { namespace: activeNamespace, prop: 'dataVolumes' }),
-    getResource(ConfigMapModel, {
-      name: STORAGE_CLASS_CONFIG_MAP_NAME,
-      namespace: STORAGE_CLASS_CONFIG_MAP_NAMESPACE,
-      prop: 'storageClassConfigMap',
-      isList: false,
-      optional: true,
-    }),
   ];
 
   const resourcesToProps = (props) => {
@@ -97,7 +88,6 @@ export const openCreateVmWizard = (activeNamespace, createTemplate = false) => {
       ...flatten('storageClasses'),
       ...flatten('persistentVolumeClaims'),
       ...flatten('dataVolumes'),
-      ...flatten('storageClassConfigMap'),
     };
   };
 

--- a/frontend/packages/kubevirt-plugin/src/constants/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/index.ts
@@ -1,4 +1,3 @@
 export * from './vm';
 export * from './vm-templates';
-export * from './storage-class';
 export * from './cdi';

--- a/frontend/packages/kubevirt-plugin/src/constants/storage-class.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/storage-class.ts
@@ -1,2 +1,0 @@
-export const STORAGE_CLASS_CONFIG_MAP_NAME = 'kubevirt-storage-class-defaults';
-export const STORAGE_CLASS_CONFIG_MAP_NAMESPACE = 'openshift';


### PR DESCRIPTION
The kubevirt-storage-class-config map retrieval is postponed till
actually needed.