### PR TITLE
Bug 1801858: Separate validation schemas for parameters and resources tab of pipelines details page

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -18,6 +18,10 @@ import {
   PipelineRuns,
 } from './detail-page-tabs';
 import PipelineForm from './pipeline-form/PipelineForm';
+import {
+  parametersValidationSchema,
+  resourcesValidationSchema,
+} from './pipeline-form/pipelineForm-validation-utils';
 
 interface PipelineDetailsPageStates {
   menuActions: Function[];
@@ -80,6 +84,7 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
               <PipelineForm
                 PipelineFormComponent={PipelineParametersForm}
                 formName="parameters"
+                validationSchema={parametersValidationSchema}
                 obj={props.obj}
                 {...props}
               />
@@ -92,6 +97,7 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
               <PipelineForm
                 PipelineFormComponent={PipelineResourcesForm}
                 formName="resources"
+                validationSchema={resourcesValidationSchema}
                 obj={props.obj}
                 {...props}
               />

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineForm.tsx
@@ -3,15 +3,20 @@ import * as _ from 'lodash';
 import { Formik } from 'formik';
 import { k8sUpdate, K8sResourceKind } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../../models';
-import { validationSchema } from './pipelineForm-validation-utils';
 
 export interface PipelineFormProps {
   PipelineFormComponent: React.ComponentType<any>;
   formName: string;
+  validationSchema: any;
   obj: K8sResourceKind;
 }
 
-const PipelineForm: React.FC<PipelineFormProps> = ({ PipelineFormComponent, formName, obj }) => {
+const PipelineForm: React.FC<PipelineFormProps> = ({
+  PipelineFormComponent,
+  formName,
+  validationSchema,
+  obj,
+}) => {
   const initialValues = {
     parameters: _.get(obj.spec, 'params', []),
     resources: _.get(obj.spec, 'resources', []),

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/__tests__/pipeline-form-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/__tests__/pipeline-form-validation-utils.spec.ts
@@ -1,0 +1,36 @@
+import { cloneDeep } from 'lodash';
+import {
+  parametersValidationSchema,
+  resourcesValidationSchema,
+} from '../pipelineForm-validation-utils';
+
+const mockParametersData = {
+  parameters: [
+    {
+      name: 'mock-param',
+      description: 'it is mock param',
+      default: 'mockery',
+    },
+  ],
+};
+
+const mockResourcesData = {
+  resources: [
+    {
+      name: 'mock-resource',
+      type: 'Git',
+    },
+  ],
+};
+
+describe('pipeline form validation utils', () => {
+  it('should validate parameters validation schema', async () => {
+    const mockData = cloneDeep(mockParametersData);
+    await parametersValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(true));
+  });
+
+  it('should validate resources form validation schema', async () => {
+    const mockData = cloneDeep(mockResourcesData);
+    await resourcesValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(true));
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/pipelineForm-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/pipelineForm-validation-utils.ts
@@ -1,12 +1,15 @@
 import * as yup from 'yup';
 
-export const validationSchema = yup.object().shape({
+export const resourcesValidationSchema = yup.object().shape({
   resources: yup.array().of(
     yup.object().shape({
       name: yup.string().required('Required'),
       type: yup.string().required('Required'),
     }),
   ),
+});
+
+export const parametersValidationSchema = yup.object().shape({
   parameters: yup.array().of(
     yup.object().shape({
       name: yup.string().required('Required'),


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3010

This PR - 
- Separates the validation schema for to tabs in pipeline details page. Earlier it was using same validation schema for both parameters and resources tab which resulted in save button always being disabled.