### PR TITLE
Correctly update monaco readOnly option

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -234,7 +234,11 @@ export const EditYAML = connect(stateToProps)(
         namespace,
       };
       checkAccess(resourceAttributes, impersonate).then((resp) => {
-        this.setState({ notAllowed: !resp.status.allowed });
+        const notAllowed = !resp.status.allowed;
+        this.setState({ notAllowed });
+        if (this.monacoRef.current) {
+          this.monacoRef.current.editor.updateOptions({ readOnly: notAllowed });
+        }
       });
     }
 


### PR DESCRIPTION
We need to call `editor.updateOptions` for the new value to take effect.
Updating the `options` prop for `MonacoEditor` is not enough.

/assign @rhamilto 