### PR TITLE
Fix topology nodes that use functions to create anchors

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/HelmReleaseNode.tsx
@@ -35,7 +35,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
   contextMenuOpen,
   dndDropRef,
 }) => {
-  useAnchor((e: Node) => new RectAnchor(e, 1.5));
+  useAnchor(React.useCallback((node: Node) => new RectAnchor(node, 1.5), []));
   const [hover, hoverRef] = useHover();
   const [{ dragging }, dragNodeRef] = useDragNode(
     nodeDragSourceSpec(TYPE_HELM_RELEASE, true, editAccess),

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/ApplicationNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/ApplicationNode.tsx
@@ -40,7 +40,7 @@ const ApplicationNode: React.FC<ApplicationGroupProps> = ({
   contextMenuOpen,
   dragging,
 }) => {
-  useAnchor((e: Node) => new RectAnchor(e, 1.5));
+  useAnchor(React.useCallback((node: Node) => new RectAnchor(node, 1.5), []));
   const [hover, hoverRef] = useHover();
   const dragNodeRef = useDragNode()[1];
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, hoverRef);

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceGroup.tsx
@@ -78,7 +78,8 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
     AnchorEnd.source,
     'revision-traffic',
   );
-  useAnchor((e: Node) => new RectAnchor(e, 1.5));
+  useAnchor(React.useCallback((node: Node) => new RectAnchor(node, 1.5), []));
+
   const [filtered] = useSearchFilter(element.getLabel());
   const { x, y, width, height } = element.getBounds();
 

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/KnativeServiceNode.tsx
@@ -44,7 +44,7 @@ const KnativeServiceNode: React.FC<KnativeServiceNodeProps> = ({
   onHideCreateConnector,
   onShowCreateConnector,
 }) => {
-  useAnchor((e: Node) => new RectAnchor(e, 1.5));
+  useAnchor(React.useCallback((node: Node) => new RectAnchor(node, 1.5), []));
   const [hover, hoverRef] = useHover();
   const [{ dragging }, dragNodeRef] = useDragNode(
     nodeDragSourceSpec(TYPE_KNATIVE_SERVICE, true, editAccess),

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/OperatorBackedServiceNode.tsx
@@ -35,7 +35,7 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   contextMenuOpen,
   dndDropRef,
 }) => {
-  useAnchor((e: Node) => new RectAnchor(e, 1.5));
+  useAnchor(React.useCallback((node: Node) => new RectAnchor(node, 1.5), []));
   const [hover, hoverRef] = useHover();
   const [{ dragging }, dragNodeRef] = useDragNode(
     nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, true, editAccess),

--- a/frontend/packages/topology/src/behavior/useAnchor.tsx
+++ b/frontend/packages/topology/src/behavior/useAnchor.tsx
@@ -17,7 +17,7 @@ export const useAnchor = (
   }
   React.useEffect(() => {
     action(() => {
-      const anchor = anchorCallback.constructor
+      const anchor = anchorCallback.prototype
         ? new (anchorCallback as any)(element)
         : (anchorCallback as any)(element);
       if (anchor) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3392

**Analysis / Root cause**: 
Updates to the typescript version caused the `.constructor` check to return true for functions passed into the useAnchor behavior thus trying to do a `new` on a function.

**Solution Description**: 
Update the check to look for a `.prototype` to determine if the callback is a class or function.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

