### PR TITLE
Incept Container Security Operator Plugin

### DIFF
--- a/frontend/packages/console-app/package.json
+++ b/frontend/packages/console-app/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@console/ceph-storage-plugin": "0.0.0-fixed",
+    "@console/container-security": "0.0.0-fixed",
     "@console/dev-console": "0.0.0-fixed",
     "@console/git-service": "0.0.0-fixed",
     "@console/internal": "0.0.0-fixed",

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -41,6 +41,17 @@ namespace ExtensionProperties {
 
     /** Resolve the subsystem's health */
     healthHandler: URLHealthHandler<R>;
+
+    /**
+     * Loader for popup content. If defined health item will be represented as link
+     * which opens popup with given content.
+     */
+    popupComponent?: LazyLoader<any>;
+
+    /**
+     * Popup title
+     */
+    popupTitle?: string;
   }
 
   export interface DashboardsOverviewHealthPrometheusSubsystem

--- a/frontend/packages/container-security/package.json
+++ b/frontend/packages/container-security/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@console/container-security",
+  "version": "0.0.0-fixed",
+  "description": "Kubernetes Container Security Operator",
+  "main": "src/index.ts",
+  "private": true,
+  "dependencies": {
+    "@console/plugin-sdk": "0.0.0-fixed"
+  },
+  "devDependencies": {
+    "@types/enzyme": "3.x",
+    "@types/jasmine": "2.8.x",
+    "@types/jasminewd2": "2.0.x",
+    "@types/jest": "21.x"
+  },
+  "consolePlugin": {
+    "entry": "src/plugin.ts"
+  }
+}

--- a/frontend/packages/container-security/src/components/__tests__/summary.spec.ts
+++ b/frontend/packages/container-security/src/components/__tests__/summary.spec.ts
@@ -1,0 +1,57 @@
+import { HealthState } from '@console/shared/src/components/dashboard/health-card/states';
+import { securityHealthHandler } from '../summary';
+import { ImageManifestVuln } from '../../types';
+
+const highVuln: ImageManifestVuln = {
+  apiVersion: 'secscan.quay.redhat.com/v1alpha1',
+  kind: 'ImageManifestVuln',
+  metadata: {
+    name: 'sha256.0208a7a39ace0fbfeb537526515006c1259139fa78b3b4889cf04f8e44d5442f',
+  },
+  spec: {
+    features: [],
+    image: 'quay.io/coreos/example',
+    manifest: 'sha256:0208a7a39ace0fbfeb537526515006c1259139fa78b3b4889cf04f8e44d5442f',
+    namespaceName: 'centos:7',
+  },
+  status: {
+    afftectedPods: {
+      'test/some-pod': ['cri-o://524638ef02d6da6bfe48650663f838f9f2fbe1e9769f886863fe509bc74b75ef'],
+    },
+    fixableCount: 61,
+    highCount: 14,
+    highestSeverity: 'High',
+    lowCount: 14,
+    mediumCount: 33,
+  },
+};
+
+describe('securityHealthHandler', () => {
+  it('returns `UNKNOWN` status if there is an error retrieving `ImageManifestVulns`', () => {
+    const vulnerabilities = { loaded: true, loadError: 'failed to fetch', data: [] };
+    const health = securityHealthHandler(null, null, vulnerabilities);
+
+    expect(health.state).toEqual(HealthState.UNKNOWN);
+  });
+
+  it('returns `LOADING` status if still retrieving `ImageManifestVulns`', () => {
+    const vulnerabilities = { loaded: false, loadError: null, data: [] };
+    const health = securityHealthHandler(null, null, vulnerabilities);
+
+    expect(health.state).toEqual(HealthState.LOADING);
+  });
+
+  it('returns `Error` status if any `ImageManifestVulns` exist', () => {
+    const vulnerabilities = { loaded: true, loadError: null, data: [highVuln] };
+    const health = securityHealthHandler(null, null, vulnerabilities);
+
+    expect(health.state).toEqual(HealthState.ERROR);
+  });
+
+  it('returns `OK` status if no vulnerabilities', () => {
+    const vulnerabilities = { loaded: true, loadError: null, data: [] };
+    const health = securityHealthHandler(null, null, vulnerabilities);
+
+    expect(health.state).toEqual(HealthState.OK);
+  });
+});

--- a/frontend/packages/container-security/src/components/summary.tsx
+++ b/frontend/packages/container-security/src/components/summary.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { ChartDonut } from '@patternfly/react-charts';
+import { SecurityIcon } from '@patternfly/react-icons';
+import { URLHealthHandler } from '@console/plugin-sdk';
+import { HealthState } from '@console/shared/src/components/dashboard/health-card/states';
+import { FirehoseResult } from '@console/internal/components/utils/types';
+import { Link } from 'react-router-dom';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ImageManifestVuln } from '../types';
+import { VulnPriority } from '../const';
+import { ImageManifestVulnModel } from '../models';
+
+export const securityHealthHandler: URLHealthHandler<string> = (
+  k8sHealth,
+  error,
+  resource: FirehoseResult<ImageManifestVuln[]>,
+) => {
+  if (error || _.get(resource, 'loadError')) {
+    return { state: HealthState.UNKNOWN, message: 'Not available' };
+  }
+  if (!_.get(resource, 'loaded')) {
+    return { state: HealthState.LOADING, message: 'Scanning in progress' };
+  }
+  if (!_.isEmpty(resource.data)) {
+    return { state: HealthState.ERROR, message: `${resource.data.length} vulnerabilities` };
+  }
+  return { state: HealthState.OK, message: '0 vulnerabilities' };
+};
+
+const quayURLFor = (vuln: ImageManifestVuln) => {
+  const base = vuln.spec.image
+    .split('/')
+    .reduce((url, part, i) => [...url, part, ...(i === 0 ? ['repository'] : [])], [])
+    .join('/');
+  return `//${base}/manifest/${vuln.spec.manifest}?tab=vulnerabilities`;
+};
+
+export const SecurityBreakdownPopup: React.FC<SecurityBreakdownPopupProps> = (props) => {
+  const vulnsFor = (severity: string) =>
+    props.k8sResult.data.filter((v) => _.get(v.status, 'highestSeverity') === severity);
+  const fixableVulns = props.k8sResult.data
+    .filter((v) => _.get(v.status, 'fixableCount', 0) > 0)
+    .reduce((all, v) => all.set(v.metadata.name, v), new Map<string, ImageManifestVuln>());
+
+  return (
+    <>
+      <div className="co-overview-status__control-plane-description">
+        Quay analyzes container images to identify vulnerabilities.
+      </div>
+      {!_.isEmpty(props.k8sResult.data) ? (
+        <div>
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <div style={{ width: '66%', marginRight: '24px' }}>
+              <div className="co-overview-status__row">
+                <div className="co-overview-status__text--bold">Severity</div>
+                <div className="text-secondary">Fixable</div>
+              </div>
+              {_.map(VulnPriority, (priority) =>
+                !_.isEmpty(vulnsFor(priority.value)) ? (
+                  <div className="co-overview-status__row" key={priority.value}>
+                    <div className="co-overview-status__text--bold">
+                      {vulnsFor(priority.value).length} {priority.title}
+                    </div>
+                    <div className="text-secondary">
+                      {
+                        props.k8sResult.data.filter(
+                          (v) =>
+                            _.get(v.status, 'highestSeverity') === priority.value &&
+                            _.get(v.status, 'fixableCount', 0) > 0,
+                        ).length
+                      }{' '}
+                      <SecurityIcon color={priority.color.value} />
+                    </div>
+                  </div>
+                ) : null,
+              )}
+            </div>
+            <div>
+              <ChartDonut
+                colorScale={_.map(VulnPriority, (priority) => priority.color.value)}
+                data={_.map(VulnPriority, (priority) => ({
+                  label: priority.title,
+                  x: priority.value,
+                  y: vulnsFor(priority.value).length,
+                }))}
+                title={`${props.k8sResult.data.length} total`}
+              />
+            </div>
+          </div>
+          {!_.isEmpty(fixableVulns) && (
+            <>
+              <div className="co-overview-status__row">
+                <div className="co-overview-status__text--bold">Fixable Vulnerabilities</div>
+              </div>
+              {_.take([...fixableVulns.values()], 5).map((v) => (
+                <div className="co-overview-status__row" key={v.metadata.name}>
+                  <span>
+                    <SecurityIcon
+                      color={VulnPriority[_.get(v.status, 'highestSeverity')].color.value}
+                    />{' '}
+                    <a href={quayURLFor(v)}>{v.spec.features[0].name}</a>
+                  </span>
+                  <div className="text-secondary">
+                    <Link
+                      to={`/k8s/all-namespaces/${referenceForModel(ImageManifestVulnModel)}?name=${
+                        v.metadata.name
+                      }`}
+                    >
+                      {
+                        props.k8sResult.data.filter(
+                          ({ metadata }) => metadata.name === v.metadata.name,
+                        ).length
+                      }{' '}
+                      namespaces
+                    </Link>
+                  </div>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      ) : (
+        <div>No vulnerabilities detected.</div>
+      )}
+    </>
+  );
+};
+
+export type SecurityBreakdownPopupProps = {
+  healthResult?: any;
+  healthResultError?: any;
+  k8sResult?: FirehoseResult<ImageManifestVuln[]>;
+};
+
+SecurityBreakdownPopup.displayName = 'SecurityBreakdownPopup';

--- a/frontend/packages/container-security/src/const.ts
+++ b/frontend/packages/container-security/src/const.ts
@@ -1,0 +1,85 @@
+import {
+  /* eslint-disable @typescript-eslint/camelcase */
+  chart_color_red_400 as red400,
+  chart_color_red_300 as red300,
+  chart_color_red_100 as red100,
+  chart_color_orange_300 as orange300,
+  chart_color_gold_400 as gold400,
+  chart_color_black_500 as black500,
+  /* eslint-enable @typescript-eslint/camelcase */
+} from '@patternfly/react-tokens';
+
+export const SecurityLabellerFlag = 'SECURITY_LABELLER';
+
+export const VulnPriority = {
+  Defcon1: {
+    color: red400,
+    description:
+      'Defcon1 is a Critical problem which has been manually highlighted by the Quay team. It requires immediate attention.',
+    index: 0,
+    level: 'error',
+    score: 11,
+    title: 'Defcon 1',
+    value: 'Defcon1',
+  },
+  Critical: {
+    color: red300,
+    description:
+      'Critical is a world-burning problem, exploitable for nearly all people in a installation of the package. Includes remote root privilege escalations, or massive data loss.',
+    index: 1,
+    level: 'error',
+    score: 10,
+    title: 'Critical',
+    value: 'Critical',
+  },
+  High: {
+    color: red100,
+    description:
+      'High is a real problem, exploitable for many people in a default installation. Includes serious remote denial of services, local root privilege escalations, or data loss.',
+    index: 2,
+    level: 'warning',
+    score: 9,
+    title: 'High',
+    value: 'High',
+  },
+  Low: {
+    color: orange300,
+    description:
+      'Low is a security problem, but is hard to exploit due to environment, requires a user-assisted attack, a small install base, or does very little damage.',
+    index: 4,
+    level: 'warning',
+    score: 3,
+    title: 'Low',
+    value: 'Low',
+  },
+  Medium: {
+    color: gold400,
+    description:
+      'Medium is a real security problem, and is exploitable for many people. Includes network daemon denial of service attacks, cross-site scripting, and gaining user privileges.',
+    index: 3,
+    level: 'warning',
+    score: 6,
+    title: 'Medium',
+    value: 'Medium',
+  },
+  Negligible: {
+    color: black500,
+    description:
+      'Negligible is technically a security problem, but is only theoretical in nature, requires a very special situation, has almost no install base, or does no real damage.',
+    index: 5,
+    level: 'info',
+    score: 1,
+    title: 'Negligible',
+    value: 'Negligible',
+  },
+  Unknown: {
+    color: black500,
+    description:
+      'Unknown is either a security problem that has not been assigned to a priority yet or a priority that our system did not recognize',
+    index: 6,
+    level: 'info',
+    score: 0,
+    title: 'Unknown',
+    value: 'Unknown',
+  },
+};

--- a/frontend/packages/container-security/src/index.ts
+++ b/frontend/packages/container-security/src/index.ts
@@ -1,0 +1,2 @@
+export * from './components/summary';
+export * from './types';

--- a/frontend/packages/container-security/src/models.ts
+++ b/frontend/packages/container-security/src/models.ts
@@ -1,0 +1,13 @@
+import { K8sKind } from '@console/internal/module/k8s';
+
+export const ImageManifestVulnModel: K8sKind = {
+  kind: 'ImageManifestVuln',
+  label: 'ImageManifestVuln',
+  labelPlural: 'ImageManifestVuln',
+  apiGroup: 'secscan.quay.redhat.com',
+  apiVersion: 'v1alpha1',
+  abbr: 'VULN',
+  namespaced: true,
+  crd: true,
+  plural: 'imagemanifestvulns',
+};

--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -1,0 +1,44 @@
+import { referenceForModel } from '@console/internal/module/k8s';
+import { Plugin, ModelDefinition, ModelFeatureFlag } from '@console/plugin-sdk';
+import { ImageManifestVulnModel } from './models';
+import { SecurityLabellerFlag } from './const';
+import { securityHealthHandler } from './components/summary';
+
+type ConsumedExtensions = ModelDefinition | ModelFeatureFlag;
+
+export default [
+  {
+    type: 'ModelDefinition',
+    properties: {
+      models: [ImageManifestVulnModel],
+    },
+  },
+  {
+    type: 'FeatureFlag/Model',
+    properties: {
+      model: ImageManifestVulnModel,
+      flag: SecurityLabellerFlag,
+    },
+  },
+  {
+    type: 'Dashboards/Overview/Health/URL',
+    properties: {
+      title: 'Image Security',
+      url: '',
+      fetch: () => null,
+      healthHandler: securityHealthHandler,
+      additionalResource: {
+        kind: referenceForModel(ImageManifestVulnModel),
+        namespaced: true,
+        isList: true,
+        prop: 'imageManifestVuln',
+      },
+      popupComponent: () =>
+        import('./components/summary' /* webpackChunkName: "container-security" */).then(
+          (m) => m.SecurityBreakdownPopup,
+        ),
+      popupTitle: 'Security breakdown',
+      required: SecurityLabellerFlag,
+    },
+  },
+] as Plugin<ConsumedExtensions>;

--- a/frontend/packages/container-security/src/types.ts
+++ b/frontend/packages/container-security/src/types.ts
@@ -1,0 +1,45 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+
+export type Feature = {
+  name: string;
+  versionformat: string;
+  namespaceName: string;
+  version: string;
+  vulnerabilities: Vulnerability[];
+};
+
+export type Vulnerability = {
+  name: string;
+  namespaceName: string;
+  description: string;
+  link: string;
+  fixedby: string;
+  severity: string;
+  metadata: string;
+};
+
+export type ImageManifestVulnSpec = {
+  image: string;
+  manifest: string;
+  namespaceName: string;
+  features: Feature[];
+};
+
+export type ImageManifestVulnStatus = {
+  lastUpdate?: string;
+  highestSeverity: string;
+  unknownCount?: number;
+  negligibleCount?: number;
+  lowCount?: number;
+  mediumCount?: number;
+  highCount?: number;
+  criticalCount?: number;
+  defcon1Count?: number;
+  fixableCount?: number;
+  afftectedPods: { [path: string]: string[] };
+};
+
+export type ImageManifestVuln = {
+  spec: ImageManifestVulnSpec;
+  status: ImageManifestVulnStatus;
+} & K8sResourceCommon;

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/status-card.tsx
@@ -66,8 +66,28 @@ const URLHealthItem = withDashboardResources(
       : null;
     const healthState = subsystem.healthHandler(healthResult, healthResultError, k8sResult);
 
+    const PopupComponentCallback = subsystem.popupComponent
+      ? React.useCallback(
+          () => (
+            <AsyncComponent
+              loader={subsystem.popupComponent}
+              healthResult={healthResult}
+              healthResultError={healthResultError}
+              k8sResult={k8sResult}
+            />
+          ),
+          [subsystem, healthResult, healthResultError, k8sResult],
+        )
+      : null;
+
     return (
-      <HealthItem title={subsystem.title} state={healthState.state} details={healthState.message} />
+      <HealthItem
+        title={subsystem.title}
+        state={healthState.state}
+        details={healthState.message}
+        popupTitle={subsystem.popupTitle}
+        PopupComponent={PopupComponentCallback}
+      />
     );
   },
 );


### PR DESCRIPTION
### Description

Introduces `packages/container-security`, which is the UI component for the [Quay Container Security Operator](https://github.com/quay/container-security-operator).

### Testing

1. Run the Container Security Operator against an OpenShift cluster
```
$ git clone git@github.com:quay/container-security-operator.git
$ cd container-security-operator
$ go run cmd/security-labeller/main.go --kubeconfig=$KUBECONFIG --config=./example-config.yaml
```
2. Build local console
```
$ yarn run build
```
3. Create pods with vulnerabilities
- `quay.io/bitnami/redis@sha256:c51f9b027d358a07b7201e37163e0fabb12b1ac06a640ab1a84a78f541e6c3fa`

### Screenshots 

**Dashboard health item (vulnerabilities present):**
![Screenshot_20191101_122801](https://user-images.githubusercontent.com/11700385/68039721-1bee9480-fca3-11e9-8667-f9c5b1ea4b0b.png)

**Dashboard health item (no vulnerabilities present):**
![Screenshot_20191101_122858](https://user-images.githubusercontent.com/11700385/68039768-33c61880-fca3-11e9-9acd-d8a73748a1a5.png)


Addresses https://jira.coreos.com/browse/QUAY-1074