### PR TITLE
Monitoring Dashboards: Add variable dropdowns

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -24,6 +24,8 @@ export enum ActionType {
   SetActivePerspective = 'setActivePerspective',
   SetCreateProjectMessage = 'setCreateProjectMessage',
   SetCurrentLocation = 'setCurrentLocation',
+  MonitoringDashboardsClearVariables = 'monitoringDashboardsClearVariables',
+  MonitoringDashboardsPatchVariable = 'monitoringDashboardsPatchVariable',
   SetMonitoringData = 'setMonitoringData',
   ToggleMonitoringGraphs = 'monitoringToggleGraphs',
   QueryBrowserAddQuery = 'queryBrowserAddQuery',
@@ -269,6 +271,10 @@ export const updateOverviewLabels = (labels: string[]) =>
   action(ActionType.UpdateOverviewLabels, { labels });
 export const updateOverviewFilterValue = (value: string) =>
   action(ActionType.UpdateOverviewFilterValue, { value });
+export const monitoringDashboardsClearVariables = () =>
+  action(ActionType.MonitoringDashboardsClearVariables);
+export const monitoringDashboardsPatchVariable = (key: string, patch: any) =>
+  action(ActionType.MonitoringDashboardsPatchVariable, { key, patch });
 export const monitoringLoading = (key: 'alerts' | 'silences') =>
   action(ActionType.SetMonitoringData, {
     key,
@@ -335,6 +341,8 @@ const uiActions = {
   updateOverviewSelectedGroup,
   updateOverviewLabels,
   updateOverviewFilterValue,
+  monitoringDashboardsClearVariables,
+  monitoringDashboardsPatchVariable,
   monitoringLoading,
   monitoringLoaded,
   monitoringErrored,

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -1,6 +1,7 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
+import { connect } from 'react-redux';
 
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
@@ -9,7 +10,11 @@ import DashboardCardBody from '@console/shared/src/components/dashboard/dashboar
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 
+import * as UIActions from '../../../actions/ui';
 import { k8sBasePath } from '../../../module/k8s';
+import { ErrorBoundaryFallback } from '../../error';
+import { RootState } from '../../../redux';
+import { getPrometheusURL, PrometheusEndpoint } from '../../graphs/helpers';
 import { Dropdown, LoadingInline, useSafeFetch } from '../../utils';
 import { parsePrometheusDuration } from '../../utils/datetime';
 import { withFallback } from '../../utils/error-boundary';
@@ -19,28 +24,57 @@ import SingleStat from './single-stat';
 import Table from './table';
 import { Panel } from './types';
 
-const evaluateTemplate = (s: string) => {
-  // TODO: Variable options will be created based on the dashboard `templating` section
-  const variables = {
-    cluster: '',
-    datasource: 'prometheus',
-    interval: '4h',
-    namespace: 'openshift-kube-apiserver',
-    node: '',
-    resolution: '5m',
-  };
-
-  return _.reduce(
+const evaluateTemplate = (s: string, variables: VariablesMap) =>
+  _.reduce(
     variables,
-    (result: string, v: string, k: string): string => {
-      return result.replace(new RegExp(`\\$${k}`, 'g'), v);
+    (result: string, v: Variable, k: string): string => {
+      return result.replace(new RegExp(`\\$${k}`, 'g'), v.value);
     },
     s,
   );
-};
 
-// TODO: Just a stub for now
-const VariableDropdowns = () => null;
+const VariableDropdown: React.FC<VariableDropdownProps> = ({
+  buttonClassName,
+  onChange,
+  options,
+  selected,
+  title,
+}) => (
+  <div className="monitoring-dashboards__dropdown-wrap">
+    {title && <h4>{title}</h4>}
+    <Dropdown
+      buttonClassName={buttonClassName}
+      items={_.zipObject(options, options)}
+      onChange={onChange}
+      selectedKey={selected}
+    />
+  </div>
+);
+
+const AllVariableDropdowns_: React.FC<AllVariableDropdownsProps> = ({
+  patchVariable,
+  variables,
+}) => (
+  <>
+    {_.map(variables, ({ options, value }, k) =>
+      _.isEmpty(options) ? null : (
+        <VariableDropdown
+          key={k}
+          onChange={(v: string) => patchVariable(k, { value: v })}
+          options={options}
+          selected={value}
+          title={k}
+        />
+      ),
+    )}
+  </>
+);
+const AllVariableDropdowns = connect(
+  ({ UI }: RootState) => ({
+    variables: UI.getIn(['monitoringDashboards', 'variables']).toJS(),
+  }),
+  { patchVariable: UIActions.monitoringDashboardsPatchVariable },
+)(AllVariableDropdowns_);
 
 const timespanOptions = ['5m', '15m', '30m', '1h', '2h', '6h', '12h', '1d', '2d', '1w', '2w'];
 const defaultTimespan = '30m';
@@ -50,30 +84,26 @@ const defaultPollInterval = '30s';
 
 // TODO: Dynamically load the list of dashboards
 const boards = [
+  'etcd',
   'k8s-resources-cluster',
   'k8s-resources-namespace',
+  'k8s-resources-workloads-namespace',
+  'k8s-resources-node',
+  'k8s-resources-pod',
+  'k8s-resources-workload',
   'cluster-total',
+  'prometheus',
   'node-cluster-rsrc-use',
+  'node-rsrc-use',
 ];
-const DashboardDropdown: React.FC<{ setBoard: (string) => void }> = ({ setBoard }) => {
-  const items = _.zipObject(boards, boards);
-  return <Dropdown items={items} onChange={(v) => setBoard(v)} selectedKey={boards[0]} />;
-};
 
-const DurationDropdown: React.FC<DurationDropdownProps> = ({ items, onChange, selected }) => (
-  <Dropdown
-    buttonClassName="monitoring-dashboards__dropdown"
-    items={_.zipObject(items, items)}
-    onChange={(v: string) => onChange(parsePrometheusDuration(v))}
-    selectedKey={selected}
-  />
-);
-
-const Card: React.FC<PanelProps> = ({ panel, pollInterval, timespan }) => {
-  const queries = _.map(panel.targets, 'expr').map(evaluateTemplate);
-  if (!queries.length) {
+const Card_: React.FC<CardProps> = ({ panel, pollInterval, timespan, variables }) => {
+  const rawQueries = _.map(panel.targets, 'expr');
+  if (!rawQueries.length) {
     return null;
   }
+
+  const queries = rawQueries.map((expr) => evaluateTemplate(expr, variables));
 
   // If panel doesn't specify a span, try to get it from the gridPos or default to full width
   let colSpan = panel.span;
@@ -118,16 +148,30 @@ const Card: React.FC<PanelProps> = ({ panel, pollInterval, timespan }) => {
     </div>
   );
 };
+const Card = connect(({ UI }: RootState) => ({
+  variables: UI.getIn(['monitoringDashboards', 'variables']).toJS(),
+}))(Card_);
 
-const Board: React.FC<{ board: string; pollInterval: number; timespan: number }> = ({
-  board,
-  pollInterval,
-  timespan,
-}) => {
+const Board: React.FC<BoardProps> = ({ board, patchVariable, pollInterval, timespan }) => {
   const [data, setData] = React.useState();
   const [error, setError] = React.useState<string>();
 
   const safeFetch = React.useCallback(useSafeFetch(), []);
+
+  const loadVariableValues = React.useCallback(
+    (name: string, rawQuery: string) => {
+      // Convert label_values queries to something Prometheus can handle
+      const query = rawQuery.replace(/label_values\((.*), (.*)\)/, 'count($1) by ($2)');
+
+      const url = getPrometheusURL({ endpoint: PrometheusEndpoint.QUERY, query });
+      safeFetch(url).then((response) => {
+        const result = _.get(response, 'data.result');
+        const options = _.flatMap(result, ({ metric }) => _.values(metric)).sort();
+        patchVariable(name, options.length ? { options, value: options[0] } : { value: '' });
+      });
+    },
+    [patchVariable, safeFetch],
+  );
 
   React.useEffect(() => {
     const path = `${k8sBasePath}/api/v1/namespaces/openshift-monitoring/configmaps/grafana-dashboard-${board}`;
@@ -138,8 +182,25 @@ const Board: React.FC<{ board: string; pollInterval: number; timespan: number }>
           setData(undefined);
           setError('Dashboard definition JSON not found');
         } else {
-          setData(JSON.parse(json));
+          const newData = JSON.parse(json);
+          setData(newData);
           setError(undefined);
+
+          const newVars = _.get(newData, 'templating.list') as TemplateVariable[];
+          const optionsVars = _.filter(newVars, (v) => v.type === 'query' || v.type === 'interval');
+
+          _.each(optionsVars, (v) => {
+            if (v.options.length === 1) {
+              patchVariable(v.name, { value: v.options[0].value });
+            } else if (v.options.length > 1) {
+              const options = _.map(v.options, 'value');
+              const selected = _.find(v.options, { selected: true });
+              const value = (selected || v.options[0]).value;
+              patchVariable(v.name, { options, value });
+            } else if (!_.isEmpty(v.query)) {
+              loadVariableValues(v.name, v.query);
+            }
+          });
         }
       })
       .catch((err) => {
@@ -148,7 +209,7 @@ const Board: React.FC<{ board: string; pollInterval: number; timespan: number }>
           setError(_.get(err, 'json.error', err.message));
         }
       });
-  }, [board, safeFetch]);
+  }, [board, loadVariableValues, patchVariable, safeFetch]);
 
   if (error) {
     return <ErrorAlert message={error} />;
@@ -172,12 +233,20 @@ const Board: React.FC<{ board: string; pollInterval: number; timespan: number }>
   );
 };
 
-const MonitoringDashboardsPage: React.FC<{}> = () => {
-  const [pollInterval, setPollInterval] = React.useState(
+const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({
+  clearVariables,
+  patchVariable,
+}) => {
+  const [pollInterval, setPollInterval] = React.useState<number>(
     parsePrometheusDuration(defaultPollInterval),
   );
-  const [timespan, setTimespan] = React.useState(parsePrometheusDuration(defaultTimespan));
+  const [timespan, setTimespan] = React.useState<number>(parsePrometheusDuration(defaultTimespan));
   const [board, setBoard] = React.useState(boards[0]);
+
+  const onBoardChange = (newBoard: string) => {
+    clearVariables();
+    setBoard(newBoard);
+  };
 
   return (
     <>
@@ -187,51 +256,94 @@ const MonitoringDashboardsPage: React.FC<{}> = () => {
       <div className="co-m-nav-title co-m-nav-title--detail">
         <h1 className="co-m-pane__heading co-m-pane__heading--monitoring-dashboards">
           Metrics Dashboards
-          <div className="monitoring-dashboards__dropdown-wrap">
-            <DashboardDropdown setBoard={setBoard} />
-          </div>
+          <VariableDropdown onChange={onBoardChange} options={boards} selected={boards[0]} />
         </h1>
         <div className="monitoring-dashboards__options">
           <div className="monitoring-dashboards__options-group">
-            <VariableDropdowns />
+            <AllVariableDropdowns />
           </div>
           <div className="monitoring-dashboards__options-group">
-            <div className="monitoring-dashboards__dropdown-wrap">
-              <h4>Time Range</h4>
-              <DurationDropdown
-                items={timespanOptions}
-                onChange={setTimespan}
-                selected={defaultTimespan}
-              />
-            </div>
-            <div className="monitoring-dashboards__dropdown-wrap">
-              <h4>Refresh Interval</h4>
-              <DurationDropdown
-                items={pollIntervalOptions}
-                onChange={setPollInterval}
-                selected={defaultPollInterval}
-              />
-            </div>
+            <VariableDropdown
+              buttonClassName="monitoring-dashboards__dropdown"
+              onChange={(v: string) => setTimespan(parsePrometheusDuration(v))}
+              options={timespanOptions}
+              selected={defaultTimespan}
+              title="Time Range"
+            />
+            <VariableDropdown
+              onChange={(v: string) => setPollInterval(parsePrometheusDuration(v))}
+              options={pollIntervalOptions}
+              selected={defaultPollInterval}
+              title="Refresh Interval"
+            />
           </div>
         </div>
       </div>
       <Dashboard>
-        {board && <Board board={board} timespan={timespan} pollInterval={pollInterval} />}
+        {board && (
+          <Board
+            board={board}
+            timespan={timespan}
+            patchVariable={patchVariable}
+            pollInterval={pollInterval}
+          />
+        )}
       </Dashboard>
     </>
   );
 };
+const MonitoringDashboardsPage = connect(
+  null,
+  {
+    clearVariables: UIActions.monitoringDashboardsClearVariables,
+    patchVariable: UIActions.monitoringDashboardsPatchVariable,
+  },
+)(MonitoringDashboardsPage_);
 
-type DurationDropdownProps = {
-  items: string[];
-  onChange: (string) => void;
-  selected: string;
+type TemplateVariable = {
+  name: string;
+  options: { selected: boolean; value: string }[];
+  query: string;
+  type: string;
 };
 
-type PanelProps = {
-  panel: Panel;
+type Variable = {
+  options?: string[];
+  value?: string;
+};
+
+type VariablesMap = { [key: string]: Variable };
+
+type VariableDropdownProps = {
+  buttonClassName?: string;
+  onChange: (v: string) => void;
+  options: string[];
+  selected: string;
+  title?: string;
+};
+
+type BoardProps = {
+  board: string;
+  patchVariable: (key: string, patch: Variable) => undefined;
   pollInterval: number;
   timespan: number;
 };
 
-export default withFallback(MonitoringDashboardsPage);
+type AllVariableDropdownsProps = {
+  patchVariable: (key: string, patch: Variable) => undefined;
+  variables: VariablesMap;
+};
+
+type CardProps = {
+  panel: Panel;
+  pollInterval: number;
+  timespan: number;
+  variables: VariablesMap;
+};
+
+type MonitoringDashboardsPageProps = {
+  clearVariables: () => undefined;
+  patchVariable: (key: string, patch: Variable) => undefined;
+};
+
+export default withFallback(MonitoringDashboardsPage, ErrorBoundaryFallback);

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -78,6 +78,9 @@ export default (state: UIState, action: UIAction): UIState => {
       }),
       user: {},
       consoleLinks: [],
+      monitoringDashboards: ImmutableMap({
+        variables: ImmutableMap(),
+      }),
       queryBrowser: ImmutableMap({
         metrics: [],
         queries: ImmutableList([newQueryBrowserQuery()]),
@@ -135,6 +138,15 @@ export default (state: UIState, action: UIAction): UIState => {
 
     case ActionType.SetUser:
       return state.set('user', action.payload.user);
+
+    case ActionType.MonitoringDashboardsClearVariables:
+      return state.setIn(['monitoringDashboards', 'variables'], ImmutableMap());
+
+    case ActionType.MonitoringDashboardsPatchVariable:
+      return state.mergeIn(
+        ['monitoringDashboards', 'variables', action.payload.key],
+        action.payload.patch,
+      );
 
     case ActionType.SetMonitoringData: {
       const alerts =


### PR DESCRIPTION
Use the dashboard JSON definition's `templating` sections to generate
dropdowns for the dashboard variables.

This PR does not handle the case where a variable's `query` contains the another variable. That will be addressed with a separate PR.