### PR TITLE
Bug 1797576: Import from Image Stream - Should Default To Your Current Project

### DIFF
--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -50,7 +50,7 @@ const DeployImage: React.FC<Props> = ({
     imageStream: {
       image: '',
       tag: '',
-      namespace: '',
+      namespace: namespace || '',
       grantAccess: true,
     },
     isi: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2432 

**Analysis / Root cause**: 
The initial value of namespace under the `imageStream` property was set to empty string
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: 
The initial value of namespace under the `imageStream` property is set to the active namespace value

**Screenshots / Gifs for design review**: 
![final_5e2f03f2db39810016a27981_521788](https://user-images.githubusercontent.com/22490998/73241485-26e49280-41c8-11ea-94f6-62dbb253952f.gif)


**Unit test coverage report**: 
There are no unit tests for the deploy image components

**Test setup:**
NA

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


/kind bug