### PR TITLE
Bug 1796522: Show multiple resources in one stream

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -58,6 +58,7 @@ const testSuites = {
     'tests/modal-annotations.scenario.ts',
     'tests/environment.scenario.ts',
   ]),
+  event: suite(['tests/event.scenario.ts']),
   crudBasic: suite(['tests/crud.scenario.ts']),
   monitoring: suite(['tests/monitoring.scenario.ts']),
   newApp: suite(['tests/overview/overview.scenario.ts', 'tests/deploy-image.scenario.ts']),
@@ -95,6 +96,7 @@ const testSuites = {
     'tests/devconsole/pipeline.scenario.ts',
     'tests/dashboards/cluster-dashboard.scenario.ts',
     'tests/dashboards/project-dashboard.scenario.ts',
+    'tests/event.scenario.ts',
   ]),
   release: suite([
     'tests/crud.scenario.ts',
@@ -108,6 +110,7 @@ const testSuites = {
     'tests/crd-extensions.scenario.ts',
     'tests/dashboards/cluster-dashboard.scenario.ts',
     'tests/dashboards/project-dashboard.scenario.ts',
+    'tests/event.scenario.ts',
   ]),
   all: suite([
     'tests/crud.scenario.ts',
@@ -129,6 +132,7 @@ const testSuites = {
     'tests/oauth.scenario.ts',
     'tests/dashboards/cluster-dashboard.scenario.ts',
     'tests/dashboards/project-dashboard.scenario.ts',
+    'tests/event.scenario.ts',
   ]),
   clusterSettings: suite(['tests/cluster-settings.scenario.ts']),
   alertmanager: suite(['tests/alertmanager.scenario.ts']),

--- a/frontend/integration-tests/tests/event.scenario.ts
+++ b/frontend/integration-tests/tests/event.scenario.ts
@@ -1,0 +1,45 @@
+import { browser, $, element, by, ExpectedConditions as until } from 'protractor';
+import { appHost, checkLogs, checkErrors, testName } from '../protractor.conf';
+import { execSync } from 'child_process';
+
+describe('Events', () => {
+  const name = `${testName}-pod`;
+  const testpod = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name,
+      namespace: testName,
+    },
+    spec: {
+      containers: [
+        {
+          name: 'hello-openshift',
+          image: 'openshift/hello-openshift',
+        },
+      ],
+    },
+  };
+  beforeAll(() => {
+    execSync(`echo '${JSON.stringify(testpod)}' | kubectl create -n ${testName} -f -`);
+  });
+  afterEach(() => {
+    checkLogs();
+    checkErrors();
+  });
+  afterAll(() => {
+    try {
+      execSync(`kubectl delete pods ${name} -n ${testName}`);
+    } catch (error) {
+      console.error(`\nFailed to delete pods ${name}:\n${error}`);
+    }
+  });
+  describe('Events', () => {
+    it('event view displays created pod', async () => {
+      await browser.get(`${appHost}/ns/${testName}/events`);
+      await browser.wait(until.presenceOf(element(by.linkText(name))));
+      await browser.wait(until.presenceOf($(`[data-test-id=${name}]`)));
+      expect($(`[data-test-id=${name}]`).getText()).toEqual(name);
+    });
+  });
+});


### PR DESCRIPTION
We now have the ability the select multiple event streams at once. Instead of showing each stream in its own section, I have combined the events to show together which is the preference for users.
![Peek 2020-02-12-events](https://user-images.githubusercontent.com/18728857/74403139-84412c00-4de3-11ea-8be4-7618e3e826a8.gif)
