### PR TITLE
Bug 1809642: Update dev console monitoring page use Dashboard components

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
@@ -3,5 +3,7 @@
     float: right;
     align-self: flex-end;
     margin-top: -65px;
+    .monitoring-dashboards__dropdown-wrap {
+      margin-bottom: 5px;
+    }
 }
-

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
@@ -1,9 +1,32 @@
-.odc-monitoring-dashboard__dropdown-options {
-    display: flex;
-    float: right;
+$no-wrap-breakpoint: 915px;
+.odc-monitoring-dashboard {
+  position: relative;
+  &__dropdown-options {
     align-self: flex-end;
-    margin-top: -65px;
-    .monitoring-dashboards__dropdown-wrap {
-      margin-bottom: 5px;
+    display: flex;
+    position: absolute;
+    right: 30px;
+    top: -65px;
+    @media(max-width: $no-wrap-breakpoint) {
+      display: block;
+      margin-left: 15px;
+      margin-top: 15px;
+      position: initial;
+      @media (min-width: 768px) {
+        margin-left: 30px;
+      }
     }
+
+    .monitoring-dashboards__dropdown-wrap {
+      @media(max-width: $no-wrap-breakpoint) {
+        display: inline-block;
+        .monitoring-dashboards__dropdown-title {
+          margin-right: 10px;
+        }
+      }
+      &:last-of-type {
+        margin-right: 0;
+      }
+    }
+  }
 }

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
@@ -46,25 +46,27 @@ export const MonitoringDashboard: React.FC<Props> = ({ match, timespan, pollInte
       <Helmet>
         <title>Dashboard</title>
       </Helmet>
-      <div className="odc-monitoring-dashboard__dropdown-options">
-        <TimespanDropdown />
-        <PollIntervalDropdown />
+      <div className="odc-monitoring-dashboard">
+        <div className="odc-monitoring-dashboard__dropdown-options">
+          <TimespanDropdown />
+          <PollIntervalDropdown />
+        </div>
+        <Dashboard>
+          {_.map(queries, (q) => (
+            <ConnectedMonitoringDashboardGraph
+              title={q.title}
+              namespace={namespace}
+              graphType={q.chartType}
+              query={q.query({ namespace, workloadName, workloadType })}
+              humanize={q.humanize}
+              byteDataType={q.byteDataType}
+              key={q.title}
+              timespan={timespan}
+              pollInterval={pollInterval}
+            />
+          ))}
+        </Dashboard>
       </div>
-      <Dashboard>
-        {_.map(queries, (q) => (
-          <ConnectedMonitoringDashboardGraph
-            title={q.title}
-            namespace={namespace}
-            graphType={q.chartType}
-            query={q.query({ namespace, workloadName, workloadType })}
-            humanize={q.humanize}
-            byteDataType={q.byteDataType}
-            key={q.title}
-            timespan={timespan}
-            pollInterval={pollInterval}
-          />
-        ))}
-      </Dashboard>
     </>
   );
 };

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import { match as RMatch } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
+import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import { RootState } from '@console/internal/redux';
 import { getURLSearchParams } from '@console/internal/components/utils';
 import {
@@ -49,7 +50,7 @@ export const MonitoringDashboard: React.FC<Props> = ({ match, timespan, pollInte
         <TimespanDropdown />
         <PollIntervalDropdown />
       </div>
-      <div className="co-m-pane__body">
+      <Dashboard>
         {_.map(queries, (q) => (
           <ConnectedMonitoringDashboardGraph
             title={q.title}
@@ -63,7 +64,7 @@ export const MonitoringDashboard: React.FC<Props> = ({ match, timespan, pollInte
             pollInterval={pollInterval}
           />
         ))}
-      </div>
+      </Dashboard>
     </>
   );
 };

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.scss
@@ -1,6 +1,10 @@
 .odc-monitoring-dashboard-graph {
+  margin-bottom: var(--pf-global--gutter--md);
+  &:last-of-type {
+    margin-bottom: 0;
+  }
   .query-browser__wrapper {
     border: none;
-    margin: 0;
+    padding: var(--pf-global--spacer--sm) 0 0;
   }
 }

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboardGraph.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
+import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
+import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
+import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import { QueryBrowser, QueryObj } from '@console/internal/components/monitoring/query-browser';
 import { Humanize } from '@console/internal/components/utils';
 import { ByteDataTypes } from '@console/shared/src/graph-helper/data-utils';
@@ -42,23 +46,27 @@ export const MonitoringDashboardGraph: React.FC<MonitoringDashboardGraphProps> =
   pollInterval,
 }) => {
   return (
-    <div className="odc-monitoring-dashboard-graph">
-      <h5>{title}</h5>
-      <PrometheusGraphLink query={query}>
-        <div onMouseEnter={() => patchQuery({ query })}>
-          <QueryBrowser
-            hideControls
-            defaultTimespan={DEFAULT_TIME_SPAN}
-            defaultSamples={DEFAULT_SAMPLES}
-            namespace={namespace}
-            queries={[query]}
-            isStack={graphType === GraphTypes.area}
-            timespan={timespan}
-            pollInterval={pollInterval}
-          />
-        </div>
-      </PrometheusGraphLink>
-    </div>
+    <DashboardCard className="odc-monitoring-dashboard-graph">
+      <DashboardCardHeader>
+        <DashboardCardTitle>{title}</DashboardCardTitle>
+      </DashboardCardHeader>
+      <DashboardCardBody>
+        <PrometheusGraphLink query={query}>
+          <div onMouseEnter={() => patchQuery({ query })}>
+            <QueryBrowser
+              hideControls
+              defaultTimespan={DEFAULT_TIME_SPAN}
+              defaultSamples={DEFAULT_SAMPLES}
+              namespace={namespace}
+              queries={[query]}
+              isStack={graphType === GraphTypes.area}
+              timespan={timespan}
+              pollInterval={pollInterval}
+            />
+          </div>
+        </PrometheusGraphLink>
+      </DashboardCardBody>
+    </DashboardCard>
   );
 };
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3162

**Analysis / Root cause**: 
Monitoring page was not using dashboard components

**Solution Description**: 
Use the shared Dashboard components to create the monitoring graphs

**Screenshots**:
Before:
![image](https://user-images.githubusercontent.com/11633780/75793968-1f238b00-5d3e-11ea-825e-3af4f26681f5.png)

After:
![image](https://user-images.githubusercontent.com/11633780/75794003-28145c80-5d3e-11ea-9891-8d6572e5f2b1.png)


**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

/kind bug

cc @openshift/team-devconsole-ux 
