### PR TITLE
Introduce baremetal enhanced Nodes listing

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDetails.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDetails.tsx
@@ -21,7 +21,7 @@ import {
   getMachineRole,
   StatusIconAndText,
 } from '@console/shared';
-import { getHostStatus } from '../../utils/host-status';
+import { getHostStatus } from '../../status/host-status';
 import {
   getHostNICs,
   getHostDescription,
@@ -125,7 +125,7 @@ const BareMetalHostDetails: React.FC<BareMetalHostDetailsProps> = ({
           <dl>
             <dt>Status</dt>
             <dd>
-              <BareMetalHostStatus status={status} />
+              <BareMetalHostStatus {...status} />
             </dd>
             <dt>Power Status</dt>
             <dd>

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDetails.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDetails.tsx
@@ -21,7 +21,7 @@ import {
   getMachineRole,
   StatusIconAndText,
 } from '@console/shared';
-import { canHostAddMachine, getHostStatus } from '../../utils/host-status';
+import { getHostStatus } from '../../utils/host-status';
 import {
   getHostNICs,
   getHostDescription,
@@ -94,11 +94,11 @@ const BareMetalHostDetails: React.FC<BareMetalHostDetailsProps> = ({
               <br />
               NICs: {ips}
             </dd>
-            {(canHostAddMachine(status.status) || machineName) && (
+            {machineName && (
               <>
                 <dt>Machine</dt>
                 <dd>
-                  <MachineLink host={host} status={status} />
+                  <MachineLink host={host} />
                 </dd>
               </>
             )}

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
@@ -15,8 +15,9 @@ import {
   HOST_PROGRESS_STATES,
   HOST_ERROR_STATES,
   HOST_SUCCESS_STATES,
-  HOST_STATUS_UNDER_MAINTENANCE,
-  HOST_STATUS_STARTING_MAINTENANCE,
+  NODE_STATUS_UNDER_MAINTENANCE,
+  NODE_STATUS_STARTING_MAINTENANCE,
+  NODE_STATUS_STOPPING_MAINTENANCE,
 } from '../../constants';
 import { BareMetalHostModel } from '../../models';
 import { getHostErrorMessage } from '../../selectors';
@@ -45,11 +46,9 @@ const BareMetalHostStatus: React.FC<StatusProps> = ({ status, title, ...props })
   switch (true) {
     case status === HOST_STATUS_DISCOVERED:
       return <AddDiscoveredHostButton host={props.host} />;
-    case [HOST_STATUS_STARTING_MAINTENANCE, HOST_STATUS_UNDER_MAINTENANCE].includes(status):
-      return (
-        <MaintenancePopover title={statusTitle} maintenance={props.maintenance} host={props.host} />
-      );
-    case HOST_PROGRESS_STATES.includes(status):
+    case [NODE_STATUS_STARTING_MAINTENANCE, NODE_STATUS_UNDER_MAINTENANCE].includes(status):
+      return <MaintenancePopover title={statusTitle} maintenance={props.maintenance} />;
+    case [NODE_STATUS_STOPPING_MAINTENANCE, ...HOST_PROGRESS_STATES].includes(status):
       return <ProgressStatus title={statusTitle} />;
     case HOST_ERROR_STATES.includes(status):
       return <ErrorStatus title={statusTitle}>{getHostErrorMessage(props.host)}</ErrorStatus>;

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../constants';
 import { BareMetalHostModel } from '../../models';
 import { getHostErrorMessage } from '../../selectors';
-import { BareMetalHostStatus } from '../types';
+import { StatusProps } from '../types';
 import MaintenancePopover from '../maintenance/MaintenancePopover';
 import { BareMetalHostKind } from '../../types';
 
@@ -40,11 +40,7 @@ export const AddDiscoveredHostButton: React.FC<{ host: BareMetalHostKind }> = (
   );
 };
 
-type BareMetalHostStatusProps = {
-  status: BareMetalHostStatus;
-};
-
-const BareMetalHostStatus = ({ status: { status, title, ...props } }: BareMetalHostStatusProps) => {
+const BareMetalHostStatus: React.FC<StatusProps> = ({ status, title, ...props }) => {
   const statusTitle = title || status;
   switch (true) {
     case status === HOST_STATUS_DISCOVERED:

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../constants';
 import { BareMetalHostModel } from '../../models';
 import { getHostErrorMessage } from '../../selectors';
-import { HostMultiStatus } from '../types';
+import { BareMetalHostStatus } from '../types';
 import MaintenancePopover from '../maintenance/MaintenancePopover';
 import { BareMetalHostKind } from '../../types';
 
@@ -41,7 +41,7 @@ export const AddDiscoveredHostButton: React.FC<{ host: BareMetalHostKind }> = (
 };
 
 type BareMetalHostStatusProps = {
-  status: HostMultiStatus;
+  status: BareMetalHostStatus;
 };
 
 const BareMetalHostStatus = ({ status: { status, title, ...props } }: BareMetalHostStatusProps) => {

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsPage.tsx
@@ -8,7 +8,7 @@ import { FirehoseResource } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { BareMetalHostModel, NodeMaintenanceModel } from '../../models';
 import { getHostMachine, getNodeMaintenanceNodeName } from '../../selectors';
-import { getHostStatus } from '../../utils/host-status';
+import { getHostStatus } from '../../status/host-status';
 import { BareMetalHostBundle } from '../types';
 import { hostStatusFilter } from './table-filters';
 import BareMetalHostsTable from './BareMetalHostsTable';

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { connect } from 'react-redux';
-import { getName, getMachineNode, createLookup } from '@console/shared';
+import { getName, createLookup, getNodeMachineName } from '@console/shared';
 import { MachineModel, NodeModel } from '@console/internal/models';
 import { MultiListPage } from '@console/internal/components/factory';
 import { FirehoseResource } from '@console/internal/components/utils';
@@ -9,7 +9,7 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { BareMetalHostModel, NodeMaintenanceModel } from '../../models';
 import { getHostMachine, getNodeMaintenanceNodeName } from '../../selectors';
 import { getHostStatus } from '../../utils/host-status';
-import { HostRowBundle } from '../types';
+import { BareMetalHostBundle } from '../types';
 import { hostStatusFilter } from './table-filters';
 import BareMetalHostsTable from './BareMetalHostsTable';
 
@@ -22,17 +22,18 @@ const flattenResources = (resources) => {
   const {
     hosts: { data: hostsData },
     machines: { data: machinesData },
-    nodes: { data: nodesData },
+    nodes,
     nodeMaintenances,
   } = resources;
 
   if (loaded) {
     const maintenancesByNodeName = createLookup(nodeMaintenances, getNodeMaintenanceNodeName);
+    const nodesByMachineName = createLookup(nodes, getNodeMachineName);
 
     return hostsData.map(
-      (host): HostRowBundle => {
+      (host): BareMetalHostBundle => {
         const machine = getHostMachine(host, machinesData);
-        const node = getMachineNode(machine, nodesData);
+        const node = nodesByMachineName[getName(machine)];
         const nodeMaintenance = maintenancesByNodeName[getName(node)];
         const status = getHostStatus({ host, machine, node, nodeMaintenance });
         // TODO(jtomasek): metadata.name is needed to make 'name' textFilter work.

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsPage.tsx
@@ -32,6 +32,8 @@ const flattenResources = (resources) => {
 
     return hostsData.map(
       (host): BareMetalHostBundle => {
+        // TODO(jtomasek): replace this with createLookup once there is metal3.io/BareMetalHost annotation
+        // on machines
         const machine = getHostMachine(host, machinesData);
         const node = nodesByMachineName[getName(machine)];
         const nodeMaintenance = maintenancesByNodeName[getName(node)];

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
@@ -92,7 +92,7 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({
         />
       </TableData>
       <TableData className={tableColumnClasses.status}>
-        <BareMetalHostStatus status={status} />
+        <BareMetalHostStatus {...status} />
         <SecondaryStatus status={getHostPowerStatus(host)} />
       </TableData>
       <TableData className={tableColumnClasses.node}>

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
@@ -5,7 +5,7 @@ import { sortable } from '@patternfly/react-table';
 import { getName, getUID, getNamespace, SecondaryStatus } from '@console/shared';
 import { TableRow, TableData, Table } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { HostRowBundle } from '../types';
+import { BareMetalHostBundle } from '../types';
 import { getHostBMCAddress, getHostPowerStatus } from '../../selectors';
 import { BareMetalHostModel } from '../../models';
 import NodeLink from './NodeLink';
@@ -60,7 +60,7 @@ const HostsTableHeader = () => [
 ];
 
 type HostsTableRowProps = {
-  obj: HostRowBundle;
+  obj: BareMetalHostBundle;
   customData: {
     hasNodeMaintenanceCapability: boolean;
   };
@@ -121,7 +121,7 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({
 };
 
 type BareMetalHostsTableProps = React.ComponentProps<typeof Table> & {
-  data: HostRowBundle[];
+  data: BareMetalHostBundle[];
   customData: {
     hasNodeMaintenanceCapability: boolean;
   };

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/MachineLink.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/MachineLink.tsx
@@ -7,12 +7,12 @@ import { ResourceLink, RequireCreatePermission } from '@console/internal/compone
 import { referenceForModel } from '@console/internal/module/k8s';
 import { getHostMachineName } from '../../selectors';
 import { canHostAddMachine } from '../../utils/host-status';
-import { HostMultiStatus } from '../types';
+import { BareMetalHostStatus } from '../types';
 import { BareMetalHostKind } from '../../types';
 
 interface MachineCellProps {
   host: BareMetalHostKind;
-  status: HostMultiStatus;
+  status: BareMetalHostStatus;
 }
 
 const MachineCell: React.FC<MachineCellProps> = ({ host, status }) => {

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/MachineLink.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/MachineLink.tsx
@@ -1,26 +1,18 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
-import { AddCircleOIcon } from '@patternfly/react-icons';
-import { DASH, StatusIconAndText } from '@console/shared';
+import { DASH, getNamespace } from '@console/shared';
 import { MachineModel } from '@console/internal/models';
-import { ResourceLink, RequireCreatePermission } from '@console/internal/components/utils';
+import { ResourceLink } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { getHostMachineName } from '../../selectors';
-import { canHostAddMachine } from '../../utils/host-status';
-import { BareMetalHostStatus } from '../types';
 import { BareMetalHostKind } from '../../types';
 
-interface MachineCellProps {
+interface MachineLinkProps {
   host: BareMetalHostKind;
-  status: BareMetalHostStatus;
 }
 
-const MachineCell: React.FC<MachineCellProps> = ({ host, status }) => {
+const MachineLink: React.FC<MachineLinkProps> = ({ host }) => {
   const machineName = getHostMachineName(host);
-
-  const {
-    metadata: { namespace },
-  } = host;
+  const namespace = getNamespace(host);
 
   if (machineName) {
     return (
@@ -32,18 +24,7 @@ const MachineCell: React.FC<MachineCellProps> = ({ host, status }) => {
       />
     );
   }
-  if (canHostAddMachine(status.status)) {
-    const ns = namespace || 'default';
-    const href = `/k8s/ns/${ns}/${referenceForModel(MachineModel)}/~new`;
-    return (
-      <RequireCreatePermission model={MachineModel} namespace={ns}>
-        <Link to={href}>
-          <StatusIconAndText icon={<AddCircleOIcon />} title="Add machine" />
-        </Link>
-      </RequireCreatePermission>
-    );
-  }
   return <>{DASH}</>;
 };
 
-export default MachineCell;
+export default MachineLink;

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
@@ -45,14 +45,14 @@ export const getBMHStatusGroups: StatusGroupMapper = (
     const machine = getHostMachine(host, machines as MachineKind[]);
     const node = getMachineNode(machine, nodes as NodeKind[]);
     const nodeMaintenance = findNodeMaintenance(maintenances, getName(node));
-    const hostMultiStatus = getHostStatus({ host, nodeMaintenance });
+    const BareMetalHostStatus = getHostStatus({ host, nodeMaintenance });
 
     const status = getHostFilterStatus({
       machine,
       node,
       host,
       nodeMaintenance,
-      status: hostMultiStatus,
+      status: BareMetalHostStatus,
     });
     const group =
       Object.keys(BMH_STATUS_GROUP_MAPPER).find((key) =>

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
@@ -1,10 +1,12 @@
 import { StatusGroupMapper } from '@console/shared/src/components/dashboard/inventory-card/InventoryItem';
 import { InventoryStatusGroup } from '@console/shared/src/components/dashboard/inventory-card/status-group';
 import { MachineKind, NodeKind } from '@console/internal/module/k8s';
-import { getMachineNode, getName } from '@console/shared/src/selectors';
+import { getName } from '@console/shared/src/selectors/common';
+import { getNodeMachineName } from '@console/shared/src/selectors/node';
+import { createBasicLookup } from '@console/shared/src/utils/utils';
 import { getHostStatus } from '../../../status/host-status';
 import { HOST_ERROR_STATES, HOST_PROGRESS_STATES, HOST_SUCCESS_STATES } from '../../../constants';
-import { findNodeMaintenance, getHostMachine } from '../../../selectors';
+import { getHostMachine, getNodeMaintenanceNodeName } from '../../../selectors';
 import { getHostFilterStatus } from '../table-filters';
 import { BareMetalHostKind } from '../../../types';
 
@@ -41,10 +43,15 @@ export const getBMHStatusGroups: StatusGroupMapper = (
     },
   };
 
+  const maintenancesByNodeName = createBasicLookup(maintenances, getNodeMaintenanceNodeName);
+  const nodesByMachineName = createBasicLookup(nodes, getNodeMachineName);
+
   hosts.forEach((host) => {
+    // TODO(jtomasek): replace this with createLookup once there is metal3.io/BareMetalHost annotation
+    // on machines
     const machine = getHostMachine(host, machines as MachineKind[]);
-    const node = getMachineNode(machine, nodes as NodeKind[]);
-    const nodeMaintenance = findNodeMaintenance(maintenances, getName(node));
+    const node = nodesByMachineName[getName(machine)] as NodeKind;
+    const nodeMaintenance = maintenancesByNodeName[getName(node)];
     const bareMetalHostStatus = getHostStatus({ host, nodeMaintenance });
 
     const status = getHostFilterStatus({

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
@@ -2,7 +2,7 @@ import { StatusGroupMapper } from '@console/shared/src/components/dashboard/inve
 import { InventoryStatusGroup } from '@console/shared/src/components/dashboard/inventory-card/status-group';
 import { MachineKind, NodeKind } from '@console/internal/module/k8s';
 import { getMachineNode, getName } from '@console/shared/src/selectors';
-import { getHostStatus } from '../../../utils/host-status';
+import { getHostStatus } from '../../../status/host-status';
 import { HOST_ERROR_STATES, HOST_PROGRESS_STATES, HOST_SUCCESS_STATES } from '../../../constants';
 import { findNodeMaintenance, getHostMachine } from '../../../selectors';
 import { getHostFilterStatus } from '../table-filters';

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
@@ -45,14 +45,14 @@ export const getBMHStatusGroups: StatusGroupMapper = (
     const machine = getHostMachine(host, machines as MachineKind[]);
     const node = getMachineNode(machine, nodes as NodeKind[]);
     const nodeMaintenance = findNodeMaintenance(maintenances, getName(node));
-    const BareMetalHostStatus = getHostStatus({ host, nodeMaintenance });
+    const bareMetalHostStatus = getHostStatus({ host, nodeMaintenance });
 
     const status = getHostFilterStatus({
       machine,
       node,
       host,
       nodeMaintenance,
-      status: BareMetalHostStatus,
+      status: bareMetalHostStatus,
     });
     const group =
       Object.keys(BMH_STATUS_GROUP_MAPPER).find((key) =>

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
@@ -10,7 +10,7 @@ import { getMachineNode, getMachineNodeName, getName } from '@console/shared';
 import { deleteModal } from '@console/internal/components/modals';
 import { findNodeMaintenance, getHostMachine, getHostPowerStatus } from '../../selectors';
 import { BareMetalHostModel, NodeMaintenanceModel } from '../../models';
-import { getHostStatus } from '../../utils/host-status';
+import { getHostStatus } from '../../status/host-status';
 import {
   HOST_POWER_STATUS_POWERING_OFF,
   HOST_POWER_STATUS_POWERED_ON,

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
@@ -6,7 +6,7 @@ import {
   MachineKind,
   NodeKind,
 } from '@console/internal/module/k8s';
-import { getMachineNode, getMachineNodeName, getName } from '@console/shared';
+import { getMachineNode, getMachineNodeName } from '@console/shared';
 import { deleteModal } from '@console/internal/components/modals';
 import { findNodeMaintenance, getHostMachine, getHostPowerStatus } from '../../selectors';
 import { BareMetalHostModel, NodeMaintenanceModel } from '../../models';
@@ -47,16 +47,12 @@ export const RemoveNodeMaintenance = (
   host: BareMetalHostKind,
   resources: {},
   { hasNodeMaintenanceCapability, nodeMaintenance, nodeName }: ActionArgs,
-): KebabOption => {
-  const hostName = getName(host);
-  return {
-    hidden: !nodeName || !hasNodeMaintenanceCapability || !nodeMaintenance,
-    label: 'Stop maintenance',
-    callback: () => stopNodeMaintenanceModal(nodeMaintenance, hostName),
-    accessReview:
-      nodeMaintenance && asAccessReview(NodeMaintenanceModel, nodeMaintenance, 'delete'),
-  };
-};
+): KebabOption => ({
+  hidden: !nodeName || !hasNodeMaintenanceCapability || !nodeMaintenance,
+  label: 'Stop maintenance',
+  callback: () => stopNodeMaintenanceModal(nodeMaintenance),
+  accessReview: nodeMaintenance && asAccessReview(NodeMaintenanceModel, nodeMaintenance, 'delete'),
+});
 
 export const PowerOn = (kindObj: K8sKind, host: BareMetalHostKind): KebabOption => {
   const title = 'Power on';

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
@@ -8,6 +8,7 @@ import {
   HOST_STATUS_TITLES,
   HOST_STATUS_PROVISIONED,
   HOST_STATUS_EXTERNALLY_PROVISIONED,
+  NODE_STATUS_TITLES,
 } from '../../constants';
 import { BareMetalHostBundle } from '../types';
 
@@ -34,7 +35,7 @@ const hostStatesToFilterMap = Object.freeze({
   },
   other: {
     title: 'Other',
-    states: Object.keys(HOST_STATUS_TITLES),
+    states: [...Object.keys(HOST_STATUS_TITLES), ...Object.keys(NODE_STATUS_TITLES)],
   },
 });
 

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
@@ -9,7 +9,7 @@ import {
   HOST_STATUS_PROVISIONED,
   HOST_STATUS_EXTERNALLY_PROVISIONED,
 } from '../../constants';
-import { HostRowBundle } from '../types';
+import { BareMetalHostBundle } from '../types';
 
 const hostStatesToFilterMap = Object.freeze({
   registering: {
@@ -38,7 +38,7 @@ const hostStatesToFilterMap = Object.freeze({
   },
 });
 
-export const getHostFilterStatus = (bundle: HostRowBundle): string => {
+export const getHostFilterStatus = (bundle: BareMetalHostBundle): string => {
   return _.findKey(hostStatesToFilterMap, ({ states }) => states.includes(bundle.status.status));
 };
 
@@ -47,7 +47,7 @@ export const hostStatusFilter: Filter = {
   selected: Object.keys(hostStatesToFilterMap),
   reducer: getHostFilterStatus,
   items: _.map(hostStatesToFilterMap, ({ title }, id) => ({ id, title })),
-  filter: (groups, bundle: HostRowBundle) => {
+  filter: (groups, bundle: BareMetalHostBundle) => {
     const status = getHostFilterStatus(bundle);
     return groups.selected.has(status) || !_.includes(groups.all, status);
   },

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodeStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodeStatus.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { Status } from '@console/shared';
+import { HOST_STATUS_UNDER_MAINTENANCE, HOST_STATUS_STARTING_MAINTENANCE } from '../../constants';
+import { StatusProps } from '../types';
+import MaintenancePopover from '../maintenance/MaintenancePopover';
+
+const BareMetalNodeStatus: React.FC<StatusProps> = ({ status, title, ...props }) => {
+  const statusTitle = title || status;
+  switch (true) {
+    case [HOST_STATUS_STARTING_MAINTENANCE, HOST_STATUS_UNDER_MAINTENANCE].includes(status):
+      return (
+        <MaintenancePopover title={statusTitle} maintenance={props.maintenance} host={props.host} />
+      );
+    default:
+      return <Status status={status} title={statusTitle} />;
+  }
+};
+
+export default BareMetalNodeStatus;

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodeStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodeStatus.tsx
@@ -1,16 +1,20 @@
 import * as React from 'react';
-import { Status } from '@console/shared';
-import { HOST_STATUS_UNDER_MAINTENANCE, HOST_STATUS_STARTING_MAINTENANCE } from '../../constants';
+import { Status, ProgressStatus } from '@console/shared';
+import {
+  NODE_STATUS_UNDER_MAINTENANCE,
+  NODE_STATUS_STARTING_MAINTENANCE,
+  NODE_STATUS_STOPPING_MAINTENANCE,
+} from '../../constants';
 import { StatusProps } from '../types';
 import MaintenancePopover from '../maintenance/MaintenancePopover';
 
 const BareMetalNodeStatus: React.FC<StatusProps> = ({ status, title, ...props }) => {
   const statusTitle = title || status;
   switch (true) {
-    case [HOST_STATUS_STARTING_MAINTENANCE, HOST_STATUS_UNDER_MAINTENANCE].includes(status):
-      return (
-        <MaintenancePopover title={statusTitle} maintenance={props.maintenance} host={props.host} />
-      );
+    case [NODE_STATUS_STARTING_MAINTENANCE, NODE_STATUS_UNDER_MAINTENANCE].includes(status):
+      return <MaintenancePopover title={statusTitle} maintenance={props.maintenance} />;
+    case status === NODE_STATUS_STOPPING_MAINTENANCE:
+      return <ProgressStatus title={statusTitle} />;
     default:
       return <Status status={status} title={statusTitle} />;
   }

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesPage.tsx
@@ -9,9 +9,9 @@ import { MultiListPage } from '@console/internal/components/factory';
 import { getNodeMaintenanceNodeName, getHostMachineName } from '../../selectors';
 import { BareMetalNodeBundle } from '../types';
 import { NodeMaintenanceModel, BareMetalHostModel } from '../../models';
-import { hostStatusFilter } from '../baremetal-hosts/table-filters';
 import { bareMetalNodeStatus } from '../../status/baremetal-node-status';
 import BareMetalNodesTable from './BareMetalNodesTable';
+import { bareMetalNodeStatusFilter } from './table-filters';
 
 const flattenResources = (resources) => {
   // TODO(jtomasek): Remove loaded check once ListPageWrapper_ is updated to call flatten only
@@ -85,7 +85,7 @@ const BareMetalNodesPage: React.FC<BareMetalNodesPageProps> = ({
   return (
     <MultiListPage
       {...props}
-      rowFilters={[hostStatusFilter]}
+      rowFilters={[bareMetalNodeStatusFilter]}
       createButtonText="Add Host"
       resources={resources}
       flatten={flattenResources}

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesPage.tsx
@@ -7,7 +7,7 @@ import * as _ from 'lodash';
 import { createLookup, getName, getMachineNodeName } from '@console/shared';
 import { MultiListPage } from '@console/internal/components/factory';
 import { getNodeMaintenanceNodeName, getHostMachineName } from '../../selectors';
-import { BareMetalHostBundle } from '../types';
+import { BareMetalNodeBundle } from '../types';
 import { getHostStatus } from '../../utils/host-status';
 import { NodeMaintenanceModel, BareMetalHostModel } from '../../models';
 import { hostStatusFilter } from '../baremetal-hosts/table-filters';
@@ -32,7 +32,7 @@ const flattenResources = (resources) => {
     const machinesByNodeName = createLookup(machines, getMachineNodeName);
 
     return nodesData.map(
-      (node): BareMetalHostBundle => {
+      (node): BareMetalNodeBundle => {
         const nodeName = getName(node);
         const machine = machinesByNodeName[nodeName];
         const host = hostsByMachineName[getName(machine)];

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesPage.tsx
@@ -7,7 +7,7 @@ import * as _ from 'lodash';
 import { createLookup, getName, getMachineNodeName } from '@console/shared';
 import { MultiListPage } from '@console/internal/components/factory';
 import { getNodeMaintenanceNodeName, getHostMachineName } from '../../selectors';
-import { HostRowBundle } from '../types';
+import { BareMetalHostBundle } from '../types';
 import { getHostStatus } from '../../utils/host-status';
 import { NodeMaintenanceModel, BareMetalHostModel } from '../../models';
 import { hostStatusFilter } from '../baremetal-hosts/table-filters';
@@ -32,7 +32,7 @@ const flattenResources = (resources) => {
     const machinesByNodeName = createLookup(machines, getMachineNodeName);
 
     return nodesData.map(
-      (node): HostRowBundle => {
+      (node): BareMetalHostBundle => {
         const nodeName = getName(node);
         const machine = machinesByNodeName[nodeName];
         const host = hostsByMachineName[getName(machine)];
@@ -82,18 +82,10 @@ const BareMetalNodesPage: React.FC<BareMetalNodesPageProps> = ({
     });
   }
 
-  // const createHostProps = {
-  //   to: `/k8s/ns/${props.namespace || 'default'}/${referenceForModel(
-  //     BareMetalHostModel,
-  //   )}/~new/form`,
-  // };
-
   return (
     <MultiListPage
       {...props}
       rowFilters={[hostStatusFilter]}
-      // canCreate
-      // createProps={createHostProps}
       createButtonText="Add Host"
       resources={resources}
       flatten={flattenResources}

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesPage.tsx
@@ -6,6 +6,7 @@ import { FirehoseResource } from '@console/internal/components/utils';
 import { MachineModel, NodeModel } from '@console/internal/models';
 import { createLookup, getName, getMachineNodeName } from '@console/shared';
 import { MultiListPage } from '@console/internal/components/factory';
+import Helmet from 'react-helmet';
 import { getNodeMaintenanceNodeName, getHostMachineName } from '../../selectors';
 import { BareMetalNodeBundle } from '../types';
 import { NodeMaintenanceModel, BareMetalHostModel } from '../../models';
@@ -83,16 +84,21 @@ const BareMetalNodesPage: React.FC<BareMetalNodesPageProps> = ({
   }
 
   return (
-    <MultiListPage
-      {...props}
-      rowFilters={[bareMetalNodeStatusFilter]}
-      createButtonText="Add Host"
-      resources={resources}
-      flatten={flattenResources}
-      ListComponent={BareMetalNodesTable}
-      customData={{ hasNodeMaintenanceCapability }}
-      title="Nodes"
-    />
+    <div className="co-m-list">
+      <Helmet>
+        <title>Nodes</title>
+      </Helmet>
+      <MultiListPage
+        {...props}
+        rowFilters={[bareMetalNodeStatusFilter]}
+        createButtonText="Add Host"
+        resources={resources}
+        flatten={flattenResources}
+        ListComponent={BareMetalNodesTable}
+        customData={{ hasNodeMaintenanceCapability }}
+        title="Nodes"
+      />
+    </div>
   );
 };
 

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesPage.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { FirehoseResource } from '@console/internal/components/utils';
+import { MachineModel, NodeModel } from '@console/internal/models';
+import * as _ from 'lodash';
+import { createLookup, getName, getMachineNodeName } from '@console/shared';
+import { MultiListPage } from '@console/internal/components/factory';
+import { getNodeMaintenanceNodeName, getHostMachineName } from '../../selectors';
+import { HostRowBundle } from '../types';
+import { getHostStatus } from '../../utils/host-status';
+import { NodeMaintenanceModel, BareMetalHostModel } from '../../models';
+import { hostStatusFilter } from '../baremetal-hosts/table-filters';
+import BareMetalNodesTable from './BareMetalNodesTable';
+
+const flattenResources = (resources) => {
+  // TODO(jtomasek): Remove loaded check once ListPageWrapper_ is updated to call flatten only
+  // when resources are loaded
+  const loaded = _.every(resources, (resource) =>
+    resource.optional ? resource.loaded || !_.isEmpty(resource.loadError) : resource.loaded,
+  );
+  const {
+    hosts,
+    machines,
+    nodes: { data: nodesData },
+    nodeMaintenances,
+  } = resources;
+
+  if (loaded) {
+    const maintenancesByNodeName = createLookup(nodeMaintenances, getNodeMaintenanceNodeName);
+    const hostsByMachineName = createLookup(hosts, getHostMachineName);
+    const machinesByNodeName = createLookup(machines, getMachineNodeName);
+
+    return nodesData.map(
+      (node): HostRowBundle => {
+        const nodeName = getName(node);
+        const machine = machinesByNodeName[nodeName];
+        const host = hostsByMachineName[getName(machine)];
+        const nodeMaintenance = maintenancesByNodeName[nodeName];
+        const status = getHostStatus({ host, machine, node, nodeMaintenance });
+        // TODO(jtomasek): metadata.name is needed to make 'name' textFilter work.
+        // Remove it when it is possible to pass custom textFilter as a function
+        return { metadata: { name: nodeName }, host, machine, node, nodeMaintenance, status };
+      },
+    );
+  }
+  return [];
+};
+
+type BareMetalNodesPageProps = {
+  hasNodeMaintenanceCapability: boolean;
+};
+
+const BareMetalNodesPage: React.FC<BareMetalNodesPageProps> = ({
+  hasNodeMaintenanceCapability,
+  ...props
+}) => {
+  const resources: FirehoseResource[] = [
+    {
+      kind: referenceForModel(BareMetalHostModel),
+      namespaced: true,
+      prop: 'hosts',
+    },
+    {
+      kind: referenceForModel(MachineModel),
+      namespaced: true,
+      prop: 'machines',
+    },
+    {
+      kind: NodeModel.kind,
+      namespaced: false,
+      prop: 'nodes',
+    },
+  ];
+
+  if (hasNodeMaintenanceCapability) {
+    resources.push({
+      kind: referenceForModel(NodeMaintenanceModel),
+      namespaced: false,
+      prop: 'nodeMaintenances',
+      optional: true,
+    });
+  }
+
+  // const createHostProps = {
+  //   to: `/k8s/ns/${props.namespace || 'default'}/${referenceForModel(
+  //     BareMetalHostModel,
+  //   )}/~new/form`,
+  // };
+
+  return (
+    <MultiListPage
+      {...props}
+      rowFilters={[hostStatusFilter]}
+      // canCreate
+      // createProps={createHostProps}
+      createButtonText="Add Host"
+      resources={resources}
+      flatten={flattenResources}
+      ListComponent={BareMetalNodesTable}
+      customData={{ hasNodeMaintenanceCapability }}
+      title="Nodes"
+    />
+  );
+};
+
+const mapStateToProps = ({ k8s }) => ({
+  hasNodeMaintenanceCapability: !!k8s.getIn([
+    'RESOURCES',
+    'models',
+    referenceForModel(NodeMaintenanceModel),
+  ]),
+});
+
+export default connect(mapStateToProps)(BareMetalNodesPage);

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
@@ -5,7 +5,7 @@ import { sortable } from '@patternfly/react-table';
 import { getName, getUID, getNamespace } from '@console/shared';
 import { TableRow, TableData, Table } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { HostRowBundle } from '../types';
+import { BareMetalHostBundle } from '../types';
 import { getHostBMCAddress } from '../../selectors';
 import { BareMetalHostModel } from '../../models';
 import BareMetalHostStatus from '../baremetal-hosts/BareMetalHostStatus';
@@ -60,7 +60,7 @@ const NodesTableHeader = () => [
 ];
 
 type NodesTableRowProps = {
-  obj: HostRowBundle;
+  obj: BareMetalHostBundle;
   customData: {
     hasNodeMaintenanceCapability: boolean;
   };
@@ -124,7 +124,7 @@ const NodesTableRow: React.FC<NodesTableRowProps> = ({
 };
 
 type BareMetalNodesTableProps = React.ComponentProps<typeof Table> & {
-  data: HostRowBundle[];
+  data: BareMetalHostBundle[];
   customData: {
     hasNodeMaintenanceCapability: boolean;
   };

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { Kebab, ResourceLink } from '@console/internal/components/utils';
+import { sortable } from '@patternfly/react-table';
+import { getName, getUID, getNamespace } from '@console/shared';
+import { TableRow, TableData, Table } from '@console/internal/components/factory';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { HostRowBundle } from '../types';
+import { getHostBMCAddress } from '../../selectors';
+import { BareMetalHostModel } from '../../models';
+import BareMetalHostStatus from '../baremetal-hosts/BareMetalHostStatus';
+import NodeLink from '../baremetal-hosts/NodeLink';
+import BareMetalHostRole from '../baremetal-hosts/BareMetalHostRole';
+import { menuActions } from '../baremetal-hosts/host-menu-actions';
+
+const tableColumnClasses = {
+  name: classNames('col-lg-3', 'col-md-4', 'col-sm-12', 'col-xs-12'),
+  status: classNames('col-lg-3', 'col-md-4', 'col-sm-6', 'hidden-xs'),
+  node: classNames('col-lg-2', 'col-md-4', 'hidden-sm', 'hidden-xs'),
+  role: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
+  address: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
+  kebab: Kebab.columnClass,
+};
+
+const NodesTableHeader = () => [
+  {
+    title: 'Name',
+    sortField: 'node.metadata.name',
+    transforms: [sortable],
+    props: { className: tableColumnClasses.name },
+  },
+  {
+    title: 'Status',
+    sortField: 'status.status',
+    transforms: [sortable],
+    props: { className: tableColumnClasses.status },
+  },
+  {
+    title: 'Node',
+    sortField: 'node.metadata.name',
+    transforms: [sortable],
+    props: { className: tableColumnClasses.node },
+  },
+  {
+    title: 'Role',
+    sortField: 'machine.metadata.labels["machine.openshift.io/cluster-api-machine-role"]',
+    transforms: [sortable],
+    props: { className: tableColumnClasses.role },
+  },
+  {
+    title: 'Management Address',
+    sortField: 'host.spec.bmc.address',
+    transforms: [sortable],
+    props: { className: tableColumnClasses.address },
+  },
+  {
+    title: '',
+    props: { className: tableColumnClasses.kebab },
+  },
+];
+
+type NodesTableRowProps = {
+  obj: HostRowBundle;
+  customData: {
+    hasNodeMaintenanceCapability: boolean;
+  };
+  index: number;
+  key?: string;
+  style: React.StyleHTMLAttributes<any>;
+};
+
+const NodesTableRow: React.FC<NodesTableRowProps> = ({
+  obj: { host, node, nodeMaintenance, machine, status },
+  customData: { hasNodeMaintenanceCapability },
+  index,
+  key,
+  style,
+}) => {
+  const nodeName = getName(node);
+  const hostName = getName(host);
+  const namespace = getNamespace(host);
+  const address = getHostBMCAddress(host);
+  const uid = getUID(node);
+
+  return (
+    <TableRow id={uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses.name}>
+        {node ? (
+          <ResourceLink kind="Node" name={nodeName} />
+        ) : (
+          <ResourceLink
+            kind={referenceForModel(BareMetalHostModel)}
+            name={hostName}
+            namespace={namespace}
+          />
+        )}
+      </TableData>
+      <TableData className={tableColumnClasses.status}>
+        <BareMetalHostStatus status={status} />
+      </TableData>
+      <TableData className={tableColumnClasses.node}>
+        <NodeLink nodeName={nodeName} />
+      </TableData>
+      <TableData className={tableColumnClasses.role}>
+        <BareMetalHostRole machine={machine} node={node} />
+      </TableData>
+      <TableData className={tableColumnClasses.address}>{address}</TableData>
+      <TableData className={tableColumnClasses.kebab}>
+        <Kebab
+          options={menuActions.map((action) =>
+            action(BareMetalHostModel, host, null, {
+              nodeMaintenance,
+              nodeName,
+              hasNodeMaintenanceCapability,
+              status: status.status,
+            }),
+          )}
+          key={`kebab-for-${uid}`}
+          id={`kebab-for-${uid}`}
+        />
+      </TableData>
+    </TableRow>
+  );
+};
+
+type BareMetalNodesTableProps = React.ComponentProps<typeof Table> & {
+  data: HostRowBundle[];
+  customData: {
+    hasNodeMaintenanceCapability: boolean;
+  };
+};
+
+const BareMetalNodesTable: React.FC<BareMetalNodesTableProps> = (props) => {
+  return (
+    <Table
+      {...props}
+      defaultSortField="node.metadata.name"
+      aria-label="Nodes"
+      Header={NodesTableHeader}
+      Row={NodesTableRow}
+      virtualize
+    />
+  );
+};
+
+export default BareMetalNodesTable;

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { Kebab, ResourceLink } from '@console/internal/components/utils';
 import { sortable } from '@patternfly/react-table';
-import { getName, getUID, getNamespace, DASH } from '@console/shared';
+import { getName, getUID, getNamespace, DASH, SecondaryStatus } from '@console/shared';
 import { TableRow, TableData, Table } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import NodeRoles from '@console/app/src/components/nodes/NodeRoles';
@@ -11,6 +11,7 @@ import { BareMetalNodeBundle } from '../types';
 import { getHostBMCAddress } from '../../selectors';
 import { BareMetalHostModel } from '../../models';
 import { menuActions } from '../baremetal-hosts/host-menu-actions';
+import { baremetalNodeSecondaryStatus } from '../../status/baremetal-node-status';
 import BareMetalNodeStatus from './BareMetalNodeStatus';
 
 const tableColumnClasses = {
@@ -97,6 +98,7 @@ const BareMetalNodesTableRow: React.FC<BareMetalNodesTableRowProps> = ({
       </TableData>
       <TableData className={tableColumnClasses.status}>
         <BareMetalNodeStatus {...status} />
+        <SecondaryStatus status={baremetalNodeSecondaryStatus({ node, nodeMaintenance, host })} />
       </TableData>
       <TableData className={tableColumnClasses.role}>
         <NodeRoles node={node} />

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
@@ -10,8 +10,8 @@ import { MachineModel } from '@console/internal/models';
 import { BareMetalNodeBundle } from '../types';
 import { getHostBMCAddress } from '../../selectors';
 import { BareMetalHostModel } from '../../models';
-import BareMetalHostStatus from '../baremetal-hosts/BareMetalHostStatus';
 import { menuActions } from '../baremetal-hosts/host-menu-actions';
+import BareMetalNodeStatus from './BareMetalNodeStatus';
 
 const tableColumnClasses = {
   name: classNames('col-lg-3', 'col-md-4', 'col-sm-12', 'col-xs-12'),
@@ -96,7 +96,7 @@ const BareMetalNodesTableRow: React.FC<BareMetalNodesTableRowProps> = ({
         )}
       </TableData>
       <TableData className={tableColumnClasses.status}>
-        <BareMetalHostStatus status={status} />
+        <BareMetalNodeStatus {...status} />
       </TableData>
       <TableData className={tableColumnClasses.role}>
         <NodeRoles node={node} />

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
@@ -2,27 +2,27 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { Kebab, ResourceLink } from '@console/internal/components/utils';
 import { sortable } from '@patternfly/react-table';
-import { getName, getUID, getNamespace } from '@console/shared';
+import { getName, getUID, getNamespace, DASH } from '@console/shared';
 import { TableRow, TableData, Table } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { BareMetalHostBundle } from '../types';
+import NodeRoles from '@console/app/src/components/nodes/NodeRoles';
+import { MachineModel } from '@console/internal/models';
+import { BareMetalNodeBundle } from '../types';
 import { getHostBMCAddress } from '../../selectors';
 import { BareMetalHostModel } from '../../models';
 import BareMetalHostStatus from '../baremetal-hosts/BareMetalHostStatus';
-import NodeLink from '../baremetal-hosts/NodeLink';
-import BareMetalHostRole from '../baremetal-hosts/BareMetalHostRole';
 import { menuActions } from '../baremetal-hosts/host-menu-actions';
 
 const tableColumnClasses = {
   name: classNames('col-lg-3', 'col-md-4', 'col-sm-12', 'col-xs-12'),
   status: classNames('col-lg-3', 'col-md-4', 'col-sm-6', 'hidden-xs'),
-  node: classNames('col-lg-2', 'col-md-4', 'hidden-sm', 'hidden-xs'),
-  role: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
+  role: classNames('col-lg-2', 'col-md-4', 'hidden-sm', 'hidden-xs'),
+  machine: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
   address: classNames('col-lg-2', 'hidden-md', 'hidden-sm', 'hidden-xs'),
   kebab: Kebab.columnClass,
 };
 
-const NodesTableHeader = () => [
+const BareMetalNodesTableHeader = () => [
   {
     title: 'Name',
     sortField: 'node.metadata.name',
@@ -36,16 +36,16 @@ const NodesTableHeader = () => [
     props: { className: tableColumnClasses.status },
   },
   {
-    title: 'Node',
-    sortField: 'node.metadata.name',
-    transforms: [sortable],
-    props: { className: tableColumnClasses.node },
-  },
-  {
     title: 'Role',
     sortField: 'machine.metadata.labels["machine.openshift.io/cluster-api-machine-role"]',
     transforms: [sortable],
     props: { className: tableColumnClasses.role },
+  },
+  {
+    title: 'Machine',
+    sortField: "metadata.annotations['machine.openshift.io/machine']",
+    transforms: [sortable],
+    props: { className: tableColumnClasses.machine },
   },
   {
     title: 'Management Address',
@@ -59,8 +59,8 @@ const NodesTableHeader = () => [
   },
 ];
 
-type NodesTableRowProps = {
-  obj: BareMetalHostBundle;
+type BareMetalNodesTableRowProps = {
+  obj: BareMetalNodeBundle;
   customData: {
     hasNodeMaintenanceCapability: boolean;
   };
@@ -69,7 +69,7 @@ type NodesTableRowProps = {
   style: React.StyleHTMLAttributes<any>;
 };
 
-const NodesTableRow: React.FC<NodesTableRowProps> = ({
+const BareMetalNodesTableRow: React.FC<BareMetalNodesTableRowProps> = ({
   obj: { host, node, nodeMaintenance, machine, status },
   customData: { hasNodeMaintenanceCapability },
   index,
@@ -98,11 +98,19 @@ const NodesTableRow: React.FC<NodesTableRowProps> = ({
       <TableData className={tableColumnClasses.status}>
         <BareMetalHostStatus status={status} />
       </TableData>
-      <TableData className={tableColumnClasses.node}>
-        <NodeLink nodeName={nodeName} />
-      </TableData>
       <TableData className={tableColumnClasses.role}>
-        <BareMetalHostRole machine={machine} node={node} />
+        <NodeRoles node={node} />
+      </TableData>
+      <TableData className={tableColumnClasses.machine}>
+        {machine ? (
+          <ResourceLink
+            kind={referenceForModel(MachineModel)}
+            name={getName(machine)}
+            namespace={getNamespace(machine)}
+          />
+        ) : (
+          DASH
+        )}
       </TableData>
       <TableData className={tableColumnClasses.address}>{address}</TableData>
       <TableData className={tableColumnClasses.kebab}>
@@ -124,7 +132,7 @@ const NodesTableRow: React.FC<NodesTableRowProps> = ({
 };
 
 type BareMetalNodesTableProps = React.ComponentProps<typeof Table> & {
-  data: BareMetalHostBundle[];
+  data: BareMetalNodeBundle[];
   customData: {
     hasNodeMaintenanceCapability: boolean;
   };
@@ -136,8 +144,8 @@ const BareMetalNodesTable: React.FC<BareMetalNodesTableProps> = (props) => {
       {...props}
       defaultSortField="node.metadata.name"
       aria-label="Nodes"
-      Header={NodesTableHeader}
-      Row={NodesTableRow}
+      Header={BareMetalNodesTableHeader}
+      Row={BareMetalNodesTableRow}
       virtualize
     />
   );

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/table-filters.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/table-filters.ts
@@ -1,0 +1,34 @@
+import * as _ from 'lodash';
+import { Filter } from '@console/shared/src/types';
+import { NODE_STATUS_TITLES } from '../../constants';
+import { BareMetalNodeBundle } from '../types';
+
+const statesToFilterMap = Object.freeze({
+  ready: {
+    title: 'Ready',
+    states: ['Ready'],
+  },
+  notReady: {
+    title: 'Not Ready',
+    states: ['Not Ready'],
+  },
+  maintenance: {
+    title: 'Maintenance',
+    states: Object.keys(NODE_STATUS_TITLES),
+  },
+});
+
+export const getBareMetalNodeFilterStatus = (bundle: BareMetalNodeBundle): string => {
+  return _.findKey(statesToFilterMap, ({ states }) => states.includes(bundle.status.status));
+};
+
+export const bareMetalNodeStatusFilter: Filter = {
+  type: 'bare-metal-node-status',
+  selected: Object.keys(statesToFilterMap),
+  reducer: getBareMetalNodeFilterStatus,
+  items: _.map(statesToFilterMap, ({ title }, id) => ({ id, title })),
+  filter: (groups, bundle: BareMetalNodeBundle) => {
+    const status = getBareMetalNodeFilterStatus(bundle);
+    return groups.selected.has(status) || !_.includes(groups.all, status);
+  },
+};

--- a/frontend/packages/metal3-plugin/src/components/maintenance/MaintenancePopover.tsx
+++ b/frontend/packages/metal3-plugin/src/components/maintenance/MaintenancePopover.tsx
@@ -1,21 +1,18 @@
 import * as React from 'react';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { PopoverStatus, getName } from '@console/shared';
+import { PopoverStatus } from '@console/shared';
 import { InProgressIcon, MaintenanceIcon } from '@patternfly/react-icons';
 import { getNodeMaintenancePhase } from '../../selectors';
-import { BareMetalHostKind } from '../../types';
 import UnderMaintenancePopoverContent from './UnderMaintenancePopoverContent';
 import StartingMaintenancePopoverContent from './StartingMaintenancePopoverContent';
 
 type MaintenancePopoverProps = {
   title: string;
   maintenance: K8sResourceKind;
-  host: BareMetalHostKind;
 };
 
-const MaintenancePopover: React.FC<MaintenancePopoverProps> = ({ title, maintenance, host }) => {
+const MaintenancePopover: React.FC<MaintenancePopoverProps> = ({ title, maintenance }) => {
   const phase = getNodeMaintenancePhase(maintenance);
-  const hostName = getName(host);
 
   return (
     <PopoverStatus
@@ -23,9 +20,9 @@ const MaintenancePopover: React.FC<MaintenancePopoverProps> = ({ title, maintena
       title={title}
     >
       {phase === 'Succeeded' ? (
-        <UnderMaintenancePopoverContent maintenance={maintenance} hostName={hostName} />
+        <UnderMaintenancePopoverContent maintenance={maintenance} />
       ) : (
-        <StartingMaintenancePopoverContent maintenance={maintenance} hostName={hostName} />
+        <StartingMaintenancePopoverContent maintenance={maintenance} />
       )}
     </PopoverStatus>
   );

--- a/frontend/packages/metal3-plugin/src/components/maintenance/StartingMaintenancePopoverContent.tsx
+++ b/frontend/packages/metal3-plugin/src/components/maintenance/StartingMaintenancePopoverContent.tsx
@@ -14,12 +14,10 @@ import MaintenancePopoverPodList from './MaintenancePopoverPodList';
 
 type StartingMaintenancePopoverContentProps = {
   maintenance: K8sResourceKind;
-  hostName: string;
 };
 
 const StartingMaintenancePopoverContent: React.FC<StartingMaintenancePopoverContentProps> = ({
   maintenance,
-  hostName,
 }) => {
   const reason = getNodeMaintenanceReason(maintenance);
   const creationTimestamp = getNodeMaintenanceCreationTimestamp(maintenance);
@@ -29,8 +27,8 @@ const StartingMaintenancePopoverContent: React.FC<StartingMaintenancePopoverCont
   return (
     <>
       <p>
-        This host is entering maintenance. The cluster will automatically rebuild host&apos;s data
-        30 minutes after entering maintenance.
+        Node is entering maintenance. The cluster will automatically rebuild node&apos;s data 30
+        minutes after entering maintenance.
       </p>
       <dl>
         <dt>Maintenance reason:</dt>
@@ -59,11 +57,7 @@ const StartingMaintenancePopoverContent: React.FC<StartingMaintenancePopoverCont
         <MaintenancePopoverPodList pods={pendingPods} />
       </Expandable>
       <br />
-      <Button
-        variant="link"
-        onClick={() => stopNodeMaintenanceModal(maintenance, hostName)}
-        isInline
-      >
+      <Button variant="link" onClick={() => stopNodeMaintenanceModal(maintenance)} isInline>
         Stop
       </Button>
     </>

--- a/frontend/packages/metal3-plugin/src/components/maintenance/UnderMaintenancePopoverContent.tsx
+++ b/frontend/packages/metal3-plugin/src/components/maintenance/UnderMaintenancePopoverContent.tsx
@@ -7,12 +7,10 @@ import stopNodeMaintenanceModal from '../modals/StopNodeMaintenanceModal';
 
 type UnderMaintenancePopoverContentProps = {
   maintenance: K8sResourceKind;
-  hostName: string;
 };
 
 const UnderMaintenancePopoverContent: React.FC<UnderMaintenancePopoverContentProps> = ({
   maintenance,
-  hostName,
 }) => {
   const reason = getNodeMaintenanceReason(maintenance);
   const creationTimestamp = getNodeMaintenanceCreationTimestamp(maintenance);
@@ -20,7 +18,7 @@ const UnderMaintenancePopoverContent: React.FC<UnderMaintenancePopoverContentPro
   return (
     <>
       <p>
-        This host is under maintenance. The cluster will automatically rebuild host&apos;s data 30
+        Node is under maintenance. The cluster will automatically rebuild node&apos;s data 30
         minutes after entering maintenance.
       </p>
       <dl>
@@ -32,11 +30,7 @@ const UnderMaintenancePopoverContent: React.FC<UnderMaintenancePopoverContentPro
         </dd>
       </dl>
       <br />
-      <Button
-        variant="link"
-        onClick={() => stopNodeMaintenanceModal(maintenance, hostName)}
-        isInline
-      >
+      <Button variant="link" onClick={() => stopNodeMaintenanceModal(maintenance)} isInline>
         Stop maintenance
       </Button>
     </>

--- a/frontend/packages/metal3-plugin/src/components/modals/PowerOffHostModal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/PowerOffHostModal.tsx
@@ -10,7 +10,7 @@ import {
 } from '@console/internal/components/factory';
 import { getName } from '@console/shared';
 import { powerOffHost } from '../../k8s/requests/host-power-operations';
-import { HOST_STATUS_UNDER_MAINTENANCE, HOST_STATUS_READY } from '../../constants';
+import { NODE_STATUS_UNDER_MAINTENANCE, HOST_STATUS_READY } from '../../constants';
 import { BareMetalHostKind } from '../../types';
 import { startNodeMaintenanceModal } from './StartNodeMaintenanceModal';
 
@@ -73,7 +73,7 @@ const ForcePowerOffDialog: React.FC<ForcePowerOffDialogProps> = ({
 };
 
 const isPowerOffSafe = (status: string) => {
-  const safeStates = [HOST_STATUS_UNDER_MAINTENANCE, HOST_STATUS_READY];
+  const safeStates = [NODE_STATUS_UNDER_MAINTENANCE, HOST_STATUS_READY];
   return safeStates.includes(status);
 };
 
@@ -120,7 +120,7 @@ const PowerOffHostModal = withHandlePromise(
     };
 
     const title = `Shut down`;
-    const isUnderMaintenance = status === HOST_STATUS_UNDER_MAINTENANCE;
+    const isUnderMaintenance = status === NODE_STATUS_UNDER_MAINTENANCE;
     return (
       <form onSubmit={submit} name="form" className="modal-content">
         <ModalTitle>

--- a/frontend/packages/metal3-plugin/src/components/modals/StopNodeMaintenanceModal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/StopNodeMaintenanceModal.tsx
@@ -2,17 +2,18 @@ import * as React from 'react';
 import { confirmModal } from '@console/internal/components/modals/confirm-modal';
 import { k8sKill, K8sResourceKind } from '@console/internal/module/k8s';
 import { NodeMaintenanceModel } from '../../models';
-import { getNodeMaintenanceReason } from '../../selectors';
+import { getNodeMaintenanceReason, getNodeMaintenanceNodeName } from '../../selectors';
 
-const stopNodeMaintenanceModal = (nodeMaintenance: K8sResourceKind, hostName: string) => {
+const stopNodeMaintenanceModal = (nodeMaintenance: K8sResourceKind) => {
   const title = 'Stop maintenance';
   const reason = getNodeMaintenanceReason(nodeMaintenance);
+  const nodeName = getNodeMaintenanceNodeName(nodeMaintenance);
   return confirmModal({
     title,
     message: (
       <>
         Are you sure you want to stop maintenance <strong>{reason ? ` (${reason}) ` : ''}</strong>on
-        host <strong>{hostName}</strong>?
+        node <strong>{nodeName}</strong>?
       </>
     ),
     btnText: title,

--- a/frontend/packages/metal3-plugin/src/components/types.ts
+++ b/frontend/packages/metal3-plugin/src/components/types.ts
@@ -1,19 +1,19 @@
 import { K8sResourceKind, MachineKind, NodeKind } from '@console/internal/module/k8s';
 import { BareMetalHostKind } from '../types';
 
+export type StatusProps = {
+  status: string;
+  title?: string;
+  [key: string]: any;
+};
+
 export type BareMetalHostBundle = {
   metadata?: { name: string };
   machine: MachineKind;
   node: NodeKind;
   host: BareMetalHostKind;
   nodeMaintenance: K8sResourceKind;
-  status: BareMetalHostStatus;
-};
-
-export type BareMetalHostStatus = {
-  status: string;
-  title: string;
-  [key: string]: any;
+  status: StatusProps;
 };
 
 export type BareMetalNodeBundle = {
@@ -23,5 +23,5 @@ export type BareMetalNodeBundle = {
   host: BareMetalHostKind;
   nodeMaintenance: K8sResourceKind;
   // TODO(jtomasek): replace with new BareMetalNodeStatus
-  status: BareMetalHostStatus;
+  status: StatusProps;
 };

--- a/frontend/packages/metal3-plugin/src/components/types.ts
+++ b/frontend/packages/metal3-plugin/src/components/types.ts
@@ -1,17 +1,27 @@
 import { K8sResourceKind, MachineKind, NodeKind } from '@console/internal/module/k8s';
 import { BareMetalHostKind } from '../types';
 
-export type HostRowBundle = {
+export type BareMetalHostBundle = {
   metadata?: { name: string };
   machine: MachineKind;
   node: NodeKind;
   host: BareMetalHostKind;
   nodeMaintenance: K8sResourceKind;
-  status: HostMultiStatus;
+  status: BareMetalHostStatus;
 };
 
-export type HostMultiStatus = {
+export type BareMetalHostStatus = {
   status: string;
   title: string;
   [key: string]: any;
+};
+
+export type BareMetalNodeBundle = {
+  metadata?: { name: string };
+  node: NodeKind;
+  machine: MachineKind;
+  host: BareMetalHostKind;
+  nodeMaintenance: K8sResourceKind;
+  // TODO(jtomasek): replace with new BareMetalNodeStatus
+  status: BareMetalHostStatus;
 };

--- a/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
+++ b/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
@@ -12,9 +12,6 @@ export const HOST_STATUS_PROVISIONING = 'provisioning';
 export const HOST_STATUS_DEPROVISIONING = 'deprovisioning';
 export const HOST_STATUS_MAKING_HOST_AVAILABLE = 'making host available';
 export const HOST_STATUS_MATCH_PROFILE = 'match profile';
-export const HOST_STATUS_STARTING_MAINTENANCE = 'starting maintenance';
-export const HOST_STATUS_UNDER_MAINTENANCE = 'under maintenance';
-export const HOST_STATUS_STOPPING_MAINTENANCE = 'stopping maintenance';
 export const HOST_STATUS_VALIDATION_ERROR = 'validation error';
 export const HOST_STATUS_REGISTRATION_ERROR = 'registration error';
 export const HOST_STATUS_PROVISIONING_ERROR = 'provisioning error';
@@ -43,9 +40,6 @@ export const HOST_STATUS_TITLES = {
   [HOST_STATUS_REGISTRATION_ERROR]: 'Registration error',
   [HOST_STATUS_PROVISIONING_ERROR]: 'Provisioning error',
   [HOST_STATUS_POWER_MANAGEMENT_ERROR]: 'Power Management Error',
-  [HOST_STATUS_STARTING_MAINTENANCE]: 'Starting maintenance',
-  [HOST_STATUS_UNDER_MAINTENANCE]: 'Under maintenance',
-  [HOST_STATUS_STOPPING_MAINTENANCE]: 'Stopping maintenance',
   [HOST_STATUS_MATCH_PROFILE]: 'Matching profile',
 };
 
@@ -78,8 +72,6 @@ export const HOST_PROGRESS_STATES = [
   HOST_STATUS_DEPROVISIONING,
   HOST_STATUS_MAKING_HOST_AVAILABLE,
   HOST_STATUS_REGISTERING,
-  HOST_STATUS_STARTING_MAINTENANCE,
-  HOST_STATUS_STOPPING_MAINTENANCE,
   HOST_STATUS_MATCH_PROFILE,
 ];
 

--- a/frontend/packages/metal3-plugin/src/constants/index.ts
+++ b/frontend/packages/metal3-plugin/src/constants/index.ts
@@ -1,0 +1,2 @@
+export * from './node-maintenance';
+export * from './bare-metal-host';

--- a/frontend/packages/metal3-plugin/src/constants/node-maintenance.ts
+++ b/frontend/packages/metal3-plugin/src/constants/node-maintenance.ts
@@ -1,0 +1,9 @@
+export const NODE_STATUS_STARTING_MAINTENANCE = 'starting maintenance';
+export const NODE_STATUS_UNDER_MAINTENANCE = 'under maintenance';
+export const NODE_STATUS_STOPPING_MAINTENANCE = 'stopping maintenance';
+
+export const NODE_STATUS_TITLES = {
+  [NODE_STATUS_STARTING_MAINTENANCE]: 'Starting maintenance',
+  [NODE_STATUS_UNDER_MAINTENANCE]: 'Under maintenance',
+  [NODE_STATUS_STOPPING_MAINTENANCE]: 'Stopping maintenance',
+};

--- a/frontend/packages/metal3-plugin/src/plugin.ts
+++ b/frontend/packages/metal3-plugin/src/plugin.ts
@@ -55,20 +55,20 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Resource/List',
     properties: {
       model: BareMetalHostModel,
-      loader: async () =>
-        (await import(
+      loader: () =>
+        import(
           './components/baremetal-hosts/BareMetalHostsPage' /* webpackChunkName: "metal3-baremetalhosts" */
-        )).default,
+        ).then((m) => m.default),
     },
   },
   {
     type: 'Page/Resource/Details',
     properties: {
       model: BareMetalHostModel,
-      loader: async () =>
-        (await import(
+      loader: () =>
+        import(
           './components/baremetal-hosts/BareMetalHostDetailsPage' /* webpackChunkName: "metal3-baremetalhost" */
-        )).default,
+        ).then((m) => m.default),
     },
   },
   {
@@ -76,10 +76,10 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       exact: true,
       path: `/k8s/ns/:ns/${referenceForModel(BareMetalHostModel)}/~new/form`,
-      loader: async () =>
-        (await import(
+      loader: () =>
+        import(
           './components/baremetal-hosts/AddHost' /* webpackChunkName: "metal3-baremetalhost" */
-        )).default,
+        ).then((m) => m.default),
     },
   },
   {
@@ -110,6 +110,17 @@ const plugin: Plugin<ConsumedExtensions> = [
       model: BareMetalHostModel,
       mapper: getBMHStatusGroups,
       required: [FLAGS.BAREMETAL, METAL3_FLAG],
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: ['/k8s/cluster/nodes/'],
+      loader: () =>
+        import(
+          './components/baremetal-nodes/BareMetalNodesPage' /* webpackChunkName: "node" */
+        ).then((m) => m.default),
     },
   },
 ];

--- a/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
@@ -12,4 +12,4 @@ export const bareMetalNodeStatus = ({
   node,
   nodeMaintenance,
 }: BareMetalNodeStatusProps): StatusProps =>
-  getNodeMaintenanceStatus(nodeMaintenance, node) || { status: nodeStatus(node), node };
+  getNodeMaintenanceStatus(nodeMaintenance) || { status: nodeStatus(node), node };

--- a/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
@@ -1,0 +1,15 @@
+import { NodeKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { nodeStatus } from '@console/app/src/status/node';
+import { StatusProps } from '../components/types';
+import { getNodeMaintenanceStatus } from './node-maintenance-status';
+
+type BareMetalNodeStatusProps = {
+  node: NodeKind;
+  nodeMaintenance: K8sResourceKind;
+};
+
+export const bareMetalNodeStatus = ({
+  node,
+  nodeMaintenance,
+}: BareMetalNodeStatusProps): StatusProps =>
+  getNodeMaintenanceStatus(nodeMaintenance, node) || { status: nodeStatus(node), node };

--- a/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
@@ -1,6 +1,9 @@
 import { NodeKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { nodeStatus } from '@console/app/src/status/node';
+import { isNodeUnschedulable } from '@console/shared';
 import { StatusProps } from '../components/types';
+import { BareMetalHostKind } from '../types';
+import { isHostPoweredOn } from '../selectors';
 import { getNodeMaintenanceStatus } from './node-maintenance-status';
 
 type BareMetalNodeStatusProps = {
@@ -13,3 +16,22 @@ export const bareMetalNodeStatus = ({
   nodeMaintenance,
 }: BareMetalNodeStatusProps): StatusProps =>
   getNodeMaintenanceStatus(nodeMaintenance) || { status: nodeStatus(node), node };
+
+type BareMetalNodeSecondaryStatusProps = {
+  node: NodeKind;
+  host?: BareMetalHostKind;
+  nodeMaintenance?: K8sResourceKind;
+};
+
+export const baremetalNodeSecondaryStatus = ({
+  node,
+  host,
+  nodeMaintenance,
+}: BareMetalNodeSecondaryStatusProps): string[] => {
+  const states = [];
+  if (!nodeMaintenance && isNodeUnschedulable(node)) {
+    states.push('Scheduling disabled');
+  }
+  if (!isHostPoweredOn(host)) states.push('Host is powered off');
+  return states;
+};

--- a/frontend/packages/metal3-plugin/src/status/host-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/host-status.ts
@@ -47,7 +47,6 @@ type HostStatusProps = {
   nodeMaintenance?: K8sResourceKind;
 };
 
-export const getHostStatus = ({ host, node, nodeMaintenance }: HostStatusProps): StatusProps => {
-  const maintenanceStatus = getNodeMaintenanceStatus(nodeMaintenance, node);
-  return maintenanceStatus ? { ...maintenanceStatus, host } : getBareMetalHostStatus(host);
+export const getHostStatus = ({ host, nodeMaintenance }: HostStatusProps): StatusProps => {
+  return getNodeMaintenanceStatus(nodeMaintenance) || getBareMetalHostStatus(host);
 };

--- a/frontend/packages/metal3-plugin/src/status/host-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/host-status.ts
@@ -8,7 +8,7 @@ import {
   HOST_STATUS_PROVISIONING,
   HOST_STATUS_PROVISIONING_ERROR,
 } from '../constants';
-import { BareMetalHostStatus } from '../components/types';
+import { StatusProps } from '../components/types';
 import { BareMetalHostKind } from '../types';
 import { getNodeMaintenanceStatus } from './node-maintenance-status';
 
@@ -47,5 +47,7 @@ type HostStatusProps = {
   nodeMaintenance?: K8sResourceKind;
 };
 
-export const getHostStatus = ({ host, nodeMaintenance }: HostStatusProps): BareMetalHostStatus =>
-  getNodeMaintenanceStatus(nodeMaintenance, host) || getBareMetalHostStatus(host);
+export const getHostStatus = ({ host, node, nodeMaintenance }: HostStatusProps): StatusProps => {
+  const maintenanceStatus = getNodeMaintenanceStatus(nodeMaintenance, node);
+  return maintenanceStatus ? { ...maintenanceStatus, host } : getBareMetalHostStatus(host);
+};

--- a/frontend/packages/metal3-plugin/src/status/node-maintenance-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/node-maintenance-status.ts
@@ -1,5 +1,5 @@
-import { K8sResourceKind } from '@console/internal/module/k8s';
-import { getDeletetionTimestamp } from '@console/shared/src/selectors/common';
+import { K8sResourceKind, NodeKind } from '@console/internal/module/k8s';
+import { getDeletetionTimestamp } from '@console/shared/src/selectors';
 import { getNodeMaintenancePhase } from '../selectors';
 import {
   HOST_STATUS_TITLES,
@@ -7,16 +7,19 @@ import {
   HOST_STATUS_STOPPING_MAINTENANCE,
   HOST_STATUS_STARTING_MAINTENANCE,
 } from '../constants';
-import { BareMetalHostKind } from '../types';
+import { StatusProps } from '../components/types';
 
-export const getNodeMaintenanceStatus = (maintenance: K8sResourceKind, host: BareMetalHostKind) => {
+export const getNodeMaintenanceStatus = (
+  maintenance: K8sResourceKind,
+  node: NodeKind,
+): StatusProps => {
   if (maintenance) {
     if (getDeletetionTimestamp(maintenance)) {
       return {
         status: HOST_STATUS_STOPPING_MAINTENANCE,
         title: HOST_STATUS_TITLES[HOST_STATUS_STOPPING_MAINTENANCE],
         maintenance,
-        host,
+        node,
       };
     }
     if (getNodeMaintenancePhase(maintenance) === 'Succeeded') {
@@ -24,14 +27,14 @@ export const getNodeMaintenanceStatus = (maintenance: K8sResourceKind, host: Bar
         status: HOST_STATUS_UNDER_MAINTENANCE,
         title: HOST_STATUS_TITLES[HOST_STATUS_UNDER_MAINTENANCE],
         maintenance,
-        host,
+        node,
       };
     }
     return {
       status: HOST_STATUS_STARTING_MAINTENANCE,
       title: HOST_STATUS_TITLES[HOST_STATUS_STARTING_MAINTENANCE],
       maintenance,
-      host,
+      node,
     };
   }
   return null;

--- a/frontend/packages/metal3-plugin/src/status/node-maintenance-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/node-maintenance-status.ts
@@ -1,41 +1,34 @@
-import { K8sResourceKind, NodeKind } from '@console/internal/module/k8s';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getDeletetionTimestamp } from '@console/shared/src/selectors';
 import { getNodeMaintenancePhase } from '../selectors';
 import {
-  HOST_STATUS_TITLES,
-  HOST_STATUS_UNDER_MAINTENANCE,
-  HOST_STATUS_STOPPING_MAINTENANCE,
-  HOST_STATUS_STARTING_MAINTENANCE,
+  NODE_STATUS_TITLES,
+  NODE_STATUS_UNDER_MAINTENANCE,
+  NODE_STATUS_STOPPING_MAINTENANCE,
+  NODE_STATUS_STARTING_MAINTENANCE,
 } from '../constants';
 import { StatusProps } from '../components/types';
 
-export const getNodeMaintenanceStatus = (
-  maintenance: K8sResourceKind,
-  node: NodeKind,
-): StatusProps => {
-  if (maintenance) {
-    if (getDeletetionTimestamp(maintenance)) {
-      return {
-        status: HOST_STATUS_STOPPING_MAINTENANCE,
-        title: HOST_STATUS_TITLES[HOST_STATUS_STOPPING_MAINTENANCE],
-        maintenance,
-        node,
-      };
-    }
-    if (getNodeMaintenancePhase(maintenance) === 'Succeeded') {
-      return {
-        status: HOST_STATUS_UNDER_MAINTENANCE,
-        title: HOST_STATUS_TITLES[HOST_STATUS_UNDER_MAINTENANCE],
-        maintenance,
-        node,
-      };
-    }
+export const getNodeMaintenanceStatus = (maintenance: K8sResourceKind): StatusProps => {
+  if (!maintenance) return null;
+
+  if (getDeletetionTimestamp(maintenance)) {
     return {
-      status: HOST_STATUS_STARTING_MAINTENANCE,
-      title: HOST_STATUS_TITLES[HOST_STATUS_STARTING_MAINTENANCE],
+      status: NODE_STATUS_STOPPING_MAINTENANCE,
+      title: NODE_STATUS_TITLES[NODE_STATUS_STOPPING_MAINTENANCE],
       maintenance,
-      node,
     };
   }
-  return null;
+  if (getNodeMaintenancePhase(maintenance) === 'Succeeded') {
+    return {
+      status: NODE_STATUS_UNDER_MAINTENANCE,
+      title: NODE_STATUS_TITLES[NODE_STATUS_UNDER_MAINTENANCE],
+      maintenance,
+    };
+  }
+  return {
+    status: NODE_STATUS_STARTING_MAINTENANCE,
+    title: NODE_STATUS_TITLES[NODE_STATUS_STARTING_MAINTENANCE],
+    maintenance,
+  };
 };

--- a/frontend/packages/metal3-plugin/src/utils/host-status.ts
+++ b/frontend/packages/metal3-plugin/src/utils/host-status.ts
@@ -1,53 +1,16 @@
 import { K8sResourceKind, MachineKind, NodeKind } from '@console/internal/module/k8s';
-import { getDeletetionTimestamp } from '@console/shared/src/selectors';
-import {
-  getHostOperationalStatus,
-  getHostProvisioningState,
-  getNodeMaintenancePhase,
-} from '../selectors';
+import { getHostOperationalStatus, getHostProvisioningState } from '../selectors';
 import {
   HOST_STATUS_TITLES,
-  HOST_STATUS_UNDER_MAINTENANCE,
-  HOST_STATUS_STOPPING_MAINTENANCE,
-  HOST_STATUS_READY,
   HOST_STATUS_REGISTRATION_ERROR,
   HOST_STATUS_REGISTERING,
   HOST_STATUS_ERROR,
   HOST_STATUS_PROVISIONING,
   HOST_STATUS_PROVISIONING_ERROR,
-  HOST_STATUS_STARTING_MAINTENANCE,
-  // HOST_STATUS_STARTING_MAINTENANCE,
 } from '../constants';
 import { BareMetalHostStatus } from '../components/types';
 import { BareMetalHostKind } from '../types';
-
-const getMaintenanceStatus = (maintenance: K8sResourceKind, host: BareMetalHostKind) => {
-  if (maintenance) {
-    if (getDeletetionTimestamp(maintenance)) {
-      return {
-        status: HOST_STATUS_STOPPING_MAINTENANCE,
-        title: HOST_STATUS_TITLES[HOST_STATUS_STOPPING_MAINTENANCE],
-        maintenance,
-        host,
-      };
-    }
-    if (getNodeMaintenancePhase(maintenance) === 'Succeeded') {
-      return {
-        status: HOST_STATUS_UNDER_MAINTENANCE,
-        title: HOST_STATUS_TITLES[HOST_STATUS_UNDER_MAINTENANCE],
-        maintenance,
-        host,
-      };
-    }
-    return {
-      status: HOST_STATUS_STARTING_MAINTENANCE,
-      title: HOST_STATUS_TITLES[HOST_STATUS_STARTING_MAINTENANCE],
-      maintenance,
-      host,
-    };
-  }
-  return null;
-};
+import { getNodeMaintenanceStatus } from './node-maintenance-status';
 
 const getBareMetalHostStatus = (host: BareMetalHostKind) => {
   const operationalStatus = getHostOperationalStatus(host);
@@ -85,6 +48,4 @@ type HostStatusProps = {
 };
 
 export const getHostStatus = ({ host, nodeMaintenance }: HostStatusProps): BareMetalHostStatus =>
-  getMaintenanceStatus(nodeMaintenance, host) || getBareMetalHostStatus(host);
-
-export const canHostAddMachine = (status: string): boolean => [HOST_STATUS_READY].includes(status);
+  getNodeMaintenanceStatus(nodeMaintenance, host) || getBareMetalHostStatus(host);

--- a/frontend/packages/metal3-plugin/src/utils/host-status.ts
+++ b/frontend/packages/metal3-plugin/src/utils/host-status.ts
@@ -18,7 +18,7 @@ import {
   HOST_STATUS_STARTING_MAINTENANCE,
   // HOST_STATUS_STARTING_MAINTENANCE,
 } from '../constants';
-import { HostMultiStatus } from '../components/types';
+import { BareMetalHostStatus } from '../components/types';
 import { BareMetalHostKind } from '../types';
 
 const getMaintenanceStatus = (maintenance: K8sResourceKind, host: BareMetalHostKind) => {
@@ -84,7 +84,7 @@ type HostStatusProps = {
   nodeMaintenance?: K8sResourceKind;
 };
 
-export const getHostStatus = ({ host, nodeMaintenance }: HostStatusProps): HostMultiStatus =>
+export const getHostStatus = ({ host, nodeMaintenance }: HostStatusProps): BareMetalHostStatus =>
   getMaintenanceStatus(nodeMaintenance, host) || getBareMetalHostStatus(host);
 
 export const canHostAddMachine = (status: string): boolean => [HOST_STATUS_READY].includes(status);

--- a/frontend/packages/metal3-plugin/src/utils/node-maintenance-status.ts
+++ b/frontend/packages/metal3-plugin/src/utils/node-maintenance-status.ts
@@ -1,0 +1,38 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { getDeletetionTimestamp } from '@console/shared/src/selectors/common';
+import { getNodeMaintenancePhase } from '../selectors';
+import {
+  HOST_STATUS_TITLES,
+  HOST_STATUS_UNDER_MAINTENANCE,
+  HOST_STATUS_STOPPING_MAINTENANCE,
+  HOST_STATUS_STARTING_MAINTENANCE,
+} from '../constants';
+import { BareMetalHostKind } from '../types';
+
+export const getNodeMaintenanceStatus = (maintenance: K8sResourceKind, host: BareMetalHostKind) => {
+  if (maintenance) {
+    if (getDeletetionTimestamp(maintenance)) {
+      return {
+        status: HOST_STATUS_STOPPING_MAINTENANCE,
+        title: HOST_STATUS_TITLES[HOST_STATUS_STOPPING_MAINTENANCE],
+        maintenance,
+        host,
+      };
+    }
+    if (getNodeMaintenancePhase(maintenance) === 'Succeeded') {
+      return {
+        status: HOST_STATUS_UNDER_MAINTENANCE,
+        title: HOST_STATUS_TITLES[HOST_STATUS_UNDER_MAINTENANCE],
+        maintenance,
+        host,
+      };
+    }
+    return {
+      status: HOST_STATUS_STARTING_MAINTENANCE,
+      title: HOST_STATUS_TITLES[HOST_STATUS_STARTING_MAINTENANCE],
+      maintenance,
+      host,
+    };
+  }
+  return null;
+};


### PR DESCRIPTION
Introduces Nodes listing, status, filters and actions enhanced with baremetal information as part of metal3 plugin.

~~Depends on https://github.com/openshift/console/pull/2968~~
Required by https://github.com/openshift/console/pull/3009