### PR TITLE
Allow Start Last Run in the Overview to work again

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunDetailsPage.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
 import { Kebab, navFactory } from '@console/internal/components/utils';
 import { pipelineRunStatus } from '../../utils/pipeline-filter-reducer';
-import { rerunPipeline, stopPipelineRun } from '../../utils/pipeline-actions';
+import { rerunPipelineAndRedirect, stopPipelineRun } from '../../utils/pipeline-actions';
 import { PipelineRunDetails } from './PipelineRunDetails';
 import { PipelineRunLogsWithActiveTask } from './PipelineRunLogs';
 
 const PipelineRunDetailsPage: React.FC<DetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
-    menuActions={[rerunPipeline, stopPipelineRun, Kebab.factory.Delete]}
+    menuActions={[rerunPipelineAndRedirect, stopPipelineRun, Kebab.factory.Delete]}
     getResourceStatus={pipelineRunStatus}
     pages={[
       navFactory.details(PipelineRunDetails),

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -4,7 +4,7 @@ import { Kebab, navFactory } from '@console/internal/components/utils';
 import { k8sGet, k8sList } from '@console/internal/module/k8s';
 import { ErrorPage404 } from '@console/internal/components/error';
 import {
-  rerunPipeline,
+  rerunPipelineAndRedirect,
   startPipeline,
   handlePipelineRunSubmit,
 } from '../../utils/pipeline-actions';
@@ -40,7 +40,7 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
               menuActions: [
                 () => startPipeline(PipelineModel, res, handlePipelineRunSubmit),
                 ...(latestRun && latestRun.metadata
-                  ? [() => rerunPipeline(PipelineRunModel, latestRun)]
+                  ? [() => rerunPipelineAndRedirect(PipelineRunModel, latestRun)]
                   : []),
                 Kebab.factory.Delete,
               ],

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineRow.tsx
@@ -7,7 +7,7 @@ import { pipelineFilterReducer } from '../../utils/pipeline-filter-reducer';
 import { Pipeline } from '../../utils/pipeline-augment';
 import { PipelineModel, PipelineRunModel } from '../../models';
 import {
-  rerunPipeline,
+  rerunPipelineAndRedirect,
   startPipeline,
   handlePipelineRunSubmit,
 } from '../../utils/pipeline-actions';
@@ -28,7 +28,7 @@ const PipelineRow: React.FC<PipelineRowProps> = ({ obj, index, key, style }) => 
   const menuActions = [
     () => startPipeline(PipelineModel, obj, handlePipelineRunSubmit),
     ...(obj.latestRun && obj.latestRun.metadata
-      ? [() => rerunPipeline(PipelineRunModel, obj.latestRun)]
+      ? [() => rerunPipelineAndRedirect(PipelineRunModel, obj.latestRun)]
       : []),
     Kebab.factory.Delete,
   ];

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
@@ -53,7 +53,7 @@ const PipelinesOverview: React.FC<PipelinesOverviewProps> = ({
               />
             </FlexItem>
             <FlexItem>
-              <TriggerLastRunButton disabled={pipelineRuns.length === 0} pipeline={pipeline} />
+              <TriggerLastRunButton pipelineRuns={pipelineRuns} />
             </FlexItem>
           </Flex>
         </li>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineRunItem.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineRunItem.tsx
@@ -5,7 +5,7 @@ import { resourcePath } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { Status } from '@console/shared';
 import { fromNow } from '@console/internal/components/utils/datetime';
-import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
+import { pipelineRunStatus } from '../../../utils/pipeline-filter-reducer';
 import { PipelineRunModel } from '../../../models';
 import { PipelineRun } from '../../../utils/pipeline-augment';
 
@@ -30,7 +30,7 @@ const PipelineRunItem: React.FC<PipelineRunItemProps> = ({ pipelineRun }) => {
           {lastUpdated && <span className="text-muted">&nbsp;({fromNow(lastUpdated)})</span>}
         </GridItem>
         <GridItem span={3}>
-          <Status status={pipelineRunFilterReducer(pipelineRun)} />
+          <Status status={pipelineRunStatus(pipelineRun) || 'Pending'} />
         </GridItem>
         <GridItem span={3} className="text-right">
           <Link to={`${path}/logs`}>View Logs</Link>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/TriggerLastRunButton.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/TriggerLastRunButton.tsx
@@ -1,30 +1,27 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { connect } from 'react-redux';
 import { impersonateStateToProps } from '@console/internal/reducers/ui';
-import { K8sResourceKind } from '@console/internal/module/k8s';
 import { useAccessReview } from '@console/internal/components/utils';
 import { Button } from 'patternfly-react';
-import { rerunPipeline } from '../../../utils/pipeline-actions';
+import { rerunPipelineAndStay } from '../../../utils/pipeline-actions';
 import { PipelineModel } from '../../../models';
+import { getLatestRun, PipelineRun } from '../../../utils/pipeline-augment';
 
 type TriggerLastRunButtonProps = {
-  pipeline: K8sResourceKind;
-  disabled?: boolean;
+  pipelineRuns: PipelineRun[];
   impersonate?;
 };
 
 const TriggerLastRunButton: React.FC<TriggerLastRunButtonProps> = ({
-  pipeline,
+  pipelineRuns,
   impersonate,
-  disabled,
 }) => {
-  const latestRun = _.get(pipeline, ['latestRun'], null);
-  const { label, callback, accessReview } = rerunPipeline(PipelineModel, pipeline, latestRun);
+  const latestRun = getLatestRun({ data: pipelineRuns }, 'startTimestamp');
+  const { label, callback, accessReview } = rerunPipelineAndStay(PipelineModel, latestRun);
   const isAllowed = useAccessReview(accessReview, impersonate);
   return (
     isAllowed && (
-      <Button variant="secondary" onClick={callback} disabled={disabled}>
+      <Button variant="secondary" onClick={callback} disabled={pipelineRuns.length === 0}>
         {label}
       </Button>
     )

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
@@ -1,6 +1,6 @@
 import {
   stopPipelineRun,
-  rerunPipeline,
+  rerunPipelineAndRedirect,
   reRunPipelineRun,
   startPipeline,
   getPipelineRunData,
@@ -40,7 +40,7 @@ export const actionPipelineRuns: PipelineRun[] = [
 
 describe('PipelineAction testing rerunPipeline create correct labels and callbacks', () => {
   it('expect label to be "Start Last Run" when latestRun is available', () => {
-    const rerunAction = rerunPipeline(PipelineRunModel, actionPipelineRuns[0]);
+    const rerunAction = rerunPipelineAndRedirect(PipelineRunModel, actionPipelineRuns[0]);
     expect(rerunAction.label).toBe('Start Last Run');
     expect(rerunAction.callback).not.toBeNull();
   });


### PR DESCRIPTION
https://jira.coreos.com/browse/ODC-2177

Fixes the Start Last Run button on the Overview pane in Topology. It ran into a conflict with another work that reworked the API.

Issue:
![StartLastRun](https://user-images.githubusercontent.com/8126518/68165911-ba425a80-ff2e-11e9-95cd-a93268c94bf2.gif)

Fixed:
![StartLastRunWorking](https://user-images.githubusercontent.com/8126518/68165912-ba425a80-ff2e-11e9-8732-e0034c123e63.gif)

The shaking appears related to https://jira.coreos.com/browse/ODC-2122 if you look at the dev tools you can see the vibration happens at the time it remounts.