### PR TITLE
Bug 1823252: spaces are needed for the error message when selected namespace does not support installation mode

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -302,8 +302,8 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
         >
           The operator group in the {selectedTargetNamespace} namespace does not support the
           {selectedInstallMode === InstallModeType.InstallModeTypeAllNamespaces
-            ? 'global'
-            : 'single namespace'}
+            ? ' global '
+            : ' single namespace '}
           installation mode.
         </Alert>
       )) ||


### PR DESCRIPTION
/assign @spadgett 