### PR TITLE
clicking on build decorator takes to build logs tab

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
@@ -92,7 +92,11 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
         build && (
           <Link
             key="build"
-            to={resourcePathFromModel(BuildModel, build.metadata.name, build.metadata.namespace)}
+            to={`${resourcePathFromModel(
+              BuildModel,
+              build.metadata.name,
+              build.metadata.namespace,
+            )}/logs`}
             className="odc-decorator__link"
           >
             <Decorator


### PR DESCRIPTION
ODC-bug: https://jira.coreos.com/browse/ODC-1774

![decorator-log](https://user-images.githubusercontent.com/9278015/64362732-ab255600-d02c-11e9-95a1-0acd936a32bb.gif)

cc: @serenamarie125 