### PR TITLE
add test to KnativeResourceOverviewPage

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyResourcePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyResourcePanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ResourceOverviewPage } from '@console/internal/components/overview/resource-overview-page';
 import * as _ from 'lodash';
-import { KnativeOverviewPage } from '@console/knative-plugin/src/components/overview/KnativeResourceOverviewPage';
+import { KnativeResourceOverviewPage } from '@console/knative-plugin/src/components/overview/KnativeResourceOverviewPage';
 import { TopologyDataObject } from './topology-types';
 
 export type TopologyResourcePanelProps = {
@@ -13,7 +13,7 @@ const TopologyResourcePanel: React.FC<TopologyResourcePanelProps> = ({ item }) =
   // adds extra check, custom sidebar for all knative resources excluding deployment
   const itemKind = _.get(item, 'data.kind', null);
   if (_.get(item, 'data.isKnativeResource', false) && itemKind && itemKind !== 'Deployment') {
-    return <KnativeOverviewPage item={item.resources} />;
+    return <KnativeResourceOverviewPage item={item.resources} />;
   }
   return (
     resourceItemToShowOnSideBar && (

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeOverview.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeOverview.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { ResourceSummary } from '@console/internal/components/utils';
+import { OverviewItem, PodRing } from '@console/shared';
+import { RevisionModel } from '../../models';
+
+export type KnativeOverviewProps = {
+  item?: OverviewItem;
+};
+
+export const KnativeOverview: React.FC<KnativeOverviewProps> = ({ item }) => {
+  const { obj, current } = item;
+  return (
+    <div className="overview__sidebar-pane-body resource-overview__body">
+      {obj.kind === RevisionModel.kind && (
+        <div className="resource-overview__pod-counts">
+          <PodRing
+            pods={current ? current.pods : []}
+            obj={obj}
+            rc={current && current.obj}
+            resourceKind={RevisionModel}
+            path="/spec/replicas"
+          />
+        </div>
+      )}
+      <div className="resource-overview__summary">
+        <ResourceSummary resource={obj} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -1,38 +1,16 @@
 import * as React from 'react';
-import { ResourceSummary, Kebab, LoadingBox } from '@console/internal/components/utils';
+import { Kebab, LoadingBox } from '@console/internal/components/utils';
 import { ResourceOverviewDetails } from '@console/internal/components/overview/resource-overview-details';
-import { OverviewItem, PodRing } from '@console/shared';
+import { OverviewItem } from '@console/shared';
 import { groupVersionFor, K8sKind } from '@console/internal/module/k8s';
 import { getKsResourceModel } from '../../utils/get-knative-resources';
-import { RevisionModel } from '../../models';
+import { KnativeOverview } from './KnativeOverview';
 import OverviewDetailsKnativeResourcesTab from './OverviewDetailsKnativeResourcesTab';
 
 export type KnativeResourceOverviewPageProps = {
   item?: OverviewItem;
   knativeModels?: K8sKind[];
   kindsInFlight?: boolean;
-};
-
-const KnativeOverview: React.FC<KnativeResourceOverviewPageProps> = ({ item }) => {
-  const { obj, current } = item;
-  return (
-    <div className="overview__sidebar-pane-body resource-overview__body">
-      {obj.kind === RevisionModel.kind && (
-        <div className="resource-overview__pod-counts">
-          <PodRing
-            pods={current ? current.pods : []}
-            obj={obj}
-            rc={current && current.obj}
-            resourceKind={RevisionModel}
-            path="/spec/replicas"
-          />
-        </div>
-      )}
-      <div className="resource-overview__summary">
-        <ResourceSummary resource={item.obj} />
-      </div>
-    </div>
-  );
 };
 const tabs = [
   {
@@ -45,27 +23,29 @@ const tabs = [
   },
 ];
 
-export const KnativeOverviewPage: React.ComponentType<
-  KnativeResourceOverviewPageProps
-> = getKsResourceModel(
-  ({ item, knativeModels, kindsInFlight }: KnativeResourceOverviewPageProps) => {
-    if (kindsInFlight) {
-      return !knativeModels ? null : <LoadingBox />;
-    }
-    const apiInfo = groupVersionFor(item.obj.apiVersion);
-    const resourceModel = knativeModels.find(
-      (model) =>
-        model.kind === item.obj.kind &&
-        model.apiGroup === apiInfo.group &&
-        model.apiVersion === apiInfo.version,
-    );
-    return (
-      <ResourceOverviewDetails
-        item={item}
-        kindObj={resourceModel}
-        menuActions={[...Kebab.getExtensionsActionsForKind(resourceModel), ...Kebab.factory.common]}
-        tabs={tabs}
-      />
-    );
-  },
-);
+export const KnativeResourceOverviewPage: React.ComponentType<KnativeResourceOverviewPageProps> = ({
+  item,
+  knativeModels,
+  kindsInFlight,
+}: KnativeResourceOverviewPageProps) => {
+  if (kindsInFlight) {
+    return !knativeModels ? null : <LoadingBox />;
+  }
+  const apiInfo = groupVersionFor(item.obj.apiVersion);
+  const resourceModel = knativeModels.find(
+    (model) =>
+      model.kind === item.obj.kind &&
+      model.apiGroup === apiInfo.group &&
+      model.apiVersion === apiInfo.version,
+  );
+  return (
+    <ResourceOverviewDetails
+      item={item}
+      kindObj={resourceModel}
+      menuActions={[...Kebab.getExtensionsActionsForKind(resourceModel), ...Kebab.factory.common]}
+      tabs={tabs}
+    />
+  );
+};
+
+export default getKsResourceModel(KnativeResourceOverviewPage);

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeOverview.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeOverview.spec.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import * as _ from 'lodash';
+import { PodRing, OverviewItem } from '@console/shared';
+import { ResourceSummary } from '@console/internal/components/utils';
+import { revisionObj } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import { RevisionModel } from '../../../models';
+import { KnativeOverview } from '../KnativeOverview';
+
+describe('KnativeOverview', () => {
+  let item: OverviewItem;
+  beforeEach(() => {
+    item = {
+      buildConfigs: [],
+      obj: revisionObj,
+      routes: [],
+      services: [],
+    };
+  });
+
+  it('should render PodRing with proper resourceKind if obj.kind is RevisionModel.kind', () => {
+    const wrapper = shallow(<KnativeOverview item={item} />);
+    expect(wrapper.find(PodRing)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(PodRing)
+        .at(0)
+        .props().resourceKind,
+    ).toEqual(RevisionModel);
+  });
+  it('should render ResourceSummary', () => {
+    const wrapper = shallow(<KnativeOverview item={item} />);
+    expect(wrapper.find(ResourceSummary)).toHaveLength(1);
+  });
+  it('should not render PodRing if obj.kind is not RevisionModel.kind', () => {
+    const mockItemKindRoute = _.set(_.cloneDeep(item), 'obj.kind', 'Route');
+    const wrapper = shallow(<KnativeOverview item={mockItemKindRoute} />);
+    expect(wrapper.find(PodRing)).toHaveLength(0);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeResourceOverviewPage.spec.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { OverviewItem } from '@console/shared';
+import { LoadingBox } from '@console/internal/components/utils';
+import { ResourceOverviewDetails } from '@console/internal/components/overview/resource-overview-details';
+import { revisionObj } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import { RevisionModel } from '@console/knative-plugin/src/models';
+import { KnativeResourceOverviewPage } from '../KnativeResourceOverviewPage';
+
+describe('KnativeResourceOverviewPage', () => {
+  let item: OverviewItem;
+  beforeEach(() => {
+    item = {
+      buildConfigs: [],
+      obj: revisionObj,
+      routes: [],
+      services: [],
+    };
+  });
+
+  it('should not render if kindsInFlight is true and knativeModels is empty', () => {
+    const wrapper = shallow(<KnativeResourceOverviewPage item={item} kindsInFlight />);
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+  it('should render LoadingBox kindsInFlight is true and knativeModels is not empty', () => {
+    const wrapper = shallow(
+      <KnativeResourceOverviewPage item={item} knativeModels={[RevisionModel]} kindsInFlight />,
+    );
+    expect(wrapper.find(LoadingBox)).toHaveLength(1);
+  });
+  it('should render ResourceOverviewDetails kindsInFlight is false', () => {
+    const wrapper = shallow(
+      <KnativeResourceOverviewPage
+        item={item}
+        knativeModels={[RevisionModel]}
+        kindsInFlight={false}
+      />,
+    );
+    expect(wrapper.find(ResourceOverviewDetails)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
This PR
- refactors KnativeResourceOverviewPage, splitting it and creating KnativeOverview component
- adds test to KnativeOverview component
- adds test to KnativeOverviewPage component
- is tracked by https://issues.redhat.com/browse/ODC-2637