### PR TITLE
Bug 1810601: auto focus on the topology filter component to avoid confusion

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
@@ -49,6 +49,7 @@ const TopologyFilterBar: React.FC<TopologyFilterBarProps> = ({
           <TextFilter
             placeholder="Find by name..."
             value={searchQuery}
+            autoFocus
             onChange={(e) => onSearchQueryChange(e.target.value)}
           />
         </ToolbarItem>

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -24,7 +24,7 @@ import {
   RequireCreatePermission,
 } from '../utils';
 
-/** @type {React.SFC<{disabled?: boolean, label?: string, onChange: React.ChangeEventHandler<any>, defaultValue?: string, value?: string, placeholder?: string,}}>} */
+/** @type {React.SFC<{disabled?: boolean, label?: string, onChange: React.ChangeEventHandler<any>, defaultValue?: string, value?: string, placeholder?: string, autoFocus?: boolean,}}>} */
 export const TextFilter = ({
   label,
   onChange,
@@ -33,6 +33,7 @@ export const TextFilter = ({
   className,
   value,
   placeholder = `Filter ${label}...`,
+  autoFocus = false,
 }) => {
   const input = React.useRef();
   const onKeyDown = (e) => {
@@ -73,6 +74,7 @@ export const TextFilter = ({
         style={style}
         tabIndex={0}
         type="text"
+        autoFocus={autoFocus}
       />
       <span className="form-control-feedback form-control-feedback--keyboard-hint">
         <kbd>/</kbd>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3254

**Analysis / Root cause**: 
When navigating to the topology page no component gets focus. Clicking on nodes does not get focus so clicking on a link then leaves focus on the nav. When navigating away, the focus is still on the 'Topology' so it appears to still be selected. Also, if the user then hits the enter key, they will be navigated back to Topology.

**Solution Description**: 
Focus on the filter component upon entry of the topology view. This is consistent with the Operator Hub view and Add from Catalog view.

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

/kind bug
