### PR TITLE
Using resource extension to show health on dashboards

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/independent-dashboard-page/status-card/card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/independent-dashboard-page/status-card/card.tsx
@@ -1,43 +1,20 @@
 import * as React from 'react';
 import { GalleryItem, Gallery } from '@patternfly/react-core';
-import { withDashboardResources } from '@console/internal/components/dashboard/with-dashboard-resources';
 import DashboardCard from '@console/shared/src/components/dashboard/dashboard-card/DashboardCard';
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import HealthBody from '@console/shared/src/components/dashboard/status-card/HealthBody';
 import DashboardCardHeader from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardHeader';
 import DashboardCardBody from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardBody';
 import HealthItem from '@console/shared/src/components/dashboard/status-card/HealthItem';
-import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
-import { FirehoseResource, FirehoseResult } from '@console/internal/components/utils/types';
-import { OCSServiceModel } from '../../../models';
-import { getClusterHealth } from '../../independent-mode/utils';
-import { OCS_INDEPENDENT_CR_NAME, CEPH_STORAGE_NAMESPACE } from '../../../constants';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { getCephHealthState } from '../../dashboard-page/storage-dashboard/status-card/utils';
+import { cephClusterResource } from '../../../constants/resources';
 
-const clusterResource: FirehoseResource = {
-  kind: referenceForModel(OCSServiceModel),
-  name: OCS_INDEPENDENT_CR_NAME,
-  namespaced: true,
-  namespace: CEPH_STORAGE_NAMESPACE,
-  isList: false,
-  prop: 'ocs',
-};
+const StatusCard: React.FC = () => {
+  const [data, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>(cephClusterResource);
 
-const StatusCard = withDashboardResources((props) => {
-  const { watchK8sResource, stopWatchK8sResource, resources } = props;
-
-  React.useEffect(() => {
-    watchK8sResource(clusterResource);
-    return () => {
-      stopWatchK8sResource(clusterResource);
-    };
-  }, [watchK8sResource, stopWatchK8sResource]);
-
-  const cluster = resources?.ocs as FirehoseResult<K8sResourceKind>;
-  const data = cluster?.data;
-  const loaded = cluster?.loaded;
-  const error = cluster?.loadError;
-
-  const status = getClusterHealth(data, loaded, error);
+  const cephHealth = getCephHealthState({ ceph: { data, loaded, loadError } });
 
   return (
     <DashboardCard gradient>
@@ -48,13 +25,13 @@ const StatusCard = withDashboardResources((props) => {
         <HealthBody>
           <Gallery className="co-overview-status__health" gutter="md">
             <GalleryItem>
-              <HealthItem title="OCS Cluster" state={status} />
+              <HealthItem title="OCS Cluster" state={cephHealth.state} />
             </GalleryItem>
           </Gallery>
         </HealthBody>
       </DashboardCardBody>
     </DashboardCard>
   );
-});
+};
 
 export default StatusCard;

--- a/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
@@ -8,10 +8,3 @@ export const cephClusterResource: FirehoseResource = {
   isList: true,
   prop: 'ceph',
 };
-export enum StorageDashboardResource {
-  CEPH_CLUSTER_RESOURCE = 'CEPH_CLUSTER_RESOURCE',
-}
-
-export const STORAGE_HEALTH_RESOURCES = {
-  [StorageDashboardResource.CEPH_CLUSTER_RESOURCE]: cephClusterResource,
-};

--- a/frontend/packages/ceph-storage-plugin/src/plugin.ts
+++ b/frontend/packages/ceph-storage-plugin/src/plugin.ts
@@ -1,14 +1,10 @@
 import * as _ from 'lodash';
 import * as models from './models';
-import {
-  CAPACITY_USAGE_QUERIES,
-  STORAGE_HEALTH_QUERIES,
-  StorageDashboardQuery,
-} from './constants/queries';
+import { CAPACITY_USAGE_QUERIES, StorageDashboardQuery } from './constants/queries';
 import {
   ClusterServiceVersionAction,
   DashboardsCard,
-  DashboardsOverviewHealthPrometheusSubsystem,
+  DashboardsOverviewHealthResourceSubsystem,
   DashboardsOverviewUtilizationItem,
   DashboardsTab,
   FeatureFlag,
@@ -35,13 +31,14 @@ import { referenceForModel, referenceFor } from '@console/internal/module/k8s';
 import { PersistentVolumeClaimModel } from '@console/internal/models';
 import { getCephHealthState } from './components/dashboard-page/storage-dashboard/status-card/utils';
 import { isClusterExpandActivity } from './components/dashboard-page/storage-dashboard/activity-card/cluster-expand-activity';
+import { WatchCephResource } from './types';
 
 type ConsumedExtensions =
   | ModelFeatureFlag
   | ModelDefinition
   | DashboardsTab
   | DashboardsCard
-  | DashboardsOverviewHealthPrometheusSubsystem
+  | DashboardsOverviewHealthResourceSubsystem<WatchCephResource>
   | DashboardsOverviewUtilizationItem
   | RoutePage
   | ActionFeatureFlag
@@ -205,10 +202,16 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'Dashboards/Overview/Health/Prometheus',
+    type: 'Dashboards/Overview/Health/Resource',
     properties: {
       title: 'Storage',
-      queries: [STORAGE_HEALTH_QUERIES[StorageDashboardQuery.CEPH_STATUS_QUERY]],
+      resources: {
+        ceph: {
+          kind: referenceForModel(models.CephClusterModel),
+          namespaced: false,
+          isList: true,
+        },
+      },
       healthHandler: getCephHealthState,
     },
     flags: {

--- a/frontend/packages/ceph-storage-plugin/src/types.ts
+++ b/frontend/packages/ceph-storage-plugin/src/types.ts
@@ -1,0 +1,5 @@
+import { K8sResourceKind } from '@console/internal/module/k8s';
+
+export type WatchCephResource = {
+  ceph: K8sResourceKind[];
+};

--- a/frontend/packages/container-security/src/components/__tests__/summary.spec.ts
+++ b/frontend/packages/container-security/src/components/__tests__/summary.spec.ts
@@ -28,29 +28,33 @@ const highVuln: ImageManifestVuln = {
 
 describe('securityHealthHandler', () => {
   it('returns `UNKNOWN` status if there is an error retrieving `ImageManifestVulns`', () => {
-    const vulnerabilities = { loaded: true, loadError: 'failed to fetch', data: [] };
-    const health = securityHealthHandler(null, null, vulnerabilities);
+    const vulnerabilities = {
+      imageManifestVuln: { loaded: true, loadError: 'failed to fetch', data: [] },
+    };
+    const health = securityHealthHandler(vulnerabilities);
 
     expect(health.state).toEqual(HealthState.UNKNOWN);
   });
 
   it('returns `LOADING` status if still retrieving `ImageManifestVulns`', () => {
-    const vulnerabilities = { loaded: false, loadError: null, data: [] };
-    const health = securityHealthHandler(null, null, vulnerabilities);
+    const vulnerabilities = { imageManifestVuln: { loaded: false, loadError: null, data: [] } };
+    const health = securityHealthHandler(vulnerabilities);
 
     expect(health.state).toEqual(HealthState.LOADING);
   });
 
   it('returns `Error` status if any `ImageManifestVulns` exist', () => {
-    const vulnerabilities = { loaded: true, loadError: null, data: [highVuln] };
-    const health = securityHealthHandler(null, null, vulnerabilities);
+    const vulnerabilities = {
+      imageManifestVuln: { loaded: true, loadError: null, data: [highVuln] },
+    };
+    const health = securityHealthHandler(vulnerabilities);
 
     expect(health.state).toEqual(HealthState.ERROR);
   });
 
   it('returns `OK` status if no vulnerabilities', () => {
-    const vulnerabilities = { loaded: true, loadError: null, data: [] };
-    const health = securityHealthHandler(null, null, vulnerabilities);
+    const vulnerabilities = { imageManifestVuln: { loaded: true, loadError: null, data: [] } };
+    const health = securityHealthHandler(vulnerabilities);
 
     expect(health.state).toEqual(HealthState.OK);
   });

--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -6,6 +6,7 @@ import {
   KebabActions,
   ResourceListPage,
   DashboardsOverviewHealthURLSubsystem,
+  DashboardsOverviewHealthResourceSubsystem,
   RoutePage,
   ResourceDetailsPage,
   ResourceNSNavItem,
@@ -15,6 +16,7 @@ import { ImageManifestVulnModel } from './models';
 import { SecurityLabellerFlag } from './const';
 import { securityHealthHandler } from './components/summary';
 import { getKebabActionsForKind } from './kebab-actions';
+import { WatchImageVuln } from './types';
 
 type ConsumedExtensions =
   | ModelDefinition
@@ -22,6 +24,7 @@ type ConsumedExtensions =
   | ResourceListPage
   | ResourceDetailsPage
   | DashboardsOverviewHealthURLSubsystem
+  | DashboardsOverviewHealthResourceSubsystem<WatchImageVuln>
   | RoutePage
   | KebabActions
   | ResourceNSNavItem;
@@ -89,23 +92,22 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
-    type: 'Dashboards/Overview/Health/URL',
+    type: 'Dashboards/Overview/Health/Resource',
     properties: {
       title: 'Quay Image Security',
-      url: '',
-      fetch: () => null,
-      healthHandler: securityHealthHandler,
-      additionalResource: {
-        kind: referenceForModel(ImageManifestVulnModel),
-        namespaced: true,
-        isList: true,
-        prop: 'imageManifestVuln',
+      resources: {
+        imageManifestVuln: {
+          kind: referenceForModel(ImageManifestVulnModel),
+          namespaced: true,
+          isList: true,
+        },
       },
+      healthHandler: securityHealthHandler,
+      popupTitle: 'Quay Image Security breakdown',
       popupComponent: () =>
         import('./components/summary' /* webpackChunkName: "container-security" */).then(
           (m) => m.SecurityBreakdownPopup,
         ),
-      popupTitle: 'Quay Image Security breakdown',
     },
     flags: {
       required: [SecurityLabellerFlag],

--- a/frontend/packages/container-security/src/types.ts
+++ b/frontend/packages/container-security/src/types.ts
@@ -43,3 +43,7 @@ export type ImageManifestVuln = {
   spec: ImageManifestVulnSpec;
   status: ImageManifestVulnStatus;
 } & K8sResourceCommon;
+
+export type WatchImageVuln = {
+  imageManifestVuln: ImageManifestVuln[];
+};

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/status-card.tsx
@@ -5,9 +5,12 @@ import { Map as ImmutableMap } from 'immutable';
 import {
   useExtensions,
   DashboardsOverviewHealthSubsystem,
+  DashboardsOverviewHealthPrometheusSubsystem,
   isDashboardsOverviewHealthSubsystem,
   isDashboardsOverviewHealthURLSubsystem,
+  DashboardsOverviewHealthURLSubsystem,
   isDashboardsOverviewHealthPrometheusSubsystem,
+  isDashboardsOverviewHealthResourceSubsystem,
   isDashboardsOverviewHealthOperator,
 } from '@console/plugin-sdk';
 import { ArrowCircleUpIcon } from '@patternfly/react-icons';
@@ -36,17 +39,25 @@ import {
 import { ClusterVersionModel } from '../../../../models';
 import { clusterUpdateModal } from '../../../modals/cluster-update-modal';
 import { RootState } from '../../../../redux';
-import { OperatorHealthItem, PrometheusHealthItem, URLHealthItem } from './health-item';
+import {
+  OperatorHealthItem,
+  PrometheusHealthItem,
+  URLHealthItem,
+  ResourceHealthItem,
+} from './health-item';
 
 const filterSubsystems = (
   subsystems: DashboardsOverviewHealthSubsystem[],
   k8sModels: ImmutableMap<string, K8sKind>,
 ) =>
-  subsystems.filter((subsystem) => {
+  subsystems.filter((s) => {
     if (
-      isDashboardsOverviewHealthURLSubsystem(subsystem) ||
-      isDashboardsOverviewHealthPrometheusSubsystem(subsystem)
+      isDashboardsOverviewHealthURLSubsystem(s) ||
+      isDashboardsOverviewHealthPrometheusSubsystem(s)
     ) {
+      const subsystem = s as
+        | DashboardsOverviewHealthPrometheusSubsystem
+        | DashboardsOverviewHealthURLSubsystem;
       return subsystem.properties.additionalResource &&
         !subsystem.properties.additionalResource.optional
         ? !!k8sModels.get(subsystem.properties.additionalResource.kind)
@@ -176,6 +187,11 @@ export const StatusCard = connect<StatusCardProps>(mapStateToProps)(({ k8sModels
       healthItems.push({
         title: subsystem.properties.title,
         Component: <PrometheusHealthItem subsystem={subsystem.properties} models={k8sModels} />,
+      });
+    } else if (isDashboardsOverviewHealthResourceSubsystem(subsystem)) {
+      healthItems.push({
+        title: subsystem.properties.title,
+        Component: <ResourceHealthItem subsystem={subsystem.properties} />,
       });
     }
   });


### PR DESCRIPTION
Depends on #4840 

This PR makes changes to
- cluster dashboard
- conatiner security plugin
- persistent dahsboard
- independent mode dashboard

State of dashboards with this PR:
![Screenshot from 2020-03-27 18-10-19](https://user-images.githubusercontent.com/25664409/77757116-9d7dff00-7056-11ea-840d-b6fae7247a9c.png)
![Screenshot from 2020-03-27 18-10-26](https://user-images.githubusercontent.com/25664409/77757120-9f47c280-7056-11ea-9c13-f6f06d6b521d.png)
![Screenshot from 2020-03-27 18-10-32](https://user-images.githubusercontent.com/25664409/77757121-9fe05900-7056-11ea-8bf9-7b2c600e7b18.png)
