### PR TITLE
Bug 1797521: disable pod count filter by default

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/redux/const.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/const.ts
@@ -1,7 +1,7 @@
 export const TOPOLOGGY_FILTERS_LOCAL_STORAGE_KEY = `bridge/topology-filters`;
 export const DEFAULT_TOPOLOGY_FILTERS = {
   display: {
-    podCount: true,
+    podCount: false,
     eventSources: true,
     knativeServices: true,
     appGrouping: true,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-2796

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
The new feature in 4.4 to provide a filter to display the pod count in topology is enabled by default.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Disable the pod count filter by default.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Peek 2020-02-03 16-46](https://user-images.githubusercontent.com/2561818/73649253-6702b400-46a5-11ea-8df6-100841618732.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
