### PR TITLE
Bug 1797643: Set shorter names when generating pipeline on import flows

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
@@ -1,5 +1,55 @@
 import { GitImportFormData, Resources } from '../import-types';
 
+export const mockPipelineTemplate = {
+  apiVersion: 'tekton.dev/v1alpha1',
+  kind: 'Pipeline',
+  metadata: {
+    name: 'new-pipeline',
+    namespace: 'new-proj',
+  },
+  spec: {
+    params: [
+      {
+        name: 'paramName',
+        type: 'string',
+      },
+    ],
+    resources: [
+      {
+        name: 'app-git',
+        type: 'git',
+      },
+      {
+        name: 'app-image',
+        type: 'image',
+      },
+    ],
+    tasks: [
+      {
+        name: 'build-app',
+        taskRef: {
+          name: 's2i-java-11',
+          kind: 'ClusterTask',
+        },
+        resources: {
+          inputs: [
+            {
+              name: 'source',
+              resource: 'app-git',
+            },
+          ],
+          outputs: [
+            {
+              name: 'image',
+              resource: 'app-image',
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
 export const defaultData: GitImportFormData = {
   project: {
     name: 'gijohn',
@@ -123,6 +173,7 @@ export const defaultData: GitImportFormData = {
   },
   pipeline: {
     enabled: false,
+    template: mockPipelineTemplate,
   },
 };
 

--- a/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
@@ -27,7 +27,7 @@ export const createPipelineForImportFlow = async (formData: GitImportFormData) =
   const template = _.cloneDeep(pipeline.template);
 
   template.metadata = {
-    name: `${name}-${template.metadata.name}`,
+    name: `${name}`,
     namespace,
     labels: { ...template.metadata.labels, 'app.kubernetes.io/instance': name },
   };


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-2761

This PR 
- Shortens the pipeline name that gets generated using pipeline template in import flows.
- Adds unit tests and fixes old ones.