### PR TITLE
Fix race condition for kebab actions

### DIFF
--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -58,7 +58,8 @@ export const actions = Object.freeze({
   edit: 'Edit',
   delete: 'Delete',
 });
-export const actionForLabel = (label: string) => $(`[data-test-action="${label}"]`);
+export const actionForLabel = (label: string) =>
+  $(`[data-test-action="${label}"]:not(.pf-m-disabled)`);
 
 export const filterForName = async (name: string) => {
   await browser.wait(until.presenceOf(textFilter));

--- a/frontend/integration-tests/views/monitoring.view.ts
+++ b/frontend/integration-tests/views/monitoring.view.ts
@@ -45,9 +45,7 @@ export const openFirstRowKebabMenu = () => {
   return firstRow
     .$('[data-test-id="kebab-button"]')
     .click()
-    .then(() =>
-      browser.wait(until.elementToBeClickable(crudView.actionForLabel('Delete Receiver'))),
-    );
+    .then(() => browser.wait(until.visibilityOf($('[data-test-id="action-items"]'))));
 };
 
 export const clickFirstRowKebabAction = (actionLabel: string) => {


### PR DESCRIPTION
Fix integration test race condition where kebab items were being clicked before access review had completed, causing no-op on click and test timeout. Increase specificity of protractor selector for kebab items so that they are only clicked when the 'pf-m-disabled' class is not applied.

This fix initially broke the alert manager test case 'prevents deletion of default receiver' because the kebab menu item for deleting the receiver is expected to be disabled. The helper 'openFirstRowKebabMenu' was waiting for the delete receiver kebab menu item to be clickable to confirm that the kebab menu was open. Updated that helper to wait for the kebab menu dropdown items to be visible instead.