### PR TITLE
Bug 1784352: Fix bug where regular users cannot view Pods tab pods

### DIFF
--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -516,6 +516,7 @@ export const PodsPage = connect<{}, PodPagePropsFromDispatch, PodPageProps>(
       kind="Pod"
       ListComponent={PodList}
       rowFilters={filters}
+      namespace={namespace}
     />
   );
 });


### PR DESCRIPTION
Before:
![Screen Shot 2020-01-14 at 3 09 47 PM](https://user-images.githubusercontent.com/895728/72378846-3223c280-36e0-11ea-89c1-aacfc3e15134.png)

After:
![Screen Shot 2020-01-14 at 3 09 11 PM](https://user-images.githubusercontent.com/895728/72378852-364fe000-36e0-11ea-9846-692a3e8bfd38.png)
