### PR TITLE
Monitoring: Add missing <title> to Alert and Silence list pages

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -861,6 +861,9 @@ const MonitoringListPage = connect(filtersToProps)(
 
       return (
         <>
+          <Helmet>
+            <title>Alerting</title>
+          </Helmet>
           <div className="co-m-nav-title">
             <PageDescription />
           </div>


### PR DESCRIPTION
Looks like this was accidentally removed.