### PR TITLE
Bug 1772094: Disable NADs UI if CNV is missing & disable SR-IOV support

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -41,7 +41,7 @@ type ConsumedExtensions =
   | DashboardsStorageCapacityDropdownItem
   | ReduxReducer;
 
-const FLAG_KUBEVIRT = 'KUBEVIRT';
+export const FLAG_KUBEVIRT = 'KUBEVIRT';
 
 const plugin: Plugin<ConsumedExtensions> = [
   {

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -310,8 +310,10 @@ const mapStateToProps = ({ k8s }) => {
 
   return {
     // FIXME: These should be feature flags.
-    hasSriovNetNodePolicyCRD:
-      !kindsInFlight && !!k8sModels.get(referenceForModel(SriovNetworkNodePolicyModel)),
+    // TODO: Change back when ready to add back SR-IOV support
+    // hasSriovNetNodePolicyCRD:
+    //   !kindsInFlight && !!k8sModels.get(referenceForModel(SriovNetworkNodePolicyModel)),
+    hasSriovNetNodePolicyCRD: false,
     hasHyperConvergedCRD: !kindsInFlight && !!k8sModels.get(referenceForModel(HyperConvergedModel)),
   };
 };

--- a/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/constants/index.ts
@@ -9,12 +9,12 @@ export const ELEMENT_TYPES = {
 
 export const networkTypes = {
   sriov: 'SR-IOV',
-  'cnv-bridge': 'Linux bridge',
+  'cnv-bridge': 'CNV Linux bridge',
 };
 
 export enum NetworkTypes {
   SRIOV = 'SR-IOV',
-  'CNV-Bridge' = 'Linux bridge',
+  'CNV-Bridge' = 'CNV Linux bridge',
 }
 
 export const networkTypeParams: NetworkTypeParamsList = {
@@ -45,10 +45,6 @@ export const networkTypeParams: NetworkTypeParamsList = {
       name: 'VLAN Tag Number',
       hintText: 'Ex: 100',
       type: ELEMENT_TYPES.TEXT,
-    },
-    ipam: {
-      name: 'IP Address Management',
-      type: ELEMENT_TYPES.TEXTAREA,
     },
   },
 };

--- a/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/plugin.ts
@@ -10,6 +10,7 @@ import {
   RoutePage,
 } from '@console/plugin-sdk';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { FLAG_KUBEVIRT } from '@console/kubevirt-plugin/src/plugin';
 import * as models from './models';
 import { NetworkAttachmentDefinitionsYAMLTemplates } from './models/templates';
 
@@ -45,7 +46,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       componentProps: {
         name: 'Network Attachment Definitions',
         resource: referenceForModel(models.NetworkAttachmentDefinitionModel),
-        required: FLAG_NET_ATTACH_DEF,
+        required: [FLAG_NET_ATTACH_DEF, FLAG_KUBEVIRT],
       },
       mergeAfter: 'Network Policies',
     },


### PR DESCRIPTION
This PR makes the following changes:
- Removes the network attachment definitions side nav item if CNV isn't installed
- Disables support for SR-IOV in the creation form
- Updates the name of "Linux bridge" to "CNV Linux bridge" for clarification purposes

@phoracek @rawagner 