### PR TITLE
Bug 1805835: Changes to monitoring dashboard dropdown behavior

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -3,7 +3,11 @@
 }
 
 .monitoring-dashboards__dropdown-button {
-  width: 140px;
+  max-width: 280px !important; // allow truncation
+  min-width: 100px;
+  @media (min-width: $screen-sm-min) {
+    max-width: 100% !important;
+  }
 }
 
 .monitoring-dashboards__dropdown-title {
@@ -22,6 +26,12 @@
   @media (min-width: $screen-lg-min) {
     min-width: 225px;
   }
+}
+
+.monitoring-dashboards__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
 }
 
 .monitoring-dashboards__options {
@@ -78,6 +88,7 @@
 
 .monitoring-dashboards__variables {
   display: flex;
+  flex-wrap: wrap;
 }
 
 .query-browser__toggle-graph {

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -468,11 +468,13 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({
         <title>Metrics Dashboards</title>
       </Helmet>
       <div className="co-m-nav-title co-m-nav-title--detail">
-        <div className="monitoring-dashboards__options">
-          <TimespanDropdown />
-          <PollIntervalDropdown />
+        <div className="monitoring-dashboards__header">
+          <h1 className="co-m-pane__heading">Dashboards</h1>
+          <div className="monitoring-dashboards__options">
+            <TimespanDropdown />
+            <PollIntervalDropdown />
+          </div>
         </div>
-        <h1 className="co-m-pane__heading">Dashboards</h1>
         <div className="monitoring-dashboards__variables">
           <VariableDropdown
             items={boardItems}


### PR DESCRIPTION
- Enable time range and interval to wrap beneath `<h1>`
- Remove set width from dropdowns so that long selected item text isn't aggressively truncated.
- and enable truncation at mobile widths

addresses https://bugzilla.redhat.com/show_bug.cgi?id=1804447

![Screen Shot 2020-02-18 at 4 01 13 PM](https://user-images.githubusercontent.com/1874151/74978248-34bdba00-53fa-11ea-8d8a-aea0892e9cc7.png)
<img width="359" alt="Screen Shot 2020-02-20 at 11 38 34 AM" src="https://user-images.githubusercontent.com/1874151/74978289-47d08a00-53fa-11ea-81cc-4c0cab48c8a6.png">

----
**After**
<img width="730" alt="Screen Shot 2020-02-20 at 3 28 16 PM" src="https://user-images.githubusercontent.com/1874151/74978324-5b7bf080-53fa-11ea-8ad9-674812fe0f24.png">
<img width="314" alt="Screen Shot 2020-02-20 at 3 27 35 PM" src="https://user-images.githubusercontent.com/1874151/74978325-5c148700-53fa-11ea-8f46-93241d836e8f.png">


