### PR TITLE
Use consistent case in view links

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
@@ -37,7 +37,7 @@ const PipelinesOverview: React.FC<PipelinesOverviewProps> = ({
             className="sidebar__section-view-all"
             to={`${resourcePath(referenceForModel(PipelineModel), name, namespace)}/Runs`}
           >
-            {`View All (${pipelineRuns.length})`}
+            {`View all (${pipelineRuns.length})`}
           </Link>
         )}
       </SidebarSectionHeading>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineRunItem.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineRunItem.tsx
@@ -33,7 +33,7 @@ const PipelineRunItem: React.FC<PipelineRunItemProps> = ({ pipelineRun }) => {
           <Status status={pipelineRunStatus(pipelineRun) || 'Pending'} />
         </GridItem>
         <GridItem span={3} className="text-right">
-          <Link to={`${path}/logs`}>View Logs</Link>
+          <Link to={`${path}/logs`}>View logs</Link>
         </GridItem>
       </Grid>
     </li>

--- a/frontend/packages/dev-console/src/components/topology/ApplicationGroupResource.tsx
+++ b/frontend/packages/dev-console/src/components/topology/ApplicationGroupResource.tsx
@@ -31,7 +31,7 @@ const ApplicationGroupResource: React.FC<ApplicationGroupResourceProps> = ({
                   resourcesData[0],
                 )}&q=${encodeURIComponent(`app.kubernetes.io/part-of=${group}`)}`}
               >
-                {`View All (${_.size(resourcesData)})`}
+                {`View all (${_.size(resourcesData)})`}
               </Link>
             )}
           </SidebarSectionHeading>

--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -47,7 +47,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal, cv }
             <>
               Update available.{' '}
               <Link to="/settings/cluster" onClick={closeAboutModal}>
-                View Cluster Settings
+                View cluster settings
               </Link>
             </>
           }
@@ -62,7 +62,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = ({ closeAboutModal, cv }
                 <div className="co-select-to-copy">{openshiftVersion}</div>
                 {errataLink && (
                   <div>
-                    <ExternalLink text="View Errata" href={errataLink} />
+                    <ExternalLink text="View errata" href={errataLink} />
                   </div>
                 )}
               </TextListItem>

--- a/frontend/public/components/build-pipeline.tsx
+++ b/frontend/public/components/build-pipeline.tsx
@@ -46,7 +46,7 @@ const BuildSummaryStatusIcon: React.SFC<BuildSummaryStatusIconProps> = ({ status
 export const BuildPipelineLogLink: React.SFC<BuildPipelineLogLinkProps> = ({ obj }) => {
   const link = getJenkinsLogURL(obj);
   return link ? (
-    <ExternalLink href={link} text="View Logs" additionalClassName="build-pipeline__log-link" />
+    <ExternalLink href={link} text="View logs" additionalClassName="build-pipeline__log-link" />
   ) : null;
 };
 

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -113,7 +113,7 @@ export const BuildLogLink = ({ build }) => {
   return isPipeline ? (
     <BuildPipelineLogLink obj={build} />
   ) : (
-    <Link to={`${resourcePath('Build', name, namespace)}/logs`}>View Logs</Link>
+    <Link to={`${resourcePath('Build', name, namespace)}/logs`}>View logs</Link>
   );
 };
 

--- a/frontend/public/components/catalog/catalog-item-details.jsx
+++ b/frontend/public/components/catalog/catalog-item-details.jsx
@@ -54,7 +54,7 @@ export class CatalogTileDetails extends React.Component {
     const iconClass = tileIconClass ? normalizeIconClass(tileIconClass) : null;
     const creationTimestamp = _.get(obj, 'metadata.creationTimestamp');
 
-    const supportUrlLink = <ExternalLink href={supportUrl} text="Get Support" />;
+    const supportUrlLink = <ExternalLink href={supportUrl} text="Get support" />;
     const documentationUrlLink = (
       <ExternalLink
         href={documentationUrl}

--- a/frontend/public/components/cluster-service-class-info.tsx
+++ b/frontend/public/components/cluster-service-class-info.tsx
@@ -36,12 +36,12 @@ export const ClusterServiceClassInfo: React.FC<ClusterServiceClassInfoProps> = (
             <ul className="list-inline">
               {documentationURL && (
                 <li className="co-break-word">
-                  <ExternalLink href={documentationURL} text="View Documentation" />
+                  <ExternalLink href={documentationURL} text="View documentation" />
                 </li>
               )}
               {supportURL && (
                 <li className="co-break-word">
-                  <ExternalLink href={supportURL} text="Get Support" />
+                  <ExternalLink href={supportURL} text="Get support" />
                 </li>
               )}
             </ul>

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -325,7 +325,7 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
         <SectionHeading text="Update History">
           {errataLink && (
             <small>
-              <ExternalLink text="View Errata" href={errataLink} />
+              <ExternalLink text="View errata" href={errataLink} />
             </small>
           )}
         </SectionHeading>

--- a/frontend/public/components/instantiate-template.tsx
+++ b/frontend/public/components/instantiate-template.tsx
@@ -93,12 +93,12 @@ const TemplateInfo: React.FC<TemplateInfoProps> = ({ template }) => {
             <ul className="list-inline">
               {documentationURL && (
                 <li className="co-break-word">
-                  <ExternalLink href={documentationURL} text="View Documentation" />
+                  <ExternalLink href={documentationURL} text="View documentation" />
                 </li>
               )}
               {supportURL && (
                 <li className="co-break-word">
-                  <ExternalLink href={supportURL} text="Get Support" />
+                  <ExternalLink href={supportURL} text="Get support" />
                 </li>
               )}
             </ul>

--- a/frontend/public/components/overview/pods-overview.tsx
+++ b/frontend/public/components/overview/pods-overview.tsx
@@ -91,7 +91,7 @@ const PodOverviewItem: React.FC<PodOverviewItemProps> = ({ pod }) => {
           <Status status={phase} />
         </span>
         <span className="col-xs-3 text-right">
-          <Link to={`${resourcePath(kind, name, namespace)}/logs`}>View Logs</Link>
+          <Link to={`${resourcePath(kind, name, namespace)}/logs`}>View logs</Link>
         </span>
       </div>
     </li>
@@ -132,7 +132,7 @@ export const PodsOverview: React.SFC<PodsOverviewProps> = ({ pods, obj }) => {
             className="sidebar__section-view-all"
             to={`${resourcePath(obj.kind, name, namespace)}/pods`}
           >
-            {`View All (${_.size(pods)})`}
+            {`View all (${_.size(pods)})`}
           </Link>
         )}
       </SidebarSectionHeading>

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -127,7 +127,7 @@ class ServiceInstanceMessage_ extends React.Component<
         >
           This service instance is marked for deletion, but still has bindings. You must delete the
           bindings before the instance will be deleted.{' '}
-          <Link to={`${basePath}/servicebindings`}>View Service Bindings</Link>
+          <Link to={`${basePath}/servicebindings`}>View service bindings</Link>
         </Alert>
       );
     }
@@ -194,7 +194,7 @@ const ServiceInstanceDetails: React.SFC<ServiceInstanceDetailsProps> = ({ obj: s
                 <>
                   <dt>Dashboard</dt>
                   <dd>
-                    <ExternalLink href={dashboardURL} text="View Dashboard" />
+                    <ExternalLink href={dashboardURL} text="View dashboard" />
                   </dd>
                 </>
               )}

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -142,7 +142,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
                     isInline
                     variant="link"
                   >
-                    View Details
+                    View details
                   </Button>
                 )}
               </li>


### PR DESCRIPTION
We're inconsistent between `View all` and `View All`. Patternfly recommends the former, and sentence case is used in more places currently. I think this fixes most of them.

https://www.patternfly.org/v4/design-guidelines/content/grammar-and-terminology#capitalization

/cc @christianvogt @openshift/team-ux-review 