### PR TITLE
Fetching noobaa system resources irrespective of the namespace 

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/health-card/health-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/health-card/health-card.tsx
@@ -26,9 +26,7 @@ import { NooBaaSystemModel } from '../../models';
 
 const noobaaSystemResource: FirehoseResource = {
   kind: referenceForModel(NooBaaSystemModel),
-  namespaced: true,
-  namespace: 'openshift-storage',
-  name: 'noobaa-system',
+  namespaced: false,
   isList: false,
   prop: 'noobaa',
 };


### PR DESCRIPTION
### Bug:
The health card is not showing the correct message due to the unavailability of  the current fetched resource.

### Fix:
Fixed the firehose api request format.