### PR TITLE
optimistically regroup nodes for smoother UI

### DIFF
--- a/frontend/packages/dev-console/src/components/topology2/componentUtils.ts
+++ b/frontend/packages/dev-console/src/components/topology2/componentUtils.ts
@@ -79,11 +79,11 @@ const nodeDragSourceSpec = (
       }
     : undefined,
   canCancel: (monitor) => monitor.getOperation() === REGROUP_OPERATION,
-  end: (dropResult, monitor, props) => {
+  end: async (dropResult, monitor, props) => {
     if (monitor.didDrop() && dropResult && props && props.element.getParent() !== dropResult) {
-      return moveNodeToGroup(props.element, isNode(dropResult) ? dropResult : null);
+      await moveNodeToGroup(props.element, isNode(dropResult) ? dropResult : null);
+      dropResult.appendChild(props.element);
     }
-    return undefined;
   },
   collect: (monitor) => ({
     dragging: monitor.isDragging(),


### PR DESCRIPTION
When we regroup nodes, the data would change and we'd wait for firehose to retrieve the new data before updating the topology data structure. This caused brief flashes of intermediate state where the node will have changed locations but the group had yet to be updated.

This change optimistically updates the UI knowing that the data operation had already succeeded. Now we no longer wait for a data round trip to the server and the user sees the regrouping results immediately.

before:
![beforeoopupdate](https://user-images.githubusercontent.com/14068621/68901116-51fc3180-0703-11ea-94db-3a438ec5e391.gif)


after:
![opupdate](https://user-images.githubusercontent.com/14068621/68901113-4f99d780-0703-11ea-9de7-8db313851a54.gif)

/assign @jeff-phillips-18 