### PR TITLE
update force layout when nodes and edges are added or removed

### DIFF
--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -204,3 +204,9 @@ export interface Controller extends WithState {
   fireEvent(type: string, ...args: any): void;
   getElements(): GraphElement[];
 }
+
+export type AddElementEventListener = EventListener<[GraphElement[]]>;
+export type RemoveElementEventListener = EventListener<[GraphElement[]]>;
+
+export const ADD_ELEMENT_EVENT = 'add-element';
+export const REMOVE_ELEMENT_EVENT = 'remove-element';

--- a/frontend/packages/topology/src/utils/useHover.ts
+++ b/frontend/packages/topology/src/utils/useHover.ts
@@ -16,7 +16,7 @@ const useHover = <T extends Element>(
   );
 
   // The unset handle needs to be referred by listeners in different closures.
-  const unsetHandle = React.useRef<any>();
+  const unsetHandle = React.useRef<number>();
 
   const callbackRef = useCallbackRef(
     React.useCallback(
@@ -27,7 +27,7 @@ const useHover = <T extends Element>(
 
           const onMouseEnter = () => {
             if (delay != null) {
-              delayHandle = setTimeout(() => {
+              delayHandle = window.setTimeout(() => {
                 delayHandle = clearTimeout(unsetHandle.current);
                 setHover(true);
               }, delay);
@@ -54,7 +54,7 @@ const useHover = <T extends Element>(
               // This can happen with layers. Rendering a node to a new layer will unmount the old node
               // and remount a new node at the same location. This will prevent flickering and getting
               // stuck in a hover state.
-              unsetHandle.current = setTimeout(() => setHover(false), 0);
+              unsetHandle.current = window.setTimeout(() => setHover(false), 0);
             }
           };
         }


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-2220

Added two new events to the topology visualization: `ADD_ELEMENT_EVENT`, `REMOVE_ELEMENT_EVENT`.
These events are fired (and batched when deserializing a model), whenever new nodes are added and removed. The Force layout is updated to listen for these events. This greatly simplifies the force layout update process which was previously using mobx reactions to react to changes in the graph nodes and edges. This process involved diffing the change because a reaction would fire when the nodes and edges were re-ordered in the array in addition to adding and removing.

The force layout now updates its internal data model on add and remove. It will restart the simulation only when new nodes and edges are added, but not when removed.

This has fixed the issue where new edges were not participating in the layout after a new connection was made.

Before:
![edge](https://user-images.githubusercontent.com/14068621/68519725-ddd41080-0260-11ea-9cae-6eb00d708c78.gif)

After:
![deleteedge](https://user-images.githubusercontent.com/14068621/68519619-25a66800-0260-11ea-868e-2c2a7f716722.gif)

/assign @jeff-phillips-18 