### PR TITLE
Bug 1807275: fix pod text for daemon workload

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodRing.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRing.tsx
@@ -70,7 +70,7 @@ const PodRing: React.FC<PodRingProps> = ({
   const resourceObj = rc || obj;
   const { title, subTitle, titleComponent, subTitleComponent } = podRingLabel(
     resourceObj,
-    isScalingAllowed,
+    obj.kind,
     pods,
   );
 

--- a/frontend/packages/console-shared/src/utils/__mocks__/pod-utils-test-data.ts
+++ b/frontend/packages/console-shared/src/utils/__mocks__/pod-utils-test-data.ts
@@ -72,6 +72,28 @@ export const deployment: K8sResourceKind = {
   },
 };
 
+export const daemonSet: K8sResourceKind = {
+  kind: 'DaemonSet',
+  metadata: {
+    name: 'node',
+    namespace: 'testproject1',
+    uid: '02f680df-680f-b69e-5254003f9382',
+    labels: {
+      app: 'nodejs',
+      'serving.knative.dev/configuration': 'mocks',
+    },
+    annotations: {
+      'app.openshift.io/vcs-uri': 'https://github.com/redhat-developer/topology-example',
+      'app.openshift.io/vcs-ref': 'master',
+      'idling.alpha.openshift.io/idled-at': 'mock-data',
+    },
+  },
+  status: {
+    currentNumberScheduled: 2,
+    desiredNumberScheduled: 2,
+  },
+};
+
 export const mockPod: K8sResourceKind = {
   kind: 'Pod',
   metadata: {

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
@@ -5,54 +5,127 @@ import { RevisionModel } from '@console/knative-plugin';
 import * as utils from '../pod-utils';
 import { usePodScalingAccessStatus, podRingLabel } from '../pod-ring-utils';
 import { testHook } from '../../test-utils/hooks-utils';
-import { mockPod } from '../__mocks__/pod-utils-test-data';
+import {
+  deployment,
+  deploymentConfig,
+  statefulSets,
+  daemonSet,
+  mockPod,
+} from '../__mocks__/pod-utils-test-data';
 import { ExtPodKind } from '../../types';
 
 describe('pod-ring utils:', () => {
   it('should return proper title, subtitle for podRingLabel', () => {
-    const podWithReplicas = _.set(mockPod, 'spec.replicas', 2);
-    const mockData = _.set(podWithReplicas, 'status.availableReplicas', 2);
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).title).toEqual(2);
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitle).toEqual('pods');
+    const deploymentWithReplicas = _.set(_.cloneDeep(deployment), 'spec.replicas', 2);
+    const mockDeploymentData = _.set(deploymentWithReplicas, 'status.readyReplicas', 2);
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).title,
+    ).toEqual('2');
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).subTitle,
+    ).toEqual('pods');
+  });
+
+  it('should return title scaled to 0, empty subtitle for podRingLabel when no pods exist', () => {
+    const mockDeploymentData = _.set(_.cloneDeep(deployment), 'spec.replicas', 0);
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).title,
+    ).toEqual('Scaled to 0');
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).subTitle,
+    ).toEqual('');
   });
 
   it('should return title 0, subtitle scaling to 2 and no titleComponent, subtitleComponent for podRingLabel when scaling from 1 to 2 pods', () => {
-    const podWithReplicas = _.set(_.cloneDeep(mockPod), 'spec.replicas', 2);
-    const mockData = _.set(podWithReplicas, 'status.availableReplicas', 1);
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).title).toEqual(1);
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitle).toEqual('scaling to 2');
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).titleComponent).toEqual(
-      undefined,
-    );
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitleComponent).toEqual(
-      undefined,
-    );
+    const deploymentWithReplicas = _.set(_.cloneDeep(deployment), 'spec.replicas', 2);
+    const mockDeploymentData = _.set(deploymentWithReplicas, 'status.readyReplicas', 1);
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).title,
+    ).toEqual('1');
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).subTitle,
+    ).toEqual('scaling to 2');
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind])
+        .titleComponent,
+    ).toEqual(undefined);
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind])
+        .subTitleComponent,
+    ).toEqual(undefined);
   });
 
   it('should return title 0, subtitle scaling to 1 and no titleComponent, subtitleComponent for podRingLabel when the first pod is being created', () => {
-    const podWithReplicas = _.set(mockPod, 'spec.replicas', 1);
-    const mockData = _.set(podWithReplicas, 'status.availableReplicas', 0);
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).title).toEqual('0');
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitle).toEqual('scaling to 1');
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).titleComponent).toEqual(
-      undefined,
-    );
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitleComponent).toEqual(
-      undefined,
-    );
+    const deploymentWithReplicas = _.set(_.cloneDeep(deployment), 'spec.replicas', 1);
+    const mockDeploymentData = _.set(deploymentWithReplicas, 'status.readyReplicas', 0);
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).title,
+    ).toEqual('0');
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind]).subTitle,
+    ).toEqual('scaling to 1');
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind])
+        .titleComponent,
+    ).toEqual(undefined);
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind])
+        .subTitleComponent,
+    ).toEqual(undefined);
   });
 
   it('should return title 0, subtitle scaling to 1 and no titleComponent, subtitleComponent for podRingLabel when pod count is 1 and status is pending', () => {
-    const podWithReplicas = _.set(_.cloneDeep(mockPod), 'spec.replicas', 1);
-    const mockData = _.set(podWithReplicas, 'status.phase', 'Pending');
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).title).toEqual('0');
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitle).toEqual('scaling to 1');
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).titleComponent).toEqual(
-      undefined,
-    );
-    expect(podRingLabel(mockData, true, [mockData as ExtPodKind]).subTitleComponent).toEqual(
-      undefined,
-    );
+    const mockDeploymentData = _.set(_.cloneDeep(deployment), 'spec.replicas', 1);
+    const mockPodData = _.set(_.cloneDeep(mockPod), 'status.phase', 'Pending');
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPodData as ExtPodKind]).title,
+    ).toEqual('0');
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPodData as ExtPodKind])
+        .subTitle,
+    ).toEqual('scaling to 1');
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPodData as ExtPodKind])
+        .titleComponent,
+    ).toEqual(undefined);
+    expect(
+      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPodData as ExtPodKind])
+        .subTitleComponent,
+    ).toEqual(undefined);
+  });
+
+  it('should return proper title, subtitle for podRingLabel for Daemon sets', () => {
+    const mockDaemonData = _.cloneDeep(daemonSet);
+    expect(
+      podRingLabel(mockDaemonData, mockDaemonData.kind, [mockPod as ExtPodKind]).title,
+    ).toEqual('2');
+    expect(
+      podRingLabel(mockDaemonData, mockDaemonData.kind, [mockPod as ExtPodKind]).subTitle,
+    ).toEqual('pods');
+  });
+
+  it('should return proper title, subtitle for podRingLabel for Deployment Config', () => {
+    const deploymentConfigWithReplicas = _.set(_.cloneDeep(deploymentConfig), 'spec.replicas', 2);
+    const mockDeploymentConfigData = _.set(deploymentConfigWithReplicas, 'status.readyReplicas', 2);
+    expect(
+      podRingLabel(mockDeploymentConfigData, mockDeploymentConfigData.kind, [mockPod as ExtPodKind])
+        .title,
+    ).toEqual('2');
+    expect(
+      podRingLabel(mockDeploymentConfigData, mockDeploymentConfigData.kind, [mockPod as ExtPodKind])
+        .subTitle,
+    ).toEqual('pods');
+  });
+
+  it('should return proper title, subtitle for podRingLabel for Stateful sets', () => {
+    const statefulSetWithReplicas = _.set(_.cloneDeep(statefulSets), 'spec.replicas', 2);
+    const mockStatefulSetData = _.set(statefulSetWithReplicas, 'status.readyReplicas', 2);
+    expect(
+      podRingLabel(mockStatefulSetData, mockStatefulSetData.kind, [mockPod as ExtPodKind]).title,
+    ).toEqual('2');
+    expect(
+      podRingLabel(mockStatefulSetData, mockStatefulSetData.kind, [mockPod as ExtPodKind]).subTitle,
+    ).toEqual('pods');
   });
 });
 

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/PodSet.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/PodSet.tsx
@@ -1,13 +1,6 @@
 import * as React from 'react';
 import { get } from 'lodash';
-import {
-  PodStatus,
-  calculateRadius,
-  getPodData,
-  podRingLabel,
-  usePodScalingAccessStatus,
-} from '@console/shared';
-import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import { PodStatus, calculateRadius, getPodData, podRingLabel } from '@console/shared';
 import { DonutStatusData } from '../../topology-types';
 
 interface PodSetProps {
@@ -50,16 +43,11 @@ const PodSet: React.FC<PodSetProps> = ({ size, data, x = 0, y = 0, showPodCount 
     data.previous,
     data.isRollingOut,
   );
-  const accessAllowed = usePodScalingAccessStatus(
-    data.dc,
-    modelFor(referenceFor(data.dc)),
-    get(data, ['current', 'pods'], []),
-    true,
-  );
+
   const obj = get(data, ['current', 'obj'], null) || data.dc;
   const { title, subTitle, titleComponent, subTitleComponent } = podRingLabel(
     obj,
-    accessAllowed,
+    data.dc.kind,
     data?.pods,
   );
   return (


### PR DESCRIPTION
Analysis / Root cause:
Pod ring text shows wrong text for daemon sets. It shows scaling subtitle even though pods are up.

Solution Description:
Pod ring text should show correct pod ring text for all workloads.

This PR solves issue https://issues.redhat.com/browse/ODC-3145
The issue of pod text overlapping visible in the screenshot is being tracked in https://issues.redhat.com/browse/ODC-3036

Screens-
cc @openshift/team-devconsole-ux 

![daemon-pod-text](https://user-images.githubusercontent.com/38663217/74973581-ac670580-5449-11ea-9eaf-2efcf5387824.png)
