### PR TITLE
Update to TypeScript 3.7.2

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -1,4 +1,4 @@
-import { Config, browser, logging, $ } from 'protractor';
+import { browser, $ } from 'protractor';
 import { execSync } from 'child_process';
 import { promise as webdriverpromise } from 'selenium-webdriver';
 import * as HtmlScreenshotReporter from 'protractor-jasmine2-screenshot-reporter';
@@ -36,7 +36,7 @@ const junitReporter = new JUnitXmlReporter({
   savePath: `./${screenshotsDir}`,
   consolidateAll: true,
 });
-const browserLogs: logging.Entry[] = [];
+const browserLogs = [];
 
 const suite = (tests: string[]): string[] =>
   (!_.isNil(process.env.BRIDGE_KUBEADMIN_PASSWORD) ? ['tests/login.scenario.ts'] : []).concat([
@@ -121,7 +121,7 @@ const testSuites = {
   login: ['tests/login.scenario.ts'],
 };
 
-export const config: Config = {
+export const config = {
   framework: 'jasmine',
   directConnect: true,
   skipSourceMapSupport: true,

--- a/frontend/integration-tests/protractor.d.ts
+++ b/frontend/integration-tests/protractor.d.ts
@@ -1,0 +1,12 @@
+// https://github.com/angular/protractor/issues/5348#issuecomment-558790111
+// Note: This stub exists to override Protractor types which are incompatible with TS 3.7 as of 5.4.2 and 6.0.0
+declare module 'protractor' {
+  let $: any;
+  let $$: any;
+  let browser: any;
+  let by: any;
+  let element: any;
+  let ExpectedConditions: any;
+  let Key: any;
+  let until: any;
+}

--- a/frontend/integration-tests/tests/performance.scenario.ts
+++ b/frontend/integration-tests/tests/performance.scenario.ts
@@ -37,14 +37,14 @@ describe('Performance test', () => {
     await browser.get(`${appHost}/k8s/ns/openshift-console/configmaps`);
     await crudView.isLoaded();
 
-    const initialChunks = await browser.executeScript<{ name: string; size: number }[]>(() =>
+    const initialChunks = await browser.executeScript(() =>
       performance.getEntriesByType('resource').filter(({ name }) => name.endsWith('.js')),
     );
 
     await crudView.clickKebabAction('console-config', 'Edit Config Map');
     await yamlView.isLoaded();
 
-    const postChunks = await browser.executeScript<{ name: string; size: number }[]>(() =>
+    const postChunks = await browser.executeScript(() =>
       performance.getEntriesByType('resource').filter(({ name }) => name.endsWith('.js')),
     );
 
@@ -70,7 +70,7 @@ describe('Performance test', () => {
       await sidenavView.clickNavLink([route.section, route.name]);
       await browser.wait(crudView.untilNoLoadersPresent);
 
-      const routeChunk = await browser.executeScript<PerformanceEntry>(routeChunkFor, routeName);
+      const routeChunk = await browser.executeScript(routeChunkFor, routeName);
 
       expect(routeChunk).not.toBeNull();
       // FIXME: Really need to address this chunk size

--- a/frontend/integration-tests/views/secrets.view.ts
+++ b/frontend/integration-tests/views/secrets.view.ts
@@ -1,12 +1,4 @@
-import {
-  $,
-  $$,
-  browser,
-  by,
-  ExpectedConditions as until,
-  element,
-  ElementFinder,
-} from 'protractor';
+import { $, $$, browser, by, ExpectedConditions as until, element } from 'protractor';
 import { Base64 } from 'js-base64';
 import { execSync } from 'child_process';
 import * as _ from 'lodash';
@@ -73,7 +65,7 @@ export const clickRevealValues = async () => {
 export const encode = (username, password) => Base64.encode(`${username}:${password}`);
 
 export const createSecret = async (
-  linkElement: ElementFinder,
+  linkElement: any,
   ns: string,
   name: string,
   updateForm: Function,

--- a/frontend/integration-tests/views/yaml.view.ts
+++ b/frontend/integration-tests/views/yaml.view.ts
@@ -9,8 +9,7 @@ export const isLoaded = () =>
     .then(() => browser.sleep(1000));
 
 const getValue = () => (window as any).monaco.editor.getModels()[0].getValue();
-export const getEditorContent = async (): Promise<string> =>
-  await browser.executeScript<string>(getValue);
+export const getEditorContent = async (): Promise<string> => await browser.executeScript(getValue);
 
 const setValue = (text) => (window as any).monaco.editor.getModels()[0].setValue(text);
 export const setEditorContent = async (text: string) => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -194,7 +194,7 @@
     "ts-jest": "21.x",
     "ts-loader": "5.3.3",
     "ts-node": "5.x",
-    "typescript": "3.6.3",
+    "typescript": "3.7.2",
     "webpack": "4.40.2",
     "webpack-bundle-analyzer": "^3.5.0",
     "webpack-cli": "^3.3.9",

--- a/frontend/packages/console-shared/src/components/popper/Popper.tsx
+++ b/frontend/packages/console-shared/src/components/popper/Popper.tsx
@@ -5,7 +5,7 @@ import Portal from './Portal';
 
 // alignment with PopperJS reference API
 type PopperJSReference = {
-  getBoundingClientRect: Element['getBoundingClientRect'];
+  getBoundingClientRect: PopperJS['reference']['getBoundingClientRect'];
   clientWidth: number;
   clientHeight: number;
 };
@@ -17,16 +17,14 @@ type Reference = Element | PopperJSReference | ClientRectProp;
 class VirtualReference implements PopperJSReference {
   private rect: ClientRect;
 
-  constructor(rect: ClientRectProp) {
-    const width = rect.width || 0;
-    const height = rect.height || 0;
+  constructor({ height = 0, width = 0, x, y }: ClientRectProp) {
     this.rect = {
-      left: rect.x,
-      top: rect.y,
-      right: rect.x + width,
-      bottom: rect.y + height,
-      width,
+      bottom: y + height,
       height,
+      left: x,
+      right: x + width,
+      top: y,
+      width,
     };
   }
 

--- a/frontend/packages/console-shared/src/test-utils/utils.ts
+++ b/frontend/packages/console-shared/src/test-utils/utils.ts
@@ -1,14 +1,6 @@
 /* eslint-disable no-await-in-loop, no-console, no-underscore-dangle */
 import { execSync } from 'child_process';
-import {
-  $,
-  by,
-  ElementFinder,
-  browser,
-  ExpectedConditions as until,
-  element,
-  ElementArrayFinder,
-} from 'protractor';
+import { $, by, browser, ExpectedConditions as until, element } from 'protractor';
 import { By } from 'selenium-webdriver';
 import { config } from '@console/internal-integration-tests/protractor.conf';
 
@@ -86,7 +78,7 @@ export async function withResource(
   }
 }
 
-export async function click(elem: ElementFinder, timeout?: number) {
+export async function click(elem: any, timeout?: number) {
   const _timeout = resolveTimeout(timeout, config.jasmineNodeOpts.defaultTimeoutInterval);
   await browser.wait(until.elementToBeClickable(elem), _timeout);
   await elem.click();
@@ -132,21 +124,21 @@ export async function asyncForEach(iterable, callback) {
   }
 }
 
-export const waitForCount = (elementArrayFinder: ElementArrayFinder, targetCount: number) => {
+export const waitForCount = (elementArrayFinder: any, targetCount: number) => {
   return async () => {
     const count = await elementArrayFinder.count();
     return count === targetCount;
   };
 };
 
-export const waitForStringInElement = (elem: ElementFinder, needle: string) => {
+export const waitForStringInElement = (elem: any, needle: string) => {
   return async () => {
     const content = await elem.getText();
     return content.includes(needle);
   };
 };
 
-export const waitForStringNotInElement = (elem: ElementFinder, needle: string) => {
+export const waitForStringNotInElement = (elem: any, needle: string) => {
   return async () => {
     const content = await elem.getText();
     return !content.includes(needle);

--- a/frontend/packages/dev-console/integration-tests/views/git-import-flow.view.ts
+++ b/frontend/packages/dev-console/integration-tests/views/git-import-flow.view.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console, promise/catch-or-return */
-import { ElementFinder, browser, ExpectedConditions as until, by, element, Key } from 'protractor';
+import { browser, ExpectedConditions as until, by, element, Key } from 'protractor';
 
 export const addNavigate = element(by.css('[data-test-id="+Add-header"]'));
 export const gitImportButton = element(by.css('[data-test-id="import-from-git"]'));
@@ -36,7 +36,7 @@ export const enterGitRepoUrl = async function(gitUrl: string) {
 };
 
 export const safeSendKeys = async function(
-  uiElement: ElementFinder,
+  uiElement: any,
   uiElementName: string,
   newValue: string,
 ) {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import { execSync } from 'child_process';
 import * as _ from 'lodash';
-import { $, $$, ElementFinder, browser, by, ExpectedConditions as until } from 'protractor';
+import { $, $$, browser, by, ExpectedConditions as until } from 'protractor';
 import { appHost } from '@console/internal-integration-tests/protractor.conf';
 import {
   isLoaded,
@@ -12,7 +12,7 @@ import { click } from '@console/shared/src/test-utils/utils';
 import { STORAGE_CLASS, PAGE_LOAD_TIMEOUT_SECS } from './consts';
 import { NodePortService } from './types';
 
-export async function fillInput(elem: ElementFinder, value: string) {
+export async function fillInput(elem: any, value: string) {
   // Sometimes there seems to be an issue with clear() method not clearing the input
   let attempts = 3;
   do {
@@ -52,23 +52,23 @@ export async function createProject(name: string) {
   }
 }
 
-export async function getInputValue(elem: ElementFinder) {
+export async function getInputValue(elem: any) {
   return elem.getAttribute('value');
 }
 
-export async function getSelectedOptionText(selector: ElementFinder) {
+export async function getSelectedOptionText(selector: any) {
   return selector.$('option:checked').getText();
 }
 
-export async function selectOptionByText(selector: ElementFinder, option: string) {
+export async function selectOptionByText(selector: any, option: string) {
   await click(selector.all(by.cssContainingText('option', option)).first());
 }
 
-export async function selectOptionByOptionValue(selector: ElementFinder, option: string) {
+export async function selectOptionByOptionValue(selector: any, option: string) {
   await click(selector.all(by.css(`option[value="${option}"]`)).first());
 }
 
-export async function getSelectOptions(selector: ElementFinder): Promise<string[]> {
+export async function getSelectOptions(selector: any): Promise<string[]> {
   const options = [];
   await selector.$$('option').each((elem) => {
     elem

--- a/frontend/packages/network-attachment-definition-plugin/integration-tests/tests/models/nadForm.ts
+++ b/frontend/packages/network-attachment-definition-plugin/integration-tests/tests/models/nadForm.ts
@@ -1,4 +1,4 @@
-import { browser, ElementFinder, ExpectedConditions as until } from 'protractor';
+import { browser, ExpectedConditions as until } from 'protractor';
 import { BROWSER_TIMEOUT, testName } from '@console/internal-integration-tests/protractor.conf';
 import { createYAMLButton, isLoaded } from '@console/internal-integration-tests/views/crud.view';
 import { PAGE_LOAD_TIMEOUT_SECS } from '@console/kubevirt-plugin/integration-tests/tests/utils/consts';
@@ -6,7 +6,7 @@ import { click, selectDropdownOptionById } from '@console/shared/src/test-utils/
 import * as nadFormView from '../../views/nad.form.view';
 
 // TODO See about moving this function from kubevirt-plugin to console-shared
-async function fillInput(elem: ElementFinder, value: string) {
+async function fillInput(elem: any, value: string) {
   // Sometimes there seems to be an issue with clear() method not clearing the input
   let attempts = 3;
 

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
@@ -1,13 +1,5 @@
 import { execSync } from 'child_process';
-import {
-  browser,
-  element,
-  by,
-  $,
-  $$,
-  ExpectedConditions as until,
-  ElementFinder,
-} from 'protractor';
+import { browser, element, by, $, $$, ExpectedConditions as until } from 'protractor';
 import { safeDump } from 'js-yaml';
 import { startCase, get, find, isUndefined } from 'lodash';
 import {
@@ -83,7 +75,7 @@ const defaultValueFor = <C extends SpecCapability | StatusCapability>(capability
   }
 };
 
-const inputValueFor = (capability: SpecCapability) => async (el: ElementFinder) => {
+const inputValueFor = (capability: SpecCapability) => async (el: any) => {
   switch (capability) {
     case SpecCapability.podCount:
       return parseInt(await el.$('input').getAttribute('value'), 10);

--- a/frontend/public/module/k8s/swagger.ts
+++ b/frontend/public/module/k8s/swagger.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash-es';
 
 import { STORAGE_PREFIX } from '../../const';
 import { coFetchJSON } from '../../co-fetch';
-import { K8sKind, referenceForModel, SwaggerDefinitions } from './';
+import { K8sKind, referenceForModel } from './';
 
 const SWAGGER_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/swagger-definitions`;
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,7 +12,10 @@
     "experimentalDecorators": true,
     "sourceMap": true,
     "noUnusedLocals": true,
-    "types": ["jest"]
+    "types": ["jest"],
+    "paths": {
+      "protractor": ["integration-tests/protractor.d.ts"]
+    }
   },
   "exclude": [".yarn", "**/node_modules", "public/dist"],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16002,10 +16002,10 @@ typescript@3.4.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
   integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
-typescript@3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
Update to TypeScript 3.7.2

Fix breaking changes:
- Fix PopperJSReference type and slightly refactor the class constructor.
- Work around for https://github.com/angular/protractor/issues/5348 - Override Protractor types to prevent TS errors. Protractor functions are no longer type safe, and references to Protractor types have been removed from our test cases and config.



