### PR TITLE
feat(topology filter): added filter for knative event sources

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
@@ -15,6 +15,8 @@ import {
   getTopologyResourceObject,
   createTopologyResourceConnection,
 } from '../topology-utils';
+import { DEFAULT_TOPOLOGY_FILTERS } from '../redux/const';
+import { TopologyFilters } from '../filters/filter-utils';
 import {
   resources,
   topologyData,
@@ -30,12 +32,16 @@ export function getTranformedTopologyData(
   mockData: TopologyDataResources,
   transformByProp: string[],
   mockCheURL?: string,
+  filters?: TopologyFilters,
 ) {
-  const result = transformTopologyData(mockData, transformByProp, undefined, mockCheURL, [
-    getKnativeServingRevisions,
-    getKnativeServingConfigurations,
-    getKnativeServingRoutes,
-  ]);
+  const result = transformTopologyData(
+    mockData,
+    transformByProp,
+    undefined,
+    mockCheURL,
+    [getKnativeServingRevisions, getKnativeServingConfigurations, getKnativeServingRoutes],
+    filters,
+  );
   const topologyTransformedData = result.topology;
   const graphData = result.graph;
   return { topologyTransformedData, graphData, keys: Object.keys(topologyTransformedData) };
@@ -265,6 +271,33 @@ describe('TopologyUtils ', () => {
       'deployments',
     ]);
     expect((topologyTransformedData[keys[2]].data as WorkloadData).builderImage).toBe(csvIcon);
+  });
+
+  it('should not render event sources if corresponding filter returns false', () => {
+    const eventFilter: TopologyFilters = _.set(
+      _.cloneDeep(DEFAULT_TOPOLOGY_FILTERS),
+      'display.eventSources',
+      false,
+    );
+    const { topologyTransformedData } = getTranformedTopologyData(
+      MockKnativeResources,
+      [],
+      '',
+      eventFilter,
+    );
+    expect(topologyTransformedData['1317f615-9636-11e9-b134-06a61d886b689']).toBe(undefined);
+  });
+  it('should render event sources if corresponding filter returns true', () => {
+    const eventFilter: TopologyFilters = _.cloneDeep(DEFAULT_TOPOLOGY_FILTERS);
+    const { topologyTransformedData } = getTranformedTopologyData(
+      MockKnativeResources,
+      [],
+      '',
+      eventFilter,
+    );
+    expect(topologyTransformedData['1317f615-9636-11e9-b134-06a61d886b689'].type).toBe(
+      'event-source',
+    );
   });
 });
 

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -387,7 +387,8 @@ export const transformTopologyData = (
 
   const knSvcResources: K8sResourceKind[] = _.get(resources, ['ksservices', 'data'], []);
   knSvcResources.length && getKnativeTopologyData(knSvcResources, NodeType.KnService);
-  const knEventSources: K8sResourceKind[] = getKnativeEventSources();
+  const knEventSources: K8sResourceKind[] =
+    filters && filters.display.eventSources ? getKnativeEventSources() : [];
   knEventSources.length && getKnativeTopologyData(knEventSources, NodeType.EventSource);
   const knRevResources: K8sResourceKind[] = _.get(resources, ['revisions', 'data'], []);
   knRevResources.length && getKnativeTopologyData(knRevResources, NodeType.Revision);


### PR DESCRIPTION
This PR adds functionality for topology filter option "event sources" under the "show" section
Jira issue - https://jira.coreos.com/browse/ODC-2458
this PR depends on https://github.com/openshift/console/pull/3746
screens
![screen1](https://user-images.githubusercontent.com/38663217/70716543-95ea5280-1d12-11ea-8e69-748c42277fda.png)
![screen2](https://user-images.githubusercontent.com/38663217/70716559-9d116080-1d12-11ea-8da7-89a7c4581209.png)


