### PR TITLE
Bug 1809813: Handle object references with missing API version

### DIFF
--- a/frontend/packages/container-security/src/__tests__/kebab-actions.spec.ts
+++ b/frontend/packages/container-security/src/__tests__/kebab-actions.spec.ts
@@ -1,11 +1,11 @@
+import * as k8sModels from '@console/internal/module/k8s';
 import { ServiceModel, PodModel } from '@console/internal/models';
 import { mockPod } from '@console/shared/src/utils/__mocks__/pod-utils-test-data';
-import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getKebabActionsForKind } from '../kebab-actions';
 import { ImageManifestVulnModel } from '../models';
 
 describe('getKebabActionsForKind', () => {
-  const pod: K8sResourceKind = {
+  const pod: k8sModels.K8sResourceKind = {
     ...mockPod,
     status: {
       phase: 'Running',
@@ -25,6 +25,7 @@ describe('getKebabActionsForKind', () => {
   };
 
   it('returns `ViewImageVulnerabilities` kebab action if given `PodModel`', () => {
+    spyOn(k8sModels, 'modelFor').and.returnValue(PodModel);
     const actions = getKebabActionsForKind(PodModel);
 
     expect(actions.length).toEqual(1);
@@ -41,6 +42,7 @@ describe('getKebabActionsForKind', () => {
   });
 
   it('returns no actions if not given `PodModel`', () => {
+    spyOn(k8sModels, 'modelFor').and.returnValue(ServiceModel);
     expect(getKebabActionsForKind(ServiceModel).length).toEqual(0);
   });
 });


### PR DESCRIPTION
`apiVersion` is optional in some object references such as `involvedObject` on events. Fall back to `modelFor` to locate the model from the kind when it's missing.

/assign @rhamilto 

Before:

![Screenshot_2020-03-03 Events · Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/1167259/75825938-64fb4600-5d74-11ea-9496-74699ae57803.png)

After:

![Screenshot_2020-03-03 Events · OKD(1)](https://user-images.githubusercontent.com/1167259/75825952-6c225400-5d74-11ea-940a-73a90601406f.png)
