### PR TITLE
Fix OCD-1839: Add actions to Pipeline Run Details page #3134

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
-import { navFactory } from '@console/internal/components/utils';
+import { Kebab, navFactory } from '@console/internal/components/utils';
 import { pipelineRunStatus } from '../../utils/pipeline-filter-reducer';
+import { rerunPipeline, stopPipelineRun } from '../../utils/pipeline-actions';
 import { PipelineRunDetails } from './PipelineRunDetails';
 import { PipelineRunLogsWithActiveTask } from './PipelineRunLogs';
 
 const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
+    menuActions={[rerunPipeline, stopPipelineRun, Kebab.factory.Delete]}
     getResourceStatus={pipelineRunStatus}
     pages={[
       navFactory.details(PipelineRunDetails),
@@ -21,5 +23,4 @@ const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => (
     ]}
   />
 );
-
 export default PipelineRunDetailsPage;

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -40,7 +40,7 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
               menuActions: [
                 () => startPipeline(PipelineModel, res, handlePipelineRunSubmit),
                 ...(latestRun && latestRun.metadata
-                  ? [() => rerunPipeline(PipelineRunModel, res, latestRun, handlePipelineRunSubmit)]
+                  ? [() => rerunPipeline(PipelineRunModel, latestRun)]
                   : []),
                 Kebab.factory.Delete,
               ],

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -40,7 +40,7 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
               menuActions: [
                 () => startPipeline(PipelineModel, res, handlePipelineRunSubmit),
                 ...(latestRun && latestRun.metadata
-                  ? [() => rerunPipeline(PipelineModel, res, latestRun, handlePipelineRunSubmit)]
+                  ? [() => rerunPipeline(PipelineRunModel, res, latestRun, handlePipelineRunSubmit)]
                   : []),
                 Kebab.factory.Delete,
               ],

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineRow.tsx
@@ -28,7 +28,7 @@ const PipelineRow: React.FC<PipelineRowProps> = ({ obj, index, key, style }) => 
   const menuActions = [
     () => startPipeline(PipelineModel, obj, handlePipelineRunSubmit),
     ...(obj.latestRun && obj.latestRun.metadata
-      ? [() => rerunPipeline(PipelineModel, obj, obj.latestRun, handlePipelineRunSubmit)]
+      ? [() => rerunPipeline(PipelineRunModel, obj.latestRun)]
       : []),
     Kebab.factory.Delete,
   ];

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
@@ -1,4 +1,10 @@
-import { stopPipelineRun, rerunPipeline } from '../pipeline-actions';
+import {
+  stopPipelineRun,
+  rerunPipeline,
+  reRunPipelineRun,
+  startPipeline,
+  getPipelineRunData,
+} from '../pipeline-actions';
 import { PipelineRun, Pipeline } from '../pipeline-augment';
 import { PipelineModel, PipelineRunModel } from '../../models';
 
@@ -20,28 +26,71 @@ export const actionPipelineRuns: PipelineRun[] = [
     apiVersion: 'abhiapi/v1',
     kind: 'PipelineRun',
     metadata: { name: 'winterfell', namespace: 'corazon' },
+    spec: { pipelineRef: { name: 'sansa-stark' } },
     status: { creationTimestamp: '31', conditions: [{ type: 'Succeeded', status: 'True' }] },
   },
   {
     apiVersion: 'abhiapi/v1',
     kind: 'Pipeline',
     metadata: { name: 'dragonstone', namespace: 'corazon' },
+    spec: { pipelineRef: { name: 'danaerys-targaeryen' } },
     status: { creationTimestamp: '31', conditions: [{ type: 'Succeeded', status: 'Unknown' }] },
   },
 ];
 
 describe('PipelineAction testing rerunPipeline create correct labels and callbacks', () => {
   it('expect label to be "Start Last Run" when latestRun is available', () => {
-    const rerunAction = rerunPipeline(PipelineModel, actionPipelines[0], actionPipelineRuns[0]);
+    const rerunAction = rerunPipeline(PipelineRunModel, actionPipelineRuns[0]);
     expect(rerunAction.label).toBe('Start Last Run');
     expect(rerunAction.callback).not.toBeNull();
   });
 });
 
+describe('PipelineAction testing reRunPipelineRun create correct labels and callbacks', () => {
+  it('expect label to be "Rerun" when latestRun is available', () => {
+    const rerunAction = reRunPipelineRun(PipelineRunModel, actionPipelineRuns[0]);
+    expect(rerunAction.label).toBe('Rerun');
+    expect(rerunAction.callback).not.toBeNull();
+  });
+});
+
+describe('PipelineAction testing startPipeline create correct labels and callbacks', () => {
+  it('expect label to be "Start" when latestRun is available', () => {
+    const rerunAction = startPipeline(PipelineModel, actionPipelines[0]);
+    expect(rerunAction.label).toBe('Start');
+    expect(rerunAction.callback).not.toBeNull();
+  });
+});
+
 describe('PipelineAction testing stopPipelineRun create correct labels and callbacks', () => {
-  it('expect label to be "Stop" when latest Run is running', () => {
+  it('expect label to be "Stop" with hidden flag as false when latest Run is running', () => {
     const stopAction = stopPipelineRun(PipelineRunModel, actionPipelineRuns[1]);
     expect(stopAction.label).toBe('Stop');
     expect(stopAction.callback).not.toBeNull();
+    expect(stopAction.hidden).toBeFalsy();
+  });
+
+  it('expect label to be "Stop" with hidden flag as true when latest Run is not running', () => {
+    const stopAction = stopPipelineRun(PipelineRunModel, actionPipelineRuns[0]);
+    expect(stopAction.label).toBe('Stop');
+    expect(stopAction.callback).not.toBeNull();
+    expect(stopAction.hidden).not.toBeFalsy();
+  });
+});
+
+describe('PipelineAction testing getPipelineRunData', () => {
+  it('expect null to be returned when no arguments are passed', () => {
+    const runData = getPipelineRunData();
+    expect(runData).toBeNull();
+  });
+
+  it('expect pipeline run data to be returned when only Pipeline argument is passed', () => {
+    const runData = getPipelineRunData(actionPipelines[0]);
+    expect(runData).not.toBeNull();
+  });
+
+  it('expect pipeline run data to be returned when only PipelineRun argument is passed', () => {
+    const runData = getPipelineRunData(null, actionPipelineRuns[0]);
+    expect(runData).not.toBeNull();
   });
 });


### PR DESCRIPTION
Fix for defect: https://jira.coreos.com/browse/ODC-1839
1. Added Actions 'Start Last Run', 'Stop' & 'Delete Pipeline Run' to Pipeline Run Details page
2. Refactored pipeline-action 'rerunPipeline' to work for both Pipeline Details Page as well as Pipeline Run Details page.
3. Enhanced pipeline-action 'stopPipelineRun' to show/hide 'Stop' action.