### PR TITLE
Fix runtime error when PVC creation fails

### DIFF
--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -313,8 +313,8 @@ export const CreatePVCPage: React.FC<CreatePVCPageProps> = (props) => {
         setInProgress(false);
         history.push(resourceObjPath(resource, referenceFor(resource)));
       },
-      (err) => {
-        setError(err);
+      ({ message }: { message: string }) => {
+        setError(message || 'Could not create persistent volume claim.');
         setInProgress(false);
       },
     );


### PR DESCRIPTION
We were passing an object as the error instead of a string.

With the fix:

<img width="571" alt="Create Persistent Volume Claim · OKD 2019-10-28 17-22-39" src="https://user-images.githubusercontent.com/1167259/67719113-923f7e00-f9a7-11e9-964f-680341c8aabd.png">

/kind bug
/assign @rhamilto @zherman0 