### PR TITLE
fixes permission issue with serverless in topology and sidebar

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/overview.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/overview.ts
@@ -1,4 +1,4 @@
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, AccessReviewResourceAttributes } from '@console/internal/module/k8s';
 import { FirehoseResource } from '@console/internal/components/utils';
 import { OverviewDetailsResourcesTabProps } from '@console/internal/components/overview/resource-overview-page';
 import { OverviewMainContentProps } from '@console/internal/components/overview';
@@ -19,6 +19,9 @@ namespace ExtensionProperties {
 
     /** util to check get resources. */
     utils: (dc: K8sResourceKind, props: OverviewMainContentProps) => ResourceItem;
+
+    /** resource attribute to check authorization(RBAC) against */
+    auth: (namespace: string) => AccessReviewResourceAttributes;
   }
 
   export interface OverviewResourceTab {

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -25,6 +25,7 @@ import {
   knativeServingResourcesRevision,
   knativeServingResourcesConfigurations,
   knativeServingResourcesRoutes,
+  checkServerlessAccess,
 } from './utils/create-knative-utils';
 import {
   getKnativeServingConfigurations,
@@ -146,6 +147,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       resources: knativeServingResourcesRevision,
       required: FLAG_KNATIVE_SERVING_REVISION,
       utils: getKnativeServingRevisions,
+      auth: checkServerlessAccess,
     },
   },
   {
@@ -154,6 +156,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       resources: knativeServingResourcesConfigurations,
       required: FLAG_KNATIVE_SERVING_CONFIGURATION,
       utils: getKnativeServingConfigurations,
+      auth: checkServerlessAccess,
     },
   },
   {
@@ -162,6 +165,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       resources: knativeServingResourcesRoutes,
       required: FLAG_KNATIVE_SERVING_ROUTE,
       utils: getKnativeServingRoutes,
+      auth: checkServerlessAccess,
     },
   },
   {

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -1,4 +1,9 @@
-import { k8sCreate, K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import {
+  k8sCreate,
+  K8sResourceKind,
+  referenceForModel,
+  AccessReviewResourceAttributes,
+} from '@console/internal/module/k8s';
 import { FirehoseResource } from '@console/internal/components/utils';
 import {
   ServiceModel,
@@ -181,4 +186,14 @@ export const knativeServingResourcesRoutes = (namespace: string): FirehoseResour
     },
   ];
   return knativeResource;
+};
+
+export const checkServerlessAccess = (namespace: string): AccessReviewResourceAttributes => {
+  const resourceAttributes: AccessReviewResourceAttributes = {
+    group: ServiceModel.apiGroup,
+    resource: ServiceModel.plural,
+    verb: 'get',
+    namespace,
+  };
+  return resourceAttributes;
 };


### PR DESCRIPTION
- fixes permission issue with serverless in topology and sidebar

Tracks : https://jira.coreos.com/browse/ODC-1945

Steps to test : 
- Login with `kubeadmin`,  create a namespace/project say "kubeApp" and deploy an application in it.
- Setup serverless TP1 on the cluster, follow https://docs.openshift.com/container-platform/4.1/serverless/installing-openshift-serverless.html
- create a namespace/project say "appServerless" and deploy a serverless application in it.
- Create a non-admin user
- Create a namespace/project say "appDeveloper" and deploy a serverless application in it.
- When non Admin user tries to access Project "kubeApp" or "appServerless" Via topology view or workloads would get permission issue as in Jira ticket.
- With this PR shouldn't get Permission issue 