### PR TITLE
Bug 1798006: VM details, Align href to page name

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -17,7 +17,7 @@ import {
 import { VMDashboardContext } from '../../vms/vm-dashboard-context';
 import { VirtualMachineModel } from '../../../models';
 import { getVmiIpAddresses } from '../../../selectors/vmi/ip-address';
-import { VM_DETAIL_OVERVIEW_HREF } from '../../../constants';
+import { VM_DETAIL_DETAILS_HREF } from '../../../constants';
 import { findVMPod } from '../../../selectors/pod/selectors';
 
 export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
@@ -37,7 +37,7 @@ export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
     VirtualMachineModel.kind,
     name,
     namespace,
-  )}/${VM_DETAIL_OVERVIEW_HREF}`;
+  )}/${VM_DETAIL_DETAILS_HREF}`;
 
   return (
     <DashboardCard>

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../models';
 import { getResource } from '../../utils';
 import {
-  VM_DETAIL_OVERVIEW_HREF,
+  VM_DETAIL_DETAILS_HREF,
   VM_DETAIL_DISKS_HREF,
   VM_DETAIL_NETWORKS_HREF,
   VM_DETAIL_CONSOLES_HREF,
@@ -40,7 +40,7 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
   };
 
   const overviewPage = {
-    href: VM_DETAIL_OVERVIEW_HREF,
+    href: VM_DETAIL_DETAILS_HREF,
     name: 'Details',
     component: VMDetailsFirehose,
   };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../models';
 import { getResource } from '../../utils';
 import {
-  VM_DETAIL_OVERVIEW_HREF,
+  VM_DETAIL_DETAILS_HREF,
   VM_DETAIL_DISKS_HREF,
   VM_DETAIL_NETWORKS_HREF,
   VM_DETAIL_CONSOLES_HREF,
@@ -44,7 +44,7 @@ export const VirtualMachinesInstanceDetailsPage: React.FC<VirtualMachinesInstanc
   };
 
   const overviewPage = {
-    href: VM_DETAIL_OVERVIEW_HREF,
+    href: VM_DETAIL_DETAILS_HREF,
     name: 'Overview',
     component: VMDetailsFirehose,
   };

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -27,7 +27,7 @@ export const LABEL_USED_TEMPLATE_NAMESPACE = 'vm.kubevirt.io/template-namespace'
 
 export const DEFAULT_RDP_PORT = 3389;
 
-export const VM_DETAIL_OVERVIEW_HREF = 'overview';
+export const VM_DETAIL_DETAILS_HREF = 'details';
 export const VM_DETAIL_DISKS_HREF = 'disks';
 export const VM_DETAIL_NETWORKS_HREF = 'nics';
 export const VM_DETAIL_CONSOLES_HREF = 'consoles';


### PR DESCRIPTION
In #3934 we renamed Overview pages to Details

This PR align the href of the details page to the new name.

Screenshot:
before:
![Screenshot from 2020 02 04 13 32 42 jpg  JPEG Image  1437 × 640 pixels ](https://user-images.githubusercontent.com/2181522/73741742-89eba180-4753-11ea-976e-71b315cc3e3b.png)

after:
![Screenshot from 2020-02-04 13-39-05](https://user-images.githubusercontent.com/2181522/73741866-d1722d80-4753-11ea-8348-be79d85179e9.jpg)
