### PR TITLE
Bug 1750363: fall back to showing image digest on nodes page

### DIFF
--- a/frontend/public/components/node.tsx
+++ b/frontend/public/components/node.tsx
@@ -319,8 +319,8 @@ const Details = ({obj: node}) => {
           </thead>
           <tbody>
             {_.map(images, (image, i) => <tr key={i}>
-              <td className="co-break-all">{image.names.find(name => !name.includes('@')) || image.names[0]}</td>
-              <td>{units.humanize(image.sizeBytes, 'decimalBytes', true).string || '-'}</td>
+              <td className="co-break-all co-select-to-copy">{image.names.find((name: string) => !name.includes('@') && !name.includes('<none>')) || image.names[0]}</td>
+              <td>{units.humanize(image.sizeBytes, 'binaryBytes', true).string || '-'}</td>
             </tr>)}
           </tbody>
         </table>


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1750363

<img width="953" alt="ip-10-0-129-246 ec2 internal · Details · OKD 2019-09-14 08-05-07" src="https://user-images.githubusercontent.com/1167259/64907877-65b8f680-d6c6-11e9-9e92-2d58870a703d.png">
