### PR TITLE
Make Pipeline Task Status bar use space more efficiently

### DIFF
--- a/frontend/packages/dev-console/src/components/charts/HorizontalStackedBars.scss
+++ b/frontend/packages/dev-console/src/components/charts/HorizontalStackedBars.scss
@@ -1,0 +1,13 @@
+.odc-horizontal-stacked-bars {
+  display: inline-flex;
+  flex-direction: row;
+  height: 100%;
+  outline: none;
+  vertical-align: middle;
+  width: 100%;
+
+  &__data-bar {
+    height: 100%;
+    transition: flex-grow 300ms linear;
+  }
+}

--- a/frontend/packages/dev-console/src/components/charts/HorizontalStackedBars.tsx
+++ b/frontend/packages/dev-console/src/components/charts/HorizontalStackedBars.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import './HorizontalStackedBars.scss';
+
+export type StackedValue = {
+  color: string;
+  name: string;
+  size: number;
+};
+
+export type HorizontalStackedBarsProps = {
+  disableAnimation?: boolean;
+  height?: number | string;
+  values: StackedValue[];
+  width?: number | string;
+};
+
+const HorizontalStackedBars: React.FC<HorizontalStackedBarsProps> = ({
+  disableAnimation,
+  height,
+  values,
+  width,
+}) => {
+  return (
+    <div className="odc-horizontal-stacked-bars" style={{ height, width }}>
+      {values.map(({ color, name, size }) => (
+        <div
+          key={name}
+          className="odc-horizontal-stacked-bars__data-bar"
+          style={{
+            background: color,
+            flexGrow: size,
+            transition: disableAnimation ? 'initial' : undefined,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default HorizontalStackedBars;


### PR DESCRIPTION
Addressing Pipeline Status Bars not filling their table cell.

https://jira.coreos.com/browse/ODC-1459

Dropped victory charts as the nature of the design was going to require a more finicky "resize-sensor" like action to make it do what Flexbox could do out of the gate.

![image](https://user-images.githubusercontent.com/8126518/63870855-cf2bcc00-c988-11e9-9621-8f2cf0cf248a.png)
