### PR TITLE
Add icons to replication controller status

### DIFF
--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -4,6 +4,7 @@ import * as classNames from 'classnames';
 
 import { Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
+import { Status } from '@console/shared';
 import { ResourceEventStream } from './events';
 import { DetailsPage, ListPage, Table, TableData, TableRow } from './factory';
 import { replicaSetMenuActions } from './replicaset';
@@ -62,7 +63,9 @@ const Details = ({ obj: replicationController }) => {
             {phase && (
               <>
                 <dt>Phase</dt>
-                <dd>{phase}</dd>
+                <dd>
+                  <Status status={phase} />
+                </dd>
               </>
             )}
             <ResourcePodCount resource={replicationController} />
@@ -187,7 +190,9 @@ const ReplicationControllerTableRow = ({ obj, index, key, style }) => {
           {obj.status.replicas || 0} of {obj.spec.replicas} pods
         </Link>
       </TableData>
-      <TableData className={tableColumnClasses[3]}>{phase}</TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <Status status={phase} />
+      </TableData>
       <TableData className={tableColumnClasses[4]}>
         <OwnerReferences resource={obj} />
       </TableData>


### PR DESCRIPTION
Replication controllers weren't using the standard `Status` component, so were missing icons.

/kind bug
/assign @rhamilto 

![example · Details · OKD 2019-11-21 14-03-48](https://user-images.githubusercontent.com/1167259/69368384-0c41ea80-0c68-11ea-9e29-40e85d084533.png)
