### PR TITLE
Fix not available state for operators

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/state-utils.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/state-utils.ts
@@ -55,7 +55,10 @@ export const getOperatorsStatus = <R extends K8sResourceCommon>(
 export const getOperatorsHealthState = (
   healthStatuses: OperatorHealth[],
 ): { health: HealthState; detailMessage: string } => {
-  if (healthStatuses.some((s) => s.health === HealthState.LOADING)) {
+  if (healthStatuses.some((s) => s.health === HealthState.NOT_AVAILABLE)) {
+    return { health: HealthState.NOT_AVAILABLE, detailMessage: undefined };
+  }
+  if (healthStatuses.some((s) => HealthState.LOADING === s.health)) {
     return { health: HealthState.LOADING, detailMessage: undefined };
   }
   const sortedStatuses = healthStatuses.sort(


### PR DESCRIPTION
Before - says `0 Not Available` for operators status
![Screenshot from 2020-01-29 09-58-51](https://user-images.githubusercontent.com/2078045/73341961-f6f7c680-427d-11ea-8f9e-5f56cc6b6d1a.png)

After
![Screenshot from 2020-01-29 09-55-50](https://user-images.githubusercontent.com/2078045/73341962-f6f7c680-427d-11ea-9690-520ac60b9dc2.png)
