### PR TITLE
KNIP-525: Add an Environment tab for Virtual Machines

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -21,7 +21,8 @@ import { VMConsoleFirehose } from './vm-console';
 import { VMDetailsFirehose } from './vm-details';
 import { vmMenuActionsCreator } from './menu-actions';
 import { VMDashboard } from './vm-dashboard';
-import { TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM } from '../../constants/vm';
+import { TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM, VM_DETAIL_ENVIRONMENT } from '../../constants/vm';
+import { VMEnvironmentFirehose } from './vm-environment/vm-environment-page';
 
 export const breadcrumbsForVMPage = (match: any) => () => [
   {
@@ -64,6 +65,12 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
     component: VMDisksFirehose,
   };
 
+  const environmentPage = {
+    href: VM_DETAIL_ENVIRONMENT,
+    name: 'Environment',
+    component: VMEnvironmentFirehose,
+  };
+
   const pages = [
     dashboardPage,
     overviewPage,
@@ -72,6 +79,7 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
     navFactory.events(VMEvents),
     nicsPage,
     disksPage,
+    environmentPage,
   ];
 
   const resources = [

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/constants.ts
@@ -1,0 +1,12 @@
+export const configMapList = 'ConfigMapList';
+export const secretList = 'SecretList';
+export const serviceAccountList = 'ServiceAccountList';
+export const configMapKind = 'configMap';
+export const secretKind = 'secret';
+export const serviceAccountKind = 'serviceAccount';
+export const configMapRef = 'configMapRef';
+export const secretRef = 'secretRef';
+export const serviceAccountRef = 'serviceAccountRef';
+
+export const duplicateSerialsErrorMsg = 'There are two or more sources with the same Serial Number';
+export const emptySerialErrorMsg = 'Some sources are missing a Serial Number';

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/selectors.ts
@@ -1,0 +1,150 @@
+import * as _ from 'lodash';
+import { SOURCES, EnvDisk } from './types';
+import { V1Volume } from '../../../types/vm/disk/V1Volume';
+import {
+  configMapKind,
+  configMapRef,
+  secretRef,
+  secretKind,
+  serviceAccountRef,
+  serviceAccountKind,
+} from './constants';
+import { getRandomChars } from '@console/shared';
+import {
+  EnvVarSource,
+  ListKind,
+  ConfigMapKind,
+  SecretKind,
+  ServiceAccountKind,
+} from '@console/internal/module/k8s';
+import { V1Disk } from 'packages/kubevirt-plugin/src/types/vm/disk/V1Disk';
+
+export const getSerial = (ed: EnvDisk): string => ed[0];
+export const getEnvVarSource = (ed: EnvDisk): EnvVarSource => ed[1];
+
+export const getSourceName = (source): string =>
+  source?.configMapRef?.name || source?.secretRef?.name || source?.serviceAccountRef?.name || '';
+
+export const getEnvDiskRefKind = (envDisk: EnvDisk) =>
+  getEnvVarSource(envDisk) && Object.keys(getEnvVarSource(envDisk))[0];
+
+export const getSourceKind = (envDisk: EnvDisk): string => {
+  switch (getEnvDiskRefKind(envDisk)) {
+    case configMapRef:
+      return configMapKind;
+    case secretRef:
+      return secretKind;
+    case serviceAccountRef:
+      return serviceAccountKind;
+    default:
+      return null;
+  }
+};
+
+export const getNewDiskName = (sourceName: string) => `${sourceName}-${getRandomChars(6)}-disk`;
+
+export const areEnvDisksEqual = (envDisk1: EnvDisk, envDisk2: EnvDisk): boolean => {
+  if (!envDisk1 && !envDisk2) {
+    return true;
+  }
+  if (!envDisk1 || !envDisk2) {
+    return false;
+  }
+
+  return (
+    getSerial(envDisk1) === getSerial(envDisk2) &&
+    _.isEqual(getEnvVarSource(envDisk1), getEnvVarSource(envDisk2))
+  );
+};
+
+export const toListObj = (
+  kind: string,
+  items,
+): ListKind<ConfigMapKind | SecretKind | ServiceAccountKind> => {
+  return {
+    apiVersion: 'v1',
+    kind,
+    metadata: {},
+    items,
+  };
+};
+
+export const getAvailableSources = (allSources, usedSources) =>
+  allSources.filter(
+    (src) =>
+      !usedSources.find(
+        (ed) => getEnvVarSource(ed)[getEnvDiskRefKind(ed)].name === src.metadata.name,
+      ),
+  );
+
+export const getNewEnvVarSource = (kind: string, name: string): EnvVarSource => {
+  if (!kind || !name) {
+    return null;
+  }
+
+  switch (kind) {
+    case SOURCES.configMapKind:
+      return { configMapRef: { name } };
+    case SOURCES.secretKind:
+      return { secretRef: { name } };
+    case SOURCES.serviceAccountKind:
+      return { serviceAccountRef: { name } };
+    default:
+      return null;
+  }
+};
+
+export const getSerialNumber = () =>
+  getRandomChars(10)
+    .concat(getRandomChars(6))
+    .toLocaleUpperCase();
+
+export const setNewSourceDisk = (diskName: string, serial: string, diskBus: string): V1Disk => {
+  return {
+    disk: { bus: diskBus },
+    name: diskName,
+    serial,
+  };
+};
+
+const setNewconfigMapVolume = (sourceName: string, diskName: string): V1Volume => {
+  return {
+    configMap: { name: sourceName },
+    name: diskName,
+  };
+};
+
+const setNewSecretVolume = (sourceName: string, diskName: string): V1Volume => {
+  return {
+    secret: { secretName: sourceName },
+    name: diskName,
+  };
+};
+
+const setNewServiceAccountVolume = (sourceName: string, diskName: string): V1Volume => {
+  return {
+    serviceAccount: { serviceAccountName: sourceName },
+    name: diskName,
+  };
+};
+
+export const setNewSourceVolume = (
+  volKind: string,
+  sourceName: string,
+  diskName: string,
+): V1Volume => {
+  switch (volKind) {
+    case 'configMap':
+      return setNewconfigMapVolume(sourceName, diskName);
+    case 'secret':
+      return setNewSecretVolume(sourceName, diskName);
+    case 'serviceAccount':
+      return setNewServiceAccountVolume(sourceName, diskName);
+    default:
+      return null;
+  }
+};
+
+export const areThereDupSerials = (serials: string[]): boolean => {
+  return serials.length !== new Set(serials).size;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/types.ts
@@ -1,0 +1,13 @@
+import { EnvVarSource } from '../../../../../../public/module/k8s/index';
+
+export enum SOURCES {
+  configMapKind = 'configMap',
+  secretKind = 'secret',
+  serviceAccountKind = 'serviceAccount',
+}
+
+export type EnvDisk = [string, EnvVarSource, number];
+
+export type NameValuePairs = {
+  nameValuePairs: EnvDisk[];
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment-footer.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Button, ActionGroup } from '@patternfly/react-core';
+import { ModalErrorMessage, ModalSimpleMessage } from '../../modals/modal/modal-footer';
+
+export const VMEnvironmentFooter: React.FC<VMEnvironmentFooterProps> = ({
+  reload,
+  save,
+  errorMsg,
+  isSuccess,
+}) => {
+  return (
+    <footer className="co-m-btn-bar">
+      {errorMsg && <ModalErrorMessage message={errorMsg} />}
+      {!errorMsg && isSuccess && <ModalSimpleMessage message="Success" variant="success" />}
+      <ActionGroup className="pf-c-form">
+        <Button isDisabled={false} type="submit" variant="primary" onClick={save}>
+          Save
+        </Button>
+        <Button isDisabled={false} type="button" variant="secondary" onClick={reload}>
+          Reload
+        </Button>
+      </ActionGroup>
+    </footer>
+  );
+};
+
+type VMEnvironmentFooterProps = {
+  reload: () => void;
+  save: (event: any) => Promise<void>;
+  errorMsg: string;
+  isSuccess: boolean;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment-page.tsx
@@ -1,0 +1,400 @@
+import * as React from 'react';
+import { VMKind } from '../../../types/vm';
+import {
+  SecretKind,
+  ConfigMapKind,
+  EnvVarSource,
+  TemplateKind,
+  k8sPatch,
+  Patch,
+  ServiceAccountKind,
+} from '@console/internal/module/k8s';
+import { getNamespace } from '@console/shared';
+import { getResource } from '../../../utils';
+import {
+  SecretModel,
+  ConfigMapModel,
+  ServiceAccountModel,
+  TemplateModel,
+} from '@console/internal/models';
+import {
+  Firehose,
+  FirehoseResult,
+  FieldLevelHelp,
+  AsyncComponent,
+  HandlePromiseProps,
+  withHandlePromise,
+} from '@console/internal/components/utils';
+import { VMTabProps } from '../types';
+import { isVM, getVMLikeModel } from '../../../selectors/vm';
+import * as _ from 'lodash';
+import {
+  areEnvDisksEqual,
+  getEnvDiskRefKind,
+  getAvailableSources,
+  getNewEnvVarSource,
+  toListObj,
+  getSourceName,
+  getNewDiskName,
+  setNewSourceDisk,
+  getSourceKind,
+  getSerialNumber,
+  setNewSourceVolume,
+  areThereDupSerials,
+  getSerial,
+  getEnvVarSource,
+} from './selectors';
+import { SOURCES, EnvDisk, NameValuePairs } from './types';
+import { VMWrapper } from '../../../k8s/wrapper/vm/vm-wrapper';
+import {
+  configMapList,
+  secretList,
+  serviceAccountList,
+  secretKind,
+  configMapKind,
+  serviceAccountKind,
+  configMapRef,
+  secretRef,
+  serviceAccountRef,
+  duplicateSerialsErrorMsg,
+  emptySerialErrorMsg,
+} from './constants';
+import { VMEnvironmentFooter } from './vm-environment-footer';
+import './vm-environment.scss';
+import {
+  getTemplateValidationsFromTemplate,
+  getVMTemplateNamespacedName,
+} from '../../../selectors/vm-template/selectors';
+import { PatchBuilder } from '@console/shared/src/k8s/patch';
+import { getVMLikePatches } from '../../../k8s/patches/vm-template';
+import { V1Volume } from '../../../types/vm/disk/V1Volume';
+import { VirtualMachineModel } from '../../../models';
+import { V1Disk } from '../../../types/vm/disk/V1Disk';
+
+export const VMEnvironmentFirehose: React.FC<VMTabProps> = ({
+  obj: objProp,
+  vm: vmProp,
+  customData: { kindObj },
+}) => {
+  const vm = kindObj === VirtualMachineModel && isVM(objProp) ? objProp : vmProp;
+  const resources = [
+    getResource(SecretModel, { namespace: getNamespace(vm), prop: 'secretsResource' }),
+    getResource(ConfigMapModel, { namespace: getNamespace(vm), prop: 'configmapsResource' }),
+    getResource(ServiceAccountModel, {
+      namespace: getNamespace(vm),
+      prop: 'serviceAccountsResource',
+    }),
+  ];
+
+  const underlyingTemplate = getVMTemplateNamespacedName(vm);
+  if (underlyingTemplate) {
+    resources.push({
+      kind: TemplateModel.kind,
+      model: TemplateModel,
+      name: underlyingTemplate.name,
+      namespace: underlyingTemplate.namespace,
+      isList: false,
+      prop: 'templateResource',
+    });
+  }
+
+  return (
+    <div className="co-m-pane__body">
+      <Firehose resources={resources}>
+        <VMEnvironment vm={vm} />
+      </Firehose>
+    </div>
+  );
+};
+
+const EnvFromEditorComponent = (props) => (
+  <AsyncComponent
+    loader={() =>
+      import('@console/internal/components/utils/name-value-editor').then((c) => c.EnvFromEditor)
+    }
+    {...props}
+  />
+);
+
+const defaultEnvVar: EnvVarSource = {
+  configMapSecretRef: { name: 'Select a resource', key: '' },
+};
+const emptyEnvDisk: EnvDisk = ['', defaultEnvVar, 0];
+
+/*
+This component uses `EnvFromEditor` drap-n-drop list.
+The list accepts items of the following format:
+[Some-string (string), envVar object (of type EnvVarSource), index (number)]
+The format is represented here as 'envDisk'.
+
+Example:
+['ATF3O39YMJFGWTQE', configMapRef: { name: 'my-config' }, 4]
+*/
+const VMEnvironment = withHandlePromise<VMEnvironmentProps>(
+  ({
+    secretsResource,
+    configmapsResource,
+    serviceAccountsResource,
+    templateResource,
+    vm,
+    handlePromise,
+    inProgress,
+    errorMessage,
+  }) => {
+    const configMaps = configmapsResource?.data;
+    const secrets = secretsResource?.data;
+    const serviceAccounts = serviceAccountsResource?.data;
+    const template = templateResource?.data;
+    const vmWrapper = new VMWrapper(vm);
+
+    const [errMsg, setErrMsg] = React.useState(errorMessage);
+    const [isSuccess, setIsSuccess] = React.useState(false);
+
+    const setUsedSources = (isReload: boolean = false): EnvDisk[] => {
+      let counter = 0;
+      if (isReload) {
+        setErrMsg('');
+        setIsSuccess(false);
+      }
+      const configmapEnvDisks: EnvDisk[] = vmWrapper
+        .getConfigMaps()
+        .map((cm) => [
+          vmWrapper.getDiskSerial(cm.name),
+          getNewEnvVarSource(SOURCES.configMapKind, cm.configMap.name),
+          counter++,
+        ]);
+
+      const secretsEnvDisks: EnvDisk[] = vmWrapper
+        .getSecrets()
+        .map((s) => [
+          vmWrapper.getDiskSerial(s.name),
+          getNewEnvVarSource(SOURCES.secretKind, s.secret.secretName),
+          counter++,
+        ]);
+
+      const serviceAccountEnvDisks: EnvDisk[] = vmWrapper
+        .getServiceAccounts()
+        .map((sa) => [
+          vmWrapper.getDiskSerial(sa.name),
+          getNewEnvVarSource(SOURCES.serviceAccountKind, sa.serviceAccount.serviceAccountName),
+          counter++,
+        ]);
+
+      const usedSources = [...configmapEnvDisks, ...secretsEnvDisks, ...serviceAccountEnvDisks];
+      return usedSources.length > 0 ? usedSources : [emptyEnvDisk];
+    };
+
+    const [envDisks, setEnvDisks] = React.useState(setUsedSources());
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const onReload = React.useCallback(() => setEnvDisks(setUsedSources(true)), []);
+
+    const detectSourceChange = (update: NameValuePairs): EnvDisk => {
+      setIsSuccess(false);
+      if (!update) {
+        return null;
+      }
+
+      const newEnvDisks: EnvDisk[] = update.nameValuePairs;
+
+      // Resource was added or removed
+      if (newEnvDisks.length !== envDisks.length) {
+        return null;
+      }
+
+      const zipChange = _.zip(envDisks, newEnvDisks);
+      // Get the record that changed
+      const inPlaceChange = zipChange.find((pair) => !areEnvDisksEqual(pair[0], pair[1]));
+      if (inPlaceChange) {
+        const oldEnvDisk: EnvDisk = inPlaceChange[0];
+        const newEnvDisk: EnvDisk = inPlaceChange[1];
+
+        // The list had had only 1 record and it was deleted
+        if (
+          getSerial(newEnvDisk) !== getSerial(oldEnvDisk) &&
+          getEnvDiskRefKind(oldEnvDisk) !== getEnvDiskRefKind(newEnvDisk)
+        ) {
+          return null;
+        }
+
+        // Serial has changed
+        if (getSerial(newEnvDisk) !== getSerial(oldEnvDisk)) {
+          return null;
+        }
+
+        // Source has changed - return the changed envDisk
+        return newEnvDisk;
+      }
+
+      return null;
+    };
+
+    const updateEnvDisks = (newEnvDisks: NameValuePairs) => {
+      const newEnvDisk: EnvDisk = detectSourceChange(newEnvDisks);
+
+      if (newEnvDisk) {
+        // new envDisk was added
+        newEnvDisks.nameValuePairs[newEnvDisk[2]][0] = getSerialNumber();
+      }
+
+      // Update index
+      for (let i = 0; i < newEnvDisks.nameValuePairs.length; i++) {
+        newEnvDisks.nameValuePairs[i][2] = i;
+      }
+
+      if (newEnvDisks.nameValuePairs[0].length > 2) {
+        setEnvDisks(newEnvDisks.nameValuePairs);
+      } else {
+        setEnvDisks([emptyEnvDisk]);
+      }
+    };
+
+    const onSubmit = async (event) => {
+      event.preventDefault();
+
+      // Check for empty serials
+      const isEmptySerial: EnvDisk = envDisks.find(
+        (ed) => getSerial(ed) === '' && getSourceKind(ed),
+      );
+      if (isEmptySerial) {
+        setErrMsg(emptySerialErrorMsg);
+        return;
+      }
+      // Check for duplicate serials:
+      const duplicateSerials: boolean = areThereDupSerials(
+        envDisks.map((ed) => getSerial(ed)).filter((srl) => srl.length > 0),
+      );
+      if (duplicateSerials) {
+        setErrMsg(duplicateSerialsErrorMsg);
+        return;
+      }
+      setErrMsg('');
+
+      // Get all current non-source disks
+      const currentOtherDisks: V1Disk[] = vmWrapper
+        .getDisks()
+        .filter((disk) => !Object.keys(disk).includes('serial'));
+
+      // Get all current non-source volumes
+      const currentOtherVolumes: V1Volume[] = vmWrapper
+        .getVolumes()
+        .filter(
+          (vol) =>
+            !Object.keys(vol).includes(secretKind) &&
+            !Object.keys(vol).includes(configMapKind) &&
+            !Object.keys(vol).includes(serviceAccountKind),
+        );
+
+      // Evaluate a valid diskBus
+      const diskBus: string = getTemplateValidationsFromTemplate(template)
+        .getDefaultBus()
+        .getValue();
+
+      // construct new volumes and disks lists with the new sources
+      let newSourcesDisks: V1Disk[] = [];
+      let newSourcesVolumes: V1Volume[] = [];
+      envDisks.forEach((ed) => {
+        const sourceName = getSourceName(getEnvVarSource(ed));
+
+        if (sourceName) {
+          const sourceDiskName = getNewDiskName(sourceName);
+          const newDisk = setNewSourceDisk(sourceDiskName, getSerial(ed), diskBus);
+          const newVolume = setNewSourceVolume(getSourceKind(ed), sourceName, sourceDiskName);
+          newSourcesDisks = [...newSourcesDisks, newDisk];
+          newSourcesVolumes = [...newSourcesVolumes, newVolume];
+        }
+      });
+
+      newSourcesDisks = [...currentOtherDisks, ...newSourcesDisks];
+      newSourcesVolumes = [...currentOtherVolumes, ...newSourcesVolumes];
+
+      const patches: Patch[] = [
+        new PatchBuilder('/spec/template/spec/domain/devices/disks')
+          .replace(newSourcesDisks)
+          .build(),
+        new PatchBuilder('/spec/template/spec/volumes').replace(newSourcesVolumes).build(),
+      ];
+
+      const promise = k8sPatch(
+        getVMLikeModel(vm),
+        vm,
+        getVMLikePatches(vm, () => patches),
+      );
+
+      handlePromise(promise)
+        .then(() => {
+          setIsSuccess(true);
+          setEnvDisks(envDisks.filter((ed) => getSerial(ed)));
+        })
+        .catch((err) => {
+          setIsSuccess(false);
+          setErrMsg(err);
+        });
+    };
+
+    const usedConfigMaps: EnvDisk[] = envDisks.filter(
+      (ed) => getEnvDiskRefKind(ed) === configMapRef,
+    );
+    const usedSecrets: EnvDisk[] = envDisks.filter((ed) => getEnvDiskRefKind(ed) === secretRef);
+    const usedServiceAccounts: EnvDisk[] = envDisks.filter(
+      (ed) => getEnvDiskRefKind(ed) === serviceAccountRef,
+    );
+
+    const availableConfigMaps = configMaps
+      ? toListObj(configMapList, getAvailableSources(configMaps, usedConfigMaps))
+      : toListObj(configMapList, []);
+
+    const availableSecrets = secrets
+      ? toListObj(secretList, getAvailableSources(secrets, usedSecrets))
+      : toListObj(secretList, []);
+
+    const availableServiceAccounts = serviceAccounts
+      ? toListObj(serviceAccountList, getAvailableSources(serviceAccounts, usedServiceAccounts))
+      : toListObj(serviceAccountList, []);
+
+    const addButtonDisabled =
+      envDisks.length >= configMaps?.length + secrets?.length + serviceAccounts?.length;
+
+    return (
+      <>
+        <div className="co-m-pane__body-group">
+          <h3 className="co-section-heading-tertiary">
+            Include all values from existing config maps, secrets or service accounts (as Disk)
+            <FieldLevelHelp>
+              Add new values by referencing an existing config map, secret or service account. Using
+              these values requires mounting them manually to the VM.
+            </FieldLevelHelp>
+          </h3>
+          <EnvFromEditorComponent
+            nameValueId={0}
+            nameValuePairs={envDisks}
+            updateParentData={updateEnvDisks}
+            readOnly={false}
+            configMaps={availableConfigMaps}
+            secrets={availableSecrets}
+            serviceAccounts={availableServiceAccounts}
+            firstTitle="configmap / secret / service account"
+            secondTitle="Serial Number"
+            addButtonDisabled={addButtonDisabled || inProgress}
+          />
+        </div>
+        <div className="environment-buttons">
+          <VMEnvironmentFooter
+            save={onSubmit}
+            reload={onReload}
+            errorMsg={errMsg}
+            isSuccess={isSuccess}
+          />
+        </div>
+      </>
+    );
+  },
+);
+
+type VMEnvironmentProps = HandlePromiseProps & {
+  vm: VMKind;
+  secretsResource?: FirehoseResult<SecretKind[]>;
+  configmapsResource?: FirehoseResult<ConfigMapKind[]>;
+  serviceAccountsResource?: FirehoseResult<ServiceAccountKind[]>;
+  templateResource?: FirehoseResult<TemplateKind>;
+};

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-environment/vm-environment.scss
@@ -1,0 +1,4 @@
+.environment-buttons {
+    border-top: 1px solid #ddd;
+    padding-top: var(--pf-global--spacer--lg);
+  }

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -33,6 +33,7 @@ export const VM_DETAIL_DETAILS_HREF = 'details';
 export const VM_DETAIL_DISKS_HREF = 'disks';
 export const VM_DETAIL_NETWORKS_HREF = 'nics';
 export const VM_DETAIL_CONSOLES_HREF = 'consoles';
+export const VM_DETAIL_ENVIRONMENT = 'environment';
 
 export const CLOUDINIT_DISK = 'cloudinitdisk';
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm/vm-wrapper.ts
@@ -63,6 +63,18 @@ export class VMWrapper extends K8sResourceWrapper<VMKind, VMWrapper> implements 
 
   getTolerations = () => getTolerations(this.data);
 
+  getConfigMaps = () => this.getVolumes().filter((vol) => Object.keys(vol).includes('configMap'));
+
+  getSecrets = () => this.getVolumes().filter((vol) => Object.keys(vol).includes('secret'));
+
+  getServiceAccounts = () =>
+    this.getVolumes().filter((vol) => Object.keys(vol).includes('serviceAccount'));
+
+  getDiskSerial = (diskName) => {
+    const disk = this.getDisks().find((d) => d.name === diskName);
+    return disk && Object.keys(disk).includes('serial') && disk.serial;
+  };
+
   isDedicatedCPUPlacement = () => isDedicatedCPUPlacement(this.data);
 
   addTemplateLabel = (key: string, value: string) => {

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/devices.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/devices.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { BootableDeviceType, V1NetworkInterface } from '../../types';
 import { DiskWrapper } from '../../k8s/wrapper/vm/disk-wrapper';
 import { DeviceType } from '../../constants';
-import { getDisks, getInterfaces } from './selectors';
+import { getBootableDisks, getInterfaces } from './selectors';
 import { asVM } from './vmlike';
 import { VMLikeEntityKind } from '../../types/vmLike';
 import { V1Disk } from '../../types/vm/disk/V1Disk';
@@ -33,7 +33,7 @@ export const transformDevices = (
 
 export const getDevices = (vmLikeEntity: VMLikeEntityKind): BootableDeviceType[] => {
   const vm = asVM(vmLikeEntity);
-  return transformDevices(getDisks(vm), getInterfaces(vm));
+  return transformDevices(getBootableDisks(vm), getInterfaces(vm));
 };
 
 export const getBootableDevices = (vm: VMLikeEntityKind): BootableDeviceType[] => {

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -39,6 +39,9 @@ export const getDisks = (vm: VMKind, defaultValue: V1Disk[] = []): V1Disk[] =>
   _.get(vm, 'spec.template.spec.domain.devices.disks') == null
     ? defaultValue
     : vm.spec.template.spec.domain.devices.disks;
+
+export const getBootableDisks = (vm: VMKind, defaultValue: V1Disk[] = []): V1Disk[] =>
+  getDisks(vm, defaultValue).filter((disk) => !Object.keys(disk).includes('serial'));
 export const getInterfaces = (
   vm: VMKind,
   defaultValue: V1NetworkInterface[] = [],

--- a/frontend/public/components/environment.jsx
+++ b/frontend/public/components/environment.jsx
@@ -497,6 +497,7 @@ export const EnvironmentPage = connect(stateToProps)(
       }
 
       const envVar = currentEnvVars.getEnvVarByTypeAndIndex(containerType, containerIndex);
+
       const containerDropdown = currentEnvVars.isContainerArray ? (
         <ContainerDropdown
           currentKey={rawEnvData[containerType][containerIndex].name}

--- a/frontend/public/components/utils/name-value-editor.jsx
+++ b/frontend/public/components/utils/name-value-editor.jsx
@@ -253,7 +253,17 @@ export const EnvFromEditor = withDragDropContext(
     }
 
     render() {
-      const { nameValuePairs, readOnly, nameValueId, configMaps, secrets } = this.props;
+      const {
+        nameValuePairs,
+        readOnly,
+        nameValueId,
+        configMaps,
+        secrets,
+        serviceAccounts,
+        firstTitle,
+        secondTitle,
+        addButtonDisabled,
+      } = this.props;
       const pairElems = nameValuePairs.map((pair, i) => {
         const key = _.get(pair, [EnvFromPair.Index], i);
 
@@ -271,6 +281,7 @@ export const EnvFromEditor = withDragDropContext(
             rowSourceId={nameValueId}
             configMaps={configMaps}
             secrets={secrets}
+            serviceAccounts={serviceAccounts}
           />
         );
       });
@@ -279,8 +290,8 @@ export const EnvFromEditor = withDragDropContext(
         <>
           <div className="row pairs-list__heading">
             {!readOnly && <div className="col-xs-1 co-empty__header" />}
-            <div className="col-xs-5 text-secondary text-uppercase">Config Map/Secret</div>
-            <div className="col-xs-5 text-secondary text-uppercase">Prefix (Optional)</div>
+            <div className="col-xs-5 text-secondary text-uppercase">{firstTitle}</div>
+            <div className="col-xs-5 text-secondary text-uppercase">{secondTitle}</div>
             <div className="col-xs-1 co-empty__header" />
           </div>
           {pairElems}
@@ -292,6 +303,7 @@ export const EnvFromEditor = withDragDropContext(
                   onClick={this._append}
                   type="button"
                   variant="link"
+                  isDisabled={addButtonDisabled}
                 >
                   <PlusCircleIcon /> Add All From Config Map or Secret
                 </Button>
@@ -318,10 +330,17 @@ EnvFromEditor.propTypes = {
   updateParentData: PropTypes.func.isRequired,
   configMaps: PropTypes.object,
   secrets: PropTypes.object,
+  serviceAccounts: PropTypes.object,
+  firstTitle: PropTypes.string,
+  secondTitle: PropTypes.string,
+  addButtonDisabled: PropTypes.bool,
 };
 EnvFromEditor.defaultProps = {
   readOnly: false,
   nameValueId: 0,
+  firstTitle: 'Config map/secret',
+  secondTitle: 'Prefix (Optional)',
+  addButtonDisabled: false,
 };
 
 const pairSource = {
@@ -595,6 +614,7 @@ const EnvFromPairElement = DragSource(
           pair,
           configMaps,
           secrets,
+          serviceAccounts,
         } = this.props;
         const deleteButton = (
           <>
@@ -630,6 +650,7 @@ const EnvFromPairElement = DragSource(
                   pair={pair[EnvFromPair.Resource]}
                   configMaps={configMaps}
                   secrets={secrets}
+                  serviceAccounts={serviceAccounts}
                   onChange={this._onChangeResource}
                   disabled={readOnly}
                 />

--- a/frontend/public/module/k8s/index.ts
+++ b/frontend/public/module/k8s/index.ts
@@ -177,7 +177,7 @@ export type ResourceList = {
   [resourceName: string]: string;
 };
 
-type EnvVarSource = {
+export type EnvVarSource = {
   fieldRef?: {
     apiVersion?: string;
     fieldPath: string;
@@ -193,6 +193,22 @@ type EnvVarSource = {
   };
   secretKeyRef?: {
     key: string;
+    name: string;
+  };
+  configMapRef?: {
+    key?: string;
+    name: string;
+  };
+  secretRef?: {
+    key?: string;
+    name: string;
+  };
+  configMapSecretRef?: {
+    key?: string;
+    name: string;
+  };
+  serviceAccountRef?: {
+    key?: string;
     name: string;
   };
 };
@@ -908,6 +924,21 @@ export type GroupVersionKind = string;
  * Maintains backwards-compatibility with references using the `kind` string field.
  */
 export type K8sResourceKindReference = GroupVersionKind | string;
+
+export type SecretKind = {
+  data: { [key: string]: string };
+  stringData: { [key: string]: string };
+  type: string;
+} & K8sResourceCommon;
+
+export type ServiceAccountKind = {
+  automountServiceAccountToken?: boolean;
+  secrets: SecretKind[];
+} & K8sResourceCommon;
+
+export type ListKind<R extends K8sResourceCommon> = K8sResourceCommon & {
+  items: R[];
+};
 
 export type EventKind = {
   action?: string;


### PR DESCRIPTION
- Add an Environment tab for virtual machines
- The user can now add configmaps, secrets and service accounts
  to VMs as disks but has to mount them manually.
  (not all images support CloudInit)

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>