### PR TITLE
Increase timeouts for kubevirt-plugin integration tests

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/consts.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/consts.ts
@@ -3,8 +3,8 @@ export const { STORAGE_CLASS = 'rook-ceph-block' } = process.env;
 
 // TIMEOUTS
 const SEC = 1000;
-export const CLONE_VM_TIMEOUT_SECS = 360 * SEC;
-export const CLONED_VM_BOOTUP_TIMEOUT_SECS = 150 * SEC;
+export const CLONE_VM_TIMEOUT_SECS = 720 * SEC;
+export const CLONED_VM_BOOTUP_TIMEOUT_SECS = 300 * SEC;
 export const PAGE_LOAD_TIMEOUT_SECS = 15 * SEC;
 export const TEMPLATE_ACTIONS_TIMEOUT_SECS = 90 * SEC;
 export const VM_ACTIONS_TIMEOUT_SECS = 250 * SEC;
@@ -12,7 +12,7 @@ export const VM_BOOTUP_TIMEOUT_SECS = 230 * SEC;
 export const VM_MIGRATION_TIMEOUT_SECS = 260 * SEC;
 export const VM_STOP_TIMEOUT_SECS = 10 * SEC;
 export const VM_IP_ASSIGNMENT_TIMEOUT_SECS = 180 * SEC;
-export const VM_IMPORT_TIMEOUT_SECS = 80 * SEC;
+export const VM_IMPORT_TIMEOUT_SECS = 160 * SEC;
 export const WINDOWS_IMPORT_TIMEOUT_SECS = 150 * SEC;
 export const VM_CREATE_AND_EDIT_TIMEOUT_SECS = 200 * SEC;
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/mocks.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/mocks.ts
@@ -30,7 +30,7 @@ export const dataVolumeManifest = ({ name, namespace, sourceURL, accessMode, vol
         dataSource: null,
         resources: {
           requests: {
-            storage: '5Gi',
+            storage: '1Gi',
           },
         },
         volumeMode,

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.actions.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.actions.scenario.ts
@@ -100,7 +100,8 @@ describe('Test VM actions', () => {
       createResource(testVM);
       addLeakableResource(leakedResources, testVM);
       await vm.navigateToTab(TABS.OVERVIEW);
-    });
+      await waitForStatusIcon(statusIcons.off, VM_IMPORT_TIMEOUT_SECS);
+    }, VM_IMPORT_TIMEOUT_SECS);
 
     it(
       'Starts VM',

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.migration.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.migration.scenario.ts
@@ -26,7 +26,7 @@ import {
 import { VirtualMachine } from './models/virtualMachine';
 
 describe('Test VM Migration', () => {
-  const testVm = getVMManifest('URL', testName);
+  let testVm;
   let vm: VirtualMachine;
 
   const MIGRATE_VM = 'Migrate Virtual Machine';
@@ -34,7 +34,7 @@ describe('Test VM Migration', () => {
   const VM_BOOT_AND_MIGRATE_TIMEOUT = VM_BOOTUP_TIMEOUT_SECS + VM_MIGRATION_TIMEOUT_SECS;
 
   beforeEach(async () => {
-    testVm.metadata.name = `migrationvm-${getRandStr(4)}`;
+    testVm = getVMManifest('URL', testName, `migrationvm-${getRandStr(4)}`);
     vm = new VirtualMachine(testVm.metadata);
     createResource(testVm);
     await vm.navigateToTab(TABS.OVERVIEW);


### PR DESCRIPTION
RHOS (PSI) environment is slower than clusters running on libvirt, we need to extend timeout some of the timeouts.
