### PR TITLE
Bug 1749199: Fix login integration test scenario flake

### DIFF
--- a/frontend/integration-tests/tests/login.scenario.ts
+++ b/frontend/integration-tests/tests/login.scenario.ts
@@ -89,6 +89,8 @@ describe('Auth test', () => {
 
   it('is authenticated as cluster admin user', async() => {
     expect(await browser.getCurrentUrl()).toContain(appHost);
+    await browser.wait(until.visibilityOf(sidenavView.navSectionFor('Compute')));
+    await browser.wait(until.visibilityOf(sidenavView.navSectionFor('Operators')));
     await browser.wait(until.visibilityOf(sidenavView.navSectionFor('Administration')));
     await sidenavView.clickNavLink(['Administration', 'Cluster Settings']);
     await clusterSettingsView.isLoaded();


### PR DESCRIPTION
Suspect that the flake was caused by a race condition between the nav state and clicking on the 'Administration' nav section item. Sometimes the nav state would change at just the right moment to cause the click to occur on the wrong nav item. Updated the login scenario to wait for all expected cluster admin nav sections to be present before trying to click on the 'Administration' section.