### PR TITLE
chore: bump node-sass to 4.13.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -180,7 +180,7 @@
     "mini-css-extract-plugin": "0.4.x",
     "monaco-editor-core": "0.14.0",
     "monaco-editor-webpack-plugin": "^1.7.0",
-    "node-sass": "4.12.x",
+    "node-sass": "4.13.x",
     "prettier": "1.19.1",
     "protractor": "5.4.x",
     "protractor-fail-fast": "3.x",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11520,10 +11520,10 @@ node-releases@^1.1.29, node-releases@^1.1.38:
   dependencies:
     semver "^6.3.0"
 
-node-sass@4.12.x:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.12.0.tgz#0914f531932380114a30cc5fa4fa63233a25f017"
-  integrity sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==
+node-sass@4.13.x:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -11532,7 +11532,7 @@ node-sass@4.12.x:
     get-stdin "^4.0.1"
     glob "^7.0.3"
     in-publish "^2.0.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     meow "^3.7.0"
     mkdirp "^0.5.1"
     nan "^2.13.2"


### PR DESCRIPTION
Required for Node.js 13.

/assign @benjaminapetersen @rhamilto 
https://issues.redhat.com/browse/CONSOLE-2031