### PR TITLE
Bug 1795452:  fix bug where <ErrorStatus> text can overflow table cell

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -207,7 +207,7 @@ const ClusterServiceVersionStatus: React.FC<ClusterServiceVersionStatusProps> = 
           {showSuccessIcon && <SuccessStatus title={statusString} />}
         </span>
       ) : (
-        <span className="co-error co-icon-and-text">
+        <span className="co-icon-and-text">
           <ErrorStatus title={statusString} />
         </span>
       )}
@@ -328,7 +328,7 @@ export const FailedSubscriptionTableRow: React.FC<FailedSubscriptionTableRowProp
     }
     if (FAILED_SUBSCRIPTION_STATES.includes(subscriptionState)) {
       return (
-        <span className="co-icon-and-text co-error">
+        <span className="co-icon-and-text">
           <ErrorStatus title={subscriptionState} />
         </span>
       );


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1795452

Notes:

* this bug is specific to Firefox.
* this means the `<ErrorStatus>` text is no longer red on the Installed Operators page, but this brings it line with all other instances of `<ErrorStatus>` within the console.

After (Firefox for macOS):
![Screen Shot 2020-02-05 at 3 56 04 PM](https://user-images.githubusercontent.com/895728/73882619-63e7ff00-4830-11ea-933b-e2ee03623c6c.png)
