### PR TITLE
Avoid proptype error for virtual tables

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -437,7 +437,7 @@ export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TablePro
         <TableWrapper virtualize={virtualize} ariaLabel={ariaLabel} ariaRowCount={ariaRowCount}>
           <PfTable
             cells={columns}
-            rows={virtualize ? customData : Rows({componentProps, selectedResourcesForKind, customData})}
+            rows={virtualize ? (customData || []) : Rows({componentProps, selectedResourcesForKind, customData})}
             gridBreakPoint={gridBreakPoint}
             onSort={this._onSort}
             onSelect={onSelect}


### PR DESCRIPTION
/assign @priley86 

Avoids this error:

```
Warning: Failed prop type: The prop `rows` is marked as required in `Table`, but its value is `undefined`.
    in Table (created by TableInner)
    in TableInner (created by ConnectFunction)
    in ConnectFunction (created by PodList)
    in PodList (created by ListPageWrapper_)
```