### PR TITLE
add labels to spec.selector and spec.template

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -105,7 +105,7 @@ export const createDeploymentConfig = (
       selector: podLabels,
       template: {
         metadata: {
-          labels: podLabels,
+          labels: { ...labels, ...podLabels },
           annotations,
         },
         spec: {

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -174,7 +174,7 @@ export const createDeploymentConfig = (
       replicas,
       template: {
         metadata: {
-          labels: podLabels,
+          labels: { ...defaultLabels, ...userLabels, ...podLabels },
         },
         spec: {
           containers: [


### PR DESCRIPTION
ODC-bug: https://jira.coreos.com/browse/ODC-1793

This PR adds the labels to `spec.selector` and `spec.template.metadata.labels` and these labels propagate to RC and pods.

<img width="628" alt="Screen Shot 2019-09-10 at 11 46 49 PM" src="https://user-images.githubusercontent.com/9278015/64639500-96c6cc00-d425-11e9-95f5-e50a9000bc07.png">

<img width="624" alt="Screen Shot 2019-09-10 at 11 47 28 PM" src="https://user-images.githubusercontent.com/9278015/64639501-96c6cc00-d425-11e9-8c36-ab4692d0cdf4.png">
<img width="633" alt="Screen Shot 2019-09-10 at 11 47 45 PM" src="https://user-images.githubusercontent.com/9278015/64639502-975f6280-d425-11e9-9636-38eb7720f2af.png">
<img width="660" alt="Screen Shot 2019-09-10 at 11 48 07 PM" src="https://user-images.githubusercontent.com/9278015/64639503-97f7f900-d425-11e9-9bdd-f91b59c7c067.png">
<img width="624" alt="Screen Shot 2019-09-10 at 11 48 40 PM" src="https://user-images.githubusercontent.com/9278015/64639506-98908f80-d425-11e9-80d9-ae19d5239602.png">
