### PR TITLE
Bug 1823854: Use ordered-values.yaml in Helm install/upgrade

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
@@ -9,9 +9,7 @@ import HelmChartVersionDropdown from './HelmChartVersionDropdown';
 
 export interface HelmInstallUpgradeFormProps {
   chartHasValues: boolean;
-  activeChartVersion?: string;
   submitLabel: string;
-  chartName: string;
 }
 
 const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUpgradeFormProps> = ({
@@ -21,11 +19,11 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
   handleReset,
   status,
   isSubmitting,
-  activeChartVersion,
-  chartName,
   submitLabel,
+  values,
   dirty,
 }) => {
+  const { chartName, chartVersion } = values;
   return (
     <FlexForm onSubmit={handleSubmit}>
       <FormSection fullWidth>
@@ -37,14 +35,11 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
               label="Release Name"
               helpText="A unique name for the Helm Chart release."
               required
-              isDisabled={!_.isEmpty(activeChartVersion)}
+              isDisabled={!!chartVersion}
             />
           </GridItem>
-          {activeChartVersion && (
-            <HelmChartVersionDropdown
-              activeChartVersion={activeChartVersion}
-              chartName={chartName}
-            />
+          {chartVersion && (
+            <HelmChartVersionDropdown chartName={chartName} chartVersion={chartVersion} />
           )}
         </Grid>
       </FormSection>
@@ -54,7 +49,7 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
         errorMessage={status && status.submitError}
         isSubmitting={isSubmitting}
         submitLabel={submitLabel}
-        disableSubmit={(activeChartVersion && !dirty) || !_.isEmpty(errors)}
+        disableSubmit={(chartVersion && !dirty) || !_.isEmpty(errors)}
         resetLabel="Cancel"
       />
     </FlexForm>

--- a/frontend/packages/dev-console/src/components/helm/form/__tests__/HelmInstallUpgradeForm.spec.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/__tests__/HelmInstallUpgradeForm.spec.tsx
@@ -9,15 +9,19 @@ let helmInstallUpgradeFormProps: React.ComponentProps<typeof HelmInstallUpgradeF
 describe('HelmInstallUpgradeForm', () => {
   helmInstallUpgradeFormProps = {
     chartHasValues: true,
-    chartName: 'helm-release',
-    activeChartVersion: null,
     submitLabel: 'Install',
-    values: {},
+    values: {
+      helmReleaseName: 'helm-release',
+      chartName: 'helm-release',
+      chartValuesYAML: 'chart-yaml-values',
+      chartVersion: '',
+    },
     errors: {},
     touched: {},
     isValid: true,
     initialValues: {
       helmReleaseName: 'helm-release',
+      chartName: 'helm-release',
       chartValuesYAML: 'chart-yaml-values',
       chartVersion: '0.3',
     },
@@ -67,7 +71,7 @@ describe('HelmInstallUpgradeForm', () => {
   });
 
   it('should render the Dropdown Field component when active version exists', () => {
-    helmInstallUpgradeFormProps.activeChartVersion = '0.1';
+    helmInstallUpgradeFormProps.values.chartVersion = '0.1';
     helmInstallUpgradeForm = shallow(<HelmInstallUpgradeForm {...helmInstallUpgradeFormProps} />);
     expect(helmInstallUpgradeForm.find(HelmChartVersionDropdown).exists()).toBe(true);
   });

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -1,9 +1,11 @@
 import * as fuzzy from 'fuzzysearch';
 import * as _ from 'lodash';
+import { safeDump } from 'js-yaml';
 import { coFetchJSON } from '@console/internal/co-fetch';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import {
   HelmRelease,
+  HelmChart,
   HelmReleaseStatus,
   HelmChartMetaData,
   HelmActionType,
@@ -126,3 +128,12 @@ export const flattenReleaseResources = (resources: { [kind: string]: { data: K8s
     }
     return acc;
   }, []);
+
+export const getChartValuesYAML = (chart: HelmChart): string => {
+  const orderedValuesFile = chart?.files?.find((file) => file.name === 'ordered-values.yaml');
+  const orderedValues = orderedValuesFile ? atob(orderedValuesFile.data) : '';
+
+  if (orderedValues) return orderedValues;
+
+  return !_.isEmpty(chart?.values) ? safeDump(chart?.values) : '';
+};


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3485
Fixes - https://github.com/openshift/console/issues/4736

This PR -
- Updates the logic of getting chart values in Helm Install/Upgrade form.
- Now the form gives a preference to `ordered-values.yaml`

Screenshot - 
![Screenshot from 2020-04-14 21-31-42](https://user-images.githubusercontent.com/6041994/79246822-52a61900-7e97-11ea-8f5c-ea949de57700.png)
