### PR TITLE
Follow up to Ceph storage extension PRs

### DIFF
--- a/frontend/packages/ceph-storage-plugin/package.json
+++ b/frontend/packages/ceph-storage-plugin/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-fixed",
   "description": "Ceph Storage - Persistent storage for Kubernetes",
   "private": true,
+  "main": "src/index.ts",
   "dependencies": {
     "@console/plugin-sdk": "0.0.0-fixed",
     "@console/shared": "0.0.0-fixed",

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-card/capacity-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-card/capacity-card.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as plugins from '@console/internal/plugins';
 import { connectToFlags, FlagsObject, WithFlagsProps } from '@console/internal/reducers/features';
-import { getFlagsForExtensions } from '@console/internal/components/dashboards-page/utils';
 import { CapacityBody, CapacityItem } from '@console/internal/components/dashboard/capacity-card';
 import {
   DashboardCard,
@@ -13,7 +12,6 @@ import {
   DashboardItemProps,
   withDashboardResources,
 } from '@console/internal/components/dashboards-page/with-dashboard-resources';
-import { DashboardsStorageCapacityDropdownItem } from '@console/plugin-sdk';
 import {
   Dropdown,
   FieldLevelHelp,
@@ -21,6 +19,14 @@ import {
 } from '@console/internal/components/utils';
 import { getInstantVectorStats, GetStats } from '@console/internal/components/graphs/utils';
 import { PrometheusResponse } from '@console/internal/components/graphs';
+import {
+  getFlagsForExtensions,
+  isDashboardExtensionInUse,
+} from '@console/internal/components/dashboards-page/utils';
+import {
+  DashboardsStorageCapacityDropdownItem,
+  isDashboardsStorageCapacityDropdownItem,
+} from '../../../../extensions/dashboards';
 import { StorageDashboardQuery, CAPACITY_USAGE_QUERIES } from '../../../../constants/queries';
 import './capacity-card.scss';
 
@@ -48,19 +54,22 @@ const QueriesMatchingCapacityView: QueryMapType = {
   ],
 };
 
-const getItems = (plugin: DashboardsStorageCapacityDropdownItem[], flags: FlagsObject) =>
-  plugin.filter((e) => flags[e.properties.required]);
+const getItems = (extensions: DashboardsStorageCapacityDropdownItem[], flags: FlagsObject) =>
+  extensions.filter((e) => isDashboardExtensionInUse(e, flags));
 
 const getCapacityQueries = (flags: FlagsObject) => {
   const capacityQueries = { ...QueriesMatchingCapacityView };
-  getItems(plugins.registry.getDashboardsStorageCapacityDropdownItem(), flags).forEach(
-    (pluginItem) => {
-      if (!capacityQueries[pluginItem.properties.metric]) {
-        capacityQueries[pluginItem.properties.metric] = pluginItem.properties.queries;
-        CapacityViewType[pluginItem.properties.metric] = pluginItem.properties.metric;
-      }
-    },
-  );
+  getItems(
+    plugins.registry.get<DashboardsStorageCapacityDropdownItem>(
+      isDashboardsStorageCapacityDropdownItem,
+    ),
+    flags,
+  ).forEach((pluginItem) => {
+    if (!capacityQueries[pluginItem.properties.metric]) {
+      capacityQueries[pluginItem.properties.metric] = pluginItem.properties.queries;
+      CapacityViewType[pluginItem.properties.metric] = pluginItem.properties.metric;
+    }
+  });
   return capacityQueries;
 };
 
@@ -132,7 +141,7 @@ export const CapacityCard: React.FC<DashboardItemProps & WithFlagsProps> = ({
 };
 
 export default connectToFlags(
-  ...getFlagsForExtensions(plugins.registry.getDashboardsStorageCapacityDropdownItem()),
+  ...getFlagsForExtensions(plugins.registry.get(isDashboardsStorageCapacityDropdownItem)),
 )(withDashboardResources(CapacityCard));
 
 export type QueryMapType = {

--- a/frontend/packages/ceph-storage-plugin/src/extensions/dashboards.ts
+++ b/frontend/packages/ceph-storage-plugin/src/extensions/dashboards.ts
@@ -1,12 +1,7 @@
-import { Extension } from '../extension';
+import { Extension, DashboardsExtensionProperties } from '@console/plugin-sdk';
 
 namespace ExtensionProperties {
-  interface DashboardExtension {
-    /** Name of feature flag for this item. */
-    required: string;
-  }
-
-  export interface DashboardsStorageTopConsumerUsed extends DashboardExtension {
+  export interface DashboardsStorageTopConsumerUsed extends DashboardsExtensionProperties {
     /** The name of the storage top consumer used */
     name: string;
 
@@ -17,7 +12,7 @@ namespace ExtensionProperties {
     query: string;
   }
 
-  export interface DashboardsStorageTopConsumerRequested extends DashboardExtension {
+  export interface DashboardsStorageTopConsumerRequested extends DashboardsExtensionProperties {
     /** The name of the storage top consumer requested  */
     name: string;
 
@@ -28,7 +23,7 @@ namespace ExtensionProperties {
     query: string;
   }
 
-  export interface DashboardsStorageCapacityDropdownItem extends DashboardExtension {
+  export interface DashboardsStorageCapacityDropdownItem extends DashboardsExtensionProperties {
     /** The name of the metric */
     metric: string;
 
@@ -52,6 +47,10 @@ export interface DashboardsStorageCapacityDropdownItem
   type: 'Dashboards/Storage/Capacity/Dropdown/Item';
 }
 
+export type DashboardsStorageTopConsumerExtension =
+  | DashboardsStorageTopConsumerUsed
+  | DashboardsStorageTopConsumerRequested;
+
 export const isDashboardsStorageTopConsumerUsed = (
   e: Extension,
 ): e is DashboardsStorageTopConsumerUsed => e.type === 'Dashboards/Storage/TopConsumers/Used';
@@ -65,7 +64,3 @@ export const isDashboardsStorageCapacityDropdownItem = (
   e: Extension,
 ): e is DashboardsStorageCapacityDropdownItem =>
   e.type === 'Dashboards/Storage/Capacity/Dropdown/Item';
-
-export type DashboardStorageExtension =
-  | DashboardsStorageTopConsumerRequested
-  | DashboardsStorageTopConsumerUsed;

--- a/frontend/packages/ceph-storage-plugin/src/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/index.ts
@@ -1,0 +1,1 @@
+export * from './extensions/dashboards';

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import {
   Extension,
+  ExtensionTypeGuard,
   ActivePlugin,
   isModelDefinition,
   isFeatureFlag,
@@ -18,9 +19,6 @@ import {
   isDashboardsOverviewQuery,
   isDashboardsOverviewUtilizationItem,
   isDashboardsOverviewTopConsumerItem,
-  isDashboardsStorageTopConsumerUsed,
-  isDashboardsStorageTopConsumerRequested,
-  isDashboardsStorageCapacityDropdownItem,
   isOverviewResourceTab,
   isOverviewCRD,
   isGlobalConfig,
@@ -39,6 +37,10 @@ export class ExtensionRegistry {
 
   public constructor(plugins: ActivePlugin[]) {
     this.extensions = _.flatMap(plugins.map((p) => p.extensions));
+  }
+
+  public get<E extends Extension>(typeGuard: ExtensionTypeGuard<E>): E[] {
+    return this.extensions.filter(typeGuard);
   }
 
   public getModelDefinitions() {
@@ -103,18 +105,6 @@ export class ExtensionRegistry {
 
   public getDashboardsOverviewTopConsumerItems() {
     return this.extensions.filter(isDashboardsOverviewTopConsumerItem);
-  }
-
-  public getDashboardsStorageTopConsumerUsed() {
-    return this.extensions.filter(isDashboardsStorageTopConsumerUsed);
-  }
-
-  public getDashboardsStorageTopConsumerRequested() {
-    return this.extensions.filter(isDashboardsStorageTopConsumerRequested);
-  }
-
-  public getDashboardsStorageCapacityDropdownItem() {
-    return this.extensions.filter(isDashboardsStorageCapacityDropdownItem);
   }
 
   public getOverviewResourceTabs() {

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -13,13 +13,13 @@ import { PrometheusResponse } from '@console/internal/components/graphs';
 import { Extension } from './extension';
 import { LazyLoader } from './types';
 
-namespace ExtensionProperties {
-  interface DashboardExtension {
-    /** Name of feature flag for this item. */
-    required?: string | string[];
-  }
+export interface DashboardsExtensionProperties {
+  /** Name of feature flag for this item. */
+  required?: string | string[];
+}
 
-  interface DashboardsOverviewHealthSubsystem extends DashboardExtension {
+namespace ExtensionProperties {
+  interface DashboardsOverviewHealthSubsystem extends DashboardsExtensionProperties {
     /** The subsystem's display name */
     title: string;
   }
@@ -69,7 +69,7 @@ namespace ExtensionProperties {
     popupTitle?: string;
   }
 
-  export interface DashboardsTab extends DashboardExtension {
+  export interface DashboardsTab extends DashboardsExtensionProperties {
     /** The tab's ID which will be used as part of href within dashboards page */
     id: string;
 
@@ -77,7 +77,7 @@ namespace ExtensionProperties {
     title: string;
   }
 
-  export interface DashboardsCard extends DashboardExtension {
+  export interface DashboardsCard extends DashboardsExtensionProperties {
     /** The tab's ID where this card should be rendered */
     tab: string;
 
@@ -91,7 +91,7 @@ namespace ExtensionProperties {
     span?: DashboardCardSpan;
   }
 
-  export interface DashboardsOverviewQuery extends DashboardExtension {
+  export interface DashboardsOverviewQuery extends DashboardsExtensionProperties {
     /** The original Prometheus query key to replace */
     queryKey: OverviewQuery;
 
@@ -99,7 +99,7 @@ namespace ExtensionProperties {
     query: string;
   }
 
-  export interface DashboardsOverviewTopConsumerItem extends DashboardExtension {
+  export interface DashboardsOverviewTopConsumerItem extends DashboardsExtensionProperties {
     /** The k8s model of top consumer item */
     model: K8sKind;
 
@@ -116,7 +116,7 @@ namespace ExtensionProperties {
     mutator?: ConsumerMutator;
   }
 
-  export interface DashboardsOverviewInventoryItem extends DashboardExtension {
+  export interface DashboardsOverviewInventoryItem extends DashboardsExtensionProperties {
     /** Resource which will be fetched and grouped by `mapper` function. */
     resource: FirehoseResource;
 
@@ -136,7 +136,7 @@ namespace ExtensionProperties {
     expandedComponent?: LazyLoader<ExpandedComponentProps>;
   }
 
-  export interface DashboardsInventoryItemGroup extends DashboardExtension {
+  export interface DashboardsInventoryItemGroup extends DashboardsExtensionProperties {
     /** The ID of status group. */
     id: string;
 
@@ -144,7 +144,7 @@ namespace ExtensionProperties {
     icon: React.ReactElement;
   }
 
-  export interface DashboardsOverviewUtilizationItem extends DashboardExtension {
+  export interface DashboardsOverviewUtilizationItem extends DashboardsExtensionProperties {
     /** The utilization item title */
     title: string;
 
@@ -155,7 +155,7 @@ namespace ExtensionProperties {
     humanizeValue: Humanize;
   }
 
-  export interface DashboardsOverviewResourceActivity extends DashboardExtension {
+  export interface DashboardsOverviewResourceActivity extends DashboardsExtensionProperties {
     /** Resource to watch */
     k8sResource: FirehoseResource;
 
@@ -172,7 +172,7 @@ namespace ExtensionProperties {
     loader: LazyLoader<K8sActivityProps>;
   }
 
-  export interface DashboardsOverviewPrometheusActivity extends DashboardExtension {
+  export interface DashboardsOverviewPrometheusActivity extends DashboardsExtensionProperties {
     /** Queries to watch */
     queries: string[];
 
@@ -273,7 +273,7 @@ export interface DashboardsOverviewResourceActivity
 }
 
 export const isDashboardsOverviewResourceActivity = (
-  e: Extension<any>,
+  e: Extension,
 ): e is DashboardsOverviewResourceActivity => e.type === 'Dashboards/Overview/Activity/Resource';
 
 export interface DashboardsOverviewPrometheusActivity
@@ -282,7 +282,7 @@ export interface DashboardsOverviewPrometheusActivity
 }
 
 export const isDashboardsOverviewPrometheusActivity = (
-  e: Extension<any>,
+  e: Extension,
 ): e is DashboardsOverviewPrometheusActivity =>
   e.type === 'Dashboards/Overview/Activity/Prometheus';
 

--- a/frontend/packages/console-plugin-sdk/src/typings/extension.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/extension.ts
@@ -67,3 +67,5 @@ export type ActivePlugin = {
   name: string;
   extensions: Extension[];
 };
+
+export type ExtensionTypeGuard<E extends Extension> = (e: E) => e is E;

--- a/frontend/packages/console-plugin-sdk/src/typings/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/index.ts
@@ -13,5 +13,4 @@ export * from './perspectives';
 export * from './yaml-templates';
 export * from './global-configs';
 export * from './clusterserviceversions';
-export * from './plugins/ceph-storage-plugin';
 export * from './dev-catalog';

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -12,10 +12,12 @@ import {
   DashboardsOverviewHealthURLSubsystem,
   DashboardsOverviewInventoryItem,
   DashboardsInventoryItemGroup,
-  DashboardsStorageTopConsumerRequested,
-  DashboardsStorageTopConsumerUsed,
-  DashboardsStorageCapacityDropdownItem,
 } from '@console/plugin-sdk';
+import {
+  DashboardsStorageTopConsumerUsed,
+  DashboardsStorageTopConsumerRequested,
+  DashboardsStorageCapacityDropdownItem,
+} from '@console/ceph-storage-plugin';
 import { TemplateModel, PodModel } from '@console/internal/models';
 import * as models from './models';
 import { VMTemplateYAMLTemplates, VirtualMachineYAMLTemplates } from './models/templates';
@@ -38,8 +40,8 @@ type ConsumedExtensions =
   | DashboardsOverviewHealthURLSubsystem
   | DashboardsOverviewInventoryItem
   | DashboardsInventoryItemGroup
-  | DashboardsStorageTopConsumerRequested
   | DashboardsStorageTopConsumerUsed
+  | DashboardsStorageTopConsumerRequested
   | DashboardsStorageCapacityDropdownItem;
 
 const FLAG_KUBEVIRT = 'KUBEVIRT';


### PR DESCRIPTION
This is a follow-up to #2476 and #2478.

- [x] move Ceph storage specific extension types under `ceph-storage-plugin` package
- [x] avoid SDK => Ceph plugin reference in `ExtensionRegistry`, work with type guards instead
- [x] address [this](https://github.com/openshift/console/pull/2476#discussion_r319581855) and [this](https://github.com/openshift/console/pull/2476#discussion_r319582981) review comment

This is in-line with @christianvogt's [suggestion](https://github.com/openshift/console/pull/2476#issuecomment-526686742):

> IMO extension types should be in the package that has the implementation that utilizes the extensions and not putting everything into the SDK.

cc @christianvogt @rawagner @cloudbehl 
