### PR TITLE
Bug 1770919: WIP: Display message when no network types available

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
@@ -31,7 +31,7 @@ const CreateNetAttachDefYAMLConnected = connectToPlural(
 
     const netAttachDefTemplatePath = (o: K8sResourceKind) =>
       resourcePathFromModel(
-        { ...NetworkAttachmentDefinitionModel, plural: 'networkattachmentdefinitions' },
+        { ...NetworkAttachmentDefinitionModel, plural: 'network-attachment-definitions' },
         getName(o),
         getNamespace(o),
       );

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml.tsx
@@ -30,11 +30,7 @@ const CreateNetAttachDefYAMLConnected = connectToPlural(
     obj.metadata.namespace = match.params.ns || 'default';
 
     const netAttachDefTemplatePath = (o: K8sResourceKind) =>
-      resourcePathFromModel(
-        { ...NetworkAttachmentDefinitionModel, plural: 'network-attachment-definitions' },
-        getName(o),
-        getNamespace(o),
-      );
+      resourcePathFromModel(NetworkAttachmentDefinitionModel, getName(o), getNamespace(o));
     const DroppableEditYAML = () =>
       import('@console/internal/components/droppable-edit-yaml').then((c) => c.DroppableEditYAML);
 

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash';
 import { Form, FormControl, FormGroup, HelpBlock } from 'patternfly-react';
-import { ActionGroup, Button } from '@patternfly/react-core';
+import { Alert, ActionGroup, Button } from '@patternfly/react-core';
 import { ButtonBar, Dropdown, Firehose, history } from '@console/internal/components/utils';
 import { k8sCreate } from '@console/internal/module/k8s';
 import { validateDNS1123SubdomainValue, ValidationErrorType } from '@console/shared';
@@ -186,6 +186,7 @@ const NetworkAttachmentDefinitionFormBase = (props) => {
   const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({});
 
   const networkTypeDropdownItems = getNetworkTypes(hasSriovNetNodePolicyCRD, hasHyperConvergedCRD);
+  const noNetworkTypesAvailable = !hasSriovNetNodePolicyCRD && !hasHyperConvergedCRD;
 
   const formIsValid = React.useMemo(
     () => validateForm(fieldErrors, name, networkType, typeParamsData, setError),
@@ -200,107 +201,129 @@ const NetworkAttachmentDefinitionFormBase = (props) => {
 
   return (
     <div className="co-m-pane__body co-m-pane__form">
-      <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
-        <div className="co-m-pane__name">Create Network Attachment Definition</div>
-        <div className="co-m-pane__heading-link">
+      {noNetworkTypesAvailable ? (
+        <Alert variant="info" className="co-alert" isInline title="Form not available">
+            This form is currently unavailable. To create a Network Attachment Definition please use
+            the
           <Link
             to={`/k8s/ns/${namespace}/networkattachmentdefinitions/~new`}
             id="yaml-link"
             replace
           >
-            Edit YAML
+            &nbsp;YAML editor.
           </Link>
-        </div>
-      </h1>
-      <Form>
-        <FormGroup
-          fieldId="basic-settings-name"
-          validationState={fieldErrors.nameValidationMsg ? 'error' : null}
-        >
-          <label className="control-label co-required" htmlFor="network-attachment-definition-name">
-            Name
-          </label>
-          <FormControl
-            type="text"
-            bsClass="pf-c-form-control"
-            placeholder={name}
-            id="network-attachment-definition-name"
-            onChange={(e) => handleNameChange(e.target.value, fieldErrors, setName, setFieldErrors)}
-            value={name}
-          />
-          <HelpBlock>{fieldErrors.nameValidationMsg || null}</HelpBlock>
-        </FormGroup>
+        </Alert>
+      ) : (
+        <>
+          <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
+            <div className="co-m-pane__name">Create Network Attachment Definition</div>
 
-        <FormGroup fieldId="basic-settings-description">
-          <label htmlFor="network-attachment-definition-description">Description</label>
-          <FormControl
-            type="text"
-            bsClass="pf-c-form-control"
-            id="network-attachment-definition-description"
-            onChange={(e) => setDescription(e.target.value)}
-            value={description}
-          />
-        </FormGroup>
-
-        <FormGroup fieldId="basic-settings-network-type">
-          <label className="control-label co-required" htmlFor="network-type">
-            Network Type
-          </label>
-          <Dropdown
-            id="network-type"
-            title="Network Type"
-            items={networkTypeDropdownItems}
-            dropDownClassName="dropdown--full-width"
-            selectedKey={networkType}
-            onChange={(e) => setNetworkType(e)}
-            disabled={_.isEmpty(networkTypeDropdownItems)}
-          />
-        </FormGroup>
-
-        <div className="co-form-subsection">
-          <NetworkTypeOptions
-            networkType={networkType}
-            setTypeParamsData={setTypeParamsData}
-            sriovNetNodePoliciesData={sriovNetNodePoliciesData}
-            typeParamsData={typeParamsData}
-          />
-        </div>
-
-        <ButtonBar errorMessage={error ? error.message : ''} inProgress={loading}>
-          <ActionGroup className="pf-c-form">
-            <Button
-              id="save-changes"
-              isDisabled={!formIsValid}
-              onClick={(e) =>
-                createNetAttachDef(
-                  e,
-                  description,
-                  name,
-                  networkType,
-                  typeParamsData,
-                  namespace,
-                  setError,
-                  setLoading,
-                )
-              }
-              type="submit"
-              variant="primary"
+            <div className="co-m-pane__heading-link">
+              <Link
+                to={`/k8s/ns/${namespace}/networkattachmentdefinitions/~new`}
+                id="yaml-link"
+                replace
+              >
+                Edit YAML
+              </Link>
+            </div>
+          </h1>
+          <Form>
+            <FormGroup
+              fieldId="basic-settings-name"
+              validationState={fieldErrors.nameValidationMsg ? 'error' : null}
             >
-              Create
-            </Button>
-            <Button
-              id="cancel"
-              onClick={() =>
-                history.push(`/k8s/ns/${namespace || 'default'}/networkattachmentdefinitions`)
-              }
-              type="button"
-              variant="secondary"
-            >
-              Cancel
-            </Button>
-          </ActionGroup>
-        </ButtonBar>
-      </Form>
+              <label
+                className="control-label co-required"
+                htmlFor="network-attachment-definition-name"
+              >
+                Name
+              </label>
+              <FormControl
+                type="text"
+                bsClass="pf-c-form-control"
+                placeholder={name}
+                id="network-attachment-definition-name"
+                onChange={(e) =>
+                  handleNameChange(e.target.value, fieldErrors, setName, setFieldErrors)
+                }
+                value={name}
+              />
+              <HelpBlock>{fieldErrors.nameValidationMsg || null}</HelpBlock>
+            </FormGroup>
+
+            <FormGroup fieldId="basic-settings-description">
+              <label htmlFor="network-attachment-definition-description">Description</label>
+              <FormControl
+                type="text"
+                bsClass="pf-c-form-control"
+                id="network-attachment-definition-description"
+                onChange={(e) => setDescription(e.target.value)}
+                value={description}
+              />
+            </FormGroup>
+
+            <FormGroup fieldId="basic-settings-network-type">
+              <label className="control-label co-required" htmlFor="network-type">
+                Network Type
+              </label>
+              <Dropdown
+                id="network-type"
+                title="Network Type"
+                items={networkTypeDropdownItems}
+                dropDownClassName="dropdown--full-width"
+                selectedKey={networkType}
+                onChange={(e) => setNetworkType(e)}
+                disabled={_.isEmpty(networkTypeDropdownItems)}
+              />
+            </FormGroup>
+
+            <div className="co-form-subsection">
+              <NetworkTypeOptions
+                networkType={networkType}
+                setTypeParamsData={setTypeParamsData}
+                sriovNetNodePoliciesData={sriovNetNodePoliciesData}
+                typeParamsData={typeParamsData}
+              />
+            </div>
+
+            <ButtonBar errorMessage={error ? error.message : ''} inProgress={loading}>
+              <ActionGroup className="pf-c-form">
+                <Button
+                  id="save-changes"
+                  isDisabled={!formIsValid}
+                  onClick={(e) =>
+                    createNetAttachDef(
+                      e,
+                      description,
+                      name,
+                      networkType,
+                      typeParamsData,
+                      namespace,
+                      setError,
+                      setLoading,
+                    )
+                  }
+                  type="submit"
+                  variant="primary"
+                >
+                  Create
+                </Button>
+                <Button
+                  id="cancel"
+                  onClick={() =>
+                    history.push(`/k8s/ns/${namespace || 'default'}/networkattachmentdefinitions`)
+                  }
+                  type="button"
+                  variant="secondary"
+                >
+                  Cancel
+                </Button>
+              </ActionGroup>
+            </ButtonBar>
+          </Form>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
@@ -9,7 +9,7 @@ export const ELEMENT_TYPES = {
 
 export const networkTypes = {
   sriov: 'SR-IOV',
-  bridge: 'Linux bridge',
+  'cnv-bridge': 'Linux bridge',
 };
 
 export const networkTypeParams: NetworkTypeParamsList = {
@@ -30,8 +30,8 @@ export const networkTypeParams: NetworkTypeParamsList = {
       type: ELEMENT_TYPES.TEXTAREA,
     },
   },
-  bridge: {
-    bridgeName: {
+  'cnv-bridge': {
+    bridge: {
       name: 'Bridge Name',
       required: true,
       type: ELEMENT_TYPES.TEXT,

--- a/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
@@ -12,6 +12,11 @@ export const networkTypes = {
   'cnv-bridge': 'Linux bridge',
 };
 
+export enum NetworkTypes {
+  SRIOV = 'SR-IOV',
+  'CNV-Bridge' = 'Linux bridge',
+}
+
 export const networkTypeParams: NetworkTypeParamsList = {
   sriov: {
     resourceName: {

--- a/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
@@ -23,3 +23,15 @@ export const SriovNetworkNodePolicyModel: K8sKind = {
   kind: 'SriovNetworkNodePolicy',
   id: 'sriov-network-node-policy',
 };
+
+export const HyperConvergedModel: K8sKind = {
+  label: 'HyperConverged Cluster',
+  labelPlural: 'HyperConverged Clusters',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'hco.kubevirt.io',
+  plural: 'hyperconverged',
+  namespaced: false,
+  abbr: 'SRNNPM', // TODO check on this
+  kind: 'hyperconverged',
+  id: 'hyperconverged',
+};

--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -1,5 +1,10 @@
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
+export type NetworkAttachmentDefinitionAnnotations = {
+  description?: string;
+  'k8s.v1.cni.cncf.io/resourceName': string;
+};
+
 export type IPAMConfig = {
   type?: string;
   subnet?: string;
@@ -13,7 +18,7 @@ export type NetworkAttachmentDefinitionConfig = {
   bridge?: string;
   isGateway?: true;
   ipam?: IPAMConfig;
-  plugins?: NetworkAttachmentDefinitionConfig[];
+  plugins?: any[];
 };
 
 // The config is a JSON object with the NetworkAttachmentDefinitionConfig type stored as a string

--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -11,6 +11,10 @@ export type IPAMConfig = {
   dataDir?: string;
 };
 
+export type NetworkAttachmentDefinitionPlugin = {
+  [key: string]: any;
+};
+
 export type NetworkAttachmentDefinitionConfig = {
   cniVersion: string;
   name: string;
@@ -18,7 +22,7 @@ export type NetworkAttachmentDefinitionConfig = {
   bridge?: string;
   isGateway?: true;
   ipam?: IPAMConfig;
-  plugins?: any[];
+  plugins?: NetworkAttachmentDefinitionPlugin[];
 };
 
 // The config is a JSON object with the NetworkAttachmentDefinitionConfig type stored as a string
@@ -29,3 +33,12 @@ export type NetworkAttachmentDefinitionSpec = {
 export type NetworkAttachmentDefinitionKind = {
   spec?: NetworkAttachmentDefinitionSpec;
 } & K8sResourceKind;
+
+export type TypeParamsDataItem = {
+  value?: any;
+  validationMsg?: string;
+};
+
+export type TypeParamsData = {
+  [key: string]: TypeParamsDataItem;
+};


### PR DESCRIPTION
This PR displays an informational message when no network types are available which directs the user to use the YAML editor instead.

Depends on https://github.com/openshift/console/pull/3183

![OKD - Google Chrome_624](https://user-images.githubusercontent.com/8544299/68034171-92859500-fc97-11e9-9b6c-1c62a57e2c36.png)

@phoracek @matthewcarleton 