### PR TITLE
[WIP] Add support for Skipped Pipeline Task Status

### DIFF
--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -321,6 +321,8 @@ export const getTaskStatus = (pipelinerun: PipelineRun, pipeline: Pipeline): Tas
         taskStatus[runStatus.Failed]++;
       } else if (status === 'Cancelled') {
         taskStatus[runStatus.Cancelled]++;
+      } else if (status === 'Skipped') {
+        taskStatus[runStatus.Skipped]++;
       } else {
         taskStatus[runStatus.Pending]++;
       }

--- a/frontend/packages/dev-console/src/utils/pipeline-filter-reducer.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-filter-reducer.ts
@@ -8,6 +8,11 @@ export const pipelineRunStatus = (pipelineRun): string => {
   if (isCancelled) {
     return 'Cancelled';
   }
+  const isSkipped = conditions.find((c) => c.reason === 'ConditionCheckFailed');
+  if (isSkipped) {
+    return 'Skipped';
+  }
+
   if (conditions.length === 0) return null;
 
   const condition = conditions.find((c) => c.type === 'Succeeded');


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-3144

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
There is a problem with our Add-flow pipelines, they do not properly address all resource types (Deployments, DeploymentConfigs, and Knative). We need to be able to setup the Pipelines to handle that configuration and filter that on the add flow with the appropriate UX changes. All of this is to say, it's going to become less desirable to back port that change due to what we would need to do to make it happen.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
@siamaksade informed us that there is a Condition resource kind for Pipelines. By using this we can successfully "skip" tasks that do deployments specific to the resource type. Essentially allowing us to fully support all 3 in parallel, and just ignore the 2 resource types that don't match. This causes the UI to show an error... but we can easily get around that with this change.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![image](https://user-images.githubusercontent.com/8126518/74959803-3fb42280-53d9-11ea-9756-c1b3c76ff849.png)

@openshift/team-devconsole-ux 

**Unit test coverage report**: 
<!-- Attach test coverage report -->
- [ ] todo - we have test coverage on this method, we should be able to test this

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
TODO, coming soon.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

<!-- /kind <bug | cleanup | feature > -->
/kind bug