### PR TITLE
Improve Console extension React hook & HOC

### DIFF
--- a/frontend/__tests__/reducers/features.spec.tsx
+++ b/frontend/__tests__/reducers/features.spec.tsx
@@ -1,10 +1,20 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
+import * as _ from 'lodash-es';
 
 import { setFlag } from '../../public/actions/features';
 import { receivedResources } from '../../public/actions/k8s';
 import { FLAGS } from '@console/shared';
-import { featureReducer, defaults, connectToFlags } from '../../public/reducers/features';
+import {
+  featureReducer,
+  featureReducerName,
+  defaults,
+  connectToFlags,
+  stateToFlagsObject,
+  getFlagsObject,
+  FeatureState,
+} from '../../public/reducers/features';
+import { RootState } from '../../public/redux';
 
 describe('featureReducer', () => {
   it('returns default values if state is uninitialized', () => {
@@ -74,5 +84,52 @@ describe('connectToFlags', () => {
     const jsx = <MyComponentWithFlags propA={42} propB={false} />;
 
     expect(jsx).toBeDefined();
+  });
+});
+
+describe('stateToFlagsObject', () => {
+  it('maps the desired flags to a new object', () => {
+    const featureState: FeatureState = Immutable.Map({
+      FOO: true,
+      BAR: false,
+      QUX: undefined,
+    });
+
+    expect(
+      _.isEqual(stateToFlagsObject(featureState, ['BAR', 'QUX']), {
+        BAR: false,
+        QUX: undefined,
+      }),
+    ).toBe(true);
+
+    expect(
+      _.isEqual(stateToFlagsObject(featureState, ['BAR', 'BAZ', 'QUX']), {
+        BAR: false,
+        BAZ: undefined,
+        QUX: undefined,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('getFlagsObject', () => {
+  it('maps the root state to feature sub-state as a new object', () => {
+    const featureState: FeatureState = Immutable.Map({
+      FOO: true,
+      BAR: false,
+      QUX: undefined,
+    });
+
+    const rootState = {
+      [featureReducerName]: featureState,
+    };
+
+    expect(
+      _.isEqual(getFlagsObject(rootState as RootState), {
+        FOO: true,
+        BAR: false,
+        QUX: undefined,
+      }),
+    ).toBe(true);
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,6 +123,7 @@
     "react-transition-group": "2.3.x",
     "react-virtualized": "9.x",
     "redux": "4.0.1",
+    "reselect": "4.x",
     "sanitize-html": "1.x",
     "screenfull": "4.x",
     "semver": "^6.0.0",

--- a/frontend/packages/console-plugin-sdk/src/withExtensions.tsx
+++ b/frontend/packages/console-plugin-sdk/src/withExtensions.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import * as _ from 'lodash';
 import { RootState } from '@console/internal/redux';
-import { stateToProps } from '@console/internal/reducers/features';
+import { stateToFlagsObject } from '@console/internal/reducers/features';
 import { pluginStore } from '@console/internal/plugins';
 import { getGatingFlagNames, isExtensionInUse } from './store';
 import { Extension, ExtensionTypeGuard } from './typings';
@@ -11,46 +11,76 @@ import { Extension, ExtensionTypeGuard } from './typings';
  * React higher-order component (HOC) for consuming Console extensions.
  *
  * This is semantically equivalent to `useExtensions` hook with one difference:
- * instead of using multiple HOCs for retrieving different extension types, you
- * may pass multiple type guards as arguments so that your component receives
- * all relevant extensions via single `extensions` prop.
+ * this HOC supports retrieving different extension types and providing them to
+ * your component as props.
  *
  * Example usage:
  *
  * ```ts
- * import { withExtensions, WithExtensionsProps, isNavItem, isPerspective } from '@console/plugin-sdk';
+ * import {
+ *   withExtensions,
+ *   NavItem,
+ *   Perspective,
+ *   isNavItem,
+ *   isPerspective,
+ * } from '@console/plugin-sdk';
  *
- * const Example = withExtensions(isNavItem, isPerspective)(
- *   class Example extends React.Component<ExampleOwnProps & WithExtensionsProps> {
+ * const Example = withExtensions<ExampleExtensionProps>({
+ *   navItemExtensions: isNavItem,
+ *   perspectiveExtensions: isPerspective,
+ * })(
+ *   class Example extends React.Component<ExampleOwnProps & ExampleExtensionProps> {
  *     render() {
- *       const navItems = this.props.extensions.filter(isNavItem);
- *       const perspectives = this.props.extensions.filter(isPerspective);
+ *       const { navItemExtensions, perspectiveExtensions } = this.props;
  *       // process extensions and render your component
  *     }
  *   },
  * );
+ *
+ * type ExampleExtensionProps = {
+ *   navItemExtensions: NavItem[];
+ *   perspectiveExtensions: Perspective[];
+ * };
  * ```
  *
- * @param typeGuards Type guard(s) used to narrow the extension type(s).
+ * @param typeGuardMapper Object that maps prop names to extension type guards.
+ * It's basically an object-based analogy to Redux `mapStateToProps` function.
  */
-export const withExtensions: WithExtensions = (...typeGuards) => {
+export const withExtensions = <
+  TExtensionProps extends ExtensionProps<E>,
+  E extends Extension = Extension
+>(
+  typeGuardMapper: ExtensionTypeGuardMapper<E, TExtensionProps>,
+): (<P extends TExtensionProps>(
+  C: React.ComponentType<P>,
+) => React.ComponentType<Omit<P, keyof TExtensionProps>> & {
+  WrappedComponent: React.ComponentType<P>;
+}) => {
   const allExtensions = pluginStore.getAllExtensions();
 
-  // 1) Narrow extensions according to type guard(s)
-  const matchedExtensions = _.flatMap(typeGuards.map((tg) => allExtensions.filter(tg)));
+  // 1) Narrow extensions according to type guards
+  const matchedExtensions = _.flatMap(
+    Object.values(typeGuardMapper).map((tg) => allExtensions.filter(tg)),
+  );
 
   // 2.a) Compute flags relevant for gating matched extensions
   const gatingFlagNames = getGatingFlagNames(matchedExtensions);
 
-  return connect(
-    (state: RootState) => {
+  return connect<TExtensionProps, any, any, RootState>(
+    (state) => {
       // 2.b) Compute flags relevant for gating matched extensions
-      const gatingFlags = stateToProps(gatingFlagNames, state).flags;
+      const gatingFlags = stateToFlagsObject(state.FLAGS, gatingFlagNames);
 
       // 3) Gate matched extensions by relevant feature flags
       const extensionsInUse = matchedExtensions.filter((e) => isExtensionInUse(e, gatingFlags));
 
-      return { extensions: extensionsInUse };
+      return Object.keys(typeGuardMapper).reduce(
+        (props, propName) => ({
+          ...props,
+          [propName]: extensionsInUse.filter(typeGuardMapper[propName]),
+        }),
+        {},
+      ) as TExtensionProps;
     },
     null,
     null,
@@ -61,14 +91,10 @@ export const withExtensions: WithExtensions = (...typeGuards) => {
   );
 };
 
-type WithExtensions = <E extends Extension, P extends WithExtensionsProps<E>>(
-  ...typeGuards: ExtensionTypeGuard<E>[]
-) => (
-  C: React.ComponentType<P>,
-) => React.ComponentType<Omit<P, keyof WithExtensionsProps<E>>> & {
-  WrappedComponent: React.ComponentType<P>;
+type ExtensionProps<E extends Extension> = {
+  [propName: string]: E[];
 };
 
-export type WithExtensionsProps<E extends Extension = Extension> = {
-  extensions: readonly E[];
+type ExtensionTypeGuardMapper<E extends Extension, P extends ExtensionProps<E>> = {
+  [K in keyof P]: ExtensionTypeGuard<E>;
 };

--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -5,7 +5,7 @@ import { CaretDownIcon } from '@patternfly/react-icons';
 import { Perspective } from '@console/plugin-sdk';
 import * as plugins from '../../plugins';
 import { RootState } from '../../redux';
-import { stateToFlagsObject, FlagsObject, featureReducerName } from '../../reducers/features';
+import { featureReducerName, getFlagsObject, FlagsObject } from '../../reducers/features';
 import { getActivePerspective } from '../../reducers/ui';
 import * as UIActions from '../../actions/ui';
 import { history } from '../utils';
@@ -104,7 +104,7 @@ const NavHeader_: React.FC<NavHeaderProps & StateProps> = ({
 
 const mapStateToProps = (state: RootState): StateProps => ({
   activePerspective: getActivePerspective(state),
-  flags: stateToFlagsObject(state),
+  flags: getFlagsObject(state),
 });
 
 export default connect<StateProps, {}, NavHeaderProps, RootState>(

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -3,7 +3,13 @@ import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 import { NavExpandable } from '@patternfly/react-core';
 
-import { withExtensions, WithExtensionsProps, isNavItem, isPerspective } from '@console/plugin-sdk';
+import {
+  withExtensions,
+  NavItem,
+  Perspective,
+  isNavItem,
+  isPerspective,
+} from '@console/plugin-sdk';
 import { RootState } from '../../redux';
 import { featureReducerName, flagPending, FeatureState } from '../../reducers/features';
 import { stripBasePath } from '../utils';
@@ -40,10 +46,10 @@ const mergePluginChild = (
 };
 
 export const NavSection = connect(navSectionStateToProps)(
-  withExtensions(
-    isNavItem,
-    isPerspective,
-  )(
+  withExtensions<NavSectionExtensionProps>({
+    navItemExtensions: isNavItem,
+    perspectiveExtensions: isPerspective,
+  })(
     class NavSection extends React.Component<Props, NavSectionState> {
       public state: NavSectionState;
 
@@ -116,14 +122,13 @@ export const NavSection = connect(navSectionStateToProps)(
       };
 
       getNavItemExtensions = (perspective: string, section: string) => {
-        const navItems = this.props.extensions.filter(isNavItem);
-        const perspectives = this.props.extensions.filter(isPerspective);
+        const { navItemExtensions, perspectiveExtensions } = this.props;
 
-        const defaultPerspective = _.find(perspectives, (p) => p.properties.default);
+        const defaultPerspective = _.find(perspectiveExtensions, (p) => p.properties.default);
         const isDefaultPerspective =
           defaultPerspective && perspective === defaultPerspective.properties.id;
 
-        return navItems.filter(
+        return navItemExtensions.filter(
           (item) =>
             // check if the item is contributed to the current perspective,
             // or if no perspective specified, are we in the default perspective
@@ -222,12 +227,17 @@ type NavSectionStateProps = {
   perspective: string;
 };
 
-export type NavSectionProps = {
+type NavSectionExtensionProps = {
+  navItemExtensions: NavItem[];
+  perspectiveExtensions: Perspective[];
+};
+
+type NavSectionProps = {
   title: NavSectionTitle | string;
   required?: string;
 };
 
-type Props = NavSectionProps & NavSectionStateProps & WithExtensionsProps;
+type Props = NavSectionProps & NavSectionStateProps & NavSectionExtensionProps;
 
 type NavSectionState = {
   isOpen: boolean;

--- a/frontend/public/reducers/features.ts
+++ b/frontend/public/reducers/features.ts
@@ -94,15 +94,15 @@ export const featureReducer = (state: FeatureState, action: FeatureAction): Feat
   }
 };
 
-export const stateToFlagsObject = (state: RootState): FlagsObject =>
-  state[featureReducerName].toObject();
+export const stateToFlagsObject = (state: FeatureState, desiredFlags: string[]): FlagsObject =>
+  desiredFlags.reduce((allFlags, f) => ({ ...allFlags, [f]: state.get(f) }), {} as FlagsObject);
 
-export const stateToProps = (desiredFlags: string[], state: RootState): WithFlagsProps => ({
-  flags: desiredFlags.reduce(
-    (allFlags, f) => ({ ...allFlags, [f]: state[featureReducerName].get(f) }),
-    {},
-  ),
+const stateToProps = (state: FeatureState, desiredFlags: string[]): WithFlagsProps => ({
+  flags: stateToFlagsObject(state, desiredFlags),
 });
+
+export const getFlagsObject = ({ [featureReducerName]: featureState }: RootState): FlagsObject =>
+  featureState.toObject();
 
 export type FlagsObject = { [key: string]: boolean };
 
@@ -119,7 +119,7 @@ export type ConnectToFlags = <P extends WithFlagsProps>(
 };
 
 export const connectToFlags: ConnectToFlags = (...flags) =>
-  connect((state: RootState) => stateToProps(flags, state), null, null, {
+  connect((state: RootState) => stateToProps(state[featureReducerName], flags), null, null, {
     areStatePropsEqual: _.isEqual,
   });
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14505,6 +14505,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+reselect@4.x:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"


### PR DESCRIPTION
This PR includes the following improvements:

- pick up changes from #3383 that got lost during rebase :coffee: ([`withExtensions` parameter change](https://github.com/openshift/console/pull/3383#issuecomment-576414658))
- fix `useExtensions` not memoizing its result properly (`gatingFlags` was always recomputed)

`useExtensions` result value can now be used as a "stable" dependency of other hooks:
- `React.useMemo`
- `React.useEffect` (this one also throws if one of its dependencies changes on every render)
- etc.

cc @christianvogt @spadgett @benjaminapetersen @rawagner 