### PR TITLE
Fix Git/Docker import forms on Edge

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -56,7 +56,7 @@ const config: Configuration = {
       { test: /\.glsl$/, loader: 'raw!glslify' },
       {
         test: /(\.jsx?)|(\.tsx?)$/,
-        exclude: /node_modules/,
+        exclude: /node_modules\/(?!(bitbucket|ky)\/)/,
         use: [
           { loader: 'cache-loader' },
           {


### PR DESCRIPTION
https://jira.coreos.com/browse/ODC-2316

There are some things that Edge just doesn't support. [Object spread in destructuring is one of them](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax).

![image](https://user-images.githubusercontent.com/8126518/69189980-7a15d700-0aed-11ea-97d3-105f5962b134.png)

To that extent, the Git Import and Dockerfile Import forms failed when they went through our 3rd party libs to help us detect the git repo type/name/etc.

To fix this issue, two libraries were specifically targeted to get transpiled for use in Edge.

- [node-bitbucket](https://github.com/MunifTanjim/node-bitbucket) (the case from the ticket)
```
$ yarn why bitbucket
yarn why v1.17.3
[1/4] Why do we have the module "bitbucket"...?
=> Found "bitbucket@1.15.1"
info Reasons this module exists
   - "_project_#@console#git-service" depends on it
```
- [ky](https://github.com/sindresorhus/ky)
```
$ yarn why ky
yarn why v1.17.3
[1/4] Why do we have the module "ky"...?
=> Found "ky@0.11.2"
info Reasons this module exists
   - "_project_#@console#git-service#gitlab" depends on it
```