### PR TITLE
Added helm chart repo proxy to the console backend

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/console/pkg/auth"
 	"github.com/openshift/console/pkg/bridge"
 	"github.com/openshift/console/pkg/crypto"
+	"github.com/openshift/console/pkg/helm"
 	"github.com/openshift/console/pkg/proxy"
 	"github.com/openshift/console/pkg/server"
 	"github.com/openshift/console/pkg/serverconfig"
@@ -107,6 +108,8 @@ func main() {
 	fDocumentationBaseURL := fs.String("documentation-base-url", "", "The base URL for documentation links.")
 
 	fLoadTestFactor := fs.Int("load-test-factor", 0, "DEV ONLY. The factor used to multiply k8s API list responses for load testing purposes.")
+
+	helmConfig := helm.RegisterFlags(fs)
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -520,6 +523,8 @@ func main() {
 	default:
 		bridge.FlagFatalf("listen", "scheme must be one of: http, https")
 	}
+
+	helmConfig.Configure(srv)
 
 	httpsrv := &http.Server{
 		Addr:    listenURL.Host,

--- a/pkg/helm/config.go
+++ b/pkg/helm/config.go
@@ -1,0 +1,62 @@
+package helm
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"io/ioutil"
+
+	"github.com/coreos/pkg/capnslog"
+
+	"github.com/openshift/console/pkg/bridge"
+	"github.com/openshift/console/pkg/crypto"
+	"github.com/openshift/console/pkg/proxy"
+	"github.com/openshift/console/pkg/server"
+)
+
+var (
+	log = capnslog.NewPackageLogger("github.com/openshift/console", "pkg/helm")
+)
+
+type config struct {
+	repoUrl    string
+	repoCaFile string
+}
+
+func RegisterFlags(fs *flag.FlagSet) *config {
+
+	cfg := new(config)
+
+	fs.StringVar(&cfg.repoUrl, "helm-chart-repo-url", "https://redhat-developer.github.com/redhat-helm-charts", "Helm chart repository URL")
+	fs.StringVar(&cfg.repoCaFile, "helm-chart-repo-ca-file", "", "CA bundle for Helm chart repository.")
+
+	return cfg
+}
+
+func (cfg *config) Configure(srv *server.Server) {
+	repoURL := bridge.ValidateFlagIsURL("helm-chart-repo-repoUrl", cfg.repoUrl)
+
+	var rootCAs *x509.CertPool
+	if cfg.repoCaFile != "" {
+		rootCAs = x509.NewCertPool()
+		certPEM, err := ioutil.ReadFile(cfg.repoCaFile)
+		if err != nil {
+			log.Fatalf("failed to read helm chart repo ca file %v : %v", cfg.repoCaFile, err)
+		}
+		if !rootCAs.AppendCertsFromPEM(certPEM) {
+			log.Fatalf("No CA found for Helm chart repo proxy")
+		}
+	} else {
+		rootCAs, _ = x509.SystemCertPool()
+	}
+
+	srv.HelmChartRepoProxyConfig = &proxy.Config{
+		TLSClientConfig: &tls.Config{
+			RootCAs:      rootCAs,
+			CipherSuites: crypto.DefaultCiphers(),
+		},
+		HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
+		Endpoint:        repoURL,
+	}
+
+}

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -35,7 +35,18 @@ func SetFlagsFromConfig(fs *flag.FlagSet, filename string) (err error) {
 	addAuth(fs, &config.Auth)
 	addCustomization(fs, &config.Customization)
 	addProviders(fs, &config.Providers)
+	addHelmConfig(fs, &config.Helm)
 
+	return nil
+}
+
+func addHelmConfig(fs *flag.FlagSet, helmConfig *Helm) (err error) {
+	if helmConfig.ChartRepo.URL != "" {
+		fs.Set("helm-chart-repo-url", helmConfig.ChartRepo.URL)
+	}
+	if helmConfig.ChartRepo.CAFile != "" {
+		fs.Set("helm-chart-repo-ca-file", helmConfig.ChartRepo.CAFile)
+	}
 	return nil
 }
 

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -13,6 +13,7 @@ type Config struct {
 	Auth          `yaml:"auth"`
 	Customization `yaml:"customization"`
 	Providers     `yaml:"providers"`
+	Helm          `yaml:"helm"`
 }
 
 // ServingInfo holds configuration for serving HTTP.
@@ -57,4 +58,13 @@ type Customization struct {
 
 type Providers struct {
 	StatuspageID string `yaml:"statuspageID,omitempty"`
+}
+
+type HelmChartRepo struct {
+	URL    string `yaml:"url,omitempty"`
+	CAFile string `yaml:"caFile,omitempty"`
+}
+
+type Helm struct {
+	ChartRepo HelmChartRepo `yaml:"chartRepository"`
 }


### PR DESCRIPTION
All requests to `/api/helm/charts/*` are forwarded to the declared Helm chart repository.
By default this is `https://redhat-developer.github.com/redhat-helm-charts`, but configurable via

- `helm-chart-repo-url` CLI argument
- BRIDGE_HELM_CHART_REPO_URL env variable
- `config.yaml`:

```
.
.
.
helm:
  chart-repo: 
    url: https://foo.bar

```