### PR TITLE
Fix typo in name of cluster-thanos flag error display name

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -320,7 +320,7 @@ func main() {
 				Endpoint:        offClusterPrometheusURL,
 			}
 
-			offClusterThanosURL := bridge.ValidateFlagIsURL("k8s-mode-off-thanos-prometheus", *fK8sModeOffClusterThanos)
+			offClusterThanosURL := bridge.ValidateFlagIsURL("k8s-mode-off-cluster-thanos", *fK8sModeOffClusterThanos)
 			offClusterThanosURL.Path = "/api"
 			srv.ThanosTenancyProxyConfig = &proxy.Config{
 				TLSClientConfig: serviceProxyTLSConfig,


### PR DESCRIPTION
When `k8s-mode-off-cluster-thanos` flag is invalid the display error is wrong.

cc:// @irosenzw 