### PR TITLE
Bug 1804143: Monitoring Dashboards: Remove broken bar chart links & clean up

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -28,6 +28,7 @@ export enum ActionType {
   SetCurrentLocation = 'setCurrentLocation',
   MonitoringDashboardsClearVariables = 'monitoringDashboardsClearVariables',
   MonitoringDashboardsPatchVariable = 'monitoringDashboardsPatchVariable',
+  MonitoringDashboardsPatchAllVariables = 'monitoringDashboardsPatchAllVariables',
   MonitoringDashboardsSetPollInterval = 'monitoringDashboardsSetPollInterval',
   MonitoringDashboardsSetTimespan = 'monitoringDashboardsSetTimespan',
   MonitoringDashboardsVariableOptionsLoaded = 'monitoringDashboardsVariableOptionsLoaded',
@@ -269,6 +270,8 @@ export const monitoringDashboardsClearVariables = () =>
   action(ActionType.MonitoringDashboardsClearVariables);
 export const monitoringDashboardsPatchVariable = (key: string, patch: any) =>
   action(ActionType.MonitoringDashboardsPatchVariable, { key, patch });
+export const monitoringDashboardsPatchAllVariables = (variables: any) =>
+  action(ActionType.MonitoringDashboardsPatchAllVariables, { variables });
 export const monitoringDashboardsSetPollInterval = (pollInterval: number) =>
   action(ActionType.MonitoringDashboardsSetPollInterval, { pollInterval });
 export const monitoringDashboardsSetTimespan = (timespan: number) =>
@@ -346,6 +349,7 @@ const uiActions = {
   updateOverviewFilterValue,
   monitoringDashboardsClearVariables,
   monitoringDashboardsPatchVariable,
+  monitoringDashboardsPatchAllVariables,
   monitoringDashboardsSetPollInterval,
   monitoringDashboardsSetTimespan,
   monitoringDashboardsVariableOptionsLoaded,

--- a/frontend/public/components/graphs/bar.tsx
+++ b/frontend/public/components/graphs/bar.tsx
@@ -23,13 +23,14 @@ const PADDING_RATIO = 1 / 3;
 export const BarChart: React.FC<BarChartProps> = ({
   barSpacing = 15,
   barWidth = DEFAULT_BAR_WIDTH,
-  title,
-  query,
   data = [],
-  theme = getCustomTheme(ChartThemeColor.blue, ChartThemeVariant.light, barTheme),
-  titleClassName,
-  loading = false,
+  isLink = true,
   LabelComponent,
+  loading = false,
+  query,
+  theme = getCustomTheme(ChartThemeColor.blue, ChartThemeVariant.light, barTheme),
+  title,
+  titleClassName,
 }) => {
   const [containerRef, width] = useRefWidth();
 
@@ -46,7 +47,7 @@ export const BarChart: React.FC<BarChartProps> = ({
   return (
     <PrometheusGraph ref={containerRef} title={title} className={titleClassName}>
       {data.length ? (
-        <PrometheusGraphLink query={query}>
+        <PrometheusGraphLink query={isLink ? query : undefined}>
           {data.map((datum, index) => (
             <React.Fragment key={index}>
               <div className="graph-bar__label">
@@ -80,16 +81,17 @@ export const BarChart: React.FC<BarChartProps> = ({
 };
 
 export const Bar: React.FC<BarProps> = ({
-  delay = undefined,
-  humanize = humanizeNumber,
-  metric,
-  namespace,
   barSpacing,
   barWidth,
-  theme,
-  query,
-  title,
+  delay = undefined,
+  humanize = humanizeNumber,
+  isLink = true,
   LabelComponent,
+  metric,
+  namespace,
+  query,
+  theme,
+  title,
 }) => {
   const [response, , loading] = usePrometheusPoll({
     delay,
@@ -101,14 +103,15 @@ export const Bar: React.FC<BarProps> = ({
 
   return (
     <BarChart
-      title={title}
-      query={query}
-      data={data}
       barSpacing={barSpacing}
       barWidth={barWidth}
-      theme={theme}
-      loading={loading}
+      data={data}
+      isLink={isLink}
       LabelComponent={LabelComponent}
+      loading={loading}
+      query={query}
+      theme={theme}
+      title={title}
     />
   );
 };
@@ -119,25 +122,27 @@ type LabelComponentProps = {
 };
 
 type BarChartProps = {
-  LabelComponent?: React.ComponentType<LabelComponentProps>;
   barSpacing?: number;
   barWidth?: number;
+  data?: DataPoint[];
+  isLink?: boolean;
+  LabelComponent?: React.ComponentType<LabelComponentProps>;
+  loading?: boolean;
   query?: string;
   theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
   title?: string;
-  data?: DataPoint[];
   titleClassName?: string;
-  loading?: boolean;
 };
 
 type BarProps = {
-  LabelComponent?: React.ComponentType<LabelComponentProps>;
-  delay?: number;
-  humanize?: Humanize;
-  metric: string;
-  namespace?: string;
   barSpacing?: number;
   barWidth?: number;
+  delay?: number;
+  humanize?: Humanize;
+  isLink?: boolean;
+  LabelComponent?: React.ComponentType<LabelComponentProps>;
+  metric: string;
+  namespace?: string;
   query: string;
   theme?: any; // TODO figure out the best way to import VictoryThemeDefinition
   title?: string;

--- a/frontend/public/components/monitoring/dashboards/bar-chart.tsx
+++ b/frontend/public/components/monitoring/dashboards/bar-chart.tsx
@@ -6,7 +6,14 @@ import { Bar } from '../../graphs';
 const Label = ({ metric }) => <>{_.values(metric).join()}</>;
 
 const BarChart: React.FC<BarChartProps> = ({ pollInterval, query }) => (
-  <Bar barSpacing={5} barWidth={8} delay={pollInterval} query={query} LabelComponent={Label} />
+  <Bar
+    barSpacing={5}
+    barWidth={8}
+    delay={pollInterval}
+    isLink={false}
+    LabelComponent={Label}
+    query={query}
+  />
 );
 
 type BarChartProps = {

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -254,7 +254,7 @@ const PollIntervalDropdown_: React.FC<PollIntervalDropdownProps> = ({
       items={pollIntervalOptions}
       label="Refresh Interval"
       onChange={onChange}
-      selectedKey={formatPrometheusDuration(pollInterval)}
+      selectedKey={pollInterval === null ? pollOffText : formatPrometheusDuration(pollInterval)}
     />
   );
 };

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -379,7 +379,7 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({
   patchVariable,
 }) => {
   const [board, setBoard] = React.useState();
-  const [boards, setBoards] = React.useState([]);
+  const [boards, setBoards] = React.useState<Board[]>([]);
   const [error, setError] = React.useState();
   const [isLoading, , , setLoaded] = useBoolean(true);
 
@@ -394,7 +394,7 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({
         setLoaded();
         setError(undefined);
 
-        const getBoardData = (item) => ({
+        const getBoardData = (item): Board => ({
           data: JSON.parse(_.values(item?.data)[0]),
           name: item.metadata.name,
         });
@@ -421,7 +421,7 @@ const MonitoringDashboardsPage_: React.FC<MonitoringDashboardsPageProps> = ({
 
       const data = _.find(boards, { name: newBoard })?.data;
 
-      _.each(data?.templating?.list as TemplateVariable[], (v) => {
+      _.each(data?.templating?.list, (v) => {
         if (v.type === 'query' || v.type === 'interval') {
           patchVariable(v.name, {
             isHidden: v.hide !== 0,
@@ -491,6 +491,22 @@ type TemplateVariable = {
   type: string;
 };
 
+type Row = {
+  panels: Panel[];
+};
+
+type Board = {
+  data: {
+    panels: Panel[];
+    rows: Row[];
+    templating: {
+      list: TemplateVariable[];
+    };
+    title: string;
+  };
+  name: string;
+};
+
 type Variable = {
   isHidden?: boolean;
   isLoading?: boolean;
@@ -521,7 +537,7 @@ type SingleVariableDropdownProps = {
 };
 
 type BoardProps = {
-  rows: Panel[];
+  rows: Row[];
 };
 
 type AllVariableDropdownsProps = {

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -150,6 +150,12 @@ export default (state: UIState, action: UIAction): UIState => {
         ImmutableMap(action.payload.patch),
       );
 
+    case ActionType.MonitoringDashboardsPatchAllVariables:
+      return state.setIn(
+        ['monitoringDashboards', 'variables'],
+        ImmutableMap(action.payload.variables),
+      );
+
     case ActionType.MonitoringDashboardsSetPollInterval:
       return state.setIn(['monitoringDashboards', 'pollInterval'], action.payload.pollInterval);
 


### PR DESCRIPTION
The bar chart panels were linking to the Query Browser page, but the
links were broken. Fixed by removing the links since the other panels
are not links and we should be consistent.

Fix issue where the "Refresh Interval"'s `Off` text was not being displayed.

Add `Board` type to address feedback on PR https://github.com/openshift/console/pull/4388

Call `changeBoard()` from `useEffect` hook instead of during render.
This is a bug fix since `changeBoard()` changes the component state, so
it shouldn't be called during render.

Speed up dashboard switching by
  - Adding a Redux action for updating all dashboard variables at once
  - Setting the `isLoading` flag to `true` immediately for `query`
    variables, which prevents that flag being quickly switched from
    `false` to `true` and triggering unnecessary renders