### PR TITLE
Bug 1797327: Add top margin to the timed out fetching new data message

### DIFF
--- a/frontend/public/components/utils/_status-box.scss
+++ b/frontend/public/components/utils/_status-box.scss
@@ -41,11 +41,8 @@
 
 .co-m-timeout-error {
   margin-bottom: 30px;
+  margin-top: 20px;
   text-align: center;
-  .co-cluster-updates__component &,
-  .co-m-horizontal-nav & {
-    margin-top: 30px;
-  }
 }
 
 .loading-box {


### PR DESCRIPTION
There are multiple different places we are using the `StatusBox` component which renders the "Timed out fetching new data" message: 
 

- After the horizontal navigation
<img width="803" alt="Screenshot 2020-02-04 at 11 36 36" src="https://user-images.githubusercontent.com/1668218/73737300-a92e0300-4742-11ea-8f02-7a4620bd0576.png">


- Resource sections
<img width="825" alt="Screenshot 2020-02-04 at 11 40 17" src="https://user-images.githubusercontent.com/1668218/73737899-bbf50780-4743-11ea-9c27-4ab9f418080e.png">


- When editing resources(eg. secrets)
<img width="1024" alt="Screenshot 2020-02-04 at 10 43 19" src="https://user-images.githubusercontent.com/1668218/73737961-d6c77c00-4743-11ea-9d0f-d2e723c7d975.png">


for that reason I propose to unify this by simply adding an additional margin-top.


Also removing orphaned `.co-cluster-updates__component` that we are not using anymore and also the `.co-m-horizontal-nav` which is not nesting the `.co-m-timeout-error` anymore
<img width="754" alt="Screenshot 2020-02-04 at 11 57 27" src="https://user-images.githubusercontent.com/1668218/73738887-8a7d3b80-4745-11ea-87ec-ff8bb7084e27.png">


Result:

- 
<img width="844" alt="Screenshot 2020-02-04 at 11 59 11" src="https://user-images.githubusercontent.com/1668218/73739081-e5af2e00-4745-11ea-9507-b490836ed9d2.png">

- 
<img width="836" alt="Screenshot 2020-02-04 at 11 59 17" src="https://user-images.githubusercontent.com/1668218/73739082-e5af2e00-4745-11ea-8446-3386f1c5cd07.png">

-
<img width="851" alt="Screenshot 2020-02-04 at 11 59 48" src="https://user-images.githubusercontent.com/1668218/73739083-e5af2e00-4745-11ea-99fe-12d8b762db61.png">

- 
<img width="849" alt="Screenshot 2020-02-04 at 11 59 59" src="https://user-images.githubusercontent.com/1668218/73739085-e647c480-4745-11ea-9e0e-813dd0777ad0.png">



/assign @spadgett 