### PR TITLE
Fix runtime error in area chart

### DIFF
--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -43,7 +43,7 @@ const chartStatusColors = {
 
 export const AreaChart: React.FC<AreaChartProps> = ({
   className,
-  data,
+  data = [],
   formatDate = twentyFourHourTime,
   height = DEFAULT_HEIGHT,
   humanize = humanizeNumber,


### PR DESCRIPTION
Add default value to AreaChart component data prop to prevent runtime error.

We are using Array.prototype functions against the data prop, so we need to ensure it is always defined, at the very least as an empty array.