### PR TITLE
test for traffic splitting and refactor component

### DIFF
--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingModal.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingModal.spec.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { MultiColumnField } from '@console/shared';
+import { ModalBody, ModalSubmitFooter } from '@console/internal/components/factory/modal';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
+import TrafficSplittingModal from '../TrafficSplittingModal';
+import {
+  mockTrafficData,
+  mockRevisionItems,
+} from '../../../utils/__mocks__/traffic-splitting-utils-mock';
+
+type TrafficSplittingModalProps = React.ComponentProps<typeof TrafficSplittingModal>;
+
+describe('TrafficSplittingModal', () => {
+  let wrapper: ShallowWrapper<TrafficSplittingModalProps>;
+  let formProps: TrafficSplittingModalProps;
+  beforeEach(() => {
+    formProps = {
+      ...formikFormProps,
+      status: { error: 'checkErrorProp' },
+      values: { trafficSplitting: mockTrafficData },
+      revisionItems: mockRevisionItems,
+    };
+    wrapper = shallow(<TrafficSplittingModal {...formProps} />);
+  });
+
+  it('should disable delete row button for one value', () => {
+    wrapper = shallow(
+      <TrafficSplittingModal
+        {...formProps}
+        revisionItems={[{ 'overlayimage-fdqsf': 'overlayimage-fdqsf' }]}
+        values={{ trafficSplitting: [{ percent: 100, revisionName: 'overlayimage-fdqsf' }] }}
+      />,
+    );
+    expect(
+      wrapper
+        .find(ModalBody)
+        .dive()
+        .find(MultiColumnField)
+        .first()
+        .props().disableDeleteRow,
+    ).toBe(true);
+  });
+
+  it('should not disable delete row button for more than one values', () => {
+    expect(
+      wrapper
+        .find(ModalBody)
+        .dive()
+        .find(MultiColumnField)
+        .first()
+        .props().disableDeleteRow,
+    ).toBe(false);
+  });
+
+  it('should render modal footer with proper values', () => {
+    wrapper.find('form').simulate('submit', {
+      preventDefault: () => {},
+    });
+    expect(
+      wrapper
+        .find(ModalSubmitFooter)
+        .first()
+        .props().inProgress,
+    ).toBe(true);
+    expect(
+      wrapper
+        .find(ModalSubmitFooter)
+        .first()
+        .props().errorMessage,
+    ).toEqual('checkErrorProp');
+  });
+
+  it('should call handleSubmit on submit', () => {
+    wrapper.find('form').simulate('submit', {
+      preventDefault: () => {},
+    });
+    expect(formProps.handleSubmit).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes
issue https://issues.redhat.com/browse/ODC-3281

Analysis / Root cause:
Increase test coverage for components in the knative package

Solution Description:
adds unit test to `TrafficSplittingModal` component

Screens:
![Screenshot from 2020-03-24 05-58-55](https://user-images.githubusercontent.com/38663217/77375811-9de77300-6d94-11ea-9ffc-8f8ad3bdb2ee.png)

Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge