### PR TITLE
Remove min-height rules that can cause content overlap at mobile

### DIFF
--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -1,4 +1,5 @@
 .co-actions {
+  align-items: flex-start; // Keep dropdown menu positioned correctly when titles wrap
   display: flex;
   @media(max-width: $screen-xs){
     align-items: flex-end;
@@ -25,14 +26,10 @@
   }
   &--detail {
     border-bottom: 1px solid $color-grey-background-border;
-    // Set min-height to prevent shifting of page content when actions btn is rendered after page content
-    min-height: 90px; // h1 text + top & bottom margin + bottom border (29 + 30 + 30 + 1)
     flex-shrink: 0; // do not allow to shrink
   }
   // Positioned after --detail to take precedence, since they will be a siblings
   &--breadcrumbs {
-    // Set min-height to prevent shifting of page content when actions btn is rendered after page content
-    min-height: 118px; // breadcrumb text + top & bottom padding + h1 text + bottom margin + bottom border +  (21 + 25 + 12 + 29 + 30 + 1)
     padding-top: 0;
   }
 }


### PR DESCRIPTION
**Corrects 2 issues**

1 . Fix bug https://bugzilla.redhat.com/show_bug.cgi?id=1787623
<img width="488" alt="Screen Shot 2020-01-07 at 5 35 36 PM" src="https://user-images.githubusercontent.com/1874151/72082947-044d1100-32cf-11ea-92de-01d52893b8b9.png">

**before**
![OperatorHub Subscription Â· Red Hat OpenShift Container Platform 2020-01-03 12-22-07 (1)](https://user-images.githubusercontent.com/1874151/72082984-129b2d00-32cf-11ea-877c-57cfef5a9d95.png)

---

2. And prevent details page action dropdown menu from being positioned incorrectly.

<img width="592" alt="Screen Shot 2020-01-07 at 5 19 20 PM" src="https://user-images.githubusercontent.com/1874151/72082919-f5665e80-32ce-11ea-8af3-1f290e1e41ed.png">

**before**

<img width="588" alt="Screen Shot 2020-01-07 at 5 19 40 PM" src="https://user-images.githubusercontent.com/1874151/72082937-feefc680-32ce-11ea-9b70-93abe0869fec.png">

