### PR TITLE
[WIP] Allow secondary tabs to wrap and hide 4-n operator tabs

### DIFF
--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -3,14 +3,14 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: 15px;
 .co-m-horizontal-nav__menu {
   border-bottom: 1px solid $color-grey-background-border;
   display: flex;
-  white-space: nowrap;
   @media (min-width: $grid-float-breakpoint) {
     margin-left: (-$co-m-horizontal-nav__menu-item-link-padding-lr);
     padding: 0 30px;
   }
 }
 
-.co-m-horizontal-nav__menu-primary {
+.co-m-horizontal-nav__menu-primary,
+.co-m-horizontal-nav__menu-secondary {
   display: flex;
   list-style: none;
   margin: 0;
@@ -18,13 +18,16 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: 15px;
 }
 
 .co-m-horizontal-nav__menu-secondary {
-  display: flex;
-  list-style: none;
-  margin: 0 0 -1px; // -1px bottom so co-m-horizontal-nav__menu-item *::after are fully visible
+  flex-wrap: wrap;
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 0;
   -webkit-overflow-scrolling: touch;
+  // hide tabs 4 - n on operator pages
+  .co-m-horizontal-nav__menu-item:nth-child(n + 4) {
+    [href*="~ClusterServiceVersion"], [href*="clusterserviceversions/"] {
+      display: none;
+    }
+  }
 }
 
 .co-m-horizontal-nav__menu-item {
@@ -47,7 +50,7 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: 15px;
       }
     }
     &::after {
-      bottom: -1px;
+      bottom: 0;
       content: "";
       display: block;
       height: 2px;


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1429

This is a hack, but it's low risk.  We need to maintain the operand list and details pages to keep things consistent, and there is currently no way to exclude tabs from the nav with `<DetailsPage>`.   Thoughts? 

![localhost_9000_k8s_ns_robb_clusterserviceversions_strimzi-cluster-operator v0 13 0_instances(iPhone 6_7_8) (2)](https://user-images.githubusercontent.com/895728/63967152-cad7df80-ca6a-11e9-9d49-7e5a7245fbde.png)
![localhost_9000_k8s_ns_robb_clusterserviceversions_strimzi-cluster-operator v0 13 0_instances(iPhone 6_7_8)](https://user-images.githubusercontent.com/895728/63967153-cad7df80-ca6a-11e9-8c62-df134dfbb2dd.png)
![localhost_9000_k8s_ns_robb_clusterserviceversions_strimzi-cluster-operator v0 13 0_instances(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/895728/63967166-cf03fd00-ca6a-11e9-9610-9ec356a88dd0.png)
![localhost_9000_k8s_ns_tony_operators coreos com_v1alpha1_ClusterServiceVersion_strimzi-cluster-operator v0 13 0 (2)](https://user-images.githubusercontent.com/895728/63967195-dcb98280-ca6a-11e9-96fd-84a6ae8bade4.png)
![localhost_9000_k8s_ns_tony_operators coreos com_v1alpha1_ClusterServiceVersion_strimzi-cluster-operator v0 13 0 (3)](https://user-images.githubusercontent.com/895728/63967196-dcb98280-ca6a-11e9-858c-fd0f96be0b24.png)
![localhost_9000_k8s_ns_tony_operators coreos com_v1alpha1_ClusterServiceVersion_strimzi-cluster-operator v0 13 0 (4)](https://user-images.githubusercontent.com/895728/63967197-dcb98280-ca6a-11e9-89dd-8c8236cc881b.png)
