### PR TITLE
Bug 1796664: Add links to Marketplace workflows in OperatorHub

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -50,6 +50,8 @@ export type OperatorHubCSVAnnotations = {
   description?: string;
   categories?: string;
   capabilities?: CapabilityLevel;
+  'marketplace.openshift.io/action-text'?: string;
+  'marketplace.openshift.io/remote-workflow'?: string;
 };
 
 type OperatorHubSpec = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -2,8 +2,11 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import * as _ from 'lodash';
 import LazyLoad from 'react-lazyload';
-import { Button, Modal } from '@patternfly/react-core';
 import { CatalogItemHeader, CatalogTile } from '@patternfly/react-catalog-view-extension';
+import * as classNames from 'classnames';
+import { Button, Modal } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
 import {
   COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY,
   GreenCheckCircleIcon,
@@ -323,6 +326,7 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
   const createLink =
     detailsItem &&
     `/operatorhub/subscribe?pkg=${detailsItem.obj.metadata.name}&catalog=${detailsItem.catalogSource}&catalogNamespace=${detailsItem.catalogSourceNamespace}&targetNamespace=${props.namespace}`;
+
   const uninstallLink = () =>
     detailsItem &&
     `/k8s/ns/${detailsItem.subscription.metadata.namespace}/${SubscriptionModel.plural}/${detailsItem.subscription.metadata.name}?showDelete=true`;
@@ -352,9 +356,22 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
                 vendor={`${detailsItem.version} provided by ${detailsItem.provider}`}
               />
               <div className="co-catalog-page__button">
+                {detailsItem.marketplaceRemoteWorkflow && (
+                  <Link
+                    className="pf-c-button pf-c-external pf-m-primary co-catalog-page__overlay-remo5e-workflow"
+                    to={detailsItem.marketplaceRemoteWorkflow}
+                  >
+                    {detailsItem.marketplaceActionText || 'View Details'} <ExternalLinkAltIcon />
+                  </Link>
+                )}
                 {!detailsItem.installed ? (
                   <Link
-                    className="pf-c-button pf-m-primary co-catalog-page__overlay-create"
+                    className={classNames(
+                      'pf-c-button',
+                      { 'pf-m-secondary': detailsItem.marketplaceRemoteWorkflow },
+                      { 'pf-m-primary': !detailsItem.marketplaceRemoteWorkflow },
+                      'co-catalog-page__overlay-create',
+                    )}
                     to={createLink}
                   >
                     Install

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -48,6 +48,8 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
         createdAt,
         support,
         capabilities: capabilityLevel,
+        'marketplace.openshift.io/action-text': marketplaceActionText,
+        'marketplace.openshift.io/remote-workflow': marketplaceRemoteWorkflow,
       } = currentCSVAnnotations;
 
       return {
@@ -86,6 +88,8 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
         createdAt,
         support,
         capabilityLevel,
+        marketplaceActionText,
+        marketplaceRemoteWorkflow,
       };
     },
   );

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -232,6 +232,13 @@ $co-modal-ignore-warning-icon-width: 30px;
     text-overflow: ellipsis;
   }
 
+  &__overlay-remote-workflow {
+    display: inline-flex !important;
+    margin-right: var(--pf-global--spacer--sm);
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+  }
+
   &__overlay-description {
     margin: 20px 0 0;
     white-space: pre-wrap;


### PR DESCRIPTION
Read annotations and use action text, remote workflow link, and support link from annotations if present. Default to original values if not found.

The annotations don't seem to be present yet, but I added code to handle them for when they show up.

Fixes https://issues.redhat.com/projects/CONSOLE/issues/CONSOLE-1953.