### PR TITLE
Follow on to update inline edit links in kubevirt-plugin

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -9,6 +9,8 @@ import {
   getBootableDevicesInOrder,
   TemplateSource,
 } from 'kubevirt-web-ui-components';
+import { PencilAltIcon } from '@patternfly/react-icons';
+import { Button } from '@patternfly/react-core';
 import { ResourceSummary } from '@console/internal/components/utils';
 import { DASH } from '@console/shared';
 import { TemplateKind, K8sResourceKind } from '@console/internal/module/k8s';
@@ -33,11 +35,14 @@ export const VMTemplateResourceSummary: React.FC<VMTemplateResourceSummaryProps>
       <dt>
         Description
         {canUpdateTemplate && (
-          <button
+          <Button
+            variant="link"
             type="button"
-            className="btn btn-link co-modal-btn-link co-modal-btn-link--left"
+            className="pf-m-inline"
             onClick={() => vmDescriptionModal({ vmLikeEntity: template })}
-          />
+          >
+            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+          </Button>
         )}
       </dt>
       <dd id={prefixedID(id, 'description')} className="kubevirt-vm-resource-summary__description">

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -15,6 +15,8 @@ import {
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
 import { PodKind } from '@console/internal/module/k8s';
 import { getName, getNamespace, DASH } from '@console/shared';
+import { Button } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
 import { PodModel } from '@console/internal/models';
 import { VMKind, VMIKind } from '../../types';
 import { VMTemplateLink } from '../vm-templates/vm-template-link';
@@ -36,11 +38,14 @@ export const VMResourceSummary: React.FC<VMResourceSummaryProps> = ({ vm, canUpd
       <dt>
         Description
         {canUpdateVM && (
-          <button
+          <Button
+            variant="link"
             type="button"
-            className="btn btn-link co-modal-btn-link co-modal-btn-link--left"
+            className="pf-m-inline"
             onClick={() => vmDescriptionModal({ vmLikeEntity: vm })}
-          />
+          >
+            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+          </Button>
         )}
       </dt>
       <dd id={prefixedID(id, 'description')} className="kubevirt-vm-resource-summary__description">

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -398,38 +398,6 @@ $co-external-link-padding-right: 15px;
   max-width: 600px;
 }
 
-// Enable word-break and append pencil icon ::after so that it doesn't wrap without text
-.co-modal-btn-link {
-  outline: none;
-  padding: 0 20px 0 0;
-  white-space: normal;
-  word-break: break-all; // Firefox
-  word-break: break-word;
-  &::after {
-    @include font-awesome-free-solid;
-    color: $color-pf-black-600;
-    content: fa-content($fa-var-pencil-alt);
-    line-height: 1;
-    margin-left: 5px;
-    margin-right: -20px; // width + margin-left
-    pointer-events: none;
-    position: relative;
-    right: 0;
-    width: 15px;
-  }
-  &:hover::after {
-    color: $color-pf-black-700;
-  }
-}
-
-.co-modal-btn-link--inline {
-  margin: 0 8px;
-}
-
-.co-modal-btn-link--left {
-  text-align: left;
-}
-
 .co-m-pane__body-group {
   padding: 0 0 30px 0;
 }

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -119,8 +119,25 @@ h6 {
   margin-left: auto !important;
 }
 
+.pf-c-button.pf-m-link {
+  white-space: normal; // override default .pf-c-button to enable wrapping
+}
+
 .pf-c-button.pf-m-link--align-left {
   padding-left: 0;
+}
+
+.pf-c-button {
+  &:hover,
+  &:focus {
+    .pf-c-button-icon--plain {
+      color: var(--pf-c-button--m-plain--hover--Color);
+    }
+  }
+}
+
+.pf-c-button-icon--plain {
+  color: var(--pf-c-button--m-plain--Color);
 }
 
 // PF components that calculate their correct height based on --pf-global--FontSize--md: 1rem


### PR DESCRIPTION
related to https://github.com/openshift/console/pull/2666

this also no longer used `co-modal-btn-link` styles

