### PR TITLE
Bug 1819289: Fix navigation separator background colour

### DIFF
--- a/frontend/public/components/nav/_nav-header.scss
+++ b/frontend/public/components/nav/_nav-header.scss
@@ -51,3 +51,7 @@
   }
 
 }
+
+.pf-c-nav__separator {
+  background-color: var(--pf-global--BackgroundColor--dark-400) !important;
+}


### PR DESCRIPTION
The version of PF we are using in 4.3 is pointing `--pf-c-nav__separator--BackgroundColor` to `#212427`, which is too dark to see the separator. PF that we use in 4.4 and up is  pointing `--pf-c-nav__separator--BackgroundColor` to `#4f5255` which `--pf-global--BackgroundColor--dark-400` is also pointing to. By overriding it the separator is visible once again.

![Screenshot 2020-03-31 at 12 18 30](https://user-images.githubusercontent.com/1668218/78015585-e29d7c00-7349-11ea-82ea-bc5e422d875c.png)

/assign @rhamilto  