### PR TITLE
Alertmanager Configuration: Edit & Delete Receivers

### DIFF
--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -467,6 +467,15 @@ const AppContents = connect((state: RootState) => ({
                 }
               />
               <LazyRoute
+                path="/monitoring/alertmanagerconfig/receivers/:name/edit"
+                exact
+                loader={() =>
+                  import(
+                    './monitoring/alert-manager-receiver-forms' /* webpackChunkName: "monitoring" */
+                  ).then((m) => m.EditReceiver)
+                }
+              />
+              <LazyRoute
                 path="/monitoring"
                 loader={() =>
                   import('./monitoring' /* webpackChunkName: "monitoring" */).then(

--- a/frontend/public/components/monitoring/alert-manager-config.tsx
+++ b/frontend/public/components/monitoring/alert-manager-config.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as fuzzy from 'fuzzysearch';
-
-import { K8sResourceKind } from '../../module/k8s';
-import { MsgBox, SectionHeading, StatusBox } from '../utils';
-import { createAlertRoutingModal } from '../modals';
-import { Table, TableData, TableRow, TextFilter } from '../factory';
+import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import {
@@ -16,10 +12,21 @@ import {
   EmptyStateVariant,
   Title,
 } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
-import { getAlertManagerConfig } from './alert-manager-utils';
 
-const AlertRouting: React.FC<AlertManagerProps> = ({ config, secret }) => {
+import { K8sResourceKind } from '../../module/k8s';
+import { history, Kebab, MsgBox, SectionHeading, StatusBox } from '../utils';
+import { confirmModal, createAlertRoutingModal } from '../modals';
+import { Table, TableData, TableRow, TextFilter } from '../factory';
+import {
+  getAlertManagerConfig,
+  patchAlertManagerConfig,
+  receiverTypes,
+} from './alert-manager-utils';
+
+let secret: K8sResourceKind = null; // alertmanager-main Secret which holds alertmanager configuration yaml
+let config: AlertManagerConfig = null; // alertmanager configuration yaml as object
+
+const AlertRouting = () => {
   const groupBy = _.get(config, ['route', 'group_by'], []);
   return (
     <div className="co-m-pane__body">
@@ -56,6 +63,7 @@ const tableColumnClasses = [
   classNames('col-lg-3', 'col-md-3', 'col-sm-6', 'col-xs-6'),
   classNames('col-lg-3', 'col-md-3', 'hidden-sm', 'hidden-xs'),
   classNames('col-lg-6', 'col-md-6', 'col-sm-6', 'col-xs-6'),
+  Kebab.columnClass,
 ];
 
 const ReceiverTableHeader = () => {
@@ -74,34 +82,90 @@ const ReceiverTableHeader = () => {
       title: 'Routing Labels',
       props: { className: tableColumnClasses[2] },
     },
+    {
+      title: '',
+      props: { className: tableColumnClasses[3] },
+    },
   ];
 };
 ReceiverTableHeader.displayName = 'ReceiverTableHeader';
 
-const getIntegrationTypes = (receiver) => {
+const getIntegrationTypes = (receiver: AlertManagerReceiver): string[] => {
   /* Given receiver = {
        "name": "team-X-pager",
        "email_configs": [...],
        "pagerduty_configs": [...]
      };
-     returns "email, pagerduty"
+     returns ['email_configs', 'pagerduty_configs']
   */
-  const integrationTypes = _.filter(_.keys(receiver), (key) => _.includes(key, '_configs'));
-  return _.join(_.map(integrationTypes, (type) => type.substr(0, type.indexOf('_configs'))), ', ');
+  return _.filter(_.keys(receiver), (v) => _.endsWith(v, '_configs'));
 };
 
-// Recursive function to get hierarchy of routing labels for each receiver
-const getRoutingLabels = (routes, parentLabels) => {
-  let results = [];
+/**
+ * Recursive function which transverses routes and sub-routes to get labels for each receiver.
+ * Each entry is a set of labels used to route alerts to a receiver
+ *
+ * Ex: returns
+ * [{
+ *   "receiver": "team-Y-pager",
+ *   "labels": {
+ *     "service": "database",
+ *     "owner": "team-Y"
+ *   }
+ * },
+ * {
+ *   "receiver": "team-Y-pager",
+ *   "labels": {
+ *     "service": "files",
+ *     "severity": "critical"
+ *   }
+ * }]
+}*/
+const getRoutingLabelsByReceivers = (routes, parentLabels): RoutingLabelsByReceivers[] => {
+  let results: RoutingLabelsByReceivers[] = [];
   let labels = {};
   for (const obj of routes) {
     labels = _.merge({}, parentLabels, obj.match, obj.match_re);
     results.push({ receiver: obj.receiver, labels });
     if (obj.routes) {
-      results = results.concat(getRoutingLabels(obj.routes, labels));
+      results = results.concat(getRoutingLabelsByReceivers(obj.routes, labels));
     }
   }
   return results;
+};
+
+/**
+ * Is receiver used in a top-level route that has no sub routes, or
+ * is receiver not in any route (no routing labels)?
+ */
+const hasSimpleRoute = (
+  receiver: AlertManagerReceiver,
+  receiverRoutingLabels: RoutingLabelsByReceivers[],
+): boolean => {
+  const routes = _.get(config, ['route', 'routes']);
+  return (
+    _.filter(routes, (route) => {
+      return route.receiver === receiver.name && _.isUndefined(route.routes);
+    }).length > 0 || _.isEmpty(receiverRoutingLabels)
+  );
+};
+
+/**
+ * Does receiver contains a single known receiver type (ex: pagerduty_config), which has a single config.
+ * No receiver type specified is valid, as well as a single receiver type with no config
+ */
+const hasSimpleReceiver = (
+  receiver: AlertManagerReceiver,
+  receiverIntegrationTypes: string[],
+): boolean => {
+  if (receiverIntegrationTypes.length === 0) {
+    return true;
+  } else if (receiverIntegrationTypes.length === 1) {
+    const receiverConfig = receiverIntegrationTypes[0]; // ex: 'pagerduty_configs'
+    const numConfigs = _.get(receiver, receiverConfig).length; // 'pagerduty_configs' is array and may have multiple sets of properties
+    return _.hasIn(receiverTypes, receiverConfig) && numConfigs <= 1; // known receiver type and a single set of props
+  }
+  return false;
 };
 
 // Puts sets of key=value pairs into single comma delimited label
@@ -122,28 +186,93 @@ const RoutingLabel: React.FC<RoutingLabelProps> = ({ labels }) => {
       </React.Fragment>
     );
   });
-  return <div className="co-m-label co-m-label--expand">{list}</div>;
+  return (
+    <div>
+      <div className="co-m-label co-m-label--expand">{list}</div>
+    </div>
+  );
 };
+
+const deleteReceiver = (receiverName: string) => {
+  // remove any routes which use receiverToDelete
+  _.update(config, 'route.routes', (routes) => {
+    _.remove(routes, (route: AlertManagerRoute) => route.receiver === receiverName);
+    return routes;
+  });
+  // delete receiver
+  _.update(config, 'receivers', (receivers) => {
+    _.remove(receivers, (receiver: AlertManagerReceiver) => receiver.name === receiverName);
+    return receivers;
+  });
+  return patchAlertManagerConfig(secret, config).then(() => {
+    history.push('/monitoring/alertmanagerconfig');
+  });
+};
+
+const receiverMenuItems = (receiverName: string, canDelete: boolean, canUseEditForm: boolean) => [
+  {
+    label: `Edit ${canUseEditForm ? 'Receiver' : 'YAML'}`,
+    callback: () => {
+      const targetUrl = canUseEditForm
+        ? `/monitoring/alertmanagerconfig/receivers/${receiverName}/edit`
+        : `/monitoring/alertmanageryaml`;
+      return history.push(targetUrl);
+    },
+  },
+  {
+    label: 'Delete Receiver',
+    isDisabled: !canDelete,
+    tooltip: !canDelete
+      ? 'Cannot delete the default receiver, or a receiver which has a sub-route'
+      : '',
+    callback: () =>
+      confirmModal({
+        title: 'Delete Receiver',
+        message: `Are you sure you want to delete receiver '${receiverName}' ?`,
+        btnText: 'Delete Receiver',
+        executeFn: () => deleteReceiver(receiverName),
+      }),
+  },
+];
 
 const ReceiverTableRow: React.FC<ReceiverTableRowProps> = ({
   obj: receiver,
   index,
   key,
   style,
-  customData: routingLabels,
+  customData,
 }) => {
+  const { routingLabelsByReceivers, defaultReceiverName } = customData;
   // filter to routing labels belonging to current Receiver
-  const receiverRoutingLabels = _.filter(routingLabels, { receiver: receiver.name });
+  const receiverRoutingLabels = _.filter(routingLabelsByReceivers, { receiver: receiver.name });
+  const receiverIntegrationTypes = getIntegrationTypes(receiver);
+  const integrationTypesLabel = _.join(
+    _.map(receiverIntegrationTypes, (type) => type.substr(0, type.indexOf('_configs'))),
+    ', ',
+  );
+  const isDefaultReceiver = receiver.name === defaultReceiverName;
+  const receiverHasSimpleRoute = hasSimpleRoute(receiver, receiverRoutingLabels);
+
+  // Receiver form can only handle simple configurations. Can edit via form if receiver
+  // has a simple route and receiver
+  const canUseEditForm =
+    receiverHasSimpleRoute && hasSimpleReceiver(receiver, receiverIntegrationTypes);
+
+  // Receivers can be deleted if it has a simple route and not the default receiver
+  const canDelete = !isDefaultReceiver && receiverHasSimpleRoute;
+
   return (
     <TableRow id={index} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>{receiver.name}</TableData>
-      <TableData className={tableColumnClasses[1]}>{getIntegrationTypes(receiver)}</TableData>
+      <TableData className={tableColumnClasses[1]}>{integrationTypesLabel}</TableData>
       <TableData className={tableColumnClasses[2]}>
-        {_.map(receiverRoutingLabels, (route, i) => (
-          <div key={i}>
-            <RoutingLabel labels={_.get(route, 'labels')} />
-          </div>
-        ))}
+        {isDefaultReceiver && <RoutingLabel labels={{ default: 'all' }} />}
+        {_.map(receiverRoutingLabels, (route, i) => {
+          return !_.isEmpty(route.labels) ? <RoutingLabel key={i} labels={route.labels} /> : null;
+        })}
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <Kebab options={receiverMenuItems(receiver.name, canDelete, canUseEditForm)} />
       </TableData>
     </TableRow>
   );
@@ -151,19 +280,17 @@ const ReceiverTableRow: React.FC<ReceiverTableRowProps> = ({
 ReceiverTableRow.displayName = 'ReceiverTableRow';
 
 const ReceiversTable: React.FC<ReceiverTableProps> = (props) => {
-  const { route, filterValue } = props;
-  const { receiver: defaultReceiver, routes } = route;
+  const { filterValue } = props;
+  const { route } = config;
+  const { receiver: defaultReceiverName, routes } = route;
 
-  const routingLabels = _.isEmpty(routes) ? [] : getRoutingLabels(routes, {});
-  if (defaultReceiver) {
-    routingLabels.push({ receiver: defaultReceiver, labels: { default: 'all' } });
-  }
+  const routingLabelsByReceivers = _.isEmpty(routes) ? [] : getRoutingLabelsByReceivers(routes, {});
   const EmptyMsg = () => <MsgBox title={`No Receivers match filter '${filterValue}'`} />;
   return (
     <Table
       {...props}
       aria-label="Receivers"
-      customData={routingLabels}
+      customData={{ routingLabelsByReceivers, defaultReceiverName }}
       EmptyMsg={EmptyMsg}
       Header={ReceiverTableHeader}
       Row={ReceiverTableRow}
@@ -187,7 +314,7 @@ const ReceiversEmptyState: React.FC = () => (
   </EmptyState>
 );
 
-const Receivers: React.FC<AlertManagerProps> = ({ config }) => {
+const Receivers = () => {
   const [receiverFilter, setReceiverFilter] = React.useState('');
   let receivers = _.get(config, 'receivers', []);
   if (receiverFilter) {
@@ -216,19 +343,15 @@ const Receivers: React.FC<AlertManagerProps> = ({ config }) => {
       {_.isEmpty(receivers) && !receiverFilter ? (
         <ReceiversEmptyState />
       ) : (
-        <ReceiversTable
-          filterValue={receiverFilter}
-          data={receivers}
-          route={_.get(config, 'route')}
-        />
+        <ReceiversTable filterValue={receiverFilter} data={receivers} />
       )}
     </div>
   );
 };
 
-const AlertManagerConfiguration: React.FC<AlertManagerConfigurationProps> = ({ obj: secret }) => {
+const AlertManagerConfiguration: React.FC<AlertManagerConfigurationProps> = ({ obj }) => {
   const [errorMsg, setErrorMsg] = React.useState('');
-  let config: AlertManagerConfig;
+  secret = obj; // alertmanager-main Secret which holds encoded alertmanager configuration yaml
   if (!errorMsg) {
     config = getAlertManagerConfig(secret, setErrorMsg);
   }
@@ -248,8 +371,8 @@ const AlertManagerConfiguration: React.FC<AlertManagerConfigurationProps> = ({ o
 
   return (
     <>
-      <AlertRouting secret={secret} config={config} />
-      <Receivers config={config} />
+      <AlertRouting />
+      <Receivers />
     </>
   );
 };
@@ -279,7 +402,7 @@ type labels = {
   [key: string]: string;
 };
 
-type AlertManagerRoute = {
+export type AlertManagerRoute = {
   receiver?: string;
   groupBy?: { [key: string]: string };
   groupWait?: string;
@@ -290,13 +413,24 @@ type AlertManagerRoute = {
   routes?: AlertManagerRoute[];
 };
 
-type RoutesByReceivers = {
+type RoutingLabelsByReceivers = {
   receiver: string;
   labels: { [key: string]: string };
 };
 
+type WebhookConfig = {
+  url: string;
+};
+
+type PagerDutyConfig = {
+  routingKey?: string;
+  serviceKey?: string;
+};
+
 export type AlertManagerReceiver = {
   name: string;
+  webhookConfigs?: WebhookConfig[];
+  pagerdutyConfigs?: PagerDutyConfig[];
 };
 
 export type AlertManagerConfig = {
@@ -304,15 +438,9 @@ export type AlertManagerConfig = {
   receivers: AlertManagerReceiver[];
 };
 
-type AlertManagerProps = {
-  config: AlertManagerConfig;
-  secret?: K8sResourceKind;
-};
-
 type ReceiverTableProps = {
   data: AlertManagerReceiver[];
   filterValue?: string;
-  route: AlertManagerRoute;
 };
 
 type ReceiverTableRowProps = {
@@ -320,7 +448,10 @@ type ReceiverTableRowProps = {
   index: number;
   key?: string;
   style: object;
-  customData: RoutesByReceivers;
+  customData: {
+    routingLabelsByReceivers: RoutingLabelsByReceivers[];
+    defaultReceiverName: string;
+  };
 };
 
 type RoutingLabelProps = {

--- a/frontend/public/components/monitoring/alert-manager-utils.tsx
+++ b/frontend/public/components/monitoring/alert-manager-utils.tsx
@@ -1,10 +1,17 @@
+/* eslint-disable camelcase */
 import * as _ from 'lodash-es';
 import { Base64 } from 'js-base64';
 import { safeLoad, safeDump } from 'js-yaml';
 
 import { k8sPatch, K8sResourceKind } from '../../module/k8s';
-import { AlertManagerConfig } from './alert-manager-config';
+import {
+  AlertManagerConfig,
+  AlertManagerReceiver,
+  AlertManagerRoute,
+} from './alert-manager-config';
 import { SecretModel } from '../../models';
+
+export const DEFAULT_RECEIVER_LABEL = 'All (default receiver)';
 
 export const getAlertManagerConfig = (secret: K8sResourceKind, setErrorMsg) => {
   const alertManagerYaml = _.get(secret, ['data', 'alertmanager.yaml']);
@@ -36,6 +43,138 @@ export const patchAlertManagerConfig = (
 };
 
 export const receiverTypes = {
-  pagerduty: 'PagerDuty',
-  webhook: 'Webhook Receiver',
+  pagerduty_configs: 'PagerDuty',
+  webhook_configs: 'Webhook Receiver',
+};
+
+/**
+ * Converts route object:
+ * {
+ *   receiver: "MyReceiver",
+ *   match: {
+ *     severity: "warning",
+ *     cluster: "myCluster"
+ *   },
+ *   match_re: {
+ *    service: "$foobar"
+ *  }
+};
+ * ...to array of labels for Routing Labels form component
+ * [
+ *   {
+ *     "name": "severity",
+ *     "value": "warning",
+ *     "isRegex": false
+ *   },
+ *   {
+ *     "name": "cluster",
+ *     "value": "myCluster",
+ *     "isRegex": false
+ *   },
+ *   {
+ *     "name": "service",
+ *     "value": "$foobar",
+ *     "isRegex": true
+ *   }
+ * ]
+ */
+export const getRouteLabelsForForm = (
+  receiver: AlertManagerReceiver,
+  routes: AlertManagerRoute[],
+) => {
+  const routesOfReceiver = _.find(
+    routes,
+    (aRoute: AlertManagerRoute) => aRoute.receiver === receiver.name,
+  );
+  const matches = _.map(_.get(routesOfReceiver, 'match', {}), (v, k) => {
+    return { name: k, value: v, isRegex: false };
+  });
+  const regexMatches = _.map(_.get(routesOfReceiver, 'match_re', {}), (v, k) => {
+    return { name: k, value: v, isRegex: true };
+  });
+  return _.concat([], matches, regexMatches);
+};
+
+/**
+ * Returns new Route object
+ * Ex:
+ * {
+ *   receiver: myNewReceiver,
+ *   match: {
+ *     "severity": "warning",
+ *     "cluster": "myCluster"
+ *   }
+ *   match_re {
+ *     "service": "^(foo1|foo2|baz)$",
+ *   }
+ * }
+ */
+export const createRoute = (receiver: AlertManagerReceiver, routeLabels) => {
+  const newRoute = { receiver: receiver.name };
+  _.each(routeLabels, (label) => {
+    _.set(newRoute, [label.isRegex ? 'match_re' : 'match', label.name], label.value);
+  });
+  return newRoute;
+};
+
+/**
+ * Returns new Receiver object
+ * Ex:
+ * {
+ *   name: MyNewReceiver
+ *   pagerduty_configs: {
+ *     routing_key: <integration_key>
+ *   }
+ * }
+ */
+export const createReceiver = (
+  receiverName: string,
+  receiverType: string,
+  pagerDutyValues: any,
+  webhookUrl: string,
+) => {
+  let receiverConfig;
+  switch (receiverType) {
+    case 'pagerduty_configs':
+      // eslint-disable-next-line no-case-declarations
+      const pagerDutyIntegrationKeyName = `${
+        pagerDutyValues.integrationType === 'events' ? 'routing' : 'service'
+      }_key`;
+      receiverConfig = {
+        [pagerDutyIntegrationKeyName]: pagerDutyValues.integrationKey,
+      };
+      break;
+    case 'webhook_configs':
+      receiverConfig = { url: webhookUrl };
+      break;
+    default:
+  }
+  return {
+    name: receiverName,
+    [receiverType]: [{ ...receiverConfig }],
+  };
+};
+
+export const isDefaultReceiverLabel = (routeLabel: AlertRoutingLabel) => {
+  return routeLabel.name === DEFAULT_RECEIVER_LABEL && routeLabel.value === DEFAULT_RECEIVER_LABEL;
+};
+
+export const addDefaultReceiverLabel = () => [
+  { name: DEFAULT_RECEIVER_LABEL, value: DEFAULT_RECEIVER_LABEL, isRegex: false },
+];
+
+export const removeDefaultReceiverLabel = (routeLabels: AlertRoutingLabel[]) => {
+  const index = _.findIndex(routeLabels, {
+    name: DEFAULT_RECEIVER_LABEL,
+    value: DEFAULT_RECEIVER_LABEL,
+  });
+  if (index !== -1) {
+    routeLabels.splice(index, 1);
+  }
+};
+
+type AlertRoutingLabel = {
+  name: string;
+  value: string;
+  isRegex: boolean;
 };

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { connect } from 'react-redux';
-import { KEY_CODES } from '@patternfly/react-core';
+import { KEY_CODES, Tooltip } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import {
   annotationsModal,
@@ -59,10 +59,22 @@ const KebabItemAccessReview_ = (props: KebabItemProps & { impersonate: string })
 const KebabItemAccessReview = connect(impersonateStateToProps)(KebabItemAccessReview_);
 
 export const KebabItem: React.FC<KebabItemProps> = (props) => {
-  return props.option.accessReview ? (
-    <KebabItemAccessReview {...props} />
+  let item;
+
+  if (props.option.accessReview) {
+    item = <KebabItemAccessReview {...props} />;
+  } else if (props.option.isDisabled) {
+    item = <KebabItemDisabled option={props.option} />;
+  } else {
+    item = <KebabItemEnabled {...props} />;
+  }
+
+  return props.option.tooltip ? (
+    <Tooltip position="left" content={props.option.tooltip}>
+      {item}
+    </Tooltip>
   ) : (
-    <KebabItemEnabled {...props} />
+    item
   );
 };
 
@@ -282,6 +294,8 @@ export type KebabOption = {
   href?: string;
   callback?: () => any;
   accessReview?: AccessReviewResourceAttributes;
+  isDisabled?: boolean;
+  tooltip?: string;
 };
 export type KebabAction = (
   kind: K8sKind,

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -432,3 +432,8 @@ h6 {
   // see https://github.com/xtermjs/xterm.js/issues/1974
   border-right: 1px solid transparent;
 }
+
+button.pf-c-dropdown__menu-item.pf-m-disabled  {
+  // enables tooltips for disabled menu items
+  pointer-events: auto;
+}


### PR DESCRIPTION
Added kebab menu for Receivers Table rows with edit and delete options.  The edit menu item will say 'Edit Receiver' when can be edited via form, else will say 'Edit YAML'.  @cshinn I know this is a little different from design, let me know if ok.  Also, next PR will move these to Admin -> Cluster Settings and change the action items on the Configuration page per updated designs.
![image](https://user-images.githubusercontent.com/12733153/67584638-167dd100-f71c-11e9-9ea9-e993a1bfc6ab.png)

### **Edit Default Receiver**
* which doesn't have a Receiver Type specified
![image](https://user-images.githubusercontent.com/12733153/67585685-11ba1c80-f71e-11e9-9e04-01791f07a3b9.png)

- After selecting 'PagerDuty' Receiver Type
![image](https://user-images.githubusercontent.com/12733153/67587804-96a73500-f722-11e9-9c51-ec1a79636658.png)

### **Edit YAML scenario**
![image](https://user-images.githubusercontent.com/12733153/67587673-5f388880-f722-11e9-9924-21f146eb3d4a.png)

