### PR TITLE
API Explorer: Add verbs and short names to details overview

### DIFF
--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -90,12 +90,12 @@ const getResources_ = () => coFetchJSON('api/kubernetes/apis')
         const adminResources = [];
 
         const defineModels = (list: APIResourceList): K8sKind[] => list.resources.filter(({name}) => !name.includes('/'))
-          .map(({name, singularName, namespaced, kind, verbs}) => {
+          .map(({name, singularName, namespaced, kind, verbs, shortNames}) => {
             const label = kind.replace(/([A-Z]+)/g, ' $1').slice(1);
             const groupVersion = list.groupVersion.split('/').length === 2 ? list.groupVersion : `core/${list.groupVersion}`;
 
             return {
-              kind, namespaced, label, verbs,
+              kind, namespaced, label, verbs, shortNames,
               plural: name,
               apiVersion: groupVersion.split('/')[1],
               abbr: kindToAbbr(kind),
@@ -130,5 +130,6 @@ export type APIResourceList = {
     namespaced?: boolean;
     kind: string;
     verbs: K8sVerb[];
+    shortNames?: string[];
   }[];
 };

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -656,6 +656,7 @@ export type K8sKind = {
   labels?: {[key: string]: string};
   annotations?: {[key: string]: string};
   verbs?: K8sVerb[];
+  shortNames?: string[];
 };
 
 export type Cause = {

--- a/frontend/public/reducers/k8s.ts
+++ b/frontend/public/reducers/k8s.ts
@@ -99,7 +99,8 @@ export default (state: K8sState, action: K8sAction): K8sState => {
           // FIXME: Need to use `kind` as model reference for legacy components accessing k8s primitives
           const [modelRef, model] = allModels().findEntry(staticModel => !staticModel.crd && referenceForModel(staticModel) === referenceForModel(newModel))
             || [referenceForModel(newModel), newModel];
-          return prevState.updateIn(['RESOURCES', 'models'], models => models.set(modelRef, model));
+          // Verbs and short names are not part of the static model definitions, so use the values found during discovery.
+          return prevState.updateIn(['RESOURCES', 'models'], models => models.set(modelRef, {...model, verbs: newModel.verbs, shortNames: newModel.shortNames}));
         }, state)
         // TODO: Determine where these are used and implement filtering in that component instead of storing in Redux
         .setIn(['RESOURCES', 'allResources'], action.payload.resources.allResources)


### PR DESCRIPTION
Fixes a bug where types you can't list can show up in the search page resource dropdown and adds verbs / short names to the API explorer.

I plan to look at subresources separately.

https://jira.coreos.com/browse/CONSOLE-789

/assign @rhamilto 
@smarterclayton fyi

![Config Map · OKD 2019-09-04 15-48-33](https://user-images.githubusercontent.com/1167259/64286447-7c738680-cf2b-11e9-8fdb-6b485ec79ed7.png)
