### PR TITLE
Alertmanager: Added Email and Slack Receiver forms, implemented Save-As-Global/Default functionality

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -88,6 +88,7 @@ const testSuites = {
     'tests/deploy-image.scenario.ts',
     'tests/performance.scenario.ts',
     'tests/monitoring.scenario.ts',
+    'tests/alertmanager.scenario.ts',
     'tests/crd-extensions.scenario.ts',
     'tests/devconsole/pipeline.scenario.ts',
   ]),
@@ -114,12 +115,14 @@ const testSuites = {
     'tests/deploy-image.scenario.ts',
     'tests/developer-catalog.scenario.ts',
     'tests/monitoring.scenario.ts',
+    'tests/alertmanager.scenario.ts',
     'tests/devconsole/dev-perspective.scenario.ts',
     'tests/devconsole/git-import-flow.scenario.ts',
     'tests/devconsole/pipeline.scenario.ts',
     'tests/crd-extensions.scenario.ts',
   ]),
   clusterSettings: suite(['tests/cluster-settings.scenario.ts']),
+  alertmanager: suite(['tests/alertmanager.scenario.ts']),
   login: ['tests/login.scenario.ts'],
 };
 

--- a/frontend/integration-tests/tests/alertmanager.scenario.ts
+++ b/frontend/integration-tests/tests/alertmanager.scenario.ts
@@ -1,0 +1,362 @@
+import { browser, ExpectedConditions as until } from 'protractor';
+import * as _ from 'lodash';
+import { safeLoad } from 'js-yaml';
+
+import { checkLogs, checkErrors, firstElementByTestID, appHost } from '../protractor.conf';
+import { dropdownMenuForTestID } from '../views/form.view';
+import {
+  AlertmanagerConfig,
+  AlertmanagerReceiver,
+} from '@console/internal/components/monitoring/alert-manager-config';
+import * as crudView from '../views/crud.view';
+import * as yamlView from '../views/yaml.view';
+import * as monitoringView from '../views/monitoring.view';
+import * as horizontalnavView from '../views/horizontal-nav.view';
+import { execSync } from 'child_process';
+
+const replaceInput = async (fieldName: string, value: string) => {
+  await firstElementByTestID(fieldName).clear();
+  await firstElementByTestID(fieldName).sendKeys(value);
+};
+
+const getGlobalsAndReceiverConfig = (configName: string, yamlStr: string) => {
+  const config: AlertmanagerConfig = safeLoad(yamlStr);
+  const receiverConfig: AlertmanagerReceiver = _.find(config.receivers, { name: 'MyReceiver' });
+  return {
+    globals: config.global,
+    receiverConfig: receiverConfig[configName][0],
+  };
+};
+
+xdescribe('Alertmanager: PagerDuty Receiver Form', () => {
+  afterAll(() => {
+    execSync(
+      `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
+    );
+  });
+
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+
+  it('creates PagerDuty Receiver correctly', async () => {
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig`);
+    await crudView.isLoaded();
+    await firstElementByTestID('create-receiver').click();
+    await crudView.isLoaded();
+    await firstElementByTestID('receiver-name').sendKeys('MyReceiver');
+    await firstElementByTestID('dropdown-button').click();
+    await crudView.isLoaded();
+    await dropdownMenuForTestID('pagerduty_configs').click();
+    await crudView.isLoaded();
+    await firstElementByTestID('integration-key').sendKeys('<integration_key>');
+    await firstElementByTestID('label-name-0').sendKeys('severity');
+    await firstElementByTestID('label-value-0').sendKeys('warning');
+
+    expect(firstElementByTestID('pagerduty-url').getAttribute('value')).toEqual(
+      'https://events.pagerduty.com/v2/enqueue',
+    );
+
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+    monitoringView.getFirstRowAsText().then((text) => {
+      expect(text).toEqual('MyReceiver pagerduty severity = warning');
+    });
+  });
+
+  it('saves as default/global correctly', async () => {
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig/receivers/MyReceiver/edit`);
+    await browser.wait(until.presenceOf(firstElementByTestID('cancel')));
+
+    // monitoringView.saveAsDefault checkbox disabled when url equals global url
+    expect(monitoringView.saveAsDefault.isEnabled()).toBeFalsy();
+
+    // changing url, enables monitoringView.saveAsDefault unchecked, should save pagerduty_url with Receiver
+    await replaceInput('pagerduty-url', 'http://pagerduty-url-specific-to-receiver');
+    expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy();
+    expect(monitoringView.saveAsDefault.getAttribute('checked')).toBeFalsy();
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+
+    //pagerduty_url should be saved with Receiver and not global
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await yamlView.isLoaded();
+    let yamlStr = await yamlView.getEditorContent();
+    let configs = getGlobalsAndReceiverConfig('pagerduty_configs', yamlStr);
+    expect(_.has(configs.globals, 'pagerduty_url')).toBeFalsy();
+    expect(configs.receiverConfig.url).toBe('http://pagerduty-url-specific-to-receiver');
+
+    // save pagerduty_url as default/global
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig/receivers/MyReceiver/edit`);
+    await browser.wait(until.presenceOf(firstElementByTestID('cancel')));
+    await replaceInput('pagerduty-url', 'http://global-pagerduty-url');
+    await crudView.isLoaded();
+    expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy();
+    monitoringView.saveAsDefault.click();
+    expect(monitoringView.saveAsDefault.getAttribute('checked')).toBeTruthy();
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+
+    // pagerduty_url should be saved as global, not with Receiver
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await yamlView.isLoaded();
+    yamlStr = await yamlView.getEditorContent();
+    configs = getGlobalsAndReceiverConfig('pagerduty_configs', yamlStr);
+    expect(configs.globals.pagerduty_url).toBe('http://global-pagerduty-url');
+    expect(_.has(configs.receiverConfig, 'url')).toBeFalsy();
+
+    // save pagerduty url to receiver with an existing global
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig/receivers/MyReceiver/edit`);
+    await browser.wait(until.presenceOf(firstElementByTestID('cancel')));
+    await replaceInput('pagerduty-url', 'http://pagerduty-url-specific-to-receiver');
+    expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy();
+    expect(monitoringView.saveAsDefault.getAttribute('checked')).toBeFalsy();
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+
+    // pagerduty_url should be saved with Receiver, as well as having a global pagerduty_url prop
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await yamlView.isLoaded();
+    yamlStr = await yamlView.getEditorContent();
+    configs = getGlobalsAndReceiverConfig('pagerduty_configs', yamlStr);
+    expect(configs.globals.pagerduty_url).toBe('http://global-pagerduty-url');
+    expect(configs.receiverConfig.url).toBe('http://pagerduty-url-specific-to-receiver');
+  });
+});
+
+xdescribe('Alertmanager: Email Receiver Form', () => {
+  afterAll(() => {
+    execSync(
+      `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
+    );
+  });
+
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+
+  it('creates Email Receiver correctly', async () => {
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig`);
+    await crudView.isLoaded();
+    await firstElementByTestID('create-receiver').click();
+    await crudView.isLoaded();
+    await replaceInput('receiver-name', 'MyReceiver');
+    await firstElementByTestID('dropdown-button').click();
+    await crudView.isLoaded();
+    await dropdownMenuForTestID('email_configs').click();
+    await crudView.isLoaded();
+
+    // check defaults
+    expect(monitoringView.saveAsDefault.isEnabled()).toBeFalsy(); // prior to smtp change, monitoringView.saveAsDefault disabled
+    expect(firstElementByTestID('email-hello').getAttribute('value')).toEqual('localhost');
+    expect(firstElementByTestID('email-require-tls').getAttribute('checked')).toBeTruthy();
+
+    // change required fields
+    await replaceInput('email-to', 'you@there.com');
+    await replaceInput('email-from', 'me@here.com');
+    expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy(); // monitoringView.saveAsDefault enabled
+    await replaceInput('email-smarthost', 'smarthost:8080');
+    await replaceInput('label-name-0', 'severity');
+    await replaceInput('label-value-0', 'warning');
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+
+    // all required fields should be saved with Receiver and not globally
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await yamlView.isLoaded();
+    const yamlStr = await yamlView.getEditorContent();
+    const configs = getGlobalsAndReceiverConfig('email_configs', yamlStr);
+    expect(_.has(configs.globals, 'email_to')).toBeFalsy();
+    expect(_.has(configs.globals, 'smtp_from')).toBeFalsy();
+    expect(_.has(configs.globals, 'smtp_smarthost')).toBeFalsy();
+    expect(_.has(configs.globals, 'smtp_require_tls')).toBeFalsy();
+    expect(configs.receiverConfig.to).toBe('you@there.com');
+    expect(configs.receiverConfig.from).toBe('me@here.com');
+    expect(configs.receiverConfig.smarthost).toBe('smarthost:8080');
+    expect(_.has(configs.receiverConfig, 'require_tls')).toBeFalsy(); // unchanged from global value
+  });
+
+  it('saves as default/global correctly', async () => {
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig/receivers/MyReceiver/edit`);
+    await browser.wait(until.presenceOf(firstElementByTestID('cancel')));
+
+    // Check Updated Values
+    expect(firstElementByTestID('email-to').getAttribute('value')).toEqual('you@there.com');
+    expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy(); // smtp_from different from global
+    expect(monitoringView.saveAsDefault.getAttribute('checked')).toBeFalsy();
+    expect(firstElementByTestID('email-from').getAttribute('value')).toEqual('me@here.com');
+    expect(firstElementByTestID('email-hello').getAttribute('value')).toEqual('localhost');
+
+    // Change All Remaining Fields
+    await replaceInput('email-auth-username', 'username');
+    await replaceInput('email-auth-password', 'password');
+    await replaceInput('email-auth-identity', 'identity');
+    await replaceInput('email-auth-secret', 'secret');
+    await firstElementByTestID('email-require-tls').click();
+
+    await monitoringView.saveButton.click(); // monitoringView.saveAsDefault not checked, so all should be saved with Reciever
+    await crudView.isLoaded();
+
+    // all fields saved with Receiver
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await yamlView.isLoaded();
+    let yamlStr = await yamlView.getEditorContent();
+    let configs = getGlobalsAndReceiverConfig('email_configs', yamlStr);
+    expect(_.has(configs.globals, 'smtp_auth_username')).toBeFalsy();
+    expect(configs.receiverConfig.auth_username).toBe('username');
+    expect(configs.receiverConfig.auth_password).toBe('password');
+    expect(configs.receiverConfig.auth_identity).toBe('identity');
+    expect(configs.receiverConfig.auth_secret).toBe('secret');
+    expect(configs.receiverConfig.require_tls).toBeFalsy();
+
+    // Save As Default
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig/receivers/MyReceiver/edit`);
+    await browser.wait(until.presenceOf(firstElementByTestID('cancel')));
+    monitoringView.saveAsDefault.click();
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+    // global fields saved in config.global
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await yamlView.isLoaded();
+    yamlStr = await yamlView.getEditorContent();
+    configs = getGlobalsAndReceiverConfig('email_configs', yamlStr);
+    expect(configs.globals.smtp_from).toBe('me@here.com');
+    expect(configs.globals.smtp_hello).toBe('localhost');
+    expect(configs.globals.smtp_smarthost).toBe('smarthost:8080');
+    expect(configs.globals.smtp_auth_username).toBe('username');
+    expect(configs.globals.smtp_auth_password).toBe('password');
+    expect(configs.globals.smtp_auth_identity).toBe('identity');
+    expect(configs.globals.smtp_auth_secret).toBe('secret');
+    expect(configs.globals.smtp_require_tls).toBeFalsy();
+    // non-global fields should still be saved with Receiver
+    expect(configs.receiverConfig.to).toBe('you@there.com');
+  });
+});
+
+xdescribe('Alertmanager: Slack Receiver Form', () => {
+  afterAll(() => {
+    execSync(
+      `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
+    );
+  });
+
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+
+  it('creates Slack Receiver correctly', async () => {
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig`);
+    await crudView.isLoaded();
+    await firstElementByTestID('create-receiver').click();
+    await crudView.isLoaded();
+    await replaceInput('receiver-name', 'MyReceiver');
+    await firstElementByTestID('dropdown-button').click();
+    await crudView.isLoaded();
+    await dropdownMenuForTestID('slack_configs').click();
+    await crudView.isLoaded();
+
+    // check defaults
+    expect(monitoringView.saveAsDefault.isEnabled()).toBeFalsy();
+
+    // change required fields
+    await replaceInput('slack-api-url', 'http://myslackapi');
+    expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy(); // monitoringView.saveAsDefault enabled
+    await replaceInput('slack-channel', 'myslackchannel');
+    await replaceInput('label-name-0', 'severity');
+    await replaceInput('label-value-0', 'warning');
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+
+    // all required fields should be saved with Receiver and not globally
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await yamlView.isLoaded();
+    const yamlStr = await yamlView.getEditorContent();
+    const configs = getGlobalsAndReceiverConfig('slack_configs', yamlStr);
+    expect(_.has(configs.globals, 'slack_api_url')).toBeFalsy();
+    expect(configs.receiverConfig.channel).toBe('myslackchannel');
+    expect(configs.receiverConfig.api_url).toBe('http://myslackapi');
+  });
+
+  it('saves as default/global correctly', async () => {
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig/receivers/MyReceiver/edit`);
+    await browser.wait(until.presenceOf(firstElementByTestID('cancel')));
+
+    // Check Updated Values
+    expect(firstElementByTestID('slack-channel').getAttribute('value')).toEqual('myslackchannel');
+    expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy(); // different from global
+    expect(firstElementByTestID('slack-api-url').getAttribute('value')).toEqual(
+      'http://myslackapi',
+    );
+
+    monitoringView.saveAsDefault.click(); // save in global section
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await yamlView.isLoaded();
+    const yamlStr = await yamlView.getEditorContent();
+    const configs = getGlobalsAndReceiverConfig('slack_configs', yamlStr);
+    expect(configs.globals.slack_api_url).toBe('http://myslackapi');
+    expect(_.has(configs.receiverConfig, 'api_url')).toBeFalsy();
+    expect(configs.receiverConfig.channel).toBe('myslackchannel');
+  });
+});
+
+xdescribe('Alertmanager: Webhook Receiver Form', () => {
+  afterAll(() => {
+    execSync(
+      `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
+    );
+  });
+
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+
+  it('creates Webhook Receiver correctly', async () => {
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig`);
+    await crudView.isLoaded();
+    await firstElementByTestID('create-receiver').click();
+    await crudView.isLoaded();
+    await replaceInput('receiver-name', 'MyReceiver');
+    await firstElementByTestID('dropdown-button').click();
+    await crudView.isLoaded();
+    await dropdownMenuForTestID('webhook_configs').click();
+    await crudView.isLoaded();
+
+    // change required fields
+    await replaceInput('webhook-url', 'http://mywebhookurl');
+    await replaceInput('label-name-0', 'severity');
+    await replaceInput('label-value-0', 'warning');
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+
+    // all required fields should be saved with Receiver
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await yamlView.isLoaded();
+    const yamlStr = await yamlView.getEditorContent();
+    const configs = getGlobalsAndReceiverConfig('webhook_configs', yamlStr);
+    expect(configs.receiverConfig.url).toBe('http://mywebhookurl');
+  });
+
+  it('edits Webhook Receiver correctly', async () => {
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig/receivers/MyReceiver/edit`);
+    await browser.wait(until.presenceOf(firstElementByTestID('cancel')));
+
+    // Check Updated Values
+    expect(firstElementByTestID('webhook-url').getAttribute('value')).toEqual(
+      'http://mywebhookurl',
+    );
+    await replaceInput('webhook-url', 'http://myupdatedwebhookurl');
+    await monitoringView.saveButton.click();
+    await crudView.isLoaded();
+    await horizontalnavView.clickHorizontalTab('YAML');
+    await yamlView.isLoaded();
+    const yamlStr = await yamlView.getEditorContent();
+    const configs = getGlobalsAndReceiverConfig('webhook_configs', yamlStr);
+    expect(configs.receiverConfig.url).toBe('http://myupdatedwebhookurl');
+  });
+});

--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -8,6 +8,7 @@ import * as monitoringView from '../views/monitoring.view';
 import * as namespaceView from '../views/namespace.view';
 import * as sidenavView from '../views/sidenav.view';
 import * as horizontalnavView from '../views/horizontal-nav.view';
+import { execSync } from 'child_process';
 
 const testAlertName = 'Watchdog';
 
@@ -214,6 +215,12 @@ xdescribe('Alertmanager: YAML', () => {
 });
 
 xdescribe('Alertmanager: Configuration', () => {
+  afterAll(() => {
+    execSync(
+      `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
+    );
+  });
+
   afterEach(() => {
     checkLogs();
     checkErrors();
@@ -253,9 +260,8 @@ xdescribe('Alertmanager: Configuration', () => {
     expect(firstElementByTestID('repeat_interval_value').getText()).toEqual('24h');
   });
 
-  it('creates PagerDuty Receiver correctly', async () => {
+  it('creates a receiver correctly', async () => {
     await crudView.isLoaded();
-    expect(firstElementByTestID('create-receiver').isPresent()).toBe(true);
     await firstElementByTestID('create-receiver').click();
     await crudView.isLoaded();
 
@@ -264,9 +270,7 @@ xdescribe('Alertmanager: Configuration', () => {
     expect(firstElementByTestID('receiver-routing-labels-editor').isPresent()).toBe(false);
     expect(monitoringView.saveButton.isEnabled()).toBe(false);
 
-    expect(firstElementByTestID('receiver-name').isPresent()).toBe(true);
     await firstElementByTestID('receiver-name').sendKeys('MyReceiver');
-
     await firstElementByTestID('dropdown-button').click();
     await crudView.isLoaded();
 
@@ -280,10 +284,13 @@ xdescribe('Alertmanager: Configuration', () => {
     expect(firstElementByTestID('pagerduty-key-label').getText()).toEqual('Routing Key');
     await firstElementByTestID('integration-type-prometheus').click();
     expect(firstElementByTestID('pagerduty-key-label').getText()).toEqual('Service Key');
+
+    // pagerduty subform should still be invalid at this point, thus save button should be disabled
+    expect(monitoringView.saveButton.isEnabled()).toBe(false);
     await firstElementByTestID('integration-key').sendKeys('<integration_key>');
+    expect(monitoringView.saveButton.isEnabled()).toBe(true); // subform valid, save should be enabled at this point
 
-    expect(monitoringView.saveButton.isEnabled()).toBe(true); // should be enabled at this point
-
+    // labels
     await firstElementByTestID('label-name-0').sendKeys('severity');
     await firstElementByTestID('label-value-0').sendKeys('warning');
 
@@ -294,7 +301,7 @@ xdescribe('Alertmanager: Configuration', () => {
     });
   });
 
-  it('edits PagerDuty Receiver correctly', async () => {
+  it('edits a receiver correctly', async () => {
     await crudView.isLoaded();
     expect(crudView.resourceRows.count()).toBe(2);
     await monitoringView.clickFirstRowKebabAction('Edit Receiver');
@@ -325,7 +332,8 @@ xdescribe('Alertmanager: Configuration', () => {
     });
   });
 
-  it('deletes PagerDuty Receiver correctly', async () => {
+  it('deletes a receiver correctly', async () => {
+    await horizontalnavView.clickHorizontalTab('Overview');
     await crudView.isLoaded();
     expect(crudView.resourceRows.count()).toBe(2);
 
@@ -369,32 +377,5 @@ receivers:
     await monitoringView.openFirstRowKebabMenu();
     expect(monitoringView.disabledDeleteReceiverMenuItem.isPresent()).toBe(true);
     expect(crudView.actionForLabel('Edit YAML').isPresent()).toBe(true); // should be 'Edit YAML' not 'Edit Receiver'
-  });
-
-  it('restores default/initial alertmanager.yaml', async () => {
-    // add receiver with sub-route
-    const defaultAlertmanagerYaml = `"global":
-  "resolve_timeout": "5m"
-"receivers":
-- "name": "null"
-"route":
-  "group_by":
-  - "job"
-  "group_interval": "5m"
-  "group_wait": "30s"
-  "receiver": "null"
-  "repeat_interval": "12h"
-  "routes":
-  - "match":
-      "alertname": "Watchdog"
-    "receiver": "null"`;
-
-    await crudView.isLoaded();
-    await horizontalnavView.clickHorizontalTab('YAML');
-    await yamlView.isLoaded();
-    await yamlView.setEditorContent(defaultAlertmanagerYaml);
-    await yamlView.saveButton.click();
-    await yamlView.isLoaded();
-    expect(monitoringView.successAlert.isPresent()).toBe(true);
   });
 });

--- a/frontend/integration-tests/views/monitoring.view.ts
+++ b/frontend/integration-tests/views/monitoring.view.ts
@@ -1,5 +1,8 @@
+import { Base64 } from 'js-base64';
+
 import { $, $$, browser, by, element, ExpectedConditions as until } from 'protractor';
 import * as crudView from '../views/crud.view';
+import { firstElementByTestID } from '../protractor.conf';
 
 export const wait = async (condition) => await browser.wait(condition, 15000);
 
@@ -61,3 +64,21 @@ export const getFirstRowAsText = () => {
     return text.replace(/[\n\r]/g, ' ');
   });
 };
+
+export const saveAsDefault = firstElementByTestID('save-as-default');
+
+export const defaultAlertmanagerYaml = Base64.encode(`"global":
+  "resolve_timeout": "5m"
+"receivers":
+- "name": "null"
+"route":
+  "group_by":
+  - "job"
+  "group_interval": "5m"
+  "group_wait": "30s"
+  "receiver": "null"
+  "repeat_interval": "12h"
+  "routes":
+  - "match":
+      "alertname": "Watchdog"
+    "receiver": "null"`);

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -294,3 +294,8 @@ $tooltip-background-color: #151515;
 .co-alert-manager-config__edit-alert-routing-btn {
   margin-bottom: 10px;
 }
+
+.co-alert-manager-config__save-as-default-label {
+  padding-left: 4px;
+  padding-right: 4px;
+}

--- a/frontend/public/components/monitoring/alert-manager-config.tsx
+++ b/frontend/public/components/monitoring/alert-manager-config.tsx
@@ -445,6 +445,7 @@ export type AlertmanagerReceiver = {
 };
 
 export type AlertmanagerConfig = {
+  global: { [key: string]: string };
   route: AlertmanagerRoute;
   receivers: AlertmanagerReceiver[];
 };

--- a/frontend/public/components/monitoring/alert-manager-utils.tsx
+++ b/frontend/public/components/monitoring/alert-manager-utils.tsx
@@ -9,7 +9,9 @@ import { SecretModel } from '../../models';
 
 export const receiverTypes = Object.freeze({
   pagerduty_configs: 'PagerDuty',
-  webhook_configs: 'Webhook Receiver',
+  webhook_configs: 'Webhook',
+  email_configs: 'Email',
+  slack_configs: 'Slack',
 });
 
 export const getAlertmanagerYAML = (secret: K8sResourceKind, setErrorMsg): string => {

--- a/frontend/public/components/monitoring/receiver-forms/email-receiver-form.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/email-receiver-form.tsx
@@ -1,0 +1,311 @@
+/* eslint-disable camelcase */
+import * as _ from 'lodash-es';
+import * as React from 'react';
+
+import { SectionHeading } from '../../utils';
+import { SaveAsDefaultCheckbox, FormProps } from './alert-manager-receiver-forms';
+
+const SMTP_GLOBAL_FIELDS = [
+  'smtp_from',
+  'smtp_smarthost',
+  'smtp_hello',
+  'smtp_auth_username',
+  'smtp_auth_password',
+  'smtp_auth_identity',
+  'smtp_auth_secret',
+  'smtp_require_tls',
+];
+const GLOBAL_FIELDS = [...SMTP_GLOBAL_FIELDS]; //TODO follow up PR will add advanced fields
+
+const getGlobalValue = (globals, propName) => {
+  const fieldName = SMTP_GLOBAL_FIELDS.includes(propName)
+    ? propName
+    : propName.replace('smtp_', 'email_'); // 'email_...' are globals for advanced fields
+  return globals[fieldName];
+};
+
+export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormChange }) => {
+  // disable saveAsDefault if all SMTP form fields match global values
+  const disableSaveAsDefault = SMTP_GLOBAL_FIELDS.every(
+    (propName) => formValues[propName] === getGlobalValue(globals, propName),
+  );
+
+  return (
+    <div data-test-id="email-receiver-form">
+      <div className="form-group">
+        <label className="control-label co-required" htmlFor="email-to">
+          To Address
+        </label>
+        <input
+          className="pf-c-form-control"
+          type="text"
+          aria-describedby="email-to-help"
+          id="email-to"
+          data-test-id="email-to"
+          value={formValues.emailTo}
+          onChange={(e) =>
+            dispatchFormChange({
+              type: 'setFormValues',
+              payload: { emailTo: e.target.value },
+            })
+          }
+        />
+        <div className="help-block" id="email-to-help">
+          The email address to send notifications to
+        </div>
+      </div>
+      <div className="form-group">
+        <div className="co-m-pane__body--section-heading">
+          <div className="row">
+            <div className="col-sm-6">
+              <SectionHeading text="SMTP Configuration" />
+            </div>
+            <div className="col-sm-6">
+              <SaveAsDefaultCheckbox
+                formField="emailSaveAsDefault"
+                disabled={disableSaveAsDefault}
+                aria-disabled={disableSaveAsDefault}
+                label="Save as default SMTP configuration"
+                formValues={formValues}
+                dispatchFormChange={dispatchFormChange}
+                tooltip="Checking this box will write these values to the global section of the
+                configuration file where they will become defaults for future email receivers."
+              />
+            </div>
+          </div>
+          <div className="form-group">
+            <label className="control-label co-required" htmlFor="email-from">
+              From Address
+            </label>
+            <input
+              className="pf-c-form-control"
+              type="text"
+              aria-describedby="email-from-help"
+              id="email-from"
+              data-test-id="email-from"
+              value={formValues.smtp_from}
+              onChange={(e) =>
+                dispatchFormChange({
+                  type: 'setFormValues',
+                  payload: { smtp_from: e.target.value },
+                })
+              }
+            />
+            <div className="help-block" id="email-from-help">
+              The email address to send notifications from
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-sm-6">
+              <div className="form-group">
+                <label className="control-label co-required" htmlFor="email-smarthost">
+                  SMTP Smarthost
+                </label>
+                <input
+                  className="pf-c-form-control"
+                  type="text"
+                  aria-describedby="email-smarthost-help"
+                  id="email-smarthost"
+                  data-test-id="email-smarthost"
+                  value={formValues.smtp_smarthost}
+                  onChange={(e) =>
+                    dispatchFormChange({
+                      type: 'setFormValues',
+                      payload: { smtp_smarthost: e.target.value },
+                    })
+                  }
+                />
+                <div className="help-block" id="email-smarthost-help">
+                  Smarthost used for sending emails, including port number
+                </div>
+              </div>
+            </div>
+            <div className="col-sm-6">
+              <div className="form-group">
+                <label className="control-label co-required" htmlFor="email-hello">
+                  SMTP Hello
+                </label>
+                <input
+                  className="pf-c-form-control"
+                  type="text"
+                  aria-describedby="email-hello-help"
+                  id="email-hello"
+                  data-test-id="email-hello"
+                  value={formValues.smtp_hello}
+                  onChange={(e) =>
+                    dispatchFormChange({
+                      type: 'setFormValues',
+                      payload: { smtp_hello: e.target.value },
+                    })
+                  }
+                />
+                <div className="help-block" id="email-hello-help">
+                  The hostname to identify to the SMTP server
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-sm-6">
+              <div className="form-group">
+                <label className="control-label" htmlFor="email-auth-username">
+                  Auth Username
+                </label>
+                <input
+                  className="pf-c-form-control"
+                  type="text"
+                  id="email-auth-username"
+                  data-test-id="email-auth-username"
+                  value={formValues.smtp_auth_username}
+                  onChange={(e) =>
+                    dispatchFormChange({
+                      type: 'setFormValues',
+                      payload: { smtp_auth_username: e.target.value },
+                    })
+                  }
+                />
+              </div>
+            </div>
+            <div className="col-sm-6">
+              <div className="form-group">
+                <label className="control-label" htmlFor="email-auth-password">
+                  Auth Password (Using LOGIN and PLAIN)
+                </label>
+                <input
+                  className="pf-c-form-control"
+                  type="password"
+                  id="email-auth-password"
+                  data-test-id="email-auth-password"
+                  value={formValues.smtp_auth_password}
+                  onChange={(e) =>
+                    dispatchFormChange({
+                      type: 'setFormValues',
+                      payload: { smtp_auth_password: e.target.value },
+                    })
+                  }
+                />
+              </div>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-sm-6">
+              <div className="form-group">
+                <label className="control-label" htmlFor="email-auth-identity">
+                  Auth Identity (Using PLAIN)
+                </label>
+                <input
+                  className="pf-c-form-control"
+                  type="text"
+                  id="email-auth-identity"
+                  data-test-id="email-auth-identity"
+                  value={formValues.smtp_auth_identity}
+                  onChange={(e) =>
+                    dispatchFormChange({
+                      type: 'setFormValues',
+                      payload: { smtp_auth_identity: e.target.value },
+                    })
+                  }
+                />
+              </div>
+            </div>
+            <div className="col-sm-6">
+              <div className="form-group">
+                <label className="control-label" htmlFor="email-auth-secret">
+                  Auth Secret (CRAM-MDS)
+                </label>
+                <input
+                  className="pf-c-form-control"
+                  type="password"
+                  id="email-auth-secret"
+                  data-test-id="email-auth-secret"
+                  value={formValues.smtp_auth_secret}
+                  onChange={(e) =>
+                    dispatchFormChange({
+                      type: 'setFormValues',
+                      payload: { smtp_auth_secret: e.target.value },
+                    })
+                  }
+                />
+              </div>
+            </div>
+          </div>
+          <label className="co-no-bold" htmlFor="email-require-tls">
+            <input
+              type="checkbox"
+              id="email-require-tls"
+              data-test-id="email-require-tls"
+              onChange={(e) =>
+                dispatchFormChange({
+                  type: 'setFormValues',
+                  payload: {
+                    smtp_require_tls: e.target.checked,
+                  },
+                })
+              }
+              checked={formValues.smtp_require_tls}
+              aria-checked={formValues.smtp_require_tls}
+            />
+            &nbsp; Require TLS
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const getInitialValues = (globals, receiverConfig) => {
+  const initValues: any = {
+    emailSaveAsDefault: false,
+    emailTo: receiverConfig?.to,
+  };
+
+  GLOBAL_FIELDS.forEach((fld) => {
+    const configFieldName = fld.substring(fld.indexOf('_') + 1); //strip off leading 'email_' or 'smtp_' prefix
+    initValues[fld] = _.get(receiverConfig, configFieldName, getGlobalValue(globals, fld));
+  });
+
+  return initValues;
+};
+
+export const isFormInvalid = (formValues) => {
+  return (
+    !formValues.emailTo ||
+    !formValues.smtp_from ||
+    !formValues.smtp_smarthost ||
+    !formValues.smtp_hello
+  );
+};
+
+export const updateGlobals = (globals, formValues) => {
+  const updatedGlobals = {};
+  if (formValues.emailSaveAsDefault) {
+    SMTP_GLOBAL_FIELDS.forEach((propName) => {
+      const formValue = formValues[propName];
+      if (formValue !== undefined) {
+        _.set(updatedGlobals, propName, formValue);
+      }
+    });
+  }
+  return updatedGlobals;
+};
+
+export const createReceiverConfig = (globals, formValues, receiverConfig) => {
+  _.set(receiverConfig, 'to', formValues.emailTo);
+
+  // Only save these props in receiverConfig if different from global
+  GLOBAL_FIELDS.forEach((fld) => {
+    const formValue = formValues[fld];
+    const configFieldName = fld.substring(fld.indexOf('_') + 1); //strip off leading 'email_' or 'smtp_' prefix
+    if (formValue !== getGlobalValue(globals, fld)) {
+      if (SMTP_GLOBAL_FIELDS.includes(fld) && formValues.emailSaveAsDefault) {
+        _.unset(receiverConfig, configFieldName); // saving as global so unset in config
+      } else {
+        _.set(receiverConfig, configFieldName, formValue);
+      }
+    } else {
+      _.unset(receiverConfig, configFieldName); // equals global, unset in config so global is used
+    }
+  });
+
+  return receiverConfig;
+};

--- a/frontend/public/components/monitoring/receiver-forms/pagerduty-receiver-form.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/pagerduty-receiver-form.tsx
@@ -2,90 +2,172 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
 
-import { SectionHeading } from '../../utils';
 import { RadioInput } from '../../radio';
+import { FormProps, SaveAsDefaultCheckbox } from './alert-manager-receiver-forms';
 
-export const Form = ({ formValues, dispatchFormChange }) => (
-  <div data-test-id="pagerduty-receiver-form" className="co-m-pane__body--section-heading">
-    <SectionHeading text="PagerDuty Configuration" />
-    <div className="form-group">
-      <label className="control-label">Integration Type</label>
-      <div>
-        <RadioInput
-          title="Events API v2"
-          name="pagerDutyIntegrationType"
-          id="integration-type-events"
-          value="events"
+const GLOBAL_FIELDS = ['pagerduty_url']; //TODO follow up PR will add advanced fields
+
+export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormChange }) => {
+  return (
+    <div data-test-id="pagerduty-receiver-form">
+      <div className="form-group">
+        <label className="control-label" htmlFor="integration-type-events">
+          Integration Type
+        </label>
+        <div>
+          <RadioInput
+            title="Events API v2"
+            id="integration-type-events"
+            value="events"
+            onChange={(e) =>
+              dispatchFormChange({
+                type: 'setFormValues',
+                payload: { pagerDutyIntegrationType: e.target.value },
+              })
+            }
+            checked={formValues.pagerdutyIntegrationKeyType === 'events'}
+            aria-checked={formValues.pagerdutyIntegrationKeyType === 'events'}
+            inline
+          />
+          <RadioInput
+            title="Prometheus"
+            name="pagerdutyIntegrationKeyType"
+            data-test-id="integration-type-prometheus"
+            value="prometheus"
+            onChange={(e) =>
+              dispatchFormChange({
+                type: 'setFormValues',
+                payload: { pagerdutyIntegrationKeyType: e.target.value },
+              })
+            }
+            checked={formValues.pagerdutyIntegrationKeyType === 'prometheus'}
+            aria-checked={formValues.pagerdutyIntegrationKeyType === 'prometheus'}
+            inline
+          />
+        </div>
+      </div>
+      <div className="form-group">
+        <label
+          data-test-id="pagerduty-key-label"
+          className="control-label co-required"
+          htmlFor="integration-key"
+        >
+          {formValues.pagerdutyIntegrationKeyType === 'events' ? 'Routing' : 'Service'} Key
+        </label>
+        <input
+          className="pf-c-form-control"
+          type="text"
+          aria-describedby="integration-key-help"
+          id="integration-key"
+          data-test-id="integration-key"
+          value={formValues.pagerdutyIntegrationKey}
           onChange={(e) =>
             dispatchFormChange({
               type: 'setFormValues',
-              payload: { pagerDutyIntegrationType: e.target.value },
+              payload: { pagerdutyIntegrationKey: e.target.value },
             })
           }
-          checked={formValues.pagerDutyIntegrationType === 'events'}
-          inline
         />
-        <RadioInput
-          title="Prometheus"
-          name="pagerDutyIntegrationType"
-          data-test-id="integration-type-prometheus"
-          value="prometheus"
-          onChange={(e) =>
-            dispatchFormChange({
-              type: 'setFormValues',
-              payload: { pagerDutyIntegrationType: e.target.value },
-            })
-          }
-          checked={formValues.pagerDutyIntegrationType === 'prometheus'}
-          inline
-        />
+        <div className="help-block" id="integration-key-help">
+          PagerDuty integration key
+        </div>
+      </div>
+      <div className="form-group">
+        <label
+          data-test-id="pagerduty-url-label"
+          className="control-label co-required"
+          htmlFor="pagerduty-url"
+        >
+          PagerDuty URL
+        </label>
+        <div className="row">
+          <div className="col-sm-7">
+            <input
+              className="pf-c-form-control"
+              type="text"
+              id="pagerduty-url"
+              aria-describedby="pagerduty-url-help"
+              data-test-id="pagerduty-url"
+              value={formValues.pagerduty_url}
+              onChange={(e) =>
+                dispatchFormChange({
+                  type: 'setFormValues',
+                  payload: { pagerduty_url: e.target.value },
+                })
+              }
+            />
+          </div>
+          <div className="col-sm-5">
+            <SaveAsDefaultCheckbox
+              formField="pagerdutySaveAsDefault"
+              disabled={formValues.pagerduty_url === globals?.pagerduty_url}
+              label="Save as default PagerDuty URL"
+              formValues={formValues}
+              dispatchFormChange={dispatchFormChange}
+              tooltip="Checking this box will write the url to the global section of the
+                configuration file where it will become default url for future PagerDuty receivers."
+            />
+          </div>
+        </div>
+        <div className="help-block" id="pagerduty-url-help">
+          The URL of your PagerDuty Installation
+        </div>
       </div>
     </div>
-    <div className="form-group">
-      <label data-test-id="pagerduty-key-label" className="control-label co-required">
-        {formValues.pagerDutyIntegrationType === 'events' ? 'Routing' : 'Service'} Key
-      </label>
-      <input
-        className="pf-c-form-control"
-        type="text"
-        aria-describedby="integration-key-help"
-        name="pagerDutyIntegrationKey"
-        data-test-id="integration-key"
-        value={formValues.pagerDutyIntegrationKey}
-        onChange={(e) =>
-          dispatchFormChange({
-            type: 'setFormValues',
-            payload: { pagerDutyIntegrationKey: e.target.value },
-          })
-        }
-      />
-      <div className="help-block" id="integration-key-help">
-        PagerDuty integration key
-      </div>
-    </div>
-  </div>
-);
+  );
+};
 
-export const getInitialValues = (receiverConfig) => {
-  return _.isEmpty(receiverConfig)
-    ? {
-        pagerDutyIntegrationType: 'events', // 'Events API v2'
-        pagerDutyIntegrationKey: '',
-      }
-    : {
-        pagerDutyIntegrationType: receiverConfig?.routing_key ? 'events' : 'prometheus',
-        pagerDutyIntegrationKey: receiverConfig?.routing_key || receiverConfig?.service_key,
-      };
+export const getInitialValues = (globals, receiverConfig) => {
+  const initValues: any = { pagerdutySaveAsDefault: false };
+
+  initValues.pagerdutyIntegrationKeyType = _.has(receiverConfig, 'service_key')
+    ? 'prometheus'
+    : 'events';
+  initValues.pagerdutyIntegrationKey = receiverConfig?.service_key || receiverConfig?.routing_key;
+
+  GLOBAL_FIELDS.forEach((fld) => {
+    const configFieldName = fld.substring(fld.indexOf('_') + 1); //strip off leading 'pagerduty_' prefix
+    initValues[fld] = _.get(receiverConfig, configFieldName, globals[fld]);
+  });
+
+  return initValues;
 };
 
 export const isFormInvalid = (formValues): boolean => {
-  return !formValues.pagerDutyIntegrationKey;
+  return !formValues.pagerdutyIntegrationKey;
 };
 
-export const createReceiverConfig = (formValues, receiverConfig) => {
-  const pagerDutyIntegrationKeyName = `${
-    formValues.pagerDutyIntegrationType === 'events' ? 'routing' : 'service'
+export const updateGlobals = (globals, formValues) => {
+  const updatedGlobals = {};
+  if (formValues.pagerdutySaveAsDefault && formValues.pagerduty_url) {
+    _.set(updatedGlobals, 'pagerduty_url', formValues.pagerduty_url);
+  }
+  return updatedGlobals;
+};
+
+export const createReceiverConfig = (globals, formValues, receiverConfig) => {
+  // handle integration key props
+  _.unset(receiverConfig, 'routing_key');
+  _.unset(receiverConfig, 'service_key');
+  const pagerdutyIntegrationKeyName = `${
+    formValues.pagerdutyIntegrationKeyType === 'events' ? 'routing' : 'service'
   }_key`;
-  _.set(receiverConfig, pagerDutyIntegrationKeyName, formValues.pagerDutyIntegrationKey);
+  _.set(receiverConfig, pagerdutyIntegrationKeyName, formValues.pagerdutyIntegrationKey);
+
+  // Only save these props in formValues different from globals
+  GLOBAL_FIELDS.forEach((fld) => {
+    const formValue = formValues[fld];
+    const configFieldName = fld.substring(fld.indexOf('_') + 1); //strip off leading 'pagerduty_' prefix
+    if (formValue !== globals[fld]) {
+      if (fld === 'pagerduty_url' && formValues.pagerdutySaveAsDefault) {
+        _.unset(receiverConfig, 'url'); // saving as global so unset in config
+      } else {
+        _.set(receiverConfig, configFieldName, formValue);
+      }
+    } else {
+      _.unset(receiverConfig, configFieldName); // equals global, unset in config so global is used
+    }
+  });
+
   return receiverConfig;
 };

--- a/frontend/public/components/monitoring/receiver-forms/slack-receiver-form.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/slack-receiver-form.tsx
@@ -1,0 +1,124 @@
+/* eslint-disable camelcase */
+import * as _ from 'lodash-es';
+import * as React from 'react';
+
+import { FormProps, SaveAsDefaultCheckbox } from './alert-manager-receiver-forms';
+
+const GLOBAL_FIELDS = ['slack_api_url']; //TODO follow up PR will add advanced fields
+
+export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormChange }) => {
+  return (
+    <div data-test-id="slack-receiver-form">
+      <div className="form-group">
+        <label
+          data-test-id="api-url-label"
+          className="control-label co-required"
+          htmlFor="slack-api-url"
+        >
+          Slack API Url
+        </label>
+        <div className="row">
+          <div className="col-sm-7">
+            <input
+              className="pf-c-form-control"
+              type="text"
+              id="slack-api-url"
+              aria-describedby="slack-api-url-help"
+              data-test-id="slack-api-url"
+              value={formValues.slack_api_url}
+              onChange={(e) =>
+                dispatchFormChange({
+                  type: 'setFormValues',
+                  payload: { slack_api_url: e.target.value },
+                })
+              }
+            />
+          </div>
+          <div className="col-sm-5">
+            <SaveAsDefaultCheckbox
+              formField="slackSaveAsDefault"
+              disabled={formValues.slack_api_url === globals?.slack_api_url}
+              label="Save as default Slack API Url"
+              formValues={formValues}
+              dispatchFormChange={dispatchFormChange}
+              tooltip="Checking this box will write the api url to the global section of the
+                configuration file where it will become default api url for future Slack receivers."
+            />
+          </div>
+        </div>
+        <div className="help-block" id="slack-api-url-help">
+          The URL of the Slack Webhook
+        </div>
+      </div>
+      <div className="form-group">
+        <label className="control-label co-required" htmlFor="slack-channel">
+          Channel
+        </label>
+        <input
+          className="pf-c-form-control"
+          type="text"
+          id="slack-channel"
+          aria-describedby="slack-channel-help"
+          data-test-id="slack-channel"
+          value={formValues.slackChannel}
+          onChange={(e) =>
+            dispatchFormChange({
+              type: 'setFormValues',
+              payload: { slackChannel: e.target.value },
+            })
+          }
+        />
+        <div className="help-block" id="slack-channel-help">
+          The Slack channel or user to send notifications to
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const getInitialValues = (globals, receiverConfig) => {
+  const initValues: any = {
+    slackSaveAsDefault: false,
+    slackChannel: _.get(receiverConfig, 'channel'),
+  };
+
+  GLOBAL_FIELDS.forEach((fld) => {
+    const configFieldName = fld.substring(fld.indexOf('_') + 1); //strip off leading 'slack_' prefix
+    initValues[fld] = _.get(receiverConfig, configFieldName, globals[fld]);
+  });
+
+  return initValues;
+};
+
+export const isFormInvalid = (formValues): boolean => {
+  return !formValues.slack_api_url || !formValues.slackChannel;
+};
+
+export const updateGlobals = (globals, formValues) => {
+  const updatedGlobals = {};
+  if (formValues.slackSaveAsDefault && formValues.slack_api_url) {
+    _.set(updatedGlobals, 'slack_api_url', formValues.slack_api_url);
+  }
+  return updatedGlobals;
+};
+
+export const createReceiverConfig = (globals, formValues, receiverConfig) => {
+  _.set(receiverConfig, 'channel', formValues.slackChannel);
+
+  // Only save these props in receiverConfig if different from global
+  GLOBAL_FIELDS.forEach((fld) => {
+    const formValue = formValues[fld];
+    const configFieldName = fld.substring(fld.indexOf('_') + 1); //strip off leading 'slack_' prefix
+    if (formValue !== globals[fld]) {
+      if (fld === 'slack_api_url' && formValues.slackSaveAsDefault) {
+        _.unset(receiverConfig, 'api_url'); // saving as global so unset in config
+      } else {
+        _.set(receiverConfig, configFieldName, formValue);
+      }
+    } else {
+      _.unset(receiverConfig, configFieldName); // equals global, unset in config so global is used
+    }
+  });
+
+  return receiverConfig;
+};

--- a/frontend/public/components/monitoring/receiver-forms/webhook-receiver-form.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/webhook-receiver-form.tsx
@@ -1,14 +1,17 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
+import { FormProps } from './alert-manager-receiver-forms';
 
-export const Form = ({ formValues, dispatchFormChange }) => (
+export const Form: React.FC<FormProps> = ({ formValues, dispatchFormChange }) => (
   <div data-test-id="webhook-receiver-form" className="form-group">
-    <label className="control-label co-required">URL</label>
+    <label className="control-label co-required" htmlFor="webhook-url">
+      URL
+    </label>
     <input
       className="pf-c-form-control"
       type="text"
       aria-describedby="webhook-url-help"
-      name="webhookUrl"
+      id="webhook-url"
       data-test-id="webhook-url"
       value={formValues.webhookUrl}
       onChange={(e) =>
@@ -24,7 +27,7 @@ export const Form = ({ formValues, dispatchFormChange }) => (
   </div>
 );
 
-export const getInitialValues = (receiverConfig) => {
+export const getInitialValues = (globals, receiverConfig) => {
   return {
     webhookUrl: receiverConfig?.url || '',
   };
@@ -34,6 +37,11 @@ export const isFormInvalid = (formValues) => {
   return !formValues.webhookUrl;
 };
 
-export const createReceiverConfig = (formValues, receiverConfig) => {
-  return _.set(receiverConfig, 'url', formValues.webhookUrl);
+export const updateGlobals = () => {
+  return {};
+};
+
+export const createReceiverConfig = (globals, formValues, receiverConfig) => {
+  _.set(receiverConfig, 'url', formValues.webhookUrl);
+  return receiverConfig;
 };


### PR DESCRIPTION
- Implemented 'Save as Default/Global' functionality, which defaults certain form fields to global values, and saves values in global section if 'Save as Default' checked.  Includes new call to `${alertManagerBaseURL}/api/v2/status/` to get global values not found in alertmanager-main's alertmanager.yaml's global properties.
- Added Email and Slack Receiver forms
- Added new alertmanager integration test suite which tests initializing and saving global fields/values.  Removed global testing from monitor integration test suite, does not need to run during CI.

### [Screenshots](https://docs.google.com/document/d/1WET_0RszsS2ep3qLoQE--LrXJnbAdM26RqhbXXvu52Q/edit?usp=sharing)

Follow on [WIP] PR adds advanced fields:  https://github.com/openshift/console/pull/4044