### PR TITLE
bug 1752922: PVC mismatch in storage dashboard

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
@@ -14,7 +14,12 @@ export const getCephPVCs = (
   cephSCNames: string[] = [],
   pvcsData: K8sResourceKind[] = [],
 ): K8sResourceKind[] =>
-  pvcsData.filter((pvc) => cephSCNames.includes(_.get(pvc, 'spec.storageClassName')));
+  pvcsData.filter((pvc) =>
+    cephSCNames.includes(
+      _.get(pvc, 'spec.storageClassName') ||
+        _.get(pvc, ['metadata', 'annotations', 'volume.beta.kubernetes.io/storage-class']),
+    ),
+  );
 
 export const getCephPVs = (pvsData: K8sResourceKind[] = []): K8sResourceKind[] =>
   pvsData.filter((pv) => {


### PR DESCRIPTION
I am having 3 PVC created which has storage class name in `spec.storageClassName` and 2 PVC which has name in `metadata.annotations.volume.beta.kubernetes.io/storage-class` and now all are listed. 

![Screenshot from 2019-09-19 20-53-51](https://user-images.githubusercontent.com/6695156/65257909-a4640c00-db1f-11e9-91d3-753f34bc0e66.png)
