### PR TITLE
Bug 1804728: Relax table panel `transform` check

### DIFF
--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -324,7 +324,7 @@ const CardBody_: React.FC<CardBodyProps> = ({ panel, pollInterval, variables }) 
       {panel.type === 'singlestat' && (
         <SingleStat panel={panel} pollInterval={pollInterval} query={queries[0]} />
       )}
-      {panel.type === 'table' && panel.transform === 'table' && (
+      {panel.type === 'table' && (
         <Table panel={panel} pollInterval={pollInterval} queries={queries} />
       )}
     </>


### PR DESCRIPTION
Not all panels have the transform property set, although they render fine.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1804728
/assign @rhamilto 

![Screen Shot 2020-02-19 at 9 13 39 AM](https://user-images.githubusercontent.com/1167259/74842591-a9103480-52f8-11ea-9c3d-21ed99497019.png)
