### PR TITLE
Bug 1805903: Fix tab order in dropdown list

### DIFF
--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -29,7 +29,11 @@ const blacklistResources = ImmutableSet([
 const DropdownItem: React.SFC<DropdownItemProps> = ({ model, showGroup, checked }) => (
   <>
     <span className={'co-resource-item'}>
-      <Checkbox id={`${model.apiGroup}:${model.apiVersion}:${model.kind}`} isChecked={checked} />
+      <Checkbox
+        tabIndex={-1}
+        id={`${model.apiGroup}:${model.apiVersion}:${model.kind}`}
+        isChecked={checked}
+      />
       <span className="co-resource-icon--fixed-width">
         <ResourceIcon kind={referenceForModel(model)} />
       </span>


### PR DESCRIPTION
The new checkbox in the resource dropdown forces an extra tab for each value.  I have removed the checkbox itself from the tab order and now the user can just select the row.