### PR TITLE
Combine e2e and olm tests suites back into one

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -155,6 +155,10 @@ export const config: Config = {
       'tests/performance.scenario.ts',
       'tests/monitoring.scenario.ts',
       'tests/crd-extensions.scenario.ts',
+      '../packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts',
+      '../packages/operator-lifecycle-manager/integration-tests/scenarios/operator-hub.scenario.ts',
+      '../packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts',
+      '../packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts',
     ]),
     release: suite([
       'tests/crud.scenario.ts',


### PR DESCRIPTION
This adds the OLM tests into the e2e suite, then we can remove the e2e-aws-console-olm from  openshift/release.

/assign @benjaminapetersen @jcaianirh 
@smarterclayton 