### PR TITLE
Dedicated pages for OB and OBC

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/create-obc.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/create-obc.tsx
@@ -1,0 +1,134 @@
+import * as _ from 'lodash';
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import { match } from 'react-router';
+import { Link } from 'react-router-dom';
+import {
+  ButtonBar,
+  history,
+  resourceObjPath,
+  resourcePathFromModel,
+} from '@console/internal/components/utils';
+import { StorageClassDropdown } from '@console/internal/components/utils/storage-class-dropdown';
+import {
+  apiVersionForModel,
+  k8sCreate,
+  K8sResourceKind,
+  referenceFor,
+} from '@console/internal/module/k8s';
+import { NooBaaObjectBucketClaimModel } from '@console/noobaa-storage-plugin/src/models';
+import { ActionGroup, Button } from '@patternfly/react-core';
+import { getName } from '@console/shared';
+import { commonReducer, defaultState } from '../object-bucket-page/state';
+
+export const CreateOBCPage: React.FC<CreateOBCPageProps> = (props) => {
+  const [state, dispatch] = React.useReducer(commonReducer, defaultState);
+
+  const namespace = _.get(props, 'match.params.ns');
+
+  React.useEffect(() => {
+    const obj: K8sResourceKind = {
+      apiVersion: apiVersionForModel(NooBaaObjectBucketClaimModel),
+      kind: NooBaaObjectBucketClaimModel.kind,
+      metadata: {
+        namespace,
+      },
+      spec: {
+        ssl: false,
+      },
+    };
+    if (state.scName) {
+      obj.spec.storageClassName = state.scName;
+    }
+    if (state.name) {
+      obj.metadata.name = state.name;
+      obj.spec.generateBucketName = state.name;
+    } else {
+      obj.metadata.generateName = 'bucketclaim-';
+      obj.spec.generateBucketName = 'bucket-';
+    }
+    dispatch({ type: 'setPayload', payload: obj });
+  }, [namespace, state.name, state.scName]);
+
+  const save = (e: React.FormEvent<EventTarget>) => {
+    e.preventDefault();
+    dispatch({ type: 'setProgress' });
+    k8sCreate(NooBaaObjectBucketClaimModel, state.payload)
+      .then((resource) => {
+        dispatch({ type: 'unsetProgress' });
+        history.push(resourceObjPath(resource, referenceFor(resource)));
+      })
+      .catch((err) => {
+        dispatch({ type: 'setError', message: err.message });
+        dispatch({ type: 'unsetProgress' });
+      });
+  };
+
+  return (
+    <div className="co-m-pane__body co-m-pane__form">
+      <Helmet>
+        <title>Create Object Bucket Claim</title>
+      </Helmet>
+      <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
+        <div className="co-m-pane__name">Create Object Bucket Claim</div>
+        <div className="co-m-pane__heading-link">
+          <Link
+            to={`${resourcePathFromModel(NooBaaObjectBucketClaimModel, null, namespace)}/~new`}
+            replace
+          >
+            Edit YAML
+          </Link>
+        </div>
+      </h1>
+      <form className="co-m-pane__body-group" onSubmit={save}>
+        <div>
+          <div className="form-group">
+            <label className="control-label" htmlFor="obc-name">
+              Object Bucket Claim Name
+            </label>
+            <div className="form-group">
+              <input
+                className="pf-c-form-control"
+                type="text"
+                onChange={(e) => dispatch({ type: 'setName', name: e.currentTarget.value })}
+                placeholder="my-object-bucket"
+                aria-describedby="obc-name-help"
+                id="obc-name"
+                name="obcName"
+                pattern="[a-z0-9](?:[-a-z0-9]*[a-z0-9])?"
+              />
+              <p className="help-block" id="obc-name-help">
+                If not provided, a generic name will be generated.
+              </p>
+            </div>
+            <div className="form-group">
+              <StorageClassDropdown
+                onChange={(sc) => dispatch({ type: 'setStorage', name: getName(sc) })}
+                required
+                name="storageClass"
+                className="co-required"
+              />
+              <p className="help-block">
+                Defines the object-store service and the bucket provisioner.
+              </p>
+            </div>
+          </div>
+        </div>
+        <ButtonBar errorMessage={state.error} inProgress={state.progress}>
+          <ActionGroup className="pf-c-form">
+            <Button type="submit" variant="primary">
+              Create
+            </Button>
+            <Button onClick={history.goBack} type="button" variant="secondary">
+              Cancel
+            </Button>
+          </ActionGroup>
+        </ButtonBar>
+      </form>
+    </div>
+  );
+};
+
+type CreateOBCPageProps = {
+  match: match<{ ns?: string }>;
+};

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/menu-actions.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/menu-actions.ts
@@ -1,0 +1,18 @@
+import { asAccessReview, Kebab } from '@console/internal/components/utils';
+import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { attachDeploymentToOBCModal } from './modals/attach-deployment-obc-modal';
+
+const attachDeployment = (kind: K8sKind, resource: K8sResourceKind) => ({
+  label: 'Attach to Deployment',
+  callback: () =>
+    attachDeploymentToOBCModal({
+      kind,
+      resource,
+    }),
+  accessReview: asAccessReview(kind, resource, 'patch'),
+});
+
+export const menuActions = [attachDeployment, ...Kebab.factory.common];
+
+export const menuActionCreator = (kindObj: K8sKind, resource: K8sResourceKind) =>
+  menuActions.map((action) => action(kindObj, resource));

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/modals/attach-deployment-obc-modal.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/modals/attach-deployment-obc-modal.tsx
@@ -1,0 +1,179 @@
+import * as _ from 'lodash';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import {
+  createModalLauncher,
+  ModalBody,
+  ModalComponentProps,
+  ModalTitle,
+  ModalSubmitFooter,
+} from '@console/internal/components/factory/modal';
+import {
+  Dropdown,
+  FirehoseResult,
+  Firehose,
+  HandlePromiseProps,
+  history,
+  resourceObjPath,
+  withHandlePromise,
+} from '@console/internal/components/utils';
+import { DeploymentModel } from '@console/internal/models';
+import {
+  ContainerSpec,
+  K8sKind,
+  k8sPatch,
+  K8sResourceKind,
+  referenceFor,
+} from '@console/internal/module/k8s/';
+import { getName } from '@console/shared';
+
+const AttachDeploymentToOBCModal = withHandlePromise((props: AttachDeploymentToOBCModalProps) => {
+  const [requestDeployment, setRequestedDeployment] = React.useState({});
+  const [deploymentObjects, setDeployments] = React.useState({});
+  const [deploymentNames, setDeploymentNames] = React.useState({});
+  const { handlePromise, close, cancel, resource, deployments } = props;
+
+  const obcName = getName(resource);
+  const deploymentData = _.get(deployments, 'data');
+  const inProgress = _.get(props, 'loaded');
+  const errorMessage = _.get(props, 'loadError');
+
+  React.useEffect(() => {
+    const deploymentObjectList = {};
+    const deploymentNameList = {};
+
+    _.map(deploymentData, (data) => {
+      const name = getName(data);
+      deploymentObjectList[name] = data;
+      deploymentNameList[name] = name;
+    });
+
+    setDeployments(deploymentObjectList);
+    setDeploymentNames(deploymentNameList);
+  }, [deploymentData, deployments]);
+
+  const getPatches = () => {
+    const configMapRef = {
+      name: 'CONFIGMAP_BUCKET',
+      valueFrom: {
+        configMapKeyRef: {
+          name: obcName,
+          key: obcName,
+        },
+      },
+    };
+    const secretMapRef = {
+      name: 'SECRET_BUCKET',
+      valueFrom: {
+        secretKeyRef: {
+          name: obcName,
+          key: obcName,
+        },
+      },
+    };
+
+    const containers: ContainerSpec[] = _.get(
+      requestDeployment,
+      'spec.template.spec.containers',
+      [],
+    );
+    const patches = containers.reduce((patch, container, i) => {
+      if (_.isEmpty(container.env)) {
+        patch.push({
+          op: 'add',
+          path: `/spec/template/spec/containers/${i}/env`,
+          value: [configMapRef],
+        });
+        patch.push({
+          op: 'add',
+          path: `/spec/template/spec/containers/${i}/env/-`,
+          value: secretMapRef,
+        });
+      } else {
+        patch.push({
+          op: 'add',
+          path: `/spec/template/spec/containers/${i}/env/-`,
+          value: configMapRef,
+        });
+        patch.push({
+          op: 'add',
+          path: `/spec/template/spec/containers/${i}/env/-`,
+          value: secretMapRef,
+        });
+      }
+      return patch;
+    }, []);
+    return patches;
+  };
+
+  const submit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    handlePromise(k8sPatch(DeploymentModel, requestDeployment, getPatches()))
+      .then((res) => {
+        history.push(resourceObjPath(res, referenceFor(res)));
+        close();
+      })
+      .catch(() => {
+        close();
+      });
+  };
+
+  return (
+    <form onSubmit={submit} name="form" className="modal-content modal-content--no-inner-scroll">
+      <ModalTitle>Attach OBC to a Deployment</ModalTitle>
+      <ModalBody>
+        <label htmlFor="dropdown-selectbox" className="control-label co-required">
+          Deployment Name
+        </label>
+        <Dropdown
+          items={deploymentNames}
+          dropDownClassName="dropdown--full-width"
+          id="dropdown-selectbox"
+          onChange={(deploymentName) => setRequestedDeployment(deploymentObjects[deploymentName])}
+        />
+      </ModalBody>
+      <ModalSubmitFooter
+        errorMessage={errorMessage}
+        inProgress={!inProgress}
+        submitText="Attach"
+        cancel={cancel}
+      />
+    </form>
+  );
+});
+
+const AttachDeploymentToOBCFirehose: React.FC<AttachDeploymentToOBCFirehoseProps> = (props) => {
+  const { namespace } = props;
+  const resource = [{ kind: DeploymentModel.kind, namespace, prop: 'deployments', isList: true }];
+  return (
+    <Firehose resources={resource}>
+      <AttachDeploymentToOBCModal {...props} />
+    </Firehose>
+  );
+};
+
+const attachDeploymentToOBCModalStateToProps = ({ UI }) => {
+  const namespace = UI.getIn(['activeNamespace']);
+  return {
+    namespace,
+  };
+};
+
+const AttachDeploymentToOBCModalConnected = connect(attachDeploymentToOBCModalStateToProps)(
+  AttachDeploymentToOBCFirehose,
+);
+
+export const attachDeploymentToOBCModal = createModalLauncher(AttachDeploymentToOBCModalConnected);
+
+type AttachDeploymentToOBCModalProps = HandlePromiseProps &
+  ModalComponentProps & {
+    kind: K8sKind;
+    resource: K8sResourceKind;
+    deployments?: FirehoseResult<K8sResourceKind[]>;
+  };
+
+type AttachDeploymentToOBCFirehoseProps = ModalComponentProps & {
+  kind: K8sKind;
+  resource: K8sResourceKind;
+  namespace: string;
+};

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/object-bucket-claim.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/object-bucket-claim.tsx
@@ -1,0 +1,243 @@
+import * as classNames from 'classnames';
+import * as _ from 'lodash';
+import * as React from 'react';
+import { ResourceEventStream } from '@console/internal/components/events';
+import {
+  DetailsPage,
+  ListPage,
+  Table,
+  TableRow,
+  TableData,
+} from '@console/internal/components/factory';
+import {
+  Kebab,
+  navFactory,
+  ResourceKebab,
+  ResourceLink,
+  resourcePathFromModel,
+  ResourceSummary,
+  SectionHeading,
+} from '@console/internal/components/utils';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import {
+  NooBaaObjectBucketClaimModel,
+  NooBaaObjectBucketModel,
+} from '@console/noobaa-storage-plugin/src/models';
+import { Status } from '@console/shared';
+import { sortable } from '@patternfly/react-table';
+import { obcStatusFilter } from '../../table-filters';
+import { isBound, getOBCPhase } from '../../utils';
+import { menuActionCreator, menuActions } from './menu-actions';
+import { GetSecret } from './secret';
+
+const kind = referenceForModel(NooBaaObjectBucketClaimModel);
+
+export const OBCStatus: React.FC<OBCStatusProps> = ({ obc }) => (
+  <Status status={getOBCPhase(obc)} />
+);
+
+const tableColumnClasses = [
+  classNames('col-lg-3', 'col-md-2', 'col-sm-4', 'col-xs-6'),
+  classNames('col-lg-2', 'col-md-2', 'col-sm-4', 'col-xs-6'),
+  classNames('col-lg-2', 'col-md-2', 'col-sm-4', 'hidden-xs'),
+  classNames('col-lg-2', 'col-md-3', 'hidden-sm', 'hidden-xs'),
+  classNames('col-lg-3', 'col-md-3', 'hidden-sm', 'hidden-xs'),
+  Kebab.columnClass,
+];
+
+const OBCTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Namespace',
+      sortField: 'metadata.namespace',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Status',
+      sortField: 'status.Phase',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: 'Secret',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[3] },
+    },
+    {
+      title: 'Storage Class',
+      sortField: 'spec.storageClassName',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[4] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[5] },
+    },
+  ];
+};
+OBCTableHeader.displayName = 'OBCTableHeader';
+
+const OBCTableRow: React.FC<OBCTableRowProps> = ({ obj, index, key, style }) => {
+  return (
+    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink
+          kind={kind}
+          name={obj.metadata.name}
+          namespace={obj.metadata.namespace}
+          title={obj.metadata.name}
+        />
+      </TableData>
+      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+        <ResourceLink
+          kind="Namespace"
+          name={obj.metadata.namespace}
+          title={obj.metadata.namespace}
+        />
+      </TableData>
+      <TableData className={classNames(tableColumnClasses[2])}>
+        <OBCStatus obc={obj} />
+      </TableData>
+      <TableData className={classNames(tableColumnClasses[3])}>
+        {isBound(obj) ? (
+          <ResourceLink
+            kind="Secret"
+            name={obj.metadata.name}
+            title={obj.metadata.name}
+            namespace={obj.metadata.namespace}
+          />
+        ) : (
+          '-'
+        )}
+      </TableData>
+      <TableData className={tableColumnClasses[4]}>
+        {_.get(obj, 'spec.storageClassName', '-')}
+      </TableData>
+      <TableData className={tableColumnClasses[5]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={obj} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+OBCTableRow.displayName = 'OBCTableRow';
+
+const Details: React.FC<DetailsProps> = ({ obj }) => {
+  const storageClassName = _.get(obj, 'spec.storageClassName');
+  return (
+    <React.Fragment>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Object Bucket Claim Overview" />
+        <div className="row">
+          <div className="col-sm-6">
+            <ResourceSummary resource={obj} />
+            {isBound(obj) && (
+              <React.Fragment>
+                <dt>Secret</dt>
+                <dd>
+                  <ResourceLink
+                    kind="Secret"
+                    name={obj.metadata.name}
+                    title={obj.metadata.name}
+                    namespace={obj.metadata.namespace}
+                  />
+                </dd>
+              </React.Fragment>
+            )}
+          </div>
+          <div className="col-sm-6">
+            <dt>Status</dt>
+            <dd>
+              <OBCStatus obc={obj} />
+            </dd>
+            <dt>Storage Class</dt>
+            <dd>
+              {storageClassName ? (
+                <ResourceLink kind="StorageClass" name={storageClassName} />
+              ) : (
+                '-'
+              )}
+            </dd>
+            {isBound(obj) && (
+              <React.Fragment>
+                <dt>Object Bucket</dt>
+                <dd>
+                  <ResourceLink
+                    kind={referenceForModel(NooBaaObjectBucketModel)}
+                    name={obj.spec.ObjectBucketName}
+                  />
+                </dd>
+              </React.Fragment>
+            )}
+          </div>
+        </div>
+      </div>
+      <GetSecret obj={obj} />
+    </React.Fragment>
+  );
+};
+
+const ObjectBucketClaimsList: React.FC = (props) => (
+  <Table
+    {...props}
+    aria-label="Object Bucket Claims"
+    Header={OBCTableHeader}
+    Row={OBCTableRow}
+    virtualize
+  />
+);
+
+export const ObjectBucketClaimsPage: React.FC = (props) => {
+  const createProps = {
+    to: `${resourcePathFromModel(
+      NooBaaObjectBucketClaimModel,
+      null,
+      _.get(props, 'namespace', 'default'),
+    )}/~new/form`,
+  };
+  return (
+    <ListPage
+      {...props}
+      ListComponent={ObjectBucketClaimsList}
+      kind={referenceForModel(NooBaaObjectBucketClaimModel)}
+      canCreate
+      createProps={createProps}
+      rowFilters={[obcStatusFilter]}
+    />
+  );
+};
+
+export const ObjectBucketClaimsDetailsPage = (props) => (
+  <DetailsPage
+    {...props}
+    menuActions={menuActionCreator}
+    pages={[
+      navFactory.details(Details),
+      navFactory.editYaml(),
+      navFactory.events(ResourceEventStream),
+    ]}
+  />
+);
+
+type OBCStatusProps = {
+  obc: K8sResourceKind;
+};
+
+type OBCTableRowProps = {
+  obj: K8sResourceKind;
+  index: number;
+  key: string;
+  style: object;
+};
+
+type DetailsProps = {
+  obj: K8sResourceKind;
+};

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/secret.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/secret.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Base64 } from 'js-base64';
+import { SecretData } from '@console/internal/components/configmap-and-secret-data';
+import { ConfigMapModel, SecretModel } from '@console/internal/models';
+import { k8sGet, K8sResourceKind } from '@console/internal/module/k8s';
+import { getName, getNamespace } from '@console/shared';
+import { isBound } from '../../utils';
+
+export const GetSecret: React.FC<GetSecretProps> = ({ obj }) => {
+  const secretData = {
+    BUCKET_NAME: Base64.encode(getName(obj)),
+    ACCESS_KEY: Base64.encode('loading..'),
+    SECRET_KEY: Base64.encode('loading..'),
+    ENDPOINT: Base64.encode('http://loading.com'),
+  };
+  if (isBound(obj)) {
+    const secret = k8sGet(SecretModel, getName(obj), getNamespace(obj));
+    const configMap = k8sGet(ConfigMapModel, getName(obj), getNamespace(obj));
+    Promise.all([secret, configMap])
+      .then((data) => {
+        secretData.ACCESS_KEY = Base64.encode(_.get(data[0], 'data.AWS_ACCESS_KEY_ID'));
+        secretData.SECRET_KEY = Base64.encode(_.get(data[0], 'data.AWS_SECRET_ACCESS_KEY'));
+        const endpoint = `${_.get(data[1], 'data.BUCKET_HOST')}:${_.get(
+          data[1],
+          'data.BUCKET_PORT',
+        )}`;
+        secretData.ENDPOINT = Base64.encode(endpoint);
+      })
+      .catch(() => undefined);
+    return (
+      <div className="co-m-pane__body">
+        <SecretData title="Object Bucket Claim Data" data={secretData} />
+      </div>
+    );
+  }
+
+  return null;
+};
+
+type GetSecretProps = {
+  obj: K8sResourceKind;
+};

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-page/create-ob.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-page/create-ob.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+import {
+  ButtonBar,
+  history,
+  resourceObjPath,
+  resourcePathFromModel,
+} from '@console/internal/components/utils';
+import { StorageClassDropdown } from '@console/internal/components/utils/storage-class-dropdown';
+import {
+  apiVersionForModel,
+  k8sCreate,
+  K8sResourceKind,
+  referenceFor,
+} from '@console/internal/module/k8s';
+import { NooBaaObjectBucketModel } from '@console/noobaa-storage-plugin/src/models';
+import { getName } from '@console/shared';
+import { ActionGroup, Button } from '@patternfly/react-core';
+import { commonReducer, defaultState } from './state';
+
+export const CreateOBPage: React.FC = () => {
+  const [state, dispatch] = React.useReducer(commonReducer, defaultState);
+
+  React.useEffect(() => {
+    const obj: K8sResourceKind = {
+      apiVersion: apiVersionForModel(NooBaaObjectBucketModel),
+      kind: NooBaaObjectBucketModel.kind,
+      metadata: {
+        name: state.name,
+      },
+      spec: {
+        ssl: false,
+      },
+    };
+    if (state.scName) {
+      obj.spec.storageClassName = state.scName;
+    }
+    dispatch({ type: 'setPayload', payload: obj });
+  }, [state.name, state.scName]);
+
+  const save = (e: React.FormEvent<EventTarget>) => {
+    e.preventDefault();
+    dispatch({ type: 'setProgress' });
+    k8sCreate(NooBaaObjectBucketModel, state.payload)
+      .then((resource) => {
+        dispatch({ type: 'unsetProgress' });
+        history.push(resourceObjPath(resource, referenceFor(resource)));
+      })
+      .catch((err) => {
+        dispatch({ type: 'setError', message: err.message });
+        dispatch({ type: 'unsetProgress' });
+      });
+  };
+
+  return (
+    <div className="co-m-pane__body co-m-pane__form">
+      <Helmet>
+        <title>Create Object Bucket</title>
+      </Helmet>
+      <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
+        <div className="co-m-pane__name">Create Object Bucket</div>
+        <div className="co-m-pane__heading-link">
+          <Link to={`${resourcePathFromModel(NooBaaObjectBucketModel)}~new`} replace>
+            Edit YAML
+          </Link>
+        </div>
+      </h1>
+      <form className="co-m-pane__body-group" onSubmit={save}>
+        <div>
+          <div className="form-group">
+            <label className="control-label co-required" htmlFor="ob-name">
+              Object Bucket Name
+            </label>
+            <div className="form-group">
+              <input
+                className="pf-c-form-control"
+                type="text"
+                onChange={(e) => {
+                  dispatch({ type: 'setName', name: e.currentTarget.value });
+                }}
+                placeholder="my-object-bucket"
+                aria-describedby="ob-name-help"
+                id="ob-name"
+                name="obName"
+                pattern="[a-z0-9](?:[-a-z0-9]*[a-z0-9])?"
+                required
+              />
+              <p className="help-block" id="ob-name-help">
+                If not provided, a generic name will be generated.
+              </p>
+            </div>
+            <div className="form-group">
+              <StorageClassDropdown
+                onChange={(sc) => dispatch({ type: 'setStorage', name: getName(sc) })}
+                required
+                name="storageClass"
+              />
+              <p className="help-block">
+                Defines the object-store service and the bucket provisioner.
+              </p>
+            </div>
+          </div>
+        </div>
+        <ButtonBar errorMessage={state.error} inProgress={state.progress}>
+          <ActionGroup className="pf-c-form">
+            <Button type="submit" variant="primary">
+              Create
+            </Button>
+            <Button onClick={history.goBack} type="button" variant="secondary">
+              Cancel
+            </Button>
+          </ActionGroup>
+        </ButtonBar>
+      </form>
+    </div>
+  );
+};

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-page/object-bucket.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-page/object-bucket.tsx
@@ -1,0 +1,183 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import * as classNames from 'classnames';
+import { Status } from '@console/shared';
+import {
+  DetailsPage,
+  ListPage,
+  Table,
+  TableData,
+  TableRow,
+} from '@console/internal/components/factory';
+import {
+  Kebab,
+  navFactory,
+  ResourceKebab,
+  ResourceLink,
+  ResourceSummary,
+  SectionHeading,
+} from '@console/internal/components/utils';
+import { ResourceEventStream } from '@console/internal/components/events';
+import {
+  NooBaaObjectBucketClaimModel,
+  NooBaaObjectBucketModel,
+} from '@console/noobaa-storage-plugin/src/models';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import { sortable } from '@patternfly/react-table';
+import { getOBPhase } from '../../utils';
+import { obStatusFilter } from '../../table-filters';
+
+const kind = referenceForModel(NooBaaObjectBucketModel);
+const menuActions = [...Kebab.factory.common];
+
+const OBStatus: React.FC<OBStatusProps> = ({ ob }) => <Status status={getOBPhase(ob)} />;
+
+const tableColumnClasses = [
+  classNames('col-lg-4', 'col-md-4', 'col-sm-6', 'col-xs-6'),
+  classNames('col-lg-3', 'col-md-3', 'col-sm-6', 'hidden-xs'),
+  classNames('col-lg-4', 'col-md-4', 'hidden-sm', 'hidden-xs'),
+  Kebab.columnClass,
+];
+
+const OBTableHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[0] },
+    },
+    {
+      title: 'Status',
+      sortField: 'status.phase',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[1] },
+    },
+    {
+      title: 'Storage Class',
+      sortField: 'spec.storageClassName',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[2] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
+  ];
+};
+OBTableHeader.displayName = 'OBTableHeader';
+
+const OBTableRow: React.FC<OBTableRowProps> = ({ obj, index, key, style }) => {
+  return (
+    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink
+          kind={kind}
+          name={obj.metadata.name}
+          namespace={obj.metadata.namespace}
+          title={obj.metadata.name}
+        />
+      </TableData>
+      <TableData className={classNames(tableColumnClasses[1])}>
+        <OBStatus ob={obj} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        {_.get(obj, 'spec.storageClassName', '-')}
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <ResourceKebab actions={menuActions} kind={kind} resource={obj} />
+      </TableData>
+    </TableRow>
+  );
+};
+OBTableRow.displayName = 'OBTableRow';
+
+const Details: React.FC<DetailsProps> = ({ obj }) => {
+  const storageClassName = _.get(obj, 'spec.storageClassName');
+  const [OBCName, OBCNamespace] = [
+    _.get(obj, 'spec.claimRef.name'),
+    _.get(obj, 'spec.claimRef.namespace'),
+  ];
+  return (
+    <React.Fragment>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Object Bucket Overview" />
+        <div className="row">
+          <div className="col-sm-6">
+            <ResourceSummary resource={obj} />
+          </div>
+          <div className="col-sm-6">
+            <dl>
+              <dt>Status</dt>
+              <dd>
+                <OBStatus ob={obj} />
+              </dd>
+              <dt>Storage Class</dt>
+              <dd>
+                {storageClassName ? (
+                  <ResourceLink kind="StorageClass" name={storageClassName} />
+                ) : (
+                  '-'
+                )}
+              </dd>
+              <dt>Object Bucket Claim</dt>
+              <dd>
+                <ResourceLink
+                  kind={referenceForModel(NooBaaObjectBucketClaimModel)}
+                  name={OBCName}
+                  namespace={OBCNamespace}
+                />
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </React.Fragment>
+  );
+};
+
+const ObjectBucketsList: React.FC = (props) => (
+  <Table
+    {...props}
+    aria-label="Object Buckets"
+    Header={OBTableHeader}
+    Row={OBTableRow}
+    virtualize
+  />
+);
+
+export const ObjectBucketsPage: React.FC = (props) => (
+  <ListPage
+    {...props}
+    ListComponent={ObjectBucketsList}
+    kind={kind}
+    rowFilters={[obStatusFilter]}
+  />
+);
+
+export const ObjectBucketDetailsPage = (props) => (
+  <DetailsPage
+    {...props}
+    menuActions={menuActions}
+    pages={[
+      navFactory.details(Details),
+      navFactory.editYaml(),
+      navFactory.events(ResourceEventStream),
+    ]}
+  />
+);
+
+type OBStatusProps = {
+  ob: K8sResourceKind;
+};
+
+type OBTableRowProps = {
+  obj: K8sResourceKind;
+  index: number;
+  key: string;
+  style: object;
+};
+
+type DetailsProps = {
+  obj: K8sResourceKind;
+};

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-page/state.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-page/state.ts
@@ -1,0 +1,51 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+type State = {
+  name: string;
+  scName: string;
+  sizeValue: string;
+  sizeUnit: string;
+  progress: boolean;
+  error: string;
+  payload: K8sResourceKind;
+};
+
+export const defaultState = {
+  name: '',
+  scName: '',
+  progress: false,
+  error: '',
+  payload: {},
+  sizeUnit: 'GiB',
+  sizeValue: '',
+};
+
+type Action =
+  | { type: 'setName'; name: string }
+  | { type: 'setStorage'; name: string }
+  | { type: 'setProgress' }
+  | { type: 'unsetProgress' }
+  | { type: 'setError'; message: string }
+  | { type: 'setPayload'; payload: {} }
+  | { type: 'setSize'; unit: string; value: string };
+
+export const commonReducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'setName':
+      return Object.assign({}, state, { name: action.name });
+    case 'setStorage':
+      return Object.assign({}, state, { scName: action.name });
+    case 'setProgress':
+      return Object.assign({}, state, { progress: true });
+    case 'unsetProgress':
+      return Object.assign({}, state, { progress: false });
+    case 'setError':
+      return Object.assign({}, state, { error: action.message });
+    case 'setSize':
+      return Object.assign({}, state, { sizeUnit: action.unit, sizeValue: action.value });
+    case 'setPayload':
+      return Object.assign({}, state, { payload: action.payload });
+    default:
+      return defaultState;
+  }
+};

--- a/frontend/packages/noobaa-storage-plugin/src/models.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/models.ts
@@ -45,9 +45,22 @@ export const NooBaaObjectBucketClaimModel: K8sKind = {
   apiVersion: 'v1alpha1',
   apiGroup: 'objectbucket.io',
   plural: 'objectbucketclaims',
-  abbr: 'NOBC',
+  abbr: 'OBC',
   namespaced: true,
   kind: 'ObjectBucketClaim',
-  id: 'noobaaobjectbucketclaims',
+  id: 'objectbucketclaims',
+  crd: true,
+};
+
+export const NooBaaObjectBucketModel: K8sKind = {
+  label: 'Object Bucket',
+  labelPlural: 'Object Buckets',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'objectbucket.io',
+  plural: 'objectbuckets',
+  abbr: 'OB',
+  namespaced: false,
+  kind: 'ObjectBucket',
+  id: 'objectbucket',
   crd: true,
 };

--- a/frontend/packages/noobaa-storage-plugin/src/plugin.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/plugin.ts
@@ -5,11 +5,28 @@ import {
   ModelDefinition,
   ModelFeatureFlag,
   Plugin,
+  ResourceClusterNavItem,
+  ResourceDetailsPage,
+  ResourceListPage,
+  ResourceNSNavItem,
+  RoutePage,
+  YAMLTemplate,
 } from '@console/plugin-sdk';
 import { GridPosition } from '@console/internal/components/dashboard/grid';
+import { referenceForModel } from '@console/internal/module/k8s';
 import * as models from './models';
 
-type ConsumedExtensions = ModelFeatureFlag | ModelDefinition | DashboardsTab | DashboardsCard;
+type ConsumedExtensions =
+  | ModelFeatureFlag
+  | ModelDefinition
+  | DashboardsTab
+  | DashboardsCard
+  | ResourceNSNavItem
+  | ResourceClusterNavItem
+  | ResourceListPage
+  | ResourceDetailsPage
+  | YAMLTemplate
+  | RoutePage;
 
 const NOOBAA_FLAG = 'NOOBAA';
 
@@ -129,6 +146,78 @@ const plugin: Plugin<ConsumedExtensions> = [
           './components/object-data-reduction-card/object-data-reduction-card' /* webpackChunkName: "object-service-data-reduction-card" */
         ).then((m) => m.default),
       required: NOOBAA_FLAG,
+    },
+  },
+  {
+    type: 'NavItem/ResourceCluster',
+    properties: {
+      section: 'Storage',
+      componentProps: {
+        name: 'Object Buckets',
+        resource: models.NooBaaObjectBucketModel.plural,
+        required: NOOBAA_FLAG,
+      },
+    },
+  },
+  {
+    type: 'Page/Resource/List',
+    properties: {
+      model: models.NooBaaObjectBucketModel,
+      loader: () =>
+        import(
+          './components/object-bucket-page/object-bucket' /* webpackChunkName: "object-bucket-page" */
+        ).then((m) => m.ObjectBucketsPage),
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: models.NooBaaObjectBucketModel,
+      loader: () =>
+        import(
+          './components/object-bucket-page/object-bucket' /* webpackChunkName: "object-bucket-page" */
+        ).then((m) => m.ObjectBucketDetailsPage),
+    },
+  },
+  {
+    type: 'NavItem/ResourceNS',
+    properties: {
+      section: 'Storage',
+      componentProps: {
+        name: 'Object Bucket Claims',
+        resource: models.NooBaaObjectBucketClaimModel.plural,
+        required: NOOBAA_FLAG,
+      },
+    },
+  },
+  {
+    type: 'Page/Resource/List',
+    properties: {
+      model: models.NooBaaObjectBucketClaimModel,
+      loader: () =>
+        import(
+          './components/object-bucket-claim-page/object-bucket-claim' /* webpackChunkName: "object-bucket-claim-page" */
+        ).then((m) => m.ObjectBucketClaimsPage),
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: models.NooBaaObjectBucketClaimModel,
+      loader: () =>
+        import(
+          './components/object-bucket-claim-page/object-bucket-claim' /* webpackChunkName: "object-bucket-claim-page" */
+        ).then((m) => m.ObjectBucketClaimsDetailsPage),
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      path: `/k8s/ns/:ns/${referenceForModel(models.NooBaaObjectBucketClaimModel)}/~new/form`,
+      loader: () =>
+        import(
+          './components/object-bucket-claim-page/create-obc' /* webpackChunkName: "create-obc" */
+        ).then((m) => m.CreateOBCPage),
     },
   },
 ];

--- a/frontend/packages/noobaa-storage-plugin/src/table-filters.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/table-filters.ts
@@ -1,0 +1,39 @@
+import * as _ from 'lodash';
+import { Filter } from '@console/shared';
+import { getOBPhase, getOBCPhase } from './utils';
+
+const allPhases = ['Pending', 'Bound', 'Lost'];
+
+export const obcStatusFilter: Filter = {
+  type: 'obc-status',
+  selected: allPhases,
+  reducer: getOBCPhase,
+  items: _.map(allPhases, (phase) => ({
+    id: phase,
+    title: phase,
+  })),
+  filter: (phases, obc) => {
+    if (!phases || !phases.selected) {
+      return true;
+    }
+    const phase = getOBCPhase(obc);
+    return phases.selected.has(phase) || !_.includes(phases.all, phase);
+  },
+};
+
+export const obStatusFilter: Filter = {
+  type: 'ob-status',
+  selected: allPhases,
+  reducer: getOBPhase,
+  items: _.map(allPhases, (phase) => ({
+    id: phase,
+    title: phase,
+  })),
+  filter: (phases, ob) => {
+    if (!phases || !phases.selected) {
+      return true;
+    }
+    const phase = getOBPhase(ob);
+    return phases.selected.has(phase) || !_.includes(phases.all, phase);
+  },
+};

--- a/frontend/packages/noobaa-storage-plugin/src/utils.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/utils.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { Alert } from '@console/internal/components/monitoring';
 import { PrometheusResponse } from '@console/internal/components/graphs';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 
 export const filterNooBaaAlerts = (alerts: Alert[]): Alert[] =>
   alerts.filter((alert) => _.get(alert, 'annotations.storage_type') === 'NooBaa');
@@ -15,4 +16,17 @@ export const getValue = (result: PrometheusMetricResult): number => _.get(result
 export type PrometheusMetricResult = {
   metric: { [key: string]: any };
   value?: [number, string | number];
+};
+
+export const getOBCPhase = (obc: K8sResourceKind): string => {
+  const phase: string = _.get(obc, 'status.Phase');
+  return phase ? phase.charAt(0).toUpperCase() + phase.substring(1) : 'Lost';
+};
+
+/** NooBaa issue currently no status is shown  */
+export const isBound = (obc: K8sResourceKind): boolean => getOBCPhase(obc) === 'Bound';
+
+export const getOBPhase = (ob: K8sResourceKind): string => {
+  const phase: string = _.get(ob, 'status.phase');
+  return phase ? phase.charAt(0).toUpperCase() + phase.substring(1) : 'Lost';
 };

--- a/frontend/public/components/configmap-and-secret-data.tsx
+++ b/frontend/public/components/configmap-and-secret-data.tsx
@@ -74,7 +74,7 @@ export const SecretValue: React.FC<SecretValueProps> = ({ value, reveal, encoded
 };
 SecretValue.displayName = 'SecretValue';
 
-export const SecretData: React.FC<SecretDataProps> = ({ data }) => {
+export const SecretData: React.FC<SecretDataProps> = ({ data, title = 'Data' }) => {
   const [reveal, setReveal] = React.useState(false);
 
   const dl = [];
@@ -91,7 +91,7 @@ export const SecretData: React.FC<SecretDataProps> = ({ data }) => {
 
   return (
     <React.Fragment>
-      <SectionHeading text="Data">
+      <SectionHeading text={title}>
         {dl.length ? (
           <button className="btn btn-link" type="button" onClick={() => setReveal(!reveal)}>
             {reveal ? (
@@ -135,4 +135,5 @@ type SecretValueProps = {
 
 type SecretDataProps = {
   data: KeyValueData;
+  title?: string;
 };


### PR DESCRIPTION
Implementation of the following design: http://openshift.github.io/openshift-origin-design/web-console/Storage/OB-OB-Lifecycle-Management/OB-OBC-Lifecycle

Features:
- [x] Details Page OB/C
- [x] List Page OB/C
- [x] Creation of OB/C
- [x] Delete OB/C
- [x] Secret OBC
- [x] Attach Pod Modal
- [x] Confirm Delete Modal
- [x] Endpoint OBC

Screenshots:
1)OBC List Page
![obc list](https://user-images.githubusercontent.com/54092533/65421013-40dc2600-de20-11e9-8182-cb726c21e68b.png)
2) OB List Page
![ob list](https://user-images.githubusercontent.com/54092533/65421497-7d5c5180-de21-11e9-8e23-a01223d58792.png)
2) OBC Details Page
![obc details](https://user-images.githubusercontent.com/54092533/65421024-489bca80-de20-11e9-8462-bb6209485013.png)
3) Create OB
![create ob](https://user-images.githubusercontent.com/54092533/65421036-505b6f00-de20-11e9-8541-95531b792a64.png)
4) Create OBC
![Screenshot from 2019-09-23 16-29-53](https://user-images.githubusercontent.com/54092533/65421094-81d43a80-de20-11e9-9188-b86cdb19635e.png)
5) Attach Deployment
![attach dep](https://user-images.githubusercontent.com/54092533/65421062-623d1200-de20-11e9-86a0-81ada3f669e4.png)
6) Result for Deployment
![Screenshot from 2019-09-23 16-41-57](https://user-images.githubusercontent.com/54092533/65421378-2ce4f400-de21-11e9-8b27-1d9c6276fb83.png)
