### PR TITLE
Require OpenShift flag to show Dashboards page

### DIFF
--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -41,7 +41,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       icon: <CogsIcon />,
       getLandingPageURL: (flags) =>
         flags[FLAGS.CAN_LIST_NS] ? '/dashboards' : '/k8s/cluster/projects',
-      getK8sLandingPageURL: () => '/dashboards',
+      getK8sLandingPageURL: () => '/search',
       default: true,
       getImportRedirectURL: (project) => `/k8s/cluster/projects/${project}/workloads`,
     },

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -83,7 +83,7 @@ const AdminNav = () => (
         href="/dashboards"
         activePath="/dashboards/"
         name="Dashboards"
-        required={FLAGS.CAN_LIST_NS}
+        required={[FLAGS.CAN_LIST_NS, FLAGS.OPENSHIFT]}
       />
       <ResourceClusterLink resource="projects" name="Projects" required={FLAGS.OPENSHIFT} />
       <HrefLink href="/search" name="Search" startsWith={searchStartsWith} />


### PR DESCRIPTION
@spadgett what should be the landing page for k8s cluster ?

https://jira.coreos.com/browse/CONSOLE-1858