### PR TITLE
fix bug wherein runtime label is not taking precedence over name when both are present to determine topology node icon

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
@@ -42,7 +42,7 @@ Object {
   "topology": Object {
     "02f680df-680f-11e9-b69e-5254003f9382": Object {
       "data": Object {
-        "builderImage": undefined,
+        "builderImage": "test-file-stub",
         "donutStatus": Object {
           "build": undefined,
           "pods": Array [
@@ -306,7 +306,7 @@ Object {
     },
     "5ca9ae28-680d-11e9-8c69-5254003f9382": Object {
       "data": Object {
-        "builderImage": "python",
+        "builderImage": "test-file-stub",
         "donutStatus": Object {
           "build": undefined,
           "pods": Array [
@@ -761,7 +761,7 @@ Object {
     },
     "60a9b423-680d-11e9-8c69-5254003f9382": Object {
       "data": Object {
-        "builderImage": "nodejs",
+        "builderImage": "test-file-stub",
         "donutStatus": Object {
           "build": undefined,
           "pods": Array [

--- a/frontend/packages/dev-console/src/components/topology/shapes/BaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/BaseNode.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import SvgDropShadowFilter from '../../svg/SvgDropShadowFilter';
 import { createSvgIdUrl } from '../../../utils/svg-utils';
 import SvgBoxedText from '../../svg/SvgBoxedText';
@@ -122,9 +121,7 @@ export default class BaseNode extends React.Component<BaseNodeProps, State> {
               y={-innerRadius}
               width={innerRadius * 2}
               height={innerRadius * 2}
-              xlinkHref={
-                getImageForIconClass(`icon-${icon}`) || getImageForIconClass('icon-openshift')
-              }
+              xlinkHref={icon}
             />
             {label != null && (
               <SvgBoxedText

--- a/frontend/packages/dev-console/src/components/topology/shapes/__tests__/BaseNode.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/__tests__/BaseNode.spec.tsx
@@ -93,18 +93,6 @@ describe('BaseNode', () => {
     expect(wrapper.find('#second').exists()).toBeTruthy();
   });
 
-  it('should render icon', () => {
-    const wrapper = shallow(<BaseNode outerRadius={100} icon="testicon" />);
-    const imageWrapper = wrapper.find('image');
-    expect(imageWrapper.props().xlinkHref).toBe('icon-testicon');
-  });
-
-  it('should render fallback icon if icon cannot be found', () => {
-    const wrapper = shallow(<BaseNode outerRadius={100} icon="unknown" />);
-    const imageWrapper = wrapper.find('image');
-    expect(imageWrapper.props().xlinkHref).toBe('icon-openshift');
-  });
-
   it('should handle selection', () => {
     const onSelect = jest.fn();
     const fakeEvent = { stopPropagation: jest.fn() };

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -4,6 +4,7 @@ import { getRouteWebURL } from '@console/internal/components/routes';
 import { KNATIVE_SERVING_LABEL } from '@console/knative-plugin';
 import { sortBuilds } from '@console/internal/components/overview';
 import { ResourceProps, TransformPodData, updateResourceApplication } from '@console/shared';
+import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import { TopologyDataModel, TopologyDataResources, TopologyDataObject } from './topology-types';
 
 const isKnativeDeployment = (dc: ResourceProps): boolean => {
@@ -140,7 +141,10 @@ export class TransformTopologyData {
           editUrl:
             deploymentsAnnotations['app.openshift.io/edit-url'] ||
             getEditURL(deploymentsAnnotations['app.openshift.io/vcs-uri'], this.cheURL),
-          builderImage: deploymentsLabels['app.kubernetes.io/name'],
+          builderImage:
+            getImageForIconClass(`icon-${deploymentsLabels['app.openshift.io/runtime']}`) ||
+            getImageForIconClass(`icon-${deploymentsLabels['app.kubernetes.io/name']}`) ||
+            getImageForIconClass(`icon-openshift`),
           isKnativeResource: this.transformPodData.isKnativeServing(
             deploymentConfig,
             'metadata.labels',

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -10,6 +10,7 @@ export const getAppLabels = (
     'app.kubernetes.io/instance': name,
     'app.kubernetes.io/component': name,
     'app.kubernetes.io/name': imageStreamName,
+    'app.openshift.io/runtime': imageStreamName,
     ...(selectedTag && { 'app.openshift.io/runtime-version': selectedTag }),
   };
 };


### PR DESCRIPTION
Jira Issue: https://jira.coreos.com/browse/ODC-1696

Fixed the issue by using `app.openshift.io/runtime` label value first for the `builderImage` if the label exists.