### PR TITLE
fix bug pod donut size is inconsistent when browser is resized

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodRing.scss
+++ b/frontend/packages/console-shared/src/components/pod/PodRing.scss
@@ -1,4 +1,5 @@
 .odc-pod-ring {
+  max-width: 130px;
   & svg {
     overflow: visible!important;
   }


### PR DESCRIPTION
Bug fix - https://jira.coreos.com/browse/ODC-1729

![Peek 2019-09-04 12-20](https://user-images.githubusercontent.com/2561818/64231970-93f04680-cf0e-11e9-8dab-0ca8fd283b1e.gif)
