### PR TITLE
Bug 1735520: Query Browser: Set default query input height to 2 rows

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -10,12 +10,16 @@
 }
 
 .query-browser__clear-icon {
+  border: none;
   color: $color-pf-black-600;
   font-size: 18px;
+  height: 18px;
+  line-height: 18px;
   padding: 0;
   position: absolute;
-  right: 4px;
-  top: 2px;
+  right: 6px;
+  top: 6px;
+  width: 18px;
 }
 
 .query-browser__dropdown--subtitle {
@@ -93,6 +97,7 @@
 }
 
 .query-browser__query-input {
+  padding-right: 24px !important;
   resize: vertical;
 }
 

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -364,7 +364,7 @@ const QueryInput_: React.FC<QueryInputProps> = (({index, metrics, patchQuery, ru
     }, _.isEmpty);
 
   // Set the default textarea height to the number of lines in the query text
-  const rows = Math.min((text.match(/\n/g) || []).length + 1, 10);
+  const rows = _.clamp((text.match(/\n/g) || []).length + 1, 2, 10);
 
   return <div className="query-browser__query pf-c-dropdown">
     <textarea


### PR DESCRIPTION
Input height still automatically resizes to match the number of lines in
the input text, but the minimum number of rows is now 2 instead of 1.

You can still override by manually resizing the textarea.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1735520

<img width="436" alt="screenshot" src="https://user-images.githubusercontent.com/460802/63908004-7c214a00-ca58-11e9-92ff-7c758a28fb38.png">

FYI @cshinn 