### PR TITLE
Fix broken OLM documentation link

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/clusterserviceversion.tsx
@@ -228,7 +228,7 @@ export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps
 export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProps> = (props) => {
   const title = 'Installed Operators';
   const helpText = <p className="co-help-text">
-    Installed Operators are represented by Cluster Service Versions within this namespace. For more information, see the <ExternalLink href="https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/architecture.md" text="Operator Lifecycle Manager documentation" />. Or create an Operator and Cluster Service Version using the <ExternalLink href="https://github.com/operator-framework/operator-sdk" text="Operator SDK" />.
+    Installed Operators are represented by Cluster Service Versions within this namespace. For more information, see the <ExternalLink href="https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/architecture.md" text="Operator Lifecycle Manager documentation" />. Or create an Operator and Cluster Service Version using the <ExternalLink href="https://github.com/operator-framework/operator-sdk" text="Operator SDK" />.
   </p>;
 
   return <React.Fragment>


### PR DESCRIPTION
This changes the "Operator Lifecycle Manager documentation" link seen here:

![image](https://user-images.githubusercontent.com/9122899/65007280-a3d73580-d8d3-11e9-9ea3-a504833c853f.png)

From [this broken URL](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/architecture.md) to [this fixed one](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/architecture.md) instead.

I think this is the only URL that was affected by [this recent `operator-framework` commit](https://github.com/operator-framework/operator-lifecycle-manager/commit/1cb06815e85e881fcf700d4eef461b38c5eabf99#diff-caef5734d18b659e5fd25ba8c2de063a).