### PR TITLE
adjust z-index of popper to prevent overlap

### DIFF
--- a/frontend/packages/console-shared/src/components/popper/Popper.tsx
+++ b/frontend/packages/console-shared/src/components/popper/Popper.tsx
@@ -69,6 +69,7 @@ type PopperProps = {
   popperOptions?: PopperOptions;
   popperRef?: React.Ref<PopperJS>;
   reference: Reference | (() => Reference);
+  zIndex?: number;
 };
 
 const DEFAULT_POPPER_OPTIONS: PopperOptions = {};
@@ -85,6 +86,7 @@ const Popper: React.FC<PopperProps> = ({
   closeOnOutsideClick,
   onRequestClose,
   popperRef: popperRefIn,
+  zIndex = 9999,
 }) => {
   const controlled = typeof open === 'boolean';
   const openProp = controlled ? open : true;
@@ -194,7 +196,7 @@ const Popper: React.FC<PopperProps> = ({
 
   return isOpen ? (
     <Portal container={container}>
-      <div ref={nodeRefCallback} className={className}>
+      <div ref={nodeRefCallback} className={className} style={{ zIndex }}>
         {children}
       </div>
     </Portal>


### PR DESCRIPTION
Popper was introduced as part https://github.com/openshift/console/pull/3370.

Although the popper `div` is appended to the `body`, it doesn't include a `z-index` by default. This can lead to the kebab menu appearing below other elements with a z-index. As shown here:

![image](https://user-images.githubusercontent.com/14068621/68986792-248db180-07f1-11ea-9a93-cc8b225f5072.png)

This change introduces a default `z-index: 9999`. This is the same default used patternfly's popover component.

cc @spadgett @suomiy