### PR TITLE
Monitoring: Add Alerting Rules list page

### DIFF
--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -32,6 +32,7 @@ export enum ActionType {
   MonitoringDashboardsSetPollInterval = 'monitoringDashboardsSetPollInterval',
   MonitoringDashboardsSetTimespan = 'monitoringDashboardsSetTimespan',
   MonitoringDashboardsVariableOptionsLoaded = 'monitoringDashboardsVariableOptionsLoaded',
+  MonitoringSetRules = 'monitoringSetRules',
   SetMonitoringData = 'setMonitoringData',
   ToggleMonitoringGraphs = 'monitoringToggleGraphs',
   NotificationDrawerToggleExpanded = 'notificationDrawerExpanded',
@@ -304,6 +305,7 @@ export const monitoringErrored = (
   key: 'alerts' | 'silences' | 'notificationAlerts',
   loadError: any,
 ) => action(ActionType.SetMonitoringData, { key, data: { loaded: true, loadError, data: null } });
+export const monitoringSetRules = (rules: any) => action(ActionType.MonitoringSetRules, { rules });
 export const monitoringToggleGraphs = () => action(ActionType.ToggleMonitoringGraphs);
 export const notificationDrawerToggleExpanded = () =>
   action(ActionType.NotificationDrawerToggleExpanded);
@@ -373,6 +375,7 @@ const uiActions = {
   monitoringLoading,
   monitoringLoaded,
   monitoringErrored,
+  monitoringSetRules,
   monitoringToggleGraphs,
   queryBrowserAddQuery,
   queryBrowserDeleteAllQueries,

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -434,6 +434,15 @@ const AppContents_: React.FC<AppContentsProps> = ({ activePerspective, flags }) 
             }
           />
           <LazyRoute
+            path="/monitoring/alertrules"
+            exact
+            loader={() =>
+              import('./monitoring' /* webpackChunkName: "monitoring" */).then(
+                (m) => m.MonitoringUI,
+              )
+            }
+          />
+          <LazyRoute
             path="/monitoring/silences"
             exact
             loader={() =>

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -15,7 +15,7 @@ import {
   getTemplateInstanceStatus,
 } from '../../module/k8s';
 
-import { alertState, silenceState } from '../../reducers/monitoring';
+import { alertingRuleIsActive, alertState, silenceState } from '../../reducers/monitoring';
 
 export const fuzzyCaseInsensitive = (a: string, b: string): boolean =>
   fuzzy(_.toLower(a), _.toLower(b));
@@ -29,6 +29,10 @@ export const tableFilters: TableFilterMap = {
   'alert-name': (filter, alert) => fuzzyCaseInsensitive(filter, _.get(alert, 'labels.alertname')),
 
   'alert-state': (filter, alert) => filter.selected.has(alertState(alert)),
+
+  'alerting-rule-active': (filter, rule) => filter.selected.has(alertingRuleIsActive(rule)),
+
+  'alerting-rule-name': (filter, rule) => fuzzyCaseInsensitive(filter, rule.name),
 
   'silence-name': (filter, silence) => fuzzyCaseInsensitive(filter, silence.name),
 

--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -166,6 +166,10 @@ $screen-phone-landscape-min-width: 567px;
   flex-wrap: wrap;
 }
 
+.monitoring-icon-wrap {
+  margin-right: 10px;
+}
+
 .query-browser__toggle-graph {
   margin-bottom: 5px;
   float: right;

--- a/frontend/public/reducers/monitoring.ts
+++ b/frontend/public/reducers/monitoring.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash-es';
 
 import { MonitoringAction, ActionType } from '../actions/monitoring';
 
-export const enum AlertSeverities {
+export const enum AlertSeverity {
   Critical = 'critical',
   Info = 'info',
   None = 'none',
@@ -13,15 +13,14 @@ export const enum AlertSeverities {
 
 export const enum AlertStates {
   Firing = 'firing',
-  Silenced = 'silenced',
   Pending = 'pending',
-  NotFiring = 'not-firing',
+  Silenced = 'silenced',
 }
 
 export const enum SilenceStates {
   Active = 'active',
-  Pending = 'pending',
   Expired = 'expired',
+  Pending = 'pending',
 }
 
 export enum MonitoringRoutes {
@@ -60,14 +59,14 @@ const stateToProps = (desiredURLs: string[], state) => {
 
 export const connectToURLs = (...urls) => connect((state) => stateToProps(urls, state));
 
-export const alertState = (a) => _.get(a, 'state', AlertStates.NotFiring);
-export const silenceState = (s) => _.get(s, 'status.state');
+export const alertState = (a) => a?.state;
+export const silenceState = (s) => s?.status?.state;
+
+export const alertingRuleIsActive = (rule) => (rule.state === 'inactive' ? 'false' : 'true');
 
 // Sort alerts and silences by their state (sort first by the state itself, then by the timestamp relevant to the state)
 export const alertStateOrder = (alert) => [
-  [AlertStates.Firing, AlertStates.Silenced, AlertStates.Pending, AlertStates.NotFiring].indexOf(
-    alertState(alert),
-  ),
+  [AlertStates.Firing, AlertStates.Silenced, AlertStates.Pending].indexOf(alertState(alert)),
   alertState(alert) === AlertStates.Silenced
     ? _.max(_.map(alert.silencedBy, 'endsAt'))
     : _.get(alert, 'activeAt'),

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -194,6 +194,9 @@ export default (state: UIState, action: UIAction): UIState => {
           };
       return state.mergeIn(['monitoringDashboards', 'variables', key], ImmutableMap(patch));
     }
+    case ActionType.MonitoringSetRules:
+      return state.setIn(['monitoring', 'rules'], action.payload.rules);
+
     case ActionType.SetMonitoringData: {
       // alerts used by monitoring -> alerting pages
       const alerts =


### PR DESCRIPTION
Add an Alerting Rules list page under Monitoring > Alerting.

Remove the "Not Firing" alerts from the Alerts list page. These "Not
Firing" alerts represented alerting rules that were not firing, so we
are removing them since we now have a separate alerting rules list.

![screenshot](https://user-images.githubusercontent.com/460802/78013204-18aa2280-7381-11ea-9b42-ad093d0d8ff6.png)

FYI @cshinn, @sichvoge 