### PR TITLE
Monitoring: User user's username as default silence creator value

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1459,14 +1459,18 @@ const EditSilence = connect(silenceParamToProps)(({ loaded, loadError, silence }
   );
 });
 
-const CreateSilence = () => {
+const CreateSilence_ = ({ createdBy }) => {
   const matchers = _.map(getURLSearchParams(), (value, name) => ({ name, value, isRegex: false }));
   return _.isEmpty(matchers) ? (
-    <SilenceForm saveButtonText="Create" title="Create Silence" />
+    <SilenceForm defaults={{ createdBy }} saveButtonText="Create" title="Create Silence" />
   ) : (
-    <SilenceForm defaults={{ matchers }} saveButtonText="Create" title="Silence Alert" />
+    <SilenceForm defaults={{ createdBy, matchers }} saveButtonText="Create" title="Silence Alert" />
   );
 };
+const createSilenceStateToProps = ({ UI }: RootState) => ({
+  createdBy: UI.get('user')?.metadata?.name,
+});
+const CreateSilence = connect(createSilenceStateToProps)(CreateSilence_);
 
 const AlertmanagerYAML = () => {
   return (


### PR DESCRIPTION
When creating a new silence, automatically fill the "Creator" field with
the user's username.

![screenshot](https://user-images.githubusercontent.com/460802/78236084-820e6a80-7514-11ea-85ca-b8c7eaa25045.png)

FYI @cshinn 