### PR TITLE
Bug 1796094: Status field on pod details page missing popop over help info

### DIFF
--- a/frontend/packages/console-shared/src/utils/ResourceStatus.tsx
+++ b/frontend/packages/console-shared/src/utils/ResourceStatus.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { resourceObjPath } from '@console/internal/components/utils';
-import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
-import { PodStatus } from '@console/internal/components/pod';
+import { K8sResourceKind, PodKind, podPhase } from '@console/internal/module/k8s';
+import { Status } from '../components/status';
 import { PodControllerOverviewItem } from '../types';
 
 export const resourceStatus = (
@@ -22,7 +22,7 @@ export const resourceStatus = (
 };
 
 export const podStatus = (obj: PodKind) => {
-  return <PodStatus pod={obj} />;
+  return <Status status={podPhase(obj)} />;
 };
 
 type OverviewItemReadinessProps = {

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -341,15 +341,12 @@ const PodGraphs = requirePrometheus(({ pod }) => (
   </>
 ));
 
-export const PodStatus: React.FC<PodStatusProps> = ({ pod }) => <Status status={podPhase(pod)} />;
-
 export const PodDetailsList: React.FC<PodDetailsListProps> = ({ pod }) => {
   return (
     <dl className="co-m-pane__details">
-      <dt>Status</dt>
-      <dd>
-        <PodStatus pod={pod} />
-      </dd>
+      <DetailsItem label="Status" obj={pod} path="status.phase">
+        {podPhase(pod)}
+      </DetailsItem>
       <DetailsItem label="Restart Policy" obj={pod} path="spec.restartPolicy">
         {getRestartPolicyLabel(pod)}
       </DetailsItem>
@@ -559,10 +556,6 @@ type ContainerRowProps = {
 type PodContainerTableProps = {
   heading: string;
   containers: ContainerSpec[];
-  pod: PodKind;
-};
-
-type PodStatusProps = {
   pod: PodKind;
 };
 


### PR DESCRIPTION
Also moved the `PodStatus` component into `console-shared` package since its used only there now.

/assign @spadgett 