### PR TITLE
[release-4.3] Bug 1808436: Make dev-console project selector sticky again

### DIFF
--- a/frontend/packages/dev-console/src/components/MetricsPage.tsx
+++ b/frontend/packages/dev-console/src/components/MetricsPage.tsx
@@ -3,9 +3,9 @@ import { Helmet } from 'react-helmet';
 import { match as RMatch } from 'react-router';
 import { TechPreviewBadge } from '@console/shared';
 import { QueryBrowserPage } from '@console/internal/components/monitoring/metrics';
-import { NamespaceBar } from '@console/internal/components/namespace';
 import { withStartGuide } from '@console/internal/components/start-guide';
 import ProjectListPage from './projects/ProjectListPage';
+import NamespacedPage, { NamespacedPageVariants } from './NamespacedPage';
 
 export interface MetricsPageProps {
   match: RMatch<{
@@ -16,8 +16,7 @@ export interface MetricsPageProps {
 const MetricsPage: React.FC<MetricsPageProps> = ({ match }) => {
   const namespace = match.params.ns;
   return (
-    <>
-      <NamespaceBar />
+    <NamespacedPage variant={NamespacedPageVariants.light}>
       <Helmet>
         <title>Metrics</title>
       </Helmet>
@@ -28,7 +27,7 @@ const MetricsPage: React.FC<MetricsPageProps> = ({ match }) => {
           Select a project to view metrics
         </ProjectListPage>
       )}
-    </>
+    </NamespacedPage>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/NamespacedPage.scss
+++ b/frontend/packages/dev-console/src/components/NamespacedPage.scss
@@ -6,9 +6,11 @@
 
   &__content {
     display: flex;
-    flex: 1 0 auto;
+    flex: 1;
     flex-direction: column;
     background-color: var(--pf-global--Color--light-200);
+    overflow-y: auto;
+    position: relative;
 
     &.is-light {
       background-color: var(--pf-global--Color--light-100);

--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccessPage.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccessPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { match as RMatch } from 'react-router';
-import { NamespaceBar } from '@console/internal/components/namespace';
-import RenderProjectAccessPage, { RenderProjectAccessPageProps } from './RenderProjectAccessPage';
+import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
+import RenderProjectAccess from './RenderProjectAccessPage';
 
 export interface ProjectAccessPageProps {
   match: RMatch<{
@@ -11,14 +11,13 @@ export interface ProjectAccessPageProps {
 
 const ProjectAccessPage: React.FC<ProjectAccessPageProps> = ({ match }) => {
   const namespace = match.params.ns;
-  const props: RenderProjectAccessPageProps = {
+  const props: React.ComponentProps<typeof RenderProjectAccess> = {
     namespace,
   };
   return (
-    <>
-      <NamespaceBar />
-      <RenderProjectAccessPage {...props} />
-    </>
+    <NamespacedPage variant={NamespacedPageVariants.light}>
+      <RenderProjectAccess {...props} />
+    </NamespacedPage>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/project-access/__tests__/ProjectAccessPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/__tests__/ProjectAccessPage.spec.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import ProjectAccessPage from '../ProjectAccessPage';
+import RenderProjectAccess from '../RenderProjectAccessPage';
+import NamespacedPage from '../../NamespacedPage';
+
+describe('Project Access Page', () => {
+  const projectAccessPageProps: React.ComponentProps<typeof ProjectAccessPage> = {
+    match: {
+      isExact: true,
+      path: `/project-access/ns/:ns`,
+      url: ``,
+      params: {
+        ns: 'default',
+      },
+    },
+  };
+  const wrapper = shallow(<ProjectAccessPage {...projectAccessPageProps} />);
+  it('should have the NamespacedPage Component', () => {
+    expect(wrapper.find(NamespacedPage).exists()).toBeTruthy();
+  });
+  it('should render the RenderProjectAccessPage Component', () => {
+    expect(wrapper.find(RenderProjectAccess).exists()).toBeTruthy();
+  });
+});

--- a/frontend/packages/dev-console/src/components/projects/ProjectListPage.scss
+++ b/frontend/packages/dev-console/src/components/projects/ProjectListPage.scss
@@ -1,6 +1,6 @@
 .odc-project-list-page {
   background-color: var(--pf-global--BackgroundColor--light-100);
-  min-height: 100%;
+  flex: 1;
   &__section-border {
     margin-top: 30px;
     margin-bottom: 30px;


### PR DESCRIPTION
This is a manual cherry pick of #4056 

**Problem**:
This Bug is caused by the changes made in this PR - https://github.com/openshift/console/pull/4210


**Solution**:
This PR fixes the secondary masthead in the devconsole pages.

![image](https://user-images.githubusercontent.com/9964343/75558360-bbf8d680-5a67-11ea-98cf-fa8aeba954d0.png)


Fixes: https://issues.redhat.com/browse/ODC-2770
