### PR TITLE
console-shared: Introduce RecentEventsBodyContent

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/ActivityBody.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/ActivityBody.tsx
@@ -25,7 +25,7 @@ const Activity: React.FC<ActivityProps> = ({ timestamp, children }) => (
   </div>
 );
 
-export const RecentEventsBody: React.FC<RecentEventsBodyProps> = ({ events, filter }) => {
+export const RecentEventsBodyContent: React.FC<RecentEventsBodyProps> = ({ events, filter }) => {
   const [expanded, setExpanded] = React.useState([]);
   const onToggle = React.useCallback(
     (uid: string) => {
@@ -46,41 +46,44 @@ export const RecentEventsBody: React.FC<RecentEventsBodyProps> = ({ events, filt
     [isExpanded, onToggle],
   );
 
-  let eventsBody: React.ReactNode;
   if (events && events.loadError) {
-    eventsBody = <ErrorLoadingEvents />;
-  } else if (!(events && events.loaded)) {
-    eventsBody = <div className="skeleton-activity" />;
-  } else {
-    const filteredEvents = filter ? events.data.filter(filter) : events.data;
-    const sortedEvents = _.orderBy(filteredEvents, ['lastTimestamp', 'name'], ['desc', 'asc']);
-    eventsBody =
-      filteredEvents.length === 0 ? (
-        <Activity>
-          <div className="text-secondary">There are no recent events.</div>
-        </Activity>
-      ) : (
-        <Accordion
-          asDefinitionList={false}
-          headingLevel="h5"
-          className="co-activity-card__recent-accordion"
-        >
-          <EventStreamList
-            className="co-activity-card__recent-list"
-            events={sortedEvents}
-            EventComponent={eventItem}
-            scrollableElementId="activity-body"
-          />
-        </Accordion>
-      );
+    return <ErrorLoadingEvents />;
+  }
+  if (!(events && events.loaded)) {
+    return <div className="skeleton-activity" />;
+  }
+
+  const filteredEvents = filter ? events.data.filter(filter) : events.data;
+  const sortedEvents = _.orderBy(filteredEvents, ['lastTimestamp', 'name'], ['desc', 'asc']);
+  if (filteredEvents.length === 0) {
+    return (
+      <Activity>
+        <div className="text-secondary">There are no recent events.</div>
+      </Activity>
+    );
   }
   return (
-    <>
-      <div className="co-activity-card__recent-title">Recent events</div>
-      {eventsBody}
-    </>
+    <Accordion
+      asDefinitionList={false}
+      headingLevel="h5"
+      className="co-activity-card__recent-accordion"
+    >
+      <EventStreamList
+        className="co-activity-card__recent-list"
+        events={sortedEvents}
+        EventComponent={eventItem}
+        scrollableElementId="activity-body"
+      />
+    </Accordion>
   );
 };
+
+export const RecentEventsBody: React.FC<RecentEventsBodyProps> = (props) => (
+  <>
+    <div className="co-activity-card__recent-title">Recent events</div>
+    <RecentEventsBodyContent {...props} />
+  </>
+);
 
 export const OngoingActivityBody: React.FC<OngoingActivityBodyProps> = ({
   loaded,

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-activity.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-activity.tsx
@@ -5,7 +5,7 @@ import DashboardCardHeader from '@console/shared/src/components/dashboard/dashbo
 import DashboardCardLink from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardLink';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import ActivityBody, {
-  RecentEventsBody,
+  RecentEventsBodyContent,
 } from '@console/shared/src/components/dashboard/activity-card/ActivityBody';
 import { getName, getNamespace } from '@console/shared';
 import { resourcePath, FirehoseResource, FirehoseResult } from '@console/internal/components/utils';
@@ -43,7 +43,7 @@ const RecentEvent = withDashboardResources(
       return null;
     }, [watchK8sResource, stopWatchK8sResource, vm]);
     return (
-      <RecentEventsBody
+      <RecentEventsBodyContent
         events={resources.events as FirehoseResult<EventKind[]>}
         filter={combinedVmFilter(vm)}
       />


### PR DESCRIPTION
Former `RecentEventsBody` is splitted to enable optional rendering of the title.

Needed for the VM Dashboard Events card.

Depends on:
- [x] #3024 

Just the last commit is relevant.

---

![events](https://user-images.githubusercontent.com/17194943/67282279-b09e0900-f4d1-11e9-9c3a-517304ae650a.png)
