### PR TITLE
Bug 1786591: Shows the values in expand modal dropdown

### DIFF
--- a/frontend/public/components/utils/storage-class-dropdown.tsx
+++ b/frontend/public/components/utils/storage-class-dropdown.tsx
@@ -23,7 +23,7 @@ type StorageClassDropdownItems = {
 
 const getUnorderedItems = (
   items: StorageClass[],
-  filter: StorageClassFilter = (resource) => _.isEmpty(resource),
+  filter: StorageClassFilter = (resource) => !_.isEmpty(resource),
 ): StorageClassDropdownItems =>
   items.reduce(
     (acc, resource) => ({


### PR DESCRIPTION
The bug is only seen in 4.2, this change is not required in 4.3 or 4.4, that's why created the PR directly.
Before:
![Screenshot from 2019-12-31 19-15-23](https://user-images.githubusercontent.com/12200504/71623381-2de8a700-2c02-11ea-9965-bf0a14100769.png)


After:
![Screenshot from 2019-12-31 19-15-09](https://user-images.githubusercontent.com/12200504/71623386-33de8800-2c02-11ea-9a85-8f2695ea287e.png)

Thanks @bipuladh.
Signed-off-by: Kanika <kmurarka@redhat.com>

/assign @bipuladh @afreen23 @gnehapk  @cloudbehl 