### PR TITLE
Container Security Operator UI Improvements

### DIFF
--- a/frontend/packages/container-security/integration-tests/bad-pods.ts
+++ b/frontend/packages/container-security/integration-tests/bad-pods.ts
@@ -1,0 +1,87 @@
+import { vulnPriority, Priority } from '../src/const';
+import { ImageManifestVuln } from '../src/types';
+
+export const fakeVulnFor = (priority: Priority): ImageManifestVuln => {
+  return {
+    apiVersion: 'secscan.quay.redhat.com/v1alpha1',
+    kind: 'ImageManifestVuln',
+    metadata: {
+      creationTimestamp: '2019-12-23T18:30:33Z',
+      generation: 76,
+      labels: {
+        'default/3scale-operator-7864b9bb5d-frhnt': 'true',
+      },
+      name: `sha256.e94c22ba519b1e0ae035e1786a7d2eb9425d62ff60be8ba2dc6b86234540bcb${
+        vulnPriority.get(priority).index
+      }`,
+      namespace: 'default',
+      resourceVersion: '3082821',
+      selfLink:
+        '/apis/secscan.quay.redhat.com/v1alpha1/namespaces/default/imagemanifestvulns/sha256.e94c22ba519b1e0ae035e1786a7d2eb9425d62ff60be8ba2dc6b86234540bcbf',
+      uid: `74b640b4-0503-4fbe-9354-1939630e082${vulnPriority.get(priority).index}`,
+    },
+    spec: {
+      features: [
+        {
+          name: 'libcurl',
+          namespaceName: 'centos:7',
+          version: '7.29.0-51.el7',
+          versionformat: 'rpm',
+          vulnerabilities: [
+            {
+              description:
+                'The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP. Security Fix(es): * curl: NTLM password overflow via integer overflow (CVE-2018-14618) For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section. Bug Fix(es): * baseurl with file:// hangs and then timeout in yum repo (BZ#1709474) * curl crashes on http links with rate-limit (BZ#1711914)',
+              fixedby: '0:7.29.0-51.el7_6.3',
+              link: 'https://access.redhat.com/errata/RHSA-2019:1880',
+              name: 'RHSA-2019:1880',
+              namespaceName: 'centos:7',
+              severity: vulnPriority.get(priority).title,
+            },
+          ],
+        },
+        {
+          name: 'libssh2',
+          namespaceName: 'centos:7',
+          version: '1.4.3-12.el7_6.2',
+          versionformat: 'rpm',
+          vulnerabilities: [
+            {
+              description:
+                'The libssh2 packages provide a library that implements the SSH2 protocol. Security Fix(es): * libssh2: Out-of-bounds memory comparison with specially crafted message channel request (CVE-2019-3862) For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.',
+              fixedby: '0:1.4.3-12.el7_6.3',
+              link: 'https://access.redhat.com/errata/RHSA-2019:1884',
+              name: 'RHSA-2019:1884',
+              namespaceName: 'centos:7',
+              severity: 'Low',
+            },
+            {
+              description:
+                'The libssh2 packages provide a library that implements the SSH2 protocol. The following packages have been upgraded to a later upstream version: libssh2 (1.8.0). (BZ#1592784) Security Fix(es): * libssh2: Zero-byte allocation with a specially crafted SFTP packed leading to an out-of-bounds read (CVE-2019-3858) * libssh2: Out-of-bounds reads with specially crafted SSH packets (CVE-2019-3861) For more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section. Additional Changes: For detailed information on changes in this release, see the Red Hat Enterprise Linux 7.7 Release Notes linked from the References section.',
+              fixedby: '0:1.8.0-3.el7',
+              link: 'https://access.redhat.com/errata/RHSA-2019:2136',
+              name: 'RHSA-2019:2136',
+              namespaceName: 'centos:7',
+              severity: 'Medium',
+            },
+          ],
+        },
+      ],
+      image: 'quay.io/alecmerdler/bad-pod',
+      manifest: 'sha256:e94c22ba519b1e0ae035e1786a7d2eb9425d62ff60be8ba2dc6b86234540bcbf',
+      namespaceName: 'centos:7',
+    },
+    status: {
+      affectedPods: {
+        'default/3scale-operator-7864b9bb5d-frhnt': [
+          'cri-o://fa5adc149410ef015919abd1b7b0f747d1cc8958f76e4d6ce79538d701018abc',
+        ],
+      },
+      fixableCount: 0,
+      highCount: 0,
+      highestSeverity: vulnPriority.get(priority).title,
+      lastUpdate: '2019-12-27 22:00:48.328470155 +0000 UTC',
+      lowCount: 1,
+      mediumCount: 1,
+    },
+  };
+};

--- a/frontend/packages/container-security/src/__tests__/kebab-actions.spec.ts
+++ b/frontend/packages/container-security/src/__tests__/kebab-actions.spec.ts
@@ -1,0 +1,46 @@
+import { ServiceModel, PodModel } from '@console/internal/models';
+import { mockPod } from '@console/shared/src/utils/__mocks__/pod-utils-test-data';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { getKebabActionsForKind } from '../kebab-actions';
+import { ImageManifestVulnModel } from '../models';
+
+describe('getKebabActionsForKind', () => {
+  const pod: K8sResourceKind = {
+    ...mockPod,
+    status: {
+      phase: 'Running',
+      containerStatuses: [
+        {
+          name: 'mock-container',
+          ready: true,
+          restartCount: 0,
+          imageID:
+            'docker-pullable://quay.io/example/example@sha256:73d60e4f2adbc70ed8df93245fb2d83c9e0062489a22110d897b83c21918e101',
+          image:
+            'quay.io/example/example@sha256:73d60e4f2adbc70ed8df93245fb2d83c9e0062489a22110d897b83c21918e101',
+          containerID: 'docker://410fa79084b1ae605b6483bb21f6d4459f90c54ad1d55f56a05fb0b654acfd44',
+        },
+      ],
+    },
+  };
+
+  it('returns `ViewImageVulnerabilities` kebab action if given `PodModel`', () => {
+    const actions = getKebabActionsForKind(PodModel);
+
+    expect(actions.length).toEqual(1);
+    expect(actions[0](PodModel, pod).label).toEqual('View Image Vulnerabilities');
+    expect(actions[0](PodModel, pod).href).toEqual(
+      '/k8s/ns/testproject3/secscan.quay.redhat.com~v1alpha1~ImageManifestVuln/?name=sha256.73d60e4f2adbc70ed8df93245fb2d83c9e0062489a22110d897b83c21918e101',
+    );
+    expect(actions[0](PodModel, pod).accessReview).toEqual({
+      group: ImageManifestVulnModel.apiGroup,
+      resource: ImageManifestVulnModel.plural,
+      namespace: pod.metadata.namespace,
+      verb: 'list',
+    });
+  });
+
+  it('returns no actions if not given `PodModel`', () => {
+    expect(getKebabActionsForKind(ServiceModel).length).toEqual(0);
+  });
+});

--- a/frontend/packages/container-security/src/components/__tests__/image-manifest-vuln.spec.tsx
+++ b/frontend/packages/container-security/src/components/__tests__/image-manifest-vuln.spec.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { SecurityIcon } from '@patternfly/react-icons';
+import { shallow, ShallowWrapper } from 'enzyme';
+import * as _ from 'lodash';
+import { ChartDonut } from '@patternfly/react-charts';
+import {
+  ImageVulnerabilityRow,
+  ImageVulnerabilityRowProps,
+  ImageVulnerabilitiesTable,
+  ImageVulnerabilitiesTableProps,
+  ImageManifestVulnDetails,
+  ImageManifestVulnDetailsProps,
+} from '../image-manifest-vuln';
+import { fakeVulnFor } from '../../../integration-tests/bad-pods';
+import { Priority, vulnPriority, totalFor } from '../../const';
+
+describe(ImageVulnerabilityRow.displayName, () => {
+  let wrapper: ShallowWrapper<ImageVulnerabilityRowProps>;
+
+  it('renders a `SecurityIcon` with the correct color for the severity', () => {
+    const vuln = fakeVulnFor(Priority.Critical);
+
+    wrapper = shallow(
+      <ImageVulnerabilityRow
+        vulnerability={vuln.spec.features[0].vulnerabilities[0]}
+        currentVersion={vuln.spec.features[0].version}
+        packageName={vuln.spec.features[0].name}
+      />,
+    );
+
+    expect(wrapper.find(SecurityIcon).props().color).toEqual(
+      vulnPriority.get(Priority.Critical).color.value,
+    );
+  });
+});
+
+describe(ImageVulnerabilitiesTable.displayName, () => {
+  let wrapper: ShallowWrapper<ImageVulnerabilitiesTableProps>;
+
+  it('displays vulnerabilities sorted by their severity', () => {
+    const vuln = fakeVulnFor(Priority.Critical);
+
+    wrapper = shallow(<ImageVulnerabilitiesTable features={vuln.spec.features} />);
+
+    expect(wrapper.find(ImageVulnerabilityRow).length).toEqual(3);
+    const indexes = wrapper
+      .find(ImageVulnerabilityRow)
+      .map((r) => vulnPriority.find((p) => p.title === r.props().vulnerability.severity).index);
+    expect(indexes).toEqual(_.sortBy(indexes));
+  });
+});
+
+describe(ImageManifestVulnDetails.displayName, () => {
+  let wrapper: ShallowWrapper<ImageManifestVulnDetailsProps>;
+  const vuln = fakeVulnFor(Priority.Critical);
+
+  beforeEach(() => {
+    wrapper = shallow(<ImageManifestVulnDetails obj={vuln} />);
+  });
+
+  it('renders donut chart with breakdown of vulnerabilities by severity', () => {
+    const chart = wrapper.find(ChartDonut);
+
+    chart.props().data.forEach((d) => {
+      expect(vulnPriority.has(d.x)).toBe(true);
+      expect(d.y).toEqual(totalFor(d.x)(vuln));
+    });
+    expect(chart.props().title).toEqual(`3 total`);
+    expect(chart.props().colorScale).toEqual(
+      vulnPriority.map((priority) => priority.color.value).toArray(),
+    );
+  });
+
+  it('renders text breakdown of vulnerabilities by severity', () => {
+    expect(wrapper.find('.imagemanifestvuln-details__summary').find(SecurityIcon).length).toEqual(
+      2,
+    );
+  });
+});

--- a/frontend/packages/container-security/src/components/__tests__/summary.spec.ts
+++ b/frontend/packages/container-security/src/components/__tests__/summary.spec.ts
@@ -15,7 +15,7 @@ const highVuln: ImageManifestVuln = {
     namespaceName: 'centos:7',
   },
   status: {
-    afftectedPods: {
+    affectedPods: {
       'test/some-pod': ['cri-o://524638ef02d6da6bfe48650663f838f9f2fbe1e9769f886863fe509bc74b75ef'],
     },
     fixableCount: 61,

--- a/frontend/packages/container-security/src/components/image-manifest-vuln.scss
+++ b/frontend/packages/container-security/src/components/image-manifest-vuln.scss
@@ -1,0 +1,13 @@
+.imagemanifestvuln-details__donut {
+  padding: 30px;
+  width: 20%;
+}
+
+.imagemanifestvuln-details__summary {
+  width: 80%;
+}
+
+.imagemanifestvuln-details__summary-list {
+  display: flex;
+  flex-direction: column;
+}

--- a/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
+++ b/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
@@ -1,0 +1,354 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import * as classNames from 'classnames';
+import { sortable } from '@patternfly/react-table';
+import { SecurityIcon } from '@patternfly/react-icons';
+import {
+  MultiListPage,
+  Table,
+  TableRow,
+  TableData,
+  DetailsPage,
+  ListPage,
+} from '@console/internal/components/factory';
+import { referenceForModel, PodKind } from '@console/internal/module/k8s';
+import { match } from 'react-router';
+import {
+  ResourceLink,
+  ExternalLink,
+  navFactory,
+  SectionHeading,
+  ResourceSummary,
+  DetailsItem,
+} from '@console/internal/components/utils';
+import { ChartDonut } from '@patternfly/react-charts';
+import { DefaultList } from '@console/internal/components/default-resource';
+import { vulnPriority, totalFor } from '../const';
+import { ImageManifestVuln, Feature, Vulnerability } from '../types';
+import { ImageManifestVulnModel } from '../models';
+import { quayURLFor } from './summary';
+import './image-manifest-vuln.scss';
+
+const shortenImage = (img: string) =>
+  img
+    .split('/')
+    .slice(1, 3)
+    .join('/');
+const shortenHash = (hash: string) => hash.slice(7, 18);
+
+export const ImageVulnerabilityRow: React.FC<ImageVulnerabilityRowProps> = (props) => {
+  return (
+    <div className="row">
+      <div className="col-lg-2 col-md-3 col-sm-4 col-xs-5">
+        <ExternalLink text={props.vulnerability.name} href={props.vulnerability.link} />
+      </div>
+      <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7">
+        <SecurityIcon
+          color={vulnPriority.find((p) => p.title === props.vulnerability.severity).color.value}
+        />
+        &nbsp;{props.vulnerability.severity}
+      </div>
+      <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs">{props.packageName}</div>
+      <div className="col-lg-1 col-md-2 hidden-sm hidden-xs">{props.currentVersion}</div>
+      <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">
+        {props.vulnerability.fixedby || '-'}
+      </div>
+    </div>
+  );
+};
+
+export const ImageVulnerabilitiesTable: React.FC<ImageVulnerabilitiesTableProps> = (props) => {
+  const vulnerabilites = _.sortBy(
+    _.flatten(
+      props.features.map((feature) =>
+        feature.vulnerabilities.map((vulnerability) => ({ feature, vulnerability })),
+      ),
+    ),
+    (v) => vulnPriority.find((p) => p.title === v.vulnerability.severity).index,
+  );
+
+  return (
+    <>
+      <SectionHeading text="Vulnerabilities" />
+      <div className="co-m-table-grid co-m-table-grid--bordered">
+        <div className="row co-m-table-grid__head">
+          <div className="col-lg-2 col-md-3 col-sm-4 col-xs-5">Vulnerability</div>
+          <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7">Severity</div>
+          <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs">Package</div>
+          <div className="col-lg-1 col-md-2 hidden-sm hidden-xs">Current Version</div>
+          <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">Fixed in Version</div>
+        </div>
+        <div className="co-m-table-grid__body">
+          {vulnerabilites.map(({ feature, vulnerability }) => (
+            <ImageVulnerabilityRow
+              key={`${feature.name}-${vulnerability.name}`}
+              vulnerability={vulnerability}
+              packageName={feature.name}
+              currentVersion={feature.version}
+            />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export const ImageManifestVulnDetails: React.FC<ImageManifestVulnDetailsProps> = (props) => {
+  const total = props.obj.spec.features.reduce((sum, f) => sum + f.vulnerabilities.length, 0);
+
+  return (
+    <>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Image Manifest Vuln Overview" />
+        <div style={{ display: 'flex' }}>
+          <div className="imagemanifestvuln-details__donut">
+            <ChartDonut
+              colorScale={vulnPriority.map((priority) => priority.color.value).toArray()}
+              data={vulnPriority
+                .map((priority, key) => ({
+                  label: priority.title,
+                  x: priority.value,
+                  y: totalFor(key)(props.obj),
+                }))
+                .toArray()}
+              title={`${total} total`}
+            />
+          </div>
+          <div className="imagemanifestvuln-details__summary">
+            <h3>Quay Security Scanner has detected {total} vulnerabilities.</h3>
+            <h4>Patches are available for {props.obj.status.fixableCount} vulnerabilities.</h4>
+            <div className="imagemanifestvuln-details__summary-list">
+              {vulnPriority
+                .map((v, k) =>
+                  totalFor(k)(props.obj) > 0 ? (
+                    <span style={{ margin: '5px' }} key={v.index}>
+                      <SecurityIcon color={v.color.value} />
+                      &nbsp;<strong>{totalFor(k)(props.obj)}</strong> {v.title} vulnerabilities.
+                    </span>
+                  ) : null,
+                )
+                .toArray()}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="co-m-pane__body">
+        <div className="row">
+          <div className="col-sm-6">
+            <ResourceSummary resource={props.obj} />
+          </div>
+          <div className="col-sm-6">
+            <dl className="co-m-pane__details">
+              <DetailsItem label="Registry" obj={props.obj} path="spec.image" />
+            </dl>
+          </div>
+        </div>
+      </div>
+      <div className="co-m-pane__body">
+        <ImageVulnerabilitiesTable features={props.obj.spec.features} />
+      </div>
+    </>
+  );
+};
+
+export const AffectedPods: React.FC<AffectedPodsProps> = (props) => {
+  const affectedPodsFor = (pods: PodKind[]) =>
+    pods.filter((p) =>
+      _.keys(props.obj.status.affectedPods).includes(
+        [p.metadata.namespace, p.metadata.name].join('/'),
+      ),
+    );
+
+  return (
+    <ListPage
+      kind="Pod"
+      namespace={props.obj.metadata.namespace}
+      canCreate={false}
+      showTitle={false}
+      ListComponent={(listProps) => (
+        <DefaultList {...listProps} data={affectedPodsFor(listProps.data)} />
+      )}
+    />
+  );
+};
+
+export const ImageManifestVulnDetailsPage: React.FC<ImageManifestVulnDetailsPageProps> = (
+  props,
+) => {
+  return (
+    <DetailsPage
+      match={props.match}
+      kindObj={ImageManifestVulnModel}
+      titleFunc={(obj: ImageManifestVuln) =>
+        !_.isEmpty(obj) ? `${shortenImage(obj.spec.image)}@${shortenHash(obj.spec.manifest)}` : null
+      }
+      name={props.match.params.name}
+      namespace={props.match.params.ns}
+      kind={referenceForModel(ImageManifestVulnModel)}
+      menuActions={[]}
+      pages={[
+        navFactory.details(ImageManifestVulnDetails),
+        navFactory.editYaml(),
+        {
+          href: 'pods',
+          name: 'Affected Pods',
+          component: AffectedPods,
+        },
+      ]}
+    />
+  );
+};
+
+// TODO(alecmerdler): Fix classes here to ensure responsiveness
+const tableColumnClasses = ['', '', '', '', '', ''];
+
+export const ImageManifestVulnTableRow: React.FC<ImageManifestVulnTableRowProps> = (props) => {
+  const { obj, index, key, style } = props;
+  const { name, namespace } = props.obj.metadata;
+
+  return (
+    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses[0]}>
+        <ResourceLink
+          kind={referenceForModel(ImageManifestVulnModel)}
+          name={name}
+          namespace={namespace}
+          displayName={shortenImage(obj.spec.image)}
+        />
+      </TableData>
+      <TableData className={classNames(tableColumnClasses[1], 'co-break-word')}>
+        <ResourceLink kind="Namespace" name={namespace} />
+      </TableData>
+      <TableData className={tableColumnClasses[2]}>
+        <SecurityIcon
+          color={vulnPriority.find(({ title }) => obj.status.highestSeverity === title).color.value}
+        />
+        &nbsp;{obj.status.highestSeverity}
+      </TableData>
+      <TableData className={tableColumnClasses[3]}>
+        {Object.keys(obj.status.affectedPods).length}
+      </TableData>
+      <TableData className={tableColumnClasses[4]}>{obj.status.fixableCount}</TableData>
+      <TableData className={tableColumnClasses[4]}>
+        <ExternalLink text={shortenHash(obj.spec.manifest)} href={quayURLFor(obj)} />
+      </TableData>
+    </TableRow>
+  );
+};
+
+export const ImageManifestVulnTableHeader = () => [
+  {
+    title: 'Image Name',
+    sortField: 'spec.image',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[0] },
+  },
+  {
+    title: 'Namespace',
+    sortField: 'metadata.namespace',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[1] },
+  },
+  {
+    title: 'Highest Severity',
+    sortField: 'status.highestSeverity',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[2] },
+  },
+  {
+    title: 'Affected Pods',
+    props: { className: tableColumnClasses[3] },
+  },
+  {
+    title: 'Fixable',
+    sortField: 'status.fixableCount',
+    transforms: [sortable],
+    props: { className: tableColumnClasses[4] },
+  },
+  {
+    title: 'Manifest',
+    props: { className: tableColumnClasses[5] },
+  },
+];
+
+export const ImageManifestVulnList: React.FC<ImageManifestVulnListProps> = (props) => {
+  return (
+    <Table
+      {...props}
+      aria-label="Image Manifest Vulns"
+      Header={ImageManifestVulnTableHeader}
+      Row={ImageManifestVulnTableRow}
+      virtualize
+    />
+  );
+};
+
+export const ImageManifestVulnPage: React.FC<ImageManifestVulnPageProps> = (props) => {
+  const namespace = _.get(props.match, 'params.ns');
+
+  return (
+    <MultiListPage
+      {...props}
+      namespace={namespace}
+      resources={[
+        {
+          kind: referenceForModel(ImageManifestVulnModel),
+          namespace,
+          namespaced: true,
+          prop: 'imageManifestVuln',
+        },
+      ]}
+      flatten={(resources) => _.get(resources.imageManifestVuln, 'data', [])}
+      title="Image Manifest Vulnerabilities"
+      showTitle
+      ListComponent={ImageManifestVulnList}
+    />
+  );
+};
+
+export type ImageManifestVulnDetailsPageProps = {
+  match: match<{ ns: string; name: string }>;
+};
+
+export type ImageManifestVulnPageProps = {
+  namespace?: string;
+  match?: match<{ ns?: string }>;
+};
+
+export type ImageManifestVulnListProps = {
+  data: ImageManifestVuln[];
+};
+
+export type ImageManifestVulnDetailsProps = {
+  obj: ImageManifestVuln;
+};
+
+export type ImageManifestVulnTableRowProps = {
+  obj: ImageManifestVuln;
+  index: number;
+  key: string;
+  style: object;
+};
+
+export type ImageManifestVulnListTableHeaderProps = {};
+
+export type AffectedPodsProps = {
+  obj: ImageManifestVuln;
+};
+
+export type ImageVulnerabilitiesTableProps = {
+  features: Feature[];
+};
+
+export type ImageVulnerabilityRowProps = {
+  vulnerability: Vulnerability;
+  currentVersion: string;
+  packageName: string;
+};
+
+ImageManifestVulnPage.displayName = 'ImageManifestVulnPage';
+ImageManifestVulnList.displayName = 'ImageManifestVulnList';
+AffectedPods.displayName = 'AffectedPods';
+ImageVulnerabilitiesTable.displayName = 'ImageVulnerabilitiesTable';
+ImageManifestVulnTableRow.displayName = 'ImageManifestVulnTableRow';
+ImageVulnerabilityRow.displayName = 'ImageVulnerabilityRow';

--- a/frontend/packages/container-security/src/const.ts
+++ b/frontend/packages/container-security/src/const.ts
@@ -8,11 +8,23 @@ import {
   chart_color_black_500 as black500,
   /* eslint-enable @typescript-eslint/camelcase */
 } from '@patternfly/react-tokens';
+import { Map as ImmutableMap } from 'immutable';
+import { ImageManifestVuln } from './types';
 
 export const SecurityLabellerFlag = 'SECURITY_LABELLER';
 
-export const VulnPriority = {
-  Defcon1: {
+export enum Priority {
+  Defcon1 = 'Defcon1',
+  Critical = 'Critical',
+  High = 'High',
+  Medium = 'Medium',
+  Low = 'Low',
+  Negligible = 'Negligible',
+  Unknown = 'Unknown',
+}
+
+export const vulnPriority = ImmutableMap<Priority, VulnPriorityDescription>()
+  .set(Priority.Defcon1, {
     color: red400,
     description:
       'Defcon1 is a Critical problem which has been manually highlighted by the Quay team. It requires immediate attention.',
@@ -21,8 +33,8 @@ export const VulnPriority = {
     score: 11,
     title: 'Defcon 1',
     value: 'Defcon1',
-  },
-  Critical: {
+  })
+  .set(Priority.Critical, {
     color: red300,
     description:
       'Critical is a world-burning problem, exploitable for nearly all people in a installation of the package. Includes remote root privilege escalations, or massive data loss.',
@@ -31,8 +43,8 @@ export const VulnPriority = {
     score: 10,
     title: 'Critical',
     value: 'Critical',
-  },
-  High: {
+  })
+  .set(Priority.High, {
     color: red100,
     description:
       'High is a real problem, exploitable for many people in a default installation. Includes serious remote denial of services, local root privilege escalations, or data loss.',
@@ -41,18 +53,8 @@ export const VulnPriority = {
     score: 9,
     title: 'High',
     value: 'High',
-  },
-  Low: {
-    color: orange300,
-    description:
-      'Low is a security problem, but is hard to exploit due to environment, requires a user-assisted attack, a small install base, or does very little damage.',
-    index: 4,
-    level: 'warning',
-    score: 3,
-    title: 'Low',
-    value: 'Low',
-  },
-  Medium: {
+  })
+  .set(Priority.Medium, {
     color: gold400,
     description:
       'Medium is a real security problem, and is exploitable for many people. Includes network daemon denial of service attacks, cross-site scripting, and gaining user privileges.',
@@ -61,8 +63,18 @@ export const VulnPriority = {
     score: 6,
     title: 'Medium',
     value: 'Medium',
-  },
-  Negligible: {
+  })
+  .set(Priority.Low, {
+    color: orange300,
+    description:
+      'Low is a security problem, but is hard to exploit due to environment, requires a user-assisted attack, a small install base, or does very little damage.',
+    index: 4,
+    level: 'warning',
+    score: 3,
+    title: 'Low',
+    value: 'Low',
+  })
+  .set(Priority.Negligible, {
     color: black500,
     description:
       'Negligible is technically a security problem, but is only theoretical in nature, requires a very special situation, has almost no install base, or does no real damage.',
@@ -71,8 +83,8 @@ export const VulnPriority = {
     score: 1,
     title: 'Negligible',
     value: 'Negligible',
-  },
-  Unknown: {
+  })
+  .set(Priority.Unknown, {
     color: black500,
     description:
       'Unknown is either a security problem that has not been assigned to a priority yet or a priority that our system did not recognize',
@@ -81,5 +93,35 @@ export const VulnPriority = {
     score: 0,
     title: 'Unknown',
     value: 'Unknown',
-  },
+  });
+
+export type VulnPriorityDescription = {
+  color: any;
+  description: string;
+  index: number;
+  level: 'error' | 'warning' | 'info';
+  score: number;
+  title: string;
+  value: string;
+};
+
+export const totalFor = (priority: Priority) => (obj: ImageManifestVuln) => {
+  switch (priority) {
+    case Priority.Defcon1:
+      return obj.status.defcon1Count || 0;
+    case Priority.Critical:
+      return obj.status.criticalCount || 0;
+    case Priority.High:
+      return obj.status.highCount || 0;
+    case Priority.Medium:
+      return obj.status.mediumCount || 0;
+    case Priority.Low:
+      return obj.status.lowCount || 0;
+    case Priority.Negligible:
+      return obj.status.negligibleCount || 0;
+    case Priority.Unknown:
+      return obj.status.unknownCount || 0;
+    default:
+      return 0;
+  }
 };

--- a/frontend/packages/container-security/src/kebab-actions.ts
+++ b/frontend/packages/container-security/src/kebab-actions.ts
@@ -1,0 +1,35 @@
+import { K8sKind, PodKind } from '@console/internal/module/k8s';
+import { referenceForModel } from '@console/internal/module/k8s/k8s';
+import { KebabAction, KebabOption } from '@console/internal/components/utils/kebab';
+import { PodModel } from '@console/internal/models';
+import { ImageManifestVulnModel } from './models';
+
+const listPathFor = (namespace: string, imageID: string) =>
+  [
+    '/k8s',
+    namespace === '' ? 'all-namespaces' : `ns/${namespace}`,
+    referenceForModel(ImageManifestVulnModel),
+    `?name=sha256.${imageID.split('sha256:')[1]}`,
+  ].join('/');
+
+const ViewImageVulnerabilities = (model: K8sKind, obj: PodKind): KebabOption => {
+  const ready = (obj.status?.containerStatuses || []).length > 0;
+
+  return {
+    label: 'View Image Vulnerabilities',
+    hidden: !ready,
+    href: ready ? listPathFor(obj.metadata.namespace, obj.status.containerStatuses[0].imageID) : '',
+    accessReview: {
+      group: ImageManifestVulnModel.apiGroup,
+      resource: ImageManifestVulnModel.plural,
+      namespace: obj.metadata.namespace,
+      verb: 'list',
+    },
+  };
+};
+
+export const getKebabActionsForKind = (model: K8sKind): KebabAction[] => {
+  return model && (referenceForModel(model) === referenceForModel(PodModel) || model.kind === 'Pod')
+    ? [ViewImageVulnerabilities]
+    : [];
+};

--- a/frontend/packages/container-security/src/models.ts
+++ b/frontend/packages/container-security/src/models.ts
@@ -6,7 +6,7 @@ export const ImageManifestVulnModel: K8sKind = {
   labelPlural: 'ImageManifestVuln',
   apiGroup: 'secscan.quay.redhat.com',
   apiVersion: 'v1alpha1',
-  abbr: 'VULN',
+  abbr: 'IMV',
   namespaced: true,
   crd: true,
   plural: 'imagemanifestvulns',

--- a/frontend/packages/container-security/src/types.ts
+++ b/frontend/packages/container-security/src/types.ts
@@ -15,7 +15,7 @@ export type Vulnerability = {
   link: string;
   fixedby: string;
   severity: string;
-  metadata: string;
+  metadata?: string;
 };
 
 export type ImageManifestVulnSpec = {
@@ -36,7 +36,7 @@ export type ImageManifestVulnStatus = {
   criticalCount?: number;
   defcon1Count?: number;
   fixableCount?: number;
-  afftectedPods: { [path: string]: string[] };
+  affectedPods: { [path: string]: string[] };
 };
 
 export type ImageManifestVuln = {

--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -125,7 +125,7 @@ export const DefaultList = (props) => {
     />
   );
 };
-DefaultList.displayName = DefaultList;
+DefaultList.displayName = 'DefaultList';
 
 export const DefaultPage = (props) => (
   <ListPage

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -51,6 +51,7 @@ import {
   requirePrometheus,
 } from './graphs';
 import { VolumesTable } from './volumes-table';
+import { PodModel } from '../models';
 
 // Only request metrics if the device's screen width is larger than the
 // breakpoint where metrics are visible.
@@ -88,7 +89,10 @@ const fetchPodMetrics = (namespace: string): Promise<UIActions.PodMetrics> => {
   return Promise.all(promises).then((data: any[]) => _.assign({}, ...data));
 };
 
-export const menuActions = [...Kebab.factory.common];
+export const menuActions = [
+  ...Kebab.getExtensionsActionsForKind(PodModel),
+  ...Kebab.factory.common,
+];
 
 const tableColumnClasses = [
   '',


### PR DESCRIPTION
### Description

Improves on the OpenShift integration with Quay via the [Container Security Operator](https://github.com/quay/container-security-operator) (CSO) console extension. 

### Changes

- List view for `ImageManifestVuln`
- Detail view for `ImageManifestVuln`
- Nav item for `ImageManifestVuln` under **Administration**
- Kebab action for `Pods` to view associated `ImageManifestVulns` (if any)

### Screenshots

**`ImageManifestVuln` list view:**
![Screenshot_20191227_145932](https://user-images.githubusercontent.com/11700385/71535270-885bcd80-28b9-11ea-892b-617e926d887e.png)

**`ImageManifestVuln` detail view:**
![Screenshot_20200103_120459](https://user-images.githubusercontent.com/11700385/71746950-35d36180-2e23-11ea-8734-d76f99733450.png)

**`ImageManifestVuln` detail view (continued):**
![Screenshot_20200106_165334](https://user-images.githubusercontent.com/11700385/71859818-2ebb8600-30a5-11ea-88f8-5b4b31729025.png)


**`ImageManifestVuln` detail view (affected pods):**
![Screenshot_20200103_120530](https://user-images.githubusercontent.com/11700385/71746972-4aaff500-2e23-11ea-872f-ac9b16f303f7.png)

**Kebab action on `Pods` list view:**
![Screenshot_20200106_165502](https://user-images.githubusercontent.com/11700385/71859877-5ca0ca80-30a5-11ea-8885-1928078aa3d7.png)

### Future Work

- **Image Security** tab on `Pod` detail view (requires https://github.com/openshift/console/pull/3917)
- End-to-end tests using Protractor

Addresses https://issues.redhat.com/browse/PROJQUAY-119