### PR TITLE
support multiple service binding request backingServiceSelectors

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/service-binding-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/service-binding-test-data.ts
@@ -1,4 +1,5 @@
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { DeploymentKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { TopologyDataResources } from '../topology-types';
 
 export const serviceBindingRequest: K8sResourceKind = {
   data: {
@@ -23,5 +24,151 @@ export const serviceBindingRequest: K8sResourceKind = {
       },
       detectBindingResources: true,
     },
+  },
+};
+
+export const sbrBackingServiceSelectors: Partial<TopologyDataResources> = {
+  deployments: {
+    loaded: true,
+    loadError: null,
+    data: [
+      {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          name: 'app',
+          uid: 'uid-app',
+        },
+      } as DeploymentKind,
+      {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          name: 'db-1',
+          uid: 'uid-db-1',
+          ownerReferences: [
+            {
+              apiVersion: 'db/v1alpha1',
+              kind: 'Database',
+              name: 'db-demo1',
+              uid: 'uid-db-demo1',
+            },
+          ],
+        },
+      } as DeploymentKind,
+      {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          name: 'db-2',
+          uid: 'uid-db-2',
+          ownerReferences: [
+            {
+              apiVersion: 'postgresql.baiju.dev/v1alpha1',
+              kind: 'Database',
+              name: 'db-demo2',
+              uid: 'uid-db-demo2',
+            },
+          ],
+        },
+      } as DeploymentKind,
+    ],
+  },
+  serviceBindingRequests: {
+    loaded: true,
+    loadError: null,
+    data: [
+      {
+        apiVersion: 'apps.openshift.io/v1alpha1',
+        kind: 'ServiceBindingRequest',
+        metadata: {
+          name: 'sbr-1',
+        },
+        spec: {
+          applicationSelector: {
+            resourceRef: 'app',
+            group: 'apps',
+            version: 'v1',
+            resource: 'deployments',
+          },
+          backingServiceSelectors: [
+            {
+              group: 'postgresql.baiju.dev',
+              version: 'v1alpha1',
+              kind: 'Database',
+              resourceRef: 'db-demo1',
+            },
+            {
+              group: 'postgresql.baiju.dev',
+              version: 'v1alpha1',
+              kind: 'Database',
+              resourceRef: 'db-demo2',
+            },
+          ],
+          detectBindingResources: true,
+        },
+      },
+    ],
+  },
+};
+
+export const sbrBackingServiceSelector: Partial<TopologyDataResources> = {
+  deployments: {
+    loaded: true,
+    loadError: null,
+    data: [
+      {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          name: 'app',
+          uid: 'uid-app',
+        },
+      } as DeploymentKind,
+      {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+          name: 'db-1',
+          uid: 'uid-db-1',
+          ownerReferences: [
+            {
+              apiVersion: 'db/v1alpha1',
+              kind: 'Database',
+              name: 'db-demo1',
+              uid: 'uid-db-demo1',
+            },
+          ],
+        },
+      } as DeploymentKind,
+    ],
+  },
+  serviceBindingRequests: {
+    loaded: true,
+    loadError: null,
+    data: [
+      {
+        apiVersion: 'apps.openshift.io/v1alpha1',
+        kind: 'ServiceBindingRequest',
+        metadata: {
+          name: 'sbr-2',
+        },
+        spec: {
+          applicationSelector: {
+            resourceRef: 'app',
+            group: 'apps',
+            version: 'v1',
+            resource: 'deployments',
+          },
+          backingServiceSelector: {
+            group: 'postgresql.baiju.dev',
+            version: 'v1alpha1',
+            kind: 'Database',
+            resourceRef: 'db-demo1',
+          },
+          detectBindingResources: true,
+        },
+      },
+    ],
   },
 };

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
@@ -17,10 +17,16 @@ import {
   isHelmReleaseNode,
   getTopologyHelmReleaseGroupItem,
   getTrafficConnectors,
+  getTopologyEdgeItems,
 } from '../topology-utils';
 import { DEFAULT_TOPOLOGY_FILTERS } from '../redux/const';
 import { TopologyFilters } from '../filters/filter-utils';
-import { TYPE_HELM_RELEASE, TYPE_OPERATOR_BACKED_SERVICE, TYPE_TRAFFIC_CONNECTOR } from '../const';
+import {
+  TYPE_HELM_RELEASE,
+  TYPE_OPERATOR_BACKED_SERVICE,
+  TYPE_TRAFFIC_CONNECTOR,
+  TYPE_SERVICE_BINDING,
+} from '../const';
 import {
   resources,
   topologyData,
@@ -33,7 +39,11 @@ import {
   MockKialiGraphData,
 } from './topology-test-data';
 import { MockKnativeResources } from './topology-knative-test-data';
-import { serviceBindingRequest } from './service-binding-test-data';
+import {
+  serviceBindingRequest,
+  sbrBackingServiceSelector,
+  sbrBackingServiceSelectors,
+} from './service-binding-test-data';
 
 export function getTranformedTopologyData(
   mockData: TopologyDataResources,
@@ -444,6 +454,43 @@ describe('TopologyUtils ', () => {
     );
     expect(transformedData.graph.edges).toHaveLength(2);
     expect(transformedData.graph.edges[0].type).toEqual(TYPE_TRAFFIC_CONNECTOR);
+  });
+
+  it('should support single  binding service selectors', () => {
+    const testResources = sbrBackingServiceSelector.deployments.data;
+    const deployments = sbrBackingServiceSelector.deployments.data;
+    const sbrs = sbrBackingServiceSelector.serviceBindingRequests.data;
+    expect(getTopologyEdgeItems(deployments[0], testResources, sbrs)).toEqual([
+      {
+        id: `uid-app_uid-db-1`,
+        type: TYPE_SERVICE_BINDING,
+        source: 'uid-app',
+        target: 'uid-db-1',
+        data: { sbr: sbrs[0] },
+      },
+    ]);
+  });
+
+  it('should support multiple binding service selectors', () => {
+    const testResources = sbrBackingServiceSelectors.deployments.data;
+    const deployments = sbrBackingServiceSelectors.deployments.data;
+    const sbrs = sbrBackingServiceSelectors.serviceBindingRequests.data;
+    expect(getTopologyEdgeItems(deployments[0], testResources, sbrs)).toEqual([
+      {
+        id: `uid-app_uid-db-1`,
+        type: TYPE_SERVICE_BINDING,
+        source: 'uid-app',
+        target: 'uid-db-1',
+        data: { sbr: sbrs[0] },
+      },
+      {
+        id: `uid-app_uid-db-2`,
+        type: TYPE_SERVICE_BINDING,
+        source: 'uid-app',
+        target: 'uid-db-2',
+        data: { sbr: sbrs[0] },
+      },
+    ]);
   });
 });
 

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -301,33 +301,38 @@ export const getTopologyEdgeItems = (
   });
 
   _.forEach(edgesFromServiceBinding(dc, sbrs), (sbr) => {
-    // handles multiple edges
-    const targetNode = _.get(
-      _.find(resources, (deployment) => {
-        const targetFound =
-          _.get(deployment, 'metadata.ownerReferences[0].name') ===
-            sbr.spec.backingServiceSelector.resourceRef &&
-          _.get(deployment, 'metadata.ownerReferences[0].kind') ===
-            sbr.spec.backingServiceSelector.kind;
-        const appGroup = _.get(
-          deployment,
-          ['metadata', 'labels', 'app.kubernetes.io/part-of'],
-          null,
-        );
-        return targetFound && (!application || application === appGroup);
-      }),
-      ['metadata', 'uid'],
-    );
-    const uid = _.get(dc, ['metadata', 'uid']);
-    if (targetNode) {
-      edges.push({
-        id: `${uid}_${targetNode}`,
-        type: TYPE_SERVICE_BINDING,
-        source: uid,
-        target: targetNode,
-        data: { sbr },
-      });
-    }
+    // look for multiple backing services first in `backingServiceSelectors`
+    // followed by a fallback to the single reference in `backingServiceSelector`
+    _.forEach(sbr.spec.backingServiceSelectors || [sbr.spec.backingServiceSelector], (bss) => {
+      // handles multiple edges
+      const targetNode = _.get(
+        _.find(resources, (deployment) => {
+          const name = _.get(deployment, 'metadata.ownerReferences[0].name');
+          const kind = _.get(deployment, 'metadata.ownerReferences[0].kind');
+          const targetFound = bss.kind === kind && bss.resourceRef === name;
+          if (targetFound) {
+            const appGroup = _.get(
+              deployment,
+              ['metadata', 'labels', 'app.kubernetes.io/part-of'],
+              null,
+            );
+            return !application || application === appGroup;
+          }
+          return false;
+        }),
+        ['metadata', 'uid'],
+      );
+      const uid = _.get(dc, ['metadata', 'uid']);
+      if (targetNode) {
+        edges.push({
+          id: `${uid}_${targetNode}`,
+          type: TYPE_SERVICE_BINDING,
+          source: uid,
+          target: targetNode,
+          data: { sbr },
+        });
+      }
+    });
   });
 
   return edges;


### PR DESCRIPTION
**Fixes**: 
Fixes https://issues.redhat.com/browse/ODC-3119

**Analysis / Root cause**: 
ServiceBindingRequest is adding support for multiple backing service selectors.
See example:
https://github.com/redhat-developer/service-binding-operator/tree/master/examples/multiple_services

Old spec will be deprecated and removed in the future.

**Solution Description**: 
Added support for the new `spec.backingServiceSelectors` selectors.
Kept backward compatibility with `spec.backingServiceSelector`.

Solution first checks for new spec will fallback to old.

Added unit tests.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

cc @sbose78 @invincibleJai 
