### PR TITLE
[WIP] Removed unused maxDescriptionLength prop from PF CatalogTile

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -367,7 +367,6 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
         vendor={vendor}
         description={description}
         onClick={() => openOverlay(item)}
-        maxDescriptionLength={-1}
         footer={
           installed ? (
             <span>

--- a/frontend/public/components/catalog/catalog-items.tsx
+++ b/frontend/public/components/catalog/catalog-items.tsx
@@ -301,7 +301,6 @@ export class CatalogTileViewPage extends React.Component<
         vendor={vendor}
         description={tileDescription}
         data-test={`${kind}-${obj.metadata.name}`}
-        maxDescriptionLength={-1}
       />
     );
   };


### PR DESCRIPTION
#4168 set `maxDescriptionLength` to -1 thus nullifying it's usage.   In latest PF packages/versions `maxDescriptionLength` has been removed entirely.   If was an optional prop, so I'm not sure if removing it from PF was correct procedure, as removing it entirely could be considered a breaking change.  This was discussed [here](https://github.com/patternfly/patternfly-react/pull/3830#pullrequestreview-366463600) and the change in PF was made.

This PR removes the property from OpenShift so when we upgrade to latest PF we won't have build errors ie. `Property 'maxDescriptionLength' does not exist on type 'IntrinsicAttributes &`

UPDATE: Per @spadgett comments we will hold off implementing until upgrade to latest PF.  
Similar PF Update PR: #4705 
