### PR TITLE
Pipeline getTaskStatus Tests

### DIFF
--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment-test-data.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment-test-data.ts
@@ -1,12 +1,12 @@
-import { PropPipelineData, KeyedRuns } from '../pipeline-augment';
+import { PropPipelineData, KeyedRuns, Pipeline, PipelineRun } from '../pipeline-augment';
 
-interface PipelineAgumentData {
+interface PipelineAugmentData {
   data?: PropPipelineData[];
   propsReferenceForRuns?: string[];
   keyedRuns?: KeyedRuns;
 }
 
-export const testData: PipelineAgumentData[] = [
+export const testData: PipelineAugmentData[] = [
   {},
   { data: [] },
   {
@@ -94,3 +94,375 @@ export const testData: PipelineAgumentData[] = [
     },
   },
 ];
+
+export enum DataState {
+  IN_PROGRESS = 'In Progress',
+  SUCCESS = 'Completed Successfully',
+  CANCELLED = 'Cancelled',
+  FAILED = 'Completed But Failed',
+}
+
+type CombinedPipelineTestData = {
+  dataSource: string; // where the data was sourced from
+  pipeline: Pipeline;
+  pipelineRuns: { [key in DataState]?: PipelineRun };
+  // esLint seems to be having issues detecting the usage above - but typescript is properly typing the value
+  eslint_workaround?: PipelineRun;
+};
+
+export enum PipelineExampleNames {
+  COMPLEX_PIPELINE = 'complex-pipeline',
+  PARTIAL_PIPELINE = 'partial-pipeline',
+  SIMPLE_PIPELINE = 'simple-pipeline',
+}
+
+type PipelineTestData = { [key in PipelineExampleNames]?: CombinedPipelineTestData };
+
+export const taskStatusData: PipelineTestData = {
+  [PipelineExampleNames.SIMPLE_PIPELINE]: {
+    dataSource: 'simple-pipeline',
+    pipeline: {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'Pipeline',
+      metadata: {
+        name: 'simple-pipeline',
+        namespace: 'tekton-pipelines',
+      },
+      spec: {
+        tasks: [
+          {
+            name: 'hello-world-1',
+            taskRef: { name: 'hello-world-1' },
+          },
+          {
+            name: 'hello-world-truncate-more-than-20-char',
+            taskRef: { name: 'hello-world-truncate-more-than-20-char' },
+          },
+        ],
+      },
+    },
+    pipelineRuns: {
+      [DataState.IN_PROGRESS]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'simple-pipeline-br8cxv',
+          namespace: 'tekton-pipelines',
+        },
+        spec: {
+          pipelineRef: { name: 'simple-pipeline' },
+          resources: [
+            { name: 'source-repo', resourceRef: { name: 'mapit-git' } },
+            { name: 'web-image', resourceRef: { name: 'mapit-image' } },
+          ],
+          serviceAccount: '',
+          trigger: { type: 'manual' },
+        },
+        status: {
+          taskRuns: {
+            'simple-pipeline-br8cxv-hello-world-1-vqkzl': {
+              pipelineTaskName: 'hello-world-1',
+              status: {
+                conditions: [{ status: 'Unknown', type: 'Succeeded' }],
+              },
+            },
+            'simple-pipeline-br8cxv-hello-world-truncate-more-than-20--87v4h': {
+              pipelineTaskName: 'hello-world-truncate-more-than-20-char',
+              status: {
+                conditions: [{ status: 'Unknown', type: 'Succeeded' }],
+              },
+            },
+          },
+        },
+      },
+      [DataState.SUCCESS]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'simple-pipeline-p1bun0',
+          namespace: 'tekton-pipelines',
+        },
+        spec: {
+          pipelineRef: { name: 'simple-pipeline' },
+          resources: [
+            { name: 'source-repo', resourceRef: { name: 'mapit-git' } },
+            {
+              name: 'web-image',
+              resourceRef: { name: 'mapit-image' },
+            },
+          ],
+          serviceAccount: '',
+          trigger: { type: 'manual' },
+        },
+        status: {
+          taskRuns: {
+            'simple-pipeline-p1bun0-hello-world-1-rlj9b': {
+              pipelineTaskName: 'hello-world-1',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'simple-pipeline-p1bun0-hello-world-truncate-more-than-20--cnd82': {
+              pipelineTaskName: 'hello-world-truncate-more-than-20-char',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  [PipelineExampleNames.PARTIAL_PIPELINE]: {
+    dataSource: 'partial-pipeline',
+    pipeline: {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'Pipeline',
+      metadata: {
+        name: 'partial-pipeline',
+        namespace: 'tekton-pipelines',
+      },
+      spec: {
+        tasks: [
+          { name: 'hello-world-1', taskRef: { name: 'hello-world-1' } },
+          {
+            name: 'hello-world-truncate-more-than-20-char',
+            taskRef: { name: 'hello-world-truncate-more-than-20-char' },
+          },
+          { name: 'hello-world-3', taskRef: { name: 'hello-world-3' } },
+        ],
+      },
+    },
+    pipelineRuns: {
+      [DataState.FAILED]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'partial-pipeline-3tt7aw',
+          namespace: 'tekton-pipelines',
+        },
+        spec: {
+          pipelineRef: { name: 'partial-pipeline' },
+          serviceAccount: '',
+          trigger: { type: 'manual' },
+        },
+        status: {
+          conditions: [
+            {
+              status: 'False',
+              type: 'Succeeded',
+            },
+          ],
+        },
+      },
+    },
+  },
+  [PipelineExampleNames.COMPLEX_PIPELINE]: {
+    dataSource: 'complex-pipeline',
+    pipeline: {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'Pipeline',
+      metadata: {
+        name: 'complex-pipeline',
+        namespace: 'tekton-pipelines',
+      },
+      spec: {
+        tasks: [
+          { name: 'build-app', taskRef: { name: 'noop-task' } },
+          { name: 'analyse-code', runAfter: ['build-app'], taskRef: { name: 'noop-task' } },
+          { name: 'style-checks', runAfter: ['build-app'], taskRef: { name: 'noop-task' } },
+          { name: 'find-bugs', runAfter: ['build-app'], taskRef: { name: 'noop-task' } },
+          {
+            name: 'build-image',
+            runAfter: ['find-bugs', 'style-checks', 'analyse-code'],
+            taskRef: { name: 'noop-task' },
+          },
+          { name: 'deploy-image', runAfter: ['build-image'], taskRef: { name: 'noop-task' } },
+          { name: 'test-suite-1', runAfter: ['deploy-image'], taskRef: { name: 'noop-task' } },
+          { name: 'test-suite-2', runAfter: ['deploy-image'], taskRef: { name: 'noop-task' } },
+          { name: 'test-suite-3', runAfter: ['deploy-image'], taskRef: { name: 'noop-task' } },
+          { name: 'test-suite-4', runAfter: ['deploy-image'], taskRef: { name: 'noop-task' } },
+          { name: 'test-suite-5', runAfter: ['deploy-image'], taskRef: { name: 'noop-task' } },
+          { name: 'test-suite-6', runAfter: ['deploy-image'], taskRef: { name: 'noop-task' } },
+          {
+            name: 'verify',
+            runAfter: [
+              'test-suite-1',
+              'test-suite-2',
+              'test-suite-3',
+              'test-suite-4',
+              'test-suite-5',
+              'test-suite-6',
+            ],
+            taskRef: { name: 'noop-task' },
+          },
+        ],
+      },
+    },
+    pipelineRuns: {
+      [DataState.CANCELLED]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'complex-pipeline-fm4hax',
+          namespace: 'tekton-pipelines',
+        },
+        spec: {
+          params: [{ name: 'APP_NAME', value: '' }],
+          pipelineRef: { name: 'complex-pipeline' },
+          resources: [
+            { name: 'app-git', resourceRef: { name: 'mapit-git' } },
+            { name: 'app-image', resourceRef: { name: 'mapit-image' } },
+          ],
+          serviceAccount: '',
+          status: 'PipelineRunCancelled',
+          trigger: { type: 'manual' },
+        },
+        status: {
+          conditions: [
+            {
+              status: 'False',
+              type: 'Succeeded',
+            },
+          ],
+          taskRuns: {
+            'complex-pipeline-fm4hax-build-app-gpq78': {
+              pipelineTaskName: 'build-app',
+              status: {
+                conditions: [{ status: 'False', type: 'Succeeded' }],
+              },
+            },
+          },
+        },
+      },
+      [DataState.IN_PROGRESS]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'complex-pipeline-6w9np2',
+          namespace: 'tekton-pipelines',
+        },
+        spec: {
+          params: [{ name: 'APP_NAME', value: '' }],
+          pipelineRef: { name: 'complex-pipeline' },
+          resources: [
+            { name: 'app-git', resourceRef: { name: 'mapit-git' } },
+            { name: 'app-image', resourceRef: { name: 'mapit-image' } },
+          ],
+          serviceAccount: '',
+          trigger: { type: 'manual' },
+        },
+        status: {
+          taskRuns: {
+            'complex-pipeline-6w9np2-build-app-6gkss': {
+              pipelineTaskName: 'build-app',
+              status: {
+                conditions: [{ status: 'Unknown', type: 'Succeeded' }],
+              },
+            },
+          },
+        },
+      },
+      [DataState.SUCCESS]: {
+        apiVersion: 'tekton.dev/v1alpha1',
+        kind: 'PipelineRun',
+        metadata: {
+          name: 'complex-pipeline-6w9np2',
+          namespace: 'tekton-pipelines',
+        },
+        spec: {
+          params: [{ name: 'APP_NAME', value: '' }],
+          pipelineRef: { name: 'complex-pipeline' },
+          resources: [
+            { name: 'app-git', resourceRef: { name: 'mapit-git' } },
+            { name: 'app-image', resourceRef: { name: 'mapit-image' } },
+          ],
+          serviceAccount: '',
+          trigger: { type: 'manual' },
+        },
+        status: {
+          taskRuns: {
+            'complex-pipeline-6w9np2-test-suite-3-kh8pz': {
+              pipelineTaskName: 'test-suite-3',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-test-suite-5-2l8ms': {
+              pipelineTaskName: 'test-suite-5',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-deploy-image-vrmcf': {
+              pipelineTaskName: 'deploy-image',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-build-app-6gkss': {
+              pipelineTaskName: 'build-app',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-build-image-rkctm': {
+              pipelineTaskName: 'build-image',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-verify-6djz9': {
+              pipelineTaskName: 'verify',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-test-suite-2-88mk2': {
+              pipelineTaskName: 'test-suite-2',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-test-suite-4-xqk5x': {
+              pipelineTaskName: 'test-suite-4',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-test-suite-6-hvd6w': {
+              pipelineTaskName: 'test-suite-6',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-test-suite-1-9bddh': {
+              pipelineTaskName: 'test-suite-1',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-analyse-code-wrx7t': {
+              pipelineTaskName: 'analyse-code',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-find-bugs-zqsdf': {
+              pipelineTaskName: 'find-bugs',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+            'complex-pipeline-6w9np2-style-checks-d9s6v': {
+              pipelineTaskName: 'style-checks',
+              status: {
+                conditions: [{ status: 'True', type: 'Succeeded' }],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -90,6 +90,7 @@ export type K8sResourceKind = {
   apiVersion?: string;
   kind?: string;
   metadata?: ObjectMetadata;
+  pipelineTaskName?: string;
   spec?: {
     selector?: Selector;
     [key: string]: any


### PR DESCRIPTION
Added more tests for the `pipeline-augment` utilities. I broke the work into two commits so rework of logic is tracked separately from the tests written to test the logic.

- 1st Commit - Rework of types/logic
    - Had to change some of the types to match live data (structures were off)
    - I made a functionality change to the `getTaskStatus` utility to produce a smaller result on the other end as it blindly created properties on the object it never modified (so they were always 0)
- 2nd Commit - Tests and test data

```
  PipelineAugment test getRunStatusColor handles all runStatus values
    ✓ expect all but PipelineNotStarted to produce a non-default result (1ms)
    ✓ expect all status colors to return visible text to show in a tooltip
  PipelineAugment test correct task status state is pulled from pipeline/pipelineruns
    ✓ expect no arguments to produce a net-zero result
    Successfully completed Pipelines
      ✓ expect a simple pipeline to have task-count equal to Succeeded states
      ✓ expect a complex pipeline to have task-count equal to Succeeded states
    In Progress pipelines
      ✓ expect a simple pipeline to have task-count equal to Pending, Running and Succeeded states (1ms)
      ✓ expect a complex pipeline to have task-count equal to Pending, Running and Succeeded states
    Failed / Cancelled pipelines
      ✓ expect a partial pipeline to have task-count equal to Failed and Cancelled states
      ✓ expect a cancelled complex pipeline to have task-count equal to Failed and Cancelled states
```