### PR TITLE
Bug 1750281: Query Browser: Fix sidebar link to load without pre-populated query

### DIFF
--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -56,7 +56,7 @@ const MonitoringNavSection_ = ({grafanaURL, canAccess, kibanaURL}) => {
   return showAlerts || showSilences || showGrafana || kibanaURL
     ? <NavSection title="Monitoring">
       {showAlerts && <HrefLink href="/monitoring/alerts" name="Alerting" startsWith={monitoringAlertsStartsWith} />}
-      {showAlerts && <HrefLink href="/monitoring/query-browser" name="Metrics" />}
+      {showAlerts && <HrefLink href="/monitoring/query-browser?query0=" name="Metrics" />}
       {showGrafana && <ExternalLink href={grafanaURL} name="Dashboards" />}
       {kibanaURL && <ExternalLink href={kibanaURL} name="Logging" />}
     </NavSection>


### PR DESCRIPTION
Fixes a bug where the Query Browser could load pre-populated with
whatever query was last viewed in the Query Browser. When clicking the
sidebar link, the page should load without any queries displayed.

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1750281