### PR TITLE
Query Browser: Eliminate unnecessary re-renders following some actions

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -859,7 +859,9 @@ const QueryBrowserWrapper_: React.FC<QueryBrowserWrapperProps> = ({
   // re-renders of QueryBrowser, which can be quite slow
   const queriesMemoKey = JSON.stringify(_.map(queries, 'query'));
   const queryStrings = React.useMemo(() => _.map(queries, 'query'), [queriesMemoKey]);
-  const disabledSeriesMemoKey = JSON.stringify(_.map(queries, 'disabledSeries'));
+  const disabledSeriesMemoKey = JSON.stringify(
+    _.reject(_.map(queries, 'disabledSeries'), _.isEmpty),
+  );
   const disabledSeries = React.useMemo(() => _.map(queries, 'disabledSeries'), [
     disabledSeriesMemoKey,
   ]);


### PR DESCRIPTION
This change fixes an issue where the following actions caused the graph
to re-render, even though we know the action will not change the graph.
  - Adding a new (empty) query
  - Disabling an empty query
  - Deleting an empty query