### PR TITLE
Update VirtualMachineInstance badge color

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/models/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/index.ts
@@ -22,6 +22,7 @@ export const VirtualMachineInstanceModel: K8sKind = {
   namespaced: true,
   kind: 'VirtualMachineInstance',
   id: 'virtualmachineinstance',
+  color: '#002F5D',
 };
 
 export const VirtualMachineInstancePresetModel: K8sKind = {


### PR DESCRIPTION
On Jan 9 we decided to make the VMI badge colour different than the VM badge color.

The colour of the VMI badge is designed to be #002F5D.
Ref. https://github.com/openshift/openshift-origin-design/pull/310/files#diff-cef3d67592c99f1c121ddd5658e1fb47R16

Design:
openshift/openshift-origin-design#310

Screenshots:
after:
![Virtual Machine Instances · OKD](https://user-images.githubusercontent.com/2181522/72238240-e68cee00-35e5-11ea-8027-82770e3ee74c.png)

before:
![Virtual Machine Instances · Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/2181522/72238252-ebea3880-35e5-11ea-9ac0-b1709a020359.png)

