### PR TITLE
Inject the resource name in pipeline params

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/pipeline/pipeline-template-utils.ts
@@ -35,7 +35,7 @@ export const createPipelineForImportFlow = async (formData: GitImportFormData) =
   template.spec.params =
     template.spec.params &&
     template.spec.params.map((param) => {
-      if (param.name === 'APP_NAME') {
+      if (param.name === 'APPLICATION_NAME') {
         param.default = name;
       }
       return param;


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-3117

On import flows, the generating pipeline needs the application name in the APPLICATION_NAME param in order to correctly redeploy the application.
https://github.com/openshift/tektoncd-pipeline-operator/blob/master/deploy/resources/v0.9.2/addons/pipelines/s2i-java-11/s2i-java-11-build-deploy.yaml#L45

Solution:
We already have handled this scenario, but it was having a different param name `APP_NAME`, this is now modified to `APPLICATION_NAME`.
A pipeline template which has this  param (`APPLICATION_NAME`) in it,  will now have a deployment name injected as default value while creating a new pipeline.

![test-maven-app-four · Details · OKD](https://user-images.githubusercontent.com/9964343/75153328-268cd800-5731-11ea-9cd5-c7460449b928.png)

cc: @andrewballantyne 