### PR TITLE
Secrets list page should also show size with binary data

### DIFF
--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -54,7 +54,7 @@ const ConfigMapTableRow = ({obj: configMap, index, key, style}) => {
         <ResourceLink kind="Namespace" name={configMap.metadata.namespace} title={configMap.metadata.namespace} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
-        {_.size(configMap.data)}
+        {_.size(configMap.data) + _.size(configMap.binaryData)}
       </TableData>
       <TableData className={tableColumnClasses[3]}>
         {fromNow(configMap.metadata.creationTimestamp)}

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -86,7 +86,7 @@ const filterPropType = (props, propName, componentName) => {
 const sorts = {
   alertStateOrder,
   daemonsetNumScheduled: daemonset => _.toInteger(_.get(daemonset, 'status.currentNumberScheduled')),
-  dataSize: resource => _.size(_.get(resource, 'data')),
+  dataSize: resource => _.size(_.get(resource, 'data')) + _.size(_.get(resource, 'binaryData')),
   ingressValidHosts,
   serviceCatalogStatus,
   jobCompletions: job => getJobTypeAndCompletions(job).completions,

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -86,7 +86,7 @@ const filterPropType = (props, propName, componentName) => {
 const sorts = {
   alertStateOrder,
   daemonsetNumScheduled: daemonset => _.toInteger(_.get(daemonset, 'status.currentNumberScheduled')),
-  dataSize: resource => _.size(_.get(resource, 'data')),
+  dataSize: resource => _.size(_.get(resource, 'data')) + _.size(_.get(resource, 'binaryData')),
   ingressValidHosts,
   serviceCatalogStatus,
   jobCompletions: job => getJobTypeAndCompletions(job).completions,


### PR DESCRIPTION
For some reason we are not counting the `binaryData` when couting the size of the configMap.

/assign @spadgett 