### PR TITLE
Add view alerts link to status card

### DIFF
--- a/frontend/public/components/dashboard/dashboards-page/overview-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/overview-dashboard/status-card.tsx
@@ -13,6 +13,7 @@ import { Gallery, GalleryItem, Button } from '@patternfly/react-core';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
+import DashboardCardLink from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardLink';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
@@ -292,6 +293,7 @@ export const StatusCard = connect(mapStateToProps)(
       <DashboardCard>
         <DashboardCardHeader>
           <DashboardCardTitle>Status</DashboardCardTitle>
+          <DashboardCardLink to="monitoring/alerts">View alerts</DashboardCardLink>
         </DashboardCardHeader>
         <DashboardCardBody>
           <HealthBody>


### PR DESCRIPTION
Design has a dropdown with more options (generate diagnostic report) but currently we have only one action here, so Im rendering just a simple link. I also changed wording from `View all alerts` to `View alerts` to align with rest of the cards (`View events`, `View settings`) 

@andybraren 

![view_alerts](https://user-images.githubusercontent.com/2078045/70048451-a2600400-15ca-11ea-8944-49c0310fe8c8.png)
