### PR TITLE
kubevirt: bump kubevirt-web-ui-components to v0.1.45

### DIFF
--- a/frontend/packages/kubevirt-plugin/package.json
+++ b/frontend/packages/kubevirt-plugin/package.json
@@ -10,7 +10,7 @@
     "@console/internal": "0.0.0-fixed",
     "@console/plugin-sdk": "0.0.0-fixed",
     "@console/shared": "0.0.0-fixed",
-    "kubevirt-web-ui-components": "~0.1.44"
+    "kubevirt-web-ui-components": "~0.1.45"
   },
   "consolePlugin": {
     "entry": "src/plugin.tsx"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7248,10 +7248,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
-kubevirt-web-ui-components@~0.1.44:
-  version "0.1.44"
-  resolved "https://registry.yarnpkg.com/kubevirt-web-ui-components/-/kubevirt-web-ui-components-0.1.44.tgz#02a7a37e088d749d758545cb89c1ee3816e975d0"
-  integrity sha512-gOJzBkuj6/8jo1SAOinExQVvBI1TGJXg0MlQ2t7Ig2XtLTow36AUOjai6Hl8qbMkYvXddSi+6k7fg/xg6dlLnA==
+kubevirt-web-ui-components@~0.1.45:
+  version "0.1.45"
+  resolved "https://registry.yarnpkg.com/kubevirt-web-ui-components/-/kubevirt-web-ui-components-0.1.45.tgz#600569cec9662cd178f62e80f4621aee9d211696"
+  integrity sha512-BLGbsYDR95WgGrT9RmrejRXCKdV0e7YBSN3RsuGzOMmXceWJ/VdlKFPFZUpCJ8g9BKqRxHMXFxBd3w/qRqQuNQ==
   dependencies:
     "@patternfly/react-console" "1.x"
     babel-plugin-transform-es2015-modules-umd "6.24.1"


### PR DESCRIPTION
Change log: https://github.com/kubevirt/web-ui-components/releases/tag/v0.1.45