### PR TITLE
Bug 1806974: Kubevirt vm real node name

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -16,7 +16,7 @@ import {
 } from '@console/internal/components/utils';
 import { VMDashboardContext } from '../../vms/vm-dashboard-context';
 import { VirtualMachineModel, VirtualMachineInstanceModel } from '../../../models';
-import { getVmiIpAddresses } from '../../../selectors/vmi/ip-address';
+import { getVmiIpAddresses, getVMINodeName } from '../../../selectors/vmi';
 import { VM_DETAIL_DETAILS_HREF } from '../../../constants';
 import { findVMPod } from '../../../selectors/pod/selectors';
 
@@ -25,13 +25,14 @@ export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
   const { vm, vmi, pods } = vmDashboardContext;
   const vmiLike = vm || vmi;
 
-  const launcherPod = findVMPod(vmiLike, pods);
+  const launcherPod = findVMPod(vmi, pods);
 
   const ipAddrs = getVmiIpAddresses(vmi).join(', ');
 
   const isNodeLoading = !vmiLike || !pods;
   const name = getName(vmiLike);
   const namespace = getNamespace(vmiLike);
+  const nodeName = getVMINodeName(vmi) || getNodeName(launcherPod);
 
   const viewAllLink = `${resourcePath(
     vm ? VirtualMachineModel.kind : VirtualMachineInstanceModel.kind,
@@ -66,8 +67,8 @@ export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
           <DetailItem title="Created" error={false} isLoading={!vmiLike}>
             <Timestamp timestamp={getCreationTimestamp(vmiLike)} />
           </DetailItem>
-          <DetailItem title="Node" error={!isNodeLoading && !launcherPod} isLoading={isNodeLoading}>
-            {launcherPod && <NodeLink name={getNodeName(launcherPod)} />}
+          <DetailItem title="Node" error={!isNodeLoading && !nodeName} isLoading={isNodeLoading}>
+            {nodeName && <NodeLink name={nodeName} />}
           </DetailItem>
           <DetailItem
             title="IP Address"

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -18,14 +18,14 @@ import { VMDashboardContext } from '../../vms/vm-dashboard-context';
 import { VirtualMachineModel, VirtualMachineInstanceModel } from '../../../models';
 import { getVmiIpAddresses, getVMINodeName } from '../../../selectors/vmi';
 import { VM_DETAIL_DETAILS_HREF } from '../../../constants';
-import { findVMPod } from '../../../selectors/pod/selectors';
+import { findVMIPod } from '../../../selectors/pod/selectors';
 
 export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
   const vmDashboardContext = React.useContext(VMDashboardContext);
   const { vm, vmi, pods } = vmDashboardContext;
   const vmiLike = vm || vmi;
 
-  const launcherPod = findVMPod(vmi, pods);
+  const launcherPod = findVMIPod(vmi, pods);
 
   const ipAddrs = getVmiIpAddresses(vmi).join(', ');
 

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -19,7 +19,7 @@ import {
 } from '@console/shared/src/components/dashboard/duration-hook';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
 import { VMDashboardContext } from '../../vms/vm-dashboard-context';
-import { findVMPod } from '../../../selectors/pod/selectors';
+import { findVMIPod } from '../../../selectors/pod/selectors';
 import { isVMRunningWithVMI } from '../../../selectors/vm';
 import { getUtilizationQueries, getMultilineUtilizationQueries, VMQueries } from './queries';
 import { getPrometheusQueryEndTimestamp } from '@console/internal/components/graphs/helpers';
@@ -51,7 +51,7 @@ export const VMUtilizationCard: React.FC = () => {
   const vmiLike = vm || vmi;
   const vmName = getName(vmiLike);
   const namespace = getNamespace(vmiLike);
-  const launcherPodName = getName(findVMPod(vmi, pods));
+  const launcherPodName = getName(findVMIPod(vmi, pods));
   const vmIsRunning = isVMRunningWithVMI({ vm, vmi });
 
   const queries = React.useMemo(

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -51,7 +51,7 @@ export const VMUtilizationCard: React.FC = () => {
   const vmiLike = vm || vmi;
   const vmName = getName(vmiLike);
   const namespace = getNamespace(vmiLike);
-  const launcherPodName = getName(findVMPod(vmiLike, pods));
+  const launcherPodName = getName(findVMPod(vmi, pods));
   const vmIsRunning = isVMRunningWithVMI({ vm, vmi });
 
   const queries = React.useMemo(

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../selectors/vmi';
 import { getVMStatus } from '../../statuses/vm/vm';
 import { getLoadedData, getResource } from '../../utils';
-import { findVMPod } from '../../selectors/pod/selectors';
+import { findVMIPod } from '../../selectors/pod/selectors';
 import { isVMStarting, isWindows, asVM, isVM, isVMI } from '../../selectors/vm';
 import { VMIKind, VMKind } from '../../types/vm';
 import { menuActionStart } from './menu-actions';
@@ -108,7 +108,7 @@ const VmConsolesWrapper: React.FC<VmConsolesWrapperProps> = (props) => {
   let rdp;
   if (isWindows(vm)) {
     const rdpService = findRDPService(vmi, services);
-    const launcherPod = findVMPod(vmi, pods);
+    const launcherPod = findVMIPod(vmi, pods);
     rdp = getRdpConnectionDetails(vmi, rdpService, launcherPod);
   }
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
@@ -108,7 +108,7 @@ const VmConsolesWrapper: React.FC<VmConsolesWrapperProps> = (props) => {
   let rdp;
   if (isWindows(vm)) {
     const rdpService = findRDPService(vmi, services);
-    const launcherPod = findVMPod(vm, pods);
+    const launcherPod = findVMPod(vmi, pods);
     rdp = getRdpConnectionDetails(vmi, rdpService, launcherPod);
   }
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -25,7 +25,7 @@ import {
 } from '../modals/dedicated-resources-modal/consts';
 import { getOperatingSystemName, getOperatingSystem } from '../../selectors/vm';
 import { getVmiIpAddresses } from '../../selectors/vmi/ip-address';
-import { findVMPod as findVMIPod } from '../../selectors/pod/selectors';
+import { findVMIPod } from '../../selectors/pod/selectors';
 import { isVMIPaused, getVMINodeName } from '../../selectors/vmi';
 import { VirtualMachineInstanceModel, VirtualMachineModel } from '../../models';
 import { asVMILikeWrapper } from '../../k8s/wrapper/utils/convert';

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -25,8 +25,8 @@ import {
 } from '../modals/dedicated-resources-modal/consts';
 import { getOperatingSystemName, getOperatingSystem } from '../../selectors/vm';
 import { getVmiIpAddresses } from '../../selectors/vmi/ip-address';
-import { findVMPod } from '../../selectors/pod/selectors';
-import { isVMIPaused } from '../../selectors/vmi';
+import { findVMPod as findVMIPod } from '../../selectors/pod/selectors';
+import { isVMIPaused, getVMINodeName } from '../../selectors/vmi';
 import { VirtualMachineInstanceModel, VirtualMachineModel } from '../../models';
 import { asVMILikeWrapper } from '../../k8s/wrapper/utils/convert';
 
@@ -121,11 +121,11 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
 
   const [isStatusModalOpen, setStatusModalOpen] = React.useState<boolean>(false);
 
-  const launcherPod = findVMPod(vmiLike, pods);
+  const launcherPod = findVMIPod(vmi, pods);
   const id = getBasicID(vmiLike);
   const cds = vmiLikeWrapper?.getCDROMs() || [];
   const devices = vmiLikeWrapper?.getLabeledDevices() || [];
-  const nodeName = getNodeName(launcherPod);
+  const nodeName = getVMINodeName(vmi) || getNodeName(launcherPod);
   const ipAddrs = getVmiIpAddresses(vmi).join(', ');
   const workloadProfile = vmiLikeWrapper?.getWorkloadProfile();
   const flavorText = getFlavorText({

--- a/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
@@ -1,9 +1,9 @@
 import { get } from 'lodash';
-import { getName, getNamespace, getOwnerReferences } from '@console/shared/src/selectors';
+import { getName, getNamespace, getOwnerReferences, getUID } from '@console/shared/src/selectors';
 import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
 import { PodKind } from '@console/internal/module/k8s';
 import { getLabelValue } from '../selectors';
-import { VMKind } from '../../types';
+import { VMKind, VMIKind } from '../../types';
 import { getDataVolumeTemplates } from '../vm';
 import {
   CDI_KUBEVIRT_IO,
@@ -12,7 +12,6 @@ import {
 } from '../../constants';
 import { buildOwnerReferenceForModel } from '../../utils';
 import { VirtualMachineInstanceModel } from '../../models';
-import { VMILikeEntityKind } from '../../types/vmLike';
 
 export const getHostName = (pod: PodKind) =>
   get(pod, 'spec.hostname') as PodKind['spec']['hostname'];
@@ -47,26 +46,29 @@ export const isPodSchedulable = (pod: PodKind) => {
   );
 };
 
+const isPodReady = (pod: PodKind): boolean =>
+  pod?.status?.phase === 'Running' && pod?.status?.containerStatuses?.every((s) => s.ready);
+
 export const findVMPod = (
-  vm: VMILikeEntityKind,
+  vmi?: VMIKind,
   pods?: PodKind[],
   podNamePrefix = VIRT_LAUNCHER_POD_PREFIX,
 ) => {
-  if (!pods) {
+  if (!pods || !vmi) {
     return null;
   }
 
   // the UID is not set as we mimic VMI here
   const vmOwnerReference = buildOwnerReferenceForModel(
     VirtualMachineInstanceModel,
-    getName(vm),
-    null,
+    getName(vmi),
+    getUID(vmi),
   );
-  const prefix = `${podNamePrefix}${getName(vm)}-`;
+  const prefix = `${podNamePrefix}${getName(vmi)}-`;
   const prefixedPods = pods.filter((p) => {
     const podOwnerReferences = getOwnerReferences(p);
     return (
-      getNamespace(p) === getNamespace(vm) &&
+      getNamespace(p) === getNamespace(vmi) &&
       getName(p).startsWith(prefix) &&
       podOwnerReferences &&
       podOwnerReferences.some((podOwnerReference) =>
@@ -75,10 +77,12 @@ export const findVMPod = (
     );
   });
 
-  // Return the newet Pod created
-  return prefixedPods.sort((a: PodKind, b: PodKind) =>
-    a.metadata.creationTimestamp > b.metadata.creationTimestamp ? -1 : 1,
-  )[0];
+  // Return the newet most ready Pod created
+  return prefixedPods
+    .sort((a: PodKind, b: PodKind) =>
+      a.metadata.creationTimestamp > b.metadata.creationTimestamp ? -1 : 1,
+    )
+    .sort((a: PodKind) => (isPodReady(a) ? -1 : 1))[0];
 };
 
 export const getVMImporterPods = (

--- a/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
@@ -49,7 +49,7 @@ export const isPodSchedulable = (pod: PodKind) => {
 const isPodReady = (pod: PodKind): boolean =>
   pod?.status?.phase === 'Running' && pod?.status?.containerStatuses?.every((s) => s.ready);
 
-export const findVMPod = (
+export const findVMIPod = (
   vmi?: VMIKind,
   pods?: PodKind[],
   podNamePrefix = VIRT_LAUNCHER_POD_PREFIX,
@@ -78,11 +78,9 @@ export const findVMPod = (
   });
 
   // Return the newet most ready Pod created
-  return prefixedPods
-    .sort((a: PodKind, b: PodKind) =>
-      a.metadata.creationTimestamp > b.metadata.creationTimestamp ? -1 : 1,
-    )
-    .sort((a: PodKind) => (isPodReady(a) ? -1 : 1))[0];
+  return prefixedPods.sort((a: PodKind, b: PodKind) =>
+    isPodReady(a) && a.metadata.creationTimestamp > b.metadata.creationTimestamp ? -1 : 1,
+  )[0];
 };
 
 export const getVMImporterPods = (

--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
@@ -7,7 +7,7 @@ import {
   getMigrationStatusPhase,
 } from '../../selectors/vmi-migration';
 import {
-  findVMPod,
+  findVMIPod,
   getVMImporterPods,
   getPodStatusPhase,
   getPodContainerStatuses,
@@ -251,7 +251,7 @@ export const getVMStatus = ({
   migrations?: K8sResourceKind[];
 }): VMStatus => {
   const vmLike = vm || vmi;
-  const launcherPod = findVMPod(vmi, pods);
+  const launcherPod = findVMIPod(vmi, pods);
   return (
     isPaused(vmi) ||
     isV2VConversion(vmLike, pods) || // these statuses must precede isRunning() because they do not rely on ready vms

--- a/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/statuses/vm/vm.ts
@@ -251,7 +251,7 @@ export const getVMStatus = ({
   migrations?: K8sResourceKind[];
 }): VMStatus => {
   const vmLike = vm || vmi;
-  const launcherPod = findVMPod(vmLike, pods);
+  const launcherPod = findVMPod(vmi, pods);
   return (
     isPaused(vmi) ||
     isV2VConversion(vmLike, pods) || // these statuses must precede isRunning() because they do not rely on ready vms


### PR DESCRIPTION
The page displays the migration target node, instead the source node the VM was originally running on. VMI contains correct Node (the original one). Interestingly, after cca 5 or 6 minutes, the VM Status is suddenly 'Stopping', without invoking any action. VMI again reads correct phase Running.

Description:
_Problem A_ - we choose the VM pod by the last luncher pod created, in case of failed migration this will be the failed migration pod.
_Fix A_ - try to choose ready pods.

_Problem B_ - we show the VM node by checking the pod node and not the VMI node.
_FIx B_ - show node using VMI.

Screenshoot:
After:
![Peek 2020-02-25 13-10](https://user-images.githubusercontent.com/2181522/75243693-06155a00-57d3-11ea-86a9-d74a557243d9.gif)

Before:
![Peek 2020-02-25 13-17](https://user-images.githubusercontent.com/2181522/75243674-0150a600-57d3-11ea-90a0-618e211623e5.gif)
