### PR TITLE
Restore Bootstrap 3 / PatternFly 3 dropdown SCSS

### DIFF
--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -18,6 +18,7 @@
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/forms";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/buttons";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/component-animations";
+@import "~bootstrap-sass/assets/stylesheets/bootstrap/dropdowns"; // required by @patternfly/react-console
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/button-groups";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/input-groups";
 @import "~bootstrap-sass/assets/stylesheets/bootstrap/breadcrumbs";
@@ -32,6 +33,7 @@
 @import "~patternfly/dist/sass/patternfly/mixins";  // Including this file breaks sourcemaps
 @import '~patternfly/dist/sass/patternfly/type';
 @import '~patternfly/dist/sass/patternfly/buttons';
+@import '~patternfly/dist/sass/patternfly/dropdowns';  // required by @patternfly/react-console
 @import '~patternfly/dist/sass/patternfly/breadcrumbs';
 @import '~patternfly/dist/sass/patternfly/hint-block';
 @import '~patternfly/dist/sass/patternfly/modals';


### PR DESCRIPTION
as @patternfly/react-console requires it

cc: @mareklibra 