### PR TITLE
Remove Knative Service when in-context

### DIFF
--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -95,6 +95,7 @@ const DeployImage: React.FC<Props> = ({
       },
     },
     resources: Resources.Kubernetes,
+    resourceTypesNotValid: contextualSource ? [Resources.KnativeService] : [],
     build: {
       env: [],
       triggers: {

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -93,6 +93,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       },
     },
     resources: Resources.Kubernetes,
+    resourceTypesNotValid: contextualSource ? [Resources.KnativeService] : [],
     serverless: {
       scaling: {
         minpods: 0,

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -70,6 +70,7 @@ export interface DeployImageFormData {
   image: ImageStreamImageData;
   isSearchingForImage: boolean;
   resources: Resources;
+  resourceTypesNotValid?: Resources[];
   serverless?: ServerlessData;
   pipeline?: PipelineData;
   labels: { [name: string]: string };
@@ -92,6 +93,7 @@ export interface GitImportFormData {
   image: ImageData;
   route: RouteData;
   resources: Resources;
+  resourceTypesNotValid?: Resources[];
   build: BuildData;
   deployment: DeploymentData;
   labels: { [name: string]: string };


### PR DESCRIPTION
**Fixes**:
https://issues.redhat.com/browse/ODC-3237

**Analysis / Root cause**:
Connections can't be drawn to Knative Services. So in-context fails on the connector when it tries to connect to a Knative Service (as the target of the in-context flow).

**Solution Description**:
Remove the option.

**Screen shots / Gifs for design review**:
Just removed the item - gif incoming momentarily.

**Unit test coverage report**:
No change

**Test setup:**
* Using any Application (including Knative) and drag the connector to any location and do a new in-context add of anything in the list
* Knative Service should not be an option.

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug