### PR TITLE
Bug 1794943: Monitoring dashboards: Fix tooltips and legends

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -62,6 +62,15 @@
   }
 }
 
+.monitoring-dashboards__legend-wrap {
+  height: 75px;
+  overflow-x: auto;
+  padding-top: 1px;
+  svg {
+    max-height: 50px; // Required for Chrome. legend-wrap - scrollbar height
+  }
+}
+
 .monitoring-dashboards__header {
   display: flex;
   flex-wrap: wrap;
@@ -111,11 +120,11 @@ $screen-phone-landscape-min-width: 567px;
   }
   .monitoring-dashboards__panel--max-3 {
     flex: 1 0 33%;
-		min-width: 33%;
+    min-width: 33%;
   }
   .monitoring-dashboards__panel--max-4 {
     flex: 0 0 25%;
-		min-width: 25%;
+    min-width: 25%;
   }
 }
 

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -1,3 +1,5 @@
+$tooltip-background-color: #151515;
+
 .graph-empty-state {
   min-height: 310px;
 }
@@ -24,10 +26,21 @@
     min-height: 305px; // Allow for chart legend
   }
 
+  // Move tooltip above cursor to work around bug where the legend is visible through the tooltip
+  .query-browser__tooltip-arrow {
+    border-bottom: none;
+    border-top: 12px solid $tooltip-background-color;
+  }
+  .query-browser__tooltip-svg-wrap {
+    transform: translate(0, -500px);
+  }
+  .query-browser__tooltip-wrap {
+    flex-direction: column-reverse;
+  }
+
   .query-browser__wrapper {
     border: 0;
     margin: 0;
-    overflow: hidden;
     padding: 0;
   }
 }
@@ -317,8 +330,6 @@ $screen-phone-landscape-min-width: 567px;
 .query-browser__tech-preview {
   margin: 0 10px;
 }
-
-$tooltip-background-color: #151515;
 
 .query-browser__tooltip-wrap {
   align-items: center;

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -226,6 +226,18 @@ const graphContainer = (
   />
 );
 
+const LegendContainer = ({ children }: { children?: React.ReactNode }) => {
+  // The first child should be a <rect> with a `width` prop giving the legend's content width
+  const width = children?.[0]?.[0]?.props?.width ?? '100%';
+  return (
+    <foreignObject height={75} width="100%" y={230}>
+      <div className="monitoring-dashboards__legend-wrap">
+        <svg width={width}>{children}</svg>
+      </div>
+    </foreignObject>
+  );
+};
+
 const Graph: React.FC<GraphProps> = React.memo(
   ({ allSeries, disabledSeries, formatLegendLabel, isStack, span, xDomain }) => {
     const [containerRef, width] = useRefWidth();
@@ -321,14 +333,13 @@ const Graph: React.FC<GraphProps> = React.memo(
             {legendData && (
               <ChartLegend
                 data={legendData}
+                groupComponent={<LegendContainer />}
                 itemsPerRow={4}
                 orientation="vertical"
                 style={{
                   labels: { fontSize: 11 },
                 }}
                 symbolSpacer={4}
-                x={0}
-                y={230}
               />
             )}
           </Chart>

--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -172,7 +172,13 @@ const TooltipInner_: React.FC<TooltipInnerProps> = ({
   const height = 500;
 
   return (
-    <foreignObject height={height} width={width} x={x - width / 2} y={y}>
+    <foreignObject
+      className="query-browser__tooltip-svg-wrap"
+      height={height}
+      width={width}
+      x={x - width / 2}
+      y={y}
+    >
       <div className="query-browser__tooltip-wrap">
         <div className="query-browser__tooltip-arrow" />
         <div className="query-browser__tooltip">


### PR DESCRIPTION
Fixes
- https://bugzilla.redhat.com/show_bug.cgi?id=1794943
- https://bugzilla.redhat.com/show_bug.cgi?id=1800652

Introduces a new bug where SVG elements of the graph to the right are visible through the tooltip (see screenshot).

<img width="173" alt="screenshot" src="https://user-images.githubusercontent.com/460802/76612876-773d6700-6560-11ea-834f-b2029d011473.png">

This happens because SVG elements are rendered in the order they appear in the document. I think this is acceptable for now because it only happens if tooltip is near the right edge of the graph and if there is another graph to the right.

In the future, I think the better solution is probably to move the tooltip outside of the graph container, so it's not using SVG.
