### PR TITLE
build link on topology should not refresh page

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/shapes/Decorator.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/Decorator.tsx
@@ -10,7 +10,7 @@ type DecoratorTypes = {
   x: number;
   y: number;
   radius: number;
-  onClick?(): void;
+  onClick?(event: React.MouseEvent<SVGGElement, MouseEvent>): void;
   href?: string;
   external?: boolean;
   title: string;
@@ -33,14 +33,7 @@ const Decorator: React.FunctionComponent<DecoratorTypes> = ({
   const [hover, setHover] = React.useState(false);
 
   const decorator = (
-    <g
-      className="odc-decorator"
-      transform={`translate(${x}, ${y})`}
-      onClick={(e) => {
-        e.stopPropagation();
-        onClick && onClick();
-      }}
-    >
+    <g className="odc-decorator" transform={`translate(${x}, ${y})`} onClick={onClick}>
       <g onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}>
         <SvgDropShadowFilter id={FILTER_ID} stdDeviation={1} floodOpacity={0.5} />
         <circle


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-1701

`onClick` of `Decorator` was calling `e.stopPropagation` which was causing the react-router `Link` to refresh the page instead of following the route in the same page.

Removed the call to `e.stopPropagation`. This makes more sense anyways and lets the users of `Decorator` have more control.