### PR TITLE
Bug 1801762: Don't re-run discovery on modified APIService

### DIFF
--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -81,7 +81,7 @@ export type DiscoveryResources = {
   safeResources: string[];
 };
 
-const getResources_ = () =>
+export const getResources = () =>
   coFetchJSON('api/kubernetes/apis').then((res) => {
     const preferredVersions = res.groups.map((group) => group.preferredVersion);
     const all: Promise<APIResourceList>[] = _.flatten(
@@ -151,11 +151,6 @@ const getResources_ = () =>
       } as DiscoveryResources;
     });
   });
-
-// Never attemp to re-run API discovery more than once every 30s. This will
-// prevent the console from thrashing when one of the API services is
-// misbehaving, which can cause frequent WebSocket updates.
-export const getResources = _.throttle(getResources_, 30 * 1000);
 
 export type APIResourceList = {
   kind: 'APIResourceList';


### PR DESCRIPTION
Only re-run discovery when an APIService is added or removed. This prevents the console from thrashing when an APIService is unhealthy.

https://bugzilla.redhat.com/show_bug.cgi?id=1801762

/assign @andrewballantyne @benjaminapetersen 