### PR TITLE
Bug 1769915: Fix bare metal backed node secondary status

### DIFF
--- a/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
@@ -32,6 +32,7 @@ export const baremetalNodeSecondaryStatus = ({
   if (!nodeMaintenance && isNodeUnschedulable(node)) {
     states.push('Scheduling disabled');
   }
-  if (!isHostPoweredOn(host)) states.push('Host is powered off');
+  // show host power status only if there is actual host associated to node
+  if (host && !isHostPoweredOn(host)) states.push('Host is powered off');
   return states;
 };


### PR DESCRIPTION
* Don't show host power status in Node's secondary status until host
  is properly linked to it through the associated machine