### PR TITLE
Always remove CSV when removing Subscription

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -117,12 +117,18 @@ const editSubscription = (sub: SubscriptionKind): KebabOption =>
         )}/yaml`,
       }
     : null;
-const uninstall = (sub: SubscriptionKind): KebabOption =>
+const uninstall = (sub: SubscriptionKind, displayName?: string): KebabOption =>
   !_.isNil(sub)
     ? {
         label: 'Uninstall Operator',
         callback: () =>
-          createUninstallOperatorModal({ k8sKill, k8sGet, k8sPatch, subscription: sub }),
+          createUninstallOperatorModal({
+            k8sKill,
+            k8sGet,
+            k8sPatch,
+            subscription: sub,
+            displayName,
+          }),
         accessReview: {
           group: SubscriptionModel.apiGroup,
           resource: SubscriptionModel.plural,
@@ -164,7 +170,10 @@ export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionT
       );
     const menuActions = [Kebab.factory.Edit].concat(
       !_.isNil(subscription)
-        ? [() => editSubscription(subscription), () => uninstall(subscription)]
+        ? [
+            () => editSubscription(subscription),
+            () => uninstall(subscription, obj.spec.displayName),
+          ]
         : [Kebab.factory.Delete],
     );
 
@@ -232,7 +241,7 @@ export const FailedSubscriptionTableRow: React.FC<FailedSubscriptionTableRowProp
   const { obj, index, key, style } = props;
 
   const route = resourceObjPath(obj, referenceForModel(SubscriptionModel));
-  const menuActions = [Kebab.factory.Edit, () => uninstall(obj)];
+  const menuActions = [Kebab.factory.Edit, () => uninstall(obj, obj.spec.displayName)];
   const subscriptionState = _.get(obj.status, 'state', 'Unknown');
 
   return (

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.spec.tsx
@@ -52,18 +52,6 @@ describe(UninstallOperatorModal.name, () => {
     expect(wrapper.find(ModalSubmitFooter).props().submitText).toEqual('Remove');
   });
 
-  it('renders checkbox for setting cascading delete', () => {
-    expect(
-      wrapper
-        .find('.co-delete-modal-checkbox-label')
-        .find('input')
-        .props().checked,
-    ).toBe(true);
-    expect(wrapper.find('.co-delete-modal-checkbox-label').text()).toContain(
-      'Also completely remove the Operator from the selected namespace.',
-    );
-  });
-
   it('calls `props.k8sKill` to delete the subscription when form is submitted', (done) => {
     spyAndExpect(close)(null)
       .then(() => {
@@ -116,21 +104,7 @@ describe(UninstallOperatorModal.name, () => {
     wrapper.find('form').simulate('submit', new Event('submit'));
   });
 
-  it('does not call `props.k8sKill` to delete `ClusterServiceVersion` if `state.deleteCSV` is false', (done) => {
-    wrapper.find('input').simulate('click');
-    wrapper = wrapper.setProps({ subscription: testSubscription });
-
-    spyAndExpect(close)(null)
-      .then(() => {
-        expect(k8sKill.calls.count()).toEqual(1);
-        done();
-      })
-      .catch((err) => fail(err));
-
-    wrapper.find('form').simulate('submit', new Event('submit'));
-  });
-
-  it('adds delete options with `propagationPolicy` if cascading delete checkbox is checked', (done) => {
+  it('adds delete options with `propagationPolicy`', (done) => {
     spyAndExpect(close)(null)
       .then(() => {
         expect(k8sKill.calls.argsFor(0)[3]).toEqual({

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -13,12 +13,11 @@ import {
 } from '@console/internal/components/utils';
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { getActiveNamespace } from '@console/internal/actions/ui';
+import { YellowExclamationTriangleIcon } from '@console/shared';
 import { SubscriptionKind } from '../../types';
 import { ClusterServiceVersionModel, SubscriptionModel } from '../../models';
 
 export const UninstallOperatorModal = withHandlePromise((props: UninstallOperatorModalProps) => {
-  const [deleteCSV, setDeleteCSV] = React.useState(true);
-
   const submit = (event) => {
     event.preventDefault();
 
@@ -29,7 +28,7 @@ export const UninstallOperatorModal = withHandlePromise((props: UninstallOperato
       propagationPolicy: 'Foreground',
     };
     const promises = [k8sKill(SubscriptionModel, subscription, {}, deleteOptions)].concat(
-      _.get(subscription, 'status.installedCSV') && deleteCSV
+      _.get(subscription, 'status.installedCSV')
         ? k8sKill(
             ClusterServiceVersionModel,
             {
@@ -61,26 +60,25 @@ export const UninstallOperatorModal = withHandlePromise((props: UninstallOperato
 
   return (
     <form onSubmit={submit} name="form" className="modal-content co-catalog-install-modal">
-      <ModalTitle className="modal-header">Remove Operator Subscription</ModalTitle>
+      <ModalTitle className="modal-header">Uninstall Operator?</ModalTitle>
       <ModalBody>
-        <div>
-          <p>
-            This will remove the subscription from <i>{props.subscription.metadata.namespace}</i>{' '}
-            and the Operator will no longer receive updates.
-          </p>
-        </div>
-        <div>
-          <label className="co-delete-modal-checkbox-label">
-            <input type="checkbox" checked={deleteCSV} onChange={() => setDeleteCSV(!deleteCSV)} />
-            &nbsp;&nbsp;{' '}
-            <strong>Also completely remove the Operator from the selected namespace.</strong>
-          </label>
+        <div className="co-delete-modal">
+          <YellowExclamationTriangleIcon className="co-delete-modal__icon" />
+          <div>
+            <p className="lead">Uninstall {props.displayName || props.subscription.spec.name}?</p>
+            <div>
+              This will remove the operator from <i>{props.subscription.metadata.namespace}</i>.
+              Your application will keep running, but it will no longer receive updates or
+              configuration changes.
+            </div>
+          </div>
         </div>
       </ModalBody>
       <ModalSubmitFooter
         inProgress={props.inProgress}
         errorMessage={props.errorMessage}
         cancel={props.cancel}
+        submitDanger
         submitText="Remove"
       />
     </form>
@@ -103,6 +101,7 @@ export type UninstallOperatorModalProps = {
     data: { op: string; path: string; value: any }[],
   ) => Promise<any>;
   subscription: SubscriptionKind;
+  displayName?: string;
 };
 
 UninstallOperatorModal.displayName = 'UninstallOperatorModal';


### PR DESCRIPTION
This removes the ability to delete only the subscription from the UI since it's not a path we want to encourage. You can still delete the subscription from the CLI if needed. It also tweaks the dialog so the message is stronger and adds more detail about what this means.

![Installed Operators · OKD 2019-09-30 16-14-23](https://user-images.githubusercontent.com/1167259/65913325-ad65a080-e39d-11e9-8250-ba8f28ee02bc.png)

@openshift/openshift-team-olm @dmesser @jwforres 

/hold
for feebdack