### PR TITLE
Bug 1784725: Console should do special character check when create routing labels

### DIFF
--- a/frontend/__tests__/components/monitoring.spec.tsx
+++ b/frontend/__tests__/components/monitoring.spec.tsx
@@ -1,0 +1,21 @@
+import { getRouteLabelFieldErrors } from '../../public/components/monitoring/receiver-forms/routing-labels-editor';
+
+describe('Routing Label Editor', () => {
+  it('validates label names correctly', () => {
+    // label names cannot start with digit, and may only contain alphanumeric and '_'
+    // these are valid
+    let labelErrors = getRouteLabelFieldErrors([{ name: 'aa', value: '', isRegex: false }]);
+    expect(labelErrors['0_name']).toBe(undefined);
+    labelErrors = getRouteLabelFieldErrors([{ name: '_bb', value: '', isRegex: false }]);
+    expect(labelErrors['0_name']).toBe(undefined);
+    labelErrors = getRouteLabelFieldErrors([{ name: '_cc98a7_', value: '', isRegex: false }]);
+    expect(labelErrors['0_name']).toBe(undefined);
+    // these are invalid
+    labelErrors = getRouteLabelFieldErrors([{ name: '9abc', value: '', isRegex: false }]);
+    expect(labelErrors['0_name']).toBeTruthy();
+    labelErrors = getRouteLabelFieldErrors([{ name: 'aa&^%', value: '', isRegex: false }]);
+    expect(labelErrors['0_name']).toBeTruthy();
+    labelErrors = getRouteLabelFieldErrors([{ name: '_abc_%', value: '', isRegex: false }]);
+    expect(labelErrors['0_name']).toBeTruthy();
+  });
+});

--- a/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
@@ -232,7 +232,10 @@ const ReceiverBaseForm: React.FC<ReceiverBaseFormProps> = ({
   const SubForm = subformFactory(formValues.receiverType);
 
   const isFormInvalid =
-    !formValues.receiverName || !formValues.receiverType || SubForm.isFormInvalid(formValues);
+    !formValues.receiverName ||
+    !formValues.receiverType ||
+    SubForm.isFormInvalid(formValues) ||
+    !_.isEmpty(formValues.routeLabelFieldErrors);
 
   const save = (e) => {
     e.preventDefault();

--- a/frontend/public/components/monitoring/receiver-forms/routing-labels-editor.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/routing-labels-editor.tsx
@@ -1,10 +1,23 @@
 import * as _ from 'lodash-es';
 import * as React from 'react';
-import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
-import { Button } from '@patternfly/react-core';
+import * as classNames from 'classnames';
+import { MinusCircleIcon, PlusCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';
+import { Button, Tooltip } from '@patternfly/react-core';
+
 import { ExternalLink, SectionHeading } from '../../utils';
 
 const DEFAULT_RECEIVER_LABEL = 'All (default receiver)';
+const labelNamePattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+export const getRouteLabelFieldErrors = (labels) => {
+  const routeLabelFieldErrors = {};
+  labels.forEach((label, i) => {
+    if (label.name && !label.name.match(labelNamePattern)) {
+      routeLabelFieldErrors[`${i}_name`] = true;
+    }
+  });
+  return routeLabelFieldErrors;
+};
 
 export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultReceiver }) => {
   const setRouteLabel = (path: string, v: any): void => {
@@ -14,6 +27,7 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
       type: 'setFormValues',
       payload: {
         routeLabels: labels,
+        routeLabelFieldErrors: getRouteLabelFieldErrors(labels),
       },
     });
   };
@@ -44,6 +58,21 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
       },
     });
   };
+
+  const InvalidLabelName = () => (
+    <span data-test-id="invalidLabelNameError">
+      Invalid name
+      <Tooltip
+        content={
+          <p>
+            Label name must not begin with a digit and contain only alphanumeric characters or '_'.
+          </p>
+        }
+      >
+        <InfoCircleIcon className="co-icon-space-l" />
+      </Tooltip>
+    </span>
+  );
 
   return (
     <div data-test-id="receiver-routing-labels-editor" className="form-group">
@@ -90,12 +119,17 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
         </div>
       )}
       {_.map(formValues.routeLabels, (routeLabel, i: number) => {
+        const hasLabelNameError = formValues?.routeLabelFieldErrors?.[`${i}_name`];
         return (
           <div className="row form-group" key={i}>
             <div className="col-xs-10">
               <div className="row">
                 <div className="col-xs-6 pairs-list__name-field">
-                  <div className="form-group">
+                  <div
+                    className={classNames('form-group', {
+                      'has-error': hasLabelNameError,
+                    })}
+                  >
                     <input
                       type="text"
                       className="pf-c-form-control"
@@ -105,6 +139,7 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
                       value={routeLabel.name}
                       required
                     />
+                    <span className="help-block">{hasLabelNameError && <InvalidLabelName />}</span>
                   </div>
                 </div>
                 <div className="col-xs-6 pairs-list__value-field">


### PR DESCRIPTION
Routing Label names have this [regex validation](https://prometheus.io/docs/alerting/configuration/#labelname).  
- Haven't found validation for Routing Label values, which can also be regex chars themselves if Regular Expression checkbox is checked.
 
Implemented Receiver Form routing label name validation:

<hr/>

![image](https://user-images.githubusercontent.com/12733153/73978969-59df0280-48fb-11ea-97c0-067ee6ed3076.png)

<hr/>

![image](https://user-images.githubusercontent.com/12733153/73978983-5e0b2000-48fb-11ea-8ed8-45c57d830edd.png)

<hr/>
