### PR TITLE
Feat(CLI-terminal): Open terminal in new Tab

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellDrawer.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellDrawer.tsx
@@ -35,8 +35,7 @@ const CloudShellDrawer: React.FC<CloudShellDrawerProps> = ({ children, onClose }
           <Button
             variant="plain"
             component="a"
-            // change this once we can open terminal in new tab
-            href={null}
+            href="/terminal"
             target="_blank"
             aria-label="Open terminal in new tab"
           >

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.scss
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.scss
@@ -1,0 +1,16 @@
+.co-cloud-shell-tab {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background-color: var(--pf-global--Color--dark-100);
+  &__header {
+    flex-shrink: 0;
+    min-height: var(--pf-global--target-size--MinHeight);
+    background-color: var(--pf-global--palette--black-200);
+    display: flex;
+    align-items: center;
+    padding: 0 var(--pf-global--spacer--md);
+  }
+}

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTab.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import CloudShellTerminal from './CloudShellTerminal';
+import './CloudShellTab.scss';
+
+const CloudShellTab: React.FC = () => (
+  <div className="co-cloud-shell-tab">
+    <div className="co-cloud-shell-tab__header">OpenShift command line terminal</div>
+    <CloudShellTerminal />
+  </div>
+);
+
+export default CloudShellTab;

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminalFrame.scss
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminalFrame.scss
@@ -1,6 +1,8 @@
 .co-cloud-shell-terminal-frame {
   background-color: #000;
+  width: 100%;
   height: 100%;
+  overflow: hidden;
 
   & > iframe {
     height: 100%;

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTab.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTab.spec.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import store from '@console/internal/redux';
+import CloudShellTab from '../CloudShellTab';
+import CloudShellTerminal from '../CloudShellTerminal';
+
+describe('CloudShell Tab Test', () => {
+  it('should render cloudshellterminal', () => {
+    const cloudShellTabWrapper = mount(<CloudShellTab />, {
+      wrappingComponent: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+    expect(cloudShellTabWrapper.find(CloudShellTerminal).exists()).toBe(true);
+  });
+});

--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -3,11 +3,11 @@ import * as React from 'react';
 import { render } from 'react-dom';
 import { Helmet } from 'react-helmet';
 import { Provider } from 'react-redux';
-import { Route, Router } from 'react-router-dom';
+import { Route, Router, Switch } from 'react-router-dom';
 // AbortController is not supported in some older browser versions
 import 'abort-controller/polyfill';
 import CloudShell from '@console/app/src/components/cloud-shell/CloudShell';
-
+import CloudShellTab from '@console/app/src/components/cloud-shell/CloudShellTab';
 import store from '../redux';
 import { detectFeatures } from '../actions/features';
 import AppContents from './app-contents';
@@ -227,7 +227,10 @@ if ('serviceWorker' in navigator) {
 render(
   <Provider store={store}>
     <Router history={history} basename={window.SERVER_FLAGS.basePath}>
-      <Route path="/" component={App} />
+      <Switch>
+        <Route path="/terminal" component={CloudShellTab} />
+        <Route path="/" component={App} />
+      </Switch>
     </Router>
   </Provider>,
   document.getElementById('app'),


### PR DESCRIPTION
### Feature:
https://issues.redhat.com/browse/ODC-3056

**The restore link has been removed after discussion with UX**
**This PR doesn't handle the session management for cloudshell terminal** 

### Analysis / Root cause:
Launch Cloudshell in new Tab

### Solution Description:
1. Creates a new Route `/cloudshell` to load Terminal as a full page component at this URL.
2. Creates a new `CloudshellTab` component with holds the Terminal and exposes it over the given route.


**To Do**
1. Add Unit tests :heavy_check_mark:
2. Comment out CloudShellIcon from mastheadToolbar. :heavy_check_mark:

### ScreenShots
![cst1](https://user-images.githubusercontent.com/24852534/78798125-3e18db00-79d6-11ea-815e-2a80111e607d.gif)
![cst2](https://user-images.githubusercontent.com/24852534/78798138-41ac6200-79d6-11ea-8c3d-0c3165b0ec5e.gif)

### Unit Test
CloudShellTab.spec.tsx

### Broswer conformance
Chrome 73

### How to Review
- Setup che-workspace-controller on cluster

1. clone repo https://github.com/che-incubator/che-workspace-operator
 Run the following commands from repo root
3. export IMG=quay.io/che-incubator/che-workspace-controller:nightly
4. export TOOL=oc # Use 'export TOOL=kubectl' for kubernetes
5. make deploy

- Uncomment the import and addition of CloudShellMastHeadIcon in masthead-toolbar.jsx at line 27 and 578