### PR TITLE
Add max values (quota limits) to project utilization card

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -15,6 +15,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
     max = null,
     TopConsumerPopover,
     byteDataType,
+    maxSuffix,
   }) => {
     let current;
     if (data.length) {
@@ -66,7 +67,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
           <div className="pf-l-level">
             <span className="co-utilization-card__item__text" />
             <span className="co-utilization-card__item__text">
-              {humanMax && <span>of {humanMax}</span>}
+              {humanMax && <span>of {maxSuffix ? `${humanMax} ${maxSuffix}` : humanMax}</span>}
             </span>
           </div>
         </div>
@@ -88,6 +89,7 @@ type UtilizationItemProps = {
   max?: number;
   byteDataType?: ByteDataTypes;
   TopConsumerPopover?: React.ComponentType<TopConsumerPopoverProp>;
+  maxSuffix?: string;
 };
 
 type TopConsumerPopoverProp = {


### PR DESCRIPTION
![util_quotas](https://user-images.githubusercontent.com/2078045/67980963-d6d54e80-fc1f-11e9-855f-8c1b52389b27.png)

with https://github.com/openshift/console/pull/3166 applied you also get `<number> available` under resource

![util_quota_avail](https://user-images.githubusercontent.com/2078045/67980990-ebb1e200-fc1f-11e9-85c1-63ffeaecb37e.png)
