### PR TITLE
Update tooltip for Build decorator to say "Build" rather than "build name"

### DIFF
--- a/frontend/packages/dev-console/src/components/topology2/components/nodes/build-decorators/build-decorator-utils.tsx
+++ b/frontend/packages/dev-console/src/components/topology2/components/nodes/build-decorators/build-decorator-utils.tsx
@@ -36,7 +36,7 @@ export const getBuildDecoratorParts = (workloadData: WorkloadData): BuildDecorat
       currentPipeline.latestRun.metadata.namespace,
     )}/logs`;
   } else if (build) {
-    tooltipContent = `${build.metadata.name} ${build.status && build.status.phase}`;
+    tooltipContent = `Build ${build.status && build.status.phase}`;
     decoratorIcon = <Status status={build.status.phase} iconOnly noTooltip />;
     linkRef = `${resourcePathFromModel(
       BuildModel,


### PR DESCRIPTION
Related Bug - https://jira.coreos.com/browse/ODC-2150