### PR TITLE
Bug 1790528: Fix removal of OPERATOR_LIFECYCLE_MANAGER flag from olm package causi…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
@@ -36,8 +36,8 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'FeatureFlag/Model',
     properties: {
-      model: models.PackageManifestModel,
-      flag: Flags.CAN_LIST_PACKAGE_MANIFEST,
+      model: models.ClusterServiceVersionModel,
+      flag: Flags.OPERATOR_LIFECYCLE_MANAGER,
     },
   },
   {


### PR DESCRIPTION
Reverts the removal of `OPERATOR_LIFECYCLE_MANAGER` flag from OLM plugin so that the dev catalog can show content.

Before:

![Screen Shot 2020-01-16 at 12 33 33 PM](https://user-images.githubusercontent.com/280512/72548364-83f15780-385c-11ea-99dc-c5d95cf59555.png)


After:

![Screen Shot 2020-01-16 at 12 26 09 PM](https://user-images.githubusercontent.com/280512/72548369-881d7500-385c-11ea-8fa9-b75a5faab580.png)

For all interested:
/assign @spadgett @jeff-phillips-18 @andrewballantyne 

With hopes that this one stirs up efforts for at least basic test coverage where possible.