### PR TITLE
Monitoring Dashboards: Add graph legends

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -30,6 +30,10 @@
 
   .query-browser__wrapper {
     border: 0;
+    margin: 0;
+    overflow: hidden;
+    padding-right: 0;
+    padding-top: 0;
   }
 }
 

--- a/frontend/public/components/monitoring/dashboards/graph.tsx
+++ b/frontend/public/components/monitoring/dashboards/graph.tsx
@@ -1,10 +1,17 @@
 import * as React from 'react';
 
-import { QueryBrowser } from '../query-browser';
+import { FormatLegendLabel, QueryBrowser } from '../query-browser';
 
-const Graph: React.FC<Props> = ({ isStack, pollInterval, queries, timespan }) => (
+const Graph: React.FC<Props> = ({
+  formatLegendLabel,
+  isStack,
+  pollInterval,
+  queries,
+  timespan,
+}) => (
   <QueryBrowser
     defaultSamples={30}
+    formatLegendLabel={formatLegendLabel}
     hideControls
     isStack={isStack}
     pollInterval={pollInterval}
@@ -14,6 +21,7 @@ const Graph: React.FC<Props> = ({ isStack, pollInterval, queries, timespan }) =>
 );
 
 type Props = {
+  formatLegendLabel?: FormatLegendLabel;
   isStack: boolean;
   pollInterval: number;
   queries: string[];

--- a/frontend/public/components/monitoring/dashboards/types.ts
+++ b/frontend/public/components/monitoring/dashboards/types.ts
@@ -15,6 +15,9 @@ export type Panel = {
     y: number;
   };
   id: string;
+  legend?: {
+    show: boolean;
+  };
   panels: Panel[];
   postfix?: string;
   prefix?: string;
@@ -23,6 +26,7 @@ export type Panel = {
   styles?: ColumnStyle[];
   targets: {
     expr: string;
+    legendFormat?: string;
   };
   title: string;
   transform?: string;

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -226,7 +226,7 @@ const graphContainer = (
 );
 
 const Graph: React.FC<GraphProps> = React.memo(
-  ({ allSeries, disabledSeries, isStack, span, xDomain }) => {
+  ({ allSeries, disabledSeries, formatLegendLabel, isStack, span, xDomain }) => {
     const [containerRef, width] = useRefWidth();
 
     // Remove any disabled series
@@ -264,6 +264,12 @@ const Graph: React.FC<GraphProps> = React.memo(
 
     const xTickFormat = span < 5 * 60 * 1000 ? twentyFourHourTimeWithSeconds : twentyFourHourTime;
 
+    const legendData = formatLegendLabel
+      ? _.flatMap(allSeries, (series, i) =>
+          _.map(series, (s) => ({ name: formatLegendLabel(s[0], i) })),
+        )
+      : undefined;
+
     return (
       <div ref={containerRef} style={{ width: '100%' }}>
         {width > 0 && (
@@ -272,6 +278,9 @@ const Graph: React.FC<GraphProps> = React.memo(
             domain={domain}
             domainPadding={{ y: 1 }}
             height={200}
+            legendAllowWrap={true}
+            legendData={legendData}
+            legendPosition="bottom-left"
             scale={{ x: 'time', y: 'linear' }}
             theme={chartTheme}
             width={width}
@@ -352,6 +361,7 @@ const minPollInterval = 10 * 1000;
 const ZoomableGraph: React.FC<ZoomableGraphProps> = ({
   allSeries,
   disabledSeries,
+  formatLegendLabel,
   isStack,
   onZoom,
   span,
@@ -411,6 +421,7 @@ const ZoomableGraph: React.FC<ZoomableGraphProps> = ({
       <Graph
         allSeries={allSeries}
         disabledSeries={disabledSeries}
+        formatLegendLabel={formatLegendLabel}
         isStack={isStack}
         span={span}
         xDomain={xDomain}
@@ -424,6 +435,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   defaultTimespan = parsePrometheusDuration('30m'),
   disabledSeries = [],
   filterLabels,
+  formatLegendLabel,
   GraphLink,
   hideControls,
   hideGraphs,
@@ -624,6 +636,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
             <ZoomableGraph
               allSeries={graphData}
               disabledSeries={disabledSeries}
+              formatLegendLabel={formatLegendLabel}
               isStack={isStack}
               onZoom={onZoom}
               span={span}
@@ -663,9 +676,12 @@ export type QueryObj = {
 
 type PrometheusValue = [number, string];
 
+export type FormatLegendLabel = (labels: Labels, i: number) => string;
+
 type GraphProps = {
   allSeries: Series[];
   disabledSeries?: Labels[][];
+  formatLegendLabel?: FormatLegendLabel;
   isStack?: boolean;
   span: number;
   xDomain?: AxisDomain;
@@ -674,6 +690,7 @@ type GraphProps = {
 type ZoomableGraphProps = {
   allSeries: Series[];
   disabledSeries?: Labels[][];
+  formatLegendLabel?: FormatLegendLabel;
   isStack?: boolean;
   onZoom: (from: number, to: number) => void;
   span: number;
@@ -688,6 +705,7 @@ export type QueryBrowserProps = {
   GraphLink?: React.ComponentType<{}>;
   hideControls?: boolean;
   hideGraphs: boolean;
+  formatLegendLabel?: FormatLegendLabel;
   isStack?: boolean;
   namespace?: string;
   patchQuery: (index: number, patch: QueryObj) => any;


### PR DESCRIPTION
Also includes some graph card style fixes to remove unnecessary margins and padding.

There is a problem with the legend labels sometimes not fitting in the available space below the graph, which will be addressed along with other style issues in a later PR.

![screenshot](https://user-images.githubusercontent.com/460802/72880228-ce357580-3d41-11ea-8c61-bed57b9b4bcc.png)

FYI @cshinn 