### PR TITLE
Fix bug where `.co-m-nav-title--detail` shrinks smaller than contents

### DIFF
--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -27,6 +27,7 @@
     border-bottom: 1px solid $color-grey-background-border;
     // Set min-height to prevent shifting of page content when actions btn is rendered after page content
     min-height: 90px; // h1 text + top & bottom margin + bottom border (29 + 30 + 30 + 1)
+    flex-shrink: 0; // do not allow to shrink
   }
   // Positioned after --detail to take precedence, since they will be a siblings
   &--breadcrumbs {


### PR DESCRIPTION
It was introduced by changes in #3633.

before:
![Screen Shot 2019-12-17 at 3 15 41 PM](https://user-images.githubusercontent.com/895728/71030826-327c6e00-20e0-11ea-95e9-c90148245940.png)

after:
![Screen Shot 2019-12-17 at 3 15 35 PM](https://user-images.githubusercontent.com/895728/71030836-38724f00-20e0-11ea-81a8-4ae0c4eb5f26.png)


cc: @sg00dwin 
