### PR TITLE
Bug 1797729:  fix bug where text can overlap on operand details page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
@@ -256,13 +256,11 @@ export const SpecDescriptor: React.SFC<DescriptorProps> = (props) => {
 
   return (
     <dl className="olm-descriptor">
-      <div style={{ width: 'max-content' }}>
-        <Tooltip content={descriptor.description}>
-          <dt className="olm-descriptor__title" data-test-descriptor-label={descriptor.displayName}>
-            {descriptor.displayName}
-          </dt>
-        </Tooltip>
-      </div>
+      <Tooltip content={descriptor.description}>
+        <dt className="olm-descriptor__title" data-test-descriptor-label={descriptor.displayName}>
+          {descriptor.displayName}
+        </dt>
+      </Tooltip>
       <dd className="olm-descriptor__value">
         <Capability
           descriptor={descriptor}

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -112,13 +112,11 @@ export const StatusDescriptor: React.SFC<DescriptorProps> = (props) => {
 
   return (
     <dl className="olm-descriptor">
-      <div style={{ width: 'max-content' }}>
-        <Tooltip content={descriptor.description}>
-          <dt className="olm-descriptor__title" data-test-descriptor-label={descriptor.displayName}>
-            {descriptor.displayName}
-          </dt>
-        </Tooltip>
-      </div>
+      <Tooltip content={descriptor.description}>
+        <dt className="olm-descriptor__title" data-test-descriptor-label={descriptor.displayName}>
+          {descriptor.displayName}
+        </dt>
+      </Tooltip>
       <dd className="olm-descriptor__value">
         {descriptor.displayName === 'Status' ? (
           value === 'Running' ? (

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -288,3 +288,7 @@ $co-affinity-row-margin: 15px;
 .key-operator-value__row {
   padding-bottom: 15px;
 }
+
+.olm-descriptor__title {
+  display: inline-block;
+}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1797729

After:

![Screen Shot 2020-02-04 at 10 34 36 AM](https://user-images.githubusercontent.com/895728/73759463-02ddff80-473a-11ea-9343-72254c5e7bbb.png)
![Screen Shot 2020-02-04 at 10 34 44 AM](https://user-images.githubusercontent.com/895728/73759464-03769600-473a-11ea-9900-0b46422949e5.png)
