### PR TITLE
Bug 1806914: redirect to topology when resource created from dev-catalog

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/create-operand-form.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-operand-form.tsx
@@ -519,6 +519,7 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = ({
   operandModel,
   providedAPI,
   namespace,
+  activePerspective,
   onToggleEditMethod = _.noop,
 }) => {
   // Map providedAPI spec descriptors and openAPI spec properties to OperandField[] array
@@ -700,11 +701,13 @@ export const CreateOperandForm: React.FC<CreateOperandFormProps> = ({
       k8sCreate(operandModel, formData.setIn(['metadata', 'namespace'], namespace).toJS())
         .then(() =>
           history.push(
-            `${resourcePathFromModel(
-              ClusterServiceVersionModel,
-              clusterServiceVersion.metadata.name,
-              namespace,
-            )}/${referenceForModel(operandModel)}`,
+            activePerspective === 'dev'
+              ? '/topology'
+              : `${resourcePathFromModel(
+                  ClusterServiceVersionModel,
+                  clusterServiceVersion.metadata.name,
+                  namespace,
+                )}/${referenceForModel(operandModel)}`,
           ),
         )
         .catch((err: { json: Status }) => {
@@ -1306,6 +1309,7 @@ export type CreateOperandFormProps = {
   clusterServiceVersion: ClusterServiceVersionKind;
   buffer?: K8sResourceKind;
   namespace: string;
+  activePerspective: string;
 };
 
 export type CreateOperandYAMLProps = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/create-operand.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-operand.spec.tsx
@@ -22,6 +22,8 @@ import { referenceForProvidedAPI } from '.';
 
 import Spy = jasmine.Spy;
 
+const activePerspective = 'admin';
+
 describe(CreateOperand.displayName, () => {
   let wrapper: ShallowWrapper<CreateOperandProps>;
 
@@ -34,6 +36,7 @@ describe(CreateOperand.displayName, () => {
     };
     wrapper = shallow(
       <CreateOperand
+        activePerspective={activePerspective}
         operandModel={testModel}
         clusterServiceVersion={{ data: testClusterServiceVersion, loaded: true, loadError: null }}
         customResourceDefinition={{ data: testCRD, loaded: true, loadError: null }}
@@ -132,6 +135,7 @@ describe(CreateOperandForm.displayName, () => {
   beforeEach(() => {
     wrapper = shallow(
       <CreateOperandForm
+        activePerspective={activePerspective}
         namespace="default"
         operandModel={testModel}
         providedAPI={testClusterServiceVersion.spec.customresourcedefinitions.owned[0]}
@@ -207,6 +211,7 @@ describe(CreateOperandYAML.displayName, () => {
   beforeEach(() => {
     wrapper = shallow(
       <CreateOperandYAML
+        activePerspective={activePerspective}
         operandModel={testModel}
         providedAPI={testClusterServiceVersion.spec.customresourcedefinitions.owned[0]}
         clusterServiceVersion={testClusterServiceVersion}

--- a/frontend/public/components/instantiate-template.tsx
+++ b/frontend/public/components/instantiate-template.tsx
@@ -29,6 +29,8 @@ import {
   TemplateInstanceKind,
   TemplateParameter,
 } from '../module/k8s';
+import { getActivePerspective } from '../reducers/ui';
+import { RootState } from '../redux';
 
 const TemplateResourceDetails: React.FC<TemplateResourceDetailsProps> = ({ template }) => {
   const resources = _.uniq(_.compact(_.map(template.objects, 'kind'))).sort();
@@ -112,8 +114,9 @@ const TemplateInfo: React.FC<TemplateInfoProps> = ({ template }) => {
 };
 TemplateInfo.displayName = 'TemplateInfo';
 
-const stateToProps = ({ k8s }) => ({
-  models: k8s.getIn(['RESOURCES', 'models']),
+const stateToProps = (state: RootState) => ({
+  models: state.k8s.getIn(['RESOURCES', 'models']),
+  activePerspective: getActivePerspective(state),
 });
 
 class TemplateForm_ extends React.Component<TemplateFormProps, TemplateFormState> {
@@ -209,11 +212,13 @@ class TemplateForm_ extends React.Component<TemplateFormProps, TemplateFormState
         return this.createTemplateInstance(secret).then((instance: TemplateInstanceKind) => {
           this.setState({ inProgress: false });
           history.push(
-            resourcePathFromModel(
-              TemplateInstanceModel,
-              instance.metadata.name,
-              instance.metadata.namespace,
-            ),
+            this.props.activePerspective === 'dev'
+              ? `/topology`
+              : resourcePathFromModel(
+                  TemplateInstanceModel,
+                  instance.metadata.name,
+                  instance.metadata.namespace,
+                ),
           );
         });
       })
@@ -362,6 +367,7 @@ type TemplateFormProps = {
   obj: any;
   preselectedNamespace: string;
   models: any;
+  activePerspective: string;
 };
 
 type TemplateFormState = {


### PR DESCRIPTION
ODC-Bug: https://issues.redhat.com/browse/ODC-3152

This PR adds functionality to redirect page to the topology page when a resource is installed from dev-catalog.

**Template**
![t-to](https://user-images.githubusercontent.com/9278015/75236565-f7836e80-57e3-11ea-8444-e9c17bb35b13.gif)

**Operator-backed**
![ob-to](https://user-images.githubusercontent.com/9278015/75236541-f0f4f700-57e3-11ea-888b-20467c963ad7.gif)
