### PR TITLE
[release-4.4] Bug 1816742: Fix workload detail notification drawer overlap without breaking full screen terminal

### DIFF
--- a/frontend/public/components/_notification-drawer.scss
+++ b/frontend/public/components/_notification-drawer.scss
@@ -1,3 +1,3 @@
 .co-notification-drawer {
-  z-index: 1;
+  z-index: 10;
 }


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1816742