### PR TITLE
Bug 1751794: Align info tootip

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/_add-capacity-modal.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/_add-capacity-modal.scss
@@ -1,5 +1,9 @@
 @import '~@patternfly/patternfly/sass-utilities/colors';
 
+.add-capacity-modal__hide {
+  display: none;
+}
+
 .add-capacity-modal--padding {
   .co-storage-class-dropdown {
     .dropdown {
@@ -20,17 +24,10 @@
       top: 8.5rem;
     }
   }
-  
   padding-top: 2em;
 }
 
 .add-capacity-modal__span {
   margin-left: 3em;
   color: $pf-color-black-500;
-  button {
-    position: absolute;
-    left: 9.1rem;
-    top: 3.8rem
-  }
 }
-

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
@@ -73,8 +73,8 @@ export const AddCapacityModal = withHandlePromise((props: AddCapacityModalProps)
           <div className="form-group">
             <label className="control-label" htmlFor="request-size-input">
               Requested Capacity
+              <DashboardCardHelp>{labelTooltip}</DashboardCardHelp>
               <span className="add-capacity-modal__span">
-                <DashboardCardHelp>{labelTooltip}</DashboardCardHelp>
                 <span>
                   Provisioned Capacity:
                   {presentCount ? ` ${presentCount / 3}Ti` : ' Unavailable'}
@@ -91,13 +91,15 @@ export const AddCapacityModal = withHandlePromise((props: AddCapacityModalProps)
               required
             />
           </div>
-          <div className="toolTip_dropdown">
+          <label className="control-label">
+            Storage Class
             <DashboardCardHelp>{storageClassTooltip}</DashboardCardHelp>
-          </div>
+          </label>
           <OCSStorageClassDropdown
             onChange={handleStorageClass}
             name="storageClass"
             defaultClass={storageClass}
+            hideClassName="add-capacity-modal__hide"
             required
           />
         </div>

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
@@ -40,4 +40,5 @@ type OCSStorageClassDropdownProps = {
   describedBy?: string;
   defaultClass: string;
   required?: boolean;
+  hideClassName?: string;
 };

--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -123,7 +123,7 @@ export class StorageClassDropdownInner extends React.Component<StorageClassDropd
     return <React.Fragment>
       {loaded && itemsAvailableToShow &&
         <div>
-          <label className="control-label" htmlFor={id}>
+          <label className={this.props.hideClassName ? `${this.props.hideClassName } control-label`: 'control-label'} htmlFor={id}>
             Storage Class
           </label>
           <Dropdown
@@ -190,4 +190,5 @@ export type StorageClassDropdownInnerProps = {
   describedBy: string;
   defaultClass: string;
   required?: boolean;
+  hideClassName?: string;
 };


### PR DESCRIPTION
The tooltips are gets misaligned when the font-size of
browser changes from browser setting.PR fixes this issue.
Before: (For Large Size Chrome)
![Screenshot from 2019-09-18 17-52-13](https://user-images.githubusercontent.com/12200504/65149070-10bb0e80-da3f-11e9-8768-192ce1e61271.png)

After: (For Large Size Chrome)
![Screenshot from 2019-09-18 17-47-23](https://user-images.githubusercontent.com/12200504/65149075-144e9580-da3f-11e9-9483-b5fd2c5bcfde.png)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1751794
Signed-off-by: Kanika <kmurarka@redhat.com>