### PR TITLE
Bug 1789602: Property array should render its properties on schema page

### DIFF
--- a/frontend/public/components/sidebars/explore-type-sidebar.tsx
+++ b/frontend/public/components/sidebars/explore-type-sidebar.tsx
@@ -39,6 +39,8 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
     ? currentSelection.path
     : [getDefinitionKey(kindObj, allDefinitions)];
   const currentDefinition: SwaggerDefinition = _.get(allDefinitions, currentPath) || {};
+  const currentProperties =
+    _.get(currentDefinition, 'properties') || _.get(currentDefinition, 'items.properties');
 
   // Prefer the description saved in `currentSelection`. It won't always be defined in the definition itself.
   const description = currentSelection
@@ -113,11 +115,11 @@ export const ExploreType: React.FC<ExploreTypeProps> = (props) => {
           <LinkifyExternal>{description}</LinkifyExternal>
         </p>
       )}
-      {_.isEmpty(currentDefinition.properties) ? (
+      {_.isEmpty(currentProperties) ? (
         <EmptyBox label="Properties" />
       ) : (
         <ul className="co-resource-sidebar-list">
-          {_.map(currentDefinition.properties, (definition: SwaggerDefinition, name: string) => {
+          {_.map(currentProperties, (definition: SwaggerDefinition, name: string) => {
             const path = getDrilldownPath(name);
             const definitionType = definition.type || getTypeForRef(getRef(definition));
             return (


### PR DESCRIPTION
The issue was that we didnt take into account that the property type can also be an array, which also contains `properties` field.

Noticed that the BZ Target Release is set to 4.5., not sure why.

/assign @spadgett 