### PR TITLE
Bug 1807212: Fix async bug where models not loaded in time

### DIFF
--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -405,6 +405,8 @@ describe('Kubernetes resource CRUD operations', () => {
             '/k8s/ns/openshift-monitoring/monitoring.coreos.com~v1~Alertmanager/main',
             '/settings/cluster',
             '/monitoring/query-browser',
+            // Test loading search page for a kind with no static model.
+            '/search/all-namespaces?kind=config.openshift.io~v1~Console',
           ]
         : []),
     ];

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -145,7 +145,12 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
   };
 
   const getToggleText = (item: string) => {
-    const { labelPlural, apiVersion, apiGroup } = modelFor(item);
+    const model = modelFor(item);
+    // API discovery happens asynchronously. Avoid runtime errors if the model hasn't loaded.
+    if (!model) {
+      return '';
+    }
+    const { labelPlural, apiVersion, apiGroup } = model;
     return (
       <span className="co-search-group__accordion-label">
         {labelPlural}{' '}


### PR DESCRIPTION
CRD models were not loaded in time when displaying the Search page with a pre-selected kind.  Added error check to make sure we have the model before trying to display it.