### PR TITLE
topology: support promise return value on drag end

### DIFF
--- a/frontend/packages/console-shared/src/components/popper/Popper.tsx
+++ b/frontend/packages/console-shared/src/components/popper/Popper.tsx
@@ -89,7 +89,7 @@ const Popper: React.FC<PopperProps> = ({
   const controlled = typeof open === 'boolean';
   const openProp = controlled ? open : true;
   const nodeRef = React.useRef<Element>();
-  const popperRef = React.useRef<PopperJS>();
+  const popperRef = React.useRef<PopperJS>(null);
   const popperRefs = useCombineRefs<PopperJS>(popperRef, popperRefIn);
   const [isOpen, setOpen] = React.useState(openProp);
 

--- a/frontend/packages/dev-console/src/components/topology2/componentUtils.ts
+++ b/frontend/packages/dev-console/src/components/topology2/componentUtils.ts
@@ -78,11 +78,12 @@ const nodeDragSourceSpec = (
         [Modifiers.SHIFT]: REGROUP_OPERATION,
       }
     : undefined,
-  canCancel: false,
+  canCancel: (monitor) => monitor.getOperation() === REGROUP_OPERATION,
   end: (dropResult, monitor, props) => {
     if (monitor.didDrop() && dropResult && props && props.element.getParent() !== dropResult) {
-      moveNodeToGroup(props.element, isNode(dropResult) ? dropResult : null);
+      return moveNodeToGroup(props.element, isNode(dropResult) ? dropResult : null);
     }
+    return undefined;
   },
   collect: (monitor) => ({
     dragging: monitor.isDragging(),

--- a/frontend/packages/topology/src/behavior/dnd-types.ts
+++ b/frontend/packages/topology/src/behavior/dnd-types.ts
@@ -18,7 +18,7 @@ export type DragSource = {
   canDrag(dndManager: DndManager): boolean;
   beginDrag(dndManager: DndManager): any;
   drag(dndManager: DndManager): void;
-  endDrag(dndManager: DndManager): void;
+  endDrag(dndManager: DndManager): void | Promise<void>;
   canCancel(dndManager: DndManager): boolean;
 };
 
@@ -120,7 +120,11 @@ export interface DragSourceSpec<
   operation?: DragSpecOperation;
   begin?: (monitor: DragSourceMonitor, props: Props) => any;
   drag?: (event: DragEvent, monitor: DragSourceMonitor, props: Props) => void;
-  end?: (dropResult: DropResult | undefined, monitor: DragSourceMonitor, props: Props) => void;
+  end?: (
+    dropResult: DropResult | undefined,
+    monitor: DragSourceMonitor,
+    props: Props,
+  ) => void | Promise<void>;
   canDrag?: boolean | ((monitor: DragSourceMonitor, props: Props) => boolean);
   collect?: (monitor: DragSourceMonitor, props: Props) => CollectedProps;
   canCancel?: boolean | ((monitor: DragSourceMonitor, props: Props) => boolean);

--- a/frontend/packages/topology/src/behavior/useDndDrop.tsx
+++ b/frontend/packages/topology/src/behavior/useDndDrop.tsx
@@ -14,6 +14,7 @@ import {
   DropTargetMonitor,
   Identifier,
   DragEvent,
+  DropTarget,
 } from './dnd-types';
 import { useDndManager } from './useDndManager';
 
@@ -86,9 +87,9 @@ export const useDndDrop = <
   elementRef.current = element;
 
   React.useEffect(() => {
-    const [targetId, unregister] = dndManager.registerTarget({
+    const dropTarget: DropTarget = {
       type: spec.accept,
-      hitTest: (x: number, y: number): boolean => {
+      hitTest: (x: number, y: number) => {
         if (specRef.current.hitTest) {
           return specRef.current.hitTest(x, y, propsRef.current);
         }
@@ -146,10 +147,11 @@ export const useDndDrop = <
         }
         return false;
       },
-      hover: (): void =>
+      hover: () => {
         specRef.current.hover &&
-        specRef.current.hover(monitor.getItem(), monitor, propsRef.current),
-      canDrop: (): boolean =>
+          specRef.current.hover(monitor.getItem(), monitor, propsRef.current);
+      },
+      canDrop: () =>
         typeof specRef.current.canDrop === 'boolean'
           ? specRef.current.canDrop
           : typeof specRef.current.canDrop === 'function'
@@ -161,7 +163,8 @@ export const useDndDrop = <
           : !monitor.didDrop()
           ? elementRef.current
           : undefined,
-    });
+    };
+    const [targetId, unregister] = dndManager.registerTarget(dropTarget);
     monitor.receiveHandlerId(targetId);
     return unregister;
   }, [spec.accept, dndManager, monitor]);

--- a/frontend/packages/topology/src/behavior/useDndManager.tsx
+++ b/frontend/packages/topology/src/behavior/useDndManager.tsx
@@ -212,20 +212,27 @@ export class DndManagerImpl implements DndManager {
   }
 
   endDrag(): void {
+    this.doEndDrag();
+  }
+
+  private async doEndDrag(): Promise<void> {
     const source = this.getSource(this.getSourceId());
-    if (source) {
-      source.endDrag(this);
+    try {
+      if (source) {
+        await source.endDrag(this);
+      }
+    } finally {
+      // clear state
+      delete this.state.didDrop;
+      delete this.state.dropResult;
+      delete this.state.event;
+      delete this.state.isDragging;
+      delete this.state.item;
+      delete this.state.sourceId;
+      delete this.state.targetIds;
+      delete this.state.operation;
+      delete this.state.cancelled;
     }
-    // clear state
-    delete this.state.didDrop;
-    delete this.state.dropResult;
-    delete this.state.event;
-    delete this.state.isDragging;
-    delete this.state.item;
-    delete this.state.sourceId;
-    delete this.state.targetIds;
-    delete this.state.operation;
-    delete this.state.cancelled;
   }
 
   drop(): void {

--- a/frontend/packages/topology/src/components/contextmenu/ContextMenu.tsx
+++ b/frontend/packages/topology/src/components/contextmenu/ContextMenu.tsx
@@ -6,7 +6,8 @@ import {
   DropdownSeparator,
 } from '@patternfly/react-core';
 import styles from '@patternfly/react-styles/css/components/Dropdown/dropdown';
-import { Popper } from '@console/shared';
+// FIXME fully qualified due to the effect of long build times on storybook
+import Popper from '@console/shared/src/components/popper/Popper';
 
 import './ContextMenu.scss';
 

--- a/frontend/packages/topology/src/utils/useCombineRefs.ts
+++ b/frontend/packages/topology/src/utils/useCombineRefs.ts
@@ -1,3 +1,4 @@
-import { useCombineRefs } from '@console/shared';
+// FIXME fully qualified due to the effect of long build times on storybook
+import { useCombineRefs } from '@console/shared/src/utils/useCombineRefs';
 
 export default useCombineRefs;


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-1755

Added support to return a promise on drag end to allow cancelling the drag operation at user request. The drag operation is no longer ended immediately when the user stops dragging if an unresolved promise is returned. Instead it now halts the drag operation and leaves all drag state active until the promise resolves. This lets us keep the node in the last dragged position while the confirm dialog is opened. If the user cancels, the node is returned to it's initial position before cancelling the operation altogether.

Before:
![regroup-op](https://user-images.githubusercontent.com/14068621/68821774-2fafd880-065d-11ea-8d67-ab7157c487b5.gif)

After:
![dragpromise](https://user-images.githubusercontent.com/14068621/68821684-f7a89580-065c-11ea-96cf-62612254d3c0.gif)

/assign @jeff-phillips-18 

_Updated some types that were changed in the refactor move of some files to console-shared due to affects on storybook dev env for topology_