### PR TITLE
fix vscode prettier integration

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[javascript]": {
     "editor.formatOnSave": true
   },
@@ -13,14 +14,14 @@
   },
 
   "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
+    { "language": "javascript", "autoFix": true },
+    { "language": "javascriptreact", "autoFix": true },
+    { "language": "typescript", "autoFix": true },
+    { "language": "typescriptreact", "autoFix": true }
   ],
   "eslint.enable": true,
+  "eslint.autoFixOnSave": true,
 
-  "prettier.eslintIntegration": true,
   "javascript.validate.enable": false,
   "debug.node.autoAttach": "on",
   "typescript.tsdk": "node_modules/typescript/lib",
@@ -28,7 +29,7 @@
     "**/node_modules": true,
     "**/bower_components": true,
     "**/.cache-loader": true,
-    "**/public/dist": true,
+    "**/public/dist": true
   }
 
   // TODO support prettier + stylelint

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -177,6 +177,7 @@
     "monaco-editor-core": "0.14.0",
     "monaco-editor-webpack-plugin": "^1.7.0",
     "node-sass": "4.12.x",
+    "prettier": "1.17.1",
     "protractor": "5.4.x",
     "protractor-fail-fast": "3.x",
     "protractor-jasmine2-screenshot-reporter": "0.5.x",


### PR DESCRIPTION
Removed setting `prettier.eslintIntegration` which no longer was supported.

vscode prettier plugin will only use the local prettier version if it is located in the package.json of the root (a bit odd). Therefore copied the version of prettier from the eslint-plugin-console package to the root package.json dev dependency

@rhamilto @spadgett 