### PR TITLE
Bug 1806994: fixes issue with editing knative service created via cli

### DIFF
--- a/frontend/packages/dev-console/src/actions/__tests__/modify-application.spec.ts
+++ b/frontend/packages/dev-console/src/actions/__tests__/modify-application.spec.ts
@@ -1,0 +1,45 @@
+import { DeploymentModel } from '@console/internal/models';
+import { ServiceModel } from '@console/knative-plugin';
+import { knativeServiceObj } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import { sampleDeployments } from '@console/dev-console/src/components/topology/__tests__/topology-test-data';
+import { EditApplication } from '../modify-application';
+
+describe('modify application edit flow', () => {
+  it('expect EditApplication to return hidden false for knative service without annotations', () => {
+    const editAppData = EditApplication(ServiceModel, knativeServiceObj);
+    expect(editAppData.hidden).toBe(false);
+  });
+
+  it('expect EditApplication to return hidden false for knative service with annotations', () => {
+    const knativeServiceObjWithAnnoations = {
+      ...knativeServiceObj,
+      metadata: {
+        ...knativeServiceObj.metadata,
+        annotations: {
+          'openshift.io/generated-by': 'OpenShiftWebConsole',
+        },
+      },
+    };
+    const editAppData = EditApplication(ServiceModel, knativeServiceObjWithAnnoations);
+    expect(editAppData.hidden).toBe(false);
+  });
+
+  it('expect EditApplication to return hidden true for Deployments without annotations', () => {
+    const editAppData = EditApplication(DeploymentModel, sampleDeployments.data[0]);
+    expect(editAppData.hidden).toBe(true);
+  });
+
+  it('expect EditApplication to return hidden false for Deployments with annotations', () => {
+    const sampleDeploymentWithAnnoations = {
+      ...sampleDeployments.data[0],
+      metadata: {
+        ...sampleDeployments.data[0].metadata,
+        annotations: {
+          'openshift.io/generated-by': 'OpenShiftWebConsole',
+        },
+      },
+    };
+    const editAppData = EditApplication(DeploymentModel, sampleDeploymentWithAnnoations);
+    expect(editAppData.hidden).toBe(false);
+  });
+});

--- a/frontend/packages/dev-console/src/actions/modify-application.ts
+++ b/frontend/packages/dev-console/src/actions/modify-application.ts
@@ -1,6 +1,7 @@
 import { KebabOption } from '@console/internal/components/utils';
 import { truncateMiddle } from '@console/internal/components/utils/truncate-middle';
 import { K8sResourceKind, K8sKind } from '@console/internal/module/k8s';
+import { ServiceModel } from '@console/knative-plugin';
 import { RESOURCE_NAME_TRUNCATE_LENGTH } from '../const';
 import { editApplicationModal } from '../components/modals';
 
@@ -28,7 +29,7 @@ export const EditApplication = (model: K8sKind, obj: K8sResourceKind): KebabOpti
   const annotation = obj?.metadata?.annotations?.['openshift.io/generated-by'];
   return {
     label: `Edit ${truncateMiddle(obj.metadata.name, { length: RESOURCE_NAME_TRUNCATE_LENGTH })}`,
-    hidden: annotation !== 'OpenShiftWebConsole',
+    hidden: obj.kind !== ServiceModel.kind && annotation !== 'OpenShiftWebConsole',
     href: `/edit/ns/${obj.metadata.namespace}?name=${obj.metadata.name}&kind=${obj.kind ||
       model.kind}`,
     accessReview: {

--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
@@ -586,3 +586,81 @@ export const internalImageValues: DeployImageFormData = {
   build: { env: [], triggers: {}, strategy: '' },
   isSearchingForImage: false,
 };
+
+export const knAppResources: AppResources = {
+  editAppResource: {
+    loaded: true,
+    loadError: '',
+    data: knativeService,
+  },
+  route: {
+    loaded: false,
+    loadError: 'routes.route.openshift.io "greeter" not found',
+    data: {},
+  },
+  buildConfig: {
+    loaded: false,
+    loadError: 'Error: buildconfigs.build.openshift.io "greeter" not found',
+    data: {},
+  },
+  imageStream: {
+    loaded: true,
+    loadError: '',
+    data: [],
+  },
+};
+
+export const knExternalImageValues: DeployImageFormData = {
+  application: { name: '', selectedKey: '#UNASSIGNED_KEY#' },
+  build: { env: [], strategy: '', triggers: {} },
+  deployment: { env: [], replicas: 1, triggers: { image: false } },
+  formType: 'edit',
+  image: { image: {}, name: '', ports: [], status: { metadata: {}, status: '' }, tag: '' },
+  imageStream: { grantAccess: true, image: '', namespace: '', tag: '' },
+  isSearchingForImage: false,
+  isi: { image: {}, name: '', ports: [], status: { metadata: {}, status: '' }, tag: '' },
+  labels: {},
+  limits: {
+    cpu: {
+      defaultLimitUnit: '',
+      defaultRequestUnit: '',
+      limit: '',
+      limitUnit: '',
+      request: '',
+      requestUnit: '',
+    },
+    memory: {
+      defaultLimitUnit: 'Mi',
+      defaultRequestUnit: 'Mi',
+      limit: '',
+      limitUnit: 'Mi',
+      request: '',
+      requestUnit: 'Mi',
+    },
+  },
+  name: 'nationalparks-py',
+  pipeline: { enabled: false },
+  project: { name: 'div' },
+  registry: 'external',
+  resources: Resources.KnativeService,
+  route: {
+    create: true,
+    defaultUnknownPort: 8080,
+    disable: true,
+    hostname: '',
+    path: '',
+    secure: false,
+    targetPort: '',
+    tls: {
+      caCertificate: '',
+      certificate: '',
+      destinationCACertificate: '',
+      insecureEdgeTerminationPolicy: '',
+      privateKey: '',
+      termination: '',
+    },
+    unknownTargetPort: '',
+  },
+  searchTerm: 'openshift/hello-openshift',
+  serverless: { scaling: { concurrencylimit: '', concurrencytarget: '', maxpods: '', minpods: 0 } },
+};

--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-utils.spec.ts
@@ -1,13 +1,17 @@
+import * as _ from 'lodash';
 import { BuildStrategyType } from '@console/internal/components/build';
 import {
   getResourcesType,
   getPageHeading,
   CreateApplicationFlow,
   getInitialValues,
+  getExternalImagelValues,
 } from '../edit-application-utils';
 import { Resources } from '../../import/import-types';
 import {
   knativeService,
+  knAppResources,
+  knExternalImageValues,
   appResources,
   gitImportInitialValues,
   externalImageValues,
@@ -34,5 +38,17 @@ describe('Edit Application Utils', () => {
     expect(getInitialValues({ editAppResource, route }, 'nationalparks-py', 'div')).toEqual(
       internalImageValues,
     );
+  });
+
+  it('getExternalImagelValues should return image name in search term', () => {
+    const externalImageData = getExternalImagelValues(knativeService);
+    expect(_.get(externalImageData, 'searchTerm')).toEqual('openshift/hello-openshift');
+  });
+
+  it('getInitialValues should return values externalImageValues on the resources', () => {
+    const { route, editAppResource, imageStream } = knAppResources;
+    expect(
+      getInitialValues({ editAppResource, route, imageStream }, 'nationalparks-py', 'div'),
+    ).toEqual(knExternalImageValues);
   });
 });

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -92,6 +92,7 @@ export const getRouteData = (route: K8sResourceKind, resource: K8sResourceKind) 
         _.get(resource, 'metadata.labels["serving.knative.dev/visibility"]', '') !==
         'cluster-local',
       unknownTargetPort: _.toString(port),
+      targetPort: _.toString(port),
     };
   }
   return routeData;
@@ -314,11 +315,13 @@ const deployImageInitialValues = {
   isSearchingForImage: false,
 };
 
-export const getExternalImageInitialValues = (imageStream: K8sResourceKind) => {
-  if (_.isEmpty(imageStream)) {
+export const getExternalImageInitialValues = (appResources: AppResources) => {
+  const imageStreamList = appResources?.imageStream?.data;
+  if (_.isEmpty(imageStreamList)) {
     return {};
   }
-  const name = _.get(imageStream, 'spec.tags[0].from.name');
+  const imageStream = _.orderBy(imageStreamList, ['metadata.resourceVersion'], ['desc']);
+  const name = imageStream.length && imageStream[0]?.spec?.tags?.[0]?.from?.name;
   return {
     ...deployImageInitialValues,
     searchTerm: name,

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -402,12 +402,16 @@ export const createOrUpdateDeployImageResources = async (
     let imageStreamUrl: string = image?.dockerImageReference;
     if (registry === RegistryType.External) {
       let generatedImageStreamName: string = '';
-      if (imageStreamList && imageStreamList.length && verb === 'update') {
-        const originalImageStreamTag = _.find(originalImageStream?.status?.tags, [
-          'tag',
-          imageStreamTag,
-        ]);
-        if (!_.isEmpty(originalImageStreamTag)) {
+      if (verb === 'update') {
+        if (imageStreamList && imageStreamList.length) {
+          const originalImageStreamTag = _.find(originalImageStream?.status?.tags, [
+            'tag',
+            imageStreamTag,
+          ]);
+          if (!_.isEmpty(originalImageStreamTag)) {
+            generatedImageStreamName = `${name}-${getRandomChars()}`;
+          }
+        } else {
           generatedImageStreamName = `${name}-${getRandomChars()}`;
         }
       }

--- a/frontend/packages/dev-console/src/components/import/serverless/ServerlessRouteSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/serverless/ServerlessRouteSection.tsx
@@ -5,7 +5,6 @@ import { useFormikContext, FormikValues } from 'formik';
 import { InputField, DropdownField } from '@console/shared';
 import FormSection from '../section/FormSection';
 import { RouteData } from '../import-types';
-import { makePortName } from '../../../utils/imagestream-utils';
 
 export interface ServerlessRouteSectionProps {
   route: RouteData;
@@ -15,12 +14,15 @@ const ServerlessRouteSection: React.FC<ServerlessRouteSectionProps> = ({ route }
   const {
     values: {
       image: { ports },
-      route: { defaultUnknownPort, targetPort },
+      route: { defaultUnknownPort, targetPort: routeTargetPort },
     },
   } = useFormikContext<FormikValues>();
+  const targetPort = routeTargetPort.split('-')[0];
   const portOptions = ports.reduce((acc, port) => {
-    const name = makePortName(port);
-    acc[name] = <>{port.containerPort}</>;
+    const name = port?.containerPort;
+    if (name) {
+      acc[name] = <>{port.containerPort}</>;
+    }
     return acc;
   }, {});
   return (

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { K8sResourceKind, referenceForModel, ImagePullPolicy } from '@console/internal/module/k8s';
 import { FirehoseResource } from '@console/internal/components/utils';
 import {
@@ -131,7 +132,14 @@ export const getKnativeServiceDepResource = (
     },
   };
 
-  const knativeDeployResource = mergeData(originalKnativeService || {}, newKnativeDeployResource);
+  let knativeServiceUpdated = {};
+  if (!_.isEmpty(originalKnativeService)) {
+    knativeServiceUpdated = _.omit(originalKnativeService, [
+      'status',
+      'spec.template.metadata.name',
+    ]);
+  }
+  const knativeDeployResource = mergeData(knativeServiceUpdated || {}, newKnativeDeployResource);
 
   return knativeDeployResource;
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3071

**Analysis / Root cause**: 
Edit flow doesn't work in knative service is created via CLI i.e on edit it doesn't show associated image as pre selected


**Solution Description**: 
if associated imageStreams are not found while editing going with value provided by user in yaml for container image

**Screen shots / Gifs for design review**: 
![ezgif com-optimize](https://user-images.githubusercontent.com/5129024/75249767-e5fa9080-57fc-11ea-8d61-0539e3779661.gif)

**Test Coverage**
<img width="788" alt="Screenshot 2020-03-09 at 8 59 21 PM" src="https://user-images.githubusercontent.com/5129024/76233651-84034780-624e-11ea-8fcc-a7a3991f0f26.png">

<img width="909" alt="Screenshot 2020-03-09 at 9 38 21 PM" src="https://user-images.githubusercontent.com/5129024/76233672-8b2a5580-624e-11ea-8648-b86342e71d4a.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
