### PR TITLE
fix(serverless): apply release badge to serverless details pages

### DIFF
--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionDetailsPage.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { DefaultDetailsPage } from '@console/internal/components/default-resource';
+import { DetailsPageProps } from '@console/internal/components/factory';
+import { TechPreviewBadge } from '@console/shared';
+
+const RevisionDetailsPage: React.FC<DetailsPageProps> = (props) => (
+  <DefaultDetailsPage {...props} badge={<TechPreviewBadge />} />
+);
+
+export default RevisionDetailsPage;

--- a/frontend/packages/knative-plugin/src/components/routes/RouteDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RouteDetailsPage.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { DefaultDetailsPage } from '@console/internal/components/default-resource';
+import { DetailsPageProps } from '@console/internal/components/factory';
+import { TechPreviewBadge } from '@console/shared';
+
+const RouteDetailsPage: React.FC<DetailsPageProps> = (props) => (
+  <DefaultDetailsPage {...props} badge={<TechPreviewBadge />} />
+);
+
+export default RouteDetailsPage;

--- a/frontend/packages/knative-plugin/src/components/services/ServiceDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceDetailsPage.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { DefaultDetailsPage } from '@console/internal/components/default-resource';
+import { DetailsPageProps } from '@console/internal/components/factory';
+import { TechPreviewBadge } from '@console/shared';
+
+const ServiceDetailsPage: React.FC<DetailsPageProps> = (props) => (
+  <DefaultDetailsPage {...props} badge={<TechPreviewBadge />} />
+);
+
+export default ServiceDetailsPage;

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -7,6 +7,7 @@ import {
   OverviewResourceTab,
   OverviewCRD,
   ResourceListPage,
+  ResourceDetailsPage,
   GlobalConfig,
   YAMLTemplate,
 } from '@console/plugin-sdk';
@@ -31,7 +32,8 @@ type ConsumedExtensions =
   | OverviewResourceTab
   | OverviewCRD
   | ResourceListPage
-  | YAMLTemplate;
+  | YAMLTemplate
+  | ResourceDetailsPage;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -149,6 +151,16 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: models.RevisionModel,
+      loader: async () =>
+        (await import(
+          './components/revisions/RevisionDetailsPage' /* webpackChunkName: "knative-revision-details-page" */
+        )).default,
+    },
+  },
+  {
     type: 'Page/Resource/List',
     properties: {
       model: models.ServiceModel,
@@ -159,12 +171,32 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: models.ServiceModel,
+      loader: async () =>
+        (await import(
+          './components/services/ServiceDetailsPage' /* webpackChunkName: "knative-service-details-page" */
+        )).default,
+    },
+  },
+  {
     type: 'Page/Resource/List',
     properties: {
       model: models.RouteModel,
       loader: async () =>
         (await import(
           './components/routes/RoutesPage' /* webpackChunkName: "knative-routes-page" */
+        )).default,
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: models.RouteModel,
+      loader: async () =>
+        (await import(
+          './components/routes/RouteDetailsPage' /* webpackChunkName: "knative-route-details-page" */
         )).default,
     },
   },


### PR DESCRIPTION
Fixes Bug -
- https://jira.coreos.com/browse/ODC-1343

This PR -
- Implements details pages for serverless Services, Revisions and Routes in admin perspective
- Applies Tech Preview Badge to the above details pages

Screens -
![ServiceDetails](https://user-images.githubusercontent.com/38663217/64714393-2e86f180-d4dc-11e9-9a77-2ac3ecf7894d.png)
![RevisionDetails](https://user-images.githubusercontent.com/38663217/64714416-39da1d00-d4dc-11e9-90a3-ce43cfe6efe7.png)
![RouteDetails](https://user-images.githubusercontent.com/38663217/64714438-3f376780-d4dc-11e9-8e8b-b10f4fbdd32c.png)
