### PR TITLE
Bug 1801278: Restructure the devconsole navigation menu

### DIFF
--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -155,9 +155,22 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
+      section: 'More',
       perspective: 'dev',
       componentProps: {
-        name: 'Helm Releases',
+        name: 'Search',
+        href: '/search',
+        testID: 'more-search-header',
+      },
+    },
+  },
+  {
+    type: 'NavItem/Href',
+    properties: {
+      section: 'More',
+      perspective: 'dev',
+      componentProps: {
+        name: 'Helm',
         href: '/helm-releases',
         testID: 'helm-releases-header',
       },
@@ -169,12 +182,12 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/ResourceCluster',
     properties: {
-      section: 'Advanced',
+      section: 'More',
       perspective: 'dev',
       componentProps: {
         name: 'Project Details',
         resource: 'projects',
-        testID: 'advanced-project-header',
+        testID: 'more-project-header',
       },
     },
     flags: {
@@ -184,24 +197,12 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'NavItem/Href',
     properties: {
-      section: 'Advanced',
+      section: 'More',
       perspective: 'dev',
       componentProps: {
         name: 'Project Access',
         href: '/project-access',
-        testID: 'advanced-project-access-header',
-      },
-    },
-  },
-  {
-    type: 'NavItem/Href',
-    properties: {
-      section: 'Advanced',
-      perspective: 'dev',
-      componentProps: {
-        name: 'Search',
-        href: '/search',
-        testID: 'advanced-search-header',
+        testID: 'more-project-access-header',
       },
     },
   },


### PR DESCRIPTION
Restructure and rename the navigation menu 
1. Renamed `Advanced` section to `More`
2. Moved `Helm Releases` menu item into the  `More` section and renamed it to Helm


![AwesomeScreenshot-2020-2-10-1581344117892](https://user-images.githubusercontent.com/9964343/74157935-2ffd4700-4c3f-11ea-854e-50e7324fbfca.gif)

Fixes: https://issues.redhat.com/browse/ODC-2967

cc: @christianvogt @serenamarie125 