### PR TITLE
Bug 1802045: fix(RevisionOverviewList)- show traffic receving revisions sorted by timestamp

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewList.tsx
@@ -1,17 +1,20 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Button } from '@patternfly/react-core';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { SidebarSectionHeading, useAccessReview } from '@console/internal/components/utils';
 import { setTrafficDistributionModal } from '../modals';
-import { ServiceModel } from '../../models';
+import { ServiceModel, RevisionModel } from '../../models';
 import RevisionsOverviewListItem from './RevisionsOverviewListItem';
 import './RevisionsOverviewList.scss';
+import { Link } from 'react-router-dom';
 
 export type RevisionsOverviewListProps = {
   revisions: K8sResourceKind[];
   service: K8sResourceKind;
 };
+
+const MAX_REVISIONS: number = 3;
 
 const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({ revisions, service }) => {
   const canSetTrafficDistribution = useAccessReview({
@@ -20,9 +23,41 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({ revisions
     namespace: service.metadata.namespace,
     verb: 'update',
   });
+
+  const namespace = service.metadata?.namespace;
+  const traffic = service.status?.traffic;
+  const name = service.metadata?.name;
+
+  const filteredRevisions = (): K8sResourceKind[] => {
+    if (!revisions || !revisions.length) {
+      return [];
+    }
+    const [revWithTraffic, revWithoutTraffic] = _.partition(revisions, (element) => {
+      return traffic ? _.find(traffic, { revisionName: element.metadata?.name }) : false;
+    }).map((element) => _.sortBy(element, ['metadata.creationTimestamp']));
+    return revWithTraffic.length < MAX_REVISIONS
+      ? _.concat(revWithTraffic, revWithoutTraffic.slice(0, MAX_REVISIONS - revWithTraffic.length))
+      : revWithTraffic;
+  };
+
+  const getRevisionsLink = () => {
+    const url = `/search/ns/${namespace}`;
+    const searchQuery = `serving.knative.dev/service=${name}`;
+    const params = new URLSearchParams();
+    params.append('kind', referenceForModel(RevisionModel));
+    params.append('q', searchQuery);
+    return `${url}?${params.toString()}`;
+  };
+
   return (
     <>
       <SidebarSectionHeading text="Revisions" className="revision-overview-list">
+        {revisions?.length > MAX_REVISIONS && (
+          <Link className="sidebar__section-view-all" to={getRevisionsLink()}>
+            {`View all (${revisions.length})`}
+          </Link>
+        )}
+
         {canSetTrafficDistribution && (
           <Button
             variant="secondary"
@@ -37,7 +72,7 @@ const RevisionsOverviewList: React.FC<RevisionsOverviewListProps> = ({ revisions
         <span className="text-muted">No Revisions found for this resource.</span>
       ) : (
         <ul className="list-group">
-          {_.map(revisions, (revision) => (
+          {_.map(filteredRevisions(), (revision) => (
             <RevisionsOverviewListItem
               key={revision.metadata.uid}
               revision={revision}

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewList.spec.tsx
@@ -1,11 +1,20 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { Button } from '@patternfly/react-core';
 import * as utils from '@console/internal/components/utils';
 import { MockKnativeResources } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import {
+  mockRevisions,
+  mockTrafficData,
+} from '@console/knative-plugin/src/utils/__mocks__/traffic-splitting-utils-mock';
+
 import * as modal from '../../modals';
 import RevisionsOverviewList, { RevisionsOverviewListProps } from '../RevisionsOverviewList';
 import RevisionsOverviewListItem from '../RevisionsOverviewListItem';
+import { Link } from 'react-router-dom';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { RevisionModel } from '../../../models';
 
 describe('RevisionsOverviewList', () => {
   let wrapper: ShallowWrapper<RevisionsOverviewListProps>;
@@ -28,13 +37,13 @@ describe('RevisionsOverviewList', () => {
     ).toEqual('Revisions');
   });
 
-  it('should show info if no Revisions present and traffic split sshould button should be disabled', () => {
+  it('should show info if no Revisions present, link for all revisions should not be shown and traffic split button should be disabled', () => {
     const spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
     spyUseAccessReview.mockReturnValue(true);
     wrapper = shallow(
       <RevisionsOverviewList revisions={[]} service={MockKnativeResources.revisions.data[0]} />,
     );
-    expect(wrapper.find('span')).toHaveLength(1);
+    expect(wrapper.find(Link)).toHaveLength(0);
     expect(wrapper.text().includes('No Revisions found for this resource.')).toBe(true);
     expect(
       wrapper
@@ -42,6 +51,39 @@ describe('RevisionsOverviewList', () => {
         .at(0)
         .props().isDisabled,
     ).toBe(true);
+  });
+
+  it('should show Resource Link if number of revisions is more than MAX_REVISIONS', () => {
+    wrapper = shallow(
+      <RevisionsOverviewList
+        revisions={mockRevisions}
+        service={MockKnativeResources.ksservices.data[0]}
+      />,
+    );
+    expect(wrapper.find(Link)).toHaveLength(1);
+    const url = `/search/ns/${MockKnativeResources.ksservices.data[0].metadata?.namespace}`;
+    const params = new URLSearchParams();
+    params.append('kind', referenceForModel(RevisionModel));
+    params.append(
+      'q',
+      `serving.knative.dev/service=${MockKnativeResources.ksservices.data[0].metadata?.name}`,
+    );
+    expect(
+      wrapper
+        .find(Link)
+        .at(0)
+        .props().to,
+    ).toEqual(`${url}?${params.toString()}`);
+    expect(
+      wrapper
+        .find(Link)
+        .at(0)
+        .props().children,
+    ).toEqual('View all (4)');
+  });
+
+  it('should not show Resource Link if number of revisions is less than MAX_REVISIONS', () => {
+    expect(wrapper.find(Link)).toHaveLength(0);
   });
 
   it('should have button for traffic distribution and enabled', () => {
@@ -81,7 +123,25 @@ describe('RevisionsOverviewList', () => {
     expect(wrapper.find(Button).exists()).toBe(false);
   });
 
-  it('should render RevisionsOverviewListItem', () => {
-    expect(wrapper.find(RevisionsOverviewListItem)).toHaveLength(1);
+  it('should render RevisionsOverviewListItem for revisions as many as MAX_REVISION if number of revisions receiving traffic is less than MAX_REVISION', () => {
+    wrapper = shallow(
+      <RevisionsOverviewList
+        revisions={mockRevisions}
+        service={MockKnativeResources.ksservices.data[0]}
+      />,
+    );
+    expect(wrapper.find(RevisionsOverviewListItem)).toHaveLength(3);
+  });
+
+  it('should render RevisionsOverviewListItem for all revisions receiving traffic', () => {
+    const serviceWithTraffic = _.set(
+      _.cloneDeep(MockKnativeResources.ksservices.data[0]),
+      'status.traffic',
+      mockTrafficData,
+    );
+    wrapper = shallow(
+      <RevisionsOverviewList revisions={mockRevisions} service={serviceWithTraffic} />,
+    );
+    expect(wrapper.find(RevisionsOverviewListItem)).toHaveLength(4);
   });
 });

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/traffic-splitting-utils-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/traffic-splitting-utils-mock.ts
@@ -1,87 +1,35 @@
-import { RevisionModel, ServiceModel } from '../../models';
+import * as _ from 'lodash';
+import {
+  knativeServiceObj,
+  revisionObj,
+} from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
 import { RevisionKind, ServiceKind as knativeServiceKind } from '../../types';
 
-export const mockTrafficData = [
-  { percent: 50, tag: 'tag-1', revisionName: 'rev-1' },
-  { percent: 50, tag: 'tag-2', revisionName: 'rev-2' },
-];
-export const mockServiceData: knativeServiceKind = {
-  apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
-  kind: ServiceModel.kind,
-  spec: {
-    traffic: [
-      {
-        percent: 50,
-        revisionName: 'rev-1',
-        tag: 'tag-1',
-      },
-      {
-        percent: 50,
-        revisionName: 'rev-2',
-        tag: 'tag-2',
-      },
-    ],
-  },
-  status: {
-    traffic: [
-      {
-        latestRevision: false,
-        percent: 100,
-        revisionName: 'rev-1',
-        tag: 'tag-1',
-      },
-    ],
-  },
-};
+export const mockServiceData: knativeServiceKind = _.cloneDeep(knativeServiceObj);
 
-export const mockUpdateRequestObj: knativeServiceKind = {
-  apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
-  kind: ServiceModel.kind,
-  spec: {
-    traffic: [
-      {
-        percent: 50,
-        revisionName: 'rev-1',
-        tag: 'tag-1',
-      },
-      {
-        percent: 50,
-        revisionName: 'rev-2',
-        tag: 'tag-2',
-      },
-    ],
-  },
-};
+export const mockTrafficData = [
+  { percent: 25, tag: 'tag-1', revisionName: 'overlayimage-fdqsf' },
+  { percent: 25, tag: 'tag-2', revisionName: 'overlayimage-tkvz5' },
+  { percent: 25, tag: 'tag-3', revisionName: 'overlayimage-bwpxq' },
+  { percent: 25, tag: 'tag-4', revisionName: 'overlayimage-n2b7n' },
+];
+
+export const mockUpdateRequestObj: knativeServiceKind = _.set(
+  _.omit(_.cloneDeep(knativeServiceObj), 'status'),
+  'spec.traffic',
+  mockTrafficData,
+);
 
 export const mockRevisions: RevisionKind[] = [
-  {
-    apiVersion: `${RevisionModel.apiGroup}/${RevisionModel.apiVersion}  `,
-    kind: RevisionModel.kind,
-    metadata: {
-      name: 'rev-1',
-      namespace: 'namespace',
-    },
-  },
-  {
-    apiVersion: `${RevisionModel.apiGroup}/${RevisionModel.apiVersion}`,
-    kind: RevisionModel.kind,
-    metadata: {
-      name: 'rev-2',
-      namespace: 'namespace',
-    },
-  },
-  {
-    apiVersion: `${RevisionModel.apiGroup}/${RevisionModel.apiVersion}`,
-    kind: RevisionModel.kind,
-    metadata: {
-      name: 'rev-3',
-      namespace: 'namespace',
-    },
-  },
+  revisionObj,
+  _.set(_.cloneDeep(revisionObj), 'metadata.name', 'overlayimage-tkvz5'),
+  _.set(_.cloneDeep(revisionObj), 'metadata.name', 'overlayimage-bwpxq'),
+  _.set(_.cloneDeep(revisionObj), 'metadata.name', 'overlayimage-n2b7n'),
 ];
 
 export const mockRevisionItems = {
-  'rev-1': 'rev-1',
-  'rev-2': 'rev-2',
-  'rev-3': 'rev-3',
+  'overlayimage-fdqsf': 'overlayimage-fdqsf',
+  'overlayimage-tkvz5': 'overlayimage-tkvz5',
+  'overlayimage-bwpxq': 'overlayimage-bwpxq',
+  'overlayimage-n2b7n': 'overlayimage-n2b7n',
 };


### PR DESCRIPTION
This PR-
* addresses issue https://issues.redhat.com/browse/ODC-2397
* sorts revisions by creationTimestamp
* shows revisions receiving traffic first
* limits number of revisions to 3 if revisions receiving traffic is less than 3
* provides link to show all revisions
* modifies current tests and adds new tests according to the changes

Screen-
![filter-revisions](https://user-images.githubusercontent.com/38663217/74637022-2cae1200-518f-11ea-974a-d6695e450dc1.gif)

