### PR TITLE
Create Helm Release Details Page

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseDetails.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseDetails.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { match as RMatch } from 'react-router';
+import { Firehose } from '@console/internal/components/utils';
+import { NamespaceBar } from '@console/internal/components/namespace';
+import { SecretModel } from '@console/internal/models';
+import HelmReleaseDetailsPage from './HelmReleaseDetailsPage';
+
+export interface HelmReleaseDetailsProps {
+  match: RMatch<{
+    ns?: string;
+    name?: string;
+  }>;
+}
+
+const HelmReleaseDetails: React.FC<HelmReleaseDetailsProps> = ({ match }) => {
+  const namespace = match.params.ns;
+  const helmReleaseName = match.params.name;
+  return (
+    <>
+      <NamespaceBar />
+      <Firehose
+        resources={[
+          {
+            kind: SecretModel.kind,
+            namespace,
+            isList: true,
+            selector: { name: `${helmReleaseName}` },
+            prop: 'secret',
+          },
+        ]}
+      >
+        <HelmReleaseDetailsPage match={match} />
+      </Firehose>
+    </>
+  );
+};
+
+export default HelmReleaseDetails;

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseDetailsPage.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { match as RMatch } from 'react-router';
+import {
+  navFactory,
+  LoadingBox,
+  StatusBox,
+  FirehoseResult,
+} from '@console/internal/components/utils';
+import { SecretModel } from '@console/internal/models';
+import { ErrorPage404 } from '@console/internal/components/error';
+import { DetailsPage } from '@console/internal/components/factory';
+import { K8sResourceKindReference } from '@console/internal/module/k8s';
+import HelmReleaseOverview from './HelmReleaseOverview';
+
+const SecretReference: K8sResourceKindReference = 'Secret';
+const HelmReleaseReference = 'HelmRelease';
+
+export interface HelmReleaseDetailsPageProps {
+  match: RMatch<{
+    ns?: string;
+  }>;
+  secret?: FirehoseResult;
+}
+
+const HelmReleaseDetailsPage: React.FC<HelmReleaseDetailsPageProps> = ({ secret, match }) => {
+  const namespace = match.params.ns;
+  if (!secret || (!secret.loaded && _.isEmpty(secret.loadError))) {
+    return <LoadingBox />;
+  }
+  if (secret.loadError) {
+    return <StatusBox loaded={secret.loaded} loadError={secret.loadError} />;
+  }
+  const secretResource = secret.data;
+  if (!_.isEmpty(secretResource)) {
+    return (
+      <DetailsPage
+        match={match}
+        kindObj={SecretModel}
+        name={secretResource[0]?.metadata.name}
+        namespace={namespace}
+        breadcrumbsFor={() => [
+          {
+            name: `Helm Releases`,
+            path: `/helm-releases/ns/${namespace}`,
+          },
+          { name: `Helm Release Details`, path: `${match.url}` },
+        ]}
+        title={secretResource[0]?.metadata.labels?.name}
+        kind={SecretReference}
+        pages={[navFactory.details(HelmReleaseOverview)]}
+        customKind={HelmReleaseReference}
+      />
+    );
+  }
+  return <ErrorPage404 />;
+};
+
+export default HelmReleaseDetailsPage;

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseOverview.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseOverview.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { ResourceSummary, SectionHeading } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export interface HelmReleaseOverviewProps {
+  obj: K8sResourceKind;
+}
+
+const HelmReleaseOverview: React.FC<HelmReleaseOverviewProps> = ({ obj: resourceDetails }) => {
+  return (
+    <div className="co-m-pane__body">
+      <SectionHeading text="Helm Release Overview" />
+      <div className="row">
+        <div className="col-sm-6">
+          <ResourceSummary resource={resourceDetails} customPathName={'metadata.labels.name'} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HelmReleaseOverview;

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseDetails.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseDetails.spec.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { NamespaceBar } from '@console/internal/components/namespace';
+import HelmReleaseDetails from '../HelmReleaseDetails';
+import HelmReleaseDetailsPage from '../HelmReleaseDetailsPage';
+
+let helmReleaseDetailsProps: React.ComponentProps<typeof HelmReleaseDetails>;
+
+describe('HelmReleaseDetails', () => {
+  helmReleaseDetailsProps = {
+    match: {
+      url: '/helm-releases/ns/xyz/release/helm-mysql',
+      isExact: false,
+      path: '/helm-releases/ns/xyz/release/:name',
+      params: {
+        ns: 'xyz',
+      },
+    },
+  };
+  const helmReleaseDetails = shallow(<HelmReleaseDetails {...helmReleaseDetailsProps} />);
+  it('should render the NamespaceBar component', () => {
+    expect(helmReleaseDetails.find(NamespaceBar).exists()).toBe(true);
+  });
+  it('should render the HelmReleaseDetailsPage component', () => {
+    expect(helmReleaseDetails.find(HelmReleaseDetailsPage).exists()).toBe(true);
+  });
+});

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseDetailsPage.spec.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { ErrorPage404 } from '@console/internal/components/error';
+import { DetailsPage } from '@console/internal/components/factory';
+import { LoadingBox, StatusBox } from '@console/internal/components/utils';
+import HelmReleaseDetailsPage from '../HelmReleaseDetailsPage';
+
+let helmReleaseDetailsPageProps: React.ComponentProps<typeof HelmReleaseDetailsPage>;
+
+describe('HelmReleaseDetailsPage', () => {
+  beforeEach(() => {
+    helmReleaseDetailsPageProps = {
+      secret: {
+        data: [
+          {
+            metadata: {
+              name: 'secret-name',
+              namespace: 'xyz',
+              creationTimestamp: '2020-01-13T05:42:19Z',
+              labels: {
+                name: 'helm-mysql',
+                owner: 'helm',
+                status: 'deployed',
+              },
+            },
+          },
+        ],
+        loadError: null,
+        loaded: true,
+      },
+      match: {
+        params: {
+          ns: 'xyz',
+        },
+        url: '/helm-releases/ns/xyz/release/helm-mysql',
+        isExact: true,
+        path: '/helm-releases/ns/xyz/release/:name',
+      },
+    };
+  });
+  it('should show the loading box if secret is not loaded', () => {
+    helmReleaseDetailsPageProps.secret.loaded = false;
+    helmReleaseDetailsPageProps.secret.loadError = undefined;
+    const helmReleaseDetailsPage = shallow(
+      <HelmReleaseDetailsPage {...helmReleaseDetailsPageProps} />,
+    );
+    expect(helmReleaseDetailsPage.find(LoadingBox).exists()).toBe(true);
+  });
+  it('should show the status box if there is an error loading the secret', () => {
+    helmReleaseDetailsPageProps.secret.loadError = 'error 404';
+    const helmReleaseDetailsPage = shallow(
+      <HelmReleaseDetailsPage {...helmReleaseDetailsPageProps} />,
+    );
+    expect(helmReleaseDetailsPage.find(StatusBox).exists()).toBe(true);
+  });
+  it('should render the DetailsPage component when secret gets loaded', () => {
+    const helmReleaseDetailsPage = shallow(
+      <HelmReleaseDetailsPage {...helmReleaseDetailsPageProps} />,
+    );
+    expect(helmReleaseDetailsPage.find(DetailsPage).exists()).toBe(true);
+  });
+  it('should show the ErrorPage404 for an incorrect release name in the url', () => {
+    helmReleaseDetailsPageProps.secret.data = undefined;
+    const helmReleaseDetailsPage = shallow(
+      <HelmReleaseDetailsPage {...helmReleaseDetailsPageProps} />,
+    );
+    expect(helmReleaseDetailsPage.find(ErrorPage404).exists()).toBe(true);
+  });
+});

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseOverview.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseOverview.spec.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { ResourceSummary, SectionHeading } from '@console/internal/components/utils';
+import HelmReleaseOverview from '../HelmReleaseOverview';
+
+const helmReleaseOverviewProps: React.ComponentProps<typeof HelmReleaseOverview> = {
+  obj: {
+    metadata: {
+      name: 'secret-name',
+      namespace: 'xyz',
+      creationTimestamp: '2020-01-13T05:42:19Z',
+      labels: {
+        name: 'helm-mysql',
+        owner: 'helm',
+        status: 'deployed',
+      },
+    },
+  },
+};
+
+describe('HelmReleaseOverview', () => {
+  it('should render the Section Heading for the Overview page', () => {
+    const helmReleaseOverview = shallow(<HelmReleaseOverview {...helmReleaseOverviewProps} />);
+    expect(
+      helmReleaseOverview
+        .find(SectionHeading)
+        .at(0)
+        .props().text,
+    ).toEqual('Helm Release Overview');
+  });
+  it('should render the ResourceSummary component', () => {
+    const helmReleaseOverview = shallow(<HelmReleaseOverview {...helmReleaseOverviewProps} />);
+    expect(helmReleaseOverview.find(ResourceSummary).exists()).toBe(true);
+  });
+});

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -501,6 +501,19 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Page/Route',
     properties: {
+      path: ['/helm-releases/ns/:ns/release/:name'],
+      exact: false,
+      loader: async () =>
+        (
+          await import(
+            './components/helm/HelmReleaseDetails' /* webpackChunkName: "dev-console-helmReleaseDetails" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
       perspective: 'dev',
       exact: true,
       path: ['/k8s/all-namespaces/buildconfigs', '/k8s/ns/:ns/buildconfigs'],

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -32,11 +32,11 @@ export const DetailsPage = withFallback<DetailsPageProps>((props) => {
     >
       <PageHeading
         detail={true}
-        title={props.name}
+        title={props.title || props.name}
         titleFunc={props.titleFunc}
         menuActions={props.menuActions}
         buttonActions={props.buttonActions}
-        kind={props.kind}
+        kind={props.customKind || props.kind}
         breadcrumbsFor={
           props.breadcrumbsFor
             ? props.breadcrumbsFor
@@ -89,6 +89,7 @@ export type DetailsPageProps = {
   icon?: React.ComponentType<{ obj: K8sResourceKind }>;
   getResourceStatus?: (resource: K8sResourceKind) => string;
   children?: React.ReactNode;
+  customKind?: string;
 };
 
 DetailsPage.displayName = 'DetailsPage';

--- a/frontend/public/components/utils/details-page.tsx
+++ b/frontend/public/components/utils/details-page.tsx
@@ -36,6 +36,7 @@ const getNodeSelectorPath = (obj: K8sResourceKind): string => {
 export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({
   children,
   resource,
+  customPathName,
   showPodSelector = false,
   showNodeSelector = false,
   showAnnotations = true,
@@ -59,7 +60,7 @@ export const ResourceSummary: React.SFC<ResourceSummaryProps> = ({
 
   return (
     <dl data-test-id="resource-summary" className="co-m-pane__details">
-      <DetailsItem label="Name" obj={resource} path="metadata.name" />
+      <DetailsItem label="Name" obj={resource} path={customPathName || 'metadata.name'} />
       {metadata.namespace && (
         <DetailsItem label="Namespace" obj={resource} path="metadata.namespace">
           <ResourceLink
@@ -149,6 +150,7 @@ export type ResourceSummaryProps = {
   showTolerations?: boolean;
   podSelector?: string;
   children?: React.ReactNode;
+  customPathName?: string;
 };
 
 export type ResourcePodCountProps = {


### PR DESCRIPTION
This PR includes:
- the overview tab for the Helm Release Details page
- testcases

Refer Jira Story: https://issues.redhat.com/browse/ODC-2639

![Screenshot from 2020-01-14 15-14-47](https://user-images.githubusercontent.com/22490998/72334095-d0188c80-36e2-11ea-8ea5-67adbe65a6b4.png)

Test with URL : `/helm-releases/ns/<namespace-name>/release/<release-name>`