### PR TITLE
Bug 1802431: Remove label input placeholder if any labels are present

### DIFF
--- a/frontend/public/components/utils/selector-input.jsx
+++ b/frontend/public/components/utils/selector-input.jsx
@@ -89,7 +89,7 @@ export class SelectorInput extends React.Component {
       autoFocus: this.props.autoFocus,
       className: classNames('input', { 'invalid-tag': !isInputValid }),
       onChange: this.handleInputChange.bind(this),
-      placeholder: 'app=frontend',
+      placeholder: _.isEmpty(tags) ? 'app=frontend' : '',
       spellCheck: 'false',
       value: inputValue,
       id: 'tags-input',


### PR DESCRIPTION
If the `SelectorInput` component will contain any item the placeholder wont be present in the inputbox.

/assign @rhamilto 