### PR TITLE
Bug 1775720: Backport to 4.2 - Chargeback Reports and ReportQueries change to v1 apiVersion

### DIFF
--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -38,7 +38,7 @@ import {
 
 export const ReportReference: GroupVersionKind = referenceForModel(ChargebackReportModel);
 export const ScheduledReportReference: GroupVersionKind = 'metering.openshift.io~ScheduledReport';
-export const ReportGenerationQueryReference: GroupVersionKind = 'metering.openshift.io~v1alpha1~ReportQuery';
+export const ReportGenerationQueryReference: GroupVersionKind = 'metering.openshift.io~v1~ReportQuery';
 
 const reportPages=[
   {name: 'All Reports', href: ReportReference},

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -141,7 +141,7 @@ export const ChargebackReportModel: K8sKind = {
   label: 'Report',
   labelPlural: 'Reports',
   apiGroup: 'metering.openshift.io',
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1',
   crd: true,
   plural: 'reports',
   abbr: 'R',

--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -152,7 +152,7 @@ spec:
     imageChange: {}
   - type: ConfigChange
 `).setIn([referenceForModel(k8sModels.ChargebackReportModel), 'default'], `
-apiVersion: metering.openshift.io/v1alpha1
+apiVersion: metering.openshift.io/v1
 kind: Report
 metadata:
   name: namespace-memory-request


### PR DESCRIPTION
Backport of #3478 
* Note `ReportQueryModel` was added post 4.2
* Tested against 4.2 cluster on release-4.2 branch using Metering OLM v4.2.5.  All chargeback Report and ReportQuery urls work and creation of new Report using `v1` apiVersion template work.