### PR TITLE
feat(delete-group): Delete application group

### DIFF
--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -32,5 +32,6 @@ export type OverviewItem = {
   status?: React.ReactNode;
   ksroutes?: K8sResourceKind[];
   configurations?: K8sResourceKind[];
+  ksservices?: K8sResourceKind[];
   revisions?: K8sResourceKind[];
 };

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -45,15 +45,19 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
     const url = sampleRepo;
     const ref = getSampleRef(tag);
     const dir = getSampleContextDir(tag);
+    const gitType = detectGitType(url);
     const name = values.name || values.image.selected;
     values.name !== name && setFieldValue('name', name);
     !values.application.name && setFieldValue('application.name', `${name}-app`);
     setFieldValue('git.url', url);
     setFieldValue('git.dir', dir);
     setFieldValue('git.ref', ref);
+    setFieldValue('git.type', gitType);
+    setFieldTouched('git.url', true);
     validateForm();
   }, [
     sampleRepo,
+    setFieldTouched,
     setFieldValue,
     tag,
     validateForm,

--- a/frontend/packages/dev-console/src/components/modals/DeleteApplicationModal.tsx
+++ b/frontend/packages/dev-console/src/components/modals/DeleteApplicationModal.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { TextInputTypes } from '@patternfly/react-core';
+import { PromiseComponent } from '@console/internal/components/utils';
+import {
+  createModalLauncher,
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+} from '@console/internal/components/factory/modal';
+import { Formik, FormikProps, FormikValues } from 'formik';
+import { YellowExclamationTriangleIcon } from '@console/shared';
+import { InputField } from '../formik-fields';
+
+type DeleteApplicationModalProps = {
+  initialApplication: string;
+  onSubmit: (values: FormikValues) => Promise<any>;
+  cancel?: () => void;
+  close?: () => void;
+};
+
+type DeleteApplicationModalState = {
+  inProgress: boolean;
+  errorMessage: string;
+};
+
+const DeleteApplicationForm: React.FC<FormikProps<FormikValues> & DeleteApplicationModalProps> = ({
+  handleSubmit,
+  isSubmitting,
+  cancel,
+  values,
+  initialApplication,
+  status,
+}) => {
+  const isValid = _.get(values, 'application.userInput') === initialApplication;
+  return (
+    <form onSubmit={handleSubmit} className="modal-content modal-content--no-inner-scroll">
+      <ModalTitle>Delete Application Group</ModalTitle>
+      <ModalBody>
+        <div className="co-delete-modal">
+          <YellowExclamationTriangleIcon className="co-delete-modal__icon" />
+          <div>
+            <p>
+              This action cannot be undone. All associated Deployments, Routes, Builds, Pipelines,
+              Storage/PVC&#39;s, secrets, configmaps will be deleted.
+            </p>
+            <p>
+              Confirm deletion by typing{' '}
+              <strong className="co-break-word">{initialApplication}</strong> below:
+            </p>
+            <InputField type={TextInputTypes.text} name="application.userInput" />
+          </div>
+        </div>
+      </ModalBody>
+      <ModalSubmitFooter
+        submitText="Delete"
+        submitDisabled={(status && !!status.submitError) || !isValid}
+        cancel={cancel}
+        inProgress={isSubmitting}
+        errorMessage={status && status.submitError}
+      />
+    </form>
+  );
+};
+
+class DeleteApplicationModal extends PromiseComponent<
+  DeleteApplicationModalProps,
+  DeleteApplicationModalState
+> {
+  private handleSubmit = (values, actions) => {
+    const { onSubmit, close } = this.props;
+    onSubmit &&
+      this.handlePromise(onSubmit(values))
+        .then(() => {
+          actions.setSubmitting(false);
+          close();
+        })
+        .catch((errorMessage) => {
+          actions.setSubmitting(false);
+          actions.setStatus({ submitError: errorMessage });
+          close();
+        });
+  };
+
+  render() {
+    const { initialApplication } = this.props;
+
+    const initialValues = {
+      application: {
+        name: initialApplication,
+        userInput: '',
+      },
+    };
+    return (
+      <Formik
+        initialValues={initialValues}
+        onSubmit={this.handleSubmit}
+        render={(formProps) => <DeleteApplicationForm {...formProps} {...this.props} />}
+      />
+    );
+  }
+}
+
+export const deleteApplicationModal = createModalLauncher((props: DeleteApplicationModalProps) => (
+  <DeleteApplicationModal {...props} />
+));

--- a/frontend/packages/dev-console/src/components/modals/DeleteApplicationModal.tsx
+++ b/frontend/packages/dev-console/src/components/modals/DeleteApplicationModal.tsx
@@ -10,11 +10,12 @@ import {
 } from '@console/internal/components/factory/modal';
 import { Formik, FormikProps, FormikValues } from 'formik';
 import { YellowExclamationTriangleIcon } from '@console/shared';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { InputField } from '../formik-fields';
 
 type DeleteApplicationModalProps = {
   initialApplication: string;
-  onSubmit: (values: FormikValues) => Promise<any>;
+  onSubmit: (values: FormikValues) => Promise<K8sResourceKind[]>;
   cancel?: () => void;
   close?: () => void;
 };
@@ -35,14 +36,14 @@ const DeleteApplicationForm: React.FC<FormikProps<FormikValues> & DeleteApplicat
   const isValid = _.get(values, 'application.userInput') === initialApplication;
   return (
     <form onSubmit={handleSubmit} className="modal-content modal-content--no-inner-scroll">
-      <ModalTitle>Delete Application Group</ModalTitle>
+      <ModalTitle>Delete Application</ModalTitle>
       <ModalBody>
         <div className="co-delete-modal">
           <YellowExclamationTriangleIcon className="co-delete-modal__icon" />
           <div>
             <p>
               This action cannot be undone. All associated Deployments, Routes, Builds, Pipelines,
-              Storage/PVC&#39;s, secrets, configmaps will be deleted.
+              Storage/PVC&#39;s, secrets, and configmaps will be deleted.
             </p>
             <p>
               Confirm deletion by typing{' '}
@@ -57,6 +58,7 @@ const DeleteApplicationForm: React.FC<FormikProps<FormikValues> & DeleteApplicat
         submitDisabled={(status && !!status.submitError) || !isValid}
         cancel={cancel}
         inProgress={isSubmitting}
+        submitDanger
         errorMessage={status && status.submitError}
       />
     </form>
@@ -84,7 +86,6 @@ class DeleteApplicationModal extends PromiseComponent<
 
   render() {
     const { initialApplication } = this.props;
-
     const initialValues = {
       application: {
         name: initialApplication,

--- a/frontend/packages/dev-console/src/components/modals/index.ts
+++ b/frontend/packages/dev-console/src/components/modals/index.ts
@@ -2,3 +2,8 @@ export const editApplicationModal = (props) =>
   import('./EditApplicationModal' /* webpackChunkName: "tags" */).then((m) =>
     m.editApplicationModal(props),
   );
+
+export const deleteApplicationModal = (props) =>
+  import('./DeleteApplicationModal' /* webpackChunkName: "delete-application-modal" */).then((m) =>
+    m.deleteApplicationModal(props),
+  );

--- a/frontend/packages/dev-console/src/components/topology/D3ForceDirectedRenderer.tsx
+++ b/frontend/packages/dev-console/src/components/topology/D3ForceDirectedRenderer.tsx
@@ -581,6 +581,14 @@ export default class D3ForceDirectedRenderer extends React.Component<
             this.state.groupsById[this.state.groups[0]].nodes.length !== this.state.nodes.length,
         ),
     );
+    $group.on('contextmenu', this.onGroupContextMenu);
+  };
+
+  onGroupContextMenu = (d: ViewGroup) => {
+    const { contextMenu } = this.props;
+    if (contextMenu.open(GraphElementType.group, d.name, d3.event.pageX, d3.event.pageY)) {
+      d3.event.preventDefault();
+    }
   };
 
   private onGroupDragStart = (d: ViewGroup) => {

--- a/frontend/packages/dev-console/src/components/topology/TopologyApplicationPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyApplicationPanel.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { ResourceIcon } from '@console/internal/components/utils';
+import { ResourceIcon, ActionsMenu } from '@console/internal/components/utils';
 import { TopologyApplicationObject } from './topology-types';
 import TopologyApplicationResources from './TopologyApplicationResources';
+import { groupActions } from './actions/groupActions';
 
 export type TopologyApplicationPanelProps = {
   application: TopologyApplicationObject;
@@ -14,6 +15,9 @@ const TopologyApplicationPanel: React.FC<TopologyApplicationPanelProps> = ({ app
         <div className="co-m-pane__name co-resource-item">
           <ResourceIcon className="co-m-resource-icon--lg" kind="application" />
           {application.name}
+        </div>
+        <div className="co-actions">
+          <ActionsMenu actions={groupActions(application)} />
         </div>
       </h1>
     </div>

--- a/frontend/packages/dev-console/src/components/topology/actions-providers.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions-providers.ts
@@ -1,6 +1,7 @@
 import { KebabOption } from '@console/internal/components/utils';
 import { GraphElementType, TopologyDataMap } from './topology-types';
 import { workloadActions } from './actions/workloadActions';
+import { groupActions, getGroupComponents } from './actions/groupActions';
 
 export class ActionProviders {
   private readonly topology: TopologyDataMap;
@@ -22,8 +23,9 @@ export class ActionProviders {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
   public getEdgeActions = (edgeId: string): KebabOption[] => null;
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-  public getGroupActions = (groupId: string): KebabOption[] => null;
+  public getGroupActions = (groupId: string): KebabOption[] => {
+    return groupActions(getGroupComponents(groupId, this.topology));
+  };
 
   public getActions = (type: GraphElementType, id: string) => {
     switch (type) {

--- a/frontend/packages/dev-console/src/components/topology/actions/groupActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/groupActions.ts
@@ -1,0 +1,52 @@
+import * as _ from 'lodash';
+import { KebabOption } from '@console/internal/components/utils/kebab';
+import { modelFor } from '@console/internal/module/k8s';
+import { asAccessReview } from '@console/internal/components/utils';
+import { TopologyDataMap, TopologyApplicationObject } from '../topology-types';
+import { getResourceDeploymentObject } from '../topology-utils';
+import { deleteApplicationModal } from '../../modals';
+import { cleanUpWorkload } from '../../../utils/application-utils';
+
+export const getGroupComponents = (
+  groupId: string,
+  topology: TopologyDataMap,
+): TopologyApplicationObject => {
+  return _.values(topology).reduce(
+    (acc, val) => {
+      const dc = getResourceDeploymentObject(val);
+      if (_.get(dc, ['metadata', 'labels', 'app.kubernetes.io/part-of']) === groupId) {
+        acc.resources.push(topology[dc.metadata.uid]);
+      }
+      return acc;
+    },
+    { id: groupId, name: groupId, resources: [] },
+  );
+};
+
+const deleteGroup = (application: TopologyApplicationObject) => {
+  // accessReview needs a resource but group is not a k8s resource,
+  // so currently picking the first resource to do the rbac checks (might change in future)
+  const primaryResource = _.get(application.resources[0], ['resources', 'obj']);
+  return {
+    label: 'Delete Application Group',
+    callback: () => {
+      const reqs = [];
+      deleteApplicationModal({
+        blocking: true,
+        initialApplication: application.name,
+        onSubmit: () => {
+          application.resources.forEach((workload) => {
+            const resource = _.get(workload, ['resources', 'obj']);
+            reqs.push(cleanUpWorkload(resource, workload));
+          });
+          return Promise.all(reqs);
+        },
+      });
+    },
+    accessReview: asAccessReview(modelFor(primaryResource.kind), primaryResource, 'delete'),
+  };
+};
+
+export const groupActions = (application: TopologyApplicationObject): KebabOption[] => {
+  return [deleteGroup(application)];
+};

--- a/frontend/packages/dev-console/src/components/topology/actions/groupActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/groupActions.ts
@@ -28,7 +28,7 @@ const deleteGroup = (application: TopologyApplicationObject) => {
   // so currently picking the first resource to do the rbac checks (might change in future)
   const primaryResource = _.get(application.resources[0], ['resources', 'obj']);
   return {
-    label: 'Delete Application Group',
+    label: 'Delete Application',
     callback: () => {
       const reqs = [];
       deleteApplicationModal({

--- a/frontend/packages/dev-console/src/utils/__tests__/application-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/application-utils.spec.ts
@@ -1,0 +1,142 @@
+import * as k8s from '@console/internal/module/k8s';
+import {
+  ImageStreamModel,
+  ServiceModel,
+  DeploymentConfigModel,
+  RouteModel,
+  BuildConfigModel,
+  DaemonSetModel,
+  StatefulSetModel,
+} from '@console/internal/models';
+import {
+  RevisionModel,
+  ConfigurationModel,
+  ServiceModel as KnativeServiceModel,
+  RouteModel as KnativeRouteModel,
+} from '@console/knative-plugin';
+import * as utils from '@console/internal/components/utils';
+import { TopologyDataResources } from '../../components/topology/topology-types';
+import {
+  transformTopologyData,
+  getResourceDeploymentObject,
+} from '../../components/topology/topology-utils';
+import { cleanUpWorkload } from '../application-utils';
+import { MockResources } from '../../components/topology/__tests__/topology-test-data';
+import { MockKnativeResources } from '../../components/topology/__tests__/topology-knative-test-data';
+
+import Spy = jasmine.Spy;
+
+const spyAndReturn = (spy: Spy) => (returnValue: any) =>
+  new Promise((resolve) =>
+    spy.and.callFake((...args) => {
+      resolve(args);
+      return returnValue;
+    }),
+  );
+const getTopologyData = (mockData: TopologyDataResources, transformByProp: string[]) => {
+  const result = transformTopologyData(mockData, transformByProp);
+  const topologyTransformedData = result.topology;
+  const keys = Object.keys(topologyTransformedData);
+  const resource = getResourceDeploymentObject(topologyTransformedData[keys[0]]);
+  return { resource, topologyTransformedData, keys };
+};
+describe('ApplicationUtils ', () => {
+  let spy;
+  let checkAccessSpy;
+  beforeEach(() => {
+    spy = spyOn(k8s, 'k8sKill');
+    checkAccessSpy = spyOn(utils, 'checkAccess');
+    spyAndReturn(spy)(Promise.resolve({}));
+    spyAndReturn(checkAccessSpy)(Promise.resolve({ status: { allowed: true } }));
+  });
+
+  it('Should delete all the specific models related to deployment config', (done) => {
+    const { resource, topologyTransformedData, keys } = getTopologyData(MockResources, [
+      'deploymentConfigs',
+    ]);
+
+    cleanUpWorkload(resource, topologyTransformedData[keys[0]])
+      .then(() => {
+        const allArgs = spy.calls.allArgs();
+        const removedModels = allArgs.map((arg) => arg[0]);
+
+        expect(spy.calls.count()).toEqual(7);
+        expect(removedModels).toContain(DeploymentConfigModel);
+        expect(removedModels).toContain(ImageStreamModel);
+        expect(removedModels).toContain(ServiceModel);
+        expect(removedModels).toContain(RouteModel);
+        expect(removedModels).toContain(BuildConfigModel);
+        expect(removedModels.filter((model) => model.kind === 'Secret')).toHaveLength(2);
+        done();
+      })
+      .catch((err) => fail(err));
+  });
+
+  it('Should delete all the specific models related to knative deployments', (done) => {
+    const { resource, topologyTransformedData, keys } = getTopologyData(MockKnativeResources, [
+      'deployments',
+    ]);
+    cleanUpWorkload(resource, topologyTransformedData[keys[0]])
+      .then(() => {
+        const allArgs = spy.calls.allArgs();
+        const removedModels = allArgs.map((arg) => arg[0]);
+        expect(spy.calls.count()).toEqual(7);
+        expect(removedModels).toContain(ConfigurationModel);
+        expect(removedModels).toContain(RevisionModel);
+        expect(removedModels).toContain(KnativeServiceModel);
+        expect(removedModels).toContain(KnativeRouteModel);
+        expect(removedModels).toContain(BuildConfigModel);
+        expect(removedModels).toContain(ImageStreamModel);
+        expect(removedModels.filter((model) => model.kind === 'Secret')).toHaveLength(1);
+        done();
+      })
+      .catch((err) => fail(err));
+  });
+
+  it('Should delete all the specific models related to daemonsets', (done) => {
+    const { resource, topologyTransformedData, keys } = getTopologyData(MockResources, [
+      'daemonSets',
+    ]);
+    cleanUpWorkload(resource, topologyTransformedData[keys[0]])
+      .then(() => {
+        const allArgs = spy.calls.allArgs();
+        const removedModels = allArgs.map((arg) => arg[0]);
+        expect(spy.calls.count()).toEqual(1);
+        expect(removedModels).toContain(DaemonSetModel);
+        expect(removedModels.filter((model) => model.kind === 'Secret')).toHaveLength(0);
+        done();
+      })
+      .catch((err) => fail(err));
+  });
+
+  it('Should delete all the specific models related to statefulsets', (done) => {
+    const { resource, topologyTransformedData, keys } = getTopologyData(MockResources, [
+      'statefulSets',
+    ]);
+    cleanUpWorkload(resource, topologyTransformedData[keys[0]])
+      .then(() => {
+        const allArgs = spy.calls.allArgs();
+        const removedModels = allArgs.map((arg) => arg[0]);
+        expect(spy.calls.count()).toEqual(1);
+        expect(removedModels).toContain(StatefulSetModel);
+        expect(removedModels.filter((model) => model.kind === 'Secret')).toHaveLength(0);
+        done();
+      })
+      .catch((err) => fail(err));
+  });
+  it('Should not delete any of the models, if delete access is not available', (done) => {
+    const { resource, topologyTransformedData, keys } = getTopologyData(MockResources, [
+      'deploymentConfigs',
+    ]);
+    spyAndReturn(checkAccessSpy)(Promise.resolve({ status: { allowed: false } }));
+    cleanUpWorkload(resource, topologyTransformedData[keys[0]])
+      .then(() => {
+        const allArgs = spy.calls.allArgs();
+        const removedModels = allArgs.map((arg) => arg[0]);
+        expect(spy.calls.count()).toEqual(0);
+        expect(removedModels).toHaveLength(0);
+        done();
+      })
+      .catch((err) => fail(err));
+  });
+});

--- a/frontend/packages/dev-console/src/utils/application-utils.ts
+++ b/frontend/packages/dev-console/src/utils/application-utils.ts
@@ -310,8 +310,8 @@ export const cleanUpWorkload = (
   };
   if (isKnativeResource) {
     // delete knative resources
-    const knativeRoute = _.find(workload.resources.ksroutes, { kind: 'Route' });
-    resourceData.metadata.name = _.get(knativeRoute, 'metadata.name', '');
+    const knativeService = _.find(workload.resources.ksservices, { kind: 'Service' });
+    resourceData.metadata.name = _.get(knativeService, 'metadata.name', '');
     batchDeleteRequests(knativeDeleteModels, resourceData);
   } else {
     // delete non knative resources

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -25,11 +25,13 @@ import {
   knativeServingResourcesRevision,
   knativeServingResourcesConfigurations,
   knativeServingResourcesRoutes,
+  knativeServingResourcesServices,
 } from './utils/create-knative-utils';
 import {
   getKnativeServingConfigurations,
   getKnativeServingRoutes,
   getKnativeServingRevisions,
+  getKnativeServingServices,
 } from './utils/get-knative-resources';
 
 type ConsumedExtensions =
@@ -162,6 +164,14 @@ const plugin: Plugin<ConsumedExtensions> = [
       resources: knativeServingResourcesRoutes,
       required: FLAG_KNATIVE_SERVING_ROUTE,
       utils: getKnativeServingRoutes,
+    },
+  },
+  {
+    type: 'Overview/CRD',
+    properties: {
+      resources: knativeServingResourcesServices,
+      required: FLAG_KNATIVE_SERVING_SERVICE,
+      utils: getKnativeServingServices,
     },
   },
   {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-knative-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-knative-utils.spec.ts
@@ -2,7 +2,7 @@ import { FirehoseResource } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import {
   getKnativeServiceDepResource,
-  knativeServingResources,
+  knativeServingResourcesServices,
   knativeServingResourcesRevision,
   knativeServingResourcesConfigurations,
   knativeServingResourcesRoutes,
@@ -12,10 +12,13 @@ import { defaultData } from './knative-serving-data';
 describe('Create knative Utils', () => {
   describe('knative Serving Resources', () => {
     const SAMPLE_NAMESPACE = 'mynamespace';
-    it('expect knativeServingResource to return revision, service, configurations, routes with proper namespace', () => {
-      const knServingResource: FirehoseResource[] = knativeServingResources(SAMPLE_NAMESPACE);
-      expect(knServingResource).toHaveLength(4);
-      expect(knServingResource[0].namespace).toBe(SAMPLE_NAMESPACE);
+    it('expect knativeServingResource to return service with proper namespace', () => {
+      const serviceServingResource: FirehoseResource[] = knativeServingResourcesServices(
+        SAMPLE_NAMESPACE,
+      );
+      expect(serviceServingResource).toHaveLength(1);
+      expect(serviceServingResource[0].namespace).toBe(SAMPLE_NAMESPACE);
+      expect(serviceServingResource[0].prop).toBe('ksservices');
     });
 
     it('expect knativeServingResourcesRevision to return revision with proper namespace', () => {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/get-knative-resources.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/get-knative-resources.spec.ts
@@ -4,6 +4,7 @@ import {
   getKnativeServingRevisions,
   getKnativeServingConfigurations,
   getKnativeServingRoutes,
+  getKnativeServingServices,
 } from '../get-knative-resources';
 import { deploymentData, deploymentKnativeData } from './knative-serving-data';
 
@@ -43,6 +44,18 @@ describe('Get knative resources', () => {
     });
     it('expect getKnativeServingRoutes to return route as undefined', () => {
       const knServingResource = getKnativeServingRoutes(deploymentData, MockResources);
+      expect(knServingResource).toBeUndefined();
+    });
+    it('expect getKnativeServingServices to return service data', () => {
+      const knServingResource = getKnativeServingServices(
+        deploymentKnativeData,
+        MockKnativeResources,
+      );
+      expect(knServingResource.ksservices).toBeDefined();
+      expect(knServingResource.ksservices).toHaveLength(1);
+    });
+    it('expect getKnativeServingServices to return service as undefined', () => {
+      const knServingResource = getKnativeServingServices(deploymentData, MockResources);
       expect(knServingResource).toBeUndefined();
     });
   });

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -143,11 +143,8 @@ export const knativeServingResourcesRoutes = (namespace: string): FirehoseResour
   return knativeResource;
 };
 
-export const knativeServingResources = (namespace: string): FirehoseResource[] => {
+export const knativeServingResourcesServices = (namespace: string): FirehoseResource[] => {
   const knativeResource = [
-    ...knativeServingResourcesRevision(namespace),
-    ...knativeServingResourcesConfigurations(namespace),
-    ...knativeServingResourcesRoutes(namespace),
     {
       isList: true,
       kind: referenceForModel(ServiceModel),

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -6,30 +6,21 @@ type KnativeItem = {
   revisions?: K8sResourceKind[];
   configurations?: K8sResourceKind[];
   ksroutes?: K8sResourceKind[];
+  ksservices?: K8sResourceKind[];
 };
 
 const isKnativeDeployment = (dc: K8sResourceKind) => {
   return !!_.get(dc.metadata, `labels["${KNATIVE_SERVING_LABEL}"]`);
 };
 
-const getKSRoute = (dc: K8sResourceKind, { ksroutes }): K8sResourceKind[] => {
-  let routeResource = [];
+const getKsResource = (dc: K8sResourceKind, res: K8sResourceKind): K8sResourceKind[] => {
+  let ksResource = [];
   if (isKnativeDeployment(dc)) {
-    routeResource = _.filter(ksroutes.data, (routeConfig: K8sResourceKind) => {
-      return dc.metadata.labels[KNATIVE_SERVING_LABEL] === _.get(routeConfig, 'metadata.name');
-    });
-  }
-  return routeResource;
-};
-
-const getConfigurations = (dc: K8sResourceKind, { configurations }): K8sResourceKind[] => {
-  let configurationResource = [];
-  if (isKnativeDeployment(dc)) {
-    configurationResource = _.filter(configurations.data, (config: K8sResourceKind) => {
+    ksResource = _.filter(res.data, (config: K8sResourceKind) => {
       return dc.metadata.labels[KNATIVE_SERVING_LABEL] === _.get(config, 'metadata.name');
     });
   }
-  return configurationResource;
+  return ksResource;
 };
 
 const getRevisions = (dc: K8sResourceKind, { revisions }): K8sResourceKind[] => {
@@ -51,11 +42,17 @@ export const getKnativeServingConfigurations = (
   dc: K8sResourceKind,
   props,
 ): KnativeItem | undefined => {
-  const configurations = getConfigurations(dc, props);
-  return configurations.length > 0 ? { configurations } : undefined;
+  const configurations =
+    props && props.configurations ? getKsResource(dc, props.configurations) : undefined;
+  return configurations && configurations.length > 0 ? { configurations } : undefined;
 };
 
 export const getKnativeServingRoutes = (dc: K8sResourceKind, props): KnativeItem | undefined => {
-  const ksroutes = getKSRoute(dc, props);
-  return ksroutes.length > 0 ? { ksroutes } : undefined;
+  const ksroutes = props && props.ksroutes ? getKsResource(dc, props.ksroutes) : undefined;
+  return ksroutes && ksroutes.length > 0 ? { ksroutes } : undefined;
+};
+
+export const getKnativeServingServices = (dc: K8sResourceKind, props): KnativeItem | undefined => {
+  const ksservices = props && props.ksservices ? getKsResource(dc, props.ksservices) : undefined;
+  return ksservices && ksservices.length > 0 ? { ksservices } : undefined;
 };


### PR DESCRIPTION
This PR contains the custom actions and modals to delete an application from the topology page.

1. Added group actions available in the context menu
![deleteApplication](https://user-images.githubusercontent.com/9964343/66563580-ae57b880-eb7b-11e9-98aa-89491cc5fc3c.gif)
2. Added group actions in the sidebar menu
![sidebar_group_action](https://user-images.githubusercontent.com/9964343/66587360-e248d300-eba7-11e9-8e6d-b2806834e287.gif)

contains tests for all the supported workloads in topology.
```
 PASS  packages/dev-console/src/utils/__tests__/application-utils.spec.ts
  ApplicationUtils 
    ✓ Should delete all the specific models related to deployment config (25ms)
    ✓ Should delete all the specific models related to knative deployments (4ms)
    ✓ Should delete all the specific models related to daemonsets (4ms)
    ✓ Should delete all the specific models related to statefulsets (4ms)
```

Fixes:  https://jira.coreos.com/browse/ODC-1795 ,  https://jira.coreos.com/browse/ODC-846