### PR TITLE
make traffic link a solid line

### DIFF
--- a/frontend/packages/dev-console/src/components/topology2/components/edges/TrafficLink.scss
+++ b/frontend/packages/dev-console/src/components/topology2/components/edges/TrafficLink.scss
@@ -3,9 +3,6 @@
   --edge--stroke: #bbbbbb;
   --edge--fill: #bbbbbb;
   --edge__link--stroke: #bbbbbb;
-  .odc2-base-edge__link {
-    stroke-dasharray: 5, 5;
-  }
 }
 
 .odc-traffic-link {


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-2297

Changes traffic link from dashed to solid line.

![image](https://user-images.githubusercontent.com/14068621/68969826-e32ae100-07b3-11ea-9c1f-85fd4ea6842a.png)

cc @serenamarie125 @openshift/team-devconsole-ux 