### PR TITLE
Bug 1807865: Don't show node if pod is dead

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -67,8 +67,8 @@ export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
           <DetailItem title="Created" error={false} isLoading={!vmiLike}>
             <Timestamp timestamp={getCreationTimestamp(vmiLike)} />
           </DetailItem>
-          <DetailItem title="Node" error={!isNodeLoading && !nodeName} isLoading={isNodeLoading}>
-            {nodeName && <NodeLink name={nodeName} />}
+          <DetailItem title="Node" error={!isNodeLoading} isLoading={!launcherPod || isNodeLoading}>
+            {launcherPod && nodeName && <NodeLink name={nodeName} />}
           </DetailItem>
           <DetailItem
             title="IP Address"

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -191,8 +191,12 @@ export const VMDetailsList: React.FC<VMResourceListProps> = ({
         {launcherPod && ipAddrs}
       </VMDetailsItem>
 
-      <VMDetailsItem title="Node" idValue={prefixedID(id, 'node')} isNotAvail={!nodeName}>
-        {nodeName && <NodeLink name={nodeName} />}
+      <VMDetailsItem
+        title="Node"
+        idValue={prefixedID(id, 'node')}
+        isNotAvail={!launcherPod || !nodeName}
+      >
+        {launcherPod && nodeName && <NodeLink name={nodeName} />}
       </VMDetailsItem>
 
       <VMDetailsItem title="Flavor" idValue={prefixedID(id, 'flavor')} isNotAvail={!flavorText}>


### PR DESCRIPTION
When stoping a VM we may have, for a short while, a VMI but no Pod, we do not want to show the node in this cases.

Screenshoot:
After:
![OKD(3)](https://user-images.githubusercontent.com/2181522/75447640-6e4e7200-5972-11ea-9237-0ccc14321cfe.png)

Before:
![OKD(4)](https://user-images.githubusercontent.com/2181522/75447868-d9984400-5972-11ea-9049-033736c9c4b5.png)

