### PR TITLE
Align cd summary list with design

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-summary.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-summary.scss
@@ -1,3 +1,6 @@
-.co-vm-details-cdroms__datalist-dd {
+.kubevirt-disk-summary__datalist-dt {
+  color: var(--pf-global--Color--300);
+}
+.kubevirt-disk-summary__datalist-dd {
   margin-bottom: var(--pf-global--spacer--sm);
 }

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-summary.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-summary.tsx
@@ -12,7 +12,7 @@ import { V1Disk } from '../../types/vm/disk/V1Disk';
 import './disk-summary.scss';
 
 export const DiskSummary: React.FC<DiskSummaryProps> = ({ disks, vm }) => (
-  <dl className="oc-vm-details__datalist kubevirt-disk-summary">
+  <dl className="kubevirt-disk-summary">
     {disks.map(({ name }) => {
       const container = getContainerImageByDisk(vm, name);
       const pvc = getPVCSourceByDisk(vm, name);
@@ -32,13 +32,13 @@ export const DiskSummary: React.FC<DiskSummaryProps> = ({ disks, vm }) => (
 
       return (
         <>
-          <dt id={nameKey} key={nameKey}>
+          <dt id={nameKey} key={nameKey} className="kubevirt-disk-summary__datalist-dt">
             {name}
           </dt>
           <dd
             id={`${nameKey}-info`}
             key={`${nameKey}-info`}
-            className="co-vm-details-cdroms__datalist-dd text-secondary"
+            className="kubevirt-disk-summary__datalist-dd"
           >
             {value}
           </dd>


### PR DESCRIPTION
Kubevirt VM overview CD-ROMs view is not aligned with design.

Ref: https://github.com/openshift/console/pull/3679#discussion_r354444438

Design:
![End to End flow for CD ROMs in Virtual Machines   Google Docs](https://user-images.githubusercontent.com/2181522/70542011-b5497a00-1b70-11ea-808b-1a01f677f6fb.png)

After:
![av2v cnv rhel7 mini · Details · OKD](https://user-images.githubusercontent.com/2181522/70542004-b1b5f300-1b70-11ea-846c-d3993c114a40.png)

Before:
![av2v cnv rhel7 mini · Details · OKD(1)](https://user-images.githubusercontent.com/2181522/70542023-b8dd0100-1b70-11ea-92a4-323622f0780d.png)
