### PR TITLE
kubevirt: VM status dashboard card

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertsBody.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertsBody.tsx
@@ -5,9 +5,14 @@ import {
   EmptyStateIcon,
   EmptyStateBody,
 } from '@patternfly/react-core';
-import { CheckCircleIcon, UnknownIcon } from '@patternfly/react-icons';
+import { UnknownIcon, CheckCircleIcon } from '@patternfly/react-icons';
 
-const AlertsBody: React.FC<AlertsBodyProps> = ({ isLoading, error, children, emptyMessage }) => {
+const AlertsBody: React.FC<AlertsBodyProps> = ({
+  isLoading = false,
+  error = false,
+  children,
+  emptyMessage,
+}) => {
   let body: React.ReactNode;
   if (error) {
     body = (
@@ -40,8 +45,8 @@ const AlertsBody: React.FC<AlertsBodyProps> = ({ isLoading, error, children, emp
 export default AlertsBody;
 
 type AlertsBodyProps = {
-  isLoading: boolean;
-  error: boolean;
+  isLoading?: boolean;
+  error?: boolean;
   children?: React.ReactNode;
   emptyMessage: string;
 };

--- a/frontend/packages/console-shared/src/components/status/icons.tsx
+++ b/frontend/packages/console-shared/src/components/status/icons.tsx
@@ -3,11 +3,13 @@ import {
   CheckCircleIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
+  InfoCircleIcon,
 } from '@patternfly/react-icons';
 import {
   global_warning_color_100 as warningColor,
   global_danger_color_100 as dangerColor,
   global_success_color_200 as okColor,
+  global_info_color_100 as blueInfoColor,
 } from '@patternfly/react-tokens';
 
 export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
@@ -20,6 +22,10 @@ export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({ className
 
 export const YellowExclamationTriangleIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
   <ExclamationTriangleIcon color={warningColor.value} className={className} alt={alt} />
+);
+
+export const BlueInfoCircleIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
+  <InfoCircleIcon color={blueInfoColor.value} className={className} alt={alt} />
 );
 
 type ColoredIconProps = {

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/index.ts
@@ -1,2 +1,3 @@
 export * from './vm-details-card';
 export * from './vm-inventory-card';
+export * from './vm-status-card';

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-alerts.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-alerts.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
+import { StatusItem } from '@console/shared/src/components/dashboard/status-card/AlertItem';
+import { BlueInfoCircleIcon } from '@console/shared/src/components/status';
+import { VMIKind, VMKind } from '../../../types';
+import { getVMIConditionByType } from '../../../selectors/vmi';
+
+// Based on: https://github.com/kubevirt/kubevirt/blob/f71e9c9615a6c36178169d66814586a93ba515b5/staging/src/kubevirt.io/client-go/api/v1/types.go#L337
+const VMI_CONDITION_AGENT_CONNECTED = 'AgentConnected';
+
+const isGuestAgentInstalled = (vmi: VMIKind) => {
+  // the condition type is unique
+  const conditions = getVMIConditionByType(vmi, VMI_CONDITION_AGENT_CONNECTED);
+  return conditions && conditions.length > 0 && conditions[0].status === 'True';
+};
+
+export const VMAlerts: React.FC<VMAlertsProps> = ({ vm, vmi }) => {
+  return (
+    <AlertsBody emptyMessage="No VM messages" isLoading={!vm}>
+      {vmi && vmi.status && !isGuestAgentInstalled(vmi) && (
+        <StatusItem
+          Icon={BlueInfoCircleIcon}
+          message="This VM does not have guest agent installed. Some metrics and management features will not be available."
+          LinkComponent={() => null /* TODO(mlibra) */}
+        />
+      )}
+    </AlertsBody>
+  );
+};
+
+type VMAlertsProps = {
+  vm?: VMKind;
+  vmi?: VMIKind;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-alerts.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-alerts.tsx
@@ -3,30 +3,28 @@ import AlertsBody from '@console/shared/src/components/dashboard/status-card/Ale
 import { StatusItem } from '@console/shared/src/components/dashboard/status-card/AlertItem';
 import { BlueInfoCircleIcon } from '@console/shared/src/components/status';
 import { VMIKind, VMKind } from '../../../types';
-import { getVMIConditionByType } from '../../../selectors/vmi';
+import { getVMIConditionsByType } from '../../../selectors/vmi';
 
 // Based on: https://github.com/kubevirt/kubevirt/blob/f71e9c9615a6c36178169d66814586a93ba515b5/staging/src/kubevirt.io/client-go/api/v1/types.go#L337
 const VMI_CONDITION_AGENT_CONNECTED = 'AgentConnected';
 
 const isGuestAgentInstalled = (vmi: VMIKind) => {
   // the condition type is unique
-  const conditions = getVMIConditionByType(vmi, VMI_CONDITION_AGENT_CONNECTED);
+  const conditions = getVMIConditionsByType(vmi, VMI_CONDITION_AGENT_CONNECTED);
   return conditions && conditions.length > 0 && conditions[0].status === 'True';
 };
 
-export const VMAlerts: React.FC<VMAlertsProps> = ({ vm, vmi }) => {
-  return (
-    <AlertsBody emptyMessage="No VM messages" isLoading={!vm}>
-      {vmi && vmi.status && !isGuestAgentInstalled(vmi) && (
-        <StatusItem
-          Icon={BlueInfoCircleIcon}
-          message="This VM does not have guest agent installed. Some metrics and management features will not be available."
-          LinkComponent={() => null /* TODO(mlibra) */}
-        />
-      )}
-    </AlertsBody>
-  );
-};
+export const VMAlerts: React.FC<VMAlertsProps> = ({ vm, vmi }) => (
+  <AlertsBody emptyMessage="No VM messages" isLoading={!vm}>
+    {vmi && vmi.status && !isGuestAgentInstalled(vmi) && (
+      <StatusItem
+        Icon={BlueInfoCircleIcon}
+        message="This VM does not have guest agent installed. Some metrics and management features will not be available."
+        LinkComponent={() => null /* TODO(mlibra) */}
+      />
+    )}
+  </AlertsBody>
+);
 
 type VMAlertsProps = {
   vm?: VMKind;

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-status-card.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-status-card.scss
@@ -1,0 +1,5 @@
+// Fix of styling in kubevirt-web-ui-components
+// TODO(mlibra): move VmStatus component to openshift/console and remove this fix
+.co-dashboard-card .kubevirt-status__icon {
+  padding-top: 3px;
+}

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-status-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-status-card.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { VmStatus } from 'kubevirt-web-ui-components';
+import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
+import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
+import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
+import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
+import HealthBody from '@console/shared/src/components/dashboard/health-card/HealthBody';
+import { DashboardItemProps } from '@console/internal/components/dashboard/with-dashboard-resources';
+import { VMDashboardContext } from '../../vms/vm-dashboard-context';
+import { VMAlerts } from './vm-alerts';
+
+import './vm-status-card.scss';
+
+export const VMStatusCard: React.FC<VMStatusCardProps> = () => {
+  const vmDashboardContext = React.useContext(VMDashboardContext);
+  const { vm, vmi, pods, migrations } = vmDashboardContext;
+
+  return (
+    <DashboardCard>
+      <DashboardCardHeader>
+        <DashboardCardTitle>Status</DashboardCardTitle>
+      </DashboardCardHeader>
+      <DashboardCardBody>
+        <HealthBody>
+          <VmStatus vm={vm} pods={pods} migrations={migrations} />
+        </HealthBody>
+        <VMAlerts vm={vm} vmi={vmi} />
+      </DashboardCardBody>
+    </DashboardCard>
+  );
+};
+
+type VMStatusCardProps = DashboardItemProps;

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
@@ -3,10 +3,10 @@ import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import DashboardGrid from '@console/shared/src/components/dashboard/DashboardGrid';
 import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
 import { VMKind, VMIKind } from '../../types';
-import { VMDetailsCard, VMInventoryCard } from '../dashboards-page/vm-dashboard';
+import { VMDetailsCard, VMInventoryCard, VMStatusCard } from '../dashboards-page/vm-dashboard';
 import { VMDashboardContext } from './vm-dashboard-context';
 
-const mainCards = [];
+const mainCards = [{ Card: VMStatusCard }];
 const leftCards = [{ Card: VMDetailsCard }, { Card: VMInventoryCard }];
 const rightCards = [];
 

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/selectors.ts
@@ -17,3 +17,11 @@ export const getVMIDisks = (vmi: VMIKind): VMIKind['spec']['domain']['devices'][
   vmi && vmi.spec && vmi.spec.domain && vmi.spec.domain.devices && vmi.spec.domain.devices.disks
     ? vmi.spec.domain.devices.disks
     : [];
+
+export const getVMIConditionByType = (
+  vmi: VMIKind,
+  condType: string,
+): VMIKind['status']['conditions'] => {
+  const conditions = vmi && vmi.status && vmi.status.conditions;
+  return (conditions || []).filter((cond) => cond.type === condType);
+};

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/selectors.ts
@@ -18,7 +18,7 @@ export const getVMIDisks = (vmi: VMIKind): VMIKind['spec']['domain']['devices'][
     ? vmi.spec.domain.devices.disks
     : [];
 
-export const getVMIConditionByType = (
+export const getVMIConditionsByType = (
   vmi: VMIKind,
   condType: string,
 ): VMIKind['status']['conditions'] => {

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/status-card.tsx
@@ -5,9 +5,8 @@ import {
   DashboardsOverviewHealthURLSubsystem,
   DashboardsOverviewHealthPrometheusSubsystem,
 } from '@console/plugin-sdk';
-import { Button } from 'patternfly-react';
 import { ArrowCircleUpIcon } from '@patternfly/react-icons';
-import { Gallery, GalleryItem } from '@patternfly/react-core';
+import { Gallery, GalleryItem, Button } from '@patternfly/react-core';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
@@ -172,7 +171,7 @@ const ClusterAlerts = withDashboardResources(
       () => (
         <Button
           className="co-status-card__link-button"
-          bsStyle="link"
+          variant="link"
           onClick={() => clusterUpdateModal({ cv })}
         >
           View details


### PR DESCRIPTION
The alerts-section is so far just two-state - `No messages` and `Missing guest agent`.

Edit: per discussion bellow, the action firing guest agent installation is removed and wil be added once implemented by #2477 or its follow-up.

---
![01_starting](https://user-images.githubusercontent.com/17194943/66191459-a89b3800-e68e-11e9-8ec0-bbc648aa1ff1.png)

![02_running](https://user-images.githubusercontent.com/17194943/66191368-7558a900-e68e-11e9-929e-e247b5cde52e.png)

![03_off](https://user-images.githubusercontent.com/17194943/66191634-19425480-e68f-11e9-9b91-b318cdfb26c1.png)
