### PR TITLE
Bug 1795707: improve notification drawer performance

### DIFF
--- a/analyze.sh
+++ b/analyze.sh
@@ -14,11 +14,12 @@ if [ -d "$ARTIFACT_DIR" ]; then
   cp public/dist/report.html "${ARTIFACT_DIR}"
 fi
 
+MAX_BYTES=2621440 # ~2.5 MiB
 VENDORS_MAIN_BYTES=$(jq -r '.assets[] | select(.name | match("^vendors~main-chunk.*js$")) | .size' public/dist/stats.json)
 DISPLAY_VALUE=$(awk "BEGIN {printf \"%.2f\n\", $VENDORS_MAIN_BYTES/1024/1024}")
 echo "Main vendor bundle size: $DISPLAY_VALUE MiB"
-if (( $VENDORS_MAIN_BYTES > (2 * 1024 * 1024) )); then
-  echo "FAILURE: Main vendor bundle is larger than the 2 MiB limit."
+if (( VENDORS_MAIN_BYTES > MAX_BYTES )); then
+  echo "FAILURE: Main vendor bundle is larger than the 2.5 MiB limit."
   echo "If you haven't added a new dependency, an import might have accidentally pulled an existing dependency into the main vendor bundle."
   echo "If adding a large dependency, consider lazy loading the component with AsyncComponent."
   exit 1

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -12,8 +12,9 @@ import { detectFeatures } from '../actions/features';
 import AppContents from './app-contents';
 import { getBrandingDetails, Masthead } from './masthead';
 import { ConsoleNotifier } from './console-notifier';
+import { ConnectedNotificationDrawer } from './notification-drawer';
 import { Navigation } from './nav';
-import { history, Firehose, AsyncComponent } from './utils';
+import { history, Firehose } from './utils';
 import * as UIActions from '../actions/ui';
 import { fetchSwagger, getCachedResources, referenceForModel } from '../module/k8s';
 import { receivedResources, watchAPIServices } from '../actions/k8s';
@@ -40,13 +41,6 @@ const cvResource = [
 
 // Edge lacks URLSearchParams
 import 'url-search-params-polyfill';
-
-const NotificationDrawer = (props) => (
-  <AsyncComponent
-    loader={() => import('./notification-drawer').then((c) => c.ConnectedNotificationDrawer)}
-    {...props}
-  />
-);
 
 class App extends React.PureComponent {
   constructor(props) {
@@ -147,9 +141,9 @@ class App extends React.PureComponent {
           }
         >
           <Firehose resources={cvResource}>
-            <NotificationDrawer isDesktop={isDrawerInline}>
+            <ConnectedNotificationDrawer isDesktop={isDrawerInline}>
               <AppContents />
-            </NotificationDrawer>
+            </ConnectedNotificationDrawer>
           </Firehose>
         </Page>
         <ConsoleNotifier location="BannerBottom" />


### PR DESCRIPTION
* Don't lazy-load component since it will always load. This prevents the black box over the entire page during load
* Fix problem where `useEffect` hook constantly fires
* Don't return a new object each call to `notificationStateToProps` when alerts are empty
* Fix incorrect FirehoseResult type

/assign @jcaianirh @benjaminapetersen 