### PR TITLE
kubevirt: migrate utility functions from web-ui-components

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/ip-addresses.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/ip-addresses.ts
@@ -1,6 +1,6 @@
-import { getVmiIpAddresses } from 'kubevirt-web-ui-components';
 import { VMIKind } from '../types';
 import { VMStatus, isVmOff } from '../statuses/vm/vm';
+import { getVmiIpAddresses } from '../selectors/vmi/ip-address';
 
 // the vmStatus is precomputed by caller for optimization
 export const getVmiIpAddressesString = (vmi: VMIKind, vmStatus: VMStatus): string => {

--- a/frontend/packages/kubevirt-plugin/src/components/ip-addresses.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/ip-addresses.ts
@@ -1,6 +1,6 @@
-import { getVmiIpAddresses, isVmOff } from 'kubevirt-web-ui-components';
+import { getVmiIpAddresses } from 'kubevirt-web-ui-components';
 import { VMIKind } from '../types';
-import { VMStatus } from '../statuses/vm/vm';
+import { VMStatus, isVmOff } from '../statuses/vm/vm';
 
 // the vmStatus is precomputed by caller for optimization
 export const getVmiIpAddressesString = (vmi: VMIKind, vmStatus: VMStatus): string => {

--- a/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/cdrom-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/cdrom-modal.tsx
@@ -6,7 +6,6 @@ import {
   HandlePromiseProps,
   withHandlePromise,
 } from '@console/internal/components/utils';
-import { isWindows } from 'kubevirt-web-ui-components';
 import { ModalTitle, ModalBody, ModalComponentProps } from '@console/internal/components/factory';
 import { PlusCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { k8sPatch } from '@console/internal/module/k8s';
@@ -22,6 +21,7 @@ import {
   getStorageSizeByDisk,
   getStorageClassNameByDisk,
   isVMRunning,
+  isWindows,
 } from '../../../selectors/vm/selectors';
 import { isValidationError, validateURL } from '../../../utils/validations/common';
 import { VMKind, VMLikeEntityKind } from '../../../types';

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Firehose, FirehoseResult, LoadingInline } from '@console/internal/components/utils';
-import { VmConsoles, isWindows } from 'kubevirt-web-ui-components';
+import { VmConsoles } from 'kubevirt-web-ui-components';
 import { getName, getNamespace } from '@console/shared';
 import { WSFactory } from '@console/internal/module/ws-factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
@@ -20,6 +20,7 @@ import { findVMPod } from '../../selectors/pod/selectors';
 import { VMIKind, VMKind } from '../../types/vm';
 import { getVMStatus } from '../../statuses/vm/vm';
 import { getLoadedData, getResource } from '../../utils';
+import { isWindows } from '../../selectors/vm';
 import { menuActionStart } from './menu-actions';
 import { VMTabProps } from './types';
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { getServicesForVm } from 'kubevirt-web-ui-components';
 import {
   Firehose,
   StatusBox,
@@ -16,6 +15,7 @@ import { ServicesList } from '@console/internal/components/service';
 import { VMKind, VMIKind } from '../../types';
 import { getLoadedData, getResource } from '../../utils';
 import { VirtualMachineInstanceModel } from '../../models';
+import { getServicesForVmi } from '../../selectors/service';
 import { VMResourceSummary, VMDetailsList } from './vm-resource';
 import { VMTabProps } from './types';
 
@@ -47,7 +47,7 @@ const VMDetails: React.FC<VMDetailsProps> = (props) => {
     templates,
   };
 
-  const vmServicesData = getServicesForVm(getLoadedData(props.services, []), vm);
+  const vmServicesData = getServicesForVmi(getLoadedData(props.services, []), vmi);
 
   const canUpdate = useAccessReview(asAccessReview(VirtualMachineInstanceModel, vm, 'patch'));
 

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -28,6 +28,8 @@ export const VM_DETAIL_CONSOLES_HREF = 'consoles';
 
 export const CLOUDINIT_DISK = 'cloudinitdisk';
 
+export const OS_WINDOWS_PREFIX = 'win';
+
 export enum DeviceType {
   NIC = 'NIC',
   DISK = 'DISK',

--- a/frontend/packages/kubevirt-plugin/src/selectors/service/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/service/selectors.ts
@@ -1,7 +1,24 @@
 import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
+import { ServiceKind } from '@console/knative-plugin/src/types';
+import { VMIKind } from '../../types';
+import { getVmiTemplateLabels } from '../vmi/basic';
 
 export const getServicePort = (service: K8sResourceKind, targetPort: number) =>
   _.get(service, ['spec', 'ports'], []).find(
     (servicePort) => targetPort === servicePort.targetPort,
   );
+
+const getServiceSelectors = (service: ServiceKind) =>
+  service && service.spec && service.spec.selector ? service.spec.selector : {};
+
+export const getServicesForVmi = (services: ServiceKind[], vmi: VMIKind): ServiceKind[] => {
+  const vmLabels = getVmiTemplateLabels(vmi);
+  return services.filter((service) => {
+    const selectors = getServiceSelectors(service);
+    const selectorKeys = Object.keys(selectors);
+    return selectorKeys.length > 0
+      ? selectorKeys.every((key) => vmLabels[key] === selectors[key])
+      : false;
+  });
+};

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -7,6 +7,7 @@ import {
   TEMPLATE_OS_LABEL,
   TEMPLATE_OS_NAME_ANNOTATION,
   TEMPLATE_WORKLOAD_LABEL,
+  OS_WINDOWS_PREFIX,
 } from '../../constants/vm';
 import { V1Network, V1NetworkInterface, VMKind, VMLikeEntityKind, CPURaw } from '../../types';
 import { findKeySuffixValue, getSimpleName, getValueByPrefix } from '../utils';
@@ -40,7 +41,7 @@ export const getVolumes = (vm: VMKind, defaultValue = []) =>
 export const getDataVolumeTemplates = (vm: VMKind, defaultValue = []) =>
   _.get(vm, 'spec.dataVolumeTemplates') == null ? defaultValue : vm.spec.dataVolumeTemplates;
 
-export const getOperatingSystem = (vm: VMLikeEntityKind) =>
+export const getOperatingSystem = (vm: VMLikeEntityKind): string =>
   findKeySuffixValue(getLabels(vm), TEMPLATE_OS_LABEL);
 export const getOperatingSystemName = (vm: VMKind) =>
   getValueByPrefix(getAnnotations(vm), `${TEMPLATE_OS_NAME_ANNOTATION}/${getOperatingSystem(vm)}`);
@@ -131,3 +132,6 @@ export const getStorageClassNameByDisk = (vm: VMKind, diskName: string) =>
   getDataVolumeStorageClassName(
     getDataVolumeTemplates(vm).find((vol) => getName(vol).includes(diskName)),
   );
+
+export const isWindows = (vm: VMKind) =>
+  (getOperatingSystem(vm) || '').startsWith(OS_WINDOWS_PREFIX);

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { VMIKind } from '../../types';
 
 export const getVMIDisks = (vmi: VMIKind): VMIKind['spec']['domain']['devices']['disks'] =>
@@ -17,9 +18,4 @@ export const getVMIConditionsByType = (
 };
 
 export const getVmiTemplateLabels = (vmi: VMIKind): { [key: string]: string } =>
-  (vmi &&
-    vmi.spec &&
-    vmi.spec.template &&
-    vmi.spec.template.metadata &&
-    vmi.spec.template.metadata.labels) ||
-  {};
+  (_.get(vmi, 'vmi.spec.template.metadata') && vmi.spec.template.metadata.labels) || {};

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
@@ -15,3 +15,11 @@ export const getVMIConditionsByType = (
   const conditions = vmi && vmi.status && vmi.status.conditions;
   return (conditions || []).filter((cond) => cond.type === condType);
 };
+
+export const getVmiTemplateLabels = (vmi: VMIKind): { [key: string]: string } =>
+  (vmi &&
+    vmi.spec &&
+    vmi.spec.template &&
+    vmi.spec.template.metadata &&
+    vmi.spec.template.metadata.labels) ||
+  {};

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/index.ts
@@ -1,3 +1,4 @@
 export * from './basic';
 export * from './combined';
 export * from './selectors';
+export * from './ip-address';

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/ip-address.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/ip-address.ts
@@ -1,0 +1,21 @@
+import { get, uniq, flatMap } from 'lodash';
+import { VMIKind } from '../../types';
+
+export const getVmiIpAddresses = (vmi: VMIKind) =>
+  uniq(
+    flatMap(
+      // get IPs only for named interfaces because Windows reports IPs for other devices like Loopback Pseudo-Interface 1 etc.
+      get(vmi, 'status.interfaces', []).filter((i) => !!i.name),
+      (i) => {
+        const arr = [];
+        if (i.ipAddress) {
+          // the "ipAddress" is deprecated but still can contain useful value
+          arr.push(i.ipAddress.trim());
+        }
+        if (i.ipAddresses && Array.isArray(i.ipAddresses) && i.ipAddresses.length > 0) {
+          arr.push(...i.ipAddresses.map((ip) => ip.trim()));
+        }
+        return arr;
+      },
+    ).filter((ip) => ip && ip.length > 0),
+  );

--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
@@ -262,6 +262,8 @@ export const getSimpleVMStatus = (
     : VM_SIMPLE_STATUS_OTHER;
 };
 
+export const isVmOff = (vmStatus: VMStatus) => vmStatus.status === VM_STATUS_OFF;
+
 export type VMStatus = Status & {
   pod?: PodKind;
   launcherPod?: PodKind;


### PR DESCRIPTION
Part of the gradual effort to remove the `kubevirt-web-ui-components` dependency.

Includes small migrations:
- migrate `isVmOff()`
- migrate `getVmiIpAddresses()`
- migrate `getServicesForVmi()`
- migrate `isWindows()`