### PR TITLE
adds utils to process kn resources to data model

### DIFF
--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -171,7 +171,7 @@ export const getBuildAlerts = (buildConfigs: BuildConfigOverviewItem[]): Overvie
   return buildAlerts;
 };
 
-const getOwnedResources = <T extends K8sResourceKind>(
+export const getOwnedResources = <T extends K8sResourceKind>(
   { metadata: { uid } }: K8sResourceKind,
   resources: T[],
 ): T[] => {

--- a/frontend/packages/dev-console/src/components/topology/D3ForceDirectedRenderer.tsx
+++ b/frontend/packages/dev-console/src/components/topology/D3ForceDirectedRenderer.tsx
@@ -1255,7 +1255,7 @@ class EdgeWrapper extends React.Component<EdgeWrapperProps> {
   componentDidUpdate(prevProps: EdgeWrapperProps) {
     if (prevProps.view !== this.props.view) {
       // we need to update the data so that d3 apis get the correct new edge
-      this.$targetArrow.datum(this.props.view);
+      this.$targetArrow && this.$targetArrow.datum(this.props.view);
     }
   }
 

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
@@ -198,6 +198,16 @@ const sampleKnativeConfigurations: FirehoseResult = {
           'serving.knative.dev/route': 'overlayimage',
           'serving.knative.dev/service': 'overlayimage',
         },
+        ownerReferences: [
+          {
+            apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+            kind: RouteModel.kind,
+            name: 'overlayimage',
+            uid: 'cea9496b-8ce0-11e9-bb7b-0ebb55b110b8',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
       },
       spec: {},
       status: {
@@ -228,6 +238,16 @@ const sampleKnativeRevisions: FirehoseResult = {
           'serving.knative.dev/configurationGeneration': '2',
           'serving.knative.dev/service': 'overlayimage',
         },
+        ownerReferences: [
+          {
+            apiVersion: `${ConfigurationModel.apiGroup}/${ConfigurationModel.apiVersion}`,
+            kind: RouteModel.kind,
+            name: 'overlayimage',
+            uid: '1317f615-9636-11e9-b134-06a61d886b62',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
       },
       spec: {},
       status: {
@@ -256,6 +276,16 @@ export const sampleKnativeRoutes: FirehoseResult = {
           'serving.knative.dev/route': 'overlayimage',
           'serving.knative.dev/service': 'overlayimage',
         },
+        ownerReferences: [
+          {
+            apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+            kind: RouteModel.kind,
+            name: 'overlayimage',
+            uid: 'cea9496b-8ce0-11e9-bb7b-0ebb55b110b8',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
       },
       spec: {},
       status: {
@@ -280,12 +310,27 @@ export const sampleKnativeServices: FirehoseResult = {
         uid: 'cea9496b-8ce0-11e9-bb7b-0ebb55b110b8',
         resourceVersion: '1157349',
       },
-      spec: {},
+      spec: {
+        template: {
+          metadata: {
+            labels: {
+              'app.kubernetes.io/part-of': 'myapp',
+            },
+          },
+        },
+      },
       status: {
         observedGeneration: 1,
         url: 'http://overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
         latestCreatedRevisionName: 'overlayimage-fdqsf',
         latestReadyRevisionName: 'overlayimage-fdqsf',
+        traffic: [
+          {
+            latestRevision: true,
+            percent: 100,
+            revisionName: 'overlayimage-fdqsf',
+          },
+        ],
       },
     },
   ],

--- a/frontend/packages/dev-console/src/components/topology/shape-providers.ts
+++ b/frontend/packages/dev-console/src/components/topology/shape-providers.ts
@@ -9,6 +9,8 @@ export const nodeProvider: NodeProvider = (type) => {
   switch (type) {
     case 'workload':
       return WorkloadNode;
+    case 'revision':
+      return WorkloadNode;
     default:
       return DefaultNode;
   }

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -66,8 +66,8 @@ export interface TopologyDataModel {
 }
 
 export type TopologyOverviewItem = OverviewItem & {
-  pipelines: Pipeline[];
-  pipelineRuns: PipelineRun[];
+  pipelines?: Pipeline[];
+  pipelineRuns?: PipelineRun[];
 };
 
 export interface TopologyDataObject<D = {}> {
@@ -75,7 +75,7 @@ export interface TopologyDataObject<D = {}> {
   name: string;
   type: string;
   resources: OverviewItem;
-  pods: ExtPodKind[];
+  pods?: ExtPodKind[];
   data: D;
   operatorBackedService: boolean;
 }

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -58,7 +58,7 @@ const getRouteData = (ksroute: K8sResourceKind[]): string => {
 /**
  * get routes url
  */
-const getRoutesUrl = (routes: RouteKind[], ksroute?: K8sResourceKind[]): string => {
+export const getRoutesUrl = (routes: RouteKind[], ksroute?: K8sResourceKind[]): string => {
   if (routes.length > 0 && !_.isEmpty(routes[0].spec)) {
     return getRouteWebURL(routes[0]);
   }
@@ -86,10 +86,11 @@ const createInstanceForResource = (resources: TopologyDataResources, utils?: Fun
  * @param dc resource item
  * @param cheURL che link
  */
-const createTopologyNodeData = (
+export const createTopologyNodeData = (
   dc: TopologyOverviewItem,
   operatorBackedServiceKinds: string[],
   cheURL?: string,
+  type?: string,
 ): TopologyDataObject => {
   const {
     obj: deploymentConfig,
@@ -108,7 +109,7 @@ const createTopologyNodeData = (
     id: dcUID,
     name:
       _.get(deploymentConfig, 'metadata.name') || deploymentsLabels['app.kubernetes.io/instance'],
-    type: 'workload',
+    type: type || 'workload',
     resources: { ...dc },
     pods: dc.pods,
     operatorBackedService: operatorBackedServiceKinds.includes(nodeResourceKind),
@@ -222,7 +223,7 @@ const getTopologyEdgeItems = (
  * @param dc
  * @param groups
  */
-const getTopologyGroupItems = (dc: K8sResourceKind, groups: Group[]): Group[] => {
+export const getTopologyGroupItems = (dc: K8sResourceKind, groups: Group[]): Group[] => {
   const labels = _.get(dc, ['metadata', 'labels']);
   const uid = _.get(dc, ['metadata', 'uid']);
   _.forEach(labels, (label, key) => {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
@@ -1,0 +1,107 @@
+import { MockKnativeResources } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import {
+  getKnativeServiceData,
+  getKnativeTopologyNodeItem,
+  getEventTopologyEdgeItems,
+  getTrafficTopologyEdgeItems,
+  filterKnativeBasedOnActiveApplication,
+  getTopologyServiceGroupItems,
+  nodeType,
+} from '../knative-topology-utils';
+
+describe('knative topology utils', () => {
+  it('expect getKnativeServiceData to return knative resources', () => {
+    const knResource = getKnativeServiceData(
+      MockKnativeResources.ksservices.data[0],
+      MockKnativeResources,
+    );
+    expect(knResource.ksroutes).toBeDefined();
+    expect(knResource.ksroutes).toHaveLength(1);
+    expect(knResource.configurations).toBeDefined();
+    expect(knResource.configurations).toHaveLength(1);
+    expect(knResource.revisions).toBeDefined();
+    expect(knResource.revisions).toHaveLength(1);
+  });
+
+  it('expect getKnativeTopologyNodeItem to return node data for service', () => {
+    const knServiceNode = getKnativeTopologyNodeItem(
+      MockKnativeResources.ksservices.data[0],
+      nodeType.KnService,
+      MockKnativeResources,
+    );
+    expect(knServiceNode).toBeDefined();
+    expect(knServiceNode).toHaveProperty('children');
+    expect(knServiceNode.id).toBe('cea9496b-8ce0-11e9-bb7b-0ebb55b110b8');
+    expect(knServiceNode.type).toBe(nodeType.KnService);
+  });
+
+  it('expect getKnativeTopologyNodeItem to return node data for revision', () => {
+    const knServiceNode = getKnativeTopologyNodeItem(
+      MockKnativeResources.revisions.data[0],
+      nodeType.Revision,
+      MockKnativeResources,
+    );
+    expect(knServiceNode).toBeDefined();
+    expect(knServiceNode.id).toBe('02c34a0e-9638-11e9-b134-06a61d886b62');
+    expect(knServiceNode.type).toBe(nodeType.Revision);
+  });
+
+  it('expect getKnativeTopologyNodeItem to return node data for event sources', () => {
+    const knServiceNode = getKnativeTopologyNodeItem(
+      MockKnativeResources.eventSourceCronjob.data[0],
+      nodeType.EventSource,
+      MockKnativeResources,
+    );
+    expect(knServiceNode).toBeDefined();
+    expect(knServiceNode.id).toBe('1317f615-9636-11e9-b134-06a61d886b689');
+    expect(knServiceNode.type).toBe(nodeType.EventSource);
+  });
+
+  it('expect getEventTopologyEdgeItems to return edge data for event sources', () => {
+    const knEventEdge = getEventTopologyEdgeItems(
+      MockKnativeResources.eventSourceCronjob.data[0],
+      MockKnativeResources.ksservices,
+    );
+    expect(knEventEdge).toBeDefined();
+    expect(knEventEdge).toHaveLength(1);
+    expect(knEventEdge[0].source).toBe('1317f615-9636-11e9-b134-06a61d886b689');
+    expect(knEventEdge[0].target).toBe('cea9496b-8ce0-11e9-bb7b-0ebb55b110b8');
+    expect(knEventEdge[0].type).toBe('connects-to-src');
+  });
+
+  it('expect getTrafficTopologyEdgeItems to return edge data for knative revisions with traffic split info', () => {
+    const knRevisionsEdge = getTrafficTopologyEdgeItems(
+      MockKnativeResources.ksservices.data[0],
+      MockKnativeResources.revisions,
+    );
+    expect(knRevisionsEdge).toBeDefined();
+    expect(knRevisionsEdge).toHaveLength(1);
+    expect(knRevisionsEdge[0].source).toBe('cea9496b-8ce0-11e9-bb7b-0ebb55b110b8');
+    expect(knRevisionsEdge[0].target).toBe('02c34a0e-9638-11e9-b134-06a61d886b62');
+    expect(knRevisionsEdge[0].type).toBe('connects-to-traffic');
+  });
+
+  it('expect filterKnativeBasedOnActiveApplication to return resources based on active application', () => {
+    const activeApplications = filterKnativeBasedOnActiveApplication(
+      MockKnativeResources.ksservices.data,
+      'myapp',
+    );
+    expect(activeApplications).toBeDefined();
+    expect(activeApplications).toHaveLength(1);
+  });
+
+  it('expect filterKnativeBasedOnActiveApplication to return resources based on active application', () => {
+    const activeApplications = filterKnativeBasedOnActiveApplication(
+      MockKnativeResources.revisions.data,
+      'myapp',
+    );
+    expect(activeApplications).toBeDefined();
+    expect(activeApplications).toHaveLength(0);
+  });
+
+  it('expect getTopologyServiceGroupItems to form group data based on labels', () => {
+    const groupData = getTopologyServiceGroupItems(MockKnativeResources.ksservices.data[0], []);
+    expect(groupData).toBeDefined();
+    expect(groupData).toHaveLength(1);
+  });
+});

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { KNATIVE_SERVING_LABEL } from '../const';
 
-type KnativeItem = {
+export type KnativeItem = {
   revisions?: K8sResourceKind[];
   configurations?: K8sResourceKind[];
   ksroutes?: K8sResourceKind[];

--- a/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
@@ -1,0 +1,333 @@
+import * as _ from 'lodash';
+import { K8sResourceKind, apiVersionForModel, DeploymentKind } from '@console/internal/module/k8s';
+import {
+  TransformResourceData,
+  getResourcePausedAlert,
+  getBuildAlerts,
+  getOwnedResources,
+  OverviewItem,
+} from '@console/shared';
+import {
+  Node,
+  Edge,
+  Group,
+  TopologyDataResources,
+  TopologyDataModel,
+  TopologyDataObject,
+} from '@console/dev-console/src/components/topology/topology-types';
+import {
+  getTopologyGroupItems,
+  createTopologyNodeData,
+  getRoutesUrl,
+  getEditURL,
+} from '@console/dev-console/src/components/topology/topology-utils';
+import { DeploymentModel } from '@console/internal/models';
+import { KnativeItem } from './get-knative-resources';
+
+export enum nodeType {
+  EventSource = 'eventsource',
+  KnService = 'knservice',
+  Revision = 'revision',
+}
+
+/**
+ * Forms data with respective revisions, configurations, routes based on kntaive service
+ */
+export const getKnativeServiceData = (
+  resource: K8sResourceKind,
+  resources: TopologyDataResources,
+): KnativeItem => {
+  const configurations = getOwnedResources(resource, resources.configurations.data);
+  const ksroutes = getOwnedResources(resource, resources.ksroutes.data);
+  const revisions = getOwnedResources(configurations[0], resources.revisions.data);
+  const knativedata = { configurations, revisions, ksroutes };
+  return knativedata;
+};
+
+/**
+ * Rollup data for deployments for revisions/ event sources
+ */
+const createKnativeDeploymentItems = (
+  resource: K8sResourceKind,
+  resources: TopologyDataResources,
+  utils?: Function[],
+): OverviewItem => {
+  const transformResourceData = new TransformResourceData(resources, utils);
+  const associatedDeployment = getOwnedResources(resource, resources.deployments.data);
+  if (associatedDeployment && associatedDeployment.length) {
+    const depObj: K8sResourceKind = {
+      ...associatedDeployment[0],
+      apiVersion: apiVersionForModel(DeploymentModel),
+      kind: DeploymentModel.kind,
+    };
+    const replicaSets = transformResourceData.getReplicaSetsForResource(depObj);
+    const [current, previous] = replicaSets;
+    const isRollingOut = !!current && !!previous;
+    const buildConfigs = transformResourceData.getBuildConfigsForResource(depObj);
+    const services = transformResourceData.getServicesForResource(depObj);
+    const routes = transformResourceData.getRoutesForServices(services);
+    const alerts = {
+      ...getResourcePausedAlert(depObj),
+      ...getBuildAlerts(buildConfigs),
+    };
+    const overviewItems = {
+      obj: resource,
+      alerts,
+      buildConfigs,
+      current,
+      isRollingOut,
+      previous,
+      pods: [..._.get(current, 'pods', []), ..._.get(previous, 'pods', [])],
+      routes,
+      services,
+    };
+
+    if (utils) {
+      return utils.reduce((acc, element) => {
+        return { ...acc, ...element(depObj, resources) };
+      }, overviewItems);
+    }
+    return overviewItems;
+  }
+  const services = transformResourceData.getServicesForResource(resource);
+  const routes = transformResourceData.getRoutesForServices(services);
+  const knResources = getKnativeServiceData(resource, resources);
+  return { obj: resource, buildConfigs: [], routes, services, ...knResources };
+};
+
+/**
+ * Form Node data for revisions/event/service sources
+ */
+export const getKnativeTopologyNodeItem = (
+  resource: K8sResourceKind,
+  type: string,
+  resources?: TopologyDataResources,
+): Node => {
+  const uid = _.get(resource, ['metadata', 'uid']);
+  const name = _.get(resource, ['metadata', 'name']);
+  const label = _.get(resource, ['metadata', 'labels', 'app.openshift.io/instance']);
+  const children = [];
+  if (type === 'knservice' && resources && resources.configurations) {
+    const configurations = getOwnedResources(resource, resources.configurations.data);
+    const configUidData = _.get(configurations[0], ['metadata', 'uid']);
+    const ChildData = _.filter(resources.revisions.data, {
+      metadata: { ownerReferences: [{ uid: configUidData }] },
+    });
+    _.forEach(ChildData, (c) => {
+      children.push(_.get(c, ['metadata', 'uid']));
+    });
+  }
+  return {
+    id: uid,
+    type,
+    name: label || name,
+    ...(children.length && { children }),
+  };
+};
+
+/**
+ * Form Edge data for event sources
+ */
+export const getEventTopologyEdgeItems = (resource: K8sResourceKind, { data }): Edge[] => {
+  const uid = _.get(resource, ['metadata', 'uid']);
+  const sinkSvc = _.get(resource, ['spec', 'sink'], {});
+  const edges = [];
+  if (sinkSvc.kind === 'Service') {
+    _.forEach(data, (res) => {
+      const resname = _.get(res, ['metadata', 'name']);
+      const resUid = _.get(res, ['metadata', 'uid']);
+      if (resname === sinkSvc.name) {
+        edges.push({
+          id: `${uid}_${resUid}`,
+          type: 'connects-to-src',
+          source: uid,
+          target: resUid,
+        });
+      }
+    });
+  }
+  return edges;
+};
+
+/**
+ * Form Edge data for service sources with traffic data
+ */
+export const getTrafficTopologyEdgeItems = (resource: K8sResourceKind, { data }): Edge[] => {
+  const uid = _.get(resource, ['metadata', 'uid']);
+  const trafficSvc = _.get(resource, ['status', 'traffic'], []);
+  const edges = [];
+  _.forEach(trafficSvc, (res) => {
+    const resname = _.get(res, ['revisionName']);
+    const trafficPercent = _.get(res, ['percent']);
+    const revisionObj = _.find(data, (rev) => {
+      const revname = _.get(rev, ['metadata', 'name']);
+      return revname === resname;
+    });
+    const resUid = _.get(revisionObj, ['metadata', 'uid'], null);
+    if (resUid) {
+      edges.push({
+        id: `${uid}_${resUid}`,
+        type: 'connects-to-traffic',
+        source: uid,
+        target: resUid,
+        data: { percent: trafficPercent },
+      });
+    }
+  });
+  return edges;
+};
+
+/**
+ * Form Group data for service sources
+ */
+export const getTopologyServiceGroupItems = (
+  resource: K8sResourceKind,
+  groups: Group[],
+): Group[] => {
+  const labels = _.get(resource, ['spec', 'template', 'metadata', 'labels'], []);
+  const uid = _.get(resource, ['metadata', 'uid']);
+  _.forEach(labels, (label, key) => {
+    if (key !== 'app.kubernetes.io/part-of') {
+      return;
+    }
+    // find and add the groups
+    const groupExists = _.some(groups, {
+      name: label,
+    });
+    if (!groupExists) {
+      groups.push({
+        id: `group:${label}`,
+        name: label,
+        nodes: [uid],
+      });
+    } else {
+      const gIndex = _.findIndex(groups, { name: label });
+      groups[gIndex].nodes.push(uid);
+    }
+  });
+  return groups;
+};
+
+/**
+ * Filter Knative resources based on part-of label
+ */
+export const filterKnativeBasedOnActiveApplication = (
+  data: K8sResourceKind[],
+  application: string,
+): K8sResourceKind[] => {
+  const PART_OF = 'app.kubernetes.io/part-of';
+  if (!application) {
+    return data;
+  }
+  return data.filter((d) => {
+    return (
+      _.get(d, ['metadata', 'labels', PART_OF]) === application ||
+      _.get(d, ['spec', 'template', 'metadata', 'labels', PART_OF]) === application
+    );
+  });
+};
+
+/**
+ * create all data that need to be shown on a topology data for knative service
+ */
+export const createTopologyServiceNodeData = (
+  svcRes: OverviewItem,
+  operatorBackedServiceKinds: string[],
+  cheURL?: string,
+): TopologyDataObject => {
+  const { obj: knativeSvc } = svcRes;
+  const uid = _.get(knativeSvc, 'metadata.uid');
+  const labels = _.get(knativeSvc, 'metadata.labels', {});
+  const annotations = _.get(knativeSvc, 'metadata.annotations', {});
+  const nodeResourceKind = _.get(knativeSvc, 'metadata.ownerReferences[0].kind');
+  return {
+    id: uid,
+    name: _.get(knativeSvc, 'metadata.name') || labels['app.kubernetes.io/instance'],
+    type: 'eventsource',
+    resources: { ...svcRes },
+    operatorBackedService: operatorBackedServiceKinds.includes(nodeResourceKind),
+    data: {
+      url: getRoutesUrl(svcRes.routes, _.get(svcRes, ['ksroutes'])),
+      kind: knativeSvc.kind,
+      editUrl:
+        annotations['app.openshift.io/edit-url'] ||
+        getEditURL(annotations['app.openshift.io/vcs-uri'], cheURL),
+      isKnativeResource: true,
+    },
+  };
+};
+
+let groupsData = [];
+export const tranformKnNodeData = (
+  knResourcesData: K8sResourceKind[],
+  type: string,
+  topologyGraphAndNodeData: TopologyDataModel,
+  resources: TopologyDataResources,
+  operatorBackedServiceKinds: string[],
+  utils?: Function[],
+  cheURL?: string,
+  application?: string,
+) => {
+  let nodesData = [];
+  let edgesData = [];
+  const dataToShowOnNodes = {};
+  const resourceData = filterKnativeBasedOnActiveApplication(knResourcesData, application);
+  _.forEach(resourceData, (res) => {
+    const uid = _.get(res, ['metadata', 'uid']);
+    if (!_.some(topologyGraphAndNodeData.graph.nodes, { id: uid })) {
+      nodesData = [...nodesData, getKnativeTopologyNodeItem(res, type, resources)];
+      const item = createKnativeDeploymentItems(res, resources, utils);
+      const { obj: knServiceData } = item;
+      const uidRes = _.get(knServiceData, ['metadata', 'uid']);
+      switch (type) {
+        case nodeType.EventSource: {
+          dataToShowOnNodes[uidRes] = createTopologyNodeData(
+            item,
+            operatorBackedServiceKinds,
+            cheURL,
+            type,
+          );
+          edgesData = [...edgesData, ...getEventTopologyEdgeItems(res, resources.ksservices)];
+          groupsData = [...getTopologyGroupItems(res, topologyGraphAndNodeData.graph.groups)];
+          break;
+        }
+        case nodeType.Revision: {
+          dataToShowOnNodes[uidRes] = createTopologyNodeData(
+            item,
+            operatorBackedServiceKinds,
+            cheURL,
+            type,
+          );
+          groupsData = [...getTopologyGroupItems(res, topologyGraphAndNodeData.graph.groups)];
+          break;
+        }
+        case nodeType.KnService: {
+          dataToShowOnNodes[uidRes] = createTopologyServiceNodeData(
+            item,
+            operatorBackedServiceKinds,
+            cheURL,
+          );
+          edgesData = [...edgesData, ...getTrafficTopologyEdgeItems(res, resources.revisions)];
+          groupsData = [
+            ...getTopologyServiceGroupItems(res, topologyGraphAndNodeData.graph.groups),
+          ];
+          break;
+        }
+        default:
+          break;
+      }
+    }
+  });
+
+  return { nodesData, edgesData, dataToShowOnNodes, groupsData };
+};
+
+/**
+ * Filter out deployments not created via revisions
+ */
+export const filterNonKnativeDeployments = (resources: DeploymentKind[]): DeploymentKind[] => {
+  const KNATIVE_CONFIGURATION = 'serving.knative.dev/configuration';
+  return resources.filter((d) => {
+    return !_.get(d, ['metadata', 'labels', KNATIVE_CONFIGURATION]);
+  });
+};


### PR DESCRIPTION
adds utils to process knative resources(Services/Revisions/Event sources) to the data model

PR adds
- [x] Add utils to form node data for knative services with type "knservice"
- [x] Add utils to form node data for knative revisions with type "revisions"
- [x] Add utils to form node data for knative event sources with type "eventsource"
- [x] Add utils to form Edge data for event sources to knative services if sink is to service
- [x] Add utils to form Edge data for knative service to it's revisions
- [x] Add utils to pass revisions as children to knative service node data
- [x] Add topology data with required resources
- [x]  Add specs for utils

Tracks :  
Story: https://jira.coreos.com/browse/ODC-1027
Task : https://jira.coreos.com/browse/ODC-2109

This Utils would be used in later PR for integration