### PR TITLE
Bug 1801736: fixes issue with external image registry not working for tags

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -114,7 +114,7 @@ export interface ImageData {
 
 export interface ImageStreamImageData {
   name: string;
-  image: object;
+  image: { [key: string]: any };
   tag: string;
   status: { metadata: {}; status: string };
   ports: ContainerPort[];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3033

**Analysis / Root cause**: 
cannot create an application as Developer from Add flow in container image when I use image URLs from Docker hub i.e `tensorflow/tensorflow:latest-jupyter`

**Solution Description**: 
Updated logic to fetch image digest once resolved

**Screen shots / Gifs for design review**: 
![ezgif com-video-to-gif (24)](https://user-images.githubusercontent.com/5129024/74363594-dfc5e680-4df0-11ea-9bb9-ce9a1a363382.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
