### PR TITLE
Bug 1807562: hide the dev catalog and database option from context menu

### DIFF
--- a/frontend/packages/dev-console/src/actions/add-resources.tsx
+++ b/frontend/packages/dev-console/src/actions/add-resources.tsx
@@ -52,3 +52,9 @@ export const addResourceMenu: KebabAction[] = [
   fromDockerfile,
   fromDatabaseCatalog,
 ];
+
+export const addResourceMenuWithoutCatalog: KebabAction[] = [
+  fromGit,
+  containerImage,
+  fromDockerfile,
+];

--- a/frontend/packages/dev-console/src/components/topology/actions/graphActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/graphActions.ts
@@ -1,11 +1,12 @@
 import * as _ from 'lodash';
 import { Node } from '@console/topology';
-import { addResourceMenu } from '../../../actions/add-resources';
+import { addResourceMenu, addResourceMenuWithoutCatalog } from '../../../actions/add-resources';
 import { GraphData } from '../topology-types';
 
 export const graphActions = (graphData: GraphData, connectorSource?: Node) => {
+  const resourceMenu = connectorSource ? addResourceMenuWithoutCatalog : addResourceMenu;
   return _.reduce(
-    addResourceMenu,
+    resourceMenu,
     (menuItems, menuItem) => {
       const item = menuItem(
         null,

--- a/frontend/packages/dev-console/src/components/topology/actions/groupActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/groupActions.ts
@@ -3,7 +3,7 @@ import { KebabOption } from '@console/internal/components/utils/kebab';
 import { modelFor, referenceFor } from '@console/internal/module/k8s';
 import { Node } from '@console/topology';
 import { asAccessReview } from '@console/internal/components/utils';
-import { addResourceMenu } from '../../../actions/add-resources';
+import { addResourceMenuWithoutCatalog } from '../../../actions/add-resources';
 import { TopologyDataMap, TopologyApplicationObject, GraphData } from '../topology-types';
 import { getTopologyResourceObject } from '../topology-utils';
 import { deleteApplicationModal } from '../../modals';
@@ -60,7 +60,7 @@ const addResourcesMenu = (
   const primaryResource = application.resources[0]?.resources?.obj;
   const connectorSourceObj = connectorSource?.getData()?.resources?.obj || {};
   return _.reduce(
-    addResourceMenu,
+    addResourceMenuWithoutCatalog,
     (menuItems, menuItem) => {
       const item = menuItem(
         primaryResource,


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-2896

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
In context to Add for application and connector is not working for dev catalog and database

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Since we have `In context` working for BuilderImage only and for `Template` and `Helm Chart` created resources can be anything. This will end up as a broken experience. After discussion with @christianvogt and @andrewballantyne, It was decided to Hide both item dev catalog and database from the context menu.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
Hide both items when the connector is dropped on Graph from a node.
![Screenshot from 2020-02-26 23-50-01](https://user-images.githubusercontent.com/9278015/75374719-c9408480-58f2-11ea-8112-7f95c10c1e2b.png)
Show all items on the context menu for right-click on the graph because no context for either app or connector is involved
![Screenshot from 2020-02-26 21-08-47](https://user-images.githubusercontent.com/9278015/75361364-32b59880-58dd-11ea-9e0a-1819f1dcb2db.png)
Hide both items on context menu for right click on application
![Screenshot from 2020-02-26 21-09-02](https://user-images.githubusercontent.com/9278015/75361367-334e2f00-58dd-11ea-8b9a-9af3000a5329.png)
Hide both items when connector is dropped on Graph from a node..
![Screenshot from 2020-02-26 23-51-59](https://user-images.githubusercontent.com/9278015/75374877-11f83d80-58f3-11ea-9b7b-9abe4297fbad.png)
Hide Both items on context menu if connector is dropped on a application
![Screenshot from 2020-02-26 21-09-30](https://user-images.githubusercontent.com/9278015/75361371-347f5c00-58dd-11ea-88cf-558fdd758b87.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
