### PR TITLE
Bug 1820307: Hide yaml editor links when window width is less than 991px

### DIFF
--- a/frontend/packages/console-shared/src/components/editor/YAMLEditorToolbar.scss
+++ b/frontend/packages/console-shared/src/components/editor/YAMLEditorToolbar.scss
@@ -1,3 +1,5 @@
+@import '~bootstrap-sass/assets/stylesheets/bootstrap/variables';
+
 .ocs-yaml-editor-toolbar {
   &__links {
     display: flex;
@@ -5,7 +7,7 @@
     justify-content: flex-end;
     margin: 2px;
     z-index: 1;
-    @media(max-width: 767px) {
+    @media(max-width: $screen-sm-max) {
       display: none;
     }
   }

--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -58,7 +58,7 @@ export const EditYAML_ = connect(stateToProps)(
         stale: false,
         sampleObj: props.sampleObj,
         fileUpload: props.fileUpload,
-        showSidebar: props.create,
+        showSidebar: !!props.create,
       };
       this.monacoRef = React.createRef();
       // k8s uses strings for resource versions


### PR DESCRIPTION
This PR - 
- Fixes the css to hide yaml editor links at small screen sizes.
- Fixes the initial value of `showSidebar` being `undefined`.