### PR TITLE
Fix env var typo in test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ You must run this command once, and every time the dependencies change. `node_mo
 
 #### Interactive Development
 
-The following build task will watch the source code for changes and compile automatically.  
+The following build task will watch the source code for changes and compile automatically.
 If you would like to disable hot reloading, set the environment variable `HOT_RELOAD` to `false`.
 ```
 yarn run dev
@@ -214,8 +214,8 @@ Downloading chrome requires `curl`, `unzip`, and `sha256sum` command line utilit
 
 ```
 # # For Chrome Version 76.0.3809.0 (Developer Build) (64-bit)
-$ export FORCE_CHRMOE_BRANCH_BASE="665006"
-$ export FORCE_CHRMOE_BRANCH_SHA256SUM="a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"
+$ export FORCE_CHROME_BRANCH_BASE="665006"
+$ export FORCE_CHROME_BRANCH_SHA256SUM="a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"
 $ ./test-gui.sh e2e
 ```
 

--- a/frontend/test-e2e.sh
+++ b/frontend/test-e2e.sh
@@ -45,8 +45,8 @@ export BRIDGE_BASE_PATH
 
 # Chrome Version 76.0.3809.0 (Developer Build) (64-bit)
 # get the branch base position for a specific chrmoe version using https://omahaproxy.appspot.com/
-export FORCE_CHRMOE_BRANCH_BASE="665006"
-export FORCE_CHRMOE_BRANCH_SHA256SUM="a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"
+export FORCE_CHROME_BRANCH_BASE="665006"
+export FORCE_CHROME_BRANCH_SHA256SUM="a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"
 
 out=/out
 set +e

--- a/test-gui.sh
+++ b/test-gui.sh
@@ -4,9 +4,9 @@ set -exuo pipefail
 
 cd frontend
 
-if [ -v FORCE_CHRMOE_BRANCH_BASE ];
+if [ -v FORCE_CHROME_BRANCH_BASE ];
 then
-  BRANCH_BASE=${FORCE_CHRMOE_BRANCH_BASE}
+  BRANCH_BASE=${FORCE_CHROME_BRANCH_BASE}
   export CHROME_BINARY_PATH="${PWD}/__chrome_browser__/${BRANCH_BASE}/chrome-linux/chrome"
 
   # look for chrome binary
@@ -25,7 +25,7 @@ then
     unzip "${CHROME_DIR}/chrome-linux-${BRANCH_BASE}.zip" -d "${CHROME_DIR}/${BRANCH_BASE}"
 
     # check sha256sum
-    if [ "$(sha256sum ${CHROME_DIR}/chrome-linux-${BRANCH_BASE}.zip | cut -f 1 -d ' ')" != "${FORCE_CHRMOE_BRANCH_SHA256SUM}" ];
+    if [ "$(sha256sum ${CHROME_DIR}/chrome-linux-${BRANCH_BASE}.zip | cut -f 1 -d ' ')" != "${FORCE_CHROME_BRANCH_SHA256SUM}" ];
     then
       rm -rf "${CHROME_DIR}/${BRANCH_BASE}"
 

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -27,7 +27,7 @@ oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-h
 
 # Chrome Version 76.0.3809.0 (Developer Build) (64-bit)
 # get the branch base position for a specific chrmoe version using https://omahaproxy.appspot.com/
-export FORCE_CHRMOE_BRANCH_BASE="665006"
-export FORCE_CHRMOE_BRANCH_SHA256SUM="a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"
+export FORCE_CHROME_BRANCH_BASE="665006"
+export FORCE_CHROME_BRANCH_SHA256SUM="a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"
 
 ./test-gui.sh ${1:-e2e}


### PR DESCRIPTION
Chrome was misspelled in a few places