### PR TITLE
[WIP] Bug 1768662: Remove kubevrit-web-ui-components from main vendor bundle

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -4,7 +4,6 @@ import {
   getOperatingSystemName,
   getOperatingSystem,
   getWorkloadProfile,
-  getVmTemplate,
   BootOrder,
   getBootableDevicesInOrder,
   TemplateSource,
@@ -17,6 +16,7 @@ import { vmDescriptionModal } from '../modals/vm-description-modal';
 import { VMCDRomModal } from '../modals/cdrom-vm-modal';
 import { getDescription } from '../../selectors/selectors';
 import { getCDRoms } from '../../selectors/vm/selectors';
+import { getVMTemplate } from '../../selectors/vm-template/selectors';
 import { vmFlavorModal } from '../modals';
 import { getFlavorText } from '../flavor-text';
 import { EditButton } from '../edit-button';
@@ -32,7 +32,7 @@ export const VMTemplateResourceSummary: React.FC<VMTemplateResourceSummaryProps>
   canUpdateTemplate,
 }) => {
   const id = getBasicID(template);
-  const base = getVmTemplate(template);
+  const base = getVMTemplate(template);
 
   const description = getDescription(template);
   const os = getOperatingSystemName(template) || getOperatingSystem(template);

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getVmTemplate, BootOrder, getBootableDevicesInOrder } from 'kubevirt-web-ui-components';
+import { BootOrder, getBootableDevicesInOrder } from 'kubevirt-web-ui-components';
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
 import { PodKind } from '@console/internal/module/k8s';
 import { getName, getNamespace, getNodeName } from '@console/shared';
@@ -11,6 +11,7 @@ import { vmDescriptionModal, vmFlavorModal } from '../modals';
 import { VMCDRomModal } from '../modals/cdrom-vm-modal';
 import { getDescription } from '../../selectors/selectors';
 import { getCDRoms } from '../../selectors/vm/selectors';
+import { getVMTemplate } from '../../selectors/vm-template/selectors';
 import { getVMStatus } from '../../statuses/vm/vm';
 import { getFlavorText } from '../flavor-text';
 import { EditButton } from '../edit-button';
@@ -44,7 +45,7 @@ export const VMDetailsItem: React.FC<VMDetailsItemProps> = ({
 };
 
 export const VMResourceSummary: React.FC<VMResourceSummaryProps> = ({ vm, canUpdateVM }) => {
-  const template = getVmTemplate(vm);
+  const template = getVMTemplate(vm);
 
   const id = getBasicID(vm);
   const description = getDescription(vm);

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-template/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-template/selectors.ts
@@ -1,5 +1,4 @@
 import * as _ from 'lodash';
-import { getVmTemplate } from 'kubevirt-web-ui-components';
 import { TemplateKind } from '@console/internal/module/k8s';
 import { VirtualMachineModel } from '../../models';
 import { VMKind, VMLikeEntityKind } from '../../types';
@@ -11,6 +10,16 @@ import {
 } from '../../constants';
 import { getLabels } from '../selectors';
 import { getOperatingSystem, getWorkloadProfile } from '../vm/selectors';
+
+export const getVMTemplate = (vm: VMLikeEntityKind): { name: string; namespace: string } => {
+  if (!vm || !vm.metadata || !vm.metadata.labels) {
+    return null;
+  }
+
+  const name = vm.metadata.labels['vm.kubevirt.io/template'];
+  const namespace = vm.metadata.labels['vm.kubevirt.io/template-namespace'];
+  return name && namespace ? { name, namespace } : null;
+};
 
 export const selectVM = (vmTemplate: TemplateKind): VMKind =>
   _.get(vmTemplate, 'objects', []).find((obj) => obj.kind === VirtualMachineModel.kind);
@@ -80,7 +89,7 @@ export const getTemplateForFlavor = (templates: TemplateKind[], vm: VMKind, flav
 };
 
 export const getFlavors = (vm: VMLikeEntityKind, templates: TemplateKind[]) => {
-  const vmTemplate = getVmTemplate(vm);
+  const vmTemplate = getVMTemplate(vm);
 
   const flavors = {
     // always listed


### PR DESCRIPTION
/assign @mareklibra @vojtechszocs 
cc @rhamilto 

I don't have an environment to test. @mareklibra or @vojtechszocs, can one of you verify that I haven't broken anything?

/hold
to verify the changes

Original `getVmTemplate` implementation here: https://github.com/kubevirt/web-ui-components/blob/4b172e362c07e994912960750d3e7fffaf2aa912/src/selectors/vm/selectors.js#L33-L43

<img width="573" alt="Webpack Bundle Analyzer  8 Nov 2019 at 13:2  2019-11-08 13-15-02" src="https://user-images.githubusercontent.com/1167259/68500490-d8a79f00-0229-11ea-9e60-ab1635f2a5a1.png">
