### PR TITLE
Shrinks the Sidebar Header Size/Spacing

### DIFF
--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -60,7 +60,8 @@ $overview-sidebar-width: 550px;
   padding-top: 5px;
 
   .co-m-pane__heading {
-    margin: 0 20px 25px;
+    font-size: var(--pf-global--FontSize--xl);
+    margin: 0 20px var(--pf-global--spacer--md);
   }
 
   .co-actions-menu {


### PR DESCRIPTION
Small font change requested by UX. https://jira.coreos.com/browse/ODC-2254

Slight font size decrease and spacing beneath the header is slightly reduced.

What it was:
![Screen Shot 2019-11-13 at 9 30 01 PM](https://user-images.githubusercontent.com/8126518/68821761-27f03400-065d-11ea-90ad-3ad660706de0.png)


What it is now:
![Screen Shot 2019-11-13 at 9 23 44 PM](https://user-images.githubusercontent.com/8126518/68821748-1e66cc00-065d-11ea-8256-266b25ec27ad.png)

/cc @openshift/team-devconsole-ux 
/cc @serenamarie125 