### PR TITLE
Bug 1808076: Fix UI crash when deleting revisions

### DIFF
--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -45,9 +45,10 @@ export const podRingLabel = (
 ): PodRingLabelType => {
   const {
     spec: { replicas },
-    status: { availableReplicas },
+    status,
     kind,
   } = obj;
+  const { availableReplicas } = status || {};
 
   const isPending = (pods?.length === 1 && pods[0].status?.phase === 'Pending') || replicas;
   const pluralize = replicas > 1 || replicas === 0 ? 'pods' : 'pod';

--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmRelease.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmRelease.tsx
@@ -11,11 +11,7 @@ export type HelmReleaseProps = {
   WithDndDropProps;
 
 const HelmRelease: React.FC<HelmReleaseProps> = (props) => {
-  if (
-    props.element.isCollapsed() ||
-    !props.element.getData().groupResources ||
-    !props.element.getData().groupResources.length
-  ) {
+  if (props.element.isCollapsed()) {
     return <HelmReleaseNode {...props} />;
   }
 

--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseGroup.tsx
@@ -42,6 +42,7 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
   );
   const refs = useCombineRefs(dragNodeRef, dndDropRef, hoverRef);
   const [filtered] = useSearchFilter(element.getLabel());
+  const hasChildren = element.getChildren()?.length > 0;
   return (
     <>
       <NodeShadows />
@@ -69,6 +70,11 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
                 : NODE_SHADOW_FILTER_ID,
             )}
           />
+          {!hasChildren && (
+            <text x={x + width / 2} y={y + height / 2} dy="0.35em" textAnchor="middle">
+              No Resources
+            </text>
+          )}
         </g>
       </Layer>
       {element.getLabel() && (

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeService.tsx
@@ -35,11 +35,7 @@ const KnativeService: React.FC<KnativeServiceProps> = (props) => {
     name: resourceObj.metadata.name,
     namespace: resourceObj.metadata.namespace,
   });
-  if (
-    props.element.isCollapsed() ||
-    !props.element.getData().groupResources ||
-    !props.element.getData().groupResources.length
-  ) {
+  if (props.element.isCollapsed()) {
     return <KnativeServiceNode {...props} editAccess={editAccess} />;
   }
 

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceGroup.tsx
@@ -67,6 +67,7 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
   );
 
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
+  const hasChildren = element.getChildren()?.length > 0;
   const { data } = element.getData();
   const hasDataUrl = !!data.url;
   useAnchor(
@@ -139,6 +140,11 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
                   : NODE_SHADOW_FILTER_ID,
               )}
             />
+            {!hasChildren && (
+              <text x={x + width / 2} y={y + height / 2} dy="0.35em" textAnchor="middle">
+                No Revisions
+              </text>
+            )}
           </g>
         </Layer>
         {hasDataUrl && (

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedService.tsx
@@ -13,11 +13,7 @@ export type OperatorBackedServiceProps = {
 const OperatorBackedService: React.FC<OperatorBackedServiceProps> = (
   props: OperatorBackedServiceProps,
 ) => {
-  if (
-    props.element.isCollapsed() ||
-    !props.element.getData().groupResources ||
-    !props.element.getData().groupResources.length
-  ) {
+  if (props.element.isCollapsed()) {
     return <OperatorBackedServiceNode {...props} />;
   }
 

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceGroup.tsx
@@ -44,6 +44,7 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
   );
 
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
+  const hasChildren = element.getChildren()?.length > 0;
   const { data } = element.getData();
   const [filtered] = useSearchFilter(element.getLabel());
   const { x, y, width, height } = element.getBounds();
@@ -82,6 +83,11 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
                 : NODE_SHADOW_FILTER_ID,
             )}
           />
+          {!hasChildren && (
+            <text x={x + width / 2} y={y + height / 2} dy="0.35em" textAnchor="middle">
+              No Resources
+            </text>
+          )}
         </g>
       </Layer>
       {(data.kind || element.getLabel()) && (

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -734,7 +734,7 @@ export const topologyModelFromDataModel = (
           ((d.type === TYPE_KNATIVE_SERVICE && !filters.display.knativeServices) ||
             (d.type === TYPE_OPERATOR_BACKED_SERVICE && !filters.display.operatorGrouping)),
         children: d.children,
-        group: d.children?.length > 0,
+        group: true,
         shape: NodeShape.rect,
         style: {
           padding: d.type === TYPE_KNATIVE_SERVICE ? KNATIVE_GROUP_NODE_PADDING : GROUP_PADDING,

--- a/frontend/packages/knative-plugin/src/components/overview/DeploymentOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/DeploymentOverviewList.tsx
@@ -6,7 +6,8 @@ type DeploymentOverviewListProps = {
   current: PodControllerOverviewItem;
 };
 
-const DeploymentOverviewList: React.FC<DeploymentOverviewListProps> = ({ current: { obj } }) => {
+const DeploymentOverviewList: React.FC<DeploymentOverviewListProps> = ({ current }) => {
+  const { obj } = current || {};
   const namespace = obj?.metadata?.namespace;
   const deploymentData = obj?.metadata?.ownerReferences[0];
   return (
@@ -23,7 +24,7 @@ const DeploymentOverviewList: React.FC<DeploymentOverviewListProps> = ({ current
           </li>
         </ul>
       ) : (
-        <span className="text-muted">No Deploymennt found for this resource.</span>
+        <span className="text-muted">No Deployment found for this resource.</span>
       )}
     </>
   );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3181

**Analysis / Root cause**: 
When the UI refreshed on a delete of a revision, fields being used were not yet set by the creation of the new revision causing an NPE.

**Solution Description**: 
Check fields before using them.
Updated the UI to show the Knative Service as a group when not collapsed even if there are no `active` revisions.

**Screen shots / Gifs for design review**: 
![no-revisions-group](https://user-images.githubusercontent.com/11633780/75475446-ced7b200-5966-11ea-932e-65bad483328c.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
