### PR TITLE
Add Pipelines to admin nav

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/PipelinesPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelinesPage.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { FireMan_ as FireMan } from '@console/internal/components/factory';
 import { Firehose } from '@console/internal/components/utils';
 import { getBadgeFromType } from '@console/shared';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { getActivePerspective } from '@console/internal/reducers/ui';
+import { RootState } from '@console/internal/redux';
 import { PipelineModel } from '../../models';
 import ProjectListPage from '../projects/ProjectListPage';
 import { filters } from './PipelineAugmentRuns';
@@ -12,7 +15,14 @@ interface PipelinesPageProps {
   namespace: string;
 }
 
-const PipelinesPage: React.FC<PipelinesPageProps> = ({ namespace }) => {
+interface StateProps {
+  perspective: string;
+}
+
+export const PipelinesPage: React.FC<PipelinesPageProps & StateProps> = ({
+  namespace,
+  perspective,
+}) => {
   const resources = [
     {
       isList: true,
@@ -22,7 +32,7 @@ const PipelinesPage: React.FC<PipelinesPageProps> = ({ namespace }) => {
       filters: { ...filters },
     },
   ];
-  return namespace ? (
+  return namespace || perspective !== 'dev' ? (
     <FireMan
       canCreate
       createButtonText={`Create ${PipelineModel.label}`}
@@ -44,4 +54,11 @@ const PipelinesPage: React.FC<PipelinesPageProps> = ({ namespace }) => {
   );
 };
 
-export default PipelinesPage;
+const mapStateToProps = (state: RootState): StateProps => {
+  const perspective = getActivePerspective(state);
+  return {
+    perspective,
+  };
+};
+
+export default connect(mapStateToProps)(PipelinesPage);

--- a/frontend/packages/dev-console/src/components/pipelines/__tests__/Pipeline.spec.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/__tests__/Pipeline.spec.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { ListPage } from '@console/internal/components/factory';
-import PipelinePage from '../PipelinesPage';
+import { PipelinesPage } from '../PipelinesPage';
 import PipelineRuns from '../PipelineRuns';
 
 const pipelinePageProps = {
-  namespace: 'all-namespaces',
+  namespace: 'my-project',
+  perspective: 'dev',
 };
 
 const pipelineRunProps = {
@@ -16,7 +17,7 @@ const pipelineRunProps = {
   },
 };
 
-const pipelineWrapper = shallow(<PipelinePage {...pipelinePageProps} />);
+const pipelineWrapper = shallow(<PipelinesPage {...pipelinePageProps} />);
 const pipelineRunWrapper = shallow(<PipelineRuns {...pipelineRunProps} />);
 
 describe('Pipeline List', () => {

--- a/frontend/packages/dev-console/src/models/pipelines.ts
+++ b/frontend/packages/dev-console/src/models/pipelines.ts
@@ -63,10 +63,24 @@ export const PipelineResourceModel: K8sKind = {
   label: 'Pipeline Resource',
   plural: 'pipelineresources',
   abbr: 'PR',
+  namespaced: true,
   kind: 'PipelineResource',
   id: 'pipelineresource',
   labelPlural: 'Pipeline Resources',
-  namespaced: true,
+  crd: true,
+  badge: BadgeType.DEV,
+};
+
+export const ClusterTaskModel: K8sKind = {
+  apiGroup: 'tekton.dev',
+  apiVersion: 'v1alpha1',
+  label: 'Cluster Task',
+  plural: 'clustertasks',
+  abbr: 'CT',
+  namespaced: false,
+  kind: 'ClusterTask',
+  id: 'clustertask',
+  labelPlural: 'Cluster Tasks',
   crd: true,
   badge: BadgeType.DEV,
 };

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -28,7 +28,14 @@ import {
 import { FLAG_OPENSHIFT_PIPELINE, ALLOW_SERVICE_BINDING } from './const';
 import { newPipelineTemplate } from './templates';
 
-const { PipelineModel, PipelineRunModel } = models;
+const {
+  ClusterTaskModel,
+  PipelineModel,
+  PipelineResourceModel,
+  PipelineRunModel,
+  TaskModel,
+  TaskRunModel,
+} = models;
 
 type ConsumedExtensions =
   | ModelDefinition
@@ -105,7 +112,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       perspective: 'dev',
       componentProps: {
-        name: 'Pipelines',
+        name: PipelineModel.labelPlural,
         resource: referenceForModel(PipelineModel),
         required: FLAG_OPENSHIFT_PIPELINE,
         testID: 'pipeline-header',
@@ -180,6 +187,78 @@ const plugin: Plugin<ConsumedExtensions> = [
       resources: tknPipelineAndPipelineRunsResources,
       required: FLAG_OPENSHIFT_PIPELINE,
       utils: getPipelinesAndPipelineRunsForResource,
+    },
+  },
+  {
+    type: 'NavItem/ResourceNS',
+    properties: {
+      perspective: 'admin',
+      section: 'Pipelines',
+      componentProps: {
+        name: PipelineModel.labelPlural,
+        resource: referenceForModel(PipelineModel),
+        required: SHOW_PIPELINE,
+      },
+    },
+  },
+  {
+    type: 'NavItem/ResourceNS',
+    properties: {
+      perspective: 'admin',
+      section: 'Pipelines',
+      componentProps: {
+        name: PipelineRunModel.labelPlural,
+        resource: referenceForModel(PipelineRunModel),
+        required: SHOW_PIPELINE,
+      },
+    },
+  },
+  {
+    type: 'NavItem/ResourceNS',
+    properties: {
+      perspective: 'admin',
+      section: 'Pipelines',
+      componentProps: {
+        name: PipelineResourceModel.labelPlural,
+        resource: referenceForModel(PipelineResourceModel),
+        required: SHOW_PIPELINE,
+      },
+    },
+  },
+  {
+    type: 'NavItem/ResourceNS',
+    properties: {
+      perspective: 'admin',
+      section: 'Pipelines',
+      componentProps: {
+        name: TaskModel.labelPlural,
+        resource: referenceForModel(TaskModel),
+        required: SHOW_PIPELINE,
+      },
+    },
+  },
+  {
+    type: 'NavItem/ResourceNS',
+    properties: {
+      perspective: 'admin',
+      section: 'Pipelines',
+      componentProps: {
+        name: TaskRunModel.labelPlural,
+        resource: referenceForModel(TaskRunModel),
+        required: SHOW_PIPELINE,
+      },
+    },
+  },
+  {
+    type: 'NavItem/ResourceCluster',
+    properties: {
+      perspective: 'admin',
+      section: 'Pipelines',
+      componentProps: {
+        name: ClusterTaskModel.labelPlural,
+        resource: referenceForModel(ClusterTaskModel),
+        required: SHOW_PIPELINE,
+      },
     },
   },
   {

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -197,7 +197,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       componentProps: {
         name: PipelineModel.labelPlural,
         resource: referenceForModel(PipelineModel),
-        required: SHOW_PIPELINE,
+        required: FLAG_OPENSHIFT_PIPELINE,
       },
     },
   },
@@ -209,7 +209,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       componentProps: {
         name: PipelineRunModel.labelPlural,
         resource: referenceForModel(PipelineRunModel),
-        required: SHOW_PIPELINE,
+        required: FLAG_OPENSHIFT_PIPELINE,
       },
     },
   },
@@ -221,7 +221,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       componentProps: {
         name: PipelineResourceModel.labelPlural,
         resource: referenceForModel(PipelineResourceModel),
-        required: SHOW_PIPELINE,
+        required: FLAG_OPENSHIFT_PIPELINE,
       },
     },
   },
@@ -233,7 +233,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       componentProps: {
         name: TaskModel.labelPlural,
         resource: referenceForModel(TaskModel),
-        required: SHOW_PIPELINE,
+        required: FLAG_OPENSHIFT_PIPELINE,
       },
     },
   },
@@ -245,7 +245,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       componentProps: {
         name: TaskRunModel.labelPlural,
         resource: referenceForModel(TaskRunModel),
-        required: SHOW_PIPELINE,
+        required: FLAG_OPENSHIFT_PIPELINE,
       },
     },
   },
@@ -257,7 +257,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       componentProps: {
         name: ClusterTaskModel.labelPlural,
         resource: referenceForModel(ClusterTaskModel),
-        required: SHOW_PIPELINE,
+        required: FLAG_OPENSHIFT_PIPELINE,
       },
     },
   },

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -114,7 +114,7 @@ const AdminNav = () => (
     </NavSection>
 
     {/* Temporary addition of Knative Serverless section until extensibility allows for section ordering
-         and admin-nav gets contributed through extensions. */}
+        and admin-nav gets contributed through extensions. */}
     <NavSection title="Serverless" />
 
     <NavSection title="Networking">
@@ -143,6 +143,10 @@ const AdminNav = () => (
         startsWith={imagestreamsStartsWith}
       />
     </NavSection>
+
+    {/* Temporary addition of Tekton Pipelines section until extensibility allows for section ordering
+        and admin-nav gets contributed through extensions. */}
+    <NavSection title="Pipelines" />
 
     <NavSection title="Service Catalog" required={FLAGS.SERVICE_CATALOG}>
       <HrefLink


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-1727

This adds a Pipelines nav item to the admin console build section. I'm opening to get input on the user experience we want. Alternately, we could create a separate nav section with all the pipeline resources.

@siamaksade @sspeiche @alimobrem @beanh66 @serenamarie125 @christianvogt thoughts?

![Screen Shot 2019-09-19 at 1 12 11 PM](https://user-images.githubusercontent.com/1167259/65265542-2f70e200-dadf-11e9-91ce-25a0daa0a55f.png)

![Screen Shot 2019-09-19 at 1 12 17 PM](https://user-images.githubusercontent.com/1167259/65265549-326bd280-dadf-11e9-9b6d-ed47d6652d3e.png)
