### PR TITLE
Bug 1808955: Add IP separator in VM list

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -123,7 +123,7 @@ const VMRow: React.FC<VMRowProps> = ({
       <TableData className={dimensify()}>
         {node && <ResourceLink kind={NodeModel.kind} name={node} namespace={namespace} />}
       </TableData>
-      <TableData className={dimensify()}>{vmi && getVmiIpAddresses(vmi)}</TableData>
+      <TableData className={dimensify()}>{vmi && getVmiIpAddresses(vmi).join(', ')}</TableData>
       <TableData className={dimensify(true)}>
         <Kebab options={options} key={`kebab-for-${uid}`} id={`kebab-for-${uid}`} />
       </TableData>


### PR DESCRIPTION
In VM list view the IPs are printed without separator.

Screenshots:
After:
![Virtual Machines · OKD(1)](https://user-images.githubusercontent.com/2181522/75757039-4d06d080-5d3a-11ea-8be4-0560c3fd56b3.png)

Before:
![Virtual Machines · OKD](https://user-images.githubusercontent.com/2181522/75757040-4e37fd80-5d3a-11ea-96fa-cd793a78e1d3.png)
