### PR TITLE
Bug 1801752: Fix knative sidebar to show podlist in  topology sidebar

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
@@ -287,7 +287,7 @@ export const revisionObj: RevisionKind = {
     ],
   },
 };
-const sampleKnativeRevisions: FirehoseResult = {
+export const sampleKnativeRevisions: FirehoseResult = {
   loaded: true,
   loadError: '',
   data: [revisionObj],

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
@@ -1,21 +1,43 @@
 import * as React from 'react';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import * as _ from 'lodash';
+import { K8sResourceKind, podPhase, PodKind } from '@console/internal/module/k8s';
+import { PodModel } from '@console/internal/models';
+import { AllPodStatus } from '@console/shared';
+import { PodsOverview } from '@console/internal/components/overview/pods-overview';
 import RevisionsOverviewList from './RevisionsOverviewList';
 import KSRoutesOverviewList from './RoutesOverviewList';
 
-export type KnativeServiceResourceProps = {
+const REVISIONS_AUTOSCALED = 'All Revisions are autoscaled to 0';
+
+type KnativeServiceResourceProps = {
   obj: K8sResourceKind;
   revisions: K8sResourceKind[];
   ksroutes: K8sResourceKind[];
+  pods?: PodKind[];
 };
 
 const KnativeServiceResources: React.FC<KnativeServiceResourceProps> = ({
   revisions,
   ksroutes,
   obj,
+  pods,
 }) => {
+  const {
+    kind: resKind,
+    metadata: { name, namespace },
+  } = obj;
+  const activePods = _.filter(pods, (pod) => podPhase(pod) !== AllPodStatus.AutoScaledTo0);
+  const linkUrl = `/search/ns/${namespace}?kind=${PodModel.kind}&q=${encodeURIComponent(
+    `serving.knative.dev/${resKind.toLowerCase()}=${name}`,
+  )}`;
   return (
     <>
+      <PodsOverview
+        pods={activePods}
+        obj={obj}
+        emptyText={REVISIONS_AUTOSCALED}
+        allPodsLink={linkUrl}
+      />
       <RevisionsOverviewList revisions={revisions} service={obj} />
       <KSRoutesOverviewList ksroutes={ksroutes} resource={obj} />
     </>

--- a/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
@@ -41,7 +41,9 @@ const getSidebarResources = ({
         />
       );
     case ServiceModel.kind:
-      return <KnativeServiceResources ksroutes={ksroutes} obj={obj} revisions={revisions} />;
+      return (
+        <KnativeServiceResources ksroutes={ksroutes} obj={obj} revisions={revisions} pods={pods} />
+      );
     case EventSourceCronJobModel.kind:
     case EventSourceContainerModel.kind:
     case EventSourceApiServerModel.kind:

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { PodsOverview } from '@console/internal/components/overview/pods-overview';
+import {
+  sampleKnativePods,
+  sampleKnativeRoutes,
+  sampleKnativeRevisions,
+  knativeServiceObj,
+} from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import KnativeServiceResources from '../KnativeServiceResources';
+import KSRoutesOverviewList from '../RoutesOverviewList';
+import RevisionsOverviewList from '../RevisionsOverviewList';
+
+describe('KnativeServiceResources', () => {
+  it('should render KnativeServiceResources', () => {
+    const wrapper = shallow(
+      <KnativeServiceResources
+        revisions={sampleKnativeRevisions.data}
+        ksroutes={sampleKnativeRoutes.data}
+        obj={knativeServiceObj}
+        pods={sampleKnativePods.data}
+      />,
+    );
+    expect(wrapper.find(PodsOverview)).toHaveLength(1);
+    expect(wrapper.find(KSRoutesOverviewList)).toHaveLength(1);
+    expect(wrapper.find(RevisionsOverviewList)).toHaveLength(1);
+  });
+});

--- a/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-resources.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
 import { KNATIVE_SERVING_LABEL } from '../const';
 
 export type KnativeItem = {
@@ -12,6 +12,7 @@ export type KnativeItem = {
   eventSourceApiserver?: K8sResourceKind[];
   eventSourceCamel?: K8sResourceKind[];
   eventSourceKafka?: K8sResourceKind[];
+  pods?: PodKind[];
 };
 
 const isKnativeDeployment = (dc: K8sResourceKind) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2538

**Analysis / Root cause**: 
There isn't any way to navigate to the pods resource from selecting the knative service in topology. 

**Solution Description**: 
Knative sservice sidebar has list of pods along with link to view logs

**Screen shots / Gifs for design review**: 
![knsvc-sidebar](https://user-images.githubusercontent.com/5129024/74251983-fc8bec80-4d12-11ea-99e4-d4b58cb52503.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 