### PR TITLE
Bug 1796450: Disable the zoom feature for QueryBrowser when hideControls props is true

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -648,15 +648,26 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
             />
           )}
           <div className="graph-wrapper graph-wrapper--query-browser">
-            <ZoomableGraph
-              allSeries={graphData}
-              disabledSeries={disabledSeries}
-              formatLegendLabel={formatLegendLabel}
-              isStack={isStack}
-              onZoom={onZoom}
-              span={span}
-              xDomain={xDomain}
-            />
+            {hideControls ? (
+              <Graph
+                allSeries={graphData}
+                disabledSeries={disabledSeries}
+                formatLegendLabel={formatLegendLabel}
+                isStack={isStack}
+                span={span}
+                xDomain={xDomain}
+              />
+            ) : (
+              <ZoomableGraph
+                allSeries={graphData}
+                disabledSeries={disabledSeries}
+                formatLegendLabel={formatLegendLabel}
+                isStack={isStack}
+                onZoom={onZoom}
+                span={span}
+                xDomain={xDomain}
+              />
+            )}
           </div>
         </>
       )}


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-2779
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
On the dev-monitoring dashboard, users are able to zoom the graph but there is no option to reset the zoom.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Disable the zoom feature when ```hideControls``` prop is true.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Peek 2020-01-30 22-44](https://user-images.githubusercontent.com/2561818/73473133-39babb00-43b2-11ea-80d8-098485b0304a.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge