### PR TITLE
Bug 1803213: Update collapsed groups in topology to match designs

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
@@ -13,7 +13,6 @@ import {
 } from '@console/topology';
 import NodeShadows, { NODE_SHADOW_FILTER_ID_HOVER, NODE_SHADOW_FILTER_ID } from '../NodeShadows';
 import useSearchFilter from '../../filters/useSearchFilter';
-import ResourceKindsInfo from '../nodes/ResourceKindsInfo';
 import GroupNode from '../nodes/GroupNode';
 
 export type HelmReleaseNodeProps = {
@@ -55,9 +54,12 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({ element, onSelect, se
         rx="5"
         ry="5"
       />
-      <GroupNode kind="HelmRelease" title={element.getLabel()} typeIconClass="icon-helm">
-        <ResourceKindsInfo groupResources={element.getData().groupResources} />
-      </GroupNode>
+      <GroupNode
+        kind="HelmRelease"
+        element={element}
+        typeIconClass="icon-helm"
+        groupResources={element.getData().groupResources}
+      />
     </g>
   );
 };

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/ApplicationNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/ApplicationNode.tsx
@@ -18,7 +18,6 @@ import useSearchFilter from '../../filters/useSearchFilter';
 import NodeShadows, { NODE_SHADOW_FILTER_ID, NODE_SHADOW_FILTER_ID_HOVER } from '../NodeShadows';
 import { getTopologyResourceObject } from '../../topology-utils';
 import GroupNode from './GroupNode';
-import ResourceKindsInfo from './ResourceKindsInfo';
 import { ApplicationModel } from '../../../../models';
 
 type ApplicationGroupProps = {
@@ -83,9 +82,11 @@ const ApplicationNode: React.FC<ApplicationGroupProps> = ({
         rx="5"
         ry="5"
       />
-      <GroupNode title={element.getLabel()} kind={ApplicationModel.kind}>
-        <ResourceKindsInfo groupResources={element.getData().groupResources} />
-      </GroupNode>
+      <GroupNode
+        element={element}
+        kind={ApplicationModel.kind}
+        groupResources={element.getData().groupResources}
+      />
     </g>
   );
 };

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/GroupNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/GroupNode.tsx
@@ -5,33 +5,44 @@ import {
   shouldTruncate,
   TruncateOptions,
 } from '@console/internal/components/utils';
-import { useSize, useHover } from '@console/topology';
+import { Node, useSize, useHover } from '@console/topology';
 import SvgResourceIcon from './ResourceIcon';
 import SvgCircledIcon from '../../../svg/SvgCircledIcon';
 
 import './GroupNode.scss';
+import { TopologyDataObject } from '../../topology-types';
+import ResourceKindsInfo from './ResourceKindsInfo';
 
 const TOP_MARGIN = 20;
 const LEFT_MARGIN = 20;
 const TEXT_MARGIN = 10;
-const CONTENT_MARGIN = 40;
 
 const truncateOptions: TruncateOptions = {
   length: 35,
 };
 
 type GroupNodeProps = {
-  title: string;
+  element: Node;
   kind?: string;
+  emptyValue?: React.ReactNode;
+  groupResources?: TopologyDataObject;
   children?: React.ReactNode;
   typeIconClass?: string;
 };
 
-const GroupNode: React.FC<GroupNodeProps> = ({ children, kind, title, typeIconClass }) => {
+const GroupNode: React.FC<GroupNodeProps> = ({
+  element,
+  groupResources,
+  children,
+  kind,
+  emptyValue,
+  typeIconClass,
+}) => {
   const [textHover, textHoverRef] = useHover();
   const [iconSize, iconRef] = useSize([kind]);
   const iconWidth = iconSize ? iconSize.width : 0;
   const iconHeight = iconSize ? iconSize.height : 0;
+  const title = element.getLabel();
   return (
     <>
       {typeIconClass && (
@@ -44,7 +55,7 @@ const GroupNode: React.FC<GroupNodeProps> = ({ children, kind, title, typeIconCl
           iconClass={typeIconClass}
         />
       )}
-      <SvgResourceIcon ref={iconRef} x={TOP_MARGIN} y={LEFT_MARGIN} kind={kind} leftJustified />
+      <SvgResourceIcon ref={iconRef} x={LEFT_MARGIN} y={TOP_MARGIN - 2} kind={kind} leftJustified />
       {title && (
         <Tooltip
           content={title}
@@ -64,12 +75,16 @@ const GroupNode: React.FC<GroupNodeProps> = ({ children, kind, title, typeIconCl
           </text>
         </Tooltip>
       )}
-      {children && (
-        <g
-          transform={`translate(${LEFT_MARGIN + iconWidth}, ${TOP_MARGIN +
-            iconHeight +
-            CONTENT_MARGIN})`}
-        >
+      {(children || groupResources || emptyValue) && (
+        <g transform={`translate(${LEFT_MARGIN}, ${TOP_MARGIN + iconHeight})`}>
+          {(groupResources || emptyValue) && (
+            <ResourceKindsInfo
+              groupResources={groupResources}
+              emptyValue={emptyValue}
+              width={element.getBounds().width - LEFT_MARGIN}
+              height={element.getBounds().height - TOP_MARGIN - iconHeight}
+            />
+          )}
           {children}
         </g>
       )}

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceNode.tsx
@@ -19,7 +19,6 @@ import { nodeDragSourceSpec } from '../../componentUtils';
 import { TYPE_KNATIVE_SERVICE } from '../../const';
 import NodeShadows, { NODE_SHADOW_FILTER_ID, NODE_SHADOW_FILTER_ID_HOVER } from '../NodeShadows';
 import GroupNode from './GroupNode';
-import ResourceKindsInfo from './ResourceKindsInfo';
 
 type KnativeServiceNodeProps = {
   element: Node;
@@ -97,12 +96,13 @@ const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
         rx="5"
         ry="5"
       />
-      <GroupNode kind={kind} title={element.getLabel()} typeIconClass="icon-knative">
-        <ResourceKindsInfo
-          groupResources={element.getData().groupResources}
-          emptyKind="Revisions"
-        />
-      </GroupNode>
+      <GroupNode
+        kind={kind}
+        element={element}
+        typeIconClass="icon-knative"
+        groupResources={element.getData().groupResources}
+        emptyValue="No Revisions"
+      />
     </g>
   );
 };

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceNode.tsx
@@ -16,7 +16,6 @@ import { nodeDragSourceSpec } from '../../componentUtils';
 import { TYPE_OPERATOR_BACKED_SERVICE } from '../../const';
 import NodeShadows, { NODE_SHADOW_FILTER_ID, NODE_SHADOW_FILTER_ID_HOVER } from '../NodeShadows';
 import GroupNode from './GroupNode';
-import ResourceKindsInfo from './ResourceKindsInfo';
 
 export type OperatorBackedServiceNodeProps = {
   element: Node;
@@ -65,11 +64,10 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
       />
       <GroupNode
         kind={kind}
-        title={element.getLabel()}
+        element={element}
+        groupResources={element.getData().groupResources}
         typeIconClass={element.getData().data.builderImage}
-      >
-        <ResourceKindsInfo groupResources={element.getData().groupResources} />
-      </GroupNode>
+      />
     </g>
   );
 };

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/ResourceKindsInfo.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/ResourceKindsInfo.scss
@@ -1,0 +1,29 @@
+.odc-resource-kinds-info {
+  padding: var(--pf-global--spacer--md) var(--pf-global--spacer--md) var(--pf-global--spacer--md) 0;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+
+  &__table {
+    width: 100%;
+    td {
+      padding-bottom: var(--pf-global--spacer--sm);
+      padding-right: var(--pf-global--spacer--sm);
+      &:last-of-type {
+        padding-right: 0;
+      }
+    }
+  }
+
+  &__resource-icon {
+    width: 1%;
+    .co-m-resource-icon {
+      font-size: 80%;
+      margin-right: 0;
+    }
+  }
+  &__count {
+    text-align: end;
+    width: 1%;
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -693,7 +693,7 @@ export const topologyModelFromDataModel = (
       data.groupResources = d.children && d.children.map((id) => dataModel.topology[id]);
       return {
         width: 300,
-        height: 100,
+        height: d.type === TYPE_KNATIVE_SERVICE ? 100 : 180,
         id: d.id,
         type: d.type,
         label: dataModel.topology[d.id].name,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2946

**Analysis / Root cause**: 
Collapsed groups showed only text for kind and used only the resource kind string to determine the value.

**Solution Description**: 
Update the collapsed group component to show badges for each resource kind, find the correct kind model based on the objects being shown.

** Sample Screen Shots **
![image](https://user-images.githubusercontent.com/11633780/74561506-aac3ac00-4f36-11ea-9900-dcf3045b6727.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @serenamarie125 @Veethika @openshift/team-devconsole-ux 