### PR TITLE
Bug 1821420: Support TechPreview Task Changes

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/__tests__/resource-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/__tests__/resource-utils.spec.ts
@@ -1,0 +1,60 @@
+import { omit } from 'lodash';
+import { taskTestData } from '../../../test/pipeline-data';
+import { getTaskParameters, getTaskResources } from '../resource-utils';
+
+describe('getTaskResources gets back valid structures', () => {
+  it('expect always to get a non-null value', () => {
+    expect(getTaskResources(null)).toEqual({});
+
+    const alphaTask = omit(taskTestData.v1alpha1.buildah, [
+      'spec.inputs.resources',
+      'spec.outputs.resources',
+    ]);
+    expect(getTaskResources(alphaTask)).toEqual({ inputs: undefined, outputs: undefined });
+
+    const betaTask = omit(taskTestData.v1beta1.buildah, 'spec.resources');
+    expect(getTaskResources(betaTask)).toEqual({});
+  });
+
+  it('expect to walk a v1alpha1 Task to the appropriate resources', () => {
+    const resources = getTaskResources(taskTestData.v1alpha1.buildah);
+
+    expect(resources.inputs).toBeDefined();
+    expect(resources.inputs).toHaveLength(1);
+    expect(resources.outputs).toBeDefined();
+    expect(resources.outputs).toHaveLength(1);
+  });
+
+  it('expect to walk a v1beta1 Task to get the appropriate resources', () => {
+    const resources = getTaskResources(taskTestData.v1beta1.buildah);
+
+    expect(resources.inputs).toBeDefined();
+    expect(resources.inputs).toHaveLength(1);
+    expect(resources.outputs).toBeDefined();
+    expect(resources.outputs).toHaveLength(1);
+  });
+});
+
+describe('getTaskParameters gets back valid structures', () => {
+  it('expect always to get a non-null value', () => {
+    expect(getTaskParameters(null)).toEqual([]);
+
+    const alphaTask = omit(taskTestData.v1alpha1.buildah, 'spec.inputs.params');
+    expect(getTaskParameters(alphaTask)).toEqual([]);
+
+    const betaTask = omit(taskTestData.v1beta1.buildah, 'spec.params');
+    expect(getTaskParameters(betaTask)).toEqual([]);
+  });
+
+  it('expect to walk a v1alpha1 Task to get the parameters associated', () => {
+    const parameters = getTaskParameters(taskTestData.v1alpha1.buildah);
+
+    expect(parameters).toHaveLength(2);
+  });
+
+  it('expect to walk a v1beta1 Task to get the parameters associated', () => {
+    const parameters = getTaskParameters(taskTestData.v1beta1.buildah);
+
+    expect(parameters).toHaveLength(2);
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebar.tsx
@@ -11,6 +11,7 @@ import {
   PipelineTaskParam,
   PipelineTaskResource,
 } from '../../../../utils/pipeline-augment';
+import { getTaskParameters, getTaskResources } from '../../resource-utils';
 import { ResourceTarget, TaskErrorMap, UpdateOperationUpdateTaskData } from '../types';
 import { TaskErrorType } from '../const';
 import TaskSidebarParam from './TaskSidebarParam';
@@ -46,9 +47,10 @@ const TaskSidebar: React.FC<TaskSidebarProps> = (props) => {
 
   const thisTaskError = errorMap[taskField.value.name];
 
-  const params = taskResource.spec?.inputs?.params;
-  const inputResources = taskResource.spec?.inputs?.resources;
-  const outputResources = taskResource.spec?.outputs?.resources;
+  const params = getTaskParameters(taskResource);
+  const resources = getTaskResources(taskResource);
+  const inputResources = resources.inputs;
+  const outputResources = resources.outputs;
 
   const renderResource = (type: ResourceTarget) => (resource: PipelineResourceTaskResource) => {
     const taskResources: PipelineTaskResource[] = taskField.value?.resources?.[type] || [];

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -7,6 +7,7 @@ import {
   PipelineTaskResource,
 } from '../../../utils/pipeline-augment';
 import { AddNodeDirection } from '../pipeline-topology/const';
+import { getTaskParameters, getTaskResources } from '../resource-utils';
 import { TaskErrorType, UpdateOperationType } from './const';
 import {
   CleanupResults,
@@ -113,7 +114,8 @@ const mapAddRelatedToOthers = <TaskType extends PipelineBuilderTaskBase>(
 
 // TODO: Can we use yup? Do we need this level of checking for errors?
 const getErrors = (task: PipelineTask, resource: PipelineResourceTask): TaskErrorMap => {
-  const resourceParams = resource?.spec?.inputs?.params || [];
+  const params = getTaskParameters(resource);
+  const resourceParams = params || [];
   const requiredParamNames = resourceParams
     .filter((param) => !param.default)
     .map((param) => param.name);
@@ -124,12 +126,14 @@ const getErrors = (task: PipelineTask, resource: PipelineResourceTask): TaskErro
 
   const needsName = !task.name;
 
+  const resources = getTaskResources(resource);
+
   const taskInputResources = task.resources?.inputs?.length || 0;
-  const requiredInputResources = resource.spec?.inputs?.resources?.length || 0;
+  const requiredInputResources = resources.inputs?.length || 0;
   const missingInputResources = requiredInputResources - taskInputResources > 0;
 
   const taskOutputResources = task.resources?.outputs?.length || 0;
-  const requiredOutputResources = resource.spec?.outputs?.resources?.length || 0;
+  const requiredOutputResources = resources.outputs?.length || 0;
   const missingOutputResources = requiredOutputResources - taskOutputResources > 0;
 
   const errorListing: TaskErrorType[] = [];

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
@@ -2,6 +2,7 @@ import { history, resourcePathFromModel } from '@console/internal/components/uti
 import { apiVersionForModel, referenceForModel } from '@console/internal/module/k8s';
 import { ClusterTaskModel, PipelineModel } from '../../../models';
 import { Pipeline, PipelineResourceTask, PipelineTask } from '../../../utils/pipeline-augment';
+import { getTaskParameters } from '../resource-utils';
 import { TASK_ERROR_STRINGS, TaskErrorType } from './const';
 import { PipelineBuilderFormikValues, PipelineBuilderFormValues, TaskErrorMap } from './types';
 
@@ -30,7 +31,7 @@ export const convertResourceToTask = (
       kind: resource.kind === ClusterTaskModel.kind ? ClusterTaskModel.kind : undefined,
       name: resource.metadata.name,
     },
-    params: resource.spec.inputs?.params?.map((param) => ({
+    params: getTaskParameters(resource).map((param) => ({
       name: param.name,
       value: param.default,
     })),

--- a/frontend/packages/dev-console/src/components/pipelines/resource-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/resource-utils.ts
@@ -1,0 +1,57 @@
+import { get } from 'lodash';
+import {
+  PipelineResourceTask,
+  PipelineResourceTaskParam,
+  PipelineResourceTaskResource,
+} from '../../utils/pipeline-augment';
+
+type PipelineResourceTaskAlpha = PipelineResourceTask & {
+  spec: {
+    inputs?: {
+      params?: PipelineResourceTaskParam[];
+      resources?: PipelineResourceTaskResource[];
+    };
+    outputs?: {
+      resources?: PipelineResourceTaskResource[];
+    };
+  };
+};
+
+export type InputOutputResources = {
+  inputs?: PipelineResourceTaskResource[];
+  outputs?: PipelineResourceTaskResource[];
+};
+
+enum PATHS {
+  alphaInputResources = 'spec.inputs.resources',
+  alphaOutputResources = 'spec.outputs.resources',
+  alphaParameters = 'spec.inputs.params',
+
+  betaInputResources = 'spec.resources.inputs',
+  betaOutputResources = 'spec.resources.outputs',
+  betaParameters = 'spec.params',
+}
+
+export const getTaskResources = (
+  taskResource: PipelineResourceTask | PipelineResourceTaskAlpha,
+): InputOutputResources => {
+  const inputs =
+    get(taskResource, PATHS.alphaInputResources) || get(taskResource, PATHS.betaInputResources);
+  const outputs =
+    get(taskResource, PATHS.alphaOutputResources) || get(taskResource, PATHS.betaOutputResources);
+
+  if (inputs || outputs) {
+    return {
+      inputs,
+      outputs,
+    };
+  }
+
+  return {};
+};
+
+export const getTaskParameters = (
+  taskResource: PipelineResourceTask | PipelineResourceTaskAlpha,
+): PipelineResourceTaskParam[] => {
+  return get(taskResource, PATHS.alphaParameters) || get(taskResource, PATHS.betaParameters) || [];
+};

--- a/frontend/packages/dev-console/src/test/pipeline-data.ts
+++ b/frontend/packages/dev-console/src/test/pipeline-data.ts
@@ -786,3 +786,88 @@ export const pipelineTestData: PipelineTestData = {
     },
   },
 };
+
+export const taskTestData = {
+  v1alpha1: {
+    buildah: {
+      apiVersion: 'tekton.dev/v1alpha1',
+      kind: 'ClusterTask',
+      metadata: {
+        name: 'buildah',
+      },
+      spec: {
+        inputs: {
+          params: [
+            {
+              default: 'quay.io/buildah/stable:v1.11.0',
+              description: 'The location of the buildah builder image.',
+              name: 'BUILDER_IMAGE',
+              type: 'string',
+            },
+            {
+              default: './Dockerfile',
+              description: 'Path to the Dockerfile to build.',
+              name: 'DOCKERFILE',
+              type: 'string',
+            },
+          ],
+          resources: [
+            {
+              name: 'source',
+              type: 'git',
+            },
+          ],
+        },
+        outputs: {
+          resources: [
+            {
+              name: 'image',
+              type: 'image',
+            },
+          ],
+        },
+        steps: [],
+      },
+    },
+  },
+  v1beta1: {
+    buildah: {
+      apiVersion: 'tekton.dev/v1beta1',
+      kind: 'ClusterTask',
+      metadata: {
+        name: 'buildah',
+      },
+      spec: {
+        params: [
+          {
+            default: 'quay.io/buildah/stable:v1.11.0',
+            description: 'The location of the buildah builder image.',
+            name: 'BUILDER_IMAGE',
+            type: 'string',
+          },
+          {
+            default: './Dockerfile',
+            description: 'Path to the Dockerfile to build.',
+            name: 'DOCKERFILE',
+            type: 'string',
+          },
+        ],
+        resources: {
+          inputs: [
+            {
+              name: 'source',
+              type: 'git',
+            },
+          ],
+          outputs: [
+            {
+              name: 'image',
+              type: 'image',
+            },
+          ],
+        },
+        steps: [],
+      },
+    },
+  },
+};

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -120,13 +120,12 @@ export interface PipelineResourceTaskResource {
 }
 export interface PipelineResourceTask extends K8sResourceKind {
   spec: {
-    inputs?: {
-      params?: PipelineResourceTaskParam[];
-      resources?: PipelineResourceTaskResource[];
+    params?: PipelineResourceTaskParam[];
+    resources?: {
+      inputs?: PipelineResourceTaskResource[];
+      outputs?: PipelineResourceTaskResource[];
     };
-    outputs?: {
-      resources?: PipelineResourceTaskResource[];
-    };
+
     steps: {
       // TODO: Figure out required fields
       args?: string[];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3493

**Analysis / Root cause**: 
TechPreview of the OpenShift Pipelines Operator has changed the spec of Tasks.

**Solution Description**: 
 Adding support for both beta and alpha structure of the Task resource.

**Test Status:**

```
 PASS  packages/dev-console/src/components/pipelines/__tests__/resource-utils.spec.ts
  getTaskResources gets back valid structures
    ✓ expect always to get a non-null value (3ms)
    ✓ expect to walk a v1alpha1 Task to the appropriate resources (1ms)
    ✓ expect to walk a v1beta1 Task to get the appropriate resources (1ms)
  getTaskParameters gets back valid structures
    ✓ expect always to get a non-null value
    ✓ expect to walk a v1alpha1 Task to get the parameters associated
    ✓ expect to walk a v1beta1 Task to get the parameters associated

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
```

**Test setup:**

* OpenShift Pipelines Operator 1.0
* Pipeline Builder has the only support we use the direct Task structure, the sidebar will be able to find the parameters and resources if the support is properly there.

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge