### PR TITLE
Top-align status card alert icons and action

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/dashboard-card/card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/dashboard-card/card.scss
@@ -44,7 +44,6 @@ $co-dashboard-card--line-height: 19px;
 
 .co-dashboard-icon {
   font-size: 1.2rem;
-  margin-top: 0.2rem;
 }
 
 .co-dashboard-text--small {

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -28,7 +28,7 @@ export const StatusItem: React.FC<StatusItemProps> = ({
 }) => {
   return (
     <div className="co-status-card__alert-item">
-      <div className="co-dashboard-icon">
+      <div className="co-status-card__alert-item-icon co-dashboard-icon">
         <Icon />
       </div>
       <div className="co-status-card__alert-item-text">

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
@@ -34,11 +34,14 @@
 }
 
 .co-status-card__alert-item {
-  align-items: center;
   display: flex;
   padding-bottom: 0.5rem;
   padding-left: var(--pf-c-card--child--PaddingLeft);
   padding-right: var(--pf-c-card--child--PaddingRight);
+}
+
+.co-status-card__alert-item-icon {
+  display: flex;
 }
 
 .co-status-card__alert-item-message {
@@ -54,7 +57,6 @@
 }
 
 .co-status-card__alert-item-text {
-  align-items: center;
   display: flex;
   justify-content: space-between;
   width: 100%;


### PR DESCRIPTION
As mentioned in #3319, top-aligns the icon and action so that alerts with very long messages feel more structured.

IIRC @rawagner suggested this a long while ago and was right. 🙂

@spadgett The icon is about `1px` off from vertically centered with the date because we'd likely need to restructure the HTML to get it perfect. We could add `margin-top: 1px;` to the icon but that feels a bit dirty. @matthewcarleton do you agree, or see a better way?

![image](https://user-images.githubusercontent.com/9122899/68622931-43aedb00-04a1-11ea-950f-6a63819dd18c.png)

Before:
<img width="629" alt="2019-11-11 16 28 21" src="https://user-images.githubusercontent.com/9122899/68623097-b455f780-04a1-11ea-9bc2-dab16cc68701.png">

After:
<img width="629" alt="2019-11-11 16 27 55" src="https://user-images.githubusercontent.com/9122899/68623104-b91aab80-04a1-11ea-9731-03cc3fb8eb30.png">

![image](https://user-images.githubusercontent.com/9122899/68623748-34309180-04a3-11ea-97d2-210c448a986e.png)