### PR TITLE
Allow long string container names to wrap and add spacing to checkbox rows

### DIFF
--- a/frontend/public/components/container-selector.tsx
+++ b/frontend/public/components/container-selector.tsx
@@ -8,7 +8,7 @@ export const ContainerSelector: React.FC<ContainerSelectorProps> = ({
   onChange,
   selected,
 }) => (
-  <div>
+  <div className="pf-c-form__checkbox-row">
     {containers.map((container: ContainerSpec) => (
       <Checkbox
         key={container.name}

--- a/frontend/public/components/storage/attach-storage.tsx
+++ b/frontend/public/components/storage/attach-storage.tsx
@@ -332,7 +332,7 @@ export const AttachStorageForm: React.FC<AttachStorageFormProps> = (props) => {
           </p>
         )}
         {useContainerSelector && (
-          <div className="form-group">
+          <div className="form-group co-break-word">
             <label className="control-label">Containers</label>
             <Button type="button" onClick={handleSelectContainers} variant="link">
               (use all containers)

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -72,6 +72,11 @@
   justify-content: flex-end;
 }
 
+.pf-c-form__checkbox-row {
+  display: grid;
+  row-gap: ($grid-gutter-width / 2);
+}
+
 .pf-c-form__group--no-top-margin {
   margin-top: 0 !important;
 }


### PR DESCRIPTION
Before
<img width="605" alt="Screen Shot 2020-01-20 at 11 30 31 AM" src="https://user-images.githubusercontent.com/1874151/72845110-e76bf280-3c6b-11ea-9ccd-db2e27834f49.png">

----

After
<img width="589" alt="Screen Shot 2020-01-21 at 4 18 39 PM" src="https://user-images.githubusercontent.com/1874151/72845127-f488e180-3c6b-11ea-941b-585e5912b301.png">

