### PR TITLE
Bug 1802308: Fetch Helm resources based on manifest in release data

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
@@ -30,20 +30,19 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets })
     const activeFilters = queryArgument?.split(',');
 
     const fetchHelmReleases = async () => {
-      let res: HelmRelease[];
+      let namespacedReleases: HelmRelease[];
       try {
-        res = await coFetchJSON('/api/helm/releases');
+        namespacedReleases = await coFetchJSON(`/api/helm/releases?ns=${namespace}`);
       } catch {
         if (ignore) return;
 
         setReleases([]);
         setFetched(true);
       }
-      const namespacedReleases = (res && res.filter((rel) => rel.namespace === namespace)) || [];
 
       if (ignore) return;
 
-      setReleases(namespacedReleases);
+      setReleases(namespacedReleases || []);
       setFetched(true);
 
       if (activeFilters) {

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseResources.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseResources.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import { MultiListPage } from '@console/internal/components/factory';
+import { FirehoseResource } from '@console/internal/components/utils';
 import { flattenResources } from './helm-release-resources-utils';
 import HelmResourcesListComponent from './HelmResourcesListComponent';
 
 export interface HelmReleaseResourcesProps {
-  helmManifestResources;
+  helmManifestResources: FirehoseResource[];
 }
 
 const HelmReleaseResources: React.FC<HelmReleaseResourcesProps> = ({ helmManifestResources }) => (
   <MultiListPage
-    filterLabel={'Resources by name'}
+    filterLabel="Resources by name"
     resources={helmManifestResources}
     flatten={flattenResources}
     label="Resources"

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseResources.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseResources.tsx
@@ -1,60 +1,20 @@
 import * as React from 'react';
 import { MultiListPage } from '@console/internal/components/factory';
-import { K8sResourceKind } from '@console/internal/module/k8s';
-import { DeploymentModel, StatefulSetModel, PodModel, SecretModel } from '@console/internal/models';
-import HelmResourcesListComponent from './HelmResourcesListComponent';
 import { flattenResources } from './helm-release-resources-utils';
-import { ServiceModel } from '../../../../knative-plugin/src/models';
+import HelmResourcesListComponent from './HelmResourcesListComponent';
 
 export interface HelmReleaseResourcesProps {
-  obj: K8sResourceKind;
+  helmManifestResources;
 }
 
-const HelmReleaseResources: React.FC<HelmReleaseResourcesProps> = ({ obj: resourceDetails }) => {
-  const { namespace } = resourceDetails?.metadata;
-  const helmReleaseName = resourceDetails.metadata.labels?.name;
-  const resources = [
-    {
-      kind: DeploymentModel.kind,
-      namespaced: true,
-      isList: true,
-      selector: { release: `${helmReleaseName}` },
-    },
-    {
-      kind: ServiceModel.kind,
-      namespaced: true,
-      isList: true,
-      selector: { release: `${helmReleaseName}` },
-    },
-    {
-      kind: StatefulSetModel.kind,
-      namespaced: true,
-      isList: true,
-      selector: { release: `${helmReleaseName}` },
-    },
-    {
-      kind: PodModel.kind,
-      namespaced: true,
-      isList: true,
-      selector: { release: `${helmReleaseName}` },
-    },
-    {
-      kind: SecretModel.kind,
-      namespaced: true,
-      isList: true,
-      selector: { name: `${helmReleaseName}` },
-    },
-  ];
-  return (
-    <MultiListPage
-      filterLabel={'Resources by name'}
-      resources={resources}
-      flatten={flattenResources}
-      label="Resources"
-      namespace={namespace}
-      ListComponent={HelmResourcesListComponent}
-    />
-  );
-};
+const HelmReleaseResources: React.FC<HelmReleaseResourcesProps> = ({ helmManifestResources }) => (
+  <MultiListPage
+    filterLabel={'Resources by name'}
+    resources={helmManifestResources}
+    flatten={flattenResources}
+    label="Resources"
+    ListComponent={HelmResourcesListComponent}
+  />
+);
 
 export default HelmReleaseResources;

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResources.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResources.spec.tsx
@@ -8,9 +8,11 @@ describe('HelmReleaseResources', () => {
     helmManifestResources: [
       {
         kind: 'Service',
-        isNamespaced: true,
+        prop: 'service',
         namespace: 'test-helm',
         name: 'nodejs-example',
+        isList: false,
+        optional: true,
       },
     ],
   };

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResources.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResources.spec.tsx
@@ -5,20 +5,14 @@ import HelmReleaseResources from '../HelmReleaseResources';
 
 describe('HelmReleaseResources', () => {
   const helmReleaseResourcesProps: React.ComponentProps<typeof HelmReleaseResources> = {
-    obj: {
-      data: {
-        release: 'SDRzSUFBQUFBQUFDLyt5OUNYT2pTTFl3K2xjVW1vbVk5K0xhTG',
-        kind: 'Secret',
+    helmManifestResources: [
+      {
+        kind: 'Service',
+        isNamespaced: true,
+        namespace: 'test-helm',
+        name: 'nodejs-example',
       },
-      metadata: {
-        creationTimestamp: '2020-01-20T05:37:13Z',
-        name: 'sh.helm.release.v1.helm-mysql.v1',
-        namespace: 'deb',
-        labels: {
-          name: 'helm-mysql',
-        },
-      },
-    },
+    ],
   };
   const helmReleaseResources = shallow(<HelmReleaseResources {...helmReleaseResourcesProps} />);
   it('should render the MultiListPage component', () => {

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-resources-utils.data.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-resources-utils.data.ts
@@ -1,32 +1,28 @@
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
 export const resources: {
-  [key: string]: { data: K8sResourceKind[] };
+  [key: string]: { data: K8sResourceKind };
 } = {
   Deployment: {
-    data: [
-      {
-        kind: 'Deployment',
-        metadata: {
-          name: 'helm-mysql',
-          namespace: 'xyz',
-        },
+    data: {
+      kind: 'Deployment',
+      metadata: {
+        name: 'helm-mysql',
+        namespace: 'xyz',
       },
-    ],
+    },
   },
   StatefulSet: {
-    data: [
-      {
-        kind: 'StatefulSet',
-        metadata: {
-          name: 'helm-mysql',
-          namespace: 'xyz',
-        },
+    data: {
+      kind: 'StatefulSet',
+      metadata: {
+        name: 'helm-mysql',
+        namespace: 'xyz',
       },
-    ],
+    },
   },
   Pod: {
-    data: [],
+    data: {},
   },
 };
 

--- a/frontend/packages/dev-console/src/components/helm/helm-release-resources-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-release-resources-utils.ts
@@ -1,7 +1,10 @@
+import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
-export const flattenResources = (resources: { [kind: string]: { data: K8sResourceKind[] } }) =>
-  Object.keys(resources).reduce(
-    (acc, kind) => [...acc, ...resources[kind].data.map((res) => ({ ...res, kind }))],
-    [],
-  );
+export const flattenResources = (resources: { [kind: string]: { data: K8sResourceKind } }) =>
+  Object.keys(resources).reduce((acc, kind) => {
+    if (!_.isEmpty(resources[kind].data)) {
+      acc.push(resources[kind].data);
+    }
+    return acc;
+  }, []);

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -468,7 +468,7 @@ export const MultiListPage = (props) => {
 
   const resources = _.map(props.resources, (r) => ({
     ...r,
-    isList: true,
+    isList: r.isList !== undefined ? r.isList : true,
     namespace: r.namespaced ? namespace : r.namespace,
     prop: r.prop || r.kind,
   }));


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-2813

This PR - 
- Adds functionality to fetch helm release manifest using helm release list API on helm release details page.
- It creates a resources array for Firehose using the manifest of the helm chart.
- Using `MultiListPage` then it lists all the resources that were created by the Helm release.

Screencast -
Older implementation - 
![Peek 2020-02-13 02-34](https://user-images.githubusercontent.com/6041994/74377161-6ab2db00-4e09-11ea-9337-54eda65954de.gif)
 
Newer Implementation - 
![Peek 2020-02-13 02-33](https://user-images.githubusercontent.com/6041994/74377154-6686bd80-4e09-11ea-9b2b-941be3204034.gif)
