### PR TITLE
Bug 1769076: Fix top consumer queries

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeGraphs.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeGraphs.tsx
@@ -16,11 +16,11 @@ type NodeGraphsProps = {
 };
 
 const NodeGraphs: React.FC<NodeGraphsProps> = ({ node }) => {
-  const instanceQuery = `{instance='${node.metadata.name}'}`;
+  const instanceQuery = `{instance="${node.metadata.name}"}`;
   const nodeIp = _.find(getNodeAddresses(node), {
     type: 'InternalIP',
   });
-  const ipQuery = nodeIp && `{instance=~'${nodeIp.address}:.*'}`;
+  const ipQuery = nodeIp && `{instance=~"${nodeIp.address}:.*"}`;
 
   return (
     <>
@@ -30,7 +30,7 @@ const NodeGraphs: React.FC<NodeGraphsProps> = ({ node }) => {
             title="Memory Usage"
             humanize={humanizeBinaryBytes}
             byteDataType={ByteDataTypes.BinaryBytes}
-            query={`node_memory_Active_bytes${instanceQuery}`}
+            query={`node_memory_MemTotal_bytes${instanceQuery} - node_memory_MemAvailable_bytes${instanceQuery}`}
           />
         </div>
         <div className="col-md-12 col-lg-4">

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/queries.ts
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/queries.ts
@@ -23,22 +23,23 @@ export enum OverviewQuery {
 
 const top25Queries = {
   [OverviewQuery.PODS_BY_CPU]:
-    'topk(25, sort_desc(sum(rate(container_cpu_usage_seconds_total{container="",pod!=""}[5m])) BY (pod, namespace)))',
+    'topk(25, sort_desc(sum(avg_over_time(pod:container_cpu_usage:sum{container="",pod!=""}[5m])) BY (pod, namespace)))',
   [OverviewQuery.PODS_BY_MEMORY]:
-    'topk(25, sort_desc(sum(container_memory_working_set_bytes{container="",pod!=""}) BY (pod, namespace)))',
+    'topk(25, sort_desc(sum(avg_over_time(container_memory_working_set_bytes{container="",pod!=""}[5m])) BY (pod, namespace)))',
   [OverviewQuery.PODS_BY_STORAGE]:
-    'topk(25, sort_desc(avg by (pod, namespace)(irate(container_fs_io_time_seconds_total{container="POD", pod!=""}[1m]))))',
-  [OverviewQuery.NODES_BY_CPU]: 'topk(5,sort_desc(instance:node_cpu_utilisation:rate1m))',
+    'topk(25, sort_desc(sum(avg_over_time(pod:container_fs_usage_bytes:sum{container="", pod!=""}[5m])) BY (pod, namespace)))',
+  [OverviewQuery.NODES_BY_CPU]:
+    'topk(25, sort_desc(avg_over_time(instance:node_cpu:rate:sum[5m])))',
   [OverviewQuery.NODES_BY_MEMORY]:
-    'topk(25,sort_desc(node_memory_MemTotal_bytes{job="node-exporter"} - node_memory_MemAvailable_bytes{job="node-exporter"}))',
+    'topk(25, sort_desc(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes))',
   [OverviewQuery.NODES_BY_STORAGE]:
-    'topk(25, sort_desc(avg by (instance) (instance_device:node_disk_io_time_seconds:rate1m)))',
+    'topk(25, sort_desc(avg_over_time(instance:node_filesystem_usage:sum[5m])))',
   [OverviewQuery.PROJECTS_BY_CPU]:
-    'topk(25, sort_desc(sum(rate(container_cpu_usage_seconds_total{container="",pod!=""}[5m])) BY (namespace)))',
+    'topk(25, sort_desc(sum(avg_over_time(pod:container_cpu_usage:sum{container="",pod!=""}[5m])) BY (namespace)))',
   [OverviewQuery.PROJECTS_BY_MEMORY]:
-    'topk(25, sort_desc(sum(container_memory_working_set_bytes{container="",pod!=""}) BY (namespace)))',
+    'topk(25, sort_desc(sum(avg_over_time(container_memory_working_set_bytes{container="",pod!=""}[5m])) BY (namespace)))',
   [OverviewQuery.PROJECTS_BY_STORAGE]:
-    'topk(25, sort_desc(avg by (namespace)(irate(container_fs_io_time_seconds_total{container="POD", pod!=""}[1m]))))',
+    'topk(25, sort_desc(sum(avg_over_time(pod:container_fs_usage_bytes:sum{container="", pod!=""}[5m])) BY (namespace)))',
 };
 
 const overviewQueries = {
@@ -52,32 +53,6 @@ const overviewQueries = {
   [OverviewQuery.STORAGE_UTILIZATION]:
     '(sum(node_filesystem_size_bytes) - sum(node_filesystem_free_bytes))',
   [OverviewQuery.STORAGE_TOTAL]: 'sum(node_filesystem_size_bytes)',
-  [OverviewQuery.PODS_BY_CPU]:
-    'sort_desc(sum(rate(container_cpu_usage_seconds_total{container="",pod!=""}[5m])) BY (pod, namespace))',
-  [OverviewQuery.PODS_BY_MEMORY]:
-    'sort_desc(sum(container_memory_working_set_bytes{container="",pod!=""}) BY (pod, namespace))',
-  [OverviewQuery.PODS_BY_STORAGE]:
-    'sort_desc(avg by (pod, namespace)(irate(container_fs_io_time_seconds_total{container="POD", pod!=""}[1m])))',
-  [OverviewQuery.PODS_BY_NETWORK]:
-    'sort_desc(sum by (pod, namespace)(irate(container_network_receive_bytes_total{container="POD", pod!=""}[1m])' +
-    ' + irate(container_network_transmit_bytes_total{container="POD", pod!=""}[1m])))',
-  [OverviewQuery.NODES_BY_CPU]: 'sort_desc(instance:node_cpu_utilisation:rate1m)',
-  [OverviewQuery.NODES_BY_MEMORY]:
-    'sort_desc(node_memory_MemTotal_bytes{job="node-exporter"} - node_memory_MemAvailable_bytes{job="node-exporter"})',
-  [OverviewQuery.NODES_BY_STORAGE]:
-    'sort_desc(avg by (instance) (instance_device:node_disk_io_time_seconds:rate1m))',
-  [OverviewQuery.NODES_BY_NETWORK]:
-    'sort_desc(sum by (instance) (instance:node_network_transmit_bytes_excluding_lo:rate1m+instance:node_network_receive_bytes_excluding_lo:rate1m))',
-};
-
-export const capacityQueries = {
-  [OverviewQuery.MEMORY_TOTAL]: overviewQueries[OverviewQuery.MEMORY_TOTAL],
-  [OverviewQuery.MEMORY_UTILIZATION]: overviewQueries[OverviewQuery.MEMORY_UTILIZATION],
-  [OverviewQuery.NETWORK_TOTAL]: overviewQueries[OverviewQuery.NETWORK_TOTAL],
-  [OverviewQuery.NETWORK_UTILIZATION]: overviewQueries[OverviewQuery.NETWORK_UTILIZATION],
-  [OverviewQuery.CPU_UTILIZATION]: overviewQueries[OverviewQuery.CPU_UTILIZATION],
-  [OverviewQuery.STORAGE_UTILIZATION]: overviewQueries[OverviewQuery.STORAGE_UTILIZATION],
-  [OverviewQuery.STORAGE_TOTAL]: overviewQueries[OverviewQuery.STORAGE_TOTAL],
 };
 
 export const utilizationQueries = {
@@ -93,20 +68,6 @@ export const utilizationQueries = {
     utilization: overviewQueries[OverviewQuery.STORAGE_UTILIZATION],
     total: overviewQueries[OverviewQuery.STORAGE_TOTAL],
   },
-};
-
-export const topConsumersQueries = {
-  [OverviewQuery.PODS_BY_CPU]: overviewQueries[OverviewQuery.PODS_BY_CPU],
-  [OverviewQuery.PODS_BY_MEMORY]: overviewQueries[OverviewQuery.PODS_BY_MEMORY],
-  [OverviewQuery.PODS_BY_STORAGE]: overviewQueries[OverviewQuery.PODS_BY_STORAGE],
-  [OverviewQuery.PODS_BY_NETWORK]: overviewQueries[OverviewQuery.PODS_BY_NETWORK],
-  [OverviewQuery.NODES_BY_CPU]: overviewQueries[OverviewQuery.NODES_BY_CPU],
-  [OverviewQuery.NODES_BY_MEMORY]: overviewQueries[OverviewQuery.NODES_BY_MEMORY],
-  [OverviewQuery.NODES_BY_STORAGE]: overviewQueries[OverviewQuery.NODES_BY_STORAGE],
-  [OverviewQuery.NODES_BY_NETWORK]: overviewQueries[OverviewQuery.NODES_BY_NETWORK],
-  [OverviewQuery.PROJECTS_BY_CPU]: overviewQueries[OverviewQuery.PROJECTS_BY_CPU],
-  [OverviewQuery.PROJECTS_BY_MEMORY]: overviewQueries[OverviewQuery.PROJECTS_BY_MEMORY],
-  [OverviewQuery.PROJECTS_BY_STORAGE]: overviewQueries[OverviewQuery.PROJECTS_BY_STORAGE],
 };
 
 export const top25ConsumerQueries = {

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/utilization-card.tsx
@@ -15,18 +15,12 @@ import {
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import { isDashboardsOverviewUtilizationItem } from '@console/plugin-sdk';
 import { DashboardItemProps, withDashboardResources } from '../../with-dashboard-resources';
-import {
-  humanizeBinaryBytes,
-  humanizeCpuCores,
-  humanizeSeconds,
-  secondsToNanoSeconds,
-} from '../../../utils/units';
+import { humanizeBinaryBytes, humanizeCpuCores } from '../../../utils/units';
 import { getRangeVectorStats, getInstantVectorStats } from '../../../graphs/utils';
 import { Dropdown } from '../../../utils/dropdown';
 import { OverviewQuery, utilizationQueries, top25ConsumerQueries } from './queries';
 import { connectToFlags, FlagsObject, WithFlagsProps } from '../../../../reducers/features';
 import * as plugins from '../../../../plugins';
-import { Humanize } from '../../../utils/types';
 import { NodeModel, PodModel, ProjectModel } from '../../../../models';
 
 const metricDurations = [ONE_HR, SIX_HR, TWENTY_FOUR_HR];
@@ -102,8 +96,6 @@ const getQueries = (flags: FlagsObject) => {
     });
   return _.defaults(pluginQueries, utilizationQueries);
 };
-
-const humanizeFromSeconds: Humanize = (value) => humanizeSeconds(secondsToNanoSeconds(value));
 
 const UtilizationCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
   watchPrometheus,
@@ -192,7 +184,7 @@ const UtilizationCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
         title="CPU"
         current={current}
         consumers={cpuQueriesPopup}
-        humanize={humanizeFromSeconds}
+        humanize={humanizeCpuCores}
       />
     ),
     [],
@@ -216,7 +208,7 @@ const UtilizationCard_: React.FC<DashboardItemProps & WithFlagsProps> = ({
         title="Disk Usage"
         current={current}
         consumers={storageQueriesPopup}
-        humanize={humanizeFromSeconds}
+        humanize={humanizeBinaryBytes}
       />
     ),
     [],

--- a/frontend/public/components/dashboard/project-dashboard/queries.ts
+++ b/frontend/public/components/dashboard/project-dashboard/queries.ts
@@ -22,10 +22,10 @@ const queries = {
 
 const top25Queries = {
   [ProjectQueries.PODS_BY_CPU]: _.template(
-    `topk(25, sort_desc(sum(rate(container_cpu_usage_seconds_total{container="",pod!="",namespace='<%= project %>'}[5m])) BY (pod, namespace)))`,
+    `topk(25, sort_desc(sum(avg_over_time(pod:container_cpu_usage:sum{container="",pod!="",namespace='<%= project %>'}[5m])) BY (pod, namespace)))`,
   ),
   [ProjectQueries.PODS_BY_MEMORY]: _.template(
-    `topk(25, sort_desc(sum(container_memory_working_set_bytes{container="",pod!="",namespace='<%= project %>'}) BY (pod, namespace)))`,
+    `topk(25, sort_desc(sum(avg_over_time(container_memory_working_set_bytes{container="",pod!="",namespace='<%= project %>'}[5m])) BY (pod, namespace)))`,
   ),
 };
 

--- a/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
@@ -13,14 +13,7 @@ import {
   UTILIZATION_QUERY_HOUR_MAP,
 } from '@console/shared/src/components/dashboard/utilization-card/dropdown-value';
 import { Dropdown } from '../../utils/dropdown';
-import {
-  humanizeCpuCores,
-  humanizeNumber,
-  humanizeBinaryBytes,
-  Humanize,
-  humanizeSeconds,
-  secondsToNanoSeconds,
-} from '../../utils';
+import { humanizeCpuCores, humanizeNumber, humanizeBinaryBytes } from '../../utils';
 import { getRangeVectorStats } from '../../graphs/utils';
 import { PrometheusResponse } from '../../graphs';
 import { ProjectDashboardContext } from './project-dashboard-context';
@@ -32,8 +25,6 @@ import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 
 const metricDurations = [ONE_HR, SIX_HR, TWENTY_FOUR_HR];
 const metricDurationsOptions = _.zipObject(metricDurations, metricDurations);
-
-const humanizeFromSeconds: Humanize = (value) => humanizeSeconds(secondsToNanoSeconds(value));
 
 export const UtilizationCard = withDashboardResources(
   ({ watchPrometheus, stopWatchPrometheusQuery, prometheusResults }: DashboardItemProps) => {
@@ -88,7 +79,7 @@ export const UtilizationCard = withDashboardResources(
               metric: 'pod',
             },
           ]}
-          humanize={humanizeFromSeconds}
+          humanize={humanizeCpuCores}
           namespace={projectName}
         />
       ),


### PR DESCRIPTION
 - use avg instead of irate
 - get values in cores for CPU metrics
 - get values in bytes for storage usage

@kyoto can you please take a look ? I changed `irate`/`rate` to `avg_over_time` as I think that one is correct.