### PR TITLE
kubevirt: migrate `getBootableDevicesInOrder()` and `BootOrder` from web-ui-components

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/boot-order.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { BootableDeviceType } from '../types';
+
+export const BootOrder: React.FC<BootOrderProps> = ({ bootableDevices }) => {
+  const listItems = bootableDevices.map((dev) => (
+    <li key={`${dev.type}-${dev.value.name}`}>{dev.value.name}</li>
+  ));
+
+  return <ol className="kubevirt-boot-order__list">{listItems}</ol>;
+};
+
+type BootOrderProps = {
+  bootableDevices: BootableDeviceType[];
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -4,7 +4,6 @@ import {
   getOperatingSystem,
   getWorkloadProfile,
   BootOrder,
-  getBootableDevicesInOrder,
 } from 'kubevirt-web-ui-components';
 import { ResourceSummary } from '@console/internal/components/utils';
 import { TemplateKind } from '@console/internal/module/k8s';
@@ -19,7 +18,7 @@ import { getFlavorText } from '../flavor-text';
 import { EditButton } from '../edit-button';
 import { VMDetailsItem } from '../vms/vm-resource';
 import { DiskSummary } from '../vm-disks/disk-summary';
-import { asVM } from '../../selectors/vm';
+import { asVM, getBootableDevicesInOrder } from '../../selectors/vm';
 import { VMTemplateLink } from './vm-template-link';
 import { TemplateSource } from './vm-template-source';
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -3,7 +3,6 @@ import {
   getOperatingSystemName,
   getOperatingSystem,
   getWorkloadProfile,
-  BootOrder,
 } from 'kubevirt-web-ui-components';
 import { ResourceSummary } from '@console/internal/components/utils';
 import { TemplateKind } from '@console/internal/module/k8s';
@@ -19,6 +18,7 @@ import { EditButton } from '../edit-button';
 import { VMDetailsItem } from '../vms/vm-resource';
 import { DiskSummary } from '../vm-disks/disk-summary';
 import { asVM, getBootableDevicesInOrder } from '../../selectors/vm';
+import { BootOrder } from '../boot-order';
 import { VMTemplateLink } from './vm-template-link';
 import { TemplateSource } from './vm-template-source';
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { BootOrder } from 'kubevirt-web-ui-components';
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
 import { PodKind } from '@console/internal/module/k8s';
 import { getName, getNamespace, getNodeName } from '@console/shared';
@@ -18,6 +17,7 @@ import { EditButton } from '../edit-button';
 import { getVmiIpAddressesString } from '../ip-addresses';
 import { VMStatuses } from '../vm-status';
 import { DiskSummary } from '../vm-disks/disk-summary';
+import { BootOrder } from '../boot-order';
 import {
   getOperatingSystemName,
   getOperatingSystem,

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BootOrder, getBootableDevicesInOrder } from 'kubevirt-web-ui-components';
+import { BootOrder } from 'kubevirt-web-ui-components';
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
 import { PodKind } from '@console/internal/module/k8s';
 import { getName, getNamespace, getNodeName } from '@console/shared';
@@ -18,7 +18,12 @@ import { EditButton } from '../edit-button';
 import { getVmiIpAddressesString } from '../ip-addresses';
 import { VMStatuses } from '../vm-status';
 import { DiskSummary } from '../vm-disks/disk-summary';
-import { getOperatingSystemName, getOperatingSystem, getWorkloadProfile } from '../../selectors/vm';
+import {
+  getOperatingSystemName,
+  getOperatingSystem,
+  getWorkloadProfile,
+  getBootableDevicesInOrder,
+} from '../../selectors/vm';
 
 import './vm-resource.scss';
 

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -26,6 +26,9 @@ export const VM_DETAIL_DISKS_HREF = 'disks';
 export const VM_DETAIL_NETWORKS_HREF = 'nics';
 export const VM_DETAIL_CONSOLES_HREF = 'consoles';
 
+export const DEVICE_TYPE_INTERFACE = 'interface';
+export const DEVICE_TYPE_DISK = 'disk';
+
 export const CLOUDINIT_DISK = 'cloudinitdisk';
 
 export enum DeviceType {

--- a/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-cdrom-patches.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-cdrom-patches.ts
@@ -1,9 +1,4 @@
 import { last, includes } from 'lodash';
-import {
-  BOOT_ORDER_SECOND,
-  BOOT_ORDER_FIRST,
-  getBootableDevicesInOrder,
-} from 'kubevirt-web-ui-components';
 import { getName } from '@console/shared';
 import { Volume, k8sGet } from '@console/internal/module/k8s';
 import { CD, StorageType } from '../../../components/modals/cdrom-vm-modal/constants';
@@ -21,8 +16,10 @@ import {
   getDisks,
   getVolumeDataVolumeName,
   asVM,
+  getBootableDevicesInOrder,
 } from '../../../selectors/vm';
 import { getVMLikePatches } from '../vm-template';
+import { BOOT_ORDER_FIRST, BOOT_ORDER_SECOND } from '../../../constants';
 
 const getNextAvailableBootOrderIndex = (vm: VMLikeEntityKind) => {
   const sortedBootableDevices = getBootableDevicesInOrder(vm);

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/devices.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/devices.ts
@@ -1,5 +1,32 @@
+import { VMKind, V1NetworkInterface, VMLikeEntityKind } from '../../types';
+import { DEVICE_TYPE_DISK, DEVICE_TYPE_INTERFACE } from '../../constants';
+import { V1Disk } from '../../types/vm/disk/V1Disk';
+import { getDisks, getInterfaces } from './selectors';
+import { asVM } from './vmlike';
+
+type BootableDeviceType = {
+  type: string;
+  value: V1Disk | V1NetworkInterface;
+};
+
 export const getBootDeviceIndex = (devices, bootOrder) =>
   devices.findIndex((device) => device.bootOrder === bootOrder);
 
 export const getDeviceBootOrder = (device, defaultValue?): number =>
   device && device.bootOrder === undefined ? defaultValue : device.bootOrder;
+
+const getBootableDevices = (vm: VMKind): BootableDeviceType[] => {
+  const disks = getDisks(vm)
+    .filter((disk) => disk.bootOrder)
+    .map((disk) => ({ type: DEVICE_TYPE_DISK, value: disk }));
+  const nics = getInterfaces(vm)
+    .filter((nic) => nic.bootOrder)
+    .map((nic) => ({ type: DEVICE_TYPE_INTERFACE, value: nic }));
+
+  return [...disks, ...nics];
+};
+
+export const getBootableDevicesInOrder = (vmLike: VMLikeEntityKind): BootableDeviceType[] => {
+  const vm = asVM(vmLike);
+  return getBootableDevices(vm).sort((a, b) => a.value.bootOrder - b.value.bootOrder);
+};

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/devices.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/devices.ts
@@ -1,13 +1,7 @@
-import { VMKind, V1NetworkInterface, VMLikeEntityKind } from '../../types';
+import { VMKind, VMLikeEntityKind, BootableDeviceType } from '../../types';
 import { DEVICE_TYPE_DISK, DEVICE_TYPE_INTERFACE } from '../../constants';
-import { V1Disk } from '../../types/vm/disk/V1Disk';
 import { getDisks, getInterfaces } from './selectors';
 import { asVM } from './vmlike';
-
-type BootableDeviceType = {
-  type: string;
-  value: V1Disk | V1NetworkInterface;
-};
 
 export const getBootDeviceIndex = (devices, bootOrder) =>
   devices.findIndex((device) => device.bootOrder === bootOrder);

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -13,6 +13,7 @@ import { findKeySuffixValue, getSimpleName, getValueByPrefix } from '../utils';
 import { getAnnotations, getLabels } from '../selectors';
 import { NetworkWrapper } from '../../k8s/wrapper/vm/network-wrapper';
 import { getDataVolumeStorageSize, getDataVolumeStorageClassName } from '../dv/selectors';
+import { V1Disk } from '../../types/vm/disk/V1Disk';
 import { getDiskBus } from './disk';
 import {
   getVolumeContainerImage,
@@ -24,7 +25,7 @@ import { vCPUCount } from './cpu';
 export const getMemory = (vm: VMKind) =>
   _.get(vm, 'spec.template.spec.domain.resources.requests.memory');
 export const getCPU = (vm: VMKind): CPURaw => _.get(vm, 'spec.template.spec.domain.cpu');
-export const getDisks = (vm: VMKind, defaultValue = []) =>
+export const getDisks = (vm: VMKind, defaultValue = []): V1Disk[] =>
   _.get(vm, 'spec.template.spec.domain.devices.disks') == null
     ? defaultValue
     : vm.spec.template.spec.domain.devices.disks;

--- a/frontend/packages/kubevirt-plugin/src/types/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/types.ts
@@ -1,5 +1,6 @@
 import { PodKind, TemplateKind } from '@console/internal/module/k8s';
-import { VMKind } from './vm';
+import { VMKind, V1NetworkInterface } from './vm';
+import { V1Disk } from './vm/disk/V1Disk';
 
 export type VMLikeEntityKind = VMKind | TemplateKind;
 
@@ -10,4 +11,9 @@ export type VMMultiStatus = {
   launcherPod?: PodKind;
   importerPodsStatuses?: any[];
   progress?: number;
+};
+
+export type BootableDeviceType = {
+  type: string;
+  value: V1Disk | V1NetworkInterface;
 };


### PR DESCRIPTION
Another dependency less.
This is part of the gradual effort to remove the kubevirt-web-ui dependency.