### PR TITLE
Bug: Nooba data consumption label undefined

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card.tsx
@@ -101,7 +101,7 @@ const DataConsumptionCard: React.FC<DashboardItemProps> = ({
               containerComponent={
                 <ChartVoronoiContainer
                   labelComponent={<ChartTooltip style={{ fontSize: 8, paddingBottom: 0 }} />}
-                  labels={(datum) => `${datum.y} ${maxUnit}`}
+                  labels={({ datum }) => `${datum.y} ${maxUnit}`}
                   voronoiDimension="x"
                 />
               }


### PR DESCRIPTION
Before:
![Screenshot from 2019-10-22 22-59-55](https://user-images.githubusercontent.com/12200504/67313100-05687080-f520-11e9-95c6-34604bb907ca.png)
After:
![Screenshot from 2019-10-22 22-54-05](https://user-images.githubusercontent.com/12200504/67313117-0b5e5180-f520-11e9-9936-ce5c06d8ae79.png)

Label for the data-consumption card is showing as undefined due to upgrade of Victory chart package (through patternfly/react-charts package) old: labels={(d)=> 'x: ${d.x}'}, changed to new labels={({ datum }) => 'x: ${d.x}'}, hence now labels should be given a single argument.
https://github.com/FormidableLabs/victory/releases/tag/v33.0.0
Signed-off-by: Kanika <kmurarka@redhat.com>