### PR TITLE
Query Browser: Reduce the minimum number of data samples

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -296,7 +296,7 @@ const maxDataPointsSoft = 6000;
 const maxDataPointsHard = 10000;
 
 // Min and max number of data samples per data series
-const minSamples = 20;
+const minSamples = 10;
 const maxSamples = 300;
 
 // We don't want to refresh all the graph data for just a small adjustment in the number of samples, so don't update


### PR DESCRIPTION
Reduce the minimum number of data samples per series (line on the graph)
to 10. This allows the graph to render fewer data points in 2 cases
  - The time range is very short
  - There are hundreds of data series to render