### PR TITLE
Query Browser: Add seconds to data point time in tooltip

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -28,7 +28,12 @@ import { connect } from 'react-redux';
 import * as UIActions from '../../actions/ui';
 import { RootState } from '../../redux';
 import { Dropdown, humanizeNumberSI, LoadingInline, usePoll, useRefWidth, useSafeFetch } from '../utils';
-import { formatPrometheusDuration, parsePrometheusDuration, twentyFourHourTime } from '../utils/datetime';
+import {
+  formatPrometheusDuration,
+  parsePrometheusDuration,
+  twentyFourHourTime,
+  twentyFourHourTimeWithSeconds,
+} from '../utils/datetime';
 import { withFallback } from '../utils/error-boundary';
 import { PrometheusResponse } from '../graphs';
 import { GraphEmpty } from '../graphs/graph-empty';
@@ -133,7 +138,7 @@ const TooltipInner_: React.FC<TooltipInnerProps> = ({datum, labels, query, serie
       <div className="query-browser__tooltip">
         <div className="query-browser__tooltip-group">
           <div className="query-browser__series-btn" style={{backgroundColor: colors[seriesIndex % colors.length]}}></div>
-          {datum.x && <div className="query-browser__tooltip-time">{twentyFourHourTime(datum.x)}</div>}
+          {datum.x && <div className="query-browser__tooltip-time">{twentyFourHourTimeWithSeconds(datum.x)}</div>}
         </div>
         <div className="query-browser__tooltip-group">
           <div className="co-nowrap co-truncate">{query}</div>

--- a/frontend/public/components/utils/datetime.ts
+++ b/frontend/public/components/utils/datetime.ts
@@ -158,3 +158,10 @@ export const twentyFourHourTime = (date: Date): string => {
   const minutes = zeroPad(date.getMinutes());
   return `${hours}:${minutes}`;
 };
+
+export const twentyFourHourTimeWithSeconds = (date: Date): string => {
+  const hours = zeroPad(date.getHours());
+  const minutes = zeroPad(date.getMinutes());
+  const seconds = zeroPad(date.getSeconds());
+  return `${hours}:${minutes}:${seconds}`;
+};


### PR DESCRIPTION
The time is often not granular enough unless we include seconds.