### PR TITLE
fetches application name for knative service

### DIFF
--- a/frontend/packages/dev-console/src/components/dropdown/ApplicationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ApplicationDropdown.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { Firehose } from '@console/internal/components/utils';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ServiceModel } from '@console/knative-plugin';
 import ResourceDropdown from './ResourceDropdown';
 
 interface ApplicationDropdownProps {
@@ -53,6 +55,13 @@ const ApplicationDropdown: React.FC<ApplicationDropdownProps> = ({ namespace, ..
       kind: 'DaemonSet',
       namespace,
       prop: 'daemonSets',
+    },
+    {
+      isList: true,
+      kind: referenceForModel(ServiceModel),
+      namespace,
+      prop: 'knativeService',
+      optional: true,
     },
   ];
   return (


### PR DESCRIPTION
This PR -
- adds support in application dropdown to fetch application name for knative services
- fixes bug https://jira.coreos.com/browse/ODC-2169
- depends on PR https://github.com/openshift/console/pull/3232 for application labels in metadata

Screens -
![application-dropdown](https://user-images.githubusercontent.com/38663217/68203479-e53eb400-ffeb-11e9-8eb0-70b207c5d5f9.gif)
