### PR TITLE
make dnd end an async action

### DIFF
--- a/frontend/packages/topology/package.json
+++ b/frontend/packages/topology/package.json
@@ -8,7 +8,8 @@
     "@console/shared": "0.0.0-fixed",
     "mobx": "^5.14.2",
     "mobx-react": "^6.1.4",
-    "mobx-react-lite": "^1.4.2"
+    "mobx-react-lite": "^1.4.2",
+    "mobx-utils": "^5.5.2"
   },
   "consolePlugin": {
     "entry": "src/plugin.tsx"

--- a/frontend/packages/topology/src/behavior/useDndManager.tsx
+++ b/frontend/packages/topology/src/behavior/useDndManager.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { observable } from 'mobx';
+import { actionAsync } from 'mobx-utils';
 import ControllerContext from '../utils/ControllerContext';
 import {
   DndManager,
@@ -215,6 +216,7 @@ export class DndManagerImpl implements DndManager {
     this.doEndDrag();
   }
 
+  @actionAsync
   private async doEndDrag(): Promise<void> {
     const source = this.getSource(this.getSourceId());
     try {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10971,6 +10971,11 @@ mobx-react@^6.1.4:
   dependencies:
     mobx-react-lite "^1.4.2"
 
+mobx-utils@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/mobx-utils/-/mobx-utils-5.5.2.tgz#3d3230067f14e9315559d2bfd31d86ec2e8999f0"
+  integrity sha512-cOlFJDWU/NHyGKvdhWqPdHmhPfeKewElAIZp5XticWIsSLGAA+4Uou3+8ookhQ/yG7qZXzvjAq90TZWXiR5+XA==
+
 mobx@^5.14.2:
   version "5.14.2"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.14.2.tgz#608b8ee9bc9f9e406b48da676e677b150e901eba"


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-2308

When regrouping, mobx was triggering a force update in the middle of model changes because there were asynchronous changes happening that weren't wrapped in an async action.

Change `useDndManager#endDrag` to execute a mobx async action such that reactions are trigged at the end of the action and batched.

/assign @jeff-phillips-18 