### PR TITLE
Bug 1798954: Fix view all dashboard links

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-activity.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-activity.tsx
@@ -17,7 +17,7 @@ import {
   withDashboardResources,
   DashboardItemProps,
 } from '@console/internal/components/dashboard/with-dashboard-resources';
-import { VirtualMachineModel } from '../../../models';
+import { VirtualMachineModel, VirtualMachineInstanceModel } from '../../../models';
 import { getVmEventsFilters } from '../../../selectors/event';
 import { VMDashboardContext } from '../../vms/vm-dashboard-context';
 import { VMILikeEntityKind } from '../../../types/vmLike';
@@ -64,7 +64,11 @@ export const VMActivityCard: React.FC = () => {
 
   const name = getName(vmiLike);
   const namespace = getNamespace(vmiLike);
-  const viewEventsLink = `${resourcePath(VirtualMachineModel.kind, name, namespace)}/events`;
+  const viewEventsLink = `${resourcePath(
+    vm ? VirtualMachineModel.kind : VirtualMachineInstanceModel.kind,
+    name,
+    namespace,
+  )}/events`;
 
   return (
     <DashboardCard gradient>

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -15,7 +15,7 @@ import {
   resourcePath,
 } from '@console/internal/components/utils';
 import { VMDashboardContext } from '../../vms/vm-dashboard-context';
-import { VirtualMachineModel } from '../../../models';
+import { VirtualMachineModel, VirtualMachineInstanceModel } from '../../../models';
 import { getVmiIpAddresses } from '../../../selectors/vmi/ip-address';
 import { VM_DETAIL_DETAILS_HREF } from '../../../constants';
 import { findVMPod } from '../../../selectors/pod/selectors';
@@ -34,7 +34,7 @@ export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
   const namespace = getNamespace(vmiLike);
 
   const viewAllLink = `${resourcePath(
-    VirtualMachineModel.kind,
+    vm ? VirtualMachineModel.kind : VirtualMachineInstanceModel.kind,
     name,
     namespace,
   )}/${VM_DETAIL_DETAILS_HREF}`;


### PR DESCRIPTION
When viewing VMI overview page, the Events and Details cards "view all" links, link to VM instead of VMI.

Screenshot:
![OKD(1)](https://user-images.githubusercontent.com/2181522/73933739-c51dda00-48e5-11ea-9668-9ebf30f35958.png)