### PR TITLE
Add NamespaceDashboard option to ConsoleLink

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -22,7 +22,7 @@ import { setFlag } from '../actions/features';
 import { openshiftHelpBase } from './utils/documentation';
 import { createProjectMessageStateToProps } from '../reducers/ui';
 import { Overview } from './overview';
-import { OverviewNamespaceDashboard } from './overview/namespace-overview';
+import { OverviewNamespaceDashboard, ConsoleLinks, getNamespaceDashboardConsoleLinks } from './overview/namespace-overview';
 
 const getModel = useProjects => useProjects ? ProjectModel : NamespaceModel;
 const getDisplayName = obj => _.get(obj, ['metadata', 'annotations', 'openshift.io/display-name']);
@@ -317,15 +317,26 @@ export const NamespaceSummary = ({ns}) => {
   </div>;
 };
 
-const Details = ({obj: ns}) => {
+const Details_ = ({obj: ns, consoleLinks}) => {
+  const links = getNamespaceDashboardConsoleLinks(ns, consoleLinks);
   return <div>
     <div className="co-m-pane__body">
       <SectionHeading text={`${ns.kind} Overview`} />
       <NamespaceSummary ns={ns} />
     </div>
     <ResourceUsage ns={ns} />
+    {!_.isEmpty(links) && <div className="co-m-pane__body">
+      <SectionHeading text="Launcher" />
+      <ConsoleLinks consoleLinks={links} />
+    </div>}
   </div>;
 };
+
+const DetailsStateToProps = ({UI}) => ({
+  consoleLinks: UI.get('consoleLinks'),
+});
+
+const Details = connect(DetailsStateToProps)(Details_);
 
 const RolesPage = ({obj: {metadata}}) => <RoleBindingsPage namespace={metadata.name} showTitle={false} />;
 

--- a/frontend/public/components/overview/namespace-overview.tsx
+++ b/frontend/public/components/overview/namespace-overview.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
+import { connect } from 'react-redux';
 
 import { requirePrometheus } from '../graphs';
 import { Health } from '../graphs/health';
 import { deleteModal, NamespaceLineCharts, NamespaceSummary, TopPodsBarChart } from '../namespace';
-import { Firehose, ResourceLink, resourceListPathFromModel, StatusBox } from '../utils';
+import { ExternalLink, Firehose, ResourceLink, resourceListPathFromModel, StatusBox } from '../utils';
 import { RoleBindingModel } from '../../models';
 import { K8sResourceKind } from '../../module/k8s';
 import { getQuotaResourceTypes, hasComputeResources, QuotaGaugeCharts, QuotaScopesInline } from '../resource-quota';
@@ -43,6 +44,44 @@ const OverviewNamespaceSummary = ({ns}) => <div className="group">
     <NamespaceSummary ns={ns} />
   </div>
 </div>;
+
+export const getNamespaceDashboardConsoleLinks = (ns: K8sResourceKind, consoleLinks: K8sResourceKind[]): K8sResourceKind[] => {
+  return _.filter(consoleLinks, (link: K8sResourceKind) => {
+    if (link.spec.location !== 'NamespaceDashboard') {
+      return false;
+    }
+    const namespaces: string[] = _.get(link, ['spec', 'namespaceDashboard', 'namespaces']);
+    return _.isEmpty(namespaces) || _.includes(namespaces, ns.metadata.name);
+  });
+};
+
+export const ConsoleLinks: React.FC<ConsoleLinksProps> = ({consoleLinks}) => {
+  return <ul className="list-unstyled">
+    {_.map(_.sortBy(consoleLinks, 'spec.text'), (link: K8sResourceKind) => {
+      return <li key={link.metadata.uid}><ExternalLink href={link.spec.href} text={link.spec.text} /></li>;
+    })}
+  </ul>;
+};
+
+const OverviewLinks_: React.FC<OverviewLinksProps> = ({ns, consoleLinks}) => {
+  const links = getNamespaceDashboardConsoleLinks(ns, consoleLinks);
+  return (
+    !_.isEmpty(links) && <div className="group">
+      <div className="group__title">
+        <h2 className="h3">Launcher</h2>
+      </div>
+      <div className="container-fluid group__body group__namespace-details">
+        <ConsoleLinks consoleLinks={links} />
+      </div>
+    </div>
+  );
+};
+
+const OverviewLinksStateToProps = ({UI}) => ({
+  consoleLinks: UI.get('consoleLinks'),
+});
+
+export const OverviewLinks = connect(OverviewLinksStateToProps)(OverviewLinks_);
 
 const ResourceQuotaCharts = ({quota, resourceTypes}) => {
   const scopes = _.get(quota, 'spec.scopes');
@@ -100,8 +139,18 @@ export const OverviewNamespaceDashboard = ({obj: ns}) => <div className="co-m-pa
   <OverviewHealth ns={ns} />
   <OverviewResourceQuotas ns={ns} />
   <OverviewResourceUsage ns={ns} />
+  <OverviewLinks ns={ns} />
   <OverviewNamespaceSummary ns={ns} />
 </div>;
+
+export type ConsoleLinksProps = {
+  consoleLinks: K8sResourceKind[];
+}
+
+export type OverviewLinksProps = {
+  ns: K8sResourceKind;
+  consoleLinks: K8sResourceKind[];
+}
 
 export type QuotaBoxesProps = {
   resourceQuotas?: {loaded: boolean, loadError: string, data: K8sResourceKind};


### PR DESCRIPTION
Replaces https://github.com/openshift/console/pull/2579 as this PR does not include Cluster dashboard per @beanh66.

Note:  the Launcher sections only appear if `ConsoleLink`s with location `NamespaceDashboard` exist (and optionally match the current namespace).

![Screen Shot 2019-09-12 at 9 48 19 AM](https://user-images.githubusercontent.com/895728/64790485-2c587d80-d544-11e9-8549-ef1e6e056e84.png)
![Screen Shot 2019-09-12 at 9 47 53 AM](https://user-images.githubusercontent.com/895728/64790500-31b5c800-d544-11e9-9c83-3f43aa81deea.png)

![Screen Shot 2019-09-12 at 9 48 36 AM](https://user-images.githubusercontent.com/895728/64790573-48f4b580-d544-11e9-97d9-e05f4360610b.png)
![Screen Shot 2019-09-12 at 9 49 01 AM](https://user-images.githubusercontent.com/895728/64790574-48f4b580-d544-11e9-8134-25076eced16f.png)

Updated ConsoleLink CRD:
```yaml
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: consolelinks.console.openshift.io
  annotations:
    displayName: ConsoleLinks
    description: Extension for customizing OpenShift web console links
spec:
  scope: Cluster
  group: console.openshift.io
  versions:
  - name: v1
    served: true
    storage: true
  names:
    plural: consolelinks
    singular: consolelink
    kind: ConsoleLink
    listKind: ConsoleLinkList
  additionalPrinterColumns:
  - name: Text
    type: string
    JSONPath: .spec.text
  - name: URL
    type: string
    JSONPath: .spec.href
  - name: Menu
    type: string
    JSONPath: .spec.menu
  - name: Age
    type: date
    JSONPath: .metadata.creationTimestamp
  subresources:
    status: {}
  validation:
    openAPIV3Schema:
      properties:
        spec:
          type: object
          description: Represents console link customizations spec
          required:
          - text
          - href
          - location
          properties:
            text:
              type: string
              description: Text of the link
            href:
              type: string
              description: Absolute secure URL for the link (must use https)
              pattern: '^https://([\w-]+.)+[\w-]+(/[\w- ./?%&=])?$'
            location:
              type: string
              description: Determines where the link is added (ApplicationMenu, HelpMenu, UserMenu, NamespaceDashboard)
              pattern: ^(ApplicationMenu|HelpMenu|UserMenu|NamespaceDashboard)$
            applicationMenu:
              type: object
              description: Object that holds application menu properties if the location is set to ApplicationMenu
              required:
                - section
              properties:
                section:
                  type: string
                  description: The section of the application menu in which the link should appear
                imageURL:
                  type: string
                  description: The URL for the icon used in front of the link in the application menu.  The URL must be an HTTPS URL or a Data URI. The image should be square and will be shown at 24x24 pixels.
            namespaceDashboard:
              type: object
              description: Object that holds namespace dashboard link properties if the location is set to NamespaceDashboard
              properties:
                namespaces:
                  type: array
                  description: The namespaces in which the dashboard link should appear.  If not specified, the link will appear in all namespaces.
```