### PR TITLE
Bug 1822130: Clicking “Quay Image Security" makes status card disappear

### DIFF
--- a/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
+++ b/frontend/packages/console-plugin-sdk/src/typings/dashboards.ts
@@ -92,7 +92,7 @@ namespace ExtensionProperties {
      * Loader for popup content. If defined health item will be represented as link
      * which opens popup with given content.
      */
-    popupComponent?: LazyLoader<any>;
+    popupComponent?: LazyLoader<WatchK8sResults<R>>;
 
     /**
      * Popup title

--- a/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/health-item.tsx
+++ b/frontend/public/components/dashboard/dashboards-page/cluster-dashboard/health-item.tsx
@@ -235,7 +235,7 @@ export const ResourceHealthItem: React.FC<ResourceHealthItemProps> = ({ subsyste
   const healthState = healthHandler(resourcesResult);
 
   const PopupComponentCallback = React.useCallback(
-    () => <AsyncComponent loader={popupComponent} resourcesResult={resourcesResult} />,
+    () => <AsyncComponent loader={popupComponent} {...resourcesResult} />,
     [popupComponent, resourcesResult],
   );
 


### PR DESCRIPTION
- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1822130
- Wrong props were passed down
  - Fixed props of security breakdown popover
  - Added correct types for props

