### PR TITLE
Bug 1796626: fix create connector arrow head in topology

### DIFF
--- a/frontend/packages/console-shared/src/components/popper/Popper.tsx
+++ b/frontend/packages/console-shared/src/components/popper/Popper.tsx
@@ -89,12 +89,12 @@ const Popper: React.FC<PopperProps> = ({
   returnFocus,
 }) => {
   const controlled = typeof open === 'boolean';
-  const openProp = controlled ? open : true;
+  const openProp = controlled ? open || false : true;
   const nodeRef = React.useRef<Element>();
   const popperRef = React.useRef<PopperJS>(null);
   const popperRefs = useCombineRefs<PopperJS>(popperRef, popperRefIn);
   const [isOpen, setOpenState] = React.useState(openProp);
-  const focusRef = React.useRef<Element>();
+  const focusRef = React.useRef<Element | null>();
   const onRequestCloseRef = React.useRef(onRequestClose);
   onRequestCloseRef.current = onRequestClose;
 

--- a/frontend/packages/topology/src/components/GraphComponent.tsx
+++ b/frontend/packages/topology/src/components/GraphComponent.tsx
@@ -4,7 +4,6 @@ import { Graph } from '../types';
 import { WithPanZoomProps } from '../behavior/usePanZoom';
 import { WithDndDropProps } from '../behavior/useDndDrop';
 import { WithSelectionProps } from '../behavior/useSelection';
-import useCombineRefs from '../utils/useCombineRefs';
 import { WithContextMenuProps } from '../behavior/withContextMenu';
 import LayersProvider from './layers/LayersProvider';
 import { DEFAULT_LAYER } from './layers/LayersContext';
@@ -50,7 +49,6 @@ const GraphComponent: React.FC<GraphComponentProps> = ({
   onContextMenu,
 }) => {
   const layout = element.getLayout();
-  const refs = useCombineRefs<SVGPathElement>(panZoomRef, dndDropRef);
   React.useEffect(() => {
     element.layout();
     // Only re-run if the layout changes
@@ -61,6 +59,7 @@ const GraphComponent: React.FC<GraphComponentProps> = ({
   return (
     <>
       <rect
+        ref={dndDropRef}
         x={0}
         y={0}
         width={bounds.width}
@@ -71,7 +70,7 @@ const GraphComponent: React.FC<GraphComponentProps> = ({
       />
       <g
         data-surface="true"
-        ref={refs}
+        ref={panZoomRef}
         transform={`translate(${bounds.x}, ${bounds.y}) scale(${element.getScale()})`}
       >
         <Inner element={element} />


### PR DESCRIPTION
**Fixes**: 
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1796626
Issue noticed during review of https://github.com/openshift/console/pull/3979
The connector line was switching between an arrowhead and the + marker. While hovering the empty space of the graph, it should always remain a + marker.

**Analysis / Root cause**: 
Drop ref was referencing a group node which doesn't have a fixed size. The size of a group depends on the size of its children.
![drag-arrow](https://user-images.githubusercontent.com/14068621/73092112-f04a0780-3ea9-11ea-9fd2-9e25047ff18b.gif)

**Solution Description**: 
Assign the drop ref to the background node which is a fixed size and always represents the background area of the visible graph.

Changes to popper are type fixes needed to get storybook to run again :(

**Test setup:**
`yarn storybook`
http://localhost:6006/?path=/story/connector--create-connector

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
