### PR TITLE
[release-4.3] Bug 1814075: Mount OCS form when csv is available

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import { Firehose, FieldLevelHelp } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { StorageClassDropdownInner } from '@console/internal/components/utils/storage-class-dropdown';
-import { cephStorageProvisioners } from '@console/shared';
+import { cephStorageProvisioners, getName } from '@console/shared';
 import { storageClassTooltip } from '../../constants/ocs-install';
 import './storage-class-dropdown.scss';
 
@@ -30,7 +30,8 @@ export const OCSStorageClassDropdown: React.FC<OCSStorageClassDropdownProps> = (
   const { onChange, defaultClass } = props;
 
   const handleStorageClass = (sc: K8sResourceKind) => {
-    onChange(sc.metadata.name);
+    const name = getName(sc);
+    onChange(name);
   };
   return (
     <>

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-ocs-service.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/create-ocs-service.tsx
@@ -52,12 +52,14 @@ export const CreateOCSService: React.FC<CreateOCSServiceProps> = React.memo((pro
           )}
         </div>
       </div>
-      <CreateOCSServiceForm
-        namespace={props.match.params.ns}
-        operandModel={OCSServiceModel}
-        sample={sample}
-        clusterServiceVersion={clusterServiceVersion !== null && clusterServiceVersion}
-      />
+      {clusterServiceVersion && sample && (
+        <CreateOCSServiceForm
+          namespace={props.match.params.ns}
+          operandModel={OCSServiceModel}
+          sample={sample}
+          clusterServiceVersion={clusterServiceVersion !== null && clusterServiceVersion}
+        />
+      )}
     </>
   );
 });


### PR DESCRIPTION
Cherrypick for https://github.com/openshift/console/pull/4723/commits (#4723  )
There were conflicts, hence sending separate PR with resolved conflicts and **cherry picking the original commit  5b1e7394fc5d53ed8755812d433c7c62a466e883)**

I verified [cherry pick commit](https://github.com/openshift/console/pull/4723/commits/5b1e7394fc5d53ed8755812d433c7c62a466e883) locally , its genuine:
```
git cherry upstream/release-4.3 upstream/release-4.4 | grep 5b1e7394fc5d53ed8755812d433c7c62a466e883
+  5b1e7394fc5d53ed8755812d433c7c62a466e883
```

Summary of conflicts and reasons:
* `packages/ceph-storage-plugin/src/components/ocs-install/install-page.tsx` file is not present in 4.3
* Import conflicts in ` packages/ceph-storage-plugin/src/components/modals/storage-class-dropdown.tsx`. The file is not using some imports in 4.4 and 4.5 that were used in 4.3

-------------------
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1804107
The OCS form is unmounted when the parent component's state changes. We should render the component only once we have got all the data.
Internally the states of inner children components are getting affected.

Signed-off-by: Afreen Rahman <afrahman@redhat.com>
(cherry picked from commit 5b1e7394fc5d53ed8755812d433c7c62a466e883)