### PR TITLE
Bug 1748559:Data point labels in chart in Top Consumers panel of Persistent Storage lacks timestamps fix

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/top-consumers-card/top-consumers-card-body.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/top-consumers-card/top-consumers-card-body.tsx
@@ -61,7 +61,9 @@ export const TopConsumersBody: React.FC<TopConsumerBodyProps> = React.memo(
             padding={{ top: 20, bottom: 20, left: 40, right: 20 }}
             containerComponent={
               <ChartVoronoiContainer
-                labels={(datum) => `${datum.y} ${maxCapacityConverted.unit}`}
+                labels={(datum) =>
+                  `${datum.y} ${maxCapacityConverted.unit} at ${twentyFourHourTime(datum.x)}`
+                }
                 labelComponent={<ChartTooltip style={{ fontSize: 8, padding: 5 }} />}
               />
             }


### PR DESCRIPTION
Bugfix to add the timestamp in the top consumer card in the Ceph dashboard.