### PR TITLE
Bug 1755477: Removes dependency on SC for filtering cpeh PVCs

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/inventory-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/inventory-card.tsx
@@ -96,7 +96,7 @@ const InventoryCard: React.FC<DashboardItemProps> = ({
             error={!!pvcsLoadError}
             kind={PersistentVolumeClaimModel}
             useAbbr
-            resources={getCephPVCs(filteredSCNames, pvcsData)}
+            resources={getCephPVCs(filteredSCNames, pvcsData, pvsData)}
             mapper={getPVCStatusGroups}
             showLink={false}
           />

--- a/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
@@ -10,17 +10,6 @@ const cephStorageLabel = 'cluster.ocs.openshift.io/openshift-storage';
 export const filterCephAlerts = (alerts: Alert[]): Alert[] =>
   alerts.filter((alert) => _.get(alert, 'annotations.storage_type') === 'ceph');
 
-export const getCephPVCs = (
-  cephSCNames: string[] = [],
-  pvcsData: K8sResourceKind[] = [],
-): K8sResourceKind[] =>
-  pvcsData.filter((pvc) =>
-    cephSCNames.includes(
-      _.get(pvc, 'spec.storageClassName') ||
-        _.get(pvc, ['metadata', 'annotations', 'volume.beta.kubernetes.io/storage-class']),
-    ),
-  );
-
 export const getCephPVs = (pvsData: K8sResourceKind[] = []): K8sResourceKind[] =>
   pvsData.filter((pv) => {
     return cephStorageProvisioners.some((provisioner: string) =>
@@ -29,6 +18,28 @@ export const getCephPVs = (pvsData: K8sResourceKind[] = []): K8sResourceKind[] =
       ),
     );
   });
+
+const getPVStorageClass = (pv: K8sResourceKind) => _.get(pv, 'spec.storageClassName');
+const getStorageClassName = (pvc: K8sResourceKind) =>
+  _.get(pvc, ['metadata', 'annotations', 'volume.beta.kubernetes.io/storage-class']) ||
+  _.get(pvc, 'spec.storageClassName');
+const isBound = (pvc: K8sResourceKind) => _.get(pvc, 'status.phase') === 'Bound';
+
+export const getCephPVCs = (
+  cephSCNames: string[] = [],
+  pvcsData: K8sResourceKind[] = [],
+  pvsData: K8sResourceKind[] = [],
+): K8sResourceKind[] => {
+  const cephPVs = getCephPVs(pvsData);
+  const cephSCNameSet = new Set<string>([...cephSCNames, ...cephPVs.map(getPVStorageClass)]);
+  const cephBoundPVCUIDSet = new Set<string>(_.map(cephPVs, 'spec.claimRef.uid'));
+  // If the PVC is bound use claim uid(links PVC to PV) else storage class to verify it's provisioned by ceph.
+  return pvcsData.filter((pvc: K8sResourceKind) =>
+    isBound(pvc)
+      ? cephBoundPVCUIDSet.has(pvc.metadata.uid)
+      : cephSCNameSet.has(getStorageClassName(pvc)),
+  );
+};
 
 export const getCephNodes = (nodesData: K8sResourceKind[] = []): K8sResourceKind[] =>
   nodesData.filter((node) => _.keys(_.get(node, 'metadata.labels')).includes(cephStorageLabel));


### PR DESCRIPTION
The count of PVC's on the persistent storage dashboard now is not dependent on storage class.
- For bound PVC's it uses the claim reference between the PV and PVC to get Ceph provisioned PVCs.
-For unbound PVC's it uses the storage class names provisioned by Ceph and if they are not present then it can also use the storage class name of the PVC's and matches it against the PV's storage classes which are provisioned by the Ceph provisioner.