### PR TITLE
Bug 1808402: Add yaml editor for values.yaml in helm install form

### DIFF
--- a/frontend/packages/console-shared/src/components/form-utils/FormFooter.scss
+++ b/frontend/packages/console-shared/src/components/form-utils/FormFooter.scss
@@ -1,0 +1,3 @@
+.ocs-form-footer {
+  padding: var(--pf-global--spacer--md) 0;
+}

--- a/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ActionGroup, Alert, Button, ButtonVariant } from '@patternfly/react-core';
 import { ButtonBar } from '@console/internal/components/utils';
 import { FormFooterProps } from './form-utils-types';
+import './FormFooter.scss';
 
 const FormFooter: React.FC<FormFooterProps> = ({
   handleSubmit,
@@ -18,13 +19,18 @@ const FormFooter: React.FC<FormFooterProps> = ({
   disableSubmit,
   showAlert,
 }) => (
-  <ButtonBar inProgress={isSubmitting} errorMessage={errorMessage} successMessage={successMessage}>
+  <ButtonBar
+    className="ocs-form-footer"
+    inProgress={isSubmitting}
+    errorMessage={errorMessage}
+    successMessage={successMessage}
+  >
     {showAlert && (
       <Alert isInline className="co-alert" variant="info" title={infoTitle}>
         {infoMessage}
       </Alert>
     )}
-    <ActionGroup className="pf-c-form">
+    <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
       <Button
         type={handleSubmit ? 'button' : 'submit'}
         {...(handleSubmit && { onClick: handleSubmit })}

--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.scss
@@ -1,4 +1,4 @@
-.yaml-editor-formik-field {
+.ocs-yaml-editor-field {
   margin: 0 !important;
   padding: 0 !important;
 }

--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.scss
@@ -1,0 +1,4 @@
+.yaml-editor-formik-field {
+  margin: 0 !important;
+  padding: 0 !important;
+}

--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
@@ -6,7 +6,7 @@ import { getFieldId } from './field-utils';
 import { AsyncComponent } from '@console/internal/components/utils';
 import './YAMLEditorField.scss';
 
-const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({ name }) => {
+const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({ name, actionButtonsRef }) => {
   const [field] = useField(name);
   const { setFieldValue } = useFormikContext<FormikValues>();
   const fieldId = getFieldId(name, 'yaml-editor');
@@ -20,6 +20,7 @@ const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({ name }) => {
         onChange={(yaml: string) => setFieldValue(name, yaml)}
         download={false}
         customClass="ocs-yaml-editor-field"
+        buttonsRef={actionButtonsRef.current}
         create
         hideHeader
         genericYAML

--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { FormikValues, useField, useFormikContext } from 'formik';
+import { FormGroup } from '@patternfly/react-core';
+import { YAMLEditorFieldProps } from './field-types';
+import { getFieldId } from './field-utils';
+import { AsyncComponent } from '@console/internal/components/utils';
+import './YAMLEditorField.scss';
+
+const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({ name }) => {
+  const [field] = useField(name);
+  const { setFieldValue } = useFormikContext<FormikValues>();
+  const fieldId = getFieldId(name, 'yaml-editor');
+
+  return (
+    <FormGroup fieldId={fieldId}>
+      <AsyncComponent
+        loader={() => import('@console/internal/components/edit-yaml').then((c) => c.EditYAML)}
+        obj={field.value}
+        onChange={(yaml: string) => setFieldValue(name, yaml)}
+        download={false}
+        customClass="yaml-editor-formik-field"
+        create
+        hideHeader
+        genericYAML
+        hideActions
+      />
+    </FormGroup>
+  );
+};
+
+export default YAMLEditorField;

--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
@@ -19,7 +19,7 @@ const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({ name }) => {
         obj={field.value}
         onChange={(yaml: string) => setFieldValue(name, yaml)}
         download={false}
-        customClass="yaml-editor-formik-field"
+        customClass="ocs-yaml-editor-field"
         create
         hideHeader
         genericYAML

--- a/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/YAMLEditorField.tsx
@@ -14,7 +14,8 @@ const YAMLEditorField: React.FC<YAMLEditorFieldProps> = ({ name }) => {
   return (
     <FormGroup fieldId={fieldId}>
       <AsyncComponent
-        loader={() => import('@console/internal/components/edit-yaml').then((c) => c.EditYAML)}
+        // eslint-disable-next-line no-underscore-dangle
+        loader={() => import('@console/internal/components/edit-yaml').then((c) => c.EditYAML_)}
         obj={field.value}
         onChange={(yaml: string) => setFieldValue(name, yaml)}
         download={false}

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -71,6 +71,7 @@ export interface MultiColumnFieldProps extends FieldProps {
 
 export interface YAMLEditorFieldProps extends FieldProps {
   onChange?: (value: string) => void;
+  actionButtonsRef?: React.MutableRefObject<HTMLDivElement>;
 }
 
 export interface NameValuePair {

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -69,6 +69,10 @@ export interface MultiColumnFieldProps extends FieldProps {
   children: React.ReactNode;
 }
 
+export interface YAMLEditorFieldProps extends FieldProps {
+  onChange?: (value: string) => void;
+}
+
 export interface NameValuePair {
   name: string;
   value: string;

--- a/frontend/packages/console-shared/src/components/formik-fields/index.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/index.ts
@@ -11,5 +11,6 @@ export { default as ResourceDropdownField } from './ResourceDropdownField';
 export { default as ResourceLimitField } from './ResourceLimitField';
 export { default as SwitchField } from './SwitchField';
 export { default as TextAreaField } from './TextAreaField';
+export { default as YAMLEditorField } from './YAMLEditorField';
 export * from './field-utils';
 export * from './field-types';

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { Form, TextInputTypes } from '@patternfly/react-core';
 import { FormikProps, FormikValues } from 'formik';
-import { InputField, FormFooter } from '@console/shared';
+import { InputField, FormFooter, YAMLEditorField } from '@console/shared';
 import FormSection from '../import/section/FormSection';
 
 const HelmInstallForm: React.FC<FormikProps<FormikValues>> = ({
@@ -22,6 +22,7 @@ const HelmInstallForm: React.FC<FormikProps<FormikValues>> = ({
         helpText="A unique name for the Helm Chart release."
         required
       />
+      <YAMLEditorField name="valuesYAML" />
     </FormSection>
     <FormFooter
       handleReset={handleReset}

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
@@ -11,10 +11,9 @@ const HelmInstallForm: React.FC<FormikProps<FormikValues>> = ({
   handleReset,
   status,
   isSubmitting,
-  dirty,
 }) => (
   <Form onSubmit={handleSubmit}>
-    <FormSection title="General">
+    <FormSection>
       <InputField
         type={TextInputTypes.text}
         name="releaseName"
@@ -29,7 +28,7 @@ const HelmInstallForm: React.FC<FormikProps<FormikValues>> = ({
       errorMessage={status && status.submitError}
       isSubmitting={isSubmitting}
       submitLabel="Install"
-      disableSubmit={!dirty || !_.isEmpty(errors)}
+      disableSubmit={!_.isEmpty(errors)}
       resetLabel="Cancel"
     />
   </Form>

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
@@ -5,7 +5,12 @@ import { FormikProps, FormikValues } from 'formik';
 import { InputField, FormFooter, YAMLEditorField } from '@console/shared';
 import FormSection from '../import/section/FormSection';
 
-const HelmInstallForm: React.FC<FormikProps<FormikValues>> = ({
+interface HelmInstallFormProps {
+  chartHasValues: boolean;
+}
+
+const HelmInstallForm: React.FC<FormikProps<FormikValues> & HelmInstallFormProps> = ({
+  chartHasValues,
   errors,
   handleSubmit,
   handleReset,
@@ -21,7 +26,7 @@ const HelmInstallForm: React.FC<FormikProps<FormikValues>> = ({
         helpText="A unique name for the Helm Chart release."
         required
       />
-      <YAMLEditorField name="valuesYAML" />
+      {chartHasValues && <YAMLEditorField name="chartValuesYAML" />}
     </FormSection>
     <FormFooter
       handleReset={handleReset}

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallForm.tsx
@@ -16,27 +16,32 @@ const HelmInstallForm: React.FC<FormikProps<FormikValues> & HelmInstallFormProps
   handleReset,
   status,
   isSubmitting,
-}) => (
-  <Form onSubmit={handleSubmit}>
-    <FormSection>
-      <InputField
-        type={TextInputTypes.text}
-        name="releaseName"
-        label="Release Name"
-        helpText="A unique name for the Helm Chart release."
-        required
-      />
-      {chartHasValues && <YAMLEditorField name="chartValuesYAML" />}
-    </FormSection>
-    <FormFooter
-      handleReset={handleReset}
-      errorMessage={status && status.submitError}
-      isSubmitting={isSubmitting}
-      submitLabel="Install"
-      disableSubmit={!_.isEmpty(errors)}
-      resetLabel="Cancel"
-    />
-  </Form>
-);
+}) => {
+  const footerRef = React.useRef<HTMLDivElement>(null);
+  return (
+    <Form onSubmit={handleSubmit}>
+      <FormSection>
+        <InputField
+          type={TextInputTypes.text}
+          name="releaseName"
+          label="Release Name"
+          helpText="A unique name for the Helm Chart release."
+          required
+        />
+        {chartHasValues && <YAMLEditorField name="chartValuesYAML" actionButtonsRef={footerRef} />}
+      </FormSection>
+      <div ref={footerRef}>
+        <FormFooter
+          handleReset={handleReset}
+          errorMessage={status && status.submitError}
+          isSubmitting={isSubmitting}
+          submitLabel="Install"
+          disableSubmit={!_.isEmpty(errors)}
+          resetLabel="Cancel"
+        />
+      </div>
+    </Form>
+  );
+};
 
 export default HelmInstallForm;

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallPage.tsx
@@ -99,7 +99,7 @@ export const HelmInstallPage: React.FunctionComponent<HelmInstallPageProps> = ({
   }
 
   return (
-    <NamespacedPage disabled variant={NamespacedPageVariants.light}>
+    <NamespacedPage variant={NamespacedPageVariants.light} disabled hideApplications>
       <Helmet>
         <title>Install Helm Chart</title>
       </Helmet>
@@ -107,7 +107,7 @@ export const HelmInstallPage: React.FunctionComponent<HelmInstallPageProps> = ({
         {chartHasValues &&
           'The helm chart will be installed using the YAML shown in the editor below.'}
       </PageHeading>
-      <div className="co-m-pane__body">
+      <div className="co-m-pane__body" style={{ paddingBottom: 0 }}>
         <Formik
           initialValues={initialValues}
           onSubmit={handleSubmit}

--- a/frontend/packages/dev-console/src/components/helm/helm-release-resources-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-release-resources-utils.ts
@@ -8,3 +8,32 @@ export const flattenResources = (resources: { [kind: string]: { data: K8sResourc
     }
     return acc;
   }, []);
+
+export const mockValues = {
+  affinity: {},
+  fullnameOverride: '',
+  image: {
+    pullPolicy: 'IfNotPresent',
+    repository: 'nginx',
+  },
+  ingress: {
+    annotations: {},
+    enabled: false,
+    hosts: [
+      {
+        host: 'chart-example.local',
+        paths: [],
+      },
+    ],
+    tls: [],
+  },
+  nameOverride: '',
+  nodeSelector: {},
+  replicaCount: 1,
+  resources: {},
+  service: {
+    port: 80,
+    type: 'ClusterIP',
+  },
+  tolerations: [],
+};

--- a/frontend/packages/dev-console/src/components/helm/helm-release-resources-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-release-resources-utils.ts
@@ -8,32 +8,3 @@ export const flattenResources = (resources: { [kind: string]: { data: K8sResourc
     }
     return acc;
   }, []);
-
-export const mockValues = {
-  affinity: {},
-  fullnameOverride: '',
-  image: {
-    pullPolicy: 'IfNotPresent',
-    repository: 'nginx',
-  },
-  ingress: {
-    annotations: {},
-    enabled: false,
-    hosts: [
-      {
-        host: 'chart-example.local',
-        paths: [],
-      },
-    ],
-    tls: [],
-  },
-  nameOverride: '',
-  nodeSelector: {},
-  replicaCount: 1,
-  resources: {},
-  service: {
-    port: 80,
-    type: 'ClusterIP',
-  },
-  tolerations: [],
-};

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -206,14 +206,15 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
       (normalizedCharts, charts) => {
         charts.forEach((chart: HelmChart) => {
           const tags = chart.keywords;
-          const name = _.startCase(chart.name);
+          const chartName = chart.name;
+          const tileName = `${_.startCase(chartName)} v${chart.version}`;
           const tileImgUrl = chart.icon || getImageForIconClass('icon-helm');
           const chartURL = encodeURIComponent(_.get(chart, 'urls.0'));
 
           normalizedCharts.push({
             obj: { ...chart, ...{ metadata: { uid: chart.digest } } },
             kind: 'HelmChart',
-            tileName: `${name} v${chart.version}`,
+            tileName,
             tileIconClass: null,
             tileImgUrl,
             tileDescription: chart.description,
@@ -222,7 +223,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
             tileProvider: _.get(chart, 'maintainers.0.name'),
             documentationUrl: chart.home,
             supportUrl: chart.home,
-            href: `/catalog/helm-install?chartURL=${chartURL}&preselected-ns=${currentNamespace}`,
+            href: `/catalog/helm-install?chartName=${chartName}&chartURL=${chartURL}&preselected-ns=${currentNamespace}`,
           });
         });
         return normalizedCharts;

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -111,6 +111,7 @@ export const EditYAML_ = connect(stateToProps)(
       this.onCancel = 'onCancel' in props ? props.onCancel : history.goBack;
       this.downloadSampleYaml_ = this.downloadSampleYaml_.bind(this);
       this.editorDidMount = this.editorDidMount.bind(this);
+      this.buttons = this.props.buttonsRef;
 
       if (this.props.error) {
         this.handleError(this.props.error);
@@ -187,7 +188,7 @@ export const EditYAML_ = connect(stateToProps)(
     }
 
     get editorHeight() {
-      const buttonsHeight = this.buttons.getBoundingClientRect().height;
+      const buttonsHeight = this.buttons ? this.buttons.getBoundingClientRect().height : 0;
       // if viewport width is > 767, also subtract top padding on .yaml-editor
       return isDesktop()
         ? Math.floor(this.height - buttonsHeight - desktopGutter)
@@ -806,86 +807,79 @@ export const EditYAML_ = connect(stateToProps)(
                         this.setState({ yaml: newValue }, () => onChange(newValue))
                       }
                     />
-                    <div ref={(r) => (this.buttons = r)}>
-                      {!hideActions && (
-                        <div className="yaml-editor__buttons">
-                          {customAlerts}
-                          {error && (
-                            <Alert
-                              isInline
-                              className="co-alert co-alert--scrollable"
-                              variant="danger"
-                              title="An error occurred"
+                    {!hideActions && (
+                      <div className="yaml-editor__buttons" ref={(r) => (this.buttons = r)}>
+                        {customAlerts}
+                        {error && (
+                          <Alert
+                            isInline
+                            className="co-alert co-alert--scrollable"
+                            variant="danger"
+                            title="An error occurred"
+                          >
+                            <div className="co-pre-line">{error}</div>
+                          </Alert>
+                        )}
+                        {success && (
+                          <Alert isInline className="co-alert" variant="success" title={success} />
+                        )}
+                        {stale && (
+                          <Alert
+                            isInline
+                            className="co-alert"
+                            variant="info"
+                            title="This object has been updated."
+                          >
+                            Click reload to see the new version.
+                          </Alert>
+                        )}
+                        <ActionGroup className="pf-c-form__group--no-top-margin">
+                          {create && (
+                            <Button
+                              type="submit"
+                              variant="primary"
+                              id="save-changes"
+                              onClick={() => this.save()}
                             >
-                              <div className="co-pre-line">{error}</div>
-                            </Alert>
-                          )}
-                          {success && (
-                            <Alert
-                              isInline
-                              className="co-alert"
-                              variant="success"
-                              title={success}
-                            />
-                          )}
-                          {stale && (
-                            <Alert
-                              isInline
-                              className="co-alert"
-                              variant="info"
-                              title="This object has been updated."
-                            >
-                              Click reload to see the new version.
-                            </Alert>
-                          )}
-                          <ActionGroup className="pf-c-form__group--no-top-margin">
-                            {create && (
-                              <Button
-                                type="submit"
-                                variant="primary"
-                                id="save-changes"
-                                onClick={() => this.save()}
-                              >
-                                Create
-                              </Button>
-                            )}
-                            {!create && !readOnly && (
-                              <Button
-                                type="submit"
-                                variant="primary"
-                                id="save-changes"
-                                onClick={() => this.save()}
-                              >
-                                Save
-                              </Button>
-                            )}
-                            {!create && !genericYAML && (
-                              <Button
-                                type="submit"
-                                variant="secondary"
-                                id="reload-object"
-                                onClick={() => this.reload()}
-                              >
-                                Reload
-                              </Button>
-                            )}
-                            <Button variant="secondary" id="cancel" onClick={() => this.onCancel()}>
-                              Cancel
+                              Create
                             </Button>
-                            {download && (
-                              <Button
-                                type="submit"
-                                variant="secondary"
-                                className="pf-c-button--align-right hidden-sm hidden-xs"
-                                onClick={() => this.download()}
-                              >
-                                <DownloadIcon /> Download
-                              </Button>
-                            )}
-                          </ActionGroup>
-                        </div>
-                      )}
-                    </div>
+                          )}
+                          {!create && !readOnly && (
+                            <Button
+                              type="submit"
+                              variant="primary"
+                              id="save-changes"
+                              onClick={() => this.save()}
+                            >
+                              Save
+                            </Button>
+                          )}
+                          {!create && !genericYAML && (
+                            <Button
+                              type="submit"
+                              variant="secondary"
+                              id="reload-object"
+                              onClick={() => this.reload()}
+                            >
+                              Reload
+                            </Button>
+                          )}
+                          <Button variant="secondary" id="cancel" onClick={() => this.onCancel()}>
+                            Cancel
+                          </Button>
+                          {download && (
+                            <Button
+                              type="submit"
+                              variant="secondary"
+                              className="pf-c-button--align-right hidden-sm hidden-xs"
+                              onClick={() => this.download()}
+                            >
+                              <DownloadIcon /> Download
+                            </Button>
+                          )}
+                        </ActionGroup>
+                      </div>
+                    )}
                   </div>
                 </div>
                 {hasSidebarContent && (

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -693,7 +693,9 @@ const EditYAML_ = connect(stateToProps)(
         canDrop,
         create,
         yamlSamplesList,
+        customClass,
         onChange = () => null,
+        hideActions = false,
       } = this.props;
       const klass = classNames('co-file-dropzone-container', {
         'co-file-dropzone--drop-over': isOver,
@@ -742,7 +744,10 @@ const EditYAML_ = connect(stateToProps)(
             <div className="pf-c-form">
               <div className="co-p-has-sidebar">
                 <div className="co-p-has-sidebar__body">
-                  <div className="yaml-editor" ref={(r) => (this.editor = r)}>
+                  <div
+                    className={classNames('yaml-editor', customClass)}
+                    ref={(r) => (this.editor = r)}
+                  >
                     <div className="yaml-editor__links">
                       {!genericYAML && (
                         <div className="yaml-editor__link">
@@ -802,75 +807,84 @@ const EditYAML_ = connect(stateToProps)(
                       }
                     />
                     <div className="yaml-editor__buttons" ref={(r) => (this.buttons = r)}>
-                      {customAlerts}
-                      {error && (
-                        <Alert
-                          isInline
-                          className="co-alert co-alert--scrollable"
-                          variant="danger"
-                          title="An error occurred"
-                        >
-                          <div className="co-pre-line">{error}</div>
-                        </Alert>
+                      {!hideActions && (
+                        <>
+                          {customAlerts}
+                          {error && (
+                            <Alert
+                              isInline
+                              className="co-alert co-alert--scrollable"
+                              variant="danger"
+                              title="An error occurred"
+                            >
+                              <div className="co-pre-line">{error}</div>
+                            </Alert>
+                          )}
+                          {success && (
+                            <Alert
+                              isInline
+                              className="co-alert"
+                              variant="success"
+                              title={success}
+                            />
+                          )}
+                          {stale && (
+                            <Alert
+                              isInline
+                              className="co-alert"
+                              variant="info"
+                              title="This object has been updated."
+                            >
+                              Click reload to see the new version.
+                            </Alert>
+                          )}
+                          <ActionGroup className="pf-c-form__group--no-top-margin">
+                            {create && (
+                              <Button
+                                type="submit"
+                                variant="primary"
+                                id="save-changes"
+                                onClick={() => this.save()}
+                              >
+                                Create
+                              </Button>
+                            )}
+                            {!create && !readOnly && (
+                              <Button
+                                type="submit"
+                                variant="primary"
+                                id="save-changes"
+                                onClick={() => this.save()}
+                              >
+                                Save
+                              </Button>
+                            )}
+                            {!create && !genericYAML && (
+                              <Button
+                                type="submit"
+                                variant="secondary"
+                                id="reload-object"
+                                onClick={() => this.reload()}
+                              >
+                                Reload
+                              </Button>
+                            )}
+                            <Button variant="secondary" id="cancel" onClick={() => this.onCancel()}>
+                              Cancel
+                            </Button>
+                            {download && (
+                              <Button
+                                type="submit"
+                                variant="secondary"
+                                className="pf-c-button--align-right hidden-sm hidden-xs"
+                                onClick={() => this.download()}
+                              >
+                                <DownloadIcon /> Download
+                              </Button>
+                            )}
+                          </ActionGroup>
+                        </>
                       )}
-                      {success && (
-                        <Alert isInline className="co-alert" variant="success" title={success} />
-                      )}
-                      {stale && (
-                        <Alert
-                          isInline
-                          className="co-alert"
-                          variant="info"
-                          title="This object has been updated."
-                        >
-                          Click reload to see the new version.
-                        </Alert>
-                      )}
-                      <ActionGroup className="pf-c-form__group--no-top-margin">
-                        {create && (
-                          <Button
-                            type="submit"
-                            variant="primary"
-                            id="save-changes"
-                            onClick={() => this.save()}
-                          >
-                            Create
-                          </Button>
-                        )}
-                        {!create && !readOnly && (
-                          <Button
-                            type="submit"
-                            variant="primary"
-                            id="save-changes"
-                            onClick={() => this.save()}
-                          >
-                            Save
-                          </Button>
-                        )}
-                        {!create && !genericYAML && (
-                          <Button
-                            type="submit"
-                            variant="secondary"
-                            id="reload-object"
-                            onClick={() => this.reload()}
-                          >
-                            Reload
-                          </Button>
-                        )}
-                        <Button variant="secondary" id="cancel" onClick={() => this.onCancel()}>
-                          Cancel
-                        </Button>
-                        {download && (
-                          <Button
-                            type="submit"
-                            variant="secondary"
-                            className="pf-c-button--align-right hidden-sm hidden-xs"
-                            onClick={() => this.download()}
-                          >
-                            <DownloadIcon /> Download
-                          </Button>
-                        )}
-                      </ActionGroup>
                     </div>
                   </div>
                 </div>

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -84,7 +84,7 @@ const desktopGutter = 30;
  * Consider using `AsyncComponent` to dynamically load this component when needed.
  */
 /** @augments {React.Component<{obj?: any, create: boolean, kind: string, redirectURL?: string, resourceObjPath?: (obj: K8sResourceKind, objRef: string) => string}, onChange?: (yaml: string) => void>} */
-const EditYAML_ = connect(stateToProps)(
+export const EditYAML_ = connect(stateToProps)(
   class EditYAML extends React.Component {
     constructor(props) {
       super(props);
@@ -806,9 +806,9 @@ const EditYAML_ = connect(stateToProps)(
                         this.setState({ yaml: newValue }, () => onChange(newValue))
                       }
                     />
-                    <div className="yaml-editor__buttons" ref={(r) => (this.buttons = r)}>
+                    <div ref={(r) => (this.buttons = r)}>
                       {!hideActions && (
-                        <>
+                        <div className="yaml-editor__buttons">
                           {customAlerts}
                           {error && (
                             <Alert
@@ -883,7 +883,7 @@ const EditYAML_ = connect(stateToProps)(
                               </Button>
                             )}
                           </ActionGroup>
-                        </>
+                        </div>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
### Fixes - https://issues.redhat.com/browse/ODC-3066

### This PR -
- Adds a new formik field that wraps `EditYAML` component.
- Updates `EditYAML` with some new props to configure editor so that it's suitable in a Formik form.
- Uses `/api/helm/chart` endpoint to fetch chart details and dump chart values in the yaml editor and then uses that to send payload to helm installation API.


### Steps to test this PR - 
- Run `./build-backend.sh` on latest master to get the backend API endpoint changes in `bridge`.
- Run `export HELM_REPOSITORY_CONFIG="/tmp/repositories.yaml"` before running `./bin/bridge`.



Screenshots -
![Screenshot from 2020-02-27 00-34-20](https://user-images.githubusercontent.com/6041994/75377988-dbbdbc80-58f8-11ea-8199-ae3c4ce8b766.png)
