### PR TITLE
[WIP] Bug 1802034: Silenced alerts should not show up in the Dashboards page of the console

### DIFF
--- a/frontend/integration-tests/views/monitoring.view.ts
+++ b/frontend/integration-tests/views/monitoring.view.ts
@@ -4,7 +4,7 @@ import { $, $$, browser, by, element, ExpectedConditions as until } from 'protra
 import * as crudView from '../views/crud.view';
 import { firstElementByTestID } from '../protractor.conf';
 
-export const wait = async (condition) => await browser.wait(condition, 15000);
+export const wait = async (condition) => await browser.wait(condition, 20000);
 
 // List pages
 export const listPageHeading = $('.co-m-pane__heading');

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/status-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/status-card.tsx
@@ -1,16 +1,14 @@
 import * as React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
-import { ALERTS_KEY } from '@console/internal/actions/dashboards';
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
 import AlertItem from '@console/shared/src/components/dashboard/status-card/AlertItem';
-import { alertURL, PrometheusRulesResponse } from '@console/internal/components/monitoring';
+import { alertURL } from '@console/internal/components/monitoring';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
 import HealthItem from '@console/shared/src/components/dashboard/status-card/HealthItem';
-import { getAlerts } from '@console/shared/src/components/dashboard/status-card/alert-utils';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import {
   withDashboardResources,
@@ -27,32 +25,22 @@ import { getCephHealthState, getDataResiliencyState } from './utils';
 const cephStatusQuery = STORAGE_HEALTH_QUERIES[StorageDashboardQuery.CEPH_STATUS_QUERY];
 const resiliencyProgressQuery = DATA_RESILIENCY_QUERY[StorageDashboardQuery.RESILIENCY_PROGRESS];
 
-export const CephAlerts = withDashboardResources(
-  ({ watchAlerts, stopWatchAlerts, alertsResults }) => {
-    React.useEffect(() => {
-      watchAlerts();
-      return () => {
-        stopWatchAlerts();
-      };
-    }, [watchAlerts, stopWatchAlerts]);
-
-    const alertsResponse = alertsResults.getIn([ALERTS_KEY, 'data']) as PrometheusRulesResponse;
-    const alertsResponseError = alertsResults.getIn([ALERTS_KEY, 'loadError']);
-    const alerts = filterCephAlerts(getAlerts(alertsResponse));
-
-    return (
-      <AlertsBody
-        isLoading={!alertsResponse}
-        error={alertsResponseError}
-        emptyMessage="No persistent storage alerts"
-      >
-        {alerts.length
-          ? alerts.map((alert) => <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />)
-          : null}
-      </AlertsBody>
-    );
-  },
-);
+export const CephAlerts = withDashboardResources(({ notificationAlerts }) => {
+  const { data: allAlerts, loaded: alertsLoaded, loadError: alertsResponseError } =
+    notificationAlerts || {};
+  const alerts = filterCephAlerts(allAlerts);
+  return (
+    <AlertsBody
+      isLoading={!alertsLoaded}
+      error={alertsResponseError}
+      emptyMessage="No persistent storage alerts"
+    >
+      {alerts.length
+        ? alerts.map((alert) => <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />)
+        : null}
+    </AlertsBody>
+  );
+});
 
 export const StatusCard: React.FC<DashboardItemProps> = ({
   watchPrometheus,

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/StatusCard.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/StatusCard.tsx
@@ -12,11 +12,9 @@ import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboa
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
 import HealthItem from '@console/shared/src/components/dashboard/status-card/HealthItem';
 import { HealthState } from '@console/shared/src/components/dashboard/status-card/states';
-import { ALERTS_KEY } from '@console/internal/actions/dashboards';
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
 import AlertItem from '@console/shared/src/components/dashboard/status-card/AlertItem';
-import { getAlerts } from '@console/shared/src/components/dashboard/status-card/alert-utils';
-import { Alert, PrometheusRulesResponse, alertURL } from '@console/internal/components/monitoring';
+import { Alert, alertURL } from '@console/internal/components/monitoring';
 import { getBareMetalHostStatus } from '../../../status/host-status';
 import {
   HOST_SUCCESS_STATES,
@@ -66,21 +64,13 @@ const getHostHardwareHealthState = (obj): HostHealthState => {
 const filterAlerts = (alerts: Alert[]): Alert[] =>
   alerts.filter((alert) => _.get(alert, 'labels.hwalert'));
 
-const HealthCard: React.FC<HealthCardProps> = ({ watchAlerts, stopWatchAlerts, alertsResults }) => {
+const HealthCard: React.FC<HealthCardProps> = ({ notificationAlerts }) => {
   const { obj } = React.useContext(BareMetalHostDashboardContext);
-
-  React.useEffect(() => {
-    watchAlerts();
-    return () => stopWatchAlerts();
-  }, [watchAlerts, stopWatchAlerts]);
-
   const health = getHostHealthState(obj);
   const hwHealth = getHostHardwareHealthState(obj);
-
-  const alertsResponse = alertsResults.getIn([ALERTS_KEY, 'data']) as PrometheusRulesResponse;
-  const alertsResponseError = alertsResults.getIn([ALERTS_KEY, 'loadError']);
-  const alerts = filterAlerts(getAlerts(alertsResponse));
-
+  const { data: allAlerts, loaded: alertsLoaded, loadError: alertsResponseError } =
+    notificationAlerts || {};
+  const alerts = filterAlerts(allAlerts);
   return (
     <DashboardCard gradient>
       <DashboardCardHeader>
@@ -98,7 +88,7 @@ const HealthCard: React.FC<HealthCardProps> = ({ watchAlerts, stopWatchAlerts, a
           </Gallery>
         </HealthBody>
         <AlertsBody
-          isLoading={!alertsResponse}
+          isLoading={!alertsLoaded}
           error={alertsResponseError}
           emptyMessage="No alerts or messages"
         >

--- a/frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
-import { ALERTS_KEY } from '@console/internal/actions/dashboards';
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
 import AlertItem from '@console/shared/src/components/dashboard/status-card/AlertItem';
-import { alertURL, PrometheusRulesResponse } from '@console/internal/components/monitoring';
+import { alertURL } from '@console/internal/components/monitoring';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
 import HealthItem from '@console/shared/src/components/dashboard/status-card/HealthItem';
-import { getAlerts } from '@console/shared/src/components/dashboard/status-card/alert-utils';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import {
   withDashboardResources,
@@ -34,21 +32,14 @@ const noobaaResource: FirehoseResource = {
   prop: 'noobaa',
 };
 
-const NooBaaAlerts = withDashboardResources(({ watchAlerts, stopWatchAlerts, alertsResults }) => {
-  React.useEffect(() => {
-    watchAlerts();
-    return () => {
-      stopWatchAlerts();
-    };
-  }, [watchAlerts, stopWatchAlerts]);
-
-  const alertsResponse = alertsResults.getIn([ALERTS_KEY, 'data']) as PrometheusRulesResponse;
-  const alertsResponseError = alertsResults.getIn([ALERTS_KEY, 'loadError']);
-  const alerts = filterNooBaaAlerts(getAlerts(alertsResponse));
+const NooBaaAlerts = withDashboardResources(({ notificationAlerts }) => {
+  const { data: allAlerts, loaded: alertsLoaded, loadError: alertsResponseError } =
+    notificationAlerts || {};
+  const alerts = filterNooBaaAlerts(allAlerts);
 
   return (
     <AlertsBody
-      isLoading={!alertsResponse}
+      isLoading={!alertsLoaded}
       error={alertsResponseError}
       emptyMessage="No object service alerts"
     >

--- a/frontend/public/actions/dashboards.ts
+++ b/frontend/public/actions/dashboards.ts
@@ -19,8 +19,6 @@ export enum ActionType {
 
 const REFRESH_TIMEOUT = 5000;
 
-export const ALERTS_KEY = 'alerts';
-
 export const stopWatch = (type: RESULTS_TYPE, key: string) =>
   action(ActionType.StopWatch, { type, key });
 export const setData = (type: RESULTS_TYPE, key: string, data) =>
@@ -121,33 +119,9 @@ export const watchURL: WatchURLAction = (url, fetch = coFetchJSON) => (dispatch,
   }
 };
 
-export const watchAlerts: WatchAlertsAction = () => (dispatch, getState) => {
-  const isActive = isWatchActive(getState().dashboards, RESULTS_TYPE.ALERTS, ALERTS_KEY);
-  dispatch(activateWatch(RESULTS_TYPE.ALERTS, ALERTS_KEY));
-  if (!isActive) {
-    const { prometheusBaseURL } = window.SERVER_FLAGS;
-    if (!prometheusBaseURL) {
-      dispatch(
-        setError(RESULTS_TYPE.ALERTS, ALERTS_KEY, new Error('Prometheus URL is not available')),
-      );
-    } else {
-      const prometheusURL = () => `${prometheusBaseURL}/api/v1/rules`;
-      fetchPeriodically(
-        dispatch,
-        RESULTS_TYPE.ALERTS,
-        ALERTS_KEY,
-        prometheusURL,
-        getState,
-        coFetchJSON,
-      );
-    }
-  }
-};
-
 export const stopWatchPrometheusQuery: StopWatchPrometheusAction = (query, timespan) =>
   stopWatch(RESULTS_TYPE.PROMETHEUS, getQueryKey(query, timespan));
 export const stopWatchURL = (url: string) => stopWatch(RESULTS_TYPE.URL, url);
-export const stopWatchAlerts = () => stopWatch(RESULTS_TYPE.ALERTS, ALERTS_KEY);
 
 type ThunkAction = (dispatch: Dispatch, getState: () => RootState) => void;
 
@@ -157,10 +131,8 @@ export type WatchPrometheusQueryAction = (
   namespace?: string,
   timespan?: number,
 ) => ThunkAction;
-export type WatchAlertsAction = () => ThunkAction;
 export type StopWatchURLAction = (url: string) => void;
 export type StopWatchPrometheusAction = (query: string, timespan?: number) => void;
-export type StopWatchAlertsAction = () => void;
 
 export type Fetch = (url: string) => Promise<any>;
 

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -39,6 +39,7 @@ import { formatPrometheusDuration } from './utils/datetime';
 import { withFallback } from './utils/error-boundary';
 import { AlertmanagerYAMLEditorWrapper } from './monitoring/alert-manager-yaml-editor';
 import { AlertmanagerConfigWrapper } from './monitoring/alert-manager-config';
+import { refreshNotificationPollers } from './notification-drawer';
 import {
   ActionsMenu,
   ButtonBar,
@@ -100,12 +101,6 @@ const silencesToProps = ({ UI }) => UI.getIn(['monitoring', 'silences']) || {};
 const pollers = {};
 const pollerTimeouts = {};
 
-// Force a poller to execute now instead of waiting for the next poll interval
-const refreshPoller = (key) => {
-  clearTimeout(pollerTimeouts[key]);
-  _.invoke(pollers, key);
-};
-
 const silenceAlert = (alert) => ({
   label: 'Silence Alert',
   href: `${SilenceResource.plural}/~new?${labelsToParams(alert.labels)}`,
@@ -131,7 +126,7 @@ const cancelSilence = (silence) => ({
       executeFn: () =>
         coFetchJSON
           .delete(`${window.SERVER_FLAGS.alertManagerBaseURL}/api/v1/silence/${silence.id}`)
-          .then(() => refreshPoller('silences')),
+          .then(() => refreshNotificationPollers()),
     }),
 });
 
@@ -575,7 +570,7 @@ const silenceParamToProps = (state, { match }) => {
   const { data: silences, loaded, loadError }: Silences = silencesToProps(state);
   const { loaded: alertsLoaded }: Alerts = alertsToProps(state);
   const silence = _.find(silences, { id: _.get(match, 'params.id') });
-  return { alertsLoaded, loaded, loadError, silence };
+  return { alertsLoaded, loaded, loadError, silence, silences };
 };
 
 const SilencesDetailsPage = withFallback(
@@ -1185,7 +1180,7 @@ class SilenceForm_ extends React.Component<SilenceFormProps, SilenceFormState> {
       .post(`${alertManagerBaseURL}/api/v1/silences`, body)
       .then(({ data }) => {
         this.setState({ error: undefined });
-        refreshPoller('silences');
+        refreshNotificationPollers();
         history.push(`${SilenceResource.plural}/${encodeURIComponent(_.get(data, 'silenceId'))}`);
       })
       .catch((err) =>
@@ -1495,7 +1490,7 @@ export const getAlerts = (data: PrometheusRulesResponse['data']): Alert[] => {
 
 const PollerPages = () => {
   React.useEffect(() => {
-    const poll: Poll = (url, key: 'alerts' | 'silences', dataHandler) => {
+    const poll: Poll = (url, key: 'alerts', dataHandler) => {
       store.dispatch(UIActions.monitoringLoading(key));
       const poller = (): void => {
         coFetchJSON(url)
@@ -1508,34 +1503,13 @@ const PollerPages = () => {
       poller();
     };
 
-    const { alertManagerBaseURL, prometheusBaseURL } = window.SERVER_FLAGS;
+    const { prometheusBaseURL } = window.SERVER_FLAGS;
 
     if (prometheusBaseURL) {
       poll(`${prometheusBaseURL}/api/v1/rules`, 'alerts', getAlerts);
     } else {
       store.dispatch(UIActions.monitoringErrored('alerts', new Error('prometheusBaseURL not set')));
     }
-
-    if (alertManagerBaseURL) {
-      poll(`${alertManagerBaseURL}/api/v1/silences`, 'silences', (data) => {
-        // Set a name field on the Silence to make things easier
-        _.each(data, (s) => {
-          s.name = _.get(_.find(s.matchers, { name: 'alertname' }), 'value');
-          if (!s.name) {
-            // No alertname, so fall back to displaying the other matchers
-            s.name = s.matchers
-              .map((m) => `${m.name}${m.isRegex ? '=~' : '='}${m.value}`)
-              .join(', ');
-          }
-        });
-        return data;
-      });
-    } else {
-      store.dispatch(
-        UIActions.monitoringErrored('silences', new Error('alertManagerBaseURL not set')),
-      );
-    }
-
     return () => _.each(pollerTimeouts, clearTimeout);
   }, []);
 

--- a/frontend/public/reducers/dashboards.ts
+++ b/frontend/public/reducers/dashboards.ts
@@ -4,13 +4,11 @@ import { Map as ImmutableMap, fromJS } from 'immutable';
 export enum RESULTS_TYPE {
   PROMETHEUS = 'PROMETHEUS',
   URL = 'URL',
-  ALERTS = 'ALERTS',
 }
 
 export const defaults = {
   [RESULTS_TYPE.PROMETHEUS]: fromJS({}),
   [RESULTS_TYPE.URL]: fromJS({}),
-  [RESULTS_TYPE.ALERTS]: fromJS({}),
 };
 
 type Request<R> = {

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -43,6 +43,30 @@ const newQueryBrowserQuery = (): ImmutableMap<string, any> =>
     isExpanded: true,
   });
 
+const getFiringAlerts = (alerts) =>
+  _.filter([...[].concat(alerts || [])], (a) => {
+    return [AlertStates.Firing, AlertStates.Silenced].includes(a?.state);
+  });
+
+const silenceFiringAlerts = (firingAlerts, silences) => {
+  // For each firing alert, store a list of the Silences that are silencing it and set its state to show it is silenced
+  _.each(firingAlerts, (a) => {
+    a.silencedBy = _.filter(
+      _.get(silences, 'data'),
+      (s) => _.get(s, 'status.state') === SilenceStates.Active && isSilenced(a, s),
+    );
+    if (a.silencedBy.length) {
+      a.state = AlertStates.Silenced;
+      // Also set the state of Alerts in `rule.alerts`
+      _.each(a.rule.alerts, (ruleAlert) => {
+        if (_.some(a.silencedBy, (s) => isSilenced(ruleAlert, s))) {
+          ruleAlert.state = AlertStates.Silenced;
+        }
+      });
+    }
+  });
+};
+
 export default (state: UIState, action: UIAction): UIState => {
   if (!state) {
     const { pathname } = window.location;
@@ -169,38 +193,32 @@ export default (state: UIState, action: UIAction): UIState => {
       return state.mergeIn(['monitoringDashboards', 'variables', key], ImmutableMap(patch));
     }
     case ActionType.SetMonitoringData: {
+      // alerts used by monitoring -> alerting pages
       const alerts =
         action.payload.key === 'alerts'
           ? action.payload.data
           : state.getIn(['monitoring', 'alerts']);
+      // notificationAlerts used by notification drawer and certain dashboards
       const notificationAlerts =
         action.payload.key === 'notificationAlerts'
           ? action.payload.data
           : state.getIn(['monitoring', 'notificationAlerts']);
-      const firingAlerts = _.filter(_.get(alerts, 'data'), (a) =>
-        [AlertStates.Firing, AlertStates.Silenced].includes(a.state),
-      );
       const silences =
         action.payload.key === 'silences'
           ? action.payload.data
           : state.getIn(['monitoring', 'silences']);
 
-      // For each Alert, store a list of the Silences that are silencing it and set its state to show it is silenced
-      _.each(firingAlerts, (a) => {
-        a.silencedBy = _.filter(
-          _.get(silences, 'data'),
-          (s) => _.get(s, 'status.state') === SilenceStates.Active && isSilenced(a, s),
-        );
-        if (a.silencedBy.length) {
-          a.state = AlertStates.Silenced;
-          // Also set the state of Alerts in `rule.alerts`
-          _.each(a.rule.alerts, (ruleAlert) => {
-            if (_.some(a.silencedBy, (s) => isSilenced(ruleAlert, s))) {
-              ruleAlert.state = AlertStates.Silenced;
-            }
-          });
-        }
-      });
+      const firingAlerts = getFiringAlerts(_.get(alerts, 'data', []));
+      silenceFiringAlerts(firingAlerts, silences);
+      silenceFiringAlerts(getFiringAlerts(_.get(notificationAlerts, 'data', [])), silences);
+      // filter out silenced alerts from notificationAlerts
+      _.set(
+        notificationAlerts,
+        'data',
+        !_.isEmpty(notificationAlerts?.data)
+          ? notificationAlerts.data.filter((a) => a?.state !== AlertStates.Silenced)
+          : notificationAlerts?.data,
+      );
       state = state.setIn(['monitoring', 'alerts'], alerts);
       state = state.setIn(['monitoring', 'notificationAlerts'], notificationAlerts);
 


### PR DESCRIPTION
This PR addresses hiding silenced alerts in dashboards as well as the notification drawer.
This PR could be broken into two PRs, one for notification drawer and another for dashboards.  I could see backporting the notification drawer PR, but  maybe dashboard changes are too risky to backport?

This WIP PR:
- moves polling for Silences from Monitoring -> alert pages to Notification Drawer alert polling
- updates monitor reducer to also tag notification alerts as silenced, and filters out silenced notificaitonAlerts (which are used in notification drawer and dashbards).
- removes alert watching/polling from Dashboards, and switches them to use Notification Drawer notificaitonAlerts polling

**Now Silencing an Alert hides it from Notification Drawer and Cluster Dashboard:**
_***Note the long pause/refresh/component update when Expiring A Silence, see Open Issues below**_

<img src="https://raw.githubusercontent.com/dtaylor113/images/master/SilencedAlerts.gif" />

TODO/Open Issues:
1. Updated `frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/StatusCard.tsx`, need to figure out how to test
2. Updated `frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx`, need to figure out how to test
3. Typescript pass
4. Note the long pause/refresh/component update when Expiring A Silence, this sometimes happen when [creating a Silence](https://raw.githubusercontent.com/dtaylor113/images/master/LongCreateSilence.gif) as well. Debugged through it, polling is happening, but silences seem to take some time to update on the backend after POST and/or DELETE.  Although browser reload always seems to immediately get the updated silences; so maybe a component update issue?
4. Break WIP PR into smaller PRs, or handle all in one (this) PR?