### PR TITLE
Addition of alert class modifier to apply top-margin in cases where the adjacent element above doesn't have bottom margin.

### DIFF
--- a/frontend/public/components/utils/list-dropdown.jsx
+++ b/frontend/public/components/utils/list-dropdown.jsx
@@ -121,7 +121,7 @@ class ListDropdown_ extends React.Component {
 
     return <div>
       { Component }
-      { loaded && _.isEmpty(items) && <Alert isInline className="co-alert" variant="info" title={`No ${desc} found or defined`} />}
+      { loaded && _.isEmpty(items) && <Alert isInline className="co-alert pf-c-alert--top-margin" variant="info" title={`No ${desc} found or defined`} />}
     </div>;
   }
 }

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -103,6 +103,10 @@ kbd {
   max-width: 100%;
 }
 
+.pf-c-alert--top-margin {
+  margin-top: var(--pf-global--spacer--lg);
+}
+
 // Temp fix to adjust dropdown item spacing until issue can be addressed upstream in PatternFly
 .pf-c-app-launcher {
   &__group {


### PR DESCRIPTION
Prevent alerts from touching adjacent elements above them, that don't have `bottom-margin`
In this case 'pf-c-dropdown' and 'pf-c-alert' need margin between them.

<img width="1192" alt="Screen Shot 2019-08-22 at 2 25 12 PM" src="https://user-images.githubusercontent.com/1874151/63705576-7a0e7f80-c7fb-11e9-9b97-948eb33b1a97.png">


**Fix**
<img width="695" alt="Screen Shot 2019-08-26 at 12 15 45 PM" src="https://user-images.githubusercontent.com/1874151/63705589-8561ab00-c7fb-11e9-87b0-c62e0a5d75a1.png">
