### PR TITLE
Bug 1826234: Filter out duplicate OSes in the new VM wizard

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/combined.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/combined.ts
@@ -3,7 +3,7 @@ import { TemplateKind } from '@console/internal/module/k8s';
 import { ITemplate } from '../../../types/template';
 import { getTemplateOperatingSystems } from '../../../selectors/vm-template/advanced';
 import { concatImmutableLists, immutableListToShallowJS } from '../../../utils/immutable';
-import { operatingSystemsNative } from '../native/consts';
+import { operatingSystemsNative } from '../../../constants/vm-templates/os';
 
 export const getOS = ({ osID, iUserTemplates, openshiftFlag, iCommonTemplates }: GetOSParams) => {
   const operatingSystems = openshiftFlag

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
@@ -21,7 +21,7 @@ import { VMSettingsField } from '../../types';
 import { iGetFieldValue } from '../../selectors/immutable/field';
 import { getPlaceholder } from '../../utils/renderable-field-utils';
 import { nullOnEmptyChange } from '../../utils/utils';
-import { operatingSystemsNative } from '../../native/consts';
+import { operatingSystemsNative } from '../../../../constants/vm-templates/os';
 
 export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
   ({

--- a/frontend/packages/kubevirt-plugin/src/constants/vm-templates/os.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm-templates/os.ts
@@ -1,4 +1,6 @@
-export const operatingSystemsNative = [
+import { OperatingSystemRecord } from '../../types/types';
+
+export const operatingSystemsNative: OperatingSystemRecord[] = [
   { id: 'centos8', name: 'CentOS 8.0' },
   { id: 'centos7', name: 'CentOS 7.0' },
   { id: 'centos6', name: 'CentOS 6.0' },

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-template/advanced.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-template/advanced.ts
@@ -16,6 +16,7 @@ import {
 import { getCloudInitVolume } from '../vm/selectors';
 import { VolumeWrapper } from '../../k8s/wrapper/vm/volume-wrapper';
 import { selectVM } from './basic';
+import { removeOSDups } from '../../utils/sort';
 
 export const getTemplatesWithLabels = (templates: TemplateKind[], labels: string[]) => {
   const requiredLabels = labels.filter((label) => label);
@@ -71,17 +72,19 @@ export const getTemplateHostname = (template: TemplateKind) => {
 
 export const getTemplateOperatingSystems = (templates: TemplateKind[]) => {
   const osIds = getTemplatesLabelValues(templates, TEMPLATE_OS_LABEL);
-  return osIds.map((osId) => {
-    const nameAnnotation = `${TEMPLATE_OS_NAME_ANNOTATION}/${osId}`;
-    const template = templates.find(
-      (t) =>
-        !!Object.keys(getAnnotations(t, {})).find((annotation) => annotation === nameAnnotation),
-    );
-    return {
-      id: osId,
-      name: getAnnotation(template, nameAnnotation),
-    };
-  });
+  return removeOSDups(
+    osIds.map((osId) => {
+      const nameAnnotation = `${TEMPLATE_OS_NAME_ANNOTATION}/${osId}`;
+      const template = templates.find(
+        (t) =>
+          !!Object.keys(getAnnotations(t, {})).find((annotation) => annotation === nameAnnotation),
+      );
+      return {
+        id: osId,
+        name: getAnnotation(template, nameAnnotation),
+      };
+    }),
+  );
 };
 
 export const getTemplateWorkloadProfiles = (templates: TemplateKind[]) =>

--- a/frontend/packages/kubevirt-plugin/src/types/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/types.ts
@@ -11,3 +11,8 @@ export type BootableDeviceType = {
 export type IDEntity = {
   id: number;
 };
+
+export type OperatingSystemRecord = {
+  id: string;
+  name: string;
+};

--- a/frontend/packages/kubevirt-plugin/src/utils/__tests__/sort.spec.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/__tests__/sort.spec.ts
@@ -1,0 +1,104 @@
+import * as _ from 'lodash';
+import { compareVersions, removeOSDups } from '../sort';
+import { OperatingSystemRecord } from '../../types/types';
+
+/**
+ * Compare two versions: ver1 and ver2
+ * return  1 : ver1 > ver2
+ * return -1 : ver1 < ver2
+ * return  0 : ver1 = ver2
+ */
+
+describe('compareVersions', () => {
+  const osVersion0: number[] = null;
+  const osVersion1: number[] = [1, 2, 3];
+  const osVersion2: number[] = [1, 2, 4];
+  const osVersion3: number[] = [1, 1];
+  const osVersion4: number[] = [1];
+  const osVersion5: number[] = [2];
+  const osVersion6: number[] = [1, 0];
+  const osVersion7: number[] = [1, 0, 0];
+  const osVersion8: number[] = [0];
+  const osVersion9: number[] = [0, 0, 0];
+
+  it('check non-equal versions with same length', () => {
+    expect(compareVersions(osVersion1, osVersion2)).toEqual(-1);
+    expect(compareVersions(osVersion2, osVersion1)).toEqual(1);
+    expect(compareVersions(osVersion5, osVersion4)).toEqual(1);
+  });
+
+  it('check non-equal versions with different length', () => {
+    expect(compareVersions(osVersion1, osVersion3)).toEqual(1);
+    expect(compareVersions(osVersion5, osVersion2)).toEqual(1);
+    expect(compareVersions(osVersion2, osVersion6)).toEqual(1);
+    expect(compareVersions(osVersion4, osVersion1)).toEqual(-1);
+  });
+
+  it('check equal versions with same length', () => {
+    expect(compareVersions(osVersion1, osVersion1)).toEqual(0);
+    expect(compareVersions(osVersion3, osVersion3)).toEqual(0);
+    expect(compareVersions(osVersion4, osVersion4)).toEqual(0);
+  });
+
+  it('check equal versions with different length', () => {
+    expect(compareVersions(osVersion4, osVersion6)).toEqual(0);
+    expect(compareVersions(osVersion7, osVersion4)).toEqual(0);
+    expect(compareVersions(osVersion7, osVersion6)).toEqual(0);
+  });
+
+  it('check non-equal versions when one of them is null', () => {
+    expect(compareVersions(osVersion0, osVersion6)).toEqual(-1);
+    expect(compareVersions(osVersion2, osVersion0)).toEqual(1);
+  });
+
+  it('check equal versions when one of them is null and the other has only zeros', () => {
+    expect(compareVersions(osVersion0, osVersion8)).toEqual(0);
+    expect(compareVersions(osVersion9, osVersion0)).toEqual(0);
+  });
+
+  it('check equal versions when both of them are null', () => {
+    expect(compareVersions(osVersion0, osVersion0)).toEqual(0);
+  });
+});
+
+describe('removeOSDups', () => {
+  const osWithDups: OperatingSystemRecord[] = [
+    { id: 'centos8.0', name: 'CentOS 8.0 or higher' },
+    { id: 'centos7', name: 'CentOS 7.0 or higher' },
+    { id: 'centos7.1', name: 'CentOS 7.0 or higher' },
+    { id: 'centos7.10', name: 'CentOS 7.0 or higher' },
+    { id: 'centos6.0', name: 'CentOS 6.0 or higher' },
+    { id: 'centos6.1', name: 'CentOS 6.0 or higher' },
+    { id: 'centos6.2', name: 'CentOS 6.0 or higher' },
+    { id: 'centos6.3', name: 'CentOS 6.0 or higher' },
+    { id: 'centos6.4', name: 'CentOS 6.0 or higher' },
+    { id: 'fedora31', name: 'Fedora 29 or higher' },
+    { id: 'fedora30', name: 'Fedora 29 or higher' },
+    { id: 'fedora29', name: 'Fedora 29 or higher' },
+    { id: 'win10', name: 'Microsoft Windows 10' },
+    { id: 'opensuse15.0', name: 'openSUSE 15' },
+    { id: 'rhel8', name: 'Red Hat Linux 8' },
+    { id: 'rhel7', name: 'Red Hat Linux 7' },
+    { id: 'rhel6', name: 'Red Hat Linux 6' },
+    { id: 'ubuntu18.04', name: 'Ubuntu 17 or higher' },
+    { id: 'ubuntu17.10', name: 'Ubuntu 17 or higher' },
+    { id: 'ubuntu17.04', name: 'Ubuntu 17 or higher' },
+  ];
+
+  const osWithoutDups: OperatingSystemRecord[] = [
+    { id: 'centos8.0', name: 'CentOS 8.0 or higher' },
+    { id: 'centos7.10', name: 'CentOS 7.0 or higher' },
+    { id: 'centos6.4', name: 'CentOS 6.0 or higher' },
+    { id: 'fedora31', name: 'Fedora 29 or higher' },
+    { id: 'win10', name: 'Microsoft Windows 10' },
+    { id: 'opensuse15.0', name: 'openSUSE 15' },
+    { id: 'rhel8', name: 'Red Hat Linux 8' },
+    { id: 'rhel7', name: 'Red Hat Linux 7' },
+    { id: 'rhel6', name: 'Red Hat Linux 6' },
+    { id: 'ubuntu18.04', name: 'Ubuntu 17 or higher' },
+  ];
+
+  it('remove duplicate records with the same name leaving the id with the highest version', () => {
+    expect(_.sortBy(removeOSDups(osWithDups), ['id'])).toEqual(_.sortBy(osWithoutDups, ['id']));
+  });
+});

--- a/frontend/packages/kubevirt-plugin/src/utils/sort.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/sort.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import { CUSTOM_FLAVOR } from '../constants/vm';
+import { OperatingSystemRecord } from '../types';
 
 const FLAVOR_ORDER = {
   tiny: 0,
@@ -46,3 +47,72 @@ export const ignoreCaseSort = <T>(
   };
   return array.sort((a, b) => resolve(a).localeCompare(resolve(b)));
 };
+
+const getOSVersion = (osID: string): number[] =>
+  (osID || '')
+    .split(/\D/)
+    .filter((x) => x)
+    .map((num) => parseInt(num, 10));
+
+/**
+ *
+ *
+ * Compare the numbers between the two versions by the order of their appearance
+ * in the OS name.
+ *
+ * For example:
+ * osVersion1: [10,2] for OS: 'Windows 10 R2',
+ * osVersion2: [10] for OS: 'Windows 10',
+ * (return 1)
+ *
+ * osVersion1: [9,10] for OS: 'ubuntu9.10',
+ * osVersion2: [10,4] for OS: 'ubuntu10.04',
+ * (return -1)
+ *
+ * return 0 when equal.
+ *
+ */
+export const compareVersions = (osVersion1: number[], osVersion2: number[]): number => {
+  if (!osVersion1 && !osVersion2) {
+    return 0;
+  }
+
+  const osVer1 = osVersion1 || [];
+  const osVer2 = osVersion2 || [];
+
+  const zipped = _.zip(osVer1, osVer2);
+  let idx = 0;
+  while (idx < zipped.length) {
+    /*
+      undefined values are equal to 0, eg:
+      14.0 == 14 -> zipped = [[14,14],[0,undefined]]
+      1.0.0 == 1 -> zipped = [[1,1],[0,undefined],[0,undefined]]
+    */
+    const ver1 = !zipped[idx][0] ? 0 : zipped[idx][0];
+    const ver2 = !zipped[idx][1] ? 0 : zipped[idx][1];
+
+    if (ver1 > ver2) {
+      return 1;
+    }
+
+    if (ver2 > ver1) {
+      return -1;
+    }
+
+    idx++;
+  }
+
+  return 0;
+};
+
+const descSortOSes = (os1: OperatingSystemRecord, os2: OperatingSystemRecord): number => {
+  const nameCMP = (os1.name || '').localeCompare(os2.name || '');
+  if (nameCMP !== 0) {
+    return nameCMP * -1;
+  }
+
+  return compareVersions(getOSVersion(os1.id), getOSVersion(os2.id)) * -1;
+};
+
+export const removeOSDups = (osArr: OperatingSystemRecord[]): OperatingSystemRecord[] =>
+  _.uniqBy(osArr.filter((x) => x).sort(descSortOSes), 'name');


### PR DESCRIPTION
templates in `common-templates` have some labels pointing to the same name annotation. 
Thus, filter the duplicate OSes names presented in the VM wizard.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>

![Screenshot from 2020-04-16 12-58-33](https://user-images.githubusercontent.com/18301938/79688873-e726c780-8259-11ea-914f-051f536aa3d1.png)