### PR TITLE
Fixed Bug 1796083: Create Receiver page loads forever when Prometheus API request returns an error

### DIFF
--- a/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
@@ -435,22 +435,28 @@ const ReceiverWrapper: React.FC<ReceiverFormsWrapperProps> = React.memo(({ obj, 
       setLoadError({ message: `Error alertManagerBaseURL not set` });
       return;
     }
-    coFetchJSON(`${alertManagerBaseURL}/api/v2/status/`).then((data) => {
-      const originalAlertmanagerConfigJSON = data?.config?.original;
-      if (_.isEmpty(originalAlertmanagerConfigJSON)) {
-        setLoadError({ message: 'alertmanager.v2.status.config.original not found.' });
-      } else {
-        try {
-          const { global } = safeLoad(originalAlertmanagerConfigJSON);
-          setAlertmanagerGlobals(global);
-          setLoaded(true);
-        } catch ({ message }) {
-          setLoadError({
-            message: `Error parsing Alertmanager config.original: ${message || 'invalid YAML'}`,
-          });
+    coFetchJSON(`${alertManagerBaseURL}/api/v2/status/`)
+      .then((data) => {
+        const originalAlertmanagerConfigJSON = data?.config?.original;
+        if (_.isEmpty(originalAlertmanagerConfigJSON)) {
+          setLoadError({ message: 'alertmanager.v2.status.config.original not found.' });
+        } else {
+          try {
+            const { global } = safeLoad(originalAlertmanagerConfigJSON);
+            setAlertmanagerGlobals(global);
+            setLoaded(true);
+          } catch ({ message }) {
+            setLoadError({
+              message: `Error parsing Alertmanager config.original: ${message || 'invalid YAML'}`,
+            });
+          }
         }
-      }
-    });
+      })
+      .catch((e) =>
+        setLoadError({
+          message: `Error loading ${alertManagerBaseURL}/api/v2/status/: ${e.message}`,
+        }),
+      );
   }, [alertManagerBaseURL]);
 
   return (


### PR DESCRIPTION
Added reject method to coFetchJSON(`${alertManagerBaseURL}/api/v2/status/`).then(...)

**Now we see this after a few seconds:**

![image](https://user-images.githubusercontent.com/12733153/73390567-59fc5400-42a4-11ea-8413-3d394c14c405.png)


