### PR TITLE
[Doc] Update README with how to set default value in schema or alm-examples

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/README.md
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/README.md
@@ -26,7 +26,9 @@ type Descriptor = {
 
 The `x-descriptors` field can be thought of as "capabilities" (and is referenced in the code using this term). Capabilities are defined in `types.ts` provide a mapping between descriptors and different UI components (implemented as React components) using [URN format](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier).
 
-The `value` field is an optional field. If present, the value of this spec is the same for all instances of the CRD and can be found here instead of on the CR. You can specify the default value of the field on CRD in [OpenAPI v3 validation schema](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#defaulting).
+The `value` field is an optional field. If present, the value of this spec is the same for all instances of the CRD and can be found here instead of on the CR. This should not be used to apply a default value to a given custom resource for consumption by the console.
+
+You can assign the default value of the field on CRD in OpenAPI v3 validation schema (see [Defaulting](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#defaulting) feature in Kubernetes 1.17). Alternatively, you can specify the value of a field in [CRD Templates](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#crd-templates) in the `ClusterServiceVersion` to set (or override) the default value on the CRD.
 
 
 ## Example


### PR DESCRIPTION
Add detailed info about:
1. external doc for "set a default value on OpenAPI schema" (Need CRD v1 api / k8s 1.17+).
2. link to "alm-examples" to specify value to set/override the default value on CRD.

**Current:**
<img width="977" alt="current-doc" src="https://user-images.githubusercontent.com/5903705/74393850-146d7a00-4dc0-11ea-902d-fddd58fdceec.png">

**This PR:**
<img width="974" alt="this-pr" src="https://user-images.githubusercontent.com/5903705/74786993-eb873200-5262-11ea-9e13-d6abcf35c269.png">



