### PR TITLE
Request Port When Unknown

### DIFF
--- a/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
@@ -17,11 +17,20 @@ export interface AdvancedSectionProps {
   values: FormikValues;
 }
 
+const ROUTING_NAME = 'Routing';
+
 const AdvancedSection: React.FC<AdvancedSectionProps> = ({ values }) => {
   const [visibleItems, setVisibleItems] = React.useState([]);
   const handleVisibleItemChange = (item: string) => {
     setVisibleItems([...visibleItems, item]);
   };
+
+  const needsPort = values.route.supplyPort;
+  React.useEffect(() => {
+    if (needsPort && !visibleItems.includes(ROUTING_NAME)) {
+      setVisibleItems([...visibleItems, ROUTING_NAME]);
+    }
+  }, [needsPort, visibleItems]);
 
   return (
     <FormSection title="Advanced Options" fullWidth>
@@ -31,7 +40,7 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({ values }) => {
         visibleItems={visibleItems}
         onVisibleItemChange={handleVisibleItemChange}
       >
-        <ProgressiveListItem name="Routing">
+        <ProgressiveListItem disableScroll={needsPort} name={ROUTING_NAME}>
           {values.serverless.enabled ? (
             <ServerlessRouteSection route={values.route} />
           ) : (

--- a/frontend/packages/dev-console/src/components/import/deployImage-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-validation-utils.ts
@@ -92,6 +92,7 @@ export const deployValidationSchema = yup.object().shape({
       }),
   }),
   route: yup.object().shape({
+    create: yup.boolean(),
     secure: yup.boolean(),
     tls: yup.object().when('secure', {
       is: true,
@@ -110,5 +111,13 @@ export const deployValidationSchema = yup.object().shape({
     path: yup
       .string()
       .matches(pathRegex, { message: 'Path must start with /.', excludeEmptyString: true }),
+    targetPort: yup.string().when('supplyPort', {
+      is: true,
+      then: yup.string().when('create', {
+        is: true,
+        then: yup.string().required('A target port is required.'),
+      }),
+    }),
+    supplyPort: yup.boolean(),
   }),
 });

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
@@ -62,6 +62,7 @@ const ImageSearch: React.FC = () => {
           setFieldValue('isi.status', status);
           setFieldValue('isi.ports', ports);
           setFieldValue('image.ports', ports);
+          ports.length === 0 && setFieldValue('route.supplyPort', true);
           !values.name && setFieldValue('name', getSuggestedName(name));
           !values.application.name &&
             setFieldValue('application.name', `${getSuggestedName(name)}-app`);

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -111,6 +111,7 @@ export interface DockerData {
 export interface RouteData {
   create: boolean;
   targetPort: string;
+  supplyPort?: boolean;
   path: string;
   hostname: string;
   secure: boolean;

--- a/frontend/packages/dev-console/src/components/import/route/CreateRoute.tsx
+++ b/frontend/packages/dev-console/src/components/import/route/CreateRoute.tsx
@@ -9,7 +9,7 @@ const CreateRoute: React.FC = () => {
   const {
     values: {
       image: { ports },
-      route: { targetPort },
+      route: { supplyPort, targetPort },
     },
   } = useFormikContext<FormikValues>();
   const portOptions = ports.reduce((acc, port) => {
@@ -37,7 +37,16 @@ const CreateRoute: React.FC = () => {
         placeholder="/"
         helpText="Path that the router watches to route traffic to the service."
       />
-      {!_.isEmpty(ports) && (
+      {_.isEmpty(ports) ? (
+        <InputField
+          type={TextInputTypes.text}
+          name="route.targetPort"
+          label="Target Port"
+          placeholder="8080"
+          helpText="Target port for traffic."
+          required={supplyPort}
+        />
+      ) : (
         <DropdownField
           name="route.targetPort"
           label="Target Port"

--- a/frontend/packages/dev-console/src/components/progressive-list/ProgressiveListItem.tsx
+++ b/frontend/packages/dev-console/src/components/progressive-list/ProgressiveListItem.tsx
@@ -1,14 +1,17 @@
 import * as React from 'react';
 
 export interface ProgressiveListItemProps {
+  disableScroll?: boolean;
   name: string;
 }
 
-const ProgressiveListItem: React.FC<ProgressiveListItemProps> = ({ children }) => {
+const ProgressiveListItem: React.FC<ProgressiveListItemProps> = ({ children, disableScroll }) => {
   const element = React.useRef<HTMLDivElement>();
   React.useEffect(() => {
-    element.current.scrollIntoView({ behavior: 'smooth' });
-  }, []);
+    if (!disableScroll) {
+      element.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [disableScroll]);
   return <div ref={element}>{children}</div>;
 };
 


### PR DESCRIPTION
Allowing for the routing to work on images that don't expose a port.

https://jira.coreos.com/browse/ODC-1727

- Added the Route section if we don't know the port
- Made the Route Target Port a text field when no ports are detected
- Made the Target Port a required input field

![image](https://user-images.githubusercontent.com/8126518/65189725-cb4b1100-da3f-11e9-8ff6-c8c0f6bea121.png)
