### PR TITLE
Bug 1786271: update the number of pods in daemon set with correct status prop

### DIFF
--- a/frontend/packages/console-shared/src/utils/ResourceStatus.tsx
+++ b/frontend/packages/console-shared/src/utils/ResourceStatus.tsx
@@ -4,12 +4,22 @@ import { resourceObjPath } from '@console/internal/components/utils';
 import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
 import { PodStatus } from '@console/internal/components/pod';
 import { PodControllerOverviewItem } from '../types';
+import { DaemonSetModel } from '@console/internal/models';
 
 export const resourceStatus = (
   obj: K8sResourceKind,
   current?: PodControllerOverviewItem,
   isRollingOut?: boolean,
 ) => {
+  if (obj.kind === DaemonSetModel.kind) {
+    return (
+      <OverviewItemReadiness
+        desired={obj?.status?.desiredNumberScheduled}
+        ready={obj?.status?.currentNumberScheduled}
+        resource={obj}
+      />
+    );
+  }
   return isRollingOut ? (
     <span className="text-muted">Rollout in progress...</span>
   ) : (


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-2679

**Analysis / Root cause:**
Create daemon set in project, and all pods for daemon set are running, check daemon set under project "Workloads" tab, it shows 0/0 pods for daemon set.

**Solution description**
Shows correct number of pods on the workload page

**Browser conformance:**
- [x]  Chrome
- [x]  Firefox
- [ ]  Safari
- [ ]  Edge

![Screenshot from 2020-02-11 20-13-02](https://user-images.githubusercontent.com/9278015/74246739-03aefc80-4d0b-11ea-9ae9-a3337cf76839.png)
