### PR TITLE
fix(Pipeline-Rerun): Assign Correct Service Account from latestRun

### DIFF
--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { ALL_NAMESPACES_KEY } from '@console/internal/const';
 import { history } from '@console/internal/components/utils';
 import { getNamespace } from '@console/internal/components/utils/link';
@@ -105,10 +106,7 @@ export const newPipelineRun = (pipeline: Pipeline, latestRun: PipelineRun): Pipe
       trigger: {
         type: 'manual',
       },
-      serviceAccount:
-        latestRun && latestRun.spec && latestRun.spec.serviceAccount
-          ? latestRun.spec.serviceAccount
-          : 'pipeline',
+      serviceAccount: latestRun && _.get(latestRun, ['spec', 'serviceAccount']),
     },
   };
 };


### PR DESCRIPTION
Assigns serviceAccount to next `PipelineRun` from the spec of previous `PipelineRun`

![serviceAccont](https://user-images.githubusercontent.com/24852534/63588203-932ceb80-c5c3-11e9-9e11-4658530d5b72.gif)
