### PR TITLE
disable the option to delete the last revision in traffic splitting modal

### DIFF
--- a/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/dev-console/src/components/formik-fields/field-types.ts
@@ -7,6 +7,8 @@ export interface FieldProps {
   required?: boolean;
   style?: React.CSSProperties;
   isReadOnly?: boolean;
+  disableDeleteRow?: boolean;
+  disableAddRow?: boolean;
   className?: string;
 }
 

--- a/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.scss
+++ b/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.scss
@@ -18,5 +18,9 @@
     line-height: var(--pf-global--spacer--xl);
     position: absolute;
     right: -16px;
+    &.is-disabled {
+      pointer-events: none;
+      color: var(--pf-global--disabled-color--200);
+    }
   }
 }

--- a/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
@@ -17,6 +17,8 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
   headers,
   emptyValues,
   isReadOnly,
+  disableDeleteRow,
+  disableAddRow,
   toolTip,
 }) => (
   <FieldArray
@@ -40,12 +42,17 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
                 rowIndex={index}
                 onDelete={() => remove(index)}
                 isReadOnly={isReadOnly}
+                disableDeleteRow={disableDeleteRow}
               >
                 {children}
               </MultiColumnFieldRow>
             ))}
           {!isReadOnly && (
-            <MultiColumnFieldFooter addLabel={addLabel} onAdd={() => push(emptyValues)} />
+            <MultiColumnFieldFooter
+              disableAddRow={disableAddRow}
+              addLabel={addLabel}
+              onAdd={() => push(emptyValues)}
+            />
           )}
         </FormGroup>
       );

--- a/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnFieldFooter.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnFieldFooter.tsx
@@ -1,15 +1,25 @@
 import * as React from 'react';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { Button } from 'patternfly-react';
+import { Button } from '@patternfly/react-core';
 
 export interface MultiColumnFieldHeader {
   addLabel: string;
   onAdd: () => void;
+  disableAddRow?: boolean;
 }
 
-const MultiColumnFieldFooter: React.FC<MultiColumnFieldHeader> = ({ addLabel, onAdd }) => (
-  <Button type="button" bsStyle="link" className="btn-link--no-btn-default-values" onClick={onAdd}>
-    <PlusCircleIcon style={{ marginRight: 'var(--pf-global--spacer--xs)' }} />
+const MultiColumnFieldFooter: React.FC<MultiColumnFieldHeader> = ({
+  addLabel,
+  onAdd,
+  disableAddRow = false,
+}) => (
+  <Button
+    variant="link"
+    isDisabled={disableAddRow}
+    onClick={onAdd}
+    icon={<PlusCircleIcon />}
+    isInline
+  >
     {addLabel || 'Add values'}
   </Button>
 );

--- a/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnFieldRow.tsx
+++ b/frontend/packages/dev-console/src/components/formik-fields/multi-column-field/MultiColumnFieldRow.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cx from 'classnames';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 import { Tooltip } from '@patternfly/react-core';
 import './MultiColumnField.scss';
@@ -10,22 +11,27 @@ export interface MultiColumnFieldRowProps {
   children: React.ReactNode;
   onDelete: () => void;
   isReadOnly?: boolean;
+  disableDeleteRow?: boolean;
 }
 
-const minusCircleIcon = (onDelete: () => void, toolTip?: string) => {
+const minusCircleIcon = (onDelete: () => void, disableDeleteRow?: boolean, toolTip?: string) => {
   return (
-    <div className="odc-multi-column-field__col--button">
+    <div className={cx('odc-multi-column-field__col--button', { 'is-disabled': disableDeleteRow })}>
       <MinusCircleIcon aria-hidden="true" onClick={onDelete} />
       <span className="sr-only">{toolTip || 'Delete'}</span>
     </div>
   );
 };
 
-const renderMinusCircleIcon = (onDelete: () => void, toolTip?: string) => {
+const renderMinusCircleIcon = (
+  onDelete: () => void,
+  toolTip?: string,
+  disableDeleteRow?: boolean,
+) => {
   return toolTip ? (
-    <Tooltip content={toolTip}>{minusCircleIcon(onDelete, toolTip)}</Tooltip>
+    <Tooltip content={toolTip}>{minusCircleIcon(onDelete, disableDeleteRow, toolTip)}</Tooltip>
   ) : (
-    minusCircleIcon(onDelete)
+    minusCircleIcon(onDelete, disableDeleteRow)
   );
 };
 
@@ -36,6 +42,7 @@ const MultiColumnFieldRow: React.FC<MultiColumnFieldRowProps> = ({
   onDelete,
   children,
   isReadOnly,
+  disableDeleteRow,
 }) => (
   <div className="odc-multi-column-field__row">
     {React.Children.map(children, (child: React.ReactElement) => {
@@ -47,7 +54,7 @@ const MultiColumnFieldRow: React.FC<MultiColumnFieldRowProps> = ({
         </div>
       );
     })}
-    {!isReadOnly && renderMinusCircleIcon(onDelete, toolTip)}
+    {!isReadOnly && renderMinusCircleIcon(onDelete, toolTip, disableDeleteRow)}
   </div>
 );
 

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
@@ -24,6 +24,7 @@ const TrafficSplittingModal: React.FC<Props> = ({
   handleReset,
   isSubmitting,
   status,
+  values,
 }) => {
   return (
     <form className="modal-content" onSubmit={handleSubmit}>
@@ -35,6 +36,7 @@ const TrafficSplittingModal: React.FC<Props> = ({
           addLabel="Add Revision"
           headers={['Split', 'Tag', 'Revision']}
           emptyValues={{ percent: '', tag: '', revisionName: '' }}
+          disableDeleteRow={values.trafficSplitting.length === 1}
         >
           <InputField
             name="percent"


### PR DESCRIPTION
1. disables the option to delete row if we have only one revision in traffic splitting modal 
2. fixes the alignment of the Add revision button

![disable_traffic_modal](https://user-images.githubusercontent.com/9964343/69268562-65246b00-0bf5-11ea-8031-6c3e159dc31c.gif)


Fixes: https://jira.coreos.com/browse/ODC-2250