### PR TITLE
Added 'Other' option when the git type is unknown

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-validation-utils.spec.ts
@@ -1,20 +1,21 @@
 import { cloneDeep } from 'lodash';
 import { validationSchema, detectGitType } from '../import-validation-utils';
 import { mockFormData } from '../__mocks__/import-validation-mock';
+import { GitTypes } from '../import-types';
 
 describe('ValidationUtils', () => {
   describe('Detect Git Type', () => {
-    it('should return undefined for invalid git url', () => {
+    it('should return the invalid enum key for invalid git url', () => {
       const gitType = detectGitType('test');
-      expect(gitType).toEqual(undefined);
+      expect(gitType).toEqual(GitTypes.invalid);
     });
-    it('should return empty string for valid but unknown git url ', () => {
+    it('should return the unsure enum key for valid but unknown git url ', () => {
       const gitType = detectGitType('https://svnsource.test.com');
-      expect(gitType).toEqual('');
+      expect(gitType).toEqual(GitTypes.unsure);
     });
     it('should return proper git type for valid known git url', () => {
       const gitType = detectGitType('https://github.com/test/repo');
-      expect(gitType).toEqual('github');
+      expect(gitType).toEqual(GitTypes.github);
     });
   });
 

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -144,11 +144,19 @@ export interface ServerlessScaling {
 }
 
 export enum GitTypes {
-  '' = 'Please choose Git type',
-  github = 'GitHub',
-  gitlab = 'GitLab',
-  bitbucket = 'Bitbucket',
+  github = 'github',
+  gitlab = 'gitlab',
+  bitbucket = 'bitbucket',
+  unsure = 'other',
+  invalid = '',
 }
+
+export const GitReadableTypes = {
+  [GitTypes.github]: 'GitHub',
+  [GitTypes.gitlab]: 'GitLab',
+  [GitTypes.bitbucket]: 'Bitbucket',
+  [GitTypes.unsure]: 'Other',
+};
 
 export enum ImportTypes {
   git = 'git',

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -2,6 +2,7 @@ import * as yup from 'yup';
 import * as _ from 'lodash';
 import { convertToBaseValue } from '@console/internal/components/utils';
 import { isInteger } from '../../utils/yup-validation-util';
+import { GitTypes } from './import-types';
 
 const urlRegex = /^(((ssh|git|https?):\/\/[\w]+)|(git@[\w]+.[\w]+:))([\w\-._~/?#[\]!$&'()*+,;=])+$/;
 const hostnameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
@@ -220,20 +221,22 @@ export const validationSchema = yup.object().shape({
   }),
 });
 
-export const detectGitType = (url: string): string | undefined => {
+export const detectGitType = (url: string): string => {
   if (!urlRegex.test(url)) {
-    return undefined;
+    // Not a URL
+    return GitTypes.invalid;
   }
   if (url.includes('github.com')) {
-    return 'github';
+    return GitTypes.github;
   }
   if (url.includes('bitbucket.org')) {
-    return 'bitbucket';
+    return GitTypes.bitbucket;
   }
   if (url.includes('gitlab.com')) {
-    return 'gitlab';
+    return GitTypes.gitlab;
   }
-  return '';
+  // Not a known URL
+  return GitTypes.unsure;
 };
 
 export const detectGitRepoName = (url: string): string | undefined => {

--- a/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
@@ -12,6 +12,7 @@ import { Link } from 'react-router-dom';
 import { resourcePathFromModel } from '@console/internal/components/utils';
 import { BuildModel } from '@console/internal/models';
 import { detectGitType } from '../../import/import-validation-utils';
+import { GitTypes } from '../../import/import-types';
 import { NodeProps, WorkloadData } from '../topology-types';
 import Decorator from './Decorator';
 import BaseNode from './BaseNode';
@@ -35,11 +36,11 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
 
   const routeDecoratorIcon = (editUrl: string): React.ReactElement => {
     switch (detectGitType(editUrl)) {
-      case 'github':
+      case GitTypes.github:
         return <GithubIcon style={{ fontSize: decoratorRadius }} alt="Edit Source Code" />;
-      case 'bitbucket':
+      case GitTypes.bitbucket:
         return <BitbucketIcon style={{ fontSize: decoratorRadius }} alt="Edit Source Code" />;
-      case 'gitlab':
+      case GitTypes.gitlab:
         return <GitlabIcon style={{ fontSize: decoratorRadius }} alt="Edit Source Code" />;
       default:
         return <GitAltIcon style={{ fontSize: decoratorRadius }} alt="Edit Source Code" />;


### PR DESCRIPTION
There is some concern about a blocker being in the way when we fail to detect which type of git URL they are using. To that extent, a new option is added and auto-selected when we don't know the git type. Allowing the user the same control over picking the git type (as before) but not blocking their flow.

https://jira.coreos.com/browse/ODC-1757

![image](https://user-images.githubusercontent.com/8126518/64211838-758a3c80-ce75-11e9-8f23-8e53d151c189.png)

In motion:

![OtherGitType](https://user-images.githubusercontent.com/8126518/64277006-4b895680-cf17-11e9-8009-a33bd3cb5035.gif)
