### PR TITLE
Add metrics for Node Table

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -1,21 +1,38 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
+import { connect } from 'react-redux';
+import * as _ from 'lodash';
 import { sortable } from '@patternfly/react-table';
-import { getNodeMachineNameAndNamespace, getName, getUID } from '@console/shared';
-import { MachineModel, NodeModel } from '@console/internal/models';
+import { getName, getUID } from '@console/shared';
+import { NodeModel } from '@console/internal/models';
 import { NodeKind, referenceForModel } from '@console/internal/module/k8s';
 import { Table, TableRow, TableData, ListPage } from '@console/internal/components/factory';
-import { Kebab, ResourceKebab, ResourceLink } from '@console/internal/components/utils';
+import {
+  Kebab,
+  ResourceKebab,
+  ResourceLink,
+  humanizeBinaryBytes,
+  formatCores,
+} from '@console/internal/components/utils';
+import { NodeMetrics, setNodeMetrics } from '@console/internal/actions/ui';
+import { PROMETHEUS_BASE_PATH } from '@console/internal/components/graphs';
+import { coFetchJSON } from '@console/internal/co-fetch';
+import { fromNow } from '@console/internal/components/utils/datetime';
+import { getPrometheusURL, PrometheusEndpoint } from '@console/internal/components/graphs/helpers';
 import { nodeStatus } from '../../status/node';
 import NodeRoles from './NodeRoles';
 import { menuActions } from './menu-actions';
 import NodeStatus from './NodeStatus';
 
 const tableColumnClasses = [
-  classNames('col-md-4', 'col-sm-4', 'col-xs-8'),
-  classNames('col-md-3', 'col-sm-4', 'col-xs-4'),
-  classNames('col-md-2', 'col-sm-4', 'hidden-xs'),
-  classNames('col-md-3', 'hidden-sm', 'hidden-xs'),
+  '',
+  '',
+  '',
+  classNames('pf-m-hidden', 'pf-m-visible-on-xl'),
+  classNames('pf-m-hidden', 'pf-m-visible-on-xl'),
+  classNames('pf-m-hidden', 'pf-m-visible-on-xl'),
+  classNames('pf-m-hidden', 'pf-m-visible-on-xl'),
+  classNames('pf-m-hidden', 'pf-m-visible-on-lg'),
   Kebab.columnClass,
 ];
 
@@ -40,50 +57,102 @@ const NodeTableHeader = () => {
       props: { className: tableColumnClasses[2] },
     },
     {
-      title: 'Machine',
-      sortField: "metadata.annotations['machine.openshift.io/machine']",
+      title: 'Pods',
+      sortFunc: 'nodePods',
       transforms: [sortable],
       props: { className: tableColumnClasses[3] },
     },
     {
-      title: '',
+      title: 'Memory',
+      sortFunc: 'nodeMemory',
+      transforms: [sortable],
       props: { className: tableColumnClasses[4] },
+    },
+    {
+      title: 'CPU',
+      sortFunc: 'nodeCPU',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[5] },
+    },
+    {
+      title: 'Filesystem',
+      sortFunc: 'nodeFS',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[6] },
+    },
+    {
+      title: 'Created At',
+      sortField: 'metadata.creationTimestamp',
+      transforms: [sortable],
+      props: { className: tableColumnClasses[7] },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses[8] },
     },
   ];
 };
 NodeTableHeader.displayName = 'NodeTableHeader';
 
-const NodesTableRow: React.FC<NodesTableRowProps> = ({ obj: node, index, key, style }) => {
-  const { name: machineName, namespace: machineNamespace } = getNodeMachineNameAndNamespace(node);
-  const nodeName = getName(node);
-  const nodeUID = getUID(node);
-  return (
-    <TableRow id={nodeUID} index={index} trKey={key} style={style}>
-      <TableData className={tableColumnClasses[0]}>
-        <ResourceLink kind={referenceForModel(NodeModel)} name={nodeName} title={nodeUID} />
-      </TableData>
-      <TableData className={tableColumnClasses[1]}>
-        <NodeStatus node={node} />
-      </TableData>
-      <TableData className={tableColumnClasses[2]}>
-        <NodeRoles node={node} />
-      </TableData>
-      <TableData className={tableColumnClasses[3]}>
-        {machineName && (
-          <ResourceLink
-            kind={referenceForModel(MachineModel)}
-            name={machineName}
-            namespace={machineNamespace}
-          />
-        )}
-      </TableData>
-      <TableData className={tableColumnClasses[4]}>
-        <ResourceKebab actions={menuActions} kind={referenceForModel(NodeModel)} resource={node} />
-      </TableData>
-    </TableRow>
-  );
+const mapStateToProps = ({ UI }) => ({
+  metrics: UI.getIn(['metrics', 'node']),
+});
+
+type NodesRowMapFromStateProps = {
+  metrics: NodeMetrics;
 };
+
+const NodesTableRow = connect<NodesRowMapFromStateProps, null, NodesTableRowProps>(mapStateToProps)(
+  ({ obj: node, index, key, style, metrics }: NodesTableRowProps & NodesRowMapFromStateProps) => {
+    const nodeName = getName(node);
+    const nodeUID = getUID(node);
+    const usedMem = metrics?.usedMemory?.[nodeName];
+    const totalMem = metrics?.totalMemory?.[nodeName];
+    const memory =
+      Number.isFinite(usedMem) && Number.isFinite(totalMem)
+        ? `${humanizeBinaryBytes(usedMem).string} / ${humanizeBinaryBytes(totalMem).string}`
+        : '-';
+    const cores = metrics?.cpu?.[nodeName];
+    const usedStrg = metrics?.usedStorage?.[nodeName];
+    const totalStrg = metrics?.totalStorage?.[nodeName];
+    const storage =
+      Number.isFinite(usedStrg) && Number.isFinite(totalStrg)
+        ? `${humanizeBinaryBytes(usedStrg).string} / ${humanizeBinaryBytes(totalStrg).string}`
+        : '-';
+    const pods = metrics?.pods?.[nodeName] ?? '-';
+    return (
+      <TableRow id={nodeUID} index={index} trKey={key} style={style}>
+        <TableData className={tableColumnClasses[0]}>
+          <ResourceLink kind={referenceForModel(NodeModel)} name={nodeName} title={nodeUID} />
+        </TableData>
+        <TableData className={tableColumnClasses[1]}>
+          <NodeStatus node={node} />
+        </TableData>
+        <TableData className={tableColumnClasses[2]}>
+          <NodeRoles node={node} />
+        </TableData>
+        <TableData className={tableColumnClasses[3]}>{pods}</TableData>
+        <TableData className={tableColumnClasses[4]}>{memory}</TableData>
+        <TableData className={tableColumnClasses[5]}>
+          {cores ? `${formatCores(cores)} cores` : '-'}
+        </TableData>
+        <TableData className={tableColumnClasses[6]}>{storage}</TableData>
+        <TableData className={tableColumnClasses[7]}>
+          {fromNow(node.metadata.creationTimestamp)}
+        </TableData>
+        <TableData className={tableColumnClasses[8]}>
+          <ResourceKebab
+            actions={menuActions}
+            kind={referenceForModel(NodeModel)}
+            resource={node}
+          />
+        </TableData>
+      </TableRow>
+    );
+  },
+);
 NodesTableRow.displayName = 'NodesTableRow';
+
 type NodesTableRowProps = {
   obj: NodeKind;
   index: number;
@@ -91,9 +160,14 @@ type NodesTableRowProps = {
   style: object;
 };
 
-const NodesTable: React.FC<NodesTableProps> = (props) => (
-  <Table {...props} aria-label="Nodes" Header={NodeTableHeader} Row={NodesTableRow} virtualize />
-);
+const NodesTable: React.FC<NodesTableProps> = React.memo((props) => {
+  const row = React.useCallback(
+    (rowProps: NodesTableRowProps) => <NodesTableRow {...rowProps} />,
+    [],
+  );
+  return <Table {...props} aria-label="Nodes" Header={NodeTableHeader} Row={row} virtualize />;
+});
+
 type NodesTableProps = React.ComponentProps<typeof Table> & {
   data: NodeKind[];
 };
@@ -110,8 +184,79 @@ const filters = [
   },
 ];
 
-const NodesPage = (props) => (
-  <ListPage {...props} ListComponent={NodesTable} rowFilters={filters} />
-);
+const fetchNodeMetrics = (): Promise<NodeMetrics> => {
+  const metrics = [
+    {
+      key: 'usedMemory',
+      query: 'sum by (instance) (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes)',
+    },
+    {
+      key: 'totalMemory',
+      query: 'sum by (instance) (node_memory_MemTotal_bytes)',
+    },
+    {
+      key: 'usedStorage',
+      query: 'sum by (instance) (node_filesystem_size_bytes - node_filesystem_free_bytes)',
+    },
+    {
+      key: 'totalStorage',
+      query: 'sum by (instance) (node_filesystem_size_bytes)',
+    },
+    {
+      key: 'cpu',
+      query: 'sum by(instance) (instance:node_cpu:rate:sum)',
+    },
+    {
+      key: 'pods',
+      query: 'sum by(node)(kubelet_running_pod_count)',
+    },
+  ];
+  const promises = metrics.map(({ key, query }) => {
+    const url = getPrometheusURL({ endpoint: PrometheusEndpoint.QUERY, query });
+    return coFetchJSON(url).then(({ data: { result } }) => {
+      return result.reduce((acc, data) => {
+        const value = Number(data.value[1]);
+        return _.set(acc, [key, data.metric.instance || data.metric.node], value);
+      }, {});
+    });
+  });
+  return Promise.all(promises).then((data: any[]) => _.assign({}, ...data));
+};
+
+const mapDispatchToProps = (dispatch): MapDispatchToProps => ({
+  setNodeMetrics: (metrics) => dispatch(setNodeMetrics(metrics)),
+});
+
+const showMetrics = PROMETHEUS_BASE_PATH && window.innerWidth > 1200;
+
+const NodesPage = connect<{}, MapDispatchToProps>(
+  null,
+  mapDispatchToProps,
+)((props: MapDispatchToProps) => {
+  const { setNodeMetrics: setMetrics } = props;
+
+  React.useEffect(() => {
+    const updateMetrics = () =>
+      fetchNodeMetrics()
+        .then(setMetrics)
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error('Error fetching node metrics: ', e);
+        });
+    updateMetrics();
+    if (showMetrics) {
+      const id = setInterval(updateMetrics, 30 * 1000);
+      return () => clearInterval(id);
+    }
+    return () => {};
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <ListPage {...props} kind="Node" ListComponent={NodesTable} rowFilters={filters} />;
+});
+
+type MapDispatchToProps = {
+  setNodeMetrics: (metrics) => void;
+};
 
 export default NodesPage;

--- a/frontend/packages/console-shared/src/index.ts
+++ b/frontend/packages/console-shared/src/index.ts
@@ -4,3 +4,4 @@ export * from './selectors';
 export * from './types';
 export * from './utils';
 export * from './hooks';
+export * from './sorts';

--- a/frontend/packages/console-shared/src/sorts/index.ts
+++ b/frontend/packages/console-shared/src/sorts/index.ts
@@ -1,0 +1,1 @@
+export * from './nodes';

--- a/frontend/packages/console-shared/src/sorts/nodes.ts
+++ b/frontend/packages/console-shared/src/sorts/nodes.ts
@@ -1,0 +1,15 @@
+import * as UIActions from '@console/internal/actions/ui';
+import { NodeKind } from '@console/internal/module/k8s';
+
+export const nodeMemory = (node: NodeKind): number => {
+  const used = UIActions.getNodeMetric(node, 'usedMemory');
+  const total = UIActions.getNodeMetric(node, 'totalMemory');
+  return total === 0 ? 0 : used / total;
+};
+export const nodeFS = (node: NodeKind): number => {
+  const used = UIActions.getNodeMetric(node, 'usedStorage');
+  const total = UIActions.getNodeMetric(node, 'totalStorage');
+  return total === 0 ? 0 : used / total;
+};
+export const nodeCPU = (node: NodeKind): number => Number(UIActions.getNodeMetric(node, 'cpu'));
+export const nodePods = (node: NodeKind): number => Number(UIActions.getNodeMetric(node, 'pods'));

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -11,7 +11,7 @@ import {
   LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
   LAST_PERSPECTIVE_LOCAL_STORAGE_KEY,
 } from '@console/shared/src/constants';
-import { K8sResourceKind, PodKind } from '../module/k8s';
+import { K8sResourceKind, PodKind, NodeKind } from '../module/k8s';
 import { allModels } from '../module/k8s/k8s-models';
 import { detectFeatures, clearSSARFlags } from './features';
 import { OverviewSpecialGroup } from '../components/overview/constants';
@@ -61,6 +61,7 @@ export enum ActionType {
   SetConsoleLinks = 'setConsoleLinks',
   SetPodMetrics = 'setPodMetrics',
   SetNamespaceMetrics = 'setNamespaceMetrics',
+  SetNodeMetrics = 'setNodeMetrics',
 }
 
 type MetricValuesByName = {
@@ -79,6 +80,15 @@ type MetricValuesByNamespace = {
 export type PodMetrics = {
   cpu: MetricValuesByNamespace;
   memory: MetricValuesByNamespace;
+};
+
+export type NodeMetrics = {
+  cpu: MetricValuesByName;
+  pods: MetricValuesByName;
+  usedMemory: MetricValuesByName;
+  totalMemory: MetricValuesByName;
+  usedStorage: MetricValuesByName;
+  totalStorage: MetricValuesByName;
 };
 
 // URL routes that can be namespaced
@@ -105,7 +115,12 @@ export const getNamespaceMetric = (ns: K8sResourceKind, metric: string): number 
 
 export const getPodMetric = (pod: PodKind, metric: string): number => {
   const metrics = store.getState().UI.getIn(['metrics', 'pod']);
-  return _.get(metrics, [metric, pod.metadata.namespace, pod.metadata.name], 0);
+  return metrics?.[metric]?.[pod.metadata.namespace]?.[pod.metadata.name] ?? 0;
+};
+
+export const getNodeMetric = (node: NodeKind, metric: string): number => {
+  const metrics = store.getState().UI.getIn(['metrics', 'node']);
+  return metrics?.[metric]?.[node.metadata.name] ?? 0;
 };
 
 export const formatNamespaceRoute = (activeNamespace, originalPath, location?) => {
@@ -325,6 +340,8 @@ export const setPodMetrics = (podMetrics: PodMetrics) =>
   action(ActionType.SetPodMetrics, { podMetrics });
 export const setNamespaceMetrics = (namespaceMetrics: NamespaceMetrics) =>
   action(ActionType.SetNamespaceMetrics, { namespaceMetrics });
+export const setNodeMetrics = (nodeMetrics: NodeMetrics) =>
+  action(ActionType.SetNodeMetrics, { nodeMetrics });
 
 // TODO(alecmerdler): Implement all actions using `typesafe-actions` and add them to this export
 const uiActions = {
@@ -371,6 +388,7 @@ const uiActions = {
   setConsoleLinks,
   setPodMetrics,
   setNamespaceMetrics,
+  setNodeMetrics,
   notificationDrawerToggleExpanded,
   notificationDrawerToggleRead,
 };

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -2,7 +2,14 @@ import * as _ from 'lodash-es';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { getNodeRoles, getMachinePhase } from '@console/shared';
+import {
+  getNodeRoles,
+  getMachinePhase,
+  nodeMemory,
+  nodeCPU,
+  nodeFS,
+  nodePods,
+} from '@console/shared';
 import * as UIActions from '../../actions/ui';
 import { ingressValidHosts } from '../ingress';
 import { alertStateOrder, silenceStateOrder } from '../../reducers/monitoring';
@@ -122,7 +129,11 @@ const sorts = {
     const roles = getNodeRoles(node);
     return roles.sort().join(', ');
   },
+  nodeMemory: (node: NodeKind): number => nodeMemory(node),
+  nodeCPU: (node: NodeKind): number => nodeCPU(node),
+  nodeFS: (node: NodeKind): number => nodeFS(node),
   machinePhase: (machine: MachineKind): string => getMachinePhase(machine),
+  nodePods: (node: NodeKind): number => nodePods(node),
 };
 
 const stateToProps = (

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -376,6 +376,9 @@ export type NodeKind = {
     unschedulable?: boolean;
   };
   status?: {
+    capacity?: {
+      [key: string]: string;
+    };
     conditions?: NodeCondition[];
     images?: {
       names: string[];

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -338,6 +338,8 @@ export default (state: UIState, action: UIAction): UIState => {
 
     case ActionType.SetNamespaceMetrics:
       return state.setIn(['metrics', 'namespace'], action.payload.namespaceMetrics);
+    case ActionType.SetNodeMetrics:
+      return state.setIn(['metrics', 'node'], action.payload.nodeMetrics);
 
     default:
       break;


### PR DESCRIPTION
![Screenshot from 2020-03-11 14-49-27](https://user-images.githubusercontent.com/54092533/76401601-271ba480-63a8-11ea-9066-623c85f32791.png)

Adds metrics for Node table and sorts for X/Y fields on the basis of x/y(division) values.