### PR TITLE
Fixed the broken links in object service dashboard

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card.tsx
@@ -69,7 +69,7 @@ const ObjectDashboardBucketsCard: React.FC<DashboardItemProps> = ({
   const noobaaSystemName = getMetric(bucketsLinksResponse, 'system_name');
   let link = null;
   if (noobaaSystemAddress && noobaaSystemName)
-    link = `${noobaaSystemAddress}/fe/systems/${noobaaSystemName}/buckets/data-buckets`;
+    link = `${noobaaSystemAddress}fe/systems/${noobaaSystemName}/buckets/data-buckets`;
 
   const bucketProps: BucketsType = {
     bucketsCount: getPropsData(objectBucketsCount),

--- a/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card.tsx
@@ -73,7 +73,7 @@ const ResourceProviders: React.FC<DashboardItemProps> = ({
   const noobaaSystemName = getMetric(resourcesLinksResponse, 'system_name');
   let link = null;
   if (noobaaSystemAddress && noobaaSystemName)
-    link = `${noobaaSystemAddress}/fe/systems/${noobaaSystemName}/resources/cloud/`;
+    link = `${noobaaSystemAddress}fe/systems/${noobaaSystemName}/resources/cloud/`;
 
   const allProviders = createProvidersList(providersTypesQueryResult);
   const unhealthyProviders = createProvidersList(unhealthyProvidersTypesQueryResult);

--- a/frontend/packages/noobaa-storage-plugin/src/utils.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/utils.ts
@@ -7,7 +7,7 @@ export const filterNooBaaAlerts = (alerts: Alert[]): Alert[] =>
 export const getPropsData = (data) => _.get(data, 'data.result[0].value[1]', null);
 
 export const getMetric = (result: PrometheusMetricResult, metric: string): string =>
-  _.get(result, ['metric', metric], null);
+  _.get(result, ['data', 'result', '0', 'metric', metric], null);
 
 export const getValue = (result: PrometheusMetricResult): number => _.get(result, 'value[1]', null);
 


### PR DESCRIPTION
### Bug: 
links to unhealthy buckets and resource providers are currently broken and lands to wrong URL

### Fix:
- removing `/` from the path
- modifying the `getMetric` function to fetch the correct metric name from the `prometheus object`. [_This function then can be reused in other cards as well, by providing the metric name only_]