### PR TITLE
Bug 1801741: Update tooltip to show all the status on hovering a pod donut chart

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodStatus.scss
+++ b/frontend/packages/console-shared/src/components/pod/PodStatus.scss
@@ -1,13 +1,14 @@
 .odc-pod-status-tooltip {
-  align-items: center;
-  display: flex;
-
+  &__content {
+    align-items: center;
+    display: flex;
+  }
   &__status-box {
     width: var(--pf-global--icon--FontSize--sm);
     height: var(--pf-global--icon--FontSize--sm);
     margin-right: var(--pf-global--spacer--sm);
   }
   &__status-count {
-    margin-left: var(--pf-global--spacer--sm);
+    margin-right: var(--pf-global--spacer--xs);
   }
 }

--- a/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodStatus.tsx
@@ -103,23 +103,10 @@ class PodStatus extends React.Component<PodStatusProps, PodStatusState> {
       titleComponent,
       subTitleComponent,
     } = this.props;
-    const { vData, updateOnEnd, tipIndex } = this.state;
-
-    const tooltipEvent: any = showTooltip
-      ? [
-          {
-            eventHandlers: {
-              onMouseOver: (e, hoverSlice) => {
-                this.setState({ tipIndex: hoverSlice.index });
-              },
-            },
-          },
-        ]
-      : undefined;
+    const { vData, updateOnEnd } = this.state;
 
     const chartDonut = (
       <ChartDonut
-        events={tooltipEvent}
         animate={{
           duration: ANIMATION_DURATION,
           onEnd: updateOnEnd ? this.doUpdate : undefined,
@@ -153,20 +140,22 @@ class PodStatus extends React.Component<PodStatusProps, PodStatusState> {
     if (showTooltip) {
       const tipContent = (
         <div className="odc-pod-status-tooltip">
-          {vData[tipIndex] && (
-            <>
-              <span
-                className="odc-pod-status-tooltip__status-box"
-                style={{ background: podColor[vData[tipIndex].x] }}
-              />
-              {vData[tipIndex].x}
-              {podStatusIsNumeric(vData[tipIndex].x) && (
-                <span key={3} className="odc-pod-status-tooltip__status-count">
-                  {Math.round(vData[tipIndex].y)}
-                </span>
-              )}
-            </>
-          )}
+          {vData.map((data) => {
+            return data.y > 0 ? (
+              <div key={data.x} className="odc-pod-status-tooltip__content">
+                <span
+                  className="odc-pod-status-tooltip__status-box"
+                  style={{ background: podColor[data.x] }}
+                />
+                {podStatusIsNumeric(data.x) && (
+                  <span key={3} className="odc-pod-status-tooltip__status-count">
+                    {`${Math.round(data.y)}`}
+                  </span>
+                )}
+                {data.x}
+              </div>
+            ) : null;
+          })}
         </div>
       );
       return <Tooltip content={tipContent}>{chartDonut}</Tooltip>;


### PR DESCRIPTION

The pod donut ring should have a single tooltip rather than one for each arc

Problem:
On hovering the pod donut ring, it would show only the status of hovered slice in the tooltip.

Solution:
Instead of showing the status of hovered slice, show all the status together in the tooltip. This solution  works in topolgy, sidepanel and detail page.

![AwesomeScreenshot-2020-2-11-1581432318611](https://user-images.githubusercontent.com/9964343/74256579-95be0180-4d19-11ea-959d-f3a5e6a13633.gif)




Fixes: https://issues.redhat.com/browse/ODC-2969

cc: @serenamarie125 