### PR TITLE
Add Remove Trigger

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/ModalStructure.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/ModalStructure.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+import { FormikProps, FormikValues } from 'formik';
+import { Form } from '@patternfly/react-core';
+import {
+  ModalBody,
+  ModalComponentProps,
+  ModalSubmitFooter,
+  ModalTitle,
+} from '@console/internal/components/factory';
+
+type ModalStructureProps = {
+  children: React.ReactNode;
+  submitBtnText: string;
+  submitDanger?: boolean;
+  title: string;
+};
+
+type ModalStructureCombinedProps = FormikProps<FormikValues> &
+  ModalComponentProps &
+  ModalStructureProps;
+
+const ModalStructure: React.FC<ModalStructureCombinedProps> = (props) => {
+  const {
+    children,
+    close,
+    errors,
+    isSubmitting,
+    handleSubmit,
+    status,
+    submitBtnText,
+    submitDanger,
+    title,
+  } = props;
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <div className="modal-content">
+        <ModalTitle>{title}</ModalTitle>
+        <ModalBody>
+          <div className="pf-c-form">{children}</div>
+        </ModalBody>
+        <ModalSubmitFooter
+          errorMessage={status?.submitError}
+          inProgress={isSubmitting}
+          submitText={submitBtnText}
+          submitDisabled={!_.isEmpty(errors)}
+          submitDanger={submitDanger}
+          cancel={close}
+        />
+      </div>
+    </Form>
+  );
+};
+
+export default ModalStructure;

--- a/frontend/packages/dev-console/src/components/pipelines/modals/index.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/index.ts
@@ -1,0 +1,1 @@
+export { default as removeTriggerModal } from './triggers/RemoveTriggerModal';

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/RemoveTriggerForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/RemoveTriggerForm.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { Split, SplitItem } from '@patternfly/react-core';
+import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { Pipeline } from '../../../../utils/pipeline-augment';
+import TriggerTemplateSelector from './TriggerTemplateSelector';
+
+type RemoveTriggerFormProps = {
+  pipeline: Pipeline;
+};
+
+const RemoveTriggerForm: React.FC<RemoveTriggerFormProps> = (props) => {
+  const { pipeline } = props;
+
+  return (
+    <Split className="odc-modal-content" gutter="md">
+      <SplitItem>
+        <ExclamationTriangleIcon size="md" color={warningColor.value} />
+      </SplitItem>
+      <SplitItem isFilled>
+        <p className="co-break-word">
+          Select the trigger to remove from pipeline <b>{pipeline.metadata.name}</b>.
+        </p>
+        <TriggerTemplateSelector
+          name="selectedTrigger"
+          placeholder="Select Trigger Template"
+          pipeline={pipeline}
+        />
+      </SplitItem>
+    </Split>
+  );
+};
+
+export default RemoveTriggerForm;

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/RemoveTriggerModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/RemoveTriggerModal.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { Formik, FormikHelpers } from 'formik';
+import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
+import { Pipeline } from '../../../../utils/pipeline-augment';
+import ModalStructure from '../common/ModalStructure';
+import RemoveTriggerForm from './RemoveTriggerForm';
+import { removeTrigger } from './remove-utils';
+import { RemoveTriggerFormValues } from './types';
+import { removeTriggerSchema } from './validation-utils';
+
+type RemoveTriggerModalProps = ModalComponentProps & {
+  pipeline: Pipeline;
+};
+
+const RemoveTriggerModal: React.FC<RemoveTriggerModalProps> = ({ pipeline, close }) => {
+  const initialValues: RemoveTriggerFormValues = {
+    selectedTrigger: null,
+  };
+
+  const handleSubmit = (
+    values: RemoveTriggerFormValues,
+    actions: FormikHelpers<RemoveTriggerFormValues>,
+  ) => {
+    actions.setSubmitting(true);
+
+    removeTrigger(values, pipeline)
+      .then(() => {
+        actions.setSubmitting(false);
+        close();
+      })
+      .catch((e) => {
+        actions.setSubmitting(false);
+        actions.setStatus({ submitError: e.message });
+      });
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      validationSchema={removeTriggerSchema}
+    >
+      {(props) => (
+        <ModalStructure
+          {...props}
+          submitBtnText="Remove"
+          submitDanger
+          title="Remove Trigger"
+          close={close}
+        >
+          <RemoveTriggerForm pipeline={pipeline} />
+        </ModalStructure>
+      )}
+    </Formik>
+  );
+};
+
+export default createModalLauncher(RemoveTriggerModal);

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/TriggerTemplateSelector.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/TriggerTemplateSelector.scss
@@ -1,0 +1,9 @@
+.odc-trigger-template-selector {
+  &__confirmationMessage {
+    padding: var(--pf-global--spacer--md) 0;
+  }
+
+  &__pfModalHack {
+    padding: var(--pf-global--spacer--md);
+  }
+}

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/TriggerTemplateSelector.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/TriggerTemplateSelector.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { useField } from 'formik';
+import { DropdownField } from '@console/shared/src';
+import { Pipeline } from '../../../../utils/pipeline-augment';
+import { RouteTemplate, usePipelineTriggerTemplateNames } from '../../utils/triggers';
+
+import './TriggerTemplateSelector.scss';
+
+type TriggerTemplateSelectorProps = {
+  name: string;
+  pipeline: Pipeline;
+  placeholder: string;
+};
+
+const TriggerTemplateSelector: React.FC<TriggerTemplateSelectorProps> = (props) => {
+  const { name, pipeline, placeholder } = props;
+
+  const [field] = useField(name);
+  const selection = field.value;
+
+  const templateNames: RouteTemplate[] = usePipelineTriggerTemplateNames(pipeline) || [];
+  const items = templateNames.reduce(
+    (acc, { triggerTemplateName }) => ({ ...acc, [triggerTemplateName]: triggerTemplateName }),
+    {},
+  );
+
+  return (
+    <div className="odc-trigger-template-selector">
+      <DropdownField
+        fullWidth
+        disabled={templateNames.length === 0}
+        items={items}
+        name={name}
+        title={placeholder}
+      />
+      {selection ? (
+        <div className="co-break-word odc-trigger-template-selector__confirmationMessage">
+          Are you sure you want to remove <b>{selection}</b> from <b>{pipeline.metadata.name}</b>?
+        </div>
+      ) : (
+        <div className="odc-trigger-template-selector__pfModalHack" />
+      )}
+    </div>
+  );
+};
+
+export default TriggerTemplateSelector;

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/remove-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/remove-utils.ts
@@ -1,0 +1,52 @@
+import { k8sKill, k8sList, k8sPatch } from '@console/internal/module/k8s';
+import { EventListenerModel, TriggerTemplateModel } from '../../../../models';
+import { Pipeline } from '../../../../utils/pipeline-augment';
+import { EventListenerKind } from '../../resource-types';
+import { RemoveTriggerFormValues } from './types';
+
+export const removeTrigger = async (values: RemoveTriggerFormValues, pipeline: Pipeline) => {
+  const ns = pipeline.metadata.namespace;
+  const selectedTriggerTemplate = values.selectedTrigger;
+
+  // Remove the selected TriggerTemplate
+  await k8sKill(TriggerTemplateModel, {
+    metadata: { name: selectedTriggerTemplate, namespace: ns },
+  });
+
+  const triggerMatchesTriggerTemplate = ({ template: { name } }) =>
+    name === selectedTriggerTemplate;
+
+  // Get all the event listeners so we can update their references
+  const eventListeners: EventListenerKind[] = await k8sList(EventListenerModel, { ns });
+  const matchingEventListeners = eventListeners.filter(({ spec: { triggers } }) =>
+    triggers.find(triggerMatchesTriggerTemplate),
+  );
+
+  const singleTriggers = ({ spec: { triggers } }) => triggers.length === 1;
+
+  // Delete all EventListeners that only had the one trigger
+  const deletableEventListeners: EventListenerKind[] = matchingEventListeners.filter(
+    singleTriggers,
+  );
+  await Promise.all(
+    deletableEventListeners.map((eventListener) => k8sKill(EventListenerModel, eventListener)),
+  );
+
+  // Update all EventListeners that had more than one trigger
+  const updatableEventListeners: EventListenerKind[] = matchingEventListeners.filter(
+    (eventListener) => !singleTriggers(eventListener),
+  );
+  await Promise.all(
+    updatableEventListeners.map((eventListener) =>
+      k8sPatch(EventListenerModel, eventListener, [
+        {
+          opt: 'replace',
+          path: '/spec/triggers',
+          value: eventListener.spec.triggers.filter(triggerMatchesTriggerTemplate),
+        },
+      ]),
+    ),
+  );
+
+  return Promise.resolve();
+};

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/types.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/types.ts
@@ -1,0 +1,5 @@
+import { FormikValues } from 'formik';
+
+export type RemoveTriggerFormValues = FormikValues & {
+  selectedTrigger: string;
+};

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/validation-utils.ts
@@ -1,0 +1,5 @@
+import * as yup from 'yup';
+
+export const removeTriggerSchema = yup.object().shape({
+  selectedTrigger: yup.string().required('Required'),
+});

--- a/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/utils/triggers.ts
@@ -79,7 +79,7 @@ export type RouteTemplate = {
 };
 
 export const usePipelineTriggerTemplateNames = (pipeline: Pipeline): RouteTemplate[] | null => {
-  const eventListenerResources: EventListenerKind[] = useAllEventListeners(pipeline);
+  const eventListenerResources = useAllEventListeners(pipeline);
   const {
     metadata: { namespace },
   } = pipeline;
@@ -87,7 +87,11 @@ export const usePipelineTriggerTemplateNames = (pipeline: Pipeline): RouteTempla
     if (!eventListenerResources) {
       return {};
     }
-    return flatten(eventListenerResources.map(getEventListenerTemplateNames)).reduce(
+    return flatten(
+      eventListenerResources.map((el: EventListenerKind) =>
+        el.spec.triggers.map((elTrigger: EventListenerKindTrigger) => elTrigger.template.name),
+      ),
+    ).reduce(
       (resourceMap, triggerTemplateName: string) => ({
         ...resourceMap,
         [triggerTemplateName]: {

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -8,6 +8,7 @@ import {
 import { k8sCreate, K8sKind, k8sPatch, referenceForModel } from '@console/internal/module/k8s';
 import { errorModal } from '@console/internal/components/modals';
 import { getRandomChars } from '@console/shared/src/utils';
+import { removeTriggerModal } from '../components/pipelines/modals';
 import { PipelineModel, PipelineRunModel } from '../models';
 import startPipelineModal from '../components/pipelines/pipeline-form/StartPipelineModal';
 import { Pipeline, PipelineRun } from './pipeline-augment';
@@ -266,15 +267,30 @@ export const stopPipelineRun: KebabAction = (kind: K8sKind, pipelineRun: Pipelin
   };
 };
 
-export const getPipelineKebabActions = (pipelineRun?: PipelineRun): KebabAction[] => [
-  (model, resource: Pipeline) => startPipeline(model, resource, handlePipelineRunSubmit),
-  ...(pipelineRun ? [() => rerunPipelineAndRedirect(PipelineRunModel, pipelineRun)] : []),
-  editPipeline,
-  Kebab.factory.Delete,
-];
+const removeTrigger: KebabAction = (kind: K8sKind, pipeline: Pipeline) => ({
+  label: 'Remove Trigger',
+  callback: () => {
+    removeTriggerModal({ pipeline });
+  },
+  accessReview: {
+    group: kind.apiGroup,
+    resource: kind.plural,
+    name: pipeline.metadata.name,
+    namespace: pipeline.metadata.namespace,
+    verb: 'delete',
+  },
+});
 
 export const getPipelineRunKebabActions = (redirectReRun?: boolean): KebabAction[] => [
   redirectReRun ? rerunPipelineRunAndRedirect : reRunPipelineRun,
   stopPipelineRun,
+  Kebab.factory.Delete,
+];
+
+export const getPipelineKebabActions = (pipelineRun?: PipelineRun): KebabAction[] => [
+  (model, resource: Pipeline) => startPipeline(model, resource, handlePipelineRunSubmit),
+  ...(pipelineRun ? [() => rerunPipelineAndRedirect(PipelineRunModel, pipelineRun)] : []),
+  removeTrigger,
+  editPipeline,
   Kebab.factory.Delete,
 ];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3349

**Analysis / Root cause**: 
Need a way to remove the triggers we add.

**Solution Description**: 
Remove trigger modal.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux

Empty state seems lame... Probably should find a way not to show the modal... but it requires fetching to find out that information... 🤔 
![Screen Shot 2020-04-12 at 2 45 34 PM](https://user-images.githubusercontent.com/8126518/79077055-67828100-7ccc-11ea-9fb3-e29590a33d6f.png)

I added a minor gap slightly smaller than a single line message to hack our way around PatternFly and their dropdown/modal issue:
![Screen Shot 2020-04-12 at 2 45 56 PM](https://user-images.githubusercontent.com/8126518/79077056-681b1780-7ccc-11ea-8e7f-79fdeeedb44f.png)

Selected and ready to remove:
![Screen Shot 2020-04-12 at 2 46 05 PM](https://user-images.githubusercontent.com/8126518/79077057-68b3ae00-7ccc-11ea-8811-ccff83bc9690.png)

**Unit test coverage report**: 

- [ ] Likely some components that can be tested here

**Test setup:**

* Install Pipelines Operator
* Have a trigger installed
* Remove

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge