### PR TITLE
Retitle project's Utilization Card

### DIFF
--- a/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
@@ -68,7 +68,7 @@ export const UtilizationCard = withDashboardResources(
     return (
       <DashboardCard>
         <DashboardCardHeader>
-          <DashboardCardTitle>Utilization Card</DashboardCardTitle>
+          <DashboardCardTitle>Utilization</DashboardCardTitle>
           <Dropdown
             items={metricDurationsOptions}
             onChange={setDuration}


### PR DESCRIPTION
Former title: `Utilization Card`
Fixed to: just `Utilization`