### PR TITLE
Capacity items wraps in 4-2-1 manner

### DIFF
--- a/frontend/public/components/dashboards-page/overview-dashboard/capacity-card.scss
+++ b/frontend/public/components/dashboards-page/overview-dashboard/capacity-card.scss
@@ -1,0 +1,8 @@
+.co-overview-capacity__item {
+  display: flex;
+  justify-content: space-evenly;
+}
+
+.co-overview-capacity__grid {
+  width: 100%;
+}

--- a/frontend/public/components/dashboards-page/overview-dashboard/capacity-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/capacity-card.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
+import { Grid, GridItem } from '@patternfly/react-core';
 
 import * as plugins from '../../../plugins';
 import {
@@ -10,7 +11,7 @@ import {
 } from '../../dashboard/dashboard-card';
 import { CapacityBody, CapacityItem } from '../../dashboard/capacity-card';
 import { withDashboardResources, DashboardItemProps } from '../with-dashboard-resources';
-import { humanizePercentage, humanizeDecimalBytesPerSec, humanizeBinaryBytesWithoutB } from '../../utils';
+import { humanizePercentage, humanizeDecimalBytesPerSec, humanizeBinaryBytesWithoutB, useRefWidth } from '../../utils';
 import { getInstantVectorStats, getRangeVectorStats, GetStats } from '../../graphs/utils';
 import { OverviewQuery, capacityQueries } from './queries';
 import { connectToFlags, FlagsObject, WithFlagsProps } from '../../../reducers/features';
@@ -38,6 +39,7 @@ export const CapacityCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
   prometheusResults,
   flags = {},
 }) => {
+  const [containerRef, width] = useRefWidth();
   React.useEffect(() => {
     const queries = getQueries(flags);
     Object.keys(queries).forEach(key => watchPrometheus(queries[key]));
@@ -55,44 +57,103 @@ export const CapacityCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
   const networkUsed = prometheusResults.getIn([queries[OverviewQuery.NETWORK_UTILIZATION], 'result']);
   const networkTotal = prometheusResults.getIn([queries[OverviewQuery.NETWORK_TOTAL], 'result']);
 
+  const CPUItem = (
+    <CapacityItem
+      title="CPU"
+      used={getLastStats(cpuUtilization, getRangeVectorStats)}
+      total={100}
+      formatValue={humanizePercentage}
+      isLoading={!cpuUtilization}
+    />
+  );
+
+  const MemoryItem = (
+    <CapacityItem
+      title="Memory"
+      used={getLastStats(memoryUtilization, getRangeVectorStats)}
+      total={getLastStats(memoryTotal, getInstantVectorStats)}
+      formatValue={humanizeBinaryBytesWithoutB}
+      isLoading={!(memoryUtilization && memoryTotal)}
+    />
+  );
+
+  const StorageItem = (
+    <CapacityItem
+      title="Storage"
+      used={getLastStats(storageUsed, getRangeVectorStats)}
+      total={getLastStats(storageTotal, getInstantVectorStats)}
+      formatValue={humanizeBinaryBytesWithoutB}
+      isLoading={!(storageUsed && storageTotal)}
+    />
+  );
+
+  const NetworkItem = (
+    <CapacityItem
+      title="Network"
+      used={getLastStats(networkUsed, getInstantVectorStats)}
+      total={getLastStats(networkTotal, getInstantVectorStats)}
+      formatValue={humanizeDecimalBytesPerSec}
+      isLoading={!(networkUsed && networkTotal)}
+    />
+  );
+
+
+  let grid;
+  if (width <= 300) {
+    grid = (
+      <>
+        <GridItem className="co-overview-capacity__item">
+          {CPUItem}
+        </GridItem>
+        <GridItem className="co-overview-capacity__item">
+          {MemoryItem}
+        </GridItem>
+        <GridItem className="co-overview-capacity__item">
+          {StorageItem}
+        </GridItem>
+        <GridItem className="co-overview-capacity__item">
+          {NetworkItem}
+        </GridItem>
+      </>
+    );
+  } else if (width <= 650) {
+    grid = (
+      <>
+        <GridItem className="co-overview-capacity__item">
+          {CPUItem}
+          {MemoryItem}
+        </GridItem>
+        <GridItem className="co-overview-capacity__item">
+          {StorageItem}
+          {NetworkItem}
+        </GridItem>
+      </>
+    );
+  } else {
+    grid = (
+      <>
+        <GridItem className="co-overview-capacity__item">
+          {CPUItem}
+          {MemoryItem}
+          {StorageItem}
+          {NetworkItem}
+        </GridItem>
+      </>
+    );
+  }
   return (
-    <DashboardCard>
-      <DashboardCardHeader>
-        <DashboardCardTitle>Cluster Capacity</DashboardCardTitle>
-      </DashboardCardHeader>
-      <DashboardCardBody>
-        <CapacityBody>
-          <CapacityItem
-            title="CPU"
-            used={getLastStats(cpuUtilization, getRangeVectorStats)}
-            total={100}
-            formatValue={humanizePercentage}
-            isLoading={!cpuUtilization}
-          />
-          <CapacityItem
-            title="Memory"
-            used={getLastStats(memoryUtilization, getRangeVectorStats)}
-            total={getLastStats(memoryTotal, getInstantVectorStats)}
-            formatValue={humanizeBinaryBytesWithoutB}
-            isLoading={!(memoryUtilization && memoryTotal)}
-          />
-          <CapacityItem
-            title="Storage"
-            used={getLastStats(storageUsed, getRangeVectorStats)}
-            total={getLastStats(storageTotal, getInstantVectorStats)}
-            formatValue={humanizeBinaryBytesWithoutB}
-            isLoading={!(storageUsed && storageTotal)}
-          />
-          <CapacityItem
-            title="Network"
-            used={getLastStats(networkUsed, getInstantVectorStats)}
-            total={getLastStats(networkTotal, getInstantVectorStats)}
-            formatValue={humanizeDecimalBytesPerSec}
-            isLoading={!(networkUsed && networkTotal)}
-          />
-        </CapacityBody>
-      </DashboardCardBody>
-    </DashboardCard>
+    <div ref={containerRef}>
+      <DashboardCard>
+        <DashboardCardHeader>
+          <DashboardCardTitle>Cluster Capacity</DashboardCardTitle>
+        </DashboardCardHeader>
+        <DashboardCardBody>
+          <CapacityBody>
+            <Grid className="co-overview-capacity__grid">{grid}</Grid>
+          </CapacityBody>
+        </DashboardCardBody>
+      </DashboardCard>
+    </div>
   );
 };
 

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -104,5 +104,6 @@
 @import "components/dashboard/top-consumers-card/top-consumers-card";
 
 @import "components/dashboards-page/overview-dashboard/top-consumers-card";
+@import "components/dashboards-page/overview-dashboard/capacity-card";
 
 @import "components/nav/nav-header";


### PR DESCRIPTION
This PR fixes wrapping of Capacity Card Items in 4-2-1 (no 3 up, 1 down). It uses useRefWidth hook to know the width of the card and changes grid accordingly. Breakpoints are 300px, 650px based on observation.

We cannot use `md`/`lg`..props on Grid as those are based on window size, not card size

@spadgett