### PR TITLE
tests: addition OLM scenario fixes

### DIFF
--- a/frontend/integration-tests/views/catalog.view.ts
+++ b/frontend/integration-tests/views/catalog.view.ts
@@ -1,6 +1,7 @@
 import { $, $$, browser, by, ExpectedConditions as until } from 'protractor';
 
 export const categoryTabs = $$('.vertical-tabs-pf-tab > a');
+export const categoryTabsPresent = () => browser.wait(until.presenceOf($('.vertical-tabs-pf-tab')));
 export const pageHeading = $('.co-catalog-page__heading');
 export const pageNumberItemsHeading = $('.co-catalog-page__num-items');
 export const pageHeadingNumberOfItems = () =>

--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -121,6 +121,7 @@ export const deleteRow = (kind: string) => (name: string) =>
   });
 
 export const rowFilters = $$('.row-filter__box');
+export const rowFiltersPresent = () => browser.wait(until.presenceOf($('.row-filter__box')));
 export const rowFilterFor = (name: string) =>
   rowFilters.filter((el) => el.getText().then((text) => text.includes(name))).first();
 export const activeRowFilters = $$('.row-filter__box--active');

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
@@ -88,6 +88,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
   });
 
   it('displays subscription creation form for selected Operator', async () => {
+    await catalogView.categoryTabsPresent();
     await catalogView.categoryTabs.get(0).click();
     await catalogPageView.clickFilterCheckbox('providerType-custom');
     await catalogPageView.catalogTileByID(jaegerTileID).click();
@@ -117,7 +118,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
   });
 
   it(`displays Operator in "Cluster Service Versions" view for "${testName}" namespace`, async () => {
-    await catalogPageView.catalogTileByID(jaegerTileID).click();
+    await retry(() => catalogPageView.catalogTileByID(jaegerTileID).click());
     await operatorHubView.operatorModalIsLoaded();
     await operatorHubView.viewInstalledOperator();
     await crudView.isLoaded();
@@ -199,6 +200,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
     await element(by.linkText('Resources')).click();
     await crudView.isLoaded();
 
+    await crudView.rowFiltersPresent();
     jaegerResources.forEach((kind) => {
       expect(crudView.rowFilterFor(kind).isDisplayed()).toBe(true);
     });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
@@ -70,6 +70,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
   });
 
   it('displays subscription creation form for selected Operator', async () => {
+    await catalogView.categoryTabsPresent();
     await catalogView.categoryTabs.get(0).click();
     await catalogPageView.clickFilterCheckbox('providerType-custom');
     await catalogPageView.catalogTileFor('Prometheus Operator').click();
@@ -104,7 +105,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
   });
 
   it(`displays Operator in "Cluster Service Versions" view for "${testName}" namespace`, async () => {
-    await catalogPageView.catalogTileFor('Prometheus Operator').click();
+    await retry(() => catalogPageView.catalogTileFor('Prometheus Operator').click());
     await operatorHubView.operatorModalIsLoaded();
     await operatorHubView.viewInstalledOperator();
     await crudView.isLoaded();
@@ -203,6 +204,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     await element(by.linkText('Resources')).click();
     await crudView.isLoaded();
 
+    await crudView.rowFiltersPresent();
     prometheusResources.forEach((kind) => {
       expect(crudView.rowFilterFor(kind).isDisplayed()).toBe(true);
     });


### PR DESCRIPTION
* Wait for category tabs before trying to click.
* Wait for row filters to appears before testing for specific filters.
* Retry clicks on OperatorHub tiles to avoid StaleElementReferenceErrors.

/assign @rhamilto 
/kind test-flake