### PR TITLE
Bug 1782811: Let server do validation of PVC name

### DIFF
--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -226,7 +226,6 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
           aria-describedby="pvc-name-help"
           id="pvc-name"
           name="pvcName"
-          pattern="[a-z0-9](?:[-a-z0-9]*[a-z0-9])?"
           required
         />
         <p className="help-block" id="pvc-name-help">
@@ -268,7 +267,7 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
       </label>
       <RequestSizeInput
         name="requestSize"
-        required={false}
+        required
         onChange={handleRequestSizeInputChange}
         defaultRequestSizeUnit={requestSizeUnit}
         defaultRequestSizeValue={requestSizeValue}


### PR DESCRIPTION
This avoids a vague error message when the pattern doesn't match and is in line with how other forms work in console.

Also mark the request size input required.

/assign @zherman0 @rhamilto 

![Screen Shot 2019-12-12 at 8 55 30 AM](https://user-images.githubusercontent.com/1167259/70717943-58a7a580-1cbd-11ea-8ab9-1538500b79a3.png)
