### PR TITLE
dashboard: line-clamp long event messages

### DIFF
--- a/frontend/public/components/dashboard/events-card/events-card.scss
+++ b/frontend/public/components/dashboard/events-card/events-card.scss
@@ -29,6 +29,7 @@
 .co-events-card__item-message {
   font-size: 0.875rem;
   margin-top: 0.5em;
+  @include co-line-clamp(5);
 }
 
 .co-events-card__item-resourcelink {


### PR DESCRIPTION
Limit event message length to five lines in the dashboard card. The full event message is visible if you click "View all."

/assign @rawagner @andybraren 

Before:

<img width="344" alt="Screen Shot 2019-08-10 at 10 41 49 AM" src="https://user-images.githubusercontent.com/1167259/63789468-6f202180-c8c5-11e9-9f40-7e8b84c441c9.png">

After:

![Screen Shot 2019-08-27 at 12 21 51 PM](https://user-images.githubusercontent.com/1167259/63789520-8a8b2c80-c8c5-11e9-8d5e-85a111cc2670.png)
