### PR TITLE
Bug 1801295: fix pod ring text while scaling up from 0

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodRing.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRing.tsx
@@ -71,6 +71,7 @@ const PodRing: React.FC<PodRingProps> = ({
   const { title, subTitle, titleComponent, subTitleComponent } = podRingLabel(
     resourceObj,
     isScalingAllowed,
+    pods,
   );
 
   return (

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
@@ -1,0 +1,52 @@
+import * as _ from 'lodash';
+import { mockPod } from '../__mocks__/pod-utils-test-data';
+import { podRingLabel } from '../pod-ring-utils';
+import { ExtPodKind } from '../../types';
+
+describe('pod-ring utils:', () => {
+  it('should return proper title, subtitle for podRingLabel', () => {
+    const podWithReplicas = _.set(mockPod, 'spec.replicas', 2);
+    const mockData = _.set(podWithReplicas, 'status.availableReplicas', 2);
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).title).toEqual(2);
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitle).toEqual('pods');
+  });
+
+  it('should return title 0, subtitle scaling to 2 and no titleComponent, subtitleComponent for podRingLabel when scaling from 1 to 2 pods', () => {
+    const podWithReplicas = _.set(_.cloneDeep(mockPod), 'spec.replicas', 2);
+    const mockData = _.set(podWithReplicas, 'status.availableReplicas', 1);
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).title).toEqual(1);
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitle).toEqual('scaling to 2');
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).titleComponent).toEqual(
+      undefined,
+    );
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitleComponent).toEqual(
+      undefined,
+    );
+  });
+
+  it('should return title 0, subtitle scaling to 1 and no titleComponent, subtitleComponent for podRingLabel when the first pod is being created', () => {
+    const podWithReplicas = _.set(mockPod, 'spec.replicas', 1);
+    const mockData = _.set(podWithReplicas, 'status.availableReplicas', 0);
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).title).toEqual('0');
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitle).toEqual('scaling to 1');
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).titleComponent).toEqual(
+      undefined,
+    );
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitleComponent).toEqual(
+      undefined,
+    );
+  });
+
+  it('should return title 0, subtitle scaling to 1 and no titleComponent, subtitleComponent for podRingLabel when pod count is 1 and status is pending', () => {
+    const podWithReplicas = _.set(_.cloneDeep(mockPod), 'spec.replicas', 1);
+    const mockData = _.set(podWithReplicas, 'status.phase', 'Pending');
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).title).toEqual('0');
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitle).toEqual('scaling to 1');
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).titleComponent).toEqual(
+      undefined,
+    );
+    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitleComponent).toEqual(
+      undefined,
+    );
+  });
+});

--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -38,21 +38,27 @@ const applyPods = (podsData: PodRingData, dc: PodRCData) => {
   return podsData;
 };
 
-export const podRingLabel = (obj: K8sResourceKind, canScale: boolean): PodRingLabelType => {
+export const podRingLabel = (
+  obj: K8sResourceKind,
+  canScale: boolean,
+  pods: ExtPodKind[],
+): PodRingLabelType => {
   const {
     spec: { replicas },
     status: { availableReplicas },
     kind,
   } = obj;
 
+  const isPending = (pods?.length === 1 && pods[0].status?.phase === 'Pending') || replicas;
   const pluralize = replicas > 1 || replicas === 0 ? 'pods' : 'pod';
   const knativeSubtitle = canScale ? '' : 'to 0';
   const scalingSubtitle = !replicas ? knativeSubtitle : `scaling to ${replicas}`;
-  const title = availableReplicas || (canScale ? 'Scaled to 0' : 'Autoscaled');
+  const title = availableReplicas || (isPending ? '0' : canScale ? 'Scaled to 0' : 'Autoscaled');
   const subTitle = replicas !== availableReplicas ? scalingSubtitle : pluralize;
-  const titleComponent = !availableReplicas
-    ? React.createElement(ChartLabel, { style: { fontSize: '14px' } })
-    : undefined;
+  const titleComponent =
+    !availableReplicas && !isPending
+      ? React.createElement(ChartLabel, { style: { fontSize: '14px' } })
+      : undefined;
   const subTitleComponent =
     kind === 'Revision'
       ? React.createElement(ChartLabel, { style: { fontSize: '14px' } })

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/PodSet.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/PodSet.tsx
@@ -57,7 +57,11 @@ const PodSet: React.FC<PodSetProps> = ({ size, data, x = 0, y = 0, showPodCount 
     true,
   );
   const obj = get(data, ['current', 'obj'], null) || data.dc;
-  const { title, subTitle, titleComponent, subTitleComponent } = podRingLabel(obj, accessAllowed);
+  const { title, subTitle, titleComponent, subTitleComponent } = podRingLabel(
+    obj,
+    accessAllowed,
+    data?.pods,
+  );
   return (
     <>
       <PodStatus


### PR DESCRIPTION
This PR fixes https://issues.redhat.com/browse/ODC-2566

**Analysis / Root cause:**
Pod ring text shows two phrases when scaling from 0 to 1. Title is set to "scaled to 0" and Subtitle is set to "scaling to 1".

**Solution description**
checks status and spec for the workload are equal to set proper title for the case of scaling up from 0 to 1

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

**Screens:**
![pod-text](https://user-images.githubusercontent.com/38663217/73273447-fe7d8800-4209-11ea-8e87-f77daebc3557.gif)
