### PR TITLE
Allow creation of network attachment definition YAML

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/index.ts
@@ -1,0 +1,2 @@
+export * from './network-attachment-definition';
+export * from './network-attachment-definition-create-yaml';

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/network-attachment-definition-create-yaml.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/network-attachment-definition-create-yaml.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { safeLoad } from 'js-yaml';
+import { CreateYAMLProps } from '@console/internal/components/create-yaml';
+import { ErrorPage404 } from '@console/internal/components/error';
+import {
+  LoadingBox,
+  AsyncComponent,
+  resourcePathFromModel,
+} from '@console/internal/components/utils';
+import { connectToPlural } from '@console/internal/kinds';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { getNamespace, getName } from '@console/shared';
+import { NET_ATTACH_DEF_HEADER_LABEL } from '../../constants';
+import { NetworkAttachmentDefinitionsYAMLTemplates } from '../../models/templates';
+import { NetworkAttachmentDefinitionModel } from '../../models';
+
+const CreateNetAttachDefYAMLConnected = connectToPlural(
+  ({ match, kindsInFlight, kindObj }: CreateYAMLProps) => {
+    if (!kindObj) {
+      if (kindsInFlight) {
+        return <LoadingBox />;
+      }
+      return <ErrorPage404 />;
+    }
+
+    const template = NetworkAttachmentDefinitionsYAMLTemplates.getIn(['default']);
+    const obj = safeLoad(template);
+    obj.kind = kindObj.kind;
+    obj.metadata = obj.metadata || {};
+    obj.metadata.namespace = match.params.ns || 'default';
+
+    const netAttachDefTemplatePath = (o: K8sResourceKind) =>
+      resourcePathFromModel(
+        { ...NetworkAttachmentDefinitionModel, plural: 'networkattachmentdefinitions' },
+        getName(o),
+        getNamespace(o),
+      );
+    const DroppableEditYAML = () =>
+      import('@console/internal/components/droppable-edit-yaml').then((c) => c.DroppableEditYAML);
+
+    return (
+      <AsyncComponent
+        loader={DroppableEditYAML}
+        obj={obj}
+        create
+        kind={kindObj.kind}
+        resourceObjPath={netAttachDefTemplatePath}
+        header={NET_ATTACH_DEF_HEADER_LABEL}
+      />
+    );
+  },
+);
+
+export const CreateNetAttachDefYAML = (props: any) => (
+  <CreateNetAttachDefYAMLConnected
+    {...props as any}
+    plural={NetworkAttachmentDefinitionModel.plural}
+  />
+);

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/network-attachment-definition.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/network-attachment-definition.tsx
@@ -126,6 +126,7 @@ export const NetworkAttachmentDefinitionsPage: React.FC<NetworkAttachmentDefinit
     kind={NetworkAttachmentDefinitionModel.kind}
     ListComponent={NetworkAttachmentDefinitionsList}
     filterLabel={props.filterLabel}
+    canCreate
   />
 );
 NetworkAttachmentDefinitionsPage.displayName = 'NetworkAttachmentDefinitionsPage';

--- a/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const NET_ATTACH_DEF_HEADER_LABEL = 'Create Network Attachment Definition';

--- a/frontend/packages/network-attachment-definition-plugin/src/models/templates/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/models/templates/index.ts
@@ -1,0 +1,27 @@
+import { Map as ImmutableMap } from 'immutable';
+import { NetworkAttachmentDefinitionModel } from '..';
+
+export const NetworkAttachmentDefinitionsYAMLTemplates = ImmutableMap().setIn(
+  ['default'],
+  `
+apiVersion: ${NetworkAttachmentDefinitionModel.apiGroup}/${
+    NetworkAttachmentDefinitionModel.apiVersion
+  }
+kind: ${NetworkAttachmentDefinitionModel.kind}
+metadata:
+  name: example
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "a-bridge-network",
+    "type": "bridge",
+    "bridge": "br0",
+    "isGateway": true,
+    "ipam": {
+      "type": "host-local",
+      "subnet": "192.168.5.0/24",
+      "dataDir": "/mnt/cluster-ipam"
+    }
+  }'
+`,
+);

--- a/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
@@ -9,6 +9,7 @@ import {
   RoutePage,
 } from '@console/plugin-sdk';
 import * as models from './models';
+import { NetworkAttachmentDefinitionsYAMLTemplates } from './models/templates';
 
 type ConsumedExtensions =
   | ResourceNSNavItem
@@ -54,6 +55,24 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/network-attachment-definitions/network-attachment-definition' /* webpackChunkName: "network-attachment-definitions" */
         ).then((m) => m.NetworkAttachmentDefinitionsPage),
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: ['/k8s/ns/:ns/networkattachmentdefinitions/~new'],
+      loader: () =>
+        import(
+          './components/network-attachment-definitions' /* webpackChunkName: "network-attachment-definitions" */
+        ).then((m) => m.CreateNetAttachDefYAML),
+    },
+  },
+  {
+    type: 'YAMLTemplate',
+    properties: {
+      model: models.NetworkAttachmentDefinitionModel,
+      template: NetworkAttachmentDefinitionsYAMLTemplates.getIn(['default']),
     },
   },
 ];


### PR DESCRIPTION
This PR adds the ability to create a network attachment definition by its YAML definition.

Depends on: https://github.com/openshift/console/pull/2545