### PR TITLE
Query Browser: Fix series toggle buttons when queries are disabled

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -467,7 +467,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
                     : [metric, formatSeriesValues(values, samples, span)];
                 });
               });
-              setGraphData(_.reject(newGraphData, _.isEmpty));
+              setGraphData(newGraphData);
 
               _.each(newResults, (r, i) =>
                 patchQuery(i, {


### PR DESCRIPTION
Don't discard empty query results because that causes the list of all
query results and the list of all disabled data series to go out of
sync.

This was causing the data series (lines in the graph) toggle buttons to
break if an earlier query returned no data (e.g. if it was disabled).

Bug was introduced by https://github.com/openshift/console/pull/3118