### PR TITLE
Correct SR-IOV resourceName prefix in network attachment definitions form

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -59,12 +59,9 @@ const buildConfig = (name, networkType, typeParamsData): NetworkAttachmentDefini
 };
 
 const getResourceName = (networkType, typeParamsData): string => {
-  const resourceName =
-    networkType === 'cnv-bridge'
-      ? _.get(typeParamsData, 'bridge.value', '')
-      : _.get(typeParamsData, 'resourceName.value', '');
-
-  return `bridge.network.kubevirt.io/${resourceName}`;
+  return networkType === 'cnv-bridge'
+    ? `bridge.network.kubevirt.io/${_.get(typeParamsData, 'bridge.value', '')}`
+    : `openshift.io/${_.get(typeParamsData, 'resourceName.value', '')}`;
 };
 
 const createNetAttachDef = (


### PR DESCRIPTION
This PR corrects the prefix for the SR-IOV network type changing it from `bridge.network.kubevirt.io` to `openshift.io`. Example YAML output is below:

```yaml
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  annotations:
    k8s.v1.cni.cncf.io/resourceName: openshift.io/sriov_net
  creationTimestamp: '2019-11-03T22:32:40Z'
  generation: 1
  name: test-sriov
  namespace: test-project
  resourceVersion: '3811298'
  selfLink: >-
    /apis/k8s.cni.cncf.io/v1/namespaces/test-project/network-attachment-definitions/test-sriov
  uid: d841499b-fe89-11e9-bf66-525400f2bdf7
spec:
  config: '{"name":"test-sriov","type":"sriov","cniVersion":"0.3.1","ipam":{}}'
```

@phoracek 