### PR TITLE
kubevirt: move and refactor v2v requests from kubevirt-web-ui-components 

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/create-vm-wizard.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { createVm as importVM } from 'kubevirt-web-ui-components';
 import { Wizard, WizardStep } from '@patternfly/react-core';
 import { FLAGS } from '@console/shared';
 import {
@@ -11,58 +10,27 @@ import {
   FlagsObject,
 } from '@console/internal/reducers/features';
 import { TemplateModel } from '@console/internal/models';
-import { Firehose, history, units } from '@console/internal/components/utils';
-import { k8sGet, TemplateKind } from '@console/internal/module/k8s';
+import { Firehose, history } from '@console/internal/components/utils';
 import { Location } from 'history';
 import { match as RouterMatch } from 'react-router';
 import { withReduxID } from '../../utils/redux/common';
 import { DataVolumeModel, VirtualMachineModel } from '../../models';
-import {
-  TEMPLATE_TYPE_BASE,
-  TEMPLATE_TYPE_LABEL,
-  TEMPLATE_TYPE_VM,
-  VolumeType,
-} from '../../constants/vm';
+import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM } from '../../constants/vm';
 import { getResource } from '../../utils';
 import { EnhancedK8sMethods } from '../../k8s/enhancedK8sMethods/enhancedK8sMethods';
 import { cleanupAndGetResults, getResults } from '../../k8s/enhancedK8sMethods/k8sMethodsUtils';
-import {
-  concatImmutableLists,
-  iGetIn,
-  iGetLoadedData,
-  immutableListToShallowJS,
-} from '../../utils/immutable';
-import { getTemplateOperatingSystems } from '../../selectors/vm-template/advanced';
+import { iGetIn, iGetLoadedData, immutableListToJS } from '../../utils/immutable';
 import { ResultsWrapper } from '../../k8s/enhancedK8sMethods/types';
-import { NetworkWrapper } from '../../k8s/wrapper/vm/network-wrapper';
-import { NetworkInterfaceWrapper } from '../../k8s/wrapper/vm/network-interface-wrapper';
-import { VolumeWrapper } from '../../k8s/wrapper/vm/volume-wrapper';
-import { DiskWrapper } from '../../k8s/wrapper/vm/disk-wrapper';
-import { DataVolumeWrapper } from '../../k8s/wrapper/vm/data-volume-wrapper';
-import {
-  getDefaultSCAccessModes,
-  getDefaultSCVolumeMode,
-} from '../../selectors/config-map/sc-defaults';
-import { getStorageClassConfigMap } from '../../k8s/requests/config-map/storage-class';
 import { makeIDReferences } from '../../utils/redux/id-reference';
-import { PersistentVolumeClaimWrapper } from '../../k8s/wrapper/vm/persistent-volume-claim-wrapper';
-import { ProvisionSource } from '../../constants/vm/provision-source';
-import { getVolumeCloudInitNoCloud } from '../../selectors/vm';
-import {
-  CloudInitDataHelper,
-  CloudInitDataFormKeys,
-} from '../../k8s/wrapper/vm/cloud-init-data-helper';
 import { createVM, createVMTemplate } from '../../k8s/requests/vm/create/create';
 import {
   ChangedCommonData,
   CommonData,
   CreateVMWizardComponentProps,
   DetectCommonDataChanges,
-  VMSettingsField,
   VMWizardNetwork,
   VMWizardProps,
   VMWizardStorage,
-  VMWizardStorageType,
   VMWizardTab,
 } from './types';
 import { CREATE_VM, CREATE_VM_TEMPLATE, TabTitleResolver, IMPORT_VM } from './strings/strings';
@@ -87,138 +55,6 @@ import { CloudInitTab } from './tabs/cloud-init-tab/cloud-init-tab';
 import { VirtualHardwareTab } from './tabs/virtual-hardware-tab/virtual-hardware-tab';
 
 import './create-vm-wizard.scss';
-
-// TODO remove after moving create functions from kubevirt-web-ui-components
-/** *
- * kubevirt-web-ui-components InterOP
- */
-const kubevirtInterOP = async ({
-  activeNamespace,
-  vmSettings,
-  networks,
-  storages,
-  templates,
-}: {
-  activeNamespace: string;
-  vmSettings: any;
-  networks: VMWizardNetwork[];
-  storages: VMWizardStorage[];
-  templates: TemplateKind[];
-}) => {
-  const clonedVMsettings = _.cloneDeep(vmSettings);
-  const clonedNetworks = _.cloneDeep(networks);
-  const clonedStorages = _.cloneDeep(storages);
-
-  const cloudInitVolume = clonedStorages.map((stor) => stor.volume).find(getVolumeCloudInitNoCloud);
-  const data = new VolumeWrapper(cloudInitVolume).getCloudInitNoCloud();
-  const hostname = new CloudInitDataHelper(data).get(CloudInitDataFormKeys.HOSTNAME);
-  if (hostname) {
-    clonedVMsettings.hostname = { value: hostname };
-  }
-
-  clonedVMsettings.namespace = { value: activeNamespace };
-  const operatingSystems = getTemplateOperatingSystems(templates);
-  const osField = clonedVMsettings[VMSettingsField.OPERATING_SYSTEM];
-  const osID = osField.value;
-  osField.value = operatingSystems.find(({ id }) => id === osID);
-
-  const provisionSourceTypeField = clonedVMsettings[VMSettingsField.PROVISION_SOURCE_TYPE];
-  // createVMTemplate (source URL) creates unwanted dataVolume and removes already prepared dataVolumeTemplate
-  if (provisionSourceTypeField.value === ProvisionSource.URL.getValue()) {
-    provisionSourceTypeField.value = undefined;
-  }
-
-  const interOPNetworks = clonedNetworks.map(({ networkInterface, network }) => {
-    const networkInterfaceWrapper = new NetworkInterfaceWrapper(networkInterface);
-    const networkWrapper = new NetworkWrapper(network);
-
-    return {
-      name: networkInterfaceWrapper.getName(),
-      mac: networkInterfaceWrapper.getMACAddress(),
-      binding: networkInterfaceWrapper.getTypeValue(),
-      isBootable: networkInterfaceWrapper.isFirstBootableDevice(),
-      network: networkWrapper.getReadableName(),
-      networkType: networkWrapper.getTypeValue(),
-      templateNetwork: {
-        network,
-        interface: networkInterface,
-      },
-    };
-  });
-
-  const storageClassConfigMap = await getStorageClassConfigMap({ k8sGet });
-
-  const interOPStorages = clonedStorages.map(
-    ({ type, disk, volume, dataVolume, persistentVolumeClaim, importData }) => {
-      const diskWrapper = new DiskWrapper(disk);
-      const volumeWrapper = new VolumeWrapper(volume);
-      const dataVolumeWrapper = dataVolume && new DataVolumeWrapper(dataVolume, true);
-      const persistentVolumeClaimWrapper =
-        persistentVolumeClaim && new PersistentVolumeClaimWrapper(persistentVolumeClaim);
-
-      const isImport =
-        persistentVolumeClaimWrapper &&
-        [
-          VMWizardStorageType.V2V_VMWARE_IMPORT,
-          VMWizardStorageType.V2V_VMWARE_IMPORT_TEMP,
-        ].includes(type);
-      const resolveType = (dv) => {
-        if (type === VMWizardStorageType.V2V_VMWARE_IMPORT) {
-          return 'external-import';
-        }
-        if (type === VMWizardStorageType.V2V_VMWARE_IMPORT_TEMP) {
-          return 'external-v2v-temp';
-        }
-        return volumeWrapper.getType() === VolumeType.DATA_VOLUME && dv ? 'datavolume' : undefined;
-      };
-
-      if (isImport) {
-        return {
-          name: diskWrapper.getName(),
-          isBootable: diskWrapper.isFirstBootableDevice(),
-          storageType: resolveType(dataVolume),
-          size: persistentVolumeClaimWrapper.getSize().value,
-          unit: persistentVolumeClaimWrapper.getSize().unit,
-          storageClass: persistentVolumeClaimWrapper.getStorageClassName(),
-          data: importData,
-        };
-      }
-
-      let finalDataVolume;
-      if (dataVolumeWrapper) {
-        finalDataVolume = dataVolumeWrapper
-          .assertDefaultModes(
-            getDefaultSCVolumeMode(
-              storageClassConfigMap,
-              dataVolumeWrapper.getStorageClassName(),
-            ).toString(),
-            getDefaultSCAccessModes(
-              storageClassConfigMap,
-              dataVolumeWrapper.getStorageClassName(),
-            ).map((a) => a.toString()),
-          )
-          .asResource();
-      }
-
-      return {
-        name: diskWrapper.getName(),
-        isBootable: diskWrapper.isFirstBootableDevice(),
-        storageType: resolveType(finalDataVolume),
-        templateStorage: {
-          volume,
-          disk,
-          dataVolumeTemplate: finalDataVolume,
-        },
-      };
-    },
-  );
-
-  return {
-    interOPVMSettings: clonedVMsettings,
-    interOPNetworks,
-    interOPStorages,
-  };
-};
 
 export class CreateVMWizardComponent extends React.Component<CreateVMWizardComponentProps> {
   private isClosed = false;
@@ -279,57 +115,31 @@ export class CreateVMWizardComponent extends React.Component<CreateVMWizardCompo
 
   finish = async () => {
     this.props.onResultsChanged({ errors: [], requestResults: [] }, null, true, true); // reset
-    const { isCreateTemplate, activeNamespace, isProviderImport, openshiftFlag } = this.props;
+    const { isCreateTemplate, activeNamespace, openshiftFlag } = this.props;
 
     const enhancedK8sMethods = new EnhancedK8sMethods();
     const vmSettings = iGetIn(this.props.stepData, [VMWizardTab.VM_SETTINGS, 'value']).toJS();
-    const networks = immutableListToShallowJS<VMWizardNetwork>(
+    const networks = immutableListToJS<VMWizardNetwork>(
       iGetIn(this.props.stepData, [VMWizardTab.NETWORKING, 'value']),
     );
-    const storages = immutableListToShallowJS(
+    const storages = immutableListToJS<VMWizardStorage>(
       iGetIn(this.props.stepData, [VMWizardTab.STORAGE, 'value']),
     );
 
     const iUserTemplates = iGetLoadedData(this.props[VMWizardProps.userTemplates]);
     const iCommonTemplates = iGetLoadedData(this.props[VMWizardProps.commonTemplates]);
-    let promise;
 
-    if (isProviderImport) {
-      const templates = immutableListToShallowJS<TemplateKind>(
-        concatImmutableLists(iUserTemplates, iCommonTemplates),
-      );
-      const { interOPVMSettings, interOPNetworks, interOPStorages } = await kubevirtInterOP({
-        vmSettings,
-        networks,
-        storages,
-        templates,
-        activeNamespace,
-      });
-
-      promise = importVM(
-        enhancedK8sMethods,
-        templates,
-        interOPVMSettings,
-        interOPNetworks,
-        interOPStorages,
-        [],
-        units,
-      );
-    } else {
-      const create = isCreateTemplate ? createVMTemplate : createVM;
-      promise = create({
-        enhancedK8sMethods,
-        vmSettings,
-        networks,
-        storages,
-        iUserTemplates,
-        iCommonTemplates,
-        namespace: activeNamespace,
-        openshiftFlag,
-      });
-    }
-
-    promise
+    const create = isCreateTemplate ? createVMTemplate : createVM;
+    create({
+      enhancedK8sMethods,
+      vmSettings,
+      networks,
+      storages,
+      iUserTemplates,
+      iCommonTemplates,
+      namespace: activeNamespace,
+      openshiftFlag,
+    })
       .then(() => getResults(enhancedK8sMethods))
       .catch((error) => cleanupAndGetResults(enhancedK8sMethods, error))
       .then(({ isValid, ...rest }: ResultsWrapper) =>

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/provider-definitions.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/provider-definitions.ts
@@ -5,7 +5,8 @@ import { UpdateOptions } from './redux/types';
 import { cleanupVmWareProvider } from './redux/stateUpdate/vmSettings/providers/vmware-cleanup';
 
 type Provider = {
-  name: VMImportProvider;
+  id: VMImportProvider;
+  name: string;
   getInitialState?: () => any;
   getStateUpdater?: (options: UpdateOptions) => any;
   cleanup?: (options: UpdateOptions) => any;
@@ -14,7 +15,8 @@ type Provider = {
 // TODO: make imports async
 export const getProviders = (): Provider[] => [
   {
-    name: VMImportProvider.VMWARE,
+    name: 'VMware',
+    id: VMImportProvider.VMWARE,
     getInitialState: getVmWareInitialState,
     getStateUpdater: getVMWareProviderStateUpdater,
     cleanup: cleanupVmWareProvider,

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
@@ -48,7 +48,7 @@ export const getInitialVmSettings = (data: CommonData): VMSettings => {
     [VMSettingsField.PROVIDER]: {
       isRequired: asRequired(isProviderImport),
       isHidden: asHidden(!isProviderImport),
-      providers: getProviders().map((provider) => provider.name),
+      providers: getProviders().map((provider) => ({ name: provider.name, id: provider.id })),
     },
     [VMSettingsField.PROVISION_SOURCE_TYPE]: {
       value: isProviderImport ? ProvisionSource.IMPORT.getValue() : undefined,
@@ -81,7 +81,7 @@ export const getInitialVmSettings = (data: CommonData): VMSettings => {
     },
     [VMSettingsField.PROVIDERS_DATA]: {
       ...getProviders().reduce((allProviders, provider) => {
-        allProviders[provider.name] = provider.getInitialState();
+        allProviders[provider.id] = provider.getInitialState();
         return allProviders;
       }, {}),
     },

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/providers/vmware-prefill-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/providers/vmware-prefill-vm.ts
@@ -98,7 +98,7 @@ export const getDisks = (parsedVm): VMWizardStorage[] => {
     );
 
     const name = _.get(device, ['DeviceInfo', 'Label']);
-    const bootOrder = idx === 0 ? 0 : undefined;
+    const bootOrder = idx === 0 ? 1 : undefined;
 
     return {
       id: idx + 1,
@@ -114,11 +114,13 @@ export const getDisks = (parsedVm): VMWizardStorage[] => {
         type: VolumeType.PERSISTENT_VOLUME_CLAIM,
         typeData: { claimName: name },
       }).asResource(),
-      persistentVolumeClaim: PersistentVolumeClaimWrapper.initializeFromSimpleData({
-        name,
-        size: size.value,
-        unit: size.unit,
-      }).asResource(),
+      persistentVolumeClaim: new PersistentVolumeClaimWrapper()
+        .init({
+          name,
+          size: size.value,
+          unit: size.unit,
+        })
+        .asResource(),
       importData: {
         fileName: _.get(device, ['Backing', 'FileName']),
         mountPath: `/data/vm/disk${idx + 1}`, // hardcoded
@@ -142,11 +144,13 @@ export const getDisks = (parsedVm): VMWizardStorage[] => {
       type: VolumeType.PERSISTENT_VOLUME_CLAIM,
       typeData: { claimName: name },
     }).asResource(),
-    persistentVolumeClaim: PersistentVolumeClaimWrapper.initializeFromSimpleData({
-      name,
-      size: 2,
-      unit: BinaryUnit.Gi,
-    }).asResource(),
+    persistentVolumeClaim: new PersistentVolumeClaimWrapper()
+      .init({
+        name,
+        size: 2,
+        unit: BinaryUnit.Gi,
+      })
+      .asResource(),
     importData: {
       mountPath: CONVERSION_POD_TEMP_MOUNT_PATH, // hardcoded; always Filesystem mode
     },

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/providers/vmware-provider-actions.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/providers/vmware-provider-actions.ts
@@ -1,4 +1,3 @@
-import { requestVmDetail, startV2VVMWareController } from 'kubevirt-web-ui-components';
 import { getName } from '@console/shared/src';
 import { VMImportProvider, VMWareProviderField, VMWizardProps } from '../../../../types';
 import { InternalActionType, UpdateOptions } from '../../../types';
@@ -21,6 +20,8 @@ import {
   createV2VvmwareObject,
   createV2VvmwareObjectWithSecret,
 } from '../../../../../../k8s/requests/v2v/create-v2vvmware-object';
+import { requestVmDetail } from '../../../../../../k8s/requests/v2v/request-vm-detail';
+import { startV2VVMWareController } from '../../../../../../k8s/requests/v2v/start-v2vvmware-controller';
 
 const { info: consoleInfo, warn: consoleWarn, error: consoleError } = console;
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/providers/vmware-provider-actions.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/stateUpdate/vmSettings/providers/vmware-provider-actions.ts
@@ -1,9 +1,4 @@
-import {
-  createV2VvmwareObject,
-  createV2VvmwareObjectWithSecret,
-  requestVmDetail,
-  startV2VVMWareController,
-} from 'kubevirt-web-ui-components';
+import { requestVmDetail, startV2VVMWareController } from 'kubevirt-web-ui-components';
 import { getName } from '@console/shared/src';
 import { VMImportProvider, VMWareProviderField, VMWizardProps } from '../../../../types';
 import { InternalActionType, UpdateOptions } from '../../../types';
@@ -22,6 +17,10 @@ import { asDisabled, asHidden } from '../../../../utils/utils';
 import { deleteV2VvmwareObject } from '../../../../../../k8s/requests/v2v/delete-v2vvmware-object';
 import { getSimpleV2vVMwareStatus } from '../../../../../../statuses/v2vvmware';
 import { getVMWareConnectionName } from '../../../../../../selectors/v2v';
+import {
+  createV2VvmwareObject,
+  createV2VvmwareObjectWithSecret,
+} from '../../../../../../k8s/requests/v2v/create-v2vvmware-object';
 
 const { info: consoleInfo, warn: consoleWarn, error: consoleError } = console;
 

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/provider/vmware/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/provider/vmware/selectors.ts
@@ -1,6 +1,30 @@
 import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getSimpleV2vVMwareStatus, V2VVMwareStatus } from '../../../../../statuses/v2vvmware';
+import { VMSettings } from '../../../redux/initial-state/types';
+import { VMImportProvider, VMSettingsField, VMWareProviderField } from '../../../types';
+
+export const getVmwareField = (
+  vmSettings: VMSettings,
+  key: VMWareProviderField,
+  defaultValue: any = undefined,
+) =>
+  _.get(vmSettings, [VMSettingsField.PROVIDERS_DATA, VMImportProvider.VMWARE, key]) || defaultValue;
+
+export const getVmwareAttribute = (
+  vmSettings: VMSettings,
+  key: VMWareProviderField,
+  attribute = 'value',
+  defaultValue: any = undefined,
+) =>
+  _.get(vmSettings, [VMSettingsField.PROVIDERS_DATA, VMImportProvider.VMWARE, key, attribute]) ||
+  defaultValue;
+
+export const getVmwareValue = (
+  vmSettings: VMSettings,
+  key: VMWareProviderField,
+  defaultValue: any = undefined,
+) => getVmwareAttribute(vmSettings, key, 'value', defaultValue);
 
 export const getVms = (v2vvmware: K8sResourceKind, defaultValue) =>
   _.get(v2vvmware, 'spec.vms', defaultValue);

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/vm-settings-tab.tsx
@@ -7,7 +7,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { connect } from 'react-redux';
-import { iGet, iGetIn } from '../../../../utils/immutable';
+import { iGet, iGetIn, immutableListToShallowJS } from '../../../../utils/immutable';
 import { FormFieldMemoRow } from '../../form/form-field-row';
 import { FormField, FormFieldType } from '../../form/form-field';
 import { FormSelectPlaceholderOption } from '../../../form/form-select-placeholder-option';
@@ -70,11 +70,11 @@ export class VMSettingsTabComponent extends React.Component<VMSettingsTabCompone
                 placeholder={getPlaceholder(VMSettingsField.PROVIDER)}
                 isDisabled={!!this.getFieldValue(VMSettingsField.PROVIDER)}
               />
-              {(this.getFieldAttribute(VMSettingsField.PROVIDER, 'providers') || []).map(
-                (provider) => (
-                  <FormSelectOption key={provider} value={provider} label={provider} />
-                ),
-              )}
+              {immutableListToShallowJS(
+                this.getFieldAttribute(VMSettingsField.PROVIDER, 'providers'),
+              ).map(({ id, name }) => (
+                <FormSelectOption key={id} value={id} label={name} />
+              ))}
             </FormSelect>
           </FormField>
         </FormFieldMemoRow>

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -40,26 +40,26 @@ export enum VMWizardProps {
 
 export const ALL_VM_WIZARD_TABS = getStringEnumValues<VMWizardTab>(VMWizardTab);
 
-export enum VMSettingsField { // TODO refactor to NAME = 'NAME' format for easier debugging once kubevirt-web-ui-components is deprecated
-  NAME = 'name',
-  HOSTNAME = 'hostname',
-  DESCRIPTION = 'description',
-  PROVISION_SOURCE_TYPE = 'provisionSourceType',
-  CONTAINER_IMAGE = 'containerImage',
-  IMAGE_URL = 'imageURL',
-  PROVIDER = 'provider',
-  PROVIDERS_DATA = 'providersData',
-  USER_TEMPLATE = 'userTemplate',
-  OPERATING_SYSTEM = 'operatingSystem',
-  FLAVOR = 'flavor',
-  MEMORY = 'memory',
-  CPU = 'cpu',
-  WORKLOAD_PROFILE = 'workloadProfile',
-  START_VM = 'startVM',
+export enum VMSettingsField {
+  NAME = 'NAME',
+  HOSTNAME = 'HOSTNAME',
+  DESCRIPTION = 'DESCRIPTION',
+  PROVISION_SOURCE_TYPE = 'PROVISION_SOURCE_TYPE',
+  CONTAINER_IMAGE = 'CONTAINER_IMAGE',
+  IMAGE_URL = 'IMAGE_URL',
+  PROVIDER = 'PROVIDER',
+  PROVIDERS_DATA = 'PROVIDERS_DATA',
+  USER_TEMPLATE = 'USER_TEMPLATE',
+  OPERATING_SYSTEM = 'OPERATING_SYSTEM',
+  FLAVOR = 'FLAVOR',
+  MEMORY = 'MEMORY',
+  CPU = 'CPU',
+  WORKLOAD_PROFILE = 'WORKLOAD_PROFILE',
+  START_VM = 'START_VM',
 }
 
-export enum VMImportProvider { // TODO refactor to VMWARE = 'VMWARE' once kubevirt-web-ui-components is deprecated
-  VMWARE = 'VMware',
+export enum VMImportProvider {
+  VMWARE = 'VMWARE',
 }
 
 export enum VMWareProviderProps {
@@ -71,21 +71,21 @@ export enum VMWareProviderProps {
   activeVcenterSecret = 'activeVcenterSecret',
 }
 
-export enum VMWareProviderField { // TODO refactor to VCENTER_KEY = 'VCENTER_KEY' once kubevirt-web-ui-components is deprecated
-  VCENTER = 'vCenterInstance',
-  HOSTNAME = 'vmwareHostname',
-  USER_NAME = 'vmwareUserName',
-  USER_PASSWORD_AND_CHECK_CONNECTION = 'vmwarePassword',
-  REMEMBER_PASSWORD = 'rememberVMwareCredentials',
+export enum VMWareProviderField {
+  VCENTER = 'VCENTER',
+  HOSTNAME = 'HOSTNAME',
+  USER_NAME = 'USER_NAME',
+  USER_PASSWORD_AND_CHECK_CONNECTION = 'USER_PASSWORD_AND_CHECK_CONNECTION',
+  REMEMBER_PASSWORD = 'REMEMBER_PASSWORD',
 
-  CHECK_CONNECTION = 'checkConnectionButton',
-  STATUS = 'vmwareStatus',
+  CHECK_CONNECTION = 'CHECK_CONNECTION',
+  STATUS = 'STATUS',
 
-  VM = 'vmwareVm',
+  VM = 'VM',
 
-  V2V_NAME = 'v2vVmwareName',
-  V2V_LAST_ERROR = 'PROVIDER_VMWARE_V2V_LAST_ERROR',
-  NEW_VCENTER_NAME = 'newVCenterName',
+  V2V_NAME = 'V2V_NAME',
+  V2V_LAST_ERROR = 'V2V_LAST_ERROR',
+  NEW_VCENTER_NAME = 'NEW_VCENTER_NAME',
 }
 
 export enum CloudInitField {
@@ -217,6 +217,7 @@ export type VMWizardStorage = {
   persistentVolumeClaim?: V1PersistentVolumeClaim;
   importData?: {
     mountPath?: string;
+    devicePath?: string;
     fileName?: string;
   };
 };

--- a/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/disk-modal/disk-modal.tsx
@@ -209,14 +209,15 @@ export const DiskModal = withHandlePromise((props: DiskModalProps) => {
 
   let resultPersistentVolumeClaim;
   if (source.requiresNewPVC()) {
-    resultPersistentVolumeClaim = PersistentVolumeClaimWrapper.initializeFromSimpleData({
-      name,
-      storageClassName,
-      size,
-      unit,
-      accessModes: accessMode ? [accessMode.toString()] : null,
-      volumeMode: volumeMode ? volumeMode.toString() : null,
-    });
+    resultPersistentVolumeClaim = new PersistentVolumeClaimWrapper()
+      .init({
+        name,
+        storageClassName,
+        size,
+        unit,
+      })
+      .addAccessMode(accessMode?.toString())
+      .setVolumeMode(volumeMode?.toString());
   }
 
   const {

--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
@@ -80,7 +80,7 @@ const VMStatusPopoverContent: React.FC<VMStatusPopoverContentProps> = ({
   <>
     {message}
     {children && <div className="kubevirt-vm-status__detail-section">{children}</div>}
-    {progress && (
+    {progress != null && (
       <div className="kubevirt-vm-status__detail-section">
         <Progress value={progress} variant={ProgressVariant.info} size={ProgressSize.sm} />
       </div>

--- a/frontend/packages/kubevirt-plugin/src/constants/pvc/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/pvc/constants.ts
@@ -1,8 +1,0 @@
-export const PVC_ACCESSMODE_RWO = 'ReadWriteOnce';
-export const PVC_ACCESSMODE_RWM = 'ReadWriteMany';
-
-export const PVC_VOLUMEMODE_FS = 'Filesystem';
-export const PVC_VOLUMEMODE_BLOCK = 'Block';
-
-export const PVC_ACCESSMODE_DEFAULT = PVC_ACCESSMODE_RWO;
-export const PVC_VOLUMEMODE_DEFAULT = PVC_VOLUMEMODE_FS;

--- a/frontend/packages/kubevirt-plugin/src/constants/pvc/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/pvc/index.ts
@@ -1,1 +1,0 @@
-export * from './constants';

--- a/frontend/packages/kubevirt-plugin/src/constants/v2v.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/v2v.ts
@@ -2,9 +2,25 @@ export const CONVERSION_POD_TEMP_MOUNT_PATH = '/var/tmp';
 
 export const V2VVMWARE_DEPLOYMENT_NAME = 'v2v-vmware';
 
+export const CONVERSION_BASE_NAME = 'kubevirt-v2v-conversion';
+export const CONVERSION_GENERATE_NAME = `${CONVERSION_BASE_NAME}-`;
+
+export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME = 'v2v-vmware';
+// Different releases, different locations. Respect the order when resolving. Otherwise the configMap name/namespace is considered as well-known.
+export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES = [
+  'openshift-cnv',
+  'kubevirt-hyperconverged',
+];
+
 export const VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAMESPACE = 'kube-public'; // note: common-templates are in the "openshift" namespace
 // TODO: make it configurable via VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP
 export const VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAME = 'vmware-to-kubevirt-os'; // single configMap per cluster, contains mapping of vmware guestId to common-templates OS ID
 
+export const CONVERSION_SERVICEACCOUNT_DELAY = 2 * 1000; // in ms
+
 export const VCENTER_TYPE_LABEL = 'kubevirt.io/vcenter';
 export const VCENTER_TEMPORARY_LABEL = 'kubevirt.io/temporary';
+
+export const CONVERSION_VDDK_INIT_POD_NAME = 'vddk-init';
+export const CONVERSION_VOLUME_VDDK_NAME = 'volume-vddk';
+export const CONVERSION_VDDK_MOUNT_PATH = '/opt/vmware-vix-disklib-distrib';

--- a/frontend/packages/kubevirt-plugin/src/k8s/enhancedK8sMethods/enhancedK8sMethods.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/enhancedK8sMethods/enhancedK8sMethods.ts
@@ -5,6 +5,7 @@ import {
   k8sKill as _k8sKill,
   K8sKind,
   k8sPatch as _k8sPatch,
+  K8sResourceCommon,
   K8sResourceKind,
   Patch,
   referenceFor,
@@ -59,7 +60,7 @@ export class EnhancedK8sMethods {
   };
 
   k8sWrapperCreate = async <
-    U extends K8sResourceKind,
+    U extends K8sResourceCommon,
     T extends Wrapper<U, T> & K8sResourceKindMethods
   >(
     wrapper: T,
@@ -77,6 +78,15 @@ export class EnhancedK8sMethods {
       throw new K8sCreateError(error.message, data);
     }
   };
+
+  k8sWrapperPatch = async <
+    U extends K8sResourceCommon,
+    T extends Wrapper<U, T> & K8sResourceKindMethods
+  >(
+    wrapper: T,
+    patches: Patch[],
+    enhancedOpts?: EnhancedOpts,
+  ) => this.k8sPatch(wrapper.getModel(), wrapper.asResource(), patches, enhancedOpts);
 
   k8sPatch = async (
     kind: K8sKind,

--- a/frontend/packages/kubevirt-plugin/src/k8s/objects/vm/datavolume-template/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/objects/vm/datavolume-template/index.ts
@@ -12,6 +12,9 @@ type DataVolumeTemplateArgs = {
   storageClassName?: string;
 };
 
+/**
+ * @deprecated FIXME deprecate in favor of DataVolumeWrapper
+ */
 export class DataVolumeTemplate {
   private data: K8sResourceKind;
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/objects/vmi-migration/vmi-migration.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/objects/vmi-migration/vmi-migration.ts
@@ -4,6 +4,9 @@ import { apiVersionForModel, K8sResourceKind } from '@console/internal/module/k8
 import { VMIKind } from '../../../types/vm';
 import { VirtualMachineInstanceMigrationModel } from '../../../models';
 
+/**
+ * @deprecated FIXME deprecate in favor of VMIMigrationWrapper
+ */
 export class VMIMigration {
   private data: K8sResourceKind;
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-cdrom-patches.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-cdrom-patches.ts
@@ -98,10 +98,8 @@ export const getCDsPatch = async (vm: VMLikeEntityKind, cds: CD[]) => {
 
         finalDataVolume = dataVolumeWrapper
           .assertDefaultModes(
-            getDefaultSCVolumeMode(storageClassConfigMap, storageClassName).toString(),
-            getDefaultSCAccessModes(storageClassConfigMap, storageClassName).map((a) =>
-              a.toString(),
-            ),
+            getDefaultSCVolumeMode(storageClassConfigMap, storageClassName),
+            getDefaultSCAccessModes(storageClassConfigMap, storageClassName),
           )
           .asResource();
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-disk-patches.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-disk-patches.ts
@@ -98,8 +98,8 @@ export const getUpdateDiskPatches = async (
 
     finalDataVolume = dataVolumeWrapper
       .assertDefaultModes(
-        getDefaultSCVolumeMode(storageClassConfigMap, storageClassName).toString(),
-        getDefaultSCAccessModes(storageClassConfigMap, storageClassName).map((a) => a.toString()),
+        getDefaultSCVolumeMode(storageClassConfigMap, storageClassName),
+        getDefaultSCAccessModes(storageClassConfigMap, storageClassName),
       )
       .asResource();
   }

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/create-v2vvmware-object.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/create-v2vvmware-object.ts
@@ -1,0 +1,85 @@
+import { V2VVMwareModel } from '../../../models';
+import { EnhancedK8sMethods } from '../../enhancedK8sMethods/enhancedK8sMethods';
+import { V2VVMwareWrappper } from '../../wrapper/v2vvmware/v2vvmware-wrapper';
+import { getDefaultSecretName } from './utils/utils';
+import { getName, getOwnerReferences } from '@console/shared/src';
+import { SecretModel } from '@console/internal/models';
+import { PatchBuilder } from '@console/shared/src/k8s';
+import { buildOwnerReference } from '../../../utils';
+import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
+import { SecretWrappper } from '../../wrapper/k8s/secret-wrapper';
+import { VCENTER_TEMPORARY_LABEL, VCENTER_TYPE_LABEL } from '../../../constants/v2v';
+
+export const createV2VvmwareObjectWithSecret = async (
+  {
+    url,
+    username,
+    password,
+    namespace,
+  }: { url?: string; username?: string; password?: string; namespace?: string },
+  { k8sCreate, k8sPatch }: EnhancedK8sMethods,
+) => {
+  const secretName = `${getDefaultSecretName({ url, username })}-`;
+  const secret = await k8sCreate(
+    SecretModel,
+    new SecretWrappper()
+      .init({
+        generateName: secretName,
+        namespace,
+        labels: {
+          [VCENTER_TYPE_LABEL]: 'true',
+          [VCENTER_TEMPORARY_LABEL]: 'true', // garbage collect and do not list this temporary secret in the dropdown box
+        },
+      })
+      .setValue('username', username)
+      .setValue('password', password)
+      .setValue('url', url)
+      .asResource(),
+  );
+
+  const v2vvmware = await k8sCreate(
+    V2VVMwareModel,
+    new V2VVMwareWrappper()
+      .init({
+        namespace,
+        generateName: `check-${getDefaultSecretName({ url, username })}-`,
+        isTemporary: true,
+      })
+      .setConnection(getName(secret))
+      .asResource(),
+  );
+
+  if (v2vvmware) {
+    await k8sPatch(SecretModel, secret, [
+      new PatchBuilder('/metadata/ownerReferences')
+        .setListUpdate(
+          buildOwnerReference(v2vvmware),
+          getOwnerReferences(secret),
+          compareOwnerReference,
+        )
+        .build(),
+    ]);
+  }
+
+  return v2vvmware;
+};
+// ATM, Kubernetes does not support deletion of CRs with a gracefulPeriod (delayed deletion).
+// The only object with this support are PODs.
+// More info: https://github.com/kubernetes/kubernetes/issues/56567
+// Workaround: handle garbage collection on our own by:
+// - set VCENTER_TEMPORARY_LABEL label to 'true'
+// - controller will set deletionTimestamp label with RFC 3339 timestamp
+// - controller will remove the object after the timeStamp
+// - can be easily extended for delaying the deletionTimestamp (recently not needed, so not implemented)
+
+export const createV2VvmwareObject = async (
+  { connectionSecretName, namespace }: { connectionSecretName?: string; namespace?: string },
+  { k8sCreate }: EnhancedK8sMethods,
+) =>
+  k8sCreate(
+    V2VVMwareModel,
+    new V2VVMwareWrappper()
+      .init({ namespace, generateName: `v2vvmware-${connectionSecretName}-`, isTemporary: true })
+      .setConnection(connectionSecretName)
+      .asResource(),
+  );

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/import-v2vvmware.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/import-v2vvmware.ts
@@ -1,0 +1,347 @@
+/* eslint-disable camelcase, @typescript-eslint/camelcase,no-await-in-loop */
+import { CreateVMEnhancedParams } from '../../vm/create/types';
+import { ImporterResult } from '../../vm/types';
+import { buildOwnerReference } from '../../../../utils';
+import { PatchBuilder } from '@console/shared/src/k8s';
+import { PodModel, ServiceAccountModel } from '@console/internal/models';
+import { createBasicLookup, getName, getNamespace, getOwnerReferences } from '@console/shared/src';
+import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
+import { SecretWrappper } from '../../../wrapper/k8s/secret-wrapper';
+import {
+  CONVERSION_GENERATE_NAME,
+  CONVERSION_SERVICEACCOUNT_DELAY,
+} from '../../../../constants/v2v';
+import {
+  VMSettingsField,
+  VMWareProviderField,
+  VMWizardStorage,
+  VMWizardStorageType,
+} from '../../../../components/create-vm-wizard/types';
+import {
+  getVmwareAttribute,
+  getVmwareField,
+  getVmwareValue,
+} from '../../../../components/create-vm-wizard/selectors/provider/vmware/selectors';
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { ServiceAccountWrappper } from '../../../wrapper/k8s/service-account-wrapper';
+import { RoleWrappper } from '../../../wrapper/k8s/role-wrapper';
+import { RoleBindingWrappper } from '../../../wrapper/k8s/role-binding-wrapper';
+import { PersistentVolumeClaimWrapper } from '../../../wrapper/vm/persistent-volume-claim-wrapper';
+import {
+  getDefaultSCAccessModes,
+  getDefaultSCVolumeMode,
+} from '../../../../selectors/config-map/sc-defaults';
+import { VolumeWrapper } from '../../../wrapper/vm/volume-wrapper';
+import { AccessMode, VolumeMode, VolumeType } from '../../../../constants/vm/storage';
+import { buildConversionPod } from './objects/conversion-pod';
+import { getVmwareConfigMap } from '../v2vvmware-configmap';
+import {
+  getKubevirtV2vConversionContainerImage,
+  getV2vImagePullPolicy,
+  getVddkInitContainerImage,
+} from '../../../../selectors/v2v';
+import { PodWrappper } from '../../../wrapper/k8s/pod-wrapper';
+import { delay } from '../../../../utils/utils';
+import { getFieldValue } from '../../../../components/create-vm-wizard/selectors/vm-settings';
+import { getGeneratedName } from '../../../../selectors/selectors';
+
+const isImportStorage = (storage: VMWizardStorage) =>
+  [VMWizardStorageType.V2V_VMWARE_IMPORT, VMWizardStorageType.V2V_VMWARE_IMPORT_TEMP].includes(
+    storage.type,
+  );
+
+const createConversionPodSecret = async ({
+  enhancedK8sMethods: { k8sWrapperCreate },
+  vmSettings,
+  storages,
+  namespace,
+}: CreateVMEnhancedParams) => {
+  const { vm, thumbprint } = getVmwareField(vmSettings, VMWareProviderField.VM);
+  const secret = new SecretWrappper(
+    getVmwareAttribute(vmSettings, VMWareProviderField.VCENTER, 'secret'),
+  );
+
+  const username = encodeURIComponent(
+    getVmwareValue(vmSettings, VMWareProviderField.USER_NAME) || secret.getValue('username', true),
+  );
+  const password =
+    getVmwareValue(vmSettings, VMWareProviderField.USER_PASSWORD_AND_CHECK_CONNECTION) ||
+    secret.getValue('password', true);
+
+  const hostname =
+    getVmwareValue(vmSettings, VMWareProviderField.HOSTNAME) || secret.getValue('url', true);
+
+  const sourceDisks = (storages || [])
+    .filter((storage) => storage.type === VMWizardStorageType.V2V_VMWARE_IMPORT)
+    .map(({ importData }) => importData.fileName);
+
+  const secretWrapper = new SecretWrappper()
+    .init({ namespace, generateName: CONVERSION_GENERATE_NAME })
+    .setJSONValue(
+      'conversion.json',
+      {
+        daemonize: false,
+
+        vm_name: vm.name,
+        transport_method: 'vddk',
+
+        vmware_fingerprint: thumbprint,
+        vmware_uri: `vpx://${username}@${hostname}${vm?.detail?.hostPath}?no_verify=1`,
+        vmware_password: password,
+
+        source_disks: sourceDisks,
+      },
+      true,
+    );
+
+  const conversionPodSecret = await k8sWrapperCreate(secretWrapper);
+
+  return {
+    conversionPodSecret: conversionPodSecret as K8sResourceCommon,
+  };
+};
+
+const resolveRolesAndServiceAccount = async ({
+  enhancedK8sMethods: { k8sWrapperCreate },
+  namespace,
+}: CreateVMEnhancedParams) => {
+  const serviceAccount = await k8sWrapperCreate(
+    new ServiceAccountWrappper().init({ namespace, generateName: CONVERSION_GENERATE_NAME }),
+  );
+  const role = await k8sWrapperCreate(
+    new RoleWrappper().init({ namespace, generateName: CONVERSION_GENERATE_NAME }).addRules(
+      {
+        apiGroups: [''],
+        resources: ['pods'],
+        verbs: ['patch', 'get'],
+      },
+      {
+        apiGroups: ['security.openshift.io'],
+        resources: ['securitycontextconstraints'],
+        verbs: ['*'],
+      },
+    ),
+  );
+
+  const roleBinding = await k8sWrapperCreate(
+    new RoleBindingWrappper()
+      .init({ namespace, generateName: CONVERSION_GENERATE_NAME })
+      .setRole(getName(role))
+      .bindServiceAccount(getName(serviceAccount)),
+  );
+
+  return {
+    serviceAccount,
+    role,
+    roleBinding,
+  };
+};
+
+const resolveStorages = async ({
+  enhancedK8sMethods: { k8sWrapperCreate },
+  storages,
+  storageClassConfigMap,
+  namespace,
+}: CreateVMEnhancedParams) => {
+  const extImportPvcsPromises = storages
+    .filter(isImportStorage)
+    .map(({ persistentVolumeClaim, type }) => {
+      const pvcWrapper = new PersistentVolumeClaimWrapper(persistentVolumeClaim, true);
+      const storageClassName = pvcWrapper.getStorageClassName();
+
+      pvcWrapper
+        .setGenerateName(`${pvcWrapper.getName()}-`)
+        .setNamespace(namespace)
+        // temp disk is always of Filesystem/RWO mode
+        .assertDefaultModes(
+          type === VMWizardStorageType.V2V_VMWARE_IMPORT_TEMP
+            ? VolumeMode.FILESYSTEM
+            : getDefaultSCVolumeMode(storageClassConfigMap, storageClassName),
+          type === VMWizardStorageType.V2V_VMWARE_IMPORT_TEMP
+            ? [AccessMode.SINGLE_USER]
+            : getDefaultSCAccessModes(storageClassConfigMap, storageClassName),
+        );
+
+      return k8sWrapperCreate(pvcWrapper);
+    });
+
+  const resultImportPvcs = createBasicLookup(
+    await Promise.all(extImportPvcsPromises),
+    getGeneratedName,
+  );
+
+  const resolvedStorages = storages.map((storage) => {
+    if (isImportStorage(storage)) {
+      const persistentVolumeClaim = resultImportPvcs[`${getName(storage.persistentVolumeClaim)}-`];
+      return {
+        ...storage,
+        volume: new VolumeWrapper(storage.volume, true)
+          .setType(VolumeType.PERSISTENT_VOLUME_CLAIM, {
+            claimName: getName(persistentVolumeClaim),
+          })
+          .asResource(),
+        persistentVolumeClaim,
+      };
+    }
+    return storage;
+  });
+
+  return {
+    resolvedStorages,
+  };
+};
+
+/**
+ * Workaround for a race condition.
+ *
+ * A ServiceAccount is provided automatically (but asynchronously) for API tokens (as Secrets).
+ * A ServiceAccount can be attached to a pod only if the tokens are ready, otherwise API-level
+ * validation throws a permanent error.
+ *
+ * As a workaround, let's wait till the tokens are ready before proceeding.
+ *
+ * Note regarding implementation:
+ * polling is the simplest method how to wait for changes.
+ * There is similar k8sWatchObject function which should be used instead for consistency, but
+ * it is implemented using polling as well but with much more complex general contract than this
+ * simple flow here.
+ */
+const waitForServiceAccountSecrets = async (serviceAccount, { k8sGet }, counter = 15) => {
+  let sa = serviceAccount;
+  for (let i = 0; i < counter; i++) {
+    if ((sa?.secrets?.length || 0) > 0) {
+      return true;
+    }
+    await delay(CONVERSION_SERVICEACCOUNT_DELAY);
+    sa = await k8sGet(ServiceAccountModel, getName(serviceAccount), getNamespace(serviceAccount));
+  }
+
+  return false;
+};
+
+// Start of the Conversion pod is blocked until the PVCs are bound
+const startConversionPod = async (
+  {
+    enhancedK8sMethods: { k8sGet, k8sWrapperCreate, k8sWrapperPatch },
+    vmSettings,
+    namespace,
+    storages,
+  }: CreateVMEnhancedParams,
+  {
+    serviceAccount,
+    role,
+    roleBinding,
+    conversionPodSecret,
+  }: {
+    serviceAccount: K8sResourceCommon;
+    role: K8sResourceCommon;
+    roleBinding: K8sResourceCommon;
+    conversionPodSecret: K8sResourceCommon;
+  },
+) => {
+  const kubevirtVmwareConfigMap = await getVmwareConfigMap({ k8sGet });
+
+  const conversionPodWrapper = new PodWrappper(
+    buildConversionPod({
+      namespace,
+      vmName: getFieldValue(vmSettings, VMSettingsField.NAME),
+      serviceAccountName: getName(serviceAccount),
+      secretName: getName(conversionPodSecret),
+      imagePullPolicy: getV2vImagePullPolicy(kubevirtVmwareConfigMap),
+      image: getKubevirtV2vConversionContainerImage(kubevirtVmwareConfigMap),
+      vddkInitImage: getVddkInitContainerImage(kubevirtVmwareConfigMap),
+    }),
+  );
+
+  storages.filter(isImportStorage).forEach(({ volume, persistentVolumeClaim, importData }) => {
+    const volumeWrapper = new VolumeWrapper(volume);
+    const pvcWrapper = new PersistentVolumeClaimWrapper(persistentVolumeClaim);
+    const container = conversionPodWrapper.getContainers()[0];
+    if (pvcWrapper.getVolumeModeEnum() === VolumeMode.BLOCK) {
+      container.volumeDevices.push({
+        name: volumeWrapper.getName(),
+        devicePath: importData.devicePath,
+      });
+    } else {
+      container.volumeMounts.push({
+        name: volumeWrapper.getName(),
+        mountPath: importData.mountPath,
+      });
+    }
+    conversionPodWrapper.getVolumes().push(volumeWrapper.asResource(true));
+  });
+  //
+  //
+  await waitForServiceAccountSecrets(serviceAccount, { k8sGet });
+
+  const conversionPod = await k8sWrapperCreate(conversionPodWrapper);
+
+  if (conversionPod) {
+    const newOwnerReference = buildOwnerReference(conversionPod);
+    const pvcwrappers = storages
+      .filter((storage) => storage.type === VMWizardStorageType.V2V_VMWARE_IMPORT_TEMP)
+      .map(({ persistentVolumeClaim }) => new PersistentVolumeClaimWrapper(persistentVolumeClaim));
+
+    const patchPromises = [
+      new ServiceAccountWrappper(serviceAccount),
+      new RoleWrappper(role),
+      new RoleBindingWrappper(roleBinding),
+      new SecretWrappper(conversionPodSecret),
+      ...pvcwrappers,
+    ].map((wrapper) =>
+      k8sWrapperPatch(wrapper, [
+        new PatchBuilder('/metadata/ownerReferences')
+          .setListUpdate(newOwnerReference, wrapper.getOwnerReferences(), compareOwnerReference)
+          .build(),
+      ]),
+    );
+    await Promise.all(patchPromises);
+  }
+
+  return {
+    conversionPod,
+  };
+};
+
+const finalizeStorages = (storages: VMWizardStorage[]) =>
+  storages
+    .filter((storage) => storage.type !== VMWizardStorageType.V2V_VMWARE_IMPORT_TEMP)
+    .map((storage) => {
+      if (storage.type === VMWizardStorageType.V2V_VMWARE_IMPORT) {
+        const result = { ...storage };
+        delete result.persistentVolumeClaim;
+        return result;
+      }
+      return storage;
+    });
+
+export const importV2VVMwareVm = async (
+  params: CreateVMEnhancedParams,
+): Promise<ImporterResult> => {
+  const { networks, enhancedK8sMethods } = params;
+
+  const { conversionPodSecret } = await createConversionPodSecret(params);
+  const { role, roleBinding, serviceAccount } = await resolveRolesAndServiceAccount(params);
+  const { resolvedStorages } = await resolveStorages(params);
+
+  const { conversionPod } = await startConversionPod(
+    { ...params, storages: resolvedStorages },
+    { conversionPodSecret, role, roleBinding, serviceAccount },
+  );
+
+  return {
+    storages: finalizeStorages(resolvedStorages),
+    networks,
+    onCreate: async (vm) => {
+      await enhancedK8sMethods.k8sPatch(PodModel, conversionPod, [
+        new PatchBuilder('/metadata/ownerReferences')
+          .setListUpdate(
+            buildOwnerReference(vm),
+            getOwnerReferences(conversionPod),
+            compareOwnerReference,
+          )
+          .build(),
+      ]);
+    },
+  };
+};

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/import-v2vvmware.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/import-v2vvmware.ts
@@ -62,14 +62,14 @@ const createConversionPodSecret = async ({
   );
 
   const username = encodeURIComponent(
-    getVmwareValue(vmSettings, VMWareProviderField.USER_NAME) || secret.getValue('username', true),
+    getVmwareValue(vmSettings, VMWareProviderField.USER_NAME) || secret.getValue('username'),
   );
   const password =
     getVmwareValue(vmSettings, VMWareProviderField.USER_PASSWORD_AND_CHECK_CONNECTION) ||
-    secret.getValue('password', true);
+    secret.getValue('password');
 
   const hostname =
-    getVmwareValue(vmSettings, VMWareProviderField.HOSTNAME) || secret.getValue('url', true);
+    getVmwareValue(vmSettings, VMWareProviderField.HOSTNAME) || secret.getValue('url');
 
   const sourceDisks = (storages || [])
     .filter((storage) => storage.type === VMWizardStorageType.V2V_VMWARE_IMPORT)
@@ -77,22 +77,18 @@ const createConversionPodSecret = async ({
 
   const secretWrapper = new SecretWrappper()
     .init({ namespace, generateName: CONVERSION_GENERATE_NAME })
-    .setJSONValue(
-      'conversion.json',
-      {
-        daemonize: false,
+    .setJSONValue('conversion.json', {
+      daemonize: false,
 
-        vm_name: vm.name,
-        transport_method: 'vddk',
+      vm_name: vm.name,
+      transport_method: 'vddk',
 
-        vmware_fingerprint: thumbprint,
-        vmware_uri: `vpx://${username}@${hostname}${vm?.detail?.hostPath}?no_verify=1`,
-        vmware_password: password,
+      vmware_fingerprint: thumbprint,
+      vmware_uri: `vpx://${username}@${hostname}${vm?.detail?.hostPath}?no_verify=1`,
+      vmware_password: password,
 
-        source_disks: sourceDisks,
-      },
-      true,
-    );
+      source_disks: sourceDisks,
+    });
 
   const conversionPodSecret = await k8sWrapperCreate(secretWrapper);
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/objects/conversion-pod.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/objects/conversion-pod.ts
@@ -1,0 +1,86 @@
+import { ImagePullPolicy } from '@console/internal/module/k8s';
+import { PodWrappper } from '../../../../wrapper/k8s/pod-wrapper';
+import {
+  CONVERSION_BASE_NAME,
+  CONVERSION_GENERATE_NAME,
+  CONVERSION_VDDK_INIT_POD_NAME,
+  CONVERSION_VDDK_MOUNT_PATH,
+  CONVERSION_VOLUME_VDDK_NAME,
+} from '../../../../../constants/v2v';
+
+export const buildConversionPod = ({
+  vmName,
+  namespace,
+  serviceAccountName,
+  secretName,
+  imagePullPolicy,
+  image,
+  vddkInitImage,
+}: {
+  vmName: string;
+  namespace: string;
+  serviceAccountName: string;
+  secretName: string;
+  imagePullPolicy: ImagePullPolicy;
+  image: string;
+  vddkInitImage: string;
+}) =>
+  new PodWrappper()
+    .init({
+      generateName: `${CONVERSION_GENERATE_NAME}${vmName}-`,
+      namespace,
+      restartPolicy: 'Never',
+    })
+    .setServiceAccountName(serviceAccountName)
+    .addInitContainers({
+      name: CONVERSION_VDDK_INIT_POD_NAME,
+      image: vddkInitImage,
+      volumeMounts: [
+        {
+          name: CONVERSION_VOLUME_VDDK_NAME,
+          mountPath: CONVERSION_VDDK_MOUNT_PATH,
+        },
+      ],
+    })
+    .addContainers({
+      name: CONVERSION_BASE_NAME,
+      imagePullPolicy,
+      image,
+      securityContext: {
+        privileged: true,
+      },
+      volumeMounts: [
+        {
+          name: 'configuration',
+          mountPath: '/data/input',
+        },
+        {
+          name: 'kvm',
+          mountPath: '/dev/kvm',
+        },
+        {
+          name: CONVERSION_VOLUME_VDDK_NAME,
+          mountPath: CONVERSION_VDDK_MOUNT_PATH,
+        },
+      ],
+      volumeDevices: [],
+    })
+    .addVolumes(
+      {
+        name: 'configuration',
+        secret: {
+          secretName,
+        },
+      },
+      {
+        name: 'kvm',
+        hostPath: {
+          path: '/dev/kvm',
+        },
+      },
+      {
+        name: CONVERSION_VOLUME_VDDK_NAME,
+        emptyDir: {},
+      },
+    )
+    .asResource();

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/objects/v2vvmware-deployment.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/objects/v2vvmware-deployment.ts
@@ -1,0 +1,65 @@
+import { ImagePullPolicy } from '@console/internal/module/k8s';
+import { DeploymentWrappper } from '../../../wrapper/k8s/deployment-wrapper';
+
+export const buildV2VVMwareDeployment = ({
+  name,
+  namespace,
+  image,
+  imagePullPolicy,
+}: {
+  name: string;
+  namespace: string;
+  image: string;
+  imagePullPolicy: ImagePullPolicy;
+}) => {
+  return new DeploymentWrappper()
+    .init({ name, namespace, replicas: 1 })
+    .setSelector({
+      matchLabels: {
+        name,
+      },
+    })
+    .setTemplate({
+      metadata: {
+        labels: {
+          name,
+        },
+      },
+      spec: {
+        serviceAccountName: name,
+        containers: [
+          {
+            name,
+            image,
+            imagePullPolicy,
+            command: ['kubevirt-vmware'],
+            env: [
+              {
+                name: 'WATCH_NAMESPACE',
+                valueFrom: {
+                  fieldRef: {
+                    apiVersion: 'v1',
+                    fieldPath: 'metadata.namespace',
+                  },
+                },
+              },
+              {
+                name: 'POD_NAME',
+                valueFrom: {
+                  fieldRef: {
+                    apiVersion: 'v1',
+                    fieldPath: 'metadata.name',
+                  },
+                },
+              },
+              {
+                name: 'OPERATOR_NAME',
+                value: name,
+              },
+            ],
+          },
+        ],
+      },
+    })
+    .asResource();
+};

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/objects/v2vvmware-role.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/objects/v2vvmware-role.ts
@@ -1,0 +1,47 @@
+import { RoleWrappper } from '../../../wrapper/k8s/role-wrapper';
+
+export const buildV2VVMwareRole = ({ name, namespace }: { name: string; namespace: string }) =>
+  new RoleWrappper()
+    .init({ name, namespace })
+    .addRules(
+      {
+        apiGroups: [''],
+        attributeRestrictions: null,
+        resources: [
+          // TODO: review what's really needed
+          'configmaps',
+          'endpoints',
+          'events',
+          'persistentvolumeclaims',
+          'pods',
+          'secrets',
+          'services',
+        ],
+        verbs: ['*'],
+      },
+      {
+        apiGroups: [''],
+        attributeRestrictions: null,
+        resources: ['namespaces'],
+        verbs: ['get'],
+      },
+      {
+        apiGroups: ['apps'],
+        attributeRestrictions: null,
+        resources: ['daemonsets', 'deployments', 'replicasets', 'statefulsets'],
+        verbs: ['*'],
+      },
+      {
+        apiGroups: ['monitoring.coreos.com'],
+        attributeRestrictions: null,
+        resources: ['servicemonitors'],
+        verbs: ['create', 'get'],
+      },
+      {
+        apiGroups: ['kubevirt.io'],
+        attributeRestrictions: null,
+        resources: ['*'],
+        verbs: ['*'],
+      },
+    )
+    .asResource();

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/request-vm-detail.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/request-vm-detail.ts
@@ -1,0 +1,39 @@
+import { EnhancedK8sMethods } from '../../enhancedK8sMethods/enhancedK8sMethods';
+import { V2VVMwareModel } from '../../../models';
+import { PatchBuilder } from '@console/shared/src/k8s';
+
+const { warn } = console;
+
+export const requestVmDetail = async (
+  {
+    vmName,
+    v2vwmwareName,
+    namespace,
+  }: { vmName: string; v2vwmwareName: string; namespace: string },
+  { k8sGet, k8sPatch }: EnhancedK8sMethods,
+) => {
+  const safeVMName = (vmName || '').trim();
+
+  // The V2VVMWare object can be reused from the VCenterVmsConnected component or re-queried here. The later option helps to minimize conflicts.
+  const v2vvmware = await k8sGet(V2VVMwareModel, v2vwmwareName, namespace);
+
+  // Strategic merge patches seem not to work, so let's do mapping via positional arrays.
+  // Probably not a big deal as the controller is designed to avoid VMs list refresh
+  const index = (v2vvmware?.spec?.vms || []).findIndex((vm) => vm?.name === safeVMName);
+
+  if (index >= 0) {
+    // the controller will supply details for the selected VM
+    await k8sPatch(V2VVMwareModel, v2vvmware, [
+      new PatchBuilder(`/spec/vms/${index}`)
+        .setObjectUpdate('detailRequest', true, v2vvmware.spec.vms[index])
+        .build(),
+    ]);
+  } else {
+    warn(
+      'onVCenterVmSelectedConnected: The retrieved V2VVMware object is missing desired VM: "',
+      safeVMName,
+      '", ',
+      v2vvmware,
+    );
+  }
+};

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/start-v2vvmware-controller.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/start-v2vvmware-controller.ts
@@ -1,0 +1,171 @@
+import { DeploymentModel, RoleModel } from '@console/internal/models';
+import { getName } from '@console/shared/src';
+import { V2VVMWARE_DEPLOYMENT_NAME } from '../../../constants/v2v';
+import { getVmwareConfigMap } from './v2vvmware-configmap';
+import { getContainerImage } from '../../../selectors/pod/container';
+import { getKubevirtV2vVmwareContainerImage, getV2vImagePullPolicy } from '../../../selectors/v2v';
+import { ConfigMapKind, DeploymentKind, K8sResourceCommon } from '@console/internal/module/k8s';
+import { EnhancedK8sMethods } from '../../enhancedK8sMethods/enhancedK8sMethods';
+import { ServiceAccountWrappper } from '../../wrapper/k8s/service-account-wrapper';
+import { buildV2VVMwareRole } from './objects/v2vvmware-role';
+import { RoleBindingWrappper } from '../../wrapper/k8s/role-binding-wrapper';
+import { buildV2VVMwareDeployment } from './objects/v2vvmware-deployment';
+import { PatchBuilder } from '@console/shared/src/k8s';
+import { buildOwnerReference } from '../../../utils';
+import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
+import { RoleWrappper } from '../../wrapper/k8s/role-wrapper';
+
+const { info } = console;
+
+const OLD_VERSION = 'OLD_VERSION';
+
+// prevent parallel execution of startV2VVMWareController()
+const semaphors = {};
+
+const cleanupOldDeployment = async (
+  { activeDeployment }: { activeDeployment: DeploymentKind },
+  { k8sKill }: EnhancedK8sMethods,
+) => {
+  if (activeDeployment) {
+    await k8sKill(DeploymentModel, activeDeployment);
+  }
+  return null;
+};
+
+const resolveRolesAndServiceAccount = async (
+  { name, namespace }: { name: string; namespace: string },
+  { k8sCreate, k8sWrapperCreate }: EnhancedK8sMethods,
+) => {
+  const serviceAccount = await k8sWrapperCreate(
+    new ServiceAccountWrappper().init({ name, namespace }),
+  );
+  const role = await k8sCreate(RoleModel, buildV2VVMwareRole({ name, namespace }));
+
+  const roleBinding = await k8sWrapperCreate(
+    new RoleBindingWrappper()
+      .init({ name, namespace })
+      .setRole(getName(role))
+      .bindServiceAccount(getName(serviceAccount)),
+  );
+
+  return {
+    serviceAccount,
+    role,
+    roleBinding,
+  };
+};
+
+const startVmWare = async (
+  {
+    name,
+    namespace,
+    serviceAccount,
+    role,
+    roleBinding,
+    kubevirtVmwareConfigMap,
+  }: {
+    name: string;
+    namespace: string;
+    serviceAccount: K8sResourceCommon;
+    role: K8sResourceCommon;
+    roleBinding: K8sResourceCommon;
+    kubevirtVmwareConfigMap: ConfigMapKind;
+  },
+  { k8sCreate, k8sWrapperPatch }: EnhancedK8sMethods,
+) => {
+  const deployment = await k8sCreate(
+    DeploymentModel,
+    buildV2VVMwareDeployment({
+      name,
+      namespace,
+      image: getKubevirtV2vVmwareContainerImage(kubevirtVmwareConfigMap),
+      imagePullPolicy: getV2vImagePullPolicy(kubevirtVmwareConfigMap),
+    }),
+  );
+
+  if (deployment) {
+    const newOwnerReference = buildOwnerReference(deployment);
+
+    const patchPromises = [
+      new ServiceAccountWrappper(serviceAccount),
+      new RoleWrappper(role),
+      new RoleBindingWrappper(roleBinding),
+    ].map((object) => {
+      return k8sWrapperPatch(object, [
+        new PatchBuilder('/metadata/ownerReferences')
+          .setListUpdate(newOwnerReference, object.getOwnerReferences(), compareOwnerReference)
+          .build(),
+      ]);
+    });
+    await Promise.all(patchPromises);
+  }
+
+  return {
+    deployment,
+  };
+};
+
+// The controller is namespace-scoped, especially due to security reasons
+// Let's make sure its started within the desired namespace (which is not by default).
+// The V2VVmware CRD is expected to be already created within the cluster (by Web UI installation)
+// TODO: The controller should be deployed by a provider and not via following UI code.
+export const startV2VVMWareController = async (
+  { namespace }: { namespace: string },
+  enhancedK8sMethods: EnhancedK8sMethods,
+) => {
+  if (!namespace) {
+    throw new Error('V2V VMWare: namespace must be selected');
+  }
+  const { k8sGet } = enhancedK8sMethods;
+
+  const name = V2VVMWARE_DEPLOYMENT_NAME;
+  let activeDeployment: DeploymentKind;
+
+  if (semaphors[namespace]) {
+    info(`startV2VVMWareController for "${namespace}" namespace already in progress. Skipping...`);
+    return;
+  }
+  semaphors[namespace] = true;
+  let kubevirtVmwareConfigMap = null;
+
+  try {
+    kubevirtVmwareConfigMap = await getVmwareConfigMap({ k8sGet });
+
+    if (!kubevirtVmwareConfigMap) {
+      return; // pass through finally()
+    }
+
+    activeDeployment = await k8sGet(DeploymentModel, name, namespace);
+
+    const container = (activeDeployment?.spec?.template?.spec?.containers || []).find(
+      (c) => c.name === name,
+    );
+
+    if (
+      getContainerImage(container) !== getKubevirtV2vVmwareContainerImage(kubevirtVmwareConfigMap)
+    ) {
+      throw new Error(OLD_VERSION);
+    }
+  } catch (e) {
+    // Deployment does not exist or does not have permissions to see Deployments in this namespace
+    info(
+      e && e.message === OLD_VERSION
+        ? 'updating V2V VMWare controller'
+        : 'V2V VMWare controller deployment not found, so creating one ...',
+    );
+
+    await cleanupOldDeployment({ activeDeployment }, enhancedK8sMethods);
+    const { serviceAccount, role, roleBinding } = await resolveRolesAndServiceAccount(
+      { name, namespace },
+      enhancedK8sMethods,
+    );
+    await startVmWare(
+      { name, namespace, serviceAccount, role, roleBinding, kubevirtVmwareConfigMap },
+      enhancedK8sMethods,
+    );
+
+    info(`startV2VVMWareController for "${namespace}" namespace finished.`);
+  } finally {
+    delete semaphors[namespace];
+  }
+};

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/utils/__tests__/utils.spec.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/utils/__tests__/utils.spec.ts
@@ -1,0 +1,45 @@
+import { getDefaultSecretName } from '../utils';
+
+describe('getDefaultSecretName', () => {
+  it(`generates provider's secret name correctly`, () => {
+    const url = 'https://my.host.com';
+    const urlNoProtocol = 'my.host.com';
+    const urlSingleDomain = 'my-host';
+    const urlLong = 'my-host.with-very-long-url-exceeding-all-reasonable-limits.com';
+
+    const username = 'myuser';
+    const usernameNone = undefined;
+    const usernameEmpty = '';
+    const usernameDomain = 'mydomainuser@domain.com';
+    const usernameLong =
+      'verylongusernameexceedinglimits@very-long-domain-which-makes-no-sense.com';
+    const usernameNonalphanum = '.nonalpha@.-';
+    const usernameNonalphanum2 = '.@.-';
+
+    expect(getDefaultSecretName({ username, url })).toEqual('myuser-my-host-com');
+    expect(getDefaultSecretName({ username, url: urlNoProtocol })).toEqual('myuser-my-host-com');
+    expect(getDefaultSecretName({ username, url: urlSingleDomain })).toEqual('myuser-my-host');
+    expect(getDefaultSecretName({ username, url: urlLong })).toEqual(
+      'myuser-my-host-with-very-long',
+    );
+
+    expect(getDefaultSecretName({ username: usernameNonalphanum, url })).toEqual(
+      'nonalpha-my-host-com',
+    );
+    expect(getDefaultSecretName({ username: usernameNonalphanum2, url })).toEqual(
+      'nouser-my-host-com',
+    );
+    expect(getDefaultSecretName({ username: usernameNone, url })).toEqual('nousername-my-host-com');
+    expect(getDefaultSecretName({ username: usernameEmpty, url })).toEqual(
+      'nousername-my-host-com',
+    );
+    expect(getDefaultSecretName({ username: usernameDomain, url })).toEqual(
+      'mydomainuser-my-host-com',
+    );
+    expect(getDefaultSecretName({ username: usernameLong, url })).toEqual(
+      'verylongusernam-my-host-com',
+    );
+
+    expect(() => getDefaultSecretName({ username, url: undefined })).toThrow();
+  });
+});

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/utils/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/utils/utils.ts
@@ -1,0 +1,31 @@
+import { alignWithDNS1123 } from '@console/shared/src';
+
+/**
+ * Based on V2V Provider Pod manifest.yaml
+ */
+
+const MAX_LEN = 30;
+
+export const getDefaultSecretName = ({ username, url }) => {
+  if (!url) {
+    throw new Error('VMware URL can not be empty.');
+  }
+  let resultUrl = url;
+  let resultUsername = username;
+
+  if (!resultUrl.startsWith('https://') && !resultUrl.startsWith('http://')) {
+    resultUrl = `https://${resultUrl}`;
+  }
+  const u = new URL(resultUrl);
+  resultUsername = resultUsername || 'nousername';
+
+  let user = resultUsername.split('@')[0].substring(0, 15);
+  let host = (u.host || 'nohost').substring(0, MAX_LEN - user.length - 1);
+
+  user = alignWithDNS1123(user);
+  host = alignWithDNS1123(host);
+
+  user = user || 'nouser';
+
+  return `${user}-${host}`;
+};

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/v2vvmware-configmap.ts
@@ -1,0 +1,41 @@
+import { ConfigMapModel } from '@console/internal/models';
+import {
+  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME,
+  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES,
+} from '../../../constants/v2v';
+
+const { info, warn } = console;
+
+const getVmwareConfigMapInNamespace = async ({ k8sGet, namespace }) => {
+  try {
+    return await k8sGet(ConfigMapModel, VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME, namespace, null, {
+      disableHistory: true,
+    });
+  } catch (e) {
+    info(
+      `The ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} can not be found in the ${namespace} namespace.  Another namespace will be queried, if any left. Error: `,
+      e,
+    );
+  }
+  return null;
+};
+
+export const getVmwareConfigMap = async (props) => {
+  // query namespaces sequentially to respect order
+  for (const namespace of VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES) {
+    // eslint-disable-next-line no-await-in-loop
+    const configMap = await getVmwareConfigMapInNamespace({
+      namespace,
+      ...props,
+    });
+    if (configMap) {
+      return configMap;
+    }
+  }
+  warn(
+    `The ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} can not be found in none of following namespaces: `,
+    JSON.stringify(VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES),
+    '. The v2v pods can not be created.',
+  );
+  return null;
+};

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/initialize-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/initialize-vm.ts
@@ -74,14 +74,8 @@ const initializeStorage = (params: CreateVMEnhancedParams, vm: VMWrapper) => {
         )
         .setNamespace(isPlainDataVolume ? namespace : undefined)
         .assertDefaultModes(
-          getDefaultSCVolumeMode(
-            storageClassConfigMap,
-            dataVolumeWrapper.getStorageClassName(),
-          ).toString(),
-          getDefaultSCAccessModes(
-            storageClassConfigMap,
-            dataVolumeWrapper.getStorageClassName(),
-          ).map((a) => a.toString()),
+          getDefaultSCVolumeMode(storageClassConfigMap, dataVolumeWrapper.getStorageClassName()),
+          getDefaultSCAccessModes(storageClassConfigMap, dataVolumeWrapper.getStorageClassName()),
         );
 
       if (volumeWrapper.getType() === VolumeType.DATA_VOLUME) {

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/types.ts
@@ -1,0 +1,10 @@
+import { VMWizardNetwork, VMWizardStorage } from '../../../components/create-vm-wizard/types';
+import { VMKind } from '../../../types/vm';
+
+export type OnVMCreate = (vm: VMKind) => Promise<void>;
+
+export type ImporterResult = {
+  networks: VMWizardNetwork[];
+  storages: VMWizardStorage[];
+  onCreate: OnVMCreate;
+};

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/common/k8s-resource-object-with-type-property-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/common/k8s-resource-object-with-type-property-wrapper.ts
@@ -1,5 +1,5 @@
 /* eslint-disable lines-between-class-members */
-import { getName, hasLabel, getLabels } from '@console/shared/src';
+import { getName, hasLabel, getLabels, getOwnerReferences } from '@console/shared/src';
 import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { K8sResourceKindMethods } from '../types/types';
 import { ObjectWithTypePropertyWrapper } from './object-with-type-property-wrapper';
@@ -43,6 +43,7 @@ export abstract class K8sResourceObjectWithTypePropertyWrapper<
   getName = () => getName(this.data);
   getLabels = (defaultValue = {}) => getLabels(this.data, defaultValue);
   hasLabel = (label: string) => hasLabel(this.data, label);
+  getOwnerReferences = () => getOwnerReferences(this.data);
 
   setName = (name: string) => {
     this.ensurePath('metadata');

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/common/k8s-resource-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/common/k8s-resource-wrapper.ts
@@ -1,12 +1,18 @@
 /* eslint-disable lines-between-class-members */
-import { getName, getNamespace, hasLabel, getLabels } from '@console/shared/src';
-import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
+import {
+  getName,
+  getNamespace,
+  hasLabel,
+  getLabels,
+  getOwnerReferences,
+} from '@console/shared/src';
+import { K8sKind, K8sResourceCommon } from '@console/internal/module/k8s';
 import { Wrapper } from './wrapper';
 import { K8sResourceKindMethods } from '../types/types';
 import { clearRuntimeMetadata, initK8sObject, K8sInitAddon } from './util/k8s-mixin';
 
 export abstract class K8sResourceWrapper<
-  RESOURCE extends K8sResourceKind,
+  RESOURCE extends K8sResourceCommon,
   SELF extends K8sResourceWrapper<RESOURCE, SELF>
 > extends Wrapper<RESOURCE, SELF> implements K8sResourceKindMethods {
   private readonly model: K8sKind;
@@ -34,10 +40,19 @@ export abstract class K8sResourceWrapper<
   getNamespace = () => getNamespace(this.data);
   getLabels = (defaultValue = {}) => getLabels(this.data, defaultValue);
   hasLabel = (label: string) => hasLabel(this.data, label);
+  getOwnerReferences = () => getOwnerReferences(this.data);
 
   setName = (name: string) => {
     this.ensurePath('metadata');
     this.data.metadata.name = name;
+    delete this.data.metadata.generateName;
+    return (this as any) as SELF;
+  };
+
+  setGenerateName = (generateName: string) => {
+    this.ensurePath('metadata');
+    this.data.metadata.generateName = generateName;
+    delete this.data.metadata.name;
     return (this as any) as SELF;
   };
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/common/wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/common/wrapper.ts
@@ -47,4 +47,6 @@ export abstract class Wrapper<RESOURCE extends {}, SELF extends Wrapper<RESOURCE
     }
     return (this as any) as SELF;
   };
+
+  protected uncheckedData = () => this.data as any;
 }

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/deployment-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/deployment-wrapper.ts
@@ -1,0 +1,44 @@
+import {
+  DeploymentKind,
+  K8sResourceCommon,
+  PodTemplate,
+  Selector,
+} from '@console/internal/module/k8s';
+import { DeploymentModel } from '@console/internal/models';
+import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
+import { K8sInitAddon } from '../common/util/k8s-mixin';
+
+export class DeploymentWrappper extends K8sResourceWrapper<DeploymentKind, DeploymentWrappper> {
+  constructor(deployment?: K8sResourceCommon | DeploymentWrappper | any, copy = false) {
+    super(DeploymentModel, deployment, copy);
+  }
+
+  init(data: K8sInitAddon & { replicas?: number } = {}) {
+    super.init(data);
+    const { replicas } = data;
+
+    if (replicas != null) {
+      this.setReplicas(replicas);
+    }
+
+    return this;
+  }
+
+  setReplicas = (replicas: number) => {
+    this.ensurePath('spec');
+    this.data.spec.replicas = replicas;
+    return this;
+  };
+
+  setSelector = (selector: Selector) => {
+    this.ensurePath('spec');
+    this.data.spec.selector = selector;
+    return this;
+  };
+
+  setTemplate = (template: PodTemplate) => {
+    this.ensurePath('spec');
+    this.data.spec.template = template;
+    return this;
+  };
+}

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/pod-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/pod-wrapper.ts
@@ -1,10 +1,10 @@
-import { ContainerSpec, K8sResourceCommon, PodKind, Volume } from '@console/internal/module/k8s';
+import { ContainerSpec, PodKind, Volume } from '@console/internal/module/k8s';
 import { PodModel } from '@console/internal/models';
 import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
 import { K8sInitAddon } from '../common/util/k8s-mixin';
 
 export class PodWrappper extends K8sResourceWrapper<PodKind, PodWrappper> {
-  constructor(pod?: K8sResourceCommon | PodWrappper | any, copy = false) {
+  constructor(pod?: PodKind | PodWrappper | any, copy = false) {
     super(PodModel, pod, copy);
   }
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/pod-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/pod-wrapper.ts
@@ -1,0 +1,53 @@
+import { ContainerSpec, K8sResourceCommon, PodKind, Volume } from '@console/internal/module/k8s';
+import { PodModel } from '@console/internal/models';
+import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
+import { K8sInitAddon } from '../common/util/k8s-mixin';
+
+export class PodWrappper extends K8sResourceWrapper<PodKind, PodWrappper> {
+  constructor(pod?: K8sResourceCommon | PodWrappper | any, copy = false) {
+    super(PodModel, pod, copy);
+  }
+
+  init(data: K8sInitAddon & { restartPolicy?: 'Always' | 'OnFailure' | 'Never' } = {}) {
+    super.init(data);
+    const { restartPolicy } = data;
+    this.ensurePath('spec');
+    this.setRestartPolicy(restartPolicy || 'Never');
+
+    return this;
+  }
+
+  getContainers = () => this.data.spec?.containers;
+
+  getVolumes = () => this.data.spec?.volumes;
+
+  setServiceAccountName = (serviceAccountName: string) => {
+    this.ensurePath('spec');
+    this.data.spec.serviceAccountName = serviceAccountName;
+    return this;
+  };
+
+  setRestartPolicy = (restartPolicy: 'Always' | 'OnFailure' | 'Never') => {
+    this.ensurePath('spec');
+    this.data.spec.restartPolicy = restartPolicy;
+    return this;
+  };
+
+  addVolumes = (...volumes: Volume[]) => {
+    this.ensurePath('spec.volumes', []);
+    this.data.spec.volumes.push(...volumes);
+    return this;
+  };
+
+  addContainers = (...containers: ContainerSpec[]) => {
+    this.ensurePath('spec.containers', []);
+    this.data.spec.containers.push(...containers);
+    return this;
+  };
+
+  addInitContainers = (...initContainers: ContainerSpec[]) => {
+    this.ensurePath('spec.initContainers', []);
+    this.data.spec.initContainers.push(...initContainers);
+    return this;
+  };
+}

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/role-binding-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/role-binding-wrapper.ts
@@ -1,0 +1,31 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { RoleBindingModel, RoleModel, ServiceAccountModel } from '@console/internal/models';
+import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
+
+export class RoleBindingWrappper extends K8sResourceWrapper<
+  K8sResourceCommon,
+  RoleBindingWrappper
+> {
+  constructor(roleBinding?: K8sResourceCommon | RoleBindingWrappper | any, copy = false) {
+    super(RoleBindingModel, roleBinding, copy);
+  }
+
+  setRole = (roleName: string) => {
+    this.uncheckedData().roleRef = {
+      kind: RoleModel.kind,
+      name: roleName,
+      apiGroup: RoleModel.apiGroup,
+    };
+    return this;
+  };
+
+  bindServiceAccount = (serviceAccountName: string) => {
+    this.ensurePath('subjects', []);
+
+    this.uncheckedData().subjects.push({
+      kind: ServiceAccountModel.kind,
+      name: serviceAccountName,
+    });
+    return this;
+  };
+}

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/role-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/role-wrapper.ts
@@ -1,0 +1,15 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { RoleModel } from '@console/internal/models';
+import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
+
+export class RoleWrappper extends K8sResourceWrapper<K8sResourceCommon, RoleWrappper> {
+  constructor(role?: K8sResourceCommon | RoleWrappper | any, copy = false) {
+    super(RoleModel, role, copy);
+  }
+
+  addRules = (...rules: any[]) => {
+    this.ensurePath('rules', []);
+    this.uncheckedData().rules.push(...rules);
+    return this;
+  };
+}

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/secret-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/secret-wrapper.ts
@@ -1,0 +1,46 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
+import { SecretModel } from '@console/internal/models';
+import { K8sInitAddon } from '../common/util/k8s-mixin';
+
+export class SecretWrappper extends K8sResourceWrapper<K8sResourceCommon, SecretWrappper> {
+  constructor(secret?: K8sResourceCommon | SecretWrappper | any, copy = false) {
+    super(SecretModel, secret, copy);
+  }
+
+  init(data: K8sInitAddon & { type?: string } = {}) {
+    super.init(data);
+    if (data.type || !this.uncheckedData().type) {
+      this.setType(data.type || 'Opaque');
+    }
+
+    return this;
+  }
+
+  setType = (type: string) => {
+    this.uncheckedData().type = type;
+    return this;
+  };
+
+  getValue = (key: string, isBase64Encoded = false) => {
+    const value = this.uncheckedData().data ? this.uncheckedData().data[key] : undefined;
+    return isBase64Encoded ? atob(value) : value;
+  };
+
+  getFromJSONValue = (key: string, isBase64Encoded = false) =>
+    JSON.parse(this.getValue(key, isBase64Encoded));
+
+  setData = (data: object) => {
+    this.uncheckedData().data = data;
+    return this;
+  };
+
+  setValue = (key: string, value: string, isBase64Encoded = false) => {
+    this.ensurePath('data');
+    this.uncheckedData().data[key] = isBase64Encoded ? btoa(value) : value;
+    return this;
+  };
+
+  setJSONValue = (key: string, value: object, isBase64Encoded = false) =>
+    this.setValue(key, JSON.stringify(value), isBase64Encoded);
+}

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/secret-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/secret-wrapper.ts
@@ -22,12 +22,12 @@ export class SecretWrappper extends K8sResourceWrapper<K8sResourceCommon, Secret
     return this;
   };
 
-  getValue = (key: string, isBase64Encoded = false) => {
+  getValue = (key: string, isBase64Encoded = true) => {
     const value = this.uncheckedData().data ? this.uncheckedData().data[key] : undefined;
     return isBase64Encoded ? atob(value) : value;
   };
 
-  getFromJSONValue = (key: string, isBase64Encoded = false) =>
+  getFromJSONValue = (key: string, isBase64Encoded = true) =>
     JSON.parse(this.getValue(key, isBase64Encoded));
 
   setData = (data: object) => {
@@ -35,12 +35,12 @@ export class SecretWrappper extends K8sResourceWrapper<K8sResourceCommon, Secret
     return this;
   };
 
-  setValue = (key: string, value: string, isBase64Encoded = false) => {
+  setValue = (key: string, value: string, isBase64Encoded = true) => {
     this.ensurePath('data');
     this.uncheckedData().data[key] = isBase64Encoded ? btoa(value) : value;
     return this;
   };
 
-  setJSONValue = (key: string, value: object, isBase64Encoded = false) =>
+  setJSONValue = (key: string, value: object, isBase64Encoded = true) =>
     this.setValue(key, JSON.stringify(value), isBase64Encoded);
 }

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/service-account-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/k8s/service-account-wrapper.ts
@@ -1,0 +1,12 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { ServiceAccountModel } from '@console/internal/models';
+import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
+
+export class ServiceAccountWrappper extends K8sResourceWrapper<
+  K8sResourceCommon,
+  ServiceAccountWrappper
+> {
+  constructor(serviceAccount?: K8sResourceCommon | ServiceAccountWrappper | any, copy = false) {
+    super(ServiceAccountModel, serviceAccount, copy);
+  }
+}

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/v2vvmware/v2vvmware-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/v2vvmware/v2vvmware-wrapper.ts
@@ -1,0 +1,33 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { K8sResourceWrapper } from '../common/k8s-resource-wrapper';
+import { V2VVMwareModel } from '../../../models';
+import { K8sInitAddon } from '../common/util/k8s-mixin';
+import { VCENTER_TEMPORARY_LABEL } from '../../../constants/v2v';
+
+type InitData = {
+  isTemporary?: boolean; // remove this object automatically (by controller)
+};
+
+export class V2VVMwareWrappper extends K8sResourceWrapper<K8sResourceCommon, V2VVMwareWrappper> {
+  constructor(v2vvmware?: K8sResourceCommon | V2VVMwareWrappper | any, copy = false) {
+    super(V2VVMwareModel, v2vvmware, copy);
+  }
+
+  init(data: K8sInitAddon & InitData = {}) {
+    super.init(data);
+    const { isTemporary } = data;
+
+    if (isTemporary) {
+      this.ensurePath('metadata.labels');
+      this.data.metadata.labels[VCENTER_TEMPORARY_LABEL] = 'true'; // will be automatically garbage-collected by the controller
+    }
+
+    return this;
+  }
+
+  setConnection = (connectionSecretName: string) => {
+    this.ensurePath('spec');
+    (this.data as any).spec.connection = connectionSecretName;
+    return this;
+  };
+}

--- a/frontend/packages/kubevirt-plugin/src/selectors/pod/container.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/pod/container.ts
@@ -1,12 +1,12 @@
 import { get, includes } from 'lodash';
-import { PodKind, ContainerStatus } from '@console/internal/module/k8s';
+import { PodKind, ContainerStatus, ContainerSpec } from '@console/internal/module/k8s';
 
 const failedWaitingContainerReasons = ['ImagePullBackOff', 'ErrImagePull', 'CrashLoopBackOff'];
 const failedTerminationContaineReasons = ['Error'];
 
 const getContainerWaitingReason = (container: ContainerStatus) =>
   get(container, 'state.waiting.reason') as ContainerStatus['state']['waiting']['reason'];
-export const getContainerImage = (container: ContainerStatus) =>
+export const getContainerImage = (container: ContainerStatus | ContainerSpec) =>
   get(container, 'image') as ContainerStatus['image'];
 const getContainerTerminatedReason = (container: ContainerStatus) =>
   get(container, 'state.terminated.reason') as ContainerStatus['state']['terminated']['reason'];

--- a/frontend/packages/kubevirt-plugin/src/selectors/v2v/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/v2v/selectors.ts
@@ -1,1 +1,33 @@
+import * as _ from 'lodash';
+import { VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME } from '../../constants/v2v';
+import { ConfigMapKind } from '@console/internal/module/k8s';
+
 export const getVMWareConnectionName = (value) => value && value.spec && value.spec.connection;
+
+// full image name of kubevirt-v2v-conversion
+// Presence and proper content of the ConfigMap is hard requirement, so ensure proper info makes it into the logs otherwise.
+export const getKubevirtV2vConversionContainerImage = (kubevirtVmwareConfigMap: ConfigMapKind) =>
+  _.get(
+    kubevirtVmwareConfigMap,
+    ['data', 'v2v-conversion-image'],
+    `v2v-conversion-image is missing in the ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} ConfigMap`,
+  );
+
+// the kubevirt-vmware provider is responsible for reading VMs list/details from the VMware API
+export const getKubevirtV2vVmwareContainerImage = (kubevirtVmwareConfigMap: ConfigMapKind) =>
+  _.get(
+    kubevirtVmwareConfigMap,
+    ['data', 'kubevirt-vmware-image'],
+    `kubevirt-vmware-image is missing in the ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} ConfigMap`,
+  );
+
+export const getVddkInitContainerImage = (kubevirtVmwareConfigMap: ConfigMapKind) =>
+  _.get(
+    kubevirtVmwareConfigMap,
+    ['data', 'vddk-init-image'],
+    `vddk-init-image is missing in the ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} ConfigMap`,
+  );
+
+// optional param in the ConfigMap
+export const getV2vImagePullPolicy = (kubevirtVmwareConfigMap: ConfigMapKind) =>
+  _.get(kubevirtVmwareConfigMap, ['data', 'kubevirt-vmware-image-pull-policy'], 'IfNotPresent');

--- a/frontend/packages/kubevirt-plugin/src/utils/immutable.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/immutable.ts
@@ -21,6 +21,9 @@ export const iFirehoseResultToJS = (immutableValue, isList = true) => {
 export const immutableListToShallowJS = <A = any>(list, defaultValue: A[] = []): A[] =>
   list ? list.toArray().map((p) => p.toJSON()) : defaultValue;
 
+export const immutableListToJS = <A = any>(list, defaultValue: A[] = []): A[] =>
+  list ? list.toArray().map((p) => p.toJS()) : defaultValue;
+
 export const hasTruthyValue = (obj) => !!(obj && !!obj.find((value) => value));
 
 export const iGet = (obj, key: string, defaultValue = undefined) =>

--- a/frontend/packages/kubevirt-plugin/src/utils/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/index.ts
@@ -64,8 +64,10 @@ export const insertName = (value: string, name) => {
   return joinIDs(name, value);
 };
 
-export const parseNumber = (value, defaultValue = null) =>
-  _.isFinite(value) ? Number(value) : defaultValue;
+export const parseNumber = (value, defaultValue = null) => {
+  const result = Number(value);
+  return Number.isNaN(result) ? defaultValue : result;
+};
 
 export const buildOwnerReference = (
   owner: K8sResourceKind,

--- a/frontend/packages/kubevirt-plugin/src/utils/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/utils.ts
@@ -5,6 +5,8 @@ import { VirtualMachineModel } from '../models';
 
 export const getSequence = (from, to) => Array.from({ length: to - from + 1 }, (v, i) => i + from);
 
+export const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export const setNativeValue = (element, value) => {
   const valueSetter = Object.getOwnPropertyDescriptor(element, 'value').set;
   const prototype = Object.getPrototypeOf(element);

--- a/frontend/packages/kubevirt-plugin/src/utils/validations/template/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/validations/template/utils.ts
@@ -50,7 +50,7 @@ export const combineIntegerValidationResults = (
     if (!hasWarning && maxBoundsResult) {
       message = maxBoundsResult.getErrorMessage();
     } else {
-      const verb = this.type === ValidationErrorType.Warn ? 'should' : 'must';
+      const verb = finalType === ValidationErrorType.Warn ? 'should' : 'must';
       // include all types to show all intervals
       message = `Memory ${verb} be in one of these intervals: ${joinGrammaticallyListOfItems(
         _.uniqWith(results, intervalEquals)


### PR DESCRIPTION
```
- remove kubevirtInterOP function
- make PersistentVolumeClaimWrapper use init
- add hook onVMCreate to createVM function
- add wrappers for used K8s objects
- use Wrappers and PatchBuilder
- introduce DeploymentWrapper
- move and refactor createV2VvmwareObject

- fix parseNumber
- add vm owner references to the storage
+ few other bug fixes
```