### PR TITLE
Add pipeline trigger resource pages and related links in details pages

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunDetails.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunDetails.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { SectionHeading, ResourceSummary, ResourceLink } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
-import PipelineRunVisualization from './PipelineRunVisualization';
 import { PipelineRun, PipelineRunReferenceResource } from '../../../utils/pipeline-augment';
 import { PipelineModel, PipelineResourceModel } from '../../../models';
+import ResourceLinkList from '../../pipelines/resource-overview/ResourceLinkList';
+import PipelineRunVisualization from './PipelineRunVisualization';
 import TriggeredBySection from './TriggeredBySection';
 
 import './TriggeredBySection.scss';
@@ -14,8 +15,11 @@ export interface PipelineRunDetailsProps {
 
 export const PipelineRunDetails: React.FC<PipelineRunDetailsProps> = ({ obj: pipelineRun }) => {
   // FIXME: If they are inline resources, we are not going to render them
-  const unfilteredResources = pipelineRun?.spec?.resources as PipelineRunReferenceResource[];
-  const renderResources = unfilteredResources?.filter(({ resourceRef }) => !!resourceRef);
+  const unfilteredResources = pipelineRun.spec.resources as PipelineRunReferenceResource[];
+  const renderResources =
+    unfilteredResources
+      ?.filter(({ resourceRef }) => !!resourceRef)
+      .map((resource) => resource.resourceRef.name) || [];
 
   return (
     <div className="co-m-pane__body odc-pipeline-run-details">
@@ -37,28 +41,12 @@ export const PipelineRunDetails: React.FC<PipelineRunDetailsProps> = ({ obj: pip
             </dd>
           </dl>
           <TriggeredBySection pipelineRun={pipelineRun} />
-          {renderResources?.length > 0 && (
-            <>
-              <SectionHeading text="Pipeline Resources" />
-              <dl>
-                {renderResources.map((res) => {
-                  return (
-                    <React.Fragment key={res.resourceRef.name}>
-                      <dt>Name: {res.resourceRef.name}</dt>
-                      <dd>
-                        <ResourceLink
-                          kind={referenceForModel(PipelineResourceModel)}
-                          name={res.resourceRef.name}
-                          namespace={pipelineRun.metadata.namespace}
-                          inline
-                        />
-                      </dd>
-                    </React.Fragment>
-                  );
-                })}
-              </dl>
-            </>
-          )}
+          <br />
+          <ResourceLinkList
+            model={PipelineResourceModel}
+            links={renderResources}
+            namespace={pipelineRun.metadata.namespace}
+          />
         </div>
       </div>
     </div>

--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/__tests__/PipelineRunDetails.spec.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/__tests__/PipelineRunDetails.spec.tsx
@@ -7,6 +7,7 @@ import { PipelineModel, PipelineResourceModel } from '../../../../models';
 import { PipelineRunDetails } from '../PipelineRunDetails';
 import { pipelineTestData, PipelineExampleNames, DataState } from '../../../../test/pipeline-data';
 import PipelineRunVisualization from '../PipelineRunVisualization';
+import ResourceLinkList from '../../../pipelines/resource-overview/ResourceLinkList';
 
 const mockPipelineRun =
   pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[DataState.SUCCESS];
@@ -31,9 +32,8 @@ describe('PipelineRun details page', () => {
   });
 
   it('should render page with pipeline run links', () => {
-    const resources = wrapper
-      .find(ResourceLink)
-      .filter({ kind: referenceForModel(PipelineResourceModel) });
+    const resourceList = wrapper.find(ResourceLinkList).filter({ model: PipelineResourceModel });
+    const resources = resourceList.dive().find(ResourceLink);
     expect(resources).toHaveLength(2);
     expect(resources.get(0).props.name).toBe('mapit-git');
     expect(resources.get(1).props.name).toBe('mapit-image');
@@ -43,18 +43,16 @@ describe('PipelineRun details page', () => {
     const pipelineRun = _.cloneDeep(mockPipelineRun);
     pipelineRun.spec.resources = [];
     wrapper.setProps({ obj: pipelineRun });
-    const resources = wrapper
-      .find(ResourceLink)
-      .filter({ kind: referenceForModel(PipelineResourceModel) });
+    const resourceList = wrapper.find(ResourceLinkList).filter({ model: PipelineResourceModel });
+    const resources = resourceList.dive().find(ResourceLink);
     expect(resources).toHaveLength(0);
   });
 
   it('should not render page with pipeline run links if resources is undefined', () => {
     const pipelineRun = _.omit(_.cloneDeep(mockPipelineRun), 'spec.resources');
     wrapper.setProps({ obj: pipelineRun });
-    const resources = wrapper
-      .find(ResourceLink)
-      .filter({ kind: referenceForModel(PipelineResourceModel) });
+    const resourceList = wrapper.find(ResourceLinkList).filter({ model: PipelineResourceModel });
+    const resources = resourceList.dive().find(ResourceLink);
     expect(resources).toHaveLength(0);
   });
 });

--- a/frontend/packages/dev-console/src/components/pipelines/EventListenerPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/EventListenerPage.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
+import { Kebab, navFactory, viewYamlComponent } from '@console/internal/components/utils';
+import EventListenerDetails from './detail-page-tabs/EventListenerDetails';
+
+const EventListenerPage: React.FC<DetailsPageProps> = (props) => (
+  <DetailsPage
+    {...props}
+    menuActions={Kebab.factory.common}
+    pages={[navFactory.details(EventListenerDetails), navFactory.editYaml(viewYamlComponent)]}
+  />
+);
+
+export default EventListenerPage;

--- a/frontend/packages/dev-console/src/components/pipelines/TriggerBindingPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/TriggerBindingPage.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
+import { Kebab, navFactory, viewYamlComponent } from '@console/internal/components/utils';
+import TriggerBindingDetails from './detail-page-tabs/TriggerBindingDetails';
+
+const TriggerBindingPage: React.FC<DetailsPageProps> = (props) => (
+  <DetailsPage
+    {...props}
+    menuActions={Kebab.factory.common}
+    pages={[navFactory.details(TriggerBindingDetails), navFactory.editYaml(viewYamlComponent)]}
+  />
+);
+
+export default TriggerBindingPage;

--- a/frontend/packages/dev-console/src/components/pipelines/TriggerTemplatePage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/TriggerTemplatePage.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { DetailsPage, DetailsPageProps } from '@console/internal/components/factory';
+import { Kebab, navFactory, viewYamlComponent } from '@console/internal/components/utils';
+import TriggerTemplateDetails from './detail-page-tabs/TriggerTemplateDetails';
+
+const TriggerTemplatePage: React.FC<DetailsPageProps> = (props) => (
+  <DetailsPage
+    {...props}
+    menuActions={Kebab.factory.common}
+    pages={[navFactory.details(TriggerTemplateDetails), navFactory.editYaml(viewYamlComponent)]}
+  />
+);
+
+export default TriggerTemplatePage;

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerDetails.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/EventListenerDetails.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
+import { TriggerTemplateModel, TriggerBindingModel } from '../../../models';
+import { EventListenerKind } from '../resource-types';
+import TriggerTemplateResourceLink from '../resource-overview/TriggerTemplateResourceLink';
+import ResourceLinkList from '../resource-overview/ResourceLinkList';
+import {
+  RouteTemplate,
+  useEventListenerTriggerTemplateNames,
+  getEventListenerTriggerBindingNames,
+} from '../utils/triggers';
+
+export interface EventListenerDetailsProps {
+  obj: EventListenerKind;
+}
+
+const EventListenerDetails: React.FC<EventListenerDetailsProps> = ({ obj: eventListener }) => {
+  const routeTemplates: RouteTemplate[] = useEventListenerTriggerTemplateNames(eventListener) || [];
+  const bindings: string[] = getEventListenerTriggerBindingNames(eventListener) || [];
+  return (
+    <div className="co-m-pane__body">
+      <SectionHeading text="Event Listener Details" />
+      <div className="row">
+        <div className="col-sm-6">
+          <ResourceSummary resource={eventListener} />
+        </div>
+        <div className="col-sm-6">
+          <TriggerTemplateResourceLink
+            namespace={eventListener.metadata.namespace}
+            model={TriggerTemplateModel}
+            links={routeTemplates}
+          />
+          <ResourceLinkList
+            namespace={eventListener.metadata.namespace}
+            model={TriggerBindingModel}
+            links={bindings}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EventListenerDetails;

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/TriggerBindingDetails.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/TriggerBindingDetails.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
+import { EventListenerModel } from '../../../models';
+import ResourceLinkList from '../resource-overview/ResourceLinkList';
+import { useTriggerBindingEventListenerNames } from '../utils/triggers';
+import { TriggerBindingKind } from '../resource-types';
+
+export interface TriggerBindingDetailsProps {
+  obj: TriggerBindingKind;
+}
+
+const TriggerBindingDetails: React.FC<TriggerBindingDetailsProps> = ({ obj: triggerBinding }) => {
+  const eventListeners: string[] = useTriggerBindingEventListenerNames(triggerBinding);
+  return (
+    <div className="co-m-pane__body">
+      <SectionHeading text="Trigger Binding Details" />
+      <div className="row">
+        <div className="col-sm-6">
+          <ResourceSummary resource={triggerBinding} />
+        </div>
+        <div className="col-sm-6">
+          <ResourceLinkList
+            namespace={triggerBinding.metadata.namespace}
+            model={EventListenerModel}
+            links={eventListeners}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TriggerBindingDetails;

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/TriggerTemplateDetails.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/TriggerTemplateDetails.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
+import { EventListenerModel, PipelineModel } from '../../../models';
+import ResourceLinkList from '../resource-overview/ResourceLinkList';
+import {
+  useTriggerTemplateEventListenerNames,
+  getTriggerTemplatePipelineName,
+} from '../utils/triggers';
+import { TriggerTemplateKind } from '../resource-types';
+
+export interface TriggerTemplateDetailsProps {
+  obj: TriggerTemplateKind;
+}
+
+const TriggerTemplateDetails: React.FC<TriggerTemplateDetailsProps> = ({
+  obj: triggerTemplate,
+}) => {
+  const eventListeners: string[] = useTriggerTemplateEventListenerNames(triggerTemplate);
+  const pipelineName: string = getTriggerTemplatePipelineName(triggerTemplate);
+  return (
+    <div className="co-m-pane__body">
+      <SectionHeading text="Trigger Template Details" />
+      <div className="row">
+        <div className="col-sm-6">
+          <ResourceSummary resource={triggerTemplate} />
+        </div>
+        <div className="col-sm-6">
+          <ResourceLinkList
+            namespace={triggerTemplate.metadata.namespace}
+            model={PipelineModel}
+            links={[pipelineName]}
+          />
+          <ResourceLinkList
+            namespace={triggerTemplate.metadata.namespace}
+            model={EventListenerModel}
+            links={eventListeners}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TriggerTemplateDetails;

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineDetails.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineDetails.tsx
@@ -1,48 +1,42 @@
 import * as React from 'react';
-import { SectionHeading, ResourceSummary, ResourceLink } from '@console/internal/components/utils';
-import { referenceForModel } from '@console/internal/module/k8s';
-import { Pipeline, getResourceModelFromTask } from '../../../../utils/pipeline-augment';
+import { SectionHeading, ResourceSummary } from '@console/internal/components/utils';
+import { Pipeline } from '../../../../utils/pipeline-augment';
+import { TriggerTemplateModel, TaskModel } from '../../../../models';
+import { usePipelineTriggerTemplateNames, RouteTemplate } from '../../utils/triggers';
+import TriggerTemplateResourceLink from '../../resource-overview/TriggerTemplateResourceLink';
+import ResourceLinkList from '../../resource-overview/ResourceLinkList';
 import PipelineVisualization from './PipelineVisualization';
 
 interface PipelineDetailsProps {
   obj: Pipeline;
 }
 
-const PipelineDetails: React.FC<PipelineDetailsProps> = ({ obj: pipeline }) => (
-  <div className="co-m-pane__body">
-    <SectionHeading text="Pipeline Details" />
-    <PipelineVisualization pipeline={pipeline} />
-    <div className="row">
-      <div className="col-sm-6">
-        <ResourceSummary resource={pipeline} />
-      </div>
-      {pipeline.spec && pipeline.spec.tasks && (
+const PipelineDetails: React.FC<PipelineDetailsProps> = ({ obj: pipeline }) => {
+  const routeTemplates: RouteTemplate[] = usePipelineTriggerTemplateNames(pipeline) || [];
+  const pipelineTasks = pipeline.spec.tasks.map((task) => task.taskRef.name);
+  return (
+    <div className="co-m-pane__body">
+      <SectionHeading text="Pipeline Details" />
+      <PipelineVisualization pipeline={pipeline} />
+      <div className="row">
         <div className="col-sm-6">
-          <SectionHeading text="Tasks" />
-          <dl>
-            {pipeline.spec.tasks.map((task) => {
-              const resourceModel = getResourceModelFromTask(task);
-              return (
-                <React.Fragment key={task.name}>
-                  <dt>Name: {task.name}</dt>
-                  <dd>
-                    Ref:{' '}
-                    <ResourceLink
-                      kind={referenceForModel(resourceModel)}
-                      name={task.taskRef.name}
-                      namespace={pipeline.metadata.namespace}
-                      title={task.taskRef.name}
-                      inline
-                    />
-                  </dd>
-                </React.Fragment>
-              );
-            })}
-          </dl>
+          <ResourceSummary resource={pipeline} />
         </div>
-      )}
+        <div className="col-sm-6">
+          <TriggerTemplateResourceLink
+            namespace={pipeline.metadata.namespace}
+            model={TriggerTemplateModel}
+            links={routeTemplates}
+          />
+          <ResourceLinkList
+            namespace={pipeline.metadata.namespace}
+            links={pipelineTasks}
+            model={TaskModel}
+          />
+        </div>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default PipelineDetails;

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { InputField } from '@console/shared';
 import { ButtonBar } from '@console/internal/components/utils';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { Pipeline } from '../../../utils/pipeline-augment';
 import { PipelineParameters, PipelineResources } from '../detail-page-tabs';
 import { UpdateOperationType } from './const';
 import { useResourceValidation } from './hooks';
@@ -33,7 +33,7 @@ import { applyChange } from './update-utils';
 import './PipelineBuilderForm.scss';
 
 type PipelineBuilderFormProps = FormikProps<FormikValues> & {
-  existingPipeline: K8sResourceKind;
+  existingPipeline: Pipeline;
   namespace: string;
 };
 

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
@@ -73,7 +73,7 @@ const removeEmptyDefaultParams = (task: PipelineTask): PipelineTask => {
 export const convertBuilderFormToPipeline = (
   formValues: PipelineBuilderFormikValues,
   namespace: string,
-  existingPipeline: Pipeline = {},
+  existingPipeline?: Pipeline,
 ): Pipeline => {
   const { name, resources, params, tasks, listTasks } = formValues;
   const listIds = listTasks.map((listTask) => listTask.name);

--- a/frontend/packages/dev-console/src/components/pipelines/resource-overview/ResourceLinkList.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/resource-overview/ResourceLinkList.scss
@@ -1,0 +1,3 @@
+.odc-resource-link-list {
+  margin-bottom: var(--pf-global--spacer--lg);
+}

--- a/frontend/packages/dev-console/src/components/pipelines/resource-overview/ResourceLinkList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/resource-overview/ResourceLinkList.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { ResourceLink } from '@console/internal/components/utils';
+import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
+import './ResourceLinkList.scss';
+
+type ResourceLinkListProps = {
+  namespace: string;
+  model: K8sKind;
+  links: string[];
+};
+const ResourceLinkList: React.FC<ResourceLinkListProps> = ({ links = [], model, namespace }) => {
+  const title = model.labelPlural;
+  const kind = referenceForModel(model);
+
+  if (links.length === 0) {
+    return null;
+  }
+  return (
+    <div className="odc-resource-link-list">
+      <dl>
+        <dt>{title}</dt>
+        <dd>
+          {links.map((name) => {
+            return (
+              <div key={name}>
+                <ResourceLink kind={kind} name={name} namespace={namespace} title={name} inline />
+              </div>
+            );
+          })}
+        </dd>
+      </dl>
+    </div>
+  );
+};
+
+export default ResourceLinkList;

--- a/frontend/packages/dev-console/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.scss
@@ -1,0 +1,6 @@
+.odc-trigger-template-list {
+  margin-bottom: var(--pf-global--spacer--lg);
+  &__url {
+    margin-left: 30px;
+  }
+}

--- a/frontend/packages/dev-console/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/resource-overview/TriggerTemplateResourceLink.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
+import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
+import { RouteTemplate } from '../utils/triggers';
+import './TriggerTemplateResourceLink.scss';
+
+type TriggerTemplateResourceLinkProps = {
+  namespace: string;
+  model: K8sKind;
+  links: RouteTemplate[];
+};
+const TriggerTemplateResourceLink: React.FC<TriggerTemplateResourceLinkProps> = ({
+  links = [],
+  namespace,
+  model,
+}) => {
+  const title = model.labelPlural;
+  const kind = referenceForModel(model);
+
+  if (links.length === 0) {
+    return null;
+  }
+  return (
+    <div className="odc-trigger-template-list">
+      <dl>
+        <dt>{title}</dt>
+        {links.map(({ routeURL, triggerTemplateName }) => {
+          return (
+            <dd key={triggerTemplateName}>
+              <ResourceLink
+                kind={kind}
+                name={triggerTemplateName}
+                namespace={namespace}
+                title={triggerTemplateName}
+                inline
+              />
+              {routeURL && (
+                <div className="odc-trigger-template-list__url">
+                  <ExternalLink href={routeURL} text={routeURL} />
+                </div>
+              )}
+            </dd>
+          );
+        })}
+      </dl>
+    </div>
+  );
+};
+
+export default TriggerTemplateResourceLink;

--- a/frontend/packages/dev-console/src/components/pipelines/resource-overview/__tests__/ResourceLinkList.spec.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/resource-overview/__tests__/ResourceLinkList.spec.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { PipelineModel } from '../../../../models';
+import ResourceLinkList from '../ResourceLinkList';
+import { ResourceLink } from '@console/internal/components/utils';
+
+type ResourceLinkListProps = React.ComponentProps<typeof ResourceLinkList>;
+describe('PipelineResourceSection component', () => {
+  const props = {
+    namespace: 'test-ns',
+    model: PipelineModel,
+    links: ['one', 'two', 'three'],
+  };
+
+  let wrapper: ShallowWrapper<ResourceLinkListProps>;
+  beforeEach(() => {
+    wrapper = shallow(<ResourceLinkList {...props} />);
+  });
+
+  it('should not render the children if links are empty', () => {
+    wrapper.setProps({ links: [] });
+    expect(wrapper.find(ResourceLink)).toHaveLength(0);
+  });
+
+  it('should render resourceLinks if the links are passed', () => {
+    expect(wrapper.find(ResourceLink)).toHaveLength(3);
+  });
+
+  it('should render proper title based on the model', () => {
+    expect(wrapper.find('dt').text()).toBe(PipelineModel.labelPlural);
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelines/resource-types/index.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/resource-types/index.ts
@@ -1,0 +1,2 @@
+// TODO: refactor pipeline-augment
+export * from './triggers';

--- a/frontend/packages/dev-console/src/components/pipelines/resource-types/triggers.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/resource-types/triggers.ts
@@ -1,0 +1,52 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { PipelineRun } from '../../../utils/pipeline-augment';
+
+export type TriggerBindingParam = {
+  name: string;
+  value: string;
+};
+
+export type TriggerBindingKind = K8sResourceCommon & {
+  spec: {
+    params: TriggerBindingParam[];
+  };
+};
+
+export type TriggerTemplateKindParam = {
+  name: string;
+  description?: string;
+  default?: string;
+};
+
+export type TriggerTemplateKindResource = PipelineRun;
+export type TriggerTemplateKind = K8sResourceCommon & {
+  spec: {
+    params: TriggerTemplateKindParam[];
+    resourcetemplates: TriggerTemplateKindResource[];
+  };
+};
+
+export type EventListenerKindBindingReference = {
+  // TriggerBinding / ClusterTriggerBinding name reference
+  name: string;
+  kind?: string;
+};
+
+export type EventListenerKindTrigger = {
+  bindings: EventListenerKindBindingReference[];
+  template: {
+    // TriggerTemplateKind name reference
+    name: string;
+  };
+};
+
+export type EventListenerKind = K8sResourceCommon & {
+  spec: {
+    triggers: EventListenerKindTrigger[];
+  };
+  status?: {
+    configuration: {
+      generatedName: string;
+    };
+  };
+};

--- a/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
@@ -1,0 +1,200 @@
+import * as React from 'react';
+import { flatten, mapValues } from 'lodash';
+import { RouteModel } from '@console/internal/models';
+import { getRouteWebURL } from '@console/internal/components/routes';
+import { K8sResourceCommon, referenceForModel, RouteKind } from '@console/internal/module/k8s';
+import { useK8sGet } from '@console/internal/components/utils/k8s-get-hook';
+import {
+  useK8sWatchResource,
+  useK8sWatchResources,
+  WatchK8sResource,
+  WatchK8sResources,
+  WatchK8sResults,
+  WatchK8sResultsObject,
+} from '@console/internal/components/utils/k8s-watch-hook';
+import { EventListenerModel, PipelineRunModel, TriggerTemplateModel } from '../../../models';
+import { Pipeline, PipelineRun } from '../../../utils/pipeline-augment';
+import {
+  EventListenerKind,
+  EventListenerKindTrigger,
+  TriggerBindingKind,
+  TriggerTemplateKind,
+} from '../resource-types';
+
+type RouteMap = { [generatedName: string]: RouteKind };
+type TriggerTemplateMapping = { [key: string]: TriggerTemplateKind };
+
+const getResourceName = (resource: K8sResourceCommon): string => resource.metadata.name;
+const getEventListenerTemplateNames = (el: EventListenerKind): string[] =>
+  el.spec.triggers.map((elTrigger: EventListenerKindTrigger) => elTrigger.template.name);
+
+const useEventListenerRoutes = (
+  namespace: string,
+  eventListenerResources: EventListenerKind[],
+): RouteMap => {
+  const memoResources: WatchK8sResources<RouteMap> = React.useMemo(() => {
+    return (eventListenerResources || [])
+      .map((eventListener: EventListenerKind) => eventListener.status.configuration.generatedName)
+      .reduce(
+        (acc, generatedName) => ({
+          ...acc,
+          [generatedName]: {
+            kind: RouteModel.kind,
+            name: generatedName,
+            namespace,
+            optional: true,
+          } as WatchK8sResource,
+        }),
+        {},
+      );
+  }, [namespace, eventListenerResources]);
+
+  const results: WatchK8sResults<RouteMap> = useK8sWatchResources<RouteMap>(memoResources);
+
+  return mapValues(results, (result: WatchK8sResultsObject<RouteKind>) => result.data);
+};
+
+const useAllEventListeners = (resource: K8sResourceCommon) => {
+  const {
+    metadata: { namespace },
+  } = resource;
+  const eventListenerResource: WatchK8sResource = React.useMemo(
+    () => ({
+      kind: referenceForModel(EventListenerModel),
+      isList: true,
+      namespace,
+    }),
+    [namespace],
+  );
+  const [resources, eventListenerLoaded] = useK8sWatchResource<EventListenerKind[]>(
+    eventListenerResource,
+  );
+
+  return eventListenerLoaded ? resources : null;
+};
+
+export type RouteTemplate = {
+  routeURL: string | null;
+  triggerTemplateName: string;
+};
+
+export const usePipelineTriggerTemplateNames = (pipeline: Pipeline): RouteTemplate[] | null => {
+  const eventListenerResources: EventListenerKind[] = useAllEventListeners(pipeline);
+  const {
+    metadata: { namespace },
+  } = pipeline;
+  const triggerTemplateResources: WatchK8sResources<TriggerTemplateMapping> = React.useMemo(() => {
+    if (!eventListenerResources) {
+      return {};
+    }
+    return flatten(eventListenerResources.map(getEventListenerTemplateNames)).reduce(
+      (resourceMap, triggerTemplateName: string) => ({
+        ...resourceMap,
+        [triggerTemplateName]: {
+          kind: referenceForModel(TriggerTemplateModel),
+          name: triggerTemplateName,
+          namespace,
+          optional: true,
+        },
+      }),
+      {},
+    );
+  }, [namespace, eventListenerResources]);
+  const triggerTemplates: WatchK8sResults<TriggerTemplateMapping> = useK8sWatchResources(
+    triggerTemplateResources,
+  );
+  const routes: RouteMap = useEventListenerRoutes(namespace, eventListenerResources);
+
+  const countExpected = Object.keys(triggerTemplateResources).length;
+  const countLoaded = Object.values(triggerTemplates).filter(({ loaded }) => loaded).length;
+  if (countLoaded !== countExpected) {
+    return null;
+  }
+  const matchingTriggerTemplateNames: string[] = Object.values(triggerTemplates)
+    .map((resourceWatch: { data: TriggerTemplateKind }) => resourceWatch.data)
+    .filter((triggerTemplate: TriggerTemplateKind) => {
+      const plr: PipelineRun = triggerTemplate?.spec?.resourcetemplates?.find(
+        ({ kind }) => kind === PipelineRunModel.kind,
+      );
+      return plr?.spec?.pipelineRef?.name === getResourceName(pipeline);
+    })
+    .map(getResourceName);
+
+  return (eventListenerResources || []).reduce((acc, ev: EventListenerKind) => {
+    const eventListenerTemplateNames = getEventListenerTemplateNames(ev);
+    const generatedRouteName = ev.status.configuration.generatedName;
+
+    const triggerTemplateName = matchingTriggerTemplateNames.find((name) =>
+      eventListenerTemplateNames.includes(name),
+    );
+    const route: RouteKind = routes[generatedRouteName];
+
+    if (!triggerTemplateName) {
+      return acc;
+    }
+
+    return [...acc, { routeURL: route ? getRouteWebURL(route) : null, triggerTemplateName }];
+  }, []);
+};
+
+export const useEventListenerTriggerTemplateNames = (
+  eventListener: EventListenerKind,
+): RouteTemplate[] | null => {
+  const {
+    metadata: { namespace },
+  } = eventListener;
+
+  const generatedRouteName = eventListener.status.configuration.generatedName;
+  const [route, routeLoaded] = useK8sGet<RouteKind>(RouteModel, generatedRouteName, namespace);
+  return (eventListener.spec.triggers || []).reduce((acc, trigger) => {
+    return [
+      ...acc,
+      {
+        routeURL: route && routeLoaded ? getRouteWebURL(route) : null,
+        triggerTemplateName: trigger.template.name,
+      },
+    ];
+  }, []);
+};
+
+export const getEventListenerTriggerBindingNames = (
+  eventListener: EventListenerKind,
+): string[] | null => {
+  const { bindings } = (eventListener.spec.triggers || []).reduce(
+    (acc, trigger) => ({
+      bindings: [...acc.bindings, ...trigger.bindings.map((binding) => binding.name)],
+    }),
+    { bindings: [] },
+  );
+  return [...bindings];
+};
+
+export const getTriggerTemplatePipelineName = (triggerTemplate: TriggerTemplateKind): string => {
+  return (
+    triggerTemplate.spec.resourcetemplates.find(({ kind }) => kind === PipelineRunModel.kind)?.spec
+      .pipelineRef.name || ''
+  );
+};
+
+export const useTriggerTemplateEventListenerNames = (triggerTemplate: TriggerTemplateKind) => {
+  const eventListenerResources = useAllEventListeners(triggerTemplate) || [];
+
+  return eventListenerResources
+    .filter((eventListener: EventListenerKind) =>
+      eventListener.spec.triggers.find(
+        ({ template: { name } }) => name === getResourceName(triggerTemplate),
+      ),
+    )
+    .map(getResourceName);
+};
+
+export const useTriggerBindingEventListenerNames = (triggerBinding: TriggerBindingKind) => {
+  const eventListenerResources = useAllEventListeners(triggerBinding) || [];
+  return eventListenerResources
+    .filter((eventListener: EventListenerKind) =>
+      eventListener.spec.triggers.find(({ bindings }) =>
+        bindings.find(({ name }) => getResourceName(triggerBinding) === name),
+      ),
+    )
+    .map(getResourceName);
+};

--- a/frontend/packages/dev-console/src/models/pipelines.ts
+++ b/frontend/packages/dev-console/src/models/pipelines.ts
@@ -109,6 +109,51 @@ export const ConditionModel: K8sKind = {
   color,
 };
 
+export const TriggerBindingModel: K8sKind = {
+  apiGroup: 'tekton.dev',
+  apiVersion: 'v1alpha1',
+  label: 'Trigger Binding',
+  plural: 'triggerbindings',
+  abbr: 'TB',
+  namespaced: true,
+  kind: 'TriggerBinding',
+  id: 'triggerbinding',
+  labelPlural: 'Trigger Bindings',
+  crd: true,
+  badge: BadgeType.DEV,
+  color,
+};
+
+export const ClusterTriggerBindingModel: K8sKind = {
+  apiGroup: 'tekton.dev',
+  apiVersion: 'v1alpha1',
+  label: 'Cluster Trigger Binding',
+  plural: 'clustertriggerbindings',
+  abbr: 'CTB',
+  namespaced: false,
+  kind: 'ClusterTriggerBinding',
+  id: 'clustertriggerbinding',
+  labelPlural: 'Cluster Trigger Bindings',
+  crd: true,
+  badge: BadgeType.DEV,
+  color,
+};
+
+export const TriggerTemplateModel: K8sKind = {
+  apiGroup: 'tekton.dev',
+  apiVersion: 'v1alpha1',
+  label: 'Trigger Template',
+  plural: 'triggertemplates',
+  abbr: 'TT',
+  namespaced: true,
+  kind: 'TriggerTemplate',
+  id: 'triggertemplate',
+  labelPlural: 'Trigger Templates',
+  crd: true,
+  badge: BadgeType.DEV,
+  color,
+};
+
 export const EventListenerModel: K8sKind = {
   apiGroup: 'tekton.dev',
   apiVersion: 'v1alpha1',

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -58,6 +58,9 @@ const {
   PipelineRunModel,
   TaskModel,
   TaskRunModel,
+  EventListenerModel,
+  TriggerTemplateModel,
+  TriggerBindingModel,
 } = models;
 
 type ConsumedExtensions =
@@ -365,6 +368,42 @@ const plugin: Plugin<ConsumedExtensions> = [
         (
           await import(
             './components/taskruns/TaskRunDetailsPage' /* webpackChunkName: "taskrun-details" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: EventListenerModel,
+      loader: async () =>
+        (
+          await import(
+            './components/pipelines/EventListenerPage' /* webpackChunkName: "eventlistener-details" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: TriggerTemplateModel,
+      loader: async () =>
+        (
+          await import(
+            './components/pipelines/TriggerTemplatePage' /* webpackChunkName: "trigger-template-details" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: TriggerBindingModel,
+      loader: async () =>
+        (
+          await import(
+            './components/pipelines/TriggerBindingPage' /* webpackChunkName: "trigger-binding-details" */
           )
         ).default,
     },

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
@@ -24,6 +24,9 @@ export const actionPipelines: Pipeline[] = [
     apiVersion: 'abhiapi/v1',
     kind: 'Pipeline',
     metadata: { name: 'danaerys-targaeryen', namespace: 'corazon' },
+    spec: {
+      tasks: [],
+    },
   },
 ];
 

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -95,7 +95,7 @@ export type KeyedRuns = { [key: string]: Runs };
 
 export interface Pipeline extends K8sResourceKind {
   latestRun?: PipelineRun;
-  spec?: {
+  spec: {
     params?: PipelineParam[];
     resources?: PipelineResource[];
     workspaces?: PipelineWorkspace[];


### PR DESCRIPTION
Fixes:- https://issues.redhat.com/browse/ODC-3427

**Analysis / Root cause:**
User should be able to traverse between the trigger resources quickly from the details page.

**Solution Description:**
Added custom pages for the trigger resources and added the links of the related resources.

**screenshot:**
![pipeline-details-link](https://user-images.githubusercontent.com/9964343/79261075-ee8e4f80-7eac-11ea-89cd-d79f76823396.gif)

Pipeline Details
![image](https://user-images.githubusercontent.com/9964343/79260617-3365b680-7eac-11ea-9605-72ade0d8ec0f.png)

Trigger Template Details
![image](https://user-images.githubusercontent.com/9964343/79260712-555f3900-7eac-11ea-984d-008228ad8f8f.png)


Eventlistener-details
![image](https://user-images.githubusercontent.com/9964343/79260765-6b6cf980-7eac-11ea-8774-bcea8a315fc1.png)

**Unit test:**
![image](https://user-images.githubusercontent.com/9964343/79268318-3666a400-7eb8-11ea-8b58-ce40bb9c9f66.png)

![image](https://user-images.githubusercontent.com/9964343/78970855-e9857500-7b27-11ea-9866-62e0ba5e746f.png)

**Browser conformance:**
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @serenamarie125 @andrewballantyne