### PR TITLE
Bug 1826808: added endpoint to fetch duck typed knative event source crds

### DIFF
--- a/cmd/bridge/main.go
+++ b/cmd/bridge/main.go
@@ -551,6 +551,24 @@ func main() {
 		},
 	}
 
+	srv.KnativeEventSourceCRDLister = &server.ResourceLister{
+		BearerToken: resourceListerToken,
+		RequestURL: &url.URL{
+			Scheme: k8sEndpoint.Scheme,
+			Host:   k8sEndpoint.Host,
+			Path:   "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions",
+			RawQuery: url.Values{
+				"labelSelector": {"duck.knative.dev/source=true"},
+			}.Encode(),
+		},
+
+		Client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: srv.K8sProxyConfig.TLSClientConfig,
+			},
+		},
+	}
+
 	listenURL := bridge.ValidateFlagIsURL("listen", *fListen)
 	switch listenURL.Scheme {
 	case "http":

--- a/pkg/knative/utils.go
+++ b/pkg/knative/utils.go
@@ -1,0 +1,66 @@
+package knative
+
+import (
+	"encoding/json"
+	"net/http"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/openshift/console/pkg/serverutils"
+)
+
+var (
+	plog = capnslog.NewPackageLogger("github.com/openshift/console", "knative")
+)
+
+// EventSourceVersion describes a version for CRD.
+type EventSourceVersion struct {
+	Name    string `json:"name" protobuf:"bytes,1,opt,name=name"`
+	Served  bool   `json:"served" protobuf:"varint,2,opt,name=served"`
+	Storage bool   `json:"storage" protobuf:"varint,3,opt,name=storage"`
+}
+
+// EventSourceSpec describes how a user wants their resource to appear
+type EventSourceSpec struct {
+	Group    string                                      `json:"group" protobuf:"bytes,1,opt,name=group"`
+	Names    apiextensions.CustomResourceDefinitionNames `json:"names" protobuf:"bytes,3,opt,name=names"`
+	Versions []EventSourceVersion                        `json:"versions" protobuf:"bytes,7,rep,name=versions"`
+}
+
+// EventSourceMeta is metadata that all persisted resources must have, which includes all objects users must create
+type EventSourceMeta struct {
+	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+}
+
+// EventSourceDefinition represents a resource that should be exposed on the API server.
+type EventSourceDefinition struct {
+	metav1.TypeMeta `json:",inline"`
+	EventSourceMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	EventSourceSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
+}
+
+// EventSourceList is a list of EventSourceDefinition objects.
+type EventSourceList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// items list individual EventSourceDefinition objects
+	Items []EventSourceDefinition `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+// EventSourceFilter shall filter partial metadata from knative event sources CRDs before propagating
+func EventSourceFilter(w http.ResponseWriter, r *http.Response) {
+	var eventSourceList EventSourceList
+
+	if err := json.NewDecoder(r.Body).Decode(&eventSourceList); err != nil {
+		plog.Errorf("Event Source CRD response deserialization failed: %s", err)
+		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
+	}
+
+	if err := json.NewEncoder(w).Encode(eventSourceList); err != nil {
+		plog.Errorf("Event Source CRD response serialization failed: %s", err)
+		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
+	}
+}

--- a/pkg/server/resource_lister.go
+++ b/pkg/server/resource_lister.go
@@ -37,7 +37,7 @@ func (l *ResourceLister) handleResources(w http.ResponseWriter, r *http.Request)
 
 	if resp.StatusCode != http.StatusOK {
 		err := fmt.Errorf("console service account cannot list resource: %s", resp.Status)
-		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
+		serverutils.SendResponse(w, resp.StatusCode, serverutils.ApiError{Err: err.Error()})
 		return
 	}
 

--- a/pkg/server/resource_lister.go
+++ b/pkg/server/resource_lister.go
@@ -9,27 +9,37 @@ import (
 	"github.com/openshift/console/pkg/serverutils"
 )
 
-// ResourceLister determines the list of resources of a particular kind
-type ResourceLister struct {
-	BearerToken string
-	RequestURL  *url.URL
-	Client      *http.Client
+// ResourceLister handles resource requests
+type ResourceLister interface {
+	HandleResources(w http.ResponseWriter, r *http.Request)
 }
 
-func (l *ResourceLister) handleResources(w http.ResponseWriter, r *http.Request) {
+// FilterFunction shall filter response before propagating
+type FilterFunction func(http.ResponseWriter, *http.Response)
+
+// resourceLister determines the list of resources of a particular kind
+type resourceLister struct {
+	bearerToken    string
+	requestURL     *url.URL
+	client         *http.Client
+	responseFilter FilterFunction
+}
+
+//HandleResources handles resource requests
+func (l *resourceLister) HandleResources(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" {
 		serverutils.SendResponse(w, http.StatusMethodNotAllowed, serverutils.ApiError{Err: "invalid method: only GET is allowed"})
 		return
 	}
 
-	req, err := http.NewRequest("GET", l.RequestURL.String(), nil)
+	req, err := http.NewRequest("GET", l.requestURL.String(), nil)
 	if err != nil {
 		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: fmt.Sprintf("failed to create GET request: %v", err)})
 		return
 	}
 
-	req.Header.Set("Authorization", "Bearer "+l.BearerToken)
-	resp, err := l.Client.Do(req)
+	req.Header.Set("Authorization", "Bearer "+l.bearerToken)
+	resp, err := l.client.Do(req)
 	if err != nil {
 		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("GET request failed: %v", err)})
 		return
@@ -42,6 +52,26 @@ func (l *ResourceLister) handleResources(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
+	l.responseFilter(w, resp)
 	resp.Body.Close()
+}
+
+// NewResourceLister shall instantiate & return resourceLister instance
+func NewResourceLister(bearerToken string, requestURL *url.URL, client *http.Client, respFilter FilterFunction) ResourceLister {
+	r := &resourceLister{
+		bearerToken:    bearerToken,
+		requestURL:     requestURL,
+		client:         client,
+		responseFilter: respFilter,
+	}
+	if r.responseFilter == nil {
+		r.responseFilter = func(w http.ResponseWriter, r *http.Response) {
+			if _, err := io.Copy(w, r.Body); err != nil {
+				plog.Errorf("console service account cannot list resource: %s", err)
+				serverutils.SendResponse(w.(http.ResponseWriter), http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
+			}
+		}
+	}
+
+	return r
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -98,8 +98,8 @@ type Server struct {
 	AlertManagerProxyConfig  *proxy.Config
 	MeteringProxyConfig      *proxy.Config
 	// A lister for resource listing of a particular kind
-	MonitoringDashboardConfigMapLister *ResourceLister
-	KnativeEventSourceCRDLister        *ResourceLister
+	MonitoringDashboardConfigMapLister ResourceLister
+	KnativeEventSourceCRDLister        ResourceLister
 	HelmChartRepoProxyConfig           *proxy.Config
 	GOARCH                             string
 	GOOS                               string
@@ -312,7 +312,7 @@ func (s *Server) HTTPHandler() http.Handler {
 	}
 
 	handle("/api/console/monitoring-dashboard-config", authHandler(s.handleMonitoringDashboardConfigmaps))
-	handle("/api/console/crd/knative-event-sources", authHandler(s.handleKnativeEventSourceCrds))
+	handle("/api/console/knative-event-sources", authHandler(s.handleKnativeEventSourceCRDs))
 	handle("/api/console/version", authHandler(s.versionHandler))
 
 	// Helm Endpoints
@@ -353,11 +353,11 @@ func (s *Server) HTTPHandler() http.Handler {
 }
 
 func (s *Server) handleMonitoringDashboardConfigmaps(w http.ResponseWriter, r *http.Request) {
-	s.MonitoringDashboardConfigMapLister.handleResources(w, r)
+	s.MonitoringDashboardConfigMapLister.HandleResources(w, r)
 }
 
-func (s *Server) handleKnativeEventSourceCrds(w http.ResponseWriter, r *http.Request) {
-	s.KnativeEventSourceCRDLister.handleResources(w, r)
+func (s *Server) handleKnativeEventSourceCRDs(w http.ResponseWriter, r *http.Request) {
+	s.KnativeEventSourceCRDLister.HandleResources(w, r)
 }
 
 func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -99,6 +99,7 @@ type Server struct {
 	MeteringProxyConfig      *proxy.Config
 	// A lister for resource listing of a particular kind
 	MonitoringDashboardConfigMapLister *ResourceLister
+	KnativeEventSourceCRDLister        *ResourceLister
 	HelmChartRepoProxyConfig           *proxy.Config
 	GOARCH                             string
 	GOOS                               string
@@ -311,6 +312,7 @@ func (s *Server) HTTPHandler() http.Handler {
 	}
 
 	handle("/api/console/monitoring-dashboard-config", authHandler(s.handleMonitoringDashboardConfigmaps))
+	handle("/api/console/crd/knative-event-sources", authHandler(s.handleKnativeEventSourceCrds))
 	handle("/api/console/version", authHandler(s.versionHandler))
 
 	// Helm Endpoints
@@ -352,6 +354,10 @@ func (s *Server) HTTPHandler() http.Handler {
 
 func (s *Server) handleMonitoringDashboardConfigmaps(w http.ResponseWriter, r *http.Request) {
 	s.MonitoringDashboardConfigMapLister.handleResources(w, r)
+}
+
+func (s *Server) handleKnativeEventSourceCrds(w http.ResponseWriter, r *http.Request) {
+	s.KnativeEventSourceCRDLister.handleResources(w, r)
 }
 
 func (s *Server) indexHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3398

**Analysis / Root cause**: 
Need a new end point in console that specifically returns metadata for all knative event source CRDs. This shall allow an unprivileged user to access this information without read access to CRDs. 

**Solution Description**: 
Added an end point `/api/console/knative-event-sources` to fetch all duck typed event source CRDs. Updated `ResourceLister` handler to propagate response error status as is & also added a `ResponseFilter` function to filter any response before propagation.
        In order to allow an unprivileged user to get this information without read access to CRDs, new RBAC has been added in `console-operator` to authorise service account to list CRDs. Ref PR: https://github.com/openshift/console-operator/pull/413

**Screen shots / Gifs for design review**: 
N/A

**Unit test coverage report**: 
N/A

**Test setup:**
Need to build backend & console-operator to test above API
Note: In off-cluster mode, user token shall be used & hence user need to be authorised to verify this API. Whereas for in-cluster mode, service account shall be used & it has RBAC to authorise for unprivileged user.

**Browser conformance**: 
N/A
