### PR TITLE
add Download all button to pipeline logs

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunLogs.tsx
@@ -9,6 +9,7 @@ import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer
 import { PipelineRun } from '../../../utils/pipeline-augment';
 import { PipelineRunModel } from '../../../models';
 import LogsWrapperComponent from '../logs/LogsWrapperComponent';
+import { getDownloadAllLogsCallback } from '../logs/logs-utils';
 import './PipelineRunLogs.scss';
 
 interface PipelineRunLogsProps {
@@ -58,8 +59,8 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
           : -1;
       }
       return taskRunFromYaml[b].status.completionTime ||
-        new Date(taskRunFromYaml[a].status.startTime) >
-          new Date(taskRunFromYaml[b].status.startTime)
+        new Date(taskRunFromYaml[a].status?.startTime) >
+          new Date(taskRunFromYaml[b].status?.startTime)
         ? 1
         : -1;
     });
@@ -80,6 +81,15 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
     const taskRuns = this.getSortedTaskRun(taskRunFromYaml);
 
     const taskCount = taskRuns.length;
+    const downloadAllCallback =
+      taskCount > 1
+        ? getDownloadAllLogsCallback(
+            taskRuns,
+            taskRunFromYaml,
+            obj.metadata?.namespace,
+            obj.metadata?.name,
+          )
+        : undefined;
     const resources = taskCount > 0 && [
       {
         name: _.get(taskRunFromYaml[activeItem], ['status', 'podName'], ''),
@@ -132,6 +142,8 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
             <Firehose key={activeItem} resources={resources}>
               <LogsWrapperComponent
                 taskName={_.get(taskRunFromYaml, [activeItem, 'pipelineTaskName'], '-')}
+                downloadAllLabel="Download All Task Logs"
+                onDownloadAll={downloadAllCallback}
               />
             </Firehose>
           ) : _.has(obj, ['status', 'conditions', 0, 'message']) ? (

--- a/frontend/packages/dev-console/src/components/pipelineruns/logs/LogsWrapperComponent.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/logs/LogsWrapperComponent.tsx
@@ -7,14 +7,16 @@ import { PodKind } from '@console/internal/module/k8s';
 type LogsWrapperComponentProps = {
   obj?: FirehoseResult<PodKind>;
   taskName: string;
+  downloadAllLabel?: string;
+  onDownloadAll?: () => Promise<Error>;
 };
 
-const LogsWrapperComponent: React.FC<LogsWrapperComponentProps> = ({ obj, taskName }) => {
+const LogsWrapperComponent: React.FC<LogsWrapperComponentProps> = ({ obj, ...props }) => {
   const ref = React.useRef(obj?.data);
   if (!_.isEmpty(obj?.data)) {
     ref.current = obj.data;
   }
-  return ref.current ? <MultiStreamLogs taskName={taskName} resource={ref.current} /> : null;
+  return ref.current ? <MultiStreamLogs {...props} resource={ref.current} /> : null;
 };
 
 export default LogsWrapperComponent;

--- a/frontend/packages/dev-console/src/components/pipelineruns/logs/MultiStreamLogs.scss
+++ b/frontend/packages/dev-console/src/components/pipelineruns/logs/MultiStreamLogs.scss
@@ -5,11 +5,23 @@
   height: 100%;
 
   &--fullscreen {
-    .co-toolbar {
-      background-color: var(--pf-global--BackgroundColor--100);
-      padding: var(--pf-global--spacer--sm);
-    }
+    background-color: var(--pf-global--BackgroundColor--100);
+    padding: var(--pf-global--spacer--sm);
   }
+
+  &__icon {
+    margin-right: var(--pf-global--spacer--xs);
+  }
+
+  &__divider {
+    color: var(--pf-global--palette--black-600);
+    margin: 0 var(--pf-global--spacer--sm);
+  }
+
+  &__button {
+    margin-right: 0;
+  }
+
   &__container {
     display: flex;
     flex: 1;

--- a/frontend/packages/dev-console/src/components/pipelineruns/logs/logs-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelineruns/logs/logs-utils.ts
@@ -1,21 +1,44 @@
-import { PodKind, ContainerSpec, ContainerStatus } from '@console/internal/module/k8s';
+import { saveAs } from 'file-saver';
+import {
+  PodKind,
+  ContainerSpec,
+  ContainerStatus,
+  resourceURL,
+  k8sGet,
+} from '@console/internal/module/k8s';
+import {
+  LOG_SOURCE_TERMINATED,
+  LOG_SOURCE_WAITING,
+  LineBuffer,
+} from '@console/internal/components/utils';
+import { PodModel } from '@console/internal/models';
+import { coFetchText } from '@console/internal/co-fetch';
+import { errorModal } from '@console/internal/components/modals';
 import { containerToLogSourceStatus } from '../../../utils/pipeline-utils';
-import { LOG_SOURCE_TERMINATED } from '@console/internal/components/utils';
+import { TaskRuns } from '../../../utils/pipeline-augment';
+
+const getSortedContainerStatus = (
+  containers: ContainerSpec[],
+  containerStatuses: ContainerStatus[],
+): ContainerStatus[] => {
+  const containerNames = containers.map((c) => c.name);
+  const sortedContainerStatus = [];
+  containerStatuses.forEach((cs) => {
+    const containerIndex = containerNames.indexOf(cs.name);
+    sortedContainerStatus[containerIndex] = cs;
+  });
+  return sortedContainerStatus;
+};
 
 export const getRenderContainers = (
   pod: PodKind,
 ): { containers: ContainerSpec[]; stillFetching: boolean } => {
   const containers: ContainerSpec[] = pod.spec?.containers ?? [];
-  const containerStatus: ContainerStatus[] = pod.status?.containerStatuses ?? [];
+  const containerStatuses: ContainerStatus[] = pod.status?.containerStatuses ?? [];
 
-  const containerNames = containers.map((c) => c.name);
-  const sortedContainerStatus = [];
-  containerStatus.forEach((cs) => {
-    const containerIndex = containerNames.indexOf(cs.name);
-    sortedContainerStatus[containerIndex] = cs;
-  });
+  const sortedContainerStatuses = getSortedContainerStatus(containers, containerStatuses);
 
-  const firstRunningCont = sortedContainerStatus.findIndex(
+  const firstRunningCont = sortedContainerStatuses.findIndex(
     (container) => containerToLogSourceStatus(container) !== LOG_SOURCE_TERMINATED,
   );
   return {
@@ -24,5 +47,121 @@ export const getRenderContainers = (
       firstRunningCont === -1 ? containers.length : firstRunningCont + 1,
     ),
     stillFetching: firstRunningCont !== -1,
+  };
+};
+
+const getOrderedStepsFromPod = (name: string, ns: string): Promise<ContainerStatus[]> => {
+  return k8sGet(PodModel, name, ns)
+    .then((pod: PodKind) => {
+      return getSortedContainerStatus(
+        pod.spec.containers ?? [],
+        pod.status?.containerStatuses ?? [],
+      );
+    })
+    .catch((err) => {
+      errorModal({ error: err.message || 'Error downloading logs.' });
+      return [];
+    });
+};
+
+type StepsWatchUrl = {
+  [key: string]: {
+    name: string;
+    steps: { [step: string]: WatchURLStatus };
+  };
+};
+
+type WatchURLStatus = {
+  status: string;
+  url: string;
+};
+
+export const getDownloadAllLogsCallback = (
+  sortedTaskRuns: string[],
+  taskRunFromYaml: TaskRuns,
+  namespace: string,
+  pipelineRunName: string,
+): (() => Promise<Error>) => {
+  const getWatchUrls = async (): Promise<StepsWatchUrl> => {
+    const stepsList: ContainerStatus[][] = await Promise.all(
+      sortedTaskRuns.map((currTask) => {
+        const { status = {} } = taskRunFromYaml[currTask];
+        const { podName } = status;
+        return getOrderedStepsFromPod(podName, namespace);
+      }),
+    );
+    return sortedTaskRuns.reduce((acc, currTask, i) => {
+      const { pipelineTaskName, status = {} } = taskRunFromYaml[currTask];
+      const { podName } = status;
+      const steps = stepsList[i];
+      const allStepUrls = steps.reduce((stepUrls, currentStep) => {
+        const { name } = currentStep;
+        const currentStatus = containerToLogSourceStatus(currentStep);
+        if (currentStatus === LOG_SOURCE_WAITING) return stepUrls;
+        const urlOpts = {
+          ns: namespace,
+          name: podName,
+          path: 'log',
+          queryParams: {
+            container: name,
+            follow: 'true',
+          },
+        };
+        return {
+          ...stepUrls,
+          [name]: {
+            status: currentStatus,
+            url: resourceURL(PodModel, urlOpts),
+          } as WatchURLStatus,
+        };
+      }, {});
+      acc[currTask] = {
+        name: pipelineTaskName,
+        steps: { ...allStepUrls },
+      };
+      return acc;
+    }, {});
+  };
+
+  const fetchLogs = async (tasksPromise: Promise<StepsWatchUrl>) => {
+    const tasks = await tasksPromise;
+    const allRequests: Promise<string>[] = sortedTaskRuns.reduce((acc, currTask) => {
+      const task = tasks[currTask];
+      const promises: Promise<string>[] = Object.keys(task.steps).map((step, i) => {
+        let heading = '';
+        if (i === 0) {
+          heading += `${task.name}\n\n`;
+        }
+        heading += `${step}\n\n`;
+        const { url, status } = task.steps[step];
+        const getContentPromise = coFetchText(url).then((logs) => {
+          return `${heading}${logs}\n\n`;
+        });
+        if (status === LOG_SOURCE_TERMINATED) {
+          // If we are done, we want this log content
+          return getContentPromise;
+        }
+        // If we are not done, let's not wait indefinitely
+        return Promise.race([
+          getContentPromise,
+          new Promise<string>((resolve) => {
+            setTimeout(() => resolve(''), 1000);
+          }),
+        ]);
+      });
+      return [...acc, ...promises];
+    }, []);
+    const buffer = new LineBuffer(null);
+    return Promise.all(allRequests).then((allLogs) => {
+      buffer.ingest(allLogs.join(''));
+      const blob = buffer.getBlob({
+        type: 'text/plain;charset=utf-8',
+      });
+      saveAs(blob, `${pipelineRunName}.log`);
+      return null;
+    });
+  };
+  return (): Promise<Error> => {
+    return fetchLogs(getWatchUrls());
   };
 };

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -89,6 +89,12 @@ export interface Pipeline extends K8sResourceKind {
   };
 }
 
+export type TaskRunKind = { pipelineTaskName?: string } & K8sResourceKind;
+
+export interface TaskRuns {
+  [key: string]: TaskRunKind;
+}
+
 export interface PipelineRun extends K8sResourceKind {
   spec?: {
     pipelineRef: { name: string };
@@ -105,9 +111,7 @@ export interface PipelineRun extends K8sResourceKind {
     conditions?: Condition[];
     startTime?: string;
     completionTime?: string;
-    taskRuns?: {
-      [key: string]: { pipelineTaskName?: string } & K8sResourceKind;
-    };
+    taskRuns?: TaskRuns;
   };
 }
 


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-2435
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

[**NOTE**] : This PR is dependent on https://github.com/openshift/console/pull/4845 and for this story only review 17e7a7174df11dfbe1dbc83d00b21a78c08d1046
**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Missing Download all task Logs button

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
This PR adds download All task logs button

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screenshot from 2020-04-03 03-56-14](https://user-images.githubusercontent.com/9278015/78305652-1b626e80-755f-11ea-871e-77ab4f0a6259.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->
**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
