### PR TITLE
frontend: Fix developer catalog heights

### DIFF
--- a/frontend/public/components/catalog/catalog-items.jsx
+++ b/frontend/public/components/catalog/catalog-items.jsx
@@ -207,6 +207,7 @@ export class CatalogTileViewPage extends React.Component {
     const iconImgUrl = tileImgUrl || catalogImg;
     return (
       <CatalogTile
+        className="co-catalog-tile"
         key={uid}
         onClick={() => this.openOverlay(item)}
         title={tileName}
@@ -215,6 +216,7 @@ export class CatalogTileViewPage extends React.Component {
         vendor={vendor}
         description={tileDescription}
         data-test={`${kind}-${obj.metadata.name}`}
+        maxDescriptionLength={55}
       />
     );
   }


### PR DESCRIPTION
Add class from OperatorHub tiles to developer catalog tiles and add maxTruncation prop to these tiles.

<img width="1210" alt="Screen Shot 2019-12-04 at 2 57 21 PM" src="https://user-images.githubusercontent.com/7014965/70176397-67330300-16a6-11ea-8c39-da629c204a61.png">

Heads up @jcaianirh and @spadgett.
