### PR TITLE
Fix infinite network calls and handle network errors gracefully

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmChartVersionDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmChartVersionDropdown.tsx
@@ -46,12 +46,13 @@ const HelmChartVersionDropdown: React.FunctionComponent<HelmChartVersionDropdown
   }, [chartName]);
 
   const onChartVersionChange = (value: string) => {
+    const chartURL = getChartURL(helmChartEntries, value);
+
     setChartVersion(value);
     setFieldValue('chartVersion', value);
-    const chartURL = getChartURL(helmChartEntries, value);
     setFieldValue('helmChartURL', chartURL);
-    const url = getChartURL(helmChartEntries, value);
-    coFetchJSON(`/api/helm/chart?url=${url}`)
+
+    coFetchJSON(`/api/helm/chart?url=${chartURL}`)
       .then((res) => {
         setFieldValue('chartValuesYAML', !_.isEmpty(res.values) ? safeDump(res.values) : undefined);
       })

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -66,6 +66,7 @@ export enum HelmActionType {
 
 export interface HelmActionConfigType {
   title: string;
+  subTitle: string;
   helmReleaseApi: string;
   fetch: (url: any, json: any, options?: {}) => Promise<any>;
   redirectURL: string;

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -1,7 +1,13 @@
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash';
 import { coFetchJSON } from '@console/internal/co-fetch';
-import { HelmRelease, HelmReleaseStatus, HelmChartMetaData } from './helm-types';
+import {
+  HelmRelease,
+  HelmReleaseStatus,
+  HelmChartMetaData,
+  HelmActionType,
+  HelmActionConfigType,
+} from './helm-types';
 import { CustomResourceListRowFilter } from '../custom-resource-list/custom-resource-list-types';
 
 export const HelmReleaseStatusLabels = {
@@ -81,4 +87,32 @@ export const getChartVersions = (chartEntries: HelmChartMetaData[]) => {
     {},
   );
   return chartVersions;
+};
+
+export const getHelmActionConfig = (
+  helmAction: HelmActionType,
+  releaseName: string,
+  namespace: string,
+  chartURL: string,
+): HelmActionConfigType | undefined => {
+  switch (helmAction) {
+    case HelmActionType.Install:
+      return {
+        title: 'Install Helm Chart',
+        subTitle: 'The helm chart will be installed using the YAML shown in the editor below.',
+        helmReleaseApi: `/api/helm/chart?url=${chartURL}`,
+        fetch: coFetchJSON.post,
+        redirectURL: `/topology/ns/${namespace}`,
+      };
+    case HelmActionType.Upgrade:
+      return {
+        title: 'Upgrade Helm Release',
+        subTitle: '',
+        helmReleaseApi: `/api/helm/release?ns=${namespace}&release_name=${releaseName}`,
+        fetch: coFetchJSON.put,
+        redirectURL: `/helm-releases/ns/${namespace}`,
+      };
+    default:
+      return undefined;
+  }
 };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3475
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Due to incorrect use of `useEffect` dependency array, infinite calls to network were happening on install and upgrade forms of helm. Also, if the network call fails the page kept loading infinitely without handling it gracefully.


**Solution Description**: Fix the `useEffect` dependency by creating a context and using it everywhere. Use TS optional chaining to safeguard against network failures.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge