### PR TITLE
Add required class to form <h3> heading that contains, at least, 1 or more required fields

### DIFF
--- a/frontend/public/components/cluster-settings/request-header-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/request-header-idp-form.tsx
@@ -151,7 +151,7 @@ export class AddRequestHeaderPage extends PromiseComponent<{}, AddRequestHeaderP
           </p>
           <IDPNameInput value={name} onChange={this.nameChanged} />
           <div className="co-form-section__separator" />
-          <h3>URLs</h3>
+          <h3 className="co-required">URLs</h3>
           <p className="co-m-pane__explanation">At least one URL must be provided.</p>
           <div className="form-group">
             <label className="control-label" htmlFor="challenge-url">

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -12,10 +12,16 @@
   flex-flow: row-reverse;
 }
 
-.co-required:after {
-  color: $color-pf-red-200;
-  content: '*';
-  padding-left: 3px;
+.co-required {
+  position: relative;
+  &:after {
+    color: $color-pf-red-200;
+    content: '*';
+    font-size: $font-size-base;
+    padding-left: 3px;
+    position: absolute;
+    top: 0;
+  }
 }
 
 .co-form-section__label {


### PR DESCRIPTION
Set explicit `font-size` and `position`, so that asterisk is consistent to usage on `<label>` 

fix https://bugzilla.redhat.com/show_bug.cgi?id=1772814
<img width="607" alt="Screen Shot 2019-12-03 at 4 26 28 PM" src="https://user-images.githubusercontent.com/1874151/70091850-02ff3900-15eb-11ea-8a33-228938c60717.png">
