### PR TITLE
Fix HOT_RELOAD fallback value

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -17,7 +17,7 @@ interface Configuration extends webpack.Configuration {
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
-const HOT_RELOAD = process.env.HOT_RELOAD || 'false';
+const HOT_RELOAD = process.env.HOT_RELOAD || 'true';
 const CHECK_CYCLES = process.env.CHECK_CYCLES || 'false';
 
 /* Helpers */


### PR DESCRIPTION
Fixing a bug caused by #4874

`yarn dev` starting `webpack-dev-server` (instead of `webpack --watch`) is meant to facilitate hot code reloading by default.