### PR TITLE
Add sticky footer in the Add flow forms

### DIFF
--- a/frontend/packages/console-shared/src/components/form-utils/FormFooter.scss
+++ b/frontend/packages/console-shared/src/components/form-utils/FormFooter.scss
@@ -1,3 +1,8 @@
 .ocs-form-footer {
   padding: var(--pf-global--spacer--md) 0;
+  &__sticky {
+    position: sticky;
+    background: var(--pf-chart-global--Fill--Color--white);
+    bottom: 0;
+  }
 }

--- a/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/FormFooter.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as cx from 'classnames';
 import { ActionGroup, Alert, Button, ButtonVariant } from '@patternfly/react-core';
 import { ButtonBar } from '@console/internal/components/utils';
 import { FormFooterProps } from './form-utils-types';
@@ -18,9 +19,12 @@ const FormFooter: React.FC<FormFooterProps> = ({
   successMessage,
   disableSubmit,
   showAlert,
+  sticky,
 }) => (
   <ButtonBar
-    className="ocs-form-footer"
+    className={cx('ocs-form-footer', {
+      'ocs-form-footer__sticky': sticky,
+    })}
     inProgress={isSubmitting}
     errorMessage={errorMessage}
     successMessage={successMessage}
@@ -36,16 +40,27 @@ const FormFooter: React.FC<FormFooterProps> = ({
         {...(handleSubmit && { onClick: handleSubmit })}
         variant={ButtonVariant.primary}
         isDisabled={disableSubmit}
+        data-test-id="submit-button"
       >
         {submitLabel}
       </Button>
       {handleReset && (
-        <Button type="button" variant={ButtonVariant.secondary} onClick={handleReset}>
+        <Button
+          type="button"
+          data-test-id="reset-button"
+          variant={ButtonVariant.secondary}
+          onClick={handleReset}
+        >
           {resetLabel}
         </Button>
       )}
       {handleCancel && (
-        <Button type="button" variant={ButtonVariant.secondary} onClick={handleCancel}>
+        <Button
+          type="button"
+          data-test-id="cancel-button"
+          variant={ButtonVariant.secondary}
+          onClick={handleCancel}
+        >
           {cancelLabel}
         </Button>
       )}

--- a/frontend/packages/console-shared/src/components/form-utils/__tests__/FormFooter.spec.tsx
+++ b/frontend/packages/console-shared/src/components/form-utils/__tests__/FormFooter.spec.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { FormFooter } from '@console/shared';
+import { Button } from '@patternfly/react-core';
+
+type FormFooterProps = React.ComponentProps<typeof FormFooter>;
+describe('FormFooter', () => {
+  let wrapper: ShallowWrapper<any>;
+  let props: FormFooterProps;
+  const className = 'ocs-form-footer';
+  beforeEach(() => {
+    props = {
+      errorMessage: 'error',
+      submitLabel: 'Create',
+      resetLabel: 'Reset',
+      cancelLabel: 'Cancel',
+      handleReset: jest.fn(),
+      handleCancel: jest.fn(),
+      sticky: false,
+      disableSubmit: false,
+      isSubmitting: false,
+    };
+    wrapper = shallow(<FormFooter {...props} />);
+  });
+
+  it('should contain submit, reset and cancel button', () => {
+    const submitButton = wrapper.find('[data-test-id="submit-button"]');
+    const resetButton = wrapper.find('[data-test-id="reset-button"]');
+    expect(wrapper.find(Button)).toHaveLength(3);
+    expect(submitButton.exists()).toBe(true);
+    expect(resetButton.exists()).toBe(true);
+  });
+
+  it('should contain right lables in the submit and reset button', () => {
+    expect(wrapper.find('[data-test-id="submit-button"]').props().children).toBe('Create');
+    expect(wrapper.find('[data-test-id="reset-button"]').props().children).toBe('Reset');
+    expect(wrapper.find('[data-test-id="cancel-button"]').props().children).toBe('Cancel');
+  });
+
+  it('should be able to configure data-test-id and labels', () => {
+    wrapper.setProps({
+      submitLabel: 'submit-lbl',
+      resetLabel: 'reset-lbl',
+      cancelLabel: 'cancel-lbl',
+    });
+    expect(wrapper.find('[type="submit"]').props().children).toBe('submit-lbl');
+    expect(wrapper.find('[data-test-id="reset-button"]').props().children).toBe('reset-lbl');
+    expect(wrapper.find('[data-test-id="cancel-button"]').props().children).toBe('cancel-lbl');
+  });
+
+  it('should be able to make the action buttons sticky', () => {
+    wrapper.setProps({
+      sticky: true,
+    });
+    expect(wrapper.at(0).props().className).toBe(`${className} ${className}__sticky`);
+  });
+
+  it('should have submit button when handle submit is not passed', () => {
+    expect(wrapper.find('[data-test-id="submit-button"]').props().type).toBe('submit');
+  });
+
+  it('should not have submit button when handle submit callback is passed', () => {
+    const additionalProps = { handleSubmit: jest.fn() };
+    wrapper.setProps(additionalProps);
+    expect(wrapper.find('[data-test-id="submit-button"]').props().type).not.toBe('submit');
+  });
+
+  it('should call the handler when a button is clicked', () => {
+    const additionalProps = { handleSubmit: jest.fn() };
+    wrapper.setProps(additionalProps);
+    wrapper.find('[data-test-id="submit-button"]').simulate('click');
+    expect(additionalProps.handleSubmit).toHaveBeenCalled();
+
+    wrapper.find('[data-test-id="reset-button"]').simulate('click');
+    expect(props.handleReset).toHaveBeenCalled();
+
+    wrapper.find('[data-test-id="cancel-button"]').simulate('click');
+    expect(props.handleCancel).toHaveBeenCalled();
+  });
+});

--- a/frontend/packages/console-shared/src/components/form-utils/form-utils-types.ts
+++ b/frontend/packages/console-shared/src/components/form-utils/form-utils-types.ts
@@ -2,6 +2,7 @@ export interface FormFooterProps {
   handleSubmit?: () => void;
   handleReset?: () => void;
   handleCancel?: () => void;
+  sticky?: boolean;
   submitLabel?: string;
   resetLabel?: string;
   cancelLabel?: string;

--- a/frontend/packages/dev-console/integration-tests/tests/git-import-flow.scenario.ts
+++ b/frontend/packages/dev-console/integration-tests/tests/git-import-flow.scenario.ts
@@ -15,6 +15,7 @@ import {
 } from '../views/git-import-flow.view';
 import { newApplicationName, newAppName } from '../views/new-app-name.view';
 import { switchPerspective, Perspective, sideHeader } from '../views/dev-perspective.view';
+import { scrollIntoView } from '../utils/page';
 
 describe('git import flow', () => {
   let newApplication;
@@ -43,6 +44,7 @@ describe('git import flow', () => {
     expect(importFromGitHeader.getText()).toContain('Import from git');
     await enterGitRepoUrl('https://github.com/sclorg/nodejs-ex.git');
 
+    scrollIntoView(appName);
     await appName.click();
     expect(appName.getAttribute('value')).toContain('nodejs-ex-git');
     await addApplication(newApplication, newApp);

--- a/frontend/packages/dev-console/integration-tests/utils/page.ts
+++ b/frontend/packages/dev-console/integration-tests/utils/page.ts
@@ -1,0 +1,7 @@
+import { browser } from 'protractor';
+
+export const scrollIntoView = (el) => {
+  browser.executeScript((element) => {
+    element.scrollIntoView();
+  }, el.getWebElement());
+};

--- a/frontend/packages/dev-console/integration-tests/views/git-import-flow.view.ts
+++ b/frontend/packages/dev-console/integration-tests/views/git-import-flow.view.ts
@@ -20,7 +20,9 @@ export const builderImage = element(
   by.cssContainingText('.pf-c-card.odc-builder-image-card', 'Node.js'),
 );
 export const buildImageVersion = element(by.id('form-dropdown-image-tag-field'));
-export const createButton = element(by.css('[data-test-id="import-git-create-button"]'));
+export const createButton = element(by.css('[data-test-id="import-git-form"]')).element(
+  by.css('[data-test-id="submit-button"]'),
+);
 export const builderImageVersionName = element(by.id('8-link'));
 
 export const navigateImportFromGit = async function() {

--- a/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImageForm.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { FormikProps, FormikValues } from 'formik';
-import { ButtonBar } from '@console/internal/components/utils';
-import { Form, ActionGroup, ButtonVariant, Button } from '@patternfly/react-core';
+import { FormFooter } from '@console/shared/src/components/form-utils';
+import { Form } from '@patternfly/react-core';
 import { DeployImageFormProps } from './import-types';
 import ImageSearchSection from './image-search/ImageSearchSection';
 import AppSection from './app/AppSection';
@@ -19,7 +19,7 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
   dirty,
   projects,
 }) => (
-  <Form className="co-deploy-image" onSubmit={handleSubmit}>
+  <Form className="co-deploy-image" data-test-id="deploy-image-form" onSubmit={handleSubmit}>
     <ImageSearchSection />
     <AppSection
       project={values.project}
@@ -27,21 +27,15 @@ const DeployImageForm: React.FC<FormikProps<FormikValues> & DeployImageFormProps
     />
     <ResourceSection />
     <AdvancedSection values={values} />
-    <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
-      <ActionGroup className="pf-c-form">
-        <Button
-          type="submit"
-          variant={ButtonVariant.primary}
-          isDisabled={!dirty || !_.isEmpty(errors)}
-          data-test-id="deploy-image-form-submit-btn"
-        >
-          Create
-        </Button>
-        <Button type="button" variant={ButtonVariant.secondary} onClick={handleReset}>
-          Cancel
-        </Button>
-      </ActionGroup>
-    </ButtonBar>
+    <FormFooter
+      handleReset={handleReset}
+      errorMessage={status && status.submitError}
+      isSubmitting={isSubmitting}
+      submitLabel="Create"
+      sticky
+      disableSubmit={!dirty || !_.isEmpty(errors)}
+      resetLabel="Cancel"
+    />
   </Form>
 );
 

--- a/frontend/packages/dev-console/src/components/import/DeployImagePage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImagePage.tsx
@@ -19,7 +19,7 @@ const DeployImagePage: React.FunctionComponent<DeployImagePageProps> = ({ match,
         <title>Deploy Image</title>
       </Helmet>
       <PageHeading title="Deploy Image" />
-      <div className="co-m-pane__body">
+      <div className="co-m-pane__body" style={{ paddingBottom: 0 }}>
         <QueryFocusApplication>
           {(desiredApplication) => (
             <Firehose resources={[{ kind: 'Project', prop: 'projects', isList: true }]}>

--- a/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/GitImportForm.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { Form, ActionGroup, ButtonVariant, Button } from '@patternfly/react-core';
+import { Form } from '@patternfly/react-core';
 import { FormikProps, FormikValues } from 'formik';
-import { ButtonBar } from '@console/internal/components/utils';
+import { FormFooter } from '@console/shared/src/components/form-utils';
 import { GitImportFormProps } from './import-types';
 import GitSection from './git/GitSection';
 import BuilderSection from './builder/BuilderSection';
@@ -23,7 +23,7 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
   dirty,
   projects,
 }) => (
-  <Form onSubmit={handleSubmit}>
+  <Form onSubmit={handleSubmit} data-test-id="import-git-form">
     <GitSection />
     <BuilderSection image={values.image} builderImages={builderImages} />
     <DockerSection buildStrategy={values.build.strategy} />
@@ -34,21 +34,15 @@ const GitImportForm: React.FC<FormikProps<FormikValues> & GitImportFormProps> = 
     <PipelineSection />
     <ResourceSection />
     <AdvancedSection values={values} />
-    <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
-      <ActionGroup className="pf-c-form">
-        <Button
-          type="submit"
-          variant={ButtonVariant.primary}
-          isDisabled={!dirty || !_.isEmpty(errors)}
-          data-test-id="import-git-create-button"
-        >
-          Create
-        </Button>
-        <Button type="button" variant={ButtonVariant.secondary} onClick={handleReset}>
-          Cancel
-        </Button>
-      </ActionGroup>
-    </ButtonBar>
+    <FormFooter
+      handleReset={handleReset}
+      errorMessage={status && status.submitError}
+      isSubmitting={isSubmitting}
+      submitLabel="Create"
+      sticky
+      disableSubmit={!dirty || !_.isEmpty(errors)}
+      resetLabel="Cancel"
+    />
   </Form>
 );
 

--- a/frontend/packages/dev-console/src/components/import/ImportPage.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportPage.tsx
@@ -97,7 +97,7 @@ const ImportPage: React.FunctionComponent<ImportPageProps> = ({ match, location 
             <title>{importData.title}</title>
           </Helmet>
           <PageHeading title={importData.title} />
-          <div className="co-m-pane__body">
+          <div className="co-m-pane__body" style={{ paddingBottom: 0 }}>
             <Firehose resources={resources}>
               <ImportForm
                 forApplication={application}

--- a/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/SourceToImageForm.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { FormikProps, FormikValues } from 'formik';
-import { ButtonBar } from '@console/internal/components/utils';
-import { Form, ActionGroup, ButtonVariant, Button } from '@patternfly/react-core';
+import { FormFooter } from '@console/shared/src/components/form-utils';
+import { Form } from '@patternfly/react-core';
 import { SourceToImageFormProps } from './import-types';
 import GitSection from './git/GitSection';
 import BuilderSection from './builder/BuilderSection';
@@ -32,20 +32,15 @@ const SourceToImageForm: React.FC<FormikProps<FormikValues> & SourceToImageFormP
     <PipelineSection />
     <ResourceSection />
     <AdvancedSection values={values} />
-    <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
-      <ActionGroup className="pf-c-form">
-        <Button
-          type="submit"
-          variant={ButtonVariant.primary}
-          isDisabled={!dirty || !_.isEmpty(errors)}
-        >
-          Create
-        </Button>
-        <Button type="button" variant={ButtonVariant.secondary} onClick={handleReset}>
-          Cancel
-        </Button>
-      </ActionGroup>
-    </ButtonBar>
+    <FormFooter
+      handleReset={handleReset}
+      errorMessage={status && status.submitError}
+      isSubmitting={isSubmitting}
+      submitLabel="Create"
+      disableSubmit={!dirty || !_.isEmpty(errors)}
+      resetLabel="Cancel"
+      sticky
+    />
   </Form>
 );
 


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-2678

**Analysis / Root cause:**
As a user I'd like to be able to accept the defaults of a form quickly and not have to scroll through all the options to reach the Create button.


**Solution Description:**
Added a sticky section and place all the form actions inside the fixed section.

**Screen shots / Gifs for design review:**

![sticky_footer](https://user-images.githubusercontent.com/9964343/76780271-bd016600-67d2-11ea-8ed1-0fffcf50d3f5.gif)

**Unit test coverage report:**
![image](https://user-images.githubusercontent.com/9964343/77176013-7ae56680-6ae9-11ea-8f7f-93354f05d168.png)


**Browser conformance:**

 - [x]  Chrome
 - [x] Firefox
 - [ ] Safari
 - [ ] Edge

cc: @serenamarie125 @openshift/team-devconsole-ux 