### PR TITLE
kubevirt: Add missing keys to disk summary

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-summary.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-summary.tsx
@@ -31,7 +31,7 @@ export const DiskSummary: React.FC<DiskSummaryProps> = ({ disks, vm }) => (
       }
 
       return (
-        <>
+        <React.Fragment key={nameKey}>
           <dt id={nameKey} key={nameKey} className="kubevirt-disk-summary__datalist-dt">
             {name}
           </dt>
@@ -42,7 +42,7 @@ export const DiskSummary: React.FC<DiskSummaryProps> = ({ disks, vm }) => (
           >
             {value}
           </dd>
-        </>
+        </React.Fragment>
       );
     })}
   </dl>


### PR DESCRIPTION
fixing this:

<img width="521" alt="Screen Shot 2019-12-12 at 12 08 24" src="https://user-images.githubusercontent.com/24938324/70703536-05435080-1cd9-11ea-9531-0204c38f2933.png">
