### PR TITLE
Bug 1796247: `marketplace` missing from `operatorProviderTypeMap`

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -97,12 +97,12 @@ const providerTypeSort = (provider) => {
       return 1;
     case ProviderType.Community:
       return 2;
+    case ProviderType.Marketplace:
+      return 3;
     case ProviderType.Custom:
       return 4;
-    case ProviderType.Marketplace:
-      return 5;
     default:
-      return 6;
+      return 5;
   }
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 
 export const operatorProviderTypeMap = {
   redhat: 'Red Hat',
+  marketplace: 'Marketplace',
   certified: 'Certified',
   community: 'Community',
   custom: 'Custom',


### PR DESCRIPTION
This was preventing the `Marketplace` provider type from working in OperatorHub.

/assign @benjaminapetersen @rebeccaalpert 
@alimobrem 