### PR TITLE
kubevirt: make VM Wizard errors more explicit

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.scss
@@ -1,5 +1,4 @@
 .kubevirt-create-vm-modal__footer-error {
   width: 100%;
   margin-bottom: 1em;
-  align-items: center;
 }

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard-footer.tsx
@@ -12,9 +12,10 @@ import {
 import * as _ from 'lodash';
 import { Prompt } from 'react-router';
 import { useShowErrorToggler } from '../../hooks/use-show-error-toggler';
-import { getDialogUIError } from '../../utils/strings';
+import { getDialogUIError, getSimpleDialogUIError } from '../../utils/strings';
 import { ALL_VM_WIZARD_TABS, VMWizardProps, VMWizardTab } from './types';
 import {
+  getStepError,
   hasStepAllRequiredFilled,
   isStepLocked,
   isStepValid,
@@ -54,6 +55,8 @@ const CreateVMWizardFooterComponent: React.FC<CreateVMWizardFooterComponentProps
         const activeStepID = activeStep.id as VMWizardTab;
         const isLocked = _.some(ALL_VM_WIZARD_TABS, (id) => isStepLocked(stepData, id));
         const isValid = isStepValid(stepData, activeStepID);
+        const hasStepAllRequired = hasStepAllRequiredFilled(stepData, activeStepID);
+        const stepError = getStepError(stepData, activeStepID);
         checkValidity(isValid);
 
         const isFirstStep = activeStepID === VMWizardTab.VM_SETTINGS;
@@ -79,11 +82,17 @@ const CreateVMWizardFooterComponent: React.FC<CreateVMWizardFooterComponentProps
             />
             {!isValid && showError && (
               <Alert
-                title={getDialogUIError(hasStepAllRequiredFilled(stepData, activeStepID))}
+                title={
+                  stepError
+                    ? getSimpleDialogUIError(hasStepAllRequired)
+                    : getDialogUIError(hasStepAllRequired)
+                }
                 isInline
                 variant="danger"
                 className="kubevirt-create-vm-modal__footer-error"
-              />
+              >
+                {stepError}
+              </Alert>
             )}
             {!isLastStep && (
               <Button

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/cloud-init-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/cloud-init-tab-initial-state.ts
@@ -1,12 +1,14 @@
 import { CloudInitField } from '../../types';
+import { InitialStepStateGetter } from './types';
 
-export const getCloudInitInitialState = () => ({
+export const getCloudInitInitialState: InitialStepStateGetter = () => ({
   value: {
     [CloudInitField.IS_FORM]: {
       value: true,
     },
   },
+  error: null,
   isValid: true,
   hasAllRequiredFilled: true,
-  error: null,
+  isLocked: false,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/cloud-init-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/cloud-init-tab-initial-state.ts
@@ -8,4 +8,5 @@ export const getCloudInitInitialState = () => ({
   },
   isValid: true,
   hasAllRequiredFilled: true,
+  error: null,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/initial-state.ts
@@ -5,8 +5,9 @@ import { getStorageInitialState } from './storage-tab-initial-state';
 import { getResultInitialState } from './result-tab-initial-state';
 import { getReviewInitialState } from './review-tab-initial-state';
 import { getCloudInitInitialState } from './cloud-init-tab-initial-state';
+import { InitialStepStateGetter, StepState } from './types';
 
-const initialStateGetterResolver = {
+const initialStateGetterResolver: { [key in VMWizardTab]: InitialStepStateGetter } = {
   [VMWizardTab.VM_SETTINGS]: getVmSettingsInitialState,
   [VMWizardTab.NETWORKING]: getNetworksInitialState,
   [VMWizardTab.STORAGE]: getStorageInitialState,
@@ -15,12 +16,12 @@ const initialStateGetterResolver = {
   [VMWizardTab.RESULT]: getResultInitialState,
 };
 
-export const getTabInitialState = (tabKey: VMWizardTab, props: CommonData) => {
+export const getTabInitialState = (tabKey: VMWizardTab, data: CommonData): StepState => {
   const getter = initialStateGetterResolver[tabKey];
 
-  let result;
+  let result: StepState;
   if (getter) {
-    result = getter(props);
+    result = getter(data);
   }
 
   return (

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/initial-state.ts
@@ -23,5 +23,13 @@ export const getTabInitialState = (tabKey: VMWizardTab, props: CommonData) => {
     result = getter(props);
   }
 
-  return result || { value: {}, isValid: false, isLocked: false, hasAllRequiredFilled: false };
+  return (
+    result || {
+      value: {},
+      error: null,
+      isValid: false,
+      isLocked: false,
+      hasAllRequiredFilled: false,
+    }
+  );
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/networks-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/networks-tab-initial-state.ts
@@ -3,6 +3,7 @@ import { NetworkInterfaceWrapper } from '../../../../k8s/wrapper/vm/network-inte
 import { NetworkInterfaceModel, NetworkType } from '../../../../constants/vm/network';
 import { NetworkWrapper } from '../../../../k8s/wrapper/vm/network-wrapper';
 import { getSequenceName } from '../../../../utils/strings';
+import { InitialStepStateGetter } from './types';
 
 export const podNetwork: VMWizardNetwork = {
   id: '0',
@@ -18,9 +19,10 @@ export const podNetwork: VMWizardNetwork = {
   }).asResource(),
 };
 
-export const getNetworksInitialState = () => ({
+export const getNetworksInitialState: InitialStepStateGetter = () => ({
   value: [podNetwork],
-  isValid: true,
-  hasAllRequiredFilled: true,
   error: null,
+  hasAllRequiredFilled: true,
+  isValid: true,
+  isLocked: false,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/networks-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/networks-tab-initial-state.ts
@@ -22,4 +22,5 @@ export const getNetworksInitialState = () => ({
   value: [podNetwork],
   isValid: true,
   hasAllRequiredFilled: true,
+  error: null,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/providers/vmware-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/providers/vmware-initial-state.ts
@@ -1,8 +1,9 @@
 import { VMImportProvider, VMWareProviderField } from '../../../types';
 import { asDisabled, asHidden } from '../../../utils/utils';
 import { V2VVMwareStatus } from '../../../../../statuses/v2vvmware';
+import { VMwareSettings } from '../types';
 
-export const getVmWareInitialState = () => {
+export const getVmWareInitialState = (): VMwareSettings => {
   const hiddenByVCenter = asHidden(true, VMWareProviderField.VCENTER);
   const fields = {
     [VMWareProviderField.VCENTER]: {},

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/result-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/result-tab-initial-state.ts
@@ -1,10 +1,14 @@
-export const getResultInitialState = () => ({
+import { InitialStepStateGetter } from './types';
+
+export const getResultInitialState: InitialStepStateGetter = () => ({
   value: {
     mainError: null,
     errors: [],
     requestResults: [],
   },
+  error: null,
+  isLocked: false,
+  hasAllRequiredFilled: null,
   isValid: null,
   isPending: false,
-  error: null,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/result-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/result-tab-initial-state.ts
@@ -6,4 +6,5 @@ export const getResultInitialState = () => ({
   },
   isValid: null,
   isPending: false,
+  error: null,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/review-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/review-tab-initial-state.ts
@@ -2,4 +2,5 @@ export const getReviewInitialState = () => ({
   value: {},
   isValid: true,
   hasAllRequiredFilled: true,
+  error: null,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/review-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/review-tab-initial-state.ts
@@ -1,6 +1,9 @@
-export const getReviewInitialState = () => ({
+import { InitialStepStateGetter } from './types';
+
+export const getReviewInitialState: InitialStepStateGetter = () => ({
   value: {},
+  error: null,
   isValid: true,
   hasAllRequiredFilled: true,
-  error: null,
+  isLocked: false,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/storage-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/storage-tab-initial-state.ts
@@ -13,6 +13,7 @@ import { ProvisionSource } from '../../../../constants/vm/provision-source';
 import { VM_TEMPLATE_NAME_PARAMETER } from '../../../../constants/vm-templates';
 import { BinaryUnit } from '../../../form/size-unit-utils';
 import { WINTOOLS_CONTAINER_NAMES } from '../../../modals/cdrom-vm-modal/constants';
+import { InitialStepStateGetter } from './types';
 
 const ROOT_DISK_NAME = 'rootdisk';
 const WINTOOLS_DISK_NAME = 'windows-guest-tools';
@@ -80,9 +81,10 @@ export const getProvisionSourceStorage = (provisionSource: ProvisionSource): VMW
   return null;
 };
 
-export const getStorageInitialState = () => ({
+export const getStorageInitialState: InitialStepStateGetter = () => ({
   value: [],
   error: null,
-  isValid: true, // empty Storages are valid
   hasAllRequiredFilled: true,
+  isValid: true, // empty Storages are valid
+  isLocked: false,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/storage-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/storage-tab-initial-state.ts
@@ -82,6 +82,7 @@ export const getProvisionSourceStorage = (provisionSource: ProvisionSource): VMW
 
 export const getStorageInitialState = () => ({
   value: [],
+  error: null,
   isValid: true, // empty Storages are valid
   hasAllRequiredFilled: true,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/types.ts
@@ -1,0 +1,32 @@
+import { CommonData, VMImportProvider, VMSettingsField, VMWareProviderField } from '../../types';
+
+export type StepState = {
+  value: any;
+  error: string;
+  isValid: boolean;
+  isLocked: boolean;
+  hasAllRequiredFilled: boolean;
+};
+
+export type InitialStepStateGetter = (data: CommonData) => StepState;
+
+export type FieldMultiFlag = { [k: string]: boolean };
+
+type SettingsField = {
+  key?: VMSettingsField | VMWareProviderField;
+  value?: any;
+  isHidden?: FieldMultiFlag;
+  isRequired?: FieldMultiFlag;
+  skipValidation?: boolean;
+};
+
+export type VMwareSettings = { [key in VMWareProviderField]: SettingsField } & {
+  [VMWareProviderField.V2V_NAME]: string;
+  [VMWareProviderField.NEW_VCENTER_NAME]: string;
+};
+
+export type VMSettings = { [key in VMSettingsField]: SettingsField } & {
+  [VMSettingsField.PROVIDERS_DATA]: {
+    [VMImportProvider.VMWARE]?: VMwareSettings;
+  };
+};

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
@@ -4,6 +4,22 @@ import { asHidden, asRequired } from '../../utils/utils';
 import { ProvisionSource } from '../../../../constants/vm/provision-source';
 import { getProviders } from '../../provider-definitions';
 
+export const vmSettingsOrder = {
+  [VMSettingsField.PROVIDER]: 0,
+  [VMSettingsField.USER_TEMPLATE]: 1,
+  [VMSettingsField.PROVISION_SOURCE_TYPE]: 2,
+  [VMSettingsField.CONTAINER_IMAGE]: 3,
+  [VMSettingsField.IMAGE_URL]: 4,
+  [VMSettingsField.OPERATING_SYSTEM]: 5,
+  [VMSettingsField.FLAVOR]: 6,
+  [VMSettingsField.MEMORY]: 7,
+  [VMSettingsField.CPU]: 8,
+  [VMSettingsField.WORKLOAD_PROFILE]: 9,
+  [VMSettingsField.NAME]: 10,
+  [VMSettingsField.DESCRIPTION]: 11,
+  [VMSettingsField.START_VM]: 12,
+};
+
 export const getInitialVmSettings = (common: CommonData) => {
   const {
     data: { isCreateTemplate, isProviderImport },
@@ -77,5 +93,6 @@ export const getInitialVmSettings = (common: CommonData) => {
 
 export const getVmSettingsInitialState = (props) => ({
   value: getInitialVmSettings(props),
+  error: null,
   isValid: false,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
@@ -3,6 +3,7 @@ import { CommonData, VMSettingsField, VMWizardProps } from '../../types';
 import { asHidden, asRequired } from '../../utils/utils';
 import { ProvisionSource } from '../../../../constants/vm/provision-source';
 import { getProviders } from '../../provider-definitions';
+import { InitialStepStateGetter, VMSettings } from './types';
 
 export const vmSettingsOrder = {
   [VMSettingsField.PROVIDER]: 0,
@@ -20,10 +21,10 @@ export const vmSettingsOrder = {
   [VMSettingsField.START_VM]: 12,
 };
 
-export const getInitialVmSettings = (common: CommonData) => {
+export const getInitialVmSettings = (data: CommonData): VMSettings => {
   const {
     data: { isCreateTemplate, isProviderImport },
-  } = common;
+  } = data;
 
   const hiddenByProvider = asHidden(isProviderImport, VMWizardProps.isProviderImport);
   const hiddenByProviderOrTemplate = isProviderImport
@@ -39,6 +40,7 @@ export const getInitialVmSettings = (common: CommonData) => {
     [VMSettingsField.NAME]: {
       isRequired: asRequired(true),
     },
+    [VMSettingsField.HOSTNAME]: {},
     [VMSettingsField.DESCRIPTION]: {},
     [VMSettingsField.USER_TEMPLATE]: {
       isHidden: hiddenByProviderOrTemplate,
@@ -91,8 +93,10 @@ export const getInitialVmSettings = (common: CommonData) => {
   return fields;
 };
 
-export const getVmSettingsInitialState = (props) => ({
-  value: getInitialVmSettings(props),
+export const getVmSettingsInitialState: InitialStepStateGetter = (data) => ({
+  value: getInitialVmSettings(data),
   error: null,
+  hasAllRequiredFilled: false,
   isValid: false,
+  isLocked: false,
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/internal-actions.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/internal-actions.ts
@@ -47,12 +47,14 @@ export const vmWizardInternalActions: VMWizardInternalActions = {
     tab: VMWizardTab,
     isValid: boolean,
     hasAllRequiredFilled: boolean,
+    error: string,
   ) => ({
     payload: {
       id,
       tab,
       isValid,
       hasAllRequiredFilled,
+      error,
     },
     type: InternalActionType.SetTabValidity,
   }),

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/reducers.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/reducers.ts
@@ -184,7 +184,8 @@ export default (state, action: WizardInternalAction) => {
         .setIn(
           [dialogID, 'tabs', payload.tab, 'hasAllRequiredFilled'],
           payload.hasAllRequiredFilled,
-        );
+        )
+        .setIn([dialogID, 'tabs', payload.tab, 'error'], payload.error);
     case InternalActionType.SetTabLocked:
       return state.setIn([dialogID, 'tabs', payload.tab, 'isLocked'], payload.isLocked);
     case InternalActionType.SetVmSettingsFieldValue:

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/types.ts
@@ -76,6 +76,7 @@ export type WizardInternalAction = {
     deviceID?: string;
     deviceType?: DeviceType;
     bootOrder?: number;
+    error?: string;
   };
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/vm-settings-tab-validation.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/vm-settings-tab-validation.ts
@@ -153,10 +153,25 @@ export const validateVmSettings = (options: UpdateOptions) => {
 };
 
 const describeFields = (describe: string, fields: string[]) => {
-  if (fields.length > 0) {
-    const describedFields = fields
-      .sort((a, b) => vmSettingsOrder[iGetFieldKey(a)] - vmSettingsOrder[iGetFieldKey(b)])
-      .map((field) => getFieldReadableTitle(iGetFieldKey(field)));
+  if (fields && fields.length > 0) {
+    const describedFields = _.compact(
+      fields
+        .sort((a, b) => {
+          const aValue = vmSettingsOrder[iGetFieldKey(a)];
+          const bValue = vmSettingsOrder[iGetFieldKey(b)];
+
+          if (bValue == null) {
+            return -1;
+          }
+
+          if (aValue == null) {
+            return 1;
+          }
+
+          return aValue - bValue;
+        })
+        .map((field) => getFieldReadableTitle(iGetFieldKey(field))),
+    );
     return makeSentence(
       `${assureEndsWith(describe, ' ')}the following ${pluralize(
         fields.length,

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/vm-settings-tab-validation.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/vm-settings-tab-validation.ts
@@ -1,10 +1,11 @@
-import { isEmpty } from 'lodash';
+import * as _ from 'lodash';
 import { List } from 'immutable';
 import {
   asValidationObject,
   ValidationErrorType,
   ValidationObject,
 } from '@console/shared/src/utils/validation';
+import { assureEndsWith, joinGrammaticallyListOfItems, makeSentence } from '@console/shared/src';
 import { VMSettingsField, VMWizardProps, VMWizardTab } from '../../types';
 import {
   hasVmSettingsChanged,
@@ -29,7 +30,7 @@ import {
   VIRTUAL_MACHINE_TEMPLATE_EXISTS,
 } from '../../../../utils/validations/strings';
 import { concatImmutableLists, iGet } from '../../../../utils/immutable';
-import { getFieldTitle } from '../../utils/vm-settings-tab-utils';
+import { getFieldReadableTitle, getFieldTitle } from '../../utils/vm-settings-tab-utils';
 import {
   checkTabValidityChanged,
   iGetCommonData,
@@ -38,6 +39,8 @@ import {
   immutableListToShallowMetadataJS,
 } from '../../selectors/immutable/selectors';
 import { validatePositiveInteger } from '../../../../utils/validations/common';
+import { pluralize } from '../../../../utils/strings';
+import { vmSettingsOrder } from '../initial-state/vm-settings-tab-initial-state';
 import { getValidationUpdate } from './utils';
 
 const validateVm: VmSettingsValidator = (field, options) => {
@@ -144,9 +147,25 @@ export const validateVmSettings = (options: UpdateOptions) => {
 
   const update = getValidationUpdate(validationConfig, options, vmSettings, hasVmSettingsChanged);
 
-  if (!isEmpty(update)) {
+  if (!_.isEmpty(update)) {
     dispatch(vmWizardInternalActions[InternalActionType.UpdateVmSettings](id, update));
   }
+};
+
+const describeFields = (describe: string, fields: string[]) => {
+  if (fields.length > 0) {
+    const describedFields = fields
+      .sort((a, b) => vmSettingsOrder[iGetFieldKey(a)] - vmSettingsOrder[iGetFieldKey(b)])
+      .map((field) => getFieldReadableTitle(iGetFieldKey(field)));
+    return makeSentence(
+      `${assureEndsWith(describe, ' ')}the following ${pluralize(
+        fields.length,
+        'field',
+      )}: ${joinGrammaticallyListOfItems(describedFields)}.`,
+      false,
+    );
+  }
+  return null;
 };
 
 export const setVmSettingsTabValidity = (options: UpdateOptions) => {
@@ -155,25 +174,40 @@ export const setVmSettingsTabValidity = (options: UpdateOptions) => {
   const vmSettings = iGetVmSettings(state, id);
 
   // check if all required fields are defined
-  const hasAllRequiredFilled = vmSettings
-    .filter((field) => isFieldRequired(field) && !field.get('skipValidation'))
-    .every((field) => field.get('value'));
-  let isValid = hasAllRequiredFilled;
+  const emptyRequiredFields = vmSettings
+    .filter(
+      (field) => isFieldRequired(field) && !field.get('skipValidation') && !field.get('value'),
+    )
+    .toArray();
+  let error = describeFields('Please fill in', emptyRequiredFields);
+  const hasAllRequiredFilled = emptyRequiredFields.length === 0;
 
-  if (isValid) {
-    // check if all fields are valid
-    isValid = vmSettings.every(
-      (field) => field.getIn(['validation', 'type']) !== ValidationErrorType.Error,
-    );
+  // check if fields are valid
+  const invalidFields = vmSettings
+    .filter((field) => field.getIn(['validation', 'type']) === ValidationErrorType.Error)
+    .toArray();
+  if (invalidFields.length > 0) {
+    error = describeFields('Please correct', invalidFields);
   }
+  const isValid = hasAllRequiredFilled && invalidFields.length === 0;
 
-  if (checkTabValidityChanged(state, id, VMWizardTab.VM_SETTINGS, isValid, hasAllRequiredFilled)) {
+  if (
+    checkTabValidityChanged(
+      state,
+      id,
+      VMWizardTab.VM_SETTINGS,
+      isValid,
+      hasAllRequiredFilled,
+      error,
+    )
+  ) {
     dispatch(
       vmWizardInternalActions[InternalActionType.SetTabValidity](
         id,
         VMWizardTab.VM_SETTINGS,
         isValid,
         hasAllRequiredFilled,
+        error,
       ),
     );
   }

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/selectors.ts
@@ -2,7 +2,7 @@ import { K8sResourceKind } from '@console/internal/module/k8s';
 import { iGet, iGetIn, iGetLoadedData } from '../../../../utils/immutable';
 import { getCreateVMWizards } from '../selectors';
 import { CommonDataProp, VMWizardTab } from '../../types';
-import { hasStepAllRequiredFilled, isStepValid } from './wizard-selectors';
+import { getStepError, hasStepAllRequiredFilled, isStepValid } from './wizard-selectors';
 
 export const iGetCreateVMWizard = (state, reduxID: string) =>
   iGet(getCreateVMWizards(state), reduxID);
@@ -13,13 +13,15 @@ export const checkTabValidityChanged = (
   state,
   reduxID: string,
   tab: VMWizardTab,
-  nextIsValid,
-  nextHasAllRequiredFilled,
+  nextIsValid: boolean,
+  nextHasAllRequiredFilled: boolean,
+  nextError,
 ) => {
   const tabs = iGetCreateVMWizardTabs(state, reduxID);
   return (
     isStepValid(tabs, tab) !== nextIsValid ||
-    hasStepAllRequiredFilled(tabs, tab) !== nextHasAllRequiredFilled
+    hasStepAllRequiredFilled(tabs, tab) !== nextHasAllRequiredFilled ||
+    getStepError(tabs, tab) !== nextError
   );
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/wizard-selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/wizard-selectors.ts
@@ -11,6 +11,7 @@ export const isStepPending = (stepData, stepId: VMWizardTab) =>
   !!iGetIn(stepData, [stepId, 'isPending']);
 export const hasStepAllRequiredFilled = (stepData, stepId: VMWizardTab) =>
   !!iGetIn(stepData, [stepId, 'hasAllRequiredFilled']);
+export const getStepError = (stepData, stepId: VMWizardTab) => iGetIn(stepData, [stepId, 'error']);
 
 export const isWizardEmpty = (stepData, isProviderImport) => {
   const networks = iGetIn(stepData, [VMWizardTab.NETWORKING, 'value']);

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/cloud-init-tab/cloud-init-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/cloud-init-tab/cloud-init-tab.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { confirmModal } from '@console/internal/components/modals';
+import { joinGrammaticallyListOfItems } from '@console/shared/src';
 import { CloudInitField, VMWizardStorage, VMWizardStorageType } from '../../types';
 import { vmWizardActions } from '../../redux/actions';
 import { ActionType } from '../../redux/types';
@@ -30,6 +31,7 @@ import { iGetCloudInitValue } from '../../selectors/immutable/cloud-init';
 import {
   CloudInitDataFormKeys,
   CloudInitDataHelper,
+  formAllowedKeys,
 } from '../../../../k8s/wrapper/vm/cloud-init-data-helper';
 
 import './cloud-init-tab.scss';
@@ -240,10 +242,23 @@ const CloudInitTabComponent: React.FC<ResultTabComponentProps> = ({
       if (cloudInitData.includesOnlyFormValues()) {
         executeFn();
       } else {
+        const persistedKeys = [...formAllowedKeys].filter((key) => cloudInitData.has(key));
         confirmModal({
-          title: 'Irreversible operation',
-          message: 'Are you sure you want to discard some of the cloudInit options?',
-          btnText: 'Yes',
+          title: 'Data loss confirmation',
+          message: (
+            <>
+              When using the Cloud-init form, custom values can not be applied and will be
+              discarded.
+              {persistedKeys.length === 0
+                ? ''
+                : ` The following fields will be kept: ${joinGrammaticallyListOfItems(
+                    persistedKeys,
+                  )}.`}{' '}
+              <br />
+              Are you sure you want to want to take this action?{' '}
+            </>
+          ),
+          btnText: 'Confirm',
           executeFn,
         });
       }

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/network-boot-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/network-boot-source.tsx
@@ -13,12 +13,14 @@ type NetworkBootSourceProps = {
   isDisabled: boolean;
   networks: VMWizardNetworkWithWrappers[];
   onBootOrderChanged: (deviceID: string, bootOrder: number) => void;
+  className?: string;
 };
 
 export const NetworkBootSource: React.FC<NetworkBootSourceProps> = ({
   isDisabled,
   onBootOrderChanged,
   networks,
+  className,
 }) => {
   const pxeNetworks = networks.filter((n) => !n.networkWrapper.isPodNetwork());
   const hasPXENetworks = pxeNetworks.length > 0;
@@ -28,7 +30,7 @@ export const NetworkBootSource: React.FC<NetworkBootSourceProps> = ({
   );
 
   return (
-    <Form>
+    <Form className={className}>
       <FormRow
         title="Boot Source"
         fieldId={PXE_BOOTSOURCE_ID}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/networking-tab.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/networking-tab.scss
@@ -4,11 +4,6 @@
   min-height: 100%;
 }
 
-.kubevirt-create-vm-modal__networking-tab-main {
-  flex: 1;
-}
-
 .kubevirt-create-vm-modal__networking-tab-pxe {
-  margin-top: 1rem;
-  margin-bottom: 3rem;
+  margin-top: 2rem;
 }

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/networking-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/networking-tab.tsx
@@ -88,22 +88,19 @@ const NetworkingTabComponent: React.FC<NetworkingTabComponentProps> = ({
       </Split>
       {showNetworks && (
         <>
-          <div className="kubevirt-create-vm-modal__networking-tab-main">
-            <VMNicsTable
-              columnClasses={nicTableColumnClasses}
-              data={getNicsData(networks)}
-              customData={{ isDisabled: isLocked, withProgress, removeNIC, wizardReduxID }}
-              row={VMWizardNicRow}
-            />
-          </div>
+          <VMNicsTable
+            columnClasses={nicTableColumnClasses}
+            data={getNicsData(networks)}
+            customData={{ isDisabled: isLocked, withProgress, removeNIC, wizardReduxID }}
+            row={VMWizardNicRow}
+          />
           {isBootNICRequired && (
-            <footer className="kubevirt-create-vm-modal__networking-tab-pxe">
-              <NetworkBootSource
-                isDisabled={isLocked}
-                networks={networks}
-                onBootOrderChanged={onBootOrderChanged}
-              />
-            </footer>
+            <NetworkBootSource
+              className="kubevirt-create-vm-modal__networking-tab-pxe"
+              isDisabled={isLocked}
+              networks={networks}
+              onBootOrderChanged={onBootOrderChanged}
+            />
           )}
         </>
       )}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-boot-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-boot-source.tsx
@@ -14,12 +14,14 @@ type StorageBootOrderProps = {
   isDisabled: boolean;
   storages: VMWizardStorageWithWrappers[];
   onBootOrderChanged: (deviceID: string, bootOrder: number) => void;
+  className: string;
 };
 
 export const StorageBootSource: React.FC<StorageBootOrderProps> = ({
   isDisabled,
   onBootOrderChanged,
   storages,
+  className,
 }) => {
   const filteredStorages = storages.filter(({ volumeWrapper, dataVolumeWrapper }) =>
     [StorageUISource.ATTACH_DISK, StorageUISource.ATTACH_CLONED_DISK].includes(
@@ -36,7 +38,7 @@ export const StorageBootSource: React.FC<StorageBootOrderProps> = ({
   );
 
   return (
-    <Form>
+    <Form className={className}>
       <FormRow
         title="Boot Source"
         fieldId={STORAGE_BOOT_SOURCE}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.scss
@@ -4,11 +4,6 @@
   min-height: 100%;
 }
 
-.kubevirt-create-vm-modal__storage-tab-main {
-  flex: 1;
-}
-
 .kubevirt-create-vm-modal__storage-tab-boot-select {
-  margin-top: 1rem;
-  margin-bottom: 3rem;
+  margin-top: 2rem;
 }

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
@@ -118,22 +118,19 @@ const StorageTabFirehose: React.FC<StorageTabFirehoseProps> = ({
       </Split>
       {showStorages && (
         <>
-          <div className="kubevirt-create-vm-modal__storage-tab-main">
-            <VMDisksTable
-              columnClasses={diskTableColumnClasses}
-              data={getStoragesData(storages, persistentVolumeClaims)}
-              customData={{ isDisabled: isLocked, withProgress, removeStorage, wizardReduxID }}
-              row={VmWizardStorageRow}
-            />
-          </div>
+          <VMDisksTable
+            columnClasses={diskTableColumnClasses}
+            data={getStoragesData(storages, persistentVolumeClaims)}
+            customData={{ isDisabled: isLocked, withProgress, removeStorage, wizardReduxID }}
+            row={VmWizardStorageRow}
+          />
           {isBootDiskRequired && (
-            <footer className="kubevirt-create-vm-modal__storage-tab-boot-select">
-              <StorageBootSource
-                isDisabled={isLocked}
-                storages={storages}
-                onBootOrderChanged={onBootOrderChanged}
-              />
-            </footer>
+            <StorageBootSource
+              className="kubevirt-create-vm-modal__storage-tab-boot-select"
+              isDisabled={isLocked}
+              storages={storages}
+              onBootOrderChanged={onBootOrderChanged}
+            />
           )}
         </>
       )}

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/utils/vm-settings-tab-utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/utils/vm-settings-tab-utils.ts
@@ -33,6 +33,12 @@ const idResolver: VMSettingsRenderableFieldResolver = {
 export const getFieldId = (key: VMSettingsRenderableField | VMWareProviderField) => idResolver[key];
 export const getFieldTitle = (key: VMSettingsRenderableField | VMWareProviderField) =>
   titleResolver[key];
+export const getFieldReadableTitle = (key: VMSettingsRenderableField | VMWareProviderField) => {
+  if (key === VMSettingsField.MEMORY) {
+    return 'Memory';
+  }
+  return titleResolver[key];
+};
 export const getPlaceholder = (key: VMSettingsRenderableField | VMWareProviderField) =>
   placeholderResolver[key];
 export const getFieldHelp = (

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/utils/vm-settings-tab-utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/utils/vm-settings-tab-utils.ts
@@ -4,7 +4,7 @@ import {
   VMSettingsRenderableFieldResolver,
   VMWareProviderField,
 } from '../types';
-import { titleResolver, placeholderResolver, helpResolver } from '../strings/vm-settings';
+import { helpResolver, placeholderResolver, titleResolver } from '../strings/vm-settings';
 
 const idResolver: VMSettingsRenderableFieldResolver = {
   [VMWareProviderField.VCENTER]: 'vcenter-instance-dropdown',

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/cloud-init-data-helper.tsx
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/cloud-init-data-helper.tsx
@@ -17,7 +17,7 @@ export enum CloudInitDataFormKeys {
 }
 export const CLOUD_CONFIG_HEADER = '#cloud-config';
 
-const formAllowedKeys = new Set([
+export const formAllowedKeys = new Set([
   CloudInitDataFormKeys.NAME,
   CloudInitDataFormKeys.HOSTNAME,
   CloudInitDataFormKeys.SSH_AUTHORIZED_KEYS,

--- a/frontend/packages/kubevirt-plugin/src/utils/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/strings.ts
@@ -12,6 +12,9 @@ export const getDialogUIError = (hasAllRequiredFilled) =>
     ? 'Please correct the invalid fields.'
     : 'Please fill in all required fields.';
 
+export const getSimpleDialogUIError = (hasAllRequiredFilled) =>
+  hasAllRequiredFilled ? 'Some fields are not correct' : 'Required fields not completed';
+
 export const getCheckboxReadableValue = (value: boolean) => (value ? 'yes' : 'no');
 
 export const getSequenceName = (name: string, usedSequenceNames?: Set<string>) => {
@@ -27,3 +30,6 @@ export const getSequenceName = (name: string, usedSequenceNames?: Set<string>) =
   }
   return null;
 };
+
+export const pluralize = (i: number, singular: string, plural: string = `${singular}s`) =>
+  i === 1 ? singular : plural;


### PR DESCRIPTION
depends on:
- [x] https://github.com/openshift/console/pull/3562

VM Wizard changes:

#### General 
describe error form fields inside the footer
- mention all fields which include an error
- once those are fixed mention empty required fields
- fix disk/pxe boot source positioning

![fill](https://user-images.githubusercontent.com/3648838/69657012-df337480-1079-11ea-971a-a5101296bcb3.png)

![fill-a](https://user-images.githubusercontent.com/3648838/69657020-e195ce80-1079-11ea-80eb-adeadfce9ef1.png)

![fill-b](https://user-images.githubusercontent.com/3648838/69657025-e3f82880-1079-11ea-9918-568e05b1c566.png)


#### Cloud Init 

- make discard dialog more explicit
![clinit](https://user-images.githubusercontent.com/3648838/69657030-e6f31900-1079-11ea-93fe-79761ab516c7.png)

![clinit2](https://user-images.githubusercontent.com/3648838/69657033-e9557300-1079-11ea-9aa5-e575469cfefe.png)
