### PR TITLE
Bug 1809812: Fix catalog overflow on mobile

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -118,6 +118,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
 
   &__content {
     flex: 1 1 auto;
+    overflow: hidden;
   }
 
   &__description {


### PR DESCRIPTION
Added property to hide overflow on offending section of catalog.

<img width="305" alt="Screen Shot 2020-03-17 at 12 03 47 PM" src="https://user-images.githubusercontent.com/7014965/76875776-66823f00-6847-11ea-9fec-4321e1edc9bf.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1809812.