### PR TITLE
Bug 1804447: Set min-height to display chart legends

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -20,6 +20,10 @@
     }
   }
 
+  .graph-wrapper--query-browser {
+    min-height: 305px; // Allow for chart legend
+  }
+
   .query-browser__wrapper {
     border: 0;
     margin: 0;


### PR DESCRIPTION
Adding a min-height to `graph-wrapper--query-browser`. 

<img width="1069" alt="Screen Shot 2020-02-28 at 3 18 03 PM" src="https://user-images.githubusercontent.com/1874151/75584440-bdada480-5a3d-11ea-8554-cb17f3485de5.png">
<img width="377" alt="Screen Shot 2020-02-28 at 3 19 11 PM" src="https://user-images.githubusercontent.com/1874151/75584437-bd150e00-5a3d-11ea-8963-4af441a31deb.png">
<img width="1062" alt="Screen Shot 2020-02-28 at 3 18 23 PM" src="https://user-images.githubusercontent.com/1874151/75584439-bdada480-5a3d-11ea-8c34-bdff80a47867.png">

