### PR TITLE
Bug 1800598: updates apiGroup  for knativeServing resource

### DIFF
--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -23,7 +23,7 @@ export const ConfigurationModel: K8sKind = {
 };
 
 export const KnativeServingModel: K8sKind = {
-  apiGroup: 'serving.knative.dev',
+  apiGroup: 'operator.knative.dev',
   apiVersion: 'v1alpha1',
   kind: 'KnativeServing',
   label: 'Knative Serving',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2873

**Analysis / Root cause**: 
The API group of KnativeServing resources `serving.knative.dev` is deprecated and it has changed to `operator.knative.dev` in Serverless operator 1.4

**Solution Description**: 
Changing API group of KnativeServing resources to `operator.knative.dev`


