### PR TITLE
Bug 1789192: Avoid confirmation for the "VM start" action

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
@@ -48,7 +48,7 @@ export class VirtualMachine extends KubevirtDetailView {
     await this.navigateToTab(TAB.Details);
 
     let confirmDialog = true;
-    if ([VM_ACTION.Clone].includes(action)) {
+    if ([VM_ACTION.Clone, VM_ACTION.Start].includes(action)) {
       confirmDialog = false;
     }
 
@@ -58,11 +58,11 @@ export class VirtualMachine extends KubevirtDetailView {
     }
   }
 
-  async listViewAction(action: string, waitForAction?: boolean, timeout?: number) {
+  async listViewAction(action: VM_ACTION, waitForAction?: boolean, timeout?: number) {
     await this.navigateToListView();
 
     let confirmDialog = true;
-    if ([VM_ACTION.Clone as string].includes(action)) {
+    if ([VM_ACTION.Clone, VM_ACTION.Start].includes(action)) {
       confirmDialog = false;
     }
     await listViewAction(this.name)(action, confirmDialog);

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -40,13 +40,7 @@ export const menuActionStart = (
   return {
     hidden: isVMImporting(vmStatus) || isVMRunning(vm),
     label: title,
-    callback: () =>
-      confirmModal({
-        title,
-        message: getActionMessage(vm, VMActionType.Start),
-        btnText: _.capitalize(VMActionType.Start),
-        executeFn: () => startVM(vm),
-      }),
+    callback: () => startVM(vm),
     accessReview: asAccessReview(kindObj, vm, 'patch'),
   };
 };


### PR DESCRIPTION
The "start" action does not need to be confirmed by the user, let's start the VM immediately.