### PR TITLE
Bug 1804056: Make Hostname required in the GitHub IDP create form

### DIFF
--- a/frontend/public/components/cluster-settings/github-idp-form.tsx
+++ b/frontend/public/components/cluster-settings/github-idp-form.tsx
@@ -193,7 +193,7 @@ export class AddGitHubPage extends PromiseComponent<{}, AddGitHubPageState> {
             />
           </div>
           <div className="form-group">
-            <label className="control-label" htmlFor="hostname">
+            <label className="control-label co-required" htmlFor="hostname">
               Hostname
             </label>
             <input
@@ -203,6 +203,7 @@ export class AddGitHubPage extends PromiseComponent<{}, AddGitHubPageState> {
               value={hostname}
               id="hostname"
               aria-describedby="idp-hostname-help"
+              required
             />
             <p className="help-block" id="idp-hostname-help">
               Optional domain for use with a hosted instance of GitHub Enterprise.


### PR DESCRIPTION
Also checked other forms and they should be OK

/assign @spadgett 