### PR TITLE
Bug 1802230: Fix missing services in VM details page

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/selectors/service/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/service/selectors.ts
@@ -13,7 +13,7 @@ const getServiceSelectors = (service: ServiceKind) =>
   service && service.spec && service.spec.selector ? service.spec.selector : {};
 
 export const getServicesForVmi = (services: ServiceKind[], vmi: VMIKind): ServiceKind[] => {
-  const vmLabels = getLabels(vmi);
+  const vmLabels = getLabels(vmi, {});
   return services.filter((service) => {
     const selectors = getServiceSelectors(service);
     const selectorKeys = Object.keys(selectors);

--- a/frontend/packages/kubevirt-plugin/src/selectors/service/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/service/selectors.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { ServiceKind } from '@console/knative-plugin/src/types';
 import { VMIKind } from '../../types';
-import { getVmiTemplateLabels } from '../vmi/basic';
+import { getLabels } from '@console/shared';
 
 export const getServicePort = (service: K8sResourceKind, targetPort: number) =>
   _.get(service, ['spec', 'ports'], []).find(
@@ -13,7 +13,7 @@ const getServiceSelectors = (service: ServiceKind) =>
   service && service.spec && service.spec.selector ? service.spec.selector : {};
 
 export const getServicesForVmi = (services: ServiceKind[], vmi: VMIKind): ServiceKind[] => {
-  const vmLabels = getVmiTemplateLabels(vmi);
+  const vmLabels = getLabels(vmi);
   return services.filter((service) => {
     const selectors = getServiceSelectors(service);
     const selectorKeys = Object.keys(selectors);

--- a/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vmi/basic.ts
@@ -28,9 +28,6 @@ export const getVMIConditionsByType = (
   return (conditions || []).filter((cond) => cond.type === condType);
 };
 
-export const getVmiTemplateLabels = (vmi: VMIKind): { [key: string]: string } =>
-  (_.get(vmi, 'vmi.spec.template.metadata') && vmi.spec.template.metadata.labels) || {};
-
 export const isVMIRunning = (vmi: VMIKind) => vmi && vmi.status && vmi.status.phase === 'Running';
 
 export const getVMIAvailableStatusInterfaces = (vmi: VMIKind) =>


### PR DESCRIPTION
Fix missing services in VM details page

vmi services selector is broken, this PR fixes the services selector.

Screenshot:
![OKD](https://user-images.githubusercontent.com/2181522/74360583-01fa3d00-4dce-11ea-944c-f9defbc5a72a.png)
