### PR TITLE
Fixing the spacing and tooltip for breakdown card in storage dashboards

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-body.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-body.tsx
@@ -55,8 +55,7 @@ export const BreakdownCardBody: React.FC<BreakdownBodyProps> = ({
 
   const legends = chartData.map((d: StackDataPoint) => ({
     name: [d.name, d.label],
-    symbol: { size: 3, padding: 0 }, // To be removed
-    labels: { fill: d.color, padding: 0 },
+    labels: { fill: d.color },
     link: d.link,
   }));
 

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-card.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-card.scss
@@ -7,6 +7,7 @@
 
 .capacity-breakdown-card__capacity-body {
   font-size: var(--pf-global--FontSize--sm);
+  margin-bottom: 0;
 }
 
 .capacity-breakdown-card__header-link {

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-chart.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-chart.tsx
@@ -25,11 +25,8 @@ const LinkableLegend: React.FC<LinkableLegendProps> = (props: LinkableLegendProp
     <Link to={href} className="capacity-breakdown-card__legend-link">
       <ChartLabel
         {...props}
-        lineHeight={1.3}
-        style={[
-          { ...datum.labels, fontSize: 8, padding: 0 },
-          { fill: 'black', fontSize: 8, padding: 0 },
-        ]}
+        lineHeight={1.2}
+        style={[{ ...datum.labels, fontSize: 9 }, { fill: 'black', fontSize: 8 }]}
       />
     </Link>
   );
@@ -41,49 +38,45 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({ data, legends, m
       key={d.id}
       style={{ data: { stroke: 'white', strokeWidth: 0.7, ...isAvailableBar(d.name) } }}
       cornerRadius={getBarRadius(index, data.length)}
-      barWidth={20}
+      barWidth={18}
       padding={0}
       data={[d]}
-      labelComponent={
-        <ChartTooltip constrainToVisibleArea style={{ fontSize: 8 }} pointerOrientation="left" />
-      }
+      labelComponent={<ChartTooltip dx={0} style={{ fontSize: 8, padding: 5 }} />}
     />
   ));
 
   return (
-    <Chart
-      legendPosition="bottom-left"
-      domain={{ x: [0, 0] }}
-      domainPadding={{ x: [0, 0] }}
-      maxDomain={{ x: 0 }}
-      legendComponent={
-        <ChartLegend
-          themeColor={ChartThemeColor.purple}
-          data={legends}
-          standalone={false}
-          labelComponent={<LinkableLegend metricModel={metricModel} />}
-          orientation="horizontal"
-          symbolSpacer={5}
-          gutter={-20}
-          style={{ labels: { padding: 0 } }}
-          padding={0}
+    <>
+      <Chart
+        legendPosition="bottom-left"
+        legendComponent={
+          <ChartLegend
+            themeColor={ChartThemeColor.multiOrdered}
+            data={legends}
+            y={40}
+            labelComponent={<LinkableLegend metricModel={metricModel} />}
+            orientation="horizontal"
+            symbolSpacer={5}
+            height={50}
+            style={{ labels: { fontSize: 8 } }}
+          />
+        }
+        height={60}
+        padding={{
+          bottom: 35,
+          top: 0,
+          right: 0,
+          left: 0,
+        }}
+        themeColor={ChartThemeColor.multiOrdered}
+      >
+        <ChartAxis
+          style={{ axis: { stroke: 'none' }, ticks: { stroke: 'none' } }}
+          tickFormat={() => ''}
         />
-      }
-      height={100}
-      padding={{
-        bottom: 75,
-        top: 0,
-      }}
-      themeColor={ChartThemeColor.multiOrdered}
-    >
-      <ChartAxis
-        style={{ axis: { stroke: 'none' }, ticks: { stroke: 'none' } }}
-        tickFormat={() => ''}
-      />
-      <ChartStack horizontal padding={{ bottom: 0 }}>
-        {chartData}
-      </ChartStack>
-    </Chart>
+        <ChartStack horizontal>{chartData}</ChartStack>
+      </Chart>
+    </>
   );
 };
 

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/utils.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/utils.tsx
@@ -14,7 +14,7 @@ const addOthers = (
   const top5Total = getTotal(stats);
   const others = Number(metricTotal) - top5Total;
   const othersData = {
-    x: '',
+    x: '0',
     y: others,
     name: 'Others',
     color: Colors.OTHER,
@@ -42,7 +42,7 @@ export const addAvailable = (
   if (capacityTotal) {
     const availableInBytes = Number(capacityTotal) - Number(capacityUsed);
     availableData = {
-      x: '',
+      x: '0',
       y: availableInBytes,
       name: 'Available',
       link: '',
@@ -79,7 +79,7 @@ export const getStackChartStats: GetStackStats = (response, humanize) =>
     const capacity = humanize(r.y).string;
     return {
       // INFO: x value needs to be same for single bar stack chart
-      x: '',
+      x: '0',
       y: r.y,
       name: _.truncate(`${r.x}`, { length: 12 }),
       link: `${r.x}`,


### PR DESCRIPTION
**BEFORE**
![Screenshot from 2019-11-11 15-13-45](https://user-images.githubusercontent.com/25664409/68578480-190c5480-0498-11ea-9e05-8930fb04c460.png)
**AFTER**
![Screenshot from 2019-11-11 15-01-36](https://user-images.githubusercontent.com/25664409/68578572-49ec8980-0498-11ea-8513-439bd59ad788.png)
![Screenshot from 2019-11-11 15-06-15](https://user-images.githubusercontent.com/25664409/68578479-190c5480-0498-11ea-9f7b-fdfbe4d88c5c.png)