### PR TITLE
Host status refactoring

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostStatus.tsx
@@ -18,11 +18,6 @@ import {
   NODE_STATUS_UNDER_MAINTENANCE,
   NODE_STATUS_STARTING_MAINTENANCE,
   NODE_STATUS_STOPPING_MAINTENANCE,
-  HOST_STATUS_INSPECTING,
-  HOST_STATUS_DEPROVISIONING,
-  HOST_STATUS_AVAILABLE,
-  HOST_STATUS_READY,
-  HOST_STATUS_PROVISIONING,
 } from '../../constants';
 import { BareMetalHostModel } from '../../models';
 import { getHostErrorMessage } from '../../selectors';
@@ -46,44 +41,24 @@ export const AddDiscoveredHostButton: React.FC<{ host: BareMetalHostKind }> = (
   );
 };
 
-const BareMetalHostStatus: React.FC<StatusProps> = ({ status, title, ...props }) => {
+const BareMetalHostStatus: React.FC<StatusProps> = ({ status, title, description, ...props }) => {
   const statusTitle = title || status;
   switch (true) {
     case status === HOST_STATUS_DISCOVERED:
       return <AddDiscoveredHostButton host={props.host} />;
     case [NODE_STATUS_STARTING_MAINTENANCE, NODE_STATUS_UNDER_MAINTENANCE].includes(status):
       return <MaintenancePopover title={statusTitle} maintenance={props.maintenance} />;
-    case status === HOST_STATUS_INSPECTING:
-      return (
-        <ProgressStatus title={statusTitle}>
-          The hardware details of the host are being collected. This will take a while. The host
-          will become available when finished.
-        </ProgressStatus>
-      );
-    case status === HOST_STATUS_PROVISIONING:
-      return (
-        <ProgressStatus title={statusTitle}>
-          An image is being written to the host&apos;s disk(s). This will take a while.
-        </ProgressStatus>
-      );
-    case status === HOST_STATUS_DEPROVISIONING:
-      return (
-        <ProgressStatus title={statusTitle}>
-          The image is being wiped from the host&apos;s disk(s). This may take a while.
-        </ProgressStatus>
-      );
     case [NODE_STATUS_STOPPING_MAINTENANCE, ...HOST_PROGRESS_STATES].includes(status):
-      return <ProgressStatus title={statusTitle} />;
+      return <ProgressStatus title={statusTitle}>{description}</ProgressStatus>;
     case HOST_ERROR_STATES.includes(status):
-      return <ErrorStatus title={statusTitle}>{getHostErrorMessage(props.host)}</ErrorStatus>;
-    case [HOST_STATUS_AVAILABLE, HOST_STATUS_READY].includes(status):
       return (
-        <SuccessStatus title={statusTitle}>
-          The host is available to be provisioned as a node.
-        </SuccessStatus>
+        <ErrorStatus title={statusTitle}>
+          <p>{description}</p>
+          <p>{getHostErrorMessage(props.host)}</p>
+        </ErrorStatus>
       );
     case HOST_SUCCESS_STATES.includes(status):
-      return <SuccessStatus title={statusTitle} />;
+      return <SuccessStatus title={statusTitle}>{description}</SuccessStatus>;
     default:
       return <Status status={status} title={statusTitle} />;
   }

--- a/frontend/packages/metal3-plugin/src/components/types.ts
+++ b/frontend/packages/metal3-plugin/src/components/types.ts
@@ -4,6 +4,7 @@ import { BareMetalHostKind } from '../types';
 export type StatusProps = {
   status: string;
   title?: string;
+  description?: string;
   [key: string]: any;
 };
 

--- a/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
+++ b/frontend/packages/metal3-plugin/src/constants/bare-metal-host.ts
@@ -10,10 +10,8 @@ export const HOST_STATUS_PROVISIONED = 'provisioned';
 export const HOST_STATUS_DEPROVISIONED = 'deprovisioned';
 export const HOST_STATUS_REGISTERING = 'registering';
 export const HOST_STATUS_INSPECTING = 'inspecting';
-export const HOST_STATUS_PREPARING_TO_PROVISION = 'preparing to provision';
 export const HOST_STATUS_PROVISIONING = 'provisioning';
 export const HOST_STATUS_DEPROVISIONING = 'deprovisioning';
-export const HOST_STATUS_MAKING_HOST_AVAILABLE = 'making host available';
 export const HOST_STATUS_MATCH_PROFILE = 'match profile';
 export const HOST_STATUS_REGISTRATION_ERROR = 'registration error';
 export const HOST_STATUS_INSPECTION_ERROR = 'inspection error';
@@ -36,15 +34,30 @@ export const HOST_STATUS_TITLES = {
   [HOST_STATUS_DEPROVISIONED]: 'Deprovisioned',
   [HOST_STATUS_REGISTERING]: 'Registering',
   [HOST_STATUS_INSPECTING]: 'Inspecting',
-  [HOST_STATUS_PREPARING_TO_PROVISION]: 'Preparing to provision',
   [HOST_STATUS_PROVISIONING]: 'Provisioning',
   [HOST_STATUS_DEPROVISIONING]: 'Deprovisioning',
-  [HOST_STATUS_MAKING_HOST_AVAILABLE]: 'Making host available',
   [HOST_STATUS_REGISTRATION_ERROR]: 'Registration error',
   [HOST_STATUS_INSPECTION_ERROR]: 'Inspection error',
   [HOST_STATUS_PROVISIONING_ERROR]: 'Provisioning error',
   [HOST_STATUS_POWER_MANAGEMENT_ERROR]: 'Power Management Error',
   [HOST_STATUS_MATCH_PROFILE]: 'Matching profile',
+};
+
+export const HOST_STATUS_DESCRIPTIONS = {
+  [HOST_STATUS_READY]: 'The host is available to be provisioned as a node.',
+  [HOST_STATUS_AVAILABLE]: 'The host is available to be provisioned as a node.',
+  [HOST_STATUS_INSPECTING]:
+    'The hardware details of the host are being collected. This will take a while. The host will become available when finished.',
+  [HOST_STATUS_PROVISIONING]:
+    "An image is being written to the host's disk(s). This will take a while.",
+  [HOST_STATUS_DEPROVISIONING]:
+    "The image is being wiped from the host's disk(s). This may take a while.",
+  [HOST_STATUS_REGISTRATION_ERROR]:
+    "The details for the host's BMC are either incorrect or incomplete therefore the host could not be managed.",
+  [HOST_STATUS_INSPECTION_ERROR]: 'Collecting hardware details from the host failed',
+  [HOST_STATUS_PROVISIONING_ERROR]: 'The image could not be written to the host.',
+  [HOST_STATUS_POWER_MANAGEMENT_ERROR]:
+    'An error was found while trying to power the host either on or off.',
 };
 
 export const HOST_REGISTERING_STATES = [
@@ -53,11 +66,7 @@ export const HOST_REGISTERING_STATES = [
   HOST_STATUS_MATCH_PROFILE,
 ];
 
-export const HOST_PROVISIONING_STATES = [
-  HOST_STATUS_PREPARING_TO_PROVISION,
-  HOST_STATUS_PROVISIONING,
-  HOST_STATUS_MAKING_HOST_AVAILABLE,
-];
+export const HOST_PROVISIONING_STATES = [HOST_STATUS_PROVISIONING, HOST_STATUS_DEPROVISIONING];
 
 export const HOST_ERROR_STATES = [
   HOST_STATUS_REGISTRATION_ERROR,
@@ -71,10 +80,8 @@ export const HOST_WARN_STATES = [];
 
 export const HOST_PROGRESS_STATES = [
   HOST_STATUS_INSPECTING,
-  HOST_STATUS_PREPARING_TO_PROVISION,
   HOST_STATUS_PROVISIONING,
   HOST_STATUS_DEPROVISIONING,
-  HOST_STATUS_MAKING_HOST_AVAILABLE,
   HOST_STATUS_REGISTERING,
   HOST_STATUS_MATCH_PROFILE,
 ];

--- a/frontend/packages/metal3-plugin/src/selectors/baremetal-hosts.ts
+++ b/frontend/packages/metal3-plugin/src/selectors/baremetal-hosts.ts
@@ -18,8 +18,7 @@ import {
 
 export const getHostOperationalStatus = (host: BareMetalHostKind): string =>
   _.get(host, 'status.operationalStatus');
-export const getHostErrorType = (host: BareMetalHostKind): string =>
-  _.get(host, 'status.errorType');
+export const getHostErrorType = (host: BareMetalHostKind): string => host.status?.errorType;
 export const getHostProvisioningState = (host: BareMetalHostKind): string =>
   _.get(host, 'status.provisioning.state');
 export const getHostMachineName = (host: BareMetalHostKind): string =>

--- a/frontend/packages/metal3-plugin/src/status/host-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/host-status.ts
@@ -2,6 +2,7 @@ import { K8sResourceKind, MachineKind, NodeKind } from '@console/internal/module
 import { getHostOperationalStatus, getHostProvisioningState, getHostErrorType } from '../selectors';
 import {
   HOST_STATUS_TITLES,
+  HOST_STATUS_DESCRIPTIONS,
   HOST_STATUS_ERROR,
   HOST_STATUS_DISCOVERED,
   HOST_PROGRESS_STATES,
@@ -33,6 +34,7 @@ export const getBareMetalHostStatus = (host: BareMetalHostKind) => {
   return {
     status: hostStatus,
     title: HOST_STATUS_TITLES[hostStatus] || hostStatus,
+    description: HOST_STATUS_DESCRIPTIONS[hostStatus],
     host,
   };
 };

--- a/frontend/packages/metal3-plugin/src/types/host.ts
+++ b/frontend/packages/metal3-plugin/src/types/host.ts
@@ -82,6 +82,7 @@ export type BareMetalHostKind = {
       };
       state: string;
     };
+    errorType?: string;
     errorMessage: string;
   };
 } & K8sResourceKind;


### PR DESCRIPTION
~~Depends on https://github.com/openshift/console/pull/3964~~

- Define bare metal host status and errors descriptions in constants
- Pass status description as part of getBareMetalHostStatus helper
- Simplify BareMetalHostStatus logic
- Render status descriptions in status popovers
- Render error status descriptions in status popover together with
   detailed error message
- Remove unused bare metal host states