### PR TITLE
Bits from #2269

### DIFF
--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -46,7 +46,7 @@ type ConsumedExtensions =
   | YAMLTemplate
   | RoutePage
   | DashboardsOverviewHealthPrometheusSubsystem
-  | DashboardsOverviewHealthURLSubsystem<any>
+  | DashboardsOverviewHealthURLSubsystem
   | DashboardsTab
   | DashboardsCard
   | DashboardsOverviewInventoryItem

--- a/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
+++ b/frontend/packages/console-plugin-sdk/src/codegen/active-plugins.ts
@@ -11,7 +11,7 @@ export const loadActivePlugins = (pluginPackages: PluginPackage[]) => {
 
   for (const pkg of pluginPackages) {
     // eslint-disable-next-line
-    const plugin = require(`${pkg.name}/${pkg.consolePlugin.entry}`).default as Plugin<Extension<any>>;
+    const plugin = require(`${pkg.name}/${pkg.consolePlugin.entry}`).default as Plugin<Extension>;
     activePlugins.push({ name: pkg.name, extensions: plugin });
   }
 

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -33,7 +33,7 @@ import {
  * Registry used to query for Console extensions.
  */
 export class ExtensionRegistry {
-  private readonly extensions: Extension<any>[];
+  private readonly extensions: Extension[];
 
   public constructor(plugins: ActivePlugin[]) {
     this.extensions = _.flatMap(plugins.map((p) => p.extensions));

--- a/frontend/packages/console-plugin-sdk/src/typings/clusterserviceversions.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/clusterserviceversions.ts
@@ -19,6 +19,5 @@ export interface ClusterServiceVersionAction
   type: 'ClusterServiceVersion/Action';
 }
 
-export const isClusterServiceVersionAction = (
-  e: Extension<any>,
-): e is ClusterServiceVersionAction => e.type === 'ClusterServiceVersion/Action';
+export const isClusterServiceVersionAction = (e: Extension): e is ClusterServiceVersionAction =>
+  e.type === 'ClusterServiceVersion/Action';

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -75,7 +75,7 @@ namespace ExtensionProperties {
     position: GridPosition;
 
     /** Loader for the corresponding dashboard card component. */
-    loader: LazyLoader<any>;
+    loader: LazyLoader;
 
     /** Card's vertical span in the column. Ignored for small screens, defaults to 12. */
     span?: DashboardCardSpan;
@@ -146,14 +146,14 @@ namespace ExtensionProperties {
   }
 }
 
-export interface DashboardsOverviewHealthURLSubsystem<R>
+export interface DashboardsOverviewHealthURLSubsystem<R = any>
   extends Extension<ExtensionProperties.DashboardsOverviewHealthURLSubsystem<R>> {
   type: 'Dashboards/Overview/Health/URL';
 }
 
 export const isDashboardsOverviewHealthURLSubsystem = (
-  e: Extension<any>,
-): e is DashboardsOverviewHealthURLSubsystem<any> => e.type === 'Dashboards/Overview/Health/URL';
+  e: Extension,
+): e is DashboardsOverviewHealthURLSubsystem => e.type === 'Dashboards/Overview/Health/URL';
 
 export interface DashboardsOverviewHealthPrometheusSubsystem
   extends Extension<ExtensionProperties.DashboardsOverviewHealthPrometheusSubsystem> {
@@ -161,16 +161,16 @@ export interface DashboardsOverviewHealthPrometheusSubsystem
 }
 
 export const isDashboardsOverviewHealthPrometheusSubsystem = (
-  e: Extension<any>,
+  e: Extension,
 ): e is DashboardsOverviewHealthPrometheusSubsystem =>
   e.type === 'Dashboards/Overview/Health/Prometheus';
 
 export type DashboardsOverviewHealthSubsystem =
-  | DashboardsOverviewHealthURLSubsystem<any>
+  | DashboardsOverviewHealthURLSubsystem
   | DashboardsOverviewHealthPrometheusSubsystem;
 
 export const isDashboardsOverviewHealthSubsystem = (
-  e: Extension<any>,
+  e: Extension,
 ): e is DashboardsOverviewHealthSubsystem =>
   isDashboardsOverviewHealthURLSubsystem(e) || isDashboardsOverviewHealthPrometheusSubsystem(e);
 
@@ -178,22 +178,20 @@ export interface DashboardsTab extends Extension<ExtensionProperties.DashboardsT
   type: 'Dashboards/Tab';
 }
 
-export const isDashboardsTab = (e: Extension<any>): e is DashboardsTab =>
-  e.type === 'Dashboards/Tab';
+export const isDashboardsTab = (e: Extension): e is DashboardsTab => e.type === 'Dashboards/Tab';
 
 export interface DashboardsCard extends Extension<ExtensionProperties.DashboardsCard> {
   type: 'Dashboards/Card';
 }
 
-export const isDashboardsCard = (e: Extension<any>): e is DashboardsCard =>
-  e.type === 'Dashboards/Card';
+export const isDashboardsCard = (e: Extension): e is DashboardsCard => e.type === 'Dashboards/Card';
 
 export interface DashboardsOverviewQuery
   extends Extension<ExtensionProperties.DashboardsOverviewQuery> {
   type: 'Dashboards/Overview/Query';
 }
 
-export const isDashboardsOverviewQuery = (e: Extension<any>): e is DashboardsOverviewQuery =>
+export const isDashboardsOverviewQuery = (e: Extension): e is DashboardsOverviewQuery =>
   e.type === 'Dashboards/Overview/Query';
 
 export interface DashboardsOverviewUtilizationItem
@@ -202,7 +200,7 @@ export interface DashboardsOverviewUtilizationItem
 }
 
 export const isDashboardsOverviewUtilizationItem = (
-  e: Extension<any>,
+  e: Extension,
 ): e is DashboardsOverviewUtilizationItem => e.type === 'Dashboards/Overview/Utilization/Item';
 
 export interface DashboardsOverviewInventoryItem
@@ -211,7 +209,7 @@ export interface DashboardsOverviewInventoryItem
 }
 
 export const isDashboardsOverviewInventoryItem = (
-  e: Extension<any>,
+  e: Extension,
 ): e is DashboardsOverviewInventoryItem => e.type === 'Dashboards/Overview/Inventory/Item';
 
 export interface DashboardsInventoryItemGroup
@@ -219,9 +217,8 @@ export interface DashboardsInventoryItemGroup
   type: 'Dashboards/Inventory/Item/Group';
 }
 
-export const isDashboardsInventoryItemGroup = (
-  e: Extension<any>,
-): e is DashboardsInventoryItemGroup => e.type === 'Dashboards/Inventory/Item/Group';
+export const isDashboardsInventoryItemGroup = (e: Extension): e is DashboardsInventoryItemGroup =>
+  e.type === 'Dashboards/Inventory/Item/Group';
 
 export interface DashboardsOverviewTopConsumerItem
   extends Extension<ExtensionProperties.DashboardsOverviewTopConsumerItem> {
@@ -229,7 +226,7 @@ export interface DashboardsOverviewTopConsumerItem
 }
 
 export const isDashboardsOverviewTopConsumerItem = (
-  e: Extension<any>,
+  e: Extension,
 ): e is DashboardsOverviewTopConsumerItem => e.type === 'Dashboards/Overview/TopConsumers/Item';
 
 export type DashboardCardSpan = 4 | 6 | 12;

--- a/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dev-catalog.ts
@@ -13,6 +13,6 @@ export interface DevCatalogModel extends Extension<ExtensionProperties.DevCatalo
   type: 'DevCatalogModel';
 }
 
-export const isDevCatalogModel = (e: Extension<any>): e is DevCatalogModel => {
+export const isDevCatalogModel = (e: Extension): e is DevCatalogModel => {
   return e.type === 'DevCatalogModel';
 };

--- a/frontend/packages/console-plugin-sdk/src/typings/extension.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/extension.ts
@@ -13,7 +13,7 @@
  *
  * TODO(vojtech): write ESLint rule to guard against extension type duplicity
  */
-export type Extension<P> = {
+export type Extension<P = any> = {
   type: string;
   properties: P;
 };
@@ -57,7 +57,7 @@ export type Extension<P> = {
  *  export default plugin;
  * ```
  */
-export type Plugin<E extends Extension<any>> = E[];
+export type Plugin<E extends Extension> = E[];
 
 /**
  * From Console application perspective, a plugin is a list of extensions
@@ -65,5 +65,5 @@ export type Plugin<E extends Extension<any>> = E[];
  */
 export type ActivePlugin = {
   name: string;
-  extensions: Extension<any>[];
+  extensions: Extension[];
 };

--- a/frontend/packages/console-plugin-sdk/src/typings/features.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/features.ts
@@ -17,10 +17,10 @@ export interface ModelFeatureFlag extends Extension<ExtensionProperties.ModelFea
 // TODO(vojtech): add ActionFeatureFlag
 export type FeatureFlag = ModelFeatureFlag;
 
-export const isModelFeatureFlag = (e: Extension<any>): e is ModelFeatureFlag => {
+export const isModelFeatureFlag = (e: Extension): e is ModelFeatureFlag => {
   return e.type === 'FeatureFlag/Model';
 };
 
-export const isFeatureFlag = (e: Extension<any>): e is FeatureFlag => {
+export const isFeatureFlag = (e: Extension): e is FeatureFlag => {
   return isModelFeatureFlag(e);
 };

--- a/frontend/packages/console-plugin-sdk/src/typings/global-configs.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/global-configs.ts
@@ -22,6 +22,6 @@ export interface GlobalConfig extends Extension<ExtensionProperties.GlobalConfig
   type: 'GlobalConfig';
 }
 
-export function isGlobalConfig(e: Extension<any>): e is GlobalConfig {
+export function isGlobalConfig(e: Extension): e is GlobalConfig {
   return e.type === 'GlobalConfig';
 }

--- a/frontend/packages/console-plugin-sdk/src/typings/kebab-actions.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/kebab-actions.ts
@@ -13,6 +13,6 @@ export interface KebabActions extends Extension<ExtensionProperties.PluginKebabA
   type: 'KebabActions';
 }
 
-export function isKebabActions(e: Extension<any>): e is KebabActions {
+export function isKebabActions(e: Extension): e is KebabActions {
   return e.type === 'KebabActions';
 }

--- a/frontend/packages/console-plugin-sdk/src/typings/models.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/models.ts
@@ -12,6 +12,6 @@ export interface ModelDefinition extends Extension<ExtensionProperties.ModelDefi
   type: 'ModelDefinition';
 }
 
-export const isModelDefinition = (e: Extension<any>): e is ModelDefinition => {
+export const isModelDefinition = (e: Extension): e is ModelDefinition => {
   return e.type === 'ModelDefinition';
 };

--- a/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
@@ -50,18 +50,18 @@ export interface ResourceClusterNavItem
 
 export type NavItem = HrefNavItem | ResourceNSNavItem | ResourceClusterNavItem;
 
-export const isHrefNavItem = (e: Extension<any>): e is HrefNavItem => {
+export const isHrefNavItem = (e: Extension): e is HrefNavItem => {
   return e.type === 'NavItem/Href';
 };
 
-export const isResourceNSNavItem = (e: Extension<any>): e is ResourceNSNavItem => {
+export const isResourceNSNavItem = (e: Extension): e is ResourceNSNavItem => {
   return e.type === 'NavItem/ResourceNS';
 };
 
-export const isResourceClusterNavItem = (e: Extension<any>): e is ResourceClusterNavItem => {
+export const isResourceClusterNavItem = (e: Extension): e is ResourceClusterNavItem => {
   return e.type === 'NavItem/ResourceCluster';
 };
 
-export const isNavItem = (e: Extension<any>): e is NavItem => {
+export const isNavItem = (e: Extension): e is NavItem => {
   return isHrefNavItem(e) || isResourceNSNavItem(e) || isResourceClusterNavItem(e);
 };

--- a/frontend/packages/console-plugin-sdk/src/typings/overview.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/overview.ts
@@ -37,7 +37,7 @@ export interface OverviewCRD extends Extension<ExtensionProperties.OverviewCRD> 
   type: 'Overview/CRD';
 }
 
-export const isOverviewCRD = (e: Extension<any>): e is OverviewCRD => {
+export const isOverviewCRD = (e: Extension): e is OverviewCRD => {
   return e.type === 'Overview/CRD';
 };
 
@@ -45,6 +45,6 @@ export interface OverviewResourceTab extends Extension<ExtensionProperties.Overv
   type: 'Overview/Resource';
 }
 
-export const isOverviewResourceTab = (e: Extension<any>): e is OverviewResourceTab => {
+export const isOverviewResourceTab = (e: Extension): e is OverviewResourceTab => {
   return e.type === 'Overview/Resource';
 };

--- a/frontend/packages/console-plugin-sdk/src/typings/pages.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/pages.ts
@@ -61,14 +61,14 @@ export interface RoutePage extends Extension<ExtensionProperties.RoutePage> {
 
 export type ResourcePage = ResourceListPage | ResourceDetailsPage;
 
-export const isResourceListPage = (e: Extension<any>): e is ResourceListPage => {
+export const isResourceListPage = (e: Extension): e is ResourceListPage => {
   return e.type === 'Page/Resource/List';
 };
 
-export const isResourceDetailsPage = (e: Extension<any>): e is ResourceDetailsPage => {
+export const isResourceDetailsPage = (e: Extension): e is ResourceDetailsPage => {
   return e.type === 'Page/Resource/Details';
 };
 
-export const isRoutePage = (e: Extension<any>): e is RoutePage => {
+export const isRoutePage = (e: Extension): e is RoutePage => {
   return e.type === 'Page/Route';
 };

--- a/frontend/packages/console-plugin-sdk/src/typings/perspectives.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/perspectives.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { FlagsObject } from '@console/internal/reducers/features';
 import { Extension } from './extension';
 
 namespace ExtensionProperties {
@@ -24,8 +25,8 @@ export interface Perspective extends Extension<ExtensionProperties.Perspective> 
   type: 'Perspective';
 }
 
-export const isPerspective = (e: Extension<any>): e is Perspective => {
+export const isPerspective = (e: Extension): e is Perspective => {
   return e.type === 'Perspective';
 };
 
-export type GetLandingPage = (flags: { [key: string]: boolean }) => string;
+export type GetLandingPage = (flags: FlagsObject) => string;

--- a/frontend/packages/console-plugin-sdk/src/typings/plugins/ceph-storage-plugin.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/plugins/ceph-storage-plugin.ts
@@ -53,16 +53,16 @@ export interface DashboardsStorageCapacityDropdownItem
 }
 
 export const isDashboardsStorageTopConsumerUsed = (
-  e: Extension<any>,
+  e: Extension,
 ): e is DashboardsStorageTopConsumerUsed => e.type === 'Dashboards/Storage/TopConsumers/Used';
 
 export const isDashboardsStorageTopConsumerRequested = (
-  e: Extension<any>,
+  e: Extension,
 ): e is DashboardsStorageTopConsumerRequested =>
   e.type === 'Dashboards/Storage/TopConsumers/Requested';
 
 export const isDashboardsStorageCapacityDropdownItem = (
-  e: Extension<any>,
+  e: Extension,
 ): e is DashboardsStorageCapacityDropdownItem =>
   e.type === 'Dashboards/Storage/Capacity/Dropdown/Item';
 

--- a/frontend/packages/console-plugin-sdk/src/typings/types.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/types.ts
@@ -1,1 +1,1 @@
-export type LazyLoader<T extends {}> = () => Promise<React.ComponentType<Partial<T>>>;
+export type LazyLoader<T extends {} = {}> = () => Promise<React.ComponentType<Partial<T>>>;

--- a/frontend/packages/console-plugin-sdk/src/typings/yaml-templates.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/yaml-templates.ts
@@ -16,6 +16,6 @@ export interface YAMLTemplate extends Extension<ExtensionProperties.YAMLTemplate
   type: 'YAMLTemplate';
 }
 
-export function isYAMLTemplate(e: Extension<any>): e is YAMLTemplate {
+export function isYAMLTemplate(e: Extension): e is YAMLTemplate {
   return e.type === 'YAMLTemplate';
 }

--- a/frontend/packages/dev-console/src/components/import/serverless/ServerlessSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless/ServerlessSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { connectToFlags } from '@console/internal/reducers/features';
+import { connectToFlags, FlagsObject } from '@console/internal/reducers/features';
 import { FLAG_KNATIVE_SERVING_SERVICE } from '@console/knative-plugin';
 import { TechPreviewBadge } from '@console/shared';
 import { Split, SplitItem } from '@patternfly/react-core';
@@ -7,7 +7,7 @@ import { CheckboxField } from '../../formik-fields';
 import FormSection from '../section/FormSection';
 
 type ServerlessSectionProps = {
-  flags: { [key: string]: boolean };
+  flags: FlagsObject;
 };
 
 const ServerlessSection: React.FC<ServerlessSectionProps> = ({ flags }) => {

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -35,7 +35,7 @@ type ConsumedExtensions =
   | YAMLTemplate
   | ModelDefinition
   | RoutePage
-  | DashboardsOverviewHealthURLSubsystem<any>
+  | DashboardsOverviewHealthURLSubsystem
   | DashboardsOverviewInventoryItem
   | DashboardsInventoryItemGroup
   | DashboardsStorageTopConsumerRequested

--- a/frontend/public/actions/k8s.ts
+++ b/frontend/public/actions/k8s.ts
@@ -203,9 +203,7 @@ export const watchK8sList = (
 
       if (WS[id]) {
         // eslint-disable-next-line no-console
-        console.warn(
-          `Attempted to create multiple websockets for ${id}.  This should never happen.`,
-        );
+        console.warn(`Attempted to create multiple websockets for ${id}.`);
         return;
       }
 

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -10,7 +10,7 @@ import {
 import { Link } from 'react-router-dom';
 
 import { FLAGS } from '../const';
-import { connectToFlags } from '../reducers/features';
+import { connectToFlags, FlagsObject } from '../reducers/features';
 import { getBrandingDetails } from './masthead';
 import { ExternalLink, Firehose } from './utils';
 import { ClusterVersionModel } from '../models';
@@ -140,5 +140,5 @@ type AboutModalItemsProps = {
 type AboutModalProps = {
   isOpen: boolean;
   closeAboutModal: () => void;
-  flags: { [key: string]: boolean };
+  flags: FlagsObject;
 };

--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -22,7 +22,7 @@ import {
   referenceForModel,
   ResourceAccessReviewRequest,
 } from '../module/k8s';
-import { connectToFlags } from '../reducers/features';
+import { connectToFlags, FlagsObject } from '../reducers/features';
 import { RootState } from '../redux';
 import { CheckBox, CheckBoxControls } from './row-filter';
 import { DefaultPage } from './default-resource';
@@ -626,7 +626,7 @@ const APIResourcePage_ = ({
   match: any;
   kindObj: K8sKind;
   kindsInFlight: boolean;
-  flags: { [key: string]: boolean };
+  flags: FlagsObject;
 }) => {
   if (!kindObj) {
     return kindsInFlight ? (

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { Redirect, Route, Switch, withRouter } from 'react-router-dom';
 
 import { FLAGS } from '../const';
-import { connectToFlags, flagPending } from '../reducers/features';
+import { connectToFlags, flagPending, FlagsObject } from '../reducers/features';
 import { GlobalNotifications } from './global-notifications';
 import { NamespaceBar } from './namespace';
 import { SearchPage } from './search';
@@ -47,7 +47,7 @@ _.each(namespacedPrefixes, (p) => {
 
 type DefaultPageProps = {
   activePerspective: string;
-  flags: { [key: string]: boolean };
+  flags: FlagsObject;
 };
 
 // The default page component lets us connect to flags without connecting the entire App.

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -12,7 +12,7 @@ import {
   PartialObjectMetadata,
 } from '../../module/k8s';
 import { withStartGuide } from '../start-guide';
-import { connectToFlags, flagPending } from '../../reducers/features';
+import { connectToFlags, flagPending, FlagsObject } from '../../reducers/features';
 import {
   Firehose,
   LoadError,
@@ -383,7 +383,7 @@ export type CatalogListPageState = {
 };
 
 export type CatalogProps = {
-  flags: { [key: string]: boolean };
+  flags: FlagsObject;
   namespace?: string;
   mock: boolean;
 };

--- a/frontend/public/components/dashboards-page/overview-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboards-page/overview-dashboard/inventory-card.tsx
@@ -148,5 +148,5 @@ type ClusterInventoryItemProps = DashboardItemProps & {
   mapper: StatusGroupMapper;
   useAbbr?: boolean;
   additionalResources?: FirehoseResource[];
-  expandedComponent?: LazyLoader<any>;
+  expandedComponent?: LazyLoader;
 };

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -12,7 +12,7 @@ import {
   K8sResourceKind,
 } from '../../module/k8s';
 import { connectToModel } from '../../kinds';
-import { connectToFlags } from '../../reducers/features';
+import { connectToFlags, FlagsObject } from '../../reducers/features';
 import { FLAGS } from '../../const';
 
 const unknownKinds = new Set();
@@ -127,7 +127,7 @@ export const NodeLink = connectToFlags<NodeLinkProps>(FLAGS.CAN_LIST_NODE)(NodeL
 
 type NodeLinkProps = {
   name: string;
-  flags: { [key: string]: boolean };
+  flags: FlagsObject;
 };
 
 ResourceLink.displayName = 'ResourceLink';

--- a/frontend/public/reducers/features.ts
+++ b/frontend/public/reducers/features.ts
@@ -14,6 +14,7 @@ import {
   ConsoleExternalLogLinkModel,
 } from '../models';
 import { referenceForModel } from '../module/k8s';
+import { RootState } from '../redux';
 import { ActionType as K8sActionType } from '../actions/k8s';
 import { FeatureAction, ActionType } from '../actions/features';
 import { FLAGS } from '../const';
@@ -81,13 +82,12 @@ export const featureReducer = (state: FeatureState, action: FeatureAction): Feat
   }
 };
 
-export const stateToProps = (desiredFlags: string[], state) => {
-  const flags = desiredFlags.reduce(
-    (allFlags, f) => ({ ...allFlags, [f]: state[featureReducerName].get(f) }),
-    {},
-  );
-  return { flags };
-};
+export const stateToFlagsObject = (state: RootState): FlagsObject =>
+  state[featureReducerName].toObject();
+
+export const stateToProps = (desiredFlags: string[], state: RootState): WithFlagsProps => ({
+  flags: _.pick(stateToFlagsObject(state), desiredFlags),
+});
 
 export type FlagsObject = { [key: string]: boolean };
 
@@ -102,9 +102,10 @@ export type ConnectToFlags = <P extends WithFlagsProps>(
 ) => React.ComponentType<Omit<P, keyof WithFlagsProps>> & {
   WrappedComponent: React.ComponentType<P>;
 };
+
 export const connectToFlags: ConnectToFlags = (...flags) =>
   connect(
-    (state) => stateToProps(flags, state),
+    (state: RootState) => stateToProps(flags, state),
     null,
     null,
     { areStatePropsEqual: _.isEqual },


### PR DESCRIPTION
> Extract bits from #2269 for easier review.

**Bugfixes**
- fix landing page URL mis-handling in `NavHeader` - now using `Perspective` type

**Improvements**
- use sensible fallbacks in generic type signatures (`Extension`, `LazyLoader`)
- use `FlagsObject` type alias consistently across the codebase
- add `stateToFlagsObject` utility in `public/reducers/features.ts` along with better typings
- remove "This should never happen." part of the log when dealing with multiple websockets for the same `id` (@rawagner told me that using `Firehose` may trigger that code)
