### PR TITLE
Alertmanager integration test:  implemented clear() & sendKeys() fix

### DIFF
--- a/frontend/integration-tests/tests/alertmanager.scenario.ts
+++ b/frontend/integration-tests/tests/alertmanager.scenario.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import { safeLoad } from 'js-yaml';
 
 import { checkLogs, checkErrors, firstElementByTestID, appHost } from '../protractor.conf';
+import { fillInput } from '@console/shared/src/test-utils/utils';
 import { dropdownMenuForTestID } from '../views/form.view';
 import {
   AlertmanagerConfig,
@@ -13,12 +14,6 @@ import * as yamlView from '../views/yaml.view';
 import * as monitoringView from '../views/monitoring.view';
 import * as horizontalnavView from '../views/horizontal-nav.view';
 import { execSync } from 'child_process';
-
-const replaceInput = async (fieldName: string, value: string) => {
-  await browser.wait(until.elementToBeClickable(firstElementByTestID(fieldName)));
-  await firstElementByTestID(fieldName).clear();
-  await firstElementByTestID(fieldName).sendKeys(value);
-};
 
 const getGlobalsAndReceiverConfig = (configName: string, yamlStr: string) => {
   const config: AlertmanagerConfig = safeLoad(yamlStr);
@@ -77,7 +72,10 @@ describe('Alertmanager: PagerDuty Receiver Form', () => {
     expect(monitoringView.saveAsDefault.isEnabled()).toBeFalsy();
 
     // changing url, enables monitoringView.saveAsDefault unchecked, should save pagerduty_url with Receiver
-    await replaceInput('pagerduty-url', 'http://pagerduty-url-specific-to-receiver');
+    await fillInput(
+      firstElementByTestID('pagerduty-url'),
+      'http://pagerduty-url-specific-to-receiver',
+    );
     expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy();
     expect(monitoringView.saveAsDefault.getAttribute('checked')).toBeFalsy();
     await monitoringView.saveButton.click();
@@ -94,7 +92,7 @@ describe('Alertmanager: PagerDuty Receiver Form', () => {
     // save pagerduty_url as default/global
     await browser.get(`${appHost}/monitoring/alertmanagerconfig/receivers/MyReceiver/edit`);
     await browser.wait(until.presenceOf(firstElementByTestID('cancel')));
-    await replaceInput('pagerduty-url', 'http://global-pagerduty-url');
+    await fillInput(firstElementByTestID('pagerduty-url'), 'http://global-pagerduty-url');
     await crudView.isLoaded();
     expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy();
     monitoringView.saveAsDefault.click();
@@ -113,7 +111,10 @@ describe('Alertmanager: PagerDuty Receiver Form', () => {
     // save pagerduty url to receiver with an existing global
     await browser.get(`${appHost}/monitoring/alertmanagerconfig/receivers/MyReceiver/edit`);
     await browser.wait(until.presenceOf(firstElementByTestID('cancel')));
-    await replaceInput('pagerduty-url', 'http://pagerduty-url-specific-to-receiver');
+    await fillInput(
+      firstElementByTestID('pagerduty-url'),
+      'http://pagerduty-url-specific-to-receiver',
+    );
     expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy();
     expect(monitoringView.saveAsDefault.getAttribute('checked')).toBeFalsy();
     await monitoringView.saveButton.click();
@@ -146,7 +147,7 @@ describe('Alertmanager: Email Receiver Form', () => {
     await crudView.isLoaded();
     await firstElementByTestID('create-receiver').click();
     await crudView.isLoaded();
-    await replaceInput('receiver-name', 'MyReceiver');
+    await fillInput(firstElementByTestID('receiver-name'), 'MyReceiver');
     await firstElementByTestID('dropdown-button').click();
     await crudView.isLoaded();
     await dropdownMenuForTestID('email_configs').click();
@@ -158,12 +159,12 @@ describe('Alertmanager: Email Receiver Form', () => {
     expect(firstElementByTestID('email-require-tls').getAttribute('checked')).toBeTruthy();
 
     // change required fields
-    await replaceInput('email-to', 'you@there.com');
-    await replaceInput('email-from', 'me@here.com');
+    await fillInput(firstElementByTestID('email-to'), 'you@there.com');
+    await fillInput(firstElementByTestID('email-from'), 'me@here.com');
     expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy(); // monitoringView.saveAsDefault enabled
-    await replaceInput('email-smarthost', 'smarthost:8080');
-    await replaceInput('label-name-0', 'severity');
-    await replaceInput('label-value-0', 'warning');
+    await fillInput(firstElementByTestID('email-smarthost'), 'smarthost:8080');
+    await fillInput(firstElementByTestID('label-name-0'), 'severity');
+    await fillInput(firstElementByTestID('label-value-0'), 'warning');
     await monitoringView.saveButton.click();
     await crudView.isLoaded();
 
@@ -194,10 +195,10 @@ describe('Alertmanager: Email Receiver Form', () => {
     expect(firstElementByTestID('email-hello').getAttribute('value')).toEqual('localhost');
 
     // Change All Remaining Fields
-    await replaceInput('email-auth-username', 'username');
-    await replaceInput('email-auth-password', 'password');
-    await replaceInput('email-auth-identity', 'identity');
-    await replaceInput('email-auth-secret', 'secret');
+    await fillInput(firstElementByTestID('email-auth-username'), 'username');
+    await fillInput(firstElementByTestID('email-auth-password'), 'password');
+    await fillInput(firstElementByTestID('email-auth-identity'), 'identity');
+    await fillInput(firstElementByTestID('email-auth-secret'), 'secret');
     await firstElementByTestID('email-require-tls').click();
 
     await monitoringView.saveButton.click(); // monitoringView.saveAsDefault not checked, so all should be saved with Reciever
@@ -256,7 +257,7 @@ describe('Alertmanager: Slack Receiver Form', () => {
     await crudView.isLoaded();
     await firstElementByTestID('create-receiver').click();
     await crudView.isLoaded();
-    await replaceInput('receiver-name', 'MyReceiver');
+    await fillInput(firstElementByTestID('receiver-name'), 'MyReceiver');
     await firstElementByTestID('dropdown-button').click();
     await crudView.isLoaded();
     await dropdownMenuForTestID('slack_configs').click();
@@ -266,11 +267,11 @@ describe('Alertmanager: Slack Receiver Form', () => {
     expect(monitoringView.saveAsDefault.isEnabled()).toBeFalsy();
 
     // change required fields
-    await replaceInput('slack-api-url', 'http://myslackapi');
+    await fillInput(firstElementByTestID('slack-api-url'), 'http://myslackapi');
     expect(monitoringView.saveAsDefault.isEnabled()).toBeTruthy(); // monitoringView.saveAsDefault enabled
-    await replaceInput('slack-channel', 'myslackchannel');
-    await replaceInput('label-name-0', 'severity');
-    await replaceInput('label-value-0', 'warning');
+    await fillInput(firstElementByTestID('slack-channel'), 'myslackchannel');
+    await fillInput(firstElementByTestID('label-name-0'), 'severity');
+    await fillInput(firstElementByTestID('label-value-0'), 'warning');
     await monitoringView.saveButton.click();
     await crudView.isLoaded();
 
@@ -325,16 +326,16 @@ describe('Alertmanager: Webhook Receiver Form', () => {
     await crudView.isLoaded();
     await firstElementByTestID('create-receiver').click();
     await crudView.isLoaded();
-    await replaceInput('receiver-name', 'MyReceiver');
+    await fillInput(firstElementByTestID('receiver-name'), 'MyReceiver');
     await firstElementByTestID('dropdown-button').click();
     await crudView.isLoaded();
     await dropdownMenuForTestID('webhook_configs').click();
     await crudView.isLoaded();
 
     // change required fields
-    await replaceInput('webhook-url', 'http://mywebhookurl');
-    await replaceInput('label-name-0', 'severity');
-    await replaceInput('label-value-0', 'warning');
+    await fillInput(firstElementByTestID('webhook-url'), 'http://mywebhookurl');
+    await fillInput(firstElementByTestID('label-name-0'), 'severity');
+    await fillInput(firstElementByTestID('label-value-0'), 'warning');
     await monitoringView.saveButton.click();
     await crudView.isLoaded();
 
@@ -354,7 +355,7 @@ describe('Alertmanager: Webhook Receiver Form', () => {
     expect(firstElementByTestID('webhook-url').getAttribute('value')).toEqual(
       'http://mywebhookurl',
     );
-    await replaceInput('webhook-url', 'http://myupdatedwebhookurl');
+    await fillInput(firstElementByTestID('webhook-url'), 'http://myupdatedwebhookurl');
     await monitoringView.saveButton.click();
     await crudView.isLoaded();
     await horizontalnavView.clickHorizontalTab('YAML');

--- a/frontend/packages/console-shared/src/test-utils/utils.ts
+++ b/frontend/packages/console-shared/src/test-utils/utils.ts
@@ -84,6 +84,22 @@ export async function click(elem: any, timeout?: number) {
   await elem.click();
 }
 
+export async function fillInput(elem: any, value: string) {
+  // Sometimes there seems to be an issue with clear() method not clearing the input
+  let attempts = 3;
+  do {
+    --attempts;
+    if (attempts < 0) {
+      throw Error(`Failed to fill input with value: '${value}'.`);
+    }
+    await browser.wait(until.and(until.presenceOf(elem), until.elementToBeClickable(elem)));
+    // TODO: line below can be removed when pf4 tables in use.
+    await elem.click();
+    await elem.clear();
+    await elem.sendKeys(value);
+  } while ((await elem.getAttribute('value')) !== value);
+}
+
 async function selectDropdownOptionByLocator(dropdownId: string, optionLocator: By) {
   await click($(dropdownId));
   await browser.wait(until.presenceOf(element(optionLocator)));

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/dialogs/cloneVirtualMachineDialog.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/dialogs/cloneVirtualMachineDialog.ts
@@ -1,6 +1,6 @@
 import { browser, ExpectedConditions as until } from 'protractor';
-import { click } from '@console/shared/src/test-utils/utils';
-import { fillInput, selectOptionByText } from '../utils/utils';
+import { click, fillInput } from '@console/shared/src/test-utils/utils';
+import { selectOptionByText } from '../utils/utils';
 import { PAGE_LOAD_TIMEOUT_SECS } from '../utils/consts';
 import * as cloneDialogView from '../../views/dialogs/cloneVirtualMachineDialog.view';
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/dialogs/diskDialog.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/dialogs/diskDialog.ts
@@ -1,10 +1,5 @@
-import { click } from '@console/shared/src/test-utils/utils';
-import {
-  fillInput,
-  selectOptionByText,
-  getSelectedOptionText,
-  getSelectOptions,
-} from '../utils/utils';
+import { click, fillInput } from '@console/shared/src/test-utils/utils';
+import { selectOptionByText, getSelectedOptionText, getSelectOptions } from '../utils/utils';
 import * as view from '../../views/dialogs/diskDialog.view';
 import { modalSubmitButton, saveButton } from '../../views/kubevirtDetailView.view';
 import { StorageResource, DiskSourceConfig } from '../utils/types';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/dialogs/networkInterfaceDialog.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/dialogs/networkInterfaceDialog.ts
@@ -1,6 +1,6 @@
-import { click } from '@console/shared/src/test-utils/utils';
+import { click, fillInput } from '@console/shared/src/test-utils/utils';
 import * as view from '../../views/dialogs/networkInterface.view';
-import { fillInput, selectOptionByText, getSelectOptions } from '../utils/utils';
+import { selectOptionByText, getSelectOptions } from '../utils/utils';
 import { NetworkResource } from '../utils/types';
 import { modalSubmitButton, saveButton } from '../../views/kubevirtDetailView.view';
 import { waitForNoLoaders } from '../../views/wizard.view';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/importWizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/importWizard.ts
@@ -1,10 +1,10 @@
 import { browser, ExpectedConditions as until } from 'protractor';
 import { createItemButton, isLoaded } from '@console/internal-integration-tests/views/crud.view';
-import { click, asyncForEach } from '@console/shared/src/test-utils/utils';
+import { click, fillInput, asyncForEach } from '@console/shared/src/test-utils/utils';
 import { NetworkInterfaceDialog } from '../dialogs/networkInterfaceDialog';
 import { DiskDialog } from '../dialogs/diskDialog';
 import { tableRows, saveButton } from '../../views/kubevirtDetailView.view';
-import { fillInput, selectOptionByText, setCheckboxState } from '../utils/utils';
+import { selectOptionByText, setCheckboxState } from '../utils/utils';
 import {
   POD_CREATION_TIMEOUT_SECS,
   V2V_INSTANCE_CONNECTION_TIMEOUT,

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
@@ -5,8 +5,8 @@ import {
   isLoaded,
 } from '@console/internal-integration-tests/views/crud.view';
 import { clickNavLink } from '@console/internal-integration-tests/views/sidenav.view';
-import { click, asyncForEach } from '@console/shared/src/test-utils/utils';
-import { fillInput, selectOptionByText } from '../utils/utils';
+import { click, fillInput, asyncForEach } from '@console/shared/src/test-utils/utils';
+import { selectOptionByText } from '../utils/utils';
 import { CloudInitConfig, StorageResource, NetworkResource, FlavorConfig } from '../utils/types';
 import { WIZARD_CREATE_VM_SUCCESS, PAGE_LOAD_TIMEOUT_SECS, KEBAP_ACTION } from '../utils/consts';
 import * as wizardView from '../../views/wizard.view';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/utils.ts
@@ -19,22 +19,6 @@ import {
 import { STORAGE_CLASS, PAGE_LOAD_TIMEOUT_SECS, SEC } from './consts';
 import { NodePortService } from './types';
 
-export async function fillInput(elem: any, value: string) {
-  // Sometimes there seems to be an issue with clear() method not clearing the input
-  let attempts = 3;
-  do {
-    --attempts;
-    if (attempts < 0) {
-      throw Error(`Failed to fill input with value: '${value}'.`);
-    }
-    await browser.wait(until.and(until.presenceOf(elem), until.elementToBeClickable(elem)));
-    // TODO: line below can be removed when pf4 tables in use.
-    await elem.click();
-    await elem.clear();
-    await elem.sendKeys(value);
-  } while ((await elem.getAttribute('value')) !== value && attempts > 0);
-}
-
 export async function setCheckboxState(elem: any, targetState: boolean) {
   const checkboxState = await elem.isSelected();
   if (checkboxState !== targetState) {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.actions.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.actions.scenario.ts
@@ -12,9 +12,10 @@ import {
   removeLeakedResources,
   removeLeakableResource,
   waitForCount,
+  fillInput,
 } from '@console/shared/src/test-utils/utils';
 import { getVMManifest } from './utils/mocks';
-import { fillInput, pauseVM } from './utils/utils';
+import { pauseVM } from './utils/utils';
 import {
   VM_BOOTUP_TIMEOUT_SECS,
   VM_ACTIONS_TIMEOUT_SECS,

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.detail.flavor.scenario.ts
@@ -1,12 +1,12 @@
 import { browser, ExpectedConditions as until } from 'protractor';
 import { testName } from '@console/internal-integration-tests/protractor.conf';
-import { withResource, click } from '@console/shared/src/test-utils/utils';
+import { withResource, fillInput, click } from '@console/shared/src/test-utils/utils';
 import * as virtualMachineView from '../views/virtualMachine.view';
 import { VM_CREATE_AND_EDIT_TIMEOUT_SECS } from './utils/consts';
 import { VirtualMachine } from './models/virtualMachine';
 import { vmConfig, getProvisionConfigs } from './vm.wizard.configs';
 import * as editFlavorView from './models/editFlavorView';
-import { fillInput, selectOptionByText, getSelectedOptionText } from './utils/utils';
+import { selectOptionByText, getSelectedOptionText } from './utils/utils';
 import { ProvisionConfigName } from './utils/constants/wizard';
 
 describe('KubeVirt VM detail - edit flavor', () => {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.non-admin.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.non-admin.scenario.ts
@@ -4,6 +4,7 @@ import { appHost, testName } from '@console/internal-integration-tests/protracto
 import * as loginView from '@console/internal-integration-tests/views/login.view';
 import {
   withResource,
+  fillInput,
   removeLeakedResources,
   waitForCount,
   removeLeakableResource,
@@ -14,7 +15,7 @@ import {
   resourceRows,
 } from '@console/internal-integration-tests/views/crud.view';
 import { restrictedAccessBlock, hintBlockTitle } from '../views/vms.list.view';
-import { createProject, fillInput } from './utils/utils';
+import { createProject } from './utils/utils';
 import { vmConfig, getProvisionConfigs } from './vm.wizard.configs';
 import { ProvisionConfigName } from './utils/constants/wizard';
 import { VirtualMachine } from './models/virtualMachine';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.actions.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.actions.scenario.ts
@@ -11,9 +11,9 @@ import {
   removeLeakedResources,
   removeLeakableResource,
   waitForCount,
+  fillInput,
 } from '@console/shared/src/test-utils/utils';
 import { getVMIManifest } from './utils/mocks';
-import { fillInput } from './utils/utils';
 import {
   VM_DELETE_TIMEOUT_SECS,
   VMI_ACTION,

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.list-filtering.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.list-filtering.scenario.ts
@@ -5,6 +5,7 @@ import {
   createResource,
   removeLeakedResources,
   removeLeakableResource,
+  fillInput,
 } from '@console/shared/src/test-utils/utils';
 import {
   resourceRowsPresent,
@@ -15,7 +16,6 @@ import { getVMManifest, getVMIManifest } from './utils/mocks';
 import { VM_STATUS } from './utils/consts';
 import { filterBoxCount } from '../views/vms.list.view';
 import { VirtualMachine } from './models/virtualMachine';
-import { fillInput } from './utils/utils';
 
 const waitForVM = async (
   manifest: any,


### PR DESCRIPTION
This should cut down on flakes in Alertmanager integration tests.