### PR TITLE
Add pf datatoolbar to search

### DIFF
--- a/frontend/public/components/search-filter-dropdown.tsx
+++ b/frontend/public/components/search-filter-dropdown.tsx
@@ -38,29 +38,27 @@ export const SearchFilterDropdown: React.SFC<SearchFilterDropdownProps> = (props
   };
 
   return (
-    <div className="form-group co-search-group__filter">
-      <div className="pf-c-input-group">
-        <Dropdown
-          onSelect={onSelect}
-          toggle={
-            <DropdownToggle id="toggle-id" onToggle={onToggle} iconComponent={CaretDownIcon}>
-              <>
-                <FilterIcon className="span--icon__right-margin" /> {selected}
-              </>
-            </DropdownToggle>
-          }
-          isOpen={isOpen}
-          dropdownItems={dropdownItems}
-        />
-        <TextInput
-          onChange={handleInputValue}
-          placeholder={selected === searchFilterValues.Label ? 'app=frontend' : 'my-resource'}
-          name="search-filter-input"
-          id="search-filter-input"
-          value={selected === searchFilterValues.Label ? labelFilterInput : nameFilterInput}
-          onKeyDown={handleKeyDown}
-        />
-      </div>
+    <div className="pf-c-input-group">
+      <Dropdown
+        onSelect={onSelect}
+        toggle={
+          <DropdownToggle id="toggle-id" onToggle={onToggle} iconComponent={CaretDownIcon}>
+            <>
+              <FilterIcon className="span--icon__right-margin" /> {selected}
+            </>
+          </DropdownToggle>
+        }
+        isOpen={isOpen}
+        dropdownItems={dropdownItems}
+      />
+      <TextInput
+        onChange={handleInputValue}
+        placeholder={selected === searchFilterValues.Label ? 'app=frontend' : 'my-resource'}
+        name="search-filter-input"
+        id="search-filter-input"
+        value={selected === searchFilterValues.Label ? labelFilterInput : nameFilterInput}
+        onKeyDown={handleKeyDown}
+      />
     </div>
   );
 };

--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -234,6 +234,12 @@ h6 {
   }
 
   // `.pf-c-page` specificity required
+  .pf-c-data-toolbar {
+    --pf-c-data-toolbar--PaddingTop: 0;
+    --pf-c-data-toolbar__content--PaddingLeft: 0;
+    --pf-c-data-toolbar__content--PaddingRight: 0;
+  }
+
   .pf-c-page__main-section {
     --pf-c-page__main-section--PaddingBottom: 0;
     --pf-c-page__main-section--PaddingLeft: 0;

--- a/frontend/public/vendor.scss
+++ b/frontend/public/vendor.scss
@@ -49,6 +49,7 @@
 @import "~@patternfly/patternfly/components/Form/form";
 @import "~@patternfly/patternfly/components/FormControl/form-control";
 @import "~@patternfly/patternfly/components/InputGroup/input-group";
+@import "~@patternfly/patternfly/components/DataToolbar/data-toolbar";
 @import "~@patternfly/patternfly/components/NotificationBadge/notification-badge";
 @import "~@patternfly/patternfly/components/NotificationDrawer/notification-drawer";
 @import "~@patternfly/patternfly/utilities/Sizing/sizing";


### PR DESCRIPTION
Add the patternfly datatoolbar component to search. In the image you see the parity between the current implementation vs the patternfly implementation.

I found that there was an issue with the pf data toolbar, and filed an issue and pr here:
issue: 

Issue: https://github.com/patternfly/patternfly-react/issues/4059
PR: https://github.com/patternfly/patternfly-react/pull/4060
View the DataToolbar with remove all in filter here (see the status filter in the example): https://patternfly-react-pr-4060.surge.sh/documentation/react/components/datatoolbar#data-toolbar-with-filters

![toolbarwip](https://user-images.githubusercontent.com/35978579/79149365-0a9ecd80-7d95-11ea-93bb-ee02081dd03f.gif)
