### PR TITLE
Modified array field group descriptor to allow add or remove fields f…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -150,6 +150,7 @@ $co-affinity-row-margin: 15px;
 .co-field-group {
   --pf-c-accordion__toggle--PaddingLeft: 0rem !important;
   --pf-c-accordion__toggle--PaddingRight: 0.9375rem !important;
+  --pf-c-accordion__toggle--m-expanded--BorderLeftColor: none !important;
   --pf-c-accordion__expanded-content-body--PaddingLeft: 0.9375rem !important;
   --pf-c-accordion__expanded-content--Color: var(--pf-global--Color--100) !important;
   --pf-c-accordion__toggle-text--active--Color: var(--pf-global--Color--100) !important;
@@ -171,6 +172,14 @@ $co-affinity-row-margin: 15px;
   }
 
   margin-bottom: 0.5rem;
+}
+
+.co-array-field-group__remove {
+  display: flex;
+}
+
+.co-array-field-group__remove-btn {
+  margin-left: auto !important;
 }
 
 .co-create-operand__form-group {


### PR DESCRIPTION
This PR contains the change for the new "arrayFieldGroup" Spec Descriptor for the OLM Create Operand Form. With this descriptor, the Field Group can be added to the Field Group Array or removed from the Field Group Array.

### Concepts
**ArrayFieldGroup**: ArrayFieldGroup is a Spec Descriptor which allows you to specify a set of fields together as an array item. Nested fields will automatically be grouped using the CRD’s OpenAPI validation.
**Field Group**: Field Group is a set of fields.
**Field Group Array**: Field Group Array is an array containing many Field Group.

### X-descriptor Structure
The “arrayFieldGroup” x-descriptor allows users to specify a Field Group Array. In the array, each element is a Field Group, users can add/remove Field Group. The following image demonstrates the structure of the Descriptor.
![image](https://user-images.githubusercontent.com/24922241/72939890-cd99e080-3d3b-11ea-92f9-e49f21c1346b.png)

### Usage

- Add the “arrayFieldGroup” x-descriptor into the “x-descriptors” array of the field object. 

- Replace the “FIELD_GROUP_ARRAY_NAME” with the real name.
