### PR TITLE
Bug 1780629: Add `<Status>` to Operator resources

### DIFF
--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  ClipboardListIcon,
   HourglassStartIcon,
   HourglassHalfIcon,
   SyncAltIcon,
@@ -7,6 +8,7 @@ import {
   ExclamationTriangleIcon,
   UnknownIcon,
 } from '@patternfly/react-icons';
+import { GreenCheckCircleIcon, YellowExclamationTriangleIcon } from '@console/shared';
 import { DASH } from '../../constants';
 import StatusIconAndText from './StatusIconAndText';
 import { ErrorStatus, InfoStatus, ProgressStatus, SuccessStatus } from './statuses';
@@ -21,10 +23,14 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
     case 'Pending':
       return <StatusIconAndText {...statusProps} icon={<HourglassHalfIcon />} />;
 
+    case 'Planning':
+      return <StatusIconAndText {...statusProps} icon={<ClipboardListIcon />} />;
+
     case 'ContainerCreating':
       return <ProgressStatus {...statusProps} />;
 
     case 'In Progress':
+    case 'Installing':
     case 'Running':
     case 'Updating':
     case 'Upgrading':
@@ -39,11 +45,16 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
     case 'Warning':
       return <StatusIconAndText {...statusProps} icon={<ExclamationTriangleIcon />} />;
 
+    case 'RequiresApproval':
+      return <StatusIconAndText {...statusProps} icon={<YellowExclamationTriangleIcon />} />;
+
     case 'ContainerCannotRun':
     case 'CrashLoopBackOff':
     case 'Critical':
     case 'Error':
+    case 'ErrorImagePull':
     case 'Failed':
+    case 'ImagePullBackOff':
     case 'InstallCheckFailed':
     case 'Lost':
     case 'Rejected':
@@ -59,6 +70,9 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
     case 'Ready':
     case 'Up to date':
       return <SuccessStatus {...statusProps} />;
+
+    case 'Created':
+      return <StatusIconAndText {...statusProps} icon={<GreenCheckCircleIcon />} />;
 
     case 'Info':
       return <InfoStatus {...statusProps}>{children}</InfoStatus>;

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -12,6 +12,7 @@ import {
   ErrorStatus,
   getName,
   ProgressStatus,
+  Status,
   SuccessStatus,
   WarningStatus,
   getNamespace,
@@ -709,7 +710,9 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
             </div>
             <div className="col-sm-6">
               <dt>Status</dt>
-              <dd>{status ? status.phase : 'Unknown'}</dd>
+              <dd>
+                <Status status={status ? status.phase : 'Unknown'} />
+              </dd>
               <dt>Status Reason</dt>
               <dd>{status ? status.message : 'Unknown'}</dd>
               <dt>Operator Deployments</dt>

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -32,7 +32,7 @@ import {
   k8sUpdate,
   apiVersionForReference,
 } from '@console/internal/module/k8s';
-import { GreenCheckCircleIcon, YellowExclamationTriangleIcon } from '@console/shared';
+import { GreenCheckCircleIcon, Status } from '@console/shared';
 import {
   SubscriptionModel,
   ClusterServiceVersionModel,
@@ -96,14 +96,7 @@ export const InstallPlanTableRow: React.FC<InstallPlanTableRowProps> = ({
   key,
   style,
 }) => {
-  const phaseFor = (phase: InstallPlanKind['status']['phase']) =>
-    phase === 'RequiresApproval' ? (
-      <>
-        <YellowExclamationTriangleIcon /> {phase}
-      </>
-    ) : (
-      phase
-    );
+  const phaseFor = (phase: InstallPlanKind['status']['phase']) => <Status status={phase} />;
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -269,7 +262,9 @@ export const InstallPlanDetails: React.SFC<InstallPlanDetailsProps> = ({ obj }) 
             <div className="col-sm-6">
               <dl className="co-m-pane__details">
                 <dt>Status</dt>
-                <dd>{_.get(obj.status, 'phase', 'Unknown')}</dd>
+                <dd>
+                  <Status status={_.get(obj.status, 'phase', 'Unknown')} />
+                </dd>
                 <dt>Components</dt>
                 {(obj.spec.clusterServiceVersionNames || []).map((csvName) => (
                   <dd key={csvName}>

--- a/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { match } from 'react-router';
+import { Status } from '@console/shared';
 import {
   ResourceLink,
   Timestamp,
@@ -63,7 +64,9 @@ export const ResourceTableRow: React.FC<ResourceTableRowProps> = ({
   <TableRow id={obj.metadata.uid} index={index} trKey={obj.metadata.uid} style={style}>
     <TableData className={tableColumnClasses[0]}>{linkFor(obj)}</TableData>
     <TableData className={tableColumnClasses[1]}>{obj.kind}</TableData>
-    <TableData className={tableColumnClasses[2]}>{_.get(obj.status, 'phase', 'Created')}</TableData>
+    <TableData className={tableColumnClasses[2]}>
+      <Status status={_.get(obj.status, 'phase', 'Created')} />
+    </TableData>
     <TableData className={tableColumnClasses[3]}>
       <Timestamp timestamp={obj.metadata.creationTimestamp} />
     </TableData>


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1780629

Bonus:  adds missing `ErrorImagePull` and `ImagePullBackOff` cases to `<Status>`

![Screen Shot 2019-12-06 at 10 19 38 AM](https://user-images.githubusercontent.com/895728/70334248-142a8e80-1813-11ea-8b58-23cc2dba9d8c.png)
![Screen Shot 2019-12-06 at 10 19 52 AM](https://user-images.githubusercontent.com/895728/70334249-142a8e80-1813-11ea-96ff-f62916b9a808.png)
![Screen Shot 2019-12-06 at 10 20 01 AM](https://user-images.githubusercontent.com/895728/70334250-142a8e80-1813-11ea-8333-5d105695d4f7.png)
![Screen Shot 2019-12-06 at 10 20 16 AM](https://user-images.githubusercontent.com/895728/70334251-142a8e80-1813-11ea-94b6-fc65df46313d.png)
