### PR TITLE
Bug 1818691: Monitoring: Use blue circle "info" icon for `none` severity alerts

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -213,6 +213,7 @@ const AlertStateDescription = ({ alert }) => {
 const severityIcons = {
   [AlertSeverities.Critical]: RedExclamationCircleIcon,
   [AlertSeverities.Info]: BlueInfoCircleIcon,
+  [AlertSeverities.None]: BlueInfoCircleIcon,
   [AlertSeverities.Warning]: YellowExclamationTriangleIcon,
 };
 
@@ -228,15 +229,8 @@ const SeverityIcon: React.FC<SeverityIconProps> = ({ label, severity }) => {
   );
 };
 
-const Severity: React.FC<{ severity?: string }> = ({ severity }) => {
-  if (_.isNil(severity)) {
-    return <>-</>;
-  }
-  if (severity === AlertSeverities.None) {
-    return <>None</>;
-  }
-  return <SeverityIcon label={_.startCase(severity)} severity={severity} />;
-};
+const Severity: React.FC<{ severity?: string }> = ({ severity }) =>
+  _.isNil(severity) ? <>-</> : <SeverityIcon label={_.startCase(severity)} severity={severity} />;
 
 const SeverityCounts: React.FC<{ alerts: Alert[] }> = ({ alerts }) => {
   const counts = _.countBy(alerts, (a) => {


### PR DESCRIPTION
Use the blue circle "info" icon for alerts with severity `none` in
addition to those with severity `info`.

This was already the case for the silences list page, so this change
makes the severity icons consistent across all pages.

Currently, only the "Watchdog" alerts has severity `none`, so that is
the only alert affected by this change.

![screenshot](https://user-images.githubusercontent.com/460802/77982431-4e321a00-7347-11ea-9fa4-a04bd2372a23.png)

FYI @cshinn 