### PR TITLE
kubevirt: fix outdated web-ui-components imports

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/vm-flavor-modal/vm-flavor-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/vm-flavor-modal/vm-flavor-modal.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import * as classNames from 'classnames';
-import { getResource } from 'kubevirt-web-ui-components';
 import {
   HandlePromiseProps,
   withHandlePromise,
@@ -36,6 +35,7 @@ import {
   TEMPLATE_TYPE_LABEL,
   TEMPLATE_TYPE_BASE,
 } from '../../../constants';
+import { getResource } from '../../../utils';
 import './_vm-flavor-modal.scss';
 
 const MB = 1000 ** 2;

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
-import {
-  getOperatingSystemName,
-  getOperatingSystem,
-  getWorkloadProfile,
-} from 'kubevirt-web-ui-components';
 import { ResourceSummary } from '@console/internal/components/utils';
 import { TemplateKind } from '@console/internal/module/k8s';
 import { getBasicID, prefixedID } from '../../utils';
 import { vmDescriptionModal } from '../modals/vm-description-modal';
 import { VMCDRomModal } from '../modals/cdrom-vm-modal';
 import { getDescription } from '../../selectors/selectors';
-import { getCDRoms } from '../../selectors/vm/selectors';
+import {
+  getCDRoms,
+  getOperatingSystemName,
+  getOperatingSystem,
+  getWorkloadProfile,
+} from '../../selectors/vm/selectors';
 import { getVMTemplateNamespacedName } from '../../selectors/vm-template/selectors';
 import { vmFlavorModal } from '../modals';
 import { getFlavorText } from '../flavor-text';

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -2,11 +2,6 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import {
-  getTemplateOperatingSystems,
-  getTemplateFlavors,
-  TEMPLATE_TYPE_LABEL,
-} from 'kubevirt-web-ui-components';
 import { ListPage, Table, TableRow, TableData } from '@console/internal/components/factory';
 import { Kebab, ResourceLink, ResourceKebab } from '@console/internal/components/utils';
 import { TemplateModel } from '@console/internal/models';
@@ -21,10 +16,14 @@ import {
 } from '@console/shared';
 import { match } from 'react-router';
 import { VM_TEMPLATE_LABEL_PLURAL } from '../../constants/vm-templates';
+import {
+  getTemplateOperatingSystems,
+  getTemplateFlavors,
+} from '../../selectors/vm-template/advanced';
+import { TEMPLATE_TYPE_LABEL } from '../../constants';
 import { TemplateSource } from './vm-template-source';
 import { menuActions } from './menu-actions';
 import { VMTemplateLink } from './vm-template-link';
-
 import './vm-template.scss';
 
 const { kind } = TemplateModel;
@@ -112,7 +111,7 @@ const VMTemplateTableRow: React.FC<VMTemplateTableRowProps> = ({
       <TableData className={dimensify()}>
         <TemplateSource template={template} />
       </TableData>
-      <TableData className={dimensify()}>{os ? os.name || os.fieldId : DASH}</TableData>
+      <TableData className={dimensify()}>{os ? os.name || os.id : DASH}</TableData>
       <TableData className={dimensify()}>{getTemplateFlavors([template])[0]}</TableData>
       <TableData className={dimensify(true)}>
         <ResourceKebab actions={menuActions} kind={kind} resource={template} />

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -41,10 +41,14 @@ export const getVolumes = (vm: VMKind, defaultValue = []) =>
 export const getDataVolumeTemplates = (vm: VMKind, defaultValue = []) =>
   _.get(vm, 'spec.dataVolumeTemplates') == null ? defaultValue : vm.spec.dataVolumeTemplates;
 
-export const getOperatingSystem = (vm: VMLikeEntityKind): string =>
-  findKeySuffixValue(getLabels(vm), TEMPLATE_OS_LABEL);
-export const getOperatingSystemName = (vm: VMKind): string =>
-  getValueByPrefix(getAnnotations(vm), `${TEMPLATE_OS_NAME_ANNOTATION}/${getOperatingSystem(vm)}`);
+export const getOperatingSystem = (vmLike: VMLikeEntityKind): string =>
+  findKeySuffixValue(getLabels(vmLike), TEMPLATE_OS_LABEL);
+export const getOperatingSystemName = (vmLike: VMLikeEntityKind) =>
+  getValueByPrefix(
+    getAnnotations(vmLike),
+    `${TEMPLATE_OS_NAME_ANNOTATION}/${getOperatingSystem(vmLike)}`,
+  );
+
 export const getWorkloadProfile = (vm: VMLikeEntityKind) =>
   findKeySuffixValue(getLabels(vm), TEMPLATE_WORKLOAD_LABEL);
 export const getFlavor = (vmLike: VMLikeEntityKind) =>


### PR DESCRIPTION
Part of the gradual effort to remove the kubevirt-web-ui-components dependency.

Depends on:
- [x] #3396 
- [x] #3444
- [x] #3442 

Most of the commits will be removed after rebase.