### PR TITLE
Bug 1718047: Avoid runtime error when name isn't a string

### DIFF
--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -66,7 +66,7 @@ export const k8sCreate = (kind, data, opts = {}) => {
 
   // Lowercase the resource name
   // https://github.com/kubernetes/kubernetes/blob/HEAD/docs/user-guide/identifiers.md#names
-  if (data.metadata.name && !data.metadata.generateName) {
+  if (data.metadata.name && _.isString(data.metadata.name) && !data.metadata.generateName) {
     data.metadata.name = data.metadata.name.toLowerCase();
   }
 


### PR DESCRIPTION
Fixes a runtime error when the user enters a value other than a string
for `metadata.name` in the YAML editor.

https://bugzilla.redhat.com/show_bug.cgi?id=1718047

/assign @rhamilto 