### PR TITLE
humanizeCpuCores: add space between value and unit

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/node-list.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/node-list.tsx
@@ -22,7 +22,7 @@ import { ButtonBar } from '@console/internal/components/utils/button-bar';
 import { history } from '@console/internal/components/utils/router';
 import {
   convertToBaseValue,
-  humanizeCpuCores,
+  humanizeCpuCoresLong,
   humanizeBinaryBytes,
   ResourceLink,
 } from '@console/internal/components/utils/index';
@@ -117,7 +117,7 @@ const getRows = (nodes: NodeKind[]) => {
           title: _.get(node.metadata.labels, 'failure-domain.beta.kubernetes.io/zone') || '-',
         },
         {
-          title: `${humanizeCpuCores(cpuCapacity).string || '-'}`,
+          title: `${humanizeCpuCoresLong(cpuCapacity).string || '-'}`,
         },
         {
           title: `${getConvertedUnits(allocatableMemory)}`,

--- a/frontend/packages/console-app/src/components/nodes/NodeGraphs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeGraphs.tsx
@@ -4,7 +4,7 @@ import { requirePrometheus } from '@console/internal/components/graphs';
 import { Area } from '@console/internal/components/graphs/area';
 import {
   humanizeBinaryBytes,
-  humanizeCpuCores,
+  humanizeCpuCoresLong,
   humanizeDecimalBytesPerSec,
 } from '@console/internal/components/utils';
 import { NodeKind } from '@console/internal/module/k8s';
@@ -36,7 +36,7 @@ const NodeGraphs: React.FC<NodeGraphsProps> = ({ node }) => {
         <div className="col-md-12 col-lg-4">
           <Area
             title="CPU Usage"
-            humanize={humanizeCpuCores}
+            humanize={humanizeCpuCoresLong}
             query={`instance:node_cpu:rate:sum${instanceQuery}`}
           />
         </div>

--- a/frontend/packages/console-app/src/components/nodes/NodeGraphs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeGraphs.tsx
@@ -6,6 +6,7 @@ import {
   humanizeBinaryBytes,
   humanizeCpuCoresLong,
   humanizeDecimalBytesPerSec,
+  humanizeCpuCores,
 } from '@console/internal/components/utils';
 import { NodeKind } from '@console/internal/module/k8s';
 import { getNodeAddresses } from '@console/shared';
@@ -36,7 +37,8 @@ const NodeGraphs: React.FC<NodeGraphsProps> = ({ node }) => {
         <div className="col-md-12 col-lg-4">
           <Area
             title="CPU Usage"
-            humanize={humanizeCpuCoresLong}
+            humanize={humanizeCpuCores}
+            humanizeLong={humanizeCpuCoresLong}
             query={`instance:node_cpu:rate:sum${instanceQuery}`}
           />
         </div>

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -9,6 +9,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
     title,
     data,
     humanizeValue,
+    humanizeValueCompact,
     isLoading = false,
     query,
     error,
@@ -45,7 +46,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
         loading={!error && isLoading}
         query={query}
         xAxis={false}
-        humanize={humanizeValue}
+        humanize={humanizeValueCompact || humanizeValue}
         padding={{ top: 13, left: 70, bottom: 0, right: 0 }}
         height={70}
         chartStatus={chartStatus}
@@ -90,6 +91,7 @@ type UtilizationItemProps = {
   data?: DataPoint[];
   isLoading: boolean;
   humanizeValue: Humanize;
+  humanizeValueCompact?: Humanize;
   query: string;
   error: boolean;
   max?: number;

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -47,6 +47,7 @@ export const UtilizationItem: React.FC<UtilizationItemProps> = React.memo(
         query={query}
         xAxis={false}
         humanize={humanizeValueCompact || humanizeValue}
+        humanizeLong={humanizeValue}
         padding={{ top: 13, left: 70, bottom: 0, right: 0 }}
         height={70}
         chartStatus={chartStatus}

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -8,7 +8,7 @@ import {
   Dropdown,
   humanizeDecimalBytes,
   humanizeCpuCoresLong,
-  humanizeCpuCoresCompact,
+  humanizeCpuCores,
 } from '@console/internal/components/utils';
 import { getName, getNamespace } from '@console/shared';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
@@ -109,7 +109,7 @@ export const VMUtilizationCard = withDashboardResources(
             data={cpuStats}
             isLoading={!namespace || !cpuUtilization}
             humanizeValue={humanizeCpuCoresLong}
-            humanizeValueCompact={humanizeCpuCoresCompact}
+            humanizeValueCompact={humanizeCpuCores}
             query={queries[VMQueries.CPU_USAGE]}
             error={cpuError}
           />

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -7,7 +7,8 @@ import {
 import {
   Dropdown,
   humanizeDecimalBytes,
-  humanizeCpuCores as humanizeCpuCoresUtil,
+  humanizeCpuCoresLong,
+  humanizeCpuCoresCompact,
 } from '@console/internal/components/utils';
 import { getName, getNamespace } from '@console/shared';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
@@ -29,15 +30,6 @@ import { getUtilizationQueries, VMQueries } from './queries';
 
 const metricDurations = [ONE_HR, SIX_HR, TWENTY_FOUR_HR];
 const metricDurationsOptions = _.zipObject(metricDurations, metricDurations);
-
-// TODO: extend humanizeCpuCores() from @console/internal for the flexibility of space
-const humanizeCpuCores = (v) => {
-  const humanized = humanizeCpuCoresUtil(v);
-  // add space betwee value and unit
-  const val = humanized.string.match(/[\d.]+/) || [humanized.string];
-  humanized.string = `${val[0]} ${humanized.unit}`;
-  return humanized;
-};
 
 export const VMUtilizationCard = withDashboardResources(
   ({ watchPrometheus, stopWatchPrometheusQuery, prometheusResults }: DashboardItemProps) => {
@@ -116,7 +108,8 @@ export const VMUtilizationCard = withDashboardResources(
             title="CPU"
             data={cpuStats}
             isLoading={!namespace || !cpuUtilization}
-            humanizeValue={humanizeCpuCores}
+            humanizeValue={humanizeCpuCoresLong}
+            humanizeValueCompact={humanizeCpuCoresCompact}
             query={queries[VMQueries.CPU_USAGE]}
             error={cpuError}
           />

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/UtilizationCard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/UtilizationCard.tsx
@@ -25,7 +25,7 @@ import ConsumerPopover from '@console/shared/src/components/dashboard/utilizatio
 import {
   humanizeBinaryBytesWithoutB,
   humanizeBinaryBytes,
-  humanizeCpuCoresCompact,
+  humanizeCpuCores,
   humanizeCpuCoresLong,
 } from '@console/internal/components/utils';
 import { MachineKind } from '@console/internal/module/k8s';
@@ -218,7 +218,7 @@ const UtilizationCard: React.FC<UtilizationCardProps> = ({
           error={cpuUtilizationError}
           isLoading={!cpuUtilization}
           humanizeValue={humanizeCpuCoresLong}
-          humanizeValueCompact={humanizeCpuCoresCompact}
+          humanizeValueCompact={humanizeCpuCores}
           query={queries[HostQuery.CPU_UTILIZATION].utilization}
           TopConsumerPopover={cpuPopover}
         />

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/UtilizationCard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/UtilizationCard.tsx
@@ -25,7 +25,8 @@ import ConsumerPopover from '@console/shared/src/components/dashboard/utilizatio
 import {
   humanizeBinaryBytesWithoutB,
   humanizeBinaryBytes,
-  humanizeCpuCores,
+  humanizeCpuCoresCompact,
+  humanizeCpuCoresLong,
 } from '@console/internal/components/utils';
 import { MachineKind } from '@console/internal/module/k8s';
 import { getMachineNodeName } from '@console/shared';
@@ -128,7 +129,7 @@ const UtilizationCard: React.FC<UtilizationCardProps> = ({
         <ConsumerPopover
           title="CPU"
           current={current}
-          humanize={humanizeCpuCores}
+          humanize={humanizeCpuCoresLong}
           consumers={[
             {
               query: topConsumerQueries[HostQuery.PROJECTS_BY_CPU],
@@ -216,7 +217,8 @@ const UtilizationCard: React.FC<UtilizationCardProps> = ({
           data={cpuStats}
           error={cpuUtilizationError}
           isLoading={!cpuUtilization}
-          humanizeValue={humanizeCpuCores}
+          humanizeValue={humanizeCpuCoresLong}
+          humanizeValueCompact={humanizeCpuCoresCompact}
           query={queries[HostQuery.CPU_UTILIZATION].utilization}
           TopConsumerPopover={cpuPopover}
         />

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -25,7 +25,7 @@ import {
   ExternalLink,
   history,
   humanizeBinaryBytes,
-  humanizeCpuCores,
+  humanizeCpuCoresLong,
   Kebab,
   KebabAction,
   navFactory,
@@ -150,7 +150,7 @@ const BuildGraphs = requirePrometheus(({ build }) => {
         <div className="col-md-12 col-lg-4">
           <Area
             title="CPU Usage"
-            humanize={humanizeCpuCores}
+            humanize={humanizeCpuCoresLong}
             namespace={namespace}
             query={`pod:container_cpu_usage:sum{pod='${podName}',container='',namespace='${namespace}'}`}
           />

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/utilization-card.tsx
@@ -16,7 +16,11 @@ import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import { isDashboardsOverviewUtilizationItem } from '@console/plugin-sdk';
 import { PopoverPosition } from '@patternfly/react-core';
 import { DashboardItemProps, withDashboardResources } from '../../with-dashboard-resources';
-import { humanizeBinaryBytes, humanizeCpuCores } from '../../../utils/units';
+import {
+  humanizeBinaryBytes,
+  humanizeCpuCoresLong,
+  humanizeCpuCoresCompact,
+} from '../../../utils/units';
 import { getRangeVectorStats, getInstantVectorStats } from '../../../graphs/utils';
 import { Dropdown } from '../../../utils/dropdown';
 import { OverviewQuery, utilizationQueries, top25ConsumerQueries } from './queries';
@@ -168,7 +172,7 @@ const UtilizationCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
         title="CPU"
         current={current}
         consumers={cpuQueriesPopup}
-        humanize={humanizeCpuCores}
+        humanize={humanizeCpuCoresLong}
         position={PopoverPosition.top}
       />
     ),
@@ -218,7 +222,8 @@ const UtilizationCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
           data={cpuStats}
           error={cpuUtilizationError || cpuTotalError}
           isLoading={!cpuUtilization || !cpuTotal}
-          humanizeValue={humanizeCpuCores}
+          humanizeValue={humanizeCpuCoresLong}
+          humanizeValueCompact={humanizeCpuCoresCompact}
           query={utilizationQueries[OverviewQuery.CPU_UTILIZATION].utilization}
           TopConsumerPopover={cpuPopover}
           max={cpuMax.length ? cpuMax[0].y : null}

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/utilization-card.tsx
@@ -16,11 +16,7 @@ import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import { isDashboardsOverviewUtilizationItem } from '@console/plugin-sdk';
 import { PopoverPosition } from '@patternfly/react-core';
 import { DashboardItemProps, withDashboardResources } from '../../with-dashboard-resources';
-import {
-  humanizeBinaryBytes,
-  humanizeCpuCoresLong,
-  humanizeCpuCoresCompact,
-} from '../../../utils/units';
+import { humanizeBinaryBytes, humanizeCpuCoresLong, humanizeCpuCores } from '../../../utils/units';
 import { getRangeVectorStats, getInstantVectorStats } from '../../../graphs/utils';
 import { Dropdown } from '../../../utils/dropdown';
 import { OverviewQuery, utilizationQueries, top25ConsumerQueries } from './queries';
@@ -223,7 +219,7 @@ const UtilizationCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
           error={cpuUtilizationError || cpuTotalError}
           isLoading={!cpuUtilization || !cpuTotal}
           humanizeValue={humanizeCpuCoresLong}
-          humanizeValueCompact={humanizeCpuCoresCompact}
+          humanizeValueCompact={humanizeCpuCores}
           query={utilizationQueries[OverviewQuery.CPU_UTILIZATION].utilization}
           TopConsumerPopover={cpuPopover}
           max={cpuMax.length ? cpuMax[0].y : null}

--- a/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
@@ -23,7 +23,7 @@ import {
   humanizeDecimalBytesPerSec,
   humanizeNumber,
   humanizeCpuCoresLong,
-  humanizeCpuCoresCompact,
+  humanizeCpuCores,
 } from '../../utils';
 import { getRangeVectorStats } from '../../graphs/utils';
 import { ProjectDashboardContext } from './project-dashboard-context';
@@ -181,7 +181,7 @@ export const UtilizationCard = withDashboardResources(
             data={cpuStats}
             isLoading={!projectName || !cpuUtilization}
             humanizeValue={humanizeCpuCoresLong}
-            humanizeValueCompact={humanizeCpuCoresCompact}
+            humanizeValueCompact={humanizeCpuCores}
             query={queries[ProjectQueries.CPU_USAGE]}
             error={cpuError}
             TopConsumerPopover={cpuPopover}

--- a/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
@@ -20,9 +20,10 @@ import { withDashboardResources, DashboardItemProps } from '../with-dashboard-re
 import { Dropdown } from '../../utils/dropdown';
 import {
   humanizeBinaryBytes,
-  humanizeCpuCores,
   humanizeDecimalBytesPerSec,
   humanizeNumber,
+  humanizeCpuCoresLong,
+  humanizeCpuCoresCompact,
 } from '../../utils';
 import { getRangeVectorStats } from '../../graphs/utils';
 import { ProjectDashboardContext } from './project-dashboard-context';
@@ -95,7 +96,7 @@ export const UtilizationCard = withDashboardResources(
               metric: 'pod',
             },
           ]}
-          humanize={humanizeCpuCores}
+          humanize={humanizeCpuCoresLong}
           namespace={projectName}
           position={PopoverPosition.top}
         />
@@ -179,7 +180,8 @@ export const UtilizationCard = withDashboardResources(
             title="CPU"
             data={cpuStats}
             isLoading={!projectName || !cpuUtilization}
-            humanizeValue={humanizeCpuCores}
+            humanizeValue={humanizeCpuCoresLong}
+            humanizeValueCompact={humanizeCpuCoresCompact}
             query={queries[ProjectQueries.CPU_USAGE]}
             error={cpuError}
             TopConsumerPopover={cpuPopover}

--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -44,6 +44,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
   formatDate = twentyFourHourTime,
   height = DEFAULT_HEIGHT,
   humanize = humanizeNumber,
+  humanizeLong,
   loading = true,
   padding,
   query,
@@ -73,9 +74,10 @@ export const AreaChart: React.FC<AreaChartProps> = ({
     humanize,
     unit,
   ]);
+  const humanizeLabel = humanizeLong || humanize;
   const getLabel = React.useCallback(
-    ({ datum: { x, y } }) => `${humanize(y, unit, unit).string} at ${formatDate(x)}`,
-    [humanize, unit, formatDate],
+    ({ datum: { x, y } }) => `${humanizeLabel(y, unit, unit).string} at ${formatDate(x)}`,
+    [humanizeLabel, unit, formatDate],
   );
   const container = <ChartVoronoiContainer voronoiDimension="x" labels={getLabel} />;
   const style = chartStatus ? { data: { fill: chartStatusColors[chartStatus] } } : null;
@@ -129,6 +131,7 @@ type AreaChartProps = {
   className?: string;
   formatDate?: (date: Date) => string;
   humanize?: Humanize;
+  humanizeLong?: Humanize;
   height?: number;
   loading?: boolean;
   query?: string;

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -30,7 +30,7 @@ import {
   ResourceSummary,
   SectionHeading,
   humanizeBinaryBytes,
-  humanizeCpuCores,
+  humanizeCpuCoresLong,
   navFactory,
   useAccessReview,
 } from './utils';
@@ -348,7 +348,7 @@ export const NamespaceLineCharts = ({ ns }) => (
     <div className="col-md-6 col-sm-12">
       <Area
         title="CPU Usage"
-        humanize={humanizeCpuCores}
+        humanize={humanizeCpuCoresLong}
         namespace={ns.metadata.name}
         query={`namespace:container_cpu_usage:sum{namespace='${ns.metadata.name}'}`}
       />

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -34,6 +34,7 @@ import {
   pluralize,
   units,
   humanizeCpuCoresLong,
+  humanizeCpuCores,
 } from './utils';
 import { PodLogs } from './pod-logs';
 import { requirePrometheus, Area } from './graphs';
@@ -250,7 +251,8 @@ const PodGraphs = requirePrometheus(({ pod }) => (
       <div className="col-md-12 col-lg-4">
         <Area
           title="CPU Usage"
-          humanize={humanizeCpuCoresLong}
+          humanize={humanizeCpuCores}
+          humanizeLong={humanizeCpuCoresLong}
           namespace={pod.metadata.namespace}
           query={`pod:container_cpu_usage:sum{pod='${pod.metadata.name}',namespace='${
             pod.metadata.namespace

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -30,10 +30,10 @@ import {
   SectionHeading,
   Timestamp,
   humanizeBinaryBytes,
-  humanizeCpuCores,
   navFactory,
   pluralize,
   units,
+  humanizeCpuCoresLong,
 } from './utils';
 import { PodLogs } from './pod-logs';
 import { requirePrometheus, Area } from './graphs';
@@ -250,7 +250,7 @@ const PodGraphs = requirePrometheus(({ pod }) => (
       <div className="col-md-12 col-lg-4">
         <Area
           title="CPU Usage"
-          humanize={humanizeCpuCores}
+          humanize={humanizeCpuCoresLong}
           namespace={pod.metadata.namespace}
           query={`pod:container_cpu_usage:sum{pod='${pod.metadata.name}',namespace='${
             pod.metadata.namespace

--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -213,7 +213,9 @@ export const humanizeNumberSI = (v, initialUnit, preferredUnit) =>
   humanize(v, 'SI', true, initialUnit, preferredUnit);
 export const humanizeSeconds = (v, initialUnit, preferredUnit) =>
   humanize(v, 'seconds', true, initialUnit, preferredUnit);
+
 export const humanizeCpuCores = (v) => {
+  // conforms k8s format
   const value = v < 1 ? round(v * 1000) : v;
   const unit = v < 1 ? 'm' : '';
   return {
@@ -222,6 +224,24 @@ export const humanizeCpuCores = (v) => {
     value,
   };
 };
+export const humanizeCpuCoresLong = (v) => {
+  const humanized = humanizeCpuCores(v);
+  const transformedUnit = humanized.unit === 'm' ? ' millicores' : ' cores';
+  return {
+    ...humanized,
+    string: `${formatValue(humanized.value)}${transformedUnit}`,
+  };
+};
+export const humanizeCpuCoresCompact = (v) => {
+  // keep k8s values but round to 3 decimal digits
+  const value = Math.round(v * 1000) / 1000;
+  return {
+    string: `${value}`,
+    unit: '',
+    value,
+  };
+};
+
 export const humanizePercentage = (value) => {
   if (!isFinite(value)) {
     value = 0;

--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -226,7 +226,7 @@ export const humanizeCpuCores = (v) => {
 
 export const humanizeCpuCoresLong = (v) => {
   const humanized = humanizeCpuCores(v);
-  const transformedUnit = humanized.unit === 'm' ? ' millicores' : ' cores';
+  const transformedUnit = humanized.unit === ' m' ? ' millicores' : ' cores';
   return {
     ...humanized,
     string: `${formatValue(humanized.value)}${transformedUnit}`,

--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -215,30 +215,21 @@ export const humanizeSeconds = (v, initialUnit, preferredUnit) =>
   humanize(v, 'seconds', true, initialUnit, preferredUnit);
 
 export const humanizeCpuCores = (v) => {
-  // conforms k8s format
   const value = v < 1 ? round(v * 1000) : v;
-  const unit = v < 1 ? 'm' : '';
+  const unit = v < 1 ? ' m' : '';
   return {
     string: `${formatValue(value)}${unit}`,
     unit,
     value,
   };
 };
+
 export const humanizeCpuCoresLong = (v) => {
   const humanized = humanizeCpuCores(v);
   const transformedUnit = humanized.unit === 'm' ? ' millicores' : ' cores';
   return {
     ...humanized,
     string: `${formatValue(humanized.value)}${transformedUnit}`,
-  };
-};
-export const humanizeCpuCoresCompact = (v) => {
-  // keep k8s values but round to 3 decimal digits
-  const value = Math.round(v * 1000) / 1000;
-  return {
-    string: `${value}`,
-    unit: '',
-    value,
   };
 };
 


### PR DESCRIPTION
To make the humanized string for CPU millicores consistent with other units.

After this change, the non-space format is used for Number/NumberSI types only.

---

Follow-up for: https://github.com/openshift/console/pull/3153#discussion_r340661032