### PR TITLE
Bug 1724555: Query Browser: Reduce default results per page to 50

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -463,7 +463,7 @@ const QueryTable_: React.FC<QueryTableProps> = ({index, isEnabled, isExpanded, q
   const [data, setData] = React.useState();
   const [error, setError] = React.useState();
   const [page, setPage] = React.useState(1);
-  const [perPage, setPerPage] = React.useState(100);
+  const [perPage, setPerPage] = React.useState(50);
   const [sortBy, setSortBy] = React.useState<ISortBy>({index: 1, direction: 'asc'});
 
   const safeFetch = React.useCallback(useSafeFetch(), []);


### PR DESCRIPTION
Reduce the default number of rows in the results table to improve render
performance generally, but particularly to help with Firefox issue
https://bugzilla.redhat.com/show_bug.cgi?id=1724555.