### PR TITLE
Correct form structure to prevent breakage at narrow widths

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1198,14 +1198,11 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
     const { data, error, inProgress } = this.state;
 
     return (
-      <div className="co-m-pane__body">
+      <div className="co-m-pane__body co-m-pane__form">
         <Helmet>
           <title>{title}</title>
         </Helmet>
-        <form
-          className="co-m-pane__body-group silence-form co-m-pane__form"
-          onSubmit={this.onSubmit}
-        >
+        <form className="co-m-pane__body-group silence-form" onSubmit={this.onSubmit}>
           <SectionHeading text={title} />
           <p className="co-m-pane__explanation">
             A silence is configured based on matchers (label selectors). No notification will be
@@ -1231,38 +1228,50 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
               label constraints, though they may have additional labels as well.
             </p>
             <div className="row monitoring-grid-head text-secondary text-uppercase">
-              <div className="col-xs-4">Name</div>
-              <div className="col-xs-4">Value</div>
+              <div className="col-xs-5">Name</div>
+              <div className="col-xs-6">Value</div>
             </div>
             {_.map(data.matchers, (matcher, i) => (
               <div className="row form-group" key={i}>
-                <div className="col-xs-4">
-                  <Text
-                    onChange={this.onFieldChange(`matchers[${i}].name`)}
-                    placeholder="Name"
-                    value={matcher.name}
-                    required
-                  />
+                <div className="col-xs-10">
+                  <div className="row">
+                    <div className="col-xs-6 pairs-list__name-field">
+                      <div className="form-group">
+                        <Text
+                          onChange={this.onFieldChange(`matchers[${i}].name`)}
+                          placeholder="Name"
+                          value={matcher.name}
+                          required
+                        />
+                      </div>
+                    </div>
+                    <div className="col-xs-6 pairs-list__value-field">
+                      <div className="form-group">
+                        <Text
+                          onChange={this.onFieldChange(`matchers[${i}].value`)}
+                          placeholder="Value"
+                          value={matcher.value}
+                          required
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="row">
+                    <div className="col-xs-12 col-sm-12">
+                      <div className="form-group">
+                        <label className="co-no-bold">
+                          <input
+                            type="checkbox"
+                            onChange={(e) => this.onIsRegexChange(e, i)}
+                            checked={matcher.isRegex}
+                          />
+                          &nbsp; Regular Expression
+                        </label>
+                      </div>
+                    </div>
+                  </div>
                 </div>
-                <div className="col-xs-4">
-                  <Text
-                    onChange={this.onFieldChange(`matchers[${i}].value`)}
-                    placeholder="Value"
-                    value={matcher.value}
-                    required
-                  />
-                </div>
-                <div className="col-xs-3">
-                  <label className="co-no-bold">
-                    <input
-                      type="checkbox"
-                      onChange={(e) => this.onIsRegexChange(e, i)}
-                      checked={matcher.isRegex}
-                    />
-                    &nbsp; Regular Expression
-                  </label>
-                </div>
-                <div className="col-xs-1">
+                <div className="col-xs-2 pairs-list__action">
                   <Button
                     type="button"
                     onClick={() => this.removeMatcher(i)}

--- a/frontend/public/components/monitoring/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/alert-manager-receiver-forms.tsx
@@ -138,57 +138,73 @@ const RoutingLabels = ({ routeLabels, setRouteLabels, showAddLabel }) => {
         <ExternalLink href="https://github.com/google/re2/wiki/Syntax" text="regular expression" />.
       </p>
       <div className="row monitoring-grid-head text-secondary text-uppercase">
-        <div className="col-xs-4">Label Name</div>
-        <div className="col-xs-4">Label Value</div>
+        <div className="col-xs-5">Name</div>
+        <div className="col-xs-6">Value</div>
       </div>
       {_.map(routeLabels, (routeLabel, i) => {
         const isDefaultReceiverRouteLabel = isDefaultReceiverLabel(routeLabel);
         return (
           <div className="row form-group" key={i}>
-            <div className="col-xs-4">
-              <input
-                type="text"
-                className="pf-c-form-control"
-                onChange={onRoutingLabelChange(`${i}, name`)}
-                placeholder="Name"
-                value={routeLabel.name}
-                disabled={isDefaultReceiverRouteLabel}
-                required
-              />
-            </div>
-            <div className="col-xs-4">
-              <input
-                type="text"
-                className="pf-c-form-control"
-                onChange={onRoutingLabelChange(`${i}, value`)}
-                placeholder="Value"
-                value={routeLabel.value}
-                disabled={isDefaultReceiverRouteLabel}
-                required
-              />
+            <div className="col-xs-10">
+              <div className="row">
+                <div className="col-xs-6 pairs-list__name-field">
+                  <div className="form-group">
+                    <input
+                      type="text"
+                      className="pf-c-form-control"
+                      onChange={onRoutingLabelChange(`${i}, name`)}
+                      placeholder="Name"
+                      value={routeLabel.name}
+                      disabled={isDefaultReceiverRouteLabel}
+                      required
+                    />
+                  </div>
+                </div>
+                <div className="col-xs-6 pairs-list__value-field">
+                  <div className="form-group">
+                    <input
+                      type="text"
+                      className="pf-c-form-control"
+                      onChange={onRoutingLabelChange(`${i}, value`)}
+                      placeholder="Value"
+                      value={routeLabel.value}
+                      disabled={isDefaultReceiverRouteLabel}
+                      required
+                    />
+                  </div>
+                </div>
+              </div>
+              {!isDefaultReceiverRouteLabel && (
+                <>
+                  <div className="row">
+                    <div className="col-xs-12 col-sm-12">
+                      <div className="form-group">
+                        <label className="co-no-bold">
+                          <input
+                            type="checkbox"
+                            onChange={(e) => onRoutingLabelRegexChange(e, _.toNumber(i))}
+                            checked={routeLabel.isRegex}
+                          />
+                          &nbsp; Regular Expression
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </>
+              )}
             </div>
             {!isDefaultReceiverRouteLabel && (
               <>
-                <div className="col-xs-3">
-                  <label className="co-no-bold">
-                    <input
-                      type="checkbox"
-                      onChange={(e) => onRoutingLabelRegexChange(e, _.toNumber(i))}
-                      checked={routeLabel.isRegex}
-                    />
-                    &nbsp; Regular Expression
-                  </label>
-                </div>
-                <div className="col-xs-1">
-                  <button
+                <div className="col-xs-2 pairs-list__action">
+                  <Button
                     type="button"
-                    className="btn btn-link btn-link--inherit-color"
                     onClick={() => removeRoutingLabel(_.toNumber(i))}
                     aria-label="Remove Route Label"
                     disabled={routeLabels.length <= 1}
+                    variant="plain"
                   >
                     <MinusCircleIcon />
-                  </button>
+                  </Button>
                 </div>
               </>
             )}
@@ -355,11 +371,11 @@ const ReceiverBaseForm: React.FC<ReceiverBaseFormProps> = ({
     (receiverType === 'webhook_configs' && _.isEmpty(webhookUrl));
 
   return (
-    <div className="co-m-pane__body">
+    <div className="co-m-pane__body co-m-pane__form">
       <Helmet>
         <title>{titleVerb} Receiver</title>
       </Helmet>
-      <form className="co-m-pane__body-group co-m-pane__form" onSubmit={save}>
+      <form className="co-m-pane__body-group" onSubmit={save}>
         <h1 className="co-m-pane__heading">
           {titleVerb} {isDefaultReceiver && 'Default'} Receiver
         </h1>


### PR DESCRIPTION
- Convert default <button> to PF4 component
- Make label names consistent

fixes https://jira.coreos.com/browse/CONSOLE-1872

**before**
<img width="324" alt="Screen Shot 2019-11-05 at 1 06 59 PM" src="https://user-images.githubusercontent.com/1874151/68233520-57ec6700-ffcd-11e9-88b2-8223f50b74d6.png">
<img width="450" alt="Screen Shot 2019-11-05 at 1 06 11 PM" src="https://user-images.githubusercontent.com/1874151/68233606-7bafad00-ffcd-11e9-82d8-bf53da59a3cb.png">

---

**after**

<img width="319" alt="Screen Shot 2019-11-05 at 12 54 54 PM" src="https://user-images.githubusercontent.com/1874151/68233884-17411d80-ffce-11e9-9f08-ac3d4eb4af1c.png">

<img width="688" alt="Screen Shot 2019-11-05 at 12 56 16 PM" src="https://user-images.githubusercontent.com/1874151/68233589-72264500-ffcd-11e9-9a46-1246fa9547cc.png">
<img width="822" alt="Screen Shot 2019-11-05 at 12 53 57 PM" src="https://user-images.githubusercontent.com/1874151/68233672-a4d03d80-ffcd-11e9-8471-c65f3c9c72ba.png">



