### PR TITLE
Add credential management section in start pipeline modal.

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/const.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/const.ts
@@ -12,3 +12,4 @@ export enum VolumeTypes {
   Secret = 'Secret',
   PVC = 'PVC',
 }
+export const PIPELINE_SERVICE_ACCOUNT = 'pipeline';

--- a/frontend/packages/dev-console/src/components/pipelines/const.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/const.ts
@@ -12,4 +12,15 @@ export enum VolumeTypes {
   Secret = 'Secret',
   PVC = 'PVC',
 }
+
+export enum SecretAnnotationId {
+  Git = 'git',
+  Image = 'docker',
+}
+
+export const SecretAnnotationType = {
+  [SecretAnnotationId.Git]: 'Git Server',
+  [SecretAnnotationId.Image]: 'Docker Registry',
+};
+
 export const PIPELINE_SERVICE_ACCOUNT = 'pipeline';

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineSecretSection.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineSecretSection.scss
@@ -1,0 +1,10 @@
+.odc-pipeline-secret-section {
+  padding-left: var(--pf-global--spacer--lg);
+  &__secrets {
+    padding-left: var(--pf-global--spacer--lg);
+  }
+  &__secret-form {
+    border: 1px dashed var(--pf-global--BorderColor--100);
+    padding: var(--pf-global--spacer--md);
+  }
+}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineSecretSection.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineSecretSection.scss
@@ -1,10 +1,15 @@
 .odc-pipeline-secret-section {
+  margin-top: var(--pf-global--spacer--sm);
   padding-left: var(--pf-global--spacer--lg);
-  &__secrets {
-    padding-left: var(--pf-global--spacer--lg);
-  }
   &__secret-form {
     border: 1px dashed var(--pf-global--BorderColor--100);
     padding: var(--pf-global--spacer--md);
   }
+  &__secret-action {
+    margin-top: var(--pf-global--spacer--sm);
+    padding-left: 0;
+  }
+}
+.odc-pipeline-expandable-content {
+  margin-top: var(--pf-global--spacer--sm);
 }

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineSecretSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/PipelineSecretSection.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { Formik } from 'formik';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Button } from '@patternfly/react-core';
+import { ExpandCollapse } from '@console/internal/components/utils';
+import { SecretType } from '@console/internal/components/secrets/create-secret';
+import { SecretModel } from '@console/internal/models';
+import { k8sCreate } from '@console/internal/module/k8s';
+import SecretForm from './SecretForm';
+import { associateServiceAccountToSecret } from '../../../utils/pipeline-utils';
+import SecretsList from './SecretsList';
+import './PipelineSecretSection.scss';
+
+const initialValues = {
+  secretName: '',
+  type: SecretType.dockerconfigjson,
+  formData: {},
+};
+
+type PipelineSecretSectionProps = {
+  namespace: string;
+};
+
+const PipelineSecretSection: React.FC<PipelineSecretSectionProps> = ({ namespace }) => {
+  const [addSecret, setAddSecret] = React.useState(false);
+
+  const handleSubmit = (values, actions) => {
+    actions.setSubmitting(true);
+    const newSecret = {
+      apiVersion: SecretModel.apiVersion,
+      kind: SecretModel.kind,
+      metadata: {
+        name: values.secretName,
+        namespace,
+      },
+      type: values.type,
+      stringData: values.formData,
+    };
+
+    k8sCreate(SecretModel, newSecret)
+      .then((resp) => {
+        actions.setSubmitting(false);
+        setAddSecret(false);
+        associateServiceAccountToSecret(resp, namespace);
+      })
+      .catch((err) => {
+        actions.setSubmitting(false);
+        actions.setStatus({ submitError: err.message });
+      });
+  };
+
+  const handleReset = (values, actions) => {
+    actions.resetForm({ values: initialValues, status: {} });
+    setAddSecret(false);
+  };
+
+  const handleAddSecret = () => {
+    setAddSecret(true);
+  };
+  return (
+    <ExpandCollapse textExpanded="Hide Credential Options" textCollapsed="Show Credential Options">
+      <div className="odc-pipeline-secret-section">
+        <p>The following secrets are available for all pipelines in this namespace:</p>
+        <div className="odc-pipeline-secret-section__secrets">
+          <SecretsList namespace={namespace} />
+          {addSecret ? (
+            <div className="odc-pipeline-secret-section__secret-form">
+              <Formik initialValues={initialValues} onSubmit={handleSubmit} onReset={handleReset}>
+                {(props) => <SecretForm {...props} />}
+              </Formik>
+            </div>
+          ) : (
+            <Button variant="link" onClick={handleAddSecret} icon={<PlusCircleIcon />}>
+              Add Secret
+            </Button>
+          )}
+        </div>
+      </div>
+    </ExpandCollapse>
+  );
+};
+
+export default PipelineSecretSection;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretAnnotation.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretAnnotation.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { TextInputTypes } from '@patternfly/react-core';
+import { InputField, DropdownField } from '@console/shared';
+import { SecretAnnotationType } from '../const';
+
+type SecretAnnotationParam = {
+  fieldName: string;
+  isReadOnly?: boolean;
+};
+
+const SecretAnnotation: React.FC<SecretAnnotationParam> = (props) => {
+  const { fieldName, isReadOnly = false } = props;
+  return (
+    <div className="row">
+      <div className="col-lg-6">
+        <DropdownField
+          name={`${fieldName}.key`}
+          items={SecretAnnotationType}
+          label="Access to"
+          disabled={isReadOnly}
+          fullWidth
+          required
+        />
+      </div>
+      <div className="col-lg-6">
+        <InputField
+          name={`${fieldName}.value`}
+          type={TextInputTypes.text}
+          isReadOnly={isReadOnly}
+          label="Server URL"
+          required
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SecretAnnotation;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretForm.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretForm.scss
@@ -1,0 +1,8 @@
+.odc-secret-form {
+  &__title {
+    margin-top: 0;
+  }
+  &__help-text {
+    margin: var(--pf-global--spacer--md) 0;
+  }
+}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretForm.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { FormikValues, useFormikContext } from 'formik';
+import { ActionGroup, Button, ButtonVariant, TextInputTypes } from '@patternfly/react-core';
+import { CheckIcon, CloseIcon } from '@patternfly/react-icons';
+import { ButtonBar } from '@console/internal/components/utils';
+import {
+  SecretType,
+  BasicAuthSubform,
+  SSHAuthSubform,
+  CreateConfigSubform,
+} from '@console/internal/components/secrets/create-secret';
+import { DropdownField, InputField } from '@console/shared';
+import './SecretForm.scss';
+
+const authTypes = {
+  [SecretType.dockerconfigjson]: 'Image Registry Credentials',
+  [SecretType.basicAuth]: 'Basic Authentication',
+  [SecretType.sshAuth]: 'SSH Key',
+};
+
+const renderSecretForm = (
+  type: string,
+  stringData: {
+    [key: string]: any;
+  },
+  onDataChanged: (event: Event) => void,
+) => {
+  switch (type) {
+    case SecretType.basicAuth:
+      return (
+        <BasicAuthSubform onChange={onDataChanged} stringData={stringData[SecretType.basicAuth]} />
+      );
+    case SecretType.sshAuth:
+      return (
+        <SSHAuthSubform onChange={onDataChanged} stringData={stringData[SecretType.sshAuth]} />
+      );
+    case SecretType.dockerconfigjson:
+      return (
+        <CreateConfigSubform
+          onChange={onDataChanged}
+          stringData={stringData[SecretType.dockerconfigjson]}
+        />
+      );
+    default:
+      return null;
+  }
+};
+
+const SecretForm: React.FC<FormikValues> = ({
+  handleSubmit,
+  handleReset,
+  status,
+  isSubmitting,
+}) => {
+  const { values, setFieldValue } = useFormikContext<FormikValues>();
+  const [stringData, setStringData] = React.useState({
+    [SecretType.basicAuth]: {},
+    [SecretType.sshAuth]: {},
+    [SecretType.dockerconfigjson]: {},
+  });
+
+  const setValues = (type) => {
+    type === SecretType.dockerconfigjson
+      ? setFieldValue(
+          'formData',
+          _.mapValues({ '.dockerconfigjson': stringData[type] }, JSON.stringify),
+        )
+      : setFieldValue('formData', stringData[type]);
+  };
+
+  const onDataChanged = (event) => {
+    setStringData((prevState) => ({ ...prevState, [values.type]: event }));
+    setValues(values.type);
+  };
+
+  const handleTypeChange = (type) => {
+    setValues(type);
+  };
+
+  return (
+    <div className="odc-secret-form">
+      <h1 className="odc-secret-form__title">Create Secret</h1>
+      <p className="odc-secret-form__help-text help-block">
+        Source secrets let you authenticate against a Git server.
+      </p>
+      <div className="form-group">
+        <InputField
+          type={TextInputTypes.text}
+          required
+          name="secretName"
+          label="Secret Name"
+          helpText="Unique name of the new secret."
+        />
+      </div>
+      <div className="form-group">
+        <DropdownField
+          name="type"
+          label="Authentication Type"
+          items={authTypes}
+          title={authTypes[values.type]}
+          onChange={handleTypeChange}
+          fullWidth
+          required
+        />
+      </div>
+      {renderSecretForm(values.type, stringData, onDataChanged)}
+      <ButtonBar errorMessage={status && status.submitError} inProgress={isSubmitting}>
+        <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
+          <Button
+            type="button"
+            variant={ButtonVariant.link}
+            onClick={handleSubmit}
+            className="odc-pipeline-resource-param__action-btn"
+            aria-label="create"
+          >
+            <CheckIcon />
+          </Button>
+          <Button
+            type="button"
+            className="odc-pipeline-resource-param__action-btn"
+            variant={ButtonVariant.plain}
+            onClick={handleReset}
+            aria-label="close"
+          >
+            <CloseIcon />
+          </Button>
+        </ActionGroup>
+      </ButtonBar>
+    </div>
+  );
+};
+
+export default SecretForm;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretForm.tsx
@@ -11,6 +11,7 @@ import {
   CreateConfigSubform,
 } from '@console/internal/components/secrets/create-secret';
 import { DropdownField, InputField } from '@console/shared';
+import SecretAnnotation from './SecretAnnotation';
 import './SecretForm.scss';
 
 const authTypes = {
@@ -20,11 +21,11 @@ const authTypes = {
 };
 
 const renderSecretForm = (
-  type: string,
+  type: SecretType,
   stringData: {
     [key: string]: any;
   },
-  onDataChanged: (event: Event) => void,
+  onDataChanged: (value: string) => void,
 ) => {
   switch (type) {
     case SecretType.basicAuth:
@@ -60,22 +61,20 @@ const SecretForm: React.FC<FormikValues> = ({
     [SecretType.dockerconfigjson]: {},
   });
 
-  const setValues = (type) => {
-    type === SecretType.dockerconfigjson
-      ? setFieldValue(
-          'formData',
-          _.mapValues({ '.dockerconfigjson': stringData[type] }, JSON.stringify),
-        )
-      : setFieldValue('formData', stringData[type]);
+  const setValues = (type: SecretType) => {
+    if (type === SecretType.dockerconfigjson) {
+      setFieldValue(
+        'formData',
+        _.mapValues({ '.dockerconfigjson': stringData[type] }, JSON.stringify),
+      );
+    } else {
+      setFieldValue('formData', stringData[type]);
+    }
   };
 
-  const onDataChanged = (event) => {
-    setStringData((prevState) => ({ ...prevState, [values.type]: event }));
+  const onDataChanged = (value: string) => {
+    setStringData(_.merge(stringData, { [values.type]: value }));
     setValues(values.type);
-  };
-
-  const handleTypeChange = (type) => {
-    setValues(type);
   };
 
   return (
@@ -94,12 +93,15 @@ const SecretForm: React.FC<FormikValues> = ({
         />
       </div>
       <div className="form-group">
+        <SecretAnnotation fieldName="annotations" />
+      </div>
+      <div className="form-group">
         <DropdownField
           name="type"
           label="Authentication Type"
           items={authTypes}
           title={authTypes[values.type]}
-          onChange={handleTypeChange}
+          onChange={(type: SecretType) => setValues(type)}
           fullWidth
           required
         />

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.scss
@@ -1,0 +1,6 @@
+.odc-secrets-list {
+  &__secrets {
+    padding-left: var(--pf-global--spacer--lg);
+    padding-bottom: var(--pf-global--spacer--lg);
+  }
+}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.scss
@@ -1,6 +1,5 @@
 .odc-secrets-list {
-  &__secrets {
-    padding-left: var(--pf-global--spacer--lg);
-    padding-bottom: var(--pf-global--spacer--lg);
+  &__secretsItem {
+    margin-top: var(--pf-global--spacer--sm);
   }
 }

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import {
+  ResourceLink,
+  Firehose,
+  FirehoseResult,
+  FirehoseResource,
+} from '@console/internal/components/utils';
+import { SecretModel, ServiceAccountModel } from '@console/internal/models';
+import { SecretType } from '@console/internal/components/secrets/create-secret';
+import { SecondaryStatus } from '@console/shared';
+import { SecretKind, ServiceAccountKind } from '@console/internal/module/k8s';
+import { PIPELINE_SERVICE_ACCOUNT } from '../const';
+import './SecretsList.scss';
+
+type SecretsProps = {
+  secrets?: FirehoseResult<SecretKind[]>;
+  serviceaccounts?: FirehoseResult<ServiceAccountKind>;
+};
+
+type SecretsListProps = {
+  namespace: string;
+};
+
+const secretTypes = [SecretType.dockerconfigjson, SecretType.basicAuth, SecretType.sshAuth];
+
+const Secrets: React.FC<SecretsProps> = ({ secrets, serviceaccounts }) => {
+  const servicAccountSecrets = _.map(serviceaccounts.data.secrets, 'name');
+  const filterData = _.filter(
+    secrets.data,
+    (secret) =>
+      _.includes(secretTypes, secret.type) &&
+      _.includes(servicAccountSecrets, secret.metadata.name),
+  );
+  const sortedFilterData = _.sortBy(filterData, (data) => data.metadata.name);
+
+  return (
+    <div className="odc-secrets-list">
+      <label>Secrets ({sortedFilterData.length})</label>
+      <div className="odc-secrets-list__secrets">
+        {sortedFilterData.map((secret) => {
+          return (
+            <ResourceLink
+              key={secret.metadata.uid}
+              kind={SecretModel.kind}
+              name={secret.metadata.name}
+              namespace={secret.metadata.namespace}
+              title={secret.metadata.name}
+            />
+          );
+        })}
+        {_.isEmpty(sortedFilterData) && <SecondaryStatus status="No source secrets found" />}
+      </div>
+    </div>
+  );
+};
+
+const SecretsList: React.FC<SecretsListProps> = ({ namespace }) => {
+  const resources: FirehoseResource[] = [
+    {
+      isList: true,
+      namespace,
+      kind: SecretModel.kind,
+      prop: SecretModel.plural,
+    },
+    {
+      isList: false,
+      namespace,
+      kind: ServiceAccountModel.kind,
+      prop: ServiceAccountModel.plural,
+      name: PIPELINE_SERVICE_ACCOUNT,
+    },
+  ];
+
+  return (
+    <Firehose resources={resources}>
+      <Secrets />
+    </Firehose>
+  );
+};
+
+export default SecretsList;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/SecretsList.tsx
@@ -9,13 +9,14 @@ import {
 import { SecretModel, ServiceAccountModel } from '@console/internal/models';
 import { SecretType } from '@console/internal/components/secrets/create-secret';
 import { SecondaryStatus } from '@console/shared';
-import { SecretKind, ServiceAccountKind } from '@console/internal/module/k8s';
+import { SecretKind } from '@console/internal/module/k8s';
+import { ServiceAccountType } from '../../../utils/pipeline-utils';
 import { PIPELINE_SERVICE_ACCOUNT } from '../const';
 import './SecretsList.scss';
 
 type SecretsProps = {
   secrets?: FirehoseResult<SecretKind[]>;
-  serviceaccounts?: FirehoseResult<ServiceAccountKind>;
+  serviceaccounts?: FirehoseResult<ServiceAccountType>;
 };
 
 type SecretsListProps = {
@@ -25,12 +26,12 @@ type SecretsListProps = {
 const secretTypes = [SecretType.dockerconfigjson, SecretType.basicAuth, SecretType.sshAuth];
 
 const Secrets: React.FC<SecretsProps> = ({ secrets, serviceaccounts }) => {
-  const servicAccountSecrets = _.map(serviceaccounts.data.secrets, 'name');
+  const serviceAccountSecrets = _.map(serviceaccounts.data.secrets, 'name');
   const filterData = _.filter(
     secrets.data,
     (secret) =>
       _.includes(secretTypes, secret.type) &&
-      _.includes(servicAccountSecrets, secret.metadata.name),
+      _.includes(serviceAccountSecrets, secret.metadata.name),
   );
   const sortedFilterData = _.sortBy(filterData, (data) => data.metadata.name);
 
@@ -41,6 +42,7 @@ const Secrets: React.FC<SecretsProps> = ({ secrets, serviceaccounts }) => {
         {sortedFilterData.map((secret) => {
           return (
             <ResourceLink
+              className="odc-secrets-list__secretsItem"
               key={secret.metadata.uid}
               kind={SecretModel.kind}
               name={secret.metadata.name}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineForm.tsx
@@ -7,9 +7,11 @@ import {
   ModalBody,
   ModalSubmitFooter,
 } from '@console/internal/components/factory/modal';
+import FormSection from '../../import/section/FormSection';
 import PipelineResourceSection, { ResourceProps } from './PipelineResourceSection';
 import PipelineParameterSection from './PipelineParameterSection';
 import PipelineWorkspacesSection from './PiplelineWorkspacesSection';
+import PipelineSecretSection from './PipelineSecretSection';
 
 const StartPipelineForm: React.FC<FormikValues> = ({
   values,
@@ -40,6 +42,9 @@ const StartPipelineForm: React.FC<FormikValues> = ({
           <PipelineParameterSection parameters={values.parameters} />
           <PipelineResourceSection resources={resources} />
           <PipelineWorkspacesSection />
+          <FormSection title="Advanced Options" fullWidth>
+            <PipelineSecretSection namespace={values.namespace} />
+          </FormSection>
         </ModalBody>
         <ModalSubmitFooter
           errorMessage={status && status.submitError}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
@@ -85,8 +85,9 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
       initialValues={initialValues}
       onSubmit={handleSubmit}
       validationSchema={startPipelineSchema}
-      render={(props) => <StartPipelineForm {...props} close={close} />}
-    />
+    >
+      {(props) => <StartPipelineForm {...props} close={close} />}
+    </Formik>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/StartPipelineModal.tsx
@@ -48,6 +48,7 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
         ...workspace,
         type: 'EmptyDirectory',
       })) ?? [],
+    secretOpen: false,
   };
   initialValues.resources.map((resource: PipelineResource) =>
     _.merge(resource, { resourceRef: { name: '' } }),

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-form/pipelineForm-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-form/pipelineForm-validation-utils.ts
@@ -88,4 +88,14 @@ export const startPipelineSchema = yup.object().shape({
       data: volumeTypeSchema,
     }),
   ),
+  secretOpen: yup.boolean().equals([false]),
+});
+
+export const advancedSectionValidationSchema = yup.object().shape({
+  secretName: yup.string().required('Required'),
+  type: yup.string().required('Required'),
+  annotations: yup.object().shape({
+    key: yup.string().required('Required'),
+    value: yup.string().required('Required'),
+  }),
 });

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceForm.tsx
@@ -96,10 +96,9 @@ const PipelineResourceForm: React.FC<PipelineResourceFormProps> = ({
       onSubmit={handleSubmit}
       onReset={handleReset}
       validationSchema={validationSchema}
-      render={(props) => (
-        <PipelineResourceParam {...props} type={type} closeDisabled={closeDisabled} />
-      )}
-    />
+    >
+      {(props) => <PipelineResourceParam {...props} type={type} closeDisabled={closeDisabled} />}
+    </Formik>
   );
 };
 

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-utils.spec.ts
@@ -6,12 +6,14 @@ import {
   LOG_SOURCE_TERMINATED,
 } from '@console/internal/components/utils';
 import { ContainerStatus } from '@console/internal/module/k8s';
+import { SecretAnnotationId } from '../../components/pipelines/const';
 import {
   getPipelineTasks,
   containerToLogSourceStatus,
   constructCurrentPipeline,
   getPipelineRunParams,
   pipelineRunDuration,
+  getSecretAnnotations,
 } from '../pipeline-utils';
 import {
   constructPipelineData,
@@ -102,5 +104,29 @@ describe('pipeline-utils ', () => {
     const duration = pipelineRunDuration(mockRunDurationTest[2]);
     expect(duration).not.toBeNull();
     expect(duration).toBe('1m 13s');
+  });
+  it('expect annotation to return an empty object if keyValue pair is not passed', () => {
+    const annotation = getSecretAnnotations(null);
+    expect(annotation).toEqual({});
+  });
+
+  it('expect annotation to have a valid git annotation key and value', () => {
+    const annotation = getSecretAnnotations({
+      key: SecretAnnotationId.Git,
+      value: 'github.com',
+    });
+    expect(annotation).toEqual({
+      'tekton.dev/git-0': 'github.com',
+    });
+  });
+
+  it('expect annotation to have a valid image annotation key and value', () => {
+    const annotation = getSecretAnnotations({
+      key: SecretAnnotationId.Image,
+      value: 'docker.io',
+    });
+    expect(annotation).toEqual({
+      'tekton.dev/docker-0': 'docker.io',
+    });
   });
 });

--- a/frontend/public/components/secrets/create-secret.tsx
+++ b/frontend/public/components/secrets/create-secret.tsx
@@ -521,7 +521,7 @@ type CreateConfigSubformState = {
   }[];
 };
 
-class CreateConfigSubform extends React.Component<
+export class CreateConfigSubform extends React.Component<
   CreateConfigSubformProps,
   CreateConfigSubformState
 > {


### PR DESCRIPTION
This PR contains an additional commit 7e449bd9a3f5c237a218a3e33b1b6b6153a1699b on top of @vikram-raj's [PR-4868](https://github.com/openshift/console/pull/4868) 
Fixes: https://issues.redhat.com/browse/ODC-3351
**Problem:**
If pipeline resources are private, then ability to provide secret while starting a pipeline is missing.

**Solution:**
Added Advanced options in the start pipeline modal and added ability to create new secret and all the linked secrets are listed for user's reference.

**Screeshot/gif:**
![Pipeline-creds-mgmt](https://user-images.githubusercontent.com/9964343/78719937-66ef9080-7942-11ea-869e-ecdb8b81c4fb.gif)

**Overall structure of the form:**
![fields](https://user-images.githubusercontent.com/9964343/78721228-be8efb80-7944-11ea-93c0-720b1a0455db.gif)

**Pipeline execution succeeded with private git and docker registry:**
![image](https://user-images.githubusercontent.com/9964343/78720735-d74ae180-7943-11ea-87ca-637759731a80.png)

**Unit test coverage:**
![image](https://user-images.githubusercontent.com/9964343/78720012-8c7c9a00-7942-11ea-9986-d3516232ab37.png)

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @serenamarie125 @andrewballantyne @vikram-raj 