### PR TITLE
Rework s2i verbiage so it stays true to what it does

### DIFF
--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -53,7 +53,7 @@ const ODCEmptyState: React.FC<Props> = ({
           href={`/deploy-image?preselected-ns=${activeNamespace}`}
           title="Container Image"
           iconClass="pficon-image"
-          description="Deploy an existing image from an image registry or image stream tag"
+          description="Deploy an existing image from an image registry"
         />
         <CatalogTile
           onClick={(e: Event) => navigateTo(e, '/catalog')}
@@ -76,7 +76,7 @@ const ODCEmptyState: React.FC<Props> = ({
           href={formatNamespacedRouteForResource('import', activeNamespace)}
           title="YAML"
           iconImg={yamlIcon}
-          description="Create or replace resources from their YAML or JSON definitions."
+          description="Create resources from their YAML or JSON definitions"
         />
         <CatalogTile
           onClick={(e: Event) => navigateTo(e, '/catalog?category=databases')}


### PR DESCRIPTION
Quick rework of the Container Image verbiage so it stays true to what it actually does.

https://jira.coreos.com/browse/ODC-1917

Current look:

![image](https://user-images.githubusercontent.com/8126518/65344103-c81d6580-dba4-11e9-8283-27065372cac2.png)
