### PR TITLE
Monitoring: Show warning icon for alerts with unrecognized severities

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -211,14 +211,14 @@ const Severity: React.FC<{ severity?: string }> = ({ severity }) => {
       </>
     );
   }
-  if (severity === 'warning') {
-    return (
-      <>
-        <YellowExclamationTriangleIcon /> Warning
-      </>
-    );
+  if (severity === 'none') {
+    return <>None</>;
   }
-  return <>{_.startCase(severity) || '-'}</>;
+  return (
+    <>
+      <YellowExclamationTriangleIcon /> {_.startCase(severity) || '-'}
+    </>
+  );
 };
 
 const Annotation = ({ children, title }) =>


### PR DESCRIPTION
Only omit the icon if the severity is `none`.

![screenshot](https://user-images.githubusercontent.com/460802/76923638-4e79f080-6917-11ea-972d-070b59178a0a.png)

Corrects icon logic introduced by https://github.com/openshift/console/pull/4749

FYI @cshinn 