### PR TITLE
Bug 1800748: Re-enable monitoring tests in CI

### DIFF
--- a/frontend/integration-tests/tests/alertmanager.scenario.ts
+++ b/frontend/integration-tests/tests/alertmanager.scenario.ts
@@ -28,7 +28,7 @@ const getGlobalsAndReceiverConfig = (configName: string, yamlStr: string) => {
   };
 };
 
-xdescribe('Alertmanager: PagerDuty Receiver Form', () => {
+describe('Alertmanager: PagerDuty Receiver Form', () => {
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -125,7 +125,7 @@ xdescribe('Alertmanager: PagerDuty Receiver Form', () => {
   });
 });
 
-xdescribe('Alertmanager: Email Receiver Form', () => {
+describe('Alertmanager: Email Receiver Form', () => {
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -235,7 +235,7 @@ xdescribe('Alertmanager: Email Receiver Form', () => {
   });
 });
 
-xdescribe('Alertmanager: Slack Receiver Form', () => {
+describe('Alertmanager: Slack Receiver Form', () => {
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -304,7 +304,7 @@ xdescribe('Alertmanager: Slack Receiver Form', () => {
   });
 });
 
-xdescribe('Alertmanager: Webhook Receiver Form', () => {
+describe('Alertmanager: Webhook Receiver Form', () => {
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,

--- a/frontend/integration-tests/tests/alertmanager.scenario.ts
+++ b/frontend/integration-tests/tests/alertmanager.scenario.ts
@@ -15,6 +15,7 @@ import * as horizontalnavView from '../views/horizontal-nav.view';
 import { execSync } from 'child_process';
 
 const replaceInput = async (fieldName: string, value: string) => {
+  await browser.wait(until.elementToBeClickable(firstElementByTestID(fieldName)));
   await firstElementByTestID(fieldName).clear();
   await firstElementByTestID(fieldName).sendKeys(value);
 };

--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -20,7 +20,7 @@ const testDetailsPage = (subTitle, alertName, expectLabel = true) => {
   }
 };
 
-xdescribe('Monitoring: Alerts', () => {
+describe('Monitoring: Alerts', () => {
   afterEach(() => {
     checkLogs();
     checkErrors();
@@ -106,7 +106,7 @@ xdescribe('Monitoring: Alerts', () => {
   });
 });
 
-xdescribe('Monitoring: Silences', () => {
+describe('Monitoring: Silences', () => {
   afterEach(() => {
     checkLogs();
     checkErrors();
@@ -186,7 +186,7 @@ xdescribe('Monitoring: Silences', () => {
   });
 });
 
-xdescribe('Alertmanager: YAML', () => {
+describe('Alertmanager: YAML', () => {
   afterEach(() => {
     checkLogs();
     checkErrors();
@@ -214,7 +214,7 @@ xdescribe('Alertmanager: YAML', () => {
   });
 });
 
-xdescribe('Alertmanager: Configuration', () => {
+describe('Alertmanager: Configuration', () => {
   afterAll(() => {
     execSync(
       `kubectl patch secret 'alertmanager-main' -n 'openshift-monitoring' --type='json' -p='[{ op: 'replace', path: '/data/alertmanager.yaml', value: ${monitoringView.defaultAlertmanagerYaml}}]'`,
@@ -291,7 +291,18 @@ xdescribe('Alertmanager: Configuration', () => {
     expect(monitoringView.saveButton.isEnabled()).toBe(true); // subform valid, save should be enabled at this point
 
     // labels
+    expect(firstElementByTestID('invalid-label-name-error').isPresent()).toBe(false);
+    await firstElementByTestID('label-name-0').sendKeys('9abcgo'); // invalid, cannot start with digit
+    expect(firstElementByTestID('invalid-label-name-error').isPresent()).toBe(true);
+    await firstElementByTestID('label-name-0').clear();
+    await firstElementByTestID('label-name-0').sendKeys('_abcd'); // valid, can start with and contain '_'
+    expect(firstElementByTestID('invalid-label-name-error').isPresent()).toBe(false);
+    await firstElementByTestID('label-name-0').clear();
+    await firstElementByTestID('label-name-0').sendKeys('abcd@#$R@T%'); // invalid chars
+    expect(firstElementByTestID('invalid-label-name-error').isPresent()).toBe(true);
+    await firstElementByTestID('label-name-0').clear();
     await firstElementByTestID('label-name-0').sendKeys('severity');
+    expect(firstElementByTestID('invalid-label-name-error').isPresent()).toBe(false);
     await firstElementByTestID('label-value-0').sendKeys('warning');
 
     await monitoringView.saveButton.click();
@@ -333,7 +344,7 @@ xdescribe('Alertmanager: Configuration', () => {
   });
 
   it('deletes a receiver correctly', async () => {
-    await horizontalnavView.clickHorizontalTab('Overview');
+    await horizontalnavView.clickHorizontalTab('Details');
     await crudView.isLoaded();
     expect(crudView.resourceRows.count()).toBe(2);
 

--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -1,6 +1,6 @@
 import { browser, ExpectedConditions as until } from 'protractor';
 
-import { checkLogs, checkErrors, firstElementByTestID } from '../protractor.conf';
+import { checkLogs, checkErrors, firstElementByTestID, appHost } from '../protractor.conf';
 import { dropdownMenuForTestID } from '../views/form.view';
 import * as crudView from '../views/crud.view';
 import * as yamlView from '../views/yaml.view';
@@ -227,13 +227,7 @@ describe('Alertmanager: Configuration', () => {
   });
 
   it('displays the Alermanager Configuration Details page', async () => {
-    await sidenavView.clickNavLink(['Administration', 'Cluster Settings']);
-    await crudView.isLoaded();
-    await horizontalnavView.clickHorizontalTab('Global Configuration');
-    await crudView.isLoaded();
-    await monitoringView.wait(until.elementToBeClickable(firstElementByTestID('alertmanager')));
-    expect(firstElementByTestID('alertmanager').getText()).toContain('Alertmanager');
-    await firstElementByTestID('alertmanager').click();
+    await browser.get(`${appHost}/monitoring/alertmanagerconfig`);
     await crudView.isLoaded();
     expect(monitoringView.alertRoutingHeader.getText()).toContain('Alert Routing');
   });

--- a/frontend/public/components/monitoring/receiver-forms/routing-labels-editor.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/routing-labels-editor.tsx
@@ -60,7 +60,7 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
   };
 
   const InvalidLabelName = () => (
-    <span data-test-id="invalidLabelNameError">
+    <span data-test-id="invalid-label-name-error">
       Invalid name
       <Tooltip
         content={


### PR DESCRIPTION
Re-enabled Monitoring and Alertmanager integration tests

### **Monitoring**
* Also added Routing Label name validation tests

![image](https://user-images.githubusercontent.com/12733153/74269821-21af3980-4cd8-11ea-9420-44ae0d7b994b.png)

### **Alertmanager**
![image](https://user-images.githubusercontent.com/12733153/74269886-40153500-4cd8-11ea-8782-e95937b5a85f.png)

