### PR TITLE
Console backend endpoint for requesting dashboard config

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -378,6 +378,24 @@ func main() {
 		},
 	}
 
+	srv.MonitoringDashboardConfigMapLister = &server.ResourceLister{
+		BearerToken: k8sAuthServiceAccountBearerToken,
+		RequestURL: &url.URL{
+			Scheme: k8sEndpoint.Scheme,
+			Host:   k8sEndpoint.Host,
+			Path:   "/api/v1/namespaces/openshift-config-managed/configmaps",
+			RawQuery: url.Values{
+				"labelSelector": {"console.openshift.io/dashboard=true"},
+			}.Encode(),
+		},
+
+		Client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: srv.K8sProxyConfig.TLSClientConfig,
+			},
+		},
+	}
+
 	switch *fUserAuth {
 	case "oidc", "openshift":
 		bridge.ValidateFlagNotEmpty("base-address", *fBaseAddress)

--- a/pkg/server/resource_lister.go
+++ b/pkg/server/resource_lister.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// ResourceLister determines the list of resources of a particular kind
+type ResourceLister struct {
+	BearerToken string
+	RequestURL  *url.URL
+	Client      *http.Client
+}
+
+func (l *ResourceLister) handleResources(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		sendResponse(w, http.StatusMethodNotAllowed, apiError{"invalid method: only GET is allowed"})
+		return
+	}
+
+	req, err := http.NewRequest("GET", l.RequestURL.String(), nil)
+	if err != nil {
+		sendResponse(w, http.StatusInternalServerError, apiError{fmt.Sprintf("failed to create GET request: %v", err)})
+		return
+	}
+
+	req.Header.Set("Authorization", "Bearer "+l.BearerToken)
+	resp, err := l.Client.Do(req)
+	if err != nil {
+		sendResponse(w, http.StatusBadGateway, apiError{fmt.Sprintf("GET request failed: %v", err)})
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err := fmt.Errorf("console service account cannot list resource: %s", resp.Status)
+		sendResponse(w, http.StatusInternalServerError, apiError{err.Error()})
+		return
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+	resp.Body.Close()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -89,6 +89,8 @@ type Server struct {
 	ThanosTenancyProxyConfig *proxy.Config
 	AlertManagerProxyConfig  *proxy.Config
 	MeteringProxyConfig      *proxy.Config
+	// A lister for resource listing of a particular kind
+	MonitoringDashboardConfigMapLister *ResourceLister
 }
 
 func (s *Server) authDisabled() bool {
@@ -292,10 +294,15 @@ func (s *Server) HTTPHandler() http.Handler {
 		)
 	}
 
+	handle("/api/console/monitoring-dashboard-config", authHandler(s.handleMonitoringDashboardConfigmaps))
 	handle("/api/console/version", authHandler(s.versionHandler))
 	mux.HandleFunc(s.BaseURL.Path, s.indexHandler)
 
 	return securityHeadersMiddleware(http.Handler(mux))
+}
+
+func (s *Server) handleMonitoringDashboardConfigmaps(w http.ResponseWriter, r *http.Request) {
+	s.MonitoringDashboardConfigMapLister.handleResources(w, r)
 }
 
 func sendResponse(rw http.ResponseWriter, code int, resp interface{}) {


### PR DESCRIPTION
Adding new endpoint on the console server to be used as a proxy to get ConfigMaps for monitoring dashboard.
I've called the endpoint `/api/console/monitoring-dashboard-config` 
The label for querying the right configmaps is set to `console.openshift.io/dashboard=true` but also `monitoring.openshift.io/dashboard=true` was suggested.
Opening the discussion about the naming.

ATM Im getting `403 Forbidden` as a from the API server, so labeling as WIP since there are still missing parts

/assign @spadgett 