### PR TITLE
dashboards: use round tick values for project filesystem usage

### DIFF
--- a/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/project-dashboard/utilization-card.tsx
@@ -195,6 +195,7 @@ export const UtilizationCard = withDashboardResources(
             isLoading={!projectName || !filesystemUtilization}
             humanizeValue={humanizeBinaryBytes}
             query={queries[ProjectQueries.FILESYSTEM_USAGE]}
+            byteDataType={ByteDataTypes.BinaryBytes}
             error={filesystemError}
             TopConsumerPopover={filesystemPopover}
           />


### PR DESCRIPTION
/assign @TheRealJon @rawagner 
/cc @andybraren 

Before:

![openshift-console · Details · Red Hat OpenShift Container Platform 2019-11-19 13-07-07](https://user-images.githubusercontent.com/1167259/69173538-f8fb1780-0acd-11ea-860d-f64dbb1b628c.png)

After:

![openshift-console · Details · OKD 2019-11-19 13-10-44](https://user-images.githubusercontent.com/1167259/69173564-044e4300-0ace-11ea-8846-5aa1d63cff42.png)
