### PR TITLE
Retrieve the list of Helm charts via chart repo proxy endpoint

### DIFF
--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -334,13 +334,11 @@ export const Catalog = connectToFlags<CatalogProps>(
   }, [loadTemplates, namespace]);
 
   React.useEffect(() => {
-    coFetch('https://redhat-developer.github.io/redhat-helm-charts/index.yaml').then(
-      async (res) => {
-        const yaml = await res.text();
-        const json = safeLoad(yaml);
-        setHelmCharts(json.entries);
-      },
-    );
+    coFetch('/api/helm/charts/index.yaml').then(async (res) => {
+      const yaml = await res.text();
+      const json = safeLoad(yaml);
+      setHelmCharts(json.entries);
+    });
   }, []);
 
   const error = templateError || projectTemplateError;

--- a/pkg/helm/chartproxy/config.go
+++ b/pkg/helm/chartproxy/config.go
@@ -27,7 +27,7 @@ func RegisterFlags(fs *flag.FlagSet) *config {
 
 	cfg := new(config)
 
-	fs.StringVar(&cfg.repoUrl, "helm-chart-repo-url", "https://redhat-developer.github.com/redhat-helm-charts", "Helm chart repository URL")
+	fs.StringVar(&cfg.repoUrl, "helm-chart-repo-url", "https://redhat-developer.github.io/redhat-helm-charts", "Helm chart repository URL")
 	fs.StringVar(&cfg.repoCaFile, "helm-chart-repo-ca-file", "", "CA bundle for Helm chart repository.")
 
 	return cfg

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -308,7 +308,8 @@ func (s *Server) HTTPHandler() http.Handler {
 
 	helmChartRepoProxy := proxy.NewProxy(s.HelmChartRepoProxyConfig)
 
-	handle(helmChartRepoProxyEndpoint, http.StripPrefix(
+	// Only proxy requests to chart repo index file
+	handle(helmChartRepoProxyEndpoint+"index.yaml", http.StripPrefix(
 		proxy.SingleJoiningSlash(s.BaseURL.Path, helmChartRepoProxyEndpoint),
 		http.HandlerFunc(helmChartRepoProxy.ServeHTTP)))
 


### PR DESCRIPTION
The reverse proxy obtained via httputil.NewSingleHostReverseProxy does not follow redirects,
and returns such requests to UI causing CORS issue, failing to load index.yaml from UI.

Our default repo redhat-developer.github.com redirects to redhat-developer.github.io and in order
to fix index.yaml loading, we started to use redhat-developer.github.io