### PR TITLE
Expose access and volume modes in the create/edit disk modal

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -188,8 +188,14 @@ const kubevirtInterOP = async ({
       if (dataVolumeWrapper) {
         finalDataVolume = dataVolumeWrapper
           .assertDefaultModes(
-            getDefaultSCVolumeMode(storageClassConfigMap, dataVolumeWrapper.getStorageClassName()),
-            getDefaultSCAccessModes(storageClassConfigMap, dataVolumeWrapper.getStorageClassName()),
+            getDefaultSCVolumeMode(
+              storageClassConfigMap,
+              dataVolumeWrapper.getStorageClassName(),
+            ).toString(),
+            getDefaultSCAccessModes(
+              storageClassConfigMap,
+              dataVolumeWrapper.getStorageClassName(),
+            ).map((a) => a.toString()),
           )
           .asResource();
       }

--- a/frontend/packages/kubevirt-plugin/src/components/form/form-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/form/form-row.tsx
@@ -16,6 +16,7 @@ export const FormRow: React.FC<FormRowProps> = ({
   validationType,
   validation,
   children,
+  className,
 }) => {
   if (isHidden) {
     return null;
@@ -33,6 +34,7 @@ export const FormRow: React.FC<FormRowProps> = ({
       helperText={
         type === ValidationErrorType.Info || type === ValidationErrorType.Warn ? message : undefined
       }
+      className={className}
     >
       {help && (
         <span className="kubevirt-form-row__icon-status-container">
@@ -72,4 +74,5 @@ type FormRowProps = {
     type?: ValidationErrorType;
   };
   children?: React.ReactNode;
+  className?: string;
 };

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.scss
@@ -1,0 +1,3 @@
+div.disk-access-mode {
+  padding-top: 1.5rem;
+}

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/storage-ui-source.ts
@@ -112,6 +112,16 @@ export class StorageUISource extends ObjectEnum<string> {
 
   requiresNamespace = () => this === StorageUISource.ATTACH_CLONED_DISK;
 
+  requiresAccessModes = () =>
+    this !== StorageUISource.ATTACH_DISK &&
+    this !== StorageUISource.CONTAINER &&
+    this !== StorageUISource.OTHER;
+
+  requiresVolumeMode = () =>
+    this !== StorageUISource.ATTACH_DISK &&
+    this !== StorageUISource.CONTAINER &&
+    this !== StorageUISource.OTHER;
+
   isEditingSupported = () => !this.dataVolumeSourceType; // vm disks - do not support because pvc was already created from DV
 
   isNameEditingSupported = (diskType: DiskType) => diskType !== DiskType.CDROM;

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/storage/access-mode.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/storage/access-mode.ts
@@ -1,0 +1,40 @@
+/* eslint-disable lines-between-class-members */
+import { ObjectEnum } from '../../object-enum';
+
+export class AccessMode extends ObjectEnum<string> {
+  static readonly SINGLE_USER = new AccessMode('ReadWriteOnce');
+  static readonly SHARED_ACCESS = new AccessMode('ReadWriteMany');
+  static readonly READ_ONLY = new AccessMode('ReadOnlyMany');
+
+  private static readonly ALL = Object.freeze(
+    ObjectEnum.getAllClassEnumProperties<AccessMode>(AccessMode),
+  );
+
+  private static readonly stringMapper = AccessMode.ALL.reduce(
+    (accumulator, accessMode: AccessMode) => ({
+      ...accumulator,
+      [accessMode.value]: accessMode,
+    }),
+    {},
+  );
+
+  static getAll = () => AccessMode.ALL;
+
+  static fromSerialized = (accessMode: { value: string }): AccessMode =>
+    AccessMode.fromString(accessMode && accessMode.value);
+
+  static fromString = (model: string): AccessMode => AccessMode.stringMapper[model];
+
+  toLabel = () => {
+    switch (this) {
+      case AccessMode.SINGLE_USER:
+        return 'Single User (RWO)';
+      case AccessMode.SHARED_ACCESS:
+        return 'Shared Access (RWX)';
+      case AccessMode.READ_ONLY:
+        return 'Read Only (ROX)';
+      default:
+        return this.value;
+    }
+  };
+}

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/storage/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/storage/index.ts
@@ -1,4 +1,6 @@
+export * from './access-mode';
 export * from './data-volume-source-type';
 export * from './disk-bus';
 export * from './disk-type';
 export * from './volume-type';
+export * from './volume-mode';

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/storage/volume-mode.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/storage/volume-mode.ts
@@ -1,0 +1,26 @@
+/* eslint-disable lines-between-class-members */
+import { ObjectEnum } from '../../object-enum';
+
+export class VolumeMode extends ObjectEnum<string> {
+  static readonly BLOCK = new VolumeMode('Block');
+  static readonly FILESYSTEM = new VolumeMode('Filesystem');
+
+  private static readonly ALL = Object.freeze(
+    ObjectEnum.getAllClassEnumProperties<VolumeMode>(VolumeMode),
+  );
+
+  private static readonly stringMapper = VolumeMode.ALL.reduce(
+    (accumulator, volumeMode: VolumeMode) => ({
+      ...accumulator,
+      [volumeMode.value]: volumeMode,
+    }),
+    {},
+  );
+
+  static getAll = () => VolumeMode.ALL;
+
+  static fromSerialized = (volumeMode: { value: string }): VolumeMode =>
+    VolumeMode.fromString(volumeMode && volumeMode.value);
+
+  static fromString = (model: string): VolumeMode => VolumeMode.stringMapper[model];
+}

--- a/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-cdrom-patches.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-cdrom-patches.ts
@@ -98,8 +98,10 @@ export const getCDsPatch = async (vm: VMLikeEntityKind, cds: CD[]) => {
 
         finalDataVolume = dataVolumeWrapper
           .assertDefaultModes(
-            getDefaultSCVolumeMode(storageClassConfigMap, storageClassName),
-            getDefaultSCAccessModes(storageClassConfigMap, storageClassName),
+            getDefaultSCVolumeMode(storageClassConfigMap, storageClassName).toString(),
+            getDefaultSCAccessModes(storageClassConfigMap, storageClassName).map((a) =>
+              a.toString(),
+            ),
           )
           .asResource();
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-disk-patches.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-disk-patches.ts
@@ -98,8 +98,8 @@ export const getUpdateDiskPatches = async (
 
     finalDataVolume = dataVolumeWrapper
       .assertDefaultModes(
-        getDefaultSCVolumeMode(storageClassConfigMap, storageClassName),
-        getDefaultSCAccessModes(storageClassConfigMap, storageClassName),
+        getDefaultSCVolumeMode(storageClassConfigMap, storageClassName).toString(),
+        getDefaultSCAccessModes(storageClassConfigMap, storageClassName).map((a) => a.toString()),
       )
       .asResource();
   }

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/initialize-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/initialize-vm.ts
@@ -74,8 +74,14 @@ const initializeStorage = (params: CreateVMEnhancedParams, vm: VMWrapper) => {
         )
         .setNamespace(isPlainDataVolume ? namespace : undefined)
         .assertDefaultModes(
-          getDefaultSCVolumeMode(storageClassConfigMap, dataVolumeWrapper.getStorageClassName()),
-          getDefaultSCAccessModes(storageClassConfigMap, dataVolumeWrapper.getStorageClassName()),
+          getDefaultSCVolumeMode(
+            storageClassConfigMap,
+            dataVolumeWrapper.getStorageClassName(),
+          ).toString(),
+          getDefaultSCAccessModes(
+            storageClassConfigMap,
+            dataVolumeWrapper.getStorageClassName(),
+          ).map((a) => a.toString()),
         );
 
       if (volumeWrapper.getType() === VolumeType.DATA_VOLUME) {


### PR DESCRIPTION
This PR adds the access and volume mode options in an advanced drawer to the create/edit disk modal.

![OKD - Google Chrome_649](https://user-images.githubusercontent.com/8544299/76959156-6fc6e680-68ef-11ea-9eee-0be2cb86b124.png)
