### PR TITLE
Bug 1801028: Improve dashboard single-stat number formatting

### DIFF
--- a/frontend/public/components/monitoring/dashboards/format.tsx
+++ b/frontend/public/components/monitoring/dashboards/format.tsx
@@ -1,0 +1,36 @@
+import * as _ from 'lodash-es';
+import * as React from 'react';
+
+import {
+  humanizeBinaryBytes,
+  humanizeDecimalBytesPerSec,
+  humanizePacketsPerSec,
+} from '../../utils';
+
+export const formatNumber = (s: string, decimals = 2, format = 'short'): React.ReactNode => {
+  const value = Number(s);
+  if (_.isNil(s) || isNaN(value)) {
+    return s || <span className="text-muted">-</span>;
+  }
+
+  switch (format) {
+    case 'percentunit':
+      return Intl.NumberFormat(undefined, {
+        style: 'percent',
+        maximumFractionDigits: decimals,
+        minimumFractionDigits: decimals,
+      }).format(value);
+    case 'bytes':
+      return humanizeBinaryBytes(value).string;
+    case 'Bps':
+      return humanizeDecimalBytesPerSec(value).string;
+    case 'pps':
+      return humanizePacketsPerSec(value).string;
+    case 'short':
+    // fall through
+    default:
+      return Intl.NumberFormat(undefined, {
+        maximumFractionDigits: decimals,
+      }).format(value);
+  }
+};

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -257,15 +257,7 @@ const Card_: React.FC<CardProps> = ({ panel, pollInterval, timespan, variables }
             </div>
           )}
           {panel.type === 'singlestat' && (
-            <SingleStat
-              decimals={panel.decimals}
-              format={panel.format}
-              pollInterval={pollInterval}
-              postfix={panel.postfix}
-              prefix={panel.prefix}
-              query={queries[0]}
-              units={panel.units}
-            />
+            <SingleStat panel={panel} pollInterval={pollInterval} query={queries[0]} />
           )}
           {panel.type === 'table' && panel.transform === 'table' && (
             <Table panel={panel} pollInterval={pollInterval} queries={queries} />

--- a/frontend/public/components/monitoring/dashboards/single-stat.tsx
+++ b/frontend/public/components/monitoring/dashboards/single-stat.tsx
@@ -4,6 +4,8 @@ import { Bullseye } from '@patternfly/react-core';
 
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 
+import { formatNumber } from './format';
+import { Panel } from './types';
 import { PrometheusResponse } from '../../graphs';
 import { getPrometheusURL, PrometheusEndpoint } from '../../graphs/helpers';
 import { LoadingInline, usePoll, useSafeFetch } from '../../utils';
@@ -12,15 +14,17 @@ const Body: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <Bullseye className="monitoring-dashboards__single-stat">{children}</Bullseye>
 );
 
-const SingleStat: React.FC<Props> = ({
-  decimals = 2,
-  format = 'none',
-  pollInterval,
-  postfix = '',
-  prefix = '',
-  query,
-  units = '',
-}) => {
+const SingleStat: React.FC<Props> = ({ panel, pollInterval, query }) => {
+  const {
+    decimals,
+    format,
+    postfix,
+    postfixFontSize,
+    prefix,
+    prefixFontSize,
+    valueFontSize,
+  } = panel;
+
   const [error, setError] = React.useState<string>();
   const [isLoading, setIsLoading] = React.useState(true);
   const [value, setValue] = React.useState<string>();
@@ -50,37 +54,20 @@ const SingleStat: React.FC<Props> = ({
   if (error) {
     return <ErrorAlert message={error} />;
   }
-  if (value === undefined) {
-    return (
-      <Body>
-        <span className="text-muted">-</span>
-      </Body>
-    );
-  }
-
-  const numberValue = Number(value);
-  if (isNaN(numberValue)) {
-    return <ErrorAlert message={`Could not parse value "${value}" as a number`} />;
-  }
 
   return (
     <Body>
-      {prefix}
-      {(format === 'percentunit' ? 100 * numberValue : numberValue).toFixed(decimals)}
-      {format === 'percentunit' ? '%' : units}
-      {postfix}
+      {prefix && <span style={{ fontSize: prefixFontSize }}>{prefix}</span>}
+      <span style={{ fontSize: valueFontSize }}>{formatNumber(value, decimals, format)}</span>
+      {postfix && <span style={{ fontSize: postfixFontSize }}>{postfix}</span>}
     </Body>
   );
 };
 
 type Props = {
-  decimals?: number;
-  format?: string;
+  panel: Panel;
   pollInterval: number;
-  postfix?: string;
-  prefix?: string;
   query: string;
-  units?: string;
 };
 
 export default SingleStat;

--- a/frontend/public/components/monitoring/dashboards/table.tsx
+++ b/frontend/public/components/monitoring/dashboards/table.tsx
@@ -11,44 +11,12 @@ import {
 
 import ErrorAlert from '@console/shared/src/components/alerts/error';
 
+import { formatNumber } from './format';
 import { ColumnStyle, Panel } from './types';
 import { PrometheusResponse } from '../../graphs';
 import { getPrometheusURL, PrometheusEndpoint } from '../../graphs/helpers';
-import {
-  EmptyBox,
-  formatToFractionalDigits,
-  humanizeBinaryBytes,
-  humanizeDecimalBytesPerSec,
-  humanizePacketsPerSec,
-  usePoll,
-  useSafeFetch,
-} from '../../utils';
+import { EmptyBox, usePoll, useSafeFetch } from '../../utils';
 import { TablePagination } from '../metrics';
-
-const formatNumber = (s: string, decimals: number, unit: string): string => {
-  const value = Number(s);
-  if (_.isNil(value) || isNaN(value)) {
-    return s || '-';
-  }
-
-  switch (unit) {
-    case 'short':
-      return formatToFractionalDigits(value, decimals);
-    case 'percentunit':
-      return Intl.NumberFormat(undefined, {
-        style: 'percent',
-        maximumFractionDigits: decimals,
-      }).format(value);
-    case 'bytes':
-      return humanizeBinaryBytes(value).string;
-    case 'Bps':
-      return humanizeDecimalBytesPerSec(value).string;
-    case 'pps':
-      return humanizePacketsPerSec(value).string;
-    default:
-      return `${formatToFractionalDigits(value, decimals)} ${unit}`;
-  }
-};
 
 const paginationOptions = [5, 10, 20, 50, 100].map((n) => ({
   title: n.toString(),

--- a/frontend/public/components/monitoring/dashboards/types.ts
+++ b/frontend/public/components/monitoring/dashboards/types.ts
@@ -21,7 +21,9 @@ export type Panel = {
   };
   panels: Panel[];
   postfix?: string;
+  postfixFontSize?: string;
   prefix?: string;
+  prefixFontSize?: string;
   span: number;
   stack: boolean;
   styles?: ColumnStyle[];
@@ -33,4 +35,5 @@ export type Panel = {
   transform?: string;
   type: string;
   units?: string;
+  valueFontSize?: string;
 };


### PR DESCRIPTION
* Share `formatValue` utility between single state and table cards
* Honor font-size from single stat panel definition

https://bugzilla.redhat.com/show_bug.cgi?id=1801028

/assign @kyoto 