### PR TITLE
Bug 1745485: Query Browser: Fix tooltips

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -158,7 +158,7 @@ $tooltip-background-color: #151515;
 .query-browser__tooltip-wrap {
   align-items: center;
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   height: 100%;
   width: 100%;
 }
@@ -166,16 +166,16 @@ $tooltip-background-color: #151515;
 .query-browser__tooltip {
   background-color: $tooltip-background-color;
   color: #eee;
-  font-size: var(--pf-global--FontSize--sm);
+  font-size: 12px;
   overflow-y: auto;
   padding: 15px;
   width: 100%;
 }
 
 .query-browser__tooltip-arrow {
+  border-bottom: 12px solid $tooltip-background-color;
   border-left: 12px solid transparent;
   border-right: 12px solid transparent;
-  border-top: 12px solid $tooltip-background-color;
   height: 0;
   width: 0;
 }


### PR DESCRIPTION
Fixes several tooltip bugs
- Fix crash when displaying tooltip.
- Change tooltips to go below the cursor rather than above, which means
  they can be taller. Fixes an issue where not all labels were visible
  and it was not possible to scroll the tooltip.
- Fix tooltip on the alert details page by ensuring that `query` is set
  when the graph `series` are stored. Necessary because the Query
  Browser page sets `query`, but the alert details page does not. (bug
  introduced by https://github.com/openshift/console/pull/2481)
- Reduce the font size and add text truncation to better handle long
  labels.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1745485
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1738757

![screenshot](https://user-images.githubusercontent.com/460802/63874386-654d0a00-c9fc-11e9-96fa-065c8d0b1230.png)

FYI @cshinn 