### PR TITLE
kubevirt: add sample Role to grant privileges for non-admin to run v2v

### DIFF
--- a/frontend/packages/kubevirt-plugin/integration-tests/data/role.v2v-vmware.yaml
+++ b/frontend/packages/kubevirt-plugin/integration-tests/data/role.v2v-vmware.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: openshift-cnv
+  name: v2v-vmware-configmap-read
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["v2v-vmware", "kubevirt-storage-class-defaults"]
+  verbs: ["get", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: openshift-cnv
+  name: v2v-vmware-configmap-read
+subjects:
+- kind: User
+  name: test # change to particular user who needs to run v2v
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role 
+  name: v2v-vmware-configmap-read
+  apiGroup: rbac.authorization.k8s.io
+
+#####################################
+# Following permissions are optional
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-public
+  name: vmware-to-kubevirt-os-configmap-read
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["vmware-to-kubevirt-os"]
+  verbs: ["get", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-public
+  name: vmware-to-kubevirt-os-configmap-read
+subjects:
+- kind: User
+  name: test # change to particular user who needs to run v2v
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role 
+  name: vmware-to-kubevirt-os-configmap-read
+  apiGroup: rbac.authorization.k8s.io
+

--- a/frontend/packages/kubevirt-plugin/integration-tests/data/role.v2v-vmware.yaml
+++ b/frontend/packages/kubevirt-plugin/integration-tests/data/role.v2v-vmware.yaml
@@ -7,7 +7,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
-  resourceNames: ["v2v-vmware", "kubevirt-storage-class-defaults"]
+  resourceNames: ["v2v-vmware"]
   verbs: ["get", "watch"]
 
 ---
@@ -17,9 +17,14 @@ metadata:
   namespace: openshift-cnv
   name: v2v-vmware-configmap-read
 subjects:
-- kind: User
-  name: test # change to particular user who needs to run v2v
-  apiGroup: rbac.authorization.k8s.io
+# enable for all authenticated users
+- kind: Group
+  name: system:authenticated
+  apiGroup: "rbac.authorization.k8s.io"
+# Or enable for a named user only:
+#- kind: User
+#  name: test # change to particular user who needs to run v2v
+#  apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: Role 
   name: v2v-vmware-configmap-read
@@ -46,9 +51,13 @@ metadata:
   namespace: kube-public
   name: vmware-to-kubevirt-os-configmap-read
 subjects:
-- kind: User
-  name: test # change to particular user who needs to run v2v
-  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:authenticated
+  apiGroup: "rbac.authorization.k8s.io"
+# Or enable for a named user only:
+#- kind: User
+#  name: test # change to particular user who needs to run v2v
+#  apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: Role 
   name: vmware-to-kubevirt-os-configmap-read

--- a/frontend/packages/kubevirt-plugin/integration-tests/data/role.v2v-vmware.yaml
+++ b/frontend/packages/kubevirt-plugin/integration-tests/data/role.v2v-vmware.yaml
@@ -8,6 +8,7 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   resourceNames: ["v2v-vmware"]
+  # resourceNames: ["v2v-vmware", "kubevirt-storage-class-defaults"] # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1784467
   verbs: ["get", "watch"]
 
 ---


### PR DESCRIPTION
So far, the v2v controller deployment is still managed by the UI.
This is planed to be changed but recent state is like that.

To allow a non-admin user to run "Import VM" (v2v), read access
to the `v2v-vmware` configmap in the `openshift-cnv` namespace
needs to be granted.

This patch contains sample `Role` and `RoleBinding` objects to do so for
a named user.

In a nutshell, to grant access for a non-admin user, the admin needs to:
- update/add the name of the user in the `role.v2v-vmware.yaml`
- `oc apply -f role.v2v-vmware.yaml`

To verify, the non-admin user should get successful result for:
- `oc get configmap v2v-vmware -n openshift-cnv -o yaml`

---

Permissions to access `kubevirt-storage-class-defaults` configmap were removed from this PR in favor of https://github.com/kubevirt/hyperconverged-cluster-operator/pull/498 . However, the user needs to have read access to this configmap to be able to start v2v.

As a workaround till https://github.com/kubevirt/hyperconverged-cluster-operator/pull/498 lands, corresponding row in the `role.v2v-vmware.yaml` can be uncommented.

