### PR TITLE
Fixed loading in ceph utilization card

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utilization-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utilization-card.tsx
@@ -124,7 +124,7 @@ const UtilizationCard: React.FC<DashboardItemProps> = ({
             byteDataType={ByteDataTypes.BinaryBytes}
             query={UTILIZATION_QUERY[StorageDashboardQuery.CEPH_CAPACITY_USED]}
             error={capacityUtilizationError || totalCapacityError}
-            isLoading={!capacityUtilization || !totalCapacity}
+            isLoading={!capacityUtilization && !totalCapacity}
             max={maxCapacityStats}
             TopConsumerPopover={storagePopover}
           />


### PR DESCRIPTION
-Fixed persistent loading seen in Ceph utilization when empty data is received.
Before:
![Screenshot from 2019-11-15 15-16-27](https://user-images.githubusercontent.com/54092533/68933571-f1c8c680-07ba-11ea-8ce1-123831fd6ccc.png)
After:
![Screenshot from 2019-11-15 15-13-55](https://user-images.githubusercontent.com/54092533/68933577-f55c4d80-07ba-11ea-88dc-573e97aa3bdb.png)
