### PR TITLE
fix(table): fix cache key to use uid

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -210,13 +210,9 @@ const VirtualBody: React.SFC<VirtualBodyProps> = (props) => {
   const cellMeasurementCache = new CellMeasurerCache({
     fixedWidth: true,
     minHeight: 44,
-    keyMapper: rowIndex => {
-      const key = getRowKey(data[rowIndex], rowIndex);
-      return key;
-    },
   });
 
-  const rowRenderer = ({index, isScrolling: scrolling, style, parent}) => {
+  const rowRenderer = ({index, isScrolling: scrolling, key, style, parent}) => {
     const rowKey = getRowKey(data[index], index);
     const rowArgs = {obj: data[index], index, columns, isScrolling: scrolling, key: rowKey, style, customData};
     const row = (Row as RowFunction)(rowArgs as RowFunctionArgs);
@@ -224,7 +220,7 @@ const VirtualBody: React.SFC<VirtualBodyProps> = (props) => {
     return <CellMeasurer
       cache={cellMeasurementCache}
       columnIndex={0}
-      key={rowKey}
+      key={key}
       parent={parent}
       rowIndex={index}>{row}</CellMeasurer>;
   };
@@ -238,7 +234,6 @@ const VirtualBody: React.SFC<VirtualBodyProps> = (props) => {
       rowHeight={cellMeasurementCache.rowHeight}
       height={height || 0}
       isScrolling={isScrolling}
-      isScrollingOptOut={true}
       onScroll={onChildScroll}
       columnCount={1}
       rows={data}

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -205,7 +205,16 @@ const getRowKey = (obj, index) => {
 };
 
 const VirtualBody: React.SFC<VirtualBodyProps> = (props) => {
-  const { bindBodyRef, cellMeasurementCache, customData, Row, height, isScrolling, onChildScroll, data, columns, scrollTop, width } = props;
+  const { bindBodyRef, customData, Row, height, isScrolling, onChildScroll, data, columns, scrollTop, width } = props;
+
+  const cellMeasurementCache = new CellMeasurerCache({
+    fixedWidth: true,
+    minHeight: 44,
+    keyMapper: rowIndex => {
+      const key = getRowKey(data[rowIndex], rowIndex);
+      return key;
+    },
+  });
 
   const rowRenderer = ({index, isScrolling: scrolling, style, parent}) => {
     const rowKey = getRowKey(data[index], index);
@@ -246,7 +255,6 @@ export type RowFunction = (args: RowFunctionArgs) => JSX.Element;
 
 export type VirtualBodyProps = {
   bindBodyRef: Function;
-  cellMeasurementCache: any;
   customData?: any;
   Row: RowFunction | React.ComponentClass<any, any> | React.ComponentType<any>;
   height: number;
@@ -326,7 +334,6 @@ export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TablePro
       scrollElement: PropTypes.oneOf([PropTypes.object, PropTypes.func]),
     };
     _columnShift: number;
-    _cellMeasurementCache: any;
     _bodyRef: any;
 
     constructor(props){
@@ -340,7 +347,6 @@ export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TablePro
       this._onSort = this._onSort.bind(this);
       this._handleResize = _.debounce(this._handleResize.bind(this), 100);
       this._bindBodyRef = this._bindBodyRef.bind(this);
-      this._refreshGrid = _.debounce(this._refreshGrid.bind(this), 100);
 
       let sortBy = {};
       if (currentSortField && currentSortOrder) {
@@ -355,16 +361,6 @@ export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TablePro
         }
       }
       this.state = { columns, sortBy };
-
-      this._cellMeasurementCache = new CellMeasurerCache({
-        fixedWidth: true,
-        minHeight: 44,
-        keyMapper: rowIndex => {
-          const { data } = this.props;
-          const key = getRowKey(data[rowIndex], rowIndex);
-          return key;
-        },
-      });
     }
 
     componentDidMount(){
@@ -388,22 +384,13 @@ export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TablePro
       window.addEventListener('resize', this._handleResize);
     }
 
-    componentDidUpdate(prevProps){
-      const {data, virtualize} = this.props;
-      if (virtualize && this._bodyRef && !_.isEqual(prevProps.data, data)){
-        console.log('refresh grid');
-        // force react-virtualized to update after data changes with `isScrollingOptOut` set true
-        this._refreshGrid();
-      }
-    }
-
     componentWillUnmount(){
       window.removeEventListener('resize', this._handleResize);
     }
 
     _refreshGrid() {
-      this._cellMeasurementCache.clearAll();
       this._bodyRef.recomputeVirtualGridSize();
+      this.forceUpdate();
     }
 
     _handleResize() {
@@ -449,7 +436,6 @@ export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TablePro
                 <div ref={registerChild}>
                   <VirtualBody
                     bindBodyRef={this._bindBodyRef}
-                    cellMeasurementCache={this._cellMeasurementCache}
                     Row={Row}
                     customData={customData}
                     height={height}

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -206,11 +206,11 @@ const VirtualBody: React.SFC<VirtualBodyProps> = (props) => {
   const rowRenderer = ({index, isScrolling: scrolling, key, style, parent}) => {
     const rowArgs = {obj: data[index], index, columns, isScrolling: scrolling, key, style, customData};
     const row = (Row as RowFunction)(rowArgs as RowFunctionArgs);
-
+    const uid = _.get(rowArgs, 'obj.metadata.uid');
     return <CellMeasurer
       cache={cellMeasurementCache}
       columnIndex={0}
-      key={key}
+      key={uid || key}
       parent={parent}
       rowIndex={index}>{row}</CellMeasurer>;
   };
@@ -355,7 +355,8 @@ export const Table = connect<TablePropsFromState,TablePropsFromDispatch,TablePro
         fixedWidth: true,
         minHeight: 44,
         keyMapper: rowIndex => {
-          const uid = _.get(props.data[rowIndex], 'metadata.uid', rowIndex);
+          const { data } = this.props;
+          const uid = _.get(data[rowIndex], 'metadata.uid', rowIndex);
           return uid;
         },
       });

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -203,16 +203,7 @@ const subscriptionFor = (csv: ClusterServiceVersionKind) => (subs: SubscriptionK
   return sub.metadata.namespace === (csv.metadata.annotations || {})['olm.operatorNamespace'] && _.get(sub.status, 'installedCSV') === csv.metadata.name;
 });
 
-export const filterData = (data) => {
-  return data.map((item) => {
-    const viewData = {...item};
-    delete viewData.metadata.resourceVersion;
-    delete viewData.status.lastUpdateTime;
-    return viewData;
-  });
-};
-
-export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps> = ({data, ...props}) => {
+export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps> = (props) => {
 
   const EmptyMsg = () => <MsgBox title="No Operators match filter" detail="" />;
 
@@ -225,7 +216,6 @@ export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps
 
   return <Table
     {...props}
-    data={filterData(data)}
     aria-label="Installed Operators"
     Header={ClusterServiceVersionTableHeader}
     Row={(rowProps) => referenceFor(rowProps.obj) === referenceForModel(ClusterServiceVersionModel)


### PR DESCRIPTION
Relates to: https://bugzilla.redhat.com/show_bug.cgi?id=1750906 

The current method of assigning cache key is incorrectly using reading UID. `props` is getting old prop data in the constructor and uid is not being extracted. Also, we can attempt to use uid in the cell measurement cache's `key` if it exists.

Old logic was similar: https://github.com/openshift/console/blob/master/frontend/public/components/factory/list.tsx#L184

Refactor `CellMeasurementCache` usage to match existing instantiation:
https://github.com/priley86/web-ui/blob/b0d8abdacf02e77680ddaa0fd06353a794dc00c4/frontend/public/components/factory/list.tsx#L181