### PR TITLE
[release-4.2] Bug 1789119: Support for Pipeline Operator 0.9 on OpenShift 4.2

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/__tests__/pipelinerun-mock.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/__tests__/pipelinerun-mock.ts
@@ -36,10 +36,6 @@ export const mockPipelineRun = {
         },
       },
     ],
-    serviceAccount: '',
-    trigger: {
-      type: 'manual',
-    },
   },
   status: {
     completionTime: '2019-06-08T18:27:28Z',

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -58,7 +58,7 @@ export interface Pipeline extends K8sResourceKind {
     params: Param[];
     resources: PipelineResource[];
     tasks: K8sResourceKind[];
-    serviceAccount?: string;
+    serviceAccountName?: string;
   };
 }
 
@@ -67,7 +67,7 @@ export interface PipelineRun extends K8sResourceKind {
     pipelineRef?: { name: string };
     params?: Param[];
     resources?: PipelineResource[];
-    serviceAccount?: string;
+    serviceAccountName?: string;
   };
   status?: {
     succeededCondition?: string;


### PR DESCRIPTION
4.2 back-port of #3632 (was manual due to code conflicts)

The 4.3 back-port is #3869 

A necessary back-port to allow OpenShift Console code to work with Pipeline Operator v0.9.x.