### PR TITLE
Add uninstall helm release action to list, detail and topology pages

### DIFF
--- a/frontend/packages/dev-console/src/actions/modify-helm-release.ts
+++ b/frontend/packages/dev-console/src/actions/modify-helm-release.ts
@@ -1,0 +1,19 @@
+import { coFetchJSON } from '@console/internal/co-fetch';
+import { deleteResourceModal } from '../components/modals';
+
+export const deleteHelmRelease = (releaseName: string, namespace: string, redirect?: string) => {
+  return {
+    label: 'Delete Helm Release',
+    callback: () => {
+      deleteResourceModal({
+        blocking: true,
+        resourceName: releaseName,
+        resourceType: 'Helm Release',
+        redirect,
+        onSubmit: () => {
+          return coFetchJSON.delete(`/api/helm/release?name=${releaseName}&ns=${namespace}`);
+        },
+      });
+    },
+  };
+};

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseDetailsPage.tsx
@@ -13,6 +13,7 @@ import { DetailsPage } from '@console/internal/components/factory';
 import { K8sResourceKindReference } from '@console/internal/module/k8s';
 import HelmReleaseResources from './HelmReleaseResources';
 import HelmReleaseOverview from './HelmReleaseOverview';
+import { deleteHelmRelease } from '../../actions/modify-helm-release';
 
 const SecretReference: K8sResourceKindReference = 'Secret';
 const HelmReleaseReference = 'HelmRelease';
@@ -37,36 +38,42 @@ const HelmReleaseDetailsPage: React.FC<HelmReleaseDetailsPageProps> = ({ secret,
 
   const secretResource = secret.data;
 
-  if (!_.isEmpty(secretResource)) {
-    return (
-      <DetailsPage
-        match={match}
-        kindObj={SecretModel}
-        name={secretResource[0]?.metadata.name}
-        namespace={namespace}
-        breadcrumbsFor={() => [
-          {
-            name: `Helm Releases`,
-            path: `/helm-releases/ns/${namespace}`,
-          },
-          { name: `Helm Release Details`, path: `${match.url}` },
-        ]}
-        title={secretResource[0]?.metadata.labels?.name}
-        kind={SecretReference}
-        pages={[
-          navFactory.details(HelmReleaseOverview),
-          {
-            href: 'resources',
-            name: 'Resources',
-            component: HelmReleaseResources,
-          },
-        ]}
-        customKind={HelmReleaseReference}
-      />
-    );
-  }
+  if (_.isEmpty(secretResource)) return <ErrorPage404 />;
 
-  return <ErrorPage404 />;
+  const secretName = secretResource[0]?.metadata.name;
+  const releaseName = secretResource[0]?.metadata.labels?.name;
+
+  const menuActions = [
+    () => deleteHelmRelease(releaseName, namespace, `/helm-releases/ns/${namespace}`),
+  ];
+
+  return (
+    <DetailsPage
+      kindObj={SecretModel}
+      match={match}
+      menuActions={menuActions}
+      name={secretName}
+      namespace={namespace}
+      breadcrumbsFor={() => [
+        {
+          name: `Helm Releases`,
+          path: `/helm-releases/ns/${namespace}`,
+        },
+        { name: `Helm Release Details`, path: `${match.url}` },
+      ]}
+      title={releaseName}
+      kind={SecretReference}
+      pages={[
+        navFactory.details(HelmReleaseOverview),
+        {
+          href: 'resources',
+          name: 'Resources',
+          component: HelmReleaseResources,
+        },
+      ]}
+      customKind={HelmReleaseReference}
+    />
+  );
 };
 
 export default HelmReleaseDetailsPage;

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseHeader.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseHeader.tsx
@@ -1,4 +1,5 @@
 import { sortable } from '@patternfly/react-table';
+import { Kebab } from '@console/internal/components/utils';
 
 export const tableColumnClasses = {
   name: 'col-lg-2 col-md-3 col-sm-4 col-xs-4',
@@ -7,6 +8,7 @@ export const tableColumnClasses = {
   status: 'col-lg-2 col-md-2 hidden-sm hidden-xs',
   chartName: 'col-lg-2 hidden-md hidden-sm hidden-xs',
   appVersion: 'col-lg-2 hidden-md hidden-sm hidden-xs',
+  kebab: Kebab.columnClass,
 };
 
 const HelmReleaseHeader = () => {
@@ -46,6 +48,10 @@ const HelmReleaseHeader = () => {
       sortField: 'chart.metadata.appVersion',
       transforms: [sortable],
       props: { className: tableColumnClasses.appVersion },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses.kebab },
     },
   ];
 };

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseRow.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { Status } from '@console/shared';
 import { TableRow, TableData } from '@console/internal/components/factory';
-import { Timestamp } from '@console/internal/components/utils';
+import { Timestamp, Kebab } from '@console/internal/components/utils';
 import { Link } from 'react-router-dom';
 import { HelmRelease } from './helm-types';
 import { tableColumnClasses } from './HelmReleaseHeader';
+import { deleteHelmRelease } from '../../actions/modify-helm-release';
 
 interface HelmReleaseRowProps {
   obj: HelmRelease;
@@ -15,6 +16,7 @@ interface HelmReleaseRowProps {
 }
 
 const HelmReleaseRow: React.FC<HelmReleaseRowProps> = ({ obj, index, key, style }) => {
+  const menuActions = [deleteHelmRelease(obj.name, obj.namespace)];
   return (
     <TableRow id={obj.name} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses.name}>
@@ -36,6 +38,9 @@ const HelmReleaseRow: React.FC<HelmReleaseRowProps> = ({ obj, index, key, style 
       <TableData className={tableColumnClasses.chartName}>{obj.chart.metadata.name}</TableData>
       <TableData className={tableColumnClasses.appVersion}>
         {obj.chart.metadata.appVersion}
+      </TableData>
+      <TableData className={tableColumnClasses.kebab}>
+        <Kebab options={menuActions} />
       </TableData>
     </TableRow>
   );

--- a/frontend/packages/dev-console/src/components/modals/DeleteResourceModal.tsx
+++ b/frontend/packages/dev-console/src/components/modals/DeleteResourceModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TextInputTypes } from '@patternfly/react-core';
-import { PromiseComponent } from '@console/internal/components/utils';
+import { PromiseComponent, history } from '@console/internal/components/utils';
 import {
   createModalLauncher,
   ModalTitle,
@@ -14,6 +14,7 @@ import { K8sResourceKind } from '@console/internal/module/k8s';
 type DeleteResourceModalProps = {
   resourceName: string;
   resourceType: string;
+  redirect?: string;
   onSubmit: (values: FormikValues) => Promise<K8sResourceKind[]>;
   cancel?: () => void;
   close?: () => void;
@@ -68,17 +69,17 @@ class DeleteResourceModal extends PromiseComponent<
 > {
   private handleSubmit = (values, actions) => {
     actions.setSubmitting(true);
-    const { onSubmit, close } = this.props;
+    const { onSubmit, close, redirect } = this.props;
     onSubmit &&
       this.handlePromise(onSubmit(values))
         .then(() => {
           actions.setSubmitting(false);
           close();
+          redirect && history.push(redirect);
         })
         .catch((errorMessage) => {
           actions.setSubmitting(false);
           actions.setStatus({ submitError: errorMessage });
-          close();
         });
   };
 

--- a/frontend/packages/dev-console/src/components/modals/DeleteResourceModal.tsx
+++ b/frontend/packages/dev-console/src/components/modals/DeleteResourceModal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { TextInputTypes } from '@patternfly/react-core';
 import { PromiseComponent } from '@console/internal/components/utils';
 import {
@@ -12,31 +11,33 @@ import { Formik, FormikProps, FormikValues } from 'formik';
 import { YellowExclamationTriangleIcon, InputField } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 
-type DeleteApplicationModalProps = {
-  initialApplication: string;
+type DeleteResourceModalProps = {
+  resourceName: string;
+  resourceType: string;
   onSubmit: (values: FormikValues) => Promise<K8sResourceKind[]>;
   cancel?: () => void;
   close?: () => void;
 };
 
-type DeleteApplicationModalState = {
+type DeleteResourceModalState = {
   inProgress: boolean;
   errorMessage: string;
 };
 
-const DeleteApplicationForm: React.FC<FormikProps<FormikValues> & DeleteApplicationModalProps> = ({
+const DeleteResourceForm: React.FC<FormikProps<FormikValues> & DeleteResourceModalProps> = ({
   handleSubmit,
+  resourceName,
+  resourceType,
   isSubmitting,
   cancel,
   values,
-  initialApplication,
   status,
 }) => {
-  const isValid = _.get(values, 'application.userInput') === initialApplication;
+  const isValid = values.resourceName === resourceName;
   return (
     <form onSubmit={handleSubmit} className="modal-content modal-content--no-inner-scroll">
       <ModalTitle>
-        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Delete Application?
+        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Delete {resourceType}?
       </ModalTitle>
       <ModalBody>
         <p>
@@ -44,10 +45,10 @@ const DeleteApplicationForm: React.FC<FormikProps<FormikValues> & DeleteApplicat
           Storage/PVC&#39;s, secrets, and configmaps will be deleted.
         </p>
         <p>
-          Confirm deletion by typing <strong className="co-break-word">{initialApplication}</strong>{' '}
+          Confirm deletion by typing <strong className="co-break-word">{resourceName}</strong>{' '}
           below:
         </p>
-        <InputField type={TextInputTypes.text} name="application.userInput" />
+        <InputField type={TextInputTypes.text} name="resourceName" />
       </ModalBody>
       <ModalSubmitFooter
         submitText="Delete"
@@ -61,9 +62,9 @@ const DeleteApplicationForm: React.FC<FormikProps<FormikValues> & DeleteApplicat
   );
 };
 
-class DeleteApplicationModal extends PromiseComponent<
-  DeleteApplicationModalProps,
-  DeleteApplicationModalState
+class DeleteResourceModal extends PromiseComponent<
+  DeleteResourceModalProps,
+  DeleteResourceModalState
 > {
   private handleSubmit = (values, actions) => {
     actions.setSubmitting(true);
@@ -82,23 +83,17 @@ class DeleteApplicationModal extends PromiseComponent<
   };
 
   render() {
-    const { initialApplication } = this.props;
     const initialValues = {
-      application: {
-        name: initialApplication,
-        userInput: '',
-      },
+      resourceName: '',
     };
     return (
-      <Formik
-        initialValues={initialValues}
-        onSubmit={this.handleSubmit}
-        render={(formProps) => <DeleteApplicationForm {...formProps} {...this.props} />}
-      />
+      <Formik initialValues={initialValues} onSubmit={this.handleSubmit}>
+        {(formProps) => <DeleteResourceForm {...formProps} {...this.props} />}
+      </Formik>
     );
   }
 }
 
-export const deleteApplicationModal = createModalLauncher((props: DeleteApplicationModalProps) => (
-  <DeleteApplicationModal {...props} />
+export const deleteResourceModal = createModalLauncher((props: DeleteResourceModalProps) => (
+  <DeleteResourceModal {...props} />
 ));

--- a/frontend/packages/dev-console/src/components/modals/index.ts
+++ b/frontend/packages/dev-console/src/components/modals/index.ts
@@ -8,7 +8,7 @@ export const groupEditApplicationModal = (props) =>
     m.groupEditApplicationModal(props),
   );
 
-export const deleteApplicationModal = (props) =>
-  import('./DeleteApplicationModal' /* webpackChunkName: "dev-console-modals" */).then((m) =>
-    m.deleteApplicationModal(props),
+export const deleteResourceModal = (props) =>
+  import('./DeleteResourceModal' /* webpackChunkName: "dev-console-modals" */).then((m) =>
+    m.deleteResourceModal(props),
   );

--- a/frontend/packages/dev-console/src/components/topology/actions/groupActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/groupActions.ts
@@ -6,7 +6,7 @@ import { asAccessReview } from '@console/internal/components/utils';
 import { addResourceMenuWithoutCatalog } from '../../../actions/add-resources';
 import { TopologyDataMap, TopologyApplicationObject, GraphData } from '../topology-types';
 import { getTopologyResourceObject } from '../topology-utils';
-import { deleteApplicationModal } from '../../modals';
+import { deleteResourceModal } from '../../modals';
 import { cleanUpWorkload } from '../../../utils/application-utils';
 
 export const getGroupComponents = (
@@ -36,9 +36,10 @@ const deleteGroup = (application: TopologyApplicationObject) => {
     label: 'Delete Application',
     callback: () => {
       const reqs = [];
-      deleteApplicationModal({
+      deleteResourceModal({
         blocking: true,
-        initialApplication: application.name,
+        resourceName: application.name,
+        resourceType: 'Application',
         onSubmit: () => {
           application.resources.forEach((workload) => {
             const resource = _.get(workload, ['resources', 'obj']);

--- a/frontend/packages/dev-console/src/components/topology/actions/helmReleaseActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/helmReleaseActions.ts
@@ -1,0 +1,10 @@
+import { KebabOption } from '@console/internal/components/utils/kebab';
+import { Node } from '@console/topology';
+import { regroupActions } from './regroupActions';
+import { deleteHelmRelease } from '../../../actions/modify-helm-release';
+
+export const helmReleaseActions = (helmRelease: Node): KebabOption[] => {
+  const name = helmRelease.getLabel();
+  const { namespace } = helmRelease.getData().groupResources[0].resources.obj.metadata;
+  return [deleteHelmRelease(name, namespace), ...regroupActions(helmRelease)];
+};

--- a/frontend/packages/dev-console/src/components/topology/componentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/componentFactory.ts
@@ -24,8 +24,8 @@ import {
   groupContextMenu,
   nodeContextMenu,
   graphContextMenu,
-  regroupContextMenu,
   regroupGroupContextMenu,
+  helmReleaseContextMenu,
 } from './nodeContextMenu';
 import {
   graphWorkloadDropTargetSpec,
@@ -107,7 +107,7 @@ class ComponentFactory {
           return withSelection(
             false,
             true,
-          )(withContextMenu(regroupContextMenu)(withNoDrop()(HelmRelease)));
+          )(withContextMenu(helmReleaseContextMenu)(withNoDrop()(HelmRelease)));
         case TYPE_HELM_WORKLOAD:
           return this.withAddResourceConnector()(
             withDndDrop<

--- a/frontend/packages/dev-console/src/components/topology/helm-details/TopologyHelmReleasePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm-details/TopologyHelmReleasePanel.tsx
@@ -6,11 +6,13 @@ import {
   ResourceIcon,
   SimpleTabNav,
   StatusBox,
+  ActionsMenu,
 } from '@console/internal/components/utils';
 import * as UIActions from '@console/internal/actions/ui';
 import { Node } from '@console/topology';
 import HelmReleaseOverview from '../../helm/HelmReleaseOverview';
 import TopologyHelmReleaseResourcesPanel from './TopologyHelmReleaseResourcesPanel';
+import { helmReleaseActions } from '../actions/helmReleaseActions';
 
 type PropsFromState = {
   selectedDetailsTab?: any;
@@ -73,6 +75,9 @@ const TopologyHelmReleasePanel = connect<
             >
               {name}
             </Link>
+          </div>
+          <div className="co-actions">
+            <ActionsMenu actions={helmReleaseActions(helmRelease)} />
           </div>
         </h1>
       </div>

--- a/frontend/packages/dev-console/src/components/topology/nodeContextMenu.tsx
+++ b/frontend/packages/dev-console/src/components/topology/nodeContextMenu.tsx
@@ -14,6 +14,7 @@ import { nodeActions } from './actions/nodeActions';
 import { graphActions } from './actions/graphActions';
 import { TopologyApplicationObject } from './topology-types';
 import { regroupActions } from './actions/regroupActions';
+import { helmReleaseActions } from './actions/helmReleaseActions';
 
 const onKebabOptionClick = (option: KebabOption) => {
   if (option.callback) {
@@ -64,3 +65,6 @@ export const regroupContextMenu = (element: Node) =>
 
 export const regroupGroupContextMenu = (element: Node) =>
   createMenuItems(kebabOptionsToMenu(regroupActions(element, true)));
+
+export const helmReleaseContextMenu = (element: Node) =>
+  createMenuItems(kebabOptionsToMenu(helmReleaseActions(element)));


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3059

**Analysis / Root cause**: There is no way for a user to delete/uninstall a Helm release from UI.

**Solution Description**: Add action menu items for deleting helm release in helm release list page, helm release details page, context menu for helm release in topology and release details panel in topology.


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Helm Delete](https://user-images.githubusercontent.com/6041994/77345624-ebdf8500-6d5a-11ea-9d2d-d37e73bcf022.gif)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
The UI depends on APIs being added by https://github.com/openshift/console/pull/4580. Need to build the backend on top of that PR in order to test the API.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

cc: @openshift/team-ux-review 
