### PR TITLE
Add conditions for hiding 'Restart VM' Action

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -14,6 +14,7 @@ import { startVMIMigration } from '../../k8s/requests/vmi';
 import { cancelMigration } from '../../k8s/requests/vmim';
 import { cloneVMModal } from '../modals/clone-vm-modal';
 import { getVMStatus } from '../../statuses/vm/vm';
+import { VM_STATUS_STARTING, VM_STATUS_VMI_WAITING } from '@console/kubevirt-plugin/src/statuses/vm/constants';
 
 type ActionArgs = {
   migration?: K8sResourceKind;
@@ -71,7 +72,12 @@ const menuActionRestart = (
 ): KebabOption => {
   const title = 'Restart Virtual Machine';
   return {
-    hidden: isVMImporting(vmStatus) || !isVMRunningWithVMI({ vm, vmi }) || isMigrating(migration),
+    hidden:
+      isVMImporting(vmStatus) ||
+      !isVMRunningWithVMI({ vm, vmi }) ||
+      isMigrating(migration) ||
+      vmStatus.status === VM_STATUS_STARTING ||
+      vmStatus.status === VM_STATUS_VMI_WAITING,
     label: title,
     callback: () =>
       confirmModal({


### PR DESCRIPTION
Hide the action 'Restart Virtual Machine' from the VM's
Actions dropdown menu when the VM is also at a "Starting" and
"Waiting" state.
This should prevent from the user to restart the VM before the
VM is at a running or a failed state.

Fixes: https://bugzilla.redhat.com/1743514

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>