### PR TITLE
Bug 1811886: Specify ts-loader configFile in webpack.config.ts

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -69,6 +69,8 @@ const config: Configuration = {
           {
             loader: 'ts-loader',
             options: {
+              // Always use the root tsconfig.json. Packages might have a separate tsconfig.json for storybook.
+              configFile: path.resolve(__dirname, 'tsconfig.json'),
               happyPackMode: true, // This implicitly enables transpileOnly! No type checking!
               transpileOnly: true, // fork-ts-checker-webpack-plugin takes care of type checking
             },


### PR DESCRIPTION
The topology package has its own tsconfig.json for development with
storybook. In some cases, ts-loader was incorrectly picking up this
config when building other packages, which could cause runtime errors
since it uses different values for `target` and `downlevelIteration`.

Always use the top-level tsconfig.json file when building console.

https://github.com/TypeStrong/ts-loader#configfile

/assign @christianvogt @benjaminapetersen 