### PR TITLE
Fix legacy linter settings error in vscode

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -12,15 +12,9 @@
     "editor.formatOnSave": true
   },
 
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "eslint.enable": true,
 
-  "prettier.eslintIntegration": true,
   "javascript.validate.enable": false,
   "debug.node.autoAttach": "on",
   "typescript.tsdk": "node_modules/typescript/lib",
@@ -28,7 +22,7 @@
     "**/node_modules": true,
     "**/bower_components": true,
     "**/.cache-loader": true,
-    "**/public/dist": true,
+    "**/public/dist": true
   }
 
   // TODO support prettier + stylelint


### PR DESCRIPTION
`prettier.eslintIntegration` config option is deprecated