### PR TITLE
Fix to show topology view for unprivileged users

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -52,12 +52,15 @@ const Controller: React.FC<ControllerProps> = ({
   serviceBinding,
   trafficData,
 }) => {
-  const secretCount = React.useRef<number>(0);
+  const secretCount = React.useRef<number>(-1);
   const [helmResourcesMap, setHelmResourcesMap] = React.useState<HelmReleaseResourcesMap>(null);
 
   React.useEffect(() => {
     const count = resources?.secrets?.data?.length ?? 0;
-    if (count !== secretCount.current) {
+    if (
+      (resources.secrets?.loaded && count !== secretCount.current) ||
+      resources.secrets?.loadError
+    ) {
       secretCount.current = count;
       if (count === 0) {
         setHelmResourcesMap({});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3456

**Analysis / Root cause**: 
If loading secrets fails, the topology view was not proceeding due to not fetching the helm release data.

**Solution Description**: 
Proceed with loading the view when loading secrets fails.

**Screen shots / Gifs for design review**: 
No Visual Changes

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug