### PR TITLE
Dynamically generate che workspace factory URL in Topology after getting cheURL from ConsoleLink CR

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -16,6 +16,7 @@ export interface ControllerProps {
   resources?: TopologyDataResources;
   render(RenderProps): React.ReactElement;
   application: string;
+  cheURL: string;
 }
 
 export interface TopologyDataControllerProps {
@@ -23,15 +24,16 @@ export interface TopologyDataControllerProps {
   render(RenderProps): React.ReactElement;
   application: string;
   knative: boolean;
+  cheURL: string;
 }
 
 const Controller: React.FC<ControllerProps> = React.memo(
-  ({ render, application, resources, loaded, loadError }) =>
+  ({ render, application, cheURL, resources, loaded, loadError }) =>
     render({
       loaded,
       loadError,
       data: loaded
-        ? new TransformTopologyData(resources, application)
+        ? new TransformTopologyData(resources, application, cheURL)
             .transformDataBy('deployments')
             .transformDataBy('deploymentConfigs')
             .transformDataBy('daemonSets')
@@ -46,6 +48,7 @@ const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
   render,
   application,
   knative,
+  cheURL,
 }) => {
   let resources: FirehoseResource[] = [
     {
@@ -122,7 +125,7 @@ const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
   }
   return (
     <Firehose resources={resources} forceUpdate>
-      <Controller application={application} render={render} />
+      <Controller application={application} cheURL={cheURL} render={render} />
     </Firehose>
   );
 };

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -10,12 +10,14 @@ import { FLAG_KNATIVE_SERVING } from '@console/knative-plugin/src/const';
 import EmptyState from '../EmptyState';
 import NamespacedPage from '../NamespacedPage';
 import DefaultPage from '../DefaultPage';
+import { getCheURL } from './topology-utils';
 import TopologyDataController, { RenderProps } from './TopologyDataController';
 import Topology from './Topology';
 
 interface StateProps {
   activeApplication: string;
   knative: boolean;
+  cheURL: string;
 }
 
 export interface TopologyPageProps {
@@ -54,7 +56,7 @@ export function renderTopology({ loaded, loadError, data }: RenderProps) {
   );
 }
 
-const TopologyPage: React.FC<Props> = ({ match, activeApplication, knative }) => {
+const TopologyPage: React.FC<Props> = ({ match, activeApplication, knative, cheURL }) => {
   const namespace = match.params.ns;
   const application = activeApplication === ALL_APPLICATIONS_KEY ? undefined : activeApplication;
   return (
@@ -69,6 +71,7 @@ const TopologyPage: React.FC<Props> = ({ match, activeApplication, knative }) =>
             namespace={namespace}
             render={renderTopology}
             knative={knative}
+            cheURL={cheURL}
           />
         ) : (
           <DefaultPage title="Topology">Select a project to view the topology</DefaultPage>
@@ -81,9 +84,11 @@ const TopologyPage: React.FC<Props> = ({ match, activeApplication, knative }) =>
 const getKnativeStatus = ({ FLAGS }: RootState): boolean => FLAGS.get(FLAG_KNATIVE_SERVING);
 
 const mapStateToProps = (state: RootState): StateProps => {
+  const consoleLinks = state.UI.get('consoleLinks');
   return {
     activeApplication: getActiveApplication(state),
     knative: getKnativeStatus(state),
+    cheURL: getCheURL(consoleLinks),
   };
 };
 

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyDataController.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyDataController.spec.tsx
@@ -10,6 +10,7 @@ describe('TopologyDataController', () => {
     namespace: 'test',
     resources,
     knative: false,
+    cheURL: 'https://test-che.test-cluster.com',
     render: () => <TestInner />,
   };
   let wrapper: ShallowWrapper<TopologyDataControllerProps>;

--- a/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
@@ -89,7 +89,7 @@ Object {
             },
           ],
         },
-        "editUrl": undefined,
+        "editUrl": "https://github.com/redhat-developer/topology-example",
         "isKnativeResource": false,
         "kind": "DeploymentConfig",
         "url": "http://nodejs-testproject3.192.168.42.60.nip.io",
@@ -144,6 +144,10 @@ Object {
           "apiVersion": "apps/v1",
           "kind": "DeploymentConfig",
           "metadata": Object {
+            "annotations": Object {
+              "app.openshift.io/vcs-ref": "master",
+              "app.openshift.io/vcs-uri": "https://github.com/redhat-developer/topology-example",
+            },
             "creationTimestamp": "2019-04-22T11:58:33Z",
             "generation": 2,
             "labels": Object {

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -36,6 +36,10 @@ export const sampleDeploymentConfigs: Resource = {
         labels: {
           app: 'nodejs',
         },
+        annotations: {
+          'app.openshift.io/vcs-uri': 'https://github.com/redhat-developer/topology-example',
+          'app.openshift.io/vcs-ref': 'master',
+        },
       },
       spec: {
         template: {


### PR DESCRIPTION
This PR - 
- Looks for `ConsoleLink` CR which will be created by `Eclipse Che` Operator and will have `Che Dashboard` URL.  
- Based on the Che URL from `ConsoleLink` we generate a Che Factory URL that will take the user through the workspace creation process.
- Based on the annotation for Git Repo URL and `Che URL` dynamically adds `Edit URL` on topology nodes.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/6041994/63948073-afce9500-ca95-11e9-98c3-f7d49b017e4a.gif)
 