### PR TITLE
Bug 1790557: Fix Pipeline Params

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
@@ -7,7 +7,12 @@ import {
 } from '@console/internal/components/factory/modal';
 import { k8sCreate } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../../models';
-import { Pipeline, PipelineResource, Param, PipelineRun } from '../../../utils/pipeline-augment';
+import {
+  Pipeline,
+  PipelineResource,
+  PipelineRun,
+  PipelineParam,
+} from '../../../utils/pipeline-augment';
 import StartPipelineForm from './StartPipelineForm';
 import { startPipelineSchema } from './pipelineForm-validation-utils';
 
@@ -20,7 +25,7 @@ export interface StartPipelineModalProps {
 }
 export interface StartPipelineFormValues extends FormikValues {
   namespace: string;
-  parameters: Param[];
+  parameters: PipelineParam[];
   resources: PipelineResource[];
 }
 
@@ -41,16 +46,15 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
 
   const handleSubmit = (values: StartPipelineFormValues, actions): void => {
     actions.setSubmitting(true);
-    const pipelineRunData = {
+    const newPipeline: Pipeline = {
+      ...pipeline,
       spec: {
-        pipelineRef: {
-          name: pipeline.metadata.name,
-        },
+        ...pipeline.spec,
         params: values.parameters,
         resources: values.resources,
       },
     };
-    k8sCreate(PipelineRunModel, getPipelineRunData(pipeline, pipelineRunData))
+    k8sCreate(PipelineRunModel, getPipelineRunData(newPipeline))
       .then((res) => {
         actions.setSubmitting(false);
         onSubmit && onSubmit(res);

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -8,8 +8,9 @@ import { errorModal } from '@console/internal/components/modals';
 import { PipelineModel, PipelineRunModel } from '../models';
 import startPipelineModal from '../components/pipelines/pipeline-form/StartPipelineModal';
 import { getRandomChars } from '../components/pipelines/pipeline-resource/pipelineResource-utils';
-import { Pipeline, PipelineRun } from './pipeline-augment';
+import { Pipeline, PipelineParam, PipelineRun, PipelineRunParam } from './pipeline-augment';
 import { pipelineRunFilterReducer } from './pipeline-filter-reducer';
+import { getPipelineRunParams } from './pipeline-utils';
 
 interface Action {
   label: string | Record<string, any>;
@@ -71,7 +72,10 @@ export const getPipelineRunData = (pipeline: Pipeline, latestRun?: PipelineRun):
     resourceRef: resource.resourceRef,
   }));
 
-  const newPipelineRun = {
+  const pipelineRunParams: PipelineRunParam[] = _.get(latestRun, 'spec.params');
+  const pipelineParams: PipelineParam[] = _.get(pipeline, 'spec.params');
+
+  const newPipelineRun: PipelineRun = {
     apiVersion: pipeline ? pipeline.apiVersion : latestRun.apiVersion,
     kind: PipelineRunModel.kind,
     metadata: {
@@ -90,12 +94,7 @@ export const getPipelineRunData = (pipeline: Pipeline, latestRun?: PipelineRun):
         name: pipeline.metadata.name,
       },
       resources,
-      params:
-        latestRun && latestRun.spec && latestRun.spec.params
-          ? latestRun.spec.params
-          : pipeline.spec && pipeline.spec.params
-          ? pipeline.spec.params
-          : null,
+      params: pipelineRunParams || getPipelineRunParams(pipelineParams),
     },
   };
 

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -55,7 +55,7 @@ export interface Pipeline extends K8sResourceKind {
   latestRun?: PipelineRun;
   spec?: {
     pipelineRef?: { name: string };
-    params: Param[];
+    params: PipelineParam[];
     resources: PipelineResource[];
     tasks: K8sResourceKind[];
     serviceAccountName?: string;
@@ -65,7 +65,7 @@ export interface Pipeline extends K8sResourceKind {
 export interface PipelineRun extends K8sResourceKind {
   spec?: {
     pipelineRef?: { name: string };
-    params?: Param[];
+    params?: PipelineRunParam[];
     resources?: PipelineResource[];
     serviceAccountName?: string;
   };
@@ -86,9 +86,19 @@ export interface Condition {
   message?: string;
 }
 
-export interface Param {
-  input: string;
-  output: string;
+interface Param {
+  name: string;
+}
+
+export interface PipelineParam extends Param {
+  default?: string;
+  description?: string;
+}
+
+export interface PipelineRunParam extends Param {
+  value: string;
+  input?: string;
+  output?: string;
   resource?: object;
 }
 

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -7,7 +7,7 @@ import {
   LOG_SOURCE_RUNNING,
   LOG_SOURCE_TERMINATED,
 } from '@console/internal/components/utils';
-import { runStatus } from './pipeline-augment';
+import { PipelineParam, PipelineRunParam, runStatus } from './pipeline-augment';
 
 interface Resources {
   inputs?: Resource[];
@@ -229,4 +229,14 @@ export const containerToLogSourceStatus = (container: ContainerStatus): string =
     return LOG_SOURCE_TERMINATED;
   }
   return LOG_SOURCE_RUNNING;
+};
+
+export const getPipelineRunParams = (pipelineParams: PipelineParam[]): PipelineRunParam[] => {
+  return (
+    pipelineParams &&
+    pipelineParams.map((param) => ({
+      name: param.name,
+      value: param.default,
+    }))
+  );
 };


### PR DESCRIPTION
Fixes the issue with Pipeline Params causing an issue starting a 4.2 PipelineRun. This is a pure UI issue and was corrected in future releases but slipped through the cracks getting back ported.

Ticket: https://issues.redhat.com/browse/ODC-2719

Used as much of the code from current implementation (and tried to place it in a relative position) in the hopes to make it easier to do any future cherry-picks.

/assign @christianvogt 

Data used:
```
apiVersion: tekton.dev/v1alpha1
kind: Pipeline
metadata:
  name: custom-echo-pipeline
spec:
  params:
    - name: echo-value
      description: The value to echo out
      default: pipeline echo value
  tasks:
    - name: echo
      taskRef:
        name: echo-task
      params:
        - name: echo-value-for-task
          value: "$(params.echo-value)"
---
apiVersion: tekton.dev/v1alpha1
kind: Task
metadata:
  name: echo-task
spec:
  inputs:
    params:
      - name: echo-value-for-task
        description: The value to echo out
        default: this is not the param you're looking for
  steps:
    - name: echo
      image: ubuntu
      command:
        - echo
      args:
        - "$(inputs.params.echo-value-for-task)"
```

cc @siamaksade 