### PR TITLE
check for knative Service on the Add page

### DIFF
--- a/frontend/packages/dev-console/src/components/AddPage.tsx
+++ b/frontend/packages/dev-console/src/components/AddPage.tsx
@@ -3,7 +3,8 @@ import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { match as RMatch } from 'react-router';
 import { history, Firehose, FirehoseResource, HintBlock } from '@console/internal/components/utils';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import { ServiceModel } from '@console/knative-plugin';
 import ODCEmptyState from './EmptyState';
 import NamespacedPage from './NamespacedPage';
 import ProjectsExistWrapper from './ProjectsExistWrapper';
@@ -20,6 +21,7 @@ interface ResourcesType {
   deployments: K8sResourceKind;
   daemonSets: K8sResourceKind;
   statefulSets: K8sResourceKind;
+  knativeService: K8sResourceKind;
 }
 interface EmptyStateLoaderProps {
   resources?: ResourcesType;
@@ -39,7 +41,8 @@ const EmptyStateLoader: React.FC<EmptyStateLoaderProps> = ({ resources, loaded, 
         _.isEmpty(resources.deploymentConfigs.data) &&
           _.isEmpty(resources.deployments.data) &&
           _.isEmpty(resources.daemonSets.data) &&
-          _.isEmpty(resources.statefulSets.data),
+          _.isEmpty(resources.statefulSets.data) &&
+          _.isEmpty(resources.knativeService.data),
       );
     } else if (loadError) {
       setNoWorkloads(false);
@@ -51,6 +54,7 @@ const EmptyStateLoader: React.FC<EmptyStateLoaderProps> = ({ resources, loaded, 
     resources.deploymentConfigs.data,
     resources.deployments.data,
     resources.statefulSets.data,
+    resources.knativeService.data,
   ]);
   return noWorkloads ? (
     <ODCEmptyState
@@ -76,24 +80,36 @@ const RenderEmptyState = ({ namespace }) => {
       kind: 'DeploymentConfig',
       namespace,
       prop: 'deploymentConfigs',
+      limit: 1,
     },
     {
       isList: true,
       kind: 'Deployment',
       namespace,
       prop: 'deployments',
+      limit: 1,
     },
     {
       isList: true,
       kind: 'DaemonSet',
       namespace,
       prop: 'daemonSets',
+      limit: 1,
     },
     {
       isList: true,
       kind: 'StatefulSet',
       namespace,
       prop: 'statefulSets',
+      limit: 1,
+    },
+    {
+      isList: true,
+      kind: referenceForModel(ServiceModel),
+      namespace,
+      prop: 'knativeService',
+      optional: true,
+      limit: 1,
     },
   ];
   return (

--- a/frontend/public/actions/k8s.ts
+++ b/frontend/public/actions/k8s.ts
@@ -161,7 +161,11 @@ export const watchK8sList = (
 
     const response = await k8sList(
       k8skind,
-      { ...query, limit: paginationLimit, ...(continueToken ? { continue: continueToken } : {}) },
+      {
+        limit: paginationLimit,
+        ...query,
+        ...(continueToken ? { continue: continueToken } : {}),
+      },
       true,
     );
 

--- a/frontend/public/components/utils/firehose.jsx
+++ b/frontend/public/components/utils/firehose.jsx
@@ -205,6 +205,7 @@ export const Firehose = connect(
               resource.selector,
               resource.fieldSelector,
               resource.name,
+              resource.limit,
             );
             const k8sKind = k8sModels.get(resource.kind);
             const id = makeReduxID(k8sKind, query);
@@ -267,6 +268,7 @@ Firehose.propTypes = {
       fieldSelector: PropTypes.string,
       isList: PropTypes.bool,
       optional: PropTypes.bool, // do not block children-rendering while resource is still being loaded; do not fail if resource is missing (404)
+      limit: PropTypes.number,
     }),
   ).isRequired,
 };

--- a/frontend/public/components/utils/types.ts
+++ b/frontend/public/components/utils/types.ts
@@ -39,6 +39,7 @@ export type FirehoseResource = {
   prop: string;
   namespaced?: boolean;
   optional?: boolean;
+  limit?: number;
 };
 
 export type HumanizeResult = {


### PR DESCRIPTION
This PR fixes:
- adds the knative service to the list of resources we fetch in the Add page
- checks for one resource per kind to decide whether to show the `no workloads found` banner on the Add page

Issue : https://jira.coreos.com/browse/ODC-2232

GIF: 
![final_5dd40430ae94cc0014ee9e9c_285527](https://user-images.githubusercontent.com/22490998/69158318-4007fd80-0b0c-11ea-8dd4-cd0583ecf548.gif)
