### PR TITLE
Bug 1749021: Ensure Using Correct PackageManifest in Subscription Detail

### DIFF
--- a/frontend/__mocks__/k8sResourcesMocks.ts
+++ b/frontend/__mocks__/k8sResourcesMocks.ts
@@ -343,7 +343,8 @@ export const testSubscription: SubscriptionKind = {
     uid: '09232c51-ed3e-4e60-b58e-9bee576ee612',
   },
   spec: {
-    source: 'ocs',
+    source: 'test-catalog',
+    sourceNamespace: 'tectonic-system',
     name: 'test-package',
     channel: 'stable',
   },

--- a/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
+++ b/frontend/__tests__/components/operator-lifecycle-manager/clusterserviceversion.spec.tsx
@@ -288,6 +288,16 @@ describe(CSVSubscription.displayName, () => {
     expect(wrapper.find(SubscriptionDetails).props().installedCSV).toEqual(obj);
     expect(wrapper.find(SubscriptionDetails).props().pkg).toEqual(testPackageManifest);
   });
+
+  it('passes the matching `PackageManifest` if there are multiple with the same `metadata.name`', () => {
+    const obj = _.set(_.cloneDeep(testClusterServiceVersion), 'metadata.annotations', {'olm.operatorNamespace': 'default'});
+    const subscription = _.set(_.cloneDeep(testSubscription), 'status', {installedCSV: obj.metadata.name});
+    const otherPkg = _.set(_.cloneDeep(testPackageManifest), 'status.catalogSource', 'other-source');
+
+    wrapper = shallow(<CSVSubscription obj={obj} packageManifest={[testPackageManifest, otherPkg]} subscription={[testSubscription, subscription]} />);
+
+    expect(wrapper.find(SubscriptionDetails).props().pkg).toEqual(testPackageManifest);
+  });
 });
 
 describe(ClusterServiceVersionsDetailsPage.displayName, () => {

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -378,7 +378,9 @@ export const CSVSubscription: React.FC<CSVSubscriptionProps> = (props) => {
     <SubscriptionDetails
       obj={subscription}
       installedCSV={props.obj}
-      pkg={!_.isNil(subscription) ? props.packageManifest.find(pkg => pkg.status.packageName === subscription.spec.name) : null} />
+      pkg={!_.isNil(subscription)
+        ? props.packageManifest.find(({status}) => status.packageName === subscription.spec.name && status.catalogSource === subscription.spec.source && status.catalogSourceNamespace === subscription.spec.sourceNamespace)
+        : null} />
   </StatusBox>;
 };
 


### PR DESCRIPTION
### Description

Add checks for the name and namespace of the `CatalogSource` to associate the correct `PackageManifest` with its `Subscription`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1749021