### PR TITLE
Bug 1819206: Input Field Should Have Accessible Label

### DIFF
--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -75,6 +75,7 @@ export const TextFilter = ({
         tabIndex={0}
         type="text"
         autoFocus={autoFocus}
+        aria-label={placeholder}
       />
       <span className="form-control-feedback form-control-feedback--keyboard-hint">
         <kbd>/</kbd>


### PR DESCRIPTION
This adds an aria label to the input field on multiple pages (ex: /k8s/cluster/projects). It fixes the following axe error: 
```
"data": null,
    "id": "aria-label",
    "impact": "serious",
    "message": "aria-label attribute does not exist or is empty",
    "relatedNodes": [
      {
        "html": "<input autocapitalize="none" class="pf-c-form-control co-text-filter" placeholder="Filter by name or display name..." tabindex="0" type="text" value="">"
      }
```


