### PR TITLE
Fix TypeError: Cannot read property 'status' of undefined for pipeline run detail page

### DIFF
--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -112,7 +112,7 @@ const appendPipelineRunStatus = (pipeline, pipelineRun) => {
     if (!mTask.status) {
       mTask.status = { reason: 'Idle' };
     } else if (mTask.status && mTask.status.conditions) {
-      const statusCondition = mTask.status.conditions.pop();
+      const statusCondition = mTask.status.conditions.pop() || {};
       switch (statusCondition.status) {
         case 'True':
           mTask.status.reason = 'Succeeded';


### PR DESCRIPTION
Fix bug:

```
TypeError: Cannot read property 'status' of undefined
    at http://localhost:9000/static/pipeline-details~pipelinerun-details-583eb8ce00d0a640c968.js:296:37
    at arrayMap (http://localhost:9000/static/vendors~main-79fb8ea96d7868151561.js:239325:21)
    at Module.map (http://localhost:9000/static/vendors~main-79fb8ea96d7868151561.js:262111:10)
    at appendPipelineRunStatus (http://localhost:9000/static/pipeline-details~pipelinerun-details-583eb8ce00d0a640c968.js:274:54)
    at getPipelineTasks (http://localhost:9000/static/pipeline-details~pipelinerun-details-583eb8ce00d0a640c968.js:321:20)
    at PipelineRunVisualization.push../packages/dev-console/src/components/pipelineruns/PipelineRunVisualization.tsx.PipelineRunVisualization.render (http://localhost:9000/static/pipelinerun-details-05739d7fcb5b5fc70453.js:261:308)
    at finishClassComponent (http://localhost:9000/static/vendors~main-79fb8ea96d7868151561.js:370027:31)
    at updateClassComponent (http://localhost:9000/static/vendors~main-79fb8ea96d7868151561.js:369982:24)
    at beginWork (http://localhost:9000/static/vendors~main-79fb8ea96d7868151561.js:370930:16)
    at performUnitOfWork (http://localhost:9000/static/vendors~main-79fb8ea96d7868151561.js:374598:12)
```

/cc @karthikjeeyar 