### PR TITLE
return node to previous location when regroup operation fails

### DIFF
--- a/frontend/packages/dev-console/src/components/topology2/componentUtils.ts
+++ b/frontend/packages/dev-console/src/components/topology2/componentUtils.ts
@@ -79,11 +79,11 @@ const nodeDragSourceSpec = (
       }
     : undefined,
   canCancel: (monitor) => monitor.getOperation() === REGROUP_OPERATION,
-  end: (dropResult, monitor, props) => {
+  end: async (dropResult, monitor, props) => {
     if (monitor.didDrop() && dropResult && props && props.element.getParent() !== dropResult) {
-      return moveNodeToGroup(props.element, isNode(dropResult) ? dropResult : null);
+      await moveNodeToGroup(props.element, isNode(dropResult) ? dropResult : null);
+      dropResult.appendChild(props.element);
     }
-    return undefined;
   },
   collect: (monitor) => ({
     dragging: monitor.isDragging(),

--- a/frontend/packages/dev-console/src/components/topology2/componentUtils.ts
+++ b/frontend/packages/dev-console/src/components/topology2/componentUtils.ts
@@ -80,10 +80,16 @@ const nodeDragSourceSpec = (
     : undefined,
   canCancel: (monitor) => monitor.getOperation() === REGROUP_OPERATION,
   end: async (dropResult, monitor, props) => {
-    if (monitor.didDrop() && dropResult && props && props.element.getParent() !== dropResult) {
-      await moveNodeToGroup(props.element, isNode(dropResult) ? dropResult : null);
-      dropResult.appendChild(props.element);
+    if (monitor.getOperation() === REGROUP_OPERATION) {
+      if (monitor.didDrop() && dropResult && props && props.element.getParent() !== dropResult) {
+        await moveNodeToGroup(props.element, isNode(dropResult) ? dropResult : null);
+        dropResult.appendChild(props.element);
+      } else {
+        // cancel operation
+        return Promise.reject();
+      }
     }
+    return undefined;
   },
   collect: (monitor) => ({
     dragging: monitor.isDragging(),


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-2296

Depends on: https://github.com/openshift/console/pull/3408

If the regroup operation fails, then we cancel the operation. By cancelling the operation, the node is returned to its previous location.

This gif shows first an attempt to ungroup a node that has no group by dropping it on a the surface outside of any group. The second attempt tries to drop the node within the group it already belongs to.

![regroupfail](https://user-images.githubusercontent.com/14068621/68967946-5b42d800-07af-11ea-8639-15452eb6ef1b.gif)

/assign @jeff-phillips-18 

fyi @serenamarie125 @openshift/team-devconsole-ux 