### PR TITLE
Bug 1807561: show edit option for only resources created via add flow.

### DIFF
--- a/frontend/packages/dev-console/src/actions/modify-application.ts
+++ b/frontend/packages/dev-console/src/actions/modify-application.ts
@@ -1,7 +1,6 @@
 import { KebabOption } from '@console/internal/components/utils';
 import { truncateMiddle } from '@console/internal/components/utils/truncate-middle';
 import { K8sResourceKind, K8sKind } from '@console/internal/module/k8s';
-import { ServiceModel } from '@console/knative-plugin';
 import { RESOURCE_NAME_TRUNCATE_LENGTH } from '../const';
 import { editApplicationModal } from '../components/modals';
 
@@ -29,9 +28,7 @@ export const EditApplication = (model: K8sKind, obj: K8sResourceKind): KebabOpti
   const annotation = obj?.metadata?.annotations?.['openshift.io/generated-by'];
   return {
     label: `Edit ${truncateMiddle(obj.metadata.name, { length: RESOURCE_NAME_TRUNCATE_LENGTH })}`,
-    hidden:
-      (obj.kind !== ServiceModel.kind && !annotation) ||
-      (annotation && annotation !== 'OpenShiftWebConsole'),
+    hidden: annotation !== 'OpenShiftWebConsole',
     href: `/edit/ns/${obj.metadata.namespace}?name=${obj.metadata.name}&kind=${obj.kind ||
       model.kind}`,
     accessReview: {

--- a/frontend/packages/dev-console/src/actions/modify-application.ts
+++ b/frontend/packages/dev-console/src/actions/modify-application.ts
@@ -1,6 +1,7 @@
 import { KebabOption } from '@console/internal/components/utils';
 import { truncateMiddle } from '@console/internal/components/utils/truncate-middle';
 import { K8sResourceKind, K8sKind } from '@console/internal/module/k8s';
+import { ServiceModel } from '@console/knative-plugin';
 import { RESOURCE_NAME_TRUNCATE_LENGTH } from '../const';
 import { editApplicationModal } from '../components/modals';
 
@@ -25,8 +26,12 @@ export const ModifyApplication = (kind: K8sKind, obj: K8sResourceKind): KebabOpt
 };
 
 export const EditApplication = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
+  const annotation = obj?.metadata?.annotations?.['openshift.io/generated-by'];
   return {
     label: `Edit ${truncateMiddle(obj.metadata.name, { length: RESOURCE_NAME_TRUNCATE_LENGTH })}`,
+    hidden:
+      (obj.kind !== ServiceModel.kind && !annotation) ||
+      (annotation && annotation !== 'OpenShiftWebConsole'),
     href: `/edit/ns/${obj.metadata.namespace}?name=${obj.metadata.name}&kind=${obj.kind ||
       model.kind}`,
     accessReview: {

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -417,7 +417,7 @@ export const createOrUpdateDeployImageResources = async (
       internalImageName || name,
       imageStreamTag,
       internalImageNamespace,
-      undefined,
+      annotations,
       _.get(appResources, 'editAppResource.data'),
     );
     requests.push(

--- a/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
+++ b/frontend/packages/dev-console/src/utils/__tests__/__snapshots__/shared-submit-utils.spec.ts.snap
@@ -43,6 +43,7 @@ Object {
     "defaultAnnotations": Object {
       "app.openshift.io/vcs-ref": "master",
       "app.openshift.io/vcs-uri": "https://github.com/test/repo",
+      "openshift.io/generated-by": "OpenShiftWebConsole",
     },
     "labels": Object {
       "app": "test-app",
@@ -109,6 +110,7 @@ Object {
     "annotations": Object {
       "app.openshift.io/vcs-ref": "master",
       "app.openshift.io/vcs-uri": "https://github.com/test/repo",
+      "openshift.io/generated-by": "OpenShiftWebConsole",
     },
     "labels": Object {
       "app": "test-app",

--- a/frontend/packages/dev-console/src/utils/kebab-actions.ts
+++ b/frontend/packages/dev-console/src/utils/kebab-actions.ts
@@ -9,11 +9,16 @@ import {
 } from '@console/internal/models';
 import { ModifyApplication, EditApplication } from '../actions/modify-application';
 
-const modifyApplicationRefs = [
+const modifyWebConsoleApplicationRefs = [
   referenceForModel(DeploymentConfigModel),
   referenceForModel(DeploymentModel),
   referenceForModel(DaemonSetModel),
   referenceForModel(StatefulSetModel),
+];
+
+const editApplicationRefs = [
+  referenceForModel(DeploymentConfigModel),
+  referenceForModel(DeploymentModel),
 ];
 
 export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => {
@@ -22,7 +27,12 @@ export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => 
     return [];
   }
 
-  return _.includes(modifyApplicationRefs, referenceForModel(resourceKind))
-    ? [ModifyApplication, EditApplication]
+  return _.includes(modifyWebConsoleApplicationRefs, referenceForModel(resourceKind))
+    ? [
+        ModifyApplication,
+        ...(_.includes(editApplicationRefs, referenceForModel(resourceKind))
+          ? [EditApplication]
+          : []),
+      ]
     : [];
 };

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -34,6 +34,7 @@ export const getAppAnnotations = (gitURL: string, gitRef: string) => {
   return {
     'app.openshift.io/vcs-uri': gitURL,
     'app.openshift.io/vcs-ref': ref,
+    'openshift.io/generated-by': 'OpenShiftWebConsole',
   };
 };
 

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -73,6 +73,7 @@ export const getKnativeServiceDepResource = (
         ...labels,
         ...(!create && { 'serving.knative.dev/visibility': `cluster-local` }),
       },
+      annotations,
     },
     spec: {
       template: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2975

**Analysis / Root cause**: 
In some cases edit resource is not working if resources is not created via add flow.

**Solution Description**: 
The option to `Edit ${resource name}` on a workload should only be available if the workload was created via the `Add` flow.
**GIF**:
![Kapture 2020-02-26 at 21 27 38](https://user-images.githubusercontent.com/2561818/75362633-0d298e80-58df-11ea-8d63-508942b9e6e8.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
