### PR TITLE
Bug 1806644: Allow regrouping of operator groups and helm releases

### DIFF
--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -116,6 +116,12 @@ export const getResourceList = (namespace: string, resList?: any) => {
     },
     {
       isList: true,
+      kind: 'Secret',
+      namespace,
+      prop: 'secrets',
+    },
+    {
+      isList: true,
       kind: 'Event',
       namespace,
       prop: 'events',

--- a/frontend/packages/dev-console/src/components/dropdown/ApplicationDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/dropdown/ApplicationDropdown.tsx
@@ -63,6 +63,12 @@ const ApplicationDropdown: React.FC<ApplicationDropdownProps> = ({ namespace, ..
       prop: 'knativeService',
       optional: true,
     },
+    {
+      isList: true,
+      kind: 'Secret',
+      namespace,
+      prop: 'secrets',
+    },
   ];
   return (
     <Firehose resources={resources}>

--- a/frontend/packages/dev-console/src/components/modals/index.ts
+++ b/frontend/packages/dev-console/src/components/modals/index.ts
@@ -1,9 +1,14 @@
 export const editApplicationModal = (props) =>
-  import('./EditApplicationModal' /* webpackChunkName: "tags" */).then((m) =>
+  import('./EditApplicationModal' /* webpackChunkName: "dev-console-modals" */).then((m) =>
     m.editApplicationModal(props),
   );
 
+export const groupEditApplicationModal = (props) =>
+  import('./EditApplicationModal' /* webpackChunkName: "dev-console-modals" */).then((m) =>
+    m.groupEditApplicationModal(props),
+  );
+
 export const deleteApplicationModal = (props) =>
-  import('./DeleteApplicationModal' /* webpackChunkName: "delete-application-modal" */).then((m) =>
+  import('./DeleteApplicationModal' /* webpackChunkName: "dev-console-modals" */).then((m) =>
     m.deleteApplicationModal(props),
   );

--- a/frontend/packages/dev-console/src/components/topology/TopologyHelmReleasePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyHelmReleasePanel.tsx
@@ -1,45 +1,30 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import * as _ from 'lodash';
 import {
-  Firehose,
-  FirehoseResult,
-  LoadingBox,
-  StatusBox,
   navFactory,
   ResourceIcon,
   SimpleTabNav,
-  FirehoseResource,
+  StatusBox,
 } from '@console/internal/components/utils';
-import { SecretModel } from '@console/internal/models';
-import { K8sResourceCommon } from '@console/internal/module/k8s';
 import { Node } from '@console/topology';
 import HelmReleaseOverview from '../helm/HelmReleaseOverview';
-
-export type TopologyHelmReleasePanelObjProps = {
-  obj?: FirehoseResult<K8sResourceCommon>;
-};
-
-export type TopologyHelmReleasePanelSecretsProps = {
-  secrets?: FirehoseResult<K8sResourceCommon[]>;
-  helmReleaseName: string;
-};
 
 export type TopologyHelmReleasePanelProps = {
   helmRelease: Node;
 };
 
-const TopologyHelmReleasePanelObj: React.FC<TopologyHelmReleasePanelObjProps> = ({ obj }) => {
-  if (!obj || (!obj.loaded && _.isEmpty(obj.loadError))) {
-    return <LoadingBox />;
-  }
+const TopologyHelmReleasePanel: React.FC<TopologyHelmReleasePanelProps> = ({ helmRelease }) => {
+  const secret = helmRelease.getData().resources.obj;
+  const { namespace, labels } = secret?.metadata || {};
 
-  if (obj.loadError) {
-    return <StatusBox loaded={obj.loaded} loadError={obj.loadError} />;
+  if (!secret || !labels) {
+    return (
+      <StatusBox
+        loaded
+        loadError={{ message: `Unable to find resource for ${helmRelease.getLabel()}` }}
+      />
+    );
   }
-
-  const name = obj.data?.metadata.labels?.name;
-  const namespace = obj.data?.metadata.namespace;
 
   return (
     <div className="overview__sidebar-pane resource-overview">
@@ -48,10 +33,10 @@ const TopologyHelmReleasePanelObj: React.FC<TopologyHelmReleasePanelObjProps> = 
           <div className="co-m-pane__name co-resource-item">
             <ResourceIcon className="co-m-resource-icon--lg" kind="HelmRelease" />
             <Link
-              to={`/helm-releases/ns/${namespace}/release/${name}`}
+              to={`/helm-releases/ns/${namespace}/release/${labels.name}`}
               className="co-resource-item__resource-name"
             >
-              {name}
+              {labels.name}
             </Link>
           </div>
         </h1>
@@ -59,70 +44,10 @@ const TopologyHelmReleasePanelObj: React.FC<TopologyHelmReleasePanelObjProps> = 
       <SimpleTabNav
         selectedTab={'Details'}
         tabs={[{ name: 'Details', component: navFactory.details(HelmReleaseOverview).component }]}
-        tabProps={{ obj: obj.data }}
+        tabProps={{ obj: secret }}
         additionalClassNames="co-m-horizontal-nav__menu--within-sidebar co-m-horizontal-nav__menu--within-overview-sidebar"
       />
     </div>
-  );
-};
-
-const TopologyHelmReleasePanelSecrets: React.FC<TopologyHelmReleasePanelSecretsProps> = ({
-  secrets,
-  helmReleaseName,
-}) => {
-  if (!secrets || (!secrets.loaded && _.isEmpty(secrets.loadError))) {
-    return <LoadingBox />;
-  }
-
-  if (secrets.loadError) {
-    return <StatusBox loaded={secrets.loaded} loadError={secrets.loadError} />;
-  }
-
-  const secretResource = secrets.data[0];
-  if (!secretResource) {
-    return (
-      <StatusBox
-        loaded={secrets.loaded}
-        loadError={{ message: `Unable to find resource for ${helmReleaseName}` }}
-      />
-    );
-  }
-
-  return (
-    <Firehose
-      resources={[
-        {
-          kind: SecretModel.kind,
-          kindObj: SecretModel,
-          name: secretResource.metadata.name,
-          namespace: secretResource.metadata.namespace,
-          isList: false,
-          prop: 'obj',
-        } as FirehoseResource,
-      ]}
-    >
-      <TopologyHelmReleasePanelObj />
-    </Firehose>
-  );
-};
-
-const TopologyHelmReleasePanel: React.FC<TopologyHelmReleasePanelProps> = ({ helmRelease }) => {
-  const { namespace } = helmRelease.getData().groupResources[0].resources.obj.metadata;
-  const helmReleaseName = helmRelease.getLabel();
-  return (
-    <Firehose
-      resources={[
-        {
-          kind: SecretModel.kind,
-          namespace,
-          isList: true,
-          selector: { name: `${helmReleaseName}` },
-          prop: 'secrets',
-        },
-      ]}
-    >
-      <TopologyHelmReleasePanelSecrets helmReleaseName={helmReleaseName} />
-    </Firehose>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-utils.spec.ts
@@ -343,16 +343,21 @@ describe('TopologyUtils ', () => {
   });
 
   it('should add to groups with helm grouping type for a helm chart node', () => {
-    let groups = getTopologyHelmReleaseGroupItem(
+    const groups = [];
+    getTopologyHelmReleaseGroupItem(
       sampleDeploymentConfigs.data[0],
-      [],
+      groups,
       sampleHelmResourcesMap,
+      [],
+      {},
     );
     expect(groups).toHaveLength(0);
-    groups = getTopologyHelmReleaseGroupItem(
+    getTopologyHelmReleaseGroupItem(
       sampleHelmChartDeploymentConfig,
-      [],
+      groups,
       sampleHelmResourcesMap,
+      [],
+      {},
     );
     expect(groups).toHaveLength(1);
     expect(groups[0].type).toEqual(TYPE_HELM_RELEASE);

--- a/frontend/packages/dev-console/src/components/topology/actions/regroupActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/regroupActions.ts
@@ -1,0 +1,32 @@
+import { KebabOption } from '@console/internal/components/utils/kebab';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import { Node } from '@console/topology';
+import { editApplicationModal, groupEditApplicationModal } from '../../modals';
+
+export const regroupActions = (obj: Node, regroupChildren: boolean = false): KebabOption[] => {
+  if (regroupChildren) {
+    return [
+      {
+        label: 'Edit Application Grouping',
+        callback: () =>
+          groupEditApplicationModal({
+            group: obj,
+            blocking: true,
+          }),
+      },
+    ];
+  }
+  const resource = obj.getData()?.resources?.obj;
+  const resourceKind = modelFor(referenceFor(resource));
+  return [
+    {
+      label: 'Edit Application Grouping',
+      callback: () =>
+        editApplicationModal({
+          resourceKind,
+          resource,
+          blocking: true,
+        }),
+    },
+  ];
+};

--- a/frontend/packages/dev-console/src/components/topology/componentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/componentFactory.ts
@@ -24,6 +24,8 @@ import {
   groupContextMenu,
   nodeContextMenu,
   graphContextMenu,
+  regroupContextMenu,
+  regroupGroupContextMenu,
 } from './nodeContextMenu';
 import {
   graphWorkloadDropTargetSpec,
@@ -102,7 +104,10 @@ class ComponentFactory {
     return (kind, type): React.ComponentType<{ element: GraphElement }> | undefined => {
       switch (type) {
         case TYPE_HELM_RELEASE:
-          return withSelection(false, true)(withNoDrop()(HelmRelease));
+          return withSelection(
+            false,
+            true,
+          )(withContextMenu(regroupContextMenu)(withNoDrop()(HelmRelease)));
         case TYPE_HELM_WORKLOAD:
           return this.withAddResourceConnector()(
             withDndDrop<
@@ -123,7 +128,10 @@ class ComponentFactory {
             withSelection(false, true)(withContextMenu(groupContextMenu)(Application)),
           );
         case TYPE_OPERATOR_BACKED_SERVICE:
-          return withSelection(false, true)(withNoDrop()(OperatorBackedService));
+          return withSelection(
+            false,
+            true,
+          )(withContextMenu(regroupGroupContextMenu)(withNoDrop()(OperatorBackedService)));
         case TYPE_OPERATOR_WORKLOAD:
           return this.withAddResourceConnector()(
             withEditReviewAccess('patch')(

--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmRelease.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmRelease.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { Node, observer, WithSelectionProps, WithDndDropProps } from '@console/topology';
+import {
+  Node,
+  observer,
+  WithSelectionProps,
+  WithDndDropProps,
+  WithContextMenuProps,
+} from '@console/topology';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import { useAccessReview } from '@console/internal/components/utils';
+import { getTopologyResourceObject } from '../../topology-utils';
 import HelmReleaseNode from './HelmReleaseNode';
 import HelmReleaseGroup from './HelmReleaseGroup';
 
@@ -8,14 +17,24 @@ import './HelmRelease.scss';
 export type HelmReleaseProps = {
   element: Node;
 } & WithSelectionProps &
+  WithContextMenuProps &
   WithDndDropProps;
 
 const HelmRelease: React.FC<HelmReleaseProps> = (props) => {
+  const resourceObj = getTopologyResourceObject(props.element.getData().groupResources[0]);
+  const resourceModel = modelFor(referenceFor(resourceObj));
+  const editAccess = useAccessReview({
+    group: resourceModel.apiGroup,
+    verb: 'patch',
+    resource: resourceModel.plural,
+    name: resourceObj.metadata.name,
+    namespace: resourceObj.metadata.namespace,
+  });
   if (props.element.isCollapsed()) {
-    return <HelmReleaseNode {...props} />;
+    return <HelmReleaseNode editAccess={editAccess} {...props} />;
   }
 
-  return <HelmReleaseGroup {...props} />;
+  return <HelmReleaseGroup editAccess={editAccess} {...props} />;
 };
 
 export default observer(HelmRelease);

--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
@@ -9,6 +9,7 @@ import {
   useDragNode,
   WithSelectionProps,
   WithDndDropProps,
+  WithContextMenuProps,
   observer,
   useCombineRefs,
 } from '@console/topology';
@@ -20,20 +21,28 @@ import { TYPE_HELM_RELEASE } from '../../const';
 
 export type HelmReleaseNodeProps = {
   element: Node;
+  editAccess: boolean;
 } & WithSelectionProps &
+  WithContextMenuProps &
   WithDndDropProps;
 
 const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
   element,
-  onSelect,
+  editAccess,
   selected,
+  onSelect,
+  onContextMenu,
+  contextMenuOpen,
   dndDropRef,
 }) => {
   useAnchor((e: Node) => new RectAnchor(e, 4));
   const [hover, hoverRef] = useHover();
-  const [{ dragging }, dragNodeRef] = useDragNode(nodeDragSourceSpec(TYPE_HELM_RELEASE, false), {
-    element,
-  });
+  const [{ dragging }, dragNodeRef] = useDragNode(
+    nodeDragSourceSpec(TYPE_HELM_RELEASE, true, editAccess),
+    {
+      element,
+    },
+  );
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, dndDropRef, hoverRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const { width, height } = element.getBounds();
@@ -42,6 +51,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
     <g
       ref={refs}
       onClick={onSelect}
+      onContextMenu={editAccess ? onContextMenu : null}
       className={classNames('odc-helm-release', {
         'is-dragging': dragging,
         'is-selected': selected,
@@ -51,7 +61,9 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
       <NodeShadows />
       <rect
         filter={createSvgIdUrl(
-          hover || dragging ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID,
+          hover || contextMenuOpen || dragging
+            ? NODE_SHADOW_FILTER_ID_HOVER
+            : NODE_SHADOW_FILTER_ID,
         )}
         className="odc-helm-release__bg"
         x={0}

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { Node, observer, WithSelectionProps, WithDndDropProps } from '@console/topology';
+import {
+  Node,
+  observer,
+  WithSelectionProps,
+  WithDndDropProps,
+  WithContextMenuProps,
+} from '@console/topology';
+import { modelFor, referenceFor } from '@console/internal/module/k8s';
+import { useAccessReview } from '@console/internal/components/utils';
+import { getTopologyResourceObject } from '../../topology-utils';
 import OperatorBackedServiceGroup from './OperatorBackedServiceGroup';
 import OperatorBackedServiceNode from './OperatorBackedServiceNode';
 
@@ -8,16 +17,26 @@ import './OperatorBackedService.scss';
 export type OperatorBackedServiceProps = {
   element: Node;
 } & WithSelectionProps &
+  WithContextMenuProps &
   WithDndDropProps;
 
 const OperatorBackedService: React.FC<OperatorBackedServiceProps> = (
   props: OperatorBackedServiceProps,
 ) => {
+  const resourceObj = getTopologyResourceObject(props.element.getData());
+  const resourceModel = modelFor(referenceFor(resourceObj));
+  const editAccess = useAccessReview({
+    group: resourceModel.apiGroup,
+    verb: 'patch',
+    resource: resourceModel.plural,
+    name: resourceObj.metadata.name,
+    namespace: resourceObj.metadata.namespace,
+  });
   if (props.element.isCollapsed()) {
-    return <OperatorBackedServiceNode {...props} />;
+    return <OperatorBackedServiceNode editAccess={editAccess} {...props} />;
   }
 
-  return <OperatorBackedServiceGroup {...props} />;
+  return <OperatorBackedServiceGroup editAccess={editAccess} {...props} />;
 };
 
 export default observer(OperatorBackedService);

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceGroup.tsx
@@ -5,6 +5,7 @@ import {
   observer,
   WithSelectionProps,
   WithDndDropProps,
+  WithContextMenuProps,
   useDragNode,
   Layer,
   useHover,
@@ -19,25 +20,30 @@ import NodeShadows, { NODE_SHADOW_FILTER_ID, NODE_SHADOW_FILTER_ID_HOVER } from 
 
 export type OperatorBackedServiceGroupProps = {
   element: Node;
+  editAccess: boolean;
 } & WithSelectionProps &
+  WithContextMenuProps &
   WithDndDropProps;
 
 const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
   element,
+  editAccess,
   selected,
   onSelect,
+  onContextMenu,
+  contextMenuOpen,
   dndDropRef,
 }) => {
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
-  const [{ dragging }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
+  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(
+    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, true, editAccess),
     {
       element,
     },
   );
-  const [{ dragging: labelDragging }, dragLabelRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
+  const [{ dragging: labelDragging, regrouping: labelRegrouping }, dragLabelRef] = useDragNode(
+    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, true, editAccess),
     {
       element,
     },
@@ -53,13 +59,16 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
     <g
       ref={hoverRef}
       onClick={onSelect}
+      onContextMenu={editAccess ? onContextMenu : null}
       className={classNames('odc-operator-backed-service', {
         'is-dragging': dragging || labelDragging,
         'is-filtered': filtered,
       })}
     >
       <NodeShadows />
-      <Layer id={dragging || labelDragging ? undefined : 'groups2'}>
+      <Layer
+        id={(dragging || labelDragging) && (regrouping || labelRegrouping) ? undefined : 'groups2'}
+      >
         <g
           ref={nodeRefs}
           className={classNames('odc-operator-backed-service', {
@@ -78,7 +87,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
             rx="5"
             ry="5"
             filter={createSvgIdUrl(
-              hover || innerHover || dragging || labelDragging
+              hover || innerHover || contextMenuOpen || dragging || labelDragging
                 ? NODE_SHADOW_FILTER_ID_HOVER
                 : NODE_SHADOW_FILTER_ID,
             )}

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceNode.tsx
@@ -5,6 +5,7 @@ import {
   Node,
   WithSelectionProps,
   WithDndDropProps,
+  WithContextMenuProps,
   useAnchor,
   RectAnchor,
   useCombineRefs,
@@ -20,19 +21,24 @@ import GroupNode from './GroupNode';
 
 export type OperatorBackedServiceNodeProps = {
   element: Node;
+  editAccess: boolean;
 } & WithSelectionProps &
+  WithContextMenuProps &
   WithDndDropProps;
 
 const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   element,
+  editAccess,
   selected,
   onSelect,
+  onContextMenu,
+  contextMenuOpen,
   dndDropRef,
 }) => {
   useAnchor((e: Node) => new RectAnchor(e, 4));
   const [hover, hoverRef] = useHover();
   const [{ dragging }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
+    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, true, editAccess),
     {
       element,
     },
@@ -46,6 +52,7 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
     <g
       ref={refs}
       onClick={onSelect}
+      onContextMenu={editAccess ? onContextMenu : null}
       className={classNames('odc-operator-backed-service', {
         'is-dragging': dragging,
         'is-selected': selected,
@@ -56,7 +63,9 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
       <rect
         className="odc-operator-backed-service__bg"
         filter={createSvgIdUrl(
-          hover || dragging ? NODE_SHADOW_FILTER_ID_HOVER : NODE_SHADOW_FILTER_ID,
+          hover || contextMenuOpen || dragging
+            ? NODE_SHADOW_FILTER_ID_HOVER
+            : NODE_SHADOW_FILTER_ID,
         )}
         x={0}
         y={0}

--- a/frontend/packages/dev-console/src/components/topology/nodeContextMenu.tsx
+++ b/frontend/packages/dev-console/src/components/topology/nodeContextMenu.tsx
@@ -13,6 +13,7 @@ import { groupActions } from './actions/groupActions';
 import { nodeActions } from './actions/nodeActions';
 import { graphActions } from './actions/graphActions';
 import { TopologyApplicationObject } from './topology-types';
+import { regroupActions } from './actions/regroupActions';
 
 const onKebabOptionClick = (option: KebabOption) => {
   if (option.callback) {
@@ -57,3 +58,9 @@ export const nodeContextMenu = (element: Node) =>
 
 export const graphContextMenu = (graph: Graph, connectorSource?: Node) =>
   createMenuItems(kebabOptionsToMenu(graphActions(graph.getData(), connectorSource)));
+
+export const regroupContextMenu = (element: Node) =>
+  createMenuItems(kebabOptionsToMenu(regroupActions(element)));
+
+export const regroupGroupContextMenu = (element: Node) =>
+  createMenuItems(kebabOptionsToMenu(regroupActions(element, true)));

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -17,6 +17,7 @@ export interface TopologyDataResources {
   buildConfigs: FirehoseResult;
   builds: FirehoseResult;
   daemonSets?: FirehoseResult;
+  secrets?: FirehoseResult;
   ksroutes?: FirehoseResult;
   configurations?: FirehoseResult;
   revisions?: FirehoseResult;

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -6,6 +6,7 @@ import {
   DeploymentKind,
   referenceFor,
 } from '@console/internal/module/k8s';
+import { SecretModel } from '@console/internal/models';
 import { getRouteWebURL } from '@console/internal/components/routes';
 import {
   TransformResourceData,
@@ -38,6 +39,7 @@ import {
   TopologyDataModel,
   TopologyDataResources,
   TopologyDataObject,
+  TopologyDataMap,
   Node,
   Edge,
   Group,
@@ -135,6 +137,17 @@ export const getRoutesUrl = (resource: OverviewItem): string => {
     return getRouteWebURL(routes[0]);
   }
   return getRouteData(ksroutes, resource);
+};
+
+const dataObjectFromModel = (node: Node | Group): TopologyDataObject => {
+  return {
+    id: node.id,
+    name: node.name,
+    type: node.type,
+    resources: null,
+    operatorBackedService: false,
+    data: null,
+  };
 };
 
 /**
@@ -337,46 +350,12 @@ export const getTopologyEdgeItems = (
   return edges;
 };
 
-export const getTopologyHelmReleaseGroupItem = (
-  obj: K8sResourceKind,
-  groups: Group[],
-  helmResourcesMap: HelmReleaseResourcesMap,
-): Group[] => {
-  const resourceKindName = `${obj.kind}---${obj.metadata.name}`;
-  const releaseName = helmResourcesMap[resourceKindName]?.releaseName;
-  const uid = _.get(obj, ['metadata', 'uid'], null);
-
-  if (!releaseName) return groups;
-
-  const releaseExists = _.some(groups, { name: releaseName });
-
-  if (!releaseExists) {
-    groups.push({
-      id: `${TYPE_HELM_RELEASE}:${releaseName}`,
-      type: TYPE_HELM_RELEASE,
-      name: releaseName,
-      nodes: [uid],
-    });
-  } else {
-    const gIndex = _.findIndex(groups, { name: releaseName });
-    groups[gIndex].nodes.push(uid);
-  }
-  return groups;
-};
-
 /**
  * create groups data for graph
  * @param dc
  * @param groups
  */
-export const getTopologyGroupItems = (
-  dc: K8sResourceKind,
-  groups: Group[],
-  helmResourcesMap?: HelmReleaseResourcesMap,
-): Group[] => {
-  if (isHelmReleaseNode(dc, helmResourcesMap)) {
-    return getTopologyHelmReleaseGroupItem(dc, groups, helmResourcesMap);
-  }
+export const getTopologyGroupItems = (dc: K8sResourceKind, groups: Group[]): void => {
   const labels = _.get(dc, ['metadata', 'labels']);
   const uid = _.get(dc, ['metadata', 'uid']);
   _.forEach(labels, (label, key) => {
@@ -401,8 +380,57 @@ export const getTopologyGroupItems = (
       }
     }
   });
-  return groups;
 };
+
+export const getTopologyHelmReleaseGroupItem = (
+  obj: K8sResourceKind,
+  groups: Group[],
+  helmResourcesMap: HelmReleaseResourcesMap,
+  secrets: K8sResourceKind[],
+  dataToShowOnNodes: TopologyDataMap,
+): void => {
+  const resourceKindName = getHelmReleaseKey(obj);
+  const releaseName = helmResourcesMap[resourceKindName]?.releaseName;
+  const uid = _.get(obj, ['metadata', 'uid'], null);
+
+  if (!releaseName) return;
+
+  const releaseExists = _.some(groups, { name: releaseName });
+
+  if (!releaseExists) {
+    const secret = secrets.find((nextSecret) => {
+      const { labels } = nextSecret.metadata;
+      return labels && labels.name && labels.name.includes(releaseName);
+    });
+    const helmGroup = {
+      id: `${TYPE_HELM_RELEASE}:${releaseName}`,
+      type: TYPE_HELM_RELEASE,
+      name: releaseName,
+      nodes: [uid],
+    };
+
+    if (secret) {
+      helmGroup.id = secret.metadata.uid;
+      getTopologyGroupItems(secret, groups);
+    }
+
+    const dataModel = dataObjectFromModel(helmGroup);
+    const { kind, apiVersion } = SecretModel;
+    dataModel.resources = {
+      obj: secret ? { ...secret, kind, apiVersion } : null,
+      buildConfigs: null,
+      services: null,
+      routes: null,
+    };
+    dataToShowOnNodes[helmGroup.id] = dataModel;
+    groups.push(helmGroup);
+    return;
+  }
+
+  const gIndex = _.findIndex(groups, { name: releaseName });
+  groups[gIndex].nodes.push(uid);
+};
+
 /**
  * Creates the operator backed services topology data
  * @param resources
@@ -629,14 +657,15 @@ export const transformTopologyData = (
     }),
   );
 
+  const secrets = _.get(resources, 'secrets.data', []);
   _.forEach(transformBy, (key) => {
     if (!_.isEmpty(resources[key].data)) {
       // filter data based on the active application
       const resourceData = filterBasedOnActiveApplication(resources[key].data, application);
       let nodesData = [];
       let edgesData = [];
-      let groupsData = topologyGraphAndNodeData.graph.groups;
-      const dataToShowOnNodes = {};
+      const groupsData = topologyGraphAndNodeData.graph.groups;
+      const dataToShowOnNodes: TopologyDataMap = {};
 
       transformResourceData[key](resourceData).forEach((item) => {
         const { obj: deploymentConfig } = item;
@@ -651,7 +680,6 @@ export const transformTopologyData = (
         );
         if (!_.some(topologyGraphAndNodeData.graph.nodes, { id: uid })) {
           const operatorBacked = dataToShowOnNodes[uid].operatorBackedService;
-
           const nodeType = operatorBacked
             ? TYPE_OPERATOR_WORKLOAD
             : isHelmReleaseNode(deploymentConfig, helmResourcesMap)
@@ -669,13 +697,17 @@ export const transformTopologyData = (
             ),
           ];
           if (!operatorBacked) {
-            groupsData = [
-              ...getTopologyGroupItems(
+            if (!isHelmReleaseNode(deploymentConfig, helmResourcesMap)) {
+              getTopologyGroupItems(deploymentConfig, groupsData);
+            } else {
+              getTopologyHelmReleaseGroupItem(
                 deploymentConfig,
-                topologyGraphAndNodeData.graph.groups,
+                groupsData,
                 helmResourcesMap,
-              ),
-            ];
+                secrets,
+                dataToShowOnNodes,
+              );
+            }
           }
         }
       });
@@ -701,17 +733,6 @@ export const transformTopologyData = (
     topologyGraphAndNodeData,
   );
   return topologyGraphAndNodeData;
-};
-
-const dataObjectFromModel = (node: Node | Group): TopologyDataObject => {
-  return {
-    id: node.id,
-    name: node.name,
-    type: node.type,
-    resources: null,
-    operatorBackedService: false,
-    data: null,
-  };
 };
 
 export const topologyModelFromDataModel = (

--- a/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
@@ -348,7 +348,7 @@ export const tranformKnNodeData = (
 ) => {
   let nodesData = [];
   let edgesData = [];
-  let groupsData = [];
+  const groupsData = topologyGraphAndNodeData.graph.groups;
   const dataToShowOnNodes = {};
   const serviceBindingRequests = _.get(resources, 'serviceBindingRequests.data');
   const allResources = _.flatten(
@@ -378,7 +378,7 @@ export const tranformKnNodeData = (
             ...edgesData,
             ...getEventTopologyEdgeItems(res, resources.ksservices, application),
           ];
-          groupsData = [...getTopologyGroupItems(res, topologyGraphAndNodeData.graph.groups)];
+          getTopologyGroupItems(res, groupsData);
           break;
         }
         case NodeType.Revision: {
@@ -389,7 +389,6 @@ export const tranformKnNodeData = (
             type,
             filters,
           );
-          groupsData = [...topologyGraphAndNodeData.graph.groups];
           break;
         }
         case NodeType.KnService: {
@@ -405,7 +404,7 @@ export const tranformKnNodeData = (
             ...getTrafficTopologyEdgeItems(res, resources.revisions),
             ...getTopologyEdgeItems(res, allResources, serviceBindingRequests, application),
           ];
-          groupsData = [...getTopologyGroupItems(res, topologyGraphAndNodeData.graph.groups)];
+          getTopologyGroupItems(res, groupsData);
           break;
         }
         default:

--- a/frontend/packages/topology/src/behavior/useDragNode.tsx
+++ b/frontend/packages/topology/src/behavior/useDragNode.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { action } from 'mobx';
 import { observer } from 'mobx-react';
 import ElementContext from '../utils/ElementContext';
 import { EventListener, isNode, Node } from '../types';
@@ -108,6 +109,8 @@ export const useDragNode = <
         },
         canDrag: spec ? spec.canDrag : undefined,
         end: async (dropResult, monitor, p) => {
+          // FIXME: Get the controller up front due it issues with model updates during dnd operations
+          const controller = elementRef.current.getController();
           if (spec && spec.end) {
             try {
               await spec.end(dropResult, monitor, p);
@@ -116,14 +119,14 @@ export const useDragNode = <
             }
           }
 
-          elementRef.current
-            .getController()
-            .fireEvent(
+          action(() => {
+            controller.fireEvent(
               DRAG_NODE_END_EVENT,
               elementRef.current,
               monitor.getDragEvent(),
               monitor.getOperation(),
             );
+          })();
         },
         collect: spec ? spec.collect : undefined,
         canCancel: spec ? spec.canCancel : true,

--- a/frontend/packages/topology/src/components/ElementWrapper.tsx
+++ b/frontend/packages/topology/src/components/ElementWrapper.tsx
@@ -10,10 +10,12 @@ type ElementWrapperProps = {
 
 // in a separate component so that changes to behaviors do not re-render children
 const ElementComponent: React.FC<ElementWrapperProps> = observer(({ element }) => {
-  const Component = React.useMemo(
-    () => element.getController().getComponent(element.getKind(), element.getType()),
-    [element],
-  );
+  const kind = element.getKind();
+  const type = element.getType();
+
+  const Component = React.useMemo(() => {
+    return element.getController().getComponent(kind, type);
+  }, [element, kind, type]);
 
   return (
     <ElementContext.Provider value={element}>

--- a/frontend/packages/topology/src/elements/BaseElement.ts
+++ b/frontend/packages/topology/src/elements/BaseElement.ts
@@ -19,6 +19,7 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
   implements GraphElement<E, D> {
   private id: string = '';
 
+  @observable
   private type: string = '';
 
   @observable.ref

--- a/frontend/packages/topology/src/elements/BaseNode.ts
+++ b/frontend/packages/topology/src/elements/BaseNode.ts
@@ -217,6 +217,9 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
     if (r) {
       this.setBounds(r);
     }
+    if ('type' in model) {
+      this.setType(model.type);
+    }
     if ('group' in model) {
       this.group = !!model.group;
     }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3105
https://issues.redhat.com/browse/ODC-3123

**Analysis / Root cause**: 
Operator groups and Helm Releases were not allowed to be added to, or removed from, application groups.

**Solution Description**: 
1. Add the ability to drag/drop operator groups and helm releases to/from application groups.
2. Provide a context menu for these items allowing the user to `Edit Application Grouping`.
3. Associate the `secret` for the helm release with the helm release object and use the label of the secret to determine the application group. This allowed the removal of the secret fetching code in the side panel for helm release details.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

/kind bug