### PR TITLE
Bug 1819628: Fix bug where networking metrics unavailable to regular users

### DIFF
--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -326,6 +326,7 @@ const PodGraphs = requirePrometheus(({ pod }) => (
         <Area
           title="Network In"
           humanize={humanizeDecimalBytesPerSec}
+          namespace={pod.metadata.namespace}
           query={`sum(irate(container_network_receive_bytes_total{pod='${pod.metadata.name}', namespace='${pod.metadata.namespace}'}[5m])) by (pod, namespace)`}
         />
       </div>
@@ -333,6 +334,7 @@ const PodGraphs = requirePrometheus(({ pod }) => (
         <Area
           title="Network Out"
           humanize={humanizeDecimalBytesPerSec}
+          namespace={pod.metadata.namespace}
           query={`sum(irate(container_network_transmit_bytes_total{pod='${pod.metadata.name}', namespace='${pod.metadata.namespace}'}[5m])) by (pod, namespace)`}
         />
       </div>


### PR DESCRIPTION
After:
![console-openshift-console apps rhamilto devcluster openshift com_k8s_ns_test_pods_example(5  PFXL)](https://user-images.githubusercontent.com/895728/78718059-97f2a580-78ef-11ea-9ea5-cc6deae38294.png)
