### PR TITLE
Bug 1734431: Disable ROX access-mode for Ceph based provisioner

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
@@ -59,3 +59,10 @@ export const getOCSVersion = (items: FirehoseResult): string => {
   );
   return _.get(operator, 'status.currentCSV');
 };
+
+// To check if the provisioner is OCS based
+export const isCephProvisioner = (scProvisioner: string) => {
+  return cephStorageProvisioners.some((provisioner: string) =>
+    _.endsWith(scProvisioner, provisioner),
+  );
+};


### PR DESCRIPTION
ROX being not supported in 4.2 for OCS, shouldn't be allowed to be selected by user for creating PVCs.
![Screenshot from 2019-09-27 18-58-28](https://user-images.githubusercontent.com/12200504/65774589-2e355a00-e15c-11e9-94b9-4d50c18b5d0c.png)

Signed-off-by: Kanika <kmurarka@redhat.com>

Thanks @gnehapk for pointers