### PR TITLE
BareMetalHost: Add Restart action

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDetails.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import { RebootingIcon } from '@patternfly/react-icons';
 import {
   referenceForModel,
   K8sResourceKind,
@@ -39,12 +40,14 @@ import {
   getHostBios,
   getHostProvisioningState,
   getHostBootMACAddress,
+  isHostScheduledForRestart,
 } from '../../selectors';
 import { BareMetalHostKind } from '../../types';
 import { HOST_REGISTERING_STATES } from '../../constants/bare-metal-host';
 import MachineLink from './MachineLink';
 import BareMetalHostPowerStatusIcon from './BareMetalHostPowerStatusIcon';
 import BareMetalHostStatus from './BareMetalHostStatus';
+import { HOST_SCHEDULED_FOR_RESTART } from './BareMetalHostSecondaryStatus';
 
 type BareMetalHostDetailsProps = {
   obj: BareMetalHostKind;
@@ -148,6 +151,12 @@ const BareMetalHostDetails: React.FC<BareMetalHostDetailsProps> = ({
                     title={powerStatus}
                     icon={<BareMetalHostPowerStatusIcon powerStatus={powerStatus} />}
                   />
+                  {isHostScheduledForRestart(host) && (
+                    <StatusIconAndText
+                      title={HOST_SCHEDULED_FOR_RESTART}
+                      icon={<RebootingIcon />}
+                    />
+                  )}
                 </dd>
               </>
             )}

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostSecondaryStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostSecondaryStatus.tsx
@@ -12,7 +12,7 @@ type BareMetalHostSecondaryStatusProps = {
   host: BareMetalHostKind;
 };
 
-export const HOST_SCHEDULED_FOR_RESTART = 'Scheduled for restart';
+export const HOST_SCHEDULED_FOR_RESTART = 'Restart pending';
 
 const BareMetalHostSecondaryStatus: React.FC<BareMetalHostSecondaryStatusProps> = ({ host }) => {
   const powerStatus = getHostPowerStatus(host);

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostSecondaryStatus.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostSecondaryStatus.tsx
@@ -1,25 +1,36 @@
 import * as React from 'react';
 import { SecondaryStatus } from '@console/shared';
 import { BareMetalHostKind } from '../../types';
-import { getHostPowerStatus, getHostProvisioningState } from '../../selectors';
+import {
+  getHostPowerStatus,
+  getHostProvisioningState,
+  isHostScheduledForRestart,
+} from '../../selectors';
 import { HOST_POWER_STATUS_POWERED_ON, HOST_REGISTERING_STATES } from '../../constants';
 
 type BareMetalHostSecondaryStatusProps = {
   host: BareMetalHostKind;
 };
 
+export const HOST_SCHEDULED_FOR_RESTART = 'Scheduled for restart';
+
 const BareMetalHostSecondaryStatus: React.FC<BareMetalHostSecondaryStatusProps> = ({ host }) => {
   const powerStatus = getHostPowerStatus(host);
   const provisioningState = getHostProvisioningState(host);
   const status = [];
-  // don't show power status when host is powered on
+
   // don't show power status when host registration/inspection hasn't finished
-  if (
-    !(powerStatus === HOST_POWER_STATUS_POWERED_ON) &&
-    !HOST_REGISTERING_STATES.includes(provisioningState)
-  ) {
-    status.push(powerStatus);
+  if (!HOST_REGISTERING_STATES.includes(provisioningState)) {
+    if (isHostScheduledForRestart(host)) {
+      status.push(HOST_SCHEDULED_FOR_RESTART);
+    }
+
+    // don't show power status when host is powered on
+    if (powerStatus !== HOST_POWER_STATUS_POWERED_ON) {
+      status.push(powerStatus);
+    }
   }
+
   return <SecondaryStatus status={status} />;
 };
 

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
@@ -17,7 +17,12 @@ import {
 } from '@console/shared';
 import { confirmModal, deleteModal } from '@console/internal/components/modals';
 import { MachineModel, MachineSetModel } from '@console/internal/models';
-import { findNodeMaintenance, getHostMachine, getHostPowerStatus } from '../../selectors';
+import {
+  findNodeMaintenance,
+  getHostMachine,
+  getHostPowerStatus,
+  isHostScheduledForRestart,
+} from '../../selectors';
 import { BareMetalHostModel, NodeMaintenanceModel } from '../../models';
 import { getHostStatus } from '../../status/host-status';
 import {
@@ -39,6 +44,7 @@ import { DELETE_MACHINE_ANNOTATION } from '../../constants/machine';
 import { deprovision } from '../../k8s/requests/bare-metal-host';
 import { getMachineMachineSetOwner } from '../../selectors/machine';
 import { findMachineSet } from '../../selectors/machine-set';
+import { restartHostModal } from '../modals/RestartHostModal';
 
 type ActionArgs = {
   machine?: MachineKind;
@@ -129,6 +135,16 @@ export const PowerOff = (
   accessReview: host && asAccessReview(BareMetalHostModel, host, 'update'),
 });
 
+export const Restart = (kindObj: K8sKind, host: BareMetalHostKind) => ({
+  hidden:
+    [HOST_POWER_STATUS_POWERED_OFF, HOST_POWER_STATUS_POWERING_OFF].includes(
+      getHostPowerStatus(host),
+    ) || isHostScheduledForRestart(host),
+  label: 'Restart',
+  callback: () => restartHostModal({ host }),
+  accessReview: host && asAccessReview(BareMetalHostModel, host, 'update'),
+});
+
 export const Delete = (
   kindObj: K8sKind,
   host: BareMetalHostKind,
@@ -159,6 +175,7 @@ export const menuActions = [
   PowerOn,
   Deprovision,
   PowerOff,
+  Restart,
   Kebab.factory.ModifyLabels,
   Kebab.factory.ModifyAnnotations,
   Edit,

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
@@ -135,13 +135,13 @@ export const PowerOff = (
   accessReview: host && asAccessReview(BareMetalHostModel, host, 'update'),
 });
 
-export const Restart = (kindObj: K8sKind, host: BareMetalHostKind) => ({
+export const Restart = (kindObj: K8sKind, host: BareMetalHostKind, { nodeName }: ActionArgs) => ({
   hidden:
     [HOST_POWER_STATUS_POWERED_OFF, HOST_POWER_STATUS_POWERING_OFF].includes(
       getHostPowerStatus(host),
     ) || isHostScheduledForRestart(host),
   label: 'Restart',
-  callback: () => restartHostModal({ host }),
+  callback: () => restartHostModal({ host, nodeName }),
   accessReview: host && asAccessReview(BareMetalHostModel, host, 'update'),
 });
 

--- a/frontend/packages/metal3-plugin/src/components/modals/RestartHostModal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/RestartHostModal.tsx
@@ -12,6 +12,7 @@ import { restartHost } from '../../k8s/requests/bare-metal-host';
 
 export type RestartHostModalProps = {
   host: BareMetalHostKind;
+  nodeName: string;
   handlePromise: <T>(promise: Promise<T>) => Promise<T>;
   inProgress: boolean;
   errorMessage: string;
@@ -21,6 +22,7 @@ export type RestartHostModalProps = {
 
 const RestartHostModal = ({
   host,
+  nodeName,
   inProgress,
   errorMessage,
   handlePromise,
@@ -37,13 +39,16 @@ const RestartHostModal = ({
     [host, close, handlePromise],
   );
 
+  const text = nodeName
+    ? `The bare metal host ${getName(
+        host,
+      )} will be restarted gracefully after all managed workloads are moved.`
+    : `The bare metal host ${getName(host)} will be restarted gracefully.`;
+
   return (
     <form onSubmit={onSubmit} name="form" className="modal-content">
-      <ModalTitle>Restart host {getName(host)}</ModalTitle>
-      <ModalBody>
-        The bare metal host will be scheduled for restart which will be executed once all managed
-        workloads are moved to nodes on other hosts.
-      </ModalBody>
+      <ModalTitle>Restart Bare Metal Host</ModalTitle>
+      <ModalBody>{text}</ModalBody>
       <ModalSubmitFooter
         cancel={cancel}
         errorMessage={errorMessage}

--- a/frontend/packages/metal3-plugin/src/components/modals/RestartHostModal.tsx
+++ b/frontend/packages/metal3-plugin/src/components/modals/RestartHostModal.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { getName } from '@console/shared';
+import { withHandlePromise } from '@console/internal/components/utils';
+import {
+  createModalLauncher,
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+} from '@console/internal/components/factory';
+import { BareMetalHostKind } from '../../types';
+import { restartHost } from '../../k8s/requests/bare-metal-host';
+
+export type RestartHostModalProps = {
+  host: BareMetalHostKind;
+  handlePromise: <T>(promise: Promise<T>) => Promise<T>;
+  inProgress: boolean;
+  errorMessage: string;
+  cancel?: () => void;
+  close?: () => void;
+};
+
+const RestartHostModal = ({
+  host,
+  inProgress,
+  errorMessage,
+  handlePromise,
+  close = undefined,
+  cancel = undefined,
+}: RestartHostModalProps) => {
+  const onSubmit = React.useCallback(
+    async (event) => {
+      event.preventDefault();
+      const promise = restartHost(host);
+      await handlePromise(promise);
+      return close();
+    },
+    [host, close, handlePromise],
+  );
+
+  return (
+    <form onSubmit={onSubmit} name="form" className="modal-content">
+      <ModalTitle>Restart host {getName(host)}</ModalTitle>
+      <ModalBody>
+        The bare metal host will be scheduled for restart which will be executed once all managed
+        workloads are moved to nodes on other hosts.
+      </ModalBody>
+      <ModalSubmitFooter
+        cancel={cancel}
+        errorMessage={errorMessage}
+        inProgress={inProgress}
+        submitDisabled={false}
+        submitText="Restart"
+      />
+    </form>
+  );
+};
+
+export const restartHostModal = createModalLauncher(withHandlePromise(RestartHostModal));

--- a/frontend/packages/metal3-plugin/src/k8s/requests/bare-metal-host.ts
+++ b/frontend/packages/metal3-plugin/src/k8s/requests/bare-metal-host.ts
@@ -25,6 +25,18 @@ export const powerOffHost = (host: BareMetalHostKind) =>
 export const powerOnHost = (host: BareMetalHostKind) =>
   k8sPatch(BareMetalHostModel, host, [{ op: 'replace', path: '/spec/online', value: true }]);
 
+export const restartHost = (host: BareMetalHostKind) =>
+  k8sPatch(BareMetalHostModel, host, [
+    {
+      op: 'replace',
+      path: '/metadata/annotations',
+      value: {
+        ...host.metadata.annotations,
+        'reboot.metal3.io': 'UI', // value is irrelevant
+      },
+    },
+  ]);
+
 export const deprovision = async (machine: MachineKind, machineSet?: MachineSetKind) => {
   await k8sPatch(MachineModel, machine, [
     new PatchBuilder('/metadata/annotations')

--- a/frontend/packages/metal3-plugin/src/selectors/baremetal-hosts.ts
+++ b/frontend/packages/metal3-plugin/src/selectors/baremetal-hosts.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { getName } from '@console/shared/src/selectors/common';
+import { getName, getAnnotations } from '@console/shared/src/selectors/common';
 import { MachineKind } from '@console/internal/module/k8s';
 import {
   BareMetalHostDisk,
@@ -15,6 +15,8 @@ import {
   HOST_POWER_STATUS_POWERING_ON,
   HOST_POWER_STATUS_POWERED_OFF,
 } from '../constants';
+
+const ANNOTATION_HOST_RESTART = 'reboot.metal3.io';
 
 export const getHostOperationalStatus = (host: BareMetalHostKind): string =>
   _.get(host, 'status.operationalStatus');
@@ -42,6 +44,12 @@ export const getHostDescription = (host: BareMetalHostKind): string =>
   _.get(host, 'spec.description', '');
 export const isHostPoweredOn = (host: BareMetalHostKind): boolean =>
   _.get(host, 'status.poweredOn', false);
+export const isHostScheduledForRestart = (host: BareMetalHostKind) =>
+  !!Object.getOwnPropertyNames(getAnnotations(host, {})).find(
+    (annotation) =>
+      annotation === ANNOTATION_HOST_RESTART ||
+      annotation.startsWith(`${ANNOTATION_HOST_RESTART}/`),
+  );
 export const getHostPowerStatus = (host: BareMetalHostKind): string => {
   const isOnline = isHostOnline(host);
   const isPoweredOn = isHostPoweredOn(host);

--- a/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
+++ b/frontend/packages/metal3-plugin/src/status/baremetal-node-status.ts
@@ -33,6 +33,8 @@ export const baremetalNodeSecondaryStatus = ({
     states.push('Scheduling disabled');
   }
   // show host power status only if there is actual host associated to node
-  if (host && !isHostPoweredOn(host)) states.push('Host is powered off');
+  if (host && !isHostPoweredOn(host)) {
+    states.push('Host is powered off');
+  }
   return states;
 };


### PR DESCRIPTION
Bare Metal Host list and detail pages are extended for the "Restart" action (available for a running BMH only).

The status field is enriched to reflect new state.

Implementation is based on https://github.com/metal3-io/metal3-docs/blob/master/design/reboot-interface.md