### PR TITLE
Bug 1769742: kubevirt: Fix Cancel button in Create VM Wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.tsx
@@ -116,7 +116,7 @@ const CreateVMWizardFooterComponent: React.FC<CreateVMWizardFooterComponentProps
               </Button>
             )}
             {!activeStep.hideCancelButton && (
-              <Button variant={ButtonVariant.link} onClick={onClose}>
+              <Button variant={ButtonVariant.link} onClick={() => onClose()}>
                 Cancel
               </Button>
             )}


### PR DESCRIPTION
The `<Button>` component passes `event` as first argument which confuses later `disposeOnly` check.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1769742