### PR TITLE
Query Browser: Limit minimum time step to 5s

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -304,6 +304,15 @@ const maxSamples = 300;
 // unless the number of samples would change by at least this proportion
 const samplesLeeway = 0.2;
 
+// Minimum step (milliseconds between data samples) because tiny steps reduce performance for almost no benefit
+const minStep = 5 * 1000;
+
+// Don't allow zooming to less than this number of milliseconds
+const minSpan = 30 * 1000;
+
+// Don't poll more often than this number of milliseconds
+const minPollInterval = 10 * 1000;
+
 const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   defaultTimespan,
   disabledSeries = [],
@@ -317,13 +326,17 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   // For the default time span, use the first of the suggested span options that is at least as long as defaultTimespan
   const defaultSpanText = spans.find((s) => parsePrometheusDuration(s) >= defaultTimespan);
 
+  const [span, setSpan] = React.useState(parsePrometheusDuration(defaultSpanText));
+
+  // Limit the number of samples so that the step size doesn't fall below minStep
+  const maxSamplesForSpan = _.clamp(Math.round(span / minStep), minSamples, maxSamples);
+
   const [xDomain, setXDomain] = React.useState();
   const [error, setError] = React.useState();
   const [isDatasetTooBig, setIsDatasetTooBig] = React.useState(false);
   const [isZooming, setIsZooming] = React.useState(false);
   const [results, setResults] = React.useState();
-  const [samples, setSamples] = React.useState(maxSamples);
-  const [span, setSpan] = React.useState(parsePrometheusDuration(defaultSpanText));
+  const [samples, setSamples] = React.useState(maxSamplesForSpan);
   const [updating, setUpdating] = React.useState(true);
   const [x1, setX1] = React.useState(0);
   const [x2, setX2] = React.useState(0);
@@ -365,7 +378,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
             const newSamples = _.clamp(
               Math.floor((samples * maxDataPointsSoft) / numDataPoints),
               minSamples,
-              maxSamples,
+              maxSamplesForSpan,
             );
 
             // Change `samples` if either
@@ -373,7 +386,8 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
             //   - It will change to the upper or lower limit of its allowed range
             if (
               Math.abs(newSamples - samples) / samples > samplesLeeway ||
-              (newSamples !== samples && (newSamples === maxSamples || newSamples === minSamples))
+              (newSamples !== samples &&
+                (newSamples === maxSamplesForSpan || newSamples === minSamples))
             ) {
               setSamples(newSamples);
             } else {
@@ -395,8 +409,8 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
           });
 
   // Don't poll if an end time was set (because the latest data is not displayed) or if the graph is hidden. Otherwise
-  // use a polling interval relative to the graph's timespan, but not less than 5s.
-  const delay = endTime || hideGraphs ? null : Math.max(span / 120, 5000);
+  // use a polling interval relative to the graph's timespan.
+  const delay = endTime || hideGraphs ? null : Math.max(span / 120, minPollInterval);
 
   usePoll(tick, delay, endTime, namespace, queries, samples, span);
 
@@ -486,8 +500,6 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
       let to = oldFrom + (span * xMax) / width;
       let newSpan = to - from;
 
-      // Don't allow zooming to less than 10 seconds
-      const minSpan = 10 * 1000;
       if (newSpan < minSpan) {
         newSpan = minSpan;
         const middle = (from + to) / 2;
@@ -525,7 +537,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
       {_.isEmpty(graphData) && !updating && <GraphEmpty />}
       {!_.isEmpty(graphData) && (
         <React.Fragment>
-          {samples < maxSamples && (
+          {samples < maxSamplesForSpan && (
             <Alert
               isInline
               className="co-alert"


### PR DESCRIPTION
It doesn't make much sense to allow sampling data at very frequent
intervals and it reduces performance. Particularly since by default,
Prometheus is configured to ingest data just every 30s.

Also increase the minimum time span shown in the graph from 10s to 30s
and increase the minimum polling interval from 5s to 10s.

FYI @christianvogt, @cshinn, @simonpasquier, @s-urbaniak 