### PR TITLE
Improve Dockerfile Add Pipeline Missing Text

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
@@ -7,6 +7,10 @@ import { PipelineModel } from '../../../models';
 import { CheckboxField } from '../../formik-fields';
 import { PipelineVisualization } from '../../pipelines/PipelineVisualization';
 
+const MISSING_DOCKERFILE_LABEL_TEXT =
+  'The pipeline template for Dockerfiles is not available at this time.';
+const MISSING_RUNTIME_LABEL_TEXT = 'There are no pipeline templates available for this runtime.';
+
 const PipelineTemplate: React.FC = () => {
   const [noTemplateForRuntime, setNoTemplateForRuntime] = React.useState(false);
   const [isExpanded, setIsExpanded] = React.useState(false);
@@ -57,9 +61,7 @@ const PipelineTemplate: React.FC = () => {
       <Alert
         isInline
         variant="info"
-        title={`There are no pipeline templates available for ${
-          isDockerStrategy ? 'dockerfile strategy' : 'this runtime'
-        }.`}
+        title={isDockerStrategy ? MISSING_DOCKERFILE_LABEL_TEXT : MISSING_RUNTIME_LABEL_TEXT}
       />
     );
   }


### PR DESCRIPTION
Slight text change from #3364 
https://jira.coreos.com/browse/ODC-2277

Updating the text used when we are lacking the Dockerfile label (`pipeline.openshift.io/strategy: docker`) on a Pipeline in the `openshift` namespace.

![Screen Shot 2019-11-14 at 12 33 19 PM](https://user-images.githubusercontent.com/8126518/68881544-49900080-06db-11ea-910c-6a7d91e842e6.png)

FYI @beaumorley
FYI @openshift/team-devconsole-ux 