### PR TITLE
Gets the ResourceKind before updating the app label

### DIFF
--- a/frontend/packages/dev-console/src/utils/application-utils.ts
+++ b/frontend/packages/dev-console/src/utils/application-utils.ts
@@ -110,7 +110,7 @@ export const updateResourceApplication = (
       _.forEach(list, (item) => {
         // verify the case of no previous application
         if (prevApplication || !_.get(item, ['metadata', 'labels', 'app.kubernetes.io/part-of'])) {
-          patches.push(updateItemAppLabel(item.resourceKind, item, application));
+          patches.push(updateItemAppLabel(modelFor(item.kind), item, application));
         }
       });
     });


### PR DESCRIPTION
When moving a node between two applications, sometimes it would throw up an error in the move-confirm modal.

https://jira.coreos.com/browse/ODC-1800