### PR TITLE
Pipeline Visualization Tooltip Rework

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/PipelineVisualizationStepList.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineVisualizationStepList.scss
@@ -1,20 +1,57 @@
 .odc-pipeline-vis-steps-list {
-  list-style: none;
-  padding: 0;
-  width: 10em;
-  &__item {
-    padding: 5px;
-    border-radius: 10px;
-    margin-bottom: 10px;
-    border: 1px solid var(--pf-global--BorderColor--light-100);
-    background: var(--pf-global--BackgroundColor--200);
-    color: var(--pf-global--Color--dark-100);
-    justify-content: center;
-    align-items: center;
+  min-width: 10em;
+
+  &__task-name {
+    font-weight: var(--pf-global--FontWeight--bold);
+    line-height: 1.5em;
+    max-height: 3em;
+
+    // Limit the size of the title so the content doesn't have unnecessary whitespace in the middle
+    max-width: 15em;
+    margin: 0 auto 10px auto;
+
+    // Apply ellipsis at multiple lines (apparently decent support cross browser)
+    // ref: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+
+  &__step {
     display: flex;
-    text-align: center;
+    margin-bottom: 10px;
+
     &:last-child {
-      margin-bottom: 0px;
+      margin-bottom: 0;
     }
+  }
+
+  &__icon {
+    flex: 0 0 18px;
+  }
+
+  &__icon-backdrop {
+    fill: var(--pf-global--Color--light-100);
+  }
+
+  &__name {
+    flex: 1 1 auto;
+    overflow: hidden;
+    padding-left: var(--pf-global--spacer--sm);
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &.is-main-focus {
+      padding: 0 var(--pf-global--spacer--sm);
+      text-align: center;
+    }
+  }
+
+  &__duration {
+    flex: 0 0 auto;
+    padding-left: var(--pf-global--spacer--sm);
+    text-align: right;
   }
 }

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineVisualizationStepList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineVisualizationStepList.tsx
@@ -1,20 +1,74 @@
 import * as React from 'react';
+import classNames from 'classnames';
+import { getRunStatusColor, runStatus } from '../../utils/pipeline-augment';
+import { StatusIcon } from './StatusIcon';
+import { StepStatus } from './pipeline-step-utils';
 
 import './PipelineVisualizationStepList.scss';
 
 export interface PipelineVisualizationStepListProps {
-  steps: { name: string }[];
+  isSpecOverview: boolean;
+  taskName: string;
+  steps: StepStatus[];
 }
+
+const TooltipColoredStatusIcon = ({ status }) => {
+  const size = 18;
+  const sharedProps = {
+    height: size,
+    width: size,
+  };
+
+  const icon = <StatusIcon status={status} {...sharedProps} />;
+
+  if (status === runStatus.Succeeded || status === runStatus.Failed) {
+    // Succeeded and Failed icons have transparent centers shapes - in tooltips, this becomes an undesired black
+    // This will simply wrap the icon and place a white backdrop
+    return (
+      <div style={{ color: getRunStatusColor(status).pftoken.value }}>
+        <svg {...sharedProps}>
+          <circle
+            className="odc-pipeline-vis-steps-list__icon-backdrop"
+            cx={size / 2}
+            cy={size / 2}
+            r={size / 2 - 1}
+          />
+          {icon}
+        </svg>
+      </div>
+    );
+  }
+
+  return icon;
+};
+
 export const PipelineVisualizationStepList: React.FC<PipelineVisualizationStepListProps> = ({
+  isSpecOverview,
+  taskName,
   steps,
 }) => (
-  <ul className="odc-pipeline-vis-steps-list">
-    {steps.map((step) => {
+  <div className="odc-pipeline-vis-steps-list">
+    <div className="odc-pipeline-vis-steps-list__task-name">{taskName}</div>
+    {steps.map(({ duration, name, runStatus: status }) => {
       return (
-        <li key={step.name} className="odc-pipeline-vis-steps-list__item">
-          {step.name}
-        </li>
+        <div className="odc-pipeline-vis-steps-list__step" key={name}>
+          {!isSpecOverview && (
+            <div className="odc-pipeline-vis-steps-list__icon">
+              <TooltipColoredStatusIcon status={status} />
+            </div>
+          )}
+          <div
+            className={classNames('odc-pipeline-vis-steps-list__name', {
+              'is-main-focus': isSpecOverview,
+            })}
+          >
+            {name}
+          </div>
+          {!isSpecOverview && (
+            <div className="odc-pipeline-vis-steps-list__duration">{duration}</div>
+          )}
+        </div>
       );
     })}
-  </ul>
+  </div>
 );

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineVisualizationTask.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineVisualizationTask.scss
@@ -62,9 +62,6 @@ $border-color: var(--pf-global--BorderColor--light-100);
     flex-grow: 0;
     flex-shrink: 0;
     order: -1;
-    display: flex;
-    justify-content: center;
-    align-items: center;
   }
 
   &__title-wrapper {

--- a/frontend/packages/dev-console/src/components/pipelines/StatusIcon.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/StatusIcon.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import {
+  AngleDoubleRightIcon,
+  BanIcon,
+  CheckCircleIcon,
+  CircleIcon,
+  ExclamationCircleIcon,
+  PendingIcon,
+  SyncAltIcon,
+} from '@patternfly/react-icons';
+import { getRunStatusColor, runStatus } from '../../utils/pipeline-augment';
+
+interface StatusIconProps {
+  status: string;
+  height?: number;
+  width?: number;
+}
+
+export const StatusIcon: React.FC<StatusIconProps> = ({ status, ...props }) => {
+  switch (status) {
+    case runStatus['In Progress']:
+      return <SyncAltIcon {...props} className="fa-spin" />;
+
+    case runStatus.Succeeded:
+      return <CheckCircleIcon {...props} />;
+
+    case runStatus.Failed:
+      return <ExclamationCircleIcon {...props} />;
+
+    case runStatus.Pending:
+      return <PendingIcon {...props} />;
+
+    case runStatus.Cancelled:
+      return <BanIcon {...props} />;
+
+    case runStatus.Skipped:
+      return <AngleDoubleRightIcon {...props} />;
+
+    default:
+      return <CircleIcon {...props} />;
+  }
+};
+
+export const ColoredStatusIcon: React.FC<StatusIconProps> = ({ status, ...others }) => {
+  return (
+    <div
+      style={{
+        color: status
+          ? getRunStatusColor(status).pftoken.value
+          : getRunStatusColor(runStatus.Cancelled).pftoken.value,
+      }}
+    >
+      <StatusIcon status={status} {...others} />
+    </div>
+  );
+};

--- a/frontend/packages/dev-console/src/components/pipelines/TaskComponentTaskStatus.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/TaskComponentTaskStatus.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { getRunStatusColor } from '../../utils/pipeline-augment';
+import HorizontalStackedBars, { StackedValue } from '../charts/HorizontalStackedBars';
+import { StepStatus } from './pipeline-step-utils';
+
+interface TaskStatusProps {
+  steps: StepStatus[];
+}
+
+const TaskComponentTaskStatus: React.FC<TaskStatusProps> = ({ steps }) => {
+  if (steps.length === 0) return null;
+
+  const visualValues: StackedValue[] = steps.map(({ name, runStatus }) => {
+    return {
+      color: getRunStatusColor(runStatus).pftoken.value,
+      name,
+      size: 1,
+    };
+  });
+
+  return <HorizontalStackedBars values={visualValues} barGap={2} height={2} />;
+};
+
+export default TaskComponentTaskStatus;

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -7,6 +7,7 @@ import {
   LOG_SOURCE_RUNNING,
   LOG_SOURCE_TERMINATED,
 } from '@console/internal/components/utils';
+import { runStatus } from './pipeline-augment';
 
 interface Resources {
   inputs?: Resource[];
@@ -96,7 +97,7 @@ const appendPipelineRunStatus = (pipeline, pipelineRun) => {
       return task;
     }
     if (pipelineRun.status && !pipelineRun.status.taskRuns) {
-      return _.merge(task, { status: { reason: 'Failed' } });
+      return _.merge(task, { status: { reason: runStatus.Failed } });
     }
     const mTask = _.merge(task, {
       status: _.get(_.find(pipelineRun.status.taskRuns, { pipelineTaskName: task.name }), 'status'),
@@ -110,21 +111,21 @@ const appendPipelineRunStatus = (pipeline, pipelineRun) => {
     }
     // append task status
     if (!mTask.status) {
-      mTask.status = { reason: 'Idle' };
+      mTask.status = { reason: runStatus.Idle };
     } else if (mTask.status && mTask.status.conditions) {
       const statusCondition = mTask.status.conditions.pop() || {};
       switch (statusCondition.status) {
         case 'True':
-          mTask.status.reason = 'Succeeded';
+          mTask.status.reason = runStatus.Succeeded;
           break;
         case 'Unknown':
-          mTask.status.reason = 'In Progress';
+          mTask.status.reason = runStatus['In Progress'];
           break;
         case 'False':
-          mTask.status.reason = 'Failed';
+          mTask.status.reason = runStatus.Failed;
           break;
         default:
-          mTask.status.reason = 'Idle';
+          mTask.status.reason = runStatus.Idle;
           break;
       }
     }


### PR DESCRIPTION
UX wanted a rework of the visualization pipeline tooltips to go along with the new visualization graph.

https://jira.coreos.com/browse/ODC-1824


**Pipeline Visualization Tooltips:**
![image](https://user-images.githubusercontent.com/8126518/64778239-b47d5980-d529-11e9-9ac9-47eaa5eb2ab0.png)

![image](https://user-images.githubusercontent.com/8126518/64778174-88fa6f00-d529-11e9-81ea-5655cf99f446.png)

**Pipeline Run Visualization Tooltips (done):**
![image](https://user-images.githubusercontent.com/8126518/64778289-d5de4580-d529-11e9-972d-90de1fb7f712.png)

**Pipeline Run Visualization Tooltips (failed / cancelled):**
![image](https://user-images.githubusercontent.com/8126518/64778307-e0004400-d529-11e9-9216-8ca200d73226.png)

![image](https://user-images.githubusercontent.com/8126518/64779002-fce94700-d52a-11e9-81d5-ba25b2bfb901.png)

**Pipeline Run Visualization Tooltips (various in progress states):**
![image](https://user-images.githubusercontent.com/8126518/64778323-ea224280-d529-11e9-8c45-dae017185324.png)

![image](https://user-images.githubusercontent.com/8126518/64778326-f1e1e700-d529-11e9-970a-c660c488d64b.png)

----

There are a few rough edges with the UX here. I have been in talks with @serenamarie125 to make sure the design met UX expectations. Due to this being a Dev Preview feature, Serena believes some rough edges are okay.

Some of the know usability caveats are:
 - The timer for in progress may tick a second past before getting an 'all-complete' from the server and then shifting back a second.
 - Tooltips show the name of the task, but if that task name is longer than 2 lines the title will be truncated - this is to avoid a 100 line tooltip title.