### PR TITLE
Fix bug where `<table>` styles differed across `<MarkdownView>`s

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -83,26 +83,6 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
       item.subscription.metadata.name
     }?showDelete=true`;
 
-  const markdownStyles = `
-    table {
-      margin-bottom: 10px;
-    }
-    tr > th {
-      text-align: left;
-    }
-    th, td {
-      padding: 5px 15px;
-      word-break: break-word;
-      border: none;
-      border-bottom: 1px solid #ededed;
-      vertical-align: top;
-    }
-    code {
-      padding: 0;
-      background: transparent;
-      border: 0;
-    }`;
-
   return (
     <React.Fragment>
       <Modal.Header>
@@ -146,11 +126,7 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
               </PropertiesSidePanel>
               <div className="co-catalog-page__overlay-description">
                 {getHintBlock()}
-                {longDescription ? (
-                  <MarkdownView content={longDescription} styles={markdownStyles} />
-                ) : (
-                  description
-                )}
+                {longDescription ? <MarkdownView content={longDescription} /> : description}
               </div>
             </div>
           </div>

--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -68,10 +68,23 @@ export class SyncMarkdownView extends React.Component<{content: string, styles?:
       ${linkRefs}
       <style type="text/css">
       body {
-          color: ${this.props.content ? '#333' : '#999'};
-          background-color: transparent !important;
-          min-width: auto !important;
-          font-family: var(--pf-global--FontFamily--sans-serif);
+        background-color: transparent !important;
+        color: ${this.props.content ? '#333' : '#999'};
+        font-family: var(--pf-global--FontFamily--sans-serif);
+        min-width: auto !important;
+      }
+      table {
+        margin-bottom: 11.5px;
+      }
+      td,
+      th {
+        border-bottom: 1px solid #ededed;
+        padding: 10px;
+        vertical-align: top;
+        word-break: break-word;
+      }
+      th {
+        padding-top: 0;
       }
       ${this.props.styles ? this.props.styles : ''}
       </style>


### PR DESCRIPTION
And:
* better align `<table>` styles with what's in use throughout the console.
* remove `<code>` style overrides so `<code>` is consistent throughout the console.

Fixes https://jira.coreos.com/browse/CONSOLE-1768

After:
<img width="1407" alt="Screen Shot 2019-09-24 at 2 29 36 PM" src="https://user-images.githubusercontent.com/895728/65539626-cb339100-ded7-11e9-89ee-35959368476c.png">
<img width="923" alt="Screen Shot 2019-09-24 at 2 29 47 PM" src="https://user-images.githubusercontent.com/895728/65539627-cb339100-ded7-11e9-93b4-80c6fd956045.png">
