### PR TITLE
Bug 1795695: Status of terminating pv and pvc doesn't match in cli and ui

### DIFF
--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -26,7 +26,9 @@ const menuActions = [
   ...common,
 ];
 
-const PVCStatus = ({ pvc }) => <Status status={pvc.status.phase} />;
+const PVCStatus = ({ pvc }) => (
+  <Status status={pvc.metadata.deletionTimestamp ? 'Terminating' : pvc.status.phase} />
+);
 
 const tableColumnClasses = [
   classNames('col-lg-2', 'col-md-2', 'col-sm-4', 'col-xs-6'),

--- a/frontend/public/components/persistent-volume.jsx
+++ b/frontend/public/components/persistent-volume.jsx
@@ -20,7 +20,9 @@ import { PersistentVolumeModel } from '../models';
 const { common } = Kebab.factory;
 const menuActions = [...Kebab.getExtensionsActionsForKind(PersistentVolumeModel), ...common];
 
-const PVStatus = ({ pv }) => <Status status={pv.status.phase} />;
+const PVStatus = ({ pv }) => (
+  <Status status={pv.metadata.deletionTimestamp ? 'Terminating' : pv.status.phase} />
+);
 
 const tableColumnClasses = [
   classNames('col-lg-2', 'col-md-2', 'col-sm-4', 'col-xs-6'),


### PR DESCRIPTION
After deleting PV or PVC, their status is still showing *Bound* even though they show *Terminating* in CLI.
 
/assign @spadgett 