### PR TITLE
kubevirt: Add link to PVC from VM Disk page

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -108,7 +108,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
     volume.getContainerImage() || '',
   );
 
-  const [pvcName, setPVCName] = React.useState<string>(combinedDisk.getPVCName(source));
+  const [pvcName, setPVCName] = React.useState<string>(combinedDisk.getPVCNameBySource(source));
 
   const [name, setName] = React.useState<string>(
     disk.getName() || getSequenceName('disk', usedDiskNames),

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
@@ -5,9 +5,10 @@ import {
   Kebab,
   KebabOption,
   LoadingInline,
+  ResourceLink,
 } from '@console/internal/components/utils';
-import { DASH, dimensifyRow, getDeletetionTimestamp } from '@console/shared';
-import { TemplateModel } from '@console/internal/models';
+import { DASH, dimensifyRow, getDeletetionTimestamp, getNamespace } from '@console/shared';
+import { TemplateModel, PersistentVolumeClaimModel } from '@console/internal/models';
 import { deleteDeviceModal, DeviceType } from '../modals/delete-device-modal';
 import { VMLikeEntityKind } from '../../types/vmLike';
 import { asVM, isVM, isVMI, isVMRunning } from '../../selectors/vm';
@@ -98,7 +99,7 @@ export type VMDiskSimpleRowProps = {
 };
 
 export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
-  data: { name, source, size, diskInterface, storageClass },
+  data: { name, namespace, source, size, diskInterface, storageClass, pvc },
   validation = {},
   columnClasses,
   actionsComponent,
@@ -134,6 +135,17 @@ export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
           </ValidationCell>
         )}
       </TableData>
+      <TableData className={dimensify()}>
+        <ValidationCell validation={validation.pvc}>
+          <ResourceLink
+            kind={PersistentVolumeClaimModel.kind}
+            name={pvc}
+            namespace={namespace}
+            title={pvc}
+            hideIcon
+          />
+        </ValidationCell>
+      </TableData>
       <TableData className={dimensify(true)}>{actionsComponent}</TableData>
     </TableRow>
   );
@@ -154,7 +166,7 @@ export const DiskRow: React.FC<VMDiskRowProps> = ({
 }) => {
   return (
     <DiskSimpleRow
-      data={restData}
+      data={{ ...restData, namespace: getNamespace(vmLikeEntity) }}
       columnClasses={columnClasses}
       index={index}
       style={style}

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
@@ -4,11 +4,13 @@ import { CombinedDisk } from '../../k8s/wrapper/vm/combined-disk';
 
 export type StorageSimpleData = {
   name?: string;
+  namespace?: string;
   content?: string;
   source?: string;
   diskInterface?: string;
   size?: string;
   storageClass?: string;
+  pvc?: string;
 };
 
 export type StorageSimpleDataValidation = {
@@ -18,6 +20,7 @@ export type StorageSimpleDataValidation = {
   diskInterface?: ValidationObject;
   size?: ValidationObject;
   storageClass?: ValidationObject;
+  pvc?: ValidationObject;
 };
 
 export type StorageBundle = StorageSimpleData & {

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/utils.ts
@@ -7,6 +7,7 @@ export const diskTableColumnClasses = [
   classNames('col-lg-2'),
   classNames('col-lg-2'),
   classNames('col-lg-2'),
+  classNames('col-lg-2'),
   Kebab.columnClass,
 ];
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -48,7 +48,7 @@ const getStoragesData = ({
       diskInterface: disk.getDiskInterface(),
       size: disk.getReadableSize(),
       storageClass: disk.getStorageClassName(),
-      pvc: disk.getPVCNameBySource() || disk.getPVCName(),
+      pvc: disk.getPVCNameBySource(disk.getSource()) || disk.getPVCName(),
     }));
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -10,10 +10,10 @@ import { sortable } from '@patternfly/react-table';
 import { DataVolumeModel } from '../../models';
 import { VMGenericLikeEntityKind } from '../../types/vmLike';
 import { VMLikeEntityTabProps } from '../vms/types';
-import { getResource } from '../../utils';
+import { getResource, getLoadedData } from '../../utils';
 import { wrapWithProgress } from '../../utils/utils';
 import { diskModalEnhanced } from '../modals/disk-modal/disk-modal-enhanced';
-import { CombinedDiskFactory } from '../../k8s/wrapper/vm/combined-disk';
+import { CombinedDiskFactory, CombinedDisk } from '../../k8s/wrapper/vm/combined-disk';
 import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
 import { VHW_TYPES } from '../create-vm-wizard/tabs/virtual-hardware-tab/types';
 import { StorageBundle } from './types';
@@ -21,6 +21,20 @@ import { DiskRow } from './disk-row';
 import { diskTableColumnClasses } from './utils';
 import { isVMI } from '../../selectors/vm';
 import { ADD_DISK } from '../../utils/strings';
+
+const lookupPVCName = (pvcs: FirehoseResult<K8sResourceKind[]>, disk: CombinedDisk) => {
+  const loadedPVCs: K8sResourceKind[] = getLoadedData(pvcs) || [];
+  const name = disk.dataVolumeWrapper && disk.dataVolumeWrapper.getName();
+  const pvc =
+    name &&
+    loadedPVCs.find((p) =>
+      p.metadata.ownerReferences.some(
+        (ownerReference) =>
+          ownerReference.name === name && ownerReference.kind === DataVolumeModel.kind,
+      ),
+    );
+  return (pvc && pvc.metadata.name) || null;
+};
 
 const getStoragesData = ({
   vmLikeEntity,
@@ -48,6 +62,7 @@ const getStoragesData = ({
       diskInterface: disk.getDiskInterface(),
       size: disk.getReadableSize(),
       storageClass: disk.getStorageClassName(),
+      pvc: disk.getPVCName() || lookupPVCName(pvcs, disk),
     }));
 };
 
@@ -97,6 +112,11 @@ export const VMDisksTable: React.FC<VMDisksTableProps> = ({
             {
               title: 'Storage Class',
               sortField: 'storageClass',
+              transforms: [sortable],
+            },
+            {
+              title: 'Persistent Volume Claim',
+              sortField: 'pvc',
               transforms: [sortable],
             },
             {

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -10,10 +10,10 @@ import { sortable } from '@patternfly/react-table';
 import { DataVolumeModel } from '../../models';
 import { VMGenericLikeEntityKind } from '../../types/vmLike';
 import { VMLikeEntityTabProps } from '../vms/types';
-import { getResource, getLoadedData } from '../../utils';
+import { getResource } from '../../utils';
 import { wrapWithProgress } from '../../utils/utils';
 import { diskModalEnhanced } from '../modals/disk-modal/disk-modal-enhanced';
-import { CombinedDiskFactory, CombinedDisk } from '../../k8s/wrapper/vm/combined-disk';
+import { CombinedDiskFactory } from '../../k8s/wrapper/vm/combined-disk';
 import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
 import { VHW_TYPES } from '../create-vm-wizard/tabs/virtual-hardware-tab/types';
 import { StorageBundle } from './types';
@@ -21,20 +21,6 @@ import { DiskRow } from './disk-row';
 import { diskTableColumnClasses } from './utils';
 import { isVMI } from '../../selectors/vm';
 import { ADD_DISK } from '../../utils/strings';
-
-const lookupPVCName = (pvcs: FirehoseResult<K8sResourceKind[]>, disk: CombinedDisk) => {
-  const loadedPVCs: K8sResourceKind[] = getLoadedData(pvcs) || [];
-  const name = disk.dataVolumeWrapper && disk.dataVolumeWrapper.getName();
-  const pvc =
-    name &&
-    loadedPVCs.find((p) =>
-      p.metadata.ownerReferences.some(
-        (ownerReference) =>
-          ownerReference.name === name && ownerReference.kind === DataVolumeModel.kind,
-      ),
-    );
-  return (pvc && pvc.metadata.name) || null;
-};
 
 const getStoragesData = ({
   vmLikeEntity,
@@ -62,7 +48,7 @@ const getStoragesData = ({
       diskInterface: disk.getDiskInterface(),
       size: disk.getReadableSize(),
       storageClass: disk.getStorageClassName(),
-      pvc: disk.getPVCNameBySource() || lookupPVCName(pvcs, disk),
+      pvc: disk.getPVCNameBySource() || disk.getPVCName(),
     }));
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -62,7 +62,7 @@ const getStoragesData = ({
       diskInterface: disk.getDiskInterface(),
       size: disk.getReadableSize(),
       storageClass: disk.getStorageClassName(),
-      pvc: disk.getPVCName() || lookupPVCName(pvcs, disk),
+      pvc: disk.getPVCNameBySource() || lookupPVCName(pvcs, disk),
     }));
 };
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
@@ -118,7 +118,7 @@ export class CombinedDisk {
       (dataVolumeWrapper) => dataVolumeWrapper.getStorageClassName(),
     );
 
-  getPVCName = (source?: StorageUISource) => {
+  getPVCNameBySource = (source?: StorageUISource) => {
     const resolvedSource = source || this.source;
     if (resolvedSource === StorageUISource.IMPORT_DISK) {
       return this.persistentVolumeClaimWrapper && this.persistentVolumeClaimWrapper.getName();
@@ -142,13 +142,13 @@ export class CombinedDisk {
         return this.dataVolumeWrapper.getURL();
       }
       case StorageUISource.IMPORT_DISK: {
-        return this.getPVCName(this.source);
+        return this.getPVCNameBySource(this.source);
       }
       case StorageUISource.ATTACH_DISK: {
-        return this.getPVCName(this.source);
+        return this.getPVCNameBySource(this.source);
       }
       case StorageUISource.ATTACH_CLONED_DISK: {
-        return this.getPVCName(this.source);
+        return this.getPVCNameBySource(this.source);
       }
       default:
         return null;

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/combined-disk.ts
@@ -53,7 +53,7 @@ export class CombinedDisk {
     dataVolumesLoading?: boolean;
     pvcsLoading?: boolean;
     isNewPVC?: boolean;
-    pvcName: string;
+    pvcName?: string;
   }) {
     this.diskWrapper = diskWrapper;
     this.volumeWrapper = volumeWrapper;
@@ -124,15 +124,14 @@ export class CombinedDisk {
       (dataVolumeWrapper) => dataVolumeWrapper.getStorageClassName(),
     );
 
-  getPVCNameBySource = (source?: StorageUISource) => {
-    const resolvedSource = source || this.source;
-    if (resolvedSource === StorageUISource.IMPORT_DISK) {
+  getPVCNameBySource = (source: StorageUISource) => {
+    if (source === StorageUISource.IMPORT_DISK) {
       return this.persistentVolumeClaimWrapper && this.persistentVolumeClaimWrapper.getName();
     }
-    if (resolvedSource === StorageUISource.ATTACH_DISK) {
+    if (source === StorageUISource.ATTACH_DISK) {
       return this.volumeWrapper && this.volumeWrapper.getPersistentVolumeClaimName();
     }
-    if (resolvedSource === StorageUISource.ATTACH_CLONED_DISK) {
+    if (source === StorageUISource.ATTACH_CLONED_DISK) {
       return this.dataVolumeWrapper && this.dataVolumeWrapper.getPesistentVolumeClaimName();
     }
 

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/vm/disk.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/vm/disk.ts
@@ -133,7 +133,7 @@ export const validateDisk = (
       dataVolumeWrapper: dataVolume,
       persistentVolumeClaimWrapper,
       isNewPVC: !!persistentVolumeClaimWrapper,
-    }).getPVCName(source);
+    }).getPVCNameBySource(source);
     addRequired(pvcName);
     validations.pvc = validatePVCName(pvcName, usedPVCNames);
   }


### PR DESCRIPTION
The user can be easily navigated from the Virtual Machine Disks subtab to the Persistent Volume Claim detail page.

![pvcLink](https://user-images.githubusercontent.com/17194943/73253656-3b6f5d80-41bd-11ea-85c2-aba575c0ac26.png)
