### PR TITLE
Bug 1820130: [release-4.4] Backport 4.4 correct ocs version

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/selectors/index.ts
@@ -57,5 +57,5 @@ export const getOCSVersion = (items: FirehoseResult): string => {
     itemsData,
     (item) => _.get(item, 'spec.name') === OCS_OPERATOR,
   );
-  return _.get(operator, 'status.currentCSV');
+  return _.get(operator, 'status.installedCSV');
 };


### PR DESCRIPTION
[Cherry pick](https://github.com/openshift/console/pull/4986#issuecomment-611708010) failed for #4986  hence sending direct backport PR with resolved conflicts

