### PR TITLE
Bug 1797460: Fix view more button padding for cluster update message

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/status-card.scss
@@ -94,10 +94,6 @@
   padding-right: 0;
 }
 
-.co-status-card__link-button {
-  padding: 0;
-}
-
 .co-status-card__popup {
   padding: 0;
 }

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -101,11 +101,7 @@ const ClusterAlerts = connectToFlags(FLAGS.OPENSHIFT)(
       const cvLoaded = _.get(resources.cv, 'loaded');
       const LinkComponent = React.useCallback(
         () => (
-          <Button
-            className="co-status-card__link-button"
-            variant="link"
-            onClick={() => clusterUpdateModal({ cv })}
-          >
+          <Button variant="link" onClick={() => clusterUpdateModal({ cv })} isInline>
             View details
           </Button>
         ),


### PR DESCRIPTION
Before - view more for cluster update message in status card is misaligned
![update_before](https://user-images.githubusercontent.com/2078045/72627444-ceea9800-394c-11ea-906b-8126ed4e2a5f.png)
After
![update_after](https://user-images.githubusercontent.com/2078045/72627446-cf832e80-394c-11ea-86a4-2029eba66f7b.png)
