### PR TITLE
BaremetalHost: Use new errorType field in Host CR

### DIFF
--- a/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
+++ b/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
@@ -15,8 +15,8 @@ export const HOST_STATUS_PROVISIONING = 'provisioning';
 export const HOST_STATUS_DEPROVISIONING = 'deprovisioning';
 export const HOST_STATUS_MAKING_HOST_AVAILABLE = 'making host available';
 export const HOST_STATUS_MATCH_PROFILE = 'match profile';
-export const HOST_STATUS_VALIDATION_ERROR = 'validation error';
 export const HOST_STATUS_REGISTRATION_ERROR = 'registration error';
+export const HOST_STATUS_INSPECTION_ERROR = 'inspection error';
 export const HOST_STATUS_PROVISIONING_ERROR = 'provisioning error';
 export const HOST_STATUS_POWER_MANAGEMENT_ERROR = 'power management error';
 
@@ -40,8 +40,8 @@ export const HOST_STATUS_TITLES = {
   [HOST_STATUS_PROVISIONING]: 'Provisioning',
   [HOST_STATUS_DEPROVISIONING]: 'Deprovisioning',
   [HOST_STATUS_MAKING_HOST_AVAILABLE]: 'Making host available',
-  [HOST_STATUS_VALIDATION_ERROR]: 'Validation Error(s)',
   [HOST_STATUS_REGISTRATION_ERROR]: 'Registration error',
+  [HOST_STATUS_INSPECTION_ERROR]: 'Inspection error',
   [HOST_STATUS_PROVISIONING_ERROR]: 'Provisioning error',
   [HOST_STATUS_POWER_MANAGEMENT_ERROR]: 'Power Management Error',
   [HOST_STATUS_MATCH_PROFILE]: 'Matching profile',
@@ -61,8 +61,8 @@ export const HOST_PROVISIONING_STATES = [
 
 export const HOST_ERROR_STATES = [
   HOST_STATUS_REGISTRATION_ERROR,
+  HOST_STATUS_INSPECTION_ERROR,
   HOST_STATUS_PROVISIONING_ERROR,
-  HOST_STATUS_VALIDATION_ERROR,
   HOST_STATUS_POWER_MANAGEMENT_ERROR,
   HOST_STATUS_ERROR,
 ];

--- a/frontend/packages/metal3-plugin/src/selectors/baremetal-hosts.ts
+++ b/frontend/packages/metal3-plugin/src/selectors/baremetal-hosts.ts
@@ -18,6 +18,8 @@ import {
 
 export const getHostOperationalStatus = (host: BareMetalHostKind): string =>
   _.get(host, 'status.operationalStatus');
+export const getHostErrorType = (host: BareMetalHostKind): string =>
+  _.get(host, 'status.errorType');
 export const getHostProvisioningState = (host: BareMetalHostKind): string =>
   _.get(host, 'status.provisioning.state');
 export const getHostMachineName = (host: BareMetalHostKind): string =>

--- a/frontend/packages/metal3-plugin/src/status/host-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/host-status.ts
@@ -1,12 +1,8 @@
 import { K8sResourceKind, MachineKind, NodeKind } from '@console/internal/module/k8s';
-import { getHostOperationalStatus, getHostProvisioningState } from '../selectors';
+import { getHostOperationalStatus, getHostProvisioningState, getHostErrorType } from '../selectors';
 import {
   HOST_STATUS_TITLES,
-  HOST_STATUS_REGISTRATION_ERROR,
-  HOST_STATUS_REGISTERING,
   HOST_STATUS_ERROR,
-  HOST_STATUS_PROVISIONING,
-  HOST_STATUS_PROVISIONING_ERROR,
   HOST_STATUS_DISCOVERED,
   HOST_PROGRESS_STATES,
   HOST_STATUS_DEPROVISIONING,
@@ -18,19 +14,15 @@ import { getNodeMaintenanceStatus } from './node-maintenance-status';
 export const getBareMetalHostStatus = (host: BareMetalHostKind) => {
   const operationalStatus = getHostOperationalStatus(host);
   const provisioningState = getHostProvisioningState(host);
+  const errorType = getHostErrorType(host);
 
   let hostStatus;
 
   if (operationalStatus === HOST_STATUS_ERROR) {
-    switch (provisioningState) {
-      case HOST_STATUS_REGISTERING:
-        hostStatus = HOST_STATUS_REGISTRATION_ERROR;
-        break;
-      case HOST_STATUS_PROVISIONING:
-        hostStatus = HOST_STATUS_PROVISIONING_ERROR;
-        break;
-      default:
-        hostStatus = HOST_STATUS_ERROR;
+    if (errorType) {
+      hostStatus = errorType;
+    } else {
+      hostStatus = HOST_STATUS_ERROR;
     }
   } else if (operationalStatus === HOST_STATUS_DISCOVERED) {
     hostStatus = HOST_STATUS_DISCOVERED;


### PR DESCRIPTION
When the operational status is in error, the BaremetalHost operator now (since metal3-io/baremetal-operator#369) reports the type of error from a fixed list. This is more reliable than determining the type of error from the provisioning status (e.g. a registration error may occur while the host is provisioning).

The possible error types are registration, inspection, provisioning, and power management errors. There is [no longer](https://github.com/metal3-io/baremetal-operator/commit/706c29d5120dfe11b411292cb101c1f53c32787c) a validation error, and such errors have not been produced for [some time](https://github.com/metal3-io/baremetal-operator/commit/c52346e95c4803bfed16d9c67326f0499c8919c1).

Currently, there are actually separate provisioning states for each error type, so the Host would never have been in a Registering or Provisioning state after an error anyway, and this code would always have reported the host status as just 'error'. These separate states are being removed (in metal3-io/baremetal-operator#388) in favour of the separate errorType field. Since the existing code was not reachable, there is no need to keep it for backward compatibility with older versions of the operator.