### PR TITLE
add role binding from ui and show validation messages

### DIFF
--- a/frontend/packages/dev-console/src/components/formik-fields/DropdownField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/DropdownField.tsx
@@ -28,6 +28,7 @@ const DropdownField: React.FC<DropdownFieldProps> = ({ label, helpText, required
         dropDownClassName={cx({ 'dropdown--full-width': props.fullWidth })}
         aria-describedby={`${fieldId}-helper`}
         onChange={(value: string) => {
+          props.onChange && props.onChange(value);
           setFieldValue(props.name, value);
           setFieldTouched(props.name, true);
         }}

--- a/frontend/packages/dev-console/src/components/formik-fields/ResourceDropdownField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/ResourceDropdownField.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import cx from 'classnames';
+import { useField, useFormikContext, FormikValues } from 'formik';
+import { FormGroup } from '@patternfly/react-core';
+import { Firehose, FirehoseResource } from '@console/internal/components/utils';
+import ResourceDropdown from '../dropdown/ResourceDropdown';
+import { DropdownFieldProps } from './field-types';
+import { getFieldId } from './field-utils';
+
+export interface ResourceDropdownFieldProps extends DropdownFieldProps {
+  dataSelector: string[] | number[] | symbol[];
+  resources: FirehoseResource[];
+}
+const ResourceDropdownField: React.FC<ResourceDropdownFieldProps> = ({
+  label,
+  helpText,
+  required,
+  fullWidth,
+  dataSelector,
+  resources,
+  ...props
+}) => {
+  const [field, { touched, error }] = useField(props.name);
+  const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
+  const fieldId = getFieldId(props.name, 'ns-dropdown');
+  const isValid = !(touched && error);
+  const errorMessage = !isValid ? error : '';
+  return (
+    <FormGroup
+      fieldId={fieldId}
+      label={label}
+      helperText={helpText}
+      helperTextInvalid={errorMessage}
+      isValid={isValid}
+      isRequired={required}
+    >
+      <Firehose resources={resources}>
+        <ResourceDropdown
+          {...props}
+          id={fieldId}
+          dataSelector={dataSelector}
+          selectedKey={field.value}
+          dropDownClassName={cx({ 'dropdown--full-width': fullWidth })}
+          onChange={(value: string) => {
+            props.onChange && props.onChange(value);
+            setFieldValue(props.name, value);
+            setFieldTouched(props.name, true);
+          }}
+        />
+      </Firehose>
+    </FormGroup>
+  );
+};
+
+export default ResourceDropdownField;

--- a/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
@@ -37,6 +37,7 @@ export interface DropdownFieldProps extends FieldProps {
   title?: React.ReactNode;
   fullWidth?: boolean;
   disabled?: boolean;
+  onChange?: (value: string) => void;
 }
 
 export interface EnvironmentFieldProps extends FieldProps {

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -42,6 +42,7 @@ const DeployImage: React.FC<Props> = ({ namespace, projects, activeApplication, 
       image: '',
       tag: '',
       namespace: '',
+      grantAccess: true,
     },
     isi: {
       name: '',

--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -21,10 +21,7 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
   imageStreams,
 }) => (
   <Form className="co-deploy-image" onSubmit={handleSubmit}>
-    <ImageSearchSection
-      projects={projects.loaded ? projects.data : []}
-      imageStreams={imageStreams.loaded ? imageStreams.data : []}
-    />
+    <ImageSearchSection imageStreams={imageStreams.loaded ? imageStreams.data : []} />
     <AppSection
       project={values.project}
       noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
@@ -10,10 +10,9 @@ import SearchStatus from './SearchStatus';
 import SearchResults from './SearchResults';
 
 export interface ImageSearchSectionProps {
-  projects: K8sResourceKind[];
   imageStreams: K8sResourceKind[];
 }
-const ImageSearchSection: React.FC<ImageSearchSectionProps> = ({ projects, imageStreams }) => {
+const ImageSearchSection: React.FC<ImageSearchSectionProps> = ({ imageStreams }) => {
   const { values, setFieldValue, initialValues } = useFormikContext<FormikValues>();
   const [registry, setRegistry] = React.useState(values.registry);
 
@@ -49,7 +48,7 @@ const ImageSearchSection: React.FC<ImageSearchSectionProps> = ({ projects, image
           {
             label: imageRegistryType.Internal.label,
             value: imageRegistryType.Internal.value,
-            activeChildren: <ImageStream projects={projects} imageStreams={imageStreams} />,
+            activeChildren: <ImageStream imageStreams={imageStreams} />,
           },
         ]}
       />

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStream.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStream.tsx
@@ -1,150 +1,133 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Alert } from '@patternfly/react-core';
-import { useField, useFormikContext, FormikValues } from 'formik';
-import { k8sGet, K8sResourceKind } from '@console/internal/module/k8s';
-import { ImageStreamTagModel } from '@console/internal/models';
-import { DropdownField } from '../../formik-fields';
+import { useFormikContext, FormikValues } from 'formik';
+import { k8sGet } from '@console/internal/module/k8s';
+import { ImageStreamTagModel, RoleBindingModel } from '@console/internal/models';
+import { useAccessReview } from '@console/internal/components/utils';
+import { DropdownField, CheckboxField } from '../../formik-fields';
 import { ImageStreamProps } from '../import-types';
 import {
   getSuggestedName,
   getPorts,
   makePortName,
-  normalizeBuilderImages,
-  NormalizedBuilderImages,
-  BuilderImage,
-  registryType,
-  builderImagesNamespace,
+  RegistryType,
+  getProjectResource,
+  BuilderImagesNamespace,
+  getImageStreamByNamespace,
+  getImageStreamTags,
 } from '../../../utils/imagestream-utils';
 import './ImageStream.scss';
+import ResourceDropdownField from '../../formik-fields/ResourceDropdownField';
 
 const ImageStream: React.FC<ImageStreamProps> = ({ imageStreams }) => {
-  const projectList = {};
+  const resources = getProjectResource();
+  let imageStreamList = {};
+  let imageStreamTagList = {};
 
-  imageStreams.reduce((acc, { metadata: { namespace } }) => {
-    if (!acc[namespace]) {
-      acc[namespace] = namespace;
-    }
-    return acc;
-  }, projectList);
-
-  const [imageNamespace] = useField('imageStream.namespace');
-  const [imageTag] = useField('imageStream.tag');
-  const [imageName] = useField('imageStream.image');
-  const { values, setFieldValue, setFieldError, initialValues } = useFormikContext<FormikValues>();
-  const [selectedProject, setselectedProject] = React.useState(imageNamespace.value);
-  const [selectedTag, setselectedTag] = React.useState(imageTag.value);
-  const [selectedName, setselectedName] = React.useState(imageName.value);
-
-  const searchImageTag = React.useCallback(() => {
-    setFieldValue('isSearchingForImage', true);
-    k8sGet(ImageStreamTagModel, `${imageName.value}:${imageTag.value}`, imageNamespace.value)
-      .then((imageStreamImport) => {
-        const { image, tag, status } = imageStreamImport;
-        const name = imageName.value;
-        const isi = { name, image, tag, status };
-        const ports = getPorts(isi);
-        setFieldValue('isSearchingForImage', false);
-        setFieldValue('isi.name', name);
-        setFieldValue('isi.image', image);
-        setFieldValue('isi.tag', imageTag.value);
-        setFieldValue('isi.ports', ports);
-        setFieldValue('image.ports', ports);
-        setFieldValue('name', getSuggestedName(name));
-        !values.application.name &&
-          setFieldValue('application.name', `${getSuggestedName(name)}-app`);
-        // set default port value
-        const targetPort = _.head(ports);
-        targetPort && setFieldValue('route.targetPort', makePortName(targetPort));
-      })
-      .catch((error) => {
-        setFieldError('isi.image', error.message);
-        setFieldValue('isi', {});
-        setFieldValue('isSearchingForImage', false);
-      });
-  }, [
+  const {
+    values: { imageStream, application, project, registry },
     setFieldValue,
-    imageName.value,
-    imageTag.value,
-    imageNamespace.value,
-    values.application.name,
     setFieldError,
-  ]);
-  const getImageStreamByNamespace = (ns: string) => {
-    const imageStreamsList = {};
-    const isBuilderImageNamespace = ns === builderImagesNamespace.Openshift;
-    const imgStreams = isBuilderImageNamespace
-      ? (normalizeBuilderImages(imageStreams) as NormalizedBuilderImages)
-      : (imageStreams as K8sResourceKind[]);
-    _.each(imgStreams, (img: BuilderImage | K8sResourceKind) => {
-      const { name, namespace } = isBuilderImageNamespace
-        ? (img as BuilderImage).obj.metadata
-        : (img as K8sResourceKind).metadata;
-      if (namespace === ns) {
-        imageStreamsList[name] = name;
-      }
-    });
-    return imageStreamsList;
-  };
-  const getImageStreamTags = (name: string) => {
-    const tags = {};
-    const imageStream = _.find(imageStreams, ['metadata.name', name]);
-    name &&
-      !_.isEmpty(imageStream) &&
-      _.each(imageStream.status.tags, ({ tag }) => {
-        tags[tag] = tag;
-      });
-    return tags;
-  };
-  React.useEffect(() => {
-    if (imageNamespace.value !== selectedProject) {
-      setselectedProject(imageNamespace.value);
-      setFieldValue('imageStream.image', '');
-      setFieldValue('imageStream.tag', '');
-      setFieldValue('isi', initialValues.isi);
-    }
-    if (imageName.value !== selectedName) {
-      setselectedName(imageName.value);
-      setFieldValue('imageStream.tag', '');
-    }
-    if (imageTag.value !== selectedTag) {
-      setselectedTag(imageTag.value);
-      imageTag.value !== '' && searchImageTag();
-    }
-  }, [
-    imageNamespace,
-    imageName,
-    imageTag,
-    selectedProject,
-    selectedName,
-    selectedTag,
-    setFieldValue,
-    initialValues.isi,
-    searchImageTag,
-  ]);
+    initialValues,
+  } = useFormikContext<FormikValues>();
+  const [hasAccessToPullImage, setHasAccessToPullImage] = React.useState(false);
+
+  const searchImageTag = React.useCallback(
+    (selectedTag: string) => {
+      setFieldValue('isSearchingForImage', true);
+      k8sGet(ImageStreamTagModel, `${imageStream.image}:${selectedTag}`, imageStream.namespace)
+        .then((imageStreamImport) => {
+          const { image, tag, status } = imageStreamImport;
+          const name = imageStream.image;
+          const isi = { name, image, tag, status };
+          const ports = getPorts(isi);
+          setFieldValue('isSearchingForImage', false);
+          setFieldValue('isi.name', name);
+          setFieldValue('isi.image', image);
+          setFieldValue('isi.tag', selectedTag);
+          setFieldValue('isi.ports', ports);
+          setFieldValue('image.ports', ports);
+          setFieldValue('name', getSuggestedName(name));
+          !application.name && setFieldValue('application.name', `${getSuggestedName(name)}-app`);
+          // set default port value
+          const targetPort = _.head(ports);
+          targetPort && setFieldValue('route.targetPort', makePortName(targetPort));
+        })
+        .catch((error) => {
+          setFieldError('isi.image', error.message);
+          setFieldValue('isi', {});
+          setFieldValue('isSearchingForImage', false);
+        });
+    },
+    [setFieldValue, imageStream, application.name, setFieldError],
+  );
+
+  const hasCreateAccess = useAccessReview({
+    group: RoleBindingModel.apiGroup,
+    resource: RoleBindingModel.plural,
+    verb: 'create',
+    name: 'system:image-puller',
+    namespace: imageStream.namespace,
+  });
+  if (hasCreateAccess) {
+    imageStreamList = getImageStreamByNamespace(imageStreams, imageStream.namespace);
+    imageStreamTagList = getImageStreamTags(imageStreams, imageStream.image, imageStream.namespace);
+  }
+  const isNamespaceSelected = imageStream.namespace !== '';
+  const isStreamsAvailable = isNamespaceSelected && !_.isEmpty(imageStreamList);
+  const isTagsAvailable = isStreamsAvailable && !_.isEmpty(imageStreamTagList);
+  const isImageStreamSelected = imageStream.image !== '';
+  const canGrantAccess =
+    hasCreateAccess &&
+    isStreamsAvailable &&
+    isTagsAvailable &&
+    !hasAccessToPullImage &&
+    isNamespaceSelected &&
+    registry === RegistryType.Internal &&
+    imageStream.namespace !== BuilderImagesNamespace.Openshift &&
+    project.name !== imageStream.namespace;
 
   return (
     <>
       <div className="row">
         <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
-          <DropdownField
+          <ResourceDropdownField
             name="imageStream.namespace"
             label="Projects"
-            items={projectList}
-            title="Project"
+            title="Select Project"
             fullWidth
             required
+            resources={resources}
+            dataSelector={['metadata', 'name']}
+            onChange={(selectedProject) => {
+              setFieldValue('imageStream.image', '');
+              setFieldValue('imageStream.tag', '');
+              setFieldValue('isi', initialValues.isi);
+              k8sGet(RoleBindingModel, 'system:image-puller', selectedProject)
+                .then(() => {
+                  setHasAccessToPullImage(true);
+                  setFieldValue('imageStream.grantAccess', false);
+                })
+                .catch(() => setHasAccessToPullImage(false));
+            }}
           />
         </div>
         <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
           <DropdownField
             name="imageStream.image"
             label="ImageStreams"
-            items={getImageStreamByNamespace(values.imageStream.namespace)}
-            title="ImageStreams"
+            items={imageStreamList}
+            title={
+              isNamespaceSelected && !isStreamsAvailable ? 'No Image Stream' : 'Select Image Stream'
+            }
             fullWidth
-            disabled={values.imageStream.namespace === ''}
+            disabled={!isNamespaceSelected || (isNamespaceSelected && !isStreamsAvailable)}
             required
+            onChange={() => {
+              setFieldValue('imageStream.tag', '');
+              setFieldValue('isi', initialValues.isi);
+            }}
           />
           <div className="odc-imagestream-separator">/</div>
         </div>
@@ -152,41 +135,55 @@ const ImageStream: React.FC<ImageStreamProps> = ({ imageStreams }) => {
           <DropdownField
             name="imageStream.tag"
             label="Tag"
-            items={getImageStreamTags(values.imageStream.image)}
-            title="Tag"
-            disabled={values.imageStream.image === ''}
+            items={imageStreamTagList}
+            title={
+              isNamespaceSelected && isImageStreamSelected && !isTagsAvailable
+                ? 'No Tag'
+                : 'Select Tag'
+            }
+            disabled={!isImageStreamSelected}
             fullWidth
             required
+            onChange={(tag) => {
+              tag !== '' && searchImageTag(tag);
+            }}
           />
           <div className="odc-imagestream-separator">:</div>
         </div>
       </div>
-      {values.registry === registryType.Internal &&
-        imageNamespace.value &&
-        imageNamespace.value !== builderImagesNamespace.Openshift &&
-        values.project.name !== imageNamespace.value && (
-          <div className="row odc-imagestream-alert">
-            <div className="col-lg-12">
-              <Alert
-                variant="warning"
-                title="add cluster policy to use internal imagestream"
-                isInline
-              >
-                Service account <strong>default</strong> will need image pull authority to deploy
-                images from <strong>{imageNamespace.value}</strong>. You can grant authority with
-                the command:
-                <p>
-                  <code>
-                    oc policy add-role-to-user system:image-puller system:serviceaccount:
-                    {values.project.name}:default -n {imageNamespace.value}
-                  </code>
-                </p>
-              </Alert>
-            </div>
-          </div>
-        )}
+      {isNamespaceSelected && isImageStreamSelected && !isTagsAvailable && hasCreateAccess && (
+        <div className="odc-imagestream-alert">
+          <Alert variant="warning" title="No Image streams tags found" isInline>
+            No tags are available in image stream {imageStream.image}
+          </Alert>
+        </div>
+      )}
+      {isNamespaceSelected && !isStreamsAvailable && hasCreateAccess && (
+        <div className="odc-imagestream-alert">
+          <Alert variant="warning" title="No Image streams found" isInline>
+            No image streams are available in project {imageStream.namespace}
+          </Alert>
+        </div>
+      )}
+      {isNamespaceSelected && !hasCreateAccess && (
+        <div className="odc-imagestream-alert">
+          <Alert variant="warning" title="Permission denied" isInline>
+            Service account default does not have authority to pull images from{' '}
+            {imageStream.namespace}. Select another project to continue.
+          </Alert>
+        </div>
+      )}
+      {canGrantAccess && (
+        <div className="odc-imagestream-alert">
+          <CheckboxField
+            name="imageStream.grantAccess"
+            label={`Grant service account default authority to pull images from
+                ${imageStream.namespace}`}
+          />
+        </div>
+      )}
     </>
   );
 };
 
-export default ImageStream;
+export default React.memo(ImageStream);

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -10,7 +10,6 @@ export interface DeployImageFormProps {
 }
 
 export interface ImageStreamProps {
-  projects?: K8sResourceKind[];
   imageStreams: K8sResourceKind[];
 }
 
@@ -45,6 +44,7 @@ export interface DeployImageFormData {
     image: string;
     tag: string;
     namespace: string;
+    grantAccess?: boolean;
   };
   isi: ImageStreamImageData;
   image: ImageStreamImageData;

--- a/frontend/packages/dev-console/src/utils/__tests__/imagestream-test-data.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/imagestream-test-data.ts
@@ -1,0 +1,220 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { ImageTag } from '../imagestream-utils';
+
+export const ImageStreamTagData: ImageTag = {
+  kind: 'ImageStreamTag',
+  apiVersion: 'image.openshift.io/v1',
+  metadata: {
+    name: 'os-test-image:latest',
+    namespace: 'rhd-devproject',
+    selfLink:
+      '/apis/image.openshift.io/v1/namespaces/rhd-devproject/imagestreamtags/os-test-image%3Alatest',
+    uid: '0a7cfc61-03ed-11ea-a8ff-0a580a80013c',
+    resourceVersion: '808616',
+    creationTimestamp: '2019-11-10T19:05:22Z',
+    labels: {
+      app: 'os-test-image',
+      'app.kubernetes.io/component': 'os-test-image',
+      'app.kubernetes.io/instance': 'os-test-image',
+      'app.kubernetes.io/part-of': 'php-app',
+    },
+    annotations: {
+      'openshift.io/generated-by': 'OpenShiftWebConsole',
+      'openshift.io/imported-from': 'openshift/hello-openshift',
+    },
+  },
+  tag: {
+    name: 'latest',
+    annotations: {
+      'openshift.io/generated-by': 'OpenShiftWebConsole',
+      'openshift.io/imported-from': 'openshift/hello-openshift',
+    },
+    from: {
+      kind: 'DockerImage',
+      name: 'openshift/hello-openshift',
+    },
+    generation: 2,
+    importPolicy: {},
+    referencePolicy: {
+      type: 'Source',
+    },
+  },
+  generation: 2,
+  lookupPolicy: {
+    local: false,
+  },
+  annotations: {
+    'openshift.io/generated-by': 'OpenShiftWebConsole',
+    'openshift.io/imported-from': 'openshift/hello-openshift',
+  },
+  name: 'test',
+  image: {
+    metadata: {
+      name: 'sha256:aaea76ff622d2f8bcb32e538e7b3cd0ef6d291953f3e7c9f556c1ba5baf47e2e',
+      uid: '6953ea51-02d3-11ea-a8ff-0a580a80013c',
+      resourceVersion: '680753',
+      creationTimestamp: '2019-11-09T09:29:21Z',
+      annotations: {
+        'image.openshift.io/dockerLayersOrder': 'ascending',
+        'openshift.io/generated-by': 'OpenShiftWebConsole',
+        'openshift.io/imported-from': 'openshift/hello-openshift',
+      },
+    },
+    dockerImageReference:
+      'openshift/hello-openshift@sha256:aaea76ff622d2f8bcb32e538e7b3cd0ef6d291953f3e7c9f556c1ba5baf47e2e',
+    dockerImageMetadata: {
+      kind: 'DockerImage',
+      apiVersion: '1.0',
+      Id: 'sha256:7af3297a3fb4487b740ed6798163f618e6eddea1ee5fa0ba340329fcae31c8f6',
+      Created: '2018-04-18T10:38:59Z',
+      Container: '64ede50d59ead12e9e867f6c48681b3cde9e0c920db433666fc20cd7c322de02',
+      ContainerConfig: {
+        Hostname: '64ede50d59ea',
+        Image: 'scratchljl6nbgci72oxgam2jh83pe3',
+        Entrypoint: ['/bin/sh', '-c', '# NOP'],
+      },
+      DockerVersion: '1.13.1',
+      Author: 'Jessica Forrester <jforrest@redhat.com>',
+      Config: {
+        User: '1001',
+        ExposedPorts: {
+          '8080/tcp': {},
+          '8888/tcp': {},
+        },
+        Env: ['PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'],
+        Entrypoint: ['/hello-openshift'],
+      },
+      Architecture: 'amd64',
+      Size: 2168976,
+    },
+    dockerImageMetadataVersion: '1.0',
+    dockerImageLayers: [
+      {
+        name: 'sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1',
+        size: 32,
+        mediaType: 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+      },
+      {
+        name: 'sha256:8b32988996c5d776076ea3cd672855f6d0faac87510064a15cce4bd02cdc9d13',
+        size: 2167576,
+        mediaType: 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+      },
+    ],
+    dockerImageManifestMediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+  },
+};
+
+export const sampleImageStreams: K8sResourceKind[] = [
+  {
+    metadata: {
+      annotations: { 'openshift.io/image.dockerRepositoryCheck': '2019-11-10T19:24:36Z' },
+      selfLink: '/apis/image.openshift.io/v1/namespaces/project-1/imagestreams/os-test-image',
+      resourceVersion: '811634',
+      name: 'os-test-image',
+      uid: 'b8c35c06-03ef-11ea-a8ff-0a580a80013c',
+      creationTimestamp: '2019-11-10T19:24:32Z',
+      generation: 2,
+      namespace: 'project-1',
+      labels: {
+        app: 'os-test-image',
+        'app.kubernetes.io/component': 'os-test-image',
+        'app.kubernetes.io/instance': 'os-test-image',
+        'app.kubernetes.io/part-of': 'os-test-image-app',
+      },
+    },
+    spec: {
+      lookupPolicy: { local: false },
+      tags: [
+        {
+          name: 'latest',
+          annotations: {
+            'openshift.io/generated-by': 'OpenShiftWebConsole',
+            'openshift.io/imported-from': 'os-test-image',
+          },
+          from: { kind: 'DockerImage', name: 'os-test-image' },
+          generation: 2,
+          importPolicy: {},
+          referencePolicy: { type: 'Source' },
+        },
+      ],
+    },
+    status: {
+      dockerImageRepository:
+        'image-registry.openshift-image-registry.svc:5000/project-1/os-test-image',
+      publicDockerImageRepository:
+        'default-route-openshift-image-registry.apps-crc.testing/project-1/os-test-image',
+      tags: [
+        {
+          tag: 'latest',
+          items: null,
+          conditions: [
+            {
+              type: 'ImportSuccess',
+              status: 'False',
+              lastTransitionTime: '2019-11-10T19:24:36Z',
+              reason: 'Unauthorized',
+              message: 'you may not have access to the container image "os-test-image:latest"',
+              generation: 2,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    metadata: {
+      annotations: { 'openshift.io/image.dockerRepositoryCheck': '2019-11-10T19:24:36Z' },
+      selfLink: '/apis/image.openshift.io/v1/namespaces/project-2/imagestreams/os-test-image',
+      resourceVersion: '811634',
+      name: 'os-test-image',
+      uid: 'b8c35c06-03ef-11ea-a8ff-0a580a80013c',
+      creationTimestamp: '2019-11-10T19:24:32Z',
+      generation: 2,
+      namespace: 'project-2',
+      labels: {
+        app: 'os-test-image',
+        'app.kubernetes.io/component': 'os-test-image',
+        'app.kubernetes.io/instance': 'os-test-image',
+        'app.kubernetes.io/part-of': 'os-test-image-app',
+      },
+    },
+    spec: {
+      lookupPolicy: { local: false },
+      tags: [
+        {
+          name: 'latest',
+          annotations: {
+            'openshift.io/generated-by': 'OpenShiftWebConsole',
+            'openshift.io/imported-from': 'os-test-image',
+          },
+          from: { kind: 'DockerImage', name: 'os-test-image' },
+          generation: 2,
+          importPolicy: {},
+          referencePolicy: { type: 'Source' },
+        },
+      ],
+    },
+    status: {
+      dockerImageRepository:
+        'image-registry.openshift-image-registry.svc:5000/project-2/os-test-image',
+      publicDockerImageRepository:
+        'default-route-openshift-image-registry.apps-crc.testing/project-2/os-test-image',
+      tags: [
+        {
+          tag: 'latest',
+          items: null,
+          conditions: [
+            {
+              type: 'ImportSuccess',
+              status: 'False',
+              lastTransitionTime: '2019-11-10T19:24:36Z',
+              reason: 'Unauthorized',
+              message: 'you may not have access to the container image "os-test-image:latest"',
+              generation: 2,
+            },
+          ],
+        },
+      ],
+    },
+  },
+];

--- a/frontend/packages/dev-console/src/utils/__tests__/imagestream-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/imagestream-utils.spec.ts
@@ -1,0 +1,36 @@
+import {
+  getPorts,
+  makePortName,
+  getImageStreamByNamespace,
+  getImageStreamTags,
+} from '../imagestream-utils';
+import { ImageStreamTagData, sampleImageStreams } from './imagestream-test-data';
+
+describe('Transform image ports to k8s structure', () => {
+  it('expect port object to be transformed into k8s structure', () => {
+    expect(getPorts(ImageStreamTagData)).toEqual([
+      { containerPort: 8080, protocol: 'TCP' },
+      { containerPort: 8888, protocol: 'TCP' },
+    ]);
+  });
+});
+
+describe('Transform container port name', () => {
+  it('expect port object to be transformed with cli naming convention', () => {
+    const ports = getPorts(ImageStreamTagData);
+    expect(makePortName(ports[0])).toEqual('8080-tcp');
+    expect(makePortName(ports[1])).toEqual('8888-tcp');
+  });
+});
+
+describe('Transform imagestream data', () => {
+  it('expect to return key: value pair for dropdown component ', () => {
+    const imgStreams = getImageStreamByNamespace(sampleImageStreams, 'project-1');
+    expect(imgStreams).toMatchObject({ 'os-test-image': 'os-test-image' });
+  });
+
+  it('expect to have imagestream tags', () => {
+    const imgStreamsTags = getImageStreamTags(sampleImageStreams, 'os-test-image', 'project-1');
+    expect(imgStreamsTags).toMatchObject({ latest: 'latest' });
+  });
+});


### PR DESCRIPTION
This PR adds auto role binding from UI and shows the new validation message for deploy image via internal registry.

**scenario 1**: Restricted to pull images as a non-admin user from a project

![restricted_access](https://user-images.githubusercontent.com/9964343/68562276-f44fb700-046e-11ea-8471-1ed3ff6e7612.gif)

**scenario 2**: Has access to pull images as a non-admin user from a project

![non-admin-access](https://user-images.githubusercontent.com/9964343/68562290-0598c380-046f-11ea-9557-c4284a5d07c2.gif)

**scenario-3** : No image streams found

![no_imagestream (1)](https://user-images.githubusercontent.com/9964343/68567534-37198b00-047f-11ea-81ad-e3118f323fe7.gif)

**scneario-4**: No image stream tags found
![no_imagestream_tag](https://user-images.githubusercontent.com/9964343/68567539-3c76d580-047f-11ea-8881-a1be7db263dc.gif)

**scenario-5** : Granting access to the user to pull images from UI

![granting_access (1)](https://user-images.githubusercontent.com/9964343/68562416-8d7ecd80-046f-11ea-8232-827a7568f199.gif)




Fixes: https://jira.coreos.com/browse/ODC-2209