### PR TITLE
Bug 1803857: do not show ip if no launcher pod exist

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -71,11 +71,11 @@ export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
           </DetailItem>
           <DetailItem
             title="IP Address"
-            error={!ipAddrs}
+            error={!launcherPod || !ipAddrs}
             isLoading={!vmiLike}
             valueClassName="co-select-to-copy"
           >
-            {ipAddrs}
+            {launcherPod && ipAddrs}
           </DetailItem>
         </DetailsBody>
       </DashboardCardBody>

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -187,9 +187,9 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
       <VMDetailsItem
         title="IP Address"
         idValue={prefixedID(id, 'ip-addresses')}
-        isNotAvail={!ipAddrs}
+        isNotAvail={!launcherPod || !ipAddrs}
       >
-        {ipAddrs}
+        {launcherPod && ipAddrs}
       </VMDetailsItem>
 
       <VMDetailsItem title="Node" idValue={prefixedID(id, 'node')} isNotAvail={!nodeName}>


### PR DESCRIPTION
When a VM is stopped, the Details and Overview pages keep displaying IP address. Instead, there should be 'Not Available'.

Screenshot fixed:
![Peek 2020-02-19 15-08](https://user-images.githubusercontent.com/2181522/74837284-d2958400-5329-11ea-9550-24b26d037366.gif)
