### PR TITLE
Bug 1750344: [metal3] Pass node name to queries instead of IP

### DIFF
--- a/frontend/packages/console-shared/src/selectors/machine.ts
+++ b/frontend/packages/console-shared/src/selectors/machine.ts
@@ -20,3 +20,10 @@ export const getMachineNodeName = (obj: MachineKind) => _.get(obj, 'status.nodeR
 
 export const getMachineNode = (machine: MachineKind, nodes: NodeKind[] = []): NodeKind =>
   nodes.find((node) => getMachineNodeName(machine) === getName(node));
+
+export const getMachineAddresses = (machine: MachineKind) => _.get(machine, 'status.addresses', []);
+
+export const getMachineInternalIP = (machine: MachineKind) => {
+  const machineAddresses = getMachineAddresses(machine);
+  return _.get(machineAddresses.find((addr) => addr.type === 'InternalIP'), 'address');
+};

--- a/frontend/packages/metal3-plugin/src/components/dashboard/queries.ts
+++ b/frontend/packages/metal3-plugin/src/components/dashboard/queries.ts
@@ -11,48 +11,58 @@ export enum HostQuery {
   NUMBER_OF_PSUS = 'NUMBER_OF_PSUS',
 }
 
-const hostQueries = {
+const hostQueriesByHostName = {
   [HostQuery.CPU_UTILIZATION]: 'instance:node_cpu:rate:sum',
   [HostQuery.MEMORY_UTILIZATION]: 'node_memory_Active_bytes',
   [HostQuery.STORAGE_UTILIZATION]: 'instance:node_filesystem_usage:sum',
   [HostQuery.NETWORK_IN_UTILIZATION]: 'instance:node_network_receive_bytes:rate:sum',
   [HostQuery.NETWORK_OUT_UTILIZATION]: 'instance:node_network_transmit_bytes:rate:sum',
-  [HostQuery.NUMBER_OF_PODS]: 'kubelet_running_pod_count',
   [HostQuery.NUMBER_OF_FANS]: 'baremetal_fan_rpm',
   [HostQuery.NUMBER_OF_PSUS]: 'baremetal_current',
 };
 
-const getQueryForHost = (hostIP: string, query: string): string =>
+const hostQueriesByIP = {
+  [HostQuery.NUMBER_OF_PODS]: 'kubelet_running_pod_count',
+};
+
+const getQueryForHostName = (hostName: string, query: string): string =>
+  `${query}{instance=~'${hostName}'}[60m:5m]`;
+
+const getQueryForHostIP = (hostIP: string, query: string): string =>
   `${query}{instance=~'${hostIP}:.*'}[60m:5m]`;
 
-const getSimpleQueryForHost = (hostIP: string, query: string): string =>
+const getSimpleQueryForHostIP = (hostIP: string, query: string): string =>
   `${query}{instance=~'${hostIP}:.*'}`;
 
-export const getUtilizationQueries = (hostIP: string): HostQueryType => ({
-  [HostQuery.CPU_UTILIZATION]: getQueryForHost(hostIP, hostQueries[HostQuery.CPU_UTILIZATION]),
-  [HostQuery.MEMORY_UTILIZATION]: getQueryForHost(
-    hostIP,
-    hostQueries[HostQuery.MEMORY_UTILIZATION],
+export const getUtilizationQueries = (hostName: string, hostIP: string): HostQueryType => ({
+  [HostQuery.CPU_UTILIZATION]: getQueryForHostName(
+    hostName,
+    hostQueriesByHostName[HostQuery.CPU_UTILIZATION],
   ),
-  [HostQuery.STORAGE_UTILIZATION]: getQueryForHost(
-    hostIP,
-    hostQueries[HostQuery.STORAGE_UTILIZATION],
+  [HostQuery.MEMORY_UTILIZATION]: getQueryForHostName(
+    hostName,
+    hostQueriesByHostName[HostQuery.MEMORY_UTILIZATION],
   ),
-  [HostQuery.NETWORK_IN_UTILIZATION]: getQueryForHost(
-    hostIP,
-    hostQueries[HostQuery.NETWORK_IN_UTILIZATION],
+  [HostQuery.STORAGE_UTILIZATION]: getQueryForHostName(
+    hostName,
+    hostQueriesByHostName[HostQuery.STORAGE_UTILIZATION],
   ),
-  [HostQuery.NETWORK_OUT_UTILIZATION]: getQueryForHost(
-    hostIP,
-    hostQueries[HostQuery.NETWORK_OUT_UTILIZATION],
+  [HostQuery.NETWORK_IN_UTILIZATION]: getQueryForHostName(
+    hostName,
+    hostQueriesByHostName[HostQuery.NETWORK_IN_UTILIZATION],
   ),
-  [HostQuery.NUMBER_OF_PODS]: getQueryForHost(hostIP, hostQueries[HostQuery.NUMBER_OF_PODS]),
+  [HostQuery.NETWORK_OUT_UTILIZATION]: getQueryForHostName(
+    hostName,
+    hostQueriesByHostName[HostQuery.NETWORK_OUT_UTILIZATION],
+  ),
+  [HostQuery.NUMBER_OF_PODS]: getQueryForHostIP(hostIP, hostQueriesByIP[HostQuery.NUMBER_OF_PODS]),
 });
 
 export const getInventoryQueries = (hostIP: string): HostQueryType => ({
-  [HostQuery.NUMBER_OF_PODS]: getSimpleQueryForHost(hostIP, hostQueries[HostQuery.NUMBER_OF_PODS]),
-  [HostQuery.NUMBER_OF_FANS]: getSimpleQueryForHost(hostIP, hostQueries[HostQuery.NUMBER_OF_FANS]),
-  [HostQuery.NUMBER_OF_PSUS]: getSimpleQueryForHost(hostIP, hostQueries[HostQuery.NUMBER_OF_PSUS]),
+  [HostQuery.NUMBER_OF_PODS]: getSimpleQueryForHostIP(
+    hostIP,
+    hostQueriesByIP[HostQuery.NUMBER_OF_PODS],
+  ),
 });
 
 type HostQueryType = {

--- a/frontend/packages/metal3-plugin/src/selectors/index.ts
+++ b/frontend/packages/metal3-plugin/src/selectors/index.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
-import { K8sResourceKind, MachineKind } from '@console/internal/module/k8s';
 import { getName } from '@console/shared/src/selectors';
+import { K8sResourceKind, MachineKind } from '@console/internal/module/k8s';
 import { BaremetalHostDisk } from '../types';
 import {
   HOST_POWER_STATUS_POWERED_ON,


### PR DESCRIPTION
Queries provided by node-exporter now specify a node name under the
'instance' field instead of the original IP address.  The kubelet
queries work the same as before.  Thus, we refactor the query creation
mechanism to enable both options.

Needs a BZ, and targets 4.2.