### PR TITLE
Improve Capacity card's "out of X" text flow and style

### DIFF
--- a/frontend/public/components/dashboard/capacity-card/capacity-card.scss
+++ b/frontend/public/components/dashboard/capacity-card/capacity-card.scss
@@ -24,6 +24,7 @@
 }
 
 .co-capacity-card__item-description-value {
+  display: block;
   white-space: nowrap;
 }
 

--- a/frontend/public/components/dashboard/capacity-card/capacity-item.tsx
+++ b/frontend/public/components/dashboard/capacity-card/capacity-item.tsx
@@ -18,9 +18,8 @@ export const CapacityItem: React.FC<CapacityItemProps> = React.memo(({ title, us
   };
   const description = error ? NOT_AVAILABLE : (
     <>
-      <span className="co-dashboard-text--small co-capacity-card__item-description-value">{available.string}</span>
-      {' available out of '}
-      <span className="co-dashboard-text--small co-capacity-card__item-description-value">{totalFormatted.string}</span>
+      <span className="co-dashboard-text--small co-capacity-card__item-description-value">{available.string}{' available'}</span>
+      <span className="co-dashboard-text--small co-capacity-card__item-description-value text-secondary">{'out of '}{totalFormatted.string}</span>
     </>
   );
   return (


### PR DESCRIPTION
A minor tweak to visually separate the available capacity from the total. There's a good chance that I didn't adjust the `.tsx` the right way - let me know. 🙂

Before:

![image](https://user-images.githubusercontent.com/9122899/64380257-9fbb3600-cffe-11e9-84bd-c8cc41345ccb.png)

After:

![image](https://user-images.githubusercontent.com/9122899/64380214-8d40fc80-cffe-11e9-8048-472938412d21.png)

FYI @spadgett