### PR TITLE
Bug 1810002: Fix Prometheus query on VMI utilization graphs

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/queries.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/queries.ts
@@ -10,30 +10,26 @@ export enum VMQueries {
 }
 
 const queries = {
+  // We don't set namespace explicitly in the PromQL template because it is
+  // being injected anyway by prom-label-proxy when we query Thanos.
   [VMQueries.CPU_USAGE]: _.template(
     // TODO verify; use seconds or milicores?
     // `kubevirt_vmi_vcpu_seconds{exported_namespace='<%= namespace %>',name='<%= vmName %>'}`,
-    `pod:container_cpu_usage:sum{namespace='<%= namespace %>',pod='<%= launcherPodName %>'}`,
+    `pod:container_cpu_usage:sum{pod='<%= launcherPodName %>'}`,
   ),
-  [VMQueries.MEMORY_USAGE]: _.template(
-    `kubevirt_vmi_memory_resident_bytes{exported_namespace='<%= namespace %>',name='<%= vmName %>'}`,
-  ),
+  [VMQueries.MEMORY_USAGE]: _.template(`kubevirt_vmi_memory_resident_bytes{name='<%= vmName %>'}`),
   [VMQueries.FILESYSTEM_USAGE]: _.template(
-    `sum(kubevirt_vmi_storage_traffic_bytes_total{exported_namespace='<%= namespace %>',name='<%= vmName %>'})`,
+    `sum(kubevirt_vmi_storage_traffic_bytes_total{name='<%= vmName %>'})`,
   ),
   [VMQueries.NETWORK_IN_USAGE]: _.template(
-    `sum(kubevirt_vmi_network_traffic_bytes_total{type='rx',exported_namespace='<%= namespace %>',name='<%= vmName %>'})`,
+    `sum(kubevirt_vmi_network_traffic_bytes_total{type='rx',name='<%= vmName %>'})`,
   ),
   [VMQueries.NETWORK_OUT_USAGE]: _.template(
-    `sum(kubevirt_vmi_network_traffic_bytes_total{type='tx',exported_namespace='<%= namespace %>',name='<%= vmName %>'})`,
+    `sum(kubevirt_vmi_network_traffic_bytes_total{type='tx', name='<%= vmName %>'})`,
   ),
 };
 
-export const getUtilizationQueries = (props: {
-  vmName: string;
-  namespace: string;
-  launcherPodName?: string;
-}) => ({
+export const getUtilizationQueries = (props: { vmName: string; launcherPodName?: string }) => ({
   [VMQueries.CPU_USAGE]: queries[VMQueries.CPU_USAGE](props),
   [VMQueries.MEMORY_USAGE]: queries[VMQueries.MEMORY_USAGE](props),
   [VMQueries.FILESYSTEM_USAGE]: queries[VMQueries.FILESYSTEM_USAGE](props),
@@ -41,7 +37,6 @@ export const getUtilizationQueries = (props: {
 
 export const getMultilineUtilizationQueries = (props: {
   vmName: string;
-  namespace: string;
   launcherPodName?: string;
 }) => ({
   [VMQueries.NETWORK_USAGE]: [

--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-utilization.tsx
@@ -58,20 +58,18 @@ export const VMUtilizationCard: React.FC = () => {
     () =>
       getUtilizationQueries({
         vmName,
-        namespace,
         launcherPodName,
       }),
-    [vmName, namespace, launcherPodName],
+    [vmName, launcherPodName],
   );
 
   const multilineQueries = React.useMemo(
     () =>
       getMultilineUtilizationQueries({
         vmName,
-        namespace,
         launcherPodName,
       }),
-    [vmName, namespace, launcherPodName],
+    [vmName, launcherPodName],
   );
 
   const createdAt = getCreationTimestamp(vmi);


### PR DESCRIPTION
We should not specify the namespace label on the PromQL query because it
is being overwritten anyway by prom-query-proxy to whatever we set in
the namespace query param.

** Related PR on KubeVirt **: (ensures that the labels on our metrics are honored)
https://github.com/kubevirt/kubevirt/pull/3125

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>