### PR TITLE
update force layout data model when nodes change groups

### DIFF
--- a/frontend/packages/topology/src/Visualization.ts
+++ b/frontend/packages/topology/src/Visualization.ts
@@ -18,8 +18,6 @@ import {
   LayoutFactory,
   Layout,
   isGraph,
-  ADD_ELEMENT_EVENT,
-  REMOVE_ELEMENT_EVENT,
 } from './types';
 import defaultElementFactory from './elements/defaultElementFactory';
 import Stateful from './utils/Stateful';
@@ -42,19 +40,12 @@ export default class Visualization extends Stateful implements Controller {
   @observable.shallow
   private readonly store = {};
 
-  private batching = false;
-
-  private addedElements: GraphElement[] = [];
-
-  private removedElements: GraphElement[] = [];
-
   getStore<S = {}>(): S {
     return this.store as S;
   }
 
   @action
   fromModel(model: Model): void {
-    this.batching = true;
     // create elements
     if (model.graph) {
       this.graph = this.createElement<Graph>(ModelKind.graph, model.graph);
@@ -108,25 +99,6 @@ export default class Visualization extends Stateful implements Controller {
     if (this.graph) {
       this.parentOrphansToGraph(this.graph);
     }
-
-    this.batching = false;
-
-    // notify additions and removals
-    // capture batching data locally just incase we re-enter here
-    let removed: GraphElement[] | undefined;
-    let added: GraphElement[] | undefined;
-
-    if (this.removedElements.length) {
-      removed = this.removedElements;
-      this.removedElements = [];
-    }
-    if (this.addedElements.length) {
-      added = this.addedElements;
-      this.addedElements = [];
-    }
-
-    removed && this.fireEvent(REMOVE_ELEMENT_EVENT, removed);
-    added && this.fireEvent(ADD_ELEMENT_EVENT, added);
   }
 
   getGraph(): Graph {
@@ -158,12 +130,6 @@ export default class Visualization extends Stateful implements Controller {
     }
     element.setController(this);
     this.elements[element.getId()] = element;
-
-    if (this.batching) {
-      this.addedElements.push(element);
-    } else {
-      this.fireEvent(ADD_ELEMENT_EVENT, [element]);
-    }
   }
 
   removeElement(element: GraphElement): void {
@@ -176,12 +142,6 @@ export default class Visualization extends Stateful implements Controller {
         .forEach((child) => child.remove());
       element.setController(undefined);
       delete this.elements[element.getId()];
-
-      if (this.batching) {
-        this.removedElements.push(element);
-      } else {
-        this.fireEvent(REMOVE_ELEMENT_EVENT, [element]);
-      }
     }
   }
 

--- a/frontend/packages/topology/src/elements/BaseElement.ts
+++ b/frontend/packages/topology/src/elements/BaseElement.ts
@@ -1,6 +1,15 @@
 import { observable, computed } from 'mobx';
 import * as _ from 'lodash';
-import { ElementModel, Graph, GraphElement, isGraph, Controller, ModelKind } from '../types';
+import {
+  ElementModel,
+  Graph,
+  GraphElement,
+  isGraph,
+  Controller,
+  ModelKind,
+  ADD_CHILD_EVENT,
+  REMOVE_CHILD_EVENT,
+} from '../types';
 import Stateful from '../utils/Stateful';
 import { Translatable } from '../geom/types';
 
@@ -146,13 +155,14 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
       const idx = this.children.indexOf(child);
       if (idx !== -1) {
         this.children.splice(idx, 1);
+        this.children.splice(index, 0, child);
       } else {
         // remove from old parent
         child.remove();
         child.setParent(this);
-        child.setController(this.controller);
+        this.children.splice(index, 0, child);
+        this.getController().fireEvent(ADD_CHILD_EVENT, { target: this, child });
       }
-      this.children.splice(index, 0, child);
     }
   }
 
@@ -161,13 +171,14 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
       const idx = this.children.indexOf(child);
       if (idx !== -1) {
         this.children.splice(idx, 1);
+        this.children.push(child);
       } else {
         // remove from old parent
         child.remove();
         child.setParent(this);
-        child.setController(this.controller);
+        this.children.push(child);
+        this.getController().fireEvent(ADD_CHILD_EVENT, { target: this, child });
       }
-      this.children.push(child);
     }
   }
 
@@ -177,6 +188,7 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
       if (idx !== -1) {
         this.children.splice(idx, 1);
         child.setParent(undefined);
+        this.getController().fireEvent(REMOVE_CHILD_EVENT, { target: this, child });
       }
     }
   }

--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -205,8 +205,8 @@ export interface Controller extends WithState {
   getElements(): GraphElement[];
 }
 
-export type AddElementEventListener = EventListener<[GraphElement[]]>;
-export type RemoveElementEventListener = EventListener<[GraphElement[]]>;
+type ElementEvent = { target: GraphElement };
+export type ElementChildEventListener = EventListener<[ElementEvent & { child: GraphElement }]>;
 
-export const ADD_ELEMENT_EVENT = 'add-element';
-export const REMOVE_ELEMENT_EVENT = 'remove-element';
+export const ADD_CHILD_EVENT = 'element-add-child';
+export const REMOVE_CHILD_EVENT = 'element-remove-child';


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-2274

In a previous PR, events were added which track the addition and removal of nodes from the registry. While this worked, it failed to take into account the need to update the force layout when a node changes parents.

Removed the previously added events and replaced them with events which are fired whenever a node added or removed from the child list of a parent. The rest of the behavior is essentially the same. New nodes get an initial position defined by the layout before restarting while removed nodes simply update the layout data.

This gif shows that when a node is removed from it's group, the faux links between nodes in the layout are updated accordingly so that the node no longer follows nodes in the previous group.

![regroup-disconnect](https://user-images.githubusercontent.com/14068621/68895333-0c396c00-06f7-11ea-998d-130b3f0d84bd.gif)

/assign @jeff-phillips-18 