### PR TITLE
Bug: Adds missing tootip

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-card/capacity-card.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-card/capacity-card.scss
@@ -1,3 +1,7 @@
 .ceph-capacity-card__dashboard-card {
     height: 100%;
 }
+
+.ceph-capacity-card__tootip-dropdown {
+    display: inline-flex;
+}

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-card/capacity-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/capacity-card/capacity-card.tsx
@@ -8,6 +8,7 @@ import {
   DashboardCardBody,
   DashboardCardHeader,
   DashboardCardTitle,
+  DashboardCardHelp,
 } from '@console/internal/components/dashboard/dashboard-card';
 import {
   DashboardItemProps,
@@ -92,17 +93,21 @@ export const CapacityCard: React.FC<DashboardItemProps & WithFlagsProps> = ({
 
   const statUsed: React.ReactText = getLastStats(storageUsed, getInstantVectorStats);
   const statTotal: React.ReactText = getLastStats(storageTotal, getInstantVectorStats);
+  const infoText =
+    'Total capacity reflects the actual raw capacity of the OpenShift Container Storage cluster.  Used capacity reflects provisioned capacity which factors capacity being used to store user data and overhead from ensuring redundancy and reliability of the data.';
 
   return (
     <DashboardCard className="ceph-capacity-card__dashboard-card">
       <DashboardCardHeader>
         <DashboardCardTitle>Capacity</DashboardCardTitle>
-        <Dropdown
-          className="ceph-capacity-card__dropdown-item"
-          items={CapacityViewType}
-          onChange={setCapacityViewType}
-          selectedKey={[cvTypeSelected]}
-        />
+        <div className="ceph-capacity-card__tootip-dropdown">
+          <Dropdown
+            items={CapacityViewType}
+            onChange={setCapacityViewType}
+            selectedKey={[cvTypeSelected]}
+          />
+          <DashboardCardHelp>{infoText}</DashboardCardHelp>
+        </div>
       </DashboardCardHeader>
       <DashboardCardBody>
         <CapacityBody>


### PR DESCRIPTION
For capacity card in Persistent storage dashboard
![Screenshot from 2019-09-12 13-46-48](https://user-images.githubusercontent.com/12200504/64766583-d5fb3700-d563-11e9-9dcb-83c5e77f0649.png)

![dashboard](https://user-images.githubusercontent.com/12200504/64766421-96344f80-d563-11e9-8008-c448515a29cf.gif)

Fixes: 1749887
Signed-off-by: Kanika <kmurarka@redhat.com>