### PR TITLE
Bug 1769391:  Allow all tabs to scroll to fix bug at mobile

### DIFF
--- a/frontend/__tests__/components/cluster-settings.spec.tsx
+++ b/frontend/__tests__/components/cluster-settings.spec.tsx
@@ -82,12 +82,6 @@ describe('Cluster Settings page', () => {
       wrapper
         .find(HorizontalNav)
         .at(0)
-        .props().hideDivider,
-    ).toBe(true);
-    expect(
-      wrapper
-        .find(HorizontalNav)
-        .at(0)
         .props().pages[0].name,
     ).toBe('Overview');
     expect(

--- a/frontend/packages/dev-console/src/components/topology/TopologyApplicationResources.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyApplicationResources.tsx
@@ -25,7 +25,7 @@ const TopologyApplicationResources: React.FC<TopologyApplicationResourcesProps> 
 
   return (
     <>
-      <div
+      <ul
         className={classNames(
           'co-m-horizontal-nav__menu',
           'co-m-horizontal-nav__menu--within-sidebar',
@@ -33,12 +33,10 @@ const TopologyApplicationResources: React.FC<TopologyApplicationResourcesProps> 
           'odc-application-resource-tab',
         )}
       >
-        <ul className="co-m-horizontal-nav__menu-primary">
-          <li className="co-m-horizontal-nav__menu-item">
-            <button type="button">Resources</button>
-          </li>
-        </ul>
-      </div>
+        <li className="co-m-horizontal-nav__menu-item">
+          <button type="button">Resources</button>
+        </li>
+      </ul>
       {_.map(_.keys(resourcesData), (key) => (
         <ApplicationGroupResource
           key={`${group}-${key}`}

--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -3,16 +3,22 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: ($grid-gutter-width / 2);
 .co-m-horizontal-nav__menu {
   border-bottom: 1px solid $color-grey-background-border;
   display: flex;
+  list-style: none;
+  margin: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0;
+  -webkit-overflow-scrolling: touch;
   white-space: nowrap;
   @media (min-width: $grid-float-breakpoint) {
     padding-left: $co-m-horizontal-nav__menu-item-link-padding-lr;
-    padding-right: ($co-m-horizontal-nav__menu-item-link-padding-lr * 2);
   }
   &--within-sidebar {
     border-top: 1px solid $color-grey-background-border;
     margin-bottom: $grid-gutter-width;
     margin-left: -($grid-gutter-width / 2);
     margin-right: -($grid-gutter-width / 2);
+    overflow: visible; // so focus indicator is not clipped since these don't need to scroll
     @media (min-width: $grid-float-breakpoint) {
       margin-left: -($grid-gutter-width);
       margin-right: -($grid-gutter-width);
@@ -26,25 +32,7 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: ($grid-gutter-width / 2);
     margin-left: 0;
     margin-right: 0;
     padding-left: 5px;
-    padding-right: 5px;
   }
-}
-
-.co-m-horizontal-nav__menu-primary {
-  display: flex;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.co-m-horizontal-nav__menu-secondary {
-  display: flex;
-  list-style: none;
-  margin: 0 0 -1px; // -1px bottom so co-m-horizontal-nav__menu-item *::after are fully visible
-  overflow-x: auto;
-  overflow-y: hidden;
-  padding: 0;
-  -webkit-overflow-scrolling: touch;
 }
 
 .co-m-horizontal-nav__menu-item {
@@ -67,7 +55,7 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: ($grid-gutter-width / 2);
       }
     }
     &::after {
-      bottom: -1px;
+      bottom: 0;
       content: "";
       display: block;
       height: 2px;
@@ -85,9 +73,12 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: ($grid-gutter-width / 2);
       }
     }
   }
-}
-
-.co-m-horizontal-nav__menu-item--divider {
-  border-left: 1px solid $color-grey-background-border;
-  margin: 0 10px;
+  &:last-child {
+    @media (min-width: $grid-float-breakpoint) {
+      a,
+      button {
+        margin-right: $co-m-horizontal-nav__menu-item-link-padding-lr;
+      }
+    }
+  }
 }

--- a/frontend/public/components/broker-management.tsx
+++ b/frontend/public/components/broker-management.tsx
@@ -19,7 +19,7 @@ const pages = [
 export const BrokerManagementPage: React.SFC<BrokerManagementPageProps> = ({ match }) => (
   <>
     <PageHeading detail={true} title="Broker Management" />
-    <HorizontalNav pages={pages} match={match} hideDivider noStatusBox={true} />
+    <HorizontalNav pages={pages} match={match} noStatusBox={true} />
   </>
 );
 

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -53,7 +53,6 @@ const ChargebackNavBar: React.SFC<{ match: { url: string } }> = (props) => (
         .split('/')
         .slice(0, -1)
         .join('/')}
-      hideDivider
     />
   </div>
 );

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -411,7 +411,7 @@ export const ClusterSettingsPage: React.SFC<ClusterSettingsPageProps> = ({ match
         </h1>
       </div>
       <Firehose resources={resources}>
-        <HorizontalNav pages={pages} match={match} resourceKeys={resourceKeys} hideDivider />
+        <HorizontalNav pages={pages} match={match} resourceKeys={resourceKeys} />
       </Firehose>
     </>
   );

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1408,47 +1408,44 @@ const AlertingPage: React.SFC<AlertingPageProps> = ({ match }) => {
           </div>
         </h1>
       </div>
-      <div className="co-m-horizontal-nav__menu">
-        <ul className="co-m-horizontal-nav__menu-primary">
-          {(match.url === alertPath || match.url === silencePath) && (
-            <>
-              <li
-                className={classNames('co-m-horizontal-nav__menu-item', {
-                  'co-m-horizontal-nav-item--active': match.url === alertPath,
-                })}
-              >
-                <Link to={alertPath}>Alerts</Link>
-              </li>
-              <li
-                className={classNames('co-m-horizontal-nav__menu-item', {
-                  'co-m-horizontal-nav-item--active': match.url === silencePath,
-                })}
-              >
-                <Link to={silencePath}>Silences</Link>
-              </li>
-            </>
-          )}
-          {(match.url === ConfigPath || match.url === YAMLPath) && (
-            <>
-              <li
-                className={classNames('co-m-horizontal-nav__menu-item', {
-                  'co-m-horizontal-nav-item--active': match.url === ConfigPath,
-                })}
-              >
-                <Link to={ConfigPath}>Overview</Link>
-              </li>
-              <li
-                className={classNames('co-m-horizontal-nav__menu-item', {
-                  'co-m-horizontal-nav-item--active': match.url === YAMLPath,
-                })}
-              >
-                <Link to={YAMLPath}>YAML</Link>
-              </li>
-            </>
-          )}
-          <li className="co-m-horizontal-nav__menu-item co-m-horizontal-nav__menu-item--divider" />
-        </ul>
-      </div>
+      <ul className="co-m-horizontal-nav__menu">
+        {(match.url === alertPath || match.url === silencePath) && (
+          <>
+            <li
+              className={classNames('co-m-horizontal-nav__menu-item', {
+                'co-m-horizontal-nav-item--active': match.url === alertPath,
+              })}
+            >
+              <Link to={alertPath}>Alerts</Link>
+            </li>
+            <li
+              className={classNames('co-m-horizontal-nav__menu-item', {
+                'co-m-horizontal-nav-item--active': match.url === silencePath,
+              })}
+            >
+              <Link to={silencePath}>Silences</Link>
+            </li>
+          </>
+        )}
+        {(match.url === ConfigPath || match.url === YAMLPath) && (
+          <>
+            <li
+              className={classNames('co-m-horizontal-nav__menu-item', {
+                'co-m-horizontal-nav-item--active': match.url === ConfigPath,
+              })}
+            >
+              <Link to={ConfigPath}>Overview</Link>
+            </li>
+            <li
+              className={classNames('co-m-horizontal-nav__menu-item', {
+                'co-m-horizontal-nav-item--active': match.url === YAMLPath,
+              })}
+            >
+              <Link to={YAMLPath}>YAML</Link>
+            </li>
+          </>
+        )}
+      </ul>
       <Switch>
         <Route path="/monitoring/alerts" exact component={AlertsPage} />
         <Route path="/monitoring/silences" exact component={SilencesPage} />

--- a/frontend/public/components/provisioned-services.tsx
+++ b/frontend/public/components/provisioned-services.tsx
@@ -19,7 +19,7 @@ const pages = [
 export const ProvisionedServicesPage: React.SFC<ProvisionedServicesPageProps> = ({ match }) => (
   <>
     <PageHeading detail={true} title="Provisioned Services" />
-    <HorizontalNav pages={pages} match={match} hideDivider noStatusBox={true} />
+    <HorizontalNav pages={pages} match={match} noStatusBox={true} />
   </>
 );
 

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -130,68 +130,29 @@ export const navFactory: NavFactory = {
   }),
 };
 
-export const NavBar = withRouter<NavBarProps>(({ pages, basePath, hideDivider }) => {
-  // These tabs go before the divider
-  const before = ['', 'edit', 'yaml'];
-  const divider = (
-    <li
-      className="co-m-horizontal-nav__menu-item co-m-horizontal-nav__menu-item--divider"
-      key="_divider"
-    />
-  );
+export const NavBar = withRouter<NavBarProps>(({ pages, basePath }) => {
   basePath = basePath.replace(/\/$/, '');
 
-  const primaryTabs = (
-    <ul className="co-m-horizontal-nav__menu-primary">
-      {pages
-        .filter(
-          ({ href }, i, all) => before.includes(href) || before.includes(_.get(all[i + 1], 'href')),
-        )
-        .map(({ name, href, path }) => {
-          const matchUrl = matchPath(location.pathname, {
-            path: `${basePath}/${path || href}`,
-            exact: true,
-          });
-          const klass = classNames('co-m-horizontal-nav__menu-item', {
-            'co-m-horizontal-nav-item--active': matchUrl && matchUrl.isExact,
-          });
-          return (
-            <li className={klass} key={name}>
-              <Link to={`${basePath}/${href}`}>{name}</Link>
-            </li>
-          );
-        })}
-      {!hideDivider && divider}
-    </ul>
+  const tabs = (
+    <>
+      {pages.map(({ name, href, path }) => {
+        const matchUrl = matchPath(location.pathname, {
+          path: `${basePath}/${path || href}`,
+          exact: true,
+        });
+        const klass = classNames('co-m-horizontal-nav__menu-item', {
+          'co-m-horizontal-nav-item--active': matchUrl && matchUrl.isExact,
+        });
+        return (
+          <li className={klass} key={name}>
+            <Link to={`${basePath}/${href}`}>{name}</Link>
+          </li>
+        );
+      })}
+    </>
   );
 
-  const secondaryTabs = (
-    <ul className="co-m-horizontal-nav__menu-secondary">
-      {pages
-        .slice(React.Children.count(primaryTabs.props.children) - 1)
-        .map(({ name, href, path }) => {
-          const matchUrl = matchPath(location.pathname, {
-            path: `${basePath}/${path || href}`,
-            exact: true,
-          });
-          const klass = classNames('co-m-horizontal-nav__menu-item', {
-            'co-m-horizontal-nav-item--active': matchUrl && matchUrl.isExact,
-          });
-          return (
-            <li className={klass} key={name}>
-              <Link to={`${basePath}/${href}`}>{name}</Link>
-            </li>
-          );
-        })}
-    </ul>
-  );
-
-  return (
-    <div className="co-m-horizontal-nav__menu">
-      {primaryTabs}
-      {secondaryTabs}
-    </div>
-  );
+  return <ul className="co-m-horizontal-nav__menu">{tabs}</ul>;
 });
 NavBar.displayName = 'NavBar';
 
@@ -259,9 +220,7 @@ export const HorizontalNav: React.FC<HorizontalNavProps> = React.memo((props) =>
   return (
     <div className={props.className}>
       <div className="co-m-horizontal-nav">
-        {!props.hideNav && (
-          <NavBar pages={pages} basePath={props.match.url} hideDivider={props.hideDivider} />
-        )}
+        {!props.hideNav && <NavBar pages={pages} basePath={props.match.url} />}
         {renderContent(routes)}
       </div>
     </div>
@@ -275,7 +234,6 @@ export type PodsComponentProps = {
 export type NavBarProps = {
   pages: Page[];
   basePath: string;
-  hideDivider?: boolean;
   history: History;
   location: Location<any>;
   match: match<any>;
@@ -290,7 +248,6 @@ export type HorizontalNavProps = {
   match: any;
   resourceKeys?: string[];
   hideNav?: boolean;
-  hideDivider?: boolean;
   EmptyMsg?: React.ComponentType<any>;
   noStatusBox?: boolean;
   customData?: any;

--- a/frontend/public/components/utils/simple-tab-nav.tsx
+++ b/frontend/public/components/utils/simple-tab-nav.tsx
@@ -50,18 +50,16 @@ export class SimpleTabNav extends React.Component<SimpleTabNavProps, SimpleTabNa
 
     return (
       <>
-        <div className={classNames('co-m-horizontal-nav__menu', additionalClassNames)}>
-          <ul className="co-m-horizontal-nav__menu-primary">
-            {_.map(tabs, (tab) => (
-              <SimpleTab
-                active={selectedTab.name === tab.name}
-                key={tab.name}
-                onClick={this.onClickTab}
-                title={tab.name}
-              />
-            ))}
-          </ul>
-        </div>
+        <ul className={classNames('co-m-horizontal-nav__menu', additionalClassNames)}>
+          {_.map(tabs, (tab) => (
+            <SimpleTab
+              active={selectedTab.name === tab.name}
+              key={tab.name}
+              onClick={this.onClickTab}
+              title={tab.name}
+            />
+          ))}
+        </ul>
         <Component {...tabProps} />
       </>
     );


### PR DESCRIPTION
By removing the divider between primary and secondary tabs and allowing all tabs to scroll, the issue where secondary tabs may not be visible at mobile is resolved.

![EhSNpQ66Gy](https://user-images.githubusercontent.com/895728/68316296-3780e300-0087-11ea-925f-63c815487c44.gif)
![rtuABrA0ck](https://user-images.githubusercontent.com/895728/68316309-3d76c400-0087-11ea-892c-8d174f616fdb.gif)

Windows where scrollbars are visible
![Screen Shot 2019-11-06 at 10 05 50 AM](https://user-images.githubusercontent.com/895728/68316499-9181a880-0087-11ea-88cd-2f126cae83cf.png)
