### PR TITLE
Monitoring: Show '-' when alerting rule has no duration

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -571,7 +571,7 @@ const AlertRulesDetailsPage = withFallback(
                     {_.isInteger(duration) && (
                       <>
                         <dt>For</dt>
-                        <dd>{formatPrometheusDuration(duration * 1000)}</dd>
+                        <dd>{duration === 0 ? '-' : formatPrometheusDuration(duration * 1000)}</dd>
                       </>
                     )}
                     <dt>Expression</dt>


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/460802/78358204-befa6000-75ed-11ea-9d8e-9c7b855ee945.png)
