### PR TITLE
Migrate all dashboard extensions

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/extensions/dashboards.ts
+++ b/frontend/packages/ceph-storage-plugin/src/extensions/dashboards.ts
@@ -1,4 +1,12 @@
-import { Extension, DashboardsExtensionProperties } from '@console/plugin-sdk';
+import { Extension } from '@console/plugin-sdk';
+
+interface DashboardsExtensionProperties {
+  /** Feature flags which are required for this extension to be effective. */
+  required?: string | string[];
+
+  /** Feature flags which are disallowed for this extension to be effective. */
+  disallowed?: string | string[];
+}
 
 namespace ExtensionProperties {
   export interface DashboardsStorageCapacityDropdownItem extends DashboardsExtensionProperties {

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -99,8 +99,10 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'persistent-storage',
       title: 'Persistent Storage',
-      required: CEPH_FLAG,
-      disallowed: OCS_INDEPENDENT_FLAG,
+    },
+    flags: {
+      required: [CEPH_FLAG],
+      disallowed: [OCS_INDEPENDENT_FLAG],
     },
   },
   {
@@ -125,7 +127,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboard-page/storage-dashboard/details-card' /* webpackChunkName: "ceph-storage-details-card" */
         ).then((m) => m.default),
-      required: CEPH_FLAG,
+    },
+    flags: {
+      required: [CEPH_FLAG],
     },
   },
   {
@@ -137,7 +141,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboard-page/storage-dashboard/inventory-card' /* webpackChunkName: "ceph-storage-inventory-card" */
         ).then((m) => m.default),
-      required: CEPH_FLAG,
+    },
+    flags: {
+      required: [CEPH_FLAG],
     },
   },
   // Ceph Storage Dashboard Main Cards
@@ -150,7 +156,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboard-page/storage-dashboard/status-card/status-card' /* webpackChunkName: "ceph-storage-status-card" */
         ).then((m) => m.default),
-      required: CEPH_FLAG,
+    },
+    flags: {
+      required: [CEPH_FLAG],
     },
   },
   {
@@ -162,7 +170,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboard-page/storage-dashboard/capacity-breakdown/capacity-breakdown-card' /* webpackChunkName: "ceph-storage-usage-breakdown-card" */
         ).then((m) => m.default),
-      required: CEPH_FLAG,
+    },
+    flags: {
+      required: [CEPH_FLAG],
     },
   },
   {
@@ -174,7 +184,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboard-page/storage-dashboard/utilization-card/utilization-card' /* webpackChunkName: "ceph-storage-utilization-card" */
         ).then((m) => m.default),
-      required: CEPH_FLAG,
+    },
+    flags: {
+      required: [CEPH_FLAG],
     },
   },
   // Ceph Storage Dashboard Right Cards
@@ -187,7 +199,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboard-page/storage-dashboard/activity-card/activity-card' /* webpackChunkName: "ceph-storage-activity-card" */
         ).then((m) => m.ActivityCard),
-      required: CEPH_FLAG,
+    },
+    flags: {
+      required: [CEPH_FLAG],
     },
   },
   {
@@ -196,7 +210,9 @@ const plugin: Plugin<ConsumedExtensions> = [
       title: 'Storage',
       queries: [STORAGE_HEALTH_QUERIES[StorageDashboardQuery.CEPH_STATUS_QUERY]],
       healthHandler: getCephHealthState,
-      required: CEPH_FLAG,
+    },
+    flags: {
+      required: [CEPH_FLAG],
     },
   },
   {
@@ -205,7 +221,9 @@ const plugin: Plugin<ConsumedExtensions> = [
       id: OverviewQuery.STORAGE_UTILIZATION,
       query: CAPACITY_USAGE_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_USED],
       totalQuery: CAPACITY_USAGE_QUERIES[StorageDashboardQuery.CEPH_CAPACITY_TOTAL],
-      required: CEPH_FLAG,
+    },
+    flags: {
+      required: [CEPH_FLAG],
     },
   },
   {
@@ -255,7 +273,9 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'independent-dashboard',
       title: 'Persistent Storage',
-      required: OCS_INDEPENDENT_FLAG,
+    },
+    flags: {
+      required: [OCS_INDEPENDENT_FLAG],
     },
   },
   // Left Cards
@@ -268,7 +288,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/independent-dashboard-page/details-card/card' /* webpackChunkName: "indepedent-details-card" */
         ).then((m) => m.default),
-      required: OCS_INDEPENDENT_FLAG,
+    },
+    flags: {
+      required: [OCS_INDEPENDENT_FLAG],
     },
   },
   {
@@ -280,7 +302,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboard-page/storage-dashboard/inventory-card' /* webpackChunkName: "ceph-storage-inventory-card" */
         ).then((m) => m.default),
-      required: OCS_INDEPENDENT_FLAG,
+    },
+    flags: {
+      required: [OCS_INDEPENDENT_FLAG],
     },
   },
   // Center
@@ -293,7 +317,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/independent-dashboard-page/status-card/card' /* webpackChunkName: "indepedent-status-card" */
         ).then((m) => m.default),
-      required: OCS_INDEPENDENT_FLAG,
+    },
+    flags: {
+      required: [OCS_INDEPENDENT_FLAG],
     },
   },
   {
@@ -305,7 +331,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/independent-dashboard-page/breakdown-card/card' /* webpackChunkName: "independent-breakdown-card" */
         ).then((m) => m.default),
-      required: OCS_INDEPENDENT_FLAG,
+    },
+    flags: {
+      required: [OCS_INDEPENDENT_FLAG],
     },
   },
   {
@@ -317,7 +345,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/independent-dashboard-page/utilization-card/card' /* webpackChunkName: "utilization-card" */
         ).then((m) => m.default),
-      required: OCS_INDEPENDENT_FLAG,
+    },
+    flags: {
+      required: [OCS_INDEPENDENT_FLAG],
     },
   },
   // Right
@@ -330,7 +360,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboard-page/storage-dashboard/activity-card/activity-card' /* webpackChunkName: "ceph-storage-activity-card" */
         ).then((m) => m.ActivityCard),
-      required: OCS_INDEPENDENT_FLAG,
+    },
+    flags: {
+      required: [OCS_INDEPENDENT_FLAG],
     },
   },
   {
@@ -361,7 +393,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboard-page/storage-dashboard/activity-card/cluster-expand-activity' /* webpackChunkName: "ceph-storage-plugin" */
         ).then((m) => m.ClusterExpandActivity),
-      required: CEPH_FLAG,
+    },
+    flags: {
+      required: [CEPH_FLAG],
     },
   },
 ];

--- a/frontend/packages/console-app/src/__tests__/extension-checks/dashboards.spec.ts
+++ b/frontend/packages/console-app/src/__tests__/extension-checks/dashboards.spec.ts
@@ -1,9 +1,10 @@
 import * as _ from 'lodash';
-import { testedRegistry } from '../plugin-test-utils';
+import { isDashboardsOverviewUtilizationItem } from '@console/plugin-sdk';
+import { testedExtensions } from '../plugin-test-utils';
 
 describe('DashboardsOverviewUtilizationItem', () => {
   it('duplicate ids are not allowed', () => {
-    const items = testedRegistry.getDashboardsOverviewUtilizationItems();
+    const items = testedExtensions.toArray().filter(isDashboardsOverviewUtilizationItem);
     const dedupedItems = _.uniqWith(items, (a, b) => a.properties.id === b.properties.id);
     const duplicateItems = _.difference(items, dedupedItems);
 

--- a/frontend/packages/console-app/src/plugin.tsx
+++ b/frontend/packages/console-app/src/plugin.tsx
@@ -78,7 +78,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboards-page/ClusterUpdateActivity' /* webpackChunkName: "console-app" */
         ).then((m) => m.default),
-      required: FLAGS.CLUSTER_VERSION,
+    },
+    flags: {
+      required: [FLAGS.CLUSTER_VERSION],
     },
   },
   {
@@ -157,7 +159,9 @@ const plugin: Plugin<ConsumedExtensions> = [
           './components/dashboards-page/OperatorStatus' /* webpackChunkName: "console-app" */
         ).then((c) => c.default),
       viewAllLink: '/settings/cluster/clusteroperators',
-      required: FLAGS.CLUSTER_VERSION,
+    },
+    flags: {
+      required: [FLAGS.CLUSTER_VERSION],
     },
   },
 ];

--- a/frontend/packages/console-demo-plugin/src/plugin.tsx
+++ b/frontend/packages/console-demo-plugin/src/plugin.tsx
@@ -56,6 +56,8 @@ type ConsumedExtensions =
   | DashboardsOverviewPrometheusActivity
   | HorizontalNavTab;
 
+const TEST_MODEL_FLAG = 'TEST_MODEL';
+
 const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'ModelDefinition',
@@ -67,7 +69,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'FeatureFlag/Model',
     properties: {
       model: PodModel,
-      flag: 'TEST_MODEL_FLAG',
+      flag: TEST_MODEL_FLAG,
     },
   },
   {
@@ -80,7 +82,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       },
     },
     flags: {
-      required: ['TEST_MODEL_FLAG'],
+      required: [TEST_MODEL_FLAG],
     },
   },
   {
@@ -93,7 +95,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       },
     },
     flags: {
-      required: ['TEST_MODEL_FLAG'],
+      required: [TEST_MODEL_FLAG],
     },
   },
   {
@@ -106,7 +108,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       },
     },
     flags: {
-      required: [FLAGS.OPENSHIFT, 'TEST_MODEL_FLAG'],
+      required: [FLAGS.OPENSHIFT, TEST_MODEL_FLAG],
     },
   },
   {
@@ -153,7 +155,9 @@ const plugin: Plugin<ConsumedExtensions> = [
       title: 'Foo system',
       url: 'fooUrl',
       healthHandler: getFooHealthState,
-      required: 'TEST_MODEL_FLAG',
+    },
+    flags: {
+      required: [TEST_MODEL_FLAG],
     },
   },
   {
@@ -168,7 +172,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         namespaced: false,
         prop: 'nodes',
       },
-      required: 'TEST_MODEL_FLAG',
+    },
+    flags: {
+      required: [TEST_MODEL_FLAG],
     },
   },
   {
@@ -205,7 +211,9 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'foo-tab',
       title: 'Foo',
-      required: 'TEST_MODEL_FLAG',
+    },
+    flags: {
+      required: [TEST_MODEL_FLAG],
     },
   },
   {
@@ -217,7 +225,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import('./components/dashboards/foo-card' /* webpackChunkName: "demo" */).then(
           (m) => m.FooCard,
         ),
-      required: 'TEST_MODEL_FLAG',
+    },
+    flags: {
+      required: [TEST_MODEL_FLAG],
     },
   },
   {
@@ -229,7 +239,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboards/inventory' /* webpackChunkName: "demo-inventory-item" */
         ).then((m) => m.ExpandedRoutes),
-      required: 'TEST_MODEL_FLAG',
+    },
+    flags: {
+      required: [TEST_MODEL_FLAG],
     },
   },
   {
@@ -237,7 +249,9 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'demo-inventory-group',
       icon: <DemoGroupIcon />,
-      required: 'TEST_MODEL_FLAG',
+    },
+    flags: {
+      required: [TEST_MODEL_FLAG],
     },
   },
   {
@@ -246,7 +260,9 @@ const plugin: Plugin<ConsumedExtensions> = [
       id: OverviewQuery.STORAGE_UTILIZATION,
       query: 'barQuery',
       totalQuery: 'fooQuery',
-      required: 'TEST_MODEL_FLAG',
+    },
+    flags: {
+      required: [TEST_MODEL_FLAG],
     },
   },
   {
@@ -264,7 +280,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import('./components/dashboards/activity' /* webpackChunkName: "demo" */).then(
           (m) => m.DemoActivity,
         ),
-      required: 'TEST_MODEL_FLAG',
+    },
+    flags: {
+      required: [TEST_MODEL_FLAG],
     },
   },
   {
@@ -276,7 +294,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import('./components/dashboards/activity' /* webpackChunkName: "demo" */).then(
           (m) => m.DemoPrometheusActivity,
         ),
-      required: 'TEST_MODEL_FLAG',
+    },
+    flags: {
+      required: [TEST_MODEL_FLAG],
     },
   },
   {

--- a/frontend/packages/console-plugin-sdk/src/registry.ts
+++ b/frontend/packages/console-plugin-sdk/src/registry.ts
@@ -5,15 +5,6 @@ import {
   Extension,
   ExtensionTypeGuard,
   isClusterServiceVersionAction,
-  isDashboardsCard,
-  isDashboardsInventoryItemGroup,
-  isDashboardsOverviewHealthSubsystem,
-  isDashboardsOverviewInventoryItem,
-  isDashboardsOverviewInventoryItemReplacement,
-  isDashboardsOverviewPrometheusActivity,
-  isDashboardsOverviewResourceActivity,
-  isDashboardsOverviewUtilizationItem,
-  isDashboardsTab,
   isDevCatalogModel,
   isFeatureFlag,
   isGlobalConfig,
@@ -23,7 +14,6 @@ import {
   isOverviewResourceTab,
   isOverviewTabSection,
   isPerspective,
-  isProjectDashboardInventoryItem,
   isReduxReducer,
   isResourceDetailsPage,
   isResourceListPage,
@@ -94,30 +84,6 @@ export class ExtensionRegistry {
     return this.extensions.filter(isYAMLTemplate);
   }
 
-  public getDashboardsOverviewHealthSubsystems() {
-    return this.extensions.filter(isDashboardsOverviewHealthSubsystem);
-  }
-
-  public getDashboardsTabs() {
-    return this.extensions.filter(isDashboardsTab);
-  }
-
-  public getDashboardsCards() {
-    return this.extensions.filter(isDashboardsCard);
-  }
-
-  public getDashboardsOverviewUtilizationItems() {
-    return this.extensions.filter(isDashboardsOverviewUtilizationItem);
-  }
-
-  public getDashboardsOverviewInventoryItems() {
-    return this.extensions.filter(isDashboardsOverviewInventoryItem);
-  }
-
-  public getDashboardsInventoryItemGroups() {
-    return this.extensions.filter(isDashboardsInventoryItemGroup);
-  }
-
   public getOverviewResourceTabs() {
     return this.extensions.filter(isOverviewResourceTab);
   }
@@ -146,24 +112,8 @@ export class ExtensionRegistry {
     return this.extensions.filter(isDevCatalogModel);
   }
 
-  public getDashboardsOverviewResourceActivities() {
-    return this.extensions.filter(isDashboardsOverviewResourceActivity);
-  }
-
-  public getDashboardsOverviewPrometheusActivities() {
-    return this.extensions.filter(isDashboardsOverviewPrometheusActivity);
-  }
-
   public getReduxReducers() {
     return this.extensions.filter(isReduxReducer);
-  }
-
-  public getProjectDashboardInventoryItems() {
-    return this.extensions.filter(isProjectDashboardInventoryItem);
-  }
-
-  public getDashboardsOverviewInventoryItemReplacements() {
-    return this.extensions.filter(isDashboardsOverviewInventoryItemReplacement);
   }
 }
 

--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -14,15 +14,8 @@ import { PrometheusResponse } from '@console/internal/components/graphs';
 import { WatchK8sResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { Extension, LazyLoader } from './base';
 
-export interface DashboardsExtensionProperties {
-  /** Feature flags which are required for this extension to be effective. */
-  required?: string | string[];
-  /** Feature flags which are disallowed for this extension to be effective. */
-  disallowed?: string | string[];
-}
-
 namespace ExtensionProperties {
-  interface DashboardsOverviewHealthSubsystem extends DashboardsExtensionProperties {
+  interface DashboardsOverviewHealthSubsystem {
     /** The subsystem's display name */
     title: string;
   }
@@ -104,7 +97,7 @@ namespace ExtensionProperties {
     viewAllLink?: string;
   }
 
-  export interface DashboardsTab extends DashboardsExtensionProperties {
+  export interface DashboardsTab {
     /** The tab's ID which will be used as part of href within dashboards page */
     id: string;
 
@@ -112,7 +105,7 @@ namespace ExtensionProperties {
     title: string;
   }
 
-  export interface DashboardsCard extends DashboardsExtensionProperties {
+  export interface DashboardsCard {
     /** The tab's ID where this card should be rendered */
     tab: string;
 
@@ -126,7 +119,7 @@ namespace ExtensionProperties {
     span?: DashboardCardSpan;
   }
 
-  export interface DashboardsOverviewInventoryItem extends DashboardsExtensionProperties {
+  export interface DashboardsOverviewInventoryItem {
     /** The model for `resource` which will be fetched. The model is used for getting model's label or abbr. */
     model: K8sKind;
 
@@ -143,7 +136,7 @@ namespace ExtensionProperties {
     expandedComponent?: LazyLoader<ExpandedComponentProps>;
   }
 
-  export interface DashboardsInventoryItemGroup extends DashboardsExtensionProperties {
+  export interface DashboardsInventoryItemGroup {
     /** The ID of status group. */
     id: string;
 
@@ -151,7 +144,7 @@ namespace ExtensionProperties {
     icon: React.ReactElement;
   }
 
-  export interface DashboardsOverviewUtilizationItem extends DashboardsExtensionProperties {
+  export interface DashboardsOverviewUtilizationItem {
     /** The utilization item to be replaced */
     id: string;
 
@@ -162,7 +155,7 @@ namespace ExtensionProperties {
     totalQuery: string;
   }
 
-  export interface DashboardsOverviewResourceActivity extends DashboardsExtensionProperties {
+  export interface DashboardsOverviewResourceActivity {
     /** Resource to watch */
     k8sResource: FirehoseResource & { isList: true };
 
@@ -179,7 +172,7 @@ namespace ExtensionProperties {
     loader: LazyLoader<K8sActivityProps>;
   }
 
-  export interface DashboardsOverviewPrometheusActivity extends DashboardsExtensionProperties {
+  export interface DashboardsOverviewPrometheusActivity {
     /** Queries to watch */
     queries: string[];
 
@@ -190,7 +183,7 @@ namespace ExtensionProperties {
     loader: LazyLoader<PrometheusActivityProps>;
   }
 
-  export interface ProjectDashboardInventoryItem extends DashboardsExtensionProperties {
+  export interface ProjectDashboardInventoryItem {
     /** The K8s model which will be scoped to project, fetched and passed to `mapper` function. */
     model: K8sKind;
 

--- a/frontend/packages/console-plugin-sdk/src/useExtensions.ts
+++ b/frontend/packages/console-plugin-sdk/src/useExtensions.ts
@@ -83,4 +83,4 @@ export const useExtensions: UseExtensions = (typeGuard) => {
   return extensionsInUse;
 };
 
-type UseExtensions = <E extends Extension>(typeGuard: ExtensionTypeGuard<E>) => readonly E[];
+type UseExtensions = <E extends Extension>(typeGuard: ExtensionTypeGuard<E>) => E[];

--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -106,7 +106,9 @@ const plugin: Plugin<ConsumedExtensions> = [
           (m) => m.SecurityBreakdownPopup,
         ),
       popupTitle: 'Quay Image Security breakdown',
-      required: SecurityLabellerFlag,
+    },
+    flags: {
+      required: [SecurityLabellerFlag],
     },
   },
   {

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -216,7 +216,9 @@ const plugin: Plugin<ConsumedExtensions> = [
       title: 'Virtualization',
       url: `apis/subresources.${models.VirtualMachineModel.apiGroup}/${models.VirtualMachineModel.apiVersion}/healthz`,
       healthHandler: getKubevirtHealthState,
-      required: FLAG_KUBEVIRT,
+    },
+    flags: {
+      required: [FLAG_KUBEVIRT],
     },
   },
   {
@@ -239,7 +241,9 @@ const plugin: Plugin<ConsumedExtensions> = [
       model: models.VirtualMachineModel,
       mapper: getVMStatusGroups,
       useAbbr: true,
-      required: FLAG_KUBEVIRT,
+    },
+    flags: {
+      required: [FLAG_KUBEVIRT],
     },
   },
   {
@@ -247,7 +251,9 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'vm-off',
       icon: <VMOffGroupIcon />,
-      required: FLAG_KUBEVIRT,
+    },
+    flags: {
+      required: [FLAG_KUBEVIRT],
     },
   },
   {
@@ -292,7 +298,9 @@ const plugin: Plugin<ConsumedExtensions> = [
       model: models.VirtualMachineModel,
       mapper: getVMStatusGroups,
       useAbbr: true,
-      required: FLAG_KUBEVIRT,
+    },
+    flags: {
+      required: [FLAG_KUBEVIRT],
     },
   },
   {
@@ -309,7 +317,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboards-page/overview-dashboard/activity' /* webpackChunkName: "kubevirt-activity" */
         ).then((m) => m.DiskImportActivity),
-      required: FLAG_KUBEVIRT,
+    },
+    flags: {
+      required: [FLAG_KUBEVIRT],
     },
   },
   {
@@ -326,7 +336,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/dashboards-page/overview-dashboard/activity' /* webpackChunkName: "kubevirt-activity" */
         ).then((m) => m.V2VImportActivity),
-      required: FLAG_KUBEVIRT,
+    },
+    flags: {
+      required: [FLAG_KUBEVIRT],
     },
   },
 ];

--- a/frontend/packages/metal3-plugin/src/plugin.tsx
+++ b/frontend/packages/metal3-plugin/src/plugin.tsx
@@ -17,7 +17,7 @@ import {
 } from '@console/plugin-sdk';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { MachineModel, NodeModel } from '@console/internal/models';
-// TODO(jtomasek): chage this to '@console/shared/src/utils' once @console/shared/src/utils modules
+// TODO(jtomasek): change this to '@console/shared/src/utils' once @console/shared/src/utils modules
 // no longer import from @console/internal (cyclic deps issues)
 import { formatNamespacedRouteForResource } from '@console/shared/src/utils/namespace';
 import { BareMetalHostModel, NodeMaintenanceModel } from './models';
@@ -137,6 +137,8 @@ const plugin: Plugin<ConsumedExtensions> = [
         },
       },
       mapper: getBMNStatusGroups,
+    },
+    flags: {
       required: [BAREMETAL_FLAG, METAL3_FLAG],
     },
   },
@@ -160,6 +162,8 @@ const plugin: Plugin<ConsumedExtensions> = [
       },
       model: BareMetalHostModel,
       mapper: getBMHStatusGroups,
+    },
+    flags: {
       required: [BAREMETAL_FLAG, METAL3_FLAG],
     },
   },
@@ -201,6 +205,8 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/maintenance/MaintenanceDashboardActivity' /* webpackChunkName: "node-maintenance" */
         ).then((m) => m.default),
+    },
+    flags: {
       required: [BAREMETAL_FLAG, METAL3_FLAG],
     },
   },
@@ -227,6 +233,8 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/baremetal-hosts/dashboard/BareMetalStatusActivity' /* webpackChunkName: "metal3-powering" */
         ).then((m) => m.default),
+    },
+    flags: {
       required: [BAREMETAL_FLAG, METAL3_FLAG],
     },
   },

--- a/frontend/packages/noobaa-storage-plugin/src/plugin.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/plugin.ts
@@ -94,7 +94,9 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       id: 'object-service',
       title: 'Object Service',
-      required: NOOBAA_FLAG,
+    },
+    flags: {
+      required: [NOOBAA_FLAG],
     },
   },
   {
@@ -106,7 +108,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/status-card/status-card' /* webpackChunkName: "object-service-status-card" */
         ).then((m) => m.default),
-      required: NOOBAA_FLAG,
+    },
+    flags: {
+      required: [NOOBAA_FLAG],
     },
   },
   {
@@ -118,7 +122,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/details-card/details-card' /* webpackChunkName: "object-service-details-card" */
         ).then((m) => m.DetailsCard),
-      required: NOOBAA_FLAG,
+    },
+    flags: {
+      required: [NOOBAA_FLAG],
     },
   },
   {
@@ -130,7 +136,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/object-data-reduction-card/object-data-reduction-card' /* webpackChunkName: "object-service-data-reduction-card" */
         ).then((m) => m.default),
-      required: NOOBAA_FLAG,
+    },
+    flags: {
+      required: [NOOBAA_FLAG],
     },
   },
   {
@@ -142,7 +150,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/buckets-card/buckets-card' /* webpackChunkName: "object-service-buckets-card" */
         ).then((m) => m.BucketsCard),
-      required: NOOBAA_FLAG,
+    },
+    flags: {
+      required: [NOOBAA_FLAG],
     },
   },
   {
@@ -154,7 +164,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/capacity-breakdown/capacity-breakdown-card' /* webpackChunkName: "object-service-capacity-breakdown-card" */
         ).then((m) => m.default),
-      required: NOOBAA_FLAG,
+    },
+    flags: {
+      required: [NOOBAA_FLAG],
     },
   },
   {
@@ -166,7 +178,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/data-consumption-card/data-consumption-card' /* webpackChunkName: "object-service-data-consumption-card" */
         ).then((m) => m.default),
-      required: NOOBAA_FLAG,
+    },
+    flags: {
+      required: [NOOBAA_FLAG],
     },
   },
   {
@@ -178,7 +192,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/activity-card/activity-card' /* webpackChunkName: "object-service-activity-card" */
         ).then((m) => m.default),
-      required: NOOBAA_FLAG,
+    },
+    flags: {
+      required: [NOOBAA_FLAG],
     },
   },
   {
@@ -190,7 +206,9 @@ const plugin: Plugin<ConsumedExtensions> = [
         import(
           './components/resource-providers-card/resource-providers-card' /* webpackChunkName: "object-service-resource-providers-card" */
         ).then((m) => m.ResourceProvidersCard),
-      required: NOOBAA_FLAG,
+    },
+    flags: {
+      required: [NOOBAA_FLAG],
     },
   },
   {

--- a/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/plugin.tsx
@@ -294,7 +294,9 @@ const plugin: Plugin<ConsumedExtensions> = [
             './components/dashboard/csv-status' /* webpackChunkName: "csv-dashboard-status" */
           )
         ).default,
-      required: FLAGS.CAN_LIST_OPERATOR_GROUP,
+    },
+    flags: {
+      required: [FLAGS.CAN_LIST_OPERATOR_GROUP],
     },
   },
 ];

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -3,6 +3,8 @@ import * as _ from 'lodash-es';
 import { connect } from 'react-redux';
 import { Map as ImmutableMap } from 'immutable';
 import {
+  useExtensions,
+  DashboardsOverviewHealthSubsystem,
   isDashboardsOverviewHealthSubsystem,
   isDashboardsOverviewHealthURLSubsystem,
   isDashboardsOverviewHealthPrometheusSubsystem,
@@ -22,13 +24,7 @@ import { withDashboardResources, DashboardItemProps } from '../../with-dashboard
 import AlertItem, {
   StatusItem,
 } from '@console/shared/src/components/dashboard/status-card/AlertItem';
-import {
-  connectToFlags,
-  FlagsObject,
-  WithFlagsProps,
-  flagPending,
-} from '../../../../reducers/features';
-import * as plugins from '../../../../plugins';
+import { connectToFlags, WithFlagsProps, flagPending } from '../../../../reducers/features';
 import { FirehoseResource } from '../../../utils';
 import { alertURL } from '../../../monitoring';
 import {
@@ -42,17 +38,18 @@ import { clusterUpdateModal } from '../../../modals/cluster-update-modal';
 import { RootState } from '../../../../redux';
 import { OperatorHealthItem, PrometheusHealthItem, URLHealthItem } from './health-item';
 
-const getSubsystems = (flags: FlagsObject, k8sModels: ImmutableMap<string, K8sKind>) =>
-  plugins.registry.getDashboardsOverviewHealthSubsystems().filter((e) => {
-    if (!plugins.registry.isExtensionInUse(e, flags)) {
-      return false;
-    }
+const filterSubsystems = (
+  subsystems: DashboardsOverviewHealthSubsystem[],
+  k8sModels: ImmutableMap<string, K8sKind>,
+) =>
+  subsystems.filter((subsystem) => {
     if (
-      isDashboardsOverviewHealthPrometheusSubsystem(e) ||
-      isDashboardsOverviewHealthURLSubsystem(e)
+      isDashboardsOverviewHealthURLSubsystem(subsystem) ||
+      isDashboardsOverviewHealthPrometheusSubsystem(subsystem)
     ) {
-      return e.properties.additionalResource && !e.properties.additionalResource.optional
-        ? !!k8sModels.get(e.properties.additionalResource.kind)
+      return subsystem.properties.additionalResource &&
+        !subsystem.properties.additionalResource.optional
+        ? !!k8sModels.get(subsystem.properties.additionalResource.kind)
         : true;
     }
     return true;
@@ -153,55 +150,63 @@ const mapStateToProps = (state: RootState) => ({
   k8sModels: state.k8s.getIn(['RESOURCES', 'models']),
 });
 
-export const StatusCard = connect(mapStateToProps)(
-  connectToFlags<StatusCardProps>(
-    ...plugins.registry.getGatingFlagNames([isDashboardsOverviewHealthSubsystem]),
-  )(({ flags, k8sModels }) => {
-    const subsystems = getSubsystems(flags, k8sModels);
-    const operatorSubsystemIndex = subsystems.findIndex(isDashboardsOverviewHealthOperator);
+export const StatusCard = connect<StatusCardProps>(mapStateToProps)(({ k8sModels }) => {
+  const subsystemExtensions = useExtensions<DashboardsOverviewHealthSubsystem>(
+    isDashboardsOverviewHealthSubsystem,
+  );
 
-    const healthItems: { title: string; Component: React.ReactNode }[] = [];
-    subsystems.forEach((subsystem) => {
-      if (isDashboardsOverviewHealthURLSubsystem(subsystem)) {
-        healthItems.push({
-          title: subsystem.properties.title,
-          Component: <URLHealthItem subsystem={subsystem.properties} models={k8sModels} />,
-        });
-      } else if (isDashboardsOverviewHealthPrometheusSubsystem(subsystem)) {
-        healthItems.push({
-          title: subsystem.properties.title,
-          Component: <PrometheusHealthItem subsystem={subsystem.properties} models={k8sModels} />,
-        });
-      }
-    });
-    if (operatorSubsystemIndex !== -1) {
-      const operatorSubsystems = subsystems.filter(isDashboardsOverviewHealthOperator);
-      healthItems.splice(operatorSubsystemIndex, 0, {
-        title: 'Operators',
-        Component: <OperatorHealthItem operatorExtensions={operatorSubsystems} />,
+  const subsystems = React.useMemo(() => filterSubsystems(subsystemExtensions, k8sModels), [
+    subsystemExtensions,
+    k8sModels,
+  ]);
+
+  const operatorSubsystemIndex = React.useMemo(
+    () => subsystems.findIndex(isDashboardsOverviewHealthOperator),
+    [subsystems],
+  );
+
+  const healthItems: { title: string; Component: React.ReactNode }[] = [];
+  subsystems.forEach((subsystem) => {
+    if (isDashboardsOverviewHealthURLSubsystem(subsystem)) {
+      healthItems.push({
+        title: subsystem.properties.title,
+        Component: <URLHealthItem subsystem={subsystem.properties} models={k8sModels} />,
+      });
+    } else if (isDashboardsOverviewHealthPrometheusSubsystem(subsystem)) {
+      healthItems.push({
+        title: subsystem.properties.title,
+        Component: <PrometheusHealthItem subsystem={subsystem.properties} models={k8sModels} />,
       });
     }
-    return (
-      <DashboardCard gradient data-test-id="status-card">
-        <DashboardCardHeader>
-          <DashboardCardTitle>Status</DashboardCardTitle>
-          <DashboardCardLink to="/monitoring/alerts">View alerts</DashboardCardLink>
-        </DashboardCardHeader>
-        <DashboardCardBody>
-          <HealthBody>
-            <Gallery className="co-overview-status__health" gutter="md">
-              {healthItems.map((item) => {
-                return <GalleryItem key={item.title}>{item.Component}</GalleryItem>;
-              })}
-            </Gallery>
-          </HealthBody>
-          <ClusterAlerts />
-        </DashboardCardBody>
-      </DashboardCard>
-    );
-  }),
-);
+  });
+  if (operatorSubsystemIndex !== -1) {
+    const operatorSubsystems = subsystems.filter(isDashboardsOverviewHealthOperator);
+    healthItems.splice(operatorSubsystemIndex, 0, {
+      title: 'Operators',
+      Component: <OperatorHealthItem operatorExtensions={operatorSubsystems} />,
+    });
+  }
 
-type StatusCardProps = WithFlagsProps & {
+  return (
+    <DashboardCard gradient data-test-id="status-card">
+      <DashboardCardHeader>
+        <DashboardCardTitle>Status</DashboardCardTitle>
+        <DashboardCardLink to="/monitoring/alerts">View alerts</DashboardCardLink>
+      </DashboardCardHeader>
+      <DashboardCardBody>
+        <HealthBody>
+          <Gallery className="co-overview-status__health" gutter="md">
+            {healthItems.map((item) => {
+              return <GalleryItem key={item.title}>{item.Component}</GalleryItem>;
+            })}
+          </Gallery>
+        </HealthBody>
+        <ClusterAlerts />
+      </DashboardCardBody>
+    </DashboardCard>
+  );
+});
+
+type StatusCardProps = {
   k8sModels: ImmutableMap<string, K8sKind>;
 };

--- a/frontend/public/components/factory/details.tsx
+++ b/frontend/public/components/factory/details.tsx
@@ -37,6 +37,7 @@ export const DetailsPage = withFallback<DetailsPageProps>(({ pages = [], ...prop
   );
 
   const resourcePageExtensions = useExtensions<ResourceTabPage>(isResourceTabPage);
+
   const pluginPages = React.useMemo(
     () =>
       resourcePageExtensions


### PR DESCRIPTION
Depends on #4211 and #4232 

This PR migrates all dashboard related extensions to use the React hook introduced in #3383.

It also ensures that data derived from `useExtensions` calls is memoized via `React.useMemo` hook.

cc @rawagner 