### PR TITLE
Bug 1798858:  Fix bug where installed operators list status is missin…

### DIFF
--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -27,16 +27,20 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
       return <StatusIconAndText {...statusProps} icon={<ClipboardListIcon />} />;
 
     case 'ContainerCreating':
+    case 'UpgradePending':
       return <ProgressStatus {...statusProps} />;
 
     case 'In Progress':
     case 'Installing':
+    case 'InstallReady':
+    case 'Replacing':
     case 'Running':
     case 'Updating':
     case 'Upgrading':
       return <StatusIconAndText {...statusProps} icon={<SyncAltIcon />} />;
 
     case 'Cancelled':
+    case 'Deleting':
     case 'Expired':
     case 'Not Ready':
     case 'Terminating':
@@ -58,6 +62,7 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
     case 'InstallCheckFailed':
     case 'Lost':
     case 'Rejected':
+    case 'UpgradeFailed':
       return <ErrorStatus {...statusProps}>{children}</ErrorStatus>;
 
     case 'Accepted':
@@ -65,6 +70,7 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
     case 'Bound':
     case 'Complete':
     case 'Completed':
+    case 'Copied':
     case 'Created':
     case 'Enabled':
     case 'Succeeded':


### PR DESCRIPTION
…g or incorrect

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1798858

Before:
Status shows `status.reason` in lieu of `status.phase`, thus resulting in the bug.
![74158616-63f94d80-4be8-11ea-9f31-aa5bf6f6b4da copy](https://user-images.githubusercontent.com/895728/74182066-5788eb00-4c10-11ea-925b-7297f1dd3181.gif)

After:
Status now shows `status.phase`, which aligns it with ClusterServiceVersion Overview status **and** fixes bug where `SubscriptionTableRow` `Status` appeared in the `Deployment` column.  As a result of this change, there is no longer an indicator the operator has been copied (i.e., there is no longer a status of `Copied` as that was coming from `status.reason`).  IMO, we should explore an alternate and more obvious way to indicate an operator has been copied without repurposing `Status`.
![kNV9g6pyZt copy](https://user-images.githubusercontent.com/895728/74467023-518c4780-4e66-11ea-87a1-cde55dc7fa41.gif)


