### PR TITLE
fixes revisions to have respective routes for knative

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
@@ -24,6 +24,7 @@ export type KnativeOverviewProps = {
 export type KnativeRevisionResourceProps = {
   ksroutes: K8sResourceKind[];
   configurations: K8sResourceKind[];
+  obj: K8sResourceKind;
 };
 export type KnativeServiceResourceProps = {
   obj: K8sResourceKind;
@@ -37,7 +38,9 @@ export type OverviewDetailsResourcesTabProps = {
 const getSidebarResources = ({ obj, ksroutes, revisions, configurations }: OverviewItem) => {
   switch (obj.kind) {
     case RevisionModel.kind:
-      return <KnativeRevisionResources ksroutes={ksroutes} configurations={configurations} />;
+      return (
+        <KnativeRevisionResources ksroutes={ksroutes} obj={obj} configurations={configurations} />
+      );
     case ServiceModel.kind:
       return <KnativeServicesResources ksroutes={ksroutes} obj={obj} revisions={revisions} />;
     case EventSourceCronJobModel.kind:
@@ -64,10 +67,11 @@ const OverviewDetailsKnativeResourcesTab: React.FC<OverviewDetailsResourcesTabPr
 const KnativeRevisionResources: React.FC<KnativeRevisionResourceProps> = ({
   ksroutes,
   configurations,
+  obj,
 }) => {
   return (
     <>
-      <KSRoutesOverviewList ksroutes={ksroutes} />
+      <KSRoutesOverviewList ksroutes={ksroutes} resource={obj} />
       <ConfigurationsOverviewList configurations={configurations} />
     </>
   );
@@ -81,7 +85,7 @@ const KnativeServicesResources: React.FC<KnativeServiceResourceProps> = ({
   return (
     <>
       <RevisionsOverviewList revisions={revisions} service={obj} />
-      <KSRoutesOverviewList ksroutes={ksroutes} />
+      <KSRoutesOverviewList ksroutes={ksroutes} resource={obj} />
     </>
   );
 };
@@ -95,7 +99,7 @@ const KnativeOverview: React.FC<KnativeOverviewProps> = ({
   return (
     <>
       <RevisionsOverviewList revisions={revisions} service={obj} />
-      <KSRoutesOverviewList ksroutes={ksroutes} />
+      <KSRoutesOverviewList ksroutes={ksroutes} resource={obj} />
       <ConfigurationsOverviewList configurations={configurations} />
     </>
   );

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewList.tsx
@@ -11,28 +11,33 @@ import { RouteModel } from '@console/knative-plugin';
 
 export type RoutesOverviewListItemProps = {
   route: K8sResourceKind;
+  resource: K8sResourceKind;
 };
 
 export type RoutesOverviewListProps = {
   ksroutes: K8sResourceKind[];
+  resource: K8sResourceKind;
 };
 
-const RoutesOverviewListItem: React.FC<RoutesOverviewListItemProps> = ({
-  route: {
+const RoutesOverviewListItem: React.FC<RoutesOverviewListItemProps> = ({ route, resource }) => {
+  const {
     metadata: { name, namespace },
     status: { url },
-  },
-}) => {
+  } = route;
+  const trafficData = _.find(route.status.traffic, {
+    revisionName: resource.metadata.name,
+  });
+  const routeUrl = _.get(trafficData, 'url', url);
   return (
     <li className="list-group-item">
       <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
       <span className="text-muted">Location: </span>
-      <ExternalLink href={url} additionalClassName="co-external-link--block" text={url} />
+      <ExternalLink href={routeUrl} additionalClassName="co-external-link--block" text={routeUrl} />
     </li>
   );
 };
 
-const RoutesOverviewList: React.FC<RoutesOverviewListProps> = ({ ksroutes }) => (
+const RoutesOverviewList: React.FC<RoutesOverviewListProps> = ({ ksroutes, resource }) => (
   <>
     <SidebarSectionHeading text="Routes" />
     {_.isEmpty(ksroutes) ? (
@@ -40,7 +45,7 @@ const RoutesOverviewList: React.FC<RoutesOverviewListProps> = ({ ksroutes }) => 
     ) : (
       <ListGroup componentClass="ul">
         {_.map(ksroutes, (route) => (
-          <RoutesOverviewListItem key={route.metadata.uid} route={route} />
+          <RoutesOverviewListItem key={route.metadata.uid} route={route} resource={resource} />
         ))}
       </ListGroup>
     )}

--- a/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
@@ -251,7 +251,7 @@ export const createTopologyServiceNodeData = (
     resources: { ...svcRes },
     operatorBackedService: operatorBackedServiceKinds.includes(nodeResourceKind),
     data: {
-      url: getRoutesUrl(svcRes.routes, _.get(svcRes, ['ksroutes'])),
+      url: getRoutesUrl(svcRes),
       kind: knativeSvc.kind,
       editUrl:
         annotations['app.openshift.io/edit-url'] ||


### PR DESCRIPTION
fixes revisions to have respective routes for knative

NOTE: Revisions will have their own specific route only if there are multiple active revisions i.e we have performed traffic split else it'll have same route as of knative service.

Tracks: https://jira.coreos.com/browse/ODC-2312

Gif: 
![ezgif com-video-to-gif (9)](https://user-images.githubusercontent.com/5129024/69241190-422d9300-0bc4-11ea-8488-dcecea6725ae.gif)
