### PR TITLE
Bug 1808394:  remove default sorting from metrics table so query sort is prese…

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -606,7 +606,7 @@ const QueryTable_: React.FC<QueryTableProps> = ({
   const [error, setError] = React.useState();
   const [page, setPage] = React.useState(1);
   const [perPage, setPerPage] = React.useState(50);
-  const [sortBy, setSortBy] = React.useState<ISortBy>({ index: 1, direction: 'asc' });
+  const [sortBy, setSortBy] = React.useState<ISortBy>();
 
   const safeFetch = React.useCallback(useSafeFetch(), []);
 
@@ -632,6 +632,7 @@ const QueryTable_: React.FC<QueryTableProps> = ({
     setData(undefined);
     setError(undefined);
     setPage(1);
+    setSortBy(undefined);
   }, [namespace, query]);
 
   if (!isEnabled || !isExpanded || !query) {
@@ -722,17 +723,19 @@ const QueryTable_: React.FC<QueryTableProps> = ({
       ];
     }
 
-    // Sort Values column numerically and sort all the other columns alphabetically
-    const valuesColIndex = allLabelKeys.length + 1;
-    const sort =
-      sortBy.index === valuesColIndex
-        ? (cells) => {
-            const v = Number(cells[valuesColIndex]);
-            return Number.isNaN(v) ? 0 : v;
-          }
-        : sortBy.index;
-    const unsortedRows = _.map(result, rowMapper);
-    rows = _.orderBy(unsortedRows, [sort], [sortBy.direction]) as string[][];
+    rows = _.map(result, rowMapper);
+    if (sortBy) {
+      // Sort Values column numerically and sort all the other columns alphabetically
+      const valuesColIndex = allLabelKeys.length + 1;
+      const sort =
+        sortBy.index === valuesColIndex
+          ? (cells) => {
+              const v = Number(cells[valuesColIndex]);
+              return Number.isNaN(v) ? 0 : v;
+            }
+          : `${sortBy.index}`;
+      rows = _.orderBy(rows, [sort], [sortBy.direction]);
+    }
   }
 
   // Set the result table's break point based on the number of columns


### PR DESCRIPTION
…rved

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1808394

Do not sort data by default so the results match the query.  The use can still sort by column headers, however.

Before:
![Screen Shot 2020-02-28 at 2 05 37 PM](https://user-images.githubusercontent.com/895728/75579328-8fc36280-5a33-11ea-8ed8-3879e713910a.png)

After:
![Screen Shot 2020-03-02 at 2 57 54 PM](https://user-images.githubusercontent.com/895728/75712619-39099300-5c96-11ea-8e95-9e331d76cd6c.png)

[1] 
![Screen Shot 2020-02-28 at 2 08 04 PM](https://user-images.githubusercontent.com/895728/75579419-c39e8800-5a33-11ea-895a-0ffe0236051e.png)
