### PR TITLE
Bug 1744490: Fix Icon in Create Operator Subscription Form

### DIFF
--- a/frontend/__tests__/components/operator-hub/operator-hub.spec.tsx
+++ b/frontend/__tests__/components/operator-hub/operator-hub.spec.tsx
@@ -41,7 +41,7 @@ describe('OperatorHubList', () => {
     const amqPackageManifest = operatorHubListPageProps.packageManifest.data[0];
 
     expect(amqTileProps.title).toEqual(amqPackageManifest.status.channels[0].currentCSVDesc.displayName);
-    expect(amqTileProps.iconImg).toEqual('/api/kubernetes/apis/packages.operators.coreos.com/v1/packagemanifests/amq-streams/icon?resourceVersion=amq-streams.preview.amqstreams.v1.0.0.beta');
+    expect(amqTileProps.iconImg).toEqual('/api/kubernetes/apis/packages.operators.coreos.com/v1/namespaces/openshift-operator-lifecycle-manager/packagemanifests/amq-streams/icon?resourceVersion=amq-streams.preview.amqstreams.v1.0.0.beta');
     expect(amqTileProps.iconClass).toBe(null);
     expect(amqTileProps.vendor).toEqual(`provided by ${amqPackageManifest.metadata.labels.provider}`);
     expect(amqTileProps.description.startsWith('**Red Hat AMQ Streams** is a massively scalable, distributed, and high performance data streaming platform based on the Apache Kafka project.')).toBe(true);
@@ -53,7 +53,7 @@ describe('OperatorHubList', () => {
     const prometheusPackageManifest = operatorHubListPageProps.packageManifest.data[3];
 
     expect(prometheusTileProps.title).toEqual(prometheusPackageManifest.status.channels[0].currentCSVDesc.displayName);
-    expect(prometheusTileProps.iconImg).toEqual('/api/kubernetes/apis/packages.operators.coreos.com/v1/packagemanifests/prometheus/icon?resourceVersion=prometheus.preview.prometheusoperator.0.22.2');
+    expect(prometheusTileProps.iconImg).toEqual('/api/kubernetes/apis/packages.operators.coreos.com/v1/namespaces/openshift-operator-lifecycle-manager/packagemanifests/prometheus/icon?resourceVersion=prometheus.preview.prometheusoperator.0.22.2');
     expect(prometheusTileProps.iconClass).toBe(null);
     expect(prometheusTileProps.vendor).toEqual(`provided by ${prometheusPackageManifest.metadata.labels.provider}`);
     expect(prometheusTileProps.description.startsWith('The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.')).toBe(true);
@@ -70,7 +70,7 @@ describe('OperatorHubList', () => {
     const amqPackageManifest = operatorHubListPageProps.packageManifest.data[0];
 
     expect(modalItem.name).toEqual(amqPackageManifest.status.channels[0].currentCSVDesc.displayName);
-    expect(modalItem.imgUrl).toEqual('/api/kubernetes/apis/packages.operators.coreos.com/v1/packagemanifests/amq-streams/icon?resourceVersion=amq-streams.preview.amqstreams.v1.0.0.beta');
+    expect(modalItem.imgUrl).toEqual('/api/kubernetes/apis/packages.operators.coreos.com/v1/namespaces/openshift-operator-lifecycle-manager/packagemanifests/amq-streams/icon?resourceVersion=amq-streams.preview.amqstreams.v1.0.0.beta');
     expect(modalItem.provider).toEqual(amqPackageManifest.metadata.labels.provider);
     expect(modalItem.description.startsWith('**Red Hat AMQ Streams** is a massively scalable, distributed, and high performance data streaming platform based on the Apache Kafka project.')).toBe(true);
 

--- a/frontend/public/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-page.tsx
@@ -5,12 +5,12 @@ import { match } from 'react-router';
 
 import { Firehose, PageHeading, StatusBox, MsgBox, ExternalLink, skeletonCatalog, withFallback } from '../utils';
 import { ErrorBoundaryFallback } from '../error';
-import { referenceForModel, resourceURL } from '../../module/k8s';
+import { referenceForModel } from '../../module/k8s';
 import { fromRequirements } from '../../module/k8s/selector';
 import { PackageManifestModel, OperatorGroupModel, SubscriptionModel } from '../../models';
 import { getOperatorProviderType } from './operator-hub-utils';
 import { OperatorHubTileView } from './operator-hub-items';
-import { PackageManifestKind, OperatorGroupKind, SubscriptionKind } from '../operator-lifecycle-manager';
+import { PackageManifestKind, OperatorGroupKind, SubscriptionKind, iconFor } from '../operator-lifecycle-manager';
 import { installedFor, subscriptionFor } from '../operator-lifecycle-manager/operator-group';
 import { OperatorHubItem, OperatorHubCSVAnnotations } from './index';
 
@@ -19,7 +19,7 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
   const marketplaceItems = _.get(props.marketplacePackageManifest, 'data', [] as PackageManifestKind[]);
   const localItems = _.get(props.packageManifest, 'data', [] as PackageManifestKind[]);
   const items = marketplaceItems.concat(localItems).map(pkg => {
-    const {name, currentCSV, currentCSVDesc} = _.get(pkg, 'status.channels[0]', {});
+    const {currentCSVDesc} = _.get(pkg, 'status.channels[0]', {});
     const currentCSVAnnotations: OperatorHubCSVAnnotations = _.get(currentCSVDesc, 'annotations', {});
 
     return {
@@ -31,7 +31,7 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
       subscription: subscriptionFor(subscription.data)(operatorGroup.data)(pkg.status.packageName)(namespace),
       // FIXME: Just use `installed`
       installState: installedFor(subscription.data)(operatorGroup.data)(pkg.status.packageName)(namespace) ? 'Installed' : 'Not Installed',
-      imgUrl: resourceURL(PackageManifestModel, {ns: namespace, name: pkg.metadata.name, path: 'icon', queryParams: {resourceVersion: [pkg.metadata.name, name, currentCSV].join('.')}}),
+      imgUrl: iconFor(pkg),
       description: currentCSVAnnotations.description || currentCSVDesc.description,
       longDescription: currentCSVDesc.description || currentCSVAnnotations.description,
       provider: _.get(pkg, 'status.provider.name', _.get(pkg, 'metadata.labels.provider')),

--- a/frontend/public/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/public/components/operator-hub/operator-hub-subscribe.tsx
@@ -17,6 +17,7 @@ import {
   supportedInstallModesFor,
   providedAPIsForChannel,
   referenceForProvidedAPI,
+  iconFor,
 } from '../operator-lifecycle-manager';
 import { InstallModeType, installedFor, supports, providedAPIsFor, isGlobal } from '../operator-lifecycle-manager/operator-group';
 import { RadioGroup, RadioInput } from '../radio';
@@ -238,7 +239,10 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
       </ActionGroup>
     </div>
     <div className="col-xs-6">
-      <ClusterServiceVersionLogo displayName={_.get(channels, '[0].currentCSVDesc.displayName')} icon={_.get(channels, '[0].currentCSVDesc.icon[0]')} provider={provider} />
+      <ClusterServiceVersionLogo
+        displayName={_.get(channels, '[0].currentCSVDesc.displayName')}
+        icon={iconFor(props.packageManifest.data[0])}
+        provider={provider} />
       <h4>Provided APIs</h4>
       <div className="co-crd-card-row">
         { _.isEmpty(providedAPIsForChannel(props.packageManifest.data[0])(selectedUpdateChannel))


### PR DESCRIPTION
### Description

The base64 data was removed, so use the `packagemanifests/icon` subresource instead. Also fix `all-namespaces` icons for **OperatorHub** view (missing `namespace` parameter).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1744490