### PR TITLE
Bug 1796516: Fix title overlap in sidepanel in dev catalog

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -206,10 +206,6 @@ $catalog-tile-width: $co-m-catalog-tile-width;
       margin: 0 !important;
     }
 
-    .pf-c-title {
-      margin-right: 0 !important;
-    }
-
     .modal-body-inner-shadow-covers {
       padding-left: 0 !important;
       padding-right: 0 !important;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2921

**Analysis / Root cause**: 
Right padding for the side panel title is not enough to allow the close button to be displayed w/o overlap when there are very long titles.

**Solution Description**: 
Increase the right padding for the side panel title area

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
