### PR TITLE
Bug 1796421: Update serverless apiVersion from v1beta1 to v1 and updates URI acronym

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
@@ -206,7 +206,7 @@ export const sampleKnativeConfigurations: FirehoseResult = {
         },
         ownerReferences: [
           {
-            apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+            apiVersion: `${RouteModel.apiGroup}/${RouteModel.apiVersion}`,
             kind: RouteModel.kind,
             name: 'overlayimage',
             uid: 'cea9496b-8ce0-11e9-bb7b-0ebb55b110b8',
@@ -452,8 +452,8 @@ export const sampleEventSourceCamel: FirehoseResult = {
       },
       spec: {
         sink: {
-          apiVersion: 'serving.knative.dev/v1beta1',
-          kind: 'Service',
+          apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+          kind: ServiceModel.kind,
           name: 'overlayimage',
         },
       },
@@ -476,8 +476,8 @@ export const sampleEventSourceKafka: FirehoseResult = {
       },
       spec: {
         sink: {
-          apiVersion: 'serving.knative.dev/v1beta1',
-          kind: 'Service',
+          apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+          kind: ServiceModel.kind,
           name: 'overlayimage',
         },
       },

--- a/frontend/packages/knative-plugin/src/components/overview/EventSinkServicesOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/EventSinkServicesOverviewList.tsx
@@ -29,7 +29,7 @@ const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps
             />
             {sinkUri && (
               <>
-                <span className="text-muted">Sink uri: </span>
+                <span className="text-muted">Sink URI: </span>
                 <ExternalLink
                   href={sinkUri}
                   additionalClassName="co-external-link--block"

--- a/frontend/packages/knative-plugin/src/components/revisions/__tests__/RevisionRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/__tests__/RevisionRow.spec.tsx
@@ -31,7 +31,7 @@ describe('RevisionRow', () => {
     expect(wrapper.find(TableData)).toHaveLength(8);
     expect(serviceDataTable.find(ResourceLink)).toHaveLength(1);
     expect(serviceDataTable.find(ResourceLink).props().kind).toEqual(
-      'serving.knative.dev~v1beta1~Service',
+      'serving.knative.dev~v1~Service',
     );
   });
 

--- a/frontend/packages/knative-plugin/src/components/routes/__tests__/RouteRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/__tests__/RouteRow.spec.tsx
@@ -58,7 +58,7 @@ describe('RouteRow', () => {
     const trafficColData = wrapper.find(TableData).at(5);
     expect(trafficColData.find(ResourceLink)).toHaveLength(1);
     expect(trafficColData.find(ResourceLink).props().kind).toEqual(
-      'serving.knative.dev~v1beta1~Revision',
+      'serving.knative.dev~v1~Revision',
     );
   });
 

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -5,7 +5,7 @@ import {
 import { K8sKind } from '@console/internal/module/k8s';
 import { BadgeType } from '@console/shared/src/components/badges/badge-factory';
 
-const apiVersion = `v1beta1`;
+const apiVersion = 'v1';
 
 export const ConfigurationModel: K8sKind = {
   apiGroup: 'serving.knative.dev',

--- a/frontend/packages/knative-plugin/src/types.ts
+++ b/frontend/packages/knative-plugin/src/types.ts
@@ -3,8 +3,8 @@ import { K8sResourceKind, K8sResourceCondition } from '@console/internal/module/
 export type ConfigurationKind = K8sResourceKind;
 
 export type RevisionKind = {
-  status: {
-    conditions: K8sResourceCondition<ConditionTypes>[];
+  status?: {
+    conditions?: K8sResourceCondition<ConditionTypes>[];
   };
 } & K8sResourceKind;
 
@@ -14,6 +14,7 @@ export type ServiceKind = K8sResourceKind & {
   };
   status?: {
     url?: string;
+    traffic?: Traffic[];
   };
 };
 
@@ -35,4 +36,5 @@ export type Traffic = {
   revisionName: string;
   percent: number;
   latestRevision?: boolean;
+  tag?: string;
 };

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/traffic-splitting-utils-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/traffic-splitting-utils-mock.ts
@@ -1,10 +1,13 @@
+import { RevisionModel, ServiceModel } from '../../models';
+import { RevisionKind, ServiceKind as knativeServiceKind } from '../../types';
+
 export const mockTrafficData = [
   { percent: 50, tag: 'tag-1', revisionName: 'rev-1' },
   { percent: 50, tag: 'tag-2', revisionName: 'rev-2' },
 ];
-export const mockServiceData = {
-  apiVersion: 'serving.knative.dev/v1beta1',
-  kind: 'Service',
+export const mockServiceData: knativeServiceKind = {
+  apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+  kind: ServiceModel.kind,
   spec: {
     traffic: [
       {
@@ -31,9 +34,9 @@ export const mockServiceData = {
   },
 };
 
-export const mockUpdateRequestObj = {
-  apiVersion: 'serving.knative.dev/v1beta1',
-  kind: 'Service',
+export const mockUpdateRequestObj: knativeServiceKind = {
+  apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
+  kind: ServiceModel.kind,
   spec: {
     traffic: [
       {
@@ -50,26 +53,26 @@ export const mockUpdateRequestObj = {
   },
 };
 
-export const mockRevisions = [
+export const mockRevisions: RevisionKind[] = [
   {
-    apiVersion: 'serving.knative.dev/v1beta1',
-    kind: 'Revision',
+    apiVersion: `${RevisionModel.apiGroup}/${RevisionModel.apiVersion}  `,
+    kind: RevisionModel.kind,
     metadata: {
       name: 'rev-1',
       namespace: 'namespace',
     },
   },
   {
-    apiVersion: 'serving.knative.dev/v1beta1',
-    kind: 'Revision',
+    apiVersion: `${RevisionModel.apiGroup}/${RevisionModel.apiVersion}`,
+    kind: RevisionModel.kind,
     metadata: {
       name: 'rev-2',
       namespace: 'namespace',
     },
   },
   {
-    apiVersion: 'serving.knative.dev/v1beta1',
-    kind: 'Revision',
+    apiVersion: `${RevisionModel.apiGroup}/${RevisionModel.apiVersion}`,
+    kind: RevisionModel.kind,
     metadata: {
       name: 'rev-3',
       namespace: 'namespace',


### PR DESCRIPTION
Updates serverless apiVersion from v1beta1 to v1 and updates URI acronym for `Sink  Uri`

Tracks: 
- https://issues.redhat.com/browse/ODC-2684
- https://issues.redhat.com/browse/ODC-2398

Screenshots:

<img width="1390" alt="Screenshot 2020-01-27 at 4 45 53 PM" src="https://user-images.githubusercontent.com/5129024/73172833-e9312c80-4129-11ea-806d-ac84cfea39fb.png">

<img width="555" alt="Screenshot 2020-01-27 at 5 23 34 PM" src="https://user-images.githubusercontent.com/5129024/73172851-f64e1b80-4129-11ea-9bbc-8203f0084f02.png">

