### PR TITLE
Adapt CNV to Native k8s

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/native/consts.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/native/consts.ts
@@ -1,0 +1,16 @@
+export const operatingSystemsNative = [
+  { id: 'centos8', name: 'CentOS 8.0' },
+  { id: 'centos7', name: 'CentOS 7.0' },
+  { id: 'centos6', name: 'CentOS 6.0' },
+  { id: 'fedora31', name: 'Fedora 31' },
+  { id: 'fedora30', name: 'Fedora 30' },
+  { id: 'fedora29', name: 'Fedora 29' },
+  { id: 'win10', name: 'Microsoft Windows 10' },
+  { id: 'opensuse15.0', name: 'openSUSE 15' },
+  { id: 'rhel8', name: 'Red Hat Linux 8' },
+  { id: 'rhel7', name: 'Red Hat Linux 7' },
+  { id: 'rhel6', name: 'Red Hat Linux 6' },
+  { id: 'ubuntu18.04', name: 'Ubuntu 18.04' },
+  { id: 'ubuntu17.10', name: 'Ubuntu 17.10' },
+  { id: 'ubuntu17.04', name: 'Ubuntu 17.04' },
+];

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/vm-settings-tab-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/vm-settings-tab-state-update.ts
@@ -1,3 +1,4 @@
+import { FLAGS } from '@console/internal/const';
 import { isWinToolsImage, getVolumeContainerImage } from '../../../../../selectors/vm';
 import {
   hasVmSettingsChanged,
@@ -126,6 +127,23 @@ export const osUpdater = ({ id, prevState, dispatch, getState }: UpdateOptions) 
   }
 };
 
+export const nativeK8sUpdater = ({ id, dispatch, getState, changedCommonData }: UpdateOptions) => {
+  const state = getState();
+  if (!changedCommonData.has(VMWizardProps.openshiftFlag)) {
+    return;
+  }
+  const openshiftFlag = iGetCommonData(state, id, VMWizardProps.openshiftFlag);
+
+  dispatch(
+    vmWizardInternalActions[InternalActionType.UpdateVmSettings](id, {
+      [VMSettingsField.WORKLOAD_PROFILE]: {
+        isHidden: asHidden(!openshiftFlag, FLAGS.OPENSHIFT),
+        isRequired: asRequired(openshiftFlag),
+      },
+    }),
+  );
+};
+
 export const updateVmSettingsState = (options: UpdateOptions) =>
   [
     ...(iGetCommonData(options.getState(), options.id, VMWizardProps.isProviderImport)
@@ -135,6 +153,7 @@ export const updateVmSettingsState = (options: UpdateOptions) =>
     provisioningSourceUpdater,
     flavorUpdater,
     osUpdater,
+    nativeK8sUpdater,
   ].forEach((updater) => {
     updater && updater(options);
   });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/strings.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/strings/strings.ts
@@ -7,6 +7,7 @@ export const REVIEW_AND_CREATE = 'Review and create';
 export const NO_TEMPLATE = 'None';
 export const SELECT_TEMPLATE = '--- Select Template ---';
 export const NO_TEMPLATE_AVAILABLE = 'No template available';
+export const NO_OPENSHIFT_TEMPLATES = 'Non-Openshift Cluster detected - Templates are Unavailable';
 export const WIZARD_CLOSE_PROMPT =
   "Are you sure you want to navigate away from this form? Any data you've added will be lost.";
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
@@ -20,6 +20,7 @@ import { VMSettingsField } from '../../types';
 import { iGetFieldValue } from '../../selectors/immutable/vm-settings';
 import { getPlaceholder } from '../../utils/vm-settings-tab-utils';
 import { nullOnEmptyChange } from '../../utils/utils';
+import { operatingSystemsNative } from '../../native/consts';
 
 export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
   ({
@@ -30,6 +31,7 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
     flavorField,
     workloadProfile,
     onChange,
+    openshiftFlag,
   }) => {
     const flavor = iGetFieldValue(flavorField);
     const os = iGetFieldValue(operatinSystemField);
@@ -44,13 +46,20 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
       concatImmutableLists(iGetLoadedData(commonTemplates), iGetLoadedData(userTemplates)),
     );
 
-    const operatingSystems = ignoreCaseSort(getOperatingSystems(vanillaTemplates, params), [
-      'name',
-    ]);
+    const operatingSystems = openshiftFlag
+      ? ignoreCaseSort(getOperatingSystems(vanillaTemplates, params), ['name'])
+      : operatingSystemsNative;
 
     const flavors = flavorSort(getFlavors(vanillaTemplates, params));
 
     const workloadProfiles = getWorkloadProfiles(vanillaTemplates, params);
+
+    const loadingResources = openshiftFlag
+      ? {
+          userTemplates,
+          commonTemplates,
+        }
+      : {};
 
     let operatingSystemValidation;
     let flavorValidation;
@@ -77,10 +86,7 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
           field={operatinSystemField}
           fieldType={FormFieldType.SELECT}
           validation={operatingSystemValidation}
-          loadingResources={{
-            userTemplates,
-            commonTemplates,
-          }}
+          loadingResources={loadingResources}
         >
           <FormField>
             <FormSelect onChange={nullOnEmptyChange(onChange, VMSettingsField.OPERATING_SYSTEM)}>
@@ -98,10 +104,7 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
           field={flavorField}
           fieldType={FormFieldType.SELECT}
           validation={flavorValidation}
-          loadingResources={{
-            userTemplates,
-            commonTemplates,
-          }}
+          loadingResources={loadingResources}
         >
           <FormField isDisabled={flavor && flavors.length === 1}>
             <FormSelect onChange={nullOnEmptyChange(onChange, VMSettingsField.FLAVOR)}>
@@ -127,5 +130,6 @@ type OSFlavorProps = {
   operatinSystemField: any;
   userTemplate: string;
   workloadProfile: string;
+  openshiftFlag: boolean;
   onChange: (key: string, value: string) => void;
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/user-templates.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/user-templates.tsx
@@ -5,13 +5,18 @@ import { FormFieldRow } from '../../form/form-field-row';
 import { FormField, FormFieldType } from '../../form/form-field';
 import { ignoreCaseSort } from '../../../../utils/sort';
 import { VMSettingsField } from '../../types';
-import { NO_TEMPLATE, NO_TEMPLATE_AVAILABLE, SELECT_TEMPLATE } from '../../strings/strings';
+import {
+  NO_TEMPLATE,
+  NO_TEMPLATE_AVAILABLE,
+  SELECT_TEMPLATE,
+  NO_OPENSHIFT_TEMPLATES,
+} from '../../strings/strings';
 import { nullOnEmptyChange } from '../../utils/utils';
 import { iGetName } from '../../selectors/immutable/selectors';
 import { iGetFieldValue } from '../../selectors/immutable/vm-settings';
 
 export const UserTemplates: React.FC<UserTemplatesProps> = React.memo(
-  ({ userTemplateField, userTemplates, commonTemplates, onChange }) => {
+  ({ userTemplateField, userTemplates, commonTemplates, onChange, openshiftFlag }) => {
     const data = iGetLoadedData(userTemplates);
     const names: string[] =
       data &&
@@ -27,10 +32,14 @@ export const UserTemplates: React.FC<UserTemplatesProps> = React.memo(
       <FormFieldRow
         field={userTemplateField}
         fieldType={FormFieldType.SELECT}
-        loadingResources={{
-          userTemplates,
-          commonTemplates,
-        }}
+        loadingResources={
+          openshiftFlag
+            ? {
+                userTemplates,
+                commonTemplates,
+              }
+            : {}
+        }
       >
         <FormField isDisabled={!hasUserTemplates}>
           <FormSelect onChange={nullOnEmptyChange(onChange, VMSettingsField.USER_TEMPLATE)}>
@@ -49,7 +58,7 @@ export const UserTemplates: React.FC<UserTemplatesProps> = React.memo(
               <FormSelectOption
                 key={NO_TEMPLATE_AVAILABLE}
                 value=""
-                label={NO_TEMPLATE_AVAILABLE}
+                label={openshiftFlag ? NO_TEMPLATE_AVAILABLE : NO_OPENSHIFT_TEMPLATES}
               />
             )}
             {sortedNames.map((name) => (
@@ -63,12 +72,14 @@ export const UserTemplates: React.FC<UserTemplatesProps> = React.memo(
   (prevProps, nextProps) =>
     iGetIsLoaded(prevProps.commonTemplates) === iGetIsLoaded(nextProps.commonTemplates) && // wait for commonTemplates; required when pre-filling template
     prevProps.userTemplateField === nextProps.userTemplateField &&
-    prevProps.userTemplates === nextProps.userTemplates,
+    prevProps.userTemplates === nextProps.userTemplates &&
+    prevProps.openshiftFlag === nextProps.openshiftFlag,
 );
 
 type UserTemplatesProps = {
   userTemplateField: any;
   userTemplates: any;
   commonTemplates: any;
+  openshiftFlag: boolean;
   onChange: (key: string, value: string) => void;
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -54,6 +54,7 @@ export class VMSettingsTabComponent extends React.Component<VMSettingsTabCompone
       updateStorage,
       isReview,
       wizardReduxID,
+      openshiftFlag,
     } = this.props;
 
     return (
@@ -89,6 +90,7 @@ export class VMSettingsTabComponent extends React.Component<VMSettingsTabCompone
             userTemplateField={this.getField(VMSettingsField.USER_TEMPLATE)}
             userTemplates={userTemplates}
             commonTemplates={commonTemplates}
+            openshiftFlag={openshiftFlag}
             onChange={this.props.onFieldChange}
           />
         )}
@@ -129,6 +131,7 @@ export class VMSettingsTabComponent extends React.Component<VMSettingsTabCompone
           userTemplate={this.getFieldValue(VMSettingsField.USER_TEMPLATE)}
           workloadProfile={this.getFieldValue(VMSettingsField.WORKLOAD_PROFILE)}
           onChange={this.props.onFieldChange}
+          openshiftFlag={openshiftFlag}
         />
         <MemoryCPU
           memoryField={this.getField(VMSettingsField.MEMORY)}
@@ -145,6 +148,7 @@ export class VMSettingsTabComponent extends React.Component<VMSettingsTabCompone
           flavor={this.getFieldValue(VMSettingsField.FLAVOR)}
           onChange={this.props.onFieldChange}
         />
+
         <FormFieldMemoRow
           field={this.getField(VMSettingsField.NAME)}
           fieldType={FormFieldType.TEXT}
@@ -185,6 +189,7 @@ const stateToProps = (state, { wizardReduxID }) => ({
   vmSettings: iGetVmSettings(state, wizardReduxID),
   commonTemplates: iGetCommonData(state, wizardReduxID, VMWizardProps.commonTemplates),
   userTemplates: iGetCommonData(state, wizardReduxID, VMWizardProps.userTemplates),
+  openshiftFlag: iGetCommonData(state, wizardReduxID, VMWizardProps.openshiftFlag),
   provisionSourceStorage: iGetProvisionSourceStorage(state, wizardReduxID),
 });
 
@@ -196,6 +201,7 @@ type VMSettingsTabComponentProps = {
   commonTemplates: any;
   userTemplates: any;
   isReview: boolean;
+  openshiftFlag: boolean;
   wizardReduxID: string;
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -29,6 +29,7 @@ export enum VMWizardProps {
   isCreateTemplate = 'isCreateTemplate',
   isProviderImport = 'isProviderImport',
   activeNamespace = 'activeNamespace',
+  openshiftFlag = 'openshiftFlag',
   reduxID = 'reduxID',
   virtualMachines = 'virtualMachines',
   userTemplates = 'userTemplates',
@@ -118,6 +119,7 @@ export type ChangedCommonDataProp =
   | VMWizardProps.userTemplates
   | VMWizardProps.commonTemplates
   | VMWizardProps.dataVolumes
+  | VMWizardProps.openshiftFlag
   | VMWareProviderProps.deployment
   | VMWareProviderProps.deploymentPods
   | VMWareProviderProps.v2vvmware
@@ -134,6 +136,7 @@ export type ChangedCommonData = Set<ChangedCommonDataProp>;
 
 export const DetectCommonDataChanges = new Set<ChangedCommonDataProp>([
   VMWizardProps.activeNamespace,
+  VMWizardProps.openshiftFlag,
   VMWizardProps.virtualMachines,
   VMWizardProps.userTemplates,
   VMWizardProps.commonTemplates,
@@ -159,6 +162,7 @@ export type CreateVMWizardComponentProps = {
   isCreateTemplate: boolean;
   dataIDReferences: IDReferences;
   activeNamespace: string;
+  openshiftFlag: boolean;
   reduxID: string;
   stepData: any;
   userTemplates: FirehoseResult<TemplateKind[]>;

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -6,6 +6,7 @@ export const ANNOTATION_DESCRIPTION = 'description';
 export const ANNOTATION_PXE_INTERFACE = 'kubevirt.ui/pxeInterface';
 export const CUSTOM_FLAVOR = 'Custom';
 
+export const APP = 'app';
 export const BOOT_ORDER_FIRST = 1;
 export const BOOT_ORDER_SECOND = 2;
 
@@ -19,6 +20,7 @@ export const TEMPLATE_TYPE_BASE = 'base';
 export const TEMPLATE_WORKLOAD_LABEL = 'workload.template.kubevirt.io';
 export const TEMPLATE_VM_NAME_LABEL = 'vm.kubevirt.io/name';
 export const TEMPLATE_OS_NAME_ANNOTATION = 'name.os.template.kubevirt.io';
+export const TEMPLATE_VM_DOMAIN_LABEL = 'kubevirt.io/domain';
 
 export const LABEL_USED_TEMPLATE_NAME = 'vm.kubevirt.io/template';
 export const LABEL_USED_TEMPLATE_NAMESPACE = 'vm.kubevirt.io/template-namespace';

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/config-map/storage-class/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/config-map/storage-class/constants.ts
@@ -1,3 +1,7 @@
 export const STORAGE_CLASS_CONFIG_MAP_NAME = 'kubevirt-storage-class-defaults';
 // Different releases, different locations. Respect the order when resolving. Otherwise the configMap name/namespace is considered as well-known.
-export const STORAGE_CLASS_CONFIG_MAP_NAMESPACES = ['openshift-cnv', 'openshift'];
+export const STORAGE_CLASS_CONFIG_MAP_NAMESPACES = [
+  'openshift-cnv',
+  'openshift',
+  'kubevirt-native',
+];

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/common.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/common.ts
@@ -1,7 +1,10 @@
 import { TemplateKind } from '@console/internal/module/k8s';
 import { getName, getNamespace } from '@console/shared/src';
 import { VMSettingsField } from '../../../../components/create-vm-wizard/types';
-import { asSimpleSettings } from '../../../../components/create-vm-wizard/selectors/vm-settings';
+import {
+  asSimpleSettings,
+  getFieldValue,
+} from '../../../../components/create-vm-wizard/selectors/vm-settings';
 import {
   ANNOTATION_DESCRIPTION,
   LABEL_USED_TEMPLATE_NAME,
@@ -10,19 +13,25 @@ import {
   TEMPLATE_OS_LABEL,
   TEMPLATE_OS_NAME_ANNOTATION,
   TEMPLATE_WORKLOAD_LABEL,
+  TEMPLATE_VM_DOMAIN_LABEL,
+  TEMPLATE_VM_NAME_LABEL,
+  APP,
 } from '../../../../constants/vm';
 import { MutableVMWrapper } from '../../../wrapper/vm/vm-wrapper';
 import { getTemplateOperatingSystems } from '../../../../selectors/vm-template/advanced';
 import { MutableVMTemplateWrapper } from '../../../wrapper/vm/vm-template-wrapper';
+import { operatingSystemsNative } from '../../../../components/create-vm-wizard/native/consts';
 import { CreateVMEnhancedParams } from './types';
 
 export const initializeCommonMetadata = (
-  { vmSettings, templates }: CreateVMEnhancedParams,
+  { vmSettings, templates, openshiftFlag }: CreateVMEnhancedParams,
   entity: MutableVMWrapper | MutableVMTemplateWrapper,
-  template: TemplateKind,
+  template?: TemplateKind,
 ) => {
   const settings = asSimpleSettings(vmSettings);
-  const operatingSystems = getTemplateOperatingSystems(templates);
+  const operatingSystems = openshiftFlag
+    ? getTemplateOperatingSystems(templates)
+    : operatingSystemsNative;
   const osID = settings[VMSettingsField.OPERATING_SYSTEM];
   const osName = (operatingSystems.find(({ id }) => id === osID) || {}).name;
 
@@ -34,13 +43,35 @@ export const initializeCommonMetadata = (
 
   entity.addLabel(`${TEMPLATE_OS_LABEL}/${osID}`, 'true');
   entity.addLabel(`${TEMPLATE_FLAVOR_LABEL}/${settings[VMSettingsField.FLAVOR]}`, 'true');
-  entity.addLabel(
-    `${TEMPLATE_WORKLOAD_LABEL}/${settings[VMSettingsField.WORKLOAD_PROFILE]}`,
-    'true',
-  );
 
-  entity.addLabel(LABEL_USED_TEMPLATE_NAME, getName(template));
-  entity.addLabel(LABEL_USED_TEMPLATE_NAMESPACE, getNamespace(template));
+  if (settings[VMSettingsField.WORKLOAD_PROFILE]) {
+    entity.addLabel(
+      `${TEMPLATE_WORKLOAD_LABEL}/${settings[VMSettingsField.WORKLOAD_PROFILE]}`,
+      'true',
+    );
+  }
+
+  if (template) {
+    entity.addLabel(LABEL_USED_TEMPLATE_NAME, getName(template));
+    entity.addLabel(LABEL_USED_TEMPLATE_NAMESPACE, getNamespace(template));
+  }
 
   return entity;
+};
+
+export const initializeCommonVMMetadata = (
+  { vmSettings }: CreateVMEnhancedParams,
+  entity: MutableVMWrapper,
+) => {
+  const name = getFieldValue(vmSettings, VMSettingsField.NAME);
+
+  entity.addTemplateLabel(TEMPLATE_VM_NAME_LABEL, name); // for pairing service-vm (like for RDP)
+
+  if (!entity.hasTemplateLabel(TEMPLATE_VM_DOMAIN_LABEL)) {
+    entity.addTemplateLabel(TEMPLATE_VM_DOMAIN_LABEL, name);
+  }
+
+  if (!entity.hasLabel(APP)) {
+    entity.addLabel(APP, name);
+  }
 };

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/types.ts
@@ -10,6 +10,7 @@ export type CreateVMParams = {
   storages: VMWizardStorage[];
   templates: TemplateKind[];
   namespace: string;
+  openshiftFlag: boolean;
 };
 
 export type CreateVMEnhancedParams = CreateVMParams & {

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-template-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-template-wrapper.ts
@@ -1,4 +1,5 @@
 /* eslint-disable lines-between-class-members */
+import * as _ from 'lodash';
 import { getName } from '@console/shared/src';
 import { apiVersionForModel, K8sKind, TemplateKind } from '@console/internal/module/k8s';
 import { TemplateModel } from '@console/internal/models';
@@ -48,6 +49,7 @@ export class VMTemplateWrapper extends Wrapper<TemplateKind> {
 
   getName = () => getName(this.data);
   getLabels = (defaultValue = {}) => getLabels(this.data, defaultValue);
+  hasLabel = (label: string) => _.has(this.getLabels(null), label);
 
   getParameters = (defaultValue = []) => (this.data && this.data.parameters) || defaultValue;
 

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -17,6 +17,7 @@ import {
   DashboardsOverviewResourceActivity,
 } from '@console/plugin-sdk';
 import { DashboardsStorageCapacityDropdownItem } from '@console/ceph-storage-plugin';
+import { FLAGS } from '@console/internal/const';
 import { TemplateModel, PodModel } from '@console/internal/models';
 import { getName } from '@console/shared/src/selectors/common';
 import * as models from './models';
@@ -63,6 +64,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'NavItem/ResourceNS',
+    properties: {
+      section: 'Workloads',
+      componentProps: {
+        name: 'Virtual Machines',
+        resource: models.VirtualMachineModel.plural,
+        required: FLAG_KUBEVIRT,
+      },
+      mergeBefore: 'Deployments',
+    },
+  },
+  {
     // NOTE(yaacov): vmtemplates is a template resource with a selector.
     // 'NavItem/ResourceNS' is used, and not 'NavItem/Href', because it injects
     // the namespace needed to get the correct link to a resource ( template with selector ) in our case.
@@ -72,21 +85,9 @@ const plugin: Plugin<ConsumedExtensions> = [
       componentProps: {
         name: 'Virtual Machine Templates',
         resource: 'vmtemplates',
-        required: FLAG_KUBEVIRT,
+        required: [FLAG_KUBEVIRT, FLAGS.OPENSHIFT],
       },
       mergeBefore: 'Deployments',
-    },
-  },
-  {
-    type: 'NavItem/ResourceNS',
-    properties: {
-      section: 'Workloads',
-      componentProps: {
-        name: 'Virtual Machines',
-        resource: models.VirtualMachineModel.plural,
-        required: FLAG_KUBEVIRT,
-      },
-      mergeBefore: 'Virtual Machine Templates',
     },
   },
   {


### PR DESCRIPTION
_Changes (considering native cluster)_

- Wrote a [Gist](https://gist.github.com/glekner/27baa2248644ec6c2d4660317835aaa2) to help with quick setup 
- based upon #3751 @suomiy request logic changes
- removed Virtual Machine Templates menu item
- VM Wizard is now functional with native clusters 🎉
- Disabled User template select field with the following text:
 `Non-Openshift cluster detected - Templates are Unavailable` 
- Removed Workload select field
- Flavor fixed to Custom