### PR TITLE
Bug 1793893: Make clear what uninstalling an operator that works for all namespaces does

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -58,6 +58,15 @@ export const UninstallOperatorModal = withHandlePromise((props: UninstallOperato
       .catch(_.noop);
   };
 
+  const context =
+    props.subscription.metadata.namespace === 'openshift-operators' ? (
+      <strong>all namespaces</strong>
+    ) : (
+      <>
+        the <i>{props.subscription.metadata.namespace}</i> namespace
+      </>
+    );
+
   return (
     <form onSubmit={submit} name="form" className="modal-content co-catalog-install-modal">
       <ModalTitle className="modal-header">Uninstall Operator?</ModalTitle>
@@ -67,9 +76,8 @@ export const UninstallOperatorModal = withHandlePromise((props: UninstallOperato
           <div>
             <p className="lead">Uninstall {props.displayName || props.subscription.spec.name}?</p>
             <div>
-              This will remove the operator from <i>{props.subscription.metadata.namespace}</i>.
-              Your application will keep running, but it will no longer receive updates or
-              configuration changes.
+              This will remove the operator from {context}. Your application will keep running, but
+              it will no longer receive updates or configuration changes.
             </div>
           </div>
         </div>


### PR DESCRIPTION
When a operator with and `AllNamespaces` install mode, which is installed into `openshift-operators` is uninstalled from any of the installed namespaces, we should inform about the fact that it will be uninstalled from all the namespaces, not just that one particular:

<img width="504" alt="Screenshot 2020-01-31 at 12 42 04" src="https://user-images.githubusercontent.com/1668218/73537557-06ffd980-4429-11ea-8409-8cf543e805c7.png">

In case the operator is installed just to a single namespace we will show the original message: 

<img width="517" alt="Screenshot 2020-01-31 at 12 42 19" src="https://user-images.githubusercontent.com/1668218/73537607-2b5bb600-4429-11ea-9724-73518640f930.png">


/assign @spadgett 