### PR TITLE
table: do not pass customData as rows

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -464,7 +464,7 @@ export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TablePro
         <TableWrapper virtualize={virtualize} ariaLabel={ariaLabel} ariaRowCount={ariaRowCount}>
           <PfTable
             cells={columns}
-            rows={virtualize ? (customData || []) : Rows({componentProps, selectedResourcesForKind, customData})}
+            rows={virtualize ? [] : Rows({componentProps, selectedResourcesForKind, customData})}
             gridBreakPoint={gridBreakPoint}
             onSort={this._onSort}
             onSelect={onSelect}


### PR DESCRIPTION
This change was introduced by https://github.com/openshift/console/pull/2359, but is not used in the end.

It breaks (react warnings) original usage of this prop which is passing `customData` down to the rows.

Another prop should be introduced in the future if requirement for this use case arises. 

cc @priley86 