### PR TITLE
View and Modify Project Membership

### DIFF
--- a/frontend/integration-tests/tests/devconsole/dev-perspective.scenario.ts
+++ b/frontend/integration-tests/tests/devconsole/dev-perspective.scenario.ts
@@ -27,6 +27,7 @@ describe('Application Launcher Menu', () => {
     expect(pageSidebar.getText()).toContain('Builds');
     expect(pageSidebar.getText()).toContain('Advanced');
     expect(pageSidebar.getText()).toContain('Projects');
+    expect(pageSidebar.getText()).toContain('Project Access');
     expect(pageSidebar.getText()).toContain('Events');
     expect(pageSidebar.getText()).toContain('Search');
   });

--- a/frontend/packages/dev-console/src/components/form-utils/FormFooter.tsx
+++ b/frontend/packages/dev-console/src/components/form-utils/FormFooter.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { ActionGroup, Alert, Button, ButtonVariant } from '@patternfly/react-core';
+import { ButtonBar } from '@console/internal/components/utils';
+import { FormFooterProps } from './form-utils-types';
+
+const FormFooter: React.FC<FormFooterProps> = ({
+  handleSubmit,
+  handleReset,
+  isSubmitting,
+  errorMessage,
+  successMessage,
+  disableSubmit,
+  showAlert,
+}) => (
+  <ButtonBar inProgress={isSubmitting} errorMessage={errorMessage} successMessage={successMessage}>
+    {showAlert && (
+      <Alert isInline className="co-alert" variant="info" title="You made changes to this page.">
+        Click Save to save changes or Reload to cancel.
+      </Alert>
+    )}
+    <ActionGroup className="pf-c-form">
+      <Button
+        type={handleSubmit ? 'button' : 'submit'}
+        {...handleSubmit && { onClick: handleSubmit }}
+        variant={ButtonVariant.primary}
+        isDisabled={disableSubmit}
+      >
+        Save
+      </Button>
+      <Button type="button" variant={ButtonVariant.secondary} onClick={handleReset}>
+        Reload
+      </Button>
+    </ActionGroup>
+  </ButtonBar>
+);
+
+export default FormFooter;

--- a/frontend/packages/dev-console/src/components/form-utils/form-utils-types.ts
+++ b/frontend/packages/dev-console/src/components/form-utils/form-utils-types.ts
@@ -1,0 +1,9 @@
+export interface FormFooterProps {
+  handleSubmit?: () => void;
+  handleReset: () => void;
+  isSubmitting: boolean;
+  errorMessage: string;
+  successMessage: string;
+  disableSubmit: boolean;
+  showAlert?: boolean;
+}

--- a/frontend/packages/dev-console/src/components/form-utils/index.ts
+++ b/frontend/packages/dev-console/src/components/form-utils/index.ts
@@ -1,0 +1,1 @@
+export { default as FormFooter } from './FormFooter';

--- a/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
@@ -52,6 +52,7 @@ export interface ResourceLimitFieldProps extends FieldProps {
 
 export interface MultiColumnFieldProps extends FieldProps {
   addLabel?: string;
+  toolTip?: string;
   emptyValues: { [name: string]: string };
   headers: string[];
   children: React.ReactNode;

--- a/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
@@ -17,6 +17,7 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
   headers,
   emptyValues,
   isReadOnly,
+  toolTip,
 }) => (
   <FieldArray
     name={name}
@@ -36,6 +37,7 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
                 // eslint-disable-next-line react/no-array-index-key
                 key={`multi-column-field-row-${index}`} // There is no other usable value for key prop in this case.
                 name={name}
+                toolTip={toolTip}
                 rowIndex={index}
                 onDelete={() => remove(index)}
                 isReadOnly={isReadOnly}

--- a/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnFieldRow.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnFieldRow.tsx
@@ -1,17 +1,37 @@
 import * as React from 'react';
 import { MinusCircleIcon } from '@patternfly/react-icons';
+import { Tooltip } from '@patternfly/react-core';
 import './MultiColumnField.scss';
 
 export interface MultiColumnFieldRowProps {
   name: string;
+  toolTip?: string;
   rowIndex: number;
   children: React.ReactNode;
   onDelete: () => void;
   isReadOnly?: boolean;
 }
 
+const minusCircleIcon = (onDelete: () => void, toolTip?: string) => {
+  return (
+    <div className="odc-multi-column-field__col--button">
+      <MinusCircleIcon aria-hidden="true" onClick={onDelete} />
+      <span className="sr-only">{toolTip || 'Delete'}</span>
+    </div>
+  );
+};
+
+const renderMinusCircleIcon = (onDelete: () => void, toolTip?: string) => {
+  return toolTip ? (
+    <Tooltip content={toolTip}>{minusCircleIcon(onDelete, toolTip)}</Tooltip>
+  ) : (
+    minusCircleIcon(onDelete)
+  );
+};
+
 const MultiColumnFieldRow: React.FC<MultiColumnFieldRowProps> = ({
   name,
+  toolTip,
   rowIndex,
   onDelete,
   children,
@@ -27,12 +47,7 @@ const MultiColumnFieldRow: React.FC<MultiColumnFieldRowProps> = ({
         </div>
       );
     })}
-    {!isReadOnly && (
-      <div className="odc-multi-column-field__col--button">
-        <MinusCircleIcon aria-hidden="true" onClick={onDelete} />
-        <span className="sr-only">Delete</span>
-      </div>
-    )}
+    {!isReadOnly && renderMinusCircleIcon(onDelete, toolTip)}
   </div>
 );
 

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -18,7 +18,7 @@ import { getAppLabels, getPodLabels, getAppAnnotations } from '../../utils/resou
 import { createService, createRoute, dryRunOpt } from '../../utils/shared-submit-utils';
 import { GitImportFormData, ProjectData, GitTypes, GitReadableTypes } from './import-types';
 
-const generateSecret = () => {
+export const generateSecret = () => {
   // http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
   const s4 = () =>
     Math.floor((1 + Math.random()) * 0x10000)

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineParameters.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineParameters.tsx
@@ -1,16 +1,11 @@
 import * as React from 'react';
-import {
-  Form,
-  Button,
-  ButtonVariant,
-  Alert,
-  TextInputTypes,
-  ActionGroup,
-} from '@patternfly/react-core';
+import * as _ from 'lodash';
+import { Form, TextInputTypes } from '@patternfly/react-core';
 import { FormikProps, FormikValues } from 'formik';
-import { ButtonBar, useAccessReview } from '@console/internal/components/utils';
+import { useAccessReview } from '@console/internal/components/utils';
 import { getActiveNamespace } from '@console/internal/actions/ui';
 import { MultiColumnField, InputField } from '../formik-fields';
+import { FormFooter } from '../form-utils';
 
 const PipelineParameters: React.FC<FormikProps<FormikValues>> = ({
   handleSubmit,
@@ -26,7 +21,6 @@ const PipelineParameters: React.FC<FormikProps<FormikValues>> = ({
     namespace: getActiveNamespace(),
     verb: 'update',
   });
-
   return (
     <Form onSubmit={handleSubmit}>
       <div className="co-m-pane__form">
@@ -58,34 +52,14 @@ const PipelineParameters: React.FC<FormikProps<FormikValues>> = ({
         </MultiColumnField>
         <hr />
         {pipelineParameterAccess && (
-          <ButtonBar
-            inProgress={isSubmitting}
+          <FormFooter
+            handleReset={handleReset}
+            isSubmitting={isSubmitting}
             errorMessage={status && status.submitError}
-            successMessage={status && status.success}
-          >
-            {!status && dirty && (
-              <Alert
-                isInline
-                className="co-alert"
-                variant="info"
-                title="The information on this page is no longer current."
-              >
-                Click Reload to update and lose edits, or Save Changes to overwrite.
-              </Alert>
-            )}
-            <ActionGroup className="pf-c-form">
-              <Button
-                type="submit"
-                variant={ButtonVariant.primary}
-                isDisabled={!dirty || !!errors.parameters}
-              >
-                Save
-              </Button>
-              <Button type="button" variant={ButtonVariant.secondary} onClick={handleReset}>
-                Reload
-              </Button>
-            </ActionGroup>
-          </ButtonBar>
+            successMessage={status && !dirty && status.success}
+            disableSubmit={!dirty || !_.isEmpty(errors)}
+            showAlert={dirty}
+          />
         )}
       </div>
     </Form>

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineResources.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineResources.tsx
@@ -1,16 +1,11 @@
 import * as React from 'react';
-import {
-  Form,
-  Button,
-  Alert,
-  TextInputTypes,
-  ActionGroup,
-  ButtonVariant,
-} from '@patternfly/react-core';
+import * as _ from 'lodash';
+import { Form, TextInputTypes } from '@patternfly/react-core';
 import { FormikProps, FormikValues } from 'formik';
-import { ButtonBar, useAccessReview } from '@console/internal/components/utils';
+import { useAccessReview } from '@console/internal/components/utils';
 import { getActiveNamespace } from '@console/internal/actions/ui';
 import { MultiColumnField, InputField, DropdownField } from '../formik-fields';
+import { FormFooter } from '../form-utils';
 
 enum resourceTypes {
   '' = 'Select resource type',
@@ -59,34 +54,14 @@ const PipelineResources: React.FC<FormikProps<FormikValues>> = ({
         </MultiColumnField>
         <hr />
         {pipelineResourceAccess && (
-          <ButtonBar
-            inProgress={isSubmitting}
+          <FormFooter
+            handleReset={handleReset}
+            isSubmitting={isSubmitting}
             errorMessage={status && status.submitError}
-            successMessage={status && status.success}
-          >
-            {!status && dirty && (
-              <Alert
-                isInline
-                className="co-alert"
-                variant="info"
-                title="The information on this page is no longer current."
-              >
-                Click Reload to update and lose edits, or Save Changes to overwrite.
-              </Alert>
-            )}
-            <ActionGroup className="pf-c-form">
-              <Button
-                type="submit"
-                variant={ButtonVariant.primary}
-                isDisabled={!dirty || !!errors.resources}
-              >
-                Save
-              </Button>
-              <Button type="button" variant={ButtonVariant.secondary} onClick={handleReset}>
-                Reload
-              </Button>
-            </ActionGroup>
-          </ButtonBar>
+            successMessage={status && !dirty && status.success}
+            disableSubmit={!dirty || !_.isEmpty(errors)}
+            showAlert={dirty}
+          />
         )}
       </div>
     </Form>

--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Formik } from 'formik';
+import { Link } from 'react-router-dom';
+import { LoadingBox, PageHeading, ExternalLink } from '@console/internal/components/utils';
+import { getActiveNamespace } from '@console/internal/actions/ui';
+import { RoleBindingModel, RoleModel } from '@console/internal/models';
+import { filterRoleBindings, getUserRoleBindings } from './project-access-form-utils';
+import {
+  getRolesWithNameChange,
+  getFinalRoles,
+  sendRoleBindingRequest,
+  getNewRoles,
+  getRemovedRoles,
+} from './project-access-form-submit-utils';
+import { validationSchema } from './project-access-form-validation-utils';
+import ProjectAccessForm from './ProjectAccessForm';
+import { Verb, UserRoleBinding, Roles, roleBinding } from './project-access-form-utils-types';
+
+export interface ProjectAccessProps {
+  formName: string;
+  namespace: string;
+  roleBindings?: { data: []; loaded: boolean; loadError: {} };
+}
+
+const ProjectAccess: React.FC<ProjectAccessProps> = ({ formName, namespace, roleBindings }) => {
+  if (!roleBindings.loaded && _.isEmpty(roleBindings.loadError)) {
+    return <LoadingBox />;
+  }
+
+  const noProjectsAvailable = !_.isEmpty(roleBindings.loadError);
+
+  const filteredRoleBindings = filterRoleBindings(roleBindings, Roles);
+
+  const userRoleBindings: UserRoleBinding[] = getUserRoleBindings(filteredRoleBindings);
+
+  const initialValues = {
+    projectAccess: roleBindings.loaded && userRoleBindings,
+  };
+
+  const handleSubmit = (values, actions) => {
+    let newRoles = getNewRoles(initialValues.projectAccess, values.projectAccess);
+    let removeRoles = getRemovedRoles(initialValues.projectAccess, values.projectAccess);
+    if (_.isEmpty(newRoles) && _.isEmpty(removeRoles)) {
+      actions.setSubmitting(false);
+      actions.resetForm({
+        values: {
+          projectAccess: initialValues.projectAccess,
+        },
+        status: { success: `Successfully updated the ${formName}.` },
+      });
+      return;
+    }
+
+    const updateRoles = getRolesWithNameChange(newRoles, removeRoles);
+
+    if (!_.isEmpty(updateRoles)) {
+      newRoles = _.filter(
+        newRoles,
+        (o1) => !updateRoles.find((o2) => o1.roleBindingName === o2.roleBindingName),
+      );
+      removeRoles = _.filter(
+        removeRoles,
+        (o1) => !updateRoles.find((o2) => o1.roleBindingName === o2.roleBindingName),
+      );
+    }
+
+    const finalValues = _.isEmpty(newRoles)
+      ? values.projectAccess
+      : getFinalRoles(initialValues.projectAccess, removeRoles, newRoles);
+
+    const roleBindingRequests = [];
+    roleBinding.metadata.namespace = namespace;
+
+    actions.setSubmitting(true);
+    if (!_.isEmpty(updateRoles)) {
+      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Patch, updateRoles, roleBinding));
+    }
+    if (!_.isEmpty(removeRoles)) {
+      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Remove, removeRoles, roleBinding));
+    }
+    if (!_.isEmpty(newRoles)) {
+      roleBindingRequests.push(...sendRoleBindingRequest(Verb.Create, newRoles, roleBinding));
+    }
+
+    Promise.all(roleBindingRequests)
+      .then(() => {
+        actions.setSubmitting(false);
+        actions.resetForm({
+          values: {
+            projectAccess: finalValues,
+          },
+          status: { success: `Successfully updated the ${formName}.` },
+        });
+      })
+      .catch((err) => {
+        actions.setSubmitting(false);
+        actions.setStatus({ submitError: err.message });
+      });
+  };
+
+  const handleReset = (values, actions) => {
+    actions.resetForm({ status: { success: null } });
+  };
+
+  return (
+    <React.Fragment>
+      <PageHeading title="Project Access">
+        Project Access allows you to add or remove a user&apos;s access to the project. More
+        advanced management of role-based access control appear in{' '}
+        <Link to={`/k8s/ns/${getActiveNamespace()}/${RoleModel.plural}`}>Roles</Link> and{' '}
+        <Link to={`/k8s/ns/${getActiveNamespace()}/${RoleBindingModel.plural}`}>Role Bindings</Link>
+        . For more information, see the{' '}
+        <ExternalLink
+          href="https://docs.openshift.com/container-platform/4.1/authentication/using-rbac.html"
+          text="role-based access control documentation"
+        />{' '}
+        .
+      </PageHeading>
+      <hr />
+      {noProjectsAvailable ? (
+        <div className="cos-status-box">
+          <div className="text-center">No Role Bindings Found</div>
+        </div>
+      ) : (
+        <div className="co-m-pane__body">
+          <Formik
+            initialValues={initialValues}
+            onSubmit={handleSubmit}
+            onReset={handleReset}
+            validationSchema={validationSchema}
+            render={(props) => <ProjectAccessForm {...props} />}
+          />
+        </div>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default ProjectAccess;

--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccessForm.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccessForm.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Form, TextInputTypes } from '@patternfly/react-core';
+import { FormikProps, FormikValues } from 'formik';
+import { MultiColumnField, InputField, DropdownField } from '../formik-fields';
+import { FormFooter } from '../form-utils';
+
+enum accessRoles {
+  '' = 'Select a role',
+  admin = 'Admin',
+  view = 'View',
+  edit = 'Edit',
+}
+
+const ProjectAccess: React.FC<FormikProps<FormikValues>> = ({
+  handleSubmit,
+  handleReset,
+  isSubmitting,
+  status,
+  errors,
+  dirty,
+}) => (
+  <Form onSubmit={handleSubmit}>
+    <div className="co-m-pane__form">
+      <MultiColumnField
+        name="projectAccess"
+        addLabel="Add Access"
+        headers={['Name', 'Role']}
+        emptyValues={{ user: '', role: '' }}
+        toolTip="Remove Access"
+      >
+        <InputField name="user" type={TextInputTypes.text} placeholder="Name" />
+        <DropdownField name="role" items={accessRoles} fullWidth />
+      </MultiColumnField>
+      <hr />
+      <FormFooter
+        handleReset={handleReset}
+        isSubmitting={isSubmitting}
+        errorMessage={status && status.submitError}
+        successMessage={status && !dirty && status.success}
+        disableSubmit={!dirty || !_.isEmpty(errors)}
+        showAlert={dirty}
+      />
+    </div>
+  </Form>
+);
+
+export default ProjectAccess;

--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccessPage.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccessPage.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { match as RMatch } from 'react-router';
+import { NamespaceBar } from '@console/internal/components/namespace';
+import RenderProjectAccessPage, { RenderProjectAccessPageProps } from './RenderProjectAccessPage';
+
+export interface ProjectAccessPageProps {
+  match: RMatch<{
+    ns?: string;
+  }>;
+}
+
+const ProjectAccessPage: React.FC<ProjectAccessPageProps> = ({ match }) => {
+  const namespace = match.params.ns;
+  const props: RenderProjectAccessPageProps = {
+    namespace,
+  };
+  return (
+    <React.Fragment>
+      <NamespaceBar />
+      <RenderProjectAccessPage {...props} />
+    </React.Fragment>
+  );
+};
+
+export default ProjectAccessPage;

--- a/frontend/packages/dev-console/src/components/project-access/RenderProjectAccessPage.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/RenderProjectAccessPage.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { Firehose } from '@console/internal/components/utils';
+import { withStartGuide } from '@console/internal/components/start-guide';
+import ProjectListPage from '../projects/ProjectListPage';
+import ProjectAccess, { ProjectAccessProps } from './ProjectAccess';
+
+export interface RenderProjectAccessPageProps {
+  namespace: string;
+}
+
+const RenderProjectAccessPage: React.FC<RenderProjectAccessPageProps> = ({ namespace }) => {
+  const props: ProjectAccessProps = {
+    formName: 'project access',
+    namespace,
+  };
+  return (
+    <React.Fragment>
+      {namespace ? (
+        <React.Fragment>
+          <Firehose
+            resources={[
+              {
+                namespace,
+                kind: 'RoleBinding',
+                prop: 'roleBindings',
+                isList: true,
+                optional: true,
+              },
+            ]}
+          >
+            <ProjectAccess {...props} />
+          </Firehose>
+        </React.Fragment>
+      ) : (
+        <ProjectListPage title="Project Access">
+          Select a project to view the list of users with access to the project.
+        </ProjectListPage>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default withStartGuide(RenderProjectAccessPage);

--- a/frontend/packages/dev-console/src/components/project-access/__mocks__/project-access-form-mock.ts
+++ b/frontend/packages/dev-console/src/components/project-access/__mocks__/project-access-form-mock.ts
@@ -1,0 +1,334 @@
+import { UserRoleBinding } from '../project-access-form-utils-types';
+
+export const mockProjectAccessData = {
+  projectAccess: [
+    {
+      user: 'abc',
+      role: 'view',
+    },
+  ],
+};
+
+export const roleBindingsResourceData = {
+  data: [
+    {
+      metadata: {
+        name: 'admin',
+        namespace: 'xyz',
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: 'admin',
+      },
+      subjects: [
+        {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'User',
+          name: 'kube:admin',
+        },
+      ],
+    },
+    {
+      metadata: {
+        name: 'view',
+        namespace: 'xyz',
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: 'view',
+      },
+      subjects: [
+        {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'User',
+          name: 'abc',
+        },
+      ],
+    },
+    {
+      metadata: {
+        name: 'example',
+        namespace: 'xyz',
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: 'example-role',
+      },
+      subjects: [
+        {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'User',
+          name: 'check-role',
+        },
+      ],
+    },
+  ],
+};
+
+export const roleBindingsWithRequiredRolesResult = [
+  {
+    metadata: {
+      name: 'admin',
+      namespace: 'xyz',
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'admin',
+    },
+    subjects: [
+      {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'User',
+        name: 'kube:admin',
+      },
+    ],
+  },
+  {
+    metadata: {
+      name: 'view',
+      namespace: 'xyz',
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'view',
+    },
+    subjects: [
+      {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'User',
+        name: 'abc',
+      },
+    ],
+  },
+];
+
+export const roleBindingsWithRequiredRoles = [
+  {
+    metadata: {
+      name: 'check-admin',
+      namespace: 'xyz',
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'admin',
+    },
+    subjects: [
+      {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'User',
+        name: 'kube:admin',
+      },
+    ],
+  },
+  {
+    metadata: {
+      name: 'check-view',
+      namespace: 'xyz',
+    },
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'view',
+    },
+    subjects: [
+      {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'User',
+        name: 'abc',
+      },
+    ],
+  },
+];
+
+export const roleBindingsWithRequiredAttributes = [
+  {
+    roleBindingName: 'check-admin',
+    user: 'kube:admin',
+    role: 'admin',
+  },
+  {
+    roleBindingName: 'check-view',
+    user: 'abc',
+    role: 'view',
+  },
+];
+
+export const roleBindingsToBeCreated1: UserRoleBinding[] = [
+  {
+    roleBindingName: 'a-view',
+    user: 'ab',
+    role: 'view',
+  },
+  {
+    roleBindingName: 'b-view',
+    user: 'b',
+    role: 'admin',
+  },
+  {
+    user: 'c',
+    role: 'view',
+  },
+];
+export const rolesBindingsToBeRemoved1: UserRoleBinding[] = [
+  {
+    roleBindingName: 'a-view',
+    user: 'a',
+    role: 'view',
+  },
+  {
+    roleBindingName: 'b-view',
+    user: 'b',
+    role: 'view',
+  },
+];
+
+export const rolesWithNameChangeResult: UserRoleBinding[] = [
+  {
+    roleBindingName: 'a-view',
+    user: 'ab',
+    role: 'view',
+  },
+];
+
+export const initialRoles1: UserRoleBinding[] = [
+  {
+    roleBindingName: 'a-view',
+    user: 'ab',
+    role: 'view',
+  },
+  {
+    roleBindingName: 'b-view',
+    user: 'b',
+    role: 'admin',
+  },
+  {
+    roleBindingName: 'c-view',
+    user: 'c',
+    role: 'view',
+  },
+];
+
+export const formValues1: UserRoleBinding[] = [
+  {
+    roleBindingName: 'a-view',
+    user: 'ab',
+    role: 'view',
+  },
+  {
+    roleBindingName: 'b-view',
+    user: 'b',
+    role: 'admin',
+  },
+];
+
+export const rolesBindingsToBeRemoved: UserRoleBinding[] = [
+  {
+    roleBindingName: 'c-view',
+    user: 'c',
+    role: 'view',
+  },
+];
+
+export const formValues2: UserRoleBinding[] = [
+  {
+    roleBindingName: 'a-view',
+    user: 'ab',
+    role: 'view',
+  },
+  {
+    roleBindingName: 'b-view',
+    user: 'b',
+    role: 'admin',
+  },
+  {
+    roleBindingName: 'c-view',
+    user: 'c',
+    role: 'view',
+  },
+  {
+    user: 'd',
+    role: 'admin',
+  },
+];
+
+export const roleBindingsToBeCreated2: UserRoleBinding[] = [
+  {
+    user: 'd',
+    role: 'admin',
+  },
+];
+
+export const initialRoles2: UserRoleBinding[] = [
+  {
+    roleBindingName: 'a-view',
+    user: 'ab',
+    role: 'view',
+  },
+  {
+    roleBindingName: 'b-view',
+    user: 'b',
+    role: 'view',
+  },
+  {
+    roleBindingName: 'xy-admin',
+    user: 'xy',
+    role: 'admin',
+  },
+  {
+    roleBindingName: 'yx-view',
+    user: 'yx',
+    role: 'view',
+  },
+];
+export const roleBindingsToBeCreated3: UserRoleBinding[] = [
+  {
+    roleBindingName: 'b-view',
+    user: 'b',
+    role: 'admin',
+  },
+  {
+    user: 'c',
+    role: 'admin',
+  },
+];
+
+export const rolesBindingsToBeRemoved2: UserRoleBinding[] = [
+  {
+    roleBindingName: 'a-view',
+    user: 'ab',
+    role: 'view',
+  },
+  {
+    roleBindingName: 'b-view',
+    user: 'b',
+    role: 'view',
+  },
+];
+
+export const displayRoleBindings: UserRoleBinding[] = [
+  {
+    roleBindingName: 'xy-admin',
+    user: 'xy',
+    role: 'admin',
+  },
+  {
+    roleBindingName: 'yx-view',
+    user: 'yx',
+    role: 'view',
+  },
+  {
+    roleBindingName: 'b-view',
+    user: 'b',
+    role: 'admin',
+  },
+  {
+    user: 'c',
+    role: 'admin',
+  },
+];

--- a/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-submit-utils.spec.ts
@@ -1,0 +1,49 @@
+import {
+  getRolesWithNameChange,
+  getFinalRoles,
+  getNewRoles,
+  getRemovedRoles,
+} from '../project-access-form-submit-utils';
+import {
+  roleBindingsToBeCreated1,
+  rolesBindingsToBeRemoved1,
+  rolesWithNameChangeResult,
+  initialRoles2,
+  roleBindingsToBeCreated3,
+  rolesBindingsToBeRemoved2,
+  displayRoleBindings,
+  initialRoles1,
+  formValues1,
+  rolesBindingsToBeRemoved,
+  formValues2,
+  roleBindingsToBeCreated2,
+} from '../__mocks__/project-access-form-mock';
+
+describe('Project Access handleSubmit Utils', () => {
+  it('should get roles removed by the user', async () => {
+    const deleteRoles = getRemovedRoles(initialRoles1, formValues1);
+    expect(deleteRoles).toEqual(rolesBindingsToBeRemoved);
+  });
+
+  it('should get new roles added by the user', async () => {
+    const newRoles = getNewRoles(initialRoles1, formValues2);
+    expect(newRoles).toEqual(roleBindingsToBeCreated2);
+  });
+
+  it('should get roles with Name change', async () => {
+    const rolesWithNameChange = getRolesWithNameChange(
+      roleBindingsToBeCreated1,
+      rolesBindingsToBeRemoved1,
+    );
+    expect(rolesWithNameChange).toEqual(rolesWithNameChangeResult);
+  });
+
+  it('should get the final list of roles to be displayed in the form', async () => {
+    const finalRoles = getFinalRoles(
+      initialRoles2,
+      rolesBindingsToBeRemoved2,
+      roleBindingsToBeCreated3,
+    );
+    expect(finalRoles).toEqual(displayRoleBindings);
+  });
+});

--- a/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-utils.spec.tsx
@@ -1,0 +1,20 @@
+import { filterRoleBindings, getUserRoleBindings } from '../project-access-form-utils';
+import { Roles } from '../project-access-form-utils-types';
+import {
+  roleBindingsResourceData,
+  roleBindingsWithRequiredRolesResult,
+  roleBindingsWithRequiredRoles,
+  roleBindingsWithRequiredAttributes,
+} from '../__mocks__/project-access-form-mock';
+
+describe('Fetch required roles', () => {
+  it('should fetch the only the required rolebindings', async () => {
+    const filteredRoleBindings = filterRoleBindings(roleBindingsResourceData, Roles);
+    expect(filteredRoleBindings).toEqual(roleBindingsWithRequiredRolesResult);
+  });
+
+  it('should consider only the required attributes', async () => {
+    const userRoleBindings = getUserRoleBindings(roleBindingsWithRequiredRoles);
+    expect(userRoleBindings).toEqual(roleBindingsWithRequiredAttributes);
+  });
+});

--- a/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-validation-utils.spec.ts
@@ -1,0 +1,27 @@
+import { cloneDeep } from 'lodash';
+import { validationSchema } from '../project-access-form-validation-utils';
+import { mockProjectAccessData } from '../__mocks__/project-access-form-mock';
+
+describe('ValidationUtils', () => {
+  it('should throw an error if Name field is empty', async () => {
+    const mockData = cloneDeep(mockProjectAccessData);
+    mockData.projectAccess[0].user = '';
+
+    await validationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
+    await validationSchema.validate(mockData).catch((err) => {
+      expect(err.message).toBe('Required');
+      expect(err.type).toBe('required');
+    });
+  });
+
+  it('should throw an error if no Role is selected ', async () => {
+    const mockData = cloneDeep(mockProjectAccessData);
+    mockData.projectAccess[0].role = '';
+
+    await validationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(false));
+    await validationSchema.validate(mockData).catch((err) => {
+      expect(err.message).toBe('Required');
+      expect(err.type).toBe('required');
+    });
+  });
+});

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-submit-utils.ts
@@ -1,0 +1,87 @@
+import * as _ from 'lodash';
+import { k8sCreate, k8sKill, k8sPatch, K8sResourceKind } from '@console/internal/module/k8s';
+import { RoleBindingModel } from '@console/internal/models';
+import { generateSecret } from '../import/import-submit-utils';
+import { Verb, UserRoleBinding } from './project-access-form-utils-types';
+
+export const getRolesWithNameChange = (
+  newRoles: UserRoleBinding[],
+  removeRoles: UserRoleBinding[],
+) => {
+  const createRoles = _.filter(newRoles, 'roleBindingName');
+  const deleteRoles = _.filter(removeRoles, (o1) =>
+    createRoles.find((o2) => o1.roleBindingName === o2.roleBindingName),
+  );
+  const rolesWithNameChange = _.filter(createRoles, (o1) =>
+    deleteRoles.find(
+      (o2) =>
+        o1.roleBindingName === o2.roleBindingName && o1.user !== o2.user && o1.role === o2.role,
+    ),
+  );
+  return rolesWithNameChange;
+};
+
+export const getFinalRoles = (
+  initialValues: UserRoleBinding[],
+  removeRoles: UserRoleBinding[],
+  newRoles: UserRoleBinding[],
+) => {
+  const finalRoles = _.filter(
+    initialValues,
+    (o1) => !removeRoles.find((o2) => o1.roleBindingName === o2.roleBindingName),
+  );
+  return [...finalRoles, ...newRoles];
+};
+
+export const sendK8sRequest = (verb: string, roleBinding): Promise<K8sResourceKind> => {
+  switch (verb) {
+    case Verb.Create:
+      return k8sCreate(RoleBindingModel, roleBinding);
+    case Verb.Remove:
+      return k8sKill(RoleBindingModel, roleBinding);
+    case Verb.Patch:
+      return k8sPatch(RoleBindingModel, { metadata: roleBinding.metadata }, [
+        { op: 'replace', path: `/subjects/0`, value: roleBinding.subjects[0] },
+      ]);
+    default:
+      return null;
+  }
+};
+
+export const generateRoleBindingName = (username: string, role: string) => {
+  return `${username}-${role}-${generateSecret()}`;
+};
+
+export const getNewRoles = (initialRoles: UserRoleBinding[], formValues: UserRoleBinding[]) => {
+  const newRoles = _.uniqBy(
+    _.filter(
+      formValues,
+      (o1) => !initialRoles.find((o2) => o1.user === o2.user && o1.role === o2.role),
+    ),
+    function(user) {
+      return JSON.stringify([user.user, user.role]);
+    },
+  );
+  return newRoles;
+};
+
+export const getRemovedRoles = (initialRoles: UserRoleBinding[], formValues: UserRoleBinding[]) => {
+  const removeRoles = _.filter(
+    initialRoles,
+    (o1) => !formValues.find((o2: UserRoleBinding) => o1.user === o2.user && o1.role === o2.role),
+  );
+  return removeRoles;
+};
+
+export const sendRoleBindingRequest = (verb: string, roles: UserRoleBinding[], roleBinding) => {
+  const finalArray = [];
+  _.forEach(roles, (user) => {
+    const roleBindingName =
+      verb === Verb.Create ? generateRoleBindingName(user.user, user.role) : user.roleBindingName;
+    roleBinding.subjects[0].name = user.user;
+    roleBinding.roleRef.name = user.role;
+    roleBinding.metadata.name = roleBindingName;
+    finalArray.push(sendK8sRequest(verb, roleBinding));
+  });
+  return finalArray;
+};

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-utils-types.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-utils-types.ts
@@ -1,0 +1,52 @@
+export enum Verb {
+  Create = 'Create',
+  Remove = 'Remove',
+  Patch = 'Patch',
+}
+
+export enum Roles {
+  view = 'view',
+  admin = 'admin',
+  edit = 'edit',
+}
+
+export interface UserRole {
+  metadata: {
+    name: string;
+  };
+  roleRef: {
+    name: string;
+  };
+  subjects: [
+    {
+      name: string;
+    }
+  ];
+}
+
+export interface UserRoleBinding {
+  roleBindingName?: string;
+  user: string;
+  role: string;
+}
+
+export const roleBinding = {
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  kind: 'RoleBinding',
+  metadata: {
+    name: '',
+    namespace: '',
+  },
+  roleRef: {
+    apiGroup: 'rbac.authorization.k8s.io',
+    kind: 'ClusterRole',
+    name: '',
+  },
+  subjects: [
+    {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'User',
+      name: '',
+    },
+  ],
+};

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-utils.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-utils.ts
@@ -1,0 +1,24 @@
+import * as _ from 'lodash';
+import { UserRoleBinding, UserRole } from './project-access-form-utils-types';
+
+export const filterRoleBindings = (roleBindings, roles) => {
+  return _.filter(roleBindings.data, (user: UserRole) => _.keys(roles).includes(user.roleRef.name));
+};
+
+export const getUserRoleBindings = (roleBindings) => {
+  let userRoleBindings: UserRoleBinding[] = [];
+  roleBindings.map(
+    (user: UserRole) =>
+      (userRoleBindings = [
+        ...userRoleBindings,
+        ...[
+          {
+            roleBindingName: user.metadata.name,
+            user: user.subjects[0].name,
+            role: user.roleRef.name,
+          },
+        ],
+      ]),
+  );
+  return userRoleBindings;
+};

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-validation-utils.ts
@@ -1,0 +1,10 @@
+import * as yup from 'yup';
+
+export const validationSchema = yup.object().shape({
+  projectAccess: yup.array().of(
+    yup.object().shape({
+      user: yup.string().required('Required'),
+      role: yup.string().required('Required'),
+    }),
+  ),
+});

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -111,6 +111,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'NavItem/Href',
+    properties: {
+      section: 'Advanced',
+      perspective: 'dev',
+      componentProps: {
+        name: 'Project Access',
+        href: '/project-access',
+        testID: 'advanced-project-access-header',
+      },
+    },
+  },
+  {
     type: 'NavItem/ResourceNS',
     properties: {
       section: 'Advanced',
@@ -202,7 +214,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
-      path: ['/add', '/import', '/topology', '/deploy-image', '/metrics'],
+      path: ['/add', '/import', '/topology', '/deploy-image', '/metrics', '/project-access'],
       component: NamespaceRedirect,
     },
   },
@@ -302,6 +314,17 @@ const plugin: Plugin<ConsumedExtensions> = [
       loader: async () =>
         (await import('./components/MetricsPage' /* webpackChunkName: "dev-console-metrics" */))
           .default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: ['/project-access/all-namespaces', '/project-access/ns/:ns'],
+      loader: async () =>
+        (await import(
+          './components/project-access/ProjectAccessPage' /* webpackChunkName: "dev-console-projectAccess" */
+        )).default,
     },
   },
   {


### PR DESCRIPTION
This PR includes:
- A navigational menu item to navigate to the Project Access Form
- The Project Access form allows developers to grant or revoke permission with their project
- allows a developer to update existing roles
- the form ignores duplicate entries made by the user
- developers with no projects/first-time users will see the starting guide banner to get started
- unit tests
- a shared component used by Project Access form, Pipeline Parameters & Pipeline Resources

Refer Story: https://jira.coreos.com/browse/ODC-1287

when user has no projects :
![Screenshot from 2019-10-10 23-22-47](https://user-images.githubusercontent.com/22490998/66598570-ed5b2d80-ebbe-11e9-9d41-ecd318d12f25.png)


GIF:
![final_5d9f81e60bbdbb0014206c6d_600810](https://user-images.githubusercontent.com/22490998/66599274-70c94e80-ebc0-11e9-8f91-350a67e015bc.gif)



Note: I will squash all the commits once changes are approved