### PR TITLE
Rename "Search" to "All Resources" and "Explore" to "All Types"

### DIFF
--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -158,7 +158,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       section: 'More',
       perspective: 'dev',
       componentProps: {
-        name: 'Search',
+        name: 'All Resources',
         href: '/search',
         testID: 'more-search-header',
       },

--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -343,10 +343,10 @@ APIResourcesList.displayName = 'APIResourcesList';
 export const APIExplorerPage: React.FC<{}> = () => (
   <>
     <Helmet>
-      <title>Explore API Resources</title>
+      <title>All Types</title>
     </Helmet>
     <div className="co-m-nav-title">
-      <h1 className="co-m-pane__heading">Explore API Resources</h1>
+      <h1 className="co-m-pane__heading">All Types</h1>
     </div>
     <APIResourcesList />
   </>
@@ -640,11 +640,11 @@ const APIResourcePage_ = ({
 
   const breadcrumbs = [
     {
-      name: 'Explore',
+      name: 'All Types',
       path: '/api-explorer',
     },
     {
-      name: 'Resource Details',
+      name: 'Details',
       path: match.url,
     },
   ];

--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -98,9 +98,10 @@ const AdminNav = () => (
         required={[FLAGS.CAN_LIST_NS, FLAGS.OPENSHIFT]}
       />
       <ResourceClusterLink resource="projects" name="Projects" required={FLAGS.OPENSHIFT} />
-      <HrefLink href="/search" name="Search" startsWith={searchStartsWith} />
-      <HrefLink href="/api-explorer" name="Explore" startsWith={apiExplorerStartsWith} />
       <ResourceNSLink resource="events" name="Events" />
+      <Separator name="HomeSeparator" />
+      <HrefLink href="/search" name="All Resources" startsWith={searchStartsWith} />
+      <HrefLink href="/api-explorer" name="All Types" startsWith={apiExplorerStartsWith} />
     </NavSection>
 
     <NavSection title="Operators" />

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -159,9 +159,9 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
   return (
     <>
       <Helmet>
-        <title>Search</title>
+        <title>All Resources</title>
       </Helmet>
-      <PageHeading detail={true} title="Search">
+      <PageHeading detail={true} title="All Resources">
         <div className="co-search-group">
           <ResourceListDropdown
             selected={[...selectedItems]}


### PR DESCRIPTION
Revisiting the nav item names.

@bmignano @alimobrem @serenamarie125 @christianvogt @smarterclayton 

![Screenshot_2020-02-24 All Resources · OKD](https://user-images.githubusercontent.com/1167259/75192450-4072ee80-5722-11ea-813d-76fda8b5a222.png)

![Screenshot_2020-02-24 All Types · OKD](https://user-images.githubusercontent.com/1167259/75192421-30f3a580-5722-11ea-9af0-2e9361b752bd.png)

![Screenshot_2020-02-24 Config Map · OKD](https://user-images.githubusercontent.com/1167259/75192410-2afdc480-5722-11ea-8da5-5c76ff6a4d48.png)

![Screenshot_2020-02-24 Topology · OKD](https://user-images.githubusercontent.com/1167259/75192438-3b15a400-5722-11ea-8f4f-9764b58a2553.png)
