### PR TITLE
added monitoring tab with metrics section

### DIFF
--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -21,6 +21,7 @@ export type OverviewItem<T = K8sResourceKind> = {
   configurations?: K8sResourceKind[];
   ksservices?: K8sResourceKind[];
   revisions?: K8sResourceKind[];
+  events?: K8sResourceKind[];
 };
 
 export type DeploymentStrategy = DEPLOYMENT_STRATEGY.recreate | DEPLOYMENT_STRATEGY.rolling;

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -108,6 +108,12 @@ export const getResourceList = (namespace: string, resList?: any) => {
       namespace,
       prop: 'statefulSets',
     },
+    {
+      isList: true,
+      kind: 'Event',
+      namespace,
+      prop: 'events',
+    },
   ];
 
   let utils = [];
@@ -588,6 +594,20 @@ export class TransformResourceData {
     });
   };
 
+  public getEventsForPods = (pods) => {
+    const { events } = this.resources;
+    const kind = 'Pod';
+    const podNameList = _.map(pods, 'metadata.name');
+    const podEvents =
+      events &&
+      _.filter(events.data, (event) => {
+        return (
+          event.involvedObject.kind === kind && podNameList.includes(event.involvedObject.name)
+        );
+      });
+    return podEvents;
+  };
+
   public getServicesForResource = (resource: K8sResourceKind): K8sResourceKind[] => {
     const { services } = this.resources;
     const template: PodTemplate = this.getPodTemplate(resource);
@@ -620,6 +640,8 @@ export class TransformResourceData {
         ...rolloutAlerts,
       };
       const status = resourceStatus(obj, current, isRollingOut);
+      const pods = [..._.get(current, 'pods', []), ..._.get(previous, 'pods', [])];
+      const events = this.getEventsForPods(pods);
       const overviewItems = {
         alerts,
         buildConfigs,
@@ -627,10 +649,11 @@ export class TransformResourceData {
         isRollingOut,
         obj,
         previous,
-        pods: [..._.get(current, 'pods', []), ..._.get(previous, 'pods', [])],
+        pods,
         routes,
         services,
         status,
+        events,
       };
 
       if (this.utils) {
@@ -662,6 +685,8 @@ export class TransformResourceData {
         ...getBuildAlerts(buildConfigs),
       };
       const status = resourceStatus(obj, current, isRollingOut);
+      const pods = [..._.get(current, 'pods', []), ..._.get(previous, 'pods', [])];
+      const events = this.getEventsForPods(pods);
       const overviewItems = {
         alerts,
         buildConfigs,
@@ -669,10 +694,11 @@ export class TransformResourceData {
         isRollingOut,
         obj,
         previous,
-        pods: [..._.get(current, 'pods', []), ..._.get(previous, 'pods', [])],
+        pods,
         routes,
         services,
         status,
+        events,
       };
 
       if (this.utils) {
@@ -700,6 +726,7 @@ export class TransformResourceData {
         ...getBuildAlerts(buildConfigs),
       };
       const status = resourceStatus(obj);
+      const events = this.getEventsForPods(pods);
       return {
         alerts,
         buildConfigs,
@@ -708,6 +735,7 @@ export class TransformResourceData {
         routes,
         services,
         status,
+        events,
       };
     });
   };
@@ -728,6 +756,7 @@ export class TransformResourceData {
       const services = this.getServicesForResource(obj);
       const routes = this.getRoutesForServices(services);
       const status = resourceStatus(obj);
+      const events = this.getEventsForPods(pods);
 
       return {
         alerts,
@@ -737,6 +766,7 @@ export class TransformResourceData {
         routes,
         services,
         status,
+        events,
       };
     });
   };

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringMetricsSection.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringMetricsSection.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionToggle,
+  AccordionContent,
+  Grid,
+  GridItem,
+} from '@patternfly/react-core';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { requirePrometheus } from '@console/internal/components/graphs';
+import MonitoringDashboardGraph from '../dashboard/MonitoringDashboardGraph';
+import { workloadMetricQueries } from './queries';
+import './MonitoringSection.scss';
+
+const WorkloadGraphs = requirePrometheus(({ resource }) => {
+  const ns = resource.metadata.namespace;
+  const workloadName = resource.metadata.name;
+  const workloadType = resource.kind.toLowerCase();
+  return (
+    <Grid className="co-m-pane__body">
+      {_.map(workloadMetricQueries, (q) => (
+        <GridItem span={12} key={q.title}>
+          <MonitoringDashboardGraph
+            title={q.title}
+            namespace={ns}
+            graphType={q.chartType}
+            query={q.query({ ns, workloadName, workloadType })}
+            humanize={q.humanize}
+            byteDataType={q.byteDataType}
+          />
+        </GridItem>
+      ))}
+    </Grid>
+  );
+});
+
+type MonitoringMetricsSectionProps = {
+  resource: K8sResourceKind;
+};
+
+const MonitoringMetricsSection: React.FC<MonitoringMetricsSectionProps> = ({ resource }) => {
+  const [expanded, setExpanded] = React.useState('');
+
+  const onToggle = (id: string) => {
+    setExpanded(id === expanded ? '' : id);
+  };
+
+  return (
+    <div className="odc-monitoring-section">
+      <Accordion
+        asDefinitionList={false}
+        noBoxShadow
+        className="odc-monitoring-section__metric-accordion"
+        headingLevel="h5"
+      >
+        <AccordionItem>
+          <AccordionToggle
+            onClick={() => {
+              onToggle('metrics');
+            }}
+            isExpanded={expanded === 'metrics'}
+            id="metrics"
+          >
+            Metrics
+          </AccordionToggle>
+          <AccordionContent id="metrics" isHidden={expanded !== 'metrics'}>
+            <WorkloadGraphs resource={resource} />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+};
+
+export default MonitoringMetricsSection;

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringSection.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringSection.scss
@@ -1,0 +1,14 @@
+.odc-monitoring-section {
+    &__metric-accordion {
+        padding: 0;
+    }
+    h5 {
+        margin: 0;
+    }
+    .pf-c-accordion__expanded-content.pf-m-expanded {
+        --pf-c-accordion__expanded-content--BorderLeftColor: transparent;
+    }
+    .pf-c-accordion__toggle.pf-m-expanded {
+        --pf-c-accordion__toggle--BorderLeftColor: transparent;
+    }
+} 

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringTab.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringTab.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { OverviewItem } from '@console/shared';
+import MonitoringMetricsSection from './MonitoringMetricsSection';
+
+type MonitoringTabProps = {
+  item: OverviewItem;
+};
+
+const MonitoringTab: React.FC<MonitoringTabProps> = ({ item: { obj: res } }) => {
+  return <MonitoringMetricsSection resource={res} />;
+};
+
+export default MonitoringTab;

--- a/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringMetricsSection.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringMetricsSection.spec.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { AccordionContent, AccordionToggle } from '@patternfly/react-core';
+import MonitoringMetricsSection from '../MonitoringMetricsSection';
+
+describe('Monitoring Metric Section', () => {
+  const metSecProps: React.ComponentProps<typeof MonitoringMetricsSection> = {
+    resource: {
+      metadata: {
+        name: 'workload-name',
+        namespace: 'test',
+      },
+      spec: {},
+      status: {},
+      kind: 'Deployment',
+    },
+  };
+
+  it('should render Metric Section for workload of type Deployment', () => {
+    const component = shallow(<MonitoringMetricsSection {...metSecProps} />);
+    expect(component.find(AccordionContent).exists()).toBe(true);
+    expect(component.find(AccordionContent).prop('isExpanded')).toBe(undefined);
+  });
+
+  it('should expand & collapse Metric Section accordion', () => {
+    const component = shallow(<MonitoringMetricsSection {...metSecProps} />);
+    component.find(AccordionToggle).simulate('click');
+    expect(component.find(AccordionToggle).prop('isExpanded')).toBe(true);
+    expect(component.find(AccordionContent).prop('isHidden')).toBe(false);
+    component.find(AccordionToggle).simulate('click');
+    expect(component.find(AccordionToggle).prop('isExpanded')).toBe(false);
+    expect(component.find(AccordionContent).prop('isHidden')).toBe(true);
+  });
+});

--- a/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringTab.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/__tests__/MonitoringTab.spec.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import MonitoringTab from '../MonitoringTab';
+import MonitoringMetricsSection from '../MonitoringMetricsSection';
+
+describe('Monitoring Tab', () => {
+  const monTabProps: React.ComponentProps<typeof MonitoringTab> = {
+    item: {
+      obj: {
+        metadata: {
+          name: 'workload-name',
+          namespace: 'test',
+        },
+        kind: 'Deployment',
+        status: {},
+        spec: {
+          selector: {},
+          template: {
+            metadata: {},
+            spec: {
+              containers: [],
+            },
+          },
+        },
+      },
+      buildConfigs: [],
+      routes: [],
+      services: [],
+    },
+  };
+
+  it('should render Monitoring tab with Metrics section for selected workload', () => {
+    const component = shallow(<MonitoringTab {...monTabProps} />);
+    expect(component.find(MonitoringMetricsSection).exists()).toBe(true);
+  });
+});

--- a/frontend/packages/dev-console/src/components/monitoring/overview/queries.ts
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/queries.ts
@@ -1,0 +1,56 @@
+import { template } from 'lodash';
+import {
+  humanizeBinaryBytes,
+  humanizeCpuCores,
+  humanizeDecimalBytesPerSec,
+} from '@console/internal/components/utils';
+import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
+import { GraphTypes } from '../dashboard/MonitoringDashboardGraph';
+
+export const workloadMetricQueries = [
+  {
+    title: 'CPU Usage',
+    chartType: GraphTypes.line,
+    humanize: humanizeCpuCores,
+    byteDataType: ByteDataTypes.BinaryBytes,
+    query: template(
+      `sum(
+          node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster='', namespace='<%= ns %>'}
+          * on(namespace,pod) group_left(workload, workload_type) mixin_pod_workload{cluster='', 
+          namespace='<%= ns %>', workload='<%= workloadName %>', workload_type='<%= workloadType %>'}) by (pod)`,
+    ),
+  },
+  {
+    title: 'Memory Usage',
+    chartType: GraphTypes.line,
+    humanize: humanizeBinaryBytes,
+    byteDataType: ByteDataTypes.BinaryBytes,
+    query: template(
+      `sum(container_memory_working_set_bytes{cluster='', namespace='<%= ns %>', container!=""} 
+          * on(namespace,pod) group_left(workload, workload_type) mixin_pod_workload{cluster='', 
+          namespace='<%= ns %>', workload='<%= workloadName %>', workload_type='<%= workloadType %>'}) by (pod)`,
+    ),
+  },
+  {
+    title: 'Receive Bandwidth',
+    chartType: GraphTypes.line,
+    humanize: humanizeDecimalBytesPerSec,
+    byteDataType: ByteDataTypes.DecimalBytes,
+    query: template(
+      `sum(irate(container_network_receive_bytes_total{cluster="", namespace=~'<%= ns %>'}[4h]) 
+          * on (namespace,pod) group_left(workload,workload_type) mixin_pod_workload{cluster="", 
+          namespace=~'<%= ns %>', workload=~'<%= workloadName %>', workload_type='<%= workloadType %>'}) by (pod)`,
+    ),
+  },
+  {
+    title: 'Transmit Bandwidth',
+    chartType: GraphTypes.line,
+    humanize: humanizeDecimalBytesPerSec,
+    byteDataType: ByteDataTypes.DecimalBytes,
+    query: template(
+      `sum(irate(container_network_receive_bytes_total{cluster="", namespace=~'<%= ns %>'}[4h])
+         * on (namespace,pod) group_left(workload,workload_type) mixin_pod_workload{cluster="", 
+         namespace=~'<%= ns %>', workload=~'<%= workloadName %>', workload_type='<%= workloadType %>'}) by (pod)`,
+    ),
+  },
+];

--- a/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/__snapshots__/topology-utils.spec.ts.snap
@@ -382,6 +382,7 @@ Object {
           ],
           "revision": undefined,
         },
+        "events": undefined,
         "isRollingOut": undefined,
         "obj": Object {
           "apiVersion": "apps.openshift.io/v1",
@@ -1242,6 +1243,7 @@ Object {
           ],
           "revision": 1,
         },
+        "events": undefined,
         "isRollingOut": false,
         "obj": Object {
           "apiVersion": "apps/v1",
@@ -2213,6 +2215,7 @@ Object {
           ],
           "revision": 1,
         },
+        "events": undefined,
         "isRollingOut": false,
         "obj": Object {
           "apiVersion": "apps/v1",
@@ -2641,6 +2644,7 @@ Object {
         "alerts": Object {},
         "buildConfigs": Array [],
         "current": undefined,
+        "events": undefined,
         "isRollingOut": false,
         "obj": Object {
           "apiVersion": "apps/v1",

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -17,6 +17,7 @@ export const resources: TopologyDataResources = {
   statefulSets: { loaded: true, loadError: '', data: [] },
   pipelineRuns: { loaded: true, loadError: '', data: [] },
   pipelines: { loaded: true, loadError: '', data: [] },
+  events: { loaded: true, loadError: '', data: [] },
 };
 
 export const topologyData: TopologyDataModel = {

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -32,6 +32,7 @@ export interface TopologyDataResources {
   eventSourceKafka?: FirehoseResult;
   clusterServiceVersions?: FirehoseResult;
   serviceBindingRequests?: FirehoseResult;
+  events?: FirehoseResult;
 }
 
 export interface Node {

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -12,6 +12,7 @@ import {
   ResourceDetailsPage,
   Perspective,
   RoutePage,
+  OverviewResourceTab,
   OverviewCRD,
   YAMLTemplate,
   OverviewTabSection,
@@ -58,6 +59,7 @@ type ConsumedExtensions =
   | RoutePage
   | ReduxReducer
   | KebabActions
+  | OverviewResourceTab
   | OverviewCRD
   | YAMLTemplate
   | OverviewTabSection;
@@ -315,6 +317,17 @@ const plugin: Plugin<ConsumedExtensions> = [
       loader: () =>
         import(
           './components/pipelines/pipeline-overview/PipelineOverview' /* webpackChunkName: "pipeline-overview-list" */
+        ).then((m) => m.default),
+    },
+  },
+  {
+    type: 'Overview/Resource',
+    properties: {
+      name: 'Monitoring',
+      key: 'events',
+      loader: () =>
+        import(
+          './components/monitoring/overview/MonitoringTab' /* webpackChunkName: "monitoring-overview" */
         ).then((m) => m.default),
     },
   },

--- a/frontend/public/components/overview/resource-overview-details.tsx
+++ b/frontend/public/components/overview/resource-overview-details.tsx
@@ -20,12 +20,13 @@ const getResourceTabComp = (t) => (props) => (
 );
 
 const getPluginTabResources = (item, tabs): ResourceOverviewDetailsProps['tabs'] => {
-  const tabEntry = plugins.registry
+  let tabEntry = plugins.registry
     .getOverviewResourceTabs()
     .filter((tab) => item[tab.properties.key]);
-  const newTabs = tabs.map((tab) => {
+  const overridenTabs = tabs.map((tab) => {
     const tabEntryConfig = tabEntry.find((t) => tab.name === t.properties.name);
     if (tabEntryConfig) {
+      tabEntry = tabEntry.filter((entry) => tab.name !== entry.properties.name);
       return {
         name: tab.name,
         component: getResourceTabComp(tabEntryConfig),
@@ -33,7 +34,16 @@ const getPluginTabResources = (item, tabs): ResourceOverviewDetailsProps['tabs']
     }
     return tab;
   });
-  return newTabs;
+
+  /** Add new tabs from plugin */
+  const newTabs = tabEntry.map((entry) => {
+    return {
+      name: entry.properties.name,
+      component: getResourceTabComp(entry),
+    };
+  });
+
+  return overridenTabs.concat(newTabs);
 };
 
 export const ResourceOverviewDetails = connect<PropsFromState, PropsFromDispatch, OwnProps>(


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2586

**Analysis**: 
   This US requires a monitoring tab to be displayed in topology side panel when a workload type resource is selected. Workload types supported in this PR are Deployment, DaemonSet & StatefulSet. Other type of workloads yet to be analysed w.r.t Prometheus support.

**Solution Description**: 
   Monitoring tab has been implemented in dev console & exposed through dev console plugin. Metrics section reuses MonitoringDashboardGraph component from /monitoring/dashboard to display graphs/plots. Prometheus queries used are yet to be reviewed by @christianvogt & Steve. [Proposal doc](https://docs.google.com/document/d/1BVlzDusErxWkMTBjTDOsOeP2MMe83z4IDgLvvVCaofM/edit?usp=sharing) for queries. 
**Note:** post 4.4 feature freeze we would look into leveraging dashboard work done in console

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux 
<img width="1680" alt="Screenshot 2020-01-23 at 1 39 22 AM" src="https://user-images.githubusercontent.com/56166080/72930175-5e46df80-3d81-11ea-8cbc-1b34df080caf.png">
<img width="1680" alt="Screenshot 2020-01-23 at 1 39 42 AM" src="https://user-images.githubusercontent.com/56166080/72930177-5e46df80-3d81-11ea-88ee-68ea6b5c124e.png">
<img width="1680" alt="Screenshot 2020-01-23 at 1 40 01 AM" src="https://user-images.githubusercontent.com/56166080/72930178-5edf7600-3d81-11ea-99f3-cbbe482cb057.png">

**Unit test coverage report**: 
<img width="1252" alt="Screenshot 2020-01-23 at 1 32 16 AM" src="https://user-images.githubusercontent.com/56166080/72929664-4f136200-3d80-11ea-98e2-fe070bef88f2.png">

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
