### PR TITLE
Bug 1821990: Monitoring: Change text filter by alert description to not use fuzzy

### DIFF
--- a/frontend/integration-tests/tests/monitoring.scenario.ts
+++ b/frontend/integration-tests/tests/monitoring.scenario.ts
@@ -38,7 +38,7 @@ describe('Monitoring: Alerts', () => {
 
   it('filters Alerts by name', async () => {
     await monitoringView.wait(until.elementToBeClickable(crudView.nameFilter));
-    await crudView.nameFilter.sendKeys(`${testAlertName} PagerDuty`);
+    await crudView.nameFilter.sendKeys(testAlertName);
     expect(firstElementByTestID('alert-resource-link').getText()).toContain(testAlertName);
   });
 

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -31,9 +31,17 @@ export const tableFilters: TableFilterMap = {
 
   'catalog-source-name': (filter, obj) => fuzzyCaseInsensitive(filter, obj.name),
 
-  'alert-list-text': (filter, alert) =>
-    fuzzyCaseInsensitive(filter, alert.labels?.alertname) ||
-    fuzzyCaseInsensitive(filter, alertDescription(alert)),
+  'alert-list-text': (filter, alert) => {
+    if (fuzzyCaseInsensitive(filter, alert.labels?.alertname)) {
+      return true;
+    }
+
+    // Search in alert description. Ignore case and whitespace, but don't use fuzzy since the
+    // description can be long and will often match fuzzy searches that are not really relevant.
+    const needle = _.toLower(filter.replace(/\s/g, ''));
+    const haystack = _.toLower(alertDescription(alert).replace(/\s/g, ''));
+    return haystack.includes(needle);
+  },
 
   'alert-state': (filter, alert) => filter.selected.has(alertState(alert)),
 


### PR DESCRIPTION
This was returning too many irrelevant results because the description
string can be rather long.