### PR TITLE
Bug 1800689: Identify Operator backed services on sidebar in listview  topology 

### DIFF
--- a/frontend/packages/console-shared/src/types/resource.ts
+++ b/frontend/packages/console-shared/src/types/resource.ts
@@ -1,6 +1,7 @@
 import { K8sResourceKind, PodKind, RouteKind, EventKind } from '@console/internal/module/k8s';
 import { DEPLOYMENT_STRATEGY } from '../constants';
 import { OverviewItemAlerts, PodControllerOverviewItem } from './pod';
+import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
 
 export type BuildConfigOverviewItem = K8sResourceKind & {
   builds: K8sResourceKind[];
@@ -23,6 +24,10 @@ export type OverviewItem<T = K8sResourceKind> = {
   revisions?: K8sResourceKind[];
   events?: EventKind[];
   isOperatorBackedService?: boolean;
+};
+
+export type OperatorBackedServiceKindMap = {
+  [name: string]: ClusterServiceVersionKind;
 };
 
 export type DeploymentStrategy = DEPLOYMENT_STRATEGY.recreate | DEPLOYMENT_STRATEGY.rolling;

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import * as plugins from '@console/internal/plugins';
 import { getResourceList } from '@console/shared';
 import { referenceForModel } from '@console/internal/module/k8s';
-import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
 import { RootState } from '@console/internal/redux';
 import { ServiceBindingRequestModel } from '../../models';
 import { TopologyFilters, getTopologyFilters } from './filters/filter-utils';
@@ -85,13 +84,6 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
   filters,
 }) => {
   const { resources, utils } = getResourceList(namespace, resourceList);
-  resources.push({
-    isList: true,
-    kind: referenceForModel(ClusterServiceVersionModel),
-    namespace,
-    prop: 'clusterServiceVersions',
-    optional: true,
-  });
   if (serviceBinding) {
     resources.push({
       isList: true,

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -2,7 +2,6 @@ import { ComponentType } from 'react';
 import { FirehoseResult, KebabOption } from '@console/internal/components/utils';
 import { ExtPodKind, OverviewItem, PodControllerOverviewItem } from '@console/shared';
 import { DeploymentKind, K8sResourceKind, PodKind, EventKind } from '@console/internal/module/k8s';
-import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
 import { Pipeline, PipelineRun } from '../../utils/pipeline-augment';
 
 export type Point = [number, number];
@@ -121,10 +120,6 @@ export interface DonutStatusData {
   dc: K8sResourceKind;
   isRollingOut: boolean;
 }
-
-export type OperatorBackedServiceKindMap = {
-  [name: string]: ClusterServiceVersionKind;
-};
 
 export interface GraphApi {
   zoomIn(): void;

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -13,6 +13,8 @@ import {
   OverviewItem,
   getImageForCSVIcon,
   getDefaultOperatorIcon,
+  OperatorBackedServiceKindMap,
+  getOperatorBackedServiceKindMap,
 } from '@console/shared';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import {
@@ -30,7 +32,6 @@ import {
   createServiceBinding,
   removeServiceBinding,
   edgesFromServiceBinding,
-  getOperatorBackedServiceKindMap,
 } from '../../utils/application-utils';
 import { TopologyFilters } from './filters/filter-utils';
 import {
@@ -41,7 +42,6 @@ import {
   Edge,
   Group,
   TopologyOverviewItem,
-  OperatorBackedServiceKindMap,
   TrafficData,
   KialiNode,
 } from './topology-types';
@@ -58,6 +58,7 @@ import {
   TYPE_CONNECTS_TO,
   TYPE_SERVICE_BINDING,
 } from './const';
+import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
 
 export const allowedResources = ['deployments', 'deploymentConfigs', 'daemonSets', 'statefulSets'];
 
@@ -134,8 +135,12 @@ export const isEventWarning = (resource: OverviewItem): boolean => {
  * @param resources
  * @param utils
  */
-const createInstanceForResource = (resources: TopologyDataResources, utils?: Function[]) => {
-  const transformResourceData = new TransformResourceData(resources, utils);
+const createInstanceForResource = (
+  resources: TopologyDataResources,
+  utils?: Function[],
+  installedOperators?: ClusterServiceVersionKind[],
+) => {
+  const transformResourceData = new TransformResourceData(resources, utils, installedOperators);
 
   return {
     deployments: transformResourceData.createDeploymentItems,
@@ -599,7 +604,7 @@ export const transformTopologyData = (
   resources.deployments.data = filterNonKnativeDeployments(deploymentResources);
   // END: kn call to form topology data
 
-  const transformResourceData = createInstanceForResource(resources, utils);
+  const transformResourceData = createInstanceForResource(resources, utils, installedOperators);
   const allResources = _.flatten(
     allowedResources.map((resourceKind) => {
       return resources[resourceKind]

--- a/frontend/packages/dev-console/src/utils/application-utils.ts
+++ b/frontend/packages/dev-console/src/utils/application-utils.ts
@@ -23,10 +23,7 @@ import {
   DaemonSetModel,
   StatefulSetModel,
 } from '@console/internal/models';
-import {
-  ClusterServiceVersionKind,
-  ClusterServiceVersionModel,
-} from '@console/operator-lifecycle-manager';
+import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import {
   ServiceModel as KnativeServiceModel,
   RouteModel as KnativeRouteModel,
@@ -37,13 +34,11 @@ import {
   EventSourceKafkaModel,
 } from '@console/knative-plugin';
 import { checkAccess } from '@console/internal/components/utils';
-import {
-  OperatorBackedServiceKindMap,
-  TopologyDataObject,
-} from '../components/topology/topology-types';
+import { TopologyDataObject } from '../components/topology/topology-types';
 import { detectGitType } from '../components/import/import-validation-utils';
 import { GitTypes } from '../components/import/import-types';
 import { ServiceBindingRequestModel } from '../models';
+import { getOperatorBackedServiceKindMap } from '@console/shared';
 
 export const edgesFromAnnotations = (annotations): string[] => {
   let edges: string[] = [];
@@ -447,24 +442,6 @@ export const cleanUpWorkload = (
     deleteRequest(SecretModel, obj);
   });
   return Promise.all(reqs);
-};
-
-export const getOperatorBackedServiceKindMap = (
-  installedOperators: ClusterServiceVersionKind[],
-): OperatorBackedServiceKindMap => {
-  let operatorBackedServiceKindMap: OperatorBackedServiceKindMap = {};
-  if (installedOperators) {
-    operatorBackedServiceKindMap = installedOperators.reduce((kindMap, csv) => {
-      (csv?.spec?.customresourcedefinitions?.owned || []).forEach((crd) => {
-        if (!(crd.kind in kindMap)) {
-          kindMap[crd.kind] = csv;
-        }
-      });
-      return kindMap;
-    }, {});
-  }
-
-  return operatorBackedServiceKindMap;
 };
 
 export const doContextualBinding = async (

--- a/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
@@ -13,6 +13,7 @@ import {
   getBuildAlerts,
   getOwnedResources,
   OverviewItem,
+  OperatorBackedServiceKindMap,
 } from '@console/shared';
 import {
   Node,
@@ -20,7 +21,6 @@ import {
   TopologyDataResources,
   TopologyDataModel,
   TopologyDataObject,
-  OperatorBackedServiceKindMap,
 } from '@console/dev-console/src/components/topology/topology-types';
 import {
   allowedResources,

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -24,6 +24,7 @@ import { ResourceOverviewPage } from './resource-overview-page';
 import { OverviewSpecialGroup } from './constants';
 import * as plugins from '../../plugins';
 import { OverviewCRD } from '@console/plugin-sdk';
+import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
 
 const asOverviewGroups = (keyedItems: { [name: string]: OverviewItem[] }): OverviewGroup[] => {
   const compareGroups = (a: OverviewGroup, b: OverviewGroup) => {
@@ -315,7 +316,11 @@ class OverviewMainContent_ extends React.Component<
       updateSelectedGroup,
       updateResources,
     } = this.props;
-    this.transformResourceData = new TransformResourceData(this.props, this.props.utils);
+    this.transformResourceData = new TransformResourceData(
+      this.props,
+      this.props.utils,
+      this.props?.clusterServiceVersions?.data,
+    );
     if (!loaded) {
       return;
     }
@@ -565,6 +570,7 @@ type OverviewMainContentOwnProps = {
   selectedItem: OverviewItem;
   statefulSets?: FirehoseResult;
   title?: string;
+  clusterServiceVersions?: FirehoseResult<ClusterServiceVersionKind[]>;
   utils?: Function[];
 };
 


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-2907

**Analysis / Root cause:**
Sidebar in topology and list show doesn't identify workloads owned by Operator backed service.

**Solution description**
added operator-backed link to sidebar.

**Browser conformance:**
- [x]  Chrome
- [x]  Firefox
- [ ]  Safari
- [ ]  Edge

![Screenshot from 2020-02-07 21-43-29](https://user-images.githubusercontent.com/9278015/74045568-094ad080-49f3-11ea-9250-fbb27ee3c87d.png)
