### PR TITLE
kubevirt: don't set template namespace

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/create.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/create.ts
@@ -125,6 +125,7 @@ export const createVM = async (params: CreateVMParams) => {
 
     // ProcessedTemplates endpoint will reject the request if user cannot post to the namespace
     // common-templates are stored in openshift namespace, default user can read but cannot post
+    const templateNamespace = template.getNamespace();
     template
       .setNamespace(namespace)
       .setParameter(TEMPLATE_PARAM_VM_NAME, combinedSimpleSettings[VMSettingsField.NAME])
@@ -143,6 +144,9 @@ export const createVM = async (params: CreateVMParams) => {
       null,
       { disableHistory: true },
     ); // temporary
+
+    // Re-set template namespace
+    template.setNamespace(templateNamespace);
 
     vm = new VMWrapper(selectVM(processedTemplate));
     vm.setNamespace(namespace);

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/common/k8s-resource-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/common/k8s-resource-wrapper.ts
@@ -1,5 +1,5 @@
 /* eslint-disable lines-between-class-members */
-import { getName, hasLabel, getLabels } from '@console/shared/src';
+import { getName, getNamespace, hasLabel, getLabels } from '@console/shared/src';
 import { apiVersionForModel, K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { Wrapper } from './wrapper';
 import { K8sResourceKindMethods } from '../types/types';
@@ -9,6 +9,7 @@ export class K8sResourceWrapper<
   SELF extends K8sResourceWrapper<RESOURCE, SELF>
 > extends Wrapper<RESOURCE, SELF> implements K8sResourceKindMethods {
   getName = () => getName(this.data);
+  getNamespace = () => getNamespace(this.data);
   getLabels = (defaultValue = {}) => getLabels(this.data, defaultValue);
   hasLabel = (label: string) => hasLabel(this.data, label);
 


### PR DESCRIPTION
When creating a VM using base template we change the template namespace.

If template namespace is not the current namespace ( e.g. when using base templtates ) we will get an error, and the VM will fail to create.

Screenshots:
After:
![OKD(2)](https://user-images.githubusercontent.com/2181522/76309518-996f8480-62d5-11ea-917d-6b5e81510d1a.png)

Before:
![OKD(3)](https://user-images.githubusercontent.com/2181522/76309191-ec950780-62d4-11ea-93da-9d578f19cf0e.png)

Settings:
![OKD(1)](https://user-images.githubusercontent.com/2181522/76309174-e4d56300-62d4-11ea-9231-38eeb62645c7.png)
