### PR TITLE
Bug 1805945: fetch pipeline runs in current namespace

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -39,6 +39,7 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
       .then((res) => {
         // eslint-disable-next-line promise/no-nesting
         k8sList(PipelineRunModel, {
+          ns: this.props.namespace,
           labelSelector: { 'tekton.dev/pipeline': res.metadata.name },
         })
           .then((listres) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3109
https://github.com/openshift/console/issues/4247

**Analysis / Root cause**: 
The `Start Last Run` menu action was present for a pipeline which had no pipeline runs because in another namespace there existed the same named pipeline which had pipeline runs. When executing the action, a pipeline run was created in the other namespace.

**Solution Description**: 
The action should not be present for a pipeline which has no pipeline runs.

The call to fetch pipeline runs was missing the namespace scope.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
