### PR TITLE
Bug 1690701: Update the VM yaml format at the VM creation options

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
@@ -7,36 +7,58 @@ export const VirtualMachineYAMLTemplates = ImmutableMap().setIn(
 apiVersion: ${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}
 kind: ${VirtualMachineModel.kind}
 metadata:
+  labels:
+    app: example
+    flavor.template.kubevirt.io/tiny: 'true'
+    os.template.kubevirt.io/fedora31: 'true'
+    vm.kubevirt.io/template.revision: '1'
+    vm.kubevirt.io/template.version: v0.8.1
+    workload.template.kubevirt.io/server: 'true'
   name: example
 spec:
   running: false
   template:
+    metadata:
+      labels:
+        kubevirt.io/domain: example
+        kubevirt.io/size: tiny
     spec:
       domain:
+        cpu:
+          cores: 1
+          sockets: 1
+          threads: 1
         devices:
           disks:
             - name: containerdisk
+              bootOrder: 1
               disk:
                 bus: virtio
             - name: cloudinitdisk
               disk:
                 bus: virtio
           interfaces:
-          - name: default
-            model: virtio
-            masquerade: {}
+            - bootOrder: 2
+              masquerade: {}
+              model: virtio
+              name: nic0
+          rng: {}
         resources:
           requests:
-            memory: 64M
+            memory: 1G
+      hostname: example
       networks:
-      - name: default
-        pod: {}
+        - name: nic0
+          pod: {}
       volumes:
-        - name: containerdisk
-          containerDisk:
-            image: kubevirt/cirros-registry-disk-demo
-        - name: cloudinitdisk
-          cloudInitNoCloud:
-            userDataBase64: SGkuXG4=
+      - containerDisk:
+          image: docker.io/kubevirt/fedora-cloud-container-disk-demo:latest
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+        name: cloudinitdisk
 `,
 );


### PR DESCRIPTION
The yaml now has all the required fields so the user can
change its attributes after the VM was created via the 'details' tab.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>