### PR TITLE
Add context menu for dev topology nodes

### DIFF
--- a/frontend/packages/console-shared/src/components/contextMenu/PopupKebabMenu.scss
+++ b/frontend/packages/console-shared/src/components/contextMenu/PopupKebabMenu.scss
@@ -1,0 +1,28 @@
+.ocs-popup-kebab-menu {
+  position: fixed;
+  min-width: 150px;
+  max-width: 200px;
+
+  &__backdrop {
+    background-color: transparent;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  &__container {
+    z-index: calc(var(--pf-c-page__header--ZIndex) + 10);
+  }
+
+  // input component used to trap focus within the context menu
+  &__faux-input {
+    border: none;
+    display: block;
+    margin: 0;
+    padding: 0;
+    width: 0;
+    height: 0;
+  }
+}

--- a/frontend/packages/console-shared/src/components/contextMenu/PopupKebabMenu.tsx
+++ b/frontend/packages/console-shared/src/components/contextMenu/PopupKebabMenu.tsx
@@ -1,0 +1,172 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import * as _ from 'lodash';
+import { DropdownMenu } from '@patternfly/react-core';
+import { history, KebabItem, KebabOption } from '@console/internal/components/utils';
+import './PopupKebabMenu.scss';
+
+export interface PopupKebabMenuProps {
+  kebabOptions: KebabOption[];
+  className?: string;
+  onClose?(): void;
+  eventX: number;
+  eventY: number;
+  container?: Element;
+}
+interface PopopKebabMenuState {
+  menuTop: number;
+  menuLeft: number;
+}
+
+const MENU_PADDING = 20;
+
+export class PopupKebabMenu extends React.Component<PopupKebabMenuProps, PopopKebabMenuState> {
+  state = {
+    menuTop: 0,
+    menuLeft: 0,
+  };
+
+  private menu: Element;
+
+  componentDidMount() {
+    document.addEventListener('focus', this.handleBlur, true);
+    this.updateMenuPosition();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.eventX !== prevProps.eventX ||
+      this.props.eventY !== prevProps.eventY ||
+      !_.isEqual(this.props.kebabOptions, prevProps.kebabOptions)
+    ) {
+      this.updateMenuPosition();
+    }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('focus', this.handleBlur, true);
+  }
+
+  updateMenuPosition = () => {
+    const { container, eventX, eventY } = this.props;
+    let menuTop = eventY;
+    let menuLeft = eventX;
+
+    if (container) {
+      const menu: Element = this.menu.firstElementChild;
+      if (menu) {
+        const elementRect = container.getBoundingClientRect();
+        const menuRect = menu.getBoundingClientRect();
+
+        if (
+          eventY + menuRect.height + menuRect.top >
+          elementRect.top + elementRect.height - MENU_PADDING
+        ) {
+          menuTop = Math.max(
+            elementRect.top + elementRect.height - menuRect.height - menuRect.top - MENU_PADDING,
+            0,
+          );
+        }
+        if (
+          eventX + menuRect.width + menuRect.left >
+          elementRect.left + elementRect.width - MENU_PADDING
+        ) {
+          menuLeft = Math.max(
+            elementRect.left + elementRect.width - menuRect.width - menuRect.left - MENU_PADDING,
+            0,
+          );
+        }
+      }
+    }
+
+    if (menuTop !== this.state.menuTop || menuLeft !== this.state.menuLeft) {
+      this.setState({ menuTop, menuLeft });
+    }
+  };
+
+  handleClose = () => {
+    const { onClose } = this.props;
+
+    onClose && onClose();
+  };
+
+  handleMenuMouseDown = (e) => {
+    e.stopPropagation();
+  };
+
+  handleBlur = (e) => {
+    if (!this.menu.contains(e.target)) {
+      let focusTarget;
+
+      const menuItems = this.menu.querySelectorAll('button');
+      if (_.first(menuItems) === e.relatedTarget) {
+        focusTarget = _.last(menuItems);
+      } else if (_.last(menuItems) === e.relatedTarget) {
+        focusTarget = _.first(menuItems);
+      } else {
+        focusTarget = e.relatedTarget;
+      }
+
+      focusTarget.focus();
+    }
+  };
+
+  onKebabOptionClick = (event, option: KebabOption) => {
+    event.stopPropagation();
+
+    if (option.callback) {
+      option.callback();
+    }
+
+    if (option.href) {
+      history.push(option.href);
+    }
+
+    this.handleClose();
+  };
+
+  setMenu = (ref) => {
+    this.menu = ref;
+  };
+
+  render() {
+    const { className, kebabOptions } = this.props;
+    const { menuTop, menuLeft } = this.state;
+    const visibleOptions = _.reject(kebabOptions, (o) => _.get(o, 'hidden', false));
+    const classes = classNames('ocs-popup-kebab-menu', className);
+
+    return (
+      <div className="pf-c-page ocs-popup-kebab-menu__container">
+        <input className="ocs-popup-kebab-menu__faux-input" />
+        <div className={classes}>
+          <div
+            className="ocs-popup-kebab-menu__backdrop"
+            role="presentation"
+            onMouseDown={this.handleClose}
+          >
+            <div
+              className="pf-c-dropdown pf-m-expanded"
+              style={{ top: menuTop, left: menuLeft }}
+              ref={this.setMenu}
+              role="presentation"
+              onMouseDown={this.handleMenuMouseDown}
+            >
+              <DropdownMenu className="pf-c-dropdown__menu">
+                {_.map(visibleOptions, (o, i) => (
+                  <li key={i}>
+                    <KebabItem
+                      option={o}
+                      onClick={this.onKebabOptionClick}
+                      autoFocus={i === 0}
+                      onEscape={this.handleClose}
+                    />
+                  </li>
+                ))}
+              </DropdownMenu>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/frontend/packages/console-shared/src/components/contextMenu/index.ts
+++ b/frontend/packages/console-shared/src/components/contextMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './PopupKebabMenu';

--- a/frontend/packages/console-shared/src/components/index.ts
+++ b/frontend/packages/console-shared/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './badges';
+export * from './contextMenu';
 export * from './status';
 export * from './pod';

--- a/frontend/packages/dev-console/src/components/topology/D3ForceDirectedRenderer.tsx
+++ b/frontend/packages/dev-console/src/components/topology/D3ForceDirectedRenderer.tsx
@@ -6,23 +6,25 @@ import * as _ from 'lodash';
 import { confirmModal, errorModal } from '@console/internal/components/modals';
 import SvgDefsProvider from '../svg/SvgDefsProvider';
 import {
-  ViewNode,
-  ViewEdge,
-  NodeProvider,
+  ContextMenuProvider,
+  DragConnectionProps,
+  Edge,
+  EdgeProps,
   EdgeProvider,
+  GraphElementType,
+  GraphModel,
+  GroupElementInterface,
+  GroupProps,
+  GroupProvider,
   NodeProps,
+  NodeProvider,
   TopologyDataMap,
   TopologyDataObject,
-  GraphModel,
-  Edge,
+  ViewEdge,
   ViewGroup,
-  GroupProvider,
-  GroupProps,
-  GroupElementInterface,
-  DragConnectionProps,
-  EdgeProps,
+  ViewNode,
 } from './topology-types';
-import { DraggingCreateConnector, dragConnectorEndPoint } from './shapes/DraggingCreateConnector';
+import { dragConnectorEndPoint, DraggingCreateConnector } from './shapes/DraggingCreateConnector';
 import { DraggingMoveConnector } from './shapes/DraggingMoveConnector';
 
 const ZOOM_EXTENT: [number, number] = [0.25, 4];
@@ -71,6 +73,7 @@ export interface D3ForceDirectedRendererProps {
   nodeProvider: NodeProvider;
   edgeProvider: EdgeProvider;
   groupProvider: GroupProvider;
+  contextMenu: ContextMenuProvider;
   nodeSize: number;
   selected?: string;
   onSelect?(string): void;
@@ -378,6 +381,16 @@ export default class D3ForceDirectedRenderer extends React.Component<
         .on('end', (d) => this.onNodeDragEnd(d))
         .filter(() => this.state.nodes.length > 1),
     );
+
+    $node.on('contextmenu', this.onNodeContextMenu);
+  };
+
+  onNodeContextMenu = (d: ViewNode) => {
+    const { contextMenu } = this.props;
+
+    if (contextMenu.open(GraphElementType.node, d.id, d3.event.pageX, d3.event.pageY)) {
+      d3.event.preventDefault();
+    }
   };
 
   private onNodeDragStart = () => {

--- a/frontend/packages/dev-console/src/components/topology/Graph.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Graph.tsx
@@ -8,8 +8,11 @@ import {
   GraphModel,
   TopologyDataMap,
   GroupProvider,
+  ActionProvider,
+  ContextMenuProvider,
 } from './topology-types';
 import './Graph.scss';
+import { GraphContextMenu } from './GraphContextMenu';
 
 interface State {
   dimensions?: {
@@ -22,6 +25,7 @@ export interface GraphProps {
   nodeProvider: NodeProvider;
   edgeProvider: EdgeProvider;
   groupProvider: GroupProvider;
+  actionProvider: ActionProvider;
   graph: GraphModel;
   topology: TopologyDataMap;
   selected?: string;
@@ -37,6 +41,8 @@ export interface GraphProps {
 }
 
 export default class Graph extends React.Component<GraphProps, State> {
+  private contextMenuRef: ContextMenuProvider;
+
   constructor(props) {
     super(props);
     this.state = {};
@@ -60,12 +66,17 @@ export default class Graph extends React.Component<GraphProps, State> {
     graphApiRef && graphApiRef(r ? r.api() : null);
   };
 
+  setContextMenuRef = (r) => {
+    this.contextMenuRef = r;
+  };
+
   renderMeasure = ({ measureRef }) => {
     const {
       graph,
       nodeProvider,
       edgeProvider,
       groupProvider,
+      actionProvider,
       onSelect,
       onUpdateNodeGroup,
       onCreateConnection,
@@ -92,8 +103,10 @@ export default class Graph extends React.Component<GraphProps, State> {
             onCreateConnection={onCreateConnection}
             onRemoveConnection={onRemoveConnection}
             selected={selected}
+            contextMenu={this.contextMenuRef}
           />
         )}
+        <GraphContextMenu ref={this.setContextMenuRef} actionProvider={actionProvider} />
       </div>
     );
   };

--- a/frontend/packages/dev-console/src/components/topology/GraphContextMenu.tsx
+++ b/frontend/packages/dev-console/src/components/topology/GraphContextMenu.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { PopupKebabMenu } from '@console/shared/src';
+import { KebabOption } from '@console/internal/components/utils';
+import { ActionProvider, ContextMenuProvider, GraphElementType } from './topology-types';
+
+export interface GraphContextMenuProps {
+  actionProvider: ActionProvider;
+}
+
+interface MenuState {
+  isOpen: boolean;
+  kebabOptions: KebabOption[];
+  eventX: number;
+  eventY: number;
+}
+
+export class GraphContextMenu extends React.Component<GraphContextMenuProps, MenuState>
+  implements ContextMenuProvider {
+  private menuContainer: HTMLElement;
+
+  private modalContainer: HTMLElement;
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isOpen: false,
+      kebabOptions: null,
+      eventX: 0,
+      eventY: 0,
+    };
+  }
+
+  componentDidMount() {
+    this.modalContainer = document.getElementById('modal-container');
+  }
+
+  public open = (type: GraphElementType, id: string, eventX: number, eventY: number) => {
+    const { actionProvider } = this.props;
+
+    const kebabOptions = actionProvider(type, id);
+    const isOpen = kebabOptions && kebabOptions.length > 0;
+
+    this.setState({ isOpen, kebabOptions, eventX, eventY });
+
+    return isOpen;
+  };
+
+  public onClose = () => {
+    this.setState({ isOpen: false });
+  };
+
+  setMenuContainer = (ref: HTMLElement) => {
+    this.menuContainer = ref;
+  };
+
+  renderContextMenu() {
+    const { kebabOptions, eventX, eventY } = this.state;
+
+    return (
+      <PopupKebabMenu
+        onClose={this.onClose}
+        container={this.menuContainer}
+        kebabOptions={kebabOptions}
+        eventX={eventX}
+        eventY={eventY}
+      />
+    );
+  }
+
+  render() {
+    const { isOpen } = this.state;
+
+    return (
+      <div className="odc-graph-context-menu" ref={this.setMenuContainer}>
+        {isOpen && ReactDOM.createPortal(this.renderContextMenu(), this.modalContainer)}
+      </div>
+    );
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -11,6 +11,7 @@ import {
 } from './topology-utils';
 import TopologyControlBar from './TopologyControlBar';
 import TopologySideBar from './TopologySideBar';
+import { ActionProviders } from './actions-providers';
 
 type State = {
   selected?: string;
@@ -115,6 +116,8 @@ export default class Topology extends React.Component<TopologyProps, State> {
       />
     );
 
+    const actionProvider = new ActionProviders(topology);
+
     return (
       <TopologyView
         controlBar={<TopologyControlBar graphApi={graphApi} />}
@@ -127,6 +130,7 @@ export default class Topology extends React.Component<TopologyProps, State> {
           nodeProvider={nodeProvider}
           edgeProvider={edgeProvider}
           groupProvider={groupProvider}
+          actionProvider={actionProvider.getActions}
           selected={selected}
           onSelect={this.onSelect}
           onUpdateNodeGroup={this.onUpdateNodeGroup}

--- a/frontend/packages/dev-console/src/components/topology/actions-providers.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions-providers.ts
@@ -1,0 +1,40 @@
+import { KebabOption } from '@console/internal/components/utils';
+import { GraphElementType, TopologyDataMap } from './topology-types';
+import { workloadActions } from './actions/workloadActions';
+
+export class ActionProviders {
+  private readonly topology: TopologyDataMap;
+
+  constructor(topology: TopologyDataMap) {
+    this.topology = topology;
+  }
+
+  public getNodeActions = (nodeId: string): KebabOption[] => {
+    const node = this.topology[nodeId];
+    switch (node.type) {
+      case 'workload':
+        return workloadActions(node);
+      default:
+        return null;
+    }
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+  public getEdgeActions = (edgeId: string): KebabOption[] => null;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+  public getGroupActions = (groupId: string): KebabOption[] => null;
+
+  public getActions = (type: GraphElementType, id: string) => {
+    switch (type) {
+      case GraphElementType.node:
+        return this.getNodeActions(id);
+      case GraphElementType.edge:
+        return this.getEdgeActions(id);
+      case GraphElementType.group:
+        return this.getGroupActions(id);
+      default:
+        return null;
+    }
+  };
+}

--- a/frontend/packages/dev-console/src/components/topology/actions/workloadActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/workloadActions.ts
@@ -1,0 +1,37 @@
+import * as _ from 'lodash';
+import { KebabAction, KebabOption } from '@console/internal/components/utils';
+import { modelFor } from '@console/internal/module/k8s';
+import { menuActions as deploymentConfigMenuActions } from '@console/internal/components/deployment-config';
+import { menuActions as deploymentMenuActions } from '@console/internal/components/deployment';
+import { menuActions as statefulSetMenuActions } from '@console/internal/components/stateful-set';
+import { menuActions as daemonSetMenuActions } from '@console/internal/components/daemon-set';
+import { TopologyDataObject } from '../topology-types';
+import { getResourceDeploymentObject } from '../topology-utils';
+
+export const workloadActions = (workload: TopologyDataObject): KebabOption[] => {
+  const contextMenuResource = getResourceDeploymentObject(workload);
+
+  if (!contextMenuResource) {
+    return null;
+  }
+
+  let menuActions: KebabAction[];
+  switch (contextMenuResource.kind) {
+    case 'DeploymentConfig':
+      menuActions = deploymentConfigMenuActions;
+      break;
+    case 'Deployment':
+      menuActions = deploymentMenuActions;
+      break;
+    case 'StatefulSet':
+      menuActions = statefulSetMenuActions;
+      break;
+    case 'DaemonSet':
+      menuActions = daemonSetMenuActions;
+      break;
+    default:
+      menuActions = [];
+  }
+
+  return _.map(menuActions, (a) => a(modelFor(contextMenuResource.kind), contextMenuResource));
+};

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -1,5 +1,6 @@
 import { ComponentType } from 'react';
 import { Pod, ResourceProps, Resource } from '@console/shared';
+import { KebabOption } from '@console/internal/components/utils';
 import { Point } from '../../utils/svg-utils';
 
 export interface TopologyDataResources {
@@ -148,8 +149,19 @@ export type GroupProps = ViewGroup & {
   groupRef(element: GroupElementInterface): void;
 };
 
-export type NodeProvider = (string) => ComponentType<NodeProps>;
+export type NodeProvider = (type: string) => ComponentType<NodeProps>;
 
-export type EdgeProvider = (string) => ComponentType<EdgeProps>;
+export type EdgeProvider = (type: string) => ComponentType<EdgeProps>;
 
-export type GroupProvider = (string) => ComponentType<GroupProps>;
+export type GroupProvider = (type: string) => ComponentType<GroupProps>;
+
+export enum GraphElementType {
+  node = 'node',
+  edge = 'edge',
+  group = 'group',
+}
+export type ActionProvider = (type: GraphElementType, id: string) => KebabOption[];
+
+export type ContextMenuProvider = {
+  open: (type: GraphElementType, id: string, eventX: number, eventY: number) => boolean;
+};

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -417,7 +417,7 @@ export class TransformTopologyData {
   }
 }
 
-const getResourceDeploymentObject = (topologyObject: TopologyDataObject): ResourceProps => {
+export const getResourceDeploymentObject = (topologyObject: TopologyDataObject): ResourceProps => {
   if (!topologyObject) {
     return null;
   }

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { connect } from 'react-redux';
+import { KEY_CODES } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import {
   annotationsModal,
@@ -26,8 +27,22 @@ import { impersonateStateToProps } from '../../reducers/ui';
 import { connectToModel } from '../../kinds';
 import * as plugins from '../../plugins';
 
-const KebabItemEnabled: React.FC<KebabItemProps> = ({option, onClick}) => {
-  return <button className="pf-c-dropdown__menu-item" onClick={(e) => onClick(e, option)} data-test-action={option.label}>{option.label}</button>;
+const KebabItemEnabled: React.FC<KebabItemProps> = ({option, onClick, onEscape, autoFocus}) => {
+  const handleEscape = (e) => {
+    if (e.keyCode === KEY_CODES.ESCAPE_KEY) {
+      onEscape();
+    }
+  };
+
+  return (
+    <button
+      className="pf-c-dropdown__menu-item"
+      onClick={(e) => onClick(e, option)}
+      autoFocus={autoFocus}
+      onKeyDown={onEscape && handleEscape}
+      data-test-action={option.label}>{option.label}
+    </button>
+  );
 };
 
 const KebabItemDisabled: React.FC<KebabItemDisabledProps> = ({option}) => {
@@ -43,17 +58,17 @@ const KebabItemAccessReview_ = (props: KebabItemProps & { impersonate: string })
 };
 const KebabItemAccessReview = connect(impersonateStateToProps)(KebabItemAccessReview_);
 
-const KebabItem: React.FC<KebabItemProps> = (props) => {
+export const KebabItem: React.FC<KebabItemProps> = (props) => {
   return props.option.accessReview
     ? <KebabItemAccessReview {...props} />
     : <KebabItemEnabled {...props} />;
 };
 
-export const KebabItems: React.SFC<KebabItemsProps> = ({options, onClick}) => {
+export const KebabItems: React.SFC<KebabItemsProps> = ({options, onClick, focusItem}) => {
   const visibleOptions = _.reject(options, o => _.get(o, 'hidden', false));
   return <ul className="pf-c-dropdown__menu pf-m-align-right" data-test-id="action-items">
     {_.map(visibleOptions, (o, i) => <li key={i}>
-      <KebabItem option={o} onClick={onClick} />
+      <KebabItem option={o} onClick={onClick} autoFocus={focusItem ? o === focusItem : undefined} />
     </li>)}
   </ul>;
 };
@@ -244,9 +259,11 @@ type KebabItemProps = {
   option: KebabOption;
   onClick: (event: React.MouseEvent<{}>, option: KebabOption) => void;
   isActionDropdown?: boolean;
+  autoFocus?: boolean;
+  onEscape?: () => void;
 };
 
-type KebabItemDisabledProps = {
+type KebabItemDisabledProps = React.HTMLProps<HTMLButtonElement> & {
   option: KebabOption;
   isActionDropdown?: boolean;
 }
@@ -255,6 +272,7 @@ export type KebabItemsProps = {
   options: KebabOption[];
   onClick: (event: React.MouseEvent<{}>, option: KebabOption) => void;
   isActionDropdown?: boolean;
+  focusItem?: KebabOption;
 };
 
 export type KebabFactory = {[name: string]: KebabAction} & {common?: KebabAction[]};


### PR DESCRIPTION
Implements: https://jira.coreos.com/browse/ODC-1146

Provide a context menu for nodes in the topology nodes. Initially using the same actions available from the menu in the sidebar (subject to future change based on UX feedback).