### PR TITLE
Bug 1812139: List oc as first cli

### DIFF
--- a/frontend/__tests__/components/command-line-tools.spec.tsx
+++ b/frontend/__tests__/components/command-line-tools.spec.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import { CommandLineTools } from '../../public/components/command-line-tools';
+
+describe('CommandLineTools', () => {
+  let wrapper;
+  const obj = {
+    data: [
+      {
+        metadata: {
+          name: 'helm-download-links',
+          uid: '1',
+        },
+        spec: {
+          displayName: 'helm - Helm 3 CLI',
+          links: [],
+        },
+      },
+      {
+        metadata: {
+          name: 'oc-cli-downloads',
+          uid: '2',
+        },
+        spec: {
+          displayName: 'oc - OpenShift Command Line Interface (CLI)',
+          links: [],
+        },
+      },
+    ],
+    loadError: '',
+    loaded: true,
+  };
+
+  describe('When ordering is correct', () => {
+    beforeEach(() => {
+      wrapper = shallow(<CommandLineTools obj={obj} />);
+    });
+
+    it('shows oc first', () => {
+      expect(
+        wrapper
+          .find('.co-section-heading')
+          .first()
+          .text(),
+      ).toEqual('oc - OpenShift Command Line Interface (CLI)');
+    });
+  });
+});

--- a/frontend/public/components/command-line-tools.tsx
+++ b/frontend/public/components/command-line-tools.tsx
@@ -9,41 +9,40 @@ import { ConsoleCLIDownloadModel } from '../models';
 import { referenceForModel } from '../module/k8s';
 import { SyncMarkdownView } from './markdown-view';
 
-const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
+export const CommandLineTools: React.FC<CommandLineToolsProps> = ({ obj }) => {
   const title = 'Command Line Tools';
-  const additionalCommandLineTools = _.map(
-    _.sortBy(_.get(obj, 'data'), 'spec.displayName'),
-    (tool) => {
-      const displayName = tool.spec.displayName;
-      const defaultLinkText = `Download ${displayName}`;
-      return (
-        <React.Fragment key={tool.metadata.uid}>
-          <hr />
-          <h2 className="co-section-heading" data-test-id={displayName}>
-            {displayName}
-          </h2>
-          <SyncMarkdownView content={tool.spec.description} exactHeight />
-          {tool.spec.links.length === 1 && (
-            <p>
-              <ExternalLink
-                href={tool.spec.links[0].href}
-                text={tool.spec.links[0].text || defaultLinkText}
-              />
-            </p>
-          )}
-          {tool.spec.links.length > 1 && (
-            <ul>
-              {_.map(tool.spec.links, (link, i) => (
-                <li key={i}>
-                  <ExternalLink href={link.href} text={link.text || defaultLinkText} />
-                </li>
-              ))}
-            </ul>
-          )}
-        </React.Fragment>
-      );
-    },
-  );
+  const data = _.sortBy(_.get(obj, 'data'), 'spec.displayName');
+  const cliData = _.remove(data, (item) => item.metadata.name === 'oc-cli-downloads');
+  const additionalCommandLineTools = _.map(cliData.concat(data), (tool) => {
+    const displayName = tool.spec.displayName;
+    const defaultLinkText = `Download ${displayName}`;
+    return (
+      <React.Fragment key={tool.metadata.uid}>
+        <hr />
+        <h2 className="co-section-heading" data-test-id={displayName}>
+          {displayName}
+        </h2>
+        <SyncMarkdownView content={tool.spec.description} exactHeight />
+        {tool.spec.links.length === 1 && (
+          <p>
+            <ExternalLink
+              href={tool.spec.links[0].href}
+              text={tool.spec.links[0].text || defaultLinkText}
+            />
+          </p>
+        )}
+        {tool.spec.links.length > 1 && (
+          <ul>
+            {_.map(tool.spec.links, (link, i) => (
+              <li key={i}>
+                <ExternalLink href={link.href} text={link.text || defaultLinkText} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </React.Fragment>
+    );
+  });
 
   return (
     <>


### PR DESCRIPTION
Reordered data so oc would be the first cli on the cli page.

<img width="1002" alt="Screen Shot 2020-03-11 at 4 56 58 PM" src="https://user-images.githubusercontent.com/7014965/76463192-62729f00-63b9-11ea-91be-e0bc567053fd.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1812139.