### PR TITLE
add test and code coverage scripts to dev-console

### DIFF
--- a/frontend/packages/dev-console/package.json
+++ b/frontend/packages/dev-console/package.json
@@ -4,7 +4,9 @@
   "description": "OpenShift Developer Perspective",
   "private": true,
   "scripts": {
-    "lint": "yarn --cwd ../.. eslint packages/dev-console"
+    "coverage": "yarn test --coverage --collectCoverageFrom='[\"packages/dev-console/src/**\",\"!**/__tests__/**\",\"!packages/dev-console/src/test/**\"]'",
+    "lint": "yarn --cwd ../.. eslint packages/dev-console",
+    "test": "yarn --cwd ../.. run test packages/dev-console"
   },
   "dependencies": {
     "@console/git-service": "0.0.0-fixed",

--- a/frontend/packages/git-service/package.json
+++ b/frontend/packages/git-service/package.json
@@ -4,6 +4,11 @@
   "description": "Git Service Utility for Git Validation and Language Detection.",
   "private": true,
   "main": "src/index.ts",
+  "scripts": {
+    "coverage": "yarn test --coverage --collectCoverageFrom='[\"packages/git-service/src/**\",\"!**/__tests__/**\"]'",
+    "lint": "yarn --cwd ../.. eslint packages/git-service",
+    "test": "yarn --cwd ../.. run test packages/git-service"
+  },
   "dependencies": {
     "@octokit/rest": "^16.30.1",
     "bitbucket": "^1.15.1",

--- a/frontend/packages/knative-plugin/package.json
+++ b/frontend/packages/knative-plugin/package.json
@@ -4,6 +4,11 @@
   "description": "Knative - Kubernetes-based platform to build, deploy, and manage modern serverless workloads",
   "private": true,
   "main": "src/index.ts",
+  "scripts": {
+    "coverage": "yarn test --coverage --collectCoverageFrom='[\"packages/knative-plugin/src/**\",\"!**/__tests__/**\"]'",
+    "lint": "yarn --cwd ../.. eslint packages/knative-plugin",
+    "test": "yarn --cwd ../.. run test packages/knative-plugin"
+  },
   "dependencies": {
     "@console/plugin-sdk": "0.0.0-fixed"
   },

--- a/frontend/packages/topology/package.json
+++ b/frontend/packages/topology/package.json
@@ -32,7 +32,10 @@
     "webcola": "3.4.0"
   },
   "scripts": {
+    "build-storybook": "build-storybook",
+    "coverage": "yarn test --coverage --collectCoverageFrom='[\"packages/topology/src/**\",\"!**/__tests__/**\"]'",
+    "lint": "yarn --cwd ../.. eslint packages/topology",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "test": "yarn --cwd ../.. run test packages/topology"
   }
 }


### PR DESCRIPTION
Adds `test` and `coverage` scripts to `dev-console` package.
Adds `test`, `coverage` and `lint` scripts to `git-service`, `knative-plugin` and `topology` packages.

Can more easily test and retrieve package specific code coverage results.

/assign @andrewballantyne 