### PR TITLE
Bug 1809525: Set DND background color

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order.scss
@@ -26,3 +26,7 @@
   padding-left: var(--pf-global--spacer--lg);
   padding-right: var(--pf-global--spacer--lg);
 }
+
+.kubevirt-boot-order__data-list-item {
+  background: var(--pf-global--BackgroundColor--100);
+}

--- a/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/boot-order/boot-order.tsx
@@ -93,6 +93,7 @@ export const BootOrder = ({ devices, setDevices }: BootOrderProps) => {
                 onMove={onMove}
                 aria-labelledby={`device-${deviceKey(source)}`}
                 key={`device-${deviceKey(source)}`}
+                className="kubevirt-boot-order__data-list-item"
               >
                 <Text id={`device-${deviceKey(source)}`} component={TextVariants.p}>
                   {deviceLabel(source)}


### PR DESCRIPTION
When dragging a boot order item, the dragging preview background is transparent,  that may confuse user what is item being dragged while dragging.

Screenshots:
Before:
![Screenshot from 2020-03-03 09-06-24](https://user-images.githubusercontent.com/2181522/75766263-8abf2580-5d49-11ea-92a2-cf9be07d3422.jpg)

After:
![Screenshot from 2020-03-03 12-07-26](https://user-images.githubusercontent.com/2181522/75766265-8bf05280-5d49-11ea-9e5e-a7b0b2ef5f83.jpg)
