### PR TITLE
Bug 1810066: Fix to not allow attempts to move connector to existing targets

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/actions/edgeActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/edgeActions.ts
@@ -25,6 +25,7 @@ const moveConnection = (edge: Edge, availableTargets: Node[]) => {
     callback: () => {
       moveConnectionModal({ edge, availableTargets });
     },
+    isDisabled: availableTargets.length <= 1,
     accessReview: asAccessReview(resourceModel, resourceObj, 'delete'),
   };
 };
@@ -43,10 +44,17 @@ const deleteConnection = (edge: Edge) => {
 
 export const edgeActions = (edge: Edge, nodes: Node[]): KebabOption[] => {
   const actions: KebabOption[] = [];
+  const currentTargets = edge
+    .getSource()
+    .getSourceEdges()
+    .map((e) => e.getTarget().getId());
 
   const availableTargets = nodes
     .filter((n) => {
       if (n.getId() === edge.getSource().getId()) {
+        return false;
+      }
+      if (n.getId() !== edge.getTarget().getId() && currentTargets.includes(n.getId())) {
         return false;
       }
       if (n.getType() === TYPE_EVENT_SOURCE) {
@@ -69,9 +77,7 @@ export const edgeActions = (edge: Edge, nodes: Node[]): KebabOption[] => {
     })
     .sort((n1, n2) => n1.getLabel().localeCompare(n2.getLabel()));
 
-  if (availableTargets.length > 1) {
-    actions.push(moveConnection(edge, availableTargets));
-  }
+  actions.push(moveConnection(edge, availableTargets));
 
   switch (edge.getType()) {
     case TYPE_CONNECTS_TO:


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3201

**Analysis / Root cause**: 
Existing targets are listed as available targets when moving a connector

**Solution Description**: 
Do not present current targets as available targets for moving a connector (except the one for the connector being moved). If there are no other valid targets, disable the `Move Connector` action.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

/kind bug

cc @openshift/team-devconsole-ux 
