### PR TITLE
Add extension check for DashboardsOverviewUtilizationItem

### DIFF
--- a/frontend/packages/console-app/src/__tests__/extension-checks/dashboards.spec.ts
+++ b/frontend/packages/console-app/src/__tests__/extension-checks/dashboards.spec.ts
@@ -1,0 +1,12 @@
+import * as _ from 'lodash';
+import { testedRegistry } from '../plugin-test-utils';
+
+describe('DashboardsOverviewUtilizationItem', () => {
+  it('duplicate ids are not allowed', () => {
+    const items = testedRegistry.getDashboardsOverviewUtilizationItems();
+    const dedupedItems = _.uniqWith(items, (a, b) => a.properties.id === b.properties.id);
+    const duplicateItems = _.difference(items, dedupedItems);
+
+    expect(duplicateItems).toEqual([]);
+  });
+});


### PR DESCRIPTION
Addresses https://github.com/openshift/console/pull/3166#discussion_r341388946

Check that we're not overriding Prometheus queries _multiple times_ when handling
```
Dashboards/Overview/Utilization/Item
```
extension type.

This should pass:
```sh
# ceph-storage-plugin is active by default
yarn test packages/console-app
```

This should fail, since `demo-plugin` also attempts to override `STORAGE_UTILIZATION` query:
```sh
CONSOLE_PLUGINS=demo-plugin,ceph-storage-plugin yarn test packages/console-app
```

cc @rawagner 