### PR TITLE
Bug 1801847: Monitoring Dashboards: Fix bar chart labels and fix `row` panels

### DIFF
--- a/frontend/public/components/graphs/bar.tsx
+++ b/frontend/public/components/graphs/bar.tsx
@@ -21,6 +21,7 @@ const DEFAULT_BAR_WIDTH = 10;
 const PADDING_RATIO = 1 / 3;
 
 export const BarChart: React.FC<BarChartProps> = ({
+  barSpacing = 15,
   barWidth = DEFAULT_BAR_WIDTH,
   title,
   query,
@@ -36,7 +37,7 @@ export const BarChart: React.FC<BarChartProps> = ({
   const maxHorizontalPadding = PADDING_RATIO * width;
 
   const padding = {
-    bottom: 15,
+    bottom: barSpacing,
     left: 0,
     right: Math.min(100, maxHorizontalPadding),
     top: 0,
@@ -82,10 +83,12 @@ export const Bar: React.FC<BarProps> = ({
   humanize = humanizeNumber,
   metric,
   namespace,
+  barSpacing,
   barWidth,
   theme,
   query,
   title,
+  LabelComponent,
 }) => {
   const [response, , loading] = usePrometheusPoll({
     endpoint: PrometheusEndpoint.QUERY,
@@ -99,9 +102,11 @@ export const Bar: React.FC<BarProps> = ({
       title={title}
       query={query}
       data={data}
+      barSpacing={barSpacing}
       barWidth={barWidth}
       theme={theme}
       loading={loading}
+      LabelComponent={LabelComponent}
     />
   );
 };
@@ -113,6 +118,7 @@ type LabelComponentProps = {
 
 type BarChartProps = {
   LabelComponent?: React.ComponentType<LabelComponentProps>;
+  barSpacing?: number;
   barWidth?: number;
   query?: string;
   theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
@@ -123,9 +129,11 @@ type BarChartProps = {
 };
 
 type BarProps = {
+  LabelComponent?: React.ComponentType<LabelComponentProps>;
   humanize?: Humanize;
   metric: string;
   namespace?: string;
+  barSpacing?: number;
   barWidth?: number;
   query: string;
   theme?: any; // TODO figure out the best way to import VictoryThemeDefinition

--- a/frontend/public/components/monitoring/dashboards/bar-chart.tsx
+++ b/frontend/public/components/monitoring/dashboards/bar-chart.tsx
@@ -1,7 +1,12 @@
+import * as _ from 'lodash-es';
 import * as React from 'react';
 
 import { Bar } from '../../graphs';
 
-const BarChart: React.FC<{ query: string }> = ({ query }) => <Bar query={query} />;
+const Label = ({ metric }) => <>{_.values(metric).join()}</>;
+
+const BarChart: React.FC<{ query: string }> = ({ query }) => (
+  <Bar barSpacing={5} barWidth={8} query={query} LabelComponent={Label} />
+);
 
 export default BarChart;

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -240,13 +240,6 @@ const CardBody_: React.FC<CardBodyProps> = ({ panel, pollInterval, timespan, var
           timespan={timespan}
         />
       )}
-      {panel.type === 'row' && !_.isEmpty(panel.panels) && (
-        <div className="row">
-          {_.map(panel.panels, (p) => (
-            <Card key={p.id} panel={p} pollInterval={pollInterval} timespan={timespan} />
-          ))}
-        </div>
-      )}
       {panel.type === 'singlestat' && (
         <SingleStat panel={panel} pollInterval={pollInterval} query={queries[0]} />
       )}
@@ -261,6 +254,16 @@ const CardBody = connect(({ UI }: RootState) => ({
 }))(CardBody_);
 
 const Card: React.FC<CardProps> = ({ panel, pollInterval, timespan }) => {
+  if (panel.type === 'row') {
+    return (
+      <>
+        {_.map(panel.panels, (p) => (
+          <Card key={p.id} panel={p} pollInterval={pollInterval} timespan={timespan} />
+        ))}
+      </>
+    );
+  }
+
   // If panel doesn't specify a span, default to 12
   const panelSpan: number = _.get(panel, 'span', 12);
   // If panel.span is greater than 12, default colSpan to 12


### PR DESCRIPTION
Add bar chart labels.

Also fix a bug with handling the `row` panel type, which prevented some
of the `cluster-total` dashboard charts from rendering.

![screenshot](https://user-images.githubusercontent.com/460802/74588403-94edde00-503f-11ea-8a11-38e1d97af4c1.png)
