### PR TITLE
Enable YAML schema sidebar on create

### DIFF
--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -1,12 +1,32 @@
-$co-m-horizontal-nav__menu-item-link-padding-lr: 15px;
+$co-m-horizontal-nav__menu-item-link-padding-lr: ($grid-gutter-width / 2);
 
 .co-m-horizontal-nav__menu {
   border-bottom: 1px solid $color-grey-background-border;
   display: flex;
   white-space: nowrap;
   @media (min-width: $grid-float-breakpoint) {
-    margin-left: (-$co-m-horizontal-nav__menu-item-link-padding-lr);
-    padding: 0 30px;
+    padding-left: $co-m-horizontal-nav__menu-item-link-padding-lr;
+    padding-right: ($co-m-horizontal-nav__menu-item-link-padding-lr * 2);
+  }
+  &--within-sidebar {
+    border-top: 1px solid $color-grey-background-border;
+    margin-bottom: $grid-gutter-width;
+    margin-left: -($grid-gutter-width / 2);
+    margin-right: -($grid-gutter-width / 2);
+    @media (min-width: $grid-float-breakpoint) {
+      margin-left: -($grid-gutter-width);
+      margin-right: -($grid-gutter-width);
+    }
+    .co-m-horizontal-nav__menu-item {
+      font-size: 16px;
+      line-height: normal;
+    }
+  }
+  &--within-overview-sidebar {
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 5px;
+    padding-right: 5px;
   }
 }
 
@@ -70,17 +90,4 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: 15px;
 .co-m-horizontal-nav__menu-item--divider {
   border-left: 1px solid $color-grey-background-border;
   margin: 0 10px;
-}
-
-.overview__sidebar {
-  .co-m-horizontal-nav__menu {
-    padding: 0 5px;
-    @media (min-width: $grid-float-breakpoint) {
-      padding: 0 20px;
-    }
-  }
-  .co-m-horizontal-nav__menu-item {
-    font-size: 16px;
-    line-height: normal;
-  }
 }

--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -343,7 +343,7 @@ const APIResourceOverview: React.FC<APIResourceTabProps> = ({customData: {kindOb
 const scrollTop = () => document.getElementById('content-scrollable').scrollTop = 0;
 const APIResourceSchema: React.FC<APIResourceTabProps> = ({customData: {kindObj}}) => {
   return (
-    <div className="co-m-pane__body co-m-pane__body--no-top-margin">
+    <div className="co-m-pane__body">
       <ExploreType kindObj={kindObj} scrollTop={scrollTop} />
     </div>
   );

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -16,7 +16,6 @@ import {
 import { ALL_NAMESPACES_KEY } from '../const';
 import { k8sCreate, k8sUpdate, referenceFor, groupVersionFor, referenceForModel } from '../module/k8s';
 import { checkAccess, history, Loading, resourceObjPath } from './utils';
-import { ExploreTypeSidebar } from './sidebars/explore-type-sidebar';
 import { ResourceSidebar } from './sidebars/resource-sidebar';
 import { yamlTemplates } from '../models/yaml-templates';
 
@@ -579,8 +578,7 @@ export const EditYAML = connect(stateToProps)(
                   </div>
                 </div>
               </div>
-              {create && <ResourceSidebar isCreateMode={create} kindObj={model} height={height} loadSampleYaml={this.loadSampleYaml_} downloadSampleYaml={this.downloadSampleYaml_} />}
-              {!create && <ExploreTypeSidebar kindObj={model} height={this.state.height} />}
+              <ResourceSidebar isCreateMode={create} kindObj={model} height={height} loadSampleYaml={this.loadSampleYaml_} downloadSampleYaml={this.downloadSampleYaml_} />
             </div>
           </div>
         </div>

--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -53,12 +53,10 @@ $overview-sidebar-width: 550px;
 }
 
 .overview__sidebar-pane-body {
-  margin: $grid-gutter-width 0 0;
   padding: 0 20px;
 }
 
 .overview__sidebar-pane-head {
-  border-bottom: 1px solid $color-grey-background-border;
   padding-top: 5px;
 
   .co-m-pane__heading {

--- a/frontend/public/components/overview/resource-overview-details.tsx
+++ b/frontend/public/components/overview/resource-overview-details.tsx
@@ -51,6 +51,7 @@ export const ResourceOverviewDetails = connect<PropsFromState, PropsFromDispatch
         selectedTab={selectedDetailsTab}
         tabProps={{item}}
         tabs={getPluginTabResources(item,tabs)}
+        additionalClassNames="co-m-horizontal-nav__menu--within-sidebar co-m-horizontal-nav__menu--within-overview-sidebar"
       />
     </div>
 );

--- a/frontend/public/components/sidebars/_resource-sidebar.scss
+++ b/frontend/public/components/sidebars/_resource-sidebar.scss
@@ -1,7 +1,3 @@
-.co-resource-sidebar-header {
-  margin: 0;
-}
-
 .co-resource-sidebar-list {
   padding-left: 15px;
 }
@@ -12,6 +8,7 @@
 
   &:first-child {
     border-top: 0;
+    padding-top: 0;
   }
 }
 

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -3,7 +3,6 @@ import * as _ from 'lodash-es';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 
 import { getDefinitionKey, getStoredSwagger, K8sKind, SwaggerDefinition, SwaggerDefinitions } from '../../module/k8s';
-import { ResourceSidebarWrapper, sidebarScrollTop } from './resource-sidebar';
 import { CamelCaseWrap, EmptyBox, LinkifyExternal } from '../utils';
 
 const getRef = (definition: SwaggerDefinition): string => {
@@ -78,7 +77,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
 
   return (
     <React.Fragment>
-      <Breadcrumb>
+      {!_.isEmpty(breadcrumbs) && <Breadcrumb className="pf-c-breadcrumb--no-padding-top">
         {breadcrumbs.map((crumb, i) => {
           const isLast = i === breadcrumbs.length - 1;
           return <BreadcrumbItem key={i} isActive={isLast}>
@@ -87,7 +86,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
               : <button type="button" className="btn btn-link btn-link--no-btn-default-values" onClick={e => breadcrumbClicked(e, i)}>{crumb}</button>}
           </BreadcrumbItem>;
         })}
-      </Breadcrumb>
+      </Breadcrumb>}
       {description && <p className="co-break-word co-pre-line"><LinkifyExternal>{description}</LinkifyExternal></p>}
       {_.isEmpty(currentDefinition.properties)
         ? <EmptyBox label="Properties" />
@@ -116,17 +115,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   );
 };
 
-export const ExploreTypeSidebar: React.FC<ExploreTypeSidebarProps> = ({height, ...exploreTypeProps}) => (
-  <ResourceSidebarWrapper label={exploreTypeProps.kindObj.kind} linkLabel="View Schema" style={{height}} startHidden>
-    <ExploreType {...exploreTypeProps} scrollTop={sidebarScrollTop} />
-  </ResourceSidebarWrapper>
-);
-
 type ExploreTypeProps = {
   kindObj: K8sKind;
   scrollTop?: () => void;
 };
-
-type ExploreTypeSidebarProps = {
-  height: number;
-} & ExploreTypeProps;

--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -7,12 +7,14 @@ import {
 } from '@patternfly/react-icons';
 
 import { resourceSidebars } from './resource-sidebars';
+import { ExploreType } from './explore-type-sidebar';
+import { SimpleTabNav } from '../utils';
 
-export const sidebarScrollTop = () => {
+const sidebarScrollTop = () => {
   document.getElementsByClassName('co-p-has-sidebar__sidebar')[0].scrollTop = 0;
 };
 
-export class ResourceSidebarWrapper extends React.Component {
+class ResourceSidebarWrapper extends React.Component {
   constructor(props) {
     super(props);
     this.toggleSidebar = this.toggleSidebar.bind(this);
@@ -45,9 +47,9 @@ export class ResourceSidebarWrapper extends React.Component {
         <button type="button" className="close" aria-label="Close" onClick={this.toggleSidebar}>
           <CloseIcon />
         </button>
-        <h1 className="co-p-has-sidebar__sidebar-heading co-resource-sidebar-header text-capitalize">
+        <h2 className="co-p-has-sidebar__sidebar-heading text-capitalize">
           {label}
-        </h1>
+        </h2>
         {children}
       </div>
     </div>;
@@ -73,18 +75,49 @@ export const SampleYaml = ({sample, loadSampleYaml, downloadSampleYaml}) => {
   </li>;
 };
 
+const ResourceSchema = ({kindObj}) => <ExploreType kindObj={kindObj} scrollTop={sidebarScrollTop} />;
+
 export const ResourceSidebar = props => {
-  const {kindObj, height} = props;
-  if (!kindObj || !props.isCreateMode) {
+  const {
+    downloadSampleYaml,
+    height,
+    isCreateMode,
+    kindObj,
+    loadSampleYaml,
+  } = props;
+  if (!kindObj) {
     return null;
   }
 
   const {kind, label} = kindObj;
-  const SidebarComponent = resourceSidebars.get(kind);
-  if (SidebarComponent) {
-    return <ResourceSidebarWrapper label={`${label} Samples`} linkLabel="View Samples" style={{height}}>
-      <SidebarComponent {...props} />
-    </ResourceSidebarWrapper>;
-  }
-  return null;
+  const ResourceSamples = resourceSidebars.get(kind);
+  const showSamples = ResourceSamples && isCreateMode;
+
+  return <ResourceSidebarWrapper
+    label={label}
+    linkLabel={`View Schema ${showSamples ? 'and Samples' : ''}`}
+    style={{height}}
+    startHidden={!isCreateMode}
+  >
+    { showSamples
+      ? <SimpleTabNav
+        tabs={[
+          {
+            name: 'Schema',
+            component: ResourceSchema,
+          },
+          {
+            name: 'Samples',
+            component: ResourceSamples,
+          },
+        ]}
+        tabProps={{
+          downloadSampleYaml,
+          kindObj,
+          loadSampleYaml,
+        }}
+        additionalClassNames="co-m-horizontal-nav__menu--within-sidebar"
+      />
+      : <ResourceSchema kindObj={kindObj} /> }
+  </ResourceSidebarWrapper>;
 };

--- a/frontend/public/components/utils/simple-tab-nav.tsx
+++ b/frontend/public/components/utils/simple-tab-nav.tsx
@@ -31,19 +31,19 @@ export class SimpleTabNav extends React.Component<SimpleTabNavProps, SimpleTabNa
 
   onClickTab(name) {
     const {tabs} = this.props;
-    this.props.onClickTab(name);
+    this.props.onClickTab && this.props.onClickTab(name);
     this.setState({
       'selectedTab': _.find(tabs, {name}),
     });
   }
 
   render() {
-    const {tabs, tabProps} = this.props;
+    const {tabs, tabProps, additionalClassNames} = this.props;
     const {selectedTab} = this.state;
     const Component = selectedTab.component;
 
     return <React.Fragment>
-      <div className="co-m-horizontal-nav__menu">
+      <div className={classNames('co-m-horizontal-nav__menu', additionalClassNames)}>
         <ul className="co-m-horizontal-nav__menu-primary">
           {
             _.map(tabs, (tab) => (
@@ -70,6 +70,7 @@ type SimpleTabNavProps = {
     name: string;
     component: any;
   }[];
+  additionalClassNames?: string;
 };
 
 type SimpleTabNavState = {

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -48,12 +48,8 @@ body,
   }
 
   &__sidebar-heading {
-    font-size: 17px;
+    @include co-break-word;
     margin-bottom: 20px;
-    margin-top: 45px;
-  }
-
-  &__sidebar-heading--first {
     margin-top: 0;
   }
 

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -113,6 +113,10 @@ h6 {
 .pf-c-breadcrumb {
   padding-bottom: 12px;
   padding-top: 25px;
+
+  &--no-padding-top {
+    padding-top: 0;
+  }
 }
 
 .pf-c-button--align-right {


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-1551

When creating, the sidebar is open by default.  When editing, the sidebar is closed by default.

Tabs only appear when creating **and** the resource has samples (which is currently BuildConfig, ClusterRole, NetworkPolicy, ResourceQuota, Role).

Creating with samples
![localhost_9000_k8s_ns_openshift-console_buildconfigs__new](https://user-images.githubusercontent.com/895728/65699035-787ae600-e04b-11e9-8401-e84ae148a9d2.png)
![localhost_9000_k8s_ns_openshift-console_buildconfigs__new (1)](https://user-images.githubusercontent.com/895728/65699076-8892c580-e04b-11e9-82e4-e54b834b5b20.png)
Creating with samples closed sidebar
![localhost_9000_k8s_ns_openshift-console_buildconfigs__new (4)](https://user-images.githubusercontent.com/895728/65699120-98120e80-e04b-11e9-9395-7d2bdf3627eb.png)

Creating
![localhost_9000_k8s_ns_openshift-monitoring_buildconfigs__new](https://user-images.githubusercontent.com/895728/65699518-37cf9c80-e04c-11e9-9a5b-c7059994b070.png)
Creating closed sidebar
![localhost_9000_k8s_ns_openshift-monitoring_buildconfigs__new (1)](https://user-images.githubusercontent.com/895728/65699537-3d2ce700-e04c-11e9-81ea-ee30f5618658.png)

Editing
![localhost_9000_k8s_ns_openshift-console_buildconfigs__new (2)](https://user-images.githubusercontent.com/895728/65699077-8892c580-e04b-11e9-9749-c51ac0823d22.png)
Editing open sidebar
![localhost_9000_k8s_ns_openshift-console_buildconfigs__new (3)](https://user-images.githubusercontent.com/895728/65699135-a06a4980-e04b-11e9-8467-ab3248cae243.png)

