### PR TITLE
Use radio buttons for create operand editor toggle

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/editor-toggle.tsx
+++ b/frontend/packages/console-shared/src/components/editor/editor-toggle.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { RadioGroup, RadioGroupProps } from '@console/internal/components/radio';
+
+export enum EditorType {
+  Form = 'form',
+  YAML = 'yaml',
+}
+
+export const EditorToggle: React.FC<EditorToggleProps> = ({ value, onChange }) => {
+  return (
+    <div className="co-create-operand__editor-toggle">
+      <RadioGroup
+        label="Configure via:"
+        currentValue={value}
+        inline
+        items={[
+          {
+            value: EditorType.Form,
+            title: 'Form view',
+          },
+          {
+            value: EditorType.YAML,
+            title: 'YAML View',
+          },
+        ]}
+        onChange={onChange}
+      />
+    </div>
+  );
+};
+
+type EditorToggleProps = {
+  value: EditorType;
+  onChange: RadioGroupProps['onChange'];
+};

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
@@ -11,7 +11,6 @@ import {
   testName,
 } from '@console/internal-integration-tests/protractor.conf';
 import * as crudView from '@console/internal-integration-tests/views/crud.view';
-import * as yamlView from '@console/internal-integration-tests/views/yaml.view';
 import * as operatorView from '../views/operator.view';
 import { testCR, testCRD, testCSV } from '../mocks';
 import { inputValueFor } from '../views/descriptors.view';
@@ -98,10 +97,7 @@ describe('Using OLM descriptor components', () => {
     await $$('[data-test-id=breadcrumb-link-1]').click();
     await browser.wait(until.visibilityOf(element(by.buttonText('Create App'))));
     await retry(() => element(by.buttonText('Create App')).click());
-    await yamlView.isLoaded();
-    await element(by.buttonText('Edit Form')).click();
     await browser.wait(until.presenceOf($('#metadata\\.name')));
-
     expect($$('.co-create-operand__form-group').count()).not.toEqual(0);
   });
 
@@ -177,8 +173,6 @@ describe('Using OLM descriptor components', () => {
 
   it('successfully creates operand using form', async () => {
     await browser.refresh();
-    await yamlView.isLoaded();
-    await element(by.buttonText('Edit Form')).click();
     await browser.wait(until.presenceOf($('#metadata\\.name')));
     await element(by.buttonText('Create')).click();
     await crudView.isLoaded();

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
@@ -12,7 +12,6 @@ import * as crudView from '@console/internal-integration-tests/views/crud.view';
 import * as catalogView from '@console/internal-integration-tests/views/catalog.view';
 import * as catalogPageView from '@console/internal-integration-tests/views/catalog-page.view';
 import * as sidenavView from '@console/internal-integration-tests/views/sidenav.view';
-import * as yamlView from '@console/internal-integration-tests/views/yaml.view';
 import * as operatorView from '../views/operator.view';
 import * as operatorHubView from '../views/operator-hub.view';
 
@@ -160,16 +159,16 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
     );
   });
 
-  it('displays YAML editor for creating a new `Jaeger` instance', async () => {
+  it('displays form editor for creating a new `Jaeger` instance', async () => {
     await browser.wait(until.visibilityOf(element(by.buttonText('Create Jaeger'))));
     await retry(() => element(by.buttonText('Create Jaeger')).click());
-    await yamlView.isLoaded();
+    await browser.wait(until.presenceOf($('#metadata\\.name')));
 
     expect($('.co-create-operand__header').getText()).toContain('Create Jaeger');
   });
 
   it('displays new `Jaeger` that was created from YAML editor', async () => {
-    await $('#save-changes').click();
+    await $('button[type="submit"]').click();
     await crudView.isLoaded();
     await browser.wait(until.visibilityOf(operatorView.operandLink(jaegerName)));
 

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
@@ -12,7 +12,6 @@ import * as crudView from '@console/internal-integration-tests/views/crud.view';
 import * as catalogView from '@console/internal-integration-tests/views/catalog.view';
 import * as catalogPageView from '@console/internal-integration-tests/views/catalog-page.view';
 import * as sidenavView from '@console/internal-integration-tests/views/sidenav.view';
-import * as yamlView from '@console/internal-integration-tests/views/yaml.view';
 import * as operatorView from '../views/operator.view';
 import * as operatorHubView from '../views/operator-hub.view';
 
@@ -162,7 +161,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     );
   });
 
-  it('displays YAML editor for creating a new `Prometheus` instance', async () => {
+  it('displays form editor for creating a new `Prometheus` instance', async () => {
     await browser.wait(until.visibilityOf(element(by.buttonText('Create New'))));
     await element(by.buttonText('Create New')).click();
     await browser.wait(until.visibilityOf($$('.pf-c-dropdown__menu').first()), 1000);
@@ -170,13 +169,13 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
       .first()
       .element(by.buttonText('Prometheus'))
       .click();
-    await yamlView.isLoaded();
+    await browser.wait(until.presenceOf($('#metadata\\.name')));
 
     expect($('.co-create-operand__header').getText()).toContain('Create Prometheus');
   });
 
-  it('displays new `Prometheus` that was created from YAML editor', async () => {
-    await $('#save-changes').click();
+  it('displays new `Prometheus` that was created from form editor', async () => {
+    await $('button[type="submit"]').click();
     await crudView.isLoaded();
     await browser.wait(until.visibilityOf(operatorView.operandLink('example')));
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/create-operand.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-operand.spec.tsx
@@ -9,9 +9,8 @@ import { CreateYAML } from '@console/internal/components/create-yaml';
 import { BreadCrumbs } from '@console/internal/components/utils';
 import { testClusterServiceVersion, testResourceInstance, testModel, testCRD } from '../../mocks';
 import { ClusterServiceVersionModel } from '../models';
-import { CreateOperandForm } from './create-operand-form';
+import { CreateOperandForm, CreateOperandFormProps } from './create-operand-form';
 import {
-  CreateOperandFormProps,
   CreateOperandPage,
   CreateOperandYAML,
   CreateOperandYAMLProps,

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -209,6 +209,14 @@ $co-affinity-row-margin: 15px;
   margin: 0;
 }
 
+.co-create-operand__editor-toggle {
+  padding: 8px 30px;
+  border-bottom: 1px solid #ddd;
+  & label {
+    margin: 0;
+  }
+}
+
 .co-affinity-term {
   border: 1px solid #eee;
   display: flex;

--- a/frontend/packages/operator-lifecycle-manager/src/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/types.ts
@@ -93,6 +93,8 @@ export type APIServiceDefinition = {
   }[];
 };
 
+export type ProvidedAPI = CRDDescription | APIServiceDefinition;
+
 export type RequirementStatus = {
   group: string;
   version: string;

--- a/frontend/public/components/_radio.scss
+++ b/frontend/public/components/_radio.scss
@@ -1,0 +1,8 @@
+.co-radio-group--inline {
+  display: flex;
+  align-items: flex-start;
+}
+
+.co-radio-group .co-radio-group__label {
+  margin-right: 15px;
+}

--- a/frontend/public/components/radio.tsx
+++ b/frontend/public/components/radio.tsx
@@ -26,22 +26,44 @@ export const RadioInput: React.SFC<RadioInputProps> = (props) => {
   return props.inline ? inputElement : <div className="radio">{inputElement}</div>;
 };
 
-export const RadioGroup: React.SFC<RadioGroupProps> = ({ currentValue, onChange, items }) => (
-  <div>
-    {items.map(({ desc, title, subTitle, value, disabled }) => (
-      <RadioInput
-        key={value}
-        checked={value === currentValue}
-        desc={desc}
-        onChange={onChange}
-        title={title}
-        subTitle={subTitle}
-        value={value}
-        disabled={disabled}
-      />
-    ))}
-  </div>
-);
+export const RadioGroup: React.SFC<RadioGroupProps> = ({
+  currentValue,
+  inline = false,
+  items,
+  label,
+  onChange,
+  id = JSON.stringify(items),
+}) => {
+  const radios = items.map(({ desc, title, subTitle, value, disabled }) => (
+    <RadioInput
+      key={value}
+      checked={value === currentValue}
+      desc={desc}
+      onChange={onChange}
+      title={title}
+      subTitle={subTitle}
+      value={value}
+      disabled={disabled}
+      inline={inline}
+    />
+  ));
+  return (
+    <div className={classNames('co-radio-group', { 'co-radio-group--inline': inline })}>
+      {label ? (
+        <>
+          <label className="form-label co-radio-group__label" htmlFor={id}>
+            {label}
+          </label>
+          <div className="co-radio-group__controls" id={id}>
+            {radios}
+          </div>
+        </>
+      ) : (
+        radios
+      )}
+    </div>
+  );
+};
 
 export type RadioInputProps = {
   checked: boolean;
@@ -55,7 +77,8 @@ export type RadioInputProps = {
 
 export type RadioGroupProps = {
   currentValue: any;
-  onChange: React.InputHTMLAttributes<any>['onChange'];
+  id?: string;
+  inline?: boolean;
   items: ({
     desc?: string | JSX.Element;
     title: string | JSX.Element;
@@ -63,6 +86,8 @@ export type RadioGroupProps = {
     value: any;
     disabled?: boolean;
   } & React.InputHTMLAttributes<any>)[];
+  label?: string;
+  onChange: React.InputHTMLAttributes<any>['onChange'];
 };
 
 RadioInput.displayName = 'RadioInput';

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -94,6 +94,7 @@
 @import 'components/cluster-settings/cluster-settings';
 @import 'components/search';
 @import 'components/notification-drawer';
+@import 'components/radio';
 
 @import 'components/dashboard/dashboards-page/cluster-dashboard/activity-card';
 @import 'components/dashboard/dashboards-page/cluster-dashboard/status-card';


### PR DESCRIPTION
Change "Edit YAML/Edit Form" buttons to radio toggle and move right above edit area.
Default to form editor on create operand page.

![new-toggle](https://user-images.githubusercontent.com/22625502/76790139-a76d4b80-6794-11ea-84b8-3968fe6c5661.gif)
