### PR TITLE
update toplogy owners labels to apply dev-console label

### DIFF
--- a/frontend/packages/topology/OWNERS
+++ b/frontend/packages/topology/OWNERS
@@ -3,4 +3,4 @@ reviewers:
 approvers:
   - christianvogt
 labels:
-  - component/topology
+  - component/dev-console


### PR DESCRIPTION
Applies the `dev-console` label for the `topology` package.