### PR TITLE
filter revisions based on traffic status

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/__mocks__/traffic-splitting-utils-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/traffic-splitting-utils-mock.ts
@@ -1,6 +1,6 @@
 export const mockTrafficData = [
-  { percent: 50, tag: 'tag-1', revisionName: 'hello-openshift-2-6wv8f' },
-  { percent: 50, tag: 'tag-2', revisionName: 'hello-openshift-2-5fbjn' },
+  { percent: 50, tag: 'tag-1', revisionName: 'rev-1' },
+  { percent: 50, tag: 'tag-2', revisionName: 'rev-2' },
 ];
 export const mockServiceData = {
   apiVersion: 'serving.knative.dev/v1beta1',
@@ -9,23 +9,25 @@ export const mockServiceData = {
     traffic: [
       {
         percent: 50,
-        revisionName: 'hello-openshift-2-6wv8f',
+        revisionName: 'rev-1',
         tag: 'tag-1',
       },
       {
         percent: 50,
-        revisionName: 'hello-openshift-2-5fbjn',
+        revisionName: 'rev-2',
         tag: 'tag-2',
       },
     ],
   },
   status: {
-    traffic: {
-      latestRevision: false,
-      percent: 100,
-      revisionName: 'hello-openshift-2-6wv8f',
-      tag: 'tag-1',
-    },
+    traffic: [
+      {
+        latestRevision: false,
+        percent: 100,
+        revisionName: 'rev-1',
+        tag: 'tag-1',
+      },
+    ],
   },
 };
 
@@ -36,12 +38,12 @@ export const mockUpdateRequestObj = {
     traffic: [
       {
         percent: 50,
-        revisionName: 'hello-openshift-2-6wv8f',
+        revisionName: 'rev-1',
         tag: 'tag-1',
       },
       {
         percent: 50,
-        revisionName: 'hello-openshift-2-5fbjn',
+        revisionName: 'rev-2',
         tag: 'tag-2',
       },
     ],


### PR DESCRIPTION
ODC-bug: https://jira.coreos.com/browse/ODC-2191

This Pr adds a filter to show only revision with some traffic on them

TODO: 
- [x] unit tests

![Screenshot from 2019-11-11 21-40-46](https://user-images.githubusercontent.com/9278015/68602262-0744a480-04cc-11ea-8fc0-efd459ecb924.png)

![Screenshot from 2019-11-11 21-45-45](https://user-images.githubusercontent.com/9278015/68602616-b2555e00-04cc-11ea-9506-06773bd98374.png)

