### PR TITLE
Bug 1828602: Pipelines TechPreview Badges / ApiVersion

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineSection.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { connectToFlags, FlagsObject } from '@console/internal/reducers/features';
-import { getBadgeFromType } from '@console/shared';
-import { Split, SplitItem, Alert } from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core';
 import { getActiveNamespace } from '@console/internal/actions/ui';
 import { useAccessReview } from '@console/internal/components/utils';
 import { useFormikContext, FormikValues } from 'formik';
@@ -47,14 +46,8 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({ flags, builderImages 
   const hasCreatePipelineAccess = usePipelineAccessReview();
 
   if (flags[FLAG_OPENSHIFT_PIPELINE] && hasCreatePipelineAccess) {
-    const title = (
-      <Split gutter="md">
-        <SplitItem className="odc-form-section__heading">Pipelines</SplitItem>
-        <SplitItem>{getBadgeFromType(PipelineModel.badge)}</SplitItem>
-      </Split>
-    );
     return (
-      <FormSection title={title}>
+      <FormSection title="Pipelines">
         {values.image.selected || values.build.strategy === 'Docker' ? (
           <PipelineTemplate builderImages={builderImages} />
         ) : (

--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { LoadingInline } from '@console/internal/components/utils';
 import { k8sList } from '@console/internal/module/k8s';
 import { useFormikContext, FormikValues } from 'formik';
-import { Alert, Expandable } from '@patternfly/react-core';
+import { Alert, Badge, Expandable, Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 import { CheckboxField } from '@console/shared';
 import { CLUSTER_PIPELINE_NS } from '../../../const';
 import { PipelineModel } from '../../../models';
@@ -104,7 +104,14 @@ const PipelineTemplate: React.FC<PipelineTemplateProps> = ({ builderImages }) =>
 
   return pipeline.template ? (
     <>
-      <CheckboxField label="Add pipeline" name="pipeline.enabled" />
+      <Flex>
+        <FlexItem breakpointMods={[{ modifier: FlexModifiers['align-self-center'] }]}>
+          <CheckboxField label="Add pipeline" name="pipeline.enabled" />
+        </FlexItem>
+        <FlexItem>
+          <Badge isRead>Dev Preview</Badge>
+        </FlexItem>
+      </Flex>
       <Expandable
         toggleText={`${isExpanded ? 'Hide' : 'Show'} pipeline visualization`}
         isExpanded={isExpanded}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Button, Flex, FlexItem, FlexItemModifiers } from '@patternfly/react-core';
-import { PipelineModel } from '../../../models';
 import { warnYAML } from './modals';
-import { getBadgeFromType } from '@console/shared/src';
+import { DevPreviewBadge } from '@console/shared';
 import { Pipeline } from '../../../utils/pipeline-augment';
 import { goToYAML } from './utils';
 
@@ -37,7 +36,9 @@ const PipelineBuilderHeader: React.FC<PipelineBuilderHeaderProps> = (props) => {
             Edit YAML
           </Button>
         </FlexItem>
-        <FlexItem>{getBadgeFromType(PipelineModel.badge)}</FlexItem>
+        <FlexItem>
+          <DevPreviewBadge />
+        </FlexItem>
       </Flex>
       <hr />
     </div>

--- a/frontend/packages/dev-console/src/models/pipelines.ts
+++ b/frontend/packages/dev-console/src/models/pipelines.ts
@@ -6,7 +6,7 @@ const color = tektonGroupColor.value;
 
 export const PipelineModel: K8sKind = {
   apiGroup: 'tekton.dev',
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1beta1',
   label: 'Pipeline',
   plural: 'pipelines',
   abbr: 'PL',
@@ -15,13 +15,13 @@ export const PipelineModel: K8sKind = {
   id: 'pipeline',
   labelPlural: 'Pipelines',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };
 
 export const PipelineRunModel: K8sKind = {
   apiGroup: 'tekton.dev',
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1beta1',
   label: 'Pipeline Run',
   plural: 'pipelineruns',
   abbr: 'PLR',
@@ -30,13 +30,13 @@ export const PipelineRunModel: K8sKind = {
   id: 'pipelinerun',
   labelPlural: 'Pipeline Runs',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };
 
 export const TaskModel: K8sKind = {
   apiGroup: 'tekton.dev',
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1beta1',
   label: 'Task',
   plural: 'tasks',
   abbr: 'T',
@@ -45,13 +45,13 @@ export const TaskModel: K8sKind = {
   id: 'task',
   labelPlural: 'Tasks',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };
 
 export const TaskRunModel: K8sKind = {
   apiGroup: 'tekton.dev',
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1beta1',
   label: 'Task Run',
   plural: 'taskruns',
   abbr: 'TR',
@@ -60,7 +60,7 @@ export const TaskRunModel: K8sKind = {
   id: 'taskrun',
   labelPlural: 'Task Runs',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };
 
@@ -81,7 +81,7 @@ export const PipelineResourceModel: K8sKind = {
 
 export const ClusterTaskModel: K8sKind = {
   apiGroup: 'tekton.dev',
-  apiVersion: 'v1alpha1',
+  apiVersion: 'v1beta1',
   label: 'Cluster Task',
   plural: 'clustertasks',
   abbr: 'CT',
@@ -90,7 +90,7 @@ export const ClusterTaskModel: K8sKind = {
   id: 'clustertask',
   labelPlural: 'Cluster Tasks',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };
 

--- a/frontend/packages/dev-console/src/templates/pipelines.ts
+++ b/frontend/packages/dev-console/src/templates/pipelines.ts
@@ -1,5 +1,5 @@
 export const newPipelineTemplate = `
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: new-pipeline
@@ -41,15 +41,14 @@ spec:
 `;
 
 export const newTaskTemplate = `
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: example-task
 spec:
-  inputs:
-    params:
-      - name: appName
-        type: string
+  params:
+    - name: appName
+      type: string
   steps:
   - image: registry.redhat.io/ubi7/ubi-minimal
     command:
@@ -60,7 +59,7 @@ spec:
 `;
 
 export const newTaskRunTemplate = `
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: example-taskrun
@@ -77,15 +76,14 @@ spec:
 `;
 
 export const newClusterTaskTemplate = `
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: ClusterTask
 metadata:
   name: example-cluster-task
 spec:
-  inputs:
-    params:
-      - name: appName
-        type: string
+  params:
+    - name: appName
+      type: string
   steps:
   - image: registry.redhat.io/ubi7/ubi-minimal
     command:

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment.spec.ts
@@ -1,3 +1,4 @@
+import { referenceForModel } from '@console/internal/module/k8s';
 import { pipelineTestData, DataState, PipelineExampleNames } from '../../test/pipeline-data';
 import {
   getResources,
@@ -9,7 +10,7 @@ import {
   runStatus,
   getResourceModelFromTask,
 } from '../pipeline-augment';
-import { ClusterTaskModel, TaskModel } from '../../models';
+import { ClusterTaskModel, PipelineRunModel, TaskModel } from '../../models';
 import { testData } from './pipeline-augment-test-data';
 
 describe('PipelineAugment test getResources create correct resources for firehose', () => {
@@ -28,7 +29,7 @@ describe('PipelineAugment test getResources create correct resources for firehos
   it('expect resources to be of length 1 and have the following properties & childprops', () => {
     const resources = getResources(testData[2].data);
     expect(resources.resources.length).toBe(1);
-    expect(resources.resources[0].kind).toBe('tekton.dev~v1alpha1~PipelineRun');
+    expect(resources.resources[0].kind).toBe(referenceForModel(PipelineRunModel));
     expect(resources.resources[0].namespace).toBe(testData[2].data[0].metadata.namespace);
     expect(resources.propsReferenceForRuns.length).toBe(1);
   });
@@ -36,8 +37,8 @@ describe('PipelineAugment test getResources create correct resources for firehos
   it('expect resources to be of length 2 and have the following properties & childprops', () => {
     const resources = getResources(testData[3].data);
     expect(resources.resources.length).toBe(2);
-    expect(resources.resources[0].kind).toBe('tekton.dev~v1alpha1~PipelineRun');
-    expect(resources.resources[1].kind).toBe('tekton.dev~v1alpha1~PipelineRun');
+    expect(resources.resources[0].kind).toBe(referenceForModel(PipelineRunModel));
+    expect(resources.resources[1].kind).toBe(referenceForModel(PipelineRunModel));
     expect(resources.resources[0].namespace).toBe(testData[3].data[0].metadata.namespace);
     expect(resources.resources[0].namespace).toBe(testData[3].data[1].metadata.namespace);
     expect(resources.propsReferenceForRuns.length).toBe(2);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3457

**Analysis / Root cause**: 
TechPreview of the OpenShift Pipelines Operator is being released and with it new `v1beta1` API and the desire to have "Tech Preview" badges on the beta-api resources.

**Solution Description**: 
Few things were done to facilitate this:

* Update some resources to TechPreview; this includes a `v1beta` api version and the Tech Preview badge
    * Pipeline
    * Pipeline Run
    * Task
    * Task Run
    * Cluster Task
* Complex flows & some resources are not going to Tech Preview
    * Pipeline Builder - Dev Preview
    * Add Flow - Dev Preview
    * PipelineResources - Dev Preview
* YAML Templates
    * Those matching resources that went to `v1beta1` followed with their spec
    * Task / Cluster Task templates got their paths updated to fit with the new spec changes

**Screen shots / Gifs for design review**: 

cc @openshift/team-devconsole-ux 

Add Flow got special treatment:
![Screen Shot 2020-04-09 at 3 53 04 PM](https://user-images.githubusercontent.com/8126518/78937609-c9e64200-7a7e-11ea-97dc-b5ca04a9a090.png)

Pipeline Builder stays at Dev Preview:
![Screen Shot 2020-04-04 at 4 49 08 PM](https://user-images.githubusercontent.com/8126518/78937595-c488f780-7a7e-11ea-8d32-b5b0d8122bc0.png)

Resource pages:
![Screen Shot 2020-04-04 at 4 47 10 PM](https://user-images.githubusercontent.com/8126518/78937585-c2269d80-7a7e-11ea-80f4-c9dbd9ad8065.png)
![Screen Shot 2020-04-04 at 4 48 16 PM](https://user-images.githubusercontent.com/8126518/78937586-c357ca80-7a7e-11ea-85d2-d6c885da3455.png)
![Screen Shot 2020-04-04 at 4 48 28 PM](https://user-images.githubusercontent.com/8126518/78937589-c357ca80-7a7e-11ea-8465-88ce6b392176.png)
![Screen Shot 2020-04-04 at 4 48 38 PM](https://user-images.githubusercontent.com/8126518/78937590-c3f06100-7a7e-11ea-930f-e95b5aa7a578.png)
![Screen Shot 2020-04-04 at 4 48 54 PM](https://user-images.githubusercontent.com/8126518/78937593-c3f06100-7a7e-11ea-88fc-43bf2b7463d1.png)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

cc @siamaksade @vdemeester 

**Note: This PR won't work with the 0.10.x Pipeline Operator**
**Note: This PR will need to go back to 4.4.z-stream (ideally 4.4.1)**