### PR TITLE
Query Browser: Prevent some unnecessary query_range API calls

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -411,9 +411,10 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   // use a polling interval relative to the graph's timespan.
   const delay = endTime || hideGraphs ? null : Math.max(span / 120, minPollInterval);
 
-  usePoll(tick, delay, endTime, namespace, queries, samples, span);
+  const queriesKey = _.reject(queries, _.isEmpty).join();
+  usePoll(tick, delay, endTime, namespace, queriesKey, samples, span);
 
-  React.useEffect(() => setUpdating(true), [endTime, queries, samples, span]);
+  React.useEffect(() => setUpdating(true), [endTime, namespace, queriesKey, samples, span]);
 
   const graphData: GraphDataPoint[][] = React.useMemo(
     () =>


### PR DESCRIPTION
The following UI interactions were triggering a Prometheus `query_range`
API call, even though we know they will not change the graph data.
  - Adding or deleting an empty query
  - Enabling or disabling an empty query

Also fixes a bug where the loading indicator was not shown when a graph
update was triggered by changing the namespace (Developer perspective).