### PR TITLE
Bug 1787096: Sorting by 'Starting Deadlines Seconds' don't work on CronJob list page

### DIFF
--- a/frontend/public/components/cron-job.tsx
+++ b/frontend/public/components/cron-job.tsx
@@ -56,13 +56,13 @@ const CronJobTableHeader = () => {
     },
     {
       title: 'Concurrency Policy',
-      sortField: 'spec.schedule',
+      sortField: 'spec.concurrencyPolicy',
       transforms: [sortable],
       props: { className: tableColumnClasses[3] },
     },
     {
       title: 'Starting Deadline Seconds',
-      sortField: 'spec.schedule',
+      sortField: 'spec.startingDeadlineSeconds',
       transforms: [sortable],
       props: { className: tableColumnClasses[4] },
     },


### PR DESCRIPTION
Fixed `sortField` for 'Concurrency Policy' and 'Starting Deadline Seconds'.