### PR TITLE
Use dependencies from vendor dir

### DIFF
--- a/build-backend.sh
+++ b/build-backend.sh
@@ -7,6 +7,9 @@ set -e
 
 PROJECT_DIR=$(basename ${PWD})
 
+# Use deps from vendor dir.
+export GOFLAGS="-mod=vendor"
+
 GIT_TAG=${SOURCE_GIT_TAG:-$(git describe --always --tags HEAD)}
 LD_FLAGS="-w -X github.com/openshift/console/pkg/version.Version=${GIT_TAG}"
 

--- a/test-backend.sh
+++ b/test-backend.sh
@@ -14,6 +14,9 @@ set -e
 
 export GOBIN=${PWD}/bin:${GOBIN}
 
+# Use deps from vendor dir.
+export GOFLAGS=-mod=vendor
+
 # Invoke ./cover for HTML output
 COVER=${COVER:-"-cover"}
 

--- a/test-backend.sh
+++ b/test-backend.sh
@@ -15,7 +15,7 @@ set -e
 export GOBIN=${PWD}/bin:${GOBIN}
 
 # Use deps from vendor dir.
-export GOFLAGS=-mod=vendor
+export GOFLAGS="-mod=vendor"
 
 # Invoke ./cover for HTML output
 COVER=${COVER:-"-cover"}


### PR DESCRIPTION
### Why
`go test` and `go vet` downloads dependencies using `go mod`, since we already have deps in vendor dir this PR enables use of `vendor` deps.

This PR fixes `test-backend.sh` openshift-ci failure in https://github.com/openshift/console/pull/3826