### PR TITLE
Bug 1823297: Change default bus to SCSI for CD-ROM drives added from details tab

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-cdrom-patches.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/patches/vm/vm-cdrom-patches.ts
@@ -18,7 +18,7 @@ import {
   getBootableDevicesInOrder,
 } from '../../../selectors/vm';
 import { getVMLikePatches } from '../vm-template';
-import { BOOT_ORDER_FIRST, BOOT_ORDER_SECOND } from '../../../constants';
+import { BOOT_ORDER_FIRST, BOOT_ORDER_SECOND, DiskBus } from '../../../constants';
 import { CD } from '../../../components/modals/cdrom-vm-modal/types';
 
 const getNextAvailableBootOrderIndex = (vm: VMLikeEntityKind) => {
@@ -60,7 +60,7 @@ export const getCDsPatch = (
       const disk: CD = {
         name,
         bootOrder: existingCD ? bootOrder : newBootOrder,
-        cdrom: { bus: bus || 'virtio' },
+        cdrom: { bus: bus || DiskBus.SATA.getValue() },
       };
       let volume: Volume = { name };
       let finalDataVolume;


### PR DESCRIPTION
This PR changes the default bus used for CD-ROM drives added from the VM details tab from VIRTIO to SCSI.