### PR TITLE
Bug 1800976: Fix selection of PXE boot device

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
@@ -205,7 +205,7 @@ export class VirtualMachine extends KubevirtDetailView {
     }
     if (provisionSource.method === ProvisionConfigName.PXE && template === undefined) {
       // Select the last NIC as the source for booting
-      await wizard.selectBootableNIC(networkResources[networkResources.length - 1].network);
+      await wizard.selectBootableNIC(networkResources[networkResources.length - 1].name);
     }
     await wizard.next();
 


### PR DESCRIPTION
Bootable NIC is now called by the NIC name, rather than by the net-attach-def, this PR changes selection of the bootable NIC  to use the name instead. 