### PR TITLE
add test to ConfigurationsOverviewList and refactor

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
@@ -187,7 +187,7 @@ const sampleKnativeBuilds: FirehoseResult = {
   data: [],
 };
 
-const sampleKnativeConfigurations: FirehoseResult = {
+export const sampleKnativeConfigurations: FirehoseResult = {
   loaded: true,
   loadError: '',
   data: [

--- a/frontend/packages/knative-plugin/src/components/overview/ConfigurationsOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/ConfigurationsOverviewList.tsx
@@ -1,37 +1,11 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
-import { ResourceLink, SidebarSectionHeading } from '@console/internal/components/utils';
-import { ConfigurationModel } from '@console/knative-plugin';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { SidebarSectionHeading } from '@console/internal/components/utils';
+import ConfigurationsOverviewListItem from './ConfigurationsOverviewListItem';
 
 export type ConfigurationsOverviewListProps = {
   configurations: K8sResourceKind[];
-};
-
-export type ConfigurationsOverviewListItemProps = {
-  configuration: K8sResourceKind;
-};
-
-const ConfigurationsOverviewListItem: React.FC<ConfigurationsOverviewListItemProps> = ({
-  configuration: {
-    metadata: { name, namespace },
-    status: { latestCreatedRevisionName, latestReadyRevisionName },
-  },
-}) => {
-  return (
-    <li className="list-group-item">
-      <ResourceLink
-        kind={referenceForModel(ConfigurationModel)}
-        name={name}
-        namespace={namespace}
-      />
-      <span className="text-muted">Latest Created Revision name: </span>
-      <span>{latestCreatedRevisionName}</span>
-      <br />
-      <span className="text-muted">Latest Ready Revision name: </span>
-      <span>{latestReadyRevisionName}</span>
-    </li>
-  );
 };
 
 const ConfigurationsOverviewList: React.FC<ConfigurationsOverviewListProps> = ({

--- a/frontend/packages/knative-plugin/src/components/overview/ConfigurationsOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/ConfigurationsOverviewListItem.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import { ResourceLink } from '@console/internal/components/utils';
+import { ConfigurationModel } from '@console/knative-plugin';
+
+export type ConfigurationsOverviewListItemProps = {
+  configuration: K8sResourceKind;
+};
+
+const ConfigurationsOverviewListItem: React.FC<ConfigurationsOverviewListItemProps> = ({
+  configuration: {
+    metadata: { name, namespace },
+    status: { latestCreatedRevisionName, latestReadyRevisionName },
+  },
+}) => {
+  return (
+    <li className="list-group-item">
+      <ResourceLink
+        kind={referenceForModel(ConfigurationModel)}
+        name={name}
+        namespace={namespace}
+      />
+      <span className="text-muted">Latest Created Revision name: </span>
+      <span>{latestCreatedRevisionName}</span>
+      <br />
+      <span className="text-muted">Latest Ready Revision name: </span>
+      <span>{latestReadyRevisionName}</span>
+    </li>
+  );
+};
+export default ConfigurationsOverviewListItem;

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/ConfigurationsOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/ConfigurationsOverviewList.spec.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { sampleKnativeConfigurations } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import ConfigurationsOverviewList from '../ConfigurationsOverviewList';
+import ConfigurationsOverviewListItem from '../ConfigurationsOverviewListItem';
+
+describe('ConfigurationsOverviewList', () => {
+  it('should render error Message when configurations array is empty', () => {
+    const wrapper = shallow(<ConfigurationsOverviewList configurations={[]} />);
+    expect(wrapper.text().includes('No Configurations found for this resource.')).toBe(true);
+  });
+
+  it('should render ConfigurationsOverviewListItem', () => {
+    const wrapper = shallow(
+      <ConfigurationsOverviewList configurations={sampleKnativeConfigurations.data} />,
+    );
+    expect(wrapper.find(ConfigurationsOverviewListItem)).toHaveLength(1);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/ConfigurationsOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/ConfigurationsOverviewListItem.spec.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ResourceLink } from '@console/internal/components/utils';
+import { ConfigurationModel } from '@console/knative-plugin';
+import { sampleKnativeConfigurations } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import ConfigurationsOverviewListItem from '../ConfigurationsOverviewListItem';
+
+describe('ConfigurationsOverviewListItem', () => {
+  it('should list the Configuration', () => {
+    const wrapper = shallow(
+      <ConfigurationsOverviewListItem configuration={sampleKnativeConfigurations.data[0]} />,
+    );
+    expect(wrapper.type()).toBe('li');
+  });
+
+  it('should have ResourceLink with proper kind', () => {
+    const wrapper = shallow(
+      <ConfigurationsOverviewListItem configuration={sampleKnativeConfigurations.data[0]} />,
+    );
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(ResourceLink)
+        .at(0)
+        .props().kind,
+    ).toEqual(referenceForModel(ConfigurationModel));
+  });
+
+  it('should display latestCreatedRevisionName and latestReadyRevisionName', () => {
+    const wrapper = shallow(
+      <ConfigurationsOverviewListItem configuration={sampleKnativeConfigurations.data[0]} />,
+    );
+    expect(
+      wrapper.text().includes(sampleKnativeConfigurations.data[0].status.latestCreatedRevisionName),
+    ).toBe(true);
+    expect(
+      wrapper.text().includes(sampleKnativeConfigurations.data[0].status.latestReadyRevisionName),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR-
* refactors the ConfigurationsOverviewList pulling out ConfigurationsOverviewListItem from its code and to a ConfigurationsOverviewListItem.tsx
* adds unit tests for ConfigurationsOverviewList component
* adds unit tests for ConfigurationsOverviewListItem component
![test_coverage](https://user-images.githubusercontent.com/38663217/71073843-25768200-21a7-11ea-9024-104d221754a5.png)
