### PR TITLE
tests: more guards against StaleElementReferenceError in OLM scenarios

### DIFF
--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -27,6 +27,9 @@ export const resourceRowsPresent = () =>
 
 export const resourceRows = $$('[data-test-rows="resource-row"]');
 export const resourceRowNamesAndNs = $$('.co-m-resource-icon + a');
+
+// FIXME: Avoid this helper since it can result in StaleElementReferenceErrors.
+// Prefer to use a `data-test-` attribute on the row.
 export const rowForName = (name: string) =>
   resourceRows
     .filter((row) =>

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
@@ -3,9 +3,10 @@ import { browser, $, element, ExpectedConditions as until, by } from 'protractor
 import * as _ from 'lodash';
 import {
   appHost,
-  testName,
-  checkLogs,
   checkErrors,
+  checkLogs,
+  retry,
+  testName,
 } from '@console/internal-integration-tests/protractor.conf';
 import * as crudView from '@console/internal-integration-tests/views/crud.view';
 import * as catalogView from '@console/internal-integration-tests/views/catalog.view';
@@ -175,7 +176,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
   });
 
   it('displays metadata about the created `Jaeger` in its "Overview" section', async () => {
-    await operatorView.operandLink(jaegerName).click();
+    await retry(() => operatorView.operandLink(jaegerName).click());
     await browser.wait(until.presenceOf($('.loading-box__loaded')), 5000);
 
     expect($('.co-operand-details__section--info').isDisplayed()).toBe(true);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
@@ -3,9 +3,10 @@ import { browser, $, $$, element, ExpectedConditions as until, by } from 'protra
 import * as _ from 'lodash';
 import {
   appHost,
-  testName,
-  checkLogs,
   checkErrors,
+  checkLogs,
+  retry,
+  testName,
 } from '@console/internal-integration-tests/protractor.conf';
 import * as crudView from '@console/internal-integration-tests/views/crud.view';
 import * as catalogView from '@console/internal-integration-tests/views/catalog.view';
@@ -175,13 +176,13 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
   it('displays new `Prometheus` that was created from YAML editor', async () => {
     await $('#save-changes').click();
     await crudView.isLoaded();
-    await browser.wait(until.visibilityOf(crudView.rowForName('example')));
+    await browser.wait(until.visibilityOf(operatorView.operandLink('example')));
 
-    expect(crudView.rowForName('example').getText()).toContain('Prometheus');
+    expect(operatorView.operandKind('Prometheus').isDisplayed()).toBe(true);
   });
 
   it('displays metadata about the created `Prometheus` in its "Overview" section', async () => {
-    await operatorView.operandLink('example').click();
+    await retry(() => operatorView.operandLink('example').click());
     await browser.wait(until.presenceOf($('.loading-box__loaded')), 5000);
 
     expect($('.co-operand-details__section--info').isDisplayed()).toBe(true);


### PR DESCRIPTION
Guard against the failure here:

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_console/3320/pull-ci-openshift-console-master-e2e-gcp-console/2611

That `StaleElementReferenceError` occurred on this line:

https://github.com/openshift/console/blob/baeaf1264ae7fd93ffc8d976459155265f4341c3/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts#L184

All this does is select an element using a `data-test` attribute and clicks it, which can't really be simplified further. Add in some basic retry logic to avoid it in the future.

/kind test-flake