### PR TITLE
Bug 1798644: Kubevirt dont show common template

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { navFactory } from '@console/internal/components/utils';
 import { DetailsPage } from '@console/internal/components/factory';
-import { PodModel } from '@console/internal/models';
+import { PodModel, TemplateModel } from '@console/internal/models';
 import { VMDisksFirehose } from '../vm-disks';
 import { VMNics } from '../vm-nics';
 import {
@@ -21,6 +21,7 @@ import { VMConsoleFirehose } from './vm-console';
 import { VMDetailsFirehose } from './vm-details';
 import { vmMenuActionsCreator } from './menu-actions';
 import { VMDashboard } from './vm-dashboard';
+import { TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM } from '../../constants/vm';
 
 export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProps> = (props) => {
   const { name, ns: namespace } = props.match.params;
@@ -83,6 +84,12 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
     }),
     getResource(PodModel, { namespace, prop: 'pods' }),
     getResource(VirtualMachineInstanceMigrationModel, { namespace, prop: 'migrations' }),
+    getResource(TemplateModel, {
+      isList: true,
+      namespace,
+      prop: 'templates',
+      matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM },
+    }),
   ];
 
   return (

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ResourceSummary, NodeLink, ResourceLink } from '@console/internal/components/utils';
-import { K8sKind, PodKind } from '@console/internal/module/k8s';
+import { K8sKind, PodKind, TemplateKind } from '@console/internal/module/k8s';
 import { getName, getNamespace, getNodeName } from '@console/shared';
 import { PodModel } from '@console/internal/models';
 import { VMKind, VMIKind } from '../../types';
@@ -12,7 +12,7 @@ import { DedicatedResourcesModal } from '../modals/dedicated-resources-modal/ded
 import { BootOrderModal } from '../modals/boot-order-modal/boot-order-modal';
 import VMStatusModal from '../modals/vm-status-modal/vm-status-modal';
 import { getDescription } from '../../selectors/selectors';
-import { getVMTemplateNamespacedName } from '../../selectors/vm-template/selectors';
+import { getVMTemplate } from '../../selectors/vm-template/selectors';
 import { getFlavorText } from '../flavor-text';
 import { EditButton } from '../edit-button';
 import { VMStatuses } from '../vm-status';
@@ -58,12 +58,13 @@ export const VMResourceSummary: React.FC<VMResourceSummaryProps> = ({
   vm,
   vmi,
   canUpdateVM,
+  templates,
   kindObj,
 }) => {
   const isVM = kindObj === VirtualMachineModel;
   const vmiLike = isVM ? vm : vmi;
 
-  const templateNamespacedName = getVMTemplateNamespacedName(vm);
+  const template = getVMTemplate(vm, templates);
   const id = getBasicID(vmiLike);
   const description = getDescription(vmiLike);
   const os = getOperatingSystemName(vmiLike) || getOperatingSystem(vmiLike);
@@ -89,12 +90,10 @@ export const VMResourceSummary: React.FC<VMResourceSummaryProps> = ({
       </VMDetailsItem>
 
       {isVM && (
-        <VMDetailsItem
-          title="Template"
-          idValue={prefixedID(id, 'template')}
-          isNotAvail={!templateNamespacedName}
-        >
-          {templateNamespacedName && <VMTemplateLink {...templateNamespacedName} />}
+        <VMDetailsItem title="Template" idValue={prefixedID(id, 'template')} isNotAvail={!template}>
+          {template && (
+            <VMTemplateLink name={getName(template)} namespace={getNamespace(template)} />
+          )}
         </VMDetailsItem>
       )}
     </ResourceSummary>
@@ -251,6 +250,7 @@ type VMResourceSummaryProps = {
   kindObj: K8sKind;
   vm?: VMKind;
   vmi?: VMIKind;
+  templates: TemplateKind[];
   canUpdateVM: boolean;
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { navFactory, HintBlock, ExternalLink } from '@console/internal/components/utils';
 import { DetailsPage } from '@console/internal/components/factory';
-import { PodModel } from '@console/internal/models';
+import { PodModel, TemplateModel } from '@console/internal/models';
 import { VMDisksFirehose } from '../vm-disks';
 import { VMNics } from '../vm-nics';
 import {
@@ -21,6 +21,7 @@ import { VMConsoleFirehose } from './vm-console';
 import { VMDetailsFirehose } from './vm-details';
 import { vmiMenuActionsCreator } from './menu-actions';
 import { VMDashboard } from './vm-dashboard';
+import { TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM } from '../../constants/vm';
 
 import './vmi-details-page.scss';
 
@@ -87,6 +88,12 @@ export const VirtualMachinesInstanceDetailsPage: React.FC<VirtualMachinesInstanc
     }),
     getResource(PodModel, { namespace, prop: 'pods' }),
     getResource(VirtualMachineInstanceMigrationModel, { namespace, prop: 'migrations' }),
+    getResource(TemplateModel, {
+      isList: true,
+      namespace,
+      prop: 'templates',
+      matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM },
+    }),
   ];
 
   return (

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-template/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-template/selectors.ts
@@ -27,7 +27,10 @@ export const getVMTemplateNamespacedName = (
   return name && namespace ? { name, namespace } : null;
 };
 
-const getVMTemplate = (vm: VMGenericLikeEntityKind, templates: TemplateKind[]): TemplateKind => {
+export const getVMTemplate = (
+  vm: VMGenericLikeEntityKind,
+  templates: TemplateKind[],
+): TemplateKind => {
   const namespacedName = getVMTemplateNamespacedName(vm);
   return namespacedName
     ? templates.find(


### PR DESCRIPTION
When a VM is created without using a template the common template used to create the VM is showing up under "Template" in the VM Details. This should only show the name of the VM that was used to create the VM from, otherwise it should state "no template used"

Screenshot:
before:
![OKD(1)](https://user-images.githubusercontent.com/2181522/74939580-d217ee80-53f8-11ea-8151-8693b9cff216.png)

after:
![OKD](https://user-images.githubusercontent.com/2181522/74939582-d3e1b200-53f8-11ea-87d9-17e7fc0c5494.png)
