### PR TITLE
Query Browser: For autocomplete, add brackets to aggregation operators

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -54,17 +54,17 @@ import { setAllQueryArguments } from '../utils/router';
 import { chartTheme, Labels, QueryObj, QueryBrowser } from './query-browser';
 
 const aggregationOperators = [
-  'avg',
-  'bottomk',
-  'count',
-  'count_values',
-  'max',
-  'min',
-  'quantile',
-  'stddev',
-  'stdvar',
-  'sum',
-  'topk',
+  'avg()',
+  'bottomk()',
+  'count()',
+  'count_values()',
+  'max()',
+  'min()',
+  'quantile()',
+  'stddev()',
+  'stdvar()',
+  'sum()',
+  'topk()',
 ];
 
 const prometheusFunctions = [


### PR DESCRIPTION
To be consistent with the function name autocomplete suggestions.