### PR TITLE
refactors knative sidebar based on topology2

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
@@ -50,14 +50,7 @@ const getSidebarResources = ({ obj, ksroutes, revisions, configurations }: Overv
     case EventSourceKafkaModel.kind:
       return <EventSinkServicesOverviewList obj={obj} />;
     default:
-      return (
-        <KnativeOverview
-          ksroutes={ksroutes}
-          revisions={revisions}
-          configurations={configurations}
-          obj={obj}
-        />
-      );
+      return null;
   }
 };
 const OverviewDetailsKnativeResourcesTab: React.FC<OverviewDetailsResourcesTabProps> = ({
@@ -86,21 +79,6 @@ const KnativeServicesResources: React.FC<KnativeServiceResourceProps> = ({
     <>
       <RevisionsOverviewList revisions={revisions} service={obj} />
       <KSRoutesOverviewList ksroutes={ksroutes} resource={obj} />
-    </>
-  );
-};
-
-const KnativeOverview: React.FC<KnativeOverviewProps> = ({
-  ksroutes,
-  configurations,
-  revisions,
-  obj,
-}) => {
-  return (
-    <>
-      <RevisionsOverviewList revisions={revisions} service={obj} />
-      <KSRoutesOverviewList ksroutes={ksroutes} resource={obj} />
-      <ConfigurationsOverviewList configurations={configurations} />
     </>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
@@ -94,17 +94,15 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({ revisions
   return (
     <>
       <SidebarSectionHeading text="Revisions" className="revision-overview-list">
-        {/* add extra check, if sidebar is opened for a knative deployment */}
-        {canSetTrafficDistribution &&
-          (service.kind === ServiceModel.kind && (
-            <Button
-              variant="secondary"
-              onClick={() => setTrafficDistributionModal({ obj: service })}
-              isDisabled={!(revisions && revisions.length)}
-            >
-              Set Traffic Distribution
-            </Button>
-          ))}
+        {canSetTrafficDistribution && (
+          <Button
+            variant="secondary"
+            onClick={() => setTrafficDistributionModal({ obj: service })}
+            isDisabled={!(revisions && revisions.length)}
+          >
+            Set Traffic Distribution
+          </Button>
+        )}
       </SidebarSectionHeading>
       {_.isEmpty(revisions) ? (
         <span className="text-muted">No Revisions found for this resource.</span>


### PR DESCRIPTION
refactors knative sidebar based on topology2
- removes the extra check for service kind
- removes the unwanted comments and `KnativeOverview` component. 

Tracks: https://jira.coreos.com/browse/ODC-2304