### PR TITLE
add support for creating a connector to a new node

### DIFF
--- a/frontend/packages/topology/src/behavior/dnd-types.ts
+++ b/frontend/packages/topology/src/behavior/dnd-types.ts
@@ -24,6 +24,7 @@ export type DragSource = {
 
 export type DropTarget = {
   type: TargetType;
+  dropHint(dndManager: DndManager): string | undefined;
   drop(dndManager: DndManager): any;
   hover(dndManager: DndManager): void;
   canDrop(dndManager: DndManager): boolean;
@@ -52,6 +53,7 @@ export type Unregister = () => void;
 export interface DndManager {
   registerSource(source: DragSource): [string, Unregister];
   registerTarget(target: DropTarget): [string, Unregister];
+  getDropHints(): string[] | undefined;
   canDragSource(sourceId: string | undefined): boolean;
   canDropOnTarget(targetId: string | undefined): boolean;
   isDragging(): boolean;
@@ -137,10 +139,13 @@ export type DropTargetSpec<
   Props extends {} = {}
 > = {
   accept: TargetType;
+  dropHint?:
+    | string
+    | ((item: DragObject, monitor: DropTargetMonitor, props: Props) => string | undefined);
   hitTest?: (x: number, y: number, props: Props) => boolean;
   drop?: (item: DragObject, monitor: DropTargetMonitor, props: Props) => DropResult | undefined;
   hover?: (item: DragObject, monitor: DropTargetMonitor, props: Props) => void;
-  canDrop?: (item: DragObject, monitor: DropTargetMonitor, props: Props) => boolean;
+  canDrop?: boolean | ((item: DragObject, monitor: DropTargetMonitor, props: Props) => boolean);
   collect?: (monitor: DropTargetMonitor, props: Props) => CollectedProps;
 };
 
@@ -150,6 +155,7 @@ export interface HandlerManager {
 }
 
 export interface DragSourceMonitor extends HandlerManager {
+  getDropHints(): string[] | undefined;
   canDrag(): boolean;
   isCancelled(): boolean;
   isDragging(): boolean;

--- a/frontend/packages/topology/src/behavior/useDndDrag.tsx
+++ b/frontend/packages/topology/src/behavior/useDndDrag.tsx
@@ -95,6 +95,9 @@ export const useDndDrag = <
       receiveHandlerId: (sourceId: string | undefined): void => {
         idRef.current = sourceId;
       },
+      getDropHints: (): string[] | undefined => {
+        return dndManager.getDropHints();
+      },
       canDrag: (): boolean => {
         return dndManager.canDragSource(idRef.current);
       },

--- a/frontend/packages/topology/src/behavior/useDndDrop.tsx
+++ b/frontend/packages/topology/src/behavior/useDndDrop.tsx
@@ -89,6 +89,13 @@ export const useDndDrop = <
   React.useEffect(() => {
     const dropTarget: DropTarget = {
       type: spec.accept,
+      dropHint: () => {
+        return typeof specRef.current.dropHint === 'string'
+          ? specRef.current.dropHint
+          : typeof specRef.current.dropHint === 'function'
+          ? specRef.current.dropHint(monitor.getItem(), monitor, propsRef.current)
+          : elementRef.current.getType();
+      },
       hitTest: (x: number, y: number) => {
         if (specRef.current.hitTest) {
           return specRef.current.hitTest(x, y, propsRef.current);

--- a/frontend/packages/topology/src/behavior/useDndManager.tsx
+++ b/frontend/packages/topology/src/behavior/useDndManager.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { observable } from 'mobx';
+import { computed, observable } from 'mobx';
 import ControllerContext from '../utils/ControllerContext';
 import {
   DndManager,
@@ -45,6 +45,18 @@ export class DndManagerImpl implements DndManager {
   @observable.shallow
   private targets: { [key: string]: DropTarget } = {};
 
+  @computed
+  get dropHints(): string[] | undefined {
+    return this.state.targetIds
+      ? (this.state.targetIds
+          .map((id) => {
+            const target = this.getTarget(id);
+            return target ? target.dropHint(this) : undefined;
+          })
+          .filter((x) => x) as string[])
+      : undefined;
+  }
+
   registerSource(source: DragSource): [string, Unregister] {
     const key = `S${getNextUniqueId()}`;
     this.sources[key] = source;
@@ -65,6 +77,10 @@ export class DndManagerImpl implements DndManager {
         delete this.targets[key];
       },
     ];
+  }
+
+  getDropHints(): string[] | undefined {
+    return this.dropHints;
   }
 
   canDragSource(sourceId: string | undefined): boolean {

--- a/frontend/packages/topology/src/components/DefaultCreateConnector.scss
+++ b/frontend/packages/topology/src/components/DefaultCreateConnector.scss
@@ -2,10 +2,16 @@
   .topology-connector-arrow {
     stroke: var(--pf-global--active-color--400);
     fill: var(--pf-global--active-color--400);
- }
+  }
   &__line {
     stroke: var(--pf-global--active-color--400);
     stroke-width: 2px;
     stroke-dasharray: 5px, 5px;
+  }
+
+  &__create > * {
+    stroke: var(--pf-global--active-color--400);
+    fill: #fff;
+    stroke-width: 2px;
   }
 }

--- a/frontend/packages/topology/src/components/DefaultCreateConnector.tsx
+++ b/frontend/packages/topology/src/components/DefaultCreateConnector.tsx
@@ -1,19 +1,21 @@
 import * as React from 'react';
 import Point from '../geom/Point';
-import './DefaultCreateConnector.scss';
 import ConnectorArrow from './ConnectorArrow';
+
+import './DefaultCreateConnector.scss';
 
 type DefaultCreateConnectorProps = {
   startPoint: Point;
   endPoint: Point;
+  hints?: string[];
 };
 
 const DefaultCreateConnector: React.FC<DefaultCreateConnectorProps> = ({
   startPoint,
   endPoint,
+  hints,
 }) => (
   <g className="topology-default-create-connector">
-    <ConnectorArrow startPoint={startPoint} endPoint={endPoint} />
     <line
       className="topology-default-create-connector__line"
       x1={startPoint.x}
@@ -21,6 +23,17 @@ const DefaultCreateConnector: React.FC<DefaultCreateConnectorProps> = ({
       x2={endPoint.x}
       y2={endPoint.y}
     />
+    {hints && hints.length === 1 && hints[0] === 'create' ? (
+      <g
+        transform={`translate(${endPoint.x},${endPoint.y})`}
+        className="topology-default-create-connector__create"
+      >
+        <circle cx={0} cy={0} r={6} />
+        <path d="M0,-3 V3 M-3,0 H3" />
+      </g>
+    ) : (
+      <ConnectorArrow startPoint={startPoint} endPoint={endPoint} />
+    )}
   </g>
 );
 


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-2606

Adds a new capability to topology for creating a connection to a new node. The ability to create a connector to an existing node already existed. This PR improves that feature to support the graph as a valid target.

The connector handle switches between an arrow and a circle by letting the drop targets supply hints during the drag operation. Each active drop target can supply a hint which the drag source may interpret however it wants. The default connector handle widget understands the hint `create` and when supplied with this hint will create create a circle with + symbol connector end. Otherwise the default arrow is shown.

@openshift/team-devconsole-ux 
![connect-to-new](https://user-images.githubusercontent.com/14068621/71217453-e110e200-228b-11ea-9a80-7cbf2be3df6e.gif)
