### PR TITLE
Bug 1730540: Query Browser: Insert example query in focused input & run immediately

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -623,9 +623,9 @@ const QueryBrowserWrapper_: React.FC<QueryBrowserWrapperProps> = ({patchQuery, q
   }, [queryStrings]);
 
   const insertExampleQuery = () => {
-    const index = 0;
+    const index = _.get(focusedQuery, 'index', 0);
     const text = 'sum(sort_desc(sum_over_time(ALERTS{alertstate="firing"}[24h]))) by (alertname)';
-    patchQuery(index, {isEnabled: true, query: '', text});
+    patchQuery(index, {isEnabled: true, query: text, text});
   };
 
   return queryStrings.join('') === ''


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1730540

Set `query` when the example is inserted so it runs immediately. I think
this is less confusing UX.