### PR TITLE
Fix NetworkAttachmentDefinition configs & redirect after YAML creation bug

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
@@ -31,7 +31,7 @@ const CreateNetAttachDefYAMLConnected = connectToPlural(
 
     const netAttachDefTemplatePath = (o: K8sResourceKind) =>
       resourcePathFromModel(
-        { ...NetworkAttachmentDefinitionModel, plural: 'networkattachmentdefinitions' },
+        { ...NetworkAttachmentDefinitionModel, plural: 'network-attachment-definitions' },
         getName(o),
         getNamespace(o),
       );

--- a/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
@@ -9,7 +9,7 @@ export const ELEMENT_TYPES = {
 
 export const networkTypes = {
   sriov: 'SR-IOV',
-  bridge: 'Linux bridge',
+  'cnv-bridge': 'Linux bridge',
 };
 
 export const networkTypeParams: NetworkTypeParamsList = {
@@ -30,8 +30,8 @@ export const networkTypeParams: NetworkTypeParamsList = {
       type: ELEMENT_TYPES.TEXTAREA,
     },
   },
-  bridge: {
-    bridgeName: {
+  'cnv-bridge': {
+    bridge: {
       name: 'Bridge Name',
       required: true,
       type: ELEMENT_TYPES.TEXT,

--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -1,5 +1,10 @@
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
+export type NetworkAttachmentDefinitionAnnotations = {
+  description?: string;
+  'k8s.v1.cni.cncf.io/resourceName': string;
+};
+
 export type IPAMConfig = {
   type?: string;
   subnet?: string;
@@ -13,7 +18,7 @@ export type NetworkAttachmentDefinitionConfig = {
   bridge?: string;
   isGateway?: true;
   ipam?: IPAMConfig;
-  plugins?: NetworkAttachmentDefinitionConfig[];
+  plugins?: any[];
 };
 
 // The config is a JSON object with the NetworkAttachmentDefinitionConfig type stored as a string


### PR DESCRIPTION
This PR fixes the content and structure of the configurations created by using the network attachment definitions form. Example configurations created using the form are below. This PR also fixes an issue where the user was redirected to the wrong URL after successfully creating a network attachment definition via YAML.

Bridge:
```yaml
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  annotations:
    k8s.v1.cni.cncf.io/resourceName: bridge.network.kubevirt.io/br0
  creationTimestamp: '2019-10-31T12:16:06Z'
  generation: 1
  name: test-bridge
  namespace: rhodes-test
  resourceVersion: '769456'
  selfLink: >-
    /apis/k8s.cni.cncf.io/v1/namespaces/rhodes-test/network-attachment-definitions/test-bridge
  uid: 373e5ba7-fbd8-11e9-bfee-525400f2bdf7
spec:
  config: >-
    {"name":"test-bridge","type":"cnv-bridge","cniVersion":"0.3.1","plugins":[{"type":"cnv-bridge","bridge":"br0","vlan":"100","ipam":{}},{"type":"cnv-tuning"}]}
```

SR-IOV:
```yaml
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  annotations:
    k8s.v1.cni.cncf.io/resourceName: bridge.network.kubevirt.io/sriov_net
  creationTimestamp: '2019-10-31T12:16:36Z'
  generation: 1
  name: test-sriov
  namespace: rhodes-test
  resourceVersion: '769807'
  selfLink: >-
    /apis/k8s.cni.cncf.io/v1/namespaces/rhodes-test/network-attachment-definitions/test-sriov
  uid: 48a611f4-fbd8-11e9-bfee-525400f2bdf7
spec:
  config: '{"name":"test-sriov","type":"sriov","cniVersion":"0.3.1","ipam":{}}'``` 

@phoracek 