### PR TITLE
Redirect the Project Details URL properly on masthead changes

### DIFF
--- a/frontend/packages/dev-console/src/components/NamespacedPage.tsx
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.tsx
@@ -13,17 +13,19 @@ export enum NamespacedPageVariants {
 export interface NamespacedPageProps {
   disabled?: boolean;
   hideApplications?: boolean;
+  onNamespaceChange?: (newNamespace: string) => void;
   variant?: NamespacedPageVariants;
 }
 
 const NamespacedPage: React.FC<NamespacedPageProps> = ({
   children,
   disabled,
+  onNamespaceChange,
   hideApplications = false,
   variant = NamespacedPageVariants.default,
 }) => (
   <div className="odc-namespaced-page">
-    <NamespaceBar disabled={disabled}>
+    <NamespaceBar disabled={disabled} onNamespaceChange={onNamespaceChange}>
       {!hideApplications && <ApplicationSelector disabled={disabled} />}
     </NamespaceBar>
     <div

--- a/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
@@ -1,10 +1,24 @@
 import * as React from 'react';
 import { Redirect } from 'react-router';
+import { history } from '@console/internal/components/utils';
 import { ALL_NAMESPACES_KEY } from '@console/internal/const';
 import { ProjectsDetailsPage } from '@console/internal/components/namespace';
 import { ProjectModel } from '@console/internal/models';
 import NamespacedPage, { NamespacedPageVariants } from '../../NamespacedPage';
-import { PROJECT_LIST_URI, useActiveNamespace, UseActiveNamespaceProps } from './utils';
+import {
+  PROJECT_LIST_URI,
+  redirectURI,
+  useActiveNamespace,
+  UseActiveNamespaceProps,
+} from './utils';
+
+const handleNamespaceChange = (newNamespace: string): void => {
+  if (newNamespace === ALL_NAMESPACES_KEY) {
+    return;
+  }
+
+  history.push(redirectURI(newNamespace));
+};
 
 export const ProjectDetailsPage: React.FC<UseActiveNamespaceProps> = ({
   activeNamespace,
@@ -17,7 +31,11 @@ export const ProjectDetailsPage: React.FC<UseActiveNamespaceProps> = ({
   }
 
   return (
-    <NamespacedPage hideApplications variant={NamespacedPageVariants.light}>
+    <NamespacedPage
+      hideApplications
+      variant={NamespacedPageVariants.light}
+      onNamespaceChange={handleNamespaceChange}
+    >
       <ProjectsDetailsPage
         {...props}
         breadcrumbsFor={() => []}

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -502,6 +502,7 @@ class NamespaceBarDropdowns_ extends React.Component {
   render() {
     const {
       activeNamespace,
+      onNamespaceChange,
       setActiveNamespace,
       canListNS,
       useProjects,
@@ -545,6 +546,7 @@ class NamespaceBarDropdowns_ extends React.Component {
           onSubmit: (newProject) => setActiveNamespace(newProject.metadata.name),
         });
       } else {
+        onNamespaceChange && onNamespaceChange(newNamespace);
         setActiveNamespace(newNamespace);
       }
     };
@@ -580,11 +582,15 @@ const NamespaceBarDropdowns = connect(
   namespaceBarDropdownDispatchToProps,
 )(NamespaceBarDropdowns_);
 
-const NamespaceBar_ = ({ useProjects, children, disabled }) => {
+const NamespaceBar_ = ({ useProjects, children, disabled, onNamespaceChange }) => {
   return (
     <div className="co-namespace-bar">
       <Firehose resources={[{ kind: getModel(useProjects).kind, prop: 'namespace', isList: true }]}>
-        <NamespaceBarDropdowns useProjects={useProjects} disabled={disabled}>
+        <NamespaceBarDropdowns
+          useProjects={useProjects}
+          disabled={disabled}
+          onNamespaceChange={onNamespaceChange}
+        >
           {children}
         </NamespaceBarDropdowns>
       </Firehose>
@@ -598,7 +604,7 @@ const namespaceBarStateToProps = ({ k8s }) => {
     useProjects,
   };
 };
-/** @type {React.FC<{children?: ReactNode, disabled?: boolean}>} */
+/** @type {React.FC<{children?: ReactNode, disabled?: boolean, onNamespaceChange?: Function}>} */
 export const NamespaceBar = connect(namespaceBarStateToProps)(NamespaceBar_);
 
 export const NamespacesDetailsPage = (props) => (


### PR DESCRIPTION
Addresses https://jira.coreos.com/browse/ODC-2013

There was an issue that wasn't immediately noticed - when using the Project Details page and you navigated through the secondary masthead to another project your URL wouldn't update. If you were to refresh or change a sub-url (click on a sub page) you'd end up back in the project you just left.

Before Fix (the problem):
![ProjectDetails_BeforeFix](https://user-images.githubusercontent.com/8126518/66837434-fb97a980-ef30-11e9-80ae-07b440c20e51.gif)


After Fix:
![ProjectDetails_AfterFix](https://user-images.githubusercontent.com/8126518/66837046-60063900-ef30-11e9-9255-984625d404b2.gif)
