### PR TITLE
Bug 1797699: fix the order of the menu items in the project access dropdown

### DIFF
--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccessForm.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccessForm.tsx
@@ -7,8 +7,8 @@ import { MultiColumnField, InputField, DropdownField, FormFooter } from '@consol
 enum accessRoles {
   '' = 'Select a role',
   admin = 'Admin',
-  view = 'View',
   edit = 'Edit',
+  view = 'View',
 }
 
 const ProjectAccessForm: React.FC<FormikProps<FormikValues>> = ({


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2404

**Solution Description**: 
The order of menu items in the Project Access dropdown is changed to alphabetical order

**Screen shots / Gifs for design review**: 
![Screenshot from 2020-01-31 23-38-37](https://user-images.githubusercontent.com/22490998/73563210-d2207080-4482-11ea-8bd2-b2f03ded5813.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
