### PR TITLE
Fix for Project Details Workloads not being scoped to NS

### DIFF
--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -299,7 +299,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       perspective: 'dev',
-      path: ['/k8s/cluster/projects/:ns'],
+      path: ['/k8s/cluster/projects/:name'],
       loader: async () =>
         (await import(
           './components/projects/details/ProjectDetailsPage' /* webpackChunkName: "project-details" */


### PR DESCRIPTION
https://jira.coreos.com/browse/ODC-2094

Fixes an issue where the workloads tab in the Project Details pulled all namespaces instead of the specific one you were looking at.