### PR TITLE
Add create vm dropdown action

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
@@ -1,6 +1,8 @@
 import { getName, getNamespace } from '@console/shared';
 import { K8sKind, TemplateKind } from '@console/internal/module/k8s';
 import { asAccessReview, Kebab } from '@console/internal/components/utils';
+import { VMWizardName, VMWizardMode } from '../../constants/vm';
+import { getVMWizardCreateLink } from '../../utils/url';
 
 const vmTemplateEditAction = (kind: K8sKind, obj: TemplateKind) => ({
   label: `Edit VM Template`,
@@ -8,9 +10,20 @@ const vmTemplateEditAction = (kind: K8sKind, obj: TemplateKind) => ({
   accessReview: asAccessReview(kind, obj, 'update'),
 });
 
+const vmTemplateCreateVMAction = (kind: K8sKind, obj: TemplateKind) => ({
+  label: `Create Virtual Machine`,
+  href: getVMWizardCreateLink(
+    getNamespace(obj),
+    VMWizardName.WIZARD,
+    VMWizardMode.VM,
+    getName(obj),
+  ),
+});
+
 export const menuActions = [
   Kebab.factory.ModifyLabels,
   Kebab.factory.ModifyAnnotations,
   vmTemplateEditAction,
+  vmTemplateCreateVMAction,
   Kebab.factory.Delete,
 ];

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
@@ -2,6 +2,7 @@ import { getName, getNamespace } from '@console/shared';
 import { K8sKind, TemplateKind } from '@console/internal/module/k8s';
 import { asAccessReview, Kebab } from '@console/internal/components/utils';
 import { VMWizardName, VMWizardMode } from '../../constants/vm';
+import { VirtualMachineModel } from '../../models';
 import { getVMWizardCreateLink } from '../../utils/url';
 
 const vmTemplateEditAction = (kind: K8sKind, obj: TemplateKind) => ({
@@ -18,6 +19,7 @@ const vmTemplateCreateVMAction = (kind: K8sKind, obj: TemplateKind) => ({
     VMWizardMode.VM,
     getName(obj),
   ),
+  accessReview: { model: VirtualMachineModel, namespace: getNamespace(obj), verb: 'create' },
 });
 
 export const menuActions = [


### PR DESCRIPTION
Add a drop down action to create a VM from a template.

a. add a "create vm" action in vm templates list.
b. add a "create vm" action in vm template details page.

Screenshots:
![Screenshot from 2020-04-07 09-10-59](https://user-images.githubusercontent.com/2181522/78636305-c309d480-78b0-11ea-8ff6-1b365c542956.jpg)
![Screenshot from 2020-04-07 09-11-12_01](https://user-images.githubusercontent.com/2181522/78636310-c4d39800-78b0-11ea-8313-87becf2095ac.jpg)


Design: openshift/openshift-origin-design#350
Ref: https://github.com/openshift/console/pull/4811#issuecomment-609792010
