### PR TITLE
Improve discoverability of edit application grouping

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -3,6 +3,7 @@ import * as classNames from 'classnames';
 import { action } from 'mobx';
 import { connect } from 'react-redux';
 import { Button, ToolbarItem, Tooltip } from '@patternfly/react-core';
+import { TopologyIcon } from '@patternfly/react-icons';
 import {
   TopologyView,
   TopologyControlBar,
@@ -20,9 +21,14 @@ import {
   SelectionEventListener,
 } from '@console/topology';
 import { RootState } from '@console/internal/redux';
-import { TopologyIcon } from '@patternfly/react-icons';
 import TopologySideBar from './TopologySideBar';
-import { GraphData, TopologyDataModel, TopologyDataObject } from './topology-types';
+import {
+  GraphData,
+  TopologyDataModel,
+  TopologyDataObject,
+  SHOW_GROUPING_HINT_EVENT,
+  ShowGroupingHintEventListener,
+} from './topology-types';
 import TopologyResourcePanel from './TopologyResourcePanel';
 import TopologyApplicationPanel from './application-panel/TopologyApplicationPanel';
 import ConnectedTopologyEdgePanel from './TopologyEdgePanel';
@@ -61,6 +67,7 @@ const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters, acti
   const [graphData, setGraphData] = React.useState<GraphData>();
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
   const createResourceAccess: string[] = useAddToProjectAccess(activeNamespace);
+  const [dragHint, setDragHint] = React.useState<string>('');
 
   if (!componentFactoryRef.current) {
     componentFactoryRef.current = new ComponentFactory(serviceBinding);
@@ -78,6 +85,12 @@ const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters, acti
         setSelectedIds(ids);
       }
     });
+    visRef.current.addEventListener<ShowGroupingHintEventListener>(
+      SHOW_GROUPING_HINT_EVENT,
+      (element, hint) => {
+        setDragHint(hint);
+      },
+    );
     visRef.current.fromModel(graphModel);
   }
 
@@ -256,6 +269,7 @@ const Topology: React.FC<TopologyProps> = ({ data, serviceBinding, filters, acti
       sideBarOpen={!!sideBar}
     >
       <VisualizationSurface visualization={visRef.current} state={{ selectedIds }} />
+      {dragHint && <div className="odc-topology__hint-container">{dragHint}</div>}
     </TopologyView>
   );
 };

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
@@ -7,6 +7,18 @@
   top: 0;
   bottom: 0;
 
+  &__hint-container {
+    align-items: center;
+    background: var(--pf-global--Color--light-100);
+    border: 1px solid var(--pf-global--BorderColor--light-100);
+    border-radius: 8px;
+    display: flex;
+    padding: var(--pf-global--spacer--xs) var(--pf-global--spacer--sm);
+    pointer-events: none;
+    position: absolute;
+    top: var(--pf-global--spacer--sm);
+  }
+
   &__layout-group {
     display: flex;
     flex-wrap: wrap;

--- a/frontend/packages/dev-console/src/components/topology/components/RegroupHint.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/RegroupHint.scss
@@ -1,0 +1,14 @@
+.odc-regroup-hint {
+  align-items: center;
+  display: flex;
+
+  &__icon {
+    color: var(--pf-global--info-color--100);
+  }
+  &__text {
+    margin-left: var(--pf-global--spacer--sm);
+    .ocs-shortcut__cell {
+      padding-bottom: 0;
+    }
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology/components/RegroupHint.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/RegroupHint.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { ShortcutTable, Shortcut } from '@console/shared';
+
+import './RegroupHint.scss';
+
+const RegroupHint: React.FC = () => (
+  <div className="odc-regroup-hint">
+    <InfoCircleIcon className="odc-regroup-hint__icon" />
+    <span className="odc-regroup-hint__text">
+      <ShortcutTable>
+        <Shortcut shift drag>
+          Edit application grouping
+        </Shortcut>
+      </ShortcutTable>
+    </span>
+  </div>
+);
+
+export { RegroupHint };

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/Application.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/Application.tsx
@@ -6,10 +6,12 @@ import {
   WithSelectionProps,
   WithContextMenuProps,
 } from '@console/topology';
+import { SHOW_GROUPING_HINT_EVENT } from '../../topology-types';
 import ApplicationNode from './ApplicationNode';
 import ApplicationGroup from './ApplicationGroup';
 
 import './Application.scss';
+import { RegroupHint } from '../RegroupHint';
 
 type ApplicationProps = {
   element: Node;
@@ -33,6 +35,18 @@ const Application: React.FC<ApplicationProps> = ({
   contextMenuOpen,
   dragging,
 }) => {
+  const needsHintRef = React.useRef<boolean>(false);
+
+  React.useEffect(() => {
+    const needsHint = dropTarget && !canDrop;
+    if (needsHint !== needsHintRef.current) {
+      needsHintRef.current = needsHint;
+      element
+        .getController()
+        .fireEvent(SHOW_GROUPING_HINT_EVENT, element, needsHint ? <RegroupHint /> : null);
+    }
+  }, [dropTarget, canDrop, element]);
+
   if (element.isCollapsed()) {
     return (
       <ApplicationNode

--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -3,6 +3,7 @@ import { FirehoseResult, KebabOption } from '@console/internal/components/utils'
 import { ExtPodKind, OverviewItem, PodControllerOverviewItem } from '@console/shared';
 import { DeploymentKind, K8sResourceKind, PodKind, EventKind } from '@console/internal/module/k8s';
 import { Pipeline, PipelineRun } from '../../utils/pipeline-augment';
+import { Node as TopologyNode, EventListener } from '@console/topology/src/types';
 
 export type Point = [number, number];
 
@@ -247,3 +248,6 @@ export type GraphData = {
   namespace: string;
   createResourceAccess: string[];
 };
+
+export const SHOW_GROUPING_HINT_EVENT = 'show-regroup-hint';
+export type ShowGroupingHintEventListener = EventListener<[TopologyNode, string]>;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3395

**Analysis / Root cause**: 
During usability testing at UNC,

Users struggled to figure out how to edit application groupings.

- When changing application grouping, users attempted to drag and drop without knowing they needed to hold down the Shift key.

Poor discoverability for “View shortcut”

- Users did not notice and use the”View shortcut” link. The poor discoverability of “View shortcut” made it difficult for users to arrange application grouping and create service binding.

**Solution Description**: 
When dragging nodes, if the node is over an application grouping and the user is not holding the shift key, show a hint informing the user to hold the shift key in order to change the node's grouping.

**Screen shots / Gifs for design review**: 
![regroup-hint](https://user-images.githubusercontent.com/11633780/77315886-ba28d880-6cde-11ea-98f4-ef519e592486.gif)

**Unit test coverage report**: 
![image](https://user-images.githubusercontent.com/11633780/77315951-e0e70f00-6cde-11ea-90a7-619629b4df23.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux 

/kind bug