### PR TITLE
Bug 1773646: Extend dashboard grey background to full height of viewport

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/dashboard.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/dashboard.scss
@@ -4,6 +4,7 @@
 
 .co-dashboard-body {
   background-color: $pf-color-black-200;
+  flex: 1 0 auto;
   padding: ($grid-gutter-width / 2);
   @media(min-width: $grid-float-breakpoint) {
     padding: $grid-gutter-width;

--- a/frontend/packages/dev-console/src/components/NamespacedPage.scss
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.scss
@@ -5,9 +5,9 @@
   flex-direction: column;
 
   &__content {
-    flex-grow: 1;
-    position: relative;
-    overflow: auto;
+    display: flex;
+    flex: 1 0 auto;
+    flex-direction: column;
     background-color: var(--pf-global--Color--light-200);
 
     &.is-light {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -126,50 +126,52 @@ export const OperatorHubPage = withFallback(
       <Helmet>
         <title>OperatorHub</title>
       </Helmet>
-      <div className="co-catalog">
-        <PageHeading title="OperatorHub" />
-        <p className="co-catalog-page__description">
-          Discover Operators from the Kubernetes community and Red Hat partners, curated by Red Hat.
-          Operators can be installed on your clusters to provide optional add-ons and shared
-          services to your developers. Once installed, the capabilities provided by the Operator
-          appear in the <a href="/catalog">Developer Catalog</a>, providing a self-service
-          experience.
-        </p>
-        <div className="co-catalog-connect">
-          <Firehose
-            resources={[
-              {
-                isList: true,
-                kind: referenceForModel(OperatorGroupModel),
-                prop: 'operatorGroup',
-              },
-              {
-                isList: true,
-                kind: referenceForModel(PackageManifestModel),
-                namespace: props.match.params.ns,
-                selector: { 'openshift-marketplace': 'true' },
-                prop: 'marketplacePackageManifest',
-              },
-              {
-                isList: true,
-                kind: referenceForModel(PackageManifestModel),
-                namespace: props.match.params.ns,
-                selector: fromRequirements([
-                  { key: 'opsrc-owner-name', operator: 'DoesNotExist' },
-                  { key: 'csc-owner-name', operator: 'DoesNotExist' },
-                ]),
-                prop: 'packageManifest',
-              },
-              {
-                isList: true,
-                kind: referenceForModel(SubscriptionModel),
-                prop: 'subscription',
-              },
-            ]}
-          >
-            {/* FIXME(alecmerdler): Hack because `Firehose` injects props without TypeScript knowing about it */}
-            <OperatorHubList {...props as any} namespace={props.match.params.ns} />
-          </Firehose>
+      <div className="co-m-page__body">
+        <div className="co-catalog">
+          <PageHeading title="OperatorHub" />
+          <p className="co-catalog-page__description">
+            Discover Operators from the Kubernetes community and Red Hat partners, curated by Red
+            Hat. Operators can be installed on your clusters to provide optional add-ons and shared
+            services to your developers. Once installed, the capabilities provided by the Operator
+            appear in the <a href="/catalog">Developer Catalog</a>, providing a self-service
+            experience.
+          </p>
+          <div className="co-catalog-connect">
+            <Firehose
+              resources={[
+                {
+                  isList: true,
+                  kind: referenceForModel(OperatorGroupModel),
+                  prop: 'operatorGroup',
+                },
+                {
+                  isList: true,
+                  kind: referenceForModel(PackageManifestModel),
+                  namespace: props.match.params.ns,
+                  selector: { 'openshift-marketplace': 'true' },
+                  prop: 'marketplacePackageManifest',
+                },
+                {
+                  isList: true,
+                  kind: referenceForModel(PackageManifestModel),
+                  namespace: props.match.params.ns,
+                  selector: fromRequirements([
+                    { key: 'opsrc-owner-name', operator: 'DoesNotExist' },
+                    { key: 'csc-owner-name', operator: 'DoesNotExist' },
+                  ]),
+                  prop: 'packageManifest',
+                },
+                {
+                  isList: true,
+                  kind: referenceForModel(SubscriptionModel),
+                  prop: 'subscription',
+                },
+              ]}
+            >
+              {/* FIXME(alecmerdler): Hack because `Firehose` injects props without TypeScript knowing about it */}
+              <OperatorHubList {...props as any} namespace={props.match.params.ns} />
+            </Firehose>
+          </div>
         </div>
       </div>
     </>

--- a/frontend/public/components/_horizontal-nav.scss
+++ b/frontend/public/components/_horizontal-nav.scss
@@ -3,6 +3,7 @@ $co-m-horizontal-nav__menu-item-link-padding-lr: ($grid-gutter-width / 2);
 .co-m-horizontal-nav__menu {
   border-bottom: 1px solid $color-grey-background-border;
   display: flex;
+  flex-shrink: 0; // prevent collapse of tabs
   list-style: none;
   margin: 0;
   overflow-x: auto;

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -17,6 +17,7 @@ $co-modal-ignore-warning-icon-width: 30px;
 }
 
 .co-catalog {
+  background-color: $pf-color-black-200;
   display: flex;
   flex-direction: column;
   min-height: 100%;

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -357,13 +357,16 @@ export const CatalogPage = withStartGuide(({ match, noProjectsAvailable }) => {
       <Helmet>
         <title>Developer Catalog</title>
       </Helmet>
-      <div className="co-catalog">
-        <PageHeading title="Developer Catalog" />
-        <p className="co-catalog-page__description">
-          Add shared apps, services, or source-to-image builders to your project from the Developer
-          Catalog. Cluster admins can install additional apps which will show up here automatically.
-        </p>
-        <Catalog namespace={namespace} mock={noProjectsAvailable} />
+      <div className="co-m-page__body">
+        <div className="co-catalog">
+          <PageHeading title="Developer Catalog" />
+          <p className="co-catalog-page__description">
+            Add shared apps, services, or source-to-image builders to your project from the
+            Developer Catalog. Cluster admins can install additional apps which will show up here
+            automatically.
+          </p>
+          <Catalog namespace={namespace} mock={noProjectsAvailable} />
+        </div>
       </div>
     </>
   );

--- a/frontend/public/components/utils/_log-window.scss
+++ b/frontend/public/components/utils/_log-window.scss
@@ -7,7 +7,6 @@ $color-log-window-divider: $color-log-window-header-bg;
 .log-window {
   color: $color-log-window-text;
   background-color: $color-log-window-body-bg;
-  height: 100%;
 }
 
 .log-window__header {

--- a/frontend/public/components/utils/_status-box.scss
+++ b/frontend/public/components/utils/_status-box.scss
@@ -47,3 +47,9 @@
     margin-top: 30px;
   }
 }
+
+.loading-box {
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+}

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -218,11 +218,11 @@ export const HorizontalNav: React.FC<HorizontalNavProps> = React.memo((props) =>
   });
 
   return (
-    <div className={props.className}>
+    <div className={classNames('co-m-page__body', props.className)}>
       <div className="co-m-horizontal-nav">
         {!props.hideNav && <NavBar pages={pages} basePath={props.match.url} />}
-        {renderContent(routes)}
       </div>
+      {renderContent(routes)}
     </div>
   );
 }, _.isEqual);

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -14,10 +14,18 @@ body,
 }
 
 #content-scrollable {
+  display: flex;
+  flex-direction: column;
   overflow-x: auto; // so catalog is scrollable at mobile
   overflow-y: auto;
   position: relative;
   -webkit-overflow-scrolling: touch;
+}
+
+.co-m-page__body {
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
 }
 
 .co-p-has-sidebar {


### PR DESCRIPTION
Note: The markup structure was slightly different for each dashboard view.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1773646

Tested with `.pf-l-grid__item {display:none;}`

**before**
<img width="1201" alt="Screen Shot 2019-12-02 at 6 29 15 PM" src="https://user-images.githubusercontent.com/1874151/70003889-94f73b00-1532-11ea-950c-8601fc3f2596.png">
<img width="1200" alt="Screen Shot 2019-12-02 at 6 29 36 PM" src="https://user-images.githubusercontent.com/1874151/70003890-94f73b00-1532-11ea-8b4e-12da0ba0fb41.png">
<img width="1202" alt="Screen Shot 2019-12-02 at 6 29 49 PM" src="https://user-images.githubusercontent.com/1874151/70003891-958fd180-1532-11ea-9fda-4c791de7015b.png">

---

**after**
(Edge, Chrome, Firefox, Safari)

<img width="1152" alt="Screen Shot 2019-12-02 at 5 54 37 PM" src="https://user-images.githubusercontent.com/1874151/70004250-a12fc800-1533-11ea-9147-ff2a276a8b8f.png">
<img width="1150" alt="Screen Shot 2019-12-02 at 5 55 20 PM" src="https://user-images.githubusercontent.com/1874151/70004251-a12fc800-1533-11ea-85a3-8782620e21f8.png">
<img width="1150" alt="Screen Shot 2019-12-02 at 5 56 06 PM" src="https://user-images.githubusercontent.com/1874151/70004252-a12fc800-1533-11ea-9076-4e4f7cf72268.png">
<img width="1113" alt="Screen Shot 2019-12-02 at 5 57 35 PM" src="https://user-images.githubusercontent.com/1874151/70004254-a12fc800-1533-11ea-9c56-9559b1abf344.png">
<img width="1113" alt="Screen Shot 2019-12-02 at 5 57 48 PM" src="https://user-images.githubusercontent.com/1874151/70004255-a12fc800-1533-11ea-8bfc-950dd91c247d.png">
<img width="1113" alt="Screen Shot 2019-12-02 at 5 58 00 PM" src="https://user-images.githubusercontent.com/1874151/70004256-a12fc800-1533-11ea-8ae7-8071b261859e.png">
<img width="1101" alt="Screen Shot 2019-12-02 at 5 58 58 PM" src="https://user-images.githubusercontent.com/1874151/70004257-a1c85e80-1533-11ea-9009-5a2a8c287f5c.png">
<img width="1095" alt="Screen Shot 2019-12-02 at 5 59 07 PM" src="https://user-images.githubusercontent.com/1874151/70004258-a1c85e80-1533-11ea-8d13-cda8eba04cc8.png">
<img width="1096" alt="Screen Shot 2019-12-02 at 5 59 20 PM" src="https://user-images.githubusercontent.com/1874151/70004259-a1c85e80-1533-11ea-88cc-b8d4598320e6.png">
<img width="1070" alt="Screen Shot 2019-12-02 at 5 59 51 PM" src="https://user-images.githubusercontent.com/1874151/70004260-a1c85e80-1533-11ea-8ef8-63e2681031e4.png">
<img width="1027" alt="Screen Shot 2019-12-02 at 6 23 22 PM" src="https://user-images.githubusercontent.com/1874151/70004261-a1c85e80-1533-11ea-8557-1fbd67856370.png">
<img width="914" alt="Screen Shot 2019-12-02 at 6 24 58 PM" src="https://user-images.githubusercontent.com/1874151/70004262-a1c85e80-1533-11ea-83f7-4f8ef4ab8128.png">
