### PR TITLE
tests: increase timeout for OperatorHub subscription form

### DIFF
--- a/frontend/integration-tests/views/catalog-page.view.ts
+++ b/frontend/integration-tests/views/catalog-page.view.ts
@@ -1,4 +1,4 @@
-import { $, $$, element, by } from 'protractor';
+import { $, $$, browser, by, element, ExpectedConditions as until } from 'protractor';
 
 export const catalogTiles = $$('.catalog-tile-pf');
 export const catalogTileFor = (name: string) =>
@@ -9,7 +9,10 @@ export const catalogTileByID = (id: string) => $(`[data-test=${id}]`);
 export const filterSectionFor = (group: string) => $(`[data-test-group-name=${group}]`);
 export const showMoreFilters = (group: string) => $(`[data-test-group-name=${group}] .btn-link`);
 export const filterCheckboxFor = (id: string) => $(`input[data-test=${id}]`);
-export const clickFilterCheckbox = (id: string) => filterCheckboxFor(id).click();
+export const clickFilterCheckbox = async (id: string) => {
+  await browser.wait(until.presenceOf(filterCheckboxFor(id)));
+  await filterCheckboxFor(id).click();
+};
 export const filterCheckboxCount = (id: string) =>
   filterCheckboxFor(id)
     .$('.item-count')

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator-hub.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator-hub.view.ts
@@ -22,7 +22,7 @@ export const createSubscriptionFormName = $(
 );
 export const createSubscriptionFormBtn = element(by.buttonText('Subscribe'));
 export const createSubscriptionFormLoaded = () =>
-  browser.wait(until.visibilityOf(createSubscriptionFormBtn));
+  browser.wait(until.visibilityOf(createSubscriptionFormBtn), 60000);
 export const createSubscriptionFormInstallMode = element(
   by.cssContainingText('h5', 'Installation Mode'),
 );


### PR DESCRIPTION
Increase the timeout in an effort to address the following flakes. I suspect this is happening because icons might still be loading in the background, which makes the form slow to load (even with lazy icon loading).

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_console/3338/pull-ci-openshift-console-master-e2e-gcp-console/2822

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_console/3356/pull-ci-openshift-console-master-e2e-gcp-console/2823

/kind test-flake
/assign @rhamilto 