### PR TITLE
Add popover for monitored conditions in Node List Page

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodeStatus.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodeStatus.tsx
@@ -1,16 +1,58 @@
 import * as React from 'react';
+import * as _ from 'lodash';
+import ConsumerPopover from '@console/shared/src/components/dashboard/utilization-card/TopConsumerPopover';
 import { Status, SecondaryStatus, getNodeSecondaryStatus } from '@console/shared';
 import { NodeKind } from '@console/internal/module/k8s';
+import { humanizeBinaryBytes, humanizeNumber } from '@console/internal/components/utils';
 import { nodeStatus } from '../../status/node';
+import { PressureQueries, Condition } from '../../queries';
+
+const conditionDescriptionMap = Object.freeze({
+  [Condition.DISK_PRESSURE]: 'available memory is low',
+  [Condition.MEM_PRESSURE]: 'available disk capacity is low',
+  [Condition.PID_PRESSURE]: 'CPU is running a large number of processes',
+});
+
+const humanizeMap = Object.freeze({
+  [Condition.DISK_PRESSURE]: humanizeBinaryBytes,
+  [Condition.MEM_PRESSURE]: humanizeBinaryBytes,
+  [Condition.PID_PRESSURE]: humanizeNumber,
+});
+
+const isMonitoredCondition = (condition: Condition): boolean =>
+  [Condition.DISK_PRESSURE, Condition.MEM_PRESSURE, Condition.PID_PRESSURE].includes(condition);
+
+const getDegradedStates = (node: NodeKind): Condition[] => {
+  return node.status.conditions
+    .filter(({ status, type }) => status === 'True' && isMonitoredCondition(type as Condition))
+    .map(({ type }) => type as Condition);
+};
+
+const NodeStatus: React.FC<NodeStatusProps> = ({ node, showPopovers = false }) => {
+  const status = showPopovers ? getDegradedStates(node) : [];
+  return (
+    <>
+      <Status status={nodeStatus(node)} />
+      <SecondaryStatus status={getNodeSecondaryStatus(node)} />
+      {status.length > 0 &&
+        status.map((item) => (
+          <div key={item}>
+            <ConsumerPopover
+              title={_.startCase(item)}
+              current={_.startCase(item)}
+              consumers={PressureQueries[item](node.metadata.name)}
+              humanize={humanizeMap[item]}
+              description={`This node's ${conditionDescriptionMap[item]}. Performance may be degraded.`}
+            />
+          </div>
+        ))}
+    </>
+  );
+};
 
 type NodeStatusProps = {
   node: NodeKind;
+  showPopovers?: boolean;
 };
 
-const NodeStatus: React.FC<NodeStatusProps> = ({ node }) => (
-  <>
-    <Status status={nodeStatus(node)} />
-    <SecondaryStatus status={getNodeSecondaryStatus(node)} />
-  </>
-);
 export default NodeStatus;

--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -126,7 +126,7 @@ const NodesTableRow = connect<NodesRowMapFromStateProps, null, NodesTableRowProp
           <ResourceLink kind={referenceForModel(NodeModel)} name={nodeName} title={nodeUID} />
         </TableData>
         <TableData className={tableColumnClasses[1]}>
-          <NodeStatus node={node} />
+          <NodeStatus node={node} showPopovers />
         </TableData>
         <TableData className={tableColumnClasses[2]}>
           <NodeRoles node={node} />

--- a/frontend/packages/console-app/src/queries.ts
+++ b/frontend/packages/console-app/src/queries.ts
@@ -1,6 +1,40 @@
+import { PodModel } from '@console/internal/models';
+
 export const API_SERVERS_UP = '(sum(up{job="apiserver"} == 1) / count(up{job="apiserver"})) * 100';
 export const CONTROLLER_MANAGERS_UP =
   '(sum(up{job="kube-controller-manager"} == 1) / count(up{job="kube-controller-manager"})) * 100';
 export const SCHEDULERS_UP = '(sum(up{job="scheduler"} == 1) / count(up{job="scheduler"})) * 100';
 export const API_SERVER_REQUESTS_SUCCESS =
   '(1 - (sum(rate(apiserver_request_count{code=~"5.."}[5m])) or vector(0))/ sum(rate(apiserver_request_count[5m]))) * 100';
+
+export const enum Condition {
+  DISK_PRESSURE = 'DiskPressure',
+  PID_PRESSURE = 'PIDPressure',
+  MEM_PRESSURE = 'MemoryPressure',
+}
+
+export const PressureQueries = {
+  [Condition.DISK_PRESSURE]: (node: string) => [
+    {
+      model: PodModel,
+      metric: 'pod',
+      query: `(sort_desc(topk(25,sum by(pod, namespace) (container_fs_reads_total{node="${node}"}))))`,
+    },
+  ],
+
+  [Condition.MEM_PRESSURE]: (node: string) => [
+    {
+      model: PodModel,
+      metric: 'pod',
+      query: `(sort_desc(topk(25,sum by(pod, namespace) (container_memory_usage_bytes{node="${node}"}))))`,
+    },
+  ],
+
+  [Condition.PID_PRESSURE]: (node: string) => [
+    {
+      model: PodModel,
+      metric: 'pod',
+      query: `(sort_desc(topk(25,sum by(pod, namespace) (container_processes{node="${node}"}))))`,
+    },
+  ],
+};

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/TopConsumerPopover.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/TopConsumerPopover.tsx
@@ -23,7 +23,7 @@ import { DashboardCardPopupLink } from '../dashboard-card/DashboardCardLink';
 import './top-consumer-popover.scss';
 
 const ConsumerPopover: React.FC<ConsumerPopoverProps> = React.memo(
-  ({ current, title, humanize, consumers, namespace, position }) => {
+  ({ current, title, humanize, consumers, namespace, position, description }) => {
     const [isOpen, setOpen] = React.useState(false);
     return (
       <DashboardCardPopupLink
@@ -38,6 +38,7 @@ const ConsumerPopover: React.FC<ConsumerPopoverProps> = React.memo(
           consumers={consumers}
           namespace={namespace}
           isOpen={isOpen}
+          description={description}
         />
       </DashboardCardPopupLink>
     );
@@ -65,6 +66,7 @@ const PopoverBodyInternal: React.FC<DashboardItemProps &
     isOpen,
     canAccessMonitoring,
     activePerspective,
+    description,
   } = props;
   const [currentConsumer, setCurrentConsumer] = React.useState(consumers[0]);
   const { query, model, metric } = currentConsumer;
@@ -163,6 +165,7 @@ const PopoverBodyInternal: React.FC<DashboardItemProps &
 
   return (
     <div className="co-utilization-card-popover__body">
+      <div className="co-utilization-card-popover__description">{description}</div>
       <h4 className="co-utilization-card-popover__title">
         {consumers.length === 1
           ? `Top ${currentConsumer.model.label.toLowerCase()} consumers`
@@ -232,6 +235,7 @@ type PopoverBodyProps = {
   consumers: { model: K8sKind; query: string; metric: string }[];
   namespace?: string;
   isOpen: boolean;
+  description?: React.ReactText;
 };
 
 export type ConsumerPopoverProps = {
@@ -241,4 +245,5 @@ export type ConsumerPopoverProps = {
   consumers: { model: K8sKind; query: string; metric: string }[];
   namespace?: string;
   position?: PopoverPosition;
+  description?: React.ReactText;
 };

--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/top-consumer-popover.scss
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/top-consumer-popover.scss
@@ -1,44 +1,52 @@
 @import '../../../styles/skeleton-screen';
 
 .co-utilization-card-popover__body {
-    min-height: var(--pf-global--spacer--lg);
+  min-height: var(--pf-global--spacer--lg);
 }
 
 .co-utilization-card-popover__consumer-item {
-    margin-bottom: var(--pf-global--spacer--sm) !important;
+  margin-bottom: var(--pf-global--spacer--sm) !important;
 }
 
 .co-utilization-card-popover__consumer-list {
-    list-style-type: none;
-    margin-bottom: var(--pf-global--spacer--md);
-    margin-top: var(--pf-global--spacer--lg);
-    padding-left:0;
+  list-style-type: none;
+  margin-bottom: var(--pf-global--spacer--md);
+  margin-top: var(--pf-global--spacer--lg);
+  padding-left: 0;
 }
 
 .co-utilization-card-popover__consumer-name {
-    flex: 0 0 calc(70% - var(--pf-global--spacer--md));
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  flex: 0 0 calc(70% - var(--pf-global--spacer--md));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .co-utilization-card-popover__consumer-value {
-    color: var(--pf-global--Color--200);
-    flex: 0 0 30%;
-    text-align: right;
+  color: var(--pf-global--Color--200);
+  flex: 0 0 30%;
+  text-align: right;
 }
 
-.co-utilization-card-popover__dropdown, .co-utilization-card-popover__dropdown > div, .co-utilization-card-popover__dropdown .pf-c-dropdown__toggle {
-    width: 100%;
+.co-utilization-card-popover__description {
+  padding: var(--pf-global--spacer--sm) 0;
+}
+
+.co-utilization-card-popover__dropdown,
+.co-utilization-card-popover__dropdown > div,
+.co-utilization-card-popover__dropdown .pf-c-dropdown__toggle {
+  width: 100%;
 }
 
 .co-utilization-card-popover__title {
-    font-weight: var(--pf-global--FontWeight--bold);
-    margin-bottom: var(--pf-global--spacer--sm);
+  font-weight: var(--pf-global--FontWeight--bold);
+  margin-bottom: var(--pf-global--spacer--sm);
 }
 
-.co-utilization-card-popover__title, .co-utilization-card-popover__consumer-name, .co-utilization-card-popover__consumer-value {
-    font-size: var(--pf-global--FontSize--sm);
+.co-utilization-card-popover__title,
+.co-utilization-card-popover__consumer-name,
+.co-utilization-card-popover__consumer-value {
+  font-size: var(--pf-global--FontSize--sm);
 }
 
 .skeleton-consumer {
@@ -50,7 +58,7 @@
   margin-bottom: var(--pf-global--spacer--sm);
   &::after {
     background-repeat: no-repeat;
-    content: "";
+    content: '';
     display: block;
     height: 100%;
     width: 100%;


### PR DESCRIPTION
![Screenshot from 2020-03-11 17-06-47](https://user-images.githubusercontent.com/54092533/76413275-26d8d480-63bb-11ea-9446-dfbe3873234a.png)
- Add popover under the status column for node conditions.
- Show top pod consumers in the popovers.

Rebased on https://github.com/openshift/console/pull/4595