### PR TITLE
Bug 1795144: Set default pullSecret

### DIFF
--- a/frontend/public/module/k8s/resource.js
+++ b/frontend/public/module/k8s/resource.js
@@ -92,6 +92,12 @@ export const k8sPatch = (kind, resource, data, opts = {}) =>
     _.compact(data),
   );
 
+export const k8sPatchByName = (kind, name, namespace, data, opts = {}) =>
+  coFetchJSON.patch(
+    resourceURL(kind, Object.assign({ ns: namespace, name }, opts)),
+    _.compact(data),
+  );
+
 export const k8sKill = (kind, resource, opts = {}, json = null) =>
   coFetchJSON.delete(
     resourceURL(


### PR DESCRIPTION
When user sets the **Default Pull Secret** on the Project/Namespace Details page, the secret should be added as a `imagePullSecret` on the `default` ServiceAccount.

/assign @spadgett 