### PR TITLE
create a utility and component for traffic connector

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -9,7 +9,8 @@ import { RootState } from '@console/internal/redux';
 import { ServiceBindingRequestModel } from '../../models';
 import { TopologyFilters, getTopologyFilters } from './filters/filter-utils';
 import { allowedResources, transformTopologyData } from './topology-utils';
-import { TopologyDataModel, TopologyDataResources } from './topology-types';
+import { TopologyDataModel, TopologyDataResources, TrafficData } from './topology-types';
+import trafficConnectorMock from './__mocks__/traffic-connector.mock';
 
 export interface RenderProps {
   data?: TopologyDataModel;
@@ -33,6 +34,7 @@ export interface ControllerProps {
   cheURL: string;
   serviceBinding: boolean;
   topologyFilters: TopologyFilters;
+  trafficData?: TrafficData;
 }
 
 export interface TopologyDataControllerProps extends StateProps {
@@ -54,6 +56,7 @@ const Controller: React.FC<ControllerProps> = ({
   utils,
   serviceBinding,
   topologyFilters,
+  trafficData,
 }) =>
   render({
     loaded,
@@ -67,6 +70,7 @@ const Controller: React.FC<ControllerProps> = ({
           cheURL,
           utils,
           topologyFilters,
+          trafficData,
         )
       : null,
   });
@@ -106,6 +110,7 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
         utils={utils}
         serviceBinding={serviceBinding}
         topologyFilters={filters}
+        trafficData={trafficConnectorMock.elements}
       />
     </Firehose>
   );

--- a/frontend/packages/dev-console/src/components/topology/__mocks__/traffic-connector.mock.ts
+++ b/frontend/packages/dev-console/src/components/topology/__mocks__/traffic-connector.mock.ts
@@ -1,0 +1,315 @@
+/**
+ * TODO(sahil143) remove this file we have api in place
+ */
+const data = {
+  timestamp: 1579561864,
+  duration: 21600,
+  graphType: 'workload',
+  elements: {
+    nodes: [
+      {
+        data: {
+          id: '5cd385c1ee3309ae40828b5702ae57fb',
+          nodeType: 'workload',
+          namespace: 'bookinfo',
+          workload: 'details-v1',
+          app: 'details',
+          version: 'v1',
+          destServices: [
+            {
+              namespace: 'bookinfo',
+              name: 'details',
+            },
+          ],
+          traffic: [
+            {
+              protocol: 'http',
+              rates: {
+                httpIn: '0.04',
+              },
+            },
+          ],
+        },
+      },
+      {
+        data: {
+          id: '240c2314cefc993c5d9479a5c349fbd2',
+          nodeType: 'workload',
+          namespace: 'bookinfo',
+          workload: 'productpage-v1',
+          app: 'productpage',
+          version: 'v1',
+          destServices: [
+            {
+              namespace: 'bookinfo',
+              name: 'productpage',
+            },
+          ],
+          traffic: [
+            {
+              protocol: 'http',
+              rates: {
+                httpIn: '0.04',
+                httpOut: '0.08',
+              },
+            },
+          ],
+        },
+      },
+      {
+        data: {
+          id: '5fd49fef66081810598406b0686500ae',
+          nodeType: 'workload',
+          namespace: 'bookinfo',
+          workload: 'ratings-v1',
+          app: 'ratings',
+          version: 'v1',
+          destServices: [
+            {
+              namespace: 'bookinfo',
+              name: 'ratings',
+            },
+          ],
+          traffic: [
+            {
+              protocol: 'http',
+              rates: {
+                httpIn: '0.03',
+              },
+            },
+          ],
+        },
+      },
+      {
+        data: {
+          id: 'fc3e7c5bb695ef8ed8ab2c5f6ac4725b',
+          nodeType: 'workload',
+          namespace: 'bookinfo',
+          workload: 'reviews-v1',
+          app: 'reviews',
+          version: 'v1',
+          destServices: [
+            {
+              namespace: 'bookinfo',
+              name: 'reviews',
+            },
+          ],
+          traffic: [
+            {
+              protocol: 'http',
+              rates: {
+                httpIn: '0.01',
+              },
+            },
+          ],
+        },
+      },
+      {
+        data: {
+          id: '9e97011b2086f59a90626cfd5cf23fbf',
+          nodeType: 'workload',
+          namespace: 'bookinfo',
+          workload: 'reviews-v2',
+          app: 'reviews',
+          version: 'v2',
+          destServices: [
+            {
+              namespace: 'bookinfo',
+              name: 'reviews',
+            },
+          ],
+          traffic: [
+            {
+              protocol: 'http',
+              rates: {
+                httpIn: '0.01',
+                httpOut: '0.01',
+              },
+            },
+          ],
+        },
+      },
+      {
+        data: {
+          id: '731126638001dfa2b6cbeb3b326b6678',
+          nodeType: 'workload',
+          namespace: 'bookinfo',
+          workload: 'reviews-v3',
+          app: 'reviews',
+          version: 'v3',
+          destServices: [
+            {
+              namespace: 'bookinfo',
+              name: 'reviews',
+            },
+          ],
+          traffic: [
+            {
+              protocol: 'http',
+              rates: {
+                httpIn: '0.01',
+                httpOut: '0.01',
+              },
+            },
+          ],
+        },
+      },
+      {
+        data: {
+          id: 'e6016ec07f8f549a00b2d0182607347e',
+          nodeType: 'workload',
+          namespace: 't-s',
+          workload: 'istio-ingressgateway',
+          app: 'istio-ingressgateway',
+          traffic: [
+            {
+              protocol: 'http',
+              rates: {
+                httpOut: '0.04',
+              },
+            },
+          ],
+          isOutside: true,
+          isRoot: true,
+        },
+      },
+    ],
+    edges: [
+      {
+        data: {
+          id: 'df66cffc756bf9983dd453837e4e14a7',
+          source: '240c2314cefc993c5d9479a5c349fbd2',
+          target: '5cd385c1ee3309ae40828b5702ae57fb',
+          traffic: {
+            protocol: 'http',
+            rates: {
+              http: '0.04',
+              httpPercentReq: '50.6',
+            },
+            responses: {
+              '200': {
+                '-': '100.0',
+              },
+            },
+          },
+        },
+      },
+      {
+        data: {
+          id: '1da31b81ccaf408abccbc57071458462',
+          source: '240c2314cefc993c5d9479a5c349fbd2',
+          target: '731126638001dfa2b6cbeb3b326b6678',
+          traffic: {
+            protocol: 'http',
+            rates: {
+              http: '0.01',
+              httpPercentReq: '16.5',
+            },
+            responses: {
+              '200': {
+                '-': '100.0',
+              },
+            },
+          },
+        },
+      },
+      {
+        data: {
+          id: 'c2ab8814859ec0974c5efd597b5bb4fd',
+          source: '240c2314cefc993c5d9479a5c349fbd2',
+          target: '9e97011b2086f59a90626cfd5cf23fbf',
+          traffic: {
+            protocol: 'http',
+            rates: {
+              http: '0.01',
+              httpPercentReq: '16.5',
+            },
+            responses: {
+              '200': {
+                '-': '100.0',
+              },
+            },
+          },
+        },
+      },
+      {
+        data: {
+          id: '943e5cc1b00d97a8a344fe1efd941130',
+          source: '240c2314cefc993c5d9479a5c349fbd2',
+          target: 'fc3e7c5bb695ef8ed8ab2c5f6ac4725b',
+          traffic: {
+            protocol: 'http',
+            rates: {
+              http: '0.01',
+              httpPercentReq: '16.5',
+            },
+            responses: {
+              '200': {
+                '-': '100.0',
+              },
+            },
+          },
+        },
+      },
+      {
+        data: {
+          id: 'fa1db53921ef4a16b273c5260df63c2d',
+          source: '731126638001dfa2b6cbeb3b326b6678',
+          target: '5fd49fef66081810598406b0686500ae',
+          traffic: {
+            protocol: 'http',
+            rates: {
+              http: '0.01',
+              httpPercentReq: '100.0',
+            },
+            responses: {
+              '200': {
+                '-': '100.0',
+              },
+            },
+          },
+        },
+      },
+      {
+        data: {
+          id: '0b356bd23faa1d1f26b3edeb4bbf0502',
+          source: '9e97011b2086f59a90626cfd5cf23fbf',
+          target: '5fd49fef66081810598406b0686500ae',
+          traffic: {
+            protocol: 'http',
+            rates: {
+              http: '0.01',
+              httpPercentReq: '100.0',
+            },
+            responses: {
+              '200': {
+                '-': '100.0',
+              },
+            },
+          },
+        },
+      },
+      {
+        data: {
+          id: '454cd46a968f1d606a68498c741bb569',
+          source: 'e6016ec07f8f549a00b2d0182607347e',
+          target: '240c2314cefc993c5d9479a5c349fbd2',
+          traffic: {
+            protocol: 'http',
+            rates: {
+              http: '0.04',
+              httpPercentReq: '100.0',
+            },
+            responses: {
+              '200': {
+                '-': '100.0',
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+
+export default data;

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -2200,3 +2200,78 @@ export const MockResources: TopologyDataResources = {
   clusterServiceVersions: sampleClusterServiceVersions,
   events: sampleEventsResource,
 };
+
+export const MockKialiGraphData = {
+  nodes: [
+    {
+      data: {
+        id: '5cd385c1ee3309ae40828b5702ae57fb',
+        nodeType: 'workload',
+        namespace: 'testproject1',
+        workload: 'wit-deployment',
+        app: 'details',
+        version: 'v1',
+        destServices: [
+          {
+            namespace: 'bookinfo',
+            name: 'details',
+          },
+        ],
+        traffic: [
+          {
+            protocol: 'http',
+            rates: {
+              httpIn: '0.04',
+            },
+          },
+        ],
+      },
+    },
+    {
+      data: {
+        id: '240c2314cefc993c5d9479a5c349fbd2',
+        nodeType: 'workload',
+        namespace: 'testproject1',
+        workload: 'analytics-deployment',
+        app: 'productpage',
+        version: 'v1',
+        destServices: [
+          {
+            namespace: 'bookinfo',
+            name: 'productpage',
+          },
+        ],
+        traffic: [
+          {
+            protocol: 'http',
+            rates: {
+              httpIn: '0.04',
+              httpOut: '0.08',
+            },
+          },
+        ],
+      },
+    },
+  ],
+  edges: [
+    {
+      data: {
+        id: 'df66cffc756bf9983dd453837e4e14a7',
+        source: '240c2314cefc993c5d9479a5c349fbd2',
+        target: '5cd385c1ee3309ae40828b5702ae57fb',
+        traffic: {
+          protocol: 'http',
+          rates: {
+            http: '0.04',
+            httpPercentReq: '50.6',
+          },
+          responses: {
+            '200': {
+              '-': '100.0',
+            },
+          },
+        },
+      },
+    },
+  ],
+};

--- a/frontend/packages/dev-console/src/components/topology/componentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/componentFactory.ts
@@ -53,6 +53,7 @@ import {
   TYPE_HELM_WORKLOAD,
   TYPE_OPERATOR_BACKED_SERVICE,
   TYPE_OPERATOR_WORKLOAD,
+  TYPE_TRAFFIC_CONNECTOR,
 } from './const';
 import OperatorBackedService from './components/nodes/OperatorBackedService';
 import KnativeService from './components/nodes/KnativeService';
@@ -63,6 +64,7 @@ import { createConnection, createSinkConnection } from './components/createConne
 import { withEditReviewAccess } from './withEditReviewAccess';
 import HelmRelease from './components/groups/HelmRelease';
 import AggregateEdge from './components/edges/AggregateEdge';
+import TrafficConnector from './components/edges/TrafficConnector';
 
 type NodeProps = {
   element: Node;
@@ -233,6 +235,8 @@ class ComponentFactory {
           return withRemoveConnector(removeConnectorCallback)(ServiceBinding);
         case TYPE_AGGREGATE_EDGE:
           return AggregateEdge;
+        case TYPE_TRAFFIC_CONNECTOR:
+          return TrafficConnector;
         default:
           switch (kind) {
             case ModelKind.graph:

--- a/frontend/packages/dev-console/src/components/topology/components/edges/BaseEdge.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/edges/BaseEdge.scss
@@ -1,6 +1,7 @@
 .odc-base-edge {
   --edge--drag-active--cursor: grab;
   --edge--stroke-width: 1px;
+  --edge--stroke-dasharray: 0;
   --edge--stroke: var(--pf-global--BackgroundColor--dark-200);
   --edge--fill: var(--pf-global--BackgroundColor--dark-200);
   --edge--opacity: 1;
@@ -16,6 +17,7 @@
   cursor: var(--edge--cursor);
   stroke: var(--edge--stroke);
   stroke-width: var(--edge--stroke-width);
+  stroke-dasharray: var(--edge--stroke-dasharray);
   fill: var(--edge--fill);
   opacity: var(--edge--opacity);
 

--- a/frontend/packages/dev-console/src/components/topology/components/edges/TrafficConnector.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/edges/TrafficConnector.scss
@@ -1,0 +1,9 @@
+.odc-traffic-connector {
+  --edge--stroke: var(--pf-global--BackgroundColor--dark-200);
+  --edge--fill: var(--pf-global--BackgroundColor--dark-200);
+  --edge__link--stroke: var(--pf-global--BackgroundColor--dark-200);
+  --edge__arrow--cursor: default;
+  line {
+    stroke-dasharray: 5;
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology/components/edges/TrafficConnector.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/edges/TrafficConnector.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Edge, EdgeConnectorArrow } from '@console/topology';
+import BaseEdge from './BaseEdge';
+import './TrafficConnector.scss';
+
+type TrafficConnectorProps = {
+  element: Edge;
+};
+
+const TrafficConnector: React.FC<TrafficConnectorProps> = ({ element }) => (
+  <BaseEdge element={element} className="odc-traffic-connector">
+    <EdgeConnectorArrow edge={element} />
+  </BaseEdge>
+);
+
+export default TrafficConnector;

--- a/frontend/packages/dev-console/src/components/topology/const.ts
+++ b/frontend/packages/dev-console/src/components/topology/const.ts
@@ -12,3 +12,4 @@ export const TYPE_HELM_RELEASE = 'helm-release';
 export const TYPE_HELM_WORKLOAD = 'helm-workload';
 export const TYPE_OPERATOR_BACKED_SERVICE = 'operator-backed-service';
 export const TYPE_OPERATOR_WORKLOAD = 'operator-workload';
+export const TYPE_TRAFFIC_CONNECTOR = 'traffic-connector';

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -208,6 +208,33 @@ export type GroupProps = ViewGroup &
     groupRef(element: GroupElementInterface): void;
   };
 
+export type TrafficData = {
+  nodes: KialiNode[];
+  edges: KialiEdge[];
+};
+
+export type KialiNode = {
+  data: {
+    id: string;
+    nodeType: string;
+    namespace: string;
+    workload: string;
+    app: string;
+    version?: string;
+    destServices?: { [key: string]: any }[];
+    traffic?: { [key: string]: any }[];
+  };
+};
+
+export type KialiEdge = {
+  data: {
+    id: string;
+    source: string;
+    target: string;
+    traffic: { [key: string]: any };
+  };
+};
+
 export type NodeProvider = (type: string) => ComponentType<NodeProps>;
 
 export type EdgeProvider = (type: string) => ComponentType<EdgeProps>;


### PR DESCRIPTION
ODC-story: https://issues.redhat.com/browse/ODC-2461

This Pr adds the traffic connector and is based on the mock data. To test this PR locally run below cmds and select the `bookinfo` namespace
```
oc new-project bookinfo
oc apply -n bookinfo -f https://raw.githubusercontent.com/Maistra/bookinfo/maistra-1.0/bookinfo.yaml
```
![Screenshot from 2020-01-21 18-07-34](https://user-images.githubusercontent.com/9278015/72805611-51d75f80-3c79-11ea-8ac9-88526b0f8b5f.png)

