### PR TITLE
Support drag and drop of sink for event source from one knative service to another

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
@@ -282,7 +282,8 @@ describe('Topology Utils', () => {
     const target = topologyDataModel.topology['e187afa2-53b1-406d-a619-cf9ff1468032'];
     createTopologyResourceConnection(source, target, null, true)
       .then((resp) => {
-        expect(resp.data).toEqual(serviceBindingRequest.data);
+        const data = _.get(resp, 'data');
+        expect(data).toEqual(serviceBindingRequest.data);
         done();
       })
       .catch(() => {

--- a/frontend/packages/dev-console/src/components/topology/components/createConnection.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/createConnection.tsx
@@ -1,16 +1,24 @@
 import { Node } from '@console/topology';
-import { createTopologyResourceConnection } from '../topology-utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { createTopologyResourceConnection, createTopologySinkConnection } from '../topology-utils';
 
 export const createConnection = (
   sourceNode: Node,
   targetNode: Node,
   replaceTargetNode: Node = null,
-  serviceBindingFlag: boolean,
-): Promise<any> => {
+  serviceBindingFlag: boolean = false,
+): Promise<K8sResourceKind[] | K8sResourceKind> => {
   return createTopologyResourceConnection(
     sourceNode.getData(),
     targetNode.getData(),
     replaceTargetNode ? replaceTargetNode.getData() : null,
     serviceBindingFlag,
   );
+};
+
+export const createSinkConnection = (
+  sourceNode: Node,
+  targetNode: Node,
+): Promise<K8sResourceKind> => {
+  return createTopologySinkConnection(sourceNode.getData(), targetNode.getData());
 };

--- a/frontend/packages/dev-console/src/components/topology/components/edges/EventSourceLink.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/edges/EventSourceLink.scss
@@ -3,4 +3,8 @@
   --edge--stroke-width: 0;
   --edge--fill: #bbbbbb;
   --edge__link--stroke: #bbbbbb;
+  &.odc-m-editable {
+    --edge__arrow--cursor: pointer;
+  }
 }
+

--- a/frontend/packages/dev-console/src/components/topology/components/edges/EventSourceLink.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/edges/EventSourceLink.tsx
@@ -1,19 +1,46 @@
 import * as React from 'react';
-import { Edge, observer } from '@console/topology';
+import * as classNames from 'classnames';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import { useAccessReview } from '@console/internal/components/utils';
+import { Edge, observer, WithSourceDragProps, WithTargetDragProps } from '@console/topology';
+import { getTopologyResourceObject } from '../../topology-utils';
 import BaseEdge from './BaseEdge';
 import './EventSourceLink.scss';
 
-type ConnectsToProps = {
+type EventSourceLinkProps = {
   element: Edge;
-};
+  dragging: boolean;
+} & WithSourceDragProps &
+  WithTargetDragProps;
 
-const ConnectsTo: React.FC<ConnectsToProps> = ({ element }) => {
+const EventSourceLink: React.FC<EventSourceLinkProps> = ({
+  element,
+  targetDragRef,
+  children,
+  ...others
+}) => {
+  const resourceObj = getTopologyResourceObject(element.getSource().getData());
+  const resourceModel = modelFor(referenceFor(resourceObj));
+  const editAccess = useAccessReview({
+    group: resourceModel.apiGroup,
+    verb: 'update',
+    resource: resourceModel.plural,
+    name: resourceObj.metadata.name,
+    namespace: resourceObj.metadata.namespace,
+  });
   const markerPoint = element.getEndPoint();
+  const edgeClasses = classNames('odc-event-source-link', { 'odc-m-editable': editAccess });
   return (
-    <BaseEdge className="odc-event-source-link" element={element}>
-      <circle cx={markerPoint.x} cy={markerPoint.y} r={6} />
+    <BaseEdge className={edgeClasses} element={element} {...others}>
+      <circle
+        className="topology-connector-arrow"
+        ref={editAccess ? targetDragRef : null}
+        cx={markerPoint.x}
+        cy={markerPoint.y}
+        r={6}
+      />
     </BaseEdge>
   );
 };
 
-export default observer(ConnectsTo);
+export default observer(EventSourceLink);

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.scss
@@ -19,13 +19,21 @@
     fill: var(--pf-global--active-color--200);
     stroke: var(--pf-global--active-color--100);
   }
+
+  &.is-highlight {
+    stroke: var(--pf-global--active-color--400);
+    stroke-width: 4px;
+  }
 }
 
 .odc-m-drag-active {
   .odc-knative-service {
     opacity: 0.3;
     &.is-dragging {
-      opacity: 1;
+      opacity: var(--edge--drag-active--opacity);
+    }
+    &.is-highlight {
+      opacity: var(--edge--opacity);
     }
   }
 }

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.tsx
@@ -8,6 +8,7 @@ import {
   observer,
   WithSelectionProps,
   WithContextMenuProps,
+  WithDndDropProps,
   RectAnchor,
   useAnchor,
   useDragNode,
@@ -28,15 +29,21 @@ import Decorator from './Decorator';
 
 import './KnativeService.scss';
 
-export type EventSourceProps = {
+export type KnativeServiceProps = {
   element: Node;
+  droppable?: boolean;
+  hover?: boolean;
   dragging: boolean;
+  highlight?: boolean;
   regrouping: boolean;
+  canDrop?: boolean;
+  dropTarget?: boolean;
 } & WithSelectionProps &
+  WithDndDropProps &
   WithContextMenuProps;
 
 const DECORATOR_RADIUS = 13;
-const KnativeService: React.FC<EventSourceProps> = ({
+const KnativeService: React.FC<KnativeServiceProps> = ({
   element,
   selected,
   onSelect,
@@ -44,6 +51,9 @@ const KnativeService: React.FC<EventSourceProps> = ({
   contextMenuOpen,
   dragging,
   regrouping,
+  canDrop,
+  dropTarget,
+  dndDropRef,
 }) => {
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
@@ -63,7 +73,7 @@ const KnativeService: React.FC<EventSourceProps> = ({
     element,
   })[1];
 
-  const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
+  const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef, dndDropRef);
   const { data } = element.getData();
   const hasDataUrl = !!data.url;
   useAnchor(
@@ -76,54 +86,58 @@ const KnativeService: React.FC<EventSourceProps> = ({
   );
   useAnchor(RectAnchor);
   const { x, y, width, height } = element.getBounds();
+  const tipContent = `Move sink to service`;
 
   return (
-    <g ref={hoverRef} onClick={onSelect} onContextMenu={editAccess ? onContextMenu : null}>
-      <NodeShadows />
-      <Layer id={dragging && regrouping ? undefined : 'groups2'}>
-        <rect
-          ref={nodeRefs}
-          className={cx('odc-knative-service', {
-            'is-selected': selected,
-            'is-dragging': dragging,
-          })}
-          x={x}
-          y={y}
-          width={width}
-          height={height}
-          rx="5"
-          ry="5"
-          filter={createSvgIdUrl(
-            hover || innerHover || dragging || contextMenuOpen
-              ? NODE_SHADOW_FILTER_ID_HOVER
-              : NODE_SHADOW_FILTER_ID,
-          )}
-        />
-      </Layer>
-      {hasDataUrl && (
-        <Tooltip key="route" content="Open URL" position={TooltipPosition.right}>
-          <Decorator x={x + width} y={y} radius={DECORATOR_RADIUS} href={data.url} external>
-            <g transform="translate(-6.5, -6.5)">
-              <ExternalLinkAltIcon style={{ fontSize: DECORATOR_RADIUS }} alt="Open URL" />
-            </g>
-          </Decorator>
-        </Tooltip>
-      )}
-      {(data.kind || element.getLabel()) && (
-        <SvgBoxedText
-          className="odc-knative-service__label odc-base-node__label"
-          x={x + width / 2}
-          y={y + height + 20}
-          paddingX={8}
-          paddingY={4}
-          kind={data.kind}
-          truncate={16}
-          dragRef={dragLabelRef}
-        >
-          {element.getLabel()}
-        </SvgBoxedText>
-      )}
-    </g>
+    <Tooltip content={tipContent} trigger="manual" isVisible={dropTarget && canDrop}>
+      <g ref={hoverRef} onClick={onSelect} onContextMenu={editAccess ? onContextMenu : null}>
+        <NodeShadows />
+        <Layer id={dragging && regrouping ? undefined : 'groups2'}>
+          <rect
+            ref={nodeRefs}
+            className={cx('odc-knative-service', {
+              'is-selected': selected,
+              'is-dragging': dragging,
+              'is-highlight': canDrop,
+            })}
+            x={x}
+            y={y}
+            width={width}
+            height={height}
+            rx="5"
+            ry="5"
+            filter={createSvgIdUrl(
+              hover || innerHover || dragging || contextMenuOpen || dropTarget
+                ? NODE_SHADOW_FILTER_ID_HOVER
+                : NODE_SHADOW_FILTER_ID,
+            )}
+          />
+        </Layer>
+        {hasDataUrl && (
+          <Tooltip key="route" content="Open URL" position={TooltipPosition.right}>
+            <Decorator x={x + width} y={y} radius={DECORATOR_RADIUS} href={data.url} external>
+              <g transform="translate(-6.5, -6.5)">
+                <ExternalLinkAltIcon style={{ fontSize: DECORATOR_RADIUS }} alt="Open URL" />
+              </g>
+            </Decorator>
+          </Tooltip>
+        )}
+        {(data.kind || element.getLabel()) && (
+          <SvgBoxedText
+            className="odc-knative-service__label odc-base-node__label"
+            x={x + width / 2}
+            y={y + height + 20}
+            paddingX={8}
+            paddingY={4}
+            kind={data.kind}
+            truncate={16}
+            dragRef={dragLabelRef}
+          >
+            {element.getLabel()}
+          </SvgBoxedText>
+        )}
+      </g>
+    </Tooltip>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -18,6 +18,7 @@ import {
   tranformKnNodeData,
   filterNonKnativeDeployments,
   filterRevisionsByActiveApplication,
+  createKnativeEventSourceSink,
   NodeType,
 } from '@console/knative-plugin/src/utils/knative-topology-utils';
 import {
@@ -549,7 +550,7 @@ export const createTopologyResourceConnection = (
   target: TopologyDataObject,
   replaceTarget: TopologyDataObject = null,
   serviceBindingFlag: boolean,
-): Promise<any> => {
+): Promise<K8sResourceKind[] | K8sResourceKind> => {
   if (!source || !target || source === target) {
     return Promise.reject();
   }
@@ -563,6 +564,19 @@ export const createTopologyResourceConnection = (
   }
 
   return createResourceConnection(sourceObj, targetObj, replaceTargetObj);
+};
+
+export const createTopologySinkConnection = (
+  source: TopologyDataObject,
+  target: TopologyDataObject,
+): Promise<K8sResourceKind> => {
+  if (!source || !target || source === target) {
+    return Promise.reject();
+  }
+  const sourceObj = getTopologyResourceObject(source);
+  const targetObj = getTopologyResourceObject(target);
+
+  return createKnativeEventSourceSink(sourceObj, targetObj);
 };
 
 export const removeTopologyResourceConnection = (

--- a/frontend/packages/dev-console/src/components/topology/withEditReviewAccess.tsx
+++ b/frontend/packages/dev-console/src/components/topology/withEditReviewAccess.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import { modelFor, referenceFor, K8sVerb } from '@console/internal/module/k8s';
 import { useAccessReview } from '@console/internal/components/utils';
 import { Node } from '@console/topology';
 import { getTopologyResourceObject } from './topology-utils';
@@ -9,13 +9,13 @@ type ComponentProps = {
   element: Node;
 };
 
-export const withEditReviewAccess = () => (WrappedComponent: React.ComponentType) => {
+export const withEditReviewAccess = (verb: K8sVerb) => (WrappedComponent: React.ComponentType) => {
   const Component: React.FC<ComponentProps> = (props) => {
     const resourceObj = getTopologyResourceObject(props.element.getData());
     const resourceModel = modelFor(referenceFor(resourceObj));
     const editAccess = useAccessReview({
       group: resourceModel.apiGroup,
-      verb: 'patch',
+      verb,
       resource: resourceModel.plural,
       name: resourceObj.metadata.name,
       namespace: resourceObj.metadata.namespace,

--- a/frontend/packages/dev-console/src/utils/application-utils.ts
+++ b/frontend/packages/dev-console/src/utils/application-utils.ts
@@ -234,7 +234,7 @@ const updateItemAppConnectTo = (
 export const createServiceBinding = (
   source: K8sResourceKind,
   target: K8sResourceKind,
-): Promise<any> => {
+): Promise<K8sResourceKind> => {
   if (!source || !target || source === target) {
     return Promise.reject();
   }
@@ -286,7 +286,7 @@ export const createResourceConnection = (
   source: K8sResourceKind,
   target: K8sResourceKind,
   replacedTarget: K8sResourceKind = null,
-): Promise<any> => {
+): Promise<K8sResourceKind[] | K8sResourceKind> => {
   if (!source || !target || source === target) {
     return Promise.reject();
   }
@@ -303,7 +303,9 @@ export const createResourceConnection = (
     );
   const instanceName = _.get(source, ['metadata', 'labels', 'app.kubernetes.io/instance']);
 
-  const patches: Promise<any>[] = [updateItemAppConnectTo(source, connectValue, replaceValue)];
+  const patches: Promise<K8sResourceKind>[] = [
+    updateItemAppConnectTo(source, connectValue, replaceValue),
+  ];
 
   // If there is no instance label, only update this item
   if (!instanceName) {

--- a/frontend/packages/knative-plugin/src/components/overview/EventSinkServicesOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/EventSinkServicesOverviewList.tsx
@@ -13,7 +13,7 @@ export type EventSinkServicesOverviewListProps = {
 };
 
 const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps> = ({ obj }) => {
-  const sink = _.get(obj, 'spec.sink', null);
+  const sink = _.get(obj, 'spec.sink.ref') || _.get(obj, 'spec.sink');
   const sinkUri = _.get(obj, 'status.sinkUri', null);
   const namespace = _.get(obj, 'metadata.namespace', null);
   return (

--- a/frontend/packages/topology/src/behavior/useDndDrop.tsx
+++ b/frontend/packages/topology/src/behavior/useDndDrop.tsx
@@ -104,11 +104,6 @@ export const useDndDrop = <
           if (!(nodeRef.current instanceof SVGGraphicsElement)) {
             return false;
           }
-          // perform a fast bounds check
-          const { left, right, top, bottom } = nodeRef.current.getBBox();
-          if (x < left || x > right || y < top || y > bottom) {
-            return false;
-          }
 
           // Rounding the coordinates due to an issue with `point-in-svg-path` returning false
           // when the coordinates clearly are within the path.
@@ -116,6 +111,17 @@ export const useDndDrop = <
           // Translate to this element's coordinates.
           // Assumes the node is not within an svg element containing another transform.
           elementRef.current.translateFromAbsolute(point);
+
+          // perform a fast bounds check
+          const { x: bboxx, y: bboxy, width, height } = nodeRef.current.getBBox();
+          if (
+            point.x < bboxx ||
+            point.x > bboxx + width ||
+            point.y < bboxy ||
+            point.y > bboxy + height
+          ) {
+            return false;
+          }
 
           if (nodeRef.current instanceof SVGPathElement) {
             const d = nodeRef.current.getAttribute('d');


### PR DESCRIPTION
Support drag and drop of the sink from one knative service to another.

- User should be able to select and drag a connection/sink going from one event source to another
- While drag in progress should highlight only knative service as drop target
- On hover on Knative service should show "Create sink to a service" tooltip
- On drop should update event-source data with latest sink

Tracks: https://issues.redhat.com/browse/ODC-2485

gif: 

![ezgif com-video-to-gif (10)](https://user-images.githubusercontent.com/5129024/71092146-b2800200-21cc-11ea-9dc1-7caa84231318.gif)
