### PR TITLE
Bug 1798925: KnativeServing should use new operator.knative.dev apiGroup

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -5,7 +5,11 @@ import { ResourceOverviewDetails } from '@console/internal/components/overview/r
 import { groupVersionFor, K8sKind } from '@console/internal/module/k8s';
 import { RootState } from '@console/internal/redux';
 import { OverviewItem } from '@console/shared';
-import { KNATIVE_SERVING_APIGROUP, KNATIVE_EVENT_SOURCE_APIGROUP } from '../../const';
+import {
+  KNATIVE_SERVING_APIGROUP,
+  KNATIVE_OPERATOR_APIGROUP,
+  KNATIVE_EVENT_SOURCE_APIGROUP,
+} from '../../const';
 import OverviewDetailsKnativeResourcesTab from './OverviewDetailsKnativeResourcesTab';
 import KnativeOverview from './KnativeOverview';
 
@@ -62,6 +66,7 @@ const mapStateToProps = (state: RootState): StateProps => {
       .filter(
         (model: K8sKind) =>
           model.apiGroup === KNATIVE_SERVING_APIGROUP ||
+          model.apiGroup === KNATIVE_OPERATOR_APIGROUP ||
           model.apiGroup === KNATIVE_EVENT_SOURCE_APIGROUP,
       ),
   };

--- a/frontend/packages/knative-plugin/src/const.ts
+++ b/frontend/packages/knative-plugin/src/const.ts
@@ -10,4 +10,5 @@ export const FLAG_EVENT_SOURCE_CAMEL = 'EVENT_SOURCE_CAMEL';
 export const FLAG_EVENT_SOURCE_KAFKA = 'EVENT_SOURCE_KAFKA';
 export const KNATIVE_SERVING_LABEL = 'serving.knative.dev/service';
 export const KNATIVE_SERVING_APIGROUP = 'serving.knative.dev';
+export const KNATIVE_OPERATOR_APIGROUP = 'operator.knative.dev';
 export const KNATIVE_EVENT_SOURCE_APIGROUP = 'sources.eventing.knative.dev';

--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -23,7 +23,7 @@ export const ConfigurationModel: K8sKind = {
 };
 
 export const KnativeServingModel: K8sKind = {
-  apiGroup: 'serving.knative.dev',
+  apiGroup: 'operator.knative.dev',
   apiVersion: 'v1alpha1',
   kind: 'KnativeServing',
   label: 'Knative Serving',


### PR DESCRIPTION
Based on conversation with @markusthoemmes and https://github.com/openshift/openshift-docs/commit/86c912c1bfd37a58a541ad23ab999ea104122258 we need to update the apiGroup of the KnativeServing from the old `serving.knative.dev` to new `operator.knative.dev`

/assign @spadgett 