### PR TITLE
add Managed by section in resource tab for operator backed services

### DIFF
--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -22,6 +22,7 @@ export type OverviewItem<T = K8sResourceKind> = {
   ksservices?: K8sResourceKind[];
   revisions?: K8sResourceKind[];
   events?: EventKind[];
+  isOperatorBackedService?: boolean;
 };
 
 export type DeploymentStrategy = DEPLOYMENT_STRATEGY.recreate | DEPLOYMENT_STRATEGY.rolling;

--- a/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
@@ -383,6 +383,7 @@ Object {
           "revision": undefined,
         },
         "events": undefined,
+        "isOperatorBackedService": false,
         "isRollingOut": undefined,
         "obj": Object {
           "apiVersion": "apps.openshift.io/v1",
@@ -1244,6 +1245,7 @@ Object {
           "revision": 1,
         },
         "events": undefined,
+        "isOperatorBackedService": false,
         "isRollingOut": false,
         "obj": Object {
           "apiVersion": "apps/v1",
@@ -2216,6 +2218,7 @@ Object {
           "revision": 1,
         },
         "events": undefined,
+        "isOperatorBackedService": false,
         "isRollingOut": false,
         "obj": Object {
           "apiVersion": "apps/v1",
@@ -2645,6 +2648,7 @@ Object {
         "buildConfigs": Array [],
         "current": undefined,
         "events": undefined,
+        "isOperatorBackedService": true,
         "isRollingOut": false,
         "obj": Object {
           "apiVersion": "apps/v1",

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -161,7 +161,7 @@ export const createTopologyNodeData = (
     name:
       _.get(deploymentConfig, 'metadata.name') || deploymentsLabels['app.kubernetes.io/instance'],
     type: type || 'workload',
-    resources: { ...dc },
+    resources: { ...dc, isOperatorBackedService: operatorBackedService },
     pods: dc.pods,
     operatorBackedService,
     data: {

--- a/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { OverviewItem } from '@console/shared';
+import OperatorBackedOwnerReferences from '@console/internal/components/utils';
 import {
   RevisionModel,
   ServiceModel,
@@ -45,6 +46,11 @@ const getSidebarResources = ({ obj, ksroutes, revisions, configurations }: Overv
 };
 const OverviewDetailsKnativeResourcesTab: React.FC<OverviewDetailsResourcesTabProps> = ({
   item,
-}) => <div className="overview__sidebar-pane-body"> {getSidebarResources(item)} </div>;
+}) => (
+  <div className="overview__sidebar-pane-body">
+    <OperatorBackedOwnerReferences item={item} />
+    {getSidebarResources(item)}
+  </div>
+);
 
 export default OverviewDetailsKnativeResourcesTab;

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { MockKnativeResources } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import OperatorBackedOwnerReferences from '@console/internal/components/utils';
 import OverviewDetailsKnativeResourcesTab from '../OverviewDetailsKnativeResourcesTab';
 import KnativeServiceResources from '../KnativeServiceResources';
 import KnativeRevisionResources from '../KnativeRevisionResources';
@@ -23,6 +24,7 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
         buildConfigs: [],
         routes: [],
         services: [],
+        isOperatorBackedService: false,
       },
     };
   });
@@ -41,5 +43,16 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
     knItem.item = { ...knItem.item, ...{ obj: MockKnativeResources.eventSourceCronjob.data[0] } };
     const wrapper = shallow(<OverviewDetailsKnativeResourcesTab {...knItem} />);
     expect(wrapper.find(EventSinkServicesOverviewList)).toHaveLength(1);
+  });
+
+  it('should render OperatorBackedOwnerReferences with proper props', () => {
+    const wrapper = shallow(<OverviewDetailsKnativeResourcesTab item={knItem.item} />);
+    expect(wrapper.find(OperatorBackedOwnerReferences)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(OperatorBackedOwnerReferences)
+        .at(0)
+        .props().item,
+    ).toEqual(knItem.item);
   });
 });

--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -105,3 +105,11 @@ $overview-sidebar-width: 550px;
   font-size: 14px;
   margin-left: var(--pf-global--spacer--sm);
 }
+
+.sidebar__section-owner-operator-heading {
+  display: flex;
+}
+
+.sidebar__section-owner-reference-operator {
+  padding-left: var(--pf-global--spacer--sm);
+}

--- a/frontend/public/components/overview/resource-overview-details.tsx
+++ b/frontend/public/components/overview/resource-overview-details.tsx
@@ -87,6 +87,7 @@ type OwnProps = {
     name: string;
     component: any;
   }[];
+  isOperatorBacked?: boolean;
 };
 
 export type ResourceOverviewDetailsProps = PropsFromState & PropsFromDispatch & OwnProps;

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 
 import { connectToModel } from '../../kinds';
 import { referenceForModel } from '../../module/k8s';
-import { AsyncComponent, Kebab, ResourceOverviewHeading, ResourceSummary } from '../utils';
+import OperatorBackedOwnerReferences, {
+  AsyncComponent,
+  Kebab,
+  ResourceOverviewHeading,
+  ResourceSummary,
+} from '../utils';
 
 import { BuildOverview } from './build-overview';
 import { NetworkingOverview } from './networking-overview';
@@ -34,6 +39,7 @@ export const OverviewDetailsResourcesTab: React.SFC<OverviewDetailsResourcesTabP
   const pluginComponents = getPluginTabSectionResource(item);
   return (
     <div className="overview__sidebar-pane-body">
+      <OperatorBackedOwnerReferences item={item} />
       <PodsOverview pods={pods} obj={obj} />
       <BuildOverview buildConfigs={buildConfigs} />
       {pluginComponents.map(({ Component, key }) => (

--- a/frontend/public/components/utils/index.tsx
+++ b/frontend/public/components/utils/index.tsx
@@ -56,6 +56,7 @@ export * from './skeleton-catalog';
 export * from './dom-utils';
 export * from './hint-block';
 export * from './owner-references';
+export { default } from './operator-backed-owner-references';
 export * from './field-level-help';
 export * from './details-item';
 export * from './types';

--- a/frontend/public/components/utils/operator-backed-owner-references.tsx
+++ b/frontend/public/components/utils/operator-backed-owner-references.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { OverviewItem } from '@console/shared';
+import { OwnerReferences } from './owner-references';
+
+const OperatorBackedOwnerReferences: React.FC<OperatorBackedOwnerReferencesProps> = ({ item }) => {
+  return item.isOperatorBackedService ? (
+    <span className="sidebar__section-owner-operator-heading">
+      Managed by:
+      <span className="sidebar__section-owner-reference-operator">
+        <OwnerReferences resource={item.obj} />
+      </span>
+    </span>
+  ) : null;
+};
+
+type OperatorBackedOwnerReferencesProps = {
+  item: OverviewItem;
+};
+
+OperatorBackedOwnerReferences.displayName = 'OperatorBackedOwnerReferences';
+
+export default OperatorBackedOwnerReferences;


### PR DESCRIPTION
This PR-
* adds a Managed by operator section in the resource tab for operator backed services
* is tracked by issue https://issues.redhat.com/browse/ODC-2700
screens-
![managed-by-operator](https://user-images.githubusercontent.com/38663217/72323864-b588e800-36cf-11ea-90fd-c596734f43b8.png)
