### PR TITLE
Bug 1797891: fix(dev-catalog) - Remove capability level filters

### DIFF
--- a/frontend/__tests__/components/catalog.spec.tsx
+++ b/frontend/__tests__/components/catalog.spec.tsx
@@ -43,7 +43,7 @@ describe(CatalogTileViewPage.displayName, () => {
   it('renders category filter controls', () => {
     const filterItems = wrapper.find<any>(FilterSidePanelCategoryItem);
     expect(filterItems.exists()).toBe(true);
-    expect(filterItems.length).toEqual(10); // Filter by Types
+    expect(filterItems.length).toEqual(5); // Filter by Types
     expect(filterItems.at(0).props().count).toBe(0); // total count for Operator Backed
     expect(filterItems.at(0).props().checked).toBe(true); // Check operator backed filter is true by default
     expect(filterItems.at(1).props().count).toBe(0); // total count for Helm Charts
@@ -54,16 +54,6 @@ describe(CatalogTileViewPage.displayName, () => {
     expect(filterItems.at(3).props().checked).toBe(false); // filter imagestreams should be false by default
     expect(filterItems.at(4).props().count).toBe(11); // total count for clusterServiceClasses
     expect(filterItems.at(4).props().checked).toBe(false); // filter clusterServiceClasses should be false by default
-    expect(filterItems.at(5).props().count).toBe(0); // total count for Basic Install
-    expect(filterItems.at(5).props().checked).toBe(false); // Check Basic Install filter is false by default
-    expect(filterItems.at(6).props().count).toBe(0); // total count for Seamless Upgrades
-    expect(filterItems.at(6).props().checked).toBe(false); // Check Seamless Upgrades  filter is false by default
-    expect(filterItems.at(7).props().count).toBe(0); // total count for Full Lifecycle
-    expect(filterItems.at(7).props().checked).toBe(true); // Check filter Full Lifecycle should be true by default
-    expect(filterItems.at(8).props().count).toBe(0); // total count for Deep Insights
-    expect(filterItems.at(8).props().checked).toBe(true); // filter Deep Insights should be true by default
-    expect(filterItems.at(9).props().count).toBe(0); // total count for Auto Pilot
-    expect(filterItems.at(9).props().checked).toBe(true); // filter Auto Pilot should be true by default
   });
 
   it('renders tiles correctly', () => {

--- a/frontend/public/components/catalog/catalog-items.tsx
+++ b/frontend/public/components/catalog/catalog-items.tsx
@@ -190,34 +190,6 @@ const getAvailableFilters = (initialFilters): PageFilters => {
     },
   };
 
-  filters.capabilityLevel = {
-    BasicInstall: {
-      value: 'basicinstall',
-      label: 'Basic Install',
-      active: false,
-    },
-    SeamlessUpgrades: {
-      value: 'seamlessupgrades',
-      label: 'Seamless Upgrades',
-      active: false,
-    },
-    FullLifecycle: {
-      value: 'fulllifecycle',
-      label: 'Full Lifecycle',
-      active: true,
-    },
-    DeepInsights: {
-      value: 'deepinsights',
-      label: 'Deep Insights',
-      active: true,
-    },
-    AutoPilot: {
-      value: 'autopilot',
-      label: 'Auto Pilot',
-      active: true,
-    },
-  };
-
   return filters;
 };
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ODC-2937
https://bugzilla.redhat.com/show_bug.cgi?id=1797891
This takes care of the first subtask https://issues.redhat.com/browse/ODC-3048

![Screenshot from 2020-02-11 16-39-43](https://user-images.githubusercontent.com/24852534/74235988-3995b600-4cf6-11ea-8764-45490e78ee25.png)
