### PR TITLE
Added extra chart info in the Helm details page

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmChartSummary.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmChartSummary.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { HelmRelease } from './helm-types';
+import { Timestamp } from '@console/internal/components/utils';
+
+interface HelmChartSummaryProps {
+  helmRelease: HelmRelease;
+}
+
+const HelmChartSummary: React.FC<HelmChartSummaryProps> = ({ helmRelease }) => {
+  const {
+    chart: {
+      metadata: { name: chartName, version: chartVersion, appVersion },
+    },
+    info: { last_deployed: updated },
+    version: revision,
+  } = helmRelease;
+
+  return (
+    <dl className="co-m-pane__details">
+      <dt>Chart Name</dt>
+      <dd>{chartName}</dd>
+      <dt>Chart Version</dt>
+      <dd>{chartVersion}</dd>
+      <dt>App Version</dt>
+      <dd>{appVersion}</dd>
+      <dt>Revision</dt>
+      <dd>{revision}</dd>
+      <dt>Updated</dt>
+      <dd>
+        <Timestamp timestamp={updated} />
+      </dd>
+    </dl>
+  );
+};
+
+export default HelmChartSummary;

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseDetailsPage.tsx
@@ -11,6 +11,8 @@ import { SecretModel } from '@console/internal/models';
 import { ErrorPage404 } from '@console/internal/components/error';
 import { DetailsPage } from '@console/internal/components/factory';
 import { K8sResourceKindReference } from '@console/internal/module/k8s';
+import { Status } from '@console/shared';
+import { Badge } from '@patternfly/react-core';
 import { fetchHelmReleases } from './helm-utils';
 import HelmReleaseResources from './HelmReleaseResources';
 import HelmReleaseOverview from './HelmReleaseOverview';
@@ -52,7 +54,16 @@ export const LoadedHelmReleaseDetailsPage: React.FC<LoadedHelmReleaseDetailsPage
   if (_.isEmpty(secretResource)) return <ErrorPage404 />;
 
   const secretName = secretResource[0]?.metadata.name;
-  const releaseName = secretResource[0]?.metadata.labels?.name;
+  const releaseName = helmReleaseData?.name;
+
+  const title = (
+    <>
+      {releaseName}
+      <Badge isRead style={{ verticalAlign: 'middle', marginLeft: 'var(--pf-global--spacer--md)' }}>
+        <Status status={_.capitalize(helmReleaseData?.info?.status)} />
+      </Badge>
+    </>
+  );
 
   const menuActions = [
     () => upgradeHelmRelease(releaseName, namespace),
@@ -74,7 +85,7 @@ export const LoadedHelmReleaseDetailsPage: React.FC<LoadedHelmReleaseDetailsPage
         },
         { name: `Helm Release Details`, path: `${match.url}` },
       ]}
-      title={releaseName}
+      title={title}
       kind={SecretReference}
       pages={[
         navFactory.details(HelmReleaseOverview),

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseOverview.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseOverview.tsx
@@ -1,18 +1,27 @@
 import * as React from 'react';
 import { ResourceSummary, SectionHeading } from '@console/internal/components/utils';
 import { K8sResourceKind } from '@console/internal/module/k8s';
+import { HelmRelease } from './helm-types';
+import HelmChartSummary from './HelmChartSummary';
 
 export interface HelmReleaseOverviewProps {
   obj: K8sResourceKind;
+  customData: HelmRelease;
 }
 
-const HelmReleaseOverview: React.FC<HelmReleaseOverviewProps> = ({ obj: resourceDetails }) => {
+const HelmReleaseOverview: React.FC<HelmReleaseOverviewProps> = ({
+  obj: resourceDetails,
+  customData,
+}) => {
   return (
     <div className="co-m-pane__body">
       <SectionHeading text="Helm Release Details" />
       <div className="row">
         <div className="col-sm-6">
           <ResourceSummary resource={resourceDetails} customPathName={'metadata.labels.name'} />
+        </div>
+        <div className="col-sm-6">
+          <HelmChartSummary helmRelease={customData} />
         </div>
       </div>
     </div>

--- a/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseOverview.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/__tests__/HelmReleaseOverview.spec.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { ResourceSummary, SectionHeading } from '@console/internal/components/utils';
 import HelmReleaseOverview from '../HelmReleaseOverview';
+import { mockHelmReleases } from './helm-release-mock-data';
+import HelmChartSummary from '../HelmChartSummary';
 
 const helmReleaseOverviewProps: React.ComponentProps<typeof HelmReleaseOverview> = {
   obj: {
@@ -10,12 +12,13 @@ const helmReleaseOverviewProps: React.ComponentProps<typeof HelmReleaseOverview>
       namespace: 'xyz',
       creationTimestamp: '2020-01-13T05:42:19Z',
       labels: {
-        name: 'helm-mysql',
+        name: 'ghost-test',
         owner: 'helm',
         status: 'deployed',
       },
     },
   },
+  customData: mockHelmReleases[0],
 };
 
 describe('HelmReleaseOverview', () => {
@@ -31,5 +34,10 @@ describe('HelmReleaseOverview', () => {
   it('should render the ResourceSummary component', () => {
     const helmReleaseOverview = shallow(<HelmReleaseOverview {...helmReleaseOverviewProps} />);
     expect(helmReleaseOverview.find(ResourceSummary).exists()).toBe(true);
+  });
+
+  it('should render the HelmChartSummary component', () => {
+    const helmReleaseOverview = shallow(<HelmReleaseOverview {...helmReleaseOverviewProps} />);
+    expect(helmReleaseOverview.find(HelmChartSummary).exists()).toBe(true);
   });
 });


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3460


**Analysis / Root cause**:  UX changed the details tab of Helm Release details page to also include infor about the Helm Chart.

**Solution Description**: Update the overview component to also include summary of Helm Chart and release status.

**Screen shots / Gifs for design review**: 
@openshift/team-ux-review 
![Screenshot from 2020-04-02 00-21-23](https://user-images.githubusercontent.com/6041994/78175293-402fe680-7478-11ea-94e2-5bf2d10c58f8.png)


**Unit test coverage report**: 
![Screenshot from 2020-04-02 00-21-45](https://user-images.githubusercontent.com/6041994/78175316-46be5e00-7478-11ea-9d01-e287ee381f0f.png)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge