### PR TITLE
Fix modal close on confirmation of a node regroup

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/components/moveNodeToGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/moveNodeToGroup.tsx
@@ -25,6 +25,9 @@ export const moveNodeToGroup = (node: Node, targetGroup: Node): Promise<void> =>
         title,
         message,
         btnText,
+        close: () => {
+          reject();
+        },
         cancel: () => {
           reject();
         },

--- a/frontend/public/components/modals/_modals.scss
+++ b/frontend/public/components/modals/_modals.scss
@@ -11,6 +11,7 @@
 .co-overlay {
   background: rgba(0, 0, 0, 0.5);
   bottom: 0;
+  cursor: default;
   left: 0;
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ODC-2727

Adds additional change to set the correct cursor on the modal overlay.