### PR TITLE
Fix race condition for kebab actions

### DIFF
--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -58,7 +58,7 @@ export const actions = Object.freeze({
   edit: 'Edit',
   delete: 'Delete',
 });
-export const actionForLabel = (label: string) => $(`[data-test-action="${label}"]`);
+export const actionForLabel = (label: string) => $(`[data-test-action="${label}"]:not(.pf-m-disabled)`);
 
 export const filterForName = async (name: string) => {
   await browser.wait(until.presenceOf(textFilter));

--- a/frontend/public/components/utils/kebab.tsx
+++ b/frontend/public/components/utils/kebab.tsx
@@ -223,7 +223,10 @@ export const ResourceKebab = connectToModel((props: ResourceKebabProps) => {
   if (!kindObj) {
     return null;
   }
-  const options = _.reject(actions.map((a) => a(kindObj, resource)), 'hidden');
+  const options = _.reject(
+    actions.map((a) => a(kindObj, resource)),
+    'hidden',
+  );
   return (
     <Kebab
       options={options}


### PR DESCRIPTION
Update data test attribute for kebab items so that they will not be selected or clicked before access review is confirmed.