### PR TITLE
Bug 1775131: Fix downstream/upstream Windows Tools CD container names

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/cdrom-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/cdrom-modal.tsx
@@ -37,6 +37,7 @@ export const CDRomModal = withHandlePromise((props: CDRomModalProps) => {
     errorMessage,
     persistentVolumeClaims,
     storageClasses,
+    winToolsContainer,
     cancel,
     close,
   } = props;
@@ -153,7 +154,8 @@ export const CDRomModal = withHandlePromise((props: CDRomModalProps) => {
   const isFormInvalid =
     !!cdsValue.find((vol) => !vol.isURLValid) ||
     !!cdsValue.find((cd) => cd.type === StorageType.PVC && !cd.pvc) ||
-    !!cdsValue.find((cd) => cd.type === StorageType.URL && !cd.storageClass);
+    !!cdsValue.find((cd) => cd.type === StorageType.URL && !cd.storageClass) ||
+    !!cdsValue.find((cd) => cd.type === StorageType.WINTOOLS && !cd.windowsTools);
 
   return (
     <div className="modal-content">
@@ -175,6 +177,7 @@ export const CDRomModal = withHandlePromise((props: CDRomModalProps) => {
                 pvcs={persistentVolumeClaims}
                 usedPVCs={usedPVCs}
                 storageClasses={storageClasses}
+                winToolsContainer={winToolsContainer}
                 index={i}
                 isWindows={windowsBool}
                 inProgress={inProgress}
@@ -231,4 +234,5 @@ type CDRomModalProps = HandlePromiseProps &
     vmLikeEntity: VMLikeEntityKind;
     persistentVolumeClaims?: FirehoseResult<VMKind[]>;
     storageClasses?: FirehoseResult<VMKind[]>;
+    winToolsContainer: string;
   };

--- a/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/cdrom-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/cdrom-row.tsx
@@ -16,14 +16,8 @@ import { PersistentVolumeClaimModel, StorageClassModel } from '@console/internal
 import { FirehoseResult } from '@console/internal/components/utils';
 import { K8sResourceSelectRow } from '../../form/k8s-resource-select-row';
 import { VMKind } from '../../../types';
-import {
-  StorageType,
-  sourceDict,
-  CD,
-  CD_SIZE,
-  CD_STORAGE_CLASS,
-  WINTOOLS_CONTAINER_NAMES,
-} from './constants';
+import { FormSelectPlaceholderOption } from '../../form/form-select-placeholder-option';
+import { StorageType, sourceDict, CD, CD_SIZE, CD_STORAGE_CLASS } from './constants';
 
 export const CDRomRow: React.FC<CDRomRowProps> = ({
   cd,
@@ -36,6 +30,7 @@ export const CDRomRow: React.FC<CDRomRowProps> = ({
   onDelete,
   isWindows,
   inProgress,
+  winToolsContainer,
 }) => {
   const {
     name,
@@ -50,7 +45,6 @@ export const CDRomRow: React.FC<CDRomRowProps> = ({
     ejected,
     isInVM,
   } = cd;
-  const { upstream } = WINTOOLS_CONTAINER_NAMES;
 
   if (isInVM && !ejected)
     return (
@@ -189,7 +183,12 @@ export const CDRomRow: React.FC<CDRomRowProps> = ({
               value={windowsTools}
               onChange={(v) => onChange(name, StorageType.WINTOOLS, v)}
             >
-              <FormSelectOption key={upstream} value={upstream} label={upstream} />
+              <FormSelectPlaceholderOption placeholder="--- Select Windows Tools Container ---" />
+              <FormSelectOption
+                key={winToolsContainer}
+                value={winToolsContainer}
+                label={winToolsContainer}
+              />
             </FormSelect>
           </FormGroup>
         )}
@@ -207,6 +206,7 @@ export type CDRomRowProps = {
   cd: CD;
   pvcs: FirehoseResult<VMKind[]>;
   storageClasses: FirehoseResult<VMKind[]>;
+  winToolsContainer: string;
   usedPVCs: string[];
   index: number;
   onChange: (cdName: string, key: string, value: string) => void;

--- a/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/constants.ts
@@ -26,9 +26,14 @@ export type CDMap = {
 
 export const CD_SIZE = 'size';
 export const CD_STORAGE_CLASS = 'storageClass';
+
 export const WINTOOLS_CONTAINER_NAMES = {
-  downstream: 'virtio-win-container',
-  upstream: 'kubevirt/virtio-container-disk',
+  openshift: 'virtio-win-container',
+  ocp: 'virtio-win-container',
+  online: 'virtio-win-container',
+  dedicated: 'virtio-win-container',
+  azure: 'virtio-win-container',
+  okd: 'kubevirt/virtio-container-disk',
 };
 
 export const initialDisk = {

--- a/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/index.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/index.tsx
@@ -7,9 +7,13 @@ import { VMLikeEntityKind } from '../../../types';
 import { asVM } from '../../../selectors/vm';
 import { V1alpha1DataVolume } from '../../../types/vm/disk/V1alpha1DataVolume';
 import { CDRomModal } from './cdrom-modal';
+import { WINTOOLS_CONTAINER_NAMES } from './constants';
 
 const CDRomModalFirehose: React.FC<CDRomModalFirehoseProps> = (props) => {
   const { vmLikeEntity } = props;
+
+  const winToolsContainer =
+    WINTOOLS_CONTAINER_NAMES[window.SERVER_FLAGS.branding] || WINTOOLS_CONTAINER_NAMES.okd;
 
   const resources = [
     {
@@ -27,7 +31,7 @@ const CDRomModalFirehose: React.FC<CDRomModalFirehoseProps> = (props) => {
 
   return (
     <Firehose resources={resources}>
-      <CDRomModal {...props} />
+      <CDRomModal winToolsContainer={winToolsContainer} {...props} />
     </Firehose>
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
@@ -62,12 +62,7 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
     >
       {submitButtonText}
     </Button>
-    <Button
-      variant={ButtonVariant.link}
-      onClick={onCancel}
-      id={prefixedID(id, 'cancel')}
-      isDisabled={isDisabled}
-    >
+    <Button variant={ButtonVariant.link} onClick={onCancel} id={prefixedID(id, 'cancel')}>
       {cancelButtonText}
     </Button>
     {inProgress && <LoadingInline />}

--- a/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-cdrom-patches.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-cdrom-patches.ts
@@ -6,11 +6,7 @@ import {
 } from 'kubevirt-web-ui-components';
 import { getName } from '@console/shared';
 import { Volume, k8sGet } from '@console/internal/module/k8s';
-import {
-  CD,
-  WINTOOLS_CONTAINER_NAMES,
-  StorageType,
-} from '../../../components/modals/cdrom-vm-modal/constants';
+import { CD, StorageType } from '../../../components/modals/cdrom-vm-modal/constants';
 import { DataVolumeWrapper } from '../../wrapper/vm/data-volume-wrapper';
 import {
   getDefaultSCAccessMode,
@@ -56,7 +52,6 @@ export const getCDsPatch = async (vm: VMLikeEntityKind, cds: CD[]) => {
     .filter((cd) => cd.changed)
     .forEach(
       ({ name, pvc, type, bootOrder, bus, container, windowsTools, url, storageClass, size }) => {
-        const windowsTool = windowsTools || WINTOOLS_CONTAINER_NAMES.upstream;
         const existingCD = !!bootOrder;
 
         const disk: CD = {
@@ -119,7 +114,7 @@ export const getCDsPatch = async (vm: VMLikeEntityKind, cds: CD[]) => {
           volume = { name, containerDisk: { image: container } };
         }
         if (type === StorageType.WINTOOLS) {
-          volume = { name, containerDisk: { image: windowsTool } };
+          volume = { name, containerDisk: { image: windowsTools } };
         }
 
         const restOfDisks = DISKS.filter((vol) => vol.name !== name);


### PR DESCRIPTION
- Distinct between downstream/upstream Windows Tools CD container names
- Fix Cancel button of the `ModalFooter` being disabled when only the Submit button should be disabled
