### PR TITLE
Bug 1798177: Add expand/collapse of operator groups, type icons

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -29,7 +29,7 @@ import ConnectedTopologyEdgePanel from './TopologyEdgePanel';
 import { topologyModelFromDataModel } from './topology-utils';
 import { layoutFactory, COLA_LAYOUT, COLA_FORCE_LAYOUT } from './layouts/layoutFactory';
 import ComponentFactory from './componentFactory';
-import { TYPE_APPLICATION_GROUP, TYPE_HELM_RELEASE } from './const';
+import { TYPE_APPLICATION_GROUP, TYPE_HELM_RELEASE, TYPE_OPERATOR_BACKED_SERVICE } from './const';
 import TopologyFilterBar from './filters/TopologyFilterBar';
 import { getTopologyFilters, TopologyFilters } from './filters/filter-utils';
 import TopologyHelmReleasePanel from './TopologyHelmReleasePanel';
@@ -200,6 +200,9 @@ const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters }) =>
       if (selectedEntity.getType() === TYPE_HELM_RELEASE) {
         return <TopologyHelmReleasePanel helmRelease={selectedEntity} />;
       }
+      if (selectedEntity.getType() === TYPE_OPERATOR_BACKED_SERVICE) {
+        return null;
+      }
       return <TopologyResourcePanel item={selectedEntity.getData() as TopologyDataObject} />;
     }
 
@@ -212,9 +215,14 @@ const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters }) =>
   const renderSideBar = () => {
     const selectedEntity =
       selectedIds.length === 0 ? null : visRef.current.getElementById(selectedIds[0]);
+    const details = selectedItemDetails();
+    if (!selectedEntity || !details) {
+      return null;
+    }
+
     return (
-      <TopologySideBar show={!!selectedEntity} onClose={onSidebarClose}>
-        {selectedEntity && selectedItemDetails()}
+      <TopologySideBar show={!!selectedEntity && !!details} onClose={onSidebarClose}>
+        {selectedEntity && details}
       </TopologySideBar>
     );
   };
@@ -223,12 +231,14 @@ const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters }) =>
     return null;
   }
 
+  const sideBar = renderSideBar();
+
   return (
     <TopologyView
       viewToolbar={<TopologyFilterBar />}
       controlBar={renderControlBar()}
-      sideBar={renderSideBar()}
-      sideBarOpen={selectedIds.length > 0}
+      sideBar={sideBar}
+      sideBarOpen={!!sideBar}
     >
       <VisualizationSurface visualization={visRef.current} state={{ selectedIds }} />
     </TopologyView>

--- a/frontend/packages/dev-console/src/components/topology/componentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/componentFactory.ts
@@ -124,7 +124,7 @@ class ComponentFactory {
             ),
           );
         case TYPE_OPERATOR_BACKED_SERVICE:
-          return OperatorBackedService;
+          return withSelection(false, true)(OperatorBackedService);
         case TYPE_OPERATOR_WORKLOAD:
           return withCreateConnector(createConnectorCallback(this.hasServiceBinding))(
             withEditReviewAccess('patch')(

--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmRelease.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmRelease.scss
@@ -10,10 +10,10 @@
 
   &__bg {
     fill: $group-node-fill-color;
-    fill-opacity: 0.5;
+    fill-opacity: $group-node-fill-opacity;
     stroke: $group-node-stroke-color;
-    stroke-width: 4px;
-    stroke-dasharray: 9;
+    stroke-width: $group-node-stroke-width;
+    stroke-dasharray: $group-node-stroke-dasharray;
   }
 
   &.is-filtered &__bg {

--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
@@ -55,7 +55,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({ element, onSelect, se
         rx="5"
         ry="5"
       />
-      <GroupNode kind="HelmRelease" title={element.getLabel()}>
+      <GroupNode kind="HelmRelease" title={element.getLabel()} typeIconClass="icon-helm">
         <ResourceKindsInfo groupResources={element.getData().groupResources} />
       </GroupNode>
     </g>

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/GroupNode.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/GroupNode.scss
@@ -3,4 +3,8 @@
     font-size: var(--pf-global--FontSize--lg);
     font-weight: var(--pf-global--FontWeight--bold);
   }
+  &__type-icon {
+    fill: var(--pf-global--Color--light-100);
+    font-size: var(--pf-global--FontSize--md);
+  }
 }

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/GroupNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/GroupNode.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
-import { useSize } from '@console/topology';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { useSize, useHover } from '@console/topology';
 import SvgResourceIcon from './ResourceIcon';
+import SvgCircledIcon from '../../../svg/SvgCircledIcon';
 
+import './GroupNode.scss';
+
+const MAX_TITLE_LENGTH = 35;
 const TOP_MARGIN = 20;
 const LEFT_MARGIN = 20;
 const TEXT_MARGIN = 10;
@@ -11,25 +16,53 @@ type GroupNodeProps = {
   title: string;
   kind?: string;
   children?: React.ReactNode;
+  typeIconClass?: string;
 };
 
-const GroupNode: React.FC<GroupNodeProps> = ({ children, kind, title }) => {
+const shouldTruncateText = (text: string) => text.length > MAX_TITLE_LENGTH + 5;
+const truncateText = (text: string = ''): string => {
+  if (!shouldTruncateText(text)) {
+    return text;
+  }
+  return `${text.substr(0, MAX_TITLE_LENGTH - 1)}…`;
+};
+
+const GroupNode: React.FC<GroupNodeProps> = ({ children, kind, title, typeIconClass }) => {
+  const [textHover, textHoverRef] = useHover();
   const [iconSize, iconRef] = useSize([kind]);
   const iconWidth = iconSize ? iconSize.width : 0;
   const iconHeight = iconSize ? iconSize.height : 0;
   return (
     <>
+      {typeIconClass && (
+        <SvgCircledIcon
+          className="odc-group-node__type-icon"
+          x={10}
+          y={-10}
+          width={20}
+          height={20}
+          iconClass={typeIconClass}
+        />
+      )}
       <SvgResourceIcon ref={iconRef} x={TOP_MARGIN} y={LEFT_MARGIN} kind={kind} leftJustified />
       {title && (
-        <text
-          className="odc-group-node__title"
-          x={LEFT_MARGIN + iconWidth + TEXT_MARGIN}
-          y={TOP_MARGIN + iconHeight}
-          textAnchor="start"
-          dy="-0.25em"
+        <Tooltip
+          content={title}
+          position={TooltipPosition.top}
+          trigger="manual"
+          isVisible={textHover && shouldTruncateText(title)}
         >
-          {title}
-        </text>
+          <text
+            ref={textHoverRef}
+            className="odc-group-node__title"
+            x={LEFT_MARGIN + iconWidth + TEXT_MARGIN}
+            y={TOP_MARGIN + iconHeight}
+            textAnchor="start"
+            dy="-0.25em"
+          >
+            {truncateText(title)}
+          </text>
+        </Tooltip>
       )}
       {children && (
         <g

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.scss
@@ -10,9 +10,10 @@
 
   &__bg {
     fill: $group-node-fill-color;
-    fill-opacity: 0.5;
+    fill-opacity: $group-node-fill-opacity;
     stroke: $group-node-stroke-color;
-    stroke-width: 5px;
+    stroke-width: $group-node-stroke-width;
+    stroke-dasharray: $group-node-stroke-dasharray;
   }
 
   &.is-filtered &__bg {

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceGroup.tsx
@@ -135,7 +135,7 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
           <SvgBoxedText
             className="odc-knative-service__label odc-base-node__label"
             x={x + width / 2}
-            y={y + height + 30}
+            y={y + height + 20}
             paddingX={8}
             paddingY={4}
             kind={data.kind}

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.scss
@@ -10,10 +10,10 @@
 
   &__bg {
     fill: $group-node-fill-color;
-    fill-opacity: 0.5;
+    fill-opacity: $group-node-fill-opacity;
     stroke: $group-node-stroke-color;
-    stroke-width: 5px;
-    stroke-dasharray: 9;
+    stroke-width: $group-node-stroke-width;
+    stroke-dasharray: $group-node-stroke-dasharray;
   }
 
   &.is-filtered &__bg {

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.scss
@@ -19,6 +19,11 @@
   &.is-filtered &__bg {
     stroke: $filtered-stroke-color;
   }
+
+  &.is-selected &__bg {
+    fill: $selected-fill-color;
+    stroke: $selected-stroke-color;
+  }
 }
 
 .odc-m-drag-active,

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.tsx
@@ -1,93 +1,26 @@
 import * as React from 'react';
-import * as classNames from 'classnames';
-import {
-  Layer,
-  useHover,
-  Node,
-  createSvgIdUrl,
-  useDragNode,
-  observer,
-  useCombineRefs,
-} from '@console/topology';
-import NodeShadows, { NODE_SHADOW_FILTER_ID_HOVER, NODE_SHADOW_FILTER_ID } from '../NodeShadows';
-import SvgBoxedText from '../../../svg/SvgBoxedText';
-import useSearchFilter from '../../filters/useSearchFilter';
-import { nodeDragSourceSpec } from '../../componentUtils';
-import { TYPE_OPERATOR_BACKED_SERVICE } from '../../const';
+import { Node, observer, WithSelectionProps } from '@console/topology';
+import OperatorBackedServiceGroup from './OperatorBackedServiceGroup';
+import OperatorBackedServiceNode from './OperatorBackedServiceNode';
+
 import './OperatorBackedService.scss';
 
 export type OperatorBackedServiceProps = {
   element: Node;
-};
+} & WithSelectionProps;
 
-const OperatorBackedService: React.FC<OperatorBackedServiceProps> = ({ element }) => {
-  const [hover, hoverRef] = useHover();
-  const [labelHover, labelHoverRef] = useHover();
-  const { x, y, width, height } = element.getBounds();
-  const [{ dragging }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
-    {
-      element,
-    },
-  );
-  const [{ dragging: labelDragging }, dragLabelRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
-    {
-      element,
-    },
-  );
-  const refs = useCombineRefs(dragNodeRef, hoverRef);
-  const [filtered] = useSearchFilter(element.getLabel());
-  return (
-    <>
-      <NodeShadows />
-      <Layer id={dragging || labelDragging ? undefined : 'groups2'}>
-        <g
-          ref={refs}
-          className={classNames('odc-operator-backed-service', {
-            'is-dragging': dragging || labelDragging,
-            'is-filtered': filtered,
-          })}
-        >
-          <rect
-            className="odc-operator-backed-service__bg"
-            x={x}
-            y={y}
-            width={width}
-            height={height}
-            rx="5"
-            ry="5"
-            filter={createSvgIdUrl(
-              hover || labelHover ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID,
-            )}
-          />
-        </g>
-      </Layer>
-      {element.getLabel() && (
-        <g
-          ref={labelHoverRef}
-          className={classNames('odc-operator-backed-service', {
-            'is-dragging': dragging || labelDragging,
-            'is-filtered': filtered,
-          })}
-        >
-          <SvgBoxedText
-            className="odc-base-node__label"
-            x={x + width / 2}
-            y={y + height + 20}
-            paddingX={8}
-            paddingY={4}
-            kind="Operator"
-            truncate={16}
-            dragRef={dragLabelRef}
-            typeIconClass={element.getData().data.builderImage}
-          >
-            {element.getLabel()}
-          </SvgBoxedText>
-        </g>
-      )}
-    </>
-  );
+const OperatorBackedService: React.FC<OperatorBackedServiceProps> = (
+  props: OperatorBackedServiceProps,
+) => {
+  if (
+    props.element.isCollapsed() ||
+    !props.element.getData().groupResources ||
+    !props.element.getData().groupResources.length
+  ) {
+    return <OperatorBackedServiceNode {...props} />;
+  }
+
+  return <OperatorBackedServiceGroup {...props} />;
 };
 
 export default observer(OperatorBackedService);

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceGroup.tsx
@@ -50,7 +50,6 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
       ref={hoverRef}
       onClick={onSelect}
       className={classNames('odc-operator-backed-service', {
-        'is-selected': selected,
         'is-dragging': dragging || labelDragging,
         'is-filtered': filtered,
       })}
@@ -87,7 +86,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
         <SvgBoxedText
           className="odc-base-node__label"
           x={x + width / 2}
-          y={y + height + 30}
+          y={y + height + 20}
           paddingX={8}
           paddingY={4}
           kind="Operator"

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceGroup.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import {
+  Node,
+  observer,
+  WithSelectionProps,
+  useDragNode,
+  Layer,
+  useHover,
+  createSvgIdUrl,
+  useCombineRefs,
+} from '@console/topology';
+import SvgBoxedText from '../../../svg/SvgBoxedText';
+import { nodeDragSourceSpec } from '../../componentUtils';
+import { TYPE_OPERATOR_BACKED_SERVICE } from '../../const';
+import useSearchFilter from '../../filters/useSearchFilter';
+import NodeShadows, { NODE_SHADOW_FILTER_ID, NODE_SHADOW_FILTER_ID_HOVER } from '../NodeShadows';
+
+export type OperatorBackedServiceGroupProps = {
+  element: Node;
+} & WithSelectionProps;
+
+const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
+  element,
+  selected,
+  onSelect,
+}) => {
+  const [hover, hoverRef] = useHover();
+  const [innerHover, innerHoverRef] = useHover();
+  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(
+    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
+    {
+      element,
+    },
+  );
+  const [{ dragging: labelDragging, regrouping: labelRegrouping }, dragLabelRef] = useDragNode(
+    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
+    {
+      element,
+    },
+  );
+
+  const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
+  const { data } = element.getData();
+  const [filtered] = useSearchFilter(element.getLabel());
+  const { x, y, width, height } = element.getBounds();
+
+  return (
+    <g
+      ref={hoverRef}
+      onClick={onSelect}
+      className={classNames('odc-operator-backed-service', {
+        'is-selected': selected,
+        'is-dragging': dragging || labelDragging,
+        'is-filtered': filtered,
+      })}
+    >
+      <NodeShadows />
+      <Layer
+        id={(dragging || labelDragging) && (regrouping || labelRegrouping) ? undefined : 'groups2'}
+      >
+        <g
+          ref={nodeRefs}
+          className={classNames('odc-operator-backed-service', {
+            'is-dragging': dragging || labelDragging,
+            'is-filtered': filtered,
+          })}
+        >
+          <rect
+            className="odc-operator-backed-service__bg"
+            x={x}
+            y={y}
+            width={width}
+            height={height}
+            rx="5"
+            ry="5"
+            filter={createSvgIdUrl(
+              hover || innerHover || dragging || labelDragging
+                ? NODE_SHADOW_FILTER_ID_HOVER
+                : NODE_SHADOW_FILTER_ID,
+            )}
+          />
+        </g>
+      </Layer>
+      {(data.kind || element.getLabel()) && (
+        <SvgBoxedText
+          className="odc-base-node__label"
+          x={x + width / 2}
+          y={y + height + 30}
+          paddingX={8}
+          paddingY={4}
+          kind="Operator"
+          truncate={16}
+          dragRef={dragLabelRef}
+          typeIconClass={element.getData().data.builderImage}
+        >
+          {element.getLabel()}
+        </SvgBoxedText>
+      )}
+    </g>
+  );
+};
+
+export default observer(OperatorBackedServiceGroup);

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceGroup.tsx
@@ -62,6 +62,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
         <g
           ref={nodeRefs}
           className={classNames('odc-operator-backed-service', {
+            'is-selected': selected,
             'is-dragging': dragging || labelDragging,
             'is-filtered': filtered,
           })}

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceNode.tsx
@@ -3,78 +3,58 @@ import * as classNames from 'classnames';
 import {
   observer,
   Node,
+  WithSelectionProps,
   useAnchor,
   RectAnchor,
   useCombineRefs,
   useHover,
   useDragNode,
-  WithDndDropProps,
-  WithSelectionProps,
-  WithContextMenuProps,
   createSvgIdUrl,
 } from '@console/topology';
 import useSearchFilter from '../../filters/useSearchFilter';
 import { nodeDragSourceSpec } from '../../componentUtils';
-import { TYPE_KNATIVE_SERVICE } from '../../const';
+import { TYPE_OPERATOR_BACKED_SERVICE } from '../../const';
 import NodeShadows, { NODE_SHADOW_FILTER_ID, NODE_SHADOW_FILTER_ID_HOVER } from '../NodeShadows';
 import GroupNode from './GroupNode';
 import ResourceKindsInfo from './ResourceKindsInfo';
 
-type KnativeServiceNodeProps = {
+export type OperatorBackedServiceNodeProps = {
   element: Node;
-  highlight?: boolean;
-  canDrop?: boolean;
-  dropTarget?: boolean;
-  editAccess: boolean;
-} & WithSelectionProps &
-  WithDndDropProps &
-  WithContextMenuProps;
+} & WithSelectionProps;
 
-const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
+const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   element,
   selected,
   onSelect,
-  onContextMenu,
-  contextMenuOpen,
-  canDrop,
-  dropTarget,
-  dndDropRef,
-  editAccess,
 }) => {
   useAnchor((e: Node) => new RectAnchor(e, 4));
   const [hover, hoverRef] = useHover();
   const [{ dragging }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess),
+    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
     {
       element,
     },
   );
   const refs = useCombineRefs<SVGRectElement>(hoverRef, dragNodeRef);
   const [filtered] = useSearchFilter(element.getLabel());
-  const { kind } = element.getData().data;
+  const kind = 'Operator';
   const { width, height } = element.getBounds();
 
   return (
     <g
       ref={refs}
-      onContextMenu={onContextMenu}
       onClick={onSelect}
-      className={classNames('odc-knative-service', {
+      className={classNames('odc-operator-backed-service', {
         'is-dragging': dragging,
-        'is-highlight': canDrop,
         'is-selected': selected,
-        'is-dropTarget': canDrop && dropTarget,
         'is-filtered': filtered,
       })}
     >
       <NodeShadows />
       <rect
-        ref={dndDropRef}
-        className="odc-knative-service__bg"
+        className="odc-operator-backed-service__bg"
         filter={createSvgIdUrl(
-          hover || dragging || contextMenuOpen || dropTarget
-            ? NODE_SHADOW_FILTER_ID_HOVER
-            : NODE_SHADOW_FILTER_ID,
+          hover || dragging ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID,
         )}
         x={0}
         y={0}
@@ -83,14 +63,15 @@ const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
         rx="5"
         ry="5"
       />
-      <GroupNode kind={kind} title={element.getLabel()} typeIconClass="icon-knative">
-        <ResourceKindsInfo
-          groupResources={element.getData().groupResources}
-          emptyKind="Revisions"
-        />
+      <GroupNode
+        kind={kind}
+        title={element.getLabel()}
+        typeIconClass={element.getData().data.builderImage}
+      >
+        <ResourceKindsInfo groupResources={element.getData().groupResources} />
       </GroupNode>
     </g>
   );
 };
 
-export default observer(KnativeServiceNode);
+export default observer(OperatorBackedServiceNode);

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.scss
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.scss
@@ -10,6 +10,9 @@ $interactive-stroke-color: var(--pf-global--active-color--100);
 
 $group-node-stroke-color: #bbbbbb;
 $group-node-fill-color: #d1d1d1;
+$group-node-fill-opacity: 0.5;
+$group-node-stroke-width: 5px;
+$group-node-stroke-dasharray: 9;
 
 $de-emphasize-opacity: 0.4;
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2851
https://issues.redhat.com/browse/ODC-2894

**Analysis / Root cause**: 
The expand/collapse groupings never took the Operator Groups into consideration so they were not expanded/collapsed when the filter was toggled.

**Solution Description**: 
Add the necessary handling of the filter for the expand/collapse of operator groups. Allow operator groups to be selected, though there is no side panel for them at this time. To better distinguish the collapsed group types, add the grouping type icon to the upper left corner of collapsed groups.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

**Sample Screenshots**:
![groupings](https://user-images.githubusercontent.com/11633780/73774948-ea2e1380-4752-11ea-8054-3b9af9cf2b58.gif)


cc @openshift/team-devconsole-ux 
