### PR TITLE
dashboards: Fix padding in OCS buckets card

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card.tsx
@@ -135,10 +135,8 @@ const ObjectDashboardBucketsCard: React.FC<DashboardItemProps> = ({
         <DashboardCardTitle>Buckets</DashboardCardTitle>
       </DashboardCardHeader>
       <DashboardCardBody>
-        <div className="co-dashboard-card__body--no-padding">
-          <BucketsItem title="ObjectBucket" {...bucketProps} link={noobaaBucketsLink} />
-          <BucketsItem title="ObjectBucketClaim" {...bucketClaimProps} link={noobaaBucketsLink} />
-        </div>
+        <BucketsItem title="ObjectBucket" {...bucketProps} link={noobaaBucketsLink} />
+        <BucketsItem title="ObjectBucketClaim" {...bucketClaimProps} link={noobaaBucketsLink} />
       </DashboardCardBody>
     </DashboardCard>
   );

--- a/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card-body.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/resource-providers-card/resource-providers-card-body.tsx
@@ -7,7 +7,7 @@ export const ResourceProvidersBody: React.FC<ResourceProvidersBodyProps> = ({
   children,
   error,
 }) => {
-  let body;
+  let body: React.ReactNode;
   if (isLoading) {
     body = <LoadingInline />;
   }
@@ -16,7 +16,7 @@ export const ResourceProvidersBody: React.FC<ResourceProvidersBodyProps> = ({
       <div className="nb-resource-providers-card__not-available text-secondary">Unavailable</div>
     );
   }
-  return <div className="co-dashboard-card__body--no-padding">{body || children}</div>;
+  return <>{body || children}</>;
 };
 
 type ResourceProvidersBodyProps = {


### PR DESCRIPTION
/cc @rhamilto @cloudbehl @rawagner 

Fixes this bug:

<img width="691" alt="Dashboards · OKD 2019-10-28 10-34-38" src="https://user-images.githubusercontent.com/1167259/67688684-9a2ffb80-f970-11e9-9206-143bee95294a.png">
