### PR TITLE
Bug 1806114: fixes issue with editing customQueries in promQL

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/metrics/MonitoringMetrics.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/MonitoringMetrics.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
-import ConnectedMetricsQueryInput from './MetricsQueryInput';
+import MetricsQueryInput from './MetricsQueryInput';
 import { connect } from 'react-redux';
 import { getURLSearchParams } from '@console/internal/components/utils';
 import { queryBrowserRunQueries, queryBrowserPatchQuery } from '@console/internal/actions/ui';
@@ -26,7 +26,7 @@ export const MonitoringMetrics: React.FC<MonitoringMetricsProps> = ({ patchQuery
         <title>Metrics</title>
       </Helmet>
       <div className="co-m-pane__body">
-        <ConnectedMetricsQueryInput />
+        <MetricsQueryInput />
         <div className="row">
           <div className="col-xs-12">
             <ConnectedMetricsChart />

--- a/frontend/packages/dev-console/src/components/monitoring/metrics/__tests__/MetricsQueryInput.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/__tests__/MetricsQueryInput.spec.tsx
@@ -1,42 +1,44 @@
 import * as React from 'react';
+import * as redux from 'react-redux';
 import { shallow } from 'enzyme';
 import { Button } from '@patternfly/react-core';
 import { Dropdown } from '@console/internal/components/utils';
 import { QueryInput } from '@console/internal/components/monitoring/metrics';
-import { MetricsQueryInput } from '../MetricsQueryInput';
+import MetricsQueryInput from '../MetricsQueryInput';
 
 describe('Metrics Query Input', () => {
-  let props: React.ComponentProps<typeof MetricsQueryInput>;
-  beforeEach(() => {
-    props = {
-      namespace: 'my-app',
-      patchQuery: jest.fn(),
-      runQueries: jest.fn(),
-    };
-  });
-
+  // FIXME upgrading redux types is causing many errors at this time
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  const spySelector = jest.spyOn(redux, 'useSelector');
+  spySelector.mockReturnValue({ queryBrowser: { queries: [] } });
+  // FIXME upgrading redux types is causing many errors at this time
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  const spyDispatch = jest.spyOn(redux, 'useDispatch');
+  spyDispatch.mockReturnValue(() => {});
   it('should render Dropdown with default title', () => {
-    const wrapper = shallow(<MetricsQueryInput {...props} />);
+    const wrapper = shallow(<MetricsQueryInput />);
     expect(wrapper.find(Dropdown)).toHaveLength(1);
     expect(wrapper.find(Dropdown).props().title).toEqual('Select Query');
   });
 
   it('should render Button with text "Show PromQL" and not render QueryInput', () => {
-    const wrapper = shallow(<MetricsQueryInput {...props} />);
+    const wrapper = shallow(<MetricsQueryInput />);
     expect(wrapper.find(Button)).toHaveLength(1);
     expect(wrapper.find(Button).props().children).toEqual('Show PromQL');
     expect(wrapper.find(QueryInput).exists()).toBe(false);
   });
 
   it('should update Button with text "Hide PromQL" on click and render QueryInput', () => {
-    const wrapper = shallow(<MetricsQueryInput {...props} />);
+    const wrapper = shallow(<MetricsQueryInput />);
     wrapper.find(Button).simulate('click');
     expect(wrapper.find(Button).props().children).toEqual('Hide PromQL');
     expect(wrapper.find(QueryInput)).toHaveLength(1);
   });
 
   it('Custom Querey selection should update Dropdown title, show QueryInput and Button in disabled state', () => {
-    const wrapper = shallow(<MetricsQueryInput {...props} />);
+    const wrapper = shallow(<MetricsQueryInput />);
     wrapper
       .find(Dropdown)
       .props()
@@ -48,7 +50,7 @@ describe('Metrics Query Input', () => {
   });
 
   it('Metric selection should update Dropdown title and show Button in enabled state', () => {
-    const wrapper = shallow(<MetricsQueryInput {...props} />);
+    const wrapper = shallow(<MetricsQueryInput />);
     wrapper
       .find(Dropdown)
       .props()


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3141

**Analysis / Root cause**: 
An issue with typing custom query in promQl editor in metrics tab i.e if you start editing in between existing query cursor moves to the line end.

**Solution Description**: 
made use of hook `useSelector` to bring redux into the same render function and avoid using a HOC

**Screen shots / Gifs for design review**: 
![ezgif com-video-to-gif (25)](https://user-images.githubusercontent.com/5129024/75089831-c9532400-5582-11ea-9aa7-4f624094abd0.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
