### PR TITLE
backend: disable HTTP/2

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -524,6 +524,8 @@ func main() {
 	httpsrv := &http.Server{
 		Addr:    listenURL.Host,
 		Handler: srv.HTTPHandler(),
+		// Disable HTTP/2, which breaks WebSockets.
+		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 	}
 
 	log.Infof("Binding to %s...", httpsrv.Addr)


### PR DESCRIPTION
Our proxy can't handle WebSockets when using HTTP/2.

/assign @benjaminapetersen 