### PR TITLE
Bug 1810363: Monitoring Dashboards: Fix JS warning for empty table cells

### DIFF
--- a/frontend/public/components/monitoring/dashboards/format.tsx
+++ b/frontend/public/components/monitoring/dashboards/format.tsx
@@ -1,5 +1,4 @@
 import * as _ from 'lodash-es';
-import * as React from 'react';
 
 import {
   humanizeBinaryBytes,
@@ -8,10 +7,10 @@ import {
   humanizePacketsPerSec,
 } from '../../utils';
 
-export const formatNumber = (s: string, decimals = 2, format = 'short'): React.ReactNode => {
+export const formatNumber = (s: string, decimals = 2, format = 'short'): string => {
   const value = Number(s);
   if (_.isNil(s) || isNaN(value)) {
-    return s || <span className="text-muted">-</span>;
+    return s || '-';
   }
 
   switch (format) {

--- a/frontend/public/components/monitoring/dashboards/table.tsx
+++ b/frontend/public/components/monitoring/dashboards/table.tsx
@@ -134,15 +134,15 @@ const Table: React.FC<Props> = ({ panel, pollInterval, queries }) => {
   const visibleData = sortedData.slice((page - 1) * perPage, page * perPage);
 
   // Format the table rows.
-  const rows: React.ReactNode[][] = visibleData.map((values: { [key: string]: string }) => {
-    return columns.reduce((acc: React.ReactNode[], { type, decimals = 2, pattern, unit = '' }) => {
+  const rows: string[][] = visibleData.map((values: { [key: string]: string }) => {
+    return columns.reduce((acc: string[], { type, decimals = 2, pattern, unit = '' }) => {
       const value = values[pattern];
       switch (type) {
         case 'number':
           acc.push(formatNumber(value, decimals, unit));
           break;
         default:
-          acc.push(value || <span className="text-muted">-</span>);
+          acc.push(value || '-');
       }
       return acc;
     }, []);


### PR DESCRIPTION
Rendering DOM in table cells causes a JS warning message like:
`` Warning: Failed prop type: Invalid prop `rows[1]` supplied to `Table` ``

The simplest solution is to remove the `text-muted` styling for empty cells.
WDYT @spadgett?