### PR TITLE
createLookup take firehose object not list ...

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -210,9 +210,9 @@ export const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) =
       return null;
     }
 
-    const vmisLookup = createLookup(loadedVMs, getBasicID);
+    const vmisLookup = createLookup(vmis, getBasicID);
     const migrationLookup = createLookup(
-      loadedMigrations,
+      migrations,
       (m) => isMigrating(m) && `${getNamespace(m)}-${getMigrationVMIName(m)}`,
     );
     const virtualMachines = _.unionBy(loadedVMs, loadedVMIs, getBasicID);


### PR DESCRIPTION
In https://github.com/openshift/console/pull/3841 I introduced a bug using `createLookup`  in a wrong way.

Running VMs will not have correct status in list view :-)