### PR TITLE
Cluster Status: API Request Success Rate only with 5xx requests

### DIFF
--- a/frontend/packages/console-app/src/queries.ts
+++ b/frontend/packages/console-app/src/queries.ts
@@ -3,4 +3,4 @@ export const CONTROLLER_MANAGERS_UP =
   '(sum(up{job="kube-controller-manager"} == 1) / count(up{job="kube-controller-manager"})) * 100';
 export const SCHEDULERS_UP = '(sum(up{job="scheduler"} == 1) / count(up{job="scheduler"})) * 100';
 export const API_SERVER_REQUESTS_SUCCESS =
-  'sum(rate(apiserver_request_count{code=~"2.."}[5m])) / sum(rate(apiserver_request_count[5m])) * 100';
+  '(1 - sum(rate(apiserver_request_count{code=~"5.."}[5m])) / sum(rate(apiserver_request_count[5m]))) * 100';


### PR DESCRIPTION
The Cluster Status dashboard has a gauge that shows the API Request Success Rate. However right now it also takes 404 requests into account, which are considered success from an API point of view.
Thus updating the query slightly to only take 5xx as errors.
The updated version is also what we alert on in the cluster monitoring stack.

/cc @openshift/openshift-team-monitoring 