### PR TITLE
dashboards: update cluster utilization empty state message

### DIFF
--- a/frontend/__tests__/components/graphs/graph-empty.spec.tsx
+++ b/frontend/__tests__/components/graphs/graph-empty.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { EmptyState, Title } from '@patternfly/react-core';
 
 import { GraphEmpty } from '@console/internal/components/graphs/graph-empty';
 
@@ -12,7 +11,7 @@ describe('<GraphEmpty />', () => {
 
   it('should render an empty state', () => {
     const wrapper = shallow(<GraphEmpty />);
-    expect(wrapper.find(EmptyState).exists()).toBe(true);
-    expect(wrapper.find(Title).exists()).toBe(true);
+    expect(wrapper.find('.text-secondary').exists()).toBe(true);
+    expect(wrapper.text()).toEqual('No datapoints found.');
   });
 });

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-body.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-body.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { EmptyState, EmptyStateVariant, Grid, GridItem, Title } from '@patternfly/react-core';
+import { Grid, GridItem } from '@patternfly/react-core';
 import { Humanize } from '@console/internal/components/utils';
 import { K8sKind } from '@console/internal/module/k8s';
 import { addAvailable, getCapacityValue, StackDataPoint } from './utils';
@@ -22,22 +22,10 @@ export const BreakdownCardBody: React.FC<BreakdownBodyProps> = ({
     return <BreakdownChartLoading />;
   }
   if (!capacityUsed || !top5MetricsStats.length || hasLoadError) {
-    return (
-      <EmptyState variant={EmptyStateVariant.full}>
-        <Title className="graph-empty-state__title text-secondary" size="sm">
-          Not available.
-        </Title>
-      </EmptyState>
-    );
+    return <div className="text-secondary">Not available</div>;
   }
   if (capacityUsed === '0') {
-    return (
-      <EmptyState variant={EmptyStateVariant.full}>
-        <Title className="graph-empty-state__title text-secondary" size="sm">
-          Not enough usage data
-        </Title>
-      </EmptyState>
-    );
+    return <div className="text-secondary">Not enough usage data</div>;
   }
 
   const available = getCapacityValue(capacityUsed, capacityTotal, humanize);

--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -9,10 +9,6 @@
   white-space: nowrap; 
 }
 
-.graph-empty-state__title {
-  font-size: 0.875rem;
-}
-
 .graph-wrapper {
   align-items: stretch;
   display: flex;

--- a/frontend/public/components/graphs/graph-empty.tsx
+++ b/frontend/public/components/graphs/graph-empty.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { EmptyState, EmptyStateVariant, Title } from '@patternfly/react-core';
 
 export const GraphEmpty: React.FC<GraphEmptyProps> = ({ height = 180, loading = false }) => (
   <div
@@ -15,11 +14,7 @@ export const GraphEmpty: React.FC<GraphEmptyProps> = ({ height = 180, loading = 
     {loading ? (
       <div className="skeleton-chart" />
     ) : (
-      <EmptyState variant={EmptyStateVariant.full}>
-        <Title className="graph-empty-state__title text-secondary" size="sm">
-          No datapoints found.
-        </Title>
-      </EmptyState>
+      <div className="text-secondary">No datapoints found.</div>
     )}
   </div>
 );


### PR DESCRIPTION
Align more closely with the other empty state messages on the page.

/assign @andybraren @rawagner 

Before:

![Screen Shot 2020-01-28 at 3 45 09 PM](https://user-images.githubusercontent.com/1167259/73303879-30302800-41e5-11ea-8f5a-40004c7fdc85.png)

After:

![Screen Shot 2020-01-28 at 3 40 19 PM](https://user-images.githubusercontent.com/1167259/73303781-0414a700-41e5-11ea-9084-07bc3351f56d.png)
