### PR TITLE
Bug fix: use pf4 button for Start Build, Set Traffic Distribution and Start Last Run

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/TriggerLastRunButton.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/TriggerLastRunButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { impersonateStateToProps } from '@console/internal/reducers/ui';
 import { useAccessReview } from '@console/internal/components/utils';
-import { Button } from 'patternfly-react';
+import { Button } from '@patternfly/react-core';
 import { rerunPipelineAndStay } from '../../../utils/pipeline-actions';
 import { PipelineModel } from '../../../models';
 import { getLatestRun, PipelineRun } from '../../../utils/pipeline-augment';
@@ -21,7 +21,7 @@ const TriggerLastRunButton: React.FC<TriggerLastRunButtonProps> = ({
   const isAllowed = useAccessReview(accessReview, impersonate);
   return (
     isAllowed && (
-      <Button variant="secondary" onClick={callback} disabled={pipelineRuns.length === 0}>
+      <Button variant="secondary" onClick={callback} isDisabled={pipelineRuns.length === 0}>
         {label}
       </Button>
     )

--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.scss
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.scss
@@ -2,4 +2,5 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
 }

--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { ListGroup, Button } from 'patternfly-react';
+import { ListGroup } from 'patternfly-react';
+import { Button } from '@patternfly/react-core';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ResourceLink, SidebarSectionHeading } from '@console/internal/components/utils';
 import { RevisionModel } from '@console/knative-plugin';
@@ -50,9 +51,9 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({ revisions
       {/* add extra check, if sidebar is opened for a knative deployment */}
       {service.kind === ServiceModel.kind && (
         <Button
-          variant="secondry"
+          variant="secondary"
           onClick={() => trafficModalLauncher({ obj: service })}
-          disabled={!(revisions && revisions.length)}
+          isDisabled={!(revisions && revisions.length)}
         >
           Set Traffic Distribution
         </Button>

--- a/frontend/public/components/overview/_build-overview.scss
+++ b/frontend/public/components/overview/_build-overview.scss
@@ -6,6 +6,7 @@
 .build-overview__item-title {
   display: flex;
   justify-content: space-between;
+  align-items: center;
 }
 
 .build-overview__item-reason {

--- a/frontend/public/components/overview/build-overview.tsx
+++ b/frontend/public/components/overview/build-overview.tsx
@@ -1,7 +1,8 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import { Button, ListGroup } from 'patternfly-react';
+import { ListGroup } from 'patternfly-react';
 import { SyncAltIcon } from '@patternfly/react-icons';
+import { Button } from '@patternfly/react-core';
 import { Status, StatusIconAndText, BuildConfigOverviewItem } from '@console/shared';
 import { BuildNumberLink, BuildLogLink } from '../build';
 import { errorModal } from '../modals/error-modal';


### PR DESCRIPTION
Bug fix - https://jira.coreos.com/browse/ODC-2140

update button to use PF4 button for Start Build, Set Traffic Distribution and Trigger Last Run on overview panel.

![Screenshot from 2019-11-15 00-44-54](https://user-images.githubusercontent.com/2561818/68888582-37e14400-0741-11ea-8416-9d919b0c2e9f.png)
![Screenshot from 2019-11-15 00-44-11](https://user-images.githubusercontent.com/2561818/68888588-3d3e8e80-0741-11ea-9bbf-0a08ced05084.png)


![Screenshot from 2019-11-15 00-29-17](https://user-images.githubusercontent.com/2561818/68887440-fe0f3e00-073e-11ea-9fd3-4428bf7d16ba.png)


