### PR TITLE
Bug 1804852: Pipeline params & resources forms submission formik issue 

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { FieldArray } from 'formik';
+import { FieldArray, useFormikContext, FormikValues } from 'formik';
 import { FormGroup } from '@patternfly/react-core';
-import { SecondaryStatus } from '@console/shared';
+import { SecondaryStatus, useFormikValidationFix } from '@console/shared';
 import { MultiColumnFieldProps } from '../field-types';
 import MultiColumnFieldHeader from './MultiColumnFieldHeader';
 import MultiColumnFieldRow from './MultiColumnFieldRow';
@@ -23,52 +23,56 @@ const MultiColumnField: React.FC<MultiColumnFieldProps> = ({
   disableDeleteRow,
   disableAddRow,
   toolTip,
-}) => (
-  <FieldArray
-    name={name}
-    render={({ push, remove, form }) => {
-      const fieldValue = _.get(form.values, name, []);
-      return (
-        <FormGroup
-          fieldId={`form-multi-column-input-${name.replace(/\./g, '-')}-field`}
-          label={label}
-          helperText={helpText}
-          isRequired={required}
-        >
-          {fieldValue.length < 1 ? (
-            emptyMessage && (
-              <div className="odc-multi-column-field__empty-message">
-                <SecondaryStatus status={emptyMessage} />
-              </div>
-            )
-          ) : (
-            <MultiColumnFieldHeader headers={headers} />
-          )}
-          {fieldValue.length > 0 &&
-            fieldValue.map((value, index) => (
-              <MultiColumnFieldRow
-                key={`${index.toString()}`} // There is no other usable value for key prop in this case.
-                name={name}
-                toolTip={toolTip}
-                rowIndex={index}
-                onDelete={() => remove(index)}
-                isReadOnly={isReadOnly}
-                disableDeleteRow={disableDeleteRow}
-              >
-                {children}
-              </MultiColumnFieldRow>
-            ))}
-          {!isReadOnly && (
-            <MultiColumnFieldFooter
-              disableAddRow={disableAddRow}
-              addLabel={addLabel}
-              onAdd={() => push(emptyValues)}
-            />
-          )}
-        </FormGroup>
-      );
-    }}
-  />
-);
+}) => {
+  const { values } = useFormikContext<FormikValues>();
+  const fieldValue = _.get(values, name, []);
+  useFormikValidationFix(fieldValue);
+  return (
+    <FieldArray
+      name={name}
+      render={({ push, remove }) => {
+        return (
+          <FormGroup
+            fieldId={`form-multi-column-input-${name.replace(/\./g, '-')}-field`}
+            label={label}
+            helperText={helpText}
+            isRequired={required}
+          >
+            {fieldValue.length < 1 ? (
+              emptyMessage && (
+                <div className="odc-multi-column-field__empty-message">
+                  <SecondaryStatus status={emptyMessage} />
+                </div>
+              )
+            ) : (
+              <MultiColumnFieldHeader headers={headers} />
+            )}
+            {fieldValue.length > 0 &&
+              fieldValue.map((value, index) => (
+                <MultiColumnFieldRow
+                  key={`${index.toString()}`} // There is no other usable value for key prop in this case.
+                  name={name}
+                  toolTip={toolTip}
+                  rowIndex={index}
+                  onDelete={() => remove(index)}
+                  isReadOnly={isReadOnly}
+                  disableDeleteRow={disableDeleteRow}
+                >
+                  {children}
+                </MultiColumnFieldRow>
+              ))}
+            {!isReadOnly && (
+              <MultiColumnFieldFooter
+                disableAddRow={disableAddRow}
+                addLabel={addLabel}
+                onAdd={() => push(emptyValues)}
+              />
+            )}
+          </FormGroup>
+        );
+      }}
+    />
+  );
+};
 
 export default MultiColumnField;

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineParametersForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineParametersForm.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Form } from '@patternfly/react-core';
-import { FormikProps, FormikValues } from 'formik';
+import { FormikProps, FormikValues, getIn } from 'formik';
 import { useAccessReview } from '@console/internal/components/utils';
 import { FormFooter } from '@console/shared';
 import PipelineParameters from './PipelineParameters';
@@ -36,7 +36,7 @@ const PipelineParametersForm: React.FC<PipelineParametersFormProps> = ({
             isSubmitting={isSubmitting}
             errorMessage={status && status.submitError}
             successMessage={status && !dirty && status.success}
-            disableSubmit={!dirty || !_.isEmpty(errors.parameters)}
+            disableSubmit={!dirty || !_.isEmpty(_.compact(getIn(errors, 'parameters')))}
             showAlert={dirty}
           />
         )}

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineResourcesForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineResourcesForm.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Form } from '@patternfly/react-core';
-import { FormikProps, FormikValues } from 'formik';
+import { FormikProps, FormikValues, getIn } from 'formik';
 import { useAccessReview } from '@console/internal/components/utils';
 import { FormFooter } from '@console/shared';
 import PipelineResources from './PipelineResources';
@@ -36,7 +36,7 @@ const PipelineResourcesForm: React.FC<PipelineResourcesFormProps> = ({
             isSubmitting={isSubmitting}
             errorMessage={status && status.submitError}
             successMessage={status && !dirty && status.success}
-            disableSubmit={!dirty || !_.isEmpty(errors.resources)}
+            disableSubmit={!dirty || !_.isEmpty(_.compact(getIn(errors, 'resources')))}
             showAlert={dirty}
           />
         )}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/pipelineForm-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/pipelineForm-validation-utils.ts
@@ -14,7 +14,7 @@ export const parametersValidationSchema = yup.object().shape({
     yup.object().shape({
       name: yup.string().required('Required'),
       description: yup.string(),
-      default: yup.string().required('Required'),
+      default: yup.string(),
     }),
   ),
 });


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-2881

**Problem:**
After the formik upgrade, error objects has null values in it, which causes the submit button to disable when the fields are edited.
![new-pipeline-2 · Details · OKD](https://user-images.githubusercontent.com/9964343/74861631-b36e1500-5370-11ea-9043-4a5377148e65.png)

**Solution:**
Skip the null values in the error object while validating for enabling/disabling the submit button

![AwesomeScreenshot-2020-2-19-1582135721876](https://user-images.githubusercontent.com/9964343/74861994-5161df80-5371-11ea-9fb4-ee707be788e8.gif)

cc: @debsmita1 @rohitkrai03 