### PR TITLE
destroy old graph when new model has a new graph id

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
@@ -110,12 +110,7 @@ const PipelineTemplate: React.FC<PipelineTemplateProps> = ({ builderImages }) =>
         isExpanded={isExpanded}
         onToggle={() => setIsExpanded(!isExpanded)}
       >
-        {isExpanded && (
-          <PipelineVisualization
-            pipeline={pipeline.template}
-            key={pipeline.template.metadata.name} // this is a hack because of an issue with PipelineVisualization component not rerending
-          />
-        )}
+        {isExpanded && <PipelineVisualization pipeline={pipeline.template} />}
       </Expandable>
     </>
   ) : (

--- a/frontend/packages/topology/src/Visualization.ts
+++ b/frontend/packages/topology/src/Visualization.ts
@@ -46,6 +46,8 @@ export default class Visualization extends Stateful implements Controller {
 
   @action
   fromModel(model: Model): void {
+    const oldGraph = this.graph;
+
     // create elements
     if (model.graph) {
       this.graph = this.createElement<Graph>(ModelKind.graph, model.graph);
@@ -96,6 +98,10 @@ export default class Visualization extends Stateful implements Controller {
       }
     });
 
+    if (oldGraph && oldGraph !== this.graph) {
+      this.removeElement(oldGraph);
+    }
+
     if (this.graph) {
       this.parentOrphansToGraph(this.graph);
     }
@@ -140,6 +146,7 @@ export default class Visualization extends Stateful implements Controller {
         .getChildren()
         .slice()
         .forEach((child) => child.remove());
+      element.destroy();
       element.setController(undefined);
       delete this.elements[element.getId()];
     }

--- a/frontend/packages/topology/src/__tests__/Visualization.spec.ts
+++ b/frontend/packages/topology/src/__tests__/Visualization.spec.ts
@@ -1,0 +1,34 @@
+import Visualization from '../Visualization';
+
+describe('Visualization', () => {
+  it('should clean up old graph model', () => {
+    const visualization = new Visualization();
+
+    expect(visualization.getElementById('a')).toBeUndefined();
+    visualization.fromModel({
+      graph: {
+        id: 'a',
+        type: 'graph',
+      },
+    });
+    const graphA = visualization.getElementById('a');
+    expect(graphA).not.toBeUndefined();
+
+    if (!graphA) {
+      fail();
+      return;
+    }
+
+    graphA.destroy = jest.fn();
+
+    visualization.fromModel({
+      graph: {
+        id: 'b',
+        type: 'graph',
+      },
+    });
+    expect(visualization.getElementById('a')).toBeUndefined();
+    expect(visualization.getElementById('b')).not.toBeUndefined();
+    expect(graphA.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/packages/topology/src/components/VisualizationSurface.tsx
+++ b/frontend/packages/topology/src/components/VisualizationSurface.tsx
@@ -48,6 +48,8 @@ const VisualizationSurface: React.FC<VisualizationSurfaceProps> = ({ visualizati
   // dispose of onMeasure
   React.useEffect(() => () => onMeasure.cancel(), [onMeasure]);
 
+  const graph = visualization.getGraph();
+
   return (
     <ControllerContext.Provider value={visualization}>
       <ReactMeasure client onResize={onMeasure}>
@@ -56,7 +58,7 @@ const VisualizationSurface: React.FC<VisualizationSurfaceProps> = ({ visualizati
           <div data-test-id="topology" className="topology-visualization-surface" ref={measureRef}>
             <svg className="topology-visualization-surface__svg" onContextMenu={stopEvent}>
               <SVGDefsProvider>
-                <ElementWrapper element={visualization.getGraph()} />
+                <ElementWrapper element={graph} />
               </SVGDefsProvider>
             </svg>
           </div>

--- a/frontend/packages/topology/src/elements/BaseElement.ts
+++ b/frontend/packages/topology/src/elements/BaseElement.ts
@@ -215,6 +215,9 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
   }
 
   setModel(model: E): void {
+    if ('type' in model) {
+      this.setType(model.type);
+    }
     if ('visible' in model) {
       this.setVisible(!!model.visible);
     }
@@ -278,6 +281,10 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   translateFromParent(t: Translatable): void {
+    // nothing to do
+  }
+
+  destroy(): void {
     // nothing to do
   }
 }

--- a/frontend/packages/topology/src/elements/BaseGraph.ts
+++ b/frontend/packages/topology/src/elements/BaseGraph.ts
@@ -231,4 +231,10 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any> exten
   translateFromAbsolute(): void {
     // do nothing
   }
+
+  destroy(): void {
+    if (this.currentLayout) {
+      this.currentLayout.destroy();
+    }
+  }
 }

--- a/frontend/packages/topology/src/elements/BaseNode.ts
+++ b/frontend/packages/topology/src/elements/BaseNode.ts
@@ -162,7 +162,7 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
         .getCenter()
         .clone();
       this.collapsed = collapsed;
-      this.getBounds().setCenter(prevCenter.x, prevCenter.y);
+      this.setBounds(this.getBounds().setCenter(prevCenter.x, prevCenter.y));
       this.getController().fireEvent(NODE_COLLAPSE_CHANGE_EVENT, { node: this });
     }
   }
@@ -216,9 +216,6 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
 
     if (r) {
       this.setBounds(r);
-    }
-    if ('type' in model) {
-      this.setType(model.type);
     }
     if ('group' in model) {
       this.group = !!model.group;

--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -77,6 +77,7 @@ export interface Anchor {
 }
 
 export interface GraphElement<E extends ElementModel = ElementModel, D = any> extends WithState {
+  destroy(): void;
   getKind(): ModelKind;
   getLabel(): string;
   setLabel(label: string): void;


### PR DESCRIPTION
**Fixes**: 
Fixes: https://issues.redhat.com/browse/ODC-3451

**Analysis / Root cause**: 
The topology Visualization never cleaned up the old graph element reference if a new model was set with the graph having a new ID. Since IDs define element object identify in a visualization, a new graph element is created with the new ID. Therefore the old graph is no longer needed however it wasn't properly disposed.

**Solution Description**: 
Check if model contains a new graph ID and if so dispose of the old graph.
Removed the `key` from within `PipelineTemplate` which was a temporary fix.
Added test case for this 

**Screen shots / Gifs for design review**: 
![update-pipeline-viz](https://user-images.githubusercontent.com/14068621/78178016-fff74680-742c-11ea-99e0-59b967a74d2f.gif)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
