### PR TITLE
kubevirt: move VmStatus from web-ui-components

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/index.ts
@@ -1,0 +1,2 @@
+export * from './vm-status';
+export * from './vm-statuses';

--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.scss
@@ -1,0 +1,3 @@
+.kubevirt-vm-status__detail-section {
+  margin-top: 1em;
+}

--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
@@ -1,0 +1,258 @@
+import * as React from 'react';
+import { PodKind, K8sResourceKind } from '@console/internal/module/k8s';
+import {
+  OkIcon,
+  OffIcon,
+  UnknownIcon,
+  InProgressIcon,
+  HourglassHalfIcon,
+  ErrorCircleOIcon,
+} from '@patternfly/react-icons';
+import { PopoverStatus, StatusIconAndText, getNamespace, getName } from '@console/shared';
+import { Progress, ProgressVariant, ProgressSize } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { resourcePath } from '@console/internal/components/utils';
+import { POD_DETAIL_OVERVIEW_HREF } from '@console/internal/components/utils/href';
+import { PodModel } from '@console/internal/models';
+import { VirtualMachineModel } from '../../models';
+import { VM_DETAIL_EVENTS_HREF, CDI_KUBEVIRT_IO, STORAGE_IMPORT_PVC_NAME } from '../../constants';
+import { getLabels } from '../../selectors/selectors';
+import { getVMStatus } from '../../statuses/vm/vm';
+import {
+  VM_STATUS_V2V_CONVERSION_PENDING,
+  VM_STATUS_VMI_WAITING,
+  VM_STATUS_POD_ERROR,
+  VM_STATUS_IMPORT_ERROR,
+  VM_STATUS_V2V_CONVERSION_ERROR,
+  VM_STATUS_IMPORTING,
+  VM_STATUS_V2V_CONVERSION_IN_PROGRESS,
+  VM_STATUS_STARTING,
+  VM_STATUS_MIGRATING,
+  VM_STATUS_RUNNING,
+  VM_STATUS_OFF,
+  VM_STATUS_ERROR,
+} from '../../statuses/vm/constants';
+import { VMKind } from '../../types';
+
+import './vm-status.scss';
+
+const VIEW_POD_OVERVIEW = 'View pod overview';
+const VIEW_VM_EVENTS = 'View events';
+const IMPORTING_VMWARE_MESSAGE =
+  'The virtual machine is being imported from VMware. Disks will be converted to the libvirt format.';
+const IMPORTING_ERROR_VMWARE_MESSAGE = 'The virtual machine could not be imported from VMware.';
+const IMPORTING_MESSAGE =
+  'The virtual machine is being imported. Disks are being copied from the source image.';
+const IMPORTING_ERROR_MESSAGE = 'The virtual machine could not be imported.';
+const VMI_WAITING_MESSAGE = 'The virtual machine is waiting for resources to become available.';
+const STARTING_MESSAGE =
+  'This virtual machine will start shortly. Preparing storage, networking, and compute resources.';
+
+const getAdditionalImportText = (pod: PodKind): string => {
+  const labels = getLabels(pod, {});
+  const labelValue = labels[`${CDI_KUBEVIRT_IO}/${STORAGE_IMPORT_PVC_NAME}`];
+  return labelValue ? ` (${labelValue})` : null;
+};
+
+const VmStatusPopover: React.FC<VmStatusPopoverProps> = ({
+  IconComponent,
+  title,
+  message,
+  children,
+  progress,
+  linkTo,
+  linkMessage,
+}) => (
+  <PopoverStatus title={title} icon={<IconComponent />}>
+    {message}
+    {children && <div className="kubevirt-vm-status__detail-section">{children}</div>}
+    {progress && (
+      <div className="kubevirt-vm-status__detail-section">
+        <Progress
+          value={progress}
+          title={title}
+          variant={ProgressVariant.info}
+          size={ProgressSize.sm}
+        />
+      </div>
+    )}
+    {linkTo && (
+      <div className="kubevirt-vm-status__detail-section">
+        <Link to={linkTo} title={linkMessage}>
+          {linkMessage || linkTo}
+        </Link>
+      </div>
+    )}
+  </PopoverStatus>
+);
+
+const VmStatusInProgress: React.FC<VmStatusSpecificProps> = (props) => (
+  <VmStatusPopover IconComponent={InProgressIcon} {...props} />
+);
+const VmStatusPending: React.FC<VmStatusSpecificProps> = (props) => (
+  <VmStatusPopover IconComponent={HourglassHalfIcon} {...props} />
+);
+const VmStatusError: React.FC<VmStatusSpecificProps> = (props) => (
+  <VmStatusPopover IconComponent={ErrorCircleOIcon} {...props} />
+);
+
+export const VmStatus: React.FC<VmStatusProps> = ({ vm, pods, migrations, verbose = false }) => {
+  const statusDetail = getVMStatus(vm, pods, migrations);
+  const linkToVMEvents = `${resourcePath(
+    VirtualMachineModel.kind,
+    getName(vm),
+    getNamespace(vm),
+  )}/${VM_DETAIL_EVENTS_HREF}`;
+  const linkToPodOverview = `${resourcePath(
+    PodModel.kind,
+    getName(statusDetail.launcherPod),
+    getNamespace(statusDetail.launcherPod),
+  )}/${POD_DETAIL_OVERVIEW_HREF}`;
+  const additionalText = verbose ? getAdditionalImportText(statusDetail.pod) : null;
+
+  switch (statusDetail.status) {
+    case VM_STATUS_V2V_CONVERSION_PENDING:
+      return (
+        <VmStatusPending
+          title="Import pending (VMware)"
+          message={IMPORTING_VMWARE_MESSAGE}
+          linkMessage={VIEW_VM_EVENTS}
+          linkTo={linkToVMEvents}
+        >
+          {statusDetail.message}
+        </VmStatusPending>
+      );
+    case VM_STATUS_V2V_CONVERSION_ERROR:
+      return (
+        <VmStatusError
+          title="Import error (VMware)"
+          message={IMPORTING_ERROR_VMWARE_MESSAGE}
+          linkMessage={VIEW_VM_EVENTS}
+          linkTo={linkToVMEvents}
+        >
+          {statusDetail.message}
+          {additionalText}
+        </VmStatusError>
+      );
+    case VM_STATUS_V2V_CONVERSION_IN_PROGRESS:
+      return (
+        <VmStatusInProgress
+          title="Importing (VMware)"
+          message={IMPORTING_VMWARE_MESSAGE}
+          linkMessage={VIEW_VM_EVENTS}
+          linkTo={linkToVMEvents}
+          progress={statusDetail.progress}
+        >
+          {additionalText}
+        </VmStatusInProgress>
+      );
+    case VM_STATUS_POD_ERROR:
+      return (
+        <VmStatusError
+          title="Pod error"
+          message={statusDetail.message}
+          linkMessage={VIEW_POD_OVERVIEW}
+          linkTo={linkToPodOverview}
+        />
+      );
+    case VM_STATUS_ERROR:
+      return (
+        <VmStatusError
+          title="VM error"
+          message={statusDetail.message}
+          linkMessage={VIEW_VM_EVENTS}
+          linkTo={linkToVMEvents}
+        >
+          {additionalText}
+        </VmStatusError>
+      );
+    case VM_STATUS_IMPORT_ERROR:
+      return (
+        <VmStatusError
+          title="Import error"
+          message={IMPORTING_ERROR_MESSAGE}
+          linkMessage={VIEW_VM_EVENTS}
+          linkTo={linkToVMEvents}
+        >
+          {statusDetail.message}
+          {additionalText}
+        </VmStatusError>
+      );
+    case VM_STATUS_IMPORTING:
+      return (
+        <VmStatusInProgress
+          title="Importing"
+          message={IMPORTING_MESSAGE}
+          linkMessage={VIEW_VM_EVENTS}
+          linkTo={linkToVMEvents}
+          progress={statusDetail.progress}
+        >
+          {additionalText}
+        </VmStatusInProgress>
+      );
+    case VM_STATUS_VMI_WAITING:
+      return (
+        <VmStatusPending
+          title="Pending"
+          message={VMI_WAITING_MESSAGE}
+          linkMessage={VIEW_VM_EVENTS}
+          linkTo={linkToVMEvents}
+        >
+          {statusDetail.message}
+        </VmStatusPending>
+      );
+
+    case VM_STATUS_STARTING:
+      return (
+        <VmStatusInProgress
+          title="Starting"
+          message={STARTING_MESSAGE}
+          linkMessage={VIEW_VM_EVENTS}
+          linkTo={linkToVMEvents}
+          progress={statusDetail.progress}
+        >
+          {statusDetail.message}
+        </VmStatusInProgress>
+      );
+    case VM_STATUS_MIGRATING:
+      return (
+        <VmStatusInProgress
+          title="Migrating"
+          message={statusDetail.message}
+          linkMessage={VIEW_VM_EVENTS}
+          linkTo={linkToVMEvents}
+          progress={statusDetail.progress}
+        />
+      );
+    case VM_STATUS_RUNNING:
+      return <StatusIconAndText title="Running" icon={<OkIcon />} />;
+    case VM_STATUS_OFF:
+      return <StatusIconAndText title="Off" icon={<OffIcon />} />;
+    default:
+      return (
+        <PopoverStatus title="Unknown" icon={<UnknownIcon />}>
+          {statusDetail.status}
+        </PopoverStatus>
+      );
+  }
+};
+
+type VmStatusSpecificProps = {
+  title: string;
+  children?: React.ReactNode;
+  message: string;
+  progress?: number;
+  linkTo?: string;
+  linkMessage?: string;
+};
+
+type VmStatusPopoverProps = VmStatusSpecificProps & {
+  IconComponent: React.ComponentType<{}>;
+};
+
+type VmStatusProps = {
+  vm: VMKind;
+  pods?: PodKind[];
+  migrations?: K8sResourceKind[];
+  verbose?: boolean;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
@@ -53,10 +53,10 @@ const STARTING_MESSAGE =
 const getAdditionalImportText = (pod: PodKind): string => {
   const labels = getLabels(pod, {});
   const labelValue = labels[`${CDI_KUBEVIRT_IO}/${STORAGE_IMPORT_PVC_NAME}`];
-  return labelValue ? ` (${labelValue})` : null;
+  return labelValue ? `(${labelValue})` : null;
 };
 
-const VmStatusPopoverContent: React.FC<VmStatusPopoverContentProps> = ({
+const VMStatusPopoverContent: React.FC<VMStatusPopoverContentProps> = ({
   message,
   children,
   progress,
@@ -81,7 +81,7 @@ const VmStatusPopoverContent: React.FC<VmStatusPopoverContentProps> = ({
   </>
 );
 
-export const VmStatus: React.FC<VmStatusProps> = ({ vm, pods, migrations, verbose = false }) => {
+export const VMStatus: React.FC<VMStatusProps> = ({ vm, pods, migrations, verbose = false }) => {
   const statusDetail = getVMStatus(vm, pods, migrations);
   const linkToVMEvents = `${resourcePath(
     VirtualMachineModel.kind,
@@ -99,45 +99,44 @@ export const VmStatus: React.FC<VmStatusProps> = ({ vm, pods, migrations, verbos
     case VM_STATUS_V2V_CONVERSION_PENDING:
       return (
         <PendingStatus title="Import pending (VMware)">
-          <VmStatusPopoverContent
+          <VMStatusPopoverContent
             message={IMPORTING_VMWARE_MESSAGE}
             linkMessage={VIEW_VM_EVENTS}
             linkTo={linkToVMEvents}
           >
             {statusDetail.message}
-          </VmStatusPopoverContent>
+          </VMStatusPopoverContent>
         </PendingStatus>
       );
     case VM_STATUS_V2V_CONVERSION_ERROR:
       return (
         <ErrorStatus title="Import error (VMware)">
-          <VmStatusPopoverContent
+          <VMStatusPopoverContent
             message={IMPORTING_ERROR_VMWARE_MESSAGE}
             linkMessage={VIEW_VM_EVENTS}
             linkTo={linkToVMEvents}
           >
-            {statusDetail.message}
-            {additionalText}
-          </VmStatusPopoverContent>
+            {statusDetail.message} {additionalText}
+          </VMStatusPopoverContent>
         </ErrorStatus>
       );
     case VM_STATUS_V2V_CONVERSION_IN_PROGRESS:
       return (
         <ProgressStatus title="Importing (VMware)">
-          <VmStatusPopoverContent
+          <VMStatusPopoverContent
             message={IMPORTING_VMWARE_MESSAGE}
             linkMessage={VIEW_VM_EVENTS}
             linkTo={linkToVMEvents}
             progress={statusDetail.progress}
           >
             {additionalText}
-          </VmStatusPopoverContent>
+          </VMStatusPopoverContent>
         </ProgressStatus>
       );
     case VM_STATUS_POD_ERROR:
       return (
         <ErrorStatus title="Pod error">
-          <VmStatusPopoverContent
+          <VMStatusPopoverContent
             message={statusDetail.message}
             linkMessage={VIEW_POD_OVERVIEW}
             linkTo={linkToPodOverview}
@@ -147,71 +146,71 @@ export const VmStatus: React.FC<VmStatusProps> = ({ vm, pods, migrations, verbos
     case VM_STATUS_ERROR:
       return (
         <ErrorStatus title="VM error">
-          <VmStatusPopoverContent
+          <VMStatusPopoverContent
             message={statusDetail.message}
             linkMessage={VIEW_VM_EVENTS}
             linkTo={linkToVMEvents}
           >
             {additionalText}
-          </VmStatusPopoverContent>
+          </VMStatusPopoverContent>
         </ErrorStatus>
       );
     case VM_STATUS_IMPORT_ERROR:
       return (
         <ErrorStatus title="Import error">
-          <VmStatusPopoverContent
+          <VMStatusPopoverContent
             message={IMPORTING_ERROR_MESSAGE}
             linkMessage={VIEW_VM_EVENTS}
             linkTo={linkToVMEvents}
           >
             {statusDetail.message}
             {additionalText}
-          </VmStatusPopoverContent>
+          </VMStatusPopoverContent>
         </ErrorStatus>
       );
     case VM_STATUS_IMPORTING:
       return (
         <ProgressStatus title="Importing">
-          <VmStatusPopoverContent
+          <VMStatusPopoverContent
             message={IMPORTING_MESSAGE}
             linkMessage={VIEW_VM_EVENTS}
             linkTo={linkToVMEvents}
             progress={statusDetail.progress}
           >
             {additionalText}
-          </VmStatusPopoverContent>
+          </VMStatusPopoverContent>
         </ProgressStatus>
       );
     case VM_STATUS_VMI_WAITING:
       return (
         <PendingStatus title="Pending">
-          <VmStatusPopoverContent
+          <VMStatusPopoverContent
             message={VMI_WAITING_MESSAGE}
             linkMessage={VIEW_VM_EVENTS}
             linkTo={linkToVMEvents}
           >
             {statusDetail.message}
-          </VmStatusPopoverContent>
+          </VMStatusPopoverContent>
         </PendingStatus>
       );
 
     case VM_STATUS_STARTING:
       return (
         <ProgressStatus title="Starting">
-          <VmStatusPopoverContent
+          <VMStatusPopoverContent
             message={STARTING_MESSAGE}
             linkMessage={VIEW_VM_EVENTS}
             linkTo={linkToVMEvents}
             progress={statusDetail.progress}
           >
             {statusDetail.message}
-          </VmStatusPopoverContent>
+          </VMStatusPopoverContent>
         </ProgressStatus>
       );
     case VM_STATUS_MIGRATING:
       return (
         <ProgressStatus title="Migrating">
-          <VmStatusPopoverContent
+          <VMStatusPopoverContent
             message={statusDetail.message}
             linkMessage={VIEW_VM_EVENTS}
             linkTo={linkToVMEvents}
@@ -232,7 +231,7 @@ export const VmStatus: React.FC<VmStatusProps> = ({ vm, pods, migrations, verbos
   }
 };
 
-type VmStatusPopoverContentProps = {
+type VMStatusPopoverContentProps = {
   message: string;
   children?: React.ReactNode;
   progress?: number;
@@ -240,7 +239,7 @@ type VmStatusPopoverContentProps = {
   linkMessage?: string;
 };
 
-type VmStatusProps = {
+type VMStatusProps = {
   vm: VMKind;
   pods?: PodKind[];
   migrations?: K8sResourceKind[];

--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { PodKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { OffIcon, UnknownIcon, InProgressIcon, HourglassHalfIcon } from '@patternfly/react-icons';
 import {
-  OkIcon,
-  OffIcon,
-  UnknownIcon,
-  InProgressIcon,
-  HourglassHalfIcon,
-  ErrorCircleOIcon,
-} from '@patternfly/react-icons';
-import { PopoverStatus, StatusIconAndText, getNamespace, getName } from '@console/shared';
+  PopoverStatus,
+  StatusIconAndText,
+  getNamespace,
+  getName,
+  RedExclamationCircleIcon,
+  GreenCheckCircleIcon,
+} from '@console/shared';
 import { Progress, ProgressVariant, ProgressSize } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { resourcePath } from '@console/internal/components/utils';
@@ -55,7 +55,7 @@ const getAdditionalImportText = (pod: PodKind): string => {
 };
 
 const VmStatusPopover: React.FC<VmStatusPopoverProps> = ({
-  IconComponent,
+  icon,
   title,
   message,
   children,
@@ -63,7 +63,7 @@ const VmStatusPopover: React.FC<VmStatusPopoverProps> = ({
   linkTo,
   linkMessage,
 }) => (
-  <PopoverStatus title={title} icon={<IconComponent />}>
+  <PopoverStatus title={title} icon={icon}>
     {message}
     {children && <div className="kubevirt-vm-status__detail-section">{children}</div>}
     {progress && (
@@ -87,13 +87,13 @@ const VmStatusPopover: React.FC<VmStatusPopoverProps> = ({
 );
 
 const VmStatusInProgress: React.FC<VmStatusSpecificProps> = (props) => (
-  <VmStatusPopover IconComponent={InProgressIcon} {...props} />
+  <VmStatusPopover icon={<InProgressIcon />} {...props} />
 );
 const VmStatusPending: React.FC<VmStatusSpecificProps> = (props) => (
-  <VmStatusPopover IconComponent={HourglassHalfIcon} {...props} />
+  <VmStatusPopover icon={<HourglassHalfIcon />} {...props} />
 );
 const VmStatusError: React.FC<VmStatusSpecificProps> = (props) => (
-  <VmStatusPopover IconComponent={ErrorCircleOIcon} {...props} />
+  <VmStatusPopover icon={<RedExclamationCircleIcon />} {...props} />
 );
 
 export const VmStatus: React.FC<VmStatusProps> = ({ vm, pods, migrations, verbose = false }) => {
@@ -225,7 +225,7 @@ export const VmStatus: React.FC<VmStatusProps> = ({ vm, pods, migrations, verbos
         />
       );
     case VM_STATUS_RUNNING:
-      return <StatusIconAndText title="Running" icon={<OkIcon />} />;
+      return <StatusIconAndText title="Running" icon={<GreenCheckCircleIcon />} />;
     case VM_STATUS_OFF:
       return <StatusIconAndText title="Off" icon={<OffIcon />} />;
     default:
@@ -247,7 +247,7 @@ type VmStatusSpecificProps = {
 };
 
 type VmStatusPopoverProps = VmStatusSpecificProps & {
-  IconComponent: React.ComponentType<{}>;
+  icon: React.ReactElement;
 };
 
 type VmStatusProps = {

--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-statuses.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-statuses.tsx
@@ -5,7 +5,7 @@ import { VM_STATUS_IMPORTING, VM_STATUS_IMPORT_ERROR } from '../../statuses/vm/c
 import { VMKind } from '../../types';
 import { getVMStatus } from '../../statuses/vm/vm';
 import { getVMImporterPods } from '../../selectors/pod/selectors';
-import { VmStatus } from './vm-status';
+import { VMStatus } from './vm-status';
 
 const getId = (value) => `${getNamespace(value)}-${getName(value)}`;
 
@@ -21,14 +21,14 @@ export const VmStatuses: React.FC<VmStatusesProps> = (props) => {
         <>
           {importerPods.map((pod) => (
             <div key={getId(pod)}>
-              <VmStatus {...props} pods={[pod]} verbose />
+              <VMStatus {...props} pods={[pod]} verbose />
             </div>
           ))}
         </>
       );
     default:
+      return <VMStatus {...props} />;
   }
-  return <VmStatus {...props} />;
 };
 
 type VmStatusesProps = {

--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-statuses.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-statuses.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { PodKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { getNamespace, getName } from '@console/shared';
+import { VM_STATUS_IMPORTING, VM_STATUS_IMPORT_ERROR } from '../../statuses/vm/constants';
+import { VMKind } from '../../types';
+import { getVMStatus } from '../../statuses/vm/vm';
+import { getVMImporterPods } from '../../selectors/pod/selectors';
+import { VmStatus } from './vm-status';
+
+const getId = (value) => `${getNamespace(value)}-${getName(value)}`;
+
+export const VmStatuses: React.FC<VmStatusesProps> = (props) => {
+  const { vm, pods, migrations } = props;
+  const statusDetail = getVMStatus(vm, pods, migrations);
+  const importerPods = getVMImporterPods(pods, vm);
+
+  switch (statusDetail.status) {
+    case VM_STATUS_IMPORTING:
+    case VM_STATUS_IMPORT_ERROR:
+      return (
+        <>
+          {importerPods.map((pod) => (
+            <div key={getId(pod)}>
+              <VmStatus {...props} pods={[pod]} verbose />
+            </div>
+          ))}
+        </>
+      );
+    default:
+  }
+  return <VmStatus {...props} />;
+};
+
+type VmStatusesProps = {
+  vm: VMKind;
+  pods?: PodKind[];
+  migrations?: K8sResourceKind[];
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/table-filters.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/table-filters.ts
@@ -1,10 +1,7 @@
 import * as _ from 'lodash';
-import {
-  getSimpleVmStatus,
-  VM_SIMPLE_STATUS_ALL,
-  VM_SIMPLE_STATUS_TO_TEXT,
-} from 'kubevirt-web-ui-components';
+import { getSimpleVmStatus } from 'kubevirt-web-ui-components';
 import { Filter } from '@console/shared';
+import { VM_SIMPLE_STATUS_ALL, VM_SIMPLE_STATUS_TO_TEXT } from '../../statuses/vm/constants';
 
 export const vmStatusFilter: Filter = {
   type: 'vm-status',

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -1,13 +1,5 @@
 import * as React from 'react';
-import {
-  getOperatingSystemName,
-  getOperatingSystem,
-  getWorkloadProfile,
-  getVmTemplate,
-  VmStatuses,
-  BootOrder,
-  getBootableDevicesInOrder,
-} from 'kubevirt-web-ui-components';
+import { getVmTemplate, BootOrder, getBootableDevicesInOrder } from 'kubevirt-web-ui-components';
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
 import { PodKind } from '@console/internal/module/k8s';
 import { getName, getNamespace, getNodeName } from '@console/shared';
@@ -21,6 +13,8 @@ import { getVMStatus } from '../../statuses/vm/vm';
 import { getFlavorText } from '../flavor-text';
 import { EditButton } from '../edit-button';
 import { getVmiIpAddressesString } from '../ip-addresses';
+import { VmStatuses } from '../vm-status';
+import { getOperatingSystemName, getOperatingSystem, getWorkloadProfile } from '../../selectors/vm';
 
 import './_vm-resource.scss';
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -3,25 +3,19 @@ import { connect } from 'react-redux';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import {
-  VmStatus,
-  // getSimpleVmStatus,
-  // VM_SIMPLE_STATUS_ALL,
-  // VM_SIMPLE_STATUS_TO_TEXT,
-  //  DASHES,
-} from 'kubevirt-web-ui-components';
-import { NamespaceModel, PodModel } from '@console/internal/models';
-import { Table, MultiListPage, TableRow, TableData } from '@console/internal/components/factory';
-import { FirehoseResult, Kebab, ResourceLink } from '@console/internal/components/utils';
-import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
-import {
-  dimensifyHeader,
-  dimensifyRow,
   getName,
   getNamespace,
   getUID,
   createLookup,
   K8sEntityMap,
+  dimensifyHeader,
+  dimensifyRow,
 } from '@console/shared';
+import { NamespaceModel, PodModel } from '@console/internal/models';
+import { Table, MultiListPage, TableRow, TableData } from '@console/internal/components/factory';
+import { FirehoseResult, Kebab, ResourceLink } from '@console/internal/components/utils';
+import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
+import { VmStatus } from '../vm-status/vm-status';
 import {
   VirtualMachineInstanceMigrationModel,
   VirtualMachineInstanceModel,

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -15,7 +15,7 @@ import { NamespaceModel, PodModel } from '@console/internal/models';
 import { Table, MultiListPage, TableRow, TableData } from '@console/internal/components/factory';
 import { FirehoseResult, Kebab, ResourceLink } from '@console/internal/components/utils';
 import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
-import { VmStatus } from '../vm-status/vm-status';
+import { VMStatus } from '../vm-status/vm-status';
 import {
   VirtualMachineInstanceMigrationModel,
   VirtualMachineInstanceModel,
@@ -88,7 +88,7 @@ const VMRow: React.FC<VMRowProps> = ({
         <ResourceLink kind={NamespaceModel.kind} name={namespace} title={namespace} />
       </TableData>
       <TableData className={dimensify()}>
-        <VmStatus vm={vm} pods={pods} migrations={migrations} />
+        <VMStatus vm={vm} pods={pods} migrations={migrations} />
       </TableData>
       <TableData className={dimensify(true)}>
         <Kebab

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -32,3 +32,5 @@ export enum DeviceType {
   NIC = 'NIC',
   DISK = 'DISK',
 }
+
+export const VM_DETAIL_EVENTS_HREF = 'events';


### PR DESCRIPTION
The VmStatus component is migrated from the web-ui-components library to openshift/console and addapted to codestyle here and PF4.

Depends on:
- [x] #2922
- [x] #2930 
