### PR TITLE
Bug 1759487: Change the 'Create' button label on VM page

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -176,6 +176,7 @@ const VirtualMachinesPageComponent: React.FC<VirtualMachinesPageProps> = (props)
   return (
     <MultiListPage
       {...props}
+      createButtonText="Create Virtual Machine"
       canCreate
       title={VirtualMachineModel.labelPlural}
       rowFilters={[vmStatusFilter]}


### PR DESCRIPTION
Change 'Create' button label to be 'Create Virtual Machine'
for consistency.

Fixes: https://bugzilla.redhat.com/1759487

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>