### PR TITLE
Change helm grouping strategy in topology based on release manifest

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -1,3 +1,5 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
 export interface HelmRelease {
   name: string;
   namespace: string;
@@ -35,6 +37,16 @@ export interface HelmChart {
   values: object;
   lock?: object;
   schema?: string;
+}
+
+export interface HelmReleaseResourcesData {
+  releaseName: string;
+  chartIcon: string;
+  manifestResources: K8sResourceKind[];
+}
+
+export interface HelmReleaseResourcesMap {
+  [name: string]: HelmReleaseResourcesData;
 }
 
 export enum HelmReleaseStatus {

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -9,7 +9,7 @@ import { RootState } from '@console/internal/redux';
 import { safeLoadAll } from 'js-yaml';
 import { ServiceBindingRequestModel } from '../../models';
 import { TopologyFilters, getTopologyFilters } from './filters/filter-utils';
-import { allowedResources, transformTopologyData } from './topology-utils';
+import { allowedResources, transformTopologyData, getHelmReleaseKey } from './topology-utils';
 import { TopologyDataModel, TopologyDataResources, TrafficData } from './topology-types';
 import trafficConnectorMock from './__mocks__/traffic-connector.mock';
 import { HelmRelease, HelmReleaseResourcesMap } from '../helm/helm-types';
@@ -117,7 +117,7 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
         const manifestResources: K8sResourceKind[] = safeLoadAll(release.manifest);
 
         manifestResources.forEach((resource) => {
-          const resourceKindName = `${resource.kind}---${resource.metadata.name}`;
+          const resourceKindName = getHelmReleaseKey(resource);
           if (!acc.hasOwnProperty(resourceKindName)) {
             acc[resourceKindName] = {
               releaseName: release.name,

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -1,15 +1,18 @@
 import * as React from 'react';
-import { Firehose } from '@console/internal/components/utils';
 import { connect } from 'react-redux';
+import { Firehose } from '@console/internal/components/utils';
+import { coFetchJSON } from '@console/internal/co-fetch';
 import * as plugins from '@console/internal/plugins';
 import { getResourceList } from '@console/shared';
-import { referenceForModel } from '@console/internal/module/k8s';
+import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
 import { RootState } from '@console/internal/redux';
+import { safeLoadAll } from 'js-yaml';
 import { ServiceBindingRequestModel } from '../../models';
 import { TopologyFilters, getTopologyFilters } from './filters/filter-utils';
 import { allowedResources, transformTopologyData } from './topology-utils';
 import { TopologyDataModel, TopologyDataResources, TrafficData } from './topology-types';
 import trafficConnectorMock from './__mocks__/traffic-connector.mock';
+import { HelmRelease, HelmReleaseResourcesMap } from '../helm/helm-types';
 
 export interface RenderProps {
   data?: TopologyDataModel;
@@ -34,6 +37,7 @@ export interface ControllerProps {
   serviceBinding: boolean;
   topologyFilters: TopologyFilters;
   trafficData?: TrafficData;
+  helmResourcesMap?: HelmReleaseResourcesMap;
 }
 
 export interface TopologyDataControllerProps extends StateProps {
@@ -56,6 +60,7 @@ const Controller: React.FC<ControllerProps> = ({
   serviceBinding,
   topologyFilters,
   trafficData,
+  helmResourcesMap,
 }) =>
   render({
     loaded,
@@ -70,6 +75,7 @@ const Controller: React.FC<ControllerProps> = ({
           utils,
           topologyFilters,
           trafficData,
+          helmResourcesMap,
         )
       : null,
   });
@@ -83,6 +89,7 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
   serviceBinding,
   filters,
 }) => {
+  const [helmResourcesMap, setHelmResourcesMap] = React.useState();
   const { resources, utils } = getResourceList(namespace, resourceList);
   if (serviceBinding) {
     resources.push({
@@ -93,6 +100,46 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
       optional: true,
     });
   }
+
+  React.useEffect(() => {
+    let ignore = false;
+
+    const fetchHelmReleases = async () => {
+      let releases: HelmRelease[];
+      try {
+        releases = await coFetchJSON(`/api/helm/releases?ns=${namespace}`);
+      } catch {
+        return;
+      }
+      if (ignore) return;
+
+      const releaseResourcesMap = releases.reduce((acc, release) => {
+        const manifestResources: K8sResourceKind[] = safeLoadAll(release.manifest);
+
+        manifestResources.forEach((resource) => {
+          const resourceKindName = `${resource.kind}---${resource.metadata.name}`;
+          if (!acc.hasOwnProperty(resourceKindName)) {
+            acc[resourceKindName] = {
+              releaseName: release.name,
+              chartIcon: release.chart.metadata.icon,
+              manifestResources,
+            };
+          }
+        });
+
+        return acc;
+      }, {});
+
+      setHelmResourcesMap(releaseResourcesMap);
+    };
+
+    fetchHelmReleases();
+
+    return () => {
+      ignore = true;
+    };
+  }, [namespace]);
+
   return (
     <Firehose resources={resources}>
       <Controller
@@ -103,6 +150,7 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
         serviceBinding={serviceBinding}
         topologyFilters={filters}
         trafficData={trafficConnectorMock.elements}
+        helmResourcesMap={helmResourcesMap}
       />
     </Firehose>
   );

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -2162,6 +2162,14 @@ export const sampleHelmChartDeploymentConfig = {
   },
 };
 
+export const sampleHelmResourcesMap = {
+  'DeploymentConfig---nodejs-helm': {
+    releaseName: 'nodejs-helm',
+    chartIcon: '',
+    manifestResources: [sampleHelmChartDeploymentConfig],
+  },
+};
+
 export const sampleEventsResource: FirehoseResult<EventKind[]> = {
   loaded: true,
   loadError: '',

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
@@ -37,6 +37,7 @@ import {
   sampleHelmChartDeploymentConfig,
   sampleDeploymentConfigs,
   MockKialiGraphData,
+  sampleHelmResourcesMap,
 } from './topology-test-data';
 import { MockKnativeResources } from './topology-knative-test-data';
 import {
@@ -58,6 +59,8 @@ export function getTranformedTopologyData(
     mockCheURL,
     [getKnativeServingRevisions, getKnativeServingConfigurations, getKnativeServingRoutes],
     filters,
+    undefined,
+    sampleHelmResourcesMap,
   );
   const topologyTransformedData = result.topology;
   const graphData = result.graph;
@@ -335,14 +338,22 @@ describe('TopologyUtils ', () => {
     );
   });
   it('should return true for nodes created by helm charts', () => {
-    expect(isHelmReleaseNode(sampleDeploymentConfigs.data[0])).toBe(false);
-    expect(isHelmReleaseNode(sampleHelmChartDeploymentConfig)).toBe(true);
+    expect(isHelmReleaseNode(sampleDeploymentConfigs.data[0], sampleHelmResourcesMap)).toBe(false);
+    expect(isHelmReleaseNode(sampleHelmChartDeploymentConfig, sampleHelmResourcesMap)).toBe(true);
   });
 
   it('should add to groups with helm grouping type for a helm chart node', () => {
-    let groups = getTopologyHelmReleaseGroupItem(sampleDeploymentConfigs.data[0], []);
+    let groups = getTopologyHelmReleaseGroupItem(
+      sampleDeploymentConfigs.data[0],
+      [],
+      sampleHelmResourcesMap,
+    );
     expect(groups).toHaveLength(0);
-    groups = getTopologyHelmReleaseGroupItem(sampleHelmChartDeploymentConfig, []);
+    groups = getTopologyHelmReleaseGroupItem(
+      sampleHelmChartDeploymentConfig,
+      [],
+      sampleHelmResourcesMap,
+    );
     expect(groups).toHaveLength(1);
     expect(groups[0].type).toEqual(TYPE_HELM_RELEASE);
   });

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -67,6 +67,7 @@ import {
   KNATIVE_GROUP_NODE_PADDING,
 } from './const';
 import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
+import { HelmReleaseResourcesMap } from '../helm/helm-types';
 
 export const allowedResources = ['deployments', 'deploymentConfigs', 'daemonSets', 'statefulSets'];
 
@@ -77,8 +78,14 @@ export const getEditURL = (gitURL: string, cheURL: string) => {
   return gitURL && cheURL ? `${cheURL}/f?url=${gitURL}&policies.create=peruser` : gitURL;
 };
 
-export const isHelmReleaseNode = (obj: K8sResourceKind): boolean => {
-  return obj?.metadata?.labels?.['heritage'] === 'Helm' || !!obj?.metadata?.labels?.['charts'];
+export const isHelmReleaseNode = (
+  obj: K8sResourceKind,
+  helmResourcesMap: HelmReleaseResourcesMap,
+): boolean => {
+  if (helmResourcesMap) {
+    return helmResourcesMap.hasOwnProperty(`${obj.kind}---${obj.metadata.name}`);
+  }
+  return false;
 };
 
 export const getKialiLink = (consoleLinks: K8sResourceKind[], namespace: string): string => {
@@ -236,11 +243,12 @@ export const getTopologyNodeItem = (
   dc: K8sResourceKind,
   type?: string,
   children?: string[],
+  helmResourcesMap?: HelmReleaseResourcesMap,
 ): Node => {
   const uid = _.get(dc, ['metadata', 'uid']);
   const name = _.get(dc, ['metadata', 'name']);
   const label = _.get(dc, ['metadata', 'labels', 'app.openshift.io/instance']);
-  if (isHelmReleaseNode(dc)) {
+  if (isHelmReleaseNode(dc, helmResourcesMap)) {
     return {
       id: uid,
       type: TYPE_HELM_WORKLOAD,
@@ -335,20 +343,28 @@ export const getTopologyEdgeItems = (
   return edges;
 };
 
-export const getTopologyHelmReleaseGroupItem = (obj: K8sResourceKind, groups: Group[]): Group[] => {
-  const releaseLabel = _.get(obj, ['metadata', 'labels', 'release'], null);
+export const getTopologyHelmReleaseGroupItem = (
+  obj: K8sResourceKind,
+  groups: Group[],
+  helmResourcesMap: HelmReleaseResourcesMap,
+): Group[] => {
+  const resourceKindName = `${obj.kind}---${obj.metadata.name}`;
+  const releaseName = helmResourcesMap[resourceKindName]?.releaseName;
   const uid = _.get(obj, ['metadata', 'uid'], null);
-  if (!releaseLabel) return groups;
-  const releaseExists = _.some(groups, { name: releaseLabel });
+
+  if (!releaseName) return groups;
+
+  const releaseExists = _.some(groups, { name: releaseName });
+
   if (!releaseExists) {
     groups.push({
-      id: `${TYPE_HELM_RELEASE}:${releaseLabel}`,
+      id: `${TYPE_HELM_RELEASE}:${releaseName}`,
       type: TYPE_HELM_RELEASE,
-      name: releaseLabel,
+      name: releaseName,
       nodes: [uid],
     });
   } else {
-    const gIndex = _.findIndex(groups, { name: releaseLabel });
+    const gIndex = _.findIndex(groups, { name: releaseName });
     groups[gIndex].nodes.push(uid);
   }
   return groups;
@@ -359,9 +375,13 @@ export const getTopologyHelmReleaseGroupItem = (obj: K8sResourceKind, groups: Gr
  * @param dc
  * @param groups
  */
-export const getTopologyGroupItems = (dc: K8sResourceKind, groups: Group[]): Group[] => {
-  if (isHelmReleaseNode(dc)) {
-    return getTopologyHelmReleaseGroupItem(dc, groups);
+export const getTopologyGroupItems = (
+  dc: K8sResourceKind,
+  groups: Group[],
+  helmResourcesMap?: HelmReleaseResourcesMap,
+): Group[] => {
+  if (isHelmReleaseNode(dc, helmResourcesMap)) {
+    return getTopologyHelmReleaseGroupItem(dc, groups, helmResourcesMap);
   }
   const labels = _.get(dc, ['metadata', 'labels']);
   const uid = _.get(dc, ['metadata', 'uid']);
@@ -532,11 +552,11 @@ export const transformTopologyData = (
   utils?: Function[],
   filters?: TopologyFilters,
   trafficData?: TrafficData,
+  helmResourcesMap?: HelmReleaseResourcesMap,
 ): TopologyDataModel => {
   const installedOperators = _.get(resources, 'clusterServiceVersions.data');
   const operatorBackedServiceKindMap = getOperatorBackedServiceKindMap(installedOperators);
   const serviceBindingRequests = _.get(resources, 'serviceBindingRequests.data');
-
   let topologyGraphAndNodeData: TopologyDataModel = {
     graph: { nodes: [], edges: [], groups: [] },
     topology: {},
@@ -638,7 +658,10 @@ export const transformTopologyData = (
         if (!_.some(topologyGraphAndNodeData.graph.nodes, { id: uid })) {
           const operatorBacked = dataToShowOnNodes[uid].operatorBackedService;
           const nodeType = operatorBacked ? TYPE_OPERATOR_WORKLOAD : TYPE_WORKLOAD;
-          nodesData = [...nodesData, getTopologyNodeItem(deploymentConfig, nodeType)];
+          nodesData = [
+            ...nodesData,
+            getTopologyNodeItem(deploymentConfig, nodeType, undefined, helmResourcesMap),
+          ];
           edgesData = [
             ...edgesData,
             ...getTopologyEdgeItems(
@@ -650,7 +673,11 @@ export const transformTopologyData = (
           ];
           if (!operatorBacked) {
             groupsData = [
-              ...getTopologyGroupItems(deploymentConfig, topologyGraphAndNodeData.graph.groups),
+              ...getTopologyGroupItems(
+                deploymentConfig,
+                topologyGraphAndNodeData.graph.groups,
+                helmResourcesMap,
+              ),
             ];
           }
         }


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-2877

This PR -
- Changes the grouping strategy of Helm nodes in topology because grouping of Helm 3 charts was not working based on labels.
- Updates the strategy to fetch all helm releases and identify topology nodes created by Helm release manifest.
- Based on the Helm release manifest, we create a `HelmReleaseResourcesMap` to identify and group all the resources created by a particular Helm release.

Screenshots - 
![Screenshot from 2020-02-21 04-37-46](https://user-images.githubusercontent.com/6041994/74988479-f4932180-5463-11ea-88f1-5479895740ee.png)
