### PR TITLE
Bug 1796538: Fix monitoring dashboard table columns

### DIFF
--- a/frontend/public/components/monitoring/dashboards/types.ts
+++ b/frontend/public/components/monitoring/dashboards/types.ts
@@ -2,6 +2,7 @@ export type ColumnStyle = {
   alias?: string;
   decimals?: number;
   unit?: string;
+  pattern: string;
   type: string;
 };
 


### PR DESCRIPTION
* Use target `refId` to correctly associate column styles to the data
* Don't show hidden table columns

/assign @rhamilto @kyoto 

Before:

<img width="1533" alt="Screen Shot 2020-01-30 at 11 37 11 AM" src="https://user-images.githubusercontent.com/1167259/73490806-453ebf80-437b-11ea-8aab-3070165f6364.png">

After:

<img width="1340" alt="Screen Shot 2020-01-30 at 3 52 22 PM" src="https://user-images.githubusercontent.com/1167259/73489724-10ca0400-4379-11ea-855a-59b9f7735ca1.png">
