### PR TITLE
Bug 1776062: Fix inconsistent Create action naming

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -160,8 +160,8 @@ const VirtualMachineTemplates: React.FC<React.ComponentProps<typeof Table> &
 };
 const getCreateProps = ({ namespace }: { namespace: string }) => {
   const items: any = {
-    wizard: 'Create with Wizard',
-    yaml: 'Create from YAML',
+    wizard: 'New with Wizard',
+    yaml: 'New from YAML',
   };
 
   return {


### PR DESCRIPTION
For VirtualMachine vs. VirtualMachineTemplate.

Aligned to recent naming used for the `Virtual Machines`.

