### PR TITLE
Add Helm Release List Page

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseHeader.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseHeader.tsx
@@ -3,10 +3,10 @@ import { sortable } from '@patternfly/react-table';
 export const tableColumnClasses = {
   name: 'col-lg-2 col-md-3 col-sm-4 col-xs-4',
   revision: 'col-lg-2 col-md-3 col-sm-3 col-xs-3',
-  timestamp: 'col-lg-2 col-md-4 col-sm-5 col-xs-5',
+  updated: 'col-lg-2 col-md-4 col-sm-5 col-xs-5',
   status: 'col-lg-2 col-md-2 hidden-sm hidden-xs',
   chartName: 'col-lg-2 hidden-md hidden-sm hidden-xs',
-  chartVersion: 'col-lg-2 hidden-md hidden-sm hidden-xs',
+  appVersion: 'col-lg-2 hidden-md hidden-sm hidden-xs',
 };
 
 const HelmReleaseHeader = () => {
@@ -24,10 +24,10 @@ const HelmReleaseHeader = () => {
       props: { className: tableColumnClasses.revision },
     },
     {
-      title: 'Timestamp',
+      title: 'Updated',
       sortField: 'info.last_deployed',
       transforms: [sortable],
-      props: { className: tableColumnClasses.timestamp },
+      props: { className: tableColumnClasses.updated },
     },
     {
       title: 'Status',
@@ -42,10 +42,10 @@ const HelmReleaseHeader = () => {
       props: { className: tableColumnClasses.chartName },
     },
     {
-      title: 'Chart Version',
-      sortField: 'chart.metadata.version',
+      title: 'App Version',
+      sortField: 'chart.metadata.appVersion',
       transforms: [sortable],
-      props: { className: tableColumnClasses.chartVersion },
+      props: { className: tableColumnClasses.appVersion },
     },
   ];
 };

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseHeader.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseHeader.tsx
@@ -1,0 +1,53 @@
+import { sortable } from '@patternfly/react-table';
+
+export const tableColumnClasses = {
+  name: 'col-lg-2 col-md-3 col-sm-4 col-xs-4',
+  revision: 'col-lg-2 col-md-3 col-sm-3 col-xs-3',
+  timestamp: 'col-lg-2 col-md-4 col-sm-5 col-xs-5',
+  status: 'col-lg-2 col-md-2 hidden-sm hidden-xs',
+  chartName: 'col-lg-2 hidden-md hidden-sm hidden-xs',
+  chartVersion: 'col-lg-2 hidden-md hidden-sm hidden-xs',
+};
+
+const HelmReleaseHeader = () => {
+  return [
+    {
+      title: 'Name',
+      sortField: 'name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.name },
+    },
+    {
+      title: 'Revision',
+      sortField: 'version',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.revision },
+    },
+    {
+      title: 'Timestamp',
+      sortField: 'info.last_deployed',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.timestamp },
+    },
+    {
+      title: 'Status',
+      sortField: 'info.status',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.status },
+    },
+    {
+      title: 'Chart Name',
+      sortField: 'chart.metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.chartName },
+    },
+    {
+      title: 'Chart Version',
+      sortField: 'chart.metadata.version',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.chartVersion },
+    },
+  ];
+};
+
+export default HelmReleaseHeader;

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
@@ -20,7 +20,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets })
   const [filteredReleases, setFilteredReleases] = React.useState([]);
   const [fetched, setFetched] = React.useState(false);
 
-  const memoizedSecrets = useDeepCompareMemoize(secrets.data);
+  const memoizedSecrets = useDeepCompareMemoize(_.get(secrets, 'data'));
 
   React.useEffect(() => {
     let ignore = false;
@@ -30,7 +30,13 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets })
       getQueryArgument('rowFilter-helm-release-status').split(',');
 
     const fetchHelmReleases = async () => {
-      const res: HelmRelease[] = await coFetchJSON('/api/console/helm/list');
+      let res: HelmRelease[];
+      try {
+        res = await coFetchJSON('/api/helm/releases');
+      } catch {
+        setReleases([]);
+        setFetched(true);
+      }
       const namespacedReleases = (res && res.filter((rel) => rel.namespace === namespace)) || [];
 
       if (ignore) return;

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { coFetchJSON } from '@console/internal/co-fetch';
+import { Table, TextFilter } from '@console/internal/components/factory';
+import { SortByDirection } from '@patternfly/react-table';
+import { CheckBoxes } from '@console/internal/components/row-filter';
+import { FirehoseResult, getQueryArgument } from '@console/internal/components/utils';
+import { HelmRelease, HelmFilterType } from './helm-types';
+import { helmRowFilters, getFilteredItems, useDeepCompareMemoize } from './helm-utils';
+import HelmReleaseHeader from './HelmReleaseHeader';
+import HelmReleaseRow from './HelmReleaseRow';
+
+interface HelmReleaseListProps {
+  namespace: string;
+  secrets?: FirehoseResult;
+}
+
+const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets }) => {
+  const [releases, setReleases] = React.useState([]);
+  const [filteredReleases, setFilteredReleases] = React.useState([]);
+  const [fetched, setFetched] = React.useState(false);
+
+  const memoizedSecrets = useDeepCompareMemoize(secrets.data);
+
+  React.useEffect(() => {
+    let ignore = false;
+
+    const activeFilters =
+      getQueryArgument('rowFilter-helm-release-status') &&
+      getQueryArgument('rowFilter-helm-release-status').split(',');
+
+    const fetchHelmReleases = async () => {
+      const res: HelmRelease[] = await coFetchJSON('/api/console/helm/list');
+      const namespacedReleases = (res && res.filter((rel) => rel.namespace === namespace)) || [];
+
+      if (ignore) return;
+
+      setReleases(namespacedReleases);
+      setFetched(true);
+
+      if (activeFilters) {
+        const filteredItems = getFilteredItems(
+          namespacedReleases,
+          HelmFilterType.Row,
+          activeFilters,
+        );
+        setFilteredReleases(filteredItems);
+      } else {
+        setFilteredReleases(namespacedReleases);
+      }
+    };
+
+    fetchHelmReleases();
+
+    return () => {
+      ignore = true;
+    };
+  }, [namespace, memoizedSecrets]);
+
+  const applyRowFilter = React.useCallback(
+    (filter) => {
+      const filteredItems = getFilteredItems(releases, HelmFilterType.Row, filter);
+      setFilteredReleases(filteredItems);
+    },
+    [releases],
+  );
+
+  const applyTextFilter = React.useCallback(
+    (filter) => {
+      const filteredItems = getFilteredItems(releases, HelmFilterType.Text, filter);
+      setFilteredReleases(filteredItems);
+    },
+    [releases],
+  );
+
+  const RowsOfRowFilters = _.map(helmRowFilters, ({ items, reducer, selected, type }, i) => {
+    return (
+      <CheckBoxes
+        key={i}
+        applyFilter={applyRowFilter}
+        items={items}
+        itemCount={_.size(releases)}
+        numbers={_.countBy(releases, reducer)}
+        selected={selected}
+        type={type}
+        reduxIDs={[]}
+      />
+    );
+  });
+
+  return (
+    <>
+      <div className="co-m-pane__filter-bar">
+        <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--filter">
+          <TextFilter label="by name" onChange={(e) => applyTextFilter(e.target.value)} />
+        </div>
+      </div>
+
+      <div className="co-m-pane__body">
+        {!_.isEmpty(releases) && RowsOfRowFilters}
+        <Table
+          data={filteredReleases}
+          defaultSortField="name"
+          defaultSortOrder={SortByDirection.asc}
+          aria-label="Helm Releases"
+          Header={HelmReleaseHeader}
+          Row={HelmReleaseRow}
+          loaded={fetched}
+          virtualize
+        />
+      </div>
+    </>
+  );
+};
+
+export default React.memo(HelmReleaseList);

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
@@ -20,20 +20,21 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets })
   const [filteredReleases, setFilteredReleases] = React.useState([]);
   const [fetched, setFetched] = React.useState(false);
 
-  const memoizedSecrets = useDeepCompareMemoize(_.get(secrets, 'data'));
+  const memoizedSecrets = useDeepCompareMemoize(secrets?.data);
 
   React.useEffect(() => {
     let ignore = false;
 
-    const activeFilters =
-      getQueryArgument('rowFilter-helm-release-status') &&
-      getQueryArgument('rowFilter-helm-release-status').split(',');
+    const queryArgument = getQueryArgument('rowFilter-helm-release-status');
+    const activeFilters = queryArgument?.split(',');
 
     const fetchHelmReleases = async () => {
       let res: HelmRelease[];
       try {
         res = await coFetchJSON('/api/helm/releases');
       } catch {
+        if (ignore) return;
+
         setReleases([]);
         setFetched(true);
       }
@@ -79,7 +80,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets })
     [releases],
   );
 
-  const RowsOfRowFilters = _.map(helmRowFilters, ({ items, reducer, selected, type }, i) => {
+  const rowsOfRowFilters = _.map(helmRowFilters, ({ items, reducer, selected, type }, i) => {
     return (
       <CheckBoxes
         key={i}
@@ -103,7 +104,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets })
       </div>
 
       <div className="co-m-pane__body">
-        {!_.isEmpty(releases) && RowsOfRowFilters}
+        {!_.isEmpty(releases) && rowsOfRowFilters}
         <Table
           data={filteredReleases}
           defaultSortField="name"

--- a/frontend/packages/dev-console/src/components/helm/HelmReleasePage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleasePage.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router';
+import Helmet from 'react-helmet';
+import { PageHeading, Firehose } from '@console/internal/components/utils';
+import { SecretModel } from '@console/internal/models';
+import ProjectListPage from '../projects/ProjectListPage';
+import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
+import HelmReleaseList from './HelmReleaseList';
+
+type HelmReleasePageProps = RouteComponentProps<{ ns: string }>;
+
+export const HelmReleasePage: React.FC<HelmReleasePageProps> = (props) => {
+  const {
+    match: {
+      params: { ns: namespace },
+    },
+  } = props;
+
+  const resources = [
+    {
+      isList: true,
+      namespace,
+      kind: SecretModel.kind,
+      prop: 'secrets',
+      optional: true,
+      selector: { owner: 'helm' },
+    },
+  ];
+  return namespace ? (
+    <NamespacedPage variant={NamespacedPageVariants.light} hideApplications>
+      <Helmet>
+        <title>Helm Releases</title>
+      </Helmet>
+      <PageHeading title="Helm Releases" />
+      <Firehose resources={resources}>
+        <HelmReleaseList namespace={namespace} />
+      </Firehose>
+    </NamespacedPage>
+  ) : (
+    <ProjectListPage title="Helm Releases">
+      Select a project to view the list of Helm Releases
+    </ProjectListPage>
+  );
+};
+
+export default HelmReleasePage;

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseRow.tsx
@@ -21,21 +21,20 @@ const HelmReleaseRow: React.FC<HelmReleaseRowProps> = ({ obj, index, key, style 
           to={`/helm-releases/ns/${obj.namespace}/release/${obj.name}`}
           title={obj.name}
           className="co-resource-item__resource-name"
-          data-test-id={obj.name}
         >
           {obj.name}
         </Link>
       </TableData>
       <TableData className={tableColumnClasses.revision}>{obj.version}</TableData>
-      <TableData className={tableColumnClasses.timestamp}>
+      <TableData className={tableColumnClasses.updated}>
         <Timestamp timestamp={obj.info.last_deployed} />
       </TableData>
       <TableData className={tableColumnClasses.status}>
         <Status status={obj.info.status} />
       </TableData>
       <TableData className={tableColumnClasses.chartName}>{obj.chart.metadata.name}</TableData>
-      <TableData className={tableColumnClasses.chartVersion}>
-        {obj.chart.metadata.version}
+      <TableData className={tableColumnClasses.appVersion}>
+        {obj.chart.metadata.appVersion}
       </TableData>
     </TableRow>
   );

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseRow.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { Status } from '@console/shared';
+import { TableRow, TableData } from '@console/internal/components/factory';
+import { Timestamp } from '@console/internal/components/utils';
+import { Link } from 'react-router-dom';
+import { HelmRelease } from './helm-types';
+import { tableColumnClasses } from './HelmReleaseHeader';
+
+interface HelmReleaseRowProps {
+  obj: HelmRelease;
+  index: number;
+  key?: string;
+  style: object;
+}
+
+const HelmReleaseRow: React.FC<HelmReleaseRowProps> = ({ obj, index, key, style }) => {
+  return (
+    <TableRow id={obj.name} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses.name}>
+        <Link
+          to={`/helm-releases/ns/${obj.namespace}/release/${obj.name}`}
+          title={obj.name}
+          className="co-resource-item__resource-name"
+          data-test-id={obj.name}
+        >
+          {obj.name}
+        </Link>
+      </TableData>
+      <TableData className={tableColumnClasses.revision}>{obj.version}</TableData>
+      <TableData className={tableColumnClasses.timestamp}>
+        <Timestamp timestamp={obj.info.last_deployed} />
+      </TableData>
+      <TableData className={tableColumnClasses.status}>
+        <Status status={obj.info.status} />
+      </TableData>
+      <TableData className={tableColumnClasses.chartName}>{obj.chart.metadata.name}</TableData>
+      <TableData className={tableColumnClasses.chartVersion}>
+        {obj.chart.metadata.version}
+      </TableData>
+    </TableRow>
+  );
+};
+
+export default HelmReleaseRow;

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
@@ -1,0 +1,123 @@
+import { HelmRelease } from '../helm-types';
+
+/* eslint-disable @typescript-eslint/camelcase */
+export const mockHelmReleases: HelmRelease[] = [
+  {
+    name: 'ghost-test',
+    info: {
+      first_deployed: '2020-01-20T15:46:47.776679107+05:30',
+      last_deployed: '2020-01-20T15:46:47.776679107+05:30',
+      deleted: '',
+      description: 'Install complete',
+      status: 'deployed',
+      notes: '',
+    },
+    chart: {
+      metadata: {
+        name: 'ghost',
+        home: 'http://www.ghost.org/',
+        sources: ['https://github.com/bitnami/bitnami-docker-ghost'],
+        version: '9.0.2',
+        description:
+          'A simple, powerful publishing platform that allows you to share your stories with the world',
+        keywords: ['ghost', 'blog', 'http', 'web', 'application', 'nodejs', 'javascript'],
+        maintainers: [
+          {
+            name: 'Bitnami',
+            email: 'containers@bitnami.com',
+          },
+        ],
+        icon: 'https://bitnami.com/assets/stacks/ghost/img/ghost-stack-220x234.png',
+        apiVersion: 'v1',
+        appVersion: '3.1.0',
+        dependencies: [
+          {
+            name: 'mariadb',
+            version: '7.x.x',
+            repository: 'https://kubernetes-charts.storage.googleapis.com/',
+            condition: 'mariadb.enabled',
+            tags: ['ghost-database'],
+            enabled: true,
+          },
+        ],
+      },
+      lock: {
+        generated: '2019-11-27T17:17:48.26496196Z',
+        digest: 'sha256:27bef733eb099a7377055cfe2c48e013bd4d55650ff18b50138c80488c812b0b',
+        dependencies: [
+          {
+            name: 'mariadb',
+            version: '7.1.0',
+            repository: 'https://kubernetes-charts.storage.googleapis.com/',
+          },
+        ],
+      },
+      templates: [],
+      values: {},
+      schema: '',
+      files: [],
+    },
+    manifest: '',
+    hooks: [],
+    version: 1,
+    namespace: 'test-helm',
+  },
+  {
+    name: 'node-test-chart',
+    info: {
+      first_deployed: '2020-01-20T15:12:04.19900271+05:30',
+      last_deployed: '2020-01-20T15:12:04.19900271+05:30',
+      deleted: '',
+      description: 'Install complete',
+      status: 'failed',
+      notes: '',
+    },
+    chart: {
+      metadata: {
+        name: 'nodejs-ex-k',
+        version: '0.1.0',
+        description: 'A Helm chart for Kubernetes',
+        apiVersion: 'v2',
+        appVersion: '1.16.0',
+        type: 'application',
+      },
+      lock: null,
+      templates: [],
+      values: {},
+      schema: null,
+      files: [],
+    },
+    manifest: '',
+    version: 1,
+    namespace: 'test-helm',
+  },
+  {
+    name: 'node-test-chart',
+    info: {
+      first_deployed: '2020-01-20T15:12:04.19900271+05:30',
+      last_deployed: '2020-01-20T15:12:04.19900271+05:30',
+      deleted: '',
+      description: 'Install complete',
+      status: 'pending-install',
+      notes: '',
+    },
+    chart: {
+      metadata: {
+        name: 'nodejs-ex-k',
+        version: '0.1.0',
+        description: 'A Helm chart for Kubernetes',
+        apiVersion: 'v2',
+        appVersion: '1.16.0',
+        type: 'application',
+      },
+      lock: null,
+      templates: [],
+      values: {},
+      schema: null,
+      files: [],
+    },
+    manifest: '',
+    version: 1,
+    namespace: 'test-helm',
+  },
+];

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-utils.spec.ts
@@ -1,0 +1,35 @@
+import { releaseStatusReducer, getFilteredItems, otherStatuses } from '../helm-utils';
+import { HelmReleaseStatus, HelmFilterType } from '../helm-types';
+import { mockHelmReleases } from './helm-release-mock-data';
+
+describe('Helm Releases Utils', () => {
+  it('should return deployed or failed status for a helm release', () => {
+    const release = mockHelmReleases[0];
+    expect(releaseStatusReducer(release)).toEqual(HelmReleaseStatus.Deployed);
+  });
+
+  it('should return other for all other statuses for a helm release', () => {
+    const release = mockHelmReleases[2];
+    expect(releaseStatusReducer(release)).toEqual(HelmReleaseStatus.Other);
+  });
+
+  it('should return filtered release items with deployed and failed status for row filters', () => {
+    const filter = ['deployed', 'failed'];
+    const filteredReleases = getFilteredItems(mockHelmReleases, HelmFilterType.Row, filter);
+    expect(filteredReleases.length).toEqual(2);
+    expect(filteredReleases[0].info.status).toBe(HelmReleaseStatus.Deployed);
+  });
+
+  it('should return filtered release items with other status for row filters', () => {
+    const filter = ['other'];
+    const filteredReleases = getFilteredItems(mockHelmReleases, HelmFilterType.Row, filter);
+    expect(filteredReleases.length).toEqual(1);
+    expect(otherStatuses.includes(filteredReleases[0].info.status)).toBeTruthy();
+  });
+
+  it('should return filtered release items for text filter', () => {
+    const filteredReleases = getFilteredItems(mockHelmReleases, HelmFilterType.Text, 'ghost');
+    expect(filteredReleases.length).toEqual(1);
+    expect(filteredReleases[0].name).toBe('ghost-test');
+  });
+});

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -1,25 +1,40 @@
 export interface HelmRelease {
   name: string;
   namespace: string;
-  chart: {
-    files: object[];
-    metadata: {
-      name: string;
-      version: string;
-    };
-    templates: object[];
-    values: object;
-  };
+  chart: HelmChart;
   info: {
     description: string;
     deleted: string;
     first_deployed: string;
     last_deployed: string;
     status: string;
+    notes: string;
   };
-  hooks: object[];
-  manifest: string;
-  version: string;
+  version: number | string;
+  hooks?: object[];
+  manifest?: string;
+}
+
+export interface HelmChart {
+  files: object[];
+  metadata: {
+    name: string;
+    version: string;
+    description: string;
+    apiVersion: string;
+    appVersion: string;
+    keywords?: string[];
+    home?: string;
+    icon?: string;
+    sources?: string[];
+    maintainers?: object[];
+    dependencies?: object[];
+    type?: string;
+  };
+  templates: object[];
+  values: object;
+  lock?: object;
+  schema?: string;
 }
 
 export enum HelmReleaseStatus {

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -1,0 +1,34 @@
+export interface HelmRelease {
+  name: string;
+  namespace: string;
+  chart: {
+    files: object[];
+    metadata: {
+      name: string;
+      version: string;
+    };
+    templates: object[];
+    values: object;
+  };
+  info: {
+    description: string;
+    deleted: string;
+    first_deployed: string;
+    last_deployed: string;
+    status: string;
+  };
+  hooks: object[];
+  manifest: string;
+  version: string;
+}
+
+export enum HelmReleaseStatus {
+  Deployed = 'deployed',
+  Failed = 'failed',
+  Other = 'other',
+}
+
+export enum HelmFilterType {
+  Row = 'row',
+  Text = 'text',
+}

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import * as fuzzy from 'fuzzysearch';
+import { HelmRelease, HelmReleaseStatus, HelmFilterType } from './helm-types';
+
+export const HelmReleaseStatusLabels = {
+  [HelmReleaseStatus.Deployed]: 'Deployed',
+  [HelmReleaseStatus.Failed]: 'Failed',
+  [HelmReleaseStatus.Other]: 'Other',
+};
+
+export const otherStatuses = [
+  'unknown',
+  'uninstalled',
+  'superseded',
+  'uninstalling',
+  'pending-install',
+  'pending-upgrade',
+  'pending-rollback',
+];
+
+export const releaseStatusReducer = (release: HelmRelease) => {
+  if (otherStatuses.includes(release.info.status)) {
+    return HelmReleaseStatus.Other;
+  }
+  return release.info.status;
+};
+
+export const selectedStatuses = [
+  HelmReleaseStatus.Deployed,
+  HelmReleaseStatus.Failed,
+  HelmReleaseStatus.Other,
+];
+
+export const helmRowFilters = [
+  {
+    type: 'helm-release-status',
+    selected: selectedStatuses,
+    reducer: releaseStatusReducer,
+    items: selectedStatuses.map((status) => ({
+      id: status,
+      title: HelmReleaseStatusLabels[status],
+    })),
+  },
+];
+
+export const getFilteredItems = (
+  items: HelmRelease[],
+  filterType: HelmFilterType,
+  filter: string | string[],
+) => {
+  switch (filterType) {
+    case HelmFilterType.Row:
+      return items.filter((release: HelmRelease) => {
+        return otherStatuses.includes(release.info.status)
+          ? filter.includes(HelmReleaseStatus.Other)
+          : filter.includes(release.info.status);
+      });
+    case HelmFilterType.Text:
+      return items.filter((release: HelmRelease) => fuzzy(filter, release.name));
+    default:
+      return items;
+  }
+};
+
+export const useDeepCompareMemoize = (value) => {
+  const ref = React.useRef();
+
+  if (!_.isEqual(value, ref.current)) {
+    ref.current = value;
+  }
+
+  return ref.current;
+};

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -153,6 +153,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'NavItem/Href',
+    properties: {
+      perspective: 'dev',
+      componentProps: {
+        name: 'Helm Releases',
+        href: '/helm-releases',
+        required: FLAGS.OPENSHIFT,
+        testID: 'helm-releases-header',
+      },
+    },
+  },
+  {
     type: 'NavItem/ResourceCluster',
     properties: {
       section: 'Advanced',
@@ -415,6 +427,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         '/project-access',
         '/dev-monitoring',
         '/edit',
+        '/helm-releases',
       ],
       component: NamespaceRedirect,
     },
@@ -607,6 +620,19 @@ const plugin: Plugin<ConsumedExtensions> = [
       loader: async () =>
         (await import('./components/MetricsPage' /* webpackChunkName: "dev-console-metrics" */))
           .default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: ['/helm-releases/all-namespaces', '/helm-releases/ns/:ns'],
+      loader: async () =>
+        (
+          await import(
+            './components/helm/HelmReleasePage' /* webpackChunkName: "dev-console-helm-releases" */
+          )
+        ).default,
     },
   },
   {

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -159,9 +159,11 @@ const plugin: Plugin<ConsumedExtensions> = [
       componentProps: {
         name: 'Helm Releases',
         href: '/helm-releases',
-        required: FLAGS.OPENSHIFT,
         testID: 'helm-releases-header',
       },
+    },
+    flags: {
+      required: [FLAGS.OPENSHIFT],
     },
   },
   {

--- a/frontend/public/components/row-filter.jsx
+++ b/frontend/public/components/row-filter.jsx
@@ -102,6 +102,7 @@ class CheckBoxes_ extends React.Component {
     const all = _.map(this.props.items, 'id');
     const recognized = _.intersection(this.state.selected, all);
     if (!_.isEmpty(recognized)) {
+      this.props.applyFilter && this.props.applyFilter(recognized);
       this.props.reduxIDs.forEach((id) =>
         this.props.filterList(id, this.props.type, { selected: new Set(recognized), all }),
       );
@@ -163,5 +164,5 @@ class CheckBoxes_ extends React.Component {
   }
 }
 
-/** @type {React.SFC<{items: Array, itemCount: number, numbers: any, reduxIDs: Array, selected?: Array, type: string}>} */
+/** @type {React.SFC<{items: Array, itemCount: number, numbers: any, reduxIDs: Array, selected?: Array, type: string, applyFilter?: (filter) => void}>} */
 export const CheckBoxes = connect(null, { filterList })(CheckBoxes_);


### PR DESCRIPTION
### Related Story - https://issues.redhat.com/browse/ODC-2524

### Depends on https://github.com/openshift/console/pull/3826 for the `/helm/list` API.

### This PR -
- Adds a new Nav Item for `Helm Releases`.
- Adds new components - `HelmReleasePage`, `HelmReleaseList`,  `HelmReleaseHeader` and `HelmReleaseRow`.
- `HelmReleaseList` calls `/helm/list` API based on the namespace and Helm Release secrets fetch by firehose.
- To minimize the number of API calls due to `firehose` resources chaning too often, adds a new utility for deep comparisons on dependencies in `useEffect` hook.
- Adds custom text based filtering using `TextFilter` component from console.
- Adds custom row filtering based on Helm Status using `CheckBoxes` component from console. The status based filtering also adds capability to filter multiplw statuses based on combined filter `Other`.


@openshift/team-devconsole-ux 
### Screencasts - 

#### Helm Release List and Filtering - 

![Helm Release List - 1](https://user-images.githubusercontent.com/6041994/72372713-d92e4b80-372c-11ea-8562-e88227d186bd.gif)

#### Auto Update List - 

![Helm Release List - 2](https://user-images.githubusercontent.com/6041994/72372714-d9c6e200-372c-11ea-8875-09df7e51f1a1.gif)
