### PR TITLE
Prevent metrics and pod status from overlap

### DIFF
--- a/frontend/public/components/overview/_project-overview.scss
+++ b/frontend/public/components/overview/_project-overview.scss
@@ -3,7 +3,7 @@
   .project-overview__additional-info {
     align-items: center;
     display: grid;
-    grid-column-gap: 3%;
+    grid-column-gap: 1%;
     grid-row-gap: 10px;
     grid-template-columns: auto minmax(min-content, 1fr) 85px;
     width: 100%;
@@ -12,7 +12,7 @@
     }
     @media (min-width: $screen-md-min) {
       grid-template-areas: "alert memory cpu status";
-      grid-template-columns: 27% 18% 18% 28%;
+      grid-template-columns: 23% 21% 25% 28%;
     }
   }
 
@@ -41,6 +41,7 @@
   }
 
   .project-overview__detail--status {
+    text-align: right;
     @media (min-width: $screen-md-min) {
       grid-area: status;
     }
@@ -115,29 +116,23 @@
   .project-overview__metric-unit {
     color: $color-text-muted;
     font-size: ($font-size-base - 1);
-    margin-left: 3px;
+    margin-left: 1px;
   }
 
   @media (min-width: $screen-md-min) {
     // Override Patternfly list view styles so that the additional info has a
     // little more space for alerts, metrics, and pod status.
     .list-view-pf-additional-info {
-      width: 60%;
+      width: 62%;
     }
 
     .list-view-pf-description {
-      flex-basis: 40%;
-      width: 40%;
+      flex-basis: 38%;
+      width: 38%;
     }
 
     .project-overview__detail--cpu,
     .project-overview__detail--memory {
-      text-align: right;
-    }
-
-    .project-overview__detail--status {
-      // Give enough margin for the chevron.
-      margin-right: 40px;
       text-align: right;
     }
   }
@@ -192,6 +187,8 @@
     }
     .project-overview__detail--status {
       grid-column: 2;
+      // Give enough margin for the chevron.
+      margin-right: 40px;
     }
   }
 }


### PR DESCRIPTION
- Space adjustments needed to account for Red Hat font being wider than the Overpass font
https://jira.coreos.com/browse/CONSOLE-1816

<img width="1281" alt="Screen Shot 2019-10-07 at 2 15 57 PM" src="https://user-images.githubusercontent.com/1874151/66340535-59196e00-e913-11e9-8ebe-fd3475522788.png">


**> 992**
<img width="626" alt="Screen Shot 2019-10-07 at 2 14 57 PM" src="https://user-images.githubusercontent.com/1874151/66340533-59196e00-e913-11e9-9b19-1b26016a3d5e.png">

**< 992**
<img width="632" alt="Screen Shot 2019-10-07 at 2 15 09 PM" src="https://user-images.githubusercontent.com/1874151/66340534-59196e00-e913-11e9-880d-4c002b60bc44.png">

