### PR TITLE
Bug 1807865: Don't show node if pod is dead fix

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/dashboards-page/vm-dashboard/vm-details-card.tsx
@@ -29,7 +29,6 @@ export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
 
   const ipAddrs = getVmiIpAddresses(vmi).join(', ');
 
-  const isNodeLoading = !vmiLike || !pods;
   const name = getName(vmiLike);
   const namespace = getNamespace(vmiLike);
   const nodeName = getVMINodeName(vmi) || getNodeName(launcherPod);
@@ -67,7 +66,7 @@ export const VMDetailsCard: React.FC<VMDetailsCardProps> = () => {
           <DetailItem title="Created" error={false} isLoading={!vmiLike}>
             <Timestamp timestamp={getCreationTimestamp(vmiLike)} />
           </DetailItem>
-          <DetailItem title="Node" error={!isNodeLoading} isLoading={!launcherPod || isNodeLoading}>
+          <DetailItem title="Node" error={!launcherPod || !nodeName} isLoading={!vmiLike}>
             {launcherPod && nodeName && <NodeLink name={nodeName} />}
           </DetailItem>
           <DetailItem


### PR DESCRIPTION
Fix for #4531

In #4531 I intruduced a bug "The node is "Not available" on overview even vm is running."
This is a fix.
