### PR TITLE
Correct styling of text inputs

### DIFF
--- a/frontend/public/components/storage-class-form.tsx
+++ b/frontend/public/components/storage-class-form.tsx
@@ -750,6 +750,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
               </label>
               <FormControl
                 type="text"
+                bsClass="pf-c-form-control"
                 value={_.get(this.state, `newStorageClass.parameters.${key}.value`, '')}
                 onChange={(event) => this.setParameterHandler(key, event, isCheckbox)} />
             </React.Fragment>
@@ -809,6 +810,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
             <label className="control-label co-required" htmlFor="storage-class-name">Name</label>
             <FormControl
               type="text"
+              bsClass="pf-c-form-control"
               placeholder={newStorageClass.name}
               id="storage-class-name"
               onChange={(event) => this.setStorageHandler('name', event.target.value)}
@@ -820,6 +822,7 @@ export class StorageClassForm_ extends React.Component<StorageClassFormProps, St
             <label htmlFor="storage-class-description">Description</label>
             <FormControl
               type="text"
+              bsClass="pf-c-form-control"
               id="storage-class-description"
               onChange={(event) => this.setStorageHandler('description', event.target.value)}
               value={_.get(newStorageClass, 'description', '')} />


### PR DESCRIPTION
Before:
![Screen Shot 2019-09-18 at 4 53 07 PM](https://user-images.githubusercontent.com/895728/65185372-6f7b8a80-da35-11e9-837c-97481cb9a0d7.png)

After:
![Screen Shot 2019-09-18 at 4 51 58 PM](https://user-images.githubusercontent.com/895728/65185388-74d8d500-da35-11e9-9c95-35040d2e679a.png)

Note:
Changing the styling from PF3 to PF4 breaks the validation style on the `Name` input.
Before:
![Screen Shot 2019-09-18 at 4 53 43 PM](https://user-images.githubusercontent.com/895728/65185454-92a63a00-da35-11e9-9ced-c73ad9be0e61.png)
After:
![Screen Shot 2019-09-18 at 4 54 26 PM](https://user-images.githubusercontent.com/895728/65185455-92a63a00-da35-11e9-8b45-8dd6b8a4ae2a.png)

cc: @sg00dwin 

/kind bug
