### PR TITLE
Added PR template for devconsole

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/devconsole_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/devconsole_pr.md
@@ -1,0 +1,29 @@
+
+# [JIRA-ID](add JIRA link): User Story / Defect / Task Title
+<!--For e.g [ODC-100](https://jira.coreos.com/browse/ODC-100): Title of user story / defect / task -->
+
+## Root cause
+<!--Briefly describe the root cause & analysis of the problem-->
+
+## Solution Description
+<!--Describe your code changes in detail and explain the solution-->
+
+- [ ] Is U/X approved?
+<!-- If designer review required, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
+
+- [ ] Covered Unit test cases / e2e test cases? 
+<!-- Were unit tests or E2E test recorded for this change, or was only manual testing applicable. If yes, attach report else state reason for not adding -->
+
+- [ ] Does this PR need regression testing of any feature / work flow?
+<!-- If the changes have bigger impact on any feature / work flow, do mention scope for regression testing -->
+
+- [ ] Does it have any dependancies?
+<!-- Mention dependancies like PR, Defect, Prerequisite setup, application, operators, etc -->
+
+### Is this PR tested on all browsers?
+
+    - [ ] Chrome
+    - [ ] Firefox
+    - [ ] Safari
+    - [ ] Edge
+    - [ ] IE

--- a/.github/PULL_REQUEST_TEMPLATE/devconsole_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/devconsole_pr.md
@@ -1,24 +1,24 @@
-### [User Story/Defect/Task]: add JIRA link
-<!-- For e.g [User Story]: https://jira.coreos.com/browse/ODC-100 -->
+**Fixes**: 
+<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
 
-### Analysis / Root cause
-<!-- Briefly describe analysis of US/Task or root cause of defect -->
+**Analysis / Root cause**: 
+<!-- Briefly describe analysis of US/Task or root cause of Defect -->
 
-### Solution Description
+**Solution Description**: 
 <!-- Describe your code changes in detail and explain the solution -->
 
-### Screen shots / Gifs for design review
+**Screen shots / Gifs for design review**: 
 <!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
 
-### Unit test coverage report
+**Unit test coverage report**: 
 <!-- Attach test coverage report -->
 
-### Test setup
+**Test setup:**
 <!-- If any setup required to test this PR, mention the details -->
 
-### Browser conformance
+**Browser conformance**: 
 <!-- To mark tested browsers, use [x] -->
-    - [ ] Chrome
-    - [ ] Firefox
-    - [ ] Safari
-    - [ ] Edge
+- [ ] Chrome
+- [ ] Firefox
+- [ ] Safari
+- [ ] Edge

--- a/.github/PULL_REQUEST_TEMPLATE/devconsole_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/devconsole_pr.md
@@ -8,7 +8,7 @@
 <!-- Describe your code changes in detail and explain the solution -->
 
 ### Screen shots / Gifs for design review
-<!-- If designer review required, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
+<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
 
 ### Unit test coverage report
 <!-- Attach test coverage report -->

--- a/.github/PULL_REQUEST_TEMPLATE/devconsole_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/devconsole_pr.md
@@ -1,29 +1,24 @@
+### [User Story/Defect/Task]: add JIRA link
+<!-- For e.g [User Story]: https://jira.coreos.com/browse/ODC-100 -->
 
-# [JIRA-ID](add JIRA link): User Story / Defect / Task Title
-<!--For e.g [ODC-100](https://jira.coreos.com/browse/ODC-100): Title of user story / defect / task -->
+### Analysis / Root cause
+<!-- Briefly describe analysis of US/Task or root cause of defect -->
 
-## Root cause
-<!--Briefly describe the root cause & analysis of the problem-->
+### Solution Description
+<!-- Describe your code changes in detail and explain the solution -->
 
-## Solution Description
-<!--Describe your code changes in detail and explain the solution-->
-
-- [ ] Is U/X approved?
+### Screen shots / Gifs for design review
 <!-- If designer review required, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
 
-- [ ] Covered Unit test cases / e2e test cases? 
-<!-- Were unit tests or E2E test recorded for this change, or was only manual testing applicable. If yes, attach report else state reason for not adding -->
+### Unit test coverage report
+<!-- Attach test coverage report -->
 
-- [ ] Does this PR need regression testing of any feature / work flow?
-<!-- If the changes have bigger impact on any feature / work flow, do mention scope for regression testing -->
+### Test setup
+<!-- If any setup required to test this PR, mention the details -->
 
-- [ ] Does it have any dependancies?
-<!-- Mention dependancies like PR, Defect, Prerequisite setup, application, operators, etc -->
-
-### Is this PR tested on all browsers?
-
+### Browser conformance
+<!-- To mark tested browsers, use [x] -->
     - [ ] Chrome
     - [ ] Firefox
     - [ ] Safari
     - [ ] Edge
-    - [ ] IE


### PR DESCRIPTION
1. Markdown **devconsole_pr.md** has been added with PR template exclusively for devconsole PR's under folder .github/PULL_REQUEST_TEMPLATE/
2. Following are the steps to pre-populate PR template
    a. Initiate pull request and setup source & destination repositories.
    b. To pre-populate pull request form with the content of devconsole_pr.md file, developer need to navigate to the URL by passing an additional _**template**_ parameter:
For e.x. https://github.com/openshift/console/master…Test_branch?expand=1&template=devconsole_pr.md
3. Fill the template with appropriate information & create pull request.

**Note:** This template shall not be populated unless developer adds **_template_** query parameter in URL. So it shall not affect existing console PR process.