### PR TITLE
fixes sink drag and drop on knative service

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/componentUtils.ts
+++ b/frontend/packages/dev-console/src/components/topology/componentUtils.ts
@@ -245,14 +245,14 @@ const graphEventSourceDropTargetSpec: DropTargetSpec<
   accept: [CREATE_CONNECTOR_DROP_TYPE, MOVE_EV_SRC_CONNECTOR_DROP_TYPE],
   canDrop: (item, monitor, props) => {
     return (
-      monitor.getOperation() === MOVE_EV_SRC_CONNECTOR_DROP_TYPE &&
+      monitor.getItemType() === MOVE_EV_SRC_CONNECTOR_DROP_TYPE &&
       item.getSource() !== props.element
     );
   },
   collect: (monitor, props) => ({
     canDrop:
       monitor.isDragging() &&
-      monitor.getOperation() === MOVE_EV_SRC_CONNECTOR_DROP_TYPE &&
+      monitor.getItemType() === MOVE_EV_SRC_CONNECTOR_DROP_TYPE &&
       monitor.canDrop(),
     dropTarget: monitor.isOver({ shallow: true }),
     edgeDragging: nodesEdgeIsDragging(monitor, props),


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3431

**Analysis / Root cause**: 
Unable to drag and drop sink for EventSource to a different Service

**Solution Description**: 
fixed monitor type 

**Screen shots / Gifs for design review**: 
![sinkEsFixed](https://user-images.githubusercontent.com/5129024/77730620-267d4200-7027-11ea-961e-64186a98c5c8.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
