### PR TITLE
kubevirt: fix modal footer padding

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/dedicated-resources-modal/dedicated-resources-modal.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/dedicated-resources-modal/dedicated-resources-modal.scss
@@ -1,8 +1,12 @@
-.kubevirt-cpu-pinning__checkbox {
+.kubevirt-dedicated-resources__checkbox {
   margin-top: var(--pf-global--spacer--md);
   margin-bottom: var(--pf-global--spacer--md);
 }
 
-.kubevirt-cpu-pinning__helper-text {
+.kubevirt-dedicated-resources__footer {
+  padding: 0;
+}
+
+.kubevirt-dedicated-resources__helper-text {
   color: var(--pf-global--Color--200);
 }

--- a/frontend/packages/kubevirt-plugin/src/components/modals/dedicated-resources-modal/dedicated-resources-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/dedicated-resources-modal/dedicated-resources-modal.tsx
@@ -46,7 +46,7 @@ const ResourceModal = withHandlePromise<ResourceModalProps>(
     };
     const footer = (
       <ModalFooter
-        className=""
+        className="kubevirt-dedicated-resources__footer"
         warningMessage={!loadError && !isNodeAvailable && RESOURCE_NO_NODES_AVAILABLE}
         errorMessage={showPatchError && errorMessage}
         inProgress={inProgress || isLoading}
@@ -67,14 +67,14 @@ const ResourceModal = withHandlePromise<ResourceModalProps>(
         isFooterLeftAligned
       >
         <Checkbox
-          className="kubevirt-cpu-pinning__checkbox"
+          className="kubevirt-dedicated-resources__checkbox"
           label="Schedule this workload with dedicated resources (guaranteed policy)"
           isChecked={isPinned}
           isDisabled={isLoading}
           onChange={setIsPinned}
-          id="cpu-pinning-checkbox"
+          id="dedicated-resources-checkbox"
         />
-        <Text className="kubevirt-cpu-pinning__helper-text" component={TextVariants.small}>
+        <Text className="kubevirt-dedicated-resources__helper-text" component={TextVariants.small}>
           Available only on Nodes with labels{' '}
           <Label kind={NodeModel.kind} name="cpumanager" value="true" expand />
         </Text>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.scss
@@ -1,4 +1,3 @@
 .kubevirt-create-nic-modal__buttons {
-  padding: 0;
   text-align: left;
 }


### PR DESCRIPTION
- Fix naming of dedicated resources modal css classnames
- revert `padding: 0` for all use cases of `ModalFooter`