### PR TITLE
Bug 1777177: Query Browser: Fix Switch to enable when inserting example query

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -813,6 +813,7 @@ const Query_: React.FC<QueryProps> = ({
   patchQuery,
   toggleIsEnabled,
 }) => {
+  const switchKey = `${id}-${isEnabled}`;
   const switchLabel = `${isEnabled ? 'Disable' : 'Enable'} query`;
 
   const toggleIsExpanded = () => patchQuery({ isExpanded: !isExpanded });
@@ -829,9 +830,9 @@ const Query_: React.FC<QueryProps> = ({
         <div title={switchLabel}>
           <Switch
             aria-label={switchLabel}
-            id={id}
+            id={switchKey}
             isChecked={isEnabled}
-            key={id}
+            key={switchKey}
             onChange={toggleIsEnabled}
           />
         </div>


### PR DESCRIPTION
Inserting an example query sets `isEnalbed` to `true` for the query in
Redux, but that was not causing the `Switch` to update.