### PR TITLE
Bug 1803867: apply the change when node is unassigned from an application

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -12,7 +12,7 @@ import {
   getKnativeServiceDepResource,
   ServiceModel as KnServiceModel,
 } from '@console/knative-plugin';
-import { getAppLabels, getPodLabels } from '../../utils/resource-label-utils';
+import { getAppLabels, getPodLabels, mergeData } from '../../utils/resource-label-utils';
 import {
   createRoute,
   createService,
@@ -91,7 +91,7 @@ export const createOrUpdateImageStream = (
     },
   };
 
-  const imageStream = _.merge({}, originalImageStream || {}, newImageStream);
+  const imageStream = mergeData(originalImageStream, newImageStream);
 
   return verb === 'update'
     ? k8sUpdate(ImageStreamModel, imageStream)
@@ -220,7 +220,7 @@ export const createOrUpdateDeployment = (
     },
   };
 
-  const deployment = _.merge({}, originalDeployment || {}, newDeployment);
+  const deployment = mergeData(originalDeployment, newDeployment);
 
   return verb === 'update'
     ? k8sUpdate(DeploymentModel, deployment)
@@ -306,7 +306,7 @@ export const createOrUpdateDeploymentConfig = (
     },
   };
 
-  const deploymentConfig = _.merge({}, originalDeploymentConfig || {}, newDeploymentConfig);
+  const deploymentConfig = mergeData(originalDeploymentConfig, newDeploymentConfig);
 
   return verb === 'update'
     ? k8sUpdate(DeploymentConfigModel, deploymentConfig)

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
@@ -10,6 +10,7 @@ import {
   getSuggestedName,
   makePortName,
 } from '../../../utils/imagestream-utils';
+import { UNASSIGNED_KEY } from '../app/ApplicationSelector';
 import { ImageStreamContext } from './ImageStreamContext';
 
 const ImageStreamTagDropdown: React.FC = () => {
@@ -43,7 +44,9 @@ const ImageStreamTagDropdown: React.FC = () => {
           setFieldValue('isi.ports', ports);
           setFieldValue('image.ports', ports);
           formType !== 'edit' && setFieldValue('name', getSuggestedName(name));
-          !application.name && setFieldValue('application.name', `${getSuggestedName(name)}-app`);
+          application.selectedKey !== UNASSIGNED_KEY &&
+            !application.name &&
+            setFieldValue('application.name', `${getSuggestedName(name)}-app`);
           // set default port value
           const targetPort = _.head(ports);
           targetPort && setFieldValue('route.targetPort', makePortName(targetPort));
@@ -59,6 +62,7 @@ const ImageStreamTagDropdown: React.FC = () => {
       imageStream.image,
       imageStream.namespace,
       formType,
+      application.selectedKey,
       application.name,
       setFieldError,
     ],

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -17,7 +17,12 @@ import {
 import { SecretType } from '@console/internal/components/secrets/create-secret';
 import * as plugins from '@console/internal/plugins';
 import { history } from '@console/internal/components/utils';
-import { getAppLabels, getPodLabels, getAppAnnotations } from '../../utils/resource-label-utils';
+import {
+  getAppLabels,
+  getPodLabels,
+  getAppAnnotations,
+  mergeData,
+} from '../../utils/resource-label-utils';
 import { createService, createRoute, dryRunOpt } from '../../utils/shared-submit-utils';
 import { AppResources } from '../edit-application/edit-application-types';
 import {
@@ -78,8 +83,7 @@ export const createOrUpdateImageStream = (
       annotations: defaultAnnotations,
     },
   };
-
-  const imageStream = _.merge({}, originalImageStream || {}, newImageStream);
+  const imageStream = mergeData(originalImageStream, newImageStream);
 
   return verb === 'update'
     ? k8sUpdate(ImageStreamModel, imageStream)
@@ -206,7 +210,7 @@ export const createOrUpdateBuildConfig = (
     },
   };
 
-  const buildConfig = _.merge({}, originalBuildConfig || {}, newBuildConfig);
+  const buildConfig = mergeData(originalBuildConfig, newBuildConfig);
 
   return verb === 'update'
     ? k8sUpdate(BuildConfigModel, buildConfig)
@@ -292,8 +296,7 @@ export const createOrUpdateDeployment = (
       },
     },
   };
-
-  const deployment = _.merge({}, originalDeployment || {}, newDeployment);
+  const deployment = mergeData(originalDeployment, newDeployment);
 
   return verb === 'update'
     ? k8sUpdate(DeploymentModel, deployment)
@@ -380,8 +383,7 @@ export const createOrUpdateDeploymentConfig = (
       ],
     },
   };
-
-  const deploymentConfig = _.merge({}, originalDeploymentConfig || {}, newDeploymentConfig);
+  const deploymentConfig = mergeData(originalDeploymentConfig, newDeploymentConfig);
 
   return verb === 'update'
     ? k8sUpdate(DeploymentConfigModel, deploymentConfig)

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -1,3 +1,6 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import * as _ from 'lodash';
+
 export const getAppLabels = (
   name: string,
   application?: string,
@@ -39,4 +42,13 @@ export const getPodLabels = (name: string) => {
     app: name,
     deploymentconfig: name,
   };
+};
+
+export const mergeData = (originalResource: K8sResourceKind, newResource: K8sResourceKind) => {
+  const mergedData = _.merge({}, originalResource || {}, newResource);
+  mergedData.metadata.labels = newResource.metadata.labels;
+  if (mergedData.spec?.template?.metadata?.labels) {
+    mergedData.spec.template.metadata.labels = newResource.spec?.template?.metadata?.labels;
+  }
+  return mergedData;
 };

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { GitImportFormData, DeployImageFormData } from '../components/import/import-types';
-import { getAppLabels, getPodLabels, getAppAnnotations } from './resource-label-utils';
+import { getAppLabels, getPodLabels, getAppAnnotations, mergeData } from './resource-label-utils';
 import { makePortName } from './imagestream-utils';
 
 export const annotations = {
@@ -68,7 +68,7 @@ export const createService = (
     },
   };
 
-  const service = _.merge({}, originalService || {}, newService);
+  const service = mergeData(originalService, newService);
 
   return service;
 };
@@ -141,7 +141,7 @@ export const createRoute = (
     },
   };
 
-  const route = _.merge({}, originalRoute || {}, newRoute);
+  const route = mergeData(originalRoute, newRoute);
 
   return route;
 };

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -11,12 +11,11 @@ import {
   EventSourceCamelModel,
   EventSourceKafkaModel,
 } from '@console/knative-plugin';
-import { getAppLabels } from '@console/dev-console/src/utils/resource-label-utils';
+import { getAppLabels, mergeData } from '@console/dev-console/src/utils/resource-label-utils';
 import {
   DeployImageFormData,
   GitImportFormData,
 } from '@console/dev-console/src/components/import/import-types';
-import * as _ from 'lodash';
 
 export const getKnativeServiceDepResource = (
   formData: GitImportFormData | DeployImageFormData,
@@ -122,7 +121,7 @@ export const getKnativeServiceDepResource = (
     },
   };
 
-  const knativeDeployResource = _.merge({}, originalKnativeService || {}, newKnativeDeployResource);
+  const knativeDeployResource = mergeData(originalKnativeService || {}, newKnativeDeployResource);
 
   return knativeDeployResource;
 };


### PR DESCRIPTION
Fixes the issue:
https://issues.redhat.com/browse/ODC-3034

Analysis/Root Cause:
When a node is unassigned from an application the `part-of` label is not added in the list of labels. As a result, when this new resource is merged with the old resource it considers all the attributes present in the old resource and simply adds/updates the properties, present in the new resource, to the old one.

Solution:
lodash's merge is removed and spread operator is being used to merge the resources

GIF:
![unassign-node](https://user-images.githubusercontent.com/22490998/74668110-8bdd4800-51ca-11ea-864a-2280b078fb51.gif)

Browser conformance:
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
