### PR TITLE
Bug 1787583: Fix off by one bug in metrics rows count

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -753,9 +753,7 @@ const QueryTable_: React.FC<QueryTableProps> = ({
 
   const onSort = (e, i, direction) => setSortBy({ index: i, direction });
 
-  const tableRows = rows
-    .slice((page - 1) * perPage, page * perPage - 1)
-    .map((cells) => ({ cells }));
+  const tableRows = rows.slice((page - 1) * perPage, page * perPage).map((cells) => ({ cells }));
 
   return (
     <>


### PR DESCRIPTION
To demo the bug, I temporarily set `perPage` to  `2` in the screenshots below.

Before:
![Screen Shot 2020-01-03 at 9 05 17 AM](https://user-images.githubusercontent.com/895728/71727455-45917c80-2e08-11ea-80b4-e740de756eec.png)
 
After:
![Screen Shot 2020-01-03 at 9 02 45 AM](https://user-images.githubusercontent.com/895728/71727462-4b875d80-2e08-11ea-8303-475ff3716733.png)
