### PR TITLE
Show only the allowed storage interfaces on Disk-modal

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/storage-tab-validation.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/storage-tab-validation.ts
@@ -8,6 +8,8 @@ import { getStoragesWithWrappers } from '../../selectors/selectors';
 import { iGetStorages } from '../../selectors/immutable/storage';
 import { iGetProvisionSource } from '../../selectors/immutable/vm-settings';
 import { ProvisionSource } from '../../../../constants/vm/provision-source';
+import { TemplateValidations } from '../../../../utils/validations/template/template-validations';
+import { getTemplateValidation } from '../../selectors/template';
 
 export const validateStorages = (options: UpdateOptions) => {
   const { id, prevState, dispatch, getState } = options;
@@ -28,6 +30,8 @@ export const validateStorages = (options: UpdateOptions) => {
   }
 
   const storages = getStoragesWithWrappers(state, id);
+  const templateValidation = getTemplateValidation(state, id);
+  const allowedBusses = (templateValidation || new TemplateValidations()).getAllowedBusses();
 
   const validatedStorages = storages.map(
     ({
@@ -56,6 +60,7 @@ export const validateStorages = (options: UpdateOptions) => {
           {
             usedDiskNames,
             usedPVCNames,
+            allowedBusses,
           },
         ),
       };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/vm-settings-tab-validation.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/vm-settings-tab-validation.ts
@@ -44,7 +44,7 @@ import { vmSettingsOrder } from '../initial-state/vm-settings-tab-initial-state'
 import { TemplateValidations } from '../../../../utils/validations/template/template-validations';
 import { combineIntegerValidationResults } from '../../../../utils/validations/template/utils';
 import { getValidationUpdate } from './utils';
-import { getTemplateValidations } from './utils/templates-validations';
+import { getTemplateValidations } from '../../selectors/template';
 
 const validateVm: VmSettingsValidator = (field, options) => {
   const { getState, id } = options;
@@ -103,8 +103,10 @@ const memoryValidation: VmSettingsValidator = (field, options): ValidationObject
   if (memValueGB == null || memValueGB === '') {
     return null;
   }
+  const { id, getState } = options;
+  const state = getState();
   const memValueBytes = memValueGB * 1024 ** 3;
-  const validations = getTemplateValidations(options);
+  const validations = getTemplateValidations(state, id);
   if (validations.length === 0) {
     validations.push(new TemplateValidations()); // add empty validation for positive integer if it is missing one
   }

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/template.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/template.ts
@@ -1,26 +1,19 @@
-import { UpdateOptions } from '../../types';
-import {
-  iGetVmSettingAttribute,
-  iGetVmSettingValue,
-} from '../../../selectors/immutable/vm-settings';
-import { iGetLoadedCommonData } from '../../../selectors/immutable/selectors';
-import { VMSettingsField, VMWizardProps } from '../../../types';
-import { iGetTemplateValidations } from '../../../../../selectors/immutable/template/selectors';
+import { iGetTemplateValidations } from '../../../selectors/immutable/template/selectors';
+import { TemplateValidations } from '../../../utils/validations/template/template-validations';
 import {
   iGetRelevantTemplate,
   iGetRelevantTemplates,
-} from '../../../../../selectors/immutable/template/combined';
-import { TemplateValidations } from '../../../../../utils/validations/template/template-validations';
+} from '../../../selectors/immutable/template/combined';
+import { VMSettingsField, VMWizardProps } from '../types';
+import { iGetLoadedCommonData } from './immutable/selectors';
+import { iGetVmSettingAttribute, iGetVmSettingValue } from './immutable/vm-settings';
 
 const getValidationsFromTemplates = (templates): TemplateValidations[] =>
   templates.map(
     (relevantTemplate) => new TemplateValidations(iGetTemplateValidations(relevantTemplate)),
   );
 
-export const getTemplateValidations = (options: UpdateOptions): TemplateValidations[] => {
-  const { getState, id } = options;
-  const state = getState();
-
+export const getTemplateValidations = (state, id: string): TemplateValidations[] => {
   const userTemplateName = iGetVmSettingValue(state, id, VMSettingsField.USER_TEMPLATE);
   const os = iGetVmSettingAttribute(state, id, VMSettingsField.OPERATING_SYSTEM);
   const flavor = iGetVmSettingAttribute(state, id, VMSettingsField.FLAVOR);
@@ -53,4 +46,15 @@ export const getTemplateValidations = (options: UpdateOptions): TemplateValidati
   );
 
   return getValidationsFromTemplates(relevantTemplates.toArray());
+};
+
+export const getTemplateValidation = (state, id: string): TemplateValidations => {
+  const templateValidations = getTemplateValidations(state, id);
+  if (templateValidations && templateValidations.length > 0) {
+    templateValidations.length > 1 &&
+      console.warn('WARNING: getTemplateValidation: multiple template validations detected!');
+    return templateValidations[0];
+  }
+
+  return null;
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-modal-enhanced.tsx
@@ -24,6 +24,9 @@ import { DataVolumeWrapper } from '../../../../k8s/wrapper/vm/data-volume-wrappe
 import { DiskModal } from '../../../modals/disk-modal';
 import { VM_TEMPLATE_NAME_PARAMETER } from '../../../../constants/vm-templates';
 import { PersistentVolumeClaimWrapper } from '../../../../k8s/wrapper/vm/persistent-volume-claim-wrapper';
+import { TemplateValidations } from '../../../../utils/validations/template/template-validations';
+import { DiskBus } from '../../../../constants/vm/storage/disk-bus';
+import { getTemplateValidation } from '../../selectors/template';
 
 const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
   const {
@@ -34,6 +37,7 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
     useProjects,
     addUpdateStorage,
     storages,
+    templateValidations,
     ...restProps
   } = props;
   const {
@@ -80,6 +84,10 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
     },
   ];
 
+  const allowedBusses: Set<DiskBus> = (
+    templateValidations || new TemplateValidations()
+  ).getAllowedBusses();
+
   return (
     <Firehose resources={resources}>
       <DiskModal
@@ -90,6 +98,7 @@ const VMWizardStorageModal: React.FC<VMWizardStorageModalProps> = (props) => {
         onNamespaceChanged={(n) => setNamespace(n)}
         usedDiskNames={usedDiskNames}
         usedPVCNames={usedPVCNames}
+        allowedBusses={allowedBusses}
         disk={diskWrapper}
         volume={volumeWrapper}
         dataVolume={dataVolumeWrapper}
@@ -139,6 +148,7 @@ type VMWizardStorageModalProps = ModalComponentProps & {
   isCreateTemplate: boolean;
   storages: VMWizardStorageWithWrappers[];
   addUpdateStorage: (storage: VMWizardStorage) => void;
+  templateValidations: TemplateValidations;
 };
 
 const stateToProps = (state, { wizardReduxID }) => {
@@ -148,6 +158,7 @@ const stateToProps = (state, { wizardReduxID }) => {
     namespace: iGetCommonData(state, wizardReduxID, VMWizardProps.activeNamespace),
     isCreateTemplate: iGetCommonData(state, wizardReduxID, VMWizardProps.isCreateTemplate),
     storages: getStoragesWithWrappers(state, wizardReduxID),
+    templateValidations: getTemplateValidation(state, wizardReduxID),
   };
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-row.tsx
@@ -76,6 +76,7 @@ export const VmWizardStorageRow: React.FC<VMWizardNicRowProps> = ({
       validation={{
         name: validations.name || validations.url || validations.container || validations.pvc,
         size: validations.size,
+        diskInterface: validations.diskInterface,
       }}
       columnClasses={columnClasses}
       index={index}

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/common.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/common.ts
@@ -7,9 +7,11 @@ import {
   validateEmptyValue,
   ValidationErrorType,
   ValidationObject,
+  joinGrammaticallyListOfItems,
 } from '@console/shared';
 import { parseURL } from '../url';
 import { END_WHITESPACE_ERROR, START_WHITESPACE_ERROR, URL_INVALID_ERROR } from './strings';
+import { DiskBus } from '../../constants/vm/storage/disk-bus';
 
 export const isValidationError = (validationObject: ValidationObject) =>
   !!validationObject && validationObject.type === ValidationErrorType.Error;
@@ -80,4 +82,16 @@ export const validateURL = (
   }
 
   return parseURL(value) ? null : asValidationObject(addMissingSubject(URL_INVALID_ERROR, subject));
+};
+
+export const validateBus = (value: DiskBus, allowedBusses: Set<DiskBus>): ValidationObject => {
+  if (allowedBusses && !allowedBusses.has(value)) {
+    return asValidationObject(
+      `Invalid interface type. Valid types are: ${joinGrammaticallyListOfItems(
+        [...allowedBusses].map((b) => b.toString()),
+      )}`,
+      ValidationErrorType.Error,
+    );
+  }
+  return null;
 };

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/template/interval-validation-result.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/template/interval-validation-result.ts
@@ -44,7 +44,7 @@ export class MemoryIntervalValidationResult extends IntervalValidationResult {
         }`;
       }
       if (Number.isFinite(this.max)) {
-        return `Memory ${verb} be ${this.isMaxInclusive ? 'at most' : 'bellow'} ${
+        return `Memory ${verb} be ${this.isMaxInclusive ? 'at most' : 'below'} ${
           humanizeBinaryBytes(this.max).string
         }`;
       }


### PR DESCRIPTION
Fixes: CNV-2914

Enforce the validations from common and user templates
so the user can choose only from the allowed values in the Disk-modal
at the storage tab.

Depends on: #3909

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>