### PR TITLE
[WIP] Add /health/oauthconnect endpoint

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -72,6 +72,8 @@ type SpecialAuthURLs struct {
 	RequestToken string
 	// KubeAdminLogout is the logout URL for the special kube:admin user in OpenShift.
 	KubeAdminLogout string
+	// Issuer is the base URL for the OAuth server
+	Issuer string
 }
 
 // loginMethod is used to handle OAuth2 responses and associate bearer tokens

--- a/pkg/auth/auth_openshift.go
+++ b/pkg/auth/auth_openshift.go
@@ -113,6 +113,7 @@ func newOpenShiftAuth(ctx context.Context, c *openShiftConfig) (oauth2.Endpoint,
 			SpecialAuthURLs{
 				requestTokenURL,
 				kubeAdminLogoutURL,
+				metadata.Issuer,
 			},
 		}, nil
 }

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"fmt"
+	"github.com/coreos/pkg/capnslog"
+	"net/http"
+)
+
+var (
+	slog = capnslog.NewPackageLogger("github.com/openshift/console", "server")
+)
+
+// The oauth health endpoint is the proxy we will use for "console can connect to oauth"
+// It will work as follows:
+//   operator -> console /health 200 ok (console ok)
+//   operator -> console /health 400 not found (console not ok)
+//   operator -> console /health/oauth 200 ok (oauth connect ok)
+//   operator -> console /health/oauth 400 not found (oauth connect not ok. note that console /health already 200 ok)
+//   etc.
+// This means that if console /health is ok, but oauth /healtz is not, we can deduce
+//   which route is broken (or potentially that the route is fine but the pod crashed).
+// It is not the job of the console to provide reasons for the failure to connect, the
+//   oauth server itself will provide its own status.  The console simply needs to report
+//   back on success or failure so that the console-operator can report its own status.
+func (s *Server) OAuthConnect(writer http.ResponseWriter, req *http.Request) {
+	issuer := s.Auther.GetSpecialURLs().Issuer
+	health := issuer + "/healthz"
+
+	oauthReq, err := http.NewRequest(http.MethodGet, health, nil)
+	oauthResp, err := s.K8sClient.Do(oauthReq)
+	_, err = s.K8sClient.Do(oauthReq)
+	if err != nil {
+		fmt.Fprintf(writer, "error, %v", err)
+	}
+	// not using the body.
+	// defer oauthResp.Body.Close()
+
+	writer.WriteHeader(oauthResp.StatusCode)
+	slog.Infof("oauth connect health check: %v", oauthResp.Status)
+	fmt.Fprintf(writer, "%v", oauthResp.Status)
+}
+

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -194,6 +194,8 @@ func (s *Server) HTTPHandler() http.Handler {
 		Checks: []health.Checkable{},
 	}.ServeHTTP)
 
+	handleFunc("/health/oauthconnect", s.OAuthConnect)
+
 	k8sProxy := proxy.NewProxy(s.K8sProxyConfig)
 	handle(k8sProxyEndpoint, http.StripPrefix(
 		proxy.SingleJoiningSlash(s.BaseURL.Path, k8sProxyEndpoint),


### PR DESCRIPTION
For https://issues.redhat.com/browse/CONSOLE-1702

- Adds a `/health/oauthconnect` endpoint to console
Flow:
- `console-operator` will check `/health` to verify console is ok.
- `console-operator` will check `/health/oauthconnect` to verify console can connect to `oauth`.
- Both checks would be essential to verify:
   - `console route` is functional, `console-operator` can reach `console`.
   - `oauth route` is functional, `console` can reach `oauth`.
    
Gotchas & points of interest:
- Problem: if the `oauth` pods are unreachable before console pods start, the `console` pods will simply die and be recreated indefinitely. There is no way for the `console-operator` to report status in this case, the `health` and `health/oauthconnect` endpoints would both be down.  We would have to read logs directly to get meaningful information.
- if `oauth` goes down after `console` has established a connection then this endpoint is helpful.
- we aren't differentiating between 'oauth route' is down and 'oauth pods' are unreachable.  the `authentication-operator` can be responsible for this.

Ideally we would have a way to report out even if the `oauth` pod is never reachable.  This is the most likely failure scenerio (the one we face today).

Alternatively, we could just do a live `GET` from the `console-operator`.

Follow:
- [ ] `console-operator` controller loop to check health & report `OAuthConnection` `FailedRequest` on status. 

Related to additional health checks:
- https://github.com/openshift/console-operator/pull/334



