### PR TITLE
update api group for node-maintenance operator

### DIFF
--- a/frontend/packages/metal3-plugin/src/models.ts
+++ b/frontend/packages/metal3-plugin/src/models.ts
@@ -16,8 +16,8 @@ export const BareMetalHostModel: K8sKind = {
 export const NodeMaintenanceModel: K8sKind = {
   label: 'Node Maintenance',
   labelPlural: 'Node Maintenances',
-  apiVersion: 'v1alpha1',
-  apiGroup: 'kubevirt.io',
+  apiVersion: 'v1beta1',
+  apiGroup: 'nodemaintenance.kubevirt.io',
   plural: 'nodemaintenances',
   abbr: 'NM',
   namespaced: false,


### PR DESCRIPTION
Node-maintenance operator is moving into its own api group.
https://github.com/kubevirt/node-maintenance-operator/pull/73
Signed-off-by: Karel Simon <ksimon@redhat.com>