### PR TITLE
Query Browser: Add Developer perspective version

### DIFF
--- a/frontend/packages/dev-console/src/components/MetricsPage.tsx
+++ b/frontend/packages/dev-console/src/components/MetricsPage.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import { match as RMatch } from 'react-router';
+import { TechPreviewBadge } from '@console/shared';
+import { QueryBrowserPage } from '@console/internal/components/monitoring/metrics';
+import { NamespaceBar } from '@console/internal/components/namespace';
+import { withStartGuide } from '@console/internal/components/start-guide';
+import ProjectListPage from './projects/ProjectListPage';
+
+export interface MetricsPageProps {
+  match: RMatch<{
+    ns?: string;
+  }>;
+}
+
+const MetricsPage: React.FC<MetricsPageProps> = ({ match }) => {
+  const namespace = match.params.ns;
+  return (
+    <React.Fragment>
+      <NamespaceBar />
+      <Helmet>
+        <title>Metrics</title>
+      </Helmet>
+      {namespace ? (
+        <QueryBrowserPage namespace={namespace} />
+      ) : (
+        <ProjectListPage badge={<TechPreviewBadge />} title="Metrics">
+          Select a project to view metrics
+        </ProjectListPage>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default withStartGuide(MetricsPage);

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -128,6 +128,19 @@ const plugin: Plugin<ConsumedExtensions> = [
       section: 'Advanced',
       perspective: 'dev',
       componentProps: {
+        name: 'Metrics',
+        href: '/metrics',
+        required: FLAGS.OPENSHIFT,
+        testID: 'metrics-header',
+      },
+    },
+  },
+  {
+    type: 'NavItem/Href',
+    properties: {
+      section: 'Advanced',
+      perspective: 'dev',
+      componentProps: {
         name: 'Search',
         href: '/search',
         testID: 'advanced-search-header',
@@ -189,7 +202,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
-      path: ['/add', '/import', '/topology', '/deploy-image'],
+      path: ['/add', '/import', '/topology', '/deploy-image', '/metrics'],
       component: NamespaceRedirect,
     },
   },
@@ -279,6 +292,16 @@ const plugin: Plugin<ConsumedExtensions> = [
         (await import(
           './components/projects/details/ProjectDetailsPage' /* webpackChunkName: "project-details" */
         )).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: ['/metrics/all-namespaces', '/metrics/ns/:ns'],
+      loader: async () =>
+        (await import('./components/MetricsPage' /* webpackChunkName: "dev-console-metrics" */))
+          .default,
     },
   },
   {

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -164,6 +164,10 @@
   padding: 10px 20px;
 }
 
+.query-browser__tech-preview {
+  margin: 0 10px;
+}
+
 $tooltip-background-color: #151515;
 
 .query-browser__tooltip-wrap {

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -310,6 +310,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   filterLabels,
   GraphLink,
   hideGraphs,
+  namespace,
   patchQuery,
   queries,
 }) => {
@@ -338,6 +339,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
     const url = getPrometheusURL({
       endpoint: PrometheusEndpoint.QUERY_RANGE,
       endTime,
+      namespace,
       query,
       samples,
       timeout: '5s',
@@ -394,7 +396,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   // interval relative to the graph's timespan, but not less than 5s.
   const delay = endTime ? null : Math.max(span / 120, 5000);
 
-  usePoll(tick, delay, endTime, queries, samples, span);
+  usePoll(tick, delay, endTime, namespace, queries, samples, span);
 
   React.useEffect(() => setUpdating(true), [endTime, queries, samples, span]);
 
@@ -590,6 +592,7 @@ type QueryBrowserProps = {
   filterLabels?: Labels;
   GraphLink?: React.ComponentType<{}>;
   hideGraphs: boolean;
+  namespace?: string;
   patchQuery: (index: number, patch: QueryObj) => any;
   queries: string[];
 };


### PR DESCRIPTION
When a project is selected, send PromQL queries through the Prometheus
tenancy proxy to limit results to the project's namespace.

When in the Developer perspective
  - Show Project dropdown at top of page (like other Developer
    perspective pages)
  - Show "Tech Preview" badge
  - Don't show link to Prometheus UI

### Developer perspective
![screenshot-1](https://user-images.githubusercontent.com/460802/66455165-f0fa9180-eaa4-11e9-897f-a5d4d232e2ed.png)
![screenshot](https://user-images.githubusercontent.com/460802/66454930-44201480-eaa4-11e9-9ee2-707308d4f070.png)

### Administrator perspective (unchanged by this PR)
![screenshot](https://user-images.githubusercontent.com/460802/65690009-1781fb00-e0a9-11e9-83fa-d8df03377b48.png)
