### PR TITLE
API Explorer: Add text filter to the URL

### DIFF
--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -143,12 +143,12 @@ const APIResourcesList = compose(withRouter, connect<APIResourcesListPropsFromSt
   const ALL = '#all#';
   const GROUP_PARAM = 'g';
   const VERSION_PARAM = 'v';
+  const TEXT_FILTER_PARAM = 'q';
   const search = new URLSearchParams(location.search);
   // Differentiate between an empty group and an unspecified param.
   const groupFilter = search.has(GROUP_PARAM) ? search.get(GROUP_PARAM) : ALL;
   const versionFilter = search.get(VERSION_PARAM) || ALL;
-
-  const [textFilter, setTextFilter] = React.useState('');
+  const textFilter = search.get(TEXT_FILTER_PARAM) || '';
 
   // group options
   const groups: Set<string> = models.reduce((result: Set<string>, {apiGroup}) => {
@@ -213,6 +213,13 @@ const APIResourcesList = compose(withRouter, connect<APIResourcesListPropsFromSt
   };
   const onGroupSelected = (group: string) => updateURL(GROUP_PARAM, group);
   const onVersionSelected = (version: string) => updateURL(VERSION_PARAM, version);
+  const setTextFilter = (text: string) => {
+    if (!text) {
+      removeQueryArgument(TEXT_FILTER_PARAM);
+    } else {
+      setQueryArgument(TEXT_FILTER_PARAM, text);
+    }
+  };
 
   return <>
     <div className="co-m-pane__filter-bar">
@@ -237,7 +244,7 @@ const APIResourcesList = compose(withRouter, connect<APIResourcesListPropsFromSt
       </div>
       <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--filter">
         <TextFilter
-          defaultValue={textFilter}
+          value={textFilter}
           label="by kind"
           onChange={(e) => setTextFilter(e.target.value)}
         />

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -33,8 +33,8 @@ export const CompactExpandButtons = ({expand = false, onExpandChange = _.noop}) 
   </label>
 </div>;
 
-/** @type {React.SFC<{disabled?: boolean, label: string, onChange: React.ChangeEventHandler<any>, defaultValue: string}}>} */
-export const TextFilter = ({label, onChange, defaultValue, style, className}) => {
+/** @type {React.SFC<{disabled?: boolean, label: string, onChange: React.ChangeEventHandler<any>, defaultValue?: string, value?: string}}>} */
+export const TextFilter = ({label, onChange, defaultValue, style, className, value}) => {
   const input = React.useRef();
   const onKeyDown = (e) => {
     const { nodeName } = e.target;
@@ -61,6 +61,7 @@ export const TextFilter = ({label, onChange, defaultValue, style, className}) =>
         ref={input}
         autoCapitalize="none"
         className={classNames('pf-c-form-control co-text-filter', className)}
+        value={value}
         defaultValue={defaultValue}
         onChange={onChange}
         onKeyDown={e => e.key === 'Escape' && e.target.blur()}


### PR DESCRIPTION
This keeps the text filter active when using the back button and lets you share it as a link.

/assign @rhamilto 
@smarterclayton fyi