### PR TITLE
fix(traffic-split): handle duplicate traffic assignment

### DIFF
--- a/frontend/packages/dev-console/src/components/formik-fields/DropdownField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/DropdownField.tsx
@@ -5,13 +5,38 @@ import { Dropdown } from '@console/internal/components/utils';
 import { FormGroup } from '@patternfly/react-core';
 import { DropdownFieldProps } from './field-types';
 import { getFieldId } from './field-utils';
+import './_dropdown-field.scss';
 
-const DropdownField: React.FC<DropdownFieldProps> = ({ label, helpText, required, ...props }) => {
+const DropdownField: React.FC<DropdownFieldProps> = ({
+  label,
+  helpText,
+  required,
+  consumedItems,
+  handleDuplicateEntry,
+  ...props
+}) => {
   const [field, { touched, error }] = useField(props.name);
   const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
   const fieldId = getFieldId(props.name, 'dropdown');
   const isValid = !(touched && error);
   const errorMessage = !isValid ? error : '';
+
+  const checkDuplicateItemEntry = (items, fieldReference): boolean => {
+    let occurence = 0;
+    if (items && items.length > 0) {
+      items.forEach((element) => {
+        if (element === fieldReference.value) {
+          occurence++;
+        }
+      });
+    }
+    return occurence > 1;
+  };
+  const isDuplicateEntry = checkDuplicateItemEntry(consumedItems, field);
+  if (handleDuplicateEntry) {
+    handleDuplicateEntry(isDuplicateEntry);
+  }
+
   return (
     <FormGroup
       fieldId={fieldId}
@@ -32,7 +57,9 @@ const DropdownField: React.FC<DropdownFieldProps> = ({ label, helpText, required
           setFieldValue(props.name, value);
           setFieldTouched(props.name, true);
         }}
+        isValid={!isDuplicateEntry}
       />
+      {isDuplicateEntry && <p className="odc-dropdown-field__inline-error">Duplicate detected.</p>}
     </FormGroup>
   );
 };

--- a/frontend/packages/dev-console/src/components/formik-fields/_dropdown-field.scss
+++ b/frontend/packages/dev-console/src/components/formik-fields/_dropdown-field.scss
@@ -1,0 +1,6 @@
+.odc-dropdown-field {
+  &__inline-error {
+    color: --pf-global--danger-color--100;
+    font-style: 'italic';
+  }
+}

--- a/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
@@ -33,11 +33,13 @@ export interface SearchInputFieldProps extends InputFieldProps {
 
 export interface DropdownFieldProps extends FieldProps {
   items?: object;
+  consumedItems?: string[];
   selectedKey?: string;
   title?: React.ReactNode;
   fullWidth?: boolean;
   disabled?: boolean;
   onChange?: (value: string) => void;
+  handleDuplicateEntry?: any;
 }
 
 export interface EnvironmentFieldProps extends FieldProps {
@@ -58,6 +60,7 @@ export interface MultiColumnFieldProps extends FieldProps {
   emptyValues: { [name: string]: string };
   headers: string[];
   children: React.ReactNode;
+  disableAddValues?: boolean;
 }
 
 export interface NameValuePair {

--- a/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
@@ -18,6 +18,7 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
   emptyValues,
   isReadOnly,
   toolTip,
+  disableAddValues,
 }) => (
   <FieldArray
     name={name}
@@ -44,7 +45,7 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
                 {children}
               </MultiColumnFieldRow>
             ))}
-          {!isReadOnly && (
+          {!isReadOnly && !disableAddValues && (
             <MultiColumnFieldFooter addLabel={addLabel} onAdd={() => push(emptyValues)} />
           )}
         </FormGroup>

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormikProps, FormikValues } from 'formik';
+import { FormikProps, FormikValues, useField } from 'formik';
 import {
   ModalTitle,
   ModalBody,
@@ -11,6 +11,7 @@ import {
   InputField,
   DropdownField,
 } from '@console/dev-console/src/components/formik-fields';
+import * as _ from 'lodash';
 
 export interface TrafficSplittingModalProps {
   revisionItems: any;
@@ -25,6 +26,21 @@ const TrafficSplittingModal: React.FC<Props> = ({
   isSubmitting,
   status,
 }) => {
+  const getConsumedRevisions = (fieldValue): any[] => {
+    return fieldValue.length
+      ? fieldValue.reduce((accumulator, currentValue) => {
+          accumulator.push(currentValue.revisionName);
+          return accumulator;
+        }, [])
+      : [];
+  };
+  const [disableSaveButton, toggleSaveButtonState] = React.useState(false);
+  const toggleSave = (toggle: boolean) => {
+    toggleSaveButtonState(toggle);
+  };
+  const [field] = useField('trafficSplitting');
+  const consumedRevisions = getConsumedRevisions(field.value);
+  const disableAddRevision = _.size(field.value) >= _.size(revisionItems);
   return (
     <form className="modal-content" onSubmit={handleSubmit}>
       <ModalTitle>Set Traffic Distribution</ModalTitle>
@@ -35,6 +51,7 @@ const TrafficSplittingModal: React.FC<Props> = ({
           addLabel="Add Revision"
           headers={['Split', 'Tag', 'Revision']}
           emptyValues={{ percent: '', tag: '', revisionName: '' }}
+          disableAddValues={disableAddRevision}
         >
           <InputField
             name="percent"
@@ -47,7 +64,9 @@ const TrafficSplittingModal: React.FC<Props> = ({
           <DropdownField
             name="revisionName"
             items={revisionItems}
+            consumedItems={consumedRevisions}
             title="Select a revision"
+            handleDuplicateEntry={toggleSave}
             fullWidth
             required
           />
@@ -58,6 +77,7 @@ const TrafficSplittingModal: React.FC<Props> = ({
         submitText="Save"
         cancel={handleReset}
         errorMessage={status.error}
+        submitDisabled={disableSaveButton}
       />
     </form>
   );

--- a/frontend/public/components/_dropdown.scss
+++ b/frontend/public/components/_dropdown.scss
@@ -255,3 +255,7 @@ $dropdown-background--hover: $color-pf-black-200; // pf-c-dropdown__menu-item--h
     text-overflow: ellipsis;
   }
 }
+
+button.dropdown__inline-error {
+  box-shadow: 0px 0.5px 2px 1px red;
+}

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -417,12 +417,14 @@ export class Dropdown extends DropdownMixin {
       titlePrefix,
       describedBy,
       disabled,
+      isValid,
     } = this.props;
 
     const spacerBefore = this.props.spacerBefore || new Set();
     const headerBefore = this.props.headerBefore || {};
     const rows = [];
     const bookMarkRows = [];
+    const inlineErrorClass = isValid ? '' : 'dropdown__inline-error';
 
     const addItem = (key, content) => {
       const selected = key === selectedKey && !this.props.noSelection;
@@ -561,7 +563,7 @@ export class Dropdown extends DropdownMixin {
           <button
             aria-haspopup="true"
             aria-expanded={this.state.active}
-            className={classNames('pf-c-dropdown__toggle', buttonClassName)}
+            className={classNames('pf-c-dropdown__toggle', buttonClassName, inlineErrorClass)}
             data-test-id="dropdown-button"
             onClick={this.toggle}
             onKeyDown={this.onKeyDown}


### PR DESCRIPTION
This PR -
* handles multiple traffic assignment to the same revision
* restricts addition of rows greater than the number of revisions by disabling the `Add Revisions`  button
* adds functionality to dropdown component to handle inline errors
* fixes jira issue https://jira.coreos.com/browse/ODC-2164

Screens-
![traffic-modal](https://user-images.githubusercontent.com/38663217/68986080-e4a2ea80-0841-11ea-889d-c3cc9e6e7baa.gif)
