### PR TITLE
show solid border for topology shapes matching name filter

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmRelease.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmRelease.scss
@@ -19,12 +19,14 @@
   &.is-filtered &__bg {
     stroke: $filtered-stroke-color;
     stroke-width: $group-node-filtered-stroke-width;
+    stroke-dasharray: none;
   }
 
   &.is-selected &__bg {
     stroke: $selected-stroke-color;
     fill: $selected-fill-color;
     stroke-width: $group-node-selected-stroke-width;
+    stroke-dasharray: $group-node-stroke-dasharray;
   }
 }
 

--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
@@ -35,7 +35,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({ element, onSelect, se
     <g
       ref={refs}
       onClick={onSelect}
-      className={classNames('odc-knative-service', {
+      className={classNames('odc-helm-release', {
         'is-dragging': dragging,
         'is-selected': selected,
         'is-filtered': filtered,

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.scss
@@ -19,19 +19,23 @@
   &.is-filtered &__bg {
     stroke: $filtered-stroke-color;
     stroke-width: $group-node-filtered-stroke-width;
+    stroke-dasharray: none;
   }
   &.is-selected &__bg {
     fill: $selected-fill-color;
     stroke: $selected-stroke-color;
     stroke-width: $group-node-selected-stroke-width;
+    stroke-dasharray: $group-node-stroke-dasharray;
   }
   &.is-highlight &__bg {
     fill: $group-node-fill-color;
     stroke: $interactive-stroke-color;
+    stroke-dasharray: $group-node-stroke-dasharray;
   }
   &.is-dropTarget &__bg {
     fill: $interactive-fill-color;
     stroke: $interactive-stroke-color;
+    stroke-dasharray: $group-node-stroke-dasharray;
   }
 }
 

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.scss
@@ -19,12 +19,14 @@
   &.is-filtered &__bg {
     stroke: $filtered-stroke-color;
     stroke-width: $group-node-filtered-stroke-width;
+    stroke-dasharray: none;
   }
 
   &.is-selected &__bg {
     fill: $selected-fill-color;
     stroke: $selected-stroke-color;
     stroke-width: $group-node-selected-stroke-width;
+    stroke-dasharray: $group-node-stroke-dasharray;
   }
 }
 


### PR DESCRIPTION
**Fixes**: 
Fixes https://issues.redhat.com/browse/ODC-3076

**Analysis / Root cause**: 
Knative service, helm group, and operator backed groups have a dashed border. Even when the node name matches the filter, the dashed border remained and changed to orange.

**Solution Description**: 
Any node which matches the name filter now has a solid border.

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/14068621/74784588-3d858300-5276-11ea-91fe-a672d200a67e.png)
![image](https://user-images.githubusercontent.com/14068621/74784651-6279f600-5276-11ea-81e4-6bbf6817f42e.png)
![image](https://user-images.githubusercontent.com/14068621/74784663-6a399a80-5276-11ea-9cd8-105f16eddf7b.png)
![image](https://user-images.githubusercontent.com/14068621/74784690-77ef2000-5276-11ea-98e9-d5dd8cfb972e.png)
![image](https://user-images.githubusercontent.com/14068621/74784803-be447f00-5276-11ea-9e2c-3ecf80e56d67.png)
![image](https://user-images.githubusercontent.com/14068621/74784941-13809080-5277-11ea-8a6e-3ad1c4bd7269.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @andrewballantyne @openshift/team-devconsole-ux 