### PR TITLE
Bug 1801447: Fix for invalid edges, do not allow connection to knative revisions

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/componentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/componentFactory.ts
@@ -187,18 +187,16 @@ class ComponentFactory {
             ),
           );
         case TYPE_KNATIVE_REVISION:
-          return withDndDrop<any>(graphWorkloadDropTargetSpec)(
-            withDragNode(nodeDragSourceSpec(type, false))(
-              withSelection(
-                false,
-                true,
-              )(
-                withContextMenu(
-                  nodeContextMenu,
-                  document.getElementById('modal-container'),
-                  'odc-topology-context-menu',
-                )(RevisionNode),
-              ),
+          return withDragNode(nodeDragSourceSpec(type, false))(
+            withSelection(
+              false,
+              true,
+            )(
+              withContextMenu(
+                nodeContextMenu,
+                document.getElementById('modal-container'),
+                'odc-topology-context-menu',
+              )(RevisionNode),
             ),
           );
         case TYPE_REVISION_TRAFFIC:

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -742,21 +742,26 @@ export const topologyModelFromDataModel = (
     };
   });
 
-  // create links from data
-  const edges = dataModel.graph.edges.map(
-    (d): EdgeModel => ({
-      data: d,
-      source: d.source,
-      target: d.target,
-      id: `${d.source}_${d.target}`,
-      type: d.type,
-    }),
-  );
+  // create links from data, only include those which have a valid source and target
+  const allNodes = [...nodes, ...groupNodes];
+  const edges = dataModel.graph.edges
+    .filter((d) => {
+      return allNodes.find((n) => n.id === d.source) && allNodes.find((n) => n.id === d.target);
+    })
+    .map(
+      (d): EdgeModel => ({
+        data: d,
+        source: d.source,
+        target: d.target,
+        id: `${d.source}_${d.target}`,
+        type: d.type,
+      }),
+    );
 
   // create topology model
   const model: Model = {
-    nodes: [...nodes, ...groupNodes],
-    edges: createAggregateEdges(TYPE_AGGREGATE_EDGE, edges, [...nodes, ...groupNodes]),
+    nodes: allNodes,
+    edges: createAggregateEdges(TYPE_AGGREGATE_EDGE, edges, allNodes),
   };
 
   return model;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3014

**Analysis / Root cause**: 
Connections from non-knative workloads to knative objects resulted in edges with invalid targets.
We should no be allowing visual connectors to knative revisions.

**Solution Description**: 
Check the edges for valid source and target. Remove any edges that have and invalid source or target. Do not allow creation of connectors to knative revisions.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 