### PR TITLE
frontend: Fix overlap issue

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -178,7 +178,6 @@ $co-modal-ignore-warning-icon-width: 30px;
   }
 
   &__tabs {
-    flex: 0 0 220px;
     margin: 0 ($grid-gutter-width / 2) 0 0;
   }
 }


### PR DESCRIPTION
Fix overlap issue on OperatorHub where the number of items was overflowing its container.

<img width="875" alt="Screen Shot 2019-12-05 at 5 38 27 PM" src="https://user-images.githubusercontent.com/7014965/70280277-14307d00-1786-11ea-9c71-ca9c9e63d995.png">
