### PR TITLE
On Import, application name is no longer required

### DIFF
--- a/frontend/packages/dev-console/src/components/import/app/ApplicationSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/app/ApplicationSelector.tsx
@@ -60,7 +60,6 @@ const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({ namespace }) 
           label="Application Name"
           data-test-id="application-form-app-input"
           helpText="A unique name given to the application grouping to label your resources."
-          required
         />
       )}
     </React.Fragment>

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -22,7 +22,7 @@ export const validationSchema = yup.object().shape({
     name: yup.string().required('Required'),
   }),
   application: yup.object().shape({
-    name: yup.string().required('Required'),
+    name: yup.string(),
     selectedKey: yup.string().required('Required'),
   }),
   image: yup.object().when('build', {

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -1,18 +1,25 @@
 export const getAppLabels = (
   name: string,
-  application: string,
+  application?: string,
   imageStreamName?: string,
   selectedTag?: string,
 ) => {
-  return {
+  const labels = {
     app: name,
-    'app.kubernetes.io/part-of': application,
     'app.kubernetes.io/instance': name,
     'app.kubernetes.io/component': name,
     'app.kubernetes.io/name': imageStreamName,
     'app.openshift.io/runtime': imageStreamName,
-    ...(selectedTag && { 'app.openshift.io/runtime-version': selectedTag }),
   };
+
+  if (application && application.trim().length > 0) {
+    labels['app.kubernetes.io/part-of'] = application;
+  }
+  if (selectedTag) {
+    labels['app.openshift.io/runtime-version'] = selectedTag;
+  }
+
+  return labels;
 };
 
 export const getAppAnnotations = (gitURL: string, gitRef: string) => {


### PR DESCRIPTION
Removes the need to provide an application name when importing a resource.

https://jira.coreos.com/browse/ODC-1699

Related but shouldn't impact work done in https://github.com/openshift/console/pull/2539

Form not required:
![image](https://user-images.githubusercontent.com/8126518/64031093-bd2b6400-cb15-11e9-8601-5da8ad8a2721.png)

Still has the default pre-fill logic though (I'd think we'd want to remove this, but it appears to have been done in response to the same parent ticket - so I left it):
![image](https://user-images.githubusercontent.com/8126518/64033231-07164900-cb1a-11e9-818b-b7d9168658c4.png)

If you have no application name, the group will not be rendered in the Topology view:
![image](https://user-images.githubusercontent.com/8126518/64035446-d258c080-cb1e-11e9-9b49-bf46d8404ccf.png)

