### PR TITLE
Improve Installed Operators list page

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/mocks.ts
+++ b/frontend/packages/operator-lifecycle-manager/mocks.ts
@@ -30,6 +30,10 @@ export const testClusterServiceVersion: ClusterServiceVersionKind = {
   apiVersion: 'operators.coreos.com/v1alpha1',
   kind: 'ClusterServiceVersion',
   metadata: {
+    annotations: {
+      'olm.operatorNamespace': 'openshift-operators',
+      'olm.targetNamespaces': 'openshift-operators',
+    },
     name: 'testapp',
     uid: 'c02c0a8f-88e0-11e7-851b-080027b424ef',
     creationTimestamp: '2017-09-20T18:19:49Z',

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -3,11 +3,18 @@ import { Link, match as RouterMatch } from 'react-router-dom';
 import * as _ from 'lodash';
 import { connect } from 'react-redux';
 import * as classNames from 'classnames';
-import { sortable } from '@patternfly/react-table';
+import { sortable, wrappable } from '@patternfly/react-table';
 import { Helmet } from 'react-helmet';
 import { AddCircleOIcon } from '@patternfly/react-icons';
-import { Alert, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react-core';
-import * as UIActions from '@console/internal/actions/ui';
+import {
+  Alert,
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  Popover,
+} from '@patternfly/react-core';
 import { ALL_NAMESPACES_KEY, Status, WarningStatus, getNamespace, getUID } from '@console/shared';
 import {
   DetailsPage,
@@ -52,7 +59,9 @@ import {
   resourceObjPath,
   KebabAction,
 } from '@console/internal/components/utils';
+import { fromNow } from '@console/internal/components/utils/datetime';
 import { useAccessReview } from '@console/internal/components/utils/rbac';
+import { RootState } from '@console/internal/redux';
 import {
   ClusterServiceVersionModel,
   SubscriptionModel,
@@ -79,51 +88,80 @@ import { operatorGroupFor, operatorNamespaceFor } from './operator-group';
 import { SubscriptionDetails, catalogSourceForSubscription } from './subscription';
 import { ClusterServiceVersionLogo, referenceForProvidedAPI, providedAPIsFor } from './index';
 
+const clusterServiceVersionStateToProps = (state: RootState): ClusterServiceVersionStateProps => {
+  return {
+    activeNamespace: state.UI.get('activeNamespace'),
+  };
+};
+
 const isSubscription = (obj) => referenceFor(obj) === referenceForModel(SubscriptionModel);
 const isCSV = (obj) => referenceFor(obj) === referenceForModel(ClusterServiceVersionModel);
-const tableColumnClasses = [
-  '',
-  '',
-  classNames('pf-m-hidden', 'pf-m-visible-on-sm'),
-  classNames('pf-m-hidden', 'pf-m-visible-on-lg'),
-  classNames('pf-m-hidden', 'pf-m-visible-on-xl'),
-  Kebab.columnClass,
-];
 
-export const ClusterServiceVersionTableHeader = () => {
-  return [
-    {
-      title: 'Name',
-      sortField: 'metadata.name',
-      transforms: [sortable],
-      props: { className: tableColumnClasses[0] },
-    },
-    {
-      title: 'Namespace',
-      sortField: 'metadata.namespace',
-      transforms: [sortable],
-      props: { className: tableColumnClasses[1] },
-    },
-    {
-      title: 'Status',
-      props: { className: tableColumnClasses[2] },
-    },
-    {
-      title: 'Deployment',
-      sortField: 'spec.install.spec.deployments[0].name',
-      transforms: [sortable],
-      props: { className: tableColumnClasses[3] },
-    },
-    {
-      title: 'Provided APIs',
-      props: { className: tableColumnClasses[4] },
-    },
-    {
-      title: '',
-      props: { className: tableColumnClasses[5] },
-    },
-  ];
+const nameColumnClass = '';
+const namespaceColumnClass = '';
+const managedNamespacesColumnClass = classNames('pf-m-hidden', 'pf-m-visible-on-sm');
+const statusColumnClass = classNames('pf-m-hidden', 'pf-m-visible-on-lg');
+const lastUpdatedColumnClass = classNames('pf-m-hidden', 'pf-m-visible-on-2xl');
+const providedAPIsColumnClass = classNames('pf-m-hidden', 'pf-m-visible-on-xl');
+
+const nameHeader: Header = {
+  title: 'Name',
+  sortField: 'metadata.name',
+  transforms: [sortable],
+  props: { className: nameColumnClass },
 };
+
+const namespaceHeader: Header = {
+  title: 'Namespace',
+  sortFunc: 'getOperatorNamespace',
+  transforms: [sortable],
+  props: { className: namespaceColumnClass },
+};
+
+const managedNamespacesHeader: Header = {
+  title: 'Managed Namespaces',
+  sortFunc: 'formatTargetNamespaces',
+  transforms: [sortable, wrappable],
+  props: { className: managedNamespacesColumnClass },
+};
+
+const statusHeader: Header = {
+  title: 'Status',
+  props: { className: statusColumnClass },
+};
+
+const lastUpdatedHeader: Header = {
+  title: 'Last Updated',
+  props: { className: lastUpdatedColumnClass },
+};
+
+const providedAPIsHeader: Header = {
+  title: 'Provided APIs',
+  props: { className: providedAPIsColumnClass },
+};
+
+const kebabHeader: Header = {
+  title: '',
+  props: { className: Kebab.columnClass },
+};
+
+export const AllProjectsTableHeader = (): Header[] => [
+  nameHeader,
+  namespaceHeader,
+  managedNamespacesHeader,
+  statusHeader,
+  lastUpdatedHeader,
+  providedAPIsHeader,
+  kebabHeader,
+];
+export const SingleProjectTableHeader = (): Header[] => [
+  nameHeader,
+  managedNamespacesHeader,
+  statusHeader,
+  lastUpdatedHeader,
+  providedAPIsHeader,
+  kebabHeader,
+];
 
 const editSubscription = (sub: SubscriptionKind): KebabOption =>
   !_.isNil(sub)
@@ -207,96 +245,131 @@ const ClusterServiceVersionStatus: React.FC<ClusterServiceVersionStatusProps> = 
   ) : null;
 };
 
-export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionTableRowProps>(
-  ({ obj, rowKey, subscription, catalogSourceMissing, index, style }) => {
-    const { displayName, provider, version } = _.get(obj, 'spec');
-    const [icon] = _.get(obj, 'spec.icon', []);
-    const deploymentName = _.get(obj, 'spec.install.spec.deployments[0].name');
-    const namespace = getNamespace(obj);
-    const route = resourceObjPath(obj, referenceFor(obj));
-    const uid = getUID(obj);
-    const internalObjects = getInternalObjects(obj);
-    return (
-      <TableRow id={uid} trKey={rowKey} index={index} style={style}>
-        {/* Name */}
-        <TableData className={tableColumnClasses[0]}>
-          <Link
-            to={route}
-            className="co-clusterserviceversion-link"
-            data-test-operator-row={displayName}
-          >
-            <ClusterServiceVersionLogo
-              icon={icon}
-              displayName={displayName}
-              version={version}
-              provider={provider}
-            />
-          </Link>
-        </TableData>
+const ManagedNamespaces: React.FC<ManagedNamespacesProps> = ({ obj }) => {
+  const { 'olm.targetNamespaces': olmTargetNamespaces = '' } = obj.metadata?.annotations || {};
+  const managedNamespaces = olmTargetNamespaces?.split(',') || [];
 
-        {/* Namespace */}
-        <TableData className={tableColumnClasses[1]}>
-          <ResourceLink kind="Namespace" title={namespace} name={namespace} />
-        </TableData>
+  if (managedNamespaces.length === 1 && managedNamespaces[0] === '') {
+    return <span className="text-muted">All Namespaces</span>;
+  }
 
-        {/* Status */}
-        <TableData className={tableColumnClasses[2]}>
-          <div className="co-clusterserviceversion-row__status">
-            <ClusterServiceVersionStatus
-              catalogSourceMissing={catalogSourceMissing}
-              obj={obj}
-              subscription={subscription}
-            />
-          </div>
-        </TableData>
-
-        {/* Deployment */}
-        <TableData className={tableColumnClasses[3]}>
-          <ResourceLink
-            kind="Deployment"
-            name={deploymentName}
-            namespace={operatorNamespaceFor(obj)}
-            title={deploymentName}
-          />
-        </TableData>
-
-        {/* Provided APIs */}
-        <TableData className={tableColumnClasses[4]}>
-          {_.take(
-            providedAPIsFor(obj).filter((desc) => !isInternalObject(internalObjects, desc.name)),
-            4,
-          ).map((desc) => (
-            <div key={referenceForProvidedAPI(desc)}>
-              <Link to={`${route}/${referenceForProvidedAPI(desc)}`} title={desc.name}>
-                {desc.displayName}
-              </Link>
-            </div>
+  switch (managedNamespaces.length) {
+    case 0:
+      return <span className="text-muted">All Namespaces</span>;
+    case 1:
+      return (
+        <ResourceLink kind="Namespace" title={managedNamespaces[0]} name={managedNamespaces[0]} />
+      );
+    default:
+      return (
+        <Popover
+          headerContent="Managed Namespaces"
+          bodyContent={managedNamespaces.map((namespace) => (
+            <ResourceLink kind="Namespace" title={namespace} name={namespace} />
           ))}
-          {providedAPIsFor(obj).filter((desc) => !isInternalObject(internalObjects, desc.name))
-            .length > 4 && (
-            <Link
-              to={`${route}/instances`}
-              title={`View ${providedAPIsFor(obj).length - 4} more...`}
-            >
-              {`View ${providedAPIsFor(obj).length - 4} more...`}
-            </Link>
-          )}
-        </TableData>
+        >
+          <Button variant="link" isInline>
+            {managedNamespaces.length} Namespaces
+          </Button>
+        </Popover>
+      );
+  }
+};
 
-        {/* Kabob */}
-        <TableData className={tableColumnClasses[5]}>
-          <ResourceKebab
-            resource={obj}
-            kind={referenceFor(obj)}
-            actions={menuActionsForCSV(obj, subscription)}
+export const NamespacedClusterServiceVersionTableRow = withFallback<
+  ClusterServiceVersionTableRowProps
+>(({ activeNamespace, obj, rowKey, subscription, catalogSourceMissing, index, style }) => {
+  const { displayName, provider, version } = _.get(obj, 'spec');
+  const { 'olm.operatorNamespace': olmOperatorNamespace = '' } = obj.metadata?.annotations || {};
+  const [icon] = _.get(obj, 'spec.icon', []);
+  const route = resourceObjPath(obj, referenceFor(obj));
+  const uid = getUID(obj);
+  const internalObjects = getInternalObjects(obj);
+
+  return (
+    <TableRow id={uid} trKey={rowKey} index={index} style={style}>
+      {/* Name */}
+      <TableData className={nameColumnClass}>
+        <Link
+          to={route}
+          className="co-clusterserviceversion-link"
+          data-test-operator-row={displayName}
+        >
+          <ClusterServiceVersionLogo
+            icon={icon}
+            displayName={displayName}
+            version={version}
+            provider={provider}
           />
+        </Link>
+      </TableData>
+
+      {/* Operator Namespace */}
+      {activeNamespace === ALL_NAMESPACES_KEY ? (
+        <TableData className={namespaceColumnClass}>
+          <ResourceLink kind="Namespace" title={olmOperatorNamespace} name={olmOperatorNamespace} />
         </TableData>
-      </TableRow>
-    );
-  },
+      ) : null}
+
+      {/* Managed Namespaces */}
+      <TableData className={managedNamespacesColumnClass}>
+        <ManagedNamespaces obj={obj} />
+      </TableData>
+
+      {/* Status */}
+      <TableData className={statusColumnClass}>
+        <div className="co-clusterserviceversion-row__status">
+          <ClusterServiceVersionStatus
+            catalogSourceMissing={catalogSourceMissing}
+            obj={obj}
+            subscription={subscription}
+          />
+        </div>
+      </TableData>
+
+      {/* Last Updated */}
+      <TableData className={lastUpdatedColumnClass}>
+        {obj.status == null ? '-' : fromNow(obj.status.lastUpdateTime)}
+      </TableData>
+
+      {/* Provided APIs */}
+      <TableData className={providedAPIsColumnClass}>
+        {_.take(
+          providedAPIsFor(obj).filter((desc) => !isInternalObject(internalObjects, desc.name)),
+          4,
+        ).map((desc) => (
+          <div key={referenceForProvidedAPI(desc)}>
+            <Link to={`${route}/${referenceForProvidedAPI(desc)}`} title={desc.name}>
+              {desc.displayName}
+            </Link>
+          </div>
+        ))}
+        {providedAPIsFor(obj).filter((desc) => !isInternalObject(internalObjects, desc.name))
+          .length > 4 && (
+          <Link to={`${route}/instances`} title={`View ${providedAPIsFor(obj).length - 4} more...`}>
+            {`View ${providedAPIsFor(obj).length - 4} more...`}
+          </Link>
+        )}
+      </TableData>
+
+      {/* Kebab */}
+      <TableData className={Kebab.columnClass}>
+        <ResourceKebab
+          resource={obj}
+          kind={referenceFor(obj)}
+          actions={menuActionsForCSV(obj, subscription)}
+        />
+      </TableData>
+    </TableRow>
+  );
+});
+
+export const ClusterServiceVersionTableRow = connect(clusterServiceVersionStateToProps)(
+  NamespacedClusterServiceVersionTableRow,
 );
 
-const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
+const NamespacedSubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
+  activeNamespace,
   catalogSourceMissing,
   rowKey,
   obj,
@@ -328,7 +401,7 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
   return (
     <TableRow id={uid} trKey={rowKey} index={index} style={style}>
       {/* Name */}
-      <TableData className={tableColumnClasses[0]}>
+      <TableData className={nameColumnClass}>
         <Link to={route}>
           <ClusterServiceVersionLogo
             icon={null}
@@ -339,31 +412,42 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
         </Link>
       </TableData>
 
-      {/* Namespace */}
-      <TableData className={tableColumnClasses[1]}>
-        <ResourceLink kind="Namespace" title={namespace} name={namespace} />
+      {/* Operator Namespace */}
+      {activeNamespace === ALL_NAMESPACES_KEY ? (
+        <TableData className={namespaceColumnClass}>
+          <ResourceLink kind="Namespace" title={namespace} name={namespace} />
+        </TableData>
+      ) : null}
+
+      {/* Managed Namespaces */}
+      <TableData className={managedNamespacesColumnClass}>
+        <span className="text-muted">None</span>
       </TableData>
 
       {/* Status */}
-      <TableData className={tableColumnClasses[3]}>{getStatus()}</TableData>
+      <TableData className={statusColumnClass}>{getStatus()}</TableData>
 
-      {/* Deployment */}
-      <TableData className={tableColumnClasses[2]}>
-        <span className="text-muted">None</span>
+      {/* Last Updated */}
+      <TableData className={lastUpdatedColumnClass}>
+        {obj.status == null ? '-' : fromNow(obj.status.lastUpdated)}
       </TableData>
 
       {/* Provided APIs */}
-      <TableData className={tableColumnClasses[4]}>
+      <TableData className={providedAPIsColumnClass}>
         <span className="text-muted">None</span>
       </TableData>
 
-      {/* Kabob */}
-      <TableData className={tableColumnClasses[5]}>
+      {/* Kebab */}
+      <TableData className={Kebab.columnClass}>
         <ResourceKebab resource={obj} kind={referenceFor(obj)} actions={menuActions} />
       </TableData>
     </TableRow>
   );
 };
+
+export const SubscriptionTableRow = connect(clusterServiceVersionStateToProps)(
+  NamespacedSubscriptionTableRow,
+);
 
 const InstalledOperatorTableRow: React.FC<InstalledOperatorTableRowProps> = ({
   obj,
@@ -396,21 +480,24 @@ const InstalledOperatorTableRow: React.FC<InstalledOperatorTableRowProps> = ({
 
 const NoOperatorsMatchFilterMsg = () => <MsgBox title="No Operators Found" />;
 
-export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps> = ({
+export const NamespacedClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps> = ({
+  activeNamespace,
   subscriptions,
   catalogSources,
+  data,
   ...rest
 }) => {
-  const ns = UIActions.getActiveNamespace();
   const noDataDetail = (
     <>
       <div>
         No Operators are available
-        {ns !== ALL_NAMESPACES_KEY && (
+        {activeNamespace !== ALL_NAMESPACES_KEY && (
           <>
             {' '}
             for project{' '}
-            <span className="co-clusterserviceversion-empty__state__namespace">{ns}</span>
+            <span className="co-clusterserviceversion-empty__state__namespace">
+              {activeNamespace}
+            </span>
           </>
         )}
         .
@@ -422,11 +509,55 @@ export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps
   );
   const NoDataEmptyMsg = () => <MsgBox title="No Operators Found" detail={noDataDetail} />;
 
-  return (
+  const isCopiedCSV = (source, kind) => {
+    return (
+      referenceForModel(ClusterServiceVersionModel) === kind && source.status?.reason === 'Copied'
+    );
+  };
+
+  const removeCopiedCSVs = (operators: (ClusterServiceVersionKind | SubscriptionKind)[]) => {
+    return operators.filter((source) => {
+      const kind = referenceFor(source);
+      if (isSubscription(kind)) {
+        return true;
+      }
+      return !isCopiedCSV(source, kind);
+    });
+  };
+
+  const formatTargetNamespaces = (obj: ClusterServiceVersionKind | SubscriptionKind): string => {
+    if (obj.kind === 'Subscription') {
+      return 'None';
+    }
+
+    const namespaces = obj.metadata.annotations?.['olm.targetNamespaces']?.split(',') || [];
+
+    if (namespaces.length === 1 && namespaces[0] === '') {
+      return 'All Namespaces';
+    }
+
+    switch (namespaces.length) {
+      case 0:
+        return 'All Namespaces';
+      case 1:
+        return namespaces[0];
+      default:
+        return `${namespaces.length} Namespaces`;
+    }
+  };
+  const getOperatorNamespace = (
+    obj: ClusterServiceVersionKind | SubscriptionKind,
+  ): string | null => {
+    const olmOperatorNamespace = obj.metadata?.annotations?.['olm.operatorNamespace'];
+    return olmOperatorNamespace ?? getNamespace(obj);
+  };
+
+  return activeNamespace === ALL_NAMESPACES_KEY ? (
     <Table
+      data={removeCopiedCSVs(data) as any[]}
       {...rest}
       aria-label="Installed Operators"
-      Header={ClusterServiceVersionTableHeader}
+      Header={AllProjectsTableHeader}
       Row={(rowArgs: RowFunctionArgs<ClusterServiceVersionKind | SubscriptionKind>) => (
         <InstalledOperatorTableRow
           obj={rowArgs.obj}
@@ -440,9 +571,41 @@ export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps
       EmptyMsg={NoOperatorsMatchFilterMsg}
       NoDataEmptyMsg={NoDataEmptyMsg}
       virtualize
+      customSorts={{
+        formatTargetNamespaces,
+        getOperatorNamespace,
+      }}
+    />
+  ) : (
+    <Table
+      data={data}
+      {...rest}
+      aria-label="Installed Operators"
+      Header={SingleProjectTableHeader}
+      Row={(rowArgs: RowFunctionArgs<ClusterServiceVersionKind | SubscriptionKind>) => (
+        <InstalledOperatorTableRow
+          obj={rowArgs.obj}
+          index={rowArgs.index}
+          rowKey={rowArgs.key}
+          style={rowArgs.style}
+          catalogSources={catalogSources.data}
+          subscriptions={subscriptions.data}
+        />
+      )}
+      EmptyMsg={NoOperatorsMatchFilterMsg}
+      NoDataEmptyMsg={NoDataEmptyMsg}
+      virtualize
+      customSorts={{
+        formatTargetNamespaces,
+        getOperatorNamespace,
+      }}
     />
   );
 };
+
+export const ClusterServiceVersionList = connect(clusterServiceVersionStateToProps)(
+  NamespacedClusterServiceVersionList,
+);
 
 export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProps> = (props) => {
   const title = 'Installed Operators';
@@ -602,8 +765,10 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
   props,
 ) => {
   const { spec, metadata, status } = props.obj;
-  const { 'marketplace.openshift.io/support-workflow': marketplaceSupportWorkflow } =
-    metadata.annotations || {};
+  const {
+    'marketplace.openshift.io/support-workflow': marketplaceSupportWorkflow,
+    'olm.targetNamespaces': olmTargetNamespaces = '',
+  } = metadata.annotations || {};
 
   return (
     <>
@@ -686,7 +851,30 @@ export const ClusterServiceVersionDetails: React.SFC<ClusterServiceVersionDetail
         <div className="co-m-pane__body-group">
           <div className="row">
             <div className="col-sm-6">
-              <ResourceSummary resource={props.obj} />
+              <ResourceSummary resource={props.obj}>
+                <dt>
+                  <Popover
+                    headerContent={<div>Managed Namespaces</div>}
+                    bodyContent={<div>Operands in this Namespace are managed by the Operator.</div>}
+                    maxWidth="30rem"
+                  >
+                    <Button variant="plain" className="co-m-pane__details-popover-button">
+                      Managed Namespaces
+                    </Button>
+                  </Popover>
+                </dt>
+                <dd>
+                  {olmTargetNamespaces === '' ? (
+                    <span className="text-muted">All Namespaces</span>
+                  ) : (
+                    <ResourceLink
+                      kind="Namespace"
+                      name={props.obj.metadata.namespace}
+                      title={props.obj.metadata.uid}
+                    />
+                  )}
+                </dd>
+              </ResourceSummary>
             </div>
             <div className="col-sm-6">
               <dt>Status</dt>
@@ -894,6 +1082,7 @@ export type ClusterServiceVersionListProps = {
   data: ClusterServiceVersionKind[];
   subscriptions: FirehoseResult<SubscriptionKind[]>;
   catalogSources: FirehoseResult<CatalogSourceKind[]>;
+  activeNamespace?: string;
 };
 
 export type CRDCardProps = {
@@ -936,6 +1125,7 @@ export type ClusterServiceVersionTableRowProps = {
   style: object;
   catalogSourceMissing: boolean;
   subscription: SubscriptionKind;
+  activeNamespace?: string;
 };
 
 type SubscriptionTableRowProps = {
@@ -944,6 +1134,11 @@ type SubscriptionTableRowProps = {
   rowKey: string;
   style: object;
   catalogSourceMissing: boolean;
+  activeNamespace?: string;
+};
+
+type ManagedNamespacesProps = {
+  obj: ClusterServiceVersionKind;
 };
 
 export type CSVSubscriptionProps = {
@@ -954,11 +1149,25 @@ export type CSVSubscriptionProps = {
   subscriptions: SubscriptionKind[];
 };
 
+type ClusterServiceVersionStateProps = {
+  activeNamespace?: string;
+};
+
+type Header = {
+  title: string;
+  sortField?: string;
+  sortFunc?: string;
+  transforms?: any;
+  props: { className: string };
+};
+
 // TODO(alecmerdler): Find Webpack loader/plugin to add `displayName` to React components automagically
 ClusterServiceVersionList.displayName = 'ClusterServiceVersionList';
+NamespacedClusterServiceVersionList.displayName = 'ClusterServiceVersionList';
 ClusterServiceVersionsPage.displayName = 'ClusterServiceVersionsPage';
 ClusterServiceVersionTableRow.displayName = 'ClusterServiceVersionTableRow';
-ClusterServiceVersionTableHeader.displayName = 'ClusterServiceVersionTableHeader';
+SingleProjectTableHeader.displayName = 'SingleProjectClusterServiceVersionTableHeader';
+AllProjectsTableHeader.displayName = 'AllProjectsClusterServiceVersionTableHeader';
 CRDCard.displayName = 'CRDCard';
 ClusterServiceVersionsDetailsPage.displayName = 'ClusterServiceVersionsDetailsPage';
 ClusterServiceVersionDetails.displayName = 'ClusterServiceVersionDetails';

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -29,6 +29,10 @@ $co-affinity-row-margin: 15px;
   padding-bottom: 10px;
 }
 
+.co-clusterserviceversion-table-header__icon {
+  margin-left: var(--pf-global--spacer--xs);
+}
+
 .co-clusterserviceversion-link {
   .co-clusterserviceversion-logo {
     flex-direction: column;

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -20,6 +20,7 @@ import {
   getJobTypeAndCompletions,
   getTemplateInstanceStatus,
   K8sResourceKind,
+  K8sResourceKindReference,
   NodeKind,
   planExternalName,
   PodKind,
@@ -385,6 +386,14 @@ type TableOptionProps = {
   UI: any;
 };
 
+type ComponentProps = {
+  data?: any[];
+  filters?: Object;
+  selected?: any;
+  match?: any;
+  kindObj?: K8sResourceKindReference;
+};
+
 export const Table = connect<
   TablePropsFromState,
   TablePropsFromDispatch,
@@ -430,7 +439,7 @@ export const Table = connect<
 
     constructor(props) {
       super(props);
-      const componentProps: any = _.pick(props, [
+      const componentProps: ComponentProps = _.pick(props, [
         'data',
         'filters',
         'selected',
@@ -457,11 +466,18 @@ export const Table = connect<
           sortBy = { index: columnIndex + this._columnShift, direction: currentSortOrder };
         }
       }
-      this.state = { columns, sortBy };
+      this.state = { sortBy };
     }
 
     componentDidMount() {
-      const { columns } = this.state;
+      const componentProps: ComponentProps = _.pick(this.props, [
+        'data',
+        'filters',
+        'selected',
+        'match',
+        'kindObj',
+      ]);
+      const columns = this.props.Header(componentProps);
       const sp = new URLSearchParams(window.location.search);
       const columnIndex = _.findIndex(columns, { title: sp.get('sortBy') });
 
@@ -503,7 +519,15 @@ export const Table = connect<
 
     _onSort(event, index, direction) {
       event.preventDefault();
-      const sortColumn = this.state.columns[index - this._columnShift];
+      const componentProps: ComponentProps = _.pick(this.props, [
+        'data',
+        'filters',
+        'selected',
+        'match',
+        'kindObj',
+      ]);
+      const columns = this.props.Header(componentProps);
+      const sortColumn = columns[index - this._columnShift];
       this._applySort(
         sortColumn.sortField,
         sortColumn.sortFunc,
@@ -533,8 +557,9 @@ export const Table = connect<
         virtualize = true,
         customData,
         gridBreakPoint = TableGridBreakpoint.none,
+        Header,
       } = this.props;
-      const { sortBy, columns } = this.state;
+      const { sortBy } = this.state;
       const componentProps: any = _.pick(this.props, [
         'data',
         'filters',
@@ -542,6 +567,7 @@ export const Table = connect<
         'match',
         'kindObj',
       ]);
+      const columns = Header(componentProps);
       const ariaRowCount = componentProps.data && componentProps.data.length;
       const scrollNode = typeof scrollElement === 'function' ? scrollElement() : scrollElement;
       const renderVirtualizedTable = (scrollContainer) => (
@@ -660,6 +686,5 @@ export type TableInnerProps = {
 };
 
 export type TableInnerState = {
-  columns?: any[];
   sortBy: object;
 };


### PR DESCRIPTION
Fixes 98% of https://issues.redhat.com/browse/CONSOLE-2130.

## Changes
- I removed the "Deployment" column and added a "Last Updated" column.
- If "All Projects" is selected in the project selector, there is 1 row per installation of an operator/subscription:
    - If Operator X is installed globally, there is 1 row
    - If Operator X is installed in one namespace, there is 1 row
    - If Operator X is installed twice in Namespace A and Namespace B, there are 2 rows, a row per install.
- I added an "Operator Namespace" column indicating where the operator itself is installed (present on all projects view).
    - The column includes a "namespace-name" which is linked to the namespace
    - If the operator is installed globally, the muted text below "namespace-name" is "All Namespaces"
- I added a "Managed Namespace(s)" column indicating the namespace(s) that the operator is watching.
    - If the operator is global, it lists "All Namepaces" in muted text
    - If the operator is not global, it lists the namespace(s) that it is watching
    - I added a popover to list out namespaces if the list is 2+ to ensure the row doesn't blow up
- I changed the "Namespace" field on the Operator Details page to "Managed Namespace"
- I changed the "Namespace" field on the Operator Subscriptions page to "Operator Namespace"

The PatternFly React table does not currently support popovers in sortable headers, so that will be done as a follow-on. (I created this issue to track this: https://issues.redhat.com/browse/CONSOLE-2168.)

## Screenshots
Before:
<img width="995" alt="Screen Shot 2020-03-30 at 12 12 15 PM" src="https://user-images.githubusercontent.com/7014965/77936474-f630e000-7280-11ea-91da-721538eb758c.png">

After (all projects):
<img width="1034" alt="Screen Shot 2020-03-30 at 5 31 04 PM" src="https://user-images.githubusercontent.com/7014965/77963959-47a29480-72ac-11ea-989c-b316da9614e7.png">

After (single project):
<img width="1034" alt="Screen Shot 2020-03-30 at 5 30 04 PM" src="https://user-images.githubusercontent.com/7014965/77963915-348fc480-72ac-11ea-9b2c-b93d05799792.png">

Multinamespace:
<img width="964" alt="Screen Shot 2020-03-30 at 12 25 53 PM" src="https://user-images.githubusercontent.com/7014965/77936982-a999d480-7281-11ea-9588-c395d0aec0d4.png">

All namespaces:
<img width="999" alt="Screen Shot 2020-03-30 at 2 41 04 PM" src="https://user-images.githubusercontent.com/7014965/77949202-89bfdc00-7294-11ea-8abf-04a77e608bb1.png">

Subscription:
![77947237-a0b0ff00-7291-11ea-96f3-b124ad29f7bb](https://user-images.githubusercontent.com/7014965/78054245-c00e6180-734f-11ea-8086-bd9984a87762.png)

CSV Details Page:
<img width="756" alt="Screen Shot 2020-03-30 at 5 28 27 PM" src="https://user-images.githubusercontent.com/7014965/77963801-014d3580-72ac-11ea-8d08-1ce8b1fb7537.png">

Subscription Details Page:
<img width="576" alt="Screen Shot 2020-03-31 at 12 22 07 PM" src="https://user-images.githubusercontent.com/7014965/78050515-517ad500-734a-11ea-83e3-45f2c9231959.png">

Heads up @openshift/team-ux-review.