### PR TITLE
Fix Topology UI error viewing Event Source Sinks

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/layouts/TopologyColaLayout.ts
+++ b/frontend/packages/dev-console/src/components/topology/layouts/TopologyColaLayout.ts
@@ -3,6 +3,6 @@ import { layoutConstraints } from '@console/knative-plugin/src/topology/layouts/
 
 export default class TopologyColaLayout extends ColaLayout {
   protected getConstraints(nodes: ColaNode[], groups: ColaGroup[], edges: ColaLink[]): any[] {
-    return layoutConstraints(nodes, groups, edges);
+    return layoutConstraints(nodes, groups, edges, this.options);
   }
 }

--- a/frontend/packages/knative-plugin/src/topology/layouts/layoutConstraints.ts
+++ b/frontend/packages/knative-plugin/src/topology/layouts/layoutConstraints.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { ColaGroup, ColaLink, ColaNode, getGroupPadding } from '@console/topology';
+import { ColaGroup, ColaLink, ColaNode, getGroupPadding, LayoutOptions } from '@console/topology';
 import { TYPE_EVENT_SOURCE_LINK, TYPE_KNATIVE_SERVICE } from '../const';
 
 const getNodeTimeStamp = (node: ColaNode): Date => {
@@ -15,6 +15,7 @@ export const layoutConstraints = (
   nodes: ColaNode[],
   groups: ColaGroup[],
   edges: ColaLink[],
+  options: LayoutOptions,
 ): any[] => {
   const constraints: any[] = [];
 
@@ -81,7 +82,7 @@ export const layoutConstraints = (
             axis: 'x',
             left: serviceNode.index,
             right: link.source.index,
-            gap: serviceDistance + link.source.width / 2 + this.options.linkDistance,
+            gap: serviceDistance + link.source.width / 2 + options.linkDistance,
             equality: true,
           });
           nextOffset += link.source.height;

--- a/frontend/packages/topology/src/layouts/index.ts
+++ b/frontend/packages/topology/src/layouts/index.ts
@@ -1,3 +1,4 @@
+export * from './BaseLayout';
 export * from './ColaLayout';
 export * from './DagreLayout';
 export { default as ForceLayout } from './ForceLayout';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3448

**Analysis / Root cause**: 
Invalid reference to `this.options` in a function.

**Solution Description**: 
Pass the LayoutOptions to the function and remove the reference to `this`.

**Screen shots / Gifs for design review**: 
No Visual Changes

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug