### PR TITLE
kubevirt: fix getName for ownerReference

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/selectors/owner-reference/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/owner-reference/selectors.ts
@@ -8,4 +8,4 @@ export const getKind = (ownerReference: OwnerReference) =>
   _.get(ownerReference, 'kind') as OwnerReference['kind'];
 
 export const getName = (ownerReference: OwnerReference) =>
-  _.get(ownerReference, 'kind') as OwnerReference['kind'];
+  _.get(ownerReference, 'name') as OwnerReference['name'];


### PR DESCRIPTION
Typo fixed.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1753286