### PR TITLE
Bug 1771860: Query Browser: Fix "reduced resolution" message being shown briefly

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -503,7 +503,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   const queriesKey = _.reject(queries, _.isEmpty).join();
   usePoll(tick, delay, endTime, filterLabels, namespace, queriesKey, samples, span);
 
-  React.useEffect(() => setUpdating(true), [endTime, namespace, queriesKey, samples, span]);
+  React.useLayoutEffect(() => setUpdating(true), [endTime, namespace, queriesKey, samples, span]);
 
   const onSpanChange = React.useCallback((newSpan: number) => {
     setXDomain(undefined);
@@ -565,7 +565,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
       {_.isEmpty(graphData) && !updating && <GraphEmpty />}
       {!_.isEmpty(graphData) && (
         <>
-          {samples < maxSamplesForSpan && (
+          {samples < maxSamplesForSpan && !updating && (
             <Alert
               isInline
               className="co-alert"


### PR DESCRIPTION
When zooming out, the `Displaying with reduced resolution due to large dataset`
message was displayed briefly while the data updated. This
fixes that by disabling the message when `updating` is `true` and also
sets the `updating` flag in a `useLayoutEffect` hook instead of a
`useEffect` hook so that it gets set before the changes are painted to
the screen.