### PR TITLE
Add support for Helm release rollback

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/RadioButtonField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioButtonField.tsx
@@ -19,7 +19,7 @@ const RadioButtonField: React.FC<RadioButtonFieldProps> = ({ name, label, value,
       isChecked={field.value === value}
       isValid={isValid}
       isDisabled={props.isDisabled}
-      aria-describedby={`${fieldId}-helper`}
+      aria-label={`${fieldId}-${label}`}
       onChange={() => setFieldValue(name, value)}
     />
   );

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioButtonField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioButtonField.tsx
@@ -1,61 +1,27 @@
 import * as React from 'react';
-import { useField } from 'formik';
-import { FormGroup, Radio } from '@patternfly/react-core';
-import { RadioButtonProps } from './field-types';
+import { useField, useFormikContext, FormikValues } from 'formik';
+import { Radio } from '@patternfly/react-core';
+import { RadioButtonFieldProps } from './field-types';
 import { getFieldId } from './field-utils';
-import './RadioButtonField.scss';
 
-const RadioButtonField: React.FC<RadioButtonProps> = ({
-  label,
-  options,
-  helpText,
-  required,
-  ...props
-}) => {
-  const [field, { touched, error }] = useField(props.name);
-  const fieldId = getFieldId(props.name, 'radiobutton');
+const RadioButtonField: React.FC<RadioButtonFieldProps> = ({ name, label, value, ...props }) => {
+  const [field, { touched, error }] = useField(name);
+  const { setFieldValue } = useFormikContext<FormikValues>();
+  const fieldId = getFieldId(`${name}-${value}`, 'radiobutton');
   const isValid = !(touched && error);
-  const errorMessage = !isValid ? error : '';
   return (
-    <FormGroup
-      className="odc-radio-button"
-      fieldId={fieldId}
-      helperText={helpText}
-      helperTextInvalid={errorMessage}
-      isValid={isValid}
-      isRequired={required}
+    <Radio
+      {...field}
+      {...props}
+      id={fieldId}
+      value={value}
       label={label}
-    >
-      {options.map((option) => {
-        const activeChild = field.value === option.value && option.activeChildren;
-        const staticChild = option.children;
-
-        return (
-          <React.Fragment key={option.value}>
-            <Radio
-              {...field}
-              {...props}
-              id={getFieldId(option.value, 'radiobutton')}
-              value={option.value}
-              label={option.label}
-              isChecked={field.value === option.value}
-              isValid={isValid}
-              isDisabled={option.isDisabled}
-              aria-describedby={`${fieldId}-helper`}
-              onChange={(val, event) => {
-                field.onChange(event);
-              }}
-            />
-            {(activeChild || staticChild) && (
-              <div className="odc-radio-button__children">
-                {staticChild}
-                {activeChild}
-              </div>
-            )}
-          </React.Fragment>
-        );
-      })}
-    </FormGroup>
+      isChecked={field.value === value}
+      isValid={isValid}
+      isDisabled={props.isDisabled}
+      aria-describedby={`${fieldId}-helper`}
+      onChange={() => setFieldValue(name, value)}
+    />
   );
 };
 

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
@@ -1,4 +1,4 @@
-.odc-radio-button {
+.odc-radio-group {
   padding-left: var(--pf-global--spacer--sm);
 
   input[type='radio'] {
@@ -6,6 +6,6 @@
   }
 
   &__children {
-    padding: var(--pf-global--spacer--md) 0 var(--pf-global--spacer--md) 1.8rem;
+    padding: var(--pf-global--spacer--md) 0;
   }
 }

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.scss
@@ -1,4 +1,4 @@
-.odc-radio-group {
+.ocs-radio-group-field {
   padding-left: var(--pf-global--spacer--sm);
 
   input[type='radio'] {

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.tsx
@@ -19,7 +19,7 @@ const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
   const errorMessage = !isValid ? error : '';
   return (
     <FormGroup
-      className="odc-radio-button"
+      className="ocs-radio-group-field"
       fieldId={fieldId}
       helperText={helpText}
       helperTextInvalid={errorMessage}
@@ -32,7 +32,7 @@ const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
         const staticChild = option.children;
 
         const description = (activeChild || staticChild) && (
-          <div className="odc-radio-group__children">
+          <div className="ocs-radio-group-field__children">
             {staticChild}
             {activeChild}
           </div>

--- a/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/RadioGroupField.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { useField } from 'formik';
+import { FormGroup } from '@patternfly/react-core';
+import { RadioGroupFieldProps } from './field-types';
+import { getFieldId } from './field-utils';
+import RadioButtonField from './RadioButtonField';
+import './RadioGroupField.scss';
+
+const RadioGroupField: React.FC<RadioGroupFieldProps> = ({
+  label,
+  options,
+  helpText,
+  required,
+  ...props
+}) => {
+  const [field, { touched, error }] = useField(props.name);
+  const fieldId = getFieldId(props.name, 'radiogroup');
+  const isValid = !(touched && error);
+  const errorMessage = !isValid ? error : '';
+  return (
+    <FormGroup
+      className="odc-radio-button"
+      fieldId={fieldId}
+      helperText={helpText}
+      helperTextInvalid={errorMessage}
+      isValid={isValid}
+      isRequired={required}
+      label={label}
+    >
+      {options.map((option) => {
+        const activeChild = field.value === option.value && option.activeChildren;
+        const staticChild = option.children;
+
+        const description = (activeChild || staticChild) && (
+          <div className="odc-radio-group__children">
+            {staticChild}
+            {activeChild}
+          </div>
+        );
+
+        return (
+          <React.Fragment key={option.value}>
+            <RadioButtonField
+              {...field}
+              {...props}
+              value={option.value}
+              label={option.label}
+              isDisabled={option.isDisabled}
+              aria-describedby={`${fieldId}-helper`}
+              description={description}
+            />
+          </React.Fragment>
+        );
+      })}
+    </FormGroup>
+  );
+};
+
+export default RadioGroupField;

--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -3,7 +3,7 @@ import { K8sResourceKind } from '@console/internal/module/k8s';
 
 export interface FieldProps {
   name: string;
-  label?: string;
+  label?: React.ReactNode;
   helpText?: React.ReactNode;
   helpTextInvalid?: React.ReactNode;
   required?: boolean;
@@ -99,12 +99,17 @@ export interface SecretKeyRef {
   };
 }
 
-export interface RadioButtonProps extends FieldProps {
-  options: RadioOption[];
+export interface RadioButtonFieldProps extends FieldProps {
+  value: string | number;
+  description?: React.ReactNode;
 }
 
-export interface RadioOption {
-  value: string;
+export interface RadioGroupFieldProps extends FieldProps {
+  options: RadioGroupOption[];
+}
+
+export interface RadioGroupOption {
+  value: string | number;
   label: React.ReactNode;
   isDisabled?: boolean;
   children?: React.ReactNode;

--- a/frontend/packages/console-shared/src/components/formik-fields/field-utils.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-utils.ts
@@ -1,3 +1,3 @@
 export const getFieldId = (fieldName: string, fieldType: string) => {
-  return `form-${fieldType}-${fieldName.replace(/\./g, '-')}-field`;
+  return `form-${fieldType}-${fieldName?.replace(/\./g, '-')}-field`;
 };

--- a/frontend/packages/console-shared/src/components/formik-fields/index.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/index.ts
@@ -7,6 +7,7 @@ export { default as MultiColumnField } from './multi-column-field/MultiColumnFie
 export { default as NSDropdownField } from './NSDropdownField';
 export { default as NumberSpinnerField } from './NumberSpinnerField';
 export { default as RadioButtonField } from './RadioButtonField';
+export { default as RadioGroupField } from './RadioGroupField';
 export { default as ResourceDropdownField } from './ResourceDropdownField';
 export { default as ResourceLimitField } from './ResourceLimitField';
 export { default as SwitchField } from './SwitchField';

--- a/frontend/packages/dev-console/src/actions/modify-helm-release.ts
+++ b/frontend/packages/dev-console/src/actions/modify-helm-release.ts
@@ -26,3 +26,10 @@ export const upgradeHelmRelease = (releaseName: string, namespace: string) => ({
     history.push(`/helm-releases/ns/${namespace}/${releaseName}/upgrade`);
   },
 });
+
+export const rollbackHelmRelease = (releaseName: string, namespace: string) => ({
+  label: 'Rollback',
+  callback: () => {
+    history.push(`/helm-releases/ns/${namespace}/${releaseName}/rollback`);
+  },
+});

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseRollbackPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseRollbackPage.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import Helmet from 'react-helmet';
+import { Formik } from 'formik';
+import { RouteComponentProps } from 'react-router';
+import { PageBody } from '@console/shared';
+import { coFetchJSON } from '@console/internal/co-fetch';
+import { PageHeading, history } from '@console/internal/components/utils';
+
+import { HelmRelease } from './helm-types';
+import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
+import HelmReleaseRollbackForm from './form/HelmReleaseRollbackForm';
+
+type HelmReleaseRollbackPageProps = RouteComponentProps<{
+  ns?: string;
+  releaseName?: string;
+}>;
+
+type HelmRollbackFormData = {
+  revision: number;
+};
+
+const HelmReleaseRollbackPage: React.FC<HelmReleaseRollbackPageProps> = ({ match }) => {
+  const { releaseName, ns: namespace } = match.params;
+  const [releaseHistory, setReleaseHistory] = React.useState<HelmRelease[]>(null);
+
+  React.useEffect(() => {
+    let ignore = false;
+
+    const fetchReleaseHistory = async () => {
+      let res: HelmRelease[];
+      try {
+        res = await coFetchJSON(`/api/helm/release/history?ns=${namespace}&name=${releaseName}`);
+      } catch {
+        if (ignore) return;
+      }
+      if (ignore) return;
+      res.length > 0 && setReleaseHistory(res);
+    };
+
+    fetchReleaseHistory();
+
+    return () => {
+      ignore = true;
+    };
+  }, [namespace, releaseName]);
+
+  const initialValues: HelmRollbackFormData = {
+    revision: -1,
+  };
+
+  const handleSubmit = (values, actions) => {
+    actions.setStatus({ isSubmitting: true });
+    const payload = {
+      namespace,
+      name: releaseName,
+      version: values.revision,
+    };
+
+    coFetchJSON
+      .put('/api/helm/release', payload)
+      .then(() => {
+        actions.setStatus({ isSubmitting: false });
+        history.push(`/helm-releases/ns/${namespace}`);
+      })
+      .catch((err) => {
+        actions.setSubmitting(false);
+        actions.setStatus({ submitError: err.message });
+      });
+  };
+
+  return (
+    <NamespacedPage variant={NamespacedPageVariants.light} disabled hideApplications>
+      <Helmet>
+        <title>Rollback Helm Release</title>
+      </Helmet>
+      <PageHeading title="Rollback Helm Release">
+        Select the version to rollback <strong>{releaseName}</strong> to, from the table below
+      </PageHeading>
+      <PageBody>
+        <Formik initialValues={initialValues} onSubmit={handleSubmit} onReset={history.goBack}>
+          {(props) => <HelmReleaseRollbackForm {...props} releaseHistory={releaseHistory} />}
+        </Formik>
+      </PageBody>
+    </NamespacedPage>
+  );
+};
+
+export default HelmReleaseRollbackPage;

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseRollbackPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseRollbackPage.tsx
@@ -30,11 +30,10 @@ const HelmReleaseRollbackPage: React.FC<HelmReleaseRollbackPageProps> = ({ match
       let res: HelmRelease[];
       try {
         res = await coFetchJSON(`/api/helm/release/history?ns=${namespace}&name=${releaseName}`);
-      } catch {
-        if (ignore) return;
-      }
+      } catch {} // eslint-disable-line no-empty
       if (ignore) return;
-      res.length > 0 && setReleaseHistory(res);
+
+      res?.length > 0 && setReleaseHistory(res);
     };
 
     fetchReleaseHistory();
@@ -74,7 +73,7 @@ const HelmReleaseRollbackPage: React.FC<HelmReleaseRollbackPageProps> = ({ match
         <title>Rollback Helm Release</title>
       </Helmet>
       <PageHeading title="Rollback Helm Release">
-        Select the version to rollback <strong>{releaseName}</strong> to, from the table below
+        Select the version to rollback <strong>{releaseName}</strong> to, from the table below:
       </PageHeading>
       <PageBody>
         <Formik initialValues={initialValues} onSubmit={handleSubmit} onReset={history.goBack}>

--- a/frontend/packages/dev-console/src/components/helm/details/HelmReleaseDetails.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/HelmReleaseDetails.tsx
@@ -53,18 +53,25 @@ export const LoadedHelmReleaseDetails: React.FC<LoadedHelmReleaseDetailsProps> =
     return <StatusBox loaded={secret.loaded} loadError={secret.loadError} />;
   }
 
-  const secretResource = secret.data;
+  const secretResources = secret.data;
 
-  if (_.isEmpty(secretResource)) return <ErrorPage404 />;
+  if (_.isEmpty(secretResources)) return <ErrorPage404 />;
 
-  const secretName = secretResource[0]?.metadata.name;
+  const sortedSecretResources = _.orderBy(
+    secretResources,
+    (o) => Number(o.metadata.labels.version),
+    'desc',
+  );
+
+  const latestReleaseSecret = sortedSecretResources[0];
+  const secretName = latestReleaseSecret?.metadata.name;
   const releaseName = helmReleaseData?.name;
 
   const title = (
     <>
       {releaseName}
       <Badge isRead style={{ verticalAlign: 'middle', marginLeft: 'var(--pf-global--spacer--md)' }}>
-        <Status status={_.capitalize(helmReleaseData?.info?.status)} />
+        <Status status={_.capitalize(latestReleaseSecret?.metadata.labels.status)} />
       </Badge>
     </>
   );
@@ -101,7 +108,7 @@ export const LoadedHelmReleaseDetails: React.FC<LoadedHelmReleaseDetailsProps> =
         },
         {
           href: 'history',
-          name: 'History',
+          name: 'Revision History',
           component: HelmReleaseHistory,
         },
         {

--- a/frontend/packages/dev-console/src/components/helm/details/HelmReleaseDetails.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/HelmReleaseDetails.tsx
@@ -17,7 +17,11 @@ import { fetchHelmReleases } from '../helm-utils';
 import HelmReleaseResources from './resources/HelmReleaseResources';
 import HelmReleaseOverview from './overview/HelmReleaseOverview';
 import HelmReleaseHistory from './history/HelmReleaseHistory';
-import { deleteHelmRelease, upgradeHelmRelease } from '../../../actions/modify-helm-release';
+import {
+  deleteHelmRelease,
+  upgradeHelmRelease,
+  rollbackHelmRelease,
+} from '../../../actions/modify-helm-release';
 import HelmReleaseNotes from './HelmReleaseNotes';
 import { HelmRelease } from '../helm-types';
 
@@ -66,6 +70,7 @@ export const LoadedHelmReleaseDetails: React.FC<LoadedHelmReleaseDetailsProps> =
   );
 
   const menuActions = [
+    () => rollbackHelmRelease(releaseName, namespace),
     () => upgradeHelmRelease(releaseName, namespace),
     () => deleteHelmRelease(releaseName, namespace, `/helm-releases/ns/${namespace}`),
   ];

--- a/frontend/packages/dev-console/src/components/helm/details/history/HelmReleaseHistory.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/history/HelmReleaseHistory.tsx
@@ -2,21 +2,27 @@ import * as React from 'react';
 import { match as RMatch } from 'react-router';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { SortByDirection } from '@patternfly/react-table';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { useDeepCompareMemoize } from '@console/shared';
+
+import { HelmRelease } from '../../helm-types';
 import CustomResourceList from '../../../custom-resource-list/CustomResourceList';
 import HelmReleaseHistoryRow from './HelmReleaseHistoryRow';
 import HelmReleaseHistoryHeader from './HelmReleaseHistoryHeader';
-import { HelmRelease } from '../../helm-types';
 
 interface HelmReleaseHistoryProps {
   match: RMatch<{
     ns?: string;
     name?: string;
   }>;
+  obj: K8sResourceKind;
 }
 
-const HelmReleaseHistory: React.FC<HelmReleaseHistoryProps> = ({ match }) => {
+const HelmReleaseHistory: React.FC<HelmReleaseHistoryProps> = ({ match, obj }) => {
   const namespace = match.params.ns;
   const helmReleaseName = match.params.name;
+
+  const memoizedObj = useDeepCompareMemoize(obj);
 
   const getHelmReleaseRevisions = (): Promise<HelmRelease[]> => {
     return coFetchJSON(`/api/helm/release/history?ns=${namespace}&name=${helmReleaseName}`);
@@ -25,6 +31,7 @@ const HelmReleaseHistory: React.FC<HelmReleaseHistoryProps> = ({ match }) => {
   return (
     <CustomResourceList
       fetchCustomResources={getHelmReleaseRevisions}
+      dependentResource={memoizedObj}
       sortBy="version"
       sortOrder={SortByDirection.desc}
       resourceRow={HelmReleaseHistoryRow}

--- a/frontend/packages/dev-console/src/components/helm/details/history/HelmReleaseHistoryHeader.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/history/HelmReleaseHistoryHeader.tsx
@@ -1,4 +1,5 @@
 import { sortable } from '@patternfly/react-table';
+import { Kebab } from '@console/internal/components/utils';
 
 export const tableColumnClasses = {
   revision: 'col-lg-1 col-md-3 col-sm-3 col-xs-3',
@@ -8,6 +9,7 @@ export const tableColumnClasses = {
   chartVersion: 'col-lg-2 hidden-md hidden-sm hidden-xs',
   appVersion: 'col-lg-2 hidden-md hidden-sm hidden-xs',
   description: 'col-lg-2 hidden-md hidden-sm hidden-xs',
+  kebab: Kebab.columnClass,
 };
 
 const HelmReleaseHistoryHeader = () => {
@@ -15,6 +17,7 @@ const HelmReleaseHistoryHeader = () => {
     {
       title: 'Revision',
       sortField: 'version',
+      sortAsNumber: true,
       transforms: [sortable],
       props: { className: tableColumnClasses.revision },
     },
@@ -51,6 +54,10 @@ const HelmReleaseHistoryHeader = () => {
     {
       title: 'Description',
       props: { className: tableColumnClasses.description },
+    },
+    {
+      title: '',
+      props: { className: tableColumnClasses.kebab },
     },
   ];
 };

--- a/frontend/packages/dev-console/src/components/helm/details/overview/HelmChartSummary.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/overview/HelmChartSummary.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { HelmRelease } from '../../helm-types';
 import { Timestamp } from '@console/internal/components/utils';
+import { K8sResourceKind } from '@console/internal/module/k8s';
 
 interface HelmChartSummaryProps {
+  obj: K8sResourceKind;
   helmRelease: HelmRelease;
 }
 
-const HelmChartSummary: React.FC<HelmChartSummaryProps> = ({ helmRelease }) => {
+const HelmChartSummary: React.FC<HelmChartSummaryProps> = ({ obj, helmRelease }) => {
   if (!helmRelease) return null;
 
   const {
@@ -14,8 +16,13 @@ const HelmChartSummary: React.FC<HelmChartSummaryProps> = ({ helmRelease }) => {
       metadata: { name: chartName, version: chartVersion, appVersion },
     },
     info: { last_deployed: updated },
-    version: revision,
   } = helmRelease;
+
+  const {
+    metadata: {
+      labels: { version: revision },
+    },
+  } = obj;
 
   return (
     <dl className="co-m-pane__details">

--- a/frontend/packages/dev-console/src/components/helm/details/overview/HelmReleaseOverview.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/overview/HelmReleaseOverview.tsx
@@ -9,19 +9,16 @@ export interface HelmReleaseOverviewProps {
   customData: HelmRelease;
 }
 
-const HelmReleaseOverview: React.FC<HelmReleaseOverviewProps> = ({
-  obj: resourceDetails,
-  customData,
-}) => {
+const HelmReleaseOverview: React.FC<HelmReleaseOverviewProps> = ({ obj, customData }) => {
   return (
     <div className="co-m-pane__body">
       <SectionHeading text="Helm Release Details" />
       <div className="row">
         <div className="col-sm-6">
-          <ResourceSummary resource={resourceDetails} customPathName={'metadata.labels.name'} />
+          <ResourceSummary resource={obj} customPathName={'metadata.labels.name'} />
         </div>
         <div className="col-sm-6">
-          <HelmChartSummary helmRelease={customData} />
+          <HelmChartSummary helmRelease={customData} obj={obj} />
         </div>
       </div>
     </div>

--- a/frontend/packages/dev-console/src/components/helm/form/HelmReleaseRollbackForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmReleaseRollbackForm.tsx
@@ -21,6 +21,7 @@ const HelmReleaseRollbackForm: React.FC<Props> = ({
   handleSubmit,
   handleReset,
   status,
+  isSubmitting,
   dirty,
   releaseHistory,
 }) => {
@@ -41,10 +42,11 @@ const HelmReleaseRollbackForm: React.FC<Props> = ({
       <FormFooter
         handleReset={handleReset}
         errorMessage={status?.submitError}
-        isSubmitting={status?.isSubmitting}
+        isSubmitting={status?.isSubmitting || isSubmitting}
         submitLabel="Rollback"
         disableSubmit={status?.isSubmitting || !dirty || !_.isEmpty(errors)}
         resetLabel="Cancel"
+        sticky
       />
     </Form>
   );

--- a/frontend/packages/dev-console/src/components/helm/form/HelmReleaseRollbackForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmReleaseRollbackForm.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { FormikProps, FormikValues } from 'formik';
+import { Form, FormGroup } from '@patternfly/react-core';
+import { FormFooter } from '@console/shared';
+import { SortByDirection } from '@patternfly/react-table';
+import { Table } from '@console/internal/components/factory';
+import { HelmRelease } from '../helm-types';
+
+import RevisionListHeader from './rollback/RevisionListHeader';
+import RevisionListRow from './rollback/RevisionListRow';
+
+interface HelmReleaseRollbackFormProps {
+  releaseHistory: HelmRelease[];
+}
+
+type Props = FormikProps<FormikValues> & HelmReleaseRollbackFormProps;
+
+const HelmReleaseRollbackForm: React.FC<Props> = ({
+  errors,
+  handleSubmit,
+  handleReset,
+  status,
+  dirty,
+  releaseHistory,
+}) => {
+  return (
+    <Form onSubmit={handleSubmit}>
+      <FormGroup fieldId="revision-list-field" label="Revision History" isRequired>
+        <Table
+          data={releaseHistory}
+          defaultSortField="version"
+          defaultSortOrder={SortByDirection.desc}
+          aria-label="CustomResources"
+          Header={RevisionListHeader}
+          Row={RevisionListRow}
+          loaded={!!releaseHistory}
+          virtualize
+        />
+      </FormGroup>
+      <FormFooter
+        handleReset={handleReset}
+        errorMessage={status?.submitError}
+        isSubmitting={status?.isSubmitting}
+        submitLabel="Rollback"
+        disableSubmit={status?.isSubmitting || !dirty || !_.isEmpty(errors)}
+        resetLabel="Cancel"
+      />
+    </Form>
+  );
+};
+
+export default HelmReleaseRollbackForm;

--- a/frontend/packages/dev-console/src/components/helm/form/rollback/RevisionListHeader.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/rollback/RevisionListHeader.tsx
@@ -1,0 +1,64 @@
+import { sortable } from '@patternfly/react-table';
+import { Kebab } from '@console/internal/components/utils';
+
+export const tableColumnClasses = {
+  input: Kebab.columnClass,
+  revision: 'col-lg-1 col-md-3 col-sm-3 col-xs-3',
+  updated: 'col-lg-2 col-md-3 col-sm-5 col-xs-5',
+  status: 'col-lg-1 col-md-2 hidden-sm hidden-xs',
+  chartName: 'col-lg-2 hidden-md hidden-sm hidden-xs',
+  chartVersion: 'col-lg-2 hidden-md hidden-sm hidden-xs',
+  appVersion: 'col-lg-2 hidden-md hidden-sm hidden-xs',
+  description: 'col-lg-2 hidden-md hidden-sm hidden-xs',
+};
+
+const RevisionListHeader = () => {
+  return [
+    {
+      title: '',
+      props: { className: tableColumnClasses.input },
+    },
+    {
+      title: 'Revision',
+      sortField: 'version',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.revision },
+    },
+    {
+      title: 'Updated',
+      sortField: 'info.last_deployed',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.updated },
+    },
+    {
+      title: 'Status',
+      sortField: 'info.status',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.status },
+    },
+    {
+      title: 'Chart Name',
+      sortField: 'chart.metadata.name',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.chartName },
+    },
+    {
+      title: 'Chart Version',
+      sortField: 'chart.metadata.version',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.chartVersion },
+    },
+    {
+      title: 'App Version',
+      sortField: 'chart.metadata.appVersion',
+      transforms: [sortable],
+      props: { className: tableColumnClasses.appVersion },
+    },
+    {
+      title: 'Description',
+      props: { className: tableColumnClasses.description },
+    },
+  ];
+};
+
+export default RevisionListHeader;

--- a/frontend/packages/dev-console/src/components/helm/form/rollback/RevisionListHeader.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/rollback/RevisionListHeader.tsx
@@ -21,6 +21,7 @@ const RevisionListHeader = () => {
     {
       title: 'Revision',
       sortField: 'version',
+      sortAsNumber: true,
       transforms: [sortable],
       props: { className: tableColumnClasses.revision },
     },

--- a/frontend/packages/dev-console/src/components/helm/form/rollback/RevisionListRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/rollback/RevisionListRow.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { Status, RadioButtonField } from '@console/shared';
+import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
+import { Timestamp } from '@console/internal/components/utils';
+import { tableColumnClasses } from './RevisionListHeader';
+
+const RevisionListRow: RowFunction = ({ obj, index, key, style }) => {
+  return (
+    <TableRow id={obj.revision} index={index} trKey={key} style={style}>
+      <TableData className={tableColumnClasses.input}>
+        <RadioButtonField value={obj.version} name="revision" />
+      </TableData>
+      <TableData className={tableColumnClasses.revision}>{obj.version}</TableData>
+      <TableData className={tableColumnClasses.updated}>
+        <Timestamp timestamp={obj.info.last_deployed} />
+      </TableData>
+      <TableData className={tableColumnClasses.status}>
+        <Status status={_.capitalize(obj.info.status)} />
+      </TableData>
+      <TableData className={tableColumnClasses.chartName}>{obj.chart.metadata.name}</TableData>
+      <TableData className={tableColumnClasses.chartVersion}>
+        {obj.chart.metadata.version}
+      </TableData>
+      <TableData className={tableColumnClasses.appVersion}>
+        {obj.chart.metadata.appVersion}
+      </TableData>
+      <TableData className={tableColumnClasses.description}>{obj.info.description}</TableData>
+    </TableRow>
+  );
+};
+
+export default RevisionListRow;

--- a/frontend/packages/dev-console/src/components/helm/list/HelmReleaseListRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/list/HelmReleaseListRow.tsx
@@ -6,10 +6,15 @@ import { Timestamp, Kebab, ResourceIcon } from '@console/internal/components/uti
 import { Link } from 'react-router-dom';
 import { HelmRelease } from '../helm-types';
 import { tableColumnClasses } from './HelmReleaseListHeader';
-import { deleteHelmRelease, upgradeHelmRelease } from '../../../actions/modify-helm-release';
+import {
+  deleteHelmRelease,
+  upgradeHelmRelease,
+  rollbackHelmRelease,
+} from '../../../actions/modify-helm-release';
 
 const HelmReleaseListRow: RowFunction<HelmRelease> = ({ obj, index, key, style }) => {
   const menuActions = [
+    rollbackHelmRelease(obj.name, obj.namespace),
     upgradeHelmRelease(obj.name, obj.namespace),
     deleteHelmRelease(obj.name, obj.namespace),
   ];

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageSearchSection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useFormikContext, FormikValues } from 'formik';
-import { RadioButtonField } from '@console/shared';
+import { RadioGroupField } from '@console/shared';
 import FormSection from '../section/FormSection';
 import { imageRegistryType } from '../../../utils/imagestream-utils';
 import ImageStream from './ImageStream';
@@ -30,7 +30,7 @@ const ImageSearchSection: React.FC = () => {
       title="Image"
       subTitle="Deploy an existing image from an image stream or image registry."
     >
-      <RadioButtonField
+      <RadioGroupField
         name="registry"
         options={[
           {

--- a/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
@@ -8,7 +8,7 @@ import {
   ServiceModel,
   KnativeServingModel,
 } from '@console/knative-plugin';
-import { getBadgeFromType, RadioButtonField, RadioOption } from '@console/shared';
+import { getBadgeFromType, RadioGroupField, RadioGroupOption } from '@console/shared';
 import { useAccessReview } from '@console/internal/components/utils';
 import { getActiveNamespace } from '@console/internal/actions/ui';
 import { Resources, ReadableResourcesNames } from '../import-types';
@@ -34,7 +34,7 @@ const ResourceSection: React.FC<ResourceSectionProps> = ({ flags }) => {
   const [field] = useField<Resources[]>('resourceTypesNotValid');
   const invalidTypes = field.value || [];
 
-  const radioOptions: RadioOption[] = [];
+  const radioOptions: RadioGroupOption[] = [];
   if (!invalidTypes.includes(Resources.Kubernetes)) {
     radioOptions.push({
       label: ReadableResourcesNames[Resources.Kubernetes],
@@ -86,7 +86,7 @@ const ResourceSection: React.FC<ResourceSectionProps> = ({ flags }) => {
   return (
     <FormSection title="Resources" fullWidth>
       <div>Select the resource type to generate</div>
-      <RadioButtonField name="resources" options={radioOptions} />
+      <RadioGroupField name="resources" options={radioOptions} />
     </FormSection>
   );
 };

--- a/frontend/packages/dev-console/src/components/topology/actions/helmReleaseActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/helmReleaseActions.ts
@@ -1,13 +1,18 @@
 import { KebabOption } from '@console/internal/components/utils/kebab';
 import { Node } from '@console/topology';
 import { regroupActions } from './regroupActions';
-import { deleteHelmRelease, upgradeHelmRelease } from '../../../actions/modify-helm-release';
+import {
+  deleteHelmRelease,
+  upgradeHelmRelease,
+  rollbackHelmRelease,
+} from '../../../actions/modify-helm-release';
 
 export const helmReleaseActions = (helmRelease: Node): KebabOption[] => {
   const name = helmRelease.getLabel();
   const { namespace } = helmRelease.getData().groupResources[0].resources.obj.metadata;
   return name && namespace
     ? [
+        rollbackHelmRelease(name, namespace),
         upgradeHelmRelease(name, namespace),
         deleteHelmRelease(name, namespace),
         ...regroupActions(helmRelease),

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -632,6 +632,19 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
+      path: [`/helm-releases/ns/:ns/:releaseName/rollback`],
+      loader: async () =>
+        (
+          await import(
+            './components/helm/HelmReleaseRollbackPage' /* webpackChunkName: "dev-console-helm-rollback" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
       path: ['/helm-releases/all-namespaces', '/helm-releases/ns/:ns'],
       loader: async () =>
         (


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3060

**Analysis / Root cause**: 
There is no way for a user to rollback a helm release to a specific revision.

**Solution Description**: Add support for rollback action in list page, details page, topology and history tab of Helm Release.

**This PR -**
- Refactors `RadioButtonField` into `RadioGroupField` and `RadioButtonField` to handle use cases such as single radio button without the form group.
- Adds a new Helm Rollback form that list all the revisions of that helm release in a table and shows a radio button in the first column of the table.
- Adds the rollback action to helm list page, helm details page and topology.
- Adds a new action that opens a confirm modal for the rollback on History tab of Helm Release details page.
- Changes the way helm release secret was sent to the Details page. Earlier it was sending the first secret resource in the array which might be an older version of the release. Updated the logic to find the latest version of the release secret. 

**Screen shots / Gifs for design review**: 
Form - 
![HelmRollbackForm](https://user-images.githubusercontent.com/6041994/78948667-bd95cf80-7ae6-11ea-8ea0-7c7f3f792acf.gif)

History Tab -
![HelmRollbackHistoryTab](https://user-images.githubusercontent.com/6041994/78959797-a9af9500-7b09-11ea-889c-ac8ce029c7aa.gif)

cc: @openshift/team-ux-review @serenamarie125 @parvathyvr 

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge