### PR TITLE
Bug 1781835:  Fix bug where pod log links layout is wonky

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -775,7 +775,7 @@ const EditYAML_ = connect(stateToProps)(
                       )}
                       {!showSidebar && hasSidebarContent && (
                         <>
-                          <div className="co-action-divider--spaced">|</div>
+                          <div className="co-action-divider">|</div>
                           <div className="yaml-editor__link">
                             <Button
                               type="button"

--- a/frontend/public/components/utils/resource-log.jsx
+++ b/frontend/public/components/utils/resource-log.jsx
@@ -104,19 +104,14 @@ const LogControls = ({
             });
             return (
               <React.Fragment key={link.metadata.uid}>
-                <ExternalLink
-                  href={url}
-                  text={link.spec.text}
-                  additionalClassName="co-external-link--within-toolbar"
-                  dataTestID={link.metadata.name}
-                />
+                <ExternalLink href={url} text={link.spec.text} dataTestID={link.metadata.name} />
                 <span aria-hidden="true" className="co-action-divider hidden-xs">
                   |
                 </span>
               </React.Fragment>
             );
           })}
-        <Button variant="link" onClick={onDownload}>
+        <Button variant="link" isInline onClick={onDownload}>
           <DownloadIcon className="co-icon-space-r" />
           Download
         </Button>
@@ -125,7 +120,7 @@ const LogControls = ({
             <span aria-hidden="true" className="co-action-divider hidden-xs">
               |
             </span>
-            <Button variant="link" className="pf-m-link--align-right" onClick={toggleFullscreen}>
+            <Button variant="link" isInline onClick={toggleFullscreen}>
               {isFullscreen ? (
                 <>
                   <CompressIcon className="co-icon-space-r" />

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -235,11 +235,8 @@ $co-external-link-padding-right: 15px;
 
 .co-action-divider {
   color: $color-pf-black-600;
-
-  &--spaced {
-    display: inline-block;
-    margin: 0 10px 0 10px;
-  }
+  display: inline-block;
+  margin: 0 10px 0 10px;
 }
 
 .co-break-word {
@@ -280,10 +277,6 @@ $co-external-link-padding-right: 15px;
 // Enable break word within co-m-table-grid
 .co-external-link--block {
   display: block;
-}
-// Add additional padding-right so icon doesn't abut .co-action-divider
-.co-external-link--within-toolbar {
-  padding-right:  ($co-external-link-padding-right + $padding-base-horizontal);
 }
 
 .co-icon-flex-child {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1781835

Aligns pod log links with pod yaml links so there is consistency across tabs.

After:

![Screen Shot 2020-02-05 at 3 09 43 PM](https://user-images.githubusercontent.com/895728/73879237-18caed80-482a-11ea-82d3-72ffc9a4b821.png)
![Screen Shot 2020-02-05 at 3 09 50 PM](https://user-images.githubusercontent.com/895728/73879240-19638400-482a-11ea-8078-625b679e3f11.png)
![Screen Shot 2020-02-05 at 3 09 58 PM](https://user-images.githubusercontent.com/895728/73879241-19638400-482a-11ea-91e3-a73188af440d.png)

cc: @sg00dwin, I stole this bug from you.