### PR TITLE
Bug 1795305: search: use accordion component

### DIFF
--- a/frontend/public/components/_search.scss
+++ b/frontend/public/components/_search.scss
@@ -1,0 +1,26 @@
+.co-search__accordion {
+  padding-top: 0 !important;
+  .co-m-pane__filter-bar {
+    // Reduce the margin between the accordion toggle and the create button
+    // so that the space is equal above and below the button.
+    margin-top: ($grid-gutter-width / 2);
+  }
+  // There's no way to set a class name on this element with the PF4 component,
+  // so use a nested selector.
+  h3 {
+    margin-bottom: 0;
+  }
+  // There's no way to set a class name on this element, so use the PF4 class.
+  .pf-c-accordion__expanded-content-body {
+    // Left align the content with the heading on the search page.
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+  .pf-c-accordion__expanded-content-body,
+  .pf-c-accordion__toggle {
+    &:before {
+      // The expanded state indicator blends into the left nav. Hide it.
+      display: none;
+    }
+  }
+}

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -92,6 +92,7 @@
 @import 'components/storage-class-form';
 @import 'components/quota';
 @import 'components/cluster-settings/cluster-settings';
+@import 'components/search';
 
 @import 'components/dashboard/dashboards-page/cluster-dashboard/activity-card';
 @import 'components/dashboard/dashboards-page/cluster-dashboard/status-card';


### PR DESCRIPTION
* Switch to the PF4 `Accordion` component, which is closer to the design and is what we use on the Create Operand page. The accordion heading style improves the page hierarchy.
* Expand resources by default when selected, which feels more natural and works around the disappearing table rows.
* Improve the empty state message (to match design).

/assign @rhamilto @zherman0 

![Screen Shot 2020-01-27 at 8 48 18 PM](https://user-images.githubusercontent.com/1167259/73229140-b9dce880-4146-11ea-9b69-3baa766ee03a.png)
