### PR TITLE
Bug 1817549: Virtual Scroll (Events on Dashboard) is inaccessible by screen reader

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
@@ -20,7 +20,7 @@ const EventItem: React.FC<EventItemProps> = React.memo(({ event, isExpanded, onT
   const isWarning = typeFilter('warning', event);
   const expanded = isExpanded(metadata.uid);
   return (
-    <div className="co-recent-item__body">
+    <div className="co-recent-item__body" role="gridcell">
       <AccordionItem>
         <AccordionToggle
           onClick={() => onToggle(metadata.uid)}

--- a/frontend/public/components/utils/event-stream.tsx
+++ b/frontend/public/components/utils/event-stream.tsx
@@ -50,7 +50,7 @@ class SysEvent extends React.Component<SysEventProps> {
     }
 
     return (
-      <div className={classNames('co-sysevent--transition', className)} style={style}>
+      <div className={classNames('co-sysevent--transition', className)} style={style} role="row">
         <CSSTransition
           mountOnEnter={true}
           appear={shouldAnimate}


### PR DESCRIPTION
This PR adds the missing roles to the events virtual scroll on the Dashboard. This should work with VO in Safari and NVDA in Chrome, and it makes the axe error go away.