### PR TITLE
Bug 1797454: Fix Not available state for Control Plane

### DIFF
--- a/frontend/packages/console-app/src/components/dashboards-page/ControlPlaneStatus.tsx
+++ b/frontend/packages/console-app/src/components/dashboards-page/ControlPlaneStatus.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import {
-  GreenCheckCircleIcon,
-  YellowExclamationTriangleIcon,
-  RedExclamationCircleIcon,
-} from '@console/shared';
-import { HealthState } from '@console/shared/src/components/dashboard/status-card/states';
+  HealthState,
+  healthStateMapping,
+} from '@console/shared/src/components/dashboard/status-card/states';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import { getControlPlaneComponentHealth } from './status';
 
@@ -13,12 +11,8 @@ const ResponseRate: React.FC<ResponseRateProps> = ({ response, children, error }
   let icon: React.ReactNode;
   if (health.state === HealthState.LOADING) {
     icon = <div className="skeleton-health" />;
-  } else if (health.state === HealthState.OK) {
-    icon = <GreenCheckCircleIcon />;
-  } else if (health.state === HealthState.WARNING) {
-    icon = <YellowExclamationTriangleIcon />;
-  } else if (health.state === HealthState.ERROR) {
-    icon = <RedExclamationCircleIcon />;
+  } else if (health.state !== HealthState.NOT_AVAILABLE) {
+    icon = healthStateMapping[health.state].icon;
   }
   return (
     <div className="co-overview-status__row">

--- a/frontend/packages/console-app/src/components/dashboards-page/status.ts
+++ b/frontend/packages/console-app/src/components/dashboards-page/status.ts
@@ -54,7 +54,7 @@ export const getControlPlaneComponentHealth = (
       response.status === 'success' &&
       _.isNil(_.get(response, 'data.result[0].value[1]')))
   ) {
-    return { state: HealthState.NOT_AVAILABLE };
+    return { state: HealthState.NOT_AVAILABLE, message: 'Not available' };
   }
   if (!response) {
     return { state: HealthState.LOADING };
@@ -81,7 +81,7 @@ export const getControlPlaneHealth: PrometheusHealthHandler = (responses = [], e
   const errComponents = componentsHealth.filter(({ state }) => errorStates.includes(state));
   if (errComponents.length) {
     return {
-      state: errComponents.length === 4 ? HealthState.UNKNOWN : HealthState.WARNING,
+      state: errComponents.length === 4 ? HealthState.NOT_AVAILABLE : HealthState.WARNING,
       message: errComponents.length === 4 ? null : `${errComponents.length} components degraded`,
     };
   }


### PR DESCRIPTION
Before - Control plane shows `Unknown` state instead of `Not Available` and popup components miss any description
![Screenshot from 2020-01-29 09-11-36](https://user-images.githubusercontent.com/2078045/73340086-5a7ff500-427a-11ea-9d98-12306ba64db2.png)

After
![Screenshot from 2020-01-29 09-25-06](https://user-images.githubusercontent.com/2078045/73340085-5a7ff500-427a-11ea-92bb-707099f1c364.png)
