### PR TITLE
Query Browser: Allow "running" empty queries

### DIFF
--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -174,7 +174,7 @@ export default (state: UIState, action: UIAction): UIState => {
         const isEnabled = q.get('isEnabled');
         const query = q.get('query');
         const text = _.trim(q.get('text'));
-        return isEnabled && text && query !== text ? q.merge({query: text, series: undefined}) : q;
+        return isEnabled && query !== text ? q.merge({query: text, series: undefined}) : q;
       });
       return state.setIn(['queryBrowser', 'queries'], queries);
     }


### PR DESCRIPTION
This fixes a bug where clearing a query input, then clicking the Run
Queries button would have no effect. With this change, the query is
correctly removed from the graph and the results table cleared.