### PR TITLE
Create Pipeline YAML w/ Snippets

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/PipelinesPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelinesPage.tsx
@@ -24,7 +24,9 @@ const PipelinesPage: React.FC<PipelinesPageProps> = ({ namespace }) => {
   ];
   return namespace ? (
     <FireMan
-      canCreate={false}
+      canCreate
+      createButtonText={`Create ${PipelineModel.label}`}
+      createProps={{ to: `/k8s/ns/${namespace}/${referenceForModel(PipelineModel)}/~new` }}
       filterLabel="by name"
       textFilter="name"
       resources={resources}

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -13,6 +13,7 @@ import {
   Perspective,
   RoutePage,
   OverviewCRD,
+  YAMLTemplate,
 } from '@console/plugin-sdk';
 import { NamespaceRedirect } from '@console/internal/components/utils/namespace-redirect';
 import { CodeIcon } from '@patternfly/react-icons';
@@ -25,6 +26,7 @@ import {
   getPipelinesAndPipelineRunsForResource,
 } from './utils/pipeline-plugin-utils';
 import { FLAG_OPENSHIFT_PIPELINE, ALLOW_SERVICE_BINDING } from './const';
+import { newPipelineTemplate } from './templates';
 
 const { PipelineModel, PipelineRunModel } = models;
 
@@ -39,7 +41,8 @@ type ConsumedExtensions =
   | Perspective
   | RoutePage
   | KebabActions
-  | OverviewCRD;
+  | OverviewCRD
+  | YAMLTemplate;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -351,6 +354,13 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'KebabActions',
     properties: {
       getKebabActionsForKind,
+    },
+  },
+  {
+    type: 'YAMLTemplate',
+    properties: {
+      model: PipelineModel,
+      template: newPipelineTemplate,
     },
   },
 ];

--- a/frontend/packages/dev-console/src/templates/index.ts
+++ b/frontend/packages/dev-console/src/templates/index.ts
@@ -1,0 +1,1 @@
+export * from './pipeline';

--- a/frontend/packages/dev-console/src/templates/pipeline.ts
+++ b/frontend/packages/dev-console/src/templates/pipeline.ts
@@ -1,0 +1,21 @@
+export const newPipelineTemplate = `
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: new-pipeline
+  namespace: default
+spec:
+  params:
+    - name: PARAM_NAME
+      type: string
+      default: defaultValue
+  resources:
+    - name: app-source
+      type: git
+    - name: app-image
+      type: image
+  tasks:
+    - name: first-task
+      taskRef:
+        name: task-name
+`;

--- a/frontend/public/components/sidebars/resource-sidebar-samples.tsx
+++ b/frontend/public/components/sidebars/resource-sidebar-samples.tsx
@@ -2,7 +2,13 @@ import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Map as ImmutableMap } from 'immutable';
 import { Button } from '@patternfly/react-core';
-import { DownloadIcon, PasteIcon } from '@patternfly/react-icons';
+import MonacoEditor from 'react-monaco-editor';
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  DownloadIcon,
+  PasteIcon,
+} from '@patternfly/react-icons';
 
 import {
   BuildConfigModel,
@@ -216,7 +222,14 @@ export const getResourceSidebarSamples = (kindObj: K8sKind, yamlSamplesList: Fir
         };
       })
     : [];
-  return [...existingSamples, ...extensionSamples];
+
+  const allSamples = [...existingSamples, ...extensionSamples];
+
+  // For the time being, `snippets` are a superset of `samples`
+  const snippets = allSamples.filter((sample: Sample) => sample.snippet);
+  const samples = allSamples.filter((sample: Sample) => !sample.snippet);
+
+  return { snippets, samples };
 };
 
 const ResourceSidebarSample: React.FC<ResourceSidebarSampleProps> = ({
@@ -256,6 +269,85 @@ const ResourceSidebarSample: React.FC<ResourceSidebarSampleProps> = ({
   );
 };
 
+const lineHeight = 18;
+const PreviewYAML = ({ maxPreviewLines = 20, yaml }) => {
+  return (
+    <div style={{ paddingTop: 10 }}>
+      <MonacoEditor
+        height={Math.min(yaml.split('\n').length, maxPreviewLines) * lineHeight}
+        language="yaml"
+        value={yaml}
+        options={{
+          lineHeight,
+          readOnly: true,
+          folding: false,
+          minimap: { enabled: false },
+          scrollBeyondLastLine: false,
+        }}
+      />
+    </div>
+  );
+};
+
+const ResourceSidebarSnippet: React.FC<any> = ({ snippet, insertSnippetYaml }) => {
+  const [yamlPreviewOpen, setYamlPreviewOpen] = React.useState(false);
+  const toggleYamlPreview = () => setYamlPreviewOpen(!yamlPreviewOpen);
+
+  const { highlightText, title, id, yaml, targetResource, description } = snippet;
+  const reference = referenceFor(targetResource);
+  return (
+    <li className="co-resource-sidebar-item">
+      <h3 className="h4">
+        <span className="text-uppercase">{highlightText}</span> {title}
+      </h3>
+      <p>{description}</p>
+      <Button
+        type="button"
+        variant="link"
+        isInline
+        onClick={() => insertSnippetYaml(id, yaml, reference)}
+      >
+        <PasteIcon className="co-icon-space-r" />
+        Insert Snippet
+      </Button>
+      <Button
+        type="button"
+        className="pull-right"
+        variant="link"
+        isInline
+        onClick={() => toggleYamlPreview()}
+      >
+        {yamlPreviewOpen ? (
+          <>
+            Hide YAML
+            <ChevronDownIcon className="co-icon-space-l" />
+          </>
+        ) : (
+          <>
+            Show YAML
+            <ChevronRightIcon className="co-icon-space-l" />
+          </>
+        )}
+      </Button>
+      {yamlPreviewOpen && <PreviewYAML yaml={yaml} />}
+    </li>
+  );
+};
+
+export const ResourceSidebarSnippets = ({ snippets, insertSnippetYaml }) => {
+  return (
+    <ul className="co-resource-sidebar-list" style={{ listStyle: 'none', paddingLeft: 0 }}>
+      {_.map(snippets, (snippet) => (
+        <ResourceSidebarSnippet
+          key={snippet.id}
+          snippet={snippet}
+          insertSnippetYaml={insertSnippetYaml}
+        />
+      ))}
+    </ul>
+  );
+};
+
 export const ResourceSidebarSamples: React.FC<ResourceSidebarSamplesProps> = ({
   samples,
   loadSampleYaml,
@@ -282,6 +374,7 @@ type Sample = {
   description: string;
   id: string;
   yaml?: string;
+  snippet?: boolean;
   targetResource: {
     apiVersion: string;
     kind: string;

--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -3,7 +3,11 @@ import * as _ from 'lodash-es';
 import { Button } from '@patternfly/react-core';
 import { CloseIcon, InfoCircleIcon } from '@patternfly/react-icons';
 
-import { ResourceSidebarSamples, getResourceSidebarSamples } from './resource-sidebar-samples';
+import {
+  ResourceSidebarSnippets,
+  ResourceSidebarSamples,
+  getResourceSidebarSamples,
+} from './resource-sidebar-samples';
 import { ExploreType } from './explore-type-sidebar';
 import { Firehose, SimpleTabNav } from '../utils';
 import { connectToFlags } from '../../reducers/features';
@@ -85,6 +89,14 @@ const ResourceSamples = ({ samples, kindObj, downloadSampleYaml, loadSampleYaml 
   />
 );
 
+const ResourceSnippets = ({ snippets, kindObj, insertSnippetYaml }) => (
+  <ResourceSidebarSnippets
+    snippets={snippets}
+    kindObj={kindObj}
+    insertSnippetYaml={insertSnippetYaml}
+  />
+);
+
 const ResourceSidebarContent = (props) => {
   const {
     downloadSampleYaml,
@@ -92,6 +104,7 @@ const ResourceSidebarContent = (props) => {
     isCreateMode,
     kindObj,
     loadSampleYaml,
+    insertSnippetYaml,
     yamlSamplesList,
   } = props;
   if (!kindObj) {
@@ -99,8 +112,34 @@ const ResourceSidebarContent = (props) => {
   }
 
   const { label } = kindObj;
-  const samples = getResourceSidebarSamples(kindObj, yamlSamplesList);
+  const { samples, snippets } = getResourceSidebarSamples(kindObj, yamlSamplesList);
   const showSamples = !_.isEmpty(samples) && isCreateMode;
+  const showSnippets = snippets.length > 0;
+
+  let tabs = [];
+  if (showSamples) {
+    tabs.push({
+      name: 'Samples',
+      component: ResourceSamples,
+    });
+  }
+  if (showSnippets) {
+    tabs.push({
+      name: 'Snippets',
+      component: ResourceSnippets,
+    });
+  }
+  if (tabs.length > 0) {
+    // TODO: Pre-determine if we have a schema
+    // Possible Related Bug: https://jira.coreos.com/browse/CONSOLE-1611
+    tabs = [
+      {
+        name: 'Schema',
+        component: ResourceSchema,
+      },
+      ...tabs,
+    ];
+  }
 
   return (
     <ResourceSidebarWrapper
@@ -109,23 +148,16 @@ const ResourceSidebarContent = (props) => {
       style={{ height }}
       startHidden={!isCreateMode}
     >
-      {showSamples ? (
+      {tabs.length > 0 ? (
         <SimpleTabNav
-          tabs={[
-            {
-              name: 'Schema',
-              component: ResourceSchema,
-            },
-            {
-              name: 'Samples',
-              component: ResourceSamples,
-            },
-          ]}
+          tabs={tabs}
           tabProps={{
             downloadSampleYaml,
             kindObj,
             loadSampleYaml,
+            insertSnippetYaml,
             samples,
+            snippets,
           }}
           additionalClassNames="co-m-horizontal-nav__menu--within-sidebar"
         />


### PR DESCRIPTION
https://jira.coreos.com/browse/ODC-2100

- Allow access to creating Pipelines via the YAML editor
- Add "Snippets" so portions of a YAML can be inserted without replacing the whole content
- "Snippets" are a new, generic, concept build on top of the CRD CustomYAMLSample (CYS) -- looked to be improved in 4.4

Edit: Note, I did end up adding the DevPreview badge to the create-new page. They are just not in the screenshots below.

Snippets Sidebar:
![Screen Shot 2019-10-30 at 3 23 15 PM](https://user-images.githubusercontent.com/8126518/67891741-95fb0e00-fb29-11e9-89f1-f1fd51b98166.png)
![Screen Shot 2019-10-30 at 3 23 31 PM](https://user-images.githubusercontent.com/8126518/67891742-95fb0e00-fb29-11e9-89db-405f71bcc6ad.png)

After insert (text is selected):
![Screen Shot 2019-10-30 at 3 24 08 PM](https://user-images.githubusercontent.com/8126518/67891743-95fb0e00-fb29-11e9-8309-484b49bcfd2d.png)

--- 

Creating Snippets (Using the CustomYAMLSample CRD):

![image](https://user-images.githubusercontent.com/8126518/67892327-e2931900-fb2a-11e9-9281-5ebef093a198.png)
