### PR TITLE
Prevent sidebar breadcrumb breakage by adding co-break-word to explore-type-sidebar

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -86,7 +86,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
   return (
     <>
       {!_.isEmpty(breadcrumbs) && (
-        <Breadcrumb className="pf-c-breadcrumb--no-padding-top">
+        <Breadcrumb className="pf-c-breadcrumb--no-padding-top co-break-word">
           {breadcrumbs.map((crumb, i) => {
             const isLast = i === breadcrumbs.length - 1;
             return (


### PR DESCRIPTION
before
<img width="977" alt="Screen Shot 2020-01-22 at 2 00 23 PM" src="https://user-images.githubusercontent.com/1874151/72929359-adf8bd00-3d27-11ea-8d1e-7ae2413c12ec.png">


-------

after
<img width="978" alt="Screen Shot 2020-01-22 at 1 56 11 PM" src="https://user-images.githubusercontent.com/1874151/72929369-b224da80-3d27-11ea-9bcb-c8304ff1d197.png">
