### PR TITLE
Bug 1751359: Fix Create Operand Form Crashes

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -119,7 +119,6 @@ export const config: Config = {
       'tests/overview/overview.scenario.ts',
       'tests/deploy-image.scenario.ts',
     ]),
-    // TODO(alecmerdler): Rename this to `olm` (being used by ci-operator)
     olmFull: suite([
       'tests/olm/descriptors.scenario.ts',
       'tests/operator-hub/operator-hub.scenario.ts',

--- a/frontend/public/components/configmap-and-secret-data.tsx
+++ b/frontend/public/components/configmap-and-secret-data.tsx
@@ -43,12 +43,12 @@ export const ConfigMapData: React.FC<ConfigMapDataProps> = ({data, label}) => {
 };
 ConfigMapData.displayName = 'ConfigMapData';
 
-const SecretValue: React.FC<SecretValueProps> = ({value, reveal}) => {
+export const SecretValue: React.FC<SecretValueProps> = ({value, reveal, encoded = true}) => {
   if (!value) {
     return <span className="text-muted">No value</span>;
   }
 
-  const decodedValue = Base64.decode(value);
+  const decodedValue = encoded ? Base64.decode(value) : value;
   const visibleValue = reveal ? decodedValue : <MaskedData />;
   return <CopyToClipboard value={decodedValue} visibleValue={visibleValue} />;
 };
@@ -95,6 +95,7 @@ type DownloadValueProps = {
 
 type SecretValueProps = {
   value: string;
+  encoded?: boolean;
   reveal: boolean;
 };
 

--- a/frontend/public/components/operator-lifecycle-manager/_operator-lifecycle-manager.scss
+++ b/frontend/public/components/operator-lifecycle-manager/_operator-lifecycle-manager.scss
@@ -164,3 +164,9 @@
   margin-left: 15px;
   padding: 10px 0 5px 20px;
 }
+
+.co-operand-field-group-title {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}

--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -129,7 +129,7 @@ export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionT
     : <span className="co-error co-icon-and-text"><ErrorStatus title="Failed" /></span>;
   const menuActions = [Kebab.factory.Edit].concat(!_.isNil(subscription)
     ? [() => editSubscription(subscription), () => uninstall(subscription)]
-    : []);
+    : [Kebab.factory.Delete]);
 
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
@@ -245,6 +245,8 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
       flatten={({clusterServiceVersion, subscription}) => _.get(clusterServiceVersion, 'data', [] as ClusterServiceVersionKind[])
         .concat(_.get(subscription, 'data', [] as SubscriptionKind[])
           .filter(sub => ['', sub.metadata.namespace].includes(props.namespace) && _.isNil(_.get((sub as SubscriptionKind).status, 'installedCSV'))))
+        .filter((obj, i, all) => referenceFor(obj) !== referenceForModel(SubscriptionModel)
+            || _.isUndefined(all.find(({metadata}) => [_.get(obj.status, 'currentCSV'), _.get(obj.spec, 'startingCSV')].includes(metadata.name))))
       }
       namespace={props.namespace}
       ListComponent={ClusterServiceVersionList}
@@ -396,7 +398,7 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
   type ExtraResources = {subscription: SubscriptionKind[]};
   const menuActions = (model, obj: ClusterServiceVersionKind, {subscription}: ExtraResources) => [Kebab.factory.Edit(model, obj)].concat(!_.isNil(subscriptionFor(obj)(subscription))
     ? [editSubscription(subscriptionFor(obj)(subscription)), uninstall(subscriptionFor(obj)(subscription))]
-    : []);
+    : [Kebab.factory.Delete(model, obj)]);
 
   const canListSubscriptions = useAccessReview({
     group: SubscriptionModel.apiGroup,

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { Map as ImmutableMap } from 'immutable';
 import { Tooltip } from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
 import { Switch } from 'patternfly-react';
 
 import { SpecCapability, DescriptorProps, CapabilityProps } from '../types';
@@ -11,6 +12,7 @@ import { configureSizeModal } from './configure-size';
 import { Selector, ResourceLink, LoadingInline } from '../../../utils';
 import { k8sPatch } from '../../../../module/k8s';
 import { YellowExclamationTriangleIcon } from '@console/shared';
+import { SecretValue } from '@console/internal/components/configmap-and-secret-data';
 
 const Default: React.SFC<SpecCapabilityProps> = ({value}) => {
   if (_.isEmpty(value) && !_.isNumber(value)) {
@@ -74,6 +76,19 @@ const BooleanSwitch: React.FC<SpecCapabilityProps> = (props) => {
   </div>;
 };
 
+const Secret: React.FC<SpecCapabilityProps> = (props) => {
+  const [reveal, setReveal] = React.useState(false);
+
+  return <React.Fragment>
+    <button className="btn btn-link" type="button" onClick={() => setReveal(!reveal)}>
+      {reveal
+        ? <React.Fragment><EyeSlashIcon className="co-icon-space-r" />Hide Values</React.Fragment>
+        : <React.Fragment><EyeIcon className="co-icon-space-r" />Reveal Values</React.Fragment>}
+    </button>
+    <SecretValue value={props.value} encoded={false} reveal={reveal} />
+  </React.Fragment>;
+};
+
 const capabilityComponents = ImmutableMap<SpecCapability, React.ComponentType<SpecCapabilityProps>>()
   .set(SpecCapability.podCount, PodCount)
   .set(SpecCapability.endpointList, Endpoints)
@@ -82,7 +97,8 @@ const capabilityComponents = ImmutableMap<SpecCapability, React.ComponentType<Sp
   .set(SpecCapability.resourceRequirements, ResourceRequirements)
   .set(SpecCapability.k8sResourcePrefix, K8sResourceLink)
   .set(SpecCapability.selector, BasicSelector)
-  .set(SpecCapability.booleanSwitch, BooleanSwitch);
+  .set(SpecCapability.booleanSwitch, BooleanSwitch)
+  .set(SpecCapability.password, Secret);
 
 const capabilityFor = (specCapability: SpecCapability) => {
   if (_.isEmpty(specCapability)) {

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/types.ts
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/types.ts
@@ -21,6 +21,8 @@ export enum SpecCapability {
   podAntiAffinity = 'urn:alm:descriptor:com.tectonic.ui:podAntiAffinity',
   fieldGroup = 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:',
   arrayFieldGroup = 'urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:',
+  select = 'urn:alm:descriptor:com.tectonic.ui:select:',
+  advanced = 'urn:alm:descriptor:com.tectonic.ui:advanced',
 }
 
 export enum StatusCapability {


### PR DESCRIPTION
### Description

The OpenAPI for a CRD can be incomplete if it doesn't [conform to structural schema](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema). Make sure we are checking that it is fully complete before using it to construct the creation form.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1751359
Fixes https://jira.coreos.com/browse/OLM-1253