### PR TITLE
Add pinned resource pages to dev perspective navigation

### DIFF
--- a/frontend/__tests__/actions/ui.spec.ts
+++ b/frontend/__tests__/actions/ui.spec.ts
@@ -1,5 +1,9 @@
 import * as _ from 'lodash-es';
-import { ALL_NAMESPACES_KEY, LAST_PERSPECTIVE_LOCAL_STORAGE_KEY } from '@console/shared';
+import {
+  ALL_NAMESPACES_KEY,
+  LAST_PERSPECTIVE_LOCAL_STORAGE_KEY,
+  PINNED_RESOURCES_LOCAL_STORAGE_KEY,
+} from '@console/shared';
 import { formatNamespacedRouteForResource } from '@console/shared/src/utils/namespace';
 import '../../__mocks__/localStorage';
 import store from '../../public/redux';
@@ -10,6 +14,7 @@ import { getActiveNamespace } from '@console/internal/reducers/ui';
 const setActiveNamespace = (ns) => store.dispatch(UIActions.setActiveNamespace(ns));
 const setActivePerspective = (perspective) =>
   store.dispatch(UIActions.setActivePerspective(perspective));
+const setPinnedResources = (resources) => store.dispatch(UIActions.setPinnedResources(resources));
 const getNamespacedRoute = (path) =>
   UIActions.formatNamespaceRoute(getActiveNamespace(store.getState()), path);
 
@@ -133,6 +138,31 @@ describe('ui-actions', () => {
     it('sets active perspective in localStorage', () => {
       setActivePerspective('test');
       expect(localStorage.getItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY)).toEqual('test');
+    });
+  });
+
+  describe('setPinnedResources', () => {
+    it('should create setPinnedResources action', () => {
+      setActivePerspective('test');
+      expect(UIActions.setPinnedResources(['resource1', 'resource2'])).toEqual({
+        type: UIActions.ActionType.SetPinnedResources,
+        payload: {
+          resources: ['resource1', 'resource2'],
+        },
+        error: undefined,
+        meta: undefined,
+      });
+    });
+
+    it('sets pinned resources in localStorage', () => {
+      setActivePerspective('testperspective');
+      setPinnedResources(['resource1', 'resource2']);
+      setActivePerspective('testperspective2');
+      setPinnedResources(['resource3', 'resource4']);
+      expect(JSON.parse(localStorage.getItem(PINNED_RESOURCES_LOCAL_STORAGE_KEY))).toEqual({
+        testperspective: ['resource1', 'resource2'],
+        testperspective2: ['resource3', 'resource4'],
+      });
     });
   });
 });

--- a/frontend/packages/console-plugin-sdk/src/typings/perspectives.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/perspectives.ts
@@ -12,6 +12,8 @@ namespace ExtensionProperties {
     icon: React.ReactElement;
     /** Whether the perspective is the default. There can only be one default. */
     default?: boolean;
+    /** Default pinned resources on the nav */
+    defaultPins?: string[];
     /** The function to get perspective landing page URL. */
     getLandingPageURL: GetLandingPage;
     /** The function to get perspective landing page URL for k8s. */

--- a/frontend/packages/console-shared/src/constants/common.ts
+++ b/frontend/packages/console-shared/src/constants/common.ts
@@ -34,6 +34,7 @@ export const LAST_PERSPECTIVE_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/last-perspe
 export const API_DISCOVERY_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/api-discovery-resources`;
 export const COMMUNITY_PROVIDERS_WARNING_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/community-providers-warning`;
 export const DEV_CATALOG_FILTER_KEY = `${STORAGE_PREFIX}/dev-catalog-filters`;
+export const PINNED_RESOURCES_LOCAL_STORAGE_KEY = `${STORAGE_PREFIX}/pinned-resources`;
 
 // Bootstrap user for OpenShift 4.0 clusters
 export const KUBE_ADMIN_USERNAME = 'kube:admin';

--- a/frontend/packages/dev-console/integration-tests/tests/dev-perspective.scenario.ts
+++ b/frontend/packages/dev-console/integration-tests/tests/dev-perspective.scenario.ts
@@ -10,13 +10,19 @@ import {
   pageSidebar,
   sideHeader,
 } from '../views/dev-perspective.view';
+import { PINNED_RESOURCES_LOCAL_STORAGE_KEY } from '@console/shared/src';
 
 describe('Application Launcher Menu', () => {
   beforeAll(async () => {
+    localStorage.setItem(
+      PINNED_RESOURCES_LOCAL_STORAGE_KEY,
+      JSON.stringify({ dev: ['apps~v1~StatefulSet'] }),
+    );
     await browser.get(`${appHost}/k8s/cluster/projects`);
   });
 
   afterEach(() => {
+    localStorage.removeItem(PINNED_RESOURCES_LOCAL_STORAGE_KEY);
     checkLogs();
     checkErrors();
   });
@@ -33,6 +39,7 @@ describe('Application Launcher Menu', () => {
     expect(pageSidebar.getText()).toContain('Project Details');
     expect(pageSidebar.getText()).toContain('Project Access');
     expect(pageSidebar.getText()).toContain('Search');
+    expect(pageSidebar.getText()).toContain('Stateful Sets');
   });
 
   it('Switch to dev to admin perspective', async () => {

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -46,6 +46,7 @@ import {
   RouteModel,
   ServiceModel,
   ImageStreamImportsModel,
+  ConfigMapModel,
 } from '@console/internal/models';
 import * as yamlIcon from './images/yaml.svg';
 import * as importGitIcon from './images/from-git.svg';
@@ -399,6 +400,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       id: 'dev',
       name: 'Developer',
       icon: <CodeIcon />,
+      defaultPins: [ConfigMapModel.kind, SecretModel.kind],
       getLandingPageURL: () => '/topology',
       getK8sLandingPageURL: () => '/add',
       getImportRedirectURL: (project) => `/topology/ns/${project}`,

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -63,6 +63,7 @@ export enum ActionType {
   SetPodMetrics = 'setPodMetrics',
   SetNamespaceMetrics = 'setNamespaceMetrics',
   SetNodeMetrics = 'setNodeMetrics',
+  SetPinnedResources = 'setPinnedResources',
 }
 
 type MetricValuesByName = {
@@ -198,6 +199,10 @@ export const setActivePerspective = (perspective: string) => {
   // selected when returning to the console
   localStorage.setItem(LAST_PERSPECTIVE_LOCAL_STORAGE_KEY, perspective);
   return action(ActionType.SetActivePerspective, { perspective });
+};
+
+export const setPinnedResources = (resources: string[]) => {
+  return action(ActionType.SetPinnedResources, { resources });
 };
 
 export const beginImpersonate = (kind: string, name: string, subprotocols: string[]) =>
@@ -394,6 +399,7 @@ const uiActions = {
   setNodeMetrics,
   notificationDrawerToggleExpanded,
   notificationDrawerToggleRead,
+  setPinnedResources,
 };
 
 export type UIAction = Action<typeof uiActions>;

--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -26,8 +26,33 @@
 .co-search-group__accordion-label {
   display: flex;
   align-items: center;
+  flex: 1;
   .text-muted {
     margin-left: 10px;
+  }
+}
+.co-search-group__accordion-toggle {
+  .pf-c-accordion__toggle-text {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+
+    @media (min-width: 480px) {
+      flex-direction: row;
+    }
+  }
+
+  .co-search-group__pin-toggle {
+    padding-left: var(--pf-global--spacer--xs);
+    padding-right: var(--pf-global--spacer--xs);
+    margin-right: var(--pf-global--spacer--sm);
+    text-align: left;
+    &:focus {
+      outline: none;
+    }
+  }
+  .co-search-group__pin-toggle__icon {
+    margin-right: var(--pf-global--spacer--xs);
   }
 }
 

--- a/frontend/public/components/nav/_perspective-nav.scss
+++ b/frontend/public/components/nav/_perspective-nav.scss
@@ -1,0 +1,40 @@
+.oc-nav-pinned-item.pf-c-nav__item {
+  display: flex;
+
+  .pf-c-nav__link {
+    display: block;
+    flex-grow: 1;
+    overflow: hidden;
+    padding-right: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &:hover, &:focus {
+      + .oc-nav-pinned-item__unpin-button {
+        .oc-nav-pinned-item__icon {
+          opacity: 1;
+        }
+      }
+    }
+  }
+
+  .oc-nav-pinned-item__unpin-button {
+    padding-top: var(--pf-c-nav__list-link--PaddingTop);
+    padding-bottom: var(--pf-c-nav__list-link--PaddingBottom);
+    background-color: var(--pf-c-nav--m-dark__item--BackgroundColor);
+
+    .pf-m-current & {
+      background-color: var(--pf-c-nav--m-dark__item--m-current--BackgroundColor);
+    }
+
+    .oc-nav-pinned-item__icon {
+      opacity: 0;
+    }
+
+    &:hover, &:focus {
+      .oc-nav-pinned-item__icon {
+        opacity: 1;
+      }
+    }
+  }
+}

--- a/frontend/public/components/nav/confirmNavUnpinModal.tsx
+++ b/frontend/public/components/nav/confirmNavUnpinModal.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { YellowExclamationTriangleIcon } from '@console/shared';
+import { modelFor } from '../../module/k8s';
+import { confirmModal } from '../modals/confirm-modal';
+
+const confirmNavUnpinModal = (resource: string, pinnedResources: string[], updatePinsFn) => {
+  const executeFn = () => {
+    const updatedPinnedResources = [...pinnedResources];
+    const index = pinnedResources.indexOf(resource);
+    if (index >= 0) {
+      updatedPinnedResources.splice(index, 1);
+      updatePinsFn(updatedPinnedResources);
+    }
+    return Promise.resolve();
+  };
+
+  const label = modelFor(resource)?.labelPlural;
+  const title = (
+    <>
+      <YellowExclamationTriangleIcon className="co-icon-space-r" /> Remove from navigation?
+    </>
+  );
+  const message = (
+    <span>
+      Are you sure you want to remove <strong>{label}</strong> from navigation?
+    </span>
+  );
+
+  return confirmModal({
+    title,
+    message,
+    btnText: 'Remove',
+    submitDanger: true,
+    executeFn,
+  });
+};
+
+export default confirmNavUnpinModal;

--- a/frontend/public/components/nav/items.tsx
+++ b/frontend/public/components/nav/items.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 import { Link, LinkProps } from 'react-router-dom';
 import * as _ from 'lodash-es';
 import { NavItem } from '@patternfly/react-core';
@@ -53,16 +54,28 @@ class NavLink<P extends NavLinkProps> extends React.PureComponent<P> {
   }
 
   render() {
-    const { isActive, id, name, onClick, testID } = this.props;
+    const { isActive, id, name, tipText, onClick, testID, children, className } = this.props;
 
     // onClick is now handled globally by the Nav's onSelect,
     // however onClick can still be passed if desired in certain cases
 
+    const itemClasses = classNames(className, { 'pf-m-current': isActive });
+    const linkClasses = classNames('pf-c-nav__link', { 'pf-m-current': isActive });
     return (
-      <NavItem isActive={isActive}>
-        <Link id={id} data-test-id={testID} to={this.to} onClick={onClick}>
-          {name}
-        </Link>
+      <NavItem className={itemClasses} isActive={isActive}>
+        <>
+          <Link
+            className={linkClasses}
+            id={id}
+            data-test-id={testID}
+            to={this.to}
+            onClick={onClick}
+            title={tipText}
+          >
+            {name}
+          </Link>
+          {children}
+        </>
       </NavItem>
     );
   }
@@ -108,12 +121,14 @@ export class HrefLink extends NavLink<HrefLinkProps> {
 export type NavLinkProps = {
   name: string;
   id?: LinkProps['id'];
+  className?: string;
   onClick?: LinkProps['onClick'];
   isActive?: boolean;
   required?: string | string[];
   disallowed?: string;
   startsWith?: string[];
   activePath?: string;
+  tipText?: string;
   testID?: string;
 };
 
@@ -132,7 +147,7 @@ export type HrefLinkProps = NavLinkProps & {
   href: string;
 };
 
-type NavLinkComponent<T extends NavLinkProps = NavLinkProps> = React.ComponentType<T> & {
+export type NavLinkComponent<T extends NavLinkProps = NavLinkProps> = React.ComponentType<T> & {
   isActive: (props: T, resourcePath: string, activeNamespace: string) => boolean;
 };
 
@@ -174,12 +189,18 @@ const RootNavLink_: React.FC<RootNavLinkProps & RootNavLinkStateProps> = ({
   canRender,
   component: Component,
   isActive,
+  className,
+  children,
   ...props
 }) => {
   if (!canRender) {
     return null;
   }
-  return <Component {...props} isActive={isActive} />;
+  return (
+    <Component className={className} {...props} isActive={isActive}>
+      {children}
+    </Component>
+  );
 };
 
 const rootNavLinkMapStateToProps = (

--- a/frontend/public/components/nav/perspective-nav.tsx
+++ b/frontend/public/components/nav/perspective-nav.tsx
@@ -1,29 +1,115 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
+import { connect, Dispatch } from 'react-redux';
 import * as _ from 'lodash-es';
+import { NavItemSeparator, Button } from '@patternfly/react-core';
+import { MinusCircleIcon } from '@patternfly/react-icons';
 import { useExtensions, NavItem, isNavItem } from '@console/plugin-sdk';
-import { createLink } from './items';
+import { RootState } from '../../redux';
+import { setPinnedResources } from '../../actions/ui';
+import { getActivePerspective, getPinnedResources } from '../../reducers/ui';
+import { modelFor, referenceForModel } from '../../module/k8s';
+import confirmNavUnpinModal from './confirmNavUnpinModal';
 import { NavSection } from './section';
 import AdminNav from './admin-nav';
-import { getActivePerspective } from '../../reducers/ui';
-import { RootState } from '../../redux';
+import {
+  createLink,
+  NavLinkComponent,
+  ResourceClusterLink,
+  ResourceNSLink,
+  RootNavLink,
+} from './items';
+
+import './_perspective-nav.scss';
+import * as plugins from '../../plugins';
 
 type StateProps = {
   perspective: string;
+  pinnedResources: string[];
 };
 
-const PerspectiveNav: React.FC<StateProps> = ({ perspective }) => {
+interface DispatchProps {
+  onPinnedResourcesChange: (resources: string[]) => void;
+}
+
+const getLabelForResource = (resource: string): string => {
+  const model = modelFor(resource);
+  return model ? model.labelPlural : '';
+};
+
+const PerspectiveNav: React.FC<StateProps & DispatchProps> = ({
+  perspective,
+  pinnedResources,
+  onPinnedResourcesChange,
+}) => {
   const navItemExtensions = useExtensions<NavItem>(isNavItem);
+  const perspectives = React.useMemo(() => plugins.registry.getPerspectives(), []);
 
   const matchingNavItems = React.useMemo(
     () => navItemExtensions.filter((item) => item.properties.perspective === perspective),
     [navItemExtensions, perspective],
   );
 
+  const unPin = (e: React.MouseEvent<HTMLButtonElement>, resource: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    confirmNavUnpinModal(resource, pinnedResources, onPinnedResourcesChange);
+  };
+
   // Until admin perspective is contributed through extensions, simply render static `AdminNav`
   if (perspective === 'admin') {
     return <AdminNav />;
   }
+
+  const activePerspective = perspectives.find((p) => p.properties.id === perspective);
+  if (!pinnedResources && activePerspective.properties.defaultPins) {
+    onPinnedResourcesChange(activePerspective.properties.defaultPins);
+  }
+
+  const getPinnedItems = (rootNavLink: boolean = false): React.ReactElement[] =>
+    pinnedResources
+      .map((resource) => {
+        const model = modelFor(resource);
+        if (!model) {
+          return null;
+        }
+        const { labelPlural, apiVersion, apiGroup, namespaced, crd, plural } = model;
+        const duplicates =
+          pinnedResources.filter((res) => getLabelForResource(res) === labelPlural).length > 1;
+        const props = {
+          key: `pinned-${resource}`,
+          name: labelPlural,
+          resource: crd ? referenceForModel(model) : plural,
+          tipText: duplicates ? `${labelPlural}: ${apiGroup || 'core'}/${apiVersion}` : null,
+          id: resource,
+        };
+        const Component: NavLinkComponent = namespaced ? ResourceNSLink : ResourceClusterLink;
+        const removeButton = (
+          <Button
+            className="oc-nav-pinned-item__unpin-button"
+            variant="link"
+            aria-label="Unpin"
+            onClick={(e) => unPin(e, resource)}
+          >
+            <MinusCircleIcon className="oc-nav-pinned-item__icon" />
+          </Button>
+        );
+
+        return rootNavLink ? (
+          <RootNavLink
+            key={resource}
+            className="oc-nav-pinned-item"
+            component={Component}
+            {...props}
+          >
+            {removeButton}
+          </RootNavLink>
+        ) : (
+          <Component key={resource} className="oc-nav-pinned-item" {...props}>
+            {removeButton}
+          </Component>
+        );
+      })
+      .filter((p) => p !== null);
 
   // track sections so that we do not create duplicates
   const renderedSections: string[] = [];
@@ -43,6 +129,12 @@ const PerspectiveNav: React.FC<StateProps> = ({ perspective }) => {
           return createLink(item, true);
         }),
       )}
+      {pinnedResources?.length ? (
+        <>
+          <NavItemSeparator />
+          {getPinnedItems(true)}
+        </>
+      ) : null}
     </>
   );
 };
@@ -50,7 +142,14 @@ const PerspectiveNav: React.FC<StateProps> = ({ perspective }) => {
 const mapStateToProps = (state: RootState): StateProps => {
   return {
     perspective: getActivePerspective(state),
+    pinnedResources: getPinnedResources(state),
   };
 };
 
-export default connect(mapStateToProps)(PerspectiveNav);
+const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
+  onPinnedResourcesChange: (resources: string[]) => {
+    dispatch(setPinnedResources(resources));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(PerspectiveNav);

--- a/frontend/public/components/nav/section.tsx
+++ b/frontend/public/components/nav/section.tsx
@@ -102,7 +102,7 @@ export const NavSection = connect(navSectionStateToProps)(
             }
             return c.type.isActive && c.type.isActive(c.props, resourcePath, activeNamespace);
           })
-          .map((c) => c.props.name)[0];
+          .map((c) => `${c.props.id}-${c.props.name}`)[0];
       }
 
       componentDidUpdate(prevProps, prevState) {
@@ -145,7 +145,7 @@ export const NavSection = connect(navSectionStateToProps)(
 
         const { activeChild } = this.state;
         const { flags, activeNamespace } = this.props;
-        const { name, required, disallowed } = c.props;
+        const { name, required, disallowed, id } = c.props;
 
         const requiredArray = required ? _.castArray(required) : [];
         const requirementMissing = _.some(
@@ -161,7 +161,7 @@ export const NavSection = connect(navSectionStateToProps)(
 
         return React.cloneElement(c, {
           key: name,
-          isActive: name === activeChild,
+          isActive: `${id}-${name}` === activeChild,
           activeNamespace,
           flags,
         });

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -8,6 +8,7 @@ import {
   LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
   NAMESPACE_LOCAL_STORAGE_KEY,
   LAST_PERSPECTIVE_LOCAL_STORAGE_KEY,
+  PINNED_RESOURCES_LOCAL_STORAGE_KEY,
 } from '@console/shared/src/constants';
 import { AlertStates, isSilenced, SilenceStates } from '../reducers/monitoring';
 import { legalNamePattern, getNamespace } from '../components/utils/link';
@@ -80,6 +81,9 @@ export default (state: UIState, action: UIAction): UIState => {
       }
     }
 
+    const storedPins = localStorage.getItem(PINNED_RESOURCES_LOCAL_STORAGE_KEY);
+    const pinnedResources = storedPins ? JSON.parse(storedPins) : {};
+
     return ImmutableMap({
       activeNavSectionId: 'workloads',
       location: pathname,
@@ -107,6 +111,7 @@ export default (state: UIState, action: UIAction): UIState => {
         metrics: [],
         queries: ImmutableList([newQueryBrowserQuery()]),
       }),
+      pinnedResources,
     });
   }
 
@@ -354,6 +359,13 @@ export default (state: UIState, action: UIAction): UIState => {
     case ActionType.SetNodeMetrics:
       return state.setIn(['metrics', 'node'], action.payload.nodeMetrics);
 
+    case ActionType.SetPinnedResources: {
+      const pinnedResources = { ...state.get('pinnedResources') };
+      pinnedResources[state.get('activePerspective')] = action.payload.resources;
+      localStorage.setItem(PINNED_RESOURCES_LOCAL_STORAGE_KEY, JSON.stringify(pinnedResources));
+      return state.set('pinnedResources', pinnedResources);
+    }
+
     default:
       break;
   }
@@ -377,6 +389,9 @@ export const getActiveNamespace = ({ UI }: RootState): string => UI.get('activeN
 export const getActivePerspective = ({ UI }: RootState): string => UI.get('activePerspective');
 
 export const getActiveApplication = ({ UI }: RootState): string => UI.get('activeApplication');
+
+export const getPinnedResources = (rootState: RootState): string[] =>
+  rootState.UI.get('pinnedResources')[getActivePerspective(rootState)];
 
 export type NotificationAlerts = {
   data: Alert[];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3326

**Analysis / Root cause**: 
As a developer I want to be able to access my frequent search results. I use search to gain access to resource lists that aren't accessible through the existing nav in the dev perspective.

**Solution Description**: 
Add a `Pin to navigation` button to the search results header (`Unpin from navigation` if already pinned).
Show pinned items in the navigation bar for the dev perspective.

**Screen shots / Gifs for design review**:
![pin-unpin](https://user-images.githubusercontent.com/11633780/78599681-922d8f00-781f-11ea-8d72-2b6d29a79058.gif)

![image](https://user-images.githubusercontent.com/11633780/78599687-95c11600-781f-11ea-8c3d-71502e1f5664.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125

/kind feature