### PR TITLE
Bug 1796150: fixes traffic split menu option error on kebab for core service

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
@@ -1,0 +1,25 @@
+import { ServiceModel } from '@console/internal/models';
+import {
+  ModifyApplication,
+  EditApplication,
+} from '@console/dev-console/src/actions/modify-application';
+import { getKebabActionsForKind } from '../kebab-actions';
+import { setTrafficDistribution } from '../../actions/traffic-splitting';
+import { EventSourceContainerModel, ServiceModel as knSvcModel } from '../../models';
+
+describe('kebab-actions: ', () => {
+  it('kebab action should have "Edit Application Grouping" option for EventSourceContainerModel', () => {
+    const modifyApplication = getKebabActionsForKind(EventSourceContainerModel);
+    expect(modifyApplication).toEqual([ModifyApplication]);
+  });
+
+  it('kebab action should have "setTrafficDistribution", "Edit Application Grouping" and "Edit Application" option for knSvcModel', () => {
+    const modifyApplication = getKebabActionsForKind(knSvcModel);
+    expect(modifyApplication).toEqual([ModifyApplication, setTrafficDistribution, EditApplication]);
+  });
+
+  it('kebab action should not have "Edit Application Grouping" option for ServiceModel', () => {
+    const modifyApplication = getKebabActionsForKind(ServiceModel);
+    expect(modifyApplication).toEqual([]);
+  });
+});

--- a/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
+++ b/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { K8sKind, referenceFor } from '@console/internal/module/k8s';
+import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
 import { KebabAction } from '@console/internal/components/utils';
 import {
   ModifyApplication,
@@ -16,21 +16,21 @@ import {
 } from '../models';
 
 const modifyApplicationRefs = [
-  referenceFor(EventSourceApiServerModel),
-  referenceFor(EventSourceContainerModel),
-  referenceFor(EventSourceCronJobModel),
-  referenceFor(EventSourceCamelModel),
-  referenceFor(EventSourceKafkaModel),
-  referenceFor(ServiceModel),
+  referenceForModel(EventSourceApiServerModel),
+  referenceForModel(EventSourceContainerModel),
+  referenceForModel(EventSourceCronJobModel),
+  referenceForModel(EventSourceCamelModel),
+  referenceForModel(EventSourceKafkaModel),
+  referenceForModel(ServiceModel),
 ];
 
 export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => {
   const menuActions: KebabAction[] = [];
   if (resourceKind) {
-    if (_.includes(modifyApplicationRefs, referenceFor(resourceKind))) {
+    if (_.includes(modifyApplicationRefs, referenceForModel(resourceKind))) {
       menuActions.push(ModifyApplication);
     }
-    if (resourceKind.kind === ServiceModel.kind) {
+    if (referenceForModel(resourceKind) === referenceForModel(ServiceModel)) {
       menuActions.push(setTrafficDistribution, EditApplication);
     }
   }


### PR DESCRIPTION
**Fixes**: 
- https://issues.redhat.com/browse/ODC-2900

**Analysis / Root cause**: 
core service and kn service model both have the same kind "Service",  this enabled the addition of traffic split kebab menu option for core service as well.

**Solution Description**: 
Have made use of `referenceForModel` instead of directly checking for `kind`

**Screen shots / Gifs for design review**: 
<img width="1387" alt="Screenshot 2020-02-03 at 3 57 44 PM" src="https://user-images.githubusercontent.com/5129024/73645768-f3a97400-469d-11ea-8664-e51cfd1275c5.png">


**Unit test coverage report**: 
<img width="1038" alt="Screenshot 2020-02-03 at 3 55 23 PM" src="https://user-images.githubusercontent.com/5129024/73645598-9dd4cc00-469d-11ea-8af9-8ecaed156d38.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
