### PR TITLE
Avoid flicker in heading while job is loaded

### DIFF
--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -145,8 +145,7 @@ const JobTableRow = ({
 JobTableRow.displayName = 'JobTableRow';
 
 const jobStatus = (job: JobKind): string => {
-  const conditions = _.get(job, 'status.conditions', null);
-  return conditions && conditions.length > 0 ? conditions[0].type : 'In Progress';
+  return job && job.status ? _.get(job, 'status.conditions[0].type', 'In Progress') : null;
 };
 
 const JobDetails: React.FC<JobsDetailsProps> = ({ obj: job }) => (

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -91,9 +91,10 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
   const resourceTitle = titleFunc && data ? titleFunc(data) : title;
   const hasButtonActions = !_.isEmpty(buttonActions);
   const hasMenuActions = _.isFunction(menuActions) || !_.isEmpty(menuActions);
+  const hasData = !_.isEmpty(data);
   const showActions =
-    (hasButtonActions || hasMenuActions) && !_.isEmpty(data) && !_.get(data, 'deletionTimestamp');
-  const resourceStatus = getResourceStatus && getResourceStatus(data);
+    (hasButtonActions || hasMenuActions) && hasData && !_.get(data, 'deletionTimestamp');
+  const resourceStatus = hasData && getResourceStatus ? getResourceStatus(data) : null;
   return (
     <div
       className={classNames(


### PR DESCRIPTION
The status flickers quickly from "In Progress" to "Complete" when the
job data loads on the job details pages for complete jobs. Wait for the
data before showing a value.

/assign @andrewballantyne 
/kind bug