### PR TITLE
Bug 1811185: Allow users with view only privs access to topology

### DIFF
--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -119,6 +119,7 @@ export const getResourceList = (namespace: string, resList?: any) => {
       kind: 'Secret',
       namespace,
       prop: 'secrets',
+      optional: true,
     },
     {
       isList: true,

--- a/frontend/packages/dev-console/src/components/topology/TopologyHelmReleasePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyHelmReleasePanel.tsx
@@ -15,16 +15,17 @@ export type TopologyHelmReleasePanelProps = {
 
 const TopologyHelmReleasePanel: React.FC<TopologyHelmReleasePanelProps> = ({ helmRelease }) => {
   const secret = helmRelease.getData().resources.obj;
-  const { namespace, labels } = secret?.metadata || {};
+  const name = helmRelease.getLabel();
+  const { namespace } = helmRelease.getData().groupResources[0].resources.obj.metadata;
 
-  if (!secret || !labels) {
-    return (
-      <StatusBox
-        loaded
-        loadError={{ message: `Unable to find resource for ${helmRelease.getLabel()}` }}
-      />
-    );
-  }
+  const detailsComponent = !secret
+    ? () => (
+        <StatusBox
+          loaded
+          loadError={{ message: `Unable to find resource for ${helmRelease.getLabel()}` }}
+        />
+      )
+    : navFactory.details(HelmReleaseOverview).component;
 
   return (
     <div className="overview__sidebar-pane resource-overview">
@@ -33,17 +34,17 @@ const TopologyHelmReleasePanel: React.FC<TopologyHelmReleasePanelProps> = ({ hel
           <div className="co-m-pane__name co-resource-item">
             <ResourceIcon className="co-m-resource-icon--lg" kind="HelmRelease" />
             <Link
-              to={`/helm-releases/ns/${namespace}/release/${labels.name}`}
+              to={`/helm-releases/ns/${namespace}/release/${name}`}
               className="co-resource-item__resource-name"
             >
-              {labels.name}
+              {name}
             </Link>
           </div>
         </h1>
       </div>
       <SimpleTabNav
         selectedTab={'Details'}
-        tabs={[{ name: 'Details', component: navFactory.details(HelmReleaseOverview).component }]}
+        tabs={[{ name: 'Details', component: detailsComponent }]}
         tabProps={{ obj: secret }}
         additionalClassNames="co-m-horizontal-nav__menu--within-sidebar co-m-horizontal-nav__menu--within-overview-sidebar"
       />

--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmRelease.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmRelease.tsx
@@ -21,14 +21,14 @@ export type HelmReleaseProps = {
   WithDndDropProps;
 
 const HelmRelease: React.FC<HelmReleaseProps> = (props) => {
-  const resourceObj = getTopologyResourceObject(props.element.getData().groupResources[0]);
-  const resourceModel = modelFor(referenceFor(resourceObj));
+  const secretObj = getTopologyResourceObject(props.element.getData().resources.obj);
+  const resourceModel = secretObj ? modelFor(referenceFor(secretObj)) : null;
   const editAccess = useAccessReview({
-    group: resourceModel.apiGroup,
+    group: resourceModel?.apiGroup,
     verb: 'patch',
-    resource: resourceModel.plural,
-    name: resourceObj.metadata.name,
-    namespace: resourceObj.metadata.namespace,
+    resource: resourceModel?.plural,
+    name: secretObj?.metadata.name,
+    namespace: secretObj?.metadata.namespace,
   });
   if (props.element.isCollapsed()) {
     return <HelmReleaseNode editAccess={editAccess} {...props} />;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3277

**Analysis / Root cause**: 
Topology uses secrets to set/get the application groupings for Helm Releases. Secrets may not be retrieved by read only users so permission is being denied.

**Solution Description**: 
Make the retrieval of secrets optional. If they are not able to be retrieved, show the topology but w/o the ability to view/edit application groupings. Also updated the side panel to show at least the header information for the helm release (w/o the secret's info).

**Screen Shot**
![image](https://user-images.githubusercontent.com/11633780/76115098-872fd680-5fb5-11ea-9b14-5ebfe6b3891f.png)


**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux 