### PR TITLE
Fix the HyperConverged model for network attachment definitions form

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
@@ -31,10 +31,10 @@ export const HyperConvergedModel: K8sKind = {
   labelPlural: 'HyperConverged Clusters',
   apiVersion: 'v1alpha1',
   apiGroup: 'hco.kubevirt.io',
-  plural: 'hyperconverged',
-  namespaced: false,
-  abbr: 'SRNNPM', // TODO check on this
-  kind: 'hyperconverged',
+  plural: 'hyperconvergeds',
+  namespaced: true,
+  abbr: 'HCO',
+  kind: 'HyperConverged',
   id: 'hyperconverged',
   crd: true,
 };


### PR DESCRIPTION
This PR corrects mistakes in the HyperConverged model used for the network attachment definitions form.

@phoracek 