### PR TITLE
topology reset layout does not recenter the view

### DIFF
--- a/frontend/packages/topology/src/elements/BaseElement.ts
+++ b/frontend/packages/topology/src/elements/BaseElement.ts
@@ -77,10 +77,6 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
     return p;
   }
 
-  isDetached(): boolean {
-    return !this.parent;
-  }
-
   getParent(): GraphElement {
     if (!this.parent) {
       throw new Error(`GraphElement with ID '${this.getId()}' has no parent.`);

--- a/frontend/packages/topology/src/elements/BaseGraph.ts
+++ b/frontend/packages/topology/src/elements/BaseGraph.ts
@@ -17,10 +17,6 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any> exten
 
   private currentLayout?: Layout;
 
-  isDetached(): boolean {
-    return !this.getController();
-  }
-
   @computed
   private get edges(): Edge[] {
     return this.getChildren().filter(isEdge);
@@ -86,7 +82,11 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any> exten
 
   reset(): void {
     this.scale = 1;
-    this.getBounds().setLocation(0, 0);
+    this.setBounds(
+      this.getBounds()
+        .clone()
+        .setLocation(0, 0),
+    );
   }
 
   scaleBy(scale: number, location?: Point): void {

--- a/frontend/packages/topology/src/elements/__tests__/BaseGraph.spec.ts
+++ b/frontend/packages/topology/src/elements/__tests__/BaseGraph.spec.ts
@@ -1,0 +1,48 @@
+import Rect from '../../geom/Rect';
+import Point from '../../geom/Point';
+import { ModelKind, Graph } from '../../types';
+import BaseGraph from '../BaseGraph';
+
+describe('BaseGraph', () => {
+  let graph: Graph;
+
+  beforeEach(() => {
+    graph = new BaseGraph();
+  });
+
+  it('should have a graph kind', () => {
+    expect(graph.getKind()).toBe(ModelKind.graph);
+  });
+
+  it('should update bounds', () => {
+    expect(graph.getBounds()).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+    const r = new Rect(10, 20, 30, 40);
+    graph.setBounds(r);
+    expect(graph.getBounds()).toEqual({ x: 10, y: 20, width: 30, height: 40 });
+  });
+
+  it('should update scale', () => {
+    expect(graph.getScale()).toBe(1);
+    graph.setScale(4.5);
+    expect(graph.getScale()).toBe(4.5);
+  });
+
+  it('should reset position and scale', () => {
+    graph.setBounds(new Rect(10, 20, 30, 40));
+    graph.setScale(2);
+    graph.reset();
+    expect(graph.getScale()).toBe(1);
+    expect(graph.getBounds()).toEqual({ x: 0, y: 0, width: 30, height: 40 });
+  });
+
+  it('should scaleBy the given multiple around the specified location', () => {
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    graph.scaleBy(0.5);
+    expect(graph.getScale()).toBe(0.5);
+    expect(graph.getBounds()).toEqual({ x: 25, y: 25, width: 100, height: 100 });
+    graph.scaleBy(2);
+    expect(graph.getBounds()).toEqual({ x: 0, y: 0, width: 100, height: 100 });
+    graph.scaleBy(0.5, new Point(100, 100));
+    expect(graph.getBounds()).toEqual({ x: 50, y: 50, width: 100, height: 100 });
+  });
+});

--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -80,7 +80,6 @@ export interface GraphElement<E extends ElementModel = ElementModel, D = any> ex
   getLabel(): string;
   setLabel(label: string): void;
   getOrderKey(): number[];
-  isDetached(): boolean;
   getController(): Controller;
   setController(controller?: Controller): void;
   getGraph(): Graph;


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-2212

Instead of mutating the bounds object, set the new bounds object. The types need to be updated to be immutable, but that's a larger change for the future.

While creating the tests I also removed `isDetached` which is not being used anymore due to a change in implementation a while ago. It also wasn't working as expected in `BaseGraph` anymore.

![resetfix](https://user-images.githubusercontent.com/14068621/68415051-77b39480-015f-11ea-89d4-503d09d36ecc.gif)
