### PR TITLE
Bug 1810532: Fix OBS filter by application issue [openshift-4.5]

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -445,6 +445,7 @@ const getOperatoarBackedServiceData = (
   installedOperators: K8sResourceKind[],
   operatorBackedServiceKindMap: OperatorBackedServiceKindMap,
   topologyGraphAndNodeData: TopologyDataModel,
+  application: string,
 ): TopologyDataModel => {
   const obsGroups = {};
   const operatorMap = {};
@@ -456,7 +457,8 @@ const getOperatoarBackedServiceData = (
   } = topologyGraphAndNodeData;
   _.forEach(transformBy, (key) => {
     if (!_.isEmpty(resources[key].data)) {
-      _.map(resources[key].data, (deployment) => {
+      const resourceData = filterBasedOnActiveApplication(resources[key].data, application);
+      _.map(resourceData, (deployment) => {
         const nodeResourceKind = _.get(deployment, 'metadata.ownerReferences[0].kind');
         const ownerUid = _.get(deployment, 'metadata.ownerReferences[0].uid');
         const appGroup = _.get(deployment, ['metadata', 'labels', 'app.kubernetes.io/part-of']);
@@ -731,6 +733,7 @@ export const transformTopologyData = (
     installedOperators,
     operatorBackedServiceKindMap,
     topologyGraphAndNodeData,
+    application,
   );
   return topologyGraphAndNodeData;
 };


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-3106

Description:
Filtering the topology nodes by application, throws an error when the topology has operator backed services in the namespace.

Problem:
Filtering the OBS nodes based on the application in topology model is missing

Solution:
Add filters to the OBS resources to skip those nodes from the topology data model.

![OBS_filter](https://user-images.githubusercontent.com/9964343/75982921-93f8ef80-5f0d-11ea-8585-c5256e7cd5af.gif)
