### PR TITLE
Kubevirt: Add Events card to VM dashboard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-activity.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-activity.tsx
@@ -62,7 +62,7 @@ export const VMActivityCard: React.FC = () => {
     <DashboardCard>
       <DashboardCardHeader>
         <DashboardCardTitle>Events</DashboardCardTitle>
-        <DashboardCardLink to={viewEventsLink}>View events</DashboardCardLink>
+        <DashboardCardLink to={viewEventsLink}>View all</DashboardCardLink>
       </DashboardCardHeader>
       <DashboardCardBody>
         <ActivityBody>

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-activity.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-activity.tsx
@@ -20,15 +20,8 @@ import { VirtualMachineModel } from '../../models';
 import { getVmEventsFilters } from '../../selectors/event';
 import { VMDashboardContext } from './vm-dashboard-context';
 
-const combinedVmFilter = (vm: VMKind) => {
-  const filters = getVmEventsFilters(vm);
-
-  return (event: EventKind): boolean =>
-    filters.some((filter) => {
-      const { name, namespace, kind } = event.involvedObject;
-      return filter({ name, namespace, kind });
-    });
-};
+const combinedVmFilter = (vm: VMKind): EventFilterFuncion => (event) =>
+  getVmEventsFilters(vm).some((filter) => filter(event.involvedObject));
 
 const getEventsResource = (namespace: string): FirehoseResource => ({
   isList: true,
@@ -79,6 +72,8 @@ export const VMActivityCard: React.FC = () => {
     </DashboardCard>
   );
 };
+
+type EventFilterFuncion = (event: EventKind) => boolean;
 
 type RecentEventProps = DashboardItemProps & {
   vm: VMKind;

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-activity.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-activity.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
+import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
+import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
+import DashboardCardLink from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardLink';
+import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
+import ActivityBody, {
+  RecentEventsBody,
+} from '@console/shared/src/components/dashboard/activity-card/ActivityBody';
+import { getName, getNamespace } from '@console/shared';
+import { resourcePath, FirehoseResource, FirehoseResult } from '@console/internal/components/utils';
+import { EventModel } from '@console/internal/models';
+import { EventKind } from '@console/internal/module/k8s';
+import {
+  withDashboardResources,
+  DashboardItemProps,
+} from '@console/internal/components/dashboard/with-dashboard-resources';
+import { VMKind } from '../../types';
+import { VirtualMachineModel } from '../../models';
+import { getVmEventsFilters } from '../../selectors/event';
+import { VMDashboardContext } from './vm-dashboard-context';
+
+const combinedVmFilter = (vm: VMKind) => {
+  const filters = getVmEventsFilters(vm);
+
+  return (event: EventKind): boolean =>
+    filters.some((filter) => {
+      const { name, namespace, kind } = event.involvedObject;
+      return filter({ name, namespace, kind });
+    });
+};
+
+const getEventsResource = (namespace: string): FirehoseResource => ({
+  isList: true,
+  kind: EventModel.kind,
+  prop: 'events',
+  namespace,
+});
+
+const RecentEvent = withDashboardResources(
+  ({ watchK8sResource, stopWatchK8sResource, resources, vm }: RecentEventProps) => {
+    React.useEffect(() => {
+      if (vm) {
+        const eventsResource = getEventsResource(getNamespace(vm));
+        watchK8sResource(eventsResource);
+        return () => {
+          stopWatchK8sResource(eventsResource);
+        };
+      }
+      return null;
+    }, [watchK8sResource, stopWatchK8sResource, vm]);
+    return (
+      <RecentEventsBody
+        events={resources.events as FirehoseResult<EventKind[]>}
+        filter={combinedVmFilter(vm)}
+      />
+    );
+  },
+);
+
+export const VMActivityCard: React.FC = () => {
+  const { vm } = React.useContext(VMDashboardContext);
+
+  const name = getName(vm);
+  const namespace = getNamespace(vm);
+  const viewEventsLink = `${resourcePath(VirtualMachineModel.kind, name, namespace)}/events`;
+
+  return (
+    <DashboardCard>
+      <DashboardCardHeader>
+        <DashboardCardTitle>Events</DashboardCardTitle>
+        <DashboardCardLink to={viewEventsLink}>View events</DashboardCardLink>
+      </DashboardCardHeader>
+      <DashboardCardBody>
+        <ActivityBody>
+          <RecentEvent vm={vm} />
+        </ActivityBody>
+      </DashboardCardBody>
+    </DashboardCard>
+  );
+};
+
+type RecentEventProps = DashboardItemProps & {
+  vm: VMKind;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
@@ -5,10 +5,11 @@ import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
 import { VMKind, VMIKind } from '../../types';
 import { VMDetailsCard, VMInventoryCard } from '../dashboards-page/vm-dashboard';
 import { VMDashboardContext } from './vm-dashboard-context';
+import { VMActivityCard } from './vm-activity';
 
 const mainCards = [];
 const leftCards = [{ Card: VMDetailsCard }, { Card: VMInventoryCard }];
-const rightCards = [];
+const rightCards = [{ Card: VMActivityCard }];
 
 export const VMDashboard: React.FC<VMDashboardProps> = (props) => {
   const { obj: vm, vmi, pods, migrations } = props;

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-events.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-events.tsx
@@ -1,24 +1,9 @@
 import * as React from 'react';
 import { getNamespace } from '@console/shared';
 import { ResourcesEventStream } from '@console/internal/components/events';
-import {
-  importerPodEventFilter,
-  launcherPodEventFilter,
-  vmEventFilter,
-  vmiEventFilter,
-  vmiMigrationEventFilter,
-} from '../../selectors/event';
+import { getVmEventsFilters } from '../../selectors/event';
 import { VMTabProps } from './types';
 
 export const VMEvents: React.FC<VMTabProps> = ({ obj: vm }) => (
-  <ResourcesEventStream
-    filters={[
-      vmiEventFilter(vm),
-      vmEventFilter(vm),
-      launcherPodEventFilter(vm),
-      importerPodEventFilter(vm),
-      vmiMigrationEventFilter(vm),
-    ]}
-    namespace={getNamespace(vm)}
-  />
+  <ResourcesEventStream filters={getVmEventsFilters(vm)} namespace={getNamespace(vm)} />
 );

--- a/frontend/packages/kubevirt-plugin/src/selectors/event/filters.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/event/filters.ts
@@ -1,5 +1,6 @@
 import { getName, getNamespace } from '@console/shared';
 import { PodModel } from '@console/internal/models';
+import { EventInvolvedObject } from '@console/internal/module/k8s';
 import { VMIKind, VMKind } from '../../types/vm';
 import {
   VirtualMachineInstanceMigrationModel,
@@ -8,22 +9,24 @@ import {
 } from '../../models';
 import { VIRT_LAUNCHER_POD_PREFIX } from '../../constants/vm';
 
-const vmEventFilter = (vm: VMKind) => ({ kind, namespace, name }: EventFilterProps) =>
+type EventFilterFunction = (src: EventInvolvedObject) => boolean;
+
+const vmEventFilter = (vm: VMKind): EventFilterFunction => ({ kind, namespace, name }) =>
   kind === VirtualMachineModel.kind && name === getName(vm) && namespace === getNamespace(vm);
 
-const vmiEventFilter = (vm: VMKind | VMIKind) => ({ kind, namespace, name }: EventFilterProps) =>
+const vmiEventFilter = (vm: VMKind | VMIKind): EventFilterFunction => ({ kind, namespace, name }) =>
   kind === VirtualMachineInstanceModel.kind &&
   name === getName(vm) &&
   namespace === getNamespace(vm);
 
-const launcherPodEventFilter = (vm: VMKind) => {
+const launcherPodEventFilter = (vm: VMKind): EventFilterFunction => {
   const podNameStart = `${VIRT_LAUNCHER_POD_PREFIX}${getName(vm)}-`;
 
-  return ({ kind, namespace, name }: EventFilterProps) =>
+  return ({ kind, namespace, name }) =>
     kind === PodModel.kind && namespace === getNamespace(vm) && name.startsWith(podNameStart);
 };
 
-const importerPodEventFilter = (vm: VMKind) => ({ kind, namespace, name }: EventFilterProps) => {
+const importerPodEventFilter = (vm: VMKind): EventFilterFunction => ({ kind, namespace, name }) => {
   // importer pod example importer-<diskName>-<vmname>-<generatedId>
   // note: diskName and vmname may contain '-' which means pod name should have at least 4 parts
   if (
@@ -42,21 +45,15 @@ const importerPodEventFilter = (vm: VMKind) => ({ kind, namespace, name }: Event
   return false;
 };
 
-const vmiMigrationEventFilter = (vm: VMKind) => ({ kind, namespace, name }: EventFilterProps) =>
+const vmiMigrationEventFilter = (vm: VMKind): EventFilterFunction => ({ kind, namespace, name }) =>
   kind === VirtualMachineInstanceMigrationModel.kind &&
   namespace === getNamespace(vm) &&
   name === `${getName(vm)}-migration`;
 
-export const getVmEventsFilters = (vm: VMKind) => [
+export const getVmEventsFilters = (vm: VMKind): EventFilterFunction[] => [
   vmiEventFilter(vm),
   vmEventFilter(vm),
   launcherPodEventFilter(vm),
   importerPodEventFilter(vm),
   vmiMigrationEventFilter(vm),
 ];
-
-type EventFilterProps = {
-  kind: string;
-  namespace: string;
-  name: string;
-};


### PR DESCRIPTION
Reduced Activity card is added containing "Recent events".
Ongoing activities are omitted from this card.

VM event filters are refactored for reusability.

---
![events](https://user-images.githubusercontent.com/17194943/67192745-67c45280-f3f4-11e9-93bf-0f95e95911a5.png)
