### PR TITLE
pluralize namespace word in quay img security popup

### DIFF
--- a/frontend/packages/container-security/src/components/summary.tsx
+++ b/frontend/packages/container-security/src/components/summary.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import { pluralize } from '@patternfly/react-core';
 import { ChartDonut } from '@patternfly/react-charts';
 import { SecurityIcon } from '@patternfly/react-icons';
 import { URLHealthHandler } from '@console/plugin-sdk';
@@ -115,12 +116,12 @@ export const SecurityBreakdownPopup: React.FC<SecurityBreakdownPopupProps> = (pr
                         v.metadata.name
                       }`}
                     >
-                      {
+                      {pluralize(
                         props.k8sResult.data.filter(
                           ({ metadata }) => metadata.name === v.metadata.name,
-                        ).length
-                      }{' '}
-                      namespaces
+                        ).length,
+                        'namespace',
+                      )}
                     </Link>
                   </div>
                 </div>


### PR DESCRIPTION
Before - says `1 namespaces`
![Screenshot from 2020-01-29 09-45-55](https://user-images.githubusercontent.com/2078045/73341095-3c1af900-427c-11ea-8dcd-74038b33efd4.png)

After
![Screenshot from 2020-01-29 09-46-20](https://user-images.githubusercontent.com/2078045/73341094-3c1af900-427c-11ea-9cce-6381e825addb.png)
