### PR TITLE
Bug 1759945: update query for memory utilitzation

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/capacity-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/capacity-card.tsx
@@ -109,7 +109,7 @@ export const CapacityCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
   const MemoryItem = (
     <CapacityItem
       title="Memory"
-      used={getLastStats(memoryUtilization, getRangeVectorStats)}
+      used={getLastStats(memoryUtilization, getInstantVectorStats)}
       total={getLastStats(memoryTotal, getInstantVectorStats)}
       formatValue={humanizeBinaryBytesWithoutB}
       isLoading={!(memoryUtilization && memoryTotal)}

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/queries.ts
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/queries.ts
@@ -17,9 +17,8 @@ export enum OverviewQuery {
 }
 
 const overviewQueries = {
-  [OverviewQuery.MEMORY_TOTAL]: 'sum(kube_node_status_capacity_memory_bytes)',
-  [OverviewQuery.MEMORY_UTILIZATION]:
-    '(sum(kube_node_status_capacity_memory_bytes) - sum(kube_node_status_allocatable_memory_bytes))',
+  [OverviewQuery.MEMORY_TOTAL]: 'sum(node_memory_MemTotal_bytes)',
+  [OverviewQuery.MEMORY_UTILIZATION]: 'sum(node_memory_Active_bytes)',
   [OverviewQuery.NETWORK_TOTAL]: 'sum(avg by(instance)(node_network_speed_bytes))',
   [OverviewQuery.NETWORK_UTILIZATION]:
     'sum(instance:node_network_transmit_bytes_excluding_lo:rate1m+instance:node_network_receive_bytes_excluding_lo:rate1m)',


### PR DESCRIPTION
The current dashboard query calculates memory utilization using
kube_node_status_allocatable_memory_bytes.  This value remains mostly constant
through the life of the cluster so it's not a good indicator of memory
utilization.  This commit changes the query to use
node_memory_Active_bytes which should provide a more accurate estimate
of cluster memory in use.

This also changes the query from a range vector to an instant vector
since only the most recent value is needed for this query.