### PR TITLE
Bug 1796418: fixes resource tab for sidebar for knative associated deployment

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { K8sResourceKind } from '@console/internal/module/k8s';
 import { OverviewItem } from '@console/shared';
 import OperatorBackedOwnerReferences from '@console/internal/components/utils';
 import {
@@ -13,16 +12,12 @@ import {
 } from '../../models';
 import KnativeServiceResources from './KnativeServiceResources';
 import KnativeRevisionResources from './KnativeRevisionResources';
+import RevisionsOverviewList from './RevisionsOverviewList';
+import KSRoutesOverviewList from './RoutesOverviewList';
+import ConfigurationsOverviewList from './ConfigurationsOverviewList';
 import EventSinkServicesOverviewList from './EventSinkServicesOverviewList';
 
-export type KnativeOverviewProps = {
-  ksroutes: K8sResourceKind[];
-  configurations: K8sResourceKind[];
-  revisions: K8sResourceKind[];
-  obj: K8sResourceKind;
-};
-
-export type OverviewDetailsResourcesTabProps = {
+type OverviewDetailsResourcesTabProps = {
   item: OverviewItem;
 };
 
@@ -41,7 +36,13 @@ const getSidebarResources = ({ obj, ksroutes, revisions, configurations }: Overv
     case EventSourceKafkaModel.kind:
       return <EventSinkServicesOverviewList obj={obj} />;
     default:
-      return null;
+      return (
+        <>
+          <RevisionsOverviewList revisions={revisions} service={obj} />
+          <KSRoutesOverviewList ksroutes={ksroutes} resource={obj} />
+          <ConfigurationsOverviewList configurations={configurations} />
+        </>
+      );
   }
 };
 const OverviewDetailsKnativeResourcesTab: React.FC<OverviewDetailsResourcesTabProps> = ({

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
@@ -5,6 +5,9 @@ import OperatorBackedOwnerReferences from '@console/internal/components/utils';
 import OverviewDetailsKnativeResourcesTab from '../OverviewDetailsKnativeResourcesTab';
 import KnativeServiceResources from '../KnativeServiceResources';
 import KnativeRevisionResources from '../KnativeRevisionResources';
+import RevisionsOverviewList from '../RevisionsOverviewList';
+import KSRoutesOverviewList from '../RoutesOverviewList';
+import ConfigurationsOverviewList from '../ConfigurationsOverviewList';
 import EventSinkServicesOverviewList from '../EventSinkServicesOverviewList';
 
 type OverviewDetailsKnativeResourcesTabProps = React.ComponentProps<
@@ -54,5 +57,16 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
         .at(0)
         .props().item,
     ).toEqual(knItem.item);
+  });
+
+  it('should render Routes, Configuration and revision list on sidebar in case of kn deployment', () => {
+    knItem.item = {
+      ...knItem.item,
+      obj: MockKnativeResources.deployments.data[0],
+    };
+    const wrapper = shallow(<OverviewDetailsKnativeResourcesTab {...knItem} />);
+    expect(wrapper.find(RevisionsOverviewList)).toHaveLength(1);
+    expect(wrapper.find(KSRoutesOverviewList)).toHaveLength(1);
+    expect(wrapper.find(ConfigurationsOverviewList)).toHaveLength(1);
   });
 });

--- a/frontend/public/components/overview/resource-overview-details.tsx
+++ b/frontend/public/components/overview/resource-overview-details.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { connect } from 'react-redux';
 
 import * as UIActions from '../../actions/ui';
@@ -57,18 +58,33 @@ export const ResourceOverviewDetails = connect<PropsFromState, PropsFromDispatch
     onClickTab,
     selectedDetailsTab,
     tabs,
-  }: ResourceOverviewDetailsProps) => (
-    <div className="overview__sidebar-pane resource-overview">
-      <ResourceOverviewHeading actions={menuActions} kindObj={kindObj} resource={item.obj} />
-      <SimpleTabNav
-        onClickTab={onClickTab}
-        selectedTab={selectedDetailsTab}
-        tabProps={{ item }}
-        tabs={getPluginTabResources(item, tabs)}
-        additionalClassNames="co-m-horizontal-nav__menu--within-sidebar co-m-horizontal-nav__menu--within-overview-sidebar"
-      />
-    </div>
-  ),
+  }: ResourceOverviewDetailsProps) => {
+    const keys = Object.keys(item);
+    const keysRef = React.useRef(keys);
+    const tabsRef = React.useRef(tabs);
+    const pluginTabsRef = React.useRef<React.ComponentProps<typeof SimpleTabNav>['tabs']>();
+    if (
+      !pluginTabsRef.current ||
+      !_.isEqual(keys, keysRef.current) ||
+      !_.isEqual(tabs, tabsRef.current)
+    ) {
+      keysRef.current = keys;
+      tabsRef.current = tabs;
+      pluginTabsRef.current = getPluginTabResources(item, tabs);
+    }
+    return (
+      <div className="overview__sidebar-pane resource-overview">
+        <ResourceOverviewHeading actions={menuActions} kindObj={kindObj} resource={item.obj} />
+        <SimpleTabNav
+          onClickTab={onClickTab}
+          selectedTab={selectedDetailsTab}
+          tabProps={{ item }}
+          tabs={pluginTabsRef.current}
+          additionalClassNames="co-m-horizontal-nav__menu--within-sidebar co-m-horizontal-nav__menu--within-overview-sidebar"
+        />
+      </div>
+    );
+  },
 );
 
 type PropsFromState = {

--- a/frontend/public/components/utils/simple-tab-nav.tsx
+++ b/frontend/public/components/utils/simple-tab-nav.tsx
@@ -30,30 +30,42 @@ class SimpleTab extends React.PureComponent<SimpleTabProps> {
 export class SimpleTabNav extends React.Component<SimpleTabNavProps, SimpleTabNavState> {
   constructor(props) {
     super(props);
-    this.onClickTab = this.onClickTab.bind(this);
-    const selectedTab = _.find(props.tabs, { name: props.selectedTab }) || _.head(props.tabs);
-    this.state = { selectedTab };
+    this.state = { selectedTab: props.selectedTab };
   }
 
-  onClickTab(name) {
-    const { tabs } = this.props;
+  onClickTab = (name) => {
     this.props.onClickTab && this.props.onClickTab(name);
     this.setState({
-      selectedTab: _.find(tabs, { name }),
+      selectedTab: name,
     });
+  };
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const selectedTab = (
+      _.find(nextProps.tabs, { name: prevState.selectedTab }) ||
+      _.find(nextProps.tabs, { name: nextProps.selectedTab }) ||
+      _.head(nextProps.tabs)
+    ).name;
+    if (prevState.selectedTab !== selectedTab) {
+      return {
+        selectedTab,
+      };
+    }
+    return null;
   }
 
   render() {
     const { tabs, tabProps, additionalClassNames } = this.props;
     const { selectedTab } = this.state;
-    const Component = selectedTab.component;
+    const selectedTabData = _.find(tabs, { name: selectedTab }) || _.head(tabs);
+    const Component = selectedTabData.component;
 
     return (
       <>
         <ul className={classNames('co-m-horizontal-nav__menu', additionalClassNames)}>
           {_.map(tabs, (tab) => (
             <SimpleTab
-              active={selectedTab.name === tab.name}
+              active={selectedTabData.name === tab.name}
               key={tab.name}
               onClick={this.onClickTab}
               title={tab.name}
@@ -78,7 +90,7 @@ type SimpleTabNavProps = {
 };
 
 type SimpleTabNavState = {
-  selectedTab: any;
+  selectedTab: string;
 };
 
 type SimpleTabProps = {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2866

**Analysis / Root cause**:
- Resource tab on the sidebar in list view shows associated workloads in case of knative deployments should show associated  Revisions/Routes/Configurations and other deployment should show regular Pods/build/service/routes
- In case of list view if a user clicking on regular deployment sidebar shows up and click on Resource tab shows `Pods/build/service/routes` and without closing, if the user  clicks on knative deployment it still shows Pods/build/Service/routes as component didn't get updated. 

**Solution Description**:
fixes resource tab for sidebar for knative associated deployment to show associated  Revisions/Routes/Configurations and handled component lifecycle to render the proper component in case of the sidebar is open and the user clicks on a different item.

**Screen shots / Gifs for design review**:

![ezgif com-video-to-gif (19)](https://user-images.githubusercontent.com/5129024/73431166-cbe8a200-4365-11ea-850f-41874e856501.gif)

**Unit test coverage report**: 
<img width="1125" alt="Screenshot 2020-01-30 at 1 51 39 PM" src="https://user-images.githubusercontent.com/5129024/73432000-bffddf80-4367-11ea-9c66-7784ca84e541.png">


**Browser conformance**:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
