### PR TITLE
cmd/bridge: configure Thanos service

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -30,11 +30,18 @@ const (
 	k8sInClusterCA          = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	k8sInClusterBearerToken = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
-	// Well-known location of Prometheus service for OpenShift. This is only accessible in-cluster.
+	// Well-known location of the cluster monitoring (not user workload monitoring) Prometheus service for OpenShift.
+	// This is only accessible in-cluster. This is used for non-tenant global (alerting) rules requests.
 	openshiftPrometheusHost = "prometheus-k8s.openshift-monitoring.svc:9091"
 
-	// The tenancy service port (9092) performs RBAC checks for namespace-specific queries.
-	openshiftPrometheusTenancyHost = "prometheus-k8s.openshift-monitoring.svc:9092"
+	// Well-known location of the tenant aware Thanos service for OpenShift. This is only accessible in-cluster.
+	// Thanos proxies requests to both cluster monitoring and user workload monitoring prometheus instances.
+	openshiftThanosTenancyHost = "thanos-querier.openshift-monitoring.svc:9092"
+
+	// Well-known location of the Thanos service for OpenShift. This is only accessible in-cluster.
+	// This is used for non-tenant global query requests
+	// proxying to both cluster monitoring and user workload monitoring prometheus instances.
+	openshiftThanosHost = "thanos-querier.openshift-monitoring.svc:9091"
 
 	// Well-known location of Alert Manager service for OpenShift. This is only accessible in-cluster.
 	openshiftAlertManagerHost = "alertmanager-main.openshift-monitoring.svc:9094"
@@ -69,6 +76,7 @@ func main() {
 	fK8sModeOffClusterEndpoint := fs.String("k8s-mode-off-cluster-endpoint", "", "URL of the Kubernetes API server.")
 	fK8sModeOffClusterSkipVerifyTLS := fs.Bool("k8s-mode-off-cluster-skip-verify-tls", false, "DEV ONLY. When true, skip verification of certs presented by k8s API server.")
 	fK8sModeOffClusterPrometheus := fs.String("k8s-mode-off-cluster-prometheus", "", "DEV ONLY. URL of the cluster's Prometheus server.")
+	fK8sModeOffClusterThanos := fs.String("k8s-mode-off-cluster-thanos", "", "DEV ONLY. URL of the cluster's Prometheus server.")
 	fK8sModeOffClusterAlertmanager := fs.String("k8s-mode-off-cluster-alertmanager", "", "DEV ONLY. URL of the cluster's AlertManager server.")
 	fK8sModeOffClusterMetering := fs.String("k8s-mode-off-cluster-metering", "", "DEV ONLY. URL of the cluster's metering server.")
 
@@ -270,10 +278,15 @@ func main() {
 				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
 				Endpoint:        &url.URL{Scheme: "https", Host: openshiftPrometheusHost, Path: "/api"},
 			}
-			srv.PrometheusTenancyProxyConfig = &proxy.Config{
+			srv.ThanosProxyConfig = &proxy.Config{
 				TLSClientConfig: serviceProxyTLSConfig,
 				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
-				Endpoint:        &url.URL{Scheme: "https", Host: openshiftPrometheusTenancyHost, Path: "/api"},
+				Endpoint:        &url.URL{Scheme: "https", Host: openshiftThanosHost, Path: "/api"},
+			}
+			srv.ThanosTenancyProxyConfig = &proxy.Config{
+				TLSClientConfig: serviceProxyTLSConfig,
+				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
+				Endpoint:        &url.URL{Scheme: "https", Host: openshiftThanosTenancyHost, Path: "/api"},
 			}
 			srv.AlertManagerProxyConfig = &proxy.Config{
 				TLSClientConfig: serviceProxyTLSConfig,
@@ -306,10 +319,18 @@ func main() {
 				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
 				Endpoint:        offClusterPrometheusURL,
 			}
-			srv.PrometheusTenancyProxyConfig = &proxy.Config{
+
+			offClusterThanosURL := bridge.ValidateFlagIsURL("k8s-mode-off-thanos-prometheus", *fK8sModeOffClusterThanos)
+			offClusterThanosURL.Path = "/api"
+			srv.ThanosTenancyProxyConfig = &proxy.Config{
 				TLSClientConfig: serviceProxyTLSConfig,
 				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
-				Endpoint:        offClusterPrometheusURL,
+				Endpoint:        offClusterThanosURL,
+			}
+			srv.ThanosProxyConfig = &proxy.Config{
+				TLSClientConfig: serviceProxyTLSConfig,
+				HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
+				Endpoint:        offClusterThanosURL,
 			}
 		}
 


### PR DESCRIPTION
This enables console to pass requests to Thanos rather than Prometheus
and enables user workload monitoring, if enabled.

/cc @kyoto @paulfantom @LiliC 