### PR TITLE
pods: Dashboard is the default pod-detail tab

### DIFF
--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -39,7 +39,7 @@ import { formatDuration } from './utils/datetime';
 import { CamelCaseWrap } from './utils/camel-case-wrap';
 import { VolumesTable } from './volumes-table';
 import { PodDashboard } from './pod-dashboard';
-import { POD_DETAIL_DASHBOARD_HREF, POD_DETAIL_OVERVIEW_HREF } from './utils/href';
+import { POD_DETAIL_OVERVIEW_HREF } from './utils/href';
 
 export const menuActions = [...Kebab.factory.common];
 const validReadinessStates = new Set(['ContainersNotReady', 'Ready', 'PodCompleted']);
@@ -406,7 +406,7 @@ export const PodsDetailsPage: React.FC<PodDetailsPageProps> = (props) => (
     menuActions={menuActions}
     pages={[
       {
-        href: POD_DETAIL_DASHBOARD_HREF,
+        href: '',
         name: 'Dashboard',
         component: PodDashboard,
       },

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -39,6 +39,7 @@ import { formatDuration } from './utils/datetime';
 import { CamelCaseWrap } from './utils/camel-case-wrap';
 import { VolumesTable } from './volumes-table';
 import { PodDashboard } from './pod-dashboard';
+import { POD_DETAIL_DASHBOARD_HREF, POD_DETAIL_OVERVIEW_HREF } from './utils/href';
 
 export const menuActions = [...Kebab.factory.common];
 const validReadinessStates = new Set(['ContainersNotReady', 'Ready', 'PodCompleted']);
@@ -405,11 +406,11 @@ export const PodsDetailsPage: React.FC<PodDetailsPageProps> = (props) => (
     menuActions={menuActions}
     pages={[
       {
-        href: 'dashboard', // TODO: make it default once additional Cards are implemented
+        href: POD_DETAIL_DASHBOARD_HREF,
         name: 'Dashboard',
         component: PodDashboard,
       },
-      navFactory.details(Details),
+      navFactory.details(Details, POD_DETAIL_OVERVIEW_HREF),
       navFactory.editYaml(),
       navFactory.envEditor(PodEnvironmentComponent),
       navFactory.logs(PodLogs),

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -46,10 +46,10 @@ export type Page = {
   component?: React.ComponentType<any>;
 };
 
-type NavFactory = { [name: string]: (c?: React.ComponentType<any>) => Page };
+type NavFactory = { [name: string]: (c?: React.ComponentType<any>, href?: string) => Page };
 export const navFactory: NavFactory = {
-  details: (component) => ({
-    href: '',
+  details: (component, href = '') => ({
+    href,
     name: 'Overview',
     component,
   }),

--- a/frontend/public/components/utils/href.ts
+++ b/frontend/public/components/utils/href.ts
@@ -1,2 +1,1 @@
-export const POD_DETAIL_DASHBOARD_HREF = '';
 export const POD_DETAIL_OVERVIEW_HREF = 'overview';

--- a/frontend/public/components/utils/href.ts
+++ b/frontend/public/components/utils/href.ts
@@ -1,1 +1,2 @@
-export const POD_DETAIL_OVERVIEW_HREF = ''; // TODO: see pod.tsx, will be changed once Pod Dashboard becomes the default tab
+export const POD_DETAIL_DASHBOARD_HREF = '';
+export const POD_DETAIL_OVERVIEW_HREF = 'overview';


### PR DESCRIPTION
Depends on:
- [x] #2796 

Just the last commit is relevant.

I would postpone merging of this PR till more cards land on the Pod Detail Dashboard page.