### PR TITLE
Bug 1769716: Remove storage classes unrelated to the storage resource

### DIFF
--- a/frontend/packages/console-shared/src/utils/storage-utils.ts
+++ b/frontend/packages/console-shared/src/utils/storage-utils.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { StorageClass } from '@console/internal/components/storage-class-form';
 
 export const cephStorageProvisioners = [
   'ceph.rook.io/block',
@@ -12,3 +13,7 @@ export const isCephProvisioner = (scProvisioner: string): boolean => {
     _.endsWith(scProvisioner, provisioner),
   );
 };
+
+// To check that the storage class isn't noobaa based
+export const filterScOnProvisioner = (sc: StorageClass, provisioner: string = '') =>
+  sc.provisioner.includes(provisioner);

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/create-obc.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/create-obc.tsx
@@ -18,7 +18,8 @@ import {
 } from '@console/internal/module/k8s';
 import { NooBaaObjectBucketClaimModel } from '@console/noobaa-storage-plugin/src/models';
 import { ActionGroup, Button } from '@patternfly/react-core';
-import { getName } from '@console/shared';
+import { StorageClass } from '@console/internal/components/storage-class-form';
+import { filterScOnProvisioner, getName } from '@console/shared';
 import { commonReducer, defaultState } from '../object-bucket-page/state';
 
 export const CreateOBCPage: React.FC<CreateOBCPageProps> = (props) => {
@@ -64,6 +65,11 @@ export const CreateOBCPage: React.FC<CreateOBCPageProps> = (props) => {
       });
   };
 
+  const showOnlyObcScs = React.useCallback(
+    (sc: StorageClass) => filterScOnProvisioner(sc, 'noobaa.io/obc'),
+    [],
+  );
+
   return (
     <div className="co-m-pane__body co-m-pane__form">
       <Helmet>
@@ -107,6 +113,7 @@ export const CreateOBCPage: React.FC<CreateOBCPageProps> = (props) => {
                 required
                 name="storageClass"
                 className="co-required"
+                filter={showOnlyObcScs}
               />
               <p className="help-block">
                 Defines the object-store service and the bucket provisioner.

--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -3,13 +3,14 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { ActionGroup, Button } from '@patternfly/react-core';
-import { isCephProvisioner } from '@console/shared/src/utils';
+import { filterScOnProvisioner, isCephProvisioner } from '@console/shared/src/utils';
 import { k8sCreate, K8sResourceKind, referenceFor } from '../../module/k8s';
 import { AsyncComponent, ButtonBar, RequestSizeInput, history, resourceObjPath } from '../utils';
 import { StorageClassDropdown } from '../utils/storage-class-dropdown';
 import { RadioInput } from '../radio';
 import { Checkbox } from '../checkbox';
 import { PersistentVolumeClaimModel } from '../../models';
+import { StorageClass } from '../storage-class-form';
 
 const NameValueEditorComponent = (props) => (
   <AsyncComponent
@@ -196,6 +197,11 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
     setAccessMode(event.currentTarget.value);
   };
 
+  const onlyPvcSCs = React.useCallback(
+    (sc: StorageClass) => !filterScOnProvisioner(sc, 'noobaa.io/obc'),
+    [],
+  );
+
   return (
     <div>
       <div className="form-group">
@@ -205,6 +211,7 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
           describedBy="storageclass-dropdown-help"
           required={false}
           name="storageClass"
+          filter={onlyPvcSCs}
         />
       </div>
       <label className="control-label co-required" htmlFor="pvc-name">


### PR DESCRIPTION
- Filters Noobaa provisioned storage classes out of PVC creation SC selection dropdown.
- Filters SCs not being provisioned by Noobaa out of OBC creation.
![Screenshot from 2019-11-08 12-49-10](https://user-images.githubusercontent.com/54092533/68457398-376b1980-0226-11ea-8c50-4150de6945b4.png)
