### PR TITLE
adds help text to schedule and makes data optional field

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/__tests__/eventSource-validation-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/components/add/__tests__/eventSource-validation-utils.spec.ts
@@ -1,34 +1,36 @@
-import { cloneDeep } from 'lodash';
+import * as _ from 'lodash';
 import { eventSourceValidationSchema } from '../eventSource-validation-utils';
 import { getDefaultEventingData } from '../../../utils/__tests__/knative-serving-data';
 import { EventSources } from '../import-types';
 
 describe('Event Source ValidationUtils', () => {
-  it('should validate the form data', async () => {
-    const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
-    const mockData = cloneDeep(defaultEventingData);
-    await eventSourceValidationSchema
-      .isValid(mockData)
-      .then((valid) => expect(valid).toEqual(true));
-  });
+  describe('CronJobSource : Event Source Validation', () => {
+    it('should validate the form data', async () => {
+      const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
+      const mockData = _.omit(_.cloneDeep(defaultEventingData), 'data.cronjobsource.data');
+      await eventSourceValidationSchema
+        .isValid(mockData)
+        .then((valid) => expect(valid).toEqual(true));
+    });
 
-  it('should throw an error for required fields if empty', async () => {
-    const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
-    const mockData = cloneDeep(defaultEventingData);
-    mockData.sink.knativeService = '';
-    await eventSourceValidationSchema
-      .isValid(mockData)
-      .then((valid) => expect(valid).toEqual(false));
-    await eventSourceValidationSchema.validate(mockData).catch((err) => {
-      expect(err.message).toBe('Required');
-      expect(err.type).toBe('required');
+    it('should throw an error for required fields if empty', async () => {
+      const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
+      const mockData = _.cloneDeep(defaultEventingData);
+      mockData.sink.knativeService = '';
+      await eventSourceValidationSchema
+        .isValid(mockData)
+        .then((valid) => expect(valid).toEqual(false));
+      await eventSourceValidationSchema.validate(mockData).catch((err) => {
+        expect(err.message).toBe('Required');
+        expect(err.type).toBe('required');
+      });
     });
   });
 
   describe('ApiServerSource : Event Source Validation', () => {
     it('should validate the form data', async () => {
       const defaultEventingData = getDefaultEventingData(EventSources.ApiServerSource);
-      const mockData = cloneDeep(defaultEventingData);
+      const mockData = _.cloneDeep(defaultEventingData);
       await eventSourceValidationSchema
         .isValid(mockData)
         .then((valid) => expect(valid).toEqual(true));
@@ -36,7 +38,7 @@ describe('Event Source ValidationUtils', () => {
 
     it('should throw an error for required fields if empty', async () => {
       const defaultEventingData = getDefaultEventingData(EventSources.ApiServerSource);
-      const mockData = cloneDeep(defaultEventingData);
+      const mockData = _.cloneDeep(defaultEventingData);
       mockData.sink.knativeService = '';
       mockData.data.apiserversource.resources[0] = { apiVersion: '', kind: '' };
       await eventSourceValidationSchema
@@ -52,7 +54,7 @@ describe('Event Source ValidationUtils', () => {
   describe('KafkaSource : Event Source Validation', () => {
     it('should validate the form data', async () => {
       const defaultEventingData = getDefaultEventingData(EventSources.KafkaSource);
-      const mockData = cloneDeep(defaultEventingData);
+      const mockData = _.cloneDeep(defaultEventingData);
       await eventSourceValidationSchema
         .isValid(mockData)
         .then((valid) => expect(valid).toEqual(true));
@@ -60,7 +62,7 @@ describe('Event Source ValidationUtils', () => {
 
     it('should throw an error for required fields if empty', async () => {
       const defaultEventingData = getDefaultEventingData(EventSources.KafkaSource);
-      const mockData = cloneDeep(defaultEventingData);
+      const mockData = _.cloneDeep(defaultEventingData);
       mockData.data.kafkasource.bootstrapServers = '';
       await eventSourceValidationSchema
         .isValid(mockData)

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/CronJobSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/CronJobSection.tsx
@@ -5,11 +5,12 @@ import FormSection from '@console/dev-console/src/components/import/section/Form
 
 const CronJobSection: React.FC = () => (
   <FormSection title="CronJobSource">
-    <InputField type={TextInputTypes.text} name="data.cronjobsource.data" label="Data" required />
+    <InputField type={TextInputTypes.text} name="data.cronjobsource.data" label="Data" />
     <InputField
       type={TextInputTypes.text}
       name="data.cronjobsource.schedule"
       label="Schedule"
+      helpText="Schedule is described using the unix-cron string format (* * * * *)"
       required
     />
   </FormSection>

--- a/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
+++ b/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
@@ -16,10 +16,7 @@ export const sourceDataSpecSchema = yup
     is: EventSources.CronJobSource,
     then: yup.object().shape({
       cronjobsource: yup.object().shape({
-        data: yup
-          .string()
-          .max(253, 'Cannot be longer than 253 characters.')
-          .required('Required'),
+        data: yup.string().max(253, 'Cannot be longer than 253 characters.'),
         schedule: yup
           .string()
           .max(253, 'Cannot be longer than 253 characters.')

--- a/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/create-eventsources-utils.spec.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import {
   ServiceModel,
@@ -13,7 +13,7 @@ import { EventSources } from '../../components/add/import-types';
 describe('Create knative Utils', () => {
   it('expect response to be of kind CronJobSource with proper ApiGroup', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
-    const mockData = cloneDeep(defaultEventingData);
+    const mockData = _.cloneDeep(defaultEventingData);
     const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
     expect(knEventingResource.kind).toBe(EventSourceCronJobModel.kind);
     expect(knEventingResource.apiVersion).toBe(
@@ -21,17 +21,16 @@ describe('Create knative Utils', () => {
     );
   });
 
-  it('expect response to data and schedule in spec for CronJobSource', () => {
+  it('expect response to schedule in spec for CronJobSource', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
-    const mockData = cloneDeep(defaultEventingData);
+    const mockData = _.cloneDeep(defaultEventingData);
     const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
-    expect(knEventingResource.spec.data).toBe('hello');
     expect(knEventingResource.spec.schedule).toBe('* * * * *');
   });
 
   it('expect response for sink to be of kind knative service', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
-    const mockData = cloneDeep(defaultEventingData);
+    const mockData = _.cloneDeep(defaultEventingData);
     const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
     expect(knEventingResource.spec.sink.ref.kind).toBe(ServiceModel.kind);
     expect(knEventingResource.spec.sink.ref.apiVersion).toBe(
@@ -41,7 +40,7 @@ describe('Create knative Utils', () => {
 
   it('expect response to be of kind sinkBinding with proper ApiGroup', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.CronJobSource);
-    const mockData = cloneDeep(defaultEventingData);
+    const mockData = _.cloneDeep(defaultEventingData);
     mockData.type = 'SinkBinding';
     const knEventingResource: K8sResourceKind = getEventSourceResource(mockData);
     expect(knEventingResource.kind).toBe(EventSourceSinkBindingModel.kind);
@@ -52,7 +51,7 @@ describe('Create knative Utils', () => {
 
   it('expect response to be of kind kafkaSource with resource limits', () => {
     const defaultEventingData = getDefaultEventingData(EventSources.KafkaSource);
-    const mockData = cloneDeep(defaultEventingData);
+    const mockData = _.cloneDeep(defaultEventingData);
     mockData.type = 'KafkaSource';
     mockData.limits.cpu.limit = '200';
     mockData.limits.cpu.request = '100';

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -326,7 +326,7 @@ export const deploymentKnativeEventData: K8sResourceKind = {
 
 const eventSourceData = {
   cronjobsource: {
-    data: 'hello',
+    data: '',
     schedule: '* * * * *',
   },
   apiserversource: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3546

**Analysis / Root cause**: 
Missing help text for Schedule and data will not be a required field

**Solution Description**: 
In CronJob Source form added help text for schedule as  "Schedule is described using the unix-cron string format (* * * * *)" and data won't be a required field

**Screen shots / Gifs for design review**: 
<img width="897" alt="Screenshot 2020-04-13 at 11 04 17 AM" src="https://user-images.githubusercontent.com/5129024/79096429-ca325600-7d7a-11ea-890b-0defcee30bd1.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
