### PR TITLE
pipeline task name edit

### DIFF
--- a/frontend/packages/dev-console/integration-tests/tests/pipeline.scenario.ts
+++ b/frontend/packages/dev-console/integration-tests/tests/pipeline.scenario.ts
@@ -69,7 +69,7 @@ describe('Pipeline', async () => {
     checkErrors();
   });
 
-  it('displays subscription creation form for selected Operator', async () => {
+  it('displays subscription creation form for pipeline Operator', async () => {
     await switchPerspective(Perspective.Administrator);
     await catalogView.categoryTabsPresent();
     await catalogView.categoryTabs.get(0).click();
@@ -115,6 +115,7 @@ describe('Pipeline', async () => {
     await browser.get(`${appHost}/k8s/cluster/projects/${testName}`);
     await switchPerspective(Perspective.Developer);
     expect(sideHeader.getText()).toContain('Developer');
+    await browser.driver.navigate().refresh();
     await browser.wait(until.visibilityOf(pageSidebar));
     await browser.wait(until.visibilityOf(pipelineTab));
     expect(pageSidebar.getText()).toContain('Pipelines');

--- a/frontend/packages/dev-console/integration-tests/views/pipeline.view.ts
+++ b/frontend/packages/dev-console/integration-tests/views/pipeline.view.ts
@@ -4,7 +4,7 @@ export const pageSidebar = element(by.id('page-sidebar'));
 export const pipelineTab = element(by.css('[data-test-id="pipeline-header"]'));
 export const pipelinePage = element(by.css('[data-test-id="resource-title"]'));
 export const selectTask = element(by.className('odc-task-list-node__trigger'));
-export const selectBuildah = element(by.css('[data-test-action="buildah"]'));
+export const selectBuildah = element(by.css('[data-test-action="openshift-client"]'));
 export const createPipeline = element(by.css('[data-test-id="import-git-create-button"]'));
 export const createPipelineYaml = element(by.id('yaml-create'));
 export const createPipelineYamlError = $('.pf-c-alert.pf-m-danger');


### PR DESCRIPTION
Change of pipeline task name from `buildah` to `openshift-client` and some small change. These changes will enable pipeline test to run clean