### PR TITLE
Bug 1807210: added Time Range & Refresh Interval dropdowns in monitoring dashboard

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/MonitoringPage.tsx
@@ -5,7 +5,7 @@ import { HorizontalNav, PageHeading, history } from '@console/internal/component
 import { TechPreviewBadge, ALL_NAMESPACES_KEY } from '@console/shared';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import ProjectListPage from '../projects/ProjectListPage';
-import MonitoringDashboard from './dashboard/MonitoringDashboard';
+import ConnectedMonitoringDashboard from './dashboard/MonitoringDashboard';
 import ConnectedMonitoringMetrics from './metrics/MonitoringMetrics';
 import MonitoringEvents from './events/MonitoringEvents';
 
@@ -44,7 +44,7 @@ export const MonitoringPage: React.FC<MonitoringPageProps> = ({ match }) => {
                 {
                   href: '',
                   name: 'Dashboard',
-                  component: MonitoringDashboard,
+                  component: ConnectedMonitoringDashboard,
                 },
                 {
                   href: 'metrics',

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
@@ -1,0 +1,7 @@
+.odc-monitoring-dashboard__dropdown-options {
+    display: flex;
+    float: right;
+    align-self: flex-end;
+    margin-top: -65px;
+}
+

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { match as RMatch } from 'react-router-dom';
+import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
+import { RootState } from '@console/internal/redux';
 import { getURLSearchParams } from '@console/internal/components/utils';
+import {
+  TimespanDropdown,
+  PollIntervalDropdown,
+} from '@console/internal/components/monitoring/dashboards';
 import ConnectedMonitoringDashboardGraph from './MonitoringDashboardGraph';
 import {
   monitoringDashboardQueries,
@@ -10,14 +16,22 @@ import {
   MonitoringQuery,
   topWorkloadMetricsQueries,
 } from '../queries';
+import './MonitoringDashboard.scss';
 
-interface MonitoringDashboardProps {
+type MonitoringDashboardProps = {
   match: RMatch<{
     ns?: string;
   }>;
-}
+};
 
-const MonitoringDashboard: React.FC<MonitoringDashboardProps> = ({ match }) => {
+type StateProps = {
+  timespan: number;
+  pollInterval: number;
+};
+
+type Props = MonitoringDashboardProps & StateProps;
+
+export const MonitoringDashboard: React.FC<Props> = ({ match, timespan, pollInterval }) => {
   const namespace = match.params.ns;
   const params = getURLSearchParams();
   const { workloadName, workloadType } = params;
@@ -31,6 +45,10 @@ const MonitoringDashboard: React.FC<MonitoringDashboardProps> = ({ match }) => {
       <Helmet>
         <title>Dashboard</title>
       </Helmet>
+      <div className="odc-monitoring-dashboard__dropdown-options">
+        <TimespanDropdown />
+        <PollIntervalDropdown />
+      </div>
       <div className="co-m-pane__body">
         {_.map(queries, (q) => (
           <ConnectedMonitoringDashboardGraph
@@ -41,6 +59,8 @@ const MonitoringDashboard: React.FC<MonitoringDashboardProps> = ({ match }) => {
             humanize={q.humanize}
             byteDataType={q.byteDataType}
             key={q.title}
+            timespan={timespan}
+            pollInterval={pollInterval}
           />
         ))}
       </div>
@@ -48,4 +68,9 @@ const MonitoringDashboard: React.FC<MonitoringDashboardProps> = ({ match }) => {
   );
 };
 
-export default MonitoringDashboard;
+const mapStateToProps = (state: RootState): StateProps => ({
+  timespan: state.UI.getIn(['monitoringDashboards', 'timespan']),
+  pollInterval: state.UI.getIn(['monitoringDashboards', 'pollInterval']),
+});
+
+export default connect<StateProps, MonitoringDashboardProps>(mapStateToProps)(MonitoringDashboard);

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -23,12 +23,14 @@ type OwnProps = {
   graphType?: GraphTypes;
   humanize: Humanize;
   byteDataType: ByteDataTypes;
+  timespan?: number;
+  pollInterval?: number;
 };
 
 type MonitoringDashboardGraphProps = OwnProps & DispatchProps;
 
-const defaultTimespan = 30 * 60 * 1000;
-const defaultSamples = 30;
+const DEFAULT_TIME_SPAN = 30 * 60 * 1000;
+const DEFAULT_SAMPLES = 30;
 
 export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> = ({
   query,
@@ -36,6 +38,8 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
   title,
   patchQuery,
   graphType = GraphTypes.area,
+  timespan,
+  pollInterval,
 }) => {
   return (
     <div className="odc-monitoring-dashboard-graph">
@@ -44,11 +48,13 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
         <div onMouseEnter={() => patchQuery({ query })}>
           <QueryBrowser
             hideControls
-            defaultTimespan={defaultTimespan}
-            defaultSamples={defaultSamples}
+            defaultTimespan={DEFAULT_TIME_SPAN}
+            defaultSamples={DEFAULT_SAMPLES}
             namespace={namespace}
             queries={[query]}
             isStack={graphType === GraphTypes.area}
+            timespan={timespan}
+            pollInterval={pollInterval}
           />
         </div>
       </PrometheusGraphLink>

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboard.spec.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as link from '@console/internal/components/utils';
-import MonitoringDashboard from '../MonitoringDashboard';
+import {
+  TimespanDropdown,
+  PollIntervalDropdown,
+} from '@console/internal/components/monitoring/dashboards';
+import { MonitoringDashboard } from '../MonitoringDashboard';
 import ConnectedMonitoringDashboardGraph from '../MonitoringDashboardGraph';
 import { monitoringDashboardQueries, topWorkloadMetricsQueries } from '../../queries';
 
@@ -17,6 +21,8 @@ describe('Monitoring Dashboard Tab', () => {
       path: '',
       url: '',
     },
+    timespan: 1800000,
+    pollInterval: 90000,
   };
 
   it('should render Monitoring Dashboard tab', () => {
@@ -54,5 +60,11 @@ describe('Monitoring Dashboard Tab', () => {
         .first()
         .props().query,
     ).toEqual(dashboardQuery);
+  });
+
+  it('should render Time Range & Refresh Interval dropdowns', () => {
+    const wrapper = shallow(<MonitoringDashboard {...monitoringDashboardProps} />);
+    expect(wrapper.find(TimespanDropdown).exists()).toBe(true);
+    expect(wrapper.find(PollIntervalDropdown).exists()).toBe(true);
   });
 });

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboardGraph.spec.tsx
@@ -18,6 +18,8 @@ describe('Monitoring Dashboard graph', () => {
       humanize: query.humanize,
       byteDataType: query.byteDataType,
       patchQuery: jest.fn(),
+      timespan: 1800000,
+      pollInterval: 30000,
     };
   });
 

--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -217,7 +217,8 @@ const TimespanDropdown_: React.FC<TimespanDropdownProps> = ({ timespan, setTimes
     />
   );
 };
-const TimespanDropdown = connect(
+
+export const TimespanDropdown = connect(
   ({ UI }: RootState) => ({
     timespan: UI.getIn(['monitoringDashboards', 'timespan']),
   }),
@@ -258,7 +259,8 @@ const PollIntervalDropdown_: React.FC<PollIntervalDropdownProps> = ({
     />
   );
 };
-const PollIntervalDropdown = connect(
+
+export const PollIntervalDropdown = connect(
   ({ UI }: RootState) => ({
     pollInterval: UI.getIn(['monitoringDashboards', 'pollInterval']),
   }),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2822

**Analysis / Root cause**: 
Time Range & Refresh Interval drop downs in monitoring dashboard tab have been added in design lately.

**Solution Description**: 
Time Range & Refresh Interval drop down list & functionalities required in dev-console monitoring dashboard tab is same as of Admin console. Hence exported Time Range & Refresh Interval drop downs components in `@console/internal/components/monitoring/dashboards`.  And reused them in dev-console Monitoring Dashboard tab. With this dropdown selected values persist between Admin console Dashboard page & Dev-console Dashboard page.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux 
![TimeRange-RefreshInterval](https://user-images.githubusercontent.com/56166080/75390672-acb24580-590e-11ea-9212-5c9e691ac2c5.gif)

**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/56166080/75486195-10ea0d80-59d2-11ea-9af6-1bf39d000dd3.png)

**Test setup:** N/A

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
