### PR TITLE
Improve display of workloads table

### DIFF
--- a/frontend/public/components/workload-table.tsx
+++ b/frontend/public/components/workload-table.tsx
@@ -16,11 +16,11 @@ import {
 } from './utils';
 
 const tableColumnClasses = [
-  classNames('col-lg-2', 'col-md-3', 'col-sm-4', 'col-xs-6'),
-  classNames('col-lg-2', 'col-md-3', 'col-sm-4', 'col-xs-6'),
-  classNames('col-lg-3', 'col-md-4', 'col-sm-4', 'hidden-xs'),
-  classNames('col-lg-2', 'col-md-2', 'hidden-sm', 'hidden-xs'),
-  classNames('col-lg-3', 'hidden-md', 'hidden-sm', 'hidden-xs'),
+  '',
+  '',
+  classNames('pf-m-hidden', 'pf-m-visible-on-sm', 'pf-u-w-16-on-lg'),
+  classNames('pf-m-hidden', 'pf-m-visible-on-lg'),
+  classNames('pf-m-hidden', 'pf-m-visible-on-lg'),
   Kebab.columnClass,
 ];
 
@@ -50,15 +50,15 @@ export const WorkloadTableRow: React.FC<WorkloadTableRowProps> = ({
         />
       </TableData>
       <TableData className={tableColumnClasses[2]}>
-        <LabelList kind={kind} labels={obj.metadata.labels} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
         <Link
           to={`${resourcePath(kind, obj.metadata.name, obj.metadata.namespace)}/pods`}
           title="pods"
         >
           {obj.status.replicas || 0} of {obj.spec.replicas} pods
         </Link>
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        <LabelList kind={kind} labels={obj.metadata.labels} />
       </TableData>
       <TableData className={tableColumnClasses[4]}>
         <Selector selector={obj.spec.selector} namespace={obj.metadata.namespace} />
@@ -94,14 +94,14 @@ export const WorkloadTableHeader = () => {
       props: { className: tableColumnClasses[1] },
     },
     {
-      title: 'Labels',
-      sortField: 'metadata.labels',
+      title: 'Status',
+      sortFunc: 'numReplicas',
       transforms: [sortable],
       props: { className: tableColumnClasses[2] },
     },
     {
-      title: 'Status',
-      sortFunc: 'numReplicas',
+      title: 'Labels',
+      sortField: 'metadata.labels',
       transforms: [sortable],
       props: { className: tableColumnClasses[3] },
     },

--- a/frontend/public/style/_patternfly-sizing-extension.scss
+++ b/frontend/public/style/_patternfly-sizing-extension.scss
@@ -1,0 +1,12 @@
+// Extend PatternFly 4 widths to add missing sizes that comprise a 12 column grid like Bootstrap
+
+$pf-u-width-extended-options: (
+  w-8:       (width calc(100% / 12)),
+  w-16:      (width calc(100% / 12 * 2)),
+  w-42:      (width calc(100% / 12 * 5)),
+  w-58:      (width calc(100% / 12 * 7)),
+  w-83:      (width calc(100% / 12 * 10)),
+  w-92:      (width calc(100% / 12 * 11))
+);
+
+@include pf-utility-builder($pf-u-width-extended-options, $pf-global--breakpoint-list);

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -47,4 +47,8 @@
 @import "~@patternfly/patternfly/components/Form/form";
 @import "~@patternfly/patternfly/components/FormControl/form-control";
 @import "~@patternfly/patternfly/components/InputGroup/input-group";
+@import "~@patternfly/patternfly/utilities/Sizing/sizing";
 @import "~@patternfly/patternfly/patternfly-charts";
+
+// External dependency extensions
+@import "style/patternfly-sizing-extension";


### PR DESCRIPTION
covers `Deployments`, `Deployment Configs`, and `Stateful Sets`.  Moves `Status` column to third, makes use of new column sizing approach.

cc: @bmignano 

![localhost_9000_k8s_all-namespaces_deployments](https://user-images.githubusercontent.com/895728/70268513-9f9e1400-176e-11ea-86d0-97a4cf3ec8e9.png)
![localhost_9000_k8s_all-namespaces_deployments (1)](https://user-images.githubusercontent.com/895728/70268518-a2990480-176e-11ea-87aa-5dc718a6a8ce.png)
![localhost_9000_k8s_all-namespaces_deployments (2)](https://user-images.githubusercontent.com/895728/70268519-a2990480-176e-11ea-8839-649eb6fd1c2e.png)
![localhost_9000_k8s_all-namespaces_deployments (3)](https://user-images.githubusercontent.com/895728/70268520-a2990480-176e-11ea-978f-914081ff74c1.png)
![localhost_9000_k8s_all-namespaces_deployments (4)](https://user-images.githubusercontent.com/895728/70268522-a2990480-176e-11ea-9050-351bb9170b8a.png)
