### PR TITLE
Bug 1761433: Fixes Latency graph for 0 values

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utils.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/utilization-card/utils.tsx
@@ -1,6 +1,11 @@
 import * as _ from 'lodash';
 import { DataPoint } from '@console/internal/components/graphs';
-import { Humanize, humanizeNumber } from '@console/internal/components/utils';
+import {
+  Humanize,
+  humanizeNumber,
+  humanizeSeconds,
+  secondsToNanoSeconds,
+} from '@console/internal/components/utils';
 
 export const humanizeIOPS: Humanize = (value) => {
   const humanizedNumber = humanizeNumber(value);
@@ -13,13 +18,8 @@ export const humanizeIOPS: Humanize = (value) => {
 };
 
 export const humanizeLatency: Humanize = (value) => {
-  const humanizedNumber = humanizeNumber(value);
-  const unit = 'ms';
-  return {
-    ...humanizedNumber,
-    string: `${humanizedNumber.value} ${unit}`,
-    unit,
-  };
+  const humanizedTime = humanizeSeconds(secondsToNanoSeconds(value), null, 'ms');
+  return humanizedTime;
 };
 
 export const getLatestValue = (stats: DataPoint[]) => Number(_.get(stats[stats.length - 1], 'y'));


### PR DESCRIPTION
The utilization component is rounding off time value to 0 for many datapoints,
thats why there is data at those points but the vertical graph shows 0. The
PR fixes this.
![utilization](https://user-images.githubusercontent.com/12200504/69343986-9dc75180-0c94-11ea-83ad-9f9070313738.gif)


Signed-off-by: Kanika <kmurarka@redhat.com>