### PR TITLE
Bug 1780338: fix(che-icon): add che Icon in the topology

### DIFF
--- a/frontend/packages/dev-console/src/components/import/render-utils.tsx
+++ b/frontend/packages/dev-console/src/components/import/render-utils.tsx
@@ -1,9 +1,17 @@
 import * as React from 'react';
 import { BitbucketIcon, GitAltIcon, GithubIcon, GitlabIcon } from '@patternfly/react-icons';
+import CheIcon from '../topology/shapes/CheIcon';
 import { detectGitType } from './import-validation-utils';
 import { GitTypes } from './import-types';
 
-export const routeDecoratorIcon = (routeURL: string, radius: number): React.ReactElement => {
+export const routeDecoratorIcon = (
+  routeURL: string,
+  radius: number,
+  cheEnabled?: boolean,
+): React.ReactElement => {
+  if (cheEnabled && routeURL) {
+    return <CheIcon style={{ fontSize: radius }} />;
+  }
   switch (detectGitType(routeURL)) {
     case GitTypes.invalid:
       // Not a valid url and thus not safe to use

--- a/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
@@ -44,6 +44,7 @@ Object {
       "data": Object {
         "build": undefined,
         "builderImage": "test-file-stub",
+        "cheEnabled": false,
         "connectedPipeline": Object {
           "pipeline": undefined,
           "pipelineRuns": Array [],
@@ -559,6 +560,7 @@ Object {
       "data": Object {
         "build": undefined,
         "builderImage": "test-file-stub",
+        "cheEnabled": false,
         "connectedPipeline": Object {
           "pipeline": undefined,
           "pipelineRuns": Array [],
@@ -1532,6 +1534,7 @@ Object {
       "data": Object {
         "build": undefined,
         "builderImage": "test-file-stub",
+        "cheEnabled": false,
         "connectedPipeline": Object {
           "pipeline": undefined,
           "pipelineRuns": Array [],

--- a/frontend/packages/dev-console/src/components/topology/shapes/CheIcon.tsx
+++ b/frontend/packages/dev-console/src/components/topology/shapes/CheIcon.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+const CheIcon: React.FC<React.HTMLProps<SVGElement>> = ({ style }): React.ReactElement => {
+  return (
+    <svg height="1em" width="1em" version="1.1" viewBox="0 0 47 57" style={style}>
+      <g fillRule="evenodd" stroke="none" strokeWidth="1" fill="none">
+        <path
+          d="M0.032227,30.88l-0.032227-17.087,23.853-13.793,23.796,13.784-14.691,8.51-9.062-5.109-23.864,13.695z"
+          fill="#fdb940"
+        />
+        <path
+          d="M0,43.355l23.876,13.622,23.974-13.937v-16.902l-23.974,13.506-23.876-13.506v17.217z"
+          fill="#525c86"
+        />
+      </g>
+    </svg>
+  );
+};
+
+export default CheIcon;

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -100,6 +100,7 @@ export interface ConnectedWorkloadPipeline {
 export interface WorkloadData {
   url?: string;
   editUrl?: string;
+  cheEnabled?: boolean;
   builderImage?: string;
   kind?: string;
   isKnativeResource?: boolean;

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -134,6 +134,7 @@ export const createTopologyNodeData = (
       editUrl:
         deploymentsAnnotations['app.openshift.io/edit-url'] ||
         getEditURL(deploymentsAnnotations['app.openshift.io/vcs-uri'], cheURL),
+      cheEnabled: !!cheURL,
       builderImage:
         getImageForIconClass(`icon-${deploymentsLabels['app.openshift.io/runtime']}`) ||
         getImageForIconClass(`icon-${deploymentsLabels['app.kubernetes.io/name']}`) ||

--- a/frontend/packages/dev-console/src/components/topology2/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology2/components/nodes/WorkloadNode.tsx
@@ -43,12 +43,11 @@ const WorkloadNode: React.FC<WorkloadNodeProps> = ({
   const { width, height } = element.getBounds();
   const workloadData = element.getData().data;
   const size = Math.min(width, height);
-  const { donutStatus } = workloadData;
+  const { donutStatus, editUrl, cheEnabled } = workloadData;
   const { radius, decoratorRadius } = calculateRadius(size);
-  const repoIcon = routeDecoratorIcon(workloadData.editUrl, decoratorRadius);
   const cx = width / 2;
   const cy = height / 2;
-
+  const repoIcon = routeDecoratorIcon(editUrl, decoratorRadius, cheEnabled);
   const tipContent = `Create a ${
     element.getData().operatorBackedService ? 'binding' : 'visual'
   } connector`;

--- a/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
@@ -261,6 +261,7 @@ export const createTopologyServiceNodeData = (
       editUrl:
         annotations['app.openshift.io/edit-url'] ||
         getEditURL(annotations['app.openshift.io/vcs-uri'], cheURL),
+      cheEnabled: !!cheURL,
       isKnativeResource: true,
     },
   };


### PR DESCRIPTION
If the eclipse che operator is installed and configured, then show the che icon instead of git source icon.
![Topology · OKD](https://user-images.githubusercontent.com/9964343/69974307-00e59d80-154b-11ea-9b95-613e6d1dd76e.png)

![AwesomeScreenshot-2019-12-2-1575302155744](https://user-images.githubusercontent.com/9964343/69974203-c8de5a80-154a-11ea-92fc-8c6880bdf99c.gif)


Fixes: https://jira.coreos.com/browse/ODC-2383
