### PR TITLE
Fix for topology tooltips on Safari/Edge

### DIFF
--- a/frontend/packages/console-shared/src/components/SvgPodTooltip.tsx
+++ b/frontend/packages/console-shared/src/components/SvgPodTooltip.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { podColor } from '@console/shared';
 import SvgTooltip from './SvgTooltip';
 
+const STATUS_BOX_SIZE = 10;
+
 type TooltipProps = {
   datum?: any;
   active?: boolean;
@@ -25,21 +27,23 @@ const PodTooltip: React.FunctionComponent<TooltipProps> = ({
 
   const parentBox = { x, y, width, height };
 
-  const getTipContent = (boxX: number, boxY: number): React.ReactNode => {
-    return (
-      <React.Fragment>
-        <rect width={10} height={10} x={boxX} y={boxY + 3} style={{ fill: podColor[datum.x] }} />
-        <text x={boxX + 15} y={boxY + 2} textAnchor="start" dominantBaseline="hanging">
-          <tspan>{datum.x}</tspan>
-          {datum.x !== 'Scaled to 0' && datum.x !== 'Autoscaled to 0' && datum.x !== 'Idle' && (
-            <tspan dx={20}>{Math.round(datum.y)}</tspan>
-          )}
-        </text>
-      </React.Fragment>
-    );
-  };
-
-  return <SvgTooltip active={active} parentBox={parentBox} getContent={getTipContent} />;
+  return (
+    <SvgTooltip active={active} parentBox={parentBox}>
+      <rect
+        width={STATUS_BOX_SIZE}
+        height={STATUS_BOX_SIZE}
+        x={0}
+        y={4}
+        style={{ fill: podColor[datum.x] }}
+      />
+      <text x={15} y={0} dy="1em" textAnchor="start">
+        <tspan>{datum.x}</tspan>
+        {datum.x !== 'Scaled to 0' && datum.x !== 'Autoscaled to 0' && datum.x !== 'Idle' && (
+          <tspan dx={20}>{Math.round(datum.y)}</tspan>
+        )}
+      </text>
+    </SvgTooltip>
+  );
 };
 
 export default PodTooltip;

--- a/frontend/packages/console-shared/src/components/SvgTooltip.tsx
+++ b/frontend/packages/console-shared/src/components/SvgTooltip.tsx
@@ -6,7 +6,7 @@ type TooltipProps = {
   active?: boolean;
   parentBox: { x: number; y: number; width: number; height: number };
   arrowPosition?: TooltipPosition;
-  getContent: (boxX: number, boxY: number) => React.ReactNode;
+  children: React.ReactNode;
 };
 
 type State = {
@@ -75,7 +75,7 @@ export default class SvgTooltip extends React.Component<TooltipProps> {
 
   render() {
     const { isActive, bb } = this.state;
-    const { parentBox, getContent, arrowPosition = 'top' } = this.props;
+    const { parentBox, children, arrowPosition = 'top' } = this.props;
     const bbWidth = bb ? bb.width : 0;
     const bbHeight = bb ? bb.height : 0;
     let boxX;
@@ -137,7 +137,9 @@ export default class SvgTooltip extends React.Component<TooltipProps> {
       <g className="odc-svg-tooltip">
         <rect x={boxX} y={boxY} width={bbWidth + PADDING_X * 2} height={bbHeight + PADDING_Y * 2} />
         <polygon points={`${arrowPoints[0]} ${arrowPoints[1]} ${arrowPoints[2]}`} />
-        <g ref={this.groupRef}>{getContent(boxX + PADDING_X, boxY + PADDING_Y)}</g>
+        <g transform={`translate(${boxX + PADDING_X}, ${boxY + PADDING_Y})`} ref={this.groupRef}>
+          {children}
+        </g>
       </g>
     );
   }

--- a/frontend/packages/dev-console/src/components/topology/SvgDecoratorTooltip.tsx
+++ b/frontend/packages/dev-console/src/components/topology/SvgDecoratorTooltip.tsx
@@ -20,21 +20,13 @@ const DecoratorTooltip: React.FunctionComponent<TooltipProps> = ({
   position = TooltipPosition.left,
 }) => {
   const parentBox = { x: x - radius, y: y - radius, width: radius * 2, height: radius * 2 };
-  const getContent = (boxX: number, boxY: number): React.ReactNode => {
-    return (
-      <text x={boxX} y={boxY + 2} dominantBaseline="hanging" textAnchor="start">
-        <tspan>{title}</tspan>
-      </text>
-    );
-  };
 
   return (
-    <SvgTooltip
-      active={active}
-      parentBox={parentBox}
-      getContent={getContent}
-      arrowPosition={position}
-    />
+    <SvgTooltip active={active} parentBox={parentBox} arrowPosition={position}>
+      <text x={0} y={0} textAnchor="start" dy="1em">
+        <tspan>{title}</tspan>
+      </text>
+    </SvgTooltip>
   );
 };
 


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/ODC-1691

Safari and Edge do not support the dominant-baseline property on svg text components. Simplified and made more generic the tooltip text placement within its bounding box.