### PR TITLE
Bug 1772687: webpack: include contenthash in CSS filenames

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -19,7 +19,7 @@ const NODE_ENV = process.env.NODE_ENV;
 const HOT_RELOAD = process.env.HOT_RELOAD;
 
 /* Helpers */
-const extractCSS = new MiniCssExtractPlugin({ filename: 'app-bundle.css' });
+const extractCSS = new MiniCssExtractPlugin({ filename: 'app-bundle.[contenthash].css' });
 const overpassTest = /overpass-.*\.(woff2?|ttf|eot|otf)(\?.*$|$)/;
 
 const config: Configuration = {


### PR DESCRIPTION
This will bust the cache when our CSS changes.

![Dashboards · OKD 2019-11-14 14-56-26](https://user-images.githubusercontent.com/1167259/68891516-f4f68080-06ee-11ea-83d9-f8532abc36ca.png)

/assign @rhamilto 