### PR TITLE
Bug 1798697: Show support links

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -624,6 +624,9 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
   props,
 ) => {
   const { spec, metadata, status } = props.obj;
+  const {
+    'marketplace.openshift.io/support-workflow': marketplaceSupportWorkflow,
+  } = metadata.annotations;
 
   return (
     <>
@@ -652,6 +655,14 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
                 <dd>
                   {spec.provider && spec.provider.name ? spec.provider.name : 'Not available'}
                 </dd>
+                {marketplaceSupportWorkflow && (
+                  <>
+                    <dt>Support</dt>
+                    <dd>
+                      <ExternalLink href={marketplaceSupportWorkflow} text="Get support" />
+                    </dd>
+                  </>
+                )}
                 <dt>Created At</dt>
                 <dd>
                   <Timestamp timestamp={metadata.creationTimestamp} />

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -52,6 +52,7 @@ export type OperatorHubCSVAnnotations = {
   capabilities?: CapabilityLevel;
   'marketplace.openshift.io/action-text'?: string;
   'marketplace.openshift.io/remote-workflow'?: string;
+  'marketplace.openshift.io/support-workflow'?: string;
 };
 
 type OperatorHubSpec = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -68,6 +68,7 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
     createdAt,
     support,
     capabilityLevel,
+    marketplaceSupportWorkflow,
   } = item;
   const notAvailable = <span className="properties-side-panel-pf-property-label">N/A</span>;
 
@@ -144,7 +145,16 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
               <PropertyItem label="Repository" value={repository || notAvailable} />
               <PropertyItem label="Container Image" value={containerImage || notAvailable} />
               <PropertyItem label="Created At" value={createdAt || notAvailable} />
-              <PropertyItem label="Support" value={support || notAvailable} />
+              <PropertyItem
+                label="Support"
+                value={
+                  marketplaceSupportWorkflow ? (
+                    <ExternalLink href={marketplaceSupportWorkflow} text="Get support" />
+                  ) : (
+                    support || notAvailable
+                  )
+                }
+              />
             </PropertiesSidePanel>
             <div className="co-catalog-page__overlay-description">
               {getHintBlock()}

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -50,6 +50,7 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
         capabilities: capabilityLevel,
         'marketplace.openshift.io/action-text': marketplaceActionText,
         'marketplace.openshift.io/remote-workflow': marketplaceRemoteWorkflow,
+        'marketplace.openshift.io/support-workflow': marketplaceSupportWorkflow,
       } = currentCSVAnnotations;
 
       return {
@@ -90,6 +91,7 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
         capabilityLevel,
         marketplaceActionText,
         marketplaceRemoteWorkflow,
+        marketplaceSupportWorkflow,
       };
     },
   );

--- a/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
@@ -67,7 +67,7 @@ export const normalizeClusterServiceVersions = (
       href: `/ns/${desc.csv.metadata.namespace}/clusterserviceversions/${
         desc.csv.metadata.name
       }/${referenceForProvidedAPI(desc)}/~new`,
-      supportUrl: null,
+      supportUrl: desc.csv.metadata.annotations?.['marketplace.openshift.io/support-workflow'],
       longDescription: `This resource is provided by ${desc.csv.spec.displayName}, a Kubernetes Operator enabled by the Operator Lifecycle Manager.`,
       documentationUrl: _.get(
         (desc.csv.spec.links || []).find(({ name }) => name === 'Documentation'),


### PR DESCRIPTION
Support links were removed at the last minute from the original OLM workflows PR. Re-instantiating work.

Dev Catalog:
<img width="1188" alt="Screen Shot 2020-02-06 at 2 46 44 PM" src="https://user-images.githubusercontent.com/7014965/73972956-b2100780-48ef-11ea-92f9-d5b812d887b2.png">

OperatorHub:
<img width="1190" alt="Screen Shot 2020-02-06 at 2 47 26 PM" src="https://user-images.githubusercontent.com/7014965/73972974-b805e880-48ef-11ea-9096-f40f415553c4.png">

Installed Operators:
<img width="1187" alt="Screen Shot 2020-02-06 at 2 47 47 PM" src="https://user-images.githubusercontent.com/7014965/73972988-be946000-48ef-11ea-9015-742f5c08464f.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1798697.

Heads up @openshift/team-ux-review.