### PR TITLE
Add popover help to more details pages

### DIFF
--- a/frontend/__tests__/components/route-pages.spec.tsx
+++ b/frontend/__tests__/components/route-pages.spec.tsx
@@ -3,11 +3,11 @@ import { shallow, mount } from 'enzyme';
 
 import { RouteLocation, RouteStatus } from '../../public/components/routes';
 import { ExternalLink } from '../../public/components/utils';
-import { K8sResourceKind } from '../../public/module/k8s';
+import { RouteKind } from '../../public/module/k8s';
 
 describe(RouteLocation.displayName, () => {
   it('renders a https link when TLS Settings', () => {
-    const route: K8sResourceKind = {
+    const route: RouteKind = {
       apiVersion: 'v1',
       kind: 'Route',
       metadata: {
@@ -19,6 +19,11 @@ describe(RouteLocation.displayName, () => {
           termination: 'edge',
         },
         wildcardPolicy: 'None',
+        to: {
+          kind: 'Service',
+          name: 'my-service',
+          weight: 100,
+        },
       },
       status: {
         ingress: [
@@ -42,7 +47,7 @@ describe(RouteLocation.displayName, () => {
   });
 
   it('renders a http link when no TLS Settings', () => {
-    const route: K8sResourceKind = {
+    const route: RouteKind = {
       apiVersion: 'v1',
       kind: 'Route',
       metadata: {
@@ -51,6 +56,11 @@ describe(RouteLocation.displayName, () => {
       spec: {
         host: 'www.example.com',
         wildcardPolicy: 'None',
+        to: {
+          kind: 'Service',
+          name: 'my-service',
+          weight: 100,
+        },
       },
       status: {
         ingress: [
@@ -73,8 +83,8 @@ describe(RouteLocation.displayName, () => {
     expect(wrapper.find(ExternalLink).props().href).toContain('http:');
   });
 
-  it('renders additional path in url', () => {
-    const route: K8sResourceKind = {
+  it('renders oldest admitted ingress', () => {
+    const route: RouteKind = {
       apiVersion: 'v1',
       kind: 'Route',
       metadata: {
@@ -84,6 +94,59 @@ describe(RouteLocation.displayName, () => {
         host: 'www.example.com',
         path: '\\mypath',
         wildcardPolicy: 'None',
+        to: {
+          kind: 'Service',
+          name: 'my-service',
+          weight: 100,
+        },
+      },
+      status: {
+        ingress: [
+          {
+            host: 'newer.example.com',
+            conditions: [
+              {
+                type: 'Admitted',
+                status: 'True',
+                lastTransitionTime: '2019-04-30T16:55:48Z',
+              },
+            ],
+          },
+          {
+            host: 'www.example.com',
+            conditions: [
+              {
+                type: 'Admitted',
+                status: 'True',
+                lastTransitionTime: '2018-04-30T16:55:48Z',
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const wrapper = shallow(<RouteLocation obj={route} />);
+    expect(wrapper.find(ExternalLink).exists()).toBe(true);
+    expect(wrapper.find(ExternalLink).props().href).toContain('http://www.example.com');
+  });
+
+  it('renders additional path in url', () => {
+    const route: RouteKind = {
+      apiVersion: 'v1',
+      kind: 'Route',
+      metadata: {
+        name: 'example',
+      },
+      spec: {
+        host: 'www.example.com',
+        path: '\\mypath',
+        wildcardPolicy: 'None',
+        to: {
+          kind: 'Service',
+          name: 'my-service',
+          weight: 100,
+        },
       },
       status: {
         ingress: [
@@ -107,7 +170,7 @@ describe(RouteLocation.displayName, () => {
   });
 
   it('renders Subdomain', () => {
-    const route: K8sResourceKind = {
+    const route: RouteKind = {
       apiVersion: 'v1',
       kind: 'Route',
       metadata: {
@@ -116,6 +179,11 @@ describe(RouteLocation.displayName, () => {
       spec: {
         host: 'www.example.com',
         wildcardPolicy: 'Subdomain',
+        to: {
+          kind: 'Service',
+          name: 'my-service',
+          weight: 100,
+        },
       },
       status: {
         ingress: [
@@ -139,7 +207,7 @@ describe(RouteLocation.displayName, () => {
   });
 
   it('renders non-admitted label', () => {
-    const route: K8sResourceKind = {
+    const route: RouteKind = {
       apiVersion: 'v1',
       kind: 'Route',
       metadata: {
@@ -148,6 +216,11 @@ describe(RouteLocation.displayName, () => {
       spec: {
         host: 'www.example.com',
         wildcardPolicy: 'None',
+        to: {
+          kind: 'Service',
+          name: 'my-service',
+          weight: 100,
+        },
       },
       status: {
         ingress: [
@@ -173,11 +246,18 @@ describe(RouteLocation.displayName, () => {
 
 describe(RouteStatus.displayName, () => {
   it('renders Accepted status', () => {
-    const route: K8sResourceKind = {
+    const route: RouteKind = {
       apiVersion: 'v1',
       kind: 'Route',
       metadata: {
         name: 'example',
+      },
+      spec: {
+        to: {
+          kind: 'Service',
+          name: 'my-service',
+          weight: 100,
+        },
       },
       status: {
         ingress: [
@@ -201,11 +281,18 @@ describe(RouteStatus.displayName, () => {
   });
 
   it('renders Rejected status', () => {
-    const route: K8sResourceKind = {
+    const route: RouteKind = {
       apiVersion: 'v1',
       kind: 'Route',
       metadata: {
         name: 'example',
+      },
+      spec: {
+        to: {
+          kind: 'Service',
+          name: 'my-service',
+          weight: 100,
+        },
       },
       status: {
         ingress: [
@@ -229,11 +316,18 @@ describe(RouteStatus.displayName, () => {
   });
 
   it('renders Pending status', () => {
-    const route: K8sResourceKind = {
+    const route: RouteKind = {
       apiVersion: 'v1',
       kind: 'Route',
       metadata: {
         name: 'example',
+      },
+      spec: {
+        to: {
+          kind: 'Service',
+          name: 'my-service',
+          weight: 100,
+        },
       },
     };
 

--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -1,4 +1,4 @@
-import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, PodKind, RouteKind } from '@console/internal/module/k8s';
 import { DEPLOYMENT_STRATEGY } from '../constants';
 
 export type OverviewItemAlerts = {
@@ -28,7 +28,7 @@ export type OverviewItem = {
   obj: K8sResourceKind;
   pods?: PodKind[];
   previous?: PodControllerOverviewItem;
-  routes: K8sResourceKind[];
+  routes: RouteKind[];
   services: K8sResourceKind[];
   status?: React.ReactNode;
   ksroutes?: K8sResourceKind[];

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -1,10 +1,11 @@
 import * as _ from 'lodash';
 import {
   K8sResourceKind,
-  apiVersionForModel,
-  PodTemplate,
   LabelSelector,
   PodKind,
+  PodTemplate,
+  RouteKind,
+  apiVersionForModel,
 } from '@console/internal/module/k8s';
 import {
   DeploymentConfigModel,
@@ -553,7 +554,7 @@ export class TransformResourceData {
     }
   };
 
-  getRoutesForServices = (services: K8sResourceKind[]): K8sResourceKind[] => {
+  getRoutesForServices = (services: K8sResourceKind[]): RouteKind[] => {
     const { routes } = this.resources;
     return _.filter(routes.data, (route) => {
       const name = _.get(route, 'spec.to.name');

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { K8sResourceKind, modelFor } from '@console/internal/module/k8s';
+import { K8sResourceKind, modelFor, RouteKind } from '@console/internal/module/k8s';
 import { getRouteWebURL } from '@console/internal/components/routes';
 import {
   TransformResourceData,
@@ -59,7 +59,7 @@ const getRouteData = (ksroute: K8sResourceKind[]): string => {
 /**
  * get routes url
  */
-const getRoutesUrl = (routes: K8sResourceKind[], ksroute?: K8sResourceKind[]): string => {
+const getRoutesUrl = (routes: RouteKind[], ksroute?: K8sResourceKind[]): string => {
   if (routes.length > 0 && !_.isEmpty(routes[0].spec)) {
     return getRouteWebURL(routes[0]);
   }

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -10,7 +10,7 @@ import { coFetchJSON } from '../../co-fetch';
 import { PROMETHEUS_TENANCY_BASE_PATH } from '../graphs';
 import { TextFilter } from '../factory';
 import * as UIActions from '../../actions/ui';
-import { K8sResourceKind, PodKind } from '../../module/k8s';
+import { K8sResourceKind, PodKind, RouteKind } from '../../module/k8s';
 import { CloseButton, Dropdown, Firehose, StatusBox, FirehoseResult, MsgBox } from '../utils';
 
 import { ProjectOverview } from './project-overview';
@@ -564,7 +564,7 @@ type OverviewMainContentOwnProps = {
   project?: FirehoseResult<K8sResourceKind>;
   replicationControllers?: FirehoseResult;
   replicaSets?: FirehoseResult;
-  routes?: FirehoseResult;
+  routes?: FirehoseResult<RouteKind[]>;
   services?: FirehoseResult;
   selectedItem: OverviewItem;
   statefulSets?: FirehoseResult;

--- a/frontend/public/components/overview/networking-overview.tsx
+++ b/frontend/public/components/overview/networking-overview.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { ListGroup } from 'patternfly-react';
 import { LongArrowAltRightIcon } from '@patternfly/react-icons';
 
-import { K8sResourceKind } from '../../module/k8s';
+import { K8sResourceKind, RouteKind } from '../../module/k8s';
 import { RouteLocation } from '../routes';
 import { ResourceLink, SidebarSectionHeading } from '../utils';
 
@@ -82,15 +82,15 @@ export const NetworkingOverview: React.SFC<NetworkingOverviewProps> = ({ routes,
 };
 
 type RoutesOverviewListProps = {
-  routes: K8sResourceKind[];
+  routes: RouteKind[];
 };
 
 type RoutesOverviewListItemProps = {
-  route: K8sResourceKind;
+  route: RouteKind;
 };
 
 type NetworkingOverviewProps = {
-  routes: K8sResourceKind[];
+  routes: RouteKind[];
   services: K8sResourceKind[];
 };
 

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -5,15 +5,16 @@ import { sortable } from '@patternfly/react-table';
 
 import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
 import {
+  DetailsItem,
   Kebab,
-  navFactory,
   LabelList,
-  ResourceKebab,
-  SectionHeading,
   ResourceIcon,
+  ResourceKebab,
   ResourceLink,
   ResourceSummary,
+  SectionHeading,
   Selector,
+  navFactory,
 } from './utils';
 import { ServiceModel } from '../models';
 
@@ -233,8 +234,7 @@ const Details = ({ obj: s }) => (
       <div className="col-sm-6">
         <SectionHeading text="Service Overview" />
         <ResourceSummary resource={s} showPodSelector>
-          <dt>Session Affinity</dt>
-          <dd>{s.spec.sessionAffinity || '-'}</dd>
+          <DetailsItem label="Session Affinity" obj={s} path="spec.sessionAffinity" />
         </ResourceSummary>
       </div>
       <div className="col-sm-6">
@@ -244,10 +244,11 @@ const Details = ({ obj: s }) => (
           <dd className="service-ips">
             <ServiceAddress s={s} />
           </dd>
-          <dt>Service Port Mapping</dt>
-          <dd className="service-ips">
-            {s.spec.ports ? <ServicePortMapping ports={s.spec.ports} /> : '-'}
-          </dd>
+          <DetailsItem label="Service Port Mapping" obj={s} path="spec.ports">
+            <div className="service-ips">
+              {s.spec.ports ? <ServicePortMapping ports={s.spec.ports} /> : '-'}
+            </div>
+          </DetailsItem>
         </dl>
       </div>
     </div>

--- a/frontend/public/components/utils/copy-to-clipboard.tsx
+++ b/frontend/public/components/utils/copy-to-clipboard.tsx
@@ -39,7 +39,7 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = React.memo((props
 
 export type CopyToClipboardProps = {
   value: string;
-  visibleValue?: string;
+  visibleValue?: React.ReactNode;
 };
 
 CopyToClipboard.displayName = 'CopyToClipboard';

--- a/frontend/public/components/utils/details-item.tsx
+++ b/frontend/public/components/utils/details-item.tsx
@@ -29,18 +29,28 @@ const PropertyPath: React.FC<{ kind: string; path: string | string[] }> = ({ kin
   );
 };
 
-export const DetailsItem: React.FC<DetailsItemProps> = ({ label, obj, path, children }) => {
+export const DetailsItem: React.FC<DetailsItemProps> = ({
+  label,
+  obj,
+  path,
+  defaultValue = '-',
+  children,
+}) => {
   const reference: K8sResourceKindReference = referenceFor(obj);
   const model: K8sKind = modelFor(reference);
   const description: string = getPropertyDescription(model, path);
-  const value: React.ReactNode = children || _.get(obj, path) || '-';
+  const value: React.ReactNode = children || _.get(obj, path, defaultValue);
   return (
     <>
       <dt>
         {description ? (
           <Popover
             headerContent={<div>{label}</div>}
-            bodyContent={<LinkifyExternal>{description}</LinkifyExternal>}
+            bodyContent={
+              <LinkifyExternal>
+                <div className="co-pre-line">{description}</div>
+              </LinkifyExternal>
+            }
             footerContent={<PropertyPath kind={model.kind} path={path} />}
             maxWidth="30rem"
           >
@@ -61,5 +71,6 @@ export type DetailsItemProps = {
   label: string;
   obj: K8sResourceKind;
   path: string | string[];
+  defaultValue?: React.ReactNode;
   children?: React.ReactNode;
 };

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -136,10 +136,8 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({
 
 export const ResourcePodCount: React.SFC<ResourcePodCountProps> = ({ resource }) => (
   <dl>
-    <dt>Current Count</dt>
-    <dd>{resource.status.replicas || 0}</dd>
-    <dt>Desired Count</dt>
-    <dd>{resource.spec.replicas || 0}</dd>
+    <DetailsItem label="Current Count" obj={resource} path="status.replicas" defaultValue="0" />
+    <DetailsItem label="Desired Count" obj={resource} path="spec.replicas" defaultValue="0" />
   </dl>
 );
 

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -372,6 +372,47 @@ export type CustomResourceDefinitionKind = {
   };
 } & K8sResourceKind;
 
+export type RouteTarget = {
+  kind: 'Service';
+  name: string;
+  weight: number;
+};
+
+export type RouteTLS = {
+  caCertificate?: string;
+  certificate?: string;
+  destinationCACertificate?: string;
+  insecureEdgeTerminationPolicy?: string;
+  key?: string;
+  termination: string;
+};
+
+export type RouteIngress = {
+  conditions: any[];
+  host?: string;
+  routerCanonicalHostname?: string;
+  routerName?: string;
+  wildcardPolicy?: string;
+};
+
+export type RouteKind = {
+  spec: {
+    alternateBackends?: RouteTarget[];
+    host?: string;
+    path?: string;
+    port?: {
+      targetPort: number | string;
+    };
+    subdomain?: string;
+    tls?: RouteTLS;
+    to: RouteTarget;
+    wildcardPolicy?: string;
+  };
+  status?: {
+    ingress: RouteIngress[];
+  };
+} & K8sResourceKind;
+
 export type TemplateParameter = {
   name: string;
   value?: string;


### PR DESCRIPTION
Show API documentation popovers on the following details pages:

* DeploymentConfig
* ReplicaSet
* ReplicationController
* Service
* Route

Also improves type checking for routes.

/assign @rhamilto @TheRealJon  