### PR TITLE
Fix Table.Row prop typings, part 1

### DIFF
--- a/frontend/__tests__/components/limitrange.spec.tsx
+++ b/frontend/__tests__/components/limitrange.spec.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import {
   LimitRangeTableHeader,
-  LimitRangeTableRow,
   LimitRangeDetailsRowProps,
   LimitRangeDetailsRow,
 } from '../../public/components/limit-range';
@@ -13,7 +12,7 @@ describe(LimitRangeTableHeader.displayName, () => {
   });
 });
 
-describe(LimitRangeTableRow.displayName, () => {
+describe(LimitRangeDetailsRow.displayName, () => {
   let wrapper: ShallowWrapper<LimitRangeDetailsRowProps>;
   const limitContent = {
     max: '',

--- a/frontend/__tests__/components/resource-quota.spec.tsx
+++ b/frontend/__tests__/components/resource-quota.spec.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
-import {
-  ResourceQuotaTableRow,
-  UsageIcon,
-  ResourceUsageRow,
-} from '../../public/components/resource-quota';
+import { UsageIcon, ResourceUsageRow } from '../../public/components/resource-quota';
 
-describe(ResourceQuotaTableRow.displayName, () => {
+describe('UsageIcon', () => {
   let wrapper: ShallowWrapper;
 
   it('renders usageIconClass with empty UsageIcon', () => {

--- a/frontend/packages/ceph-storage-plugin/src/components/volume-snapshot/volume-snapshot.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/volume-snapshot/volume-snapshot.tsx
@@ -10,6 +10,7 @@ import {
   TableData,
   TableProps,
   TableRow,
+  RowFunction,
 } from '@console/internal/components/factory';
 import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import {
@@ -135,19 +136,7 @@ export const VolumeSnapshotDetails = (props) => (
   />
 );
 
-type VolumeSnapshotTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
-};
-
-const VolumeSnapshotTableRow: React.FC<VolumeSnapshotTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => (
+const VolumeSnapshotTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => (
   <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
     <TableData className={snapshotTableColumnClasses[0]}>
       <ResourceLink
@@ -172,8 +161,6 @@ const VolumeSnapshotTableRow: React.FC<VolumeSnapshotTableRowProps> = ({
     </TableData>
   </TableRow>
 );
-
-VolumeSnapshotTableRow.displayName = 'SnapshotTableRow';
 
 export const VolumeSnapshotList: React.FC<TableProps> = (props) => (
   <Table

--- a/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
+++ b/frontend/packages/container-security/src/components/image-manifest-vuln.tsx
@@ -10,6 +10,7 @@ import {
   TableData,
   DetailsPage,
   ListPage,
+  RowFunction,
 } from '@console/internal/components/factory';
 import { referenceForModel, PodKind } from '@console/internal/module/k8s';
 import { match } from 'react-router';
@@ -202,9 +203,13 @@ export const ImageManifestVulnDetailsPage: React.FC<ImageManifestVulnDetailsPage
 // TODO(alecmerdler): Fix classes here to ensure responsiveness
 const tableColumnClasses = ['', '', '', '', '', ''];
 
-export const ImageManifestVulnTableRow: React.FC<ImageManifestVulnTableRowProps> = (props) => {
-  const { obj, index, key, style } = props;
-  const { name, namespace } = props.obj.metadata;
+export const ImageManifestVulnTableRow: RowFunction<ImageManifestVuln> = ({
+  obj,
+  index,
+  key,
+  style,
+}) => {
+  const { name, namespace } = obj.metadata;
 
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
@@ -323,13 +328,6 @@ export type ImageManifestVulnDetailsProps = {
   obj: ImageManifestVuln;
 };
 
-export type ImageManifestVulnTableRowProps = {
-  obj: ImageManifestVuln;
-  index: number;
-  key: string;
-  style: object;
-};
-
 export type ImageManifestVulnListTableHeaderProps = {};
 
 export type AffectedPodsProps = {
@@ -350,5 +348,4 @@ ImageManifestVulnPage.displayName = 'ImageManifestVulnPage';
 ImageManifestVulnList.displayName = 'ImageManifestVulnList';
 AffectedPods.displayName = 'AffectedPods';
 ImageVulnerabilitiesTable.displayName = 'ImageVulnerabilitiesTable';
-ImageManifestVulnTableRow.displayName = 'ImageManifestVulnTableRow';
 ImageVulnerabilityRow.displayName = 'ImageVulnerabilityRow';

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseResourceTableRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseResourceTableRow.tsx
@@ -4,17 +4,10 @@ import { Link } from 'react-router-dom';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { Status } from '@console/shared';
 import { ResourceLink, Timestamp, resourcePath } from '@console/internal/components/utils';
-import { TableData, TableRow } from '@console/internal/components/factory';
+import { TableData, TableRow, RowFunction } from '@console/internal/components/factory';
 import { tableColumnClasses } from './HelmReleaseResourceTableHeader';
 
-export interface HelmResourceTableRowProps {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
-}
-
-const HelmReleaseResourceTableRow: React.FC<HelmResourceTableRowProps> = ({
+const HelmReleaseResourceTableRow: RowFunction<K8sResourceKind> = ({
   obj: resource,
   index,
   key,

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseRow.tsx
@@ -1,21 +1,14 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Status } from '@console/shared';
-import { TableRow, TableData } from '@console/internal/components/factory';
+import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { Timestamp, Kebab } from '@console/internal/components/utils';
 import { Link } from 'react-router-dom';
 import { HelmRelease } from './helm-types';
 import { tableColumnClasses } from './HelmReleaseHeader';
 import { deleteHelmRelease } from '../../actions/modify-helm-release';
 
-interface HelmReleaseRowProps {
-  obj: HelmRelease;
-  index: number;
-  key?: string;
-  style: object;
-}
-
-const HelmReleaseRow: React.FC<HelmReleaseRowProps> = ({ obj, index, key, style }) => {
+const HelmReleaseRow: RowFunction<HelmRelease> = ({ obj, index, key, style }) => {
   const menuActions = [deleteHelmRelease(obj.name, obj.namespace)];
   return (
     <TableRow id={obj.name} index={index} trKey={key} style={style}>

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResourceTableRow.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResourceTableRow.spec.tsx
@@ -1,44 +1,44 @@
-import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Link } from 'react-router-dom';
 import { Status } from '@console/shared';
-import { TableRow } from '@console/internal/components/factory';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { RowFunctionArgs } from '@console/internal/components/factory';
 import HelmReleaseResourceTableRow from '../HelmReleaseResourceTableRow';
 
-let helmReleaseResourceTableRowProps: React.ComponentProps<typeof HelmReleaseResourceTableRow>;
+let rowArgs: RowFunctionArgs<K8sResourceKind>;
 
 describe('HelmReleaseResourceTableRow', () => {
-  helmReleaseResourceTableRowProps = {
-    obj: {
-      kind: 'Secret',
-      metadata: {
-        creationTimestamp: '2020-01-20T05:37:13Z',
-        name: 'sh.helm.release.v1.helm-mysql.v1',
-        namespace: 'deb',
+  beforeEach(() => {
+    rowArgs = {
+      obj: {
+        kind: 'Secret',
+        metadata: {
+          creationTimestamp: '2020-01-20T05:37:13Z',
+          name: 'sh.helm.release.v1.helm-mysql.v1',
+          namespace: 'deb',
+        },
       },
-    },
-    index: 1,
-    style: {},
-  };
+      index: 1,
+      key: '1',
+      style: {},
+    } as any;
+  });
 
   it('should render the TableRow component', () => {
-    const helmReleaseResourceTableRow = shallow(
-      <HelmReleaseResourceTableRow {...helmReleaseResourceTableRowProps} />,
-    );
-    expect(helmReleaseResourceTableRow.find(TableRow).exists()).toBe(true);
+    const helmReleaseResourceTableRow = shallow(HelmReleaseResourceTableRow(rowArgs));
+    expect(helmReleaseResourceTableRow.find('tr').exists()).toBe(true);
   });
+
   it('should render the number of pods deployed for resources that support it', () => {
-    const helmReleaseResourceTableRow = shallow(
-      <HelmReleaseResourceTableRow {...helmReleaseResourceTableRowProps} />,
-    );
+    const helmReleaseResourceTableRow = shallow(HelmReleaseResourceTableRow(rowArgs));
     expect(helmReleaseResourceTableRow.find(Status).exists()).toBe(true);
     expect(helmReleaseResourceTableRow.find(Status).props().status).toEqual('Created');
-    helmReleaseResourceTableRowProps.obj.kind = 'Deployment';
-    helmReleaseResourceTableRowProps.obj.spec = { replicas: 1 };
-    helmReleaseResourceTableRowProps.obj.status = { replicas: 1 };
-    const helmReleaseResourcesTableRow = shallow(
-      <HelmReleaseResourceTableRow {...helmReleaseResourceTableRowProps} />,
-    );
+
+    rowArgs.obj.kind = 'Deployment';
+    rowArgs.obj.spec = { replicas: 1 };
+    rowArgs.obj.status = { replicas: 1 };
+
+    const helmReleaseResourcesTableRow = shallow(HelmReleaseResourceTableRow(rowArgs));
     expect(helmReleaseResourcesTableRow.find(Link).exists()).toBe(true);
     expect(helmReleaseResourcesTableRow.find(Link).props().title).toEqual('pods');
   });

--- a/frontend/packages/dev-console/src/components/pipelineruns/list-page/PipelineRunRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/list-page/PipelineRunRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Status } from '@console/shared';
-import { TableRow, TableData } from '@console/internal/components/factory';
+import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { Kebab, ResourceLink, Timestamp, ResourceKebab } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
@@ -13,14 +13,7 @@ import { tableColumnClasses } from './pipelinerun-table';
 
 const pipelinerunReference = referenceForModel(PipelineRunModel);
 
-interface PipelineRunRowProps {
-  obj: PipelineRun;
-  index: number;
-  key?: string;
-  style: object;
-}
-
-const PipelineRunRow: React.FC<PipelineRunRowProps> = ({ obj, index, key, style }) => {
+const PipelineRunRow: RowFunction<PipelineRun> = ({ obj, index, key, style }) => {
   const pipelineRunStatus = pipelineRunFilterReducer(obj);
 
   const menuActions = [

--- a/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Status } from '@console/shared';
-import { TableRow, TableData } from '@console/internal/components/factory';
+import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { Kebab, ResourceLink, Timestamp, ResourceKebab } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { pipelineFilterReducer } from '../../../utils/pipeline-filter-reducer';
@@ -18,14 +18,7 @@ import { tableColumnClasses } from './pipeline-table';
 const pipelineReference = referenceForModel(PipelineModel);
 const pipelinerunReference = referenceForModel(PipelineRunModel);
 
-interface PipelineRowProps {
-  obj: Pipeline;
-  index: number;
-  key?: string;
-  style: object;
-}
-
-const PipelineRow: React.FC<PipelineRowProps> = ({ obj, index, key, style }) => {
+const PipelineRow: RowFunction<Pipeline> = ({ obj, index, key, style }) => {
   const menuActions = [
     () => startPipeline(PipelineModel, obj, handlePipelineRunSubmit),
     ...(obj.latestRun && obj.latestRun.metadata

--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as cx from 'classnames';
 import * as _ from 'lodash';
-import { TableRow, TableData } from '@console/internal/components/factory';
+import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { Kebab, ResourceLink, ResourceKebab, Timestamp } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { RevisionModel, ServiceModel } from '../../models';
@@ -12,14 +12,7 @@ import { tableColumnClasses } from './revision-table';
 const revisionReference = referenceForModel(RevisionModel);
 const serviceReference = referenceForModel(ServiceModel);
 
-export interface RevisionRowProps {
-  obj: RevisionKind;
-  index: number;
-  key?: string;
-  style: object;
-}
-
-const RevisionRow: React.FC<RevisionRowProps> = ({ obj, index, key, style }) => {
+const RevisionRow: RowFunction<RevisionKind> = ({ obj, index, key, style }) => {
   const readyCondition = obj.status
     ? getCondition(obj.status.conditions, ConditionTypes.Ready)
     : null;

--- a/frontend/packages/knative-plugin/src/components/revisions/__tests__/RevisionRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/__tests__/RevisionRow.spec.tsx
@@ -1,20 +1,20 @@
-import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as _ from 'lodash';
-import { TableData } from '@console/internal/components/factory';
+import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { ResourceLink } from '@console/internal/components/utils';
 import { K8sResourceConditionStatus } from '@console/internal/module/k8s';
 import { revisionObj } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
 import RevisionRow from '../RevisionRow';
-import { ConditionTypes } from '../../../types';
+import { ConditionTypes, RevisionKind } from '../../../types';
 
-type RevisionRowProps = React.ComponentProps<typeof RevisionRow>;
-let revData: RevisionRowProps;
+let revData: RowFunctionArgs<RevisionKind>;
+
 describe('RevisionRow', () => {
   beforeEach(() => {
     revData = {
       obj: revisionObj,
       index: 0,
+      key: '0',
       style: {
         height: 'auto',
         left: 0,
@@ -22,11 +22,11 @@ describe('RevisionRow', () => {
         top: 0,
         width: '100%',
       },
-    };
+    } as any;
   });
 
   it('should show ResourceLink for associated service', () => {
-    const wrapper = shallow(<RevisionRow {...revData} />);
+    const wrapper = shallow(RevisionRow(revData));
     const serviceDataTable = wrapper.find(TableData).at(2);
     expect(wrapper.find(TableData)).toHaveLength(8);
     expect(serviceDataTable.find(ResourceLink)).toHaveLength(1);
@@ -45,27 +45,27 @@ describe('RevisionRow', () => {
         },
       },
     };
-    const wrapper = shallow(<RevisionRow {...revData} />);
+    const wrapper = shallow(RevisionRow(revData));
     const serviceDataTable = wrapper.find(TableData).at(2);
     expect(wrapper.find(TableData)).toHaveLength(8);
     expect(serviceDataTable.find(ResourceLink)).toHaveLength(0);
   });
 
   it('should show appropriate conditions', () => {
-    const wrapper = shallow(<RevisionRow {...revData} />);
+    const wrapper = shallow(RevisionRow(revData));
     const conditionColData = wrapper.find(TableData).at(4);
     expect(conditionColData.props().children).toEqual('3 OK / 4');
   });
 
   it('should show "-" in case of no status', () => {
-    revData = _.omit(revData, 'obj.status') as RevisionRowProps;
-    const wrapper = shallow(<RevisionRow {...revData} />);
+    revData = _.omit(revData, 'obj.status');
+    const wrapper = shallow(RevisionRow(revData));
     const conditionColData = wrapper.find(TableData).at(4);
     expect(conditionColData.props().children).toEqual('-');
   });
 
   it('should show appropriate ready status and reason for ready state', () => {
-    const wrapper = shallow(<RevisionRow {...revData} />);
+    const wrapper = shallow(RevisionRow(revData));
     const readyColData = wrapper.find(TableData).at(5);
     const reasonColData = wrapper.find(TableData).at(6);
     expect(readyColData.props().children).toEqual('True');
@@ -87,7 +87,7 @@ describe('RevisionRow', () => {
         ],
       },
     };
-    const wrapper = shallow(<RevisionRow {...revData} />);
+    const wrapper = shallow(RevisionRow(revData));
     const readyColData = wrapper.find(TableData).at(5);
     const reasonColData = wrapper.find(TableData).at(6);
     expect(readyColData.props().children).toEqual('False');

--- a/frontend/packages/knative-plugin/src/components/routes/RouteRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/RouteRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as cx from 'classnames';
-import { TableRow, TableData } from '@console/internal/components/factory';
+import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import {
   Kebab,
   ResourceLink,
@@ -11,25 +11,13 @@ import {
 import { referenceForModel } from '@console/internal/module/k8s';
 import { RevisionModel, RouteModel } from '../../models';
 import { getConditionString } from '../../utils/condition-utils';
-import { RouteKind, ConfigurationKind } from '../../types';
+import { RouteKind } from '../../types';
 import { tableColumnClasses } from './route-table';
 
 const routeReference = referenceForModel(RouteModel);
 const revisionReference = referenceForModel(RevisionModel);
 
-export interface RouteRowProps {
-  obj: RouteKind;
-  index: number;
-  key?: string;
-  style: object;
-  customData?: {
-    configurationsByName: {
-      [key: string]: ConfigurationKind;
-    };
-  };
-}
-
-const RouteRow: React.FC<RouteRowProps> = ({ obj, index, key, style }) => (
+const RouteRow: RowFunction<RouteKind> = ({ obj, index, key, style }) => (
   <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
     <TableData className={tableColumnClasses[0]}>
       <ResourceLink

--- a/frontend/packages/knative-plugin/src/components/routes/__tests__/RouteRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/routes/__tests__/RouteRow.spec.tsx
@@ -1,18 +1,19 @@
-import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as _ from 'lodash';
-import { TableData } from '@console/internal/components/factory';
+import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
 import { knativeRouteObj } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
 import RouteRow from '../RouteRow';
+import { RouteKind } from '../../../types';
 
-type RouteRowProps = React.ComponentProps<typeof RouteRow>;
-let routeData: RouteRowProps;
+let routeData: RowFunctionArgs<RouteKind>;
+
 describe('RouteRow', () => {
   beforeEach(() => {
     routeData = {
       obj: knativeRouteObj,
       index: 0,
+      key: '0',
       style: {
         height: 'auto',
         left: 0,
@@ -20,11 +21,11 @@ describe('RouteRow', () => {
         top: 0,
         width: '100%',
       },
-    };
+    } as any;
   });
 
   it('should show ExternalLink for associated route', () => {
-    const wrapper = shallow(<RouteRow {...routeData} />);
+    const wrapper = shallow(RouteRow(routeData));
     const serviceDataTable = wrapper.find(TableData).at(2);
     expect(wrapper.find(TableData)).toHaveLength(7);
     expect(serviceDataTable.find(ExternalLink)).toHaveLength(1);
@@ -34,27 +35,27 @@ describe('RouteRow', () => {
   });
 
   it('should not show ExternalLink for associated route if not found in status', () => {
-    routeData = _.omit(routeData, 'obj.status') as RouteRowProps;
-    const wrapper = shallow(<RouteRow {...routeData} />);
+    routeData = _.omit(routeData, 'obj.status');
+    const wrapper = shallow(RouteRow(routeData));
     const serviceDataTable = wrapper.find(TableData).at(2);
     expect(serviceDataTable.find(ExternalLink)).toHaveLength(0);
   });
 
   it('should show appropriate conditions', () => {
-    const wrapper = shallow(<RouteRow {...routeData} />);
+    const wrapper = shallow(RouteRow(routeData));
     const conditionColData = wrapper.find(TableData).at(4);
     expect(conditionColData.props().children).toEqual('3 OK / 3');
   });
 
   it('should show "-" in case of no status', () => {
-    routeData = _.omit(routeData, 'obj.status') as RouteRowProps;
-    const wrapper = shallow(<RouteRow {...routeData} />);
+    routeData = _.omit(routeData, 'obj.status');
+    const wrapper = shallow(RouteRow(routeData));
     const conditionColData = wrapper.find(TableData).at(4);
     expect(conditionColData.props().children).toEqual('-');
   });
 
   it('should show appropriate traffic status and reason for ready state', () => {
-    const wrapper = shallow(<RouteRow {...routeData} />);
+    const wrapper = shallow(RouteRow(routeData));
     const trafficColData = wrapper.find(TableData).at(5);
     expect(trafficColData.find(ResourceLink)).toHaveLength(1);
     expect(trafficColData.find(ResourceLink).props().kind).toEqual(
@@ -63,8 +64,8 @@ describe('RouteRow', () => {
   });
 
   it('should show "-" in case of no traffic', () => {
-    routeData = _.omit(routeData, 'obj.status.traffic') as RouteRowProps;
-    const wrapper = shallow(<RouteRow {...routeData} />);
+    routeData = _.omit(routeData, 'obj.status.traffic');
+    const wrapper = shallow(RouteRow(routeData));
     const trafficColData = wrapper.find(TableData).at(5);
     expect(trafficColData.props().children).toEqual('-');
   });

--- a/frontend/packages/knative-plugin/src/components/services/ServiceRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/ServiceRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as cx from 'classnames';
-import { TableRow, TableData } from '@console/internal/components/factory';
+import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import {
   Kebab,
   ResourceLink,
@@ -17,14 +17,7 @@ import { tableColumnClasses } from './service-table';
 
 const serviceReference = referenceForModel(ServiceModel);
 
-export interface ServiceRowProps {
-  obj: ServiceKind;
-  index: number;
-  key?: string;
-  style: object;
-}
-
-const ServiceRow: React.FC<ServiceRowProps> = ({ obj, index, key, style }) => {
+const ServiceRow: RowFunction<ServiceKind> = ({ obj, index, key, style }) => {
   const readyCondition = obj.status
     ? getCondition(obj.status.conditions, ConditionTypes.Ready)
     : null;

--- a/frontend/packages/knative-plugin/src/components/services/__tests__/ServiceRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/__tests__/ServiceRow.spec.tsx
@@ -1,19 +1,20 @@
-import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
-import { TableData } from '@console/internal/components/factory';
+import { TableData, RowFunctionArgs } from '@console/internal/components/factory';
 import { ExternalLink } from '@console/internal/components/utils';
 import { knativeServiceObj } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
 import ServiceRow from '../ServiceRow';
+import { ServiceKind } from '../../../types';
 
-type ServiceRowProps = React.ComponentProps<typeof ServiceRow>;
-let svcData: ServiceRowProps;
-let wrapper: ShallowWrapper<ServiceRowProps>;
+let svcData: RowFunctionArgs<ServiceKind>;
+let wrapper: ShallowWrapper;
+
 describe('ServiceRow', () => {
   beforeEach(() => {
     svcData = {
       obj: knativeServiceObj,
       index: 0,
+      key: '0',
       style: {
         height: 'auto',
         left: 0,
@@ -21,8 +22,8 @@ describe('ServiceRow', () => {
         top: 0,
         width: '100%',
       },
-    };
-    wrapper = shallow(<ServiceRow {...svcData} />);
+    } as any;
+    wrapper = shallow(ServiceRow(svcData));
   });
 
   it('should show ExternalLink for associated service', () => {
@@ -35,8 +36,8 @@ describe('ServiceRow', () => {
   });
 
   it('should show "-" in case of no url', () => {
-    svcData = _.omit(svcData, 'obj.status.url') as ServiceRowProps;
-    wrapper = shallow(<ServiceRow {...svcData} />);
+    svcData = _.omit(svcData, 'obj.status.url');
+    wrapper = shallow(ServiceRow(svcData));
     const urlColData = wrapper.find(TableData).at(2);
     expect(urlColData.props().children).toEqual('-');
   });
@@ -47,8 +48,8 @@ describe('ServiceRow', () => {
   });
 
   it('should show "-" in generations for no  associated generation', () => {
-    svcData = _.omit(svcData, 'obj.metadata.generation') as ServiceRowProps;
-    wrapper = shallow(<ServiceRow {...svcData} />);
+    svcData = _.omit(svcData, 'obj.metadata.generation');
+    wrapper = shallow(ServiceRow(svcData));
     const generationColData = wrapper.find(TableData).at(3);
     expect(generationColData.props().children).toEqual('-');
   });
@@ -59,8 +60,8 @@ describe('ServiceRow', () => {
   });
 
   it('should show "-" in conditions for no  associated generation', () => {
-    svcData = _.omit(svcData, 'obj.status') as ServiceRowProps;
-    wrapper = shallow(<ServiceRow {...svcData} />);
+    svcData = _.omit(svcData, 'obj.status');
+    wrapper = shallow(ServiceRow(svcData));
     const conditionsColData = wrapper.find(TableData).at(5);
     expect(conditionsColData.props().children).toEqual('-');
   });
@@ -80,7 +81,7 @@ describe('ServiceRow', () => {
         ],
       },
     };
-    wrapper = shallow(<ServiceRow {...svcData} />);
+    wrapper = shallow(ServiceRow(svcData));
     const readyColData = wrapper.find(TableData).at(6);
     const reasonColData = wrapper.find(TableData).at(7);
     expect(readyColData.props().children).toEqual('False');

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDisks.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDisks.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
-import { Table, TableRow, TableData } from '@console/internal/components/factory';
+import { Table, TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { humanizeDecimalBytes } from '@console/internal/components/utils';
 import { getHostStorage } from '../../selectors';
 import { BareMetalHostDisk, BareMetalHostKind } from '../../types';
@@ -15,14 +15,7 @@ const DisksTableHeader = () => [
   { title: 'HCTL', sortField: 'hctl', transforms: [sortable] },
 ];
 
-type DisksTableRowProps = {
-  obj: BareMetalHostDisk;
-  index: number;
-  key?: string;
-  style: React.StyleHTMLAttributes<any>;
-};
-
-const DisksTableRow: React.FC<DisksTableRowProps> = ({ obj, index, key, style }) => {
+const DisksTableRow: RowFunction<BareMetalHostDisk> = ({ obj, index, key, style }) => {
   const { hctl, model, name, rotational, serialNumber, sizeBytes, vendor } = obj;
   const { string: size } = humanizeDecimalBytes(sizeBytes);
   return (

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostNICs.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostNICs.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { OutlinedCheckSquareIcon, OutlinedSquareIcon } from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';
-import { Table, TableRow, TableData } from '@console/internal/components/factory';
+import { Table, TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { getHostNICs } from '../../selectors';
 import { BareMetalHostNIC, BareMetalHostKind } from '../../types';
 
@@ -15,14 +15,7 @@ const NICsTableHeader = () => [
   { title: 'VLAN ID', sortField: 'vlanId', transforms: [sortable] },
 ];
 
-type NICsTableRowProps = {
-  obj: BareMetalHostNIC;
-  index: number;
-  key?: string;
-  style: React.StyleHTMLAttributes<any>;
-};
-
-const NICsTableRow: React.FC<NICsTableRowProps> = ({ obj: nic, index, key, style }) => {
+const NICsTableRow: RowFunction<BareMetalHostNIC> = ({ obj: nic, index, key, style }) => {
   const { ip, mac, model, name, pxe, speedGbps, vlanId } = nic;
   return (
     <TableRow id={ip} index={index} trKey={key} style={style}>

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
@@ -3,7 +3,7 @@ import * as classNames from 'classnames';
 import { Kebab, ResourceLink } from '@console/internal/components/utils';
 import { sortable } from '@patternfly/react-table';
 import { getName, getUID, getNamespace, DASH } from '@console/shared';
-import { TableRow, TableData, Table } from '@console/internal/components/factory';
+import { TableRow, TableData, Table, RowFunction } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { BareMetalHostBundle } from '../types';
 import { getHostBMCAddress, getHostVendorInfo } from '../../selectors';
@@ -67,17 +67,12 @@ const HostsTableHeader = () => [
   },
 ];
 
-type HostsTableRowProps = {
-  obj: BareMetalHostBundle;
-  customData: {
+const HostsTableRow: RowFunction<
+  BareMetalHostBundle,
+  {
     hasNodeMaintenanceCapability: boolean;
-  };
-  index: number;
-  key?: string;
-  style: React.StyleHTMLAttributes<any>;
-};
-
-const HostsTableRow: React.FC<HostsTableRowProps> = ({
+  }
+> = ({
   obj: { host, node, nodeMaintenance, machine, machineSet, status },
   customData: { hasNodeMaintenanceCapability },
   index,

--- a/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-nodes/BareMetalNodesTable.tsx
@@ -3,7 +3,7 @@ import * as classNames from 'classnames';
 import { Kebab, ResourceLink } from '@console/internal/components/utils';
 import { sortable } from '@patternfly/react-table';
 import { DASH, getName, getUID, getNamespace, SecondaryStatus } from '@console/shared';
-import { TableRow, TableData, Table } from '@console/internal/components/factory';
+import { TableRow, TableData, Table, RowFunction } from '@console/internal/components/factory';
 import { referenceForModel } from '@console/internal/module/k8s';
 import NodeRoles from '@console/app/src/components/nodes/NodeRoles';
 import { MachineModel, NodeModel } from '@console/internal/models';
@@ -60,17 +60,12 @@ const BareMetalNodesTableHeader = () => [
   },
 ];
 
-type BareMetalNodesTableRowProps = {
-  obj: BareMetalNodeBundle;
-  customData: {
+const BareMetalNodesTableRow: RowFunction<
+  BareMetalNodeBundle,
+  {
     hasNodeMaintenanceCapability: boolean;
-  };
-  index: number;
-  key?: string;
-  style: React.StyleHTMLAttributes<any>;
-};
-
-const BareMetalNodesTableRow: React.FC<BareMetalNodesTableRowProps> = ({
+  }
+> = ({
   obj: { host, node, nodeMaintenance, machine, status },
   customData: { hasNodeMaintenanceCapability },
   index,

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
@@ -15,11 +15,7 @@ import { dimensifyHeader, dimensifyRow, getName, getNamespace, getUID } from '@c
 import { NetworkAttachmentDefinitionModel } from '../../models';
 import { getConfigAsJSON, getType } from '../../selectors';
 import { NetworkAttachmentDefinitionKind } from '../../types';
-import {
-  NetAttachDefBundle,
-  NetworkAttachmentDefinitionsPageProps,
-  NetworkAttachmentDefinitionsRowProps,
-} from './types';
+import { NetAttachDefBundle, NetworkAttachmentDefinitionsPageProps } from './types';
 
 const { common } = Kebab.factory;
 const menuActions = [...common];

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { ListPage, Table, TableData, TableRow } from '@console/internal/components/factory';
+import {
+  ListPage,
+  Table,
+  TableData,
+  TableRow,
+  RowFunction,
+} from '@console/internal/components/factory';
 import { Kebab, ResourceKebab, ResourceLink } from '@console/internal/components/utils';
 import { NamespaceModel } from '@console/internal/models';
 import { referenceForModel } from '@console/internal/module/k8s';
@@ -50,7 +56,7 @@ const NetworkAttachmentDefinitionsHeader = () =>
     tableColumnClasses,
   );
 
-const NetworkAttachmentDefinitionsRow: React.FC<NetworkAttachmentDefinitionsRowProps> = ({
+const NetworkAttachmentDefinitionsRow: RowFunction<NetAttachDefBundle> = ({
   obj: { name, namespace, type, metadata, netAttachDef },
   index,
   key,
@@ -83,7 +89,6 @@ const NetworkAttachmentDefinitionsRow: React.FC<NetworkAttachmentDefinitionsRowP
     </TableRow>
   );
 };
-NetworkAttachmentDefinitionsRow.displayName = 'NetworkAttachmentDefinitionsRow';
 
 const getNetAttachDefsData = (nadList: NetworkAttachmentDefinitionKind[]): NetAttachDefBundle[] => {
   return nadList

--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/types.ts
@@ -9,13 +9,6 @@ export type NetAttachDefBundle = {
   netAttachDef: any;
 };
 
-export type NetworkAttachmentDefinitionsRowProps = {
-  obj: NetAttachDefBundle;
-  index: number;
-  key?: string;
-  style: object;
-};
-
 export type NetworkAttachmentDefinitionsPageProps = {
   filterLabel: string;
   namespace?: string;

--- a/frontend/packages/noobaa-storage-plugin/src/components/noobaa-operator/resourceTable.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/noobaa-operator/resourceTable.tsx
@@ -15,6 +15,7 @@ import {
   TableData,
   TableRow,
   TableProps,
+  RowFunction,
 } from '@console/internal/components/factory';
 import { sortable } from '@patternfly/react-table';
 import { Filter } from '@console/shared';
@@ -94,8 +95,7 @@ ResourceTableHeader.displayName = 'ResourceTableHeader';
 const getModelFromKind = (name: string) =>
   name === 'BucketClass' ? NooBaaBucketClassModel : NooBaaBackingStoreModel;
 
-const ResourceTableRow: React.FC<ResourceTableRowProps> = (props) => {
-  const { obj, index, key, style } = props;
+const ResourceTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -215,13 +215,6 @@ type MCGResourceListProps = {
   customData: {
     namespace: string;
   };
-};
-
-type ResourceTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key: string;
-  style: object;
 };
 
 type Resource = {

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/object-bucket-claim.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/object-bucket-claim.tsx
@@ -8,6 +8,7 @@ import {
   Table,
   TableRow,
   TableData,
+  RowFunction,
 } from '@console/internal/components/factory';
 import {
   Kebab,
@@ -83,7 +84,7 @@ const OBCTableHeader = () => {
 };
 OBCTableHeader.displayName = 'OBCTableHeader';
 
-const OBCTableRow: React.FC<OBCTableRowProps> = ({ obj, index, key, style }) => {
+const OBCTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   const storageClassName = _.get(obj, 'spec.storageClassName');
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
@@ -126,8 +127,6 @@ const OBCTableRow: React.FC<OBCTableRowProps> = ({ obj, index, key, style }) => 
     </TableRow>
   );
 };
-
-OBCTableRow.displayName = 'OBCTableRow';
 
 const Details: React.FC<DetailsProps> = ({ obj }) => {
   const storageClassName = _.get(obj, 'spec.storageClassName');
@@ -228,13 +227,6 @@ export const ObjectBucketClaimsDetailsPage = (props) => (
 
 type OBCStatusProps = {
   obc: K8sResourceKind;
-};
-
-type OBCTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key: string;
-  style: object;
 };
 
 type DetailsProps = {

--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-page/object-bucket.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-page/object-bucket.tsx
@@ -8,6 +8,7 @@ import {
   Table,
   TableData,
   TableRow,
+  RowFunction,
 } from '@console/internal/components/factory';
 import {
   Kebab,
@@ -67,7 +68,7 @@ const OBTableHeader = () => {
 };
 OBTableHeader.displayName = 'OBTableHeader';
 
-const OBTableRow: React.FC<OBTableRowProps> = ({ obj, index, key, style }) => {
+const OBTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -90,7 +91,6 @@ const OBTableRow: React.FC<OBTableRowProps> = ({ obj, index, key, style }) => {
     </TableRow>
   );
 };
-OBTableRow.displayName = 'OBTableRow';
 
 const Details: React.FC<DetailsProps> = ({ obj }) => {
   const storageClassName = _.get(obj, 'spec.storageClassName');
@@ -169,13 +169,6 @@ export const ObjectBucketDetailsPage = (props) => (
 
 type OBStatusProps = {
   ob: K8sResourceKind;
-};
-
-type OBTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key: string;
-  style: object;
 };
 
 type DetailsProps = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
@@ -31,7 +31,6 @@ import {
   TableRow,
   TableData,
   TableProps,
-  TableRowProps,
   MultiListPage,
   RowFunction,
 } from '@console/internal/components/factory';

--- a/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/catalog-source.tsx
@@ -33,6 +33,7 @@ import {
   TableProps,
   TableRowProps,
   MultiListPage,
+  RowFunction,
 } from '@console/internal/components/factory';
 import { ConfigMapModel } from '@console/internal/models';
 import { PopoverStatus } from '@console/shared';
@@ -314,7 +315,7 @@ const getOperatorCount = (
     },
   } as any).length; // Type inferred to prevent Lodash TypeScript error.
 
-const CatalogSourceTableRow: React.FC<CatalogSourceTableRowProps> = ({
+const CatalogSourceTableRow: RowFunction<CatalogSourceTableRowObj> = ({
   obj: {
     availability = '-',
     disabled = false,
@@ -499,11 +500,6 @@ type CatalogSourceTableRowObj = {
   operatorHub: OperatorHubKind;
   source?: CatalogSourceKind;
 };
-
-type CatalogSourceTableRowProps = {
-  obj: CatalogSourceTableRowObj;
-  key: string;
-} & TableRowProps;
 
 type DefaultSourceKebabProps = {
   kind: K8sKind;

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.spec.tsx
@@ -3,7 +3,12 @@ import * as _ from 'lodash';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { Link } from 'react-router-dom';
 import { Button } from '@patternfly/react-core';
-import { Table, TableRow, MultiListPage, DetailsPage } from '@console/internal/components/factory';
+import {
+  Table,
+  MultiListPage,
+  DetailsPage,
+  RowFunctionArgs,
+} from '@console/internal/components/factory';
 import {
   ResourceKebab,
   ResourceLink,
@@ -20,7 +25,6 @@ import { InstallPlanKind, InstallPlanApproval } from '../types';
 import {
   InstallPlanTableHeader,
   InstallPlanTableRow,
-  InstallPlanTableRowProps,
   InstallPlansList,
   InstallPlansListProps,
   InstallPlansPage,
@@ -54,19 +58,31 @@ describe(InstallPlanTableHeader.displayName, () => {
   });
 });
 
-describe(InstallPlanTableRow.displayName, () => {
-  let wrapper: ShallowWrapper<InstallPlanTableRowProps>;
+describe('InstallPlanTableRow', () => {
+  let obj: InstallPlanKind;
+  let wrapper: ShallowWrapper;
+
+  const updateWrapper = () => {
+    const rowArgs: RowFunctionArgs<k8s.K8sResourceKind> = {
+      obj,
+      index: 0,
+      key: '0',
+      style: {},
+    } as any;
+
+    wrapper = shallow(InstallPlanTableRow(rowArgs));
+    return wrapper;
+  };
 
   beforeEach(() => {
-    wrapper = shallow(
-      <InstallPlanTableRow obj={_.cloneDeep(testInstallPlan)} index={0} style={{}} />,
-    );
+    obj = _.cloneDeep(testInstallPlan);
+    wrapper = updateWrapper();
   });
 
   it('renders resource kebab for performing common actions', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .find(ResourceKebab)
         .props().actions,
     ).toEqual(Kebab.factory.common);
@@ -75,28 +91,28 @@ describe(InstallPlanTableRow.displayName, () => {
   it('renders column for install plan name', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(NAME_INDEX)
         .find(ResourceLink)
         .props().kind,
     ).toEqual(k8s.referenceForModel(InstallPlanModel));
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(NAME_INDEX)
         .find(ResourceLink)
         .props().namespace,
     ).toEqual(testInstallPlan.metadata.namespace);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(NAME_INDEX)
         .find(ResourceLink)
         .props().name,
     ).toEqual(testInstallPlan.metadata.name);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(NAME_INDEX)
         .find(ResourceLink)
         .props().title,
@@ -106,21 +122,21 @@ describe(InstallPlanTableRow.displayName, () => {
   it('renders column for install plan namespace', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(NAMESPACE_INDEX)
         .find(ResourceLink)
         .props().kind,
     ).toEqual('Namespace');
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(NAMESPACE_INDEX)
         .find(ResourceLink)
         .props().title,
     ).toEqual(testInstallPlan.metadata.namespace);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(NAMESPACE_INDEX)
         .find(ResourceLink)
         .props().displayName,
@@ -130,7 +146,7 @@ describe(InstallPlanTableRow.displayName, () => {
   it('renders column for install plan status', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(STATUS_INDEX)
         .render()
         .text(),
@@ -138,25 +154,25 @@ describe(InstallPlanTableRow.displayName, () => {
   });
 
   it('renders column with fallback status if `status.phase` is undefined', () => {
-    const obj = { ..._.cloneDeep(testInstallPlan), status: null };
-    wrapper = wrapper.setProps({ obj });
+    obj = { ..._.cloneDeep(testInstallPlan), status: null };
+    wrapper = updateWrapper();
 
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(STATUS_INDEX)
         .render()
         .text(),
     ).toEqual('Unknown');
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(COMPONENTS_INDEX)
         .find(ResourceIcon).length,
     ).toEqual(1);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(COMPONENTS_INDEX)
         .find(ResourceIcon)
         .at(0)
@@ -167,21 +183,21 @@ describe(InstallPlanTableRow.displayName, () => {
   it('render column for install plan components list', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(COMPONENTS_INDEX)
         .find(ResourceLink)
         .props().kind,
     ).toEqual(k8s.referenceForModel(ClusterServiceVersionModel));
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(COMPONENTS_INDEX)
         .find(ResourceLink)
         .props().name,
     ).toEqual(testInstallPlan.spec.clusterServiceVersionNames.toString());
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(COMPONENTS_INDEX)
         .find(ResourceLink)
         .props().namespace,
@@ -191,7 +207,7 @@ describe(InstallPlanTableRow.displayName, () => {
   it('renders column for parent subscription(s) determined by `metadata.ownerReferences`', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(SUBSCRIPTIONS_INDEX)
         .find(ResourceLink).length,
     ).toEqual(1);

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -11,6 +11,7 @@ import {
   Table,
   TableRow,
   TableData,
+  RowFunction,
 } from '@console/internal/components/factory';
 import { Conditions } from '@console/internal/components/conditions';
 import {
@@ -97,12 +98,7 @@ export const InstallPlanTableHeader = () => {
 };
 InstallPlanTableHeader.displayName = 'InstallPlanTableHeader';
 
-export const InstallPlanTableRow: React.FC<InstallPlanTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+export const InstallPlanTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   const phaseFor = (phase: InstallPlanKind['status']['phase']) => <Status status={phase} />;
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
@@ -182,13 +178,6 @@ export const InstallPlanTableRow: React.FC<InstallPlanTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-InstallPlanTableRow.displayName = 'InstallPlanTableRow';
-export type InstallPlanTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 export const InstallPlansList = requireOperatorGroup((props: InstallPlansListProps) => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/k8s-resource.tsx
@@ -10,7 +10,13 @@ import {
   MsgBox,
   FirehoseResource,
 } from '@console/internal/components/utils';
-import { MultiListPage, Table, TableRow, TableData } from '@console/internal/components/factory';
+import {
+  MultiListPage,
+  Table,
+  TableRow,
+  TableData,
+  RowFunction,
+} from '@console/internal/components/factory';
 import {
   K8sResourceKind,
   GroupVersionKind,
@@ -55,12 +61,12 @@ export const ResourceTableHeader = () => [
   },
 ];
 
-export const ResourceTableRow: React.FC<ResourceTableRowProps> = ({
-  obj,
-  index,
-  style,
-  customData: { linkFor },
-}) => (
+export const ResourceTableRow: RowFunction<
+  K8sResourceKind,
+  {
+    linkFor: (obj: K8sResourceKind) => JSX.Element;
+  }
+> = ({ obj, index, style, customData: { linkFor } }) => (
   <TableRow id={obj.metadata.uid} index={index} trKey={obj.metadata.uid} style={style}>
     <TableData className={tableColumnClasses[0]}>{linkFor(obj)}</TableData>
     <TableData className={tableColumnClasses[1]}>{obj.kind}</TableData>
@@ -172,16 +178,6 @@ export type ResourcesProps = {
   obj: K8sResourceKind;
   clusterServiceVersion: ClusterServiceVersionKind;
   match: match<{ plural: GroupVersionKind; ns: string; appName: string; name: string }>;
-};
-
-export type ResourceTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
-  customData: {
-    linkFor: (obj: K8sResourceKind) => JSX.Element;
-  };
 };
 
 export type ResourceListProps = {};

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.spec.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
-import { referenceForModel } from '@console/internal/module/k8s';
-import { Table, TableRow, MultiListPage, DetailsPage } from '@console/internal/components/factory';
+import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
+import {
+  Table,
+  MultiListPage,
+  DetailsPage,
+  RowFunctionArgs,
+} from '@console/internal/components/factory';
 import { ResourceKebab, ResourceLink, Kebab } from '@console/internal/components/utils';
 import {
   SubscriptionModel,
@@ -22,7 +27,6 @@ import { SubscriptionKind, SubscriptionState } from '../types';
 import {
   SubscriptionTableHeader,
   SubscriptionTableRow,
-  SubscriptionTableRowProps,
   SubscriptionsList,
   SubscriptionsListProps,
   SubscriptionsPage,
@@ -42,19 +46,31 @@ describe(SubscriptionTableHeader.displayName, () => {
   });
 });
 
-describe(SubscriptionTableRow.displayName, () => {
-  let wrapper: ShallowWrapper<SubscriptionTableRowProps>;
+describe('SubscriptionTableRow', () => {
+  let wrapper: ShallowWrapper;
   let subscription: SubscriptionKind;
+
+  const updateWrapper = () => {
+    const rowArgs: RowFunctionArgs<K8sResourceKind> = {
+      obj: subscription,
+      index: 0,
+      key: '0',
+      style: {},
+    } as any;
+
+    wrapper = shallow(SubscriptionTableRow(rowArgs));
+    return wrapper;
+  };
 
   beforeEach(() => {
     subscription = { ..._.cloneDeep(testSubscription), status: { installedCSV: 'testapp.v1.0.0' } };
-    wrapper = shallow(<SubscriptionTableRow obj={subscription} index={0} style={{}} />);
+    wrapper = updateWrapper();
   });
 
   it('renders column for subscription name', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(0)
         .shallow()
         .find(ResourceLink)
@@ -62,7 +78,7 @@ describe(SubscriptionTableRow.displayName, () => {
     ).toEqual(subscription.metadata.name);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(0)
         .shallow()
         .find(ResourceLink)
@@ -70,7 +86,7 @@ describe(SubscriptionTableRow.displayName, () => {
     ).toEqual(subscription.metadata.name);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(0)
         .shallow()
         .find(ResourceLink)
@@ -78,7 +94,7 @@ describe(SubscriptionTableRow.displayName, () => {
     ).toEqual(subscription.metadata.namespace);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(0)
         .shallow()
         .find(ResourceLink)
@@ -90,46 +106,46 @@ describe(SubscriptionTableRow.displayName, () => {
     const menuArgs = [ClusterServiceVersionModel, subscription];
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .find(ResourceKebab)
         .props().kind,
     ).toEqual(referenceForModel(SubscriptionModel));
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .find(ResourceKebab)
         .props().resource,
     ).toEqual(subscription);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .find(ResourceKebab)
         .props().actions[0],
     ).toEqual(Kebab.factory.Edit);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .find(ResourceKebab)
         .props()
         .actions[1](...menuArgs).label,
     ).toEqual('Remove Subscription');
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .find(ResourceKebab)
         .props()
         .actions[1](...menuArgs).callback,
     ).toBeDefined();
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .find(ResourceKebab)
         .props()
         .actions[2](...menuArgs).label,
     ).toEqual(`View ${ClusterServiceVersionModel.kind}...`);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .find(ResourceKebab)
         .props()
         .actions[2](...menuArgs).href,
@@ -139,7 +155,7 @@ describe(SubscriptionTableRow.displayName, () => {
   it('renders column for namespace name', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(1)
         .shallow()
         .find(ResourceLink)
@@ -147,7 +163,7 @@ describe(SubscriptionTableRow.displayName, () => {
     ).toEqual(subscription.metadata.namespace);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(1)
         .shallow()
         .find(ResourceLink)
@@ -155,7 +171,7 @@ describe(SubscriptionTableRow.displayName, () => {
     ).toEqual(subscription.metadata.namespace);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(1)
         .shallow()
         .find(ResourceLink)
@@ -163,7 +179,7 @@ describe(SubscriptionTableRow.displayName, () => {
     ).toEqual(subscription.metadata.namespace);
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(1)
         .shallow()
         .find(ResourceLink)
@@ -173,11 +189,11 @@ describe(SubscriptionTableRow.displayName, () => {
 
   it('renders column for subscription state when update available', () => {
     subscription.status.state = SubscriptionState.SubscriptionStateUpgradeAvailable;
-    wrapper = wrapper.setProps({ obj: subscription });
+    wrapper = updateWrapper();
 
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(2)
         .shallow()
         .text(),
@@ -187,7 +203,7 @@ describe(SubscriptionTableRow.displayName, () => {
   it('renders column for subscription state when unknown state', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(2)
         .shallow()
         .text(),
@@ -196,11 +212,11 @@ describe(SubscriptionTableRow.displayName, () => {
 
   it('renders column for subscription state when update in progress', () => {
     subscription.status.state = SubscriptionState.SubscriptionStateUpgradePending;
-    wrapper = wrapper.setProps({ obj: subscription });
+    wrapper = updateWrapper();
 
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(2)
         .shallow()
         .text(),
@@ -209,11 +225,11 @@ describe(SubscriptionTableRow.displayName, () => {
 
   it('renders column for subscription state when no updates available', () => {
     subscription.status.state = SubscriptionState.SubscriptionStateAtLatest;
-    wrapper = wrapper.setProps({ obj: subscription });
+    wrapper = updateWrapper();
 
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(2)
         .shallow()
         .text(),
@@ -223,7 +239,7 @@ describe(SubscriptionTableRow.displayName, () => {
   it('renders column for current subscription channel', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(3)
         .shallow()
         .text(),
@@ -233,7 +249,7 @@ describe(SubscriptionTableRow.displayName, () => {
   it('renders column for approval strategy', () => {
     expect(
       wrapper
-        .find(TableRow)
+        .find('tr')
         .childAt(4)
         .shallow()
         .text(),

--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -11,6 +11,7 @@ import {
   Table,
   TableRow,
   TableData,
+  RowFunction,
 } from '@console/internal/components/factory';
 import {
   MsgBox,
@@ -201,12 +202,7 @@ const menuActions = [
   },
 ];
 
-export const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+export const SubscriptionTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -243,13 +239,6 @@ export const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-SubscriptionTableRow.displayName = 'SubscriptionTableRow';
-export type SubscriptionTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 export const SubscriptionsList = requireOperatorGroup((props: SubscriptionsListProps) => (

--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -231,7 +231,6 @@ const RoleBindingsTableRow = ({ obj: binding, index, key, style }) => {
     </TableRow>
   );
 };
-RoleBindingsTableRow.displayName = 'RoleBindingsTableRow';
 
 const EmptyMsg = () => (
   <MsgBox

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -84,7 +84,6 @@ const RolesTableRow = ({ obj: role, index, key, style }) => {
     </TableRow>
   );
 };
-RolesTableRow.displayName = 'RolesTableRow';
 
 class Details extends React.Component {
   constructor(props) {
@@ -206,7 +205,6 @@ const BindingsTableRow = ({ obj: binding, index, key, style }) => {
     </TableRow>
   );
 };
-BindingsTableRow.displayName = 'BindingsTableRow';
 
 const BindingsListComponent = (props) => (
   <BindingsList {...props} Header={BindingsTableHeader} Row={BindingsTableRow} virtualize />

--- a/frontend/public/components/alert-manager.tsx
+++ b/frontend/public/components/alert-manager.tsx
@@ -5,7 +5,7 @@ import { Button } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
 import { referenceForModel, K8sResourceKind } from '../module/k8s';
-import { ListPage, DetailsPage, Table, TableRow, TableData } from './factory';
+import { ListPage, DetailsPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { SectionHeading, LabelList, navFactory, ResourceLink, Selector, pluralize } from './utils';
 import { configureReplicaCountModal } from './modals';
 import { AlertmanagerModel } from '../models';
@@ -74,7 +74,7 @@ const tableColumnClasses = [
   classNames('col-md-3', 'col-sm-3', 'hidden-xs'),
 ];
 
-const AlertManagerTableRow: React.FC<AlertManagerTableRowProps> = ({
+const AlertManagerTableRow: RowFunction<K8sResourceKind> = ({
   obj: alertManager,
   index,
   key,
@@ -103,13 +103,6 @@ const AlertManagerTableRow: React.FC<AlertManagerTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-AlertManagerTableRow.displayName = 'AlertManagerTableRow';
-type AlertManagerTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const AlertManagerTableHeader = () => {

--- a/frontend/public/components/build-config.tsx
+++ b/frontend/public/components/build-config.tsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { K8sResourceKind, K8sResourceKindReference, referenceFor } from '../module/k8s';
 import { startBuild } from '../module/k8s/builds';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { errorModal } from './modals';
 import {
   BuildHooks,
@@ -146,7 +146,7 @@ const BuildConfigsTableHeader = () => {
 };
 BuildConfigsTableHeader.displayName = 'BuildConfigsTableHeader';
 
-const BuildConfigsTableRow: React.FC<BuildConfigsTableRowProps> = ({ obj, index, key, style }) => {
+const BuildConfigsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -171,13 +171,6 @@ const BuildConfigsTableRow: React.FC<BuildConfigsTableRowProps> = ({ obj, index,
       </TableData>
     </TableRow>
   );
-};
-BuildConfigsTableRow.displayName = 'BuildConfigsTableRow';
-type BuildConfigsTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const buildStrategy = (buildConfig: K8sResourceKind): BuildStrategyType =>

--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -15,7 +15,7 @@ import {
   K8sKind,
 } from '../module/k8s';
 import { cloneBuild, formatBuildDuration, getBuildNumber } from '../module/k8s/builds';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { errorModal, confirmModal } from './modals';
 import {
   AsyncComponent,
@@ -346,7 +346,7 @@ const BuildsTableHeader = () => {
 };
 BuildsTableHeader.displayName = 'BuildsTableHeader';
 
-const BuildsTableRow: React.FC<BuildsTableRowProps> = ({ obj, index, key, style }) => {
+const BuildsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -371,13 +371,6 @@ const BuildsTableRow: React.FC<BuildsTableRowProps> = ({ obj, index, key, style 
       </TableData>
     </TableRow>
   );
-};
-BuildsTableRow.displayName = 'BuildsTableRow';
-type BuildsTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 export const BuildsList: React.SFC = (props) => (

--- a/frontend/public/components/chargeback.tsx
+++ b/frontend/public/components/chargeback.tsx
@@ -6,7 +6,7 @@ import { sortable } from '@patternfly/react-table';
 import { connectToFlags } from '../reducers/features';
 import { FLAGS } from '@console/shared';
 import { Conditions } from './conditions';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { coFetchJSON } from '../co-fetch';
 import { ChargebackReportModel, ReportQueryModel } from '../models';
 import { LoadError, LoadingInline, MsgBox } from './utils/status-box';
@@ -101,7 +101,7 @@ const ReportsTableHeader = () => {
 };
 ReportsTableHeader.displayName = 'ReportsTableHeader';
 
-const ReportsTableRow: React.FC<ReportsTableRowProps> = ({ obj, index, key, style }) => {
+const ReportsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -139,13 +139,6 @@ const ReportsTableRow: React.FC<ReportsTableRowProps> = ({ obj, index, key, styl
       </TableData>
     </TableRow>
   );
-};
-ReportsTableRow.displayName = 'ReportsTableRow';
-type ReportsTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 class ReportsDetails extends React.Component<ReportsDetailsProps> {
@@ -498,7 +491,7 @@ const ReportGenerationQueriesTableHeader = () => {
 };
 ReportGenerationQueriesTableHeader.displayName = 'ReportGenerationQueriesTableHeader';
 
-const ReportGenerationQueriesTableRow: React.FC<ReportGenerationQueriesTableRowProps> = ({
+const ReportGenerationQueriesTableRow: RowFunction<K8sResourceKind> = ({
   obj,
   index,
   key,
@@ -536,13 +529,6 @@ const ReportGenerationQueriesTableRow: React.FC<ReportGenerationQueriesTableRowP
       </TableData>
     </TableRow>
   );
-};
-ReportGenerationQueriesTableRow.displayName = 'ReportGenerationQueriesTableRow';
-type ReportGenerationQueriesTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const ReportGenerationQueriesDetails: React.SFC<ReportGenerationQueriesDetailsProps> = ({

--- a/frontend/public/components/cluster-service-broker.tsx
+++ b/frontend/public/components/cluster-service-broker.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   Kebab,
   SectionHeading,
@@ -66,7 +66,7 @@ const ClusterServiceBrokerTableHeader = () => {
 };
 ClusterServiceBrokerTableHeader.displayName = 'ClusterServiceBrokerTableHeader';
 
-const ClusterServiceBrokerTableRow: React.FC<ClusterServiceBrokerTableRowProps> = ({
+const ClusterServiceBrokerTableRow: RowFunction<K8sResourceKind> = ({
   obj: serviceBroker,
   index,
   key,
@@ -96,13 +96,6 @@ const ClusterServiceBrokerTableRow: React.FC<ClusterServiceBrokerTableRowProps> 
       </TableData>
     </TableRow>
   );
-};
-ClusterServiceBrokerTableRow.displayName = 'ClusterServiceBrokerTableRow';
-type ClusterServiceBrokerTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const ClusterServiceBrokerDetails: React.SFC<ClusterServiceBrokerDetailsProps> = ({

--- a/frontend/public/components/cluster-service-class.tsx
+++ b/frontend/public/components/cluster-service-class.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   history,
   SectionHeading,
@@ -66,7 +66,7 @@ const ClusterServiceClassTableHeader = () => {
 };
 ClusterServiceClassTableHeader.displayName = 'ClusterServiceClassTableHeader';
 
-const ClusterServiceClassTableRow: React.FC<ClusterServiceClassTableRowProps> = ({
+const ClusterServiceClassTableRow: RowFunction<K8sResourceKind> = ({
   obj: serviceClass,
   index,
   key,
@@ -90,13 +90,6 @@ const ClusterServiceClassTableRow: React.FC<ClusterServiceClassTableRowProps> = 
       </TableData>
     </TableRow>
   );
-};
-ClusterServiceClassTableRow.displayName = 'ClusterServiceClassTableRow';
-type ClusterServiceClassTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const ClusterServiceClassDetails: React.FC<ClusterServiceClassDetailsProps> = ({

--- a/frontend/public/components/cluster-service-plan.tsx
+++ b/frontend/public/components/cluster-service-plan.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { SectionHeading, detailsPage, navFactory, ResourceLink, ResourceSummary } from './utils';
 import { K8sResourceKind, referenceForModel, servicePlanDisplayName } from '../module/k8s';
 import {
@@ -41,7 +41,7 @@ const ClusterServicePlanTableHeader = () => {
 };
 ClusterServicePlanTableHeader.displayName = 'ClusterServicePlanTableHeader';
 
-const ClusterServicePlanTableRow: React.FC<ClusterServicePlanTableRowProps> = ({
+const ClusterServicePlanTableRow: RowFunction<K8sResourceKind> = ({
   obj: servicePlan,
   index,
   key,
@@ -66,13 +66,6 @@ const ClusterServicePlanTableRow: React.FC<ClusterServicePlanTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-ClusterServicePlanTableRow.displayName = 'ClusterServicePlanTableRow';
-type ClusterServicePlanTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const ClusterServicePlanDetails: React.SFC<ClusterServicePlanDetailsProps> = ({

--- a/frontend/public/components/cluster-settings/cluster-operator.tsx
+++ b/frontend/public/components/cluster-settings/cluster-operator.tsx
@@ -6,7 +6,7 @@ import { Alert } from '@patternfly/react-core';
 import { SyncAltIcon, UnknownIcon } from '@patternfly/react-icons';
 
 import { ClusterOperatorModel } from '../../models';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from '../factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from '../factory';
 import { Conditions } from '../conditions';
 import {
   getClusterOperatorStatus,
@@ -90,12 +90,7 @@ const ClusterOperatorTableHeader = () => {
 };
 ClusterOperatorTableHeader.displayName = 'ClusterOperatorTableHeader';
 
-const ClusterOperatorTableRow: React.FC<ClusterOperatorTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+const ClusterOperatorTableRow: RowFunction<ClusterOperator> = ({ obj, index, key, style }) => {
   const { status, message } = getStatusAndMessage(obj);
   const operatorVersion = getClusterOperatorVersion(obj);
   return (
@@ -117,13 +112,6 @@ const ClusterOperatorTableRow: React.FC<ClusterOperatorTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-ClusterOperatorTableRow.displayName = 'ClusterOperatorTableRow';
-type ClusterOperatorTableRowProps = {
-  obj: ClusterOperator;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 export const ClusterOperatorList: React.SFC = (props) => (

--- a/frontend/public/components/configmap.jsx
+++ b/frontend/public/components/configmap.jsx
@@ -91,7 +91,6 @@ const ConfigMapTableRow = ({ obj: configMap, index, key, style }) => {
     </TableRow>
   );
 };
-ConfigMapTableRow.displayName = 'ConfigMapTableRow';
 
 const ConfigMapDetails = ({ obj: configMap }) => {
   return (

--- a/frontend/public/components/cron-job.tsx
+++ b/frontend/public/components/cron-job.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { CronJobKind } from '../module/k8s';
 import {
   ContainerTable,
@@ -74,17 +74,7 @@ const CronJobTableHeader = () => {
 };
 CronJobTableHeader.displayName = 'CronJobTableHeader';
 
-const CronJobTableRow = ({
-  obj: cronjob,
-  index,
-  key,
-  style,
-}: {
-  obj: CronJobKind;
-  index: number;
-  key: string;
-  style: any;
-}) => {
+const CronJobTableRow: RowFunction<CronJobKind> = ({ obj: cronjob, index, key, style }) => {
   return (
     <TableRow id={cronjob.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -115,7 +105,6 @@ const CronJobTableRow = ({
     </TableRow>
   );
 };
-CronJobTableRow.displayName = 'CronJobTableRow';
 
 const CronJobDetails: React.FC<CronJobDetailsProps> = ({ obj: cronjob }) => {
   const job = cronjob.spec.jobTemplate;

--- a/frontend/public/components/custom-resource-definition.tsx
+++ b/frontend/public/components/custom-resource-definition.tsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { BanIcon } from '@patternfly/react-icons';
 
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   AsyncComponent,
   DetailsItem,
@@ -107,7 +107,12 @@ const Established: React.FC<{ crd: CustomResourceDefinitionKind }> = ({ crd }) =
   );
 };
 
-const CRDTableRow: React.FC<CRDTableRowProps> = ({ obj: crd, index, key, style }) => {
+const CRDTableRow: RowFunction<CustomResourceDefinitionKind> = ({
+  obj: crd,
+  index,
+  key,
+  style,
+}) => {
   return (
     <TableRow id={crd.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -133,13 +138,6 @@ const CRDTableRow: React.FC<CRDTableRowProps> = ({ obj: crd, index, key, style }
       </TableData>
     </TableRow>
   );
-};
-CRDTableRow.displayName = 'CRDTableRow';
-type CRDTableRowProps = {
-  obj: CustomResourceDefinitionKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const Details: React.FC<{ obj: CustomResourceDefinitionKind }> = ({ obj: crd }) => {

--- a/frontend/public/components/daemon-set.tsx
+++ b/frontend/public/components/daemon-set.tsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
 import { K8sResourceKind } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   AsyncComponent,
   DetailsItem,
@@ -81,17 +81,7 @@ const DaemonSetTableHeader = () => {
 };
 DaemonSetTableHeader.displayName = 'DaemonSetTableHeader';
 
-const DaemonSetTableRow = ({
-  obj: daemonset,
-  index,
-  key,
-  style,
-}: {
-  obj: K8sResourceKind;
-  index: number;
-  key: string;
-  style: any;
-}) => {
+const DaemonSetTableRow: RowFunction<K8sResourceKind> = ({ obj: daemonset, index, key, style }) => {
   return (
     <TableRow id={daemonset.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -130,7 +120,6 @@ const DaemonSetTableRow = ({
     </TableRow>
   );
 };
-DaemonSetTableRow.displayName = 'DaemonSetTableRow';
 
 export const DaemonSetDetailsList: React.FC<DaemonSetDetailsListProps> = ({ ds }) => (
   <dl className="co-m-pane__details">

--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -87,7 +87,6 @@ const TableRowForKind = ({ obj, index, key, style, customData }) => {
     </TableRow>
   );
 };
-TableRowForKind.displayName = 'TableRowForKind';
 
 const DetailsForKind = (kind) =>
   function DetailsForKind_({ obj }) {

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -8,7 +8,7 @@ import { DeploymentConfigModel } from '../models';
 import { Conditions } from './conditions';
 import { ResourceEventStream } from './events';
 import { VolumesTable } from './volumes-table';
-import { DetailsPage, ListPage, Table } from './factory';
+import { DetailsPage, ListPage, Table, RowFunction } from './factory';
 import {
   AsyncComponent,
   ContainerTable,
@@ -270,12 +270,7 @@ DeploymentConfigsDetailsPage.displayName = 'DeploymentConfigsDetailsPage';
 
 const kind = 'DeploymentConfig';
 
-const DeploymentConfigTableRow: React.FC<DeploymentConfigTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+const DeploymentConfigTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <WorkloadTableRow
       obj={obj}
@@ -286,13 +281,6 @@ const DeploymentConfigTableRow: React.FC<DeploymentConfigTableRowProps> = ({
       kind={kind}
     />
   );
-};
-DeploymentConfigTableRow.displayName = 'DeploymentTableRow';
-type DeploymentConfigTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const DeploymentConfigTableHeader = () => {

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -328,16 +328,17 @@ const VirtualBody: React.SFC<VirtualBodyProps> = (props) => {
   );
 };
 
-export type RowFunctionArgs = {
-  obj: object;
+export type RowFunctionArgs<T = any, C = any> = {
+  obj: T;
   index: number;
   columns: [];
   isScrolling: boolean;
   key: string;
   style: object;
-  customData?: any;
+  customData?: C;
 };
-export type RowFunction = (args: RowFunctionArgs) => JSX.Element;
+
+export type RowFunction<T = any, C = any> = (args: RowFunctionArgs<T, C>) => JSX.Element;
 
 export type VirtualBodyProps = {
   customData?: any;

--- a/frontend/public/components/group.tsx
+++ b/frontend/public/components/group.tsx
@@ -6,7 +6,7 @@ import { sortable } from '@patternfly/react-table';
 
 import { GroupModel, UserModel } from '../models';
 import { referenceForModel, GroupKind, K8sKind } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { addUsersModal, removeUserModal } from './modals';
 import { RoleBindingsPage } from './RBAC';
 import { fromNow } from './utils/datetime';
@@ -81,7 +81,7 @@ const GroupTableHeader = () => {
 };
 GroupTableHeader.displayName = 'GroupTableHeader';
 
-const GroupTableRow: React.FC<GroupTableRowProps> = ({ obj, index, key, style }) => {
+const GroupTableRow: RowFunction<GroupKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -179,13 +179,6 @@ export const GroupDetailsPage: React.FC<GroupDetailsPageProps> = (props) => (
     ]}
   />
 );
-
-type GroupTableRowProps = {
-  obj: GroupKind;
-  key: string;
-  index: number;
-  style: any;
-};
 
 type UserKebabProps = {
   group: GroupKind;

--- a/frontend/public/components/hpa.tsx
+++ b/frontend/public/components/hpa.tsx
@@ -5,7 +5,7 @@ import { sortable } from '@patternfly/react-table';
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { HorizontalPodAutoscalerModel } from '../models';
 import { Conditions } from './conditions';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   DetailsItem,
   Kebab,
@@ -264,7 +264,7 @@ const HorizontalPodAutoscalersTableHeader = () => {
 };
 HorizontalPodAutoscalersTableHeader.displayName = 'HorizontalPodAutoscalersTableHeader';
 
-const HorizontalPodAutoscalersTableRow: React.FC<HorizontalPodAutoscalersTableRowProps> = ({
+const HorizontalPodAutoscalersTableRow: RowFunction<K8sResourceKind> = ({
   obj,
   index,
   key,
@@ -309,13 +309,6 @@ const HorizontalPodAutoscalersTableRow: React.FC<HorizontalPodAutoscalersTableRo
       </TableData>
     </TableRow>
   );
-};
-HorizontalPodAutoscalersTableRow.displayName = 'HorizontalPodAutoscalersTableRow';
-type HorizontalPodAutoscalersTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const HorizontalPodAutoscalersList: React.SFC = (props) => (

--- a/frontend/public/components/image-stream.tsx
+++ b/frontend/public/components/image-stream.tsx
@@ -8,7 +8,7 @@ import { QuestionCircleIcon } from '@patternfly/react-icons';
 
 import { K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { ImageStreamModel } from '../models';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   CopyToClipboard,
   ExpandableAlert,
@@ -331,7 +331,7 @@ const ImageStreamsTableHeader = () => {
 };
 ImageStreamsTableHeader.displayName = 'ImageStreamsTableHeader';
 
-const ImageStreamsTableRow: React.FC<ImageStreamsTableRowProps> = ({ obj, index, key, style }) => {
+const ImageStreamsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -356,13 +356,6 @@ const ImageStreamsTableRow: React.FC<ImageStreamsTableRowProps> = ({ obj, index,
       </TableData>
     </TableRow>
   );
-};
-ImageStreamsTableRow.displayName = 'ImageStreamsTableRow';
-type ImageStreamsTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 export const ImageStreamsList: React.SFC = (props) => (

--- a/frontend/public/components/ingress.jsx
+++ b/frontend/public/components/ingress.jsx
@@ -127,7 +127,6 @@ const IngressTableRow = ({ obj: ingress, index, key, style }) => {
     </TableRow>
   );
 };
-IngressTableRow.displayName = 'IngressTableRow';
 
 const RulesHeader = () => (
   <div className="row co-m-table-grid__head">

--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -7,7 +7,7 @@ import { sortable } from '@patternfly/react-table';
 import { Status } from '@console/shared';
 import { getJobTypeAndCompletions, K8sKind, JobKind } from '../module/k8s';
 import { Conditions } from './conditions';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { configureJobParallelismModal } from './modals';
 import {
   ContainerTable,
@@ -98,17 +98,7 @@ const JobTableHeader = () => {
 };
 JobTableHeader.displayName = 'JobTableHeader';
 
-const JobTableRow = ({
-  obj: job,
-  index,
-  key,
-  style,
-}: {
-  obj: JobKind;
-  index: number;
-  key: string;
-  style: any;
-}) => {
+const JobTableRow: RowFunction<JobKind> = ({ obj: job, index, key, style }) => {
   const { type, completions } = getJobTypeAndCompletions(job);
   return (
     <TableRow id={job.metadata.uid} index={index} trKey={key} style={style}>
@@ -142,7 +132,6 @@ const JobTableRow = ({
     </TableRow>
   );
 };
-JobTableRow.displayName = 'JobTableRow';
 
 const jobStatus = (job: JobKind): string => {
   return job && job.status ? _.get(job, 'status.conditions[0].type', 'In Progress') : null;

--- a/frontend/public/components/limit-range.tsx
+++ b/frontend/public/components/limit-range.tsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 import { K8sResourceKindReference, K8sResourceKind } from '../module/k8s';
 import { LimitRangeModel } from '../models';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   Kebab,
   navFactory,
@@ -27,12 +27,7 @@ const tableColumnClasses = [
   Kebab.columnClass,
 ];
 
-export const LimitRangeTableRow: React.FC<LimitRangeTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+export const LimitRangeTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -57,13 +52,6 @@ export const LimitRangeTableRow: React.FC<LimitRangeTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-LimitRangeTableRow.displayName = 'LimitRangeTableRow';
-type LimitRangeTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 export const LimitRangeTableHeader = () => {

--- a/frontend/public/components/machine-autoscaler.tsx
+++ b/frontend/public/components/machine-autoscaler.tsx
@@ -9,7 +9,7 @@ import {
   referenceForGroupVersionKind,
   referenceForModel,
 } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   Kebab,
   navFactory,
@@ -87,12 +87,7 @@ const MachineAutoscalerTableHeader = () => {
 };
 MachineAutoscalerTableHeader.displayName = 'MachineAutoscalerTableHeader';
 
-const MachineAutoscalerTableRow: React.FC<MachineAutoscalerTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+const MachineAutoscalerTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -119,13 +114,6 @@ const MachineAutoscalerTableRow: React.FC<MachineAutoscalerTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-MachineAutoscalerTableRow.displayName = 'MachineAutoscalerTableRow';
-type MachineAutoscalerTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const MachineAutoscalerList: React.FC = (props) => (

--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -15,7 +15,7 @@ import {
   MachineConfigPoolKind,
   referenceForModel,
 } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   Kebab,
   KebabAction,
@@ -262,7 +262,7 @@ const MachineConfigPoolTableHeader = () => {
 };
 MachineConfigPoolTableHeader.displayName = 'MachineConfigPoolTableHeader';
 
-const MachineConfigPoolTableRow: React.FC<MachineConfigPoolTableRowProps> = ({
+const MachineConfigPoolTableRow: RowFunction<MachineConfigPoolKind> = ({
   obj,
   index,
   key,
@@ -306,13 +306,6 @@ const MachineConfigPoolTableRow: React.FC<MachineConfigPoolTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-MachineConfigPoolTableRow.displayName = 'MachineConfigPoolTableRow';
-type MachineConfigPoolTableRowProps = {
-  obj: MachineConfigPoolKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const MachineConfigPoolList: React.SFC<any> = (props) => (

--- a/frontend/public/components/machine-config.tsx
+++ b/frontend/public/components/machine-config.tsx
@@ -5,7 +5,7 @@ import * as classNames from 'classnames';
 import { MachineConfigKind, referenceForModel } from '../module/k8s';
 import { MachineConfigModel } from '../models';
 import { fromNow } from './utils/datetime';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   Kebab,
   navFactory,
@@ -107,12 +107,7 @@ const MachineConfigTableHeader = () => {
 };
 MachineConfigTableHeader.displayName = 'MachineConfigTableHeader';
 
-const MachineConfigTableRow: React.FC<MachineConfigTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+const MachineConfigTableRow: RowFunction<MachineConfigKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -151,13 +146,6 @@ const MachineConfigTableRow: React.FC<MachineConfigTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-MachineConfigTableRow.displayName = 'MachineConfigTableRow';
-type MachineConfigTableRowProps = {
-  obj: MachineConfigKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const MachineConfigList: React.SFC<any> = (props) => (

--- a/frontend/public/components/machine-deployment.tsx
+++ b/frontend/public/components/machine-deployment.tsx
@@ -13,7 +13,7 @@ import {
   MachineCounts,
   MachineTabPage,
 } from './machine-set';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   Kebab,
   ResourceKebab,
@@ -71,7 +71,7 @@ const MachineDeploymentTableHeader = () => {
 };
 MachineDeploymentTableHeader.displayName = 'MachineDeploymentTableHeader';
 
-const MachineDeploymentTableRow: React.FC<MachineDeploymentTableRowProps> = ({
+const MachineDeploymentTableRow: RowFunction<MachineDeploymentKind> = ({
   obj,
   index,
   key,
@@ -106,13 +106,6 @@ const MachineDeploymentTableRow: React.FC<MachineDeploymentTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-MachineDeploymentTableRow.displayName = 'MachineDeploymentTableRow';
-type MachineDeploymentTableRowProps = {
-  obj: MachineDeploymentKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const MachineDeploymentDetails: React.SFC<MachineDeploymentDetailsProps> = ({ obj }) => {

--- a/frontend/public/components/machine-health-check.tsx
+++ b/frontend/public/components/machine-health-check.tsx
@@ -5,7 +5,7 @@ import * as classNames from 'classnames';
 
 import { MachineHealthCheckModel, MachineModel } from '../models';
 import { K8sResourceKind, referenceForModel } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   DetailsItem,
   EmptyBox,
@@ -58,12 +58,7 @@ const MachineHealthCheckTableHeader = () => {
 };
 MachineHealthCheckTableHeader.displayName = 'MachineHealthCheckTableHeader';
 
-const MachineHealthCheckTableRow: React.FC<MachineHealthCheckTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+const MachineHealthCheckTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -84,13 +79,6 @@ const MachineHealthCheckTableRow: React.FC<MachineHealthCheckTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-MachineHealthCheckTableRow.displayName = 'MachineHealthCheckTableRow';
-type MachineHealthCheckTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const MachineHealthCheckList: React.FC = (props) => (

--- a/frontend/public/components/machine-set.tsx
+++ b/frontend/public/components/machine-set.tsx
@@ -12,7 +12,7 @@ import { MachineAutoscalerModel, MachineModel, MachineSetModel } from '../models
 import { K8sKind, MachineDeploymentKind, MachineSetKind, referenceForModel } from '../module/k8s';
 import { MachinePage } from './machine';
 import { configureMachineAutoscalerModal, configureReplicaCountModal } from './modals';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   Kebab,
   KebabAction,
@@ -121,7 +121,7 @@ const MachineSetTableHeader = () => {
 };
 MachineSetTableHeader.displayName = 'MachineSetTableHeader';
 
-const MachineSetTableRow: React.FC<MachineSetTableRowProps> = ({ obj, index, key, style }) => {
+const MachineSetTableRow: RowFunction<MachineSetKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -150,13 +150,6 @@ const MachineSetTableRow: React.FC<MachineSetTableRowProps> = ({ obj, index, key
       </TableData>
     </TableRow>
   );
-};
-MachineSetTableRow.displayName = 'MachineSetTableRow';
-type MachineSetTableRowProps = {
-  obj: MachineSetKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 export const MachineCounts: React.SFC<MachineCountsProps> = ({

--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -15,7 +15,7 @@ import { MachineModel } from '../models';
 import { MachineKind, referenceForModel } from '../module/k8s';
 import { Conditions } from './conditions';
 import NodeIPList from '@console/app/src/components/nodes/NodeIPList';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   DetailsItem,
   Kebab,
@@ -98,7 +98,7 @@ MachineTableHeader.displayName = 'MachineTableHeader';
 const getMachineProviderState = (obj: MachineKind): string =>
   obj?.status?.providerStatus?.instanceState;
 
-const MachineTableRow: React.FC<MachineTableRowProps> = ({ obj, index, key, style }) => {
+const MachineTableRow: RowFunction<MachineKind> = ({ obj, index, key, style }) => {
   const nodeName = getMachineNodeName(obj);
   const region = getMachineRegion(obj);
   const zone = getMachineZone(obj);
@@ -130,13 +130,6 @@ const MachineTableRow: React.FC<MachineTableRowProps> = ({ obj, index, key, styl
       </TableData>
     </TableRow>
   );
-};
-MachineTableRow.displayName = 'MachineTableRow';
-type MachineTableRowProps = {
-  obj: MachineKind;
-  index: number;
-  key: string;
-  style: object;
 };
 
 const MachineDetails: React.SFC<MachineDetailsProps> = ({ obj }: { obj: MachineKind }) => {

--- a/frontend/public/components/monitoring/alert-manager-config.tsx
+++ b/frontend/public/components/monitoring/alert-manager-config.tsx
@@ -17,7 +17,7 @@ import {
 import { K8sResourceKind } from '../../module/k8s';
 import { history, Kebab, MsgBox, SectionHeading, StatusBox } from '../utils';
 import { confirmModal, createAlertRoutingModal } from '../modals';
-import { Table, TableData, TableRow, TextFilter } from '../factory';
+import { Table, TableData, TableRow, TextFilter, RowFunction } from '../factory';
 import {
   getAlertmanagerConfig,
   patchAlertmanagerConfig,
@@ -249,13 +249,13 @@ const receiverMenuItems = (receiverName: string, canDelete: boolean, canUseEditF
   },
 ];
 
-const ReceiverTableRow: React.FC<ReceiverTableRowProps> = ({
-  obj: receiver,
-  index,
-  key,
-  style,
-  customData,
-}) => {
+const ReceiverTableRow: RowFunction<
+  AlertmanagerReceiver,
+  {
+    routingLabelsByReceivers: RoutingLabelsByReceivers[];
+    defaultReceiverName: string;
+  }
+> = ({ obj: receiver, index, key, style, customData }) => {
   const { routingLabelsByReceivers, defaultReceiverName } = customData;
   // filter to routing labels belonging to current Receiver
   const receiverRoutingLabels = _.filter(routingLabelsByReceivers, { receiver: receiver.name });
@@ -300,7 +300,6 @@ const ReceiverTableRow: React.FC<ReceiverTableRowProps> = ({
     </TableRow>
   );
 };
-ReceiverTableRow.displayName = 'ReceiverTableRow';
 
 const ReceiversTable: React.FC<ReceiverTableProps> = (props) => {
   const { filterValue } = props;
@@ -484,17 +483,6 @@ export type AlertmanagerConfig = {
 type ReceiverTableProps = {
   data: AlertmanagerReceiver[];
   filterValue?: string;
-};
-
-type ReceiverTableRowProps = {
-  obj: AlertmanagerReceiver;
-  index: number;
-  key?: string;
-  style: object;
-  customData: {
-    routingLabelsByReceivers: RoutingLabelsByReceivers[];
-    defaultReceiverName: string;
-  };
 };
 
 type RoutingLabelProps = {

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -181,7 +181,6 @@ const NamespacesTableRow = ({ obj: ns, index, key, style }) => {
     </TableRow>
   );
 };
-NamespacesTableRow.displayName = 'NamespacesTableRow';
 
 export const NamespacesList = (props) => (
   <Table

--- a/frontend/public/components/network-policy.jsx
+++ b/frontend/public/components/network-policy.jsx
@@ -92,7 +92,6 @@ const NetworkPolicyTableRow = ({ obj: np, index, key, style }) => {
     </TableRow>
   );
 };
-NetworkPolicyTableRow.displayName = 'NetworkPolicyTableRow';
 
 const NetworkPoliciesList = (props) => (
   <Table

--- a/frontend/public/components/persistent-volume-claim.jsx
+++ b/frontend/public/components/persistent-volume-claim.jsx
@@ -140,7 +140,6 @@ const PVCTableRow = ({ obj, index, key, style }) => {
     </TableRow>
   );
 };
-PVCTableRow.displayName = 'PVCTableRow';
 
 const Details_ = ({ flags, obj: pvc }) => {
   const canListPV = flags[FLAGS.CAN_LIST_PV];

--- a/frontend/public/components/persistent-volume.jsx
+++ b/frontend/public/components/persistent-volume.jsx
@@ -123,7 +123,6 @@ const PVTableRow = ({ obj, index, key, style }) => {
     </TableRow>
   );
 };
-PVTableRow.displayName = 'PVTableRow';
 
 const Details = ({ obj: pv }) => {
   const storageClassName = _.get(pv, 'spec.storageClassName');

--- a/frontend/public/components/prometheus.jsx
+++ b/frontend/public/components/prometheus.jsx
@@ -54,7 +54,6 @@ const PrometheusTableRow = ({ obj: instance, index, key, style }) => {
     </TableRow>
   );
 };
-PrometheusTableRow.displayName = 'PrometheusTableRow';
 
 const PrometheusTableHeader = () => {
   return [

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -157,7 +157,6 @@ const ReplicaSetTableRow = ({ obj, index, key, style }) => {
     </TableRow>
   );
 };
-ReplicaSetTableRow.displayName = 'ReplicaSetTableRow';
 
 const ReplicaSetTableHeader = () => {
   return [

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -205,7 +205,6 @@ const ReplicationControllerTableRow = ({ obj, index, key, style }) => {
     </TableRow>
   );
 };
-ReplicationControllerTableRow.displayName = 'ReplicationControllerTableRow';
 
 const ReplicationControllerTableHeader = () => {
   return [

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -150,7 +150,6 @@ export const ResourceQuotaTableRow = ({ obj: rq, index, key, style }) => {
     </TableRow>
   );
 };
-ResourceQuotaTableRow.displayName = 'ResourceQuotaTableRow';
 
 export const UsageIcon = ({ percent }) => {
   let usageIcon = <UnknownIcon />;

--- a/frontend/public/components/routes.tsx
+++ b/frontend/public/components/routes.tsx
@@ -6,7 +6,7 @@ import { sortable } from '@patternfly/react-table';
 import { EyeIcon, EyeSlashIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 
 import { Status } from '@console/shared';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   CopyToClipboard,
   DetailsItem,
@@ -188,7 +188,7 @@ const RouteTableHeader = () => {
 };
 RouteTableHeader.displayName = 'RouteTableHeader';
 
-const RouteTableRow: React.FC<RouteTableRowProps> = ({ obj: route, index, key, style }) => {
+const RouteTableRow: RowFunction<RouteKind> = ({ obj: route, index, key, style }) => {
   return (
     <TableRow id={route.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -225,13 +225,6 @@ const RouteTableRow: React.FC<RouteTableRowProps> = ({ obj: route, index, key, s
       </TableData>
     </TableRow>
   );
-};
-RouteTableRow.displayName = 'RouteTableRow';
-type RouteTableRowProps = {
-  obj: RouteKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const TLSSettings: React.FC<TLSSettingsProps> = ({ route }) => {

--- a/frontend/public/components/secret.jsx
+++ b/frontend/public/components/secret.jsx
@@ -130,7 +130,6 @@ const SecretTableRow = ({ obj: secret, index, key, style }) => {
     </TableRow>
   );
 };
-SecretTableRow.displayName = 'SecretTableRow';
 
 const SecretDetails = ({ obj: secret }) => {
   return (

--- a/frontend/public/components/service-account.jsx
+++ b/frontend/public/components/service-account.jsx
@@ -168,7 +168,6 @@ const ServiceAccountTableRow = ({ obj: serviceaccount, index, key, style }) => {
     </TableRow>
   );
 };
-ServiceAccountTableRow.displayName = 'ServiceAccountTableRow';
 
 const Details = ({ obj: serviceaccount }) => {
   const {

--- a/frontend/public/components/service-binding.tsx
+++ b/frontend/public/components/service-binding.tsx
@@ -6,7 +6,7 @@ import * as classNames from 'classnames';
 import { Alert } from '@patternfly/react-core';
 
 import { serviceCatalogStatus, referenceForModel, K8sResourceKind } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   Kebab,
   SectionHeading,
@@ -164,12 +164,7 @@ const ServiceBindingsTableHeader = () => {
 };
 ServiceBindingsTableHeader.displayName = 'ServiceBindingsTableHeader';
 
-const ServiceBindingsTableRow: React.FC<ServiceBindingsTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+const ServiceBindingsTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -210,13 +205,6 @@ const ServiceBindingsTableRow: React.FC<ServiceBindingsTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-ServiceBindingsTableRow.displayName = 'ServiceBindingsTableRow';
-type ServiceBindingsTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const ServiceBindingsList: React.SFC = (props) => (

--- a/frontend/public/components/service-instance.tsx
+++ b/frontend/public/components/service-instance.tsx
@@ -12,7 +12,7 @@ import {
   serviceCatalogStatus,
   referenceForModel,
 } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   ExternalLink,
   Kebab,
@@ -300,12 +300,7 @@ const ServiceInstancesTableHeader = () => {
 };
 ServiceInstancesTableHeader.displayName = 'ServiceInstancesTableHeader';
 
-const ServiceInstancesTableRow: React.FC<ServiceInstancesTableRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+const ServiceInstancesTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   const clusterServiceClassRefName = _.get(obj, 'spec.clusterServiceClassRef.name');
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
@@ -354,13 +349,6 @@ const ServiceInstancesTableRow: React.FC<ServiceInstancesTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-ServiceInstancesTableRow.displayName = 'ServiceInstancesTableRow';
-type ServiceInstancesTableRowProps = {
-  obj: K8sResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const ServiceInstancesList: React.SFC = (props) => (

--- a/frontend/public/components/service-monitor.jsx
+++ b/frontend/public/components/service-monitor.jsx
@@ -73,7 +73,6 @@ const ServiceMonitorTableRow = ({ obj: sm, index, key, style }) => {
     </TableRow>
   );
 };
-ServiceMonitorTableRow.displayName = 'ServiceMonitorTableRow';
 
 const ServiceMonitorTableHeader = () => {
   return [

--- a/frontend/public/components/service.jsx
+++ b/frontend/public/components/service.jsx
@@ -117,7 +117,6 @@ const ServiceTableRow = ({ obj: s, index, key, style }) => {
     </TableRow>
   );
 };
-ServiceTableRow.displayName = 'ServiceTableRow';
 
 const ServiceAddress = ({ s }) => {
   const ServiceIPsRow = (name, desc, ips, note = null) => (

--- a/frontend/public/components/stateful-set.tsx
+++ b/frontend/public/components/stateful-set.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { K8sResourceKind } from '../module/k8s';
 import { ResourceEventStream } from './events';
-import { DetailsPage, ListPage, Table } from './factory';
+import { DetailsPage, ListPage, Table, RowFunction } from './factory';
 
 import { WorkloadTableRow, WorkloadTableHeader } from './workload-table';
 
@@ -27,17 +27,7 @@ export const menuActions: KebabAction[] = [
 
 const kind = 'StatefulSet';
 
-const StatefulSetTableRow = ({
-  obj,
-  index,
-  key,
-  style,
-}: {
-  obj: K8sResourceKind;
-  index: number;
-  key: string;
-  style: any;
-}) => {
+const StatefulSetTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, style }) => {
   return (
     <WorkloadTableRow
       obj={obj}
@@ -49,7 +39,6 @@ const StatefulSetTableRow = ({
     />
   );
 };
-StatefulSetTableRow.displayName = 'StatefulSetTableRow';
 
 const StatefulSetTableHeader = () => {
   return WorkloadTableHeader();

--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import { sortable } from '@patternfly/react-table';
 import * as classNames from 'classnames';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
   DetailsItem,
   Kebab,
@@ -70,7 +70,12 @@ const StorageClassTableHeader = () => {
 };
 StorageClassTableHeader.displayName = 'StorageClassTableHeader';
 
-const StorageClassTableRow: React.SFC<StorageClassTableRowProps> = ({ obj, index, key, style }) => {
+const StorageClassTableRow: RowFunction<StorageClassResourceKind> = ({
+  obj,
+  index,
+  key,
+  style,
+}) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={classNames(tableColumnClasses[0], 'co-break-word')}>
@@ -89,13 +94,6 @@ const StorageClassTableRow: React.SFC<StorageClassTableRowProps> = ({ obj, index
       </TableData>
     </TableRow>
   );
-};
-StorageClassTableRow.displayName = 'StorageClassTableRow';
-type StorageClassTableRowProps = {
-  obj: StorageClassResourceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const StorageClassDetails: React.SFC<StorageClassDetailsProps> = ({ obj }) => (

--- a/frontend/public/components/template-instance.tsx
+++ b/frontend/public/components/template-instance.tsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
 import { Status } from '@console/shared';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { Conditions } from './conditions';
 import { getTemplateInstanceStatus, referenceFor, TemplateInstanceKind } from '../module/k8s';
 import {
@@ -54,7 +54,7 @@ const TemplateInstanceTableHeader = () => {
 };
 TemplateInstanceTableHeader.displayName = 'TemplateInstanceTableHeader';
 
-const TemplateInstanceTableRow: React.FC<TemplateInstanceTableRowProps> = ({
+const TemplateInstanceTableRow: RowFunction<TemplateInstanceKind> = ({
   obj,
   index,
   key,
@@ -80,13 +80,6 @@ const TemplateInstanceTableRow: React.FC<TemplateInstanceTableRowProps> = ({
       </TableData>
     </TableRow>
   );
-};
-TemplateInstanceTableRow.displayName = 'TemplateInstanceTableRow';
-type TemplateInstanceTableRowProps = {
-  obj: TemplateInstanceKind;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 export const TemplateInstanceList: React.SFC = (props) => (

--- a/frontend/public/components/user.tsx
+++ b/frontend/public/components/user.tsx
@@ -9,7 +9,7 @@ import { sortable } from '@patternfly/react-table';
 import * as UIActions from '../actions/ui';
 import { OAuthModel, UserModel } from '../models';
 import { K8sKind, referenceForModel, UserKind } from '../module/k8s';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { RoleBindingsPage } from './RBAC';
 import {
   Kebab,
@@ -79,7 +79,7 @@ const UserKebab = connect<{}, UserKebabDispatchProps, UserKebabProps>(null, {
   startImpersonate: UIActions.startImpersonate,
 })(UserKebab_);
 
-const UserTableRow: React.FC<UserTableRowProps> = ({ obj, index, key, style }) => {
+const UserTableRow: RowFunction<UserKind> = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses[0]}>
@@ -168,13 +168,6 @@ type UserKebabDispatchProps = {
 
 type UserKebabProps = {
   user: UserKind;
-};
-
-type UserTableRowProps = {
-  obj: UserKind;
-  key: string;
-  index: number;
-  style: any;
 };
 
 const UserDetailsPage_: React.FC<UserDetailsPageProps & UserKebabDispatchProps> = ({

--- a/frontend/public/components/volumes-table.tsx
+++ b/frontend/public/components/volumes-table.tsx
@@ -22,7 +22,7 @@ import {
   SectionHeading,
   VolumeType,
 } from './utils';
-import { Table, TableData, TableRow } from './factory';
+import { Table, TableData, TableRow, RowFunction } from './factory';
 import { sortable } from '@patternfly/react-table';
 import { removeVolumeModal } from './modals';
 import { connectToModel } from '../kinds';
@@ -142,7 +142,7 @@ const VolumesTableHeader = () => {
 };
 VolumesTableHeader.displayName = 'VolumesTableHeader';
 
-const VolumesTableRow = ({ obj: volume, index, key, style }) => {
+const VolumesTableRow: RowFunction = ({ obj: volume, index, key, style }) => {
   const { name, resource, readOnly, mountPath, subPath, volumeDetail } = volume;
   const permission = readOnly ? 'Read-only' : 'Read/Write';
   const pod: PodTemplate = getPodTemplate(resource);
@@ -181,7 +181,6 @@ const VolumesTableRow = ({ obj: volume, index, key, style }) => {
     </TableRow>
   );
 };
-VolumesTableRow.displayName = 'VolumesTableRow';
 
 export const VolumesTable = (props) => {
   const { resource, ...tableProps } = props;


### PR DESCRIPTION
Originally, Console `Table.Row` prop used to reference React components.

Currently, using `VirtualTableBody.rowRenderer` from `@patternfly/react-virtualized-extension` implies that rows are callbacks, not React components.

The force cast

```ts
const row = (Row as RowFunction)(rowArgs as RowFunctionArgs);
```

is a work-around, along with

```ts
Row?: RowFunction | React.ComponentClass<any, any> | React.ComponentType<any>;
```

This PR fixes all row typings, minus a few convoluted cases which will be addressed in a follow-up.

cc @benjaminapetersen @spadgett @christianvogt @rawagner 
