### PR TITLE
Bug 1778958: Remove serviceAccount in favour of serviceAccountName

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/__tests__/pipelinerun-mock.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/__tests__/pipelinerun-mock.ts
@@ -36,10 +36,6 @@ export const mockPipelineRun = {
         },
       },
     ],
-    serviceAccount: '',
-    trigger: {
-      type: 'manual',
-    },
   },
   status: {
     completionTime: '2019-06-08T18:27:28Z',

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
@@ -5,6 +5,7 @@ import {
   reRunPipelineRun,
   startPipeline,
   getPipelineRunData,
+  migratePipelineRun,
 } from '../pipeline-actions';
 import { PipelineRun, Pipeline } from '../pipeline-augment';
 import { PipelineModel, PipelineRunModel } from '../../models';
@@ -105,5 +106,40 @@ describe('PipelineAction testing getPipelineRunData', () => {
     expect(params[0].name).toBe('APP_NAME');
     expect(params[0].value).toBe('default-app-name');
     expect(_.has(params[0], 'default')).toBeFalsy();
+  });
+});
+
+describe('PipelineAction testing migratePipelineRun', () => {
+  it('expect migratePipelineRun to do nothing when there is no migration needed', () => {
+    // Same instance should be returned if there was no need for a migration
+    expect(migratePipelineRun(actionPipelineRuns[0])).toEqual(actionPipelineRuns[0]);
+  });
+
+  it('expect migratePipelineRun to handle serviceAccount to serviceAccountName migration (Operator 0.9.x)', () => {
+    type OldPipelineRun = PipelineRun & {
+      spec: {
+        serviceAccount: string;
+      };
+    };
+    const serviceAccountValue = 'serviceAccountValue';
+    const plr: OldPipelineRun = {
+      ...actionPipelineRuns[0],
+      spec: {
+        ...actionPipelineRuns[0].spec,
+        serviceAccount: serviceAccountValue,
+      },
+    };
+
+    const result: PipelineRun = migratePipelineRun(plr);
+
+    // Should be a new instance
+    expect(result).not.toEqual(plr);
+
+    // The value should have moved
+    expect(result.spec.serviceAccountName).toEqual(serviceAccountValue);
+    expect((result as OldPipelineRun).spec.serviceAccount).toBeUndefined();
+
+    // Should still have other spec properties
+    expect(result.spec.pipelineRef).toEqual(actionPipelineRuns[0].spec.pipelineRef);
   });
 });

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -69,7 +69,7 @@ export interface Pipeline extends K8sResourceKind {
     params?: PipelineParam[];
     resources?: PipelineResource[];
     tasks: PipelineTask[];
-    serviceAccount?: string;
+    serviceAccountName?: string;
   };
 }
 
@@ -78,7 +78,6 @@ export interface PipelineRun extends K8sResourceKind {
     pipelineRef: { name: string };
     params?: PipelineRunParam[];
     resources?: PipelineResource[];
-    serviceAccount?: string;
     serviceAccountName?: string;
     // Odd status value that only appears in a single case - cancelling a pipeline
     status?: 'PipelineRunCancelled';


### PR DESCRIPTION
- Pipeline Operator 0.8.0 deprecates `serviceAccount` in favour of `serviceAccountName`
- Pipeline Operator 0.9.0 will make `serviceAccount` an invalid field

https://jira.coreos.com/browse/ODC-2439

[Tekton Pipeline 0.8.0 Release Notes](https://github.com/tektoncd/pipeline/releases/tag/v0.8.0)