### PR TITLE
Bug 1769422: frontend: Add shortcuts link to YAML and hide sidebar when no data

### DIFF
--- a/frontend/public/components/_edit-yaml.scss
+++ b/frontend/public/components/_edit-yaml.scss
@@ -32,6 +32,20 @@
   margin: 0;
 }
 
+.yaml-editor__link {
+  display: inline-block;
+}
+
+.yaml-editor__links {
+  position: absolute;
+  top: 5px;
+  right: 0;
+  z-index: 1;
+  @media(max-width: $screen-sm-max) {
+    display: none;
+  }
+}
+
 // This can't be customized in a theme, so use CSS.
 .yaml-editor .monaco-editor .margin .current-line {
   background-color: var(--pf-global--BackgroundColor--dark-200);

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -229,6 +229,11 @@ $co-external-link-padding-right: 15px;
 
 .co-action-divider {
   color: $color-pf-black-600;
+
+  &--spaced {
+    display: inline-block;
+    margin: 0 10px 0 10px;
+  }
 }
 
 .co-break-word {

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -52,11 +52,4 @@ body,
     margin-bottom: 20px;
     margin-top: 0;
   }
-
-  &__sidebar--hidden {
-    position: absolute;
-    right: $grid-gutter-width;
-    top: 5px;
-    z-index: 1;
-  }
 }


### PR DESCRIPTION
Added shortcuts link with popover to YAML page. Refactored edit yaml and sidebar a bit so I could have more control over link positioning.

Shortcuts link with "schema and samples" sidebar link:
<img width="1152" alt="Screen Shot 2019-10-31 at 3 29 46 PM" src="https://user-images.githubusercontent.com/7014965/67979791-63b5e300-fbf3-11e9-8c96-b934e4e2c023.png">

Shortcuts link with open sidebar:
<img width="1158" alt="Screen Shot 2019-10-31 at 3 29 29 PM" src="https://user-images.githubusercontent.com/7014965/67979797-6a445a80-fbf3-11e9-9d25-5a933cfe7d9c.png">

Shortcuts link with "Schema" sidebar link (on click):
<img width="1154" alt="Screen Shot 2019-10-31 at 3 36 52 PM" src="https://user-images.githubusercontent.com/7014965/67980201-4a616680-fbf4-11e9-8fae-e7645ffc0bcc.png">

Shortcuts link with open sidebar (on click):
<img width="1087" alt="Screen Shot 2019-10-31 at 9 17 35 AM" src="https://user-images.githubusercontent.com/7014965/67979762-539e0380-fbf3-11e9-9879-cda8227eca06.png">

Also added logic to hide the sidebar when there is no data.

Fixes https://jira.coreos.com/projects/CONSOLE/issues/CONSOLE-1805 and https://jira.coreos.com/browse/CONSOLE-1611.

Heads up for @openshift/team-ux-review. 