### PR TITLE
shared: move compareOwnerReferences from kubevirt

### DIFF
--- a/frontend/packages/console-shared/src/utils/owner-references.ts
+++ b/frontend/packages/console-shared/src/utils/owner-references.ts
@@ -1,0 +1,23 @@
+import { OwnerReference } from '@console/internal/module/k8s';
+
+export const compareOwnerReference = (
+  obj: OwnerReference,
+  otherObj: OwnerReference,
+  compareModelOnly?: boolean,
+) => {
+  if (obj === otherObj) {
+    return true;
+  }
+  if (!obj || !otherObj) {
+    return false;
+  }
+  const isUIDEqual = obj.uid && otherObj.uid ? compareModelOnly || obj.uid === otherObj.uid : true;
+  const isNameEqual = compareModelOnly || obj.name === otherObj.name;
+
+  return (
+    obj.apiVersion === otherObj.apiVersion &&
+    obj.kind === otherObj.kind &&
+    isNameEqual &&
+    isUIDEqual
+  );
+};

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/correct-vcenter-secret-labels.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/correct-vcenter-secret-labels.ts
@@ -1,12 +1,13 @@
 import * as _ from 'lodash';
 import { k8sPatch, K8sResourceKind } from '@console/internal/module/k8s';
+import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
 import { getOwnerReferences } from '@console/shared/src';
 import { SecretModel } from '@console/internal/models';
 import { PatchBuilder, PatchOperation } from '@console/shared/src/k8s';
 import { V2VVMwareModel } from '../../../models';
 import { VCENTER_TEMPORARY_LABEL } from '../../../constants/v2v';
 import { getLabels } from '../../../selectors/selectors';
-import { buildOwnerReferenceForModel, compareOwnerReference } from '../../../utils';
+import { buildOwnerReferenceForModel } from '../../../utils';
 
 export const correctVCenterSecretLabels = async ({
   secret,

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/data-volume-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/data-volume-wrapper.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { getName, getNamespace, getOwnerReferences } from '@console/shared/src';
 import { validate } from '@console/internal/components/utils';
+import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
 import { apiVersionForModel } from '@console/internal/module/k8s';
 import { ObjectWithTypePropertyWrapper } from '../common/object-with-type-property-wrapper';
 import { V1alpha1DataVolume } from '../../../types/vm/disk/V1alpha1DataVolume';
@@ -13,7 +14,6 @@ import {
 } from '../../../selectors/dv/selectors';
 import { toIECUnit } from '../../../components/form/size-unit-utils';
 import { DataVolumeModel } from '../../../models';
-import { compareOwnerReference } from '../../../utils';
 
 type CombinedTypeData = {
   name?: string;

--- a/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
@@ -1,5 +1,6 @@
 import { get } from 'lodash';
 import { getName, getNamespace, getOwnerReferences } from '@console/shared/src/selectors';
+import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
 import { PodKind } from '@console/internal/module/k8s';
 import { getLabelValue } from '../selectors';
 import { VMKind } from '../../types';
@@ -9,7 +10,7 @@ import {
   STORAGE_IMPORT_PVC_NAME,
   VIRT_LAUNCHER_POD_PREFIX,
 } from '../../constants';
-import { compareOwnerReference, buildOwnerReferenceForModel } from '../../utils';
+import { buildOwnerReferenceForModel } from '../../utils';
 import { VirtualMachineInstanceModel } from '../../models';
 
 export const getHostName = (pod: PodKind) =>

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/combined.ts
@@ -1,7 +1,8 @@
 import * as _ from 'lodash';
 import { getName, getNamespace, getOwnerReferences } from '@console/shared/src/selectors';
+import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
 import { PodKind } from '@console/internal/module/k8s';
-import { buildOwnerReference, compareOwnerReference } from '../../utils';
+import { buildOwnerReference } from '../../utils';
 import { VMIKind, VMKind } from '../../types/vm';
 import { VMMultiStatus } from '../../types';
 import {

--- a/frontend/packages/kubevirt-plugin/src/utils/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/index.ts
@@ -91,28 +91,6 @@ export const buildOwnerReferenceForModel = (
   uid,
 });
 
-export const compareOwnerReference = (
-  obj: OwnerReference,
-  otherObj: OwnerReference,
-  compareModelOnly?: boolean,
-) => {
-  if (obj === otherObj) {
-    return true;
-  }
-  if (!obj || !otherObj) {
-    return false;
-  }
-  const isUIDEqual = obj.uid && otherObj.uid ? compareModelOnly || obj.uid === otherObj.uid : true;
-  const isNameEqual = compareModelOnly || obj.name === otherObj.name;
-
-  return (
-    obj.apiVersion === otherObj.apiVersion &&
-    obj.kind === otherObj.kind &&
-    isNameEqual &&
-    isUIDEqual
-  );
-};
-
 export const isCPUEqual = (a: CPU, b: CPU) =>
   a.sockets === b.sockets && a.cores === b.cores && a.threads === b.threads;
 


### PR DESCRIPTION
required by https://github.com/openshift/console/pull/3811

used by metal3 and kubevirt