### PR TITLE
Improve type checking for k8s resources

### DIFF
--- a/frontend/packages/console-app/src/status/node.ts
+++ b/frontend/packages/console-app/src/status/node.ts
@@ -1,4 +1,4 @@
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { NodeKind } from '@console/internal/module/k8s';
 import { isNodeReady } from '@console/shared';
 
-export const nodeStatus = (node: K8sResourceKind) => (isNodeReady(node) ? 'Ready' : 'Not Ready');
+export const nodeStatus = (node: NodeKind) => (isNodeReady(node) ? 'Ready' : 'Not Ready');

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -345,7 +345,9 @@ const getReplicationControllerAlerts = (rc: K8sResourceKind): OverviewItemAlerts
   }
 };
 
-const getAutoscaledPods = (rc): PodKind[] => {
+// FIXME: This is not returning an actual PodKind. It's returning the RC spec
+// and status, and status.phase is not valid.
+const getAutoscaledPods = (rc: K8sResourceKind): any[] => {
   return [
     {
       ..._.pick(rc, 'metadata', 'status', 'spec'),
@@ -362,12 +364,13 @@ const getIdledStatus = (
   if (pods && !pods.length && isIdled(dc)) {
     return {
       ...rc,
+      // FIXME: This is not a PodKind.
       pods: [
         {
           ..._.pick(rc.obj, 'metadata', 'status', 'spec'),
           status: { phase: 'Idle' },
         },
-      ] as PodKind[],
+      ] as any[],
     };
   }
   return rc;

--- a/frontend/public/components/factory/list.tsx
+++ b/frontend/public/components/factory/list.tsx
@@ -29,6 +29,7 @@ import {
   K8sKind,
   K8sResourceKind,
   K8sResourceKindReference,
+  NodeKind,
   planExternalName,
   podPhase,
   podReadiness,
@@ -93,7 +94,7 @@ const sorts = {
   serviceCatalogStatus,
   jobCompletions: (job) => getJobTypeAndCompletions(job).completions,
   jobType: (job) => getJobTypeAndCompletions(job).type,
-  nodeReadiness: (node) => {
+  nodeReadiness: (node: NodeKind) => {
     let readiness = _.get(node, 'status.conditions');
     readiness = _.find(readiness, { type: 'Ready' });
     return _.get(readiness, 'status');
@@ -108,7 +109,7 @@ const sorts = {
   getClusterOperatorStatus,
   getClusterOperatorVersion,
   getTemplateInstanceStatus,
-  nodeRoles: (node: K8sResourceKind): string => {
+  nodeRoles: (node: NodeKind): string => {
     const roles = getNodeRoles(node);
     return roles.sort().join(', ');
   },

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -9,7 +9,7 @@ import { alertStateOrder, silenceStateOrder } from '../../reducers/monitoring';
 import { EmptyBox, StatusBox, WithScrollContainer } from '../utils';
 import {
   getJobTypeAndCompletions,
-  K8sResourceKind,
+  NodeKind,
   planExternalName,
   podPhase,
   podReadiness,
@@ -93,7 +93,7 @@ const sorts = {
   serviceCatalogStatus,
   jobCompletions: (job) => getJobTypeAndCompletions(job).completions,
   jobType: (job) => getJobTypeAndCompletions(job).type,
-  nodeReadiness: (node) => {
+  nodeReadiness: (node: NodeKind) => {
     let readiness = _.get(node, 'status.conditions');
     readiness = _.find(readiness, { type: 'Ready' });
     return _.get(readiness, 'status');
@@ -109,7 +109,7 @@ const sorts = {
   getClusterOperatorStatus,
   getClusterOperatorVersion,
   getTemplateInstanceStatus,
-  nodeRoles: (node: K8sResourceKind): string => {
+  nodeRoles: (node: NodeKind): string => {
     const roles = getNodeRoles(node);
     return roles.sort().join(', ');
   },

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -78,9 +78,12 @@ export type MatchExpression =
   | { key: string; operator: 'Exists' | 'DoesNotExist' }
   | { key: string; operator: 'In' | 'NotIn' | 'Equals' | 'NotEquals'; values: string[] };
 
+export type MatchLabels = {
+  [key: string]: string;
+};
+
 export type Selector = {
-  [key: string]: any;
-  matchLabels?: { [key: string]: string };
+  matchLabels?: MatchLabels;
   matchExpressions?: MatchExpression[];
 };
 
@@ -101,13 +104,23 @@ export type Toleration = {
   effect: TaintEffect;
 };
 
+// Properties common to (almost) all Kubernetes resources.
+export type K8sResourceCommon = {
+  apiVersion: string;
+  kind: string;
+  metadata: ObjectMetadata;
+};
+
+// Generic, unknown kind. Avoid when possible since it allows any key in spec
+// or status, weakening type checking.
 export type K8sResourceKind = {
   apiVersion?: string;
   kind?: string;
   metadata?: ObjectMetadata;
+  // FIXME: This should not be in the generic `K8sResourceKind` definition.
   pipelineTaskName?: string;
   spec?: {
-    selector?: Selector;
+    selector?: Selector | MatchLabels;
     [key: string]: any;
   };
   status?: { [key: string]: any };
@@ -269,19 +282,8 @@ export type PodSpec = {
   [key: string]: any;
 };
 
-type PodPhase =
-  | 'Pending'
-  | 'Running'
-  | 'Succeeded'
-  | 'Failed'
-  | 'Empty'
-  | 'Warning'
-  | 'Unknown'
-  | 'Idle'
-  | 'Not Ready'
-  | 'Scaled to 0'
-  | 'Autoscaled to 0'
-  | 'Terminating';
+// https://github.com/kubernetes/api/blob/release-1.16/core/v1/types.go#L2411-L2432
+type PodPhase = 'Pending' | 'Running' | 'Succeeded' | 'Failed' | 'Unknown';
 
 type ContainerStateValue = {
   reason?: string;
@@ -326,33 +328,39 @@ export type PodStatus = {
 };
 
 export type PodTemplate = {
+  metadata: ObjectMetadata;
   spec: PodSpec;
 };
 
 export type PodKind = {
   status: PodStatus;
-} & PodTemplate &
-  K8sResourceKind;
+} & K8sResourceCommon &
+  PodTemplate;
 
 export type StorageClassResourceKind = {
   provisioner: string;
   reclaimPolicy: string;
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type NodeKind = {
-  spec?: {
+  spec: {
     taints?: Taint[];
     unschedulable?: boolean;
   };
-} & K8sResourceKind;
+  status?: {
+    conditions?: any;
+    images?: {
+      names: string[];
+      sizeBytes?: number;
+    }[];
+    phase?: string;
+  };
+} & K8sResourceCommon;
 
 export type ConfigMapKind = {
-  apiVersion: string;
-  kind: string;
-  metadata: ObjectMetadata;
   data: { [key: string]: string };
   binaryData: { [key: string]: string };
-};
+} & K8sResourceCommon;
 
 export type CustomResourceDefinitionKind = {
   spec: {
@@ -371,7 +379,7 @@ export type CustomResourceDefinitionKind = {
       openAPIV3Schema: JSONSchema6;
     };
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type RouteTarget = {
   kind: 'Service';
@@ -412,7 +420,7 @@ export type RouteKind = {
   status?: {
     ingress: RouteIngress[];
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type TemplateParameter = {
   name: string;
@@ -428,7 +436,7 @@ export type TemplateKind = {
   objects: any[];
   parameters: TemplateParameter[];
   labels?: any[];
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 type TemplateInstanceObject = {
   ref: ObjectReference;
@@ -451,7 +459,7 @@ export type TemplateInstanceKind = {
     conditions: any[];
     objects: TemplateInstanceObject[];
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type MachineSpec = {
   providerSpec: {
@@ -482,11 +490,12 @@ export type MachineKind = {
       [key: string]: any;
     };
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type MachineSetKind = {
   spec: {
     replicas: number;
+    selector: any;
     template: {
       spec: MachineSpec;
     };
@@ -497,7 +506,7 @@ export type MachineSetKind = {
     readyReplicas: number;
     replicas: number;
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type Patch = {
   op: string;
@@ -533,14 +542,14 @@ export type MachineDeploymentKind = {
     readyReplicas: number;
     replicas: number;
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type MachineConfigKind = {
   spec: {
     osImageURL: string;
     config: any;
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export enum MachineConfigPoolConditionType {
   Updated = 'Updated',
@@ -615,7 +624,7 @@ type ClusterVersionSpec = {
 export type ClusterVersionKind = {
   spec: ClusterVersionSpec;
   status: ClusterVersionStatus;
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type OperandVersion = {
   name: string;
@@ -636,7 +645,7 @@ export type ClusterOperator = {
     versions?: OperandVersion[];
     relatedObjects?: ClusterOperatorObjectReference[];
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type MappingMethodType = 'claim' | 'lookup' | 'add';
 
@@ -682,7 +691,7 @@ export type OAuthKind = {
       error: string;
     };
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type K8sVerb =
   | 'create'
@@ -704,6 +713,9 @@ export type AccessReviewResourceAttributes = {
 };
 
 export type SelfSubjectAccessReviewKind = {
+  apiVersion: string;
+  kind: string;
+  metadata?: ObjectMetadata;
   spec: {
     resourceAttributes?: AccessReviewResourceAttributes;
   };
@@ -713,30 +725,32 @@ export type SelfSubjectAccessReviewKind = {
     reason?: string;
     evaluationError?: string;
   };
-} & K8sResourceKind;
+};
 
 export type ResourceAccessReviewRequest = {
+  apiVersion: string;
+  kind: string;
   namespace?: string;
   resourceAPIVersion: string;
   resourceAPIGroup: string;
   resource: string;
   verb: K8sVerb;
-} & K8sResourceKind;
+};
 
 export type ResourceAccessReviewResponse = {
   namespace?: string;
   users: string[];
   groups: string[];
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type UserKind = {
   fullName?: string;
   identities: string[];
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type GroupKind = {
   users: string[];
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type K8sKind = {
   abbr: string;
@@ -792,7 +806,7 @@ export type GroupVersionKind = string;
  */
 export type K8sResourceKindReference = GroupVersionKind | string;
 
-export type EventKind = K8sResourceKind & {
+export type EventKind = {
   count: number;
   type: string;
   involvedObject: EventInvolvedObject;
@@ -804,4 +818,4 @@ export type EventKind = K8sResourceKind & {
     component: string;
     host?: string;
   };
-};
+} & K8sResourceCommon;

--- a/frontend/public/module/k8s/selector.ts
+++ b/frontend/public/module/k8s/selector.ts
@@ -1,7 +1,8 @@
 import { createEquals, requirementFromString, requirementToString } from './selector-requirement';
-import { Selector, MatchExpression } from './index';
+import { Selector, MatchExpression, MatchLabels } from './index';
 
-const isOldFormat = (selector: Selector) => !selector.matchLabels && !selector.matchExpressions;
+const isOldFormat = (selector: Selector | MatchLabels) =>
+  !selector.matchLabels && !selector.matchExpressions;
 
 type Options = { undefinedWhenEmpty?: boolean; basic?: boolean };
 


### PR DESCRIPTION
Don't intersect `K8sResourceKind` in k8s type definitions. This lets us catch unrecognized properties under `spec` and `status`. (`K8sResourceKind` permits any key in these stanzas).

/cc @christianvogt @rhamilto @sahil143 