### PR TITLE
center the application label between lowest points

### DIFF
--- a/frontend/packages/dev-console/src/components/topology2/components/nodes/__tests__/ApplicationGroup.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology2/components/nodes/__tests__/ApplicationGroup.spec.tsx
@@ -1,0 +1,25 @@
+import { computeLabelLocation } from '../ApplicationGroup';
+
+describe('ApplicationGroup', () => {
+  it('should return the lowest point', () => {
+    expect(computeLabelLocation([[0, 0, 0]])).toEqual([0, 0, 0]);
+    expect(computeLabelLocation([[100, 10, 1000], [200, 30, 2000], [300, 20, 3000]])).toEqual([
+      200,
+      30,
+      2000,
+    ]);
+  });
+
+  it('should return a point whose x is the middle of similar low points', () => {
+    expect(
+      computeLabelLocation([
+        [100, 10, 1000],
+        [200, 30, 2000], // low
+        [300, 20, 3000],
+        [500, 30, 2500], // low with largest size
+        [100, 10, 1000],
+        [200, 30, 1500], // low
+      ]),
+    ).toEqual([350, 30, 2500]);
+  });
+});


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-2180

This change improves the location calculation for group labels. If there are multiple low points, the label is now placed between the low points.

Before:
![image](https://user-images.githubusercontent.com/14068621/68165596-da254e80-ff2d-11e9-837f-dbcbbece64ba.png)

After:
![image](https://user-images.githubusercontent.com/14068621/68165628-edd0b500-ff2d-11e9-8c5c-da0cae4eaf82.png)

Hull groups continue to look like this:
![image](https://user-images.githubusercontent.com/14068621/68165671-050fa280-ff2e-11e9-8943-e66c9a0805d4.png)
