### PR TITLE
Bug 1797984: VMI Rename Overview pages to Details

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
@@ -39,7 +39,7 @@ export const VirtualMachinesInstanceDetailsPage: React.FC<VirtualMachinesInstanc
 
   const dashboardPage = {
     href: '', // default landing page
-    name: 'Dashboard',
+    name: 'Details',
     component: VMDashboard,
   };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
@@ -37,15 +37,15 @@ export const VirtualMachinesInstanceDetailsPage: React.FC<VirtualMachinesInstanc
     { name: `${match.params.name} Details`, path: `${match.url}` },
   ];
 
-  const dashboardPage = {
+  const overviewPage = {
     href: '', // default landing page
-    name: 'Details',
+    name: 'Overview',
     component: VMDashboard,
   };
 
-  const overviewPage = {
+  const detailsPage = {
     href: VM_DETAIL_DETAILS_HREF,
-    name: 'Overview',
+    name: 'Details',
     component: VMDetailsFirehose,
   };
 
@@ -68,8 +68,8 @@ export const VirtualMachinesInstanceDetailsPage: React.FC<VirtualMachinesInstanc
   };
 
   const pages = [
-    dashboardPage,
     overviewPage,
+    detailsPage,
     navFactory.editYaml(),
     consolePage,
     navFactory.events(VMEvents),


### PR DESCRIPTION
In https://github.com/openshift/console/pull/3934 we renamed Overview pages to Details

This PR rename the pages in the VMI view.

Screenshots:
before:
![OKD](https://user-images.githubusercontent.com/2181522/73737824-04182800-474c-11ea-924b-794858d10594.png)

after:
![OKD(2)](https://user-images.githubusercontent.com/2181522/73737818-01b5ce00-474c-11ea-8566-33abfef82a1b.png)
