### PR TITLE
Move git-service from console-app to dev-console package

### DIFF
--- a/frontend/packages/console-app/package.json
+++ b/frontend/packages/console-app/package.json
@@ -11,7 +11,6 @@
     "@console/ceph-storage-plugin": "0.0.0-fixed",
     "@console/container-security": "0.0.0-fixed",
     "@console/dev-console": "0.0.0-fixed",
-    "@console/git-service": "0.0.0-fixed",
     "@console/internal": "0.0.0-fixed",
     "@console/knative-plugin": "0.0.0-fixed",
     "@console/kubevirt-plugin": "0.0.0-fixed",

--- a/frontend/packages/dev-console/package.json
+++ b/frontend/packages/dev-console/package.json
@@ -4,6 +4,7 @@
   "description": "OpenShift Developer Perspective",
   "private": true,
   "dependencies": {
+    "@console/git-service": "0.0.0-fixed",
     "@console/knative-plugin": "0.0.0-fixed",
     "@console/plugin-sdk": "0.0.0-fixed",
     "@console/topology": "0.0.0-fixed"


### PR DESCRIPTION
This PR - 
- Moves the `git-service` package from `package.json` of `console-app` to `package.json` of `dev-console` as `git-service` is only being used by `dev-console` as the moment.