### PR TITLE
Bug 1805292: Do not clear event list on error

### DIFF
--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -366,17 +366,14 @@ class EventStream extends React.Component {
         this.flushMessages();
       })
       .onopen(() => {
-        this.messages = {};
         this.setState({ error: false, loading: false });
       })
       .onclose((evt) => {
         if (evt && evt.wasClean === false) {
           this.setState({ error: evt.reason || 'Connection did not close cleanly.' });
         }
-        this.messages = {};
       })
       .onerror(() => {
-        this.messages = {};
         this.setState({ error: true });
       });
   }

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -367,18 +367,17 @@ class EventStream extends React.Component {
       })
       .onopen(() => {
         this.messages = {};
-        this.setState({ error: false, loading: false, sortedMessages: [], filteredEvents: [] });
+        this.setState({ error: false, loading: false });
       })
       .onclose((evt) => {
         if (evt && evt.wasClean === false) {
           this.setState({ error: evt.reason || 'Connection did not close cleanly.' });
         }
         this.messages = {};
-        this.setState({ sortedMessages: [], filteredEvents: [] });
       })
       .onerror(() => {
         this.messages = {};
-        this.setState({ error: true, sortedMessages: [], filteredEvents: [] });
+        this.setState({ error: true });
       });
   }
 


### PR DESCRIPTION
When a user navigates to Events tab of a VM, the page keeps scrollig up.

Description:
On bad connections events stream may connect and disconnect, currently on each error we clear
the events list and course the list to flicker, and on long disconnections to scroll up. but we do not need to clear the list of event on errors because if the connection will resume, we can continue from the previous points, and only if connection will die completely we will want to alert the user.

Before (with flicker):
![Peek 2020-02-24 15-30](https://user-images.githubusercontent.com/2181522/75156975-e2dba380-571b-11ea-89f4-60f066cc5ad6.gif)

After (without flicker):
![Peek 2020-02-24 15-33](https://user-images.githubusercontent.com/2181522/75156982-e5d69400-571b-11ea-83e5-f74188c3b125.gif)
