### PR TITLE
Query Browser: Fix "Metrics" sidebar entry highlight

### DIFF
--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -74,7 +74,13 @@ const MonitoringNavSection_ = ({ grafanaURL, canAccess, kibanaURL }) => {
           startsWith={monitoringAlertsStartsWith}
         />
       )}
-      {showAlerts && <HrefLink href="/monitoring/query-browser?query0=" name="Metrics" />}
+      {showAlerts && (
+        <HrefLink
+          href="/monitoring/query-browser?query0="
+          name="Metrics"
+          startsWith={['monitoring/query-browser']}
+        />
+      )}
       {showGrafana && <ExternalLink href={grafanaURL} name="Dashboards" />}
       {kibanaURL && <ExternalLink href={kibanaURL} name="Logging" />}
     </NavSection>


### PR DESCRIPTION
The "Metrics" sidebar entry was losing its highlight when a query was
run because the URL GET parameters automatically change when the query
changes. This fixes the highlight to not depend on the GET parameters.