### PR TITLE
oc-environment: Export non-empty URLs as env variables

### DIFF
--- a/contrib/oc-environment.sh
+++ b/contrib/oc-environment.sh
@@ -13,14 +13,33 @@
 # bridge command line arguments - in fact. to get more information
 # about any of them, you can run ./bin/bridge --help
 
+THANOS_URL=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.thanosURL}')
+PROMETHEUS_URL=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.prometheusURL}')
+ALERTMANAGER_URL=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.alertmanagerURL}')
+
 export BRIDGE_USER_AUTH="disabled"
 export BRIDGE_K8S_MODE="off-cluster"
 export BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
 export BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
-export BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.thanosURL}')
-export BRIDGE_K8S_MODE_OFF_CLUSTER_PROMETHEUS=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.prometheusURL}')
-export BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.alertmanagerURL}')
 export BRIDGE_K8S_AUTH="bearer-token"
 export BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token)
+export BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER="${ALERTMANAGER_URL}"
+export BRIDGE_K8S_MODE_OFF_CLUSTER_PROMETHEUS="${PROMETHEUS_URL}"
+export BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS="${THANOS_URL}"
+
+if [ -z  "${ALERTMANAGER_URL}" ]; then
+    echo "ERROR: No alert manager provider"
+    kill -INT $$
+fi
+
+if [ -z  "${PROMETHEUS_URL}" ]; then
+    echo "ERROR: No metrics provider"
+    kill -INT $$
+fi
+
+if [ -z  "${THANOS_URL}" ]; then
+     echo "Warning: No Thanos server, using Prometheus instead"
+     export BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS="${PROMETHEUS_URL}"
+fi
 
 echo "Using $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"


### PR DESCRIPTION
Export only non-empty URLs for Thanos, Prometheus and Alert-Manager.
Using Prometheus URL when Thanos URL is empty.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>