### PR TITLE
Send correct params for starting a pipeline

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
@@ -7,7 +7,13 @@ import {
 } from '@console/internal/components/factory/modal';
 import { k8sCreate } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
-import { Pipeline, PipelineResource, Param, PipelineRun } from '../../../utils/pipeline-augment';
+import {
+  Pipeline,
+  PipelineResource,
+  PipelineParam,
+  PipelineRun,
+} from '../../../utils/pipeline-augment';
+import { getPipelineRunParams } from '../../../utils/pipeline-utils';
 import StartPipelineForm from './StartPipelineForm';
 import { startPipelineSchema } from './pipelineForm-validation-utils';
 
@@ -20,7 +26,7 @@ export interface StartPipelineModalProps {
 }
 export interface StartPipelineFormValues extends FormikValues {
   namespace: string;
-  parameters: Param[];
+  parameters: PipelineParam[];
   resources: PipelineResource[];
 }
 
@@ -32,8 +38,8 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
 }) => {
   const initialValues: StartPipelineFormValues = {
     namespace: pipeline.metadata.namespace,
-    parameters: _.get(pipeline.spec, 'params', []),
-    resources: _.get(pipeline.spec, 'resources', []),
+    parameters: _.get(pipeline, 'spec.params', []),
+    resources: _.get(pipeline, 'spec.resources', []),
   };
   initialValues.resources.map((resource: PipelineResource) =>
     _.merge(resource, { resourceRef: { name: '' } }),
@@ -41,12 +47,13 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
 
   const handleSubmit = (values: StartPipelineFormValues, actions): void => {
     actions.setSubmitting(true);
-    const pipelineRunData = {
+
+    const pipelineRunData: PipelineRun = {
       spec: {
         pipelineRef: {
           name: pipeline.metadata.name,
         },
-        params: values.parameters,
+        params: getPipelineRunParams(values.parameters),
         resources: values.resources,
       },
     };

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import {
   stopPipelineRun,
   rerunPipelineAndRedirect,
@@ -13,6 +14,10 @@ export const actionPipelines: Pipeline[] = [
     apiVersion: 'abhiapi/v1',
     kind: 'Pipeline',
     metadata: { name: 'sansa-stark', namespace: 'corazon' },
+    spec: {
+      params: [{ name: 'APP_NAME', description: 'Described Param', default: 'default-app-name' }],
+      tasks: [],
+    },
   },
   {
     apiVersion: 'abhiapi/v1',
@@ -92,5 +97,13 @@ describe('PipelineAction testing getPipelineRunData', () => {
   it('expect pipeline run data to be returned when only PipelineRun argument is passed', () => {
     const runData = getPipelineRunData(null, actionPipelineRuns[0]);
     expect(runData).not.toBeNull();
+  });
+
+  it('expect params to not have default key in the pipeline run data', () => {
+    const runData = getPipelineRunData(actionPipelines[0]);
+    const { params } = runData.spec;
+    expect(params[0].name).toBe('APP_NAME');
+    expect(params[0].value).toBe('default-app-name');
+    expect(_.has(params[0], 'default')).toBeFalsy();
   });
 });

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-test-data.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-test-data.ts
@@ -9,6 +9,13 @@ export const mockPipelinesJSON: K8sResourceKind[] = [
       name: 'tutorial-pipeline',
     },
     spec: {
+      params: [
+        {
+          name: 'APP_NAME',
+          type: 'string',
+          default: 'default-app-name',
+        },
+      ],
       resources: [
         {
           name: 'source-repo',

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-utils.spec.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import {
   LOG_SOURCE_RESTARTING,
   LOG_SOURCE_WAITING,
@@ -8,6 +9,7 @@ import {
   getPipelineTasks,
   containerToLogSourceStatus,
   constructCurrentPipeline,
+  getPipelineRunParams,
 } from '../pipeline-utils';
 import { constructPipelineData, mockPipelinesJSON } from './pipeline-test-data';
 
@@ -43,6 +45,7 @@ describe('pipeline-utils ', () => {
     expect(constructCurrentPipeline(constructPipelineData.pipeline, [])).toBeNull();
     expect(constructCurrentPipeline(null, constructPipelineData.pipelineRuns)).toBeNull();
   });
+
   it('expect constructCurrentPipeline to produce a grouped pipeline with the latest run', () => {
     const data = constructCurrentPipeline(
       constructPipelineData.pipeline,
@@ -55,5 +58,12 @@ describe('pipeline-utils ', () => {
     expect(data.currentPipeline.latestRun).not.toBeNull();
     expect(data.status).not.toBeNull();
     expect(data.status).toBe('Pending');
+  });
+
+  it('should return correct params for a pipeline run', () => {
+    const pipelineParams = _.get(mockPipelinesJSON[0], 'spec.params');
+    const params = getPipelineRunParams(pipelineParams);
+    expect(params[0].name).toBe('APP_NAME');
+    expect(params[0].value).toBe('default-app-name');
   });
 });

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -39,7 +39,7 @@ export const getPipelineRunData = (
   const pipelineName = pipeline ? pipeline.metadata.name : latestRun.spec.pipelineRef.name;
 
   const latestRunParams = _.get(latestRun, 'spec.params');
-  const pipelineParams = _.get(pipeline, 'spec.params', []);
+  const pipelineParams = _.get(pipeline, 'spec.params');
 
   const params = latestRunParams || getPipelineRunParams(pipelineParams);
 
@@ -57,11 +57,11 @@ export const getPipelineRunData = (
             },
     },
     spec: {
-      ...(params && { params }),
       pipelineRef: {
         name: pipelineName,
       },
       resources,
+      ...(params && { params }),
       serviceAccount: latestRun && _.get(latestRun, ['spec', 'serviceAccount']),
     },
   };

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -7,6 +7,7 @@ import startPipelineModal from '../components/pipelines/pipeline-form/StartPipel
 import { getRandomChars } from '../components/pipelines/pipeline-resource/pipelineResource-utils';
 import { Pipeline, PipelineRun } from './pipeline-augment';
 import { pipelineRunFilterReducer } from './pipeline-filter-reducer';
+import { getPipelineRunParams } from './pipeline-utils';
 
 export const handlePipelineRunSubmit = (pipelineRun: PipelineRun) => {
   history.push(
@@ -37,6 +38,11 @@ export const getPipelineRunData = (
 
   const pipelineName = pipeline ? pipeline.metadata.name : latestRun.spec.pipelineRef.name;
 
+  const latestRunParams = _.get(latestRun, 'spec.params');
+  const pipelineParams = _.get(pipeline, 'spec.params', []);
+
+  const params = latestRunParams || getPipelineRunParams(pipelineParams);
+
   return {
     apiVersion: `${PipelineRunModel.apiGroup}/${PipelineRunModel.apiVersion}`,
     kind: PipelineRunModel.kind,
@@ -51,16 +57,11 @@ export const getPipelineRunData = (
             },
     },
     spec: {
+      ...(params && { params }),
       pipelineRef: {
         name: pipelineName,
       },
       resources,
-      params:
-        latestRun && latestRun.spec && latestRun.spec.params
-          ? latestRun.spec.params
-          : pipeline && pipeline.spec && pipeline.spec.params
-          ? pipeline.spec.params
-          : null,
       serviceAccount: latestRun && _.get(latestRun, ['spec', 'serviceAccount']),
     },
   };
@@ -78,19 +79,11 @@ export const triggerPipeline = (
 export const reRunPipelineRun: KebabAction = (kind: K8sKind, pipelineRun: PipelineRun) => ({
   label: 'Rerun',
   callback: () => {
-    if (
-      !pipelineRun ||
-      !pipelineRun.metadata ||
-      !pipelineRun.metadata.namespace ||
-      !pipelineRun.spec ||
-      !pipelineRun.spec.pipelineRef ||
-      !pipelineRun.spec.pipelineRef.name
-    ) {
-      // eslint-disable-next-line no-console
-      console.error('Improper PipelineRun metadata');
-      return;
+    const namespace = _.get(pipelineRun, 'spec.metadata.namespace');
+    const pipelineRef = _.get(pipelineRun, 'spec.spec.pipelineRef.name');
+    if (namespace && pipelineRef) {
+      k8sCreate(PipelineRunModel, getPipelineRunData(null, pipelineRun));
     }
-    k8sCreate(PipelineRunModel, getPipelineRunData(null, pipelineRun));
   },
   accessReview: {
     group: kind.apiGroup,

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -107,13 +107,14 @@ export interface Param {
 
 export interface PipelineParam extends Param {
   default?: string;
+  description?: string;
 }
 
 export interface PipelineRunParam extends Param {
+  value: string;
   input?: string;
   output?: string;
   resource?: object;
-  value?: string;
 }
 
 interface FirehoseResource {

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -7,7 +7,14 @@ import {
   LOG_SOURCE_RUNNING,
   LOG_SOURCE_TERMINATED,
 } from '@console/internal/components/utils';
-import { getLatestRun, Pipeline, PipelineRun, runStatus } from './pipeline-augment';
+import {
+  getLatestRun,
+  Pipeline,
+  PipelineRun,
+  runStatus,
+  PipelineParam,
+  PipelineRunParam,
+} from './pipeline-augment';
 import { pipelineFilterReducer } from './pipeline-filter-reducer';
 
 interface Resources {
@@ -289,4 +296,11 @@ export const constructCurrentPipeline = (
     currentPipeline,
     status,
   };
+};
+
+export const getPipelineRunParams = (pipelineParams: PipelineParam[]): PipelineRunParam[] => {
+  return pipelineParams.map((param) => ({
+    name: param.name,
+    value: param.default,
+  }));
 };

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -299,8 +299,11 @@ export const constructCurrentPipeline = (
 };
 
 export const getPipelineRunParams = (pipelineParams: PipelineParam[]): PipelineRunParam[] => {
-  return pipelineParams.map((param) => ({
-    name: param.name,
-    value: param.default,
-  }));
+  return (
+    pipelineParams &&
+    pipelineParams.map((param) => ({
+      name: param.name,
+      value: param.default,
+    }))
+  );
 };


### PR DESCRIPTION
Related Bug - https://jira.coreos.com/browse/ODC-2204

This PR - 
- Fixes the `params` being sent in the `PipelineRun` for starting a pipeline.