### PR TITLE
Show full CSV description as markdown in dev catalog item details

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
@@ -29,6 +29,9 @@ export const normalizeClusterServiceVersions = (
         }`
       : operatorLogo;
 
+  const formatTileDescription = (crdDescription: string, csvDescription: string): string =>
+    `${crdDescription}\n## Operator Description\n${csvDescription}`;
+
   const operatorProvidedAPIs: K8sResourceKind[] = _.flatten(
     clusterServiceVersions.map((csv) => providedAPIsFor(csv).map((desc) => ({ ...desc, csv }))),
   )
@@ -54,7 +57,7 @@ export const normalizeClusterServiceVersions = (
       tileName: desc.displayName,
       tileIconClass: null,
       tileImgUrl: imgFor(desc),
-      tileDescription: desc.description,
+      tileDescription: formatTileDescription(desc.description, desc.csv.spec.description),
       tileProvider: desc.csv.spec.provider.name,
       tags: desc.csv.spec.keywords,
       createLabel: 'Create',

--- a/frontend/public/components/catalog/catalog-item-details.jsx
+++ b/frontend/public/components/catalog/catalog-item-details.jsx
@@ -12,7 +12,8 @@ import {
 import { normalizeIconClass } from './catalog-item-icon';
 import { ClusterServicePlanModel } from '../../models';
 import { k8sGet } from '../../module/k8s';
-import { Timestamp, ExternalLink } from '../utils';
+import { Timestamp, ExternalLink, SectionHeading } from '../utils';
+import { SyncMarkdownView } from '../markdown-view';
 
 export class CatalogTileDetails extends React.Component {
   state = {
@@ -108,7 +109,8 @@ export class CatalogTileDetails extends React.Component {
                   )}
                 </PropertiesSidePanel>
                 <div className="co-catalog-page__overlay-description">
-                  {tileDescription && <p>{tileDescription}</p>}
+                  <SectionHeading text="Description" />
+                  {tileDescription && <SyncMarkdownView content={tileDescription} />}
                   {longDescription && <p>{longDescription}</p>}
                   {sampleRepo && <p>Sample repository: {sampleRepoLink}</p>}
                   {documentationUrl && (


### PR DESCRIPTION
Related Story - https://jira.coreos.com/browse/ODC-2457

This PR -
- Updates the catalog item details page to show full CSV description as markdown.
- It includes both the CRD description and CSV description.

Screenshots - 

Before - 
![Screenshot from 2019-12-10 02-39-17](https://user-images.githubusercontent.com/6041994/70473044-40d1f500-1af6-11ea-8ced-83bf9a139612.png)


After - 
![Screenshot from 2019-12-10 02-37-59](https://user-images.githubusercontent.com/6041994/70472972-20a23600-1af6-11ea-8c11-cfd5e39cbb7f.png)


