### PR TITLE
Created new extension to show health status from K8s Resources

### DIFF
--- a/frontend/public/components/utils/k8s-watch-hook.ts
+++ b/frontend/public/components/utils/k8s-watch-hook.ts
@@ -223,11 +223,11 @@ type GetIDAndDispatch = (
   k8sModel: K8sKind,
 ) => { id: string; dispatch: (dispatch: Dispatch, getState: () => RootState) => void };
 
-type ResourcesObject = { [key: string]: K8sResourceCommon | K8sResourceCommon[] };
+export type ResourcesObject = { [key: string]: K8sResourceCommon | K8sResourceCommon[] };
 
 type WatchK8sResult<R extends K8sResourceCommon | K8sResourceCommon[]> = [R, boolean, any];
 
-type WatchK8sResults<R extends ResourcesObject> = {
+export type WatchK8sResults<R extends ResourcesObject> = {
   [k in keyof R]: { data: R[k]; loaded: boolean; loadError: any };
 };
 


### PR DESCRIPTION
The status card health subsystem shows status fetched from prometheus and url.
This commit extends that to add an extension to show status from any K8s resources.
The new extension is `Dashboards/Overview/Health/Resource`

Followup PR to consume the extension #4824 

cc @rawagner 