### PR TITLE
Bug 1771355: Rename Ready host status to Available

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
@@ -20,6 +20,7 @@ import {
   HOST_STATUS_REGISTRATION_ERROR,
   HOST_STATUS_ERROR,
   HOST_STATUS_DISCOVERED,
+  HOST_STATUS_AVAILABLE,
 } from '../../constants';
 import { startNodeMaintenanceModal } from '../modals/StartNodeMaintenanceModal';
 import { powerOffHostModal } from '../modals/PowerOffHostModal';
@@ -94,6 +95,7 @@ export const Delete = (
   return {
     hidden: ![
       HOST_STATUS_READY,
+      HOST_STATUS_AVAILABLE,
       HOST_STATUS_REGISTRATION_ERROR,
       HOST_STATUS_ERROR,
       HOST_STATUS_DISCOVERED,

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
@@ -9,6 +9,7 @@ import {
   HOST_STATUS_PROVISIONED,
   HOST_STATUS_EXTERNALLY_PROVISIONED,
   NODE_STATUS_TITLES,
+  HOST_STATUS_AVAILABLE,
 } from '../../constants';
 import { BareMetalHostBundle } from '../types';
 
@@ -18,8 +19,8 @@ const hostStatesToFilterMap = Object.freeze({
     states: HOST_REGISTERING_STATES,
   },
   ready: {
-    title: 'Ready',
-    states: [HOST_STATUS_READY],
+    title: 'Available',
+    states: [HOST_STATUS_READY, HOST_STATUS_AVAILABLE],
   },
   provisioning: {
     title: 'Provisioning',

--- a/frontend/packages/metal3-plugin/src/components/modals/PowerOffHostModal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/PowerOffHostModal.tsx
@@ -10,7 +10,11 @@ import {
 } from '@console/internal/components/factory';
 import { getName } from '@console/shared';
 import { powerOffHost } from '../../k8s/requests/bare-metal-host';
-import { NODE_STATUS_UNDER_MAINTENANCE, HOST_STATUS_READY } from '../../constants';
+import {
+  NODE_STATUS_UNDER_MAINTENANCE,
+  HOST_STATUS_READY,
+  HOST_STATUS_AVAILABLE,
+} from '../../constants';
 import { BareMetalHostKind } from '../../types';
 import { startNodeMaintenanceModal } from './StartNodeMaintenanceModal';
 
@@ -73,7 +77,7 @@ const ForcePowerOffDialog: React.FC<ForcePowerOffDialogProps> = ({
 };
 
 const isPowerOffSafe = (status: string) => {
-  const safeStates = [NODE_STATUS_UNDER_MAINTENANCE, HOST_STATUS_READY];
+  const safeStates = [NODE_STATUS_UNDER_MAINTENANCE, HOST_STATUS_READY, HOST_STATUS_AVAILABLE];
   return safeStates.includes(status);
 };
 

--- a/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
+++ b/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
@@ -1,4 +1,7 @@
+// TODO(jtomasek): HOST_STATUS_READY is deprecated, remove its occurrences
+// once 'ready' status is replaced with 'available' in BMO
 export const HOST_STATUS_READY = 'ready';
+export const HOST_STATUS_AVAILABLE = 'available';
 export const HOST_STATUS_DISCOVERED = 'discovered';
 export const HOST_STATUS_OK = 'OK';
 export const HOST_STATUS_ERROR = 'error';
@@ -23,7 +26,8 @@ export const HOST_POWER_STATUS_POWERING_OFF = 'Shutting down';
 export const HOST_POWER_STATUS_POWERING_ON = 'Powering on';
 
 export const HOST_STATUS_TITLES = {
-  [HOST_STATUS_READY]: 'Ready',
+  [HOST_STATUS_READY]: 'Available',
+  [HOST_STATUS_AVAILABLE]: 'Available',
   [HOST_STATUS_DISCOVERED]: 'Discovered',
   [HOST_STATUS_OK]: 'OK',
   [HOST_STATUS_ERROR]: 'Error',
@@ -77,6 +81,7 @@ export const HOST_PROGRESS_STATES = [
 
 export const HOST_SUCCESS_STATES = [
   HOST_STATUS_READY,
+  HOST_STATUS_AVAILABLE,
   HOST_STATUS_DISCOVERED,
   HOST_STATUS_OK,
   HOST_STATUS_PROVISIONED,


### PR DESCRIPTION
Ready state is used by Node and since we're often combining Bare Metal Host
status and Node status, Host's Ready state is renamed to Available

This change allows console to  accomodate seamless transition on BMO side as well

Related BMO issue: https://github.com/metal3-io/baremetal-operator/issues/315