### PR TITLE
Bug 1801419: Show an error dialog when creation of a connection fails

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -808,7 +808,7 @@ export const createTopologyResourceConnection = (
   serviceBindingFlag: boolean,
 ): Promise<K8sResourceKind[] | K8sResourceKind> => {
   if (!source || !target || source === target) {
-    return Promise.reject();
+    return Promise.reject(new Error('Can not create a connection from a node to itself.'));
   }
 
   const sourceObj = getTopologyResourceObject(source);
@@ -825,7 +825,7 @@ export const createTopologyResourceConnection = (
               .then(resolve)
               .catch(reject);
           })
-          .catch(resolve);
+          .catch(reject);
       });
     }
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2962

**Analysis / Root cause**: 
On a failure to create the connection, the results were ignored

**Solution Description**: 
Catch the rejection for the creation of the connection and display an error dialog containing the returned error message. Added checks to safe guard against attempting to create a connection from a node to itself.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

/kind bug