### PR TITLE
Bug 1820058: Last navigation item needs more bottom padding

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -296,7 +296,6 @@ h6 {
 
 .pf-c-page__sidebar {
   --pf-c-page__sidebar-body--PaddingTop: 0;
-  --pf-c-page__sidebar-body--PaddingBottom: 0;
   bottom: 0;
   left: 0;
   position: absolute;


### PR DESCRIPTION
Opened an issue per slack conversation with @alimobrem @beanh66 and @smarterclayton 

Adding additional padding to the nav list

Screen:
![Screenshot 2020-04-02 at 10 15 18](https://user-images.githubusercontent.com/1668218/78225873-28358280-74cb-11ea-84b0-db5e8aca3b24.png)


/assign @rhamilto 