### PR TITLE
adds tests for RoutesOverviewList and refactor

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewList.tsx
@@ -1,39 +1,12 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
-import {
-  ResourceLink,
-  ExternalLink,
-  SidebarSectionHeading,
-} from '@console/internal/components/utils';
-import { RouteModel } from '@console/knative-plugin';
-
-export type RoutesOverviewListItemProps = {
-  route: K8sResourceKind;
-  resource: K8sResourceKind;
-};
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { SidebarSectionHeading } from '@console/internal/components/utils';
+import RoutesOverviewListItem from './RoutesOverviewListItem';
 
 export type RoutesOverviewListProps = {
   ksroutes: K8sResourceKind[];
   resource: K8sResourceKind;
-};
-
-const RoutesOverviewListItem: React.FC<RoutesOverviewListItemProps> = ({ route, resource }) => {
-  const {
-    metadata: { name, namespace },
-    status: { url },
-  } = route;
-  const trafficData = _.find(route.status.traffic, {
-    revisionName: resource.metadata.name,
-  });
-  const routeUrl = _.get(trafficData, 'url', url);
-  return (
-    <li className="list-group-item">
-      <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
-      <span className="text-muted">Location: </span>
-      <ExternalLink href={routeUrl} additionalClassName="co-external-link--block" text={routeUrl} />
-    </li>
-  );
 };
 
 const RoutesOverviewList: React.FC<RoutesOverviewListProps> = ({ ksroutes, resource }) => (

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewListItem.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { RouteModel } from '@console/knative-plugin';
+
+export type RoutesOverviewListItemProps = {
+  route: K8sResourceKind;
+  resource: K8sResourceKind;
+};
+
+const RoutesOverviewListItem: React.FC<RoutesOverviewListItemProps> = ({ route, resource }) => {
+  const {
+    metadata: { name, namespace },
+    status: { url },
+  } = route;
+  const trafficData = _.find(route.status.traffic, {
+    revisionName: resource.metadata.name,
+  });
+  const routeUrl = _.get(trafficData, 'url', url);
+  return (
+    <li className="list-group-item">
+      <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
+      <span className="text-muted">Location: </span>
+      <ExternalLink href={routeUrl} additionalClassName="co-external-link--block" text={routeUrl} />
+    </li>
+  );
+};
+
+export default RoutesOverviewListItem;

--- a/frontend/packages/knative-plugin/src/components/overview/__mocks__/overview-knative-mock.ts
+++ b/frontend/packages/knative-plugin/src/components/overview/__mocks__/overview-knative-mock.ts
@@ -1,0 +1,29 @@
+export const mockRevisionsData = [
+  {
+    apiVersion: 'serving.knative.dev/v1beta1',
+    kind: 'Revision',
+    metadata: {
+      name: 'tag-portal-v1-sh6rp',
+      namespace: 'jai-test',
+      uid: '2e4c5a8f-fa1e-4a75-b6dc-d67e4c8f8cc0',
+    },
+    resources: {},
+  },
+];
+
+export const mockRoutesData = [
+  {
+    apiVersion: 'serving.knative.dev/v1beta1',
+    kind: 'Route',
+    metadata: {
+      name: 'tag-portal-v1',
+      namespace: 'jai-test',
+      uid: '8f88ed7c-0243-4e57-94d8-1203853911a3',
+    },
+    resources: {},
+    status: {
+      traffic: [{ latestRevision: true, percent: 100, revisionName: 'tag-portal-v1-sh6rp' }],
+      url: 'http://tag-portal-v1.jai-test.apps.rhamilto.devcluster.openshift.com',
+    },
+  },
+];

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewList.spec.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import * as utils from '@console/internal/components/utils';
+import RoutesOverviewList from '../RoutesOverviewList';
+import RoutesOverviewListItem from '../RoutesOverviewListItem';
+import { mockRevisionsData, mockRoutesData } from '../__mocks__/overview-knative-mock';
+
+describe('RoutesOverviewList', () => {
+  it('should component exists', () => {
+    const wrapper = shallow(<RoutesOverviewList ksroutes={[]} resource={mockRevisionsData[0]} />);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('should have title Routes', () => {
+    const wrapper = shallow(
+      <RoutesOverviewList ksroutes={mockRoutesData} resource={mockRevisionsData[0]} />,
+    );
+    expect(wrapper.find(utils.SidebarSectionHeading)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(utils.SidebarSectionHeading)
+        .at(0)
+        .props().text,
+    ).toEqual('Routes');
+  });
+
+  it('should show info if no Routes present', () => {
+    const spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
+    spyUseAccessReview.mockReturnValue(true);
+    const wrapper = shallow(<RoutesOverviewList ksroutes={[]} resource={mockRevisionsData[0]} />);
+    expect(wrapper.find('span')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('span')
+        .at(0)
+        .props().className,
+    ).toEqual('text-muted');
+    expect(
+      wrapper
+        .find('span')
+        .at(0)
+        .props().children,
+    ).toEqual('No Routes found for this resource.');
+  });
+
+  it('should render RoutesOverviewListItem', () => {
+    const wrapper = shallow(
+      <RoutesOverviewList ksroutes={mockRoutesData} resource={mockRevisionsData[0]} />,
+    );
+    expect(wrapper.find(RoutesOverviewListItem)).toHaveLength(1);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewListItem.spec.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { RouteModel } from '@console/knative-plugin';
+import RoutesOverviewListItem from '../RoutesOverviewListItem';
+import { mockRevisionsData, mockRoutesData } from '../__mocks__/overview-knative-mock';
+
+describe('RoutesOverviewListItem', () => {
+  it('should component exists', () => {
+    const wrapper = shallow(
+      <RoutesOverviewListItem route={mockRoutesData[0]} resource={mockRevisionsData[0]} />,
+    );
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('should list the Route', () => {
+    const wrapper = shallow(
+      <RoutesOverviewListItem route={mockRoutesData[0]} resource={mockRevisionsData[0]} />,
+    );
+    expect(wrapper.find('li')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('li')
+        .at(0)
+        .props().className,
+    ).toEqual('list-group-item');
+  });
+
+  it('should have ResourceLink with proper kind', () => {
+    const wrapper = shallow(
+      <RoutesOverviewListItem route={mockRoutesData[0]} resource={mockRevisionsData[0]} />,
+    );
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(ResourceLink)
+        .at(0)
+        .props().kind,
+    ).toEqual(referenceForModel(RouteModel));
+  });
+
+  it('should have route ExternalLink with proper href', () => {
+    const wrapper = shallow(
+      <RoutesOverviewListItem route={mockRoutesData[0]} resource={mockRevisionsData[0]} />,
+    );
+    expect(wrapper.find(ExternalLink)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(ExternalLink)
+        .at(0)
+        .props().href,
+    ).toEqual('http://tag-portal-v1.jai-test.apps.rhamilto.devcluster.openshift.com');
+  });
+
+  it('should have route of specific revision as ExternalLink with proper url', () => {
+    const mockRouteData = {
+      ...mockRoutesData[0],
+      status: {
+        ...mockRoutesData[0].status,
+        traffic: [
+          {
+            ...mockRoutesData[0].status.traffic[0],
+            tag: 'abc',
+            url: 'http://abc-tag-portal-v1.jai-test.apps.rhamilto.devcluster.openshift.com',
+          },
+        ],
+      },
+    };
+    const wrapper = shallow(
+      <RoutesOverviewListItem route={mockRouteData} resource={mockRevisionsData[0]} />,
+    );
+    expect(wrapper.find(ExternalLink)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(ExternalLink)
+        .at(0)
+        .props().href,
+    ).toEqual('http://abc-tag-portal-v1.jai-test.apps.rhamilto.devcluster.openshift.com');
+  });
+});


### PR DESCRIPTION
updates test and refactors component for RoutesOverviewList

- Refactored `RoutesOverviewList` into two component `RoutesOverviewListItem` and `RoutesOverviewList`
- Added unit tests for `RoutesOverviewList`
- Added unit tests for `RoutesOverviewList`

Tracks: https://jira.coreos.com/browse/ODC-2547

Screenshot

<img width="1661" alt="Screenshot 2019-12-13 at 7 49 30 PM" src="https://user-images.githubusercontent.com/5129024/70806855-3b202c00-1de2-11ea-9ed9-8f87c6a74a00.png">
