### PR TITLE
add inital value to start_vm settings

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
@@ -59,6 +59,7 @@ export const getInitialVmSettings = (common: CommonData) => {
       isRequired: asRequired(true),
     },
     [VMSettingsField.START_VM]: {
+      value: false,
       isHidden: hiddenByProviderOrTemplate,
     },
     [VMSettingsField.PROVIDERS_DATA]: {


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1771245

Set initial value to `vm.spec.running` when using the create VM Template wizard.

a. Workloads -> Virtual machine templates -> Create template -> Create with wizard 
b. Create a VM Template using the wizard.
c. `spec.running` can't be undefined.

Screenshots:

Before:
![OKD(2)](https://user-images.githubusercontent.com/2181522/68674180-08261680-055e-11ea-8da3-cd4a956a1633.png)

After:
![OKD(3)](https://user-images.githubusercontent.com/2181522/68674187-0bb99d80-055e-11ea-8e49-652a1f6e5339.png)
