### PR TITLE
adds topology group data in sidebar as resources

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/ApplicationGroupResource.tsx
+++ b/frontend/packages/dev-console/src/components/topology/ApplicationGroupResource.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Link } from 'react-router-dom';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { SidebarSectionHeading } from '@console/internal/components/utils';
+import { getActiveNamespace } from '@console/internal/actions/ui';
+import TopologyApplicationResourceList from './TopologyApplicationList';
+
+const MAX_RESOURCES = 5;
+
+export type ApplicationGroupResourceProps = {
+  title: string;
+  kind: string;
+  resourcesData: K8sResourceKind[];
+  group: string;
+};
+
+const ApplicationGroupResource: React.FC<ApplicationGroupResourceProps> = ({
+  title,
+  kind,
+  resourcesData,
+  group,
+}) => {
+  return (
+    <React.Fragment>
+      {!_.isEmpty(resourcesData) ? (
+        <div className="overview__sidebar-pane-body">
+          <SidebarSectionHeading text={title}>
+            {_.size(resourcesData) > MAX_RESOURCES && (
+              <Link
+                className="sidebar__section-view-all"
+                to={`/search/ns/${getActiveNamespace()}?kind=${kind}&q=${encodeURIComponent(
+                  `app.kubernetes.io/part-of=${group}`,
+                )}`}
+              >
+                {`View All (${_.size(resourcesData)})`}
+              </Link>
+            )}
+          </SidebarSectionHeading>
+          <TopologyApplicationResourceList resources={_.take(resourcesData, MAX_RESOURCES)} />
+        </div>
+      ) : null}
+    </React.Fragment>
+  );
+};
+
+export default ApplicationGroupResource;

--- a/frontend/packages/dev-console/src/components/topology/TopologyApplicationList.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyApplicationList.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { ListGroup } from 'patternfly-react';
+import { ResourceLink } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export type TopologyApplicationResourceListProps = {
+  resources: K8sResourceKind[];
+};
+
+const TopologyApplicationResourceList: React.FC<TopologyApplicationResourceListProps> = ({
+  resources,
+}) => {
+  return (
+    <ListGroup componentClass="ul">
+      {_.map(resources, ({ metadata: { name, namespace, uid }, kind }) => (
+        <li className="list-group-item  container-fluid" key={uid}>
+          <ResourceLink kind={kind} name={name} namespace={namespace} />
+        </li>
+      ))}
+    </ListGroup>
+  );
+};
+
+export default TopologyApplicationResourceList;

--- a/frontend/packages/dev-console/src/components/topology/TopologyApplicationPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyApplicationPanel.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ResourceIcon } from '@console/internal/components/utils';
 import { TopologyApplicationObject } from './topology-types';
+import TopologyApplicationResources from './TopologyApplicationResources';
 
 export type TopologyApplicationPanelProps = {
   application: TopologyApplicationObject;
@@ -16,6 +17,7 @@ const TopologyApplicationPanel: React.FC<TopologyApplicationPanelProps> = ({ app
         </div>
       </h1>
     </div>
+    <TopologyApplicationResources resources={application.resources} group={application.name} />
     <div className="overview__sidebar-pane-body resource-overview__body" />
   </div>
 );

--- a/frontend/packages/dev-console/src/components/topology/TopologyApplicationResources.scss
+++ b/frontend/packages/dev-console/src/components/topology/TopologyApplicationResources.scss
@@ -1,0 +1,5 @@
+.odc-application-resource-tab {
+    & > ul > li > button {
+      pointer-events: none;
+    }
+  }

--- a/frontend/packages/dev-console/src/components/topology/TopologyApplicationResources.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyApplicationResources.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import * as _ from 'lodash';
+import { modelFor } from '@console/internal/module/k8s';
+import ApplicationGroupResource from './ApplicationGroupResource';
+import { TopologyDataObject } from './topology-types';
+import { getResourceDeploymentObject } from './topology-utils';
+
+import './TopologyApplicationResources.scss';
+
+export type TopologyApplicationResourcesProps = {
+  resources: TopologyDataObject[];
+  group: string;
+};
+
+const TopologyApplicationResources: React.FC<TopologyApplicationResourcesProps> = ({
+  resources,
+  group,
+}) => {
+  const resourcesData = {};
+  _.forEach(resources, (res) => {
+    const a = getResourceDeploymentObject(res);
+    resourcesData[a.kind] = [...(resourcesData[a.kind] ? resourcesData[a.kind] : []), a];
+  });
+
+  return (
+    <React.Fragment>
+      <div
+        className={classNames(
+          'co-m-horizontal-nav__menu',
+          'co-m-horizontal-nav__menu--within-sidebar',
+          'co-m-horizontal-nav__menu--within-overview-sidebar',
+          'odc-application-resource-tab',
+        )}
+      >
+        <ul className="co-m-horizontal-nav__menu-primary">
+          <li className="co-m-horizontal-nav__menu-item">
+            <button type="button">Resources</button>
+          </li>
+        </ul>
+      </div>
+      {_.map(_.keys(resourcesData), (key) => (
+        <ApplicationGroupResource
+          key={`${group}-${key}`}
+          title={modelFor(key).label}
+          kind={key}
+          resourcesData={resourcesData[key]}
+          group={group}
+        />
+      ))}
+    </React.Fragment>
+  );
+};
+
+export default TopologyApplicationResources;


### PR DESCRIPTION
- adds topology group data (Deployment Config, Deployment, DaemonSet, Stateful Set) in the sidebar as resources

Tracks: https://jira.coreos.com/browse/ODC-1807

![Screenshot 2019-10-10 at 7 50 06 PM](https://user-images.githubusercontent.com/5129024/66577658-68105280-eb97-11e9-8b72-ee5554329d0d.png)
