### PR TITLE
filter deployments created by event sources

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
@@ -97,6 +97,78 @@ export const sampleKnativeDeployments: FirehoseResult<DeploymentKind[]> = {
   ],
 };
 
+export const sampleEventSourceDeployments: FirehoseResult<DeploymentKind[]> = {
+  loaded: true,
+  loadError: '',
+  data: [
+    {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        annotations: {
+          'deployment.kubernetes.io/revision': '1',
+        },
+        selfLink:
+          '/apis/apps/v1/namespaces/testproject1/deployments/apiserversource-testevents-88eb61d1-b52e-4836-829c-6821e346ecf6',
+        resourceVersion: '726179',
+        name: 'apiserversource-testevents-88eb61d1-b52e-4836-829c-6821e346ecf6',
+        uid: 'bccad3e4-8ce0-11e9-bb7b-0ebb55b110b8',
+        creationTimestamp: '2019-04-22T11:35:43Z',
+        generation: 2,
+        namespace: 'testproject1',
+        labels: {
+          'eventing.knative.dev/source': 'apiserver-source-controller',
+          'eventing.knative.dev/sourceName': 'testevents',
+        },
+        ownerReferences: [
+          {
+            apiVersion: `${EventSourceApiServerModel.apiGroup}/${EventSourceApiServerModel.apiVersion}`,
+            kind: EventSourceApiServerModel.kind,
+            name: 'testevents',
+            uid: '1317f615-9636-11e9-b134-06a61d886b689',
+            controller: true,
+            blockOwnerDeletion: true,
+          },
+        ],
+      },
+      spec: {
+        replicas: 0,
+        selector: {
+          matchLabels: {
+            'eventing.knative.dev/source': 'apiserver-source-controller',
+            'eventing.knative.dev/sourceName': 'testevents',
+          },
+        },
+        template: {
+          metadata: {
+            creationTimestamp: null,
+            labels: {
+              'eventing.knative.dev/source': 'apiserver-source-controller',
+              'eventing.knative.dev/sourceName': 'testevents',
+            },
+            annotations: {
+              'sidecar.istio.io/inject': 'false',
+            },
+          },
+          spec: {
+            containers: [],
+          },
+        },
+        strategy: {
+          type: 'RollingUpdate',
+          rollingUpdate: {
+            maxUnavailable: '25%',
+            maxSurge: '25%',
+          },
+        },
+        revisionHistoryLimit: 10,
+        progressDeadlineSeconds: 600,
+      },
+      status: {},
+    },
+  ],
+};
+
 export const sampleKnativeReplicaSets: FirehoseResult = {
   loaded: true,
   loadError: '',

--- a/frontend/packages/dev-console/src/components/topology/topology-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-utils.ts
@@ -652,7 +652,7 @@ export const transformTopologyData = (
   const knRevResources: K8sResourceKind[] = _.get(resources, ['revisions', 'data'], []);
   knRevResources.length && getKnativeTopologyData(knRevResources, NodeType.Revision);
   const deploymentResources: DeploymentKind[] = _.get(resources, ['deployments', 'data'], []);
-  resources.deployments.data = filterNonKnativeDeployments(deploymentResources);
+  resources.deployments.data = filterNonKnativeDeployments(deploymentResources, knEventSources);
   // END: kn call to form topology data
 
   const transformResourceData = createInstanceForResource(resources, utils, installedOperators);

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
@@ -1,6 +1,12 @@
 import * as _ from 'lodash';
 import * as k8s from '@console/internal/module/k8s';
-import { MockKnativeResources } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import {
+  MockKnativeResources,
+  sampleEventSourceDeployments,
+  sampleKnativeDeployments,
+  sampleEventSourceApiServer,
+} from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import { sampleDeployments } from '@console/dev-console/src/components/topology/__tests__/topology-test-data';
 import {
   getKnativeServiceData,
   getKnativeTopologyNodeItems,
@@ -11,6 +17,7 @@ import {
   getParentResource,
   filterRevisionsByActiveApplication,
   createKnativeEventSourceSink,
+  filterNonKnativeDeployments,
 } from '../knative-topology-utils';
 import { mockServiceData, mockRevisions } from '../__mocks__/traffic-splitting-utils-mock';
 
@@ -116,6 +123,19 @@ describe('knative topology utils', () => {
   it('should return undefined if traffic status is not defined', () => {
     const mockService = { metadata: { name: 'ser', namepspace: '' }, status: {}, spec: {} };
     expect(filterRevisionsBaseOnTrafficStatus(mockService, mockRevisions)).toBeUndefined();
+  });
+
+  it('should filter out deployments created for knative resources and event sources', () => {
+    const MockResources: k8s.DeploymentKind[] = [
+      sampleEventSourceDeployments.data[0],
+      sampleKnativeDeployments.data[0],
+      sampleDeployments.data[0],
+    ];
+    const filteredResources: k8s.DeploymentKind[] = filterNonKnativeDeployments(MockResources, [
+      sampleEventSourceApiServer.data[0],
+    ]);
+    expect(filteredResources).toHaveLength(1);
+    expect(filteredResources[0].metadata.name).toEqual('analytics-deployment');
   });
 });
 

--- a/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/knative-topology-utils.ts
@@ -419,21 +419,17 @@ export const tranformKnNodeData = (
 /**
  * Filter out deployments not created via revisions/eventsources
  */
-export const filterNonKnativeDeployments = (resources: DeploymentKind[]): DeploymentKind[] => {
+export const filterNonKnativeDeployments = (
+  resources: DeploymentKind[],
+  eventSources?: K8sResourceKind[],
+): DeploymentKind[] => {
   const KNATIVE_CONFIGURATION = 'serving.knative.dev/configuration';
-  const KNATIVE_EVENTS_CRONJOB = 'sources.eventing.knative.dev/cronJobSource';
-  const KNATIVE_EVENTS_CONTAINER = 'sources.eventing.knative.dev/containerSource';
-  const KNATIVE_EVENTS_APISERVER = 'sources.knative.dev/apiServerSource';
-  const KNATIVE_EVENTS_CAMEL = 'sources.eventing.knative.dev/camelSource';
-  const KNATIVE_EVENTS_KAFKA = 'sources.eventing.knative.dev/kafkaSource';
+  const isEventSourceKind = (uid: string): boolean =>
+    uid && !!eventSources?.find((eventSource) => eventSource.metadata?.uid === uid);
   return _.filter(resources, (d) => {
     return (
-      !_.get(d, ['metadata', 'labels', KNATIVE_CONFIGURATION]) &&
-      !_.get(d, ['metadata', 'labels', KNATIVE_EVENTS_CRONJOB]) &&
-      !_.get(d, ['metadata', 'labels', KNATIVE_EVENTS_CONTAINER]) &&
-      !_.get(d, ['metadata', 'labels', KNATIVE_EVENTS_APISERVER]) &&
-      !_.get(d, ['metadata', 'labels', KNATIVE_EVENTS_CAMEL]) &&
-      !_.get(d, ['metadata', 'labels', KNATIVE_EVENTS_KAFKA])
+      !_.get(d, ['metadata', 'labels', KNATIVE_CONFIGURATION], false) &&
+      !isEventSourceKind(d.metadata?.ownerReferences?.[0].uid)
     );
   });
 };


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-3011

Analysis / Root cause:
Some Event Sources have associated deployment which are shown in topology view along with the eventSource e.g in case of kafka and api server source.

Solution Description:
Topology view should only show eventSource and not the deployments associated with it

Screens:
![filtereventdeployment](https://user-images.githubusercontent.com/38663217/77027857-52604e00-69bd-11ea-8d0c-4b581f414b2b.png)

Test Coverage:
![Screenshot from 2020-03-19 08-24-25](https://user-images.githubusercontent.com/38663217/77027325-eaf5ce80-69bb-11ea-92b5-5b6a46815f75.png)

Browser Conformance:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge