### PR TITLE
Fix cli-download link by changing "text" to "name"

### DIFF
--- a/frontend/public/components/command-line-tools.tsx
+++ b/frontend/public/components/command-line-tools.tsx
@@ -27,7 +27,7 @@ const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
             <p>
               <ExternalLink
                 href={tool.spec.links[0].href}
-                text={tool.spec.links[0].text || defaultLinkText}
+                text={tool.spec.links[0].name || defaultLinkText}
               />
             </p>
           )}
@@ -35,7 +35,7 @@ const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
             <ul>
               {_.map(tool.spec.links, (link, i) => (
                 <li key={i}>
-                  <ExternalLink href={link.href} text={link.text || defaultLinkText} />
+                  <ExternalLink href={link.href} text={link.name || defaultLinkText} />
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
While experimenting with options for https://github.com/openshift/console-operator/pull/301, I came across this bug:

Before:

![Screen Shot 2019-09-30 at 4 58 35 PM](https://user-images.githubusercontent.com/280512/65917414-4e0b8e80-e3a5-11e9-8b77-bedcf1336e76.png)

After:

![Screen Shot 2019-09-30 at 5 08 47 PM](https://user-images.githubusercontent.com/280512/65917420-506de880-e3a5-11e9-8851-b37854c31856.png)

Simple swap in of `.name` for `.text`. 

/assign @rhamilto @jhadvig 

