### PR TITLE
Bug 1807230: Pipeline Builder Error Icon Fix

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarResource.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarResource.tsx
@@ -17,7 +17,9 @@ type TaskSidebarResourceProps = {
 const TaskSidebarResource: React.FC<TaskSidebarResourceProps> = (props) => {
   const { availableResources, onChange, resource, taskResource } = props;
 
-  const dropdownResources = availableResources.filter(({ type }) => resource.type === type);
+  const dropdownResources = availableResources.filter(
+    ({ name, type }) => resource.type === type && !!name,
+  );
 
   return (
     <FormGroup
@@ -25,15 +27,13 @@ const TaskSidebarResource: React.FC<TaskSidebarResourceProps> = (props) => {
       label={resource.name}
       helperText={`Only showing resources for this type (${resource.type}).`}
       helperTextInvalid={
-        dropdownResources.length === 0
-          ? `No resources of type ${resource.type} available. Add pipeline resources.`
-          : ''
+        dropdownResources.length === 0 ? `No resources available. Add pipeline resources.` : ''
       }
       isValid={dropdownResources.length > 0}
       isRequired
     >
       <Dropdown
-        title="Select resource..."
+        title={`Select ${resource.type} resource...`}
         items={dropdownResources.reduce((acc, { name }) => ({ ...acc, [name]: name }), {})}
         disabled={dropdownResources.length === 0}
         selectedKey={taskResource?.resource || ''}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -328,11 +328,15 @@ const updateTask: UpdateOperationAction<UpdateOperationUpdateTaskData> = (
 
   return {
     tasks: updatedTasks,
-    listTasks: listTasks.map(
-      (listTask) =>
-        canRename && mapReplaceRelatedInOthers(newName, thisPipelineTask.name, listTask),
-    ),
-    errors: getErrors(updatedResource, taskResource),
+    listTasks: canRename
+      ? listTasks.map((listTask) =>
+          mapReplaceRelatedInOthers(newName, thisPipelineTask.name, listTask),
+        )
+      : listTasks,
+    errors: {
+      [thisPipelineTask.name]: null,
+      ...getErrors(updatedResource, taskResource),
+    },
   };
 };
 


### PR DESCRIPTION
**Fixes**:
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-3139

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Essentially the issue was caused by an over-aggressive hook that would report all task statuses at the same time based on their structure. The logic was if I have input or output resources, are they available as form-level resources... if yes, no issue (clear the error), if no, then flag an error. This would cause an issue on task selection because it's in a different spot doing different logic.

At the end of the day, this is a failure of the error code - should have tried to use `yup` instead of rolling my own but I had issues and took an easy way out that has come back to haunt me. Have logged a ticket to track the [change to yup](https://issues.redhat.com/browse/ODC-3165).

**Solution Description**:
<!-- Describe your code changes in detail and explain the solution -->
Considered refactoring to use yup - that was half done but turned out to be a large solution which is not ideal at this stage of development. So I reduced it down to the hook tracking it's own flags and clearing them as it was done with them. There is possible for hiccups still, but it's at least not clearing overly-aggressively anymore.

**Screen shots / Gifs for design review**:
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screen Shot 2020-02-25 at 7 25 20 AM](https://user-images.githubusercontent.com/8126518/75247892-f7ae4a80-57a0-11ea-82fb-fdcb694adf62.png)
cc @openshift/team-devconsole-ux

**Unit test coverage report**:
<!-- Attach test coverage report -->
Tests need to be still done for the Pipeline Builder as a whole - will need to look to do this in the 4.5 stream.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
* Pipeline Builder Operator
* Build a Pipeline and use any of the ClusterTasks that have input/output resources (essentially any of the runtime tasks)

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug