### PR TITLE
align 'View shortcuts' with admin console

### DIFF
--- a/frontend/packages/dev-console/src/components/topology2/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology2/TopologyPage.tsx
@@ -102,7 +102,7 @@ const TopologyPage: React.FC<Props> = ({
                   className="odc-topology__shortcuts-button"
                   icon={<QuestionCircleIcon />}
                 >
-                  Shortcuts
+                  View shortcuts
                 </Button>
               </Popover>
             )}


### PR DESCRIPTION
Changes `Shortcuts` to `View shortcuts` to align with the changes in https://github.com/openshift/console/pull/3525

![image](https://user-images.githubusercontent.com/14068621/69392125-f867aa00-0ca2-11ea-835e-15c9a1ec7d51.png)

cc @spadgett @rebeccaalpert 