### PR TITLE
Bug 1813707: Fix Pipeline Builder paramters of type Array

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarName.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarName.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { FormGroup, TextInput, TextInputTypes } from '@patternfly/react-core';
+import { SidebarInputWrapper } from './temp-utils';
 
 type TaskSidebarNameProps = {
   initialName: string;
@@ -35,23 +36,25 @@ const TaskSidebarName: React.FC<TaskSidebarNameProps> = (props) => {
       isValid={isValid}
       isRequired
     >
-      <TextInput
-        id="task-name"
-        isValid={isValid}
-        isRequired
-        onChange={(value) => {
-          setInterimName(value);
-          setError(getError(value));
-        }}
-        onBlur={() => {
-          if (isValid) {
-            onChange(interimName);
-          }
-        }}
-        placeholder={taskName}
-        type={TextInputTypes.text}
-        value={interimName}
-      />
+      <SidebarInputWrapper>
+        <TextInput
+          id="task-name"
+          isValid={isValid}
+          isRequired
+          onChange={(value) => {
+            setInterimName(value);
+            setError(getError(value));
+          }}
+          onBlur={() => {
+            if (isValid) {
+              onChange(interimName);
+            }
+          }}
+          placeholder={taskName}
+          type={TextInputTypes.text}
+          value={interimName}
+        />
+      </SidebarInputWrapper>
     </FormGroup>
   );
 };

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { FormGroup, TextInput } from '@patternfly/react-core';
+import { FormGroup } from '@patternfly/react-core';
 import { PipelineResourceTaskParam, PipelineTaskParam } from '../../../../utils/pipeline-augment';
+import { ArrayParam, ParameterProps, SidebarInputWrapper, StringParam } from './temp-utils';
 
 type TaskSidebarParamProps = {
   hasParamError?: boolean;
@@ -13,31 +14,36 @@ const TaskSidebarParam: React.FC<TaskSidebarParamProps> = (props) => {
   const { hasParamError, onChange, resourceParam, taskParam } = props;
   const [dirty, setDirty] = React.useState(false);
 
-  const currentValue = taskParam?.value?.toString() || '';
+  const currentValue = taskParam?.value;
   const emptyIsInvalid = !resourceParam.default;
 
-  const isValid = !(dirty && hasParamError && emptyIsInvalid && currentValue === '');
+  const isValid = !(dirty && hasParamError && emptyIsInvalid && currentValue != null);
+
+  const paramRenderProps: ParameterProps = {
+    currentValue,
+    defaultValue: resourceParam.default,
+    isValid,
+    name: resourceParam.name,
+    onChange,
+    setDirty,
+  };
 
   return (
     <FormGroup
       fieldId={resourceParam.name}
       label={resourceParam.name}
-      helperText={resourceParam.description}
+      helperText={resourceParam.type === 'string' ? resourceParam.description : null}
       helperTextInvalid="Required"
       isValid={isValid}
       isRequired={emptyIsInvalid}
     >
-      <TextInput
-        id={resourceParam.name}
-        isValid={isValid}
-        isRequired={!resourceParam.default}
-        onBlur={() => setDirty(true)}
-        onChange={(value) => {
-          onChange(value);
-        }}
-        placeholder={resourceParam.default}
-        value={currentValue}
-      />
+      {resourceParam.type === 'array' ? (
+        <ArrayParam {...paramRenderProps} description={resourceParam.description} />
+      ) : (
+        <SidebarInputWrapper>
+          <StringParam {...paramRenderProps} />
+        </SidebarInputWrapper>
+      )}
     </FormGroup>
   );
 };

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarResource.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarResource.tsx
@@ -6,6 +6,7 @@ import {
   PipelineResourceTaskResource,
   PipelineTaskResource,
 } from '../../../../utils/pipeline-augment';
+import { SidebarInputWrapper } from './temp-utils';
 
 type TaskSidebarResourceProps = {
   availableResources: PipelineResource[];
@@ -32,19 +33,21 @@ const TaskSidebarResource: React.FC<TaskSidebarResourceProps> = (props) => {
       isValid={dropdownResources.length > 0}
       isRequired
     >
-      <Dropdown
-        title={`Select ${resource.type} resource...`}
-        items={dropdownResources.reduce((acc, { name }) => ({ ...acc, [name]: name }), {})}
-        disabled={dropdownResources.length === 0}
-        selectedKey={taskResource?.resource || ''}
-        dropDownClassName="dropdown--full-width"
-        onChange={(value: string) => {
-          onChange(
-            resource.name,
-            dropdownResources.find(({ name }) => name === value),
-          );
-        }}
-      />
+      <SidebarInputWrapper>
+        <Dropdown
+          title={`Select ${resource.type} resource...`}
+          items={dropdownResources.reduce((acc, { name }) => ({ ...acc, [name]: name }), {})}
+          disabled={dropdownResources.length === 0}
+          selectedKey={taskResource?.resource || ''}
+          dropDownClassName="dropdown--full-width"
+          onChange={(value: string) => {
+            onChange(
+              resource.name,
+              dropdownResources.find(({ name }) => name === value),
+            );
+          }}
+        />
+      </SidebarInputWrapper>
     </FormGroup>
   );
 };

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/temp-utils.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/temp-utils.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { MinusCircleIcon } from '@patternfly/react-icons';
+import { global_disabled_color_200 as disabledColor } from '@patternfly/react-tokens';
+import { Flex, FlexItem, FlexModifiers, TextInput } from '@patternfly/react-core';
+import MultiColumnFieldFooter from '@console/shared/src/components/formik-fields/multi-column-field/MultiColumnFieldFooter';
+
+export type ParamValueType = string | string[];
+export type ParameterProps = {
+  currentValue: ParamValueType;
+  defaultValue: ParamValueType;
+  description?: string;
+  isValid: boolean;
+  name: string;
+  onChange: (value: ParamValueType) => void;
+  setDirty: (dirty: boolean) => void;
+};
+
+export const StringParam: React.FC<ParameterProps> = (props) => {
+  const { currentValue, defaultValue, isValid, name, onChange, setDirty } = props;
+
+  return (
+    <TextInput
+      id={name}
+      isValid={isValid}
+      isRequired={!defaultValue}
+      onBlur={() => setDirty(true)}
+      onChange={(value) => {
+        onChange(value);
+      }}
+      placeholder={defaultValue as string}
+      value={(currentValue || '') as string}
+    />
+  );
+};
+
+export const ArrayParam: React.FC<ParameterProps> = (props) => {
+  const { currentValue, defaultValue, description, name, onChange, setDirty } = props;
+
+  const values = (currentValue || defaultValue || ['']) as string[];
+
+  return (
+    <>
+      {values.map((value, index) => {
+        return (
+          <Flex
+            key={`${index.toString()}`}
+            style={{ marginBottom: 'var(--pf-global--spacer--xs)' }}
+          >
+            <FlexItem breakpointMods={[{ modifier: FlexModifiers.grow }]}>
+              <StringParam
+                {...props}
+                name={`${name}-${index}`}
+                currentValue={value}
+                onChange={(changedValue: string) => {
+                  const newValues: string[] = [...values];
+                  newValues[index] = changedValue;
+                  onChange(newValues);
+                }}
+              />
+            </FlexItem>
+            <FlexItem>
+              <MinusCircleIcon
+                aria-hidden="true"
+                style={{ color: values.length === 1 ? disabledColor.value : null }}
+                onClick={() => {
+                  if (values.length === 1) {
+                    return;
+                  }
+
+                  setDirty(true);
+                  setTimeout(
+                    () => onChange([...values.slice(0, index), ...values.slice(index + 1)]),
+                    0,
+                  );
+                }}
+              />
+            </FlexItem>
+          </Flex>
+        );
+      })}
+      <p
+        className="pf-c-form__helper-text"
+        style={{ marginBottom: 'var(--pf-global--spacer--sm)' }}
+      >
+        {description}
+      </p>
+      <MultiColumnFieldFooter
+        addLabel="Add another value"
+        onAdd={() => {
+          setDirty(true);
+          onChange([...values, '']);
+        }}
+      />
+    </>
+  );
+};
+
+export const SidebarInputWrapper: React.FC = ({ children }) => {
+  return <div style={{ width: 'calc(100% - 28px)' }}>{children}</div>;
+};


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3188

**Analysis / Root cause**: 
Pipeline Builder expected all parameters to be of type string - when dealing with array parameters, it mangled the type and caused the Tasks that used array not to work with the Pipeline Builder

**Solution Description**: 
Implemented a toggle to show an array-like component.

Issues with the foundation of the Pipeline Builder - a Formik component could not be cleanly used. A hack is being placed for the meantime as we work to fix the validation foundation in [ODC-3165](https://issues.redhat.com/browse/ODC-3165).

**Screen shots / Gifs for design review**: 

![Screen Shot 2020-03-15 at 12 00 57 PM](https://user-images.githubusercontent.com/8126518/76705446-77e81180-66b6-11ea-9dd3-eca58cdd751c.png)

@serenamarie125 
@openshift/team-devconsole-ux

**Unit test coverage report**: 

No tests exist at this time but are being added with ODC-3165.

**Test setup:**

* OpenShift Pipeline Operator installed
* Look at `openshift-client` for the array parameter
* Modify / Create a ClusterTask to see multiple different types together

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug