### PR TITLE
kubevirt: add list columns

### DIFF
--- a/frontend/packages/console-shared/src/components/status/statuses.tsx
+++ b/frontend/packages/console-shared/src/components/status/statuses.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { InfoCircleIcon, HourglassHalfIcon, InProgressIcon } from '@patternfly/react-icons';
+import { InfoCircleIcon, HourglassHalfIcon, InProgressIcon, SyncAltIcon } from '@patternfly/react-icons';
 import {
   RedExclamationCircleIcon,
-  GreenCheckCircleIcon,
   YellowExclamationTriangleIcon,
 } from './icons';
 import GenericStatus from './GenericStatus';
@@ -30,7 +29,7 @@ export const ProgressStatus: React.FC<StatusComponentProps> = (props) => (
 ProgressStatus.displayName = 'ProgressStatus';
 
 export const SuccessStatus: React.FC<StatusComponentProps> = (props) => (
-  <StatusIconAndText {...props} icon={<GreenCheckCircleIcon />} />
+  <StatusIconAndText {...props} icon={<SyncAltIcon />} />
 );
 SuccessStatus.displayName = 'SuccessStatus';
 

--- a/frontend/packages/console-shared/src/components/status/statuses.tsx
+++ b/frontend/packages/console-shared/src/components/status/statuses.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
-import { InfoCircleIcon, HourglassHalfIcon, InProgressIcon, SyncAltIcon } from '@patternfly/react-icons';
 import {
-  RedExclamationCircleIcon,
-  YellowExclamationTriangleIcon,
-} from './icons';
+  InfoCircleIcon,
+  HourglassHalfIcon,
+  InProgressIcon,
+  SyncAltIcon,
+} from '@patternfly/react-icons';
+import { RedExclamationCircleIcon, YellowExclamationTriangleIcon } from './icons';
 import GenericStatus from './GenericStatus';
 import { StatusComponentProps } from './types';
 import StatusIconAndText from './StatusIconAndText';

--- a/frontend/packages/kubevirt-plugin/src/components/resource-link-popover.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/resource-link-popover.scss
@@ -6,5 +6,5 @@
 }
 
 .kubevirt-resource-link-popover__disabled {
-  color: var(--pf-global--disabled-color--200);
+  color: var(--pf-global--disabled-color--100);
 }

--- a/frontend/packages/kubevirt-plugin/src/components/resource-link-popover.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/resource-link-popover.scss
@@ -1,0 +1,10 @@
+.kubevirt-resource-link-popover {
+  cursor: pointer;
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  width: max-content;
+}
+
+.kubevirt-resource-link-popover__disabled {
+  color: #737679;
+}

--- a/frontend/packages/kubevirt-plugin/src/components/resource-link-popover.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/resource-link-popover.scss
@@ -6,5 +6,5 @@
 }
 
 .kubevirt-resource-link-popover__disabled {
-  color: #737679;
+  color: var(--pf-global--disabled-color--200);
 }

--- a/frontend/packages/kubevirt-plugin/src/components/resource-link-popover.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/resource-link-popover.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Popover, Button, Text } from '@patternfly/react-core';
+import { ArrowIcon } from '@patternfly/react-icons';
+import { resourcePath } from '@console/internal/components/utils';
+
+import './resource-link-popover.scss';
+
+export const ResourceLinkPopover: React.FC<ResourceLinkPopoverProps> = ({
+  kind,
+  name,
+  namespace,
+  className,
+  isDisabled,
+  message,
+  linkMessage,
+  children,
+}) => (
+  <Popover
+    headerContent={name}
+    bodyContent={children}
+    position="right"
+    footerContent={
+      linkMessage && (
+        <Button variant="link" component="a" href={resourcePath(kind, name, namespace)} isInline>
+          {linkMessage} <ArrowIcon />
+        </Button>
+      )
+    }
+  >
+    <Text
+      className={
+        isDisabled
+          ? `${className} kubevirt-resource-link-popover kubevirt-resource-link-popover__disabled`
+          : `${className} kubevirt-resource-link-popover`
+      }
+    >
+      {message}
+    </Text>
+  </Popover>
+);
+
+export type ResourceLinkPopoverProps = {
+  kind?: string;
+  name: string;
+  namespace: string;
+  className?: string;
+  isDisabled?: boolean;
+  message: string;
+  linkMessage?: string;
+  children: React.ReactNode;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -46,6 +46,9 @@ const tableColumnClasses = [
   Kebab.columnClass,
 ];
 
+export const getStatus = (obj: VMKind | VMIKind) =>
+  obj.kind === VirtualMachineModel.kind ? getVMStatus({ vm: obj as VMKind }) : getPhase(obj);
+
 const VMHeader = () =>
   dimensifyHeader(
     [
@@ -56,8 +59,6 @@ const VMHeader = () =>
       },
       {
         title: 'Instance',
-        sortFunc: 'string',
-        transforms: [sortable],
       },
       {
         title: 'Namespace',
@@ -66,7 +67,7 @@ const VMHeader = () =>
       },
       {
         title: 'Status',
-        sortFunc: 'string',
+        sortFunc: 'getStatus',
         transforms: [sortable],
       },
       {
@@ -76,12 +77,9 @@ const VMHeader = () =>
       },
       {
         title: 'Node',
-        sortFunc: 'string',
-        transforms: [sortable],
       },
       {
         title: 'IP Address',
-        sortFunc: 'string',
       },
       {
         title: '',
@@ -170,9 +168,7 @@ const VMRow: React.FC<VMRowProps> = ({
         <ResourceLink kind={NamespaceModel.kind} name={namespace} title={namespace} />
       </TableData>
       <TableData className={dimensify()}>{status}</TableData>
-      <TableData className={dimensify()}>
-        {vmi && fromNow(vmi.metadata.creationTimestamp)}
-      </TableData>
+      <TableData className={dimensify()}>{fromNow(obj.metadata.creationTimestamp)}</TableData>
       <TableData className={dimensify()}>
         {getVMINodeName(vmi) && (
           <ResourceLink kind={NodeModel.kind} name={getVMINodeName(vmi)} namespace={namespace} />
@@ -262,7 +258,7 @@ export const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) =
   ];
 
   const flatten = ({ vms, vmis }) =>
-    _.unionBy(getLoadedData(vms, []), getLoadedData(vmis, []), getName);
+    _.unionBy(getLoadedData(vms, []), getLoadedData(vmis, []), getUID);
 
   const createAccessReview = skipAccessReview ? null : { model: VirtualMachineModel, namespace };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -29,7 +29,7 @@ import { VMIKind, VMKind } from '../../types';
 import { getMigrationVMIName, isMigrating } from '../../selectors/vmi-migration';
 import { getBasicID, getLoadedData, getResource } from '../../utils';
 import { getVMStatus } from '../../statuses/vm/vm';
-import { getVmiIpAddresses } from '../../selectors/vmi';
+import { getVmiIpAddresses, getVMINodeName } from '../../selectors/vmi';
 import { vmStatusFilter } from './table-filters';
 import { menuActions } from './menu-actions';
 
@@ -104,10 +104,10 @@ const VMRow: React.FC<VMRowProps> = ({
   const lookupID = getBasicID(obj);
   const migration = migrationLookup[lookupID];
 
-  let vm = null;
-  let vmi = null;
-  let status = null;
-  let vmStatus = null;
+  let vm: VMKind;
+  let vmi: VMIKind;
+  let status: React.ReactNode;
+  let vmStatus;
   let actions = [Kebab.factory.ModifyLabels, Kebab.factory.ModifyAnnotations, Kebab.factory.Delete];
 
   if (obj.kind === VirtualMachineModel.kind) {
@@ -174,8 +174,8 @@ const VMRow: React.FC<VMRowProps> = ({
         {vmi && fromNow(vmi.metadata.creationTimestamp)}
       </TableData>
       <TableData className={dimensify()}>
-        {vmi && vmi.status.nodeName && (
-          <ResourceLink kind={NodeModel.kind} name={vmi.status.nodeName} namespace={namespace} />
+        {getVMINodeName(vmi) && (
+          <ResourceLink kind={NodeModel.kind} name={getVMINodeName(vmi)} namespace={namespace} />
         )}
       </TableData>
       <TableData className={dimensify()}>{vmi && getVmiIpAddresses(vmi)}</TableData>

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -258,7 +258,11 @@ export const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) =
   ];
 
   const flatten = ({ vms, vmis }) =>
-    _.unionBy(getLoadedData(vms, []), getLoadedData(vmis, []), getUID);
+    _.unionBy(
+      getLoadedData(vms, []),
+      getLoadedData(vmis, []),
+      (obj) => `${getName(obj)}-${getNamespace(obj)}`,
+    );
 
   const createAccessReview = skipAccessReview ? null : { model: VirtualMachineModel, namespace };
 

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
@@ -24,3 +24,5 @@ export const isVMIRunning = (vmi: VMIKind) => vmi && vmi.status && vmi.status.ph
 
 export const getVMIInterfaces = (vmi: VMIKind) =>
   (vmi && vmi.status && vmi.status.interfaces) || [];
+
+export const getVMINodeName = (vmi: VMIKind) => vmi && vmi.status && vmi.status.nodeName;


### PR DESCRIPTION
Add VM list columns using the design.

  - [x] add missing columns.
  - [x] add pop-ups when pressing the "no VM" and "no VMI" name, like shown on design.
  - [x] add VMIs that do not have a VM owner.
 
Design: https://github.com/openshift/openshift-origin-design/pull/310

Screenshot:
![Peek 2019-12-24 17-56](https://user-images.githubusercontent.com/2181522/71419214-f6648280-2676-11ea-996e-f6be27a54bb6.gif)

Actions for VM row:
![Virtual Machines · OKD](https://user-images.githubusercontent.com/2181522/71416518-7126a100-2669-11ea-9d48-baa7ad685860.png)

Actions for VMI row:
![Virtual Machines · OKD(1)](https://user-images.githubusercontent.com/2181522/71416514-6e2bb080-2669-11ea-8e55-73fa21c285a6.png)

Navigating to VMI list and the VMIRS generic pages:
![Peek 2019-12-24 16-24](https://user-images.githubusercontent.com/2181522/71416686-35d8a200-266a-11ea-97df-729158becae7.gif)
