### PR TITLE
add traffic distribution action to context menu and sidebar action

### DIFF
--- a/frontend/packages/knative-plugin/src/actions/traffic-splitting.ts
+++ b/frontend/packages/knative-plugin/src/actions/traffic-splitting.ts
@@ -1,0 +1,20 @@
+import { KebabOption } from '@console/internal/components/utils';
+import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { setTrafficDistributionModal } from '../components/modals';
+
+export const setTrafficDistribution = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
+  return {
+    label: 'Set Traffic Distribution',
+    callback: () =>
+      setTrafficDistributionModal({
+        obj,
+      }),
+    accessReview: {
+      group: model.apiGroup,
+      resource: model.plural,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'update',
+    },
+  };
+};

--- a/frontend/packages/knative-plugin/src/components/modals/index.ts
+++ b/frontend/packages/knative-plugin/src/components/modals/index.ts
@@ -1,0 +1,4 @@
+export const setTrafficDistributionModal = (props) =>
+  import(
+    '../traffic-splitting/TrafficSplittingController' /* webpackChunkName: "set-traffic-splitting" */
+  ).then((m) => m.trafficModalLauncher(props));

--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
@@ -9,7 +9,7 @@ import {
   useAccessReview,
 } from '@console/internal/components/utils';
 import { RevisionModel } from '@console/knative-plugin';
-import { trafficModalLauncher } from '../traffic-splitting/TrafficSplittingController';
+import { setTrafficDistributionModal } from '../modals';
 import { ServiceModel } from '../../models';
 import './RevisionsOverviewList.scss';
 
@@ -65,7 +65,7 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({ revisions
           (service.kind === ServiceModel.kind && (
             <Button
               variant="secondary"
-              onClick={() => trafficModalLauncher({ obj: service })}
+              onClick={() => setTrafficDistributionModal({ obj: service })}
               isDisabled={!(revisions && revisions.length)}
             >
               Set Traffic Distribution

--- a/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
+++ b/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import { K8sKind, referenceFor } from '@console/internal/module/k8s';
 import { KebabAction } from '@console/internal/components/utils';
 import { ModifyApplication } from '@console/dev-console/src/actions/modify-application';
+import { setTrafficDistribution } from '../actions/traffic-splitting';
 import {
   EventSourceApiServerModel,
   EventSourceCamelModel,
@@ -21,10 +22,14 @@ const modifyApplicationRefs = [
 ];
 
 export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => {
-  if (!resourceKind) {
-    // no common actions
-    return [];
+  const menuActions: KebabAction[] = [];
+  if (resourceKind) {
+    if (_.includes(modifyApplicationRefs, referenceFor(resourceKind))) {
+      menuActions.push(ModifyApplication);
+    }
+    if (resourceKind.kind === ServiceModel.kind) {
+      menuActions.push(setTrafficDistribution);
+    }
   }
-
-  return _.includes(modifyApplicationRefs, referenceFor(resourceKind)) ? [ModifyApplication] : [];
+  return menuActions;
 };


### PR DESCRIPTION
Adds traffic distribution action for knative service in topology context menu and sidebar actions

![setTrafficDistribution1](https://user-images.githubusercontent.com/9964343/68757226-99b28880-0631-11ea-9644-d5e5352a1825.gif)

Fixes: https://jira.coreos.com/browse/ODC-2236