### PR TITLE
Fix the disappearance of status card on storage dashboards

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/status-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/status-card.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
-import { ALERTS_KEY } from '@console/internal/actions/dashboards';
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
 import AlertItem from '@console/shared/src/components/dashboard/status-card/AlertItem';
-import { alertURL, PrometheusRulesResponse } from '@console/internal/components/monitoring';
+import { alertURL } from '@console/internal/components/monitoring';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
 import HealthItem from '@console/shared/src/components/dashboard/status-card/HealthItem';
-import { getAlerts } from '@console/shared/src/components/dashboard/status-card/alert-utils';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import {
   withDashboardResources,
@@ -28,7 +27,7 @@ const cephStatusQuery = STORAGE_HEALTH_QUERIES[StorageDashboardQuery.CEPH_STATUS
 const resiliencyProgressQuery = DATA_RESILIENCY_QUERY[StorageDashboardQuery.RESILIENCY_PROGRESS];
 
 export const CephAlerts = withDashboardResources(
-  ({ watchAlerts, stopWatchAlerts, alertsResults }) => {
+  ({ watchAlerts, stopWatchAlerts, notificationAlerts }) => {
     React.useEffect(() => {
       watchAlerts();
       return () => {
@@ -36,14 +35,13 @@ export const CephAlerts = withDashboardResources(
       };
     }, [watchAlerts, stopWatchAlerts]);
 
-    const alertsResponse = alertsResults.getIn([ALERTS_KEY, 'data']) as PrometheusRulesResponse;
-    const alertsResponseError = alertsResults.getIn([ALERTS_KEY, 'loadError']);
-    const alerts = filterCephAlerts(getAlerts(alertsResponse));
+    const { data, loaded, loadError } = notificationAlerts || {};
+    const alerts = filterCephAlerts(data);
 
     return (
       <AlertsBody
-        isLoading={!alertsResponse}
-        error={alertsResponseError}
+        isLoading={!loaded}
+        error={!_.isEmpty(loadError)}
         emptyMessage="No persistent storage alerts"
       >
         {alerts.length

--- a/frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx
@@ -1,17 +1,15 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
-import { ALERTS_KEY } from '@console/internal/actions/dashboards';
 import AlertsBody from '@console/shared/src/components/dashboard/status-card/AlertsBody';
 import AlertItem from '@console/shared/src/components/dashboard/status-card/AlertItem';
-import { alertURL, PrometheusRulesResponse } from '@console/internal/components/monitoring';
+import { alertURL } from '@console/internal/components/monitoring';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
 import HealthItem from '@console/shared/src/components/dashboard/status-card/HealthItem';
-import { getAlerts } from '@console/shared/src/components/dashboard/status-card/alert-utils';
 import { PrometheusResponse } from '@console/internal/components/graphs';
 import {
   withDashboardResources,
@@ -34,29 +32,30 @@ const noobaaResource: FirehoseResource = {
   prop: 'noobaa',
 };
 
-const NooBaaAlerts = withDashboardResources(({ watchAlerts, stopWatchAlerts, alertsResults }) => {
-  React.useEffect(() => {
-    watchAlerts();
-    return () => {
-      stopWatchAlerts();
-    };
-  }, [watchAlerts, stopWatchAlerts]);
+const NooBaaAlerts = withDashboardResources(
+  ({ watchAlerts, stopWatchAlerts, notificationAlerts }) => {
+    React.useEffect(() => {
+      watchAlerts();
+      return () => {
+        stopWatchAlerts();
+      };
+    }, [watchAlerts, stopWatchAlerts]);
 
-  const alertsResponse = alertsResults.getIn([ALERTS_KEY, 'data']) as PrometheusRulesResponse;
-  const alertsResponseError = alertsResults.getIn([ALERTS_KEY, 'loadError']);
-  const alerts = filterNooBaaAlerts(getAlerts(alertsResponse));
+    const { data, loaded, loadError } = notificationAlerts || {};
+    const alerts = filterNooBaaAlerts(data);
 
-  return (
-    <AlertsBody
-      isLoading={!alertsResponse}
-      error={alertsResponseError}
-      emptyMessage="No object service alerts"
-    >
-      {alerts.length > 0 &&
-        alerts.map((alert) => <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />)}
-    </AlertsBody>
-  );
-});
+    return (
+      <AlertsBody
+        isLoading={!loaded}
+        error={!_.isEmpty(loadError)}
+        emptyMessage="No object service alerts"
+      >
+        {alerts.length > 0 &&
+          alerts.map((alert) => <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />)}
+      </AlertsBody>
+    );
+  },
+);
 
 const StatusCard: React.FC<DashboardItemProps> = ({
   watchK8sResource,


### PR DESCRIPTION
![Screenshot from 2020-03-26 13-24-10](https://user-images.githubusercontent.com/25664409/77622891-1c930a80-6f65-11ea-8a96-b135301a25f3.png)

![Screenshot from 2020-03-26 13-10-20](https://user-images.githubusercontent.com/25664409/77621929-5e22b600-6f63-11ea-8fde-ff275e12e523.png)
- withDashboardResources HOC is non longer passing `alertsresults` due to which status card on both storage dashboard is breaking.
- using the `notificationAlerts` now as per the recent changes

Signed-off-by: Afreen Rahman <afrahman@redhat.com>