### PR TITLE
Bug 1755699: Removes Add capacity option for other storage operators

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -203,6 +203,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       kind: 'StorageCluster',
       label: 'Add Capacity',
+      apiGroup: models.OCSServiceModel.apiGroup,
       callback: (kind, ocsConfig) => () => {
         const clusterObject = { ocsConfig };
         import(

--- a/frontend/packages/console-plugin-sdk/src/typings/clusterserviceversions.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/clusterserviceversions.ts
@@ -7,6 +7,8 @@ namespace ExtensionProperties {
     kind: K8sResourceKindReference;
     /** label of action */
     label: string;
+    /** API group of the resource */
+    apiGroup: string;
     /** action callback */
     callback: (kind: K8sResourceKindReference, obj: any) => () => any;
   }

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand.tsx
@@ -36,6 +36,7 @@ import {
   referenceFor,
   GroupVersionKind,
   referenceForModel,
+  groupVersionFor,
 } from '@console/internal/module/k8s';
 import { deleteModal } from '@console/internal/components/modals';
 import { RootState } from '@console/internal/redux';
@@ -60,7 +61,11 @@ const csvName = () =>
 const getActions = (selectedObj: any) => {
   const actions = plugins.registry
     .getClusterServiceVersionActions()
-    .filter((action) => action.properties.kind === selectedObj.kind);
+    .filter(
+      (action) =>
+        action.properties.kind === selectedObj.kind &&
+        groupVersionFor(selectedObj.apiVersion).group === action.properties.apiGroup,
+    );
   const pluginActions = actions.map((action) => (kind, ocsObj) => ({
     label: action.properties.label,
     callback: action.properties.callback(kind, ocsObj),


### PR DESCRIPTION
Storage like Potworx shows `Add Capacity` which is only supported
for OCS, the PR checks for storage type before showing the option
Signed-off-by: Kanika <kmurarka@redhat.com>

Thanks @umangachapagain for pointers