### PR TITLE
Update add pipeline flow based on new UX designs

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineSection.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { connectToFlags, FlagsObject } from '@console/internal/reducers/features';
 import { getBadgeFromType } from '@console/shared';
-import { Split, SplitItem } from '@patternfly/react-core';
+import { Split, SplitItem, Alert } from '@patternfly/react-core';
 import { useFormikContext, FormikValues } from 'formik';
 import { PipelineModel } from '../../../models';
 import { FLAG_OPENSHIFT_PIPELINE } from '../../../const';
-import { CheckboxField } from '../../formik-fields';
 import FormSection from '../section/FormSection';
 import PipelineTemplate from './PipelineTemplate';
 
@@ -16,17 +15,24 @@ type PipelineSectionProps = {
 const PipelineSection: React.FC<PipelineSectionProps> = ({ flags }) => {
   const { values } = useFormikContext<FormikValues>();
 
-  if (flags[FLAG_OPENSHIFT_PIPELINE] && values.image.selected) {
+  if (flags[FLAG_OPENSHIFT_PIPELINE]) {
     const title = (
       <Split gutter="md">
-        <SplitItem className="odc-form-section__heading">Pipeline</SplitItem>
+        <SplitItem className="odc-form-section__heading">Pipelines</SplitItem>
         <SplitItem>{getBadgeFromType(PipelineModel.badge)}</SplitItem>
       </Split>
     );
     return (
       <FormSection title={title}>
-        <CheckboxField label="Enable pipelines" name="pipeline.enabled" />
-        {values.pipeline.enabled && <PipelineTemplate />}
+        {values.image.selected ? (
+          <PipelineTemplate />
+        ) : (
+          <Alert
+            isInline
+            variant="info"
+            title="Select a builder image to see if there is a pipeline template available for this runtime."
+          />
+        )}
       </FormSection>
     );
   }

--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineSection.tsx
@@ -24,7 +24,7 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({ flags }) => {
     );
     return (
       <FormSection title={title}>
-        {values.image.selected ? (
+        {values.image.selected || values.build.strategy === 'Docker' ? (
           <PipelineTemplate />
         ) : (
           <Alert

--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
-import { ExpandCollapse, LoadingInline } from '@console/internal/components/utils';
+import { LoadingInline } from '@console/internal/components/utils';
 import { useFormikContext, FormikValues } from 'formik';
-import { Alert } from '@patternfly/react-core';
+import { Alert, Expandable } from '@patternfly/react-core';
+import { CheckboxField } from '../../formik-fields';
 import { PipelineVisualization } from '../../pipelines/PipelineVisualization';
 import { getPipelineTemplate } from './pipeline-template-utils';
 
 const PipelineTemplate: React.FC = () => {
   const [noTemplateForRuntime, setNoTemplateForRuntime] = React.useState(false);
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
   const {
-    values: {
-      pipeline: { template },
-      image,
-    },
+    values: { pipeline, image },
     setFieldValue,
   } = useFormikContext<FormikValues>();
 
@@ -30,6 +30,7 @@ const PipelineTemplate: React.FC = () => {
         setFieldValue('pipeline.template', null);
         setNoTemplateForRuntime(true);
       }
+      setIsExpanded(false);
     };
 
     fetchPipelineTemplate();
@@ -44,19 +45,22 @@ const PipelineTemplate: React.FC = () => {
       <Alert
         isInline
         variant="info"
-        style={{ marginLeft: 'var(--pf-global--spacer--lg)' }}
-        title="Since there are no pipeline templates available for this runtime, a pipeline cannot be created."
+        title="There are no pipeline templates available for this runtime."
       />
     );
   }
 
-  return template ? (
-    <ExpandCollapse
-      textCollapsed="Show pipeline visualization"
-      textExpanded="Hide pipeline visualization"
-    >
-      <PipelineVisualization pipeline={template} />
-    </ExpandCollapse>
+  return pipeline.template ? (
+    <>
+      <CheckboxField label="Add pipeline" name="pipeline.enabled" />
+      <Expandable
+        toggleText={`${isExpanded ? 'Hide' : 'Show'} pipeline visualization`}
+        isExpanded={isExpanded}
+        onToggle={() => setIsExpanded(!isExpanded)}
+      >
+        {isExpanded && <PipelineVisualization pipeline={pipeline.template} />}
+      </Expandable>
+    </>
   ) : (
     <LoadingInline />
   );

--- a/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
@@ -1,16 +1,8 @@
 import * as _ from 'lodash';
-import { K8sResourceKind, k8sList, k8sCreate } from '@console/internal/module/k8s';
+import { k8sCreate } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../../models';
 import { GitImportFormData } from '../import-types';
 import { createPipelineResource } from '../../pipelines/pipeline-resource/pipelineResource-utils';
-
-export const getPipelineTemplate = async (runtime: string): Promise<K8sResourceKind> => {
-  const templates = await k8sList(PipelineModel, {
-    ns: 'openshift',
-    labelSelector: { 'pipeline.openshift.io/runtime': runtime },
-  });
-  return templates && templates[0];
-};
 
 export const createGitResource = (url: string, namespace: string, ref: string = 'master') => {
   const params = { url, revision: ref };

--- a/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
@@ -37,7 +37,7 @@ export const createPipelineForImportFlow = async (formData: GitImportFormData) =
   template.metadata = {
     name: `${name}-${template.metadata.name}`,
     namespace,
-    labels: template.metadata.labels,
+    labels: { ...template.metadata.labels, 'app.kubernetes.io/instance': name },
   };
 
   template.spec.params =


### PR DESCRIPTION
Related Bug - https://jira.coreos.com/browse/ODC-2241 and https://jira.coreos.com/browse/ODC-2246.

Based on the new user flow and designs for add pipeline section, this PR -
- Updates the label of checkbox from `Enable Pipelines` -> `Add pipeline`.
- Updates the component to always show `Pipelines` section with an alert if no builder image is selected.
- Fetches the `pipeline` template when user selects a builder image and renders the checkbox and visualization in an expand collapse component.
- Shows an alert if no pipeline template is found for that builder image.
- Renders the `PipelineVisualization` component only when user expands the section to defer the fetching of all related `Task` resources.

Gif - 
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/6041994/68712633-1efe5480-05c2-11ea-9246-5f4989cc77e2.gif)


- This PR also adds support for pipelines in dockerfile flow. We fetch pipeline template based on `pipeline.openshift.io/strategy=docker` label. 

Screenshot - 
![Screenshot from 2019-11-13 04-16-11](https://user-images.githubusercontent.com/6041994/68717342-8faa6e80-05cc-11ea-8606-e4e385c3e825.png)


