### PR TITLE
frontend: Add Marketplace hint block

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -120,6 +120,18 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
       );
     }
 
+    if (providerType === 'Marketplace') {
+      return (
+        <HintBlock title="Marketplace Operator">
+          <p>
+            This Operator is purchased through Red Hat Marketplace. After completing the purchase
+            process, you can install the Operator on this or other OpenShift clusters. Visit Red Hat
+            Marketplace for more details and to track your usage of this application.
+          </p>
+        </HintBlock>
+      );
+    }
+
     return null;
   };
 


### PR DESCRIPTION
This is what it should look like when we actually have Marketplace operators (shoved it in a community operator for this screenshot; this is not actually a Marketplace operator):
<img width="625" alt="Screen Shot 2020-01-20 at 4 36 59 PM" src="https://user-images.githubusercontent.com/7014965/72759253-22eeba00-3ba3-11ea-9575-8cf10393fa75.png">

It'll be in the PF4 modal once that gets merged.

Fixes https://issues.redhat.com/projects/CONSOLE/issues/CONSOLE-2028.

Will address other Marketplace operator stuff (badges, filtering, etc.) in separate PR.