### PR TITLE
console-shared: Move pod's getNodeName() selector

### DIFF
--- a/frontend/packages/console-shared/src/selectors/index.ts
+++ b/frontend/packages/console-shared/src/selectors/index.ts
@@ -1,3 +1,4 @@
 export * from './common';
 export * from './machine';
 export * from './infrastructure';
+export * from './pod';

--- a/frontend/packages/console-shared/src/selectors/pod.ts
+++ b/frontend/packages/console-shared/src/selectors/pod.ts
@@ -1,0 +1,5 @@
+import { get } from 'lodash';
+import { PodKind } from '@console/internal/module/k8s';
+
+export const getNodeName = (pod: PodKind) =>
+  get(pod, 'spec.nodeName') as PodKind['spec']['nodeName'];

--- a/frontend/packages/console-shared/src/selectors/pod.ts
+++ b/frontend/packages/console-shared/src/selectors/pod.ts
@@ -1,5 +1,4 @@
-import { get } from 'lodash';
 import { PodKind } from '@console/internal/module/k8s';
 
-export const getNodeName = (pod: PodKind) =>
-  get(pod, 'spec.nodeName') as PodKind['spec']['nodeName'];
+export const getNodeName = (pod: PodKind): PodKind['spec']['nodeName'] =>
+  pod && pod.spec ? pod.spec.nodeName : undefined;

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -8,7 +8,7 @@ import {
   DashboardCardLink,
 } from '@console/internal/components/dashboard/dashboard-card';
 import { DetailsBody, DetailItem } from '@console/internal/components/dashboard/details-card';
-import { getName, getNamespace, getUID, getCreationTimestamp } from '@console/shared';
+import { getName, getNamespace, getUID, getCreationTimestamp, getNodeName } from '@console/shared';
 import {
   ResourceLink,
   Timestamp,
@@ -16,7 +16,6 @@ import {
   resourcePath,
 } from '@console/internal/components/utils';
 import { VMDashboardContext } from '../../vms/vm-dashboard-context';
-import { getNodeName } from '../../../selectors/pod/selectors';
 import { isVMRunning } from '../../../selectors/vm';
 import { getVMStatus } from '../../../statuses/vm/vm';
 import { VirtualMachineModel } from '../../../models';

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -4,14 +4,13 @@ import {
   getOperatingSystem,
   getWorkloadProfile,
   getVmTemplate,
-  getNodeName,
   VmStatuses,
   BootOrder,
   getBootableDevicesInOrder,
 } from 'kubevirt-web-ui-components';
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
 import { PodKind } from '@console/internal/module/k8s';
-import { getName, getNamespace } from '@console/shared';
+import { getName, getNamespace, getNodeName } from '@console/shared';
 import { PodModel } from '@console/internal/models';
 import { VMKind, VMIKind } from '../../types';
 import { VMTemplateLink } from '../vm-templates/vm-template-link';

--- a/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
@@ -6,8 +6,6 @@ import { VMKind } from '../../types';
 import { getDataVolumeTemplates } from '../vm';
 import { CDI_KUBEVIRT_IO, STORAGE_IMPORT_PVC_NAME } from '../../constants';
 
-export const getNodeName = (pod: PodKind) =>
-  get(pod, 'spec.nodeName') as PodKind['spec']['nodeName'];
 export const getHostName = (pod: PodKind) =>
   get(pod, 'spec.hostname') as PodKind['spec']['hostname'];
 


### PR DESCRIPTION
Will be reused by cluster dashboard.

Depends on:
- [x] #2600 

Just the last commit is relevant.