### PR TITLE
dashboard: Make StatusCard height flexible

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
@@ -7,6 +7,10 @@
   min-height: 6rem;
   overflow-x: hidden;
   overflow-y: auto;
+
+  .pf-c-empty-state__icon {
+    margin-bottom: 0 !important;
+  }
 }
 
 .co-status-card__alerts-body--loading {

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
@@ -3,7 +3,8 @@
 
 .co-status-card__alerts-body {
   border-top: 1px solid $pf-color-black-300;
-  height: 300px;
+  max-height: 19rem;
+  min-height: 6rem;
   overflow-x: hidden;
   overflow-y: auto;
 }


### PR DESCRIPTION
For the case when there is not enough status messages to show, the large white card looks distracting.
By making it smaller, the focus is attracted to other cards instead.

---
![01](https://user-images.githubusercontent.com/17194943/67937245-803f2480-fbcd-11e9-979d-df84c582e9b3.png)

![02](https://user-images.githubusercontent.com/17194943/67937246-80d7bb00-fbcd-11e9-8a6c-680698165780.png)

![03](https://user-images.githubusercontent.com/17194943/67937247-80d7bb00-fbcd-11e9-9bc2-1dcd9bc4b650.png)
