### PR TITLE
Bug 1768771: network attachment definition static models missing crd flag

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/vm-wizard-nic-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/vm-wizard-nic-modal-enhanced.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Firehose, FirehoseResult } from '@console/internal/components/utils';
 import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { NetworkAttachmentDefinitionModel } from '@console/network-attachment-definition-plugin';
 import { NetworkWrapper } from '../../../../k8s/wrapper/vm/network-wrapper';
 import { NetworkInterfaceWrapper } from '../../../../k8s/wrapper/vm/network-interface-wrapper';
@@ -82,7 +82,7 @@ const VMWizardNICModal: React.FC<VMWizardNICModalProps> = (props) => {
     <Firehose
       resources={[
         {
-          kind: NetworkAttachmentDefinitionModel.kind,
+          kind: referenceForModel(NetworkAttachmentDefinitionModel),
           isList: true,
           namespace,
           prop: 'nads',
@@ -107,7 +107,12 @@ type VMWizardNICModalProps = ModalComponentProps & {
 };
 
 const stateToProps = (state, { wizardReduxID }) => {
-  const hasNADs = !!state.k8s.getIn(['RESOURCES', 'models', NetworkAttachmentDefinitionModel.kind]);
+  // FIXME: This should be a flag.
+  const hasNADs = !!state.k8s.getIn([
+    'RESOURCES',
+    'models',
+    referenceForModel(NetworkAttachmentDefinitionModel),
+  ]);
   return {
     hasNADs,
     networks: getNetworksWithWrappers(state, wizardReduxID),

--- a/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/nic-modal/nic-modal-enhanced.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Firehose, FirehoseResult } from '@console/internal/components/utils';
 import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
-import { k8sPatch, K8sResourceKind } from '@console/internal/module/k8s';
+import { k8sPatch, K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { NetworkAttachmentDefinitionModel } from '@console/network-attachment-definition-plugin';
 import { getName, getNamespace } from '@console/shared';
 import { getLoadedData, getResource } from '../../../utils';
@@ -122,7 +122,12 @@ type NICModalFirehoseProps = ModalComponentProps & {
 };
 
 const nicModalStateToProps = ({ k8s }) => {
-  const hasNADs = !!k8s.getIn(['RESOURCES', 'models', NetworkAttachmentDefinitionModel.kind]);
+  // FIXME: This should be a flag.
+  const hasNADs = !!k8s.getIn([
+    'RESOURCES',
+    'models',
+    referenceForModel(NetworkAttachmentDefinitionModel),
+  ]);
   return {
     hasNADs,
   };

--- a/frontend/packages/kubevirt-plugin/src/utils/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/index.ts
@@ -107,6 +107,7 @@ export const compareOwnerReference = (
 export const isCPUEqual = (a: CPU, b: CPU) =>
   a.sockets === b.sockets && a.cores === b.cores && a.threads === b.threads;
 
+// FIXME: Avoid this helper! The implementation is not correct. We should remove this.
 export const getResource = (
   model: K8sResourceKind,
   {
@@ -139,6 +140,9 @@ export const getResource = (
   const res: any = {
     // non-admin user cannot list namespaces (k8s wont return only namespaces available to user but 403 forbidden, ).
     // Instead we need to use ProjectModel which will return available projects (namespaces)
+    //
+    // FIXME: This is incorrect! `m.kind` is not unique. These model definitions should have `crd: true`, which will
+    // break this utility. We should be using `referenceForModel` and `crd: true` in our model definitions!
     kind: m.kind,
     model: m,
     namespaced,

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
@@ -4,6 +4,7 @@ import { sortable } from '@patternfly/react-table';
 import { ListPage, Table, TableData, TableRow } from '@console/internal/components/factory';
 import { Kebab, ResourceKebab, ResourceLink } from '@console/internal/components/utils';
 import { NamespaceModel } from '@console/internal/models';
+import { referenceForModel } from '@console/internal/module/k8s';
 import { dimensifyHeader, dimensifyRow, getName, getNamespace, getUID } from '@console/shared';
 import { NetworkAttachmentDefinitionModel } from '../../models';
 import { getConfigAsJSON, getType } from '../../selectors';
@@ -61,7 +62,7 @@ const NetworkAttachmentDefinitionsRow: React.FC<NetworkAttachmentDefinitionsRowP
     <TableRow id={metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={dimensify()}>
         <ResourceLink
-          kind={NetworkAttachmentDefinitionModel.kind}
+          kind={referenceForModel(NetworkAttachmentDefinitionModel)}
           name={name}
           namespace={namespace}
         />
@@ -75,7 +76,7 @@ const NetworkAttachmentDefinitionsRow: React.FC<NetworkAttachmentDefinitionsRowP
       <TableData className={dimensify(true)}>
         <ResourceKebab
           actions={menuActions}
-          kind={NetworkAttachmentDefinitionModel.kind}
+          kind={referenceForModel(NetworkAttachmentDefinitionModel)}
           resource={netAttachDef}
         />
       </TableData>
@@ -122,14 +123,14 @@ export const NetworkAttachmentDefinitionsPage: React.FC<NetworkAttachmentDefinit
 ) => {
   const namespace = props.namespace || props.match.params.ns || 'default';
   const createProps = {
-    to: `/k8s/ns/${namespace}/networkattachmentdefinitions/~new/form`,
+    to: `/k8s/ns/${namespace}/${referenceForModel(NetworkAttachmentDefinitionModel)}/~new/form`,
   };
 
   return (
     <ListPage
       {...props}
       title={NetworkAttachmentDefinitionModel.labelPlural}
-      kind={NetworkAttachmentDefinitionModel.kind}
+      kind={referenceForModel(NetworkAttachmentDefinitionModel)}
       ListComponent={NetworkAttachmentDefinitionsList}
       filterLabel={props.filterLabel}
       canCreate

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetails.tsx
@@ -16,6 +16,7 @@ const NET_ATTACH_DEF_OVERVIEW_HEADING = 'Network Attachment Definition Overview'
 export const prefixedID = (idPrefix: string, id: string) =>
   idPrefix && id ? `${idPrefix}-${id}` : null;
 
+// FIXME: Use DetailsItem from common console utils.
 export const DetailsItem: React.FC<DetailsItemProps> = ({
   title,
   isNotAvail = false,
@@ -40,6 +41,7 @@ export const NetAttachDefinitionSummary: React.FC<NetAttachDefinitionSummaryProp
   const type = getType(getConfigAsJSON(netAttachDef));
   const id = getUID(netAttachDef);
 
+  // FIXME: This should use ResourceSummary like all other details pages.
   return (
     <>
       <DetailsItem title="Name" idValue={prefixedID(id, 'name')} isNotAvail={!name}>
@@ -62,22 +64,20 @@ export const NetAttachDefinitionSummary: React.FC<NetAttachDefinitionSummaryProp
 };
 
 export const NetworkAttachmentDefinitionDetails: React.FC<NetAttachDefDetailsProps> = (props) => {
-  const { netAttachDef } = props;
+  const { obj: netAttachDef } = props;
 
   return (
-    <div className="co-m-pane__body">
-      <StatusBox data={netAttachDef} loaded={!!netAttachDef}>
-        <ScrollToTopOnMount />
-        <div className="co-m-pane__body">
-          <SectionHeading text={NET_ATTACH_DEF_OVERVIEW_HEADING} />
-          <div className="row">
-            <div className="col-sm-6">
-              <NetAttachDefinitionSummary netAttachDef={netAttachDef} />
-            </div>
+    <StatusBox data={netAttachDef} loaded={!!netAttachDef}>
+      <ScrollToTopOnMount />
+      <div className="co-m-pane__body">
+        <SectionHeading text={NET_ATTACH_DEF_OVERVIEW_HEADING} />
+        <div className="row">
+          <div className="col-sm-6">
+            <NetAttachDefinitionSummary netAttachDef={netAttachDef} />
           </div>
         </div>
-      </StatusBox>
-    </div>
+      </div>
+    </StatusBox>
   );
 };
 
@@ -86,7 +86,7 @@ type NetAttachDefinitionSummaryProps = {
 };
 
 type NetAttachDefDetailsProps = {
-  netAttachDef: NetworkAttachmentDefinitionKind;
+  obj: NetworkAttachmentDefinitionKind;
 };
 
 type DetailsItemProps = {

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetailsPage.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionDetailsPage.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { getResource } from '@console/kubevirt-plugin/src/utils';
+import { referenceForModel, K8sResourceKindReference } from '@console/internal/module/k8s';
 import { DetailsPage } from '@console/internal/components/factory';
 import { Kebab, navFactory } from '@console/internal/components/utils';
-import { K8sResourceKindReference } from '@console/internal/module/k8s';
 import { NetworkAttachmentDefinitionModel } from '../..';
 import { NetworkAttachmentDefinitionDetails } from './NetworkAttachmentDefinitionDetails';
 
@@ -15,18 +14,6 @@ const menuActions = [
 export const NetworkAttachmentDefinitionsDetailsPage: React.FC<
   NetworkAttachmentDefinitionsDetailPageProps
 > = (props) => {
-  const { name, namespace } = props;
-
-  const resources = [
-    getResource(NetworkAttachmentDefinitionModel, {
-      name,
-      namespace,
-      isList: false,
-      prop: 'netAttachDef',
-      optional: true,
-    }),
-  ];
-
   const overviewPage = {
     href: '', // default landing page
     name: 'Overview',
@@ -35,7 +22,14 @@ export const NetworkAttachmentDefinitionsDetailsPage: React.FC<
 
   const pages = [overviewPage, navFactory.editYaml()];
 
-  return <DetailsPage {...props} pages={pages} resources={resources} menuActions={menuActions} />;
+  return (
+    <DetailsPage
+      {...props}
+      pages={pages}
+      kind={referenceForModel(NetworkAttachmentDefinitionModel)}
+      menuActions={menuActions}
+    />
+  );
 };
 
 type NetworkAttachmentDefinitionsDetailPageProps = {

--- a/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
@@ -10,6 +10,7 @@ export const NetworkAttachmentDefinitionModel: K8sKind = {
   abbr: 'NAD',
   kind: 'NetworkAttachmentDefinition',
   id: 'network-attachment-definition',
+  crd: true,
 };
 
 export const SriovNetworkNodePolicyModel: K8sKind = {
@@ -22,6 +23,7 @@ export const SriovNetworkNodePolicyModel: K8sKind = {
   abbr: 'SRNNPM', // TODO check on this
   kind: 'SriovNetworkNodePolicy',
   id: 'sriov-network-node-policy',
+  crd: true,
 };
 
 export const HyperConvergedModel: K8sKind = {
@@ -34,4 +36,5 @@ export const HyperConvergedModel: K8sKind = {
   abbr: 'SRNNPM', // TODO check on this
   kind: 'hyperconverged',
   id: 'hyperconverged',
+  crd: true,
 };

--- a/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
@@ -9,6 +9,7 @@ import {
   ModelDefinition,
   RoutePage,
 } from '@console/plugin-sdk';
+import { referenceForModel } from '@console/internal/module/k8s';
 import * as models from './models';
 import { NetworkAttachmentDefinitionsYAMLTemplates } from './models/templates';
 
@@ -43,7 +44,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       section: 'Networking',
       componentProps: {
         name: 'Network Attachment Definitions',
-        resource: models.NetworkAttachmentDefinitionModel.plural,
+        resource: referenceForModel(models.NetworkAttachmentDefinitionModel),
         required: FLAG_NET_ATTACH_DEF,
       },
       mergeAfter: 'Network Policies',
@@ -65,7 +66,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       model: models.NetworkAttachmentDefinitionModel,
       loader: () =>
         import(
-          './components/network-attachment-definitions/NetworkAttachmentDefinitionDetailsPage' /* webpackChunkName: "kubevirt" */
+          './components/network-attachment-definitions/NetworkAttachmentDefinitionDetailsPage' /* webpackChunkName: "network-attachment-definitions" */
         ).then((m) => m.NetworkAttachmentDefinitionsDetailsPage),
     },
   },
@@ -73,7 +74,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
-      path: ['/k8s/ns/:ns/networkattachmentdefinitions/~new'],
+      path: [`/k8s/ns/:ns/${referenceForModel(models.NetworkAttachmentDefinitionModel)}/~new`],
       loader: () =>
         import(
           './components/network-attachment-definitions/NetworkAttachmentDefinitionCreateYaml' /* webpackChunkName: "network-attachment-definitions" */
@@ -92,26 +93,11 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
-      path: ['/k8s/ns/:ns/networkattachmentdefinitions/~new/form'],
+      path: [`/k8s/ns/:ns/${referenceForModel(models.NetworkAttachmentDefinitionModel)}/~new/form`],
       loader: () =>
         import(
           './components/network-attachment-definitions/NetworkAttachmentDefinitionsForm' /* webpackChunkName: "network-attachment-definitions" */
         ).then((m) => m.default),
-      required: FLAG_NET_ATTACH_DEF,
-    },
-  },
-  {
-    type: 'Page/Route',
-    properties: {
-      exact: true,
-      path: [
-        '/k8s/ns/:ns/networkattachmentdefinitions',
-        '/k8s/all-namespaces/networkattachmentdefinitions',
-      ],
-      loader: () =>
-        import(
-          './components/network-attachment-definitions' /* webpackChunkName: "network-attachment-definitions" */
-        ).then((m) => m.NetworkAttachmentDefinitionsPage),
       required: FLAG_NET_ATTACH_DEF,
     },
   },


### PR DESCRIPTION
@pcbailey These models should have the `crd: true` set since they're CRDs. Let me know if you have concerns on this.

/assign @cyril-ui-developer @pcbailey 