### PR TITLE
Fix capitalization and wording in Slack receiver form

### DIFF
--- a/frontend/public/components/monitoring/receiver-forms/slack-receiver-form.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/slack-receiver-form.tsx
@@ -15,7 +15,7 @@ export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormCha
           className="control-label co-required"
           htmlFor="slack-api-url"
         >
-          Slack API Url
+          Slack API URL
         </label>
         <div className="row">
           <div className="col-sm-7">
@@ -38,11 +38,11 @@ export const Form: React.FC<FormProps> = ({ globals, formValues, dispatchFormCha
             <SaveAsDefaultCheckbox
               formField="slackSaveAsDefault"
               disabled={formValues.slack_api_url === globals?.slack_api_url}
-              label="Save as default Slack API Url"
+              label="Save as default Slack API URL"
               formValues={formValues}
               dispatchFormChange={dispatchFormChange}
-              tooltip="Checking this box will write the api url to the global section of the
-                configuration file where it will become default api url for future Slack receivers."
+              tooltip="Checking this box will write the API URL to the global section of the
+                configuration file where it will become the default API URL for future Slack receivers."
             />
           </div>
         </div>


### PR DESCRIPTION
Just some minor capitalization fixes of "URL" and "API" in the Slack receiver form, and added the word "the" to one infotip.

### Before

![image](https://user-images.githubusercontent.com/9122899/76911116-4e7de000-6886-11ea-869f-c405351389ba.png)

### After

![image](https://user-images.githubusercontent.com/9122899/76911669-c698d580-6887-11ea-9d9e-b6a5c251e219.png)

