### PR TITLE
Fix Label and ChartLegend type issue

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/__tests__/breakdown-chart.spec.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/__tests__/breakdown-chart.spec.tsx
@@ -56,7 +56,9 @@ describe('<LinkableLegend>', () => {
   });
 
   it('Returns tooltip', () => {
-    wrapper.setProps({ datum: { name: 'Other', link: '#', labels: { fill: '#000' } } });
+    wrapper.setProps({
+      datum: { name: 'Other', labelId: 'Other', link: '#', labels: { fill: '#000' } },
+    });
     expect(wrapper.find(Tooltip).exists()).toBe(true);
   });
 });

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-chart.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/breakdown-chart.tsx
@@ -34,7 +34,7 @@ export const LinkableLegend: React.FC<LinkableLegendProps> = React.memo(
         />
       </Tooltip>
     );
-    if (datum.name === OTHER || datum.name === CLUSTERWIDE) {
+    if (datum.labelId === OTHER || datum.labelId === CLUSTERWIDE) {
       return customLegend;
     }
     if (metricModel.kind === BUCKETCLASSKIND) {

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/utils.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/breakdown-card/utils.tsx
@@ -61,10 +61,11 @@ export const addAvailable = (
 
 export const getLegends = (data: StackDataPoint[]) =>
   data.map((d: StackDataPoint) => ({
-    name: d.name || d.label,
+    name: `${d.name}\n${d.label}`,
     labels: { fill: d.color },
     symbol: { fill: d.fill },
     link: d.link,
+    labelId: d.name,
     ns: d.ns,
   }));
 


### PR DESCRIPTION
- Fix the label.
- Props passed to Chart
- Legend prop `data.name` set to `string`.
![Screenshot from 2020-04-02 18-39-02](https://user-images.githubusercontent.com/54092533/78252945-402ff500-7511-11ea-8c2c-49a787a2e340.png)
cc @afreen23 