### PR TITLE
regrouping is intermittently failing on hover

### DIFF
--- a/frontend/packages/topology/src/behavior/useDndDrop.tsx
+++ b/frontend/packages/topology/src/behavior/useDndDrop.tsx
@@ -102,9 +102,11 @@ export const useDndDrop = <
             return false;
           }
 
-          // translate to this element's coordinates
-          // assumes the node is not within an svg element containing another transform
-          const point = Point.singleUse(x, y);
+          // Rounding the coordinates due to an issue with `point-in-svg-path` returning false
+          // when the coordinates clearly are within the path.
+          const point = Point.singleUse(Math.round(x), Math.round(y));
+          // Translate to this element's coordinates.
+          // Assumes the node is not within an svg element containing another transform.
           elementRef.current.translateFromAbsolute(point);
 
           if (nodeRef.current instanceof SVGPathElement) {


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-2198

The library we use for svg path hit testing, `point-in-svg-path`, seems to have an issue with decimal numbers. Hit testing seemed to fail even when the coordinates clearly lay within the path. Moving the mouse one pixel over results in a pass, then one more pixel results in a fail.

Rounding the hit test coordinates seems to fix the issue.
Tested at various zoom levels and pan transforms.

/assign @jeff-phillips-18 