### PR TITLE
Changes made in the details card of Persistent and Object Storage Dashboard

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
@@ -30,3 +30,6 @@ export const getCephNodes = (nodesData: K8sResourceKind[] = []): K8sResourceKind
 
 export const getCephSC = (scData: K8sResourceKind[]): K8sResourceKind[] =>
   scData.filter((sc) => cephStorageProvisioners.includes(_.get(sc, 'provisioner')));
+
+export const getInfrastructurePlatform = (infrastructure: K8sResourceKind): string =>
+  _.get(infrastructure, 'status.platform');


### PR DESCRIPTION
Changes made to the details card of ceph and noobaa to show ocs-operator in the version field. Also refactored a few common functions between the two cards to a new util file.
![changestoocsop](https://user-images.githubusercontent.com/54092533/64010128-ca0c7f80-cb36-11e9-9f4d-cc75167547b7.png)
