### PR TITLE
[release-4.3] Bug 1797501: Adds flexible OSD Sizes in the install flow

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/_add-capacity-modal.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/_add-capacity-modal.scss
@@ -1,37 +1,40 @@
 @import '~@patternfly/patternfly/sass-utilities/colors';
 
-.add-capacity-modal__hide {
-  display: none;
+.ceph-add-capacity__current-capacity {
+  display: flex;
 }
 
-.add-capacity-modal__input--width {
-  max-width: 250px !important;
+.ceph-add-capacity__current-capacity--loading {
+  width: 9rem;
+  margin-top: 0.2rem;
 }
 
-.add-capacity-modal__input .dropdown {
-  margin-left: var(--pf-global--spacer--md);
+.ceph-add-capacity__current-capacity--text {
+  margin-right: 0.5rem;
 }
 
-.add-capacity-modal__help-text-error {
-  color: $pf-color-red-100;  
+.ceph-add-capacity__form {
+  display: flex;
+  align-items: center;
 }
 
-.add-capacity-modal__help-text {
-  margin-top: -15px;
+.ceph-add-capacity__input {
+  max-width: 16rem !important;
 }
 
-.add-capacity-modal--padding {
-  .co-storage-class-dropdown {
-    .dropdown {
-      width: 340px;
-        button {
-          width: 100%;
-        }
-    }
-  }
+.ceph-add-capacity__input--info-text {
+  margin-left: 0.5rem;
+}
+
+.ceph-add-capacity__modal {
   padding-top: 2em;
 }
 
-.add-capacity-modal__span {
-  margin-left: 3.5rem;
+.ceph-add-capacity_sc-dropdown {
+  width: 16rem;
+  margin-bottom: 1rem;
+}
+
+.ceph-add-capacity__sc-dropdown--hide {
+  display: none;
 }

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
@@ -3,8 +3,8 @@ import * as _ from 'lodash';
 import * as classNames from 'classnames';
 import {
   FieldLevelHelp,
-  RequestSizeInput,
   withHandlePromise,
+  humanizeBinaryBytes,
 } from '@console/internal/components/utils/index';
 import {
   createModalLauncher,
@@ -12,39 +12,66 @@ import {
   ModalSubmitFooter,
   ModalTitle,
 } from '@console/internal/components/factory';
-import { k8sPatch, K8sResourceKind } from '@console/internal/module/k8s';
+import { usePrometheusPoll } from '@console/internal/components/graphs/prometheus-poll-hook';
+import { k8sPatch } from '@console/internal/module/k8s';
+import { PrometheusEndpoint } from '@console/internal/components/graphs/helpers';
+import { getName } from '@console/shared';
 import { OCSServiceModel } from '../../../models';
-import './_add-capacity-modal.scss';
+import { OSD_CAPACITY_SIZES } from '../../../utils/osd-size-dropdown';
+import { CEPH_STORAGE_NAMESPACE } from '../../../constants';
+import { labelTooltip } from '../../../constants/ocs-install';
+import { CAPACITY_USAGE_QUERIES, StorageDashboardQuery } from '../../../constants/queries';
 import { OCSStorageClassDropdown } from '../storage-class-dropdown';
+import './_add-capacity-modal.scss';
+
+const getProvisionedCapacity = (value: number) => (value % 1 ? (value * 3).toFixed(2) : value * 3);
 
 export const AddCapacityModal = withHandlePromise((props: AddCapacityModalProps) => {
   const { ocsConfig, close, cancel } = props;
-  const dropdownUnits = {
-    TiB: 'TiB',
-  };
-  const requestSizeUnit = dropdownUnits.TiB;
-  const [buttonDisabled, setButton] = React.useState(false);
-  const [requestSizeValue, setRequestSizeValue] = React.useState('2');
+
+  const [response, loadError, loading] = usePrometheusPoll({
+    endpoint: PrometheusEndpoint.QUERY,
+    namespace: CEPH_STORAGE_NAMESPACE,
+    query: CAPACITY_USAGE_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_USED],
+  });
   const [storageClass, setStorageClass] = React.useState('');
   const [inProgress, setProgress] = React.useState(false);
   const [errorMessage, setError] = React.useState('');
 
+  const osdSizeWithUnit = _.get(
+    ocsConfig,
+    'spec.storageDeviceSets[0].dataPVCTemplate.spec.resources.requests.storage',
+  );
   const presentCount = _.get(ocsConfig, 'spec.storageDeviceSets[0].count');
-  const storageClassTooltip =
-    'The Storage Class will be used to request storage from the underlying infrastructure to create the backing persistent volumes that will be used to provide the OpenShift Container Storage (OCS) service.';
-  const labelTooltip =
-    'The backing storage requested will be higher as it will factor in the requested capacity, replica factor, and fault tolerant costs associated with the requested capacity.';
+  const capacity = _.get(response, 'data.result[0].value[1]');
+
+  const osdSizeWithoutUnit = OSD_CAPACITY_SIZES[osdSizeWithUnit]?.size;
+  const provisionedCapacity = getProvisionedCapacity(osdSizeWithoutUnit);
+
+  let currentCapacity: React.ReactNode;
+
+  if (loading) {
+    currentCapacity = (
+      <div className="skeleton-text ceph-add-capacity__current-capacity--loading" />
+    );
+  } else if (loadError || !capacity || !presentCount || !osdSizeWithoutUnit) {
+    currentCapacity = <div className="text-muted">Not available</div>;
+  } else {
+    currentCapacity = (
+      <div className="text-muted">
+        <strong>{`${humanizeBinaryBytes(capacity / 3).string} / ${presentCount *
+          osdSizeWithoutUnit} TiB`}</strong>
+      </div>
+    );
+  }
 
   const submit = (event: React.FormEvent<EventTarget>) => {
     event.preventDefault();
     setProgress(true);
-    const negativeValue = Number(requestSizeValue) < 0 ? -1 : 1;
-    const newValue =
-      (Number(presentCount) + Math.abs(Number(requestSizeValue)) / 2) * negativeValue;
     const patch = {
       op: 'replace',
       path: `/spec/storageDeviceSets/0/count`,
-      value: newValue,
+      value: presentCount + 1,
     };
     props
       .handlePromise(k8sPatch(OCSServiceModel, ocsConfig, [patch]))
@@ -55,68 +82,41 @@ export const AddCapacityModal = withHandlePromise((props: AddCapacityModalProps)
       .catch((error) => {
         setError(error);
         setProgress(false);
-        setButton(true);
-        throw error;
       });
-  };
-
-  const handleRequestSizeInputChange = (capacityObj: any) => {
-    setRequestSizeValue(capacityObj.value);
-    setButton(capacityObj.value % 2 !== 0);
-  };
-
-  const handleStorageClass = (sc: K8sResourceKind) => {
-    setStorageClass(sc.metadata.name);
   };
 
   return (
     <form onSubmit={submit} className="modal-content modal-content--no-inner-scroll">
       <ModalTitle>Add Capacity</ModalTitle>
       <ModalBody>
-        Increase the capacity of <strong>{ocsConfig.metadata.name}</strong>.
-        <div className="add-capacity-modal--padding">
-          <div className="add-capacity-modal__input form-group">
-            <label className="control-label" htmlFor="request-size-input">
-              Capacity
-              <FieldLevelHelp>{labelTooltip}</FieldLevelHelp>
-              <span className="text-secondary add-capacity-modal__span">
-                <span>
-                  Provisioned:
-                  {presentCount ? ` ${presentCount * 2}TiB` : ' Unavailable'}
-                </span>
-              </span>
-            </label>
-            <RequestSizeInput
-              name="requestSize"
-              placeholder={requestSizeValue}
-              onChange={handleRequestSizeInputChange}
-              defaultRequestSizeUnit={requestSizeUnit}
-              defaultRequestSizeValue={requestSizeValue}
-              dropdownUnits={dropdownUnits}
-              step={2}
-              minValue={2}
-              inputClassName="add-capacity-modal__input--width"
-              required
-            />
-            <p
-              className={classNames('text-secondary add-capacity-modal__help-text', {
-                'add-capacity-modal__help-text-error': buttonDisabled,
-              })}
-            >
-              Please enter an even number
-            </p>
+        Adding capacity for <strong>{getName(ocsConfig)}</strong>, may increase your cloud expenses.
+        <div className="ceph-add-capacity__modal">
+          <div className="ceph-add-capacity_sc-dropdown">
+            <OCSStorageClassDropdown onChange={setStorageClass} defaultClass={storageClass} />
           </div>
-          <label className="control-label">
-            Storage Class
-            <FieldLevelHelp>{storageClassTooltip}</FieldLevelHelp>
+          <label className="control-label" htmlFor="requestSize">
+            Raw Capacity
+            <FieldLevelHelp>{labelTooltip}</FieldLevelHelp>
           </label>
-          <OCSStorageClassDropdown
-            onChange={handleStorageClass}
-            name="storageClass"
-            defaultClass={storageClass}
-            hideClassName="add-capacity-modal__hide"
-            required
-          />
+          <div className="ceph-add-capacity__form">
+            <input
+              className={classNames('pf-c-form-control', 'ceph-add-capacity__input')}
+              type="number"
+              name="requestSize"
+              value={osdSizeWithoutUnit}
+              required
+              disabled
+            />
+            <div className="ceph-add-capacity__input--info-text">
+              x 3 replicas = <strong>{provisionedCapacity} TiB</strong>
+            </div>
+          </div>
+          <div className="ceph-add-capacity__current-capacity">
+            <div className="text-secondary ceph-add-capacity__current-capacity--text">
+              <strong>Currently Used:</strong>
+            </div>
+            {currentCapacity}
+          </div>
         </div>
       </ModalBody>
       <ModalSubmitFooter
@@ -124,7 +124,6 @@ export const AddCapacityModal = withHandlePromise((props: AddCapacityModalProps)
         errorMessage={errorMessage}
         submitText="Add"
         cancel={cancel}
-        submitDisabled={buttonDisabled}
       />
     </form>
   );

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/add-capacity-modal.tsx
@@ -45,7 +45,7 @@ export const AddCapacityModal = withHandlePromise((props: AddCapacityModalProps)
   const presentCount = _.get(ocsConfig, 'spec.storageDeviceSets[0].count');
   const capacity = _.get(response, 'data.result[0].value[1]');
 
-  const osdSizeWithoutUnit = OSD_CAPACITY_SIZES[osdSizeWithUnit]?.size;
+  const osdSizeWithoutUnit = _.get(OSD_CAPACITY_SIZES[osdSizeWithUnit], 'size');
   const provisionedCapacity = getProvisionedCapacity(osdSizeWithoutUnit);
 
   let currentCapacity: React.ReactNode;

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.scss
@@ -1,0 +1,3 @@
+.ceph-sc-dropdown__hide-default {
+  display: none;
+}

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Firehose, FieldLevelHelp } from '@console/internal/components/utils';
-import { InfrastructureModel } from '@console/internal/models';
-import { K8sResourceKind, StorageClassResourceKind, k8sGet } from '@console/internal/module/k8s';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 import { StorageClassDropdownInner } from '@console/internal/components/utils/storage-class-dropdown';
-import { getInfrastructurePlatform } from '@console/shared';
-import { infraProvisionerMap, storageClassTooltip } from '../../constants/ocs-install';
+import { cephStorageProvisioners } from '@console/shared';
+import { storageClassTooltip } from '../../constants/ocs-install';
 import './storage-class-dropdown.scss';
 
 const StorageClassDropdown = (props: any) => {
@@ -33,7 +32,6 @@ export const OCSStorageClassDropdown: React.FC<OCSStorageClassDropdownProps> = (
   const handleStorageClass = (sc: K8sResourceKind) => {
     onChange(sc.metadata.name);
   };
-
   return (
     <>
       <label className="control-label" htmlFor="storageClass">

--- a/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
@@ -1,16 +1,12 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { Firehose } from '@console/internal/components/utils';
+import { Firehose, FieldLevelHelp } from '@console/internal/components/utils';
+import { InfrastructureModel } from '@console/internal/models';
+import { K8sResourceKind, StorageClassResourceKind, k8sGet } from '@console/internal/module/k8s';
 import { StorageClassDropdownInner } from '@console/internal/components/utils/storage-class-dropdown';
-import { K8sResourceKind } from '@console/internal/module/k8s';
-
-const cephStorageProvisioners = ['ceph.rook.io/block', 'cephfs.csi.ceph.com', 'rbd.csi.ceph.com'];
-
-export const OCSStorageClassDropdown: React.FC<OCSStorageClassDropdownProps> = (props) => (
-  <Firehose resources={[{ kind: 'StorageClass', prop: 'StorageClass', isList: true }]}>
-    <StorageClassDropdown {...props} />
-  </Firehose>
-);
+import { getInfrastructurePlatform } from '@console/shared';
+import { infraProvisionerMap, storageClassTooltip } from '../../constants/ocs-install';
+import './storage-class-dropdown.scss';
 
 const StorageClassDropdown = (props: any) => {
   const scConfig = _.cloneDeep(props);
@@ -31,14 +27,33 @@ const StorageClassDropdown = (props: any) => {
   return <StorageClassDropdownInner {...scConfig} />;
 };
 
+export const OCSStorageClassDropdown: React.FC<OCSStorageClassDropdownProps> = (props) => {
+  const { onChange, defaultClass } = props;
+
+  const handleStorageClass = (sc: K8sResourceKind) => {
+    onChange(sc.metadata.name);
+  };
+
+  return (
+    <>
+      <label className="control-label" htmlFor="storageClass">
+        Storage Class
+        <FieldLevelHelp>{storageClassTooltip}</FieldLevelHelp>
+      </label>
+      <Firehose resources={[{ kind: 'StorageClass', prop: 'StorageClass', isList: true }]}>
+        <StorageClassDropdown
+          onChange={handleStorageClass}
+          name="storageClass"
+          defaultClass={defaultClass}
+          hideClassName="ceph-sc-dropdown__hide-default"
+          required
+        />
+      </Firehose>
+    </>
+  );
+};
+
 type OCSStorageClassDropdownProps = {
-  id?: string;
-  loaded?: boolean;
-  resources?: any;
-  name: string;
-  onChange: (object) => void;
-  describedBy?: string;
-  defaultClass: string;
-  required?: boolean;
-  hideClassName?: string;
+  onChange: React.Dispatch<React.SetStateAction<string>>;
+  defaultClass?: string;
 };

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/node-list.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/node-list.tsx
@@ -10,7 +10,6 @@ import {
   TableGridBreakpoint,
 } from '@patternfly/react-table';
 import {
-  getInfrastructurePlatform,
   getName,
   getNodeRoles,
   getNodeCPUCapacity,
@@ -22,32 +21,31 @@ import { ButtonBar } from '@console/internal/components/utils/button-bar';
 import { history } from '@console/internal/components/utils/router';
 import {
   convertToBaseValue,
+  FieldLevelHelp,
   humanizeCpuCores,
   humanizeBinaryBytes,
   ResourceLink,
-} from '@console/internal/components/utils/index';
+} from '@console/internal/components/utils/';
 import {
   k8sCreate,
   k8sPatch,
-  k8sGet,
   K8sResourceKind,
-  k8sList,
   NodeKind,
   referenceForModel,
-  StorageClassResourceKind,
   Taint,
 } from '@console/internal/module/k8s';
-import { NodeModel, InfrastructureModel, StorageClassModel } from '@console/internal/models';
-import { isDefaultClass } from '@console/internal/components/storage-class';
+import { NodeModel } from '@console/internal/models';
 import { OCSServiceModel } from '../../models';
 import {
-  infraProvisionerMap,
   minSelectedNode,
+  labelTooltip,
   ocsRequestData,
   ocsTaint,
 } from '../../constants/ocs-install';
 import './ocs-install.scss';
+import { OSDSizeDropdown } from '../../utils/osd-size-dropdown';
 import { hasLabel } from '../../../../console-shared/src/selectors/common';
+import { OCSStorageClassDropdown } from '../modals/storage-class-dropdown';
 
 const ocsLabel = 'cluster.ocs.openshift.io/openshift-storage';
 
@@ -177,14 +175,14 @@ const CustomNodeTable: React.FC<CustomNodeTableProps> = ({
   ocsProps,
 }) => {
   const columns = getColumns();
+  const [osdSize, setOsdSize] = React.useState('2Ti');
   const [nodes, setNodes] = React.useState([]);
   const [unfilteredNodes, setUnfilteredNodes] = React.useState([]);
   const [error, setError] = React.useState('');
   const [inProgress, setProgress] = React.useState(false);
   const [selectedNodesCnt, setSelectedNodesCnt] = React.useState(0);
   const [nodesWarningMsg, setNodesWarningMsg] = React.useState('');
-
-  let storageClass = '';
+  const [storageClass, setStorageClass] = React.useState(null);
 
   // pre-selection of nodes
   if (loaded && !unfilteredNodes.length) {
@@ -238,7 +236,6 @@ const CustomNodeTable: React.FC<CustomNodeTableProps> = ({
       setNodes(filterData);
     }
   }, [data, isFiltered, nodes.length, unfilteredNodes]);
-
   const onSelect = (
     event: React.MouseEvent<HTMLButtonElement>,
     isSelected: boolean,
@@ -315,6 +312,7 @@ const CustomNodeTable: React.FC<CustomNodeTableProps> = ({
 
     const ocsObj = _.cloneDeep(ocsRequestData);
     ocsObj.spec.storageDeviceSets[0].dataPVCTemplate.spec.storageClassName = storageClass;
+    ocsObj.spec.storageDeviceSets[0].dataPVCTemplate.spec.resources.requests.storage = osdSize;
 
     Promise.all(promises)
       .then(() => {
@@ -337,30 +335,7 @@ const CustomNodeTable: React.FC<CustomNodeTableProps> = ({
     event.preventDefault();
     setProgress(true);
     setError('');
-
-    let provisioner = '';
-
-    k8sGet(InfrastructureModel, 'cluster')
-      .then((infra: K8sResourceKind) => {
-        // find infra supported provisioner
-        provisioner = infraProvisionerMap[_.toLower(getInfrastructurePlatform(infra))];
-        return k8sList(StorageClassModel);
-      })
-      .then((storageClasses: StorageClassResourceKind[]) => {
-        // find all storageclass with the given provisioner
-        const scList = _.filter(storageClasses, (sc) => sc.provisioner === provisioner);
-        // take the default storageclass
-        _.forEach(scList, (sc) => {
-          if (isDefaultClass(sc)) {
-            storageClass = sc.metadata.name;
-          }
-        });
-        makeOCSRequest();
-      })
-      .catch((err) => {
-        setProgress(false);
-        setError(err.message);
-      });
+    makeOCSRequest();
   };
 
   return (
@@ -389,6 +364,20 @@ const CustomNodeTable: React.FC<CustomNodeTableProps> = ({
           isInline
         />
       )}
+      <div className="ceph-ocs-install__ocs-service-capacity--dropdown">
+        <OCSStorageClassDropdown onChange={setStorageClass} />
+      </div>
+      <div className="ceph-ocs-install__ocs-service-capacity">
+        <label className="control-label" htmlFor="ocs-service-stoargeclass">
+          OCS Service Capacity
+          <FieldLevelHelp>{labelTooltip}</FieldLevelHelp>
+        </label>
+        <OSDSizeDropdown
+          className="ceph-ocs-install__ocs-service-capacity--dropdown"
+          selectedKey={osdSize}
+          onChange={setOsdSize}
+        />
+      </div>
       <ButtonBar errorMessage={error} inProgress={inProgress}>
         <ActionGroup className="pf-c-form">
           <Button

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-install.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/ocs-install.scss
@@ -2,6 +2,26 @@
   max-height: 400px;
   overflow: auto;
 }
+
 .ceph-ocs-install__alert {
   margin-top: 1em;
+}
+
+.ceph-ocs-install__ocs-service-capacity {
+  margin-top: var(--pf-global--spacer--md);
+  margin-bottom: var(--pf-global--spacer--3xl);
+}
+
+.ceph-ocs-install__ocs-service-capacity--dropdown {
+  width: 15rem;
+}
+
+.ceph-ocs-install__ocs-service-capacity--help-text {
+  font-size: var(--pf-global--FontSize--sm);
+  margin-bottom: 0;
+}
+
+.ceph-ocs-install__ocs-service-capacity--title {
+  font-weight: var(--pf-global--FontWeight--bold);
+  font-size: var(--pf-global--FontSize--md);
 }

--- a/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
@@ -8,6 +8,11 @@ export const ocsTaint: Taint = {
 };
 Object.freeze(ocsTaint);
 
+export const storageClassTooltip =
+  'The Storage Class will be used to request storage from the underlying infrastructure to create the backing persistent volumes that will be used to provide the OpenShift Container Storage (OCS) service.';
+export const labelTooltip =
+  'The backing storage requested will be higher as it will factor in the requested capacity, replica factor, and fault tolerant costs associated with the requested capacity.';
+
 export const ocsRequestData: K8sResourceKind = {
   apiVersion: 'ocs.openshift.io/v1',
   kind: 'StorageCluster',
@@ -32,7 +37,7 @@ export const ocsRequestData: K8sResourceKind = {
             volumeMode: 'Block',
             resources: {
               requests: {
-                storage: '2Ti',
+                storage: '',
               },
             },
           },

--- a/frontend/packages/ceph-storage-plugin/src/utils/osd-size-dropdown.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/utils/osd-size-dropdown.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { Dropdown } from '@console/internal/components/utils';
+
+export const OSD_CAPACITY_SIZES = {
+  '512Gi': {
+    scale: 'SmallScale',
+    size: 0.5,
+    title: '0.5 TiB',
+  },
+  '2Ti': {
+    scale: 'Standard',
+    size: 2,
+    title: '2 TiB',
+  },
+  '4Ti': {
+    scale: 'LargeScale',
+    size: 4,
+    title: '4 TiB',
+  },
+};
+
+const DropdownOptionsItem: React.FC<DropdownOptionsItemProps> = ({ title, scale }) => (
+  <span className="co-resource-item">
+    <span className="co-resource-item__resource-name">
+      {title}
+      <>
+        &nbsp;
+        <div className="co-resource-item__resource-api text-muted co-truncate show co-nowrap small">
+          {scale}
+        </div>
+      </>
+    </span>
+  </span>
+);
+
+type DropdownOptionsItemProps = { title: string; scale: string };
+
+export const OSDSizeDropdown: React.FC<OSDSizeDropdownProps> = ({
+  selectedKey,
+  onChange,
+  className,
+}) => {
+  const dropdownOptionsKeys: string[] = Object.keys(OSD_CAPACITY_SIZES);
+  const dropdownOptions: DropdownOptions = dropdownOptionsKeys.reduce((dropdownObject, key) => {
+    dropdownObject[key] = (
+      <DropdownOptionsItem
+        title={OSD_CAPACITY_SIZES[key].title}
+        scale={OSD_CAPACITY_SIZES[key].scale}
+      />
+    );
+    return dropdownObject;
+  }, {});
+  return (
+    <Dropdown
+      id="ocs-service-capacity-dropdown"
+      items={dropdownOptions}
+      title={OSD_CAPACITY_SIZES[selectedKey].title}
+      onChange={onChange}
+      selectedKey={selectedKey}
+      noSelection
+      buttonClassName={className}
+    />
+  );
+};
+
+type DropdownOptions = { [key: string]: React.ReactNode };
+
+type OSDSizeDropdownProps = {
+  className: string;
+  selectedKey: string;
+  onChange: React.Dispatch<React.SetStateAction<string>>;
+};


### PR DESCRIPTION
Cherrypick for https://github.com/openshift/console/pull/3966/commits
There were conflicts, hence sending separate branch.
**(cherry picked from commit a556a22036948c640c1be4c52f9c0f03879f62b2)**

I verified [cherry pick commit](https://github.com/openshift/console/pull/3966/commits/a556a22036948c640c1be4c52f9c0f03879f62b2) locally , its genuine:
```
git cherry upstream/release-4.3 upstream/master | grep a556a22036948c640c1be4c52f9c0f03879f62b2
+ a556a22036948c640c1be4c52f9c0f03879f62b2
```
The conflicting changes in cherrypick are being taken care in the separate [commit](https://github.com/openshift/console/pull/4149/commits/6f400350270f17c9099628761dc486422765796a):

Summary of conflicts and reasons:
1. Using optional chaining, not supported in 4.3
2. Importing components, which are not required to be imported.
