### PR TITLE
Bug 1703777: Fix race setting CSRF token after login

### DIFF
--- a/frontend/public/tokener.html
+++ b/frontend/public/tokener.html
@@ -1,41 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    [[ if eq .Branding "okd" ]]
-    <title>OKD</title>
-    <meta name="application-name" content="OKD">
-    [[ end ]]
-    [[ if eq .Branding "ocp" ]]
-    <title>OpenShift Container Platform</title>
-    <meta name="application-name" content="OpenShift Container Platform">
-    [[ end ]]
-    [[ if eq .Branding "online" ]]
-    <title>OpenShift Online</title>
-    <meta name="application-name" content="OpenShift Online">
-    [[ end ]]
-    [[ if eq .Branding "dedicated" ]]
-    <title>OpenShift Dedicated</title>
-    <meta name="application-name" content="OpenShift Dedicated">
-    [[ end ]]
-    [[ if eq .Branding "azure" ]]
-    <title>Azure Red Hat OpenShift</title>
-    <meta name="application-name" content="Azure Red Hat OpenShift">
-    [[ end ]]
-
-    [[ if eq .Branding "okd" ]]
-    <link rel="shortcut icon" href="<%= require('./imgs/okd-favicon.png') %>">
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="<%= require('./imgs/okd-apple-touch-icon-precomposed.png') %>">
-    <link rel="mask-icon" href="<%= require('./imgs/okd-mask-icon.svg') %>" color="#DB242F">
-    <meta name="msapplication-TileColor" content="#000000">
-    <meta name="msapplication-TileImage" content="<%= require('./imgs/okd-mstile-144x144.png') %>">
-    [[ else ]]
-    <link rel="shortcut icon" href="<%= require('./imgs/openshift-favicon.png') %>">
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="<%= require('./imgs/openshift-apple-touch-icon-precomposed.png') %>">
-    <link rel="mask-icon" href="<%= require('./imgs/openshift-mask-icon.svg') %>" color="#DB242F">
-    <meta name="msapplication-TileColor" content="#000000">
-    <meta name="msapplication-TileImage" content="<%= require('./imgs/openshift-mstile-144x144.png') %>">
-    [[ end ]]
-
     <script type="text/javascript">
       // eslint-disable-next-line no-var
       var json = [[.]];


### PR DESCRIPTION
Remove the unnecessary branding in tokener.html. The favicon in tokener.html had an incorrect path, which loaded the index and caused the CSRF cookie to be reset. This resulted in a race condition that could cause 403 errors after login.

This matches what we have in release-4.1 and master.

/assign @rhamilto 