### PR TITLE
[WIP][POC] Minimaly expose vmis in left menu

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
 import { PodKind } from '@console/internal/module/k8s';
 import { getName, getNamespace, getNodeName } from '@console/shared';
-import { PodModel } from '@console/internal/models';
 import { VMKind, VMIKind } from '../../types';
 import { VMTemplateLink } from '../vm-templates/vm-template-link';
 import { getBasicID, prefixedID } from '../../utils';
@@ -25,6 +24,7 @@ import {
   getWorkloadProfile,
   getDevices,
 } from '../../selectors/vm';
+import { VirtualMachineInstanceModel } from '../../models';
 
 import './vm-resource.scss';
 
@@ -110,12 +110,12 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
         <VMStatuses vm={vm} vmi={vmi} pods={pods} migrations={migrations} />
       </VMDetailsItem>
 
-      <VMDetailsItem title="Pod" idValue={prefixedID(id, 'pod')} isNotAvail={!launcherPod}>
-        {launcherPod && (
+      <VMDetailsItem title="VM Instance" idValue={prefixedID(id, 'vmi')} isNotAvail={!launcherPod}>
+        {vmi && (
           <ResourceLink
-            kind={PodModel.kind}
-            name={getName(launcherPod)}
-            namespace={getNamespace(launcherPod)}
+            kind={VirtualMachineInstanceModel.kind}
+            name={getName(vmi)}
+            namespace={getNamespace(vmi)}
           />
         )}
       </VMDetailsItem>

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -111,8 +111,8 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
         <VMStatuses vm={vm} vmi={vmi} pods={pods} migrations={migrations} />
       </VMDetailsItem>
 
-      <VMDetailsItem title="VM Instance" idValue={prefixedID(id, 'vmi')} isNotAvail={!vmi}>
-        {vmi && (
+      <VMDetailsItem title="VM Instance" idValue={prefixedID(id, 'vmi')} isNotAvail={!getName(vmi)}>
+        {getName(vmi) && (
           <ResourceLink
             kind={VirtualMachineInstanceModel.kind}
             name={getName(vmi)}

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
 import { PodKind } from '@console/internal/module/k8s';
 import { getName, getNamespace, getNodeName } from '@console/shared';
+import { PodModel } from '@console/internal/models';
 import { VMKind, VMIKind } from '../../types';
 import { VMTemplateLink } from '../vm-templates/vm-template-link';
 import { getBasicID, prefixedID } from '../../utils';
@@ -116,6 +117,15 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
             kind={VirtualMachineInstanceModel.kind}
             name={getName(vmi)}
             namespace={getNamespace(vmi)}
+          />
+        )}
+      </VMDetailsItem>
+      <VMDetailsItem title="Pod" idValue={prefixedID(id, 'pod')} isNotAvail={!launcherPod}>
+        {launcherPod && (
+          <ResourceLink
+            kind={PodModel.kind}
+            name={getName(launcherPod)}
+            namespace={getNamespace(launcherPod)}
           />
         )}
       </VMDetailsItem>

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -111,7 +111,7 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
         <VMStatuses vm={vm} vmi={vmi} pods={pods} migrations={migrations} />
       </VMDetailsItem>
 
-      <VMDetailsItem title="VM Instance" idValue={prefixedID(id, 'vmi')} isNotAvail={!launcherPod}>
+      <VMDetailsItem title="VM Instance" idValue={prefixedID(id, 'vmi')} isNotAvail={!vmi}>
         {vmi && (
           <ResourceLink
             kind={VirtualMachineInstanceModel.kind}

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -67,7 +67,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       section: 'Workloads',
       componentProps: {
-        name: 'Virtual Machines Instances',
+        name: models.VirtualMachineInstanceModel.labelPlural,
         resource: models.VirtualMachineInstanceModel.plural,
         required: FLAG_KUBEVIRT,
       },
@@ -86,7 +86,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         resource: 'vmtemplates',
         required: FLAG_KUBEVIRT,
       },
-      mergeBefore: 'Virtual Machines Instances',
+      mergeBefore: models.VirtualMachineInstanceModel.labelPlural,
     },
   },
   {

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -63,6 +63,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'NavItem/ResourceNS',
+    properties: {
+      section: 'Workloads',
+      componentProps: {
+        name: 'Virtual Machines Instance',
+        resource: models.VirtualMachineInstanceModel.plural,
+        required: FLAG_KUBEVIRT,
+      },
+      mergeBefore: 'Deployments',
+    },
+  },
+  {
     // NOTE(yaacov): vmtemplates is a template resource with a selector.
     // 'NavItem/ResourceNS' is used, and not 'NavItem/Href', because it injects
     // the namespace needed to get the correct link to a resource ( template with selector ) in our case.
@@ -74,7 +86,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         resource: 'vmtemplates',
         required: FLAG_KUBEVIRT,
       },
-      mergeBefore: 'Deployments',
+      mergeBefore: 'Virtual Machines Instance',
     },
   },
   {

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -67,7 +67,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       section: 'Workloads',
       componentProps: {
-        name: 'Virtual Machines Instance',
+        name: 'Virtual Machines Instances',
         resource: models.VirtualMachineInstanceModel.plural,
         required: FLAG_KUBEVIRT,
       },
@@ -86,7 +86,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         resource: 'vmtemplates',
         required: FLAG_KUBEVIRT,
       },
-      mergeBefore: 'Virtual Machines Instance',
+      mergeBefore: 'Virtual Machines Instances',
     },
   },
   {

--- a/frontend/public/components/utils/webhooks.tsx
+++ b/frontend/public/components/utils/webhooks.tsx
@@ -90,7 +90,7 @@ export const WebhookTriggers: React.FC<WebhookTriggersProps> = (props) => {
       setWebhookSecrets(_.compact(secrets));
       setLoaded(true);
     });
-  }, [isLoaded, canGetSecret]);
+  }, [isLoaded, canGetSecret]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (_.isEmpty(webhooks)) {
     return null;

--- a/frontend/public/components/utils/webhooks.tsx
+++ b/frontend/public/components/utils/webhooks.tsx
@@ -90,7 +90,7 @@ export const WebhookTriggers: React.FC<WebhookTriggersProps> = (props) => {
       setWebhookSecrets(_.compact(secrets));
       setLoaded(true);
     });
-  }, [isLoaded, canGetSecret]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isLoaded, canGetSecret]);
 
   if (_.isEmpty(webhooks)) {
     return null;


### PR DESCRIPTION
POC - Exppose the generic VMIs views.

We currently have VMIs in our console but we do not expose them.
This POC just expose the VMIs using the left menu.

Screenshots:

Generic VMI overview, showing generic owner, with actions open:
![fedora 02 · Details · OKD](https://user-images.githubusercontent.com/2181522/71146719-f99edf00-222e-11ea-8018-161fee5d5bfa.png)

Generic VMI list:
![Virtual Machine Instances · OKD](https://user-images.githubusercontent.com/2181522/71146762-2eab3180-222f-11ea-9090-5a6ea55c2e96.png)

Adding VMI link to the VM overview:
![fedora 02 · Details · OKD(1)](https://user-images.githubusercontent.com/2181522/71146745-1a673480-222f-11ea-909b-89d2345e2453.png)
 