### PR TITLE
Bug 1800559: adds pod list and deployment in revision sidebar

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/DeploymentOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/DeploymentOverviewList.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { PodControllerOverviewItem } from '@console/shared';
+import { ResourceLink, SidebarSectionHeading } from '@console/internal/components/utils';
+
+type DeploymentOverviewListProps = {
+  current: PodControllerOverviewItem;
+};
+
+const DeploymentOverviewList: React.FC<DeploymentOverviewListProps> = ({ current: { obj } }) => {
+  const namespace = obj?.metadata?.namespace;
+  const deploymentData = obj?.metadata?.ownerReferences[0];
+  return (
+    <>
+      <SidebarSectionHeading text="Deployment" />
+      {deploymentData && deploymentData.name ? (
+        <ul className="list-group">
+          <li className="list-group-item">
+            <ResourceLink
+              kind={deploymentData.kind}
+              name={deploymentData.name}
+              namespace={namespace}
+            />
+          </li>
+        </ul>
+      ) : (
+        <span className="text-muted">No Deploymennt found for this resource.</span>
+      )}
+    </>
+  );
+};
+
+export default DeploymentOverviewList;

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeRevisionResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeRevisionResources.tsx
@@ -1,21 +1,40 @@
 import * as React from 'react';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import * as _ from 'lodash';
+import { K8sResourceKind, PodKind, podPhase } from '@console/internal/module/k8s';
+import { PodControllerOverviewItem } from '@console/shared';
+import { PodsOverview } from '@console/internal/components/overview/pods-overview';
 import ConfigurationsOverviewList from './ConfigurationsOverviewList';
 import KSRoutesOverviewList from './RoutesOverviewList';
+import DeploymentOverviewList from './DeploymentOverviewList';
 
-export type KnativeRevisionResourceProps = {
+const AUTOSCALED = 'Autoscaled to 0';
+type KnativeRevisionResourceProps = {
   ksroutes: K8sResourceKind[];
   configurations: K8sResourceKind[];
   obj: K8sResourceKind;
+  pods?: PodKind[];
+  current?: PodControllerOverviewItem;
 };
 
 const KnativeRevisionResources: React.FC<KnativeRevisionResourceProps> = ({
   ksroutes,
   configurations,
   obj,
+  pods,
+  current,
 }) => {
+  const {
+    kind: resKind,
+    metadata: { name, namespace },
+  } = obj;
+  const activePods = _.filter(pods, (pod) => podPhase(pod) !== AUTOSCALED);
+  const linkUrl = `/search/ns/${namespace}?kind=Pod&q=${encodeURIComponent(
+    `serving.knative.dev/${resKind.toLowerCase()}=${name}`,
+  )}`;
   return (
     <>
+      <PodsOverview pods={activePods} obj={obj} emptyText={AUTOSCALED} allPodsLink={linkUrl} />
+      <DeploymentOverviewList current={current} />
       <KSRoutesOverviewList ksroutes={ksroutes} resource={obj} />
       <ConfigurationsOverviewList configurations={configurations} />
     </>

--- a/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
@@ -21,11 +21,24 @@ type OverviewDetailsResourcesTabProps = {
   item: OverviewItem;
 };
 
-const getSidebarResources = ({ obj, ksroutes, revisions, configurations }: OverviewItem) => {
+const getSidebarResources = ({
+  obj,
+  ksroutes,
+  revisions,
+  configurations,
+  pods,
+  current,
+}: OverviewItem) => {
   switch (obj.kind) {
     case RevisionModel.kind:
       return (
-        <KnativeRevisionResources ksroutes={ksroutes} obj={obj} configurations={configurations} />
+        <KnativeRevisionResources
+          ksroutes={ksroutes}
+          obj={obj}
+          configurations={configurations}
+          pods={pods}
+          current={current}
+        />
       );
     case ServiceModel.kind:
       return <KnativeServiceResources ksroutes={ksroutes} obj={obj} revisions={revisions} />;

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/DeploymentOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/DeploymentOverviewList.spec.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { PodControllerOverviewItem } from '@console/shared';
+import {
+  sampleKnativeReplicaSets,
+  sampleKnativePods,
+} from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import { ResourceLink, SidebarSectionHeading } from '@console/internal/components/utils';
+import DeploymentOverviewList from '../DeploymentOverviewList';
+
+type DeploymentOverviewListProps = React.ComponentProps<typeof DeploymentOverviewList>;
+let current: PodControllerOverviewItem;
+describe('DeploymentOverviewList', () => {
+  let wrapper: ShallowWrapper<DeploymentOverviewListProps>;
+  beforeEach(() => {
+    current = {
+      alerts: {},
+      revision: 1,
+      obj: sampleKnativeReplicaSets.data[0],
+      pods: sampleKnativePods.data,
+    };
+  });
+  it('should render DeploymentOverviewList with ResourceLink', () => {
+    wrapper = shallow(<DeploymentOverviewList current={current} />);
+    expect(wrapper.find(SidebarSectionHeading)).toHaveLength(1);
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeRevisionResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeRevisionResources.spec.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { PodsOverview } from '@console/internal/components/overview/pods-overview';
+import {
+  sampleKnativeConfigurations,
+  sampleKnativePods,
+  sampleKnativeRoutes,
+  revisionObj,
+} from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import KnativeRevisionResources from '../KnativeRevisionResources';
+import ConfigurationsOverviewList from '../ConfigurationsOverviewList';
+import KSRoutesOverviewList from '../RoutesOverviewList';
+import DeploymentOverviewList from '../DeploymentOverviewList';
+
+describe('KnativeRevisionResources', () => {
+  it('should render KnativeRevisionResources', () => {
+    const wrapper = shallow(
+      <KnativeRevisionResources
+        ksroutes={sampleKnativeRoutes.data}
+        obj={revisionObj}
+        configurations={sampleKnativeConfigurations.data}
+        pods={sampleKnativePods.data}
+      />,
+    );
+    expect(wrapper.find(PodsOverview)).toHaveLength(1);
+    expect(wrapper.find(ConfigurationsOverviewList)).toHaveLength(1);
+    expect(wrapper.find(KSRoutesOverviewList)).toHaveLength(1);
+    expect(wrapper.find(DeploymentOverviewList)).toHaveLength(1);
+  });
+});

--- a/frontend/public/components/overview/pods-overview.tsx
+++ b/frontend/public/components/overview/pods-overview.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 import { Status } from '@console/shared';
 import { ResourceLink, resourcePath, SidebarSectionHeading } from '../utils';
-import { podPhase, PodKind, K8sResourceKind } from '../../module/k8s';
+import { podPhase, PodKind, K8sResourceKind, referenceFor } from '../../module/k8s';
 
 const kind: string = 'Pod';
 const MAX_PODS: number = 3;
@@ -113,30 +113,33 @@ const PodsOverviewList: React.SFC<PodOverviewListProps> = ({ pods }) => (
 
 PodsOverviewList.displayName = 'PodsOverviewList';
 
-export const PodsOverview: React.SFC<PodsOverviewProps> = ({ pods, obj }) => {
+export const PodsOverview: React.SFC<PodsOverviewProps> = ({
+  pods,
+  obj,
+  allPodsLink,
+  emptyText,
+}) => {
   const {
     metadata: { name, namespace },
   } = obj;
 
   const errorPodCount = _.size(_.filter(pods, (pod) => isPodError(pod)));
   const podsShown = Math.max(Math.min(errorPodCount, MAX_ERROR_PODS), MAX_PODS);
-
+  const linkTo = allPodsLink || `${resourcePath(referenceFor(obj), name, namespace)}/pods`;
+  const emptyMessage = emptyText || 'No Pods found for this resource.';
   pods.sort(podCompare);
 
   return (
     <>
       <SidebarSectionHeading text="Pods">
         {_.size(pods) > podsShown && (
-          <Link
-            className="sidebar__section-view-all"
-            to={`${resourcePath(obj.kind, name, namespace)}/pods`}
-          >
+          <Link className="sidebar__section-view-all" to={linkTo}>
             {`View all (${_.size(pods)})`}
           </Link>
         )}
       </SidebarSectionHeading>
       {_.isEmpty(pods) ? (
-        <span className="text-muted">No Pods found for this resource.</span>
+        <span className="text-muted">{emptyMessage}</span>
       ) : (
         <PodsOverviewList pods={_.take(pods, podsShown)} />
       )}
@@ -151,4 +154,6 @@ type PodOverviewListProps = {
 type PodsOverviewProps = {
   pods: PodKind[];
   obj: K8sResourceKind;
+  allPodsLink?: string;
+  emptyText?: string;
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2964

**Analysis / Root cause**: 
There isn't any way to navigate to the deployment resource from selecting the knative revision in topology. The only way to do this would be to select the knative service and then find the revision of interest in the list. There we have a link to the related deployment.

**Solution Description**: 
Revision sidebar has list of pods and associated deployment

**Screen shots / Gifs for design review**: 
![ezgif com-video-to-gif (22)](https://user-images.githubusercontent.com/5129024/74029250-45216e00-49d2-11ea-8bf5-bcc1fc3b46e7.gif)


**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc  @openshift/team-devconsole-ux / @serenamarie125 