### PR TITLE
Bug 1769325: kubevirt: Do not preselect any user template

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
@@ -26,7 +26,6 @@ export const getInitialVmSettings = (common: CommonData) => {
     [VMSettingsField.DESCRIPTION]: {},
     [VMSettingsField.USER_TEMPLATE]: {
       isHidden: hiddenByProviderOrTemplate,
-      initialized: isProviderImport,
     },
     [VMSettingsField.PROVIDER]: {
       isRequired: asRequired(isProviderImport),

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/prefill-vm-template-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/prefill-vm-template-state-update.ts
@@ -65,7 +65,13 @@ export const prefillVmTemplateUpdater = ({ id, dispatch, getState }: UpdateOptio
       : null;
 
   let isCloudInitForm = null;
-  const vmSettingsUpdate = {};
+  const vmSettingsUpdate = {
+    // ensure the the form is reset when "None" template is selected
+    [VMSettingsField.FLAVOR]: { value: '' },
+    [VMSettingsField.OPERATING_SYSTEM]: { value: '' },
+    [VMSettingsField.WORKLOAD_PROFILE]: { value: '' },
+    [VMSettingsField.PROVISION_SOURCE_TYPE]: { value: '' },
+  };
 
   // filter out oldTemplates
   let networksUpdate = immutableListToShallowJS<VMWizardNetwork>(iGetNetworks(state, id)).filter(

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/vm-settings-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/vm-settings-tab-state-update.ts
@@ -1,7 +1,6 @@
 import {
   hasVmSettingsChanged,
   iGetProvisionSource,
-  iGetVmSettingAttribute,
   iGetVmSettingValue,
 } from '../../../selectors/immutable/vm-settings';
 import { VMSettingsField, VMWizardProps } from '../../../types';
@@ -13,56 +12,10 @@ import {
   iGetLoadedCommonData,
   iGetName,
 } from '../../../selectors/immutable/selectors';
-import { iGetIsLoaded, iGetLoadedData } from '../../../../../utils/immutable';
-import { ignoreCaseSort } from '../../../../../utils/sort';
 import { CUSTOM_FLAVOR } from '../../../../../constants/vm';
 import { ProvisionSource } from '../../../../../constants/vm/provision-source';
 import { getProviders } from '../../../provider-definitions';
 import { prefillVmTemplateUpdater } from './prefill-vm-template-state-update';
-
-export const selectUserTemplateOnLoadedUpdater = ({
-  id,
-  dispatch,
-  getState,
-  changedCommonData,
-}: UpdateOptions) => {
-  const state = getState();
-  if (
-    iGetCommonData(state, id, VMWizardProps.isCreateTemplate) ||
-    iGetVmSettingAttribute(state, id, VMSettingsField.USER_TEMPLATE, 'initialized') ||
-    !(
-      changedCommonData.has(VMWizardProps.userTemplates) ||
-      changedCommonData.has(VMWizardProps.commonTemplates)
-    )
-  ) {
-    return;
-  }
-
-  const iUserTemplatesWrapper = iGetCommonData(state, id, VMWizardProps.userTemplates);
-  const iCommonTemplatesWrapper = iGetCommonData(state, id, VMWizardProps.commonTemplates); // flavor prefill
-
-  if (!iGetIsLoaded(iUserTemplatesWrapper) || !iGetIsLoaded(iCommonTemplatesWrapper)) {
-    return;
-  }
-
-  const iUserTemplates = iGetLoadedData(iUserTemplatesWrapper);
-
-  const firstUserTemplateName = ignoreCaseSort(
-    iUserTemplates
-      .toIndexedSeq()
-      .toArray()
-      .map(iGetName),
-  )[0];
-
-  dispatch(
-    vmWizardInternalActions[InternalActionType.UpdateVmSettings](id, {
-      [VMSettingsField.USER_TEMPLATE]: {
-        initialized: true,
-        value: firstUserTemplateName,
-      },
-    }),
-  );
-};
 
 export const selectedUserTemplateUpdater = (options: UpdateOptions) => {
   const { id, prevState, dispatch, getState } = options;
@@ -92,9 +45,7 @@ export const selectedUserTemplateUpdater = (options: UpdateOptions) => {
     }),
   );
 
-  if (iGetVmSettingAttribute(state, id, VMSettingsField.USER_TEMPLATE, 'initialized')) {
-    prefillVmTemplateUpdater(options);
-  }
+  prefillVmTemplateUpdater(options);
 };
 
 export const provisioningSourceUpdater = ({ id, prevState, dispatch, getState }: UpdateOptions) => {
@@ -157,7 +108,6 @@ export const updateVmSettingsState = (options: UpdateOptions) =>
     ...(iGetCommonData(options.getState(), options.id, VMWizardProps.isProviderImport)
       ? getProviders().map((provider) => provider.getStateUpdater)
       : []),
-    selectUserTemplateOnLoadedUpdater,
     selectedUserTemplateUpdater,
     provisioningSourceUpdater,
     flavorUpdater,

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/strings.ts
@@ -5,6 +5,7 @@ export const CREATE_VM_TEMPLATE = `${CREATE_VM} Template`;
 export const IMPORT_VM = 'Import Virtual Machine';
 export const REVIEW_AND_CREATE = 'Review and create';
 export const NO_TEMPLATE = 'None';
+export const SELECT_TEMPLATE = '--- Select Template ---';
 export const NO_TEMPLATE_AVAILABLE = 'No template available';
 
 export const getCreateVMLikeEntityLabel = (isTemplate: boolean) =>

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/user-templates.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/user-templates.tsx
@@ -3,12 +3,12 @@ import { FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { iGetIsLoaded, iGetLoadedData } from '../../../../utils/immutable';
 import { FormFieldRow } from '../../form/form-field-row';
 import { FormField, FormFieldType } from '../../form/form-field';
-import { FormSelectPlaceholderOption } from '../../../form/form-select-placeholder-option';
 import { ignoreCaseSort } from '../../../../utils/sort';
 import { VMSettingsField } from '../../types';
-import { NO_TEMPLATE, NO_TEMPLATE_AVAILABLE } from '../../strings/strings';
+import { NO_TEMPLATE, NO_TEMPLATE_AVAILABLE, SELECT_TEMPLATE } from '../../strings/strings';
 import { nullOnEmptyChange } from '../../utils/utils';
 import { iGetName } from '../../selectors/immutable/selectors';
+import { iGetFieldValue } from '../../selectors/immutable/vm-settings';
 
 export const UserTemplates: React.FC<UserTemplatesProps> = React.memo(
   ({ userTemplateField, userTemplates, commonTemplates, onChange }) => {
@@ -21,6 +21,7 @@ export const UserTemplates: React.FC<UserTemplatesProps> = React.memo(
         .map(iGetName);
     const sortedNames = ignoreCaseSort(names);
     const hasUserTemplates = sortedNames.length > 0;
+    const hasFieldValue = typeof iGetFieldValue(userTemplateField) === 'undefined';
 
     return (
       <FormFieldRow
@@ -33,12 +34,27 @@ export const UserTemplates: React.FC<UserTemplatesProps> = React.memo(
       >
         <FormField isDisabled={!hasUserTemplates}>
           <FormSelect onChange={nullOnEmptyChange(onChange, VMSettingsField.USER_TEMPLATE)}>
-            <FormSelectPlaceholderOption
-              placeholder={hasUserTemplates ? NO_TEMPLATE : NO_TEMPLATE_AVAILABLE}
-            />
-            {sortedNames.map((name) => {
-              return <FormSelectOption key={name} value={name} label={name} />;
-            })}
+            {hasUserTemplates && (
+              <>
+                <FormSelectOption
+                  key={SELECT_TEMPLATE}
+                  value=""
+                  label={SELECT_TEMPLATE}
+                  isDisabled={!hasFieldValue}
+                />
+                <FormSelectOption key={NO_TEMPLATE} value="" label={NO_TEMPLATE} />
+              </>
+            )}
+            {!hasUserTemplates && (
+              <FormSelectOption
+                key={NO_TEMPLATE_AVAILABLE}
+                value=""
+                label={NO_TEMPLATE_AVAILABLE}
+              />
+            )}
+            {sortedNames.map((name) => (
+              <FormSelectOption key={name} value={name} label={name} />
+            ))}
           </FormSelect>
         </FormField>
       </FormFieldRow>


### PR DESCRIPTION
In Create VM Wizard, no template is preselected when the form is initialized.
Prior this fix, the first user template was automatically used.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1769325