### PR TITLE
Bug 1786418: The filter does not work on catalog sources list page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
@@ -471,6 +471,7 @@ export const CatalogSourceListPage: React.FC<CatalogSourceListPageProps> = (prop
     createProps={{ to: `/k8s/cluster/${referenceForModel(CatalogSourceModel)}/~new` }}
     flatten={(data) => flatten({ operatorHub: props.obj, ...data })}
     ListComponent={CatalogSourceList}
+    textFilter="catalog-source-name"
     resources={[
       {
         isList: true,

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -24,6 +24,8 @@ export const fuzzyCaseInsensitive = (a: string, b: string): boolean =>
 export const tableFilters: TableFilterMap = {
   name: (filter, obj) => fuzzyCaseInsensitive(filter, obj.metadata.name),
 
+  'catalog-source-name': (filter, obj) => fuzzyCaseInsensitive(filter, obj.name),
+
   'alert-name': (filter, alert) => fuzzyCaseInsensitive(filter, _.get(alert, 'labels.alertname')),
 
   'alert-state': (filter, alert) => filter.selected.has(alertState(alert)),


### PR DESCRIPTION
After applying name filter, was getting "Oh no! Something went wrong." with "Cannot read property 'name' of undefined".  Catalog sources table has Name column using `obj.name`, not `obj.metadata.name` as found in most k8s resource tables

Updated table-filters.ts to accommodate both  `obj.metadata.name` and `obj.name`:

![image](https://user-images.githubusercontent.com/12733153/72008187-461f7e00-3221-11ea-9ab1-d8a9ccbcb02a.png)
