### PR TITLE
Changes on the utilization card in the persistent storage.

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utils.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utils.tsx
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+import { DataPoint } from '@console/internal/components/graphs';
 import { Humanize, humanizeNumber } from '@console/internal/components/utils';
 
 export const humanizeIOPS: Humanize = (value) => {
@@ -19,3 +21,5 @@ export const humanizeLatency: Humanize = (value) => {
     unit,
   };
 };
+
+export const getLatestValue = (stats: DataPoint[]) => Number(_.get(stats[stats.length - 1], 'y'));

--- a/frontend/packages/ceph-storage-plugin/src/constants/queries.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/queries.ts
@@ -30,6 +30,8 @@ export const DATA_RESILIENCY_QUERY = {
 };
 
 export const UTILIZATION_QUERY = {
+  [StorageDashboardQuery.CEPH_CAPACITY_TOTAL]: 'ceph_cluster_total_bytes',
+  [StorageDashboardQuery.CEPH_CAPACITY_USED]: 'ceph_cluster_total_used_bytes',
   [StorageDashboardQuery.UTILIZATION_IOPS_QUERY]:
     '(sum(rate(ceph_pool_wr[1m])) + sum(rate(ceph_pool_rd[1m])))',
   [StorageDashboardQuery.UTILIZATION_LATENCY_QUERY]:

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -113,7 +113,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       position: GridPosition.MAIN,
       loader: () =>
         import(
-          './components/dashboard-page/storage-dashboard/top-consumers-card/top-consumers-card' /* webpackChunkName: "ceph-storage-top-consumers-card" */
+          './components/dashboard-page/storage-dashboard/utilization-card/utilization-card' /* webpackChunkName: "ceph-storage-utilization-card" */
         ).then((m) => m.default),
       required: CEPH_FLAG,
     },
@@ -128,18 +128,6 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboard-page/storage-dashboard/activity-card/activity-card' /* webpackChunkName: "ceph-storage-activity-card" */
         ).then((m) => m.ActivityCard),
-      required: CEPH_FLAG,
-    },
-  },
-  {
-    type: 'Dashboards/Card',
-    properties: {
-      tab: 'persistent-storage',
-      position: GridPosition.RIGHT,
-      loader: () =>
-        import(
-          './components/dashboard-page/storage-dashboard/utilization-card/utilization-card' /* webpackChunkName: "ceph-storage-utilization-card" */
-        ).then((m) => m.default),
       required: CEPH_FLAG,
     },
   },


### PR DESCRIPTION
- [x] Move the utilization to the center grid of the dashboard.
- [x] Remove top utilization from the persistent storage page.
- [x] Add "Used capacity" to utilization charts.
![Screenshot from 2019-10-14 14-34-12](https://user-images.githubusercontent.com/54092533/66740038-bcfde280-ee8f-11e9-859f-4fba1aeddf76.png)