### PR TITLE
replace useSvgAnchor with useAnchor for improved performance

### DIFF
--- a/frontend/packages/dev-console/src/components/topology2/components/anchors/RevisionTrafficSourceAnchor.ts
+++ b/frontend/packages/dev-console/src/components/topology2/components/anchors/RevisionTrafficSourceAnchor.ts
@@ -1,0 +1,30 @@
+import { AbstractAnchor, getEllipseAnchorPoint, Node, Point } from '@console/topology';
+
+export default class RevisionTrafficSourceAnchor extends AbstractAnchor {
+  private radius: number;
+
+  constructor(node: Node, radius: number) {
+    super(node);
+    this.radius = radius;
+  }
+
+  getLocation(reference: Point): Point {
+    const bounds = this.getOwner().getBounds();
+    // center point is top right corner
+    const center = new Point(bounds.right(), bounds.y);
+    if (this.radius) {
+      // location is edge of decorator
+      const size = this.radius * 2;
+      return getEllipseAnchorPoint(center, size, size, reference);
+    }
+
+    // location is center of node
+    return center;
+  }
+
+  getReferencePoint(): Point {
+    const bounds = this.getOwner().getBounds();
+    // reference point is top right corner of node
+    return new Point(bounds.right(), bounds.y);
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology2/components/anchors/RevisionTrafficTargetAnchor.ts
+++ b/frontend/packages/dev-console/src/components/topology2/components/anchors/RevisionTrafficTargetAnchor.ts
@@ -1,0 +1,37 @@
+import { AbstractAnchor, getEllipseAnchorPoint, Node, Point } from '@console/topology';
+
+export default class RevisionTrafficTargetAnchor extends AbstractAnchor {
+  private radius: number;
+
+  private offset: number;
+
+  constructor(node: Node, radius: number) {
+    super(node);
+    this.radius = radius;
+    // TODO align sizing with WorkloadNode
+    this.offset = radius * 0.7;
+  }
+
+  getLocation(reference: Point): Point {
+    const bounds = this.getOwner().getBounds();
+    if (this.radius) {
+      // location is edge of decorator
+      const center = new Point(bounds.right() - this.offset, bounds.y + this.offset);
+      const size = this.radius * 2;
+      return getEllipseAnchorPoint(center, size, size, reference);
+    }
+
+    // location is edge of outer node
+    return getEllipseAnchorPoint(bounds.getCenter(), bounds.width, bounds.height, reference);
+  }
+
+  getReferencePoint(): Point {
+    const bounds = this.getOwner().getBounds();
+    if (this.radius) {
+      // reference point is center of decorator
+      return new Point(bounds.right() - this.offset, bounds.y + this.offset);
+    }
+    // reference point is center of node
+    return bounds.getCenter();
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology2/components/anchors/__tests__/RevisionTrafficSourceAnchor.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology2/components/anchors/__tests__/RevisionTrafficSourceAnchor.spec.ts
@@ -1,0 +1,27 @@
+import { Node, Point, Rect } from '@console/topology';
+import RevisionTrafficSourceAnchor from '../RevisionTrafficSourceAnchor';
+
+function createMockNode(bounds: Rect): Node {
+  return ({
+    getBounds: () => bounds,
+  } as any) as Node;
+}
+
+describe('RevisionTrafficSourceAnchor', () => {
+  it('should return the top right corner as reference point', () => {
+    const anchor = new RevisionTrafficSourceAnchor(createMockNode(new Rect(50, 30, 80, 40)), 0);
+    expect(anchor.getReferencePoint()).toEqual({ x: 130, y: 30 });
+  });
+
+  it('should return a radius based anchor location', () => {
+    const anchor = new RevisionTrafficSourceAnchor(createMockNode(new Rect(10, 20, 130, 140)), 10);
+    const loc = anchor.getLocation(new Point(50, 60));
+    expect(loc.x).toBeCloseTo(130.86);
+    expect(loc.y).toBeCloseTo(24.06);
+  });
+
+  it('should return the top right corner as anchor location', () => {
+    const anchor = new RevisionTrafficSourceAnchor(createMockNode(new Rect(10, 20, 130, 140)), 0);
+    expect(anchor.getLocation(new Point(50, 60))).toEqual({ x: 140, y: 20 });
+  });
+});

--- a/frontend/packages/dev-console/src/components/topology2/components/anchors/__tests__/RevisionTrafficTargetAnchor.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology2/components/anchors/__tests__/RevisionTrafficTargetAnchor.spec.ts
@@ -1,0 +1,34 @@
+import { Node, Point, Rect } from '@console/topology';
+import RevisionTrafficTargetAnchor from '../RevisionTrafficTargetAnchor';
+
+function createMockNode(bounds: Rect): Node {
+  return ({
+    getBounds: () => bounds,
+  } as any) as Node;
+}
+
+describe('RevisionTrafficTargetAnchor', () => {
+  it('should return the center of decorator as reference point', () => {
+    const anchor = new RevisionTrafficTargetAnchor(createMockNode(new Rect(50, 30, 80, 40)), 10);
+    expect(anchor.getReferencePoint()).toEqual({ x: 123, y: 37 });
+  });
+
+  it('should return the center of node as reference point', () => {
+    const anchor = new RevisionTrafficTargetAnchor(createMockNode(new Rect(50, 30, 80, 40)), 0);
+    expect(anchor.getReferencePoint()).toEqual({ x: 90, y: 50 });
+  });
+
+  it('should return a decorator radius based anchor location', () => {
+    const anchor = new RevisionTrafficTargetAnchor(createMockNode(new Rect(10, 20, 130, 140)), 10);
+    const loc = anchor.getLocation(new Point(50, 60));
+    expect(loc.x).toBeCloseTo(123.71);
+    expect(loc.y).toBeCloseTo(30.69);
+  });
+
+  it('should return the outer edge as anchor location', () => {
+    const anchor = new RevisionTrafficTargetAnchor(createMockNode(new Rect(10, 20, 130, 140)), 0);
+    const loc = anchor.getLocation(new Point(50, 60));
+    expect(loc.x).toBeCloseTo(31.59);
+    expect(loc.y).toBeCloseTo(37.9);
+  });
+});

--- a/frontend/packages/dev-console/src/components/topology2/components/nodes/KnativeService.tsx
+++ b/frontend/packages/dev-console/src/components/topology2/components/nodes/KnativeService.tsx
@@ -12,13 +12,13 @@ import {
   useAnchor,
   WithDragNodeProps,
   Layer,
-  useSvgAnchor,
   useHover,
   createSvgIdUrl,
   useCombineRefs,
 } from '@console/topology';
 import SvgBoxedText from '../../../svg/SvgBoxedText';
 import Decorator from '../../../topology/shapes/Decorator';
+import RevisionTrafficSourceAnchor from '../anchors/RevisionTrafficSourceAnchor';
 import NodeShadows, { NODE_SHADOW_FILTER_ID, NODE_SHADOW_FILTER_ID_HOVER } from '../NodeShadows';
 
 import './KnativeService.scss';
@@ -31,6 +31,7 @@ export type EventSourceProps = {
   WithDragNodeProps &
   WithContextMenuProps;
 
+const DECORATOR_RADIUS = 13;
 const KnativeService: React.FC<EventSourceProps> = ({
   element,
   selected,
@@ -43,10 +44,18 @@ const KnativeService: React.FC<EventSourceProps> = ({
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
-  const trafficAnchor = useSvgAnchor(AnchorEnd.source, 'revision-traffic');
+  const { data } = element.getData();
+  const hasDataUrl = !!data.url;
+  useAnchor(
+    React.useCallback(
+      (node: Node) => new RevisionTrafficSourceAnchor(node, hasDataUrl ? DECORATOR_RADIUS : 0),
+      [hasDataUrl],
+    ),
+    AnchorEnd.source,
+    'revision-traffic',
+  );
   useAnchor(RectAnchor);
   const { x, y, width, height } = element.getBounds();
-  const { data } = element.getData();
 
   return (
     <g ref={hoverRef} onClick={onSelect} onContextMenu={onContextMenu}>
@@ -69,23 +78,14 @@ const KnativeService: React.FC<EventSourceProps> = ({
           )}
         />
       </Layer>
-      {data.url ? (
+      {hasDataUrl && (
         <Tooltip key="route" content="Open URL" position={TooltipPosition.right}>
-          <Decorator
-            circleRef={trafficAnchor}
-            x={x + width}
-            y={y}
-            radius={13}
-            href={data.url}
-            external
-          >
+          <Decorator x={x + width} y={y} radius={DECORATOR_RADIUS} href={data.url} external>
             <g transform="translate(-6.5, -6.5)">
-              <ExternalLinkAltIcon style={{ fontSize: 13 }} alt="Open URL" />
+              <ExternalLinkAltIcon style={{ fontSize: DECORATOR_RADIUS }} alt="Open URL" />
             </g>
           </Decorator>
         </Tooltip>
-      ) : (
-        <circle ref={trafficAnchor} cx={width} cy={0} r={0} fill="none" />
       )}
       {(data.kind || element.getLabel()) && (
         <SvgBoxedText

--- a/frontend/packages/dev-console/src/components/topology2/components/nodes/RevisionNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology2/components/nodes/RevisionNode.tsx
@@ -1,36 +1,20 @@
 import * as React from 'react';
-import {
-  useAnchor,
-  AnchorEnd,
-  Anchor,
-  SVGAnchor,
-  EllipseAnchor,
-  observer,
-} from '@console/topology';
+import { useAnchor, AnchorEnd, Node, observer } from '@console/topology';
+import RevisionTrafficTargetAnchor from '../anchors/RevisionTrafficTargetAnchor';
 import WorkloadNode from './WorkloadNode';
 
+const DECORATOR_RADIUS = 13;
 const RevisionNode: React.FC<React.ComponentProps<typeof WorkloadNode>> = (props) => {
-  const [trafficAnchor, setTrafficAnchor] = React.useState<Anchor>(
-    new EllipseAnchor(props.element),
-  );
-  const urlAnchorRefCallback = React.useCallback(
-    (node): void => {
-      if (node) {
-        const anchor = new SVGAnchor(props.element);
-        anchor.setSVGElement(node);
-        setTrafficAnchor(anchor);
-      } else {
-        setTrafficAnchor(new EllipseAnchor(props.element));
-      }
-    },
-    [props.element],
-  );
+  const hasDataUrl = !!props.element.getData().data.url;
   useAnchor(
-    React.useCallback(() => trafficAnchor, [trafficAnchor]),
+    React.useCallback(
+      (node: Node) => new RevisionTrafficTargetAnchor(node, hasDataUrl ? DECORATOR_RADIUS : 0),
+      [hasDataUrl],
+    ),
     AnchorEnd.target,
     'revision-traffic',
   );
-  return <WorkloadNode {...props} urlAnchorRef={urlAnchorRefCallback} />;
+  return <WorkloadNode {...props} />;
 };
 
 export default observer(RevisionNode);

--- a/frontend/packages/topology/src/anchors/AbstractAnchor.ts
+++ b/frontend/packages/topology/src/anchors/AbstractAnchor.ts
@@ -1,14 +1,14 @@
 import Point from '../geom/Point';
 import { Anchor, Node } from '../types';
 
-export default abstract class AbstractAnchor<E extends Node = Node> implements Anchor<E> {
-  private owner: Node;
+export default abstract class AbstractAnchor<E extends Node = Node> implements Anchor {
+  private owner: E;
 
-  constructor(owner: Node) {
+  constructor(owner: E) {
     this.owner = owner;
   }
 
-  protected getOwner(): Node {
+  protected getOwner(): E {
     return this.owner;
   }
 

--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -70,7 +70,7 @@ export interface GraphModel extends ElementModel {
   scale?: number;
 }
 
-export interface Anchor<E extends Node = Node> {
+export interface Anchor {
   getLocation(reference: Point): Point;
   getReferencePoint(): Point;
 }
@@ -156,15 +156,15 @@ export interface Graph<E extends GraphModel = GraphModel, D = any> extends Graph
 }
 
 export const isGraph = (element: GraphElement): element is Graph => {
-  return element && element.getKind() === 'graph';
+  return element && element.getKind() === ModelKind.graph;
 };
 
 export const isNode = (element: GraphElement): element is Node => {
-  return element && element.getKind() === 'node';
+  return element && element.getKind() === ModelKind.node;
 };
 
 export const isEdge = (element: GraphElement): element is Edge => {
-  return element && element.getKind() === 'edge';
+  return element && element.getKind() === ModelKind.edge;
 };
 
 export type EventListener<Args extends any[] = any[]> = (...args: Args) => void;

--- a/frontend/packages/topology/src/utils/anchor-utils.ts
+++ b/frontend/packages/topology/src/utils/anchor-utils.ts
@@ -8,7 +8,7 @@ const getEllipseAnchorPoint = (
 ): Point => {
   const { x, y } = reference;
   if (width === 0 || height === 0 || (center.x === x && center.y === y)) {
-    return new Point(center.x, center.y);
+    return center;
   }
 
   const dispX = (center.x - x) / (width / 2);

--- a/frontend/packages/topology/src/utils/index.ts
+++ b/frontend/packages/topology/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './anchor-utils';
 export { default as ControllerContext } from './ControllerContext';
 export { default as ElementContext } from './ElementContext';
 export * from './geom-utils';


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-2216

By replacing `useSvgAnchor` with `useAnchor` and a customized anchor implementation, we avoid triggering browser laying by no longer querying an svg DOM element for properties.

Needed to export our `anchor-utils` functions from the topology package.

/assign @jeff-phillips-18 