### PR TITLE
kubevirt: Add VM Utilization card

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/index.ts
@@ -2,3 +2,4 @@ export * from './vm-details-card';
 export * from './vm-inventory-card';
 export * from './vm-status-card';
 export * from './vm-activity';
+export * from './vm-utilization';

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/queries.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/queries.ts
@@ -1,0 +1,48 @@
+import * as _ from 'lodash';
+
+export enum VMQueries {
+  CPU_USAGE = 'CPU_USAGE',
+  MEMORY_USAGE = 'MEMORY_USAGE',
+  FILESYSTEM_USAGE = 'FILESYSTEM_USAGE',
+  NETWORK_INOUT_USAGE = 'NETWORK_INOUT_USAGE',
+  // NETWORK_IN_USAGE = 'NETWORK_IN_USAGE',
+  // NETWORK_OUT_USAGE = 'NETWORK_OUT_USAGE',
+}
+
+const queries = {
+  [VMQueries.CPU_USAGE]: _.template(
+    // TODO verify; use seconds or milicores?
+    // `kubevirt_vmi_vcpu_seconds{exported_namespace='<%= namespace %>',name='<%= vmName %>'}<%= duration %>`,
+    `pod_name:container_cpu_usage:sum{namespace='<%= namespace %>',pod_name='<%= launcherPodName %>'}<%= duration %>`,
+  ),
+  [VMQueries.MEMORY_USAGE]: _.template(
+    `kubevirt_vmi_memory_resident_bytes{exported_namespace='<%= namespace %>',name='<%= vmName %>'}<%= duration %>`,
+  ),
+  [VMQueries.FILESYSTEM_USAGE]: _.template(
+    `sum(kubevirt_vmi_storage_traffic_bytes_total{exported_namespace='<%= namespace %>',name='<%= vmName %>'})<%= duration %>`,
+  ),
+  [VMQueries.NETWORK_INOUT_USAGE]: _.template(
+    `sum(kubevirt_vmi_network_traffic_bytes_total{exported_namespace='<%= namespace %>',name='<%= vmName %>'})<%= duration %>`,
+  ),
+  /* TODO: use when multi-line chart is ready
+  [VMQueries.NETWORK_IN_USAGE]: _.template(
+    `sum(kubevirt_vmi_network_traffic_bytes_total{type='rx',exported_namespace='<%= namespace %>',name='<%= vmName %>'})<%= duration %>`,
+  ),
+  [VMQueries.NETWORK_OUT_USAGE]: _.template(
+    `sum(kubevirt_vmi_network_traffic_bytes_total{type='tx',exported_namespace='<%= namespace %>',name='<%= vmName %>'})<%= duration %>`,
+  ),
+  */
+};
+
+export const getUtilizationQueries = (props: {
+  vmName: string;
+  namespace: string;
+  duration: string;
+  launcherPodName?: string;
+}) => ({
+  [VMQueries.CPU_USAGE]: queries[VMQueries.CPU_USAGE](props),
+  [VMQueries.MEMORY_USAGE]: queries[VMQueries.MEMORY_USAGE](props),
+  [VMQueries.FILESYSTEM_USAGE]: queries[VMQueries.FILESYSTEM_USAGE](props),
+  [VMQueries.NETWORK_INOUT_USAGE]: queries[VMQueries.NETWORK_INOUT_USAGE](props),
+  // [VMQueries.NETWORK_OUT_USAGE]: queries[VMQueries.NETWORK_OUT_USAGE](props),
+});

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/queries.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/queries.ts
@@ -12,24 +12,24 @@ export enum VMQueries {
 const queries = {
   [VMQueries.CPU_USAGE]: _.template(
     // TODO verify; use seconds or milicores?
-    // `kubevirt_vmi_vcpu_seconds{exported_namespace='<%= namespace %>',name='<%= vmName %>'}<%= duration %>`,
-    `pod_name:container_cpu_usage:sum{namespace='<%= namespace %>',pod_name='<%= launcherPodName %>'}<%= duration %>`,
+    // `kubevirt_vmi_vcpu_seconds{exported_namespace='<%= namespace %>',name='<%= vmName %>'}`,
+    `pod:container_cpu_usage:sum{namespace='<%= namespace %>',pod='<%= launcherPodName %>'}`,
   ),
   [VMQueries.MEMORY_USAGE]: _.template(
-    `kubevirt_vmi_memory_resident_bytes{exported_namespace='<%= namespace %>',name='<%= vmName %>'}<%= duration %>`,
+    `kubevirt_vmi_memory_resident_bytes{exported_namespace='<%= namespace %>',name='<%= vmName %>'}`,
   ),
   [VMQueries.FILESYSTEM_USAGE]: _.template(
-    `sum(kubevirt_vmi_storage_traffic_bytes_total{exported_namespace='<%= namespace %>',name='<%= vmName %>'})<%= duration %>`,
+    `sum(kubevirt_vmi_storage_traffic_bytes_total{exported_namespace='<%= namespace %>',name='<%= vmName %>'})`,
   ),
   [VMQueries.NETWORK_INOUT_USAGE]: _.template(
-    `sum(kubevirt_vmi_network_traffic_bytes_total{exported_namespace='<%= namespace %>',name='<%= vmName %>'})<%= duration %>`,
+    `sum(kubevirt_vmi_network_traffic_bytes_total{exported_namespace='<%= namespace %>',name='<%= vmName %>'})`,
   ),
   /* TODO: use when multi-line chart is ready
   [VMQueries.NETWORK_IN_USAGE]: _.template(
-    `sum(kubevirt_vmi_network_traffic_bytes_total{type='rx',exported_namespace='<%= namespace %>',name='<%= vmName %>'})<%= duration %>`,
+    `sum(kubevirt_vmi_network_traffic_bytes_total{type='rx',exported_namespace='<%= namespace %>',name='<%= vmName %>'})`,
   ),
   [VMQueries.NETWORK_OUT_USAGE]: _.template(
-    `sum(kubevirt_vmi_network_traffic_bytes_total{type='tx',exported_namespace='<%= namespace %>',name='<%= vmName %>'})<%= duration %>`,
+    `sum(kubevirt_vmi_network_traffic_bytes_total{type='tx',exported_namespace='<%= namespace %>',name='<%= vmName %>'})`,
   ),
   */
 };
@@ -39,10 +39,22 @@ export const getUtilizationQueries = (props: {
   namespace: string;
   duration: string;
   launcherPodName?: string;
-}) => ({
-  [VMQueries.CPU_USAGE]: queries[VMQueries.CPU_USAGE](props),
-  [VMQueries.MEMORY_USAGE]: queries[VMQueries.MEMORY_USAGE](props),
-  [VMQueries.FILESYSTEM_USAGE]: queries[VMQueries.FILESYSTEM_USAGE](props),
-  [VMQueries.NETWORK_INOUT_USAGE]: queries[VMQueries.NETWORK_INOUT_USAGE](props),
-  // [VMQueries.NETWORK_OUT_USAGE]: queries[VMQueries.NETWORK_OUT_USAGE](props),
-});
+}) => {
+  const generic = {
+    [VMQueries.CPU_USAGE]: queries[VMQueries.CPU_USAGE](props),
+    [VMQueries.MEMORY_USAGE]: queries[VMQueries.MEMORY_USAGE](props),
+    [VMQueries.FILESYSTEM_USAGE]: queries[VMQueries.FILESYSTEM_USAGE](props),
+    [VMQueries.NETWORK_INOUT_USAGE]: queries[VMQueries.NETWORK_INOUT_USAGE](props),
+    // [VMQueries.NETWORK_OUT_USAGE]: queries[VMQueries.NETWORK_OUT_USAGE](props),
+  };
+
+  const queriesWithDuration = _.clone(generic);
+  Object.keys(queriesWithDuration).forEach((key) => {
+    queriesWithDuration[key] += props.duration;
+  });
+
+  return {
+    queriesWithDuration,
+    queries: generic,
+  };
+};

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -1,0 +1,154 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import {
+  withDashboardResources,
+  DashboardItemProps,
+} from '@console/internal/components/dashboard/with-dashboard-resources';
+import { PrometheusResponse } from '@console/internal/components/graphs';
+import {
+  Dropdown,
+  humanizeDecimalBytes,
+  humanizeCpuCores as humanizeCpuCoresUtil,
+} from '@console/internal/components/utils';
+import { getName, getNamespace } from '@console/shared';
+import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
+import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
+import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
+import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
+import UtilizationBody from '@console/shared/src/components/dashboard/utilization-card/UtilizationBody';
+import UtilizationItem from '@console/shared/src/components/dashboard/utilization-card/UtilizationItem';
+import {
+  ONE_HR,
+  SIX_HR,
+  TWENTY_FOUR_HR,
+  UTILIZATION_QUERY_HOUR_MAP,
+} from '@console/shared/src/components/dashboard/utilization-card/dropdown-value';
+import { getRangeVectorStats } from '@console/internal/components/graphs/utils';
+import { VMDashboardContext } from '../../vms/vm-dashboard-context';
+import { findVMPod } from '../../../selectors/pod/selectors';
+import { getUtilizationQueries, VMQueries } from './queries';
+
+const metricDurations = [ONE_HR, SIX_HR, TWENTY_FOUR_HR];
+const metricDurationsOptions = _.zipObject(metricDurations, metricDurations);
+
+const readPrometheusResult = (prometheusResults, query) => {
+  const data = prometheusResults.getIn([query, 'data']) as PrometheusResponse;
+  const error = prometheusResults.getIn([query, 'loadError']);
+  return [data, error];
+};
+
+// TODO: extend humanizeCpuCores() from @console/internal for the flexibility of space
+const humanizeCpuCores = (v) => {
+  const humanized = humanizeCpuCoresUtil(v);
+  // add space betwee value and unit
+  const val = humanized.string.match(/[\d.]+/) || [humanized.string];
+  humanized.string = `${val[0]} ${humanized.unit}`;
+  return humanized;
+};
+
+export const VMUtilizationCard = withDashboardResources(
+  ({ watchPrometheus, stopWatchPrometheusQuery, prometheusResults }: DashboardItemProps) => {
+    const [duration, setDuration] = React.useState(metricDurations[0]);
+    const { vm, pods } = React.useContext(VMDashboardContext);
+    const vmName = getName(vm);
+    const namespace = getNamespace(vm);
+    const launcherPod = findVMPod(vm, pods);
+    const queries = React.useMemo(
+      () =>
+        getUtilizationQueries({
+          vmName,
+          namespace,
+          duration: UTILIZATION_QUERY_HOUR_MAP[duration],
+          launcherPodName: getName(launcherPod),
+        }),
+      [vmName, namespace, duration, launcherPod],
+    );
+    React.useEffect(() => {
+      _.values(queries).forEach((query) => watchPrometheus(query, namespace));
+      return () => {
+        _.values(queries).forEach((query) => stopWatchPrometheusQuery(query));
+      };
+    }, [watchPrometheus, stopWatchPrometheusQuery, queries, namespace, duration]);
+
+    const [cpuUtilization, cpuError] = readPrometheusResult(
+      prometheusResults,
+      queries[VMQueries.CPU_USAGE],
+    );
+    const [memoryUtilization, memoryError] = readPrometheusResult(
+      prometheusResults,
+      queries[VMQueries.MEMORY_USAGE],
+    );
+    const [fsUtilization, fsError] = readPrometheusResult(
+      prometheusResults,
+      queries[VMQueries.FILESYSTEM_USAGE],
+    );
+    const [netUtilizationInOut, netErrorInOut] = readPrometheusResult(
+      prometheusResults,
+      queries[VMQueries.NETWORK_INOUT_USAGE],
+    );
+
+    const cpuStats = getRangeVectorStats(cpuUtilization);
+    const memoryStats = getRangeVectorStats(memoryUtilization);
+    const fsStats = getRangeVectorStats(fsUtilization);
+    const netStats = getRangeVectorStats(netUtilizationInOut);
+
+    /* TODO: use when multi-line charts are ready
+    const netStats = [
+      getRangeVectorStats(netUtilizationIn),
+      getRangeVectorStats(netUtilizationOut),
+    ];
+    const netDataUnits = ['In', 'Out'];
+    */
+
+    return (
+      <DashboardCard>
+        <DashboardCardHeader>
+          <DashboardCardTitle>Utilization</DashboardCardTitle>
+          <Dropdown
+            items={metricDurationsOptions}
+            onChange={setDuration}
+            selectedKey={duration}
+            title={duration}
+          />
+        </DashboardCardHeader>
+        <DashboardCardBody>
+          <UtilizationBody timestamps={cpuStats.map((stat) => stat.x as Date)}>
+            <UtilizationItem
+              title="CPU"
+              data={cpuStats}
+              isLoading={!namespace || !cpuUtilization}
+              humanizeValue={humanizeCpuCores}
+              query={queries[VMQueries.CPU_USAGE]}
+              error={cpuError}
+            />
+          </UtilizationBody>
+          <UtilizationItem
+            title="Memory"
+            data={memoryStats}
+            isLoading={!namespace || !memoryUtilization}
+            humanizeValue={humanizeDecimalBytes}
+            query={queries[VMQueries.MEMORY_USAGE]}
+            error={memoryError}
+          />
+          <UtilizationItem
+            title="Filesystem"
+            data={fsStats}
+            isLoading={!namespace || !fsUtilization}
+            humanizeValue={humanizeDecimalBytes}
+            query={queries[VMQueries.FILESYSTEM_USAGE]}
+            error={fsError}
+          />
+          <UtilizationItem
+            title="Network Transfer"
+            data={netStats}
+            isLoading={!namespace || !netUtilizationInOut}
+            humanizeValue={humanizeDecimalBytes}
+            query={queries[VMQueries.NETWORK_INOUT_USAGE]}
+            error={netErrorInOut}
+          />
+        </DashboardCardBody>
+      </DashboardCard>
+    );
+  },
+);
+VMUtilizationCard.displayName = 'VMUtilizationCard';

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -52,39 +52,39 @@ export const VMUtilizationCard = withDashboardResources(
     const { vm, pods } = React.useContext(VMDashboardContext);
     const vmName = getName(vm);
     const namespace = getNamespace(vm);
-    const launcherPod = findVMPod(vm, pods);
-    const queries = React.useMemo(
+    const launcherPodName = getName(findVMPod(vm, pods));
+    const { queries, queriesWithDuration } = React.useMemo(
       () =>
         getUtilizationQueries({
           vmName,
           namespace,
           duration: UTILIZATION_QUERY_HOUR_MAP[duration],
-          launcherPodName: getName(launcherPod),
+          launcherPodName,
         }),
-      [vmName, namespace, duration, launcherPod],
+      [vmName, namespace, duration, launcherPodName],
     );
     React.useEffect(() => {
-      _.values(queries).forEach((query) => watchPrometheus(query, namespace));
+      _.values(queriesWithDuration).forEach((query) => watchPrometheus(query, namespace));
       return () => {
-        _.values(queries).forEach((query) => stopWatchPrometheusQuery(query));
+        _.values(queriesWithDuration).forEach((query) => stopWatchPrometheusQuery(query));
       };
-    }, [watchPrometheus, stopWatchPrometheusQuery, queries, namespace, duration]);
+    }, [watchPrometheus, stopWatchPrometheusQuery, queriesWithDuration, namespace]);
 
     const [cpuUtilization, cpuError] = readPrometheusResult(
       prometheusResults,
-      queries[VMQueries.CPU_USAGE],
+      queriesWithDuration[VMQueries.CPU_USAGE],
     );
     const [memoryUtilization, memoryError] = readPrometheusResult(
       prometheusResults,
-      queries[VMQueries.MEMORY_USAGE],
+      queriesWithDuration[VMQueries.MEMORY_USAGE],
     );
     const [fsUtilization, fsError] = readPrometheusResult(
       prometheusResults,
-      queries[VMQueries.FILESYSTEM_USAGE],
+      queriesWithDuration[VMQueries.FILESYSTEM_USAGE],
     );
     const [netUtilizationInOut, netErrorInOut] = readPrometheusResult(
       prometheusResults,
-      queries[VMQueries.NETWORK_INOUT_USAGE],
+      queriesWithDuration[VMQueries.NETWORK_INOUT_USAGE],
     );
 
     const cpuStats = getRangeVectorStats(cpuUtilization);

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
@@ -8,10 +8,11 @@ import {
   VMInventoryCard,
   VMStatusCard,
   VMActivityCard,
+  VMUtilizationCard,
 } from '../dashboards-page/vm-dashboard';
 import { VMDashboardContext } from './vm-dashboard-context';
 
-const mainCards = [{ Card: VMStatusCard }];
+const mainCards = [{ Card: VMStatusCard }, { Card: VMUtilizationCard }];
 const leftCards = [{ Card: VMDetailsCard }, { Card: VMInventoryCard }];
 const rightCards = [{ Card: VMActivityCard }];
 


### PR DESCRIPTION
Simplified version of #3089 - the network chart is single-line only, as we are close to development freeze and aat least basic functionality should land.

There will be network In/Out traffic separated once multi-line chart support is available (wip in #3089).