### PR TITLE
Bug 1811840: Fix name conflicts during testing

### DIFF
--- a/frontend/integration-tests/tests/event.scenario.ts
+++ b/frontend/integration-tests/tests/event.scenario.ts
@@ -3,7 +3,7 @@ import { appHost, checkLogs, checkErrors, testName } from '../protractor.conf';
 import { execSync } from 'child_process';
 
 describe('Events', () => {
-  const name = `${testName}-pod`;
+  const name = `${testName}-event-test-pod`;
   const testpod = {
     apiVersion: 'v1',
     kind: 'Pod',


### PR DESCRIPTION
When running all e2e test, the pod name used might still exist due to timing of delete, so I have simply created a unique name for the event testcase.