### PR TITLE
fix(knative-icons): show icons for event sources

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/get-knative-icon.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-icon.ts
@@ -1,21 +1,29 @@
+import { referenceForModel } from '@console/internal/module/k8s';
 import * as openshiftImg from '@console/internal/imgs/logos/openshift.svg';
 import * as apiServerSourceImg from '../imgs/logos/apiserversource.png';
 import * as camelSourceImg from '../imgs/logos/camelsource.svg';
 import * as containerSourceImg from '../imgs/logos/containersource.png';
 import * as cronJobSourceImg from '../imgs/logos/cronjobsource.png';
 import * as kafkaSourceImg from '../imgs/logos/kafkasource.svg';
+import {
+  EventSourceCronJobModel,
+  EventSourceContainerModel,
+  EventSourceApiServerModel,
+  EventSourceCamelModel,
+  EventSourceKafkaModel,
+} from '../models';
 
 export const getKnativeEventSourceIcon = (kind: string): string => {
   switch (kind) {
-    case 'ApiServerSource':
+    case referenceForModel(EventSourceApiServerModel):
       return apiServerSourceImg;
-    case 'CamelSource':
+    case referenceForModel(EventSourceCamelModel):
       return camelSourceImg;
-    case 'ContainerSource':
+    case referenceForModel(EventSourceContainerModel):
       return containerSourceImg;
-    case 'CronJobSource':
+    case referenceForModel(EventSourceCronJobModel):
       return cronJobSourceImg;
-    case 'KafkaSource':
+    case referenceForModel(EventSourceKafkaModel):
       return kafkaSourceImg;
     default:
       return openshiftImg;


### PR DESCRIPTION
This PR -
* fixes the issue in the jira issue https://jira.coreos.com/browse/ODC-2156
* makes icons for different event sources visible for the corresponding event source in topology
Screen -
![event_source_icons](https://user-images.githubusercontent.com/38663217/69815850-2f970780-121d-11ea-887a-5903c189f51b.png)
