### PR TITLE
Bug 1769612: frontend: Add impersonate to Actions menu for users

### DIFF
--- a/frontend/public/components/user.tsx
+++ b/frontend/public/components/user.tsx
@@ -178,18 +178,32 @@ type UserTableRowProps = {
   style: any;
 };
 
-export const UserDetailsPage: React.FC<UserDetailsPageProps> = (props) => (
-  <DetailsPage
-    {...props}
-    kind={referenceForModel(UserModel)}
-    menuActions={Kebab.factory.common}
-    pages={[
-      navFactory.details(UserDetails),
-      navFactory.editYaml(),
-      navFactory.roles(RoleBindingsTab),
-    ]}
-  />
-);
+const UserDetailsPage_: React.FC<UserDetailsPageProps & UserKebabDispatchProps> = ({
+  startImpersonate,
+  ...props
+}) => {
+  const impersonateAction: KebabAction = (kind: K8sKind, obj: UserKind) => ({
+    label: `Impersonate User "${obj.metadata.name}"`,
+    callback: () => startImpersonate('User', obj.metadata.name),
+  });
+  return (
+    <DetailsPage
+      {...props}
+      kind={referenceForModel(UserModel)}
+      menuActions={[impersonateAction, ...Kebab.factory.common]}
+      pages={[
+        navFactory.details(UserDetails),
+        navFactory.editYaml(),
+        navFactory.roles(RoleBindingsTab),
+      ]}
+    />
+  );
+};
+
+export const UserDetailsPage = connect<{}, UserKebabDispatchProps, UserDetailsPageProps>(
+  null,
+  { startImpersonate: UIActions.startImpersonate },
+)(UserDetailsPage_);
 
 type UserPageProps = {
   autoFocus?: boolean;


### PR DESCRIPTION
Added impersonate to User detail actions menu.

<img width="1005" alt="Screen Shot 2019-11-15 at 3 56 52 PM" src="https://user-images.githubusercontent.com/7014965/68975181-90a3f180-07c0-11ea-875e-50e3a80697ce.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1769612.