### PR TITLE
Add new fieldDependency descriptor to OLM create operand form

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
@@ -388,6 +388,19 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
 
   // TODO(alecmerdler): Move this into a single `<SpecDescriptorInput>` entry component in the `descriptors/` directory
   const inputFor = (field: OperandField) => {
+    if (field.capabilities.find((c) => c.startsWith(SpecCapability.fieldDependency))) {
+      const masterFieldInfo = field.capabilities
+        .find((c) => c.startsWith(SpecCapability.fieldDependency))
+        .split(SpecCapability.fieldDependency)[1];
+      const currentMasterFieldValue = !_.isNil(formValues[masterFieldInfo.split(':')[0]])
+        ? formValues[masterFieldInfo.split(':')[0]].toString()
+        : null;
+      const expectedMasterFieldValue = masterFieldInfo.split(':')[1];
+
+      if (currentMasterFieldValue !== expectedMasterFieldValue) {
+        return null;
+      }
+    }
     if (field.capabilities.includes(SpecCapability.podCount)) {
       return (
         <NumberSpinner
@@ -710,41 +723,43 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
                 .filter((f) => !_.isNil(inputFor(f)));
 
               return (
-                <div id={group} key={group}>
-                  <FieldGroup
-                    defaultExpand={
-                      !_.some(
-                        fieldList,
-                        (f) => f.capabilities.includes(SpecCapability.advanced) && !f.required,
-                      )
-                    }
-                    groupName={groupName}
-                  >
-                    {fieldList.map((field) => (
-                      <div key={field.path}>
-                        <div className="form-group co-create-operand__form-group">
-                          <label
-                            className={classNames('form-label', {
-                              'co-required': field.required,
-                            })}
-                            htmlFor={field.path}
-                          >
-                            {field.displayName}
-                          </label>
-                          {inputFor(field)}
-                          {field.description && (
-                            <span id={`${field.path}__description`} className="help-block">
-                              {field.description}
-                            </span>
-                          )}
-                          {formErrors[field.path] && (
-                            <span className="co-error">{formErrors[field.path]}</span>
-                          )}
+                !_.isEmpty(fieldList) && (
+                  <div id={group} key={group}>
+                    <FieldGroup
+                      defaultExpand={
+                        !_.some(
+                          fieldList,
+                          (f) => f.capabilities.includes(SpecCapability.advanced) && !f.required,
+                        )
+                      }
+                      groupName={groupName}
+                    >
+                      {fieldList.map((field) => (
+                        <div key={field.path}>
+                          <div className="form-group co-create-operand__form-group">
+                            <label
+                              className={classNames('form-label', {
+                                'co-required': field.required,
+                              })}
+                              htmlFor={field.path}
+                            >
+                              {field.displayName}
+                            </label>
+                            {inputFor(field)}
+                            {field.description && (
+                              <span id={`${field.path}__description`} className="help-block">
+                                {field.description}
+                              </span>
+                            )}
+                            {formErrors[field.path] && (
+                              <span className="co-error">{formErrors[field.path]}</span>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    ))}
-                  </FieldGroup>
-                </div>
+                      ))}
+                    </FieldGroup>
+                  </div>
+                )
               );
             })}
             {[...fieldGroups].map((group) => {
@@ -754,41 +769,43 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
                 .filter((f) => !_.isNil(inputFor(f)));
 
               return (
-                <div id={group} key={group}>
-                  <FieldGroup
-                    defaultExpand={
-                      !_.some(
-                        fieldList,
-                        (f) => f.capabilities.includes(SpecCapability.advanced) && !f.required,
-                      )
-                    }
-                    groupName={groupName}
-                  >
-                    {fieldList.map((field) => (
-                      <div key={field.path}>
-                        <div className="form-group co-create-operand__form-group">
-                          <label
-                            className={classNames('form-label', {
-                              'co-required': field.required,
-                            })}
-                            htmlFor={field.path}
-                          >
-                            {field.displayName}
-                          </label>
-                          {inputFor(field)}
-                          {field.description && (
-                            <span id={`${field.path}__description`} className="help-block">
-                              {field.description}
-                            </span>
-                          )}
-                          {formErrors[field.path] && (
-                            <span className="co-error">{formErrors[field.path]}</span>
-                          )}
+                !_.isEmpty(fieldList) && (
+                  <div id={group} key={group}>
+                    <FieldGroup
+                      defaultExpand={
+                        !_.some(
+                          fieldList,
+                          (f) => f.capabilities.includes(SpecCapability.advanced) && !f.required,
+                        )
+                      }
+                      groupName={groupName}
+                    >
+                      {fieldList.map((field) => (
+                        <div key={field.path}>
+                          <div className="form-group co-create-operand__form-group">
+                            <label
+                              className={classNames('form-label', {
+                                'co-required': field.required,
+                              })}
+                              htmlFor={field.path}
+                            >
+                              {field.displayName}
+                            </label>
+                            {inputFor(field)}
+                            {field.description && (
+                              <span id={`${field.path}__description`} className="help-block">
+                                {field.description}
+                              </span>
+                            )}
+                            {formErrors[field.path] && (
+                              <span className="co-error">{formErrors[field.path]}</span>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    ))}
-                  </FieldGroup>
-                </div>
+                      ))}
+                    </FieldGroup>
+                  </div>
+                )
               );
             })}
             {fields

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
@@ -242,7 +242,8 @@ export const SpecDescriptor: React.SFC<DescriptorProps> = (props) => {
     (c) =>
       !c.startsWith(SpecCapability.fieldGroup) &&
       !c.startsWith(SpecCapability.arrayFieldGroup) &&
-      !c.startsWith(SpecCapability.advanced),
+      !c.startsWith(SpecCapability.advanced) &&
+      !c.startsWith(SpecCapability.fieldDependency),
   ) as SpecCapability;
   const Capability = capabilityFor(capability);
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts
@@ -23,6 +23,7 @@ export enum SpecCapability {
   arrayFieldGroup = 'urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:',
   select = 'urn:alm:descriptor:com.tectonic.ui:select:',
   advanced = 'urn:alm:descriptor:com.tectonic.ui:advanced',
+  fieldDependency = 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:',
 }
 
 export enum StatusCapability {


### PR DESCRIPTION
This PR contains the change for the new "fieldDependency" Spec Descriptor for the OLM Create Operand Form. With this descriptor, the Control Field can control the visibility of it's Dependent Field. Therefore, users only need to view necessary fields when they use Create Operand Form.

### Concepts

**Control Field**: a field that controls the Dependent Field.
**Dependent Field**: a field that has the “fieldDependency” x-descriptor. The visibility of the field is controlled by the Control Field.

### X-descriptor Structure

The “fieldDependency” x-descriptor allows you to specify a field as the Dependent Field of a Control Field, only show the Dependent Field  when the current value of the Control Field is equal to the expected value.
![Screen Shot 2019-11-28 at 12 38 56 PM](https://user-images.githubusercontent.com/24922241/69825112-1fab0380-11dc-11ea-909b-1cfc078c51bd.png)

### Usage

- Add the “fieldDependency” x-descriptor into the “x-descriptors” array of the field object. 
- Replace the “CONTROL_FIELD_PATH” with the value of the “path” property of the Control Field object. 
- Replace the “EXPECTED_VALUE” with the real expected value. When the current value of the Control Field is equal to the real expected value, the Dependent Fields are displayed; otherwise, the fields are hidden.

### Example

![fieldDependency-BA-example-new](https://user-images.githubusercontent.com/24922241/69826919-2ee17f80-11e3-11ea-8520-384c3efd2f0d.gif)

