### PR TITLE
Add `text` to ConsoleCLIDownload YAML template

### DIFF
--- a/frontend/integration-tests/tests/crd-extensions.scenario.ts
+++ b/frontend/integration-tests/tests/crd-extensions.scenario.ts
@@ -27,7 +27,7 @@ describe('CRD extensions', () => {
         displayName: name,
         description:
           'This is an example CLI download description that can include markdown such as paragraphs, unordered lists, code, [links](https://www.example.com), etc.',
-        links: [{ href: 'https://www.example.com' }],
+        links: [{ href: 'https://www.example.com', text: 'Example CLI Download' }],
       },
     };
 

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -1045,6 +1045,7 @@ spec:
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce a lobortis justo, eu suscipit purus.
   links:
     - href: 'https://www.example.com'
+      text: Download Example CLI
 `,
   )
   .setIn(


### PR DESCRIPTION
This fixes the merge queue until we can change the CRD validation. I think it's probably better to have the `text` property in the example anyway so users know they can change it.

/assign @rhamilto @benjaminapetersen 