### PR TITLE
fix loading missing ClusterVersionModel on Kubernetes

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -34,6 +34,7 @@ const cvResource = [
     name: 'version',
     isList: false,
     prop: 'cv',
+    optional: true,
   },
 ];
 


### PR DESCRIPTION
https://github.com/openshift/console/pull/3899 added a notification drawer, but the resource ClusterVersionModel it is listing is not present on K8s, so the whole `<AppContents />` doesn't get rendered.