### PR TITLE
Bug 1819603: Limit Bucket Class search to storage namespace in OBC creation page

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/create-obc.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/object-bucket-claim-page/create-obc.tsx
@@ -27,6 +27,7 @@ import { StorageClass } from '@console/internal/components/storage-class-form';
 import { filterScOnProvisioner, getName } from '@console/shared';
 import ResourceDropdown from '@console/dev-console/src/components/dropdown/ResourceDropdown';
 import { commonReducer, defaultState } from '../object-bucket-page/state';
+import { OCS_NS } from '../../constants';
 import './create-obc.scss';
 
 export const CreateOBCPage: React.FC<CreateOBCPageProps> = (props) => {
@@ -137,8 +138,8 @@ export const CreateOBCPage: React.FC<CreateOBCPageProps> = (props) => {
                 resources={[
                   {
                     isList: true,
-                    namespace,
                     kind: referenceForModel(NooBaaBucketClassModel),
+                    namespace: OCS_NS,
                     prop: 'bucketClass',
                   },
                 ]}

--- a/frontend/packages/noobaa-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/index.ts
@@ -6,6 +6,7 @@ export const BY_PHYSICAL_VS_LOGICAL_USAGE = 'Physical Vs Logical Usage';
 export const BY_EGRESS = 'Egress';
 export const PROJECTS = 'Projects';
 export const BUCKET_CLASS = 'Bucket Class';
+export const OCS_NS = 'openshift-storage';
 
 export const CHART_LABELS = {
   [BY_LOGICAL_USAGE]: 'Logical used capacity per account',


### PR DESCRIPTION
Original PR cherry-picked by the bot: https://github.com/openshift/console/pull/4593
 - It has multiple instances of the same prop(`namespace`), which fails the frontend test. 
 - Fixed it by removing the redundant `namespace` prop.