### PR TITLE
check for spec.sink.ref else spec.sink for event sources

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
@@ -22,6 +22,7 @@ import {
   getTopologyNodeItem,
 } from '@console/dev-console/src/components/topology/topology-utils';
 import { DeploymentModel } from '@console/internal/models';
+import { ServiceModel as knServiceModel } from '../models';
 import { KnativeItem } from './get-knative-resources';
 
 export enum NodeType {
@@ -160,9 +161,9 @@ export const getEventTopologyEdgeItems = (
   application?: string,
 ): Edge[] => {
   const uid = _.get(resource, ['metadata', 'uid']);
-  const sinkSvc = _.get(resource, ['spec', 'sink'], {});
+  const sinkSvc = _.get(resource, 'spec.sink.ref', null) || _.get(resource, 'spec.sink', null);
   const edges = [];
-  if (sinkSvc.kind === 'Service') {
+  if (sinkSvc && sinkSvc.kind === knServiceModel.kind) {
     _.forEach(data, (res) => {
       const PART_OF = 'app.kubernetes.io/part-of';
       const resname = _.get(res, ['metadata', 'name']);


### PR DESCRIPTION
check for `spec.sink.ref` else `spec.sink` for event sources as current evst sources template supports both.

Tracks: https://jira.coreos.com/browse/ODC-2307

<img width="711" alt="Screenshot 2019-11-19 at 2 55 58 PM" src="https://user-images.githubusercontent.com/5129024/69134376-65c9de00-0add-11ea-900e-9caae339095a.png">
