### PR TITLE
fix topology layout overlapping namespace bar

### DIFF
--- a/frontend/packages/dev-console/src/components/NamespacedPage.scss
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.scss
@@ -9,6 +9,7 @@
     flex: 1 0 auto;
     flex-direction: column;
     background-color: var(--pf-global--Color--light-200);
+    position: relative;
 
     &.is-light {
       background-color: var(--pf-global--Color--light-100);


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-2554

Tested in chrome, safari and firefox at various sizes.

I didn't try to track down the change that caused the namespace bar to all of a sudden get overlapped but the fix is simple. Make the container of the topology relative so that the absolute positioning will compute the size correctly according to the relative container. I tried to remove the absolute positioning however that causes more issues in safari.

There seems to be an issue in the PF topology layout regarding resizing the safari browser window to go between desktop and mobile. Will discuss wiith @jeff-phillips-18 and raise an issue in PF. But loading into various sized windows works; it's a resizing issue.

![image](https://user-images.githubusercontent.com/14068621/70821785-f8426200-1da9-11ea-8494-167e29fcaec8.png)

/assign @jeff-phillips-18 