### PR TITLE
Bug 1804684: remove multiple badge from PipelineRuns

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunsResourceList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/PipelineRunsResourceList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { getBadgeFromType } from '@console/shared';
 import { ListPage } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { PipelineRunModel } from '../../models';
@@ -16,6 +17,7 @@ const PipelineRunsResourceList: React.FC<Omit<
       kind={referenceForModel(PipelineRunModel)}
       ListComponent={PipelineRunsList}
       rowFilters={runFilters}
+      badge={getBadgeFromType(PipelineRunModel.badge)}
     />
   );
 };

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Button } from '@patternfly/react-core';
 
-import { KEYBOARD_SHORTCUTS, getBadgeFromType } from '@console/shared';
+import { KEYBOARD_SHORTCUTS } from '@console/shared';
 import { filterList } from '../../actions/k8s';
 import { CheckBoxes, storagePrefix } from '../row-filter';
 import { ErrorPage404, ErrorBoundaryFallback } from '../error';
@@ -434,7 +434,7 @@ export const ListPage = withFallback((props) => {
       showTitle={showTitle}
       textFilter={textFilter}
       title={title}
-      badge={badge || getBadgeFromType(ko.badge)}
+      badge={badge}
     />
   );
 }, ErrorBoundaryFallback);


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-3102
**Analysis / Root cause:**
Two dev preview badges on Pipeline Run Page

**Solution Description:**
removed extra badge from the Page

![Screenshot from 2020-02-19 17-53-52](https://user-images.githubusercontent.com/9278015/74834158-e1d3fc00-5340-11ea-8535-4bac3cf4e564.png)

![Screenshot from 2020-02-19 17-55-02](https://user-images.githubusercontent.com/9278015/74834208-fe703400-5340-11ea-927b-cc10eb44d3ca.png)


**Browser conformance:**

- [x]  Chrome
- [ ]  Firefox
- [ ]  Safari
- [ ]  Edge