### PR TITLE
Bug 1767865: Bump kubevirt-web-ui-components-v0.1.44-2

### DIFF
--- a/frontend/packages/kubevirt-plugin/package.json
+++ b/frontend/packages/kubevirt-plugin/package.json
@@ -10,7 +10,7 @@
     "@console/internal": "0.0.0-fixed",
     "@console/plugin-sdk": "0.0.0-fixed",
     "@console/shared": "0.0.0-fixed",
-    "kubevirt-web-ui-components": "0.1.44-1"
+    "kubevirt-web-ui-components": "0.1.44-2"
   },
   "consolePlugin": {
     "entry": "src/plugin.tsx"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7965,10 +7965,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
-kubevirt-web-ui-components@0.1.44-1:
-  version "0.1.44-1"
-  resolved "https://registry.yarnpkg.com/kubevirt-web-ui-components/-/kubevirt-web-ui-components-0.1.44-1.tgz#9e47b3c9312b7c3b4971f389c4de212dfd800a24"
-  integrity sha512-oKCdX66zUaRvRgLPIFOoPHi2rVQ6l6befUDcrvTWjhsupAeQFdTyX8SM2sSQaXKXTvTd9Icu0xq2DGsEHgdSXQ==
+kubevirt-web-ui-components@0.1.44-2:
+  version "0.1.44-2"
+  resolved "https://registry.yarnpkg.com/kubevirt-web-ui-components/-/kubevirt-web-ui-components-0.1.44-2.tgz#e2c6af1b0affee628a52242f920f1a66a07a417c"
+  integrity sha512-aA6YoaF5QNhuCYt2YMq6dnIzOz0crGahF4fMTOJvVq9z9SxYRbccj68DfBLyA7Jw1NWypZ5Z8RYpGbjtthBMdw==
   dependencies:
     "@patternfly/react-console" "1.x"
     babel-plugin-transform-es2015-modules-umd "6.24.1"


### PR DESCRIPTION
Changelog: https://github.com/kubevirt/web-ui-components/releases/tag/v0.1.44-2
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1767865
Backport of: #3230 

Note: Dependencies diverged between `master` and `release-4.2`, so automatic backport is not possible