### PR TITLE
remove browser title tooltip from topology build status icon

### DIFF
--- a/frontend/packages/console-shared/src/components/status/ErrorStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/ErrorStatus.tsx
@@ -6,16 +6,15 @@ import { RedExclamationCircleIcon } from './Icons';
 type ErrorStatusProps = {
   title?: string;
   iconOnly?: boolean;
+  noTooltip?: boolean;
 };
 
-const ErrorStatus: React.FC<ErrorStatusProps> = ({ title, iconOnly, children }) => {
+const ErrorStatus: React.FC<ErrorStatusProps> = (props) => {
   const icon = <RedExclamationCircleIcon />;
-  return children ? (
-    <PopoverStatus icon={icon} title={title} iconOnly={iconOnly}>
-      {children}
-    </PopoverStatus>
+  return props.children ? (
+    <PopoverStatus {...props} icon={icon} />
   ) : (
-    <StatusIconAndText icon={icon} title={title} iconOnly={iconOnly} />
+    <StatusIconAndText {...props} icon={icon} />
   );
 };
 

--- a/frontend/packages/console-shared/src/components/status/LinkStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/LinkStatus.tsx
@@ -8,20 +8,13 @@ type LinkStatusProps = React.ComponentProps<typeof StatusIconAndText> & {
   linkTo?: History.LocationDescriptor;
 };
 
-const LinkStatus: React.FC<LinkStatusProps> = ({
-  icon,
-  title,
-  spin,
-  linkTitle,
-  linkTo,
-  iconOnly,
-}) =>
+const LinkStatus: React.FC<LinkStatusProps> = ({ linkTitle, linkTo, ...other }) =>
   linkTo ? (
     <Link to={linkTo} title={linkTitle}>
-      <StatusIconAndText icon={icon} title={title} spin={spin} iconOnly={iconOnly} />
+      <StatusIconAndText {...other} />
     </Link>
   ) : (
-    <StatusIconAndText icon={icon} title={title} spin={spin} iconOnly={iconOnly} />
+    <StatusIconAndText {...other} />
   );
 
 export default LinkStatus;

--- a/frontend/packages/console-shared/src/components/status/PopoverStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/PopoverStatus.tsx
@@ -3,15 +3,13 @@ import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
 import StatusIconAndText from './StatusIconAndText';
 
 const PopoverStatus: React.FC<React.ComponentProps<typeof StatusIconAndText>> = ({
-  icon,
   title,
-  spin,
   children,
-  iconOnly,
+  ...other
 }) => (
   <Popover position={PopoverPosition.right} headerContent={title} bodyContent={children}>
     <Button variant="link" isInline>
-      <StatusIconAndText icon={icon} title={title} spin={spin} iconOnly={iconOnly} />
+      <StatusIconAndText {...other} title={title} />
     </Button>
   </Popover>
 );

--- a/frontend/packages/console-shared/src/components/status/ProgressStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/ProgressStatus.tsx
@@ -5,10 +5,11 @@ import StatusIconAndText from './StatusIconAndText';
 type ProgressStatusProps = {
   title?: string;
   iconOnly?: boolean;
+  noTooltip?: boolean;
 };
 
-const ProgressStatus: React.FC<ProgressStatusProps> = ({ title, iconOnly }) => (
-  <StatusIconAndText icon={<InProgressIcon />} title={title} iconOnly={iconOnly} />
+const ProgressStatus: React.FC<ProgressStatusProps> = (props) => (
+  <StatusIconAndText {...props} icon={<InProgressIcon />} />
 );
 
 export default ProgressStatus;

--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -18,10 +18,11 @@ export type StatusProps = {
   status?: string;
   title?: string;
   iconOnly?: boolean;
+  noTooltip?: boolean;
 };
 
-const Status: React.FC<StatusProps> = ({ status, title, children, iconOnly }) => {
-  const statusProps = { title: title || status, iconOnly };
+const Status: React.FC<StatusProps> = ({ status, title, children, iconOnly, noTooltip }) => {
+  const statusProps = { title: title || status, iconOnly, noTooltip };
   switch (status) {
     case 'New':
       return <StatusIconAndText {...statusProps} icon={<HourglassStartIcon />} />;

--- a/frontend/packages/console-shared/src/components/status/StatusIconAndText.tsx
+++ b/frontend/packages/console-shared/src/components/status/StatusIconAndText.tsx
@@ -8,15 +8,22 @@ type StatusIconAndTextProps = {
   title?: string;
   spin?: boolean;
   iconOnly?: boolean;
+  noTooltip?: boolean;
 };
 
-const StatusIconAndText: React.FC<StatusIconAndTextProps> = ({ icon, title, spin, iconOnly }) => {
+const StatusIconAndText: React.FC<StatusIconAndTextProps> = ({
+  icon,
+  title,
+  spin,
+  iconOnly,
+  noTooltip,
+}) => {
   if (!title) {
     return <>{DASH}</>;
   }
 
   return (
-    <span className="co-icon-and-text" title={title}>
+    <span className="co-icon-and-text" title={iconOnly && !noTooltip ? title : undefined}>
       {icon &&
         React.cloneElement(icon, {
           className: classNames(

--- a/frontend/packages/console-shared/src/components/status/SuccessStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/SuccessStatus.tsx
@@ -5,10 +5,11 @@ import StatusIconAndText from './StatusIconAndText';
 type SuccessStatusProps = {
   title?: string;
   iconOnly?: boolean;
+  noTooltip?: boolean;
 };
 
-const SuccessStatus: React.FC<SuccessStatusProps> = ({ title, iconOnly }) => (
-  <StatusIconAndText icon={<GreenCheckCircleIcon />} title={title} iconOnly={iconOnly} />
+const SuccessStatus: React.FC<SuccessStatusProps> = (props) => (
+  <StatusIconAndText {...props} icon={<GreenCheckCircleIcon />} />
 );
 
 export default SuccessStatus;

--- a/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
@@ -6,7 +6,7 @@ import {
   GithubIcon,
   BitbucketIcon,
 } from '@patternfly/react-icons';
-import { Status, calculateRadius, PodStatus, GreenCheckCircleIcon } from '@console/shared';
+import { Status, calculateRadius, PodStatus } from '@console/shared';
 import { TooltipPosition } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { resourcePathFromModel } from '@console/internal/components/utils';
@@ -108,23 +108,13 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
               position={TooltipPosition.left}
             >
               <g transform={`translate(-${decoratorRadius / 2}, -${decoratorRadius / 2})`}>
-                {build.status.phase === 'Complete' ? (
-                  <GreenCheckCircleIcon
-                    alt={`${build.metadata.name} ${build.status && build.status.phase}`}
-                  />
-                ) : (
-                  <foreignObject
-                    width={decoratorRadius}
-                    height={decoratorRadius}
-                    style={{ fontSize: decoratorRadius }}
-                  >
-                    <Status
-                      title={`${build.metadata.name} ${build.status && build.status.phase}`}
-                      status={build.status.phase}
-                      iconOnly
-                    />
-                  </foreignObject>
-                )}
+                <foreignObject
+                  width={decoratorRadius}
+                  height={decoratorRadius}
+                  style={{ fontSize: decoratorRadius }}
+                >
+                  <Status status={build.status.phase} iconOnly noTooltip />
+                </foreignObject>
               </g>
             </Decorator>
           </Link>


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-1728
Continuation of PR https://github.com/openshift/console/pull/2561

Since @invincibleJai is on vacation, continued his PR to add support for suppressing the browser title tooltip on status icons.

![image](https://user-images.githubusercontent.com/14068621/64644942-cce25c80-d3e1-11e9-80f0-4d67e01013e9.png)

cc @jtomasek @jeff-phillips-18 @invincibleJai 
