### PR TITLE
Use `networking.k8s.io` API group for ingress

### DIFF
--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -435,7 +435,7 @@ export const ProjectRequestModel: K8sKind = {
 export const IngressModel: K8sKind = {
   label: 'Ingress',
   labelPlural: 'Ingresses',
-  apiGroup: 'extensions',
+  apiGroup: 'networking.k8s.io',
   apiVersion: 'v1beta1',
   plural: 'ingresses',
   abbr: 'I',

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -303,7 +303,7 @@ spec:
       ports:
         - containerPort: 8080
 `).setIn([referenceForModel(k8sModels.IngressModel), 'default'], `
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: example


### PR DESCRIPTION
`extensions.k8s.io` will be deprecated in 1.18. The API is otherwise the same.

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

/hold
for 4.3

/assign @rhamilto 
cc @jwforres 