### PR TITLE
Lock kubevirt-web-ui-components version

### DIFF
--- a/frontend/packages/kubevirt-plugin/package.json
+++ b/frontend/packages/kubevirt-plugin/package.json
@@ -10,7 +10,7 @@
     "@console/internal": "0.0.0-fixed",
     "@console/plugin-sdk": "0.0.0-fixed",
     "@console/shared": "0.0.0-fixed",
-    "kubevirt-web-ui-components": "~0.1.45"
+    "kubevirt-web-ui-components": "0.1.45"
   },
   "consolePlugin": {
     "entry": "src/plugin.tsx"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7248,7 +7248,7 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
-kubevirt-web-ui-components@~0.1.45:
+kubevirt-web-ui-components@0.1.45:
   version "0.1.45"
   resolved "https://registry.yarnpkg.com/kubevirt-web-ui-components/-/kubevirt-web-ui-components-0.1.45.tgz#600569cec9662cd178f62e80f4621aee9d211696"
   integrity sha512-BLGbsYDR95WgGrT9RmrejRXCKdV0e7YBSN3RsuGzOMmXceWJ/VdlKFPFZUpCJ8g9BKqRxHMXFxBd3w/qRqQuNQ==


### PR DESCRIPTION
Lock [`kubevirt-web-ui-components`](https://github.com/kubevirt/web-ui-components) dependency to a specific version, based on https://github.com/openshift/console/pull/2913#discussion_r331553095.

This dependency will go away once the related code is moved over to Console monorepo.

Not using `0.1.x` pattern since we want close control over this dependency.