### PR TITLE
Bug 1807949: add empty state for DC in monitoring overview

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.scss
@@ -4,7 +4,7 @@
   }
   &__event-warning-toggle {
     .pf-c-accordion__toggle-text {
-        width: 100%
+      width: 100%;
     }
   }
   &__event-warning-body {
@@ -21,5 +21,11 @@
   }
   .pf-c-accordion__toggle.pf-m-expanded {
     --pf-c-accordion__toggle--BorderLeftColor: transparent;
+  }
+  &__empty-state {
+    &-icon {
+      color: var(--pf-global--icon--Color--light);
+      font-size: var(--pf-global--FontSize--4xl);
+    }
   }
 }

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
@@ -9,8 +9,14 @@ import {
   Split,
   SplitItem,
   Badge,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Title,
 } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { K8sResourceKind, EventKind } from '@console/internal/module/k8s';
+import { DeploymentConfigModel } from '@console/internal/models';
 import MonitoringOverviewEventsWarning from './MonitoringOverviewEventsWarning';
 import MonitoringOverviewEvents from './MonitoringOverviewEvents';
 import WorkloadGraphs from './MonitoringMetrics';
@@ -79,16 +85,31 @@ const MonitoringOverview: React.FC<MonitoringOverviewProps> = ({ resource, event
             Metrics
           </AccordionToggle>
           <AccordionContent id="metrics-content" isHidden={!expanded.includes('metrics')}>
-            <div className="odc-monitoring-overview__view-monitoring-dashboard">
-              <Link
-                to={`/dev-monitoring/ns/${resource?.metadata?.namespace}/?workloadName=${
-                  resource?.metadata?.name
-                }&workloadType=${resource?.kind?.toLowerCase()}`}
-              >
-                View monitoring dashboard
-              </Link>
-            </div>
-            <WorkloadGraphs resource={resource} />
+            {resource.kind === DeploymentConfigModel.kind ? (
+              <EmptyState>
+                <EmptyStateIcon
+                  className="odc-monitoring-overview__empty-state-icon"
+                  icon={InfoCircleIcon}
+                />
+                <Title size="md">No Metrics Found</Title>
+                <EmptyStateBody>
+                  Deployment Configuration metrics are not yet supported.
+                </EmptyStateBody>
+              </EmptyState>
+            ) : (
+              <>
+                <div className="odc-monitoring-overview__view-monitoring-dashboard">
+                  <Link
+                    to={`/dev-monitoring/ns/${resource?.metadata?.namespace}/?workloadName=${
+                      resource?.metadata?.name
+                    }&workloadType=${resource?.kind?.toLowerCase()}`}
+                  >
+                    View monitoring dashboard
+                  </Link>
+                </div>
+                <WorkloadGraphs resource={resource} />
+              </>
+            )}
           </AccordionContent>
         </AccordionItem>
 


### PR DESCRIPTION
**Fixes**: 
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->
https://issues.redhat.com/browse/ODC-2810

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
There are no metrics available for deployment configs

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
show empty state in DC sidebar for metrics section

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screenshot from 2020-02-27 20-00-01](https://user-images.githubusercontent.com/9278015/75461415-c56f3980-59a8-11ea-9af0-56fdc6a164dd.png)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
