### PR TITLE
Add Helm Chart README to catalog page sidebar

### DIFF
--- a/frontend/public/components/catalog/catalog-item-details.jsx
+++ b/frontend/public/components/catalog/catalog-item-details.jsx
@@ -11,12 +11,19 @@ import { SyncMarkdownView } from '../markdown-view';
 export class CatalogTileDetails extends React.Component {
   state = {
     plans: [],
+    markdown: '',
   };
 
   componentDidMount() {
-    const { obj, kind } = this.props.item;
+    const { obj, kind, markdownDescription } = this.props.item;
     if (kind === 'ClusterServiceClass') {
       this.getPlans(obj);
+    }
+
+    if (_.isFunction(markdownDescription)) {
+      markdownDescription().then((md) => this.setState({ markdown: md }));
+    } else {
+      this.setState({ markdown: markdownDescription });
     }
   }
 
@@ -35,14 +42,13 @@ export class CatalogTileDetails extends React.Component {
       obj,
       kind,
       tileProvider,
-      markdownDescription,
       tileDescription,
       supportUrl,
       longDescription,
       documentationUrl,
       sampleRepo,
     } = this.props.item;
-    const { plans } = this.state;
+    const { plans, markdown } = this.state;
 
     const creationTimestamp = _.get(obj, 'metadata.creationTimestamp');
 
@@ -79,7 +85,7 @@ export class CatalogTileDetails extends React.Component {
               <div className="co-catalog-page__overlay-description">
                 <SectionHeading text="Description" />
                 {tileDescription && <p>{tileDescription}</p>}
-                {markdownDescription && <SyncMarkdownView content={markdownDescription} />}
+                {markdown && <SyncMarkdownView content={markdown} />}
                 {longDescription && <p>{longDescription}</p>}
                 {sampleRepo && <p>Sample repository: {sampleRepoLink}</p>}
                 {documentationUrl && (

--- a/frontend/public/components/catalog/catalog-item-details.jsx
+++ b/frontend/public/components/catalog/catalog-item-details.jsx
@@ -47,6 +47,7 @@ export class CatalogTileDetails extends React.Component {
       longDescription,
       documentationUrl,
       sampleRepo,
+      customProperties,
     } = this.props.item;
     const { plans, markdown } = this.state;
 
@@ -73,6 +74,7 @@ export class CatalogTileDetails extends React.Component {
           <div className="modal-body-inner-shadow-covers">
             <div className="co-catalog-page__overlay-body">
               <PropertiesSidePanel>
+                {customProperties}
                 {tileProvider && <PropertyItem label="Provider" value={tileProvider} />}
                 {supportUrl && <PropertyItem label="Support" value={supportUrlLink} />}
                 {creationTimestamp && (


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3266

**Analysis / Root cause**: 
Currently in the Catalog, there is no way to better understand a Helm Chart before installing it.

**Solution Description**: 
In order to give users more information about a Helm Chart we fetch the chart data from backend and show the decoded README file of that chart in markdown view in the sidebar of catalog page.

**Screen shots / Gifs for design review**: 
cc: @openshift/team-ux-review 

![Readme](https://user-images.githubusercontent.com/6041994/79478890-9466c900-8029-11ea-8d82-f8db14848d3c.gif)


**Test setup:**
We only have one chart in our catalog right now. For testing replace the URL on line 341 of `catalog-page.tsx` with `https://raw.githubusercontent.com/IBM/charts/master/repo/community/index.yaml`.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge