### PR TITLE
Bug 1780666: Addition of dropdown placeholder text

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-operand.tsx
@@ -630,7 +630,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = (props) => {
       return (
         <div style={{}}>
           <Dropdown
-            title=""
+            title={`Select ${field.displayName}`}
             selectedKey={formValues[field.path]}
             items={field.capabilities
               .filter((c) => c.startsWith(SpecCapability.select))


### PR DESCRIPTION
Missing "Select {label}" placeholder from `<Dropdown>`

<img width="360" alt="Screen Shot 2019-12-05 at 4 25 24 PM" src="https://user-images.githubusercontent.com/1874151/70275770-d24f0900-177c-11ea-84fc-1557fdf73e74.png">
<img width="400" alt="Screen Shot 2019-12-05 at 4 58 00 PM" src="https://user-images.githubusercontent.com/1874151/70277458-6ff80780-1780-11ea-9358-2f2b09ce2350.png">

---

<img width="870" alt="Screen Shot 2019-10-21 at 3 12 35 PM" src="https://user-images.githubusercontent.com/1874151/70331838-4f768e80-180e-11ea-802b-55fd5769a24a.png">
<img width="438" alt="Screen Shot 2019-12-06 at 9 33 05 AM" src="https://user-images.githubusercontent.com/1874151/70331881-63ba8b80-180e-11ea-8eb6-321454a1d747.png">


