### PR TITLE
Add cluster-thanos arg to example bridge

### DIFF
--- a/examples/run-bridge.sh
+++ b/examples/run-bridge.sh
@@ -16,4 +16,5 @@ set -exuo pipefail
     --user-auth-oidc-client-secret-file=examples/console-client-secret \
     --user-auth-oidc-ca-file=examples/ca.crt \
     --k8s-mode-off-cluster-prometheus=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.prometheusURL}')  \
-    --k8s-mode-off-cluster-alertmanager=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.alertmanagerURL}')
+    --k8s-mode-off-cluster-alertmanager=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.alertmanagerURL}') \
+    --k8s-mode-off-cluster-thanos=$(oc -n openshift-monitoring get configmap sharing-config -o jsonpath='{.data.prometheusURL}')


### PR DESCRIPTION
`--k8s-mode-off-cluster-thanos` is required for the example authenticated bridge to work