### PR TITLE
Fix for ChartDonut data based attribute settings

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
@@ -138,12 +138,13 @@ class PodStatus extends React.Component<PodStatusProps, PodStatusState> {
         labelComponent={<Tooltip x={0} y={0} width={size} height={size * -0.2} />}
         /*
           // @ts-ignore */
-        padAngle={(d: PodData) => (d.y > 0 ? 2 : 0)}
+        padAngle={({ datum }) => (datum.y > 0 ? 2 : 0)}
         style={{
           data: {
-            fill: (d: PodData) => podColor[d.x],
-            stroke: (d: PodData) =>
-              (d.x === 'Scaled to 0' || d.x === 'Idle' || d.x === 'Autoscaled to 0') && d.y > 0
+            fill: ({ datum }) => podColor[datum.x],
+            stroke: ({ datum }) =>
+              (datum.x === 'Scaled to 0' || datum.x === 'Idle' || datum.x === 'Autoscaled to 0') &&
+              datum.y > 0
                 ? '#BBBBBB'
                 : 'none',
             strokeWidth: 1,

--- a/frontend/packages/noobaa-storage-plugin/src/components/capacity-card/capacity-card-body.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/capacity-card/capacity-card-body.tsx
@@ -67,7 +67,9 @@ export const CapacityCardBody: React.FC<CapacityCardBodyProps> = ({
           legendData={metricLegend}
           legendOrientation="vertical"
           data={metricData}
-          labels={(datum) => `${datum.x}: ${humanizePercentage(totalUsage ? datum.y : 0).string}`}
+          labels={({ datum }) =>
+            `${datum.x}: ${humanizePercentage(totalUsage ? datum.y : 0).string}`
+          }
           themeColor={ChartThemeColor.multi}
           themeVariant={ChartThemeVariant.light}
           title={totalHumanized.string}


### PR DESCRIPTION
The major update to VictoryCharts 5 changed the value passed to the callbacks.

Fixes https://jira.coreos.com/browse/CONSOLE-1776