### PR TITLE
Use sentence case for 'Select all filters' link

### DIFF
--- a/frontend/public/components/row-filter.jsx
+++ b/frontend/public/components/row-filter.jsx
@@ -40,7 +40,7 @@ export const CheckBoxControls = ({
             onClick={onSelectAll}
             variant="link"
           >
-            Select All Filters
+            Select all filters
           </Button>
           <span className="co-m-row-filter__items">
             {itemCount === selectedCount ? (


### PR DESCRIPTION
This the case consistent between similar links on the Search page. It's also consistent with similar links in other parts of console (for instance, the dashboards page).

/assign @zherman0 

Before:

![Screenshot at Jan 27 10-59-14](https://user-images.githubusercontent.com/1167259/73190766-78bbe880-40f4-11ea-8fb2-444cfe836b90.png)

After:

![Screenshot at Jan 27 11-02-32](https://user-images.githubusercontent.com/1167259/73190830-90936c80-40f4-11ea-84fd-03cc191cad2c.png)
