### PR TITLE
Allow catalog providers their own types and remove custom from Operator Hub

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
@@ -26,7 +26,6 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
   ]);
   const jaegerOperatorName = 'jaeger-operator';
   const jaegerName = 'my-jaeger';
-  const customProviderDisplayName = 'Console E2E Operators';
   const customProviderUID = 'providerType-console-e-2-e-operators';
 
   const catalogNamespace = _.get(browser.params, 'globalCatalogNamespace', 'openshift-marketplace');
@@ -45,7 +44,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
       sourceType: 'grpc',
       image:
         'quay.io/operator-framework/upstream-community-operators@sha256:5ae28f6de8affdb2a2119565ea950a2a777280b159f03b6ddddf104740571e25',
-      displayName: customProviderDisplayName,
+      displayName: 'Console E2E Operators',
       publisher: 'Red Hat, Inc',
     },
   };

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
@@ -26,6 +26,8 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
   ]);
   const jaegerOperatorName = 'jaeger-operator';
   const jaegerName = 'my-jaeger';
+  const customProviderDisplayName = 'Console E2E Operators';
+  const customProviderUID = 'providerType-console-e-2-e-operators';
 
   const catalogNamespace = _.get(browser.params, 'globalCatalogNamespace', 'openshift-marketplace');
   const jaegerTileID = `jaeger-console-e2e-${catalogNamespace}`;
@@ -43,7 +45,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
       sourceType: 'grpc',
       image:
         'quay.io/operator-framework/upstream-community-operators@sha256:5ae28f6de8affdb2a2119565ea950a2a777280b159f03b6ddddf104740571e25',
-      displayName: 'Console E2E Operators',
+      displayName: customProviderDisplayName,
       publisher: 'Red Hat, Inc',
     },
   };
@@ -89,7 +91,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
   it('displays subscription creation form for selected Operator', async () => {
     await catalogView.categoryTabsPresent();
     await catalogView.categoryTabs.get(0).click();
-    await catalogPageView.clickFilterCheckbox('providerType-custom');
+    await catalogPageView.clickFilterCheckbox(customProviderUID);
     await catalogPageView.catalogTileByID(jaegerTileID).click();
     await browser.wait(until.visibilityOf(operatorHubView.operatorModal));
     await operatorHubView.operatorModalInstallBtn.click();
@@ -209,7 +211,7 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
   it('displays button to uninstall the Operator', async () => {
     await browser.get(`${appHost}/operatorhub/ns/${testName}`);
     await crudView.isLoaded();
-    await catalogPageView.clickFilterCheckbox('providerType-custom');
+    await catalogPageView.clickFilterCheckbox(customProviderUID);
     await catalogPageView.clickFilterCheckbox('installState-installed');
     await catalogPageView.catalogTileByID(jaegerTileID).click();
     await operatorHubView.operatorModalIsLoaded();

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/single-installmode.scenario.ts
@@ -18,6 +18,7 @@ import * as operatorHubView from '../views/operator-hub.view';
 describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)', () => {
   const prometheusResources = new Set(['StatefulSet', 'Pod']);
   const prometheusOperatorName = 'prometheus-operator';
+  const customProviderUID = 'providerType-console-e-2-e-operators';
 
   const catalogSource = {
     apiVersion: 'operators.coreos.com/v1alpha1',
@@ -71,7 +72,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
   it('displays subscription creation form for selected Operator', async () => {
     await catalogView.categoryTabsPresent();
     await catalogView.categoryTabs.get(0).click();
-    await catalogPageView.clickFilterCheckbox('providerType-custom');
+    await catalogPageView.clickFilterCheckbox(customProviderUID);
     await catalogPageView.catalogTileFor('Prometheus Operator').click();
     await browser.wait(until.visibilityOf(operatorHubView.operatorModal));
     await operatorHubView.operatorModalInstallBtn.click();
@@ -98,7 +99,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
     await crudView.isLoaded();
     await browser.get(`${appHost}/operatorhub/ns/${testName}`);
     await crudView.isLoaded();
-    await catalogPageView.clickFilterCheckbox('providerType-custom');
+    await catalogPageView.clickFilterCheckbox(customProviderUID);
     await catalogPageView.clickFilterCheckbox('installState-installed');
 
     expect(catalogPageView.catalogTileFor('Prometheus Operator').isDisplayed()).toBe(true);
@@ -214,7 +215,7 @@ describe('Interacting with a `OwnNamespace` install mode Operator (Prometheus)',
   it('displays button to uninstall the Operator', async () => {
     await browser.get(`${appHost}/operatorhub/ns/${testName}`);
     await crudView.isLoaded();
-    await catalogPageView.clickFilterCheckbox('providerType-custom');
+    await catalogPageView.clickFilterCheckbox(customProviderUID);
     await catalogPageView.clickFilterCheckbox('installState-installed');
     await catalogPageView.catalogTileFor('Prometheus Operator').click();
     await operatorHubView.operatorModalIsLoaded();

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -93,7 +93,6 @@ const operatorHubFilterMap = {
 };
 
 const COMMUNITY_PROVIDER_TYPE = 'Community';
-const CUSTOM_PROVIDER_TYPE = 'Custom';
 const MARKETPLACE_PROVIDER_TYPE = 'Marketplace';
 
 const ignoredProviderTails = [', Inc.', ', Inc', ' Inc.', ' Inc', ', LLC', ' LLC'];
@@ -157,10 +156,8 @@ const providerTypeSort = (provider) => {
       return 2;
     case ProviderType.Marketplace:
       return 3;
-    case ProviderType.Custom:
-      return 4;
     default:
-      return 5;
+      return 4;
   }
 };
 
@@ -340,11 +337,7 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
 
     const { uid, name, imgUrl, provider, description, installed } = item;
     const vendor = provider ? `provided by ${provider}` : null;
-    const badges = [
-      COMMUNITY_PROVIDER_TYPE,
-      CUSTOM_PROVIDER_TYPE,
-      MARKETPLACE_PROVIDER_TYPE,
-    ].includes(item.providerType)
+    const badges = [COMMUNITY_PROVIDER_TYPE, MARKETPLACE_PROVIDER_TYPE].includes(item.providerType)
       ? [badge(item.providerType)]
       : [];
     const icon = (

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -195,7 +195,7 @@ const sortFilterValues = (values, field) => {
   }
 
   if (field === 'providerType') {
-    sorter = providerTypeSort;
+    return _.sortBy(values, [providerTypeSort, 'value']);
   }
 
   if (field === 'installState') {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
@@ -7,13 +7,8 @@ export const operatorProviderTypeMap = {
   community: 'Community',
 };
 
-const getCustomOperatorProviderType = (packageManifest) => {
-  return (
-    packageManifest.metadata?.annotations?.['marketplace.openshift.io/display-name'] ||
-    packageManifest.metadata.name
-  );
-};
-
+const getCustomOperatorProviderType = (packageManifest) =>
+  packageManifest.status.catalogSourceDisplayName || packageManifest.status.catalogSource;
 export const getOperatorProviderType = (packageManifest) => {
   const srcProvider = _.get(packageManifest, 'metadata.labels.opsrc-provider');
   return _.get(

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-utils.ts
@@ -5,10 +5,20 @@ export const operatorProviderTypeMap = {
   marketplace: 'Marketplace',
   certified: 'Certified',
   community: 'Community',
-  custom: 'Custom',
+};
+
+const getCustomOperatorProviderType = (packageManifest) => {
+  return (
+    packageManifest.metadata?.annotations?.['marketplace.openshift.io/display-name'] ||
+    packageManifest.metadata.name
+  );
 };
 
 export const getOperatorProviderType = (packageManifest) => {
   const srcProvider = _.get(packageManifest, 'metadata.labels.opsrc-provider');
-  return _.get(operatorProviderTypeMap, srcProvider, 'Custom');
+  return _.get(
+    operatorProviderTypeMap,
+    srcProvider,
+    getCustomOperatorProviderType(packageManifest),
+  );
 };


### PR DESCRIPTION
For Story: https://issues.redhat.com/browse/CONSOLE-2159

Haven't installed a custom operator, but tested by removing the Community type to give an example of how it will look using default value (name) without the new annotation.

There is also a sort for the filter that sorts the provider types. As of now, this just sorts the first three types in the order: Red Hat, Certified, Community, Marketplace...after those, the custom names will be listed in alpha sort as shown in the sample image.

sample image:
![Screen Shot 2020-03-30 at 1 09 43 PM](https://user-images.githubusercontent.com/35978579/77941204-cb965580-7287-11ea-95cb-b42a4313c25d.png)

