### PR TITLE
Add Advanced -> Explore nav item to Developer perspective

### DIFF
--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -110,14 +110,14 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'NavItem/ResourceNS',
+    type: 'NavItem/Href',
     properties: {
       section: 'Advanced',
       perspective: 'dev',
       componentProps: {
-        name: 'Events',
-        resource: 'events',
-        testID: 'advanced-events-header',
+        name: 'Search',
+        href: '/search',
+        testID: 'advanced-search-header',
       },
     },
   },
@@ -127,9 +127,21 @@ const plugin: Plugin<ConsumedExtensions> = [
       section: 'Advanced',
       perspective: 'dev',
       componentProps: {
-        name: 'Search',
-        href: '/search',
-        testID: 'advanced-search-header',
+        name: 'Explore',
+        href: '/api-explorer',
+        testID: 'advanced-explore-header',
+      },
+    },
+  },
+  {
+    type: 'NavItem/ResourceNS',
+    properties: {
+      section: 'Advanced',
+      perspective: 'dev',
+      componentProps: {
+        name: 'Events',
+        resource: 'events',
+        testID: 'advanced-events-header',
       },
     },
   },


### PR DESCRIPTION
@smarterclayton suggested we add this to the developer perspective nav. @serenamarie125 @beanh66 Thoughts?

I noticed the advanced items have a different order than admin perspective home items. Should we align?

/assign @christianvogt 

![Screen Shot 2019-09-06 at 3 53 48 PM](https://user-images.githubusercontent.com/1167259/64456589-8c6f9f80-d0be-11e9-875a-1b1b8c83c3e2.png)
