### PR TITLE
Allow to run individual gui test specs

### DIFF
--- a/test-gui.sh
+++ b/test-gui.sh
@@ -38,7 +38,10 @@ fi
 yarn install
 yarn run webdriver-update
 
-if [ $# -gt 0 ] && [ -n "$1" ];
+if [ $# -gt 0 ] && [ "$1" = "--specs" ] && [ -n "$2" ];
+then
+  yarn run test-suite --specs "$2" --params.openshift true
+elif [ $# -gt 0 ] && [ -n "$1" ];
 then
   yarn run test-suite --suite "$1" --params.openshift true
 else


### PR DESCRIPTION
Currently our `test-gui.sh` script can only run complete test suites.

It will be nice to run individual tests.

This PR adds a `--specs` option to the script, for example:
``` sh
./test-gui.sh --specs integration-tests/tests/base.scenario.ts,packages/kubevirt-plugin/integration-tests/tests/vm.detail.boot-order.scenario.ts
```