### PR TITLE
Add Capability Levels to OperatorHub items

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import * as _ from 'lodash';
+import * as classNames from 'classnames';
 import { Modal } from 'patternfly-react';
 import { Button } from '@patternfly/react-core';
 import {
@@ -6,12 +8,53 @@ import {
   PropertiesSidePanel,
   PropertyItem,
 } from '@patternfly/react-catalog-view-extension';
+import { CheckCircleIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { history, ExternalLink, HintBlock } from '@console/internal/components/utils';
 import { RH_OPERATOR_SUPPORT_POLICY_LINK } from '@console/internal/const';
 import { MarkdownView } from '../clusterserviceversion';
 import { SubscriptionModel } from '../../models';
 import { OperatorHubItem } from './index';
+
+const CapabilityLevel: React.FC<CapabilityLevelProps> = ({ capabilityLevel }) => {
+  const levels = [
+    'Basic Install',
+    'Seamless Upgrades',
+    'Full Lifecycle',
+    'Deep Insights',
+    'Auto Pilot',
+  ];
+  const capabilityLevelIndex = _.indexOf(levels, capabilityLevel);
+
+  return (
+    <ul className="properties-side-panel-pf-property-value__capability-levels">
+      {levels.map((level, i) => {
+        const active = capabilityLevelIndex >= i;
+        return (
+          <li
+            className={classNames('properties-side-panel-pf-property-value__capability-level', {
+              'properties-side-panel-pf-property-value__capability-level--active': active,
+            })}
+            key={level}
+          >
+            {active && (
+              <CheckCircleIcon
+                color="var(--pf-global--primary-color--100)"
+                className="properties-side-panel-pf-property-value__capability-level-icon"
+                title="Checked"
+              />
+            )}
+            {level}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+type CapabilityLevelProps = {
+  capabilityLevel: string;
+};
 
 export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
   item,
@@ -37,6 +80,7 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
     support,
     catalogSource,
     catalogSourceNamespace,
+    capabilityLevel,
   } = item;
   const notAvailable = <span className="properties-side-panel-pf-property-label">N/A</span>;
 
@@ -121,6 +165,16 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
                   </Button>
                 )}
                 <PropertyItem label="Operator Version" value={version || notAvailable} />
+                <PropertyItem
+                  label="Capability Level"
+                  value={
+                    capabilityLevel ? (
+                      <CapabilityLevel capabilityLevel={capabilityLevel} />
+                    ) : (
+                      notAvailable
+                    )
+                  }
+                />
                 <PropertyItem label="Provider Type" value={providerType || notAvailable} />
                 <PropertyItem label="Provider" value={provider || notAvailable} />
                 <PropertyItem label="Repository" value={repository || notAvailable} />

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -1,3 +1,6 @@
+$catalog-capability-level-icon-left: -20px;
+$catalog-capability-level-icon-top: 4px;
+$catalog-capability-level-inactive-color: var(--pf-global--Color--400);
 $catalog-item-icon-size-lg: 40px;
 $catalog-item-icon-size-sm: 24px;
 $co-modal-ignore-warning-icon-width: 30px;
@@ -233,6 +236,51 @@ $co-modal-ignore-warning-icon-width: 30px;
 
 .properties-side-panel-pf-property-label {
   font-size: ($font-size-base - 1);
+}
+
+.properties-side-panel-pf-property-value__capability-level {
+  color: $catalog-capability-level-inactive-color;
+  margin-bottom: 5px;
+  position: relative;
+
+  &--active {
+    color: inherit;
+
+    &::before {
+      display: none; // hide empty circle since icon is present
+    }
+  }
+
+  &::before { // empty circle
+    border: 1px solid $catalog-capability-level-inactive-color;
+    border-radius: 10px;
+    content: "";
+    height: 14px;
+    left: $catalog-capability-level-icon-left;
+    position: absolute;
+    top: $catalog-capability-level-icon-top;
+    width: 14px;
+  }
+
+  &:not(:last-child)::after { // pipe after circle
+    background: $catalog-capability-level-inactive-color;
+    content: "";
+    height: 6px;
+    left: -13px;
+    position: absolute;
+    top: 22px;
+    width: 1px;
+  }
+}
+
+.properties-side-panel-pf-property-value__capability-level-icon {
+  left: $catalog-capability-level-icon-left;
+  position: absolute;
+  top: $catalog-capability-level-icon-top;
+}
+
+.properties-side-panel-pf-property-value__capability-levels {
+  list-style: none;
 }
 
 // set font size to 14px


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/CONSOLE-1972

Note I have not added the help popover as it will not work with the existing modal, but the changes in #3757 should allow for its addition.

![Screen Shot 2020-01-08 at 10 11 33 AM](https://user-images.githubusercontent.com/895728/71992819-0bf3b380-3204-11ea-9e98-d2fc83141288.png)
![Screen Shot 2020-01-08 at 10 11 42 AM](https://user-images.githubusercontent.com/895728/71992820-0bf3b380-3204-11ea-9007-eec4db34666f.png)
![Screen Shot 2020-01-08 at 10 11 53 AM](https://user-images.githubusercontent.com/895728/71992821-0bf3b380-3204-11ea-99e3-f37d6e6bada6.png)


