### PR TITLE
frontend: Update OperatorHub description text

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
 import { match } from 'react-router';
 import {
   Firehose,
@@ -129,10 +130,14 @@ export const OperatorHubPage = withFallback(
           <PageHeading title="OperatorHub" />
           <p className="co-catalog-page__description">
             Discover Operators from the Kubernetes community and Red Hat partners, curated by Red
-            Hat. Operators can be installed on your clusters to provide optional add-ons and shared
-            services to your developers. Once installed, the capabilities provided by the Operator
-            appear in the <a href="/catalog">Developer Catalog</a>, providing a self-service
-            experience.
+            Hat. You can purchase commercial software through{' '}
+            <ExternalLink
+              href="https://marketplace.redhat.com/en-us?utm_source=openshift_console"
+              text="Red Hat Marketplace"
+            />
+            . You can install Operators on your clusters to provide optional add-ons and shared
+            services to your developers. After installation, the Operator capabilities will appear
+            in the <Link to="/catalog">Developer Catalog</Link> providing a self-service experience.
           </p>
           <div className="co-catalog__body">
             <Firehose


### PR DESCRIPTION
Added text from Jira including link to IBM Marketplace. Please note that @alimobrem says the Open Marketplace link isn't currently working; let's hold off on merging until the link works.

<img width="1405" alt="Screen Shot 2019-12-20 at 2 16 03 PM" src="https://user-images.githubusercontent.com/7014965/71285477-48ce3800-2333-11ea-91a1-a36948208300.png">

Fixes https://issues.redhat.com/browse/CONSOLE-1971.

Heads up @openshift/team-ux-review.