### PR TITLE
Add Release Notes tab to helm details views

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseList.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
 import { FirehoseResult } from '@console/internal/components/utils';
 import { useDeepCompareMemoize } from '@console/shared';
-import { coFetchJSON } from '@console/internal/co-fetch';
 import { SortByDirection } from '@patternfly/react-table';
 import CustomResourceList from '../custom-resource-list/CustomResourceList';
-import { helmRowFilters, getFilteredItemsByRow, getFilteredItemsByText } from './helm-utils';
+import {
+  helmRowFilters,
+  getFilteredItemsByRow,
+  getFilteredItemsByText,
+  fetchHelmReleases,
+} from './helm-utils';
 import HelmReleaseRow from './HelmReleaseRow';
 import HelmReleaseHeader from './HelmReleaseHeader';
 import { HelmRelease } from './helm-types';
@@ -18,7 +22,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets })
   const memoizedSecrets = useDeepCompareMemoize(secrets?.data);
 
   const getHelmReleases = (): Promise<HelmRelease[]> => {
-    return coFetchJSON(`/api/helm/releases?ns=${namespace}`);
+    return fetchHelmReleases(namespace);
   };
 
   return (

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseNotes.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseNotes.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import { HelmRelease } from './helm-types';
+
+export interface HelmReleaseNotesProps {
+  customData: HelmRelease;
+}
+
+const HelmReleaseNotes: React.FC<HelmReleaseNotesProps> = ({ customData }) => {
+  const helmReleaseNotes = customData?.info?.notes ?? '';
+  return (
+    <div className="co-m-pane__body">
+      <SyncMarkdownView content={helmReleaseNotes} />
+    </div>
+  );
+};
+
+export default HelmReleaseNotes;

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseResources.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseResources.tsx
@@ -1,60 +1,34 @@
 import * as React from 'react';
+import { match as RMatch } from 'react-router';
 import { safeLoadAll } from 'js-yaml';
 import { MultiListPage } from '@console/internal/components/factory';
 import { FirehoseResource } from '@console/internal/components/utils';
-import { coFetchJSON } from '@console/internal/co-fetch';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { flattenResources } from './helm-release-resources-utils';
 import HelmResourcesListComponent from './HelmResourcesListComponent';
 import { HelmRelease } from './helm-types';
-import { match as RMatch } from 'react-router';
 
 export interface HelmReleaseResourcesProps {
   match: RMatch<{
     ns?: string;
     name?: string;
   }>;
+  customData: HelmRelease;
 }
 
-const HelmReleaseResources: React.FC<HelmReleaseResourcesProps> = ({ match }) => {
+const HelmReleaseResources: React.FC<HelmReleaseResourcesProps> = ({ match, customData }) => {
   const namespace = match.params.ns;
-  const helmReleaseName = match.params.name;
-  const [helmManifestResources, setHelmManifestResources] = React.useState<FirehoseResource[]>([]);
-
-  React.useEffect(() => {
-    let ignore = false;
-
-    const fetchHelmReleases = async () => {
-      let res: HelmRelease[];
-      try {
-        res = await coFetchJSON(`/api/helm/releases?ns=${namespace}`);
-      } catch {
-        return;
-      }
-      if (ignore) return;
-
-      const releaseData = res?.filter((rel) => rel.name === helmReleaseName);
-      const helmManifest = safeLoadAll(releaseData[0].manifest);
-
-      const resources: FirehoseResource[] = helmManifest.map((resource: K8sResourceKind) => ({
-        kind: resource.kind,
-        name: resource.metadata.name,
-        namespace,
-        prop: `${resource.metadata.name}-${resource.kind.toLowerCase()}`,
-        isList: false,
-        optional: true,
-      }));
-
-      setHelmManifestResources(resources);
-    };
-
-    fetchHelmReleases();
-
-    return () => {
-      ignore = true;
-    };
-  }, [helmReleaseName, namespace]);
-
+  const helmManifest = customData ? safeLoadAll(customData.manifest) : [];
+  const helmManifestResources: FirehoseResource[] = helmManifest.map(
+    (resource: K8sResourceKind) => ({
+      kind: resource.kind,
+      name: resource.metadata.name,
+      namespace,
+      prop: `${resource.metadata.name}-${resource.kind.toLowerCase()}`,
+      isList: false,
+      optional: true,
+    }),
+  );
   return (
     <MultiListPage
       filterLabel="Resources by name"

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseDetailsPage.spec.tsx
@@ -3,9 +3,11 @@ import { shallow } from 'enzyme';
 import { ErrorPage404 } from '@console/internal/components/error';
 import { DetailsPage } from '@console/internal/components/factory';
 import { LoadingBox, StatusBox } from '@console/internal/components/utils';
-import HelmReleaseDetailsPage from '../HelmReleaseDetailsPage';
+import HelmReleaseDetailsPage, { LoadedHelmReleaseDetailsPage } from '../HelmReleaseDetailsPage';
+import { mockHelmReleases } from './helm-release-mock-data';
 
 let helmReleaseDetailsPageProps: React.ComponentProps<typeof HelmReleaseDetailsPage>;
+let loadedHelmReleaseDetailsPageProps: React.ComponentProps<typeof LoadedHelmReleaseDetailsPage>;
 
 describe('HelmReleaseDetailsPage', () => {
   beforeEach(() => {
@@ -37,32 +39,43 @@ describe('HelmReleaseDetailsPage', () => {
         path: '/helm-releases/ns/xyz/release/:name',
       },
     };
+    loadedHelmReleaseDetailsPageProps = {
+      ...helmReleaseDetailsPageProps,
+      helmReleaseData: mockHelmReleases[0],
+    };
+  });
+  it('should show the loading box if helm release data is not loaded', () => {
+    loadedHelmReleaseDetailsPageProps.helmReleaseData = null;
+    const helmReleaseDetailsPage = shallow(
+      <LoadedHelmReleaseDetailsPage {...loadedHelmReleaseDetailsPageProps} />,
+    );
+    expect(helmReleaseDetailsPage.find(LoadingBox).exists()).toBe(true);
   });
   it('should show the loading box if secret is not loaded', () => {
-    helmReleaseDetailsPageProps.secret.loaded = false;
-    helmReleaseDetailsPageProps.secret.loadError = undefined;
+    loadedHelmReleaseDetailsPageProps.secret.loaded = false;
+    loadedHelmReleaseDetailsPageProps.secret.loadError = undefined;
     const helmReleaseDetailsPage = shallow(
-      <HelmReleaseDetailsPage {...helmReleaseDetailsPageProps} />,
+      <LoadedHelmReleaseDetailsPage {...loadedHelmReleaseDetailsPageProps} />,
     );
     expect(helmReleaseDetailsPage.find(LoadingBox).exists()).toBe(true);
   });
   it('should show the status box if there is an error loading the secret', () => {
-    helmReleaseDetailsPageProps.secret.loadError = 'error 404';
+    loadedHelmReleaseDetailsPageProps.secret.loadError = 'error 404';
     const helmReleaseDetailsPage = shallow(
-      <HelmReleaseDetailsPage {...helmReleaseDetailsPageProps} />,
+      <LoadedHelmReleaseDetailsPage {...loadedHelmReleaseDetailsPageProps} />,
     );
     expect(helmReleaseDetailsPage.find(StatusBox).exists()).toBe(true);
   });
   it('should render the DetailsPage component when secret gets loaded', () => {
     const helmReleaseDetailsPage = shallow(
-      <HelmReleaseDetailsPage {...helmReleaseDetailsPageProps} />,
+      <LoadedHelmReleaseDetailsPage {...loadedHelmReleaseDetailsPageProps} />,
     );
     expect(helmReleaseDetailsPage.find(DetailsPage).exists()).toBe(true);
   });
   it('should show the ErrorPage404 for an incorrect release name in the url', () => {
-    helmReleaseDetailsPageProps.secret.data = [];
+    loadedHelmReleaseDetailsPageProps.secret.data = [];
     const helmReleaseDetailsPage = shallow(
-      <HelmReleaseDetailsPage {...helmReleaseDetailsPageProps} />,
+      <LoadedHelmReleaseDetailsPage {...loadedHelmReleaseDetailsPageProps} />,
     );
     expect(helmReleaseDetailsPage.find(ErrorPage404).exists()).toBe(true);
   });

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseNotes.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseNotes.spec.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import HelmReleaseNotes from '../HelmReleaseNotes';
+import { mockHelmReleases } from './helm-release-mock-data';
+
+describe('HelmReleaseNotes', () => {
+  it('should render the SyncMarkdownView component when notes are available', () => {
+    const helmReleaseResources = mount(<HelmReleaseNotes customData={mockHelmReleases[0]} />);
+    expect(helmReleaseResources.find(SyncMarkdownView).exists()).toBe(true);
+  });
+});

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResources.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseResources.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { MultiListPage } from '@console/internal/components/factory';
 import HelmReleaseResources from '../HelmReleaseResources';
+import { mockHelmReleases } from './helm-release-mock-data';
 
 describe('HelmReleaseResources', () => {
   const match = {
@@ -13,6 +14,7 @@ describe('HelmReleaseResources', () => {
 
   const helmReleaseResourcesProps: React.ComponentProps<typeof HelmReleaseResources> = {
     match,
+    customData: mockHelmReleases[0],
   };
 
   const helmReleaseResources = shallow(<HelmReleaseResources {...helmReleaseResourcesProps} />);

--- a/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/helm-release-mock-data.ts
@@ -10,7 +10,7 @@ export const mockHelmReleases: HelmRelease[] = [
       deleted: '',
       description: 'Install complete',
       status: 'deployed',
-      notes: '',
+      notes: 'ghost-test release notes',
     },
     chart: {
       metadata: {
@@ -70,7 +70,7 @@ export const mockHelmReleases: HelmRelease[] = [
       deleted: '',
       description: 'Install complete',
       status: 'failed',
-      notes: '',
+      notes: 'node-test-chart release notes',
     },
     chart: {
       metadata: {
@@ -99,7 +99,7 @@ export const mockHelmReleases: HelmRelease[] = [
       deleted: '',
       description: 'Install complete',
       status: 'pending-install',
-      notes: '',
+      notes: 'node-test-chart release notes',
     },
     chart: {
       metadata: {

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -43,6 +43,7 @@ export interface HelmReleaseResourcesData {
   releaseName: string;
   chartIcon: string;
   manifestResources: K8sResourceKind[];
+  releaseNotes: string;
 }
 
 export interface HelmReleaseResourcesMap {

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -1,4 +1,5 @@
 import * as fuzzy from 'fuzzysearch';
+import { coFetchJSON } from '@console/internal/co-fetch';
 import { HelmRelease, HelmReleaseStatus } from './helm-types';
 import { CustomResourceListRowFilter } from '../custom-resource-list/custom-resource-list-types';
 
@@ -53,4 +54,14 @@ export const getFilteredItemsByRow = (items: HelmRelease[], filter: string | str
 
 export const getFilteredItemsByText = (items: HelmRelease[], filter: string) => {
   return items.filter((release: HelmRelease) => fuzzy(filter, release.name));
+};
+
+export const fetchHelmReleases = (
+  namespace: string,
+  helmReleaseName?: string,
+): Promise<HelmRelease[]> => {
+  const fetchString = `/api/helm/releases?ns=${namespace}${
+    helmReleaseName ? `&name=${helmReleaseName}` : ''
+  }`;
+  return coFetchJSON(fetchString);
 };

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Firehose } from '@console/internal/components/utils';
-import { coFetchJSON } from '@console/internal/co-fetch';
 import * as plugins from '@console/internal/plugins';
 import { getResourceList } from '@console/shared';
 import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
@@ -12,6 +11,7 @@ import { transformTopologyData } from './data-transforms/data-transformer';
 import { allowedResources, getHelmReleaseKey, getServiceBindingStatus } from './topology-utils';
 import { TopologyDataModel, TopologyDataResources, TrafficData } from './topology-types';
 import { HelmReleaseResourcesMap } from '../helm/helm-types';
+import { fetchHelmReleases } from '../helm/helm-utils';
 
 export interface RenderProps {
   data?: TopologyDataModel;
@@ -64,7 +64,7 @@ const Controller: React.FC<ControllerProps> = ({
         return;
       }
 
-      coFetchJSON(`/api/helm/releases?ns=${namespace}`)
+      fetchHelmReleases(namespace)
         .then((releases) => {
           setHelmResourcesMap(
             releases.reduce((acc, release) => {
@@ -77,6 +77,7 @@ const Controller: React.FC<ControllerProps> = ({
                       releaseName: release.name,
                       chartIcon: release.chart.metadata.icon,
                       manifestResources,
+                      releaseNotes: release.info.notes,
                     };
                   }
                 });

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -2168,6 +2168,7 @@ export const sampleHelmResourcesMap = {
     releaseName: 'nodejs-helm',
     chartIcon: '',
     manifestResources: [sampleHelmChartDeploymentConfig],
+    releaseNotes: 'test release notes',
   },
 };
 

--- a/frontend/packages/dev-console/src/components/topology/actions/helmReleaseActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/helmReleaseActions.ts
@@ -6,5 +6,7 @@ import { deleteHelmRelease } from '../../../actions/modify-helm-release';
 export const helmReleaseActions = (helmRelease: Node): KebabOption[] => {
   const name = helmRelease.getLabel();
   const { namespace } = helmRelease.getData().groupResources[0].resources.obj.metadata;
-  return [deleteHelmRelease(name, namespace), ...regroupActions(helmRelease)];
+  return name && namespace
+    ? [deleteHelmRelease(name, namespace), ...regroupActions(helmRelease)]
+    : [];
 };

--- a/frontend/packages/dev-console/src/components/topology/actions/regroupActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/regroupActions.ts
@@ -17,6 +17,9 @@ export const regroupActions = (obj: Node, regroupChildren: boolean = false): Keb
     ];
   }
   const resource = obj.getData()?.resources?.obj;
+  if (!resource) {
+    return [];
+  }
   const resourceKind = modelFor(referenceFor(resource));
   return [
     {

--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseNotesPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseNotesPanel.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+
+type TopologyHelmReleaseNotesPanelProps = {
+  releaseNotes: string;
+};
+
+const TopologyHelmReleaseNotesPanel: React.SFC<TopologyHelmReleaseNotesPanelProps> = ({
+  releaseNotes,
+}) => (
+  <div className="overview__sidebar-pane-body">
+    {releaseNotes && <SyncMarkdownView content={releaseNotes} />}
+  </div>
+);
+
+export default TopologyHelmReleaseNotesPanel;

--- a/frontend/packages/dev-console/src/components/topology/helm/__tests__/TopologyHelmReleasePanel.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/__tests__/TopologyHelmReleasePanel.spec.tsx
@@ -1,8 +1,42 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
-import { SidebarSectionHeading } from '@console/internal/components/utils';
-import { mockManifest } from './mockData';
+import { shallow, mount } from 'enzyme';
+import { SidebarSectionHeading, StatusBox } from '@console/internal/components/utils';
+import { mockHelmReleaseNode, mockManifest, mockReleaseNotes } from './mockData';
 import TopologyHelmReleaseResourcesPanel from '../TopologyHelmReleaseResourcesPanel';
+import TopologyHelmReleaseNotesPanel from '../TopologyHelmReleaseNotesPanel';
+import { SyncMarkdownView } from '@console/internal/components/markdown-view';
+import { ConnectedTopologyHelmReleasePanel } from '../TopologyHelmReleasePanel';
+
+describe('TopologyHelmReleasePanel', () => {
+  it('should render the resources tab by default', () => {
+    const component = mount(
+      <ConnectedTopologyHelmReleasePanel helmRelease={mockHelmReleaseNode} />,
+    );
+    expect(component.find(TopologyHelmReleaseResourcesPanel)).toHaveLength(1);
+  });
+
+  it('should render the details tab when specified', () => {
+    const component = mount(
+      <ConnectedTopologyHelmReleasePanel
+        helmRelease={mockHelmReleaseNode}
+        selectedDetailsTab="Details"
+      />,
+    );
+    // Status box displayed because there is no mock secret
+    expect(component.find(StatusBox)).toHaveLength(1);
+  });
+
+  it('should render the release notes tab when specified', () => {
+    const component = mount(
+      <ConnectedTopologyHelmReleasePanel
+        helmRelease={mockHelmReleaseNode}
+        selectedDetailsTab="Release Notes"
+      />,
+    );
+    // Status box displayed because there is no mock secret
+    expect(component.find(TopologyHelmReleaseNotesPanel)).toHaveLength(1);
+  });
+});
 
 describe('TopologyHelmReleaseResourcesPanel', () => {
   const manifestResources = mockManifest;
@@ -12,5 +46,17 @@ describe('TopologyHelmReleaseResourcesPanel', () => {
       <TopologyHelmReleaseResourcesPanel manifestResources={manifestResources} />,
     );
     expect(component.find(SidebarSectionHeading)).toHaveLength(5);
+  });
+});
+
+describe('TopologyHelmReleaseNotesPanel', () => {
+  const releaseNotes = mockReleaseNotes;
+
+  it('should render markdown when release notes are given', () => {
+    let component = mount(<TopologyHelmReleaseNotesPanel releaseNotes={releaseNotes} />);
+    expect(component.find(SyncMarkdownView)).toHaveLength(1);
+
+    component = mount(<TopologyHelmReleaseNotesPanel releaseNotes="" />);
+    expect(component.find(SyncMarkdownView)).toHaveLength(0);
   });
 });

--- a/frontend/packages/dev-console/src/components/topology/helm/__tests__/mockData.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/__tests__/mockData.ts
@@ -1,3 +1,6 @@
+import { BaseNode } from '@console/topology/src/elements';
+import { TYPE_HELM_RELEASE } from '../components/const';
+
 export const mockManifest = [
   {
     kind: 'Secret',
@@ -49,3 +52,34 @@ export const mockManifest = [
     },
   },
 ];
+
+export const mockReleaseNotes =
+  // eslint-disable-next-line no-template-curly-in-string
+  'MySQL can be accessed via port 3306 on the following DNS name from within your cluster:\nmysql2.jeff-project.svc.cluster.local\n\nTo get your root password run:\n\n    MYSQL_ROOT_PASSWORD=$(kubectl get secret --namespace jeff-project mysql2 -o jsonpath="{.data.mysql-root-password}" | base64 --decode; echo)\n\nTo connect to your database:\n\n1. Run an Ubuntu pod that you can use as a client:\n\n    kubectl run -i --tty ubuntu --image=ubuntu:16.04 --restart=Never -- bash -il\n\n2. Install the mysql client:\n\n    $ apt-get update && apt-get install mysql-client -y\n\n3. Connect using the mysql cli, then provide your password:\n    $ mysql -h mysql2 -p\n\nTo connect to your database directly from outside the K8s cluster:\n    MYSQL_HOST=127.0.0.1\n    MYSQL_PORT=3306\n\n    # Execute the following command to route the connection:\n    kubectl port-forward svc/mysql2 3306\n\n    mysql -h ${MYSQL_HOST} -P${MYSQL_PORT} -u root -p${MYSQL_ROOT_PASSWORD}\n    \n';
+
+export const mockHelmReleaseNode = new BaseNode();
+const helmModel = {
+  id: 'mock-helm-release-id',
+  type: TYPE_HELM_RELEASE,
+  label: '',
+  data: {
+    resources: {},
+    groupResources: [
+      {
+        resources: {
+          obj: {
+            metadata: {
+              namespace: 'test-namespace',
+            },
+          },
+        },
+      },
+    ],
+    data: {
+      releaseName: '',
+      manifestResources: [],
+      releaseNotes: mockReleaseNotes,
+    },
+  },
+};
+mockHelmReleaseNode.setModel(helmModel);

--- a/frontend/packages/dev-console/src/components/topology/helm/helm-data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/helm-data-transformer.ts
@@ -41,6 +41,7 @@ export const getTopologyHelmReleaseGroupItem = (
   const resourceKindName = getHelmReleaseKey(obj);
   const helmResources = helmResourcesMap[resourceKindName];
   const releaseName = helmResources?.releaseName;
+  const releaseNotes = helmResources?.releaseNotes;
   const uid = _.get(obj, ['metadata', 'uid'], null);
   const returnData = { groups: [], dataModel: {} };
 
@@ -77,6 +78,7 @@ export const getTopologyHelmReleaseGroupItem = (
   };
   dataModel.data = {
     manifestResources: helmResources?.manifestResources || [],
+    releaseNotes,
   };
   returnData.dataModel[helmGroup.id] = dataModel;
   returnData.groups.push(helmGroup);

--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -60,11 +60,7 @@ export class SyncMarkdownView extends React.Component<
   }
 
   updateDimensions() {
-    if (
-      !this.frame ||
-      !this.frame.contentWindow.document.body ||
-      !this.frame.contentWindow.document.body.firstChild
-    ) {
+    if (!this.frame?.contentWindow?.document.body.firstChild) {
       return;
     }
     this.frame.style.height = `${this.frame.contentWindow.document.body.firstChild.scrollHeight}px`;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3309

**Analysis / Root cause:**
As a developer I want to access the helm release notes for my installation as it contains valuable information pertaining to my installation.

**Solution Description:**
Add the `Release Notes` tab to the helm release details page and helm release side panel in topology.

**Screen shots / Gifs for design review:**
![image](https://user-images.githubusercontent.com/11633780/77681935-7b0fb700-6f6c-11ea-9c2b-dabee6159d40.png)

![image](https://user-images.githubusercontent.com/11633780/77681953-81059800-6f6c-11ea-9a5b-f69d1c19a86a.png)

Test Coverage:
![image](https://user-images.githubusercontent.com/11633780/77682017-9c70a300-6f6c-11ea-8cbe-4a53ea89b0c7.png)

![image](https://user-images.githubusercontent.com/11633780/77682036-a7c3ce80-6f6c-11ea-817d-d7a73d30a034.png)

Browser Conformance:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge

/kind feature

cc @openshift/team-devconsole-ux 