### PR TITLE
Bug 1796902: Fix for right click on graph when no workloads

### DIFF
--- a/frontend/packages/dev-console/src/actions/add-resources.tsx
+++ b/frontend/packages/dev-console/src/actions/add-resources.tsx
@@ -9,31 +9,40 @@ import {
 import { ImportOptions } from '../components/import/import-types';
 import { KebabAction, createKebabAction } from '../utils/add-resources-menu-utils';
 
-export const fromGit = createKebabAction('From Git', <GitAltIcon />, ImportOptions.GIT);
+export const allImportResourceAccess = 'allImportResourceAccess';
+export const allCatalogImageResourceAccess = 'allCatalogImageResourceAccess';
+
+export const fromGit = createKebabAction(
+  'From Git',
+  <GitAltIcon />,
+  ImportOptions.GIT,
+  allImportResourceAccess,
+);
 
 export const containerImage = createKebabAction(
   'Container Image',
   <OsImageIcon />,
   ImportOptions.CONTAINER,
+  allCatalogImageResourceAccess,
 );
 
 export const fromCatalog = createKebabAction(
   'From Catalog',
   <CatalogIcon />,
   ImportOptions.CATALOG,
-  false,
 );
+
 export const fromDockerfile = createKebabAction(
   'From Dockerfile',
   <CubeIcon />,
   ImportOptions.DOCKERFILE,
+  allImportResourceAccess,
 );
 
 export const fromDatabaseCatalog = createKebabAction(
   'Database',
   <DatabaseIcon />,
   ImportOptions.DATABASE,
-  false,
 );
 
 export const addResourceMenu: KebabAction[] = [

--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -2,21 +2,13 @@ import * as React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
 import { CatalogTile } from '@patternfly/react-catalog-view-extension';
 import { connect } from 'react-redux';
-import { history, PageHeading, useAccessReview } from '@console/internal/components/utils';
+import { history, PageHeading } from '@console/internal/components/utils';
 import { formatNamespacedRouteForResource } from '@console/shared/src/utils/namespace';
-import {
-  BuildConfigModel,
-  ImageStreamModel,
-  DeploymentConfigModel,
-  ImageStreamImportsModel,
-  SecretModel,
-  RouteModel,
-  ServiceModel,
-} from '@console/internal/models';
-import { AccessReviewResourceAttributes, K8sKind } from '@console/internal/module/k8s';
 import * as importGitIcon from '../images/from-git.svg';
 import * as yamlIcon from '../images/yaml.svg';
 import * as dockerfileIcon from '../images/dockerfile.svg';
+import { useAddToProjectAccess } from '../utils/useAddToProjectAccess';
+import { allCatalogImageResourceAccess, allImportResourceAccess } from '../actions/add-resources';
 import './EmptyState.scss';
 
 interface StateProps {
@@ -35,41 +27,12 @@ const navigateTo = (e: React.SyntheticEvent, url: string) => {
   e.preventDefault();
 };
 
-const resourceAttributes = (model: K8sKind, namespace: string): AccessReviewResourceAttributes => {
-  return {
-    group: model.apiGroup || '',
-    resource: model.plural,
-    namespace,
-    verb: 'create',
-  };
-};
-
 const ODCEmptyState: React.FC<Props> = ({
   title,
   activeNamespace,
   hintBlock = 'Select a way to create an application, component or service from one of the options.',
 }) => {
-  const buildConfigsAccess = useAccessReview(resourceAttributes(BuildConfigModel, activeNamespace));
-  const imageStreamAccess = useAccessReview(resourceAttributes(ImageStreamModel, activeNamespace));
-  const deploymentConfigAccess = useAccessReview(
-    resourceAttributes(DeploymentConfigModel, activeNamespace),
-  );
-  const imageStreamImportAccess = useAccessReview(
-    resourceAttributes(ImageStreamImportsModel, activeNamespace),
-  );
-  const secretAccess = useAccessReview(resourceAttributes(SecretModel, activeNamespace));
-  const routeAccess = useAccessReview(resourceAttributes(RouteModel, activeNamespace));
-  const serviceAccess = useAccessReview(resourceAttributes(ServiceModel, activeNamespace));
-
-  const allImportResourceAccess =
-    buildConfigsAccess &&
-    imageStreamAccess &&
-    deploymentConfigAccess &&
-    secretAccess &&
-    routeAccess &&
-    serviceAccess;
-
-  const allCatalogImageResourceAccess = allImportResourceAccess && imageStreamImportAccess;
+  const createResourceAccess: string[] = useAddToProjectAccess(activeNamespace);
 
   return (
     <>
@@ -83,7 +46,7 @@ const ODCEmptyState: React.FC<Props> = ({
       </div>
       <div className="odc-empty-state__content">
         <Gallery gutter="sm">
-          {allImportResourceAccess && (
+          {createResourceAccess.includes(allImportResourceAccess) && (
             <GalleryItem key="gallery-fromgit">
               <CatalogTile
                 className="odc-empty-state__tile"
@@ -96,7 +59,7 @@ const ODCEmptyState: React.FC<Props> = ({
               />
             </GalleryItem>
           )}
-          {allCatalogImageResourceAccess && (
+          {createResourceAccess.includes(allCatalogImageResourceAccess) && (
             <GalleryItem key="gallery-container">
               <CatalogTile
                 className="odc-empty-state__tile"
@@ -120,7 +83,7 @@ const ODCEmptyState: React.FC<Props> = ({
               description="Browse the catalog to discover, deploy and connect to services"
             />
           </GalleryItem>
-          {allImportResourceAccess && (
+          {createResourceAccess.includes(allImportResourceAccess) && (
             <GalleryItem key="gallery-dockerfile">
               <CatalogTile
                 className="odc-empty-state__tile"

--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -22,7 +22,7 @@ import {
 import { RootState } from '@console/internal/redux';
 import { TopologyIcon } from '@patternfly/react-icons';
 import TopologySideBar from './TopologySideBar';
-import { TopologyDataModel, TopologyDataObject } from './topology-types';
+import { GraphData, TopologyDataModel, TopologyDataObject } from './topology-types';
 import TopologyResourcePanel from './TopologyResourcePanel';
 import TopologyApplicationPanel from './application-panel/TopologyApplicationPanel';
 import ConnectedTopologyEdgePanel from './TopologyEdgePanel';
@@ -33,10 +33,13 @@ import { TYPE_APPLICATION_GROUP, TYPE_HELM_RELEASE, TYPE_OPERATOR_BACKED_SERVICE
 import TopologyFilterBar from './filters/TopologyFilterBar';
 import { getTopologyFilters, TopologyFilters } from './filters/filter-utils';
 import TopologyHelmReleasePanel from './TopologyHelmReleasePanel';
+import { useAddToProjectAccess } from '../../utils/useAddToProjectAccess';
 
 interface StateProps {
   filters: TopologyFilters;
+  activeNamespace: string;
 }
+
 export interface TopologyProps extends StateProps {
   data: TopologyDataModel;
   serviceBinding: boolean;
@@ -50,12 +53,14 @@ const graphModel: Model = {
   },
 };
 
-const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters }) => {
+const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters, activeNamespace }) => {
   const visRef = React.useRef<Visualization | null>(null);
   const componentFactoryRef = React.useRef<ComponentFactory | null>(null);
   const [layout, setLayout] = React.useState<string>(graphModel.graph.layout);
   const [model, setModel] = React.useState<Model>();
+  const [graphData, setGraphData] = React.useState<GraphData>();
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
+  const createResourceAccess: string[] = useAddToProjectAccess(activeNamespace);
 
   if (!componentFactoryRef.current) {
     componentFactoryRef.current = new ComponentFactory(serviceBinding);
@@ -75,6 +80,15 @@ const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters }) =>
     });
     visRef.current.fromModel(graphModel);
   }
+
+  React.useEffect(() => {
+    const newGraphData: GraphData = {
+      createResourceAccess,
+      namespace: activeNamespace,
+    };
+    visRef.current.getGraph().setData(newGraphData);
+    setGraphData(newGraphData);
+  }, [activeNamespace, createResourceAccess]);
 
   React.useEffect(() => {
     componentFactoryRef.current.serviceBinding = serviceBinding;
@@ -189,6 +203,7 @@ const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters }) =>
       if (selectedEntity.getType() === TYPE_APPLICATION_GROUP) {
         return (
           <TopologyApplicationPanel
+            graphData={graphData}
             application={{
               id: selectedEntity.getId(),
               name: selectedEntity.getLabel(),
@@ -246,8 +261,10 @@ const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters }) =>
 };
 
 const TopologyStateToProps = (state: RootState): StateProps => {
-  const filters = getTopologyFilters(state);
-  return { filters };
+  return {
+    filters: getTopologyFilters(state),
+    activeNamespace: state.UI.get('activeNamespace'),
+  };
 };
 
 export default connect(TopologyStateToProps)(Topology);

--- a/frontend/packages/dev-console/src/components/topology/actions/__tests__/graphActions.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/actions/__tests__/graphActions.spec.tsx
@@ -1,0 +1,35 @@
+import {
+  allCatalogImageResourceAccess,
+  allImportResourceAccess,
+} from '../../../../actions/add-resources';
+import { GraphData } from '../../topology-types';
+import { graphActions } from '../graphActions';
+
+describe('graphActions: ', () => {
+  it('should return the correct menu items when all permissions are allowed', () => {
+    const graphData: GraphData = {
+      namespace: 'namespace',
+      createResourceAccess: [allCatalogImageResourceAccess, allImportResourceAccess],
+    };
+    const actions = graphActions(graphData);
+    expect(actions.length).toBe(5);
+  });
+
+  it('should return the correct menu items when all only import resources are allowed', () => {
+    const graphData: GraphData = {
+      namespace: 'namespace',
+      createResourceAccess: [allImportResourceAccess],
+    };
+    const actions = graphActions(graphData);
+    expect(actions.length).toBe(4);
+  });
+
+  it('should return the correct menu items when minimal resources are allowed', () => {
+    const graphData: GraphData = {
+      namespace: 'namespace',
+      createResourceAccess: [],
+    };
+    const actions = graphActions(graphData);
+    expect(actions.length).toBe(2);
+  });
+});

--- a/frontend/packages/dev-console/src/components/topology/actions/graphActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/graphActions.ts
@@ -1,28 +1,24 @@
 import * as _ from 'lodash';
-import { KebabOption } from '@console/internal/components/utils/kebab';
-import { GraphElement, Node } from '@console/topology';
-import { TYPE_WORKLOAD, TYPE_OPERATOR_WORKLOAD, TYPE_HELM_WORKLOAD } from '../const';
+import { Node } from '@console/topology';
 import { addResourceMenu } from '../../../actions/add-resources';
-import { TopologyDataObject } from '../topology-types';
+import { GraphData } from '../topology-types';
 
-const addResourcesMenu = (workload: TopologyDataObject, connectorSource?: Node) => {
-  let menuItems = [];
-  if (_.isEmpty(workload)) {
-    return menuItems;
-  }
-  const primaryResource = _.get(workload, ['resources', 'obj'], null);
-  const connectorSourceObj = connectorSource?.getData()?.resources?.obj || {};
-  if (primaryResource) {
-    menuItems = addResourceMenu.map((menuItem) =>
-      menuItem(primaryResource, false, connectorSourceObj),
-    );
-  }
-  return menuItems;
-};
-
-export const graphActions = (elements: GraphElement[], connectorSource?: Node): KebabOption[] => {
-  const primaryResource: Node = _.filter(elements, (e) =>
-    [TYPE_WORKLOAD, TYPE_OPERATOR_WORKLOAD, TYPE_HELM_WORKLOAD].includes(e.getType()),
-  )?.[0] as Node;
-  return [...addResourcesMenu(primaryResource.getData(), connectorSource)];
+export const graphActions = (graphData: GraphData, connectorSource?: Node) => {
+  return _.reduce(
+    addResourceMenu,
+    (menuItems, menuItem) => {
+      const item = menuItem(
+        null,
+        graphData.namespace,
+        false,
+        connectorSource?.getData()?.resources?.obj,
+        graphData.createResourceAccess,
+      );
+      if (item) {
+        menuItems.push(item);
+      }
+      return menuItems;
+    },
+    [],
+  );
 };

--- a/frontend/packages/dev-console/src/components/topology/application-panel/TopologyApplicationPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/application-panel/TopologyApplicationPanel.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
 import { ResourceIcon, ActionsMenu } from '@console/internal/components/utils';
-import { TopologyApplicationObject } from '../topology-types';
+import { GraphData, TopologyApplicationObject } from '../topology-types';
 import { groupActions } from '../actions/groupActions';
 import TopologyApplicationResources from './TopologyApplicationResources';
 
 export type TopologyApplicationPanelProps = {
+  graphData: GraphData;
   application: TopologyApplicationObject;
 };
 
-const TopologyApplicationPanel: React.FC<TopologyApplicationPanelProps> = ({ application }) => (
+const TopologyApplicationPanel: React.FC<TopologyApplicationPanelProps> = ({
+  graphData,
+  application,
+}) => (
   <div className="overview__sidebar-pane resource-overview">
     <div className="overview__sidebar-pane-head resource-overview__heading">
       <h1 className="co-m-pane__heading">
@@ -17,7 +21,7 @@ const TopologyApplicationPanel: React.FC<TopologyApplicationPanelProps> = ({ app
           {application.name}
         </div>
         <div className="co-actions">
-          <ActionsMenu actions={groupActions(application)} />
+          <ActionsMenu actions={groupActions(graphData, application)} />
         </div>
       </h1>
     </div>

--- a/frontend/packages/dev-console/src/components/topology/nodeContextMenu.tsx
+++ b/frontend/packages/dev-console/src/components/topology/nodeContextMenu.tsx
@@ -47,12 +47,13 @@ export const groupContextMenu = (element: Node, connectorSource?: Node) => {
     resources: element.getData().groupResources,
   };
 
-  return createMenuItems(kebabOptionsToMenu(groupActions(applicationData, connectorSource)));
+  const graphData = element.getGraph().getData();
+  return createMenuItems(
+    kebabOptionsToMenu(groupActions(graphData, applicationData, connectorSource)),
+  );
 };
 export const nodeContextMenu = (element: Node) =>
   createMenuItems(kebabOptionsToMenu(nodeActions(element.getData())));
 
-export const graphContextMenu = (element: Graph, connectorSource?: Node) =>
-  createMenuItems(
-    kebabOptionsToMenu(graphActions(element.getController().getElements(), connectorSource)),
-  );
+export const graphContextMenu = (graph: Graph, connectorSource?: Node) =>
+  createMenuItems(kebabOptionsToMenu(graphActions(graph.getData(), connectorSource)));

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -246,3 +246,8 @@ export type ActionProvider = (type: GraphElementType, id: string) => KebabOption
 export type ContextMenuProvider = {
   open: (type: GraphElementType, id: string, eventX: number, eventY: number) => boolean;
 };
+
+export type GraphData = {
+  namespace: string;
+  createResourceAccess: string[];
+};

--- a/frontend/packages/dev-console/src/utils/__tests__/add-resources-menu-utils.spec.tsx
+++ b/frontend/packages/dev-console/src/utils/__tests__/add-resources-menu-utils.spec.tsx
@@ -1,8 +1,7 @@
 import { URL } from 'url';
 import * as React from 'react';
 import { GitAltIcon } from '@patternfly/react-icons';
-import { KebabOption, asAccessReview } from '@console/internal/components/utils';
-import { DeploymentModel } from '@console/internal/models';
+import { KebabOption } from '@console/internal/components/utils';
 import {
   getMenuPath,
   getAddPageUrl,
@@ -38,7 +37,7 @@ describe('addResourceMenuUtils: ', () => {
       connectorSourceObj?.metadata?.name
     }`;
     const url = new URL(
-      getAddPageUrl(primaryResource, ImportOptions.GIT, true, contextSource),
+      getAddPageUrl(primaryResource, '', ImportOptions.GIT, true, contextSource),
       'https://mock.test.com',
     );
 
@@ -53,20 +52,26 @@ describe('addResourceMenuUtils: ', () => {
 
   it('should return the page url without application params in the url', () => {
     const { resource } = getTopologyData(MockResources, ['deployments']);
-    const url = new URL(getAddPageUrl(resource, ImportOptions.GIT, false), 'https://mock.test.com');
+    const url = new URL(
+      getAddPageUrl(resource, '', ImportOptions.GIT, false),
+      'https://mock.test.com',
+    );
     expect(url.searchParams.has('application')).toBe(false);
   });
 
   it('should return the page url without contextSource params in the url', () => {
     const { resource } = getTopologyData(MockResources, ['deployments']);
-    const url = new URL(getAddPageUrl(resource, ImportOptions.GIT, false), 'https://mock.test.com');
+    const url = new URL(
+      getAddPageUrl(resource, '', ImportOptions.GIT, false),
+      'https://mock.test.com',
+    );
     expect(url.searchParams.has('contextSource')).toBe(false);
   });
 
   it('should return the page url with proper queryparams for container image flow', () => {
     const { resource } = getTopologyData(MockResources, ['deployments']);
     const url = new URL(
-      getAddPageUrl(resource, ImportOptions.CONTAINER, true),
+      getAddPageUrl(resource, '', ImportOptions.CONTAINER, true),
       'https://mock.test.com',
     );
     expect(url.pathname).toBe('/deploy-image/ns/testproject1');
@@ -77,7 +82,7 @@ describe('addResourceMenuUtils: ', () => {
   it('should return the page url with proper queryparams for catalog flow', () => {
     const { resource } = getTopologyData(MockResources, ['deployments']);
     const url = new URL(
-      getAddPageUrl(resource, ImportOptions.CATALOG, true),
+      getAddPageUrl(resource, '', ImportOptions.CATALOG, true),
       'https://mock.test.com',
     );
     expect(url.pathname).toBe('/catalog/ns/testproject1');
@@ -88,7 +93,7 @@ describe('addResourceMenuUtils: ', () => {
   it('should return the page url with proper queryparams for dockerfile flow', () => {
     const { resource } = getTopologyData(MockResources, ['deployments']);
     const url = new URL(
-      getAddPageUrl(resource, ImportOptions.DOCKERFILE, true),
+      getAddPageUrl(resource, '', ImportOptions.DOCKERFILE, true),
       'https://mock.test.com',
     );
     expect(url.pathname).toBe('/import/ns/testproject1');
@@ -100,7 +105,7 @@ describe('addResourceMenuUtils: ', () => {
   it('should return the page url with proper queryparams for database flow', () => {
     const { resource } = getTopologyData(MockResources, ['deployments']);
     const url = new URL(
-      getAddPageUrl(resource, ImportOptions.DATABASE, true),
+      getAddPageUrl(resource, '', ImportOptions.DATABASE, true),
       'https://mock.test.com',
     );
     expect(url.pathname).toBe('/catalog/ns/testproject1');
@@ -117,7 +122,12 @@ describe('addResourceMenuUtils: ', () => {
     const label = 'From Git';
 
     const kebabAction: KebabAction = createKebabAction(label, icon, ImportOptions.GIT);
-    const kebabOption: KebabOption = kebabAction(primaryObj, hasApplication, connectorSourceObj);
+    const kebabOption: KebabOption = kebabAction(
+      primaryObj,
+      '',
+      hasApplication,
+      connectorSourceObj,
+    );
     const contextSource: string = `${referenceFor(connectorSourceObj)}/${
       connectorSourceObj?.metadata?.name
     }`;
@@ -126,9 +136,8 @@ describe('addResourceMenuUtils: ', () => {
     expect(kebabOption.icon).toEqual(icon);
     expect(kebabOption.path).toEqual(null);
     expect(kebabOption.href).toEqual(
-      getAddPageUrl(primaryObj, ImportOptions.GIT, hasApplication, contextSource),
+      getAddPageUrl(primaryObj, '', ImportOptions.GIT, hasApplication, contextSource),
     );
-    expect(kebabOption.accessReview).toEqual(asAccessReview(DeploymentModel, primaryObj, 'create'));
   });
 
   it('it should return a valid kebabAction on invoking createKebabAction without connectorSourceObj', () => {
@@ -138,13 +147,14 @@ describe('addResourceMenuUtils: ', () => {
     const label = 'From Git';
 
     const kebabAction: KebabAction = createKebabAction(label, icon, ImportOptions.GIT);
-    const kebabOption: KebabOption = kebabAction(primaryObj, hasApplication);
+    const kebabOption: KebabOption = kebabAction(primaryObj, '', hasApplication);
 
     expect(kebabOption.label).toEqual(label);
     expect(kebabOption.icon).toEqual(icon);
     expect(kebabOption.path).toEqual('Add to Application');
-    expect(kebabOption.href).toEqual(getAddPageUrl(primaryObj, ImportOptions.GIT, hasApplication));
-    expect(kebabOption.accessReview).toEqual(asAccessReview(DeploymentModel, primaryObj, 'create'));
+    expect(kebabOption.href).toEqual(
+      getAddPageUrl(primaryObj, '', ImportOptions.GIT, hasApplication),
+    );
   });
 
   it('it should not return an access review object, if checkAccess is disabled', () => {
@@ -153,8 +163,8 @@ describe('addResourceMenuUtils: ', () => {
     const hasApplication = true;
     const label = 'From Git';
 
-    const kebabAction: KebabAction = createKebabAction(label, icon, ImportOptions.GIT, false); // CheckAccess Disabled
-    const kebabOption: KebabOption = kebabAction(primaryObj, hasApplication);
+    const kebabAction: KebabAction = createKebabAction(label, icon, ImportOptions.GIT);
+    const kebabOption: KebabOption = kebabAction(primaryObj, null, hasApplication);
 
     expect(kebabOption.accessReview).toBe(undefined);
   });

--- a/frontend/packages/dev-console/src/utils/kebab-actions.ts
+++ b/frontend/packages/dev-console/src/utils/kebab-actions.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { K8sKind, referenceFor } from '@console/internal/module/k8s';
+import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
 import { KebabAction } from '@console/internal/components/utils';
 import {
   DaemonSetModel,
@@ -10,10 +10,10 @@ import {
 import { ModifyApplication, EditApplication } from '../actions/modify-application';
 
 const modifyApplicationRefs = [
-  referenceFor(DeploymentConfigModel),
-  referenceFor(DeploymentModel),
-  referenceFor(DaemonSetModel),
-  referenceFor(StatefulSetModel),
+  referenceForModel(DeploymentConfigModel),
+  referenceForModel(DeploymentModel),
+  referenceForModel(DaemonSetModel),
+  referenceForModel(StatefulSetModel),
 ];
 
 export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => {
@@ -22,7 +22,7 @@ export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => 
     return [];
   }
 
-  return _.includes(modifyApplicationRefs, referenceFor(resourceKind))
+  return _.includes(modifyApplicationRefs, referenceForModel(resourceKind))
     ? [ModifyApplication, EditApplication]
     : [];
 };

--- a/frontend/packages/dev-console/src/utils/useAddToProjectAccess.ts
+++ b/frontend/packages/dev-console/src/utils/useAddToProjectAccess.ts
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { AccessReviewResourceAttributes, K8sKind } from '@console/internal/module/k8s';
+import { useAccessReview } from '@console/internal/components/utils';
+import {
+  BuildConfigModel,
+  DeploymentConfigModel,
+  ImageStreamImportsModel,
+  ImageStreamModel,
+  RouteModel,
+  SecretModel,
+  ServiceModel,
+} from '@console/internal/models';
+import { allCatalogImageResourceAccess, allImportResourceAccess } from '../actions/add-resources';
+
+const resourceAttributes = (model: K8sKind, namespace: string): AccessReviewResourceAttributes => {
+  return {
+    group: model.apiGroup || '',
+    resource: model.plural,
+    namespace,
+    verb: 'create',
+  };
+};
+
+export const useAddToProjectAccess = (activeNamespace: string): string[] => {
+  const [addAccess, setAddAccess] = React.useState<string[]>([]);
+
+  const buildConfigsAccess = useAccessReview(resourceAttributes(BuildConfigModel, activeNamespace));
+  const imageStreamAccess = useAccessReview(resourceAttributes(ImageStreamModel, activeNamespace));
+  const deploymentConfigAccess = useAccessReview(
+    resourceAttributes(DeploymentConfigModel, activeNamespace),
+  );
+  const imageStreamImportAccess = useAccessReview(
+    resourceAttributes(ImageStreamImportsModel, activeNamespace),
+  );
+  const secretAccess = useAccessReview(resourceAttributes(SecretModel, activeNamespace));
+  const routeAccess = useAccessReview(resourceAttributes(RouteModel, activeNamespace));
+  const serviceAccess = useAccessReview(resourceAttributes(ServiceModel, activeNamespace));
+
+  React.useEffect(() => {
+    const createResourceAccess: string[] = [];
+    if (
+      buildConfigsAccess &&
+      imageStreamAccess &&
+      deploymentConfigAccess &&
+      secretAccess &&
+      routeAccess &&
+      serviceAccess
+    ) {
+      createResourceAccess.push(allImportResourceAccess);
+      if (imageStreamImportAccess) {
+        createResourceAccess.push(allCatalogImageResourceAccess);
+      }
+    }
+    setAddAccess(createResourceAccess);
+  }, [
+    buildConfigsAccess,
+    deploymentConfigAccess,
+    imageStreamAccess,
+    imageStreamImportAccess,
+    routeAccess,
+    secretAccess,
+    serviceAccess,
+  ]);
+
+  return addAccess;
+};

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -676,7 +676,8 @@ const ActionsMenu_ = ({ actions, impersonate, title = undefined }) => {
       return acc;
     }, []);
 
-    if (_.isEmpty(promises)) {
+    // Only need to resolve if all actions require access review
+    if (promises.length !== actions.length) {
       setVisible(true);
       return;
     }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2790
https://issues.redhat.com/browse/ODC-2934

**Analysis / Root cause**: 
To determine permissions for the context menu, the code was finding the first node in the topology that met certain criteria. If no items meeting the criteria were found, it proceeded and caused an NPE down the line.

**Solution Description**: 
Using the first node to determine the access permission for adding object to the project is faulty. Changed the code to check creation permissions for different object types allowing different add options to be available. The options are now the same that are used for the `+Add` page providing consistency between the two. These options are now determined in a utility function `useAddToProjectAccess` which will maintain this consistency.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
