### PR TITLE
BUG 1797586: fix(operator-binding) - add operator backed service binding

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/componentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/componentFactory.ts
@@ -128,16 +128,23 @@ class ComponentFactory {
         case TYPE_OPERATOR_WORKLOAD:
           return withCreateConnector(createConnectorCallback(this.hasServiceBinding))(
             withEditReviewAccess('patch')(
-              withDragNode(nodeDragSourceSpec(type, false))(
-                withSelection(
-                  false,
-                  true,
-                )(
-                  withContextMenu(
-                    workloadContextMenu,
-                    document.getElementById('modal-container'),
-                    'odc-topology-context-menu',
-                  )(WorkloadNode),
+              withDndDrop<
+                any,
+                any,
+                { droppable?: boolean; hover?: boolean; canDrop?: boolean },
+                NodeProps
+              >(nodeDropTargetSpec)(
+                withDragNode(nodeDragSourceSpec(type, false))(
+                  withSelection(
+                    false,
+                    true,
+                  )(
+                    withContextMenu(
+                      workloadContextMenu,
+                      document.getElementById('modal-container'),
+                      'odc-topology-context-menu',
+                    )(WorkloadNode),
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Fixes: https://issues.redhat.com/projects/ODC/issues/ODC-2923

**Analysis/ Root cause:**

Drop Target spec is missing in Operator backed workload resulting in the node not being droppable.

**Solution:**
Added the Drop HOC for operator backed workload

**Screenshots**

![AwesomeScreenshot-2020-2-3-1580734632353](https://user-images.githubusercontent.com/9964343/73654996-07130a00-46b3-11ea-9d3b-4b91df911fc0.gif)
