### PR TITLE
The +Add extension url can be parametrized for namespace

### DIFF
--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -2,41 +2,67 @@ import * as React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
 import { CatalogTile } from '@patternfly/react-catalog-view-extension';
 import { connect } from 'react-redux';
-import { history, PageHeading } from '@console/internal/components/utils';
-import { formatNamespacedRouteForResource } from '@console/shared/src/utils/namespace';
-import { FLAG_KNATIVE_EVENTING } from '@console/knative-plugin';
-import * as importGitIcon from '../images/from-git.svg';
-import * as yamlIcon from '../images/yaml.svg';
-import * as dockerfileIcon from '../images/dockerfile.svg';
-import { useAddToProjectAccess } from '../utils/useAddToProjectAccess';
-import { allCatalogImageResourceAccess, allImportResourceAccess } from '../actions/add-resources';
+import { history, PageHeading, useAccessReview } from '@console/internal/components/utils';
+import { useExtensions } from '@console/plugin-sdk';
+import { RootState } from '@console/internal/redux';
+import { isAddAction, AddAction } from '../extensions/add-actions';
 import './EmptyState.scss';
-
-interface StateProps {
-  activeNamespace: string;
-  isEventSourceEnabled?: boolean;
-}
-
-export interface EmptySProps {
-  title: string;
-  hintBlock?: React.ReactNode;
-}
-
-type Props = EmptySProps & StateProps;
 
 const navigateTo = (e: React.SyntheticEvent, url: string) => {
   history.push(url);
   e.preventDefault();
 };
 
+interface ItemProps {
+  action: AddAction;
+  namespace: string;
+}
+
+const Item: React.FC<ItemProps> = ({
+  action: {
+    properties: { label, description, icon, iconClass, url, accessReview },
+  },
+  namespace,
+}) => {
+  const access =
+    !accessReview ||
+    (Array.isArray(accessReview) ? accessReview : [accessReview])
+      // Defined extensions are immutable. This check will be consistent.
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      .map((descriptor) => useAccessReview({ namespace, ...descriptor }))
+      .every((x) => x);
+  return access ? (
+    <GalleryItem>
+      <CatalogTile
+        className="odc-empty-state__tile"
+        onClick={(e: React.SyntheticEvent) => navigateTo(e, url)}
+        href={url}
+        title={label}
+        iconImg={icon}
+        iconClass={iconClass}
+        description={description}
+      />
+    </GalleryItem>
+  ) : null;
+};
+
+interface StateProps {
+  activeNamespace: string;
+}
+
+interface EmptySProps {
+  title: string;
+  hintBlock?: React.ReactNode;
+}
+
+type Props = EmptySProps & StateProps;
+
 const ODCEmptyState: React.FC<Props> = ({
   title,
   activeNamespace,
   hintBlock = 'Select a way to create an application, component or service from one of the options.',
-  isEventSourceEnabled = false,
 }) => {
-  const createResourceAccess: string[] = useAddToProjectAccess(activeNamespace);
-
+  const addActionExtensions = useExtensions<AddAction>(isAddAction);
   return (
     <>
       <div className="odc-empty-state__title">
@@ -49,99 +75,22 @@ const ODCEmptyState: React.FC<Props> = ({
       </div>
       <div className="odc-empty-state__content">
         <Gallery className="co-catalog-tile-view" gutter="sm">
-          {createResourceAccess.includes(allImportResourceAccess) && (
-            <GalleryItem key="gallery-fromgit">
-              <CatalogTile
-                className="odc-empty-state__tile"
-                onClick={(e: React.SyntheticEvent) => navigateTo(e, '/import?importType=git')}
-                href="/import?importType=git"
-                title="From Git"
-                iconImg={importGitIcon}
-                description="Import code from your git repository to be built and deployed"
-                data-test-id="import-from-git"
-              />
-            </GalleryItem>
-          )}
-          {createResourceAccess.includes(allCatalogImageResourceAccess) && (
-            <GalleryItem key="gallery-container">
-              <CatalogTile
-                className="odc-empty-state__tile"
-                onClick={(e: React.SyntheticEvent) =>
-                  navigateTo(e, `/deploy-image?preselected-ns=${activeNamespace}`)
-                }
-                href={`/deploy-image?preselected-ns=${activeNamespace}`}
-                title="Container Image"
-                iconClass="pficon-image"
-                description="Deploy an existing image from an image registry or image stream tag"
-              />
-            </GalleryItem>
-          )}
-          <GalleryItem key="gallery-catalog">
-            <CatalogTile
-              className="odc-empty-state__tile"
-              onClick={(e: React.SyntheticEvent) => navigateTo(e, '/catalog')}
-              href="/catalog"
-              title="From Catalog"
-              iconClass="pficon-catalog"
-              description="Browse the catalog to discover, deploy and connect to services"
+          {addActionExtensions.map((action) => (
+            <Item
+              key={action.properties.id ?? action.properties.label}
+              namespace={activeNamespace}
+              action={action}
             />
-          </GalleryItem>
-          {createResourceAccess.includes(allImportResourceAccess) && (
-            <GalleryItem key="gallery-dockerfile">
-              <CatalogTile
-                className="odc-empty-state__tile"
-                onClick={(e: React.SyntheticEvent) => navigateTo(e, '/import?importType=docker')}
-                href="/import?importType=docker"
-                title="From Dockerfile"
-                iconImg={dockerfileIcon}
-                description="Import your Dockerfile from your git repo to be built & deployed"
-              />
-            </GalleryItem>
-          )}
-          <GalleryItem key="gallery-yaml">
-            <CatalogTile
-              className="odc-empty-state__tile"
-              onClick={(e: React.SyntheticEvent) =>
-                navigateTo(e, formatNamespacedRouteForResource('import', activeNamespace))
-              }
-              href={formatNamespacedRouteForResource('import', activeNamespace)}
-              title="YAML"
-              iconImg={yamlIcon}
-              description="Create resources from their YAML or JSON definitions"
-            />
-          </GalleryItem>
-          <GalleryItem key="gallery-database">
-            <CatalogTile
-              className="odc-empty-state__tile"
-              onClick={(e: React.SyntheticEvent) => navigateTo(e, '/catalog?category=databases')}
-              href="/catalog?category=databases"
-              title="Database"
-              iconClass="fas fa-database"
-              description="Browse the catalog to discover database services to add to your application"
-            />
-          </GalleryItem>
-          {isEventSourceEnabled && (
-            <GalleryItem key="gallery-eventsource">
-              <CatalogTile
-                className="odc-empty-state__tile"
-                onClick={(e: React.SyntheticEvent) => navigateTo(e, `/event-source`)}
-                href={`/event-source`}
-                title="Event Source"
-                iconClass="pficon-help"
-                description="Create an event source and sink it to Knative service"
-              />
-            </GalleryItem>
-          )}
+          ))}
         </Gallery>
       </div>
     </>
   );
 };
 
-const mapStateToProps = (state): StateProps => {
+const mapStateToProps = (state: RootState): StateProps => {
   return {
     activeNamespace: state.UI.get('activeNamespace'),
-    isEventSourceEnabled: state.FLAGS.get(FLAG_KNATIVE_EVENTING),
   };
 };
 

--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -31,12 +31,15 @@ const Item: React.FC<ItemProps> = ({
       // eslint-disable-next-line react-hooks/rules-of-hooks
       .map((descriptor) => useAccessReview({ namespace, ...descriptor }))
       .every((x) => x);
+
+  const resolvedUrl = url ? url.replace(':namespace', namespace) : undefined;
+
   return access ? (
     <GalleryItem>
       <CatalogTile
         className="odc-empty-state__tile"
-        onClick={(e: React.SyntheticEvent) => navigateTo(e, url)}
-        href={url}
+        onClick={(e: React.SyntheticEvent) => navigateTo(e, resolvedUrl)}
+        href={resolvedUrl}
         title={label}
         iconImg={icon}
         iconClass={iconClass}

--- a/frontend/packages/dev-console/src/extensions/add-actions.ts
+++ b/frontend/packages/dev-console/src/extensions/add-actions.ts
@@ -1,0 +1,29 @@
+import { Extension } from '@console/plugin-sdk/src/typings/base';
+import { AccessReviewResourceAttributes } from '@console/internal/module/k8s';
+
+namespace ExtensionProperties {
+  export type AddAction = {
+    /** Optional ID used to identify the action. */
+    id?: string;
+    /** The label of the actio.n */
+    label: string;
+    /** The description of the action.  */
+    description: string;
+    /** The perspective display icon. */
+    icon?: string;
+    /** The perspective display icon css class. */
+    iconClass?: string;
+    /** The URL to navigate to. */
+    url: string;
+    /** Optional access review to control visibility / enablement of the action. */
+    accessReview?: AccessReviewResourceAttributes | AccessReviewResourceAttributes[];
+  };
+}
+
+export interface AddAction extends Extension<ExtensionProperties.AddAction> {
+  type: 'AddAction';
+}
+
+export const isAddAction = (e: Extension): e is AddAction => {
+  return e.type === 'AddAction';
+};

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -37,6 +37,19 @@ import {
   newClusterTaskTemplate,
 } from './templates';
 import reducer from './utils/reducer';
+import { AddAction } from './extensions/add-actions';
+import {
+  BuildConfigModel,
+  ImageStreamModel,
+  DeploymentConfigModel,
+  SecretModel,
+  RouteModel,
+  ServiceModel,
+  ImageStreamImportsModel,
+} from '@console/internal/models';
+import * as yamlIcon from './images/yaml.svg';
+import * as importGitIcon from './images/from-git.svg';
+import * as dockerfileIcon from './images/dockerfile.svg';
 
 const {
   ClusterTaskModel,
@@ -62,7 +75,8 @@ type ConsumedExtensions =
   | OverviewResourceTab
   | OverviewCRD
   | YAMLTemplate
-  | OverviewTabSection;
+  | OverviewTabSection
+  | AddAction;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -410,6 +424,14 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
+      path: ['/import-yaml'],
+      component: (props) => <NamespaceRedirect {...props} basePath="/k8s" appendPath="/import" />,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
       path: ['/add/all-namespaces', '/add/ns/:ns'],
       loader: async () =>
         (await import('./components/AddPage' /* webpackChunkName: "dev-console-add" */)).default,
@@ -712,6 +734,98 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       model: ClusterTaskModel,
       template: newClusterTaskTemplate,
+    },
+  },
+  {
+    type: 'AddAction',
+    properties: {
+      id: 'import-from-git',
+      url: '/import',
+      label: 'From Git',
+      description: 'Import code from your git repository to be built and deployed',
+      icon: importGitIcon,
+      accessReview: [
+        BuildConfigModel,
+        ImageStreamModel,
+        DeploymentConfigModel,
+        SecretModel,
+        RouteModel,
+        ServiceModel,
+      ].map((model) => ({
+        group: model.apiGroup || '',
+        resource: model.plural,
+        verb: 'create',
+      })),
+    },
+  },
+  {
+    type: 'AddAction',
+    properties: {
+      url: '/deploy-image',
+      label: 'Container Image',
+      description: 'Deploy an existing image from an image registry or image stream tag',
+      iconClass: 'pficon-image',
+      accessReview: [
+        BuildConfigModel,
+        ImageStreamModel,
+        DeploymentConfigModel,
+        ImageStreamImportsModel,
+        SecretModel,
+        RouteModel,
+        ServiceModel,
+      ].map((model) => ({
+        group: model.apiGroup || '',
+        resource: model.plural,
+        verb: 'create',
+      })),
+    },
+  },
+  {
+    type: 'AddAction',
+    properties: {
+      url: '/catalog',
+      label: 'From Catalog',
+      description: 'Browse the catalog to discover, deploy and connect to services',
+      iconClass: 'pficon-catalog',
+    },
+  },
+  {
+    type: 'AddAction',
+    properties: {
+      url: '/import?importType=docker',
+      label: 'From Dockerfile',
+      description: 'Import your Dockerfile from your git repo to be built & deployed',
+      icon: dockerfileIcon,
+      accessReview: [
+        BuildConfigModel,
+        ImageStreamModel,
+        DeploymentConfigModel,
+        SecretModel,
+        RouteModel,
+        ServiceModel,
+      ].map((model) => ({
+        group: model.apiGroup || '',
+        resource: model.plural,
+        verb: 'create',
+      })),
+    },
+  },
+  {
+    type: 'AddAction',
+    properties: {
+      url: '/import-yaml',
+      label: 'YAML',
+      description: 'Create resources from their YAML or JSON definitions',
+      icon: yamlIcon,
+    },
+  },
+  {
+    type: 'AddAction',
+    properties: {
+      url: '/catalog?category=databases',
+      label: 'Database',
+      description: 'Browse the catalog to discover database services to add to your application',
+      iconClass: 'fas fa-database',
     },
   },
 ];

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -15,6 +15,7 @@ import {
 } from '@console/plugin-sdk';
 import { NamespaceRedirect } from '@console/internal/components/utils/namespace-redirect';
 import { referenceForModel } from '@console/internal/module/k8s';
+import { AddAction } from '@console/dev-console/src/extensions/add-actions';
 import * as models from './models';
 import { yamlTemplates } from './yaml-templates';
 import {
@@ -68,7 +69,8 @@ type ConsumedExtensions =
   | RoutePage
   | KebabActions
   | YAMLTemplate
-  | ResourceDetailsPage;
+  | ResourceDetailsPage
+  | AddAction;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -396,6 +398,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'KebabActions',
     properties: {
       getKebabActionsForKind,
+    },
+  },
+  {
+    type: 'AddAction',
+    flags: {
+      required: [FLAG_KNATIVE_EVENTING],
+    },
+    properties: {
+      url: '/event-source',
+      label: 'Event Source',
+      description: 'Create an event source and sink it to Knative service',
+      iconClass: 'pficon-help',
     },
   },
 ];

--- a/frontend/public/components/utils/namespace-redirect.tsx
+++ b/frontend/public/components/utils/namespace-redirect.tsx
@@ -15,12 +15,22 @@ interface StateProps {
   activeNamespace: string;
 }
 
-export type NamespaceRedirectProps = StateProps & RouteComponentProps;
+export type NamespaceRedirectProps = StateProps &
+  RouteComponentProps & {
+    basePath?: string;
+    appendPath?: string;
+  };
 
 const NamespaceRedirect_: React.FC<NamespaceRedirectProps> = ({
   activeNamespace,
   location: { pathname },
-}) => <Redirect to={appendActiveNamespace(activeNamespace, pathname) + location.search} />;
+  basePath,
+  appendPath = '',
+}) => (
+  <Redirect
+    to={appendActiveNamespace(activeNamespace, basePath ?? pathname) + appendPath + location.search}
+  />
+);
 
 const mapStateToProps = (state: RootState): StateProps => {
   return {


### PR DESCRIPTION
With this patch, the `AddAction` extension of `dev-console` can be parametrized for namespace by using `:namespace` placeholder within the URL.

Example:
```
  {
    type: 'AddAction',
    flags: {
      required: [FLAG_KUBEVIRT],
    },
    properties: {
      url: '/k8s/ns/:namespace/virtualization/~new-wizard?mode=import',
      label: 'Import Virtual Machine',
      description: 'Import a virtual machine from external hypervisor',
      icon: virtualMachineIcon,
    },
  }
```

Depends on: 
- [ ] #4933 `+Add` extension

---
First commit will be removed once #4933 lands.