### PR TITLE
Bug 1806082: dynamically determine parent scroll container for EventStreamList

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/ActivityBody.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/ActivityBody.tsx
@@ -99,7 +99,6 @@ export const RecentEventsBodyContent: React.FC<RecentEventsBodyContentProps> = (
         className="co-activity-card__recent-list"
         events={sortedEvents}
         EventComponent={eventItem}
-        scrollableElementId="activity-body"
       />
     </Accordion>
   );

--- a/frontend/public/components/utils/event-stream.tsx
+++ b/frontend/public/components/utils/event-stream.tsx
@@ -11,6 +11,7 @@ import { CSSTransition } from 'react-transition-group';
 import classNames from 'classnames';
 
 import { EventKind } from '../../module/k8s';
+import { WithScrollContainer } from './dom-utils';
 
 // Keep track of seen events so we only animate new ones.
 const seen = new Set();
@@ -73,7 +74,6 @@ export const EventStreamList: React.FC<EventStreamListProps> = ({
   events,
   className,
   EventComponent,
-  scrollableElementId = 'content-scrollable',
 }) => {
   const [list, setList] = React.useState();
   const onResize = React.useCallback(() => measurementCache.clearAll(), []);
@@ -109,39 +109,38 @@ export const EventStreamList: React.FC<EventStreamListProps> = ({
     [events, className, EventComponent],
   );
 
-  return (
-    events.length > 0 && (
-      <WindowScroller scrollElement={document.getElementById(scrollableElementId)}>
-        {({ height, isScrolling, registerChild, onChildScroll, scrollTop }) => (
-          <AutoSizer disableHeight onResize={onResize}>
-            {({ width }) => (
-              <div ref={registerChild}>
-                <VirtualList
-                  autoHeight
-                  data={events}
-                  deferredMeasurementCache={measurementCache}
-                  height={height || 0}
-                  isScrolling={isScrolling}
-                  onScroll={onChildScroll}
-                  ref={setList}
-                  rowCount={events.length}
-                  rowHeight={measurementCache.rowHeight}
-                  rowRenderer={rowRenderer}
-                  scrollTop={scrollTop}
-                  tabIndex={null}
-                  width={width}
-                />
-              </div>
-            )}
-          </AutoSizer>
-        )}
-      </WindowScroller>
-    )
+  const renderVirtualizedTable = (scrollContainer) => (
+    <WindowScroller scrollElement={scrollContainer}>
+      {({ height, isScrolling, registerChild, onChildScroll, scrollTop }) => (
+        <AutoSizer disableHeight onResize={onResize}>
+          {({ width }) => (
+            <div ref={registerChild}>
+              <VirtualList
+                autoHeight
+                data={events}
+                deferredMeasurementCache={measurementCache}
+                height={height || 0}
+                isScrolling={isScrolling}
+                onScroll={onChildScroll}
+                ref={setList}
+                rowCount={events.length}
+                rowHeight={measurementCache.rowHeight}
+                rowRenderer={rowRenderer}
+                scrollTop={scrollTop}
+                tabIndex={null}
+                width={width}
+              />
+            </div>
+          )}
+        </AutoSizer>
+      )}
+    </WindowScroller>
   );
+
+  return events.length > 0 && <WithScrollContainer>{renderVirtualizedTable}</WithScrollContainer>;
 };
 
 type EventStreamListProps = {
-  scrollableElementId?: string;
   events: EventKind[];
   EventComponent: React.ComponentType<EventComponentProps>;
   className?: string;


### PR DESCRIPTION
**Fixes**: 
Fixes: https://issues.redhat.com/browse/ODC-3148

**Analysis / Root cause**: 
Event list uses a virtual scroll component. The virtual scroll component needs to know which DOM node is the parent scroll container. By default this is the DOM node with ID `content-scrollable`. However in the monitoring page, this was the incorrect parent scroll container.

The event list was embedded in the monitoring events tab in the dev perspective however it did not override the `scrollableElementId` and therefore failed to properly use the virtual scroll behavior.

**Solution Description**: 
Updated `EventStreamList` to use `WithScrollContainer` which dynamically identifies the parent scroll container making the `EventStreamList` more easily embedded into other pages without the need to know which DOM node is the parent scroll container. This is the same technique used in `table.tsx`.

**Screen shots / Gifs for design review**: 
![event-scroll](https://user-images.githubusercontent.com/14068621/75082065-e1be3280-54df-11ea-9cfc-7bfe0d828417.gif)

**Test setup:**
There are 3 instances of the events steam list:
* Activity card in the dashboard: `Home -> Overview` in admin perspective
* `Home -> Events` in admin perspective
* `Monitoring -> Events (tab)` in dev perspective

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge

cc @rawagner @spadgett 