### PR TITLE
HorizontalNavTab Extension

### DIFF
--- a/frontend/packages/console-demo-plugin/src/components/test-pages.tsx
+++ b/frontend/packages/console-demo-plugin/src/components/test-pages.tsx
@@ -2,3 +2,4 @@ import * as React from 'react';
 
 export const DummyResourceListPage = () => <h1>Example Resource List Page</h1>;
 export const DummyResourceDetailsPage = () => <h1>Example Resource Details Page</h1>;
+export const DummyHorizontalNavTab = () => <h1>Example Resource Detail View Tab</h1>;

--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -21,6 +21,7 @@ import {
   DashboardsOverviewUtilizationItem,
   DashboardsOverviewResourceActivity,
   DashboardsOverviewPrometheusActivity,
+  HorizontalNavTab,
 } from '@console/plugin-sdk';
 // TODO(vojtech): internal code needed by plugins should be moved to console-shared package
 import { PodModel, RouteModel, NodeModel } from '@console/internal/models';
@@ -52,7 +53,8 @@ type ConsumedExtensions =
   | DashboardsInventoryItemGroup
   | DashboardsOverviewUtilizationItem
   | DashboardsOverviewResourceActivity
-  | DashboardsOverviewPrometheusActivity;
+  | DashboardsOverviewPrometheusActivity
+  | HorizontalNavTab;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -275,6 +277,20 @@ const plugin: Plugin<ConsumedExtensions> = [
           (m) => m.DemoPrometheusActivity,
         ),
       required: 'TEST_MODEL_FLAG',
+    },
+  },
+  {
+    type: 'HorizontalNavTab',
+    properties: {
+      model: PodModel,
+      page: {
+        href: 'example',
+        name: 'Example',
+      },
+      loader: () =>
+        import('./components/test-pages' /* webpackChunkName: "demo" */).then(
+          (m) => m.DummyHorizontalNavTab,
+        ),
     },
   },
 ];

--- a/frontend/packages/console-plugin-sdk/src/typings/horizontal-nav.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/horizontal-nav.ts
@@ -1,0 +1,19 @@
+import { K8sKind } from '@console/internal/module/k8s';
+import { PageComponentProps, Page } from '@console/internal/components/utils/horizontal-nav';
+import { Extension, LazyLoader } from './base';
+
+namespace ExtensionProperties {
+  export interface HorizontalNavTab {
+    model: K8sKind;
+    page: Pick<Page, 'name' | 'href' | 'path'>;
+    loader: LazyLoader<PageComponentProps>;
+  }
+}
+
+export interface HorizontalNavTab extends Extension<ExtensionProperties.HorizontalNavTab> {
+  type: 'HorizontalNavTab';
+}
+
+export const isHorizontalNavTab = (e: Extension): e is HorizontalNavTab => {
+  return e.type === 'HorizontalNavTab';
+};

--- a/frontend/packages/console-plugin-sdk/src/typings/index.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/index.ts
@@ -14,3 +14,4 @@ export * from './global-configs';
 export * from './clusterserviceversions';
 export * from './dev-catalog';
 export * from './reducers';
+export * from './horizontal-nav';

--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -78,6 +78,7 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
               <PipelineForm
                 PipelineFormComponent={PipelineParameters}
                 formName="parameters"
+                obj={props.obj}
                 {...props}
               />
             ),
@@ -89,6 +90,7 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
               <PipelineForm
                 PipelineFormComponent={PipelineResources}
                 formName="resources"
+                obj={props.obj}
                 {...props}
               />
             ),

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -783,10 +783,13 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
 ) => {
   const instancePagesFor = (obj: ClusterServiceVersionKind) => {
     const internalObjects = getInternalObjects(obj);
-    return (providedAPIsFor(obj).length > 1
-      ? [{ href: 'instances', name: 'All Instances', component: ProvidedAPIsPage }]
-      : ([] as Page[])
-    ).concat(
+    const allInstancesPage: Page = {
+      href: 'instances',
+      name: 'All Instances',
+      component: ProvidedAPIsPage,
+    };
+
+    return (providedAPIsFor(obj).length > 1 ? [allInstancesPage] : ([] as Page[])).concat(
       providedAPIsFor(obj).reduce(
         (acc, desc: CRDDescription) =>
           !isInternalObject(internalObjects, desc.name)
@@ -812,6 +815,7 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
       ),
     );
   };
+
   type ExtraResources = { subscriptions: SubscriptionKind[] };
   const menuActions = (
     model,

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -8,6 +8,7 @@ import {
   PageHeading,
   FirehoseResource,
   KebabOptionsCreator,
+  Page,
 } from '../utils';
 import { K8sResourceKindReference, K8sResourceKind, K8sKind } from '../../module/k8s';
 import { withFallback } from '../utils/error-boundary';
@@ -62,12 +63,6 @@ export const DetailsPage = withFallback<DetailsPageProps>((props) => {
     </Firehose>
   );
 }, ErrorBoundaryFallback);
-
-export type Page = {
-  href: string;
-  name: string;
-  component?: React.ComponentType<any>;
-};
 
 export type DetailsPageProps = {
   match: match<any>;


### PR DESCRIPTION
### Description

Implements the `DetailViewTab` extension type, which allows adding a new tab to an existing resource's detail view.

### Screenshots

**`Pods` detail view with demo plugin:**
![Screenshot_20200109_164724](https://user-images.githubusercontent.com/11700385/72116637-be5c7100-32ff-11ea-9963-0b70937ff0bc.png)

Needed for https://issues.redhat.com/browse/PROJQUAY-119
Blocked by https://github.com/openshift/console/pull/3383