### PR TITLE
Bug 1814639: Refactor description used for DevCatalog

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/dev-catalog.ts
@@ -29,8 +29,8 @@ export const normalizeClusterServiceVersions = (
         }`
       : operatorLogo;
 
-  const formatTileDescription = (crdDescription: string, csvDescription: string): string =>
-    `${crdDescription}\n## Operator Description\n${csvDescription}`;
+  const formatTileDescription = (csvDescription: string): string =>
+    `## Operator Description\n${csvDescription}`;
 
   const operatorProvidedAPIs: K8sResourceKind[] = _.flatten(
     clusterServiceVersions.map((csv) => providedAPIsFor(csv).map((desc) => ({ ...desc, csv }))),
@@ -60,7 +60,8 @@ export const normalizeClusterServiceVersions = (
         .toLowerCase()
         .replace(/\s/g, ''),
       tileImgUrl: imgFor(desc),
-      tileDescription: formatTileDescription(desc.description, desc.csv.spec.description),
+      tileDescription: desc.description,
+      markdownDescription: formatTileDescription(desc.csv.spec.description),
       tileProvider: desc.csv.spec.provider.name,
       tags: desc.csv.spec.keywords,
       createLabel: 'Create',

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -260,6 +260,18 @@ $catalog-tile-width: $co-m-catalog-tile-width;
     // TODO: find fix for urls that don't wrap
     // fix below causes undesirable wrapping on non-urls
     // word-break: break-all;
+    h1, h2, h3 {
+      color: #333; // same color as styles hardcoded in markdown text component
+    }
+
+    h2 {
+      font-size: 20px;
+    }
+
+    p, li, ol {
+      color: #333; // same color as styles hardcoded in markdown text component
+      font-size: $font-size-base !important;
+    }
 
     @media(min-width: $screen-sm-min) {
         flex: 1 1 auto;

--- a/frontend/public/components/catalog/catalog-item-details.jsx
+++ b/frontend/public/components/catalog/catalog-item-details.jsx
@@ -35,6 +35,7 @@ export class CatalogTileDetails extends React.Component {
       obj,
       kind,
       tileProvider,
+      markdownDescription,
       tileDescription,
       supportUrl,
       longDescription,
@@ -77,7 +78,8 @@ export class CatalogTileDetails extends React.Component {
               </PropertiesSidePanel>
               <div className="co-catalog-page__overlay-description">
                 <SectionHeading text="Description" />
-                {tileDescription && <SyncMarkdownView content={tileDescription} />}
+                {tileDescription && <p>{tileDescription}</p>}
+                {markdownDescription && <SyncMarkdownView content={markdownDescription} />}
                 {longDescription && <p>{longDescription}</p>}
                 {sampleRepo && <p>Sample repository: {sampleRepoLink}</p>}
                 {documentationUrl && (


### PR DESCRIPTION
There's now a separate variable for tile descriptions and a separate variable for markdown descriptions. They're added to the modal if they're available. I also made some minor tweaks to the modal text styling so they're consistent (same black, same font size).

<img width="1049" alt="Screen Shot 2020-03-18 at 12 49 41 PM" src="https://user-images.githubusercontent.com/7014965/76985757-196d9e00-6917-11ea-8b00-bc4e4d01f9fb.png">

<img width="1392" alt="Screen Shot 2020-03-18 at 3 56 00 PM" src="https://user-images.githubusercontent.com/7014965/77001879-07005e00-6931-11ea-8b26-81267ee53d00.png">

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1814639 and https://issues.redhat.com/browse/ODC-3126.