### PR TITLE
Use proper cross-package imports

### DIFF
--- a/frontend/packages/console-shared/src/test-utils/utils.ts
+++ b/frontend/packages/console-shared/src/test-utils/utils.ts
@@ -10,7 +10,7 @@ import {
   ElementArrayFinder,
 } from 'protractor';
 import { By } from 'selenium-webdriver';
-import { config } from '../../../../integration-tests/protractor.conf';
+import { config } from '@console/internal-integration-tests/protractor.conf';
 
 export function resolveTimeout(timeout: number, defaultTimeout: number) {
   return timeout !== undefined ? timeout : defaultTimeout;

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/cloneDialog.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/cloneDialog.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars, no-undef */
 import { browser, ExpectedConditions as until } from 'protractor';
-import { click } from '../../../../console-shared/src/test-utils/utils';
+import { click } from '@console/shared/src/test-utils/utils';
 import { fillInput, selectSelectorOption } from '../utils/utils';
 import { PAGE_LOAD_TIMEOUT_SECS } from '../utils/consts';
 import * as cloneDialogView from '../../views/cloneDialog.view';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/detailView.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/detailView.ts
@@ -1,7 +1,7 @@
 import { browser } from 'protractor';
-import { appHost, testName } from '../../../../../integration-tests/protractor.conf';
-import { clickHorizontalTab } from '../../../../../integration-tests/views/horizontal-nav.view';
-import { isLoaded, resourceTitle } from '../../../../../integration-tests/views/crud.view';
+import { appHost, testName } from '@console/internal-integration-tests/protractor.conf';
+import { clickHorizontalTab } from '@console/internal-integration-tests/views/horizontal-nav.view';
+import { isLoaded, resourceTitle } from '@console/internal-integration-tests/views/crud.view';
 import { activeTab } from '../../views/detailView.view';
 import * as VmsListView from '../../views/vms.list.view';
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
@@ -5,7 +5,7 @@ import { isLoaded } from '@console/internal-integration-tests/views/crud.view';
 import {
   selectDropdownOption,
   waitForStringNotInElement,
-} from '../../../../console-shared/src/test-utils/utils';
+} from '@console/shared/src/test-utils/utils';
 import * as vmView from '../../views/virtualMachine.view';
 import { errorMessage } from '../../views/wizard.view';
 import { VMConfig } from '../utils/types';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachineTemplate.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachineTemplate.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-vars, no-undef, no-await-in-loop, no-console */
 import { browser } from 'protractor';
-import { testName } from '../../../../../integration-tests/protractor.conf';
+import { testName } from '@console/internal-integration-tests/protractor.conf';
 import {
   errorMessage,
   filterForName,
   resourceRowsPresent,
-} from '../../../../../integration-tests/views/crud.view';
+} from '@console/internal-integration-tests/views/crud.view';
 import { VMTemplateConfig } from '../utils/types';
 import { WIZARD_CREATE_TEMPLATE_ERROR, WIZARD_TABLE_FIRST_ROW } from '../utils/consts';
 import { Wizard } from './wizard';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
@@ -2,12 +2,12 @@
 import { execSync } from 'child_process';
 import * as _ from 'lodash';
 import { $, $$, ElementFinder, browser, by, ExpectedConditions as until } from 'protractor';
-import { appHost } from '../../../../../integration-tests/protractor.conf';
+import { appHost } from '@console/internal-integration-tests/protractor.conf';
 import {
   isLoaded,
   createYAMLButton,
   rowForName,
-} from '../../../../../integration-tests/views/crud.view';
+} from '@console/internal-integration-tests/views/crud.view';
 import { STORAGE_CLASS, PAGE_LOAD_TIMEOUT_SECS } from './consts';
 import { NodePortService } from './types';
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.actions.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.actions.scenario.ts
@@ -5,19 +5,19 @@ import {
   resourceRowsPresent,
   isLoaded,
   textFilter,
-} from '../../../../integration-tests/views/crud.view';
-import {
-  waitForActionFinished,
-  waitForStatusIcon,
-  statusIcons,
-} from '../views/virtualMachine.view';
+} from '@console/internal-integration-tests/views/crud.view';
 import {
   addLeakableResource,
   createResource,
   removeLeakedResources,
   removeLeakableResource,
   waitForCount,
-} from '../../../console-shared/src/test-utils/utils';
+} from '@console/shared/src/test-utils/utils';
+import {
+  waitForActionFinished,
+  waitForStatusIcon,
+  statusIcons,
+} from '../views/virtualMachine.view';
 import { getVMManifest } from './utils/mocks';
 import { fillInput } from './utils/utils';
 import {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.clone.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.clone.scenario.ts
@@ -8,9 +8,7 @@ import {
   isLoaded,
   resourceRowsPresent,
   resourceRows,
-} from '../../../../integration-tests/views/crud.view';
-import * as cloneDialogView from '../views/cloneDialog.view';
-import { statusIcons, waitForStatusIcon } from '../views/virtualMachine.view';
+} from '@console/internal-integration-tests/views/crud.view';
 import {
   removeLeakedResources,
   waitForCount,
@@ -21,7 +19,9 @@ import {
   createResource,
   addLeakableResource,
   removeLeakableResource,
-} from '../../../console-shared/src/test-utils/utils';
+} from '@console/shared/src/test-utils/utils';
+import * as cloneDialogView from '../views/cloneDialog.view';
+import { statusIcons, waitForStatusIcon } from '../views/virtualMachine.view';
 import { getVolumes, getDataVolumeTemplates } from '../../src/selectors/vm/selectors';
 import { getResourceObject, getRandStr, createProject } from './utils/utils';
 import {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
@@ -4,7 +4,7 @@ import {
   withResource,
   selectDropdownOptionById,
   click,
-} from '../../../console-shared/src/test-utils/utils';
+} from '@console/shared/src/test-utils/utils';
 import * as virtualMachineView from '../views/virtualMachine.view';
 import { VM_CREATE_AND_EDIT_TIMEOUT_SECS } from './utils/consts';
 import { VirtualMachine } from './models/virtualMachine';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.migration.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.migration.scenario.ts
@@ -1,5 +1,10 @@
 import { browser } from 'protractor';
 import { testName } from '@console/internal-integration-tests/protractor.conf';
+import {
+  createResource,
+  deleteResource,
+  waitForStringInElement,
+} from '@console/shared/src/test-utils/utils';
 import { getDetailActionDropdownOptions } from '../views/vm.actions.view';
 import {
   statusIcon,
@@ -7,11 +12,6 @@ import {
   vmDetailNode,
   waitForStatusIcon,
 } from '../views/virtualMachine.view';
-import {
-  createResource,
-  deleteResource,
-  waitForStringInElement,
-} from '../../../console-shared/src/test-utils/utils';
 import { getRandStr } from './utils/utils';
 import { getVMManifest } from './utils/mocks';
 import {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.overview.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.overview.scenario.ts
@@ -1,12 +1,8 @@
 import * as _ from 'lodash';
 import { testName } from '@console/internal-integration-tests/protractor.conf';
 import { isLoaded, resourceTitle } from '@console/internal-integration-tests/views/crud.view';
+import { asyncForEach, createResource, deleteResource } from '@console/shared/src/test-utils/utils';
 import * as vmView from '../views/virtualMachine.view';
-import {
-  asyncForEach,
-  createResource,
-  deleteResource,
-} from '../../../console-shared/src/test-utils/utils';
 import { getVMManifest, basicVMConfig } from './utils/mocks';
 import { exposeServices } from './utils/utils';
 import { VirtualMachine } from './models/virtualMachine';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.resources.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.resources.scenario.ts
@@ -1,14 +1,14 @@
 import * as _ from 'lodash';
 import { $, browser, ExpectedConditions as until } from 'protractor';
 import { testName } from '@console/internal-integration-tests/protractor.conf';
-import { createNic, networkTypeDropdownId } from '../views/kubevirtDetailView.view';
 import {
   click,
   createResources,
   deleteResources,
   searchYAML,
   getDropdownOptions,
-} from '../../../console-shared/src/test-utils/utils';
+} from '@console/shared/src/test-utils/utils';
+import { createNic, networkTypeDropdownId } from '../views/kubevirtDetailView.view';
 import { getInterfaces } from '../../src/selectors/vm/selectors';
 import { multusNAD, hddDisk, networkInterface, getVMManifest } from './utils/mocks';
 import { getResourceObject } from './utils/utils';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.template.wizard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.template.wizard.scenario.ts
@@ -1,12 +1,12 @@
 /* eslint-disable no-undef, max-nested-callbacks */
 import { OrderedMap } from 'immutable';
-import { testName } from '../../../../integration-tests/protractor.conf';
+import { testName } from '@console/internal-integration-tests/protractor.conf';
 import {
   removeLeakedResources,
   createResources,
   deleteResources,
   withResource,
-} from '../../../console-shared/src/test-utils/utils';
+} from '@console/shared/src/test-utils/utils';
 import { NetworkResource, StorageResource, ProvisionOption } from './utils/types';
 import { VM_BOOTUP_TIMEOUT_SECS } from './utils/consts';
 import { basicVMConfig, rootDisk, networkInterface, multusNAD, hddDisk } from './utils/mocks';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
@@ -5,7 +5,7 @@ import {
   withResource,
   createResources,
   deleteResources,
-} from '../../../console-shared/src/test-utils/utils';
+} from '@console/shared/src/test-utils/utils';
 import { statusIcons, waitForStatusIcon } from '../views/virtualMachine.view';
 import { VirtualMachine } from './models/virtualMachine';
 import { getResourceObject, resolveStorageDataAttribute } from './utils/utils';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.yaml.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.yaml.scenario.ts
@@ -5,20 +5,20 @@ import {
   createYAMLLink,
   resourceTitle,
   errorMessage,
-} from '../../../../integration-tests/views/crud.view';
+} from '@console/internal-integration-tests/views/crud.view';
 import {
   isLoaded as yamlPageIsLoaded,
   saveButton,
   cancelButton,
   setEditorContent,
-} from '../../../../integration-tests/views/yaml.view';
-import { appHost, testName } from '../../../../integration-tests/protractor.conf';
+} from '@console/internal-integration-tests/views/yaml.view';
+import { appHost, testName } from '@console/internal-integration-tests/protractor.conf';
 import {
   click,
   withResource,
   createResource,
   deleteResource,
-} from '../../../console-shared/src/test-utils/utils';
+} from '@console/shared/src/test-utils/utils';
 import { VirtualMachine } from './models/virtualMachine';
 import { VM_BOOTUP_TIMEOUT_SECS, PAGE_LOAD_TIMEOUT_SECS, VM_ACTIONS } from './utils/consts';
 import { getVMManifest, multusNAD } from './utils/mocks';

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/kubevirtDetailView.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/kubevirtDetailView.view.ts
@@ -1,6 +1,6 @@
 import { $, browser, ExpectedConditions as until } from 'protractor';
-import { resourceRows } from '../../../../integration-tests/views/crud.view';
-import { click } from '../../../console-shared/src/test-utils/utils';
+import { resourceRows } from '@console/internal-integration-tests/views/crud.view';
+import { click } from '@console/shared/src/test-utils/utils';
 
 export const createNic = $('#create-nic-btn');
 export const createDisk = $('#create-disk-btn');

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/virtualMachine.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/virtualMachine.view.ts
@@ -1,5 +1,6 @@
 import { $, $$, browser, ExpectedConditions as until } from 'protractor';
-import { resolveTimeout } from '../../../console-shared/src/test-utils/utils';
+import { resourceTitle } from '@console/internal-integration-tests/views/crud.view';
+import { resolveTimeout } from '@console/shared/src/test-utils/utils';
 import {
   VM_BOOTUP_TIMEOUT_SECS,
   VM_STOP_TIMEOUT_SECS,
@@ -8,7 +9,6 @@ import {
   UNEXPECTED_ACTION_ERROR,
   VM_ACTIONS,
 } from '../tests/utils/consts';
-import { resourceTitle } from '../../../../integration-tests/views/crud.view';
 import { nameInput as cloneDialogNameInput } from './cloneDialog.view';
 
 export const statusIcon = (status) => $(`.kubevirt-status__icon.${status}`);

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/vm.actions.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/vm.actions.view.ts
@@ -1,6 +1,6 @@
 import { $, $$, browser, ExpectedConditions as until } from 'protractor';
-import { rowForName } from '../../../../integration-tests/views/crud.view';
-import { waitForCount, click } from '../../../console-shared/src/test-utils/utils';
+import { rowForName } from '@console/internal-integration-tests/views/crud.view';
+import { waitForCount, click } from '@console/shared/src/test-utils/utils';
 
 const disabledDropdownButtons = $$('.pf-m-disabled');
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
@@ -1,5 +1,5 @@
 import { $, $$ } from 'protractor';
-import { selectDropdownOption } from '../../../console-shared/src/test-utils/utils';
+import { selectDropdownOption } from '@console/shared/src/test-utils/utils';
 import { fillInput } from '../tests/utils/utils';
 
 // Wizard Common


### PR DESCRIPTION
Avoid using relative paths in cross-package imports:
- `../integration-tests/foo` :arrow_right: `@console/internal-integration-tests/foo`
- `../console-shared/foo` :arrow_right: `@console/shared/foo`

cc @rhrazdil