### PR TITLE
Bug 1819786: Improve kind plurals

### DIFF
--- a/frontend/__tests__/module/k8s/get-resources.spec.ts
+++ b/frontend/__tests__/module/k8s/get-resources.spec.ts
@@ -1,0 +1,37 @@
+import { kindToLabel, pluralizeKind } from '../../../public/module/k8s/get-resources';
+
+describe('kindToLabel', () => {
+  const testKindToLabel = (kind: string, expected: string) => {
+    it(`${kind} into ${expected}`, () => {
+      expect(kindToLabel(kind)).toEqual(expected);
+    });
+  };
+
+  testKindToLabel('DNS', 'DNS');
+  testKindToLabel('DNSRecord', 'DNS Record');
+  testKindToLabel('DeploymentConfig', 'Deployment Config');
+  testKindToLabel('OAuth', 'OAuth');
+  testKindToLabel('OAuthAccessToken', 'OAuth Access Token');
+});
+
+describe('pluralizeKind', () => {
+  const testPluralizeKind = (kind: string, expected: string) => {
+    it(`${kind} into ${expected}`, () => {
+      expect(pluralizeKind(kind)).toEqual(expected);
+    });
+  };
+
+  testPluralizeKind('DB', 'DBs');
+  testPluralizeKind('DNS', 'DNS');
+  testPluralizeKind('DNSRecord', 'DNS Records');
+  testPluralizeKind('DeploymentConfig', 'Deployment Configs');
+  testPluralizeKind('Endpoints', 'Endpoints');
+  testPluralizeKind('Identity', 'Identities');
+  testPluralizeKind('ImageContentSourcePolicy', 'Image Content Source Policies');
+  testPluralizeKind('Ingress', 'Ingresses');
+  testPluralizeKind('OAuth', 'OAuths');
+  testPluralizeKind('OAuthAccessToken', 'OAuth Access Tokens');
+  testPluralizeKind('PodMetrics', 'Pod Metrics');
+  testPluralizeKind('Prometheus', 'Prometheuses');
+  testPluralizeKind('Proxy', 'Proxies');
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,6 +101,7 @@
     "openshift-logos-icon": "1.7.1",
     "patternfly": "^3.59.1",
     "patternfly-react": "2.32.3",
+    "pluralize": "^8.0.0",
     "point-in-svg-path": "1.0.1",
     "popper.js": "^1.15.0",
     "prop-types": "15.7.x",

--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash-es';
+import { plural } from 'pluralize';
 
 import { coFetchJSON } from '../../co-fetch';
 import { K8sKind, K8sVerb } from '../../module/k8s';
@@ -81,6 +82,20 @@ export type DiscoveryResources = {
   safeResources: string[];
 };
 
+export const kindToLabel = (kind: string): string => {
+  return _.startCase(kind).replace(/\bO Auth\b/, 'OAuth');
+};
+
+export const pluralizeKind = (kind: string): string => {
+  const label = kindToLabel(kind);
+  const pluralized = plural(label);
+  // Handle special cases like DB -> DBs (instead of DBS).
+  if (pluralized === `${label}S`) {
+    return `${label}s`;
+  }
+  return pluralized;
+};
+
 export const getResources = () =>
   coFetchJSON('api/kubernetes/apis').then((res) => {
     const preferredVersions = res.groups.map((group) => group.preferredVersion);
@@ -118,12 +133,12 @@ export const getResources = () =>
               namespaced,
               verbs,
               shortNames,
-              label: kind,
+              label: kindToLabel(kind),
               plural: name,
               apiVersion,
               abbr: kindToAbbr(kind),
               ...(apiGroup ? { apiGroup } : {}),
-              labelPlural: `${kind}${kind.endsWith('s') ? 'es' : 's'}`,
+              labelPlural: pluralizeKind(kind),
               path: name,
               id: singularName,
               crd: true,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12614,6 +12614,11 @@ plugin-error@^0.1.2:
     arr-union "^2.0.1"
     extend-shallow "^1.1.2"
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"


### PR DESCRIPTION
Manual backport of #4947 (conflict in package.json)

Use the `pluralize` library to improve kind labels. This handles many special cases for us like Endpoints -> Endpoints and Identity -> Identities.

/assign @benjaminapetersen 