### PR TITLE
Bug 1769303: kubevirt: fix type of PVC volumeModes

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -163,12 +163,12 @@ const kubevirtInterOP = async ({
             ? DataVolumeWrapper.mergeWrappers(
                 dataVolumeWrapper,
                 DataVolumeWrapper.initializeFromSimpleData({
-                  accessModes:
-                    dataVolumeWrapper.getAccessModes() ||
+                  accessModes: dataVolumeWrapper.getAccessModes() || [
                     getDefaultSCAccessMode(
                       storageClassConfigMap,
                       dataVolumeWrapper.getStorageClassName(),
                     ),
+                  ],
                   volumeMode:
                     dataVolumeWrapper.getVolumeMode() ||
                     getDefaultSCVolumeMode(


### PR DESCRIPTION
An array is expected.
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1769303