### PR TITLE
fix(bug): Git-Import - Dual Image Selection

### DIFF
--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -24,7 +24,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
   projects,
 }) => (
   <Form onSubmit={handleSubmit}>
-    <GitSection builderImages={builderImages} />
+    <GitSection />
     <BuilderSection image={values.image} builderImages={builderImages} />
     <DockerSection buildStrategy={values.build.strategy} />
     <AppSection

--- a/frontend/packages/dev-console/src/components/import/builder/BuilderImageSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderImageSelector.tsx
@@ -38,7 +38,16 @@ const BuilderImageSelector: React.FC<BuilderImageSelectorProps> = ({
       const image = _.find(builderImages);
       handleImageChange(image.name);
     }
-  }, [builderImageCount, builderImages, handleImageChange, selected.value]);
+    if (!selected.value && values.image.recommended) {
+      handleImageChange(values.image.recommended);
+    }
+  }, [
+    builderImageCount,
+    builderImages,
+    handleImageChange,
+    selected.value,
+    values.image.recommended,
+  ]);
 
   if (builderImageCount === 1) {
     return null;

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { useFormikContext, FormikValues, useField } from 'formik';
 import { Alert, TextInputTypes } from '@patternfly/react-core';
 import { getGitService, GitProvider } from '@console/git-service';
@@ -8,22 +7,16 @@ import { CheckCircleIcon } from '@patternfly/react-icons';
 import { InputField, DropdownField } from '../../formik-fields';
 import { GitReadableTypes, GitTypes } from '../import-types';
 import { detectGitType, detectGitRepoName } from '../import-validation-utils';
-import {
-  getSampleRepo,
-  getSampleRef,
-  getSampleContextDir,
-  NormalizedBuilderImages,
-} from '../../../utils/imagestream-utils';
+import { getSampleRepo, getSampleRef, getSampleContextDir } from '../../../utils/imagestream-utils';
 import FormSection from '../section/FormSection';
 import SampleRepo from './SampleRepo';
 import AdvancedGitOptions from './AdvancedGitOptions';
 
 export interface GitSectionProps {
-  builderImages?: NormalizedBuilderImages;
   showSample?: boolean;
 }
 
-const GitSection: React.FC<GitSectionProps> = ({ builderImages, showSample }) => {
+const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
   const { values, setFieldValue, setFieldTouched, setFieldError, validateForm } = useFormikContext<
     FormikValues
   >();
@@ -61,10 +54,6 @@ const GitSection: React.FC<GitSectionProps> = ({ builderImages, showSample }) =>
         const buildTool = buildTools[0].buildType;
         setFieldValue('image.couldNotRecommend', false);
         setFieldValue('image.recommended', buildTool);
-        if (!values.image.selected) {
-          setFieldValue('image.selected', buildTool);
-          setFieldValue('image.tag', _.get(builderImages, `${buildTool}.recentTag.name`, ''));
-        }
       } else {
         setFieldValue('image.couldNotRecommend', true);
         setFieldValue('image.recommended', '');
@@ -78,14 +67,12 @@ const GitSection: React.FC<GitSectionProps> = ({ builderImages, showSample }) =>
 
     validateForm();
   }, [
-    builderImages,
     setFieldError,
     setFieldTouched,
     setFieldValue,
     validateForm,
     values.application.name,
     values.git,
-    values.image.selected,
     values.name,
   ]);
 


### PR DESCRIPTION
Jira Issue - https://jira.coreos.com/browse/ODC-2074

This issue was introduced because git url field  `onBlur` was getting called simultaneously with the new image value being saved in formik context and it caused a race condition wherein `handleGitUrlBlur` was getting called with old form values in the function closure. 

Resolved this issue by moving logic for handling recommended image selection from git-section to builder-image-selector.