### PR TITLE
Bug 1794825: Operator-defined namespace that requests monitoring should fully warn user of implications of enabling

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -5,9 +5,11 @@ import { match } from 'react-router';
 import { ActionGroup, Alert, Button, Checkbox, Tooltip } from '@patternfly/react-core';
 import {
   Dropdown,
+  ExternalLink,
   Firehose,
   history,
   NsDropdown,
+  openshiftHelpBase,
   BreadCrumbs,
   MsgBox,
   StatusBox,
@@ -348,10 +350,24 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
             onChange={setEnableMonitoring}
             isChecked={enableMonitoring}
           />
-          <small>
-            Note: Enabling monitoring will allow any operator or workload running on this namespace
-            to contribute metrics to the cluster metric set.
-          </small>
+          {props.packageManifest.data[0].metadata.labels['opsrc-provider'] !== 'redhat' && (
+            <Alert
+              isInline
+              className="co-alert pf-c-alert--top-margin"
+              variant="warning"
+              title="Namespace monitoring"
+            >
+              Please note that installing non Red Hat operators into openshift namespaces and
+              enabling monitoring voids user support. Enabling cluster monitoring for non Red Hat
+              operators can lead to malicious metrics data overriding existing cluster metrics. For
+              more information, see the{' '}
+              <ExternalLink
+                href={`${openshiftHelpBase}monitoring/cluster-monitoring/configuring-the-monitoring-stack.html#maintenance-and-support_configuring-monitoring`}
+                text="cluster monitoring documentation"
+              />{' '}
+              .
+            </Alert>
+          )}
         </div>
       )}
     </>


### PR DESCRIPTION
Adding a warning alert to emphasise to the users what the implications of allowing any workload to contribute metrics are. The wording is taken from the bug's Doc Text.

Here I'm not really sure if it does make sense since the warning alert will be shown in case only when `openshift-*` namespace is selected as **Installed Namespace**.  Is that on purpose 

Also the Doc Text is pointing to 4.2 docs. Should we use 4.3 instead?

Last thing, wanted to ask if there shouldn’t also be a checkbox for enabling the monitoring when user picks from an existing namespace and the operator has `openshift.io/cluster-monitoring` annotation defined. Or there was an agreement  that the checkbox will be only shown when using the recommended namespace ?

@shawn-hurley @itsptk could you help here?

Screen:
<img width="841" alt="Screenshot 2020-01-30 at 11 03 41" src="https://user-images.githubusercontent.com/1668218/73440828-4c050c80-4352-11ea-9939-95fad7364830.png">


/assign @spadgett 