### PR TITLE
chore: bump builder image dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/coreos/tectonic-console-builder:v18 AS build
+FROM quay.io/coreos/tectonic-console-builder:v19 AS build
 
 RUN mkdir -p /go/src/github.com/openshift/console/
 ADD . /go/src/github.com/openshift/console/

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,18 +1,24 @@
-# Used for compiling the tectonic-console. After editing this file,
-# (and committing your edits) you should run ./push-builder.sh to
-# push a new version of your image to quay.io/coreos/tectonic-console-builder
+# Used for testing OpenShift console in CI. After editing this file:
+#
+# * Bump the builder version in `Dockerfile` and `builder-run.sh`
+# * Commit the changes
+# * Run `DOCKER_TAG=<new-tag> ./push-builder.sh` to update the image on quay
+#   (requires edit permission to the quay.io/coreos/tectonic-console-builder repo)
+#
+# You can test the image using `./builder-run.sh`. For instance:
+#   $ ./builder-run.sh ./build-backend.sh
 
-FROM golang:1.11-stretch
+FROM golang:1.13-buster
 
 MAINTAINER Ed Rooth - CoreOS
 
 ### For golang testing stuff
-RUN go get -u github.com/golang/lint/golint
+RUN go get -u golang.org/x/lint/golint
 RUN go get github.com/jstemmer/go-junit-report
 
 ### Install NodeJS and yarn
-ENV NODE_VERSION="v10.17.0"
-ENV YARN_VERSION="v1.7.0"
+ENV NODE_VERSION="v13.6.0"
+ENV YARN_VERSION="v1.21.1"
 
 # yarn needs a home writable by any user running the container
 ENV HOME /opt/home
@@ -23,7 +29,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y -q \
     curl wget git unzip bzip2 jq
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl && \
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.1/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The console is a more friendly `kubectl` in the form of a single page webapp.  I
 
 ### Dependencies:
 
-1. [node.js](https://nodejs.org/) >= 8 & [yarn](https://yarnpkg.com/en/docs/install) >= 1.3.2
-2. [go](https://golang.org/) >= 1.11+
-3. [oc](https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.1/) or [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and an OpenShift or Kubernetes cluster
+1. [node.js](https://nodejs.org/) >= 10 & [yarn](https://yarnpkg.com/en/docs/install) >= 1.3.2
+2. [go](https://golang.org/) >= 1.13+
+3. [oc](https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.4/) or [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and an OpenShift or Kubernetes cluster
 4. `jq` (for `contrib/environment.sh`)
-5. Google Chrome/Chromium == 76.x for integration tests
+5. Google Chrome/Chromium for integration tests
 
 ### Build everything:
 

--- a/builder-run.sh
+++ b/builder-run.sh
@@ -11,7 +11,7 @@ set -e
 # Without env vars:
 #   ./builder-run.sh ./my-script --my-script-arg1 --my-script-arg2
 
-BUILDER_IMAGE="quay.io/coreos/tectonic-console-builder:v18"
+BUILDER_IMAGE="quay.io/coreos/tectonic-console-builder:v19"
 
 # forward whitelisted env variables to docker
 ENV_STR=""

--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -133,7 +133,8 @@ const formatValue = (value, options) => {
     maximumFractionDigits: fractionDigits,
   });
 
-  if (!isFinite(value)) {
+  // Handle special case of `-0`, which can be printed as "-0" in some environments.
+  if (!isFinite(value) || value === 0) {
     return Intl.NumberFormat(locales, rest).format(0);
   }
   return Intl.NumberFormat(locales, rest).format(value);
@@ -196,6 +197,10 @@ const formatPercentage = (value, options) => {
       maximumFractionDigits: 1,
     },
   );
+  // Handle special case of `-0`, which can be printed as "-0" in some environments.
+  if (!isFinite(value) || value === 0) {
+    return Intl.NumberFormat(locales, rest).format(0);
+  }
   return Intl.NumberFormat(locales, rest).format(value);
 };
 


### PR DESCRIPTION
* go 1.13
* node 13.6.0
* yarn 1.21.1
* kubectl 1.17.1

/assign @benjaminapetersen 