### PR TITLE
Bug 1796078: Filter OLM operators by architecture

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
+	"runtime"
 
 	"io/ioutil"
 	"net/http"
@@ -190,6 +191,12 @@ func main() {
 		StatuspageID:         *fStatuspageID,
 		DocumentationBaseURL: documentationBaseURL,
 		LoadTestFactor:       *fLoadTestFactor,
+	}
+
+	// if !in-cluster (dev) we should not pass these values to the frontend
+	if *fK8sMode == "in-cluster" {
+		srv.GOARCH = runtime.GOARCH
+		srv.GOOS = runtime.GOOS
 	}
 
 	if (*fKubectlClientID == "") != (*fKubectlClientSecret == "" && *fKubectlClientSecretFile == "") {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -4,10 +4,16 @@ import * as _ from 'lodash';
 import LazyLoad from 'react-lazyload';
 import { CatalogItemHeader, CatalogTile } from '@patternfly/react-catalog-view-extension';
 import * as classNames from 'classnames';
-import { Button, Modal } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { ExternalLink } from '@console/internal/components/utils';
-
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Modal,
+  Title,
+} from '@patternfly/react-core';
 import {
   COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY,
   GreenCheckCircleIcon,
@@ -19,6 +25,54 @@ import { SubscriptionModel } from '../../models';
 import { OperatorHubItemDetails } from './operator-hub-item-details';
 import { communityOperatorWarningModal } from './operator-hub-community-provider-modal';
 import { OperatorHubItem, InstalledState, ProviderType, CapabilityLevel } from './index';
+
+const osBaseLabel = 'operatorframework.io/os.';
+const targetGOOSLabel = window.SERVER_FLAGS.GOOS ? `${osBaseLabel}${window.SERVER_FLAGS.GOOS}` : '';
+const archBaseLabel = 'operatorframework.io/arch.';
+const targetGOARCHLabel = window.SERVER_FLAGS.GOARCH
+  ? `${archBaseLabel}${window.SERVER_FLAGS.GOARCH}`
+  : '';
+// if no label present, these are the assumed defaults
+const archDefaultAMD64Label = 'operatorframework.io/arch.amd64';
+const osDefaultLinuxLabel = 'operatorframework.io/os.linux';
+const filterByArchAndOS = (items: OperatorHubItem[]): OperatorHubItem[] => {
+  if (!window.SERVER_FLAGS.GOARCH || !window.SERVER_FLAGS.GOOS) {
+    return items;
+  }
+  return items.filter((item: OperatorHubItem) => {
+    // - if the operator has no flags, treat it with the defaults
+    // - if it has any flags, it must list all flags (no defaults applied)
+    const relevantLabels = _.reduce(
+      item?.obj?.metadata?.labels,
+      (result, value: string, label: string): { arch: string[]; os: string[] } => {
+        if (label.includes(archBaseLabel) && value === 'supported') {
+          result.arch.push(label);
+        }
+        if (label.includes(osBaseLabel) && value === 'supported') {
+          result.os.push(label);
+        }
+        return result;
+      },
+      {
+        arch: [],
+        os: [],
+      },
+    );
+
+    if (_.isEmpty(relevantLabels.os)) {
+      relevantLabels.os.push(osDefaultLinuxLabel);
+    }
+
+    if (_.isEmpty(relevantLabels.os)) {
+      relevantLabels.arch.push(archDefaultAMD64Label);
+    }
+
+    return (
+      _.includes(relevantLabels.os, targetGOOSLabel) &&
+      _.includes(relevantLabels.arch, targetGOARCHLabel)
+    );
+  });
+};
 
 const badge = (text: string) => (
   <span key="1" className="pf-c-badge pf-m-read">
@@ -233,12 +287,14 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
   const [detailsItem, setDetailsItem] = React.useState(null);
   const [showDetails, setShowDetails] = React.useState(false);
 
+  const filteredItems = filterByArchAndOS(props.items);
+
   React.useEffect(() => {
     const detailsItemID = new URLSearchParams(window.location.search).get('details-item');
-    const currentItem = _.find(props.items, { uid: detailsItemID });
+    const currentItem = _.find(filteredItems, { uid: detailsItemID });
     setDetailsItem(currentItem);
     setShowDetails(!_.isNil(currentItem));
-  }, [props.items]);
+  }, [filteredItems]);
 
   const showCommunityOperator = (item: OperatorHubItem) => (ignoreWarning = false) => {
     const params = new URLSearchParams(window.location.search);
@@ -332,10 +388,28 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
     detailsItem &&
     `/k8s/ns/${detailsItem.subscription.metadata.namespace}/${SubscriptionModel.plural}/${detailsItem.subscription.metadata.name}?showDelete=true`;
 
+  if (_.isEmpty(filteredItems)) {
+    return (
+      <>
+        <EmptyState variant={EmptyStateVariant.full} className="co-status-card__alerts-msg">
+          <Title headingLevel="h5" size="lg">
+            No operators available
+          </Title>
+          {window.SERVER_FLAGS.GOOS && window.SERVER_FLAGS.GOARCH && (
+            <EmptyStateBody>
+              There are no operators that match operating system {window.SERVER_FLAGS.GOOS} and
+              architecture {window.SERVER_FLAGS.GOARCH}.
+            </EmptyStateBody>
+          )}
+        </EmptyState>
+      </>
+    );
+  }
+
   return (
     <>
       <TileViewPage
-        items={props.items}
+        items={filteredItems}
         itemsSorter={(itemsToSort) => _.sortBy(itemsToSort, ({ name }) => name.toLowerCase())}
         getAvailableCategories={determineCategories}
         getAvailableFilters={determineAvailableFilters}

--- a/frontend/public/declarations.d.ts
+++ b/frontend/public/declarations.d.ts
@@ -32,6 +32,8 @@ declare interface Window {
     prometheusTenancyBaseURL: string;
     requestTokenURL: string;
     statuspageID: string;
+    GOARCH: string;
+    GOOS: string;
   };
   windowError?: boolean;
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: Function;

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -65,6 +65,8 @@ type jsGlobals struct {
 	StatuspageID             string `json:"statuspageID"`
 	DocumentationBaseURL     string `json:"documentationBaseURL"`
 	LoadTestFactor           int    `json:"loadTestFactor"`
+	GOARCH                   string `json:"GOARCH"`
+	GOOS                     string `json:"GOOS"`
 }
 
 type Server struct {
@@ -94,6 +96,8 @@ type Server struct {
 	// A lister for resource listing of a particular kind
 	MonitoringDashboardConfigMapLister *ResourceLister
 	HelmChartRepoProxyConfig           *proxy.Config
+	GOARCH                             string
+	GOOS                               string
 }
 
 func (s *Server) authDisabled() bool {
@@ -350,6 +354,8 @@ func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 		StatuspageID:         s.StatuspageID,
 		DocumentationBaseURL: s.DocumentationBaseURL.String(),
 		LoadTestFactor:       s.LoadTestFactor,
+		GOARCH:               s.GOARCH,
+		GOOS:                 s.GOOS,
 	}
 
 	if !s.authDisabled() {


### PR DESCRIPTION
4.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1796078
4.3 clone https://bugzilla.redhat.com/show_bug.cgi?id=1796079
4.2 clone https://bugzilla.redhat.com/show_bug.cgi?id=1796080

https://issues.redhat.com/browse/CONSOLE-2004

Based on the following proposal: https://github.com/operator-framework/olm-book/pull/29
OLM implementation coming here: https://github.com/operator-framework/operator-lifecycle-manager/pull/1220

- Gets the architecture & passes it to the front end via `window.SERVER_FLAGS.clusterArchitecture`
- TODO: filter operators on OLM installation page based on architecture + annotation 

The filtering portion of this may come as a separate PR, depending on complexity.   We will need 4.3 & (likely) 4.2 backports.

Labels will look like the following:

```yaml
labels:
    operatorframework.io/arch.<GOARCH>: supported
    operatorframework.io/os.<GOOS>: supported
```
specifically:

```yaml
labels:
    operatorframework.io/os.windows: supported
    operatorframework.io/os.linux: supported
```
Furthermore, rules are as follows:

```yaml
labels:
    # if no OS label, then treat it as if the following:
    operatorframework.io/os.linux: supported
```
```yaml
labels:
    # if no arch label, treat it as the following:
    operatorframework.io/arch.amd64: supported
```

Simple Empty State if there are no operators that pass the filter:
![Screen Shot 2020-01-28 at 10 44 10 PM](https://user-images.githubusercontent.com/280512/73327927-c8e69800-4225-11ea-88a6-1ccb26ab960e.png)


/assign @spadgett  @TheRealJon 