### PR TITLE
Monitoring: Remove colors from alert state icons

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -161,9 +161,9 @@ const AlertState: React.SFC<AlertStateProps> = ({ state }) => {
     return <span className="text-muted">Not Firing</span>;
   }
   const icon = {
-    [AlertStates.Firing]: <BellIcon className="alert-firing" />,
+    [AlertStates.Firing]: <BellIcon />,
     [AlertStates.Silenced]: <BellSlashIcon className="text-muted" />,
-    [AlertStates.Pending]: <OutlinedBellIcon className="alert-pending" />,
+    [AlertStates.Pending]: <OutlinedBellIcon />,
   }[state];
   return icon ? (
     <>

--- a/frontend/public/style/_icons.scss
+++ b/frontend/public/style/_icons.scss
@@ -11,14 +11,6 @@
   width: 16px;
 }
 
-.alert-firing {
-  color: $color-pf-red;
-}
-
-.alert-pending {
-  color: $color-pf-orange-300;
-}
-
 .update-pending {
   color: $color-pf-blue-400;
 }


### PR DESCRIPTION
We are now using red and yellow for the alert severity icons, so we are
removing these colors from the alert state icons. Alert state `firing`
and `pending` icons are now black.

![screenshot](https://user-images.githubusercontent.com/460802/77034774-20b3ab00-69ee-11ea-9745-d400f7a3d5b5.png)

FYI @cshinn 