### PR TITLE
Bug 1753018: Fix Update Strategy Modal

### DIFF
--- a/frontend/__tests__/components/modals/configure-update-strategy-modal.spec.tsx
+++ b/frontend/__tests__/components/modals/configure-update-strategy-modal.spec.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import Spy = jasmine.Spy;
+
+import { ConfigureUpdateStrategy, ConfigureUpdateStrategyProps } from '@console/internal/components/modals/configure-update-strategy-modal';
+import { RadioInput } from '@console/internal/components/radio';
+
+describe(ConfigureUpdateStrategy.displayName, () => {
+  let wrapper: ShallowWrapper<ConfigureUpdateStrategyProps>;
+  let onChangeStrategyType: Spy;
+  let onChangeMaxSurge: Spy;
+  let onChangeMaxUnavailable: Spy;
+
+  beforeEach(() => {
+    onChangeStrategyType = jasmine.createSpy('onChangeStrategyType');
+    onChangeMaxSurge = jasmine.createSpy('onChangeMaxSurge');
+    onChangeMaxUnavailable = jasmine.createSpy('onChangeMaxUnavailable');
+
+    wrapper = shallow(<ConfigureUpdateStrategy onChangeStrategyType={onChangeStrategyType} onChangeMaxSurge={onChangeMaxSurge} onChangeMaxUnavailable={onChangeMaxUnavailable} strategyType="Recreate" maxSurge={null} maxUnavailable={null} />);
+  });
+
+  it('renders two choices for different update strategy types', () => {
+    expect(wrapper.find(RadioInput).at(0).props().value).toEqual('RollingUpdate');
+    expect(wrapper.find(RadioInput).at(1).props().value).toEqual('Recreate');
+    expect(wrapper.find(RadioInput).at(1).props().checked).toBe(true);
+  });
+
+  it('is a controlled component', () => {
+    wrapper.find(RadioInput).at(0).dive().find('input[type="radio"]').simulate('change', {target: {value: 'RollingUpdate'}});
+    wrapper.find('#input-max-unavailable').simulate('change', {target: {value: '25%'}});
+    wrapper.find('#input-max-surge').simulate('change', {target: {value: '50%'}});
+
+    expect(onChangeStrategyType.calls.argsFor(0)[0]).toEqual('RollingUpdate');
+    expect(onChangeMaxUnavailable.calls.argsFor(0)[0]).toEqual('25%');
+    expect(onChangeMaxSurge.calls.argsFor(0)[0]).toEqual('50%');
+  });
+});

--- a/frontend/public/components/modals/configure-update-strategy-modal.tsx
+++ b/frontend/public/components/modals/configure-update-strategy-modal.tsx
@@ -53,7 +53,8 @@ export const ConfigureUpdateStrategy: React.FC<ConfigureUpdateStrategyProps> = (
                     <input disabled={props.strategyType !== 'RollingUpdate'}
                       placeholder="25%" size={5} type="text" className="pf-c-form-control"
                       id="input-max-unavailable"
-                      defaultValue={props.maxUnavailable as string}
+                      value={props.maxUnavailable}
+                      onChange={e => props.onChangeMaxUnavailable(e.target.value)}
                       aria-describedby="input-max-unavailable-help" />
                     { props.replicas && <span className="pf-c-input-group__text">
                       <Tooltip content="Current desired pod count"><span>of { pluralize(props.replicas, 'pod')}</span></Tooltip>
@@ -77,7 +78,8 @@ export const ConfigureUpdateStrategy: React.FC<ConfigureUpdateStrategyProps> = (
                       type="text"
                       className="pf-c-form-control"
                       id="input-max-surge"
-                      defaultValue={props.maxSurge as string}
+                      value={props.maxSurge}
+                      onChange={e => props.onChangeMaxSurge(e.target.value)}
                       aria-describedby="input-max-surge-help" />
                     <span className="pf-c-input-group__text">
                       <Tooltip content="Current desired pod count"><span>greater than { pluralize(props.replicas, 'pod')}</span></Tooltip>

--- a/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
+++ b/frontend/public/components/operator-lifecycle-manager/descriptors/spec/index.tsx
@@ -89,6 +89,8 @@ const Secret: React.FC<SpecCapabilityProps> = (props) => {
   </React.Fragment>;
 };
 
+const UpdateStrategy: React.FC<SpecCapabilityProps> = (props) => <div>{_.get(props.value, 'type', 'None')}</div>;
+
 const capabilityComponents = ImmutableMap<SpecCapability, React.ComponentType<SpecCapabilityProps>>()
   .set(SpecCapability.podCount, PodCount)
   .set(SpecCapability.endpointList, Endpoints)
@@ -98,7 +100,8 @@ const capabilityComponents = ImmutableMap<SpecCapability, React.ComponentType<Sp
   .set(SpecCapability.k8sResourcePrefix, K8sResourceLink)
   .set(SpecCapability.selector, BasicSelector)
   .set(SpecCapability.booleanSwitch, BooleanSwitch)
-  .set(SpecCapability.password, Secret);
+  .set(SpecCapability.password, Secret)
+  .set(SpecCapability.updateStrategy, UpdateStrategy);
 
 const capabilityFor = (specCapability: SpecCapability) => {
   if (_.isEmpty(specCapability)) {


### PR DESCRIPTION
### Description

The `onChange` handlers were missing when `ConfigureUpdateStrategy` was refactored to be a fully controlled function component.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1753018