### PR TITLE
Bug 1798348: Removed internal objects from Installed Operator List Page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -224,6 +224,7 @@ export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionT
     const namespace = getNamespace(obj);
     const route = resourceObjPath(obj, referenceFor(obj));
     const uid = getUID(obj);
+    const internalObjects = getInternalObjects(obj);
     return (
       <TableRow id={uid} trKey={key} {...rest}>
         {/* Name */}
@@ -270,14 +271,18 @@ export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionT
 
         {/* Provided APIs */}
         <TableData className={tableColumnClasses[4]}>
-          {_.take(providedAPIsFor(obj), 4).map((desc) => (
+          {_.take(
+            providedAPIsFor(obj).filter((desc) => !isInternalObject(internalObjects, desc.name)),
+            4,
+          ).map((desc) => (
             <div key={referenceForProvidedAPI(desc)}>
               <Link to={`${route}/${referenceForProvidedAPI(desc)}`} title={desc.name}>
                 {desc.displayName}
               </Link>
             </div>
           ))}
-          {providedAPIsFor(obj).length > 4 && (
+          {providedAPIsFor(obj).filter((desc) => !isInternalObject(internalObjects, desc.name))
+            .length > 4 && (
             <Link
               to={`${route}/instances`}
               title={`View ${providedAPIsFor(obj).length - 4} more...`}


### PR DESCRIPTION
![Screenshot from 2020-02-05 11-42-55](https://user-images.githubusercontent.com/54092533/73815777-00000f00-480d-11ea-8ff4-707bc8617b90.png)
- Removes Internal Objects from Provided APIs column.