### PR TITLE
Add node maintenance status to BareMetal Nodes and BareMetal Hosts

### DIFF
--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -7,9 +7,21 @@ import {
   DashboardsOverviewResourceActivity,
   DashboardsOverviewHealthURLSubsystem,
   DashboardsOverviewHealthPrometheusSubsystem,
+  DashboardsOverviewInventoryItem,
 } from '@console/plugin-sdk';
-import { ClusterVersionModel } from '@console/internal/models';
+import {
+  ClusterVersionModel,
+  NodeModel,
+  PodModel,
+  StorageClassModel,
+  PersistentVolumeClaimModel,
+} from '@console/internal/models';
 import { referenceForModel } from '@console/internal/module/k8s';
+import {
+  getNodeStatusGroups,
+  getPodStatusGroups,
+  getPVCStatusGroups,
+} from '@console/shared/src/components/dashboard/inventory-card/utils';
 import {
   isClusterUpdateActivity,
   getClusterUpdateTimestamp,
@@ -30,7 +42,8 @@ type ConsumedExtensions =
   | Perspective
   | DashboardsOverviewResourceActivity
   | DashboardsOverviewHealthURLSubsystem<any>
-  | DashboardsOverviewHealthPrometheusSubsystem;
+  | DashboardsOverviewHealthPrometheusSubsystem
+  | DashboardsOverviewInventoryItem;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -92,6 +105,34 @@ const plugin: Plugin<ConsumedExtensions> = [
           './components/dashboards-page/ControlPlaneStatus' /* webpackChunkName: "console-app" */
         ).then((m) => m.default),
       popupTitle: 'Control Plane status',
+    },
+  },
+  {
+    type: 'Dashboards/Overview/Inventory/Item',
+    properties: {
+      model: NodeModel,
+      mapper: getNodeStatusGroups,
+    },
+  },
+  {
+    type: 'Dashboards/Overview/Inventory/Item',
+    properties: {
+      model: PodModel,
+      mapper: getPodStatusGroups,
+    },
+  },
+  {
+    type: 'Dashboards/Overview/Inventory/Item',
+    properties: {
+      model: StorageClassModel,
+    },
+  },
+  {
+    type: 'Dashboards/Overview/Inventory/Item',
+    properties: {
+      model: PersistentVolumeClaimModel,
+      mapper: getPVCStatusGroups,
+      useAbbr: true,
     },
   },
 ];

--- a/frontend/packages/console-app/src/status/node.ts
+++ b/frontend/packages/console-app/src/status/node.ts
@@ -1,4 +1,4 @@
 import { NodeKind } from '@console/internal/module/k8s';
-import { isNodeReady } from '@console/shared';
+import { isNodeReady } from '@console/shared/src/selectors/node';
 
 export const nodeStatus = (node: NodeKind) => (isNodeReady(node) ? 'Ready' : 'Not Ready');

--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -215,11 +215,6 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Dashboards/Overview/Inventory/Item',
     properties: {
-      resource: {
-        isList: true,
-        kind: RouteModel.kind,
-        prop: 'routes',
-      },
       model: RouteModel,
       mapper: getRouteStatusGroups,
       expandedComponent: () =>

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -29,6 +29,7 @@ import {
   isDashboardsOverviewPrometheusActivity,
   isProjectDashboardInventoryItem,
   isReduxReducer,
+  isDashboardsOverviewInventoryItemReplacement,
 } from './typings';
 
 /**
@@ -157,6 +158,10 @@ export class ExtensionRegistry {
 
   public getProjectDashboardInventoryItems() {
     return this.extensions.filter(isProjectDashboardInventoryItem);
+  }
+
+  public getDashboardsOverviewInventoryItemReplacements() {
+    return this.extensions.filter(isDashboardsOverviewInventoryItemReplacement);
   }
 }
 

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -100,20 +100,17 @@ namespace ExtensionProperties {
   }
 
   export interface DashboardsOverviewInventoryItem extends DashboardsExtensionProperties {
-    /** Resource which will be fetched and grouped by `mapper` function. */
-    resource: FirehoseResource;
+    /** The model for `resource` which will be fetched. The model is used for getting model's label or abbr. */
+    model: K8sKind;
+
+    /** Function which will map various statuses to groups. */
+    mapper?: StatusGroupMapper;
 
     /** Additional resources which will be fetched and passed to `mapper` function. */
     additionalResources?: FirehoseResource[];
 
-    /** The model for `resource` which will be fetched. The model is used for getting model's label or abbr. */
-    model: K8sKind;
-
     /** Defines whether model's label or abbr should be used when rendering the item. Defaults to false (label). */
     useAbbr?: boolean;
-
-    /** Function which will map various statuses to groups. */
-    mapper: StatusGroupMapper;
 
     /** Loader for the component which will be used when item is expanded. */
     expandedComponent?: LazyLoader<ExpandedComponentProps>;
@@ -273,6 +270,16 @@ export interface ProjectDashboardInventoryItem
 
 export const isProjectDashboardInventoryItem = (e: Extension): e is ProjectDashboardInventoryItem =>
   e.type === 'Project/Dashboard/Inventory/Item';
+
+export interface DashboardsOverviewInventoryItemReplacement
+  extends Extension<ExtensionProperties.DashboardsOverviewInventoryItem> {
+  type: 'Dashboards/Overview/Inventory/Item/Replacement';
+}
+
+export const isDashboardsOverviewInventoryItemReplacement = (
+  e: Extension,
+): e is DashboardsOverviewInventoryItemReplacement =>
+  e.type === 'Dashboards/Overview/Inventory/Item/Replacement';
 
 export type DashboardCardSpan = 4 | 6 | 12;
 

--- a/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
@@ -150,8 +150,7 @@ const StatusLink = connectToFlags<StatusLinkProps>(
     return null;
   }
   const statusItems = encodeURIComponent(statusIDs.join(','));
-  const namespacePath = namespace ? `ns/${namespace}` : 'all-namespaces';
-  const path = basePath || `/k8s/${namespacePath}/${kind.plural}`;
+  const path = basePath || resourcePathFromModel(kind, null, namespace);
   const to =
     filterType && statusItems.length > 0 ? `${path}?rowFilter-${filterType}=${statusItems}` : path;
   const statusGroupIcons = getStatusGroupIcons(flags);

--- a/frontend/packages/console-shared/src/utils/utils.ts
+++ b/frontend/packages/console-shared/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { FirehoseResult } from '@console/internal/components/utils';
-import { getUID } from '../selectors';
+import { FirehoseResult } from '@console/internal/components/utils/types';
+import { getUID } from '../selectors/common';
 
 export type EntityMap<A> = { [propertyName: string]: A };
 export type K8sEntityMap<A extends K8sResourceKind> = EntityMap<A>;

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -197,11 +197,6 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Dashboards/Overview/Inventory/Item',
     properties: {
-      resource: {
-        isList: true,
-        kind: models.VirtualMachineModel.kind,
-        prop: 'vms',
-      },
       additionalResources: [
         {
           isList: true,

--- a/frontend/packages/metal3-plugin/package.json
+++ b/frontend/packages/metal3-plugin/package.json
@@ -8,6 +8,6 @@
     "@console/shared": "0.0.0-fixed"
   },
   "consolePlugin": {
-    "entry": "src/plugin.ts"
+    "entry": "src/plugin.tsx"
   }
 }

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/utils.ts
@@ -14,6 +14,7 @@ const BMH_STATUS_GROUP_MAPPER = {
   [InventoryStatusGroup.NOT_MAPPED]: HOST_SUCCESS_STATES,
   [InventoryStatusGroup.PROGRESS]: HOST_PROGRESS_STATES,
   [InventoryStatusGroup.ERROR]: HOST_ERROR_STATES,
+  'node-maintenance': ['maintenance'],
 };
 
 export const getBMHStatusGroups: StatusGroupMapper = (
@@ -38,6 +39,11 @@ export const getBMHStatusGroups: StatusGroupMapper = (
     },
     [InventoryStatusGroup.UNKNOWN]: {
       statusIDs: ['other'],
+      count: 0,
+      filterType: 'host-status',
+    },
+    'node-maintenance': {
+      statusIDs: ['maintenance'],
       count: 0,
       filterType: 'host-status',
     },

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/table-filters.ts
@@ -34,9 +34,13 @@ const hostStatesToFilterMap = Object.freeze({
     title: 'Error',
     states: HOST_ERROR_STATES,
   },
+  maintenance: {
+    title: 'Maintenance',
+    states: Object.keys(NODE_STATUS_TITLES),
+  },
   other: {
     title: 'Other',
-    states: [...Object.keys(HOST_STATUS_TITLES), ...Object.keys(NODE_STATUS_TITLES)],
+    states: Object.keys(HOST_STATUS_TITLES),
   },
 });
 

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/dashboard/utils.ts
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/dashboard/utils.ts
@@ -1,0 +1,46 @@
+import { StatusGroupMapper } from '@console/shared/src/components/dashboard/inventory-card/InventoryItem';
+import { createBasicLookup } from '@console/shared/src/utils/utils';
+import { getName } from '@console/shared/src/selectors/common';
+import { NodeKind } from '@console/internal/module/k8s';
+import { InventoryStatusGroup } from '@console/shared/src/components/dashboard/inventory-card/status-group';
+import { getNodeMaintenanceNodeName } from '../../../selectors';
+import { bareMetalNodeStatus } from '../../../status/baremetal-node-status';
+import { NODE_STATUS_TITLES } from '../../../constants';
+
+const BMN_STATUS_GROUP_MAPPER = {
+  [InventoryStatusGroup.PROGRESS]: ['Not Ready'],
+  [InventoryStatusGroup.NOT_MAPPED]: ['Ready'],
+  'node-maintenance': Object.keys(NODE_STATUS_TITLES),
+};
+
+export const getBMNStatusGroups: StatusGroupMapper = (nodes: NodeKind[], { maintenaces }) => {
+  const groups = {
+    [InventoryStatusGroup.NOT_MAPPED]: {
+      statusIDs: ['ready'],
+      count: 0,
+      filterType: 'bare-metal-node-status',
+    },
+    [InventoryStatusGroup.PROGRESS]: {
+      statusIDs: ['notReady'],
+      count: 0,
+      filterType: 'bare-metal-node-status',
+    },
+    'node-maintenance': {
+      statusIDs: ['maintenance'],
+      count: 0,
+      filterType: 'bare-metal-node-status',
+    },
+  };
+  const maintenancesByNodeName = createBasicLookup(maintenaces, getNodeMaintenanceNodeName);
+  nodes.forEach((node) => {
+    const nodeName = getName(node);
+    const nodeMaintenance = maintenancesByNodeName[nodeName];
+    const { status } = bareMetalNodeStatus({ node, nodeMaintenance });
+    const group =
+      Object.keys(BMN_STATUS_GROUP_MAPPER).find((key) =>
+        BMN_STATUS_GROUP_MAPPER[key].includes(status),
+      ) || InventoryStatusGroup.NOT_MAPPED;
+    groups[group].count++;
+  });
+  return groups;
+};

--- a/frontend/packages/metal3-plugin/src/plugin.tsx
+++ b/frontend/packages/metal3-plugin/src/plugin.tsx
@@ -1,4 +1,6 @@
 import * as _ from 'lodash';
+import * as React from 'react';
+import { MaintenanceIcon } from '@patternfly/react-icons';
 import {
   DashboardsOverviewInventoryItem,
   Plugin,
@@ -9,15 +11,20 @@ import {
   ModelFeatureFlag,
   ModelDefinition,
   DashboardsOverviewResourceActivity,
+  DashboardsOverviewInventoryItemReplacement,
+  DashboardsInventoryItemGroup,
 } from '@console/plugin-sdk';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { MachineModel, NodeModel } from '@console/internal/models';
 import { FLAGS } from '@console/internal/const';
 import { BareMetalHostModel, NodeMaintenanceModel } from './models';
 import { getBMHStatusGroups } from './components/baremetal-hosts/dashboard/utils';
+import { getBMNStatusGroups } from './components/baremetal-nodes/dashboard/utils';
 
 type ConsumedExtensions =
   | DashboardsOverviewInventoryItem
+  | DashboardsOverviewInventoryItemReplacement
+  | DashboardsInventoryItemGroup
   | ResourceNSNavItem
   | ResourceListPage
   | ResourceDetailsPage
@@ -87,13 +94,24 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Dashboards/Overview/Inventory/Item/Replacement',
+    properties: {
+      model: NodeModel,
+      additionalResources: [
+        {
+          isList: true,
+          kind: referenceForModel(NodeMaintenanceModel),
+          prop: 'maintenaces',
+          optional: true,
+        },
+      ],
+      mapper: getBMNStatusGroups,
+      required: [FLAGS.BAREMETAL, METAL3_FLAG],
+    },
+  },
+  {
     type: 'Dashboards/Overview/Inventory/Item',
     properties: {
-      resource: {
-        isList: true,
-        kind: referenceForModel(BareMetalHostModel),
-        prop: 'hosts',
-      },
       additionalResources: [
         {
           isList: true,
@@ -108,7 +126,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         {
           isList: true,
           kind: referenceForModel(NodeMaintenanceModel),
-          prop: 'maintenaces',
+          prop: 'maintenances',
           optional: true,
         },
       ],
@@ -155,6 +173,14 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/maintenance/MaintenanceDashboardActivity' /* webpackChunkName: "node-maintenance" */
         ).then((m) => m.default),
+      required: [FLAGS.BAREMETAL, METAL3_FLAG],
+    },
+  },
+  {
+    type: 'Dashboards/Inventory/Item/Group',
+    properties: {
+      id: 'node-maintenance',
+      icon: <MaintenanceIcon />,
       required: [FLAGS.BAREMETAL, METAL3_FLAG],
     },
   },

--- a/frontend/packages/metal3-plugin/src/selectors/baremetal-hosts.ts
+++ b/frontend/packages/metal3-plugin/src/selectors/baremetal-hosts.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { getName } from '@console/shared/src/selectors';
+import { getName } from '@console/shared/src/selectors/common';
 import { MachineKind } from '@console/internal/module/k8s';
 import {
   BareMetalHostDisk,

--- a/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
@@ -1,6 +1,6 @@
 import { NodeKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { nodeStatus } from '@console/app/src/status/node';
-import { isNodeUnschedulable } from '@console/shared';
+import { isNodeUnschedulable } from '@console/shared/src/selectors/node';
 import { StatusProps } from '../components/types';
 import { BareMetalHostKind } from '../types';
 import { isHostPoweredOn } from '../selectors';


### PR DESCRIPTION
![node_maintenance](https://user-images.githubusercontent.com/2078045/69970358-64a5a180-151e-11ea-945a-e6c6d0192a2c.png)

Added new filter `Maintenance` for BMH too (similar to same filter in BMN)
![bmh_maintenance](https://user-images.githubusercontent.com/2078045/69970368-666f6500-151e-11ea-8b55-75e51846e631.png)
