### PR TITLE
Bug 1775864: use actionAsync when calling dndManager#endDrag

### DIFF
--- a/frontend/packages/dev-console/src/components/topology2/componentUtils.ts
+++ b/frontend/packages/dev-console/src/components/topology2/componentUtils.ts
@@ -80,7 +80,7 @@ const nodeDragSourceSpec = (
     : undefined,
   canCancel: (monitor) => monitor.getOperation() === REGROUP_OPERATION,
   end: async (dropResult, monitor, props) => {
-    if (monitor.getOperation() === REGROUP_OPERATION) {
+    if (!monitor.isCancelled() && monitor.getOperation() === REGROUP_OPERATION) {
       if (monitor.didDrop() && dropResult && props && props.element.getParent() !== dropResult) {
         await moveNodeToGroup(props.element, isNode(dropResult) ? dropResult : null);
         dropResult.appendChild(props.element);

--- a/frontend/packages/topology/src/behavior/dnd-types.ts
+++ b/frontend/packages/topology/src/behavior/dnd-types.ts
@@ -80,7 +80,7 @@ export interface DndManager {
     pageY: number,
   ): void;
   hover(targetIds: string[]): void;
-  endDrag(): void;
+  endDrag(): Promise<void>;
   drag(x: number, y: number, pageX: number, pageY: number): void;
   drop(): void;
   cancel(): boolean;

--- a/frontend/packages/topology/src/behavior/useDndManager.tsx
+++ b/frontend/packages/topology/src/behavior/useDndManager.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { observable } from 'mobx';
-import { actionAsync } from 'mobx-utils';
 import ControllerContext from '../utils/ControllerContext';
 import {
   DndManager,
@@ -212,12 +211,7 @@ export class DndManagerImpl implements DndManager {
     });
   }
 
-  endDrag(): void {
-    this.doEndDrag();
-  }
-
-  @actionAsync
-  private async doEndDrag(): Promise<void> {
+  async endDrag(): Promise<void> {
     const source = this.getSource(this.getSourceId());
     try {
       if (source) {
@@ -275,6 +269,9 @@ export class DndManagerImpl implements DndManager {
   cancel(): boolean {
     if (!this.state.event) {
       throw new Error('Drag event not initialized');
+    }
+    if (this.state.cancelled) {
+      return true;
     }
     const source = this.getSource(this.getSourceId());
     if (source && source.canCancel(this)) {


### PR DESCRIPTION
fixes: https://jira.coreos.com/browse/ODC-2387

When `dndManager#endDrag` was made to support async behavior such that we could better handle the confirmation dialog for regrouping nodes, the async behavior wasn't propagated through to the caller. This resulted in some model updates not being in batched and also running out of order. By wrapping the entire `updateOperation` and any calling function in an `actionAsync` we ensure that model updates are always batched and run in order.

In the examples below, whenever the groups turn blue is when the shift button is pressed.

Before: Node kept jumping back to start position after releasing shift.
![dnd-fail](https://user-images.githubusercontent.com/14068621/69395850-6cf41600-0cae-11ea-911e-b5d06b0d1f83.gif)

After:
![regroup-fix](https://user-images.githubusercontent.com/14068621/69395821-55b52880-0cae-11ea-92e4-d759f1fda275.gif)

/assign @jeff-phillips-18 