### PR TITLE
updats name for eventSources and shows loading for source selector

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { Formik } from 'formik';
 import { connect } from 'react-redux';
 import { history } from '@console/internal/components/utils';
@@ -37,6 +38,7 @@ const EventSource: React.FC<Props> = ({
 }) => {
   const typeEventSource = EventSources.CronJobSource;
   const serviceName = contextSource?.split('/').pop() || '';
+  const name = _.kebabCase(typeEventSource);
   const initialValues: EventSourceFormData = {
     project: {
       name: namespace || '',
@@ -48,7 +50,7 @@ const EventSource: React.FC<Props> = ({
       name: sanitizeApplicationValue(activeApplication),
       selectedKey: activeApplication,
     },
-    name: '',
+    name,
     sink: {
       knativeService: serviceName,
     },

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { useFormikContext, FormikValues } from 'formik';
 import { ItemSelectorField } from '@console/shared';
 import FormSection from '@console/dev-console/src/components/import/section/FormSection';
@@ -11,18 +12,27 @@ interface EventSourcesSelectorProps {
 
 const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSourceList }) => {
   const { setFieldValue, setFieldTouched, validateForm } = useFormikContext<FormikValues>();
+  const eventSourceItems = Object.keys(eventSourceList).length;
   const handleItemChange = React.useCallback(
     (item: string) => {
-      const name = `data.${item.toLowerCase()}`;
-      setFieldValue(name, getEventSourceData(item.toLowerCase()));
-      setFieldTouched(name, true);
+      const nameData = `data.${item.toLowerCase()}`;
+      const sourceData = getEventSourceData(item.toLowerCase());
+      setFieldValue(nameData, sourceData);
+      setFieldTouched(nameData, true);
+      setFieldValue('name', _.kebabCase(item));
+      setFieldTouched('name', true);
       validateForm();
     },
     [setFieldValue, setFieldTouched, validateForm],
   );
   return (
     <FormSection title="Type" fullWidth>
-      <ItemSelectorField itemList={eventSourceList} name="type" onSelect={handleItemChange} />
+      <ItemSelectorField
+        itemList={eventSourceList}
+        loadingItems={!eventSourceItems}
+        name="type"
+        onSelect={handleItemChange}
+      />
     </FormSection>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import * as lodash from 'lodash';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { ItemSelectorField } from '@console/shared';
+import EventSourcesSelector from '../EventSourcesSelector';
+import * as sourceUtils from '../../../../utils/create-eventsources-utils';
+
+type EventSourcesSelectorProps = React.ComponentProps<typeof EventSourcesSelector>;
+
+jest.mock('formik', () => ({
+  useField: jest.fn(() => [{}, {}]),
+  useFormikContext: jest.fn(() => ({
+    setFieldValue: jest.fn(),
+    setFieldTouched: jest.fn(),
+    validateForm: jest.fn(),
+    values: {
+      type: 'SinkBinding',
+      name: 'sink-binding',
+    },
+  })),
+  getFieldId: jest.fn(),
+}));
+describe('EventSourcesSelector', () => {
+  let wrapper: ShallowWrapper<EventSourcesSelectorProps>;
+  beforeEach(() => {
+    const eventSourceList = {};
+    wrapper = shallow(<EventSourcesSelector eventSourceList={eventSourceList} />);
+  });
+
+  it('should render ItemSelectorField', () => {
+    expect(wrapper.find(ItemSelectorField)).toHaveLength(1);
+    expect(wrapper.find(ItemSelectorField).props().itemList).toEqual({});
+  });
+
+  it('should have loadingItems as true if items are not there', () => {
+    expect(wrapper.find(ItemSelectorField).props().loadingItems).toBe(true);
+  });
+
+  it('should have loadingItems as false if items are there', () => {
+    const eventSourceList = {
+      SinkBinding: {
+        title: 'sinkBinding',
+        iconUrl: 'sinkBindingIcon',
+        name: 'SinkBinding',
+        displayName: 'Sink Binding',
+      },
+    };
+    wrapper = shallow(<EventSourcesSelector eventSourceList={eventSourceList} />);
+    expect(wrapper.find(ItemSelectorField).props().loadingItems).toBe(false);
+  });
+
+  it('should call getEventSourceData onSelect', () => {
+    const spyGetEventSourceData = jest.spyOn(sourceUtils, 'getEventSourceData');
+    const spyKebabCase = jest.spyOn(lodash, 'kebabCase');
+    wrapper
+      .find(ItemSelectorField)
+      .props()
+      .onSelect('ApiServerSource');
+    expect(spyGetEventSourceData).toHaveBeenCalledWith('apiserversource');
+    expect(spyKebabCase).toHaveBeenCalledWith('ApiServerSource');
+  });
+});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3507

**Analysis / Root cause**: 
- Event Source creation flows should provide a default name
- Event Source Selector should show loading till cards load

**Solution Description**: 
- Provided a default name for Event Source creation flows i.e for CamelSource name will be in kebabCase `camel-source`
- Event Source Selector should show loading till cards load

**Screen shots / Gifs for design review**: 
![Apr-08-2020 10-05-10](https://user-images.githubusercontent.com/5129024/78745353-7e01a300-7981-11ea-828e-4e3a0dcd00c9.gif)

<img width="951" alt="Screenshot 2020-04-08 at 10 13 06 AM" src="https://user-images.githubusercontent.com/5129024/78745365-9376cd00-7981-11ea-8b1c-897c181650db.png">

cc @serenamarie125 

**Test Coverage**: 
<img width="991" alt="Screenshot 2020-04-08 at 1 59 42 PM" src="https://user-images.githubusercontent.com/5129024/78762297-4f93c000-79a1-11ea-8d37-fe88fbe040b6.png">



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
