### PR TITLE
Created new plugin for LSO

### DIFF
--- a/frontend/packages/local-storage-operator-plugin/OWNERS
+++ b/frontend/packages/local-storage-operator-plugin/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+  - a2batic
+  - afreen23
+  - bipuladh
+  - cloudbehl
+  - gnehapk
+approvers:
+  - afreen23
+  - bipuladh
+  - cloudbehl
+  - gnehapk

--- a/frontend/packages/local-storage-operator-plugin/package.json
+++ b/frontend/packages/local-storage-operator-plugin/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@console/local-storage-operator-plugin",
+  "version": "0.0.0-fixed",
+  "description": "LSO - Operator for local storage",
+  "private": true,
+  "dependencies": {
+    "@console/plugin-sdk": "0.0.0-fixed",
+    "@console/shared": "0.0.0-fixed",
+    "@console/internal": "0.0.0-fixed"
+  },
+  "consolePlugin": {
+    "entry": "src/plugin.ts"
+  }
+}

--- a/frontend/packages/local-storage-operator-plugin/src/models.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/models.ts
@@ -1,0 +1,27 @@
+import { K8sKind } from '@console/internal/module/k8s';
+
+export const LocalVolumeGroupModel: K8sKind = {
+  label: 'Local Volume Group',
+  labelPlural: 'Local Volume Groups',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'local.storage.openshift.io',
+  plural: 'localvolumegroups',
+  abbr: 'LVG',
+  namespaced: true,
+  kind: 'LocalVolumeGroup',
+  id: 'localvolumegroup',
+  crd: true,
+};
+
+export const LocalVolumeModel: K8sKind = {
+  label: 'Local Volume',
+  labelPlural: 'Local Volumes',
+  apiVersion: 'v1',
+  apiGroup: 'local.storage.openshift.io',
+  plural: 'localvolumes',
+  abbr: 'LV',
+  namespaced: true,
+  kind: 'LocalVolume',
+  id: 'localvolume',
+  crd: true,
+};

--- a/frontend/packages/local-storage-operator-plugin/src/plugin.ts
+++ b/frontend/packages/local-storage-operator-plugin/src/plugin.ts
@@ -1,0 +1,25 @@
+import * as _ from 'lodash';
+import { ModelDefinition, ModelFeatureFlag, Plugin } from '@console/plugin-sdk';
+import * as models from './models';
+
+type ConsumedExtensions = ModelFeatureFlag | ModelDefinition;
+
+const LSO_FLAG = 'LSO';
+
+const plugin: Plugin<ConsumedExtensions> = [
+  {
+    type: 'ModelDefinition',
+    properties: {
+      models: _.values(models),
+    },
+  },
+  {
+    type: 'FeatureFlag/Model',
+    properties: {
+      model: models.LocalVolumeModel,
+      flag: LSO_FLAG,
+    },
+  },
+];
+
+export default plugin;


### PR DESCRIPTION
This new plugin is required to create UI for -

- automated discovery of local disks via the `LocalVolumeDiscovery` CR and exposing the result via `LocalVolumeNodeDiscoveryResult` CR.
- automated provisioning`VolumeDiscovery` CRD and sorting them into StorageClasses based on their characteristics via the `LocalVolumeGroup` CRD. 

These CRDs will be implemented in the LocalStorageOperator(LSO)

This is required to automate OpenShift Container Storage deployment on bare metal from UI.
More details can be found [here](https://github.com/openshift/enhancements/pull/237)

