### PR TITLE
Use @typescript-eslint/parser for all code

### DIFF
--- a/frontend/packages/eslint-plugin-console/lib/config/typescript-parser.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/typescript-parser.js
@@ -1,9 +1,6 @@
 module.exports = {
   overrides: {
     files: ['*.ts', '*.tsx'],
-    parser: 'typescript-eslint-parser',
-
-    // TODO update to new parser when https://github.com/prettier/prettier-eslint/issues/201 is fixed
-    // parser: '@typescript-eslint/parser',
+    parser: '@typescript-eslint/parser',
   },
 };

--- a/frontend/packages/eslint-plugin-console/lib/config/typescript.js
+++ b/frontend/packages/eslint-plugin-console/lib/config/typescript.js
@@ -5,20 +5,18 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx'],
 
+      parser: '@typescript-eslint/parser',
+
       parserOptions: {
         ecmaVersion: 2018,
         sourceType: 'module',
       },
 
-      // TODO update to new parser https://github.com/prettier/prettier-eslint/issues/201 is fixed
-      // parser: '@typescript-eslint/parser',
-      parser: 'typescript-eslint-parser',
-
       plugins: ['@typescript-eslint'],
 
       settings: {
         'import/parsers': {
-          'typescript-eslint-parser': ['.ts', '.tsx'],
+          '@typescript-eslint/parser': ['.ts', '.tsx'],
         },
         'import/resolver': {
           typescript: {},
@@ -41,6 +39,7 @@ module.exports = {
         '@typescript-eslint/unbound-method': 'off',
       }),
     },
+
     {
       files: ['*.tsx'],
       rules: {

--- a/frontend/packages/eslint-plugin-console/package.json
+++ b/frontend/packages/eslint-plugin-console/package.json
@@ -26,7 +26,6 @@
     "eslint-plugin-react-hooks": "1.6.0",
     "eslint-plugin-sort-class-members": "1.4.0",
     "merge": "1.2.1",
-    "prettier": "1.17.1",
-    "typescript-eslint-parser": "22.0.0"
+    "prettier": "1.17.1"
   }
 }

--- a/frontend/public/components/routes/create-route.tsx
+++ b/frontend/public/components/routes/create-route.tsx
@@ -635,11 +635,11 @@ export const AlternateServicesGroup: React.FC<AlternateServiceEntryGroupProps> =
     setName(serviceName);
   };
 
-  React.useEffect(() => {
-    props.onChange({ name, weight }, props.index);
-  }, [name, weight]);
+  const { serviceOptions, availableServiceOptions, index, onChange } = props;
 
-  const { serviceOptions, availableServiceOptions, index } = props;
+  React.useEffect(() => {
+    onChange({ name, weight }, index);
+  }, [name, weight, index, onChange]);
 
   return (
     <div className="co-m-pane__body-group">

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12251,23 +12251,6 @@ typesafe-actions@^4.2.1:
   resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-4.2.1.tgz#b794e141abcc05195df20ee340038fbd60ad2262"
   integrity sha512-a+HpDcVl+hRxQS3u83vh3X2ga967b/3TwiFbcqlDOkMSsJTFwzahObsGWuTiSISjSvLKrx0ckeYheLUzti4kYw==
 
-typescript-eslint-parser@22.0.0:
-  version "22.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-22.0.0.tgz#f5e766c9b50711b03535e29a10b45f957e3c516a"
-  integrity sha512-pD8D7oTeRwWvFVxK3PaY6FYAiZsuRXFkIc2+1xkwCT3NduySgCgjeAkR5/dnIWecOiFVcEHf4ypXurF02Q6Z3Q==
-  dependencies:
-    eslint-scope "^4.0.0"
-    eslint-visitor-keys "^1.0.0"
-    typescript-estree "18.0.0"
-
-typescript-estree@18.0.0:
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-estree/-/typescript-estree-18.0.0.tgz#a309f6c6502c64d74b3f88c205d871a9af0b1d40"
-  integrity sha512-HxTWrzFyYOPWA91Ij7xL9mNUVpGTKLH2KiaBn28CMbYgX2zgWdJqU9hO7Are+pAPAqY91NxAYoaAyDDZ3rLj2A==
-  dependencies:
-    lodash.unescape "4.0.1"
-    semver "5.5.0"
-
 typescript@3.4.5:
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"


### PR DESCRIPTION
Follow-up to #1645

This makes `eslint-plugin-console` use `@typescript-eslint/parser`.

:exclamation: Note that the root `.eslintrc` already uses `@typescript-eslint/parser`.

This effectively removes the ESLint parser duality, so the following message

```
WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.
```

appears only once now.

More Console ESLint improvements to follow.