### PR TITLE
[release-4.3] Bug 1813933: Correct the selection nodes text 

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-form.tsx
@@ -44,6 +44,10 @@ export const CreateOCSServiceForm: React.FC<CreateOCSServiceFormProps> = ({
           <p className="co-legend co-required ceph-ocs-desc__legend">
             Select at least 3 nodes in different failure domains you wish to use.
           </p>
+          <p>
+            3 selected nodes are used for initial deployment. The remaining selected nodes will be
+            used by OpenShift as scheduling targets for OCS scaling.
+          </p>
           <ListPage kind={NodeModel.kind} showTitle={false} ListComponent={ListComponent} />
         </div>
       </form>


### PR DESCRIPTION
The cherry-pick failed for #4685 due to the conflicts.

Reason for conflict: 
* PF4 Title component is used in `create-form.txt` file in 4.4 + instead of div in 4.3
* Object destructuring for props in component that was not used in 4.3

Hence creating a PR manually by:
1, cherry-picking the commit from 4.4 b4ea44218b0848c3f0d30eba2d8725367b10c997 in this commit (283af0c7181bde71bd3b2aaa44099331b02a074c)
2. resolving the conflicts in a reconciliation commit (283af0c7181bde71bd3b2aaa44099331b02a074c) separately 

