### PR TITLE
Bug 1767851: Link on problematic obcs directed to OBC page

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card.scss
+++ b/frontend/packages/noobaa-storage-plugin/src/components/buckets-card/buckets-card.scss
@@ -1,33 +1,22 @@
 @import '~@patternfly/patternfly/sass-utilities/colors';
 
-.nb-buckets-card__row-status {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  :last-child {
-    margin-right: 0;
-  }
-}
-
-.nb-bucket-card__status-icon {
-  color: $pf-color-black-700;
-}
-
-.nb-buckets-card__row-status-item {
+.nb-buckets-card__buckets-failure-status {
   display: flex;
   flex-shrink: 0;
 }
 
-.nb-buckets-card__row-status-item-text {
+.nb-buckets-card__buckets-failure-status-count {
   color: $pf-color-blue-300;
-  margin-left: 0.25em;
+  margin-left: var(--pf-global--spacer--xs);
 }
 
-.nb-buckets-card__row-subtitle {
-  color: $pf-color-black-500;
+.nb-buckets-card__buckets-failure-status-item {
+  margin-left: var(--pf-global--spacer--sm);
+  .nb-buckets-card__buckets-failure-status-item--link {
+    text-decoration: none;
+  }
 }
 
-.nb-buckets-card__row-title {
-  margin-right: 0.5em;
+.nb-buckets-card__buckets-status-title {
+  margin-right: var(--pf-global--spacer--sm);
 }
-


### PR DESCRIPTION
This PR entails the following:
- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1767851
  In 4.4, the erros related to obc are seperated
   1. Provisioning error will lead to OBC page
   2. Errors not externalized to the phase of OBC
- Adds skeleton loading state
- Fixes lag issues in updating count status due to promethues polling

![Screenshot from 2019-12-12 11-44-31](https://user-images.githubusercontent.com/25664409/71506238-204fbc00-28a6-11ea-84ba-28d4d95be578.png)

![Screenshot from 2019-12-27 12-38-48](https://user-images.githubusercontent.com/25664409/71506253-3198c880-28a6-11ea-9e1d-2627b1d6af1a.png)
