### PR TITLE
Fix remaining Table.Row prop typings

### DIFF
--- a/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
+++ b/frontend/packages/console-app/src/components/nodes/NodesPage.tsx
@@ -6,7 +6,13 @@ import { sortable } from '@patternfly/react-table';
 import { getName, getUID } from '@console/shared';
 import { NodeModel } from '@console/internal/models';
 import { NodeKind, referenceForModel } from '@console/internal/module/k8s';
-import { Table, TableRow, TableData, ListPage } from '@console/internal/components/factory';
+import {
+  Table,
+  TableRow,
+  TableData,
+  ListPage,
+  RowFunctionArgs,
+} from '@console/internal/components/factory';
 import {
   Kebab,
   ResourceKebab,
@@ -103,7 +109,13 @@ type NodesRowMapFromStateProps = {
 };
 
 const NodesTableRow = connect<NodesRowMapFromStateProps, null, NodesTableRowProps>(mapStateToProps)(
-  ({ obj: node, index, key, style, metrics }: NodesTableRowProps & NodesRowMapFromStateProps) => {
+  ({
+    obj: node,
+    index,
+    rowKey,
+    style,
+    metrics,
+  }: NodesTableRowProps & NodesRowMapFromStateProps) => {
     const nodeName = getName(node);
     const nodeUID = getUID(node);
     const usedMem = metrics?.usedMemory?.[nodeName];
@@ -121,7 +133,7 @@ const NodesTableRow = connect<NodesRowMapFromStateProps, null, NodesTableRowProp
         : '-';
     const pods = metrics?.pods?.[nodeName] ?? '-';
     return (
-      <TableRow id={nodeUID} index={index} trKey={key} style={style}>
+      <TableRow id={nodeUID} index={index} trKey={rowKey} style={style}>
         <TableData className={tableColumnClasses[0]}>
           <ResourceLink kind={referenceForModel(NodeModel)} name={nodeName} title={nodeUID} />
         </TableData>
@@ -156,16 +168,23 @@ NodesTableRow.displayName = 'NodesTableRow';
 type NodesTableRowProps = {
   obj: NodeKind;
   index: number;
-  key?: string;
+  rowKey: string;
   style: object;
 };
 
 const NodesTable: React.FC<NodesTableProps> = React.memo((props) => {
-  const row = React.useCallback(
-    (rowProps: NodesTableRowProps) => <NodesTableRow {...rowProps} />,
+  const Row = React.useCallback(
+    (rowArgs: RowFunctionArgs<NodeKind>) => (
+      <NodesTableRow
+        obj={rowArgs.obj}
+        index={rowArgs.index}
+        rowKey={rowArgs.key}
+        style={rowArgs.style}
+      />
+    ),
     [],
   );
-  return <Table {...props} aria-label="Nodes" Header={NodeTableHeader} Row={row} virtualize />;
+  return <Table {...props} aria-label="Nodes" Header={NodeTableHeader} Row={Row} virtualize />;
 });
 
 type NodesTableProps = React.ComponentProps<typeof Table> & {

--- a/frontend/packages/dev-console/src/components/custom-resource-list/__tests__/CustomResourceList.spec.tsx
+++ b/frontend/packages/dev-console/src/components/custom-resource-list/__tests__/CustomResourceList.spec.tsx
@@ -2,12 +2,17 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as fuzzy from 'fuzzysearch';
 import { SortByDirection, sortable } from '@patternfly/react-table';
-import { TableRow, TableData, Table, TextFilter } from '@console/internal/components/factory';
+import {
+  TableRow,
+  TableData,
+  Table,
+  TextFilter,
+  RowFunction,
+} from '@console/internal/components/factory';
 import CustomResourceList from '../CustomResourceList';
 import {
   CustomResourceListProps,
   CustomResourceListRowFilter,
-  CustomResourceListRowProps,
 } from '../custom-resource-list-types';
 
 let customResourceListProps: CustomResourceListProps;
@@ -41,7 +46,7 @@ const MockTableHeader = () => {
   ];
 };
 
-const MockTableRow: React.FC<CustomResourceListRowProps> = ({ obj, index, key, style }) => (
+const MockTableRow: RowFunction = ({ obj, index, key, style }) => (
   <TableRow id={obj.name} index={index} trKey={key} style={style}>
     <TableData className={mockColumnClasses.name}>{obj.name}</TableData>
     <TableData className={mockColumnClasses.version}>{obj.version}</TableData>

--- a/frontend/packages/dev-console/src/components/custom-resource-list/custom-resource-list-types.ts
+++ b/frontend/packages/dev-console/src/components/custom-resource-list/custom-resource-list-types.ts
@@ -1,3 +1,4 @@
+import { RowFunction } from '@console/internal/components/factory';
 import { SortByDirection } from '@patternfly/react-table';
 
 export interface CustomResourceListRowFilter {
@@ -7,19 +8,12 @@ export interface CustomResourceListRowFilter {
   items: { [key: string]: any }[];
 }
 
-export interface CustomResourceListRowProps {
-  obj: { [key: string]: any };
-  index: number;
-  key?: string;
-  style: object;
-}
-
 export interface CustomResourceListProps {
   queryArg?: string;
   rowFilters?: CustomResourceListRowFilter[];
   sortBy: string;
   sortOrder: SortByDirection;
-  resourceRow: React.ComponentType<CustomResourceListRowProps>;
+  resourceRow: RowFunction;
   dependentResource?: any;
   resourceHeader: () => { [key: string]: any }[];
   fetchCustomResources: () => Promise<{ [key: string]: any }[]>;

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseHistoryRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseHistoryRow.tsx
@@ -1,17 +1,11 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Status } from '@console/shared';
-import { TableRow, TableData } from '@console/internal/components/factory';
+import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { Timestamp } from '@console/internal/components/utils';
 import { tableColumnClasses } from './HelmReleaseHistoryHeader';
-import { CustomResourceListRowProps } from '../custom-resource-list/custom-resource-list-types';
 
-const HelmReleaseHistoryRow: React.FC<CustomResourceListRowProps> = ({
-  obj,
-  index,
-  key,
-  style,
-}) => {
+const HelmReleaseHistoryRow: RowFunction = ({ obj, index, key, style }) => {
   return (
     <TableRow id={obj.revision} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses.revision}>{obj.version}</TableData>

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/vm-wizard-nic-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/networking-tab/vm-wizard-nic-row.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Kebab, KebabOption } from '@console/internal/components/utils';
+import { RowFunction } from '@console/internal/components/factory';
 import { NicSimpleRow } from '../../../vm-nics/nic-row';
 import { VMWizardNetworkWithWrappers } from '../../types';
 import { VMWizardNetworkBundle, VMWizardNicRowActionOpts, VMWizardNicRowCustomData } from './types';
@@ -46,14 +47,7 @@ const getActions = (
   return actions.map((a) => a(wizardNetworkData, opts));
 };
 
-export type VMWizardNicRowProps = {
-  obj: VMWizardNetworkBundle;
-  customData: VMWizardNicRowCustomData;
-  index: number;
-  style: object;
-};
-
-export const VMWizardNicRow: React.FC<VMWizardNicRowProps> = ({
+export const VMWizardNicRow: RowFunction<VMWizardNetworkBundle, VMWizardNicRowCustomData> = ({
   obj: { name, wizardNetworkData, ...restData },
   customData: { isDisabled, columnClasses, removeNIC, withProgress, wizardReduxID },
   index,

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/storage-tab/vm-wizard-storage-row.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Kebab, KebabOption } from '@console/internal/components/utils';
+import { RowFunction } from '@console/internal/components/factory';
 import { VMWizardStorageType, VMWizardStorageWithWrappers } from '../../types';
 import { DiskSimpleRow } from '../../../vm-disks/disk-row';
 import {
@@ -52,14 +53,10 @@ export const getActions = (
   opts: VMWizardStorageRowActionOpts,
 ) => [menuActionEdit, menuActionRemove].map((a) => a(wizardNetworkData, opts));
 
-export type VMWizardNicRowProps = {
-  obj: VMWizardStorageBundle;
-  customData: VMWizardStorageRowCustomData;
-  index: number;
-  style: object;
-};
-
-export const VmWizardStorageRow: React.FC<VMWizardNicRowProps> = ({
+export const VmWizardStorageRow: RowFunction<
+  VMWizardStorageBundle,
+  VMWizardStorageRowCustomData
+> = ({
   obj: { name, wizardStorageData, ...restData },
   customData: { isDisabled, columnClasses, removeStorage, withProgress, wizardReduxID },
   index,

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/virtual-hardware-tab/vm-wizard-virtualhardware-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/virtual-hardware-tab/vm-wizard-virtualhardware-row.tsx
@@ -1,18 +1,15 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Kebab } from '@console/internal/components/utils';
+import { RowFunction } from '@console/internal/components/factory';
 import { CDSimpleRow } from '../../../vm-disks/cd-row';
 import { VMWizardStorageBundle, VMWizardStorageRowCustomData } from '../storage-tab/types';
 import { getActions } from '../storage-tab/vm-wizard-storage-row';
 
-export type VmWizardVirtualHardwareRowProps = {
-  obj: VMWizardStorageBundle;
-  customData: VMWizardStorageRowCustomData;
-  index: number;
-  style: object;
-};
-
-export const VmWizardVirtualHardwareRow: React.FC<VmWizardVirtualHardwareRowProps> = ({
+export const VmWizardVirtualHardwareRow: RowFunction<
+  VMWizardStorageBundle,
+  VMWizardStorageRowCustomData
+> = ({
   obj: { name, wizardStorageData, ...restData },
   customData: { isDisabled, columnClasses, removeStorage, withProgress, wizardReduxID },
   index,

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/disk-row.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TableData, TableRow } from '@console/internal/components/factory';
+import { TableData, TableRow, RowFunction } from '@console/internal/components/factory';
 import {
   asAccessReview,
   Kebab,
@@ -141,14 +141,7 @@ export const DiskSimpleRow: React.FC<VMDiskSimpleRowProps> = ({
   );
 };
 
-export type VMDiskRowProps = {
-  obj: StorageBundle;
-  customData: VMStorageRowCustomData;
-  index: number;
-  style: object;
-};
-
-export const DiskRow: React.FC<VMDiskRowProps> = ({
+export const DiskRow: RowFunction<StorageBundle, VMStorageRowCustomData> = ({
   obj: { disk, ...restData },
   customData: { isDisabled, withProgress, vmLikeEntity, columnClasses, templateValidations },
   index,

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-cds.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-cds.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { Table } from '@console/internal/components/factory';
+import { Table, RowFunction } from '@console/internal/components/factory';
 import { dimensifyHeader } from '@console/shared';
 import { sortable } from '@patternfly/react-table';
 
 export type VMCDsTableProps = {
   data?: any[];
   customData?: object;
-  row: React.ComponentClass<any, any> | React.ComponentType<any>;
+  row: RowFunction;
   columnClasses: string[];
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-disks/vm-disks.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button, ButtonVariant } from '@patternfly/react-core';
-import { Table } from '@console/internal/components/factory';
+import { Table, RowFunction } from '@console/internal/components/factory';
 import { PersistentVolumeClaimModel, TemplateModel } from '@console/internal/models';
 import { Firehose, FirehoseResult, EmptyBox } from '@console/internal/components/utils';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
@@ -58,7 +58,7 @@ const getStoragesData = ({
 export type VMDisksTableProps = {
   data?: any[];
   customData?: object;
-  row: React.ComponentClass<any, any> | React.ComponentType<any>;
+  row: RowFunction;
   columnClasses: string[];
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/nic-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/nic-row.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TableData, TableRow } from '@console/internal/components/factory';
+import { TableData, TableRow, RowFunction } from '@console/internal/components/factory';
 import { asAccessReview, Kebab, KebabOption } from '@console/internal/components/utils';
 import { TemplateModel } from '@console/internal/models';
 import { DASH, dimensifyRow, getDeletetionTimestamp } from '@console/shared';
@@ -113,14 +113,7 @@ export const NicSimpleRow: React.FC<VMNicSimpleRowProps> = ({
   );
 };
 
-export type VMNicRowProps = {
-  obj: NetworkBundle;
-  customData: VMNicRowCustomData;
-  index: number;
-  style: object;
-};
-
-export const NicRow: React.FC<VMNicRowProps> = ({
+export const NicRow: RowFunction<NetworkBundle, VMNicRowCustomData> = ({
   obj: { name, nic, network, ...restData },
   customData: { isDisabled, withProgress, vmLikeEntity, columnClasses },
   index,

--- a/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-nics/vm-nics.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Table } from '@console/internal/components/factory';
+import { Table, RowFunction } from '@console/internal/components/factory';
 import { sortable } from '@patternfly/react-table';
 import { useSafetyFirst } from '@console/internal/components/safety-first';
 import { createBasicLookup, dimensifyHeader } from '@console/shared';
@@ -47,7 +47,7 @@ const getNicsData = (vmLikeEntity: VMGenericLikeEntityKind): NetworkBundle[] => 
 export type VMNicsTableProps = {
   data?: any[];
   customData?: object;
-  row: React.ComponentClass<any, any> | React.ComponentType<any>;
+  row: RowFunction;
   columnClasses: string[];
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -9,6 +9,7 @@ import {
   TableRow,
   TableData,
   MultiListPage,
+  RowFunction,
 } from '@console/internal/components/factory';
 import {
   Kebab,
@@ -106,13 +107,12 @@ const VMTemplateTableHeader = () =>
 
 VMTemplateTableHeader.displayName = 'VMTemplateTableHeader';
 
-const VMTemplateTableRow: React.FC<VMTemplateTableRowProps> = ({
-  obj: template,
-  customData: { dataVolumeLookup },
-  index,
-  key,
-  style,
-}) => {
+const VMTemplateTableRow: RowFunction<
+  TemplateKind,
+  {
+    dataVolumeLookup: K8sEntityMap<V1alpha1DataVolume>;
+  }
+> = ({ obj: template, customData: { dataVolumeLookup }, index, key, style }) => {
   const dimensify = dimensifyRow(tableColumnClasses);
   const os = getTemplateOperatingSystems([template])[0];
 
@@ -160,7 +160,6 @@ const VMTemplateTableRow: React.FC<VMTemplateTableRowProps> = ({
     </TableRow>
   );
 };
-VMTemplateTableRow.displayName = 'VmTemplateTableRow';
 
 type VirtualMachineTemplatesProps = {
   data: TemplateKind[];
@@ -247,16 +246,6 @@ const WrappedVirtualMachineTemplatesPage: React.FC<VirtualMachineTemplatesPagePr
 };
 
 const VirtualMachineTemplatesPage = withStartGuide(WrappedVirtualMachineTemplatesPage);
-
-type VMTemplateTableRowProps = {
-  obj: TemplateKind;
-  index: number;
-  key: string;
-  style: any;
-  customData: {
-    dataVolumeLookup: K8sEntityMap<V1alpha1DataVolume>;
-  };
-};
 
 type VirtualMachineTemplatesPageProps = {
   match: match<{ ns?: string }>;

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -18,7 +18,13 @@ import {
 import { withStartGuide } from '@console/internal/components/start-guide';
 import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
 import { NamespaceModel, PodModel, NodeModel } from '@console/internal/models';
-import { Table, MultiListPage, TableRow, TableData } from '@console/internal/components/factory';
+import {
+  Table,
+  MultiListPage,
+  TableRow,
+  TableData,
+  RowFunction,
+} from '@console/internal/components/factory';
 import { FirehoseResult, Kebab, ResourceLink } from '@console/internal/components/utils';
 import { fromNow } from '@console/internal/components/utils/datetime';
 import { K8sResourceKind, PodKind } from '@console/internal/module/k8s';
@@ -91,13 +97,14 @@ const VMHeader = () =>
     tableColumnClasses,
   );
 
-const VMRow: React.FC<VMRowProps> = ({
-  obj,
-  customData: { pods, migrations },
-  index,
-  key,
-  style,
-}) => {
+const VMRow: RowFunction<
+  VMRowObjType,
+  {
+    pods: PodKind[];
+    migrations: K8sResourceKind[];
+    vmiLookup: K8sEntityMap<VMIKind>;
+  }
+> = ({ obj, customData: { pods, migrations }, index, key, style }) => {
   const { vm, vmi, migration } = obj;
   const { name, namespace, node, creationTimestamp, uid, vmStatus } = obj.metadata;
   const dimensify = dimensifyRow(tableColumnClasses);
@@ -287,18 +294,6 @@ type VMRowObjType = {
   vm: VMKind;
   vmi: VMIKind;
   migration: VMIKind;
-};
-
-type VMRowProps = {
-  obj: VMRowObjType;
-  index: number;
-  key: string;
-  style: object;
-  customData: {
-    pods: PodKind[];
-    migrations: K8sResourceKind[];
-    vmiLookup: K8sEntityMap<VMIKind>;
-  };
 };
 
 type VMListProps = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -71,6 +71,7 @@ describe(ClusterServiceVersionTableRow.displayName, () => {
         obj={testClusterServiceVersion}
         subscription={testSubscription}
         index={0}
+        rowKey={'0'}
         style={{}}
       />,
     )
@@ -85,6 +86,7 @@ describe(ClusterServiceVersionTableRow.displayName, () => {
         obj={testClusterServiceVersion}
         subscription={testSubscription}
         index={0}
+        rowKey={'0'}
         style={{}}
       />,
     );

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -15,6 +15,7 @@ import {
   TableRow,
   TableData,
   MultiListPage,
+  RowFunctionArgs,
 } from '@console/internal/components/factory';
 import { withFallback } from '@console/shared/src/components/error/error-boundary';
 import {
@@ -207,7 +208,7 @@ const ClusterServiceVersionStatus: React.FC<ClusterServiceVersionStatusProps> = 
 };
 
 export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionTableRowProps>(
-  ({ obj, key, subscription, catalogSourceMissing, index, style }) => {
+  ({ obj, rowKey, subscription, catalogSourceMissing, index, style }) => {
     const { displayName, provider, version } = _.get(obj, 'spec');
     const [icon] = _.get(obj, 'spec.icon', []);
     const deploymentName = _.get(obj, 'spec.install.spec.deployments[0].name');
@@ -216,7 +217,7 @@ export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionT
     const uid = getUID(obj);
     const internalObjects = getInternalObjects(obj);
     return (
-      <TableRow id={uid} trKey={key} index={index} style={style}>
+      <TableRow id={uid} trKey={rowKey} index={index} style={style}>
         {/* Name */}
         <TableData className={tableColumnClasses[0]}>
           <Link
@@ -297,7 +298,7 @@ export const ClusterServiceVersionTableRow = withFallback<ClusterServiceVersionT
 
 const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
   catalogSourceMissing,
-  key,
+  rowKey,
   obj,
   index,
   style,
@@ -325,7 +326,7 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
   };
 
   return (
-    <TableRow id={uid} trKey={key} index={index} style={style}>
+    <TableRow id={uid} trKey={rowKey} index={index} style={style}>
       {/* Name */}
       <TableData className={tableColumnClasses[0]}>
         <Link to={route}>
@@ -365,8 +366,8 @@ const SubscriptionTableRow: React.FC<SubscriptionTableRowProps> = ({
 };
 
 const InstalledOperatorTableRow: React.FC<InstalledOperatorTableRowProps> = ({
-  catalogSources = [],
   obj,
+  catalogSources = [],
   subscriptions = [],
   ...rest
 }) => {
@@ -426,9 +427,12 @@ export const ClusterServiceVersionList: React.SFC<ClusterServiceVersionListProps
       {...rest}
       aria-label="Installed Operators"
       Header={ClusterServiceVersionTableHeader}
-      Row={(rowProps) => (
+      Row={(rowArgs: RowFunctionArgs<ClusterServiceVersionKind | SubscriptionKind>) => (
         <InstalledOperatorTableRow
-          {...rowProps}
+          obj={rowArgs.obj}
+          index={rowArgs.index}
+          rowKey={rowArgs.key}
+          style={rowArgs.style}
           catalogSources={catalogSources.data}
           subscriptions={subscriptions.data}
         />
@@ -917,29 +921,29 @@ export type ClusterServiceVersionDetailsProps = {
 };
 
 type InstalledOperatorTableRowProps = {
-  catalogSources: CatalogSourceKind[];
-  index: number;
-  key?: string;
   obj: ClusterServiceVersionKind | SubscriptionKind;
+  index: number;
+  rowKey: string;
   style: object;
+  catalogSources: CatalogSourceKind[];
   subscriptions: SubscriptionKind[];
 };
 
 export type ClusterServiceVersionTableRowProps = {
-  catalogSourceMissing: boolean;
-  index: number;
-  key?: string;
   obj: ClusterServiceVersionKind;
+  index: number;
+  rowKey: string;
   style: object;
+  catalogSourceMissing: boolean;
   subscription: SubscriptionKind;
 };
 
 type SubscriptionTableRowProps = {
-  catalogSourceMissing: boolean;
-  index: number;
-  key?: string;
   obj: SubscriptionKind;
+  index: number;
+  rowKey: string;
   style: object;
+  catalogSourceMissing: boolean;
 };
 
 export type CSVSubscriptionProps = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand.spec.tsx
@@ -57,7 +57,7 @@ describe(OperandTableRow.displayName, () => {
 
   beforeEach(() => {
     wrapper = shallow(
-      <OperandTableRow obj={testResourceInstance} index={0} style={{}} flags={{}} />,
+      <OperandTableRow obj={testResourceInstance} index={0} rowKey={'0'} style={{}} flags={{}} />,
     );
   });
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand.tsx
@@ -15,6 +15,7 @@ import {
   Table,
   TableRow,
   TableData,
+  RowFunctionArgs,
 } from '@console/internal/components/factory';
 import {
   Kebab,
@@ -304,12 +305,19 @@ export const OperandTableRow: React.FC<OperandTableRowProps> = ({
     </TableRow>
   );
 };
+
 // eslint-disable-next-line no-underscore-dangle
 export const OperandList_: React.FC<OperandListProps & WithFlagsProps> = (props) => {
   const { flags } = props;
   const Row = React.useCallback(
-    (rowProps: OperandTableRowProps) => (
-      <OperandTableRow {...rowProps} rowKey={rowProps.key} flags={flags ?? null} />
+    (rowArgs: RowFunctionArgs<K8sResourceKind>) => (
+      <OperandTableRow
+        obj={rowArgs.obj}
+        index={rowArgs.index}
+        rowKey={rowArgs.key}
+        style={rowArgs.style}
+        flags={flags ?? null}
+      />
     ),
     [flags],
   );
@@ -732,8 +740,7 @@ export type OperandesourceDetailsProps = {
 export type OperandTableRowProps = {
   obj: K8sResourceKind;
   index: number;
-  rowKey?: string;
-  key?: string;
+  rowKey: string;
   style: object;
   flags?: FlagsObject;
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/package-manifest.spec.tsx
@@ -36,6 +36,7 @@ describe(PackageManifestTableRow.displayName, () => {
     wrapper = shallow(
       <PackageManifestTableRow
         index={0}
+        rowKey={'0'}
         style={null}
         obj={testPackageManifest}
         catalogSourceNamespace={testCatalogSource.metadata.namespace}

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -275,7 +275,7 @@ const DeploymentConfigTableRow: RowFunction<K8sResourceKind> = ({ obj, index, ke
     <WorkloadTableRow
       obj={obj}
       index={index}
-      key={key}
+      rowKey={key}
       style={style}
       menuActions={menuActions}
       kind={kind}

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -7,7 +7,7 @@ import { configureUpdateStrategyModal, errorModal } from './modals';
 import { Conditions } from './conditions';
 import { ResourceEventStream } from './events';
 import { VolumesTable } from './volumes-table';
-import { DetailsPage, ListPage, Table } from './factory';
+import { DetailsPage, ListPage, Table, RowFunction } from './factory';
 import {
   AsyncComponent,
   DetailsItem,
@@ -236,24 +236,17 @@ type DeploymentDetailsProps = {
 
 const kind = 'Deployment';
 
-const DeploymentTableRow: React.FC<DeploymentTableRowProps> = ({ obj, index, key, style }) => {
+const DeploymentTableRow: RowFunction<DeploymentKind> = ({ obj, index, key, style }) => {
   return (
     <WorkloadTableRow
       obj={obj}
       index={index}
-      key={key}
+      rowKey={key}
       style={style}
       menuActions={menuActions}
       kind={kind}
     />
   );
-};
-DeploymentTableRow.displayName = 'DeploymentTableRow';
-type DeploymentTableRowProps = {
-  obj: DeploymentKind;
-  index: number;
-  key: string;
-  style: object;
 };
 
 const DeploymentTableHeader = () => {

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -289,7 +289,7 @@ const VirtualBody: React.SFC<VirtualBodyProps> = (props) => {
       style,
       customData,
     };
-    const row = (Row as RowFunction)(rowArgs as RowFunctionArgs);
+    const row = Row(rowArgs);
 
     // do not render non visible elements (this excludes overscan)
     if (!isVisible) {
@@ -331,18 +331,18 @@ const VirtualBody: React.SFC<VirtualBodyProps> = (props) => {
 export type RowFunctionArgs<T = any, C = any> = {
   obj: T;
   index: number;
-  columns: [];
+  columns: any[];
   isScrolling: boolean;
   key: string;
   style: object;
   customData?: C;
 };
 
-export type RowFunction<T = any, C = any> = (args: RowFunctionArgs<T, C>) => JSX.Element;
+export type RowFunction<T = any, C = any> = (args: RowFunctionArgs<T, C>) => React.ReactElement;
 
 export type VirtualBodyProps = {
   customData?: any;
-  Row: RowFunction | React.ComponentClass<any, any> | React.ComponentType<any>;
+  Row: RowFunction;
   height: number;
   isScrolling: boolean;
   onChildScroll: (...args) => any;
@@ -363,7 +363,7 @@ export type TableProps = {
   filters?: { [key: string]: any };
   Header: (...args) => any[];
   loadError?: string | Object;
-  Row?: RowFunction | React.ComponentClass<any, any> | React.ComponentType<any>;
+  Row?: RowFunction;
   Rows?: (...args) => any[];
   'aria-label': string;
   virtualize?: boolean;
@@ -630,7 +630,7 @@ export type TableInnerProps = {
   namespace?: string;
   reduxID?: string;
   reduxIDs?: string[];
-  Row?: RowFunction | React.ComponentClass<any, any> | React.ComponentType<any>;
+  Row?: RowFunction;
   Rows?: (...args) => any[];
   selector?: Object;
   sortList?: (

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -30,7 +30,7 @@ import {
   SilenceStates,
 } from '../reducers/monitoring';
 import store, { RootState } from '../redux';
-import { RowFunction, Table, TableData, TableRow, TextFilter } from './factory';
+import { Table, TableData, TableRow, TextFilter, RowFunction } from './factory';
 import { confirmModal } from './modals';
 import MonitoringDashboardsPage from './monitoring/dashboards';
 import { graphStateToProps, QueryBrowserPage, ToggleGraph } from './monitoring/metrics';
@@ -761,7 +761,7 @@ const tableAlertClasses = [
   Kebab.columnClass,
 ];
 
-const AlertTableRow: React.FC<AlertTableRowProps> = ({ obj, index, key, style }) => {
+const AlertTableRow: RowFunction<Alert> = ({ obj, index, key, style }) => {
   const { annotations = {}, labels } = obj;
   const state = alertState(obj);
 
@@ -800,12 +800,6 @@ const AlertTableRow: React.FC<AlertTableRowProps> = ({ obj, index, key, style })
       </TableData>
     </TableRow>
   );
-};
-type AlertTableRowProps = {
-  obj: Alert;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const AlertTableHeader = () => [
@@ -1117,7 +1111,7 @@ const SilenceRow = ({ obj }) => {
   );
 };
 
-const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, index, key, style }) => {
+const SilenceTableRow: RowFunction<Silence> = ({ obj, index, key, style }) => {
   const state = silenceState(obj);
 
   return (
@@ -1156,12 +1150,6 @@ const SilenceTableRow: React.FC<SilenceTableRowProps> = ({ obj, index, key, styl
       </TableData>
     </TableRow>
   );
-};
-type SilenceTableRowProps = {
-  obj: Silence;
-  index: number;
-  key?: string;
-  style: object;
 };
 
 const silencesRowFilter = {
@@ -1776,7 +1764,7 @@ export type ListPageProps = {
   match: { path: string };
   nameFilterID: string;
   reduxID: string;
-  Row: React.ComponentType<any>;
+  Row: RowFunction;
   rowFilter: {
     type: string;
     selected: string[];

--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -291,13 +291,13 @@ const projectRowStateToProps = ({ UI }) => ({
 });
 
 const ProjectTableRow = connect(projectRowStateToProps)(
-  ({ obj: project, index, key, style, customData = {}, metrics }) => {
+  ({ obj: project, index, rowKey, style, customData = {}, metrics }) => {
     const requester = getRequester(project);
     const { ProjectLinkComponent, actionsEnabled = true, showMetrics } = customData;
     const bytes = _.get(metrics, ['memory', project.metadata.name]);
     const cores = _.get(metrics, ['cpu', project.metadata.name]);
     return (
-      <TableRow id={project.metadata.uid} index={index} trKey={key} style={style}>
+      <TableRow id={project.metadata.uid} index={index} trKey={rowKey} style={style}>
         <TableData className={projectColumnClasses[0]}>
           {customData && ProjectLinkComponent ? (
             <ProjectLinkComponent project={project} />
@@ -346,7 +346,16 @@ const ProjectTableRow = connect(projectRowStateToProps)(
 );
 ProjectTableRow.displayName = 'ProjectTableRow';
 
-const Row = (rowProps) => <ProjectTableRow {...rowProps} />;
+const Row = (rowArgs) => (
+  <ProjectTableRow
+    obj={rowArgs.obj}
+    index={rowArgs.index}
+    rowKey={rowArgs.key}
+    style={rowArgs.style}
+    customData={rowArgs.customData}
+  />
+);
+
 export const ProjectsTable = (props) => (
   <Table
     {...props}

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -19,7 +19,7 @@ import {
 } from '../module/k8s/pods';
 import { getContainerState, getContainerStatus } from '../module/k8s/container';
 import { ResourceEventStream } from './events';
-import { DetailsPage, ListPage, Table, TableRow, TableData } from './factory';
+import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunctionArgs } from './factory';
 import {
   AsyncComponent,
   DetailsItem,
@@ -115,7 +115,7 @@ const podRowStateToProps = ({ UI }) => ({
 });
 
 const PodTableRow = connect<PodTableRowPropsFromState, null, PodTableRowProps>(podRowStateToProps)(
-  ({ obj: pod, index, key, style, metrics }: PodTableRowProps & PodTableRowPropsFromState) => {
+  ({ obj: pod, index, rowKey, style, metrics }: PodTableRowProps & PodTableRowPropsFromState) => {
     const { name, namespace, creationTimestamp } = pod.metadata;
     const { readyCount, totalContainers } = podReadiness(pod);
     const phase = podPhase(pod);
@@ -123,7 +123,7 @@ const PodTableRow = connect<PodTableRowPropsFromState, null, PodTableRowProps>(p
     const bytes: number = _.get(metrics, ['memory', namespace, name]);
     const cores: number = _.get(metrics, ['cpu', namespace, name]);
     return (
-      <TableRow id={pod.metadata.uid} index={index} trKey={key} style={style}>
+      <TableRow id={pod.metadata.uid} index={index} trKey={rowKey} style={style}>
         <TableData className={tableColumnClasses[0]}>
           <ResourceLink kind={kind} name={name} namespace={namespace} />
         </TableData>
@@ -489,7 +489,10 @@ export const PodsDetailsPage: React.FC<PodDetailsPageProps> = (props) => (
 );
 PodsDetailsPage.displayName = 'PodsDetailsPage';
 
-const Row = (rowProps: PodTableRowProps) => <PodTableRow {...rowProps} />;
+const Row = (rowArgs: RowFunctionArgs<PodKind>) => (
+  <PodTableRow obj={rowArgs.obj} index={rowArgs.index} rowKey={rowArgs.key} style={rowArgs.style} />
+);
+
 export const PodList: React.FC = (props) => (
   <Table {...props} aria-label="Pods" Header={PodTableHeader} Row={Row} virtualize />
 );
@@ -595,7 +598,7 @@ type PodDetailsProps = {
 type PodTableRowProps = {
   obj: PodKind;
   index: number;
-  key?: string;
+  rowKey: string;
   style: object;
 };
 

--- a/frontend/public/components/stateful-set.tsx
+++ b/frontend/public/components/stateful-set.tsx
@@ -32,7 +32,7 @@ const StatefulSetTableRow: RowFunction<K8sResourceKind> = ({ obj, index, key, st
     <WorkloadTableRow
       obj={obj}
       index={index}
-      key={key}
+      rowKey={key}
       style={style}
       menuActions={menuActions}
       kind={kind}

--- a/frontend/public/components/workload-table.tsx
+++ b/frontend/public/components/workload-table.tsx
@@ -27,13 +27,13 @@ const tableColumnClasses = [
 export const WorkloadTableRow: React.FC<WorkloadTableRowProps> = ({
   obj,
   index,
-  key,
+  rowKey,
   style,
   kind,
   menuActions,
 }) => {
   return (
-    <TableRow id={obj.metadata.uid} index={index} trKey={key} style={style}>
+    <TableRow id={obj.metadata.uid} index={index} trKey={rowKey} style={style}>
       <TableData className={tableColumnClasses[0]}>
         <ResourceLink
           kind={kind}
@@ -73,7 +73,7 @@ WorkloadTableRow.displayName = 'WorkloadTableRow';
 type WorkloadTableRowProps = {
   obj: K8sResourceKind;
   index: number;
-  key?: string;
+  rowKey: string;
   style: object;
   kind: string;
   menuActions: KebabAction[];


### PR DESCRIPTION
This is a follow-up to #4783.

Fixed remaining occurences and narrowed `Table.Row` prop type to `RowFunction` only.

cc @benjaminapetersen @spadgett @christianvogt @rawagner
