### PR TITLE
Bug 1798288: fixes sbr to work with knative service

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/componentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/componentFactory.ts
@@ -150,22 +150,24 @@ class ComponentFactory {
             ),
           );
         case TYPE_KNATIVE_SERVICE:
-          return withDndDrop<
-            any,
-            any,
-            { droppable?: boolean; hover?: boolean; canDrop?: boolean; dropTarget?: boolean },
-            NodeProps
-          >(graphEventSourceDropTargetSpec)(
-            withEditReviewAccess('update')(
-              withSelection(
-                false,
-                true,
-              )(
-                withContextMenu(
-                  nodeContextMenu,
-                  document.getElementById('modal-container'),
-                  'odc-topology-context-menu',
-                )(KnativeService),
+          return withCreateConnector(createConnectorCallback(this.hasServiceBinding))(
+            withDndDrop<
+              any,
+              any,
+              { droppable?: boolean; hover?: boolean; canDrop?: boolean; dropTarget?: boolean },
+              NodeProps
+            >(graphEventSourceDropTargetSpec)(
+              withEditReviewAccess('update')(
+                withSelection(
+                  false,
+                  true,
+                )(
+                  withContextMenu(
+                    nodeContextMenu,
+                    document.getElementById('modal-container'),
+                    'odc-topology-context-menu',
+                  )(KnativeService),
+                ),
               ),
             ),
           );
@@ -185,19 +187,17 @@ class ComponentFactory {
             ),
           );
         case TYPE_KNATIVE_REVISION:
-          return withCreateConnector(createConnectorCallback(this.hasServiceBinding))(
-            withDndDrop<any>(graphWorkloadDropTargetSpec)(
-              withDragNode(nodeDragSourceSpec(type, false))(
-                withSelection(
-                  false,
-                  true,
-                )(
-                  withContextMenu(
-                    nodeContextMenu,
-                    document.getElementById('modal-container'),
-                    'odc-topology-context-menu',
-                  )(RevisionNode),
-                ),
+          return withDndDrop<any>(graphWorkloadDropTargetSpec)(
+            withDragNode(nodeDragSourceSpec(type, false))(
+              withSelection(
+                false,
+                true,
+              )(
+                withContextMenu(
+                  nodeContextMenu,
+                  document.getElementById('modal-container'),
+                  'odc-topology-context-menu',
+                )(RevisionNode),
               ),
             ),
           );

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.tsx
@@ -5,6 +5,7 @@ import {
   WithSelectionProps,
   WithContextMenuProps,
   WithDndDropProps,
+  WithCreateConnectorProps,
 } from '@console/topology';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import { useAccessReview } from '@console/internal/components/utils';
@@ -21,7 +22,8 @@ export type KnativeServiceProps = {
   dropTarget?: boolean;
 } & WithSelectionProps &
   WithDndDropProps &
-  WithContextMenuProps;
+  WithContextMenuProps &
+  WithCreateConnectorProps;
 
 const KnativeService: React.FC<KnativeServiceProps> = (props) => {
   const resourceObj = getTopologyResourceObject(props.element.getData());

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceGroup.tsx
@@ -16,6 +16,7 @@ import {
   useHover,
   createSvgIdUrl,
   useCombineRefs,
+  WithCreateConnectorProps,
 } from '@console/topology';
 import SvgBoxedText from '../../../svg/SvgBoxedText';
 import RevisionTrafficSourceAnchor from '../anchors/RevisionTrafficSourceAnchor';
@@ -33,7 +34,8 @@ export type KnativeServiceGroupProps = {
   editAccess?: boolean;
 } & WithSelectionProps &
   WithDndDropProps &
-  WithContextMenuProps;
+  WithContextMenuProps &
+  WithCreateConnectorProps;
 
 const DECORATOR_RADIUS = 13;
 const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
@@ -46,6 +48,8 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
   dropTarget,
   dndDropRef,
   editAccess,
+  onHideCreateConnector,
+  onShowCreateConnector,
 }) => {
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
@@ -76,6 +80,16 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
   useAnchor(RectAnchor);
   const [filtered] = useSearchFilter(element.getLabel());
   const { x, y, width, height } = element.getBounds();
+
+  React.useLayoutEffect(() => {
+    if (editAccess) {
+      if (innerHover) {
+        onShowCreateConnector && onShowCreateConnector();
+      } else {
+        onHideCreateConnector && onHideCreateConnector();
+      }
+    }
+  }, [editAccess, innerHover, onShowCreateConnector, onHideCreateConnector]);
 
   return (
     <Tooltip content="Move sink to service" trigger="manual" isVisible={dropTarget && canDrop}>

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceNode.tsx
@@ -12,6 +12,7 @@ import {
   WithSelectionProps,
   WithContextMenuProps,
   createSvgIdUrl,
+  WithCreateConnectorProps,
 } from '@console/topology';
 import useSearchFilter from '../../filters/useSearchFilter';
 import { nodeDragSourceSpec } from '../../componentUtils';
@@ -28,7 +29,8 @@ type KnativeServiceNodeProps = {
   editAccess: boolean;
 } & WithSelectionProps &
   WithDndDropProps &
-  WithContextMenuProps;
+  WithContextMenuProps &
+  WithCreateConnectorProps;
 
 const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
   element,
@@ -40,6 +42,8 @@ const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
   dropTarget,
   dndDropRef,
   editAccess,
+  onHideCreateConnector,
+  onShowCreateConnector,
 }) => {
   useAnchor((e: Node) => new RectAnchor(e, 4));
   const [hover, hoverRef] = useHover();
@@ -53,6 +57,16 @@ const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
   const [filtered] = useSearchFilter(element.getLabel());
   const { kind } = element.getData().data;
   const { width, height } = element.getBounds();
+
+  React.useLayoutEffect(() => {
+    if (editAccess) {
+      if (hover) {
+        onShowCreateConnector && onShowCreateConnector();
+      } else {
+        onHideCreateConnector && onHideCreateConnector();
+      }
+    }
+  }, [editAccess, hover, onShowCreateConnector, onHideCreateConnector]);
 
   return (
     <g

--- a/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
@@ -373,10 +373,6 @@ export const tranformKnNodeData = (
             type,
             filters,
           );
-          edgesData = [
-            ...edgesData,
-            ...getTopologyEdgeItems(res, allResources, serviceBindingRequests, application),
-          ];
           groupsData = [...topologyGraphAndNodeData.graph.groups];
           break;
         }
@@ -388,7 +384,11 @@ export const tranformKnNodeData = (
             cheURL,
           );
           nodesData = [...nodesData, ...getKnativeTopologyNodeItems(res, type, resources)];
-          edgesData = [...edgesData, ...getTrafficTopologyEdgeItems(res, resources.revisions)];
+          edgesData = [
+            ...edgesData,
+            ...getTrafficTopologyEdgeItems(res, resources.revisions),
+            ...getTopologyEdgeItems(res, allResources, serviceBindingRequests, application),
+          ];
           groupsData = [...getTopologyGroupItems(res, topologyGraphAndNodeData.graph.groups)];
           break;
         }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2791

**Analysis / Root cause**: 
Currently, on hover on Revisions, we show connector which can be dropped to an Operator backed service which in turn creates Service Binding Request which is incorrect sbr should be created via knative service and in turn revisions should be rolled out

**Solution Description**: 
Service Binding Request would be from knative Service i.e on hover for knative service show connector which can be dropped to an Operator backed service which in turn creates Service Binding Request and inject required info in service.

**Screen shots / Gifs for design review**: 
On expand state: 

![ezgif com-video-to-gif (20)](https://user-images.githubusercontent.com/5129024/73815180-2a50cd00-480b-11ea-90b8-29d6008cea04.gif)

On Collapse state:

![ezgif com-video-to-gif (21)](https://user-images.githubusercontent.com/5129024/73919819-4b3c1f80-48ea-11ea-8b16-439ad26ecfa7.gif)



**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 