### PR TITLE
Update the network attachment definition YAML template

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/models/templates/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/models/templates/index.ts
@@ -11,17 +11,6 @@ kind: ${NetworkAttachmentDefinitionModel.kind}
 metadata:
   name: example
 spec:
-  config: '{
-    "cniVersion": "0.3.1",
-    "name": "a-bridge-network",
-    "type": "bridge",
-    "bridge": "br0",
-    "isGateway": true,
-    "ipam": {
-      "type": "host-local",
-      "subnet": "192.168.5.0/24",
-      "dataDir": "/mnt/cluster-ipam"
-    }
-  }'
+  config: '{}'
 `,
 );


### PR DESCRIPTION
This PR updates the network attachment definition YAML template. An example is below.

```yaml
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  name: example
  namespace: test-project
spec:
  config: '{}'
```

@phoracek 