### PR TITLE
Show in-context API documentation on details pages

### DIFF
--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash-es';
 
 import { Status, PodRingController, PodRing } from '@console/shared';
 import { DeploymentModel } from '../models';
@@ -7,11 +6,11 @@ import { K8sKind, K8sResourceKind, K8sResourceKindReference } from '../module/k8
 import { configureUpdateStrategyModal, errorModal } from './modals';
 import { Conditions } from './conditions';
 import { ResourceEventStream } from './events';
-import { formatDuration } from './utils/datetime';
 import { VolumesTable } from './volumes-table';
 import { DetailsPage, ListPage, Table } from './factory';
 import {
   AsyncComponent,
+  DetailsItem,
   Kebab,
   KebabAction,
   ContainerTable,
@@ -64,38 +63,43 @@ export const menuActions = [
 ];
 
 export const DeploymentDetailsList: React.FC<DeploymentDetailsListProps> = ({ deployment }) => {
-  const isRecreate = deployment.spec.strategy.type === 'Recreate';
-  const progressDeadlineSeconds = _.get(deployment, 'spec.progressDeadlineSeconds');
   return (
     <dl className="co-m-pane__details">
-      <dt>Update Strategy</dt>
-      <dd>{deployment.spec.strategy.type || 'RollingUpdate'}</dd>
-      {isRecreate || <dt>Max Unavailable</dt>}
-      {isRecreate || (
-        <dd>
-          {deployment.spec.strategy.rollingUpdate.maxUnavailable || 1} of{' '}
-          {pluralize(deployment.spec.replicas, 'pod')}
-        </dd>
+      <DetailsItem label="Update Strategy" obj={deployment} path="spec.strategy.type" />
+      {deployment.spec.strategy.type === 'RollingUpdate' && (
+        <>
+          <DetailsItem
+            label="Max Unavailable"
+            obj={deployment}
+            path="spec.strategy.rollingUpdate.maxUnavailable"
+          >
+            {deployment.spec.strategy.rollingUpdate.maxUnavailable || 1} of{' '}
+            {pluralize(deployment.spec.replicas, 'pod')}
+          </DetailsItem>
+          <DetailsItem
+            label="Max Surge"
+            obj={deployment}
+            path="spec.strategy.rollingUpdate.maxSurge"
+          >
+            {deployment.spec.strategy.rollingUpdate.maxSurge || 1} greater than{' '}
+            {pluralize(deployment.spec.replicas, 'pod')}
+          </DetailsItem>
+        </>
       )}
-      {isRecreate || <dt>Max Surge</dt>}
-      {isRecreate || (
-        <dd>
-          {deployment.spec.strategy.rollingUpdate.maxSurge || 1} greater than{' '}
-          {pluralize(deployment.spec.replicas, 'pod')}
-        </dd>
-      )}
-      {progressDeadlineSeconds && <dt>Progress Deadline</dt>}
-      {progressDeadlineSeconds && (
-        <dd>
-          {/* Convert to ms for formatDuration */ formatDuration(progressDeadlineSeconds * 1000)}
-        </dd>
-      )}
-      <dt>Min Ready Seconds</dt>
-      <dd>
+      <DetailsItem
+        label="Progress Deadline Seconds"
+        obj={deployment}
+        path="spec.progressDeadlineSeconds"
+      >
+        {deployment.spec.progressDeadlineSeconds
+          ? pluralize(deployment.spec.progressDeadlineSeconds, 'second')
+          : 'Not Configured'}
+      </DetailsItem>
+      <DetailsItem label="Min Ready Seconds" obj={deployment} path="spec.minReadySeconds">
         {deployment.spec.minReadySeconds
           ? pluralize(deployment.spec.minReadySeconds, 'second')
           : 'Not Configured'}
-      </dd>
+      </DetailsItem>
     </dl>
   );
 };

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -5,6 +5,7 @@ import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import {
   getDefinitionKey,
   getStoredSwagger,
+  getSwaggerPath,
   K8sKind,
   SwaggerDefinition,
   SwaggerDefinitions,
@@ -71,25 +72,11 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   // - A reference to another top-level definition
   // - Inline property declartions
   // - Inline property declartions for array items
-  const getDrilldownPath = (definition: SwaggerDefinition, name: string): string[] => {
-    const ref = getRef(definition);
+  const getDrilldownPath = (name: string): string[] => {
+    const path = getSwaggerPath(allDefinitions, currentPath, name, true);
     // Only allow drilldown if the reference has additional properties to explore.
-    if (
-      ref &&
-      (_.get(allDefinitions, [ref, 'properties']) || _.get(allDefinitions, [ref, 'items']))
-    ) {
-      return [ref];
-    }
-
-    if (definition.properties) {
-      return [...currentPath, 'properties', name];
-    }
-
-    if (_.get(definition, 'items.properties')) {
-      return [...currentPath, 'properties', name, 'items'];
-    }
-
-    return null;
+    const child = _.get(allDefinitions, path) as SwaggerDefinition;
+    return _.has(child, 'properties') || _.has(child, 'items.properties') ? path : null;
   };
 
   // Get the type to display for a property reference.
@@ -130,7 +117,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
       ) : (
         <ul className="co-resource-sidebar-list">
           {_.map(currentDefinition.properties, (definition: SwaggerDefinition, name: string) => {
-            const path = getDrilldownPath(definition, name);
+            const path = getDrilldownPath(name);
             const definitionType = definition.type || getTypeForRef(getRef(definition));
             return (
               <li key={name} className="co-resource-sidebar-item">

--- a/frontend/public/components/utils/_field-level-help.scss
+++ b/frontend/public/components/utils/_field-level-help.scss
@@ -7,6 +7,6 @@
 
   .co-field-level-help__icon {
     color: var(--pf-global--Color--dark-200);
-    font-size: 16px;
+    font-size: 12px;
   }
 }

--- a/frontend/public/components/utils/details-item.tsx
+++ b/frontend/public/components/utils/details-item.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import * as _ from 'lodash-es';
+import { Breadcrumb, BreadcrumbItem, Button, Popover } from '@patternfly/react-core';
+
+import {
+  getPropertyDescription,
+  K8sKind,
+  K8sResourceKind,
+  K8sResourceKindReference,
+  modelFor,
+  referenceFor,
+} from '../../module/k8s';
+import { LinkifyExternal } from './';
+
+const PropertyPath: React.FC<{ kind: string; path: string | string[] }> = ({ kind, path }) => {
+  const pathArray: string[] = _.toPath(path);
+  return (
+    <Breadcrumb className="pf-c-breadcrumb--no-padding-top">
+      <BreadcrumbItem>{kind}</BreadcrumbItem>
+      {pathArray.map((property, i) => {
+        const isLast = i === pathArray.length - 1;
+        return (
+          <BreadcrumbItem key={i} isActive={isLast}>
+            {property}
+          </BreadcrumbItem>
+        );
+      })}
+    </Breadcrumb>
+  );
+};
+
+export const DetailsItem: React.FC<DetailsItemProps> = ({ label, obj, path, children }) => {
+  const reference: K8sResourceKindReference = referenceFor(obj);
+  const model: K8sKind = modelFor(reference);
+  const description: string = getPropertyDescription(model, path);
+  const value: React.ReactNode = children || _.get(obj, path) || '-';
+  return (
+    <>
+      <dt>
+        {description ? (
+          <Popover
+            headerContent={<div>{label}</div>}
+            bodyContent={<LinkifyExternal>{description}</LinkifyExternal>}
+            footerContent={<PropertyPath kind={model.kind} path={path} />}
+            maxWidth="30rem"
+          >
+            <Button variant="plain" className="co-m-pane__details-popover-button">
+              {label}
+            </Button>
+          </Popover>
+        ) : (
+          label
+        )}
+      </dt>
+      <dd>{value}</dd>
+    </>
+  );
+};
+
+export type DetailsItemProps = {
+  label: string;
+  obj: K8sResourceKind;
+  path: string | string[];
+  children?: React.ReactNode;
+};

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
 import {
+  DetailsItem,
   Kebab,
   LabelList,
   OwnerReferences,
@@ -22,11 +23,14 @@ export const detailsPage = <T extends {}>(Component: React.ComponentType<T>) =>
     return <Component {...props} />;
   };
 
-const getTolerations = (obj: K8sResourceKind): Toleration[] => {
+const getTolerationsPath = (obj: K8sResourceKind): string => {
   // FIXME: Is this correct for all types (jobs, cron jobs)? It would be better for the embedding page to pass in the path.
-  return obj.kind === 'Pod'
-    ? _.get(obj, 'spec.tolerations')
-    : _.get(obj, 'spec.template.spec.tolerations');
+  return obj.kind === 'Pod' ? 'spec.tolerations' : 'spec.template.spec.tolerations';
+};
+
+const getNodeSelectorPath = (obj: K8sResourceKind): string => {
+  // FIXME: Is this correct for all types (jobs, cron jobs)? It would be better for the embedding page to pass in the path.
+  return obj.kind === 'Pod' ? 'spec.nodeSelector' : 'spec.template.spec.nodeSelector';
 };
 
 export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({
@@ -41,7 +45,9 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({
   const { metadata, type } = resource;
   const reference = referenceFor(resource);
   const model = modelFor(reference);
-  const tolerations = showTolerations ? getTolerations(resource) : null;
+  const nodeSelectorPath = getNodeSelectorPath(resource);
+  const tolerationsPath = getTolerationsPath(resource);
+  const tolerations: Toleration[] = _.get(resource, tolerationsPath);
 
   const canUpdate = useAccessReview({
     group: model.apiGroup,
@@ -53,43 +59,37 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({
 
   return (
     <dl data-test-id="resource-summary" className="co-m-pane__details">
-      <dt>Name</dt>
-      <dd>{metadata.name || '-'}</dd>
-      {metadata.namespace ? <dt>Namespace</dt> : null}
-      {metadata.namespace ? (
-        <dd>
+      <DetailsItem label="Name" obj={resource} path="metadata.name" />
+      {metadata.namespace && (
+        <DetailsItem label="Namespace" obj={resource} path="metadata.namespace">
           <ResourceLink
             kind="Namespace"
             name={metadata.namespace}
             title={metadata.uid}
             namespace={null}
           />
-        </dd>
-      ) : null}
+        </DetailsItem>
+      )}
       {type ? <dt>Type</dt> : null}
       {type ? <dd>{type}</dd> : null}
-      <dt>Labels</dt>
-      <dd>
+      <DetailsItem label="Labels" obj={resource} path="metadata.labels">
         <LabelList kind={reference} labels={metadata.labels} />
-      </dd>
-      {showPodSelector && <dt>Pod Selector</dt>}
+      </DetailsItem>
       {showPodSelector && (
-        <dd>
+        <DetailsItem label="Pod Selector" obj={resource} path={podSelector}>
           <Selector
             selector={_.get(resource, podSelector)}
             namespace={_.get(resource, 'metadata.namespace')}
           />
-        </dd>
+        </DetailsItem>
       )}
-      {showNodeSelector && <dt>Node Selector</dt>}
       {showNodeSelector && (
-        <dd>
-          <Selector kind="Node" selector={_.get(resource, 'spec.template.spec.nodeSelector')} />
-        </dd>
+        <DetailsItem label="Node Selector" obj={resource} path={nodeSelectorPath}>
+          <Selector kind="Node" selector={_.get(resource, nodeSelectorPath)} />
+        </DetailsItem>
       )}
-      {showTolerations && <dt>Tolerations</dt>}
       {showTolerations && (
-        <dd>
+        <DetailsItem label="Tolerations" obj={resource} path={tolerationsPath}>
           {canUpdate ? (
             <Button
               type="button"
@@ -103,11 +103,10 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({
           ) : (
             pluralize(_.size(tolerations), 'Toleration')
           )}
-        </dd>
+        </DetailsItem>
       )}
-      {showAnnotations && <dt>Annotations</dt>}
       {showAnnotations && (
-        <dd>
+        <DetailsItem label="Annotations" obj={resource} path="metadata.annotations">
           {canUpdate ? (
             <Button
               data-test-id="edit-annotations"
@@ -122,17 +121,15 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({
           ) : (
             pluralize(_.size(metadata.annotations), 'Annotation')
           )}
-        </dd>
+        </DetailsItem>
       )}
       {children}
-      <dt>Created At</dt>
-      <dd>
+      <DetailsItem label="Created At" obj={resource} path="metadata.creationTimestamp">
         <Timestamp timestamp={metadata.creationTimestamp} />
-      </dd>
-      <dt>Owner</dt>
-      <dd>
+      </DetailsItem>
+      <DetailsItem label="Owner" obj={resource} path="metadata.ownerReferences">
         <OwnerReferences resource={resource} />
-      </dd>
+      </DetailsItem>
     </dl>
   );
 };

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -57,4 +57,5 @@ export * from './dom-utils';
 export * from './hint-block';
 export * from './owner-references';
 export * from './field-level-help';
+export * from './details-item';
 export * from './types';

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -162,6 +162,22 @@ $co-external-link-padding-right: 15px;
   }
 }
 
+.co-m-pane__details-popover-button {
+  // Use `background-image: linear-gradient` to draw a dotted underline. This gives us more control over the styling.
+  background-image: linear-gradient(to right, var(--pf-c-button--m-plain--Color) 33%, rgba(255,255,255,0) 0%);
+  background-position: bottom;
+  background-size: 3px 1px;
+  background-repeat: repeat-x;
+  color: inherit !important;
+  font-weight: inherit !important;
+  margin-bottom: 3px;
+  padding: 0 !important;
+  &:focus,
+  &:hover {
+    background-image: linear-gradient(to right, var(--pf-c-button--m-tertiary--Color) 33%, rgba(255,255,255,0) 0%);
+  }
+}
+
 .co-m-pane__dropdown {
   margin-bottom: 20px;
 }


### PR DESCRIPTION
For hackday, I was looking at using the OpenAPI doc to show descriptions in more places in the UI. I wanted to get input on this change. This adds a `DetailsItem` component that makes it easy to add field level help descriptions for properties on our details pages. The nice thing about this approach is it gives accurate and current descriptions for almost all fields, although sometimes they are a little technical.

@openshift/team-ux-review @alimobrem @rhamilto 

![Screen Shot 2019-10-07 at 11 47 52 AM](https://user-images.githubusercontent.com/1167259/66327727-514cd000-e8f9-11e9-9e07-84a2f756a3ec.png)
