### PR TITLE
Move to useExtensions: Dashboards/Tab, Dashboards/Card

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -12,8 +12,6 @@ import {
   isYAMLTemplate,
   isRoutePage,
   isDashboardsOverviewHealthSubsystem,
-  isDashboardsCard,
-  isDashboardsTab,
   isDashboardsOverviewInventoryItem,
   isDashboardsInventoryItemGroup,
   isDashboardsOverviewUtilizationItem,
@@ -94,14 +92,6 @@ export class ExtensionRegistry {
 
   public getDashboardsOverviewHealthSubsystems() {
     return this.extensions.filter(isDashboardsOverviewHealthSubsystem);
-  }
-
-  public getDashboardsTabs() {
-    return this.extensions.filter(isDashboardsTab);
-  }
-
-  public getDashboardsCards() {
-    return this.extensions.filter(isDashboardsCard);
   }
 
   public getDashboardsOverviewUtilizationItems() {

--- a/frontend/packages/console-plugin-sdk/src/useExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/useExtensions.ts
@@ -63,4 +63,4 @@ export const useExtensions: UseExtensions = (typeGuard) => {
   return extensionsInUse;
 };
 
-type UseExtensions = <E extends Extension>(typeGuard: ExtensionTypeGuard<E>) => readonly E[];
+type UseExtensions = <E extends Extension>(typeGuard: ExtensionTypeGuard<E>) => E[];

--- a/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/dashboards.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import { Helmet } from 'react-helmet';
 
-import * as plugins from '../../../plugins';
 import { ClusterDashboard } from './cluster-dashboard/cluster-dashboard';
 import { HorizontalNav, PageHeading, LoadingBox, Page, AsyncComponent } from '../../utils';
 import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
@@ -12,13 +11,13 @@ import DashboardGrid, {
   GridPosition,
   GridDashboardCard,
 } from '@console/shared/src/components/dashboard/DashboardGrid';
-import { DashboardsCard, isDashboardsCard, isDashboardsTab } from '@console/plugin-sdk';
 import {
-  featureReducerName,
-  connectToFlags,
-  FlagsObject,
-  WithFlagsProps,
-} from '../../../reducers/features';
+  useExtensions,
+  DashboardsCard,
+  DashboardsTab,
+  isDashboardsCard,
+  isDashboardsTab,
+} from '@console/plugin-sdk';
 import { RootState } from '../../../redux';
 
 const getCardsOnPosition = (cards: DashboardsCard[], position: GridPosition): GridDashboardCard[] =>
@@ -29,47 +28,29 @@ const getCardsOnPosition = (cards: DashboardsCard[], position: GridPosition): Gr
       span: c.properties.span,
     }));
 
-const getPluginTabPages = (flags: FlagsObject): Page[] => {
-  const cards = plugins.registry
-    .getDashboardsCards()
-    .filter((e) => plugins.registry.isExtensionInUse(e, flags));
-  return plugins.registry
-    .getDashboardsTabs()
-    .filter((e) => plugins.registry.isExtensionInUse(e, flags))
-    .map((tab) => {
-      const tabCards = cards.filter((c) => c.properties.tab === tab.properties.id);
-      return {
-        href: tab.properties.id,
-        name: tab.properties.title,
-        component: () => (
-          <Dashboard>
-            <DashboardGrid
-              mainCards={getCardsOnPosition(tabCards, GridPosition.MAIN)}
-              leftCards={getCardsOnPosition(tabCards, GridPosition.LEFT)}
-              rightCards={getCardsOnPosition(tabCards, GridPosition.RIGHT)}
-            />
-          </Dashboard>
-        ),
-      };
-    });
-};
+const getPluginTabPages = (tabs: DashboardsTab[], cards: DashboardsCard[]): Page[] =>
+  tabs.map((tab) => {
+    const tabCards = cards.filter((c) => c.properties.tab === tab.properties.id);
+    return {
+      href: tab.properties.id,
+      name: tab.properties.title,
+      component: () => (
+        <Dashboard>
+          <DashboardGrid
+            mainCards={getCardsOnPosition(tabCards, GridPosition.MAIN)}
+            leftCards={getCardsOnPosition(tabCards, GridPosition.LEFT)}
+            rightCards={getCardsOnPosition(tabCards, GridPosition.RIGHT)}
+          />
+        </Dashboard>
+      ),
+    };
+  });
 
-const getTabs = (flags: FlagsObject): Page[] => [
-  {
-    href: '',
-    name: 'Cluster',
-    component: ClusterDashboard,
-  },
-  ...getPluginTabPages(flags),
-];
-
-const DashboardsPage_: React.FC<DashboardsPageProps> = ({
-  match,
-  kindsInFlight,
-  k8sModels,
-  flags,
-}) => {
+const DashboardsPage_: React.FC<DashboardsPageProps> = ({ match, kindsInFlight, k8sModels }) => {
   const title = 'Overview';
+  const tabExtensions = useExtensions<DashboardsTab>(isDashboardsTab);
+  const cardExtensions = useExtensions<DashboardsCard>(isDashboardsCard);
+
   return kindsInFlight && k8sModels.size === 0 ? (
     <LoadingBox />
   ) : (
@@ -78,7 +59,18 @@ const DashboardsPage_: React.FC<DashboardsPageProps> = ({
         <title>{title}</title>
       </Helmet>
       <PageHeading title={title} detail={true} />
-      <HorizontalNav match={match} pages={getTabs(flags)} noStatusBox />
+      <HorizontalNav
+        match={match}
+        pages={[
+          {
+            href: '',
+            name: 'Cluster',
+            component: ClusterDashboard,
+          },
+          ...getPluginTabPages(tabExtensions, cardExtensions),
+        ]}
+        noStatusBox
+      />
     </>
   );
 };
@@ -86,17 +78,11 @@ const DashboardsPage_: React.FC<DashboardsPageProps> = ({
 const mapStateToProps = (state: RootState) => ({
   kindsInFlight: state.k8s.getIn(['RESOURCES', 'inFlight']),
   k8sModels: state.k8s.getIn(['RESOURCES', 'models']),
-  flags: state[featureReducerName],
 });
 
-export const DashboardsPage = connect(mapStateToProps)(
-  connectToFlags(...plugins.registry.getGatingFlagNames([isDashboardsCard, isDashboardsTab]))(
-    DashboardsPage_,
-  ),
-);
+export const DashboardsPage = connect(mapStateToProps)(DashboardsPage_);
 
-type DashboardsPageProps = RouteComponentProps &
-  WithFlagsProps & {
-    kindsInFlight: boolean;
-    k8sModels: ImmutableMap<string, any>;
-  };
+type DashboardsPageProps = RouteComponentProps & {
+  kindsInFlight: boolean;
+  k8sModels: ImmutableMap<string, any>;
+};


### PR DESCRIPTION
Use the new React friendly mechanism for consuming Console extensions:

- `Dashboards/Tab`
- `Dashboards/Card`

cc @rawagner 