### PR TITLE
Firehose - store firehoses in state to trigger rerender when changed

### DIFF
--- a/frontend/__tests__/components/utils/firehose.spec.tsx
+++ b/frontend/__tests__/components/utils/firehose.spec.tsx
@@ -115,7 +115,11 @@ describe(Firehose.displayName, () => {
     expect(
       wrapper
         .instance()
-        .shouldComponentUpdate({ inFlight: true, loaded: true } as FirehoseProps, null, null),
+        .shouldComponentUpdate(
+          { inFlight: true, loaded: true } as FirehoseProps,
+          wrapper.instance().state,
+          null,
+        ),
     ).toBe(false);
   });
 

--- a/frontend/__tests__/components/utils/firehose.spec.tsx
+++ b/frontend/__tests__/components/utils/firehose.spec.tsx
@@ -11,7 +11,6 @@ import { FirehoseResource } from '../../../public/components/utils';
 // TODO(alecmerdler): Use these once `Firehose` is converted to TypeScript
 type FirehoseProps = {
   expand?: boolean;
-  forceUpdate?: boolean;
   resources: FirehoseResource[];
 
   // Provided by `connect`
@@ -116,7 +115,7 @@ describe(Firehose.displayName, () => {
       wrapper
         .instance()
         .shouldComponentUpdate(
-          { inFlight: true, loaded: true } as FirehoseProps,
+          { ...wrapper.instance().props, inFlight: true, loaded: true } as FirehoseProps,
           wrapper.instance().state,
           null,
         ),

--- a/frontend/__tests__/components/utils/firehose.spec.tsx
+++ b/frontend/__tests__/components/utils/firehose.spec.tsx
@@ -26,6 +26,7 @@ type FirehoseProps = {
     k8sKind: K8sKind,
   ) => void;
   watchK8sList: (id: string, query: any, k8sKind: K8sKind) => void;
+  [key: string]: any;
 };
 
 describe(Firehose.displayName, () => {
@@ -130,5 +131,62 @@ describe(Firehose.displayName, () => {
 
     expect(stopK8sWatch.calls.count()).toEqual(1);
     expect(watchK8sList.calls.count()).toEqual(2);
+  });
+
+  it('updates when props or state changes', () => {
+    wrapper = shallow(
+      <Component
+        resources={resources}
+        k8sModels={k8sModels}
+        loaded={true}
+        inFlight={false}
+        stopK8sWatch={stopK8sWatch}
+        watchK8sObject={watchK8sObject}
+        watchK8sList={watchK8sList}
+        fooProp="fooProp"
+      />,
+    );
+    expect(
+      wrapper
+        .instance()
+        .shouldComponentUpdate(
+          { ...wrapper.instance().props, fooProp: 'fooValue' },
+          wrapper.state(),
+          null,
+        ),
+    ).toBe(true);
+    expect(
+      wrapper
+        .instance()
+        .shouldComponentUpdate(
+          { ...wrapper.instance().props, barProp: 'barValue' },
+          wrapper.state(),
+          null,
+        ),
+    ).toBe(true);
+    const state = { firehoses: [] };
+    wrapper.setState(state);
+    expect(wrapper.instance().shouldComponentUpdate(wrapper.instance().props, state, null)).toBe(
+      false,
+    );
+    expect(
+      wrapper.instance().shouldComponentUpdate(wrapper.instance().props, { firehoses: [] }, null),
+    ).toBe(false);
+    expect(
+      wrapper
+        .instance()
+        .shouldComponentUpdate(wrapper.instance().props, { firehoses: [{ id: 'fooID' }] }, null),
+    ).toBe(true);
+
+    wrapper.setProps({ loaded: false });
+    expect(
+      wrapper
+        .instance()
+        .shouldComponentUpdate(
+          { ...wrapper.instance().props, inFlight: true },
+          wrapper.instance().state,
+          null,
+        ),
+    ).toBe(true);
   });
 });

--- a/frontend/packages/console-shared/src/components/pod/PodRingDataController.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRingDataController.tsx
@@ -72,7 +72,7 @@ const PodRingController: React.FC<PodRingDataControllerProps> = ({ namespace, ki
   }
 
   return (
-    <Firehose resources={resources} forceUpdate>
+    <Firehose resources={resources}>
       <Controller render={render} kind={kind} />
     </Firehose>
   );

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -53,7 +53,7 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
 }) => {
   const { resources, utils } = getResourceList(namespace, resourceList);
   return (
-    <Firehose resources={resources} forceUpdate>
+    <Firehose resources={resources}>
       <Controller application={application} cheURL={cheURL} render={render} utils={utils} />
     </Firehose>
   );

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -410,7 +410,7 @@ export const ClusterSettingsPage: React.SFC<ClusterSettingsPageProps> = ({ match
           {title}
         </h1>
       </div>
-      <Firehose forceUpdate resources={resources}>
+      <Firehose resources={resources}>
         <HorizontalNav pages={pages} match={match} resourceKeys={resourceKeys} hideDivider />
       </Firehose>
     </>

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -465,7 +465,7 @@ const Overview_: React.SFC<OverviewProps> = ({
     <div className={className}>
       <div className="overview__main-column" ref={ref} style={{ height }}>
         <div className="overview__main-column-section">
-          <Firehose resources={mock ? [] : resources} forceUpdate>
+          <Firehose resources={mock ? [] : resources}>
             <OverviewMainContent
               mock={mock}
               namespace={namespace}

--- a/frontend/public/components/overview/namespace-overview.tsx
+++ b/frontend/public/components/overview/namespace-overview.tsx
@@ -183,7 +183,7 @@ const OverviewResourceQuotas = ({ ns }) => {
     },
   ];
   return (
-    <Firehose forceUpdate resources={quotaResources}>
+    <Firehose resources={quotaResources}>
       <ResourceQuotas />
     </Firehose>
   );

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -149,7 +149,7 @@ export const Firehose = connect(
       shallowMapEquals(next.k8sModels, prev.k8sModels),
   },
 )(
-  /** @augments {React.Component<{k8sModels?: Map<string, K8sKind>, forceUpdate?: boolean}>} */
+  /** @augments {React.Component<{k8sModels?: Map<string, K8sKind>}>} */
   class Firehose extends React.Component {
     state = {
       firehoses: [],
@@ -166,20 +166,15 @@ export const Firehose = connect(
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-      const { forceUpdate = false } = this.props;
       if (
-        this.state === nextState &&
-        nextProps.inFlight !== this.props.inFlight &&
-        nextProps.loaded
+        Object.keys(nextProps).length === Object.keys(this.props).length &&
+        Object.keys(nextProps)
+          .filter((key) => key !== 'inFlight')
+          .every((key) => nextProps[key] === this.props[key]) &&
+        (nextState === this.state ||
+          (nextState.firehoses.length === 0 && this.state.firehoses.length === 0))
       ) {
-        return forceUpdate;
-      }
-      if (
-        Object.keys(nextProps).every((key) => nextProps[key] === this.props[key]) &&
-        nextState.firehoses.length === 0 &&
-        this.state.firehoses.length === 0
-      ) {
-        return false;
+        return this.props.loaded ? false : this.props.inFlight !== nextProps.inFlight;
       }
       return true;
     }
@@ -262,7 +257,6 @@ Firehose.contextTypes = {
 Firehose.propTypes = {
   children: PropTypes.node,
   expand: PropTypes.bool,
-  forceUpdate: PropTypes.bool,
   resources: PropTypes.arrayOf(
     PropTypes.shape({
       kind: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,


### PR DESCRIPTION
When we change resources to fetch, Firehose will restart the watch in `componentDidUpdate` which is incorrect lifecycle method - `this.firehoses` are updated **after** the rerender but we want them to update **before**.

I've moved the whole logic from `componentDidUpdate` to `shouldComponentUpdate` to restart the watch before rerendering.

@spadgett 