### PR TITLE
Metal3: Add validations to the Power Off modal

### DIFF
--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/BareMetalHostsTable.tsx
@@ -116,7 +116,7 @@ const HostsTableRow: RowFunction<
               hasNodeMaintenanceCapability,
               machine,
               machineSet,
-              status: status.status,
+              status,
             }),
           )}
           key={`kebab-for-${uid}`}

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/host-menu-actions.tsx
@@ -45,6 +45,7 @@ import { deprovision } from '../../k8s/requests/bare-metal-host';
 import { getMachineMachineSetOwner } from '../../selectors/machine';
 import { findMachineSet } from '../../selectors/machine-set';
 import { restartHostModal } from '../modals/RestartHostModal';
+import { StatusProps } from '../types';
 
 type ActionArgs = {
   machine?: MachineKind;
@@ -52,7 +53,7 @@ type ActionArgs = {
   nodeName?: string;
   nodeMaintenance?: K8sResourceKind;
   hasNodeMaintenanceCapability?: boolean;
-  status: string;
+  status: StatusProps;
 };
 
 export const Edit = (kindObj: K8sKind, host: BareMetalHostKind): KebabOption => ({
@@ -158,7 +159,7 @@ export const Delete = (
       HOST_STATUS_AVAILABLE,
       HOST_STATUS_DISCOVERED,
       ...HOST_ERROR_STATES,
-    ].includes(status),
+    ].includes(status.status),
     label: title,
     callback: () =>
       deleteModal({
@@ -211,7 +212,7 @@ export const menuActionsCreator = (
       nodeName,
       machine,
       machineSet,
-      status: status.status,
+      status,
     });
   });
 };

--- a/frontend/packages/metal3-plugin/src/components/modals/PowerOffHostModal.scss
+++ b/frontend/packages/metal3-plugin/src/components/modals/PowerOffHostModal.scss
@@ -1,0 +1,5 @@
+.metal3-poweroff-modal {
+  .pf-c-alert {
+    margin-bottom: 1rem;
+  }
+}


### PR DESCRIPTION
The modal confirmation dialog for the BMH Power Off action newly shows validation
messages of selected potential issues which are preventing graceful power off.