### PR TITLE
Add charts for metrics on route details

### DIFF
--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -23,6 +23,7 @@ import { MaskedData } from './configmap-and-secret-data';
 import { K8sResourceKindReference, RouteKind, RouteIngress, RouteTarget } from '../module/k8s';
 import { RouteModel } from '../models';
 import { Conditions, conditionProps } from './conditions';
+import { RouteCharts } from './routes/route-charts';
 
 const RoutesReference: K8sResourceKindReference = 'Route';
 const menuActions = [...Kebab.getExtensionsActionsForKind(RouteModel), ...Kebab.factory.common];
@@ -411,6 +412,7 @@ const RouteDetails: React.FC<RoutesDetailsProps> = ({ obj: route }) => {
     <>
       <div className="co-m-pane__body">
         <SectionHeading text="Route Overview" />
+        <RouteCharts namespace={route.metadata.namespace} route={route.metadata.name} />
         <div className="row">
           <div className="col-sm-6">
             <ResourceSummary resource={route}>

--- a/frontend/public/components/routes/route-charts.tsx
+++ b/frontend/public/components/routes/route-charts.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { Area } from '@console/internal/components/graphs/area';
+import { humanizeDecimalBytesPerSec } from '@console/internal/components/utils';
+
+// Build the RouteCharts component that presents 3 charts side by side in full screen
+const chartClasses = 'col-md-4 col-sm-12';
+
+export const RouteCharts: React.FC<RouteChartsProps> = ({ namespace, route }) => {
+  const interval = '[5m]';
+  const namespaceRouteQuery = `{exported_namespace="${namespace}",route="${route}"}${interval}`;
+  return (
+    <div className="row">
+      <div className={chartClasses}>
+        <Area
+          title="Traffic In"
+          namespace={namespace}
+          humanize={humanizeDecimalBytesPerSec}
+          query={`sum without (instance,exported_pod,exported_service,pod,server) (irate(haproxy_server_bytes_in_total${namespaceRouteQuery}))`}
+        />
+      </div>
+      <div className={chartClasses}>
+        <Area
+          title="Traffic Out"
+          humanize={humanizeDecimalBytesPerSec}
+          namespace={namespace}
+          query={`sum without (instance,exported_pod,exported_service,pod,server) (irate(haproxy_server_bytes_out_total${namespaceRouteQuery}))`}
+        />
+      </div>
+      <div className={chartClasses}>
+        <Area
+          title="Connection Rate"
+          namespace={namespace}
+          query={`sum without (instance,exported_pod,exported_service,pod,server) (irate(haproxy_backend_connections_total${namespaceRouteQuery}))`}
+        />
+      </div>
+    </div>
+  );
+};
+
+export type RouteChartsProps = {
+  namespace: string;
+  route: string;
+};


### PR DESCRIPTION
Add charts to the route overview that show some basic metrics from prometheus data.

![route-charts1](https://user-images.githubusercontent.com/18728857/67815593-fb3cf980-fa6c-11e9-81f9-39a5d89f915e.png)
![route-charts2](https://user-images.githubusercontent.com/18728857/67815605-009a4400-fa6d-11e9-830d-8f6797e247b6.png)

