### PR TITLE
Get the status of a VM by its newest Pod

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
@@ -5,7 +5,6 @@ import { getName, getNamespace } from '@console/shared';
 import { WSFactory } from '@console/internal/module/ws-factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { PodModel, ServiceModel } from '@console/internal/models';
-import { VIRT_LAUNCHER_POD_PREFIX } from '../../constants/vm';
 import {
   VirtualMachineInstanceMigrationModel,
   VirtualMachineInstanceModel,
@@ -39,7 +38,7 @@ const VmConsolesWrapper: React.FC<VmConsolesWrapperProps> = (props) => {
   let rdp;
   if (isWindows(vm)) {
     const rdpService = findRDPService(vmi, services);
-    const launcherPod = findVMPod(pods, vm, VIRT_LAUNCHER_POD_PREFIX);
+    const launcherPod = findVMPod(pods, vm);
     rdp = getRdpConnectionDetails(vmi, rdpService, launcherPod);
   }
 

--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
@@ -23,7 +23,6 @@ import {
   POD_PHASE_PENDING,
 } from '../pod/constants';
 import { NOT_HANDLED } from '../constants';
-import { VIRT_LAUNCHER_POD_PREFIX } from '../../constants';
 import { VMKind } from '../../types';
 import {
   VM_STATUS_V2V_CONVERSION_ERROR,
@@ -193,7 +192,7 @@ export const getVMStatus = (
   pods: PodKind[],
   migrations: K8sResourceKind[],
 ): VMStatus => {
-  const launcherPod = findVMPod(pods, vm, VIRT_LAUNCHER_POD_PREFIX);
+  const launcherPod = findVMPod(pods, vm);
   return (
     isV2VConversion(vm, pods) || // these statuses must precede isRunning() because they do not rely on ready vms
     isBeingMigrated(vm, migrations) || //  -||-


### PR DESCRIPTION
if a VM has two pods at the same time - when it is restarting
or migrating, while one pod is starting and the other terminates,
we should display the status of the newest pod that was created.

In addtion, a pod is found by the ownerReference and not by
the VM name prefix

Fixes: https://bugzilla.redhat.com/1743514

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>