### PR TITLE
add pipeline resource link in the pipeline run details page

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunDetails.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunDetails.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
+import { SectionHeading, ResourceSummary, ResourceLink } from '@console/internal/components/utils';
+import { referenceForModel } from '@console/internal/module/k8s';
 import PipelineRunVisualization from './PipelineRunVisualization';
 import { PipelineRun } from '../../../utils/pipeline-augment';
+import { PipelineModel } from '../../../models';
 
 export interface PipelineRunDetailsProps {
   obj: PipelineRun;
@@ -15,6 +17,18 @@ export const PipelineRunDetails: React.FC<PipelineRunDetailsProps> = ({ obj: pip
       <div className="row">
         <div className="col-sm-6">
           <ResourceSummary resource={pipelineRun} />
+        </div>
+        <div className="col-sm-6">
+          <dl>
+            <dt>Pipeline</dt>
+            <dd>
+              <ResourceLink
+                kind={referenceForModel(PipelineModel)}
+                name={pipelineRun.spec.pipelineRef.name}
+                namespace={pipelineRun.metadata.namespace}
+              />
+            </dd>
+          </dl>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-2384

**Analysis / Root cause:**
There is no way to navigate to an associated Pipeline of the Pipeline Run.

**Solution Description:**
Added a link to the Pipeline Run Details tab which takes the user back to the Pipeline Details associated with that Pipeline Run.

**GIF:**
![pipeline-resurce-link](https://user-images.githubusercontent.com/22490998/76775974-28940500-67cc-11ea-8e9a-c62ae9bfce8e.gif)

**Browser conformance:**
 - [x] Chrome
 - [x] Firefox
 - [ ] Safari
 - [ ] Edge

