### PR TITLE
fix(knative-service): knative service created via cli

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { MockKnativeResources } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
 import {
   getKnativeServiceData,
@@ -7,6 +8,7 @@ import {
   NodeType,
   filterRevisionsBaseOnTrafficStatus,
   getParentResource,
+  filterRevisionsByActiveApplication,
 } from '../knative-topology-utils';
 import { mockServiceData, mockRevisions } from '../__mocks__/traffic-splitting-utils-mock';
 
@@ -34,11 +36,22 @@ describe('knative topology utils', () => {
     expect(revision).toBeDefined();
     expect(revision.metadata.uid).toBe('cea9496b-8ce0-11e9-bb7b-0ebb55b110b8');
   });
-  it('expect getParentResource to return parent resources', () => {
+  it('expect getParentResource not to throw error if resource is not defined', () => {
     const configuration = getParentResource(undefined, MockKnativeResources.configurations.data);
     const revision = getParentResource(undefined, MockKnativeResources.services.data);
     expect(configuration).not.toBeDefined();
     expect(revision).not.toBeDefined();
+  });
+  it('expect filterRevisionsByActiveApplication not to throw error if the service does not have traffic', () => {
+    const mockResources = _.cloneDeep(MockKnativeResources);
+    mockResources.ksservices.data[0] = _.omit(MockKnativeResources.ksservices.data[0], 'status');
+    const revisions = filterRevisionsByActiveApplication(
+      mockResources.revisions.data,
+      mockResources,
+      'myapp',
+    );
+    expect(revisions).toBeDefined();
+    expect(revisions).toHaveLength(0);
   });
   it('expect getKnativeTopologyNodeItems to return node data for service', () => {
     const knServiceNode = getKnativeTopologyNodeItems(

--- a/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
@@ -77,7 +77,10 @@ export const filterRevisionsByActiveApplication = (
   _.forEach(revisions, (revision) => {
     const configuration = getParentResource(revision, resources.configurations.data);
     const service = getParentResource(configuration, resources.ksservices.data);
-    const hasTraffic = _.find(service.status.traffic, { revisionName: revision.metadata.name });
+    const hasTraffic =
+      service &&
+      service.status &&
+      _.find(service.status.traffic, { revisionName: revision.metadata.name });
     const isServicePartofGroup = filterBasedOnActiveApplication([service], application).length > 0;
     if (hasTraffic && isServicePartofGroup) {
       filteredRevisions.push(revision);


### PR DESCRIPTION
This PR fixes a error in topology, where if topology page is open and if knative service is created via CLI then it throws an error.

Fixes: https://jira.coreos.com/browse/ODC-2516