### PR TITLE
Add 'Virtual Machines' label to the vm list page

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -182,6 +182,7 @@ const VirtualMachinesPageComponent: React.FC<VirtualMachinesPageProps> = (props)
       createProps={getCreateProps({ namespace, hasCreateVMWizardsSupport })}
       resources={resources}
       flatten={flatten}
+      label={VirtualMachineModel.labelPlural}
     />
   );
 };

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -425,7 +425,7 @@ export const ListPage = withFallback((props) => {
 
 ListPage.displayName = 'ListPage';
 
-/** @type {React.SFC<{canCreate?: boolean, createButtonText?: string, createProps?: any, flatten?: Function, title?: string, showTitle?: boolean, helpText?: any, filterLabel?: string, textFilter?: string, rowFilters?: any[], resources: any[], ListComponent: React.ComponentType<any>, namespace?: string, customData?: any, badge?: React.ReactNode >} */
+/** @type {React.SFC<{canCreate?: boolean, createButtonText?: string, createProps?: any, flatten?: Function, title?: string, label?: string, showTitle?: boolean, helpText?: any, filterLabel?: string, textFilter?: string, rowFilters?: any[], resources: any[], ListComponent: React.ComponentType<any>, namespace?: string, customData?: any, badge?: React.ReactNode >} */
 export const MultiListPage = (props) => {
   const {
     autoFocus,


### PR DESCRIPTION
Display 'No Virtual Machines Found' label when there are no
VMs to present instead of showing just 'Not Found' label.

Fixes: https://bugzilla.redhat.com/1743459

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>