### PR TITLE
Bug 1805196: redirect the edit form page with in context of namespace

### DIFF
--- a/frontend/packages/dev-console/src/actions/modify-application.ts
+++ b/frontend/packages/dev-console/src/actions/modify-application.ts
@@ -27,7 +27,8 @@ export const ModifyApplication = (kind: K8sKind, obj: K8sResourceKind): KebabOpt
 export const EditApplication = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
   return {
     label: `Edit ${truncateMiddle(obj.metadata.name, { length: RESOURCE_NAME_TRUNCATE_LENGTH })}`,
-    href: `/edit?name=${obj.metadata.name}&kind=${obj.kind || model.kind}`,
+    href: `/edit/ns/${obj.metadata.namespace}?name=${obj.metadata.name}&kind=${obj.kind ||
+      model.kind}`,
     accessReview: {
       group: model.apiGroup,
       resource: model.plural,

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -401,7 +401,6 @@ const plugin: Plugin<ConsumedExtensions> = [
         '/deploy-image',
         '/project-access',
         '/dev-monitoring',
-        '/edit',
         '/helm-releases',
       ],
       component: NamespaceRedirect,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3136

**Analysis / Root cause**: 
Getting 404 error if we edit the resources from the list of all projects.

**Solution Description**: 
Redirect the URL to the edit form page with in context of namespace.

**Screen shots / Gifs for design review**: 

![Kapture 2020-02-25 at 23 05 08](https://user-images.githubusercontent.com/2561818/75272273-92e80400-5823-11ea-8fd2-f9a0f6fda39c.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
