### PR TITLE
Bug 1797587: Align the Helm Release Details page with latest UX designs

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseResourceTableHeader.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseResourceTableHeader.tsx
@@ -2,9 +2,9 @@ import { sortable } from '@patternfly/react-table';
 
 export const tableColumnClasses = {
   name: 'col-lg-4 col-md-4 col-sm-4 col-xs-6',
-  kind: 'col-lg-2 col-md-2 col-sm-4 col-xs-6',
+  type: 'col-lg-2 col-md-2 col-sm-4 col-xs-6',
   status: 'col-lg-2 col-md-3 col-sm-4 hidden-xs',
-  timestamp: 'col-lg-4 col-md-4 hidden-sm hidden-xs',
+  created: 'col-lg-4 col-md-3 hidden-sm hidden-xs',
 };
 
 const HelmReleaseResourceTableHeader = () => {
@@ -16,10 +16,10 @@ const HelmReleaseResourceTableHeader = () => {
       props: { className: tableColumnClasses.name },
     },
     {
-      title: 'Kind',
+      title: 'Type',
       sortField: 'kind',
       transforms: [sortable],
-      props: { className: tableColumnClasses.kind },
+      props: { className: tableColumnClasses.type },
     },
     {
       title: 'Status',
@@ -28,10 +28,10 @@ const HelmReleaseResourceTableHeader = () => {
       props: { className: tableColumnClasses.status },
     },
     {
-      title: 'Timestamp',
+      title: 'Created',
       sortField: 'metadata.creationTimestamp',
       transforms: [sortable],
-      props: { className: tableColumnClasses.timestamp },
+      props: { className: tableColumnClasses.created },
     },
   ];
 };

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseResourceTableRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseResourceTableRow.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import { Link } from 'react-router-dom';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { Status } from '@console/shared';
-import { ResourceLink, Timestamp } from '@console/internal/components/utils';
+import { ResourceLink, Timestamp, resourcePath } from '@console/internal/components/utils';
 import { TableData, TableRow } from '@console/internal/components/factory';
 import { tableColumnClasses } from './HelmReleaseResourceTableHeader';
 
@@ -19,6 +20,20 @@ const HelmReleaseResourceTableRow: React.FC<HelmResourceTableRowProps> = ({
   key,
   style,
 }) => {
+  const status = resource.status?.replicas ? (
+    <Link
+      to={`${resourcePath(
+        resource.kind,
+        resource.metadata.name,
+        resource.metadata.namespace,
+      )}/pods`}
+      title="pods"
+    >
+      {resource.status.replicas || 0} of {resource.spec.replicas} pods
+    </Link>
+  ) : (
+    <Status status={_.get(resource.status, 'phase', 'Created')} />
+  );
   return (
     <TableRow id={resource.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses.name}>
@@ -28,11 +43,9 @@ const HelmReleaseResourceTableRow: React.FC<HelmResourceTableRowProps> = ({
           namespace={resource.metadata.namespace}
         />
       </TableData>
-      <TableData className={tableColumnClasses.kind}>{resource.kind}</TableData>
-      <TableData className={tableColumnClasses.status}>
-        <Status status={_.get(resource.status, 'phase', 'Created')} />
-      </TableData>
-      <TableData className={tableColumnClasses.timestamp}>
+      <TableData className={tableColumnClasses.type}>{resource.kind}</TableData>
+      <TableData className={tableColumnClasses.status}>{status}</TableData>
+      <TableData className={tableColumnClasses.created}>
         <Timestamp timestamp={resource.metadata.creationTimestamp} />
       </TableData>
     </TableRow>

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseResources.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseResources.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { MultiListPage } from '@console/internal/components/factory';
-import { K8sResourceKind, kindForReference } from '@console/internal/module/k8s';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { DeploymentModel, StatefulSetModel, PodModel, SecretModel } from '@console/internal/models';
 import HelmResourcesListComponent from './HelmResourcesListComponent';
-import { flattenResources, helmReleaseResourceKindFilter } from './helm-release-resources-utils';
+import { flattenResources } from './helm-release-resources-utils';
 import { ServiceModel } from '../../../../knative-plugin/src/models';
 
 export interface HelmReleaseResourcesProps {
@@ -49,18 +49,6 @@ const HelmReleaseResources: React.FC<HelmReleaseResourcesProps> = ({ obj: resour
     <MultiListPage
       filterLabel={'Resources by name'}
       resources={resources}
-      rowFilters={[
-        {
-          type: 'helmrelease-resource-kind',
-          selected: resources.map(({ kind }) => kindForReference(kind)),
-          reducer: ({ kind }) => kindForReference(kind),
-          items: resources.map(({ kind }) => ({
-            id: kindForReference(kind),
-            title: kindForReference(kind),
-          })),
-          filter: helmReleaseResourceKindFilter,
-        },
-      ]}
       flatten={flattenResources}
       label="Resources"
       namespace={namespace}

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseRow.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { Status } from '@console/shared';
 import { TableRow, TableData } from '@console/internal/components/factory';
 import { Timestamp } from '@console/internal/components/utils';
@@ -30,7 +31,7 @@ const HelmReleaseRow: React.FC<HelmReleaseRowProps> = ({ obj, index, key, style 
         <Timestamp timestamp={obj.info.last_deployed} />
       </TableData>
       <TableData className={tableColumnClasses.status}>
-        <Status status={obj.info.status} />
+        <Status status={_.capitalize(obj.info.status)} />
       </TableData>
       <TableData className={tableColumnClasses.chartName}>{obj.chart.metadata.name}</TableData>
       <TableData className={tableColumnClasses.appVersion}>

--- a/frontend/packages/dev-console/src/components/helm/HelmResourcesListComponent.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmResourcesListComponent.tsx
@@ -6,17 +6,16 @@ import HelmReleaseResourceTableRow from './HelmReleaseResourceTableRow';
 
 const EmptyMsg = () => <MsgBox title="No Resources Found" />;
 
-const HelmResourcesListComponent: React.FC<TableProps> = (props) => {
-  return (
-    <Table
-      {...props}
-      aria-label="Resources"
-      Header={HelmReleaseResourceTableHeader}
-      Row={HelmReleaseResourceTableRow}
-      EmptyMsg={EmptyMsg}
-      virtualize
-    />
-  );
-};
+const HelmResourcesListComponent: React.FC<TableProps> = (props) => (
+  <Table
+    {...props}
+    aria-label="Resources"
+    defaultSortField="kind"
+    Header={HelmReleaseResourceTableHeader}
+    Row={HelmReleaseResourceTableRow}
+    EmptyMsg={EmptyMsg}
+    virtualize
+  />
+);
 
 export default HelmResourcesListComponent;

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResourceTableRow.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResourceTableRow.spec.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { Link } from 'react-router-dom';
+import { Status } from '@console/shared';
 import { TableRow } from '@console/internal/components/factory';
 import HelmReleaseResourceTableRow from '../HelmReleaseResourceTableRow';
-import { tableColumnClasses } from '../HelmReleaseResourceTableHeader';
 
 let helmReleaseResourceTableRowProps: React.ComponentProps<typeof HelmReleaseResourceTableRow>;
 
@@ -14,42 +15,31 @@ describe('HelmReleaseResourceTableRow', () => {
         creationTimestamp: '2020-01-20T05:37:13Z',
         name: 'sh.helm.release.v1.helm-mysql.v1',
         namespace: 'deb',
-        labels: {
-          name: 'helm-mysql',
-        },
       },
     },
     index: 1,
     style: {},
   };
-  const helmReleaseResourcesTableRow = shallow(
-    <HelmReleaseResourceTableRow {...helmReleaseResourceTableRowProps} />,
-  );
+
   it('should render the TableRow component', () => {
-    expect(helmReleaseResourcesTableRow.find(TableRow).exists()).toBe(true);
-    expect(
-      helmReleaseResourcesTableRow
-        .find(TableRow)
-        .childAt(0)
-        .hasClass(tableColumnClasses.name),
-    ).toBe(true);
-    expect(
-      helmReleaseResourcesTableRow
-        .find(TableRow)
-        .childAt(1)
-        .hasClass(tableColumnClasses.kind),
-    ).toBe(true);
-    expect(
-      helmReleaseResourcesTableRow
-        .find(TableRow)
-        .childAt(2)
-        .hasClass(tableColumnClasses.status),
-    ).toBe(true);
-    expect(
-      helmReleaseResourcesTableRow
-        .find(TableRow)
-        .childAt(3)
-        .hasClass(tableColumnClasses.timestamp),
-    ).toBe(true);
+    const helmReleaseResourceTableRow = shallow(
+      <HelmReleaseResourceTableRow {...helmReleaseResourceTableRowProps} />,
+    );
+    expect(helmReleaseResourceTableRow.find(TableRow).exists()).toBe(true);
+  });
+  it('should render the number of pods deployed for resources that support it', () => {
+    const helmReleaseResourceTableRow = shallow(
+      <HelmReleaseResourceTableRow {...helmReleaseResourceTableRowProps} />,
+    );
+    expect(helmReleaseResourceTableRow.find(Status).exists()).toBe(true);
+    expect(helmReleaseResourceTableRow.find(Status).props().status).toEqual('Created');
+    helmReleaseResourceTableRowProps.obj.kind = 'Deployment';
+    helmReleaseResourceTableRowProps.obj.spec = { replicas: 1 };
+    helmReleaseResourceTableRowProps.obj.status = { replicas: 1 };
+    const helmReleaseResourcesTableRow = shallow(
+      <HelmReleaseResourceTableRow {...helmReleaseResourceTableRowProps} />,
+    );
+    expect(helmReleaseResourcesTableRow.find(Link).exists()).toBe(true);
+    expect(helmReleaseResourcesTableRow.find(Link).props().title).toEqual('pods');
   });
 });

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResources.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResources.spec.tsx
@@ -24,17 +24,4 @@ describe('HelmReleaseResources', () => {
   it('should render the MultiListPage component', () => {
     expect(helmReleaseResources.find(MultiListPage).exists()).toBe(true);
   });
-  it('should render the proper row filters', () => {
-    const expectedHelmReleaseResourcesRowFilters: string[] = [
-      'Deployment',
-      'Service',
-      'StatefulSet',
-      'Pod',
-      'Secret',
-    ];
-    const helmReleaseResourcesRowFilters = helmReleaseResources
-      .find(MultiListPage)
-      .prop('rowFilters')[0].selected;
-    expect(helmReleaseResourcesRowFilters).toEqual(expectedHelmReleaseResourcesRowFilters);
-  });
 });

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmResourcesListComponent.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmResourcesListComponent.spec.tsx
@@ -21,7 +21,7 @@ describe('HelmResourcesListComponent', () => {
     expect(helmResourcesListComponent.find(Table).exists()).toBe(true);
   });
   it('should render the proper Headers in the Resources tab', () => {
-    const expectedHelmResourcesPageHeader: string[] = ['Name', 'Kind', 'Status', 'Timestamp'];
+    const expectedHelmResourcesPageHeader: string[] = ['Name', 'Type', 'Status', 'Created'];
 
     const headers = helmResourcesListComponent
       .find(Table)

--- a/frontend/packages/dev-console/src/components/helm/helm-release-resources-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-release-resources-utils.ts
@@ -1,15 +1,4 @@
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { TableFilter, TableFilterGroups } from '@console/internal/components/factory/table-filters';
-
-export const helmReleaseResourceKindFilter: TableFilter = (
-  filters: TableFilterGroups,
-  resource: K8sResourceKind,
-) => {
-  if (!filters || !filters.selected || !filters.selected.size) {
-    return true;
-  }
-  return filters.selected.has(resource.kind);
-};
 
 export const flattenResources = (resources: { [kind: string]: { data: K8sResourceKind[] } }) =>
   Object.keys(resources).reduce(


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2910

**Solution Description**: 
- changed column names `Kind` --> `Type` & `Timestamp` --> `Created`
- Type` is sorted by default
- Capitalized the Release status
- added the no of pods deployed, under the Status column in the Resources tab, for resources that support it
- removed the row filters
- fixed the test cases

**Screenshots for design review**: 
![Screenshot from 2020-02-05 11-44-37](https://user-images.githubusercontent.com/22490998/73817840-ffb64280-4811-11ea-8520-44f69640e2c9.png)
![Screenshot from 2020-02-05 11-43-53](https://user-images.githubusercontent.com/22490998/73817849-05ac2380-4812-11ea-9549-7caa90be04e0.png)


**Test setup:**
Installation of Helm charts is required to see the listings in the Helm Releases page

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

/kind bug