### PR TITLE
Bug 1744488: Use OpenAPI Discovery in Create Operand Form

### DIFF
--- a/frontend/__mocks__/k8sResourcesMocks.ts
+++ b/frontend/__mocks__/k8sResourcesMocks.ts
@@ -170,6 +170,9 @@ export const testCRD: CustomResourceDefinitionKind = {
   spec: {
     group: 'testapp.coreos.com',
     version: 'v1alpha1',
+    validation: {
+      openAPIV3Schema: {},
+    },
     names: {
       kind: 'TestResource',
       plural: 'testresources',

--- a/frontend/__tests__/components/operator-lifecycle-manager/create-operand.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/create-operand.spec.tsx
@@ -66,7 +66,7 @@ describe(CreateOperandPage.displayName, () => {
 
     expect(wrapper.find(Firehose).props().resources).toEqual([
       {kind: k8s.referenceForModel(ClusterServiceVersionModel), name: match.params.appName, namespace: match.params.ns, isList: false, prop: 'clusterServiceVersion'},
-      {kind: CustomResourceDefinitionModel.kind, name: k8s.nameForModel(testModel), isList: false, prop: 'customResourceDefinition'},
+      {kind: CustomResourceDefinitionModel.kind, name: k8s.nameForModel(testModel), isList: false, prop: 'customResourceDefinition', optional: true},
     ]);
   });
 });
@@ -80,7 +80,7 @@ describe(CreateOperandForm.displayName, () => {
   }));
 
   beforeEach(() => {
-    wrapper = shallow(<CreateOperandForm namespace="default" operandModel={testModel} providedAPI={testClusterServiceVersion.spec.customresourcedefinitions.owned[0]} clusterServiceVersion={testClusterServiceVersion} customResourceDefinition={testCRD} />);
+    wrapper = shallow(<CreateOperandForm namespace="default" operandModel={testModel} providedAPI={testClusterServiceVersion.spec.customresourcedefinitions.owned[0]} clusterServiceVersion={testClusterServiceVersion} openAPI={testCRD.spec.validation.openAPIV3Schema as k8s.SwaggerDefinition} />);
   });
 
   it('renders form', () => {

--- a/frontend/integration-tests/tests/olm/descriptors.scenario.ts
+++ b/frontend/integration-tests/tests/olm/descriptors.scenario.ts
@@ -87,6 +87,7 @@ describe('Using OLM descriptor components', () => {
         openAPIV3Schema: {
           properties: {
             spec: {
+              type: 'object',
               required: ['password'],
               properties: {
                 password: {

--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -48,6 +48,15 @@ export const fetchSwagger = async(): Promise<SwaggerDefinitions> => {
   }
 };
 
+export const definitionFor = _.memoize((model: K8sKind): SwaggerDefinition => {
+  const allDefinitions: SwaggerDefinitions = getStoredSwagger();
+  if (!allDefinitions) {
+    return null;
+  }
+  const key = getDefinitionKey(model, allDefinitions);
+  return _.get(allDefinitions, key);
+}, referenceForModel);
+
 export const getResourceDescription = _.memoize((kindObj: K8sKind): string => {
   const allDefinitions: SwaggerDefinitions = getStoredSwagger();
   if (!allDefinitions) {


### PR DESCRIPTION
### Description

Switch to using the published schema from `/openapi/v2` instead of defined on the `CustomResourceDefinition` itself, which users may not have RBAC permissions to fetch. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1744488