### PR TITLE
Fix bug where Monitoring > Metrics nav wasn't set to active

### DIFF
--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -74,7 +74,13 @@ const MonitoringNavSection_ = ({ grafanaURL, canAccess, kibanaURL }) => {
           startsWith={monitoringAlertsStartsWith}
         />
       )}
-      {showAlerts && <HrefLink href="/monitoring/query-browser?query0=" name="Metrics" />}
+      {showAlerts && (
+        <HrefLink
+          href="/monitoring/query-browser?query0="
+          name="Metrics"
+          startsWith={['monitoring/query-browser']}
+        />
+      )}
       {showGrafana && <ExternalLink href={grafanaURL} name="Dashboards" />}
       {kibanaURL && <ExternalLink href={kibanaURL} name="Logging" />}
     </NavSection>


### PR DESCRIPTION
Before:
![Screen Shot 2019-11-21 at 3 57 12 PM](https://user-images.githubusercontent.com/895728/69376082-a9584f80-0c77-11ea-8d41-67322360bea3.png)

After:
![Screen Shot 2019-11-21 at 3 57 24 PM](https://user-images.githubusercontent.com/895728/69376090-aeb59a00-0c77-11ea-8ca3-f366743ed16a.png)
