### PR TITLE
Improve type safety for machine pages

### DIFF
--- a/frontend/packages/console-shared/src/selectors/machine.ts
+++ b/frontend/packages/console-shared/src/selectors/machine.ts
@@ -1,5 +1,5 @@
-import * as _ from 'lodash';
 import {
+  MachineAWSPlacement,
   MachineKind,
   MachineSetKind,
   MachineDeploymentKind,
@@ -8,20 +8,25 @@ import {
 import { getName } from './common';
 
 export const getMachineRole = (obj: MachineKind | MachineSetKind | MachineDeploymentKind): string =>
-  _.get(obj, ['metadata', 'labels', 'machine.openshift.io/cluster-api-machine-role']);
+  obj?.metadata?.labels?.['machine.openshift.io/cluster-api-machine-role'];
 
 export const getMachineInstanceType = (obj: MachineKind): string =>
-  _.get(obj, ['metadata', 'labels', 'machine.openshift.io/instance-type']);
+  obj?.metadata?.labels?.['machine.openshift.io/instance-type'];
 
 export const getMachineRegion = (obj: MachineKind): string =>
-  _.get(obj, ['metadata', 'labels', 'machine.openshift.io/region']);
+  obj?.metadata?.labels?.['machine.openshift.io/region'];
 
 export const getMachineZone = (obj: MachineKind): string =>
-  _.get(obj, ['metadata', 'labels', 'machine.openshift.io/zone']);
+  obj?.metadata?.labels?.['machine.openshift.io/zone'];
 
-export const getMachineNodeName = (obj: MachineKind) => _.get(obj, 'status.nodeRef.name');
+// Machine sets don't have the region and zone labels. Use `providerSpec` if set.
+export const getMachineAWSPlacement = (
+  machineSet: MachineSetKind | MachineDeploymentKind,
+): MachineAWSPlacement => machineSet?.spec?.template?.spec?.providerSpec?.value?.placement || {};
+
+export const getMachineNodeName = (obj: MachineKind) => obj?.status?.nodeRef?.name;
 
 export const getMachineNode = (machine: MachineKind, nodes: NodeKind[] = []): NodeKind =>
   nodes.find((node) => getMachineNodeName(machine) === getName(node));
 
-export const getMachineAddresses = (machine: MachineKind) => _.get(machine, 'status.addresses', []);
+export const getMachineAddresses = (machine: MachineKind) => machine?.status?.addresses;

--- a/frontend/public/components/machine-deployment.tsx
+++ b/frontend/public/components/machine-deployment.tsx
@@ -3,12 +3,11 @@ import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
-import { getMachineRole } from '@console/shared';
+import { getMachineAWSPlacement, getMachineRole } from '@console/shared';
 import { MachineModel, MachineDeploymentModel } from '../models';
 import { MachineDeploymentKind, referenceForModel } from '../module/k8s';
 import {
   editCountAction,
-  getAWSPlacement,
   getDesiredReplicas,
   getReadyReplicas,
   MachineCounts,
@@ -118,7 +117,7 @@ type MachineDeploymentTableRowProps = {
 
 const MachineDeploymentDetails: React.SFC<MachineDeploymentDetailsProps> = ({ obj }) => {
   const machineRole = getMachineRole(obj);
-  const { availabilityZone, region } = getAWSPlacement(obj);
+  const { availabilityZone, region } = getMachineAWSPlacement(obj);
   const { minReadySeconds, progressDeadlineSeconds } = obj.spec;
   const rollingUpdateStrategy = _.get(obj, 'spec.strategy.rollingUpdate');
   return (

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
-import { getMachineRole } from '@console/shared';
+import { getMachineAWSPlacement, getMachineRole } from '@console/shared';
 import { Tooltip, Button } from '@patternfly/react-core';
 
 import { PencilAltIcon } from '@patternfly/react-icons';
@@ -73,21 +73,18 @@ const menuActions = [
 ];
 const machineReference = referenceForModel(MachineModel);
 const machineSetReference = referenceForModel(MachineSetModel);
-export const getAWSPlacement = (machineSet: MachineSetKind | MachineDeploymentKind) =>
-  _.get(machineSet, 'spec.template.spec.providerSpec.value.placement') || {};
 
 // `spec.replicas` defaults to 1 if not specified. Make sure to differentiate between undefined and 0.
 export const getDesiredReplicas = (machineSet: MachineSetKind | MachineDeploymentKind) => {
-  const replicas = _.get(machineSet, 'spec.replicas');
-  return _.isNil(replicas) ? 1 : replicas;
+  return machineSet?.spec?.replicas ?? 1;
 };
 
 const getReplicas = (machineSet: MachineSetKind | MachineDeploymentKind) =>
-  _.get(machineSet, 'status.replicas', 0);
+  machineSet?.status?.replicas || 0;
 export const getReadyReplicas = (machineSet: MachineSetKind | MachineDeploymentKind) =>
-  _.get(machineSet, 'status.readyReplicas', 0);
+  machineSet?.status?.readyReplicas || 0;
 export const getAvailableReplicas = (machineSet: MachineSetKind | MachineDeploymentKind) =>
-  _.get(machineSet, 'status.availableReplicas', 0);
+  machineSet?.status?.availableReplicas || 0;
 
 const tableColumnClasses = [
   classNames('col-sm-4', 'col-xs-6'),
@@ -253,7 +250,7 @@ export const MachineTabPage: React.SFC<MachineTabPageProps> = ({
 
 const MachineSetDetails: React.SFC<MachineSetDetailsProps> = ({ obj }) => {
   const machineRole = getMachineRole(obj);
-  const { availabilityZone, region } = getAWSPlacement(obj);
+  const { availabilityZone, region } = getMachineAWSPlacement(obj);
   return (
     <>
       <div className="co-m-pane__body">
@@ -264,7 +261,7 @@ const MachineSetDetails: React.SFC<MachineSetDetailsProps> = ({ obj }) => {
           <dd>
             <Selector
               kind={machineReference}
-              selector={_.get(obj, 'spec.selector')}
+              selector={obj.spec?.selector}
               namespace={obj.metadata.namespace}
             />
           </dd>

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash-es';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
 import {
@@ -187,7 +186,7 @@ const MachineDetails: React.SFC<MachineDetailsProps> = ({ obj }: { obj: MachineK
       </div>
       <div className="co-m-pane__body">
         <SectionHeading text="Conditions" />
-        <Conditions conditions={_.get(obj, 'status.providerStatus.conditions')} />
+        <Conditions conditions={obj.status?.providerStatus?.conditions} />
       </div>
     </>
   );

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -1,5 +1,5 @@
 import { JSONSchema6 } from 'json-schema';
-import { BadgeType } from '@console/shared';
+import { BadgeType, NodeAddress } from '@console/shared';
 import { EventInvolvedObject } from './event';
 
 export * from './job';
@@ -543,9 +543,16 @@ export type TemplateInstanceKind = {
   };
 } & K8sResourceCommon;
 
+export type MachineAWSPlacement = {
+  availabilityZone?: string;
+  region?: string;
+};
+
 export type MachineSpec = {
   providerSpec: {
-    value: K8sResourceKind;
+    value?: {
+      placement?: MachineAWSPlacement;
+    };
   };
   versions: {
     kubelet: string;
@@ -557,10 +564,7 @@ export type MachineKind = {
   spec: MachineSpec;
   status?: {
     phase?: string;
-    addresses: {
-      address?: string;
-      type: string;
-    };
+    addresses: NodeAddress[];
     lastUpdated: string;
     nodeRef: {
       kind: string;


### PR DESCRIPTION
Now that #3747 has merged, we can use TypeScript 3.7 language features. Use optional chaining instead of `_.get` for better type safety on the machine pages. (This exposed a type error in  `MachineSpec.addresses`, which is an array.)

/kind cleanup
/assign @TheRealJon 
@christianvogt fyi