### PR TITLE
Service Binding From Add Flow

### DIFF
--- a/frontend/packages/dev-console/src/components/QueryFocusApplication.tsx
+++ b/frontend/packages/dev-console/src/components/QueryFocusApplication.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { setActiveApplication } from '@console/internal/actions/ui';
+import { RootState } from '@console/internal/redux';
+import { getActiveApplication } from '@console/internal/reducers/ui';
+import { QUERY_PROPERTIES } from '../const';
+
+type StateProps = {
+  application: string;
+};
+type DispatchProps = {
+  onSetApp: (application: string) => void;
+};
+type OwnProps = {
+  children: (desiredApplication?: string) => React.ReactNode;
+};
+
+type QueryFocusApplicationProps = StateProps & DispatchProps & OwnProps;
+
+const QueryFocusApplication: React.FC<QueryFocusApplicationProps> = ({
+  children,
+  application,
+  onSetApp,
+}) => {
+  const originalApp = React.useRef(application);
+  const desiredApplication = new URLSearchParams(window.location.search).get(
+    QUERY_PROPERTIES.APPLICATION,
+  );
+
+  React.useEffect(() => {
+    const originalApplication = originalApp.current;
+    if (desiredApplication && desiredApplication !== originalApplication) {
+      onSetApp(desiredApplication);
+    }
+
+    return () => {
+      if (application !== originalApplication) {
+        onSetApp(originalApplication);
+      }
+    };
+  }, [desiredApplication, onSetApp, originalApp, application]);
+
+  return <>{children(desiredApplication)}</>;
+};
+
+export default connect<StateProps, DispatchProps, OwnProps>(
+  (state: RootState): StateProps => ({
+    application: getActiveApplication(state),
+  }),
+  {
+    onSetApp: setActiveApplication,
+  },
+)(QueryFocusApplication);

--- a/frontend/packages/dev-console/src/components/import/DeployImagePage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImagePage.tsx
@@ -2,13 +2,17 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { PageHeading, Firehose } from '@console/internal/components/utils';
+import { QUERY_PROPERTIES } from '../../const';
+import QueryFocusApplication from '../QueryFocusApplication';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import DeployImage from './DeployImage';
 
 export type DeployImagePageProps = RouteComponentProps<{ ns?: string }>;
 
-const DeployImagePage: React.FunctionComponent<DeployImagePageProps> = ({ match }) => {
+const DeployImagePage: React.FunctionComponent<DeployImagePageProps> = ({ match, location }) => {
   const namespace = match.params.ns;
+  const params = new URLSearchParams(location.search);
+
   return (
     <NamespacedPage disabled variant={NamespacedPageVariants.light}>
       <Helmet>
@@ -16,9 +20,17 @@ const DeployImagePage: React.FunctionComponent<DeployImagePageProps> = ({ match 
       </Helmet>
       <PageHeading title="Deploy Image" />
       <div className="co-m-pane__body">
-        <Firehose resources={[{ kind: 'Project', prop: 'projects', isList: true }]}>
-          <DeployImage namespace={namespace} />
-        </Firehose>
+        <QueryFocusApplication>
+          {(desiredApplication) => (
+            <Firehose resources={[{ kind: 'Project', prop: 'projects', isList: true }]}>
+              <DeployImage
+                forApplication={desiredApplication}
+                namespace={namespace}
+                contextualSource={params.get(QUERY_PROPERTIES.CONTEXT_SOURCE)}
+              />
+            </Firehose>
+          )}
+        </QueryFocusApplication>
       </div>
     </NamespacedPage>
   );

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -7,6 +7,8 @@ import { RootState } from '@console/internal/redux';
 import { connect } from 'react-redux';
 import { ALL_APPLICATIONS_KEY } from '@console/shared';
 import { NormalizedBuilderImages, normalizeBuilderImages } from '../../utils/imagestream-utils';
+import { doContextualBinding } from '../../utils/application-utils';
+import { ALLOW_SERVICE_BINDING } from '../../const';
 import { GitImportFormData, FirehoseList, ImportData, Resources } from './import-types';
 import { createOrUpdateResources, handleRedirect } from './import-submit-utils';
 import { validationSchema } from './import-validation-utils';
@@ -14,6 +16,7 @@ import { validationSchema } from './import-validation-utils';
 export interface ImportFormProps {
   namespace: string;
   importData: ImportData;
+  contextualSource?: string;
   imageStreams?: FirehoseList;
   projects?: {
     loaded: boolean;
@@ -24,15 +27,18 @@ export interface ImportFormProps {
 export interface StateProps {
   perspective: string;
   activeApplication: string;
+  serviceBindingAvailable: boolean;
 }
 
 const ImportForm: React.FC<ImportFormProps & StateProps> = ({
   namespace,
   imageStreams,
   importData,
+  contextualSource,
   perspective,
   activeApplication,
   projects,
+  serviceBindingAvailable,
 }) => {
   const initialValues: GitImportFormData = {
     name: '',
@@ -144,8 +150,22 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       project: { name: projectName },
     } = values;
 
-    createOrUpdateResources(values, imageStream, createNewProject, true)
-      .then(() => createOrUpdateResources(values, imageStream))
+    const resourceActions = createOrUpdateResources(
+      values,
+      imageStream,
+      createNewProject,
+      true,
+    ).then(() => createOrUpdateResources(values, imageStream));
+
+    if (contextualSource) {
+      resourceActions
+        .then((resources) =>
+          doContextualBinding(resources, contextualSource, serviceBindingAvailable),
+        )
+        .catch(() => {});
+    }
+
+    resourceActions
       .then(() => {
         actions.setSubmitting(false);
         handleRedirect(projectName, perspective);
@@ -178,12 +198,14 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => {
+type OwnProps = ImportFormProps & { forApplication?: string };
+const mapStateToProps = (state: RootState, ownProps: OwnProps): StateProps => {
   const perspective = getActivePerspective(state);
-  const activeApplication = getActiveApplication(state);
+  const activeApplication = ownProps.forApplication || getActiveApplication(state);
   return {
     perspective,
     activeApplication: activeApplication !== ALL_APPLICATIONS_KEY ? activeApplication : '',
+    serviceBindingAvailable: state.FLAGS.get(ALLOW_SERVICE_BINDING),
   };
 };
 

--- a/frontend/packages/dev-console/src/components/import/ImportPage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportPage.tsx
@@ -3,7 +3,9 @@ import { RouteComponentProps } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { PageHeading, Firehose, FirehoseResource } from '@console/internal/components/utils';
 import { ImageStreamModel } from '@console/internal/models';
+import { QUERY_PROPERTIES } from '../../const';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
+import QueryFocusApplication from '../QueryFocusApplication';
 import ImportForm from './ImportForm';
 import { ImportTypes, ImportData } from './import-types';
 
@@ -88,17 +90,26 @@ const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match, location 
   }
 
   return (
-    <NamespacedPage disabled variant={NamespacedPageVariants.light}>
-      <Helmet>
-        <title>{importData.title}</title>
-      </Helmet>
-      <PageHeading title={importData.title} />
-      <div className="co-m-pane__body">
-        <Firehose resources={resources}>
-          <ImportForm namespace={namespace || preselectedNamespace} importData={importData} />
-        </Firehose>
-      </div>
-    </NamespacedPage>
+    <QueryFocusApplication>
+      {(application) => (
+        <NamespacedPage disabled variant={NamespacedPageVariants.light}>
+          <Helmet>
+            <title>{importData.title}</title>
+          </Helmet>
+          <PageHeading title={importData.title} />
+          <div className="co-m-pane__body">
+            <Firehose resources={resources}>
+              <ImportForm
+                forApplication={application}
+                contextualSource={searchParams.get(QUERY_PROPERTIES.CONTEXT_SOURCE)}
+                namespace={namespace || preselectedNamespace}
+                importData={importData}
+              />
+            </Firehose>
+          </div>
+        </NamespacedPage>
+      )}
+    </QueryFocusApplication>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -30,6 +30,7 @@ import {
   createServiceBinding,
   removeServiceBinding,
   edgesFromServiceBinding,
+  getOperatorBackedServiceKindMap,
 } from '../../utils/application-utils';
 import { TopologyFilters } from './filters/filter-utils';
 import {
@@ -376,18 +377,8 @@ export const transformTopologyData = (
   filters?: TopologyFilters,
 ): TopologyDataModel => {
   const installedOperators = _.get(resources, 'clusterServiceVersions.data');
-  let operatorBackedServiceKindMap: OperatorBackedServiceKindMap;
+  const operatorBackedServiceKindMap = getOperatorBackedServiceKindMap(installedOperators);
   const serviceBindingRequests = _.get(resources, 'serviceBindingRequests.data');
-  if (installedOperators) {
-    operatorBackedServiceKindMap = installedOperators.reduce((kindMap, csv) => {
-      _.get(csv, 'spec.customresourcedefinitions.owned', []).forEach((crd) => {
-        if (!(crd.kind in kindMap)) {
-          kindMap[crd.kind] = csv;
-        }
-      });
-      return kindMap;
-    }, {});
-  }
 
   let topologyGraphAndNodeData: TopologyDataModel = {
     graph: { nodes: [], edges: [], groups: [] },

--- a/frontend/packages/dev-console/src/const.ts
+++ b/frontend/packages/dev-console/src/const.ts
@@ -1,3 +1,11 @@
 export const ALLOW_SERVICE_BINDING = 'ALLOW_SERVICE_BINDING';
 export const FLAG_OPENSHIFT_PIPELINE = 'OPENSHIFT_PIPELINE';
 export const CLUSTER_PIPELINE_NS = 'openshift';
+
+/** URL query params that adjust scope / purpose of the page */
+export enum QUERY_PROPERTIES {
+  /** For defining a contextual application group (ie, add new workload into this application group) */
+  APPLICATION = 'application',
+  /** For defining a contextual source of the redirect (ie, connect a new workload from this contextual source) */
+  CONTEXT_SOURCE = 'contextSource',
+}

--- a/frontend/packages/dev-console/src/utils/application-utils.ts
+++ b/frontend/packages/dev-console/src/utils/application-utils.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import {
   K8sKind,
+  k8sGet,
   k8sList,
   k8sPatch,
   k8sKill,
@@ -9,6 +10,7 @@ import {
   k8sCreate,
   LabelSelector,
   referenceFor,
+  referenceForModel,
 } from '@console/internal/module/k8s';
 import {
   ImageStreamModel,
@@ -22,6 +24,10 @@ import {
   StatefulSetModel,
 } from '@console/internal/models';
 import {
+  ClusterServiceVersionKind,
+  ClusterServiceVersionModel,
+} from '@console/operator-lifecycle-manager';
+import {
   ServiceModel as KnativeServiceModel,
   RouteModel as KnativeRouteModel,
   EventSourceCronJobModel,
@@ -31,7 +37,10 @@ import {
   EventSourceKafkaModel,
 } from '@console/knative-plugin';
 import { checkAccess } from '@console/internal/components/utils';
-import { TopologyDataObject } from '../components/topology/topology-types';
+import {
+  OperatorBackedServiceKindMap,
+  TopologyDataObject,
+} from '../components/topology/topology-types';
 import { detectGitType } from '../components/import/import-validation-utils';
 import { GitTypes } from '../components/import/import-types';
 import { ServiceBindingRequestModel } from '../models';
@@ -438,4 +447,77 @@ export const cleanUpWorkload = (
     deleteRequest(SecretModel, obj);
   });
   return Promise.all(reqs);
+};
+
+export const getOperatorBackedServiceKindMap = (
+  installedOperators: ClusterServiceVersionKind[],
+): OperatorBackedServiceKindMap => {
+  let operatorBackedServiceKindMap: OperatorBackedServiceKindMap = {};
+  if (installedOperators) {
+    operatorBackedServiceKindMap = installedOperators.reduce((kindMap, csv) => {
+      (csv?.spec?.customresourcedefinitions?.owned || []).forEach((crd) => {
+        if (!(crd.kind in kindMap)) {
+          kindMap[crd.kind] = csv;
+        }
+      });
+      return kindMap;
+    }, {});
+  }
+
+  return operatorBackedServiceKindMap;
+};
+
+export const doContextualBinding = async (
+  resources: K8sResourceKind[],
+  contextualSource: string,
+  serviceBindingAvailable: boolean = false,
+): Promise<K8sResourceKind[]> => {
+  if (!contextualSource) {
+    return Promise.reject(new Error('Cannot do a contextual binding without a source'));
+  }
+
+  const linkingModelRefs = [
+    referenceForModel(DeploymentConfigModel),
+    referenceForModel(DeploymentModel),
+  ];
+  const newResource: K8sResourceKind = resources.find((resource) =>
+    linkingModelRefs.includes(referenceFor(resource)),
+  );
+
+  if (!newResource) {
+    // Not a resource we want to connect to
+    return resources;
+  }
+
+  const {
+    metadata: { namespace },
+  } = newResource;
+  const [groupVersionKind, resourceName] = contextualSource.split('/');
+  const contextualResource: K8sResourceKind = await k8sGet(
+    modelFor(groupVersionKind),
+    resourceName,
+    namespace,
+  );
+
+  if (!contextualResource) {
+    return Promise.reject(
+      new Error(`Cannot find resource (${contextualSource}) to do a contextual binding to`),
+    );
+  }
+
+  if (serviceBindingAvailable) {
+    const operatorBackedServiceKindMap = getOperatorBackedServiceKindMap(
+      await k8sList(ClusterServiceVersionModel, { ns: namespace }),
+    );
+    const ownerResourceKind = newResource?.metadata?.ownerReferences?.[0]?.kind;
+    const isOperatorBacked = ownerResourceKind in operatorBackedServiceKindMap;
+
+    if (isOperatorBacked) {
+      await createServiceBinding(contextualResource, newResource);
+    }
+  }
+
+  await createResourceConnection(contextualResource, newResource);
+
+  return resources;
 };


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/ODC-2601

TODO:
- [x] Git Import
- [x] Deploy Image

We'll address these issues in a follow-up ticket. We should just get the code in for now to build that foundation.
- [ ] Test service binding
- [ ] Tests
- [ ] Catalog deployment


Given an application / workload setup like this:
<img width="1147" alt="Screen Shot 2020-01-14 at 12 38 05 PM" src="https://user-images.githubusercontent.com/8126518/72367941-182bb500-36cb-11ea-8752-8b4253306e1c.png">

Using the work to redirect to the add flow being done in #3918 to populate the URL with an application + contextSource:

![InContextAddConnector](https://user-images.githubusercontent.com/8126518/72368106-680a7c00-36cb-11ea-84eb-17111436c282.gif)

The slowness of the connector being added can be attributed to this issue: https://issues.redhat.com/browse/ODC-2726

cc @openshift/team-devconsole-ux 

---

For testing purposes while #3918 is being reviewed... Here are the steps to reproduce the above scenario:

1. Create a new project
2. Add a resource "From Git" (using https://github.com/nodeshift-starters/react-web-app)
3. Accept all the defaults & save the form
4. Use this URL (`your-namespace` will need to be updated to your chosen project in no.1) `http://localhost:9000/import/ns/your-namespace?importType=git&application=react-web-app-app&contextSource=core~v1~Deployment%2Freact-web-app`
(using https://github.com/nodeshift-starters/nodejs-rest-http)

Key parts here are the `application=react-web-app-app` and `contextSource=core~v1~Deployment%2Freact-web-app` (ie groupVersionKind/app-name)