### PR TITLE
add only userLabels to template while creating a DC

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -105,7 +105,7 @@ export const createDeploymentConfig = (
       selector: podLabels,
       template: {
         metadata: {
-          labels: { ...labels, ...podLabels },
+          labels: { ...userLabels, ...podLabels },
           annotations,
         },
         spec: {

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -174,7 +174,7 @@ export const createDeploymentConfig = (
       replicas,
       template: {
         metadata: {
-          labels: { ...defaultLabels, ...userLabels, ...podLabels },
+          labels: { ...userLabels, ...podLabels },
         },
         spec: {
           containers: [


### PR DESCRIPTION
ODC bug: https://jira.coreos.com/browse/ODC-1793
This Pr adds userlabels and podlabels to DC template 