### PR TITLE
Bug 1779800: Fixes selection of SC from dropdown

### DIFF
--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -119,11 +119,13 @@ export class StorageClassDropdownInner extends React.Component<
 
   onChange = (key) => {
     const storageClass = _.get(this.state, ['items', key], {});
-    this.setState({
-      selectedKey: key,
-      title: this.getTitle(storageClass),
-    });
-    this.props.onChange(storageClass.resource);
+    this.setState(
+      {
+        selectedKey: key,
+        title: this.getTitle(storageClass),
+      },
+      () => this.props.onChange(storageClass.resource),
+    );
   };
 
   render() {


### PR DESCRIPTION
Although `props.onChange()` function is called after setting the state of the component, the state is getting updated after, due to its async nature, due to which the `selectedKey` is not reflecting the selected value instantaneously, but only after the next state change rendering is happening. 

To prevent this from happening, the PR has moved the calling of `props.onChange()` function as a callback function to setState, which will be executed once setState is completed and the component is re-rendered, hence it will reflect new state changes instantaneously.

Thanks @gnehapk for pointers.