### PR TITLE
Bug 1798827: Monitoring Dashboards: Limit bar chart height

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -29,6 +29,16 @@
     padding: 10px;
   }
 
+  &.co-dashboard-card--gradient {
+    .pf-c-card__body {
+      max-height: 350px;
+      overflow: scroll;
+    }
+    &:after {
+      width: calc(100% - 10px);
+    }
+  }
+
   .query-browser__wrapper {
     border: 0;
     margin: 0;

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -270,7 +270,10 @@ const Card: React.FC<CardProps> = ({ panel, pollInterval, timespan }) => {
 
   return (
     <div className={`col-xs-12 col-sm-${colSpanSm} col-lg-${colSpan}`}>
-      <DashboardCard className="monitoring-dashboards__panel">
+      <DashboardCard
+        className="monitoring-dashboards__panel"
+        gradient={panel.type === 'grafana-piechart-panel'}
+      >
         <DashboardCardHeader className="monitoring-dashboards__card-header">
           <DashboardCardTitle>{panel.title}</DashboardCardTitle>
         </DashboardCardHeader>


### PR DESCRIPTION
Uses a gradient at the bottom of the card to indicate it is scrollable.

![screenshot](https://user-images.githubusercontent.com/460802/73908227-5728e100-48ec-11ea-8246-aca7010bc87d.png)
