### PR TITLE
Bug 1772889: Do not show VM Utilization graphs for an off-VM

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -20,6 +20,7 @@ import {
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import { VMDashboardContext } from '../../vms/vm-dashboard-context';
 import { findVMPod } from '../../../selectors/pod/selectors';
+import { isVMRunningWithVMI } from '../../../selectors/vm';
 import { getUtilizationQueries, getMultilineUtilizationQueries, VMQueries } from './queries';
 
 // TODO: extend humanizeCpuCores() from @console/internal for the flexibility of space
@@ -39,6 +40,8 @@ export const VMUtilizationCard: React.FC = () => {
   const vmName = getName(vmiLike);
   const namespace = getNamespace(vmiLike);
   const launcherPodName = getName(findVMPod(vmiLike, pods));
+  const vmIsRunning = isVMRunningWithVMI({ vm, vmi });
+
   const queries = React.useMemo(
     () =>
       getUtilizationQueries({
@@ -73,6 +76,7 @@ export const VMUtilizationCard: React.FC = () => {
           duration={duration}
           setTimestamps={setTimestamps}
           namespace={namespace}
+          isDisabled={!vmIsRunning}
         />
         <PrometheusUtilizationItem
           title="Memory"
@@ -81,6 +85,7 @@ export const VMUtilizationCard: React.FC = () => {
           byteDataType={ByteDataTypes.BinaryBytes}
           duration={duration}
           namespace={namespace}
+          isDisabled={!vmIsRunning}
         />
         <PrometheusUtilizationItem
           title="Filesystem"
@@ -89,6 +94,7 @@ export const VMUtilizationCard: React.FC = () => {
           byteDataType={ByteDataTypes.BinaryBytes}
           duration={duration}
           namespace={namespace}
+          isDisabled={!vmIsRunning}
         />
         <PrometheusMultilineUtilizationItem
           title="Network Transfer"
@@ -97,6 +103,7 @@ export const VMUtilizationCard: React.FC = () => {
           byteDataType={ByteDataTypes.BinaryBytes}
           duration={duration}
           namespace={namespace}
+          isDisabled={!vmIsRunning}
         />
       </UtilizationBody>
     </DashboardCard>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/utilization-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/utilization-card.tsx
@@ -168,13 +168,13 @@ export const PrometheusUtilizationItem = withDashboardResources<PrometheusUtiliz
     utilizationQuery,
     totalQuery,
     duration,
-    adjustDuration = (start: number) => start,
+    adjustDuration,
     title,
     TopConsumerPopover,
     humanizeValue,
     byteDataType,
     setTimestamps,
-    namespace, 
+    namespace,
     isDisabled = false,
   }) => {
     let stats = [];
@@ -184,7 +184,10 @@ export const PrometheusUtilizationItem = withDashboardResources<PrometheusUtiliz
     let isLoading = false;
 
     const effectiveDuration = React.useMemo(
-      () => adjustDuration(UTILIZATION_QUERY_HOUR_MAP[duration]),
+      () =>
+        adjustDuration
+          ? adjustDuration(UTILIZATION_QUERY_HOUR_MAP[duration])
+          : UTILIZATION_QUERY_HOUR_MAP[duration],
       [adjustDuration, duration],
     );
     React.useEffect(() => {
@@ -246,7 +249,7 @@ export const PrometheusMultilineUtilizationItem = withDashboardResources<
     prometheusResults,
     queries,
     duration,
-    adjustDuration = (start: number) => start,
+    adjustDuration,
     title,
     TopConsumerPopovers,
     humanizeValue,
@@ -255,19 +258,28 @@ export const PrometheusMultilineUtilizationItem = withDashboardResources<
     isDisabled = false,
   }) => {
     const effectiveDuration = React.useMemo(
-      () => adjustDuration(UTILIZATION_QUERY_HOUR_MAP[duration]),
+      () =>
+        adjustDuration
+          ? adjustDuration(UTILIZATION_QUERY_HOUR_MAP[duration])
+          : UTILIZATION_QUERY_HOUR_MAP[duration],
       [adjustDuration, duration],
     );
     React.useEffect(() => {
       if (!isDisabled) {
-        queries.forEach((q) =>
-          watchPrometheus(q.query, namespace, effectiveDuration)
-        );
+        queries.forEach((q) => watchPrometheus(q.query, namespace, effectiveDuration));
         return () => {
           queries.forEach((q) => stopWatchPrometheusQuery(q.query, effectiveDuration));
         };
-      };
-    }, [watchPrometheus, stopWatchPrometheusQuery, duration, queries, namespace, isDisabled]);
+      }
+    }, [
+      watchPrometheus,
+      stopWatchPrometheusQuery,
+      duration,
+      queries,
+      namespace,
+      isDisabled,
+      effectiveDuration,
+    ]);
 
     const stats = [];
     let hasError = false;

--- a/frontend/public/components/graphs/helpers.ts
+++ b/frontend/public/components/graphs/helpers.ts
@@ -8,10 +8,12 @@ export enum PrometheusEndpoint {
   QUERY_RANGE = 'api/v1/query_range',
 }
 
+export const getPrometheusQeuryEndTimestamp = () => Date.now();
+
 // Range vector queries require end, start, and step search params
 const getRangeVectorSearchParams = (
   timespan: number,
-  endTime: number = Date.now(),
+  endTime: number = getPrometheusQeuryEndTimestamp(),
   samples: number = 60,
 ): URLSearchParams => {
   const params = new URLSearchParams();

--- a/frontend/public/components/graphs/helpers.ts
+++ b/frontend/public/components/graphs/helpers.ts
@@ -8,12 +8,12 @@ export enum PrometheusEndpoint {
   QUERY_RANGE = 'api/v1/query_range',
 }
 
-export const getPrometheusQeuryEndTimestamp = () => Date.now();
+export const getPrometheusQueryEndTimestamp = () => Date.now();
 
 // Range vector queries require end, start, and step search params
 const getRangeVectorSearchParams = (
   timespan: number,
-  endTime: number = getPrometheusQeuryEndTimestamp(),
+  endTime: number = getPrometheusQueryEndTimestamp(),
   samples: number = 60,
 ): URLSearchParams => {
   const params = new URLSearchParams();


### PR DESCRIPTION
Considering the scenario of start->stop->start VM.

Prior this fix, Prometheus data were merged for both the former and later VMI objects causing confusing user experience (misleading graph).

With this fix, the retrieved data are not older than age of the existing VMI object.

This is a workaround for the issue with collision of names for old vs. recent VMI same as for lack of possibility to use the UUID within the corresponding prometheus metrics.

In addition, the grapgs are not shown for an off-VM at all.