### PR TITLE
Bug 1747434: Fix plugin nav items highlighting on page refresh

### DIFF
--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -88,16 +88,15 @@ export const NavSection = connect(navSectionStateToProps)(
     }
 
     componentDidUpdate(prevProps, prevState) {
-      if (prevProps.location === this.props.location) {
-        return;
-      }
-
       const activeChild = this.getActiveChild();
-      const state: Partial<NavSectionState> = {activeChild};
-      if (activeChild && !prevState.activeChild) {
-        state.isOpen = true;
+
+      if (prevState.activeChild !== activeChild) {
+        const state: Partial<NavSectionState> = {activeChild};
+        if (activeChild && !prevState.activeChild) {
+          state.isOpen = true;
+        }
+        this.setState(state as NavSectionState);
       }
-      this.setState(state as NavSectionState);
     }
 
     toggle = (e, expandState) => {


### PR DESCRIPTION
Nav items provided by plugins were not correctly highlighted as active
on page refresh because NavSection was updating activeChild state
only on location change.

https://bugzilla.redhat.com/show_bug.cgi?id=1747434
https://jira.coreos.com/browse/CONSOLE-1527