### PR TITLE
Bug 1806023: Fix bug where required indicator overlays label aside

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1223,7 +1223,7 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
           <div className="co-form-section__separator" />
 
           <div className="form-group">
-            <label className="co-required">Matchers</label> (label selectors)
+            <label className="co-required">Matchers (label selectors)</label>
             <p className="co-help-text">
               Alerts affected by this silence. Matching alerts must satisfy all of the specified
               label constraints, though they may have additional labels as well.


### PR DESCRIPTION
Before:
<img width="1445" alt="Screen Shot 2020-02-21 at 3 15 14 PM" src="https://user-images.githubusercontent.com/895728/75282442-16333680-57df-11ea-9ef3-e2b082debb8d.png">

After:
![Screen Shot 2020-02-25 at 2 54 49 PM](https://user-images.githubusercontent.com/895728/75282459-1c291780-57df-11ea-9065-41e011154a9a.png)
