### PR TITLE
Bug 1798096: Fix issue with prop name clash of applyFilter in CheckBoxes

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
@@ -84,7 +84,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets })
     return (
       <CheckBoxes
         key={i}
-        applyFilter={applyRowFilter}
+        onFilterChange={applyRowFilter}
         items={items}
         itemCount={_.size(releases)}
         numbers={_.countBy(releases, reducer)}

--- a/frontend/public/components/row-filter.jsx
+++ b/frontend/public/components/row-filter.jsx
@@ -102,7 +102,7 @@ class CheckBoxes_ extends React.Component {
     const all = _.map(this.props.items, 'id');
     const recognized = _.intersection(this.state.selected, all);
     if (!_.isEmpty(recognized)) {
-      this.props.applyFilter && this.props.applyFilter(recognized);
+      this.props.onFilterChange?.(recognized);
       this.props.reduxIDs.forEach((id) =>
         this.props.filterList(id, this.props.type, { selected: new Set(recognized), all }),
       );
@@ -164,5 +164,5 @@ class CheckBoxes_ extends React.Component {
   }
 }
 
-/** @type {React.SFC<{items: Array, itemCount: number, numbers: any, reduxIDs: Array, selected?: Array, type: string, applyFilter?: (filter) => void}>} */
+/** @type {React.SFC<{items: Array, itemCount: number, numbers: any, reduxIDs: Array, selected?: Array, type: string, onFilterChange?: (filter: string[]) => void}>} */
 export const CheckBoxes = connect(null, { filterList })(CheckBoxes_);


### PR DESCRIPTION
Fixes - https://bugzilla.redhat.com/show_bug.cgi?id=1798096

This PR - 
- Changes the prop `applyFilter` to `applyCustomFilter` to avoid name clash and fix the bug of wrong filters being set in redux.

cc: @spadgett 