### PR TITLE
Bug 1757110: Don't allow to set Node schedulable when it is in maintenance

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/menu-actions.tsx
+++ b/frontend/packages/console-app/src/components/nodes/menu-actions.tsx
@@ -17,9 +17,14 @@ export const MarkAsUnschedulable: KebabAction = (kind: K8sKind, obj: NodeKind) =
   },
 });
 
-export const MarkAsSchedulable: KebabAction = (kind: K8sKind, obj: NodeKind) => ({
+export const MarkAsSchedulable: KebabAction = (
+  kind: K8sKind,
+  obj: NodeKind,
+  resources: {},
+  { nodeMaintenance }, // NOTE: used by node actions in metal3-plugin
+) => ({
   label: 'Mark as Schedulable',
-  hidden: !isNodeUnschedulable(obj),
+  hidden: !isNodeUnschedulable(obj) || nodeMaintenance,
   callback: () => makeNodeSchedulable(obj),
   accessReview: {
     group: kind.apiGroup,


### PR DESCRIPTION
MarkAsSchedulable action can take an optional 'nodeMaintenance' custom
data. If maintenance exists, don't allow the action as schedulability is
handled by the maintenance in that case