### PR TITLE
Remove backdrop-filter from pf-c-backdrop to fix Chrome bug

### DIFF
--- a/frontend/public/components/_about-modal.scss
+++ b/frontend/public/components/_about-modal.scss
@@ -17,3 +17,9 @@
 .co-about-modal__alert {
   margin-bottom: var(--pf-global--spacer--xl);
 }
+
+// Temp fix until https://github.com/patternfly/patternfly-next/issues/2447 is fixed upstream
+.pf-c-backdrop {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important; // so Safari is consistent with Chrome
+}


### PR DESCRIPTION
Before:
![Screen Shot 2019-11-18 at 9 38 56 AM](https://user-images.githubusercontent.com/895728/69065638-148ef100-09ee-11ea-940f-cd28a804f163.png)
![Screen Shot 2019-11-18 at 10 08 30 AM](https://user-images.githubusercontent.com/895728/69065641-148ef100-09ee-11ea-9589-13d7debae4f8.png)

After:
![localhost_9000_k8s_ns_openshift-operator-lifecycle-manager_operators coreos com_v1alpha1_ClusterServiceVersion_packageserver](https://user-images.githubusercontent.com/895728/69065661-1b1d6880-09ee-11ea-913a-b61e76ec60be.png)
