### PR TITLE
Alertmanager Configuration: Routing Labels Editor display fix

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -229,6 +229,10 @@ $tooltip-background-color: #151515;
   z-index: 1;
 }
 
+.co-alert-manager-routing-labels-useregex {
+  margin-top: 6px;
+}
+
 .co-alert-manager-yaml__explanation {
   margin-bottom: 0;
 }

--- a/frontend/public/components/monitoring/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/alert-manager-receiver-forms.tsx
@@ -147,7 +147,7 @@ const RoutingLabels = ({ routeLabels, setRouteLabels, showAddLabel }) => {
           <div className="row form-group" key={i}>
             <div className="col-xs-10">
               <div className="row">
-                <div className="col-xs-6 pairs-list__name-field">
+                <div className="col-xs-4 pairs-list__name-field">
                   <div className="form-group">
                     <input
                       type="text"
@@ -160,7 +160,7 @@ const RoutingLabels = ({ routeLabels, setRouteLabels, showAddLabel }) => {
                     />
                   </div>
                 </div>
-                <div className="col-xs-6 pairs-list__value-field">
+                <div className="col-xs-4 pairs-list__value-field">
                   <div className="form-group">
                     <input
                       type="text"
@@ -173,25 +173,21 @@ const RoutingLabels = ({ routeLabels, setRouteLabels, showAddLabel }) => {
                     />
                   </div>
                 </div>
-              </div>
-              {!isDefaultReceiverRouteLabel && (
-                <>
-                  <div className="row">
-                    <div className="col-xs-12 col-sm-12">
-                      <div className="form-group">
-                        <label className="co-no-bold">
-                          <input
-                            type="checkbox"
-                            onChange={(e) => onRoutingLabelRegexChange(e, _.toNumber(i))}
-                            checked={routeLabel.isRegex}
-                          />
-                          &nbsp; Regular Expression
-                        </label>
-                      </div>
+                {!isDefaultReceiverRouteLabel && (
+                  <div className="col-xs-4">
+                    <div className="form-group co-alert-manager-routing-labels-useregex">
+                      <label className="co-no-bold">
+                        <input
+                          type="checkbox"
+                          onChange={(e) => onRoutingLabelRegexChange(e, _.toNumber(i))}
+                          checked={routeLabel.isRegex}
+                        />
+                        &nbsp; Regular Expression
+                      </label>
                     </div>
                   </div>
-                </>
-              )}
+                )}
+              </div>
             </div>
             {!isDefaultReceiverRouteLabel && (
               <>


### PR DESCRIPTION
### Regular Expression checkbox should be on same line as row:
![image](https://user-images.githubusercontent.com/12733153/68501038-253faa00-022b-11ea-8160-8081396ae3eb.png)

### Fixed
![image](https://user-images.githubusercontent.com/12733153/68501017-1822bb00-022b-11ea-8040-f939a7b0ab4b.png)
