### PR TITLE
Bug 1768341: Query Browser: Fix bug where the cursor jumped to the end of the input

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -829,6 +829,7 @@ const Query_: React.FC<QueryProps> = ({
             aria-label={switchLabel}
             id={id}
             isChecked={isEnabled}
+            key={id}
             onChange={toggleIsEnabled}
           />
         </div>
@@ -944,17 +945,15 @@ const RunQueriesButton = connect(
   { runQueries: UIActions.queryBrowserRunQueries },
 )(RunQueriesButton_);
 
-const QueriesList_ = ({ ids, namespace }) => (
+const QueriesList_ = ({ count, namespace }) => (
   <>
-    {_.map(ids, (id, i) => (
-      <Query index={i} key={id} namespace={namespace} />
+    {_.range(count).map((i) => (
+      <Query index={i} key={i} namespace={namespace} />
     ))}
   </>
 );
 const QueriesList = connect(({ UI }: RootState) => ({
-  ids: UI.getIn(['queryBrowser', 'queries'])
-    .map((q) => q.get('id'))
-    .toArray(),
+  count: UI.getIn(['queryBrowser', 'queries']).size,
 }))(QueriesList_);
 
 const TechPreview = () => (

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -36,7 +36,7 @@ export function getDefaultPerspective() {
   return activePerspective || undefined;
 }
 
-const newQueryBrowserQuery = () =>
+const newQueryBrowserQuery = (): ImmutableMap<string, any> =>
   ImmutableMap({
     id: _.uniqueId('query-browser-query'),
     isEnabled: true,
@@ -204,12 +204,13 @@ export default (state: UIState, action: UIAction): UIState => {
           : oldText + newText;
       return state.setIn(['queryBrowser', 'queries', index, 'text'], text);
     }
-    case ActionType.QueryBrowserPatchQuery:
-      return state.mergeIn(
-        ['queryBrowser', 'queries', action.payload.index],
-        ImmutableMap(action.payload.patch),
-      );
-
+    case ActionType.QueryBrowserPatchQuery: {
+      const { index, patch } = action.payload;
+      const query = state.hasIn(['queryBrowser', 'queries', index])
+        ? ImmutableMap(patch)
+        : newQueryBrowserQuery().merge(patch);
+      return state.mergeIn(['queryBrowser', 'queries', index], query);
+    }
     case ActionType.QueryBrowserRunQueries: {
       const queries = state.getIn(['queryBrowser', 'queries']).map((q) => {
         const isEnabled = q.get('isEnabled');


### PR DESCRIPTION
Bug was introduced by PR #3104, which fixed a `Switch` bug.

This commit partially reverts that change and instead fixes the `Switch`
by giving it a `key={id}` attribute and modifying
`ActionType.QueryBrowserPatchQuery` to ensure all queries have an `id`.