### PR TITLE
shared: make alert props optional in FormFooter and update patch

### DIFF
--- a/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
@@ -10,6 +10,8 @@ const FormFooter: React.FC<FormFooterProps> = ({
   submitLabel = 'Save',
   resetLabel = 'Reload',
   cancelLabel = 'Cancel',
+  infoTitle = 'You made changes to this page.',
+  infoMessage = `Click ${submitLabel} to save changes or ${resetLabel} to cancel changes.`,
   isSubmitting,
   errorMessage,
   successMessage,
@@ -18,8 +20,8 @@ const FormFooter: React.FC<FormFooterProps> = ({
 }) => (
   <ButtonBar inProgress={isSubmitting} errorMessage={errorMessage} successMessage={successMessage}>
     {showAlert && (
-      <Alert isInline className="co-alert" variant="info" title="You made changes to this page.">
-        {`Click ${submitLabel} to save changes or ${resetLabel} to cancel changes.`}
+      <Alert isInline className="co-alert" variant="info" title={infoTitle}>
+        {infoMessage}
       </Alert>
     )}
     <ActionGroup className="pf-c-form">

--- a/frontend/packages/console-shared/src/components/form-utils/form-utils-types.ts
+++ b/frontend/packages/console-shared/src/components/form-utils/form-utils-types.ts
@@ -10,4 +10,6 @@ export interface FormFooterProps {
   successMessage?: string;
   disableSubmit: boolean;
   showAlert?: boolean;
+  infoTitle?: string;
+  infoMessage?: string;
 }


### PR DESCRIPTION
- make alert props optional in FormFooter
- add basic methods and a method for adding multiple object keys to PatchBuilder

required by https://github.com/openshift/console/pull/3998