### PR TITLE
Use common method to render the cd summary

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-summary.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-summary.scss
@@ -1,0 +1,3 @@
+.co-vm-details-cd-roms--datalist--dd {
+  margin-bottom: var(--pf-global--spacer--sm);
+}

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-summary.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-summary.tsx
@@ -9,56 +9,48 @@ import { WINTOOLS_CONTAINER_NAMES } from '../modals/cdrom-vm-modal/constants';
 import { VMKind } from '../../types';
 import { V1Disk } from '../../types/vm/disk/V1Disk';
 
-const DiskSummaryRow: React.FC<DiskSummaryRowProps> = ({ title, value }) => (
-  <div className="kubevirt-disk-summary__disk">
-    <div id={`kubevirt-disk-summary-disk-title-${title}`}>{title}</div>
-    <div id={`kubevirt-disk-summary-disk-value-${value}`}>{value}</div>
-  </div>
-);
+import './disk-summary.scss';
 
 export const DiskSummary: React.FC<DiskSummaryProps> = ({ disks, vm }) => (
-  <div className="kubevirt-disk-summary">
-    {disks.map(({ name }, i) => {
+  <dl className="oc-vm-details__datalist kubevirt-disk-summary">
+    {disks.map(({ name }) => {
       const container = getContainerImageByDisk(vm, name);
       const pvc = getPVCSourceByDisk(vm, name);
       const url = getURLSourceByDisk(vm, name);
+      let value = '';
 
       if (_.includes(WINTOOLS_CONTAINER_NAMES, container)) {
-        return (
-          <DiskSummaryRow
-            key={`disk-summary-${name}`}
-            title={`Drive ${i + 1}: Windows Tools`}
-            value={container}
-          />
-        );
+        value = `Windows Tools: ${container}`;
+      } else if (container) {
+        value = `Container: ${container}`;
+      } else if (url) {
+        value = `URL: ${url}`;
+      } else if (pvc) {
+        value = `PVC: ${pvc}`;
       }
-      if (container) {
-        return (
-          <DiskSummaryRow
-            key={`disk-summary-${name}`}
-            title={`Drive ${i + 1}: Container`}
-            value={container}
-          />
-        );
-      }
-      if (url) {
-        return (
-          <DiskSummaryRow key={`disk-summary-${name}`} title={`Drive ${i + 1}: URL`} value={url} />
-        );
-      }
+
+      const nameKey = `kubevirt-disk-summary-disk-title-${name}`;
+      const valueKey = `kubevirt-disk-summary-disk-title-${value}`;
+
       return (
-        <DiskSummaryRow key={`disk-summary-${name}`} title={`Drive ${i + 1}: PVC`} value={pvc} />
+        <>
+          <dt id={nameKey} key={nameKey}>
+            {name}
+          </dt>
+          <dd
+            id={valueKey}
+            key={valueKey}
+            className="co-vm-details-cd-roms--datalist--dd text-secondary"
+          >
+            {value}
+          </dd>
+        </>
       );
     })}
-  </div>
+  </dl>
 );
 
 type DiskSummaryProps = {
   vm: VMKind;
   disks: V1Disk[];
-};
-
-type DiskSummaryRowProps = {
-  title: string;
-  value: string;
 };


### PR DESCRIPTION
In #3560 we introduced a unified way to label bootable devices.

This PR use the unified pattern for cd's.

Using the unified view:
![hello · Details · OKD](https://user-images.githubusercontent.com/2181522/70209186-41eed500-1738-11ea-8726-52a45a356350.png)

Before:
![hello · Details · OKD(1)](https://user-images.githubusercontent.com/2181522/70131888-bcade680-168b-11ea-8d6b-792626974a6f.png)
