### PR TITLE
Bug 1741132: Fix PVC dropdown unit label behavior

### DIFF
--- a/frontend/public/components/utils/request-size-input.tsx
+++ b/frontend/public/components/utils/request-size-input.tsx
@@ -38,7 +38,7 @@ export class RequestSizeInput extends React.Component<RequestSizeInputProps> {
             min={this.props.minValue}
           />
           <Dropdown
-            title={this.props.defaultRequestSizeUnit}
+            title={this.props.dropdownUnits[this.props.defaultRequestSizeUnit]}
             selectedKey={this.props.defaultRequestSizeUnit}
             name={dropdownName}
             className="btn-group"


### PR DESCRIPTION
(Almost) fixes [1741132 (comment 4)](https://bugzilla.redhat.com/show_bug.cgi?id=1741132#c4) so that selecting MiB/GiB/TiB in the dropdown no longer changes the dropdown field's value to Mi/Gi/Ti instead. This fix is for both the Create and Expand PVC forms.

![72308023-f2aa9700-3649-11ea-928e-f0370dc35397](https://user-images.githubusercontent.com/9122899/74072832-21f8bd80-49d6-11ea-9223-75d0b87fc8aa.png)