### PR TITLE
CONSOLE-2124:  Add badges to operator attributes

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/mocks.ts
+++ b/frontend/packages/operator-lifecycle-manager/mocks.ts
@@ -737,6 +737,8 @@ export const operatorHubTileViewPageProps = {
       categories: ['messaging', 'streaming'],
       catalogSource: 'testing',
       catalogSourceNamespace: 'openshift-marketplace',
+      validSubscription: undefined,
+      infraFeatures: undefined,
     },
     {
       obj: etcdPackageManifest,
@@ -762,6 +764,8 @@ export const operatorHubTileViewPageProps = {
       categories: ['database'],
       catalogSource: 'testing',
       catalogSourceNamespace: 'openshift-marketplace',
+      validSubscription: undefined,
+      infraFeatures: undefined,
     },
     {
       obj: federationv2PackageManifest,
@@ -787,6 +791,8 @@ export const operatorHubTileViewPageProps = {
       categories: [],
       catalogSource: 'testing',
       catalogSourceNamespace: 'openshift-marketplace',
+      validSubscription: undefined,
+      infraFeatures: undefined,
     },
     {
       obj: prometheusPackageManifest,
@@ -811,6 +817,8 @@ export const operatorHubTileViewPageProps = {
       categories: ['monitoring', 'alerting'],
       catalogSource: 'testing',
       catalogSourceNamespace: 'openshift-marketplace',
+      validSubscription: undefined,
+      infraFeatures: undefined,
     },
     {
       obj: svcatPackageManifest,
@@ -836,6 +844,8 @@ export const operatorHubTileViewPageProps = {
       categories: ['catalog'],
       catalogSource: 'testing',
       catalogSourceNamespace: 'openshift-marketplace',
+      validSubscription: undefined,
+      infraFeatures: undefined,
     },
   ] as OperatorHubItem[],
   openOverlay: null,
@@ -869,6 +879,8 @@ export const operatorHubTileViewPagePropsWithDummy = {
       categories: ['dummy'],
       catalogSource: 'testing',
       catalogSourceNamespace: 'openshift-marketplace',
+      validSubscription: undefined,
+      infraFeatures: undefined,
     },
   ],
   openOverlay: null,
@@ -984,4 +996,6 @@ export const itemWithLongDescription = {
   categories: ['messaging', 'streaming'],
   catalogSource: 'testing',
   catalogSourceNamespace: 'openshift-marketplace',
+  validSubscription: undefined,
+  infraFeatures: undefined,
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -21,6 +21,12 @@ export enum CapabilityLevel {
   DeepInsights = 'Deep Insights',
 }
 
+export enum InfraFeatures {
+  Disconnected = 'Disconnected',
+  Proxy = 'Proxy',
+  FipsMode = 'FIPS Mode',
+}
+
 export type OperatorHubItem = {
   obj: PackageManifestKind;
   name: string;
@@ -38,6 +44,8 @@ export type OperatorHubItem = {
   catalogSource: string;
   catalogSourceNamespace: string;
   [key: string]: any;
+  validSubscription: string[];
+  infraFeatures: InfraFeatures[];
 };
 
 export type OperatorHubCSVAnnotations = {
@@ -53,6 +61,9 @@ export type OperatorHubCSVAnnotations = {
   'marketplace.openshift.io/action-text'?: string;
   'marketplace.openshift.io/remote-workflow'?: string;
   'marketplace.openshift.io/support-workflow'?: string;
+  tags?: string[];
+  'operators.openshift.io/infrastructure-features'?: string;
+  'operators.openshift.io/valid-subscription'?: string;
 };
 
 type OperatorHubSpec = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-item-details.tsx
@@ -69,6 +69,8 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
     support,
     capabilityLevel,
     marketplaceSupportWorkflow,
+    infraFeatures,
+    validSubscription,
   } = item;
   const notAvailable = <span className="properties-side-panel-pf-property-label">N/A</span>;
 
@@ -123,6 +125,12 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
     return null;
   };
 
+  const mappedData = (data) =>
+    Array.isArray(data) ? data.map((d) => <div key={d}>{d}</div>) : notAvailable;
+
+  const mappedInfraFeatures = mappedData(infraFeatures);
+  const mappedValidSubscription = mappedData(validSubscription);
+
   return (
     <div className="modal-body modal-body-border">
       <div className="modal-body-content">
@@ -142,6 +150,12 @@ export const OperatorHubItemDetails: React.SFC<OperatorHubItemDetailsProps> = ({
               />
               <PropertyItem label="Provider Type" value={providerType || notAvailable} />
               <PropertyItem label="Provider" value={provider || notAvailable} />
+              {infraFeatures && (
+                <PropertyItem label="Infrastructure Features" value={mappedInfraFeatures} />
+              )}
+              {validSubscription && (
+                <PropertyItem label="Valid Subscriptions" value={mappedValidSubscription} />
+              )}
               <PropertyItem label="Repository" value={repository || notAvailable} />
               <PropertyItem label="Container Image" value={containerImage || notAvailable} />
               <PropertyItem label="Created At" value={createdAt || notAvailable} />

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-page.tsx
@@ -66,6 +66,8 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
           'marketplace.openshift.io/action-text': marketplaceActionText,
           'marketplace.openshift.io/remote-workflow': marketplaceRemoteWorkflow,
           'marketplace.openshift.io/support-workflow': marketplaceSupportWorkflow,
+          'operators.openshift.io/infrastructure-features': infrastructure,
+          'operators.openshift.io/valid-subscription': validSubscription,
         } = currentCSVAnnotations;
 
         return {
@@ -107,6 +109,8 @@ export const OperatorHubList: React.SFC<OperatorHubListProps> = (props) => {
           marketplaceActionText,
           marketplaceRemoteWorkflow,
           marketplaceSupportWorkflow,
+          validSubscription: validSubscription ? JSON.parse(validSubscription) : undefined,
+          infraFeatures: infrastructure ? JSON.parse(infrastructure) : undefined,
         };
       },
     );

--- a/frontend/public/components/utils/tile-view-page.jsx
+++ b/frontend/public/components/utils/tile-view-page.jsx
@@ -219,6 +219,9 @@ const filterByGroup = (items, filters) => {
         );
 
         filtered[key] = _.filter(items, (item) => {
+          if (Array.isArray(item[key])) {
+            return item[key].some((f) => values.includes(f));
+          }
           return values.includes(item[key]);
         });
       }
@@ -413,6 +416,10 @@ const getFilterGroupCounts = (
       ];
 
       const matchedItems = _.filter(activeItems, (item) => {
+        if (Array.isArray(item[filterGroup])) {
+          return item[filterGroup].some((f) => filterValues.includes(f));
+        }
+
         return filterValues.includes(item[filterGroup]);
       });
 


### PR DESCRIPTION
/assign @TheRealJon
/cc @benjaminapetersen @spadgett 

I am unable to create custom operator for array 'infrastructure' property as a. property of annotations in Operator App Registry. On docker build , I got the below error: 

<img width="901" alt="Screen Shot 2020-03-23 at 11 28 26 AM" src="https://user-images.githubusercontent.com/15249132/77334582-637dc780-6cfb-11ea-9648-50671dbe74be.png">
<img width="889" alt="Screen Shot 2020-03-23 at 11 28 36 AM" src="https://user-images.githubusercontent.com/15249132/77334637-77292e00-6cfb-11ea-92c3-138126ec3657.png">

The YAML seems to be valid, also I tried to create same property as a property of spec and it works. 

UPDATE:  issue resolved (@benjaminapetersen )