### PR TITLE
Bug 1786429 : Add replicas info on StatefulSet Overview

### DIFF
--- a/frontend/public/components/overview/stateful-set-overview.tsx
+++ b/frontend/public/components/overview/stateful-set-overview.tsx
@@ -3,14 +3,31 @@ import * as React from 'react';
 import { StatefulSetModel } from '../../models';
 import { menuActions } from '../stateful-set';
 import { ResourceSummary } from '../utils';
+import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 
 import { OverviewDetailsResourcesTab } from './resource-overview-page';
 import { ResourceOverviewDetails } from './resource-overview-details';
 import { OverviewItem } from '@console/shared';
 
-const StatefulSetOverviewDetails: React.SFC<StatefulSetOverviewDetailsProps> = ({ item }) => (
+const StatefulSetOverviewDetails: React.SFC<StatefulSetOverviewDetailsProps> = ({
+  item: { obj: ss, pods: pods, current, previous, isRollingOut },
+}) => (
   <div className="overview__sidebar-pane-body resource-overview__body">
-    <ResourceSummary resource={item.obj} showPodSelector showNodeSelector showTolerations />
+    <div className="resource-overview__pod-counts">
+      <PodRingSet
+        key={ss.metadata.uid}
+        podData={{
+          pods,
+          current,
+          previous,
+          isRollingOut,
+        }}
+        obj={ss}
+        resourceKind={StatefulSetModel}
+        path="/spec/replicas"
+      />
+    </div>
+    <ResourceSummary resource={ss} showPodSelector showNodeSelector showTolerations />
   </div>
 );
 


### PR DESCRIPTION
/assign @TheRealJon
/cc @benjaminapetersen @spadgett

This PR is a follow-on to PR #4590.
The original PR #4590 fixed adding replicas info on StatefulSets overview of the bug- #1786429, while this PR is a fix for adding replicas info on StatefulSet Project Overview sidebar .