### PR TITLE
Make co-search-input height match pf-c-form-control default

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -15,7 +15,8 @@
   align-items: center;
   display: flex;
   height: auto; // allow tags to wrap
-  padding: 3px 0;
+  min-height: 34px; // Make consistent with pf-c-form-control
+  padding-bottom: 4px; // reduce 2px to offset for the co-m-label 2px margin-bottom
   width: 100%;
 }
 

--- a/frontend/public/components/operator-lifecycle-manager/create-operand.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/create-operand.tsx
@@ -407,8 +407,8 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
   useScrollToTopOnMount();
 
   return <div className="co-m-pane__body">
-    <form className="col-md-6" onSubmit={submit}>
-      <div className="row">
+    <div className="row">
+      <form className="col-md-6" onSubmit={submit}>
         <div className="form-group">
           <label className="control-label co-required" htmlFor="name">Name</label>
           <input
@@ -419,78 +419,76 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
             id="metadata.name"
             required />
         </div>
-      </div>
-      <div className="row">
         <div className="form-group">
           <label className="control-label" htmlFor="tags-input">Labels</label>
           <SelectorInput onChange={labels => setFormValues(values => ({...values, 'metadata.labels': labels}))} tags={formValues['metadata.labels']} />
         </div>
-      </div>
-      { [...arrayFieldGroups].map(group => <div key={group} className="row">
-        <label className="form-label">{_.startCase(group.split(SpecCapability.arrayFieldGroup)[1])}</label>
-        <div className="co-operand-field-group">
-          { fields.filter(f => f.capabilities.includes(group))
-            .filter(f => !_.isNil(inputFor(f))).map(field => <div key={field.path}>
-              <div className="form-group co-create-operand__form-group">
-                <label className={classNames('form-label', {'co-required': field.required})} htmlFor={field.path}>{field.displayName}</label>
-                { inputFor(field) }
-                { field.description && <span id={`${field.path}__description`} className="help-block text-muted">{field.description}</span> }
-                { formErrors[field.path] && <span className="co-error">{formErrors[field.path]}</span> }
-              </div>
-            </div>) }
-        </div>
-      </div>) }
-      { [...fieldGroups].map(group => <div key={group} className="row">
-        <label className="form-label">{_.startCase(group.split(SpecCapability.fieldGroup)[1])}</label>
-        <div className="co-operand-field-group">
-          { fields.filter(f => f.capabilities.includes(group))
-            .filter(f => !_.isNil(inputFor(f))).map(field => <div key={field.path}>
-              <div className="form-group co-create-operand__form-group">
-                <label className={classNames('form-label', {'co-required': field.required})} htmlFor={field.path}>{field.displayName}</label>
-                { inputFor(field) }
-                { field.description && <span id={`${field.path}__description`} className="help-block text-muted">{field.description}</span> }
-                { formErrors[field.path] && <span className="co-error">{formErrors[field.path]}</span> }
-              </div>
-            </div>) }
-        </div>
-      </div>) }
-      { fields.filter(f => !f.capabilities.some(c => c.startsWith(SpecCapability.fieldGroup) || c.startsWith(SpecCapability.arrayFieldGroup)))
-        .filter(f => !_.isNil(inputFor(f))).map(field => <div className="row" key={field.path}>
-          <div className="form-group co-create-operand__form-group">
-            <label className={classNames('form-label', {'co-required': field.required})} htmlFor={field.path}>{field.displayName}</label>
-            { inputFor(field) }
-            { field.description && <span id={`${field.path}__description`} className="help-block text-muted">{field.description}</span> }
-            { formErrors[field.path] && <span className="co-error">{formErrors[field.path]}</span> }
+        { [...arrayFieldGroups].map(group => <div key={group}>
+          <label className="form-label">{_.startCase(group.split(SpecCapability.arrayFieldGroup)[1])}</label>
+          <div className="co-operand-field-group">
+            { fields.filter(f => f.capabilities.includes(group))
+              .filter(f => !_.isNil(inputFor(f))).map(field => <div key={field.path}>
+                <div className="form-group co-create-operand__form-group">
+                  <label className={classNames('form-label', {'co-required': field.required})} htmlFor={field.path}>{field.displayName}</label>
+                  { inputFor(field) }
+                  { field.description && <span id={`${field.path}__description`} className="help-block text-muted">{field.description}</span> }
+                  { formErrors[field.path] && <span className="co-error">{formErrors[field.path]}</span> }
+                </div>
+              </div>) }
           </div>
         </div>) }
-      {(!_.isEmpty(error) || !_.isEmpty(_.compact(_.values(formErrors)))) && <div className="row">
-        <Alert isInline className="co-alert co-break-word" variant="danger" title={error || 'Fix above errors'} />
-      </div>}
-      <div className="row" style={{paddingBottom: '30px'}}>
-        <ActionGroup className="pf-c-form">
-          <Button
-            onClick={submit}
-            type="submit"
-            variant="primary">
-            Create
-          </Button>
-          <Button
-            onClick={history.goBack}
-            variant="secondary">
-            Cancel
-          </Button>
-        </ActionGroup>
+        { [...fieldGroups].map(group => <div key={group}>
+          <label className="form-label">{_.startCase(group.split(SpecCapability.fieldGroup)[1])}</label>
+          <div className="co-operand-field-group">
+            { fields.filter(f => f.capabilities.includes(group))
+              .filter(f => !_.isNil(inputFor(f))).map(field => <div key={field.path}>
+                <div className="form-group co-create-operand__form-group">
+                  <label className={classNames('form-label', {'co-required': field.required})} htmlFor={field.path}>{field.displayName}</label>
+                  { inputFor(field) }
+                  { field.description && <span id={`${field.path}__description`} className="help-block text-muted">{field.description}</span> }
+                  { formErrors[field.path] && <span className="co-error">{formErrors[field.path]}</span> }
+                </div>
+              </div>) }
+          </div>
+        </div>) }
+        { fields.filter(f => !f.capabilities.some(c => c.startsWith(SpecCapability.fieldGroup) || c.startsWith(SpecCapability.arrayFieldGroup)))
+          .filter(f => !_.isNil(inputFor(f))).map(field => <div key={field.path}>
+            <div className="form-group co-create-operand__form-group">
+              <label className={classNames('form-label', {'co-required': field.required})} htmlFor={field.path}>{field.displayName}</label>
+              { inputFor(field) }
+              { field.description && <span id={`${field.path}__description`} className="help-block text-muted">{field.description}</span> }
+              { formErrors[field.path] && <span className="co-error">{formErrors[field.path]}</span> }
+            </div>
+          </div>) }
+        {(!_.isEmpty(error) || !_.isEmpty(_.compact(_.values(formErrors)))) &&
+          <Alert isInline className="co-alert co-break-word" variant="danger" title={error || 'Fix above errors'} />
+        }
+        <div style={{paddingBottom: '30px'}}>
+          <ActionGroup className="pf-c-form">
+            <Button
+              onClick={submit}
+              type="submit"
+              variant="primary">
+              Create
+            </Button>
+            <Button
+              onClick={history.goBack}
+              variant="secondary">
+              Cancel
+            </Button>
+          </ActionGroup>
+        </div>
+      </form>
+      <div className="col-md-6">
+        { props.clusterServiceVersion && props.providedAPI && <div style={{marginBottom: '30px'}}>
+          <ClusterServiceVersionLogo
+            displayName={props.providedAPI.displayName}
+            icon={_.get(props.clusterServiceVersion, 'spec.icon[0]')}
+            provider={_.get(props.clusterServiceVersion, 'spec.provider')} />
+          { props.providedAPI.description }
+        </div> }
+        <Alert isInline className="co-alert co-break-word" variant="info" title={'Note: Some fields may not be represented in this form. Please select "Edit YAML" for full control of object creation.'} />
       </div>
-    </form>
-    <div className="col-md-6">
-      { props.clusterServiceVersion && props.providedAPI && <div style={{marginBottom: '30px'}}>
-        <ClusterServiceVersionLogo
-          displayName={props.providedAPI.displayName}
-          icon={_.get(props.clusterServiceVersion, 'spec.icon[0]')}
-          provider={_.get(props.clusterServiceVersion, 'spec.provider')} />
-        { props.providedAPI.description }
-      </div> }
-      <Alert isInline className="co-alert co-break-word" variant="info" title={'Note: Some fields may not be represented in this form. Please select "Edit YAML" for full control of object creation.'} />
     </div>
   </div>;
 };

--- a/frontend/public/components/utils/_label.scss
+++ b/frontend/public/components/utils/_label.scss
@@ -4,7 +4,7 @@
   border-radius: 12px;
   display: inline-flex;
   line-height: $co-m-label-line-height;
-  margin: 2px 2px 2px 0;
+  margin: 0 2px 2px 0;
   max-width: 100%;
   padding: 0 8px;
 
@@ -46,7 +46,6 @@ tags-input .tags {
   color: $input-color;
   cursor: text;
   line-height: $co-m-label-line-height;
-  padding: 0 $padding-base-horizontal;
 }
 
 .modal-body tags-input .tags {


### PR DESCRIPTION
also... Fix incorrect row column gutter width and remove superfluous rows around form fields
https://jira.coreos.com/browse/CONSOLE-1703

**Before**
<img width="960" alt="Screen Shot 2019-08-28 at 12 29 01 PM" src="https://user-images.githubusercontent.com/1874151/63879878-9694ee00-c99a-11e9-82b3-d35ec57246d9.png">

**after**
<img width="958" alt="Screen Shot 2019-08-28 at 1 37 58 PM" src="https://user-images.githubusercontent.com/1874151/63879899-a44a7380-c99a-11e9-90b0-2f0abf619e3b.png">

Search input group maintains it's correct size
<img width="614" alt="Screen Shot 2019-08-28 at 1 56 29 PM" src="https://user-images.githubusercontent.com/1874151/63880513-de684500-c99b-11e9-9b4a-5dc3147de490.png">
<img width="622" alt="Screen Shot 2019-08-28 at 1 56 22 PM" src="https://user-images.githubusercontent.com/1874151/63880529-e3c58f80-c99b-11e9-8512-161646f55927.png">

