### PR TITLE
Bug 1764540: Use default channel for OperatorHub item descriptions

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -29,10 +29,11 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
     'data',
     [] as PackageManifestKind[],
   );
-  const localItems = _.get(props.packageManifest, 'data', [] as PackageManifestKind[]);
+  const localItems = _.get(props, 'packageManifest.data', [] as PackageManifestKind[]);
   const items: OperatorHubItem[] = marketplaceItems.concat(localItems).map(
     (pkg): OperatorHubItem => {
-      const { currentCSVDesc } = _.get(pkg, 'status.channels[0]', {});
+      const { channels, defaultChannel } = _.get(pkg, 'status');
+      const { currentCSVDesc } = _.find(channels || [], { name: defaultChannel } as any);
       const currentCSVAnnotations: OperatorHubCSVAnnotations = _.get(
         currentCSVDesc,
         'annotations',

--- a/frontend/packages/operator-lifecycle-manager/src/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/types.ts
@@ -214,6 +214,7 @@ export type PackageManifestKind = {
       name: string;
       currentCSV: string;
       currentCSVDesc: {
+        description?: string;
         displayName: string;
         icon: { mediatype: string; base64data: string }[];
         version: string;


### PR DESCRIPTION
Use default channel for OperatorHub item descriptions instead of first channel in list.