### PR TITLE
Bug 1760828: update Active RC logic  to not show Failed deployments

### DIFF
--- a/frontend/packages/console-shared/src/constants/resource.ts
+++ b/frontend/packages/console-shared/src/constants/resource.ts
@@ -9,6 +9,8 @@ export const CONTAINER_WAITING_STATE_ERROR_REASONS = [
 export const DEPLOYMENT_CONFIG_LATEST_VERSION_ANNOTATION =
   'openshift.io/deployment-config.latest-version';
 
+export const DEPLOYMENT_CONFIG_NAME_ANNOTATION = 'openshift.io/deployment-config.name';
+
 // Annotation key for deployment phase
 export const DEPLOYMENT_PHASE_ANNOTATION = 'openshift.io/deployment.phase';
 
@@ -31,6 +33,7 @@ export enum DEPLOYMENT_STRATEGY {
 }
 
 export enum DEPLOYMENT_PHASE {
+  new = 'New',
   running = 'Running',
   pending = 'Pending',
   complete = 'Complete',


### PR DESCRIPTION
ODC Bug: https://jira.coreos.com/browse/ODC-1412

This PR updates the logic to get the active replication controller.
Steps:
1. Get all the RCs for a resource.
2. Sort them based on the revision.
3. Get the first RC(most recent) from the sorted list to add the alerts if it's failed or canceled
4. filter out the RCs based on `status.replicas` or if an RC is in `New`, `Pending`, `Running` or `Complete` phase to determine active RCs.

using the logic from 3.11 code: https://github.com/openshift/origin-web-console/blob/enterprise-3.11/app/scripts/controllers/overview.js#L785-L831 