### PR TITLE
Remove getActiveNamespace usage

### DIFF
--- a/frontend/__tests__/components/routes/create-route.spec.tsx
+++ b/frontend/__tests__/components/routes/create-route.spec.tsx
@@ -4,18 +4,17 @@ import { Button } from '@patternfly/react-core';
 
 import { ButtonBar, Dropdown } from '../../../public/components/utils';
 import {
-  CreateRoute,
+  CreateRoute_,
   CreateRouteState,
   AlternateServicesGroup,
+  CreateRouteProps,
 } from '../../../public/components/routes/create-route';
-import * as UIActions from '../../../public/actions/ui';
 import * as k8sActions from '../../../public/module/k8s';
 
 describe('Create Route', () => {
-  let wrapper: ShallowWrapper<{}, CreateRouteState>;
+  let wrapper: ShallowWrapper<CreateRouteProps, CreateRouteState>;
 
   beforeEach(() => {
-    spyOn(UIActions, 'getActiveNamespace').and.returnValue('default');
     spyOn(k8sActions, 'k8sList').and.returnValue(
       Promise.resolve([
         { metadata: { name: 'service1' } },
@@ -24,7 +23,7 @@ describe('Create Route', () => {
         { metadata: { name: 'service4' } },
       ]),
     );
-    wrapper = shallow(<CreateRoute />);
+    wrapper = shallow(<CreateRoute_ namespace="default" />);
   });
 
   it('should render CreateRoute component', () => {

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './namespace';

--- a/frontend/packages/console-shared/src/hooks/namespace.ts
+++ b/frontend/packages/console-shared/src/hooks/namespace.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
+import { useSelector } from 'react-redux';
+import { getActiveNamespace } from '@console/internal/reducers/ui';
+import { RootState } from '@console/internal/redux';
+
+export const useActiveNamespace = (): string => useSelector<RootState, string>(getActiveNamespace);

--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineSection.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { connectToFlags, FlagsObject } from '@console/internal/reducers/features';
 import { getBadgeFromType } from '@console/shared';
 import { Split, SplitItem, Alert } from '@patternfly/react-core';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { useAccessReview } from '@console/internal/components/utils';
 import { useFormikContext, FormikValues } from 'formik';
 import { PipelineModel, PipelineResourceModel } from '../../../models';
@@ -25,14 +24,12 @@ const usePipelineAccessReview = (): boolean => {
   const canCreatePipelines = useAccessReview({
     group: PipelineModel.apiGroup,
     resource: PipelineModel.plural,
-    namespace: getActiveNamespace(),
     verb: 'create',
   });
 
   const canCreatePipelineResource = useAccessReview({
     group: PipelineResourceModel.apiGroup,
     resource: PipelineResourceModel.plural,
-    namespace: getActiveNamespace(),
     verb: 'create',
   });
 

--- a/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
@@ -9,7 +9,6 @@ import {
 } from '@console/knative-plugin';
 import { getBadgeFromType, RadioButtonField, RadioOption } from '@console/shared';
 import { useAccessReview } from '@console/internal/components/utils';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { Resources } from '../import-types';
 import FormSection from './FormSection';
 import './ResourceSection.scss';
@@ -53,7 +52,6 @@ const ResourceSection: React.FC<ResourceSectionProps> = ({ flags }) => {
   const knativeServiceAccess = useAccessReview({
     group: ServiceModel.apiGroup,
     resource: ServiceModel.plural,
-    namespace: getActiveNamespace(),
     verb: 'create',
   });
 

--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -8,7 +8,6 @@ import {
   ExternalLink,
   StatusBox,
 } from '@console/internal/components/utils';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { RoleBindingModel, RoleModel } from '@console/internal/models';
 import { filterRoleBindings, getUserRoleBindings } from './project-access-form-utils';
 import {
@@ -111,9 +110,9 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ formName, namespace, role
       <PageHeading title="Project Access">
         Project Access allows you to add or remove a user&apos;s access to the project. More
         advanced management of role-based access control appear in{' '}
-        <Link to={`/k8s/ns/${getActiveNamespace()}/${RoleModel.plural}`}>Roles</Link> and{' '}
-        <Link to={`/k8s/ns/${getActiveNamespace()}/${RoleBindingModel.plural}`}>Role Bindings</Link>
-        . For more information, see the{' '}
+        <Link to={`/k8s/ns/${namespace}/${RoleModel.plural}`}>Roles</Link> and{' '}
+        <Link to={`/k8s/ns/${namespace}/${RoleBindingModel.plural}`}>Role Bindings</Link>. For more
+        information, see the{' '}
         <ExternalLink
           href="https://docs.openshift.com/container-platform/4.1/authentication/using-rbac.html"
           text="role-based access control documentation"

--- a/frontend/packages/dev-console/src/components/projects/details/AllProjectsDetailList.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/AllProjectsDetailList.tsx
@@ -1,17 +1,19 @@
 import * as React from 'react';
 import { Redirect } from 'react-router';
 import { ALL_NAMESPACES_KEY } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks';
 import { ProjectList } from '@console/internal/components/namespace';
 import { history } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import NamespacedPage, { NamespacedPageVariants } from '../../NamespacedPage';
 import CreateProjectListPage from '../CreateProjectListPage';
-import { redirectURI, useActiveNamespace, UseActiveNamespaceProps } from './utils';
+import { redirectURI } from './utils';
 
 const handleProjectCreate = (project: K8sResourceKind) =>
   history.push(redirectURI(project.metadata.name));
 
-export const AllProjectsDetailList: React.FC<UseActiveNamespaceProps> = ({ activeNamespace }) => {
+const AllProjectsDetailList: React.FC = () => {
+  const activeNamespace = useActiveNamespace();
   const allNamespaces = activeNamespace === ALL_NAMESPACES_KEY;
 
   if (!allNamespaces) {
@@ -29,6 +31,4 @@ export const AllProjectsDetailList: React.FC<UseActiveNamespaceProps> = ({ activ
   );
 };
 
-// TODO Figure out why this breaks eslint rules-of-hooks even though it is not a hook
-// eslint-disable-next-line react-hooks/rules-of-hooks
-export default useActiveNamespace(AllProjectsDetailList);
+export default AllProjectsDetailList;

--- a/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
@@ -2,15 +2,11 @@ import * as React from 'react';
 import { Redirect } from 'react-router';
 import { history } from '@console/internal/components/utils';
 import { ALL_NAMESPACES_KEY } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks';
 import { ProjectsDetailsPage } from '@console/internal/components/namespace';
 import { ProjectModel } from '@console/internal/models';
 import NamespacedPage, { NamespacedPageVariants } from '../../NamespacedPage';
-import {
-  PROJECT_LIST_URI,
-  redirectURI,
-  useActiveNamespace,
-  UseActiveNamespaceProps,
-} from './utils';
+import { PROJECT_LIST_URI, redirectURI } from './utils';
 
 const handleNamespaceChange = (newNamespace: string): void => {
   if (newNamespace === ALL_NAMESPACES_KEY) {
@@ -20,10 +16,8 @@ const handleNamespaceChange = (newNamespace: string): void => {
   history.push(redirectURI(newNamespace));
 };
 
-export const ProjectDetailsPage: React.FC<UseActiveNamespaceProps> = ({
-  activeNamespace,
-  ...props
-}) => {
+const ProjectDetailsPage: React.FC = (props) => {
+  const activeNamespace = useActiveNamespace();
   const allNamespaces = activeNamespace === ALL_NAMESPACES_KEY;
 
   if (allNamespaces) {
@@ -47,6 +41,4 @@ export const ProjectDetailsPage: React.FC<UseActiveNamespaceProps> = ({
   );
 };
 
-// TODO Figure out why this breaks eslint rules-of-hooks even though it is not a hook
-// eslint-disable-next-line react-hooks/rules-of-hooks
-export default useActiveNamespace(ProjectDetailsPage);
+export default ProjectDetailsPage;

--- a/frontend/packages/dev-console/src/components/projects/details/__tests__/AllProjectsDetailList.spec.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/__tests__/AllProjectsDetailList.spec.tsx
@@ -2,17 +2,20 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Redirect } from 'react-router';
 import { ALL_NAMESPACES_KEY } from '@console/shared';
-import { AllProjectsDetailList } from '../AllProjectsDetailList';
+import * as hooks from '@console/shared/src/hooks';
+import AllProjectsDetailList from '../AllProjectsDetailList';
 
 describe('AllProjectsDetailList', () => {
   it('expect AllProjectsDetailList to render redirect when an active namespace is present', () => {
-    const component = shallow(<AllProjectsDetailList activeNamespace="test-namespace" />);
+    jest.spyOn(hooks, 'useActiveNamespace').mockReturnValue('test-namespace');
+    const component = shallow(<AllProjectsDetailList />);
 
     expect(component.find(Redirect).exists()).toBe(true);
   });
 
   it('expect AllProjectDetailsList to not render a redirect when in the all-projects namespace', () => {
-    const component = shallow(<AllProjectsDetailList activeNamespace={ALL_NAMESPACES_KEY} />);
+    jest.spyOn(hooks, 'useActiveNamespace').mockReturnValue(ALL_NAMESPACES_KEY);
+    const component = shallow(<AllProjectsDetailList />);
 
     expect(component.find(Redirect).exists()).not.toBe(true);
   });

--- a/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
@@ -3,24 +3,28 @@ import { shallow } from 'enzyme';
 import { Redirect } from 'react-router';
 import { ALL_NAMESPACES_KEY } from '@console/shared';
 import { BreadCrumbs } from '@console/internal/components/utils';
-import { ProjectDetailsPage } from '../ProjectDetailsPage';
+import ProjectDetailsPage from '../ProjectDetailsPage';
+import * as hooks from '@console/shared/src/hooks';
 
 describe('ProjectDetailsPage', () => {
   it('expect ProjectDetailsPage to render a redirect when in the all-projects namespace', () => {
-    const component = shallow(<ProjectDetailsPage activeNamespace={ALL_NAMESPACES_KEY} />);
+    jest.spyOn(hooks, 'useActiveNamespace').mockReturnValue(ALL_NAMESPACES_KEY);
+    const component = shallow(<ProjectDetailsPage />);
 
     expect(component.find(Redirect).exists()).toBe(true);
   });
 
   it('expect ProjectDetailsPage to not render a redirect when a namespace is provided', () => {
-    const component = shallow(<ProjectDetailsPage activeNamespace="test-project" />);
+    jest.spyOn(hooks, 'useActiveNamespace').mockReturnValue('test-project');
+    const component = shallow(<ProjectDetailsPage />);
 
     expect(component.find(Redirect).exists()).not.toBe(true);
   });
 
   it('expect ProjectDetailsPage not to render breadcrumbs', () => {
+    jest.spyOn(hooks, 'useActiveNamespace').mockReturnValue('test-project');
     // Currently rendering the breadcrumbs will buck-up against the redirects and not work as expected
-    const component = shallow(<ProjectDetailsPage activeNamespace="test-project" />);
+    const component = shallow(<ProjectDetailsPage />);
 
     expect(component.find(BreadCrumbs).exists()).not.toBe(true);
   });

--- a/frontend/packages/dev-console/src/components/projects/details/utils.ts
+++ b/frontend/packages/dev-console/src/components/projects/details/utils.ts
@@ -1,14 +1,3 @@
-import { connect } from 'react-redux';
-import { getActiveNamespace } from '@console/internal/reducers/ui';
-import { RootState } from '@console/internal/redux';
-
 export const PROJECT_LIST_URI = '/k8s/cluster/projects';
 
 export const redirectURI = (ns) => `${PROJECT_LIST_URI}/${ns}`;
-
-export const useActiveNamespace = (Component) =>
-  connect((state: RootState) => ({ activeNamespace: getActiveNamespace(state) }))(Component);
-
-export type UseActiveNamespaceProps = {
-  activeNamespace: string;
-};

--- a/frontend/packages/dev-console/src/components/topology/application-panel/ApplicationGroupResource.tsx
+++ b/frontend/packages/dev-console/src/components/topology/application-panel/ApplicationGroupResource.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Link } from 'react-router-dom';
+import { useActiveNamespace } from '@console/shared/src/hooks';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { SidebarSectionHeading } from '@console/internal/components/utils';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import TopologyApplicationResourceList from './TopologyApplicationList';
 
 const MAX_RESOURCES = 5;
@@ -18,14 +18,15 @@ const ApplicationGroupResource: React.FC<ApplicationGroupResourceProps> = ({
   title,
   resourcesData,
   group,
-}) =>
-  !_.isEmpty(resourcesData) ? (
+}) => {
+  const activeNamespace = useActiveNamespace();
+  return !_.isEmpty(resourcesData) ? (
     <div className="overview__sidebar-pane-body">
       <SidebarSectionHeading text={title}>
         {_.size(resourcesData) > MAX_RESOURCES && (
           <Link
             className="sidebar__section-view-all"
-            to={`/search/ns/${getActiveNamespace()}?kind=${referenceFor(
+            to={`/search/ns/${activeNamespace}?kind=${referenceFor(
               resourcesData[0],
             )}&q=${encodeURIComponent(`app.kubernetes.io/part-of=${group}`)}`}
           >
@@ -36,5 +37,6 @@ const ApplicationGroupResource: React.FC<ApplicationGroupResourceProps> = ({
       <TopologyApplicationResourceList resources={_.take(resourcesData, MAX_RESOURCES)} />
     </div>
   ) : null;
+};
 
 export default ApplicationGroupResource;

--- a/frontend/packages/dev-console/src/components/topology/application-panel/__tests__/ApplicationGroupResource.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/application-panel/__tests__/ApplicationGroupResource.spec.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Link } from 'react-router-dom';
+import * as hooks from '@console/shared/src/hooks';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import TopologyApplicationResourceList from '../TopologyApplicationList';
 import ApplicationGroupResource from '../ApplicationGroupResource';
 import { sampleDeployments } from '../../__tests__/topology-test-data';
 
 describe(ApplicationGroupResource.displayName, () => {
+  beforeEach(() => {
+    jest.spyOn(hooks, 'useActiveNamespace').mockReturnValue('default');
+  });
   it('should component exists', () => {
     const wrapper = shallow(
       <ApplicationGroupResource

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewList.spec.tsx
@@ -10,6 +10,7 @@ import RevisionsOverviewListItem from '../RevisionsOverviewListItem';
 describe('RevisionsOverviewList', () => {
   let wrapper: ShallowWrapper<RevisionsOverviewListProps>;
   beforeEach(() => {
+    jest.spyOn(utils, 'useAccessReview').mockReturnValue(true);
     wrapper = shallow(
       <RevisionsOverviewList
         revisions={MockKnativeResources.revisions.data}
@@ -29,8 +30,6 @@ describe('RevisionsOverviewList', () => {
   });
 
   it('should show info if no Revisions present and traffic split sshould button should be disabled', () => {
-    const spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
-    spyUseAccessReview.mockReturnValue(true);
     wrapper = shallow(
       <RevisionsOverviewList revisions={[]} service={MockKnativeResources.revisions.data[0]} />,
     );
@@ -45,8 +44,6 @@ describe('RevisionsOverviewList', () => {
   });
 
   it('should have button for traffic distribution and enabled', () => {
-    const spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
-    spyUseAccessReview.mockReturnValue(true);
     expect(wrapper.find(Button)).toHaveLength(1);
     expect(
       wrapper
@@ -70,8 +67,7 @@ describe('RevisionsOverviewList', () => {
   });
 
   it('should not show button for traffic distribution if access is not there', () => {
-    const spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
-    spyUseAccessReview.mockReturnValue(false);
+    jest.spyOn(utils, 'useAccessReview').mockReturnValue(false);
     wrapper = shallow(
       <RevisionsOverviewList
         revisions={MockKnativeResources.revisions.data}

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -7,7 +7,6 @@ import { sortable } from '@patternfly/react-table';
 import { Helmet } from 'react-helmet';
 import { AddCircleOIcon } from '@patternfly/react-icons';
 import { Alert, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react-core';
-import * as UIActions from '@console/internal/actions/ui';
 import {
   ALL_NAMESPACES_KEY,
   ErrorStatus,
@@ -18,6 +17,7 @@ import {
   getNamespace,
   getUID,
 } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks';
 import {
   DetailsPage,
   Table,
@@ -415,7 +415,7 @@ export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps
   catalogSources,
   ...rest
 }) => {
-  const ns = UIActions.getActiveNamespace();
+  const ns = useActiveNamespace();
   const noDataDetail = (
     <>
       <div>

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -12,12 +12,13 @@ import {
   withHandlePromise,
 } from '@console/internal/components/utils';
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { YellowExclamationTriangleIcon } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks';
 import { SubscriptionKind } from '../../types';
 import { ClusterServiceVersionModel, SubscriptionModel } from '../../models';
 
 export const UninstallOperatorModal = withHandlePromise((props: UninstallOperatorModalProps) => {
+  const activeNamespace = useActiveNamespace();
   const submit = (event) => {
     event.preventDefault();
 
@@ -52,7 +53,7 @@ export const UninstallOperatorModal = withHandlePromise((props: UninstallOperato
           window.location.pathname.split('/').includes(subscription.metadata.name) ||
           window.location.pathname.split('/').includes(subscription.status.installedCSV)
         ) {
-          history.push(resourceListPathFromModel(ClusterServiceVersionModel, getActiveNamespace()));
+          history.push(resourceListPathFromModel(ClusterServiceVersionModel, activeNamespace));
         }
       })
       .catch(_.noop);

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Link } from 'react-router-dom';
+import { useActiveNamespace } from '@console/shared/src/hooks';
 import { MsgBox } from '@console/internal/components/utils/status-box';
 import {
   K8sResourceKind,
@@ -9,7 +10,6 @@ import {
   referenceForGroupVersionKind,
 } from '@console/internal/module/k8s';
 import { AsyncComponent } from '@console/internal/components/utils/async';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { OperatorGroupModel } from '../models';
 import { OperatorGroupKind, SubscriptionKind, InstallModeType } from '../types';
 
@@ -20,20 +20,23 @@ export const operatorNamespaceFor = (obj: K8sResourceKind) =>
 export const operatorGroupFor = (obj: K8sResourceKind) =>
   _.get(obj, ['metadata', 'annotations', 'olm.operatorGroup']);
 
-export const NoOperatorGroupMsg: React.SFC = () => (
-  <MsgBox
-    title="Namespace Not Enabled"
-    detail={
-      <p>
-        The Operator Lifecycle Manager will not watch this namespace because it is not configured
-        with an OperatorGroup.{' '}
-        <Link to={`/ns/${getActiveNamespace()}/${referenceForModel(OperatorGroupModel)}/~new`}>
-          Create one here.
-        </Link>
-      </p>
-    }
-  />
-);
+export const NoOperatorGroupMsg: React.SFC = () => {
+  const activeNamespace = useActiveNamespace();
+  return (
+    <MsgBox
+      title="Namespace Not Enabled"
+      detail={
+        <p>
+          The Operator Lifecycle Manager will not watch this namespace because it is not configured
+          with an OperatorGroup.{' '}
+          <Link to={`/ns/${activeNamespace}/${referenceForModel(OperatorGroupModel)}/~new`}>
+            Create one here.
+          </Link>
+        </p>
+      }
+    />
+  );
+};
 
 type RequireOperatorGroupProps = {
   operatorGroup: { loaded: boolean; data?: OperatorGroupKind[] };

--- a/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.tsx
@@ -6,8 +6,8 @@ import { Button } from '@patternfly/react-core';
 import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
 import { StatusBox, MsgBox } from '@console/internal/components/utils';
 import { MultiListPage, Table, TableRow, TableData } from '@console/internal/components/factory';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { ALL_NAMESPACES_KEY, OPERATOR_HUB_LABEL } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks';
 import {
   PackageManifestModel,
   SubscriptionModel,
@@ -56,7 +56,7 @@ export const PackageManifestTableRow: React.SFC<PackageManifestTableRowProps> = 
     key,
     style,
   } = props;
-  const ns = getActiveNamespace();
+  const ns = useActiveNamespace();
   const channel = !_.isEmpty(obj.status.defaultChannel)
     ? obj.status.channels.find((ch) => ch.name === obj.status.defaultChannel)
     : obj.status.channels[0];
@@ -121,6 +121,7 @@ export const PackageManifestList = requireOperatorGroup((props: PackageManifestL
       }),
     new Map<string, CatalogSourceInfo>(),
   );
+  const activeNamespace = useActiveNamespace();
 
   return (
     <StatusBox
@@ -176,7 +177,7 @@ export const PackageManifestList = requireOperatorGroup((props: PackageManifestL
                   props.canSubscribe &&
                   !installedFor(props.subscription.data)(props.operatorGroup.data)(
                     rowProps.obj.status.packageName,
-                  )(getActiveNamespace()) &&
+                  )(activeNamespace) &&
                   props.operatorGroup.data
                     .filter(
                       (og) =>

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -6,6 +6,7 @@ import * as classNames from 'classnames';
 import { ActionGroup, Button } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import { FLAGS } from '@console/shared/src/constants';
+import { useActiveNamespace } from '@console/shared/src/hooks';
 import { ClusterRoleBindingModel } from '../../models';
 import { getQN, k8sCreate, k8sPatch, referenceFor } from '../../module/k8s';
 import * as UIActions from '../../actions/ui';
@@ -628,7 +629,7 @@ export const CreateRoleBinding = ({ match: { params }, location }) => {
   const searchParams = new URLSearchParams(location.search);
   const roleKind = searchParams.get('rolekind');
   const roleName = searchParams.get('rolename');
-  const metadata = { namespace: UIActions.getActiveNamespace() };
+  const metadata = { namespace: useActiveNamespace() };
   const clusterAllowed = useAccessReview({
     group: ClusterRoleBindingModel.apiGroup,
     resource: ClusterRoleBindingModel.plural,

--- a/frontend/public/components/utils/rbac.tsx
+++ b/frontend/public/components/utils/rbac.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 

--- a/frontend/public/components/utils/rbac.tsx
+++ b/frontend/public/components/utils/rbac.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore: FIXME missing exports due to out-of-sync @types/react-redux version
 import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
 import { getName, getNamespace } from '@console/shared';
+import { useActiveNamespace } from '@console/shared/src/hooks';
 
 import store from '../../redux';
 import { impersonateStateToProps } from '../../reducers/ui';
@@ -99,8 +102,9 @@ export const useAccessReview = (
     subresource = '',
     verb = '' as K8sVerb,
     name = '',
-    namespace = '',
   } = resourceAttributes;
+  const activeNamespace = useActiveNamespace();
+  const namespace = resourceAttributes.namespace || activeNamespace || '';
   const impersonateKey = getImpersonateKey(impersonate);
   React.useEffect(() => {
     checkAccessInternal(group, resource, subresource, verb, name, namespace, impersonateKey)


### PR DESCRIPTION
- Replace `useActiveNamespace` HOC with `useActiveNamespace` hook
- Update `useAccessReview` hook to use `useActiveNamespace` hook as a namespace default
- Replace `getActiveNamespace` (from public/actions/ui.ts) with `useActiveNamespace` hook to avoid accessing the redux store directly

Next step (separate PR):
- move 'getActiveNamespace' redux selector from 'public/reducers/ui.ts into @console/shared
- remove `getActiveNamespace` from `public/actions/ui.ts` and avoid importing store there