### PR TITLE
Bug 1770749: Fix Bare Metal Hosts nav item position

### DIFF
--- a/frontend/packages/metal3-plugin/src/plugin.ts
+++ b/frontend/packages/metal3-plugin/src/plugin.ts
@@ -43,7 +43,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'NavItem/ResourceNS',
     properties: {
       section: 'Compute',
-      mergeAfter: 'Machine Autoscalers',
+      mergeAfter: 'Machine Health Checks',
       componentProps: {
         name: 'Bare Metal Hosts',
         resource: referenceForModel(BareMetalHostModel),


### PR DESCRIPTION
As discussed at https://github.com/openshift/console/pull/3310, this change separately fixes 'Bare Metal Hosts' nav item position.