### PR TITLE
fix text overflow for event source

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
@@ -99,9 +99,12 @@
 .co-recent-item__content-resourcelink {
   display: block;
   flex: 2 0 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+
+  .co-resource-item__resource-name {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
 }
 
 .co-recent-item__icon--error {


### PR DESCRIPTION

![event_long](https://user-images.githubusercontent.com/2078045/70059235-b6166500-15e0-11ea-926e-fb44e33d951a.png)

before
![event_long_before](https://user-images.githubusercontent.com/2078045/70059233-b4e53800-15e0-11ea-8af3-27617d6d09cb.png)
