### PR TITLE
Add VMI link to VM detauls page

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -19,6 +19,7 @@ import { getVmiIpAddressesString } from '../ip-addresses';
 import { VMStatuses } from '../vm-status';
 import { DiskSummary } from '../vm-disks/disk-summary';
 import { BootOrderSummary } from '../boot-order';
+import { VirtualMachineInstanceModel } from '../../models';
 import {
   getOperatingSystemName,
   getOperatingSystem,
@@ -108,6 +109,16 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
     <dl className="co-m-pane__details">
       <VMDetailsItem title="Status" idValue={prefixedID(id, 'vm-statuses')}>
         <VMStatuses vm={vm} vmi={vmi} pods={pods} migrations={migrations} />
+      </VMDetailsItem>
+
+      <VMDetailsItem title="VM Instance" idValue={prefixedID(id, 'vmi')} isNotAvail={!getName(vmi)}>
+        {getName(vmi) && (
+          <ResourceLink
+            kind={VirtualMachineInstanceModel.kind}
+            name={getName(vmi)}
+            namespace={getNamespace(vmi)}
+          />
+        )}
       </VMDetailsItem>
 
       <VMDetailsItem title="Pod" idValue={prefixedID(id, 'pod')} isNotAvail={!launcherPod}>

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -112,13 +112,11 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
       </VMDetailsItem>
 
       <VMDetailsItem title="VM Instance" idValue={prefixedID(id, 'vmi')} isNotAvail={!getName(vmi)}>
-        {getName(vmi) && (
-          <ResourceLink
-            kind={VirtualMachineInstanceModel.kind}
-            name={getName(vmi)}
-            namespace={getNamespace(vmi)}
-          />
-        )}
+        <ResourceLink
+          kind={VirtualMachineInstanceModel.kind}
+          name={getName(vmi)}
+          namespace={getNamespace(vmi)}
+        />
       </VMDetailsItem>
 
       <VMDetailsItem title="Pod" idValue={prefixedID(id, 'pod')} isNotAvail={!launcherPod}>


### PR DESCRIPTION
Add VMI link to VM detauls page

We decided to expose VMIs to users, this PR expose the the VMI in the VM details page. 

Refs:
https://issues.redhat.com/browse/KNIP-1165
https://github.com/openshift/openshift-origin-design/pull/310

![vm cirros · Details · OKD](https://user-images.githubusercontent.com/2181522/71616626-e7725880-2bbf-11ea-93bd-f5107556609b.png)
