### PR TITLE
adds associated deployment and pods in sidebar for event sources

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-knative-test-data.ts
@@ -14,6 +14,7 @@ import {
   RevisionKind,
   RouteKind,
   ServiceKind as knativeServiceKind,
+  EventSourceApiServerModel,
 } from '@console/knative-plugin';
 import { TopologyDataResources } from '../topology-types';
 
@@ -411,6 +412,33 @@ export const sampleEventSourceCronjob: FirehoseResult = {
   ],
 };
 
+export const sampleEventSourceApiServer: FirehoseResult = {
+  loaded: true,
+  loadError: '',
+  data: [
+    {
+      apiVersion: `${EventSourceApiServerModel.apiGroup}/${EventSourceApiServerModel.apiVersion}`,
+      kind: EventSourceApiServerModel.kind,
+      metadata: {
+        name: 'testevents',
+        namespace: 'testproject1',
+        uid: '1317f615-9636-11e9-b134-06a61d886b689',
+        creationTimestamp: '2019-06-12T07:07:57Z',
+      },
+      spec: {
+        sink: {
+          apiVersion: 'serving.knative.dev/v1',
+          kind: 'Service',
+          name: 'overlayimage',
+        },
+      },
+      status: {
+        sinkUri: 'http://testevents.testproject1.svc.cluster.local',
+      },
+    },
+  ],
+};
+
 export const sampleEventSourceContainers: FirehoseResult = {
   loaded: true,
   loadError: '',
@@ -451,13 +479,7 @@ export const sampleEventSourceCamel: FirehoseResult = {
         uid: '1317f615-9636-11e9-b134-06a61d886b689',
         creationTimestamp: '2019-06-12T07:07:57Z',
       },
-      spec: {
-        sink: {
-          apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
-          kind: ServiceModel.kind,
-          name: 'overlayimage',
-        },
-      },
+      spec: {},
     },
   ],
 };
@@ -641,6 +663,7 @@ export const MockKnativeResources: TopologyDataResources = {
   eventSourceContainers: sampleEventSourceContainers,
   eventSourceCamel: sampleEventSourceCamel,
   eventSourceKafka: sampleEventSourceKafka,
+  eventSourceApiserver: sampleEventSourceApiServer,
   eventSourceSinkbinding: sampleEventSourceSinkbinding,
   clusterServiceVersions: sampleClusterServiceVersions,
 };

--- a/frontend/packages/knative-plugin/src/components/overview/EventSinkServicesOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/EventSinkServicesOverviewList.tsx
@@ -1,21 +1,39 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceForModel, PodKind } from '@console/internal/module/k8s';
 import {
   ResourceLink,
   ExternalLink,
   SidebarSectionHeading,
 } from '@console/internal/components/utils';
+import { PodControllerOverviewItem } from '@console/shared';
+import { PodModel } from '@console/internal/models';
+import { PodsOverview } from '@console/internal/components/overview/pods-overview';
 import { ServiceModel } from '@console/knative-plugin';
 
 export type EventSinkServicesOverviewListProps = {
   obj: K8sResourceKind;
+  pods?: PodKind[];
+  current?: PodControllerOverviewItem;
 };
 
-const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps> = ({ obj }) => {
+const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps> = ({
+  obj,
+  pods,
+  current,
+}) => {
+  const {
+    kind: resKind,
+    apiVersion,
+    metadata: { name, namespace },
+  } = obj;
   const sink = _.get(obj, 'spec.sink.ref') || _.get(obj, 'spec.sink');
-  const sinkUri = _.get(obj, 'status.sinkUri', null);
-  const namespace = _.get(obj, 'metadata.namespace', null);
+  const sinkUri = obj?.status?.sinkUri;
+  const deploymentData = current?.obj?.metadata?.ownerReferences?.[0];
+  const apiGroup = apiVersion.split('/')[0];
+  const linkUrl = `/search/ns/${namespace}?kind=${PodModel.kind}&q=${encodeURIComponent(
+    `${apiGroup}/${_.lowerFirst(resKind)}=${name}`,
+  )}`;
   return (
     <>
       <SidebarSectionHeading text="Knative Services" />
@@ -41,6 +59,21 @@ const EventSinkServicesOverviewList: React.FC<EventSinkServicesOverviewListProps
         </ul>
       ) : (
         <span className="text-muted">No services found for this resource.</span>
+      )}
+      {pods?.length && <PodsOverview pods={pods} obj={obj} allPodsLink={linkUrl} />}
+      {deploymentData?.name && (
+        <>
+          <SidebarSectionHeading text="Deployment" />
+          <ul className="list-group">
+            <li className="list-group-item">
+              <ResourceLink
+                kind={deploymentData.kind}
+                name={deploymentData.name}
+                namespace={namespace}
+              />
+            </li>
+          </ul>
+        </>
       )}
     </>
   );

--- a/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
@@ -51,7 +51,7 @@ const getSidebarResources = ({
     case EventSourceCamelModel.kind:
     case EventSourceKafkaModel.kind:
     case EventSourceServiceBindingModel.kind:
-      return <EventSinkServicesOverviewList obj={obj} />;
+      return <EventSinkServicesOverviewList obj={obj} pods={pods} current={current} />;
     default:
       return (
         <>

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSinkServicesOverviewList.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/EventSinkServicesOverviewList.spec.tsx
@@ -1,22 +1,78 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as _ from 'lodash';
-import { referenceForModel } from '@console/internal/module/k8s';
-import { sampleEventSourceContainers } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
-import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { referenceForModel, PodKind } from '@console/internal/module/k8s';
+import { PodControllerOverviewItem } from '@console/shared';
+import { PodsOverview } from '@console/internal/components/overview/pods-overview';
+import {
+  sampleEventSourceApiServer,
+  sampleEventSourceCamel,
+} from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import {
+  ResourceLink,
+  ExternalLink,
+  SidebarSectionHeading,
+} from '@console/internal/components/utils';
 import { ServiceModel } from '@console/knative-plugin';
 import EventSinkServicesOverviewList from '../EventSinkServicesOverviewList';
 
 describe('EventSinkServicesOverviewList', () => {
+  const current: PodControllerOverviewItem = {
+    obj: {
+      metadata: {
+        name: 'apiserversource-es-1-3f120723-370a-4a08-9eb6-791a7bc90621-5898f657c4',
+        uid: '724ec872-ec82-4362-a933-d7a6e54ccfd8',
+        namespace: 'testproject1',
+        ownerReferences: [
+          {
+            apiVersion: 'apps/v1',
+            kind: 'Deployment',
+            name: 'apiserversource-es-1-3f120723-370a-4a08-9eb6-791a7bc90621',
+            uid: 'efe9d39b-e16c-4f05-a82f-0ae1a80e20de',
+          },
+        ],
+      },
+    },
+    revision: 1,
+    alerts: {},
+    pods: [
+      {
+        metadata: {
+          name: 'apiserversource-es-1-3f120723-370a-4a08-9eb6-791a7bc90621-58wpf6b',
+          uid: 'b893336d-fe16-4fb5-ba29-cb2353ca0301',
+          namespace: 'testproject1',
+        },
+        status: {
+          phase: 'Running',
+        },
+      },
+    ],
+  };
+
+  const pods: PodKind[] = [
+    {
+      metadata: {
+        name: 'apiserversource-es-1-3f120723-370a-4a08-9eb6-791a7bc90621-58wpf6b',
+        uid: 'b893336d-fe16-4fb5-ba29-cb2353ca0301',
+        namespace: 'testproject1',
+      },
+      spec: {
+        containers: [],
+      },
+      status: {
+        phase: 'Running',
+      },
+    },
+  ];
+
   it('should show error info if no sink present or sink,kind is incorrect', () => {
-    const mockEventSourceEmpty = {};
-    const wrapper = shallow(<EventSinkServicesOverviewList obj={mockEventSourceEmpty} />);
-    expect(wrapper.text().includes('No services found for this resource.')).toBe(true);
+    const wrapper = shallow(<EventSinkServicesOverviewList obj={sampleEventSourceCamel.data[0]} />);
+    expect(wrapper.find('span').text()).toBe('No services found for this resource.');
   });
 
   it('should have ResourceLink with proper kind', () => {
     const wrapper = shallow(
-      <EventSinkServicesOverviewList obj={sampleEventSourceContainers.data[0]} />,
+      <EventSinkServicesOverviewList obj={sampleEventSourceApiServer.data[0]} />,
     );
     const findResourceLink = wrapper.find(ResourceLink);
     expect(findResourceLink).toHaveLength(1);
@@ -25,14 +81,47 @@ describe('EventSinkServicesOverviewList', () => {
 
   it('should have ExternaLink when sinkUri is present', () => {
     const wrapper = shallow(
-      <EventSinkServicesOverviewList obj={sampleEventSourceContainers.data[0]} />,
+      <EventSinkServicesOverviewList obj={sampleEventSourceApiServer.data[0]} />,
     );
     expect(wrapper.find(ExternalLink)).toHaveLength(1);
   });
 
   it('should not have ExternalLink when no sinkUri is present', () => {
-    const mockEventSourceDataNoURI = _.omit(sampleEventSourceContainers.data[0], 'status');
+    const mockEventSourceDataNoURI = _.omit(sampleEventSourceApiServer.data[0], 'status');
     const wrapper = shallow(<EventSinkServicesOverviewList obj={mockEventSourceDataNoURI} />);
     expect(wrapper.find(ExternalLink)).toHaveLength(0);
+  });
+
+  it('should show Deployment if present', () => {
+    const wrapper = shallow(
+      <EventSinkServicesOverviewList obj={sampleEventSourceApiServer.data[0]} current={current} />,
+    );
+    const findResourceLink = wrapper.find(ResourceLink);
+    const findSidebarSectionHeading = wrapper.find(SidebarSectionHeading);
+    expect(findSidebarSectionHeading).toHaveLength(2);
+    expect(findResourceLink).toHaveLength(2);
+    expect(findResourceLink.at(1).props().kind).toEqual('Deployment');
+    expect(findSidebarSectionHeading.at(1).props().text).toEqual('Deployment');
+  });
+
+  it('should show pods if present', () => {
+    const wrapper = shallow(
+      <EventSinkServicesOverviewList
+        obj={sampleEventSourceApiServer.data[0]}
+        current={current}
+        pods={pods}
+      />,
+    );
+    expect(wrapper.find(PodsOverview)).toHaveLength(1);
+    expect(wrapper.find(PodsOverview).props().allPodsLink).toEqual(
+      '/search/ns/testproject1?kind=Pod&q=sources.knative.dev%2FapiServerSource%3Dtestevents',
+    );
+  });
+
+  it('should not show pods if not present', () => {
+    const wrapper = shallow(
+      <EventSinkServicesOverviewList obj={sampleEventSourceApiServer.data[0]} current={current} />,
+    );
+    expect(wrapper.find(PodsOverview)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3006

**Analysis / Root cause**: 
Currently, Event Sources sidebar just show knative serving it's syncing to and it should show associated deployments/pods if any.

**Solution Description**: 
Event Sources sidebar will list knative serving it's syncing to and associated deployments/pods if any.

**Screen shots / Gifs for design review**: 
![Mar-20-2020 01-29-58](https://user-images.githubusercontent.com/5129024/77109687-643c0280-6a4a-11ea-83b7-2a22cb7f4b24.gif)


<img width="1738" alt="Screenshot 2020-03-19 at 8 01 18 PM" src="https://user-images.githubusercontent.com/5129024/77109710-7453e200-6a4a-11ea-89f1-28d4f84de65a.png">


**Unit test coverage report**: 
<img width="1036" alt="Screenshot 2020-03-20 at 1 32 30 AM" src="https://user-images.githubusercontent.com/5129024/77109886-b41ac980-6a4a-11ea-84b1-3e82da5a4896.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

cc @serenamarie125 @openshift/team-devconsole-ux 
