### PR TITLE
Set catalog min-width at minimum shrinkable width of it's ui child elements

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -136,7 +136,7 @@ export const OperatorHubPage = withFallback(
             appear in the <a href="/catalog">Developer Catalog</a>, providing a self-service
             experience.
           </p>
-          <div className="co-catalog-connect">
+          <div className="co-catalog__body">
             <Firehose
               resources={[
                 {

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -17,12 +17,18 @@ $co-modal-ignore-warning-icon-width: 30px;
 }
 
 .co-catalog {
-  background-color: $pf-color-black-200;
   display: flex;
   flex-direction: column;
   min-height: 100%;
   min-width: 515px; // in order to accommodate filters and tiles at mobile
   padding: 0 0 ($grid-gutter-width / 2);
+}
+
+.co-catalog__body {
+  min-width: 575px; // Minimum shrinkable width of .co-catalog child elements => 15 + ((220 + 15) + (30 + 250 + 30)) + 15
+  @media (min-width: $screen-sm-min) {
+    min-width: 590px; // Left margin 30 instead of 15
+  }
 }
 
 .co-catalog-item-details {
@@ -123,7 +129,7 @@ $co-modal-ignore-warning-icon-width: 30px;
   }
 
   &__header {
-    margin: 0 ($grid-gutter-width / 2) 0 0;
+    margin: 0 $grid-gutter-width 0 0;
   }
 
   &__heading {
@@ -132,7 +138,7 @@ $co-modal-ignore-warning-icon-width: 30px;
   }
 
   &__input {
-    margin: 0 0 20px 30px;
+    margin: 0 10px 20px 30px;
     width: auto !important;
   }
 

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -339,14 +339,16 @@ export const Catalog = connectToFlags<CatalogProps>(
   ];
 
   return (
-    <Firehose resources={mock ? [] : resources}>
-      <CatalogListPage
-        namespace={namespace}
-        templateMetadata={templateMetadata}
-        projectTemplateMetadata={projectTemplateMetadata}
-        {...props as any}
-      />
-    </Firehose>
+    <div className="co-catalog__body">
+      <Firehose resources={mock ? [] : resources}>
+        <CatalogListPage
+          namespace={namespace}
+          templateMetadata={templateMetadata}
+          projectTemplateMetadata={projectTemplateMetadata}
+          {...props as any}
+        />
+      </Firehose>
+    </div>
   );
 });
 


### PR DESCRIPTION
For both Admin and Dev Catalogs
Set the minimum width 590px (575 mobile) that the catalog container can shrink based on the widths needed for its child elements. 
Note: horizontal scroll below this width is allowed, based on the UI designs. We should give consideration of a collapse filter list which would alleviate that issue. https://www.patternfly.org/v4/documentation/react/experimental/drawer

**Before**
<img width="309" alt="Screen Shot 2019-12-11 at 3 01 34 PM" src="https://user-images.githubusercontent.com/1874151/70665678-1178d080-1c3b-11ea-8826-92bcc25f37e5.png">



**After**
![Screen Shot 2019-12-11 at 5 25 48 PM](https://user-images.githubusercontent.com/1874151/70665781-4dac3100-1c3b-11ea-877e-050dde6b6cdc.png)

