### PR TITLE
tests: use config map in annotation tests

### DIFF
--- a/frontend/integration-tests/tests/modal-annotations.scenario.ts
+++ b/frontend/integration-tests/tests/modal-annotations.scenario.ts
@@ -8,7 +8,7 @@ import * as modalAnnotationsView from '../views/modal-annotations.view';
 import * as yamlView from '../views/yaml.view';
 
 const BROWSER_TIMEOUT = 15000;
-const WORKLOAD_NAME = `modal-${testName}`;
+const CONFIG_MAP_NAME = `modal-${testName}`;
 const Actions = {
   add: 'add',
   update: 'update',
@@ -17,14 +17,20 @@ const Actions = {
 
 describe('Modal Annotations', () => {
   beforeAll(async () => {
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps`);
     await crudView.isLoaded();
     await crudView.createYAMLButton.click();
     await yamlView.isLoaded();
     const content = await yamlView.getEditorContent();
     const newContent = _.defaultsDeep(
       {},
-      { metadata: { name: WORKLOAD_NAME, labels: { 'lbl-modal': testName } } },
+      {
+        metadata: {
+          name: CONFIG_MAP_NAME,
+          labels: { test: testName },
+          annotations: { test: testName },
+        },
+      },
       safeLoad(content),
     );
     await yamlView.setEditorContent(safeDump(newContent));
@@ -41,10 +47,10 @@ describe('Modal Annotations', () => {
   });
 
   afterAll(async () => {
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps`);
     await crudView.resourceRowsPresent();
-    await crudView.nameFilter.sendKeys(WORKLOAD_NAME);
-    await crudView.deleteRow('Deployment')(WORKLOAD_NAME);
+    await crudView.nameFilter.sendKeys(CONFIG_MAP_NAME);
+    await crudView.deleteRow('ConfigMap')(CONFIG_MAP_NAME);
     checkLogs();
     checkErrors();
   });
@@ -85,7 +91,7 @@ describe('Modal Annotations', () => {
     annotationKey: string,
     annotationValue: string,
   ) {
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments/${WORKLOAD_NAME}`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps/${CONFIG_MAP_NAME}`);
     await clickModalAnnotationsLink();
     await modalAnnotationsView.isLoaded();
 
@@ -119,7 +125,7 @@ describe('Modal Annotations', () => {
     isPresent: boolean,
   ) {
     await crudAnnotationFromDetail(action, annotationKey, annotationValue);
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments/${WORKLOAD_NAME}`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps/${CONFIG_MAP_NAME}`);
     await clickModalAnnotationsLink();
     await modalAnnotationsView.isLoaded();
     await validateKeyAndValue(annotationKey, annotationValue, isPresent);
@@ -138,7 +144,7 @@ describe('Modal Annotations', () => {
     const annotationValue = 'delete';
 
     await crudAnnotationFromDetail(Actions.add, annotationKey, annotationValue);
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments/${WORKLOAD_NAME}`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps/${CONFIG_MAP_NAME}`);
     await browser.wait(
       until.textToBePresentInElement(crudView.modalAnnotationsLink, '2'),
       BROWSER_TIMEOUT,
@@ -148,7 +154,7 @@ describe('Modal Annotations', () => {
     await validateKeyAndValue(annotationKey, annotationValue, true);
 
     await crudAnnotationFromDetail(Actions.delete, annotationKey, annotationValue);
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments/${WORKLOAD_NAME}`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps/${CONFIG_MAP_NAME}`);
     await browser.wait(
       until.textToBePresentInElement(crudView.modalAnnotationsLink, '1'),
       BROWSER_TIMEOUT,
@@ -161,7 +167,7 @@ describe('Modal Annotations', () => {
   // Scenario: Add numeric Annotation from grid
   // Given I log in into the console if it's required
   //   And I create a deployment
-  //   And I go to the deployments list page
+  //   And I go to the configmaps list page
   //   And I open modal annotations from gear option
   //  When I add an annotation
   //   And I close the modal
@@ -173,19 +179,19 @@ describe('Modal Annotations', () => {
     const annotationValue = '2233344';
     const annotationYAML = `${annotationKey}: '${annotationValue}'`;
 
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps`);
     await crudView.isLoaded();
-    await crudView.clickKebabAction(WORKLOAD_NAME, crudView.actions.annotations);
+    await crudView.clickKebabAction(CONFIG_MAP_NAME, crudView.actions.annotations);
     await modalAnnotationsView.isLoaded();
     await modalAnnotationsView.addAnnotation(annotationKey, annotationValue);
     await modalAnnotationsView.isLoaded();
     await modalAnnotationsView.confirmActionBtn.click();
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps`);
     await crudView.isLoaded();
-    await crudView.clickKebabAction(WORKLOAD_NAME, crudView.actions.annotations);
+    await crudView.clickKebabAction(CONFIG_MAP_NAME, crudView.actions.annotations);
     await modalAnnotationsView.isLoaded();
     await validateKeyAndValue(annotationKey, annotationValue, true);
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments/${WORKLOAD_NAME}/yaml`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps/${CONFIG_MAP_NAME}/yaml`);
     await yamlView.isLoaded();
     expect(yamlView.getEditorContent()).toContain(annotationYAML);
   });
@@ -207,7 +213,7 @@ describe('Modal Annotations', () => {
 
     await crudAndValidate(Actions.add, annotationKey, annotationValue, true);
 
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments/${WORKLOAD_NAME}/yaml`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps/${CONFIG_MAP_NAME}/yaml`);
     await yamlView.isLoaded();
     expect(yamlView.getEditorContent()).toContain(annotationYAML);
   });
@@ -227,7 +233,7 @@ describe('Modal Annotations', () => {
 
     await crudAndValidate(Actions.add, annotationKey, annotationValue, true);
 
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments/${WORKLOAD_NAME}/yaml`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps/${CONFIG_MAP_NAME}/yaml`);
     await yamlView.isLoaded();
     expect(yamlView.getEditorContent()).toContain(annotationYAML);
   });
@@ -280,7 +286,7 @@ describe('Modal Annotations', () => {
     await crudAndValidate(Actions.add, annotationKey, annotationValueBeforeUpd, true);
     await crudAndValidate(Actions.update, annotationKey, annotationValueAfterUpd, true);
 
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments/${WORKLOAD_NAME}/yaml`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps/${CONFIG_MAP_NAME}/yaml`);
     await yamlView.isLoaded();
     expect(yamlView.getEditorContent()).toContain(annotationYAML);
   });
@@ -288,7 +294,7 @@ describe('Modal Annotations', () => {
   // Scenario: Cancel add Annotation
   // Given I log in into the console if it's required
   //   And I create a deployment
-  //   And I go to the deployments list page
+  //   And I go to the configmaps list page
   //   And I open modal annotations from gear option
   //  When I add an annotation
   //   And I cancel the action
@@ -298,15 +304,15 @@ describe('Modal Annotations', () => {
     const annotationKey = 'KEY_Cancel';
     const annotationValue = 'cancel';
 
-    await browser.get(`${appHost}/k8s/ns/${testName}/deployments`);
+    await browser.get(`${appHost}/k8s/ns/${testName}/configmaps`);
     await crudView.isLoaded();
-    await crudView.clickKebabAction(WORKLOAD_NAME, crudView.actions.annotations);
+    await crudView.clickKebabAction(CONFIG_MAP_NAME, crudView.actions.annotations);
     await modalAnnotationsView.isLoaded();
     await modalAnnotationsView.addAnnotation(annotationKey, annotationValue);
     await modalAnnotationsView.isLoaded();
     await modalAnnotationsView.cancelBtn.click();
     await crudView.isLoaded();
-    await crudView.clickKebabAction(WORKLOAD_NAME, crudView.actions.annotations);
+    await crudView.clickKebabAction(CONFIG_MAP_NAME, crudView.actions.annotations);
     await modalAnnotationsView.isLoaded();
     await validateKeyAndValue(annotationKey, annotationValue, false);
   });


### PR DESCRIPTION
https://jira.coreos.com/browse/CONSOLE-1294

This should reduce the number of StaleElementReferenceErrors we see in
CI. Deployments roll out and make frequent status updates when they're
created, which changes the DOM while the tests run. Config maps avoid
this possible error.