### PR TITLE
Bug 1760858: Add special Edge drop shadow

### DIFF
--- a/frontend/packages/dev-console/src/components/svg/SvgDropShadowFilter.tsx
+++ b/frontend/packages/dev-console/src/components/svg/SvgDropShadowFilter.tsx
@@ -19,24 +19,50 @@ const SvgDropShadowFilter: React.FC<SvgDropShadowFilterProps> = ({
   stdDeviation = 2,
   floodColor = '#030303',
   floodOpacity = 0.2,
-}) => (
-  <SVGDefs id={id}>
-    <filter
-      id={id}
-      x={`-${stdDeviation * 12.5}%`}
-      y={`-${stdDeviation * 12.5}%`}
-      width={`${100 + stdDeviation * 25}%`}
-      height={`${100 + stdDeviation * 25}%`}
-    >
-      <feDropShadow
-        dx={dx}
-        dy={dy}
-        stdDeviation={stdDeviation}
-        floodColor={floodColor}
-        floodOpacity={floodOpacity}
-      />
-    </filter>
-  </SVGDefs>
-);
+}) => {
+  if (window.navigator.userAgent.includes('Edge')) {
+    // feDropShadow is not supported by Edge
+    return (
+      <SVGDefs id={id}>
+        <filter
+          id={id}
+          x={`-${stdDeviation * 12.5}%`}
+          y={`-${stdDeviation * 12.5}%`}
+          width={`${100 + stdDeviation * 25}%`}
+          height={`${100 + stdDeviation * 25}%`}
+        >
+          <feGaussianBlur in="SourceAlpha" stdDeviation={stdDeviation} />
+          <feOffset dx={dx} dy={dy} result="offsetblur" />
+          <feFlood floodColor={floodColor} floodOpacity={floodOpacity} />
+          <feComposite in2="offsetblur" operator="in" />
+          <feMerge>
+            <feMergeNode />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </SVGDefs>
+    );
+  }
+
+  return (
+    <SVGDefs id={id}>
+      <filter
+        id={id}
+        x={`-${stdDeviation * 12.5}%`}
+        y={`-${stdDeviation * 12.5}%`}
+        width={`${100 + stdDeviation * 25}%`}
+        height={`${100 + stdDeviation * 25}%`}
+      >
+        <feDropShadow
+          dx={dx}
+          dy={dy}
+          stdDeviation={stdDeviation}
+          floodColor={floodColor}
+          floodOpacity={floodOpacity}
+        />
+      </filter>
+    </SVGDefs>
+  );
+};
 
 export default SvgDropShadowFilter;


### PR DESCRIPTION
Fixes the following issues:

- https://jira.coreos.com/browse/ODC-2186 (node is rendered broken) - also the linked bugzilla
- https://jira.coreos.com/browse/ODC-1575 (can't see build progress)
- https://jira.coreos.com/browse/ODC-1576 (can't see app name)

### Edge Before

![EdgeBrokenTopology](https://user-images.githubusercontent.com/8126518/69170298-debe3b00-0ac7-11ea-86bc-e8a74e5dd92e.png)

### Edge After

![EdgeUpdatedTopology2](https://user-images.githubusercontent.com/8126518/69300911-89c31780-0be2-11ea-9a7b-3e49a305dd5a.png)

### Chrome

![image](https://user-images.githubusercontent.com/8126518/69170312-e4b41c00-0ac7-11ea-8c0c-c8135939566e.png)

### Firefox

![image](https://user-images.githubusercontent.com/8126518/69170455-1a590500-0ac8-11ea-8784-6e91b13ce498.png)

### Safari

![image](https://user-images.githubusercontent.com/8126518/69170539-3ceb1e00-0ac8-11ea-897e-32533599115d.png)
