### PR TITLE
Bug 1753618: kubevirt: Fix VM readiness checking

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -25,7 +25,7 @@ export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
   const vmDashboardContext = React.useContext(VMDashboardContext);
   const { vm, vmi, pods, migrations } = vmDashboardContext;
 
-  const vmStatus = getVMStatus(vm, pods, migrations);
+  const vmStatus = getVMStatus({ vm, vmi, pods, migrations });
   const { launcherPod } = vmStatus;
 
   const ipAddrs = getVmiIpAddressesString(vmi, vmStatus);

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-status-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-status-card.tsx
@@ -20,7 +20,7 @@ export const VMStatusCard: React.FC<VMStatusCardProps> = () => {
       </DashboardCardHeader>
       <DashboardCardBody>
         <HealthBody>
-          <VMStatus vm={vm} pods={pods} migrations={migrations} />
+          <VMStatus vm={vm} vmi={vmi} pods={pods} migrations={migrations} />
         </HealthBody>
         <VMAlerts vm={vm} vmi={vmi} />
       </DashboardCardBody>

--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
@@ -34,7 +34,7 @@ import {
   VM_STATUS_OFF,
   VM_STATUS_ERROR,
 } from '../../statuses/vm/constants';
-import { VMKind } from '../../types';
+import { VMKind, VMIKind } from '../../types';
 
 import './vm-status.scss';
 
@@ -81,8 +81,14 @@ const VMStatusPopoverContent: React.FC<VMStatusPopoverContentProps> = ({
   </>
 );
 
-export const VMStatus: React.FC<VMStatusProps> = ({ vm, pods, migrations, verbose = false }) => {
-  const statusDetail = getVMStatus(vm, pods, migrations);
+export const VMStatus: React.FC<VMStatusProps> = ({
+  vm,
+  vmi,
+  pods,
+  migrations,
+  verbose = false,
+}) => {
+  const statusDetail = getVMStatus({ vm, vmi, pods, migrations });
   const linkToVMEvents = `${resourcePath(
     VirtualMachineModel.kind,
     getName(vm),
@@ -252,6 +258,7 @@ type VMStatusPopoverContentProps = {
 
 type VMStatusProps = {
   vm: VMKind;
+  vmi?: VMIKind;
   pods?: PodKind[];
   migrations?: K8sResourceKind[];
   verbose?: boolean;

--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-statuses.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-statuses.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import { PodKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { getUID } from '@console/shared';
 import { VM_STATUS_IMPORTING, VM_STATUS_IMPORT_ERROR } from '../../statuses/vm/constants';
-import { VMKind } from '../../types';
+import { VMKind, VMIKind } from '../../types';
 import { getVMStatus } from '../../statuses/vm/vm';
 import { getVMImporterPods } from '../../selectors/pod/selectors';
 import { VMStatus } from './vm-status';
 
 export const VMStatuses: React.FC<VMStatusesProps> = (props) => {
-  const { vm, pods, migrations } = props;
-  const statusDetail = getVMStatus(vm, pods, migrations);
+  const { vm, vmi, pods, migrations } = props;
+  const statusDetail = getVMStatus({ vm, vmi, pods, migrations });
   const importerPods = getVMImporterPods(vm, pods);
 
   switch (statusDetail.status) {
@@ -31,6 +31,7 @@ export const VMStatuses: React.FC<VMStatusesProps> = (props) => {
 
 type VMStatusesProps = {
   vm: VMKind;
+  vmi?: VMIKind;
   pods?: PodKind[];
   migrations?: K8sResourceKind[];
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -172,7 +172,7 @@ export const menuActionsCreator = (
   vm: VMKind,
   { vmi, pods, migrations }: ExtraResources,
 ) => {
-  const vmStatus = getVMStatus(vm, pods, migrations);
+  const vmStatus = getVMStatus({ vm, vmi, pods, migrations });
   const migration = findVMIMigration(vmi, migrations);
 
   return menuActions.map((action) => {

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
@@ -31,7 +31,7 @@ const VmConsolesWrapper: React.FC<VmConsolesWrapperProps> = (props) => {
   const migrations = getLoadedData(props.migrations);
 
   const onStartVm = () => {
-    const vmStatus = getVMStatus(vm, pods, migrations);
+    const vmStatus = getVMStatus({ vm, vmi, pods, migrations });
     menuActionStart(VirtualMachineModel, vm, { vmStatus }).callback();
   };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -82,7 +82,7 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
   canUpdateVM,
 }) => {
   const id = getBasicID(vm);
-  const vmStatus = getVMStatus(vm, pods, migrations);
+  const vmStatus = getVMStatus({ vm, vmi, pods, migrations });
   const { launcherPod } = vmStatus;
   const cds = getCDRoms(vm);
   const sortedBootableDevices = getBootableDevicesInOrder(vm);
@@ -94,7 +94,7 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
   return (
     <dl className="co-m-pane__details">
       <VMDetailsItem title="Status" idValue={prefixedID(id, 'vm-statuses')}>
-        <VMStatuses vm={vm} pods={pods} migrations={migrations} />
+        <VMStatuses vm={vm} vmi={vmi} pods={pods} migrations={migrations} />
       </VMDetailsItem>
 
       <VMDetailsItem title="Pod" idValue={prefixedID(id, 'pod')} isNotAvail={!launcherPod}>

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -70,11 +70,11 @@ const VMRow: React.FC<VMRowProps> = ({
   const name = getName(vm);
   const namespace = getNamespace(vm);
   const uid = getUID(vm);
-  const vmStatus = getVMStatus(vm, pods, migrations);
   const lookupID = getBasicID(vm);
 
   const migration = migrationLookup[lookupID];
   const vmi = vmiLookup[lookupID];
+  const vmStatus = getVMStatus({ vm, vmi, pods, migrations });
 
   return (
     <TableRow id={uid} index={index} trKey={key} style={style}>
@@ -85,7 +85,7 @@ const VMRow: React.FC<VMRowProps> = ({
         <ResourceLink kind={NamespaceModel.kind} name={namespace} title={namespace} />
       </TableData>
       <TableData className={dimensify()}>
-        <VMStatus vm={vm} pods={pods} migrations={migrations} />
+        <VMStatus vm={vm} vmi={vmi} pods={pods} migrations={migrations} />
       </TableData>
       <TableData className={dimensify(true)}>
         <Kebab

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -195,6 +195,11 @@ const plugin: Plugin<ConsumedExtensions> = [
       additionalResources: [
         {
           isList: true,
+          kind: models.VirtualMachineInstanceModel.kind,
+          prop: 'vmis',
+        },
+        {
+          isList: true,
           kind: PodModel.kind,
           prop: 'pods',
         },


### PR DESCRIPTION
The `vmi.status.phase === running` is used instead of `vm.status.ready`
as it is more reliable (not affected by RunStrategy timeout in the backend).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1753618