### PR TITLE
Apply a gap between each Pipeline status

### DIFF
--- a/frontend/packages/dev-console/src/components/charts/HorizontalStackedBars.scss
+++ b/frontend/packages/dev-console/src/components/charts/HorizontalStackedBars.scss
@@ -1,12 +1,22 @@
+$gapSize: 3px;
+
 .odc-horizontal-stacked-bars {
-  display: inline-flex;
-  flex-direction: row;
+  display: inline-block;
   height: 100%;
-  outline: none;
+  overflow: hidden;
   vertical-align: middle;
   width: 100%;
 
+  &__bars {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    outline: none;
+    width: calc(100% + #{$gapSize});
+  }
+
   &__data-bar {
+    box-shadow: inset -#{$gapSize} 0 0 #ffffff;
     height: 100%;
     transition: flex-grow 300ms linear;
   }

--- a/frontend/packages/dev-console/src/components/charts/HorizontalStackedBars.tsx
+++ b/frontend/packages/dev-console/src/components/charts/HorizontalStackedBars.tsx
@@ -22,17 +22,19 @@ const HorizontalStackedBars: React.FC<HorizontalStackedBarsProps> = ({
 }) => {
   return (
     <div className="odc-horizontal-stacked-bars" style={{ height, width }}>
-      {values.map(({ color, name, size }) => (
-        <div
-          key={name}
-          className="odc-horizontal-stacked-bars__data-bar"
-          style={{
-            background: color,
-            flexGrow: size,
-            transition: disableAnimation ? 'initial' : undefined,
-          }}
-        />
-      ))}
+      <div className="odc-horizontal-stacked-bars__bars">
+        {values.map(({ color, name, size }) => (
+          <div
+            key={name}
+            className="odc-horizontal-stacked-bars__data-bar"
+            style={{
+              background: color,
+              flexGrow: size,
+              transition: disableAnimation ? 'initial' : undefined,
+            }}
+          />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Adds a visual gap between each of the task status bars in the horizontal stacked bar component.

https://jira.coreos.com/browse/ODC-1723

![image](https://user-images.githubusercontent.com/8126518/64054857-0b148c00-cb57-11e9-983a-8f763647e85c.png)

In motion:
![box-shadow](https://user-images.githubusercontent.com/8126518/64054930-6d6d8c80-cb57-11e9-9591-2c8a4258275f.gif)
