### PR TITLE
kubevirt: migrate getSimpleVMStatus() from web-ui-components

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-statuses.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-statuses.tsx
@@ -12,7 +12,7 @@ const getId = (value) => `${getNamespace(value)}-${getName(value)}`;
 export const VmStatuses: React.FC<VmStatusesProps> = (props) => {
   const { vm, pods, migrations } = props;
   const statusDetail = getVMStatus(vm, pods, migrations);
-  const importerPods = getVMImporterPods(pods, vm);
+  const importerPods = getVMImporterPods(vm, pods);
 
   switch (statusDetail.status) {
     case VM_STATUS_IMPORTING:

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -162,7 +162,7 @@ export const menuActionsCreator = (
   { vmi, pods, migrations }: ExtraResources,
 ) => {
   const vmStatus = getVMStatus(vm, pods, migrations);
-  const migration = findVMIMigration(migrations, vmi);
+  const migration = findVMIMigration(vmi, migrations);
 
   return menuActions.map((action) => {
     return action(kindObj, vm, { vmi, vmStatus, migration });

--- a/frontend/packages/kubevirt-plugin/src/components/vms/table-filters.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/table-filters.ts
@@ -1,18 +1,18 @@
 import * as _ from 'lodash';
-import { getSimpleVmStatus } from 'kubevirt-web-ui-components';
 import { Filter } from '@console/shared';
 import { VM_SIMPLE_STATUS_ALL, VM_SIMPLE_STATUS_TO_TEXT } from '../../statuses/vm/constants';
+import { getSimpleVMStatus } from '../../statuses/vm/vm';
 
 export const vmStatusFilter: Filter = {
   type: 'vm-status',
   selected: VM_SIMPLE_STATUS_ALL,
-  reducer: getSimpleVmStatus,
+  reducer: getSimpleVMStatus,
   items: VM_SIMPLE_STATUS_ALL.map((status) => ({
     id: status,
     title: VM_SIMPLE_STATUS_TO_TEXT[status],
   })),
   filter: (statuses, vm) => {
-    const status = getSimpleVmStatus(vm);
+    const status = getSimpleVMStatus(vm);
     return statuses.selected.has(status) || !_.includes(statuses.all, status);
   },
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
@@ -38,7 +38,7 @@ const VmConsolesWrapper: React.FC<VmConsolesWrapperProps> = (props) => {
   let rdp;
   if (isWindows(vm)) {
     const rdpService = findRDPService(vmi, services);
-    const launcherPod = findVMPod(pods, vm);
+    const launcherPod = findVMPod(vm, pods);
     rdp = getRdpConnectionDetails(vmi, rdpService, launcherPod);
   }
 

--- a/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
@@ -43,8 +43,8 @@ export const isPodSchedulable = (pod: PodKind) => {
 };
 
 export const findVMPod = (
-  pods: PodKind[],
   vm: VMKind,
+  pods?: PodKind[],
   podNamePrefix = VIRT_LAUNCHER_POD_PREFIX,
 ) => {
   if (!pods) {
@@ -76,8 +76,8 @@ export const findVMPod = (
 };
 
 export const getVMImporterPods = (
-  pods: PodKind[],
   vm: VMKind,
+  pods?: PodKind[],
   pvcNameLabel = `${CDI_KUBEVIRT_IO}/${STORAGE_IMPORT_PVC_NAME}`,
 ) => {
   if (!pods) {

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi-migration/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi-migration/combined.ts
@@ -3,7 +3,7 @@ import { K8sResourceKind } from '@console/internal/module/k8s';
 import { VMIKind, VMKind } from '../../types/vm';
 import { getMigrationVMIName, isMigrating } from './selectors';
 
-export const findVMIMigration = (migrations: K8sResourceKind[], vmi: VMIKind | VMKind) => {
+export const findVMIMigration = (vmi: VMIKind | VMKind, migrations?: K8sResourceKind[]) => {
   if (!migrations) {
     return null;
   }

--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
@@ -43,8 +43,8 @@ import {
 } from './constants';
 import { Status } from '..';
 
-const isBeingMigrated = (vm: VMKind, migrations: K8sResourceKind[]): VMStatus => {
-  const migration = findVMIMigration(migrations, vm);
+const isBeingMigrated = (vm: VMKind, migrations?: K8sResourceKind[]): VMStatus => {
+  const migration = findVMIMigration(vm, migrations);
   if (isMigrating(migration)) {
     return { status: VM_STATUS_MIGRATING, message: getMigrationStatusPhase(migration) };
   }
@@ -102,8 +102,8 @@ const isCreated = (vm: VMKind, launcherPod: PodKind = null): VMStatus => {
   return NOT_HANDLED;
 };
 
-const isBeingImported = (vm: VMKind, pods: PodKind[]): VMStatus => {
-  const importerPods = getVMImporterPods(pods, vm);
+const isBeingImported = (vm: VMKind, pods?: PodKind[]): VMStatus => {
+  const importerPods = getVMImporterPods(vm, pods);
   if (importerPods && importerPods.length > 0 && !isVMCreated(vm)) {
     const importerPodsStatuses = importerPods.map((pod) => {
       const podStatus = getPodStatus(pod);
@@ -140,7 +140,7 @@ const isBeingImported = (vm: VMKind, pods: PodKind[]): VMStatus => {
   return NOT_HANDLED;
 };
 
-const isV2VConversion = (vm: VMKind, pods: PodKind[]): VMStatus => {
+const isV2VConversion = (vm: VMKind, pods?: PodKind[]): VMStatus => {
   const conversionPod = findConversionPod(vm, pods);
   const podPhase = getPodStatusPhase(conversionPod);
   if (conversionPod && podPhase !== POD_PHASE_SUCEEDED) {
@@ -189,10 +189,10 @@ const isWaitingForVMI = (vm: VMKind): VMStatus => {
 
 export const getVMStatus = (
   vm: VMKind,
-  pods: PodKind[],
-  migrations: K8sResourceKind[],
+  pods?: PodKind[],
+  migrations?: K8sResourceKind[],
 ): VMStatus => {
-  const launcherPod = findVMPod(pods, vm);
+  const launcherPod = findVMPod(vm, pods);
   return (
     isV2VConversion(vm, pods) || // these statuses must precede isRunning() because they do not rely on ready vms
     isBeingMigrated(vm, migrations) || //  -||-
@@ -205,7 +205,7 @@ export const getVMStatus = (
   );
 };
 
-export const getSimpleVMStatus = (vm: VMKind, pods: PodKind[], migrations: K8sResourceKind[]) => {
+export const getSimpleVMStatus = (vm: VMKind, pods?: PodKind[], migrations?: K8sResourceKind[]) => {
   const vmStatus = getVMStatus(vm, pods, migrations).status;
   return vmStatus === VM_STATUS_OFF || vmStatus === VM_STATUS_RUNNING
     ? vmStatus


### PR DESCRIPTION
Next dependency on web-ui-components library removed.