### PR TITLE
Bug 1823451: Fix error handling in coFetch to return json.error

### DIFF
--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -65,10 +65,10 @@ const validateStatus = (response, url) => {
       reason = json.message;
     }
     if (!reason) {
-      reason = response.statusText;
+      reason = json.error;
     }
     if (!reason) {
-      reason = json.error;
+      reason = response.statusText;
     }
     const error = new Error(reason);
     error.response = response;


### PR DESCRIPTION
## Fixes - https://issues.redhat.com/browse/ODC-3539

## This PR -
- Changes the order of setting error message from an HTTP response. 
- `json.error` is given priority to `response.statusText`

## Screenshots - 

### Before --
![Screenshot from 2020-04-13 23-44-39](https://user-images.githubusercontent.com/6041994/79146951-cdf8c380-7de0-11ea-9c68-17eba388e760.png)

### After --
![Screenshot from 2020-04-13 23-44-03](https://user-images.githubusercontent.com/6041994/79146946-ccc79680-7de0-11ea-87a4-c0ba97efc826.png)
