### PR TITLE
 kubevirt integration-tests fixes from 4.4-release

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachine.ts
@@ -28,6 +28,7 @@ import { Wizard } from './wizard';
 import { appHost, testName } from '@console/internal-integration-tests/protractor.conf';
 import { KubevirtDetailView } from './kubevirtDetailView';
 import { ImportWizard } from './importWizard';
+import { VirtualMachineModel } from '../../../src/models/index';
 
 const noConfirmDialogActions: (VM_ACTION | VMI_ACTION)[] = [VM_ACTION.Start, VM_ACTION.Clone];
 
@@ -198,7 +199,7 @@ export class VirtualMachine extends KubevirtDetailView {
   }: VMConfig) {
     const wizard = new Wizard();
     await this.navigateToListView();
-    await wizard.openWizard();
+    await wizard.openWizard(VirtualMachineModel.labelPlural);
     if (template !== undefined) {
       await wizard.selectTemplate(template);
     } else {
@@ -265,7 +266,6 @@ export class VirtualMachine extends KubevirtDetailView {
     // Review page
     await wizard.confirmAndCreate();
     await wizard.waitForCreation();
-
     await this.navigateToTab(TAB.Details);
     if (startOnCreation === true) {
       // If startOnCreation is true, wait for VM to boot up

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachineTemplate.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/virtualMachineTemplate.ts
@@ -28,7 +28,7 @@ export class VirtualMachineTemplate extends KubevirtDetailView {
 
     // Basic Settings for VM template
     const wizard = new Wizard();
-    await wizard.openWizard();
+    await wizard.openWizard('Virtual Machine Templates');
 
     await wizard.selectProvisionSource(provisionSource);
     await wizard.selectOperatingSystem(operatingSystem);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/wizard.ts
@@ -15,12 +15,9 @@ import { DiskDialog } from '../dialogs/diskDialog';
 import { Flavor } from '../utils/constants/wizard';
 
 export class Wizard {
-  async openWizard() {
-    if (
-      !(await resourceTitle.isPresent()) ||
-      (await resourceTitle.getText()) !== 'Virtual Machines'
-    ) {
-      await clickNavLink(['Workloads', 'Virtual Machines']);
+  async openWizard(kind: string) {
+    if (!(await resourceTitle.isPresent()) || (await resourceTitle.getText()) !== kind) {
+      await clickNavLink(['Workloads', kind]);
       await isLoaded();
     }
     await click(createItemButton);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/consts.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/consts.ts
@@ -59,7 +59,7 @@ export const KUBEVIRT_STORAGE_CLASS_DEFAULTS = 'kubevirt-storage-class-defaults'
 export const KUBEVIRT_PROJECT_NAME = 'openshift-cnv';
 
 export const COMMON_TEMPLATES_VERSION = rhelTinyCommonTemplateName.match(/v\d+\.\d+\.\d+/)[0];
-export const INNER_TEMPLATE_VERSION = 'v0.8.2';
+export const INNER_TEMPLATE_VERSION = 'v0.9.1';
 
 export const COMMON_TEMPLATES_NAMESPACE = 'openshift';
 export const COMMON_TEMPLATES_REVISION = '1';

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/mocks.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/mocks.ts
@@ -66,6 +66,8 @@ export const basicVMConfig: BaseVMConfig = {
   sourceContainer: 'kubevirt/cirros-registry-disk-demo',
   cloudInitScript: `#cloud-config\nuser: cloud-user\npassword: atomic\nchpasswd: {expire: False}\nhostname: vm-${testName}`,
 };
+Object.freeze(basicVMConfig.flavorConfig);
+Object.freeze(basicVMConfig);
 
 export const defaultWizardPodNetworkingInterface = {
   name: 'nic0',
@@ -84,7 +86,7 @@ export const defaultYAMLPodNetworkingInterface = {
 };
 
 // Fake windows machine, still cirros in the heart
-export const widowsVMConfig: BaseVMConfig = {
+export const windowsVMConfig: BaseVMConfig = {
   operatingSystem: OperatingSystem.WINDOWS_10,
   flavorConfig: { flavor: Flavor.MEDIUM },
   workloadProfile: WorkloadProfile.DESKTOP,

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/templates/windowsVMForRDPL2.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/utils/templates/windowsVMForRDPL2.ts
@@ -59,7 +59,7 @@ spec:
           type: ''
         resources:
           requests:
-            memory: 1G
+            memory: 1Gi
       evictionStrategy: LiveMigrate
       hostname: fake-windows
       networks:

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.actions.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.actions.scenario.ts
@@ -13,6 +13,7 @@ import {
   removeLeakableResource,
   waitForCount,
   fillInput,
+  click,
 } from '@console/shared/src/test-utils/utils';
 import { getVMManifest } from './utils/mocks';
 import { pauseVM } from './utils/utils';
@@ -26,6 +27,7 @@ import {
   VM_STATUS,
 } from './utils/consts';
 import { VirtualMachine } from './models/virtualMachine';
+import { unpauseButton } from '../views/editStatusView';
 
 describe('Test VM actions', () => {
   const leakedResources = new Set<string>();
@@ -130,6 +132,15 @@ describe('Test VM actions', () => {
       },
       VM_ACTIONS_TIMEOUT_SECS,
     );
+
+    it('Unpauses VM via modal dialog', async () => {
+      await vm.waitForStatus(VM_STATUS.Running);
+      pauseVM(vmName, testName);
+      await vm.waitForStatus(VM_STATUS.Paused);
+      await vm.modalEditStatus();
+      await click(unpauseButton);
+      await vm.waitForStatus(VM_STATUS.Running);
+    });
 
     it('Stops VM', async () => {
       await vm.action(VM_ACTION.Stop);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.consoles.rdp.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.consoles.rdp.scenario.ts
@@ -10,6 +10,7 @@ import {
   selectDropdownOption,
   selectDropdownOptionById,
   createResource,
+  removeLeakedResources,
 } from '@console/shared/src/test-utils/utils';
 import {
   consoleTypeSelector,
@@ -32,7 +33,7 @@ import {
 import { VirtualMachine } from './models/virtualMachine';
 import { vmConfig, getProvisionConfigs } from './vm.wizard.configs';
 import { ProvisionConfigName } from './utils/constants/wizard';
-import { widowsVMConfig, multusNAD } from './utils/mocks';
+import { windowsVMConfig, multusNAD } from './utils/mocks';
 import { getWindowsVM } from './utils/templates/windowsVMForRDPL2';
 
 const VM_IP = '123.123.123.123';
@@ -58,6 +59,10 @@ describe('KubeVirt VM console - RDP', () => {
   provisionConfig.networkResources = [];
   provisionConfig.storageResources = [];
 
+  afterEach(() => {
+    removeLeakedResources(leakedResources);
+  });
+
   it(
     'connects via exposed service',
     async () => {
@@ -65,7 +70,7 @@ describe('KubeVirt VM console - RDP', () => {
         configName.toLowerCase(),
         testName,
         provisionConfig,
-        widowsVMConfig,
+        windowsVMConfig,
         true, // startOnCreation
       );
       const vm = new VirtualMachine(windowsConfig);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.dashboard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.dashboard.scenario.ts
@@ -13,6 +13,7 @@ import {
 } from '../views/dashboard.view';
 import { getVMManifest, hddDisk, multusNetworkInterface, multusNAD } from './utils/mocks';
 import { VirtualMachine } from './models/virtualMachine';
+import { waitForStringInElement } from '../../../console-shared/src/test-utils/utils';
 import {
   VM_STATUS,
   VM_BOOTUP_TIMEOUT_SECS,
@@ -83,7 +84,7 @@ describe('Test VM dashboard', () => {
     expect(vmStatus.getText()).toEqual(VM_STATUS.Running);
   });
 
-  it('BZ(1807865) Details card', async () => {
+  it('Details card', async () => {
     expect(vmDetailsName.getText()).toEqual(vm.name);
     expect(vmDetailsNamespace.getText()).toEqual(vm.namespace);
     expect(vmDetailsNode.getText()).not.toEqual(NOT_AVAILABLE);
@@ -92,7 +93,7 @@ describe('Test VM dashboard', () => {
     await vm.action(VM_ACTION.Stop, true, VM_STOP_TIMEOUT_SECS);
     await vm.navigateToTab(TAB.Overview);
 
-    expect(vmDetailsNode.getText()).toEqual(NOT_AVAILABLE);
-    expect(vmDetailsIPAddress.getText()).toEqual(NOT_AVAILABLE);
+    await browser.wait(waitForStringInElement(vmDetailsNode, NOT_AVAILABLE));
+    await browser.wait(waitForStringInElement(vmDetailsIPAddress, NOT_AVAILABLE));
   });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.overview.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.overview.scenario.ts
@@ -4,16 +4,9 @@ import { resourceTitle } from '@console/internal-integration-tests/views/crud.vi
 import { asyncForEach, createResource, deleteResource } from '@console/shared/src/test-utils/utils';
 import * as vmView from '../views/virtualMachine.view';
 import { getVMManifest, basicVMConfig } from './utils/mocks';
-import { exposeServices, pauseVM } from './utils/utils';
+import { exposeServices } from './utils/utils';
 import { VirtualMachine } from './models/virtualMachine';
-import {
-  TAB,
-  VM_BOOTUP_TIMEOUT_SECS,
-  VM_ACTION,
-  VM_STATUS,
-  COMMON_TEMPLATES_VERSION,
-  NOT_AVAILABLE,
-} from './utils/consts';
+import { TAB, VM_BOOTUP_TIMEOUT_SECS, VM_ACTION, VM_STATUS, NOT_AVAILABLE } from './utils/consts';
 import { NodePortService } from './utils/types';
 
 describe('Test VM overview', () => {
@@ -62,9 +55,9 @@ describe('Test VM overview', () => {
       description: testName,
       os: basicVMConfig.operatingSystem,
       profile: basicVMConfig.workloadProfile,
-      template: `rhel7-desktop-tiny-${COMMON_TEMPLATES_VERSION}`,
+      template: NOT_AVAILABLE,
       bootOrder: ['rootdisk (Disk)', 'nic0 (NIC)', 'cloudinitdisk (Disk)'],
-      flavor: 'Tiny: 1 vCPU, 1 GiB Memory',
+      flavorConfig: 'Tiny: 1 vCPU, 1 GiB Memory',
       ip: NOT_AVAILABLE,
       pod: NOT_AVAILABLE,
       node: NOT_AVAILABLE,
@@ -121,13 +114,5 @@ describe('Test VM overview', () => {
         `/k8s/ns/${testName}/services/${srv.exposeName}`,
       );
     });
-  });
-
-  it('Check unpause VM when VM is running', async () => {
-    await vm.action(VM_ACTION.Start);
-    pauseVM(vmName, testName);
-    expect(await vm.getStatus()).toEqual(VM_STATUS.Paused);
-    await vm.modalEditStatus();
-    expect(await vm.getStatus()).toEqual(VM_STATUS.Running);
   });
 });

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.resources.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.resources.scenario.ts
@@ -43,6 +43,7 @@ import {
 import { VirtualMachine } from './models/virtualMachine';
 import { Wizard } from './models/wizard';
 import { NetworkInterfaceDialog } from './dialogs/networkInterfaceDialog';
+import { VirtualMachineModel } from '../../src/models/index';
 
 describe('Add/remove disks and NICs on respective VM pages', () => {
   const testVm = getVMManifest('Container', testName, `vm-disk-nic-${testName}`);
@@ -143,7 +144,7 @@ describe('Test network type presets and options', () => {
   it('Test NIC type in VM Wizard', async () => {
     await browser.get(`${appHost}/k8s/ns/${testName}/virtualmachines`);
     await isLoaded();
-    await wizard.openWizard();
+    await wizard.openWizard(VirtualMachineModel.labelPlural);
 
     await wizard.fillName(getRandStr(5));
     await wizard.fillDescription(testName);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.windows-guest-tools.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.windows-guest-tools.scenario.ts
@@ -6,7 +6,7 @@ import { VirtualMachine } from './models/virtualMachine';
 import { VM_BOOTUP_TIMEOUT_SECS } from './utils/consts';
 import { getProvisionConfigs, vmConfig } from './vm.wizard.configs';
 import { ProvisionConfigName } from './utils/constants/wizard';
-import { widowsVMConfig } from './utils/mocks';
+import { windowsVMConfig } from './utils/mocks';
 import { getResourceObject } from './utils/utils';
 import { windowsGuestToolsCDElement } from '../views/editCDView';
 
@@ -27,7 +27,7 @@ describe('Kubevirt Windows Guest tools', () => {
         configName.toLowerCase(),
         testName,
         provisionConfig,
-        widowsVMConfig,
+        windowsVMConfig,
         false, // dont startOnCreation
       );
       const vm = new VirtualMachine(windowsConfig);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.wizard.scenario.ts
@@ -16,7 +16,6 @@ import {
   CLONED_VM_BOOTUP_TIMEOUT_SECS,
   VM_STATUS,
   COMMON_TEMPLATES_VERSION,
-  COMMON_TEMPLATES_NAMESPACE,
   COMMON_TEMPLATES_REVISION,
   INNER_TEMPLATE_VERSION,
 } from './utils/consts';
@@ -88,6 +87,7 @@ describe('Kubevirt create VM using wizard', () => {
         'windows10',
         testName,
         provisionConfigs.get(ProvisionConfigName.CONTAINER),
+        _.cloneDeep(basicVMConfig),
       );
       testVMConfig.networkResources = [];
       testVMConfig.operatingSystem = OperatingSystem.WINDOWS_10;
@@ -115,8 +115,7 @@ describe('Kubevirt create VM using wizard', () => {
           [`workload.template.kubevirt.io/${testVMConfig.workloadProfile}`]: 'true',
           [`flavor.template.kubevirt.io/${testVMConfig.flavorConfig.flavor}`]: 'true',
           [`os.template.kubevirt.io/${osID}`]: 'true',
-          'vm.kubevirt.io/template': `win2k12r2-${testVMConfig.workloadProfile}-${testVMConfig.flavorConfig.flavor}-${COMMON_TEMPLATES_VERSION}`,
-          'vm.kubevirt.io/template.namespace': COMMON_TEMPLATES_NAMESPACE,
+          'vm.kubevirt.io/template': `windows-${testVMConfig.workloadProfile}-${testVMConfig.flavorConfig.flavor}-${COMMON_TEMPLATES_VERSION}`,
           'vm.kubevirt.io/template.revision': COMMON_TEMPLATES_REVISION,
           'vm.kubevirt.io/template.version': INNER_TEMPLATE_VERSION,
         };

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.list-filtering.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.list-filtering.scenario.ts
@@ -1,12 +1,6 @@
 import { browser } from 'protractor';
 import { appHost, testName } from '@console/internal-integration-tests/protractor.conf';
-import {
-  addLeakableResource,
-  createResource,
-  removeLeakedResources,
-  removeLeakableResource,
-  fillInput,
-} from '@console/shared/src/test-utils/utils';
+import { createResource, deleteResources, fillInput } from '@console/shared/src/test-utils/utils';
 import {
   resourceRowsPresent,
   textFilter,
@@ -20,13 +14,11 @@ import { VirtualMachine } from './models/virtualMachine';
 const waitForVM = async (
   manifest: any,
   status: VM_STATUS,
-  resourcesSet: Set<string>,
   kind?: 'virtualmachines' | 'virtualmachineinstances',
 ) => {
   const vm = new VirtualMachine(manifest.metadata, kind || 'virtualmachines');
 
   createResource(manifest);
-  addLeakableResource(resourcesSet, manifest);
   await vm.waitForStatus(status);
 };
 
@@ -36,21 +28,18 @@ const waitForVMList = async () => {
 };
 
 describe('Test List View Filtering (VMI)', () => {
-  const leakedResources = new Set<string>();
   const testVM = getVMManifest('Container', testName, `${testName}-vm-test`);
   const testVMI = getVMIManifest('Container', testName, `${testName}-vmi-test`);
 
   beforeAll(async () => {
-    await waitForVM(testVM, VM_STATUS.Off, leakedResources);
-    await waitForVM(testVMI, VM_STATUS.Running, leakedResources, 'virtualmachineinstances');
+    await waitForVM(testVM, VM_STATUS.Off);
+    await waitForVM(testVMI, VM_STATUS.Running, 'virtualmachineinstances');
 
     await waitForVMList();
   });
 
   afterAll(async () => {
-    removeLeakableResource(leakedResources, testVM);
-    removeLeakableResource(leakedResources, testVMI);
-    removeLeakedResources(leakedResources);
+    deleteResources([testVM, testVMI]);
   });
 
   it('Displays correct count of Off VMs', async () => {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.overview.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vmi.overview.scenario.ts
@@ -8,6 +8,7 @@ import { exposeServices } from './utils/utils';
 import { VirtualMachine } from './models/virtualMachine';
 import { TAB, VM_STATUS, NOT_AVAILABLE } from './utils/consts';
 import { NodePortService } from './utils/types';
+import { vmiDetailFlavor } from '../views/virtualMachineInstance.view';
 
 describe('Test VMI Details', () => {
   const vmiName = `vmi-${testName}`;
@@ -69,7 +70,7 @@ describe('Test VMI Details', () => {
       os: await vmView.vmDetailOS(testName, vmiName).getText(),
       profile: await vmView.vmDetailWorkloadProfile(testName, vmiName).getText(),
       bootOrderTexts: await vmView.vmDetailBootOrder(testName, vmiName).getText(),
-      flavorText: await vmView.vmDetailFlavor(testName, vmiName).getText(),
+      flavorText: await vmiDetailFlavor(testName, vmiName).getText(),
     };
 
     const equal = _.isEqual(found, expectation);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vmtemplate.wizard.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vmtemplate.wizard.scenario.ts
@@ -94,7 +94,6 @@ describe('Kubevirt create VM Template using wizard', () => {
       provisionConfig,
     );
     const vmTemplate = new VirtualMachineTemplate(templateCfg);
-
     await withResource(leakedResources, vmTemplate.asResource(), async () => {
       await vmTemplate.create(templateCfg);
       await vmTemplate.navigateToTab(TAB.Details);

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/wizard.validation.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/wizard.validation.scenario.ts
@@ -21,6 +21,7 @@ import { getRandStr } from './utils/utils';
 import { diskInterfaceHelper } from '../views/dialogs/diskDialog.view';
 import { DiskDialog } from './dialogs/diskDialog';
 import { saveButton } from '../views/kubevirtDetailView.view';
+import { VirtualMachineModel } from '../../src/models/index';
 
 describe('Wizard validation', () => {
   const wizard = new Wizard();
@@ -46,7 +47,7 @@ describe('Wizard validation', () => {
   });
 
   beforeEach(async () => {
-    await wizard.openWizard();
+    await wizard.openWizard(VirtualMachineModel.labelPlural);
   });
 
   afterEach(async () => {

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/editStatusView.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/editStatusView.ts
@@ -1,4 +1,4 @@
 import { $, by } from 'protractor';
 
-export const unpauseVMDialog = $(`[aria-label="Edit pause state"]`);
-export const saveButton = unpauseVMDialog.element(by.buttonText('Unpause'));
+export const unpauseVMDialog = $('[aria-label="Edit pause state"]');
+export const unpauseButton = unpauseVMDialog.element(by.buttonText('Unpause'));

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/virtualMachine.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/virtualMachine.view.ts
@@ -10,6 +10,8 @@ export const rdpPort = manualConnectionValues.last();
 // VM detail view
 export const vmDetailItemId = (namespace, vmName, itemName) =>
   `#${namespace}-${vmName}-${itemName}`;
+export const vmDetailButtonItemId = (namespace, vmName, itemName) =>
+  `#${namespace}-${vmName}-${itemName}-edit`;
 
 export const vmDetailStatus = (namespace, vmName) =>
   $(vmDetailItemId(namespace, vmName, 'vm-statuses'));
@@ -22,7 +24,7 @@ export const vmDetailIP = (namespace, vmName) =>
 export const vmDetailWorkloadProfile = (namespace, vmName) =>
   $(vmDetailItemId(namespace, vmName, 'workload-profile'));
 export const vmDetailTemplate = (namespace, vmName) =>
-  $(`${vmDetailItemId(namespace, vmName, 'template')} > a`);
+  $(`${vmDetailItemId(namespace, vmName, 'template')}`);
 export const vmDetailNamespace = (namespace, vmName) =>
   $(vmDetailItemId(namespace, vmName, 'namespace'));
 export const vmDetailPod = (namespace, vmName) => $(vmDetailItemId(namespace, vmName, 'pod'));
@@ -30,7 +32,8 @@ export const vmDetailNode = (namespace, vmName) => $(vmDetailItemId(namespace, v
 export const vmDetailCd = (namespace, vmName) => $(vmDetailItemId(namespace, vmName, 'cdrom'));
 export const vmDetailCdEditButton = (namespace, vmName) =>
   $(vmDetailItemId(namespace, vmName, 'cdrom-edit'));
-export const vmDetailFlavor = (namespace, vmName) => $(vmDetailItemId(namespace, vmName, 'flavor'));
+export const vmDetailFlavor = (namespace, vmName) =>
+  $(vmDetailButtonItemId(namespace, vmName, 'flavor'));
 export const vmDetailFlavorEditButton = (namespace, vmName) =>
   $(vmDetailItemId(namespace, vmName, 'flavor-edit'));
 export const vmDetailFlavorDropdownId = (namespace, vmName) =>

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/virtualMachineInstance.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/virtualMachineInstance.view.ts
@@ -1,0 +1,5 @@
+import { $ } from 'protractor';
+import { vmDetailItemId } from './virtualMachine.view';
+
+export const vmiDetailFlavor = (namespace, vmName) =>
+  $(vmDetailItemId(namespace, vmName, 'flavor'));

--- a/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/views/wizard.view.ts
@@ -44,7 +44,7 @@ export const diskWarning = (resourceName) =>
   $(`[data-id="${resourceName}"]`).$('.kubevirt-validation-cell__cell--warning');
 
 // Virtual Hardware tab
-export const addCDButton = $('#attach-cdrom');
+export const addCDButton = $('#vm-cd-add-btn');
 
 // Advanced -- Cloud-init
 export const cloudInitFormCheckbox = $('#cloud-init-edit-mode-first-option');


### PR DESCRIPTION
- bring into master fixes done during 4.4 regression testing
- removed `changes tiny to large` test case as we only support changing flavor to custom now
- Moved `Unpause` tests under vm.actions.scenario.ts
