### PR TITLE
Bug 1765068: Make optional resources optional in inventory card

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/inventory-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/inventory-card.tsx
@@ -72,15 +72,15 @@ const ClusterInventoryItem = withDashboardResources(
       let additionalResourcesLoaded = true;
       let additionalResourcesLoadError = false;
       if (additionalResources) {
-        additionalResourcesLoaded = additionalResources.every((r) =>
-          _.get(resources[r.prop], 'loaded'),
-        );
+        additionalResourcesLoaded = additionalResources
+          .filter((r) => !r.optional)
+          .every((r) => _.get(resources[r.prop], 'loaded'));
         additionalResources.forEach((r) => {
           additionalResourcesData[r.prop] = _.get(resources[r.prop], 'data');
         });
-        additionalResourcesLoadError = additionalResources.some(
-          (r) => !!_.get(resources[r.prop], 'loadError'),
-        );
+        additionalResourcesLoadError = additionalResources
+          .filter((r) => !r.optional)
+          .some((r) => !!_.get(resources[r.prop], 'loadError'));
       }
 
       const ExpandedComponent = React.useCallback(


### PR DESCRIPTION
In the inventory card, when calculating the loaded status of additional
resources, treat optional resources as already loaded.

If the calculation of some inventory value depends on an operator that
isn't installed, it will no longer block the rest of the resources.