### PR TITLE
Bug 1796619: useSafetyFirst in rbac useAccessReview hook

### DIFF
--- a/frontend/public/components/safety-first.tsx
+++ b/frontend/public/components/safety-first.tsx
@@ -4,16 +4,18 @@ import * as React from 'react';
  * You should pretty much always use this if you are setting React state asynchronously and your component could be unmounted.
  * (https://github.com/facebook/react/issues/14113)
  */
-export const useSafetyFirst = <S extends {}>(initialState: S) => {
+export const useSafetyFirst = <S extends any>(
+  initialState: S | (() => S),
+): [S, React.Dispatch<React.SetStateAction<S>>] => {
   const mounted = React.useRef(true);
   React.useEffect(() => () => (mounted.current = false), []);
 
   const [value, setValue] = React.useState(initialState);
-  const setValueSafe = (newValue) => {
+  const setValueSafe = (newValue: S) => {
     if (mounted.current) {
-      return setValue(newValue);
+      setValue(newValue);
     }
   };
 
-  return [value, setValueSafe] as [S, React.Dispatch<React.SetStateAction<S>>];
+  return [value, setValueSafe];
 };

--- a/frontend/public/components/utils/rbac.tsx
+++ b/frontend/public/components/utils/rbac.tsx
@@ -15,6 +15,7 @@ import {
   SelfSubjectAccessReviewKind,
 } from '../../module/k8s';
 import { ProjectModel, SelfSubjectAccessReviewModel } from '../../models';
+import { useSafetyFirst } from '../../components/safety-first';
 
 // Memoize the result so we only make the request once for each access review.
 // This does mean that the user will have to refresh the page to see updates.
@@ -90,7 +91,7 @@ export const useAccessReview = (
   resourceAttributes: AccessReviewResourceAttributes,
   impersonate?,
 ): boolean => {
-  const [isAllowed, setAllowed] = React.useState(false);
+  const [isAllowed, setAllowed] = useSafetyFirst(false);
   // Destructure the attributes to pass them as dependencies to `useEffect`,
   // which doesn't do deep comparison of object dependencies.
   const {
@@ -115,7 +116,7 @@ export const useAccessReview = (
         // still enforces access control.
         setAllowed(true);
       });
-  }, [group, resource, subresource, verb, name, namespace, impersonateKey]);
+  }, [setAllowed, group, resource, subresource, verb, name, namespace, impersonateKey]);
 
   return isAllowed;
 };


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1796619

Swapped `useState` with `useStafetyFirst` in rbac `useAccessReview` hook because it has potential to call state function `setAllowed` after the component has unmounted.

Also updated the types for `safety-first` to avoid using `as`.