### PR TITLE
Bug 1794754: correctly show schema information for all core resources

### DIFF
--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -382,7 +382,7 @@ const APIResourceDetails: React.FC<APIResourceTabProps> = ({ customData: { kindO
         {description && (
           <>
             <dt>Description</dt>
-            <dd className="co-break-word co-pre-line">
+            <dd className="co-break-word co-pre-wrap">
               <LinkifyExternal>{description}</LinkifyExternal>
             </dd>
           </>

--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -109,7 +109,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
         </Breadcrumb>
       )}
       {description && (
-        <p className="co-break-word co-pre-line">
+        <p className="co-break-word co-pre-wrap">
           <LinkifyExternal>{description}</LinkifyExternal>
         </p>
       )}
@@ -131,7 +131,7 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
                   </small>
                 </h5>
                 {definition.description && (
-                  <p className="co-break-word co-pre-line">
+                  <p className="co-break-word co-pre-wrap">
                     <LinkifyExternal>{definition.description}</LinkifyExternal>
                   </p>
                 )}

--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -5,8 +5,8 @@ import { selectorToString } from './selector';
 import { WSFactory } from '../ws-factory';
 
 /** @type {(model: K8sKind) => string} */
-const getK8sAPIPath = (model) => {
-  const isLegacy = _.get(model, 'apiGroup', 'core') === 'core' && model.apiVersion === 'v1';
+const getK8sAPIPath = ({ apiGroup = 'core', apiVersion }) => {
+  const isLegacy = apiGroup === 'core' && apiVersion === 'v1';
   let p = k8sBasePath;
 
   if (isLegacy) {
@@ -15,11 +15,11 @@ const getK8sAPIPath = (model) => {
     p += '/apis/';
   }
 
-  if (!isLegacy && model.apiGroup) {
-    p += `${model.apiGroup}/`;
+  if (!isLegacy && apiGroup) {
+    p += `${apiGroup}/`;
   }
 
-  p += model.apiVersion;
+  p += apiVersion;
   return p;
 };
 


### PR DESCRIPTION
Core k8s resources that didn't have a static model defined were missing
schema information in the Explore page and YAML editor sidebar. This is
because we were using API group `core` internally and incorrectly using
the internal group when looking up the resource in the OpenAPI doc.

This changes console to not use `core` in when creating models from
discovery.

/assign @rhamilto 
@smarterclayton fyi

![Screen Shot 2020-01-24 at 9 39 32 AM](https://user-images.githubusercontent.com/1167259/73077088-760b8a00-3e8d-11ea-9bc4-e1a18d8b9ec2.png)
