### PR TITLE
Project Details Page

### DIFF
--- a/frontend/packages/dev-console/src/components/AddPage.tsx
+++ b/frontend/packages/dev-console/src/components/AddPage.tsx
@@ -3,12 +3,11 @@ import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { match as RMatch } from 'react-router';
 import { history, Firehose, FirehoseResource, HintBlock } from '@console/internal/components/utils';
-import { createProjectModal } from '@console/internal/components/modals';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import ODCEmptyState from './EmptyState';
 import NamespacedPage from './NamespacedPage';
 import ProjectsExistWrapper from './ProjectsExistWrapper';
-import DefaultPage from './DefaultPage';
+import CreateProjectListPage from './projects/CreateProjectListPage';
 
 export interface AddPageProps {
   match: RMatch<{
@@ -28,11 +27,8 @@ interface EmptyStateLoaderProps {
   loadError?: string;
 }
 
-const openProjectModal = () =>
-  createProjectModal({
-    blocking: true,
-    onSubmit: (project) => history.push(`/add/ns/${project.metadata.name}`),
-  });
+const handleProjectCreate = (project: K8sResourceKind) =>
+  history.push(`/add/ns/${project.metadata.name}`);
 
 const EmptyStateLoader: React.FC<EmptyStateLoaderProps> = ({ resources, loaded, loadError }) => {
   const [noWorkloads, setNoWorkloads] = React.useState(false);
@@ -122,17 +118,7 @@ const AddPage: React.FC<AddPageProps> = ({ match }) => {
               namespace ? (
                 <RenderEmptyState namespace={namespace} />
               ) : (
-                <DefaultPage title="Add">
-                  Select a project to start adding to it or{' '}
-                  <button
-                    style={{ verticalAlign: 'baseline' }}
-                    type="button"
-                    className="btn btn-link btn-link--no-btn-default-values"
-                    onClick={openProjectModal}
-                  >
-                    create a project
-                  </button>
-                </DefaultPage>
+                <CreateProjectListPage onCreate={handleProjectCreate} title="Add" />
               )
             }
           </ProjectsExistWrapper>

--- a/frontend/packages/dev-console/src/components/BuildConfigPage.tsx
+++ b/frontend/packages/dev-console/src/components/BuildConfigPage.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import { match as RMatch } from 'react-router';
 import { BuildConfigsPage } from '@console/internal/components/build-config';
 import { withStartGuide } from '../../../../public/components/start-guide';
-import DefaultPage from './DefaultPage';
+import ProjectListPage from './projects/ProjectListPage';
 
 export interface BuildConfigPageProps {
   match: RMatch<{
@@ -22,9 +22,9 @@ const BuildConfigPage: React.FC<BuildConfigPageProps> = ({ noProjectsAvailable, 
       {namespace ? (
         <BuildConfigsPage {...props} mock={noProjectsAvailable} />
       ) : (
-        <DefaultPage title="Build Configs">
+        <ProjectListPage title="Build Configs">
           Select a project to view the list of build configs
-        </DefaultPage>
+        </ProjectListPage>
       )}
     </React.Fragment>
   );

--- a/frontend/packages/dev-console/src/components/NamespacedPage.tsx
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.tsx
@@ -12,17 +12,19 @@ export enum NamespacedPageVariants {
 
 export interface NamespacedPageProps {
   disabled?: boolean;
+  hideApplications?: boolean;
   variant?: NamespacedPageVariants;
 }
 
 const NamespacedPage: React.FC<NamespacedPageProps> = ({
   children,
   disabled,
+  hideApplications = false,
   variant = NamespacedPageVariants.default,
 }) => (
   <div className="odc-namespaced-page">
     <NamespaceBar disabled={disabled}>
-      <ApplicationSelector disabled={disabled} />
+      {!hideApplications && <ApplicationSelector disabled={disabled} />}
     </NamespaceBar>
     <div
       className={cx('odc-namespaced-page__content', {

--- a/frontend/packages/dev-console/src/components/pipelines/PipelinesPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelinesPage.tsx
@@ -4,7 +4,7 @@ import { Firehose } from '@console/internal/components/utils';
 import { DevPreviewBadge } from '@console/shared';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../models';
-import DefaultPage from '../DefaultPage';
+import ProjectListPage from '../projects/ProjectListPage';
 import { filters } from './PipelineAugmentRuns';
 import PipelineAugmentRunsWrapper from './PipelineAugmentRunsWrapper';
 
@@ -36,9 +36,9 @@ const PipelinesPage: React.FC<PipelinesPageProps> = ({ namespace }) => {
       </Firehose>
     </FireMan>
   ) : (
-    <DefaultPage title="Pipelines" badge={<DevPreviewBadge />}>
+    <ProjectListPage title="Pipelines" badge={<DevPreviewBadge />}>
       Select a project to view the list of pipelines
-    </DefaultPage>
+    </ProjectListPage>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/projects/CreateProjectListPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/CreateProjectListPage.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { createProjectModal } from '@console/internal/components/modals';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import ProjectListPage, { ProjectListPageProps } from './ProjectListPage';
+
+export interface CreateProjectListPageProps extends ProjectListPageProps {
+  onCreate: (project: K8sResourceKind) => void;
+  title: string;
+}
+
+const CreateProjectListPage: React.FC<CreateProjectListPageProps> = ({
+  onCreate,
+  title,
+  ...props
+}) => {
+  const openProjectModal = () => createProjectModal({ blocking: true, onSubmit: onCreate });
+
+  return (
+    <ProjectListPage {...props} title={title}>
+      Select a project to start adding to it or{' '}
+      <Button isInline variant="link" onClick={openProjectModal}>
+        create a project
+      </Button>
+    </ProjectListPage>
+  );
+};
+
+export default CreateProjectListPage;

--- a/frontend/packages/dev-console/src/components/projects/ProjectListPage.scss
+++ b/frontend/packages/dev-console/src/components/projects/ProjectListPage.scss
@@ -1,4 +1,4 @@
-.odc-default-page {
+.odc-project-list-page {
   background-color: var(--pf-global--BackgroundColor--light-100);
   min-height: 100%;
   &__section-border {

--- a/frontend/packages/dev-console/src/components/projects/ProjectListPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/ProjectListPage.tsx
@@ -2,27 +2,28 @@ import * as React from 'react';
 import { ListPage } from '@console/internal/components/factory';
 import { ProjectsTable } from '@console/internal/components/namespace';
 import { PageHeading } from '@console/internal/components/utils';
-import './DefaultPage.scss';
+import './ProjectListPage.scss';
 
-export interface DefaultPageProps {
+export interface ProjectListPageProps {
   title: string;
+  listComponent?: React.ComponentType<any>;
   children?: React.ReactNode;
   badge?: React.ReactNode;
 }
-const DefaultPage: React.FC<DefaultPageProps> = (props) => (
-  <div className="odc-default-page">
+const ProjectListPage: React.FC<ProjectListPageProps> = (props) => (
+  <div className="odc-project-list-page">
     <PageHeading title={props.title} badge={props.badge}>
       {props.children}
     </PageHeading>
-    <hr className="odc-default-page__section-border" />
+    <hr className="odc-project-list-page__section-border" />
     <ListPage
       {...props}
       showTitle={false}
       kind="Project"
-      ListComponent={ProjectsTable}
+      ListComponent={props.listComponent || ProjectsTable}
       canCreate={false}
     />
   </div>
 );
 
-export default DefaultPage;
+export default ProjectListPage;

--- a/frontend/packages/dev-console/src/components/projects/details/AllProjectsDetailList.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/AllProjectsDetailList.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Redirect } from 'react-router';
+import { ALL_NAMESPACES_KEY } from '@console/internal/const';
+import { ProjectList } from '@console/internal/components/namespace';
+import { history } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import NamespacedPage, { NamespacedPageVariants } from '../../NamespacedPage';
+import CreateProjectListPage from '../CreateProjectListPage';
+import { redirectURI, useActiveNamespace, UseActiveNamespaceProps } from './utils';
+
+const handleProjectCreate = (project: K8sResourceKind) =>
+  history.push(redirectURI(project.metadata.name));
+
+export const AllProjectsDetailList: React.FC<UseActiveNamespaceProps> = ({ activeNamespace }) => {
+  const allNamespaces = activeNamespace === ALL_NAMESPACES_KEY;
+
+  if (!allNamespaces) {
+    return <Redirect to={redirectURI(activeNamespace)} />;
+  }
+
+  return (
+    <NamespacedPage hideApplications variant={NamespacedPageVariants.light}>
+      <CreateProjectListPage
+        listComponent={ProjectList}
+        onCreate={handleProjectCreate}
+        title="Project Details"
+      />
+    </NamespacedPage>
+  );
+};
+
+export default useActiveNamespace(AllProjectsDetailList);

--- a/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Redirect } from 'react-router';
+import { ALL_NAMESPACES_KEY } from '@console/internal/const';
+import { ProjectsDetailsPage } from '@console/internal/components/namespace';
+import { ProjectModel } from '@console/internal/models';
+import NamespacedPage, { NamespacedPageVariants } from '../../NamespacedPage';
+import { PROJECT_LIST_URI, useActiveNamespace, UseActiveNamespaceProps } from './utils';
+
+export const ProjectDetailsPage: React.FC<UseActiveNamespaceProps> = ({
+  activeNamespace,
+  ...props
+}) => {
+  const allNamespaces = activeNamespace === ALL_NAMESPACES_KEY;
+
+  if (allNamespaces) {
+    return <Redirect to={PROJECT_LIST_URI} />;
+  }
+
+  return (
+    <NamespacedPage hideApplications variant={NamespacedPageVariants.light}>
+      <ProjectsDetailsPage
+        {...props}
+        breadcrumbsFor={() => []}
+        name={activeNamespace}
+        kind={ProjectModel.kind}
+        kindObj={ProjectModel}
+      />
+    </NamespacedPage>
+  );
+};
+
+export default useActiveNamespace(ProjectDetailsPage);

--- a/frontend/packages/dev-console/src/components/projects/details/__tests__/AllProjectsDetailList.spec.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/__tests__/AllProjectsDetailList.spec.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Redirect } from 'react-router';
+import { ALL_NAMESPACES_KEY } from '@console/internal/const';
+import { AllProjectsDetailList } from '../AllProjectsDetailList';
+
+describe('AllProjectsDetailList', () => {
+  it('expect AllProjectsDetailList to render redirect when an active namespace is present', () => {
+    const component = shallow(<AllProjectsDetailList activeNamespace="test-namespace" />);
+
+    expect(component.find(Redirect).exists()).toBe(true);
+  });
+
+  it('expect AllProjectDetailsList to not render a redirect when in the all-projects namespace', () => {
+    const component = shallow(<AllProjectsDetailList activeNamespace={ALL_NAMESPACES_KEY} />);
+
+    expect(component.find(Redirect).exists()).not.toBe(true);
+  });
+});

--- a/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Redirect } from 'react-router';
+import { ALL_NAMESPACES_KEY } from '@console/internal/const';
+import { BreadCrumbs } from '@console/internal/components/utils';
+import { ProjectDetailsPage } from '../ProjectDetailsPage';
+
+describe('ProjectDetailsPage', () => {
+  it('expect ProjectDetailsPage to render a redirect when in the all-projects namespace', () => {
+    const component = shallow(<ProjectDetailsPage activeNamespace={ALL_NAMESPACES_KEY} />);
+
+    expect(component.find(Redirect).exists()).toBe(true);
+  });
+
+  it('expect ProjectDetailsPage to not render a redirect when a namespace is provided', () => {
+    const component = shallow(<ProjectDetailsPage activeNamespace="test-project" />);
+
+    expect(component.find(Redirect).exists()).not.toBe(true);
+  });
+
+  it('expect ProjectDetailsPage not to render breadcrumbs', () => {
+    // Currently rendering the breadcrumbs will buck-up against the redirects and not work as expected
+    const component = shallow(<ProjectDetailsPage activeNamespace="test-project" />);
+
+    expect(component.find(BreadCrumbs).exists()).not.toBe(true);
+  });
+});

--- a/frontend/packages/dev-console/src/components/projects/details/utils.ts
+++ b/frontend/packages/dev-console/src/components/projects/details/utils.ts
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import { getActiveNamespace } from '@console/internal/reducers/ui';
+import { RootState } from '@console/internal/redux';
+
+export const PROJECT_LIST_URI = '/k8s/cluster/projects';
+
+export const redirectURI = (ns) => `${PROJECT_LIST_URI}/${ns}`;
+
+export const useActiveNamespace = (Component) =>
+  connect((state: RootState) => ({ activeNamespace: getActiveNamespace(state) }))(Component);
+
+export type UseActiveNamespaceProps = {
+  activeNamespace: string;
+};

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -10,7 +10,7 @@ import { FLAG_KNATIVE_SERVING_SERVICE } from '@console/knative-plugin';
 import EmptyState from '../EmptyState';
 import NamespacedPage from '../NamespacedPage';
 import ProjectsExistWrapper from '../ProjectsExistWrapper';
-import DefaultPage from '../DefaultPage';
+import ProjectListPage from '../projects/ProjectListPage';
 import { getCheURL } from './topology-utils';
 import ConnectedTopologyDataController, { RenderProps } from './TopologyDataController';
 import Topology from './Topology';
@@ -90,7 +90,9 @@ const TopologyPage: React.FC<Props> = ({ match, activeApplication, knative, cheU
                   cheURL={cheURL}
                 />
               ) : (
-                <DefaultPage title="Topology">Select a project to view the topology</DefaultPage>
+                <ProjectListPage title="Topology">
+                  Select a project to view the topology
+                </ProjectListPage>
               );
             }}
           </ProjectsExistWrapper>

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -103,7 +103,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       section: 'Advanced',
       perspective: 'dev',
       componentProps: {
-        name: 'Projects',
+        name: 'Project Details',
         resource: 'projects',
         required: FLAGS.OPENSHIFT,
         testID: 'advanced-project-header',
@@ -255,6 +255,29 @@ const plugin: Plugin<ConsumedExtensions> = [
       loader: async () =>
         (await import(
           './components/import/DeployImagePage' /* webpackChunkName: "dev-console-deployImage" */
+        )).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      perspective: 'dev',
+      exact: true,
+      path: ['/k8s/cluster/projects'],
+      loader: async () =>
+        (await import(
+          './components/projects/details/AllProjectsDetailList' /* webpackChunkName: "all-projects-detail-list" */
+        )).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      perspective: 'dev',
+      path: ['/k8s/cluster/projects/:ns'],
+      loader: async () =>
+        (await import(
+          './components/projects/details/ProjectDetailsPage' /* webpackChunkName: "project-details" */
         )).default,
     },
   },


### PR DESCRIPTION
Addresses https://jira.coreos.com/browse/ODC-1974

A few introductory notes to this PR to save some back and forth:

- `DefaultPage` got renamed to `ProjectListPage` to fit more with what it does
- `dev-console/src/projects` was created and `ProjectListPage` was moved in there
- `ProjectListPage` needed to accept an override to the list component so the Project list was able to render a route-change for each item instead of the default of "no route change, but change active project"
- There are two pages at work here `AllProjectDetailList` and `ProjectDetailsPage`
    - `AllProjectDetailsList` is specifically for `all-projects` (exactly, the `/k8s/cluster/projects` route)
    - `ProjectDetailsPage` is for the selected project as well as any nested pages within (`/k8s/cluster/projects/*`)
    - These two differences are tied to route differences noted above... and are needed so we can make use of the ResourceCluster nav item (keeping the admin routes) while still providing the dev-perspective "project focus"
    - **Legacy knowledge:** If we don't make use of the `/k8s/cluster/projects/:ns` route, sub pages will append additional parts on the end causing the namespace to change rather than route to a sub page
- An important goal of this work is to keep the same route as the admin perspective, so the link is sharable between perspectives

![Screen Shot 2019-10-09 at 12 13 26 PM](https://user-images.githubusercontent.com/8126518/66499681-47a8a100-ea8e-11e9-8059-11f848812794.png)
![Screen Shot 2019-10-09 at 12 13 05 PM](https://user-images.githubusercontent.com/8126518/66499679-47a8a100-ea8e-11e9-95a7-ca36afa8f6c7.png)

```
PASS  packages/dev-console/src/components/projects/details/__tests__/AllProjectsDetailList.spec.tsx
  AllProjectsDetailList
    ✓ expect AllProjectsDetailList to render redirect when an active namespace is present (15ms)
    ✓ expect AllProjectDetailsList to not render a redirect when in the all-projects namespace (3ms)
PASS  packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
  ProjectDetailsPage
    ✓ expect ProjectDetailsPage to render a redirect when in the all-projects namespace (12ms)
    ✓ expect ProjectDetailsPage to not render a redirect when a namespace is provided (2ms)
    ✓ expect ProjectDetailsPage not to render breadcrumbs (3ms)
```
