### PR TITLE
Rename Domain to URL in Knative Service List

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
@@ -220,8 +220,6 @@ export const sampleKnativeRoutes = {
       spec: {},
       status: {
         observedGeneration: 1,
-        domain: 'overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
-        domainInternal: 'overlayimage.knativeapps.svc.cluster.local',
         url: 'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
       },
     },
@@ -243,8 +241,7 @@ export const sampleKnativeServices: Resource = {
       spec: {},
       status: {
         observedGeneration: 1,
-        domain: 'overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
-        domainInternal: 'overlayimage.knativeapps.svc.cluster.local',
+        url: 'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
         latestCreatedRevisionName: 'overlayimage-fdqsf',
         latestReadyRevisionName: 'overlayimage-fdqsf',
       },

--- a/frontend/packages/knative-plugin/src/components/services/ServiceHeader.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceHeader.tsx
@@ -16,8 +16,8 @@ const ServiceHeader = () => {
       props: { className: tableColumnClasses[1] },
     },
     {
-      title: 'Domain',
-      sortField: 'domain',
+      title: 'URL',
+      sortField: 'status.url',
       transforms: [sortable],
       props: { className: tableColumnClasses[2] },
     },

--- a/frontend/packages/knative-plugin/src/components/services/ServiceRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceRow.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import * as cx from 'classnames';
 import { TableRow, TableData } from '@console/internal/components/factory';
-import { Kebab, ResourceLink, ResourceKebab, Timestamp } from '@console/internal/components/utils';
+import {
+  Kebab,
+  ResourceLink,
+  ResourceKebab,
+  Timestamp,
+  ExternalLink,
+} from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { ServiceModel } from '../../models';
 import { getConditionString, getCondition } from '../../utils/condition-utils';
@@ -35,7 +41,10 @@ const ServiceRow: React.FC<ServiceRowProps> = ({ obj, index, key, style }) => {
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData className={cx(tableColumnClasses[2], 'co-break-word')}>
-        {obj.metadata.domain || '-'}
+        {(obj.status && obj.status.url && (
+          <ExternalLink href={obj.status.url} text={obj.status.url} />
+        )) ||
+          '-'}
       </TableData>
       <TableData className={tableColumnClasses[3]}>{obj.metadata.generation || '-'}</TableData>
       <TableData className={tableColumnClasses[4]}>

--- a/frontend/packages/knative-plugin/src/types.ts
+++ b/frontend/packages/knative-plugin/src/types.ts
@@ -11,7 +11,9 @@ export type RevisionKind = {
 export type ServiceKind = K8sResourceKind & {
   metadata?: {
     generation?: number;
-    domain?: string;
+  };
+  status?: {
+    url?: string;
   };
 };
 


### PR DESCRIPTION
Knative Services no longer have a `status.domain` property, nor did
they ever have a `metadata.domain` property which is what was being
used to populate the Domain column in the Knative Service list.

They do, however, have a `status.url` property identical to Knative
Routes. So, I updated the Knative ServiceRow to use the same logic as
the RouteRow to display that URL. This also means the column header
was renamed from Domain to URL.

This fixes https://jira.coreos.com/browse/CONSOLE-1704