### PR TITLE
Query browser: Fix negative value formatting & fix tooltip for null values

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -148,7 +148,7 @@ const TooltipInner_: React.FC<TooltipInnerProps> = ({datum, labels, query, serie
 };
 const TooltipInner = connect(tooltipStateToProps)(TooltipInner_);
 
-const Tooltip: React.FC<TooltipProps> = ({datum, x, y}) => datum && _.isFinite(x) && _.isFinite(y)
+const Tooltip: React.FC<TooltipProps> = ({datum, x, y}) => datum && _.isFinite(datum.y) && _.isFinite(x) && _.isFinite(y)
   ? <TooltipInner datum={datum} seriesIndex={datum._stack - 1} x={x} y={y} />
   : null;
 

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -41,7 +41,10 @@ const chartTheme = getCustomTheme(ChartThemeColor.multi, ChartThemeVariant.light
 export const colors = chartTheme.line.colorScale;
 
 // Use exponential notation for small or very large numbers to avoid labels with too many characters
-const formatValue = v => v === 0 || (0.001 <= v && v < 1e23) ? humanizeNumberSI(v).string : v.toExponential(1);
+const formatPositiveValue = (v: number): string => v === 0 || (0.001 <= v && v < 1e23)
+  ? humanizeNumberSI(v).string
+  : v.toExponential(1);
+const formatValue = (v: number): string => (v < 0 ? '-' : '') + formatPositiveValue(Math.abs(v));
 
 export const Error = ({error, title = 'An error occurred'}) =>
   <Alert isInline className="co-alert" title={title} variant="danger">


### PR DESCRIPTION
- The humanize unit functions seem to not handle negative values well. I guess this is because no other graphs have negative values currently, but the Query Browser does need to handle negatives.
- We use `null` values when there is a gap in the data, so no tooltip should be displayed for these.