### PR TITLE
clean up deploymentKindMap usage

### DIFF
--- a/frontend/packages/console-shared/src/constants/pod.ts
+++ b/frontend/packages/console-shared/src/constants/pod.ts
@@ -1,10 +1,3 @@
-import {
-  DeploymentModel,
-  DaemonSetModel,
-  StatefulSetModel,
-  DeploymentConfigModel,
-} from '@console/internal/models';
-
 export const podColor = {
   Running: '#0066CC',
   'Not Ready': '#519DE9',
@@ -18,27 +11,4 @@ export const podColor = {
   'Scaled to 0': '#FFFFFF',
   Idle: '#FFFFFF',
   'Autoscaled to 0': '#FFFFFF',
-};
-
-export const deploymentKindMap = {
-  deployments: {
-    dcKind: DeploymentModel.kind,
-    rcKind: 'ReplicaSet',
-    rController: 'replicaSets',
-  },
-  daemonSets: {
-    dcKind: DaemonSetModel.kind,
-    rcKind: 'ReplicaSet',
-    rController: 'replicaSets',
-  },
-  statefulSets: {
-    dcKind: StatefulSetModel.kind,
-    rcKind: 'ReplicaSet',
-    rController: 'replicaSets',
-  },
-  deploymentConfigs: {
-    dcKind: DeploymentConfigModel.kind,
-    rcKind: 'ReplicationController',
-    rController: 'replicationControllers',
-  },
 };

--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -1,7 +1,6 @@
 import * as _ from 'lodash';
 import { DeploymentConfigModel, DeploymentModel } from '@console/internal/models';
 import { PodRCData, PodRingResources, PodRingData } from '../types';
-import { deploymentKindMap } from '../constants';
 import { TransformResourceData } from './resource-utils';
 
 const applyPods = (podsData: PodRingData, dc: PodRCData) => {
@@ -25,14 +24,14 @@ const applyPods = (podsData: PodRingData, dc: PodRCData) => {
 
 export const transformPodRingData = (resources: PodRingResources, kind: string): PodRingData => {
   const deploymentKinds = {
-    Deployment: 'deployments',
-    DeploymentConfig: 'deploymentConfigs',
+    [DeploymentModel.kind]: 'deployments',
+    [DeploymentConfigModel.kind]: 'deploymentConfigs',
   };
 
   const targetDeployment = deploymentKinds[kind];
   const transformResourceData = new TransformResourceData(resources);
 
-  if (!deploymentKindMap[targetDeployment]) {
+  if (!targetDeployment) {
     throw new Error(`Invalid target deployment resource: (${targetDeployment})`);
   }
   if (_.isEmpty(resources[targetDeployment].data)) {
@@ -40,16 +39,15 @@ export const transformPodRingData = (resources: PodRingResources, kind: string):
   }
 
   const podsData: PodRingData = {};
-  const targetDeploymentsKind = deploymentKindMap[targetDeployment].dcKind;
   const resourceData = resources[targetDeployment].data;
 
-  if (targetDeploymentsKind === DeploymentConfigModel.kind) {
+  if (kind === DeploymentConfigModel.kind) {
     return transformResourceData
       .getPodsForDeploymentConfigs(resourceData)
       .reduce(applyPods, podsData);
   }
 
-  if (targetDeploymentsKind === DeploymentModel.kind) {
+  if (kind === DeploymentModel.kind) {
     return transformResourceData.getPodsForDeployments(resourceData).reduce(applyPods, podsData);
   }
   return podsData;

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
@@ -30,19 +30,6 @@ describe('TopologyUtils ', () => {
     expect(transformTopologyData(resources, ['deployments'])).toBeTruthy();
   });
 
-  it('should throw an error, if the invalid target deployment string is provided', () => {
-    const invalidTargetDeployment = ['dconfig']; // valid values are 'deployments' or 'deploymentConfigs'
-    expect(() => {
-      transformTopologyData(resources, invalidTargetDeployment);
-    }).toThrowError(`Invalid target deployment resource: (${invalidTargetDeployment})`);
-  });
-
-  it('should not throw an error, if the valid target deployment string is provided', () => {
-    const validTargetDeployment = ['deployments']; // valid values are 'deployments' or 'deploymentConfigs'
-    expect(() => {
-      transformTopologyData(resources, validTargetDeployment);
-    }).not.toThrowError(`Invalid target deployment resource: (${validTargetDeployment})`);
-  });
   it('should return graph and topology data', () => {
     expect(transformTopologyData(resources, ['deployments'])).toEqual(topologyData);
   });

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { K8sResourceKind, modelFor, RouteKind, DeploymentKind } from '@console/internal/module/k8s';
 import { getRouteWebURL } from '@console/internal/components/routes';
-import { TransformResourceData, isKnativeServing, deploymentKindMap } from '@console/shared';
+import { TransformResourceData, isKnativeServing } from '@console/shared';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import {
   tranformKnNodeData,
@@ -349,9 +349,6 @@ export const transformTopologyData = (
   );
 
   _.forEach(transformBy, (key) => {
-    if (!deploymentKindMap[key]) {
-      throw new Error(`Invalid target deployment resource: (${key})`);
-    }
     if (!_.isEmpty(resources[key].data)) {
       // filter data based on the active application
       const resourceData = filterBasedOnActiveApplication(resources[key].data, application);


### PR DESCRIPTION
This PR removes the usage of deploymentKindMap. After the topology-utils refactor `deploymentKindMap` is used for some basic logic that can be accomplished without it. The main use of `deploymentKindMap` was to determine whether to look for `ReplicationController` or `ReplicaSet` to get the pods of a resource. But this is not needed anymore since we have a separate utils `resource-utils` which takes care of that logic.

ODC-bug: https://jira.coreos.com/browse/ODC-2222