### PR TITLE
Bug 1786259: Fix Edit YAML link on NAD creation page

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/models/index.ts
@@ -11,6 +11,7 @@ export const NetworkAttachmentDefinitionModel: K8sKind = {
   kind: 'NetworkAttachmentDefinition',
   id: 'network-attachment-definition',
   crd: true,
+  legacyPluralURL: true,
 };
 
 export const SriovNetworkNodePolicyModel: K8sKind = {


### PR DESCRIPTION
This PR fixes an issue where the Edit YAML link on the create network attachment definition form page leads to a page with a 404 error. The issue was caused by changes made in https://github.com/openshift/console/pull/3690.

@rawagner @mareklibra  