### PR TITLE
kubevirt: Replace VMStatus usage by its in-house migrated variant

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-status-card.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-status-card.scss
@@ -1,5 +1,0 @@
-// Fix of styling in kubevirt-web-ui-components
-// TODO(mlibra): move VmStatus component to openshift/console and remove this fix
-.co-dashboard-card .kubevirt-status__icon {
-  padding-top: 3px;
-}

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-status-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-status-card.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
-import { VmStatus } from 'kubevirt-web-ui-components';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import HealthBody from '@console/shared/src/components/dashboard/health-card/HealthBody';
 import { DashboardItemProps } from '@console/internal/components/dashboard/with-dashboard-resources';
+import { VMStatus } from '../../vm-status';
 import { VMDashboardContext } from '../../vms/vm-dashboard-context';
 import { VMAlerts } from './vm-alerts';
-
-import './vm-status-card.scss';
 
 export const VMStatusCard: React.FC<VMStatusCardProps> = () => {
   const vmDashboardContext = React.useContext(VMDashboardContext);
@@ -22,7 +20,7 @@ export const VMStatusCard: React.FC<VMStatusCardProps> = () => {
       </DashboardCardHeader>
       <DashboardCardBody>
         <HealthBody>
-          <VmStatus vm={vm} pods={pods} migrations={migrations} />
+          <VMStatus vm={vm} pods={pods} migrations={migrations} />
         </HealthBody>
         <VMAlerts vm={vm} vmi={vmi} />
       </DashboardCardBody>


### PR DESCRIPTION
The component has been migrated from web-ui-components recently,
so let's start using it.