### PR TITLE
Fixed bucket class wizard next logic and default region for aws

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/bucket-class/create-bc.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/bucket-class/create-bc.tsx
@@ -96,7 +96,7 @@ const CreateBucketClass: React.FC<CreateBCProps> = ({ match }) => {
       id: CreateStepsBC.GENERAL,
       name: 'General',
       component: <GeneralPage dispatch={dispatch} state={state} />,
-      enableNext: !!state.bucketClassName,
+      enableNext: !!state.bucketClassName.trim().length,
     },
     {
       id: CreateStepsBC.PLACEMENT,

--- a/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
@@ -129,7 +129,7 @@ const S3EndPointType: React.FC<S3EndpointTypeProps> = (props) => {
               dispatch({ type: 'setRegion', value: e });
             }}
             items={awsRegionItems}
-            selectedKey={provider}
+            selectedKey={awsRegions[0]}
           />
         </FormGroup>
       )}


### PR DESCRIPTION
- Added us-east-1 as default region for AWS
- Next button doesn't get enabled for whitespaces only
