### PR TITLE
Bug 1800794: look for correct OLM cluster monitoring annotation

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -93,7 +93,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
   const suggestedNamespace =
     currentCSVDesc.annotations?.['operatorframework.io/suggested-namespace'];
   const operatorRequestsMonitoring =
-    currentCSVDesc.annotations?.['openshift.io/cluster-monitoring'] === 'true';
+    currentCSVDesc.annotations?.['operatorframework.io/cluster-monitoring'] === 'true';
 
   const globalNS =
     (props.operatorGroup?.data || ([] as OperatorGroupKind[])).find(


### PR DESCRIPTION
We should look for `operatorframework.io/cluster-monitoring`, not `openshift.io/clsuter-monitoring`. (The label added to the new namespace should still be `openshift.io/cluster-monitoring`, however.)

https://github.com/openshift/enhancements/blob/master/enhancements/olm/olm-managed-operator-metrics.md