### PR TITLE
Monitoring Dashboards: Add currently displayed dashboard to URL

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1557,7 +1557,7 @@ const PollerPages = () => {
 export const MonitoringUI = () => (
   <Switch>
     <Redirect from="/monitoring" exact to="/monitoring/alerts" />
-    <Route path="/monitoring/dashboards" exact component={MonitoringDashboardsPage} />
+    <Route path="/monitoring/dashboards/:board?" exact component={MonitoringDashboardsPage} />
     <Route path="/monitoring/query-browser" exact component={QueryBrowserPage} />
     <Route path="/monitoring/silences/~new" exact component={CreateSilence} />
     <Route component={PollerPages} />

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -1,7 +1,3 @@
-.co-m-pane__heading--monitoring-dashboards {
-  justify-content: flex-start;
-}
-
 .monitoring-dashboards__card-header {
   flex: 20 0 auto;
 }
@@ -11,17 +7,14 @@
 }
 
 .monitoring-dashboards__dropdown-wrap {
-  margin-bottom: 10px;
-  margin-left: 20px;
+  margin-right: 20px;
 }
 
 .monitoring-dashboards__options {
   display: flex;
-  justify-content: space-between;
-}
-
-.monitoring-dashboards__options-group {
-  display: flex;
+  float: right;
+  margin-right: -20px;
+  margin-top: -20px;
 }
 
 .monitoring-dashboards__panel {
@@ -50,6 +43,10 @@
 
 .monitoring-dashboards__table-container {
   overflow-x: auto;
+}
+
+.monitoring-dashboards__variables {
+  display: flex;
 }
 
 .query-browser__toggle-graph {


### PR DESCRIPTION
Also changes the layout of the dropdown options to bring it closer to
the mocks.

Now clears any dashboard data as soon as the current dashboard is
changed, so that all cards from the previous dashboard are immediately
cleared.