### PR TITLE
Add left margin to alerts text

### DIFF
--- a/frontend/public/components/dashboard/health-card/alert-item.tsx
+++ b/frontend/public/components/dashboard/health-card/alert-item.tsx
@@ -14,14 +14,14 @@ const getSeverityIcon = (severity: string) => {
     default:
       icon = <YellowExclamationTriangleIcon />;
   }
-  return <div className="co-dashboard-icon co-health-card__icon">{icon}</div>;
+  return <div className="co-dashboard-icon">{icon}</div>;
 };
 
 export const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
   return (
     <div className="co-health-card__alerts-item">
       {getSeverityIcon(getAlertSeverity(alert))}
-      {getAlertDescription(alert) || getAlertMessage(alert)}
+      <span className="co-health-card__text">{getAlertDescription(alert) || getAlertMessage(alert)}</span>
     </div>
   );
 };


### PR DESCRIPTION
Margin is missing between icon and text
![alerts_icon](https://user-images.githubusercontent.com/2078045/64047151-44a4c180-cb6e-11e9-8b74-c460acc519df.png)

after fix
![alerts_fixed](https://user-images.githubusercontent.com/2078045/64047161-51291a00-cb6e-11e9-8953-32d07380f677.png)
