### PR TITLE
kubevirt: split VMI selectors

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
@@ -1,0 +1,17 @@
+import { VMIKind } from '../../types';
+
+export const getVMIDisks = (vmi: VMIKind): VMIKind['spec']['domain']['devices']['disks'] =>
+  vmi && vmi.spec && vmi.spec.domain && vmi.spec.domain.devices && vmi.spec.domain.devices.disks
+    ? vmi.spec.domain.devices.disks
+    : [];
+
+export const getVMINetworks = (vmi: VMIKind): VMIKind['spec']['networks'] =>
+  vmi && vmi.spec && vmi.spec.networks ? vmi.spec.networks : [];
+
+export const getVMIConditionsByType = (
+  vmi: VMIKind,
+  condType: string,
+): VMIKind['status']['conditions'] => {
+  const conditions = vmi && vmi.status && vmi.status.conditions;
+  return (conditions || []).filter((cond) => cond.type === condType);
+};

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/index.ts
@@ -1,2 +1,3 @@
+export * from './basic';
 export * from './combined';
 export * from './selectors';

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/selectors.ts
@@ -10,18 +10,3 @@ export const getVMIApiPath = (vmi: VMIKind) =>
   `${VirtualMachineInstanceModel.apiVersion}/namespaces/${getNamespace(vmi)}/${
     VirtualMachineInstanceModel.plural
   }/${getName(vmi)}`;
-
-export const getVMINetworks = (vmi: VMIKind): VMIKind['spec']['networks'] =>
-  vmi && vmi.spec && vmi.spec.networks ? vmi.spec.networks : [];
-export const getVMIDisks = (vmi: VMIKind): VMIKind['spec']['domain']['devices']['disks'] =>
-  vmi && vmi.spec && vmi.spec.domain && vmi.spec.domain.devices && vmi.spec.domain.devices.disks
-    ? vmi.spec.domain.devices.disks
-    : [];
-
-export const getVMIConditionsByType = (
-  vmi: VMIKind,
-  condType: string,
-): VMIKind['status']['conditions'] => {
-  const conditions = vmi && vmi.status && vmi.status.conditions;
-  return (conditions || []).filter((cond) => cond.type === condType);
-};


### PR DESCRIPTION
Hot fix to enable integration tests #3189.

When importing from `kubevirt-plugin/src/selectors/vmi/selectors.ts` in an integration
test, the tests are failing on unrelated errors (i.e. from CSS loader).

There is suspicion that the issue is related to node.js environment where `window`
object is missing but `@console/internal` modules are requesting it without function
wrapper (i.e. k8s.ts and `k8sBasePath`). I will further investigate.

This change does not break other flows, just enables to import simplier
modules to by-pass immediate execution of code in more complex ones.