### PR TITLE
Bug 1784264: add namespace level imagestream fetching

### DIFF
--- a/frontend/packages/console-shared/src/components/dropdown/ResourceDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/dropdown/ResourceDropdown.tsx
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import * as fuzzy from 'fuzzysearch';
 import { Dropdown, FirehoseResult, LoadingInline } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 
 interface State {
   items: {};
@@ -35,7 +36,7 @@ interface ResourceDropdownProps {
   resources?: FirehoseResult[];
   selectedKey: string;
   autoSelect?: boolean;
-  resourceFilter?: (resource: any) => boolean;
+  resourceFilter?: (resource: K8sResourceKind) => boolean;
   onChange?: (key: string, name?: string, isListEmpty?: boolean) => void;
   onLoad?: (items: { [key: string]: string }) => void;
 }

--- a/frontend/packages/console-shared/src/components/formik-fields/ResourceDropdownField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/ResourceDropdownField.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import cx from 'classnames';
 import { useField, useFormikContext, FormikValues } from 'formik';
 import { FormGroup } from '@patternfly/react-core';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { Firehose, FirehoseResource } from '@console/internal/components/utils';
 import ResourceDropdown from '../dropdown/ResourceDropdown';
 import { DropdownFieldProps } from './field-types';
@@ -10,6 +11,8 @@ import { getFieldId } from './field-utils';
 export interface ResourceDropdownFieldProps extends DropdownFieldProps {
   dataSelector: string[] | number[] | symbol[];
   resources: FirehoseResource[];
+  onLoad?: (items: { [key: string]: string }) => void;
+  resourceFilter?: (resource: K8sResourceKind) => boolean;
 }
 const ResourceDropdownField: React.FC<ResourceDropdownFieldProps> = ({
   label,
@@ -18,6 +21,8 @@ const ResourceDropdownField: React.FC<ResourceDropdownFieldProps> = ({
   fullWidth,
   dataSelector,
   resources,
+  onLoad,
+  resourceFilter,
   ...props
 }) => {
   const [field, { touched, error }] = useField(props.name);
@@ -41,6 +46,8 @@ const ResourceDropdownField: React.FC<ResourceDropdownFieldProps> = ({
           dataSelector={dataSelector}
           selectedKey={field.value}
           dropDownClassName={cx({ 'dropdown--full-width': fullWidth })}
+          onLoad={onLoad}
+          resourceFilter={resourceFilter}
           onChange={(value: string) => {
             props.onChange && props.onChange(value);
             setFieldValue(props.name, value);

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -14,7 +14,6 @@ import DeployImageForm from './DeployImageForm';
 export interface DeployImageProps {
   namespace: string;
   projects?: FirehoseList;
-  imageStreams?: FirehoseList;
 }
 
 interface StateProps {
@@ -23,7 +22,7 @@ interface StateProps {
 
 type Props = DeployImageProps & StateProps;
 
-const DeployImage: React.FC<Props> = ({ namespace, projects, activeApplication, imageStreams }) => {
+const DeployImage: React.FC<Props> = ({ namespace, projects, activeApplication }) => {
   const initialValues: DeployImageFormData = {
     project: {
       name: namespace || '',
@@ -152,9 +151,7 @@ const DeployImage: React.FC<Props> = ({ namespace, projects, activeApplication, 
       onSubmit={handleSubmit}
       onReset={history.goBack}
       validationSchema={deployValidationSchema}
-      render={(props) => (
-        <DeployImageForm {...props} projects={projects} imageStreams={imageStreams} />
-      )}
+      render={(props) => <DeployImageForm {...props} projects={projects} />}
     />
   );
 };

--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -18,10 +18,9 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
   isSubmitting,
   dirty,
   projects,
-  imageStreams,
 }) => (
   <Form className="co-deploy-image" onSubmit={handleSubmit}>
-    <ImageSearchSection imageStreams={imageStreams.loaded ? imageStreams.data : []} />
+    <ImageSearchSection />
     <AppSection
       project={values.project}
       noProjectsAvailable={projects.loaded && _.isEmpty(projects.data)}

--- a/frontend/packages/dev-console/src/components/import/DeployImagePage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImagePage.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { PageHeading, Firehose } from '@console/internal/components/utils';
-import { ImageStreamModel } from '@console/internal/models';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import DeployImage from './DeployImage';
 
@@ -17,16 +16,7 @@ const DeployImagePage: React.FunctionComponent<DeployImagePageProps> = ({ match 
       </Helmet>
       <PageHeading title="Deploy Image" />
       <div className="co-m-pane__body">
-        <Firehose
-          resources={[
-            { kind: 'Project', prop: 'projects', isList: true },
-            {
-              kind: ImageStreamModel.kind,
-              prop: 'imageStreams',
-              isList: true,
-            },
-          ]}
-        >
+        <Firehose resources={[{ kind: 'Project', prop: 'projects', isList: true }]}>
           <DeployImage namespace={namespace} />
         </Firehose>
       </div>

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useFormikContext, FormikValues } from 'formik';
-import { K8sResourceKind } from '@console/internal/module/k8s';
 import { RadioButtonField } from '@console/shared';
 import FormSection from '../section/FormSection';
 import { imageRegistryType } from '../../../utils/imagestream-utils';
@@ -9,13 +8,9 @@ import ImageSearch from './ImageSearch';
 import SearchStatus from './SearchStatus';
 import SearchResults from './SearchResults';
 
-export interface ImageSearchSectionProps {
-  imageStreams: K8sResourceKind[];
-}
-const ImageSearchSection: React.FC<ImageSearchSectionProps> = ({ imageStreams }) => {
+const ImageSearchSection: React.FC = () => {
   const { values, setFieldValue, initialValues } = useFormikContext<FormikValues>();
   const [registry, setRegistry] = React.useState(values.registry);
-
   React.useEffect(() => {
     if (values.registry !== registry) {
       setRegistry(values.registry);
@@ -48,7 +43,7 @@ const ImageSearchSection: React.FC<ImageSearchSectionProps> = ({ imageStreams })
           {
             label: imageRegistryType.Internal.label,
             value: imageRegistryType.Internal.value,
-            activeChildren: <ImageStream imageStreams={imageStreams} />,
+            activeChildren: <ImageStream />,
           },
         ]}
       />

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStream.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStream.tsx
@@ -2,79 +2,68 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { Alert } from '@patternfly/react-core';
 import { useFormikContext, FormikValues } from 'formik';
-import { k8sGet } from '@console/internal/module/k8s';
-import { ImageStreamTagModel, RoleBindingModel } from '@console/internal/models';
-import { useAccessReview } from '@console/internal/components/utils';
-import { DropdownField, ResourceDropdownField, CheckboxField } from '@console/shared';
-import { ImageStreamProps } from '../import-types';
+import { CheckboxField } from '@console/shared';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import {
-  getSuggestedName,
-  getPorts,
-  makePortName,
   RegistryType,
-  getProjectResource,
   BuilderImagesNamespace,
-  getImageStreamByNamespace,
   getImageStreamTags,
 } from '../../../utils/imagestream-utils';
+import { ImageStreamState, ImageStreamAction, ImageStreamActions } from '../import-types';
+import { ImageStreamContext } from './ImageStreamContext';
+import ImageStreamNsDropdown from './ImageStreamNsDropdown';
+import ImageStreamDropdown from './ImageStreamDropdown';
+import ImageStreamTagDropdown from './ImageStreamTagDropdown';
+
 import './ImageStream.scss';
 
-const ImageStream: React.FC<ImageStreamProps> = ({ imageStreams }) => {
-  const resources = getProjectResource();
-  let imageStreamList = {};
-  let imageStreamTagList = {};
+export const initialState: ImageStreamState = {
+  hasAccessToPullImage: true,
+  loading: false,
+  accessLoading: false,
+  hasCreateAccess: false,
+  selectedImageStream: {},
+};
 
-  const {
-    values: { imageStream, application, project, registry },
-    setFieldValue,
-    setFieldError,
-    initialValues,
-  } = useFormikContext<FormikValues>();
-  const [hasAccessToPullImage, setHasAccessToPullImage] = React.useState(false);
-
-  const searchImageTag = React.useCallback(
-    (selectedTag: string) => {
-      setFieldValue('isSearchingForImage', true);
-      k8sGet(ImageStreamTagModel, `${imageStream.image}:${selectedTag}`, imageStream.namespace)
-        .then((imageStreamImport) => {
-          const { image, tag, status } = imageStreamImport;
-          const name = imageStream.image;
-          const isi = { name, image, tag, status };
-          const ports = getPorts(isi);
-          setFieldValue('isSearchingForImage', false);
-          setFieldValue('isi.name', name);
-          setFieldValue('isi.image', image);
-          setFieldValue('isi.tag', selectedTag);
-          setFieldValue('isi.ports', ports);
-          setFieldValue('image.ports', ports);
-          setFieldValue('name', getSuggestedName(name));
-          !application.name && setFieldValue('application.name', `${getSuggestedName(name)}-app`);
-          // set default port value
-          const targetPort = _.head(ports);
-          targetPort && setFieldValue('route.targetPort', makePortName(targetPort));
-        })
-        .catch((error) => {
-          setFieldError('isi.image', error.message);
-          setFieldValue('isi', {});
-          setFieldValue('isSearchingForImage', false);
-        });
-    },
-    [setFieldValue, imageStream, application.name, setFieldError],
-  );
-
-  const hasCreateAccess = useAccessReview({
-    group: RoleBindingModel.apiGroup,
-    resource: RoleBindingModel.plural,
-    verb: 'create',
-    name: 'system:image-puller',
-    namespace: imageStream.namespace,
-  });
-  if (hasCreateAccess) {
-    imageStreamList = getImageStreamByNamespace(imageStreams, imageStream.namespace);
-    imageStreamTagList = getImageStreamTags(imageStreams, imageStream.image, imageStream.namespace);
+export const ImageStreamReducer = (state: ImageStreamState, action: ImageStreamAction) => {
+  const { value } = action;
+  switch (action.type) {
+    case ImageStreamActions.setHasAccessToPullImage:
+      return { ...state, hasAccessToPullImage: value };
+    case ImageStreamActions.setLoading:
+      return { ...state, loading: value };
+    case ImageStreamActions.setAccessLoading:
+      return { ...state, accessLoading: value };
+    case ImageStreamActions.setHasCreateAccess:
+      return { ...state, hasCreateAccess: value };
+    case ImageStreamActions.setSelectedImageStream:
+      return { ...state, selectedImageStream: value };
+    default:
+      throw new Error('Invalid action was provided in imagestream reducer');
   }
-  const isNamespaceSelected = imageStream.namespace !== '';
-  const isStreamsAvailable = isNamespaceSelected && !_.isEmpty(imageStreamList);
+};
+
+const ImageStream: React.FC = () => {
+  const {
+    values: { imageStream, project, registry },
+    setFieldValue,
+  } = useFormikContext<FormikValues>();
+  const [state, dispatch] = React.useReducer(ImageStreamReducer, initialState);
+  const [hasImageStreams, setHasImageStreams] = React.useState(false);
+  const {
+    hasAccessToPullImage,
+    loading,
+    accessLoading,
+    hasCreateAccess,
+    selectedImageStream,
+  } = state;
+
+  React.useEffect(() => {
+    setFieldValue('imageStream.grantAccess', true);
+  }, [imageStream.namespace, setFieldValue]);
+  const imageStreamTagList = getImageStreamTags(selectedImageStream as K8sResourceKind);
+  const isNamespaceSelected = imageStream.namespace !== '' && !accessLoading;
+  const isStreamsAvailable = isNamespaceSelected && hasImageStreams && !loading;
   const isTagsAvailable = isStreamsAvailable && !_.isEmpty(imageStreamTagList);
   const isImageStreamSelected = imageStream.image !== '';
   const canGrantAccess =
@@ -89,98 +78,52 @@ const ImageStream: React.FC<ImageStreamProps> = ({ imageStreams }) => {
 
   return (
     <>
-      <div className="row">
-        <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
-          <ResourceDropdownField
-            name="imageStream.namespace"
-            label="Projects"
-            title="Select Project"
-            fullWidth
-            required
-            resources={resources}
-            dataSelector={['metadata', 'name']}
-            onChange={(selectedProject) => {
-              setFieldValue('imageStream.image', '');
-              setFieldValue('imageStream.tag', '');
-              setFieldValue('isi', initialValues.isi);
-              k8sGet(RoleBindingModel, 'system:image-puller', selectedProject)
-                .then(() => {
-                  setHasAccessToPullImage(true);
-                  setFieldValue('imageStream.grantAccess', false);
-                })
-                .catch(() => setHasAccessToPullImage(false));
-            }}
-          />
+      <ImageStreamContext.Provider value={{ state, dispatch, hasImageStreams, setHasImageStreams }}>
+        <div className="row">
+          <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
+            <ImageStreamNsDropdown />
+          </div>
+          <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
+            <ImageStreamDropdown />
+            <div className="odc-imagestream-separator">/</div>
+          </div>
+          <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
+            <ImageStreamTagDropdown />
+            <div className="odc-imagestream-separator">:</div>
+          </div>
         </div>
-        <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
-          <DropdownField
-            name="imageStream.image"
-            label="ImageStreams"
-            items={imageStreamList}
-            title={
-              isNamespaceSelected && !isStreamsAvailable ? 'No Image Stream' : 'Select Image Stream'
-            }
-            fullWidth
-            disabled={!isNamespaceSelected || (isNamespaceSelected && !isStreamsAvailable)}
-            required
-            onChange={() => {
-              setFieldValue('imageStream.tag', '');
-              setFieldValue('isi', initialValues.isi);
-            }}
-          />
-          <div className="odc-imagestream-separator">/</div>
-        </div>
-        <div className="col-lg-4 col-md-4 col-sm-4 col-xs-12">
-          <DropdownField
-            name="imageStream.tag"
-            label="Tag"
-            items={imageStreamTagList}
-            title={
-              isNamespaceSelected && isImageStreamSelected && !isTagsAvailable
-                ? 'No Tag'
-                : 'Select Tag'
-            }
-            disabled={!isImageStreamSelected || !isTagsAvailable}
-            fullWidth
-            required
-            onChange={(tag) => {
-              tag !== '' && searchImageTag(tag);
-            }}
-          />
-          <div className="odc-imagestream-separator">:</div>
-        </div>
-      </div>
-      {isNamespaceSelected && isImageStreamSelected && !isTagsAvailable && hasCreateAccess && (
-        <div className="odc-imagestream-alert">
-          <Alert variant="warning" title="No Image streams tags found" isInline>
-            No tags are available in image stream {imageStream.image}
-          </Alert>
-        </div>
-      )}
-      {isNamespaceSelected && !isStreamsAvailable && hasCreateAccess && (
-        <div className="odc-imagestream-alert">
-          <Alert variant="warning" title="No Image streams found" isInline>
-            No image streams are available in project {imageStream.namespace}
-          </Alert>
-        </div>
-      )}
-      {isNamespaceSelected && !hasCreateAccess && (
-        <div className="odc-imagestream-alert">
-          <Alert variant="warning" title="Permission denied" isInline>
-            Service account default does not have authority to pull images from{' '}
-            {imageStream.namespace}. Select another project to continue.
-          </Alert>
-        </div>
-      )}
-      {canGrantAccess && (
-        <div className="odc-imagestream-alert">
-          <CheckboxField
-            name="imageStream.grantAccess"
-            label={`Grant service account default authority to pull images from
+        {isNamespaceSelected && isImageStreamSelected && !isTagsAvailable && hasCreateAccess && (
+          <div className="odc-imagestream-alert">
+            <Alert variant="warning" title="No Image streams tags found" isInline>
+              No tags are available in image stream {imageStream.image}
+            </Alert>
+          </div>
+        )}
+        {isNamespaceSelected && !loading && !isStreamsAvailable && hasCreateAccess && (
+          <div className="odc-imagestream-alert">
+            <Alert variant="warning" title="No Image streams found" isInline>
+              No image streams are available in project {imageStream.namespace}
+            </Alert>
+          </div>
+        )}
+        {isNamespaceSelected && !accessLoading && !hasCreateAccess && (
+          <div className="odc-imagestream-alert">
+            <Alert variant="warning" title="Permission denied" isInline>
+              Service account default does not have authority to pull images from{' '}
+              {imageStream.namespace}. Select another project to continue.
+            </Alert>
+          </div>
+        )}
+        {canGrantAccess && (
+          <div className="odc-imagestream-alert">
+            <CheckboxField
+              name="imageStream.grantAccess"
+              label={`Grant service account default authority to pull images from
                 ${imageStream.namespace}`}
-          />
-        </div>
-      )}
+            />
+          </div>
+        )}
+      </ImageStreamContext.Provider>
     </>
   );
 };

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamContext.ts
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamContext.ts
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { ImageStreamContextProps } from '../import-types';
+
+export const ImageStreamContext = React.createContext<ImageStreamContextProps>(undefined as any);

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamDropdown.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { useFormikContext, FormikValues } from 'formik';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { ResourceDropdownField } from '@console/shared';
+import { getImageStreamResource } from '../../../utils/imagestream-utils';
+import { ImageStreamActions } from '../import-types';
+import { ImageStreamContext } from './ImageStreamContext';
+
+const ImageStreamDropdown: React.FC = () => {
+  const imgCollection = {};
+
+  const {
+    values: { imageStream },
+    setFieldValue,
+    initialValues,
+  } = useFormikContext<FormikValues>();
+  const { state, dispatch, hasImageStreams, setHasImageStreams } = React.useContext(
+    ImageStreamContext,
+  );
+  const { accessLoading, loading, hasCreateAccess } = state;
+  const isNamespaceSelected = imageStream.namespace !== '' && !accessLoading;
+  const isStreamsAvailable = isNamespaceSelected && hasImageStreams && !loading;
+  const collectImageStreams = (namespace: string, resource: K8sResourceKind): void => {
+    if (!imgCollection[namespace]) {
+      imgCollection[namespace] = {};
+    }
+    imgCollection[namespace][resource.metadata.name] = resource;
+  };
+  const getTitle = () => {
+    return loading && !isStreamsAvailable
+      ? ''
+      : !isStreamsAvailable || !hasCreateAccess
+      ? 'No Image Stream'
+      : 'Select Image Stream';
+  };
+  const onDropdownChange = (img: string) => {
+    setFieldValue('imageStream.tag', '');
+    setFieldValue('isi', initialValues.isi);
+    const image = imgCollection[imageStream.namespace][img];
+    dispatch({ type: ImageStreamActions.setSelectedImageStream, value: image });
+  };
+  const onLoad = (imgstreams) => {
+    const imageStreamAvailable = !_.isEmpty(imgstreams);
+    setHasImageStreams(imageStreamAvailable);
+    loading &&
+      isNamespaceSelected &&
+      dispatch({ type: ImageStreamActions.setLoading, value: false });
+  };
+  const resourceFilter = (resource: K8sResourceKind) => {
+    const {
+      metadata: { namespace },
+    } = resource;
+    collectImageStreams(namespace, resource);
+    return namespace === imageStream.namespace;
+  };
+  return (
+    <ResourceDropdownField
+      name="imageStream.image"
+      label="ImageStreams"
+      resources={getImageStreamResource(imageStream.namespace)}
+      dataSelector={['metadata', 'name']}
+      key={imageStream.namespace}
+      fullWidth
+      required
+      title={getTitle()}
+      disabled={!hasCreateAccess || !isStreamsAvailable}
+      onChange={onDropdownChange}
+      onLoad={onLoad}
+      resourceFilter={resourceFilter}
+    />
+  );
+};
+
+export default ImageStreamDropdown;

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamNsDropdown.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { useFormikContext, FormikValues } from 'formik';
+import { k8sGet } from '@console/internal/module/k8s';
+import { RoleBindingModel } from '@console/internal/models';
+import { checkAccess } from '@console/internal/components/utils';
+import { ResourceDropdownField } from '@console/shared';
+import { getProjectResource } from '../../../utils/imagestream-utils';
+import { ImageStreamActions as Action } from '../import-types';
+import { ImageStreamContext } from './ImageStreamContext';
+
+const ImageStreamNsDropdown: React.FC = () => {
+  const { setFieldValue, initialValues } = useFormikContext<FormikValues>();
+  const { dispatch } = React.useContext(ImageStreamContext);
+  const onDropdownChange = (selectedProject: string) => {
+    const promiseArr = [];
+    setFieldValue('imageStream.image', '');
+    setFieldValue('imageStream.tag', '');
+    setFieldValue('isi', initialValues.isi);
+    dispatch({ type: Action.setLoading, value: true });
+    dispatch({ type: Action.setAccessLoading, value: true });
+    promiseArr.push(
+      checkAccess({
+        group: RoleBindingModel.apiGroup,
+        resource: RoleBindingModel.plural,
+        verb: 'create',
+        name: 'system:image-puller',
+        namespace: selectedProject,
+      })
+        .then((resp) => dispatch({ type: Action.setHasCreateAccess, value: resp.status.allowed }))
+        .catch(() => dispatch({ type: Action.setHasAccessToPullImage, value: false })),
+    );
+    promiseArr.push(
+      k8sGet(RoleBindingModel, 'system:image-puller', selectedProject)
+        .then(() => {
+          dispatch({
+            type: Action.setHasAccessToPullImage,
+            value: true,
+          });
+          setFieldValue('imageStream.grantAccess', false);
+        })
+        .catch(() => dispatch({ type: Action.setHasAccessToPullImage, value: false })),
+    );
+    return Promise.all(promiseArr).then(() =>
+      dispatch({ type: Action.setAccessLoading, value: false }),
+    );
+  };
+  return (
+    <ResourceDropdownField
+      name="imageStream.namespace"
+      label="Projects"
+      title="Select Project"
+      fullWidth
+      required
+      resources={getProjectResource()}
+      dataSelector={['metadata', 'name']}
+      onChange={onDropdownChange}
+    />
+  );
+};
+export default ImageStreamNsDropdown;

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { useFormikContext, FormikValues } from 'formik';
+import { DropdownField } from '@console/shared';
+import { k8sGet, K8sResourceKind } from '@console/internal/module/k8s';
+import { ImageStreamTagModel } from '@console/internal/models';
+import {
+  getImageStreamTags,
+  getPorts,
+  getSuggestedName,
+  makePortName,
+} from '../../../utils/imagestream-utils';
+import { ImageStreamContext } from './ImageStreamContext';
+
+const ImageStreamTagDropdown: React.FC = () => {
+  let imageStreamTagList = {};
+  const {
+    values: { imageStream, application },
+    setFieldValue,
+    setFieldError,
+  } = useFormikContext<FormikValues>();
+  const { state, hasImageStreams } = React.useContext(ImageStreamContext);
+  const { selectedImageStream, accessLoading, loading } = state;
+  imageStreamTagList = getImageStreamTags(selectedImageStream as K8sResourceKind);
+  const isNamespaceSelected = imageStream.namespace !== '' && !accessLoading;
+  const isStreamsAvailable = isNamespaceSelected && hasImageStreams && !loading;
+  const isTagsAvailable = isStreamsAvailable && !_.isEmpty(imageStreamTagList);
+  const isImageStreamSelected = imageStream.image !== '';
+
+  const searchImageTag = React.useCallback(
+    (selectedTag: string) => {
+      setFieldValue('isSearchingForImage', true);
+      k8sGet(ImageStreamTagModel, `${imageStream.image}:${selectedTag}`, imageStream.namespace)
+        .then((imageStreamImport) => {
+          const { image, tag, status } = imageStreamImport;
+          const name = imageStream.image;
+          const isi = { name, image, tag, status };
+          const ports = getPorts(isi);
+          setFieldValue('isSearchingForImage', false);
+          setFieldValue('isi.name', name);
+          setFieldValue('isi.image', image);
+          setFieldValue('isi.tag', selectedTag);
+          setFieldValue('isi.ports', ports);
+          setFieldValue('image.ports', ports);
+          setFieldValue('name', getSuggestedName(name));
+          !application.name && setFieldValue('application.name', `${getSuggestedName(name)}-app`);
+          // set default port value
+          const targetPort = _.head(ports);
+          targetPort && setFieldValue('route.targetPort', makePortName(targetPort));
+        })
+        .catch((error) => {
+          setFieldError('isi.image', error.message);
+          setFieldValue('isi', {});
+          setFieldValue('isSearchingForImage', false);
+        });
+    },
+    [setFieldValue, imageStream, application.name, setFieldError],
+  );
+  return (
+    <DropdownField
+      name="imageStream.tag"
+      label="Tag"
+      items={imageStreamTagList}
+      key={imageStream.image}
+      title={
+        isNamespaceSelected && isImageStreamSelected && !isTagsAvailable ? 'No Tag' : 'Select Tag'
+      }
+      disabled={!isImageStreamSelected || !isTagsAvailable}
+      fullWidth
+      required
+      onChange={(tag) => {
+        tag !== '' && searchImageTag(tag);
+      }}
+    />
+  );
+};
+
+export default ImageStreamTagDropdown;

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -6,13 +6,30 @@ import { NormalizedBuilderImages } from '../../utils/imagestream-utils';
 export interface DeployImageFormProps {
   builderImages?: NormalizedBuilderImages;
   projects?: FirehoseList;
-  imageStreams?: FirehoseList;
 }
+export type ImageStreamPayload = boolean | K8sResourceKind;
 
-export interface ImageStreamProps {
-  imageStreams: K8sResourceKind[];
+export type ImageStreamState = {
+  hasAccessToPullImage: ImageStreamPayload;
+  accessLoading: ImageStreamPayload;
+  loading: ImageStreamPayload;
+  hasCreateAccess: ImageStreamPayload;
+  selectedImageStream: ImageStreamPayload;
+};
+export enum ImageStreamActions {
+  setAccessLoading = 'setAccessLoading',
+  setLoading = 'setLoading',
+  setSelectedImageStream = 'setSelectedImageStream',
+  setHasAccessToPullImage = 'setHasAccessToPullImage',
+  setHasCreateAccess = 'setHasCreateAccess',
 }
-
+export type ImageStreamAction = { type: ImageStreamActions; value: ImageStreamPayload };
+export interface ImageStreamContextProps {
+  state: ImageStreamState;
+  dispatch: React.Dispatch<ImageStreamAction>;
+  hasImageStreams: boolean;
+  setHasImageStreams: (value: boolean) => void;
+}
 export interface SourceToImageFormProps {
   builderImages?: NormalizedBuilderImages;
   projects?: {

--- a/frontend/packages/dev-console/src/utils/__tests__/imagestream-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/imagestream-utils.spec.ts
@@ -1,8 +1,8 @@
 import {
   getPorts,
   makePortName,
-  getImageStreamByNamespace,
   getImageStreamTags,
+  getImageStreamResource,
 } from '../imagestream-utils';
 import { ImageStreamTagData, sampleImageStreams } from './imagestream-test-data';
 
@@ -24,13 +24,25 @@ describe('Transform container port name', () => {
 });
 
 describe('Transform imagestream data', () => {
-  it('expect to return key: value pair for dropdown component ', () => {
-    const imgStreams = getImageStreamByNamespace(sampleImageStreams, 'project-1');
-    expect(imgStreams).toMatchObject({ 'os-test-image': 'os-test-image' });
+  it('expect to have imagestream tags', () => {
+    const imgStreamsTags = getImageStreamTags(sampleImageStreams[0]);
+    expect(imgStreamsTags).toMatchObject({ latest: 'latest' });
   });
 
-  it('expect to have imagestream tags', () => {
-    const imgStreamsTags = getImageStreamTags(sampleImageStreams, 'os-test-image', 'project-1');
-    expect(imgStreamsTags).toMatchObject({ latest: 'latest' });
+  it('expect to not have imagestream tags', () => {
+    const imgStreamsTags = getImageStreamTags({});
+    expect(imgStreamsTags).toMatchObject({});
+  });
+
+  it('expect to return the resource without namespace', () => {
+    const resources = getImageStreamResource('');
+    expect(resources).toHaveLength(0);
+    expect(resources).toMatchObject([]);
+  });
+
+  it('expect to return the resource with namespace', () => {
+    const resource = getImageStreamResource('test');
+    expect(resource).toHaveLength(1);
+    expect(resource[0].namespace).toBe('test');
   });
 });

--- a/frontend/packages/dev-console/src/utils/imagestream-utils.ts
+++ b/frontend/packages/dev-console/src/utils/imagestream-utils.ts
@@ -10,7 +10,7 @@ import {
   getImageStreamIcon,
   getImageForIconClass,
 } from '@console/internal/components/catalog/catalog-item-icon';
-import { ProjectModel } from '@console/internal/models';
+import { ProjectModel, ImageStreamModel } from '@console/internal/models';
 import { FirehoseResource } from '@console/internal/components/utils';
 
 export interface ImageTag {
@@ -174,33 +174,12 @@ export const getSortedTags = (imageStream: K8sResourceKind) => {
       })
     : [];
 };
-export const getImageStreamTags = (imageStreams: K8sResourceKind[], name: string, ns: string) => {
-  const imageStream = _.find(imageStreams, (img) => {
-    return img.metadata.name === name && img.metadata.namespace === ns;
-  });
-  const sortedTags =
-    name && imageStream && !_.isEmpty(imageStream) ? getSortedTags(imageStream) : [];
+export const getImageStreamTags = (imageStream: K8sResourceKind) => {
+  const sortedTags = imageStream && !_.isEmpty(imageStream) ? getSortedTags(imageStream) : [];
   return sortedTags.reduce((tags, { tag }) => {
     tags[tag] = tag;
     return tags;
   }, {});
-};
-
-export const getImageStreamByNamespace = (imageStreams: K8sResourceKind[], ns: string) => {
-  const imageStreamsList = {};
-  const isBuilderImageNamespace = ns === BuilderImagesNamespace.Openshift;
-  const imgStreams = isBuilderImageNamespace
-    ? (normalizeBuilderImages(imageStreams) as NormalizedBuilderImages)
-    : (imageStreams as K8sResourceKind[]);
-  _.each(imgStreams, (img: BuilderImage | K8sResourceKind) => {
-    const { name, namespace } = isBuilderImageNamespace
-      ? (img as BuilderImage).obj.metadata
-      : (img as K8sResourceKind).metadata;
-    if (namespace === ns) {
-      imageStreamsList[name] = name;
-    }
-  });
-  return imageStreamsList;
 };
 
 export const getProjectResource = (): FirehoseResource[] => {
@@ -211,4 +190,17 @@ export const getProjectResource = (): FirehoseResource[] => {
       prop: ProjectModel.id,
     },
   ];
+};
+
+export const getImageStreamResource = (namespace: string): FirehoseResource[] => {
+  const resource = [];
+  if (namespace) {
+    resource.push({
+      isList: true,
+      kind: ImageStreamModel.kind,
+      prop: ImageStreamModel.id,
+      namespace,
+    });
+  }
+  return resource;
 };


### PR DESCRIPTION

User with limited permissions (few namespaces) will be able to pull the images from namespaces accordingly.


user with limited permissions to namespaces:
![test · Details · OKD](https://user-images.githubusercontent.com/9964343/71461161-da76f300-27d4-11ea-9c66-75123bbe14a7.png)
`

![AwesomeScreenshot-2019-12-26-1577335013068](https://user-images.githubusercontent.com/9964343/71461109-a8659100-27d4-11ea-9184-ec44cedd16e1.gif)




Fixes: https://issues.redhat.com/browse/ODC-2536