### PR TITLE
Bug 1806552: fixes issue with prefetching of container ports for image

### DIFF
--- a/frontend/packages/dev-console/src/components/import/serverless/ServerlessRouteSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless/ServerlessRouteSection.tsx
@@ -1,24 +1,51 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { TextInputTypes } from '@patternfly/react-core';
-import { InputField } from '@console/shared';
+import { useFormikContext, FormikValues } from 'formik';
+import { InputField, DropdownField } from '@console/shared';
 import FormSection from '../section/FormSection';
 import { RouteData } from '../import-types';
+import { makePortName } from '../../../utils/imagestream-utils';
 
 export interface ServerlessRouteSectionProps {
   route: RouteData;
 }
 
 const ServerlessRouteSection: React.FC<ServerlessRouteSectionProps> = ({ route }) => {
+  const {
+    values: {
+      image: { ports },
+      route: { defaultUnknownPort, targetPort },
+    },
+  } = useFormikContext<FormikValues>();
+  const portOptions = ports.reduce((acc, port) => {
+    const name = makePortName(port);
+    acc[name] = <>{port.containerPort}</>;
+    return acc;
+  }, {});
   return (
     <FormSection title="Routing">
       {route.create && (
-        <InputField
-          type={TextInputTypes.text}
-          name="route.unknownTargetPort"
-          label="Target Port"
-          placeholder="8080"
-          helpText="Target port for traffic."
-        />
+        <>
+          {_.isEmpty(ports) ? (
+            <InputField
+              type={TextInputTypes.text}
+              name="route.unknownTargetPort"
+              label="Target Port"
+              placeholder={defaultUnknownPort}
+              helpText="Target port for traffic."
+            />
+          ) : (
+            <DropdownField
+              name="route.targetPort"
+              label="Target Port"
+              items={portOptions}
+              title={portOptions[targetPort] || 'Select target port'}
+              helpText="Target port for traffic."
+              fullWidth
+            />
+          )}
+        </>
       )}
     </FormSection>
   );

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -33,11 +33,13 @@ export const getKnativeServiceDepResource = (
     project: { name: namespace },
     serverless: { scaling },
     limits,
-    route: { unknownTargetPort, create },
+    route: { unknownTargetPort, create, targetPort },
     labels,
     image: { tag: imageTag },
   } = formData;
-  const contTargetPort: number = parseInt(unknownTargetPort, 10);
+  const contTargetPort = targetPort
+    ? parseInt(targetPort.split('-')[0], 10)
+    : parseInt(unknownTargetPort, 10);
   const { concurrencylimit, concurrencytarget, minpods, maxpods } = scaling;
   const {
     cpu: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3070

**Analysis / Root cause**: 
Issue with prefetching of container ports for images in case knative under Advance options in route

**Solution Description**: 
Added Dropdown with preselected ports if any else show input-box

**Screen shots / Gifs for design review**: 
![ezgif com-optimize](https://user-images.githubusercontent.com/5129024/75159769-cb61e200-573e-11ea-93bc-dece99c06ce9.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
