### PR TITLE
fix issue with serverless image stream with tags

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -257,7 +257,7 @@ export const createResources = async (
   const formData = ensurePortExists(rawFormData);
   const {
     route: { create: canCreateRoute },
-    isi: { ports },
+    isi: { ports, tag: imageStreamTag },
   } = formData;
 
   const requests: Promise<K8sResourceKind>[] = [];
@@ -274,10 +274,10 @@ export const createResources = async (
   } else if (!dryRun) {
     // Do not run serverless call during the dry run.
     const [imageStreamResponse] = await Promise.all(requests);
-    const knDeploymentResource = getKnativeServiceDepResource(
-      formData,
-      imageStreamResponse.status.dockerImageRepository,
-    );
+    const imageStreamUrl = imageStreamTag
+      ? `${imageStreamResponse.status.dockerImageRepository}:${imageStreamTag}`
+      : imageStreamResponse.status.dockerImageRepository;
+    const knDeploymentResource = getKnativeServiceDepResource(formData, imageStreamUrl);
     requests.push(k8sCreate(KnServiceModel, knDeploymentResource));
   }
 


### PR DESCRIPTION
fix issue with serverless image stream with tags

Tracks: https://jira.coreos.com/browse/ODC-1726

Steps:
1. Click on Add "Container Image"
2. Pass image "docker.io/mgencur/helloworld-go:0.1"
3. Should work as expected