### PR TITLE
Add Virtual Hardware tab to Create VM Wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -76,6 +76,7 @@ import { ReviewTab } from './tabs/review-tab/review-tab';
 import { ResultTab } from './tabs/result-tab/result-tab';
 import { StorageTab } from './tabs/storage-tab/storage-tab';
 import { CloudInitTab } from './tabs/cloud-init-tab/cloud-init-tab';
+import { VirtualHardwareTab } from './tabs/virtual-hardware-tab/virtual-hardware-tab';
 
 import './create-vm-wizard.scss';
 
@@ -433,6 +434,15 @@ export class CreateVMWizardComponent extends React.Component<CreateVMWizardCompo
               <>
                 <ResourceLoadErrors wizardReduxID={reduxID} />
                 <CloudInitTab wizardReduxID={reduxID} />
+              </>
+            ),
+          },
+          {
+            id: VMWizardTab.ADVANCED_VIRTUAL_HARDWARE,
+            component: (
+              <>
+                <ResourceLoadErrors wizardReduxID={reduxID} />
+                <VirtualHardwareTab wizardReduxID={reduxID} />
               </>
             ),
           },

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/initial-state.ts
@@ -6,12 +6,14 @@ import { getResultInitialState } from './result-tab-initial-state';
 import { getReviewInitialState } from './review-tab-initial-state';
 import { getCloudInitInitialState } from './cloud-init-tab-initial-state';
 import { InitialStepStateGetter, StepState } from './types';
+import { getVirtualHardwareInitialState } from './virtual-hardware-tab-initial-state';
 
 const initialStateGetterResolver: { [key in VMWizardTab]: InitialStepStateGetter } = {
   [VMWizardTab.VM_SETTINGS]: getVmSettingsInitialState,
   [VMWizardTab.NETWORKING]: getNetworksInitialState,
   [VMWizardTab.STORAGE]: getStorageInitialState,
   [VMWizardTab.ADVANCED_CLOUD_INIT]: getCloudInitInitialState,
+  [VMWizardTab.ADVANCED_VIRTUAL_HARDWARE]: getVirtualHardwareInitialState,
   [VMWizardTab.REVIEW]: getReviewInitialState,
   [VMWizardTab.RESULT]: getResultInitialState,
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/virtual-hardware-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/virtual-hardware-tab-initial-state.ts
@@ -1,0 +1,9 @@
+import { InitialStepStateGetter } from './types';
+
+export const getVirtualHardwareInitialState: InitialStepStateGetter = () => ({
+  value: {},
+  isValid: true, // empty Virtual Storages are valid
+  hasAllRequiredFilled: true,
+  isLocked: false,
+  error: null,
+});

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/storage.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/storage.ts
@@ -1,3 +1,4 @@
 export const ADD_DISK = 'Add Disk';
+export const ATTACH_CD = 'Attach CD-ROM';
 export const NO_BOOTABLE_ATTACHED_DISK_ERROR = 'A bootable attached disk could not be found';
 export const SELECT_BOOTABLE_DISK = '--- Select Bootable Disk ---';

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/strings.ts
@@ -18,6 +18,7 @@ export const TabTitleResolver = {
   [VMWizardTab.NETWORKING]: 'Networking',
   [VMWizardTab.STORAGE]: 'Storage',
   [VMWizardTab.ADVANCED_CLOUD_INIT]: 'Cloud-init',
+  [VMWizardTab.ADVANCED_VIRTUAL_HARDWARE]: 'Virtual Hardware',
   [VMWizardTab.REVIEW]: 'Review',
   [VMWizardTab.RESULT]: 'Result',
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
@@ -29,6 +29,7 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
   const {
     storage,
     isCreateTemplate,
+    isEditing,
     namespace: vmNamespace,
     useProjects,
     addUpdateStorage,
@@ -98,6 +99,7 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
           VMWizardStorageType.PROVISION_SOURCE_TEMPLATE_DISK,
         ].includes(type)}
         isCreateTemplate={isCreateTemplate}
+        isEditing={isEditing}
         onSubmit={(
           resultDiskWrapper,
           resultVolumeWrapper,
@@ -130,6 +132,7 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
 };
 
 type VMWizardStorageModalProps = ModalComponentProps & {
+  isEditing?: boolean;
   storage?: VMWizardStorageWithWrappers;
   namespace: string;
   useProjects?: boolean;

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-row.tsx
@@ -24,6 +24,7 @@ const menuActionEdit = (
       withProgress(
         vmWizardStorageModalEnhanced({
           blocking: true,
+          isEditing: true,
           wizardReduxID,
           storage: storageWithWrappers,
         }).result,
@@ -50,7 +51,7 @@ const menuActionRemove = (
     ),
 });
 
-const getActions = (
+export const getActions = (
   wizardNetworkData: VMWizardStorageWithWrappers,
   opts: VMWizardStorageRowActionOpts,
 ) => [menuActionEdit, menuActionRemove].map((a) => a(wizardNetworkData, opts));

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/virtual-hardware-tab/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/virtual-hardware-tab/types.ts
@@ -1,0 +1,3 @@
+import { DiskType } from '../../../../constants';
+
+export const VHW_TYPES = new Set<DiskType>([DiskType.CDROM]);

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/virtual-hardware-tab/virtual-hardware-tab.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/virtual-hardware-tab/virtual-hardware-tab.scss
@@ -1,0 +1,21 @@
+.kubevirt-create-vm-modal__virtual-hardware-tab-container {
+  display: flex;
+  flex-direction: column;
+
+  .virtual-hardware-tab-cd-title {
+    margin-top: var(--pf-global--spacer--md);
+  }
+
+  .virtual-hardware-tab-add-btn {
+    margin-top: var(--pf-global--spacer--sm);
+  }
+
+  .virtual-hardware-tab-empty-state {
+    margin-top: var(--pf-global--spacer--sm);
+
+    .pf-c-title {
+      color: var(--pf-global--Color--200);
+    }
+  }
+}
+

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/virtual-hardware-tab/virtual-hardware-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/virtual-hardware-tab/virtual-hardware-tab.tsx
@@ -1,0 +1,214 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Button, ButtonVariant, Title, Tooltip } from '@patternfly/react-core';
+import { PlusCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Firehose, FirehoseResult } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { createLookup, getName } from '@console/shared/src';
+import { PersistentVolumeClaimModel } from '@console/internal/models';
+import { iGetCommonData, iGetCreateVMWizardTabs } from '../../selectors/immutable/selectors';
+import { isStepLocked } from '../../selectors/immutable/wizard-selectors';
+import {
+  VMWizardProps,
+  VMWizardStorageWithWrappers,
+  VMWizardTab,
+  VMWizardStorageType,
+} from '../../types';
+import { vmWizardActions } from '../../redux/actions';
+import { ActionType } from '../../redux/types';
+import { getStoragesWithWrappers } from '../../selectors/selectors';
+import { wrapWithProgress } from '../../../../utils/utils';
+import { cdTableColumnClasses } from '../../../vm-disks/utils';
+import { CombinedDisk } from '../../../../k8s/wrapper/vm/combined-disk';
+import { isLoaded } from '../../../../utils';
+import { ATTACH_CD } from '../../strings/storage';
+import { DiskType, DiskBus } from '../../../../constants/vm';
+import { getAvailableCDName } from '../../../modals/cdrom-vm-modal/helpers';
+import { PersistentVolumeClaimWrapper } from '../../../../k8s/wrapper/vm/persistent-volume-claim-wrapper';
+import { VMWizardStorageBundle } from '../storage-tab/types';
+import { vmWizardStorageModalEnhanced } from '../storage-tab/vm-wizard-storage-modal-enhanced';
+import { VMCDsTable } from '../../../vm-disks/vm-cds';
+import { DiskWrapper } from '../../../../k8s/wrapper/vm/disk-wrapper';
+import { VHW_TYPES } from './types';
+import { VmWizardVirtualHardwareRow } from './vm-wizard-virtualhardware-row';
+import './virtual-hardware-tab.scss';
+
+const getVirtualStoragesData = (
+  storages: VMWizardStorageWithWrappers[],
+  pvcs: FirehoseResult<K8sResourceKind[]>,
+): VMWizardStorageBundle[] => {
+  const pvcLookup = createLookup(pvcs, getName);
+
+  return storages
+    .filter((storage) => VHW_TYPES.has(storage.diskWrapper.getType()))
+    .map((wizardStorageData) => {
+      const {
+        diskWrapper,
+        volumeWrapper,
+        dataVolumeWrapper,
+        persistentVolumeClaimWrapper,
+      } = wizardStorageData;
+
+      const pvc = pvcLookup[volumeWrapper.getPersistentVolumeClaimName()];
+
+      const combinedDisk = new CombinedDisk({
+        diskWrapper,
+        volumeWrapper,
+        dataVolumeWrapper,
+        persistentVolumeClaimWrapper:
+          persistentVolumeClaimWrapper || (pvc && PersistentVolumeClaimWrapper.initialize(pvc)),
+        isNewPVC: !!persistentVolumeClaimWrapper,
+        pvcsLoading: !isLoaded(pvcs),
+      });
+
+      return {
+        wizardStorageData,
+        source: combinedDisk.getCDROMSourceValue(),
+        content: combinedDisk.getContent(),
+        storageClass: combinedDisk.getStorageClassName(),
+      };
+    });
+};
+
+const VirtualHardwareTabFirehose: React.FC<VirtualHardwareTabFirehoseProps> = ({
+  wizardReduxID,
+  isLocked,
+  setTabLocked,
+  removeStorage,
+  storages,
+  persistentVolumeClaims,
+}) => {
+  const virtualStorages = getVirtualStoragesData(storages, persistentVolumeClaims);
+  const showStorages = virtualStorages.length > 0;
+  const disableAddCD = isLocked || virtualStorages.length > 1;
+  const availableCDName = getAvailableCDName(storages.map((storage) => storage.disk));
+  const withProgress = wrapWithProgress(setTabLocked);
+  const diskWrapper = DiskWrapper.initializeFromSimpleData({
+    name: availableCDName,
+    type: DiskType.CDROM,
+    bus: DiskBus.VIRTIO,
+  });
+
+  const addButton = (
+    <Button
+      variant={ButtonVariant.link}
+      isDisabled={disableAddCD}
+      icon={<PlusCircleIcon />}
+      id="attach-cdrom"
+      className="pf-m-link--align-left virtual-hardware-tab-add-btn"
+      onClick={() =>
+        withProgress(
+          vmWizardStorageModalEnhanced({
+            storage: {
+              diskWrapper,
+              type: VMWizardStorageType.UI_INPUT,
+            },
+            blocking: true,
+            wizardReduxID,
+          }).result,
+        )
+      }
+    >
+      {ATTACH_CD}
+    </Button>
+  );
+
+  return (
+    <div className="kubevirt-create-vm-modal__virtual-hardware-tab-container">
+      <Title headingLevel="h5" size="lg">
+        Virtual Hardware
+      </Title>
+      <Title className="virtual-hardware-tab-cd-title" headingLevel="h4" size="md">
+        CD-ROMs
+      </Title>
+      {showStorages && (
+        <>
+          <div className="virtual-hardware-tab-main">
+            <VMCDsTable
+              columnClasses={cdTableColumnClasses}
+              data={virtualStorages}
+              customData={{ isDisabled: isLocked, withProgress, removeStorage, wizardReduxID }}
+              row={VmWizardVirtualHardwareRow}
+            />
+            {addButton}
+            {disableAddCD && (
+              <Tooltip
+                position="bottom"
+                content="You have reached the maximum amount of CD-ROM drives"
+              >
+                <OutlinedQuestionCircleIcon />
+              </Tooltip>
+            )}
+          </div>
+        </>
+      )}
+      {!showStorages && (
+        <div className="virtual-hardware-tab-empty-state">
+          <Title size="sm">There are no CD-ROMs currently attached.</Title>
+          {addButton}
+        </div>
+      )}
+    </div>
+  );
+};
+
+type VirtualHardwareTabFirehoseProps = {
+  isLocked: boolean;
+  isBootDiskRequired: boolean;
+  wizardReduxID: string;
+  storages: VMWizardStorageWithWrappers[];
+  removeStorage: (id: string) => void;
+  setTabLocked: (isLocked: boolean) => void;
+  persistentVolumeClaims: FirehoseResult<K8sResourceKind[]>;
+};
+
+const VirtualHardwareConnected: React.FC<VirtualHardwareConnectedProps> = ({
+  namespace,
+  ...rest
+}) => (
+  <Firehose
+    resources={[
+      {
+        kind: PersistentVolumeClaimModel.kind,
+        isList: true,
+        namespace,
+        prop: 'persistentVolumeClaims',
+      },
+    ]}
+  >
+    <VirtualHardwareTabFirehose {...rest} />
+  </Firehose>
+);
+
+type VirtualHardwareConnectedProps = VirtualHardwareTabFirehoseProps & {
+  namespace: string;
+};
+
+const stateToProps = (state, { wizardReduxID }) => {
+  const stepData = iGetCreateVMWizardTabs(state, wizardReduxID);
+  return {
+    namespace: iGetCommonData(state, wizardReduxID, VMWizardProps.activeNamespace),
+    isLocked: isStepLocked(stepData, VMWizardTab.ADVANCED_VIRTUAL_HARDWARE),
+    storages: getStoragesWithWrappers(state, wizardReduxID),
+  };
+};
+
+const dispatchToProps = (dispatch, { wizardReduxID }) => ({
+  setTabLocked: (isLocked) => {
+    dispatch(
+      vmWizardActions[ActionType.SetTabLocked](
+        wizardReduxID,
+        VMWizardTab.ADVANCED_VIRTUAL_HARDWARE,
+        isLocked,
+      ),
+    );
+  },
+  removeStorage: (id: string) => {
+    dispatch(vmWizardActions[ActionType.RemoveStorage](wizardReduxID, id));
+  },
+});
+
+export const VirtualHardwareTab = connect(
+  stateToProps,
+  dispatchToProps,
+)(VirtualHardwareConnected);

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/virtual-hardware-tab/vm-wizard-virtualhardware-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/virtual-hardware-tab/vm-wizard-virtualhardware-row.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Kebab } from '@console/internal/components/utils';
+import { CDSimpleRow } from '../../../vm-disks/cd-row';
+import { VMWizardStorageBundle, VMWizardStorageRowCustomData } from '../storage-tab/types';
+import { getActions } from '../storage-tab/vm-wizard-storage-row';
+
+export type VmWizardVirtualHardwareRowProps = {
+  obj: VMWizardStorageBundle;
+  customData: VMWizardStorageRowCustomData;
+  index: number;
+  style: object;
+};
+
+export const VmWizardVirtualHardwareRow: React.FC<VmWizardVirtualHardwareRowProps> = ({
+  obj: { name, wizardStorageData, ...restData },
+  customData: { isDisabled, columnClasses, removeStorage, withProgress, wizardReduxID },
+  index,
+  style,
+}) => {
+  const validations = _.get(wizardStorageData, ['validation', 'validations'], {});
+  return (
+    <CDSimpleRow
+      data={{ ...restData, name }}
+      validation={{
+        content: validations.content || validations.url || validations.container || validations.pvc,
+        size: validations.size,
+      }}
+      columnClasses={columnClasses}
+      index={index}
+      style={style}
+      actionsComponent={
+        <Kebab
+          options={getActions(wizardStorageData, { wizardReduxID, removeStorage, withProgress })}
+          isDisabled={isDisabled}
+          id={`kebab-for-${name}`}
+        />
+      }
+    />
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -19,6 +19,7 @@ export enum VMWizardTab { // order important
   VM_SETTINGS = 'VM_SETTINGS',
   NETWORKING = 'NETWORKING',
   ADVANCED_CLOUD_INIT = 'ADVANCED_CLOUD_INIT',
+  ADVANCED_VIRTUAL_HARDWARE = 'ADVANCED_VIRTUAL_HARDWARE',
   STORAGE = 'STORAGE',
   REVIEW = 'REVIEW',
   RESULT = 'RESULT',
@@ -204,8 +205,8 @@ export enum VMWizardStorageType {
 export type VMWizardStorage = {
   id?: string;
   type: VMWizardStorageType;
-  disk: V1Disk;
-  volume: V1Volume;
+  disk?: V1Disk;
+  volume?: V1Volume;
   dataVolume?: V1alpha1DataVolume;
   validation?: UIDiskValidation;
   persistentVolumeClaim?: V1PersistentVolumeClaim;
@@ -216,8 +217,8 @@ export type VMWizardStorage = {
 };
 
 export type VMWizardStorageWithWrappers = VMWizardStorage & {
-  diskWrapper: DiskWrapper;
-  volumeWrapper: VolumeWrapper;
+  diskWrapper?: DiskWrapper;
+  volumeWrapper?: VolumeWrapper;
   dataVolumeWrapper?: DataVolumeWrapper;
   persistentVolumeClaimWrapper?: PersistentVolumeClaimWrapper;
 };

--- a/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/cdrom-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/cdrom-modal.tsx
@@ -25,6 +25,7 @@ import {
 import { isValidationError, validateURL } from '../../../utils/validations/common';
 import { VMKind, VMLikeEntityKind } from '../../../types';
 import { CDRomRow } from './cdrom-row';
+import { getAvailableCDName } from './helpers';
 import { initialDisk, WINTOOLS_CONTAINER_NAMES, StorageType, CD, CDMap } from './constants';
 import './cdrom-modal.scss';
 
@@ -102,12 +103,7 @@ export const CDRomModal = withHandlePromise((props: CDRomModalProps) => {
   };
 
   const onCDAdd = () => {
-    let index = 1;
-    let name = `cd-drive-${index}`;
-    while (cds[name]) {
-      index++;
-      name = `cd-drive-${index}`;
-    }
+    const name = getAvailableCDName(Object.values(cds));
     const newCD = {
       ...initialDisk,
       type: StorageType.CONTAINER,

--- a/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/helpers.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/helpers.ts
@@ -1,0 +1,10 @@
+import { CD } from './constants';
+
+export const getAvailableCDName = (cds: CD[]) => {
+  const cdSet = new Set(cds.map((cd) => cd.name));
+  let index = 1;
+  while (cdSet.has(`cd-drive-${index}`)) {
+    index++;
+  }
+  return `cd-drive-${index}`;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
@@ -69,6 +69,7 @@ type DiskModalFirehoseComponentProps = ModalComponentProps & {
   disk?: any;
   volume?: any;
   dataVolume?: any;
+  isEditing?: boolean;
   namespace: string;
   onNamespaceChanged: (namespace: string) => void;
   storageClasses?: FirehoseResult<VMLikeEntityKind[]>;
@@ -127,6 +128,7 @@ type DiskModalFirehoseProps = ModalComponentProps & {
   disk?: any;
   volume?: any;
   dataVolume?: any;
+  isEditing?: boolean;
   useProjects: boolean;
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
@@ -1,7 +1,7 @@
 /* eslint-disable lines-between-class-members */
 
 import { ValueEnum, VolumeType } from '../../../constants';
-import { DataVolumeSourceType } from '../../../constants/vm/storage';
+import { DataVolumeSourceType, DiskType } from '../../../constants/vm/storage';
 import { getStringEnumValues } from '../../../utils/types';
 import { BinaryUnit } from '../../form/size-unit-utils';
 
@@ -114,6 +114,8 @@ export class StorageUISource extends ValueEnum<string> {
 
   isEditingSupported = () => !this.dataVolumeSourceType; // vm disks - do not support because pvc was already created from DV
 
+  isNameEditingSupported = (diskType: DiskType) => diskType !== DiskType.CDROM;
+
   isSizeEditingSupported = () => this !== StorageUISource.IMPORT_DISK;
 
   isPlainDataVolume = (isCreateTemplate: boolean) =>
@@ -121,6 +123,14 @@ export class StorageUISource extends ValueEnum<string> {
 
   hasDynamicSize = () => this === StorageUISource.CONTAINER;
 
-  canBeChangedToThisSource = () =>
-    this !== StorageUISource.IMPORT_DISK && this !== StorageUISource.OTHER;
+  canBeChangedToThisSource = (diskType: DiskType) => {
+    if (diskType === DiskType.CDROM) {
+      return (
+        this === StorageUISource.ATTACH_DISK ||
+        this === StorageUISource.URL ||
+        this === StorageUISource.CONTAINER
+      );
+    }
+    return this !== StorageUISource.IMPORT_DISK && this !== StorageUISource.OTHER;
+  };
 }

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/cd-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/cd-row.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { TableData, TableRow } from '@console/internal/components/factory';
+import { LoadingInline } from '@console/internal/components/utils';
+import { dimensifyRow, DASH } from '@console/shared';
+import { ValidationCell } from '../table/validation-cell';
+import { StorageSimpleData, StorageSimpleDataValidation } from './types';
+
+export type VMCDSimpleRowProps = {
+  data: StorageSimpleData;
+  validation?: StorageSimpleDataValidation;
+  columnClasses: string[];
+  actionsComponent: React.ReactNode;
+  index: number;
+  style: object;
+};
+
+export const CDSimpleRow: React.FC<VMCDSimpleRowProps> = ({
+  data: { source, content, storageClass },
+  validation = {},
+  columnClasses,
+  actionsComponent,
+  index,
+  style,
+}) => {
+  const dimensify = dimensifyRow(columnClasses);
+
+  const isStorageClassLoading = storageClass === undefined;
+  return (
+    <TableRow id={content} index={index} trKey={content} style={style}>
+      <TableData className={dimensify()}>
+        <ValidationCell validation={validation.content}>{content}</ValidationCell>
+      </TableData>
+      <TableData className={dimensify()}>
+        <ValidationCell validation={validation.source}>{source}</ValidationCell>
+      </TableData>
+      <TableData className={dimensify()}>
+        {isStorageClassLoading && <LoadingInline />}
+        {!isStorageClassLoading && (
+          <ValidationCell validation={validation.storageClass}>
+            {storageClass || DASH}
+          </ValidationCell>
+        )}
+      </TableData>
+      <TableData className={dimensify(true)}>{actionsComponent}</TableData>
+    </TableRow>
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
@@ -15,9 +15,7 @@ import { VirtualMachineModel } from '../../models';
 import { ValidationCell } from '../table/validation-cell';
 import { VMNicRowActionOpts } from '../vm-nics/types';
 import { diskModalEnhanced } from '../modals/disk-modal/disk-modal-enhanced';
-import { VMCDRomModal } from '../modals/cdrom-vm-modal';
 import { CombinedDisk } from '../../k8s/wrapper/vm/combined-disk';
-import { DiskType } from '../../constants';
 import {
   StorageBundle,
   StorageSimpleData,
@@ -33,22 +31,15 @@ const menuActionEdit = (
 ): KebabOption => ({
   label: 'Edit',
   callback: () =>
-    disk.getType() !== DiskType.CDROM
-      ? withProgress(
-          diskModalEnhanced({
-            vmLikeEntity,
-            disk: disk.diskWrapper.asResource(),
-            volume: disk.volumeWrapper.asResource(),
-            dataVolume: disk.dataVolumeWrapper && disk.dataVolumeWrapper.asResource(),
-          }).result,
-        )
-      : withProgress(
-          VMCDRomModal({
-            vmLikeEntity,
-            dataVolume: disk.dataVolumeWrapper && disk.dataVolumeWrapper.asResource(),
-            modalClassName: 'modal-lg',
-          }).result,
-        ),
+    withProgress(
+      diskModalEnhanced({
+        vmLikeEntity,
+        isEditing: true,
+        disk: disk.diskWrapper.asResource(),
+        volume: disk.volumeWrapper.asResource(),
+        dataVolume: disk.dataVolumeWrapper && disk.dataVolumeWrapper.asResource(),
+      }).result,
+    ),
   accessReview: asAccessReview(
     isVM(vmLikeEntity) ? VirtualMachineModel : TemplateModel,
     vmLikeEntity,

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
@@ -4,6 +4,7 @@ import { CombinedDisk } from '../../k8s/wrapper/vm/combined-disk';
 
 export type StorageSimpleData = {
   name?: string;
+  content?: string;
   source?: string;
   diskInterface?: string;
   size?: string;
@@ -12,6 +13,7 @@ export type StorageSimpleData = {
 
 export type StorageSimpleDataValidation = {
   name?: ValidationObject;
+  content?: ValidationObject;
   source?: ValidationObject;
   diskInterface?: ValidationObject;
   size?: ValidationObject;

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/utils.ts
@@ -9,3 +9,10 @@ export const diskTableColumnClasses = [
   classNames('col-lg-2'),
   Kebab.columnClass,
 ];
+
+export const cdTableColumnClasses = [
+  classNames('col-lg-4'),
+  classNames('col-lg-4'),
+  classNames('col-lg-4'),
+  Kebab.columnClass,
+];

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-cds.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-cds.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { Table } from '@console/internal/components/factory';
+import { dimensifyHeader } from '@console/shared';
+import { sortable } from '@patternfly/react-table';
+
+export type VMCDsTableProps = {
+  data?: any[];
+  customData?: object;
+  row: React.ComponentClass<any, any> | React.ComponentType<any>;
+  columnClasses: string[];
+};
+
+export const VMCDsTable: React.FC<VMCDsTableProps> = ({
+  data,
+  customData,
+  row: Row,
+  columnClasses,
+}) => {
+  return (
+    <Table
+      aria-label="VM Disks List"
+      data={data}
+      Header={() =>
+        dimensifyHeader(
+          [
+            {
+              title: 'Content',
+              sortField: 'name',
+              transforms: [sortable],
+            },
+            {
+              title: 'Source',
+              sortField: 'source',
+              transforms: [sortable],
+            },
+            {
+              title: 'Storage Class',
+              sortField: 'storageClass',
+              transforms: [sortable],
+            },
+            {
+              title: '',
+            },
+          ],
+          columnClasses,
+        )
+      }
+      Row={Row}
+      customData={{ ...customData, columnClasses }}
+      virtualize
+      loaded
+    />
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -15,6 +15,7 @@ import { wrapWithProgress } from '../../utils/utils';
 import { diskModalEnhanced } from '../modals/disk-modal/disk-modal-enhanced';
 import { CombinedDiskFactory } from '../../k8s/wrapper/vm/combined-disk';
 import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
+import { VHW_TYPES } from '../create-vm-wizard/tabs/virtual-hardware-tab/types';
 import { StorageBundle } from './types';
 import { DiskRow } from './disk-row';
 import { diskTableColumnClasses } from './utils';
@@ -34,15 +35,18 @@ const getStoragesData = ({
     pvcs,
   );
 
-  return combinedDiskFactory.getCombinedDisks().map((disk) => ({
-    disk,
-    // for sorting
-    name: disk.getName(),
-    source: disk.getSourceValue(),
-    diskInterface: disk.getDiskInterface(),
-    size: disk.getReadableSize(),
-    storageClass: disk.getStorageClassName(),
-  }));
+  return combinedDiskFactory
+    .getCombinedDisks()
+    .filter((storage) => !VHW_TYPES.has(storage.diskWrapper.getType()))
+    .map((disk) => ({
+      disk,
+      // for sorting
+      name: disk.getName(),
+      source: disk.getSourceValue(),
+      diskInterface: disk.getDiskInterface(),
+      size: disk.getReadableSize(),
+      storageClass: disk.getStorageClassName(),
+    }));
 };
 
 export type VMDisksTableProps = {


### PR DESCRIPTION
**_Changes_**

- Created a new Virtual Hardware tab for attaching CD-ROMs to a VM/Template
- Updated `DiskModal` to support CD-ROM Add/Edit
- Removed CD-ROMs from the Disks table (Create VM Storage Tab, Overview Disks tab)
- Removed redundant `Type` Column from Disks table (Create VM Storage Tab, Overview Disks tab)

<img width="996" alt="Screen Shot 2019-11-21 at 16 06 57" src="https://user-images.githubusercontent.com/24938324/69353324-027baf80-0c87-11ea-8811-33021fd13742.png">


<img width="981" alt="Screen Shot 2019-11-19 at 13 26 22" src="https://user-images.githubusercontent.com/24938324/69353338-06a7cd00-0c87-11ea-99f0-ef256f72cfa1.png">


