### PR TITLE
List all resources in the topology sidepanel when a Helm Release group is selected

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -32,7 +32,7 @@ import ComponentFactory from './componentFactory';
 import { TYPE_APPLICATION_GROUP, TYPE_HELM_RELEASE, TYPE_OPERATOR_BACKED_SERVICE } from './const';
 import TopologyFilterBar from './filters/TopologyFilterBar';
 import { getTopologyFilters, TopologyFilters } from './filters/filter-utils';
-import TopologyHelmReleasePanel from './TopologyHelmReleasePanel';
+import TopologyHelmReleasePanel from './helm-details/TopologyHelmReleasePanel';
 import { useAddToProjectAccess } from '../../utils/useAddToProjectAccess';
 
 interface StateProps {

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -114,18 +114,22 @@ export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
       if (ignore) return;
 
       const releaseResourcesMap = releases.reduce((acc, release) => {
-        const manifestResources: K8sResourceKind[] = safeLoadAll(release.manifest);
+        try {
+          const manifestResources: K8sResourceKind[] = safeLoadAll(release.manifest);
 
-        manifestResources.forEach((resource) => {
-          const resourceKindName = getHelmReleaseKey(resource);
-          if (!acc.hasOwnProperty(resourceKindName)) {
-            acc[resourceKindName] = {
-              releaseName: release.name,
-              chartIcon: release.chart.metadata.icon,
-              manifestResources,
-            };
-          }
-        });
+          manifestResources.forEach((resource) => {
+            const resourceKindName = getHelmReleaseKey(resource);
+            if (!acc.hasOwnProperty(resourceKindName)) {
+              acc[resourceKindName] = {
+                releaseName: release.name,
+                chartIcon: release.chart.metadata.icon,
+                manifestResources,
+              };
+            }
+          });
+        } catch (e) {
+          console.error(e);
+        }
 
         return acc;
       }, {});

--- a/frontend/packages/dev-console/src/components/topology/helm-details/TopologyHelmReleasePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm-details/TopologyHelmReleasePanel.tsx
@@ -1,20 +1,49 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
 import {
   navFactory,
   ResourceIcon,
   SimpleTabNav,
   StatusBox,
 } from '@console/internal/components/utils';
+import * as UIActions from '@console/internal/actions/ui';
 import { Node } from '@console/topology';
-import HelmReleaseOverview from '../helm/HelmReleaseOverview';
+import HelmReleaseOverview from '../../helm/HelmReleaseOverview';
+import TopologyHelmReleaseResourcesPanel from './TopologyHelmReleaseResourcesPanel';
 
-export type TopologyHelmReleasePanelProps = {
+type PropsFromState = {
+  selectedDetailsTab?: any;
+};
+
+type PropsFromDispatch = {
+  onClickTab?: (name: string) => void;
+};
+
+const stateToProps = ({ UI }): PropsFromState => ({
+  selectedDetailsTab: UI.getIn(['overview', 'selectedDetailsTab']),
+});
+
+const dispatchToProps = (dispatch): PropsFromDispatch => ({
+  onClickTab: (name) => dispatch(UIActions.selectOverviewDetailsTab(name)),
+});
+
+type OwnProps = {
   helmRelease: Node;
 };
 
-const TopologyHelmReleasePanel: React.FC<TopologyHelmReleasePanelProps> = ({ helmRelease }) => {
+type TopologyHelmReleasePanelProps = PropsFromState & PropsFromDispatch & OwnProps;
+
+const TopologyHelmReleasePanel = connect<
+  PropsFromState,
+  PropsFromDispatch,
+  TopologyHelmReleasePanelProps
+>(
+  stateToProps,
+  dispatchToProps,
+)(({ helmRelease, selectedDetailsTab, onClickTab }: TopologyHelmReleasePanelProps) => {
   const secret = helmRelease.getData().resources.obj;
+  const { manifestResources } = helmRelease.getData().data;
   const name = helmRelease.getLabel();
   const { namespace } = helmRelease.getData().groupResources[0].resources.obj.metadata;
 
@@ -26,6 +55,11 @@ const TopologyHelmReleasePanel: React.FC<TopologyHelmReleasePanelProps> = ({ hel
         />
       )
     : navFactory.details(HelmReleaseOverview).component;
+
+  const resourcesComponent = () =>
+    manifestResources ? (
+      <TopologyHelmReleaseResourcesPanel manifestResources={manifestResources} />
+    ) : null;
 
   return (
     <div className="overview__sidebar-pane resource-overview">
@@ -43,13 +77,17 @@ const TopologyHelmReleasePanel: React.FC<TopologyHelmReleasePanelProps> = ({ hel
         </h1>
       </div>
       <SimpleTabNav
-        selectedTab={'Details'}
-        tabs={[{ name: 'Details', component: detailsComponent }]}
+        selectedTab={selectedDetailsTab || 'Resources'}
+        onClickTab={onClickTab}
+        tabs={[
+          { name: 'Details', component: detailsComponent },
+          { name: 'Resources', component: resourcesComponent },
+        ]}
         tabProps={{ obj: secret }}
         additionalClassNames="co-m-horizontal-nav__menu--within-sidebar co-m-horizontal-nav__menu--within-overview-sidebar"
       />
     </div>
   );
-};
+});
 
 export default TopologyHelmReleasePanel;

--- a/frontend/packages/dev-console/src/components/topology/helm-details/TopologyHelmReleaseResourceItem.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm-details/TopologyHelmReleaseResourceItem.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { ResourceLink } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+type TopologyHelmReleaseResourceItemProps = {
+  item: K8sResourceKind;
+};
+
+const TopologyHelmReleaseResourceItem: React.FC<TopologyHelmReleaseResourceItemProps> = ({
+  item,
+}) => {
+  const {
+    kind,
+    metadata: { name, namespace },
+  } = item;
+
+  return (
+    <li className="list-group-item container-fluid">
+      <div className="row">
+        <span className="col-xs-12">
+          <ResourceLink kind={kind} name={name} namespace={namespace} />
+        </span>
+      </div>
+    </li>
+  );
+};
+
+export default TopologyHelmReleaseResourceItem;

--- a/frontend/packages/dev-console/src/components/topology/helm-details/TopologyHelmReleaseResourceList.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm-details/TopologyHelmReleaseResourceList.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import TopologyHelmReleaseResourceItem from './TopologyHelmReleaseResourceItem';
+
+type TopologyHelmReleaseResourceListProps = {
+  resources: K8sResourceKind[];
+};
+
+const TopologyHelmReleaseResourceList: React.FC<TopologyHelmReleaseResourceListProps> = ({
+  resources,
+}) => {
+  return (
+    <ul className="list-group">
+      {resources
+        .sort((r1, r2) => r1.metadata.name.localeCompare(r2.metadata.name))
+        .map((resource) => (
+          <TopologyHelmReleaseResourceItem key={resource.metadata.name} item={resource} />
+        ))}
+    </ul>
+  );
+};
+
+export default TopologyHelmReleaseResourceList;

--- a/frontend/packages/dev-console/src/components/topology/helm-details/TopologyHelmReleaseResourcesPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm-details/TopologyHelmReleaseResourcesPanel.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { K8sResourceKind, modelFor } from '@console/internal/module/k8s';
+import { SidebarSectionHeading } from '@console/internal/components/utils';
+import TopologyHelmReleaseResourceList from './TopologyHelmReleaseResourceList';
+
+type TopologyHelmReleaseResourcesPanelProps = {
+  manifestResources: K8sResourceKind[];
+};
+
+const TopologyHelmReleaseResourcesPanel: React.SFC<TopologyHelmReleaseResourcesPanelProps> = ({
+  manifestResources,
+}) => {
+  const kinds = manifestResources
+    .reduce((resourceKinds, resource) => {
+      if (!resourceKinds.includes(resource.kind)) {
+        resourceKinds.push(resource.kind);
+      }
+      return resourceKinds;
+    }, [])
+    .sort((a, b) => a.localeCompare(b));
+
+  const resourceLists = kinds.reduce((lists, kind) => {
+    const model = modelFor(kind);
+    const resources = manifestResources.filter((resource) => resource.kind === model.kind);
+    if (resources.length) {
+      lists.push(
+        <div key={model.kind}>
+          <SidebarSectionHeading text={model.labelPlural} />
+          <TopologyHelmReleaseResourceList resources={resources} />
+        </div>,
+      );
+    }
+    return lists;
+  }, []);
+
+  return <div className="overview__sidebar-pane-body">{resourceLists}</div>;
+};
+
+export default TopologyHelmReleaseResourcesPanel;

--- a/frontend/packages/dev-console/src/components/topology/helm-details/__tests__/TopologyHelmReleasePanel.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm-details/__tests__/TopologyHelmReleasePanel.spec.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { SidebarSectionHeading } from '@console/internal/components/utils';
+import { mockManifest } from './mockData';
+import TopologyHelmReleaseResourcesPanel from '../TopologyHelmReleaseResourcesPanel';
+
+describe('TopologyHelmReleaseResourcesPanel', () => {
+  const manifestResources = mockManifest;
+
+  it('should render the correct number of resource categories', () => {
+    const component = shallow(
+      <TopologyHelmReleaseResourcesPanel manifestResources={manifestResources} />,
+    );
+    expect(component.find(SidebarSectionHeading)).toHaveLength(5);
+  });
+});

--- a/frontend/packages/dev-console/src/components/topology/helm-details/__tests__/mockData.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm-details/__tests__/mockData.ts
@@ -1,0 +1,51 @@
+export const mockManifest = [
+  {
+    kind: 'Secret',
+    metadata: {
+      name: 'mysql2',
+      namespace: 'jeff-project',
+    },
+  },
+  {
+    kind: 'PersistentVolumeClaim',
+    metadata: {
+      name: 'mysql2-pvc2',
+      namespace: 'jeff-project',
+    },
+  },
+  {
+    kind: 'ConfigMap',
+    metadata: {
+      name: 'mysql2-test',
+      namespace: 'jeff-project',
+    },
+  },
+  {
+    kind: 'PersistentVolumeClaim',
+    metadata: {
+      name: 'mysql2',
+      namespace: 'jeff-project',
+    },
+  },
+  {
+    kind: 'Deployment',
+    metadata: {
+      name: 'mysql2-d2',
+      namespace: 'jeff-project',
+    },
+  },
+  {
+    kind: 'Service',
+    metadata: {
+      name: 'mysql2',
+      namespace: 'jeff-project',
+    },
+  },
+  {
+    kind: 'Deployment',
+    metadata: {
+      name: 'mysql2',
+      namespace: 'jeff-project',
+    },
+  },
+];

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -25,6 +25,7 @@ import {
   createKnativeEventSourceSink,
   NodeType,
 } from '@console/knative-plugin/src/utils/knative-topology-utils';
+import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
 import {
   edgesFromAnnotations,
   createResourceConnection,
@@ -68,7 +69,6 @@ import {
   KNATIVE_GROUP_NODE_HEIGHT,
   KNATIVE_GROUP_NODE_PADDING,
 } from './const';
-import { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
 import { HelmReleaseResourcesMap } from '../helm/helm-types';
 
 export const allowedResources = ['deployments', 'deploymentConfigs', 'daemonSets', 'statefulSets'];
@@ -390,7 +390,8 @@ export const getTopologyHelmReleaseGroupItem = (
   dataToShowOnNodes: TopologyDataMap,
 ): void => {
   const resourceKindName = getHelmReleaseKey(obj);
-  const releaseName = helmResourcesMap[resourceKindName]?.releaseName;
+  const helmResources = helmResourcesMap[resourceKindName];
+  const releaseName = helmResources?.releaseName;
   const uid = _.get(obj, ['metadata', 'uid'], null);
 
   if (!releaseName) return;
@@ -421,6 +422,9 @@ export const getTopologyHelmReleaseGroupItem = (
       buildConfigs: null,
       services: null,
       routes: null,
+    };
+    dataModel.data = {
+      manifestResources: helmResources?.manifestResources || [],
     };
     dataToShowOnNodes[helmGroup.id] = dataModel;
     groups.push(helmGroup);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2874

**Analysis / Root cause**: 
Resources for the Helm release were not being shown in the side panel.

**Solution Description**: 
List the resources associated with the helm release in a `Resources` tab in the details view. The resources are available via the helm resource map. Sort the resource types alphabetically by `kind`, sort the resources alphabetically by name.

**Screen Shots**
![image](https://user-images.githubusercontent.com/11633780/76348340-6a114580-62de-11ea-901b-419771800e56.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux 