### PR TITLE
Bug 1804107: Mount OCS form when csv is available

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
@@ -4,7 +4,7 @@ import { Firehose, FieldLevelHelp } from '@console/internal/components/utils';
 import { InfrastructureModel } from '@console/internal/models';
 import { K8sResourceKind, StorageClassResourceKind, k8sGet } from '@console/internal/module/k8s';
 import { StorageClassDropdownInner } from '@console/internal/components/utils/storage-class-dropdown';
-import { getInfrastructurePlatform } from '@console/shared';
+import { getInfrastructurePlatform, getName } from '@console/shared';
 import { infraProvisionerMap, storageClassTooltip } from '../../constants/ocs-install';
 import './storage-class-dropdown.scss';
 
@@ -43,7 +43,8 @@ export const OCSStorageClassDropdown: React.FC<OCSStorageClassDropdownProps> = (
   const { onChange, defaultClass } = props;
 
   const handleStorageClass = (sc: K8sResourceKind) => {
-    onChange(sc.metadata.name);
+    const name = getName(sc);
+    onChange(name);
   };
 
   return (

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-ocs-service.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-ocs-service.tsx
@@ -52,12 +52,14 @@ export const CreateOCSService: React.FC<CreateOCSServiceProps> = React.memo((pro
           )}
         </div>
       </div>
-      <CreateOCSServiceForm
-        namespace={props.match.params.ns}
-        operandModel={OCSServiceModel}
-        sample={sample}
-        clusterServiceVersion={clusterServiceVersion !== null && clusterServiceVersion}
-      />
+      {clusterServiceVersion && sample && (
+        <CreateOCSServiceForm
+          namespace={props.match.params.ns}
+          operandModel={OCSServiceModel}
+          sample={sample}
+          clusterServiceVersion={clusterServiceVersion !== null && clusterServiceVersion}
+        />
+      )}
     </>
   );
 });

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx
@@ -102,14 +102,16 @@ const InstallCluster: React.FC<InstallClusterProps> = ({ match }) => {
             </div>
           </div>
         )}
-        {(isIndependent === false || mode === MODES.CONVERGED) && (
-          <CreateOCSServiceForm
-            namespace={ns}
-            operandModel={OCSServiceModel}
-            sample={sample}
-            clusterServiceVersion={clusterServiceVersion !== null && clusterServiceVersion}
-          />
-        )}
+        {(isIndependent === false || mode === MODES.CONVERGED) &&
+          clusterServiceVersion &&
+          sample && (
+            <CreateOCSServiceForm
+              namespace={ns}
+              operandModel={OCSServiceModel}
+              sample={sample}
+              clusterServiceVersion={clusterServiceVersion !== null && clusterServiceVersion}
+            />
+          )}
         {mode === MODES.INDEPENDENT && <InstallExternalCluster match={match} />}
       </div>
     </>


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1804107
The OCS form is unmounted when the parent component's state changes and it re renders. We should render the component only once we have got all the data. (i.e csv)
Internally the states of inner children components are getting affected due to this behavior.

Additional Info on internal state management of the dropdown:
_The selectedKey value is set to null in storage class dropdown. This happens when the parent components gets re-rendered and the shouldComponentupdate lifecycle hook returns false because the current state === next state. This does not happen on initial render, since props were different (firehose takes some time to fetch data). Also, if the state is changed by selection then it got set too._