### PR TITLE
Topology: do not drag on MB2, MB3, or control clicks.

### DIFF
--- a/frontend/packages/topology/src/behavior/useDndDrag.tsx
+++ b/frontend/packages/topology/src/behavior/useDndDrag.tsx
@@ -229,7 +229,10 @@ export const useDndDrag = <
                   }
                 }),
               )
-              .filter(() => dndManager.canDragSource(idRef.current)),
+              .filter(
+                () =>
+                  !d3.event.ctrlKey && !d3.event.button && dndManager.canDragSource(idRef.current),
+              ),
           );
         }
         return () => {

--- a/frontend/packages/topology/src/behavior/usePanZoom.tsx
+++ b/frontend/packages/topology/src/behavior/usePanZoom.tsx
@@ -45,7 +45,8 @@ export const usePanZoom = (zoomExtent: [number, number] = ZOOM_EXTENT): PanZoomR
                 );
                 elementRef.current.setScale(d3.event.transform.k);
               }),
-            );
+            )
+            .filter(() => !d3.event.ctrlKey && !d3.event.button);
           zoom($svg);
 
           // Update the d3 transform whenever the scale or bounds change.


### PR DESCRIPTION
Resolves https://jira.coreos.com/browse/ODC-2178

Prevents dragging from starting on a middle or right click or a left click with the control button pressed (also used for context menu). 