### PR TITLE
Hide linux bridge option if HCO is not installed

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
@@ -31,7 +31,7 @@ const CreateNetAttachDefYAMLConnected = connectToPlural(
 
     const netAttachDefTemplatePath = (o: K8sResourceKind) =>
       resourcePathFromModel(
-        { ...NetworkAttachmentDefinitionModel, plural: 'networkattachmentdefinitions' },
+        { ...NetworkAttachmentDefinitionModel, plural: 'network-attachment-definitions' },
         getName(o),
         getNamespace(o),
       );

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
@@ -30,11 +30,7 @@ const CreateNetAttachDefYAMLConnected = connectToPlural(
     obj.metadata.namespace = match.params.ns || 'default';
 
     const netAttachDefTemplatePath = (o: K8sResourceKind) =>
-      resourcePathFromModel(
-        { ...NetworkAttachmentDefinitionModel, plural: 'network-attachment-definitions' },
-        getName(o),
-        getNamespace(o),
-      );
+      resourcePathFromModel(NetworkAttachmentDefinitionModel, getName(o), getNamespace(o));
     const DroppableEditYAML = () =>
       import('@console/internal/components/droppable-edit-yaml').then((c) => c.DroppableEditYAML);
 

--- a/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
@@ -9,7 +9,7 @@ export const ELEMENT_TYPES = {
 
 export const networkTypes = {
   sriov: 'SR-IOV',
-  bridge: 'Linux bridge',
+  'cnv-bridge': 'Linux bridge',
 };
 
 export const networkTypeParams: NetworkTypeParamsList = {
@@ -30,8 +30,8 @@ export const networkTypeParams: NetworkTypeParamsList = {
       type: ELEMENT_TYPES.TEXTAREA,
     },
   },
-  bridge: {
-    bridgeName: {
+  'cnv-bridge': {
+    bridge: {
       name: 'Bridge Name',
       required: true,
       type: ELEMENT_TYPES.TEXT,

--- a/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
@@ -12,6 +12,11 @@ export const networkTypes = {
   'cnv-bridge': 'Linux bridge',
 };
 
+export enum NetworkTypes {
+  SRIOV = 'SR-IOV',
+  'CNV-Bridge' = 'Linux bridge',
+}
+
 export const networkTypeParams: NetworkTypeParamsList = {
   sriov: {
     resourceName: {

--- a/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
@@ -23,3 +23,15 @@ export const SriovNetworkNodePolicyModel: K8sKind = {
   kind: 'SriovNetworkNodePolicy',
   id: 'sriov-network-node-policy',
 };
+
+export const HyperConvergedModel: K8sKind = {
+  label: 'HyperConverged Cluster',
+  labelPlural: 'HyperConverged Clusters',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'hco.kubevirt.io',
+  plural: 'hyperconverged',
+  namespaced: false,
+  abbr: 'SRNNPM', // TODO check on this
+  kind: 'hyperconverged',
+  id: 'hyperconverged',
+};

--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -1,5 +1,10 @@
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
+export type NetworkAttachmentDefinitionAnnotations = {
+  description?: string;
+  'k8s.v1.cni.cncf.io/resourceName': string;
+};
+
 export type IPAMConfig = {
   type?: string;
   subnet?: string;
@@ -13,7 +18,7 @@ export type NetworkAttachmentDefinitionConfig = {
   bridge?: string;
   isGateway?: true;
   ipam?: IPAMConfig;
-  plugins?: NetworkAttachmentDefinitionConfig[];
+  plugins?: any[];
 };
 
 // The config is a JSON object with the NetworkAttachmentDefinitionConfig type stored as a string

--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -11,6 +11,10 @@ export type IPAMConfig = {
   dataDir?: string;
 };
 
+export type NetworkAttachmentDefinitionPlugin = {
+  [key: string]: any;
+};
+
 export type NetworkAttachmentDefinitionConfig = {
   cniVersion: string;
   name: string;
@@ -18,7 +22,7 @@ export type NetworkAttachmentDefinitionConfig = {
   bridge?: string;
   isGateway?: true;
   ipam?: IPAMConfig;
-  plugins?: any[];
+  plugins?: NetworkAttachmentDefinitionPlugin[];
 };
 
 // The config is a JSON object with the NetworkAttachmentDefinitionConfig type stored as a string
@@ -29,3 +33,12 @@ export type NetworkAttachmentDefinitionSpec = {
 export type NetworkAttachmentDefinitionKind = {
   spec?: NetworkAttachmentDefinitionSpec;
 } & K8sResourceKind;
+
+export type TypeParamsDataItem = {
+  value?: any;
+  validationMsg?: string;
+};
+
+export type TypeParamsData = {
+  [key: string]: TypeParamsDataItem;
+};


### PR DESCRIPTION
This PR hides the "Linux bridge" Network Type option in the network attachment definitions creation form if the HyperConverged Cluster Operator isn't installed. It also disables the Network Type dropdown if no types are available.

@phoracek 