### PR TITLE
List VMIs in the VM list view

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PodKind, K8sResourceKind } from '@console/internal/module/k8s';
-import { OffIcon, UnknownIcon } from '@patternfly/react-icons';
+import { OffIcon, UnknownIcon, SyncAltIcon } from '@patternfly/react-icons';
 import {
   PopoverStatus,
   StatusIconAndText,
@@ -9,7 +9,6 @@ import {
   ErrorStatus,
   ProgressStatus,
   PendingStatus,
-  SuccessStatus,
 } from '@console/shared';
 import { Progress, ProgressVariant, ProgressSize } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
@@ -250,7 +249,7 @@ export const VMStatus: React.FC<VMStatusProps> = ({
         </ProgressStatus>
       );
     case VM_STATUS_RUNNING:
-      return <SuccessStatus title="Running" />;
+      return <StatusIconAndText title="Running" icon={<SyncAltIcon />} />;
     case VM_STATUS_OFF:
       return <StatusIconAndText title="Off" icon={<OffIcon />} />;
     default:

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -152,7 +152,7 @@ const menuActionCdEdit = (kindObj: K8sKind, vm: VMKind, { vmStatus }: ActionArgs
   };
 };
 
-export const menuActions = [
+export const vmMenuActions = [
   menuActionStart,
   menuActionStop,
   menuActionRestart,
@@ -160,6 +160,12 @@ export const menuActions = [
   menuActionCancelMigration,
   menuActionClone,
   menuActionCdEdit,
+  Kebab.factory.ModifyLabels,
+  Kebab.factory.ModifyAnnotations,
+  Kebab.factory.Delete,
+];
+
+export const vmiMenuActions = [
   Kebab.factory.ModifyLabels,
   Kebab.factory.ModifyAnnotations,
   Kebab.factory.Delete,
@@ -175,7 +181,7 @@ export const menuActionsCreator = (
   const vmStatus = getVMStatus({ vm, vmi, pods, migrations });
   const migration = findVMIMigration(vmi, migrations);
 
-  return menuActions.map((action) => {
+  return vmMenuActions.map((action) => {
     return action(kindObj, vm, { vmi, vmStatus, migration });
   });
 };

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/vmlike.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/vmlike.ts
@@ -1,10 +1,10 @@
 import { K8sKind } from '@console/internal/module/k8s';
 import { TemplateModel } from '@console/internal/models';
-import { VMLikeEntityKind, VMKind } from '../../types';
+import { VMLikeEntityKind, VMKind, VMIKind } from '../../types';
 import { VirtualMachineModel } from '../../models';
 import { selectVM } from '../vm-template/selectors';
 
-export const isVM = (vmLikeEntity: VMLikeEntityKind): vmLikeEntity is VMKind =>
+export const isVM = (vmLikeEntity: VMLikeEntityKind | VMIKind): vmLikeEntity is VMKind =>
   vmLikeEntity && vmLikeEntity.kind === VirtualMachineModel.kind;
 
 export const getVMLikeModel = (vmLikeEntity: VMLikeEntityKind): K8sKind =>

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
@@ -24,3 +24,5 @@ export const isVMIRunning = (vmi: VMIKind) => vmi && vmi.status && vmi.status.ph
 
 export const getVMIInterfaces = (vmi: VMIKind) =>
   (vmi && vmi.status && vmi.status.interfaces) || [];
+
+export const getVMINodeName = (vmi: VMIKind) => vmi && vmi.status && vmi.status.nodeName;

--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/constants.ts
@@ -44,3 +44,38 @@ export const VM_SIMPLE_STATUS_TO_TEXT = {
 };
 
 export const CONVERSION_PROGRESS_ANNOTATION = 'v2vConversionProgress';
+
+export const getVMStatusSortString = (vmStatus) => {
+  switch (vmStatus.status) {
+    case VM_STATUS_V2V_CONVERSION_PENDING:
+      return 'Pending (Import VMware)';
+    case VM_STATUS_IMPORT_PENDING:
+      return 'Pending (Import)';
+    case VM_STATUS_V2V_CONVERSION_IN_PROGRESS:
+      return 'Importing (VMware)';
+    case VM_STATUS_V2V_CONVERSION_ERROR:
+      return 'Error (Import VMware)';
+    case VM_STATUS_POD_ERROR:
+      return 'Error (Pod)';
+    case VM_STATUS_ERROR:
+      return 'Error (VM)';
+    case VM_STATUS_IMPORT_ERROR:
+      return 'Error (Import)';
+    case VM_STATUS_IMPORTING:
+      return 'Importing';
+    case VM_STATUS_VMI_WAITING:
+      return 'Pending';
+    case VM_STATUS_STARTING:
+      return 'Starting';
+    case VM_STATUS_MIGRATING:
+      return 'Migrating';
+    case VM_STATUS_STOPPING:
+      return 'Stopping';
+    case VM_STATUS_RUNNING:
+      return 'Running';
+    case VM_STATUS_OFF:
+      return 'Off';
+    default:
+      return 'Unknown';
+  }
+};


### PR DESCRIPTION
List VMIs in the VM list view

We decided to expose VMIs to users, this PR expose the the VMI in the VM list page.

1. list VMIs in the "Virtual machines" list.
2. Add created, node and IP columns.
3. Update the "running" icon to align with console "running" icon.
4. Sort by status.

Refs:
https://issues.redhat.com/browse/KNIP-1165
openshift/openshift-origin-design#310

![Virtual Machines · OKD(2)](https://user-images.githubusercontent.com/2181522/71618102-e0027d80-2bc6-11ea-8565-9f8392ec9d99.png)
