### PR TITLE
Bug 1797457: Show not available if there are no data in multiline charts

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -61,7 +61,7 @@ export const MultilineUtilizationItem: React.FC<MultilineUtilizationItemProps> =
         <div className="co-utilization-card__item-description">
           <div className="co-utilization-card__item-section-multiline">
             <h4 className="pf-c-title pf-m-md">{title}</h4>
-            {error || (!isLoading && !data.length) ? (
+            {error || (!isLoading && !data.every((datum) => datum.length)) ? (
               <div className="text-secondary">Not available</div>
             ) : (
               <div className="co-utilization-card__item-description">{currentValue}</div>


### PR DESCRIPTION
Before - Network Transfer does not show `Not available` for current usage
![Screenshot from 2020-01-31 10-15-33](https://user-images.githubusercontent.com/2078045/73527039-a1085780-4412-11ea-9ec4-f1b2abfe9ba3.png)

After
![Screenshot from 2020-01-31 10-13-28](https://user-images.githubusercontent.com/2078045/73527040-a1085780-4412-11ea-9373-4b4bbb281a47.png)
