### PR TITLE
Bug 1807868: fixes issue with knative service in edit flow

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/EditApplicationPage.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplicationPage.tsx
@@ -9,6 +9,7 @@ import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import EditApplication from './EditApplication';
 import { EditApplicationProps } from './edit-application-types';
 
+const INSTANCE_LABEL = 'app.kubernetes.io/instance';
 const EditApplicationComponentLoader: React.FunctionComponent<EditApplicationProps> = (
   props: EditApplicationProps,
 ) => {
@@ -48,8 +49,11 @@ const EditApplicationPage: React.FunctionComponent<ImportPageProps> = ({ match, 
     {
       kind: 'ImageStream',
       prop: 'imageStream',
-      name: appName,
+      isList: true,
       namespace,
+      selector: {
+        matchLabels: { [INSTANCE_LABEL]: appName },
+      },
       optional: true,
     },
     {

--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
@@ -319,41 +319,43 @@ export const appResources: AppResources = {
   imageStream: {
     loaded: true,
     loadError: '',
-    data: {
-      kind: 'ImageStream',
-      apiVersion: 'image.openshift.io/v1',
-      metadata: {
-        annotations: {
-          'app.openshift.io/vcs-ref': 'master',
-          'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
+    data: [
+      {
+        kind: 'ImageStream',
+        apiVersion: 'image.openshift.io/v1',
+        metadata: {
+          annotations: {
+            'app.openshift.io/vcs-ref': 'master',
+            'app.openshift.io/vcs-uri': 'https://github.com/divyanshiGupta/nationalparks-py',
+          },
+          selfLink: '/apis/image.openshift.io/v1/namespaces/div/imagestreams/nationalparks-py',
+          resourceVersion: '676247',
+          name: 'nationalparks-py',
+          uid: '2bc985ac-f834-45e5-9a86-830edb6bc8bd',
+          creationTimestamp: '2020-01-15T15:51:47Z',
+          generation: 1,
+          namespace: 'div',
+          labels: {
+            app: 'nationalparks-py',
+            'app.kubernetes.io/component': 'nationalparks-py',
+            'app.kubernetes.io/instance': 'nationalparks-py',
+            'app.kubernetes.io/name': 'python',
+            'app.kubernetes.io/part-of': 'nodejs-rest-http-app',
+            'app.openshift.io/runtime': 'python',
+            'app.openshift.io/runtime-version': '3.6',
+          },
         },
-        selfLink: '/apis/image.openshift.io/v1/namespaces/div/imagestreams/nationalparks-py',
-        resourceVersion: '676247',
-        name: 'nationalparks-py',
-        uid: '2bc985ac-f834-45e5-9a86-830edb6bc8bd',
-        creationTimestamp: '2020-01-15T15:51:47Z',
-        generation: 1,
-        namespace: 'div',
-        labels: {
-          app: 'nationalparks-py',
-          'app.kubernetes.io/component': 'nationalparks-py',
-          'app.kubernetes.io/instance': 'nationalparks-py',
-          'app.kubernetes.io/name': 'python',
-          'app.kubernetes.io/part-of': 'nodejs-rest-http-app',
-          'app.openshift.io/runtime': 'python',
-          'app.openshift.io/runtime-version': '3.6',
+        spec: {
+          lookupPolicy: {
+            local: false,
+          },
+        },
+        status: {
+          dockerImageRepository:
+            'image-registry.openshift-image-registry.svc:5000/div/nationalparks-py',
         },
       },
-      spec: {
-        lookupPolicy: {
-          local: false,
-        },
-      },
-      status: {
-        dockerImageRepository:
-          'image-registry.openshift-image-registry.svc:5000/div/nationalparks-py',
-      },
-    },
+    ],
   },
 };
 

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-types.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-types.ts
@@ -5,7 +5,7 @@ export interface AppResources {
   service?: FirehoseResult<K8sResourceKind>;
   route?: FirehoseResult<K8sResourceKind>;
   buildConfig?: FirehoseResult<K8sResourceKind>;
-  imageStream?: FirehoseResult<K8sResourceKind>;
+  imageStream?: FirehoseResult<K8sResourceKind[]>;
   editAppResource?: FirehoseResult<K8sResourceKind>;
   imageStreams?: FirehoseResult;
 }

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -266,11 +266,13 @@ export const getGitAndDockerfileInitialValues = (
   return initialValues;
 };
 
-export const getExternalImageInitialValues = (imageStream: K8sResourceKind) => {
-  if (_.isEmpty(imageStream)) {
+export const getExternalImageInitialValues = (appResources: AppResources) => {
+  const imageStreamList = appResources?.imageStream?.data;
+  if (_.isEmpty(imageStreamList)) {
     return {};
   }
-  const name = _.get(imageStream, 'spec.tags[0].from.name');
+  const imageStream = _.orderBy(imageStreamList, ['metadata.resourceVersion'], ['desc']);
+  const name = imageStream.length && imageStream[0]?.spec?.tags?.[0]?.from?.name;
   const deployImageInitialValues = {
     searchTerm: name,
     registry: 'external',
@@ -367,7 +369,7 @@ export const getInitialValues = (
   let internalImageValues = {};
 
   if (_.isEmpty(gitDockerValues)) {
-    externalImageValues = getExternalImageInitialValues(_.get(appResources, 'imageStream.data'));
+    externalImageValues = getExternalImageInitialValues(appResources);
     internalImageValues = _.isEmpty(externalImageValues)
       ? getInternalImageInitialValues(_.get(appResources, 'editAppResource.data'))
       : {};

--- a/frontend/packages/dev-console/src/components/pipelines/__tests__/pipelineResource-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/__tests__/pipelineResource-validation-utils.spec.ts
@@ -1,6 +1,7 @@
 import { cloneDeep } from 'lodash';
 import { validationSchema } from '../pipeline-resource/pipelineResource-validation-utils';
-import { getDefinedObj, getRandomChars } from '../pipeline-resource/pipelineResource-utils';
+import { getDefinedObj } from '../pipeline-resource/pipelineResource-utils';
+import { getRandomChars } from '../../../utils/shared-submit-utils';
 import { mockPipelineResourceData } from '../__mocks__/pipeline-resource-mock';
 
 describe('Validation Pipeline Resource', () => {

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -5,7 +5,7 @@ import {
   PipelineTaskParam,
   PipelineTaskResource,
 } from '../../../utils/pipeline-augment';
-import { getRandomChars } from '../pipeline-resource/pipelineResource-utils';
+import { getRandomChars } from '../../../utils/shared-submit-utils';
 import { AddNodeDirection } from '../pipeline-topology/const';
 import { TaskErrorType, UpdateOperationType } from './const';
 import {

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/pipelineResource-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/pipelineResource-utils.ts
@@ -2,17 +2,11 @@ import * as _ from 'lodash';
 import { k8sCreate, K8sResourceKind } from '@console/internal/module/k8s';
 import { SecretModel } from '@console/internal/models';
 import { PipelineResourceModel } from '../../../models';
+import { getRandomChars } from '../../../utils/shared-submit-utils';
 
 export interface ParamData {
   [key: string]: any;
 }
-
-export const getRandomChars = (digit = 6): string => {
-  return Math.random()
-    .toString(36)
-    .replace(/[^a-z0-9]+/g, '')
-    .substr(1, digit);
-};
 
 export const getDefinedObj = (objData: ParamData): ParamData => {
   return _.omitBy(objData, (v) => _.isUndefined(v) || _.isNull(v) || v === '');

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -4,10 +4,10 @@ import { k8sCreate, K8sKind, k8sPatch, referenceForModel } from '@console/intern
 import { errorModal } from '@console/internal/components/modals';
 import { PipelineModel, PipelineRunModel } from '../models';
 import startPipelineModal from '../components/pipelines/pipeline-form/StartPipelineModal';
-import { getRandomChars } from '../components/pipelines/pipeline-resource/pipelineResource-utils';
 import { Pipeline, PipelineRun } from './pipeline-augment';
 import { pipelineRunFilterReducer } from './pipeline-filter-reducer';
 import { getPipelineRunParams } from './pipeline-utils';
+import { getRandomChars } from './shared-submit-utils';
 
 export const handlePipelineRunSubmit = (pipelineRun: PipelineRun) => {
   history.push(

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -145,3 +145,10 @@ export const createRoute = (
 
   return route;
 };
+
+export const getRandomChars = (digit = 6): string => {
+  return Math.random()
+    .toString(36)
+    .replace(/[^a-z0-9]+/g, '')
+    .substr(1, digit);
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3069

**Analysis / Root cause**: 
On editing knative Service from topology view with different image not creating new revision.

**Solution Description**: 
In case of knative service edit generating new Image Stream with `name-randomChars` and update service with new image registry url and filtering image stream based on instance name.

**Screen shots / Gifs for design review**: 
![ezgif com-optimize (1)](https://user-images.githubusercontent.com/5129024/75443581-b6c45a80-5987-11ea-95ee-cfa4e54044ee.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
