### PR TITLE
Bug fix: ODC-2540  Deploy Image - 2nd bullet has incorrect text

### DIFF
--- a/frontend/packages/dev-console/src/utils/imagestream-utils.ts
+++ b/frontend/packages/dev-console/src/utils/imagestream-utils.ts
@@ -152,7 +152,7 @@ export const imageRegistryType = {
   },
   Internal: {
     value: RegistryType.Internal,
-    label: 'Image name from internal registry',
+    label: 'Image stream tag from internal registry',
   },
 };
 


### PR DESCRIPTION
Bug - https://issues.redhat.com/browse/ODC-2540
Under +Add > Container Image
Changed  the second bullet to 
"Image name from internal registry" 
TO 
"Image **stream tag** from internal registry"