### PR TITLE
Query Browser: Show seconds on X-axis when timespan is small

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -247,7 +247,9 @@ const Graph: React.FC<GraphProps> = React.memo(({ allSeries, disabledSeries, spa
     maxY = 0;
   }
 
-  const tickFormat =
+  const xTickFormat = span < 5 * 60 * 1000 ? twentyFourHourTimeWithSeconds : twentyFourHourTime;
+
+  const yTickFormat =
     Math.abs(maxY - minY) < 0.005 ? (v) => (v === 0 ? '0' : v.toExponential(1)) : formatValue;
 
   return (
@@ -262,8 +264,8 @@ const Graph: React.FC<GraphProps> = React.memo(({ allSeries, disabledSeries, spa
           theme={chartTheme}
           width={width}
         >
-          <ChartAxis tickCount={5} tickFormat={twentyFourHourTime} />
-          <ChartAxis crossAxis={false} dependentAxis tickCount={6} tickFormat={tickFormat} />
+          <ChartAxis tickCount={5} tickFormat={xTickFormat} />
+          <ChartAxis crossAxis={false} dependentAxis tickCount={6} tickFormat={yTickFormat} />
           <ChartGroup>
             {_.map(data, (values, i) => (
               <ChartLine key={i} data={values} />


### PR DESCRIPTION
Without this change, some X-axis ticks have the same labels at short
time spans.

### Before
![before](https://user-images.githubusercontent.com/460802/69305880-e79a4280-0c68-11ea-9b86-78481cb26f45.png)

### After
![after](https://user-images.githubusercontent.com/460802/69305875-e6691580-0c68-11ea-8472-a1740a8f8cf5.png)