### PR TITLE
Bug 1802776: Show pending icon for pipeline Idle state

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/StatusIcon.tsx
@@ -28,6 +28,7 @@ export const StatusIcon: React.FC<StatusIconProps> = ({ status, ...props }) => {
     case runStatus.Failed:
       return <ExclamationCircleIcon {...props} />;
 
+    case runStatus.Idle:
     case runStatus.Pending:
       return <PendingIcon {...props} />;
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-2997
**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
For pipeline Idle state we are showing the circle icon.
**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Show pending icon for pipleine Idle state
**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screenshot from 2020-02-14 01-22-05](https://user-images.githubusercontent.com/2561818/74472873-abbdf480-4ec8-11ea-9c37-87c40d6e67c5.png)
![Peek 2020-02-14 01-23](https://user-images.githubusercontent.com/2561818/74472885-b24c6c00-4ec8-11ea-882b-18891db03286.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
