### PR TITLE
Bug 1797974: fix overview status

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
@@ -29,8 +29,9 @@ export const VMDetailsFirehose: React.FC<VMTabProps> = ({
   templates,
   customData: { kindObj },
 }) => {
-  const vm = kindObj === VirtualMachineModel && isVM(objProp) ? objProp : vmProp;
-  const vmi = kindObj === VirtualMachineInstanceModel && isVMI(objProp) ? objProp : vmiProp;
+  const vm = kindObj === VirtualMachineModel && isVM(objProp) ? objProp : isVM(vmProp) && vmProp;
+  const vmi =
+    kindObj === VirtualMachineInstanceModel && isVMI(objProp) ? objProp : isVMI(vmiProp) && vmiProp;
 
   const resources = [
     getResource(ServiceModel, { namespace: getNamespace(objProp), prop: 'services' }),
@@ -92,9 +93,9 @@ const VMDetails: React.FC<VMDetailsProps> = (props) => {
 type VMDetailsProps = {
   kindObj: K8sKind;
   vm?: VMKind;
+  vmi?: VMIKind;
   pods?: PodKind[];
   migrations?: K8sResourceKind[];
-  vmi?: VMIKind;
   services?: FirehoseResult<K8sResourceKind[]>;
   templates?: TemplateKind[];
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
@@ -29,9 +29,14 @@ export const VMDetailsFirehose: React.FC<VMTabProps> = ({
   templates,
   customData: { kindObj },
 }) => {
-  const vm = kindObj === VirtualMachineModel && isVM(objProp) ? objProp : isVM(vmProp) && vmProp;
+  const vm =
+    kindObj === VirtualMachineModel && isVM(objProp) ? objProp : isVM(vmProp) ? vmProp : null;
   const vmi =
-    kindObj === VirtualMachineInstanceModel && isVMI(objProp) ? objProp : isVMI(vmiProp) && vmiProp;
+    kindObj === VirtualMachineInstanceModel && isVMI(objProp)
+      ? objProp
+      : isVMI(vmiProp)
+      ? vmiProp
+      : null;
 
   const resources = [
     getResource(ServiceModel, { namespace: getNamespace(objProp), prop: 'services' }),

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -27,10 +27,10 @@ import { getOperatingSystemName, getOperatingSystem } from '../../selectors/vm';
 import { getVmiIpAddresses } from '../../selectors/vmi/ip-address';
 import { findVMPod } from '../../selectors/pod/selectors';
 import { isVMIPaused } from '../../selectors/vmi';
-
-import './vm-resource.scss';
 import { VirtualMachineInstanceModel, VirtualMachineModel } from '../../models';
 import { asVMILikeWrapper } from '../../k8s/wrapper/utils/convert';
+
+import './vm-resource.scss';
 
 export const VMDetailsItem: React.FC<VMDetailsItemProps> = ({
   title,

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -32,9 +32,9 @@ import { getVmiIpAddresses, getVMINodeName } from '../../selectors/vmi';
 import { isVM, getVMLikeModel } from '../../selectors/vm';
 import { vmStatusFilter } from './table-filters';
 import { vmMenuActions, vmiMenuActions } from './menu-actions';
+import { VMILikeEntityKind } from '../../types/vmLike';
 
 import './vm.scss';
-import { VMILikeEntityKind } from '../../types/vmLike';
 
 const tableColumnClasses = [
   classNames('col-lg-2', 'col-md-2', 'col-sm-6', 'col-xs-6'),


### PR DESCRIPTION
In https://github.com/openshift/console/pull/3949 I introduced an error in status rendering.

This PR fixes the status rendering in vm/vmi overview. 

Screenshots
before:
![OKD](https://user-images.githubusercontent.com/2181522/73735098-6884b880-4747-11ea-9a5e-bd3b6396dc38.png)

after:
![OKD(1)](https://user-images.githubusercontent.com/2181522/73735409-e3e66a00-4747-11ea-8a60-81cc46582e00.png)

