### PR TITLE
Bug 1786429: Add replicas info on StatefulSet Overview 

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodRingDataController.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRingDataController.tsx
@@ -69,6 +69,13 @@ const PodRingController: React.FC<PodRingDataControllerProps> = ({ namespace, ki
       namespace,
       prop: 'deploymentConfigs',
     });
+  } else if (kind === 'StatefulSet') {
+    resources.push({
+      isList: true,
+      kind: 'StatefulSet',
+      namespace,
+      prop: 'statefulSets',
+    });
   }
 
   return (

--- a/frontend/public/components/stateful-set.tsx
+++ b/frontend/public/components/stateful-set.tsx
@@ -14,9 +14,12 @@ import {
   ResourceSummary,
   SectionHeading,
   navFactory,
+  LoadingInline,
 } from './utils';
 import { VolumesTable } from './volumes-table';
 import { StatefulSetModel } from '../models';
+import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
+import { PodRingController } from '@console/shared';
 
 const { AddStorage, common } = Kebab.factory;
 export const menuActions: KebabAction[] = [
@@ -49,6 +52,23 @@ const StatefulSetDetails: React.FC<StatefulSetDetailsProps> = ({ obj: ss }) => (
   <>
     <div className="co-m-pane__body">
       <SectionHeading text="StatefulSet Details" />
+      <PodRingController
+        namespace={ss.metadata.namespace}
+        kind={ss.kind}
+        render={(d) => {
+          return d.loaded ? (
+            <PodRingSet
+              key={ss.metadata.uid}
+              podData={d.data[ss.metadata.uid]}
+              obj={ss}
+              resourceKind={StatefulSetModel}
+              path="/spec/replicas"
+            />
+          ) : (
+            <LoadingInline />
+          );
+        }}
+      />
       <ResourceSummary resource={ss} showPodSelector showNodeSelector showTolerations />
     </div>
     <div className="co-m-pane__body">


### PR DESCRIPTION
/assign @TheRealJon
/cc @benjaminapetersen @spadgett

There are ("Annotation key for deployment revision -'deployment.kubernetes.io/revision'  " and "Annotation key for deployment config latest version- 'openshift.io/deployment-config.latest-version' ") constants used in the implementation of Deployment and DeploymentConfig pod info for donut chart. 

I am wondering if there is "Annotation key..." for StatefulSet resource. Although, the donut plots without it.

<img width="1257" alt="Screen Shot 2020-03-05 at 9 13 06 AM" src="https://user-images.githubusercontent.com/15249132/75989706-b9600c00-5ec1-11ea-89c3-a93fff071fbb.png">
