### PR TITLE
request closing of popper on mouse down instead of click

### DIFF
--- a/frontend/packages/console-shared/src/components/popper/Popper.tsx
+++ b/frontend/packages/console-shared/src/components/popper/Popper.tsx
@@ -102,7 +102,7 @@ const Popper: React.FC<PopperProps> = ({
   const onKeyDown = React.useCallback(
     (e: KeyboardEvent) => {
       if (e.keyCode === 27) {
-        onRequestClose ? controlled && onRequestClose() : setOpen(false);
+        controlled ? onRequestClose && onRequestClose() : setOpen(false);
       }
     },
     [onRequestClose, controlled],
@@ -110,8 +110,8 @@ const Popper: React.FC<PopperProps> = ({
 
   const onClickOutside = React.useCallback(
     (e: MouseEvent) => {
-      if (nodeRef.current && e.target instanceof Node && !nodeRef.current.contains(e.target)) {
-        onRequestClose ? controlled && onRequestClose(e) : setOpen(false);
+      if (!nodeRef.current || (e.target instanceof Node && !nodeRef.current.contains(e.target))) {
+        controlled ? onRequestClose && onRequestClose(e) : setOpen(false);
       }
     },
     [onRequestClose, controlled],
@@ -122,7 +122,8 @@ const Popper: React.FC<PopperProps> = ({
       popperRef.current.destroy();
       popperRefs(null);
       document.removeEventListener('keydown', onKeyDown, true);
-      document.removeEventListener('click', onClickOutside, true);
+      document.removeEventListener('mousedown', onClickOutside, true);
+      document.removeEventListener('touchstart', onClickOutside, true);
     }
   }, [onClickOutside, onKeyDown, popperRefs]);
 
@@ -155,7 +156,8 @@ const Popper: React.FC<PopperProps> = ({
       document.addEventListener('keydown', onKeyDown, true);
     }
     if (closeOnOutsideClick) {
-      document.addEventListener('click', onClickOutside, true);
+      document.addEventListener('mousedown', onClickOutside, true);
+      document.addEventListener('touchstart', onClickOutside, true);
     }
   }, [
     popperRefs,


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-2339

In topology, the context menu wasn't closing if the user right clicked on one node after another. The popper now listens to mouse down which is fired when the context menu is requested and therefore closes the opened menus.

![topology-context-menu](https://user-images.githubusercontent.com/14068621/69272536-c1ab6a00-0ba4-11ea-91ae-2eb11f9841c0.gif)

Since we also use popper in the kabab. The behavior is actually improved when clicking to a new kebab while one is currently opened. Here's a gif showing the kebab continues to function:
![kebab-popper](https://user-images.githubusercontent.com/14068621/69275260-12719180-0baa-11ea-81eb-4abf462562d5.gif)

cc @jeff-phillips-18  @spadgett 