### PR TITLE
Bug 1748823: Some reports data are not shown correctly and sorting doesn't work

### DIFF
--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -166,6 +166,7 @@ const numericUnits = new Set([
   'cpu_cores',
   'memory_bytes',
   'memory_byte_seconds',
+  'numeric',
   'seconds',
 ]);
 
@@ -188,14 +189,14 @@ const DataTable = ({cols, rows, schema}: DataTableProps) => {
 
   const getUnit = (col: string) => {
     const colSchema = _.find(schema.values, {'name': col});
-    return _.get(colSchema, 'unit');
+    return _.get(colSchema, 'unit', _.isFinite(_.get(colSchema, 'value')) ? 'numeric' : null);
   };
 
   const DataTableHeader = () => _.map(cols, col => {
     return ({
       sortAsNumber: numericUnits.has(getUnit(col)),
       sortField: col,
-      title: col.replace(/_/g, ' '),
+      title: <span className="pf-m-wrap co-break-word">{col.replace(/_/g, ' ')}</span>,
       transforms: [sortable],
     });
   });


### PR DESCRIPTION
Determined that v2 Table API doesn't return `unit` for many numeric fields such as 'avg node count' or 'total cluster capacity cpu core seconds'.  Added numeric check which will right-align and sort numeric fields correctly.   Also wrapped table column heading titles.

**Before:**
![image](https://user-images.githubusercontent.com/12733153/64358094-c87a0600-cfd3-11e9-93e9-678c131437a2.png)

**After:**
![image](https://user-images.githubusercontent.com/12733153/64358105-cfa11400-cfd3-11e9-95b9-f8adff9823e6.png)

This fix also addresses Bug 1729437: Usage Report table overlaps when view on smaller screen size
**Now at Mobile:**
![image](https://user-images.githubusercontent.com/12733153/64358235-1727a000-cfd4-11e9-8929-1a5af0e96d4c.png)