### PR TITLE
add shadows to knative service nodes

### DIFF
--- a/frontend/packages/dev-console/src/components/topology2/components/nodes/ApplicationGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology2/components/nodes/ApplicationGroup.tsx
@@ -19,8 +19,9 @@ import {
   hullPath,
 } from '@console/topology';
 import * as classNames from 'classnames';
-import SvgDropShadowFilter from '../../../svg/SvgDropShadowFilter';
 import SvgBoxedText from '../../../svg/SvgBoxedText';
+import NodeShadows, { NODE_SHADOW_FILTER_ID, NODE_SHADOW_FILTER_ID_HOVER } from '../NodeShadows';
+
 import './ApplicationGroup.scss';
 
 type ApplicationGroupProps = {
@@ -28,13 +29,11 @@ type ApplicationGroupProps = {
   droppable?: boolean;
   canDrop?: boolean;
   dropTarget?: boolean;
+  dragging?: boolean;
 } & WithSelectionProps &
   WithDragNodeProps &
   WithDndDropProps &
   WithContextMenuProps;
-
-const FILTER_ID = 'ApplicationGroupShadowFilterId';
-const FILTER_ID_HOVER = 'ApplicationGroupDropShadowFilterId--hover';
 
 type PointWithSize = [number, number, number];
 
@@ -70,6 +69,7 @@ const ApplicationGroup: React.FC<ApplicationGroupProps> = ({
   canDrop,
   dropTarget,
   onContextMenu,
+  dragging,
 }) => {
   const [groupHover, groupHoverRef] = useHover();
   const [groupLabelHover, groupLabelHoverRef] = useHover();
@@ -125,13 +125,14 @@ const ApplicationGroup: React.FC<ApplicationGroupProps> = ({
 
   return (
     <>
-      <SvgDropShadowFilter id={FILTER_ID} />
-      <SvgDropShadowFilter id={FILTER_ID_HOVER} dy={3} stdDeviation={7} floodOpacity={0.24} />
+      <NodeShadows />
       <Layer id="groups">
         <g ref={groupHoverRef} onContextMenu={onContextMenu} onClick={onSelect}>
           <path
             ref={refs}
-            filter={hover ? createSvgIdUrl(FILTER_ID_HOVER) : createSvgIdUrl(FILTER_ID)}
+            filter={createSvgIdUrl(
+              hover || dragging ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID,
+            )}
             className={pathClasses}
             d={pathRef.current}
           />

--- a/frontend/packages/dev-console/src/components/topology2/components/nodes/EventSource.tsx
+++ b/frontend/packages/dev-console/src/components/topology2/components/nodes/EventSource.tsx
@@ -17,6 +17,7 @@ import './EventSource.scss';
 
 export type EventSourceProps = {
   element: Node;
+  dragging?: boolean;
 } & WithSelectionProps &
   WithDragNodeProps &
   WithContextMenuProps;
@@ -27,6 +28,7 @@ const EventSource: React.FC<EventSourceProps> = ({
   onSelect,
   onContextMenu,
   dragNodeRef,
+  dragging,
 }) => {
   const svgAnchorRef = useSvgAnchor();
   const [hover, hoverRef] = useHover();
@@ -46,7 +48,9 @@ const EventSource: React.FC<EventSourceProps> = ({
       <polygon
         className="odc-event-source__bg"
         ref={svgAnchorRef}
-        filter={createSvgIdUrl(hover ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID)}
+        filter={createSvgIdUrl(
+          hover || dragging ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID,
+        )}
         points={`${width / 2}, ${(height - size) / 2} ${width - (width - size) / 2},${height /
           2} ${width / 2},${height - (height - size) / 2} ${(width - size) / 2},${height / 2}`}
       />

--- a/frontend/packages/dev-console/src/components/topology2/components/nodes/KnativeService.tsx
+++ b/frontend/packages/dev-console/src/components/topology2/components/nodes/KnativeService.tsx
@@ -13,9 +13,13 @@ import {
   WithDragNodeProps,
   Layer,
   useSvgAnchor,
+  useHover,
+  createSvgIdUrl,
+  useCombineRefs,
 } from '@console/topology';
 import SvgBoxedText from '../../../svg/SvgBoxedText';
 import Decorator from '../../../topology/shapes/Decorator';
+import NodeShadows, { NODE_SHADOW_FILTER_ID, NODE_SHADOW_FILTER_ID_HOVER } from '../NodeShadows';
 
 import './KnativeService.scss';
 
@@ -36,16 +40,20 @@ const KnativeService: React.FC<EventSourceProps> = ({
   dragging,
   regrouping,
 }) => {
+  const [hover, hoverRef] = useHover();
+  const [innerHover, innerHoverRef] = useHover();
+  const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const trafficAnchor = useSvgAnchor(AnchorEnd.source, 'revision-traffic');
   useAnchor(RectAnchor);
   const { x, y, width, height } = element.getBounds();
   const { data } = element.getData();
 
   return (
-    <g onClick={onSelect} onContextMenu={onContextMenu}>
+    <g ref={hoverRef} onClick={onSelect} onContextMenu={onContextMenu}>
+      <NodeShadows />
       <Layer id={dragging && regrouping ? undefined : 'groups2'}>
         <rect
-          ref={dragNodeRef}
+          ref={nodeRefs}
           className={cx('odc-knative-service', {
             'is-selected': selected,
             'is-dragging': dragging,
@@ -56,6 +64,9 @@ const KnativeService: React.FC<EventSourceProps> = ({
           height={height}
           rx="5"
           ry="5"
+          filter={createSvgIdUrl(
+            hover || innerHover || dragging ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID,
+          )}
         />
       </Layer>
       {data.url ? (


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-2194

To be consistent with the application group, a small shadow is added to the default state of the knative service. On hover a larger shadow is shown.

Normal state with small shadow:
![image](https://user-images.githubusercontent.com/14068621/68248181-4f565980-ffea-11e9-81aa-c45a0922722d.png)

Hover state with larger shadow:
![image](https://user-images.githubusercontent.com/14068621/68248141-41a0d400-ffea-11e9-8db1-a78ade1de601.png)

fyi @serenamarie125 @Veethika 
