### PR TITLE
Bug 1760376: Update create operand breadcrumb

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
@@ -951,7 +951,11 @@ export const CreateOperand: React.FC<CreateOperandProps> = (props) => {
               breadcrumbs={[
                 {
                   name: props.clusterServiceVersion.data.spec.displayName,
-                  path: window.location.pathname.replace('/~new', ''),
+                  path: resourcePathFromModel(
+                    ClusterServiceVersionModel,
+                    props.clusterServiceVersion.data.metadata.name,
+                    props.clusterServiceVersion.data.metadata.namespace,
+                  ),
                 },
                 { name: `Create ${props.operandModel.label}`, path: window.location.pathname },
               ]}


### PR DESCRIPTION
Go to the ClusterServiceVersion Overview tab instead of the resource tab
when clicking on the breadcrumb of the create operand form. Often,
you've arrived at the create operand form by clicking on "Create
Instance" in one of the cards. Returning to the resource tab instead of
Overview can be disorienting.

/assign @rhamilto 