### PR TITLE
Bug 1749469: Align event types with k8s

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { AccordionContent, AccordionItem, AccordionToggle } from '@patternfly/react-core';
 import classNames from 'classnames';
-import { RedExclamationCircleIcon } from '@console/shared';
-import { categoryFilter, getLastTime } from '@console/internal/components/events';
+import { typeFilter, getLastTime } from '@console/internal/components/events';
 import { twentyFourHourTime } from '@console/internal/components/utils/datetime';
 import { ResourceIcon } from '@console/internal/components/utils/resource-icon';
 import { ResourceLink } from '@console/internal/components/utils/resource-link';
 import { EventKind, referenceFor } from '@console/internal/module/k8s';
+import { YellowExclamationTriangleIcon } from '../../status';
 
 const propsAreEqual = (prevProps: EventItemProps, nextProps: EventItemProps) =>
   prevProps.event.metadata.uid === nextProps.event.metadata.uid &&
@@ -15,9 +15,9 @@ const propsAreEqual = (prevProps: EventItemProps, nextProps: EventItemProps) =>
   prevProps.onToggle === nextProps.onToggle;
 
 const EventItem: React.FC<EventItemProps> = React.memo(({ event, isExpanded, onToggle }) => {
-  const { involvedObject, message, reason, metadata } = event;
+  const { involvedObject, message, metadata } = event;
   const lastTime = getLastTime(event);
-  const isError = categoryFilter('error', { reason });
+  const isWarning = typeFilter('warning', event);
   const expanded = isExpanded(metadata.uid);
   return (
     <div className="co-recent-item__body">
@@ -27,7 +27,7 @@ const EventItem: React.FC<EventItemProps> = React.memo(({ event, isExpanded, onT
           isExpanded={expanded}
           id={metadata.uid}
           className={classNames('co-recent-item__toggle', {
-            'co-recent-item--error': isError && expanded,
+            'co-recent-item--warning': isWarning && expanded,
           })}
         >
           <div className="co-recent-item__title">
@@ -39,8 +39,8 @@ const EventItem: React.FC<EventItemProps> = React.memo(({ event, isExpanded, onT
               )}
             </div>
             <div className="co-recent-item__title-message">
-              {isError && (
-                <RedExclamationCircleIcon className="co-dashboard-icon co-recent-item__icon--error" />
+              {isWarning && (
+                <YellowExclamationTriangleIcon className="co-dashboard-icon co-recent-item__icon--warning" />
               )}
               {!expanded && (
                 <>
@@ -53,7 +53,9 @@ const EventItem: React.FC<EventItemProps> = React.memo(({ event, isExpanded, onT
         </AccordionToggle>
         <AccordionContent
           isHidden={!expanded}
-          className={classNames('co-recent-item__content', { 'co-recent-item--error': isError })}
+          className={classNames('co-recent-item__content', {
+            'co-recent-item--warning': isWarning,
+          })}
         >
           <div>
             <div className="co-recent-item__content-header">

--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
@@ -40,8 +40,8 @@
     padding-right: var(--pf-c-card--child--PaddingRight);
   }
 
-  .co-recent-item--error {
-    border-left-color: var(--pf-global--danger-color--100);
+  .co-recent-item--warning {
+    border-left-color: var(--pf-global--warning-color--100);
   }
 
   .pf-c-accordion__toggle {
@@ -104,7 +104,7 @@
   white-space: nowrap;
 }
 
-.co-recent-item__icon--error {
+.co-recent-item__icon--warning {
   align-items: center;
   display: flex;
   margin-right: 0.3rem;

--- a/frontend/packages/console-shared/src/components/dashboard/events-card/EventItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/events-card/EventItem.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { RedExclamationCircleIcon } from '@console/shared';
-import { categoryFilter, getLastTime } from '@console/internal/components/events';
+import { typeFilter, getLastTime } from '@console/internal/components/events';
 import { EventComponentProps } from '@console/internal/components/utils/event-stream';
 import { twentyFourHourTime } from '@console/internal/components/utils/datetime';
 
 const EventItem: React.FC<EventComponentProps> = React.memo(({ event }) => {
   const { message } = event;
   const lastTime = getLastTime(event);
-  const isError = categoryFilter('error', event);
+  const isError = typeFilter('warning', event);
   return (
     <div className="co-events-card__item">
       <div className="co-recent-item__title">

--- a/frontend/public/components/_sysevent-icon.scss
+++ b/frontend/public/components/_sysevent-icon.scss
@@ -10,14 +10,12 @@
 }
 
 
-.co-sysevent--error {
-  $failure-red: #d64456;
-
+.co-sysevent--warning {
   .co-sysevent-icon,
   .co-sysevent__box {
-    border-color: $failure-red;
+    border-color: var(--pf-global--warning-color--100);
   }
   .co-sysevent__icon-line {
-    background-color: $failure-red;
+    background-color: var(--pf-global--warning-color--100);
   }
 }

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -113,7 +113,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
               <span className="co-resource-icon--fixed-width">
                 <ResourceIcon kind="All" />
               </span>
-              <span className="co-resource-item__resource-name">All Types</span>
+              <span className="co-resource-item__resource-name">All Resources</span>
             </span>
             {/* <ResourceIcon kind="All" /> */}
           </>


### PR DESCRIPTION
Console currently uses Info/Error types for Events but k8s has Normal/Warning. This PR aligns terminology with k8s and also changes colors from red to yellow.

Before this change Event was categorized on basis of words in `reason` field - if it contained any of `error, failed, unhealthy, nodenotready` than the event was considered as error type - after this change we categorize events by `type` field.

![events](https://user-images.githubusercontent.com/2078045/70045832-15667c00-15c5-11ea-8de5-b558f71fc983.png)
![events_dashboard](https://user-images.githubusercontent.com/2078045/70045835-1697a900-15c5-11ea-9105-91d79ad24b34.png)

This change is based on the feedback for 4.3 dashboards https://docs.google.com/document/d/1YfS8QXLvm1Iw2M-9P3dPNrmS6rOHJkMbqAbbLYO53QE/edit#heading=h.ksft1vlhuehh

@spadgett @andybraren 