### PR TITLE
Effort to convert inline edit button links with pencil icon to use pf4 components

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.spec.tsx
@@ -52,9 +52,9 @@ describe(SpecDescriptor.name, () => {
         .find('dd')
         .childAt(0)
         .shallow()
-        .find('button.co-modal-btn-link')
+        .find('[data-test-id="configure-modal-btn"]')
         .text(),
-    ).toEqual(`${value} pods`);
+    ).toEqual(`${value}`);
 
     spyOn(configureSize, 'configureSizeModal').and.callFake((props) => {
       expect(props).toEqual({
@@ -69,7 +69,7 @@ describe(SpecDescriptor.name, () => {
       .find('dd')
       .childAt(0)
       .shallow()
-      .find('button.co-modal-btn-link')
+      .find('[data-test-id="configure-modal-btn"]')
       .props()
       .onClick(null);
   });

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/resource-requirements.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/resource-requirements.spec.tsx
@@ -99,19 +99,34 @@ describe(ResourceRequirementsModalLink.displayName, () => {
     const { memory, cpu } = obj.spec.resources.limits;
     wrapper = wrapper.setProps({ type: 'requests' });
 
-    expect(wrapper.find('button').text()).toEqual(`CPU: ${cpu}, Memory: ${memory}`);
+    expect(
+      wrapper
+        .find('button')
+        .childAt(0)
+        .text(),
+    ).toEqual(`CPU: ${cpu}, Memory: ${memory}`);
   });
 
   it('renders a button link with the resource limits', () => {
     const { memory, cpu } = obj.spec.resources.requests;
-    expect(wrapper.find('button').text()).toEqual(`CPU: ${cpu}, Memory: ${memory}`);
+    expect(
+      wrapper
+        .find('button')
+        .childAt(0)
+        .text(),
+    ).toEqual(`CPU: ${cpu}, Memory: ${memory}`);
   });
 
   it('renders default values if undefined', () => {
     obj.spec.resources = undefined;
     wrapper.setProps({ obj });
 
-    expect(wrapper.find('button').text()).toEqual('CPU: none, Memory: none');
+    expect(
+      wrapper
+        .find('button')
+        .childAt(0)
+        .text(),
+    ).toEqual('CPU: none, Memory: none');
   });
 
   it('opens resource requirements modal when clicked', (done) => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/resource-requirements.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/resource-requirements.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { connect } from 'react-redux';
+import { Button } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
 import { withHandlePromise } from '@console/internal/components/utils';
 import { k8sUpdate, referenceFor, K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import {
@@ -119,11 +121,16 @@ export const ResourceRequirementsModalLink = connect(stateToProps)(
     };
 
     return (
-      <button
+      <Button
         type="button"
-        className="btn btn-link co-modal-btn-link"
+        isInline
+        data-test-id="configure-modal-btn"
         onClick={onClick}
-      >{`CPU: ${cpu}, Memory: ${memory}`}</button>
+        variant="link"
+      >
+        <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+        {`CPU: ${cpu}, Memory: ${memory}`}
+      </Button>
     );
   },
 );

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.spec.tsx
@@ -301,7 +301,9 @@ describe(SubscriptionUpdates.name, () => {
       )
       .parents()
       .at(0)
-      .find('dd')
+      .shallow()
+      .find('dd button')
+      .childAt(0)
       .text();
 
     expect(channel).toEqual(testSubscription.spec.channel);
@@ -314,7 +316,9 @@ describe(SubscriptionUpdates.name, () => {
       )
       .parents()
       .at(0)
-      .find('dd')
+      .shallow()
+      .find('dd button')
+      .childAt(0)
       .text();
 
     expect(strategy).toEqual(testSubscription.spec.installPlanApproval || 'Automatic');

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -3,7 +3,8 @@ import * as _ from 'lodash';
 import { match, Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
-import { InProgressIcon } from '@patternfly/react-icons';
+import { Button } from '@patternfly/react-core';
+import { InProgressIcon, PencilAltIcon } from '@patternfly/react-icons';
 import {
   DetailsPage,
   MultiListPage,
@@ -379,13 +380,10 @@ export class SubscriptionUpdates extends React.Component<
                 {this.state.waitingForUpdate ? (
                   <LoadingInline />
                 ) : (
-                  <button
-                    type="button"
-                    className="btn btn-link co-modal-btn-link"
-                    onClick={() => channelModal()}
-                  >
+                  <Button type="button" isInline onClick={() => channelModal()} variant="link">
                     {obj.spec.channel || 'default'}
-                  </button>
+                    <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+                  </Button>
                 )}
               </dd>
             </dl>
@@ -397,13 +395,10 @@ export class SubscriptionUpdates extends React.Component<
                 {this.state.waitingForUpdate ? (
                   <LoadingInline />
                 ) : (
-                  <button
-                    type="button"
-                    className="btn btn-link co-modal-btn-link"
-                    onClick={() => approvalModal()}
-                  >
+                  <Button type="button" isInline onClick={() => approvalModal()} variant="link">
                     {obj.spec.installPlanApproval || 'Automatic'}
-                  </button>
+                    <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+                  </Button>
                 )}
               </dd>
             </dl>

--- a/frontend/public/components/alert-manager.tsx
+++ b/frontend/public/components/alert-manager.tsx
@@ -2,6 +2,9 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
+import { Button } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+
 import { referenceForModel, K8sResourceKind } from '../module/k8s';
 import { ListPage, DetailsPage, Table, TableRow, TableData } from './factory';
 import { SectionHeading, LabelList, navFactory, ResourceLink, Selector, Firehose, LoadingInline, pluralize } from './utils';
@@ -38,7 +41,10 @@ const Details: React.SFC<DetailsProps> = (props) => {
             <dd>{spec.version}</dd>
             <dt>Replicas</dt>
             <dd>
-              <button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={openReplicaCountModal}>{pluralize(spec.replicas, 'pod')}</button>
+              <Button variant="link" type="button" isInline onClick={openReplicaCountModal}>
+                {pluralize(spec.replicas, 'pod')}
+                <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+              </Button>
             </dd>
           </dl>
         </div>

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
-import { Button } from 'patternfly-react';
+import { Button , Tooltip } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
-import { Tooltip } from '@patternfly/react-core';
+
 import {
   AddCircleOIcon,
   ArrowCircleUpIcon,
   SyncAltIcon,
+  PencilAltIcon,
 } from '@patternfly/react-icons';
 
 import { ClusterOperatorPage } from './cluster-operator';
@@ -58,15 +59,18 @@ const cancelUpdate = (cv: ClusterVersionKind) => {
 
 export const clusterAutoscalerReference = referenceForModel(ClusterAutoscalerModel);
 
-export const CurrentChannel: React.SFC<CurrentChannelProps> = ({cv}) => <button className="btn btn-link co-modal-btn-link" data-test-id="current-channel-update-link" onClick={() => clusterChannelModal({cv})}>
+export const CurrentChannel: React.SFC<CurrentChannelProps> = ({cv}) => <Button type="button" isInline data-test-id="current-channel-update-link" onClick={() => clusterChannelModal({cv})} variant="link">
   {cv.spec.channel || '-'}
-</button>;
+  <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+</Button>;
 
 const InvalidMessage: React.SFC<CVStatusMessageProps> = ({cv}) => <>
   <div>
     <RedExclamationCircleIcon /> Invalid cluster version
   </div>
-  <Button bsStyle="primary" onClick={() => cancelUpdate(cv)}>
+  <Button
+    onClick={() => cancelUpdate(cv)}
+    variant="primary">
     Cancel update
   </Button>
 </>;
@@ -76,7 +80,9 @@ const UpdatesAvailableMessage: React.SFC<CVStatusMessageProps> = ({cv}) => <>
     <ArrowCircleUpIcon className="update-pending" /> Update available
   </div>
   <div>
-    <Button bsStyle="primary" onClick={() => clusterUpdateModal({cv})}>
+    <Button
+      onClick={() => clusterUpdateModal({cv})}
+      variant="primary">
       Update now
     </Button>
   </div>
@@ -157,7 +163,7 @@ export const UpdateLink: React.SFC<CurrentVersionProps> = ({cv}) => {
   return <>
     {
       updatesAvailable && (status === ClusterUpdateStatus.ErrorRetrieving || status === ClusterUpdateStatus.Failing || status === ClusterUpdateStatus.Updating)
-        ? <Button bsStyle="link" className="btn-link--no-btn-default-values" onClick={() => (clusterUpdateModal({cv}))}>Update to another version</Button>
+        ? <Button variant="link" className="btn-link--no-btn-default-values" onClick={() => (clusterUpdateModal({cv}))}>Update to another version</Button>
         : null
     }
   </>;

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -4,7 +4,9 @@ import { Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
 import { getMachineRole } from '@console/shared';
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip , Button } from '@patternfly/react-core';
+
+import { PencilAltIcon } from '@patternfly/react-icons';
 
 import { MachineAutoscalerModel, MachineModel, MachineSetModel } from '../models';
 import { K8sKind, MachineDeploymentKind, MachineSetKind, referenceForModel } from '../module/k8s';
@@ -160,7 +162,10 @@ export const MachineCounts: React.SFC<MachineCountsProps> = ({resourceKind, reso
             <dt className="co-detail-table__section-header">Desired Count</dt>
             <dd>
               {canUpdate
-                ? <button type="button" className="btn btn-link co-modal-btn-link" onClick={editReplicas}>{desiredReplicasText}</button>
+                ? <Button variant="link" type="button" isInline onClick={editReplicas}>
+                  {desiredReplicasText}
+                  <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+                </Button>
                 : desiredReplicasText}
             </dd>
           </dl>

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -3,7 +3,9 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { connect } from 'react-redux';
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip , Button } from '@patternfly/react-core';
+
+import { PencilAltIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import * as fuzzy from 'fuzzysearch';
 import { Status } from '@console/shared';
@@ -244,7 +246,10 @@ export const PullSecret = (props) => {
   }
   const modal = () => configureNamespacePullSecretModal({namespace: props.namespace, pullSecret: data});
 
-  return <button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={modal}>{_.get(data, 'metadata.name') || 'Not Configured'}</button>;
+  return <Button variant="link" type="button" isInline onClick={modal}>
+    {_.get(data, 'metadata.name') || 'Not Configured'}
+    <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+  </Button>;
 };
 
 export const NamespaceLineCharts = ({ns}) => <div className="row">

--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -2,6 +2,8 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
+import { Button } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
 
 import { Status } from '@console/shared';
 import { getNodeRoles, nodeStatus, makeNodeSchedulable, NodeKind, referenceForModel } from '../module/k8s';
@@ -232,13 +234,19 @@ const Details = ({obj: node}) => {
             <dt>Taints</dt>
             <dd>
               {canUpdate
-                ? <button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyTaints(NodeModel, node).callback}>{pluralize(_.size(node.spec.taints), 'Taint')}</button>
+                ? <Button variant="link" type="button" isInline onClick={Kebab.factory.ModifyTaints(NodeModel, node).callback}>
+                  {pluralize(_.size(node.spec.taints), 'Taint')}
+                  <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+                </Button>
                 : pluralize(_.size(node.spec.taints), 'Taint')}
             </dd>
             <dt>Annotations</dt>
             <dd>
               {canUpdate
-                ? <button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyAnnotations(NodeModel, node).callback}>{pluralize(_.size(node.metadata.annotations), 'Annotation')}</button>
+                ? <Button variant="link" type="button" isInline onClick={Kebab.factory.ModifyAnnotations(NodeModel, node).callback}>
+                  {pluralize(_.size(node.metadata.annotations), 'Annotation')}
+                  <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+                </Button>
                 : pluralize(_.size(node.metadata.annotations), 'Annotation')}
             </dd>
             {machine && <React.Fragment>

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
+import { Button } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
 
 import {
   Kebab,
@@ -61,7 +63,11 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, reso
     {showTolerations && (
       <dd>
         {canUpdate
-          ? <button type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyTolerations(model, resource).callback}>{pluralize(_.size(tolerations), 'Toleration')}</button>
+          ? <Button type="button" isInline onClick={Kebab.factory.ModifyTolerations(model, resource).callback}
+            variant="link">
+            {pluralize(_.size(tolerations), 'Toleration')}
+            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+          </Button>
           : pluralize(_.size(tolerations), 'Toleration')}
       </dd>
     )}
@@ -69,7 +75,10 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({children, reso
     {showAnnotations && (
       <dd>
         {canUpdate
-          ? <button data-test-id="edit-annotations" type="button" className="btn btn-link co-modal-btn-link co-modal-btn-link--left" onClick={Kebab.factory.ModifyAnnotations(model, resource).callback}>{pluralize(_.size(metadata.annotations), 'Annotation')}</button>
+          ? <Button data-test-id="edit-annotations" type="button" isInline onClick={Kebab.factory.ModifyAnnotations(model, resource).callback} variant="link">
+            {pluralize(_.size(metadata.annotations), 'Annotation')}
+            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+          </Button>
           : pluralize(_.size(metadata.annotations), 'Annotation')}
       </dd>
     )}

--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -1,5 +1,5 @@
 .co-icon-space-l {
-  margin-left: 0.25em;
+  margin-left: 0.35em;
 }
 
 .co-icon-space-r {

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -123,8 +123,25 @@ h6 {
   margin-left: auto !important;
 }
 
+.pf-c-button.pf-m-link {
+  white-space: normal; // override default .pf-c-button to enable wrapping
+}
+
 .pf-c-button.pf-m-link--align-left {
   padding-left: 0;
+}
+
+.pf-c-button {
+  &:hover,
+  &:focus {
+    .pf-c-button-icon--plain {
+      color: var(--pf-c-button--m-plain--hover--Color);
+    }
+  }
+}
+
+.pf-c-button-icon--plain {
+  color: var(--pf-c-button--m-plain--Color);
 }
 
 // PF components that calculate their correct height based on --pf-global--FontSize--md: 1rem


### PR DESCRIPTION
<img width="456" alt="Screen Shot 2019-09-10 at 3 52 04 PM" src="https://user-images.githubusercontent.com/1874151/64646079-3f543c00-d3e4-11e9-8843-2d09d0992cad.png">
<img width="269" alt="Screen Shot 2019-09-10 at 3 52 36 PM" src="https://user-images.githubusercontent.com/1874151/64646080-3f543c00-d3e4-11e9-99dc-ac7bff710ccd.png">


note: related changes to kubevirt-plugin vm pages will be in a separate pr