### PR TITLE
add submenu support to resource action menus

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/nodeContextMenu.tsx
+++ b/frontend/packages/dev-console/src/components/topology/nodeContextMenu.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-import { ContextMenuItem, GraphElement, Node } from '@console/topology';
-import { history, KebabItem, KebabOption } from '@console/internal/components/utils';
+import { ContextMenuItem, ContextSubMenuItem, GraphElement, Node } from '@console/topology';
+import {
+  history,
+  KebabItem,
+  KebabOption,
+  KebabMenuOption,
+  kebabOptionsToMenu,
+  isKebabSubMenu,
+} from '@console/internal/components/utils';
 import { workloadActions } from './actions/workloadActions';
 import { groupActions } from './actions/groupActions';
 import { nodeActions } from './actions/nodeActions';
@@ -15,17 +22,22 @@ const onKebabOptionClick = (option: KebabOption) => {
   }
 };
 
-const createMenuItems = (actions: KebabOption[]) =>
-  actions
-    .filter((o) => !o.hidden)
-    .map((option) => (
+const createMenuItems = (actions: KebabMenuOption[]) =>
+  actions.map((option) =>
+    isKebabSubMenu(option) ? (
+      <ContextSubMenuItem label={option.label} key={option.label}>
+        {createMenuItems(option.children)}
+      </ContextSubMenuItem>
+    ) : (
       <ContextMenuItem
         key={option.label}
         component={<KebabItem option={option} onClick={() => onKebabOptionClick(option)} />}
       />
-    ));
+    ),
+  );
 
-const workloadContextMenu = (element: Node) => createMenuItems(workloadActions(element.getData()));
+const workloadContextMenu = (element: Node) =>
+  createMenuItems(kebabOptionsToMenu(workloadActions(element.getData())));
 
 const groupContextMenu = (element: Node) => {
   const applicationData: TopologyApplicationObject = {
@@ -34,9 +46,10 @@ const groupContextMenu = (element: Node) => {
     resources: element.getChildren().map((node: GraphElement) => node.getData()),
   };
 
-  return createMenuItems(groupActions(applicationData));
+  return createMenuItems(kebabOptionsToMenu(groupActions(applicationData)));
 };
 
-const nodeContextMenu = (element: Node) => createMenuItems(nodeActions(element.getData()));
+const nodeContextMenu = (element: Node) =>
+  createMenuItems(kebabOptionsToMenu(nodeActions(element.getData())));
 
 export { workloadContextMenu, groupContextMenu, nodeContextMenu };

--- a/frontend/packages/topology/src/behavior/withCreateConnector.tsx
+++ b/frontend/packages/topology/src/behavior/withCreateConnector.tsx
@@ -4,7 +4,7 @@ import { hullPath } from '../utils/svg-utils';
 import DefaultCreateConnector from '../components/DefaultCreateConnector';
 import Point from '../geom/Point';
 import Layer from '../components/layers/Layer';
-import ContextMenu, { ContextMenuItem } from '../components/contextmenu/ContextMenu';
+import { ContextMenu, ContextMenuItem } from '../components/contextmenu';
 import { Node, isNode, AnchorEnd, GraphElement, isGraph, Graph } from '../types';
 import { DragSourceSpec, DragSourceMonitor, DragEvent } from './dnd-types';
 import { useDndDrag } from './useDndDrag';

--- a/frontend/packages/topology/src/components/contextmenu/ContextMenu.scss
+++ b/frontend/packages/topology/src/components/contextmenu/ContextMenu.scss
@@ -1,3 +1,5 @@
 .topology-context-menu {
-  position: initial !important;
+  .pf-c-dropdown__menu {
+    position: initial !important;
+  }
 }

--- a/frontend/packages/topology/src/components/contextmenu/ContextMenu.tsx
+++ b/frontend/packages/topology/src/components/contextmenu/ContextMenu.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-  DropdownMenu,
-  DropdownItem,
-  DropdownContext,
-  DropdownSeparator,
-} from '@patternfly/react-core';
+import { DropdownMenu, DropdownContext } from '@patternfly/react-core';
 import styles from '@patternfly/react-styles/css/components/Dropdown/dropdown';
 // FIXME fully qualified due to the effect of long build times on storybook
 import Popper from '@console/shared/src/components/popper/Popper';
@@ -57,8 +52,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
           separatorClass: styles.dropdownSeparator,
         }}
       >
-        <div className="pf-c-dropdown pf-m-expanded">
-          <DropdownMenu className="pf-c-dropdown__menu topology-context-menu" autoFocus>
+        <div className="pf-c-dropdown pf-m-expanded topology-context-menu">
+          <DropdownMenu className="pf-c-dropdown__menu " autoFocus>
             {children}
           </DropdownMenu>
         </div>
@@ -68,7 +63,3 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 };
 
 export default ContextMenu;
-
-// re-export dropdown components as context menu components
-export const ContextMenuSeparator = DropdownSeparator;
-export const ContextMenuItem = DropdownItem;

--- a/frontend/packages/topology/src/components/contextmenu/ContextSubMenuItem.scss
+++ b/frontend/packages/topology/src/components/contextmenu/ContextSubMenuItem.scss
@@ -1,0 +1,11 @@
+.topology-context-sub-menu {
+  position: relative;
+  padding-right: var(--pf-global--spacer--lg);
+
+  &__arrow {
+    position: absolute;
+    right: var(--pf-global--spacer--xs);
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}

--- a/frontend/packages/topology/src/components/contextmenu/ContextSubMenuItem.tsx
+++ b/frontend/packages/topology/src/components/contextmenu/ContextSubMenuItem.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { DropdownMenu, DropdownItem } from '@patternfly/react-core';
+// FIXME fully qualified due to the effect of long build times on storybook
+import Popper from '@console/shared/src/components/popper/Popper';
+import { AngleRightIcon } from '@patternfly/react-icons';
+
+import './ContextSubMenuItem.scss';
+
+type ContextSubMenuItemProps = {
+  label: React.ReactNode;
+  children: React.ReactNode[];
+};
+
+const ContextSubMenuItem: React.FC<ContextSubMenuItemProps> = ({ label, children, ...other }) => {
+  const nodeRef = React.useRef<HTMLButtonElement>(null);
+  const subMenuRef = React.useRef<HTMLDivElement>(null);
+  const [open, setOpen] = React.useState(false);
+  const referenceCb = React.useCallback(() => nodeRef.current || { x: 0, y: 0 }, []);
+
+  return (
+    <>
+      <DropdownItem
+        {...other}
+        className="topology-context-sub-menu"
+        component={
+          <button
+            ref={nodeRef}
+            type="button"
+            // prevent this DropdownItem from executing like a normal action item
+            onClick={(e) => e.stopPropagation()}
+            // mouse enter will open the sub menu
+            onMouseEnter={() => setOpen(true)}
+            onMouseLeave={(e) => {
+              // if the mouse leaves this item, close the sub menu only if the mouse did not enter the sub menu itself
+              if (!subMenuRef.current || !subMenuRef.current.contains(e.relatedTarget as Node)) {
+                setOpen(false);
+              }
+            }}
+            onKeyDown={(e) => {
+              // open the sub menu on enter or right arrow
+              if (e.keyCode === 39 || e.keyCode === 13) {
+                setOpen(true);
+                e.stopPropagation();
+              }
+            }}
+          >
+            {label}
+            <AngleRightIcon className="topology-context-sub-menu__arrow" />
+          </button>
+        }
+      />
+      <Popper
+        open={open}
+        placement="right-start"
+        closeOnEsc
+        closeOnOutsideClick
+        onRequestClose={(e) => {
+          // only close the sub menu if clicking anywhere outside the menu item that owns the sub menu
+          if (!e || !nodeRef.current || !nodeRef.current.contains(e.target as Node)) {
+            setOpen(false);
+          }
+        }}
+        reference={referenceCb}
+        // use the parent node to capture the li
+        container={nodeRef.current ? nodeRef.current.parentElement : nodeRef.current}
+        returnFocus
+      >
+        <div
+          ref={subMenuRef}
+          role="presentation"
+          className="pf-c-dropdown pf-m-expanded"
+          onMouseLeave={(e) => {
+            // only close the sub menu if the mouse does not enter the item
+            if (!nodeRef.current || !nodeRef.current.contains(e.relatedTarget as Node)) {
+              setOpen(false);
+            }
+          }}
+          onKeyDown={(e) => {
+            // close the sub menu on left arrow
+            if (e.keyCode === 37) {
+              setOpen(false);
+              e.stopPropagation();
+            }
+          }}
+        >
+          <DropdownMenu className="pf-c-dropdown__menu" autoFocus>
+            {children}
+          </DropdownMenu>
+        </div>
+      </Popper>
+    </>
+  );
+};
+
+export default ContextSubMenuItem;

--- a/frontend/packages/topology/src/components/contextmenu/index.ts
+++ b/frontend/packages/topology/src/components/contextmenu/index.ts
@@ -1,2 +1,8 @@
-export * from './ContextMenu';
 export { default as ContextMenu } from './ContextMenu';
+export { default as ContextSubMenuItem } from './ContextSubMenuItem';
+
+// re-export dropdown components as context menu components
+export {
+  DropdownItem as ContextMenuItem,
+  DropdownSeparator as ContextMenuSeparator,
+} from '@patternfly/react-core';

--- a/frontend/public/components/utils/_kebab.scss
+++ b/frontend/public/components/utils/_kebab.scss
@@ -1,3 +1,17 @@
-.oc-kebab__popper-items {
-  position: initial !important;
+.oc-kebab {
+  &__popper-items {
+    position: initial !important;
+  }
+
+  &__sub.pf-c-dropdown__menu-item {
+    position: relative;
+    padding-right: var(--pf-global--spacer--lg);
+  }
+
+  &__arrow {
+    position: absolute;
+    right: var(--pf-global--spacer--xs);
+    top: 50%;
+    transform: translateY(-50%);
+  }
 }


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ODC-2712
Related to work in topology view to have a way to access the Add actions in-context: https://github.com/openshift/console/pull/3918

### Problem
Kebab actions only support a flat list.
Patternfly does not have any sub menu support either.
Many more actions are being added to resources and a flat list of actions will become much too large.

### Solution
This PR builds off the earlier support for popper.js based menus. These menus automatically align to the left or right depending on where space is available. The preference is set to always open to the right if there is available space. This is why in the screenshots for the kebab and actions dropdown, the 2nd nested menu appears out to the right. The nesting of sub menus multiple levels deep is shown in the screenshots because the solution has no restriction on depth.

There is some duplicate code between kebab and topology in the popper setup but they are are based on two very different menu implementations. Also, we are trying to keep topology pure from console dependencies to eventually push it to PF.

The way to specify actions to appear in a sub menu is by using the new `path` prop of the `KebabOption`. The path is a `/` separated string where each segment denotes a new sub menu entry. Eg. `Menu 1/Menu 2/Menu 3`

There is keyboard support as well.
- `Right-Arrow | Enter` opens a sub menu
- `Left-Arrow` closes a sub menu
- `Esc` continues to close the entire menu for kebab and topology while only closing sub menus in the dropdown. This is because of the way dropdowns have a very different implementation.

![image](https://user-images.githubusercontent.com/14068621/72197599-132be480-33f1-11ea-9db2-5bf910c08764.png)

![image](https://user-images.githubusercontent.com/14068621/72197660-d3b1c800-33f1-11ea-9770-17820d7d08a8.png)

![image](https://user-images.githubusercontent.com/14068621/72197672-e62c0180-33f1-11ea-88d4-965ef687552d.png)

Keyboard navigation:
![submenus](https://user-images.githubusercontent.com/14068621/72198039-753b1880-33f6-11ea-9655-e16b39bc1fad.gif)

cc @spadgett @karthikjeeyar @andrewballantyne 
