### PR TITLE
Bug 1693169: Change details page memory charts to use binary bytes

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeGraphs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeGraphs.tsx
@@ -3,12 +3,13 @@ import * as _ from 'lodash';
 import { requirePrometheus } from '@console/internal/components/graphs';
 import { Area } from '@console/internal/components/graphs/area';
 import {
-  humanizeDecimalBytes,
+  humanizeBinaryBytes,
   humanizeCpuCores,
   humanizeDecimalBytesPerSec,
 } from '@console/internal/components/utils';
 import { NodeKind } from '@console/internal/module/k8s';
 import { getNodeAddresses } from '@console/shared';
+import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 
 type NodeGraphsProps = {
   node: NodeKind;
@@ -27,7 +28,8 @@ const NodeGraphs: React.FC<NodeGraphsProps> = ({ node }) => {
         <div className="col-md-12 col-lg-4">
           <Area
             title="Memory Usage"
-            humanize={humanizeDecimalBytes}
+            humanize={humanizeBinaryBytes}
+            byteDataType={ByteDataTypes.BinaryBytes}
             query={`node_memory_Active_bytes${instanceQuery}`}
           />
         </div>
@@ -60,7 +62,8 @@ const NodeGraphs: React.FC<NodeGraphsProps> = ({ node }) => {
         <div className="col-md-12 col-lg-4">
           <Area
             title="Filesystem"
-            humanize={humanizeDecimalBytes}
+            humanize={humanizeBinaryBytes}
+            byteDataType={ByteDataTypes.BinaryBytes}
             query={`instance:node_filesystem_usage:sum${instanceQuery}`}
           />
         </div>

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -5,6 +5,7 @@ import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
 import { Status } from '@console/shared';
+import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import {
   K8sResourceKindReference,
   referenceFor,
@@ -21,8 +22,8 @@ import {
   BuildStrategy,
   DetailsItem,
   history,
+  humanizeBinaryBytes,
   humanizeCpuCores,
-  humanizeDecimalBytes,
   Kebab,
   KebabAction,
   navFactory,
@@ -138,7 +139,8 @@ const BuildGraphs = requirePrometheus(({ build }) => {
         <div className="col-md-12 col-lg-4">
           <Area
             title="Memory Usage"
-            humanize={humanizeDecimalBytes}
+            humanize={humanizeBinaryBytes}
+            byteDataType={ByteDataTypes.BinaryBytes}
             namespace={namespace}
             query={`sum(container_memory_working_set_bytes{pod='${podName}',namespace='${namespace}',container=''}) BY (pod, namespace)`}
           />
@@ -154,7 +156,8 @@ const BuildGraphs = requirePrometheus(({ build }) => {
         <div className="col-md-12 col-lg-4">
           <Area
             title="Filesystem"
-            humanize={humanizeDecimalBytes}
+            humanize={humanizeBinaryBytes}
+            byteDataType={ByteDataTypes.BinaryBytes}
             namespace={namespace}
             query={`pod:container_fs_usage_bytes:sum{pod='${podName}',container='',namespace='${namespace}'}`}
           />

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -9,6 +9,7 @@ import { PencilAltIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import * as fuzzy from 'fuzzysearch';
 import { Status, getRequester } from '@console/shared';
+import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 
 import { NamespaceModel, ProjectModel, SecretModel } from '../models';
 import { k8sGet } from '../module/k8s';
@@ -28,8 +29,8 @@ import {
   ResourceLink,
   ResourceSummary,
   SectionHeading,
+  humanizeBinaryBytes,
   humanizeCpuCores,
-  humanizeDecimalBytes,
   navFactory,
   useAccessReview,
 } from './utils';
@@ -368,7 +369,8 @@ export const NamespaceLineCharts = ({ ns }) => (
     <div className="col-md-6 col-sm-12">
       <Area
         title="Memory Usage"
-        humanize={humanizeDecimalBytes}
+        humanize={humanizeBinaryBytes}
+        byteDataType={ByteDataTypes.BinaryBytes}
         namespace={ns.metadata.name}
         query={`sum by(namespace) (container_memory_working_set_bytes{namespace="${
           ns.metadata.name
@@ -385,7 +387,7 @@ export const TopPodsBarChart = ({ ns }) => (
     query={`sort_desc(topk(10, sum by (pod)(container_memory_working_set_bytes{container="",pod!="",namespace="${
       ns.metadata.name
     }"})))`}
-    humanize={humanizeDecimalBytes}
+    humanize={humanizeBinaryBytes}
     metric="pod"
   />
 );

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -4,6 +4,7 @@ import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { Status, ErrorStatus } from '@console/shared';
+import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 
 import { ContainerSpec, K8sResourceKindReference, PodKind } from '../module/k8s';
 import {
@@ -28,8 +29,8 @@ import {
   ScrollToTopOnMount,
   SectionHeading,
   Timestamp,
+  humanizeBinaryBytes,
   humanizeCpuCores,
-  humanizeDecimalBytes,
   navFactory,
   pluralize,
   units,
@@ -239,7 +240,8 @@ const PodGraphs = requirePrometheus(({ pod }) => (
       <div className="col-md-12 col-lg-4">
         <Area
           title="Memory Usage"
-          humanize={humanizeDecimalBytes}
+          humanize={humanizeBinaryBytes}
+          byteDataType={ByteDataTypes.BinaryBytes}
           namespace={pod.metadata.namespace}
           query={`sum(container_memory_working_set_bytes{pod='${pod.metadata.name}',namespace='${
             pod.metadata.namespace
@@ -259,7 +261,8 @@ const PodGraphs = requirePrometheus(({ pod }) => (
       <div className="col-md-12 col-lg-4">
         <Area
           title="Filesystem"
-          humanize={humanizeDecimalBytes}
+          humanize={humanizeBinaryBytes}
+          byteDataType={ByteDataTypes.BinaryBytes}
           namespace={pod.metadata.namespace}
           query={`pod:container_fs_usage_bytes:sum{pod='${pod.metadata.name}',namespace='${
             pod.metadata.namespace


### PR DESCRIPTION
Namespace Details:

<img width="850" alt="openshift-sdn · Details · OKD 2019-10-27 12-50-59" src="https://user-images.githubusercontent.com/1167259/67638214-7315f300-f8b8-11e9-9746-ec8ff168b645.png">

Node Details:

<img width="1063" alt="ip-10-0-134-121 us-east-2 compute internal · Details · OKD 2019-10-27 12-51-29" src="https://user-images.githubusercontent.com/1167259/67638228-85902c80-f8b8-11e9-94f9-857366a80787.png">

Pod Details:

<img width="1051" alt="ovs-dxrww · Details · OKD 2019-10-27 12-51-55" src="https://user-images.githubusercontent.com/1167259/67638231-917bee80-f8b8-11e9-9f78-0b81aaa1378b.png">

Build Details:

<img width="413" alt="ruby-sample-build-1 · Details · OKD 2019-10-27 12-54-27" src="https://user-images.githubusercontent.com/1167259/67638271-f0416800-f8b8-11e9-85c1-88ca704d785e.png">
