### PR TITLE
Bug 1811733: Show message when an InstallPlan fails

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -12,6 +12,7 @@ import {
   TableRow,
   TableData,
 } from '@console/internal/components/factory';
+import { Conditions } from '@console/internal/components/conditions';
 import {
   SectionHeading,
   MsgBox,
@@ -315,6 +316,10 @@ export const InstallPlanDetails: React.SFC<InstallPlanDetailsProps> = ({ obj }) 
             </div>
           </div>
         </div>
+      </div>
+      <div className="co-m-pane__body">
+        <SectionHeading text="Conditions" />
+        <Conditions conditions={obj.status?.conditions} />
       </div>
     </>
   );

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -309,8 +309,12 @@ export const SubscriptionDetails: React.FC<SubscriptionDetailsProps> = ({
   const catalogSource = catalogSourceForSubscription(catalogSources, obj);
   const installedCSV = installedCSVForSubscription(clusterServiceVersions, obj);
   const installPlan = installPlanForSubscription(installPlans, obj);
-  const installStatusPhase = _.get(installPlan, 'status.phase');
-  const installStatusMessage = _.get(installPlan, 'status.message') || 'Unknown';
+  const installStatusPhase = installPlan?.status?.phase;
+  const installFailedCondition = installPlan?.status?.conditions?.find(
+    ({ type, status }) => type === 'Installed' && status === 'False',
+  );
+  const installFailedMessage =
+    installFailedCondition?.message || installFailedCondition?.reason || 'Install plan failed';
 
   const pkg = packageForSubscription(packageManifests, obj);
   if (new URLSearchParams(window.location.search).has('showDelete')) {
@@ -330,10 +334,12 @@ export const SubscriptionDetails: React.FC<SubscriptionDetailsProps> = ({
       {installStatusPhase === InstallPlanPhase.InstallPlanPhaseFailed && (
         <Alert
           isInline
-          className="co-alert"
+          className="co-alert co-alert--scrollable"
           variant="danger"
-          title={`${installStatusPhase}: ${installStatusMessage}`}
-        />
+          title={installStatusPhase}
+        >
+          {installFailedMessage}
+        </Alert>
       )}
       <SectionHeading text="Subscription Details" />
       <div className="co-m-pane__body-group">

--- a/frontend/packages/operator-lifecycle-manager/src/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/types.ts
@@ -1,4 +1,10 @@
-import { K8sResourceKind, OwnerReference, Selector } from '@console/internal/module/k8s';
+import {
+  K8sResourceCommon,
+  K8sResourceCondition,
+  K8sResourceKind,
+  OwnerReference,
+  Selector,
+} from '@console/internal/module/k8s';
 import { Descriptor } from './components/descriptors/types';
 
 export enum AppCatalog {
@@ -168,8 +174,9 @@ export type InstallPlanKind = {
     phase: InstallPlanPhase;
     catalogSources: string[];
     plan: Step[];
+    conditions?: K8sResourceCondition[];
   };
-} & K8sResourceKind;
+} & K8sResourceCommon;
 
 export type SubscriptionKind = {
   apiVersion: 'operators.coreos.com/v1alpha1';


### PR DESCRIPTION
The Subscription page was looking for `status.message` in the
InstallPlan, which is never set. Instead, read the message from the
InstallPlan failed condition to show an alert on the Subscription page.
Additionally, show all `status.conditions` on the InstallPlan page.

/assign @benjaminapetersen 

Before:

![Screen Shot 2020-03-09 at 12 25 03 PM](https://user-images.githubusercontent.com/1167259/76235116-0a913800-6201-11ea-8807-1ceef03c4c4c.png)

After:

![Screen Shot 2020-03-09 at 12 08 42 PM](https://user-images.githubusercontent.com/1167259/76234989-d3bb2200-6200-11ea-9913-c90bfebe35ea.png)

InstallPlan details:

![Screen Shot 2020-03-09 at 11 47 01 AM](https://user-images.githubusercontent.com/1167259/76235000-d7e73f80-6200-11ea-8388-23fa8dc4f8ed.png)
