### PR TITLE
vendor.scss: add patternfly/dropdowns scss

### DIFF
--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -29,9 +29,11 @@
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/utilities";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/responsive-utilities";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/popovers";
+@import "~bootstrap-sass/assets/stylesheets/bootstrap/dropdowns"; // required by @patternfly/react-console
 @import "~patternfly/dist/sass/patternfly/mixins";  // Including this file breaks sourcemaps
 @import '~patternfly/dist/sass/patternfly/type';
 @import '~patternfly/dist/sass/patternfly/buttons';
+@import '~patternfly/dist/sass/patternfly/dropdowns'; // required by @patternfly/react-console
 @import '~patternfly/dist/sass/patternfly/breadcrumbs';
 @import '~patternfly/dist/sass/patternfly/hint-block';
 @import '~patternfly/dist/sass/patternfly/modals';


### PR DESCRIPTION
PF3/Bootstrap 3 Dropdowns are still used.

Partially reverting https://github.com/openshift/console/commit/79158bdc284e8ef295997d7a33ab6445aea06a46