### PR TITLE
Remove pod link from vm overview

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
 import { PodKind } from '@console/internal/module/k8s';
 import { getName, getNamespace, getNodeName } from '@console/shared';
-import { PodModel } from '@console/internal/models';
 import { VMKind, VMIKind } from '../../types';
 import { VMTemplateLink } from '../vm-templates/vm-template-link';
 import { getBasicID, prefixedID } from '../../utils';
@@ -117,16 +116,6 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
           name={getName(vmi)}
           namespace={getNamespace(vmi)}
         />
-      </VMDetailsItem>
-
-      <VMDetailsItem title="Pod" idValue={prefixedID(id, 'pod')} isNotAvail={!launcherPod}>
-        {launcherPod && (
-          <ResourceLink
-            kind={PodModel.kind}
-            name={getName(launcherPod)}
-            namespace={getNamespace(launcherPod)}
-          />
-        )}
       </VMDetailsItem>
 
       <VMDetailsItem


### PR DESCRIPTION
On Jan 9 we decided that after exposing the VMI link we do not need the pod link.

This PR remove the pod link from the VM overview page.

Design:
https://github.com/openshift/openshift-origin-design/pull/310

Screenshot
after:
![example · Details · OKD](https://user-images.githubusercontent.com/2181522/72237571-a2005300-35e3-11ea-8350-9b8b4910c0a9.png)

before:
![example · Details · Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/2181522/72237815-73cf4300-35e4-11ea-88ea-8a3579170c91.png)
