### PR TITLE
fix pipeline resource dropdown loading issue

### DIFF
--- a/frontend/packages/dev-console/src/components/dropdown/PipelineResourceDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/PipelineResourceDropdown.tsx
@@ -13,7 +13,7 @@ export interface PipelineResourceDropdownProps {
     actionKey: string;
   }[];
   selectedKey: string;
-  onChange?: (key: string) => void;
+  onChange?: (key: string, name: string, isListEmpty?: boolean) => void;
   title?: React.ReactNode;
   id?: string;
   autoselect?: boolean;

--- a/frontend/packages/dev-console/src/components/dropdown/ResourceDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ResourceDropdown.tsx
@@ -42,7 +42,7 @@ interface ResourceDropdownProps {
   selectedKey: string;
   autoSelect?: boolean;
   resourceFilter?: (resource: any) => boolean;
-  onChange?: (key: string, name?: string) => void;
+  onChange?: (key: string, name?: string, isListEmpty?: boolean) => void;
   onLoad?: (items: { [key: string]: string }) => void;
 }
 
@@ -96,6 +96,8 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
 
   private getDropdownList = (
     {
+      loaded,
+      actionItems,
       autoSelect,
       selectedKey,
       resources,
@@ -141,15 +143,15 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
     if (updateSelection) {
       let selectedItem = selectedKey;
       if (
-        (_.isEmpty(sortedList) || !sortedList[this.props.selectedKey]) &&
+        (_.isEmpty(sortedList) || !sortedList[selectedKey]) &&
         allSelectorItem &&
-        allSelectorItem.allSelectorKey !== this.props.selectedKey
+        allSelectorItem.allSelectorKey !== selectedKey
       ) {
         selectedItem = allSelectorItem.allSelectorKey;
       } else if (autoSelect && !selectedKey) {
         selectedItem =
-          this.props.loaded && _.isEmpty(sortedList) && this.props.actionItems
-            ? this.props.actionItems[0].actionKey
+          loaded && _.isEmpty(sortedList) && actionItems
+            ? actionItems[0].actionKey
             : _.get(_.keys(sortedList), 0);
       }
       selectedItem && this.handleChange(selectedItem, sortedList);
@@ -166,7 +168,7 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
       this.setState({ title });
     }
     if (key !== selectedKey) {
-      onChange && onChange(key, name);
+      onChange && onChange(key, name, _.isEmpty(items));
     }
   };
 

--- a/frontend/packages/dev-console/src/components/dropdown/__tests__/ResourceDropdown.spec.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/__tests__/ResourceDropdown.spec.tsx
@@ -32,7 +32,7 @@ describe('ResourceDropdown test suite', () => {
     const spy = jest.fn();
     const component = shallow(componentFactory({ onChange: spy }));
     component.setProps({ resources: [] });
-    expect(spy).toHaveBeenCalledWith('#CREATE_APPLICATION_KEY#', undefined);
+    expect(spy).toHaveBeenCalledWith('#CREATE_APPLICATION_KEY#', undefined, true);
   });
 
   it('should select Create New Application as default option when more than one action items is available', () => {
@@ -53,7 +53,7 @@ describe('ResourceDropdown test suite', () => {
       }),
     );
     component.setProps({ resources: [] });
-    expect(spy).toHaveBeenCalledWith('#CREATE_APPLICATION_KEY#', undefined);
+    expect(spy).toHaveBeenCalledWith('#CREATE_APPLICATION_KEY#', undefined, true);
   });
 
   it('should select Choose Existing Application as default option when selectedKey is passed as #CHOOSE_APPLICATION_KEY#', () => {
@@ -75,28 +75,28 @@ describe('ResourceDropdown test suite', () => {
     );
     component.setProps({ resources: [], selectedKey: '#CHOOSE_APPLICATION_KEY#' });
     expect(component.state('title')).toEqual('Choose Existing Application');
-    expect(spy).toHaveBeenCalledWith('#CHOOSE_APPLICATION_KEY#', undefined);
+    expect(spy).toHaveBeenCalledWith('#CHOOSE_APPLICATION_KEY#', undefined, true);
   });
 
   it('should select first item as default option when an item is available', () => {
     const spy = jest.fn();
     const component = shallow(componentFactory({ onChange: spy }));
     component.setProps({ resources: mockDropdownData.slice(0, 1) });
-    expect(spy).toHaveBeenCalledWith('app-group-1', 'app-group-1');
+    expect(spy).toHaveBeenCalledWith('app-group-1', 'app-group-1', false);
   });
 
   it('should select first item as default option when more than one items are available', () => {
     const spy = jest.fn();
     const component = shallow(componentFactory({ onChange: spy }));
     component.setProps({ resources: mockDropdownData });
-    expect(spy).toHaveBeenCalledWith('app-group-1', 'app-group-1');
+    expect(spy).toHaveBeenCalledWith('app-group-1', 'app-group-1', false);
   });
 
   it('should select given selectedKey as default option when more than one items are available', () => {
     const spy = jest.fn();
     const component = shallow(componentFactory({ onChange: spy, selectedKey: 'app-group-1' }));
     component.setProps({ resources: mockDropdownData, selectedKey: 'app-group-2' });
-    expect(spy).toHaveBeenCalledWith('app-group-2', 'app-group-2');
+    expect(spy).toHaveBeenCalledWith('app-group-2', 'app-group-2', false);
   });
 
   it('should reset to default item when the selectedKey is no longer available in the items', () => {
@@ -113,9 +113,9 @@ describe('ResourceDropdown test suite', () => {
       }),
     );
     component.setProps({ resources: mockDropdownData, selectedKey: 'app-group-2' });
-    expect(spy).toHaveBeenCalledWith('app-group-2', 'app-group-2');
+    expect(spy).toHaveBeenCalledWith('app-group-2', 'app-group-2', false);
     component.setProps({ resources: [] });
-    expect(spy).toHaveBeenCalledWith('#ALL_APPS#', undefined);
+    expect(spy).toHaveBeenCalledWith('#ALL_APPS#', undefined, true);
   });
 
   it('should callback selected item from dropdown and change the title to selected item', () => {
@@ -126,7 +126,7 @@ describe('ResourceDropdown test suite', () => {
       componentFactory({ onChange: spy, selectedKey: 'app-group-1', id: 'dropdown1' }),
     );
     component.setProps({ resources: mockDropdownData, selectedKey: 'app-group-2' });
-    expect(spy).toHaveBeenCalledWith('app-group-2', 'app-group-2');
+    expect(spy).toHaveBeenCalledWith('app-group-2', 'app-group-2', false);
 
     const dropdownComponent = component.find('Dropdown#dropdown1').shallow();
     const dropdownBtn = dropdownComponent.find('button#dropdown1');
@@ -139,7 +139,18 @@ describe('ResourceDropdown test suite', () => {
       .find('#app-group-3-link');
     dropdownItem.simulate('click', { preventDefault, stopPropagation });
 
-    expect(spy).toHaveBeenCalledWith('app-group-3', 'app-group-3');
+    expect(spy).toHaveBeenCalledWith('app-group-3', 'app-group-3', false);
     expect(component.state('title')).toEqual('app-group-3');
+  });
+
+  it('should pass a third arugment in the onChange handler based on the resources availability', () => {
+    const spy = jest.fn();
+    const component = shallow(componentFactory({ onChange: spy }));
+
+    component.setProps({ resources: mockDropdownData.slice(0, 1) });
+    expect(spy).toHaveBeenCalledWith('app-group-1', 'app-group-1', false);
+
+    component.setProps({ resources: [] });
+    expect(spy).toHaveBeenCalledWith('#CREATE_APPLICATION_KEY#', undefined, true);
   });
 });

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineParameterSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineParameterSection.tsx
@@ -31,6 +31,7 @@ const PipelineParameterSection: React.FC<ParamertersSectionProps> = ({ parameter
                 label={parameter.name}
                 helpText={parameter.description}
                 placeholder="Name"
+                required
               />
             </div>
           ))}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineForm.tsx
@@ -43,7 +43,7 @@ const StartPipelineForm: React.FC<FormikValues> = ({
           errorMessage={status && status.submitError}
           inProgress={isSubmitting}
           submitText="Start"
-          submitDisabled={!_.isEmpty(errors) || !!status.subFormsOpened}
+          submitDisabled={!_.isEmpty(errors)}
           cancel={close}
         />
       </div>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
@@ -9,7 +9,7 @@ import { k8sCreate } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
 import { Pipeline, PipelineResource, Param, PipelineRun } from '../../../utils/pipeline-augment';
 import StartPipelineForm from './StartPipelineForm';
-import { validationSchema } from './pipelineForm-validation-utils';
+import { startPipelineSchema } from './pipelineForm-validation-utils';
 
 export type newPipelineRun = (Pipeline: Pipeline, latestRun: PipelineRun) => {};
 
@@ -69,9 +69,8 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
   return (
     <Formik
       initialValues={initialValues}
-      initialStatus={{ subFormsOpened: 0 }}
       onSubmit={handleSubmit}
-      validationSchema={validationSchema}
+      validationSchema={startPipelineSchema}
       render={(props) => <StartPipelineForm {...props} close={close} />}
     />
   );

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/pipelineForm-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/pipelineForm-validation-utils.ts
@@ -15,3 +15,22 @@ export const validationSchema = yup.object().shape({
     }),
   ),
 });
+
+export const startPipelineSchema = yup.object().shape({
+  resources: yup.array().of(
+    yup.object().shape({
+      name: yup.string().required('Required'),
+      type: yup.string().required('Required'),
+      resourceRef: yup.object().shape({
+        name: yup.string().required('Required'),
+      }),
+    }),
+  ),
+  parameters: yup.array().of(
+    yup.object().shape({
+      name: yup.string().required('Required'),
+      description: yup.string(),
+      default: yup.string().required('Required'),
+    }),
+  ),
+});

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceForm.tsx
@@ -11,6 +11,7 @@ export interface PipelineResourceFormProps {
   type: string;
   onCreate: Function;
   onClose: Function;
+  closeDisabled?: boolean;
   namespace: string;
 }
 
@@ -19,6 +20,7 @@ const PipelineResourceForm: React.FC<PipelineResourceFormProps> = ({
   onCreate,
   onClose,
   namespace,
+  closeDisabled,
 }) => {
   const initialValues = {
     git: {
@@ -97,7 +99,9 @@ const PipelineResourceForm: React.FC<PipelineResourceFormProps> = ({
       onSubmit={handleSubmit}
       onReset={handleReset}
       validationSchema={validationSchema}
-      render={(props) => <PipelineResourceParam {...props} type={type} />}
+      render={(props) => (
+        <PipelineResourceParam {...props} type={type} closeDisabled={closeDisabled} />
+      )}
     />
   );
 };

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceParam.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceParam.tsx
@@ -12,9 +12,10 @@ import './PipelineResourceParam.scss';
 
 export interface PipelineResourceParamProps {
   type: string;
+  closeDisabled?: boolean;
 }
 
-const PipelineResourceParam: React.FC<PipelineResourceParamProps> = ({ type }) => {
+const PipelineResourceParam: React.FC<PipelineResourceParamProps> = ({ type, closeDisabled }) => {
   const { errors, handleReset, status, isSubmitting, dirty, submitForm } = useFormikContext<
     FormikValues
   >();
@@ -57,6 +58,7 @@ const PipelineResourceParam: React.FC<PipelineResourceParamProps> = ({ type }) =
             className="odc-pipeline-resource-param__action-btn"
             variant={ButtonVariant.plain}
             onClick={handleReset}
+            isDisabled={closeDisabled}
             aria-label="close"
           >
             <CloseIcon />


### PR DESCRIPTION
1. Fixes the infinite loading state in Resource dropdown
2. Avoids the un-necessary re-render of the dropdown(with no items & autoselect enabled) in the start pipeline form

![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/9964343/64884582-b35e4080-d67f-11e9-99de-281f77b6f490.gif)


Fixes: https://jira.coreos.com/browse/ODC-1846