### PR TITLE
Bug 1795401: Improve monitoring dashboards performance

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -376,6 +376,9 @@ const maxDataPointsHard = 10000;
 const minSamples = 10;
 const maxSamples = 300;
 
+// Fall back to a line chart for performance if there are too many series
+const maxStacks = 20;
+
 // We don't want to refresh all the graph data for just a small adjustment in the number of samples,
 // so don't update unless the number of samples would change by at least this proportion
 const samplesLeeway = 0.2;
@@ -504,6 +507,8 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
   const endTime = _.get(xDomain, '[1]');
 
   const safeFetch = useSafeFetch();
+
+  const stack = isStack && _.sumBy(graphData, 'length') <= maxStacks;
 
   // If provided, `timespan` overrides any existing span setting
   React.useEffect(() => {
@@ -676,7 +681,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
                 allSeries={graphData}
                 disabledSeries={disabledSeries}
                 formatLegendLabel={formatLegendLabel}
-                isStack={isStack}
+                isStack={stack}
                 span={span}
                 xDomain={xDomain}
               />
@@ -685,7 +690,7 @@ const QueryBrowser_: React.FC<QueryBrowserProps> = ({
                 allSeries={graphData}
                 disabledSeries={disabledSeries}
                 formatLegendLabel={formatLegendLabel}
-                isStack={isStack}
+                isStack={stack}
                 onZoom={onZoom}
                 span={span}
                 xDomain={xDomain}


### PR DESCRIPTION
Avoid stacked area charts when there are too many series.

@kyoto Opinion on this change? The stacked area charts seem to be the ones with performance issues. Switching to a line chart when there are a lot of series makes a noticeable difference.