### PR TITLE
fix(dev-catalog): reject the internal objects when creating from CSV

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
@@ -12,7 +12,6 @@ const isInternal = (crd: { name: string }): boolean => {
   );
   try {
     const internalOpList = JSON.parse(internalOpListString); // JSON.parse fails if incorrect annotation structure
-    if (!Array.isArray(internalOpList) || internalOpList.length === 0) return false;
     return internalOpList.some((op) => op === crd.name);
   } catch {
     /* eslint-disable-next-line no-console */

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -114,15 +114,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
       ...projectTemplateItems,
     ];
 
-    //blacklisting all CRDs with annotation 'operators.operatorframework.io/internal-object' set to true
-    const filteredItems = _.reject(items, [
-      'obj',
-      'metadata',
-      'annotations',
-      'operators.operatorframework.io/internal-object',
-    ]);
-
-    return _.sortBy(filteredItems, 'tileName');
+    return _.sortBy(items, 'tileName');
   }
 
   normalizeClusterServiceClasses(serviceClasses) {


### PR DESCRIPTION
------------------------------------------------------------------------------
Addresses https://jira.coreos.com/browse/ODC-2263
P.S: try-catch is used as an annotation is a free string and can have any structure
Test cases:
------------------------------------------------------------------------------
Test 1: CSV with annotation and internal CRD present in array
![Screenshot from 2019-12-03 19-00-47](https://user-images.githubusercontent.com/24852534/70056409-6d22d880-1601-11ea-9486-7ed774f45ccf.png)
![Screenshot from 2019-12-03 19-00-06](https://user-images.githubusercontent.com/24852534/70056429-7318b980-1601-11ea-85de-3b884ed124cb.png)
---------------------------------------------------------------------------------
Test 2: CSV with annotation and internal CRD not listed in array
![Screenshot from 2019-12-03 19-01-45](https://user-images.githubusercontent.com/24852534/70056486-8cba0100-1601-11ea-9184-8838a846142d.png)
![Screenshot from 2019-12-03 19-02-04](https://user-images.githubusercontent.com/24852534/70056489-8d529780-1601-11ea-94ef-8fe5b987ccd2.png)
----------------------------------------------------------------------------------
Test 3: CSV with annotation and only internal CRD
![Screenshot from 2019-12-03 19-03-40](https://user-images.githubusercontent.com/24852534/70056560-ab1ffc80-1601-11ea-8fb3-198cf5bee0cd.png)
![Screenshot from 2019-12-03 19-04-03](https://user-images.githubusercontent.com/24852534/70056561-ab1ffc80-1601-11ea-82b4-2778e5a9112b.png)
------------------------------------------------------------------------------------
Test 4: CSV without the required annotation at all
![Screenshot from 2019-12-03 19-05-22](https://user-images.githubusercontent.com/24852534/70056626-cbe85200-1601-11ea-8d9e-ace33e9824bd.png)
![Screenshot from 2019-12-03 19-05-40](https://user-images.githubusercontent.com/24852534/70056628-cbe85200-1601-11ea-922b-31dd5bc581c5.png)
-------------------------------------------------------------------------------------
