### PR TITLE
Bug 1806284: add await to create Image Stream request in deploy-image

### DIFF
--- a/frontend/integration-tests/tests/deploy-image.scenario.ts
+++ b/frontend/integration-tests/tests/deploy-image.scenario.ts
@@ -23,9 +23,6 @@ describe('Deploy Image', () => {
     });
 
     it('should render applications dropdown disabled', async () => {
-      // Navigate to the deploy-image page
-      await browser.get(`${appHost}/deploy-image/ns/${testName}?preselected-ns=${testName}`);
-
       const dropdown = '[data-test-id=namespace-bar-dropdown] > *:nth-child(2) button:disabled';
       // Wait for the Applications dropdown to appear
       await browser.wait(until.presenceOf(element(by.css(dropdown))));

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -359,9 +359,12 @@ export const createOrUpdateDeployImageResources = async (
   }
   if (formData.resources !== Resources.KnativeService) {
     registry === RegistryType.External &&
-      requests.push(
-        createOrUpdateImageStream(formData, dryRun, _.get(appResources, 'imageStream.data'), verb),
-      );
+      (await createOrUpdateImageStream(
+        formData,
+        dryRun,
+        _.get(appResources, 'imageStream.data'),
+        verb,
+      ));
     if (formData.resources === Resources.Kubernetes) {
       requests.push(
         createOrUpdateDeployment(


### PR DESCRIPTION
This Pr fixes the intermittent failure of deploy image integration tests.

Failure message: `Deployment.apps \"hello-openshift\" is invalid: spec.template.spec.containers[0].image: Forbidden: this image is prohibited by policy: this image is prohibited by policy (changed after admission)`