### PR TITLE
Bug 1768616: Allow gating RoutePage extensions by feature flags

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -66,6 +66,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/ocs-install/create-ocs-service' /* webpackChunkName: "ceph-ocs-service" */
         ).then((m) => m.CreateOCSService),
+      required: CEPH_FLAG,
     },
   },
   // Ceph Storage Dashboard Left cards

--- a/frontend/packages/console-plugin-sdk/src/typings/pages.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/pages.ts
@@ -44,6 +44,8 @@ namespace ExtensionProperties {
     path: string | string[];
     /** Perspective id to which this page belongs to. */
     perspective?: string;
+    /** Feature flags required for this extension to be effective. */
+    required?: string | string[];
   };
 }
 

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -128,6 +128,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import('./components/vm-templates/vm-template' /* webpackChunkName: "kubevirt" */).then(
           (m) => m.VirtualMachineTemplatesPage,
         ),
+      required: FLAG_KUBEVIRT,
     },
   },
   {
@@ -139,6 +140,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/vm-templates/vm-template-create-yaml' /* webpackChunkName: "kubevirt" */
         ).then((m) => m.CreateVMTemplateYAML),
+      required: FLAG_KUBEVIRT,
     },
   },
   {
@@ -150,6 +152,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/create-vm-wizard' /* webpackChunkName: "kubevirt-create-vm-wizard" */
         ).then((m) => m.CreateVMWizardPage),
+      required: FLAG_KUBEVIRT,
     },
   },
   {
@@ -161,6 +164,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/create-vm-wizard' /* webpackChunkName: "kubevirt-create-vm-wizard" */
         ).then((m) => m.CreateVMWizardPage),
+      required: FLAG_KUBEVIRT,
     },
   },
   {
@@ -171,6 +175,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/vm-templates/vm-template-details-page' /* webpackChunkName: "kubevirt" */
         ).then((m) => m.VMTemplateDetailsPage),
+      required: FLAG_KUBEVIRT,
     },
   },
   {

--- a/frontend/packages/metal3-plugin/src/plugin.ts
+++ b/frontend/packages/metal3-plugin/src/plugin.ts
@@ -80,6 +80,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/baremetal-hosts/add-baremetal-host/AddBareMetalHostPage' /* webpackChunkName: "metal3-baremetalhost" */
         ).then((m) => m.default),
+      required: [FLAGS.BAREMETAL, METAL3_FLAG],
     },
   },
   {
@@ -121,6 +122,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/baremetal-nodes/BareMetalNodesPage' /* webpackChunkName: "node" */
         ).then((m) => m.default),
+      required: [FLAGS.BAREMETAL, METAL3_FLAG],
     },
   },
   {
@@ -132,6 +134,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/baremetal-nodes/BareMetalNodeDetailsPage' /* webpackChunkName: "node" */
         ).then((m) => m.default),
+      required: [FLAGS.BAREMETAL, METAL3_FLAG],
     },
   },
 ];

--- a/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
@@ -78,6 +78,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml' /* webpackChunkName: "network-attachment-definitions" */
         ).then((m) => m.default),
+      required: FLAG_NET_ATTACH_DEF,
     },
   },
   {
@@ -96,6 +97,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/network-attachment-definitions/NetworkAttachmentDefinitionsForm' /* webpackChunkName: "network-attachment-definitions" */
         ).then((m) => m.default),
+      required: FLAG_NET_ATTACH_DEF,
     },
   },
   {
@@ -110,6 +112,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/network-attachment-definitions' /* webpackChunkName: "network-attachment-definitions" */
         ).then((m) => m.NetworkAttachmentDefinitionsPage),
+      required: FLAG_NET_ATTACH_DEF,
     },
   },
 ];

--- a/frontend/packages/noobaa-storage-plugin/src/plugin.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/plugin.ts
@@ -49,6 +49,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import('./components/bucket-class/create-bc' /* webpackChunkName: "create-bc" */).then(
           (m) => m.default,
         ),
+      required: NOOBAA_FLAG,
     },
   },
   {
@@ -65,6 +66,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/create-backingstore-page/create-bs-page' /* webpackChunkName: "create-bs" */
         ).then((m) => m.default),
+      required: NOOBAA_FLAG,
     },
   },
   {
@@ -248,6 +250,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/object-bucket-claim-page/create-obc' /* webpackChunkName: "create-obc" */
         ).then((m) => m.CreateOBCPage),
+      required: NOOBAA_FLAG,
     },
   },
 ];

--- a/frontend/packages/operator-lifecycle-manager/src/components/create-catalog-source.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-catalog-source.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
+import { match } from 'react-router-dom';
 import { ActionGroup, Button, Form, FormGroup, TextInput } from '@patternfly/react-core';
 import {
   ButtonBar,
@@ -30,7 +31,7 @@ const availabilityKinds = [
   },
 ];
 
-export const CreateCatalogSource: React.FC<HandlePromiseProps> = withHandlePromise(
+export const CreateCatalogSource: React.FC<CreateCatalogSourceProps> = withHandlePromise(
   ({ handlePromise, inProgress, errorMessage }) => {
     const [availability, setAvailability] = React.useState(AvailabilityValue.ALL_NAMESPACES);
     const [image, setImage] = React.useState('');
@@ -162,3 +163,7 @@ export const CreateCatalogSource: React.FC<HandlePromiseProps> = withHandlePromi
     );
   },
 );
+
+type CreateCatalogSourceProps = HandlePromiseProps & {
+  match: match;
+};

--- a/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
@@ -1,14 +1,32 @@
 import * as _ from 'lodash';
-import { Plugin, ModelDefinition, ModelFeatureFlag } from '@console/plugin-sdk';
+import {
+  Plugin,
+  ModelDefinition,
+  ModelFeatureFlag,
+  HrefNavItem,
+  ResourceNSNavItem,
+  ResourceListPage,
+  ResourceDetailsPage,
+  RoutePage,
+  DevCatalogModel,
+} from '@console/plugin-sdk';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { normalizeClusterServiceVersions } from './dev-catalog';
 import * as models from './models';
 import { Flags } from './const';
 import './style.scss';
 
-type ConsumedExtensions = ModelDefinition | ModelFeatureFlag;
+type ConsumedExtensions =
+  | ModelDefinition
+  | ModelFeatureFlag
+  | HrefNavItem
+  | ResourceNSNavItem
+  | ResourceListPage
+  | ResourceDetailsPage
+  | RoutePage
+  | DevCatalogModel;
 
-export default [
+const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'ModelDefinition',
     properties: {
@@ -223,4 +241,6 @@ export default [
       loader: async () => (await import('./components/create-catalog-source')).CreateCatalogSource,
     },
   },
-] as Plugin<ConsumedExtensions>;
+];
+
+export default plugin;

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -1,7 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Redirect, Route, Switch, withRouter } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 
 import { FLAGS } from '../const';
 import { connectToFlags, flagPending, FlagsObject } from '../reducers/features';
@@ -87,553 +87,558 @@ const LazyRoute = (props) => (
   />
 );
 
-const getPageRouteExtensions = (perspective: string) =>
-  plugins.registry.getRoutePages().map((r) => {
-    if (r.properties.perspective && r.properties.perspective !== perspective) {
-      return null;
-    }
-    const Component = r.properties.loader ? LazyRoute : Route;
-    return <Component {...r.properties} key={Array.from(r.properties.path).join(',')} />;
-  });
+const getPluginPageRoutes = (activePerspective: string, flags: FlagsObject) =>
+  plugins.registry
+    .getRoutePages()
+    .filter((e) => plugins.registry.isExtensionInUse(e, flags))
+    .map((r) => {
+      if (r.properties.perspective && r.properties.perspective !== activePerspective) {
+        return null;
+      }
+      const Component = r.properties.loader ? LazyRoute : Route;
+      return <Component {...r.properties} key={Array.from(r.properties.path).join(',')} />;
+    });
 
-// use `withRouter` to force a re-render when routes change since we are using React.memo
+type AppContentsProps = {
+  activePerspective: string;
+  flags: FlagsObject;
+};
+
+const AppContents_: React.FC<AppContentsProps> = ({ activePerspective, flags }) => (
+  <PageSection variant={PageSectionVariants.light}>
+    <div id="content">
+      <GlobalNotifications />
+      <Route path={namespacedRoutes} component={NamespaceBar} />
+      <div id="content-scrollable">
+        <Switch>
+          {getPluginPageRoutes(activePerspective, flags)}
+
+          <Route path={['/all-namespaces', '/ns/:ns']} component={RedirectComponent} />
+          <LazyRoute
+            path="/dashboards"
+            loader={() =>
+              import(
+                './dashboard/dashboards-page/dashboards' /* webpackChunkName: "dashboards" */
+              ).then((m) => m.DashboardsPage)
+            }
+          />
+
+          {/* Redirect legacy routes to avoid breaking links */}
+          <Redirect from="/cluster-status" to="/dashboards" />
+          <Redirect from="/status/all-namespaces" to="/dashboards" />
+          <Redirect from="/status/ns/:ns" to="/k8s/cluster/projects/:ns" />
+          <Route path="/status" exact component={NamespaceRedirect} />
+          <Redirect from="/overview/all-namespaces" to="/dashboards" />
+          <Redirect from="/overview/ns/:ns" to="/k8s/cluster/projects/:ns/workloads" />
+          <Route path="/overview" exact component={NamespaceRedirect} />
+
+          <LazyRoute
+            path="/api-explorer"
+            exact
+            loader={() =>
+              import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
+                (m) => m.APIExplorerPage,
+              )
+            }
+          />
+          <LazyRoute
+            path="/api-resource/cluster/:plural"
+            loader={() =>
+              import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
+                (m) => m.APIResourcePage,
+              )
+            }
+          />
+          <LazyRoute
+            path="/api-resource/all-namespaces/:plural"
+            loader={() =>
+              import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
+                NamespaceFromURL(m.APIResourcePage),
+              )
+            }
+          />
+          <LazyRoute
+            path="/api-resource/ns/:ns/:plural"
+            loader={() =>
+              import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
+                NamespaceFromURL(m.APIResourcePage),
+              )
+            }
+          />
+
+          <LazyRoute
+            path="/command-line-tools"
+            exact
+            loader={() =>
+              import('./command-line-tools' /* webpackChunkName: "command-line-tools" */).then(
+                (m) => m.CommandLineToolsPage,
+              )
+            }
+          />
+
+          <Route path="/operatorhub" exact component={NamespaceRedirect} />
+
+          <LazyRoute
+            path="/catalog/all-namespaces"
+            exact
+            loader={() =>
+              import('./catalog/catalog-page' /* webpackChunkName: "catalog" */).then(
+                (m) => m.CatalogPage,
+              )
+            }
+          />
+          <LazyRoute
+            path="/catalog/ns/:ns"
+            exact
+            loader={() =>
+              import('./catalog/catalog-page' /* webpackChunkName: "catalog" */).then(
+                (m) => m.CatalogPage,
+              )
+            }
+          />
+          <Route path="/catalog" exact component={NamespaceRedirect} />
+
+          <LazyRoute
+            path="/provisionedservices/all-namespaces"
+            loader={() =>
+              import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(
+                (m) => m.ProvisionedServicesPage,
+              )
+            }
+          />
+          <LazyRoute
+            path="/provisionedservices/ns/:ns"
+            loader={() =>
+              import('./provisioned-services' /* webpackChunkName: "provisionedservices" */).then(
+                (m) => m.ProvisionedServicesPage,
+              )
+            }
+          />
+          <Route path="/provisionedservices" component={NamespaceRedirect} />
+
+          <LazyRoute
+            path="/brokermanagement"
+            loader={() =>
+              import('./broker-management' /* webpackChunkName: "brokermanagment" */).then(
+                (m) => m.BrokerManagementPage,
+              )
+            }
+          />
+
+          <LazyRoute
+            path="/catalog/create-service-instance"
+            exact
+            loader={() =>
+              import(
+                './service-catalog/create-instance' /* webpackChunkName: "create-service-instance" */
+              ).then((m) => m.CreateInstancePage)
+            }
+          />
+          <LazyRoute
+            path="/k8s/ns/:ns/serviceinstances/:name/create-binding"
+            exact
+            loader={() =>
+              import(
+                './service-catalog/create-binding' /* webpackChunkName: "create-binding" */
+              ).then((m) => m.CreateBindingPage)
+            }
+          />
+          <LazyRoute
+            path="/catalog/instantiate-template"
+            exact
+            loader={() =>
+              import('./instantiate-template' /* webpackChunkName: "instantiate-template" */).then(
+                (m) => m.InstantiateTemplatePage,
+              )
+            }
+          />
+
+          <Route
+            path="/k8s/ns/:ns/alertmanagers/:name"
+            exact
+            render={({ match }) => (
+              <Redirect
+                to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
+                  match.params.name
+                }`}
+              />
+            )}
+          />
+
+          <LazyRoute
+            path="/k8s/all-namespaces/events"
+            exact
+            loader={() =>
+              import('./events' /* webpackChunkName: "events" */).then((m) =>
+                NamespaceFromURL(m.EventStreamPage),
+              )
+            }
+          />
+          <LazyRoute
+            path="/k8s/ns/:ns/events"
+            exact
+            loader={() =>
+              import('./events' /* webpackChunkName: "events" */).then((m) =>
+                NamespaceFromURL(m.EventStreamPage),
+              )
+            }
+          />
+          <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
+          <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
+          <Route path="/search" exact component={NamespaceRedirect} />
+
+          <LazyRoute
+            path="/k8s/all-namespaces/import"
+            exact
+            loader={() =>
+              import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+                NamespaceFromURL(m.ImportYamlPage),
+              )
+            }
+          />
+          <LazyRoute
+            path="/k8s/ns/:ns/import/"
+            exact
+            loader={() =>
+              import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
+                NamespaceFromURL(m.ImportYamlPage),
+              )
+            }
+          />
+
+          {
+            // These pages are temporarily disabled. We need to update the safe resources list.
+            // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+            // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+          }
+
+          {
+            // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+            // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
+          }
+
+          <LazyRoute
+            path="/k8s/ns/:ns/secrets/~new/:type"
+            exact
+            kind="Secret"
+            loader={() =>
+              import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+                (m) => m.CreateSecret,
+              )
+            }
+          />
+          <LazyRoute
+            path="/k8s/ns/:ns/secrets/:name/edit"
+            exact
+            kind="Secret"
+            loader={() =>
+              import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
+                (m) => m.EditSecret,
+              )
+            }
+          />
+          <LazyRoute
+            path="/k8s/ns/:ns/secrets/:name/edit-yaml"
+            exact
+            kind="Secret"
+            loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
+          />
+
+          <LazyRoute
+            path="/k8s/ns/:ns/routes/~new/form"
+            exact
+            kind="Route"
+            loader={() =>
+              import('./routes/create-route' /* webpackChunkName: "create-route" */).then(
+                (m) => m.CreateRoute,
+              )
+            }
+          />
+
+          <LazyRoute
+            path="/k8s/cluster/rolebindings/~new"
+            exact
+            loader={() =>
+              import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+            }
+            kind="RoleBinding"
+          />
+          <LazyRoute
+            path="/k8s/ns/:ns/rolebindings/~new"
+            exact
+            loader={() =>
+              import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
+            }
+            kind="RoleBinding"
+          />
+          <LazyRoute
+            path="/k8s/ns/:ns/rolebindings/:name/copy"
+            exact
+            kind="RoleBinding"
+            loader={() =>
+              import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+            }
+          />
+          <LazyRoute
+            path="/k8s/ns/:ns/rolebindings/:name/edit"
+            exact
+            kind="RoleBinding"
+            loader={() =>
+              import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+            }
+          />
+          <LazyRoute
+            path="/k8s/cluster/clusterrolebindings/:name/copy"
+            exact
+            kind="ClusterRoleBinding"
+            loader={() =>
+              import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
+            }
+          />
+          <LazyRoute
+            path="/k8s/cluster/clusterrolebindings/:name/edit"
+            exact
+            kind="ClusterRoleBinding"
+            loader={() =>
+              import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
+            }
+          />
+          <LazyRoute
+            path="/k8s/ns/:ns/:plural/:name/attach-storage"
+            exact
+            loader={() =>
+              import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
+                (m) => m.AttachStorage,
+              )
+            }
+          />
+
+          <LazyRoute
+            path="/k8s/ns/:ns/persistentvolumeclaims/~new/form"
+            exact
+            kind="PersistentVolumeClaim"
+            loader={() =>
+              import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
+                (m) => m.CreatePVC,
+              )
+            }
+          />
+
+          <LazyRoute
+            path="/monitoring/alerts"
+            exact
+            loader={() =>
+              import('./monitoring' /* webpackChunkName: "monitoring" */).then(
+                (m) => m.MonitoringUI,
+              )
+            }
+          />
+          <LazyRoute
+            path="/monitoring/silences"
+            exact
+            loader={() =>
+              import('./monitoring' /* webpackChunkName: "monitoring" */).then(
+                (m) => m.MonitoringUI,
+              )
+            }
+          />
+          <LazyRoute
+            path="/monitoring/alertmanageryaml"
+            exact
+            loader={() =>
+              import('./monitoring' /* webpackChunkName: "monitoring" */).then(
+                (m) => m.MonitoringUI,
+              )
+            }
+          />
+          <LazyRoute
+            path="/monitoring/alertmanagerconfig"
+            exact
+            loader={() =>
+              import('./monitoring' /* webpackChunkName: "monitoring" */).then(
+                (m) => m.MonitoringUI,
+              )
+            }
+          />
+          <LazyRoute
+            path="/monitoring/alertmanagerconfig/receivers/~new"
+            exact
+            loader={() =>
+              import(
+                './monitoring/alert-manager-receiver-forms' /* webpackChunkName: "monitoring" */
+              ).then((m) => m.CreateReceiver)
+            }
+          />
+          <LazyRoute
+            path="/monitoring/alertmanagerconfig/receivers/:name/edit"
+            exact
+            loader={() =>
+              import(
+                './monitoring/alert-manager-receiver-forms' /* webpackChunkName: "monitoring" */
+              ).then((m) => m.EditReceiver)
+            }
+          />
+          <LazyRoute
+            path="/monitoring"
+            loader={() =>
+              import('./monitoring' /* webpackChunkName: "monitoring" */).then(
+                (m) => m.MonitoringUI,
+              )
+            }
+          />
+
+          <LazyRoute
+            path="/settings/idp/github"
+            exact
+            loader={() =>
+              import(
+                './cluster-settings/github-idp-form' /* webpackChunkName: "github-idp-form" */
+              ).then((m) => m.AddGitHubPage)
+            }
+          />
+          <LazyRoute
+            path="/settings/idp/gitlab"
+            exact
+            loader={() =>
+              import(
+                './cluster-settings/gitlab-idp-form' /* webpackChunkName: "gitlab-idp-form" */
+              ).then((m) => m.AddGitLabPage)
+            }
+          />
+          <LazyRoute
+            path="/settings/idp/google"
+            exact
+            loader={() =>
+              import(
+                './cluster-settings/google-idp-form' /* webpackChunkName: "google-idp-form" */
+              ).then((m) => m.AddGooglePage)
+            }
+          />
+          <LazyRoute
+            path="/settings/idp/htpasswd"
+            exact
+            loader={() =>
+              import(
+                './cluster-settings/htpasswd-idp-form' /* webpackChunkName: "htpasswd-idp-form" */
+              ).then((m) => m.AddHTPasswdPage)
+            }
+          />
+          <LazyRoute
+            path="/settings/idp/keystone"
+            exact
+            loader={() =>
+              import(
+                './cluster-settings/keystone-idp-form' /* webpackChunkName: "keystone-idp-form" */
+              ).then((m) => m.AddKeystonePage)
+            }
+          />
+          <LazyRoute
+            path="/settings/idp/ldap"
+            exact
+            loader={() =>
+              import(
+                './cluster-settings/ldap-idp-form' /* webpackChunkName: "ldap-idp-form" */
+              ).then((m) => m.AddLDAPPage)
+            }
+          />
+          <LazyRoute
+            path="/settings/idp/oidconnect"
+            exact
+            loader={() =>
+              import(
+                './cluster-settings/openid-idp-form' /* webpackChunkName: "openid-idp-form" */
+              ).then((m) => m.AddOpenIDPage)
+            }
+          />
+          <LazyRoute
+            path="/settings/idp/basicauth"
+            exact
+            loader={() =>
+              import(
+                './cluster-settings/basicauth-idp-form' /* webpackChunkName: "basicauth-idp-form" */
+              ).then((m) => m.AddBasicAuthPage)
+            }
+          />
+          <LazyRoute
+            path="/settings/idp/requestheader"
+            exact
+            loader={() =>
+              import(
+                './cluster-settings/request-header-idp-form' /* webpackChunkName: "request-header-idp-form" */
+              ).then((m) => m.AddRequestHeaderPage)
+            }
+          />
+          <LazyRoute
+            path="/settings/cluster"
+            loader={() =>
+              import(
+                './cluster-settings/cluster-settings' /* webpackChunkName: "cluster-settings" */
+              ).then((m) => m.ClusterSettingsPage)
+            }
+          />
+
+          <LazyRoute
+            path={'/k8s/cluster/storageclasses/~new/form'}
+            exact
+            loader={() =>
+              import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(
+                (m) => m.StorageClassForm,
+              )
+            }
+          />
+
+          <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
+          <LazyRoute
+            path="/k8s/cluster/:plural/~new"
+            exact
+            loader={() =>
+              import('./create-yaml' /* webpackChunkName: "create-yaml" */).then(
+                (m) => m.CreateYAML,
+              )
+            }
+          />
+          <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
+          <LazyRoute
+            path="/k8s/ns/:ns/pods/:podName/containers/:name"
+            loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
+          />
+          <LazyRoute
+            path="/k8s/ns/:ns/:plural/~new"
+            exact
+            loader={() =>
+              import('./create-yaml' /* webpackChunkName: "create-yaml" */).then((m) =>
+                NamespaceFromURL(m.CreateYAML),
+              )
+            }
+          />
+          <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
+          <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
+
+          <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
+          <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
+
+          <LazyRoute
+            path="/error"
+            exact
+            loader={() =>
+              import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage)
+            }
+          />
+          <Route path="/" exact component={DefaultPage} />
+
+          <LazyRoute
+            loader={() =>
+              import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
+            }
+          />
+        </Switch>
+      </div>
+    </div>
+  </PageSection>
+);
+
 const AppContents = connect((state: RootState) => ({
   activePerspective: getActivePerspective(state),
-}))(
-  withRouter(
-    React.memo(({ activePerspective }) => (
-      <PageSection variant={PageSectionVariants.light}>
-        <div id="content">
-          <GlobalNotifications />
-          <Route path={namespacedRoutes} component={NamespaceBar} />
-          <div id="content-scrollable">
-            <Switch>
-              {getPageRouteExtensions(activePerspective)}
-
-              <Route path={['/all-namespaces', '/ns/:ns']} component={RedirectComponent} />
-              <LazyRoute
-                path="/dashboards"
-                loader={() =>
-                  import(
-                    './dashboard/dashboards-page/dashboards' /* webpackChunkName: "dashboards" */
-                  ).then((m) => m.DashboardsPage)
-                }
-              />
-
-              {/* Redirect legacy routes to avoid breaking links */}
-              <Redirect from="/cluster-status" to="/dashboards" />
-              <Redirect from="/status/all-namespaces" to="/dashboards" />
-              <Redirect from="/status/ns/:ns" to="/k8s/cluster/projects/:ns" />
-              <Route path="/status" exact component={NamespaceRedirect} />
-              <Redirect from="/overview/all-namespaces" to="/dashboards" />
-              <Redirect from="/overview/ns/:ns" to="/k8s/cluster/projects/:ns/workloads" />
-              <Route path="/overview" exact component={NamespaceRedirect} />
-
-              <LazyRoute
-                path="/api-explorer"
-                exact
-                loader={() =>
-                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
-                    (m) => m.APIExplorerPage,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/api-resource/cluster/:plural"
-                loader={() =>
-                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then(
-                    (m) => m.APIResourcePage,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/api-resource/all-namespaces/:plural"
-                loader={() =>
-                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
-                    NamespaceFromURL(m.APIResourcePage),
-                  )
-                }
-              />
-              <LazyRoute
-                path="/api-resource/ns/:ns/:plural"
-                loader={() =>
-                  import('./api-explorer' /* webpackChunkName: "api-explorer" */).then((m) =>
-                    NamespaceFromURL(m.APIResourcePage),
-                  )
-                }
-              />
-
-              <LazyRoute
-                path="/command-line-tools"
-                exact
-                loader={() =>
-                  import('./command-line-tools' /* webpackChunkName: "command-line-tools" */).then(
-                    (m) => m.CommandLineToolsPage,
-                  )
-                }
-              />
-
-              <Route path="/operatorhub" exact component={NamespaceRedirect} />
-
-              <LazyRoute
-                path="/catalog/all-namespaces"
-                exact
-                loader={() =>
-                  import('./catalog/catalog-page' /* webpackChunkName: "catalog" */).then(
-                    (m) => m.CatalogPage,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/catalog/ns/:ns"
-                exact
-                loader={() =>
-                  import('./catalog/catalog-page' /* webpackChunkName: "catalog" */).then(
-                    (m) => m.CatalogPage,
-                  )
-                }
-              />
-              <Route path="/catalog" exact component={NamespaceRedirect} />
-
-              <LazyRoute
-                path="/provisionedservices/all-namespaces"
-                loader={() =>
-                  import(
-                    './provisioned-services' /* webpackChunkName: "provisionedservices" */
-                  ).then((m) => m.ProvisionedServicesPage)
-                }
-              />
-              <LazyRoute
-                path="/provisionedservices/ns/:ns"
-                loader={() =>
-                  import(
-                    './provisioned-services' /* webpackChunkName: "provisionedservices" */
-                  ).then((m) => m.ProvisionedServicesPage)
-                }
-              />
-              <Route path="/provisionedservices" component={NamespaceRedirect} />
-
-              <LazyRoute
-                path="/brokermanagement"
-                loader={() =>
-                  import('./broker-management' /* webpackChunkName: "brokermanagment" */).then(
-                    (m) => m.BrokerManagementPage,
-                  )
-                }
-              />
-
-              <LazyRoute
-                path="/catalog/create-service-instance"
-                exact
-                loader={() =>
-                  import(
-                    './service-catalog/create-instance' /* webpackChunkName: "create-service-instance" */
-                  ).then((m) => m.CreateInstancePage)
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/serviceinstances/:name/create-binding"
-                exact
-                loader={() =>
-                  import(
-                    './service-catalog/create-binding' /* webpackChunkName: "create-binding" */
-                  ).then((m) => m.CreateBindingPage)
-                }
-              />
-              <LazyRoute
-                path="/catalog/instantiate-template"
-                exact
-                loader={() =>
-                  import(
-                    './instantiate-template' /* webpackChunkName: "instantiate-template" */
-                  ).then((m) => m.InstantiateTemplatePage)
-                }
-              />
-
-              <Route
-                path="/k8s/ns/:ns/alertmanagers/:name"
-                exact
-                render={({ match }) => (
-                  <Redirect
-                    to={`/k8s/ns/${match.params.ns}/${referenceForModel(AlertmanagerModel)}/${
-                      match.params.name
-                    }`}
-                  />
-                )}
-              />
-
-              <LazyRoute
-                path="/k8s/all-namespaces/events"
-                exact
-                loader={() =>
-                  import('./events' /* webpackChunkName: "events" */).then((m) =>
-                    NamespaceFromURL(m.EventStreamPage),
-                  )
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/events"
-                exact
-                loader={() =>
-                  import('./events' /* webpackChunkName: "events" */).then((m) =>
-                    NamespaceFromURL(m.EventStreamPage),
-                  )
-                }
-              />
-              <Route path="/search/all-namespaces" exact component={NamespaceFromURL(SearchPage)} />
-              <Route path="/search/ns/:ns" exact component={NamespaceFromURL(SearchPage)} />
-              <Route path="/search" exact component={NamespaceRedirect} />
-
-              <LazyRoute
-                path="/k8s/all-namespaces/import"
-                exact
-                loader={() =>
-                  import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
-                    NamespaceFromURL(m.ImportYamlPage),
-                  )
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/import/"
-                exact
-                loader={() =>
-                  import('./import-yaml' /* webpackChunkName: "import-yaml" */).then((m) =>
-                    NamespaceFromURL(m.ImportYamlPage),
-                  )
-                }
-              />
-
-              {
-                // These pages are temporarily disabled. We need to update the safe resources list.
-                // <LazyRoute path="/k8s/cluster/clusterroles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-                // <LazyRoute path="/k8s/cluster/clusterroles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-              }
-
-              {
-                // <LazyRoute path="/k8s/ns/:ns/roles/:name/add-rule" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-                // <LazyRoute path="/k8s/ns/:ns/roles/:name/:rule/edit" exact loader={() => import('./RBAC' /* webpackChunkName: "rbac" */).then(m => m.EditRulePage)} />
-              }
-
-              <LazyRoute
-                path="/k8s/ns/:ns/secrets/~new/:type"
-                exact
-                kind="Secret"
-                loader={() =>
-                  import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
-                    (m) => m.CreateSecret,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/secrets/:name/edit"
-                exact
-                kind="Secret"
-                loader={() =>
-                  import('./secrets/create-secret' /* webpackChunkName: "create-secret" */).then(
-                    (m) => m.EditSecret,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/secrets/:name/edit-yaml"
-                exact
-                kind="Secret"
-                loader={() => import('./create-yaml').then((m) => m.EditYAMLPage)}
-              />
-
-              <LazyRoute
-                path="/k8s/ns/:ns/routes/~new/form"
-                exact
-                kind="Route"
-                loader={() =>
-                  import('./routes/create-route' /* webpackChunkName: "create-route" */).then(
-                    (m) => m.CreateRoute,
-                  )
-                }
-              />
-
-              <LazyRoute
-                path="/k8s/cluster/rolebindings/~new"
-                exact
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
-                }
-                kind="RoleBinding"
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/rolebindings/~new"
-                exact
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CreateRoleBinding)
-                }
-                kind="RoleBinding"
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/rolebindings/:name/copy"
-                exact
-                kind="RoleBinding"
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/rolebindings/:name/edit"
-                exact
-                kind="RoleBinding"
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
-                }
-              />
-              <LazyRoute
-                path="/k8s/cluster/clusterrolebindings/:name/copy"
-                exact
-                kind="ClusterRoleBinding"
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.CopyRoleBinding)
-                }
-              />
-              <LazyRoute
-                path="/k8s/cluster/clusterrolebindings/:name/edit"
-                exact
-                kind="ClusterRoleBinding"
-                loader={() =>
-                  import('./RBAC' /* webpackChunkName: "rbac" */).then((m) => m.EditRoleBinding)
-                }
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/:plural/:name/attach-storage"
-                exact
-                loader={() =>
-                  import('./storage/attach-storage' /* webpackChunkName: "attach-storage" */).then(
-                    (m) => m.AttachStorage,
-                  )
-                }
-              />
-
-              <LazyRoute
-                path="/k8s/ns/:ns/persistentvolumeclaims/~new/form"
-                exact
-                kind="PersistentVolumeClaim"
-                loader={() =>
-                  import('./storage/create-pvc' /* webpackChunkName: "create-pvc" */).then(
-                    (m) => m.CreatePVC,
-                  )
-                }
-              />
-
-              <LazyRoute
-                path="/monitoring/alerts"
-                exact
-                loader={() =>
-                  import('./monitoring' /* webpackChunkName: "monitoring" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/monitoring/silences"
-                exact
-                loader={() =>
-                  import('./monitoring' /* webpackChunkName: "monitoring" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/monitoring/alertmanageryaml"
-                exact
-                loader={() =>
-                  import('./monitoring' /* webpackChunkName: "monitoring" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/monitoring/alertmanagerconfig"
-                exact
-                loader={() =>
-                  import('./monitoring' /* webpackChunkName: "monitoring" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-              <LazyRoute
-                path="/monitoring/alertmanagerconfig/receivers/~new"
-                exact
-                loader={() =>
-                  import(
-                    './monitoring/alert-manager-receiver-forms' /* webpackChunkName: "monitoring" */
-                  ).then((m) => m.CreateReceiver)
-                }
-              />
-              <LazyRoute
-                path="/monitoring/alertmanagerconfig/receivers/:name/edit"
-                exact
-                loader={() =>
-                  import(
-                    './monitoring/alert-manager-receiver-forms' /* webpackChunkName: "monitoring" */
-                  ).then((m) => m.EditReceiver)
-                }
-              />
-              <LazyRoute
-                path="/monitoring"
-                loader={() =>
-                  import('./monitoring' /* webpackChunkName: "monitoring" */).then(
-                    (m) => m.MonitoringUI,
-                  )
-                }
-              />
-
-              <LazyRoute
-                path="/settings/idp/github"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/github-idp-form' /* webpackChunkName: "github-idp-form" */
-                  ).then((m) => m.AddGitHubPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/gitlab"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/gitlab-idp-form' /* webpackChunkName: "gitlab-idp-form" */
-                  ).then((m) => m.AddGitLabPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/google"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/google-idp-form' /* webpackChunkName: "google-idp-form" */
-                  ).then((m) => m.AddGooglePage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/htpasswd"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/htpasswd-idp-form' /* webpackChunkName: "htpasswd-idp-form" */
-                  ).then((m) => m.AddHTPasswdPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/keystone"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/keystone-idp-form' /* webpackChunkName: "keystone-idp-form" */
-                  ).then((m) => m.AddKeystonePage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/ldap"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/ldap-idp-form' /* webpackChunkName: "ldap-idp-form" */
-                  ).then((m) => m.AddLDAPPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/oidconnect"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/openid-idp-form' /* webpackChunkName: "openid-idp-form" */
-                  ).then((m) => m.AddOpenIDPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/basicauth"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/basicauth-idp-form' /* webpackChunkName: "basicauth-idp-form" */
-                  ).then((m) => m.AddBasicAuthPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/idp/requestheader"
-                exact
-                loader={() =>
-                  import(
-                    './cluster-settings/request-header-idp-form' /* webpackChunkName: "request-header-idp-form" */
-                  ).then((m) => m.AddRequestHeaderPage)
-                }
-              />
-              <LazyRoute
-                path="/settings/cluster"
-                loader={() =>
-                  import(
-                    './cluster-settings/cluster-settings' /* webpackChunkName: "cluster-settings" */
-                  ).then((m) => m.ClusterSettingsPage)
-                }
-              />
-
-              <LazyRoute
-                path={'/k8s/cluster/storageclasses/~new/form'}
-                exact
-                loader={() =>
-                  import('./storage-class-form' /* webpackChunkName: "storage-class-form" */).then(
-                    (m) => m.StorageClassForm,
-                  )
-                }
-              />
-
-              <Route path="/k8s/cluster/:plural" exact component={ResourceListPage} />
-              <LazyRoute
-                path="/k8s/cluster/:plural/~new"
-                exact
-                loader={() =>
-                  import('./create-yaml' /* webpackChunkName: "create-yaml" */).then(
-                    (m) => m.CreateYAML,
-                  )
-                }
-              />
-              <Route path="/k8s/cluster/:plural/:name" component={ResourceDetailsPage} />
-              <LazyRoute
-                path="/k8s/ns/:ns/pods/:podName/containers/:name"
-                loader={() => import('./container').then((m) => m.ContainersDetailsPage)}
-              />
-              <LazyRoute
-                path="/k8s/ns/:ns/:plural/~new"
-                exact
-                loader={() =>
-                  import('./create-yaml' /* webpackChunkName: "create-yaml" */).then((m) =>
-                    NamespaceFromURL(m.CreateYAML),
-                  )
-                }
-              />
-              <Route path="/k8s/ns/:ns/:plural/:name" component={ResourceDetailsPage} />
-              <Route path="/k8s/ns/:ns/:plural" exact component={ResourceListPage} />
-
-              <Route path="/k8s/all-namespaces/:plural" exact component={ResourceListPage} />
-              <Route path="/k8s/all-namespaces/:plural/:name" component={ResourceDetailsPage} />
-
-              <LazyRoute
-                path="/error"
-                exact
-                loader={() =>
-                  import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage)
-                }
-              />
-              <Route path="/" exact component={DefaultPage} />
-
-              <LazyRoute
-                loader={() =>
-                  import('./error' /* webpackChunkName: "error" */).then((m) => m.ErrorPage404)
-                }
-              />
-            </Switch>
-          </div>
-        </div>
-      </PageSection>
-    )),
-  ),
-);
+}))(connectToFlags(...plugins.registry.getRequiredFlags([plugins.isRoutePage]))(AppContents_));
 
 export default AppContents;


### PR DESCRIPTION
Follow up to https://github.com/openshift/console/pull/3066#discussion_r341392636 the `RoutePage` extension now supports gating by Console feature flags.

Entry modules of following plugins were modified to utilize this feature:
- `ceph-storage-plugin` (cc @cloudbehl)
- `kubevirt-plugin` (cc @mareklibra)
- `metal3-plugin` (cc @jtomasek)
- `network-attachment-definition-plugin` (cc @pcbailey)
- `noobaa-storage-plugin` (cc @afreen23)

Entry module of `operator-lifecycle-manager` (cc @alecmerdler) now uses declared consumed extension types (the `as` operator in TypeScript is a "force" cast and should be avoided if possible).

@jtomasek Can you please verify this with existing Metal3 plugin routes?
