### PR TITLE
Bug 1796521: Notification drawer alert to setup monitoring directs user to config page

### DIFF
--- a/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
+++ b/frontend/packages/patternfly/src/components/notification-drawer/notification-entry.tsx
@@ -36,65 +36,88 @@ const NotificationIcon: React.FC<NotificationIconTypes> = ({ type }) => {
   }
 };
 
+const NotificationAction: React.FC<NotificationActionProps> = ({ onClick, text, path }) => (
+  <div className="pf-c-notification-drawer__header-action">
+    <Link
+      to={path}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick(e);
+      }}
+    >
+      {text}
+    </Link>
+  </div>
+);
+
 const NotificationEntry: React.FC<NotificationEntryProps> = ({
+  actionText,
+  actionPath,
   title,
   description,
   isRead = false,
   timestamp,
-  targetURL,
+  targetPath,
   toggleNotificationDrawer,
   type,
-}) => {
-  const notificationAction = type === NotificationTypes.update && targetURL && (
-    <div className="pf-c-notification-drawer__header-action">
-      <Link to="">Install Update</Link>
+}) => (
+  <li
+    className={classNames(`pf-c-notification-drawer__list-item pf-m-hoverable pf-m-${type}`, {
+      'pf-m-read': isRead,
+    })}
+    tabIndex={0}
+    onClick={
+      targetPath
+        ? () => {
+            history.push(targetPath);
+            toggleNotificationDrawer();
+          }
+        : null
+    }
+  >
+    <div className="pf-c-notification-drawer__list-item-header">
+      <span className="pf-c-notification-drawer__list-item-header-icon">
+        <NotificationIcon type={type} />
+      </span>
+      <h4 className="pf-c-notification-drawer__list-item-header-title">
+        <span className="pf-screen-reader">{`${_.capitalize(type)} notification:`}</span>
+        {title}
+      </h4>
+      {actionText && actionPath && (
+        <NotificationAction
+          text={actionText}
+          path={actionPath}
+          onClick={toggleNotificationDrawer}
+        />
+      )}
     </div>
-  );
-  return (
-    <li
-      className={classNames(`pf-c-notification-drawer__list-item pf-m-hoverable pf-m-${type}`, {
-        'pf-m-read': isRead,
-      })}
-      tabIndex={0}
-      onClick={
-        targetURL
-          ? () => {
-              history.push(targetURL);
-              toggleNotificationDrawer();
-            }
-          : null
-      }
-    >
-      <div className="pf-c-notification-drawer__list-item-header">
-        <span className="pf-c-notification-drawer__list-item-header-icon">
-          <NotificationIcon type={type} />
-        </span>
-        <h4 className="pf-c-notification-drawer__list-item-header-title">
-          <span className="pf-screen-reader">{`${_.capitalize(type)} notification:`}</span>
-          {title}
-        </h4>
-        {notificationAction}
-      </div>
-      <div className="pf-c-notification-drawer__list-item-description">{description}</div>
-      <div className="pf-c-notification-drawer__list-item-timestamp">
-        {timestamp && <Timestamp simple timestamp={timestamp} />}
-      </div>
-    </li>
-  );
-};
+    <div className="pf-c-notification-drawer__list-item-description">{description}</div>
+    <div className="pf-c-notification-drawer__list-item-timestamp">
+      {timestamp && <Timestamp simple timestamp={timestamp} />}
+    </div>
+  </li>
+);
 
 export type NotificationEntryProps = {
-  title: string;
+  actionText?: string;
+  actionPath?: string;
   description: string;
   isRead?: boolean;
-  targetURL?: string;
+  targetPath?: string;
   timestamp?: string;
+  title: string;
   toggleNotificationDrawer?: () => any;
   type: NotificationTypes;
 };
 
 type NotificationIconTypes = {
   type: NotificationTypes;
+};
+
+type NotificationActionProps = {
+  onClick: (event: React.MouseEvent<HTMLElement>) => void;
+  text: string;
+  path: string;
 };
 
 export default NotificationEntry;

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -70,6 +70,14 @@ const AlertEmptyState: React.FC<AlertEmptyProps> = ({ drawerToggle }) => (
   </EmptyState>
 );
 
+const actionAlerts: ActionAlertType[] = [
+  {
+    name: 'AlertmanagerReceiversNotConfigured',
+    text: 'Configure receivers',
+    path: '/monitoring/alertmanagerconfig',
+  },
+];
+
 const getAlertNotificationEntries = (
   isLoaded: boolean,
   alertData: Alert[],
@@ -79,17 +87,24 @@ const getAlertNotificationEntries = (
   isLoaded && !_.isEmpty(alertData)
     ? alertData
         .filter((a) => (isCritical ? criticalCompare(a) : otherAlertCompare(a)))
-        .map((alert, i) => (
-          <NotificationEntry
-            key={`${i}_${alert.activeAt}`}
-            description={getAlertDescription(alert) || getAlertMessage(alert)}
-            timestamp={getAlertTime(alert)}
-            type={NotificationTypes[getAlertSeverity(alert)]}
-            title={getAlertName(alert)}
-            toggleNotificationDrawer={toggleNotificationDrawer}
-            targetURL={alertURL(alert, alert.rule.id)}
-          />
-        ))
+        .map((alert, i) => {
+          const actionAlertMatch = actionAlerts.find(
+            (actionAlert) => actionAlert.name === alert.rule.name,
+          );
+          return (
+            <NotificationEntry
+              key={`${i}_${alert.activeAt}`}
+              description={getAlertDescription(alert) || getAlertMessage(alert)}
+              timestamp={getAlertTime(alert)}
+              type={NotificationTypes[getAlertSeverity(alert)]}
+              title={getAlertName(alert)}
+              toggleNotificationDrawer={toggleNotificationDrawer}
+              targetPath={alertURL(alert, alert.rule.id)}
+              actionText={actionAlertMatch?.text}
+              actionPath={actionAlertMatch?.path}
+            />
+          );
+        })
     : [];
 
 const getUpdateNotificationEntries = (
@@ -105,7 +120,7 @@ const getUpdateNotificationEntries = (
           type={NotificationTypes.update}
           title="Cluster update available"
           toggleNotificationDrawer={toggleNotificationDrawer}
-          targetURL="/settings/cluster"
+          targetPath="/settings/cluster"
         />,
       ]
     : [];
@@ -278,6 +293,12 @@ const notificationStateToProps = ({ UI }: RootState): WithNotificationsProps => 
   notificationsRead: !!UI.getIn(['notifications', 'isRead']),
   alerts: UI.getIn(['monitoring', 'notificationAlerts']) || {},
 });
+
+type ActionAlertType = {
+  name: string;
+  text: string;
+  path: string;
+};
 
 type AlertErrorProps = {
   errorText: string;


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1796521

design: https://openshift.github.io/openshift-origin-design/designs/administrator/4.4/notification-drawer/

<img width="495" alt="Screen Shot 2020-02-07 at 9 28 21 PM" src="https://user-images.githubusercontent.com/35978579/74077779-d1428e00-49f0-11ea-886f-acd8238fbb32.png">

cc: @cshinn , @dtaylor113 