### PR TITLE
Fix runtime error selecting items in namespace dropdown

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -340,6 +340,7 @@ const namespaceBarDropdownStateToProps = state => {
   return { activeNamespace, canListNS };
 };
 const namespaceBarDropdownDispatchToProps = (dispatch) => ({
+  setActiveNamespace: (ns) => dispatch(UIActions.setActiveNamespace(ns)),
   showStartGuide: (show) => dispatch(setFlag(FLAGS.SHOW_OPENSHIFT_START_GUIDE, show)),
 });
 
@@ -353,7 +354,7 @@ class NamespaceBarDropdowns_ extends React.Component {
   }
 
   render() {
-    const { activeNamespace, dispatch, canListNS, useProjects, children, disabled } = this.props;
+    const { activeNamespace, setActiveNamespace, canListNS, useProjects, children, disabled } = this.props;
     if (flagPending(canListNS)) {
       return null;
     }
@@ -384,10 +385,10 @@ class NamespaceBarDropdowns_ extends React.Component {
       if (newNamespace === CREATE_NEW_RESOURCE) {
         createProjectModal({
           blocking: true,
-          onSubmit: (newProject) => dispatch(UIActions.setActiveNamespace(newProject.metadata.name)),
+          onSubmit: (newProject) => setActiveNamespace(newProject.metadata.name),
         });
       } else {
-        dispatch(UIActions.setActiveNamespace(newNamespace));
+        setActiveNamespace(newNamespace);
       }
     };
 


### PR DESCRIPTION
/assign @rhamilto 

Fixes this error:

```
namespace.jsx:390 Uncaught TypeError: dispatch is not a function
    at onChange (namespace.jsx:390)
    at Dropdown.push../public/components/utils/dropdown.jsx.DropdownMixin.onClick_ (dropdown.jsx:55)
    at Dropdown._this.onClick (dropdown.jsx:140)
    at onClick (dropdown.jsx:127)
    at HTMLUnknownElement.callCallback (react-dom.development.js:149)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:199)
    at invokeGuardedCallback (react-dom.development.js:256)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:270)
    at executeDispatch (react-dom.development.js:561)
    at executeDispatchesInOrder (react-dom.development.js:583)
```