### PR TITLE
Add SecondaryStatus component

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeStatus.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Status, isNodeUnschedulable } from '@console/shared';
+import { Status, SecondaryStatus, getNodeSecondaryStatus } from '@console/shared';
 import { NodeKind } from '@console/internal/module/k8s';
 import { nodeStatus } from '../../status/node';
 
@@ -10,7 +10,7 @@ type NodeStatusProps = {
 const NodeStatus: React.FC<NodeStatusProps> = ({ node }) => (
   <>
     <Status status={nodeStatus(node)} />
-    {isNodeUnschedulable(node) && <small className="text-muted">Scheduling Disabled</small>}
+    <SecondaryStatus status={getNodeSecondaryStatus(node)} />
   </>
 );
 export default NodeStatus;

--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -12,8 +12,8 @@ import { menuActions } from './menu-actions';
 import NodeStatus from './NodeStatus';
 
 const tableColumnClasses = [
-  classNames('col-md-5', 'col-sm-5', 'col-xs-8'),
-  classNames('col-md-2', 'col-sm-3', 'col-xs-4'),
+  classNames('col-md-4', 'col-sm-4', 'col-xs-8'),
+  classNames('col-md-3', 'col-sm-4', 'col-xs-4'),
   classNames('col-md-2', 'col-sm-4', 'hidden-xs'),
   classNames('col-md-3', 'hidden-sm', 'hidden-xs'),
   Kebab.columnClass,

--- a/frontend/packages/console-shared/src/components/status/SecondaryStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/SecondaryStatus.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+
+type SecondaryStatusProps = {
+  status?: string | string[];
+};
+
+const SecondaryStatus: React.FC<SecondaryStatusProps> = ({ status }) => {
+  const statusLabel = _.compact(_.concat([], status)).join(', ');
+  if (statusLabel) {
+    return <small className="text-muted">{statusLabel}</small>;
+  }
+  return null;
+};
+
+export default SecondaryStatus;

--- a/frontend/packages/console-shared/src/components/status/index.ts
+++ b/frontend/packages/console-shared/src/components/status/index.ts
@@ -7,4 +7,5 @@ export { default as SuccessStatus } from './SuccessStatus';
 export { default as ErrorStatus } from './ErrorStatus';
 export { default as InfoStatus } from './InfoStatus';
 export { default as ProgressStatus } from './ProgressStatus';
+export { default as SecondaryStatus } from './SecondaryStatus';
 export * from './Icons';

--- a/frontend/packages/console-shared/src/selectors/node.ts
+++ b/frontend/packages/console-shared/src/selectors/node.ts
@@ -40,3 +40,11 @@ export const isNodeReady = (node: NodeKind): boolean => {
 
   return readyState && readyState.status === 'True';
 };
+
+export const getNodeSecondaryStatus = (node: NodeKind): string[] => {
+  const states = [];
+  if (isNodeUnschedulable(node)) {
+    states.push('Scheduling disabled');
+  }
+  return states;
+};

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
@@ -13,49 +13,49 @@ import BareMetalHostStatus from './BareMetalHostStatus';
 import BareMetalHostRole from './BareMetalHostRole';
 import { menuActions } from './host-menu-actions';
 
-const tableColumnClasses = [
-  classNames('col-lg-3', 'col-md-4', 'col-sm-12', 'col-xs-12'),
-  classNames('col-lg-2', 'col-md-4', 'col-sm-6', 'hidden-xs'),
-  classNames('col-lg-3', 'col-md-4', 'hidden-sm', 'hidden-xs'),
-  classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
-  classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
-  Kebab.columnClass,
-];
+const tableColumnClasses = {
+  name: classNames('col-lg-3', 'col-md-4', 'col-sm-12', 'col-xs-12'),
+  status: classNames('col-lg-3', 'col-md-4', 'col-sm-6', 'hidden-xs'),
+  node: classNames('col-lg-2', 'col-md-4', 'hidden-sm', 'hidden-xs'),
+  role: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
+  address: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
+  kebab: Kebab.columnClass,
+};
 
 const HostsTableHeader = () => [
   {
     title: 'Name',
     sortField: 'host.metadata.name',
     transforms: [sortable],
-    props: { className: tableColumnClasses[0] },
+    props: { className: tableColumnClasses.name },
   },
   {
     title: 'Status',
     sortField: 'status.status',
     transforms: [sortable],
-    props: { className: tableColumnClasses[1] },
+    props: { className: tableColumnClasses.status },
   },
   {
     title: 'Node',
     sortField: 'node.metadata.name',
     transforms: [sortable],
-    props: { className: tableColumnClasses[2] },
+    props: { className: tableColumnClasses.node },
   },
   {
     title: 'Role',
     sortField: 'machine.metadata.labels["machine.openshift.io/cluster-api-machine-role"]',
     transforms: [sortable],
-    props: { className: tableColumnClasses[3] },
+    props: { className: tableColumnClasses.role },
   },
   {
     title: 'Management Address',
     sortField: 'host.spec.bmc.address',
     transforms: [sortable],
-    props: { className: tableColumnClasses[4] },
+    props: { className: tableColumnClasses.address },
   },
   {
     title: '',
-    props: { className: tableColumnClasses[5] },
+    props: { className: tableColumnClasses.kebab },
   },
 ];
 
@@ -84,25 +84,25 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({
 
   return (
     <TableRow id={uid} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
+      <TableData className={tableColumnClasses.name}>
         <ResourceLink
           kind={referenceForModel(BareMetalHostModel)}
           name={name}
           namespace={namespace}
         />
       </TableData>
-      <TableData className={tableColumnClasses[1]}>
+      <TableData className={tableColumnClasses.status}>
         <BareMetalHostStatus status={status} />
         <SecondaryStatus status={getHostPowerStatus(host)} />
       </TableData>
-      <TableData className={tableColumnClasses[2]}>
+      <TableData className={tableColumnClasses.node}>
         <NodeLink nodeName={nodeName} />
       </TableData>
-      <TableData className={tableColumnClasses[3]}>
+      <TableData className={tableColumnClasses.role}>
         <BareMetalHostRole machine={machine} node={node} />
       </TableData>
-      <TableData className={tableColumnClasses[4]}>{address}</TableData>
-      <TableData className={tableColumnClasses[5]}>
+      <TableData className={tableColumnClasses.address}>{address}</TableData>
+      <TableData className={tableColumnClasses.kebab}>
         <Kebab
           options={menuActions.map((action) =>
             action(BareMetalHostModel, host, null, {

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { Kebab, ResourceLink } from '@console/internal/components/utils';
 import { sortable } from '@patternfly/react-table';
-import { getName, getUID, getNamespace } from '@console/shared';
+import { getName, getUID, getNamespace, SecondaryStatus } from '@console/shared';
 import { TableRow, TableData, Table } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { HostRowBundle } from '../types';
-import { getHostBMCAddress } from '../../selectors';
+import { getHostBMCAddress, getHostPowerStatus } from '../../selectors';
 import { BareMetalHostModel } from '../../models';
 import NodeLink from './NodeLink';
 import BareMetalHostStatus from './BareMetalHostStatus';
@@ -93,6 +93,7 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({
       </TableData>
       <TableData className={tableColumnClasses[1]}>
         <BareMetalHostStatus status={status} />
+        <SecondaryStatus status={getHostPowerStatus(host)} />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
         <NodeLink nodeName={nodeName} />


### PR DESCRIPTION
Depends on ~~https://github.com/openshift/console/pull/2882~~ (to avoid rebase issues)

Introduce SecondaryStatus component. This component is reused by Node and Bare metal host status in the listings to track secondary states which are not included in primary status (e.g. node is unschedulable, host power status)

<img width="961" alt="Screenshot 2019-10-03 at 16 33 17" src="https://user-images.githubusercontent.com/1121740/66151104-e9576a80-e616-11e9-8e8c-3c1eb35438f5.png">
