### PR TITLE
Bug 1768614: Fix add disk modal

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -33,7 +33,7 @@ import { useShowErrorToggler } from '../../../hooks/use-show-error-toggler';
 import { DiskWrapper } from '../../../k8s/wrapper/vm/disk-wrapper';
 import { DataVolumeWrapper } from '../../../k8s/wrapper/vm/data-volume-wrapper';
 import { VolumeWrapper } from '../../../k8s/wrapper/vm/volume-wrapper';
-import { DiskBus } from '../../../constants/vm/storage';
+import { DiskBus, DiskType } from '../../../constants/vm/storage';
 import { getPvcStorageSize } from '../../../selectors/pvc/selectors';
 import { K8sResourceSelectRow } from '../../form/k8s-resource-select-row';
 import { SizeUnitFormRow, BinaryUnit } from '../../form/size-unit-form-row';
@@ -106,7 +106,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
   const resultDisk = DiskWrapper.initializeFromSimpleData({
     name,
     bus,
-    type: disk.getType(),
+    type: disk.getType() || DiskType.DISK,
   });
 
   const resultDataVolumeName = prefixedID(vmName, name);

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/disk-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/disk-wrapper.ts
@@ -25,7 +25,7 @@ export class DiskWrapper extends ObjectWithTypePropertyWrapper<V1Disk, DiskType>
       },
       {
         initializeWithType: type,
-        initializeWithTypeData: type === DiskType.DISK && bus ? { bus: bus.getValue() } : undefined,
+        initializeWithTypeData: bus ? { bus: bus.getValue() } : undefined,
       },
     );
   };


### PR DESCRIPTION
After a disk has been added to a VM
its type and interface are now passed to the VM's yaml.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>