### PR TITLE
Bug 1798858:  follow on code cleanup

### DIFF
--- a/frontend/packages/console-shared/src/components/status/Status.tsx
+++ b/frontend/packages/console-shared/src/components/status/Status.tsx
@@ -71,7 +71,6 @@ export const Status: React.FC<StatusProps> = ({ status, title, children, iconOnl
     case 'Bound':
     case 'Complete':
     case 'Completed':
-    case 'Copied':
     case 'Created':
     case 'Enabled':
     case 'Succeeded':


### PR DESCRIPTION
The `Copied` case is not needed as that is a `status.reason` status, which is not needed as we no longer display it.