### PR TITLE
Fixes the Pipeline Logs streaming issue

### DIFF
--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-utils.spec.ts
@@ -34,13 +34,17 @@ describe('pipeline-utils ', () => {
   });
 
   it('should return correct Container Status', () => {
-    let status = containerToLogSourceStatus({ state: { waiting: {} } });
+    let status = containerToLogSourceStatus({ name: 'test', state: { waiting: {} } });
     expect(status).toBe(LOG_SOURCE_WAITING);
-    status = containerToLogSourceStatus({ state: { waiting: {} }, lastState: LOG_SOURCE_WAITING });
+    status = containerToLogSourceStatus({
+      name: 'test',
+      state: { waiting: {} },
+      lastState: LOG_SOURCE_WAITING,
+    });
     expect(status).toBe(LOG_SOURCE_RESTARTING);
-    status = containerToLogSourceStatus({ state: { running: {} } });
+    status = containerToLogSourceStatus({ name: 'test', state: { running: {} } });
     expect(status).toBe(LOG_SOURCE_RUNNING);
-    status = containerToLogSourceStatus({ state: { terminated: {} } });
+    status = containerToLogSourceStatus({ name: 'test', state: { terminated: {} } });
     expect(status).toBe(LOG_SOURCE_TERMINATED);
   });
 

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -29,6 +29,7 @@ interface Resource {
 }
 
 export interface ContainerStatus {
+  name: string;
   lastState?: string;
   state?: {
     waiting?: Record<string, any>;


### PR DESCRIPTION
https://jira.coreos.com/browse/ODC-1849
https://jira.coreos.com/browse/ODC-1804

Fixes the streaming issue of Pipeline Logs. There was a misunderstanding that the `container statuses` and the `container specs` were two arrays that were in parallel, that doesn't seem to be the case. The issue we saw in the UI was it was rendering the first container based off of another container (in this case, the build container) which took much longer to complete. Looked like the logs stalled, but it was just not rendering the containers properly.

- [ ] ~Fix the scrolling issue~
    - ~the logs do not anchor to the bottom, so now that the logs properly stream they don't actually make it easy to see all the live results as they happen~
- [ ] ~Capture a gif of the logs streaming AND scrolling~

After talking with @christianvogt, the issues of logs being capped at 1k lines and the scrolling issue has been put into separate bugs. The streaming of logs works again via this PR, so it'll serve as a foundation as we discuss what else is to be fixed for 4.3.

Related Issues:
- https://jira.coreos.com/browse/ODC-2379 (1k log limit)
- https://jira.coreos.com/browse/ODC-2380 (scroll issue)

cc @abhinandan13jan @christianvogt 