### PR TITLE
Changed how humanize is implemented and used in Area graph

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import { Humanize } from '@console/internal/components/utils/types';
 import { AreaChart, AreaChartStatus } from '@console/internal/components/graphs/area';
 import { DataPoint } from '@console/internal/components/graphs';
+import { ByteDataTypes } from 'packages/console-shared/src/graph-helper/data-utils';
 
 export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
-  ({ title, data, humanizeValue, isLoading = false, query, error, max = null }) => {
+  ({ title, data, humanizeValue, isLoading = false, query, error, max = null, byteDataType }) => {
     let current;
     if (data.length) {
       const latestData = data[data.length - 1];
@@ -35,6 +36,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
         padding={{ top: 13, left: 70, bottom: 0, right: 0 }}
         height={80}
         chartStatus={chartStatus}
+        byteDataType={byteDataType}
       />
     );
 
@@ -68,4 +70,5 @@ type UtilizationItemProps = {
   query: string;
   error: boolean;
   max?: number;
+  byteDataType?: ByteDataTypes;
 };

--- a/frontend/packages/console-shared/src/graph-helper/data-utils.ts
+++ b/frontend/packages/console-shared/src/graph-helper/data-utils.ts
@@ -1,0 +1,56 @@
+import * as _ from 'lodash';
+import { DataPoint } from '@console/internal/components/graphs';
+import { getType } from '@console/internal/components/utils/units';
+
+const log = (x: number, y: number) => {
+  return Math.log(y) / Math.log(x);
+};
+
+const frequentUnit = (dataPoints: DataPoint[], type) => {
+  // Reduces the dataset to the most frequently used unit
+  const [bestLevel] = dataPoints.reduce(
+    (acc, point) => {
+      const [maxUnit, maxCount, counts] = acc;
+      // Appropriate power level for the datapoint
+      const index = Math.floor(log(_.get(type, 'divisor', 1024), point.y));
+      const unit = _.get(type, ['units', index], '');
+      const unitCount = _.get(counts, unit, 0) + 1;
+      return [
+        ...(unitCount > maxCount ? [unit, unitCount] : [maxUnit, maxCount]),
+        {
+          ...counts,
+          [unit]: unitCount,
+        },
+      ];
+    },
+    ['', 0, {}],
+  );
+  return bestLevel;
+};
+
+// Array based procssor
+export const processFrame = (dataPoints: DataPoint[], typeName: string): ProcessFrameResult => {
+  const type = getType(typeName);
+  let unit = null;
+  if (dataPoints) {
+    // Get the appropriate unit and convert the dataset to that level
+    unit = frequentUnit(dataPoints, type);
+    const frameLevel = type.units.indexOf(unit);
+    dataPoints.forEach((point) => {
+      point.y /= type.divisor ** frameLevel;
+    });
+  }
+  return { processedData: dataPoints, unit };
+};
+
+export type ProcessFrameResult = {
+  processedData: DataPoint[];
+  unit: string;
+};
+
+export enum ByteDataTypes {
+  BinaryBytes = 'binaryBytes',
+  BinaryBytesWithoutB = 'binaryBytesWithoutB',
+  DecimalBytes = 'decimalBytes',
+  DecimalBytesWithoutB = 'decimalBytesWithoutB',
+}

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/UtilizationCard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/UtilizationCard.tsx
@@ -22,6 +22,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { MachineModel } from '@console/internal/models';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import { getNamespace, getMachineNodeName, getMachineInternalIP } from '@console/shared';
+import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import { getHostMachineName } from '../../../selectors';
 import { BareMetalHostKind } from '../../../types';
 import { getUtilizationQueries, HostQuery } from './queries';
@@ -162,6 +163,7 @@ const UtilizationCard: React.FC<UtilizationCardProps> = ({
           humanizeValue={humanizeBinaryBytesWithoutB}
           query={queries[HostQuery.MEMORY_UTILIZATION]}
           max={memoryTotalValue}
+          byteDataType={ByteDataTypes.BinaryBytesWithoutB}
         />
         <UtilizationItem
           title="Number of pods"
@@ -178,6 +180,7 @@ const UtilizationCard: React.FC<UtilizationCardProps> = ({
           isLoading={itemIsLoading(networkInUtilization)}
           humanizeValue={humanizeBinaryBytesWithoutB}
           query={queries[HostQuery.NETWORK_IN_UTILIZATION]}
+          byteDataType={ByteDataTypes.BinaryBytesWithoutB}
         />
         <UtilizationItem
           title="Network Out"
@@ -186,6 +189,7 @@ const UtilizationCard: React.FC<UtilizationCardProps> = ({
           isLoading={itemIsLoading(networkOutUtilization)}
           humanizeValue={humanizeBinaryBytesWithoutB}
           query={queries[HostQuery.NETWORK_OUT_UTILIZATION]}
+          byteDataType={ByteDataTypes.BinaryBytesWithoutB}
         />
         <UtilizationItem
           title="Filesystem"
@@ -195,6 +199,7 @@ const UtilizationCard: React.FC<UtilizationCardProps> = ({
           humanizeValue={humanizeBinaryBytesWithoutB}
           query={queries[HostQuery.STORAGE_UTILIZATION]}
           max={storageTotalValue}
+          byteDataType={ByteDataTypes.BinaryBytesWithoutB}
         />
       </UtilizationBody>
     </DashboardCard>

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/utilization-card.tsx
@@ -13,6 +13,7 @@ import { humanizePercentage, humanizeBinaryBytesWithoutB } from '../../../utils'
 import { OverviewQuery, utilizationQueries } from './queries';
 import { connectToFlags, FlagsObject, WithFlagsProps } from '../../../../reducers/features';
 import { getFlagsForExtensions, isDashboardExtensionInUse } from '../../utils';
+import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 
 const getQueries = (flags: FlagsObject) => {
   const pluginQueries = {};
@@ -104,6 +105,7 @@ const UtilizationCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
           isLoading={!memoryUtilization}
           humanizeValue={humanizeBinaryBytesWithoutB}
           query={queries[OverviewQuery.MEMORY_UTILIZATION]}
+          byteDataType={ByteDataTypes.BinaryBytesWithoutB}
         />
         <UtilizationItem
           title="Disk Usage"
@@ -112,6 +114,7 @@ const UtilizationCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
           isLoading={!storageUtilization}
           humanizeValue={humanizeBinaryBytesWithoutB}
           query={queries[OverviewQuery.STORAGE_UTILIZATION]}
+          byteDataType={ByteDataTypes.BinaryBytesWithoutB}
         />
         {pluginItems.map(({ properties }, index) => {
           const utilization = prometheusResults.getIn([properties.query, 'data']);

--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -46,7 +46,7 @@ const TYPES = {
   },
 };
 
-const getType = (name) => {
+export const getType = (name) => {
   const type = TYPES[name];
   if (!_.isPlainObject(type)) {
     return {


### PR DESCRIPTION
This PR changes the usage of humanize in the area graph. We take account of the whole data frame rather than only one data in time so that the unit shown is something suitable to all the values. Also, data is preprocessed to eradicate radix issues. 
Screenshot:
![Screenshot from 2019-10-09 15-30-08](https://user-images.githubusercontent.com/54092533/66471965-e55d9980-eaa9-11e9-8891-73fc267eee9e.png)
![Screenshot from 2019-10-09 15-57-57](https://user-images.githubusercontent.com/54092533/66473833-b47f6380-eaad-11e9-9f4c-629a17b187fe.png)
