### PR TITLE
Bug 1796244: Subtext in resource dropdown shows as white instead of muted when item selected

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -36,24 +36,10 @@
 }
 
 .co-type-selector {
-  .pf-c-dropdown__toggle .show {
-    display: inline !important;
-    &::before {
-      content: '- ';
-    }
-  }
   .pf-c-dropdown__menu {
     min-width: 290px;
     @media (min-width: 480px) {
       min-width: 350px;
-    }
-    &:active,
-    .active a,
-    .active a:focus,
-    .active a:hover {
-      .co-resource-item__resource-api {
-        color: $dropdown-link-active-color;
-      }
     }
   }
 }


### PR DESCRIPTION
Removing white `color` style for picked resources in ResourceListDropdown component, since dont use blue background for active list items as we did [before](https://user-images.githubusercontent.com/1874151/54845943-1c589300-4cb1-11e9-9a53-5ea79c764314.png)

Also ResourceListDropdown component is no longer showing resource API groups, but instead a Badge with a number of selected resources, so we dont need to prefix the API group with dash.

/assign @sg00dwin 