### PR TITLE
Bug 1805330: Fix sorting by age in serverless services

### DIFF
--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionHeader.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionHeader.tsx
@@ -17,13 +17,13 @@ const RevisionHeader = () => {
     },
     {
       title: 'Service',
-      sortField: 'obj.metadata.labels["serving.knative.dev/service"]',
+      sortField: 'metadata.labels["serving.knative.dev/service"]',
       transforms: [sortable],
       props: { className: tableColumnClasses[2] },
     },
     {
       title: 'Age',
-      sortField: 'obj.metadata.creationTimestamp',
+      sortField: 'metadata.creationTimestamp',
       transforms: [sortable],
       props: { className: tableColumnClasses[3] },
     },

--- a/frontend/packages/knative-plugin/src/components/routes/RouteHeader.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RouteHeader.tsx
@@ -23,14 +23,12 @@ const RouteHeader = () => {
     },
     {
       title: 'Age',
-      sortField: 'age',
+      sortField: 'metadata.creationTimestamp',
       transforms: [sortable],
       props: { className: tableColumnClasses[3] },
     },
     {
       title: 'Conditions',
-      sortField: 'conditions',
-      transforms: [sortable],
       props: { className: tableColumnClasses[4] },
     },
     {

--- a/frontend/packages/knative-plugin/src/components/services/ServiceHeader.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceHeader.tsx
@@ -23,13 +23,13 @@ const ServiceHeader = () => {
     },
     {
       title: 'Generation',
-      sortField: 'obj.metadata.generation',
+      sortField: 'metadata.generation',
       transforms: [sortable],
       props: { className: tableColumnClasses[3] },
     },
     {
       title: 'Age',
-      sortField: 'obj.metadata.creationTimestamp',
+      sortField: 'metadata.creationTimestamp',
       transforms: [sortable],
       props: { className: tableColumnClasses[4] },
     },


### PR DESCRIPTION
Retrieving `obj.metadata.creationTimestamp` in the table component returned nothing (hence why sorting didn't work); only `metadata.creationTimestamp` is needed. This restores sorting behavior on serverless services.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1802429.