### PR TITLE
Add 'webdriver-update:osx' task to automatically pick correct version of Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ If you your local Chrome version doesn't match the Chromedriver version from the
 ```
 yarn run webdriver-update --versions.chrome=77.0.3865.120
 ```
+Or if you are using macOS (OS X), run:
+```
+# automatically select the correct Chrome version
+yarn run webdriver-update-webdriver-update-macos
+```
+
 
 You can look up the version number you need at [omahaProxy.appspot.com](https://omahaproxy.appspot.com/).
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "test": "jest",
     "debug-test": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "webdriver-update": "webdriver-manager update --gecko=false",
+    "webdriver-update-macos": "CHROME_VERSION=$(/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --version) && yarn webdriver-update --versions.chrome=\"${CHROME_VERSION}\"",
     "test-gui-tap": "TAP=true yarn run test-gui",
     "test-gui-openshift": "yarn run test-suite --suite crud --params.openshift true",
     "test-gui": "yarn run test-suite --suite all",


### PR DESCRIPTION
A convenience `yarn` task to run on OSX and get a webdriver update to the installed version of Chrome.

/assign @spadgett @rhamilto 