### PR TITLE
Restructure html form widgets for setting node, pod, pod anti afinity

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
@@ -455,7 +455,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
     }
     if (field.capabilities.includes(SpecCapability.password)) {
       return (
-        <div style={{ width: '50%' }}>
+        <div>
           <input
             className="pf-c-form-control"
             id={field.path}
@@ -477,7 +477,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
       const model = modelFor(groupVersionKind);
 
       return (
-        <div style={{ width: '50%' }}>
+        <div>
           {!_.isUndefined(model) ? (
             <ListDropdown
               resources={[
@@ -555,7 +555,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
     }
     if (field.capabilities.includes(SpecCapability.text)) {
       return (
-        <div style={{ width: '50%' }}>
+        <div>
           <input
             className="pf-c-form-control"
             id={field.path}
@@ -570,7 +570,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
     }
     if (field.capabilities.includes(SpecCapability.number)) {
       return (
-        <div style={{ width: '50%' }}>
+        <div>
           <input
             className="pf-c-form-control"
             id={field.path}
@@ -675,7 +675,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
   return (
     <div className="co-m-pane__body">
       <div className="row">
-        <form className="col-md-6" onSubmit={submit}>
+        <form className="col-md-8 col-lg-7" onSubmit={submit}>
           <Accordion asDefinitionList={false} className="co-create-operand__accordion">
             <div className="form-group">
               <label className="control-label co-required" htmlFor="name">
@@ -855,10 +855,12 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
           {(!_.isEmpty(error) || !_.isEmpty(_.compact(_.values(formErrors)))) && (
             <Alert
               isInline
-              className="co-alert co-break-word"
+              className="co-alert co-break-word co-alert--scrollable"
               variant="danger"
-              title={error || 'Fix above errors'}
-            />
+              title="Error"
+            >
+              {error || 'Fix above errors'}
+            </Alert>
           )}
           <div style={{ paddingBottom: '30px' }}>
             <ActionGroup className="pf-c-form">
@@ -871,7 +873,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
             </ActionGroup>
           </div>
         </form>
-        <div className="col-md-6">
+        <div className="col-md-4 col-lg-5">
           {props.clusterServiceVersion && props.providedAPI && (
             <div style={{ marginBottom: '30px' }}>
               <ClusterServiceVersionLogo

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/affinity.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/affinity.tsx
@@ -125,27 +125,29 @@ export const NodeAffinity: React.FC<NodeAffinityProps> = (props) => {
                   Remove Preferred
                 </Button>
               )}
-              <label className="control-label co-required" htmlFor={`preference-${i}`}>
-                Weight
-              </label>
-              <input
-                className="pf-c-form-control"
-                type="number"
-                value={
-                  weight ||
-                  affinity.preferredDuringSchedulingIgnoredDuringExecution[i - 1].weight + 1
-                }
-                onChange={(e) =>
-                  props.onChangeAffinity(
-                    _.set(
-                      affinity,
-                      `preferredDuringSchedulingIgnoredDuringExecution[${i}].weight`,
-                      _.toInteger(e.target.value),
-                    ),
-                  )
-                }
-                required
-              />
+              <div className="co-affinity-term__weight-input">
+                <label className="control-label co-required" htmlFor={`preference-${i}`}>
+                  Weight
+                </label>
+                <input
+                  className="pf-c-form-control"
+                  type="number"
+                  value={
+                    weight ||
+                    affinity.preferredDuringSchedulingIgnoredDuringExecution[i - 1].weight + 1
+                  }
+                  onChange={(e) =>
+                    props.onChangeAffinity(
+                      _.set(
+                        affinity,
+                        `preferredDuringSchedulingIgnoredDuringExecution[${i}].weight`,
+                        _.toInteger(e.target.value),
+                      ),
+                    )
+                  }
+                  required
+                />
+              </div>
               <MatchExpressions
                 matchExpressions={preference.matchExpressions || ([] as MatchExpression[])}
                 onChangeMatchExpressions={(matchExpressions) =>
@@ -320,7 +322,7 @@ export const PodAffinity: React.FC<PodAffinityProps> = (props) => {
                 </Button>
               )}
               <div className="co-affinity-term__topology">
-                <div className="co-affinity-term__topology-input">
+                <div className="co-affinity-term__weight-input">
                   <label className="control-label co-required" htmlFor={`preference-${i}`}>
                     Weight
                   </label>

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/match-expressions.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/match-expressions.tsx
@@ -23,31 +23,29 @@ export const MatchExpressions: React.FC<MatchExpressionsProps> = (props) => {
 
   return (
     <>
-      <div className="row toleration-modal__heading hidden-sm hidden-xs">
+      <div className="row key-operator-value__heading hidden-sm hidden-xs">
         <div className="col-md-4 text-secondary text-uppercase">Key</div>
-        <div className="col-md-2 text-secondary text-uppercase">Operator</div>
+        <div className="col-md-3 text-secondary text-uppercase">Operator</div>
         <div className="col-md-3 text-secondary text-uppercase">Value</div>
-        <div className="col-md-1" />
       </div>
       {props.matchExpressions.map((expression, i) => (
-        <div className="row toleration-modal__row" key={JSON.stringify(expression)}>
-          <div className="col-md-4 col-sm-5 col-xs-5 toleration-modal__field">
-            <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">
+        <div className="row key-operator-value__row" key={JSON.stringify(expression)}>
+          <div className="col-md-4 col-xs-5 key-operator-value__name-field">
+            <div className="key-operator-value__heading hidden-md hidden-lg text-secondary text-uppercase">
               Key
             </div>
             <input
               type="text"
-              className="form-control"
+              className="pf-c-form-control"
               value={expression.key}
               onChange={(e) => changeKey(e.target.value, i)}
             />
           </div>
-          <div className="col-md-2 col-sm-5 col-xs-5 toleration-modal__field">
-            <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">
+          <div className="col-md-3 col-xs-5 key-operator-value__operator-field">
+            <div className="key-operator-value__heading hidden-md hidden-lg text-secondary text-uppercase">
               Operator
             </div>
             <Dropdown
-              className="toleration-modal__dropdown"
               dropDownClassName="dropdown--full-width"
               items={allowedOperators.reduce((acc, o) => ({ ...acc, [o]: o }), {})}
               onChange={(op: MatchExpression['operator']) => changeOperator(op, i)}
@@ -55,41 +53,39 @@ export const MatchExpressions: React.FC<MatchExpressionsProps> = (props) => {
               title={expression.operator}
             />
           </div>
-          <div className="clearfix visible-sm visible-xs" />
-          <div className="col-md-3 col-sm-5 col-xs-5 toleration-modal__field">
-            <div className="toleration-modal__heading hidden-md hidden-lg text-secondary text-uppercase">
+          <div className="col-md-3 col-xs-5 key-operator-value__value-field key-operator-value__value-field--stacked">
+            <div className="key-operator-value__heading hidden-md hidden-lg text-secondary text-uppercase">
               Value
             </div>
             <input
+              className="pf-c-form-control"
               type="text"
-              className="form-control"
               value={(expression as any).value || ''}
               onChange={(e) => changeValue(e.target.value, i)}
               readOnly={['Exists', 'DoesNotExist'].includes(expression.operator)}
             />
           </div>
-          <div className="col-md-1 col-sm-2 col-xs-2">
+          <div className="col-xs-1 key-operator-value__action key-operator-value__action--stacked">
+            <div className="key-operator-value__heading key-operator-value__heading-button hidden-md hidden-lg" />
             <Button
               type="button"
-              className="toleration-modal__delete-icon"
               onClick={() =>
                 props.onChangeMatchExpressions(
                   props.matchExpressions.filter((e, index) => index !== i),
                 )
               }
               aria-label="Delete"
+              className="key-operator-value__delete-button"
               variant="plain"
             >
-              <MinusCircleIcon className="pairs-list__side-btn pairs-list__delete-icon" />
+              <MinusCircleIcon />
             </Button>
           </div>
         </div>
       ))}
       <div className="row">
         <Button
-          className="pf-m-link--align-left"
           type="button"
-          style={{ marginLeft: '10px' }}
           onClick={() =>
             onChangeMatchExpressions(matchExpressions.concat({ key: '', operator: 'Exists' }))
           }

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -9,6 +9,8 @@
 @import '~patternfly/dist/sass/patternfly/icons';
 @import "~patternfly-react/dist/sass/patternfly-react";
 
+$co-affinity-row-margin: 15px;
+
 .co-clusterserviceversion-list {
   display: flex;
   flex-wrap: wrap;
@@ -62,8 +64,8 @@
 .co-clusterserviceversion-logo__name__clusterserviceversion {
   font-size: 15px;
   font-weight: var(--pf-global--FontWeight--normal);
-  margin-top: 0;
   margin-bottom: 5px;
+  margin-top: 0;
 }
 .co-m-pane__heading--logo
 .co-clusterserviceversion-logo__name__provider {
@@ -81,9 +83,9 @@
   margin-bottom: 15px;
 
   .pf-c-card {
-    width: 300px;
-    margin-right: 20px;
     margin-bottom: 20px;
+    margin-right: 20px;
+    width: 300px;
   }
 }
 
@@ -111,10 +113,10 @@
 }
 
 .co-catalogsource-list__section__packages {
+  align-items: flex-end;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: flex-end;
   margin-bottom: 20px;
 }
 
@@ -130,8 +132,8 @@
 }
 
 .co-spec-descriptor--switch {
-  display: flex;
   align-items: center;
+  display: flex;
   height: 25px;
 }
 
@@ -176,7 +178,7 @@
   border-bottom: 1px solid #ddd;
   padding: 10px 15px;
   @media(min-width: $screen-sm-min) {
-    padding: 10px 31px; // left alignment with namespace selector text
+    padding: 0 30px 15px;
   }
 }
 
@@ -194,7 +196,7 @@
   display: flex;
   flex-direction: column;
   margin-bottom: 15px;
-  padding: 10px 0 5px 20px;
+  padding: 10px 0 5px 15px;
 }
 
 .co-affinity-term__remove {
@@ -203,14 +205,26 @@
 
 .co-affinity-term__topology {
   display: flex;
-  margin-bottom: 15px;
 }
+
+.co-affinity-term__topology-input,
+.co-affinity-term__weight-input {
+  margin-bottom: $co-affinity-row-margin;
+}
+
 
 .co-affinity-term__topology-input {
   display: flex;
   flex-direction: column;
   padding-right: 15px;
-  width: 50%;
+  width: 100%;
+}
+
+.co-affinity-term__weight-input {
+  display: flex;
+  flex-direction: column;
+  padding-right: 20px;
+  width: 100px;
 }
 
 .co-operand-field-group {
@@ -219,7 +233,7 @@
   flex-direction: column;
   margin-bottom: 15px;
   margin-left: 15px;
-  padding: 10px 0 5px 20px;
+  padding: 10px 15px 5px;
 }
 
 .co-operand-field-group-title {
@@ -231,4 +245,33 @@
 .catalog-source__table-row--disabled {
   background-color: var(--pf-global--BackgroundColor--200);
   color: var(--pf-global--Color--400);
+}
+
+.key-operator-value__action {
+  padding: 0;
+  width: 28px;
+}
+@media (max-width: $screen-sm-max) {
+  .key-operator-value__action--stacked,
+  .key-operator-value__value-field--stacked {
+    padding-top: 10px;
+  }
+}
+
+.key-operator-value__delete-button {
+  padding-left: 0 !important;
+}
+
+.key-operator-value__heading-button {
+  height: 23px; // for vertical alignment with input field; equals $pf-global--LineHeight--md
+}
+
+.key-operator-value__name-field,
+.key-operator-value__operator-field,
+.key-operator-value__value-field {
+  padding-right: 0 !important;
+}
+
+.key-operator-value__row {
+  padding-bottom: 15px;
 }


### PR DESCRIPTION
Improved presentation of `Key, Operator, Value [delete] ` row
Increase width of column for the `form`
Adjust spacing above `breadcrumb` and set correct left alignment within header

https://jira.coreos.com/browse/CONSOLE-1812

<img width="1071" alt="Screen Shot 2019-11-01 at 3 14 02 PM" src="https://user-images.githubusercontent.com/1874151/68050953-ad1e3500-fcbc-11e9-9a87-553c55f5013e.png">
<img width="769" alt="Screen Shot 2019-11-01 at 3 14 50 PM" src="https://user-images.githubusercontent.com/1874151/68050954-ad1e3500-fcbc-11e9-921e-cfaed02a7b89.png">
<img width="771" alt="Screen Shot 2019-11-01 at 3 15 04 PM" src="https://user-images.githubusercontent.com/1874151/68050955-ad1e3500-fcbc-11e9-84f9-2a4e6191a4ab.png">
<img width="768" alt="Screen Shot 2019-11-01 at 3 15 36 PM" src="https://user-images.githubusercontent.com/1874151/68050956-ad1e3500-fcbc-11e9-9f52-c1dd5ab5d2fb.png">
<img width="519" alt="Screen Shot 2019-11-01 at 3 16 27 PM" src="https://user-images.githubusercontent.com/1874151/68050958-ad1e3500-fcbc-11e9-9ea3-66fba85886a5.png">
<img width="519" alt="Screen Shot 2019-11-01 at 3 16 41 PM" src="https://user-images.githubusercontent.com/1874151/68050959-ad1e3500-fcbc-11e9-95ab-e045816947c3.png">
<img width="368" alt="Screen Shot 2019-11-01 at 3 17 21 PM" src="https://user-images.githubusercontent.com/1874151/68050960-adb6cb80-fcbc-11e9-9a35-398dc06945c2.png">


