### PR TITLE
Bug 1821846: Hide `OpenShift Cluster Manager` when branding is `azure`

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -274,7 +274,7 @@ export const ClusterVersionDetailsTable: React.SFC<ClusterVersionDetailsTablePro
           </div>
         </div>
         <div className="co-m-pane__body-group">
-          {window.SERVER_FLAGS.branding !== 'okd' && (
+          {window.SERVER_FLAGS.branding !== 'okd' && window.SERVER_FLAGS.branding !== 'azure' && (
             <p className="co-m-pane__explanation">
               View this cluster and manage subscription settings in{' '}
               <ExternalLink text="OpenShift Cluster Manager" href={getOCMLink(clusterID)} />.

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/details-card.tsx
@@ -150,9 +150,10 @@ export const DetailsCard_ = connect(mapStateToProps)(
                   isLoading={!clusterVersionLoaded}
                 >
                   <div className="co-select-to-copy">{clusterId}</div>
-                  {window.SERVER_FLAGS.branding !== 'okd' && (
-                    <ExternalLink text="OpenShift Cluster Manager" href={getOCMLink(clusterId)} />
-                  )}
+                  {window.SERVER_FLAGS.branding !== 'okd' &&
+                    window.SERVER_FLAGS.branding !== 'azure' && (
+                      <ExternalLink text="OpenShift Cluster Manager" href={getOCMLink(clusterId)} />
+                    )}
                 </DetailItem>
                 <DetailItem
                   title="Provider"

--- a/frontend/public/components/masthead-toolbar.jsx
+++ b/frontend/public/components/masthead-toolbar.jsx
@@ -246,7 +246,11 @@ class MastheadToolbarContents_ extends React.Component {
     const launcherItems = this._getAdditionalLinks(consoleLinks, 'ApplicationMenu');
 
     const sections = [];
-    if (clusterID && window.SERVER_FLAGS.branding !== 'okd') {
+    if (
+      clusterID &&
+      window.SERVER_FLAGS.branding !== 'okd' &&
+      window.SERVER_FLAGS.branding !== 'azure'
+    ) {
       sections.push({
         name: 'Red Hat Applications',
         isSection: true,


### PR DESCRIPTION
Fixes https://github.com/Azure/ARO-RP/issues/298.

Needs to be backported to `release-4.3`.