### PR TITLE
Bug 1770152: Wrap Secondary status in block level element

### DIFF
--- a/frontend/packages/console-shared/src/components/status/SecondaryStatus.tsx
+++ b/frontend/packages/console-shared/src/components/status/SecondaryStatus.tsx
@@ -8,7 +8,11 @@ type SecondaryStatusProps = {
 const SecondaryStatus: React.FC<SecondaryStatusProps> = ({ status }) => {
   const statusLabel = _.compact(_.concat([], status)).join(', ');
   if (statusLabel) {
-    return <small className="text-muted">{statusLabel}</small>;
+    return (
+      <div>
+        <small className="text-muted">{statusLabel}</small>
+      </div>
+    );
   }
   return null;
 };


### PR DESCRIPTION
Before:
<img width="740" alt="Screenshot 2019-11-08 at 11 11 03" src="https://user-images.githubusercontent.com/1121740/68569777-4557af00-045f-11ea-8e11-a870b9337d8a.png">
After:
<img width="720" alt="Screenshot 2019-11-08 at 11 22 35" src="https://user-images.githubusercontent.com/1121740/68569783-4ab4f980-045f-11ea-89f1-41d612957561.png">
