### PR TITLE
Bug 1804049: Alertmanager - Prevent duplicate/same router label keys on Receiver forms

### DIFF
--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -295,9 +295,16 @@ describe('Alertmanager: Configuration', () => {
     await firstElementByTestID('label-name-0').sendKeys('abcd@#$R@T%'); // invalid chars
     expect(firstElementByTestID('invalid-label-name-error').isPresent()).toBe(true);
     await firstElementByTestID('label-name-0').clear();
+    expect(firstElementByTestID('duplicate-label-name-error').isPresent()).toBe(false);
     await firstElementByTestID('label-name-0').sendKeys('severity');
     expect(firstElementByTestID('invalid-label-name-error').isPresent()).toBe(false);
     await firstElementByTestID('label-value-0').sendKeys('warning');
+    await firstElementByTestID('add-routing-label').click();
+    await firstElementByTestID('label-name-1').sendKeys('severity');
+    await firstElementByTestID('label-value-1').sendKeys('warning');
+    expect(firstElementByTestID('duplicate-label-name-error').isPresent()).toBe(true);
+    await firstElementByTestID('remove-routing-label').click();
+    expect(firstElementByTestID('duplicate-label-name-error').isPresent()).toBe(false);
 
     await monitoringView.saveButton.click();
     await crudView.isLoaded();

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -327,3 +327,7 @@ $tooltip-background-color: #151515;
   padding-left: 4px;
   padding-right: 4px;
 }
+
+.co-routing-label-editor__error-message {
+  margin-top: -15px;
+}

--- a/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
@@ -231,11 +231,12 @@ const ReceiverBaseForm: React.FC<ReceiverBaseFormProps> = ({
   const [formValues, dispatchFormChange] = React.useReducer(formReducer, INITIAL_STATE);
   const SubForm = subformFactory(formValues.receiverType);
 
-  const isFormInvalid =
+  const isFormInvalid: boolean =
     !formValues.receiverName ||
     !formValues.receiverType ||
     SubForm.isFormInvalid(formValues) ||
-    !_.isEmpty(formValues.routeLabelFieldErrors);
+    !_.isEmpty(formValues.routeLabelFieldErrors) ||
+    formValues.routeLabelDuplicateNamesError;
 
   const save = (e) => {
     e.preventDefault();
@@ -523,7 +524,7 @@ type ReceiverBaseFormProps = {
   alertmanagerGlobals?: { [key: string]: any };
 };
 
-type RouteEditorLabel = {
+export type RouteEditorLabel = {
   name: string;
   value: string;
   isRegex: boolean;
@@ -539,7 +540,7 @@ type FormAction = {
 type FormState = {
   receiverType: string;
   routeLabels: any[];
-  [key: string]: string | any[];
+  [key: string]: string | any[] | any;
 };
 
 export type FormProps = {

--- a/frontend/public/components/monitoring/receiver-forms/routing-labels-editor.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/routing-labels-editor.tsx
@@ -5,11 +5,12 @@ import { MinusCircleIcon, PlusCircleIcon, InfoCircleIcon } from '@patternfly/rea
 import { Button, Tooltip } from '@patternfly/react-core';
 
 import { ExternalLink, SectionHeading } from '../../utils';
+import { RouteEditorLabel } from './alert-manager-receiver-forms';
 
 const DEFAULT_RECEIVER_LABEL = 'All (default receiver)';
 const labelNamePattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
-export const getRouteLabelFieldErrors = (labels) => {
+export const getRouteLabelFieldErrors = (labels: RouteEditorLabel[]) => {
   const routeLabelFieldErrors = {};
   labels.forEach((label, i) => {
     if (label.name && !label.name.match(labelNamePattern)) {
@@ -17,6 +18,11 @@ export const getRouteLabelFieldErrors = (labels) => {
     }
   });
   return routeLabelFieldErrors;
+};
+
+const hasDuplicateNames = (labels: RouteEditorLabel[]): boolean => {
+  const names = _.map(labels, (label) => label.name);
+  return names.length !== _.uniq(names).length;
 };
 
 export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultReceiver }) => {
@@ -28,6 +34,7 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
       payload: {
         routeLabels: labels,
         routeLabelFieldErrors: getRouteLabelFieldErrors(labels),
+        routeLabelDuplicateNamesError: hasDuplicateNames(labels),
       },
     });
   };
@@ -55,6 +62,7 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
       type: 'setFormValues',
       payload: {
         routeLabels: labels,
+        routeLabelDuplicateNamesError: hasDuplicateNames(labels),
       },
     });
   };
@@ -178,6 +186,7 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
                 aria-label="Remove Route Label"
                 isDisabled={!isDefaultReceiver && formValues.routeLabels.length <= 1}
                 variant="plain"
+                data-test-id="remove-routing-label"
               >
                 <MinusCircleIcon />
               </Button>
@@ -185,12 +194,32 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
           </div>
         );
       })}
+      <div
+        className={classNames(
+          'form-group',
+          {
+            'has-error': formValues.routeLabelDuplicateNamesError,
+          },
+          'co-routing-label-editor__error-message',
+        )}
+      >
+        <span className="help-block">
+          {formValues.routeLabelDuplicateNamesError ? (
+            <span data-test-id="duplicate-label-name-error">
+              Routing label names must be unique.
+            </span>
+          ) : (
+            ''
+          )}
+        </span>
+      </div>
       {!isDefaultReceiver && (
         <Button
           className="pf-m-link--align-left"
           onClick={addRoutingLabel}
           type="button"
           variant="link"
+          data-test-id="add-routing-label"
         >
           <PlusCircleIcon className="co-icon-space-r" />
           Add Label


### PR DESCRIPTION
Added validation to check for duplicate routing label keys/names.

![image](https://user-images.githubusercontent.com/12733153/74941873-c78e3280-53c1-11ea-9379-5b89fb93724c.png)
