### PR TITLE
Bug 1801983: Monitoring Dashboards: Fixes for variable handling and performance

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -28,6 +28,9 @@ export enum ActionType {
   SetCurrentLocation = 'setCurrentLocation',
   MonitoringDashboardsClearVariables = 'monitoringDashboardsClearVariables',
   MonitoringDashboardsPatchVariable = 'monitoringDashboardsPatchVariable',
+  MonitoringDashboardsSetPollInterval = 'monitoringDashboardsSetPollInterval',
+  MonitoringDashboardsSetTimespan = 'monitoringDashboardsSetTimespan',
+  MonitoringDashboardsVariableOptionsLoaded = 'monitoringDashboardsVariableOptionsLoaded',
   SetMonitoringData = 'setMonitoringData',
   ToggleMonitoringGraphs = 'monitoringToggleGraphs',
   NotificationDrawerToggleExpanded = 'notificationDrawerExpanded',
@@ -266,6 +269,12 @@ export const monitoringDashboardsClearVariables = () =>
   action(ActionType.MonitoringDashboardsClearVariables);
 export const monitoringDashboardsPatchVariable = (key: string, patch: any) =>
   action(ActionType.MonitoringDashboardsPatchVariable, { key, patch });
+export const monitoringDashboardsSetPollInterval = (pollInterval: number) =>
+  action(ActionType.MonitoringDashboardsSetPollInterval, { pollInterval });
+export const monitoringDashboardsSetTimespan = (timespan: number) =>
+  action(ActionType.MonitoringDashboardsSetTimespan, { timespan });
+export const monitoringDashboardsVariableOptionsLoaded = (key: string, newOptions: string[]) =>
+  action(ActionType.MonitoringDashboardsVariableOptionsLoaded, { key, newOptions });
 export const monitoringLoading = (key: 'alerts' | 'silences' | 'notificationAlerts') =>
   action(ActionType.SetMonitoringData, {
     key,
@@ -337,6 +346,9 @@ const uiActions = {
   updateOverviewFilterValue,
   monitoringDashboardsClearVariables,
   monitoringDashboardsPatchVariable,
+  monitoringDashboardsSetPollInterval,
+  monitoringDashboardsSetTimespan,
+  monitoringDashboardsVariableOptionsLoaded,
   monitoringLoading,
   monitoringLoaded,
   monitoringErrored,

--- a/frontend/public/components/graphs/bar.tsx
+++ b/frontend/public/components/graphs/bar.tsx
@@ -80,6 +80,7 @@ export const BarChart: React.FC<BarChartProps> = ({
 };
 
 export const Bar: React.FC<BarProps> = ({
+  delay = undefined,
   humanize = humanizeNumber,
   metric,
   namespace,
@@ -91,6 +92,7 @@ export const Bar: React.FC<BarProps> = ({
   LabelComponent,
 }) => {
   const [response, , loading] = usePrometheusPoll({
+    delay,
     endpoint: PrometheusEndpoint.QUERY,
     namespace,
     query,
@@ -130,6 +132,7 @@ type BarChartProps = {
 
 type BarProps = {
   LabelComponent?: React.ComponentType<LabelComponentProps>;
+  delay?: number;
   humanize?: Humanize;
   metric: string;
   namespace?: string;

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -11,6 +11,8 @@
 }
 
 .monitoring-dashboards__dropdown-wrap {
+  display: flex;
+  flex-direction: column;
   margin-right: 20px;
 }
 

--- a/frontend/public/components/monitoring/dashboards/bar-chart.tsx
+++ b/frontend/public/components/monitoring/dashboards/bar-chart.tsx
@@ -5,8 +5,12 @@ import { Bar } from '../../graphs';
 
 const Label = ({ metric }) => <>{_.values(metric).join()}</>;
 
-const BarChart: React.FC<{ query: string }> = ({ query }) => (
-  <Bar barSpacing={5} barWidth={8} query={query} LabelComponent={Label} />
+const BarChart: React.FC<BarChartProps> = ({ pollInterval, query }) => (
+  <Bar barSpacing={5} barWidth={8} delay={pollInterval} query={query} LabelComponent={Label} />
 );
 
+type BarChartProps = {
+  pollInterval: number;
+  query: string;
+};
 export default BarChart;

--- a/frontend/public/components/monitoring/dashboards/graph.tsx
+++ b/frontend/public/components/monitoring/dashboards/graph.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 
 import * as UIActions from '../../../actions/ui';
+import { RootState } from '../../../redux';
 import { FormatLegendLabel, PatchQuery, QueryBrowser } from '../query-browser';
 
 // Set the queries in Redux so that other components like the graph tooltip can access them
@@ -10,7 +11,7 @@ const patchAllQueries = (queries: string[], patchQuery: PatchQuery): void => {
   _.each(queries, (query, i) => patchQuery(i, { query }));
 };
 
-const Graph: React.FC<Props> = ({
+const Graph_: React.FC<Props> = ({
   formatLegendLabel,
   isStack,
   patchQuery,
@@ -30,6 +31,9 @@ const Graph: React.FC<Props> = ({
     />
   </div>
 );
+const Graph = connect(({ UI }: RootState) => ({
+  timespan: UI.getIn(['monitoringDashboards', 'timespan']),
+}))(Graph_);
 
 type Props = {
   formatLegendLabel?: FormatLegendLabel;


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1801983
Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1795401

Move `timespan` and `pollInterval` to Redux instead of passing as props
to all dashboard components. This means we can avoid updating some
components when these values are changed.

Convert dropdowns to use the PatternFly `Dropdown` component, which
fixes a bug where changing the dropdown value dynamically was not
reflected in the UI.

Avoid some dashboard card updates by eliminating some prop value changes
and some Redux value changes.

Fix bug where the `pollInterval` was not applied to bar charts

Fix typo in some `timespan` and `pollInterval` dropdown options.