### PR TITLE
Resource statuses

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeDetailsPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeDetailsPage.tsx
@@ -3,6 +3,7 @@ import { navFactory } from '@console/internal/components/utils';
 import { PodsPage } from '@console/internal/components/pod';
 import { ResourceEventStream } from '@console/internal/components/events';
 import { DetailsPage } from '@console/internal/components/factory';
+import { nodeStatus } from '../../status/node';
 import NodeDetails from './NodeDetails';
 import { menuActions } from './menu-actions';
 
@@ -17,7 +18,7 @@ const pages = [
   events(ResourceEventStream),
 ];
 const NodeDetailsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (props) => (
-  <DetailsPage {...props} menuActions={menuActions} pages={pages} />
+  <DetailsPage {...props} getResourceStatus={nodeStatus} menuActions={menuActions} pages={pages} />
 );
 
 export default NodeDetailsPage;

--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { navFactory } from '@console/internal/components/utils';
+import { pipelineRunStatus } from '../../utils/pipeline-filter-reducer';
 import { PipelineRunDetails } from './PipelineRunDetails';
 import { PipelineRunLogsWithActiveTask } from './PipelineRunLogs';
 
 const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
+    getResourceStatus={pipelineRunStatus}
     pages={[
       navFactory.details(PipelineRunDetails),
       navFactory.editYaml(),

--- a/frontend/packages/dev-console/src/utils/pipeline-filter-reducer.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-filter-reducer.ts
@@ -12,23 +12,28 @@ export const pipelineFilterReducer = (pipeline): string => {
   return pipeline.latestRun.status.succeededCondition;
 };
 
-export const pipelineRunFilterReducer = (pipelineRun): string => {
+export const pipelineRunStatus = (pipelineRun): string => {
   if (
     !pipelineRun ||
     !pipelineRun.status ||
     !pipelineRun.status.conditions ||
     pipelineRun.status.conditions.length === 0
   ) {
-    return '-';
+    return null;
   }
   const condition = pipelineRun.status.conditions.find((c) => c.type === 'Succeeded');
   return !condition || !condition.status
-    ? '-'
+    ? null
     : condition.status === 'True'
     ? 'Succeeded'
     : condition.status === 'False'
     ? 'Failed'
     : 'Running';
+};
+
+export const pipelineRunFilterReducer = (pipelineRun): string => {
+  const status = pipelineRunStatus(pipelineRun);
+  return status || '-';
 };
 
 export const pipelineStatusFilter = (filters, pipeline) => {

--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -144,4 +144,12 @@
   &__resource-name {
     min-width: 0; // required so co-break-word works
   }
+  &__resource-status {
+    padding-left: 8px;
+    white-space: nowrap;
+
+    &-badge {
+      vertical-align: middle;
+    }
+  }
 }

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -43,6 +43,7 @@ export const DetailsPage = withFallback<DetailsPageProps>((props) => {
             : breadcrumbsForDetailsPage(props.kindObj, props.match)
         }
         resourceKeys={resourceKeys}
+        getResourceStatus={props.getResourceStatus}
         customData={props.customData}
         badge={props.badge || getBadgeFromType(props.kindObj && props.kindObj.badge)}
         icon={props.icon}
@@ -84,6 +85,7 @@ export type DetailsPageProps = {
   customData?: any;
   badge?: React.ReactNode;
   icon?: React.ComponentType<{ obj: K8sResourceKind }>;
+  getResourceStatus?: (resource: K8sResourceKind) => string;
 };
 
 DetailsPage.displayName = 'DetailsPage';

--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
@@ -143,6 +144,11 @@ const JobTableRow = ({
 };
 JobTableRow.displayName = 'JobTableRow';
 
+const jobStatus = (job: JobKind): string => {
+  const conditions = _.get(job, 'status.conditions', null);
+  return conditions && conditions.length > 0 ? conditions[0].type : 'In Progress';
+};
+
 const JobDetails: React.FC<JobsDetailsProps> = ({ obj: job }) => (
   <>
     <div className="co-m-pane__body">
@@ -168,11 +174,7 @@ const JobDetails: React.FC<JobsDetailsProps> = ({ obj: job }) => (
           <dl className="co-m-pane__details">
             <dt>Status</dt>
             <dd>
-              {job.status.conditions ? (
-                <Status status={job.status.conditions[0].type} />
-              ) : (
-                <Status status="In Progress" />
-              )}
+              <Status status={jobStatus(job)} />
             </dd>
             <DetailsItem label="Start Time" obj={job} path="status.startTime">
               <Timestamp timestamp={job.status.startTime} />
@@ -207,6 +209,7 @@ const { details, pods, editYaml, events } = navFactory;
 const JobsDetailsPage: React.FC<JobsDetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
+    getResourceStatus={jobStatus}
     kind={kind}
     menuActions={menuActions}
     pages={[details(JobDetails), editYaml(), pods(), events(ResourceEventStream)]}

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -392,6 +392,7 @@ const PodExecLoader: React.FC<PodExecLoaderProps> = ({ obj }) => (
 export const PodsDetailsPage: React.FC<PodDetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
+    getResourceStatus={podPhase}
     menuActions={menuActions}
     pages={[
       navFactory.details(Details),

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -133,6 +133,9 @@ const menuActions = [CancelAction, ...replicaSetMenuActions];
 export const ReplicationControllersDetailsPage = (props) => (
   <DetailsPage
     {...props}
+    getResourceStatus={(resource) =>
+      _.get(resource, ['metadata', 'annotations', 'openshift.io/deployment.phase'], null)
+    }
     menuActions={menuActions}
     pages={[
       details(Details),

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -503,6 +503,7 @@ const RouteDetails: React.FC<RoutesDetailsProps> = ({ obj: route }) => {
 export const RoutesDetailsPage: React.FC<RoutesDetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
+    getResourceStatus={routeStatus}
     kind={RoutesReference}
     menuActions={menuActions}
     pages={[navFactory.details(detailsPage(RouteDetails)), navFactory.editYaml()]}

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -2,7 +2,15 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
-import { Breadcrumb, BreadcrumbItem, Button, SplitItem, Split } from '@patternfly/react-core';
+import {
+  Badge,
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  SplitItem,
+  Split,
+} from '@patternfly/react-core';
+import { Status } from '@console/shared';
 import {
   ActionsMenu,
   ResourceIcon,
@@ -72,6 +80,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
     style,
     customData,
     badge,
+    getResourceStatus = (resource) => _.get(resource, ['status', 'phase'], null),
   } = props;
   const extraResources = _.reduce(
     props.resourceKeys,
@@ -84,6 +93,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
   const hasMenuActions = _.isFunction(menuActions) || !_.isEmpty(menuActions);
   const showActions =
     (hasButtonActions || hasMenuActions) && !_.isEmpty(data) && !_.get(data, 'deletionTimestamp');
+  const resourceStatus = getResourceStatus && getResourceStatus(data);
   return (
     <div
       className={classNames(
@@ -111,6 +121,13 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
             <span data-test-id="resource-title" className="co-resource-item__resource-name">
               {resourceTitle}
             </span>
+            {resourceStatus && (
+              <span className="co-resource-item__resource-status">
+                <Badge className="co-resource-item__resource-status-badge" isRead>
+                  <Status status={resourceStatus} />
+                </Badge>
+              </span>
+            )}
           </div>
         )}
         {!breadcrumbsFor && badge}
@@ -214,6 +231,7 @@ export type PageHeadingProps = {
   customData?: any;
   badge?: React.ReactNode;
   icon?: React.ComponentType<{ obj?: K8sResourceKind }>;
+  getResourceStatus?: (resource: K8sResourceKind) => string;
 };
 
 export type ResourceOverviewHeadingProps = {


### PR DESCRIPTION
https://jira.coreos.com/browse/ODC-2026

Direction changed a bit since this PR started. The goal is now to provide as many resource statuses as we can.

The base check is `K8sResourceKind.status.phase`, if that works then the resource has a status badge. There are some resources that do not subscribe to this location for status values, I've manually provided lookups for them. They are:
- PipelineRuns
- Jobs
- Nodes
- Routes
- Pods (makes use of `.status.phase` but there is a better utility to use `podPhase`)

Examples:
![Screen Shot 2019-10-23 at 4 17 23 PM](https://user-images.githubusercontent.com/8126518/67430723-d9490000-f5b0-11e9-8f9e-86686dcd5e17.png)
![Screen Shot 2019-10-23 at 4 18 20 PM](https://user-images.githubusercontent.com/8126518/67430724-d9e19680-f5b0-11e9-9c49-cd3a0684e0c1.png)
![Screen Shot 2019-10-23 at 4 18 35 PM](https://user-images.githubusercontent.com/8126518/67430725-d9e19680-f5b0-11e9-9c21-6a64925f8898.png)

Wrapping with long text:
![Screen Shot 2019-10-27 at 2 14 12 PM](https://user-images.githubusercontent.com/8126518/67639399-a14dff80-f8c5-11e9-9f7e-57d7ac08d427.png)
