### PR TITLE
Add a null check for params in pipeline template

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
@@ -40,13 +40,14 @@ export const createPipelineForImportFlow = async (formData: GitImportFormData) =
     labels: template.metadata.labels,
   };
 
-  template.spec.params = template.spec.params.map((param) => {
-    if (param.name === 'APP_NAME') {
-      param.default = name;
-    }
-
-    return param;
-  });
+  template.spec.params =
+    template.spec.params &&
+    template.spec.params.map((param) => {
+      if (param.name === 'APP_NAME') {
+        param.default = name;
+      }
+      return param;
+    });
 
   try {
     await createGitResource(git.url, namespace, git.ref);


### PR DESCRIPTION
Related Bug - https://jira.coreos.com/browse/ODC-2202

This PR 
- Fixes the issue of pipeline resource creating failing if no params in pipeline template.