### PR TITLE
Optional proxy of Prometheus from outside the cluster

### DIFF
--- a/contrib/oc-environment.sh
+++ b/contrib/oc-environment.sh
@@ -17,6 +17,8 @@ export BRIDGE_USER_AUTH="disabled"
 export BRIDGE_K8S_MODE="off-cluster"
 export BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
 export BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
+export BRIDGE_K8S_MODE_OFF_CLUSTER_PROMETHEUS=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.prometheusURL}')
+export BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.alertmanagerURL}')
 export BRIDGE_K8S_AUTH="bearer-token"
 export BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token)
 

--- a/examples/run-bridge.sh
+++ b/examples/run-bridge.sh
@@ -14,4 +14,6 @@ set -exuo pipefail
     --user-auth=openshift \
     --user-auth-oidc-client-id=console-oauth-client \
     --user-auth-oidc-client-secret-file=examples/console-client-secret \
-    --user-auth-oidc-ca-file=examples/ca.crt
+    --user-auth-oidc-ca-file=examples/ca.crt \
+    --k8s-mode-off-cluster-prometheus=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.prometheusURL}')  \
+    --k8s-mode-off-cluster-alertmanager=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.alertmanagerURL}')

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -107,15 +107,16 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Header.Del(h)
 	}
 
+	r.Host = p.config.Endpoint.Host
+	r.URL.Host = p.config.Endpoint.Host
+	r.URL.Scheme = p.config.Endpoint.Scheme
+
 	if !isWebsocket {
 		p.reverseProxy.ServeHTTP(w, r)
 		return
 	}
 
-	r.Host = p.config.Endpoint.Host
-	r.URL.Host = p.config.Endpoint.Host
 	r.URL.Path = SingleJoiningSlash(p.config.Endpoint.Path, r.URL.Path)
-	r.URL.Scheme = p.config.Endpoint.Scheme
 
 	if r.URL.Scheme == "https" {
 		r.URL.Scheme = "wss"


### PR DESCRIPTION
**Description**:
It will be nice to have an option to proxy prometheus from outside the cluster for devel.

This PR adds the option to proxy Prometheus and AlertManager when running outside the
cluster.

It adds new CLI options:
```
./bin/bridge --help
...
  -k8s-mode-off-cluster-alertmanager string
    	DEV ONLY. URL of the cluster's AlertManager server.
  -k8s-mode-off-cluster-prometheus string
    	DEV ONLY. URL of the cluster's Pormetheus server.

...
```

**Usage**:
Already integrated when running dev scripts:
```
source ./contrib/oc-environment.sh
./bin/bridge
```
And
```
./examples/run-bridge.sh
```

Ref:
https://docs.google.com/document/d/1epyQuj0AqL77zCLuea6T6WUKq-v47NbT9v24pOBFS1A/edit

https://jira.coreos.com/browse/CONSOLE-737