### PR TITLE
Humanize inventory numbers

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
@@ -12,7 +12,7 @@ import {
   AccordionContent,
 } from '@patternfly/react-core';
 import * as plugins from '@console/internal/plugins';
-import { pluralize } from '@console/internal/components/utils';
+import { pluralize, humanizeNumberSI } from '@console/internal/components/utils';
 import { isDashboardsInventoryItemGroup } from '@console/plugin-sdk';
 import { InventoryStatusGroup } from './status-group';
 import './inventory-card.scss';
@@ -72,7 +72,7 @@ const InventoryItem: React.FC<InventoryItemProps> = React.memo(
   }) => {
     const [expanded, setExpanded] = React.useState(false);
     const onClick = React.useCallback(() => setExpanded(!expanded), [expanded]);
-    const titleMessage = isLoading || error ? title : pluralize(count, title, titlePlural);
+    const titleMessage = isLoading || error ? title : pluralize(count, title, titlePlural, true);
     return ExpandedComponent ? (
       <Accordion
         asDefinitionList={false}
@@ -138,7 +138,7 @@ export const Status = connectToFlags<StatusProps>(
   return (
     <div className="co-inventory-card__status">
       <span className="co-dashboard-icon">{groupIcon}</span>
-      <span className="co-inventory-card__status-text">{count}</span>
+      <span className="co-inventory-card__status-text">{humanizeNumberSI(count).string}</span>
     </div>
   );
 });
@@ -160,7 +160,7 @@ const StatusLink = connectToFlags<StatusLinkProps>(
     <div className="co-inventory-card__status">
       <Link to={to} style={{ textDecoration: 'none' }}>
         <span className="co-dashboard-icon">{groupIcon}</span>
-        <span className="co-inventory-card__status-text">{count}</span>
+        <span className="co-inventory-card__status-text">{humanizeNumberSI(count).string}</span>
       </Link>
     </div>
   );

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -14,9 +14,17 @@ import {
   useAccessReview,
 } from './index';
 import { K8sResourceKind, modelFor, referenceFor, Toleration } from '../../module/k8s';
+import { humanizeNumberSI } from './units';
 
-export const pluralize = (i: number, singular: string, plural: string = `${singular}s`) =>
-  `${i || 0} ${i === 1 ? singular : plural}`;
+export const pluralize = (
+  i: number,
+  singular: string,
+  plural: string = `${singular}s`,
+  humanize?: boolean,
+) => {
+  const count = i || 0;
+  return `${humanize ? humanizeNumberSI(count).string : count} ${i === 1 ? singular : plural}`;
+};
 
 export const detailsPage = <T extends {}>(Component: React.ComponentType<T>) =>
   function DetailsPage(props: T) {


### PR DESCRIPTION
![pods_humanized](https://user-images.githubusercontent.com/2078045/70048934-c1ab6100-15cb-11ea-9a28-5b714e5eab2c.png)

@andybraren instead of 3920 pods we will show 3.92k etc. WDYT?