### PR TITLE
Support no dockerfile pipeline template

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
@@ -91,7 +91,7 @@ const PipelineTemplate: React.FC<PipelineTemplateProps> = ({ builderImages }) =>
   }, [resources, image.selected, isDockerStrategy, setFieldValue]);
 
   if (noTemplateForRuntime) {
-    const builderImageTitle = builderImages[image.selected].title;
+    const builderImageTitle = builderImages?.[image.selected]?.title || 'this builder image';
     const resourceName = ReadableResourcesNames[resources];
     return (
       <Alert


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3502

**Analysis / Root cause**: 
Caused by https://github.com/openshift/console/pull/4857, and we didn't catch it because the template was already there (by the Operator at install). The cluster Christian was testing on just had no templates (for whatever reason) and thus revealed this issue. 

**Solution Description**: 
Just optional chain the property... it's not even used for this path.

**Screen shots / Gifs for design review**: 
(no change)
![image](https://user-images.githubusercontent.com/8126518/78608313-b2b11580-782e-11ea-9bf2-0bfe1fa52bda.png)

**Test setup:**

* OpenShift Pipeline Operator installed
* No dockerfile strategy Pipeline (`buildah`) in the `openshift` namespace
* Navigate to "From Dockerfile"

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge