### PR TITLE
 Bug 1752829: select nodes labeling info fixed

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
@@ -24,9 +24,12 @@ export const CreateOCSServiceForm: React.FC<CreateOCSServiceFormProps> = (props)
         <div className="form-group co-create-route__name">
           <label htmlFor="select-node-help">Select Nodes</label>
           <p className="co-m-pane__explanation">
-            A minimum of 3 nodes needs to be labeled with{' '}
-            <code>cluster.ocs.openshift.io/openshift-storage=&quot;&quot;</code> in order to create
-            the OCS Service.
+            Selected nodes will be labeled with
+            <code>cluster.ocs.openshift.io/openshift-storage=&quot;&quot;</code> to create the OCS
+            Service. These nodes will also be tainted with
+            <code>node.ocs.openshift.io/storage=true:NoSchedule</code> to dedicate these nodes to
+            allow only OCS components to be scheduled on them. Note: Ensure you have additional
+            worker nodes that are not tainted to run other workloads in your OpenShift cluster.
           </p>
           <Alert
             className="co-alert"


### PR DESCRIPTION
This PR updates the explanation under the select node's label in the create OCS service form. Since the selected nodes will be labeled with `cluster.ocs.openshift.io/openshift-storage=""` we are letting the users know about these changes in the nodes. These nodes will also be tainted with `node.ocs.openshift.io/storage=true:NoSchedule`. However, since the previous explanation was ambiguous the updated statement lets the user know that these taints have been added to schedule only OCS components and nothing else. It also lets the user know that they should have other additional nodes that are not tainted so that there are nodes where the other workloads can be scheduled.

Screenshot:
![Screenshot from 2019-09-18 11-49-55](https://user-images.githubusercontent.com/54092533/65119985-94a6d380-da0a-11e9-8beb-36d8b6170e4e.png)
