### PR TITLE
Bug 1797567: add unit test for custome hook usePodScalingAccessStatus

### DIFF
--- a/frontend/packages/console-shared/src/test-utils/hooks-utils.tsx
+++ b/frontend/packages/console-shared/src/test-utils/hooks-utils.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+const TestHook: React.FC<{ callback: () => void }> = ({ callback }) => {
+  callback();
+  return null;
+};
+
+export const testHook = (callback: () => void) => {
+  mount(<TestHook callback={callback} />);
+};

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
@@ -1,6 +1,11 @@
 import * as _ from 'lodash';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { DeploymentConfigModel } from '@console/internal/models';
+import { RevisionModel } from '@console/knative-plugin';
+import * as utils from '../pod-utils';
+import { usePodScalingAccessStatus, podRingLabel } from '../pod-ring-utils';
+import { testHook } from '../../test-utils/hooks-utils';
 import { mockPod } from '../__mocks__/pod-utils-test-data';
-import { podRingLabel } from '../pod-ring-utils';
 import { ExtPodKind } from '../../types';
 
 describe('pod-ring utils:', () => {
@@ -48,5 +53,51 @@ describe('pod-ring utils:', () => {
     expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitleComponent).toEqual(
       undefined,
     );
+  });
+});
+
+describe('usePodScalingAccessStatus', () => {
+  let obj: K8sResourceKind;
+
+  beforeEach(() => {
+    jest
+      .spyOn(utils, 'checkPodEditAccess')
+      .mockImplementation(() => Promise.resolve({ status: { allowed: false } }));
+    obj = {
+      kind: '',
+      metadata: {},
+      spec: {},
+      status: {},
+    };
+  });
+
+  it('should return false for scaling when enableScaling is false', () => {
+    obj.kind = 'Deployment';
+    testHook(() => {
+      expect(usePodScalingAccessStatus(obj, DeploymentConfigModel, [], false)).toBe(false);
+    });
+  });
+
+  it('should return false for knative revisions', () => {
+    obj.kind = 'Revision';
+    testHook(() => {
+      expect(usePodScalingAccessStatus(obj, RevisionModel, [], true)).toBe(false);
+    });
+  });
+
+  it('should return false when api call returns false for a resource', () => {
+    obj.kind = 'DeploymentConfig';
+    testHook(() => {
+      expect(usePodScalingAccessStatus(obj, DeploymentConfigModel, [], true)).toBe(false);
+    });
+  });
+
+  it('should return false when API call results in an error', () => {
+    jest
+      .spyOn(utils, 'checkPodEditAccess')
+      .mockImplementation(() => Promise.reject(new Error('error')));
+    testHook(() => {
+      expect(usePodScalingAccessStatus(obj, DeploymentConfigModel, [], true)).toBe(false);
+    });
   });
 });

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
@@ -71,33 +71,37 @@ describe('usePodScalingAccessStatus', () => {
     };
   });
 
-  it('should return false for scaling when enableScaling is false', () => {
+  it('should return false for scaling when enableScaling is false', (done) => {
     obj.kind = 'Deployment';
     testHook(() => {
       expect(usePodScalingAccessStatus(obj, DeploymentConfigModel, [], false)).toBe(false);
+      done();
     });
   });
 
-  it('should return false for knative revisions', () => {
+  it('should return false for knative revisions', (done) => {
     obj.kind = 'Revision';
     testHook(() => {
       expect(usePodScalingAccessStatus(obj, RevisionModel, [], true)).toBe(false);
+      done();
     });
   });
 
-  it('should return false when api call returns false for a resource', () => {
+  it('should return false when api call returns false for a resource', (done) => {
     obj.kind = 'DeploymentConfig';
     testHook(() => {
       expect(usePodScalingAccessStatus(obj, DeploymentConfigModel, [], true)).toBe(false);
+      done();
     });
   });
 
-  it('should return false when API call results in an error', () => {
+  it('should return false when API call results in an error', (done) => {
     jest
       .spyOn(utils, 'checkPodEditAccess')
       .mockImplementation(() => Promise.reject(new Error('error')));
     testHook(() => {
       expect(usePodScalingAccessStatus(obj, DeploymentConfigModel, [], true)).toBe(false);
+      done();
     });
   });
 });

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-utils.spec.ts
@@ -98,24 +98,26 @@ describe('checkPodEditAccess', () => {
     };
   });
 
-  it('should have access true if check Access return allowed true', () => {
+  it('should have access true if check Access return allowed true', (done) => {
     jest
       .spyOn(utils, 'checkAccess')
       .mockImplementation(() => Promise.resolve({ status: { allowed: true } }));
     checkPodEditAccess(obj, DeploymentConfigModel, undefined)
       .then((resp) => {
         expect(resp.status.allowed).toBe(true);
+        done();
       })
       .catch(() => {});
   });
 
-  it('should have access false if check Access return allowed false', () => {
+  it('should have access false if check Access return allowed false', (done) => {
     jest
       .spyOn(utils, 'checkAccess')
       .mockImplementation(() => Promise.resolve({ status: { allowed: false } }));
     checkPodEditAccess(obj, DeploymentConfigModel, undefined)
       .then((resp) => {
         expect(resp.status.allowed).toBe(false);
+        done();
       })
       .catch(() => {});
   });


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-2669
This PR adds unit test for custom hook `usePodScalingAccessStatus` which was missing in PR #3746 