### PR TITLE
[WIP] Cleanup PipelineBuilder validation code

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/DropdownField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/DropdownField.tsx
@@ -32,8 +32,11 @@ const DropdownField: React.FC<DropdownFieldProps> = ({ label, helpText, required
         dropDownClassName={cx({ 'dropdown--full-width': props.fullWidth })}
         aria-describedby={`${fieldId}-helper`}
         onChange={(value: string) => {
-          props.onChange && props.onChange(value);
-          setFieldValue(props.name, value);
+          if (props.onChange) {
+            props.onChange(value);
+          } else {
+            setFieldValue(props.name, value);
+          }
           setFieldTouched(props.name, true);
         }}
       />

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStreamTagDropdown.tsx
@@ -130,9 +130,6 @@ const ImageStreamTagDropdown: React.FC = () => {
       disabled={!isImageStreamSelected || !isTagsAvailable}
       fullWidth
       required
-      onChange={(tag) => {
-        tag !== '' && searchImageTag(tag);
-      }}
     />
   );
 };

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
@@ -36,6 +36,8 @@ const PipelineBuilderPage: React.FC<PipelineBuilderPageProps> = (props) => {
     tasks: [],
     listTasks: [],
     ...(convertPipelineToBuilderForm(existingPipeline) || {}),
+    namespacedTasks: null,
+    clusterTasks: null,
   };
 
   const handleSubmit = (

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderVisualization.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderVisualization.tsx
@@ -7,8 +7,9 @@ import { getEdgesFromNodes } from '../pipeline-topology/utils';
 import { useNodes } from './hooks';
 import {
   PipelineBuilderTaskGroup,
+  ResourceTaskStatus,
   SelectTaskCallback,
-  TaskErrorMap,
+  TaskErrorList,
   UpdateTasksCallback,
 } from './types';
 
@@ -17,7 +18,8 @@ type PipelineBuilderVisualizationProps = {
   onTaskSelection: SelectTaskCallback;
   onUpdateTasks: UpdateTasksCallback;
   taskGroup: PipelineBuilderTaskGroup;
-  tasksInError: TaskErrorMap;
+  tasksInError: TaskErrorList;
+  resourceTasks: ResourceTaskStatus;
 };
 
 const PipelineBuilderVisualization: React.FC<PipelineBuilderVisualizationProps> = ({
@@ -26,19 +28,27 @@ const PipelineBuilderVisualization: React.FC<PipelineBuilderVisualizationProps> 
   onUpdateTasks,
   taskGroup,
   tasksInError,
+  resourceTasks,
 }) => {
-  const { tasksLoaded, tasksCount, nodes, loadingTasksError } = useNodes(
+  const nodes = useNodes(
     namespace,
     onTaskSelection,
     onUpdateTasks,
     taskGroup,
     tasksInError,
+    resourceTasks,
   );
 
-  if (loadingTasksError) {
+  const { clusterTasks, namespacedTasks, errorMsg } = resourceTasks;
+  const localTaskCount = namespacedTasks?.length || 0;
+  const clusterTaskCount = clusterTasks?.length || 0;
+  const tasksCount = localTaskCount + clusterTaskCount;
+  const tasksLoaded = !!namespacedTasks && !!clusterTasks;
+
+  if (errorMsg) {
     return (
       <Alert variant="danger" isInline title="Error loading the tasks.">
-        {loadingTasksError}
+        {errorMsg}
       </Alert>
     );
   }

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/__tests__/utils-data.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/__tests__/utils-data.ts
@@ -1,0 +1,152 @@
+import { TASK_ERROR_STRINGS, TaskErrorType } from '../const';
+import { PipelineBuilderFormikValues, ResourceTaskStatus } from '../types';
+import { PipelineTaskRef } from '../../../../utils/pipeline-augment';
+import { ClusterTaskModel } from '../../../../models';
+
+const MISSING_ALL_RESOURCES = {
+  resources: TASK_ERROR_STRINGS[TaskErrorType.MISSING_RESOURCES],
+};
+const MISSING_PARAMETER_STRING = { params: [{ value: 'Required' }] };
+const MISSING_PARAMETER_ARRAY_STRING = { params: [{ value: ['Required'] }] };
+
+export const TASK_ERRORS = {
+  NO_ERRORS: [],
+  RESOURCES_ALL_MISSING_ERROR: [MISSING_ALL_RESOURCES],
+  PARAMETERS_STRING_EMPTY: [MISSING_PARAMETER_STRING],
+  PARAMETERS_ARRAY_PARTIALLY_EMPTY: [MISSING_PARAMETER_ARRAY_STRING],
+  BOTH_PARAM_AND_RESOURCE_ERRORS: [{ ...MISSING_ALL_RESOURCES, ...MISSING_PARAMETER_STRING }],
+};
+
+export const RESOURCES_TASKS_LOADING: ResourceTaskStatus = {
+  clusterTasks: null,
+  namespacedTasks: null,
+};
+
+export const RESOURCE_TASKS_ERRORED: ResourceTaskStatus = {
+  clusterTasks: null,
+  namespacedTasks: null,
+  errorMsg: 'Failed to load namespace Tasks.',
+};
+
+export const PIPELINE_REF_REG_TASK: PipelineTaskRef = { name: 'test-task-cli' };
+export const PIPELINE_REF_CLUSTER_TASK: PipelineTaskRef = {
+  name: 'buildah',
+  kind: ClusterTaskModel.kind,
+};
+export const RESOURCE_TASKS: ResourceTaskStatus = {
+  clusterTasks: [
+    {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'ClusterTask',
+      metadata: {
+        name: PIPELINE_REF_CLUSTER_TASK.name,
+        ownerReferences: [
+          {
+            apiVersion: 'operator.tekton.dev/v1alpha1',
+            blockOwnerDeletion: true,
+            controller: true,
+            kind: 'Config',
+            name: 'cluster',
+            uid: '8f260bc9-6092-48b7-8f5e-ad7715a1e134',
+          },
+        ],
+      },
+      spec: {
+        params: [
+          {
+            default: 'quay.io/buildah/stable:v1.11.0',
+            description: 'The location of the buildah builder image.',
+            name: 'BUILDER_IMAGE',
+            type: 'string',
+          },
+          {
+            default: './Dockerfile',
+            description: 'Path to the Dockerfile to build.',
+            name: 'DOCKERFILE',
+            type: 'string',
+          },
+          {
+            default: 'true',
+            description:
+              'Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)',
+            name: 'TLSVERIFY',
+            type: 'string',
+          },
+        ],
+        resources: {
+          inputs: [
+            {
+              name: 'source',
+              type: 'git',
+            },
+          ],
+          outputs: [
+            {
+              name: 'image',
+              type: 'image',
+            },
+          ],
+        },
+        steps: [],
+      },
+    },
+  ],
+  namespacedTasks: [
+    {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'Task',
+      metadata: {
+        name: PIPELINE_REF_REG_TASK.name,
+      },
+      spec: {
+        params: [
+          {
+            default: ['help'],
+            description: 'The CLI Arguments to run',
+            name: 'ARGS',
+            type: 'array',
+          },
+          {
+            name: 'required-param',
+            description: 'A field that is required',
+            type: 'string',
+          },
+        ],
+        steps: [],
+      },
+    },
+  ],
+};
+
+export const BUILDER_FORM_DATA_EXAMPLE: PipelineBuilderFormikValues = {
+  name: 'test-pipeline',
+  tasks: [
+    {
+      name: 'task-1',
+      taskRef: { name: 'test-task-cli' },
+      runAfter: ['wont-make-it'],
+      params: [
+        { name: 'ARGS', value: ['rollout', 'latest', '$(params.image-name)'] },
+        { name: 'required-param', value: 'some-value' },
+      ],
+    },
+    {
+      name: 'task-2',
+      taskRef: { name: 'buildah', kind: ClusterTaskModel.kind },
+      runAfter: ['task-1'],
+      params: [{ name: 'TLSVERIFY', value: '' }],
+      resources: {
+        inputs: [{ name: 'source', resource: 'src' }],
+        outputs: [{ name: 'image', resource: 'img' }],
+      },
+    },
+  ],
+  params: [{ name: 'image-name' }],
+  resources: [
+    { name: 'src', type: 'git' },
+    { name: 'img', type: 'image' },
+  ],
+  listTasks: [{ name: 'wont-make-it' }],
+  clusterTasks: null,
+  namespacedTasks: null,
+};

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/__tests__/utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/__tests__/utils.spec.ts
@@ -1,5 +1,25 @@
-import { PipelineResourceTaskParam } from '../../../../utils/pipeline-augment';
-import { taskParamIsRequired } from '../utils';
+import { pipelineTestData, PipelineExampleNames } from '../../../../test/pipeline-data';
+import { ClusterTaskModel, PipelineModel } from '../../../../models';
+import { Pipeline, PipelineResourceTaskParam } from '../../../../utils/pipeline-augment';
+import { TASK_ERROR_STRINGS, TASK_INCOMPLETE_ERROR_MESSAGE, TaskErrorType } from '../const';
+import {
+  convertBuilderFormToPipeline,
+  convertPipelineToBuilderForm,
+  convertResourceToTask,
+  findTask,
+  getErrorMessage,
+  getPipelineURL,
+  taskParamIsRequired,
+} from '../utils';
+import {
+  BUILDER_FORM_DATA_EXAMPLE,
+  PIPELINE_REF_CLUSTER_TASK,
+  PIPELINE_REF_REG_TASK,
+  RESOURCE_TASKS,
+  RESOURCE_TASKS_ERRORED,
+  RESOURCES_TASKS_LOADING,
+  TASK_ERRORS,
+} from './utils-data';
 
 describe('taskParamIsRequired properly detects what is required', () => {
   const structure: PipelineResourceTaskParam = {
@@ -26,5 +46,205 @@ describe('taskParamIsRequired properly detects what is required', () => {
 
   it('expect an array default to always be not required', () => {
     expect(taskParamIsRequired({ ...structure, type: 'array', default: [] })).toBe(false);
+  });
+});
+
+describe('getErrorMessage returns condensed errors', () => {
+  it('expect no error for empty error list', () => {
+    expect(getErrorMessage(TASK_ERRORS.NO_ERRORS)(42)).toBe(null);
+  });
+
+  it('expect resource error to give when all resource data is missing', () => {
+    expect(getErrorMessage(TASK_ERRORS.RESOURCES_ALL_MISSING_ERROR)(0)).toBe(
+      TASK_ERROR_STRINGS[TaskErrorType.MISSING_RESOURCES],
+    );
+  });
+
+  it('expect param error to given when there is a missing required param', () => {
+    expect(getErrorMessage(TASK_ERRORS.PARAMETERS_STRING_EMPTY)(0)).toBe(
+      TASK_ERROR_STRINGS[TaskErrorType.MISSING_REQUIRED_PARAMS],
+    );
+  });
+
+  it('expect param error to given when there is an array with a missing param', () => {
+    expect(getErrorMessage(TASK_ERRORS.PARAMETERS_ARRAY_PARTIALLY_EMPTY)(0)).toBe(
+      TASK_ERROR_STRINGS[TaskErrorType.MISSING_REQUIRED_PARAMS],
+    );
+  });
+
+  it('expect resource error when given both a param and resource error', () => {
+    expect(getErrorMessage(TASK_ERRORS.BOTH_PARAM_AND_RESOURCE_ERRORS)(0)).toBe(
+      TASK_ERROR_STRINGS[TaskErrorType.MISSING_RESOURCES],
+    );
+  });
+
+  it('expect to gracefully handle a generic error if something was uncaught', () => {
+    expect(getErrorMessage([{ something: 'else' }] as any)(0)).toBe(TASK_INCOMPLETE_ERROR_MESSAGE);
+  });
+
+  it('expect to be able to report errors for other tasks', () => {
+    expect(getErrorMessage([undefined, ...TASK_ERRORS.PARAMETERS_STRING_EMPTY])(0)).toBe(null);
+  });
+});
+
+describe('findTask locates relevant tasks', () => {
+  it('expect to get a regular Task when no taskRef kind is provided', () => {
+    expect(findTask(RESOURCE_TASKS, PIPELINE_REF_REG_TASK)).toBe(RESOURCE_TASKS.namespacedTasks[0]);
+  });
+
+  it('expect to get a regular Task when giving a nonsensical kind value', () => {
+    expect(findTask(RESOURCE_TASKS, { ...PIPELINE_REF_REG_TASK, kind: 'not-a-kind' })).toBe(
+      RESOURCE_TASKS.namespacedTasks[0],
+    );
+  });
+
+  it('expect to get nothing back if there are no matches for the name', () => {
+    expect(findTask(RESOURCE_TASKS, { name: 'not-a-match' })).toBe(undefined);
+  });
+
+  it('expect to get nothing while the data is still loading', () => {
+    expect(findTask(RESOURCES_TASKS_LOADING, PIPELINE_REF_REG_TASK)).toBe(null);
+  });
+
+  it('expect to get nothing if the data is errored out', () => {
+    expect(findTask(RESOURCE_TASKS_ERRORED, PIPELINE_REF_REG_TASK)).toBe(null);
+  });
+
+  it('expect to get nothing if nothing is passed', () => {
+    expect(findTask(null, null)).toBe(null);
+  });
+
+  it('expect to get a ClusterTask back if providing a matching name with the ClusterTask kind', () => {
+    expect(findTask(RESOURCE_TASKS, PIPELINE_REF_CLUSTER_TASK)).toBe(
+      RESOURCE_TASKS.clusterTasks[0],
+    );
+  });
+});
+
+describe('convertResourceToTask maps successfully', () => {
+  const clusterTask = RESOURCE_TASKS.clusterTasks[0];
+  const namespacedTask = RESOURCE_TASKS.namespacedTasks[0];
+
+  it('expect to get the resource name as the Task name', () => {
+    const pipelineTask = convertResourceToTask(clusterTask);
+    expect(pipelineTask.name).toEqual(clusterTask.metadata.name);
+  });
+
+  it('expect to get the proper taskRef back to the resource', () => {
+    const pipelineTask = convertResourceToTask(clusterTask);
+    expect(pipelineTask.taskRef).toEqual({
+      kind: ClusterTaskModel.kind,
+      name: clusterTask.metadata.name,
+    });
+  });
+
+  it('expect to get parameters back pre-filled with the resource default', () => {
+    const pipelineTask = convertResourceToTask(clusterTask);
+    expect(pipelineTask.params).toEqual([
+      {
+        name: 'BUILDER_IMAGE',
+        value: 'quay.io/buildah/stable:v1.11.0',
+      },
+      {
+        name: 'DOCKERFILE',
+        value: './Dockerfile',
+      },
+      {
+        name: 'TLSVERIFY',
+        value: 'true',
+      },
+    ]);
+  });
+
+  it('expect to get an empty param value when there is no resource default', () => {
+    const pipelineTask = convertResourceToTask(namespacedTask);
+    expect(pipelineTask.params[1]).toEqual({
+      name: 'required-param',
+      value: undefined,
+    });
+  });
+});
+
+describe('getPipelineURL returns a link to the root of Pipelines', () => {
+  it('expect to get the path to Pipelines', () => {
+    expect(getPipelineURL('test-ns')).toBe('/k8s/ns/test-ns/tekton.dev~v1alpha1~Pipeline');
+  });
+});
+
+describe('convertBuilderFormToPipeline returns a valid Pipeline', () => {
+  describe('form properly converts to Pipeline', () => {
+    const pipeline = convertBuilderFormToPipeline(BUILDER_FORM_DATA_EXAMPLE, 'test-ns');
+
+    it('expect top-level properties to be there', () => {
+      expect(pipeline.apiVersion).toBeDefined();
+      expect(pipeline.kind).toBe(PipelineModel.kind);
+      expect(pipeline.metadata).toBeDefined();
+      expect(pipeline.spec).toBeDefined();
+      expect(Object.keys(pipeline)).toHaveLength(4);
+    });
+
+    it('expect metadata to be properly populated', () => {
+      expect(pipeline.metadata.name).toBe(BUILDER_FORM_DATA_EXAMPLE.name);
+      expect(pipeline.metadata.namespace).toBe('test-ns');
+    });
+
+    it('expect spec to be properly populated', () => {
+      expect(pipeline.spec.tasks).toHaveLength(BUILDER_FORM_DATA_EXAMPLE.tasks.length);
+      // We trim empty params as they have a default
+      expect(pipeline.spec.tasks[1].params).toHaveLength(0);
+      // We remove list tasks from the run afters
+      expect(pipeline.spec.tasks[0].runAfter).toHaveLength(0);
+    });
+  });
+
+  describe('form properly converts to Pipeline with existing Pipeline', () => {
+    const existingPipeline: Pipeline = {
+      ...pipelineTestData[PipelineExampleNames.CLUSTER_PIPELINE].pipeline,
+      latestRun: null, // just to show it will stay around
+    };
+    const newPipeline = convertBuilderFormToPipeline(
+      BUILDER_FORM_DATA_EXAMPLE,
+      'test-ns',
+      existingPipeline,
+    );
+
+    it('expect top-level properties to be there', () => {
+      expect(newPipeline.apiVersion).toBeDefined();
+      expect(newPipeline.kind).toBe(PipelineModel.kind);
+      expect(newPipeline.metadata).toBeDefined();
+      expect(newPipeline.spec).toBeDefined();
+      // Kept our top-level property
+      expect(newPipeline.latestRun).toBe(null);
+    });
+
+    it('expect metadata to be properly populated', () => {
+      expect(newPipeline.metadata.name).toBe(BUILDER_FORM_DATA_EXAMPLE.name);
+      expect(newPipeline.metadata.namespace).toBe('test-ns');
+      // Pre-existing label that should be carried over
+      // TODO: When we upgrade to the latest Jest (25+), this should be .toHaveProperty(['...'])
+      expect(newPipeline.metadata.labels['pipeline.openshift.io/runtime']).toBeDefined();
+    });
+
+    it('expect spec to be properly populated', () => {
+      // Does not use tasks from the existingPipeline
+      expect(newPipeline.spec.tasks).toHaveLength(BUILDER_FORM_DATA_EXAMPLE.tasks.length);
+    });
+  });
+});
+
+describe('convertPipelineToBuilderForm properly populates the commonality between Pipeline & form', () => {
+  it('expect the form to be populated with relevant Pipeline items', () => {
+    const existingPipeline = pipelineTestData[PipelineExampleNames.CLUSTER_PIPELINE].pipeline;
+    const formValues = convertPipelineToBuilderForm(existingPipeline);
+    expect(formValues.name).toBe(existingPipeline.metadata.name);
+    expect(formValues.params).toEqual([]);
+    expect(formValues.resources).toEqual([]);
+    expect(formValues.tasks).toEqual(existingPipeline.spec.tasks);
+    expect(formValues.listTasks).toEqual([]);
+  });
+
+  it('expect the form to not return if no Pipeline is provided', () => {
+    expect(convertPipelineToBuilderForm(undefined)).toBe(null);
+    expect(convertPipelineToBuilderForm(null)).toBe(null);
   });
 });

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/const.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/const.ts
@@ -20,8 +20,3 @@ export const TASK_ERROR_STRINGS = {
   [TaskErrorType.MISSING_REQUIRED_PARAMS]: 'Missing Parameters',
   [TaskErrorType.MISSING_NAME]: 'Task Name is Required',
 };
-
-export const nodeTaskErrors = [
-  TaskErrorType.MISSING_REQUIRED_PARAMS,
-  TaskErrorType.MISSING_RESOURCES,
-];

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarName.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarName.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
+import { useField } from 'formik';
 import { FormGroup, TextInput, TextInputTypes } from '@patternfly/react-core';
-import { SidebarInputWrapper } from './temp-utils';
+import { SidebarInputWrapper } from './field-utils';
 
 type TaskSidebarNameProps = {
-  initialName: string;
+  name: string;
+  placeholder: string;
   onChange: (newName: string) => void;
-  taskName: string;
 };
 
+// TODO: Fix the visualization dependency on name for the id and we can fully use Formik
 const VALID_NAME = /^([a-z]([-a-z0-9]*[a-z0-9])?)*$/;
 const INVALID_ERROR_MESSAGE =
   'Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.';
@@ -23,8 +25,9 @@ const getError = (value: string): string | null => {
 };
 
 const TaskSidebarName: React.FC<TaskSidebarNameProps> = (props) => {
-  const { initialName, onChange, taskName } = props;
-  const [interimName, setInterimName] = React.useState(initialName);
+  const { name, placeholder, onChange } = props;
+  const [field] = useField(name);
+  const [interimName, setInterimName] = React.useState<string>(field.value);
   const [error, setError] = React.useState(null);
   const isValid = !error;
 
@@ -50,7 +53,7 @@ const TaskSidebarName: React.FC<TaskSidebarNameProps> = (props) => {
               onChange(interimName);
             }
           }}
-          placeholder={taskName}
+          placeholder={placeholder}
           type={TextInputTypes.text}
           value={interimName}
         />

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.tsx
@@ -1,51 +1,41 @@
 import * as React from 'react';
-import { FormGroup } from '@patternfly/react-core';
-import { PipelineResourceTaskParam, PipelineTaskParam } from '../../../../utils/pipeline-augment';
-import { taskParamIsRequired } from '../utils';
-import { ArrayParam, ParameterProps, SidebarInputWrapper, StringParam } from './temp-utils';
+import { useField } from 'formik';
+import { TextInputTypes } from '@patternfly/react-core';
+import { InputField } from '@console/shared';
+import { PipelineResourceTaskParam } from '../../../../utils/pipeline-augment';
+import { SidebarInputWrapper } from './field-utils';
+import TaskSidebarParamArray from './TaskSidebarParamArray';
 
 type TaskSidebarParamProps = {
-  hasParamError?: boolean;
+  name: string;
   resourceParam: PipelineResourceTaskParam;
-  taskParam?: PipelineTaskParam;
-  onChange: (newValue: string) => void;
 };
 
 const TaskSidebarParam: React.FC<TaskSidebarParamProps> = (props) => {
-  const { hasParamError, onChange, resourceParam, taskParam } = props;
-  const [dirty, setDirty] = React.useState(false);
+  const { name: paramName, resourceParam } = props;
+  const name = `${paramName}.value`;
+  const [{ value }, { error, touched }] = useField<string | string[]>(name);
+  const isRequired = !resourceParam.default;
 
-  const currentValue = taskParam?.value;
-  const emptyIsInvalid = taskParamIsRequired(resourceParam);
-
-  const isValid = !(dirty && hasParamError && emptyIsInvalid && currentValue != null);
-
-  const paramRenderProps: ParameterProps = {
-    currentValue,
-    defaultValue: resourceParam.default,
-    isValid,
-    name: resourceParam.name,
-    onChange,
-    setDirty,
-  };
-
-  return (
-    <FormGroup
-      fieldId={resourceParam.name}
-      label={resourceParam.name}
-      helperText={resourceParam.type === 'string' ? resourceParam.description : null}
-      helperTextInvalid="Required"
-      validated={isValid ? 'default' : 'error'}
-      isRequired={emptyIsInvalid}
-    >
-      {resourceParam.type === 'array' ? (
-        <ArrayParam {...paramRenderProps} description={resourceParam.description} />
-      ) : (
-        <SidebarInputWrapper>
-          <StringParam {...paramRenderProps} />
-        </SidebarInputWrapper>
-      )}
-    </FormGroup>
+  return resourceParam.type === 'array' ? (
+    <TaskSidebarParamArray
+      isRequired={isRequired}
+      isValid={touched && !error}
+      name={name}
+      resourceParam={resourceParam}
+      values={value as string[]}
+    />
+  ) : (
+    <SidebarInputWrapper>
+      <InputField
+        label={resourceParam.name}
+        helpText={resourceParam.description}
+        type={TextInputTypes.text}
+        name={name}
+        placeholder={resourceParam.default as string}
+        required={isRequired}
+      />
+    </SidebarInputWrapper>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParamArray.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParamArray.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { FieldArray } from 'formik';
+import {
+  Flex,
+  FlexItem,
+  FormGroup,
+  TextInputTypes,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import { MinusCircleIcon } from '@patternfly/react-icons';
+import { global_disabled_color_200 as disabledColor } from '@patternfly/react-tokens';
+import { InputField } from '@console/shared';
+import MultiColumnFieldFooter from '@console/shared/src/components/formik-fields/multi-column-field/MultiColumnFieldFooter';
+import { PipelineResourceTaskParam } from '../../../../utils/pipeline-augment';
+
+type TaskSidebarParamArrayProps = {
+  isRequired: boolean;
+  isValid: boolean;
+  name: string;
+  resourceParam: PipelineResourceTaskParam;
+  values: string[];
+};
+
+/**
+ * @deprecated
+ * TODO: Replace with frontend/packages/console-shared/src/components/formik-fields/TextColumnField.tsx
+ * Once https://github.com/openshift/console/pull/4931 is merged
+ */
+const TaskSidebarParamArray: React.FC<TaskSidebarParamArrayProps> = (props) => {
+  const { isRequired, isValid, name, resourceParam, values } = props;
+
+  if (!values) {
+    return null;
+  }
+
+  return (
+    <FieldArray
+      name={name}
+      render={(arrayHelpers) => {
+        return (
+          <>
+            <FormGroup
+              fieldId={resourceParam.name}
+              label={resourceParam.name}
+              validated={isValid ? ValidatedOptions.success : ValidatedOptions.error}
+              isRequired={isRequired}
+            >
+              {values.map((v, idx) => {
+                return (
+                  <Flex
+                    key={`${idx.toString()}`}
+                    style={{ marginBottom: 'var(--pf-global--spacer--xs)' }}
+                  >
+                    <FlexItem grow={{ default: 'grow' }}>
+                      <InputField type={TextInputTypes.text} name={`${name}.${idx}`} />
+                    </FlexItem>
+                    <FlexItem>
+                      <MinusCircleIcon
+                        aria-hidden="true"
+                        style={{ color: values.length === 1 ? disabledColor.value : null }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          arrayHelpers.remove(idx);
+                        }}
+                      />
+                    </FlexItem>
+                  </Flex>
+                );
+              })}
+            </FormGroup>
+            <p
+              className="pf-c-form__helper-text"
+              style={{ marginBottom: 'var(--pf-global--spacer--sm)' }}
+            >
+              {resourceParam.description}
+            </p>
+            <MultiColumnFieldFooter
+              addLabel="Add another value"
+              onAdd={() => {
+                arrayHelpers.push('');
+              }}
+            />
+          </>
+        );
+      }}
+    />
+  );
+};
+
+export default TaskSidebarParamArray;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarResource.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarResource.tsx
@@ -1,54 +1,46 @@
 import * as React from 'react';
-import { FormGroup } from '@patternfly/react-core';
-import { Dropdown } from '@console/internal/components/utils';
-import {
-  PipelineResource,
-  PipelineResourceTaskResource,
-  PipelineTaskResource,
-} from '../../../../utils/pipeline-augment';
-import { SidebarInputWrapper } from './temp-utils';
+import { useFormikContext, FormikValues } from 'formik';
+import { DropdownField } from '@console/shared';
+import { PipelineResource, PipelineResourceTaskResource } from '../../../../utils/pipeline-augment';
+import { SidebarInputWrapper } from './field-utils';
 
 type TaskSidebarResourceProps = {
   availableResources: PipelineResource[];
-  onChange: (resourceName: string, resource: PipelineResource) => void;
+  name: string;
   resource: PipelineResourceTaskResource;
-  taskResource?: PipelineTaskResource;
 };
 
 const TaskSidebarResource: React.FC<TaskSidebarResourceProps> = (props) => {
-  const { availableResources, onChange, resource, taskResource } = props;
+  const { availableResources, name, resource } = props;
+  const { setFieldValue } = useFormikContext<FormikValues>();
 
   const dropdownResources = availableResources.filter(
-    ({ name, type }) => resource.type === type && !!name,
+    ({ name: resourceName, type }) => resource.type === type && !!resourceName,
   );
 
   return (
-    <FormGroup
-      fieldId={resource.name}
-      label={resource.name}
-      helperText={`Only showing resources for this type (${resource.type}).`}
-      helperTextInvalid={
-        dropdownResources.length === 0 ? `No resources available. Add pipeline resources.` : ''
-      }
-      validated={dropdownResources.length > 0 ? 'default' : 'error'}
-      isRequired
-    >
-      <SidebarInputWrapper>
-        <Dropdown
-          title={`Select ${resource.type} resource...`}
-          items={dropdownResources.reduce((acc, { name }) => ({ ...acc, [name]: name }), {})}
-          disabled={dropdownResources.length === 0}
-          selectedKey={taskResource?.resource || ''}
-          dropDownClassName="dropdown--full-width"
-          onChange={(value: string) => {
-            onChange(
-              resource.name,
-              dropdownResources.find(({ name }) => name === value),
-            );
-          }}
-        />
-      </SidebarInputWrapper>
-    </FormGroup>
+    <SidebarInputWrapper>
+      <DropdownField
+        label={resource.name}
+        fullWidth
+        disabled={dropdownResources.length === 0}
+        title={`Select ${resource.type} resource...`}
+        items={dropdownResources.reduce(
+          (acc, { name: resourceName }) => ({ ...acc, [resourceName]: resourceName }),
+          {},
+        )}
+        required
+        name={`${name}.resource`}
+        helpText={
+          dropdownResources.length === 0
+            ? 'No resources available. Add pipeline resources.'
+            : `Only showing ${resource.type} resources.`
+        }
+        onChange={(resourceName: string) => {
+          setFieldValue(name, { name: resource.name, resource: resourceName });
+        }}
+      />
+    </SidebarInputWrapper>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/field-utils.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/field-utils.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export const SidebarInputWrapper: React.FC = ({ children }) => {
+  return <div style={{ width: 'calc(100% - 28px)' }}>{children}</div>;
+};

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/types.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/types.ts
@@ -1,33 +1,46 @@
-import { FormikValues } from 'formik';
+import { FormikErrors, FormikValues } from 'formik';
 import {
   PipelineParam,
   PipelineResource,
   PipelineResourceTask,
   PipelineTask,
+  PipelineTaskResources,
 } from '../../../utils/pipeline-augment';
 import { PipelineVisualizationTaskItem } from '../../../utils/pipeline-utils';
 import { AddNodeDirection } from '../pipeline-topology/const';
-import { TaskErrorType, UpdateOperationType } from './const';
+import { UpdateOperationType } from './const';
 
-export type UpdateErrors = (errors?: TaskErrorMap) => void;
+export type ResourceTaskStatus = {
+  namespacedTasks: PipelineResourceTask[] | null;
+  clusterTasks: PipelineResourceTask[] | null;
+  errorMsg?: string;
+};
 
 export type PipelineBuilderTaskBase = { name: string; runAfter?: string[] };
 
 export type PipelineBuilderListTask = PipelineBuilderTaskBase;
 
+/** Generic Builder visualization data */
 export type PipelineBuilderTaskGrouping = {
   tasks: PipelineTask[];
   listTasks: PipelineBuilderListTask[];
 };
 
-export type PipelineBuilderTaskGroup = PipelineBuilderTaskGrouping & {
-  highlightedIds: string[];
-};
-
-export type PipelineBuilderFormValues = PipelineBuilderTaskGrouping & {
+/** Values derived from an existing Pipeline */
+export type PipelineBuilderFormExistingPipelineValues = PipelineBuilderTaskGrouping & {
   name: string;
   params: PipelineParam[];
   resources: PipelineResource[];
+};
+
+/** Values for the Form as a state */
+export type PipelineBuilderFormValues = PipelineBuilderFormExistingPipelineValues & {
+  namespacedTasks: PipelineResourceTask[];
+  clusterTasks: PipelineResourceTask[];
+};
+
+export type PipelineBuilderTaskGroup = PipelineBuilderTaskGrouping & {
+  highlightedIds: string[];
 };
 
 export type PipelineBuilderFormikValues = FormikValues & PipelineBuilderFormValues;
@@ -37,9 +50,11 @@ export type SelectedBuilderTask = {
   taskIndex: number;
 };
 
-export type TaskErrorMap = {
-  [pipelineInErrorName: string]: TaskErrorType[];
+type ErrorPipelineTask = FormikErrors<PipelineTask> & {
+  // Resources can be in error in their entirety (there are no default values when tasks are created)
+  resources?: string | FormikErrors<PipelineTaskResources>;
 };
+export type TaskErrorList = ErrorPipelineTask[];
 
 export type SelectTaskCallback = (
   task: PipelineVisualizationTaskItem,
@@ -80,30 +95,15 @@ export type UpdateOperationRemoveTaskData = UpdateOperationBaseData & {
 };
 
 export type ResourceTarget = 'inputs' | 'outputs';
-export type UpdateTaskResourceData = {
-  resourceTarget: ResourceTarget;
-  selectedPipelineResource: PipelineResource;
-  taskResourceName: string;
-};
-export type UpdateTaskParamData = {
-  newValue: string;
-  taskParamName: string;
-};
-export type UpdateOperationUpdateTaskData = UpdateOperationBaseData & {
-  // Task information
-  thisPipelineTask: PipelineTask;
-  taskResource: PipelineResourceTask;
 
-  // Change information
-  newName?: string;
-  params?: UpdateTaskParamData;
-  resources?: UpdateTaskResourceData;
+export type UpdateOperationUpdateTaskData = UpdateOperationBaseData & {
+  oldName: string;
+  newName: string;
 };
 
 export type CleanupResults = {
   tasks: PipelineTask[];
   listTasks: PipelineBuilderListTask[];
-  errors?: TaskErrorMap;
 };
 
 export type UpdateOperationAction<D extends UpdateOperationBaseData> = (

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/validation-utils.ts
@@ -1,51 +1,191 @@
 import * as yup from 'yup';
+import * as _ from 'lodash';
+import {
+  PipelineResourceTask,
+  PipelineResourceTaskResource,
+  PipelineTaskRef,
+  PipelineTaskResource,
+  PipelineTaskResources,
+} from '../../../utils/pipeline-augment';
+import { nameValidationSchema } from '../../import/validation-schema';
+import { TASK_ERROR_STRINGS, TaskErrorType } from './const';
+import { PipelineBuilderFormValues, ResourceTarget } from './types';
+import { findTask } from './utils';
+import { getTaskParameters, getTaskResources } from '../resource-utils';
 
-const taskResourceValidation = yup.array().of(
-  yup.object({
-    name: yup.string().required('Required'),
-    resource: yup.string().required('Required'),
-  }),
-);
+/**
+ * Get a k8s Pipeline Task from the top-level formik validation.
+ *
+ * @param formValues - The top-level formik form values
+ * @param path - The current path to where the validation was called from
+ * @param distance - How far from the root of the task is it? (defaults to 2 'hops' up)
+ */
+const getTask = (
+  formValues: PipelineBuilderFormValues,
+  path: string,
+  distance: number = 2,
+): PipelineResourceTask => {
+  const pathParts = path.split('.');
+  const taskPath = pathParts.slice(0, pathParts.length - distance);
+  const taskRef: PipelineTaskRef = _.get(formValues, `${taskPath.join('.')}.taskRef`);
+  return findTask(
+    {
+      namespacedTasks: formValues.namespacedTasks,
+      clusterTasks: formValues.clusterTasks,
+    },
+    taskRef,
+  );
+};
 
-export const validationSchema = yup.object({
-  name: yup.string().required('Required'),
-  params: yup.array().of(
-    yup.object({
-      name: yup.string().required('Required'),
-      description: yup.string(),
-      default: yup.string(),
-    }),
-  ),
-  resources: yup.array().of(
-    yup.object({
-      name: yup.string().required('Required'),
-      type: yup.string().required('Required'),
-    }),
-  ),
-  tasks: yup
-    .array()
-    .of(
+const isParamNullable = (
+  formValues: PipelineBuilderFormValues,
+  path: string,
+  paramName: string,
+): boolean => {
+  const task = getTask(formValues, path);
+  const taskParam = getTaskParameters(task).find(({ name }) => name === paramName);
+  return !!taskParam?.default;
+};
+
+const getResourceTarget = (path: string): ResourceTarget | null => {
+  return path.match(/(inputs|outputs)/)?.[0] as ResourceTarget | null;
+};
+
+const isResourceTheCorrectType = (
+  formValues: PipelineBuilderFormValues,
+  path: string,
+  resourceValue: string,
+  resourceName: string,
+): boolean => {
+  const task = getTask(formValues, path, 3);
+  const target = getResourceTarget(path);
+  const resources = getTaskResources(task);
+  const resource = resources[target]?.find(({ name }) => name === resourceName);
+  const formResource = formValues.resources.find(({ name }) => name === resourceValue);
+
+  return resource?.type === formResource?.type;
+};
+
+const getRequiredResources = (
+  formValues: PipelineBuilderFormValues,
+  path: string,
+): PipelineResourceTaskResource[] => {
+  const task = getTask(formValues, path, 1);
+
+  const resources = getTaskResources(task);
+  const inputResources = resources.inputs || [];
+  const outputResources = resources.outputs || [];
+  return [...inputResources, ...outputResources];
+};
+
+const isResourceRequired = (
+  formValues: PipelineBuilderFormValues,
+  path: string,
+  resourceValue?: PipelineTaskResource[],
+): boolean => {
+  const resources = getRequiredResources(formValues, path);
+
+  return resources?.length === resourceValue?.length;
+};
+
+export const validationSchema = yup.mixed().test({
+  test(formValues: PipelineBuilderFormValues) {
+    const { resources } = formValues;
+
+    const resourceDefinition = yup.array().of(
       yup.object({
         name: yup.string().required('Required'),
-        runAfter: yup.array().of(yup.string()),
-        taskRef: yup
-          .object({
-            name: yup.string().required('Required'),
-            kind: yup.string(),
+        resource: yup
+          .string()
+          .test(
+            'is-resource-link-broken',
+            'Resource name has changed, reselect',
+            (resourceValue?: string) =>
+              !!resourceValue && !!resources.find(({ name }) => name === resourceValue),
+          )
+          .test('is-resource-type-valid', 'Resource type has changed, reselect', function(
+            resourceValue?: string,
+          ) {
+            return isResourceTheCorrectType(formValues, this.path, resourceValue, this.parent.name);
           })
           .required('Required'),
-        resources: yup.object({
-          inputs: taskResourceValidation,
-          outputs: taskResourceValidation,
-        }),
       }),
-    )
-    .min(1, 'Must define at least one task')
-    .required('Required'),
-  taskList: yup.array().of(
-    yup.object({
-      name: yup.string().required('Required'),
-      runAfter: yup.string(),
-    }),
-  ),
+    );
+
+    const formDefinition = yup.object({
+      name: nameValidationSchema.required('Required'),
+      params: yup.array().of(
+        yup.object({
+          name: yup.string().required('Required'),
+          description: yup.string(),
+          default: yup.string(),
+        }),
+      ),
+      resources: yup.array().of(
+        yup.object({
+          name: yup.string().required('Required'),
+          type: yup.string().required('Required'),
+        }),
+      ),
+      tasks: yup
+        .array()
+        .of(
+          yup.object({
+            name: yup.string().required('Required'),
+            runAfter: yup.array().of(yup.string()),
+            params: yup.array().of(
+              yup.object({
+                name: yup.string().required('Required'),
+                value: yup.lazy((value) => {
+                  if (Array.isArray(value)) {
+                    return yup.array().of(yup.string().required('Required'));
+                  }
+                  return yup
+                    .string()
+                    .test('is-param-optional', 'Required', function(paramValue?: string) {
+                      if (paramValue == null || paramValue?.trim() === '') {
+                        // Param is empty -- check to see if it's required by the Task
+                        return isParamNullable(formValues, this.path, this.parent.name);
+                      }
+
+                      return true;
+                    });
+                }),
+              }),
+            ),
+            taskRef: yup
+              .object({
+                name: yup.string().required('Required'),
+                kind: yup.string(),
+              })
+              .required('Required'),
+            resources: yup
+              .object({
+                inputs: resourceDefinition,
+                outputs: resourceDefinition,
+              })
+              .test(
+                'is-resources-required',
+                TASK_ERROR_STRINGS[TaskErrorType.MISSING_RESOURCES],
+                function(resourceValue?: PipelineTaskResources) {
+                  return isResourceRequired(formValues, this.path, [
+                    ...(resourceValue?.inputs || []),
+                    ...(resourceValue?.outputs || []),
+                  ]);
+                },
+              ),
+          }),
+        )
+        .min(1, 'Must define at least one task')
+        .required('Required'),
+      taskList: yup.array().of(
+        yup.object({
+          name: yup.string().required('Required'),
+          runAfter: yup.string(),
+        }),
+      ),
+    });
+
+    return formDefinition.validate(formValues, { abortEarly: false });
+  },
 });

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-topology/utils.ts
@@ -185,12 +185,12 @@ export const tasksToBuilderNodes = (
   taskList: PipelineVisualizationTaskItem[],
   onAddNode: (task: PipelineVisualizationTaskItem, direction: AddNodeDirection) => void,
   onNodeSelection: (task: PipelineVisualizationTaskItem) => void,
-  getError: (taskName: string) => string,
+  getError: (taskIdx: number) => string,
   selectedIds: string[],
 ): PipelineMixedNodeModel[] => {
-  return taskList.map((task) => {
+  return taskList.map((task, idx: number) => {
     return createBuilderNode(task.name, {
-      error: getError(task.name),
+      error: getError(idx),
       task,
       selected: selectedIds.includes(task.name),
       onNodeSelection: () => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3165

**Analysis / Root cause**: 
When the Pipeline Builder was put into 4.4 as a feature the week before Feature Freeze, corners were cut to get around some `yup` & Formik issues. This has caused a very brittle validation schema and served as non-stop issues.

**Solution Description**: 
Rewrite the validation schema to validate the entirety of the Pipeline Builder and remove all custom error code / handling.

**Screen shots / Gifs for design review**: 

@openshift/team-devconsole-ux 

Empty Name:
![Screen Shot 2020-03-24 at 9 00 30 AM](https://user-images.githubusercontent.com/8126518/77430289-502d3380-6db1-11ea-9240-708c667574c2.png)

Invalid Name:
![Screen Shot 2020-03-24 at 9 06 21 AM](https://user-images.githubusercontent.com/8126518/77430290-50c5ca00-6db1-11ea-95b4-adcf23c4a324.png)

Array Param with error & description (breaks from the norm?):
![image](https://user-images.githubusercontent.com/8126518/77434281-00516b00-6db7-11ea-95ff-782163e3e028.png)

Counter example of first field error:
![image](https://user-images.githubusercontent.com/8126518/77434333-12330e00-6db7-11ea-98fa-1fe08e66242d.png)

Successful Resource connections:
![Screen Shot 2020-03-24 at 9 17 42 AM](https://user-images.githubusercontent.com/8126518/77430291-50c5ca00-6db1-11ea-8a8a-3d47aebf27c5.png)

Rename a resource; breaks connection:
![Screen Shot 2020-03-24 at 10 49 46 AM](https://user-images.githubusercontent.com/8126518/77439348-4dd0d680-6dbd-11ea-919f-ae0143c80881.png)


Update to correct:
![Screen Shot 2020-03-24 at 9 18 13 AM](https://user-images.githubusercontent.com/8126518/77430295-515e6080-6db1-11ea-9753-5a0028dc1781.png)

Delete resource (breaks connection but no fix):
![Screen Shot 2020-03-24 at 10 50 03 AM](https://user-images.githubusercontent.com/8126518/77439316-45789b80-6dbd-11ea-9578-880b6b1e720b.png)

**Unit test coverage report**: 

- [ ] Tests coming

**Test setup:**

- Need Pipeline Operator
- Need to be on the Pipeline Builder (create Pipeline button on the Pipelines page)

This is my validation path, these should all pass (with the exception of one -- noted below).

1. Name
    1. Empty (error)
    2. Invalid characters (error)
2. Tasks (prompts a silent error for needing at least one)
    1. Visualization
        1. No initial errors; `openshift-client` (no error)
        2. Initial Resource errors; `s2i-nodejs` (error)
        3. Initial Param & Resource errors; `s2i-java-11` (error, resources over params)
    2. Details
        1. Array Param; ie `openshift-client`
            1. Add a new row (error); removing empty should clear the error
            2. Emptying the only field there (error)
        2. Param & Resource errors; `s2i-java-11`
            1. Initial (error, resources)
            2. Clear the Resource error by creating resources (error, params)
            3. Clear the param error by filling in the required fields (no error)
        3. Name
            1. Emptying (error)
            2. Invalid (error)
            3. Doesn’t update unless valid and on blur (to be fixed later)
        4. Resources connections
            1. Add `s2i-nodejs` (error)
            2. Create two resources; git & image (still in error)
            3. Update both in the details panel (no error)
            4. Change the name of one of the resources in the main form (error)
            5. Update in Details (no error)
            6. Delete resource from main form (error)
            7. No change possible (still in error)
            8. Add `openshift-client` task (for a positive passing task)
            9. Remove `s2i-nodejs` (error? — Formik has issues, still looking into it, any further update clears the error)
3. Parameters & Resources should error on blur of any required field (name for both & type for resources)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind cleanup
/cc @rohitkrai03 