### PR TITLE
Show the zero savings in object data reduction card

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/capacity-card/capacity-card-body.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/capacity-card/capacity-card-body.tsx
@@ -5,7 +5,7 @@ import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 import {
   LoadingInline,
   humanizePercentage,
-  humanizeBinaryBytes,
+  humanizeBinaryBytesWithoutB,
 } from '@console/internal/components/utils';
 import './capacity-card.scss';
 
@@ -51,7 +51,7 @@ export const CapacityCardBody: React.FC<CapacityCardBodyProps> = ({
   if (!metricData.length) {
     return <GraphEmpty />;
   }
-  const totalHumanized = humanizeBinaryBytes(totalUsage, null, totalUsage ? null : 'MiB');
+  const totalHumanized = humanizeBinaryBytesWithoutB(totalUsage, null, totalUsage ? null : 'MiB');
   return (
     <div className="nb-capacity-card__body-chart">
       <div className="noobaa-capacity-card__item">

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card-utils.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card-utils.ts
@@ -1,5 +1,9 @@
 import * as _ from 'lodash';
-import { Humanize, humanizeBinaryBytes, humanizeNumber } from '@console/internal/components/utils';
+import {
+  Humanize,
+  humanizeBinaryBytesWithoutB,
+  humanizeNumber,
+} from '@console/internal/components/utils';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import {
   ACCOUNTS,
@@ -88,7 +92,7 @@ export const getDataConsumptionChartData: GetDataConsumptionChartData = (
         getChartData(
           result.logicalUsage,
           metric,
-          humanizeBinaryBytes,
+          humanizeBinaryBytesWithoutB,
           'Total Logical Used Capacity',
         ),
       ];
@@ -96,7 +100,7 @@ export const getDataConsumptionChartData: GetDataConsumptionChartData = (
         {
           name: `Total Logical Used Capacity ${getLegendData(
             result.totalLogicalUsage,
-            humanizeBinaryBytes,
+            humanizeBinaryBytesWithoutB,
           )}`,
         },
       ];
@@ -106,13 +110,13 @@ export const getDataConsumptionChartData: GetDataConsumptionChartData = (
         getChartData(
           result.physicalUsage,
           metric,
-          humanizeBinaryBytes,
+          humanizeBinaryBytesWithoutB,
           'Total Logical Used Capacity',
         ),
         getChartData(
           result.logicalUsage,
           metric,
-          humanizeBinaryBytes,
+          humanizeBinaryBytesWithoutB,
           'Total Physical Used Capacity',
         ),
       ];
@@ -120,21 +124,21 @@ export const getDataConsumptionChartData: GetDataConsumptionChartData = (
         {
           name: `Total Logical Used Capacity ${getLegendData(
             result.totalPhysicalUsage,
-            humanizeBinaryBytes,
+            humanizeBinaryBytesWithoutB,
           )}`,
         },
         {
           name: `Total Physical Used Capacity ${getLegendData(
             result.totalLogicalUsage,
-            humanizeBinaryBytes,
+            humanizeBinaryBytesWithoutB,
           )}`,
         },
       ];
       break;
     case 'PROVIDERS_BY_EGRESS':
-      chartData = [getChartData(result.egress, metric, humanizeBinaryBytes)];
+      chartData = [getChartData(result.egress, metric, humanizeBinaryBytesWithoutB)];
       legendData = chartData[0].map((dataPoint) => ({
-        name: `${dataPoint.x} ${humanizeBinaryBytes(dataPoint.y).string}`,
+        name: `${dataPoint.x} ${humanizeBinaryBytesWithoutB(dataPoint.y).string}`,
       }));
       break;
     default:

--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.tsx
@@ -21,7 +21,7 @@ import {
   withDashboardResources,
 } from '@console/internal/components/dashboards-page/with-dashboard-resources';
 import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
-import { humanizeBinaryBytes, humanizeNumber } from '@console/internal/components/utils';
+import { humanizeBinaryBytesWithoutB, humanizeNumber } from '@console/internal/components/utils';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import { BY_IOPS, CHART_LABELS, PROVIDERS } from '../../constants';
 import {
@@ -67,7 +67,7 @@ const DataConsumptionCard: React.FC<DashboardItemProps> = ({
   // chartData = [[]] or [[],[]]
   if (!chartData.some(_.isEmpty)) {
     maxVal = _.maxBy(chartData.map((data) => _.maxBy(data, 'y')), 'y').y;
-    maxUnit = humanizeBinaryBytes(maxVal).unit;
+    maxUnit = humanizeBinaryBytesWithoutB(maxVal).unit;
     suffixLabel = maxUnit;
     if (sortByKpi === BY_IOPS) {
       suffixLabel = numberInWords(maxVal);

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card-item.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card-item.tsx
@@ -7,80 +7,57 @@ import {
   LoadingInline,
 } from '@console/internal/components/utils';
 
-const ItemBody: React.FC<ItemBodyProps> = React.memo(({ title, children }) => (
-  <div className="co-inventory-card__item">
-    <div className="nb-object-data-reduction-card__row-title">{title}</div>
-    {children}
-  </div>
-));
+const ItemBody: React.FC<ItemBodyProps> = React.memo(({ title, stats, infoText, isLoading }) => {
+  let status: React.ReactElement;
+  if (isLoading) {
+    status = <LoadingInline />;
+  } else if (!stats) {
+    status = <span className="co-dashboard-text--small text-muted">Unavailable</span>;
+  } else {
+    status = <span className="nb-object-data-reduction-card__row-status-item-text">{stats}</span>;
+  }
+  return (
+    <div className="co-inventory-card__item">
+      <div className="nb-object-data-reduction-card__row-title">{title}</div>
+      <div className="nb-object-data-reduction-card__row-status-item">
+        {status}
+        <DashboardCardHelp>{infoText}</DashboardCardHelp>
+      </div>
+    </div>
+  );
+});
 
 export const EfficiencyItem: React.FC<EfficiencyItemProps> = React.memo(
   ({ efficiency, isLoading }) => {
-    let text = (
-      <span className="co-dashboard-text--small nb-object-data-reduction-card__row-subtitle">
-        Unavailable
-      </span>
-    );
     const infoText =
       'Efficiency ratio refers to the deduplication and compression process effectiveness.';
-
-    if (isLoading) {
-      text = <LoadingInline />;
-    } else if (!_.isNil(efficiency)) {
-      text = (
-        <span className="nb-object-data-reduction-card__row-status-item-text">
-          {Number(efficiency).toFixed(1)}:1
-        </span>
-      );
-    }
+    const stats: string = !_.isNil(efficiency) ? `${Number(efficiency).toFixed(1)}:1` : null;
     return (
-      <ItemBody title="Efficiency Ratio">
-        <div className="nb-object-data-reduction-card__row-status-item">
-          {text}
-          <DashboardCardHelp>{infoText}</DashboardCardHelp>
-        </div>
-      </ItemBody>
+      <ItemBody title="Efficiency Ratio" stats={stats} infoText={infoText} isLoading={isLoading} />
     );
   },
 );
 
 export const SavingsItem: React.FC<SavingsItemProps> = React.memo(
   ({ savings, logicalSize, isLoading }) => {
-    let text = (
-      <span className="co-dashboard-text--small nb-object-data-reduction-card__row-subtitle">
-        Unavailable
-      </span>
-    );
     const infoText =
       'Savings shows the uncompressed and non-deduped data that would have been stored without those techniques';
-
-    if (isLoading) {
-      text = <LoadingInline />;
-    } else if (!_.isNil(savings)) {
+    let stats: string = null;
+    if (!_.isNil(savings)) {
       const savingsPercentage = logicalSize
         ? `(${humanizePercentage((100 * Number(savings)) / logicalSize).string})`
-        : null;
-      const savingsFormattted = humanizeBinaryBytesWithoutB(Number(savings));
-      text = (
-        <span className="nb-object-data-reduction-card__row-status-item-text">
-          {`${savingsFormattted.string} ${savingsPercentage}`}
-        </span>
-      );
+        : '';
+      stats = `${humanizeBinaryBytesWithoutB(savings).string} ${savingsPercentage}`;
     }
-    return (
-      <ItemBody title="Savings">
-        <div className="nb-object-data-reduction-card__row-status-item">
-          {text}
-          <DashboardCardHelp>{infoText}</DashboardCardHelp>
-        </div>
-      </ItemBody>
-    );
+    return <ItemBody title="Savings" stats={stats} infoText={infoText} isLoading={isLoading} />;
   },
 );
 
 type ItemBodyProps = {
   title: string;
-  children: React.ReactNode;
+  stats: string;
+  infoText: string;
+  isLoading: boolean;
 };
 
 type EfficiencyItemProps = {

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card.scss
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card.scss
@@ -19,10 +19,6 @@
   margin-left: 0.25em;
 }
 
-.nb-object-data-reduction-card__row-subtitle {
-  color: $pf-color-black-500;
-}
-
 .nb-object-data-reduction-card__row-title {
   margin-right: 0.5em;
 }

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-data-reduction-card/object-data-reduction-card.tsx
@@ -62,11 +62,9 @@ const DataReductionCard: React.FC<DashboardItemProps> = ({
       <DashboardCardHeader>
         <DashboardCardTitle>Object Data Reduction</DashboardCardTitle>
       </DashboardCardHeader>
-      <DashboardCardBody>
-        <div className="co-dashboard-card__body--no-padding">
-          <EfficiencyItem {...efficiencyProps} />
-          <SavingsItem {...savingsProps} />
-        </div>
+      <DashboardCardBody className="co-dashboard-card__body--no-padding">
+        <EfficiencyItem {...efficiencyProps} />
+        <SavingsItem {...savingsProps} />
       </DashboardCardBody>
     </DashboardCard>
   );

--- a/frontend/packages/noobaa-storage-plugin/src/queries.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/queries.ts
@@ -10,7 +10,7 @@ export enum DATA_RESILIENCE_QUERIES {
 
 export enum ObjectDataReductionQueries {
   EFFICIENCY_QUERY = 'NooBaa_reduction_ratio',
-  SAVINGS_QUERY = '(NooBaa_object_savings_logical_size - NooBaa_object_savings_physical_size) > 0',
+  SAVINGS_QUERY = '(NooBaa_object_savings_logical_size - NooBaa_object_savings_physical_size) >= 0',
   LOGICAL_SAVINGS_QUERY = 'NooBaa_object_savings_logical_size',
 }
 


### PR DESCRIPTION
### Bug
![mini2](https://user-images.githubusercontent.com/25664409/64232765-3826bd00-cf10-11e9-9f58-79af692d2e54.png)

### Fix
![new2](https://user-images.githubusercontent.com/25664409/64356361-63003680-d020-11e9-9bcf-ea3f762b9cd1.png)

Refactored the code a bit.
Also changed the units back to `withB` in order to be consistent with the console