### PR TITLE
Bug 1803192: use monitoring config from openshift-config-managed namespace

### DIFF
--- a/frontend/public/actions/features.ts
+++ b/frontend/public/actions/features.ts
@@ -193,7 +193,7 @@ const detectCanCreateProject = (dispatch) =>
     },
   );
 
-const monitoringConfigMapPath = `${k8sBasePath}/api/v1/namespaces/openshift-monitoring/configmaps/sharing-config`;
+const monitoringConfigMapPath = `${k8sBasePath}/api/v1/namespaces/openshift-config-managed/configmaps/monitoring-shared-config`;
 const detectMonitoringURLs = (dispatch) =>
   coFetchJSON(monitoringConfigMapPath).then(
     (res) => {


### PR DESCRIPTION
This is the counter part of https://github.com/openshift/cluster-monitoring-operator/pull/654