### PR TITLE
firehose: add optimization for those who do not require mapped redux data to JS

### DIFF
--- a/frontend/__tests__/components/utils/firehose.spec.tsx
+++ b/frontend/__tests__/components/utils/firehose.spec.tsx
@@ -11,6 +11,7 @@ import { FirehoseResource } from '../../../public/components/utils';
 // TODO(alecmerdler): Use these once `Firehose` is converted to TypeScript
 type FirehoseProps = {
   expand?: boolean;
+  doNotConnectToState?: boolean;
   resources: FirehoseResource[];
 
   // Provided by `connect`

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -509,7 +509,7 @@ export const CreateVMWizardPageComponent: React.FC<CreateVMWizardPageComponentPr
   dataIDReferences[VMWizardProps.activeNamespace] = ['UI', 'activeNamespace'];
 
   return (
-    <Firehose resources={resources}>
+    <Firehose resources={resources} doNotConnectToState>
       <CreateVMWizard
         isCreateTemplate={!path.includes('/virtualmachines/')}
         isProviderImport={new URLSearchParams(search).get('mode') === 'import'}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/providers/vmware-import-provider/vmware-import-provider.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/providers/vmware-import-provider/vmware-import-provider.tsx
@@ -207,7 +207,7 @@ const VMWareImportProviderConnected: React.FC<VMWareImportProviderConnectedProps
   }
 
   return (
-    <Firehose resources={resources}>
+    <Firehose resources={resources} doNotConnectToState>
       <VMWareImportProviderFirehose {...rest} dataIDReferences={makeIDReferences(resources)} />
     </Firehose>
   );


### PR DESCRIPTION
kubevirt VM Wizard uses firehose only to start watching resources and does not require connecting to state by the firehose and subsequent mapping of immutables to JS