### PR TITLE
Bug 1802840: zoom on double click of graph only

### DIFF
--- a/frontend/packages/topology/src/components/ElementWrapper.tsx
+++ b/frontend/packages/topology/src/components/ElementWrapper.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import ElementContext from '../utils/ElementContext';
 import { GraphElement, isGraph, isEdge, isNode } from '../types';
+import { ATTR_DATA_ID, ATTR_DATA_KIND, ATTR_DATA_TYPE } from '../const';
 
 type ElementWrapperProps = {
   element: GraphElement;
@@ -52,14 +53,14 @@ const ElementWrapper: React.FC<ElementWrapperProps> = observer(({ element }) => 
       return null;
     }
   }
-  const commonProps = {
-    [`data-id`]: element.getId(),
-    [`data-kind`]: element.getKind(),
-    [`data-type`]: element.getType(),
+  const commonAttrs = {
+    [ATTR_DATA_ID]: element.getId(),
+    [ATTR_DATA_KIND]: element.getKind(),
+    [ATTR_DATA_TYPE]: element.getType(),
   };
   if (isGraph(element)) {
     return (
-      <g {...commonProps}>
+      <g {...commonAttrs}>
         <ElementComponent element={element} />
       </g>
     );
@@ -67,14 +68,14 @@ const ElementWrapper: React.FC<ElementWrapperProps> = observer(({ element }) => 
   if (isNode(element) && (!element.isGroup() || element.isCollapsed())) {
     const { x, y } = element.getBounds();
     return (
-      <g {...commonProps} transform={`translate(${x}, ${y})`}>
+      <g {...commonAttrs} transform={`translate(${x}, ${y})`}>
         <ElementComponent element={element} />
         <ElementChildren element={element} />
       </g>
     );
   }
   return (
-    <g {...commonProps}>
+    <g {...commonAttrs}>
       <ElementComponent element={element} />
       <ElementChildren element={element} />
     </g>

--- a/frontend/packages/topology/src/components/layers/LayerContainer.tsx
+++ b/frontend/packages/topology/src/components/layers/LayerContainer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import ElementContext from '../../utils/ElementContext';
 import { isNode } from '../../types';
+import { ATTR_DATA_ID, ATTR_DATA_KIND, ATTR_DATA_TYPE } from '../../const';
 
 type LayerContainerProps = {
   children: React.ReactNode;
@@ -12,7 +13,8 @@ const LayerContainer: React.RefForwardingComponent<SVGGElement, LayerContainerPr
   ref,
 ) => {
   // accumulate parent positions
-  let p = React.useContext(ElementContext);
+  const element = React.useContext(ElementContext);
+  let p = element;
   let x = 0;
   let y = 0;
   while (isNode(p)) {
@@ -23,8 +25,13 @@ const LayerContainer: React.RefForwardingComponent<SVGGElement, LayerContainerPr
     }
     p = p.getParent();
   }
+  const commonAttrs = {
+    [ATTR_DATA_ID]: element.getId(),
+    [ATTR_DATA_KIND]: element.getKind(),
+    [ATTR_DATA_TYPE]: element.getType(),
+  };
   return (
-    <g ref={ref} transform={`translate(${x}, ${y})`}>
+    <g ref={ref} transform={`translate(${x}, ${y})`} {...commonAttrs}>
       {children}
     </g>
   );

--- a/frontend/packages/topology/src/const.ts
+++ b/frontend/packages/topology/src/const.ts
@@ -1,0 +1,3 @@
+export const ATTR_DATA_KIND = 'data-kind';
+export const ATTR_DATA_TYPE = 'data-type';
+export const ATTR_DATA_ID = 'data-id';


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-2981

**Analysis / Root cause**: 
D3 zoom is listeners for double click events on the graph to apply a zoom effect regardless of which child node the event originates from. A double click of a workload node or connector still results in a zoom effect.

The desired behavior is to only zoom when double clicking the graph surface. This will prevent accidental zoom when attempting to select a node in the topology.

**Solution Description**: 
D3 zoom supports a filter to allow filtering events that should not cause the zoom to take place. Added a check which looks to identify which DOM node the event originates from relative to the topology tree model. If the DOM node belongs to an edge or node, then the event is ignored. If the DOM node belongs to the graph surface, the event is accepted.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @jeff-phillips-18 @openshift/team-devconsole-ux 