### PR TITLE
Bug 1798851: Dont set the targetNamespace when changing update channel

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -513,8 +513,6 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
               onChange={(e) => {
                 setUpdateChannel(e.currentTarget.value);
                 setInstallMode(null);
-                setTargetNamespace(null);
-                setCannotResolve(false);
               }}
             />
           </div>


### PR DESCRIPTION
We have been setting the state of the `ListDropdown` component from its previous state. We should be using the nextProps instead.

/assign @spadgett 