### PR TITLE
Bug 1776682: Show network interface name for PXE boot

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/network-boot-source.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/network-boot-source.tsx
@@ -47,12 +47,12 @@ export const NetworkBootSource: React.FC<NetworkBootSourceProps> = ({
           isDisabled={isDisabled}
         >
           <FormSelectPlaceholderOption isDisabled placeholder={SELECT_PXE_NIC} />
-          {ignoreCaseSort(pxeNetworks, null, (n) => n.networkWrapper.getReadableName()).map(
+          {ignoreCaseSort(pxeNetworks, null, (n) => n.networkInterfaceWrapper.getName()).map(
             (network) => (
               <FormSelectOption
                 key={network.id}
                 value={network.id}
-                label={network.networkWrapper.getReadableName()}
+                label={network.networkWrapper.getName()}
               />
             ),
           )}


### PR DESCRIPTION
In Create VM Wizard, the "network interface name" is listed among
the "Boot Source" options instead of a "network name" to conform
the description provided by the drop-down box.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1776682

After fix:
![nicName](https://user-images.githubusercontent.com/17194943/73755020-b0b2d380-4765-11ea-80bd-ff2d9449d418.png)
