### PR TITLE
Bug 1797027: Monitoring Dashboards: Fix variables handling

### DIFF
--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -142,12 +142,19 @@ export default (state: UIState, action: UIAction): UIState => {
     case ActionType.MonitoringDashboardsClearVariables:
       return state.setIn(['monitoringDashboards', 'variables'], ImmutableMap());
 
-    case ActionType.MonitoringDashboardsPatchVariable:
-      return state.mergeIn(
-        ['monitoringDashboards', 'variables', action.payload.key],
-        action.payload.patch,
-      );
+    case ActionType.MonitoringDashboardsPatchVariable: {
+      const { key, patch } = action.payload;
 
+      // If we don't have a value, but do have options, use the first option as the value
+      if (
+        patch.value === undefined &&
+        patch.options?.length &&
+        state.getIn(['monitoringDashboards', 'variables', key, 'value']) === undefined
+      ) {
+        patch.value = patch.options[0];
+      }
+      return state.mergeIn(['monitoringDashboards', 'variables', key], patch);
+    }
     case ActionType.SetMonitoringData: {
       const alerts =
         action.payload.key === 'alerts'


### PR DESCRIPTION
Fixes a bug where some variable dropdowns were not rendered, which in
turn caused cards that used the variable to not be rendered.

Also fixes a bug where the variable values were getting reset when the
Time Range option was changed.

Move the logic for loading variable options into the `SingleVariableDropdown` component.

Add error message when the variable options fail to load.