### PR TITLE
[WIP] add proxy to access Kiali backend API

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/console/pkg/bridge"
 	"github.com/openshift/console/pkg/crypto"
 	"github.com/openshift/console/pkg/helm"
+	"github.com/openshift/console/pkg/kiali"
 	"github.com/openshift/console/pkg/proxy"
 	"github.com/openshift/console/pkg/server"
 	"github.com/openshift/console/pkg/serverconfig"
@@ -110,6 +111,8 @@ func main() {
 	fLoadTestFactor := fs.Int("load-test-factor", 0, "DEV ONLY. The factor used to multiply k8s API list responses for load testing purposes.")
 
 	helmConfig := helm.RegisterFlags(fs)
+
+	kialiConfig := kiali.RegisterFlags(fs)
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -525,6 +528,8 @@ func main() {
 	}
 
 	helmConfig.Configure(srv)
+
+	kialiConfig.Configure(srv)
 
 	httpsrv := &http.Server{
 		Addr:    listenURL.Host,

--- a/pkg/kiali/config.go
+++ b/pkg/kiali/config.go
@@ -1,0 +1,62 @@
+package kiali
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"io/ioutil"
+
+	"github.com/coreos/pkg/capnslog"
+
+	"github.com/openshift/console/pkg/bridge"
+	"github.com/openshift/console/pkg/crypto"
+	"github.com/openshift/console/pkg/proxy"
+	"github.com/openshift/console/pkg/server"
+)
+
+var (
+	log = capnslog.NewPackageLogger("github.com/openshift/console", "pkg/kiali")
+)
+
+type config struct {
+	kialiHostUrl string
+	kialiCaFile  string
+}
+
+func RegisterFlags(fs *flag.FlagSet) *config {
+
+	cfg := new(config)
+
+	fs.StringVar(&cfg.kialiHostUrl, "kiali-host-url", "https://kiali-istio-system.apps.sp33.devcluster.openshift.com", "Kiali backend URL")
+	fs.StringVar(&cfg.kialiCaFile, "kiali-host-ca-file", "", "CA bundle for Kiali host.")
+
+	return cfg
+}
+
+func (cfg *config) Configure(srv *server.Server) {
+	kialiHostUrl := bridge.ValidateFlagIsURL("kiali-backend-hostUrl", cfg.kialiHostUrl)
+
+	var rootCAs *x509.CertPool
+	if cfg.kialiCaFile != "" {
+		rootCAs = x509.NewCertPool()
+		certPEM, err := ioutil.ReadFile(cfg.kialiCaFile)
+		if err != nil {
+			log.Fatalf("failed to read kiali ca file %v : %v", cfg.kialiCaFile, err)
+		}
+		if !rootCAs.AppendCertsFromPEM(certPEM) {
+			log.Fatalf("No CA found for kiali proxy")
+		}
+	} else {
+		rootCAs, _ = x509.SystemCertPool()
+	}
+
+	srv.KialiProxyConfig = &proxy.Config{
+		TLSClientConfig: &tls.Config{
+			RootCAs:      rootCAs,
+			CipherSuites: crypto.DefaultCiphers(),
+		},
+		HeaderBlacklist: []string{"Cookie", "X-CSRFToken"},
+		Endpoint:        kialiHostUrl,
+	}
+
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,6 +35,7 @@ const (
 	meteringProxyEndpoint          = "/api/metering"
 	customLogoEndpoint             = "/custom-logo"
 	helmChartRepoProxyEndpoint     = "/api/helm/charts/"
+	kialiProxyEndpoint             = "/api/namespaces"
 )
 
 var (
@@ -93,6 +94,7 @@ type Server struct {
 	// A lister for resource listing of a particular kind
 	MonitoringDashboardConfigMapLister *ResourceLister
 	HelmChartRepoProxyConfig           *proxy.Config
+	KialiProxyConfig                   *proxy.Config
 }
 
 func (s *Server) authDisabled() bool {
@@ -304,6 +306,12 @@ func (s *Server) HTTPHandler() http.Handler {
 	handle(helmChartRepoProxyEndpoint, http.StripPrefix(
 		proxy.SingleJoiningSlash(s.BaseURL.Path, helmChartRepoProxyEndpoint),
 		http.HandlerFunc(helmChartRepoProxy.ServeHTTP)))
+
+	kialiProxy := proxy.NewProxy(s.KialiProxyConfig)
+
+	handle(kialiProxyEndpoint, http.StripPrefix(
+		proxy.SingleJoiningSlash(s.BaseURL.Path, kialiProxyEndpoint),
+		http.HandlerFunc(kialiProxy.ServeHTTP)))
 
 	mux.HandleFunc(s.BaseURL.Path, s.indexHandler)
 

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -36,6 +36,7 @@ func SetFlagsFromConfig(fs *flag.FlagSet, filename string) (err error) {
 	addCustomization(fs, &config.Customization)
 	addProviders(fs, &config.Providers)
 	addHelmConfig(fs, &config.Helm)
+	addKialiConfig(fs, &config.Kiali)
 
 	return nil
 }
@@ -46,6 +47,16 @@ func addHelmConfig(fs *flag.FlagSet, helmConfig *Helm) (err error) {
 	}
 	if helmConfig.ChartRepo.CAFile != "" {
 		fs.Set("helm-chart-repo-ca-file", helmConfig.ChartRepo.CAFile)
+	}
+	return nil
+}
+
+func addKialiConfig(fs *flag.FlagSet, kialiConfig *Kiali) (err error) {
+	if kialiConfig.URL != "" {
+		fs.Set("kiali-host-url", kialiConfig.URL)
+	}
+	if kialiConfig.CAFile != "" {
+		fs.Set("kiali-host-ca-file", kialiConfig.CAFile)
 	}
 	return nil
 }

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -14,6 +14,7 @@ type Config struct {
 	Customization `yaml:"customization"`
 	Providers     `yaml:"providers"`
 	Helm          `yaml:"helm"`
+	Kiali         `yaml:"kiali"`
 }
 
 // ServingInfo holds configuration for serving HTTP.
@@ -67,4 +68,9 @@ type HelmChartRepo struct {
 
 type Helm struct {
 	ChartRepo HelmChartRepo `yaml:"chartRepository"`
+}
+
+type Kiali struct {
+	URL    string `yaml:"url,omitempty"`
+	CAFile string `yaml:"caFile,omitempty"`
 }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2769

**Analysis / Root cause**: 
To draw relationship between components in topology, Kiali backend API should be used for consistency in the data that is presented. Hence we need a proxy in console to access Kiali API

**Solution Description**: 
Created a proxy for Kiali backend in console using a hardcoded Kiali hostname. 
**Note**: Requests are failing with 502 Bad Gateway. Looks like we need Kiali to support their back-end API over openshift-session-token. Also Kiali hostname is dynamic & depends on namespace in which Service mesh control plane is installed. Hence hardcoded the host name until we finalise on approach to get associated Kiali host URL. For these 2 reason it's a WIP PR.

**Screen shots / Gifs for design review**: 
N/A

**Test setup:**
Need to build backend & test using browser or curl.
