### PR TITLE
Fix typo in "podStatuse" statusDescriptor guide

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
@@ -754,14 +754,14 @@ This descriptor allows you to expose the status of pods for your instance. It ex
 …
 status:
   [PATH_TO_THE_FIELD]:
-    ready:
+    [STATE_1]:
       - [FIELD_MEMBER_NAME]
       - [FIELD_MEMBER_NAME]
       - [FIELD_MEMBER_NAME]
-    starting:
+    [STATE_2]:
       - [FIELD_MEMBER_NAME]
       - [FIELD_MEMBER_NAME]
-    stopped:
+    [STATE_3]:
       - [FIELD_MEMBER_NAME]
 …
 ```


### PR DESCRIPTION
"podStatuse" statusDescriptor honors the states being exposed in status block of the CR.

**Current:**
<img width="975" alt="current__" src="https://user-images.githubusercontent.com/5903705/75401971-82ce3400-58b8-11ea-92af-d656c61bb560.png">


**This PR:**
<img width="977" alt="new__" src="https://user-images.githubusercontent.com/5903705/75401975-86fa5180-58b8-11ea-88ef-0ee81c94ef20.png">
