### PR TITLE
Add network attachment definition creation form

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
@@ -119,14 +119,24 @@ NetworkAttachmentDefinitionsList.displayName = 'NetworkAttachmentDefinitionsList
 
 export const NetworkAttachmentDefinitionsPage: React.FC<NetworkAttachmentDefinitionsPageProps> = (
   props,
-) => (
-  <ListPage
-    {...props}
-    title={NetworkAttachmentDefinitionModel.labelPlural}
-    kind={NetworkAttachmentDefinitionModel.kind}
-    ListComponent={NetworkAttachmentDefinitionsList}
-    filterLabel={props.filterLabel}
-    canCreate
-  />
-);
+) => {
+  const namespace = props.namespace || props.match.params.ns || 'default';
+  const createProps = {
+    to: `/k8s/ns/${namespace}/networkattachmentdefinitions/~new/form`,
+  };
+
+  return (
+    <ListPage
+      {...props}
+      title={NetworkAttachmentDefinitionModel.labelPlural}
+      kind={NetworkAttachmentDefinitionModel.kind}
+      ListComponent={NetworkAttachmentDefinitionsList}
+      filterLabel={props.filterLabel}
+      canCreate
+      createProps={createProps}
+    />
+  );
+};
 NetworkAttachmentDefinitionsPage.displayName = 'NetworkAttachmentDefinitionsPage';
+
+export default NetworkAttachmentDefinitionsPage;

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
@@ -51,7 +51,7 @@ const CreateNetAttachDefYAMLConnected = connectToPlural(
   },
 );
 
-export const CreateNetAttachDefYAML = (props: any) => (
+export default (props: any) => (
   <CreateNetAttachDefYAMLConnected
     {...props as any}
     plural={NetworkAttachmentDefinitionModel.plural}

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -1,0 +1,288 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import * as _ from 'lodash';
+import { Form, FormControl, FormGroup, HelpBlock } from 'patternfly-react';
+import { ActionGroup, Button } from '@patternfly/react-core';
+import { ButtonBar, Dropdown, Firehose, history } from '@console/internal/components/utils';
+import { k8sCreate } from '@console/internal/module/k8s';
+import { validateDNS1123SubdomainValue, ValidationErrorType } from '@console/shared';
+import { NetworkAttachmentDefinitionModel, SriovNetworkNodePolicyModel } from '../..';
+import { NetworkAttachmentDefinitionConfig } from '../../types';
+import { networkTypeParams, networkTypes } from '../../constants';
+import NetworkTypeOptions from './NetworkTypeOptions';
+
+const buildConfig = (name, networkType, typeParamsData): NetworkAttachmentDefinitionConfig => {
+  const config: NetworkAttachmentDefinitionConfig = {
+    name,
+    type: networkType,
+    cniVersion: '0.3.1',
+  };
+
+  _.forOwn(typeParamsData, (val, key) => {
+    config[key] = _.get(val, 'value', null);
+  });
+
+  return config;
+};
+
+const createNetAttachDef = (
+  e: React.FormEvent<EventTarget>,
+  description,
+  name,
+  networkType,
+  typeParamsData,
+  namespace,
+  setError,
+  setLoading,
+) => {
+  e.preventDefault();
+
+  setLoading(true);
+  setError(null);
+
+  const config = JSON.stringify(buildConfig(name, networkType, typeParamsData));
+  const newNetAttachDef = {
+    apiVersion: `${NetworkAttachmentDefinitionModel.apiGroup}/${
+      NetworkAttachmentDefinitionModel.apiVersion
+    }`,
+    kind: NetworkAttachmentDefinitionModel.kind,
+    metadata: {
+      name,
+      namespace,
+      annotations: {
+        description,
+      },
+    },
+    spec: {
+      config,
+    },
+  };
+
+  k8sCreate(NetworkAttachmentDefinitionModel, newNetAttachDef)
+    .then(() => {
+      setLoading(false);
+      history.push(`/k8s/ns/${namespace || 'default'}/networkattachmentdefinitions`);
+    })
+    .catch((err) => {
+      setError(err);
+      setLoading(false);
+      console.error(err); // eslint-disable-line no-console
+    });
+};
+
+const handleNameChange = (enteredName, fieldErrors, setName, setFieldErrors) => {
+  const fieldErrorsUpdate = { ...fieldErrors };
+  delete fieldErrorsUpdate.nameValidationMsg;
+
+  const nameValidation = validateDNS1123SubdomainValue(enteredName);
+  if (_.get(nameValidation, 'type', null) === ValidationErrorType.Error) {
+    fieldErrorsUpdate.nameValidationMsg = nameValidation.message;
+  }
+
+  setName(enteredName);
+  setFieldErrors(fieldErrorsUpdate);
+};
+
+const getNetworkTypes = (hasSriovNetNodePolicyCRD) => {
+  const types = _.clone(networkTypes);
+  if (!hasSriovNetNodePolicyCRD) {
+    delete types.sriov;
+  }
+
+  return types;
+};
+
+const allTypeParamFieldsValid = (typeParamsData) => {
+  return !_.some(typeParamsData, ({ validationMsg }) => validationMsg !== null);
+};
+
+const allRequiredFieldsFilled = (name, networkType, typeParamsData): boolean => {
+  if (_.isEmpty(name) || networkType === null) {
+    return false;
+  }
+
+  const allParamsForType = _.get(networkTypeParams, [networkType]);
+  const requiredKeys = _.keys(allParamsForType).filter((key) =>
+    _.get(allParamsForType, [key, 'required'], false),
+  );
+
+  return _.every(requiredKeys, (key) => {
+    const value = _.get(typeParamsData, [key, 'value']);
+    return !_.isEmpty(value);
+  });
+};
+
+const validateForm = (fieldErrors, name, networkType, typeParamsData, setError) => {
+  setError(null);
+  const nameIsValid = _.get(fieldErrors, 'nameValidationMsg', '') === '';
+
+  return (
+    nameIsValid &&
+    allRequiredFieldsFilled(name, networkType, typeParamsData) &&
+    allTypeParamFieldsValid(typeParamsData)
+  );
+};
+
+const NetworkAttachmentDefinitionFormBase = (props) => {
+  const { loaded, match, resources, hasSriovNetNodePolicyCRD } = props;
+  const namespace = _.get(match, 'params.ns', 'default');
+  const sriovNetNodePoliciesData = _.get(resources, 'sriovnetworknodepolicies.data', []);
+
+  const [loading, setLoading] = React.useState(loaded);
+  const [name, setName] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [networkType, setNetworkType] = React.useState(null);
+  const [typeParamsData, setTypeParamsData] = React.useState({}); // TODO add typing
+  const [error, setError] = React.useState(null);
+  const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({});
+
+  const networkTypeDropdownItems = React.useMemo(() => getNetworkTypes(hasSriovNetNodePolicyCRD), [
+    hasSriovNetNodePolicyCRD,
+  ]);
+
+  const formIsValid = React.useMemo(
+    () => validateForm(fieldErrors, name, networkType, typeParamsData, setError),
+    [fieldErrors, name, networkType, typeParamsData],
+  );
+
+  return (
+    <div className="co-m-pane__body co-m-pane__form">
+      <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
+        <div className="co-m-pane__name">Create Network Attachment Definition</div>
+        <div className="co-m-pane__heading-link">
+          <Link
+            to={`/k8s/ns/${namespace}/networkattachmentdefinitions/~new`}
+            id="yaml-link"
+            replace
+          >
+            Edit YAML
+          </Link>
+        </div>
+      </h1>
+      <Form>
+        <FormGroup
+          fieldId="basic-settings-name"
+          validationState={fieldErrors.nameValidationMsg ? 'error' : null}
+        >
+          <label className="control-label co-required" htmlFor="network-attachment-definition-name">
+            Name
+          </label>
+          <FormControl
+            type="text"
+            bsClass="pf-c-form-control"
+            placeholder={name}
+            id="network-attachment-definition-name"
+            onChange={(e) => handleNameChange(e.target.value, fieldErrors, setName, setFieldErrors)}
+            value={name}
+          />
+          <HelpBlock>{fieldErrors.nameValidationMsg || null}</HelpBlock>
+        </FormGroup>
+
+        <FormGroup fieldId="basic-settings-description">
+          <label htmlFor="network-attachment-definition-description">Description</label>
+          <FormControl
+            type="text"
+            bsClass="pf-c-form-control"
+            id="network-attachment-definition-description"
+            onChange={(e) => setDescription(e.target.value)}
+            value={description}
+          />
+        </FormGroup>
+
+        <FormGroup fieldId="basic-settings-network-type">
+          <label className="control-label co-required" htmlFor="network-type">
+            Network Type
+          </label>
+          <Dropdown
+            id="network-type"
+            title="Network Type"
+            items={networkTypeDropdownItems}
+            dropDownClassName="dropdown--full-width"
+            selectedKey={networkType}
+            onChange={(e) => setNetworkType(e)}
+          />
+        </FormGroup>
+
+        <div className="co-form-subsection">
+          <NetworkTypeOptions
+            networkType={networkType}
+            setTypeParamsData={setTypeParamsData}
+            sriovNetNodePoliciesData={sriovNetNodePoliciesData}
+            typeParamsData={typeParamsData}
+          />
+        </div>
+
+        <ButtonBar errorMessage={error ? error.message : ''} inProgress={loading}>
+          <ActionGroup className="pf-c-form">
+            <Button
+              id="save-changes"
+              isDisabled={!formIsValid}
+              onClick={(e) =>
+                createNetAttachDef(
+                  e,
+                  description,
+                  name,
+                  networkType,
+                  typeParamsData,
+                  namespace,
+                  setError,
+                  setLoading,
+                )
+              }
+              type="submit"
+              variant="primary"
+            >
+              Create
+            </Button>
+            <Button
+              id="cancel"
+              onClick={() =>
+                history.push(`/k8s/ns/${namespace || 'default'}/networkattachmentdefinitions`)
+              }
+              type="button"
+              variant="secondary"
+            >
+              Cancel
+            </Button>
+          </ActionGroup>
+        </ButtonBar>
+      </Form>
+    </div>
+  );
+};
+
+const mapStateToProps = ({ k8s }) => {
+  const kindsInFlight = k8s.getIn(['RESOURCES', 'inFlight']);
+  const k8sModels = k8s.getIn(['RESOURCES', 'models']);
+
+  return {
+    hasSriovNetNodePolicyCRD: !kindsInFlight && !!k8sModels.get(SriovNetworkNodePolicyModel.kind),
+  };
+};
+
+export const ConnectedNetworkAttachmentDefinitionForm = connect(mapStateToProps)(
+  NetworkAttachmentDefinitionFormBase,
+);
+
+const resources = [
+  {
+    model: SriovNetworkNodePolicyModel,
+    kind: SriovNetworkNodePolicyModel.kind,
+    namespace: 'sriov-network-operator',
+    isList: true,
+    prop: 'sriovnetworknodepolicies',
+  },
+];
+
+export default (props) => {
+  return (
+    <Firehose resources={resources}>
+      <ConnectedNetworkAttachmentDefinitionForm {...props} />
+    </Firehose>
+  );
+};
+
+type FieldErrors = {
+  nameValidationMsg?: string;
+};

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkTypeOptions.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkTypeOptions.tsx
@@ -1,0 +1,194 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import * as _ from 'lodash';
+import { FormControl, FormGroup, HelpBlock } from 'patternfly-react';
+import { Dropdown } from '@console/internal/components/utils';
+import { ELEMENT_TYPES, networkTypeParams, NetworkTypeParams } from '../../constants';
+
+const handleTypeParamChange = (
+  paramKey,
+  event,
+  elemType,
+  networkType,
+  setTypeParamsData,
+  typeParamsData,
+) => {
+  const paramsUpdate = { ...typeParamsData };
+
+  if (elemType === ELEMENT_TYPES.CHECKBOX) {
+    paramsUpdate[paramKey] = { value: event.target.checked };
+  } else if (event.target) {
+    paramsUpdate[paramKey] = { value: event.target.value };
+  } else {
+    paramsUpdate[paramKey] = { value: event };
+  }
+
+  _.forOwn(paramsUpdate, (value, key) => {
+    if (key === paramKey) {
+      const validation = _.get(networkTypeParams[networkType], [key, 'validation'], null);
+
+      paramsUpdate[key].validationMsg = validation ? validation(paramsUpdate) : null;
+    }
+  });
+
+  setTypeParamsData(paramsUpdate);
+};
+
+const getSriovNetNodePolicyResourceNames = (sriovNetNodePoliciesData) => {
+  const resourceNames = {};
+
+  sriovNetNodePoliciesData.forEach((policy) => {
+    const resourceName = _.get(policy, 'spec.resourceName', '');
+    if (resourceName !== '') {
+      resourceNames[resourceName] = resourceName;
+    }
+  });
+
+  return resourceNames;
+};
+
+export default (props) => {
+  const { networkType, setTypeParamsData, sriovNetNodePoliciesData, typeParamsData } = props;
+  const params: NetworkTypeParams = networkType && networkTypeParams[networkType];
+
+  if (_.isEmpty(params)) {
+    return null;
+  }
+
+  if (networkType === 'sriov') {
+    params.resourceName.values = getSriovNetNodePolicyResourceNames(sriovNetNodePoliciesData);
+  }
+
+  const dynamicContent = _.map(params, (parameter, key) => {
+    const validationMsg = _.get(typeParamsData, [key, 'validationMsg'], null);
+    const elemType = _.get(parameter, 'type');
+
+    let children;
+    switch (elemType) {
+      case ELEMENT_TYPES.TEXTAREA:
+        children = (
+          <React.Fragment>
+            <label
+              className={classNames('control-label', {
+                'co-required': parameter.required,
+              })}
+            >
+              {_.get(parameter, 'name', key)}
+            </label>
+            <FormControl
+              componentClass={ELEMENT_TYPES.TEXTAREA}
+              bsClass="pf-c-form-control"
+              value={_.get(typeParamsData, `${key}.value`, '')}
+              onChange={(event) =>
+                handleTypeParamChange(
+                  key,
+                  event,
+                  ELEMENT_TYPES.TEXTAREA,
+                  networkType,
+                  setTypeParamsData,
+                  typeParamsData,
+                )
+              }
+            />
+            <HelpBlock>{validationMsg || null}</HelpBlock>
+          </React.Fragment>
+        );
+        break;
+      case ELEMENT_TYPES.CHECKBOX:
+        children = (
+          <React.Fragment>
+            <div className="checkbox">
+              <label>
+                <input
+                  type="checkbox"
+                  className="create-storage-class-form__checkbox"
+                  onChange={(event) =>
+                    handleTypeParamChange(
+                      key,
+                      event,
+                      ELEMENT_TYPES.CHECKBOX,
+                      networkType,
+                      setTypeParamsData,
+                      typeParamsData,
+                    )
+                  }
+                  checked={_.get(typeParamsData, `${key}.value`, false)}
+                  id={`network-type-params-${key}-checkbox`}
+                />
+                {_.get(parameter, 'name', key)}
+              </label>
+            </div>
+            <HelpBlock>{validationMsg || null}</HelpBlock>
+          </React.Fragment>
+        );
+        break;
+      case ELEMENT_TYPES.DROPDOWN:
+        children = (
+          <React.Fragment>
+            <label className={classNames('control-label', { 'co-required': parameter.required })}>
+              {_.get(parameter, 'name', key)}
+            </label>
+            <Dropdown
+              title={parameter.hintText}
+              items={parameter.values}
+              dropDownClassName="dropdown--full-width"
+              selectedKey={_.get(typeParamsData, `${key}.value`)}
+              onChange={(event) =>
+                handleTypeParamChange(
+                  key,
+                  event,
+                  ELEMENT_TYPES.DROPDOWN,
+                  networkType,
+                  setTypeParamsData,
+                  typeParamsData,
+                )
+              }
+            />
+            <HelpBlock>{validationMsg || null}</HelpBlock>
+          </React.Fragment>
+        );
+        break;
+      case ELEMENT_TYPES.TEXT:
+      default:
+        children = (
+          <React.Fragment>
+            <label
+              className={classNames('control-label', {
+                'co-required': parameter.required,
+              })}
+            >
+              {_.get(parameter, 'name', key)}
+            </label>
+            <FormControl
+              type="text"
+              bsClass="pf-c-form-control"
+              value={_.get(typeParamsData, `${key}.value`, '')}
+              onChange={(event) =>
+                handleTypeParamChange(
+                  key,
+                  event,
+                  ELEMENT_TYPES.TEXT,
+                  networkType,
+                  setTypeParamsData,
+                  typeParamsData,
+                )
+              }
+            />
+            <HelpBlock>{validationMsg || null}</HelpBlock>
+          </React.Fragment>
+        );
+    }
+
+    return (
+      <FormGroup
+        key={key}
+        controlId={`network-type-parameters-${key}`}
+        validationState={_.get(typeParamsData, `${key}.validationMsg`, null) ? 'error' : null}
+      >
+        {children}
+      </FormGroup>
+    );
+  });
+
+  return <React.Fragment>{dynamicContent}</React.Fragment>;
+};

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/index.ts
@@ -1,2 +1,2 @@
-export * from './network-attachment-definition';
-export * from './network-attachment-definition-create-yaml';
+export * from './NetworkAttachmentDefinition';
+export * from './NetworkAttachmentDefinitionsForm';

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/types.ts
@@ -18,5 +18,6 @@ export type NetworkAttachmentDefinitionsRowProps = {
 
 export type NetworkAttachmentDefinitionsPageProps = {
   filterLabel: string;
-  namespace: string;
+  namespace?: string;
+  match: any;
 };

--- a/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
@@ -1,1 +1,65 @@
 export const NET_ATTACH_DEF_HEADER_LABEL = 'Create Network Attachment Definition';
+
+export const ELEMENT_TYPES = {
+  CHECKBOX: 'checkbox',
+  DROPDOWN: 'dropdown',
+  TEXT: 'text',
+  TEXTAREA: 'textarea',
+};
+
+export const networkTypes = {
+  sriov: 'SR-IOV',
+  bridge: 'Linux bridge',
+};
+
+export const networkTypeParams: NetworkTypeParamsList = {
+  sriov: {
+    resourceName: {
+      name: 'Resource Name',
+      values: {},
+      required: true,
+      type: ELEMENT_TYPES.DROPDOWN,
+    },
+    vlanTagNum: {
+      name: 'VLAN Tag Number',
+      hintText: 'Ex: 100',
+      type: ELEMENT_TYPES.TEXT,
+    },
+    ipam: {
+      name: 'IP Address Management',
+      type: ELEMENT_TYPES.TEXTAREA,
+    },
+  },
+  bridge: {
+    bridgeName: {
+      name: 'Bridge Name',
+      required: true,
+      type: ELEMENT_TYPES.TEXT,
+    },
+    vlanTagNum: {
+      name: 'VLAN Tag Number',
+      hintText: 'Ex: 100',
+      type: ELEMENT_TYPES.TEXT,
+    },
+    ipam: {
+      name: 'IP Address Management',
+      type: ELEMENT_TYPES.TEXTAREA,
+    },
+  },
+};
+
+type NetworkTypeParamsList = {
+  [key: string]: NetworkTypeParams;
+};
+
+export type NetworkTypeParams = {
+  [key: string]: NetworkTypeParameter;
+};
+
+export type NetworkTypeParameter = {
+  name: string;
+  required?: boolean;
+  type: string;
+  hintText?: string;
+  values?: { [key: string]: string };
+};

--- a/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
@@ -11,3 +11,15 @@ export const NetworkAttachmentDefinitionModel: K8sKind = {
   kind: 'NetworkAttachmentDefinition',
   id: 'network-attachment-definition',
 };
+
+export const SriovNetworkNodePolicyModel: K8sKind = {
+  label: 'SR-IOV Network Node Policy',
+  labelPlural: 'SR-IOV Network Node Policies',
+  apiVersion: 'v1',
+  apiGroup: 'sriovnetwork.openshift.io',
+  plural: 'sriovnetworknodepolicies',
+  namespaced: true,
+  abbr: 'SRNNPM', // TODO check on this
+  kind: 'SriovNetworkNodePolicy',
+  id: 'sriov-network-node-policy',
+};

--- a/frontend/packages/network-attachment-definition-plugin/src/models/templates/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/models/templates/index.ts
@@ -12,7 +12,7 @@ metadata:
   name: example
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.3.1",
     "name": "a-bridge-network",
     "type": "bridge",
     "bridge": "br0",

--- a/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
@@ -53,7 +53,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       model: models.NetworkAttachmentDefinitionModel,
       loader: () =>
         import(
-          './components/network-attachment-definitions/network-attachment-definition' /* webpackChunkName: "network-attachment-definitions" */
+          './components/network-attachment-definitions/NetworkAttachmentDefinition' /* webpackChunkName: "network-attachment-definitions" */
         ).then((m) => m.NetworkAttachmentDefinitionsPage),
     },
   },
@@ -64,8 +64,8 @@ const plugin: Plugin<ConsumedExtensions> = [
       path: ['/k8s/ns/:ns/networkattachmentdefinitions/~new'],
       loader: () =>
         import(
-          './components/network-attachment-definitions' /* webpackChunkName: "network-attachment-definitions" */
-        ).then((m) => m.CreateNetAttachDefYAML),
+          './components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml' /* webpackChunkName: "network-attachment-definitions" */
+        ).then((m) => m.default),
     },
   },
   {
@@ -73,6 +73,31 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       model: models.NetworkAttachmentDefinitionModel,
       template: NetworkAttachmentDefinitionsYAMLTemplates.getIn(['default']),
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: ['/k8s/ns/:ns/networkattachmentdefinitions/~new/form'],
+      loader: () =>
+        import(
+          './components/network-attachment-definitions/NetworkAttachmentDefinitionsForm' /* webpackChunkName: "network-attachment-definitions" */
+        ).then((m) => m.default),
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: [
+        '/k8s/ns/:ns/networkattachmentdefinitions',
+        '/k8s/all-namespaces/networkattachmentdefinitions',
+      ],
+      loader: () =>
+        import(
+          './components/network-attachment-definitions' /* webpackChunkName: "network-attachment-definitions" */
+        ).then((m) => m.NetworkAttachmentDefinitionsPage),
     },
   },
 ];

--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -7,9 +7,9 @@ export type IPAMConfig = {
 };
 
 export type NetworkAttachmentDefinitionConfig = {
-  cniVersion?: string;
-  name?: string;
-  type?: string;
+  cniVersion: string;
+  name: string;
+  type: string;
   bridge?: string;
   isGateway?: true;
   ipam?: IPAMConfig;


### PR DESCRIPTION
This PR adds a form for creating network attachment definitions.

![Selection_614](https://user-images.githubusercontent.com/8544299/67058388-9acfc300-f122-11e9-801a-24674d39e252.png)

Linux bridge screenshot:
![OKD - Google Chrome_617](https://user-images.githubusercontent.com/8544299/67492154-fbd82900-f643-11e9-8262-85a2d68bb329.png)

SR-IOV screenshot 1:
![OKD - Google Chrome_618](https://user-images.githubusercontent.com/8544299/67502394-d0f5d100-f653-11e9-9c55-1df9d96450e4.png)

SR-IOV screenshot 2 (showing the "Resource Name" dropdown opened):
![OKD - Google Chrome_619](https://user-images.githubusercontent.com/8544299/67502426-dd7a2980-f653-11e9-911e-57a1fc357698.png)
