### PR TITLE
Bug 1823714: Fix display of APIcast

### DIFF
--- a/frontend/__tests__/module/k8s/get-resources.spec.ts
+++ b/frontend/__tests__/module/k8s/get-resources.spec.ts
@@ -7,6 +7,7 @@ describe('kindToLabel', () => {
     });
   };
 
+  testKindToLabel('APIcast', 'APIcast');
   testKindToLabel('DNS', 'DNS');
   testKindToLabel('DNSRecord', 'DNS Record');
   testKindToLabel('DeploymentConfig', 'Deployment Config');

--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -83,7 +83,9 @@ export type DiscoveryResources = {
 };
 
 export const kindToLabel = (kind: string): string => {
-  return _.startCase(kind).replace(/\bO Auth\b/, 'OAuth');
+  return _.startCase(kind)
+    .replace(/\bAP Icast\b/, 'APIcast')
+    .replace(/\bO Auth\b/, 'OAuth');
 };
 
 export const pluralizeKind = (kind: string): string => {


### PR DESCRIPTION
Bug caused by #4947.  Perhaps there are other special cases?

After:
<img width="737" alt="Screen Shot 2020-04-14 at 9 37 35 AM" src="https://user-images.githubusercontent.com/895728/79231450-11305200-7e34-11ea-82b7-e8dd675b973d.png">
<img width="688" alt="Screen Shot 2020-04-14 at 9 37 46 AM" src="https://user-images.githubusercontent.com/895728/79231451-11c8e880-7e34-11ea-80b4-3168a1b26a83.png">
