### PR TITLE
Bug 1804827: Improve monitoring dashboards table layout

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -16,6 +16,14 @@
   margin-right: 20px;
 }
 
+.monitoring-dashboards__label-column-header {
+  // Set a min-width to avoid aggressive wrapping, which makes the table much taller.
+  min-width: 175px;
+  @media (min-width: $screen-lg-min) {
+    min-width: 225px;
+  }
+}
+
 .monitoring-dashboards__options {
   display: flex;
   float: right;

--- a/frontend/public/components/monitoring/dashboards/format.tsx
+++ b/frontend/public/components/monitoring/dashboards/format.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import {
   humanizeBinaryBytes,
   humanizeDecimalBytesPerSec,
+  humanizeNumber,
   humanizePacketsPerSec,
 } from '../../utils';
 
@@ -29,8 +30,6 @@ export const formatNumber = (s: string, decimals = 2, format = 'short'): React.R
     case 'short':
     // fall through
     default:
-      return Intl.NumberFormat(undefined, {
-        maximumFractionDigits: decimals,
-      }).format(value);
+      return humanizeNumber(value).string;
   }
 };


### PR DESCRIPTION
* Make label columns wider to avoid wrapping
* Order label columns first
* Humanize `short` numbers
* Use horizontal scrolling even at mobile to reduce table height

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1804827

/assign @rhamilto 

![Screen Shot 2020-02-19 at 11 21 06 AM](https://user-images.githubusercontent.com/1167259/74858451-5d1eb900-5313-11ea-825a-4ea492fedaa8.png)

![Screen Shot 2020-02-19 at 12 31 06 PM](https://user-images.githubusercontent.com/1167259/74858738-d0282f80-5313-11ea-9e53-6a520c17b050.png)
