### PR TITLE
Support multiple ssh keys for kubevirt VM Wizard integration tests

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
@@ -1,6 +1,6 @@
 import { browser, ExpectedConditions as until } from 'protractor';
 import { createItemButton } from '@console/internal-integration-tests/views/crud.view';
-import { click } from '@console/shared/src/test-utils/utils';
+import { click, asyncForEach } from '@console/shared/src/test-utils/utils';
 import { fillInput, selectOptionByText } from '../utils/utils';
 import { CloudInitConfig, StorageResource, NetworkResource } from '../utils/types';
 import { WIZARD_CREATE_VM_SUCCESS, PAGE_LOAD_TIMEOUT_SECS } from '../utils/consts';
@@ -63,8 +63,11 @@ export class Wizard {
       await click(wizardView.cloudInitCustomScriptCheckbox);
       await fillInput(wizardView.customCloudInitScriptTextArea, cloudInitOptions.customScript);
     } else {
-      await fillInput(wizardView.cloudInitHostname, cloudInitOptions.hostname);
-      await fillInput(wizardView.cloudInitSSHKey, cloudInitOptions.sshKey);
+      await fillInput(wizardView.cloudInitHostname, cloudInitOptions.hostname || '');
+      await asyncForEach(cloudInitOptions.sshKeys, async (sshKey: string, index: number) => {
+        await fillInput(wizardView.cloudInitSSHKey(index + 1), sshKey);
+        await click(wizardView.cloudInitAddKeyButton);
+      });
     }
   }
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/types.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/types.ts
@@ -34,7 +34,7 @@ export type CloudInitConfig = {
   useCustomScript?: boolean;
   customScript?: string;
   hostname?: string;
-  sshKey?: string;
+  sshKeys?: string[];
 };
 
 export type NodePortService = {

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
@@ -43,9 +43,8 @@ export const cloudInitFormCheckbox = $('#cloud-init-edit-mode-first-option');
 export const cloudInitCustomScriptCheckbox = $('#cloud-init-edit-mode-second-option');
 export const customCloudInitScriptTextArea = $('#cloudinit-custom-custom-script');
 export const cloudInitAddKeyButton = $('#cloudinit-ssh-authorized-keys-add');
-export const cloudInitHostname = $('#cloud-init-hostname');
-export const cloudInitSSH = $('#cloud-init-ssh');
-export const cloudInitSSHKey = $$('.pf-c-form-control').get(1);
+export const cloudInitHostname = $('#cloudinit-hostname');
+export const cloudInitSSHKey = (rowNumber) => $(`#cloudinit-ssh-authorized-keys-key-${rowNumber}`);
 
 // Result tab
 export const creationStatus = $('h5.pf-c-title');


### PR DESCRIPTION
Adding support for defining multiple SSH Keys in coud init section of VM Wizard.
Will be used by #2976 