### PR TITLE
Adjust padding for search input and label line-height

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -15,8 +15,7 @@
   align-items: center;
   display: flex;
   height: auto; // allow tags to wrap
-  min-height: 34px; // Make consistent with pf-c-form-control
-  padding-bottom: 4px; // reduce 2px to offset for the co-m-label 2px margin-bottom
+  padding: 3px 9px;
   width: 100%;
 }
 

--- a/frontend/public/style/_vars.scss
+++ b/frontend/public/style/_vars.scss
@@ -39,7 +39,7 @@ $table-border-color: $color-pf-black-200;
 
 // == Custom variables
 
-$co-m-label-line-height: 19px;
+$co-m-label-line-height: 20px;
 $pf-header-icon-fontsize: 16px; // Patternfly 4 default
 $co-side-nav-font-size: 16px; // Side nav section (sub-section set by body)
 


### PR DESCRIPTION
fixes https://jira.coreos.com/browse/CONSOLE-1732

Removed min-height which caused Safari height issue
Adjusted padding and label line-height for`.co-search-input.pf-c-form-control`

<img width="432" alt="Screen Shot 2019-09-04 at 3 34 10 PM" src="https://user-images.githubusercontent.com/1874151/64285347-9b711900-cf29-11e9-8a9f-7f1ffc6934c7.png">

<img width="924" alt="Screen Shot 2019-09-04 at 2 20 09 PM" src="https://user-images.githubusercontent.com/1874151/64285363-a3c95400-cf29-11e9-84de-d893d203940e.png">
<img width="1048" alt="Screen Shot 2019-09-04 at 2 20 30 PM" src="https://user-images.githubusercontent.com/1874151/64285364-a3c95400-cf29-11e9-8432-d9bd8b65c14a.png">
<img width="965" alt="Screen Shot 2019-09-04 at 2 21 03 PM" src="https://user-images.githubusercontent.com/1874151/64285365-a3c95400-cf29-11e9-8e2d-bde985baf681.png">
<img width="762" alt="Screen Shot 2019-09-04 at 2 24 19 PM" src="https://user-images.githubusercontent.com/1874151/64285366-a3c95400-cf29-11e9-9b78-5bddeb042c17.png">
