### PR TITLE
add shortcuts table shared components

### DIFF
--- a/frontend/packages/console-shared/src/components/index.ts
+++ b/frontend/packages/console-shared/src/components/index.ts
@@ -3,3 +3,4 @@ export * from './contextMenu';
 export * from './status';
 export * from './pod';
 export * from './popper';
+export * from './shortcuts';

--- a/frontend/packages/console-shared/src/components/shortcuts/Shortcut.scss
+++ b/frontend/packages/console-shared/src/components/shortcuts/Shortcut.scss
@@ -1,0 +1,16 @@
+.ocs-shortcut {
+  &__cell {
+    padding-bottom: var(--pf-global--spacer--sm);
+
+    &:first-child {
+      padding-right: var(--pf-global--spacer--md);
+      text-align: right;
+      white-space: nowrap;
+      vertical-align: top;
+    }
+  }
+
+  &__command:not(:last-child):after {
+    content: ' + ';
+  }
+}

--- a/frontend/packages/console-shared/src/components/shortcuts/Shortcut.tsx
+++ b/frontend/packages/console-shared/src/components/shortcuts/Shortcut.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { MouseIcon } from '@patternfly/react-icons';
+import './Shortcut.scss';
+
+interface ShortcutProps {
+  children: React.ReactNode;
+  alt?: boolean;
+  click?: boolean;
+  ctrl?: boolean;
+  drag?: boolean;
+  hover?: boolean;
+  keyName?: string;
+  rightClick?: boolean;
+  shift?: boolean;
+}
+
+const Command: React.FC = ({ children }) => (
+  <span className="ocs-shortcut__command">
+    <kbd>{children}</kbd>
+  </span>
+);
+
+const Shortcut: React.FC<ShortcutProps> = ({
+  children,
+  ctrl,
+  shift,
+  alt,
+  keyName,
+  drag,
+  click,
+  rightClick,
+  hover,
+}) => {
+  const isMac = window.navigator.platform.includes('Mac');
+  return (
+    <tr>
+      <td className="ocs-shortcut__cell">
+        {!isMac && ctrl && <Command>Ctrl</Command>}
+        {alt && <Command>{isMac ? '⌥ Opt' : 'Alt'}</Command>}
+        {shift && <Command>Shift</Command>}
+        {isMac && ctrl && <Command>⌘ Cmd</Command>}
+        {hover && (
+          <Command>
+            <MouseIcon /> Hover
+          </Command>
+        )}
+        {keyName && <Command>{keyName.toUpperCase()}</Command>}
+        {drag && (
+          <Command>
+            <MouseIcon /> Drag
+          </Command>
+        )}
+        {click && (
+          <Command>
+            <MouseIcon /> Click
+          </Command>
+        )}
+        {rightClick && (
+          <Command>
+            <MouseIcon /> Right Click
+          </Command>
+        )}
+      </td>
+      <td className="ocs-shortcut__cell">{children}</td>
+    </tr>
+  );
+};
+
+export default Shortcut;

--- a/frontend/packages/console-shared/src/components/shortcuts/ShortcutTable.tsx
+++ b/frontend/packages/console-shared/src/components/shortcuts/ShortcutTable.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+const ShortcutTable: React.FC = ({ children }) => (
+  <table>
+    <tbody>{children}</tbody>
+  </table>
+);
+
+export default ShortcutTable;

--- a/frontend/packages/console-shared/src/components/shortcuts/index.ts
+++ b/frontend/packages/console-shared/src/components/shortcuts/index.ts
@@ -1,0 +1,2 @@
+export { default as Shortcut } from './Shortcut';
+export { default as ShortcutTable } from './ShortcutTable';


### PR DESCRIPTION
In support of https://github.com/openshift/console/pull/3489 and https://github.com/openshift/console/pull/3178

Created a reusable component for laying out a shortcuts table.

example usage:
```
  <ShortcutTable>
    <Shortcut drag>move node or application</Shortcut>
    <Shortcut shift drag>
      move node in/out of an application group
    </Shortcut>
    <Shortcut rightClick>access respective context menus</Shortcut>
    <Shortcut click>view node or application details</Shortcut>
    <Shortcut hover>show node drag and drop connector</Shortcut>
  </ShortcutTable>
```

Results in:
![image](https://user-images.githubusercontent.com/14068621/69255456-d7f5fd80-0b85-11ea-9659-2fa64e4a1994.png)

cc @divyanshiGupta @serenamarie125 @openshift/team-devconsole-ux @spadgett @rebeccaalpert 

