### PR TITLE
Use ConsoleCliDownloads instead of hardcoded cli tools

### DIFF
--- a/frontend/public/components/command-line-tools.tsx
+++ b/frontend/public/components/command-line-tools.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import * as _ from 'lodash-es';
 
-import { OC_DOWNLOAD_LINK, ODO_DOWNLOAD_LINK, FLAGS } from '../const';
+import { FLAGS } from '../const';
 import { ExternalLink, Firehose, FirehoseResult } from './utils';
 import { connectToFlags } from '../reducers/features';
 import { ConsoleCLIDownloadModel } from '../models';
@@ -46,7 +46,7 @@ const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
   );
 
   return (
-    <React.Fragment>
+    <>
       <Helmet>
         <title>{title}</title>
       </Helmet>
@@ -54,47 +54,18 @@ const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
         <h1 className="co-m-pane__heading">
           <div className="co-m-pane__name">{title}</div>
         </h1>
-        <h2 className="co-section-heading">oc - OpenShift Command Line Interface (CLI)</h2>
-        <p>
-          With the OpenShift command line interface, you can create applications and manage
-          OpenShift projects from a terminal.
-        </p>
-        <p>
-          The oc binary offers the same capabilities as the kubectl binary, but it is further
-          extended to natively support OpenShift Container Platform features.
-        </p>
-        <p>
-          <ExternalLink href={OC_DOWNLOAD_LINK} text="Download oc" />
-          {(window as any).SERVER_FLAGS.requestTokenURL && (
-            <React.Fragment>
-              &nbsp;
-              <span className="co-action-divider" aria-hidden="true">
-                |
-              </span>
-              &nbsp;
-              <ExternalLink
-                href={(window as any).SERVER_FLAGS.requestTokenURL}
-                text="Copy Login Command"
-              />
-            </React.Fragment>
-          )}
-        </p>
-        <hr />
-        <h2 className="co-section-heading">odo - Developer-focused CLI for OpenShift</h2>
-        <p>
-          OpenShift Do (odo) is a fast, iterative, and straightforward CLI tool for developers who
-          write, build, and deploy applications on OpenShift.
-        </p>
-        <p>
-          odo abstracts away complex Kubernetes and OpenShift concepts, thus allowing developers to
-          focus on what is most important to them: code.
-        </p>
-        <p>
-          <ExternalLink href={ODO_DOWNLOAD_LINK} text="Download odo" />
-        </p>
+        {(window as any).SERVER_FLAGS.requestTokenURL && (
+          <>
+            <hr />
+            <ExternalLink
+              href={(window as any).SERVER_FLAGS.requestTokenURL}
+              text="Copy Login Command"
+            />
+          </>
+        )}
         {additionalCommandLineTools}
       </div>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -284,7 +284,9 @@ class MastheadToolbar_ extends React.Component {
   };
 
   _helpActions(additionalHelpActions) {
+    const { flags } = this.props;
     const helpActions = [];
+
     helpActions.push({
       name: '',
       isSection: true,
@@ -294,10 +296,14 @@ class MastheadToolbar_ extends React.Component {
           externalLink: true,
           href: openshiftHelpBase,
         },
-        {
-          label: 'Command Line Tools',
-          callback: this._onCommandLineTools,
-        },
+        ...(flags[FLAGS.CONSOLE_CLI_DOWNLOAD]
+          ? [
+              {
+                label: 'Command Line Tools',
+                callback: this._onCommandLineTools,
+              },
+            ]
+          : []),
         {
           label: 'About',
           callback: this._onAboutModal,
@@ -592,5 +598,10 @@ const mastheadToolbarStateToProps = ({ UI }) => ({
 });
 
 export const MastheadToolbar = connect(mastheadToolbarStateToProps)(
-  connectToFlags(FLAGS.AUTH_ENABLED, FLAGS.OPENSHIFT, FLAGS.CLUSTER_VERSION)(MastheadToolbar_),
+  connectToFlags(
+    FLAGS.AUTH_ENABLED,
+    FLAGS.CLUSTER_VERSION,
+    FLAGS.CONSOLE_CLI_DOWNLOAD,
+    FLAGS.OPENSHIFT,
+  )(MastheadToolbar_),
 );

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -41,7 +41,6 @@ import {
 import { RoleBindingsPage } from './RBAC';
 import { Bar, Area, requirePrometheus } from './graphs';
 import {
-  OC_DOWNLOAD_LINK,
   ALL_NAMESPACES_KEY,
   KEYBOARD_SHORTCUTS,
   NAMESPACE_LOCAL_STORAGE_KEY,
@@ -285,7 +284,7 @@ const ProjectList_ = (props) => {
         <ExternalLink href={openshiftHelpBase} text="documentation" />.
       </p>
       <p>
-        Download the <ExternalLink href={OC_DOWNLOAD_LINK} text="command-line tools" />.
+        Download the <Link to="/command-line-tools">command-line tools</Link>
       </p>
     </React.Fragment>
   );

--- a/frontend/public/const.ts
+++ b/frontend/public/const.ts
@@ -43,9 +43,6 @@ export const RH_OPERATOR_SUPPORT_POLICY_LINK =
 // Package manifests for the OperatorHub use this label.
 export const OPERATOR_HUB_LABEL = 'openshift-marketplace';
 
-export const OC_DOWNLOAD_LINK = 'https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.2';
-export const ODO_DOWNLOAD_LINK = 'https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest';
-
 export enum FLAGS {
   AUTH_ENABLED = 'AUTH_ENABLED',
   PROMETHEUS = 'PROMETHEUS',


### PR DESCRIPTION
Replacing hardcoded cli tools for ConsoleCliDownloads that are handled by console-operator, addressed by  https://github.com/openshift/console-operator/pull/306

This leaves an open question how to display empty state of the `Command Line Tools` page.

@spadgett @openshift/team-ux-review any suggestions ?