### PR TITLE
[WIP] Bug 1811886: Disable `downlevelIteration` in tsconfig.json

### DIFF
--- a/frontend/integration-tests/tests/crud.scenario.ts
+++ b/frontend/integration-tests/tests/crud.scenario.ts
@@ -62,7 +62,7 @@ describe('Kubernetes resource CRUD operations', () => {
   });
 
   afterAll(() => {
-    const leakedArray: Array<string> = [...leakedResources];
+    const leakedArray: string[] = Array.from(leakedResources);
     console.error(
       `Leaked ${leakedArray.length} resources out of ${testObjs.size}:\n${leakedArray.join('\n')}`,
     );

--- a/frontend/packages/console-shared/src/test-utils/utils.ts
+++ b/frontend/packages/console-shared/src/test-utils/utils.ts
@@ -9,7 +9,7 @@ export function resolveTimeout(timeout: number, defaultTimeout: number) {
 }
 
 export function removeLeakedResources(leakedResources: Set<string>) {
-  const leakedArray: string[] = [...leakedResources];
+  const leakedArray: string[] = Array.from(leakedResources);
   if (leakedArray.length > 0) {
     console.error(`Leaked ${leakedArray.join()}`);
     leakedArray
@@ -118,7 +118,7 @@ export async function getDropdownOptions(dropdownId: string): Promise<string[]> 
 }
 
 export async function asyncForEach(iterable, callback) {
-  const array = [...iterable];
+  const array = Array.from(iterable);
   for (let index = 0; index < array.length; index++) {
     await callback(array[index], index, array);
   }

--- a/frontend/packages/console-shared/src/utils/validation/validation.ts
+++ b/frontend/packages/console-shared/src/utils/validation/validation.ts
@@ -90,7 +90,7 @@ export const validateDNS1123SubdomainValue = (
 
   if (forbiddenCharacters.size > 0) {
     const forbiddenChars = joinGrammaticallyListOfItems(
-      [...forbiddenCharacters].sort((a, b) => b.length - a.length),
+      Array.from(forbiddenCharacters).sort((a, b) => b.length - a.length),
     );
     const forbiddenCharsSentence = makeSentence(`${forbiddenChars} characters are not allowed`);
     result = result ? `${result} ${forbiddenCharsSentence}` : forbiddenCharsSentence;

--- a/frontend/packages/container-security/src/components/summary.tsx
+++ b/frontend/packages/container-security/src/components/summary.tsx
@@ -99,7 +99,7 @@ export const SecurityBreakdownPopup: React.FC<SecurityBreakdownPopupProps> = (pr
               <div className="co-overview-status__row">
                 <div className="co-overview-status__text--bold">Fixable Vulnerabilities</div>
               </div>
-              {_.take([...fixableVulns.values()], 5).map((v) => (
+              {_.take(Array.from(fixableVulns.values()), 5).map((v) => (
                 <div className="co-overview-status__row" key={v.metadata.name}>
                   <span>
                     <SecurityIcon

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
@@ -134,7 +134,7 @@ export function getResourceObject(name: string, namespace: string, kind: string)
 }
 
 export function exposeServices(services: Set<any>) {
-  const servicesArray: NodePortService[] = [...services];
+  const servicesArray: NodePortService[] = Array.from(services);
   servicesArray.forEach(({ name, kind, port, targetPort, exposeName, type, namespace }) => {
     execSync(
       `virtctl expose ${kind} ${name} --port=${port} --target-port=${targetPort} --name=${exposeName} --type=${type} -n ${namespace}`,

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -231,7 +231,7 @@ export class CreateVMWizardComponent extends React.Component<CreateVMWizardCompo
     if (this.isClosed) {
       return;
     }
-    const changedProps = [...DetectCommonDataChanges].reduce((changedPropsAcc, propName) => {
+    const changedProps = Array.from(DetectCommonDataChanges).reduce((changedPropsAcc, propName) => {
       if (prevProps[propName] !== this.props[propName]) {
         changedPropsAcc.add(propName);
       }
@@ -493,7 +493,7 @@ export class CreateVMWizardComponent extends React.Component<CreateVMWizardCompo
 const wizardStateToProps = (state, { reduxID }) => ({
   stepData: iGetCreateVMWizardTabs(state, reduxID),
   // fetch data from store to detect and fire changes
-  ...[...DetectCommonDataChanges].reduce((acc, propName) => {
+  ...Array.from(DetectCommonDataChanges).reduce((acc, propName) => {
     acc[propName] = iGetCommonData(state, reduxID, propName);
     return acc;
   }, {}),

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/providers/vmware-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/providers/vmware-state-update.ts
@@ -270,7 +270,8 @@ const providerUpdater = (options: UpdateOptions) => {
           [VMWareProviderField.STATUS]: {
             isHidden: asHidden(
               !isVmWareProvider ||
-                [...V2V_WMWARE_STATUS_ALL_OK, V2VVMwareStatus.UNKNOWN].includes(status),
+                V2V_WMWARE_STATUS_ALL_OK.has(status) ||
+                status === V2VVMwareStatus.UNKNOWN,
               VMImportProvider.VMWARE,
             ),
           },

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/wizard-selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/wizard-selectors.ts
@@ -36,7 +36,7 @@ export const isWizardEmpty = (stepData, isProviderImport) => {
   // providers data do not need to be checked because the change is detected through selection of provider
   fields.delete(VMSettingsField.PROVIDERS_DATA);
 
-  return ![...fields].some((fieldKey) => {
+  return !Array.from(fields).some((fieldKey) => {
     const value = iGetIn(stepData, [VMWizardTab.VM_SETTINGS, 'value', fieldKey, 'value']);
     return fieldKey === VMSettingsField.FLAVOR && value === CUSTOM_FLAVOR ? null : value;
   });

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/cloud-init-tab/cloud-init-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/cloud-init-tab/cloud-init-tab.tsx
@@ -109,7 +109,7 @@ const CloudInitFormRows: React.FC<CloudInitFormRowsProps> = ({
                   value={authKey || ''}
                   id={inputID}
                   onChange={(val) => {
-                    const result = [...authKeys];
+                    const result = Array.from(authKeys);
                     result[idx] = val;
                     onEntryChange(
                       CloudInitDataFormKeys.SSH_AUTHORIZED_KEYS,
@@ -242,7 +242,7 @@ const CloudInitTabComponent: React.FC<ResultTabComponentProps> = ({
       if (cloudInitData.includesOnlyFormValues()) {
         executeFn();
       } else {
-        const persistedKeys = [...formAllowedKeys].filter((key) => cloudInitData.has(key));
+        const persistedKeys = Array.from(formAllowedKeys).filter((key) => cloudInitData.has(key));
         confirmModal({
           title: 'Data loss confirmation',
           message: (

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -119,7 +119,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
         ? null
         : validAllowedBuses.has(DiskBus.VIRTIO)
         ? DiskBus.VIRTIO
-        : [...validAllowedBuses][0]),
+        : Array.from(validAllowedBuses)[0]),
   );
   const [storageClassName, setStorageClassName] = React.useState<string>(
     combinedDisk.getStorageClassName(),
@@ -407,7 +407,7 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
                   label={bus.toString()}
                 />
               )}
-              {[...validAllowedBuses].map((b) => (
+              {Array.from(validAllowedBuses).map((b) => (
                 <FormSelectOption
                   key={b.getValue()}
                   value={b.getValue()}

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/common.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/common.ts
@@ -88,7 +88,7 @@ export const validateBus = (value: DiskBus, allowedBuses: Set<DiskBus>): Validat
   if (allowedBuses && !allowedBuses.has(value)) {
     return asValidationObject(
       `Invalid interface type. Valid types are: ${joinGrammaticallyListOfItems(
-        [...allowedBuses].map((b) => b.toString()),
+        Array.from(allowedBuses).map((b) => b.toString()),
       )}`,
       ValidationErrorType.Error,
     );

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/template/disk-bus-validation-result.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/template/disk-bus-validation-result.ts
@@ -26,10 +26,10 @@ export class DiskBusValidationResult {
       return `There are no ${adj.toLowerCase()} bus types`;
     }
     if (this.allowedBuses.size === 1) {
-      return `${adj2} bus type. ${adj} type is ${[...this.allowedBuses][0]}`;
+      return `${adj2} bus type. ${adj} type is ${Array.from(this.allowedBuses)[0]}`;
     }
     return `${adj2} bus type. ${adj} types are: ${joinGrammaticallyListOfItems(
-      [...this.allowedBuses].map((b) => b.toString()),
+      Array.from(this.allowedBuses).map((b) => b.toString()),
     )}`;
   };
 

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/template/template-validations.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/template/template-validations.ts
@@ -50,9 +50,9 @@ export class TemplateValidations {
 
   getRecommendedBuses = (): Set<DiskBus> => {
     const allowedBuses = this.getAllowedBuses();
-    const recommendedBuses = [...this.getAllowedBuses(ValidationErrorType.Warn)].filter((b) =>
-      allowedBuses.has(b),
-    );
+    const recommendedBuses = Array.from(
+      this.getAllowedBuses(ValidationErrorType.Warn),
+    ).filter((b) => allowedBuses.has(b));
     return recommendedBuses.length === 0 ? allowedBuses : new Set(recommendedBuses);
   };
 
@@ -70,8 +70,8 @@ export class TemplateValidations {
     return (
       allowedBuses.size === otherAllowedBuses.size &&
       recommendedBuses.size === otherRecommendedBuses.size &&
-      [...allowedBuses].every((bus) => otherAllowedBuses.has(bus)) &&
-      [...recommendedBuses].every((bus) => otherRecommendedBuses.has(bus))
+      Array.from(allowedBuses).every((bus) => otherAllowedBuses.has(bus)) &&
+      Array.from(recommendedBuses).every((bus) => otherRecommendedBuses.has(bus))
     );
   };
 
@@ -110,10 +110,10 @@ export class TemplateValidations {
     }
 
     if (recommendedBuses.size > 0) {
-      return [...recommendedBuses][0];
+      return Array.from(recommendedBuses)[0];
     }
 
-    return allowedBuses.has(defaultBus) ? defaultBus : [...allowedBuses][0];
+    return allowedBuses.has(defaultBus) ? defaultBus : Array.from(allowedBuses)[0];
   };
 
   private validateMemoryByType = (

--- a/frontend/packages/noobaa-storage-plugin/src/components/bucket-class/wizard-pages/backingstore-page.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/bucket-class/wizard-pages/backingstore-page.tsx
@@ -146,7 +146,7 @@ const BackingStorePage: React.FC<BackingStorePageProps> = React.memo(
       selectedItem.selected = !selectedItem.selected;
       isSelected ? (selectedItem.selectedBy = tableId) : (selectedItem.selectedBy = '');
       store.add(selectedItem);
-      dispatcher({ type: 'setBackingStores', value: [...store] });
+      dispatcher({ type: 'setBackingStores', value: Array.from(store) });
       // 0 tier-1 table, 1 tier-2 table
       const itemsTable1 = filterSelectedItems(storeMain, 0);
       dispatcher({ type: 'setBackingStoreTier1', value: itemsTable1 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.tsx
@@ -135,7 +135,7 @@ export const PackageManifestList = requireOperatorGroup((props: PackageManifestL
         />
       )}
     >
-      {_.sortBy([...catalogs.values()], 'displayName').map((catalog) => (
+      {_.sortBy(Array.from(catalogs.values()), 'displayName').map((catalog) => (
         <div key={catalog.name} className="co-catalogsource-list__section">
           <div className="co-catalogsource-list__section__packages">
             <div>

--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -193,7 +193,7 @@ const APIResourcesList = compose(
   const groups: Set<string> = models.reduce((result: Set<string>, { apiGroup }) => {
     return apiGroup ? result.add(apiGroup) : result;
   }, new Set<string>());
-  const sortedGroups: string[] = [...groups].sort();
+  const sortedGroups: string[] = Array.from(groups).sort();
   const groupOptions = sortedGroups.reduce(
     (result, group: string) => {
       result[group] = <Group value={group} />;
@@ -215,7 +215,7 @@ const APIResourcesList = compose(
   const versions: Set<string> = models.reduce((result: Set<string>, { apiVersion }) => {
     return result.add(apiVersion);
   }, new Set<string>());
-  const sortedVersions: string[] = [...versions].sort();
+  const sortedVersions: string[] = Array.from(versions).sort();
   const versionOptions = sortedVersions.reduce(
     (result, version: string) => {
       result[version] = version;

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -304,7 +304,7 @@ class OverviewMainContent_ extends React.Component<
       const itemLabels = _.get(i, 'obj.metadata.labels') as K8sResourceKind['metadata']['labels'];
       _.each(itemLabels, (v: string, k: string) => labelSet.add(k));
     });
-    return [...labelSet].sort();
+    return Array.from(labelSet).sort();
   }
 
   createOverviewData(): OverviewMainContentState {

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -86,7 +86,7 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
     const updateItems = selectedItems;
     updateItems.has(selection) ? updateItems.delete(selection) : updateItems.add(selection);
     setSelectedItems(updateItems);
-    setQueryArgument('kind', [...updateItems].join(','));
+    setQueryArgument('kind', Array.from(updateItems).join(','));
   };
 
   const clearSelectedItems = () => {
@@ -169,7 +169,7 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
       <PageHeading detail={true} title="Search">
         <div className="co-search-group">
           <ResourceListDropdown
-            selected={[...selectedItems]}
+            selected={Array.from(selectedItems)}
             onChange={updateSelectedItems}
             className="co-search-group__resource"
           />
@@ -182,7 +182,7 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
         <div className="form-group">
           <ChipGroup withToolbar defaultIsOpen={false}>
             <ChipGroupToolbarItem key="resources-category" categoryName="Resource">
-              {[...selectedItems].map((chip) => (
+              {Array.from(selectedItems).map((chip) => (
                 <Chip key={chip} onClick={() => updateSelectedItems(chip)}>
                   <ResourceIcon kind={chip} />
                   {kindForReference(chip)}
@@ -234,7 +234,7 @@ const SearchPage_: React.FC<SearchProps> = (props) => {
       </PageHeading>
       <div className="co-search">
         <Accordion className="co-search__accordion" asDefinitionList={false} noBoxShadow>
-          {[...selectedItems].map((item) => {
+          {Array.from(selectedItems).map((item) => {
             const isCollapsed = collapsedKinds.has(item);
             return (
               <AccordionItem key={item}>

--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -101,7 +101,7 @@ export const getResources = () =>
             namespaced && namespacedSet.add(name);
           }),
       );
-      const allResources = [...resourceSet].sort();
+      const allResources = Array.from(resourceSet).sort();
 
       const safeResources = [];
       const adminResources = [];

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,7 +8,6 @@
     "lib": ["dom", "es2015", "es2016.array.include", "es2017.string"],
     "jsx": "react",
     "allowJs": true,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "sourceMap": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
I believe this is a TypeScript bug.

We've been seeing occasional `RangeError` runtime errors when using the
spread operator on a `Set`. Here is an example from CI:

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_console/4683/pull-ci-openshift-console-release-4.4-e2e-gcp-console/746

And this bug:

https://bugzilla.redhat.com/show_bug.cgi?id=1811886

I was able to reproduce in 4.3.0-0.nightly-2020-03-09-200240 and set a
breakpoint on runtime errors. The error in this release happens here:

https://github.com/openshift/console/blob/57355dcf1ccf267dbca508589b640947a90ecc40/frontend/public/module/k8s/get-resources.ts#L104

![Screen Shot 2020-03-10 at 10 57 17 AM](https://user-images.githubusercontent.com/1167259/76341797-e8b4b580-62d3-11ea-8208-f034da1076ce.png)

`[...resourceSet]` fails, even though the `Set` has the expected data,
and you should be able to use the spread operator on a `Set` when
`downlevelIteration` is enabled in tsconfig.json. In the generated JS
`__spreadArray` function, the code attempts to read the `length`
property on the `Set` to calculate the size of the new array. `Set` does
not have a `length`, however, so this result in `NaN`. Creating a new
array with `NaN` length causes the `RangeError`.

I'm not sure under what circumstances this occurs, but this commit
switches to the alternative `Array.from`, which works with `Set`, and
disables `downlevelIteration` to avoid errors in the future.