### PR TITLE
Bug 1802034: Silenced alerts should not show up in the Dashboards page of the console [4.5]

### DIFF
--- a/frontend/public/actions/dashboards.ts
+++ b/frontend/public/actions/dashboards.ts
@@ -19,7 +19,7 @@ export enum ActionType {
 
 const REFRESH_TIMEOUT = 5000;
 
-export const ALERTS_KEY = 'alerts';
+export const ALERTS_KEY = 'alerts'; // TODO: remove once noobaa-storage-plugin, ceph-storage-plugin, and metal3-plugin status cards have been updated to switch over to alertNotifications, see https://github.com/openshift/console/pull/4539
 
 export const stopWatch = (type: RESULTS_TYPE, key: string) =>
   action(ActionType.StopWatch, { type, key });
@@ -121,27 +121,8 @@ export const watchURL: WatchURLAction = (url, fetch = coFetchJSON) => (dispatch,
   }
 };
 
-export const watchAlerts: WatchAlertsAction = () => (dispatch, getState) => {
-  const isActive = isWatchActive(getState().dashboards, RESULTS_TYPE.ALERTS, ALERTS_KEY);
+export const watchAlerts: WatchAlertsAction = () => (dispatch) => {
   dispatch(activateWatch(RESULTS_TYPE.ALERTS, ALERTS_KEY));
-  if (!isActive) {
-    const { prometheusBaseURL } = window.SERVER_FLAGS;
-    if (!prometheusBaseURL) {
-      dispatch(
-        setError(RESULTS_TYPE.ALERTS, ALERTS_KEY, new Error('Prometheus URL is not available')),
-      );
-    } else {
-      const prometheusURL = () => `${prometheusBaseURL}/api/v1/rules`;
-      fetchPeriodically(
-        dispatch,
-        RESULTS_TYPE.ALERTS,
-        ALERTS_KEY,
-        prometheusURL,
-        getState,
-        coFetchJSON,
-      );
-    }
-  }
 };
 
 export const stopWatchPrometheusQuery: StopWatchPrometheusAction = (query, timespan) =>

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -139,7 +139,7 @@ const ClusterAlerts = connectToFlags(FLAGS.CLUSTER_VERSION)(
           isLoading={
             flagPending(hasCVResource) || !alertsLoaded || (hasCVResource && !cvLoaded && !cvError)
           }
-          error={alertsResponseError}
+          error={!_.isEmpty(alertsResponseError)}
           emptyMessage="No cluster alerts or messages"
         >
           {items}

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -19,11 +19,9 @@ import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboa
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
 import { withDashboardResources, DashboardItemProps } from '../../with-dashboard-resources';
-import { getAlerts } from '@console/shared/src/components/dashboard/status-card/alert-utils';
 import AlertItem, {
   StatusItem,
 } from '@console/shared/src/components/dashboard/status-card/AlertItem';
-import { ALERTS_KEY } from '../../../../actions/dashboards';
 import {
   connectToFlags,
   FlagsObject,
@@ -32,7 +30,7 @@ import {
 } from '../../../../reducers/features';
 import * as plugins from '../../../../plugins';
 import { FirehoseResource } from '../../../utils';
-import { PrometheusRulesResponse, alertURL } from '../../../monitoring';
+import { alertURL } from '../../../monitoring';
 import {
   ClusterVersionKind,
   referenceForModel,
@@ -73,7 +71,7 @@ const ClusterAlerts = connectToFlags(FLAGS.CLUSTER_VERSION)(
     ({
       watchAlerts,
       stopWatchAlerts,
-      alertsResults,
+      notificationAlerts,
       watchK8sResource,
       stopWatchK8sResource,
       resources,
@@ -93,9 +91,8 @@ const ClusterAlerts = connectToFlags(FLAGS.CLUSTER_VERSION)(
         };
       }, [watchAlerts, stopWatchAlerts, watchK8sResource, stopWatchK8sResource, hasCVResource]);
 
-      const alertsResponse = alertsResults.getIn([ALERTS_KEY, 'data']) as PrometheusRulesResponse;
-      const alertsResponseError = alertsResults.getIn([ALERTS_KEY, 'loadError']);
-      const alerts = getAlerts(alertsResponse);
+      const { data: alerts, loaded: alertsLoaded, loadError: alertsResponseError } =
+        notificationAlerts || {};
 
       const cv = _.get(resources.cv, 'data') as ClusterVersionKind;
       const cvLoaded = _.get(resources.cv, 'loaded');
@@ -115,7 +112,7 @@ const ClusterAlerts = connectToFlags(FLAGS.CLUSTER_VERSION)(
 
       let items: React.ReactNode;
       if (!flagPending(hasCVResource)) {
-        if (hasCVResource && (hasAvailableUpdates(cv) || alerts.length)) {
+        if (hasCVResource && (hasAvailableUpdates(cv) || !_.isEmpty(alerts))) {
           items = (
             <>
               {hasAvailableUpdates(cv) && (
@@ -130,7 +127,7 @@ const ClusterAlerts = connectToFlags(FLAGS.CLUSTER_VERSION)(
               ))}
             </>
           );
-        } else if (alerts.length) {
+        } else if (!_.isEmpty(alerts)) {
           items = alerts.map((alert) => (
             <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />
           ));
@@ -140,9 +137,7 @@ const ClusterAlerts = connectToFlags(FLAGS.CLUSTER_VERSION)(
       return (
         <AlertsBody
           isLoading={
-            flagPending(hasCVResource) ||
-            !alertsResponse ||
-            (hasCVResource && !cvLoaded && !cvError)
+            flagPending(hasCVResource) || !alertsLoaded || (hasCVResource && !cvLoaded && !cvError)
           }
           error={alertsResponseError}
           emptyMessage="No cluster alerts or messages"

--- a/frontend/public/components/dashboard/with-dashboard-resources.tsx
+++ b/frontend/public/components/dashboard/with-dashboard-resources.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import * as _ from 'lodash-es';
 
 import { RESULTS_TYPE, RequestMap } from '../../reducers/dashboards';
+import { NotificationAlerts } from '../../reducers/ui';
 import {
   Fetch,
   stopWatchAlerts,
@@ -230,7 +231,7 @@ export type DashboardItemProps = {
   urlResults: RequestMap<any>;
   prometheusResults: RequestMap<PrometheusResponse>;
   alertsResults: RequestMap<PrometheusRulesResponse>; // TODO: remove once noobaa-storage-plugin, ceph-storage-plugin, and metal3-plugin status cards have been updated to switch over to alertNotifications, see https://github.com/openshift/console/pull/4539
-  notificationAlerts: any;
+  notificationAlerts: NotificationAlerts;
   watchK8sResource: WatchK8sResource;
   stopWatchK8sResource: StopWatchK8sResource;
   resources?: {

--- a/frontend/public/components/dashboard/with-dashboard-resources.tsx
+++ b/frontend/public/components/dashboard/with-dashboard-resources.tsx
@@ -4,7 +4,6 @@ import * as _ from 'lodash-es';
 
 import { RESULTS_TYPE, RequestMap } from '../../reducers/dashboards';
 import {
-  ALERTS_KEY,
   Fetch,
   stopWatchAlerts,
   StopWatchAlertsAction,
@@ -42,9 +41,7 @@ const mapStateToProps = (state: RootState) => ({
   [RESULTS_TYPE.PROMETHEUS]: state.dashboards.get(RESULTS_TYPE.PROMETHEUS) as RequestMap<
     PrometheusResponse
   >,
-  [RESULTS_TYPE.ALERTS]: state.dashboards.get(RESULTS_TYPE.ALERTS) as RequestMap<
-    PrometheusRulesResponse
-  >,
+  notificationAlerts: state.UI.getIn(['monitoring', 'notificationAlerts']),
 });
 
 type StateProps = ReturnType<typeof mapStateToProps>;
@@ -91,10 +88,8 @@ export const withDashboardResources = <P extends DashboardItemProps>(
               nextProps[RESULTS_TYPE.PROMETHEUS].getIn([query, 'loadError']),
         );
         const alertsResultChanged =
-          this.props[RESULTS_TYPE.ALERTS].getIn([ALERTS_KEY, 'data']) !==
-            nextProps[RESULTS_TYPE.ALERTS].getIn([ALERTS_KEY, 'data']) ||
-          this.props[RESULTS_TYPE.ALERTS].getIn([ALERTS_KEY, 'loadError']) !==
-            nextProps[RESULTS_TYPE.ALERTS].getIn([ALERTS_KEY, 'loadError']);
+          this.props?.notificationAlerts?.data !== nextProps?.notificationAlerts?.data ||
+          this.props?.notificationAlerts?.loadError !== nextProps?.notificationAlerts?.loadError;
         const k8sResourcesChanged = this.state.k8sResources !== nextState.k8sResources;
 
         const nextExternalProps = this.getExternalProps(nextProps);
@@ -161,7 +156,7 @@ export const withDashboardResources = <P extends DashboardItemProps>(
           'stopWatchAlerts',
           RESULTS_TYPE.URL,
           RESULTS_TYPE.PROMETHEUS,
-          RESULTS_TYPE.ALERTS,
+          'notificationAlerts',
         );
       };
 
@@ -177,7 +172,7 @@ export const withDashboardResources = <P extends DashboardItemProps>(
               stopWatchAlerts={this.stopWatchAlerts}
               urlResults={this.props[RESULTS_TYPE.URL]}
               prometheusResults={this.props[RESULTS_TYPE.PROMETHEUS]}
-              alertsResults={this.props[RESULTS_TYPE.ALERTS]}
+              notificationAlerts={this.props.notificationAlerts}
               watchK8sResource={this.watchK8sResource}
               stopWatchK8sResource={this.stopWatchK8sResource}
               {...this.getExternalProps(this.props)}
@@ -219,7 +214,7 @@ type WithDashboardResourcesProps = {
   stopWatchAlerts: StopWatchAlertsAction;
   [RESULTS_TYPE.PROMETHEUS]: RequestMap<PrometheusResponse>;
   [RESULTS_TYPE.URL]: RequestMap<any>;
-  [RESULTS_TYPE.ALERTS]: RequestMap<PrometheusRulesResponse>;
+  notificationAlerts: any;
 };
 
 export type WatchK8sResource = (resource: FirehoseResource) => void;
@@ -234,7 +229,8 @@ export type DashboardItemProps = {
   stopWatchAlerts: StopWatchAlerts;
   urlResults: RequestMap<any>;
   prometheusResults: RequestMap<PrometheusResponse>;
-  alertsResults: RequestMap<PrometheusRulesResponse>;
+  alertsResults: RequestMap<PrometheusRulesResponse>; // TODO: remove once noobaa-storage-plugin, ceph-storage-plugin, and metal3-plugin status cards have been updated to switch over to alertNotifications, see https://github.com/openshift/console/pull/4539
+  notificationAlerts: any;
   watchK8sResource: WatchK8sResource;
   stopWatchK8sResource: StopWatchK8sResource;
   resources?: {

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -11,6 +11,7 @@ import {
 import * as UIActions from '@console/internal/actions/ui';
 import store, { RootState } from '@console/internal/redux';
 import { Alert, alertURL } from '@console/internal/components/monitoring';
+import { NotificationAlerts } from '@console/internal/reducers/ui';
 import { RedExclamationCircleIcon } from '@console/shared';
 import {
   getAlertDescription,
@@ -322,13 +323,7 @@ export type ConnectedNotificationDrawerProps = {
   isDrawerExpanded: boolean;
   notificationsRead: boolean;
   onDrawerChange: () => void;
-  alerts: {
-    data: Alert[];
-    loaded: boolean;
-    loadError?: {
-      message?: string;
-    };
-  };
+  alerts: NotificationAlerts;
   resources?: {
     cv: FirehoseResult<ClusterVersionKind>;
   };

--- a/frontend/public/reducers/dashboards.ts
+++ b/frontend/public/reducers/dashboards.ts
@@ -10,7 +10,6 @@ export enum RESULTS_TYPE {
 export const defaults = {
   [RESULTS_TYPE.PROMETHEUS]: fromJS({}),
   [RESULTS_TYPE.URL]: fromJS({}),
-  [RESULTS_TYPE.ALERTS]: fromJS({}),
 };
 
 type Request<R> = {

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -14,6 +14,7 @@ import { legalNamePattern, getNamespace } from '../components/utils/link';
 import { OverviewSpecialGroup } from '../components/overview/constants';
 import { RootState } from '../redux';
 import * as plugins from '../plugins';
+import { Alert } from '../components/monitoring';
 
 export type UIState = ImmutableMap<string, any>;
 
@@ -200,7 +201,7 @@ export default (state: UIState, action: UIAction): UIState => {
           ? action.payload.data
           : state.getIn(['monitoring', 'alerts']);
       // notificationAlerts used by notification drawer and certain dashboards
-      const notificationAlerts =
+      const notificationAlerts: NotificationAlerts =
         action.payload.key === 'notificationAlerts'
           ? action.payload.data
           : state.getIn(['monitoring', 'notificationAlerts']);
@@ -371,3 +372,11 @@ export const getActiveNamespace = ({ UI }: RootState): string => UI.get('activeN
 export const getActivePerspective = ({ UI }: RootState): string => UI.get('activePerspective');
 
 export const getActiveApplication = ({ UI }: RootState): string => UI.get('activeApplication');
+
+export type NotificationAlerts = {
+  data: Alert[];
+  loaded: boolean;
+  loadError?: {
+    message?: string;
+  };
+};


### PR DESCRIPTION
This PR addresses hiding silenced alerts in the cluster dashboard

This PR removes alert watching/polling from Dashboards, and switches to use notificationAlerts (non-silenced, firing alerts) from the global Notification Drawer alerts & silences polling.

**Now Silencing an Alert hides it from Cluster Dashboard:**

<img src="https://raw.githubusercontent.com/dtaylor113/images/master/silenced-alerts-dashboard.gif" />

Note: this PR affects the following plug-ins which will need to be updated to use the new `notificationAlerts` similar to how [frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx](https://github.com/openshift/console/pull/4539/files#diff-7ff42687b5e3af296068f5144e2dfb7eL96) has been updated:
```
frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/status-card.tsx
frontend/packages/metal3-plugin/src/components/baremetal-hosts/dashboard/StatusCard.tsx
frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx