### PR TITLE
remove redundant resize call

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -369,7 +369,6 @@ export const EditYAML = connect(stateToProps)(
             const success = `${newName} has been updated to version ${o.metadata.resourceVersion}`;
             this.setState({ success, error: null });
             this.loadYaml(true, o);
-            this.resize();
           })
           .catch((e) => this.handleError(e.message));
       });


### PR DESCRIPTION
Noticed that `resize` appears to be the last call in `loadYaml` so shouldn't be necessary at the end of `save`.  Feel free to close if this is unnecessary, maybe it's there just in case :smile: .

```
    loadYaml(reload = false, obj = this.props.obj) {
      if (this.state.initialized && !reload) {
        return;
      }
      let yaml = '';
      if (obj) {
        if (_.isString(obj)) {
          yaml = obj;
        } else {
          try {
            yaml = safeDump(obj);
            this.checkEditAccess(obj);
          } catch (e) {
            yaml = `Error getting YAML: ${e}`;
          }
        }
      }
      this.displayedVersion = _.get(obj, 'metadata.resourceVersion');
      this.setState({ yaml, initialized: true, stale: false });
      this.resize();
    }
```