### PR TITLE
Bug 1806286: Limits Bucket Class search to storage namespace in OBC creation page.

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/create-obc.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/create-obc.tsx
@@ -26,6 +26,7 @@ import { ActionGroup, Button } from '@patternfly/react-core';
 import { StorageClass } from '@console/internal/components/storage-class-form';
 import { filterScOnProvisioner, getName, ResourceDropdown } from '@console/shared';
 import { commonReducer, defaultState } from '../object-bucket-page/state';
+import { OCS_NS } from '../../constants';
 import './create-obc.scss';
 
 export const CreateOBCPage: React.FC<CreateOBCPageProps> = (props) => {
@@ -138,6 +139,7 @@ export const CreateOBCPage: React.FC<CreateOBCPageProps> = (props) => {
                   {
                     isList: true,
                     kind: referenceForModel(NooBaaBucketClassModel),
+                    namespace: OCS_NS,
                     prop: 'bucketClass',
                   },
                 ]}

--- a/frontend/packages/noobaa-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/index.ts
@@ -6,6 +6,7 @@ export const BY_PHYSICAL_VS_LOGICAL_USAGE = 'Physical Vs Logical Usage';
 export const BY_EGRESS = 'Egress';
 export const PROJECTS = 'Projects';
 export const BUCKET_CLASS = 'Bucket Class';
+export const OCS_NS = 'openshift-storage';
 
 export const CHART_LABELS = {
   [BY_LOGICAL_USAGE]: 'Logical used capacity per account',


### PR DESCRIPTION
- Bucket Classes cannot exist outside of OCS namespace.
- In the future, there might be bucket classes made for other purposes in other namespaces that shouldn't be used with OBCs.
