### PR TITLE
Add network attachment definitions details page

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import {
+  // Firehose,
+  ScrollToTopOnMount,
+  SectionHeading,
+  StatusBox,
+} from '@console/internal/components/utils';
+import { getName, getUID } from '@console/shared/src';
+import { getConfigAsJSON, getDescription, getType } from '../../selectors';
+import { networkTypes } from '../../constants';
+import { NetworkAttachmentDefinitionKind } from '../../types';
+
+const NET_ATTACH_DEF_OVERVIEW_HEADING = 'Network Attachment Definition Overview';
+
+export const prefixedID = (idPrefix: string, id: string) =>
+  idPrefix && id ? `${idPrefix}-${id}` : null;
+
+export const DetailsItem: React.FC<DetailsItemProps> = ({
+  title,
+  isNotAvail = false,
+  valueClassName,
+  children,
+}) => {
+  return (
+    <>
+      <dt>{title}</dt>
+      <dd className={valueClassName}>
+        {isNotAvail ? <span className="text-secondary">Not available</span> : children}
+      </dd>
+    </>
+  );
+};
+
+export const NetAttachDefinitionSummary: React.FC<NetAttachDefinitionSummaryProps> = ({
+  netAttachDef,
+}) => {
+  const name = getName(netAttachDef);
+  const description = getDescription(netAttachDef);
+  const type = getType(getConfigAsJSON(netAttachDef));
+  const id = getUID(netAttachDef);
+
+  return (
+    <>
+      <DetailsItem title="Name" idValue={prefixedID(id, 'name')} isNotAvail={!name}>
+        {name}
+      </DetailsItem>
+
+      <DetailsItem
+        title="Description"
+        idValue={prefixedID(id, 'description')}
+        isNotAvail={!description}
+      >
+        {description}
+      </DetailsItem>
+
+      <DetailsItem title="Type" idValue={prefixedID(id, 'type')} isNotAvail={!type}>
+        {_.get(networkTypes, [type], null) || type}
+      </DetailsItem>
+    </>
+  );
+};
+
+export const NetworkAttachmentDefinitionDetails: React.FC<NetAttachDefDetailsProps> = (props) => {
+  const { netAttachDef } = props;
+
+  return (
+    <div className="co-m-pane__body">
+      <StatusBox data={netAttachDef} loaded={!!netAttachDef}>
+        <ScrollToTopOnMount />
+        <div className="co-m-pane__body">
+          <SectionHeading text={NET_ATTACH_DEF_OVERVIEW_HEADING} />
+          <div className="row">
+            <div className="col-sm-6">
+              <NetAttachDefinitionSummary netAttachDef={netAttachDef} />
+            </div>
+          </div>
+        </div>
+      </StatusBox>
+    </div>
+  );
+};
+
+type NetAttachDefinitionSummaryProps = {
+  netAttachDef: NetworkAttachmentDefinitionKind;
+};
+
+type NetAttachDefDetailsProps = {
+  netAttachDef: NetworkAttachmentDefinitionKind;
+};
+
+type DetailsItemProps = {
+  title: string;
+  idValue?: string;
+  isNotAvail?: boolean;
+  valueClassName?: string;
+  children: React.ReactNode;
+};
+
+export default NetworkAttachmentDefinitionDetails;

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetailsPage.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetailsPage.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { getResource } from '@console/kubevirt-plugin/src/utils';
+import { DetailsPage } from '@console/internal/components/factory';
+import { Kebab, navFactory } from '@console/internal/components/utils';
+import { K8sResourceKindReference } from '@console/internal/module/k8s';
+import { NetworkAttachmentDefinitionModel } from '../..';
+import { NetworkAttachmentDefinitionDetails } from './NetworkAttachmentDefinitionDetails';
+
+const { common } = Kebab.factory;
+const menuActions = [
+  ...Kebab.getExtensionsActionsForKind(NetworkAttachmentDefinitionModel),
+  ...common,
+];
+
+export const NetworkAttachmentDefinitionsDetailsPage: React.FC<
+  NetworkAttachmentDefinitionsDetailPageProps
+> = (props) => {
+  const { name, namespace } = props;
+
+  const resources = [
+    getResource(NetworkAttachmentDefinitionModel, {
+      name,
+      namespace,
+      isList: false,
+      prop: 'netAttachDef',
+      optional: true,
+    }),
+  ];
+
+  const overviewPage = {
+    href: '', // default landing page
+    name: 'Overview',
+    component: NetworkAttachmentDefinitionDetails,
+  };
+
+  const pages = [overviewPage, navFactory.editYaml()];
+
+  return <DetailsPage {...props} pages={pages} resources={resources} menuActions={menuActions} />;
+};
+
+type NetworkAttachmentDefinitionsDetailPageProps = {
+  name: string;
+  namespace: string;
+  kind: K8sResourceKindReference;
+  match: any;
+};
+
+export default NetworkAttachmentDefinitionsDetailsPage;

--- a/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import {
   Plugin,
   ResourceNSNavItem,
+  ResourceDetailsPage,
   ResourceListPage,
   ModelFeatureFlag,
   YAMLTemplate,
@@ -13,6 +14,7 @@ import { NetworkAttachmentDefinitionsYAMLTemplates } from './models/templates';
 
 type ConsumedExtensions =
   | ResourceNSNavItem
+  | ResourceDetailsPage
   | ResourceListPage
   | ModelFeatureFlag
   | YAMLTemplate
@@ -55,6 +57,16 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/network-attachment-definitions/NetworkAttachmentDefinition' /* webpackChunkName: "network-attachment-definitions" */
         ).then((m) => m.NetworkAttachmentDefinitionsPage),
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: models.NetworkAttachmentDefinitionModel,
+      loader: () =>
+        import(
+          './components/network-attachment-definitions/NetworkAttachmentDefinitionDetailsPage' /* webpackChunkName: "kubevirt" */
+        ).then((m) => m.NetworkAttachmentDefinitionsDetailsPage),
     },
   },
   {

--- a/frontend/packages/network-attachment-definition-plugin/src/selectors/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/selectors/index.ts
@@ -16,3 +16,6 @@ export const getConfigAsJSON = (
 export const getType = (config: NetworkAttachmentDefinitionConfig): string => {
   return _.get(config, 'type') === undefined ? null : config.type;
 };
+
+export const getDescription = (netAttachDef: NetworkAttachmentDefinitionKind): string =>
+  _.get(netAttachDef, 'metadata.annotations.description');


### PR DESCRIPTION
This PR adds a details page for network attachment definitions.

Depends on https://github.com/openshift/console/pull/2984

![test-net-attach-def · Details · OKD - Google Chrome_616](https://user-images.githubusercontent.com/8544299/67349886-32fcec00-f517-11e9-9e16-000f81d993fa.png)