### PR TITLE
Bug 1795374: Fix bug  where the PF react-catalog-view applies a white gradient, along with a trailing ellipsis, to truncated descriptions.

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -10,6 +10,12 @@ form.pf-c-form {
   margin-left: 3px;
 }
 
+// Removes PF white gradiant effect since it doesn't work in Firefox. Truncated text still has trailing ...
+// Upstream issue https://github.com/patternfly/patternfly-next/issues/2633
+.catalog-tile-pf-description .truncated::after {
+  background: none;
+}
+
 kbd {
   border-radius: 3px;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
The gradient does not position correctly in Firefox. In other parts of the console just the ellipsis is used to denote more text. So just removing the gradient to be consistent.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1795374

Before
<img width="734" alt="Screen Shot 2020-01-27 at 5 05 52 PM" src="https://user-images.githubusercontent.com/1874151/73218143-5becd880-4127-11ea-8c8f-3ace5330a0f1.png">

---
After
<img width="616" alt="Screen Shot 2020-01-27 at 4 55 59 PM" src="https://user-images.githubusercontent.com/1874151/73217989-03b5d680-4127-11ea-92da-107cbb8f10c7.png">
