### PR TITLE
Improve display of resource status badge

### DIFF
--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -150,6 +150,9 @@
 
     &-badge {
       vertical-align: middle;
+      .co-icon-and-text__icon {
+        top: 2px;
+      }
     }
   }
 }

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -129,7 +129,7 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
               {resourceTitle}
             </span>
             {resourceStatus && (
-              <span className="co-resource-item__resource-status">
+              <span className="co-resource-item__resource-status hidden-xs">
                 <Badge className="co-resource-item__resource-status-badge" isRead>
                   <Status status={resourceStatus} />
                 </Badge>


### PR DESCRIPTION
* center icon inside badge
* hide the badge at mobile as it's pretty cramped with it

Before:
![console-openshift-console apps rhamilto devcluster openshift com_k8s_ns_openshift-kube-apiserver_pods_installer-2-ip-10-0-129-247 us-east-2 compute internal(iPhone X)](https://user-images.githubusercontent.com/895728/68220722-3af86980-ffb6-11e9-83bc-2153b36bf794.png)
![console-openshift-console apps rhamilto devcluster openshift com_k8s_ns_openshift-kube-apiserver_pods_installer-2-ip-10-0-129-247 us-east-2 compute internal (1)](https://user-images.githubusercontent.com/895728/68220723-3af86980-ffb6-11e9-9c7f-975238f69aaa.png)

After:
![localhost_9000_k8s_ns_openshift-kube-apiserver_pods_installer-2-ip-10-0-129-247 us-east-2 compute internal(iPhone X)](https://user-images.githubusercontent.com/895728/68220764-4cda0c80-ffb6-11e9-9f46-5c0f1c9e3951.png)
![localhost_9000_k8s_ns_openshift-kube-apiserver_pods_installer-2-ip-10-0-129-247 us-east-2 compute internal](https://user-images.githubusercontent.com/895728/68220765-4d72a300-ffb6-11e9-909d-cd7a7c410c9f.png)
