### PR TITLE
kubevirt: migrate VmConsoles from web-ui-components

### DIFF
--- a/frontend/packages/kubevirt-plugin/package.json
+++ b/frontend/packages/kubevirt-plugin/package.json
@@ -10,7 +10,8 @@
     "@console/internal": "0.0.0-fixed",
     "@console/plugin-sdk": "0.0.0-fixed",
     "@console/shared": "0.0.0-fixed",
-    "kubevirt-web-ui-components": "0.1.50"
+    "kubevirt-web-ui-components": "0.1.50",
+    "@patternfly/react-console": "1.x"
   },
   "consolePlugin": {
     "entry": "src/plugin.tsx",

--- a/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/cdrom-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/cdrom-vm-modal/cdrom-modal.tsx
@@ -12,7 +12,7 @@ import { k8sPatch } from '@console/internal/module/k8s';
 import { ModalFooter } from '../modal/modal-footer';
 import { getCDsPatch } from '../../../k8s/patches/vm/vm-cdrom-patches';
 import { getRemoveDiskPatches } from '../../../k8s/patches/vm/vm-disk-patches';
-import { getVMLikeModel, asVM } from '../../../selectors/vm';
+import { getVMLikeModel, asVM, isWindows } from '../../../selectors/vm';
 import {
   getCDRoms,
   getContainerImageByDisk,
@@ -21,7 +21,6 @@ import {
   getStorageSizeByDisk,
   getStorageClassNameByDisk,
   isVMRunning,
-  isWindows,
 } from '../../../selectors/vm/selectors';
 import { isValidationError, validateURL } from '../../../utils/validations/common';
 import { VMKind, VMLikeEntityKind } from '../../../types';

--- a/frontend/packages/kubevirt-plugin/src/components/vms/desktop-viewer-selector.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/desktop-viewer-selector.scss
@@ -1,0 +1,7 @@
+.kubevirt-desktop-viewer-selector {
+    width: 100%;
+}
+
+.kubevirt-desktop-viewer-selector__form-group {
+    margin: auto;
+}

--- a/frontend/packages/kubevirt-plugin/src/components/vms/desktop-viewer-selector.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/desktop-viewer-selector.tsx
@@ -1,0 +1,189 @@
+import * as React from 'react';
+import { Form, FormGroup, Alert } from '@patternfly/react-core';
+import { DesktopViewer } from '@patternfly/react-console';
+import { Dropdown } from '@console/internal/components/utils';
+import { getName } from '@console/shared';
+import { DEFAULT_RDP_PORT, TEMPLATE_VM_NAME_LABEL, NetworkType } from '../../constants';
+import { VMKind, VMIKind } from '../../types';
+import { getNetworks } from '../../selectors/vm';
+import {
+  getVMIInterfaces,
+  RDPConnectionDetailsManualType,
+  VNCConnectionDetailsManualType,
+} from '../../selectors/vmi';
+import './desktop-viewer-selector.scss';
+
+const SELECT_NETWORK_INTERFACE = '--- Select Network Interface ---';
+const NIC = 'Network Interface';
+const GUEST_AGENT_WARNING = 'Guest Agent is not installed on Virtual Machine';
+const GUEST_AGENT_WARNING_TITLE = 'Missing Guest Agent';
+const NO_IP_ADDRESS = 'No IP address is reported for network interface';
+const NO_IP_ADDRESS_TITLE = 'Networks misconfigured';
+
+const getVmRdpNetworks = (vm: VMKind, vmi: VMIKind): Network[] => {
+  const networks = getNetworks(vm).filter((n) => n.multus || n.pod);
+  return getVMIInterfaces(vmi)
+    .filter((i) => networks.some((n) => n.name === i.name))
+    .map((i) => {
+      let ip = i.ipAddress;
+      if (i.ipAddress) {
+        const subnetIndex = i.ipAddress.indexOf('/');
+        if (subnetIndex > 0) {
+          ip = i.ipAddress.slice(0, subnetIndex);
+        }
+      }
+      const network = networks.find((n) => n.name === i.name);
+      return {
+        name: i.name,
+        type: network.multus ? NetworkType.MULTUS : NetworkType.POD,
+        ip,
+      };
+    });
+};
+
+const getDefaultNetwork = (networks: Network[]) => {
+  if (networks.length === 1) {
+    return networks[0];
+  }
+  if (networks.length > 1) {
+    return (
+      networks.find((n) => n.type === NetworkType.POD && n.ip) ||
+      networks.find((n) => n.type === NetworkType.MULTUS)
+    );
+  }
+  return null;
+};
+
+const RdpServiceNotConfigured: React.FC<RdpServiceNotConfiguredProps> = ({ vm }) => (
+  <div className="kubevirt-vm-consoles__rdp">
+    <span>
+      This is a Windows virtual machine but no Service for the RDP (Remote Desktop Protocol) can be
+      found.
+    </span>
+    <br />
+    <span>
+      For better experience accessing Windows console, it is recommended to use the RDP. To do so,
+      create a service:
+      <ul>
+        <li>
+          exposing the{' '}
+          <b>
+            {DEFAULT_RDP_PORT}
+            /tcp
+          </b>{' '}
+          port of the virtual machine
+        </li>
+        <li>
+          using selector:{' '}
+          <b>
+            {TEMPLATE_VM_NAME_LABEL}: {getName(vm)}
+          </b>
+        </li>
+        <li>
+          Example: virtctl expose virtualmachine {getName(vm)} --name {getName(vm)}
+          -rdp --port [UNIQUE_PORT] --target-port {DEFAULT_RDP_PORT} --type NodePort
+        </li>
+      </ul>
+      Make sure, the VM object has <b>spec.template.metadata.labels</b> set to{' '}
+      <b>
+        {TEMPLATE_VM_NAME_LABEL}: {getName(vm)}
+      </b>
+    </span>
+  </div>
+);
+
+export const DesktopViewerSelector: React.FC<DesktopViewerSelectorProps> = (props) => {
+  const { vm, vmi, guestAgent, rdpServiceManual, vncServiceManual } = props;
+
+  const networks = React.useMemo(() => getVmRdpNetworks(vm, vmi), [vm, vmi]);
+  const networkItems = networks.reduce((result, network) => {
+    result[network.name] = network.name;
+    return result;
+  }, {});
+  const [selectedNetwork, setSelectedNetwork] = React.useState(getDefaultNetwork(networks));
+
+  const onNetworkChange = React.useCallback(
+    (newValue) => {
+      const selected = networks.find((n) => n.name === newValue);
+      setSelectedNetwork(selected);
+    },
+    [networks],
+  );
+
+  let content = null;
+  const networkType = selectedNetwork && selectedNetwork.type;
+  switch (networkType) {
+    case NetworkType.MULTUS:
+      if (!guestAgent) {
+        content = (
+          <Alert variant="warning" isInline title={GUEST_AGENT_WARNING_TITLE}>
+            {GUEST_AGENT_WARNING}
+          </Alert>
+        );
+      } else if (!selectedNetwork || !selectedNetwork.ip) {
+        content = (
+          <Alert variant="warning" isInline title={NO_IP_ADDRESS_TITLE}>{`${NO_IP_ADDRESS} ${
+            selectedNetwork ? selectedNetwork.name : ''
+          }`}</Alert>
+        );
+      } else {
+        const rdp = {
+          address: selectedNetwork.ip,
+          port: DEFAULT_RDP_PORT,
+        };
+        content = <DesktopViewer rdp={rdp} />;
+      }
+      break;
+    case NetworkType.POD:
+      content =
+        rdpServiceManual || vncServiceManual ? (
+          <DesktopViewer rdp={rdpServiceManual} vnc={vncServiceManual} />
+        ) : (
+          <RdpServiceNotConfigured vm={vm} />
+        );
+      break;
+    default:
+      // eslint-disable-next-line no-console
+      console.warn(`Unknown network interface type ${networkType}`);
+  }
+
+  return (
+    <div className="kubevirt-desktop-viewer-selector">
+      <Form isHorizontal>
+        <FormGroup
+          className="kubevirt-desktop-viewer-selector__form-group"
+          fieldId="network-dropdown"
+          label={NIC}
+        >
+          <Dropdown
+            id="network-dropdown"
+            onChange={onNetworkChange}
+            items={networkItems}
+            selectedKey={selectedNetwork ? selectedNetwork.name : undefined}
+            title={SELECT_NETWORK_INTERFACE}
+          />
+        </FormGroup>
+      </Form>
+      {content}
+    </div>
+  );
+};
+DesktopViewerSelector.displayName = 'DesktopViewer';
+
+type DesktopViewerSelectorProps = {
+  vm: VMKind;
+  vmi: VMIKind;
+  guestAgent: boolean;
+  rdpServiceManual: RDPConnectionDetailsManualType;
+  vncServiceManual: VNCConnectionDetailsManualType;
+};
+
+type RdpServiceNotConfiguredProps = {
+  vm: VMKind;
+};
+
+type Network = {
+  name: string;
+  type: NetworkType;
+  ip: string;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/serial-console-connector.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/serial-console-connector.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { AccessConsoles, SerialConsole } from '@patternfly/react-console';
+import { WSFactory } from '@console/internal/module/ws-factory';
+import { getName } from '@console/shared/src/selectors';
+import { VMIKind } from '../../types';
+
+const { CONNECTED, DISCONNECTED, LOADING } = AccessConsoles.constants;
+
+// The protocol is complex and backend implementation not stable - let's keep logging to simplify debugging in production.
+const { debug, info, error } = console;
+
+const onResize = (rows, cols) => {
+  debug(
+    'UI has been resized, pass this info to backend. [',
+    rows,
+    ', ',
+    cols,
+    ']. Ignoring since recently not supported by backend.',
+  );
+};
+
+// KubeVirt serial console is accessed via WebSocket proxy in k8s API.
+// Protocol used is "plain.kubevirt.io", means binary and single channel - forwarding of unix socket only (vmhandler sources).
+export const SerialConsoleConnector: React.FC<SerialConsoleConnectorProps> = (props) => {
+  const [status, setStatus] = React.useState(LOADING);
+  const [passKeys, setPassKeys] = React.useState(false);
+  const [ws, setWS] = React.useState();
+  const childSerialconsole = React.useRef(null);
+
+  const onBackendDisconnected = React.useCallback(
+    (event?: any) => {
+      debug('Backend has disconnected');
+      if (childSerialconsole.current) {
+        childSerialconsole.current.onConnectionClosed('Reason for disconnect provided by backend.');
+      }
+
+      if (event) {
+        info('Serial console connection closed, reason: ', event.reason);
+      }
+
+      ws && ws.destroy && ws.destroy();
+
+      setPassKeys(false);
+      setStatus(DISCONNECTED); // will close the terminal window
+    },
+    [ws],
+  );
+
+  const setConnected = React.useCallback(() => {
+    setStatus(CONNECTED);
+    setPassKeys(true);
+  }, [setStatus, setPassKeys]);
+
+  const onDataFromBackend = React.useCallback((data) => {
+    // plain.kubevirt.io is binary and single-channel protocol
+    debug('Backend sent data, pass them to the UI component. [', data, ']');
+    if (childSerialconsole.current) {
+      const reader = new FileReader();
+      reader.addEventListener('loadend', (e) => {
+        // Blob to text transformation ...
+        const target = (e.target || e.srcElement) as any;
+        const text = target.result;
+        childSerialconsole.current.onDataReceived(text);
+      });
+      reader.readAsText(data);
+    }
+  }, []);
+
+  const onConnect = React.useCallback(() => {
+    debug('SerialConsoleConnector.onConnect(), status = ', status, ', passKeys = ', passKeys);
+    const { vmi, host, path } = props;
+
+    if (ws) {
+      ws.destroy();
+      setStatus(LOADING);
+    }
+
+    const options = {
+      host,
+      path,
+      reconnect: false,
+      jsonParse: false,
+      subprotocols: ['plain.kubevirt.io'],
+    };
+
+    setWS(
+      new WSFactory(`${getName(vmi)}-serial`, options)
+        .onmessage(onDataFromBackend)
+        .onopen(setConnected)
+        .onclose(onBackendDisconnected)
+        .onerror((event) => {
+          error('WS error received: ', event);
+        }),
+    );
+  }, [status, passKeys, props, ws, onDataFromBackend, setConnected, onBackendDisconnected]);
+
+  const onData = React.useCallback(
+    (data) => {
+      debug(
+        'UI terminal component produced data, i.e. a key was pressed, pass it to backend. [',
+        data,
+        ']',
+      );
+      // data are resent back from backend so _will_ pass through onDataFromBackend
+      ws && ws.send(new Blob([data]));
+    },
+    [ws],
+  );
+
+  return (
+    <SerialConsole
+      onConnect={onConnect}
+      onDisconnect={onBackendDisconnected}
+      onResize={onResize}
+      onData={onData}
+      id="serial-console"
+      status={status}
+      ref={childSerialconsole}
+    />
+  );
+};
+SerialConsoleConnector.displayName = AccessConsoles.constants.SERIAL_CONSOLE_TYPE; // for child-recognition by AccessConsoles
+
+type SerialConsoleConnectorProps = {
+  vmi: VMIKind;
+  host: string;
+  path: string;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import { AccessConsoles, VncConsole } from '@patternfly/react-console';
+import { Button } from '@patternfly/react-core';
 import { Firehose, FirehoseResult, LoadingInline } from '@console/internal/components/utils';
-import { VmConsoles } from 'kubevirt-web-ui-components';
 import { getName, getNamespace } from '@console/shared';
-import { WSFactory } from '@console/internal/module/ws-factory';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { PodModel, ServiceModel } from '@console/internal/models';
 import {
@@ -15,14 +15,89 @@ import {
   getRdpConnectionDetails,
   getSerialConsoleConnectionDetails,
   getVncConnectionDetails,
+  isVMIRunning,
+  isGuestAgentConnected,
+  SerialConsoleConnectionDetailsType,
+  RDPConnectionDetailsType,
+  VNCConnectionDetailsType,
 } from '../../selectors/vmi';
 import { findVMPod } from '../../selectors/pod/selectors';
-import { VMIKind, VMKind } from '../../types/vm';
 import { getVMStatus } from '../../statuses/vm/vm';
 import { getLoadedData, getResource } from '../../utils';
-import { isWindows } from '../../selectors/vm';
+import { isVMStarting, isWindows } from '../../selectors/vm';
+import { VMIKind, VMKind } from '../../types/vm';
 import { menuActionStart } from './menu-actions';
+import { SerialConsoleConnector } from './serial-console-connector';
+import { DesktopViewerSelector } from './desktop-viewer-selector';
 import { VMTabProps } from './types';
+
+const { VNC_CONSOLE_TYPE } = AccessConsoles.constants;
+
+const VMIsDown: React.FC<VMIsDownProps> = ({ onStartVm }) => {
+  const action = (
+    <Button variant="link" onClick={onStartVm}>
+      start
+    </Button>
+  );
+
+  return (
+    <div className="co-m-pane__body">
+      <div className="kubevirt-vm-consoles__loading">
+        This Virtual Machine is down. Please {action} it to access its console.
+      </div>
+    </div>
+  );
+};
+
+const VMIsStarting: React.FC<VMIsStartingProps> = ({ LoadingComponent }) => (
+  <div className="co-m-pane__body">
+    <div className="kubevirt-vm-consoles__loading">
+      <LoadingComponent />
+      This Virtual Machine is still starting up. The console will be available soon.
+    </div>
+  </div>
+);
+
+const VMConsoles: React.FC<VMConsolesProps> = ({
+  vm,
+  vmi,
+  onStartVm,
+  vnc,
+  serial,
+  rdp,
+  LoadingComponent,
+}) => {
+  if (!isVMIRunning(vmi)) {
+    return isVMStarting(vm, vmi) ? (
+      <VMIsStarting LoadingComponent={LoadingComponent} />
+    ) : (
+      <VMIsDown onStartVm={onStartVm} />
+    );
+  }
+
+  const vncServiceManual = (vnc && vnc.manual) || undefined;
+  const rdpServiceManual = (rdp && rdp.manual) || undefined;
+
+  const desktopViewverSelector = isWindows(vm) && (
+    <DesktopViewerSelector
+      vncServiceManual={vncServiceManual}
+      rdpServiceManual={rdpServiceManual}
+      vm={vm}
+      vmi={vmi}
+      guestAgent={isGuestAgentConnected(vmi)}
+    />
+  );
+
+  return (
+    <div className="co-m-pane__body">
+      <AccessConsoles preselectedType={VNC_CONSOLE_TYPE} disconnectByChange={false}>
+        <SerialConsoleConnector {...serial} />
+        <VncConsole {...vnc} />
+        {desktopViewverSelector}
+      </AccessConsoles>
+    </div>
+  );
+};
 
 const VmConsolesWrapper: React.FC<VmConsolesWrapperProps> = (props) => {
   const { vm } = props;
@@ -44,7 +119,7 @@ const VmConsolesWrapper: React.FC<VmConsolesWrapperProps> = (props) => {
   }
 
   return (
-    <VmConsoles
+    <VMConsoles
       vm={vm}
       vmi={vmi}
       onStartVm={onStartVm}
@@ -52,18 +127,9 @@ const VmConsolesWrapper: React.FC<VmConsolesWrapperProps> = (props) => {
       serial={getSerialConsoleConnectionDetails(vmi)}
       rdp={rdp}
       LoadingComponent={LoadingInline}
-      WSFactory={WSFactory}
     />
   );
 };
-
-interface VmConsolesWrapperProps {
-  vm?: VMKind;
-  vmi?: FirehoseResult<VMIKind>;
-  services?: FirehoseResult<K8sResourceKind[]>;
-  pods?: FirehoseResult<K8sResourceKind[]>;
-  migrations?: FirehoseResult<K8sResourceKind[]>;
-}
 
 export const VMConsoleFirehose: React.FC<VMTabProps> = ({ obj: vm }) => {
   const name = getName(vm);
@@ -97,4 +163,30 @@ export const VMConsoleFirehose: React.FC<VMTabProps> = ({ obj: vm }) => {
       </Firehose>
     </div>
   );
+};
+
+type VmConsolesWrapperProps = {
+  vm?: VMKind;
+  vmi?: FirehoseResult<VMIKind>;
+  services?: FirehoseResult<K8sResourceKind[]>;
+  pods?: FirehoseResult<K8sResourceKind[]>;
+  migrations?: FirehoseResult<K8sResourceKind[]>;
+};
+
+type VMConsolesProps = {
+  vm: VMKind;
+  onStartVm: () => void;
+  LoadingComponent: React.ComponentType;
+  vmi?: VMIKind;
+  vnc?: VNCConnectionDetailsType;
+  serial?: SerialConsoleConnectionDetailsType;
+  rdp?: RDPConnectionDetailsType;
+};
+
+type VMIsDownProps = {
+  onStartVm: () => void;
+};
+
+type VMIsStartingProps = {
+  LoadingComponent: React.ComponentType;
 };

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/combined.ts
@@ -8,7 +8,9 @@ import {
   VM_STATUS_IMPORTING,
   VM_STATUS_V2V_CONVERSION_IN_PROGRESS,
 } from '../../statuses/vm/constants';
-import { isVMRunning } from './selectors';
+import { OS_WINDOWS_PREFIX } from '../../constants';
+import { isVMIRunning } from '../vmi/basic';
+import { isVMRunning, getOperatingSystem } from './selectors';
 
 const IMPORTING_STATUSES = new Set([VM_STATUS_IMPORTING, VM_STATUS_V2V_CONVERSION_IN_PROGRESS]);
 
@@ -17,6 +19,11 @@ export const isVMImporting = (status: VMMultiStatus): boolean =>
 
 export const isVMRunningWithVMI = ({ vm, vmi }: { vm: VMKind; vmi: VMIKind }): boolean =>
   isVMRunning(vm) && !_.isEmpty(vmi);
+
+export const isVMStarting = (vm: VMKind, vmi: VMIKind) => isVMRunning(vm) && !isVMIRunning(vmi);
+
+export const isWindows = (vm: VMKind): boolean =>
+  (getOperatingSystem(vm) || '').startsWith(OS_WINDOWS_PREFIX);
 
 export const findConversionPod = (vm: VMKind, pods: PodKind[]) => {
   if (!pods) {

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -7,7 +7,6 @@ import {
   TEMPLATE_OS_LABEL,
   TEMPLATE_OS_NAME_ANNOTATION,
   TEMPLATE_WORKLOAD_LABEL,
-  OS_WINDOWS_PREFIX,
 } from '../../constants/vm';
 import { V1Network, V1NetworkInterface, VMKind, VMLikeEntityKind, CPURaw } from '../../types';
 import { findKeySuffixValue, getSimpleName, getValueByPrefix } from '../utils';
@@ -44,7 +43,7 @@ export const getDataVolumeTemplates = (vm: VMKind, defaultValue = []) =>
 
 export const getOperatingSystem = (vm: VMLikeEntityKind): string =>
   findKeySuffixValue(getLabels(vm), TEMPLATE_OS_LABEL);
-export const getOperatingSystemName = (vm: VMKind) =>
+export const getOperatingSystemName = (vm: VMKind): string =>
   getValueByPrefix(getAnnotations(vm), `${TEMPLATE_OS_NAME_ANNOTATION}/${getOperatingSystem(vm)}`);
 export const getWorkloadProfile = (vm: VMLikeEntityKind) =>
   findKeySuffixValue(getLabels(vm), TEMPLATE_WORKLOAD_LABEL);
@@ -130,6 +129,3 @@ export const getStorageClassNameByDisk = (vm: VMKind, diskName: string) =>
   getDataVolumeStorageClassName(
     getDataVolumeTemplates(vm).find((vol) => getName(vol).includes(diskName)),
   );
-
-export const isWindows = (vm: VMKind) =>
-  (getOperatingSystem(vm) || '').startsWith(OS_WINDOWS_PREFIX);

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
@@ -19,3 +19,8 @@ export const getVMIConditionsByType = (
 
 export const getVmiTemplateLabels = (vmi: VMIKind): { [key: string]: string } =>
   (_.get(vmi, 'vmi.spec.template.metadata') && vmi.spec.template.metadata.labels) || {};
+
+export const isVMIRunning = (vmi: VMIKind) => vmi && vmi.status && vmi.status.phase === 'Running';
+
+export const getVMIInterfaces = (vmi: VMIKind) =>
+  (vmi && vmi.status && vmi.status.interfaces) || [];

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/combined.ts
@@ -37,7 +37,7 @@ export const getRdpConnectionDetails = (
   vmi: VMIKind,
   rdpService: K8sResourceKind,
   launcherPod: PodKind,
-) => {
+): RDPConnectionDetailsType => {
   if (!vmi || !rdpService) {
     return undefined;
   }
@@ -48,7 +48,9 @@ export const getRdpConnectionDetails = (
   };
 };
 
-export const getSerialConsoleConnectionDetails = (vmi: VMIKind) => {
+export const getSerialConsoleConnectionDetails = (
+  vmi: VMIKind,
+): SerialConsoleConnectionDetailsType => {
   if (!vmi) {
     return undefined;
   }
@@ -62,7 +64,7 @@ export const getSerialConsoleConnectionDetails = (vmi: VMIKind) => {
   };
 };
 
-export const getVncConnectionDetails = (vmi: VMIKind) => {
+export const getVncConnectionDetails = (vmi: VMIKind): VNCConnectionDetailsType => {
   if (!vmi) {
     return undefined;
   }
@@ -85,4 +87,37 @@ export const getVncConnectionDetails = (vmi: VMIKind) => {
     },
     */
   };
+};
+
+const getVMIStatusConditions = (vmi: VMIKind) => (vmi && vmi.status && vmi.status.conditions) || [];
+
+export const isGuestAgentConnected = (vmi: VMIKind): boolean =>
+  getVMIStatusConditions(vmi).some(
+    (condition) => condition.type === 'AgentConnected' && condition.status === 'True',
+  );
+
+export type VNCConnectionDetailsType = {
+  encrypt: boolean;
+  host: string;
+  port: string | number;
+  path: string;
+  manual: VNCConnectionDetailsManualType; // so far not used, kept for compatibility and future extension when VNC can be accessed directly without k8s API proxy
+};
+
+export type SerialConsoleConnectionDetailsType = {
+  vmi: VMIKind;
+  host: string;
+  path: string;
+};
+
+export type VNCConnectionDetailsManualType = {};
+
+export type RDPConnectionDetailsManualType = {
+  address: string;
+  port: number | string;
+};
+
+export type RDPConnectionDetailsType = {
+  vmi: VMIKind;
+  manual: RDPConnectionDetailsManualType;
 };


### PR DESCRIPTION
Part of the gradual effort to remove the kubevirt-web-ui-components dependency.