### PR TITLE
Query Browser: Add close button to the Dev perspective alert

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -27,6 +27,7 @@ export enum ActionType {
   QueryBrowserAddQuery = 'queryBrowserAddQuery',
   QueryBrowserDeleteAllQueries = 'queryBrowserDeleteAllQueries',
   QueryBrowserDeleteQuery = 'queryBrowserDeleteQuery',
+  QueryBrowserDismissNamespaceAlert = 'queryBrowserDismissNamespaceAlert',
   QueryBrowserInsertText = 'queryBrowserInsertText',
   QueryBrowserPatchQuery = 'queryBrowserPatchQuery',
   QueryBrowserRunQueries = 'queryBrowserRunQueries',
@@ -246,6 +247,8 @@ export const monitoringErrored = (key: 'alerts' | 'silences', loadError: any) =>
 export const monitoringToggleGraphs = () => action(ActionType.ToggleMonitoringGraphs);
 export const queryBrowserAddQuery = () => action(ActionType.QueryBrowserAddQuery);
 export const queryBrowserDeleteAllQueries = () => action(ActionType.QueryBrowserDeleteAllQueries);
+export const queryBrowserDismissNamespaceAlert = () =>
+  action(ActionType.QueryBrowserDismissNamespaceAlert);
 export const queryBrowserDeleteQuery = (index: number) =>
   action(ActionType.QueryBrowserDeleteQuery, { index });
 export const queryBrowserInsertText = (
@@ -301,6 +304,7 @@ const uiActions = {
   queryBrowserAddQuery,
   queryBrowserDeleteAllQueries,
   queryBrowserDeleteQuery,
+  queryBrowserDismissNamespaceAlert,
   queryBrowserInsertText,
   queryBrowserPatchQuery,
   queryBrowserRunQueries,

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash-es';
 import {
   ActionGroup,
   Alert,
+  AlertActionCloseButton,
   Button,
   EmptyState,
   EmptyStateBody,
@@ -783,14 +784,23 @@ const QueryTable = connect(
   queryDispatchToProps,
 )(QueryTable_);
 
-const NamespaceAlert = () => (
-  <Alert
-    isInline
-    className="co-alert"
-    title="Queries entered here are limited to the data available in the currently selected project."
-    variant="info"
-  />
-);
+const NamespaceAlert_: React.FC<{ dismiss: () => undefined; isDismissed: boolean }> = ({
+  dismiss,
+  isDismissed,
+}) =>
+  isDismissed ? null : (
+    <Alert
+      action={<AlertActionCloseButton onClose={dismiss} />}
+      isInline
+      className="co-alert"
+      title="Queries entered here are limited to the data available in the currently selected project."
+      variant="info"
+    />
+  );
+const NamespaceAlert: React.ComponentType<{}> = connect(
+  ({ UI }: RootState) => ({ isDismissed: !!UI.getIn(['queryBrowser', 'dismissNamespaceAlert']) }),
+  { dismiss: UIActions.queryBrowserDismissNamespaceAlert },
+)(NamespaceAlert_);
 
 const Query_: React.FC<QueryProps> = ({
   id,
@@ -882,31 +892,26 @@ const QueryBrowserWrapper_: React.FC<QueryBrowserWrapperProps> = ({
     patchQuery(index, { isEnabled: true, query: text, text });
   };
 
-  return (
-    <>
-      {namespace && <NamespaceAlert />}
-      {queryStrings.join('') === '' ? (
-        <div className="query-browser__wrapper graph-empty-state">
-          <EmptyState variant={EmptyStateVariant.full}>
-            <EmptyStateIcon size="sm" icon={ChartLineIcon} />
-            <Title size="sm">No Query Entered</Title>
-            <EmptyStateBody>
-              Enter a query in the box below to explore metrics for this cluster.
-            </EmptyStateBody>
-            <Button onClick={insertExampleQuery} variant="primary">
-              Insert Example Query
-            </Button>
-          </EmptyState>
-        </div>
-      ) : (
-        <QueryBrowser
-          defaultTimespan={30 * 60 * 1000}
-          disabledSeries={disabledSeries}
-          namespace={namespace}
-          queries={queryStrings}
-        />
-      )}
-    </>
+  return queryStrings.join('') === '' ? (
+    <div className="query-browser__wrapper graph-empty-state">
+      <EmptyState variant={EmptyStateVariant.full}>
+        <EmptyStateIcon size="sm" icon={ChartLineIcon} />
+        <Title size="sm">No Query Entered</Title>
+        <EmptyStateBody>
+          Enter a query in the box below to explore metrics for this cluster.
+        </EmptyStateBody>
+        <Button onClick={insertExampleQuery} variant="primary">
+          Insert Example Query
+        </Button>
+      </EmptyState>
+    </div>
+  ) : (
+    <QueryBrowser
+      defaultTimespan={30 * 60 * 1000}
+      disabledSeries={disabledSeries}
+      namespace={namespace}
+      queries={queryStrings}
+    />
   );
 };
 const QueryBrowserWrapper = connect(
@@ -979,6 +984,7 @@ const QueryBrowserPage_: React.FC<QueryBrowserPageProps> = ({ deleteAll, namespa
         </h1>
       </div>
       <div className="co-m-pane__body">
+        {namespace && <NamespaceAlert />}
         <div className="row">
           <div className="col-xs-12">
             <ToggleGraph />

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -192,6 +192,9 @@ export default (state: UIState, action: UIAction): UIState => {
       }
       return state.setIn(['queryBrowser', 'queries'], queries);
     }
+    case ActionType.QueryBrowserDismissNamespaceAlert:
+      return state.setIn(['queryBrowser', 'dismissNamespaceAlert'], true);
+
     case ActionType.QueryBrowserInsertText: {
       const { index, newText, replaceFrom, replaceTo } = action.payload;
       const oldText = state.getIn(['queryBrowser', 'queries', index, 'text'], '');


### PR DESCRIPTION
Stores a flag in redux so that the alert is not shown again until the
Console is reloaded.

Also move the alert above the Hide / Show Graph button.

![screenshot](https://user-images.githubusercontent.com/460802/67829139-562c2a80-fb19-11e9-82e3-40f0a1d8e3b2.png)