### PR TITLE
Reduce number of rerenders of perspective dropdown

### DIFF
--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -5,7 +5,7 @@ import { CaretDownIcon } from '@patternfly/react-icons';
 import { Perspective } from '@console/plugin-sdk';
 import * as plugins from '../../plugins';
 import { RootState } from '../../redux';
-import { stateToFlagsObject, FlagsObject } from '../../reducers/features';
+import { stateToFlagsObject, FlagsObject, featureReducerName } from '../../reducers/features';
 import { getActivePerspective } from '../../reducers/ui';
 import * as UIActions from '../../actions/ui';
 import { history } from '../utils';
@@ -28,58 +28,67 @@ const NavHeader_: React.FC<NavHeaderProps & StateProps> = ({
 }) => {
   const [isPerspectiveDropdownOpen, setPerspectiveDropdownOpen] = React.useState(false);
 
-  const togglePerspectiveOpen = () => {
+  const togglePerspectiveOpen = React.useCallback(() => {
     setPerspectiveDropdownOpen(!isPerspectiveDropdownOpen);
-  };
+  }, [isPerspectiveDropdownOpen]);
 
-  const onPerspectiveSelect = (
-    event: React.MouseEvent<HTMLLinkElement>,
-    perspective: Perspective,
-  ): void => {
-    event.preventDefault();
-    if (perspective.properties.id !== activePerspective) {
-      setActivePerspective(perspective.properties.id);
-      history.push(perspective.properties.getLandingPageURL(flags));
-    }
+  const onPerspectiveSelect = React.useCallback(
+    (event: React.MouseEvent<HTMLLinkElement>, perspective: Perspective): void => {
+      event.preventDefault();
+      if (perspective.properties.id !== activePerspective) {
+        setActivePerspective(perspective.properties.id);
+        history.push(perspective.properties.getLandingPageURL(flags));
+      }
 
-    setPerspectiveDropdownOpen(false);
-    onPerspectiveSelected && onPerspectiveSelected();
-  };
-
-  const renderToggle = (icon: React.ReactNode, name: string) => (
-    <DropdownToggle
-      isOpen={isPerspectiveDropdownOpen}
-      onToggle={togglePerspectiveOpen}
-      iconComponent={CaretDownIcon}
-      data-test-id="perspective-switcher-toggle"
-    >
-      <Title size="md">
-        <span className="oc-nav-header__icon">{icon}</span>
-        {name}
-      </Title>
-    </DropdownToggle>
+      setPerspectiveDropdownOpen(false);
+      onPerspectiveSelected && onPerspectiveSelected();
+    },
+    [activePerspective, flags, onPerspectiveSelected, setActivePerspective],
   );
 
-  const getPerspectiveItems = (perspectives: Perspective[]) => {
-    return perspectives.map((nextPerspective: Perspective) => (
-      <DropdownItem
-        key={nextPerspective.properties.id}
-        onClick={(event: React.MouseEvent<HTMLLinkElement>) =>
-          onPerspectiveSelect(event, nextPerspective)
-        }
-        isHovered={nextPerspective.properties.id === activePerspective}
-        href="#"
+  const renderToggle = React.useCallback(
+    (icon: React.ReactNode, name: string) => (
+      <DropdownToggle
+        isOpen={isPerspectiveDropdownOpen}
+        onToggle={togglePerspectiveOpen}
+        iconComponent={CaretDownIcon}
+        data-test-id="perspective-switcher-toggle"
       >
         <Title size="md">
-          <span className="oc-nav-header__icon">{nextPerspective.properties.icon}</span>
-          {nextPerspective.properties.name}
+          <span className="oc-nav-header__icon">{icon}</span>
+          {name}
         </Title>
-      </DropdownItem>
-    ));
-  };
+      </DropdownToggle>
+    ),
+    [isPerspectiveDropdownOpen, togglePerspectiveOpen],
+  );
 
-  const perspectives = plugins.registry.getPerspectives();
-  const { icon, name } = perspectives.find((p) => p.properties.id === activePerspective).properties;
+  const getPerspectiveItems = React.useCallback(
+    (perspectives: Perspective[]) => {
+      return perspectives.map((nextPerspective: Perspective) => (
+        <DropdownItem
+          key={nextPerspective.properties.id}
+          onClick={(event: React.MouseEvent<HTMLLinkElement>) =>
+            onPerspectiveSelect(event, nextPerspective)
+          }
+          isHovered={nextPerspective.properties.id === activePerspective}
+          href="#"
+        >
+          <Title size="md">
+            <span className="oc-nav-header__icon">{nextPerspective.properties.icon}</span>
+            {nextPerspective.properties.name}
+          </Title>
+        </DropdownItem>
+      ));
+    },
+    [activePerspective, onPerspectiveSelect],
+  );
+
+  const perspectives = React.useMemo(() => plugins.registry.getPerspectives(), []);
+  const { icon, name } = React.useMemo(
+    () => perspectives.find((p) => p.properties.id === activePerspective).properties,
+    [activePerspective, perspectives],
+  );
 
   return (
     <div className="oc-nav-header">
@@ -98,7 +107,13 @@ const mapStateToProps = (state: RootState): StateProps => ({
   flags: stateToFlagsObject(state),
 });
 
-export default connect<StateProps, {}, NavHeaderProps>(
+export default connect<StateProps, {}, NavHeaderProps, RootState>(
   mapStateToProps,
   { setActivePerspective: UIActions.setActivePerspective },
+  null,
+  {
+    areStatesEqual: (next, prev) =>
+      next[featureReducerName] === prev[featureReducerName] &&
+      getActivePerspective(next) === getActivePerspective(prev),
+  },
 )(NavHeader_);


### PR DESCRIPTION
Perspective dropdown is rerendering very often because `mapStateToProps` always returns new object for `flags` on any react state update.