### PR TITLE
Memoize data derived from useExtensions

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -27,7 +27,6 @@ import {
   isReduxReducer,
   isResourceDetailsPage,
   isResourceListPage,
-  isResourceTabPage,
   isRoutePage,
   isYAMLTemplate,
 } from './typings';
@@ -85,10 +84,6 @@ export class ExtensionRegistry {
 
   public getRoutePages() {
     return this.extensions.filter(isRoutePage);
-  }
-
-  public getResourceTabPages() {
-    return this.extensions.filter(isResourceTabPage);
   }
 
   public getPerspectives() {

--- a/frontend/public/components/nav/perspective-nav.tsx
+++ b/frontend/public/components/nav/perspective-nav.tsx
@@ -13,8 +13,11 @@ type StateProps = {
 };
 
 const PerspectiveNav: React.FC<StateProps> = ({ perspective }) => {
-  const navItemExtensions = useExtensions<NavItem>(isNavItem).filter(
-    (item) => item.properties.perspective === perspective,
+  const navItemExtensions = useExtensions<NavItem>(isNavItem);
+
+  const matchingNavItems = React.useMemo(
+    () => navItemExtensions.filter((item) => item.properties.perspective === perspective),
+    [navItemExtensions, perspective],
   );
 
   // Until admin perspective is contributed through extensions, simply render static `AdminNav`
@@ -28,7 +31,7 @@ const PerspectiveNav: React.FC<StateProps> = ({ perspective }) => {
   return (
     <>
       {_.compact(
-        navItemExtensions.map((item) => {
+        matchingNavItems.map((item) => {
           const { section } = item.properties;
           if (section) {
             if (renderedSections.includes(section)) {

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -206,18 +206,23 @@ export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
     {},
   );
 
-  const navTabExtensions = useExtensions<HorizontalNavTab>(isHorizontalNavTab).filter(
-    (tab) =>
-      props.obj?.data && referenceForModel(tab.properties.model) === referenceFor(props.obj.data),
+  const objReference = props.obj?.data ? referenceFor(props.obj.data) : '';
+  const navTabExtensions = useExtensions<HorizontalNavTab>(isHorizontalNavTab);
+
+  const pluginPages = React.useMemo(
+    () =>
+      navTabExtensions
+        .filter((tab) => referenceForModel(tab.properties.model) === objReference)
+        .map((tab) => ({
+          ...tab.properties.page,
+          component: (params: PageComponentProps) => (
+            <AsyncComponent {...params} loader={tab.properties.loader} />
+          ),
+        })),
+    [navTabExtensions, objReference],
   );
-  const pages = (props.pages || props.pagesFor(props.obj?.data)).concat(
-    navTabExtensions.map((tab) => ({
-      ...tab.properties.page,
-      component: (params: PageComponentProps) => (
-        <AsyncComponent {...params} loader={tab.properties.loader} />
-      ),
-    })),
-  );
+
+  const pages = (props.pages || props.pagesFor(props.obj?.data)).concat(pluginPages);
 
   const routes = pages.map((p) => {
     const path = `${props.match.url}/${p.path || p.href}`;


### PR DESCRIPTION
With #4211 the result value of `useExtensions` hook changes only when necessary, i.e. when the relevant `RootState.FLAGS` subset is changed. (For now, the runtime list of extensions is assumed to be immutable, so the only extension-related "change vector" is Console feature flag Redux substate.)

This PR applies memoization to data derived from `useExtensions` calls to further avoid unnecessary React component re-renders.