### PR TITLE
Bug 1797482 - Operator Hub show all Operators not filtered ones when all projects are selected in project dropdown

### DIFF
--- a/frontend/public/components/utils/tile-view-page.jsx
+++ b/frontend/public/components/utils/tile-view-page.jsx
@@ -780,8 +780,10 @@ export class TileViewPage extends React.Component {
   renderItems(items, renderTile) {
     return (
       <Gallery gutter="sm" className="catalog-tile-view-pf catalog-tile-view-pf-no-categories">
-        {_.map(items, (item) => (
-          <GalleryItem key={item.uid ? `gallery-${item.uid}` : `gallery-${item.obj.metadata.uid}`}>
+        {_.map(items, (item, index) => (
+          <GalleryItem
+            key={item.uid ? `gallery-${item.uid}-${index}` : `gallery-${item.obj.metadata.uid}`}
+          >
             {renderTile(item)}
           </GalleryItem>
         ))}


### PR DESCRIPTION
/assign @TheRealJon
/cc @benjaminapetersen @spadgett 

@benjaminapetersen  @TheRealJon:- Bug 1797482 -The issue here is that the GalleryItem component encountered duplicate operators uid and throws error. To resolve I appended index to the uid. 
A better solution would be for the operators uid to be unique from the backend. 

![Screen Shot 2020-02-10 at 4 14 13 PM](https://user-images.githubusercontent.com/15249132/74192074-ccfdb700-4c22-11ea-8255-bd6cdb12b49b.png)
![Screen Shot 2020-02-10 at 4 07 47 PM](https://user-images.githubusercontent.com/15249132/74192084-d129d480-4c22-11ea-939c-1bf4ea909754.png)

