### PR TITLE
Allow children components on DetailsPage header

### DIFF
--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -47,7 +47,9 @@ export const DetailsPage = withFallback<DetailsPageProps>((props) => {
         customData={props.customData}
         badge={props.badge || getBadgeFromType(props.kindObj && props.kindObj.badge)}
         icon={props.icon}
-      />
+      >
+        {props.children}
+      </PageHeading>
       <HorizontalNav
         pages={props.pages}
         pagesFor={props.pagesFor}
@@ -86,6 +88,7 @@ export type DetailsPageProps = {
   badge?: React.ReactNode;
   icon?: React.ComponentType<{ obj: K8sResourceKind }>;
   getResourceStatus?: (resource: K8sResourceKind) => string;
+  children?: React.ReactNode;
 };
 
 DetailsPage.displayName = 'DetailsPage';


### PR DESCRIPTION
Design of the VMI details page, require a `HintBlock`  element as child of `PageHeading` inside `DetailsPage`.

This PR allow to add children to the Details Page Header.

Design:
https://github.com/openshift/openshift-origin-design/pull/310

Image of Hint Block in the developer pages:

![Add · Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/2181522/72433476-09640180-37a2-11ea-9246-382dce95e641.png)

