### PR TITLE
Bug 1801148: reinstate tech preview badge on monitoring pages

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
@@ -62,7 +62,7 @@ export const MonitoringPage: React.FC<MonitoringPageProps> = ({ match }) => {
             />
           </>
         ) : (
-          <ProjectListPage title="Monitoring">
+          <ProjectListPage badge={<TechPreviewBadge />} title="Monitoring">
             Select a project to view monitoring metrics
           </ProjectListPage>
         )}


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-2963

Analysis / Root cause:
https://github.com/openshift/console/pull/4183 removed the `Tech Preview` badge from the projects list view of the Monitoring page.

Solution Description:
The `Tech Preview` badge is added in the projects list view of the Monitoring page

Screenshots / Gifs for design review:
![monitoring](https://user-images.githubusercontent.com/22490998/74145058-f10dc800-4c23-11ea-998f-27db48ff63c8.png)

Browser conformance:
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge