### PR TITLE
Update modal styling to match PF4 modal-box

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/editFlavorView.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/editFlavorView.ts
@@ -2,7 +2,7 @@ import { $ } from 'protractor';
 
 export const flavorDropdownId = '#vm-flavor-modal-flavor-dropdown';
 
-export const modalTitle = () => $('.modal-title');
+export const modalTitle = () => $('[data-test-id="modal-title"]');
 export const flavorDropdownText = () =>
   $('.kubevirt-vm-flavor-modal__dropdown .pf-c-dropdown__toggle-text');
 export const saveButton = () => $('#confirm-action');

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/editCDView.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/editCDView.ts
@@ -11,7 +11,7 @@ export const cdTypeSelect = (number) => $(`#cd-rom-modal-select-type-cd-drive-${
 export const cdStorageClassSelect = (number) => $(`#cd-url-storageclass-input-cd-drive-${number}`);
 export const cdPVCSelect = (number) => $(`#cdrom-pvc-input-cd-drive-${number}`);
 
-export const modalTitle = $('.modal-title');
+export const modalTitle = $('[data-test-id="modal-title"]');
 export const saveButton = $('#cdrom-submit');
 export const cdValue = $('#cdrom-value');
 export const cdAddBtn = $('#vm-cd-add-btn');

--- a/frontend/public/components/factory/modal.tsx
+++ b/frontend/public/components/factory/modal.tsx
@@ -67,7 +67,9 @@ export const ModalTitle: React.SFC<ModalTitleProps> = ({
   className = 'modal-header',
 }) => (
   <div className={className}>
-    <h4 className="modal-title">{children}</h4>
+    <h1 className="pf-c-title pf-m-2xl" data-test-id="modal-title">
+      {children}
+    </h1>
   </div>
 );
 

--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -38,7 +38,8 @@
 
 .modal-body-inner-shadow-covers {
   min-height: 100%;
-  padding: ($grid-gutter-width / 2) $modal-title-padding-horizontal;
+  // --pf-c-modal-box--Padding* will not render correctly here so applying pf4 spacer values
+  padding: 0 var(--pf-global--spacer--xl) var(--pf-global--spacer--xl);
   @include scroll-shadows-vertical-covers;
   width: 100%;
 
@@ -71,8 +72,19 @@
       padding-bottom: 100px;
     }
     // Dropdown workaround: use when modal content is short and cannot expand
-    &--no-inner-scroll .modal-body {
-      overflow-y: visible ;
+    &--no-inner-scroll {
+      .modal-body {
+        overflow-y: visible !important;
+      }
+      .modal-body-content {
+        background-color: var(--pf-global--BackgroundColor--100);
+      }
+      .modal-body-inner-shadow-covers {
+        padding-bottom: var(--pf-global--spacer--lg);
+      }
+      .modal-footer {
+        padding-top: 0;
+      }
     }
   }
 }
@@ -91,7 +103,14 @@
 }
 
 .modal-footer {
+  background-color: var(--pf-global--BackgroundColor--100);
   margin-top: 0;
+  padding: var(--pf-global--spacer--md) var(--pf-global--spacer--xl) var(--pf-global--spacer--xl) var(--pf-global--spacer--xl);
+}
+
+.modal-header {
+  background-color:var(--pf-global--BackgroundColor--100);
+  padding: var(--pf-global--spacer--xl) var(--pf-global--spacer--xl) var(--pf-global--spacer--lg);
 }
 
 .toleration-modal__field, .taint-modal__field  {

--- a/frontend/public/components/modals/create-namespace-modal.jsx
+++ b/frontend/public/components/modals/create-namespace-modal.jsx
@@ -111,7 +111,7 @@ const CreateNamespaceModal = connect(
         <form
           onSubmit={this._submit.bind(this)}
           name="form"
-          className="modal-content modal-content--no-inner-scroll co-p-new-user-modal"
+          className="modal-content modal-content--no-inner-scroll"
         >
           <ModalTitle>Create {label}</ModalTitle>
           <ModalBody>

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -42,10 +42,6 @@ kbd {
   text-align: left;
 }
 
-.modal-title {
-  font-size: $font-size-base;
-}
-
 // fix bug where monaco-aria-container is visible in Firefox but shouldn't be
 // bug occurs only if the suggestions overlay has been enabled
 .monaco-aria-container {


### PR DESCRIPTION
https://issues.redhat.com/browse/CONSOLE-1966

<img width="864" alt="Screen Shot 2020-01-06 at 7 02 47 PM" src="https://user-images.githubusercontent.com/1874151/71857917-3552f900-30b7-11ea-9873-c76e661c920b.png">

<img width="326" alt="Screen Shot 2020-01-06 at 7 01 29 PM" src="https://user-images.githubusercontent.com/1874151/71857838-f9b82f00-30b6-11ea-8238-342e39e5e823.png">

![modal-resize](https://user-images.githubusercontent.com/1874151/71857772-c4abdc80-30b6-11ea-82a5-35e9b48cb24e.gif)
