### PR TITLE
Bug 1796249: Fine tuning ImageManifestVuln Vulnerabilities table at responsive widths

### DIFF
--- a/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
+++ b/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
@@ -39,18 +39,18 @@ const shortenHash = (hash: string) => hash.slice(7, 18);
 export const ImageVulnerabilityRow: React.FC<ImageVulnerabilityRowProps> = (props) => {
   return (
     <div className="row">
-      <div className="col-lg-2 col-md-3 col-sm-4 col-xs-5">
+      <div className="col-lg-3 col-md-3 col-sm-4 col-xs-6">
         <ExternalLink text={props.vulnerability.name} href={props.vulnerability.link} />
       </div>
-      <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7">
+      <div className="col-lg-2 col-md-2 col-sm-5 col-xs-6">
         <SecurityIcon
           color={vulnPriority.find((p) => p.title === props.vulnerability.severity).color.value}
         />
         &nbsp;{props.vulnerability.severity}
       </div>
       <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs">{props.packageName}</div>
-      <div className="col-lg-1 col-md-2 hidden-sm hidden-xs">{props.currentVersion}</div>
-      <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">
+      <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">{props.currentVersion}</div>
+      <div className="col-lg-3 col-md-3 hidden-sm hidden-xs">
         {props.vulnerability.fixedby || '-'}
       </div>
     </div>
@@ -72,11 +72,11 @@ export const ImageVulnerabilitiesTable: React.FC<ImageVulnerabilitiesTableProps>
       <SectionHeading text="Vulnerabilities" />
       <div className="co-m-table-grid co-m-table-grid--bordered">
         <div className="row co-m-table-grid__head">
-          <div className="col-lg-2 col-md-3 col-sm-4 col-xs-5">Vulnerability</div>
-          <div className="col-lg-2 col-md-3 col-sm-5 col-xs-7">Severity</div>
+          <div className="col-lg-3 col-md-3 col-sm-4 col-xs-6">Vulnerability</div>
+          <div className="col-lg-2 col-md-2 col-sm-5 col-xs-6">Severity</div>
           <div className="col-lg-2 col-md-2 col-sm-3 hidden-xs">Package</div>
-          <div className="col-lg-1 col-md-2 hidden-sm hidden-xs">Current Version</div>
-          <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">Fixed in Version</div>
+          <div className="col-lg-2 col-md-2 hidden-sm hidden-xs">Current Version</div>
+          <div className="col-lg-3 col-md-3 hidden-sm hidden-xs">Fixed in Version</div>
         </div>
         <div className="co-m-table-grid__body">
           {vulnerabilites.map(({ feature, vulnerability }) => (


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1796249

<img width="781" alt="Screen Shot 2020-03-05 at 2 37 52 PM" src="https://user-images.githubusercontent.com/1874151/76020942-5dfa4200-5ef2-11ea-8d14-e4b8ab4f4038.png">
<img width="551" alt="Screen Shot 2020-03-05 at 2 38 24 PM" src="https://user-images.githubusercontent.com/1874151/76020946-5fc40580-5ef2-11ea-943d-52aa71df9db4.png">
<img width="379" alt="Screen Shot 2020-03-05 at 2 40 25 PM" src="https://user-images.githubusercontent.com/1874151/76020949-618dc900-5ef2-11ea-88c0-e09a3f463628.png">
