### PR TITLE
Remove the Knative headers from Search

### DIFF
--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionsPage.tsx
@@ -4,13 +4,9 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { RevisionModel } from '../../models';
 import RevisionList from './RevisionList';
 
-export interface RevisionsPageProps {
-  namespace: string;
-}
-
-const RevisionsPage: React.FC<RevisionsPageProps> = ({ namespace }) => (
+const RevisionsPage: React.FC<React.ComponentProps<typeof ListPage>> = (props) => (
   <ListPage
-    namespace={namespace}
+    {...props}
     canCreate={false}
     kind={referenceForModel(RevisionModel)}
     ListComponent={RevisionList}

--- a/frontend/packages/knative-plugin/src/components/routes/RoutesPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RoutesPage.tsx
@@ -5,13 +5,9 @@ import { getBadgeFromType } from '@console/shared';
 import { RouteModel } from '../../models';
 import RouteList from './RouteList';
 
-export interface RoutesPageProps {
-  namespace: string;
-}
-
-const RoutesPage: React.FC<RoutesPageProps> = ({ namespace }) => (
+const RoutesPage: React.FC<React.ComponentProps<typeof ListPage>> = (props) => (
   <ListPage
-    namespace={namespace}
+    {...props}
     canCreate={false}
     kind={referenceForModel(RouteModel)}
     ListComponent={RouteList}

--- a/frontend/packages/knative-plugin/src/components/services/ServicesPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServicesPage.tsx
@@ -9,9 +9,9 @@ export interface ServicesPageProps {
   namespace: string;
 }
 
-const ServicesPage: React.FC<ServicesPageProps> = ({ namespace }) => (
+const ServicesPage: React.FC<React.ComponentProps<typeof ListPage>> = (props) => (
   <ListPage
-    namespace={namespace}
+    {...props}
     canCreate
     kind={referenceForModel(ServiceModel)}
     ListComponent={ServiceList}


### PR DESCRIPTION
https://jira.coreos.com/browse/ODC-2299

Removes the Knative (Revisions, Routes, Services) List Page headers from the Search screen.

![Screen Shot 2019-11-15 at 6 11 09 PM](https://user-images.githubusercontent.com/8126518/68982046-7aebf780-07d3-11ea-90f3-95239e98df32.png)
![Screen Shot 2019-11-15 at 6 11 21 PM](https://user-images.githubusercontent.com/8126518/68982047-7aebf780-07d3-11ea-8155-cf894a2e67cf.png)
![Screen Shot 2019-11-15 at 6 11 39 PM](https://user-images.githubusercontent.com/8126518/68982048-7aebf780-07d3-11ea-924a-18b0a667adf8.png)
