### PR TITLE
Ensure we don't allow invalid urls as source code links

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/render-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/render-utils.spec.ts
@@ -1,0 +1,63 @@
+import { BitbucketIcon, GitAltIcon, GithubIcon, GitlabIcon } from '@patternfly/react-icons';
+import { routeDecoratorIcon } from '../render-utils';
+
+describe('Ensure render utils works', () => {
+  describe('Ensure we do not get route decorator icons for invalid urls', () => {
+    it('expect route decoration icon to give nothing for bad urls', () => {
+      expect(routeDecoratorIcon('example.com', 10)).toEqual(null);
+    });
+
+    it('expect no route when using inline javascript', () => {
+      // eslint-disable-next-line no-script-url
+      expect(routeDecoratorIcon("javascript:alert('this should not work');", 10)).toEqual(null);
+    });
+
+    it('expect no route when giving empty values', () => {
+      expect(routeDecoratorIcon('', 10)).toEqual(null);
+    });
+  });
+
+  describe('Ensure we get expected icons with valid HTTPS links', () => {
+    it('expect bitbucket icon', () => {
+      expect(
+        routeDecoratorIcon('https://bitbucket.org/atlassian_tutorial/helloworld.git', 10).type,
+      ).toEqual(BitbucketIcon);
+    });
+
+    it('expect github icon', () => {
+      expect(routeDecoratorIcon('https://github.com/openshift/console.git', 10).type).toEqual(
+        GithubIcon,
+      );
+    });
+
+    it('expect gitlab icon', () => {
+      expect(
+        routeDecoratorIcon('https://gitlab.com/gitlab-org/examples/npm-install.git', 10).type,
+      ).toEqual(GitlabIcon);
+    });
+
+    it('expect git-alt icon when not a supported site', () => {
+      expect(routeDecoratorIcon('https://pagure.io/pagure.git', 10).type).toEqual(GitAltIcon);
+    });
+  });
+
+  describe('Ensure we get expected icons with valid git SSH links', () => {
+    it('expect bitbucket icon', () => {
+      expect(
+        routeDecoratorIcon('git@bitbucket.org:atlassian_tutorial/helloworld.git', 10).type,
+      ).toEqual(BitbucketIcon);
+    });
+
+    it('expect github icon', () => {
+      expect(routeDecoratorIcon('git@github.com:openshift/console.git', 10).type).toEqual(
+        GithubIcon,
+      );
+    });
+
+    it('expect gitlab icon', () => {
+      expect(
+        routeDecoratorIcon('git@gitlab.com:gitlab-org/examples/npm-install.git', 10).type,
+      ).toEqual(GitlabIcon);
+    });
+  });
+});

--- a/frontend/packages/dev-console/src/components/import/render-utils.tsx
+++ b/frontend/packages/dev-console/src/components/import/render-utils.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { BitbucketIcon, GitAltIcon, GithubIcon, GitlabIcon } from '@patternfly/react-icons';
+import { detectGitType } from './import-validation-utils';
+import { GitTypes } from './import-types';
+
+export const routeDecoratorIcon = (routeURL: string, radius: number): React.ReactElement => {
+  switch (detectGitType(routeURL)) {
+    case GitTypes.invalid:
+      // Not a valid url and thus not safe to use
+      return null;
+    case GitTypes.github:
+      return <GithubIcon style={{ fontSize: radius }} alt="Edit Source Code" />;
+    case GitTypes.bitbucket:
+      return <BitbucketIcon style={{ fontSize: radius }} alt="Edit Source Code" />;
+    case GitTypes.gitlab:
+      return <GitlabIcon style={{ fontSize: radius }} alt="Edit Source Code" />;
+    default:
+      return <GitAltIcon style={{ fontSize: radius }} alt="Edit Source Code" />;
+  }
+};

--- a/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/WorkloadNode.tsx
@@ -1,18 +1,11 @@
 import * as React from 'react';
-import {
-  ExternalLinkAltIcon,
-  GitAltIcon,
-  GitlabIcon,
-  GithubIcon,
-  BitbucketIcon,
-} from '@patternfly/react-icons';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Status, calculateRadius, PodStatus } from '@console/shared';
 import { TooltipPosition } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { resourcePathFromModel } from '@console/internal/components/utils';
 import { BuildModel } from '@console/internal/models';
-import { detectGitType } from '../../import/import-validation-utils';
-import { GitTypes } from '../../import/import-types';
+import { routeDecoratorIcon } from '../../import/render-utils';
 import { NodeProps, WorkloadData } from '../topology-types';
 import Decorator from './Decorator';
 import BaseNode from './BaseNode';
@@ -33,19 +26,7 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
       donutStatus: { build },
     },
   } = workload;
-
-  const routeDecoratorIcon = (editUrl: string): React.ReactElement => {
-    switch (detectGitType(editUrl)) {
-      case GitTypes.github:
-        return <GithubIcon style={{ fontSize: decoratorRadius }} alt="Edit Source Code" />;
-      case GitTypes.bitbucket:
-        return <BitbucketIcon style={{ fontSize: decoratorRadius }} alt="Edit Source Code" />;
-      case GitTypes.gitlab:
-        return <GitlabIcon style={{ fontSize: decoratorRadius }} alt="Edit Source Code" />;
-      default:
-        return <GitAltIcon style={{ fontSize: decoratorRadius }} alt="Edit Source Code" />;
-    }
-  };
+  const repoIcon = routeDecoratorIcon(workload.data.editUrl, decoratorRadius);
 
   return (
     <BaseNode
@@ -58,7 +39,7 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
       kind={workload.data.kind}
       {...others}
       attachments={[
-        workload.data.editUrl && (
+        repoIcon && (
           <Decorator
             key="edit"
             x={radius - decoratorRadius * 0.7}
@@ -70,7 +51,7 @@ const WorkloadNode: React.FC<NodeProps<WorkloadData>> = ({
             position={TooltipPosition.right}
           >
             <g transform={`translate(-${decoratorRadius / 2}, -${decoratorRadius / 2})`}>
-              {routeDecoratorIcon(workload.data.editUrl)}
+              {repoIcon}
             </g>
           </Decorator>
         ),


### PR DESCRIPTION
Resolves: https://jira.coreos.com/browse/ODC-1930

<img width="618" alt="Screen Shot 2019-09-30 at 7 35 50 PM" src="https://user-images.githubusercontent.com/8126518/65924190-a0ef4100-e3b9-11e9-8a53-82fc16b9156c.png"> <img width="225" alt="Screen Shot 2019-09-30 at 7 35 58 PM" src="https://user-images.githubusercontent.com/8126518/65924169-8ddc7100-e3b9-11e9-9005-a9729428ca40.png">

Tests:
```
 PASS  packages/dev-console/src/components/import/__tests__/render-utils.spec.ts
  Ensure render utils works
    Ensure we do not get route decorator icons for invalid urls
      ✓ expect route decoration icon to give nothing for bad urls (2ms)
      ✓ expect no route when using inline javascript (1ms)
      ✓ expect no route when giving empty values
    Ensure we get expected icons with valid HTTPS links
      ✓ expect bitbucket icon
      ✓ expect github icon
      ✓ expect gitlab icon (1ms)
      ✓ expect git-alt icon when not a supported site
    Ensure we get expected icons with valid git SSH links
      ✓ expect bitbucket icon
      ✓ expect github icon (1ms)
      ✓ expect gitlab icon
```