### PR TITLE
compute virtualized scroll container for tables

### DIFF
--- a/frontend/packages/dev-console/src/components/DefaultPage.scss
+++ b/frontend/packages/dev-console/src/components/DefaultPage.scss
@@ -1,5 +1,6 @@
 .odc-default-page {
   background-color: var(--pf-global--BackgroundColor--light-100);
+  min-height: 100%;
   &__section-border {
     margin-top: 30px;
     margin-bottom: 30px;

--- a/frontend/public/components/utils/dom-utils.tsx
+++ b/frontend/public/components/utils/dom-utils.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+const isHTMLElement = (n: Node): n is HTMLElement => {
+  return n.nodeType === Node.ELEMENT_NODE;
+};
+
+export const getParentScrollableElement = (node: HTMLElement) => {
+  let parentNode: Node = node;
+  while (parentNode) {
+    if (isHTMLElement(parentNode)) {
+      let overflow = parentNode.style.overflow;
+      if (!overflow.includes('scroll') && !overflow.includes('auto')) {
+        overflow = window.getComputedStyle(parentNode).overflow;
+      }
+      if (overflow.includes('scroll') || overflow.includes('auto')) {
+        return parentNode;
+      }
+    }
+    parentNode = parentNode.parentNode;
+  }
+  return undefined;
+};
+
+type WithScrollContainerProps = {
+  children: (scrollContainer: HTMLElement) => React.ReactElement | null;
+};
+
+export const WithScrollContainer: React.FC<WithScrollContainerProps> = ({ children }) => {
+  const [scrollContainer, setScrollContainer] = React.useState<HTMLElement>();
+  const ref = React.useCallback((node) => {
+    if (node) {
+      setScrollContainer(getParentScrollableElement(node));
+    }
+  }, []);
+  return scrollContainer ? children(scrollContainer) : <span ref={ref} />;
+};

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -55,6 +55,7 @@ export * from './truncate-middle';
 export * from './expand-collapse';
 export * from './volume-type';
 export * from './skeleton-catalog';
+export * from './dom-utils';
 
 /*
   Add the enum for NameValueEditorPair here and not in its namesake file because the editor should always be


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-1797

_Note: The virtualized table is quite buried many components deep vs the parent scroll container._

The virtualized Table component is dependent today on being within the `#content-scrollable` and having that component be the nearest scroll container. In certain circumstances the dev-console does not use this dom node as the nearest scroll container. As a result, embedding a virtualized table component fails.

Rather than having an explicit dependency on `#content-scrollable`, the parent scroll container is computed on render. In doing so a virtualized Table component can be reparented within any scroll container and it would function.

![scroll-table](https://user-images.githubusercontent.com/14068621/64459994-4d921780-d0c7-11e9-937e-190aefcfb443.gif)

cc @spadgett @andrewballantyne @vojtechszocs 