### PR TITLE
CONSOLE-1786: Operands' dynamic "Creation Form" not rendered correctly if no `specDescriptors` exist

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
@@ -191,9 +191,11 @@ const fieldsForOpenAPI = (openAPI: SwaggerDefinition): OperandField[] => {
 };
 
 export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
-  const fields: OperandField[] = (!_.isEmpty(props.clusterServiceVersion)
+  const fields: OperandField[] = (!_.isEmpty(
+    props.clusterServiceVersion && props.providedAPI.specDescriptors,
+  )
     ? fieldsFor(props.providedAPI)
-    : []
+    : fieldsForOpenAPI(props.openAPI)
   )
     .map((field) => {
       const capabilities = field.capabilities || [];


### PR DESCRIPTION
/assign @spadgett 