### PR TITLE
frontend: Refactor shortcuts to use ShortcutTable, add shortcut

### DIFF
--- a/frontend/packages/console-shared/src/components/shortcuts/Shortcut.tsx
+++ b/frontend/packages/console-shared/src/components/shortcuts/Shortcut.tsx
@@ -10,6 +10,7 @@ interface ShortcutProps {
   drag?: boolean;
   hover?: boolean;
   keyName?: string;
+  macCtrl?: boolean;
   rightClick?: boolean;
   shift?: boolean;
 }
@@ -30,12 +31,13 @@ const Shortcut: React.FC<ShortcutProps> = ({
   click,
   rightClick,
   hover,
+  macCtrl,
 }) => {
   const isMac = window.navigator.platform.includes('Mac');
   return (
     <tr>
       <td className="ocs-shortcut__cell">
-        {!isMac && ctrl && <Command>Ctrl</Command>}
+        {((!isMac && ctrl) || macCtrl) && <Command>Ctrl</Command>}
         {alt && <Command>{isMac ? '⌥ Opt' : 'Alt'}</Command>}
         {shift && <Command>Shift</Command>}
         {isMac && ctrl && <Command>⌘ Cmd</Command>}

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -711,16 +711,16 @@ const EditYAML_ = connect(stateToProps)(
                           bodyContent={
                             <ShortcutTable>
                               <Shortcut macCtrl keyName="space">
-                                Use Ctrl + Space to activate auto complete.
+                                Activate auto complete
                               </Shortcut>
                               <Shortcut ctrl shift keyName="o">
-                                Use Shift + {isMac ? 'Command' : 'Ctrl'} + O for document outlining.
+                                View document outline
                               </Shortcut>
                               <Shortcut hover>
-                                Hover over a property to view a description.
+                                View property descriptions
                               </Shortcut>
                               <Shortcut ctrl keyName="s">
-                                Use {isMac ? 'Command' : 'Ctrl'} + S to save.
+                                Save
                               </Shortcut>
                             </ShortcutTable>
                           }

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -676,7 +676,6 @@ const EditYAML_ = connect(stateToProps)(
       const definition = model ? definitionFor(model) : { properties: [] };
       const showSchema = definition && !_.isEmpty(definition.properties);
       const hasSidebarContent = showSchema || !_.isEmpty(samples) || !_.isEmpty(snippets);
-      const isMac = window.navigator.platform.includes('Mac');
       const editYamlComponent = (
         <div className="co-file-dropzone">
           {canDrop && (
@@ -716,9 +715,7 @@ const EditYAML_ = connect(stateToProps)(
                               <Shortcut ctrlCmd shift keyName="o">
                                 View document outline
                               </Shortcut>
-                              <Shortcut hover>
-                                View property descriptions
-                              </Shortcut>
+                              <Shortcut hover>View property descriptions</Shortcut>
                               <Shortcut ctrlCmd keyName="s">
                                 Save
                               </Shortcut>
@@ -729,7 +726,7 @@ const EditYAML_ = connect(stateToProps)(
                         >
                           <Button type="button" variant="link" isInline>
                             <QuestionCircleIcon className="co-icon-space-r co-p-has-sidebar__sidebar-link-icon" />
-                            Shortcuts
+                            View shortcuts
                           </Button>
                         </Popover>
                       </div>

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -12,7 +12,7 @@ import {
   global_BackgroundColor_300 as lineNumberForeground,
   global_BackgroundColor_dark_100 as editorBackground,
 } from '@patternfly/react-tokens';
-import { getBadgeFromType } from '@console/shared';
+import { getBadgeFromType, Shortcut, ShortcutTable } from '@console/shared';
 
 import { connectToFlags } from '../reducers/features';
 import { Firehose, checkAccess, history, Loading, resourceObjPath } from './utils';
@@ -709,13 +709,20 @@ const EditYAML_ = connect(stateToProps)(
                         <Popover
                           aria-label="Shortcuts"
                           bodyContent={
-                            <ul>
-                              <li>Use Ctrl + Space to activate auto complete.</li>
-                              <li>
-                                Use {isMac ? 'Command' : 'Ctrl'} + Shift + O for document outlining.
-                              </li>
-                              <li>Hover over a property to view a description.</li>
-                            </ul>
+                            <ShortcutTable>
+                              <Shortcut macCtrl keyName="space">
+                                Use Ctrl + Space to activate auto complete.
+                              </Shortcut>
+                              <Shortcut ctrl shift keyName="o">
+                                Use Shift + {isMac ? 'Command' : 'Ctrl'} + O for document outlining.
+                              </Shortcut>
+                              <Shortcut hover>
+                                Hover over a property to view a description.
+                              </Shortcut>
+                              <Shortcut ctrl keyName="s">
+                                Use {isMac ? 'Command' : 'Ctrl'} + S to save.
+                              </Shortcut>
+                            </ShortcutTable>
                           }
                           maxWidth="25rem"
                           distance={18}


### PR DESCRIPTION
Refactored YAML shortcuts to use new shared ShortcutTable component and added save shortcut from Sam's recent PR. Made small tweak to ShortcutTable to accommodate Mac Ctrl keys.

<img width="1107" alt="Screen Shot 2019-11-21 at 10 29 28 AM" src="https://user-images.githubusercontent.com/7014965/69353114-02aa8980-0c4c-11ea-91f8-1d608bceb0ba.png">

Heads up at @openshift/team-ux-review.