### PR TITLE
Monitoring: Change actions menu to action button on alert details page

### DIFF
--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -66,7 +66,7 @@ describe('Monitoring: Alerts', () => {
   });
 
   it('creates a new Silence from an existing alert', async () => {
-    await crudView.clickDetailsPageAction('Silence Alert');
+    await monitoringView.actionButton.click();
     await monitoringView.wait(until.presenceOf(monitoringView.saveButton));
     await monitoringView.saveButton.click();
     expect(crudView.errorMessage.isPresent()).toBe(false);

--- a/frontend/integration-tests/views/monitoring.view.ts
+++ b/frontend/integration-tests/views/monitoring.view.ts
@@ -11,6 +11,7 @@ export const listPageHeading = $('.co-m-pane__heading');
 export const createButton = $('.co-m-pane__filter-bar-group button');
 
 // Details pages
+export const actionButton = $('.co-m-nav-title .pf-m-primary.co-action-buttons__btn');
 export const detailsHeading = $('.co-m-nav-title .co-resource-item');
 export const detailsHeadingAlertIcon = $('.co-m-nav-title .co-m-resource-alert');
 export const detailsHeadingRuleIcon = $('.co-m-nav-title .co-m-resource-alertrule');

--- a/frontend/public/components/utils/headings.tsx
+++ b/frontend/public/components/utils/headings.tsx
@@ -52,7 +52,7 @@ export const BreadCrumbs: React.SFC<BreadCrumbsProps> = ({ breadcrumbs }) => (
   </Breadcrumb>
 );
 
-const ActionButtons: React.SFC<ActionButtonsProps> = ({ actionButtons }) => (
+export const ActionButtons: React.SFC<ActionButtonsProps> = ({ actionButtons }) => (
   <div className="co-action-buttons">
     {_.map(actionButtons, (actionButton, i) => {
       if (!_.isEmpty(actionButton)) {


### PR DESCRIPTION
This menu only has one action, so convert to a button.

![screenshot](https://user-images.githubusercontent.com/460802/78367580-46030480-75fd-11ea-9ff3-783b4d8c3c0e.png)

FYI @cshinn 