### PR TITLE
Bug 1806974: Find currect vm pod

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
@@ -78,9 +78,13 @@ export const findVMIPod = (
   });
 
   // Return the newet most ready Pod created
-  return prefixedPods.sort((a: PodKind, b: PodKind) =>
-    isPodReady(a) && a.metadata.creationTimestamp > b.metadata.creationTimestamp ? -1 : 1,
-  )[0];
+  return prefixedPods
+    .sort((a: PodKind, b: PodKind) =>
+      a.metadata.creationTimestamp > b.metadata.creationTimestamp ? -1 : 1,
+    )
+    .sort((a: PodKind) =>
+      isPodReady(a) ? -1 : 1,
+    )[0];
 };
 
 export const getVMImporterPods = (

--- a/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pod/selectors.ts
@@ -82,9 +82,7 @@ export const findVMIPod = (
     .sort((a: PodKind, b: PodKind) =>
       a.metadata.creationTimestamp > b.metadata.creationTimestamp ? -1 : 1,
     )
-    .sort((a: PodKind) =>
-      isPodReady(a) ? -1 : 1,
-    )[0];
+    .sort((a: PodKind) => (isPodReady(a) ? -1 : 1))[0];
 };
 
 export const getVMImporterPods = (


### PR DESCRIPTION
In some cases the running vm may have older date, so we need to sort for running after sorting by date. and not during ...)

Screenshots:

After , correct state:
![OKD(1)](https://user-images.githubusercontent.com/2181522/75445052-51637000-596d-11ea-8091-64a69c9774b8.png)

Before, wrong state:
![OKD(2)](https://user-images.githubusercontent.com/2181522/75445959-1eba7700-596f-11ea-8d61-5c175425c93f.png)

More then one pod per VM (happen if user starts migration and stop it):
![Pods · OKD](https://user-images.githubusercontent.com/2181522/75445050-50324300-596d-11ea-90c5-b4c7955a4a5b.png)
