### PR TITLE
Add separate error message for when no projects match filter

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -291,13 +291,14 @@ const ProjectList_ = (props) => {
   const ProjectEmptyMessage = () => (
     <MsgBox title="Welcome to OpenShift" detail={ProjectEmptyMessageDetail} />
   );
+  const ProjectNotFoundMessage = () => <MsgBox title="No Projects Found" />;
   return (
     <Table
       {...props}
       aria-label="Projects"
       Header={ProjectTableHeader}
       Row={ProjectTableRow}
-      EmptyMsg={ProjectEmptyMessage}
+      EmptyMsg={props.data.length > 0 ? ProjectNotFoundMessage : ProjectEmptyMessage}
       virtualize
     />
   );


### PR DESCRIPTION
With no projects:
<img width="909" alt="Screen Shot 2019-10-03 at 2 35 41 PM" src="https://user-images.githubusercontent.com/7014965/66154335-345b8880-e5eb-11e9-9326-34b05bfc5566.png">

With project:
<img width="909" alt="Screen Shot 2019-10-03 at 2 35 57 PM" src="https://user-images.githubusercontent.com/7014965/66154344-3887a600-e5eb-11e9-9378-d71ea5867e91.png">

Message when projects exist but don't match filter:
<img width="912" alt="Screen Shot 2019-10-03 at 2 36 13 PM" src="https://user-images.githubusercontent.com/7014965/66154352-3cb3c380-e5eb-11e9-85eb-acc9d07cd4ff.png">

Fixes [CONSOLE-1763](https://jira.coreos.com/browse/CONSOLE-1763).

Heads up for @openshift/team-ux-review.