### PR TITLE
Bug 1811757: Fix access review for Home -> Overview page

### DIFF
--- a/frontend/public/components/nav/admin-nav.tsx
+++ b/frontend/public/components/nav/admin-nav.tsx
@@ -95,7 +95,7 @@ const AdminNav = () => (
         href="/dashboards"
         activePath="/dashboards/"
         name="Overview"
-        required={[FLAGS.CAN_LIST_NS, FLAGS.OPENSHIFT]}
+        required={[FLAGS.CAN_GET_NS, FLAGS.OPENSHIFT]}
       />
       <ResourceClusterLink resource="projects" name="Projects" required={FLAGS.OPENSHIFT} />
       <HrefLink href="/search" name="Search" startsWith={searchStartsWith} />


### PR DESCRIPTION
We should check whether users can `get` namespaces, not `list`.

/assign @benjaminapetersen 
/cc @rawagner 