### PR TITLE
add check of undefined revisions

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
@@ -52,7 +52,7 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({ revisions
         <Button
           variant="secondry"
           onClick={() => trafficModalLauncher({ obj: service })}
-          disabled={revisions.length === 0}
+          disabled={!(revisions && revisions.length)}
         >
           Set Traffic Distribution
         </Button>


### PR DESCRIPTION
ODC-bug: https://jira.coreos.com/browse/ODC-2152

This Pr adds the check for undefined revisions i.e. when no revisions are created/present for service and disable the button for traffic splitting

![Screenshot from 2019-11-04 14-49-25](https://user-images.githubusercontent.com/9278015/68110214-7b9ea700-ff12-11e9-9e5d-e135f3b2977e.png)
