### PR TITLE
VM Overview - set boot order

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/add-device-button.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/add-device-button.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Button, Text, TextVariants } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+
+export const AddDeviceButton: React.FC<AddDeviceButtonType> = ({
+  id,
+  message,
+  disabledMessage,
+  isDisabled,
+  onClick,
+}) =>
+  isDisabled ? (
+    <Text component={TextVariants.p}>{disabledMessage}</Text>
+  ) : (
+    <Button
+      className="pf-m-link--align-left"
+      id={id}
+      variant="link"
+      onClick={onClick}
+      icon={<PlusCircleIcon />}
+    >
+      {message}
+    </Button>
+  );
+
+export type AddDeviceButtonType = {
+  id: string;
+  message: string;
+  disabledMessage: string;
+  isDisabled: boolean;
+  onClick: () => void;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/add-device-form-select.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/add-device-form-select.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { FormSelect, FormSelectOption, Button } from '@patternfly/react-core';
+import { MinusCircleIcon } from '@patternfly/react-icons';
+import { BootableDeviceType } from '../../types';
+import { deviceKey, deviceLabel } from './constants';
+
+export const AddDeviceFormSelect: React.FC<AddDeviceFormSelectProps> = ({
+  id,
+  options,
+  label,
+  onAdd,
+  onDelete,
+}) => (
+  <>
+    <FormSelect
+      value=""
+      id={id}
+      onChange={onAdd}
+      className="kubevirt-boot-order__add-device-select"
+    >
+      <FormSelectOption label={label} value="" />
+      {_.orderBy(options, ['type', 'value.name']).map((option) => (
+        <FormSelectOption
+          label={deviceLabel(option)}
+          value={deviceKey(option)}
+          key={deviceKey(option)}
+        />
+      ))}
+    </FormSelect>
+    <Button
+      onClick={onDelete}
+      variant="link"
+      className="kubevirt-boot-order__add-device-delete-btn"
+    >
+      <MinusCircleIcon />
+    </Button>
+  </>
+);
+
+export type AddDeviceFormSelectProps = {
+  id: string;
+  options: BootableDeviceType[];
+  label: string;
+  onDelete: () => void;
+  /** onAdd moves items from the options list to the sources list, key = "<type>-<name>". */
+  onAdd: (key: string) => void;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/add-device.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/add-device.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { BootableDeviceType } from '../../types';
+import { AddDeviceButton } from './add-device-button';
+import { AddDeviceFormSelect } from './add-device-form-select';
+import { addItemMessage, addItemDisabledMessage, addItemSelectLabel } from './constants';
+
+export const AddDevice = ({ devices, onAdd, isEditMode, setEditMode }: AddDeviceProps) => {
+  const options = devices.filter((device) => !device.value.bootOrder);
+
+  const canAddItem = options.length > 0;
+  const selectID = 'add-device-select';
+  const buttontID = 'add-device-btm';
+
+  return (
+    <div className="kubevirt-boot-order__add-device">
+      {isEditMode && canAddItem ? (
+        <AddDeviceFormSelect
+          id={selectID}
+          options={options}
+          label={addItemSelectLabel}
+          onAdd={onAdd}
+          onDelete={() => setEditMode(false)}
+        />
+      ) : (
+        <AddDeviceButton
+          id={buttontID}
+          message={addItemMessage}
+          disabledMessage={addItemDisabledMessage}
+          isDisabled={!canAddItem}
+          onClick={() => setEditMode(true)}
+        />
+      )}
+    </div>
+  );
+};
+
+export type AddDeviceProps = {
+  devices: BootableDeviceType[];
+  isEditMode: boolean;
+  /** onAdd moves items from the options list to the sources list, key = "<type>-<name>". */
+  onAdd: (key: string) => void;
+  setEditMode: (boolean) => void;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order-empty.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order-empty.tsx
@@ -23,7 +23,11 @@ export const BootOrderEmpty: React.FC<BootOrderEmptyProps> = ({
     </Title>
     <EmptyStateBody>{message}</EmptyStateBody>
     {!addItemIsDisabled ? (
-      <Button variant="secondary" onClick={onClick}>
+      <Button
+        variant="secondary"
+        onClick={onClick}
+        className="kubevirt-boot-order__boot-order-empty-btn"
+      >
         {addItemMessage}
       </Button>
     ) : (

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order-empty.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order-empty.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Title,
+  Alert,
+} from '@patternfly/react-core';
+
+// Display and empty with a Call to add new source if no sources are defined.
+export const BootOrderEmpty: React.FC<BootOrderEmptyProps> = ({
+  title,
+  message,
+  addItemMessage,
+  addItemIsDisabled,
+  addItemDisabledMessage,
+  onClick,
+}) => (
+  <EmptyState variant={EmptyStateVariant.full}>
+    <Title headingLevel="h5" size="lg">
+      {title}
+    </Title>
+    <EmptyStateBody>{message}</EmptyStateBody>
+    {!addItemIsDisabled ? (
+      <Button variant="primary" onClick={onClick}>
+        {addItemMessage}
+      </Button>
+    ) : (
+      <Alert variant="info" title={addItemDisabledMessage} />
+    )}
+  </EmptyState>
+);
+
+export type BootOrderEmptyProps = {
+  title: string;
+  message: string;
+  addItemMessage: string;
+  addItemIsDisabled: boolean;
+  addItemDisabledMessage?: string;
+  onClick: () => void;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order-empty.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order-empty.tsx
@@ -23,7 +23,7 @@ export const BootOrderEmpty: React.FC<BootOrderEmptyProps> = ({
     </Title>
     <EmptyStateBody>{message}</EmptyStateBody>
     {!addItemIsDisabled ? (
-      <Button variant="primary" onClick={onClick}>
+      <Button variant="secondary" onClick={onClick}>
         {addItemMessage}
       </Button>
     ) : (

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order-summary.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order-summary.scss
@@ -1,7 +1,0 @@
-.kubevirt-boot-order-summary__expandable.pf-c-expandable .pf-c-expandable__content {
-  margin-top: 0;
-}
-
-.kubevirt-boot-order-summary__empty-text {
-  margin-bottom: 0;
-}

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order.scss
@@ -1,0 +1,23 @@
+.kubevirt-boot-order-summary__expandable.pf-c-expandable .pf-c-expandable__content {
+  margin-top: 0;
+}
+
+.kubevirt-boot-order-summary__empty-text {
+  margin-bottom: 0;
+}
+
+.kubevirt-boot-order__add-device-delete-btn {
+  padding: 0;
+}
+
+.kubevirt-boot-order__add-device-select {
+  margin-left: var(--pf-global--spacer--lg);
+  margin-right: var(--pf-global--spacer--lg);
+}
+
+.kubevirt-boot-order__add-device {
+  display: flex;
+  padding-top: var(--pf-global--spacer--md);
+  padding-left: var(--pf-global--spacer--lg);
+  padding-right: var(--pf-global--spacer--lg);
+}

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order.scss
@@ -6,8 +6,13 @@
   margin-bottom: 0;
 }
 
-.kubevirt-boot-order__add-device-delete-btn {
+.kubevirt-boot-order__boot-order-empty-btn {
+  margin-top: var(--pf-global--spacer--md);
+}
+
+.pf-c-button.pf-m-link.kubevirt-boot-order__add-device-delete-btn {
   padding: 0;
+  color: var(--pf-global--Color--100);
 }
 
 .kubevirt-boot-order__add-device-select {

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Text, TextVariants } from '@patternfly/react-core';
+import { DNDDataList, DNDDataListItem } from '../dnd-list';
+import { BootableDeviceType } from '../../types';
+import { BootOrderEmpty } from './boot-order-empty';
+import { AddDevice } from './add-device';
+import {
+  addItemMessage,
+  addItemDisabledMessage,
+  bootOrderEmptyMessage,
+  bootOrderEmptyTitle,
+  deviceKey,
+  deviceLabel,
+  bootOrderAriaLabel,
+} from './constants';
+
+import './boot-order.scss';
+
+export const BootOrder = ({ devices, setDevices }: BootOrderProps) => {
+  const sources = _.sortBy(devices.filter((device) => device.value.bootOrder), 'value.bootOrder');
+  const options = devices.filter((device) => !device.value.bootOrder);
+  const [isEditMode, setEditMode] = React.useState<boolean>(false);
+
+  // Relax bootOrder and use setDevice to update the parent componenet.
+  const updateDevices = (newDevices: BootableDeviceType[]): void => {
+    _.filter(newDevices, (device) => device.value.bootOrder).forEach((source, i) => {
+      source.value.bootOrder = i + 1;
+    });
+
+    setDevices(newDevices);
+    setEditMode(false);
+  };
+
+  // Remove a bootOrder from a device by index.
+  const onDelete = (index: number) => {
+    const newDevices = _.cloneDeep(devices);
+
+    const key = deviceKey(sources[index]);
+    delete newDevices.find((device) => deviceKey(device) === key).value.bootOrder;
+
+    updateDevices(newDevices);
+  };
+
+  // Move a source from one index to another.
+  const onMove = (index: number, toIndex: number) => {
+    const unMovedSources = [...sources.slice(0, index), ...sources.slice(index + 1)];
+
+    // Create an ordered copy of the sources.
+    const newSources = _.cloneDeep([
+      ...unMovedSources.slice(0, toIndex),
+      sources[index],
+      ...unMovedSources.slice(toIndex),
+    ]);
+
+    updateDevices([...newSources, ...options]);
+  };
+
+  // Add a bootOrder to a device by key, item key is "<type>->name>".
+  const onAdd = (key: string): void => {
+    const newOptions = _.cloneDeep(options);
+    newOptions.find((option) => deviceKey(option) === key).value.bootOrder = sources.length + 1;
+
+    updateDevices([...sources, ...newOptions]);
+  };
+
+  const showEmpty = sources.length === 0 && !isEditMode;
+  const dataListID = 'VMBootOrderList';
+
+  return (
+    <>
+      {showEmpty ? (
+        <BootOrderEmpty
+          title={bootOrderEmptyTitle}
+          message={bootOrderEmptyMessage}
+          addItemMessage={addItemMessage}
+          addItemDisabledMessage={addItemDisabledMessage}
+          addItemIsDisabled={options.length === 0}
+          onClick={() => {
+            setEditMode(true);
+          }}
+        />
+      ) : (
+        <>
+          <DNDDataList id={dataListID} aria-label={bootOrderAriaLabel}>
+            {sources.map((source, index) => (
+              <DNDDataListItem
+                index={index}
+                onDelete={onDelete}
+                onMove={onMove}
+                aria-labelledby={`device-${deviceKey(source)}`}
+                key={`device-${deviceKey(source)}`}
+              >
+                <Text id={`device-${deviceKey(source)}`} component={TextVariants.p}>
+                  {deviceLabel(source)}
+                </Text>
+              </DNDDataListItem>
+            ))}
+          </DNDDataList>
+          <AddDevice
+            devices={devices}
+            onAdd={onAdd}
+            isEditMode={isEditMode}
+            setEditMode={setEditMode}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+export type BootOrderProps = {
+  devices: BootableDeviceType[];
+  setDevices: (devices: BootableDeviceType[]) => void;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/constants.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/constants.tsx
@@ -1,6 +1,13 @@
+import { BootableDeviceType } from '../../types';
+
+export const addItemMessage = 'Add source';
+export const addItemDisabledMessage = 'All sources selected';
+export const addItemSelectLabel = 'Please select a boot source';
 export const bootOrderEmptyTitle = 'No resource selected';
 export const bootOrderEmptyMessage =
   'VM will attempt to boot from disks by order of apearance in YAML file';
+export const bootOrderAriaLabel = 'VM Boot Order List';
 
-export const deviceKey = (device) => `${device.type}-${device.value.name}`;
-export const deviceLabel = (device) => `${device.value.name} (${device.typeLabel})`;
+export const deviceKey = (device: BootableDeviceType) => `${device.type}-${device.value.name}`;
+export const deviceLabel = (device: BootableDeviceType) =>
+  `${device.value.name} (${device.typeLabel})`;

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/index.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/index.tsx
@@ -1,1 +1,2 @@
-export * from './boot-order-summary';
+export * from './boot-order';
+export * from './summary/boot-order-summary';

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/index.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/index.tsx
@@ -1,2 +1,3 @@
+export { deviceKey, deviceLabel } from './constants';
 export * from './boot-order';
 export * from './summary/boot-order-summary';

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/summary/boot-order-empty-summary.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/summary/boot-order-empty-summary.tsx
@@ -1,17 +1,11 @@
 import * as React from 'react';
 import { Expandable, Text, TextVariants } from '@patternfly/react-core';
-import { BootableDeviceType } from '../../types';
-import { deviceLabel, deviceKey, bootOrderEmptyTitle, bootOrderEmptyMessage } from './constants';
+import { BootableDeviceType } from '../../../types';
+import { deviceLabel, deviceKey, bootOrderEmptyTitle, bootOrderEmptyMessage } from '../constants';
 
-import './boot-order-summary.scss';
-
-export const BootOrderSummaryEmptyState: React.FC<BootOrderSummaryEmptyStateProps> = ({
-  devices,
-}) => {
+export const BootOrderEmptySummary: React.FC<BootOrderEmptySummaryProps> = ({ devices }) => {
   const [isExpanded, setIsExpanded] = React.useState<boolean>(false);
-
   const options = devices.filter((device) => !device.value.bootOrder);
-
   const onToggle = React.useCallback(() => setIsExpanded(!isExpanded), [isExpanded]);
 
   // Note(Yaacov):
@@ -43,6 +37,6 @@ export const BootOrderSummaryEmptyState: React.FC<BootOrderSummaryEmptyStateProp
   );
 };
 
-export type BootOrderSummaryEmptyStateProps = {
+export type BootOrderEmptySummaryProps = {
   devices: BootableDeviceType[];
 };

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/summary/boot-order-summary.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/summary/boot-order-summary.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { BootableDeviceType } from '../../types';
-import { deviceLabel, deviceKey } from './constants';
-import { BootOrderSummaryEmptyState } from './boot-order-summary-empty-state';
+import { BootableDeviceType } from '../../../types';
+import { deviceLabel, deviceKey } from '../constants';
+import { BootOrderEmptySummary } from './boot-order-empty-summary';
 
 // NOTE(yaacov): using <ol> because '@patternfly/react-core' <List> currently miss isOrder parameter.
 export const BootOrderSummary: React.FC<BootOrderSummaryProps> = ({ devices }) => {
@@ -11,7 +11,7 @@ export const BootOrderSummary: React.FC<BootOrderSummaryProps> = ({ devices }) =
   return (
     <>
       {sources.length === 0 ? (
-        <BootOrderSummaryEmptyState devices={devices} />
+        <BootOrderEmptySummary devices={devices} />
       ) : (
         <ol>
           {sources.map((source) => (

--- a/frontend/packages/kubevirt-plugin/src/components/dnd-list/dnd-data-list-item.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dnd-list/dnd-data-list-item.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { MinusCircleIcon, PficonDragdropIcon } from '@patternfly/react-icons';
+import {
+  DataListItem,
+  DataListItemRow,
+  DataListItemCells,
+  DataListCell,
+  DataListItemProps,
+} from '@patternfly/react-core';
+import { useDrag, useDrop } from 'react-dnd';
+
+const DNDDataListItemTypeName = 'dnd-row';
+const DNDDataListCellMoveStyle = { cursor: 'move' };
+const DNDDataListCellSDeleteStyle = { cursor: 'pointer' };
+
+export interface DNDDataListItemProps extends DataListItemProps {
+  /** Order index of rendered item. */
+  index: number;
+  /** Action when delete icon is pressed. */
+  onDelete: (index: number) => void;
+  /** Action when item is moved from one order index to anoter. */
+  onMove: (index: number, toIndex: number) => void;
+}
+
+export const DNDDataListItem: React.FC<DNDDataListItemProps> = ({
+  index,
+  onDelete,
+  onMove,
+  'aria-labelledby': ariaLabelledby,
+  children,
+  ...props
+}) => {
+  // Create a drag item copy.
+  const [, drag, preview] = useDrag({
+    item: { type: DNDDataListItemTypeName, id: `${DNDDataListItemTypeName}-${index}`, index },
+  });
+  // Move item when hover over onoter item.
+  const [{ opacity }, drop] = useDrop({
+    accept: DNDDataListItemTypeName,
+    collect: (monitor) => ({
+      opacity: monitor.isOver() ? 0 : 1,
+    }),
+    hover(item: any) {
+      if (item.index === index) {
+        return;
+      }
+
+      onMove(item.index, index);
+      item.index = index;
+    },
+  });
+
+  // Action when item is focused and key is pressed:
+  // ArrowUp:   move item one order index down.
+  // ArrowDown: move item one order index up.
+  // '-':       delete an item.
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowUp':
+        if (index > 0) onMove(index, index - 1);
+        break;
+      case 'ArrowDown':
+        onMove(index, index + 1);
+        break;
+      case '-':
+        onDelete(index);
+        break;
+      default:
+      // We only accept up, down and minus.
+    }
+  };
+
+  const cellKey = (i: number | string) => `item-${i}`;
+  const dataListCell = [
+    <DataListCell isFilled={false} key={cellKey('drag')}>
+      <div ref={drag} style={DNDDataListCellMoveStyle}>
+        <PficonDragdropIcon />
+      </div>
+    </DataListCell>,
+    ...React.Children.map(children, (cell, i) => (
+      <DataListCell width={1} key={cellKey(i)}>
+        {cell}
+      </DataListCell>
+    )),
+    <DataListCell
+      isFilled={false}
+      alignRight
+      key={cellKey('delete')}
+      style={DNDDataListCellSDeleteStyle}
+      onClick={() => onDelete(index)}
+    >
+      <MinusCircleIcon />
+    </DataListCell>,
+  ];
+
+  return (
+    <div ref={(node) => preview(drop(node))} style={{ opacity }}>
+      <DataListItem tabIndex={0} aria-labelledby={ariaLabelledby} onKeyDown={onKeyDown} {...props}>
+        <DataListItemRow>
+          <DataListItemCells dataListCells={dataListCell} />
+        </DataListItemRow>
+      </DataListItem>
+    </div>
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/components/dnd-list/dnd-data-list.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dnd-list/dnd-data-list.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { DataList, DataListProps } from '@patternfly/react-core';
+import { DndProvider } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+
+export const DNDDataList: React.FC<DNDDataListProps> = ({ children, ...props }) => (
+  <DndProvider backend={HTML5Backend}>
+    <DataList {...props}>{children}</DataList>
+  </DndProvider>
+);
+
+export type DNDDataListProps = DataListProps;

--- a/frontend/packages/kubevirt-plugin/src/components/dnd-list/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/dnd-list/index.ts
@@ -1,0 +1,2 @@
+export * from './dnd-data-list';
+export * from './dnd-data-list-item';

--- a/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
@@ -42,7 +42,9 @@ const BootOrderModalComponent = ({
 
   // Inform user on vmLikeEntity.
   React.useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      return;
+    }
 
     // Compare only bootOrder from initialDeviceList to current device list.
     const devicesMap = createBasicLookup(getDevices(vmLikeEntity), deviceKey);

--- a/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Modal, Button, ButtonVariant } from '@patternfly/react-core';
+import { createBasicLookup } from '@console/shared/src';
+import { withHandlePromise, HandlePromiseProps } from '@console/internal/components/utils';
+import { ModalComponentProps } from '@console/internal/components/factory';
+import { k8sPatch } from '@console/internal/module/k8s';
+import { VMLikeEntityKind, BootableDeviceType } from '../../../types';
+import { getVMLikeModel, getDevices } from '../../../selectors/vm';
+import { PatchBuilder, PatchOperation } from '../../../k8s/utils/patch';
+import { getVMLikePatches } from '../../../k8s/patches/vm-template';
+import { BootOrder } from '../../boot-order';
+import { DeviceType } from '../../../constants';
+import { ModalFooter } from '../modal/modal-footer';
+
+const modalTitle = 'Virtual machine boot order';
+
+const BootOrderModalComponent = ({
+  vmLikeEntity,
+  isOpen,
+  setOpen,
+  title = modalTitle,
+  handlePromise,
+  inProgress,
+  errorMessage,
+}: BootOrderModalProps) => {
+  const [devices, setDevices] = React.useState<BootableDeviceType[]>(getDevices(vmLikeEntity));
+  const [initialDeviceList, setInitialDeviceList] = React.useState<BootableDeviceType[]>(
+    getDevices(vmLikeEntity),
+  );
+  const [showUpdatedAlert, setUpdatedAlert] = React.useState<boolean>(false);
+  const [showPatchError, setPatchError] = React.useState<boolean>(false);
+
+  const onReload = React.useCallback(() => {
+    const updatedDevices = getDevices(vmLikeEntity);
+
+    setInitialDeviceList(updatedDevices);
+    setDevices(updatedDevices);
+    setUpdatedAlert(false);
+    setPatchError(false);
+  }, [vmLikeEntity]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Inform user on vmLikeEntity.
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    // Compare only bootOrder from initialDeviceList to current device list.
+    const devicesMap = createBasicLookup(
+      getDevices(vmLikeEntity),
+      (d) => `${d.type}/${d.value.name}`,
+    );
+    const updated = initialDeviceList.some((d) => {
+      // Find the initial device in the updated list.
+      const device = devicesMap[`${d.type}/${d.value.name}`];
+
+      // If a device bootOrder changed, or it was deleted, set alert.
+      return !device || device.value.bootOrder !== d.value.bootOrder;
+    });
+
+    setUpdatedAlert(updated);
+  }, [vmLikeEntity]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-set device list on isOpen change to true.
+  React.useEffect(() => {
+    if (isOpen) {
+      onReload();
+    }
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Send new bootOrder to k8s.
+  const onSubmit = async (event) => {
+    event.preventDefault();
+
+    // Copy only bootOrder from devices to current device list.
+    const currentDevices = _.cloneDeep(getDevices(vmLikeEntity));
+    const devicesMap = createBasicLookup(currentDevices, (d) => `${d.type}/${d.value.name}`);
+    devices.forEach((d) => {
+      // Find the device to update.
+      const device = devicesMap[`${d.type}/${d.value.name}`];
+
+      // Update device bootOrder.
+      if (device && d.value.bootOrder) {
+        device.value.bootOrder = d.value.bootOrder;
+      }
+      if (device && device.value.bootOrder && !d.value.bootOrder) {
+        delete device.value.bootOrder;
+      }
+    });
+
+    // Filter disks and interfaces from devices list.
+    const disks = [
+      ...currentDevices
+        .filter((source) => source.type === DeviceType.DISK)
+        .map((source) => source.value),
+    ];
+    const interfaces = [
+      ...currentDevices
+        .filter((source) => source.type === DeviceType.NIC)
+        .map((source) => source.value),
+    ];
+
+    // Patch k8s.
+    const patches = [
+      new PatchBuilder('/spec/template/spec/domain/devices/disks')
+        .setOperation(PatchOperation.REPLACE)
+        .setValue(disks)
+        .build(),
+      new PatchBuilder('/spec/template/spec/domain/devices/interfaces')
+        .setOperation(PatchOperation.REPLACE)
+        .setValue(interfaces)
+        .build(),
+    ];
+    const promise = k8sPatch(
+      getVMLikeModel(vmLikeEntity),
+      vmLikeEntity,
+      getVMLikePatches(vmLikeEntity, () => patches),
+    );
+
+    handlePromise(promise)
+      .then(() => setOpen(false))
+      .catch(() => setPatchError(true));
+  };
+
+  const footer = (
+    <ModalFooter
+      errorMessage={showPatchError && errorMessage}
+      inProgress={inProgress}
+      onSubmit={onSubmit}
+      onCancel={() => setOpen(false)}
+      submitButtonText="Save"
+      infoTitle={showUpdatedAlert && 'Boot order has been updated outside this flow.'}
+      infoMessage={
+        <>
+          Saving these changes will override any boot order previously saved.
+          <br />
+          To see the updated order{' '}
+          <Button variant={ButtonVariant.link} isInline onClick={onReload}>
+            reload the content
+          </Button>
+          .
+        </>
+      }
+    />
+  );
+
+  return (
+    <Modal
+      title={title}
+      isOpen={isOpen}
+      isSmall
+      onClose={() => setOpen(false)}
+      footer={footer}
+      isFooterLeftAligned
+    >
+      <BootOrder devices={devices} setDevices={setDevices} />
+    </Modal>
+  );
+};
+
+export type BootOrderModalProps = HandlePromiseProps &
+  ModalComponentProps & {
+    vmLikeEntity: VMLikeEntityKind;
+    title?: string;
+    isOpen: boolean;
+    setOpen: (isOpen: boolean) => void;
+  };
+
+export const BootOrderModal = withHandlePromise(BootOrderModalComponent);

--- a/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/index.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/index.tsx
@@ -1,0 +1,1 @@
+export * from './boot-order-modal';

--- a/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
@@ -28,6 +28,17 @@ export const ModalSimpleErrorMessage: React.FC<ModalSimpleErrorMessageProps> = (
   <Alert isInline className="co-alert" variant="danger" title={message} />
 );
 
+type ModalInfoMessageProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+export const ModalInfoMessage: React.FC<ModalInfoMessageProps> = ({ title, children }) => (
+  <Alert isInline className="co-alert co-alert--scrollable" variant="info" title={title}>
+    {children}
+  </Alert>
+);
+
 type ModalFooterProps = {
   id?: string;
   errorMessage?: string;
@@ -38,6 +49,8 @@ type ModalFooterProps = {
   inProgress?: boolean;
   submitButtonText?: string;
   cancelButtonText?: string;
+  infoTitle?: string;
+  infoMessage?: React.ReactNode;
 };
 
 export const ModalFooter: React.FC<ModalFooterProps> = ({
@@ -50,10 +63,13 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
   onCancel,
   submitButtonText = 'Add',
   cancelButtonText = 'Cancel',
+  infoMessage = null,
+  infoTitle = null,
 }) => (
   <footer className="co-m-btn-bar modal-footer kubevirt-create-nic-modal__buttons">
     {errorMessage && isSimpleError && <ModalSimpleErrorMessage message={errorMessage} />}
     {errorMessage && !isSimpleError && <ModalErrorMessage message={errorMessage} />}
+    {infoTitle && <ModalInfoMessage title={infoTitle}>{infoMessage}</ModalInfoMessage>}
     <Button
       variant={ButtonVariant.primary}
       onClick={onSubmit}

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -4,6 +4,7 @@ import { TemplateKind } from '@console/internal/module/k8s';
 import { K8sEntityMap } from '@console/shared/src';
 import { getBasicID, prefixedID } from '../../utils';
 import { vmDescriptionModal } from '../modals/vm-description-modal';
+import { BootOrderModal } from '../modals/boot-order-modal';
 import { VMCDRomModal } from '../modals/cdrom-vm-modal';
 import { getDescription } from '../../selectors/selectors';
 import {
@@ -34,7 +35,7 @@ export const VMTemplateResourceSummary: React.FC<VMTemplateResourceSummaryProps>
   const templateNamespacedName = getVMTemplateNamespacedName(template);
 
   const description = getDescription(template);
-  const os = getOperatingSystemName(template) || getOperatingSystem(template);
+  const os = getOperatingSystemName(asVM(template)) || getOperatingSystem(asVM(template));
   const workloadProfile = getWorkloadProfile(template);
 
   return (
@@ -81,6 +82,8 @@ export const VMTemplateDetailsList: React.FC<VMTemplateResourceListProps> = ({
   dataVolumeLookup,
   canUpdateTemplate,
 }) => {
+  const [isBootOrderModalOpen, setBootOrderModalOpen] = React.useState<boolean>(false);
+
   const id = getBasicID(template);
   const devices = getDevices(template);
   const cds = getCDRoms(asVM(template));
@@ -88,7 +91,18 @@ export const VMTemplateDetailsList: React.FC<VMTemplateResourceListProps> = ({
 
   return (
     <dl className="co-m-pane__details">
-      <VMDetailsItem title="Boot Order" idValue={prefixedID(id, 'boot-order')}>
+      <VMDetailsItem
+        title="Boot Order"
+        canEdit
+        editButtonId={prefixedID(id, 'boot-order-edit')}
+        onEditClick={() => setBootOrderModalOpen(true)}
+        idValue={prefixedID(id, 'boot-order')}
+      >
+        <BootOrderModal
+          isOpen={isBootOrderModalOpen}
+          setOpen={setBootOrderModalOpen}
+          vmLikeEntity={template}
+        />
         <BootOrderSummary devices={devices} />
       </VMDetailsItem>
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -8,6 +8,7 @@ import { VMTemplateLink } from '../vm-templates/vm-template-link';
 import { getBasicID, prefixedID } from '../../utils';
 import { vmDescriptionModal, vmFlavorModal } from '../modals';
 import { VMCDRomModal } from '../modals/cdrom-vm-modal';
+import { BootOrderModal } from '../modals/boot-order-modal/boot-order-modal';
 import { getDescription } from '../../selectors/selectors';
 import { getCDRoms } from '../../selectors/vm/selectors';
 import { getVMTemplateNamespacedName } from '../../selectors/vm-template/selectors';
@@ -91,6 +92,8 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
   migrations,
   canUpdateVM,
 }) => {
+  const [isBootOrderModalOpen, setBootOrderModalOpen] = React.useState<boolean>(false);
+
   const id = getBasicID(vm);
   const vmStatus = getVMStatus({ vm, vmi, pods, migrations });
   const { launcherPod } = vmStatus;
@@ -117,7 +120,18 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
         )}
       </VMDetailsItem>
 
-      <VMDetailsItem title="Boot Order" idValue={prefixedID(id, 'boot-order')}>
+      <VMDetailsItem
+        title="Boot Order"
+        canEdit
+        editButtonId={prefixedID(id, 'boot-order-edit')}
+        onEditClick={() => setBootOrderModalOpen(true)}
+        idValue={prefixedID(id, 'boot-order')}
+      >
+        <BootOrderModal
+          isOpen={isBootOrderModalOpen}
+          setOpen={setBootOrderModalOpen}
+          vmLikeEntity={vm}
+        />
         <BootOrderSummary devices={devices} />
       </VMDetailsItem>
 


### PR DESCRIPTION
~Depends on - https://github.com/openshift/console/pull/3558~ - merged
~Depends on - https://github.com/openshift/console/pull/3560~ - merged

-----------

Add possibility to change boot order

  - [x] modal view.
  - [x] overview summary view .
  - [x] Implement for vms an vm templates.
  - [x] Implement keyboard control for a11y.
  - [x] implement update k8s on submit.
  - [x] handle negative flow.
  - [x] handle object changed in back-end.

Jira:
https://jira.coreos.com/browse/CNV-2907
https://jira.coreos.com/browse/CNV-2908
https://jira.coreos.com/browse/CNV-2909

Design:
https://github.com/openshift/openshift-origin-design/blob/master/web-console/knikubevirt/vm-details/vm-boot-order/vm-boot-order.md

Screenshots:

Change boot order:
![Peek 2019-12-11 10-57](https://user-images.githubusercontent.com/2181522/70606988-58000800-1c06-11ea-83f1-c86a93d0ae15.gif)

Empty state:
![Peek 2019-12-11 10-58](https://user-images.githubusercontent.com/2181522/70606990-58000800-1c06-11ea-9e37-c6b7cb6c1550.gif)

Update boot order from another process:
![Peek 2019-12-11 11-05](https://user-images.githubusercontent.com/2181522/70606991-58000800-1c06-11ea-9029-4f083e4fe0c7.gif)



