### PR TITLE
Bug 1798182: Fix operand tab order

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -794,6 +794,7 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
         (acc, desc: CRDDescription) =>
           !isInternalObject(internalObjects, desc.name)
             ? [
+                ...acc,
                 {
                   href: referenceForProvidedAPI(desc),
                   name: desc.displayName,
@@ -808,7 +809,6 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
                     _.isEqual,
                   ),
                 },
-                ...acc,
               ]
             : acc,
         [],


### PR DESCRIPTION
Show the tabs in the order as declared in the ClusterServiceVersion `spec.customresourcedefinitions.owned` array.

/assign @benjaminapetersen @rhamilto 