### PR TITLE
fix permission issue with serverless

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/overview.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/overview.ts
@@ -18,7 +18,10 @@ namespace ExtensionProperties {
     required: string;
 
     /** util to check get resources. */
-    utils: (dc: K8sResourceKind, props: OverviewMainContentProps) => ResourceItem;
+    utils: (
+      dc: K8sResourceKind,
+      props: OverviewMainContentProps,
+    ) => ResourceItem | K8sResourceKind[];
   }
 
   export interface OverviewResourceTab {

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -117,36 +117,6 @@ export const createKnativeService = (
   return k8sCreate(ServiceModel, knativeDeployResource);
 };
 
-export const knativeServingResources = (namespace: string): FirehoseResource[] => {
-  const knativeResource = [
-    {
-      isList: true,
-      kind: referenceForModel(RevisionModel),
-      namespace,
-      prop: 'revisions',
-    },
-    {
-      isList: true,
-      kind: referenceForModel(ConfigurationModel),
-      namespace,
-      prop: 'configurations',
-    },
-    {
-      isList: true,
-      kind: referenceForModel(RouteModel),
-      namespace,
-      prop: 'ksroutes',
-    },
-    {
-      isList: true,
-      kind: referenceForModel(ServiceModel),
-      namespace,
-      prop: 'ksservices',
-    },
-  ];
-  return knativeResource;
-};
-
 export const knativeServingResourcesRevision = (namespace: string): FirehoseResource[] => {
   const knativeResource = [
     {
@@ -154,6 +124,7 @@ export const knativeServingResourcesRevision = (namespace: string): FirehoseReso
       kind: referenceForModel(RevisionModel),
       namespace,
       prop: 'revisions',
+      optional: true,
     },
   ];
   return knativeResource;
@@ -166,6 +137,7 @@ export const knativeServingResourcesConfigurations = (namespace: string): Fireho
       kind: referenceForModel(ConfigurationModel),
       namespace,
       prop: 'configurations',
+      optional: true,
     },
   ];
   return knativeResource;
@@ -178,6 +150,23 @@ export const knativeServingResourcesRoutes = (namespace: string): FirehoseResour
       kind: referenceForModel(RouteModel),
       namespace,
       prop: 'ksroutes',
+      optional: true,
+    },
+  ];
+  return knativeResource;
+};
+
+export const knativeServingResources = (namespace: string): FirehoseResource[] => {
+  const knativeResource = [
+    ...knativeServingResourcesRevision(namespace),
+    ...knativeServingResourcesConfigurations(namespace),
+    ...knativeServingResourcesRoutes(namespace),
+    {
+      isList: true,
+      kind: referenceForModel(ServiceModel),
+      namespace,
+      prop: 'ksservices',
+      optional: true,
     },
   ];
   return knativeResource;

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -42,23 +42,41 @@ const getRevisions = (dc: K8sResourceKind, { revisions }): K8sResourceKind[] => 
   return revisionResource;
 };
 
-export const getKnativeServingRevisions = (dc: K8sResourceKind, props): KnativeItem => {
+export const getKnativeServingRevisions = (
+  dc: K8sResourceKind,
+  props,
+): KnativeItem | K8sResourceKind[] => {
   const revisions = getRevisions(dc, props);
-  return {
-    revisions,
-  };
+  if (revisions.length) {
+    return {
+      revisions,
+    };
+  }
+  return revisions;
 };
 
-export const getKnativeServingConfigurations = (dc: K8sResourceKind, props): KnativeItem => {
+export const getKnativeServingConfigurations = (
+  dc: K8sResourceKind,
+  props,
+): KnativeItem | K8sResourceKind[] => {
   const configurations = getConfigurations(dc, props);
-  return {
-    configurations,
-  };
+  if (configurations.length) {
+    return {
+      configurations,
+    };
+  }
+  return configurations;
 };
 
-export const getKnativeServingRoutes = (dc: K8sResourceKind, props): KnativeItem => {
+export const getKnativeServingRoutes = (
+  dc: K8sResourceKind,
+  props,
+): KnativeItem | K8sResourceKind[] => {
   const ksroutes = getKSRoute(dc, props);
-  return {
-    ksroutes,
-  };
+  if (ksroutes.length) {
+    return {
+      ksroutes,
+    };
+  }
+  return ksroutes;
 };


### PR DESCRIPTION
- fix permission issue with serverless

Tracks : https://jira.coreos.com/browse/ODC-1945

Steps to test : 
- Login with `kubeadmin`,  create a namespace/project say "kubeApp" and deploy an application in it.
- Setup serverless TP1 on the cluster, follow https://docs.openshift.com/container-platform/4.1/serverless/installing-openshift-serverless.html
- create a namespace/project say "appServerless" and deploy a serverless application in it.
- Create a non-admin user
- Create a namespace/project say "appDeveloper" and deploy a serverless application in it.
- When non Admin user tries to access Project "kubeApp" or "appServerless" Via topology view or workloads would get permission issue as in Jira ticket.
- With this PR shouldn't get Permission issue 