### PR TITLE
Bug 1799490: Correct monitoring dashboard panel issues

### DIFF
--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -60,7 +60,7 @@ export const PrometheusGraphLink = connect(mapStateToProps)(PrometheusGraphLink_
 
 export const PrometheusGraph: React.FC<PrometheusGraphProps> = React.forwardRef(
   ({ children, className, title }, ref: React.RefObject<HTMLDivElement>) => (
-    <div ref={ref} className={classNames('graph-wrapper', className)}>
+    <div ref={ref} className={classNames('graph-wrapper graph-wrapper__horizontal-bar', className)}>
       {title && <h5 className="graph-title">{title}</h5>}
       {children}
     </div>

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -26,14 +26,14 @@
   margin: 0 -5px 20px -5px;
 
   .co-dashboard-card__body--dashboard-graph {
-    padding: 0;
+    padding: 10px;
   }
 
   .query-browser__wrapper {
     border: 0;
     margin: 0;
     overflow: hidden;
-    padding-top: 0;
+    padding: 0;
   }
 }
 
@@ -44,7 +44,7 @@
 
 .monitoring-dashboards__single-stat {
   font-size: var(--pf-global--FontSize--3xl);
-  padding-top: 10px !important;
+  padding-bottom: 0;
 }
 
 .monitoring-dashboards__table {
@@ -65,8 +65,12 @@
   float: right;
 }
 
+.graph-wrapper__horizontal-bar {
+  padding-right: 10px;
+}
+
 .graph-wrapper--query-browser {
-  padding-left: 40px;
+  padding-left: 50px;
   padding-right: 10px;
 }
 

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -1,4 +1,3 @@
-import * as classNames from 'classnames';
 import * as _ from 'lodash-es';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
@@ -234,11 +233,7 @@ const Card_: React.FC<CardProps> = ({ panel, pollInterval, timespan, variables }
         <DashboardCardHeader className="monitoring-dashboards__card-header">
           <DashboardCardTitle>{panel.title}</DashboardCardTitle>
         </DashboardCardHeader>
-        <DashboardCardBody
-          className={classNames({
-            'co-dashboard-card__body--dashboard-graph': panel.type === 'graph',
-          })}
-        >
+        <DashboardCardBody className="co-dashboard-card__body--dashboard-graph">
           {panel.type === 'grafana-piechart-panel' && <BarChart query={queries[0]} />}
           {panel.type === 'graph' && (
             <Graph

--- a/frontend/public/components/monitoring/dashboards/single-stat.tsx
+++ b/frontend/public/components/monitoring/dashboards/single-stat.tsx
@@ -9,7 +9,9 @@ import { getPrometheusURL, PrometheusEndpoint } from '../../graphs/helpers';
 import { LoadingInline, usePoll, useSafeFetch } from '../../utils';
 
 const Body: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <Bullseye className="monitoring-dashboards__single-stat">{children}</Bullseye>
+  <Bullseye className="monitoring-dashboards__single-stat query-browser__wrapper">
+    {children}
+  </Bullseye>
 );
 
 const SingleStat: React.FC<Props> = ({


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1799490 
along with a few other minor display issues chart labels were being clipped.
• Use `co-dashboard-card__body--dashboard-graph` to set default padding within monitoring dashboards
Tested and works with https://github.com/openshift/console/pull/4271 

<img width="811" alt="Screen Shot 2020-02-12 at 1 16 18 PM" src="https://user-images.githubusercontent.com/1874151/74367011-1d9a1f00-4d9f-11ea-8457-248f033d821f.png">

---- 
<img width="851" alt="Screen Shot 2020-02-12 at 11 21 27 AM" src="https://user-images.githubusercontent.com/1874151/74367107-4c17fa00-4d9f-11ea-8f25-dee38f527318.png">
<img width="848" alt="Screen Shot 2020-02-12 at 10 05 47 AM" src="https://user-images.githubusercontent.com/1874151/74367117-50441780-4d9f-11ea-9789-656253132793.png">
<img width="1283" alt="Screen Shot 2020-02-12 at 1 47 28 PM" src="https://user-images.githubusercontent.com/1874151/74367118-51754480-4d9f-11ea-8225-8c3034b2d6b6.png">
<img width="983" alt="Screen Shot 2020-02-12 at 1 24 40 PM" src="https://user-images.githubusercontent.com/1874151/74367122-520ddb00-4d9f-11ea-9a4d-f03ea4c46707.png">

