### PR TITLE
Wait for cluster version resource to load

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/status-card.tsx
@@ -167,6 +167,7 @@ const ClusterAlerts = withDashboardResources(
     const alerts = getAlerts(alertsResponse);
 
     const cv = _.get(resources.cv, 'data') as ClusterVersionKind;
+    const cvLoaded = _.get(resources.cv, 'loaded');
     const LinkComponent = React.useCallback(
       () => (
         <Button
@@ -186,7 +187,7 @@ const ClusterAlerts = withDashboardResources(
 
     return (
       <AlertsBody
-        isLoading={!alertsResponse}
+        isLoading={!(alertsResponse && cvLoaded)}
         error={alertsResponseError}
         emptyMessage="No cluster alerts or messages"
       >


### PR DESCRIPTION
@spadgett this will fix the case when alerts are loaded (and there arent any) and the status card will show `No cluster alerts or messages` and after a while Cluster Version resource is loaded and the card will show available update.