### PR TITLE
Add support for listing and installation of Helm Charts from Dev Catalog

### DIFF
--- a/frontend/__tests__/components/catalog.spec.tsx
+++ b/frontend/__tests__/components/catalog.spec.tsx
@@ -46,12 +46,14 @@ describe(CatalogTileViewPage.displayName, () => {
     expect(filterItems.length).toEqual(5); // Filter by Types
     expect(filterItems.at(0).props().count).toBe(0); // total count for Operator Backed
     expect(filterItems.at(0).props().checked).toBe(true); //Check operator backed filter is true by default
-    expect(filterItems.at(1).props().count).toBe(9); // total count for templates
-    expect(filterItems.at(1).props().checked).toBe(false); // filter templates should be false by default
-    expect(filterItems.at(2).props().count).toBe(2); // total count for imagestreams
-    expect(filterItems.at(2).props().checked).toBe(false); // filter imagestreams should be false by default
-    expect(filterItems.at(3).props().count).toBe(11); // total count for clusterServiceClasses
-    expect(filterItems.at(3).props().checked).toBe(false); // filter clusterServiceClasses should be false by default
+    expect(filterItems.at(1).props().count).toBe(0); // total count for Helm Charts
+    expect(filterItems.at(1).props().checked).toBe(false); //Check Helm Charts filter is true by default
+    expect(filterItems.at(2).props().count).toBe(9); // total count for templates
+    expect(filterItems.at(2).props().checked).toBe(false); // filter templates should be false by default
+    expect(filterItems.at(3).props().count).toBe(2); // total count for imagestreams
+    expect(filterItems.at(3).props().checked).toBe(false); // filter imagestreams should be false by default
+    expect(filterItems.at(4).props().count).toBe(11); // total count for clusterServiceClasses
+    expect(filterItems.at(4).props().checked).toBe(false); // filter clusterServiceClasses should be false by default
   });
 
   it('renders tiles correctly', () => {

--- a/frontend/__tests__/components/catalog.spec.tsx
+++ b/frontend/__tests__/components/catalog.spec.tsx
@@ -43,7 +43,7 @@ describe(CatalogTileViewPage.displayName, () => {
   it('renders category filter controls', () => {
     const filterItems = wrapper.find<any>(FilterSidePanelCategoryItem);
     expect(filterItems.exists()).toBe(true);
-    expect(filterItems.length).toEqual(4); // Filter by Types
+    expect(filterItems.length).toEqual(5); // Filter by Types
     expect(filterItems.at(0).props().count).toBe(0); // total count for Operator Backed
     expect(filterItems.at(0).props().checked).toBe(true); //Check operator backed filter is true by default
     expect(filterItems.at(1).props().count).toBe(9); // total count for templates

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { Form, ActionGroup, ButtonVariant, Button, TextInputTypes } from '@patternfly/react-core';
+import { Form, TextInputTypes } from '@patternfly/react-core';
 import { FormikProps, FormikValues } from 'formik';
-import { ButtonBar } from '@console/internal/components/utils';
-import { InputField } from '@console/shared';
+import { InputField, FormFooter } from '@console/shared';
 import FormSection from '../import/section/FormSection';
 
 const HelmInstallForm: React.FC<FormikProps<FormikValues>> = ({
@@ -24,21 +23,14 @@ const HelmInstallForm: React.FC<FormikProps<FormikValues>> = ({
         required
       />
     </FormSection>
-    <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
-      <ActionGroup className="pf-c-form">
-        <Button
-          type="submit"
-          variant={ButtonVariant.primary}
-          isDisabled={!dirty || !_.isEmpty(errors)}
-          data-test-id="helm-install-create-button"
-        >
-          Create
-        </Button>
-        <Button type="button" variant={ButtonVariant.secondary} onClick={handleReset}>
-          Cancel
-        </Button>
-      </ActionGroup>
-    </ButtonBar>
+    <FormFooter
+      handleReset={handleReset}
+      errorMessage={status && status.submitError}
+      isSubmitting={isSubmitting}
+      submitLabel="Install"
+      disableSubmit={!dirty || !_.isEmpty(errors)}
+      resetLabel="Cancel"
+    />
   </Form>
 );
 

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Form, ActionGroup, ButtonVariant, Button, TextInputTypes } from '@patternfly/react-core';
+import { FormikProps, FormikValues } from 'formik';
+import { ButtonBar } from '@console/internal/components/utils';
+import { InputField } from '@console/shared';
+import FormSection from '../import/section/FormSection';
+
+const HelmInstallForm: React.FC<FormikProps<FormikValues>> = ({
+  errors,
+  handleSubmit,
+  handleReset,
+  status,
+  isSubmitting,
+  dirty,
+}) => (
+  <Form onSubmit={handleSubmit}>
+    <FormSection title="General">
+      <InputField
+        type={TextInputTypes.text}
+        name="releaseName"
+        label="Release Name"
+        helpText="A unique name for the Helm Chart release."
+        required
+      />
+    </FormSection>
+    <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
+      <ActionGroup className="pf-c-form">
+        <Button
+          type="submit"
+          variant={ButtonVariant.primary}
+          isDisabled={!dirty || !_.isEmpty(errors)}
+          data-test-id="helm-install-create-button"
+        >
+          Create
+        </Button>
+        <Button type="button" variant={ButtonVariant.secondary} onClick={handleReset}>
+          Cancel
+        </Button>
+      </ActionGroup>
+    </ButtonBar>
+  </Form>
+);
+
+export default HelmInstallForm;

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallPage.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import * as yup from 'yup';
+import { RouteComponentProps } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import { PageHeading, history } from '@console/internal/components/utils';
+import { coFetchJSON } from '@console/internal/co-fetch';
+import { Formik } from 'formik';
+import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
+import { nameValidationSchema } from '../import/validation-schema';
+import HelmInstallForm from './HelmInstallForm';
+
+export type HelmInstallPageProps = RouteComponentProps<{ ns?: string }>;
+
+export type HelmInstallFormData = {
+  releaseName: string;
+};
+
+export const HelmInstallPage: React.FunctionComponent<HelmInstallPageProps> = ({ location }) => {
+  const searchParams = new URLSearchParams(location.search);
+  const chartURL = encodeURIComponent(searchParams.get('chartURL'));
+  const preselectedNamespace = searchParams.get('preselected-ns');
+
+  const initialValues: HelmInstallFormData = {
+    releaseName: '',
+  };
+
+  const validationSchema = yup.object().shape({
+    releaseName: nameValidationSchema,
+  });
+
+  const handleSubmit = (values, actions) => {
+    const { releaseName }: HelmInstallFormData = values;
+    coFetchJSON
+      .post(
+        `/api/console/helm/install?ns=${preselectedNamespace}&name=${releaseName}&url=${chartURL}`,
+        null,
+        null,
+      )
+      .then(() => {
+        actions.setSubmitting(false);
+        history.push(`/topology/ns/${preselectedNamespace}`);
+      })
+      .catch((err) => {
+        actions.setSubmitting(false);
+        actions.setStatus({ submitError: err.message });
+      });
+  };
+
+  return (
+    <NamespacedPage disabled variant={NamespacedPageVariants.light}>
+      <Helmet>
+        <title>Install Helm Chart</title>
+      </Helmet>
+      <PageHeading title="Install Helm Chart" />
+      <div className="co-m-pane__body">
+        <Formik
+          initialValues={initialValues}
+          onSubmit={handleSubmit}
+          onReset={history.goBack}
+          validationSchema={validationSchema}
+          render={(props) => <HelmInstallForm {...props} />}
+        />
+      </div>
+    </NamespacedPage>
+  );
+};
+
+export default HelmInstallPage;

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallPage.tsx
@@ -30,12 +30,13 @@ export const HelmInstallPage: React.FunctionComponent<HelmInstallPageProps> = ({
 
   const handleSubmit = (values, actions) => {
     const { releaseName }: HelmInstallFormData = values;
+    const payload = {
+      namespace: preselectedNamespace,
+      name: releaseName,
+      url: chartURL,
+    };
     coFetchJSON
-      .post(
-        `/api/console/helm/install?ns=${preselectedNamespace}&name=${releaseName}&url=${chartURL}`,
-        null,
-        null,
-      )
+      .post('/api/helm/release', payload, null)
       .then(() => {
         actions.setSubmitting(false);
         history.push(`/topology/ns/${preselectedNamespace}`);

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -415,9 +415,11 @@ const plugin: Plugin<ConsumedExtensions> = [
       exact: true,
       path: ['/catalog/helm-install'],
       loader: async () =>
-        (await import(
-          './components/helm/HelmInstallPage' /* webpackChunkName: "dev-console-helm-install" */
-        )).default,
+        (
+          await import(
+            './components/helm/HelmInstallPage' /* webpackChunkName: "dev-console-helm-install" */
+          )
+        ).default,
     },
   },
   {

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -413,6 +413,17 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
+      path: ['/catalog/helm-install'],
+      loader: async () =>
+        (await import(
+          './components/helm/HelmInstallPage' /* webpackChunkName: "dev-console-helm-install" */
+        )).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
       path: '/edit/ns/:ns',
       loader: async () =>
         (

--- a/frontend/public/components/catalog/catalog-item-icon.tsx
+++ b/frontend/public/components/catalog/catalog-item-icon.tsx
@@ -37,6 +37,7 @@ import * as goGopherImg from '../../imgs/logos/go-gopher.svg';
 import * as grailsImg from '../../imgs/logos/grails.svg';
 import * as hadoopImg from '../../imgs/logos/hadoop.svg';
 import * as haproxyImg from '../../imgs/logos/haproxy.svg';
+import * as helmImg from '../../imgs/logos/helm.svg';
 import * as infinispanImg from '../../imgs/logos/infinispan.svg';
 import * as jbossImg from '../../imgs/logos/jboss.svg';
 import * as jenkinsImg from '../../imgs/logos/jenkins.svg';
@@ -89,7 +90,6 @@ import * as windowsImg from '../../imgs/logos/windows.svg';
 import * as wordpressImg from '../../imgs/logos/wordpress.svg';
 import * as xamarinImg from '../../imgs/logos/xamarin.svg';
 import * as zendImg from '../../imgs/logos/zend.svg';
-import * as helm from '../../imgs/logos/helm.svg';
 
 const logos = new Map()
   .set('icon-3scale', threeScaleImg)
@@ -127,7 +127,7 @@ const logos = new Map()
   .set('icon-grails', grailsImg)
   .set('icon-hadoop', hadoopImg)
   .set('icon-haproxy', haproxyImg)
-  .set('icon-helm', helm)
+  .set('icon-helm', helmImg)
   .set('icon-infinispan', infinispanImg)
   .set('icon-jboss', jbossImg)
   .set('icon-jenkins', jenkinsImg)

--- a/frontend/public/components/catalog/catalog-items.jsx
+++ b/frontend/public/components/catalog/catalog-items.jsx
@@ -123,6 +123,11 @@ const getAvailableFilters = (initialFilters) => {
       value: 'ClusterServiceClass',
       active: false,
     },
+    HelmChart: {
+      label: 'Helm Charts',
+      value: 'HelmChart',
+      active: false,
+    },
   };
 
   return filters;

--- a/frontend/public/components/catalog/catalog-items.jsx
+++ b/frontend/public/components/catalog/catalog-items.jsx
@@ -108,6 +108,11 @@ const getAvailableFilters = (initialFilters) => {
       value: 'InstalledOperator',
       active: true,
     },
+    HelmChart: {
+      label: 'Helm Charts',
+      value: 'HelmChart',
+      active: false,
+    },
     ImageStream: {
       label: 'Builder Image',
       value: 'ImageStream',
@@ -121,11 +126,6 @@ const getAvailableFilters = (initialFilters) => {
     ClusterServiceClass: {
       label: 'Service Class',
       value: 'ClusterServiceClass',
-      active: false,
-    },
-    HelmChart: {
-      label: 'Helm Charts',
-      value: 'HelmChart',
       active: false,
     },
   };

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -207,16 +207,14 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
         charts.forEach((chart: HelmChart) => {
           const tags = chart.keywords;
           const name = _.startCase(chart.name);
-          const iconClass = getImageForIconClass('icon-catalog');
-          const tileImgUrl = chart.icon;
-          const tileIconClass = tileImgUrl ? null : iconClass;
+          const tileImgUrl = chart.icon || getImageForIconClass('icon-helm');
           const chartURL = encodeURIComponent(_.get(chart, 'urls.0'));
 
           normalizedCharts.push({
             obj: { ...chart, ...{ metadata: { uid: chart.digest } } },
             kind: 'HelmChart',
             tileName: `${name} v${chart.version}`,
-            tileIconClass,
+            tileIconClass: null,
             tileImgUrl,
             tileDescription: chart.description,
             tags,
@@ -336,7 +334,7 @@ export const Catalog = connectToFlags<CatalogProps>(
   }, [loadTemplates, namespace]);
 
   React.useEffect(() => {
-    coFetch('https://raw.githubusercontent.com/IBM/charts/master/repo/community/index.yaml').then(
+    coFetch('https://redhat-developer.github.io/redhat-helm-charts/index.yaml').then(
       async (res) => {
         const yaml = await res.text();
         const json = safeLoad(yaml);

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -154,9 +154,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
           tileProvider: _.get(serviceClass, 'spec.externalMetadata.providerDisplayName'),
           tags: serviceClass.spec.tags,
           createLabel: 'Create Service Instance',
-          href: `/catalog/create-service-instance?cluster-service-class=${
-            serviceClass.metadata.name
-          }&preselected-ns=${namespace}`,
+          href: `/catalog/create-service-instance?cluster-service-class=${serviceClass.metadata.name}&preselected-ns=${namespace}`,
           supportUrl: _.get(serviceClass, 'spec.externalMetadata.supportUrl'),
           longDescription: _.get(serviceClass, 'spec.externalMetadata.longDescription'),
           documentationUrl: _.get(serviceClass, 'spec.externalMetadata.documentationUrl'),
@@ -212,6 +210,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
           const iconClass = getImageForIconClass('icon-catalog');
           const tileImgUrl = chart.icon;
           const tileIconClass = tileImgUrl ? null : iconClass;
+          const chartURL = encodeURIComponent(_.get(chart, 'urls.0'));
 
           normalizedCharts.push({
             obj: { ...chart, ...{ metadata: { uid: chart.digest } } },
@@ -225,7 +224,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
             tileProvider: _.get(chart, 'maintainers.0.name'),
             documentationUrl: chart.home,
             supportUrl: chart.home,
-            href: `/catalog/install-helm-chart?chart=${name}&preselected-ns=${currentNamespace}`,
+            href: `/catalog/helm-install?chartURL=${chartURL}&preselected-ns=${currentNamespace}`,
           });
         });
         return normalizedCharts;
@@ -402,7 +401,7 @@ export const Catalog = connectToFlags<CatalogProps>(
           templateMetadata={templateMetadata}
           projectTemplateMetadata={projectTemplateMetadata}
           helmCharts={helmCharts}
-          {...props as any}
+          {...(props as any)}
         />
       </Firehose>
     </div>
@@ -464,11 +463,11 @@ export type HelmChart = {
   digest: string;
   home: string;
   icon: string;
-  keywords: Array<string>;
+  keywords: string[];
   maintainers: Array<{ email: string; name: string }>;
   name: string;
   tillerVersion: string;
-  urls: Array<string>;
+  urls: string[];
   version: string;
 };
 


### PR DESCRIPTION
Related JIRA Story - https://issues.redhat.com/browse/ODC-2522
Related JIRA Story - https://issues.redhat.com/browse/ODC-2523

### Depends on https://github.com/openshift/console/pull/3826

### This PR - 
- Adds support for listing Helm Charts into Developer Catalog.
- Adds a filter for Helm Charts.
- Uses keywords from Helm Chart metadat to categorize the Helm Charts.
- Uses sample Helm Charts repo endpoint to fetch the Helm Charts - https://raw.githubusercontent.com/IBM/charts/master/repo/community/index.yaml.

### This PR also - 
- Adds a basic form for Helm Installation.
- Uses Helm Install API added by PR - https://github.com/openshift/console/pull/3826.
- After successfull install user is redirected to topology.

Note - The sample endpoint needs to be replaced once the final API for listing Helm Charts will be integrated into console backend.

### Screencast - 
#### Helm List
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/6041994/71682825-c889e700-2db6-11ea-9a38-06b50e534a14.gif)

#### Helm Install
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/6041994/71833343-b8ce1380-30d2-11ea-9112-624f9e2c582b.gif)


@openshift/team-devconsole-ux 