### PR TITLE
Bug 1808952: Instance creation for container security operator hit 404 error

### DIFF
--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -71,6 +71,19 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: false,
+      path: `/k8s/ns/:ns/${referenceForModel(
+        ClusterServiceVersionModel,
+      )}/:appName/${referenceForModel(ImageManifestVulnModel)}/~/new`,
+      loader: () =>
+        import(
+          './components/image-manifest-vuln' /* webpackChunkName: "container-security" */
+        ).then((m) => m.ImageManifestVulnDetailsPage),
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: false,
       path: `/k8s/ns/:ns/${ClusterServiceVersionModel.plural}/:appName/${referenceForModel(
         ImageManifestVulnModel,
       )}/:name`,


### PR DESCRIPTION
/assign @TheRealJon
/cc @benjaminapetersen @spadgett 

I found out that prior to moving OLM to a separate package, Container security / ImageManifestVuln "apiGroup" was "operators.coreos.com" .  Changed the "apiGroup" from "secscan.quay.redhat.com" to  "operators.coreos.com" and it resolved the 404 error.  

Please validate this change.
Thanks.   