### PR TITLE
Refactor Resiliency Function for Noobaa and Status Card

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/activity-card/activity-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/activity-card/activity-card.tsx
@@ -23,7 +23,7 @@ import {
 } from '@console/internal/components/dashboard/with-dashboard-resources';
 import { CEPH_STORAGE_NAMESPACE } from '../../../../constants/index';
 import { DATA_RESILIENCY_QUERY, StorageDashboardQuery } from '../../../../constants/queries';
-import { isDataResiliencyActivity } from './data-resiliency-activity';
+import { getResiliencyProgress } from '../../../../utils';
 import './activity-card.scss';
 
 const eventsResource: FirehoseResource = { isList: true, kind: EventModel.kind, prop: 'events' };
@@ -58,27 +58,27 @@ const OngoingActivity = withDashboardResources(
         stopWatchPrometheusQuery(DATA_RESILIENCY_QUERY[StorageDashboardQuery.RESILIENCY_PROGRESS]);
     }, [watchPrometheus, stopWatchPrometheusQuery]);
 
-    const resiliencyProgress = prometheusResults.getIn([
+    const progressResponse = prometheusResults.getIn([
       DATA_RESILIENCY_QUERY[StorageDashboardQuery.RESILIENCY_PROGRESS],
       'data',
     ]) as PrometheusResponse;
-    const resiliencyProgressError = prometheusResults.getIn([
+    const progressError = prometheusResults.getIn([
       DATA_RESILIENCY_QUERY[StorageDashboardQuery.RESILIENCY_PROGRESS],
       'loadError',
     ]);
     const prometheusActivities = [];
     const resourceActivities = [];
 
-    if (isDataResiliencyActivity(resiliencyProgress)) {
+    if (getResiliencyProgress(progressResponse) < 1) {
       prometheusActivities.push({
-        results: resiliencyProgress,
-        loader: () => import('./data-resiliency-activity').then((m) => m.DataResiliencyActivity),
+        results: progressResponse,
+        loader: () => import('./data-resiliency-activity').then((m) => m.DataResiliency),
       });
     }
 
     return (
       <OngoingActivityBody
-        loaded={resiliencyProgress || resiliencyProgressError}
+        loaded={progressResponse || progressError}
         resourceActivities={resourceActivities}
         prometheusActivities={prometheusActivities}
       />

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/activity-card/data-resiliency-activity.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/activity-card/data-resiliency-activity.tsx
@@ -3,21 +3,17 @@ import { Progress, ProgressSize } from '@patternfly/react-core';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import { getResiliencyProgress } from '../../../../utils';
 
-export const isDataResiliencyActivity = (results: PrometheusResponse): boolean => {
-  const progress = getResiliencyProgress(results);
-  return progress && progress < 100;
-};
-
-export const DataResiliencyActivity: React.FC<DataResiliencyProps> = ({ results }) => {
-  const progress = getResiliencyProgress(results);
+export const DataResiliency: React.FC<DataResiliencyProps> = ({ results }) => {
+  const progress: number = getResiliencyProgress(results);
+  const formattedProgress = Math.round(progress * 100);
   return (
     <>
       <Progress
         className="co-activity-item__progress"
-        value={progress}
+        value={formattedProgress}
         size={ProgressSize.sm}
         title="Rebuilding data resiliency"
-        label={`${progress}%`}
+        label={`${formattedProgress}%`}
       />
     </>
   );

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/utils.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/utils.ts
@@ -31,14 +31,17 @@ export const getCephHealthState: PrometheusHealthHandler = (responses = [], erro
 };
 
 export const getDataResiliencyState: PrometheusHealthHandler = (responses = [], errors = []) => {
+  const progress: number = getResiliencyProgress(responses[0]);
   if (errors[0]) {
     return { state: HealthState.UNKNOWN };
   }
   if (!responses[0]) {
     return { state: HealthState.LOADING };
   }
-  const progress = getResiliencyProgress(responses[0]);
-  if (progress && progress < 100) {
+  if (Number.isNaN(progress)) {
+    return { state: HealthState.UNKNOWN };
+  }
+  if (progress < 1) {
     return { state: HealthState.PROGRESS };
   }
   return { state: HealthState.OK };

--- a/frontend/packages/ceph-storage-plugin/src/utils/dashboard.ts
+++ b/frontend/packages/ceph-storage-plugin/src/utils/dashboard.ts
@@ -2,10 +2,12 @@ import * as _ from 'lodash';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 
 export const getResiliencyProgress = (results: PrometheusResponse): number => {
-  const progress = _.get(results, 'data.result[0].value[1]');
-  //  Zero PG Case
-  if (Number.isNaN(progress)) {
-    return null;
-  }
-  return Number((Number(progress) * 100).toFixed(1));
+  /**
+   * Possible values for progress:
+   *   - A float value of String type
+   *   - 'NaN'
+   *   - undefined
+   */
+  const progress: string = _.get(results, 'data.result[0].value[1]');
+  return parseFloat(progress);
 };

--- a/frontend/packages/noobaa-storage-plugin/src/components/activity-card/activity-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/activity-card/activity-card.tsx
@@ -16,8 +16,8 @@ import {
   DashboardItemProps,
   withDashboardResources,
 } from '@console/internal/components/dashboard/with-dashboard-resources';
+import { getResiliencyProgress } from '@console/ceph-storage-plugin/src/utils';
 import { DATA_RESILIENCE_QUERIES } from '../../queries';
-import { isDataResiliencyActivity } from './data-resiliency-activity/data-resiliency-activity';
 import './activity-card.scss';
 
 const eventsResource: FirehoseResource = { isList: true, kind: EventModel.kind, prop: 'events' };
@@ -79,12 +79,12 @@ const OngoingActivity = withDashboardResources(
 
     const prometheusActivities = [];
 
-    if (isDataResiliencyActivity(progress)) {
+    if (getResiliencyProgress(progress) < 1) {
       prometheusActivities.push({
         results: [progress, eta],
         loader: () =>
           import('./data-resiliency-activity/data-resiliency-activity').then(
-            (m) => m.DataResiliencyActivity,
+            (m) => m.NoobaaDataResiliency,
           ),
       });
     }

--- a/frontend/packages/noobaa-storage-plugin/src/components/activity-card/data-resiliency-activity/data-resiliency-activity.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/activity-card/data-resiliency-activity/data-resiliency-activity.tsx
@@ -1,29 +1,16 @@
 import * as React from 'react';
-import { Progress, ProgressSize } from '@patternfly/react-core';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import { formatDuration } from '@console/internal/components/utils/datetime';
-import { getGaugeValue, getResiliencyProgress } from '../../../utils';
-import { MAX_PROGRESS } from '../../../constants';
+import { DataResiliency } from '@console/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/activity-card/data-resiliency-activity';
+import { getGaugeValue } from '../../../utils';
 import './data-resiliency-activity.scss';
 
-export const isDataResiliencyActivity = (response: PrometheusResponse): boolean => {
-  const progress = getGaugeValue(response);
-  return progress < MAX_PROGRESS;
-};
-
-export const DataResiliencyActivity: React.FC<DataResiliencyProps> = ({ results }) => {
-  const progress = getResiliencyProgress(results[0]);
+export const NoobaaDataResiliency: React.FC<DataResiliencyProps> = ({ results }) => {
   const eta = getGaugeValue(results[1]);
   const formattedEta = formatDuration(eta * 1000);
   return (
     <>
-      <Progress
-        className="co-activity-item__progress"
-        value={progress}
-        size={ProgressSize.sm}
-        title="Rebuilding data resiliency"
-        label={`${progress}%`}
-      />
+      <DataResiliency results={results[0]} />
       {eta && (
         <span className="text-secondary nb-data-resiliency__eta">
           Estimating {formattedEta} to completion

--- a/frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx
@@ -19,10 +19,11 @@ import {
 } from '@console/internal/components/dashboard/with-dashboard-resources';
 import { FirehoseResource, FirehoseResult } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { getDataResiliencyState } from '@console/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/utils';
 import { filterNooBaaAlerts } from '../../utils';
 import { DATA_RESILIENCE_QUERIES, StatusCardQueries } from '../../queries';
 import { NooBaaSystemModel } from '../../models';
-import { getNooBaaState, getDataResiliencyState, ObjectServiceState } from './statuses';
+import { getNooBaaState, ObjectServiceState } from './statuses';
 import './status-card.scss';
 
 const statusCardQueries = Object.keys(StatusCardQueries);
@@ -124,8 +125,7 @@ const StatusCard: React.FC<DashboardItemProps> = ({
 
   const dataResiliencyState: ObjectServiceState = getDataResiliencyState(
     [progressResult],
-    !!progressError,
-    !progressResult,
+    [progressError],
   );
 
   return (

--- a/frontend/packages/noobaa-storage-plugin/src/components/status-card/statuses.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/status-card/statuses.tsx
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { HealthState } from '@console/shared/src/components/dashboard/health-card/states';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import { FirehoseResult } from '@console/internal/components/utils';
-import { getGaugeValue, getResiliencyProgress } from '../../utils';
+import { getGaugeValue } from '../../utils';
 
 const NooBaaStatus = [
   {
@@ -59,25 +59,6 @@ export const getNooBaaState: GetObjectServiceStatus = (
   }
   if (unhealthyBucketsRatio >= 0.3) {
     return NooBaaStatus[4];
-  }
-  return { state: HealthState.OK };
-};
-
-export const getDataResiliencyState: GetObjectServiceStatus = (
-  prometheusResponses,
-  hasLoadError,
-  isLoading,
-) => {
-  const progress = getResiliencyProgress(prometheusResponses[0]);
-
-  if (hasLoadError || !progress) {
-    return { state: HealthState.UNKNOWN };
-  }
-  if (isLoading) {
-    return { state: HealthState.LOADING };
-  }
-  if (progress < 100) {
-    return { state: HealthState.PROGRESS };
   }
   return { state: HealthState.OK };
 };

--- a/frontend/packages/noobaa-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/index.ts
@@ -4,7 +4,6 @@ export const BY_IOPS = 'I/O Operations';
 export const BY_LOGICAL_USAGE = 'Logical Used Capacity';
 export const BY_PHYSICAL_VS_LOGICAL_USAGE = 'Physical Vs Logical Usage';
 export const BY_EGRESS = 'Egress';
-export const MAX_PROGRESS = 100;
 export const PROJECTS = 'Projects';
 export const BUCKET_CLASS = 'Bucket Class';
 

--- a/frontend/packages/noobaa-storage-plugin/src/queries.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/queries.ts
@@ -19,7 +19,7 @@ export enum ObjectDashboardQuery {
 }
 
 export enum DATA_RESILIENCE_QUERIES {
-  REBUILD_PROGRESS_QUERY = 'NooBaa_rebuild_progress',
+  REBUILD_PROGRESS_QUERY = 'NooBaa_rebuild_progress/100',
   REBUILD_TIME_QUERY = 'NooBaa_rebuild_time',
 }
 

--- a/frontend/packages/noobaa-storage-plugin/src/utils.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/utils.ts
@@ -21,8 +21,3 @@ export const getPhase = (obj: K8sResourceKind): string => {
 };
 
 export const isBound = (obj: K8sResourceKind): boolean => getPhase(obj) === 'Bound';
-
-export const getResiliencyProgress = (response: PrometheusResponse): number => {
-  const progress = getGaugeValue(response);
-  return Number(Number(progress).toFixed(1));
-};


### PR DESCRIPTION
* Fix for '0' progress and prometheus cache error
* Shares ceph helper functions  in noobaa

*Updates:*
 - fixes redundant type conversions `string->number->string->number` to `string->number`
 - activity card of object service dashboard using component of OCS PV