### PR TITLE
Bug 1804285: Fix for overlapping labels in topology nodes

### DIFF
--- a/frontend/packages/dev-console/src/actions/modify-application.ts
+++ b/frontend/packages/dev-console/src/actions/modify-application.ts
@@ -1,6 +1,7 @@
 import { KebabOption } from '@console/internal/components/utils';
 import { truncateMiddle } from '@console/internal/components/utils/truncate-middle';
 import { K8sResourceKind, K8sKind } from '@console/internal/module/k8s';
+import { RESOURCE_NAME_TRUNCATE_LENGTH } from '../const';
 import { editApplicationModal } from '../components/modals';
 
 export const ModifyApplication = (kind: K8sKind, obj: K8sResourceKind): KebabOption => {
@@ -25,7 +26,7 @@ export const ModifyApplication = (kind: K8sKind, obj: K8sResourceKind): KebabOpt
 
 export const EditApplication = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
   return {
-    label: `Edit ${truncateMiddle(obj.metadata.name)}`,
+    label: `Edit ${truncateMiddle(obj.metadata.name, { length: RESOURCE_NAME_TRUNCATE_LENGTH })}`,
     href: `/edit?name=${obj.metadata.name}&kind=${obj.kind || model.kind}`,
     accessReview: {
       group: model.apiGroup,

--- a/frontend/packages/dev-console/src/components/svg/SvgBoxedText.tsx
+++ b/frontend/packages/dev-console/src/components/svg/SvgBoxedText.tsx
@@ -7,6 +7,7 @@ import {
   createSvgIdUrl,
 } from '@console/topology';
 import { truncateMiddle } from '@console/internal/components/utils';
+import { RESOURCE_NAME_TRUNCATE_LENGTH } from '../../const';
 import SvgResourceIcon from '../topology/components/nodes/ResourceIcon';
 import SvgCircledIcon from './SvgCircledIcon';
 import SvgDropShadowFilter from './SvgDropShadowFilter';
@@ -47,7 +48,7 @@ const SvgBoxedText: React.FC<SvgBoxedTextProps> = ({
   typeIconPadding = 4,
   onMouseEnter,
   onMouseLeave,
-  truncate = 20,
+  truncate = RESOURCE_NAME_TRUNCATE_LENGTH,
   dragRef,
   ...other
 }) => {

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -2,6 +2,7 @@ import { FirehoseResult } from '@console/internal/components/utils';
 import { DeploymentKind, PodKind, EventKind } from '@console/internal/module/k8s';
 import { Model } from '@console/topology';
 import { TopologyDataModel, TopologyDataResources } from '../topology-types';
+import { NODE_HEIGHT, NODE_PADDING, NODE_WIDTH } from '../const';
 
 export const resources: TopologyDataResources = {
   replicationControllers: { loaded: true, loadError: '', data: [] },
@@ -2101,11 +2102,14 @@ export const dataModel: Model = {
   nodes: [
     {
       data: topologyDataModel.topology['e187afa2-53b1-406d-a619-cf9ff1468031'],
-      height: 104,
       id: 'e187afa2-53b1-406d-a619-cf9ff1468031',
       label: 'hello-openshift',
       type: 'workload',
-      width: 104,
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+      style: {
+        padding: NODE_PADDING,
+      },
     },
   ],
   edges: [],

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/ApplicationGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/ApplicationGroup.tsx
@@ -6,7 +6,7 @@ import {
   Node,
   PointTuple,
   NodeShape,
-  GroupStyle,
+  NodeStyle,
   maxPadding,
   observer,
   useCombineRefs,
@@ -80,7 +80,7 @@ const ApplicationGroup: React.FC<ApplicationGroupProps> = ({
   const [filtered] = useSearchFilter(element.getLabel());
 
   // cast to number and coerce
-  const padding = maxPadding(element.getStyle<GroupStyle>().padding);
+  const padding = maxPadding(element.getStyle<NodeStyle>().padding);
   const hullPadding = (point: PointWithSize | PointTuple) => (point[2] || 0) + padding;
 
   if (!droppable || !pathRef.current || !labelLocation.current) {

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/GroupNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/GroupNode.tsx
@@ -6,19 +6,20 @@ import {
   TruncateOptions,
 } from '@console/internal/components/utils';
 import { Node, useSize, useHover } from '@console/topology';
-import SvgResourceIcon from './ResourceIcon';
+import { RESOURCE_NAME_TRUNCATE_LENGTH } from '../../../../const';
 import SvgCircledIcon from '../../../svg/SvgCircledIcon';
+import { TopologyDataObject } from '../../topology-types';
+import SvgResourceIcon from './ResourceIcon';
+import ResourceKindsInfo from './ResourceKindsInfo';
 
 import './GroupNode.scss';
-import { TopologyDataObject } from '../../topology-types';
-import ResourceKindsInfo from './ResourceKindsInfo';
 
 const TOP_MARGIN = 20;
 const LEFT_MARGIN = 20;
 const TEXT_MARGIN = 10;
 
 const truncateOptions: TruncateOptions = {
-  length: 35,
+  length: RESOURCE_NAME_TRUNCATE_LENGTH,
 };
 
 type GroupNodeProps = {
@@ -61,7 +62,7 @@ const GroupNode: React.FC<GroupNodeProps> = ({
           content={title}
           position={TooltipPosition.top}
           trigger="manual"
-          isVisible={textHover && shouldTruncate(title, truncateOptions)}
+          isVisible={textHover && shouldTruncate(title)}
         >
           <text
             ref={textHoverRef}

--- a/frontend/packages/dev-console/src/components/topology/const.ts
+++ b/frontend/packages/dev-console/src/components/topology/const.ts
@@ -16,3 +16,22 @@ export const TYPE_OPERATOR_BACKED_SERVICE = 'operator-backed-service';
 export const TYPE_OPERATOR_WORKLOAD = 'operator-workload';
 export const TYPE_TRAFFIC_CONNECTOR = 'traffic-connector';
 export const LAST_TOPOLOGY_VIEW_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-topology-view`;
+
+const DEFAULT_NODE_PAD = 20;
+const DEFAULT_GROUP_PAD = 40;
+
+export const NODE_WIDTH = 104;
+export const NODE_HEIGHT = 104;
+export const NODE_PADDING = [0, DEFAULT_NODE_PAD];
+
+export const GROUP_WIDTH = 300;
+export const GROUP_HEIGHT = 180;
+export const GROUP_PADDING = [DEFAULT_GROUP_PAD];
+
+export const KNATIVE_GROUP_NODE_HEIGHT = 100;
+export const KNATIVE_GROUP_NODE_PADDING = [
+  DEFAULT_GROUP_PAD,
+  DEFAULT_GROUP_PAD,
+  DEFAULT_GROUP_PAD + 10,
+  DEFAULT_GROUP_PAD,
+];

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -57,6 +57,14 @@ import {
   TYPE_WORKLOAD,
   TYPE_CONNECTS_TO,
   TYPE_SERVICE_BINDING,
+  NODE_WIDTH,
+  NODE_HEIGHT,
+  NODE_PADDING,
+  GROUP_WIDTH,
+  GROUP_HEIGHT,
+  GROUP_PADDING,
+  KNATIVE_GROUP_NODE_HEIGHT,
+  KNATIVE_GROUP_NODE_PADDING,
 } from './const';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
 
@@ -697,8 +705,8 @@ export const topologyModelFromDataModel = (
       const data: TopologyDataObject = dataModel.topology[d.id] || dataObjectFromModel(d);
       data.groupResources = d.children && d.children.map((id) => dataModel.topology[id]);
       return {
-        width: 300,
-        height: d.type === TYPE_KNATIVE_SERVICE ? 100 : 180,
+        width: GROUP_WIDTH,
+        height: d.type === TYPE_KNATIVE_SERVICE ? KNATIVE_GROUP_NODE_HEIGHT : GROUP_HEIGHT,
         id: d.id,
         type: d.type,
         label: dataModel.topology[d.id].name,
@@ -711,17 +719,20 @@ export const topologyModelFromDataModel = (
         group: d.children?.length > 0,
         shape: NodeShape.rect,
         style: {
-          padding: [40, 50, 40, 40],
+          padding: d.type === TYPE_KNATIVE_SERVICE ? KNATIVE_GROUP_NODE_PADDING : GROUP_PADDING,
         },
       };
     }
     return {
-      width: 104,
-      height: 104,
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
       id: d.id,
       type: d.type,
       label: dataModel.topology[d.id].name,
       data: dataModel.topology[d.id],
+      style: {
+        padding: NODE_PADDING,
+      },
     };
   });
 
@@ -729,8 +740,8 @@ export const topologyModelFromDataModel = (
     const data: TopologyDataObject = dataModel.topology[d.id] || dataObjectFromModel(d);
     data.groupResources = d.nodes.map((id) => dataModel.topology[id]);
     return {
-      width: 300,
-      height: 180,
+      width: GROUP_WIDTH,
+      height: GROUP_HEIGHT,
       id: d.id,
       group: true,
       type: d.type,
@@ -742,7 +753,7 @@ export const topologyModelFromDataModel = (
       children: d.nodes,
       label: d.name,
       style: {
-        padding: 40,
+        padding: GROUP_PADDING,
       },
     };
   });

--- a/frontend/packages/dev-console/src/const.ts
+++ b/frontend/packages/dev-console/src/const.ts
@@ -9,3 +9,5 @@ export enum QUERY_PROPERTIES {
   /** For defining a contextual source of the redirect (ie, connect a new workload from this contextual source) */
   CONTEXT_SOURCE = 'contextSource',
 }
+
+export const RESOURCE_NAME_TRUNCATE_LENGTH = 13;

--- a/frontend/packages/topology/src/elements/BaseNode.ts
+++ b/frontend/packages/topology/src/elements/BaseNode.ts
@@ -7,7 +7,7 @@ import {
   isNode,
   isEdge,
   AnchorEnd,
-  GroupStyle,
+  NodeStyle,
   NodeShape,
   Edge,
   GraphElement,
@@ -59,7 +59,12 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
     let rect: Rect | undefined;
     children.forEach((c) => {
       if (isNode(c)) {
-        const b = c.getBounds();
+        const { padding } = c.getStyle<NodeStyle>();
+        let b = c.getBounds();
+        // Currently non-group nodes do not include their padding in the bounds
+        if (!c.isGroup() && padding) {
+          b = b.clone().padding(c.getStyle<NodeStyle>().padding);
+        }
         if (!rect) {
           rect = b.clone();
         } else {
@@ -72,7 +77,7 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
       rect = new Rect();
     }
 
-    const { padding } = this.getStyle<GroupStyle>();
+    const { padding } = this.getStyle<NodeStyle>();
 
     return rect.padding(padding);
   }

--- a/frontend/packages/topology/src/geom/Rect.ts
+++ b/frontend/packages/topology/src/geom/Rect.ts
@@ -104,14 +104,17 @@ export default class Rect implements Translatable {
     return this;
   }
 
-  expand(h: number, v: number): Rect {
-    this.x -= h;
-    this.width += h * 2;
+  expand(v: number, h: number): Rect {
     this.y -= v;
     this.height += v * 2;
+    this.x -= h;
+    this.width += h * 2;
     return this;
   }
 
+  //
+  // Padding Format:  [all], [vertical, horizontal], [top, horizontal, bottom], [top, right, bottom, left]
+  //
   padding(padding?: Padding): Rect {
     if (padding) {
       if (typeof padding === 'number') {
@@ -121,14 +124,14 @@ export default class Rect implements Translatable {
       } else if (padding.length === 2) {
         this.expand(padding[0], padding[1]);
       } else if (padding.length === 3) {
-        this.x -= padding[0];
-        this.width += padding[0] + padding[2];
-        this.height += padding[1];
+        this.y -= padding[0];
+        this.height += padding[0] + padding[2];
+        this.width += padding[1];
       } else if (padding.length === 4) {
-        this.x -= padding[0];
-        this.width += padding[0] + padding[2];
-        this.y -= padding[3];
-        this.height += padding[1] + padding[3];
+        this.y -= padding[0];
+        this.height += padding[0] + padding[2];
+        this.x -= padding[1];
+        this.width += padding[1] + padding[3];
       }
     }
     return this;

--- a/frontend/packages/topology/src/layouts/BaseLayout.ts
+++ b/frontend/packages/topology/src/layouts/BaseLayout.ts
@@ -11,6 +11,7 @@ import {
   ElementChildEventListener,
   NODE_COLLAPSE_CHANGE_EVENT,
   NodeCollapseChangeEventListener,
+  NodeStyle,
 } from '../types';
 import {
   leafNodeElements,
@@ -26,6 +27,7 @@ import {
 } from '../behavior';
 import { BaseEdge } from '../elements';
 import { ForceSimulation } from './ForceSimulation';
+import { Rect } from '../geom';
 
 class LayoutNode {
   protected readonly node: Node;
@@ -94,12 +96,24 @@ class LayoutNode {
     );
   }
 
+  get nodeBounds(): Rect {
+    const { padding } = this.node.getStyle<NodeStyle>();
+    // Currently non-group nodes do not include their padding in the bounds
+    if (!this.node.isGroup() && padding) {
+      return this.node
+        .getBounds()
+        .clone()
+        .padding(this.node.getStyle<NodeStyle>().padding);
+    }
+    return this.node.getBounds();
+  }
+
   get width(): number {
-    return this.node.getBounds().width + this.distance * 2;
+    return this.nodeBounds.width + this.distance * 2;
   }
 
   get height(): number {
-    return this.node.getBounds().height + this.distance * 2;
+    return this.nodeBounds.height + this.distance * 2;
   }
 
   update() {

--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -23,7 +23,7 @@ export enum AnchorEnd {
   both,
 }
 
-export type GroupStyle = {
+export type NodeStyle = {
   padding?: Padding;
 };
 

--- a/frontend/packages/topology/src/utils/element-utils.ts
+++ b/frontend/packages/topology/src/utils/element-utils.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { GraphElement, Node, isNode, isGraph, GroupStyle } from '../types';
+import { GraphElement, Node, isNode, isGraph, NodeStyle } from '../types';
 
 const groupNodeElements = (nodes: GraphElement[]): Node[] => {
   if (!_.size(nodes)) {
@@ -85,7 +85,7 @@ const getClosestVisibleParent = (node: Node): Node | null => {
 };
 
 const getElementPadding = (element: GraphElement): number => {
-  const stylePadding = element.getStyle<GroupStyle>().padding;
+  const stylePadding = element.getStyle<NodeStyle>().padding;
   if (!stylePadding) {
     return 0;
   }

--- a/frontend/packages/topology/stories/components/GroupHull.tsx
+++ b/frontend/packages/topology/stories/components/GroupHull.tsx
@@ -8,7 +8,7 @@ import {
   Layer,
   Node,
   PointTuple,
-  GroupStyle,
+  NodeStyle,
   NodeShape,
   WithDndDragProps,
   WithDndDropProps,
@@ -100,7 +100,7 @@ const GroupHull: React.FC<GroupHullProps> = ({
       return null;
     }
     // cast to number and coerce
-    const padding = maxPadding(element.getStyle<GroupStyle>().padding);
+    const padding = maxPadding(element.getStyle<NodeStyle>().padding);
     const hullPadding = (point: PointWithSize) => (point[2] || 0) + padding;
     // change the box only when not dragging
     pathRef.current = hullPath(hullPoints, hullPadding);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3035

**Analysis / Root cause**: 
The change was made to be 20 characters when we added the name of the resource to the edit action in the context menu so they would be consistent. 20 characters is what the rest of the Console UI uses and we wanted consistency.

**Solution Description**: 
Change both the nodes and the context menu to truncate at 16 characters.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @Veethika @serenamarie125 