### PR TITLE
Bug 1763091: Query Browser: Use different example query for Dev perspective

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -888,7 +888,12 @@ const QueryBrowserWrapper_: React.FC<QueryBrowserWrapperProps> = ({
 
   const insertExampleQuery = () => {
     const index = _.get(focusedQuery, 'index', 0);
-    const text = 'sum(sort_desc(sum_over_time(ALERTS{alertstate="firing"}[24h]))) by (alertname)';
+
+    // Pick a suitable example query based on whether we are limiting results to a single namespace
+    const text = namespace
+      ? 'sum(rate(container_cpu_usage_seconds_total{image!="", container!="POD"}[5m])) by (pod)'
+      : 'sum(sort_desc(sum_over_time(ALERTS{alertstate="firing"}[24h]))) by (alertname)';
+
     patchQuery(index, { isEnabled: true, query: text, text });
   };
 


### PR DESCRIPTION
The Admin perspective example query generally doesn't return any data in
the Dev perspective, so use a different example for Dev.