### PR TITLE
metal3: move yaml creation link to the list menu in BareMetalHosts

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsPage.tsx
@@ -52,10 +52,33 @@ type BareMetalHostsPageProps = {
   hasNodeMaintenanceCapability: boolean;
 };
 
+const getCreateProps = ({ namespace }: { namespace: string }) => {
+  const items: any = {
+    dialog: 'New with Dialog',
+    yaml: 'New from YAML',
+  };
+
+  return {
+    items,
+    createLink: (itemName) => {
+      const base = `/k8s/ns/${namespace || 'default'}/${referenceForModel(BareMetalHostModel)}`;
+
+      switch (itemName) {
+        case 'dialog':
+          return `${base}/~new/form`;
+        case 'yaml':
+        default:
+          return `${base}/~new`;
+      }
+    },
+  };
+};
+
 const BareMetalHostsPage: React.FC<BareMetalHostsPageProps> = ({
   hasNodeMaintenanceCapability,
   ...props
 }) => {
+  const { namespace } = props;
   const resources: FirehoseResource[] = [
     {
       kind: referenceForModel(BareMetalHostModel),
@@ -84,20 +107,14 @@ const BareMetalHostsPage: React.FC<BareMetalHostsPageProps> = ({
     });
   }
 
-  const createHostProps = {
-    to: `/k8s/ns/${props.namespace || 'default'}/${referenceForModel(
-      BareMetalHostModel,
-    )}/~new/form`,
-  };
-
   return (
     <MultiListPage
       {...props}
       canCreate
       rowFilters={[hostStatusFilter]}
-      createProps={createHostProps}
+      createProps={getCreateProps({ namespace })}
       createButtonText="Add Host"
-      namespace={props.namespace}
+      namespace={namespace}
       resources={resources}
       flatten={flattenResources}
       ListComponent={BareMetalHostsTable}

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/add-baremetal-host/AddBareMetalHostPage.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/add-baremetal-host/AddBareMetalHostPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { RouteComponentProps, Link } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { Firehose, FirehoseResource } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -30,15 +30,6 @@ const AddBareMetalHostPage: React.FunctionComponent<AddBareMetalHostPageProps> =
         CreateResourceFormPageHeading) */}
         <h1 className="co-m-pane__heading co-m-pane__heading--baseline">
           <div className="co-m-pane__name">{title}</div>
-          <div className="co-m-pane__heading-link">
-            <Link
-              to={`/k8s/ns/${namespace}/${referenceForModel(BareMetalHostModel)}/~new`}
-              id="yaml-link"
-              replace
-            >
-              Edit YAML
-            </Link>
-          </div>
         </h1>
         <p className="co-m-pane__explanation">
           Expand the hardware inventory by registering new Bare Metal Host.


### PR DESCRIPTION
reasons 
- easier navigation to the YAML editor
- Edit YAML button in edit dialog seems like a switch but it behaves as a redirect only
- this convention is used in kubevirt plugin


@jtomasek @honza 