### PR TITLE
Added OCP E2E tests for Noobaa

### DIFF
--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -145,8 +145,14 @@ export const modalAnnotationsLink = $(
   '[data-test-id=resource-summary] [data-test-id=edit-annotations]',
 );
 
-export const visitResource = async (resource: string, name: string) => {
-  await browser.get(`${appHost}/k8s/ns/${testName}/${resource}/${name}`);
+export const visitResource = async (
+  resource: string,
+  name: string,
+  isNamespaced: boolean = true,
+) => {
+  isNamespaced
+    ? await browser.get(`${appHost}/k8s/ns/${testName}/${resource}/${name}`)
+    : await browser.get(`${appHost}/k8s/cluster/${resource}/${name}`);
 };
 
 export const clickDetailsPageAction = async (actionID: string) => {
@@ -157,8 +163,13 @@ export const clickDetailsPageAction = async (actionID: string) => {
   await action.click();
 };
 
-export const deleteResource = async (resource: string, kind: string, name: string) => {
-  await visitResource(resource, name);
+export const deleteResource = async (
+  resource: string,
+  kind: string,
+  name: string,
+  isNamespaced: boolean = true,
+) => {
+  await visitResource(resource, name, isNamespaced);
   await isLoaded();
   clickDetailsPageAction(deleteHumanizedKind(kind));
   await browser.wait(until.presenceOf($('#confirm-action')));

--- a/frontend/packages/noobaa-storage-plugin/integration-tests/mocks/objectData.ts
+++ b/frontend/packages/noobaa-storage-plugin/integration-tests/mocks/objectData.ts
@@ -1,0 +1,67 @@
+export const backingStore = {
+  apiVersion: 'noobaa.io/v1alpha1',
+  kind: 'BackingStore',
+  metadata: {
+    name: 'noobaa-default-backing-store',
+    namespace: 'openshift-storage',
+  },
+  spec: {
+    awsS3: {
+      region: 'us-east-1',
+      secret: {
+        name: 'noobaa-cloud-creds-secret',
+        namespace: 'openshift-storage',
+      },
+      targetBucket: 'noobaa-backing-store-dummy',
+    },
+    type: 'aws-s3',
+  },
+};
+
+export const bucketClass = {
+  apiVersion: 'noobaa.io/v1alpha1',
+  kind: 'BucketClass',
+  metadata: {
+    name: 'noobaa-default-bucket-class',
+    namespace: 'openshift-storage',
+  },
+  spec: {
+    placementPolicy: {
+      tiers: [
+        {
+          backingStores: ['noobaa-default-backing-store'],
+        },
+      ],
+    },
+  },
+};
+
+export const storageClass = {
+  apiVersion: 'storage.k8s.io/v1',
+  kind: 'StorageClass',
+  metadata: {
+    name: 'openshift-storage.noobaa.io',
+  },
+  parameters: {
+    bucketclass: 'noobaa-default-bucket-class',
+  },
+  provisioner: 'openshift-storage.noobaa.io/obc',
+  reclaimPolicy: 'Delete',
+  volumeBindingMode: 'Immediate',
+};
+
+export const objectBucket = {
+  apiVersion: 'objectbucket.io/v1alpha1',
+  kind: 'ObjectBucket',
+  metadata: {
+    name: 'test-bucket',
+  },
+  spec: {
+    ObjectBucketName: 'test-bucket',
+    additionalConfig: {
+      bucketclass: 'noobaa-default-bucket-class',
+    },
+    bucketName: 'test-bucket',
+    storageClassName: 'openshift-storage.noobaa.io',
+  },
+};

--- a/frontend/packages/noobaa-storage-plugin/integration-tests/tests/backingStoreTest.scenario.ts
+++ b/frontend/packages/noobaa-storage-plugin/integration-tests/tests/backingStoreTest.scenario.ts
@@ -24,9 +24,9 @@ describe('Tests creation of Backing Store', () => {
   beforeEach(async () => {
     await operatorsPage();
     await click(ocsOperator);
+    await browser.wait(until.and(crudView.untilNoLoadersPresent));
     const bsLink = await getBackingStoreLink();
     await click(bsLink);
-    await browser.wait(until.and(crudView.untilNoLoadersPresent));
   });
 
   afterEach(async () => {

--- a/frontend/packages/noobaa-storage-plugin/integration-tests/tests/e2e-tests/objectPages.scenario.ts
+++ b/frontend/packages/noobaa-storage-plugin/integration-tests/tests/e2e-tests/objectPages.scenario.ts
@@ -1,0 +1,47 @@
+import { $, browser, ExpectedConditions as until } from 'protractor';
+import { execSync } from 'child_process';
+import { goToOBCPage, CreateOBCHandler, goToOBPage } from '../../views/obcPage.view';
+import { testName } from '@console/internal-integration-tests/protractor.conf';
+import { backingStore, bucketClass, storageClass, objectBucket } from '../../mocks/objectData';
+import { click } from '@console/shared/src/test-utils/utils';
+import {
+  deleteResource,
+  untilNoLoadersPresent,
+} from '@console/internal-integration-tests/views/crud.view';
+import { NS } from '@console/ceph-storage-plugin/integration-tests/utils/consts';
+import { OB_RESOURCE_PATH } from '../../utils/consts';
+
+describe('Test Object Bucket Claim CRUD', () => {
+  beforeAll(async () => {
+    execSync(`echo '${JSON.stringify(backingStore)}' | oc apply -f -`);
+    execSync(`echo '${JSON.stringify(bucketClass)}' | oc apply -f -`);
+    execSync(`echo '${JSON.stringify(storageClass)}' | oc apply -f -`);
+  });
+
+  afterAll(async () => {
+    execSync(`echo '${JSON.stringify(backingStore)}' | oc delete -f -`);
+    execSync(`echo '${JSON.stringify(bucketClass)}' | oc delete -f -`);
+    execSync(`echo '${JSON.stringify(storageClass)}' | oc delete -f -`);
+  });
+
+  it('Test if Object Bucket Claim page is reachable', async () => {
+    await goToOBCPage();
+    const obcName = `${testName}obc`;
+    // Change ns to input from a const
+    const obcHandler = new CreateOBCHandler(obcName, NS);
+    await obcHandler.createBucketClaim();
+    const { name, status } = await obcHandler.getNameAndState();
+    expect(name).toEqual(obcName);
+    expect(status).toEqual('Pending');
+    await obcHandler.deleteBucketClaim();
+  });
+
+  it('Read and Delete Tests for Object Buckets', async () => {
+    execSync(`echo '${JSON.stringify(objectBucket)}' | oc apply -f -`);
+    await goToOBPage();
+    const bucketLink = $(`a[title=${objectBucket.metadata.name}]`);
+    await click(bucketLink);
+    await browser.wait(until.and(untilNoLoadersPresent));
+    await deleteResource(OB_RESOURCE_PATH, OB_RESOURCE_PATH, objectBucket.metadata.name, false);
+  });
+});

--- a/frontend/packages/noobaa-storage-plugin/integration-tests/utils/consts.ts
+++ b/frontend/packages/noobaa-storage-plugin/integration-tests/utils/consts.ts
@@ -2,3 +2,4 @@ export const OBC_NAME = 'test-obc';
 export const BOUND = 'Bound';
 export const ATTACH_TO_DEPLOYMENT = 'Attach to Deployment';
 export const OBC_RESOURCE_PATH = 'objectbucket.io~v1alpha1~ObjectBucketClaim';
+export const OB_RESOURCE_PATH = 'objectbucket.io~v1alpha1~ObjectBucket';

--- a/frontend/packages/noobaa-storage-plugin/integration-tests/views/createBS.view.ts
+++ b/frontend/packages/noobaa-storage-plugin/integration-tests/views/createBS.view.ts
@@ -14,9 +14,9 @@ export const operatorsPage = async () => {
 };
 
 export const getBackingStoreLink = async () => {
-  const index = await getOperatorHubCardIndex('BackingStore');
-  const link = $(`article:nth-child(${index}) a`);
-  return link;
+  // Map index starts from 0 child elements starts from 1
+  const cardIndex = (await getOperatorHubCardIndex('BackingStore')) + 1;
+  return $(`article:nth-child(${cardIndex}) a`);
 };
 
 export const ocsOperator = $('a[data-test-operator-row="OpenShift Container Storage"]');

--- a/frontend/packages/noobaa-storage-plugin/package.json
+++ b/frontend/packages/noobaa-storage-plugin/package.json
@@ -13,6 +13,10 @@
     "integrationTestSuites": {
       "noobaa": [
         "integration-tests/**/*.scenario.ts"
+      ],
+      "e2e": [
+        "integration-tests/**/e2e-tests/*.scenario.ts",
+        "integration-tests/**/backingStoreTest.scenario.ts"
       ]
     }
   }


### PR DESCRIPTION
- Adds CRUD test for Object Bucket Claim and Object Bucket.
- Adds CRUD test for Backing Store.

Todo: 
- Add a reliable way to install OCS Operator as well as clean it up.

Depends on https://github.com/openshift/console/pull/4413