### PR TITLE
Bug 1806912: Monitoring Dashboards: Fix X axis tick labels overlapping

### DIFF
--- a/frontend/public/components/monitoring/dashboards/index.tsx
+++ b/frontend/public/components/monitoring/dashboards/index.tsx
@@ -349,14 +349,14 @@ const Card: React.FC<CardProps> = ({ panel }) => {
     );
   }
 
-  const panelSpan: number = getPanelSpan(panel);
-  // If panel.span is greater than 12, default colSpan to 12
-  const colSpan: number = panelSpan > 12 ? 12 : panelSpan;
-  // If colSpan is less than 7, double it for small
-  const colSpanSm: number = colSpan < 7 ? colSpan * 2 : colSpan;
+  // Our grid has 12 columns, so don't allow colSpan over 12
+  const colSpan = Math.min(getPanelSpan(panel), 12);
+
+  // Don't allow very narrow panels at intermediate page widths
+  const colSpanMd = Math.max(colSpan, 3);
 
   return (
-    <div className={`col-xs-12 col-sm-${colSpanSm} col-lg-${colSpan}`}>
+    <div className={`col-xs-12 col-md-${colSpanMd} col-lg-${colSpan}`}>
       <DashboardCard
         className="monitoring-dashboards__panel"
         gradient={panel.type === 'grafana-piechart-panel'}

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -265,6 +265,18 @@ const Graph: React.FC<GraphProps> = React.memo(
 
     const xTickFormat = span < 5 * 60 * 1000 ? twentyFourHourTimeWithSeconds : twentyFourHourTime;
 
+    let xAxisStyle;
+    if (width < 225) {
+      xAxisStyle = {
+        tickLabels: {
+          angle: 45,
+          fontSize: 10,
+          textAnchor: 'start',
+          verticalAnchor: 'middle',
+        },
+      };
+    }
+
     const legendData = formatLegendLabel
       ? _.flatMap(allSeries, (series, i) =>
           _.map(series, (s) => ({ name: formatLegendLabel(s[0], i) })),
@@ -283,7 +295,7 @@ const Graph: React.FC<GraphProps> = React.memo(
             theme={chartTheme}
             width={width}
           >
-            <ChartAxis tickCount={5} tickFormat={xTickFormat} />
+            <ChartAxis style={xAxisStyle} tickCount={5} tickFormat={xTickFormat} />
             <ChartAxis crossAxis={false} dependentAxis tickCount={6} tickFormat={yTickFormat} />
             {isStack ? (
               <ChartStack>


### PR DESCRIPTION
When graphs are small, the X axis tick labels were overlapping. This
fixes that by changing the label font size and angle at small widths.

| Before | After |
| - | - |
| ![before2](https://user-images.githubusercontent.com/460802/75428766-09a01100-598c-11ea-9cc0-88bbddc96a1a.png) | ![after2](https://user-images.githubusercontent.com/460802/75428791-115fb580-598c-11ea-9ea1-ba454637a0ca.png) |

Also fixes panel layout for intermediate page widths.

| Before | After |
| - | - |
| ![before1](https://user-images.githubusercontent.com/460802/75428710-f725d780-598b-11ea-837d-28a90ce3ca8c.png) | ![after1](https://user-images.githubusercontent.com/460802/75428746-0016a900-598c-11ea-8852-5bc3498065a1.png) |

With this change, all panels become full width at `sm` page widths.

The panel layout logic change does cause the "Kubernetes / Compute Resources / Cluster" single value panels to have a gap on the second row at `md` widths (see below). I think this is acceptable since this change fixes the other layout issues and is also a little simpler.

![screenshot](https://user-images.githubusercontent.com/460802/75429337-f6417580-598c-11ea-90db-89cca75e2539.png)