### PR TITLE
Sync data between Create Operand YAML and Form 

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
@@ -401,6 +401,19 @@ describe('Using OLM descriptor components', () => {
       });
     });
 
+  // Delete operand instance created in proir steps. Fixes a failure when trying to create a
+  // duplicate operand in the 'successfully creates operand using form' step.
+  // TODO Test cases need to be fixed so that they will pass independently. They should
+  // be self-contained and not depend on state from previous steps.
+  it('deletes operand', async () => {
+    await browser.get(
+      `${appHost}/ns/${testName}/clusterserviceversions/${testCSV.metadata.name}/${testCRD.spec.group}~${testCRD.spec.version}~${testCRD.spec.names.kind}`,
+    );
+    await crudView.isLoaded();
+    await crudView.resourceRowsPresent();
+    await crudView.deleteRow(testCR.kind)(testCR.metadata.name);
+  });
+
   it('displays form for creating operand', async () => {
     await $$('[data-test-id=breadcrumb-link-1]').click();
     await browser.wait(until.visibilityOf(element(by.buttonText('Create App'))));
@@ -488,7 +501,7 @@ describe('Using OLM descriptor components', () => {
     await browser.wait(until.presenceOf($('#metadata\\.name')));
     await element(by.buttonText('Create')).click();
     await crudView.isLoaded();
-    await browser.wait(until.visibilityOf(operatorView.operandLink(testCR.metadata.name)));
+    await browser.wait(until.elementToBeClickable(operatorView.operandLink(testCR.metadata.name)));
     await operatorView.operandLink(testCR.metadata.name).click();
     await browser.wait(until.presenceOf($('.loading-box__loaded')), 5000);
 

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -163,8 +163,8 @@ $co-affinity-row-margin: 15px;
   --pf-c-accordion__toggle-text--hover--Color: var(--pf-global--Color--100) !important;
   --pf-c-accordion__toggle-text--hover--FontWeight: 600 !important;
 
-  .pf-c-accordion__toggle {
-    border-left: none !important;
+  .pf-c-accordion__toggle::before {
+    display: none;
   }
 
   h3 {

--- a/frontend/public/components/create-yaml.tsx
+++ b/frontend/public/components/create-yaml.tsx
@@ -16,7 +16,14 @@ import {
 import { ErrorPage404 } from './error';
 
 export const CreateYAML = connectToPlural((props: CreateYAMLProps) => {
-  const { match, kindsInFlight, kindObj, hideHeader = false, resourceObjPath } = props;
+  const {
+    match,
+    kindsInFlight,
+    kindObj,
+    hideHeader = false,
+    onChange = () => null,
+    resourceObjPath,
+  } = props;
   const { params } = match;
 
   if (!kindObj) {
@@ -55,6 +62,7 @@ export const CreateYAML = connectToPlural((props: CreateYAMLProps) => {
       header={header}
       hideHeader={hideHeader}
       resourceObjPath={resourceObjPath}
+      onChange={onChange}
     />
   );
 });
@@ -94,6 +102,7 @@ export type CreateYAMLProps = {
   header?: string;
   hideHeader?: boolean;
   resourceObjPath?: (obj: K8sResourceKind, kind: K8sResourceKindReference) => string;
+  onChange?: (yaml: string) => void;
 };
 
 export type EditYAMLPageProps = {

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -83,7 +83,7 @@ const desktopGutter = 30;
  * This component loads the entire Monaco editor library with it.
  * Consider using `AsyncComponent` to dynamically load this component when needed.
  */
-/** @augments {React.Component<{obj?: any, create: boolean, kind: string, redirectURL?: string, resourceObjPath?: (obj: K8sResourceKind, objRef: string) => string}>} */
+/** @augments {React.Component<{obj?: any, create: boolean, kind: string, redirectURL?: string, resourceObjPath?: (obj: K8sResourceKind, objRef: string) => string}, onChange?: (yaml: string) => void>} */
 const EditYAML_ = connect(stateToProps)(
   class EditYAML extends React.Component {
     constructor(props) {
@@ -687,7 +687,14 @@ const EditYAML_ = connect(stateToProps)(
         return <Loading />;
       }
 
-      const { connectDropTarget, isOver, canDrop, create, yamlSamplesList } = this.props;
+      const {
+        connectDropTarget,
+        isOver,
+        canDrop,
+        create,
+        yamlSamplesList,
+        onChange = () => null,
+      } = this.props;
       const klass = classNames('co-file-dropzone-container', {
         'co-file-dropzone--drop-over': isOver,
       });
@@ -790,7 +797,9 @@ const EditYAML_ = connect(stateToProps)(
                       value={yaml}
                       options={options}
                       editorDidMount={this.editorDidMount}
-                      onChange={(newValue) => this.setState({ yaml: newValue })}
+                      onChange={(newValue) =>
+                        this.setState({ yaml: newValue }, () => onChange(newValue))
+                      }
                     />
                     <div className="yaml-editor__buttons" ref={(r) => (this.buttons = r)}>
                       {customAlerts}


### PR DESCRIPTION
Sync data between yaml and form editors in the create operand workflow. Also fix visual issue where field group names overlap left blue border. It appears that the implementation of the blue border on patternfly accordions changed at some point and our css to override those styles was no longer working as expected.

Also update olm descriptor integration tests to delete the test operand between testing list/details views and creation form. There was previously no cleanup between these tests, which was causing a failure when attempting to create a new operand during the latter steps.

![video-convert](https://user-images.githubusercontent.com/22625502/73000215-8446a100-3dce-11ea-9d59-91427890073c.gif)
 