### PR TITLE
Update Helm actions to say Uninstall instead of Delete

### DIFF
--- a/frontend/packages/dev-console/src/actions/modify-helm-release.ts
+++ b/frontend/packages/dev-console/src/actions/modify-helm-release.ts
@@ -3,12 +3,13 @@ import { deleteResourceModal } from '../components/modals';
 
 export const deleteHelmRelease = (releaseName: string, namespace: string, redirect?: string) => {
   return {
-    label: 'Delete Helm Release',
+    label: 'Uninstall Helm Release',
     callback: () => {
       deleteResourceModal({
         blocking: true,
         resourceName: releaseName,
         resourceType: 'Helm Release',
+        actionLabel: 'Uninstall',
         redirect,
         onSubmit: () => {
           return coFetchJSON.delete(`/api/helm/release?name=${releaseName}&ns=${namespace}`);

--- a/frontend/packages/dev-console/src/components/modals/DeleteResourceModal.tsx
+++ b/frontend/packages/dev-console/src/components/modals/DeleteResourceModal.tsx
@@ -14,6 +14,7 @@ import { K8sResourceKind } from '@console/internal/module/k8s';
 type DeleteResourceModalProps = {
   resourceName: string;
   resourceType: string;
+  actionLabel?: string;
   redirect?: string;
   onSubmit: (values: FormikValues) => Promise<K8sResourceKind[]>;
   cancel?: () => void;
@@ -29,6 +30,7 @@ const DeleteResourceForm: React.FC<FormikProps<FormikValues> & DeleteResourceMod
   handleSubmit,
   resourceName,
   resourceType,
+  actionLabel = 'Delete',
   isSubmitting,
   cancel,
   values,
@@ -38,7 +40,7 @@ const DeleteResourceForm: React.FC<FormikProps<FormikValues> & DeleteResourceMod
   return (
     <form onSubmit={handleSubmit} className="modal-content modal-content--no-inner-scroll">
       <ModalTitle>
-        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Delete {resourceType}?
+        <YellowExclamationTriangleIcon className="co-icon-space-r" /> {actionLabel} {resourceType}?
       </ModalTitle>
       <ModalBody>
         <p>
@@ -52,7 +54,7 @@ const DeleteResourceForm: React.FC<FormikProps<FormikValues> & DeleteResourceMod
         <InputField type={TextInputTypes.text} name="resourceName" />
       </ModalBody>
       <ModalSubmitFooter
-        submitText="Delete"
+        submitText={actionLabel}
         submitDisabled={(status && !!status.submitError) || !isValid}
         cancel={cancel}
         inProgress={isSubmitting}


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3059

**Analysis / Root cause**: 
Current Helm Delete actions and modal has word Delete instead of `Uninstall` as per UXD

**Solution Description**: 
Update the actions and modal to say `Uninstall`

**Screen shots / Gifs for design review**: 
![Peek 2020-03-26 23-39](https://user-images.githubusercontent.com/6041994/77681214-0d3eac00-6fbb-11ea-8743-f8dbdccf80e4.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge