### PR TITLE
Query Browser: Fix UI rapidly flipping between two different queries

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -25,7 +25,7 @@ import store from '../redux';
 import { ResourceRow, Table, TableData, TableRow, TextFilter } from './factory';
 import { confirmModal } from './modals';
 import { graphStateToProps, QueryBrowserPage, ToggleGraph } from './monitoring/metrics';
-import { Labels, QueryBrowser } from './monitoring/query-browser';
+import { Labels, QueryBrowser, QueryObj } from './monitoring/query-browser';
 import { CheckBoxes } from './row-filter';
 import { formatPrometheusDuration } from './utils/datetime';
 import { withFallback } from './utils/error-boundary';
@@ -184,11 +184,17 @@ const Label = ({k, v}) => <div className="co-m-label co-m-label--expand" key={k}
 
 const queryBrowserURL = query => `/monitoring/query-browser?query0=${encodeURIComponent(query)}`;
 
-const Graph_ = ({hideGraphs, filterLabels = undefined, rule}) => {
+const Graph_: React.FC<GraphProps> = ({filterLabels = undefined, hideGraphs, patchQuery, rule}) => {
+  const {duration = 0, query = ''} = rule || {};
+
+  // Set the query in Redux so that other components like the graph tooltip can access it
+  React.useEffect(() => {
+    patchQuery(0, {query});
+  }, [patchQuery, query]);
+
   if (hideGraphs) {
     return null;
   }
-  const {duration = 0, query = ''} = rule || {};
 
   // 3 times the rule's duration, but not less than 30 minutes
   const timespan = Math.max(3 * duration, 30 * 60) * 1000;
@@ -202,7 +208,7 @@ const Graph_ = ({hideGraphs, filterLabels = undefined, rule}) => {
     queries={[query]}
   />;
 };
-const Graph = connect(graphStateToProps)(Graph_);
+const Graph = connect(graphStateToProps, {patchQuery: UIActions.queryBrowserPatchQuery})(Graph_);
 
 const SilenceMatchersList = ({silence}) => <div className={`co-text-${SilenceResource.kind.toLowerCase()}`}>
   {_.map(silence.matchers, ({name, isRegex, value}, i) => <Label key={i} k={name} v={isRegex ? `~${value}` : value} />)}
@@ -1221,4 +1227,11 @@ export type ListPageProps = {
 
 type AlertingPageProps = {
   match: any;
+};
+
+type GraphProps = {
+  filterLabels?: Labels;
+  hideGraphs: boolean;
+  patchQuery: (index: number, patch: QueryObj) => any;
+  rule: Rule;
 };

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -315,7 +315,6 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
       } else {
         setResults(newResults);
         _.each(newResults, (r, i) => patchQuery(i, {
-          query: queries[i],
           series: r ? _.map(r, 'metric') : undefined,
         }));
         setUpdating(false);


### PR DESCRIPTION
Fixes a bug where the Query Browser could get stuck rapidly flipping
between two different queries, causing the table results to change and
lines in the graph to appear and disappear.

This bug was caused by the poller callback updating the `query` field in
Redux, which under some circumstances caused the poller to be
reinitialized, triggering a loop.

The poller callback was updating `query` just for the Alert details page
and Alerting Rule details pages, so those pages now set `query`
themselves.