### PR TITLE
Bug 1762217: Bump kubevirt-web-ui-components v0.1.48

### DIFF
--- a/frontend/packages/kubevirt-plugin/package.json
+++ b/frontend/packages/kubevirt-plugin/package.json
@@ -10,7 +10,7 @@
     "@console/internal": "0.0.0-fixed",
     "@console/plugin-sdk": "0.0.0-fixed",
     "@console/shared": "0.0.0-fixed",
-    "kubevirt-web-ui-components": "0.1.45"
+    "kubevirt-web-ui-components": "0.1.48"
   },
   "consolePlugin": {
     "entry": "src/plugin.tsx"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7398,10 +7398,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
-kubevirt-web-ui-components@0.1.45:
-  version "0.1.45"
-  resolved "https://registry.yarnpkg.com/kubevirt-web-ui-components/-/kubevirt-web-ui-components-0.1.45.tgz#600569cec9662cd178f62e80f4621aee9d211696"
-  integrity sha512-BLGbsYDR95WgGrT9RmrejRXCKdV0e7YBSN3RsuGzOMmXceWJ/VdlKFPFZUpCJ8g9BKqRxHMXFxBd3w/qRqQuNQ==
+kubevirt-web-ui-components@0.1.48:
+  version "0.1.48"
+  resolved "https://registry.yarnpkg.com/kubevirt-web-ui-components/-/kubevirt-web-ui-components-0.1.48.tgz#2cf6a4f56b5235e57bbf923fe60d11cb08a67b92"
+  integrity sha512-xecpo+oGDkFegpf/QsSEklJiGdfMlY90Nd+i65blV5DG7SgSOUAiEUMmDb3QCWhY6uNSuHIieO/6v1BVOAZ7yQ==
   dependencies:
     "@patternfly/react-console" "1.x"
     babel-plugin-transform-es2015-modules-umd "6.24.1"


### PR DESCRIPTION
Changelog: https://github.com/kubevirt/web-ui-components/releases/tag/v0.1.48

---
Note for reviewer: to fix BZ 1762217 in `4.2.z`, this PR needs to be backported once merged to master. 
Unfortunately, versions of this dependency have diverged between openshift/console's `master` and `4.2` branch.

To avoid introduction of additional changes in z-stream except those needed to fix just the single BZ issue, there will be
- new web-ui-components `v0.1.44.1` release created, based on the existing `v0.1.44` + https://github.com/kubevirt/web-ui-components/pull/557 + https://github.com/kubevirt/web-ui-components/pull/561
- new PR referencing the `v0.1.44.1` for openshift/console to `release-4.2` branch pushed