### PR TITLE
Bug 1796477:  Fix bug where selected resource dropdown group/version …

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -47,14 +47,6 @@
     @media (min-width: 480px) {
       min-width: 350px;
     }
-    &:active,
-    .active a,
-    .active a:focus,
-    .active a:hover {
-      .co-resource-item__resource-api {
-        color: $dropdown-link-active-color;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
…description not visible

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1796477

Before:
<img width="408" alt="Screen Shot 2020-01-30 at 9 31 02 AM" src="https://user-images.githubusercontent.com/895728/73458711-b19dcc80-4343-11ea-9890-c133960315fc.png">
<img width="393" alt="Screen Shot 2020-01-30 at 9 31 06 AM" src="https://user-images.githubusercontent.com/895728/73458712-b19dcc80-4343-11ea-97c8-1dd0140d431b.png">

After:
<img width="410" alt="Screen Shot 2020-01-30 at 9 30 34 AM" src="https://user-images.githubusercontent.com/895728/73458721-b5c9ea00-4343-11ea-9d78-b874a42e5de6.png">
<img width="401" alt="Screen Shot 2020-01-30 at 9 30 39 AM" src="https://user-images.githubusercontent.com/895728/73458722-b5c9ea00-4343-11ea-956e-b316d1e4b380.png">

cc: @sg00dwin 