### PR TITLE
[release-4.3] Bug 1811525: Add Pipeline Resources on Pipelines Resources tab don't work

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/PipelineDetailsPage.tsx
@@ -17,6 +17,10 @@ import {
   PipelineRuns,
 } from './detail-page-tabs';
 import PipelineForm from './pipeline-form/PipelineForm';
+import {
+  parametersValidationSchema,
+  resourcesValidationSchema,
+} from './pipeline-form/pipelineForm-validation-utils';
 
 interface PipelineDetailsPageStates {
   menuActions: Function[];
@@ -78,6 +82,8 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
               <PipelineForm
                 PipelineFormComponent={PipelineParameters}
                 formName="parameters"
+                validationSchema={parametersValidationSchema}
+                obj={props.obj}
                 {...props}
               />
             ),
@@ -89,6 +95,8 @@ class PipelineDetailsPage extends React.Component<DetailsPageProps, PipelineDeta
               <PipelineForm
                 PipelineFormComponent={PipelineResources}
                 formName="resources"
+                validationSchema={resourcesValidationSchema}
+                obj={props.obj}
                 {...props}
               />
             ),

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineForm.tsx
@@ -3,15 +3,20 @@ import * as _ from 'lodash';
 import { Formik } from 'formik';
 import { k8sUpdate, K8sResourceKind } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../../models';
-import { validationSchema } from './pipelineForm-validation-utils';
 
 export interface PipelineFormProps {
   PipelineFormComponent: React.ComponentType<any>;
   formName: string;
+  validationSchema: any;
   obj: K8sResourceKind;
 }
 
-const PipelineForm: React.FC<PipelineFormProps> = ({ PipelineFormComponent, formName, obj }) => {
+const PipelineForm: React.FC<PipelineFormProps> = ({
+  PipelineFormComponent,
+  formName,
+  validationSchema,
+  obj,
+}) => {
   const initialValues = {
     parameters: _.get(obj.spec, 'params', []),
     resources: _.get(obj.spec, 'resources', []),

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/__tests__/pipeline-form-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/__tests__/pipeline-form-validation-utils.spec.ts
@@ -1,0 +1,36 @@
+import { cloneDeep } from 'lodash';
+import {
+  parametersValidationSchema,
+  resourcesValidationSchema,
+} from '../pipelineForm-validation-utils';
+
+const mockParametersData = {
+  parameters: [
+    {
+      name: 'mock-param',
+      description: 'it is mock param',
+      default: 'mockery',
+    },
+  ],
+};
+
+const mockResourcesData = {
+  resources: [
+    {
+      name: 'mock-resource',
+      type: 'Git',
+    },
+  ],
+};
+
+describe('pipeline form validation utils', () => {
+  it('should validate parameters validation schema', async () => {
+    const mockData = cloneDeep(mockParametersData);
+    await parametersValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(true));
+  });
+
+  it('should validate resources form validation schema', async () => {
+    const mockData = cloneDeep(mockResourcesData);
+    await resourcesValidationSchema.isValid(mockData).then((valid) => expect(valid).toEqual(true));
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/pipelineForm-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/pipelineForm-validation-utils.ts
@@ -1,12 +1,15 @@
 import * as yup from 'yup';
 
-export const validationSchema = yup.object().shape({
+export const resourcesValidationSchema = yup.object().shape({
   resources: yup.array().of(
     yup.object().shape({
       name: yup.string().required('Required'),
       type: yup.string().required('Required'),
     }),
   ),
+});
+
+export const parametersValidationSchema = yup.object().shape({
   parameters: yup.array().of(
     yup.object().shape({
       name: yup.string().required('Required'),


### PR DESCRIPTION
This PR is manual cherrypick of PR https://github.com/openshift/console/pull/4287

When user click 'Add Pipeline Resources' button on Pipelines -> Resources tab, the changes can't be saved 

Problem: 
Both pipeline paramaters & resources validation Schema are maintained in same object resulting in validating both required fields in resources tab

Solution:
@rohitkrai03  has seperated the validation schema here in https://github.com/openshift/console/pull/4287 for openshift 4.4
The PR needs to be backported to 4.3 to address the issue ticket 
https://issues.redhat.com/browse/ODC-2881
 
cc: @andrewballantyne 