### PR TITLE
Fix Webpack Hot Reloading on SSH environments 

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -39,6 +39,8 @@ const config: Configuration = {
     progress: true,
     hot: HOT_RELOAD !== 'false',
     inline: HOT_RELOAD !== 'false',
+    host: '0.0.0.0',
+    disableHostCheck: true,
   },
   resolve: {
     extensions: ['.glsl', '.ts', '.tsx', '.js', '.jsx'],


### PR DESCRIPTION
This fixes Webpack hot reloading when a remote host is running the webpack server and you are running the console with a local machine.