### PR TITLE
Bug 1770665: Fix VM's hostname not being imported from cloud-init data

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/prefill-vm-template-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/prefill-vm-template-state-update.ts
@@ -39,6 +39,7 @@ import {
   getTemplateFlavors,
   getTemplateOperatingSystems,
   getTemplateWorkloadProfiles,
+  getTemplateHostname,
 } from '../../../../../selectors/vm-template/advanced';
 import { V1Network } from '../../../../../types/vm';
 import { getFlavors } from '../../../../../selectors/vm-template/combined-dependent';
@@ -115,6 +116,10 @@ export const prefillVmTemplateUpdater = ({ id, dispatch, getState }: UpdateOptio
     vmSettingsUpdate[VMSettingsField.PROVISION_SOURCE_TYPE] = {
       value: provisionSourceDetails.type ? provisionSourceDetails.type.getValue() : null,
     };
+
+    // update hostname
+    const hostname = getTemplateHostname(userTemplate);
+    vmSettingsUpdate[VMSettingsField.HOSTNAME] = { value: hostname };
 
     const networkLookup = createBasicLookup<V1Network>(getNetworks(vm), getSimpleName);
     // prefill networks

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/vm-settings.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/vm-settings.ts
@@ -15,6 +15,7 @@ export const titleResolver: VMSettingsRenderableFieldResolver = {
   [VMWareProviderField.STATUS]: '',
   [VMWareProviderField.VM]: 'VM or Template to Import',
   [VMSettingsField.NAME]: 'Name',
+  [VMSettingsField.HOSTNAME]: 'Hostname',
   [VMSettingsField.DESCRIPTION]: 'Description',
   [VMSettingsField.USER_TEMPLATE]: 'Template',
   [VMSettingsField.PROVISION_SOURCE_TYPE]: 'Source',

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -38,6 +38,7 @@ export const ALL_VM_WIZARD_TABS = getStringEnumValues<VMWizardTab>(VMWizardTab);
 
 export enum VMSettingsField { // TODO refactor to NAME = 'NAME' format for easier debugging once kubevirt-web-ui-components is deprecated
   NAME = 'name',
+  HOSTNAME = 'hostname',
   DESCRIPTION = 'description',
   PROVISION_SOURCE_TYPE = 'provisionSourceType',
   CONTAINER_IMAGE = 'containerImage',

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/utils/vm-settings-tab-utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/utils/vm-settings-tab-utils.ts
@@ -15,6 +15,7 @@ const idResolver: VMSettingsRenderableFieldResolver = {
   [VMWareProviderField.STATUS]: 'vcenter-status',
   [VMWareProviderField.VM]: 'vcenter-vm-dropdown',
   [VMSettingsField.NAME]: 'vm-name',
+  [VMSettingsField.HOSTNAME]: 'vm-hostname',
   [VMSettingsField.DESCRIPTION]: 'vm-description',
   [VMSettingsField.USER_TEMPLATE]: 'template-dropdown',
   [VMSettingsField.PROVISION_SOURCE_TYPE]: 'image-source-type-dropdown',

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -17,7 +17,7 @@ import { getDiskBus } from './disk';
 import {
   getVolumeContainerImage,
   getVolumePersistentVolumeClaimName,
-  getVolumeCloudInitUserData,
+  getVolumeCloudInitNoCloud,
 } from './volume';
 import { vCPUCount } from './cpu';
 
@@ -85,7 +85,7 @@ export const getVMStatusConditions = (vm: VMKind) =>
   _.get(vm, 'status.conditions', []) as VMKind['status']['conditions'];
 
 export const getCloudInitVolume = (vm: VMKind) => {
-  const cloudInitVolume = getVolumes(vm).find(getVolumeCloudInitUserData);
+  const cloudInitVolume = getVolumes(vm).find(getVolumeCloudInitNoCloud);
 
   if (cloudInitVolume) {
     // make sure volume is used by disk
@@ -96,9 +96,6 @@ export const getCloudInitVolume = (vm: VMKind) => {
   }
   return null;
 };
-
-export const getCloudInitUserData = (vm: VMKind) =>
-  getVolumeCloudInitUserData(getCloudInitVolume(vm));
 
 export const hasAutoAttachPodInterface = (vm: VMKind, defaultValue = false) =>
   _.get(vm, 'spec.template.spec.domain.devices.autoattachPodInterface', defaultValue);

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/volume.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/volume.ts
@@ -4,7 +4,7 @@ export const getVolumePersistentVolumeClaimName = (volume) =>
   _.get(volume, 'persistentVolumeClaim.claimName');
 export const getVolumeDataVolumeName = (volume) => _.get(volume, 'dataVolume.name');
 
-export const getVolumeCloudInitUserData = (volume) => _.get(volume, 'cloudInitNoCloud.userData');
+export const getVolumeCloudInitNoCloud = (volume) => volume && volume.cloudInitNoCloud;
 
 export const getVolumeContainerImage = (volume) =>
   volume && volume.containerDisk && volume.containerDisk.image;


### PR DESCRIPTION
This PR Fixes two bugs:

1. Templates with cloud-init has a blank hostname : `${NAME}` instead of the cloud-init's hostname
2. VM's created from scratch with cloud-init OR template with cloud-init has the hostname set to the VM's name instead of the cloud-init's hostname

Kubevirt `createVM` method expects the hostname field to be inside the `settings` object, therefore we update the `vmSettings` from the cloud-init tab.