### PR TITLE
Monitoring: Split silenced alert counts by severity and info icon

### DIFF
--- a/frontend/public/reducers/monitoring.ts
+++ b/frontend/public/reducers/monitoring.ts
@@ -4,6 +4,13 @@ import * as _ from 'lodash-es';
 
 import { MonitoringAction, ActionType } from '../actions/monitoring';
 
+export const enum AlertSeverities {
+  Critical = 'critical',
+  Info = 'info',
+  None = 'none',
+  Warning = 'warning',
+}
+
 export const enum AlertStates {
   Firing = 'firing',
   Silenced = 'silenced',


### PR DESCRIPTION
On Silences list page, split the "Firing Alerts" counts (number of
silenced alerts) by alert severity.
Make "Firing Alerts" the second column in the Silences list.
Add icon for alerts severity `info`.

### Info Icon
![screenshot](https://user-images.githubusercontent.com/460802/77274560-8a3afe80-6cf9-11ea-8e79-e4abc495fb87.png)

### Silences List
![screenshot-1](https://user-images.githubusercontent.com/460802/77274563-8b6c2b80-6cf9-11ea-82da-371376cf0152.png)
