### PR TITLE
Bug 1794926: Search - Identify kind with more detail

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -23,6 +23,14 @@
   flex: 1 0 auto;
 }
 
+.co-search-group__accordion-label {
+  display: flex;
+  align-items: center;
+  .text-muted {
+    margin-left: 10px;
+  }
+}
+
 .co-search-group__resource {
   margin: 0 15px 15px 0;
 }

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -12,7 +12,6 @@ import {
   ChipGroupToolbarItem,
 } from '@patternfly/react-core';
 import { CloseIcon } from '@patternfly/react-icons';
-
 import { getBadgeFromType } from '@console/shared';
 import { AsyncComponent } from './utils/async';
 import { connectToModel } from '../kinds';
@@ -147,8 +146,15 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
   };
 
   const getToggleText = (item: string) => {
-    const { labelPlural } = modelFor(item);
-    return labelPlural;
+    const { labelPlural, apiVersion, apiGroup } = modelFor(item);
+    return (
+      <span className="co-search-group__accordion-label">
+        {labelPlural}{' '}
+        <span className="text-muted show small">
+          {apiGroup || 'core'}/{apiVersion}
+        </span>
+      </span>
+    );
   };
 
   return (


### PR DESCRIPTION
In order to better identify what resources are being shown, I have added the group and version to the title of each acordian section.  The chips do not have this on the toolbar as we are concerned about space.  We will discuss this further with UXD but this should help immensely for 4.4.
![Screenshot_2020-02-12 Search · OKD](https://user-images.githubusercontent.com/18728857/74387688-71fcc900-4db6-11ea-8c93-e19171a2b949.png)
![Screenshot_2020-02-12 Search · OKD(1)](https://user-images.githubusercontent.com/18728857/74387697-7628e680-4db6-11ea-9b55-511b11d48fcd.png)

