### PR TITLE
add list view to topology

### DIFF
--- a/frontend/packages/dev-console/src/components/NamespacedPage.tsx
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.tsx
@@ -15,6 +15,7 @@ export interface NamespacedPageProps {
   hideApplications?: boolean;
   onNamespaceChange?: (newNamespace: string) => void;
   variant?: NamespacedPageVariants;
+  toolbar?: React.ReactNode;
 }
 
 const NamespacedPage: React.FC<NamespacedPageProps> = ({
@@ -23,10 +24,12 @@ const NamespacedPage: React.FC<NamespacedPageProps> = ({
   onNamespaceChange,
   hideApplications = false,
   variant = NamespacedPageVariants.default,
+  toolbar,
 }) => (
   <div className="odc-namespaced-page">
     <NamespaceBar disabled={disabled} onNamespaceChange={onNamespaceChange}>
       {!hideApplications && <ApplicationSelector disabled={disabled} />}
+      {toolbar && <div style={{ marginLeft: 'auto' }}>{toolbar}</div>}
     </NamespaceBar>
     <div
       className={cx('odc-namespaced-page__content', {

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -254,7 +254,12 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
-      path: ['/topology/all-namespaces', '/topology/ns/:ns'],
+      path: [
+        '/topology/all-namespaces',
+        '/topology/ns/:name',
+        '/topology/all-namespaces/list',
+        '/topology/ns/:name/list',
+      ],
       loader: async () =>
         (await import(
           './components/topology/TopologyPage' /* webpackChunkName: "dev-console-topology" */


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-2038

Reuses the existing `Overview` component and renders it in place of the topology when visiting the topology url with the suffix `/list`.

![listview](https://user-images.githubusercontent.com/14068621/68065012-8b8f6e80-fcf9-11e9-8029-49a179b6ab7e.gif)
