### PR TITLE
get pipeline and pipeline run for deployment

### DIFF
--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -593,7 +593,7 @@ export class TransformResourceData {
       };
 
       const status = resourceStatus(obj, current, isRollingOut);
-      return {
+      const overviewItems = {
         alerts,
         buildConfigs,
         current,
@@ -605,6 +605,13 @@ export class TransformResourceData {
         services,
         status,
       };
+
+      if (this.utils) {
+        return this.utils.reduce((acc, element) => {
+          return { ...acc, ...element(obj, this.resources) };
+        }, overviewItems);
+      }
+      return overviewItems;
     });
   };
 

--- a/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
@@ -143,6 +143,7 @@ Object {
               "generation": 2,
               "labels": Object {
                 "app": "nodejs",
+                "app.kubernetes.io/instance": "nodejs",
               },
               "name": "nodejs",
               "namespace": "testproject1",
@@ -368,6 +369,7 @@ Object {
             "generation": 2,
             "labels": Object {
               "app": "nodejs",
+              "app.kubernetes.io/instance": "nodejs",
             },
             "name": "nodejs",
             "namespace": "testproject1",

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
@@ -334,6 +334,14 @@ export const sampleServices: Resource = {
   ],
 };
 
+export const samplePipeline = {
+  data: [],
+};
+
+export const samplePipelineRun = {
+  data: [],
+};
+
 export const MockKnativeResources: TopologyDataResources = {
   deployments: sampleKnativeDeployments,
   deploymentConfigs: sampleKnativeDeploymentConfigs,
@@ -348,4 +356,6 @@ export const MockKnativeResources: TopologyDataResources = {
   ksroutes: sampleKnativeRoutes,
   configurations: sampleKnativeConfigurations,
   revisions: sampleKnativeRevisions,
+  pipelines: samplePipeline,
+  pipelineRuns: samplePipelineRun,
 };

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -13,6 +13,8 @@ export const resources: TopologyDataResources = {
   builds: { data: [] },
   daemonSets: { data: [] },
   statefulSets: { data: [] },
+  pipelineRuns: { data: [] },
+  pipelines: { data: [] },
 };
 
 export const topologyData: TopologyDataModel = {
@@ -35,6 +37,7 @@ export const sampleDeploymentConfigs: Resource = {
         creationTimestamp: '2019-04-22T11:58:33Z',
         labels: {
           app: 'nodejs',
+          'app.kubernetes.io/instance': 'nodejs',
         },
         annotations: {
           'app.openshift.io/vcs-uri': 'https://github.com/redhat-developer/topology-example',
@@ -1287,6 +1290,114 @@ export const sampleStatefulSets: Resource = {
     },
   ],
 };
+
+export const samplePipeline = {
+  data: [
+    {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'Pipeline',
+      metadata: {
+        creationTimestamp: '2019-10-18T10:06:37Z',
+        generation: 1,
+        name: 'hello-world-pipeline',
+        namespace: 't-s',
+        resourceVersion: '371236',
+        selfLink: '/apis/tekton.dev/v1alpha1/namespaces/t-s/pipelines/hello-world-pipeline',
+        uid: '73d7842d-975f-44ab-99e4-727b7cf097b6',
+        labels: {
+          'app.kubernetes.io/instance': 'nodejs',
+        },
+      },
+      spec: {
+        tasks: [
+          {
+            name: 'hello-world',
+            taskRef: {
+              name: 'hello-world',
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export const samplePipelineRun = {
+  data: [
+    {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'PipelineRun',
+      metadata: {
+        creationTimestamp: '2019-10-18T10:07:28Z',
+        generation: 1,
+        labels: {
+          'tekton.dev/pipeline': 'hello-world-pipeline',
+        },
+        name: 'hello-world-pipeline',
+        namespace: 't-s',
+        resourceVersion: '371822',
+        selfLink: '/apis/tekton.dev/v1alpha1/namespaces/t-s/pipelineruns/hello-world-pipeline',
+        uid: 'a049c81e-ba40-4248-ac54-a2728893afcb',
+      },
+      spec: {
+        pipelineRef: {
+          name: 'hello-world-pipeline',
+        },
+        podTemplate: {},
+        timeout: '1h0m0s',
+      },
+      status: {
+        completionTime: '2019-10-18T10:08:00Z',
+        conditions: [
+          {
+            lastTransitionTime: '2019-10-18T10:08:00Z',
+            message: 'All Tasks have completed executing',
+            reason: 'Succeeded',
+            status: 'True',
+            type: 'Succeeded',
+          },
+        ],
+        startTime: '2019-10-18T10:07:28Z',
+        taskRuns: {
+          'hello-world-pipeline-hello-world-6mbs6': {
+            pipelineTaskName: 'hello-world',
+            status: {
+              completionTime: '2019-10-18T10:08:00Z',
+              conditions: [
+                {
+                  lastTransitionTime: '2019-10-18T10:08:00Z',
+                  message: 'All Steps have completed executing',
+                  reason: 'Succeeded',
+                  status: 'True',
+                  type: 'Succeeded',
+                },
+              ],
+              podName: 'hello-world-pipeline-hello-world-6mbs6-pod-ab38ef',
+              startTime: '2019-10-18T10:07:28Z',
+              steps: [
+                {
+                  container: 'step-echo',
+                  imageID:
+                    'docker.io/library/ubuntu@sha256:1bbdea4846231d91cce6c7ff3907d26fca444fd6b7e3c282b90c7fe4251f9f86',
+                  name: 'echo',
+                  terminated: {
+                    containerID:
+                      'cri-o://14b1d028e46e921b5fa3445def9fbeb35403ae3332da347d62c01807717eba49',
+                    exitCode: 0,
+                    finishedAt: '2019-10-18T10:07:59Z',
+                    reason: 'Completed',
+                    startedAt: '2019-10-18T10:07:57Z',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  ],
+};
+
 export const MockResources: TopologyDataResources = {
   deployments: sampleDeployments,
   deploymentConfigs: sampleDeploymentConfigs,
@@ -1299,4 +1410,6 @@ export const MockResources: TopologyDataResources = {
   builds: sampleBuilds,
   daemonSets: sampleDaemonSets,
   statefulSets: sampleStatefulSets,
+  pipelines: samplePipeline,
+  pipelineRuns: samplePipelineRun,
 };

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -20,6 +20,8 @@ export interface TopologyDataResources {
   revisions?: Resource;
   ksservices?: Resource;
   statefulSets?: Resource;
+  pipelines?: Resource;
+  pipelineRuns?: Resource;
 }
 
 export interface Node {

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -12,6 +12,7 @@ import {
   ResourceDetailsPage,
   Perspective,
   RoutePage,
+  OverviewCRD,
 } from '@console/plugin-sdk';
 import { NamespaceRedirect } from '@console/internal/components/utils/namespace-redirect';
 import { CodeIcon } from '@patternfly/react-icons';
@@ -19,6 +20,10 @@ import { FLAGS } from '@console/internal/const';
 import { referenceForModel } from '@console/internal/module/k8s';
 import * as models from './models';
 import { getKebabActionsForKind } from './utils/kebab-actions';
+import {
+  tknPipelineAndPipelineRunsResources,
+  getPipelinesAndPipelineRunsForResource,
+} from './utils/pipeline-plugin-utils';
 
 const { PipelineModel, PipelineRunModel } = models;
 
@@ -32,7 +37,8 @@ type ConsumedExtensions =
   | ResourceDetailsPage
   | Perspective
   | RoutePage
-  | KebabActions;
+  | KebabActions
+  | OverviewCRD;
 
 const SHOW_PIPELINE = 'SHOW_PIPELINE';
 
@@ -157,6 +163,14 @@ const plugin: Plugin<ConsumedExtensions> = [
         href: '/search',
         testID: 'advanced-search-header',
       },
+    },
+  },
+  {
+    type: 'Overview/CRD',
+    properties: {
+      resources: tknPipelineAndPipelineRunsResources,
+      required: SHOW_PIPELINE,
+      utils: getPipelinesAndPipelineRunsForResource,
     },
   },
   {

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-plugin-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-plugin-utils.spec.ts
@@ -1,0 +1,28 @@
+import {
+  sampleDeploymentConfigs,
+  MockResources,
+  sampleDeployments,
+} from '../../components/topology/__tests__/topology-test-data';
+import { getPipelinesAndPipelineRunsForResource } from '../pipeline-plugin-utils';
+
+describe('pipeline-plugin-utils', () => {
+  it('should return undefined when there are no pipeline and pipeline runs', () => {
+    expect(getPipelinesAndPipelineRunsForResource(sampleDeploymentConfigs.data[0], {})).toBeNull();
+  });
+
+  it('should return null when instance label is not available', () => {
+    expect(
+      getPipelinesAndPipelineRunsForResource(sampleDeployments.data[0], MockResources),
+    ).toBeNull();
+  });
+
+  it('should return pipeline and pipeline runs when instance label is present on resource', () => {
+    const pipelines = getPipelinesAndPipelineRunsForResource(
+      sampleDeploymentConfigs.data[0],
+      MockResources,
+    );
+    expect(pipelines).toHaveProperty('pipeline');
+    expect(pipelines).toHaveProperty('pipelineRuns');
+    expect(pipelines.pipelineRuns).toHaveLength(1);
+  });
+});

--- a/frontend/packages/dev-console/src/utils/pipeline-plugin-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-plugin-utils.ts
@@ -1,0 +1,73 @@
+import * as _ from 'lodash';
+import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
+import { FirehoseResource } from '@console/internal/components/utils';
+import { PipelineRunModel, PipelineModel } from '../models';
+import { Pipeline, PipelineRun } from './pipeline-augment';
+
+// label to get the pipelines
+export const INSTANCE_LABEL = 'app.kubernetes.io/instance';
+
+export const tknPipelineAndPipelineRunsResources = (namespace: string): FirehoseResource[] => {
+  const resources = [
+    {
+      isList: true,
+      kind: referenceForModel(PipelineRunModel),
+      namespace,
+      prop: 'pipelineRuns',
+      optional: true,
+    },
+    {
+      isList: true,
+      kind: referenceForModel(PipelineModel),
+      namespace,
+      prop: 'pipelines',
+      optional: true,
+    },
+  ];
+  return resources;
+};
+
+type PipelineItem = {
+  pipeline: K8sResourceKind[];
+  pipelineRuns: K8sResourceKind[];
+};
+
+const byCreationTime = (left: K8sResourceKind, right: K8sResourceKind): number => {
+  const leftCreationTime = new Date(_.get(left, ['metadata', 'creationTimestamp'], Date.now()));
+  const rightCreationTime = new Date(_.get(right, ['metadata', 'creationTimestamp'], Date.now()));
+  return rightCreationTime.getTime() - leftCreationTime.getTime();
+};
+
+const getPipelineRunsForPipeline = (pipeline: Pipeline, props): PipelineRun[] => {
+  if (!props || !props.pipelineRuns) return null;
+  const pipelineRunsData = props.pipelineRuns.data;
+  const PIPELINE_RUN_LABEL = 'tekton.dev/pipeline';
+  const pipelineName = pipeline.metadata.name;
+  return pipelineRunsData
+    .filter((pr: PipelineRun) => {
+      return (
+        pipelineName ===
+        (_.get(pr, ['spec', 'pipelineRef', 'name'], null) ||
+          _.get(pr, ['metadata', 'labels', PIPELINE_RUN_LABEL], null))
+      );
+    })
+    .sort(byCreationTime);
+};
+
+export const getPipelinesAndPipelineRunsForResource = (
+  resource: K8sResourceKind,
+  props,
+): PipelineItem => {
+  if (!_.has(props, ['pipelines', 'data'])) return null;
+  const pipelinesData = props.pipelines.data;
+  const resourceIntanceName = _.get(resource, ['metadata', 'labels', INSTANCE_LABEL], null);
+  if (!resourceIntanceName) return null;
+  const resourcePipeline = pipelinesData.find(
+    (pl) => _.get(pl, ['metadata', 'labels', INSTANCE_LABEL], null) === resourceIntanceName,
+  );
+  if (!resourcePipeline) return null;
+  return {
+    pipeline: [resourcePipeline],
+    pipelineRuns: getPipelineRunsForPipeline(resourcePipeline, props),
+  };
+};


### PR DESCRIPTION
ODC Task: https://jira.coreos.com/browse/ODC-2061

This PR adds utilities in `resource-utils` to fetch the pipeline and pipelineRuns considering that there is a label `app.openshift.io/pipeline-ref` on the resource(Deployment/Deployment Config).
Fetched data can be used in topology view and Sidebar panel