### PR TITLE
Update cycle entry format in .webpack-cycles

### DIFF
--- a/frontend/webpack.circular-deps.ts
+++ b/frontend/webpack.circular-deps.ts
@@ -62,7 +62,7 @@ const getCycleStats = (cycles: DetectedCycle[]): string => {
 };
 
 const getCycleEntries = (cycles: DetectedCycle[]): string => {
-  return cycles.map((c) => `${c.causedBy}\n${c.modulePaths.join('\n-> ')}\n`).join('\n');
+  return cycles.map((c) => `${c.causedBy}\n  ${c.modulePaths.join('\n  ')}\n`).join('\n');
 };
 
 export class CircularDependencyPreset {


### PR DESCRIPTION
Cycle entry format updated to:

```
/home/vszocs/go/src/github.com/openshift/console/frontend/public/co-fetch.js
  public/co-fetch.js
  public/module/auth.js
  public/co-fetch.js
```

Editors like VS Code support expand/collapse `▽` based on indentation:

![expand](https://user-images.githubusercontent.com/648971/78924651-7e419180-7a9a-11ea-89ac-fc6f63c0f186.png)
