### PR TITLE
Added popover for Ceph dashboard utilization card

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utilization-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utilization-card.tsx
@@ -24,7 +24,12 @@ import {
   UTILIZATION_QUERY_HOUR_MAP,
 } from '@console/shared/src/components/dashboard/utilization-card/dropdown-value';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
-import { StorageDashboardQuery, UTILIZATION_QUERY } from '../../../../constants/queries';
+import ConsumerPopover from '@console/shared/src/components/dashboard/utilization-card/TopConsumerPopover';
+import {
+  StorageDashboardQuery,
+  UTILIZATION_QUERY,
+  utilizationPopoverQueryMap,
+} from '../../../../constants/queries';
 import { getLatestValue, humanizeIOPS, humanizeLatency } from './utils';
 
 const metricDurations = [ONE_HR, SIX_HR, TWENTY_FOUR_HR];
@@ -108,6 +113,18 @@ const UtilizationCard: React.FC<DashboardItemProps> = ({
     'loadError',
   ]);
 
+  const storagePopover = React.useCallback(
+    ({ current }) => (
+      <ConsumerPopover
+        title="Used Capacity"
+        current={current}
+        consumers={utilizationPopoverQueryMap}
+        humanize={humanizeBinaryBytes}
+      />
+    ),
+    [],
+  );
+
   const capacityStats = getRangeVectorStats(capacityUtilization);
   const maxCapacityStats = getLatestValue(getRangeVectorStats(totalCapacity));
   const iopsStats = getRangeVectorStats(iopsUtilization);
@@ -140,6 +157,7 @@ const UtilizationCard: React.FC<DashboardItemProps> = ({
             error={capacityUtilizationError || totalCapacityError}
             isLoading={!capacityUtilization || !totalCapacity}
             max={maxCapacityStats}
+            TopConsumerPopover={storagePopover}
           />
           <UtilizationItem
             title="IOPS"

--- a/frontend/packages/ceph-storage-plugin/src/constants/queries.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/queries.ts
@@ -20,6 +20,7 @@ export enum StorageDashboardQuery {
   STORAGE_CEPH_CAPACITY_REQUESTED_QUERY = 'STORAGE_CEPH_CAPACITY_REQUESTED_QUERY',
   STORAGE_CEPH_CAPACITY_USED_QUERY = 'STORAGE_CEPH_CAPACITY_USED_QUERY',
   RESILIENCY_PROGRESS = 'RESILIENCY_PROGRESS',
+  NODES_BY_USED = 'NODES_BY_USED',
 }
 
 export const STORAGE_HEALTH_QUERIES = {
@@ -116,3 +117,27 @@ export const breakdownQueryMap = {
     },
   },
 };
+
+export const utilizationPopoverQueryMap = [
+  {
+    model: ProjectModel,
+    metric: 'namespace',
+    query: `(sort_desc(topk(25,(${
+      CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.PROJECTS_BY_USED]
+    }))))`,
+  },
+  {
+    model: StorageClassModel,
+    metric: 'storageclass',
+    query: `(sort_desc(topk(25,(${
+      CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.STORAGE_CLASSES_BY_USED]
+    }))))`,
+  },
+  {
+    model: PodModel,
+    metric: 'pod',
+    query: `(sort_desc(topk(25, (${
+      CAPACITY_BREAKDOWN_QUERIES[StorageDashboardQuery.PODS_BY_USED]
+    }))))`,
+  },
+];

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -123,7 +123,6 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       tab: 'persistent-storage',
       position: GridPosition.MAIN,
-      span: 6,
       loader: () =>
         import(
           './components/dashboard-page/storage-dashboard/utilization-card/utilization-card' /* webpackChunkName: "ceph-storage-utilization-card" */


### PR DESCRIPTION
Depends on [3131](https://github.com/openshift/console/pull/3131)
- Adds popover on utilization dashboard.
- Fixes the span of utilization card.

![Screenshot from 2019-10-30 19-12-56](https://user-images.githubusercontent.com/54092533/67863484-f9953380-fb49-11e9-890b-97725c34c2b4.png)
