### PR TITLE
Allow fetching additional k8s resource to prometheus health subsystem

### DIFF
--- a/frontend/packages/console-demo-plugin/src/dashboards/health.ts
+++ b/frontend/packages/console-demo-plugin/src/dashboards/health.ts
@@ -1,12 +1,21 @@
+import * as _ from 'lodash';
 import { HealthState } from '@console/internal/components/dashboard/health-card/states';
 import { SubsystemHealth } from '@console/internal/components/dashboards-page/overview-dashboard/health-card';
+import { FirehoseResult } from '@console/internal/components/utils';
 
 export const getFooHealthState = (): SubsystemHealth => ({
   message: 'Foo is healthy',
   state: HealthState.OK,
 });
 
-export const getBarHealthState = (): SubsystemHealth => ({
-  message: 'Bar is in an error state',
-  state: HealthState.ERROR,
-});
+export const getBarHealthState = (response, nodes: FirehoseResult): SubsystemHealth => {
+  if (!response || !_.get(nodes, 'loaded')) {
+    return {
+      state: HealthState.LOADING,
+    };
+  }
+  return {
+    message: 'Bar is in an error state',
+    state: HealthState.ERROR,
+  };
+};

--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -22,7 +22,7 @@ import {
   DashboardsOverviewTopConsumerItem,
 } from '@console/plugin-sdk';
 // TODO(vojtech): internal code needed by plugins should be moved to console-shared package
-import { PodModel, RouteModel } from '@console/internal/models';
+import { PodModel, RouteModel, NodeModel } from '@console/internal/models';
 import { FLAGS } from '@console/internal/const';
 import { GridPosition } from '@console/internal/components/dashboard/grid';
 import { humanizeBinaryBytesWithoutB } from '@console/internal/components/utils/units';
@@ -155,6 +155,12 @@ const plugin: Plugin<ConsumedExtensions> = [
       title: 'Bar system',
       query: 'barQuery',
       healthHandler: getBarHealthState,
+      resource: {
+        kind: NodeModel.kind,
+        isList: true,
+        namespaced: false,
+        prop: 'nodes',
+      },
       required: 'TEST_MODEL_FLAG',
     },
   },

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -1,11 +1,12 @@
 import { SubsystemHealth } from '@console/internal/components/dashboards-page/overview-dashboard/health-card';
 import { GridPosition } from '@console/internal/components/dashboard/grid';
-import { FirehoseResource, Humanize } from '@console/internal/components/utils';
-import { K8sKind } from '@console/internal/module/k8s';
+import { FirehoseResource, Humanize, FirehoseResult } from '@console/internal/components/utils';
+import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { StatusGroupMapper } from '@console/internal/components/dashboard/inventory-card/inventory-item';
 import { OverviewQuery } from '@console/internal/components/dashboards-page/overview-dashboard/queries';
 import { ConsumerMutator } from '@console/internal/components/dashboards-page/overview-dashboard/top-consumers-card';
 import { MetricType } from '@console/internal/components/dashboard/top-consumers-card/metric-type';
+import { PrometheusResponse } from '@console/internal/components/graphs';
 import { Extension } from './extension';
 import { LazyLoader } from './types';
 
@@ -15,16 +16,13 @@ namespace ExtensionProperties {
     required: string;
   }
 
-  interface DashboardsOverviewHealthSubsystem<R> extends DashboardExtension {
+  interface DashboardsOverviewHealthSubsystem extends DashboardExtension {
     /** The subsystem's display name */
     title: string;
-
-    /** Resolve the subsystem's health */
-    healthHandler: (response: R) => SubsystemHealth;
   }
 
   export interface DashboardsOverviewHealthURLSubsystem<R>
-    extends DashboardsOverviewHealthSubsystem<R> {
+    extends DashboardsOverviewHealthSubsystem {
     /**
      * The URL to fetch data from. It will be prefixed with base k8s URL.
      * For example: `healthz` will result in `<k8sBasePath>/healthz`
@@ -37,12 +35,24 @@ namespace ExtensionProperties {
      * Response is then parsed by `healthHandler`.
      */
     fetch?: (url: string) => Promise<R>;
+
+    /** Resolve the subsystem's health */
+    healthHandler: (response: R) => SubsystemHealth;
   }
 
   export interface DashboardsOverviewHealthPrometheusSubsystem
-    extends DashboardsOverviewHealthSubsystem<any> {
+    extends DashboardsOverviewHealthSubsystem {
     /** The Prometheus query */
     query: string;
+
+    /** Resource which will be fetched and passed to healthHandler  */
+    resource?: FirehoseResource;
+
+    /** Resolve the subsystem's health */
+    healthHandler: (
+      response: PrometheusResponse,
+      resource?: FirehoseResult<K8sResourceKind | K8sResourceKind[]>,
+    ) => SubsystemHealth;
   }
 
   export interface DashboardsTab extends DashboardExtension {

--- a/frontend/public/components/dashboards-page/overview-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/inventory-card.tsx
@@ -16,6 +16,7 @@ import { getPodStatusGroups, getNodeStatusGroups, getPVCStatusGroups } from '../
 import { FirehoseResource } from '../../utils';
 import { connectToFlags, FlagsObject, WithFlagsProps } from '../../../reducers/features';
 import { getFlagsForExtensions } from '../utils';
+import { uniqueResource } from './utils';
 
 const k8sResources: FirehoseResource[] = [
   {
@@ -34,11 +35,6 @@ const k8sResources: FirehoseResource[] = [
     prop: 'pvcs',
   },
 ];
-
-const uniqueResource = (resource: FirehoseResource, index: number): FirehoseResource => ({
-  ...resource,
-  prop: `${index}-${resource.prop}`,
-});
 
 const getItems = (flags: FlagsObject) =>
   plugins.registry.getDashboardsOverviewInventoryItems().filter(e => flags[e.properties.required]);

--- a/frontend/public/components/dashboards-page/overview-dashboard/utils.ts
+++ b/frontend/public/components/dashboards-page/overview-dashboard/utils.ts
@@ -1,0 +1,6 @@
+import { FirehoseResource } from '../../utils';
+
+export const uniqueResource = (resource: FirehoseResource, prefix: string | number): FirehoseResource => ({
+  ...resource,
+  prop: `${prefix}-${resource.prop}`,
+});


### PR DESCRIPTION
Ceph plugin needs to fetch k8s resource to determine the name of ceph cluster - https://github.com/openshift/console/pull/2411

@anmolsachan please let me know if it works for you. K8s resource is passed to `healthHandler` function. I've also updated `demo-plugin` to showcase the usage