### PR TITLE
[WIP] Pipeline Builder uses TechPreview Tasks

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -46,9 +46,9 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
 
   const thisTaskError = errorMap[taskField.value.name];
 
-  const params = taskResource.spec?.inputs?.params;
-  const inputResources = taskResource.spec?.inputs?.resources;
-  const outputResources = taskResource.spec?.outputs?.resources;
+  const params = taskResource.spec?.params;
+  const inputResources = taskResource.spec?.resources?.inputs;
+  const outputResources = taskResource.spec?.resources?.outputs;
 
   const renderResource = (type: ResourceTarget) => (resource: PipelineResourceTaskResource) => {
     const taskResources: PipelineTaskResource[] = taskField.value?.resources?.[type] || [];

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -113,7 +113,7 @@ const mapAddRelatedToOthers = <TaskType extends PipelineBuilderTaskBase>(
 
 // TODO: Can we use yup? Do we need this level of checking for errors?
 const getErrors = (task: PipelineTask, resource: PipelineResourceTask): TaskErrorMap => {
-  const resourceParams = resource?.spec?.inputs?.params || [];
+  const resourceParams = resource?.spec?.params || [];
   const requiredParamNames = resourceParams
     .filter((param) => !param.default)
     .map((param) => param.name);
@@ -125,11 +125,11 @@ const getErrors = (task: PipelineTask, resource: PipelineResourceTask): TaskErro
   const needsName = !task.name;
 
   const taskInputResources = task.resources?.inputs?.length || 0;
-  const requiredInputResources = resource.spec?.inputs?.resources?.length || 0;
+  const requiredInputResources = resource.spec?.resources?.inputs?.length || 0;
   const missingInputResources = requiredInputResources - taskInputResources > 0;
 
   const taskOutputResources = task.resources?.outputs?.length || 0;
-  const requiredOutputResources = resource.spec?.outputs?.resources?.length || 0;
+  const requiredOutputResources = resource.spec?.resources?.outputs?.length || 0;
   const missingOutputResources = requiredOutputResources - taskOutputResources > 0;
 
   const errorListing: TaskErrorType[] = [];

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
@@ -30,7 +30,7 @@ export const convertResourceToTask = (
       kind: resource.kind === ClusterTaskModel.kind ? ClusterTaskModel.kind : undefined,
       name: resource.metadata.name,
     },
-    params: resource.spec.inputs?.params?.map((param) => ({
+    params: resource.spec.params?.map((param) => ({
       name: param.name,
       value: param.default,
     })),

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -120,12 +120,10 @@ export interface PipelineResourceTaskResource {
 }
 export interface PipelineResourceTask extends K8sResourceKind {
   spec: {
-    inputs?: {
-      params?: PipelineResourceTaskParam[];
-      resources?: PipelineResourceTaskResource[];
-    };
-    outputs?: {
-      resources?: PipelineResourceTaskResource[];
+    params?: PipelineResourceTaskParam[];
+    resources?: {
+      inputs?: PipelineResourceTaskResource[];
+      outputs?: PipelineResourceTaskResource[];
     };
     steps: {
       // TODO: Figure out required fields


### PR DESCRIPTION
OpenShift Pipelines Operator is going TechPreview and changed the spec layout of Tasks. This is a fix for that.

Note: It's not backwards compatible... I'll look to see if it's possible to do so just so we can land it without breaking the Pipeline Builder.