### PR TITLE
Bug 1779116: vm template should create url import dataVolumes on its creation

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/storage-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/storage-tab-state-update.ts
@@ -2,7 +2,7 @@ import {
   hasVmSettingsChanged,
   iGetProvisionSource,
 } from '../../../selectors/immutable/vm-settings';
-import { VMSettingsField } from '../../../types';
+import { VMSettingsField, VMWizardStorage, VMWizardStorageType } from '../../../types';
 import { InternalActionType, UpdateOptions } from '../../types';
 import { iGetProvisionSourceStorage } from '../../../selectors/immutable/storage';
 import { getProvisionSourceStorage } from '../../initial-state/storage-tab-initial-state';
@@ -20,7 +20,7 @@ export const prefillInitialDiskUpdater = ({ id, prevState, dispatch, getState }:
   }
 
   const iOldSourceStorage = iGetProvisionSourceStorage(state, id);
-  const oldSourceStorage = iOldSourceStorage && iOldSourceStorage.toJSON();
+  const oldSourceStorage: VMWizardStorage = iOldSourceStorage && iOldSourceStorage.toJSON();
 
   const newSourceStorage = getProvisionSourceStorage(iGetProvisionSource(state, id));
   const oldType =
@@ -39,7 +39,8 @@ export const prefillInitialDiskUpdater = ({ id, prevState, dispatch, getState }:
 
   if (newType !== oldType) {
     if (!newSourceStorage) {
-      if (oldSourceStorage) {
+      // not a template provision source
+      if (oldSourceStorage && oldSourceStorage.type === VMWizardStorageType.PROVISION_SOURCE_DISK) {
         dispatch(
           vmWizardInternalActions[InternalActionType.RemoveStorage](id, oldSourceStorage.id),
         );

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/resource-load-errors.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/resource-load-errors.tsx
@@ -23,6 +23,7 @@ const stateToProps = (state, { wizardReduxID }) => ({
   errors: [
     asError(state, wizardReduxID, VMWizardProps.commonTemplates),
     asError(state, wizardReduxID, VMWizardProps.userTemplates),
+    asError(state, wizardReduxID, VMWizardProps.dataVolumes),
     asError(state, wizardReduxID, VMWizardProps.virtualMachines, AlertVariant.warning), // for validation only
   ].filter((err) => err && err.message),
 });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/vm-settings.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/vm-settings.ts
@@ -42,5 +42,5 @@ export const hasVMSettingsValueChanged = (
 ) =>
   keys.find((key) => iGetVmSettingValue(prevState, id, key) !== iGetVmSettingValue(state, id, key));
 
-export const iGetProvisionSource = (state, id: string) =>
+export const iGetProvisionSource = (state, id: string): ProvisionSource =>
   ProvisionSource.fromString(iGetVmSettingValue(state, id, VMSettingsField.PROVISION_SOURCE_TYPE));

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
@@ -28,6 +28,7 @@ import { PersistentVolumeClaimWrapper } from '../../../../k8s/wrapper/vm/persist
 const VMWizardNICModal: React.FC<VMWizardStorageModalProps> = (props) => {
   const {
     storage,
+    isCreateTemplate,
     namespace: vmNamespace,
     useProjects,
     addUpdateStorage,
@@ -96,6 +97,7 @@ const VMWizardNICModal: React.FC<VMWizardStorageModalProps> = (props) => {
           VMWizardStorageType.PROVISION_SOURCE_DISK,
           VMWizardStorageType.PROVISION_SOURCE_TEMPLATE_DISK,
         ].includes(type)}
+        isCreateTemplate={isCreateTemplate}
         onSubmit={(
           resultDiskWrapper,
           resultVolumeWrapper,
@@ -131,6 +133,7 @@ type VMWizardStorageModalProps = ModalComponentProps & {
   storage?: VMWizardStorageWithWrappers;
   namespace: string;
   useProjects?: boolean;
+  isCreateTemplate: boolean;
   storages: VMWizardStorageWithWrappers[];
   addUpdateStorage: (storage: VMWizardStorage) => void;
 };
@@ -140,6 +143,7 @@ const stateToProps = (state, { wizardReduxID }) => {
   return {
     useProjects,
     namespace: iGetCommonData(state, wizardReduxID, VMWizardProps.activeNamespace),
+    isCreateTemplate: iGetCommonData(state, wizardReduxID, VMWizardProps.isCreateTemplate),
     storages: getStoragesWithWrappers(state, wizardReduxID),
   };
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -32,6 +32,7 @@ export enum VMWizardProps {
   virtualMachines = 'virtualMachines',
   userTemplates = 'userTemplates',
   commonTemplates = 'commonTemplates',
+  dataVolumes = 'dataVolumes',
 }
 
 export const ALL_VM_WIZARD_TABS = getStringEnumValues<VMWizardTab>(VMWizardTab);
@@ -115,6 +116,7 @@ export type ChangedCommonDataProp =
   | VMWizardProps.virtualMachines
   | VMWizardProps.userTemplates
   | VMWizardProps.commonTemplates
+  | VMWizardProps.dataVolumes
   | VMWareProviderProps.deployment
   | VMWareProviderProps.deploymentPods
   | VMWareProviderProps.v2vvmware
@@ -134,6 +136,7 @@ export const DetectCommonDataChanges = new Set<ChangedCommonDataProp>([
   VMWizardProps.virtualMachines,
   VMWizardProps.userTemplates,
   VMWizardProps.commonTemplates,
+  VMWizardProps.dataVolumes,
   VMWareProviderProps.deployment,
   VMWareProviderProps.deploymentPods,
   VMWareProviderProps.v2vvmware,

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Form, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertVariant,
+  Form,
+  FormSelect,
+  FormSelectOption,
+  TextInput,
+} from '@patternfly/react-core';
 import {
   FirehoseResult,
   HandlePromiseProps,
@@ -54,6 +61,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
     onNamespaceChanged,
     usedDiskNames,
     disableSourceChange,
+    isCreateTemplate,
     onSubmit,
     inProgress,
     errorMessage,
@@ -380,6 +388,13 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
               onChange={(sc) => setStorageClassName(sc)}
             />
           )}
+          {source.isPlainDataVolume(isCreateTemplate) && (
+            <Alert
+              variant={AlertVariant.warning}
+              isInline
+              title="PVC will be created on template creation and used by VMs created from this template."
+            />
+          )}
         </Form>
       </ModalBody>
       <ModalFooter
@@ -402,6 +417,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
 export type DiskModalProps = {
   disk?: DiskWrapper;
   disableSourceChange?: boolean;
+  isCreateTemplate?: boolean;
   volume?: VolumeWrapper;
   dataVolume?: DataVolumeWrapper;
   persistentVolumeClaim?: PersistentVolumeClaimWrapper;

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
@@ -116,6 +116,9 @@ export class StorageUISource extends ValueEnum<string> {
 
   isSizeEditingSupported = () => this !== StorageUISource.IMPORT_DISK;
 
+  isPlainDataVolume = (isCreateTemplate: boolean) =>
+    isCreateTemplate && this === StorageUISource.URL;
+
   hasDynamicSize = () => this === StorageUISource.CONTAINER;
 
   canBeChangedToThisSource = () =>

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
@@ -88,7 +88,7 @@ const getActions = (
   }
 
   const isTemplate = vmLikeEntity && !isVM(vmLikeEntity);
-  if (isTemplate || disk.isEditingSupported()) {
+  if (disk.isEditingSupported(isTemplate)) {
     actions.push(menuActionEdit);
   }
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ResourceSummary } from '@console/internal/components/utils';
 import { TemplateKind } from '@console/internal/module/k8s';
+import { K8sEntityMap } from '@console/shared/src';
 import { getBasicID, prefixedID } from '../../utils';
 import { vmDescriptionModal } from '../modals/vm-description-modal';
 import { VMCDRomModal } from '../modals/cdrom-vm-modal';
@@ -19,6 +20,7 @@ import { VMDetailsItem } from '../vms/vm-resource';
 import { DiskSummary } from '../vm-disks/disk-summary';
 import { asVM, getDevices } from '../../selectors/vm';
 import { BootOrderSummary } from '../boot-order';
+import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
 import { VMTemplateLink } from './vm-template-link';
 import { TemplateSource } from './vm-template-source';
 
@@ -76,6 +78,7 @@ export const VMTemplateResourceSummary: React.FC<VMTemplateResourceSummaryProps>
 
 export const VMTemplateDetailsList: React.FC<VMTemplateResourceListProps> = ({
   template,
+  dataVolumeLookup,
   canUpdateTemplate,
 }) => {
   const id = getBasicID(template);
@@ -111,7 +114,7 @@ export const VMTemplateDetailsList: React.FC<VMTemplateResourceListProps> = ({
       </VMDetailsItem>
 
       <VMDetailsItem title="Provision Source" idValue={prefixedID(id, 'provisioning-source')}>
-        <TemplateSource template={template} detailed />
+        <TemplateSource template={template} dataVolumeLookup={dataVolumeLookup} detailed />
       </VMDetailsItem>
     </dl>
   );
@@ -119,6 +122,7 @@ export const VMTemplateDetailsList: React.FC<VMTemplateResourceListProps> = ({
 
 type VMTemplateResourceListProps = {
   template: TemplateKind;
+  dataVolumeLookup: K8sEntityMap<V1alpha1DataVolume>;
   canUpdateTemplate: boolean;
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-source.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { TemplateKind } from '@console/internal/module/k8s';
 import { Tooltip } from '@patternfly/react-core';
+import { K8sEntityMap } from '@console/shared/src';
 import { parseURL, resolveURL } from '../../utils/url';
 import { ProvisionSource } from '../../constants/vm/provision-source';
+import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
 
 export const URLObj: React.FC<URLObjProps> = ({
   urlPath,
@@ -74,8 +76,12 @@ type SourceProps = {
   error?: string;
 };
 
-export const TemplateSource: React.FC<TemplateSourceProps> = ({ template, detailed = false }) => {
-  const provisionSource = ProvisionSource.getProvisionSourceDetails(template);
+export const TemplateSource: React.FC<TemplateSourceProps> = ({
+  template,
+  dataVolumeLookup,
+  detailed = false,
+}) => {
+  const provisionSource = ProvisionSource.getProvisionSourceDetails(template, { dataVolumeLookup });
   const { type, source, error } = provisionSource;
 
   if (!detailed) {
@@ -92,5 +98,6 @@ export const TemplateSource: React.FC<TemplateSourceProps> = ({ template, detail
 
 type TemplateSourceProps = {
   template: TemplateKind;
+  dataVolumeLookup: K8sEntityMap<V1alpha1DataVolume>;
   detailed?: boolean;
 };

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/provision-source.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/provision-source.ts
@@ -1,5 +1,5 @@
 /* eslint-disable lines-between-class-members */
-import { getName, getNamespace } from '@console/shared/src';
+import { getName, getNamespace, K8sEntityMap } from '@console/shared/src';
 import { ValueEnum } from '../value-enum';
 import {
   asVM,
@@ -13,6 +13,7 @@ import { VMLikeEntityKind } from '../../types';
 import { StorageUISource } from '../../components/modals/disk-modal/storage-ui-source';
 import { VolumeWrapper } from '../../k8s/wrapper/vm/volume-wrapper';
 import { DataVolumeWrapper } from '../../k8s/wrapper/vm/data-volume-wrapper';
+import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
 import { VolumeType } from './storage';
 
 type ProvisionSourceDetails = {
@@ -47,7 +48,18 @@ export class ProvisionSource extends ValueEnum<string> {
 
   static fromString = (source: string): ProvisionSource => ProvisionSource.stringMapper[source];
 
-  static getProvisionSourceDetails = (vmLikeEntity: VMLikeEntityKind): ProvisionSourceDetails => {
+  static getProvisionSourceDetails = (
+    vmLikeEntity: VMLikeEntityKind,
+    {
+      convertTemplateDataVolumesToAttachClonedDisk,
+      dataVolumes,
+      dataVolumeLookup,
+    }: {
+      convertTemplateDataVolumesToAttachClonedDisk?: boolean;
+      dataVolumes?: V1alpha1DataVolume[];
+      dataVolumeLookup?: K8sEntityMap<V1alpha1DataVolume>;
+    } = {},
+  ): ProvisionSourceDetails => {
     const vm = asVM(vmLikeEntity);
     if (getInterfaces(vm).some((i) => i.bootOrder === 1)) {
       return {
@@ -67,9 +79,24 @@ export class ProvisionSource extends ValueEnum<string> {
       let dataVolumeWrapper;
 
       if (volumeWrapper.getType() === VolumeType.DATA_VOLUME) {
-        const dataVolume = getDataVolumeTemplates(vm).find(
-          (dv) => getName(dv) === getVolumeDataVolumeName(volume),
-        );
+        if (convertTemplateDataVolumesToAttachClonedDisk) {
+          return {
+            type: ProvisionSource.DISK,
+            source: `${getNamespace(vmLikeEntity)}/${volumeWrapper.getDataVolumeName()}`,
+          };
+        }
+        let dataVolume;
+
+        if (dataVolumeLookup) {
+          dataVolume = dataVolumeLookup[getVolumeDataVolumeName(volume)];
+        }
+        if (!dataVolume) {
+          const allDataVolumes = [...getDataVolumeTemplates(vm)];
+          if (dataVolumes) {
+            allDataVolumes.push(...dataVolumes);
+          }
+          dataVolume = allDataVolumes.find((dv) => getName(dv) === getVolumeDataVolumeName(volume));
+        }
         if (!dataVolume) {
           return {
             error: `Datavolume ${volumeWrapper.getDataVolumeName()} does not exist.`,

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
@@ -64,7 +64,16 @@ export class CombinedDisk {
 
   getSourceValue = () => this.source && this.source.getValue();
 
-  isEditingSupported = () => !!this.source && this.source.isEditingSupported();
+  isEditingSupported = (isTemplate: boolean) => {
+    if (isTemplate) {
+      // plain dataVolume creates dataVolumes on template creation
+      return this.source && this.source.isPlainDataVolume(isTemplate)
+        ? this.source.isEditingSupported()
+        : true;
+    }
+
+    return !!this.source && this.source.isEditingSupported();
+  };
 
   getName = () => this.diskWrapper.getName();
 

--- a/frontend/packages/kubevirt-plugin/src/utils/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/index.ts
@@ -15,6 +15,7 @@ import {
   getUID,
 } from '@console/shared/src/selectors';
 import { CPU } from '../types';
+import { VM_TEMPLATE_NAME_PARAMETER } from '../constants/vm-templates';
 
 export const getBasicID = <A extends K8sResourceKind = K8sResourceKind>(entity: A) =>
   `${getNamespace(entity)}-${getName(entity)}`;
@@ -55,6 +56,13 @@ export const getLoadError = (
   }
 
   return null;
+};
+
+export const insertName = (value: string, name) => {
+  if (value.indexOf(VM_TEMPLATE_NAME_PARAMETER) > -1) {
+    return value.replace(VM_TEMPLATE_NAME_PARAMETER, name);
+  }
+  return joinIDs(name, value);
 };
 
 export const parseNumber = (value, defaultValue = null) =>

--- a/frontend/packages/kubevirt-plugin/src/utils/url.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/url.ts
@@ -42,4 +42,6 @@ export const resolvePathname = ({ pathname }, maxPathnameParts) => {
 };
 
 export const resolveURL = ({ urlObj, maxHostnameParts, maxPathnameParts }) =>
-  `${resolveOrigin(urlObj, maxHostnameParts)}${resolvePathname(urlObj, maxPathnameParts)}`;
+  urlObj.origin === 'null'
+    ? urlObj.href
+    : `${resolveOrigin(urlObj, maxHostnameParts)}${resolvePathname(urlObj, maxPathnameParts)}`;

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/vm/vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/vm/vm.ts
@@ -29,7 +29,9 @@ export const validateVmLikeEntityName = (
 export const validateUserTemplateProvisionSource = (
   userTemplate: TemplateKind,
 ): ValidationObject => {
-  const provisionSourceDetails = ProvisionSource.getProvisionSourceDetails(userTemplate);
+  const provisionSourceDetails = ProvisionSource.getProvisionSourceDetails(userTemplate, {
+    convertTemplateDataVolumesToAttachClonedDisk: true,
+  });
 
   return provisionSourceDetails.error
     ? asValidationObject(`Could not select Provision Source. ${provisionSourceDetails.error}`)


### PR DESCRIPTION
- show URL provision source for templates
- provision source changed to Disk (Attach Cloned Disk) for vms created
from such templates
- add warning to the template disk modal

@mareklibra @matthewcarleton Can you take a look?

As you can see bellow, I changed a provision source of VM to `Disk`  to truthfully reflect the situation.

I added a warning to disk-modal in template creation to show the difference between template url and vm url.

Is this enough? Should I show this also in the general tab so the user knows what is going on? Or in the review?

### Templates Creation

![3](https://user-images.githubusercontent.com/3648838/70156728-aec08b80-16b4-11ea-9b63-cfb8de2b81df.png)

![2](https://user-images.githubusercontent.com/3648838/70156734-b1bb7c00-16b4-11ea-8211-46b4f6c0d4d2.png)

### Inspecting the template source

![1](https://user-images.githubusercontent.com/3648838/70156801-c7c93c80-16b4-11ea-85ab-46f1f51da327.png)

### Creating VM from the template

![4](https://user-images.githubusercontent.com/3648838/70156851-d9aadf80-16b4-11ea-80cf-582b9bf3bfd6.png)

![6](https://user-images.githubusercontent.com/3648838/70157063-2d1d2d80-16b5-11ea-9e60-9bc90e4cd7f2.png)

