### PR TITLE
Move v2vvmware CRD under v2v.kubevirt.io API group

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/objects/v2vvmware-role.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/objects/v2vvmware-role.ts
@@ -38,7 +38,7 @@ export const buildV2VVMwareRole = ({ name, namespace }: { name: string; namespac
         verbs: ['create', 'get'],
       },
       {
-        apiGroups: ['kubevirt.io'],
+        apiGroups: ['v2v.kubevirt.io'],
         attributeRestrictions: null,
         resources: ['*'],
         verbs: ['*'],

--- a/frontend/packages/kubevirt-plugin/src/models/index.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/index.ts
@@ -77,7 +77,7 @@ export const V2VVMwareModel: K8sKind = {
   label: 'V2V VMWare Provider',
   labelPlural: 'V2V VMWare Providers',
   apiVersion: 'v1alpha1',
-  apiGroup: 'kubevirt.io',
+  apiGroup: 'v2v.kubevirt.io',
   plural: 'v2vvmwares',
   abbr: 'VVW',
   namespaced: true,


### PR DESCRIPTION
Former group: kubevirt.io

Related PRs:
- https://github.com/kubevirt/hyperconverged-cluster-operator/pull/519
- https://github.com/ManageIQ/manageiq-v2v-conversion_host/pull/42