### PR TITLE
Topology: Fix to use full height at low resolutions in safari and on iOS

### DIFF
--- a/frontend/packages/dev-console/src/components/topology2/TopologyPage.scss
+++ b/frontend/packages/dev-console/src/components/topology2/TopologyPage.scss
@@ -6,4 +6,9 @@
   right: 0;
   top: 0;
   bottom: 0;
+
+  // WORKAROUND: see https://github.com/patternfly/patternfly-react/issues/3312
+  .pf-topology-container__with-sidebar {
+    flex: 1;
+  }
 }


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/ODC-2305

