### PR TITLE
Break long words in dashboard status alerts

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -36,7 +36,7 @@ export const StatusItem: React.FC<StatusItemProps> = ({
           <div className="co-health-card__alert-item-timestamp co-status-card__health-item-text text-secondary">
             {timestamp && <Timestamp simple timestamp={timestamp} />}
           </div>
-          <span className="co-status-card__health-item-text">{message}</span>
+          <span className="co-status-card__health-item-text co-break-word">{message}</span>
         </div>
         <div className="co-status-card__alert-item-more">
           <LinkComponent />


### PR DESCRIPTION
/kind bug
/assign @rawagner 

@andybraren Have we considered top aligning the icon and view details link? I think it would look better for long messages.

Before:

<img width="447" alt="Dashboards · OKD 2019-11-09 11-12-06" src="https://user-images.githubusercontent.com/1167259/68531637-69da4c80-02e2-11ea-835b-8bf3e7c8969e.png">

After:

<img width="450" alt="Dashboards · OKD 2019-11-09 11-16-58" src="https://user-images.githubusercontent.com/1167259/68531646-78c0ff00-02e2-11ea-8b01-e796780eae1e.png">
