### PR TITLE
Bug fix for data consumption prometheus query change

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.tsx
@@ -18,37 +18,19 @@ import {
   DashboardItemProps,
   withDashboardResources,
 } from '@console/internal/components/dashboards-page/with-dashboard-resources';
-import { humanizeBinaryBytes, humanizeNumber } from '@console/internal/components/utils';
 import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
-import { DATA_CONSUMPTION_QUERIES, ObjectServiceDashboardQuery } from '../../constants/queries';
+import { humanizeBinaryBytes, humanizeNumber } from '@console/internal/components/utils';
+import { PrometheusResponse } from '@console/internal/components/graphs';
+import { BY_IOPS, CHART_LABELS, PROVIDERS } from '../../constants';
 import {
-  ACCOUNTS,
-  BY_IOPS,
-  BY_LOGICAL_USAGE,
-  BY_PHYSICAL_VS_LOGICAL_USAGE,
-  BY_EGRESS,
-  PROVIDERS,
-  CHART_LABELS,
-} from '../../constants';
-import { DataConsumptionDropdown } from './data-consumption-card-dropdown';
-import {
-  BarChartData,
-  metricsChartDataMap,
-  metricsChartLegendDataMap,
+  DataConsumersValue,
+  DataConsumersSortByValue,
+  getDataConsumptionChartData,
+  getQueries,
   numberInWords,
 } from './data-consumption-card-utils';
+import { DataConsumptionDropdown } from './data-consumption-card-dropdown';
 import './data-consumption-card.scss';
-
-const DataConsumersValue = {
-  [PROVIDERS]: 'PROVIDERS_',
-  [ACCOUNTS]: 'ACCOUNTS_',
-};
-const DataConsumersSortByValue = {
-  [BY_IOPS]: 'BY_IOPS',
-  [BY_LOGICAL_USAGE]: 'BY_LOGICAL_USAGE',
-  [BY_PHYSICAL_VS_LOGICAL_USAGE]: 'BY_PHYSICAL_VS_LOGICAL_USAGE',
-  [BY_EGRESS]: 'BY_EGRESS',
-};
 
 const DataConsumptionCard: React.FC<DashboardItemProps> = ({
   watchPrometheus,
@@ -59,67 +41,52 @@ const DataConsumptionCard: React.FC<DashboardItemProps> = ({
   const [sortByKpi, setsortByKpi] = React.useState(BY_IOPS);
 
   React.useEffect(() => {
-    const query =
-      DATA_CONSUMPTION_QUERIES[
-        ObjectServiceDashboardQuery[
-          DataConsumersValue[metricType] + DataConsumersSortByValue[sortByKpi]
-        ]
-      ];
-    watchPrometheus(query);
-    return () => stopWatchPrometheusQuery(query);
+    const { queries, keys } = getQueries(metricType, sortByKpi);
+    keys.forEach((key) => watchPrometheus(queries[key]));
+    return () => keys.forEach((key) => stopWatchPrometheusQuery(queries[key]));
   }, [watchPrometheus, stopWatchPrometheusQuery, metricType, sortByKpi]);
 
-  const dataConsumptionQueryResult = prometheusResults.getIn([
-    DATA_CONSUMPTION_QUERIES[
-      ObjectServiceDashboardQuery[
-        DataConsumersValue[metricType] + DataConsumersSortByValue[sortByKpi]
-      ]
-    ],
-    'result',
-  ]);
+  const { queries, keys } = getQueries(metricType, sortByKpi);
+  const result: { [key: string]: PrometheusResponse } = {};
+  keys.forEach((key) => {
+    result[key] = prometheusResults.getIn([queries[key], 'result']); // building an object having 'key'from the queries object and 'value' as the Prometheus response
+  });
 
+  let yTickValues: number[];
   let maxVal: number;
-  let chartData = [];
-  let legendData = [];
-  let suffixLabel = '';
-  const result = _.get(dataConsumptionQueryResult, 'data.result', []);
-  if (result.length) {
-    let maxData: BarChartData | any = {
-      x: '',
-      y: 0,
-      name: '',
-      yOriginal: 0,
-      unit: '',
-    };
-    chartData = metricsChartDataMap[metricType][sortByKpi](result);
-    legendData = metricsChartLegendDataMap[metricType][sortByKpi](chartData);
-    maxData = _.maxBy(chartData.map((data) => _.maxBy(data, 'yOriginal')), 'yOriginal');
-    const maxDataV = Number(maxData.yOriginal);
-    const maxDataVStr = maxDataV.toFixed(1);
-    let maxDataH = humanizeBinaryBytes(maxDataVStr);
+  let suffixLabel: string = '';
+
+  const isLoading = _.values(result).includes(undefined);
+
+  const metric = metricType === PROVIDERS ? 'type' : 'account';
+  const curentDropdown = DataConsumersValue[metricType] + DataConsumersSortByValue[sortByKpi];
+  const { chartData, legendData } = getDataConsumptionChartData(result, metric, curentDropdown);
+
+  // chartData = [[]] or [[],[]]
+  if (!chartData.some(_.isEmpty)) {
+    maxVal = _.maxBy(chartData.map((data) => _.maxBy(data, 'y')), 'y').y;
+    let maxDataH = humanizeBinaryBytes(maxVal);
     suffixLabel = maxDataH.unit;
     if (sortByKpi === BY_IOPS) {
-      suffixLabel = numberInWords(maxDataV);
-      maxDataH = humanizeNumber(maxDataVStr);
+      suffixLabel = numberInWords(maxVal);
+      maxDataH = humanizeNumber(maxVal);
     }
     // if suffixLabel is a non-empty string, show it in expected form
     if (suffixLabel) suffixLabel = `(in ${suffixLabel})`;
-    maxVal = Number(maxDataH.value);
+    yTickValues = [
+      Number((maxVal / 10).toFixed(1)),
+      Number((maxVal / 5).toFixed(1)),
+      Number(((3 * maxVal) / 10).toFixed(1)),
+      maxVal,
+      Number(((4 * maxVal) / 10).toFixed(1)),
+      Number(((5 * maxVal) / 10).toFixed(1)),
+      Number(((6 * maxVal) / 10).toFixed(1)),
+      Number(((7 * maxVal) / 10).toFixed(1)),
+      Number(((8 * maxVal) / 10).toFixed(1)),
+      Number(((9 * maxVal) / 10).toFixed(1)),
+      Number(Number(maxVal).toFixed(1)),
+    ];
   }
-
-  const yTickValues = [
-    Number((maxVal / 10).toFixed(1)),
-    Number((maxVal / 5).toFixed(1)),
-    Number(((3 * maxVal) / 10).toFixed(1)),
-    maxVal,
-    Number(((4 * maxVal) / 10).toFixed(1)),
-    Number(((5 * maxVal) / 10).toFixed(1)),
-    Number(((6 * maxVal) / 10).toFixed(1)),
-    Number(((7 * maxVal) / 10).toFixed(1)),
-    Number(((8 * maxVal) / 10).toFixed(1)),
-    Number(((9 * maxVal) / 10).toFixed(1)),
-    Number(Number(maxVal).toFixed(1)),
-  ];
 
   return (
     <DashboardCard>
@@ -132,11 +99,8 @@ const DataConsumptionCard: React.FC<DashboardItemProps> = ({
           setKpi={setsortByKpi}
         />
       </DashboardCardHeader>
-      <DashboardCardBody
-        className="co-dashboard-card__body--top-margin"
-        isLoading={!dataConsumptionQueryResult}
-      >
-        {chartData.length > 0 ? (
+      <DashboardCardBody isLoading={isLoading}>
+        {!chartData.some(_.isEmpty) ? (
           <div>
             <span className="text-secondary">
               {CHART_LABELS[sortByKpi]} {suffixLabel}
@@ -158,8 +122,8 @@ const DataConsumptionCard: React.FC<DashboardItemProps> = ({
                 }}
               />
               <ChartGroup offset={11}>
-                {chartData.map((data) => (
-                  <ChartBar key={data.name} data={data} />
+                {chartData.map((data, i) => (
+                  <ChartBar key={i} data={data} /> // eslint-disable-line react/no-array-index-key
                 ))}
               </ChartGroup>
             </Chart>

--- a/frontend/packages/noobaa-storage-plugin/src/constants/queries.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/queries.ts
@@ -6,11 +6,36 @@ export enum ObjectServiceDashboardQuery {
   PROVIDERS_BY_EGRESS = 'PROVIDERS_BY_EGRESS',
 }
 
-export const DATA_CONSUMPTION_QUERIES = {
-  [ObjectServiceDashboardQuery.ACCOUNTS_BY_IOPS]: 'NooBaa_accounts_io_usage',
-  [ObjectServiceDashboardQuery.ACCOUNTS_BY_LOGICAL_USAGE]: 'NooBaa_accounts_io_usage',
-  [ObjectServiceDashboardQuery.PROVIDERS_BY_IOPS]: 'NooBaa_providers_ops',
-  [ObjectServiceDashboardQuery.PROVIDERS_BY_PHYSICAL_VS_LOGICAL_USAGE]:
-    'NooBaa_providers_physical_logical',
-  [ObjectServiceDashboardQuery.PROVIDERS_BY_EGRESS]: 'NooBaa_providers_bandwidth',
+export const DATA_CONSUMPTION_QUERIES: DataConsumptionQueriesType = {
+  [ObjectServiceDashboardQuery.ACCOUNTS_BY_IOPS]: {
+    read: 'sort(topk(5,NooBaa_accounts_usage_read_count)))',
+    write: 'sort(topk(5,NooBaa_accounts_usage_write_count))',
+    totalRead: 'sum(NooBaa_accounts_usage_read_count)',
+    totalWrite: 'sum(NooBaa_accounts_usage_write_count)',
+  },
+  [ObjectServiceDashboardQuery.ACCOUNTS_BY_LOGICAL_USAGE]: {
+    logicalUsage: 'sort(topk(5,NooBaa_accounts_usage_logical))',
+    totalLogicalUsage: 'sum(NooBaa_accounts_usage_logical)',
+  },
+  [ObjectServiceDashboardQuery.PROVIDERS_BY_IOPS]: {
+    read: 'sort(topk(5,NooBaa_providers_ops_read_num))',
+    write: 'sort(topk(5,NooBaa_providers_ops_write_num))',
+    totalRead: 'sum(NooBaa_providers_ops_read_num)',
+    totalWrite: 'sum(NooBaa_providers_ops_write_num)',
+  },
+  [ObjectServiceDashboardQuery.PROVIDERS_BY_PHYSICAL_VS_LOGICAL_USAGE]: {
+    physicalUsage: 'sort(topk(5,NooBaa_providers_physical_size))',
+    logicalUsage: 'sort(topk(5,NooBaa_providers_logical_size))',
+    totalPhysicalUsage: 'sum(NooBaa_providers_physical_size)',
+    totalLogicalUsage: 'sum(NooBaa_providers_logical_size)',
+  },
+  [ObjectServiceDashboardQuery.PROVIDERS_BY_EGRESS]: {
+    egress: 'sort(topk(5,NooBaa_providers_bandwidth_read_size + NooBaa_providers_bandwidth_write_size))',
+  },
+};
+
+export type DataConsumptionQueriesType = {
+  [key: string]: {
+    [key: string]: string;
+  };
 };

--- a/frontend/packages/noobaa-storage-plugin/src/constants/queries.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/queries.ts
@@ -30,7 +30,8 @@ export const DATA_CONSUMPTION_QUERIES: DataConsumptionQueriesType = {
     totalLogicalUsage: 'sum(NooBaa_providers_logical_size)',
   },
   [ObjectServiceDashboardQuery.PROVIDERS_BY_EGRESS]: {
-    egress: 'sort(topk(5,NooBaa_providers_bandwidth_read_size + NooBaa_providers_bandwidth_write_size))',
+    egress:
+      'sort(topk(5,NooBaa_providers_bandwidth_read_size + NooBaa_providers_bandwidth_write_size))',
   },
 };
 


### PR DESCRIPTION
### Bug
The data consumption card searches for stale metrics and always shows `No Prometheus Data Points`
### Fix
Updated the card with all the latest metrics 

### Prometheus Queries Overview
* On the selection of drop down, a few metrics need to polled instead single metric per drop down
* All metrics are an Instant Vector now with no values hacked into labels.
* No calculation for addition/sorting needs to be done on UI front, everything is handled by queries.

### Subsequent Changes in the UI
* Due to the change in the `Prometheus response` for the current metrics , the subsequent individual functions needs to be removed.
* Replaced the previous individual functions, with a switch case which then fetches the data from generic functions.
* Enhancement of the chart look and feel

### People
Thanx @anmolsachan for reviewing and @jeniawhite for helping with testing and providing the actual metrics for all of the cards.

### Screenshots
![Screenshot from 2019-09-04 12-09-26](https://user-images.githubusercontent.com/25664409/64235318-b5086580-cf15-11e9-9c49-5e681fa280cd.png)
![Screenshot from 2019-09-04 12-09-35](https://user-images.githubusercontent.com/25664409/64235321-b5a0fc00-cf15-11e9-9bab-1da64e76f44a.png)

