### PR TITLE
Bug 1765068: [metal3] Make maintenance optional in inventory item

### DIFF
--- a/frontend/packages/metal3-plugin/src/plugin.ts
+++ b/frontend/packages/metal3-plugin/src/plugin.ts
@@ -105,6 +105,7 @@ const plugin: Plugin<ConsumedExtensions> = [
           isList: true,
           kind: referenceForModel(NodeMaintenanceModel),
           prop: 'maintenaces',
+          optional: true,
         },
       ],
       model: BareMetalHostModel,


### PR DESCRIPTION
If the maintenance operator isn't available, the item will still render.

Related: #3291 