### PR TITLE
add pattern to .gitignore to ignore dev_* scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 /frontend/npm-debug.log
 /frontend/yarn-error.log
 /frontend/gui_test_screenshots
+
+# personal dev scripts
+dev_*
+


### PR DESCRIPTION
Allow devs to colocate personal scripts in the same dir as console with no risk of accidental commit.  

Any qualms?  I find this useful for testing many things. 

