### PR TITLE
Fix typo "occured" to "occurred"

### DIFF
--- a/frontend/public/components/utils/resource-log.jsx
+++ b/frontend/public/components/utils/resource-log.jsx
@@ -291,7 +291,7 @@ class ResourceLog_ extends React.Component {
         isInline
         className="co-alert"
         variant="danger"
-        title="An error occured while retrieving the requested logs."
+        title="An error occurred while retrieving the requested logs."
         action={<AlertActionLink onClick={this._restartStream}>Retry</AlertActionLink>}
       />}
       {stale && <Alert


### PR DESCRIPTION
There is a typo in the OpenShift web console when the message is displayed to inform the user that there was an error retrieving logs.