### PR TITLE
feat(dev-catalog): Add Capability level filters

### DIFF
--- a/frontend/__tests__/components/catalog-data.ts
+++ b/frontend/__tests__/components/catalog-data.ts
@@ -1,4 +1,6 @@
-export const developerCatalogItems = [
+import { Item } from '../../public/components/catalog/catalog-items';
+
+export const developerCatalogItems: Item[] = [
   {
     createLabel: 'Create Application',
     href:

--- a/frontend/__tests__/components/catalog.spec.tsx
+++ b/frontend/__tests__/components/catalog.spec.tsx
@@ -14,9 +14,9 @@ import {
   CatalogListPageState,
 } from '../../public/components/catalog/catalog-page';
 import {
-  CatalogTileViewPage,
   catalogCategories as initCatalogCategories,
   groupItems,
+  CatalogTileViewPage,
 } from '../../public/components/catalog/catalog-items';
 import {
   catalogListPageProps,
@@ -43,17 +43,27 @@ describe(CatalogTileViewPage.displayName, () => {
   it('renders category filter controls', () => {
     const filterItems = wrapper.find<any>(FilterSidePanelCategoryItem);
     expect(filterItems.exists()).toBe(true);
-    expect(filterItems.length).toEqual(5); // Filter by Types
+    expect(filterItems.length).toEqual(10); // Filter by Types
     expect(filterItems.at(0).props().count).toBe(0); // total count for Operator Backed
-    expect(filterItems.at(0).props().checked).toBe(true); //Check operator backed filter is true by default
+    expect(filterItems.at(0).props().checked).toBe(true); // Check operator backed filter is true by default
     expect(filterItems.at(1).props().count).toBe(0); // total count for Helm Charts
-    expect(filterItems.at(1).props().checked).toBe(false); //Check Helm Charts filter is true by default
+    expect(filterItems.at(1).props().checked).toBe(false); // Check Helm Charts filter is true by default
     expect(filterItems.at(2).props().count).toBe(9); // total count for templates
     expect(filterItems.at(2).props().checked).toBe(false); // filter templates should be false by default
     expect(filterItems.at(3).props().count).toBe(2); // total count for imagestreams
     expect(filterItems.at(3).props().checked).toBe(false); // filter imagestreams should be false by default
     expect(filterItems.at(4).props().count).toBe(11); // total count for clusterServiceClasses
     expect(filterItems.at(4).props().checked).toBe(false); // filter clusterServiceClasses should be false by default
+    expect(filterItems.at(5).props().count).toBe(0); // total count for Basic Install
+    expect(filterItems.at(5).props().checked).toBe(false); // Check Basic Install filter is false by default
+    expect(filterItems.at(6).props().count).toBe(0); // total count for Seamless Upgrades
+    expect(filterItems.at(6).props().checked).toBe(false); // Check Seamless Upgrades  filter is false by default
+    expect(filterItems.at(7).props().count).toBe(0); // total count for Full Lifecycle
+    expect(filterItems.at(7).props().checked).toBe(true); // Check filter Full Lifecycle should be true by default
+    expect(filterItems.at(8).props().count).toBe(0); // total count for Deep Insights
+    expect(filterItems.at(8).props().checked).toBe(true); // filter Deep Insights should be true by default
+    expect(filterItems.at(9).props().count).toBe(0); // total count for Auto Pilot
+    expect(filterItems.at(9).props().checked).toBe(true); // filter Auto Pilot should be true by default
   });
 
   it('renders tiles correctly', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
@@ -56,6 +56,9 @@ export const normalizeClusterServiceVersions = (
       kind: 'InstalledOperator',
       tileName: desc.displayName,
       tileIconClass: null,
+      capabilityLevel: _.get(desc, ['csv', 'metadata', 'annotations', 'capabilities'], '')
+        .toLowerCase()
+        .replace(/\s/g, ''),
       tileImgUrl: imgFor(desc),
       tileDescription: formatTileDescription(desc.description, desc.csv.spec.description),
       tileProvider: desc.csv.spec.provider.name,


### PR DESCRIPTION
This PR addresses https://issues.redhat.com/browse/ODC-2698

- Obtain capability of an operator backed object from CSV annotation and add it as a key `capabilityLevel` to an item of kind `installedOperator`
- Add capabilty filters to getFilter function
- Adjust filterGroup, filterValueMap to accommodate  `capability` filters and reflect as desired in Dev-Catalog.
- Set default filter set to true for `Auto Pilot`, `Deep Insights` and `Full Lifecycle`
- Added and adjusted tests in catalog.spec.tsx
- Convert catalog-item.jsx to tsx
- Add typings


![Screencast from 01-16-2020 04_48_30 PM](https://user-images.githubusercontent.com/24852534/72527608-288c8d00-388f-11ea-9c65-b62767e4ed73.gif)


~~TO-DO: Add typings for catalog-items.tsx~~
