### PR TITLE
Bug 1805899: Make selected items show check mark in dropdown

### DIFF
--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -7,10 +7,11 @@ import * as fuzzy from 'fuzzysearch';
 
 import { Dropdown, ResourceIcon } from './utils';
 import {
+  apiVersionForReference,
   K8sKind,
   K8sResourceKindReference,
+  modelFor,
   referenceForModel,
-  apiVersionForReference,
 } from '../module/k8s';
 import { Badge, Checkbox } from '@patternfly/react-core';
 
@@ -122,6 +123,10 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
     return fuzzy(_.toLower(text), _.toLower(model.kind));
   };
 
+  const handleSelected = (value: string) => {
+    onChange(referenceForModel(modelFor(value)));
+  };
+
   return (
     <Dropdown
       menuClassName="dropdown-menu--text-wrap"
@@ -135,7 +140,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
           </Badge>
         </div>
       }
-      onChange={onChange}
+      onChange={handleSelected}
       autocompleteFilter={autocompleteFilter}
       autocompletePlaceholder="Select Resource"
     />


### PR DESCRIPTION
The value from the dropdown select did not match the expected key for the check boxes in the dropdown for most standard resource types.  This meant the checkbox might not be checked for a selected resource.
![Screenshot_2020-02-25 Search · OKD](https://user-images.githubusercontent.com/18728857/75305944-ca938380-5804-11ea-9ebd-b222891615a9.png)

As for the solution, the underlying models are stored in an orderedmap of <key:model>. The key for most common resources are simply the kind name, i.e. "Pod" or "PersistentVolumeClaim".  However, my dropdown checkbox uses the more specific group~version~kind key (i.e. "core~v1~Pod") to prevent any ambiguity.  Instead of changing the orderedMap, I simply inject the full group-version-kind value into the selected value which is preferred to prevent future ambiguity.
  
 