### PR TITLE
Bug: Deploy image ignores target port drop down selection and always uses first entry

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__mocks__/deployImage-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/deployImage-validation-mock.ts
@@ -1,6 +1,6 @@
 import { DeployImageFormData } from '../import-types';
 
-export const mockFormData: DeployImageFormData = {
+export const mockDeployImageFormData: DeployImageFormData = {
   project: {
     name: 'mock-project',
     displayName: '',

--- a/frontend/packages/dev-console/src/components/import/__tests__/deployImage-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/deployImage-validation-utils.spec.ts
@@ -1,18 +1,18 @@
 import { cloneDeep } from 'lodash';
 import { deployValidationSchema } from '../deployImage-validation-utils';
-import { mockFormData } from '../__mocks__/deployImage-validation-mock';
+import { mockDeployImageFormData } from '../__mocks__/deployImage-validation-mock';
 import { CREATE_APPLICATION_KEY, UNASSIGNED_KEY } from '../app/ApplicationSelector';
 import { serverlessCommonTests } from './serverless-common-tests';
 
 describe('Deploy Image ValidationUtils', () => {
   describe('Validation Schema', () => {
     it('should validate the form data', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(true));
     });
 
     it('should throw an error for required fields if empty', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.name = '';
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
       await deployValidationSchema.validate(mockData).catch((err) => {
@@ -22,7 +22,7 @@ describe('Deploy Image ValidationUtils', () => {
     });
 
     it('should throw an error if name is invalid', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.name = 'app_name';
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
       await deployValidationSchema.validate(mockData).catch((err) => {
@@ -33,7 +33,7 @@ describe('Deploy Image ValidationUtils', () => {
     });
 
     it('should throw an error when no application name given for create application option', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.application.selectedKey = CREATE_APPLICATION_KEY;
       mockData.application.name = '';
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
@@ -43,21 +43,21 @@ describe('Deploy Image ValidationUtils', () => {
     });
 
     it('should not throw an error when unassigned application is chosen', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.application.selectedKey = UNASSIGNED_KEY;
       mockData.application.name = '';
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(true));
     });
 
     it('should not throw an error when allowing either create or unassigned application', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.application.selectedKey = '';
       mockData.application.name = '';
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(true));
     });
 
     it('should throw an error if path is invalid', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.route.path = 'path';
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
       await deployValidationSchema.validate(mockData).catch((err) => {
@@ -66,7 +66,7 @@ describe('Deploy Image ValidationUtils', () => {
     });
 
     it('should throw an error if hostname is invalid', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.route.hostname = 'host_name';
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
       await deployValidationSchema.validate(mockData).catch((err) => {
@@ -77,7 +77,7 @@ describe('Deploy Image ValidationUtils', () => {
     });
 
     it('should throw an error if request is greater than limit', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.limits.cpu.request = 3;
       mockData.limits.cpu.requestUnit = 'm';
       mockData.limits.cpu.limit = 2;
@@ -89,7 +89,7 @@ describe('Deploy Image ValidationUtils', () => {
     });
 
     it('should throw an error if memory request is greater than limit', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.limits.memory.request = 3;
       mockData.limits.memory.requestUnit = 'Gi';
       mockData.limits.memory.limit = 3;
@@ -101,7 +101,7 @@ describe('Deploy Image ValidationUtils', () => {
     });
 
     it('request should entered individual without validation of limit field', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.limits.cpu.request = 3;
       mockData.limits.cpu.requestUnit = 'm';
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(true));
@@ -111,7 +111,7 @@ describe('Deploy Image ValidationUtils', () => {
     });
 
     it('should throw an error if deployment replicas is not an integer', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.deployment.replicas = 3.2;
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
       await deployValidationSchema.validate(mockData).catch((err) => {
@@ -120,7 +120,7 @@ describe('Deploy Image ValidationUtils', () => {
     });
 
     it('should throw an error if deployment replicas is less than 0', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.deployment.replicas = -5;
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
       await deployValidationSchema.validate(mockData).catch((err) => {
@@ -129,7 +129,7 @@ describe('Deploy Image ValidationUtils', () => {
     });
 
     it('should throw an error if deployment replicas is greater than MAX_SAFE_INTEGER', async () => {
-      const mockData = cloneDeep(mockFormData);
+      const mockData = cloneDeep(mockDeployImageFormData);
       mockData.deployment.replicas = Number.MAX_SAFE_INTEGER + 1;
       await deployValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
       await deployValidationSchema.validate(mockData).catch((err) => {
@@ -139,6 +139,6 @@ describe('Deploy Image ValidationUtils', () => {
       });
     });
 
-    serverlessCommonTests(mockFormData, deployValidationSchema);
+    serverlessCommonTests(mockDeployImageFormData, deployValidationSchema);
   });
 });

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -1,11 +1,15 @@
 import * as _ from 'lodash';
-import { DeploymentConfigModel, ImageStreamModel } from '@console/internal/models';
+import {
+  DeploymentConfigModel,
+  ImageStreamModel,
+  ServiceModel,
+  RouteModel,
+} from '@console/internal/models';
 import { k8sCreate, K8sResourceKind } from '@console/internal/module/k8s';
 import {
   getKnativeServiceDepResource,
   ServiceModel as KnServiceModel,
 } from '@console/knative-plugin';
-import { makePortName } from '../../utils/imagestream-utils';
 import { getAppLabels, getPodLabels } from '../../utils/resource-label-utils';
 import {
   createRoute,
@@ -195,9 +199,11 @@ export const createResources = async (
     requests.push(createDeploymentConfig(formData, dryRun));
 
     if (!_.isEmpty(ports)) {
-      requests.push(createService(formData, dryRun));
+      const service = createService(formData);
+      requests.push(k8sCreate(ServiceModel, service, dryRun ? dryRunOpt : {}));
       if (canCreateRoute) {
-        requests.push(createRoute(formData, dryRun));
+        const route = createRoute(formData);
+        requests.push(k8sCreate(RouteModel, route, dryRun ? dryRunOpt : {}));
       }
     }
   } else if (!dryRun) {

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearch.tsx
@@ -62,6 +62,7 @@ const ImageSearch: React.FC = () => {
           setFieldValue('isi.status', status);
           setFieldValue('isi.ports', ports);
           setFieldValue('image.ports', ports);
+          setFieldValue('image.tag', tag);
           !values.name && setFieldValue('name', getSuggestedName(name));
           !values.application.name &&
             setFieldValue('application.name', `${getSuggestedName(name)}-app`);

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -5,6 +5,8 @@ import {
   DeploymentConfigModel,
   ProjectRequestModel,
   SecretModel,
+  ServiceModel,
+  RouteModel,
 } from '@console/internal/models';
 import { k8sCreate, K8sResourceKind } from '@console/internal/module/k8s';
 import {
@@ -316,9 +318,11 @@ export const createResources = async (
   requests.push(createDeploymentConfig(formData, imageStream, dryRun));
 
   if (!_.isEmpty(ports) || buildStrategy === 'Docker') {
-    requests.push(createService(formData, dryRun, imageStream));
+    const service = createService(formData, imageStream);
+    requests.push(k8sCreate(ServiceModel, service, dryRun ? dryRunOpt : {}));
     if (canCreateRoute) {
-      requests.push(createRoute(formData, dryRun, imageStream));
+      const route = createRoute(formData, imageStream);
+      requests.push(k8sCreate(RouteModel, route, dryRun ? dryRunOpt : {}));
     }
   }
 

--- a/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Shared submit utils Create Route should match the previous snapshot deploy image data 1`] = `
+Object {
+  "apiVersion": "route.openshift.io/v1",
+  "kind": "Route",
+  "metadata": Object {
+    "defaultAnnotations": Object {
+      "openshift.io/generated-by": "OpenShiftWebConsole",
+    },
+    "labels": Object {
+      "app": "test-app",
+      "app.kubernetes.io/component": "test-app",
+      "app.kubernetes.io/instance": "test-app",
+      "app.kubernetes.io/name": "",
+      "app.kubernetes.io/part-of": "mock-app",
+      "app.openshift.io/runtime": "",
+      "app.openshift.io/runtime-version": "latest",
+    },
+    "name": "test-app",
+    "namespace": "mock-project",
+  },
+  "spec": Object {
+    "host": "",
+    "path": "",
+    "port": Object {
+      "targetPort": "8080-tcp",
+    },
+    "to": Object {
+      "kind": "Service",
+      "name": "test-app",
+    },
+    "wildcardPolicy": "None",
+  },
+}
+`;
+
+exports[`Shared submit utils Create Route should match the previous snapshot with git import data 1`] = `
+Object {
+  "apiVersion": "route.openshift.io/v1",
+  "kind": "Route",
+  "metadata": Object {
+    "defaultAnnotations": Object {
+      "app.openshift.io/vcs-ref": "master",
+      "app.openshift.io/vcs-uri": "https://github.com/test/repo",
+    },
+    "labels": Object {
+      "app": "test-app",
+      "app.kubernetes.io/component": "test-app",
+      "app.kubernetes.io/instance": "test-app",
+      "app.kubernetes.io/name": undefined,
+      "app.kubernetes.io/part-of": "mock-app",
+      "app.openshift.io/runtime": undefined,
+      "app.openshift.io/runtime-version": "latest",
+    },
+    "name": "test-app",
+    "namespace": "mock-project",
+  },
+  "spec": Object {
+    "host": "",
+    "path": "",
+    "port": Object {
+      "targetPort": "8081-tcp",
+    },
+    "to": Object {
+      "kind": "Service",
+      "name": "test-app",
+    },
+    "wildcardPolicy": "None",
+  },
+}
+`;
+
+exports[`Shared submit utils Create Service should match the previous snapshot created with deploy image data 1`] = `
+Object {
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": Object {
+    "annotations": Object {
+      "openshift.io/generated-by": "OpenShiftWebConsole",
+    },
+    "labels": Object {
+      "app": "test-app",
+      "app.kubernetes.io/component": "test-app",
+      "app.kubernetes.io/instance": "test-app",
+      "app.kubernetes.io/name": "",
+      "app.kubernetes.io/part-of": "mock-app",
+      "app.openshift.io/runtime": "",
+      "app.openshift.io/runtime-version": "latest",
+    },
+    "name": "test-app",
+    "namespace": "mock-project",
+  },
+  "spec": Object {
+    "ports": Array [],
+    "selector": Object {
+      "app": "test-app",
+      "deploymentconfig": "test-app",
+    },
+  },
+}
+`;
+
+exports[`Shared submit utils Create Service should match the previous snapshot created with git import data 1`] = `
+Object {
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": Object {
+    "annotations": Object {
+      "app.openshift.io/vcs-ref": "master",
+      "app.openshift.io/vcs-uri": "https://github.com/test/repo",
+    },
+    "labels": Object {
+      "app": "test-app",
+      "app.kubernetes.io/component": "test-app",
+      "app.kubernetes.io/instance": "test-app",
+      "app.kubernetes.io/name": undefined,
+      "app.kubernetes.io/part-of": "mock-app",
+      "app.openshift.io/runtime": undefined,
+      "app.openshift.io/runtime-version": "latest",
+    },
+    "name": "test-app",
+    "namespace": "mock-project",
+  },
+  "spec": Object {
+    "ports": Array [],
+    "selector": Object {
+      "app": "test-app",
+      "deploymentconfig": "test-app",
+    },
+  },
+}
+`;

--- a/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
@@ -1,0 +1,42 @@
+import * as _ from 'lodash';
+import { mockFormData } from '../../components/import/__mocks__/import-validation-mock';
+import { mockDeployImageFormData } from '../../components/import/__mocks__/deployImage-validation-mock';
+import { createService, createRoute } from '../shared-submit-utils';
+import { GitImportFormData, DeployImageFormData } from '../../components/import/import-types';
+
+describe('Shared submit utils', () => {
+  describe('Create Service', () => {
+    it('should set the correct ports in service object', () => {
+      const mockData: GitImportFormData = _.cloneDeep(mockFormData);
+      const mockDeployImageData: DeployImageFormData = _.cloneDeep(mockDeployImageFormData);
+      const PORT1 = { containerPort: 8081, protocol: 'TCP' };
+      let serviceObj;
+
+      mockData.build.strategy = 'Docker';
+      mockData.docker.containerPort = 8080;
+      serviceObj = createService(mockData);
+      expect(serviceObj.spec.ports[0].port).toEqual(8080);
+
+      mockDeployImageData.image.ports = [PORT1];
+      serviceObj = createService(mockDeployImageData);
+      expect(serviceObj.spec.ports[0].port).toEqual(8081);
+    });
+  });
+
+  describe('Create Route', () => {
+    it('should set correct target port in route object', () => {
+      const mockData: GitImportFormData = _.cloneDeep(mockFormData);
+      const mockDeployImageData: DeployImageFormData = _.cloneDeep(mockDeployImageFormData);
+      let routeObj;
+
+      mockData.build.strategy = 'Docker';
+      mockData.docker.containerPort = 8080;
+      routeObj = createRoute(mockData);
+      expect(routeObj.spec.port.targetPort).toEqual('8080-tcp');
+
+      mockDeployImageData.route.targetPort = '8081-tcp';
+      routeObj = createRoute(mockDeployImageData);
+      expect(routeObj.spec.port.targetPort).toEqual('8081-tcp');
+    });
+  });
+});

--- a/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/shared-submit-utils.spec.ts
@@ -9,7 +9,7 @@ describe('Shared submit utils', () => {
     it('should set the correct ports in service object', () => {
       const mockData: GitImportFormData = _.cloneDeep(mockFormData);
       const mockDeployImageData: DeployImageFormData = _.cloneDeep(mockDeployImageFormData);
-      const PORT1 = { containerPort: 8081, protocol: 'TCP' };
+      const PORT = { containerPort: 8081, protocol: 'TCP' };
       let serviceObj;
 
       mockData.build.strategy = 'Docker';
@@ -17,9 +17,21 @@ describe('Shared submit utils', () => {
       serviceObj = createService(mockData);
       expect(serviceObj.spec.ports[0].port).toEqual(8080);
 
-      mockDeployImageData.image.ports = [PORT1];
+      mockDeployImageData.image.ports = [PORT];
       serviceObj = createService(mockDeployImageData);
       expect(serviceObj.spec.ports[0].port).toEqual(8081);
+    });
+
+    it('should match the previous snapshot created with git import data', () => {
+      const mockData: GitImportFormData = _.cloneDeep(mockFormData);
+      const serviceObj = createService(mockData);
+      expect(serviceObj).toMatchSnapshot();
+    });
+
+    it('should match the previous snapshot created with deploy image data', () => {
+      const mockDeployImageData: DeployImageFormData = _.cloneDeep(mockDeployImageFormData);
+      const serviceObj = createService(mockDeployImageData);
+      expect(serviceObj).toMatchSnapshot();
     });
   });
 
@@ -37,6 +49,20 @@ describe('Shared submit utils', () => {
       mockDeployImageData.route.targetPort = '8081-tcp';
       routeObj = createRoute(mockDeployImageData);
       expect(routeObj.spec.port.targetPort).toEqual('8081-tcp');
+    });
+
+    it('should match the previous snapshot with git import data', () => {
+      const mockData: GitImportFormData = _.cloneDeep(mockFormData);
+      mockData.route.targetPort = '8081-tcp';
+      const routeObj = createRoute(mockData);
+      expect(routeObj).toMatchSnapshot();
+    });
+
+    it('should match the previous snapshot deploy image data', () => {
+      const mockDeployImageData: DeployImageFormData = _.cloneDeep(mockDeployImageFormData);
+      mockDeployImageData.route.targetPort = '8080-tcp';
+      const routeObj = createRoute(mockDeployImageData);
+      expect(routeObj).toMatchSnapshot();
     });
   });
 });

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -1,0 +1,120 @@
+import * as _ from 'lodash';
+import { K8sResourceKind, k8sCreate } from '@console/internal/module/k8s';
+import { ServiceModel, RouteModel } from '@console/internal/models';
+import { GitImportFormData, DeployImageFormData } from '../components/import/import-types';
+import { getAppLabels, getPodLabels, getAppAnnotations } from './resource-label-utils';
+import { makePortName } from './imagestream-utils';
+
+export const annotations = {
+  'openshift.io/generated-by': 'OpenShiftWebConsole',
+};
+
+export const dryRunOpt = { queryParams: { dryRun: 'All' } };
+
+export const createService = (
+  formData: DeployImageFormData | GitImportFormData,
+  dryRun?: boolean,
+  imageStreamData?: K8sResourceKind,
+): Promise<K8sResourceKind> => {
+  const {
+    project: { name: namespace },
+    application: { name: application },
+    name,
+    labels: userLabels,
+  } = formData;
+
+  const imageStreamName = _.get(imageStreamData, 'metadata.name');
+  const imageTag = _.get(formData, 'image.tag');
+  const git = _.get(formData, 'git');
+  const ports = _.get(formData, 'image.ports') || _.get(formData, 'isi.ports');
+
+  const defaultLabels = getAppLabels(name, application, imageStreamName, imageTag);
+  const podLabels = getPodLabels(name);
+  const defaultAnnotations = git ? getAppAnnotations(git.url, git.ref) : annotations;
+
+  const service = {
+    kind: 'Service',
+    apiVersion: 'v1',
+    metadata: {
+      name,
+      namespace,
+      labels: { ...defaultLabels, ...userLabels },
+      annotations: { ...defaultAnnotations },
+    },
+    spec: {
+      selector: podLabels,
+      ports: _.map(ports, (port) => ({
+        port: port.containerPort,
+        targetPort: port.containerPort,
+        protocol: port.protocol,
+        // Use the same naming convention as CLI new-app.
+        name: makePortName(port),
+      })),
+    },
+  };
+
+  return k8sCreate(ServiceModel, service, dryRun ? dryRunOpt : {});
+};
+
+export const createRoute = (
+  formData: GitImportFormData | DeployImageFormData,
+  dryRun?: boolean,
+  imageStreamData?: K8sResourceKind,
+): Promise<K8sResourceKind> => {
+  const {
+    project: { name: namespace },
+    application: { name: application },
+    name,
+    labels: userLabels,
+    route: { hostname, secure, path, tls, targetPort: routeTargetPort },
+  } = formData;
+
+  const imageStreamName = _.get(imageStreamData, 'metadata.name');
+  const imageTag = _.get(formData, 'image.tag');
+  const git = _.get(formData, 'git');
+  const ports = _.get(formData, 'image.ports') || _.get(formData, 'isi.ports');
+
+  const defaultLabels = getAppLabels(name, application, imageStreamName, imageTag);
+  const defaultAnnotations = git ? getAppAnnotations(git.url, git.ref) : annotations;
+
+  let targetPort;
+  if (_.get(formData, 'build.strategy') === 'Docker') {
+    targetPort = makePortName({
+      containerPort: _.toInteger(_.get(formData, 'docker.containerPort')),
+      protocol: 'TCP',
+    });
+  } else {
+    targetPort = routeTargetPort || makePortName(_.head(ports));
+  }
+
+  const route = {
+    kind: 'Route',
+    apiVersion: 'route.openshift.io/v1',
+    metadata: {
+      name,
+      namespace,
+      labels: { ...defaultLabels, ...userLabels },
+      defaultAnnotations,
+    },
+    spec: {
+      to: {
+        kind: 'Service',
+        name,
+      },
+      ...(secure ? { tls } : {}),
+      host: hostname,
+      path,
+      // The service created by `createService` uses the same port as the container port.
+      port: {
+        // Use the port name, not the number for targetPort. The router looks
+        // at endpoints, not services, when resolving ports, so port numbers
+        // will not resolve correctly if the service port and container port
+        // numbers don't match.
+        targetPort,
+      },
+      wildcardPolicy: 'None',
+    },
+  };
+
+  return k8sCreate(RouteModel, route, dryRun ? dryRunOpt : {});
+};

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -1,6 +1,5 @@
 import * as _ from 'lodash';
-import { K8sResourceKind, k8sCreate } from '@console/internal/module/k8s';
-import { ServiceModel, RouteModel } from '@console/internal/models';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { GitImportFormData, DeployImageFormData } from '../components/import/import-types';
 import { getAppLabels, getPodLabels, getAppAnnotations } from './resource-label-utils';
 import { makePortName } from './imagestream-utils';
@@ -13,26 +12,30 @@ export const dryRunOpt = { queryParams: { dryRun: 'All' } };
 
 export const createService = (
   formData: DeployImageFormData | GitImportFormData,
-  dryRun?: boolean,
   imageStreamData?: K8sResourceKind,
-): Promise<K8sResourceKind> => {
+): K8sResourceKind => {
   const {
     project: { name: namespace },
     application: { name: application },
     name,
     labels: userLabels,
+    image: { ports: imagePorts, tag: imageTag },
   } = formData;
 
-  const imageStreamName = _.get(imageStreamData, 'metadata.name');
-  const imageTag = _.get(formData, 'image.tag');
+  const imageStreamName = _.get(imageStreamData, 'metadata.name') || _.get(formData, 'image.name');
   const git = _.get(formData, 'git');
-  const ports = _.get(formData, 'image.ports') || _.get(formData, 'isi.ports');
 
   const defaultLabels = getAppLabels(name, application, imageStreamName, imageTag);
   const podLabels = getPodLabels(name);
   const defaultAnnotations = git ? getAppAnnotations(git.url, git.ref) : annotations;
 
-  const service = {
+  let ports = imagePorts;
+  if (_.get(formData, 'build.strategy') === 'Docker') {
+    const port = { containerPort: _.get(formData, 'docker.containerPort'), protocol: 'TCP' };
+    ports = [port];
+  }
+
+  const service: any = {
     kind: 'Service',
     apiVersion: 'v1',
     metadata: {
@@ -53,26 +56,24 @@ export const createService = (
     },
   };
 
-  return k8sCreate(ServiceModel, service, dryRun ? dryRunOpt : {});
+  return service;
 };
 
 export const createRoute = (
   formData: GitImportFormData | DeployImageFormData,
-  dryRun?: boolean,
   imageStreamData?: K8sResourceKind,
-): Promise<K8sResourceKind> => {
+): K8sResourceKind => {
   const {
     project: { name: namespace },
     application: { name: application },
     name,
     labels: userLabels,
     route: { hostname, secure, path, tls, targetPort: routeTargetPort },
+    image: { ports, tag: imageTag },
   } = formData;
 
-  const imageStreamName = _.get(imageStreamData, 'metadata.name');
-  const imageTag = _.get(formData, 'image.tag');
+  const imageStreamName = _.get(imageStreamData, 'metadata.name') || _.get(formData, 'image.name');
   const git = _.get(formData, 'git');
-  const ports = _.get(formData, 'image.ports') || _.get(formData, 'isi.ports');
 
   const defaultLabels = getAppLabels(name, application, imageStreamName, imageTag);
   const defaultAnnotations = git ? getAppAnnotations(git.url, git.ref) : annotations;
@@ -87,7 +88,7 @@ export const createRoute = (
     targetPort = routeTargetPort || makePortName(_.head(ports));
   }
 
-  const route = {
+  const route: any = {
     kind: 'Route',
     apiVersion: 'route.openshift.io/v1',
     metadata: {
@@ -115,6 +116,5 @@ export const createRoute = (
       wildcardPolicy: 'None',
     },
   };
-
-  return k8sCreate(RouteModel, route, dryRun ? dryRunOpt : {});
+  return route;
 };

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -80,8 +80,9 @@ export const createRoute = (
 
   let targetPort;
   if (_.get(formData, 'build.strategy') === 'Docker') {
+    const port = _.get(formData, 'docker.containerPort');
     targetPort = makePortName({
-      containerPort: _.toInteger(_.get(formData, 'docker.containerPort')),
+      containerPort: _.toInteger(port),
       protocol: 'TCP',
     });
   } else {


### PR DESCRIPTION
Jira Issue - https://jira.coreos.com/browse/ODC-1911

Refactored `import-submit-utis` and `deployImage-submit-utils` 

- Extracted common code and made it shareable for both the forms
- Added container `resources` to `deploymentConfig` in `createDeploymentConfig` of `deployImage-submit-utils` 

To Do-

- [x]  Unit tests for `shared-submit-utils`