### PR TITLE
Bug 1753124: Example Report Query YAML lack of required fields

### DIFF
--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -148,6 +148,18 @@ export const ChargebackReportModel: K8sKind = {
   namespaced: true,
 };
 
+export const ReportQueryModel: K8sKind = {
+  kind: 'ReportQuery',
+  label: 'ReportQuery',
+  labelPlural: 'Report Queries',
+  apiGroup: 'metering.openshift.io',
+  apiVersion: 'v1',
+  crd: true,
+  plural: 'report queries',
+  abbr: 'RQ',
+  namespaced: true,
+};
+
 export const ServiceModel: K8sKind = {
   apiVersion: 'v1',
   label: 'Service',

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -162,8 +162,19 @@ spec:
   reportingStart: '2019-01-01T00:00:00Z'
   reportingEnd: '2019-12-30T23:59:59Z'
   runImmediately: true
-`)
-  .setIn([referenceForModel(k8sModels.DeploymentModel), 'default'], `
+`).setIn([referenceForModel(k8sModels.ReportQueryModel), 'default'], `
+apiVersion: metering.openshift.io/v1
+kind: ReportQuery
+metadata:
+  name: example
+  namespace: openshift-metering
+spec:
+  columns:
+  - name: the_time
+    type: timestamp
+  query: |
+    SELECT now() AS the_time;
+`).setIn([referenceForModel(k8sModels.DeploymentModel), 'default'], `
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Added `ReportQuery` Model & Template with required fields `spec.columns` and `spec.query`: 

![image](https://user-images.githubusercontent.com/12733153/65524049-260abf80-debb-11e9-9744-0e3e6ea1cea3.png)

User can now create & save Report Query example template without any errors.