### PR TITLE
Bug 1822128: Fix bug where pipelines doc link is incorrect

### DIFF
--- a/frontend/public/components/build.tsx
+++ b/frontend/public/components/build.tsx
@@ -175,7 +175,7 @@ export const PipelineBuildStrategyAlert: React.FC<BuildsDetailsProps> = () => {
     <Alert isInline className="co-alert" variant="info" title="Pipeline build strategy deprecation">
       With the release of{' '}
       <ExternalLink
-        href="https://openshift.github.io/pipelines-docs/docs/"
+        href="https://openshift.github.io/pipelines-docs/"
         text="OpenShift Pipelines based on Tekton"
       />
       , the pipelines build strategy has been deprecated. Users should either use Jenkins files


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1822128

Will need back porting down to 4.3