### PR TITLE
Bug 1724555: Query Browser: Add pagination to results table

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -82,6 +82,10 @@
   }
 }
 
+.query-browser__pagination {
+  margin-top: 15px;
+}
+
 .query-browser__query {
   line-height: 1;
   margin: 0 15px;


### PR DESCRIPTION
Fixes performance issues when the query returns a large number of data
series. Since the number of results is unbounded, the page could become
unresponsive.

Default to 100 rows per page.

When the query is changed, pagination resets to page 1, but retains its
"rows per page" setting.

If there are multiple results tables on the page, each can have its own
"rows per page" setting.

Does not change the series displayed in the graph.

Table sort by column is still possible.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1724555

![screenshot](https://user-images.githubusercontent.com/460802/63989119-29a86200-cb1a-11e9-91cf-290781675805.png)

![screenshot2](https://user-images.githubusercontent.com/460802/63989128-2e6d1600-cb1a-11e9-90f2-cdd8dca5b8e1.png)

FYI @cshinn 