### PR TITLE
Get version from installed CSV to show version of OCS

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
@@ -63,7 +63,7 @@ export const getOCSVersion = (items: FirehoseResult): string => {
     getSubscriptionStatus(operator as SubscriptionKind).status ===
     SubscriptionState.SubscriptionStateAtLatest
   ) {
-    return _.get(operator, 'status.currentCSV');
+    return _.get(operator, 'status.installedCSV');
   }
   return '';
 };


### PR DESCRIPTION
Even when subscription is AtLatest state, the csv takes sometime to get installed.
Meanwhile, the version of old csv is shown. Fix this to show installed csv version.
