### PR TITLE
Test Noobaa SSO link from OCP dashboard

### DIFF
--- a/frontend/packages/ceph-storage-plugin/integration-tests/tests/2-tests/noobaa-sso-scenario.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests/tests/2-tests/noobaa-sso-scenario.ts
@@ -1,0 +1,39 @@
+import { browser } from 'protractor';
+import { appHost } from '@console/internal-integration-tests/protractor.conf';
+import { dashboardIsLoaded } from '@console/shared/src/test-views/dashboard-shared.view';
+import { click } from '@console/shared/src/test-utils/utils';
+import {
+  noobaaAddStorageResource,
+  noobaaAddStorageResourceModal,
+  noobaaExternalLink,
+  objectServiceLink,
+  overviewLink,
+} from '../../views/noobaa-sso.view';
+import { SECOND } from '../../utils/consts';
+
+describe('Check noobaa link in obejct service dashboard and perform SSO.', () => {
+  beforeAll(async () => {
+    await browser.get(`${appHost}/dashboards`);
+    await dashboardIsLoaded();
+  });
+
+  it('Check that noobaa dashboard is opening and links available.', async () => {
+    await click(objectServiceLink);
+    const parentGUID = await browser.getWindowHandle();
+    await click(noobaaExternalLink);
+    await browser.sleep(2 * SECOND);
+    for (const guid of await browser.getAllWindowHandles()) {
+      if (guid !== parentGUID) {
+        browser.switchTo().window(guid);
+        break;
+      }
+    }
+
+    await click(noobaaAddStorageResource);
+    await browser.sleep(1 * SECOND);
+    expect(noobaaAddStorageResourceModal.isPresent()).toBe(true);
+    await browser.close();
+    await browser.switchTo().window(parentGUID);
+    expect(overviewLink.isPresent()).toBe(true);
+  });
+});

--- a/frontend/packages/ceph-storage-plugin/integration-tests/views/noobaa-sso.view.ts
+++ b/frontend/packages/ceph-storage-plugin/integration-tests/views/noobaa-sso.view.ts
@@ -1,0 +1,9 @@
+import { $, element, by, $$ } from 'protractor';
+
+export const objectServiceLink = element(by.cssContainingText('a', 'Object Service'));
+export const overviewLink = element(by.cssContainingText('a', 'Overview'));
+export const noobaaExternalLink = element(by.cssContainingText('a.co-external-link', 'noobaa'));
+export const noobaaAddStorageResource = $$('button.btn.overview-btn').get(0);
+export const noobaaAddStorageResourceModal = $(
+  '.modal.column.text-left.pop-centered.card-shadow.modal-small.add-resources-modal',
+);


### PR DESCRIPTION
Check that Noobaa link from OCP dashboard opens in another tab and don't require credentials.