### PR TITLE
Bug 1751178: Added check for specDescriptors

### DIFF
--- a/frontend/public/components/operator-lifecycle-manager/create-operand.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/create-operand.tsx
@@ -162,7 +162,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
 
       return {...field, capabilities, type, required, validation};
     })
-    .concat(fieldsForOpenAPI(props.openAPI).filter(crdField => !props.providedAPI.specDescriptors.some(d => d.path === crdField.path)))
+    .concat(fieldsForOpenAPI(props.openAPI).filter(crdField => props.providedAPI.specDescriptors && !props.providedAPI.specDescriptors.some(d => d.path === crdField.path)))
     // Associate `specDescriptors` with `fieldGroups` from OpenAPI
     .map((field, i, allFields) => allFields.some(f => f.capabilities.includes(SpecCapability.fieldGroup.concat(field.path.split('.')[0]) as SpecCapability.fieldGroup))
       ? {...field, capabilities: [...new Set(field.capabilities).add(SpecCapability.fieldGroup.concat(field.path.split('.')[0]) as SpecCapability.fieldGroup)]}


### PR DESCRIPTION
For ceph cluster, Noobaa and Backing Store, `providedAPI.specDescriptors` is not coming in the props, hence breaking the `Edit form` link present on create flow for respective instances. 
More details can be found at - https://bugzilla.redhat.com/show_bug.cgi?id=1751178.

@alecmerdler @spadgett Please review