### PR TITLE
Bug 1751854: Alerting - Deleting all text from Alert Manager YAML Editor causes it to disappear

### DIFF
--- a/frontend/public/components/monitoring/alert-manager-yaml-editor.tsx
+++ b/frontend/public/components/monitoring/alert-manager-yaml-editor.tsx
@@ -22,6 +22,11 @@ const AlertManagerYAMLEditor: React.FC<AlertManagerYAMLEditorProps> = ({obj, onC
 
   const save = e => {
     e.preventDefault();
+    if (_.isEmpty(yamlStringData)) {
+      setErrorMsg('Alertmanager configuration cannot be empty.');
+      setSuccessMsg('');
+      return;
+    }
     setInProgress(true);
     const patch = [{ op: 'replace', path: '/data/alertmanager.yaml', value:  Base64.encode(yamlStringData)}];
     k8sPatch(SecretModel, secret, patch)
@@ -44,7 +49,7 @@ const AlertManagerYAMLEditor: React.FC<AlertManagerYAMLEditorProps> = ({obj, onC
       <p className="co-alert-manager-yaml__explanation">
         Update this YAML to configure Routes, Receivers, Groupings and other Alertmanager settings
       </p>
-      {!_.isEmpty(yamlStringData) && <div className="co-alert-manager-yaml__form-entry-wrapper">
+      <div className="co-alert-manager-yaml__form-entry-wrapper">
         <div className="co-alert-manager-yaml__form">
           <div className="form-group">
             <DroppableFileInput
@@ -54,12 +59,11 @@ const AlertManagerYAMLEditor: React.FC<AlertManagerYAMLEditorProps> = ({obj, onC
           </div>
         </div>
       </div>
-      }
       <ButtonBar errorMessage={errorMsg} successMessage={successMsg} inProgress={inProgress}>
         <ActionGroup className="pf-c-form">
-          {!_.isEmpty(yamlStringData) && <Button type="submit" variant="primary" id="save-changes">
+          <Button type="submit" variant="primary" id="save-changes">
             Save
-          </Button> }
+          </Button>
           <Button type="button" variant="secondary" id="cancel" onClick={onCancel}>
             Cancel
           </Button>


### PR DESCRIPTION
Fix allows one to select and delete all text from alert mngr. yaml editor and empty editor textarea remains open and empty.  
Attempting to Save empty yaml results in error message:
![image](https://user-images.githubusercontent.com/12733153/64834559-5f385b00-d5b0-11e9-953d-eddd97de5f26.png)

