### PR TITLE
Change all graph links to point to the Monitoring > Metrics page

### DIFF
--- a/frontend/__tests__/components/graphs/prometheus-graph.spec.tsx
+++ b/frontend/__tests__/components/graphs/prometheus-graph.spec.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { mount, shallow } from 'enzyme';
+import { Link } from 'react-router-dom';
+import { shallow } from 'enzyme';
 
 import {
   PrometheusGraph,
   PrometheusGraphLink,
   getPrometheusExpressionBrowserURL,
 } from '@console/internal/components/graphs/prometheus-graph';
-import store from '@console/internal/redux';
-import { Provider } from 'react-redux';
 
 describe('<PrometheusGraph />', () => {
   it('should render a title', () => {
@@ -30,29 +29,23 @@ describe('<PrometheusGraph />', () => {
 });
 
 describe('<PrometheusGraphLink />', () => {
-  it('should render an anchor element', () => {
-    // Need full mount with redux store since this is a redux-connected compoenent
-    const wrapper = mount(
-      <Provider store={store}>
-        <PrometheusGraphLink query="test">
-          <p className="test-class" />
-        </PrometheusGraphLink>
-      </Provider>,
+  it('should render with a link', () => {
+    const wrapper = shallow(
+      <PrometheusGraphLink query="test">
+        <p className="test-class" />
+      </PrometheusGraphLink>,
     );
-    expect(wrapper.find('a').exists()).toBe(true);
+    expect(wrapper.find(Link).exists()).toBe(true);
     expect(wrapper.find('p.test-class').exists()).toBe(true);
   });
 
-  it('should not render an anchor element', () => {
-    // Need full mount with redux store since this is a redux-connected compoenent
-    const wrapper = mount(
-      <Provider store={store}>
-        <PrometheusGraphLink query="">
-          <p className="test-class" />
-        </PrometheusGraphLink>
-      </Provider>,
+  it('should not render with a link', () => {
+    const wrapper = shallow(
+      <PrometheusGraphLink query="">
+        <p className="test-class" />
+      </PrometheusGraphLink>,
     );
-    expect(wrapper.find('a').exists()).toBe(false);
+    expect(wrapper.find(Link).exists()).toBe(false);
     expect(wrapper.find('p.test-class').exists()).toBe(true);
   });
 });

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -1,8 +1,9 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 
-import { connectToURLs, MonitoringRoutes } from '../../reducers/monitoring';
+import { MonitoringRoutes } from '../../reducers/monitoring';
 
 export const getPrometheusExpressionBrowserURL = (urls, queries): string => {
   const base = urls && urls[MonitoringRoutes.Prometheus];
@@ -18,23 +19,23 @@ export const getPrometheusExpressionBrowserURL = (urls, queries): string => {
   return `${base}/graph?${params.toString()}`;
 };
 
-export const PrometheusGraphLink = connectToURLs(MonitoringRoutes.Prometheus)(
-  ({ children, query, urls }: React.PropsWithChildren<PrometheusGraphLinkProps>) => {
-    const url = getPrometheusExpressionBrowserURL(urls, [query]);
-    return query ? (
-      <a
-        href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ color: 'inherit', textDecoration: 'none' }}
-      >
-        {children}
-      </a>
-    ) : (
-      <>{children}</>
-    );
-  },
-);
+const getQueryBrowserURL = (query: string): string => {
+  const params = new URLSearchParams();
+  params.set('query0', query);
+  return `/monitoring/query-browser?${params.toString()}`;
+};
+
+export const PrometheusGraphLink = ({
+  children,
+  query,
+}: React.PropsWithChildren<PrometheusGraphLinkProps>) =>
+  query ? (
+    <Link to={getQueryBrowserURL(query)} style={{ color: 'inherit', textDecoration: 'none' }}>
+      {children}
+    </Link>
+  ) : (
+    <>{children}</>
+  );
 
 export const PrometheusGraph: React.FC<PrometheusGraphProps> = React.forwardRef(
   ({ children, className, title }, ref: React.RefObject<HTMLDivElement>) => (
@@ -47,7 +48,6 @@ export const PrometheusGraph: React.FC<PrometheusGraphProps> = React.forwardRef(
 
 type PrometheusGraphLinkProps = {
   query: string;
-  urls?: string[];
 };
 
 type PrometheusGraphProps = {


### PR DESCRIPTION
We currently have some links going to the Monitoring > Metrics page
(dashboard "View more" links) and some links going to the Prometheus UI
(graph links). This changes the graphs to link to Monitoring > Metrics
so that we are consistent.

FYI @TheRealJon @sichvoge @cshinn @s-urbaniak @rawagner 