### PR TITLE
add tooltip to remove connection icon button

### DIFF
--- a/frontend/packages/topology/src/components/DefaultRemoveConnector.tsx
+++ b/frontend/packages/topology/src/components/DefaultRemoveConnector.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import Point from '../geom/Point';
 
@@ -9,29 +10,42 @@ type DefaultRemoveConnectorProps = {
   size?: number;
 };
 
+function computeTooltipPosition(startPoint: Point, endPoint: Point): TooltipPosition {
+  const angle = Math.abs(
+    (Math.atan2(endPoint.y - startPoint.y, endPoint.x - startPoint.x) * 180) / Math.PI,
+  );
+  return angle < 135 && angle > 90
+    ? TooltipPosition.left
+    : angle > 45 && angle <= 90
+    ? TooltipPosition.right
+    : TooltipPosition.top;
+}
+
 const DefaultRemoveConnector: React.FC<DefaultRemoveConnectorProps> = ({
   startPoint,
   endPoint,
   onRemove,
   size = 14,
 }) => (
-  <g
-    transform={`translate(${startPoint.x + (endPoint.x - startPoint.x) * 0.5}, ${startPoint.y +
-      (endPoint.y - startPoint.y) * 0.5})`}
-    onClick={(e) => {
-      e.stopPropagation();
-      onRemove();
-    }}
-  >
-    <circle className="topology-connector__remove-bg" cx={0} cy={0} r={size} />
-    <g transform={`translate(-${size / 2}, -${size / 2})`}>
-      <TrashIcon
-        className="topology-connector__remove-icon"
-        style={{ fontSize: size }}
-        alt="Remove Connection"
-      />
+  <Tooltip content="Delete Connector" position={computeTooltipPosition(startPoint, endPoint)}>
+    <g
+      transform={`translate(${startPoint.x + (endPoint.x - startPoint.x) * 0.5}, ${startPoint.y +
+        (endPoint.y - startPoint.y) * 0.5})`}
+      onClick={(e) => {
+        e.stopPropagation();
+        onRemove();
+      }}
+    >
+      <circle className="topology-connector__remove-bg" cx={0} cy={0} r={size} />
+      <g transform={`translate(-${size / 2}, -${size / 2})`}>
+        <TrashIcon
+          className="topology-connector__remove-icon"
+          style={{ fontSize: size }}
+          alt="Delete Connector"
+        />
+      </g>
     </g>
-  </g>
+  </Tooltip>
 );
 
 export default DefaultRemoveConnector;


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-2294

Adds a tooltip to the delete connector button on hover. Tooltip position is determined by the angle of the line.

![deletetooltip](https://user-images.githubusercontent.com/14068621/68974177-13777d00-07be-11ea-8caa-e16dddadcd05.gif)

/assign @jeff-phillips-18 

cc @serenamarie125 @openshift/team-devconsole-ux 