### PR TITLE
Make storage class dropdown consistent

### DIFF
--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -209,10 +209,6 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
   }
 }
 
-.co-storage-class-dropdown .pf-c-dropdown__menu {
-  min-width: 290px;
-}
-
 .dropdown-menu__autocomplete-filter {
   max-height: 60vh;
   overflow-x: hidden;

--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -10,6 +10,7 @@
   min-width: 18px;
   padding: 1px 4px;
   text-align: center;
+  white-space: nowrap;
   &--lg {
     font-size: ($font-size-base + 3);
     line-height: 20px;

--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -149,6 +149,7 @@ export class StorageClassDropdownInner extends React.Component<
             </label>
             <Dropdown
               className="co-storage-class-dropdown"
+              dropDownClassName="dropdown--full-width"
               autocompleteFilter={this.autocompleteFilter}
               autocompletePlaceholder="Select storage class"
               items={items}
@@ -189,28 +190,21 @@ const StorageClassDropdownEntry = (props) => {
   ];
   const storageClassDescriptionLine = _.compact(storageClassProperties).join(' | ');
   return (
-    <div className="form__storage-class-dropdown__flex-column">
-      <div className="form__storage-class-dropdown__flex-row">
-        <span className="form__storage-class-dropdown__icon-column">
-          <ResourceIcon kind={props.kindLabel} />
-        </span>{' '}
-        <span>{props.name}</span>
-      </div>
-      <div className="form__storage-class-dropdown__flex-row">
-        <div className="form__storage-class-dropdown__icon-column"> &nbsp;</div>
-        <div className="text-muted"> {storageClassDescriptionLine}</div>
-      </div>
-    </div>
+    <span className="co-resource-item">
+      <ResourceIcon kind={props.kindLabel} />
+      <span className="co-resource-item__resource-name">
+        {props.name}
+        <div className="text-muted small"> {storageClassDescriptionLine}</div>
+      </span>
+    </span>
   );
 };
 
 const StorageClassDropdownNoStorageClassOption = (props) => {
   return (
-    <div className="form__storage-class-dropdown__flex-column">
-      <div className="form__storage-class-dropdown__flex-row">
-        <span className="form__storage-class-dropdown__icon-column" /> <span>{props.name}</span>
-      </div>
-    </div>
+    <span className="co-resource-item">
+      <span className="co-resource-item__resource-name">{props.name}</span>
+    </span>
   );
 };
 

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -59,20 +59,6 @@
   top: 1px;
 }
 
-.form__storage-class-dropdown__flex-column {
-  display: flex;
-  flex-direction: column;
-}
-
-.form__storage-class-dropdown__flex-row {
-  display: flex;
-}
-
-.form__storage-class-dropdown__icon-column {
-  flex-basis: 30px;
-  max-width: 30px;
-}
-
 .has-feedback .pf-c-form-control {
   padding-right: 25px;
 }


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CONSOLE-1797
Item addressed
- Prevent resource badge characters from wrapping
- Make "New claim" `dropdown` full width to match "Use existing claim" `dropdown`
- Correct alignment of title and secondary grey text
- match secondary grey text size with `Search` dropdown

**Fixed**

<img width="679" alt="Screen Shot 2019-09-26 at 3 37 50 PM" src="https://user-images.githubusercontent.com/1874151/65887044-61016d00-e36b-11e9-8642-1ac5720b8e65.png">
<img width="692" alt="Screen Shot 2019-09-26 at 3 38 01 PM" src="https://user-images.githubusercontent.com/1874151/65887049-6363c700-e36b-11e9-90eb-97976a426069.png">
<img width="422" alt="Screen Shot 2019-09-27 at 3 05 40 PM" src="https://user-images.githubusercontent.com/1874151/65887072-6e1e5c00-e36b-11e9-8dee-72dd5b74f4fe.png">
<img width="369" alt="Screen Shot 2019-09-27 at 3 05 52 PM" src="https://user-images.githubusercontent.com/1874151/65887076-6fe81f80-e36b-11e9-8f69-abac90df8442.png">


