### PR TITLE
Bug 1803780: Validate disk buses on created VMs

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal-enhanced.tsx
@@ -19,6 +19,7 @@ import { DataVolumeWrapper } from '../../../k8s/wrapper/vm/data-volume-wrapper';
 import { getUpdateDiskPatches } from '../../../k8s/patches/vm/vm-disk-patches';
 import { CombinedDiskFactory } from '../../../k8s/wrapper/vm/combined-disk';
 import { DiskModal } from './disk-modal';
+import { TemplateValidations } from '../../../utils/validations/template/template-validations';
 
 const DiskModalFirehoseComponent: React.FC<DiskModalFirehoseComponentProps> = (props) => {
   const { disk, volume, dataVolume, vmLikeEntity, vmLikeEntityLoading, ...restProps } = props;
@@ -76,6 +77,7 @@ type DiskModalFirehoseComponentProps = ModalComponentProps & {
   persistentVolumeClaims?: FirehoseResult<VMLikeEntityKind[]>;
   vmLikeEntityLoading?: FirehoseResult<VMLikeEntityKind>;
   vmLikeEntity: VMLikeEntityKind;
+  templateValidations?: TemplateValidations;
 };
 
 const DiskModalFirehose: React.FC<DiskModalFirehoseProps> = (props) => {
@@ -130,6 +132,7 @@ type DiskModalFirehoseProps = ModalComponentProps & {
   dataVolume?: any;
   isEditing?: boolean;
   useProjects: boolean;
+  templateValidations?: TemplateValidations;
 };
 
 const diskModalStateToProps = ({ k8s }) => {

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/types.ts
@@ -1,6 +1,8 @@
 import { ValidationObject } from '@console/shared';
 import { VMLikeEntityKind } from '../../types/vmLike';
 import { CombinedDisk } from '../../k8s/wrapper/vm/combined-disk';
+import { UIDiskValidation } from '../../utils/validations/vm/types';
+import { TemplateValidations } from '../../utils/validations/template/template-validations';
 
 export type StorageSimpleData = {
   name?: string;
@@ -22,10 +24,13 @@ export type StorageSimpleDataValidation = {
 
 export type StorageBundle = StorageSimpleData & {
   disk: CombinedDisk;
+  templateValidations?: TemplateValidations;
+  diskValidations?: UIDiskValidation;
 };
 
 export type VMStorageRowActionOpts = {
   withProgress: (promise: Promise<any>) => void;
+  templateValidations?: TemplateValidations;
 };
 
 export type VMStorageRowCustomData = {

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-template/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-template/selectors.ts
@@ -2,6 +2,7 @@ import { VMGenericLikeEntityKind } from '../../types/vmLike';
 import { getLabel, getName, getNamespace } from '@console/shared/src';
 import { LABEL_USED_TEMPLATE_NAME, LABEL_USED_TEMPLATE_NAMESPACE } from '../../constants/vm';
 import { TemplateKind } from '@console/internal/module/k8s';
+import { TemplateValidations } from '../../utils/validations/template/template-validations';
 
 export const getVMTemplateNamespacedName = (
   vm: VMGenericLikeEntityKind,
@@ -23,4 +24,20 @@ export const getVMTemplate = (
           getNamespace(template) === namespacedName.namespace,
       )
     : undefined;
+};
+
+export const getTemplateValidationsFromTemplate = (
+  vmTemplate: TemplateKind,
+): TemplateValidations => {
+  const result = vmTemplate?.metadata?.annotations?.validations;
+
+  if (!result) {
+    return new TemplateValidations();
+  }
+
+  try {
+    return new TemplateValidations(JSON.parse(result));
+  } catch (e) {
+    return new TemplateValidations();
+  }
 };


### PR DESCRIPTION
Validate disk bus type for created VMs storage disks
using validations written in the template
the VMs were created from.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>