### PR TITLE
Bug 1792487: Rename Machine Running phase to Provisioned as node.

### DIFF
--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -34,6 +34,7 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
     case 'Running':
     case 'Updating':
     case 'Upgrading':
+    case 'Provisioned as node':
       return <StatusIconAndText {...statusProps} icon={<SyncAltIcon />} />;
 
     case 'Cancelled':


### PR DESCRIPTION
as @enxebre suggested we could show `Running` phase as `Provisioned as node` in UI. We can also add another item to list and details pages - provider status. 

@smarterclayton @benjaminapetersen 


![Screenshot from 2020-02-07 12-50-47](https://user-images.githubusercontent.com/2078045/74027493-8d2b9b00-49a8-11ea-993c-37aa4e321802.png)
Changes for list view
 - `Phase` column shows `Provisioned as node` if phase us `Running`
 - added new column `Provider State` 

![Screenshot from 2020-02-07 12-50-56](https://user-images.githubusercontent.com/2078045/74027492-8c930480-49a8-11ea-9970-c28de453afda.png)
Changes for details view
 - renamed `Status` column to `Phase` to align with list view
 - `Phase` column shows `Provisioned as node` if phase us `Running`
 - added new column `Provider State` 




