### PR TITLE
Optimize webpack-generated KubeVirt chunks

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -90,7 +90,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       model: models.VirtualMachineModel,
       loader: () =>
-        import('./components/vms/vm' /* webpackChunkName: "kubevirt-virtual-machines" */).then(
+        import('./components/vms/vm' /* webpackChunkName: "kubevirt" */).then(
           (m) => m.VirtualMachinesPage,
         ),
     },
@@ -115,9 +115,9 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       model: models.VirtualMachineModel,
       loader: () =>
-        import(
-          './components/vms/vm-details-page' /* webpackChunkName: "kubevirt-virtual-machine-details" */
-        ).then((m) => m.VirtualMachinesDetailsPage),
+        import('./components/vms/vm-details-page' /* webpackChunkName: "kubevirt" */).then(
+          (m) => m.VirtualMachinesDetailsPage,
+        ),
     },
   },
   {
@@ -126,9 +126,9 @@ const plugin: Plugin<ConsumedExtensions> = [
       exact: true,
       path: ['/k8s/ns/:ns/vmtemplates', '/k8s/all-namespaces/vmtemplates'],
       loader: () =>
-        import(
-          './components/vm-templates/vm-template' /* webpackChunkName: "kubevirt-vmtemplates" */
-        ).then((m) => m.VirtualMachineTemplatesPage),
+        import('./components/vm-templates/vm-template' /* webpackChunkName: "kubevirt" */).then(
+          (m) => m.VirtualMachineTemplatesPage,
+        ),
     },
   },
   {
@@ -138,7 +138,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       path: ['/k8s/ns/:ns/vmtemplates/~new'],
       loader: () =>
         import(
-          './components/vm-templates/vm-template-create-yaml' /* webpackChunkName: "kubevirt-vmtemplates-create-yaml" */
+          './components/vm-templates/vm-template-create-yaml' /* webpackChunkName: "kubevirt" */
         ).then((m) => m.CreateVMTemplateYAML),
     },
   },
@@ -148,7 +148,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       path: `/k8s/ns/:ns/vmtemplates/:name`,
       loader: () =>
         import(
-          './components/vm-templates/vm-template-details-page' /* webpackChunkName: "kubevirt-virtual-machine-details" */
+          './components/vm-templates/vm-template-details-page' /* webpackChunkName: "kubevirt" */
         ).then((m) => m.VMTemplateDetailsPage),
     },
   },


### PR DESCRIPTION
Playing with `yarn analyze` on KubeVirt chunks leads to following options:

1. `kubevirt-vendor` chunk (573.93 KB) + multiple `kubevirt-xxx` chunks (1604.58 KB total)
  sum total = **2178.51 KB**
2. no `kubevirt-vendor` chunk + multiple `kubevirt-xxx` chunks (3721.75 KB total)
  sum total = **3721.75 KB**
3. `kubevirt-vendor` chunk (573.93 KB) + single `kubevirt` chunk (453.38 KB)
  sum total = **1027.31**
4. no `kubevirt-vendor` chunk + single `kubevirt` chunk (1012.65 KB)
  sum total = **1012.65 KB**

`kubevirt-vendor` chunk configuration, using webpack [cache groups](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkscachegroups):

```ts
// config.optimization.splitChunks
cacheGroups: {
  'kubevirt-vendor': {
    test: /[\\/]node_modules[\\/](kubevirt-web-ui-components|@patternfly[\\/]react-console)[\\/]/,
    name: 'kubevirt-vendor',
    chunks: 'all',
  },
},
```

This PR adopts option (4).

Once we eliminate `kubevirt-web-ui-components` dependency, we should revisit this again.

cc @spadgett @alecmerdler 
