### PR TITLE
Hide `OpenShift Cluster Manager` when branding is OKD

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -274,10 +274,12 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
           </div>
         </div>
         <div className="co-m-pane__body-group">
-          <p className="co-m-pane__explanation">
-            View this cluster and manage subscription settings in{' '}
-            <ExternalLink text="OpenShift Cluster Manager" href={getOCMLink(clusterID)} />.
-          </p>
+          {window.SERVER_FLAGS.branding !== 'okd' && (
+            <p className="co-m-pane__explanation">
+              View this cluster and manage subscription settings in{' '}
+              <ExternalLink text="OpenShift Cluster Manager" href={getOCMLink(clusterID)} />.
+            </p>
+          )}
           <dl className="co-m-pane__details">
             <dt>Cluster ID</dt>
             <dd className="co-break-all co-select-to-copy" data-test-id="cv-details-table-cid">

--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/details-card.tsx
@@ -166,7 +166,9 @@ export const DetailsCard_ = connect(mapStateToProps)(
                   isLoading={!clusterVersionLoaded}
                 >
                   <div className="co-select-to-copy">{clusterId}</div>
-                  <ExternalLink text="OpenShift Cluster Manager" href={getOCMLink(clusterId)} />
+                  {window.SERVER_FLAGS.branding !== 'okd' && (
+                    <ExternalLink text="OpenShift Cluster Manager" href={getOCMLink(clusterId)} />
+                  )}
                 </DetailItem>
                 <DetailItem
                   title="Provider"

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -245,7 +245,7 @@ class MastheadToolbarContents_ extends React.Component {
     const launcherItems = this._getAdditionalLinks(consoleLinks, 'ApplicationMenu');
 
     const sections = [];
-    if (clusterID) {
+    if (clusterID && window.SERVER_FLAGS.branding !== 'okd') {
       sections.push({
         name: 'Red Hat Applications',
         isSection: true,


### PR DESCRIPTION
Fixes https://github.com/openshift/console/issues/3377

<img width="1426" alt="Screen Shot 2019-11-13 at 11 28 08 AM" src="https://user-images.githubusercontent.com/895728/68783270-b7b7c300-0608-11ea-8244-0cfe0adcd60d.png">
<img width="1426" alt="Screen Shot 2019-11-13 at 11 28 20 AM" src="https://user-images.githubusercontent.com/895728/68783271-b8505980-0608-11ea-8125-647ec2ed09f0.png">
