### PR TITLE
Bug 1763078: Left align resource name that are buttons

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -215,6 +215,7 @@ const ProjectLink = connect(
   <span className="co-resource-item co-resource-item--truncate">
     <ResourceIcon kind="Project" />
     <Button
+      isInline
       title={project.metadata.name}
       type="button"
       className="co-resource-item__resource-name"

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -127,6 +127,10 @@ h6 {
   white-space: normal; // override default .pf-c-button to enable wrapping
 }
 
+.pf-c-button.pf-m-inline {
+  text-align: left; // override default .pf-c-button text centering
+}
+
 .pf-c-button.pf-m-link--align-left {
   padding-left: 0;
 }


### PR DESCRIPTION
Prevent resource names that are `<button>` from text centering
Fix for
bug https://bugzilla.redhat.com/show_bug.cgi?id=1763078
https://jira.coreos.com/browse/ODC-2067

<img width="1462" alt="Screen Shot 2019-10-18 at 5 05 46 PM" src="https://user-images.githubusercontent.com/1874151/67128552-01f48280-f1ca-11e9-97ab-aef43d63f53e.png">
