### PR TITLE
Bug 1806867: Monitoring Dashboards: Fix stacked graphs

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -492,13 +492,16 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
     }
   }, [timespan]);
 
+  // Define this once for all queries so that they have exactly the same time range and X values
+  const now = Date.now();
+
   const safeFetchQuery = (query: string) => {
     if (_.isEmpty(query)) {
       return Promise.resolve();
     }
     const url = getPrometheusURL({
       endpoint: PrometheusEndpoint.QUERY_RANGE,
-      endTime,
+      endTime: endTime || now,
       namespace,
       query,
       samples,


### PR DESCRIPTION
When calling the Prometheus `query_range` endpoint, the `end` time
parameter was being set to the current time. That caused graphs with
multiple queries to have slightly different `end` values, which in turn
meant they had slightly different X axis values. To solve this, ensure
that all calls use the same `end` value during a single render.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/460802/75231349-9c0fab80-57f8-11ea-8c08-990db0598109.png) | ![after](https://user-images.githubusercontent.com/460802/75231357-9f0a9c00-57f8-11ea-8350-fd77744c47dc.png) |