### PR TITLE
Modify field group component for create operand form

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
@@ -112,7 +112,7 @@ const inputValueFor = (capability: SpecCapability) => async (el: ElementFinder) 
         },
       };
     case SpecCapability.booleanSwitch:
-      return (await el.$('.pf-c-switch__input').getAttribute('checked')) !== 'false';
+      return (await el.$$('.pf-c-switch__input').getAttribute('checked')) !== 'false';
     case SpecCapability.password:
       return el.$('input').getAttribute('value');
     case SpecCapability.checkbox:
@@ -421,6 +421,12 @@ describe('Using OLM descriptor components', () => {
   });
 
   it('pre-populates form values using sample operand from ClusterServiceVersion', async () => {
+    $$('.pf-c-accordion__toggle').each(async (toggleBtn) => {
+      const toggleBtnClasses = await toggleBtn.getAttribute('class');
+      if (!toggleBtnClasses.includes('pf-m-expanded')) {
+        toggleBtn.click();
+      }
+    });
     $$('.co-create-operand__form-group').each(async (input) => {
       await browser
         .actions()

--- a/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
@@ -5,7 +5,7 @@ import { Helmet } from 'react-helmet';
 import { safeDump } from 'js-yaml';
 import * as _ from 'lodash';
 import * as classNames from 'classnames';
-import { Alert, ActionGroup, Button, Switch } from '@patternfly/react-core';
+import { Alert, ActionGroup, Button, Switch, Accordion, Checkbox } from '@patternfly/react-core';
 import { JSONSchema6TypeName } from 'json-schema';
 import {
   apiVersionForModel,
@@ -43,6 +43,7 @@ import { RootState } from '@console/internal/redux';
 import { CreateYAML } from '@console/internal/components/create-yaml';
 import { RadioGroup } from '@console/internal/components/radio';
 import { ConfigureUpdateStrategy } from '@console/internal/components/modals/configure-update-strategy-modal';
+import { ExpandCollapse } from '@console/internal/components/utils/expand-collapse';
 import { ClusterServiceVersionModel } from '../models';
 import { ClusterServiceVersionKind, CRDDescription, APIServiceDefinition } from '../types';
 import { SpecCapability, StatusCapability, Descriptor } from './descriptors/types';
@@ -53,6 +54,7 @@ import {
   defaultNodeAffinity,
   defaultPodAffinity,
 } from './descriptors/spec/affinity';
+import { FieldGroup } from './descriptors/spec/field-group';
 import { referenceForProvidedAPI, ClusterServiceVersionLogo, providedAPIsFor } from './index';
 
 const annotationKey = 'alm-examples';
@@ -453,16 +455,18 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
     }
     if (field.capabilities.includes(SpecCapability.password)) {
       return (
-        <input
-          className="pf-c-form-control"
-          id={field.path}
-          type="password"
-          {...field.validation}
-          onChange={({ currentTarget }) =>
-            setFormValues((values) => ({ ...values, [field.path]: currentTarget.value }))
-          }
-          value={formValues[field.path]}
-        />
+        <div style={{ width: '50%' }}>
+          <input
+            className="pf-c-form-control"
+            id={field.path}
+            type="password"
+            {...field.validation}
+            onChange={({ currentTarget }) =>
+              setFormValues((values) => ({ ...values, [field.path]: currentTarget.value }))
+            }
+            value={formValues[field.path]}
+          />
+        </div>
       );
     }
     if (field.capabilities.some((c) => c.startsWith(SpecCapability.k8sResourcePrefix))) {
@@ -491,15 +495,13 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
     }
     if (field.capabilities.includes(SpecCapability.checkbox)) {
       return (
-        <input
-          type="checkbox"
+        <Checkbox
           id={field.path}
           style={{ marginLeft: '10px' }}
-          checked={formValues[field.path] as boolean}
+          isChecked={formValues[field.path] as boolean}
+          label={field.displayName}
           required={field.required}
-          onChange={({ currentTarget }) =>
-            setFormValues((values) => ({ ...values, [field.path]: currentTarget.checked }))
-          }
+          onChange={(val) => setFormValues((values) => ({ ...values, [field.path]: val }))}
         />
       );
     }
@@ -631,6 +633,13 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
     return null;
   };
 
+  const getGroupName = (group, groupType) => {
+    if (!_.isString(group) || !_.isString(groupType)) {
+      return null;
+    }
+    return _.startCase(group.split(groupType)[1]);
+  };
+
   const fieldGroups = fields.reduce(
     (groups, field) =>
       field.capabilities.find((c) => c.startsWith(SpecCapability.fieldGroup))
@@ -663,28 +672,131 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
 
   useScrollToTopOnMount();
 
-  type FieldGroupProps = {
-    defaultExpand: boolean;
-    group: SpecCapability.fieldGroup;
-  };
+  return (
+    <div className="co-m-pane__body">
+      <div className="row">
+        <form className="col-md-6" onSubmit={submit}>
+          <Accordion asDefinitionList={false} className="co-create-operand__accordion">
+            <div className="form-group">
+              <label className="control-label co-required" htmlFor="name">
+                Name
+              </label>
+              <input
+                className="pf-c-form-control"
+                type="text"
+                onChange={({ target }) =>
+                  setFormValues((values) => ({ ...values, 'metadata.name': target.value }))
+                }
+                value={formValues['metadata.name']}
+                id="metadata.name"
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label className="control-label" htmlFor="tags-input">
+                Labels
+              </label>
+              <SelectorInput
+                onChange={(labels) =>
+                  setFormValues((values) => ({ ...values, 'metadata.labels': labels }))
+                }
+                tags={formValues['metadata.labels']}
+              />
+            </div>
+            {[...arrayFieldGroups].map((group) => {
+              const groupName = getGroupName(group, SpecCapability.arrayFieldGroup);
+              const fieldList = fields
+                .filter((f) => f.capabilities.includes(group))
+                .filter((f) => !_.isNil(inputFor(f)));
 
-  const FieldGroup: React.FC<FieldGroupProps> = ({ group, defaultExpand }) => {
-    const [expand, setExpand] = React.useState<boolean>(defaultExpand);
+              return (
+                <div id={group} key={group}>
+                  <FieldGroup
+                    defaultExpand={_.some(
+                      fieldList,
+                      (f) => f.capabilities.includes(SpecCapability.advanced) && !f.required,
+                    )}
+                    groupName={groupName}
+                  >
+                    {fieldList.map((field) => (
+                      <div key={field.path}>
+                        <div className="form-group co-create-operand__form-group">
+                          <label
+                            className={classNames('form-label', {
+                              'co-required': field.required,
+                            })}
+                            htmlFor={field.path}
+                          >
+                            {field.displayName}
+                          </label>
+                          {inputFor(field)}
+                          {field.description && (
+                            <span id={`${field.path}__description`} className="help-block">
+                              {field.description}
+                            </span>
+                          )}
+                          {formErrors[field.path] && (
+                            <span className="co-error">{formErrors[field.path]}</span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </FieldGroup>
+                </div>
+              );
+            })}
+            {[...fieldGroups].map((group) => {
+              const groupName = getGroupName(group, SpecCapability.fieldGroup);
+              const fieldList = fields
+                .filter((f) => f.capabilities.includes(group))
+                .filter((f) => !_.isNil(inputFor(f)));
 
-    return (
-      <div key={group} id={group}>
-        <div className="co-operand-field-group-title">
-          <label className="form-label">
-            {_.startCase(group.split(SpecCapability.fieldGroup)[1])}
-          </label>
-          <Button type="button" onClick={() => setExpand(!expand)} variant="link">
-            {expand ? 'Collapse' : 'Expand'}
-          </Button>
-        </div>
-        <div className="co-operand-field-group">
-          {expand &&
-            fields
-              .filter((f) => f.capabilities.includes(group))
+              return (
+                <div id={group} key={group}>
+                  <FieldGroup
+                    defaultExpand={_.some(
+                      fieldList,
+                      (f) => f.capabilities.includes(SpecCapability.advanced) && !f.required,
+                    )}
+                    groupName={groupName}
+                  >
+                    {fieldList.map((field) => (
+                      <div key={field.path}>
+                        <div className="form-group co-create-operand__form-group">
+                          <label
+                            className={classNames('form-label', {
+                              'co-required': field.required,
+                            })}
+                            htmlFor={field.path}
+                          >
+                            {field.displayName}
+                          </label>
+                          {inputFor(field)}
+                          {field.description && (
+                            <span id={`${field.path}__description`} className="help-block">
+                              {field.description}
+                            </span>
+                          )}
+                          {formErrors[field.path] && (
+                            <span className="co-error">{formErrors[field.path]}</span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </FieldGroup>
+                </div>
+              );
+            })}
+            {fields
+              .filter(
+                (f) =>
+                  !f.capabilities.some(
+                    (c) =>
+                      c.startsWith(SpecCapability.fieldGroup) ||
+                      c.startsWith(SpecCapability.arrayFieldGroup),
+                  ),
+              )
+              .filter((f) => !f.capabilities.includes(SpecCapability.advanced))
               .filter((f) => !_.isNil(inputFor(f)))
               .map((field) => (
                 <div key={field.path}>
@@ -697,7 +809,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
                     </label>
                     {inputFor(field)}
                     {field.description && (
-                      <span id={`${field.path}__description`} className="help-block text-muted">
+                      <span id={`${field.path}__description`} className="help-block">
                         {field.description}
                       </span>
                     )}
@@ -707,159 +819,46 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
                   </div>
                 </div>
               ))}
-        </div>
-      </div>
-    );
-  };
-  FieldGroup.displayName = 'FieldGroup';
-
-  return (
-    <div className="co-m-pane__body">
-      <div className="row">
-        <form className="col-md-6" onSubmit={submit}>
-          <div className="form-group">
-            <label className="control-label co-required" htmlFor="name">
-              Name
-            </label>
-            <input
-              className="pf-c-form-control"
-              type="text"
-              onChange={({ target }) =>
-                setFormValues((values) => ({ ...values, 'metadata.name': target.value }))
-              }
-              value={formValues['metadata.name']}
-              id="metadata.name"
-              required
-            />
-          </div>
-          <div className="form-group">
-            <label className="control-label" htmlFor="tags-input">
-              Labels
-            </label>
-            <SelectorInput
-              onChange={(labels) =>
-                setFormValues((values) => ({ ...values, 'metadata.labels': labels }))
-              }
-              tags={formValues['metadata.labels']}
-            />
-          </div>
-          {[...arrayFieldGroups].map((group) => (
-            <div key={group}>
-              <label className="form-label">
-                {_.startCase(group.split(SpecCapability.arrayFieldGroup)[1])}
-              </label>
-              <div className="co-operand-field-group">
-                {fields
-                  .filter((f) => f.capabilities.includes(group))
-                  .filter((f) => !_.isNil(inputFor(f)))
-                  .map((field) => (
-                    <div key={field.path}>
-                      <div className="form-group co-create-operand__form-group">
-                        <label
-                          className={classNames('form-label', { 'co-required': field.required })}
-                          htmlFor={field.path}
-                        >
-                          {field.displayName}
-                        </label>
-                        {inputFor(field)}
-                        {field.description && (
-                          <span id={`${field.path}__description`} className="help-block text-muted">
-                            {field.description}
-                          </span>
-                        )}
-                        {formErrors[field.path] && (
-                          <span className="co-error">{formErrors[field.path]}</span>
-                        )}
+            {advancedFields.length > 0 && (
+              <div>
+                <ExpandCollapse
+                  textExpanded="Advanced Configuration"
+                  textCollapsed="Advanced Configuration"
+                >
+                  {advancedFields
+                    .filter((f) => !_.isNil(inputFor(f)))
+                    .map((field) => (
+                      <div key={field.path}>
+                        <div className="form-group co-create-operand__form-group">
+                          <label
+                            className={classNames('form-label', { 'co-required': field.required })}
+                            htmlFor={field.path}
+                          >
+                            {field.displayName}
+                          </label>
+                          {inputFor(field)}
+                          {field.description && (
+                            <span id={`${field.path}__description`} className="help-block">
+                              {field.description}
+                            </span>
+                          )}
+                          {formErrors[field.path] && (
+                            <span className="co-error">{formErrors[field.path]}</span>
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  ))}
+                    ))}
+                </ExpandCollapse>
               </div>
-            </div>
-          ))}
-          {[...fieldGroups].map((group) => (
-            <div key={group} id={group}>
-              <FieldGroup
-                group={group}
-                defaultExpand={_.every(
-                  fields.filter((f) =>
-                    f.capabilities.includes(SpecCapability.fieldGroup.concat(
-                      group,
-                    ) as SpecCapability.fieldGroup),
-                  ),
-                  (f) => f.capabilities.includes(SpecCapability.advanced) && !f.required,
-                )}
-              />
-            </div>
-          ))}
-          {fields
-            .filter(
-              (f) =>
-                !f.capabilities.some(
-                  (c) =>
-                    c.startsWith(SpecCapability.fieldGroup) ||
-                    c.startsWith(SpecCapability.arrayFieldGroup),
-                ),
-            )
-            .filter((f) => !f.capabilities.includes(SpecCapability.advanced))
-            .filter((f) => !_.isNil(inputFor(f)))
-            .map((field) => (
-              <div key={field.path}>
-                <div className="form-group co-create-operand__form-group">
-                  <label
-                    className={classNames('form-label', { 'co-required': field.required })}
-                    htmlFor={field.path}
-                  >
-                    {field.displayName}
-                  </label>
-                  {inputFor(field)}
-                  {field.description && (
-                    <span id={`${field.path}__description`} className="help-block text-muted">
-                      {field.description}
-                    </span>
-                  )}
-                  {formErrors[field.path] && (
-                    <span className="co-error">{formErrors[field.path]}</span>
-                  )}
-                </div>
-              </div>
-            ))}
-          {advancedFields.length > 0 && (
-            <div>
-              <h3>Advanced Configuration</h3>
-              {advancedFields
-                .filter((f) => !_.isNil(inputFor(f)))
-                .map((field) => (
-                  <div key={field.path}>
-                    <div className="form-group co-create-operand__form-group">
-                      <label
-                        className={classNames('form-label', { 'co-required': field.required })}
-                        htmlFor={field.path}
-                      >
-                        {field.displayName}
-                      </label>
-                      {inputFor(field)}
-                      {field.description && (
-                        <span id={`${field.path}__description`} className="help-block text-muted">
-                          {field.description}
-                        </span>
-                      )}
-                      {formErrors[field.path] && (
-                        <span className="co-error">{formErrors[field.path]}</span>
-                      )}
-                    </div>
-                  </div>
-                ))}
-            </div>
-          )}
+            )}
+          </Accordion>
           {(!_.isEmpty(error) || !_.isEmpty(_.compact(_.values(formErrors)))) && (
             <Alert
               isInline
-              className="co-alert co-break-word co-alert--scrollable"
+              className="co-alert co-break-word"
               variant="danger"
-              title="Error"
-            >
-              {error || 'Fix above errors'}
-            </Alert>
+              title={error || 'Fix above errors'}
+            />
           )}
           <div style={{ paddingBottom: '30px' }}>
             <ActionGroup className="pf-c-form">

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/field-group.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/field-group.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { ExpandableSection } from '@console/internal/components/utils/expandable-section';
+
+export const FieldGroup: React.FC<FieldGroupProps> = ({ groupName, defaultExpand, children }) => {
+  const [expand, setExpand] = React.useState<boolean>(defaultExpand);
+
+  const onExpandableSectionToggle = (event) => {
+    event.preventDefault();
+    setExpand(!expand);
+  };
+
+  return (
+    <div className="co-field-group">
+      <ExpandableSection
+        id={groupName}
+        key={groupName}
+        isExpanded={expand}
+        listTitle={groupName}
+        onToggle={onExpandableSectionToggle}
+      >
+        {children}
+      </ExpandableSection>
+    </div>
+  );
+};
+FieldGroup.displayName = 'FieldGroup';
+
+export type FieldGroupProps = {
+  defaultExpand: boolean;
+  groupName: string;
+};

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -135,6 +135,38 @@
   height: 25px;
 }
 
+.co-create-operand__accordion {
+  --pf-c-accordion--BoxShadow: none !important;
+  --pf-c-accordion--PaddingBottom: 0rem !important;
+  --pf-c-accordion--PaddingTop: 0rem !important;
+}
+
+.co-field-group {
+  --pf-c-accordion__toggle--PaddingLeft: 0rem !important;
+  --pf-c-accordion__toggle--PaddingRight: 0.9375rem !important;
+  --pf-c-accordion__expanded-content-body--PaddingLeft: 0.9375rem !important;
+  --pf-c-accordion__expanded-content--Color: var(--pf-global--Color--100) !important;
+  --pf-c-accordion__toggle-text--active--Color: var(--pf-global--Color--100) !important;
+  --pf-c-accordion__toggle-text--active--FontWeight: 600 !important;
+  --pf-c-accordion__toggle-text--expanded--Color: var(--pf-global--Color--100) !important;
+  --pf-c-accordion__toggle-text--expanded--FontWeight	: 600 !important;
+  --pf-c-accordion__toggle-text--focus--Color: var(--pf-global--Color--100) !important;
+  --pf-c-accordion__toggle-text--focus--FontWeight: 600 !important;
+  --pf-c-accordion__toggle-text--hover--Color: var(--pf-global--Color--100) !important;
+  --pf-c-accordion__toggle-text--hover--FontWeight: 600 !important;
+  
+  .pf-c-accordion__toggle {
+    border-left: none !important;
+  }
+
+  h3 {
+    margin: 0rem;
+    font-size: var(--pf-global--FontSize);
+  }
+
+  margin-bottom: 0.5rem;
+}
+
 .co-create-operand__form-group {
   display: flex;
   flex-direction: column;

--- a/frontend/public/components/utils/expandable-section.tsx
+++ b/frontend/public/components/utils/expandable-section.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { AccordionItem, AccordionContent, AccordionToggle } from '@patternfly/react-core';
+
+interface ExpandCollapseProps {
+  listTitle: string;
+  toggleClassName?: string;
+  id?: string;
+  isExpanded?: boolean;
+  onToggle?: Function;
+}
+
+export const ExpandableSection: React.FC<ExpandCollapseProps> = ({
+  listTitle,
+  children,
+  toggleClassName,
+  id,
+  isExpanded,
+  onToggle,
+}) => {
+  return (
+    <AccordionItem>
+      <AccordionToggle
+        onClick={(event) => {
+          onToggle(event, id);
+        }}
+        isExpanded={isExpanded}
+        id={id}
+        className={toggleClassName}
+      >
+        {listTitle}
+      </AccordionToggle>
+      <AccordionContent isHidden={!isExpanded}>{children}</AccordionContent>
+    </AccordionItem>
+  );
+};

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -32,7 +32,6 @@
   margin-left: 20px;
 }
 
-
 // Restrict form widths
 .co-m-pane__form {
   @media (min-width: 769px) {
@@ -70,3 +69,4 @@
 .pf-c-form__group--no-top-margin {
   margin-top: 0 !important;
 }
+


### PR DESCRIPTION
In this PR, the enhancement for the "Field Group" component for Create Operand Form is included.

The main changes are listed below:

- Using PF4 Accordion component as the "Field Group", put fields into Accordion Content.

- The "Field Group" can be expanded/collapsed.

- The default expanded/collapsed status of the "Field Group" is configurable by modifying the associated x-descriptor of the fields in the field group. For example, if all fields' x-descriptor contains the "urn:alm:descriptor:com.tectonic.ui:advanced" the field group is collapsed by default. 

- The "Advanced Configuration" field group is collapsed by default.

- Replace "Switch" component from PF3 with "Switch" component from PF4, due to some compiling issue.

- Add a label beside the "Checkbox" component.
