### PR TITLE
Bug 1798871: Fix formik low priority validation issues

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/DropdownField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/DropdownField.tsx
@@ -5,6 +5,7 @@ import { Dropdown } from '@console/internal/components/utils';
 import { FormGroup } from '@patternfly/react-core';
 import { DropdownFieldProps } from './field-types';
 import { getFieldId } from './field-utils';
+import { useFormikValidationFix } from '../../hooks';
 
 const DropdownField: React.FC<DropdownFieldProps> = ({ label, helpText, required, ...props }) => {
   const [field, { touched, error }] = useField(props.name);
@@ -12,6 +13,9 @@ const DropdownField: React.FC<DropdownFieldProps> = ({ label, helpText, required
   const fieldId = getFieldId(props.name, 'dropdown');
   const isValid = !(touched && error);
   const errorMessage = !isValid ? error : '';
+
+  useFormikValidationFix(field.value);
+
   return (
     <FormGroup
       fieldId={fieldId}

--- a/frontend/packages/console-shared/src/components/formik-fields/NSDropdownField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/NSDropdownField.tsx
@@ -4,6 +4,7 @@ import { NsDropdown } from '@console/internal/components/utils';
 import { FormGroup } from '@patternfly/react-core';
 import { DropdownFieldProps } from './field-types';
 import { getFieldId } from './field-utils';
+import { useFormikValidationFix } from '../../hooks';
 
 const NSDropdownField: React.FC<DropdownFieldProps> = ({
   label,
@@ -17,6 +18,9 @@ const NSDropdownField: React.FC<DropdownFieldProps> = ({
   const fieldId = getFieldId(props.name, 'ns-dropdown');
   const isValid = !(touched && error);
   const errorMessage = !isValid ? error : '';
+
+  useFormikValidationFix(field.value);
+
   return (
     <FormGroup
       fieldId={fieldId}

--- a/frontend/packages/console-shared/src/components/formik-fields/NumberSpinnerField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/NumberSpinnerField.tsx
@@ -5,6 +5,7 @@ import { NumberSpinner } from '@console/internal/components/utils';
 import { FormGroup } from '@patternfly/react-core';
 import { FieldProps } from './field-types';
 import { getFieldId } from './field-utils';
+import { useFormikValidationFix } from '../../hooks';
 
 const NumberSpinnerField: React.FC<FieldProps> = ({ label, helpText, required, ...props }) => {
   const [field, { touched, error }] = useField(props.name);
@@ -12,6 +13,9 @@ const NumberSpinnerField: React.FC<FieldProps> = ({ label, helpText, required, .
   const fieldId = getFieldId(props.name, 'number-spinner');
   const isValid = !(touched && error);
   const errorMessage = !isValid ? error : '';
+
+  useFormikValidationFix(field.value);
+
   return (
     <FormGroup
       fieldId={fieldId}

--- a/frontend/packages/console-shared/src/components/formik-fields/ResourceDropdownField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/ResourceDropdownField.tsx
@@ -7,6 +7,7 @@ import { Firehose, FirehoseResource } from '@console/internal/components/utils';
 import ResourceDropdown from '../dropdown/ResourceDropdown';
 import { DropdownFieldProps } from './field-types';
 import { getFieldId } from './field-utils';
+import { useFormikValidationFix } from '../../hooks';
 
 export interface ResourceDropdownFieldProps extends DropdownFieldProps {
   dataSelector: string[] | number[] | symbol[];
@@ -30,6 +31,9 @@ const ResourceDropdownField: React.FC<ResourceDropdownFieldProps> = ({
   const fieldId = getFieldId(props.name, 'ns-dropdown');
   const isValid = !(touched && error);
   const errorMessage = !isValid ? error : '';
+
+  useFormikValidationFix(field.value);
+
   return (
     <FormGroup
       fieldId={fieldId}

--- a/frontend/packages/console-shared/src/components/formik-fields/ResourceLimitField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/ResourceLimitField.tsx
@@ -4,6 +4,7 @@ import { RequestSizeInput } from '@console/internal/components/utils';
 import { FormGroup } from '@patternfly/react-core';
 import { ResourceLimitFieldProps } from './field-types';
 import { getFieldId } from './field-utils';
+import { useFormikValidationFix } from '../../hooks';
 
 const ResourceLimitField: React.FC<ResourceLimitFieldProps> = ({
   label,
@@ -18,6 +19,9 @@ const ResourceLimitField: React.FC<ResourceLimitFieldProps> = ({
   const fieldId = getFieldId(props.name, 'resource-limit');
   const isValid = !(touched && error);
   const errorMessage = !isValid ? error : '';
+
+  useFormikValidationFix(field.value);
+
   return (
     <FormGroup
       fieldId={fieldId}

--- a/frontend/packages/console-shared/src/hooks/deep-compare-memoize.ts
+++ b/frontend/packages/console-shared/src/hooks/deep-compare-memoize.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+
+export const useDeepCompareMemoize = <T = any>(value: T): T => {
+  const ref = React.useRef<T>();
+
+  if (!_.isEqual(value, ref.current)) {
+    ref.current = value;
+  }
+
+  return ref.current;
+};

--- a/frontend/packages/console-shared/src/hooks/formik-validation-fix.ts
+++ b/frontend/packages/console-shared/src/hooks/formik-validation-fix.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { useFormikContext, FormikValues } from 'formik';
+import { useDeepCompareMemoize } from './deep-compare-memoize';
+
+export const useFormikValidationFix = (value: any) => {
+  const { validateForm } = useFormikContext<FormikValues>();
+  const memoizedValue = useDeepCompareMemoize(value);
+
+  React.useEffect(() => {
+    validateForm();
+  }, [memoizedValue, validateForm]);
+};

--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './formik-validation-fix';
+export * from './deep-compare-memoize';

--- a/frontend/packages/console-shared/src/index.ts
+++ b/frontend/packages/console-shared/src/index.ts
@@ -3,3 +3,4 @@ export * from './constants';
 export * from './selectors';
 export * from './types';
 export * from './utils';
+export * from './hooks';

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
@@ -5,8 +5,9 @@ import { Table, TextFilter } from '@console/internal/components/factory';
 import { SortByDirection } from '@patternfly/react-table';
 import { CheckBoxes } from '@console/internal/components/row-filter';
 import { FirehoseResult, getQueryArgument } from '@console/internal/components/utils';
+import { useDeepCompareMemoize } from '@console/shared';
 import { HelmRelease, HelmFilterType } from './helm-types';
-import { helmRowFilters, getFilteredItems, useDeepCompareMemoize } from './helm-utils';
+import { helmRowFilters, getFilteredItems } from './helm-utils';
 import HelmReleaseHeader from './HelmReleaseHeader';
 import HelmReleaseRow from './HelmReleaseRow';
 

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import * as _ from 'lodash';
 import * as fuzzy from 'fuzzysearch';
 import { HelmRelease, HelmReleaseStatus, HelmFilterType } from './helm-types';
 
@@ -61,14 +59,4 @@ export const getFilteredItems = (
     default:
       return items;
   }
-};
-
-export const useDeepCompareMemoize = (value) => {
-  const ref = React.useRef();
-
-  if (!_.isEqual(value, ref.current)) {
-    ref.current = value;
-  }
-
-  return ref.current;
 };

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -4,7 +4,7 @@ import { Alert, TextInputTypes } from '@patternfly/react-core';
 import { getGitService, GitProvider } from '@console/git-service';
 import { LoadingInline } from '@console/internal/components/utils';
 import { CheckCircleIcon } from '@patternfly/react-icons';
-import { InputField, DropdownField } from '@console/shared';
+import { InputField, DropdownField, useFormikValidationFix } from '@console/shared';
 import { GitReadableTypes, GitTypes } from '../import-types';
 import { detectGitType, detectGitRepoName } from '../import-validation-utils';
 import { getSampleRepo, getSampleRef, getSampleContextDir } from '../../../utils/imagestream-utils';
@@ -17,7 +17,7 @@ export interface GitSectionProps {
 }
 
 const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
-  const { values, setFieldValue, setFieldTouched, setFieldError, validateForm } = useFormikContext<
+  const { values, setFieldValue, setFieldTouched, setFieldError } = useFormikContext<
     FormikValues
   >();
   const [, { touched: gitTypeTouched }] = useField('git.type');
@@ -64,13 +64,10 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
       setFieldValue('git.isUrlValidated', false);
       setFieldError('git.url', 'Git repository is not reachable.');
     }
-
-    validateForm();
   }, [
     setFieldError,
     setFieldTouched,
     setFieldValue,
-    validateForm,
     values.application.name,
     values.git,
     values.name,
@@ -95,13 +92,11 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
     setFieldValue('git.ref', ref);
     setFieldValue('git.type', gitType);
     setFieldTouched('git.url', true);
-    validateForm();
   }, [
     sampleRepo,
     setFieldTouched,
     setFieldValue,
     tag,
-    validateForm,
     values.application.name,
     values.image.selected,
     values.name,
@@ -124,6 +119,8 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
     }
     return '';
   };
+
+  useFormikValidationFix(values.git.url);
 
   return (
     <FormSection title="Git">

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineResourceDropdownField.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineResourceDropdownField.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import cx from 'classnames';
 import { useField, useFormikContext, FormikValues } from 'formik';
 import { FormGroup } from '@patternfly/react-core';
-import { DropdownFieldProps, getFieldId } from '@console/shared';
+import { DropdownFieldProps, getFieldId, useFormikValidationFix } from '@console/shared';
 import PipelineResourceDropdown from '../../dropdown/PipelineResourceDropdown';
 import PipelineResourceForm from '../pipeline-resource/PipelineResourceForm';
 
@@ -48,6 +48,8 @@ const PipelineResourceDropdownField: React.FC<PipelineResourceDropdownFieldProps
     },
     [field, props.name],
   );
+
+  useFormikValidationFix(field.value);
 
   return (
     <>


### PR DESCRIPTION
Fixes -
- https://issues.redhat.com/browse/ODC-2965
- https://issues.redhat.com/browse/ODC-2826
- https://issues.redhat.com/browse/ODC-3007
- https://issues.redhat.com/browse/ODC-3009


This PR - 
- Adds a custom hook to trigger formik form validation when a value in formik state changes. This value is specified using value param to the hook.
- Uses `useDeepCompareMemoize` hook to deeply compare values. Also, moves the hook into `console/shared`
- Adds the custom hook call to the components or formik fields that need validation due to use of `setFieldValue`.

Screencast - 
![Peek 2020-02-10 16-20](https://user-images.githubusercontent.com/6041994/74148775-3a621580-4c2c-11ea-9547-0abaefd3db28.gif)
