### PR TITLE
tests: add additional retires to OLM scenarios

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
@@ -12,10 +12,11 @@ import { safeDump } from 'js-yaml';
 import { startCase, get, find, isUndefined } from 'lodash';
 import {
   appHost,
-  testName,
-  checkLogs,
   checkErrors,
+  checkLogs,
   create,
+  retry,
+  testName,
 } from '@console/internal-integration-tests/protractor.conf';
 import * as crudView from '@console/internal-integration-tests/views/crud.view';
 import * as yamlView from '@console/internal-integration-tests/views/yaml.view';
@@ -412,7 +413,7 @@ describe('Using OLM descriptor components', () => {
   it('displays form for creating operand', async () => {
     await $$('[data-test-id=breadcrumb-link-1]').click();
     await browser.wait(until.visibilityOf(element(by.buttonText('Create App'))));
-    await element(by.buttonText('Create App')).click();
+    await retry(() => element(by.buttonText('Create App')).click());
     await yamlView.isLoaded();
     await element(by.buttonText('Edit Form')).click();
     await browser.wait(until.presenceOf($('#metadata\\.name')));

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
@@ -173,7 +173,8 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
     await crudView.isLoaded();
     await browser.wait(until.visibilityOf(operatorView.operandLink(jaegerName)));
 
-    expect(operatorView.operandKind('Jaeger').isDisplayed()).toBe(true);
+    const isDisplayed = retry(() => operatorView.operandKind('Jaeger').isDisplayed());
+    expect(isDisplayed).toBe(true);
   });
 
   it('displays metadata about the created `Jaeger` in its "Overview" section', async () => {

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
@@ -179,7 +179,8 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     await crudView.isLoaded();
     await browser.wait(until.visibilityOf(operatorView.operandLink('example')));
 
-    expect(operatorView.operandKind('Prometheus').isDisplayed()).toBe(true);
+    const isDisplayed = retry(() => operatorView.operandKind('Prometheus').isDisplayed());
+    expect(isDisplayed).toBe(true);
   });
 
   it('displays metadata about the created `Prometheus` in its "Overview" section', async () => {


### PR DESCRIPTION
* Retry clicking the "Create App" button
* Retry checking the operand kind

Fixes https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_console/3197/pull-ci-openshift-console-master-e2e-gcp-console/2900/

Fixes https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_console/3300/pull-ci-openshift-console-master-e2e-gcp-console/3031

/assign @rhamilto 
/kind test-flake