### PR TITLE
kubevirt: fix storage tab row and add error to storage modal

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/storage-review.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/storage-review.tsx
@@ -30,6 +30,7 @@ const StorageReviewFirehose: React.FC<StorageReviewFirehoseProps> = ({
             dataVolumeWrapper,
             persistentVolumeClaimWrapper:
               persistentVolumeClaimWrapper || (pvc && PersistentVolumeClaimWrapper.initialize(pvc)),
+            isNewPVC: !!persistentVolumeClaimWrapper,
           });
 
           return {

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/storage-tab.tsx
@@ -59,6 +59,7 @@ const getStoragesData = (
       dataVolumeWrapper,
       persistentVolumeClaimWrapper:
         persistentVolumeClaimWrapper || (pvc && PersistentVolumeClaimWrapper.initialize(pvc)),
+      isNewPVC: !!persistentVolumeClaimWrapper,
       pvcsLoading: !isLoaded(pvcs),
     });
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
@@ -25,7 +25,7 @@ import { DiskModal } from '../../../modals/disk-modal';
 import { VM_TEMPLATE_NAME_PARAMETER } from '../../../../constants/vm-templates';
 import { PersistentVolumeClaimWrapper } from '../../../../k8s/wrapper/vm/persistent-volume-claim-wrapper';
 
-const VMWizardNICModal: React.FC<VMWizardStorageModalProps> = (props) => {
+const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
   const {
     storage,
     isCreateTemplate,
@@ -157,6 +157,6 @@ const dispatchToProps = (dispatch, { wizardReduxID }) => ({
 const VMWizardStorageModalConnected = connect(
   stateToProps,
   dispatchToProps,
-)(VMWizardNICModal);
+)(VMWizardStorageModal);
 
 export const vmWizardStorageModalEnhanced = createModalLauncher(VMWizardStorageModalConnected);

--- a/frontend/packages/kubevirt-plugin/src/components/form/k8s-resource-select-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/k8s-resource-select-row.tsx
@@ -10,7 +10,8 @@ import { asFormSelectValue, FormSelectPlaceholderOption } from './form-select-pl
 
 type K8sResourceSelectProps = {
   id: string;
-  isDisabled: boolean;
+  isDisabled?: boolean;
+  isRequired?: boolean;
   isPlaceholderDisabled?: boolean;
   hasPlaceholder?: boolean;
   data?: FirehoseResult<K8sResourceKind[]>;
@@ -25,6 +26,7 @@ type K8sResourceSelectProps = {
 export const K8sResourceSelectRow: React.FC<K8sResourceSelectProps> = ({
   id,
   isDisabled,
+  isRequired,
   isPlaceholderDisabled,
   hasPlaceholder,
   data,
@@ -44,17 +46,29 @@ export const K8sResourceSelectRow: React.FC<K8sResourceSelectProps> = ({
     loadedData = loadedData.filter(filter);
   }
 
+  let nameValue;
+  let missingError;
+
+  if (name && !isLoading && !loadError && !loadedData.some((entity) => getName(entity) === name)) {
+    missingError = `Selected ${name} is not available`;
+  } else {
+    nameValue = name;
+  }
+
   return (
     <FormRow
       title={title || model.label}
       fieldId={id}
       isLoading={isLoading}
-      validationMessage={loadError || (validation && validation.message)}
-      validationType={loadError ? ValidationErrorType.Error : validation && validation.type}
+      validationMessage={loadError || missingError || (validation && validation.message)}
+      validationType={
+        loadError || missingError ? ValidationErrorType.Error : validation && validation.type
+      }
+      isRequired={isRequired}
     >
       <FormSelect
         onChange={onChange}
-        value={asFormSelectValue(name)}
+        value={asFormSelectValue(nameValue)}
         id={id}
         isDisabled={isDisabled || isLoading || loadError}
       >

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -80,6 +80,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
     volumeWrapper: volume,
     dataVolumeWrapper: dataVolume,
     persistentVolumeClaimWrapper: props.persistentVolumeClaim,
+    isNewPVC: !!props.persistentVolumeClaim,
   });
   const combinedDiskSize = combinedDisk.getSize();
 
@@ -311,6 +312,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
               key="pvc-select"
               id={asId('pvc')}
               isDisabled={inProgress || !namespace}
+              isRequired
               name={pvcName}
               validation={pvcValidation}
               data={persistentVolumeClaims}

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
@@ -38,7 +38,7 @@ export class StorageUISource extends ValueEnum<string> {
 
   private readonly volumeType: VolumeType;
   private readonly dataVolumeSourceType: DataVolumeSourceType;
-  private readonly hasPVC: boolean;
+  private readonly hasNewPVC: boolean;
 
   private static readonly ALL = Object.freeze(
     ValueEnum.getAllClassEnumProperties<StorageUISource>(StorageUISource),
@@ -56,12 +56,12 @@ export class StorageUISource extends ValueEnum<string> {
     value: string,
     volumeType?: VolumeType,
     dataVolumeSourceType?: DataVolumeSourceType,
-    hasPVC: boolean = false,
+    hasNewPVC: boolean = false,
   ) {
     super(value);
     this.volumeType = volumeType;
     this.dataVolumeSourceType = dataVolumeSourceType;
-    this.hasPVC = hasPVC;
+    this.hasNewPVC = hasNewPVC;
   }
 
   static getAll = () => StorageUISource.ALL;
@@ -74,14 +74,14 @@ export class StorageUISource extends ValueEnum<string> {
   static fromTypes = (
     volumeType: VolumeType,
     dataVolumeSourceType?: DataVolumeSourceType,
-    hasPVC: boolean = false,
+    hasNewPVC: boolean = false,
   ) =>
     StorageUISource.ALL.find(
       (storageUIType) =>
         storageUIType !== StorageUISource.OTHER &&
         storageUIType.volumeType == volumeType && // eslint-disable-line eqeqeq
         storageUIType.dataVolumeSourceType == dataVolumeSourceType && // eslint-disable-line eqeqeq
-        storageUIType.hasPVC == hasPVC, // eslint-disable-line eqeqeq
+        storageUIType.hasNewPVC == hasNewPVC, // eslint-disable-line eqeqeq
     );
 
   getVolumeType = () => this.volumeType;
@@ -96,15 +96,15 @@ export class StorageUISource extends ValueEnum<string> {
   requiresPVC = () =>
     this === StorageUISource.ATTACH_DISK || this === StorageUISource.ATTACH_CLONED_DISK;
 
-  requiresNewPVC = () => this.hasPVC;
+  requiresNewPVC = () => this.hasNewPVC;
 
   requiresContainerImage = () => this === StorageUISource.CONTAINER;
 
   requiresURL = () => this === StorageUISource.URL;
 
-  requiresSize = () => this.requiresDatavolume() || this.hasPVC;
+  requiresSize = () => this.requiresDatavolume() || this.hasNewPVC;
 
-  requiresStorageClass = () => this.requiresDatavolume() || this.hasPVC;
+  requiresStorageClass = () => this.requiresDatavolume() || this.hasNewPVC;
 
   requiresVolume = () => !!this.volumeType;
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
@@ -37,6 +37,7 @@ export class CombinedDisk {
     volumeWrapper,
     dataVolumeWrapper,
     persistentVolumeClaimWrapper,
+    isNewPVC,
     dataVolumesLoading,
     pvcsLoading,
   }: {
@@ -46,6 +47,7 @@ export class CombinedDisk {
     persistentVolumeClaimWrapper?: PersistentVolumeClaimWrapper;
     dataVolumesLoading?: boolean;
     pvcsLoading?: boolean;
+    isNewPVC?: boolean;
   }) {
     this.diskWrapper = diskWrapper;
     this.volumeWrapper = volumeWrapper;
@@ -56,7 +58,7 @@ export class CombinedDisk {
     this.source = StorageUISource.fromTypes(
       volumeWrapper.getType(),
       dataVolumeWrapper && dataVolumeWrapper.getType(),
-      !!persistentVolumeClaimWrapper,
+      !!persistentVolumeClaimWrapper && isNewPVC,
     );
   }
 
@@ -109,13 +111,7 @@ export class CombinedDisk {
     );
 
   getPVCName = (source?: StorageUISource) => {
-    const resolvedSource =
-      source ||
-      StorageUISource.fromTypes(
-        this.volumeWrapper.getType(),
-        this.dataVolumeWrapper && this.dataVolumeWrapper.getType(),
-        !!this.persistentVolumeClaimWrapper,
-      );
+    const resolvedSource = source || this.source;
     if (resolvedSource === StorageUISource.IMPORT_DISK) {
       return this.persistentVolumeClaimWrapper && this.persistentVolumeClaimWrapper.getName();
     }

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/vm/disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/vm/disk.ts
@@ -124,6 +124,7 @@ export const validateDisk = (
         volumeWrapper: volume,
         dataVolumeWrapper: dataVolume,
         persistentVolumeClaimWrapper,
+        isNewPVC: !!persistentVolumeClaimWrapper,
       }).getPVCName(source);
       addRequired(pvcName);
       validations.pvc = validatePVCName(pvcName, usedPVCNames);


### PR DESCRIPTION
- fixed Attach Disk Source (was incorrectly showing Import)

![2](https://user-images.githubusercontent.com/3648838/70633106-4895b480-1c30-11ea-967f-ab39fdbe84d7.png)

- added warning to the modal if the template disk has PVC which does not exist 

![a](https://user-images.githubusercontent.com/3648838/70633190-6e22be00-1c30-11ea-8325-75825400d63d.png)

@matthewcarleton 
