### PR TITLE
add secondary masthead with disabled dropdowns to add flows

### DIFF
--- a/frontend/integration-tests/tests/deploy-image.scenario.ts
+++ b/frontend/integration-tests/tests/deploy-image.scenario.ts
@@ -11,28 +11,27 @@ describe('Deploy Image', () => {
   const imageName = 'mysql';
 
   describe('Deploy Image page', () => {
-    it('should render project/namespace dropdown when all-namespace is selected', async() => {
-      // Navigate to the deploy-image page
-      await browser.get(`${appHost}/deploy-image/all-namespaces`);
-
-      const nsSpan =
-        '#form-ns-dropdown-project-name-field .btn-dropdown__content-wrap .pf-c-dropdown__toggle-text .pf-c-dropdown__toggle-text--placeholder';
-      // Wait for the Project field to appear
-      await browser.wait(until.presenceOf(element(by.css(nsSpan))));
-      // Confirm that the project field has the right text
-      expect(element(by.css(nsSpan)).getText()).toEqual('Select namespace');
-    });
-
     it('should render project/namespace dropdown disabled when in a project context', async() => {
       // Navigate to the deploy-image page
       await browser.get(`${appHost}/deploy-image/ns/${testName}?preselected-ns=${testName}`);
 
-      const nsSpan =
-        '#form-ns-dropdown-project-name-field .btn-dropdown__content-wrap .pf-c-dropdown__toggle-text .co-resource-item .co-resource-item__resource-name';
-      // Wait for the Project field to appear
-      await browser.wait(until.presenceOf(element(by.css(nsSpan))));
-      // Confirm that the project field does not exist
-      expect(element(by.css(nsSpan)).getText()).toEqual(testName);
+      const dropdown = '[data-test-id=namespace-bar-dropdown] > *:nth-child(1) button:disabled';
+      // Wait for the Project dropdown to appear
+      await browser.wait(until.presenceOf(element(by.css(dropdown))));
+      // Confirm that the project dropdown text matches project context
+      expect(element(by.css(dropdown)).getText()).toEqual(`Project: ${testName}`);
+    });
+
+
+    it('should render applications dropdown disabled', async() => {
+      // Navigate to the deploy-image page
+      await browser.get(`${appHost}/deploy-image/ns/${testName}?preselected-ns=${testName}`);
+
+      const dropdown = '[data-test-id=namespace-bar-dropdown] > *:nth-child(2) button:disabled';
+      // Wait for the Applications dropdown to appear
+      await browser.wait(until.presenceOf(element(by.css(dropdown))));
+      // Confirm that the application dropdown is unset
+      expect(element(by.css(dropdown)).getText()).toEqual('Application: all applications');
     });
 
     it('can be used to search for an image', async() => {

--- a/frontend/packages/dev-console/src/components/NamespacedPage.scss
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.scss
@@ -7,7 +7,12 @@
   &__content {
     flex-grow: 1;
     position: relative;
+    overflow: auto;
     background-color: var(--pf-global--Color--light-200);
+
+    &.is-light {
+      background-color: var(--pf-global--Color--light-100);
+    }
   }
 
   // Override styles of namespace bar to support the addition of the application selector on mobile

--- a/frontend/packages/dev-console/src/components/NamespacedPage.tsx
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.tsx
@@ -1,15 +1,36 @@
 import * as React from 'react';
+import * as cx from 'classnames';
 import { NamespaceBar } from '@console/internal/components/namespace';
 import ApplicationSelector from './dropdown/ApplicationSelector';
 
 import './NamespacedPage.scss';
 
-const NamespacedPage: React.FC = ({ children }) => (
+export enum NamespacedPageVariants {
+  light = 'light',
+  default = 'default',
+}
+
+export interface NamespacedPageProps {
+  disabled?: boolean;
+  variant?: NamespacedPageVariants;
+}
+
+const NamespacedPage: React.FC<NamespacedPageProps> = ({
+  children,
+  disabled,
+  variant = NamespacedPageVariants.default,
+}) => (
   <div className="odc-namespaced-page">
-    <NamespaceBar>
-      <ApplicationSelector />
+    <NamespaceBar disabled={disabled}>
+      <ApplicationSelector disabled={disabled} />
     </NamespaceBar>
-    <div className="odc-namespaced-page__content">{children}</div>
+    <div
+      className={cx('odc-namespaced-page__content', {
+        [`is-${variant}`]: variant !== NamespacedPageVariants.default,
+      })}
+    >
+      {children}
+    </div>
   </div>
 );
 

--- a/frontend/packages/dev-console/src/components/dropdown/ApplicationSelector.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ApplicationSelector.tsx
@@ -10,26 +10,31 @@ import { RootState } from '@console/internal/redux';
 import { getActiveNamespace, getActiveApplication } from '@console/internal/reducers/ui';
 import ApplicationDropdown from './ApplicationDropdown';
 
-interface ApplicationSelectorProps {
+export interface ApplicationSelectorProps {
+  disabled?: boolean;
+}
+
+interface StateProps {
   namespace: string;
   application: string;
+}
+
+interface DispatchProps {
   onChange: (name: string) => void;
 }
 
-const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({
-  namespace,
-  application,
-  onChange,
-}) => {
+type Props = ApplicationSelectorProps & StateProps & DispatchProps;
+
+const ApplicationSelector: React.FC<Props> = ({ namespace, application, onChange, disabled }) => {
   const onApplicationChange = (newApplication: string, key: string) => {
     key === ALL_APPLICATIONS_KEY ? onChange(key) : onChange(newApplication);
   };
   const allApplicationsTitle = 'all applications';
 
-  const disabled = namespace === ALL_NAMESPACES_KEY;
+  const allNamespaces = namespace === ALL_NAMESPACES_KEY;
 
   let title: string = application;
-  if (disabled) {
+  if (allNamespaces) {
     title = 'No applications';
   } else if (title === ALL_APPLICATIONS_KEY) {
     title = allApplicationsTitle;
@@ -50,23 +55,23 @@ const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({
       selectedKey={application || ALL_APPLICATIONS_KEY}
       onChange={onApplicationChange}
       storageKey={APPLICATION_LOCAL_STORAGE_KEY}
-      disabled={disabled}
+      disabled={disabled || allNamespaces}
     />
   );
 };
 
-const mapStateToProps = (state: RootState) => ({
+const mapStateToProps = (state: RootState): StateProps => ({
   namespace: getActiveNamespace(state),
   application: getActiveApplication(state),
 });
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
+const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
   onChange: (app: string) => {
     dispatch(setActiveApplication(app));
   },
 });
 
-export default connect(
+export default connect<StateProps, DispatchProps, ApplicationSelectorProps>(
   mapStateToProps,
   mapDispatchToProps,
 )(ApplicationSelector);

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { Formik } from 'formik';
 import { history } from '@console/internal/components/utils';
+import { getActiveApplication } from '@console/internal/reducers/ui';
+import { RootState } from '@console/internal/redux';
+import { connect } from 'react-redux';
+import { ALL_APPLICATIONS_KEY } from '@console/internal/const';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { DeployImageFormData } from './import-types';
 import { createResources } from './deployImage-submit-utils';
@@ -11,14 +15,21 @@ export interface DeployImageProps {
   namespace: string;
 }
 
-const DeployImage: React.FC<DeployImageProps> = ({ namespace }) => {
+interface StateProps {
+  activeApplication: string;
+}
+
+type Props = DeployImageProps & StateProps;
+
+const DeployImage: React.FC<Props> = ({ namespace, activeApplication }) => {
   const initialValues: DeployImageFormData = {
     project: {
       name: namespace || '',
     },
     application: {
-      name: '',
-      selectedKey: '',
+      initial: activeApplication,
+      name: activeApplication,
+      selectedKey: activeApplication,
     },
     name: '',
     searchTerm: '',
@@ -131,4 +142,11 @@ const DeployImage: React.FC<DeployImageProps> = ({ namespace }) => {
   );
 };
 
-export default DeployImage;
+const mapStateToProps = (state: RootState): StateProps => {
+  const activeApplication = getActiveApplication(state);
+  return {
+    activeApplication: activeApplication !== ALL_APPLICATIONS_KEY ? activeApplication : '',
+  };
+};
+
+export default connect(mapStateToProps)(DeployImage);

--- a/frontend/packages/dev-console/src/components/import/DeployImagePage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImagePage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { PageHeading } from '@console/internal/components/utils';
+import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import DeployImage from './DeployImage';
 
 export type DeployImagePageProps = RouteComponentProps<{ ns?: string }>;
@@ -9,7 +10,7 @@ export type DeployImagePageProps = RouteComponentProps<{ ns?: string }>;
 const DeployImagePage: React.FunctionComponent<DeployImagePageProps> = ({ match }) => {
   const namespace = match.params.ns;
   return (
-    <React.Fragment>
+    <NamespacedPage disabled variant={NamespacedPageVariants.light}>
       <Helmet>
         <title>Deploy Image</title>
       </Helmet>
@@ -17,7 +18,7 @@ const DeployImagePage: React.FunctionComponent<DeployImagePageProps> = ({ match 
       <div className="co-m-pane__body">
         <DeployImage namespace={namespace} />
       </div>
-    </React.Fragment>
+    </NamespacedPage>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -35,6 +35,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       name: namespace || '',
     },
     application: {
+      initial: activeApplication,
       name: activeApplication,
       selectedKey: activeApplication,
     },

--- a/frontend/packages/dev-console/src/components/import/ImportPage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportPage.tsx
@@ -3,6 +3,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { PageHeading, Firehose, FirehoseResource } from '@console/internal/components/utils';
 import { ImageStreamModel } from '@console/internal/models';
+import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import ImportForm from './ImportForm';
 import { ImportTypes, ImportData } from './import-types';
 
@@ -71,7 +72,7 @@ const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match, location 
   }
 
   return (
-    <React.Fragment>
+    <NamespacedPage disabled variant={NamespacedPageVariants.light}>
       <Helmet>
         <title>{importData.title}</title>
       </Helmet>
@@ -81,7 +82,7 @@ const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match, location 
           <ImportForm namespace={namespace || preselectedNamespace} importData={importData} />
         </Firehose>
       </div>
-    </React.Fragment>
+    </NamespacedPage>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
@@ -6,6 +6,7 @@ export const mockFormData: GitImportFormData = {
     name: 'mock-project',
   },
   application: {
+    initial: 'mock-app',
     name: 'mock-app',
     selectedKey: 'mock-app',
   },

--- a/frontend/packages/dev-console/src/components/import/app/AppSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/app/AppSection.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { useField } from 'formik';
 import { TextInputTypes } from '@patternfly/react-core';
-import { InputField, NSDropdownField } from '../../formik-fields';
+import { InputField } from '../../formik-fields';
 import { ProjectData } from '../import-types';
 import FormSection from '../section/FormSection';
 import ApplicationSelector from './ApplicationSelector';
@@ -10,17 +11,10 @@ export interface AppSectionProps {
 }
 
 const AppSection: React.FC<AppSectionProps> = ({ project }) => {
+  const [initialApplication] = useField('application.initial');
   return (
     <FormSection title="General">
-      <NSDropdownField
-        data-test-id="application-form-namespace-dropdown"
-        name="project.name"
-        label="Project"
-        disabled={!!project.name}
-        fullWidth
-        required
-      />
-      <ApplicationSelector namespace={project.name} />
+      {!initialApplication.value && <ApplicationSelector namespace={project.name} />}
       <InputField
         type={TextInputTypes.text}
         data-test-id="application-form-app-name"

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -51,6 +51,7 @@ export interface GitImportFormData {
 }
 
 export interface ApplicationData {
+  initial: string;
   name: string;
   selectedKey: string;
 }

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -101,9 +101,12 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
   max-width: 60%;
 
   .pf-c-dropdown__toggle.pf-m-plain {
-    color: initial;
     font-size: ($font-size-base + 1);
     padding: 2px 0 !important;
+
+    &:not(:disabled) {
+      color: inherit;
+    }
 
     @media (min-width: $grid-float-breakpoint) {
       font-size: ($font-size-base + 2);

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -353,7 +353,7 @@ class NamespaceBarDropdowns_ extends React.Component {
   }
 
   render() {
-    const { activeNamespace, dispatch, canListNS, useProjects, children } = this.props;
+    const { activeNamespace, dispatch, canListNS, useProjects, children, disabled } = this.props;
     if (flagPending(canListNS)) {
       return null;
     }
@@ -393,6 +393,7 @@ class NamespaceBarDropdowns_ extends React.Component {
 
     return <div className="co-namespace-bar__items" data-test-id="namespace-bar-dropdown">
       <Dropdown
+        disabled={disabled}
         className="co-namespace-selector"
         menuClassName="co-namespace-selector__menu"
         buttonClassName="pf-m-plain"
@@ -415,10 +416,10 @@ class NamespaceBarDropdowns_ extends React.Component {
 
 const NamespaceBarDropdowns = connect(namespaceBarDropdownStateToProps, namespaceBarDropdownDispatchToProps)(NamespaceBarDropdowns_);
 
-const NamespaceBar_ = ({useProjects, children}) => {
+const NamespaceBar_ = ({useProjects, children, disabled}) => {
   return <div className="co-namespace-bar">
     <Firehose resources={[{kind: getModel(useProjects).kind, prop: 'namespace', isList: true}]}>
-      <NamespaceBarDropdowns useProjects={useProjects}>
+      <NamespaceBarDropdowns useProjects={useProjects} disabled={disabled}>
         {children}
       </NamespaceBarDropdowns>
     </Firehose>
@@ -431,7 +432,7 @@ const namespaceBarStateToProps = ({k8s}) => {
     useProjects,
   };
 };
-/** @type {React.FC<{children?: ReactNode}>} */
+/** @type {React.FC<{children?: ReactNode, disabled?: boolean}>} */
 export const NamespaceBar = connect(namespaceBarStateToProps)(NamespaceBar_);
 
 export const NamespacesDetailsPage = props => <DetailsPage


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-1722

This fix adds the secondary masthead with disabled dropdowns to the add flows. The user cannot change the project while in the form. They also cannot change the application if one has already been selected prior to entering the form. If no application has been selected, the user can select an existing application or create a new one.

Project with no application (app selector is part of form):
_Note: The dropdown is still part of the form. Removing it will require further refactoring and is best to do in a separate PR_
![image](https://user-images.githubusercontent.com/14068621/63983142-6d0bbd80-ca93-11e9-885e-32b4fee272ed.png)

Project with applications but none selected (app selector is part of form):
![image](https://user-images.githubusercontent.com/14068621/63983167-8ad92280-ca93-11e9-9c71-49706cd18a03.png)
![image](https://user-images.githubusercontent.com/14068621/63983185-94628a80-ca93-11e9-8bc6-c57eb7df6c6b.png)

Project with applications and application is selected (app selector is omitted from form):
![image](https://user-images.githubusercontent.com/14068621/63983200-a93f1e00-ca93-11e9-8c7f-d6fd05304d96.png)

@openshift/team-devconsole-docs 
@openshift/team-devconsole-ux 