### PR TITLE
pipeline credential management

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/const.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/const.ts
@@ -5,3 +5,5 @@ export enum PipelineResourceType {
   cluster = 'Cluster',
   storage = 'Storage',
 }
+
+export const PIPELINE_SERVICE_ACCOUNT = 'pipeline';

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineSecretSection.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineSecretSection.scss
@@ -1,0 +1,10 @@
+.odc-pipeline-secret-section {
+  padding-left: var(--pf-global--spacer--lg);
+  &__secrets {
+    padding-left: var(--pf-global--spacer--lg);
+  }
+  &__secret-form {
+    border: 1px dashed var(--pf-global--BorderColor--100);
+    padding: var(--pf-global--spacer--md);
+  }
+}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineSecretSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineSecretSection.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { Formik } from 'formik';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Button } from '@patternfly/react-core';
+import { ExpandCollapse } from '@console/internal/components/utils';
+import { SecretType } from '@console/internal/components/secrets/create-secret';
+import { SecretModel } from '@console/internal/models';
+import { k8sCreate } from '@console/internal/module/k8s';
+import SecretForm from './SecretForm';
+import { associateServiceAccountToSecret } from '../../../utils/pipeline-utils';
+import SecretsList from './SecretsList';
+import './PipelineSecretSection.scss';
+
+const initialValues = {
+  secretName: '',
+  type: SecretType.dockerconfigjson,
+  formData: {},
+};
+
+type PipelineSecretSectionProps = {
+  namespace: string;
+};
+
+const PipelineSecretSection: React.FC<PipelineSecretSectionProps> = ({ namespace }) => {
+  const [addSecret, setAddSecret] = React.useState(false);
+
+  const handleSubmit = (values, actions) => {
+    actions.setSubmitting(true);
+    const newSecret = {
+      apiVersion: SecretModel.apiVersion,
+      kind: SecretModel.kind,
+      metadata: {
+        name: values.secretName,
+        namespace,
+      },
+      type: values.type,
+      stringData: values.formData,
+    };
+
+    k8sCreate(SecretModel, newSecret)
+      .then((resp) => {
+        actions.setSubmitting(false);
+        setAddSecret(false);
+        associateServiceAccountToSecret(resp, namespace);
+      })
+      .catch((err) => {
+        actions.setSubmitting(false);
+        actions.setStatus({ submitError: err.message });
+      });
+  };
+
+  const handleReset = (values, actions) => {
+    actions.resetForm({ values: initialValues, status: {} });
+    setAddSecret(false);
+  };
+
+  const handleAddSecret = () => {
+    setAddSecret(true);
+  };
+  return (
+    <ExpandCollapse textExpanded="Hide Credential Options" textCollapsed="Show Credential Options">
+      <div className="odc-pipeline-secret-section">
+        <p>The following secrets are available for all pipelines in this namespace:</p>
+        <div className="odc-pipeline-secret-section__secrets">
+          <SecretsList namespace={namespace} />
+          {addSecret ? (
+            <div className="odc-pipeline-secret-section__secret-form">
+              <Formik initialValues={initialValues} onSubmit={handleSubmit} onReset={handleReset}>
+                {(props) => <SecretForm {...props} />}
+              </Formik>
+            </div>
+          ) : (
+            <Button variant="link" onClick={handleAddSecret} icon={<PlusCircleIcon />}>
+              Add Secret
+            </Button>
+          )}
+        </div>
+      </div>
+    </ExpandCollapse>
+  );
+};
+
+export default PipelineSecretSection;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretForm.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretForm.scss
@@ -1,0 +1,8 @@
+.odc-secret-form {
+  &__title {
+    margin-top: 0;
+  }
+  &__help-text {
+    margin: var(--pf-global--spacer--md) 0;
+  }
+}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretForm.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { FormikValues, useFormikContext } from 'formik';
+import { ActionGroup, Button, ButtonVariant, TextInputTypes } from '@patternfly/react-core';
+import { CheckIcon, CloseIcon } from '@patternfly/react-icons';
+import { ButtonBar } from '@console/internal/components/utils';
+import {
+  SecretType,
+  BasicAuthSubform,
+  SSHAuthSubform,
+  CreateConfigSubform,
+} from '@console/internal/components/secrets/create-secret';
+import { DropdownField, InputField } from '@console/shared';
+import './SecretForm.scss';
+
+const authTypes = {
+  [SecretType.dockerconfigjson]: 'Image Registry Credentials',
+  [SecretType.basicAuth]: 'Basic Authentication',
+  [SecretType.sshAuth]: 'SSH Key',
+};
+
+const renderSecretForm = (
+  type: string,
+  stringData: {
+    [key: string]: any;
+  },
+  onDataChanged: (event: Event) => void,
+) => {
+  switch (type) {
+    case SecretType.basicAuth:
+      return (
+        <BasicAuthSubform onChange={onDataChanged} stringData={stringData[SecretType.basicAuth]} />
+      );
+    case SecretType.sshAuth:
+      return (
+        <SSHAuthSubform onChange={onDataChanged} stringData={stringData[SecretType.sshAuth]} />
+      );
+    case SecretType.dockerconfigjson:
+      return (
+        <CreateConfigSubform
+          onChange={onDataChanged}
+          stringData={stringData[SecretType.dockerconfigjson]}
+        />
+      );
+    default:
+      return null;
+  }
+};
+
+const SecretForm: React.FC<FormikValues> = ({
+  handleSubmit,
+  handleReset,
+  status,
+  isSubmitting,
+}) => {
+  const { values, setFieldValue } = useFormikContext<FormikValues>();
+  const [stringData, setStringData] = React.useState({
+    [SecretType.basicAuth]: {},
+    [SecretType.sshAuth]: {},
+    [SecretType.dockerconfigjson]: {},
+  });
+
+  const setValues = (type) => {
+    type === SecretType.dockerconfigjson
+      ? setFieldValue(
+          'formData',
+          _.mapValues({ '.dockerconfigjson': stringData[type] }, JSON.stringify),
+        )
+      : setFieldValue('formData', stringData[type]);
+  };
+
+  const onDataChanged = (event) => {
+    setStringData((prevState) => ({ ...prevState, [values.type]: event }));
+    setValues(values.type);
+  };
+
+  const handleTypeChange = (type) => {
+    setValues(type);
+  };
+
+  return (
+    <div className="odc-secret-form">
+      <h1 className="odc-secret-form__title">Create Secret</h1>
+      <p className="odc-secret-form__help-text help-block">
+        Source secrets let you authenticate against a Git server.
+      </p>
+      <div className="form-group">
+        <InputField
+          type={TextInputTypes.text}
+          required
+          name="secretName"
+          label="Secret Name"
+          helpText="Unique name of the new secret."
+        />
+      </div>
+      <div className="form-group">
+        <DropdownField
+          name="type"
+          label="Authentication Type"
+          items={authTypes}
+          title={authTypes[values.type]}
+          onChange={handleTypeChange}
+          fullWidth
+          required
+        />
+      </div>
+      {renderSecretForm(values.type, stringData, onDataChanged)}
+      <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
+        <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
+          <Button
+            type="button"
+            variant={ButtonVariant.link}
+            onClick={handleSubmit}
+            className="odc-pipeline-resource-param__action-btn"
+            aria-label="create"
+          >
+            <CheckIcon />
+          </Button>
+          <Button
+            type="button"
+            className="odc-pipeline-resource-param__action-btn"
+            variant={ButtonVariant.plain}
+            onClick={handleReset}
+            aria-label="close"
+          >
+            <CloseIcon />
+          </Button>
+        </ActionGroup>
+      </ButtonBar>
+    </div>
+  );
+};
+
+export default SecretForm;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.scss
@@ -1,0 +1,6 @@
+.odc-secrets-list {
+  &__secrets {
+    padding-left: var(--pf-global--spacer--lg);
+    padding-bottom: var(--pf-global--spacer--lg);
+  }
+}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import {
+  ResourceLink,
+  Firehose,
+  FirehoseResult,
+  FirehoseResource,
+} from '@console/internal/components/utils';
+import { SecretModel, ServiceAccountModel } from '@console/internal/models';
+import { SecretType } from '@console/internal/components/secrets/create-secret';
+import { SecondaryStatus } from '@console/shared';
+import { SecretKind, ServiceAccountKind } from '@console/internal/module/k8s';
+import { PIPELINE_SERVICE_ACCOUNT } from '../const';
+import './SecretsList.scss';
+
+type SecretsProps = {
+  secrets?: FirehoseResult<SecretKind[]>;
+  serviceaccounts?: FirehoseResult<ServiceAccountKind>;
+};
+
+type SecretsListProps = {
+  namespace: string;
+};
+
+const secretTypes = [SecretType.dockerconfigjson, SecretType.basicAuth, SecretType.sshAuth];
+
+const Secrets: React.FC<SecretsProps> = ({ secrets, serviceaccounts }) => {
+  const servicAccountSecrets = _.map(serviceaccounts.data.secrets, 'name');
+  const filterData = _.filter(
+    secrets.data,
+    (secret) =>
+      _.includes(secretTypes, secret.type) &&
+      _.includes(servicAccountSecrets, secret.metadata.name),
+  );
+  const sortedFilterData = _.sortBy(filterData, (data) => data.metadata.name);
+
+  return (
+    <div className="odc-secrets-list">
+      <label>Secrets ({sortedFilterData.length})</label>
+      <div className="odc-secrets-list__secrets">
+        {sortedFilterData.map((secret) => {
+          return (
+            <ResourceLink
+              key={secret.metadata.uid}
+              kind={SecretModel.kind}
+              name={secret.metadata.name}
+              namespace={secret.metadata.namespace}
+              title={secret.metadata.name}
+            />
+          );
+        })}
+        {_.isEmpty(sortedFilterData) && <SecondaryStatus status="No source secrets found" />}
+      </div>
+    </div>
+  );
+};
+
+const SecretsList: React.FC<SecretsListProps> = ({ namespace }) => {
+  const resources: FirehoseResource[] = [
+    {
+      isList: true,
+      namespace,
+      kind: SecretModel.kind,
+      prop: SecretModel.plural,
+    },
+    {
+      isList: false,
+      namespace,
+      kind: ServiceAccountModel.kind,
+      prop: ServiceAccountModel.plural,
+      name: PIPELINE_SERVICE_ACCOUNT,
+    },
+  ];
+
+  return (
+    <Firehose resources={resources}>
+      <Secrets />
+    </Firehose>
+  );
+};
+
+export default SecretsList;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineForm.tsx
@@ -9,6 +9,8 @@ import {
 } from '@console/internal/components/factory/modal';
 import PipelineResourceSection, { ResourceProps } from './PipelineResourceSection';
 import PipelineParameterSection from './PipelineParameterSection';
+import PipelineSecretSection from './PipelineSecretSection';
+import FormSection from '../../import/section/FormSection';
 
 const StartPipelineForm: React.FC<FormikValues> = ({
   values,
@@ -38,6 +40,9 @@ const StartPipelineForm: React.FC<FormikValues> = ({
         <ModalBody>
           <PipelineParameterSection parameters={values.parameters} />
           <PipelineResourceSection resources={resources} />
+          <FormSection title="Advanced Options" fullWidth>
+            <PipelineSecretSection namespace={values.namespace} />
+          </FormSection>
         </ModalBody>
         <ModalSubmitFooter
           errorMessage={status && status.submitError}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
@@ -77,8 +77,9 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
       initialValues={initialValues}
       onSubmit={handleSubmit}
       validationSchema={startPipelineSchema}
-      render={(props) => <StartPipelineForm {...props} close={close} />}
-    />
+    >
+      {(props) => <StartPipelineForm {...props} close={close} />}
+    </Formik>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceForm.tsx
@@ -96,10 +96,9 @@ const PipelineResourceForm: React.FC<PipelineResourceFormProps> = ({
       onSubmit={handleSubmit}
       onReset={handleReset}
       validationSchema={validationSchema}
-      render={(props) => (
-        <PipelineResourceParam {...props} type={type} closeDisabled={closeDisabled} />
-      )}
-    />
+    >
+      {(props) => <PipelineResourceParam {...props} type={type} closeDisabled={closeDisabled} />}
+    </Formik>
   );
 };
 

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -1,12 +1,20 @@
 import * as _ from 'lodash';
 import { formatDuration } from '@console/internal/components/utils/datetime';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import {
+  K8sResourceKind,
+  k8sUpdate,
+  k8sGet,
+  SecretKind,
+  K8sResourceCommon,
+} from '@console/internal/module/k8s';
 import {
   LOG_SOURCE_RESTARTING,
   LOG_SOURCE_WAITING,
   LOG_SOURCE_RUNNING,
   LOG_SOURCE_TERMINATED,
 } from '@console/internal/components/utils';
+import { ServiceAccountModel } from '@console/internal/models';
+import { errorModal } from '@console/internal/components/modals/error-modal';
 import {
   getLatestRun,
   Pipeline,
@@ -17,11 +25,16 @@ import {
   PipelineTaskRef,
 } from './pipeline-augment';
 import { pipelineFilterReducer, pipelineRunStatus } from './pipeline-filter-reducer';
+import { PIPELINE_SERVICE_ACCOUNT } from '../components/pipelines/const';
 
 interface Resources {
   inputs?: Resource[];
   outputs?: Resource[];
 }
+
+type ServiceAccountKind = {
+  secrets: { [name: string]: string }[];
+} & K8sResourceCommon;
 
 interface Resource {
   name: string;
@@ -310,4 +323,25 @@ export const pipelineRunDuration = (run: PipelineRun): string => {
     ? new Date(completionTime).getTime() - start
     : new Date().getTime() - start;
   return formatDuration(duration);
+};
+
+export const updateServiceAccount = (
+  secretName: string,
+  originalServiceAccount: ServiceAccountKind,
+): Promise<ServiceAccountKind> => {
+  const updatedServiceAccount = _.cloneDeep(originalServiceAccount);
+  updatedServiceAccount.secrets = [...updatedServiceAccount.secrets, { name: secretName }];
+  return k8sUpdate(ServiceAccountModel, updatedServiceAccount);
+};
+
+export const associateServiceAccountToSecret = (secret: SecretKind, namespace: string) => {
+  k8sGet(ServiceAccountModel, PIPELINE_SERVICE_ACCOUNT, namespace)
+    .then((serviceAccount) => {
+      if (_.find(serviceAccount.secrets, (s) => s.name === secret.metadata.name) === undefined) {
+        updateServiceAccount(secret.metadata.name, serviceAccount);
+      }
+    })
+    .catch((err) => {
+      errorModal({ error: err.message });
+    });
 };

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -521,7 +521,7 @@ type CreateConfigSubformState = {
   }[];
 };
 
-class CreateConfigSubform extends React.Component<
+export class CreateConfigSubform extends React.Component<
   CreateConfigSubformProps,
   CreateConfigSubformState
 > {


### PR DESCRIPTION
**Fixes**: 
Story - https://issues.redhat.com/browse/ODC-3351

**Analysis / Root cause**: 
Pipeline fails if the user provides a private git repository.
**Solution Description**: 
Now we have an advanced option in start pipeline modal from which user can add secrets for the private git resource.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Kapture 2020-04-01 at 3 19 33](https://user-images.githubusercontent.com/2561818/78079003-db698300-73c8-11ea-89e1-7af954022844.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
