### PR TITLE
kubevirt: Don't show error message before templates are loaded

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/vm-settings-tab-validation.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/validations/vm-settings-tab-validation.ts
@@ -1,5 +1,4 @@
 import * as _ from 'lodash';
-import { List } from 'immutable';
 import {
   asValidationObject,
   ValidationErrorType,
@@ -44,7 +43,6 @@ import { vmSettingsOrder } from '../initial-state/vm-settings-tab-initial-state'
 import { TemplateValidations } from '../../../../utils/validations/template/template-validations';
 import { combineIntegerValidationResults } from '../../../../utils/validations/template/utils';
 import { getValidationUpdate } from './utils';
-
 import { getTemplateValidations } from '../../selectors/template';
 
 const validateVm: VmSettingsValidator = (field, options) => {
@@ -82,10 +80,14 @@ const validateUserTemplate: VmSettingsValidator = (field, options) => {
     return null;
   }
 
-  const userTemplate = iGetLoadedCommonData(state, id, VMWizardProps.userTemplates, List()).find(
+  const userTemplatesList = iGetLoadedCommonData(state, id, VMWizardProps.userTemplates);
+  if (!userTemplatesList) {
+    return null;
+  }
+
+  const userTemplate = userTemplatesList.find(
     (template) => iGetName(template) === userTemplateName,
   );
-
   if (!userTemplate) {
     return asValidationObject(
       "Can't verify template, template is missing",


### PR DESCRIPTION
Don't show error message before templates are loaded.

In #4811 we introduced a validation that check template name is valid,
The error is displayed until user templates are loaded (and template name can be validated)
This PR prevent the error until templates are loaded. 