### PR TITLE
topology improvements: layers, bounds

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -19,6 +19,10 @@ import {
   Model,
   SELECTION_EVENT,
   SelectionEventListener,
+  GROUPS_LAYER,
+  TOP_LAYER,
+  BOTTOM_LAYER,
+  DEFAULT_LAYER,
 } from '@console/topology';
 import { RootState } from '@console/internal/redux';
 import { useAddToProjectAccess } from '../../utils/useAddToProjectAccess';
@@ -65,6 +69,7 @@ const graphModel: Model = {
     id: 'g1',
     type: 'graph',
     layout: COLA_LAYOUT,
+    layers: [BOTTOM_LAYER, GROUPS_LAYER, 'groups2', DEFAULT_LAYER, TOP_LAYER],
   },
 };
 

--- a/frontend/packages/dev-console/src/components/topology/components/groups/ApplicationGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/ApplicationGroup.tsx
@@ -93,8 +93,9 @@ const ApplicationGroup: React.FC<ApplicationGroupProps> = ({
     const points: (PointWithSize | PointTuple)[] = [];
     _.forEach(children, (c) => {
       if (c.getNodeShape() === NodeShape.circle) {
-        const { width, height } = c.getBounds();
-        const { x, y } = c.getBounds().getCenter();
+        const bounds = c.getBounds();
+        const { width, height } = bounds;
+        const { x, y } = bounds.getCenter();
         const radius = Math.max(width, height) / 2;
         points.push([x, y, radius] as PointWithSize);
       } else {

--- a/frontend/packages/dev-console/src/components/topology/components/groups/ApplicationNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/ApplicationNode.tsx
@@ -45,7 +45,7 @@ const ApplicationNode: React.FC<ApplicationGroupProps> = ({
   const dragNodeRef = useDragNode()[1];
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, hoverRef);
   const [filtered] = useSearchFilter(element.getLabel());
-  const { width, height } = element.getBounds();
+  const { width, height } = element.getDimensions();
 
   const resourcesData = {};
   _.forEach(element.getData().groupResources, (res) => {

--- a/frontend/packages/dev-console/src/components/topology/components/groups/GroupNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/groups/GroupNode.tsx
@@ -44,6 +44,7 @@ const GroupNode: React.FC<GroupNodeProps> = ({
   const iconWidth = iconSize ? iconSize.width : 0;
   const iconHeight = iconSize ? iconSize.height : 0;
   const title = element.getLabel();
+  const { width, height } = element.getDimensions();
   return (
     <>
       {typeIconClass && (
@@ -82,8 +83,8 @@ const GroupNode: React.FC<GroupNodeProps> = ({
             <ResourceKindsInfo
               groupResources={groupResources}
               emptyValue={emptyValue}
-              width={element.getBounds().width - LEFT_MARGIN}
-              height={element.getBounds().height - TOP_MARGIN - iconHeight}
+              width={width - LEFT_MARGIN}
+              height={height - TOP_MARGIN - iconHeight}
             />
           )}
           {children}

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/BaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/BaseNode.tsx
@@ -64,8 +64,9 @@ const ObservedBaseNode: React.FC<BaseNodeProps> = ({
 }) => {
   const [hover, hoverRef] = useHover();
   useAnchor(EllipseAnchor);
-  const cx = element.getBounds().width / 2;
-  const cy = element.getBounds().height / 2;
+  const { width, height } = element.getDimensions();
+  const cx = width / 2;
+  const cy = height / 2;
   const resourceObj = getTopologyResourceObject(element.getData());
   const resourceModel = modelFor(referenceFor(resourceObj));
   const iconRadius = innerRadius * 0.9;

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.tsx
@@ -50,7 +50,7 @@ const ObservedWorkloadNode: React.FC<WorkloadNodeProps> = ({
   cheURL,
   ...rest
 }) => {
-  const { width, height } = element.getBounds();
+  const { width, height } = element.getDimensions();
   const workloadData = element.getData().data;
   const filters = useDisplayFilters();
   const size = Math.min(width, height);

--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
@@ -49,7 +49,7 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
   );
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, dndDropRef, hoverRef);
   const [filtered] = useSearchFilter(element.getLabel());
-  const { width, height } = element.getBounds();
+  const { width, height } = element.getDimensions();
 
   return (
     <g

--- a/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceNode.tsx
@@ -50,7 +50,7 @@ const OperatorBackedServiceNode: React.FC<OperatorBackedServiceNodeProps> = ({
   const refs = useCombineRefs<SVGRectElement>(hoverRef, dragNodeRef, dndDropRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const kind = 'Operator';
-  const { width, height } = element.getBounds();
+  const { width, height } = element.getDimensions();
 
   return (
     <g

--- a/frontend/packages/topology/src/behavior/useDragNode.tsx
+++ b/frontend/packages/topology/src/behavior/useDragNode.tsx
@@ -90,9 +90,9 @@ export const useDragNode = <
               }
             }
             if (moved) {
-              e.setBounds(
+              e.setPosition(
                 e
-                  .getBounds()
+                  .getPosition()
                   .clone()
                   .translate(dx, dy),
               );

--- a/frontend/packages/topology/src/behavior/usePanZoom.tsx
+++ b/frontend/packages/topology/src/behavior/usePanZoom.tsx
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react';
 import { action, autorun, IReactionDisposer } from 'mobx';
 import ElementContext from '../utils/ElementContext';
 import useCallbackRef from '../utils/useCallbackRef';
+import Point from '../geom/Point';
 import { isGraph, ModelKind } from '../types';
 import { ATTR_DATA_KIND } from '../const';
 
@@ -47,11 +48,8 @@ export const usePanZoom = (zoomExtent: [number, number] = ZOOM_EXTENT): PanZoomR
             .on(
               'zoom',
               action(() => {
-                elementRef.current.setBounds(
-                  elementRef.current
-                    .getBounds()
-                    .clone()
-                    .setLocation(d3.event.transform.x, d3.event.transform.y),
+                elementRef.current.setPosition(
+                  new Point(d3.event.transform.x, d3.event.transform.y),
                 );
                 elementRef.current.setScale(d3.event.transform.k);
               }),

--- a/frontend/packages/topology/src/components/ElementWrapper.tsx
+++ b/frontend/packages/topology/src/components/ElementWrapper.tsx
@@ -68,7 +68,7 @@ const ElementWrapper: React.FC<ElementWrapperProps> = observer(({ element }) => 
     );
   }
   if (isNode(element) && (!element.isGroup() || element.isCollapsed())) {
-    const { x, y } = element.getBounds();
+    const { x, y } = element.getPosition();
     return (
       <g {...commonAttrs} transform={`translate(${x}, ${y})`}>
         <ElementComponent element={element} />

--- a/frontend/packages/topology/src/components/GraphComponent.tsx
+++ b/frontend/packages/topology/src/components/GraphComponent.tsx
@@ -6,7 +6,6 @@ import { WithDndDropProps } from '../behavior/useDndDrop';
 import { WithSelectionProps } from '../behavior/useSelection';
 import { WithContextMenuProps } from '../behavior/withContextMenu';
 import LayersProvider from './layers/LayersProvider';
-import { DEFAULT_LAYER } from './layers/LayersContext';
 import ElementWrapper from './ElementWrapper';
 
 type ElementProps = {
@@ -34,12 +33,13 @@ const ElementChildren: React.FC<ElementProps> = observer(({ element }) => {
 });
 
 // This inner Component will prevent re-rendering layers when the transform changes
-const Inner: React.FC<ElementProps> = React.memo(({ element }) => (
-  // TODO make layers configurable
-  <LayersProvider layers={['bottom', 'groups', 'groups2', DEFAULT_LAYER, 'top']}>
-    <ElementChildren element={element} />
-  </LayersProvider>
-));
+const Inner: React.FC<ElementProps> = React.memo(
+  observer(({ element }) => (
+    <LayersProvider layers={element.getLayers()}>
+      <ElementChildren element={element} />
+    </LayersProvider>
+  )),
+);
 
 const GraphComponent: React.FC<GraphComponentProps> = ({
   element,
@@ -55,15 +55,15 @@ const GraphComponent: React.FC<GraphComponentProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [layout]);
 
-  const bounds = element.getBounds();
+  const { x, y, width, height } = element.getBounds();
   return (
     <>
       <rect
         ref={dndDropRef}
         x={0}
         y={0}
-        width={bounds.width}
-        height={bounds.height}
+        width={width}
+        height={height}
         fillOpacity={0}
         onClick={onSelect}
         onContextMenu={onContextMenu}
@@ -71,7 +71,7 @@ const GraphComponent: React.FC<GraphComponentProps> = ({
       <g
         data-surface="true"
         ref={panZoomRef}
-        transform={`translate(${bounds.x}, ${bounds.y}) scale(${element.getScale()})`}
+        transform={`translate(${x}, ${y}) scale(${element.getScale()})`}
       >
         <Inner element={element} />
       </g>

--- a/frontend/packages/topology/src/components/VisualizationSurface.tsx
+++ b/frontend/packages/topology/src/components/VisualizationSurface.tsx
@@ -10,6 +10,8 @@ import { State } from '../types';
 import Visualization from '../Visualization';
 import SVGDefsProvider from './defs/SVGDefsProvider';
 import ElementWrapper from './ElementWrapper';
+import Dimensions from '../geom/Dimensions';
+
 import './VisualizationSurface.scss';
 
 interface VisualizationSurfaceProps {
@@ -31,13 +33,9 @@ const VisualizationSurface: React.FC<VisualizationSurfaceProps> = ({ visualizati
     () =>
       _.debounce<any>(
         action((contentRect: { client: { width: number; height: number } }) => {
-          visualization.getGraph().setBounds(
-            visualization
-              .getGraph()
-              .getBounds()
-              .clone()
-              .setSize(contentRect.client.width, contentRect.client.height),
-          );
+          visualization
+            .getGraph()
+            .setDimensions(new Dimensions(contentRect.client.width, contentRect.client.height));
         }),
         100,
         { leading: true, trailing: true },

--- a/frontend/packages/topology/src/components/layers/LayerContainer.tsx
+++ b/frontend/packages/topology/src/components/layers/LayerContainer.tsx
@@ -19,7 +19,7 @@ const LayerContainer: React.RefForwardingComponent<SVGGElement, LayerContainerPr
   let y = 0;
   while (isNode(p)) {
     if (!p.isGroup() || p.isCollapsed()) {
-      const { x: px, y: py } = p.getBounds();
+      const { x: px, y: py } = p.getPosition();
       x += px;
       y += py;
     }

--- a/frontend/packages/topology/src/components/layers/LayersContext.ts
+++ b/frontend/packages/topology/src/components/layers/LayersContext.ts
@@ -1,7 +1,5 @@
 import { createContext } from 'react';
 
-export const DEFAULT_LAYER = 'default';
-
 type LayersContextProps = (id: string) => Element;
 
 const LayersContext = createContext<LayersContextProps>(undefined as any);

--- a/frontend/packages/topology/src/components/layers/LayersProvider.tsx
+++ b/frontend/packages/topology/src/components/layers/LayersProvider.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import LayersContext, { DEFAULT_LAYER } from './LayersContext';
+import { DEFAULT_LAYER } from '../../const';
+import LayersContext from './LayersContext';
 
 type LayersProviderProps = {
   layers?: string[];

--- a/frontend/packages/topology/src/const.ts
+++ b/frontend/packages/topology/src/const.ts
@@ -1,3 +1,10 @@
 export const ATTR_DATA_KIND = 'data-kind';
 export const ATTR_DATA_TYPE = 'data-type';
 export const ATTR_DATA_ID = 'data-id';
+
+export const TOP_LAYER = 'top';
+export const DEFAULT_LAYER = 'default';
+export const GROUPS_LAYER = 'groups';
+export const BOTTOM_LAYER = 'bottom';
+
+export const DEFAULT_LAYERS = [BOTTOM_LAYER, GROUPS_LAYER, DEFAULT_LAYER, TOP_LAYER];

--- a/frontend/packages/topology/src/geom/Dimensions.ts
+++ b/frontend/packages/topology/src/geom/Dimensions.ts
@@ -1,0 +1,63 @@
+import { IDimensions } from './types';
+
+export default class Dimensions implements IDimensions {
+  static readonly EMPTY = new Dimensions();
+
+  width: number = 0;
+
+  height: number = 0;
+
+  private static SINGLETON = new Dimensions();
+
+  static singleUse(width: number = 0, height: number = 0) {
+    Dimensions.SINGLETON.width = width;
+    Dimensions.SINGLETON.height = height;
+    return Dimensions.SINGLETON;
+  }
+
+  static fromDimensions(dimension: IDimensions): Dimensions {
+    return new Dimensions(dimension.width, dimension.height);
+  }
+
+  constructor(width: number = 0, height: number = 0) {
+    this.width = width;
+    this.height = height;
+  }
+
+  isEmpty(): boolean {
+    return this.width <= 0 || this.height <= 0;
+  }
+
+  setSize(w: number, h: number): Dimensions {
+    this.width = w;
+    this.height = h;
+    return this;
+  }
+
+  scale(scaleX: number, scaleY?: number): Dimensions {
+    const sy = scaleY != null ? scaleY : scaleX;
+    this.width *= scaleX;
+    this.height *= sy;
+    return this;
+  }
+
+  resize(dw: number, dh: number): Dimensions {
+    this.width += dw;
+    this.height += dh;
+    return this;
+  }
+
+  expand(h: number, v: number): Dimensions {
+    this.height += v * 2;
+    this.width += h * 2;
+    return this;
+  }
+
+  clone(): Dimensions {
+    return Dimensions.fromDimensions(this);
+  }
+
+  equals(r: IDimensions) {
+    return r.width === this.width && r.height === this.height;
+  }
+}

--- a/frontend/packages/topology/src/geom/Point.ts
+++ b/frontend/packages/topology/src/geom/Point.ts
@@ -1,6 +1,6 @@
-import { Translatable } from './types';
+import { Translatable, IPoint } from './types';
 
-export default class Point implements Translatable {
+export default class Point implements Translatable, IPoint {
   static readonly EMPTY = new Point();
 
   x: number;
@@ -15,7 +15,7 @@ export default class Point implements Translatable {
     return Point.SINGLETON;
   }
 
-  static fromPoint(point: Point): Point {
+  static fromPoint(point: IPoint): Point {
     return new Point(point.x, point.y);
   }
 
@@ -52,7 +52,7 @@ export default class Point implements Translatable {
     return Point.fromPoint(this);
   }
 
-  equals(p: Point) {
+  equals(p: IPoint) {
     return p.x === this.x && p.y === this.y;
   }
 }

--- a/frontend/packages/topology/src/geom/Rect.ts
+++ b/frontend/packages/topology/src/geom/Rect.ts
@@ -1,7 +1,7 @@
-import { Padding, Translatable } from './types';
+import { Padding, Translatable, IRect } from './types';
 import Point from './Point';
 
-export default class Rect implements Translatable {
+export default class Rect implements Translatable, IRect {
   static readonly EMPTY = new Rect();
 
   width: number = 0;
@@ -22,7 +22,7 @@ export default class Rect implements Translatable {
     return Rect.SINGLETON;
   }
 
-  static fromRect(rect: Rect): Rect {
+  static fromRect(rect: IRect): Rect {
     return new Rect(rect.x, rect.y, rect.width, rect.height);
   }
 
@@ -145,7 +145,7 @@ export default class Rect implements Translatable {
     return Rect.fromRect(this);
   }
 
-  equals(r: Rect) {
+  equals(r: IRect) {
     return r.x === this.x && r.y === this.y && r.width === this.width && r.height === this.height;
   }
 }

--- a/frontend/packages/topology/src/geom/__tests__/Dimensions.spec.ts
+++ b/frontend/packages/topology/src/geom/__tests__/Dimensions.spec.ts
@@ -1,0 +1,75 @@
+import Dimensions from '../Dimensions';
+
+describe('Dimensions', () => {
+  it('should provide an empty instance', () => {
+    expect(Dimensions.EMPTY).toEqual({ width: 0, height: 0 });
+  });
+
+  it('should re-use single use instance', () => {
+    expect(Dimensions.singleUse()).toBe(Dimensions.singleUse());
+    expect(Dimensions.singleUse()).toEqual({ width: 0, height: 0 });
+    expect(Dimensions.singleUse(1)).toEqual({ width: 1, height: 0 });
+    expect(Dimensions.singleUse(1, 2)).toEqual({ width: 1, height: 2 });
+  });
+
+  it('should create a new Dimensions from existing Dimensions', () => {
+    const d1 = new Dimensions(5, 10);
+    const d2 = Dimensions.fromDimensions(d1);
+    expect(d1).not.toBe(d2);
+    expect(d1).toEqual(d2);
+  });
+
+  it('should create a Dimensions', () => {
+    expect(new Dimensions()).toEqual({ width: 0, height: 0 });
+    expect(new Dimensions(1)).toEqual({ width: 1, height: 0 });
+    expect(new Dimensions(1, 2)).toEqual({ width: 1, height: 2 });
+  });
+
+  it('should be empty if no height or width', () => {
+    expect(new Dimensions().isEmpty()).toBe(true);
+    expect(new Dimensions(1, 0).isEmpty()).toBe(true);
+    expect(new Dimensions(0, 1).isEmpty()).toBe(true);
+    expect(new Dimensions(1, 1).isEmpty()).toBe(false);
+  });
+
+  it('should set size', () => {
+    const d = new Dimensions(8, 9);
+    expect(d.setSize(2, 3)).toBe(d);
+    expect(d).toEqual({ width: 2, height: 3 });
+  });
+
+  it('should scale Dimensions', () => {
+    const d = new Dimensions(4, 6);
+    expect(d.scale(2)).toBe(d);
+    expect(d).toEqual({ width: 8, height: 12 });
+    d.scale(0.5, 2);
+    expect(d).toEqual({ width: 4, height: 24 });
+  });
+
+  it('should resize the Dimensions', () => {
+    const d = new Dimensions(8, 9);
+    expect(d.resize(2, 3)).toBe(d);
+    expect(d).toEqual({ width: 10, height: 12 });
+  });
+
+  it('should expand the Dimensions in size', () => {
+    const d = new Dimensions(8, 9);
+    expect(d.expand(4, 5)).toBe(d);
+    expect(d).toEqual({ width: 16, height: 19 });
+  });
+
+  it('should clone Dimensions', () => {
+    const d1 = new Dimensions(5, 10);
+    const d2 = d1.clone();
+    expect(d1).not.toBe(d2);
+    expect(d1).toEqual(d2);
+  });
+
+  it('should check Dimensions equality', () => {
+    const d1 = new Dimensions(5, 10);
+    const d2 = new Dimensions(5, 10);
+    const d3 = new Dimensions(1, 2);
+    expect(d1.equals(d2)).toBe(true);
+    expect(d1.equals(d3)).toBe(false);
+  });
+});

--- a/frontend/packages/topology/src/geom/__tests__/Rect.spec.ts
+++ b/frontend/packages/topology/src/geom/__tests__/Rect.spec.ts
@@ -58,13 +58,13 @@ describe('Rect', () => {
     expect(r.getCenter()).toEqual({ x: 11, y: 18 });
   });
 
-  it('should translate rect', () => {
+  it('should translate Rect', () => {
     const r = new Rect(5, 10, 3, 4);
     expect(r.translate(2, 3)).toBe(r);
     expect(r).toEqual({ x: 7, y: 13, width: 3, height: 4 });
   });
 
-  it('should scale rect', () => {
+  it('should scale Rect', () => {
     const r = new Rect(5, 10, 4, 6);
     expect(r.scale(2)).toBe(r);
     expect(r).toEqual({ x: 10, y: 20, width: 8, height: 12 });
@@ -72,7 +72,7 @@ describe('Rect', () => {
     expect(r).toEqual({ x: 5, y: 40, width: 4, height: 24 });
   });
 
-  it('should resize', () => {
+  it('should resize the Rect ', () => {
     const r = new Rect(5, 10, 8, 9);
     expect(r.resize(2, 3)).toBe(r);
     expect(r).toEqual({ x: 5, y: 10, width: 10, height: 12 });
@@ -88,18 +88,13 @@ describe('Rect', () => {
     expect(r.right()).toBe(13);
   });
 
-  it('should expand the rect in size', () => {
-    const r = new Rect(5, 10, 8, 9);
-    expect(r.right()).toBe(13);
-  });
-
-  it('should expand the rect to enclose another rect', () => {
+  it('should expand the Rect to enclose another Rect', () => {
     const r = new Rect(5, 10, 8, 9);
     expect(r.union(new Rect(2, 12, 4, 27))).toBe(r);
     expect(r).toEqual({ x: 2, y: 10, width: 11, height: 29 });
   });
 
-  it('should expand the rect in size', () => {
+  it('should expand the Rect in size', () => {
     const r = new Rect(5, 10, 8, 9);
     expect(r.expand(4, 5)).toBe(r);
     expect(r).toEqual({ x: 1, y: 5, width: 16, height: 19 });
@@ -123,14 +118,14 @@ describe('Rect', () => {
     expect(r).toEqual({ x: 2, y: 3, width: 6, height: 7 });
   });
 
-  it('should clone rect', () => {
+  it('should clone Rect', () => {
     const r1 = new Rect(5, 10);
     const r2 = r1.clone();
     expect(r1).not.toBe(r2);
     expect(r1).toEqual(r2);
   });
 
-  it('should check rect equality', () => {
+  it('should check Rect equality', () => {
     const r1 = new Rect(5, 10, 1, 2);
     const r2 = new Rect(5, 10, 1, 2);
     const r3 = new Rect(1, 2, 3, 4);

--- a/frontend/packages/topology/src/geom/types.ts
+++ b/frontend/packages/topology/src/geom/types.ts
@@ -9,3 +9,20 @@ export type Padding =
   | [number, number]
   | [number, number, number]
   | [number, number, number, number];
+
+export interface IPoint {
+  x: number;
+  y: number;
+}
+
+export interface IDimensions {
+  width: number;
+  height: number;
+}
+
+export interface IRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}

--- a/frontend/packages/topology/src/index.ts
+++ b/frontend/packages/topology/src/index.ts
@@ -1,6 +1,7 @@
 export * from './anchors';
 export * from './behavior';
 export * from './components';
+export * from './const';
 export * from './elements';
 export * from './geom';
 export * from './layouts';

--- a/frontend/packages/topology/src/layouts/BaseLayout.ts
+++ b/frontend/packages/topology/src/layouts/BaseLayout.ts
@@ -552,11 +552,20 @@ class BaseLayout implements Layout {
     return layoutGroups;
   }
 
-  protected initializeNewNodePositions(newNodes: LayoutNode[], graph: Graph): void {
-    const cx = graph.getBounds().width / 2;
-    const cy = graph.getBounds().height / 2;
+  protected initializeNodePositions(
+    newNodes: LayoutNode[],
+    graph: Graph,
+    force: boolean = false,
+  ): void {
+    const { width, height } = graph.getBounds();
+    const cx = width / 2;
+    const cy = height / 2;
     newNodes.forEach((node: LayoutNode) => {
-      node.setPosition(cx, cy);
+      // only init position for nodes that are still at 0, 0
+      const { x, y } = node.element.getPosition();
+      if (force || (x === 0 && y === 0)) {
+        node.setPosition(cx, cy);
+      }
     });
   }
 
@@ -631,7 +640,7 @@ class BaseLayout implements Layout {
     this.edges = this.getLinks(this.graph.getEdges());
 
     // initialize new node positions
-    this.initializeNewNodePositions(newNodes, this.graph);
+    this.initializeNodePositions(newNodes, this.graph, initialRun);
 
     // re-create the nodes map
     this.nodesMap = this.nodes.reduce((acc, n) => {

--- a/frontend/packages/topology/src/layouts/ColaLayout.ts
+++ b/frontend/packages/topology/src/layouts/ColaLayout.ts
@@ -141,7 +141,8 @@ class ColaLayout extends BaseLayout implements Layout {
     edges: LayoutLink[],
     groups: LayoutGroup[],
   ): void {
-    this.d3Cola.size([graph.getBounds().width, graph.getBounds().height]);
+    const { width, height } = graph.getBounds();
+    this.d3Cola.size([width, height]);
 
     // Get any custom constraints
     this.d3Cola.constraints(this.getConstraints(nodes as ColaNode[], groups as ColaGroup[], edges));

--- a/frontend/packages/topology/src/layouts/ForceLayout.ts
+++ b/frontend/packages/topology/src/layouts/ForceLayout.ts
@@ -22,8 +22,9 @@ export default class ForceLayout extends BaseLayout implements Layout {
   };
 
   protected startLayout(graph: Graph): void {
-    const cx = graph.getBounds().width / 2;
-    const cy = graph.getBounds().height / 2;
+    const { width, height } = graph.getBounds();
+    const cx = width / 2;
+    const cy = height / 2;
     this.forceSimulation.forceCenter(cx, cy);
     this.forceSimulation.alpha(1);
     this.forceSimulation.useForceSimulation(this.nodes, this.edges, this.getLinkDistance);

--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -1,5 +1,6 @@
 import { ComponentType } from 'react';
 import Point from './geom/Point';
+import Dimensions from './geom/Dimensions';
 import Rect from './geom/Rect';
 import { Padding, Translatable } from './geom/types';
 
@@ -69,6 +70,7 @@ export interface GraphModel extends ElementModel {
   x?: number;
   y?: number;
   scale?: number;
+  layers?: string[];
 }
 
 export interface Anchor {
@@ -114,10 +116,15 @@ export interface Node<E extends NodeModel = NodeModel, D = any> extends GraphEle
   getAnchor(end: AnchorEnd, type?: string): Anchor;
   setAnchor(anchor: Anchor, end?: AnchorEnd, type?: string): void;
   getNodes(): Node[];
-  // TODO return an immutable rect
+  // TODO return an immutable bounds, position, dimensions?
   getBounds(): Rect;
   setBounds(bounds: Rect): void;
+  getPosition(): Point;
+  setPosition(location: Point): void;
+  getDimensions(): Dimensions;
+  setDimensions(dimensions: Dimensions): void;
   isGroup(): boolean;
+  setGroup(group: boolean): void;
   isCollapsed(): boolean;
   setCollapsed(collapsed: boolean): void;
   getNodeShape(): NodeShape;
@@ -147,11 +154,17 @@ export interface Graph<E extends GraphModel = GraphModel, D = any> extends Graph
   getEdges(): Edge[];
   getBounds(): Rect;
   setBounds(bounds: Rect): void;
+  getPosition(): Point;
+  setPosition(location: Point): void;
+  getDimensions(): Dimensions;
+  setDimensions(dimensions: Dimensions): void;
   getScale(): number;
   setScale(scale: number): void;
   getLayout(): string | undefined;
   setLayout(type: string | undefined): void;
   layout(): void;
+  getLayers(): string[];
+  setLayers(layers: string[]): void;
 
   // viewport operations
   reset(): void;

--- a/frontend/packages/topology/stories/4-Connector.stories.tsx
+++ b/frontend/packages/topology/stories/4-Connector.stories.tsx
@@ -286,26 +286,14 @@ export const anchors = () => {
   const NodeWithPointAnchor: React.FC<{ element: Node } & WithDragNodeProps> = (props) => {
     const nodeRef = useSvgAnchor();
     const targetRef = useSvgAnchor(AnchorEnd.target, 'edge-point');
-    const bounds = props.element.getBounds();
+    const { width, height } = props.element.getDimensions();
     return (
       <>
         <Layer id="bottom">
           <NodeRect {...(props as any)} />
         </Layer>
-        <circle
-          ref={nodeRef}
-          fill="lightgreen"
-          r="5"
-          cx={bounds.width * 0.25}
-          cy={bounds.height * 0.25}
-        />
-        <circle
-          ref={targetRef}
-          fill="red"
-          r="5"
-          cx={bounds.width * 0.75}
-          cy={bounds.height * 0.75}
-        />
+        <circle ref={nodeRef} fill="lightgreen" r="5" cx={width * 0.25} cy={height * 0.25} />
+        <circle ref={targetRef} fill="red" r="5" cx={width * 0.75} cy={height * 0.75} />
       </>
     );
   };

--- a/frontend/packages/topology/stories/5-DragDrop.stories.tsx
+++ b/frontend/packages/topology/stories/5-DragDrop.stories.tsx
@@ -126,9 +126,9 @@ export const dnd = () => {
           return props.element;
         },
         drag: (event, monitor, props) => {
-          props.element.setBounds(
+          props.element.setPosition(
             props.element
-              .getBounds()
+              .getPosition()
               .clone()
               .translate(event.dx, event.dy),
           );

--- a/frontend/packages/topology/stories/91-CollapsibleGroups.stories.tsx
+++ b/frontend/packages/topology/stories/91-CollapsibleGroups.stories.tsx
@@ -145,7 +145,7 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis }) =>
             id="collapse-blue"
             label="Collapse Blue"
             isChecked={collapseBlue}
-            onChange={setCollapseBlue}
+            onChange={(checked) => setCollapseBlue(checked)}
           />
         </ToolbarItem>
       </ToolbarGroup>
@@ -155,7 +155,7 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis }) =>
             id="collapse-light-blue"
             label="Collapse Light Blue"
             isChecked={collapseLightBlue}
-            onChange={setCollapseLightBlue}
+            onChange={(checked) => setCollapseLightBlue(checked)}
           />
         </ToolbarItem>
       </ToolbarGroup>
@@ -165,7 +165,7 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis }) =>
             id="collapse-cyan"
             label="Collapse Cyan"
             isChecked={collapseCyan}
-            onChange={setCollapseCyan}
+            onChange={(checked) => setCollapseCyan(checked)}
           />
         </ToolbarItem>
       </ToolbarGroup>
@@ -175,7 +175,7 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis }) =>
             id="collapse-orange"
             label="Collapse Orange"
             isChecked={collapseOrange}
-            onChange={setCollapseOrange}
+            onChange={(checked) => setCollapseOrange(checked)}
           />
         </ToolbarItem>
       </ToolbarGroup>
@@ -185,7 +185,7 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis }) =>
             id="collapse-pink"
             label="Collapse Pink"
             isChecked={collapsePink}
-            onChange={setCollapsePink}
+            onChange={(checked) => setCollapsePink(checked)}
           />
         </ToolbarItem>
       </ToolbarGroup>

--- a/frontend/packages/topology/stories/components/DefaultGroup.tsx
+++ b/frontend/packages/topology/stories/components/DefaultGroup.tsx
@@ -41,11 +41,11 @@ const DefaultGroup: React.FC<GroupProps> = ({
 
   if (!droppable || !boxRef.current) {
     // change the box only when not dragging
-    boxRef.current = element.getBounds().clone();
+    boxRef.current = element.getBounds();
   }
 
   if (element.isCollapsed()) {
-    const { width, height } = element.getBounds();
+    const { width, height } = element.getDimensions();
     return (
       <g>
         <rect

--- a/frontend/packages/topology/stories/components/DefaultNode.tsx
+++ b/frontend/packages/topology/stories/components/DefaultNode.tsx
@@ -41,7 +41,7 @@ const DefaultNode: React.FC<NodeProps> = ({
 }) => {
   useAnchor(EllipseAnchor);
   const refs = useCombineRefs<SVGEllipseElement>(dragNodeRef, dndDragRef, dndDropRef);
-  const { width, height } = element.getBounds();
+  const { width, height } = element.getDimensions();
 
   return (
     <ellipse

--- a/frontend/packages/topology/stories/components/NodePath.tsx
+++ b/frontend/packages/topology/stories/components/NodePath.tsx
@@ -33,7 +33,7 @@ const NodePath: React.FC<NodePathProps> = ({
 }) => {
   const anchorRef = useSvgAnchor();
   const refs = useCombineRefs<SVGPathElement>(dragNodeRef, dndDragRef, dndDropRef, anchorRef);
-  const { width, height } = element.getBounds();
+  const { width, height } = element.getDimensions();
 
   return (
     <path

--- a/frontend/packages/topology/stories/components/NodePolygon.tsx
+++ b/frontend/packages/topology/stories/components/NodePolygon.tsx
@@ -35,7 +35,7 @@ const NodePolygon: React.FC<NodePolygonProps> = ({
 }) => {
   const anchorRef = useSvgAnchor();
   const refs = useCombineRefs<SVGPolygonElement>(dragNodeRef, dndDragRef, dndDropRef, anchorRef);
-  const { width, height } = element.getBounds();
+  const { width, height } = element.getDimensions();
 
   const points: Point[] = [
     new Point(width / 2, 0),

--- a/frontend/packages/topology/stories/components/NodeRect.tsx
+++ b/frontend/packages/topology/stories/components/NodeRect.tsx
@@ -33,7 +33,7 @@ const NodeRect: React.FC<NodeRectProps> = ({
 }) => {
   const anchorRef = useSvgAnchor();
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, dndDragRef, dndDropRef, anchorRef);
-  const { width, height } = element.getBounds();
+  const { width, height } = element.getDimensions();
 
   return (
     <rect


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-2187

This PR addresses two topology improvements:
- splitting bounds into separate position and dimension objects
- adding layers to the model so that it's not hard coded

The reason for splitting bounds into 2 objects is because of how mobx works for optimizing react renders. If a node only needs the height and width but uses bounds, then anytime the position changes, the node will need to be re-rendered. This happens a lot on drag move of a node. By switching to two separate objects. The parent ElementWrapper component will re-render when position changes and only the node will re-render when the dimensions change.

Layers was a simple fix by adding a `layers: string[]` array to the `Graph` model object. This initializes the layers and removes the hard coded layers to become the default in case no layers are provided.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge

/assign @jeff-phillips-18 