### PR TITLE
support disabled property in dropdown

### DIFF
--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -568,6 +568,7 @@ export class Dropdown extends DropdownMixin {
             type="button"
             id={this.props.id}
             aria-describedby={describedBy}
+            disabled={disabled}
           >
             <span className="pf-c-dropdown__toggle-text">
               {titlePrefix && `${titlePrefix}: `}


### PR DESCRIPTION
There are two different render paths in dropdown. One path renders the `disabled` button while the other does not.

First case which supports auto complete and disabled prop:
https://github.com/openshift/console/blob/ad4649dd9c9207bb8c5d05dc446b0871bda2ddc2/frontend/public/components/utils/dropdown.jsx#L500

Simply added the `disabled` attribute for the 2nd case to be consistent.

cc @spadgett 

(fyi @karthikjeeyar this should fix the issue with the dropdowns in your PR for disabling the image and tag dropdowns in import container flows)

Before: 
![image](https://user-images.githubusercontent.com/14068621/69111797-a3325b00-0a4c-11ea-8f1b-3c4c046ff0ea.png)


After:
![image](https://user-images.githubusercontent.com/14068621/69111780-9877c600-0a4c-11ea-9304-b75665c7ca30.png)
