### PR TITLE
Bug 1768599: Use 0 as default value for no 5xx requests

### DIFF
--- a/frontend/packages/console-app/src/components/dashboards-page/status.ts
+++ b/frontend/packages/console-app/src/components/dashboards-page/status.ts
@@ -36,7 +36,11 @@ export const getControlPlaneComponentHealth = (
   response: PrometheusResponse,
   error,
 ): SubsystemHealth => {
-  if (error) {
+  if (
+    error ||
+    (response &&
+      (response.status === 'success' && _.isNil(_.get(response, 'data.result[0].value[1]'))))
+  ) {
     return { state: HealthState.UNKNOWN, message: 'Not available' };
   }
   if (!response) {

--- a/frontend/packages/console-app/src/queries.ts
+++ b/frontend/packages/console-app/src/queries.ts
@@ -3,4 +3,4 @@ export const CONTROLLER_MANAGERS_UP =
   '(sum(up{job="kube-controller-manager"} == 1) / count(up{job="kube-controller-manager"})) * 100';
 export const SCHEDULERS_UP = '(sum(up{job="scheduler"} == 1) / count(up{job="scheduler"})) * 100';
 export const API_SERVER_REQUESTS_SUCCESS =
-  '(1 - sum(rate(apiserver_request_count{code=~"5.."}[5m])) / sum(rate(apiserver_request_count[5m]))) * 100';
+  '(1 - (sum(rate(apiserver_request_count{code=~"5.."}[5m])) or vector(0))/ sum(rate(apiserver_request_count[5m]))) * 100';


### PR DESCRIPTION
As bug says, there's a possibility for health indicator to falsely show 0% - this can happen if
 - there were no 5xx requests in past 5 minutes - show 100%
 - there we have no data about api requests - show Not Available