### PR TITLE
Bug 1803614: 	Alertmanager receiver creation page should mark Routing Labels field by red-star mark

### DIFF
--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -282,7 +282,6 @@ describe('Alertmanager: Configuration', () => {
     // pagerduty subform should still be invalid at this point, thus save button should be disabled
     expect(monitoringView.saveButton.isEnabled()).toBe(false);
     await firstElementByTestID('integration-key').sendKeys('<integration_key>');
-    expect(monitoringView.saveButton.isEnabled()).toBe(true); // subform valid, save should be enabled at this point
 
     // labels
     expect(firstElementByTestID('invalid-label-name-error').isPresent()).toBe(false);
@@ -306,6 +305,7 @@ describe('Alertmanager: Configuration', () => {
     await firstElementByTestID('remove-routing-label').click();
     expect(firstElementByTestID('duplicate-label-name-error').isPresent()).toBe(false);
 
+    expect(monitoringView.saveButton.isEnabled()).toBe(true); // subform valid & labels provided, save should be enabled at this point
     await monitoringView.saveButton.click();
     await crudView.isLoaded();
     monitoringView.getFirstRowAsText().then((text) => {

--- a/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
@@ -236,7 +236,10 @@ const ReceiverBaseForm: React.FC<ReceiverBaseFormProps> = ({
     !formValues.receiverType ||
     SubForm.isFormInvalid(formValues) ||
     !_.isEmpty(formValues.routeLabelFieldErrors) ||
-    formValues.routeLabelDuplicateNamesError;
+    formValues.routeLabelDuplicateNamesError ||
+    (!isDefaultReceiver &&
+      formValues.routeLabels.length === 1 &&
+      (formValues.routeLabels[0].name === '' || formValues.routeLabels[0].value === ''));
 
   const save = (e) => {
     e.preventDefault();

--- a/frontend/public/components/monitoring/receiver-forms/routing-labels-editor.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/routing-labels-editor.tsx
@@ -84,7 +84,7 @@ export const RoutingLabelEditor = ({ formValues, dispatchFormChange, isDefaultRe
 
   return (
     <div data-test-id="receiver-routing-labels-editor" className="form-group">
-      <SectionHeading text="Routing Labels" />
+      <SectionHeading text="Routing Labels" required={!isDefaultReceiver} />
       <p className="co-help-text">
         Firing alerts with labels that match all of these selectors will be sent to this receiver.
         Label values can be matched exactly or with a &nbsp;

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -165,9 +165,20 @@ export const PageHeading = connectToModel((props: PageHeadingProps) => {
   );
 });
 
-export const SectionHeading: React.SFC<SectionHeadingProps> = ({ text, children, style }) => (
+export const SectionHeading: React.SFC<SectionHeadingProps> = ({
+  text,
+  children,
+  style,
+  required,
+}) => (
   <h2 className="co-section-heading" style={style} data-test-section-heading={text}>
-    {text}
+    <span
+      className={classNames({
+        'co-required': required,
+      })}
+    >
+      {text}
+    </span>
     {children}
   </h2>
 );
@@ -264,6 +275,7 @@ export type SectionHeadingProps = {
   children?: any;
   style?: any;
   text: string;
+  required?: boolean;
 };
 
 export type SidebarSectionHeadingProps = {


### PR DESCRIPTION
This PR adds required asterisk to the Routing Labels section for non-default receivers.  It disables the Create/Save button if there is only a single, empty routing label name:value set.
<img src="https://raw.githubusercontent.com/dtaylor113/images/master/routing_labels_required.gif" /> 