### PR TITLE
kubevirt: Add VM dashboard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/index.ts
@@ -1,0 +1,1 @@
+export * from './vm-details-card';

--- a/frontend/packages/kubevirt-plugin/src/components/ip-addresses.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/ip-addresses.ts
@@ -1,0 +1,10 @@
+import { getVmiIpAddresses, isVmOff } from 'kubevirt-web-ui-components';
+import { VMIKind } from '../types';
+import { VMStatus } from '../statuses/vm/vm';
+
+// the vmStatus is precomputed by caller for optimization
+export const getVmiIpAddressesString = (vmi: VMIKind, vmStatus: VMStatus): string => {
+  const vmIsOff = vmStatus && isVmOff(vmStatus);
+  const ipAddresses = vmIsOff ? [] : getVmiIpAddresses(vmi);
+  return ipAddresses.length > 0 ? ipAddresses.join(', ') : null;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard-context.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard-context.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { PodKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { VMKind, VMIKind } from '../../types';
+
+export const VMDashboardContext = React.createContext<VMDashboardContext>({});
+
+type VMDashboardContext = {
+  vm?: VMKind;
+  pods?: PodKind[];
+  migrations?: K8sResourceKind[];
+  vmi?: VMIKind;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Dashboard, DashboardGrid } from '@console/internal/components/dashboard';
+import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
+import { VMKind, VMIKind } from '../../types';
+import { VMDetailsCard } from '../dashboards-page/vm-dashboard/vm-details-card';
+import { VMDashboardContext } from './vm-dashboard-context';
+
+const mainCards = [];
+const leftCards = [{ Card: VMDetailsCard }];
+const rightCards = [];
+
+export const VMDashboard: React.FC<VMDashboardProps> = (props) => {
+  const { obj: vm, vmi, pods, migrations } = props;
+
+  const context = {
+    vm,
+    vmi,
+    pods,
+    migrations,
+  };
+
+  return (
+    <div className="co-m-pane__body">
+      <VMDashboardContext.Provider value={context}>
+        <Dashboard>
+          <DashboardGrid mainCards={mainCards} leftCards={leftCards} rightCards={rightCards} />
+        </Dashboard>
+      </VMDashboardContext.Provider>
+    </div>
+  );
+};
+
+type VMDashboardProps = {
+  obj?: VMKind;
+  vmi?: VMIKind;
+  pods?: PodKind[];
+  migrations?: K8sResourceKind[];
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -7,10 +7,12 @@ import { VMDisksFirehose } from '../vm-disks';
 import { VMNics } from '../vm-nics';
 import { VirtualMachineInstanceMigrationModel, VirtualMachineInstanceModel } from '../../models';
 import { getResource } from '../../utils';
+import { VM_DETAIL_OVERVIEW_HREF } from '../../constants';
 import { VMEvents } from './vm-events';
 import { VMConsoleFirehose } from './vm-console';
 import { VMDetailsFirehose } from './vm-details';
 import { menuActionsCreator } from './menu-actions';
+import { VMDashboard } from './vm-dashboard';
 
 export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProps> = (props) => {
   const { name, namespace } = props;
@@ -26,6 +28,18 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
     getResource(PodModel, { namespace, prop: 'pods' }),
     getResource(VirtualMachineInstanceMigrationModel, { namespace, prop: 'migrations' }),
   ];
+
+  const dashboardPage = {
+    href: '', // default landing page
+    name: 'Dashboard',
+    component: VMDashboard,
+  };
+
+  const overviewPage = {
+    href: VM_DETAIL_OVERVIEW_HREF,
+    name: 'Overview',
+    component: VMDetailsFirehose,
+  };
 
   const consolePage = {
     href: 'consoles',
@@ -46,7 +60,8 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
   };
 
   const pages = [
-    navFactory.details(VMDetailsFirehose),
+    dashboardPage,
+    overviewPage,
     navFactory.editYaml(),
     consolePage,
     navFactory.events(VMEvents),

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -2,13 +2,11 @@ import * as React from 'react';
 import {
   getOperatingSystemName,
   getOperatingSystem,
-  getVmiIpAddresses,
   getWorkloadProfile,
   getVmTemplate,
   getNodeName,
   VmStatuses,
   BootOrder,
-  isVmOff,
   getBootableDevicesInOrder,
 } from 'kubevirt-web-ui-components';
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
@@ -23,6 +21,7 @@ import { getDescription } from '../../selectors/selectors';
 import { getVMStatus } from '../../statuses/vm/vm';
 import { FlavorText } from '../flavor-text';
 import { EditButton } from '../edit-button';
+import { getVmiIpAddressesString } from '../ip-addresses';
 
 import './_vm-resource.scss';
 
@@ -64,8 +63,6 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
   const { launcherPod } = vmStatus;
   const sortedBootableDevices = getBootableDevicesInOrder(vm);
   const nodeName = getNodeName(launcherPod);
-  const vmIsOff = isVmOff(vmStatus);
-  const ipAddresses = vmIsOff ? [] : getVmiIpAddresses(vmi);
 
   return (
     <dl className="co-m-pane__details">
@@ -94,9 +91,7 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
         )}
       </dd>
       <dt>IP Address</dt>
-      <dd id={prefixedID(id, 'ip-addresses')}>
-        {ipAddresses.length > 0 ? ipAddresses.join(', ') : DASH}
-      </dd>
+      <dd id={prefixedID(id, 'ip-addresses')}>{getVmiIpAddressesString(vmi, vmStatus) || DASH}</dd>
       <dt>Node</dt>
       <dd id={prefixedID(id, 'node')}>{<NodeLink name={nodeName} />}</dd>
       <dt>Flavor</dt>

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -19,3 +19,5 @@ export const TEMPLATE_VM_NAME_LABEL = 'vm.kubevirt.io/name';
 export const TEMPLATE_OS_NAME_ANNOTATION = 'name.os.template.kubevirt.io';
 
 export const DEFAULT_RDP_PORT = 3389;
+
+export const VM_DETAIL_OVERVIEW_HREF = 'overview';

--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
@@ -188,7 +188,11 @@ const isWaitingForVMI = (vm: VMKind): VMStatus => {
   return NOT_HANDLED;
 };
 
-export const getVMStatus = (vm: VMKind, pods: PodKind[], migrations: K8sResourceKind[]) => {
+export const getVMStatus = (
+  vm: VMKind,
+  pods: PodKind[],
+  migrations: K8sResourceKind[],
+): VMStatus => {
   const launcherPod = findVMPod(pods, vm, VIRT_LAUNCHER_POD_PREFIX);
   return (
     isV2VConversion(vm, pods) || // these statuses must precede isRunning() because they do not rely on ready vms
@@ -209,7 +213,7 @@ export const getSimpleVMStatus = (vm: VMKind, pods: PodKind[], migrations: K8sRe
     : VM_SIMPLE_STATUS_OTHER;
 };
 
-type VMStatus = Status & {
+export type VMStatus = Status & {
   pod?: PodKind;
   launcherPod?: PodKind;
   progress?: number;

--- a/frontend/public/components/dashboard/details-card/detail-item.tsx
+++ b/frontend/public/components/dashboard/details-card/detail-item.tsx
@@ -5,7 +5,7 @@ export const DetailItem: React.FC<DetailItemProps> = React.memo(
   ({ title, isLoading = false, children, error = false }) => {
     let status: React.ReactNode;
     if (error) {
-      status = <span className="text-secondary">Unavailable</span>;
+      status = <span className="text-secondary">Not available</span>;
     } else if (isLoading) {
       status = <LoadingInline />;
     } else {


### PR DESCRIPTION
So far with just a single "Details" card. Additional cards will follow.

Depends on:
- [x] https://github.com/openshift/console/pull/2808

---

![vmDetails1](https://user-images.githubusercontent.com/17194943/65767923-b05b5980-e12f-11e9-9c42-caebdb032e5c.png)

![vmDetails2](https://user-images.githubusercontent.com/17194943/65767924-b05b5980-e12f-11e9-9986-a8d19b8bf24a.png)
