### PR TITLE
Bug 1777486: Read monitoriong URLs from the console-config configmap

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -80,7 +80,7 @@ func main() {
 	fK8sModeOffClusterEndpoint := fs.String("k8s-mode-off-cluster-endpoint", "", "URL of the Kubernetes API server.")
 	fK8sModeOffClusterSkipVerifyTLS := fs.Bool("k8s-mode-off-cluster-skip-verify-tls", false, "DEV ONLY. When true, skip verification of certs presented by k8s API server.")
 	fK8sModeOffClusterPrometheus := fs.String("k8s-mode-off-cluster-prometheus", "", "DEV ONLY. URL of the cluster's Prometheus server.")
-	fK8sModeOffClusterThanos := fs.String("k8s-mode-off-cluster-thanos", "", "DEV ONLY. URL of the cluster's Prometheus server.")
+	fK8sModeOffClusterThanos := fs.String("k8s-mode-off-cluster-thanos", "", "DEV ONLY. URL of the cluster's Thanos server.")
 	fK8sModeOffClusterAlertmanager := fs.String("k8s-mode-off-cluster-alertmanager", "", "DEV ONLY. URL of the cluster's AlertManager server.")
 	fK8sModeOffClusterMetering := fs.String("k8s-mode-off-cluster-metering", "", "DEV ONLY. URL of the cluster's metering server.")
 
@@ -107,6 +107,11 @@ func main() {
 	fCustomLogoFile := fs.String("custom-logo-file", "", "Custom product image for console branding.")
 	fStatuspageID := fs.String("statuspage-id", "", "Unique ID assigned by statuspage.io page that provides status info.")
 	fDocumentationBaseURL := fs.String("documentation-base-url", "", "The base URL for documentation links.")
+
+	fAlermanagerPublicURL := fs.String("alermanager-public-url", "", "Public URL of the cluster's AlertManager server.")
+	fGrafanaPublicURL := fs.String("grafana-public-url", "", "Public URL of the cluster's Grafana server.")
+	fPrometheusPublicURL := fs.String("prometheus-public-url", "", "Public URL of the cluster's Prometheus server.")
+	fThanosPublicURL := fs.String("thanos-public-url", "", "Public URL of the cluster's Thanos server.")
 
 	fLoadTestFactor := fs.Int("load-test-factor", 0, "DEV ONLY. The factor used to multiply k8s API list responses for load testing purposes.")
 
@@ -160,6 +165,23 @@ func main() {
 		documentationBaseURL = bridge.ValidateFlagIsURL("documentation-base-url", *fDocumentationBaseURL)
 	}
 
+	alertManagerPublicURL := &url.URL{}
+	if *fAlermanagerPublicURL != "" {
+		alertManagerPublicURL = bridge.ValidateFlagIsURL("alermanager-public-url", *fAlermanagerPublicURL)
+	}
+	grafanaPublicURL := &url.URL{}
+	if *fGrafanaPublicURL != "" {
+		grafanaPublicURL = bridge.ValidateFlagIsURL("grafana-public-url", *fGrafanaPublicURL)
+	}
+	prometheusPublicURL := &url.URL{}
+	if *fPrometheusPublicURL != "" {
+		prometheusPublicURL = bridge.ValidateFlagIsURL("prometheus-public-url", *fPrometheusPublicURL)
+	}
+	thanosPublicURL := &url.URL{}
+	if *fThanosPublicURL != "" {
+		thanosPublicURL = bridge.ValidateFlagIsURL("thanos-public-url", *fThanosPublicURL)
+	}
+
 	branding := *fBranding
 	if branding == "origin" {
 		branding = "okd"
@@ -182,15 +204,19 @@ func main() {
 	}
 
 	srv := &server.Server{
-		PublicDir:            *fPublicDir,
-		BaseURL:              baseURL,
-		LogoutRedirect:       logoutRedirect,
-		Branding:             branding,
-		CustomProductName:    *fCustomProductName,
-		CustomLogoFile:       *fCustomLogoFile,
-		StatuspageID:         *fStatuspageID,
-		DocumentationBaseURL: documentationBaseURL,
-		LoadTestFactor:       *fLoadTestFactor,
+		PublicDir:             *fPublicDir,
+		BaseURL:               baseURL,
+		LogoutRedirect:        logoutRedirect,
+		Branding:              branding,
+		CustomProductName:     *fCustomProductName,
+		CustomLogoFile:        *fCustomLogoFile,
+		StatuspageID:          *fStatuspageID,
+		DocumentationBaseURL:  documentationBaseURL,
+		AlertManagerPublicURL: alertManagerPublicURL,
+		GrafanaPublicURL:      grafanaPublicURL,
+		PrometheusPublicURL:   prometheusPublicURL,
+		ThanosPublicURL:       thanosPublicURL,
+		LoadTestFactor:        *fLoadTestFactor,
 	}
 
 	// if !in-cluster (dev) we should not pass these values to the frontend

--- a/frontend/__tests__/components/graphs/prometheus-graph.spec.tsx
+++ b/frontend/__tests__/components/graphs/prometheus-graph.spec.tsx
@@ -91,10 +91,10 @@ describe('<PrometheusGraphLink />', () => {
 });
 
 describe('getPrometheusExpressionBrowserURL()', () => {
-  const urls = {
-    'prometheus-k8s': 'https://mock.prometheus.url',
-  };
-  const url = getPrometheusExpressionBrowserURL(urls, ['test-query-1', 'test-query-2']);
+  const url = getPrometheusExpressionBrowserURL('https://mock.prometheus.url', [
+    'test-query-1',
+    'test-query-2',
+  ]);
   expect(url).toBe(
     'https://mock.prometheus.url/graph?g0.range_input=1h&g0.expr=test-query-1&g0.tab=0&g1.range_input=1h&g1.expr=test-query-2&g1.tab=0',
   );

--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -193,28 +193,6 @@ const detectCanCreateProject = (dispatch) =>
     },
   );
 
-const monitoringConfigMapPath = `${k8sBasePath}/api/v1/namespaces/openshift-monitoring/configmaps/sharing-config`;
-const detectMonitoringURLs = (dispatch) =>
-  coFetchJSON(monitoringConfigMapPath).then(
-    (res) => {
-      const { alertmanagerURL, grafanaURL, prometheusURL } = res.data;
-      if (!_.isEmpty(alertmanagerURL)) {
-        dispatch(setMonitoringURL(MonitoringRoutes.Alertmanager, alertmanagerURL));
-      }
-      if (!_.isEmpty(grafanaURL)) {
-        dispatch(setMonitoringURL(MonitoringRoutes.Grafana, grafanaURL));
-      }
-      if (!_.isEmpty(prometheusURL)) {
-        dispatch(setMonitoringURL(MonitoringRoutes.Prometheus, prometheusURL));
-      }
-    },
-    (err) => {
-      if (!_.includes([401, 403, 404, 500], _.get(err, 'response.status'))) {
-        setTimeout(() => detectMonitoringURLs(dispatch), 15000);
-      }
-    },
-  );
-
 const loggingConfigMapPath = `${k8sBasePath}/api/v1/namespaces/openshift-logging/configmaps/sharing-config`;
 const detectLoggingURL = (dispatch) =>
   coFetchJSON(loggingConfigMapPath).then(
@@ -278,7 +256,6 @@ export const detectFeatures = () => (dispatch: Dispatch) =>
   [
     detectOpenShift,
     detectCanCreateProject,
-    detectMonitoringURLs,
     detectClusterVersion,
     detectUser,
     detectLoggingURL,

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -6,13 +6,11 @@ import { Link } from 'react-router-dom';
 
 import { FLAGS } from '@console/shared';
 import { featureReducerName } from '../../reducers/features';
-import { MonitoringRoutes } from '../../reducers/monitoring';
 import { getActivePerspective, getActiveNamespace } from '../../reducers/ui';
 import { RootState } from '../../redux';
 
-export const getPrometheusExpressionBrowserURL = (urls, queries): string => {
-  const base = urls && urls[MonitoringRoutes.Prometheus];
-  if (!base || _.isEmpty(queries)) {
+export const getPrometheusExpressionBrowserURL = (url, queries): string => {
+  if (!url || _.isEmpty(queries)) {
     return null;
   }
   const params = new URLSearchParams();
@@ -21,7 +19,7 @@ export const getPrometheusExpressionBrowserURL = (urls, queries): string => {
     params.set(`g${i}.expr`, query);
     params.set(`g${i}.tab`, '0');
   });
-  return `${base}/graph?${params.toString()}`;
+  return `${url}/graph?${params.toString()}`;
 };
 
 const mapStateToProps = (state: RootState) => ({

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -21,14 +21,7 @@ import { withFallback } from '@console/shared/src/components/error/error-boundar
 import * as k8sActions from '../actions/k8s';
 import * as UIActions from '../actions/ui';
 import { coFetchJSON } from '../co-fetch';
-import {
-  alertState,
-  AlertStates,
-  connectToURLs,
-  MonitoringRoutes,
-  silenceState,
-  SilenceStates,
-} from '../reducers/monitoring';
+import { alertState, AlertStates, silenceState, SilenceStates } from '../reducers/monitoring';
 import store from '../redux';
 import { Table, TableData, TableRow, TextFilter } from './factory';
 import { confirmModal } from './modals';
@@ -767,18 +760,15 @@ const AlertsPageDescription = () => (
   </p>
 );
 
-const HeaderAlertmanagerLink_ = ({ path, urls }) =>
-  _.isEmpty(urls[MonitoringRoutes.Alertmanager]) ? null : (
+const HeaderAlertmanagerLink = ({ path }) =>
+  _.isEmpty(window.SERVER_FLAGS.alertManagerPublicURL) ? null : (
     <span className="monitoring-header-link">
       <ExternalLink
-        href={`${urls[MonitoringRoutes.Alertmanager]}${path || ''}`}
+        href={`${window.SERVER_FLAGS.alertManagerPublicURL}${path || ''}`}
         text="Alertmanager UI"
       />
     </span>
   );
-const HeaderAlertmanagerLink = connectToURLs(MonitoringRoutes.Alertmanager)(
-  HeaderAlertmanagerLink_,
-);
 
 const alertsRowFilter = {
   type: 'alert-state',

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -16,7 +16,6 @@ import { withFallback } from '@console/shared/src/components/error/error-boundar
 
 import * as UIActions from '../../../actions/ui';
 import { ErrorBoundaryFallback } from '../../error';
-import { connectToURLs, MonitoringRoutes } from '../../../reducers/monitoring';
 import { RootState } from '../../../redux';
 import { getPrometheusURL, PrometheusEndpoint } from '../../graphs/helpers';
 import { ExternalLink, history, LoadingInline, useSafeFetch } from '../../utils';
@@ -402,13 +401,12 @@ const Board: React.FC<BoardProps> = ({ rows }) => (
   </>
 );
 
-const GrafanaLink_ = ({ urls }) =>
-  _.isEmpty(urls[MonitoringRoutes.Grafana]) ? null : (
+const GrafanaLink = () =>
+  _.isEmpty(window.SERVER_FLAGS.grafanaPublicURL) ? null : (
     <span className="monitoring-header-link">
-      <ExternalLink href={urls[MonitoringRoutes.Grafana]} text="Grafana UI" />
+      <ExternalLink href={window.SERVER_FLAGS.grafanaPublicURL} text="Grafana UI" />
     </span>
   );
-const GrafanaLink = connectToURLs(MonitoringRoutes.Grafana)(GrafanaLink_);
 
 const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({
   deleteAll,

--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -43,7 +43,6 @@ import {
   YellowExclamationTriangleIcon,
 } from '@console/shared';
 import * as UIActions from '../../actions/ui';
-import { connectToURLs, MonitoringRoutes } from '../../reducers/monitoring';
 import { RootState } from '../../redux';
 import { fuzzyCaseInsensitive } from '../factory/table-filters';
 import { PROMETHEUS_BASE_PATH } from '../graphs';
@@ -171,13 +170,16 @@ const MetricsActionsMenu = connect(
   },
 )(MetricsActionsMenu_);
 
-const headerPrometheusLinkStateToProps = ({ UI }: RootState, { urls }) => {
+const headerPrometheusLinkStateToProps = ({ UI }: RootState) => {
   const liveQueries = UI.getIn(['queryBrowser', 'queries']).filter(
     (q) => q.get('isEnabled') && q.get('query'),
   );
   const queryStrings = _.map(liveQueries.toJS(), 'query');
+  const url = window.SERVER_FLAGS.prometheusPublicURL;
   return {
-    url: getPrometheusExpressionBrowserURL(urls, queryStrings) || urls[MonitoringRoutes.Prometheus],
+    url:
+      getPrometheusExpressionBrowserURL(url, queryStrings) ||
+      window.SERVER_FLAGS.prometheusPublicURL,
   };
 };
 
@@ -188,9 +190,7 @@ const HeaderPrometheusLink_ = ({ url }) => {
     </span>
   ) : null;
 };
-const HeaderPrometheusLink = connectToURLs(MonitoringRoutes.Prometheus)(
-  connect(headerPrometheusLinkStateToProps)(HeaderPrometheusLink_),
-);
+const HeaderPrometheusLink = connect(headerPrometheusLinkStateToProps)(HeaderPrometheusLink_);
 
 export const graphStateToProps = ({ UI }: RootState) => ({
   hideGraphs: !!UI.getIn(['monitoring', 'hideGraphs']),

--- a/frontend/public/declarations.d.ts
+++ b/frontend/public/declarations.d.ts
@@ -31,6 +31,10 @@ declare interface Window {
     prometheusBaseURL: string;
     prometheusTenancyBaseURL: string;
     requestTokenURL: string;
+    alertManagerPublicURL: string;
+    grafanaPublicURL: string;
+    prometheusPublicURL: string;
+    thanosPublicURL: string;
     statuspageID: string;
     GOARCH: string;
     GOOS: string;

--- a/frontend/public/reducers/monitoring.ts
+++ b/frontend/public/reducers/monitoring.ts
@@ -18,9 +18,6 @@ export const enum SilenceStates {
 }
 
 export enum MonitoringRoutes {
-  Prometheus = 'prometheus-k8s',
-  Alertmanager = 'alertmanager-main',
-  Grafana = 'grafana',
   Kibana = 'kibana',
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,6 +64,10 @@ type jsGlobals struct {
 	CustomLogoURL            string `json:"customLogoURL"`
 	StatuspageID             string `json:"statuspageID"`
 	DocumentationBaseURL     string `json:"documentationBaseURL"`
+	AlertManagerPublicURL    string `json:"alertManagerPublicURL"`
+	GrafanaPublicURL         string `json:"grafanaPublicURL"`
+	PrometheusPublicURL      string `json:"prometheusPublicURL"`
+	ThanosPublicURL          string `json:"thanosPublicURL"`
 	LoadTestFactor           int    `json:"loadTestFactor"`
 	GOARCH                   string `json:"GOARCH"`
 	GOOS                     string `json:"GOOS"`
@@ -98,6 +102,11 @@ type Server struct {
 	HelmChartRepoProxyConfig           *proxy.Config
 	GOARCH                             string
 	GOOS                               string
+	// Monitoring and Logging related URLs
+	AlertManagerPublicURL *url.URL
+	GrafanaPublicURL      *url.URL
+	PrometheusPublicURL   *url.URL
+	ThanosPublicURL       *url.URL
 }
 
 func (s *Server) authDisabled() bool {
@@ -340,23 +349,27 @@ func (s *Server) handleMonitoringDashboardConfigmaps(w http.ResponseWriter, r *h
 
 func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {
 	jsg := &jsGlobals{
-		ConsoleVersion:       version.Version,
-		AuthDisabled:         s.authDisabled(),
-		KubectlClientID:      s.KubectlClientID,
-		BasePath:             s.BaseURL.Path,
-		LoginURL:             proxy.SingleJoiningSlash(s.BaseURL.String(), authLoginEndpoint),
-		LoginSuccessURL:      proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginSuccessEndpoint),
-		LoginErrorURL:        proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginErrorEndpoint),
-		LogoutURL:            proxy.SingleJoiningSlash(s.BaseURL.String(), authLogoutEndpoint),
-		LogoutRedirect:       s.LogoutRedirect.String(),
-		KubeAPIServerURL:     s.KubeAPIServerURL,
-		Branding:             s.Branding,
-		CustomProductName:    s.CustomProductName,
-		StatuspageID:         s.StatuspageID,
-		DocumentationBaseURL: s.DocumentationBaseURL.String(),
-		LoadTestFactor:       s.LoadTestFactor,
-		GOARCH:               s.GOARCH,
-		GOOS:                 s.GOOS,
+		ConsoleVersion:        version.Version,
+		AuthDisabled:          s.authDisabled(),
+		KubectlClientID:       s.KubectlClientID,
+		BasePath:              s.BaseURL.Path,
+		LoginURL:              proxy.SingleJoiningSlash(s.BaseURL.String(), authLoginEndpoint),
+		LoginSuccessURL:       proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginSuccessEndpoint),
+		LoginErrorURL:         proxy.SingleJoiningSlash(s.BaseURL.String(), AuthLoginErrorEndpoint),
+		LogoutURL:             proxy.SingleJoiningSlash(s.BaseURL.String(), authLogoutEndpoint),
+		LogoutRedirect:        s.LogoutRedirect.String(),
+		KubeAPIServerURL:      s.KubeAPIServerURL,
+		Branding:              s.Branding,
+		CustomProductName:     s.CustomProductName,
+		StatuspageID:          s.StatuspageID,
+		DocumentationBaseURL:  s.DocumentationBaseURL.String(),
+		AlertManagerPublicURL: s.AlertManagerPublicURL.String(),
+		GrafanaPublicURL:      s.GrafanaPublicURL.String(),
+		PrometheusPublicURL:   s.PrometheusPublicURL.String(),
+		ThanosPublicURL:       s.ThanosPublicURL.String(),
+		GOARCH:                s.GOARCH,
+		GOOS:                  s.GOOS,
+		LoadTestFactor:        s.LoadTestFactor,
 	}
 
 	if !s.authDisabled() {

--- a/pkg/serverconfig/config.go
+++ b/pkg/serverconfig/config.go
@@ -35,6 +35,7 @@ func SetFlagsFromConfig(fs *flag.FlagSet, filename string) (err error) {
 	addAuth(fs, &config.Auth)
 	addCustomization(fs, &config.Customization)
 	addProviders(fs, &config.Providers)
+	addMonitoringInfo(fs, &config.MonitoringInfo)
 	addHelmConfig(fs, &config.Helm)
 
 	return nil
@@ -134,6 +135,21 @@ func addAuth(fs *flag.FlagSet, auth *Auth) {
 func addProviders(fs *flag.FlagSet, providers *Providers) {
 	if providers.StatuspageID != "" {
 		fs.Set("statuspage-id", providers.StatuspageID)
+	}
+}
+
+func addMonitoringInfo(fs *flag.FlagSet, monitoring *MonitoringInfo) {
+	if monitoring.AlertmanagerPublicURL != "" {
+		fs.Set("alermanager-url", monitoring.AlertmanagerPublicURL)
+	}
+	if monitoring.GrafanaPublicURL != "" {
+		fs.Set("grafana-url", monitoring.GrafanaPublicURL)
+	}
+	if monitoring.PrometheusPublicURL != "" {
+		fs.Set("prometheus-url", monitoring.PrometheusPublicURL)
+	}
+	if monitoring.ThanosPublicURL != "" {
+		fs.Set("thanos-url", monitoring.ThanosPublicURL)
 	}
 }
 

--- a/pkg/serverconfig/types.go
+++ b/pkg/serverconfig/types.go
@@ -6,14 +6,15 @@ package serverconfig
 
 // Config is the top-level console server cli configuration.
 type Config struct {
-	APIVersion    string `yaml:"apiVersion"`
-	Kind          string `yaml:"kind"`
-	ServingInfo   `yaml:"servingInfo"`
-	ClusterInfo   `yaml:"clusterInfo"`
-	Auth          `yaml:"auth"`
-	Customization `yaml:"customization"`
-	Providers     `yaml:"providers"`
-	Helm          `yaml:"helm"`
+	APIVersion     string `yaml:"apiVersion"`
+	Kind           string `yaml:"kind"`
+	ServingInfo    `yaml:"servingInfo"`
+	ClusterInfo    `yaml:"clusterInfo"`
+	Auth           `yaml:"auth"`
+	Customization  `yaml:"customization"`
+	Providers      `yaml:"providers"`
+	Helm           `yaml:"helm"`
+	MonitoringInfo `yaml:"monitoringInfo,omitempty"`
 }
 
 // ServingInfo holds configuration for serving HTTP.
@@ -31,6 +32,14 @@ type ServingInfo struct {
 	CipherSuites          []string      `yaml:"cipherSuites,omitempty"`
 	MaxRequestsInFlight   int64         `yaml:"maxRequestsInFlight,omitempty"`
 	RequestTimeoutSeconds int64         `yaml:"requestTimeoutSeconds,omitempty"`
+}
+
+// Monitoring holds URLs for monitoring related services
+type MonitoringInfo struct {
+	AlertmanagerPublicURL string `yaml:"alertmanagerPublicURL,omitempty"`
+	GrafanaPublicURL      string `yaml:"grafanaPublicURL,omitempty"`
+	PrometheusPublicURL   string `yaml:"prometheusPublicURL,omitempty"`
+	ThanosPublicURL       string `yaml:"thanosPublicURL,omitempty"`
 }
 
 // ClusterInfo holds information the about the cluster such as master public URL and console public URL.


### PR DESCRIPTION
Read monitoring and logging URLs from the `console-config` configmap in the `openshift-console` namespace.
Related PRs:
- https://github.com/openshift/console-operator/pull/379
- https://github.com/openshift/cluster-logging-operator/pull/361

/assign @benjaminapetersen 