### PR TITLE
Bug 1757319: Fix bare metal host secondary status

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDetails.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDetails.tsx
@@ -35,8 +35,10 @@ import {
   getHostMachine,
   findNodeMaintenance,
   getHostBios,
+  getHostProvisioningState,
 } from '../../selectors';
 import { BareMetalHostKind } from '../../types';
+import { HOST_REGISTERING_STATES } from '../../constants/bare-metal-host';
 import MachineLink from './MachineLink';
 import BareMetalHostPowerStatusIcon from './BareMetalHostPowerStatusIcon';
 import BareMetalHostStatus from './BareMetalHostStatus';
@@ -67,6 +69,7 @@ const BareMetalHostDetails: React.FC<BareMetalHostDetailsProps> = ({
   const totalStorageCapacity = humanizeDecimalBytes(getHostTotalStorageCapacity(host)).string;
   const description = getHostDescription(host);
   const powerStatus = getHostPowerStatus(host);
+  const provisioningState = getHostProvisioningState(host);
   const { count: CPUCount, model: CPUModel } = getHostCPU(host);
   const { manufacturer, productName, serialNumber } = getHostVendorInfo(host);
   const bios = getHostBios(host);
@@ -127,13 +130,18 @@ const BareMetalHostDetails: React.FC<BareMetalHostDetailsProps> = ({
             <dd>
               <BareMetalHostStatus {...status} />
             </dd>
-            <dt>Power Status</dt>
-            <dd>
-              <StatusIconAndText
-                title={powerStatus}
-                icon={<BareMetalHostPowerStatusIcon powerStatus={powerStatus} />}
-              />
-            </dd>
+            {/* power status is not available until host registration/inspection is finished */}
+            {!HOST_REGISTERING_STATES.includes(provisioningState) && (
+              <>
+                <dt>Power Status</dt>
+                <dd>
+                  <StatusIconAndText
+                    title={powerStatus}
+                    icon={<BareMetalHostPowerStatusIcon powerStatus={powerStatus} />}
+                  />
+                </dd>
+              </>
+            )}
             {role && (
               <>
                 <dt>Role</dt>

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostSecondaryStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostSecondaryStatus.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { SecondaryStatus } from '@console/shared';
+import { BareMetalHostKind } from '../../types';
+import { getHostPowerStatus, getHostProvisioningState } from '../../selectors';
+import { HOST_POWER_STATUS_POWERED_ON, HOST_REGISTERING_STATES } from '../../constants';
+
+type BareMetalHostSecondaryStatusProps = {
+  host: BareMetalHostKind;
+};
+
+const BareMetalHostSecondaryStatus: React.FC<BareMetalHostSecondaryStatusProps> = ({ host }) => {
+  const powerStatus = getHostPowerStatus(host);
+  const provisioningState = getHostProvisioningState(host);
+  const status = [];
+  // don't show power status when host is powered on
+  // don't show power status when host registration/inspection hasn't finished
+  if (
+    !(powerStatus === HOST_POWER_STATUS_POWERED_ON) &&
+    !HOST_REGISTERING_STATES.includes(provisioningState)
+  ) {
+    status.push(powerStatus);
+  }
+  return <SecondaryStatus status={status} />;
+};
+
+export default BareMetalHostSecondaryStatus;

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
@@ -2,16 +2,17 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { Kebab, ResourceLink } from '@console/internal/components/utils';
 import { sortable } from '@patternfly/react-table';
-import { getName, getUID, getNamespace, SecondaryStatus } from '@console/shared';
+import { getName, getUID, getNamespace } from '@console/shared';
 import { TableRow, TableData, Table } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { BareMetalHostBundle } from '../types';
-import { getHostBMCAddress, getHostPowerStatus } from '../../selectors';
+import { getHostBMCAddress } from '../../selectors';
 import { BareMetalHostModel } from '../../models';
 import NodeLink from './NodeLink';
 import BareMetalHostStatus from './BareMetalHostStatus';
 import BareMetalHostRole from './BareMetalHostRole';
 import { menuActions } from './host-menu-actions';
+import BareMetalHostSecondaryStatus from './BareMetalHostSecondaryStatus';
 
 const tableColumnClasses = {
   name: classNames('col-lg-3', 'col-md-4', 'col-sm-12', 'col-xs-12'),
@@ -93,7 +94,7 @@ const HostsTableRow: React.FC<HostsTableRowProps> = ({
       </TableData>
       <TableData className={tableColumnClasses.status}>
         <BareMetalHostStatus {...status} />
-        <SecondaryStatus status={getHostPowerStatus(host)} />
+        <BareMetalHostSecondaryStatus host={host} />
       </TableData>
       <TableData className={tableColumnClasses.node}>
         <NodeLink nodeName={nodeName} />

--- a/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
+++ b/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
@@ -17,7 +17,7 @@ export const HOST_STATUS_REGISTRATION_ERROR = 'registration error';
 export const HOST_STATUS_PROVISIONING_ERROR = 'provisioning error';
 export const HOST_STATUS_POWER_MANAGEMENT_ERROR = 'power management error';
 
-export const HOST_POWER_STATUS_POWERED_ON = 'Running';
+export const HOST_POWER_STATUS_POWERED_ON = 'Powered on';
 export const HOST_POWER_STATUS_POWERED_OFF = 'Powered off';
 export const HOST_POWER_STATUS_POWERING_OFF = 'Shutting down';
 export const HOST_POWER_STATUS_POWERING_ON = 'Powering on';


### PR DESCRIPTION
* Powered on is default expected status on the host, so it is not needed to highlight
  it in secondary status
* The BMO power management phase happens only after inspection. Until that's finished
  it makes no sense to show power status as it does not resemble reality