### PR TITLE
OLM: fix for single namespace monitoring checkbox

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -458,7 +458,9 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
               <RadioInput
                 onChange={(e) => {
                   setInstallMode(e.target.value);
-                  setTargetNamespace(null);
+                  setTargetNamespace(
+                    useSuggestedNSForSingleInstallMode ? suggestedNamespace : null,
+                  );
                   setCannotResolve(false);
                 }}
                 value={InstallModeType.InstallModeTypeOwnNamespace}


### PR DESCRIPTION
Correctly show the monitoring checkbox when an operator requests monitoring and the user switches to single namespace install mode.

Follow on bug fix for #3862. The selected namespace was incorrectly cleared when switching install modes.

/assign @benjaminapetersen 