### PR TITLE
Fix query browser data series selection button in FF

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -107,6 +107,7 @@
 
 .query-browser__series-btn-wrap {
   border: 1px solid transparent;
+  display: flex;
   height: 26px;
   padding: 2px;
   width: 26px;


### PR DESCRIPTION
Add display flex to button wrapper so that the button is automatically centered in the wrapper. 

![Sep-03-2019 13-35-15](https://user-images.githubusercontent.com/22625502/64196310-980a5e80-ce51-11e9-9da8-40cefda800f6.gif)
