### PR TITLE
Add project creation to Import flow when no projects exist

### DIFF
--- a/frontend/packages/dev-console/src/components/AddPage.tsx
+++ b/frontend/packages/dev-console/src/components/AddPage.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { Helmet } from 'react-helmet';
 import * as _ from 'lodash';
+import { Helmet } from 'react-helmet';
+import { HintBlock } from 'patternfly-react';
 import { match as RMatch } from 'react-router';
 import { history, Firehose, FirehoseResource } from '@console/internal/components/utils';
 import { createProjectModal } from '@console/internal/components/modals';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import ODCEmptyState from './EmptyState';
 import NamespacedPage from './NamespacedPage';
+import ProjectsExistWrapper from './ProjectsExistWrapper';
 import DefaultPage from './DefaultPage';
 
 export interface AddPageProps {
@@ -55,15 +57,18 @@ const EmptyStateLoader: React.FC<EmptyStateLoaderProps> = ({ resources, loaded, 
     resources.deployments.data,
     resources.statefulSets.data,
   ]);
-  return (
+  return noWorkloads ? (
     <ODCEmptyState
       title="Add"
-      {...noWorkloads && {
-        hintBlockTitle: 'No workloads found',
-        hintBlockDescription:
-          'To add content to your project, create an application, component or service using one of these options.',
-      }}
+      hintBlock={
+        <HintBlock
+          title="No workloads found"
+          body="To add content to your project, create an application, component or service using one of these options."
+        />
+      }
     />
+  ) : (
+    <ODCEmptyState title="Add" />
   );
 };
 
@@ -103,27 +108,34 @@ const RenderEmptyState = ({ namespace }) => {
 
 const AddPage: React.FC<AddPageProps> = ({ match }) => {
   const namespace = match.params.ns;
+
   return (
     <React.Fragment>
       <Helmet>
         <title>+Add</title>
       </Helmet>
       <NamespacedPage>
-        {namespace ? (
-          <RenderEmptyState namespace={namespace} />
-        ) : (
-          <DefaultPage title="Add">
-            Select a project to start adding to it or{' '}
-            <button
-              style={{ verticalAlign: 'baseline' }}
-              type="button"
-              className="btn btn-link btn-link--no-btn-default-values"
-              onClick={openProjectModal}
-            >
-              create a project
-            </button>
-          </DefaultPage>
-        )}
+        <Firehose resources={[{ kind: 'Project', prop: 'projects', isList: true }]}>
+          <ProjectsExistWrapper title="Add">
+            {() =>
+              namespace ? (
+                <RenderEmptyState namespace={namespace} />
+              ) : (
+                <DefaultPage title="Add">
+                  Select a project to start adding to it or{' '}
+                  <button
+                    style={{ verticalAlign: 'baseline' }}
+                    type="button"
+                    className="btn btn-link btn-link--no-btn-default-values"
+                    onClick={openProjectModal}
+                  >
+                    create a project
+                  </button>
+                </DefaultPage>
+              )
+            }
+          </ProjectsExistWrapper>
+        </Firehose>
       </NamespacedPage>
     </React.Fragment>
   );

--- a/frontend/packages/dev-console/src/components/EmptyState.scss
+++ b/frontend/packages/dev-console/src/components/EmptyState.scss
@@ -1,9 +1,9 @@
 .odc-empty-state {
-
-  &__hint-block {
-    margin: 0 30px 20px 30px;
-  }
   // work around status-box injecting intermediate node preventing pages from controling the height of their content
+  &__hint-block {
+    padding-bottom: 20px;
+  }
+
   &__title {
     background-color: var(--pf-global--BackgroundColor--light-100);
     display: flex;

--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { CatalogTile } from 'patternfly-react-extensions';
-import { HintBlock } from 'patternfly-react';
 import { connect } from 'react-redux';
 import { history, PageHeading } from '@console/internal/components/utils';
 import { formatNamespacedRouteForResource } from '@console/internal/actions/ui';
@@ -15,8 +14,7 @@ interface StateProps {
 
 export interface EmptySProps {
   title: string;
-  hintBlockTitle?: string;
-  hintBlockDescription?: string;
+  hintBlock?: React.ReactNode;
 }
 
 type Props = EmptySProps & StateProps;
@@ -29,23 +27,16 @@ const navigateTo = (e: Event, url: string) => {
 const ODCEmptyState: React.FC<Props> = ({
   title,
   activeNamespace,
-  hintBlockTitle,
-  hintBlockDescription,
+  hintBlock = 'Select a way to create an application, component or service from one of the options.',
 }) => {
   return (
     <React.Fragment>
       <div className="odc-empty-state__title">
         <PageHeading title={title} />
-        {hintBlockTitle ? (
-          <HintBlock
-            className="odc-empty-state__hint-block"
-            title={hintBlockTitle}
-            body={hintBlockDescription}
-          />
-        ) : (
-          <p className="odc-empty-state__hint-block">
-            Select a way to create an application, component or service from one of the options.
-          </p>
+        {hintBlock && (
+          <div className="co-catalog-page__description odc-empty-state__hint-block">
+            {hintBlock}
+          </div>
         )}
       </div>
       <div className="odc-empty-state__content">

--- a/frontend/packages/dev-console/src/components/ProjectsExistWrapper.tsx
+++ b/frontend/packages/dev-console/src/components/ProjectsExistWrapper.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { HintBlock } from 'patternfly-react';
+import { LoadingBox } from '@console/internal/components/utils';
+import ODCEmptyState from './EmptyState';
+
+export interface ProjectsExistWrapperProps {
+  title: string;
+  projects?: { data: []; loaded: boolean };
+  children: () => React.ReactElement;
+}
+
+const ProjectsExistWrapper: React.FC<ProjectsExistWrapperProps> = ({
+  title,
+  projects,
+  children,
+}) => {
+  if (!projects.loaded) {
+    return <LoadingBox />;
+  }
+
+  if (_.isEmpty(projects.data)) {
+    return (
+      <ODCEmptyState
+        title={title}
+        hintBlock={
+          <HintBlock
+            title="No projects exist"
+            body="Select one of the following options to create an application, component or service.
+              As part of the creation process a project and application will be created."
+          />
+        }
+      />
+    );
+  }
+
+  return children();
+};
+
+export default ProjectsExistWrapper;

--- a/frontend/packages/dev-console/src/components/dropdown/ResourceDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ResourceDropdown.tsx
@@ -62,6 +62,8 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
   componentWillReceiveProps(nextProps: ResourceDropdownProps) {
     const { loaded, loadError, autoSelect, selectedKey, placeholder, onLoad } = nextProps;
 
+    const { onLoad } = this.props;
+
     if (!loaded) {
       this.setState({ title: <LoadingInline /> });
       return;

--- a/frontend/packages/dev-console/src/components/dropdown/ResourceDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ResourceDropdown.tsx
@@ -62,8 +62,6 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
   componentWillReceiveProps(nextProps: ResourceDropdownProps) {
     const { loaded, loadError, autoSelect, selectedKey, placeholder, onLoad } = nextProps;
 
-    const { onLoad } = this.props;
-
     if (!loaded) {
       this.setState({ title: <LoadingInline /> });
       return;

--- a/frontend/packages/dev-console/src/components/formik-fields/TextAreaField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/TextAreaField.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { useField } from 'formik';
+import { FormGroup, TextArea } from '@patternfly/react-core';
+import { TextAreaProps } from './field-types';
+import { getFieldId } from './field-utils';
+
+const TextAreaField: React.FC<TextAreaProps> = ({ label, helpText, required, ...props }) => {
+  const [field, { touched, error }] = useField(props.name);
+  const fieldId = getFieldId(props.name, 'input');
+  const isValid = !(touched && error);
+  const errorMessage = !isValid ? error : '';
+  return (
+    <FormGroup
+      fieldId={fieldId}
+      label={label}
+      helperText={helpText}
+      helperTextInvalid={errorMessage}
+      isValid={isValid}
+      isRequired={required}
+    >
+      <TextArea
+        {...field}
+        {...props}
+        id={fieldId}
+        style={{ resize: 'vertical' }}
+        isValid={isValid}
+        isRequired={required}
+        aria-describedby={`${fieldId}-helper`}
+        onChange={(value, event) => field.onChange(event)}
+      />
+    </FormGroup>
+  );
+};
+
+export default TextAreaField;

--- a/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
@@ -15,6 +15,12 @@ export interface InputFieldProps extends FieldProps {
   onBlur?: (event) => void;
 }
 
+export interface TextAreaProps extends FieldProps {
+  placeholder?: string;
+  onChange?: (event) => void;
+  onBlur?: (event) => void;
+}
+
 export interface CheckboxFieldProps extends FieldProps {
   formLabel?: string;
 }

--- a/frontend/packages/dev-console/src/components/formik-fields/index.ts
+++ b/frontend/packages/dev-console/src/components/formik-fields/index.ts
@@ -1,4 +1,5 @@
 export { default as InputField } from './InputField';
+export { default as TextAreaField } from './TextAreaField';
 export { default as DropdownField } from './DropdownField';
 export { default as NSDropdownField } from './NSDropdownField';
 export { default as CheckboxField } from './CheckboxField';

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -13,6 +13,10 @@ import DeployImageForm from './DeployImageForm';
 
 export interface DeployImageProps {
   namespace: string;
+  projects?: {
+    loaded: boolean;
+    data: [];
+  };
 }
 
 interface StateProps {
@@ -21,10 +25,12 @@ interface StateProps {
 
 type Props = DeployImageProps & StateProps;
 
-const DeployImage: React.FC<Props> = ({ namespace, activeApplication }) => {
+const DeployImage: React.FC<Props> = ({ namespace, projects, activeApplication }) => {
   const initialValues: DeployImageFormData = {
     project: {
       name: namespace || '',
+      displayName: '',
+      description: '',
     },
     application: {
       initial: activeApplication,
@@ -137,7 +143,7 @@ const DeployImage: React.FC<Props> = ({ namespace, activeApplication }) => {
       onSubmit={handleSubmit}
       onReset={history.goBack}
       validationSchema={deployValidationSchema}
-      render={(props) => <DeployImageForm {...props} />}
+      render={(props) => <DeployImageForm {...props} projects={projects} />}
     />
   );
 };

--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -3,15 +3,11 @@ import * as _ from 'lodash';
 import { FormikProps, FormikValues } from 'formik';
 import { ButtonBar } from '@console/internal/components/utils';
 import { Form, ActionGroup, ButtonVariant, Button } from '@patternfly/react-core';
-import { NormalizedBuilderImages } from '../../utils/imagestream-utils';
+import { DeployImageFormProps } from './import-types';
 import ImageSearchSection from './image-search/ImageSearchSection';
 import AppSection from './app/AppSection';
 import AdvancedSection from './advanced/AdvancedSection';
 import ServerlessSection from './serverless/ServerlessSection';
-
-export interface DeployImageFormProps {
-  builderImages?: NormalizedBuilderImages;
-}
 
 const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps> = ({
   values,
@@ -21,10 +17,14 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
   status,
   isSubmitting,
   dirty,
+  projects,
 }) => (
   <Form className="co-deploy-image" onSubmit={handleSubmit}>
     <ImageSearchSection />
-    <AppSection project={values.project} />
+    <AppSection
+      project={values.project}
+      noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
+    />
     <ServerlessSection />
     <AdvancedSection values={values} />
     <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>

--- a/frontend/packages/dev-console/src/components/import/DeployImagePage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImagePage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import { PageHeading } from '@console/internal/components/utils';
+import { PageHeading, Firehose } from '@console/internal/components/utils';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import DeployImage from './DeployImage';
 
@@ -16,7 +16,9 @@ const DeployImagePage: React.FunctionComponent<DeployImagePageProps> = ({ match 
       </Helmet>
       <PageHeading title="Deploy Image" />
       <div className="co-m-pane__body">
-        <DeployImage namespace={namespace} />
+        <Firehose resources={[{ kind: 'Project', prop: 'projects', isList: true }]}>
+          <DeployImage namespace={namespace} />
+        </Firehose>
       </div>
     </NamespacedPage>
   );

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -20,12 +20,16 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
   status,
   isSubmitting,
   dirty,
+  projects,
 }) => (
   <Form onSubmit={handleSubmit}>
     <GitSection />
     <BuilderSection image={values.image} builderImages={builderImages} />
     <DockerSection buildStrategy={values.build.strategy} />
-    <AppSection project={values.project} />
+    <AppSection
+      project={values.project}
+      noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
+    />
     <ServerlessSection />
     <AdvancedSection values={values} />
     <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>

--- a/frontend/packages/dev-console/src/components/import/ImportPage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportPage.tsx
@@ -55,10 +55,21 @@ const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match, location 
         name: imageStreamName,
         namespace: imageStreamNamespace,
       },
+      {
+        kind: 'Project',
+        prop: 'projects',
+        isList: true,
+      },
     ];
   } else if (importType === ImportTypes.docker) {
     importData = ImportFlows.docker;
-    resources = [];
+    resources = [
+      {
+        kind: 'Project',
+        prop: 'projects',
+        isList: true,
+      },
+    ];
   } else {
     importData = ImportFlows.git;
     resources = [
@@ -67,6 +78,11 @@ const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match, location 
         prop: 'imageStreams',
         isList: true,
         namespace: 'openshift',
+      },
+      {
+        kind: 'Project',
+        prop: 'projects',
+        isList: true,
       },
     ];
   }

--- a/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
@@ -19,11 +19,15 @@ const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormP
   status,
   isSubmitting,
   dirty,
+  projects,
 }) => (
   <Form onSubmit={handleSubmit}>
     <BuilderSection image={values.image} builderImages={builderImages} />
     <GitSection showSample />
-    <AppSection project={values.project} />
+    <AppSection
+      project={values.project}
+      noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}
+    />
     <ServerlessSection />
     <AdvancedSection values={values} />
     <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>

--- a/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
@@ -4,6 +4,8 @@ export const mockFormData: GitImportFormData = {
   name: 'test-app',
   project: {
     name: 'mock-project',
+    displayName: '',
+    description: '',
   },
   application: {
     initial: 'mock-app',

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
@@ -45,6 +45,19 @@ describe('ValidationUtils', () => {
       });
     });
 
+    it('should throw an error if project name is invalid', async () => {
+      const mockData = cloneDeep(mockFormData);
+      mockData.project.name = 'project-!';
+      await validationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
+      await validationSchema
+        .validate(mockData)
+        .catch((err) =>
+          expect(err.message).toBe(
+            "Name must consist of lower case alphanumeric characters or '-' and must start and end with an alphanumeric character.",
+          ),
+        );
+    });
+
     it('should throw an error for required fields if empty', async () => {
       const mockData = cloneDeep(mockFormData);
       mockData.name = '';

--- a/frontend/packages/dev-console/src/components/import/app/AppSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/app/AppSection.tsx
@@ -1,20 +1,46 @@
 import * as React from 'react';
 import { useField } from 'formik';
 import { TextInputTypes } from '@patternfly/react-core';
-import { InputField } from '../../formik-fields';
+import { InputField, TextAreaField } from '../../formik-fields';
 import { ProjectData } from '../import-types';
 import FormSection from '../section/FormSection';
 import ApplicationSelector from './ApplicationSelector';
 
 export interface AppSectionProps {
   project: ProjectData;
+  noProjectsAvailable?: boolean;
 }
 
-const AppSection: React.FC<AppSectionProps> = ({ project }) => {
+const AppSection: React.FC<AppSectionProps> = ({ project, noProjectsAvailable }) => {
   const [initialApplication] = useField('application.initial');
   return (
     <FormSection title="General">
-      {!initialApplication.value && <ApplicationSelector namespace={project.name} />}
+      {noProjectsAvailable && (
+        <React.Fragment>
+          <InputField
+            type={TextInputTypes.text}
+            data-test-id="application-form-project-name"
+            name="project.name"
+            label="Project Name"
+            helpText="A unique name for the project."
+            required
+          />
+          <InputField
+            type={TextInputTypes.text}
+            data-test-id="application-form-project-display-name"
+            name="project.displayName"
+            label="Project Display Name"
+          />
+          <TextAreaField
+            data-test-id="application-form-project-description"
+            name="project.description"
+            label="Project Description"
+          />
+        </React.Fragment>
+      )}
+      {!initialApplication.value && (
+        <ApplicationSelector namespace={project.name} noProjectsAvailable={noProjectsAvailable} />
+      )}
       <InputField
         type={TextInputTypes.text}
         data-test-id="application-form-app-name"

--- a/frontend/packages/dev-console/src/components/import/app/ApplicationSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/app/ApplicationSelector.tsx
@@ -10,10 +10,16 @@ export const CREATE_APPLICATION_KEY = '#CREATE_APPLICATION_KEY#';
 
 export interface ApplicationSelectorProps {
   namespace?: string;
+  noProjectsAvailable?: boolean;
 }
 
-const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({ namespace }) => {
-  const [isZeroApplication, setIsZeroApplication] = React.useState(false);
+const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({
+  namespace,
+  noProjectsAvailable,
+}) => {
+  const [applicationsAvailable, setApplicationsAvailable] = React.useState(true);
+  const projectsAvailable = !noProjectsAvailable;
+
   const [selectedKey, { touched, error }] = useField('application.selectedKey');
   const { setFieldValue, setFieldTouched, validateForm } = useFormikContext<FormikValues>();
   const fieldId = getFieldId('application-name', 'dropdown');
@@ -32,18 +38,17 @@ const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({ namespace }) 
     validateForm();
   };
 
-  const handleOnLoad = (items: { [key: string]: string }) => {
-    const isEmptyItems = _.isEmpty(items);
-    setIsZeroApplication(isEmptyItems);
-    if (isEmptyItems) {
+  const handleOnLoad = (applicationList: { [key: string]: string }) => {
+    const noApplicationsAvailable = _.isEmpty(applicationList);
+    setApplicationsAvailable(!noApplicationsAvailable);
+    if (noApplicationsAvailable) {
       setFieldValue('application.selectedKey', CREATE_APPLICATION_KEY);
       setFieldValue('application.name', '');
     }
   };
-
   return (
     <React.Fragment>
-      {!isZeroApplication && (
+      {projectsAvailable && applicationsAvailable && (
         <FormGroup
           fieldId={fieldId}
           label="Application"
@@ -66,7 +71,7 @@ const ApplicationSelector: React.FC<ApplicationSelectorProps> = ({ namespace }) 
           />
         </FormGroup>
       )}
-      {selectedKey.value === CREATE_APPLICATION_KEY && (
+      {(noProjectsAvailable || selectedKey.value === CREATE_APPLICATION_KEY) && (
         <InputField
           type={TextInputTypes.text}
           name="application.name"

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -3,12 +3,28 @@ import { LazyLoader } from '@console/plugin-sdk/src/typings/types';
 import { NameValuePair, NameValueFromPair } from '../formik-fields/field-types';
 import { NormalizedBuilderImages } from '../../utils/imagestream-utils';
 
+export interface DeployImageFormProps {
+  builderImages?: NormalizedBuilderImages;
+  projects?: {
+    data: [];
+    loaded: boolean;
+  };
+}
+
 export interface SourceToImageFormProps {
   builderImages?: NormalizedBuilderImages;
+  projects?: {
+    data: [];
+    loaded: boolean;
+  };
 }
 
 export interface GitImportFormProps {
   builderImages?: NormalizedBuilderImages;
+  projects?: {
+    data: [];
+    loaded: boolean;
+  };
 }
 
 export interface FirehoseList {
@@ -74,6 +90,8 @@ export interface ImageStreamImageData {
 
 export interface ProjectData {
   name: string;
+  displayName: string;
+  description: string;
 }
 
 export interface GitData {

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -8,6 +8,7 @@ const urlRegex = /^(((ssh|git|https?):\/\/[\w]+)|(git@[\w]+.[\w]+:))([\w\-._~/?#
 const hostnameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 const pathRegex = /^\/.*$/;
 const nameRegex = /^([a-z]([-a-z0-9]*[a-z0-9])?)*$/;
+const projectNameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
 
 export const validationSchema = yup.object().shape({
   name: yup
@@ -20,7 +21,13 @@ export const validationSchema = yup.object().shape({
     .max(253, 'Cannot be longer than 253 characters.')
     .required('Required'),
   project: yup.object().shape({
-    name: yup.string().required('Required'),
+    name: yup
+      .string()
+      .matches(
+        projectNameRegex,
+        "Name must consist of lower case alphanumeric characters or '-' and must start and end with an alphanumeric character.",
+      )
+      .required('Required'),
   }),
   application: yup.object().shape({
     name: yup.string(),

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -2,13 +2,15 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { match as RMatch } from 'react-router-dom';
+import { HintBlock } from 'patternfly-react';
 import { getActiveApplication } from '@console/internal/reducers/ui';
 import { ALL_APPLICATIONS_KEY } from '@console/internal/const';
-import { StatusBox } from '@console/internal/components/utils';
+import { StatusBox, Firehose } from '@console/internal/components/utils';
 import { RootState } from '@console/internal/redux';
 import { FLAG_KNATIVE_SERVING } from '@console/knative-plugin/src/const';
 import EmptyState from '../EmptyState';
 import NamespacedPage from '../NamespacedPage';
+import ProjectsExistWrapper from '../ProjectsExistWrapper';
 import DefaultPage from '../DefaultPage';
 import { getCheURL } from './topology-utils';
 import TopologyDataController, { RenderProps } from './TopologyDataController';
@@ -31,8 +33,12 @@ type Props = TopologyPageProps & StateProps;
 const EmptyMsg = () => (
   <EmptyState
     title="Topology"
-    hintBlockTitle="No workloads found"
-    hintBlockDescription="To add content to your project, create an application, component or service using one of these options."
+    hintBlock={
+      <HintBlock
+        title="No workloads found"
+        body="To add content to your project, create an application, component or service using one of these options."
+      />
+    }
   />
 );
 
@@ -71,17 +77,23 @@ const TopologyPage: React.FC<Props> = ({ match, activeApplication, knative, cheU
         <title>Topology</title>
       </Helmet>
       <NamespacedPage>
-        {namespace ? (
-          <TopologyDataController
-            application={application}
-            namespace={namespace}
-            render={renderTopology}
-            knative={knative}
-            cheURL={cheURL}
-          />
-        ) : (
-          <DefaultPage title="Topology">Select a project to view the topology</DefaultPage>
-        )}
+        <Firehose resources={[{ kind: 'Project', prop: 'projects', isList: true }]}>
+          <ProjectsExistWrapper title="Topology">
+            {() => {
+              return namespace ? (
+                <TopologyDataController
+                  application={application}
+                  namespace={namespace}
+                  render={renderTopology}
+                  knative={knative}
+                  cheURL={cheURL}
+                />
+              ) : (
+                <DefaultPage title="Topology">Select a project to view the topology</DefaultPage>
+              );
+            }}
+          </ProjectsExistWrapper>
+        </Firehose>
       </NamespacedPage>
     </React.Fragment>
   );


### PR DESCRIPTION
- inform the user when no projects exist when on Add and Topology (https://jira.coreos.com/browse/ODC-1679)
- add project creation flow on the import forms when there are no projects (https://jira.coreos.com/browse/ODC-723)

![Project-creation-flow](https://user-images.githubusercontent.com/22490998/64165967-bd07cd00-ce63-11e9-8da6-82b6eb626f5d.gif)

Issues:
- there is an intermittent issue where when the user is creating the first project, after the import flow completes the Empty State with hint shows up for a sec and then the topology page loads with the application node.

Fixes #905