### PR TITLE
Bug 1798846: Add info icon and tooltip for text filter in topology view

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -235,7 +235,7 @@ const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters }) =>
 
   return (
     <TopologyView
-      viewToolbar={<TopologyFilterBar />}
+      viewToolbar={<TopologyFilterBar visualization={visRef.current} />}
       controlBar={renderControlBar()}
       sideBar={sideBar}
       sideBarOpen={!!sideBar}

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
@@ -6,4 +6,7 @@
   &__search {
     margin-left: auto;
   }
+  &__info-icon {
+    margin-left: var(--pf-global--spacer--sm);
+  }
 }

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -24,8 +24,16 @@ import {
   RequireCreatePermission,
 } from '../utils';
 
-/** @type {React.SFC<{disabled?: boolean, label: string, onChange: React.ChangeEventHandler<any>, defaultValue?: string, value?: string}}>} */
-export const TextFilter = ({ label, onChange, defaultValue, style, className, value }) => {
+/** @type {React.SFC<{disabled?: boolean, label?: string, onChange: React.ChangeEventHandler<any>, defaultValue?: string, value?: string, placeholder?: string,}}>} */
+export const TextFilter = ({
+  label,
+  onChange,
+  defaultValue,
+  style,
+  className,
+  value,
+  placeholder = `Filter ${label}...`,
+}) => {
   const input = React.useRef();
   const onKeyDown = (e) => {
     const { nodeName } = e.target;
@@ -60,7 +68,7 @@ export const TextFilter = ({ label, onChange, defaultValue, style, className, va
         defaultValue={defaultValue}
         onChange={onChange}
         onKeyDown={(e) => e.key === 'Escape' && e.target.blur()}
-        placeholder={`Filter ${label}...`}
+        placeholder={placeholder}
         style={style}
         tabIndex={0}
         type="text"


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-2869
https://issues.redhat.com/browse/ODC-2855

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Do not have info tip for the text filter and placeholder text is not correct as per the design

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Should have info tip for text filter and placeholder text should be Find by name... 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screenshot from 2020-02-11 23-50-23](https://user-images.githubusercontent.com/2561818/74266204-e8071e80-4d29-11ea-921f-2e0cf7c1770e.png)
![Peek 2020-02-12 02-35](https://user-images.githubusercontent.com/2561818/74279321-b5b4eb80-4d40-11ea-8008-0ecbff5f051e.gif)
![Screenshot from 2020-02-12 02-34-06](https://user-images.githubusercontent.com/2561818/74279331-bbaacc80-4d40-11ea-8515-fd6604d1c45c.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
