### PR TITLE
Bug 1800347: Set resource name font size to be consistent.

### DIFF
--- a/frontend/public/components/_resource.scss
+++ b/frontend/public/components/_resource.scss
@@ -142,7 +142,11 @@
     white-space: nowrap;
   }
   &__resource-name {
+    font-size: $font-size-base;
     min-width: 0; // required so co-break-word works
+    &--lg {
+      font-size: var(--pf-global--FontSize--xl);
+    }
   }
   &__resource-status {
     padding-left: 8px;

--- a/frontend/public/components/overview/_overview.scss
+++ b/frontend/public/components/overview/_overview.scss
@@ -60,7 +60,6 @@ $overview-sidebar-width: 550px;
   padding-top: 5px;
 
   .co-m-pane__heading {
-    font-size: var(--pf-global--FontSize--xl);
     margin: 0 20px var(--pf-global--spacer--md);
   }
 

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -129,7 +129,10 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
           ) : (
             <div className="co-m-pane__name co-resource-item">
               {kind && <ResourceIcon kind={kind} className="co-m-resource-icon--lg" />}{' '}
-              <span data-test-id="resource-title" className="co-resource-item__resource-name">
+              <span
+                data-test-id="resource-title"
+                className="co-resource-item__resource-name co-resource-item__resource-name--lg"
+              >
                 {resourceTitle}
               </span>
               {resourceStatus && (
@@ -204,7 +207,7 @@ export const ResourceOverviewHeading: React.SFC<ResourceOverviewHeadingProps> = 
               resource.metadata.name,
               resource.metadata.namespace,
             )}
-            className="co-resource-item__resource-name"
+            className="co-resource-item__resource-name co-resource-item__resource-name--lg"
           >
             {resource.metadata.name}
           </Link>


### PR DESCRIPTION
Explicitly set event resource name within dashboard to the correct font-size. It it too small, because of it being inherited from `pf-c-accordion` 
Also introduce `co-resource-item__resource-name--lg` for resource names used in headings.

**Before**
<img width="425" alt="Screen Shot 2020-02-06 at 4 58 52 PM" src="https://user-images.githubusercontent.com/1874151/73982849-14263800-4903-11ea-939a-a5d6b906ba24.png">

**After**
<img width="425" alt="Screen Shot 2020-02-06 at 5 01 33 PM" src="https://user-images.githubusercontent.com/1874151/73982862-18525580-4903-11ea-860a-523045646153.png">

---
<img width="427" alt="Screen Shot 2020-02-06 at 4 54 51 PM" src="https://user-images.githubusercontent.com/1874151/73982979-5b142d80-4903-11ea-9bd4-f52bdefa1417.png">

<img width="561" alt="Screen Shot 2020-02-06 at 4 55 02 PM" src="https://user-images.githubusercontent.com/1874151/73982984-5ea7b480-4903-11ea-99cb-0136c56249a3.png">


