### PR TITLE
tests: increase jasmine timeout

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -126,7 +126,7 @@ export const config: Config = {
   skipSourceMapSupport: true,
   jasmineNodeOpts: {
     print: () => null,
-    defaultTimeoutInterval: 40000,
+    defaultTimeoutInterval: 60000,
   },
   logLevel: tap ? 'ERROR' : 'INFO',
   plugins: process.env.NO_FAILFAST ? [] : [failFast.init()],

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
@@ -85,6 +85,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     await browser.wait(until.visibilityOf(operatorHubView.createSubscriptionFormInstallMode));
     await operatorHubView.ownNamespaceInstallMode.click();
     await browser.wait(until.visibilityOf(operatorHubView.installNamespaceDropdownBtn));
+    await browser.wait(crudView.untilNoLoadersPresent);
     await operatorHubView.installNamespaceDropdownBtn.click();
     await operatorHubView.installNamespaceDropdownFilter(testName);
     await operatorHubView.installNamespaceDropdownSelect(testName).click();


### PR DESCRIPTION
I believe this addresses the following OLM subscription form flake. The overall timeout for jasmine was too short, even though we increased the `browser.wait` timeout.

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_console/3418/pull-ci-openshift-console-master-e2e-gcp-console/3282

Additionally, wait until no loaders are present to fix this single install mode flake:

```
1) Interacting with a `OwnNamespace` install mode Operator (Prometheus) : selects target namespace for Operator subscription
   NoSuchElementError: No element found using locator: by.cssContainingText("a .co-resource-item__resource-name", "test-zlgd")
```