### PR TITLE
Bug 1770218: Replace mergeAfter with mergeBefore

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/nav-items.ts
@@ -17,8 +17,8 @@ namespace ExtensionProperties {
       NavLinkProps,
       'name' | 'required' | 'disallowed' | 'startsWith' | 'testID'
     >;
-    /** Nav item after which this item should be placed. */
-    mergeAfter?: string;
+    /** Nav item before which this item should be placed. */
+    mergeBefore?: string;
   }
 
   export interface HrefNavItem extends NavItem {

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -63,18 +63,6 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'NavItem/ResourceNS',
-    properties: {
-      section: 'Workloads',
-      componentProps: {
-        name: 'Virtual Machines',
-        resource: models.VirtualMachineModel.plural,
-        required: FLAG_KUBEVIRT,
-      },
-      mergeAfter: 'Pods',
-    },
-  },
-  {
     // NOTE(yaacov): vmtemplates is a template resource with a selector.
     // 'NavItem/ResourceNS' is used, and not 'NavItem/Href', because it injects
     // the namespace needed to get the correct link to a resource ( template with selector ) in our case.
@@ -86,7 +74,19 @@ const plugin: Plugin<ConsumedExtensions> = [
         resource: 'vmtemplates',
         required: FLAG_KUBEVIRT,
       },
-      mergeAfter: 'Virtual Machines',
+      mergeBefore: 'Deployments',
+    },
+  },
+  {
+    type: 'NavItem/ResourceNS',
+    properties: {
+      section: 'Workloads',
+      componentProps: {
+        name: 'Virtual Machines',
+        resource: models.VirtualMachineModel.plural,
+        required: FLAG_KUBEVIRT,
+      },
+      mergeBefore: 'Virtual Machine Templates',
     },
   },
   {

--- a/frontend/packages/metal3-plugin/src/plugin.tsx
+++ b/frontend/packages/metal3-plugin/src/plugin.tsx
@@ -56,12 +56,12 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/ResourceNS',
     properties: {
       section: 'Compute',
-      mergeAfter: 'Machine Health Checks',
       componentProps: {
         name: 'Bare Metal Hosts',
         resource: referenceForModel(BareMetalHostModel),
         required: [FLAGS.BAREMETAL, METAL3_FLAG],
       },
+      mergeBefore: 'ComputeSeparator',
     },
   },
   {

--- a/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
@@ -48,7 +48,6 @@ const plugin: Plugin<ConsumedExtensions> = [
         resource: referenceForModel(models.NetworkAttachmentDefinitionModel),
         required: [FLAG_NET_ATTACH_DEF, FLAG_KUBEVIRT],
       },
-      mergeAfter: 'Network Policies',
     },
   },
   {

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -28,10 +28,12 @@ import { NavSection } from './section';
 import { formatNamespacedRouteForResource } from '../../actions/ui';
 
 type SeparatorProps = {
+  name: string;
   required?: string;
 };
+
 // Wrap `NavItemSeparator` so we can use `required` without prop type errors.
-const Separator: React.FC<SeparatorProps> = () => <NavItemSeparator />;
+const Separator: React.FC<SeparatorProps> = ({ name }) => <NavItemSeparator name={name} />;
 
 const searchStartsWith = ['search'];
 const provisionedServicesStartsWith = ['serviceinstances', 'servicebindings'];
@@ -116,7 +118,7 @@ const AdminNav = () => (
       <ResourceNSLink resource="statefulsets" name="Stateful Sets" />
       <ResourceNSLink resource="secrets" name="Secrets" />
       <ResourceNSLink resource="configmaps" name="Config Maps" />
-      <Separator />
+      <Separator name="WorkloadsSeparator" />
       <ResourceNSLink resource="cronjobs" name="Cron Jobs" />
       <ResourceNSLink resource="jobs" name="Jobs" />
       <ResourceNSLink resource="daemonsets" name="Daemon Sets" />
@@ -211,7 +213,7 @@ const AdminNav = () => (
         name="Machine Health Checks"
         required={FLAGS.MACHINE_HEALTH_CHECK}
       />
-      <Separator required={FLAGS.MACHINE_CONFIG} />
+      <Separator required={FLAGS.MACHINE_CONFIG} name="ComputeSeparator" />
       <ResourceClusterLink
         resource={referenceForModel(MachineConfigModel)}
         name="Machine Configs"

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -30,11 +30,11 @@ const navSectionStateToProps = (
 const mergePluginChild = (
   Children: React.ReactElement[],
   pluginChild: React.ReactElement,
-  mergeAfter?: string,
+  mergeBefore?: string,
 ) => {
-  const index = mergeAfter ? Children.findIndex((c) => c.props.name === mergeAfter) : -1;
+  const index = Children.findIndex((c) => c.props.name === mergeBefore);
   if (index >= 0) {
-    Children.splice(index + 1, 0, pluginChild);
+    Children.splice(index, 0, pluginChild);
   } else {
     Children.push(pluginChild);
   }
@@ -169,7 +169,7 @@ export const NavSection = connect(navSectionStateToProps)(
       this.getPluginNavItems(perspective, title).forEach((item) => {
         const pluginChild = this.mapChild(createLink(item));
         if (pluginChild) {
-          mergePluginChild(Children, pluginChild, item.properties.mergeAfter);
+          mergePluginChild(Children, pluginChild, item.properties.mergeBefore);
         }
       });
 


### PR DESCRIPTION
* plugin nav items are put to the end of the section by default
* using `mergeBefore` plugin nav items can be put as first item in
  the section
* add `name` prop to Separator allows to merge plugin nav items before
  a separator in the section