### PR TITLE
Bug 1801395: Monitoring Dashboards: Fix stack chart Y axis when all values are zero

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -241,7 +241,15 @@ const Graph: React.FC<GraphProps> = React.memo(
 
     let yTickFormat = formatValue;
 
-    if (!isStack) {
+    if (isStack) {
+      // Specify Y axis range if all values are zero, but otherwise let Chart set it automatically
+      const isAllZero = _.every(allSeries, (series) =>
+        _.every(series, ([, values]) => _.every(values, { y: 0 })),
+      );
+      if (isAllZero) {
+        domain.y = [-1, 1];
+      }
+    } else {
       // Set a reasonable Y-axis range based on the min and max values in the data
       const findMin = (series: GraphDataPoint[]) => _.minBy(series, 'y');
       const findMax = (series: GraphDataPoint[]) => _.maxBy(series, 'y');


### PR DESCRIPTION
The stack chart Y axis should have the range [-1, 1] when all values are
zero. This matches the behavior of the line (non-stack) chart.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/460802/75415036-c040c900-596d-11ea-80b4-88ddf258c9f3.png) | ![after](https://user-images.githubusercontent.com/460802/75415042-c3d45000-596d-11ea-9c11-ae033f8df381.png) |