### PR TITLE
Bug 1798481: Preserve choice of list view when navigating back

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/const.ts
+++ b/frontend/packages/dev-console/src/components/topology/const.ts
@@ -1,3 +1,5 @@
+import { STORAGE_PREFIX } from '@console/shared';
+
 export const TYPE_WORKLOAD = 'workload';
 export const TYPE_EVENT_SOURCE = 'event-source';
 export const TYPE_EVENT_SOURCE_LINK = 'event-source-link';
@@ -13,3 +15,4 @@ export const TYPE_HELM_WORKLOAD = 'helm-workload';
 export const TYPE_OPERATOR_BACKED_SERVICE = 'operator-backed-service';
 export const TYPE_OPERATOR_WORKLOAD = 'operator-workload';
 export const TYPE_TRAFFIC_CONNECTOR = 'traffic-connector';
+export const LAST_TOPOLOGY_VIEW_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-topology-view`;

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -423,6 +423,8 @@ const plugin: Plugin<ConsumedExtensions> = [
       path: [
         '/topology/all-namespaces',
         '/topology/ns/:name',
+        '/topology/all-namespaces/graph',
+        '/topology/ns/:name/graph',
         '/topology/all-namespaces/list',
         '/topology/ns/:name/list',
       ],


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-2929
**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
When in the topology view, I switch to the list view, I then navigate to a resource, then I select topology. I would like to still be in the list view but it puts me in the graph view.
**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Save the last topology active view to the localstorage and read the data from the localstorage when the user again comes back to topology view and navigate the user to the topology view accordingly.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Peek 2020-02-05 18-47](https://user-images.githubusercontent.com/2561818/73845448-addcdf00-4848-11ea-832f-7f0f7abac8c2.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
