### PR TITLE
Fix bug where `Active Deadline Seconds` does not display on pod details

### DIFF
--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -355,7 +355,7 @@ export const PodDetailsList: React.FC<PodDetailsListProps> = ({ pod }) => {
         {getRestartPolicyLabel(pod)}
       </DetailsItem>
       <DetailsItem label="Active Deadline Seconds" obj={pod} path="spec.activeDeadlineSeconds">
-        {pod.spec.progressDeadlineSeconds
+        {pod.spec.activeDeadlineSeconds
           ? pluralize(pod.spec.activeDeadlineSeconds, 'second')
           : 'Not Configured'}
       </DetailsItem>


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1816362

After:
<img width="432" alt="Screen Shot 2020-03-23 at 4 48 47 PM" src="https://user-images.githubusercontent.com/895728/77361720-31358f80-6d26-11ea-83b2-d3343db7bb6d.png">
