### PR TITLE
check formatting of all Go sources

### DIFF
--- a/test-backend.sh
+++ b/test-backend.sh
@@ -21,7 +21,7 @@ export GOFLAGS="-mod=vendor"
 COVER=${COVER:-"-cover"}
 
 TESTABLE="pkg/auth pkg/proxy pkg/server pkg/helm/actions pkg/helm/handlers"
-FORMATTABLE="${TESTABLE} cmd/bridge pkg/version"
+FORMATTABLE="cmd pkg"
 
 # user has not provided PKG override
 if [ -z "${PKG}" ]; then


### PR DESCRIPTION
Previously, the check was made only on sources in selected folders, leaving a chance
to merge incorrectly formatted sources from unchecked folders.