### PR TITLE
Fix issue with stale values while mutating rows in MultiColumnField

### DIFF
--- a/frontend/packages/dev-console/src/components/formik-fields/InputField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/InputField.tsx
@@ -31,6 +31,7 @@ const InputField: React.FC<InputFieldProps> = ({
         isValid={isValid}
         isRequired={required}
         aria-describedby={`${fieldId}-helper`}
+        value={field.value || ''}
         onChange={(value, event) => {
           field.onChange(event);
           onChange && onChange(event);

--- a/frontend/packages/dev-console/src/components/formik-fields/InputSearchField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/InputSearchField.tsx
@@ -33,6 +33,7 @@ const InputSearchField: React.FC<SearchInputFieldProps> = ({
           isValid={isValid}
           isRequired={required}
           aria-describedby={`${fieldId}-helper`}
+          value={field.value || ''}
           onChange={(value, event) => field.onChange(event)}
           onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
             if (e.keyCode === 13) {

--- a/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
@@ -34,8 +34,7 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
           {fieldValue.length > 0 &&
             fieldValue.map((value, index) => (
               <MultiColumnFieldRow
-                // eslint-disable-next-line react/no-array-index-key
-                key={`multi-column-field-row-${index}`} // There is no other usable value for key prop in this case.
+                key={`multi-column-field-row-${index.toString()}`} // There is no other usable value for key prop in this case.
                 name={name}
                 toolTip={toolTip}
                 rowIndex={index}

--- a/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
@@ -34,7 +34,7 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
           {fieldValue.length > 0 &&
             fieldValue.map((value, index) => (
               <MultiColumnFieldRow
-                key={`multi-column-field-row-${index.toString()}`} // There is no other usable value for key prop in this case.
+                key={`${index.toString()}`} // There is no other usable value for key prop in this case.
                 name={name}
                 toolTip={toolTip}
                 rowIndex={index}

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -35,9 +35,9 @@ export class DropdownMixin extends React.PureComponent {
     this.hide(event);
   }
 
-  componentWillReceiveProps({ selectedKey }) {
+  componentWillReceiveProps({ selectedKey, items }) {
     if (selectedKey !== this.props.selectedKey) {
-      this.setState({ selectedKey });
+      this.setState({ selectedKey, title: items[selectedKey] });
     }
   }
 


### PR DESCRIPTION
Fixes bug where mutation on rows would result in stale values in `MultiColumnFieldRow`.

This PR -
- Adds `value` prop in `TextInput` component to make it controlled even if `field.value` is `undefined`.
- Fixes a bug in `Dropdown` component where the title would not update even afetr the `selectedKey` is changed in `componentWillRecieveProps`.
- Removes the line to disable es-lint in `MultiColumnField` component.