### PR TITLE
increase topology unit tests

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/components/anchors/RevisionTrafficSourceAnchor.ts
+++ b/frontend/packages/dev-console/src/components/topology/components/anchors/RevisionTrafficSourceAnchor.ts
@@ -9,7 +9,7 @@ export default class RevisionTrafficSourceAnchor extends AbstractAnchor {
   }
 
   getLocation(reference: Point): Point {
-    const bounds = this.getOwner().getBounds();
+    const bounds = this.owner.getBounds();
     // center point is top right corner
     const center = new Point(bounds.right(), bounds.y);
     if (this.radius) {
@@ -23,7 +23,7 @@ export default class RevisionTrafficSourceAnchor extends AbstractAnchor {
   }
 
   getReferencePoint(): Point {
-    const bounds = this.getOwner().getBounds();
+    const bounds = this.owner.getBounds();
     // reference point is top right corner of node
     return new Point(bounds.right(), bounds.y);
   }

--- a/frontend/packages/dev-console/src/components/topology/components/anchors/RevisionTrafficTargetAnchor.ts
+++ b/frontend/packages/dev-console/src/components/topology/components/anchors/RevisionTrafficTargetAnchor.ts
@@ -13,7 +13,7 @@ export default class RevisionTrafficTargetAnchor extends AbstractAnchor {
   }
 
   getLocation(reference: Point): Point {
-    const bounds = this.getOwner().getBounds();
+    const bounds = this.owner.getBounds();
     if (this.radius) {
       // location is edge of decorator
       const center = new Point(bounds.right() - this.radiusOffset, bounds.y + this.radiusOffset);
@@ -26,7 +26,7 @@ export default class RevisionTrafficTargetAnchor extends AbstractAnchor {
   }
 
   getReferencePoint(): Point {
-    const bounds = this.getOwner().getBounds();
+    const bounds = this.owner.getBounds();
     if (this.radius) {
       // reference point is center of decorator
       return new Point(bounds.right() - this.radiusOffset, bounds.y + this.radiusOffset);

--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
@@ -35,7 +35,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
   contextMenuOpen,
   dndDropRef,
 }) => {
-  useAnchor((e: Node) => new RectAnchor(e, 4));
+  useAnchor((e: Node) => new RectAnchor(e, 1.5));
   const [hover, hoverRef] = useHover();
   const [{ dragging }, dragNodeRef] = useDragNode(
     nodeDragSourceSpec(TYPE_HELM_RELEASE, true, editAccess),

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/ApplicationNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/ApplicationNode.tsx
@@ -40,7 +40,7 @@ const ApplicationNode: React.FC<ApplicationGroupProps> = ({
   contextMenuOpen,
   dragging,
 }) => {
-  useAnchor((e: Node) => new RectAnchor(e, 4));
+  useAnchor((e: Node) => new RectAnchor(e, 1.5));
   const [hover, hoverRef] = useHover();
   const dragNodeRef = useDragNode()[1];
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, hoverRef);

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceGroup.tsx
@@ -78,7 +78,7 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
     AnchorEnd.source,
     'revision-traffic',
   );
-  useAnchor(RectAnchor);
+  useAnchor((e: Node) => new RectAnchor(e, 1.5));
   const [filtered] = useSearchFilter(element.getLabel());
   const { x, y, width, height } = element.getBounds();
 

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceNode.tsx
@@ -44,7 +44,7 @@ const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
   onHideCreateConnector,
   onShowCreateConnector,
 }) => {
-  useAnchor((e: Node) => new RectAnchor(e, 4));
+  useAnchor((e: Node) => new RectAnchor(e, 1.5));
   const [hover, hoverRef] = useHover();
   const [{ dragging }, dragNodeRef] = useDragNode(
     nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess),

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceNode.tsx
@@ -35,7 +35,7 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   contextMenuOpen,
   dndDropRef,
 }) => {
-  useAnchor((e: Node) => new RectAnchor(e, 4));
+  useAnchor((e: Node) => new RectAnchor(e, 1.5));
   const [hover, hoverRef] = useHover();
   const [{ dragging }, dragNodeRef] = useDragNode(
     nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, true, editAccess),

--- a/frontend/packages/topology/src/anchors/AbstractAnchor.ts
+++ b/frontend/packages/topology/src/anchors/AbstractAnchor.ts
@@ -2,22 +2,24 @@ import Point from '../geom/Point';
 import { Anchor, Node } from '../types';
 
 export default abstract class AbstractAnchor<E extends Node = Node> implements Anchor {
-  private owner: E;
+  protected readonly owner: E;
 
-  protected offset = 0;
+  // Consumption of the offset depends on the concrete anchor implementation but it is
+  // indended that the reference point is moved by the offset relative to the point location
+  // in the direction of the opposing reference point.
+  protected readonly offset: number;
 
   constructor(owner: E, offset: number = 0) {
     this.owner = owner;
     this.offset = offset;
   }
 
-  protected getOwner(): E {
-    return this.owner;
-  }
-
   abstract getLocation(reference: Point): Point;
 
   getReferencePoint(): Point {
-    return this.owner.getBounds().getCenter();
+    return this.owner
+      .getBounds()
+      .getCenter()
+      .translate(this.offset, this.offset);
   }
 }

--- a/frontend/packages/topology/src/anchors/CenterAnchor.ts
+++ b/frontend/packages/topology/src/anchors/CenterAnchor.ts
@@ -1,11 +1,14 @@
 import Point from '../geom/Point';
 import AbstractAnchor from './AbstractAnchor';
+import { getEllipseAnchorPoint } from '../utils/anchor-utils';
 
 export default class CenterAnchor extends AbstractAnchor {
-  getLocation(): Point {
-    return this.getOwner()
-      .getBounds()
-      .getCenter()
-      .translate(this.offset, this.offset);
+  getLocation(reference: Point): Point {
+    const bounds = this.owner.getBounds();
+    if (this.offset === 0) {
+      return bounds.getCenter();
+    }
+    const offset2x = this.offset * 2;
+    return getEllipseAnchorPoint(bounds.getCenter(), offset2x, offset2x, reference);
   }
 }

--- a/frontend/packages/topology/src/anchors/EllipseAnchor.ts
+++ b/frontend/packages/topology/src/anchors/EllipseAnchor.ts
@@ -4,16 +4,12 @@ import AbstractAnchor from './AbstractAnchor';
 
 export default class EllipseAnchor extends AbstractAnchor {
   getLocation(reference: Point): Point {
-    const r = this.getOwner().getBounds();
+    const r = this.owner.getBounds();
     if (r.isEmpty()) {
       return r.getCenter();
     }
 
-    return getEllipseAnchorPoint(
-      r.getCenter(),
-      r.width + this.offset,
-      r.height + this.offset,
-      reference,
-    );
+    const offset2x = this.offset * 2;
+    return getEllipseAnchorPoint(r.getCenter(), r.width + offset2x, r.height + offset2x, reference);
   }
 }

--- a/frontend/packages/topology/src/anchors/RectAnchor.ts
+++ b/frontend/packages/topology/src/anchors/RectAnchor.ts
@@ -4,12 +4,13 @@ import AbstractAnchor from './AbstractAnchor';
 
 export default class RectAnchor extends AbstractAnchor {
   getLocation(reference: Point): Point {
-    const r = this.getOwner().getBounds();
+    const r = this.owner.getBounds();
     const center = r.getCenter();
     if (r.isEmpty()) {
       return center;
     }
 
-    return getRectAnchorPoint(center, r.width + this.offset, r.height + this.offset, reference);
+    const offset2x = this.offset * 2;
+    return getRectAnchorPoint(center, r.width + offset2x, r.height + offset2x, reference);
   }
 }

--- a/frontend/packages/topology/src/anchors/SVGAnchor.ts
+++ b/frontend/packages/topology/src/anchors/SVGAnchor.ts
@@ -18,17 +18,18 @@ export default class SVGAnchor extends AbstractAnchor {
 
   getCircleLocation(circle: SVGCircleElement, reference: Point): Point {
     const center: Point = new Point(circle.cx.baseVal.value, circle.cy.baseVal.value);
-    this.getOwner().translateToParent(center);
-    const diameter = circle.r.baseVal.value * 2 + this.offset;
+    this.owner.translateToParent(center);
+    const diameter = circle.r.baseVal.value * 2 + this.offset * 2;
 
     return getEllipseAnchorPoint(center, diameter, diameter, reference);
   }
 
   getEllipseLocation(ellipse: SVGEllipseElement, reference: Point): Point {
     const center: Point = new Point(ellipse.cx.baseVal.value, ellipse.cy.baseVal.value);
-    this.getOwner().translateToParent(center);
-    const width = ellipse.rx.baseVal.value * 2 + this.offset;
-    const height = ellipse.ry.baseVal.value * 2 + this.offset;
+    this.owner.translateToParent(center);
+    const offset2x = this.offset * 2;
+    const width = ellipse.rx.baseVal.value * 2 + offset2x;
+    const height = ellipse.ry.baseVal.value * 2 + offset2x;
 
     return getEllipseAnchorPoint(center, width, height, reference);
   }
@@ -41,24 +42,25 @@ export default class SVGAnchor extends AbstractAnchor {
       rect.x.baseVal.value + width / 2,
       rect.y.baseVal.value + height / 2,
     );
-    this.getOwner().translateToParent(center);
+    this.owner.translateToParent(center);
 
-    return getRectAnchorPoint(center, width + this.offset, height + this.offset, reference);
+    const offset2x = this.offset * 2;
+    return getRectAnchorPoint(center, width + offset2x, height + offset2x, reference);
   }
 
   getPathLocation(path: SVGPathElement, reference: Point): Point {
     const translatedRef = reference.clone();
-    this.getOwner().translateFromParent(translatedRef);
+    this.owner.translateFromParent(translatedRef);
     const anchorPoint = getPathAnchorPoint(path, translatedRef);
-    this.getOwner().translateToParent(anchorPoint);
+    this.owner.translateToParent(anchorPoint);
     return anchorPoint;
   }
 
   getPolygonLocation(polygon: SVGPolygonElement, reference: Point): Point {
     const translatedRef = reference.clone();
-    this.getOwner().translateFromParent(translatedRef);
+    this.owner.translateFromParent(translatedRef);
     const anchorPoint = getPolygonAnchorPoint(polygon, translatedRef);
-    this.getOwner().translateToParent(anchorPoint);
+    this.owner.translateToParent(anchorPoint);
     return anchorPoint;
   }
 
@@ -83,9 +85,7 @@ export default class SVGAnchor extends AbstractAnchor {
       return this.getPolygonLocation(this.svgElement, reference);
     }
 
-    return this.getOwner()
-      .getBounds()
-      .getCenter();
+    return this.owner.getBounds().getCenter();
   }
 
   getReferencePoint(): Point {
@@ -100,10 +100,10 @@ export default class SVGAnchor extends AbstractAnchor {
       const ref = new Point(bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);
 
       // this touches the bounds for non-groups
-      this.getOwner().translateToParent(ref);
+      this.owner.translateToParent(ref);
 
       // touch the bounds to force a re-render in case this anchor is for a group
-      this.getOwner().getBounds();
+      this.owner.getBounds();
 
       return ref;
     }

--- a/frontend/packages/topology/src/anchors/__tests__/AbstractAnchor.spec.ts
+++ b/frontend/packages/topology/src/anchors/__tests__/AbstractAnchor.spec.ts
@@ -1,0 +1,36 @@
+import AbstractAnchor from '../AbstractAnchor';
+import { Node } from '../../types';
+import { Point, Rect } from '../../geom';
+import { BaseNode } from '../../elements';
+
+class TestAnchor extends AbstractAnchor {
+  getOwner(): Node {
+    return this.owner;
+  }
+
+  getOffset() {
+    return this.offset;
+  }
+
+  getLocation(): Point {
+    return Point.EMPTY;
+  }
+}
+
+describe('AbstractAnchor', () => {
+  it('should have an owner and offset', () => {
+    const node = new BaseNode();
+    let anchor = new TestAnchor(node);
+    expect(anchor.getOffset()).toBe(0);
+    expect(anchor.getOwner()).toBe(node);
+    anchor = new TestAnchor(node, 10);
+    expect(anchor.getOffset()).toBe(10);
+  });
+
+  it('should default to node center reference point', () => {
+    const node = new BaseNode();
+    node.setBounds(new Rect(0, 0, 10, 10));
+    expect(new TestAnchor(node).getReferencePoint()).toEqual({ x: 5, y: 5 });
+    expect(new TestAnchor(node, 4).getReferencePoint()).toEqual({ x: 9, y: 9 });
+  });
+});

--- a/frontend/packages/topology/src/anchors/__tests__/CenterAnchor.spec.ts
+++ b/frontend/packages/topology/src/anchors/__tests__/CenterAnchor.spec.ts
@@ -1,0 +1,25 @@
+import CenterAnchor from '../CenterAnchor';
+import { Rect, Point } from '../../geom';
+import { BaseNode } from '../../elements';
+
+describe('CenterAnchor', () => {
+  it('should return node center location', () => {
+    const node = new BaseNode();
+    node.setBounds(new Rect(4, 5, 0, 0));
+    expect(new CenterAnchor(node).getLocation(new Point())).toEqual({ x: 4, y: 5 });
+  });
+
+  it('should return node anchor location', () => {
+    const node = new BaseNode();
+    node.setBounds(new Rect(0, 0, 10, 10));
+    expect(new CenterAnchor(node).getLocation(new Point(10, 5))).toEqual({ x: 5, y: 5 });
+    expect(new CenterAnchor(node, 4).getLocation(new Point(100, 5))).toEqual({ x: 9, y: 5 });
+    expect(new CenterAnchor(node, 4).getLocation(new Point(5, 100))).toEqual({ x: 5, y: 9 });
+  });
+
+  it('should return node center reference point', () => {
+    const node = new BaseNode();
+    node.setBounds(new Rect(0, 0, 10, 10));
+    expect(new CenterAnchor(node).getReferencePoint()).toEqual({ x: 5, y: 5 });
+  });
+});

--- a/frontend/packages/topology/src/anchors/__tests__/EllipseAnchor.spec.ts
+++ b/frontend/packages/topology/src/anchors/__tests__/EllipseAnchor.spec.ts
@@ -1,0 +1,38 @@
+import EllipseAnchor from '../EllipseAnchor';
+import { Rect, Point } from '../../geom';
+import { BaseNode } from '../../elements';
+
+describe('EllipseAnchor', () => {
+  it('should return node center location', () => {
+    const node = new BaseNode();
+    node.setBounds(new Rect(4, 5, 0, 0));
+    expect(new EllipseAnchor(node).getLocation(new Point())).toEqual({ x: 4, y: 5 });
+  });
+
+  it('should return node anchor location', () => {
+    const node = new BaseNode();
+    node.setBounds(new Rect(0, 0, 10, 10));
+    expect(new EllipseAnchor(node).getLocation(new Point(100, 5))).toEqual({ x: 10, y: 5 });
+    expect(new EllipseAnchor(node).getLocation(new Point(5, 100))).toEqual({ x: 5, y: 10 });
+    expect(new EllipseAnchor(node, 4).getLocation(new Point(100, 5))).toEqual({ x: 14, y: 5 });
+    expect(new EllipseAnchor(node, 4).getLocation(new Point(5, 100))).toEqual({ x: 5, y: 14 });
+
+    // 45deg angle
+    let point45 = 5 * Math.cos(45 * (Math.PI / 180)) + 5;
+    let loc = new EllipseAnchor(node).getLocation(new Point(100, 100));
+    expect(loc.x).toBeCloseTo(point45);
+    expect(loc.y).toBeCloseTo(point45);
+
+    // 45deg angle with offset
+    point45 = 9 * Math.cos(45 * (Math.PI / 180)) + 5;
+    loc = new EllipseAnchor(node, 4).getLocation(new Point(100, 100));
+    expect(loc.x).toBeCloseTo(point45);
+    expect(loc.y).toBeCloseTo(point45);
+  });
+
+  it('should return node center reference point', () => {
+    const node = new BaseNode();
+    node.setBounds(new Rect(0, 0, 10, 10));
+    expect(new EllipseAnchor(node).getReferencePoint()).toEqual({ x: 5, y: 5 });
+  });
+});

--- a/frontend/packages/topology/src/anchors/__tests__/RectAnchor.spec.ts
+++ b/frontend/packages/topology/src/anchors/__tests__/RectAnchor.spec.ts
@@ -1,0 +1,29 @@
+import RectAnchor from '../RectAnchor';
+import { Rect, Point } from '../../geom';
+import { BaseNode } from '../../elements';
+
+describe('RectAnchor', () => {
+  it('should return node center location', () => {
+    const node = new BaseNode();
+    node.setBounds(new Rect(4, 5, 0, 0));
+    expect(new RectAnchor(node).getLocation(new Point())).toEqual({ x: 4, y: 5 });
+  });
+
+  it('should return node anchor location', () => {
+    const node = new BaseNode();
+    node.setBounds(new Rect(0, 0, 10, 10));
+    expect(new RectAnchor(node).getLocation(new Point(100, 5))).toEqual({ x: 10, y: 5 });
+    expect(new RectAnchor(node).getLocation(new Point(5, 100))).toEqual({ x: 5, y: 10 });
+
+    expect(new RectAnchor(node).getLocation(new Point(100, 100))).toEqual({ x: 10, y: 10 });
+    expect(new RectAnchor(node, 4).getLocation(new Point(100, 5))).toEqual({ x: 14, y: 5 });
+    expect(new RectAnchor(node, 4).getLocation(new Point(5, 100))).toEqual({ x: 5, y: 14 });
+    expect(new RectAnchor(node, 4).getLocation(new Point(100, 100))).toEqual({ x: 14, y: 14 });
+  });
+
+  it('should return node center reference point', () => {
+    const node = new BaseNode();
+    node.setBounds(new Rect(0, 0, 10, 10));
+    expect(new RectAnchor(node).getReferencePoint()).toEqual({ x: 5, y: 5 });
+  });
+});

--- a/frontend/packages/topology/src/elements/BaseElement.ts
+++ b/frontend/packages/topology/src/elements/BaseElement.ts
@@ -167,7 +167,10 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
         child.remove();
         child.setParent(this);
         this.children.splice(index, 0, child);
-        this.getController().fireEvent(ADD_CHILD_EVENT, { target: this, child });
+
+        if (this.controller) {
+          this.controller.fireEvent(ADD_CHILD_EVENT, { target: this, child });
+        }
       }
     }
   }
@@ -183,7 +186,10 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
         child.remove();
         child.setParent(this);
         this.children.push(child);
-        this.getController().fireEvent(ADD_CHILD_EVENT, { target: this, child });
+
+        if (this.controller) {
+          this.controller.fireEvent(ADD_CHILD_EVENT, { target: this, child });
+        }
       }
     }
   }
@@ -194,7 +200,10 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
       if (idx !== -1) {
         this.children.splice(idx, 1);
         child.setParent(undefined);
-        this.getController().fireEvent(REMOVE_CHILD_EVENT, { target: this, child });
+
+        if (this.controller) {
+          this.controller.fireEvent(REMOVE_CHILD_EVENT, { target: this, child });
+        }
       }
     }
   }

--- a/frontend/packages/topology/src/elements/BaseGraph.ts
+++ b/frontend/packages/topology/src/elements/BaseGraph.ts
@@ -151,7 +151,10 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any> exten
     );
   }
 
-  panIntoView = (nodeElement: Node, { offset = 0, minimumVisible = 0 }): void => {
+  panIntoView = (
+    nodeElement: Node,
+    { offset = 0, minimumVisible = 0 }: { offset?: number; minimumVisible?: number } = {},
+  ): void => {
     if (!nodeElement) {
       return;
     }

--- a/frontend/packages/topology/src/elements/__tests__/BaseGraph.spec.ts
+++ b/frontend/packages/topology/src/elements/__tests__/BaseGraph.spec.ts
@@ -1,7 +1,16 @@
 import Rect from '../../geom/Rect';
 import Point from '../../geom/Point';
-import { ModelKind, Graph } from '../../types';
+import { ModelKind, Graph, Layout, GraphModel } from '../../types';
 import BaseGraph from '../BaseGraph';
+import BaseEdge from '../BaseEdge';
+import BaseNode from '../BaseNode';
+import Visualization from '../../Visualization';
+
+class TestLayout implements Layout {
+  layout = jest.fn();
+
+  destroy = jest.fn();
+}
 
 describe('BaseGraph', () => {
   let graph: Graph;
@@ -44,5 +53,262 @@ describe('BaseGraph', () => {
     expect(graph.getBounds()).toEqual({ x: 0, y: 0, width: 100, height: 100 });
     graph.scaleBy(0.5, new Point(100, 100));
     expect(graph.getBounds()).toEqual({ x: 50, y: 50, width: 100, height: 100 });
+  });
+
+  it('should get child nodes and edges', () => {
+    const e1 = new BaseEdge();
+    const n1 = new BaseNode();
+    const n2 = new BaseNode();
+    graph.appendChild(e1);
+    graph.appendChild(n1);
+    graph.appendChild(n2);
+
+    expect(graph.getNodes()).toEqual([n1, n2]);
+    expect(graph.getEdges()).toEqual([e1]);
+    // FIXME #getChildren() returns a mobx array and we need to slice it before we can assert
+    expect(graph.getChildren().slice()).toEqual([e1, n1, n2]);
+  });
+
+  it('should get and set layouts', () => {
+    const LAYOUT1_TYPE = 'layout1';
+    const LAYOUT2_TYPE = 'layout2';
+    const layout1 = new TestLayout();
+    const layout2 = new TestLayout();
+
+    const controller = new Visualization();
+    controller.setGraph(graph);
+    controller.registerLayoutFactory((type) => {
+      switch (type) {
+        case LAYOUT1_TYPE:
+          return layout1;
+        case LAYOUT2_TYPE:
+          return layout2;
+        default:
+          return undefined;
+      }
+    });
+
+    expect(graph.getLayout()).toBe(undefined);
+
+    // set initial layout
+    graph.setLayout(LAYOUT1_TYPE);
+    expect(graph.getLayout()).toBe(LAYOUT1_TYPE);
+
+    // run layout
+    expect(layout1.layout).not.toHaveBeenCalled();
+    graph.layout();
+    expect(layout1.layout).toHaveBeenCalledTimes(1);
+
+    // change layout
+    expect(layout2.destroy).not.toHaveBeenCalled();
+    graph.setLayout(LAYOUT2_TYPE);
+    expect(graph.getLayout()).toBe(LAYOUT2_TYPE);
+    expect(layout1.destroy).toHaveBeenCalledTimes(1);
+
+    // set the same layout, ensure not destroyed
+    graph.setLayout(LAYOUT2_TYPE);
+    expect(layout2.destroy).not.toHaveBeenCalled();
+
+    // unset layout
+    graph.setLayout(undefined);
+    expect(layout2.destroy).toHaveBeenCalledTimes(1);
+    // this should be a noop
+    graph.layout();
+  });
+
+  it('should adjust bounds to fit nodes', () => {
+    graph.setBounds(new Rect(0, 0, 100, 100));
+
+    // no change if no nodes
+    graph.fit();
+    expect(graph.getScale()).toBe(1);
+    expect(graph.getBounds()).toEqual({ x: 0, y: 0, width: 100, height: 100 });
+
+    // add 1 node
+    const n1 = new BaseNode();
+    n1.setBounds(new Rect(10, 10, 10, 10));
+    graph.appendChild(n1);
+
+    // centers the node in the view
+    graph.fit();
+    expect(graph.getScale()).toBe(1);
+    expect(graph.getBounds()).toEqual({ x: 35, y: 35, width: 100, height: 100 });
+
+    // increases scale back to 1 if nodes fit
+    graph.setScale(0.25);
+    graph.fit();
+    expect(graph.getScale()).toBe(1);
+    expect(graph.getBounds()).toEqual({ x: 35, y: 35, width: 100, height: 100 });
+
+    // keeps scale above 1 if nodes fit
+    graph.setScale(2);
+    graph.fit();
+    expect(graph.getScale()).toBe(2);
+    expect(graph.getBounds()).toEqual({ x: 20, y: 20, width: 100, height: 100 });
+
+    // decreases scale so that nodes fit
+    graph.setScale(100);
+    graph.fit();
+    expect(graph.getScale()).toBe(10);
+    expect(graph.getBounds()).toEqual({ x: -100, y: -100, width: 100, height: 100 });
+
+    // add another node out of bounds
+    const n2 = new BaseNode();
+    n2.setBounds(new Rect(200, 200, 10, 10));
+    graph.appendChild(n2);
+
+    // adjusts scale as needed to ensure all nodes fit
+    graph.fit();
+    expect(graph.getScale()).toBe(0.5);
+    expect(graph.getBounds()).toEqual({ x: -5, y: -5, width: 100, height: 100 });
+
+    // add some padding
+    graph.fit(20);
+    expect(graph.getScale()).toBe(0.4);
+    expect(graph.getBounds()).toEqual({ x: 6, y: 6, width: 100, height: 100 });
+  });
+
+  it('should pan node into view', () => {
+    const n1 = new BaseNode();
+    graph.appendChild(n1);
+
+    // pan from left
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    n1.setBounds(new Rect(-20, 0, 10, 10));
+    graph.panIntoView(n1);
+    expect(graph.getBounds()).toEqual({ x: 20, y: 0, width: 100, height: 100 });
+
+    // with offset
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    n1.setBounds(new Rect(-20, 0, 10, 10));
+    graph.panIntoView(n1, { offset: 10 });
+    expect(graph.getBounds()).toEqual({ x: 30, y: 0, width: 100, height: 100 });
+
+    // pan from top
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    n1.setBounds(new Rect(0, -20, 10, 10));
+    graph.panIntoView(n1);
+    expect(graph.getBounds()).toEqual({ x: 0, y: 20, width: 100, height: 100 });
+
+    // with offset
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    n1.setBounds(new Rect(0, -20, 10, 10));
+    graph.panIntoView(n1, { offset: 10 });
+    expect(graph.getBounds()).toEqual({ x: 0, y: 30, width: 100, height: 100 });
+
+    // pan from right
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    n1.setBounds(new Rect(110, 0, 10, 10));
+    graph.panIntoView(n1);
+    expect(graph.getBounds()).toEqual({ x: -20, y: 0, width: 100, height: 100 });
+
+    // with offset
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    n1.setBounds(new Rect(110, 0, 10, 10));
+    graph.panIntoView(n1, { offset: 10 });
+    expect(graph.getBounds()).toEqual({ x: -30, y: 0, width: 100, height: 100 });
+
+    // pan from top
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    n1.setBounds(new Rect(0, 110, 10, 10));
+    graph.panIntoView(n1);
+    expect(graph.getBounds()).toEqual({ x: 0, y: -20, width: 100, height: 100 });
+
+    // with offset
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    n1.setBounds(new Rect(0, 110, 10, 10));
+    graph.panIntoView(n1, { offset: 10 });
+    expect(graph.getBounds()).toEqual({ x: 0, y: -30, width: 100, height: 100 });
+  });
+
+  it('should pan node into view taking into account minimum visibile ', () => {
+    const n1 = new BaseNode();
+    graph.appendChild(n1);
+
+    // pan from left / top
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    n1.setBounds(new Rect(-7, -7, 10, 10));
+    graph.panIntoView(n1, { minimumVisible: 3 });
+    expect(graph.getBounds()).toEqual({ x: 0, y: 0, width: 100, height: 100 });
+
+    n1.setBounds(new Rect(-8, -8, 10, 10));
+    graph.panIntoView(n1, { minimumVisible: 3 });
+    expect(graph.getBounds()).toEqual({ x: 8, y: 8, width: 100, height: 100 });
+
+    // pan from right / bottom
+    graph.setBounds(new Rect(0, 0, 100, 100));
+    n1.setBounds(new Rect(97, 97, 10, 10));
+    graph.panIntoView(n1, { minimumVisible: 3 });
+    expect(graph.getBounds()).toEqual({ x: 0, y: 0, width: 100, height: 100 });
+
+    n1.setBounds(new Rect(98, 98, 10, 10));
+    graph.panIntoView(n1, { minimumVisible: 3 });
+    expect(graph.getBounds()).toEqual({ x: -8, y: -8, width: 100, height: 100 });
+  });
+
+  it('should set model layout', () => {
+    const layoutType = 'test';
+    const controller = new Visualization();
+    controller.setGraph(graph);
+    controller.registerLayoutFactory((type) => {
+      return type === layoutType ? new TestLayout() : undefined;
+    });
+
+    const model: GraphModel = {
+      id: 'g',
+      type: ModelKind.graph,
+      layout: layoutType,
+    };
+    graph.setModel(model);
+    expect(graph.getLayout()).toBe(model.layout);
+  });
+
+  it('should set model scale', () => {
+    const model: GraphModel = {
+      id: 'g',
+      type: ModelKind.graph,
+      scale: 5,
+    };
+    graph.setModel(model);
+    expect(graph.getScale()).toBe(model.scale);
+  });
+
+  it('should set model x, y', () => {
+    const model1: GraphModel = {
+      id: 'g',
+      type: ModelKind.graph,
+      x: 10,
+    };
+    graph.setModel(model1);
+    expect(graph.getBounds().x).toBe(model1.x);
+
+    const model2: GraphModel = {
+      id: 'g',
+      type: ModelKind.graph,
+      y: 20,
+    };
+    graph.setModel(model2);
+    expect(graph.getBounds().x).toBe(model1.x);
+    expect(graph.getBounds().y).toBe(model2.y);
+
+    const model3: GraphModel = {
+      id: 'g',
+      type: ModelKind.graph,
+      x: 2,
+      y: 3,
+    };
+    graph.setModel(model3);
+    expect(graph.getBounds().x).toBe(model3.x);
+    expect(graph.getBounds().y).toBe(model3.y);
+  });
+
+  it('should not support translate', () => {
+    graph.setBounds(new Rect(10, 20, 30, 40));
+    const p = new Point(5, 6);
+    graph.translateFromAbsolute(p);
+    expect(p).toEqual({ x: 5, y: 6 });
+
+    graph.translateToParent(p);
+    expect(p).toEqual({ x: 5, y: 6 });
   });
 });

--- a/frontend/packages/topology/src/elements/__tests__/defaultElementFactory.spec.ts
+++ b/frontend/packages/topology/src/elements/__tests__/defaultElementFactory.spec.ts
@@ -1,0 +1,13 @@
+import defaultElementFactory from '../defaultElementFactory';
+import { ModelKind } from '../../types';
+import BaseGraph from '../BaseGraph';
+import BaseNode from '../BaseNode';
+import BaseEdge from '../BaseEdge';
+
+describe('defaultElementFactory', () => {
+  it('should create base elements', () => {
+    expect(defaultElementFactory(ModelKind.graph, '') instanceof BaseGraph).toBe(true);
+    expect(defaultElementFactory(ModelKind.node, '') instanceof BaseNode).toBe(true);
+    expect(defaultElementFactory(ModelKind.edge, '') instanceof BaseEdge).toBe(true);
+  });
+});

--- a/frontend/packages/topology/src/geom/Rect.ts
+++ b/frontend/packages/topology/src/geom/Rect.ts
@@ -37,10 +37,6 @@ export default class Rect implements Translatable {
     return this.width <= 0 || this.height <= 0;
   }
 
-  getLocation(): Point {
-    return new Point(this.x, this.y);
-  }
-
   setLocation(x: number, y: number): Rect {
     this.x = x;
     this.y = y;
@@ -104,7 +100,7 @@ export default class Rect implements Translatable {
     return this;
   }
 
-  expand(v: number, h: number): Rect {
+  expand(h: number, v: number): Rect {
     this.y -= v;
     this.height += v * 2;
     this.x -= h;
@@ -122,7 +118,7 @@ export default class Rect implements Translatable {
       } else if (padding.length === 1) {
         this.expand(padding[0], padding[0]);
       } else if (padding.length === 2) {
-        this.expand(padding[0], padding[1]);
+        this.expand(padding[1], padding[0]);
       } else if (padding.length === 3) {
         this.y -= padding[0];
         this.height += padding[0] + padding[2];

--- a/frontend/packages/topology/src/geom/__tests__/Point.spec.ts
+++ b/frontend/packages/topology/src/geom/__tests__/Point.spec.ts
@@ -1,0 +1,68 @@
+import Point from '../Point';
+
+describe('Point', () => {
+  it('should provide an empty instance', () => {
+    expect(Point.EMPTY).toEqual({ x: 0, y: 0 });
+  });
+
+  it('should re-use single use instance', () => {
+    expect(Point.singleUse()).toBe(Point.singleUse());
+    expect(Point.singleUse()).toEqual({ x: 0, y: 0 });
+    expect(Point.singleUse(1)).toEqual({ x: 1, y: 0 });
+    expect(Point.singleUse(1, 2)).toEqual({ x: 1, y: 2 });
+  });
+
+  it('should create a new Point from existing Point', () => {
+    const p1 = new Point(5, 10);
+    const p2 = Point.fromPoint(p1);
+    expect(p1).not.toBe(p2);
+    expect(p1).toEqual(p2);
+  });
+
+  it('should create a Point', () => {
+    expect(new Point()).toEqual({ x: 0, y: 0 });
+    expect(new Point(1)).toEqual({ x: 1, y: 0 });
+    expect(new Point(1, 2)).toEqual({ x: 1, y: 2 });
+  });
+
+  it('should set location', () => {
+    const p = new Point(5, 10);
+    expect(p.setLocation(2, 3)).toBe(p);
+    expect(p).toEqual({ x: 2, y: 3 });
+  });
+
+  it('should negate point', () => {
+    const p = new Point(5, 10);
+    expect(p.negate()).toBe(p);
+    expect(p).toEqual({ x: -5, y: -10 });
+  });
+
+  it('should translate point', () => {
+    const p = new Point(5, 10);
+    expect(p.translate(2, 3)).toBe(p);
+    expect(p).toEqual({ x: 7, y: 13 });
+  });
+
+  it('should scale point', () => {
+    const p = new Point(5, 10);
+    expect(p.scale(2)).toBe(p);
+    expect(p).toEqual({ x: 10, y: 20 });
+    p.scale(1.5, 2);
+    expect(p).toEqual({ x: 15, y: 40 });
+  });
+
+  it('should clone point', () => {
+    const p1 = new Point(5, 10);
+    const p2 = p1.clone();
+    expect(p1).not.toBe(p2);
+    expect(p1).toEqual(p2);
+  });
+
+  it('should check point equality', () => {
+    const p1 = new Point(5, 10);
+    const p2 = new Point(5, 10);
+    const p3 = new Point(1, 2);
+    expect(p1.equals(p2)).toBe(true);
+    expect(p1.equals(p3)).toBe(false);
+  });
+});

--- a/frontend/packages/topology/src/geom/__tests__/Rect.spec.ts
+++ b/frontend/packages/topology/src/geom/__tests__/Rect.spec.ts
@@ -1,0 +1,140 @@
+import Rect from '../Rect';
+
+describe('Rect', () => {
+  it('should provide an empty instance', () => {
+    expect(Rect.EMPTY).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+  });
+
+  it('should re-use single use instance', () => {
+    expect(Rect.singleUse()).toBe(Rect.singleUse());
+    expect(Rect.singleUse()).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+    expect(Rect.singleUse(1)).toEqual({ x: 1, y: 0, width: 0, height: 0 });
+    expect(Rect.singleUse(1, 2)).toEqual({ x: 1, y: 2, width: 0, height: 0 });
+    expect(Rect.singleUse(1, 2, 3)).toEqual({ x: 1, y: 2, width: 3, height: 0 });
+    expect(Rect.singleUse(1, 2, 3, 4)).toEqual({ x: 1, y: 2, width: 3, height: 4 });
+  });
+
+  it('should create a new Rect from existing Rect', () => {
+    const r1 = new Rect(5, 10, 2, 4);
+    const r2 = Rect.fromRect(r1);
+    expect(r1).not.toBe(r2);
+    expect(r1).toEqual(r2);
+  });
+
+  it('should create a Rect', () => {
+    expect(new Rect()).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+    expect(new Rect(1)).toEqual({ x: 1, y: 0, width: 0, height: 0 });
+    expect(new Rect(1, 2, 3)).toEqual({ x: 1, y: 2, width: 3, height: 0 });
+    expect(new Rect(1, 2, 3, 4)).toEqual({ x: 1, y: 2, width: 3, height: 4 });
+  });
+
+  it('should be empty if no height or width', () => {
+    expect(new Rect().isEmpty()).toBe(true);
+    expect(new Rect(0, 0, 1, 0).isEmpty()).toBe(true);
+    expect(new Rect(0, 0, 0, 1).isEmpty()).toBe(true);
+    expect(new Rect(0, 0, 1, 1).isEmpty()).toBe(false);
+  });
+
+  it('should set location', () => {
+    const r = new Rect(5, 10, 8, 9);
+    expect(r.setLocation(2, 3)).toBe(r);
+    expect(r).toEqual({ x: 2, y: 3, width: 8, height: 9 });
+  });
+
+  it('should set size', () => {
+    const r = new Rect(5, 10, 8, 9);
+    expect(r.setSize(2, 3)).toBe(r);
+    expect(r).toEqual({ x: 5, y: 10, width: 2, height: 3 });
+  });
+
+  it('should set center', () => {
+    const r = new Rect(6, 10, 20, 30);
+    expect(r.setCenter(10, 30)).toBe(r);
+    expect(r).toEqual({ x: 0, y: 15, width: 20, height: 30 });
+  });
+
+  it('should get center', () => {
+    const r = new Rect(6, 10, 10, 16);
+    expect(r.getCenter()).toEqual({ x: 11, y: 18 });
+  });
+
+  it('should translate rect', () => {
+    const r = new Rect(5, 10, 3, 4);
+    expect(r.translate(2, 3)).toBe(r);
+    expect(r).toEqual({ x: 7, y: 13, width: 3, height: 4 });
+  });
+
+  it('should scale rect', () => {
+    const r = new Rect(5, 10, 4, 6);
+    expect(r.scale(2)).toBe(r);
+    expect(r).toEqual({ x: 10, y: 20, width: 8, height: 12 });
+    r.scale(0.5, 2);
+    expect(r).toEqual({ x: 5, y: 40, width: 4, height: 24 });
+  });
+
+  it('should resize', () => {
+    const r = new Rect(5, 10, 8, 9);
+    expect(r.resize(2, 3)).toBe(r);
+    expect(r).toEqual({ x: 5, y: 10, width: 10, height: 12 });
+  });
+
+  it('should get the bottom y coordinate', () => {
+    const r = new Rect(5, 10, 8, 9);
+    expect(r.bottom()).toBe(19);
+  });
+
+  it('should get the right x coordinate', () => {
+    const r = new Rect(5, 10, 8, 9);
+    expect(r.right()).toBe(13);
+  });
+
+  it('should expand the rect in size', () => {
+    const r = new Rect(5, 10, 8, 9);
+    expect(r.right()).toBe(13);
+  });
+
+  it('should expand the rect to enclose another rect', () => {
+    const r = new Rect(5, 10, 8, 9);
+    expect(r.union(new Rect(2, 12, 4, 27))).toBe(r);
+    expect(r).toEqual({ x: 2, y: 10, width: 11, height: 29 });
+  });
+
+  it('should expand the rect in size', () => {
+    const r = new Rect(5, 10, 8, 9);
+    expect(r.expand(4, 5)).toBe(r);
+    expect(r).toEqual({ x: 1, y: 5, width: 16, height: 19 });
+  });
+
+  it('should set padding according to css shorthand rules', () => {
+    const r = new Rect(5, 10, 8, 9);
+    expect(r.padding()).toBe(r);
+    expect(r.padding()).toEqual({ x: 5, y: 10, width: 8, height: 9 });
+    expect(r.padding(undefined)).toEqual({ x: 5, y: 10, width: 8, height: 9 });
+    expect(r.clone().padding(5)).toEqual({ x: 0, y: 5, width: 18, height: 19 });
+    expect(r.clone().padding([5])).toEqual({ x: 0, y: 5, width: 18, height: 19 });
+    expect(r.clone().padding([5, 2])).toEqual({ x: 3, y: 5, width: 12, height: 19 });
+    expect(r.clone().padding([5, 2, 4])).toEqual({ x: 5, y: 5, width: 10, height: 18 });
+    expect(r.clone().padding([5, 2, 4, 6])).toEqual({ x: 3, y: 5, width: 16, height: 18 });
+  });
+
+  it('should set bounds', () => {
+    const r = new Rect(5, 10, 8, 9);
+    expect(r.setBounds(2, 3, 6, 7)).toBe(r);
+    expect(r).toEqual({ x: 2, y: 3, width: 6, height: 7 });
+  });
+
+  it('should clone rect', () => {
+    const r1 = new Rect(5, 10);
+    const r2 = r1.clone();
+    expect(r1).not.toBe(r2);
+    expect(r1).toEqual(r2);
+  });
+
+  it('should check rect equality', () => {
+    const r1 = new Rect(5, 10, 1, 2);
+    const r2 = new Rect(5, 10, 1, 2);
+    const r3 = new Rect(1, 2, 3, 4);
+    expect(r1.equals(r2)).toBe(true);
+    expect(r1.equals(r3)).toBe(false);
+  });
+});

--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -156,7 +156,7 @@ export interface Graph<E extends GraphModel = GraphModel, D = any> extends Graph
   reset(): void;
   scaleBy(scale: number, location?: Point): void;
   fit(padding?: number): void;
-  panIntoView(element: Node, options: { offset?: number; minimumVisible?: number }): void;
+  panIntoView(element: Node, options?: { offset?: number; minimumVisible?: number }): void;
 }
 
 export const isGraph = (element: GraphElement): element is Graph => {


### PR DESCRIPTION
Increasing test coverage for topology package.
Also, fixed how `offset` was being used in various anchor files.

**Unit test coverage report**: 
before:
![image](https://user-images.githubusercontent.com/14068621/76654024-6a108000-6540-11ea-8ae7-5c3002282e50.png)

after:
![image](https://user-images.githubusercontent.com/14068621/76653906-1aca4f80-6540-11ea-840d-87547881da64.png)