### PR TITLE
[WIP] Refactoring changes for storage class

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/node-list.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/node-list.tsx
@@ -44,8 +44,8 @@ import {
 } from '../../constants/ocs-install';
 import './ocs-install.scss';
 import { OSDSizeDropdown } from '../../utils/osd-size-dropdown';
-import { hasLabel } from '../../../../console-shared/src/selectors/common';
 import { OCSStorageClassDropdown } from '../modals/storage-class-dropdown';
+import { hasLabel } from '../../../../console-shared/src/selectors/common';
 
 const ocsLabel = 'cluster.ocs.openshift.io/openshift-storage';
 
@@ -365,7 +365,7 @@ const CustomNodeTable: React.FC<CustomNodeTableProps> = ({
         />
       )}
       <div className="ceph-ocs-install__ocs-service-capacity--dropdown">
-        <OCSStorageClassDropdown onChange={setStorageClass} />
+        <OCSStorageClassDropdown onChange={setStorageClass} selectedKey={storageClass} />
       </div>
       <div className="ceph-ocs-install__ocs-service-capacity">
         <label className="control-label" htmlFor="ocs-service-stoargeclass">


### PR DESCRIPTION
- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1804107

The `selectedKey` value is set to null in storage class dropdown. This happens when the parent components gets re-rendered and the `shouldComponentupdate` lifecycle hook returns false because the current state === next state. This does not happen on initial render, since props were different (firehose takes some time to fetch data). Also, if the state is changed by selection then it got set too.

The logic to update the selectedKey to default class  is wriiten inside `componentDidUpdate` which is not called off (`shouldComponentUpdate` returns false).

