### PR TITLE
Remove the badge from the Topology Display dropdown

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
@@ -43,7 +43,7 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({ filters, onChange }) =>
       selections={selected}
       isExpanded={isOpen}
       onSelect={onSelect}
-      placeholderText="Display"
+      placeholderText="Display Options"
       isGrouped
     >
       {showOptions}

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.scss
@@ -9,4 +9,9 @@
   &__info-icon {
     margin-left: var(--pf-global--spacer--sm);
   }
+
+  // TODO: Remove when https://github.com/patternfly/patternfly-react/pull/3976 is available
+  .pf-c-select__toggle-badge {
+    display: none;
+  }
 }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3296

**Analysis / Root cause**: 
In topology, we have a display dropdown which shows a badge.  This badge confuses users as to what it indicates.  It should be removed.

**Solution Description**: 
Hide the badge from the dropdown, update the text to `Display Options`

**Screen shots / Gifs for design review**: 
![image](https://user-images.githubusercontent.com/11633780/77796646-13c63580-7046-11ea-8ea3-91098f37872d.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux 