### PR TITLE
Add ActionFeatureFlag extension

### DIFF
--- a/frontend/packages/console-app/src/__tests__/extension-checks/features.spec.ts
+++ b/frontend/packages/console-app/src/__tests__/extension-checks/features.spec.ts
@@ -9,7 +9,7 @@ describe('ModelFeatureFlag', () => {
     const baseModelRefs = _.keys(baseCRDs);
     const pluginModelRefs = _.flatMap(
       testedRegistry
-        .getFeatureFlags()
+        .getModelFeatureFlags()
         .filter(isModelFeatureFlag)
         .map((ff) => referenceForModel(ff.properties.model)),
     );

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -5,7 +5,8 @@ import {
   ExtensionTypeGuard,
   ActivePlugin,
   isModelDefinition,
-  isFeatureFlag,
+  isModelFeatureFlag,
+  isActionFeatureFlag,
   isNavItem,
   isResourceListPage,
   isResourceDetailsPage,
@@ -64,8 +65,12 @@ export class ExtensionRegistry {
     return this.extensions.filter(isModelDefinition);
   }
 
-  public getFeatureFlags() {
-    return this.extensions.filter(isFeatureFlag);
+  public getModelFeatureFlags() {
+    return this.extensions.filter(isModelFeatureFlag);
+  }
+
+  public getActionFeatureFlags() {
+    return this.extensions.filter(isActionFeatureFlag);
   }
 
   public getNavItems() {

--- a/frontend/packages/console-plugin-sdk/src/typings/features.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/features.ts
@@ -1,3 +1,4 @@
+import { Dispatch } from 'react-redux';
 import { K8sKind } from '@console/internal/module/k8s';
 import { Extension } from './extension';
 
@@ -8,19 +9,25 @@ namespace ExtensionProperties {
     /** The name of the feature flag. */
     flag: string;
   }
+
+  export interface ActionFeatureFlag {
+    /** Function used to detect the feature and set flag name/value via Redux action dispatch. */
+    detect: (dispatch: Dispatch) => Promise<any>;
+  }
 }
 
 export interface ModelFeatureFlag extends Extension<ExtensionProperties.ModelFeatureFlag> {
   type: 'FeatureFlag/Model';
 }
 
-// TODO(vojtech): add ActionFeatureFlag
-export type FeatureFlag = ModelFeatureFlag;
+export interface ActionFeatureFlag extends Extension<ExtensionProperties.ActionFeatureFlag> {
+  type: 'FeatureFlag/Action';
+}
 
 export const isModelFeatureFlag = (e: Extension): e is ModelFeatureFlag => {
   return e.type === 'FeatureFlag/Model';
 };
 
-export const isFeatureFlag = (e: Extension): e is FeatureFlag => {
-  return isModelFeatureFlag(e);
+export const isActionFeatureFlag = (e: Extension): e is ActionFeatureFlag => {
+  return e.type === 'FeatureFlag/Action';
 };

--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -15,6 +15,7 @@ import { MonitoringRoutes } from '../reducers/monitoring';
 import { setMonitoringURL } from './monitoring';
 import { setClusterID, setConsoleLinks, setCreateProjectMessage, setUser } from './ui';
 import { FLAGS } from '../const';
+import * as plugins from '../plugins';
 
 export enum ActionType {
   SetFlag = 'setFlag',
@@ -31,7 +32,7 @@ const retryFlagDetection = (dispatch, cb) => {
   setTimeout(() => cb(dispatch), 15000);
 };
 
-const handleError = (res, flag, dispatch, cb) => {
+export const handleError = (res, flag, dispatch, cb) => {
   const status = _.get(res, 'response.status');
   if (_.includes([403, 502], status)) {
     dispatch(setFlag(flag, undefined));
@@ -283,4 +284,5 @@ export const detectFeatures = () => (dispatch: Dispatch) =>
     detectLoggingURL,
     detectConsoleLinks,
     ...ssarCheckActions,
+    ...plugins.registry.getActionFeatureFlags().map((ff) => ff.properties.detect),
   ].forEach((detect) => detect(dispatch));

--- a/frontend/public/reducers/features.ts
+++ b/frontend/public/reducers/features.ts
@@ -42,15 +42,12 @@ export const baseCRDs = {
 
 const CRDs = { ...baseCRDs };
 
-plugins.registry
-  .getFeatureFlags()
-  .filter(plugins.isModelFeatureFlag)
-  .forEach((ff) => {
-    const modelRef = referenceForModel(ff.properties.model);
-    if (!CRDs[modelRef]) {
-      CRDs[modelRef] = ff.properties.flag as FLAGS;
-    }
-  });
+plugins.registry.getModelFeatureFlags().forEach((ff) => {
+  const modelRef = referenceForModel(ff.properties.model);
+  if (!CRDs[modelRef]) {
+    CRDs[modelRef] = ff.properties.flag as FLAGS;
+  }
+});
 
 export type FeatureState = ImmutableMap<string, boolean>;
 


### PR DESCRIPTION
This PR allows extending `detectFeatures` in `public/actions/features.ts` module.

Existing `setFlag` and `handleError` functions should be reused when implementing detection of new, plugin-specific features.

cc @christianvogt @jtomasek @bipuladh 