### PR TITLE
Make operator logo as default if the service is operator backed

### DIFF
--- a/frontend/packages/console-shared/src/utils/icon-utils.ts
+++ b/frontend/packages/console-shared/src/utils/icon-utils.ts
@@ -5,3 +5,5 @@ export type CSVIcon = { base64data: string; mediatype: string };
 export const getImageForCSVIcon = (icon: CSVIcon | undefined) => {
   return icon ? `data:${icon.mediatype};base64,${icon.base64data}` : operatorLogo;
 };
+
+export const getDefaultOperatorIcon = () => operatorLogo;

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -12,6 +12,7 @@ import {
   isKnativeServing,
   OverviewItem,
   getImageForCSVIcon,
+  getDefaultOperatorIcon,
 } from '@console/shared';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import {
@@ -141,7 +142,9 @@ export const createTopologyNodeData = (
   const builderImageIcon =
     getImageForIconClass(`icon-${deploymentsLabels['app.openshift.io/runtime']}`) ||
     getImageForIconClass(`icon-${deploymentsLabels['app.kubernetes.io/name']}`);
-  const defaultIcon = getImageForIconClass(`icon-openshift`);
+  const defaultIcon = operatorBackedService
+    ? getDefaultOperatorIcon()
+    : getImageForIconClass(`icon-openshift`);
 
   return {
     id: dcUID,
@@ -158,7 +161,7 @@ export const createTopologyNodeData = (
         deploymentsAnnotations['app.openshift.io/edit-url'] ||
         getEditURL(deploymentsAnnotations['app.openshift.io/vcs-uri'], cheURL),
       cheEnabled: !!cheURL,
-      builderImage: csvIcon || builderImageIcon || defaultIcon,
+      builderImage: builderImageIcon || csvIcon || defaultIcon,
       isKnativeResource:
         type && (type === 'event-source' || 'knative-revision')
           ? true


### PR DESCRIPTION
Related Story - https://issues.redhat.com/browse/ODC-2455

This PR - 
- Updates the default icon behaviour of topology workloads based on the changed AC of the story.
- So, no if the workload is operator backed then CSV icon or default operator icon will be shown. Otherwise builder image icon or default openshift icon will be shown.