### PR TITLE
fixes issue with sidebar for showing group resources for knative

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/ApplicationGroupResource.tsx
+++ b/frontend/packages/dev-console/src/components/topology/ApplicationGroupResource.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Link } from 'react-router-dom';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { SidebarSectionHeading } from '@console/internal/components/utils';
 import { getActiveNamespace } from '@console/internal/actions/ui';
 import TopologyApplicationResourceList from './TopologyApplicationList';
@@ -10,14 +10,12 @@ const MAX_RESOURCES = 5;
 
 export type ApplicationGroupResourceProps = {
   title: string;
-  kind: string;
   resourcesData: K8sResourceKind[];
   group: string;
 };
 
 const ApplicationGroupResource: React.FC<ApplicationGroupResourceProps> = ({
   title,
-  kind,
   resourcesData,
   group,
 }) => {
@@ -29,9 +27,9 @@ const ApplicationGroupResource: React.FC<ApplicationGroupResourceProps> = ({
             {_.size(resourcesData) > MAX_RESOURCES && (
               <Link
                 className="sidebar__section-view-all"
-                to={`/search/ns/${getActiveNamespace()}?kind=${kind}&q=${encodeURIComponent(
-                  `app.kubernetes.io/part-of=${group}`,
-                )}`}
+                to={`/search/ns/${getActiveNamespace()}?kind=${referenceFor(
+                  resourcesData[0],
+                )}&q=${encodeURIComponent(`app.kubernetes.io/part-of=${group}`)}`}
               >
                 {`View All (${_.size(resourcesData)})`}
               </Link>

--- a/frontend/packages/dev-console/src/components/topology/TopologyApplicationList.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyApplicationList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { ListGroup } from 'patternfly-react';
 import { ResourceLink } from '@console/internal/components/utils';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 
 export type TopologyApplicationResourceListProps = {
   resources: K8sResourceKind[];
@@ -13,11 +13,16 @@ const TopologyApplicationResourceList: React.FC<TopologyApplicationResourceListP
 }) => {
   return (
     <ListGroup componentClass="ul">
-      {_.map(resources, ({ metadata: { name, namespace, uid }, kind }) => (
-        <li className="list-group-item  container-fluid" key={uid}>
-          <ResourceLink kind={kind} name={name} namespace={namespace} />
-        </li>
-      ))}
+      {_.map(resources, (resource) => {
+        const {
+          metadata: { name, namespace, uid },
+        } = resource;
+        return (
+          <li className="list-group-item  container-fluid" key={uid}>
+            <ResourceLink kind={referenceFor(resource)} name={name} namespace={namespace} />
+          </li>
+        );
+      })}
     </ListGroup>
   );
 };

--- a/frontend/packages/dev-console/src/components/topology/TopologyApplicationResources.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyApplicationResources.tsx
@@ -41,7 +41,6 @@ const TopologyApplicationResources: React.FC<TopologyApplicationResourcesProps> 
         <ApplicationGroupResource
           key={`${group}-${key}`}
           title={modelFor(key) ? modelFor(key).label : key}
-          kind={key}
           resourcesData={resourcesData[key]}
           group={group}
         />


### PR DESCRIPTION
fixes issue with sidebar for showing group resources for knative
- Knative service in group sidebar,  navigate to the wrong URL
- Event Sources in group sidebar,  navigate to the wrong URL
- link to all services/event sources were not correct

Tracks: https://jira.coreos.com/browse/ODC-2213

Gif: 


![ezgif com-video-to-gif (7)](https://user-images.githubusercontent.com/5129024/68581757-0c3f2f00-049f-11ea-9003-1775e8e22a64.gif)

