### PR TITLE
OCS installation changes for baremetal infra

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/_add-capacity-modal.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/modals/add-capacity-modal/_add-capacity-modal.scss
@@ -30,9 +30,11 @@
   padding-top: 2em;
 }
 
-.ceph-add-capacity_sc-dropdown {
+.ceph-add-capacity__sc-dropdown {
   width: 16rem;
-  margin-bottom: 1rem;
+  &--margin {
+    margin-bottom: 1rem;
+  }
 }
 
 .ceph-add-capacity__sc-dropdown--hide {

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/pvs-available-capacity.scss
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/pvs-available-capacity.scss
@@ -1,0 +1,4 @@
+.ceph-pvs-available-capacity__current-capacity--loading {
+  width: 8rem;
+  margin-top: 0.2rem;
+}

--- a/frontend/packages/ceph-storage-plugin/src/components/ocs-install/pvs-available-capacity.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/ocs-install/pvs-available-capacity.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { StorageClassResourceKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { humanizeBinaryBytes } from '@console/internal/components/utils/';
+import { getName } from '@console/shared';
+import { pvResource } from '../../constants/resources';
+import { calcPVsCapacity, getSCAvailablePVs } from '../../selectors';
+import '../modals/add-capacity-modal/_add-capacity-modal.scss';
+import './pvs-available-capacity.scss';
+
+export const PVsAvailableCapacity: React.FC<PVAvaialbleCapacityProps> = ({ replica, sc }) => {
+  const [data, loaded, loadError] = useK8sWatchResource<K8sResourceKind[]>(pvResource);
+  let availableCapacity: string = '';
+
+  let availableStatusEl = (
+    <div className="skeleton-text ceph-pvs-available-capacity__current-capacity--loading" />
+  );
+
+  if ((loadError || data.length === 0) && loaded) {
+    availableStatusEl = <div className="text-muted">Not Available</div>;
+  } else if (loaded) {
+    const pvs = getSCAvailablePVs(data, getName(sc));
+    availableCapacity = humanizeBinaryBytes(calcPVsCapacity(pvs)).string;
+    availableStatusEl = <div>{`${availableCapacity} / ${replica} replicas`}</div>;
+  }
+
+  return (
+    <div className="ceph-add-capacity__current-capacity">
+      <div className="text-secondary ceph-add-capacity__current-capacity--text">
+        <strong>Available capacity:</strong>
+      </div>
+      {availableStatusEl}
+    </div>
+  );
+};
+
+type PVAvaialbleCapacityProps = {
+  replica: string;
+  sc: StorageClassResourceKind;
+};

--- a/frontend/packages/ceph-storage-plugin/src/constants/index.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/index.ts
@@ -10,3 +10,4 @@ export const BY_USED = 'By Used Capacity';
 export const BY_REQUESTED = 'By Requested Capacity';
 export const OCS_OPERATOR = 'ocs-operator';
 export const OCS_INDEPENDENT_CR_NAME = 'ocs-independent-storagecluster';
+export const NO_PROVISIONER = 'kubernetes.io/no-provisioner';

--- a/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/ocs-install.ts
@@ -51,3 +51,8 @@ export const infraProvisionerMap = {
   aws: 'kubernetes.io/aws-ebs',
   vsphere: 'kubernetes.io/vsphere-volume',
 };
+
+export enum defaultRequestSize {
+  BAREMETAL = '1',
+  NON_BAREMETAL = '2Ti',
+}

--- a/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
+++ b/frontend/packages/ceph-storage-plugin/src/constants/resources.ts
@@ -1,5 +1,7 @@
 import { FirehoseResource } from '@console/internal/components/utils/index';
 import { referenceForModel } from '@console/internal/module/k8s/k8s';
+import { PersistentVolumeModel } from '@console/internal/models';
+import { WatchK8sResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { CephClusterModel } from '../models';
 
 export const cephClusterResource: FirehoseResource = {
@@ -7,4 +9,10 @@ export const cephClusterResource: FirehoseResource = {
   namespaced: false,
   isList: true,
   prop: 'ceph',
+};
+
+export const pvResource: WatchK8sResource = {
+  kind: PersistentVolumeModel.kind,
+  namespaced: false,
+  isList: true,
 };


### PR DESCRIPTION
With OCS Baremetal cluster support in picture, following changes are required in ocs installation and add-capacity view -
For no-provisioner storage class(created by LSO flow), requested capacity should not be shown as dynamically provision of storage is not possible

Views look like below(for baremetal infra) -
![ocs-install-baremetal](https://user-images.githubusercontent.com/5517376/79120514-093dc700-7dce-11ea-8771-33fd5cf330ef.png)
![add-capacity](https://user-images.githubusercontent.com/5517376/79120521-0c38b780-7dce-11ea-8c8f-9a8b010dd464.png)
