### PR TITLE
Bug 1797486: Add icon next to pause/unpause events action

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/ActivityBody.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/ActivityBody.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { K8sActivityProps, PrometheusActivityProps, LazyLoader } from '@console/plugin-sdk';
+import { PlayIcon, PauseIcon } from '@patternfly/react-icons';
 import { Accordion } from '@patternfly/react-core';
 import { ErrorLoadingEvents, sortEvents } from '@console/internal/components/events';
 import { Timestamp } from '@console/internal/components/utils/timestamp';
@@ -111,8 +112,12 @@ export const RecentEventsBody: React.FC<RecentEventsBodyProps> = (props) => {
     <>
       <div className="co-activity-card__recent-title">
         Recent Events
-        <DashboardCardButtonLink onClick={togglePause}>
-          {paused ? 'Unpause' : 'Pause'}
+        <DashboardCardButtonLink
+          onClick={togglePause}
+          className="co-activity-card__recent-actions"
+          icon={paused ? <PlayIcon /> : <PauseIcon />}
+        >
+          {paused ? 'Resume' : 'Pause'}
         </DashboardCardButtonLink>
       </div>
       <RecentEventsBodyContent {...props} paused={paused} setPaused={setPaused} />

--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/activity-card.scss
@@ -55,6 +55,10 @@
   }
 }
 
+.co-activity-card__recent-actions svg {
+  vertical-align: -0.125rem !important;
+}
+
 .co-activity-card__recent-list {
   padding-bottom: 0 !important;
 }


### PR DESCRIPTION

![Screenshot from 2020-02-03 15-09-56](https://user-images.githubusercontent.com/2078045/73659822-47648f00-4697-11ea-95ca-f801fe483b03.png)

![Screenshot from 2020-02-03 10-35-52](https://user-images.githubusercontent.com/2078045/73641903-0194d000-4671-11ea-96b7-b2bdb75aac07.png)

@andybraren 