### PR TITLE
fix(TopologyResourcePanel): fix breaking TopologyResourcePanel

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyResourcePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyResourcePanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ResourceOverviewPage } from '@console/internal/components/overview/resource-overview-page';
 import * as _ from 'lodash';
-import { KnativeResourceOverviewPage } from '@console/knative-plugin/src/components/overview/KnativeResourceOverviewPage';
+import KnativeResourceOverviewPage from '@console/knative-plugin/src/components/overview/KnativeResourceOverviewPage';
 import { TopologyDataObject } from './topology-types';
 
 export type TopologyResourcePanelProps = {

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeOverview.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeOverview.tsx
@@ -3,11 +3,11 @@ import { ResourceSummary } from '@console/internal/components/utils';
 import { OverviewItem, PodRing } from '@console/shared';
 import { RevisionModel } from '../../models';
 
-export type KnativeOverviewProps = {
+type KnativeOverviewProps = {
   item?: OverviewItem;
 };
 
-export const KnativeOverview: React.FC<KnativeOverviewProps> = ({ item }) => {
+const KnativeOverview: React.FC<KnativeOverviewProps> = ({ item }) => {
   const { obj, current } = item;
   return (
     <div className="overview__sidebar-pane-body resource-overview__body">
@@ -28,3 +28,5 @@ export const KnativeOverview: React.FC<KnativeOverviewProps> = ({ item }) => {
     </div>
   );
 };
+
+export default KnativeOverview;

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -1,17 +1,23 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { Kebab, LoadingBox } from '@console/internal/components/utils';
 import { ResourceOverviewDetails } from '@console/internal/components/overview/resource-overview-details';
-import { OverviewItem } from '@console/shared';
 import { groupVersionFor, K8sKind } from '@console/internal/module/k8s';
-import { getKsResourceModel } from '../../utils/get-knative-resources';
-import { KnativeOverview } from './KnativeOverview';
+import { RootState } from '@console/internal/redux';
+import { OverviewItem } from '@console/shared';
+import { KNATIVE_SERVING_APIGROUP, KNATIVE_EVENT_SOURCE_APIGROUP } from '../../const';
 import OverviewDetailsKnativeResourcesTab from './OverviewDetailsKnativeResourcesTab';
+import KnativeOverview from './KnativeOverview';
 
-export type KnativeResourceOverviewPageProps = {
-  item?: OverviewItem;
-  knativeModels?: K8sKind[];
+interface StateProps {
   kindsInFlight?: boolean;
-};
+  knativeModels?: K8sKind[];
+}
+
+export interface KnativeResourceOverviewPageProps extends StateProps {
+  item?: OverviewItem;
+}
+
 const tabs = [
   {
     name: 'Overview',
@@ -48,4 +54,17 @@ export const KnativeResourceOverviewPage: React.ComponentType<KnativeResourceOve
   );
 };
 
-export default getKsResourceModel(KnativeResourceOverviewPage);
+const mapStateToProps = (state: RootState): StateProps => {
+  return {
+    kindsInFlight: state.k8s.getIn(['RESOURCES', 'inFlight']),
+    knativeModels: state.k8s
+      .getIn(['RESOURCES', 'models'])
+      .filter(
+        (model: K8sKind) =>
+          model.apiGroup === KNATIVE_SERVING_APIGROUP ||
+          model.apiGroup === KNATIVE_EVENT_SOURCE_APIGROUP,
+      ),
+  };
+};
+
+export default connect(mapStateToProps)(KnativeResourceOverviewPage);

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeOverview.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeOverview.spec.tsx
@@ -5,7 +5,7 @@ import { PodRing, OverviewItem } from '@console/shared';
 import { ResourceSummary } from '@console/internal/components/utils';
 import { revisionObj } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
 import { RevisionModel } from '../../../models';
-import { KnativeOverview } from '../KnativeOverview';
+import KnativeOverview from '../KnativeOverview';
 
 describe('KnativeOverview', () => {
   let item: OverviewItem;

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -1,12 +1,6 @@
 import * as _ from 'lodash';
-import { K8sResourceKind, K8sKind } from '@console/internal/module/k8s';
-import { connect } from 'react-redux';
-import { RootState } from '@console/internal/redux';
-import {
-  KNATIVE_SERVING_LABEL,
-  KNATIVE_EVENT_SOURCE_APIGROUP,
-  KNATIVE_SERVING_APIGROUP,
-} from '../const';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { KNATIVE_SERVING_LABEL } from '../const';
 
 export type KnativeItem = {
   revisions?: K8sResourceKind[];
@@ -19,11 +13,6 @@ export type KnativeItem = {
   eventSourceCamel?: K8sResourceKind[];
   eventSourceKafka?: K8sResourceKind[];
 };
-
-interface StateProps {
-  kindsInFlight: boolean;
-  knativeModels: K8sKind[];
-}
 
 const isKnativeDeployment = (dc: K8sResourceKind) => {
   return !!_.get(dc.metadata, `labels["${KNATIVE_SERVING_LABEL}"]`);
@@ -38,20 +27,6 @@ const getKsResource = (dc: K8sResourceKind, { data }: K8sResourceKind): K8sResou
   }
   return ksResource;
 };
-const mapStateToProps = (state: RootState): StateProps => {
-  return {
-    kindsInFlight: state.k8s.getIn(['RESOURCES', 'inFlight']),
-    knativeModels: state.k8s
-      .getIn(['RESOURCES', 'models'])
-      .filter(
-        (model: K8sKind) =>
-          model.apiGroup === KNATIVE_SERVING_APIGROUP ||
-          model.apiGroup === KNATIVE_EVENT_SOURCE_APIGROUP,
-      ),
-  };
-};
-
-export const getKsResourceModel = (wrappedComponent) => connect(mapStateToProps)(wrappedComponent);
 
 const getRevisions = (dc: K8sResourceKind, { data }): K8sResourceKind[] => {
   let revisionResource = [];


### PR DESCRIPTION
This PR -
* fixes breaking TopologyResourcePanel
* undertakes cleanup of the KnativeResourceOverview components
* addresses issue https://issues.redhat.com/browse/ODC-2720

screens-
![fix-resource-overview](https://user-images.githubusercontent.com/38663217/72305208-121ce080-3699-11ea-843a-bf423d941856.png)
![resource-overview-1](https://user-images.githubusercontent.com/38663217/72305211-15b06780-3699-11ea-9e40-f1b498dd0942.png)
