### PR TITLE
update serverless to the v1beta1 version

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologySideBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologySideBar.tsx
@@ -11,6 +11,11 @@ import {
   ServiceModel,
   BuildConfigModel,
 } from '@console/internal/models';
+import {
+  ConfigurationModel,
+  RouteModel as ServerlessRouteModel,
+  RevisionModel,
+} from '@console/knative-plugin';
 import { ResourceProps } from '@console/shared';
 import { TopologyDataObject } from './topology-types';
 
@@ -63,21 +68,22 @@ const TopologySideBar: React.FC<TopologySideBarProps> = ({ item, show, onClose }
     const ksroutes = metadataUIDCheck(
       item.resources.filter(
         (o) =>
-          o.kind === 'Route' && o.apiVersion && o.apiVersion === 'serving.knative.dev/v1alpha1',
+          o.kind === ServerlessRouteModel.kind &&
+          o.apiVersion === `${ServerlessRouteModel.apiGroup}/${ServerlessRouteModel.apiVersion}`,
       ),
     );
     const configurations = metadataUIDCheck(
       item.resources.filter(
         (o) =>
-          o.kind === 'Configuration' &&
-          o.apiVersion &&
-          o.apiVersion === 'serving.knative.dev/v1alpha1',
+          o.kind === ConfigurationModel.kind &&
+          o.apiVersion === `${ConfigurationModel.apiGroup}/${ConfigurationModel.apiVersion}`,
       ),
     );
     const revisions = metadataUIDCheck(
       item.resources.filter(
         (o) =>
-          o.kind === 'Revision' && o.apiVersion && o.apiVersion === 'serving.knative.dev/v1alpha1',
+          o.kind === RevisionModel.kind &&
+          o.apiVersion === `${RevisionModel.apiGroup}/${RevisionModel.apiVersion}`,
       ),
     );
     if (configurations.length) {

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
@@ -1,4 +1,10 @@
 import { Resource } from '@console/shared';
+import {
+  ConfigurationModel,
+  RouteModel,
+  RevisionModel,
+  ServiceModel,
+} from '@console/knative-plugin';
 import { TopologyDataResources } from '../topology-types';
 
 export const sampleKnativeDeployments = {
@@ -27,8 +33,8 @@ export const sampleKnativeDeployments = {
         },
         ownerReferences: [
           {
-            apiVersion: 'serving.knative.dev/v1alpha1',
-            kind: 'Revision',
+            apiVersion: `${RevisionModel.apiGroup}/${RevisionModel.apiVersion}`,
+            kind: RevisionModel.kind,
             name: 'overlayimage-fdqsf',
             uid: '02c34a0e-9638-11e9-b134-06a61d886b62',
             controller: true,
@@ -150,8 +156,8 @@ const sampleKnativeBuilds: Resource = {
 const sampleKnativeConfigurations: Resource = {
   data: [
     {
-      apiVersion: 'serving.knative.dev/v1alpha1',
-      kind: 'Configuration',
+      apiVersion: `${ConfigurationModel.apiGroup}/${ConfigurationModel.apiVersion}`,
+      kind: ConfigurationModel.kind,
       metadata: {
         name: 'overlayimage',
         namespace: 'testproject3',
@@ -176,8 +182,8 @@ const sampleKnativeConfigurations: Resource = {
 const sampleKnativeRevisions: Resource = {
   data: [
     {
-      apiVersion: 'serving.knative.dev/v1alpha1',
-      kind: 'Revision',
+      apiVersion: `${RevisionModel.apiGroup}/${RevisionModel.apiVersion}`,
+      kind: RevisionModel.kind,
       metadata: {
         name: 'overlayimage-fdqsf',
         namespace: 'testproject3',
@@ -203,8 +209,8 @@ const sampleKnativeRevisions: Resource = {
 export const sampleKnativeRoutes = {
   data: [
     {
-      apiVersion: 'serving.knative.dev/v1alpha1',
-      kind: 'Service',
+      apiVersion: `${RouteModel.apiGroup}/${RouteModel.apiVersion}`,
+      kind: RouteModel.kind,
       metadata: {
         name: 'overlayimage',
         namespace: 'testproject3',
@@ -229,8 +235,8 @@ export const sampleKnativeRoutes = {
 export const sampleKnativeServices: Resource = {
   data: [
     {
-      apiVersion: 'serving.knative.dev/v1alpha1',
-      kind: 'Service',
+      apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+      kind: ServiceModel.kind,
       metadata: {
         name: 'overlayimage',
         namespace: 'testproject3',
@@ -265,8 +271,8 @@ export const sampleServices: Resource = {
         },
         ownerReferences: [
           {
-            apiVersion: 'serving.knative.dev/v1alpha1',
-            kind: 'Route',
+            apiVersion: `${RouteModel.apiGroup}/${RouteModel.apiVersion}`,
+            kind: RouteModel.kind,
             name: 'overlayimage',
             uid: 'bca0d598-8ce0-11e9-bb7b-0ebb55b110b8',
             controller: true,
@@ -304,7 +310,7 @@ export const sampleServices: Resource = {
         },
         ownerReferences: [
           {
-            apiVersion: 'networking.internal.knative.dev/v1alpha1',
+            apiVersion: `networking.internal.knative.dev/${ServiceModel.apiVersion}`,
             kind: 'ServerlessService',
             name: 'overlayimage-9jsl8',
             uid: 'bcf5bfcf-8ce0-11e9-9020-0ab4b49bd478',

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import { getPodStatus, podStatus } from '@console/shared';
+import { ConfigurationModel, RevisionModel } from '@console/knative-plugin';
 import { WorkloadData, TopologyDataResources } from '../topology-types';
 import { TransformTopologyData, getEditURL } from '../topology-utils';
 import { resources, topologyData, MockResources } from './topology-test-data';
@@ -183,10 +184,8 @@ describe('TopologyUtils ', () => {
     ]);
     const revRes = topologyTransformedData[keys[0]].resources.filter(
       (item) =>
-        item.kind &&
-        item.kind === 'Revision' &&
-        item.apiVersion &&
-        item.apiVersion === 'serving.knative.dev/v1alpha1',
+        item.kind === RevisionModel.kind &&
+        item.apiVersion === `${RevisionModel.apiGroup}/${RevisionModel.apiVersion}`,
     );
     expect(revRes.length).toEqual(1);
   });
@@ -198,10 +197,8 @@ describe('TopologyUtils ', () => {
     ]);
     const configRes = topologyTransformedData[keys[0]].resources.filter(
       (item) =>
-        item.kind &&
-        item.kind === 'Configuration' &&
-        item.apiVersion &&
-        item.apiVersion === 'serving.knative.dev/v1alpha1',
+        item.kind === ConfigurationModel.kind &&
+        item.apiVersion === `${ConfigurationModel.apiGroup}/${ConfigurationModel.apiVersion}`,
     );
     expect(configRes).toHaveLength(1);
   });

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -1,8 +1,10 @@
 import { K8sKind } from '@console/internal/module/k8s';
 
+const apiVersion = `v1beta1`;
+
 export const ConfigurationModel: K8sKind = {
   apiGroup: 'serving.knative.dev',
-  apiVersion: 'v1alpha1',
+  apiVersion,
   kind: 'Configuration',
   plural: 'configurations',
   label: 'Configuration',
@@ -28,7 +30,7 @@ export const KnativeServingModel: K8sKind = {
 
 export const RevisionModel: K8sKind = {
   apiGroup: 'serving.knative.dev',
-  apiVersion: 'v1alpha1',
+  apiVersion,
   kind: 'Revision',
   label: 'Revision',
   labelPlural: 'Revisions',
@@ -41,7 +43,7 @@ export const RevisionModel: K8sKind = {
 
 export const RouteModel: K8sKind = {
   apiGroup: 'serving.knative.dev',
-  apiVersion: 'v1alpha1',
+  apiVersion,
   kind: 'Route',
   label: 'Route',
   labelPlural: 'Routes',
@@ -54,7 +56,7 @@ export const RouteModel: K8sKind = {
 
 export const ServiceModel: K8sKind = {
   apiGroup: 'serving.knative.dev',
-  apiVersion: 'v1alpha1',
+  apiVersion,
   kind: 'Service',
   label: 'Service',
   labelPlural: 'Services',

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -59,8 +59,8 @@ export const createKnativeService = (
   const defaultLabel = getAppLabels(name, applicationName, imageStreamName, imageTag);
   delete defaultLabel.app;
   const knativeDeployResource: K8sResourceKind = {
-    kind: 'Service',
-    apiVersion: 'serving.knative.dev/v1alpha1',
+    kind: ServiceModel.kind,
+    apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
     metadata: {
       name,
       namespace,


### PR DESCRIPTION
This is just an update to use the Beta version of the operator. 

This requires that the new RH `Serverless Operator` is installed. 

Fixes the bug https://jira.coreos.com/browse/ODC-1517 