### PR TITLE
Add health checks in advanced options

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
@@ -4,6 +4,8 @@ import { ServiceModel } from '@console/knative-plugin';
 import { UNASSIGNED_KEY } from '../../../const';
 import { DeployImageFormData, GitImportFormData, Resources } from '../../import/import-types';
 import { AppResources } from '../edit-application-types';
+import { healthChecksProbeInitialData } from '../../health-checks/health-check-probe-utils';
+import { healthChecksData } from '../../health-checks/__tests__/create-health-check-probe-data';
 
 export const knativeService: K8sResourceKind = {
   apiVersion: `${ServiceModel.apiGroup}/${ServiceModel.apiVersion}`,
@@ -437,6 +439,7 @@ export const gitImportInitialValues: GitImportFormData = {
     triggers: { webhook: true, image: true, config: true },
     strategy: 'Source',
   },
+  healthChecks: healthChecksProbeInitialData,
 };
 
 export const externalImageValues: DeployImageFormData = {
@@ -511,6 +514,7 @@ export const externalImageValues: DeployImageFormData = {
   },
   build: { env: [], triggers: {}, strategy: '' },
   isSearchingForImage: false,
+  healthChecks: healthChecksProbeInitialData,
 };
 
 export const internalImageValues: DeployImageFormData = {
@@ -585,6 +589,7 @@ export const internalImageValues: DeployImageFormData = {
   },
   build: { env: [], triggers: {}, strategy: '' },
   isSearchingForImage: false,
+  healthChecks: healthChecksProbeInitialData,
 };
 
 export const knAppResources: AppResources = {
@@ -663,4 +668,10 @@ export const knExternalImageValues: DeployImageFormData = {
   },
   searchTerm: 'openshift/hello-openshift',
   serverless: { scaling: { concurrencylimit: '', concurrencytarget: '', maxpods: '', minpods: 0 } },
+  healthChecks: healthChecksProbeInitialData,
+};
+
+export const gitImportInitialValuesWithHealthChecksEnabled: GitImportFormData = {
+  ...gitImportInitialValues,
+  healthChecks: healthChecksData,
 };

--- a/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/edit-application-utils.ts
@@ -13,6 +13,7 @@ import { UNASSIGNED_KEY } from '../../const';
 import { Resources, DeploymentData } from '../import/import-types';
 import { AppResources } from './edit-application-types';
 import { RegistryType } from '../../utils/imagestream-utils';
+import { getHealthChecksData } from '../health-checks/create-health-check-probe-utils';
 
 export enum CreateApplicationFlow {
   Git = 'Import from Git',
@@ -246,6 +247,7 @@ export const getCommonInitialValues = (
     deployment: getDeploymentData(editAppResource),
     labels: getUserLabels(editAppResource),
     limits: getLimitsData(editAppResource),
+    healthChecks: getHealthChecksData(editAppResource),
   };
   return commonInitialValues;
 };

--- a/frontend/packages/dev-console/src/components/health-checks/HealthCheckProbe.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/HealthCheckProbe.tsx
@@ -4,8 +4,13 @@ import { PlusCircleIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { GreenCheckCircleIcon } from '@console/shared';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import ProbeForm from './ProbeForm';
-import { getHealthChecksProbeConfig } from './health-check-probe-utils';
+import {
+  getHealthChecksProbeConfig,
+  getContainerPorts,
+  healthChecksDefaultValues,
+} from './health-check-probe-utils';
 import './HealthCheckProbe.scss';
+import { HealthCheckProbeData } from './health-checks-types';
 
 interface HealthCheckProbeProps {
   probeType: string;
@@ -13,23 +18,29 @@ interface HealthCheckProbeProps {
 
 const HealthCheckProbe: React.FC<HealthCheckProbeProps> = ({ probeType }) => {
   const {
-    values: { healthChecks },
+    values: {
+      image: { ports },
+      healthChecks,
+    },
     setFieldValue,
-    initialValues,
   } = useFormikContext<FormikValues>();
+  const [temporaryProbeData, setTemporaryProbeData] = React.useState<HealthCheckProbeData>();
   const onEditProbe = () => {
     setFieldValue(`healthChecks.${probeType}.showForm`, true);
+    setTemporaryProbeData(healthChecks?.[probeType].data);
   };
 
   const handleDeleteProbe = () => {
-    setFieldValue(`healthChecks.${probeType}`, initialValues.healthChecks[probeType]);
+    setFieldValue(`healthChecks.${probeType}`, healthChecksDefaultValues);
   };
 
   const handleReset = () => {
     if (!healthChecks?.[probeType]?.enabled) {
-      setFieldValue(`healthChecks.${probeType}`, initialValues.healthChecks[probeType]);
+      setFieldValue(`healthChecks.${probeType}`, healthChecksDefaultValues);
+    } else {
+      setFieldValue(`healthChecks.${probeType}.showForm`, false);
+      setFieldValue(`healthChecks.${probeType}.data`, temporaryProbeData);
     }
-    setFieldValue(`healthChecks.${probeType}.showForm`, false);
   };
 
   const handleSubmit = () => {
@@ -43,7 +54,14 @@ const HealthCheckProbe: React.FC<HealthCheckProbeProps> = ({ probeType }) => {
 
   const renderProbe = () => {
     if (healthChecks?.[probeType]?.showForm) {
-      return <ProbeForm onSubmit={handleSubmit} onClose={handleReset} probeType={probeType} />;
+      return (
+        <ProbeForm
+          onSubmit={handleSubmit}
+          onClose={handleReset}
+          probeType={probeType}
+          containerPorts={getContainerPorts(ports)}
+        />
+      );
     }
     if (healthChecks?.[probeType]?.enabled) {
       return (

--- a/frontend/packages/dev-console/src/components/health-checks/HealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/HealthChecks.tsx
@@ -2,18 +2,22 @@ import * as React from 'react';
 import FormSection from '../import/section/FormSection';
 import HealthCheckProbe from './HealthCheckProbe';
 import { HealthChecksProbeType } from './health-checks-types';
+import { Resources } from '../import/import-types';
 
 interface HealthChecksProps {
   title?: string;
+  resourceType: Resources;
 }
 
-const HealthChecks: React.FC<HealthChecksProps> = ({ title }) => (
+const HealthChecks: React.FC<HealthChecksProps> = ({ title, resourceType }) => (
   <FormSection title={title}>
     <HealthCheckProbe probeType={HealthChecksProbeType.ReadinessProbe} />
 
     <HealthCheckProbe probeType={HealthChecksProbeType.LivenessProbe} />
 
-    <HealthCheckProbe probeType={HealthChecksProbeType.StartupProbe} />
+    {resourceType !== Resources.KnativeService && (
+      <HealthCheckProbe probeType={HealthChecksProbeType.StartupProbe} />
+    )}
   </FormSection>
 );
 

--- a/frontend/packages/dev-console/src/components/health-checks/ProbeForm.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/ProbeForm.tsx
@@ -56,7 +56,7 @@ const ProbeForm: React.FC<ProbeFormProps> = ({ onSubmit, onClose, containerPorts
           name={`healthChecks.${probeType}.data.failureThreshold`}
           label="Failure Threshold"
           style={{ maxWidth: '100%' }}
-          helpText={'How many times the probe will try starting or restarting before giving up.'}
+          helpText="How many times the probe will try starting or restarting before giving up."
         />
         <DropdownField
           name={`healthChecks.${probeType}.data.requestType`}
@@ -99,9 +99,7 @@ const ProbeForm: React.FC<ProbeFormProps> = ({ onSubmit, onClose, containerPorts
           name={`healthChecks.${probeType}.data.successThreshold`}
           label="Success Threshold"
           style={{ maxWidth: '100%' }}
-          helpText={
-            'How many consecutive successes for the probe to be considered successful after having failed.'
-          }
+          helpText="How many consecutive successes for the probe to be considered successful after having failed."
         />
       </FormSection>
       <ActionGroupWithIcons

--- a/frontend/packages/dev-console/src/components/health-checks/__tests__/create-health-check-probe-data.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/__tests__/create-health-check-probe-data.ts
@@ -1,0 +1,92 @@
+import { HealthChecksData } from '../../import/import-types';
+import { RequestType } from '../health-checks-types';
+import { healthChecksDefaultValues } from '../health-check-probe-utils';
+
+export const healthChecksData: HealthChecksData = {
+  readinessProbe: {
+    showForm: false,
+    enabled: true,
+    data: {
+      failureThreshold: 3,
+      requestType: RequestType.HTTPGET,
+      httpGet: {
+        scheme: 'HTTP',
+        path: '/',
+        port: 8080,
+        httpHeaders: [{ name: 'header', value: 'val' }],
+      },
+      initialDelaySeconds: 0,
+      periodSeconds: 10,
+      timeoutSeconds: 1,
+      successThreshold: 1,
+    },
+  },
+  livenessProbe: {
+    showForm: false,
+    enabled: true,
+    data: {
+      failureThreshold: 3,
+      requestType: RequestType.ContainerCommand,
+      exec: { command: ['cat', '/tmp/healthy'] },
+      initialDelaySeconds: 0,
+      periodSeconds: 10,
+      timeoutSeconds: 1,
+      successThreshold: 1,
+    },
+  },
+  startupProbe: healthChecksDefaultValues,
+};
+
+export const healthChecksInputData = {
+  healthChecks: {
+    readinessProbe: {
+      showForm: false,
+      enabled: true,
+      data: {
+        ...healthChecksDefaultValues.data,
+        httpGet: {
+          scheme: 'HTTPS',
+          path: '/tmp/healthy',
+          port: 8080,
+          httpHeaders: [{ name: 'custom-header', value: 'value' }],
+        },
+      },
+    },
+    livenessProbe: healthChecksDefaultValues,
+    startupProbe: {
+      showForm: false,
+      enabled: true,
+      data: {
+        ...healthChecksDefaultValues.data,
+        requestType: RequestType.TCPSocket,
+        tcpSocket: {
+          port: 8081,
+        },
+      },
+    },
+  },
+};
+
+export const enabledProbeData = {
+  readinessProbe: {
+    failureThreshold: 3,
+    httpGet: {
+      httpHeaders: [{ name: 'custom-header', value: 'value' }],
+      path: '/tmp/healthy',
+      port: 8080,
+      scheme: 'HTTPS',
+    },
+    periodSeconds: 10,
+    successThreshold: 1,
+    timeoutSeconds: 1,
+  },
+  startupProbe: {
+    failureThreshold: 3,
+    periodSeconds: 10,
+    successThreshold: 1,
+    tcpSocket: {
+      port: 8081,
+    },
+    timeoutSeconds: 1,
+  },
+};

--- a/frontend/packages/dev-console/src/components/health-checks/__tests__/create-health-check-probe-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/__tests__/create-health-check-probe-utils.spec.ts
@@ -1,0 +1,70 @@
+import * as _ from 'lodash';
+import {
+  healthChecksData,
+  healthChecksInputData,
+  enabledProbeData,
+} from './create-health-check-probe-data';
+import {
+  getHealthChecksData,
+  getRequestType,
+  constructProbeData,
+  getProbesData,
+} from '../create-health-check-probe-utils';
+import { appResources } from '../../edit-application/__tests__/edit-application-data';
+import { Resources } from '../../import/import-types';
+
+describe('Create Health Check probe Utils', () => {
+  const { editAppResource } = appResources;
+  editAppResource.data.spec.template.spec.containers[0].readinessProbe = {
+    failureThreshold: 3,
+    httpGet: {
+      scheme: 'HTTP',
+      path: '/',
+      port: 8080,
+      httpHeaders: [{ name: 'header', value: 'val' }],
+    },
+    initialDelaySeconds: 0,
+    periodSeconds: 10,
+    timeoutSeconds: 1,
+    successThreshold: 1,
+  };
+  editAppResource.data.spec.template.spec.containers[0].livenessProbe = {
+    failureThreshold: 3,
+    exec: { command: ['cat', '/tmp/healthy'] },
+    initialDelaySeconds: 0,
+    periodSeconds: 10,
+    timeoutSeconds: 1,
+    successThreshold: 1,
+  };
+  it('getHealthChecksData should return health checks probe data based on the appresources', () => {
+    expect(getHealthChecksData(editAppResource.data)).toEqual(healthChecksData);
+  });
+  it('getRequestType should return the proper request type from the health check probe data', () => {
+    expect(
+      getRequestType(editAppResource.data.spec.template.spec.containers[0].readinessProbe),
+    ).toEqual('httpGet');
+    expect(
+      getRequestType(editAppResource.data.spec.template.spec.containers[0].livenessProbe),
+    ).toEqual('command');
+  });
+  it('constructProbeData should return the proper health check object from the health checks input data', () => {
+    expect(constructProbeData(healthChecksInputData.healthChecks.readinessProbe.data)).toEqual(
+      enabledProbeData.readinessProbe,
+    );
+    expect(constructProbeData(healthChecksInputData.healthChecks.startupProbe.data)).toEqual(
+      enabledProbeData.startupProbe,
+    );
+  });
+
+  it('getProbesData should return all the enabled probes', () => {
+    expect(getProbesData(healthChecksInputData.healthChecks)).toEqual(enabledProbeData);
+  });
+
+  it('getProbesData should not return startup probes in case of knative service', () => {
+    const enabledProbeDataForKnativeService = _.cloneDeep(enabledProbeData.readinessProbe);
+    enabledProbeDataForKnativeService.httpGet.port = 0;
+    expect(getProbesData(healthChecksInputData.healthChecks, Resources.KnativeService)).toEqual({
+      readinessProbe: enabledProbeDataForKnativeService,
+    });
+  });
+});

--- a/frontend/packages/dev-console/src/components/health-checks/create-health-check-probe-utils.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/create-health-check-probe-utils.ts
@@ -1,0 +1,106 @@
+import * as _ from 'lodash';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { HealthCheckProbeData, RequestType, HealthChecksProbeType } from './health-checks-types';
+import { Resources, HealthChecksData } from '../import/import-types';
+import { healthChecksDefaultValues } from './health-check-probe-utils';
+
+export const constructProbeData = (data: HealthCheckProbeData, resourceType?: Resources) => {
+  const probeData = {
+    ...(data.failureThreshold && { failureThreshold: data.failureThreshold }),
+    ...(data.successThreshold && { successThreshold: data.successThreshold }),
+    ...(data.requestType === RequestType.ContainerCommand && {
+      exec: data.exec,
+    }),
+    ...(data.requestType === RequestType.HTTPGET && {
+      httpGet: {
+        ...data[data.requestType],
+        ...(data[data.requestType]?.scheme?.[0] === 'HTTPS' && {
+          scheme: data[data.requestType].scheme[0],
+        }),
+        port: resourceType === Resources.KnativeService ? 0 : _.toInteger(data.httpGet.port),
+      },
+    }),
+    ...(data.requestType === RequestType.TCPSocket && {
+      tcpSocket: {
+        port: resourceType === Resources.KnativeService ? 0 : _.toInteger(data.tcpSocket.port),
+      },
+    }),
+    ...(data.initialDelaySeconds && {
+      initialDelaySeconds: data.initialDelaySeconds,
+    }),
+    ...(data.periodSeconds && { periodSeconds: data.periodSeconds }),
+    ...(data.timeoutSeconds && { timeoutSeconds: data.timeoutSeconds }),
+  };
+  return probeData;
+};
+
+export const getRequestType = (data: HealthCheckProbeData) => {
+  if (_.has(data, RequestType.HTTPGET)) return RequestType.HTTPGET;
+  if (_.has(data, RequestType.TCPSocket)) return RequestType.TCPSocket;
+  if (_.has(data, 'exec.command')) return RequestType.ContainerCommand;
+  return '';
+};
+
+export const getHealthChecksData = (resource: K8sResourceKind): HealthChecksData => {
+  const containers = resource?.spec?.template?.spec?.containers ?? [];
+  const readinessProbe = containers?.[0]?.[HealthChecksProbeType.ReadinessProbe] ?? {};
+  const livenessProbe = containers?.[0]?.[HealthChecksProbeType.LivenessProbe] ?? {};
+  const startupProbe = containers?.[0]?.[HealthChecksProbeType.StartupProbe] ?? {};
+  const healthChecks = {
+    readinessProbe: {
+      showForm: false,
+      enabled: !_.isEmpty(readinessProbe),
+      data: !_.isEmpty(readinessProbe)
+        ? {
+            ...readinessProbe,
+            requestType: getRequestType(readinessProbe),
+            ...(readinessProbe.httpGet?.scheme === 'HTTPS' && {
+              httpGet: { ...readinessProbe.httpGet, scheme: ['HTTPS'] },
+            }),
+          }
+        : healthChecksDefaultValues.data,
+    },
+    livenessProbe: {
+      showForm: false,
+      enabled: !_.isEmpty(livenessProbe),
+      data: !_.isEmpty(livenessProbe)
+        ? {
+            ...livenessProbe,
+            requestType: getRequestType(livenessProbe),
+            ...(livenessProbe.httpGet?.scheme === 'HTTPS' && {
+              httpGet: { ...livenessProbe.httpGet, scheme: ['HTTPS'] },
+            }),
+          }
+        : healthChecksDefaultValues.data,
+    },
+    startupProbe: {
+      showForm: false,
+      enabled: !_.isEmpty(startupProbe),
+      data: !_.isEmpty(startupProbe)
+        ? {
+            ...startupProbe,
+            requestType: getRequestType(startupProbe),
+            ...(startupProbe.httpGet?.scheme === 'HTTPS' && {
+              httpGet: { ...startupProbe.httpGet, scheme: ['HTTPS'] },
+            }),
+          }
+        : healthChecksDefaultValues.data,
+    },
+  };
+  return healthChecks;
+};
+
+export const getProbesData = (healthChecks: HealthChecksData, resourceType?: Resources) => {
+  const { readinessProbe, livenessProbe, startupProbe } = healthChecks;
+  return {
+    ...(readinessProbe.enabled
+      ? { readinessProbe: constructProbeData(readinessProbe.data, resourceType) }
+      : {}),
+    ...(livenessProbe.enabled
+      ? { livenessProbe: constructProbeData(livenessProbe.data, resourceType) }
+      : {}),
+    ...(resourceType !== Resources.KnativeService && startupProbe?.enabled
+      ? { startupProbe: constructProbeData(startupProbe.data) }
+      : {}),
+  };
+};

--- a/frontend/packages/dev-console/src/components/health-checks/health-check-probe-utils.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/health-check-probe-utils.ts
@@ -1,5 +1,13 @@
 import { HealthChecksProbeType, RequestType, HealthCheckProbe } from './health-checks-types';
 
+export const getContainerPorts = (ports): { [port: number]: number } => {
+  const containerPorts = ports.reduce((acc, port) => {
+    acc[port.containerPort] = port.containerPort;
+    return acc;
+  }, {});
+  return containerPorts;
+};
+
 export const getHealthChecksProbeConfig = (probe: string) => {
   switch (probe) {
     case HealthChecksProbeType.ReadinessProbe: {
@@ -28,7 +36,7 @@ export const getHealthChecksProbeConfig = (probe: string) => {
   }
 };
 
-export const defaultHealthChecksProbeValues: HealthCheckProbe = {
+export const healthChecksDefaultValues: HealthCheckProbe = {
   showForm: false,
   enabled: false,
   data: {
@@ -52,9 +60,7 @@ export const defaultHealthChecksProbeValues: HealthCheckProbe = {
 };
 
 export const healthChecksProbeInitialData = {
-  healthChecks: {
-    readinessProbe: defaultHealthChecksProbeValues,
-    livenessProbe: defaultHealthChecksProbeValues,
-    startupProbe: defaultHealthChecksProbeValues,
-  },
+  readinessProbe: healthChecksDefaultValues,
+  livenessProbe: healthChecksDefaultValues,
+  startupProbe: healthChecksDefaultValues,
 };

--- a/frontend/packages/dev-console/src/components/health-checks/health-check-probe-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/health-check-probe-validation-utils.ts
@@ -2,7 +2,7 @@ import * as yup from 'yup';
 
 const pathRegex = /^\/.*$/;
 
-export const healthChecksValidationSchema = yup.object().shape({
+const healthChecksValidationSchema = yup.object().shape({
   showForm: yup.boolean(),
   enabled: yup.boolean(),
   data: yup.object().when('showForm', {
@@ -41,4 +41,10 @@ export const healthChecksValidationSchema = yup.object().shape({
       }),
     }),
   }),
+});
+
+export const healthChecksProbesValidationSchema = yup.object().shape({
+  readinessProbe: healthChecksValidationSchema,
+  livenessProbe: healthChecksValidationSchema,
+  startupProbe: healthChecksValidationSchema,
 });

--- a/frontend/packages/dev-console/src/components/health-checks/health-checks-types.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/health-checks-types.ts
@@ -18,14 +18,13 @@ export interface HealthCheckProbeData {
   httpGet?: {
     scheme: string;
     path: string;
-
     port: number;
     httpHeaders: NameValuePair[];
   };
   tcpSocket?: {
     port: number;
   };
-  exec: { command?: string[] };
+  exec?: { command?: string[] };
   initialDelaySeconds: number;
   periodSeconds: number;
   timeoutSeconds: number;

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -12,6 +12,7 @@ import { DeployImageFormData, FirehoseList, Resources } from './import-types';
 import { createOrUpdateDeployImageResources } from './deployImage-submit-utils';
 import { deployValidationSchema } from './deployImage-validation-utils';
 import DeployImageForm from './DeployImageForm';
+import { healthChecksProbeInitialData } from '../health-checks/health-check-probe-utils';
 
 export interface DeployImageProps {
   namespace: string;
@@ -133,6 +134,7 @@ const DeployImage: React.FC<Props> = ({
         defaultLimitUnit: 'Mi',
       },
     },
+    healthChecks: healthChecksProbeInitialData,
   };
 
   const handleSubmit = (values, actions) => {

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -13,6 +13,7 @@ import { ALLOW_SERVICE_BINDING } from '../../const';
 import { GitImportFormData, FirehoseList, ImportData, Resources } from './import-types';
 import { createOrUpdateResources, handleRedirect } from './import-submit-utils';
 import { validationSchema } from './import-validation-utils';
+import { healthChecksProbeInitialData } from '../health-checks/health-check-probe-utils';
 
 export interface ImportFormProps {
   namespace: string;
@@ -141,6 +142,7 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
         defaultLimitUnit: 'Mi',
       },
     },
+    healthChecks: healthChecksProbeInitialData,
   };
   const builderImages: NormalizedBuilderImages =
     imageStreams && imageStreams.loaded && normalizeBuilderImages(imageStreams.data);

--- a/frontend/packages/dev-console/src/components/import/__mocks__/deployImage-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/deployImage-validation-mock.ts
@@ -1,4 +1,5 @@
 import { DeployImageFormData, Resources } from '../import-types';
+import { healthChecksProbeInitialData } from '../../health-checks/health-check-probe-utils';
 
 export const mockDeployImageFormData: DeployImageFormData = {
   project: {
@@ -134,4 +135,5 @@ export const mockDeployImageFormData: DeployImageFormData = {
       defaultLimitUnit: 'Mi',
     },
   },
+  healthChecks: healthChecksProbeInitialData,
 };

--- a/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
+++ b/frontend/packages/dev-console/src/components/import/__mocks__/import-validation-mock.ts
@@ -1,5 +1,6 @@
 import { ValidatedOptions } from '@patternfly/react-core';
 import { GitImportFormData, Resources } from '../import-types';
+import { healthChecksProbeInitialData } from '../../health-checks/health-check-probe-utils';
 
 export const mockFormData: GitImportFormData = {
   name: 'test-app',
@@ -96,4 +97,5 @@ export const mockFormData: GitImportFormData = {
       defaultLimitUnit: 'Mi',
     },
   },
+  healthChecks: healthChecksProbeInitialData,
 };

--- a/frontend/packages/dev-console/src/components/import/__tests__/deployImage-submit-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/deployImage-submit-utils-data.ts
@@ -1,4 +1,5 @@
 import { DeployImageFormData, Resources } from '../import-types';
+import { healthChecksProbeInitialData } from '../../health-checks/health-check-probe-utils';
 
 export const defaultData: DeployImageFormData = {
   project: {
@@ -97,6 +98,7 @@ export const defaultData: DeployImageFormData = {
       defaultLimitUnit: 'Mi',
     },
   },
+  healthChecks: healthChecksProbeInitialData,
 };
 
 export const dataWithTargetPort: DeployImageFormData = {
@@ -210,6 +212,7 @@ export const dataWithTargetPort: DeployImageFormData = {
       defaultLimitUnit: 'Mi',
     },
   },
+  healthChecks: healthChecksProbeInitialData,
 };
 
 export const dataWithPorts: DeployImageFormData = {
@@ -431,6 +434,7 @@ export const dataWithPorts: DeployImageFormData = {
       defaultLimitUnit: 'Mi',
     },
   },
+  healthChecks: healthChecksProbeInitialData,
 };
 
 export const dataWithoutPorts: DeployImageFormData = {
@@ -544,6 +548,7 @@ export const dataWithoutPorts: DeployImageFormData = {
       defaultLimitUnit: 'Mi',
     },
   },
+  healthChecks: healthChecksProbeInitialData,
 };
 
 export const internalImageData: DeployImageFormData = {
@@ -828,4 +833,5 @@ export const internalImageData: DeployImageFormData = {
       defaultLimitUnit: 'Mi',
     },
   },
+  healthChecks: healthChecksProbeInitialData,
 };

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils-data.ts
@@ -1,5 +1,6 @@
 import { ValidatedOptions } from '@patternfly/react-core';
 import { GitImportFormData, Resources } from '../import-types';
+import { healthChecksProbeInitialData } from '../../health-checks/health-check-probe-utils';
 
 export const mockPipelineTemplate = {
   apiVersion: 'tekton.dev/v1alpha1',
@@ -176,6 +177,7 @@ export const defaultData: GitImportFormData = {
     enabled: false,
     template: mockPipelineTemplate,
   },
+  healthChecks: healthChecksProbeInitialData,
 };
 
 export const nodeJsBuilderImage = {

--- a/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
@@ -14,6 +14,7 @@ import BuildConfigSection from './BuildConfigSection';
 import DeploymentConfigSection from './DeploymentConfigSection';
 import ResourceLimitSection from './ResourceLimitSection';
 import { AppResources } from '../../edit-application/edit-application-types';
+import HealthChecks from '../../health-checks/HealthChecks';
 
 export interface AdvancedSectionProps {
   values: FormikValues;
@@ -25,7 +26,6 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({ values, appResources 
   const handleVisibleItemChange = (item: string) => {
     setVisibleItems([...visibleItems, item]);
   };
-
   return (
     <FormSection title="Advanced Options" fullWidth>
       <RouteCheckbox isDisabled={values.route.disable} />
@@ -40,6 +40,9 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({ values, appResources 
           ) : (
             <RouteSection route={values.route} />
           )}
+        </ProgressiveListItem>
+        <ProgressiveListItem name="Health Checks">
+          <HealthChecks title="Health Checks" resourceType={values.resources} />
         </ProgressiveListItem>
         {/* Hide Build for Deploy Image */}
         {values.isi ? null : (

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -18,6 +18,7 @@ import {
   annotations,
   dryRunOpt,
 } from '../../utils/shared-submit-utils';
+import { getProbesData } from '../health-checks/create-health-check-probe-utils';
 import { RegistryType } from '../../utils/imagestream-utils';
 import { AppResources } from '../edit-application/edit-application-types';
 import { DeployImageFormData, Resources } from './import-types';
@@ -144,6 +145,7 @@ export const createOrUpdateDeployment = (
     labels: userLabels,
     limits: { cpu, memory },
     imageStream: { image: imgName, namespace: imgNamespace },
+    healthChecks,
   } = formData;
 
   const defaultAnnotations = {
@@ -212,6 +214,7 @@ export const createOrUpdateDeployment = (
                   },
                 }),
               },
+              ...getProbesData(healthChecks),
             },
           ],
         },
@@ -240,6 +243,7 @@ export const createOrUpdateDeploymentConfig = (
     labels: userLabels,
     limits: { cpu, memory },
     imageStream: { image: imgName, namespace: imgNamespace },
+    healthChecks,
   } = formData;
 
   const { labels, podLabels, volumes, volumeMounts } = getMetadata(formData);
@@ -283,6 +287,7 @@ export const createOrUpdateDeploymentConfig = (
                   },
                 }),
               },
+              ...getProbesData(healthChecks),
             },
           ],
         },

--- a/frontend/packages/dev-console/src/components/import/deployImage-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-validation-utils.ts
@@ -10,6 +10,7 @@ import {
   isiValidationSchema,
   resourcesValidationSchema,
 } from './validation-schema';
+import { healthChecksProbesValidationSchema } from '../health-checks/health-check-probe-validation-utils';
 
 export const deployValidationSchema = yup.object().shape({
   project: projectNameValidationSchema,
@@ -21,4 +22,5 @@ export const deployValidationSchema = yup.object().shape({
   route: routeValidationSchema,
   limits: limitsValidationSchema,
   resources: resourcesValidationSchema,
+  healthChecks: healthChecksProbesValidationSchema,
 });

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -23,6 +23,7 @@ import {
   mergeData,
 } from '../../utils/resource-label-utils';
 import { createService, createRoute, dryRunOpt } from '../../utils/shared-submit-utils';
+import { getProbesData } from '../health-checks/create-health-check-probe-utils';
 import { AppResources } from '../edit-application/edit-application-types';
 import {
   GitImportFormData,
@@ -236,6 +237,7 @@ export const createOrUpdateDeployment = (
     labels: userLabels,
     limits: { cpu, memory },
     git: { url: repository, ref },
+    healthChecks,
   } = formData;
 
   const imageStreamName = imageStream && imageStream.metadata.name;
@@ -293,6 +295,7 @@ export const createOrUpdateDeployment = (
                   },
                 }),
               },
+              ...getProbesData(healthChecks),
             },
           ],
         },
@@ -322,6 +325,7 @@ export const createOrUpdateDeploymentConfig = (
     labels: userLabels,
     limits: { cpu, memory },
     git: { url: repository, ref },
+    healthChecks,
   } = formData;
 
   const imageStreamName = imageStream && imageStream.metadata.name;
@@ -366,6 +370,7 @@ export const createOrUpdateDeploymentConfig = (
                   },
                 }),
               },
+              ...getProbesData(healthChecks),
             },
           ],
         },

--- a/frontend/packages/dev-console/src/components/import/import-types.ts
+++ b/frontend/packages/dev-console/src/components/import/import-types.ts
@@ -5,6 +5,7 @@ import { LazyLoader } from '@console/plugin-sdk';
 import { NameValuePair, NameValueFromPair } from '@console/shared';
 import { ServiceModel } from '@console/knative-plugin/src/models';
 import { NormalizedBuilderImages } from '../../utils/imagestream-utils';
+import { HealthCheckProbe } from '../health-checks/health-checks-types';
 
 export interface DeployImageFormProps {
   builderImages?: NormalizedBuilderImages;
@@ -81,6 +82,7 @@ export interface DeployImageFormData {
   build: BuildData;
   deployment: DeploymentData;
   limits: LimitsData;
+  healthChecks: HealthChecksData;
 }
 
 export interface GitImportFormData {
@@ -100,6 +102,7 @@ export interface GitImportFormData {
   deployment: DeploymentData;
   labels: { [name: string]: string };
   limits: LimitsData;
+  healthChecks: HealthChecksData;
 }
 
 export interface ApplicationData {
@@ -292,4 +295,10 @@ export enum ImportOptions {
   DOCKERFILE = 'DOCKERFILE',
   DATABASE = 'DATABASE',
   EVENTSOURCE = 'EVENTSOURCE',
+}
+
+export interface HealthChecksData {
+  readinessProbe: HealthCheckProbe;
+  livenessProbe: HealthCheckProbe;
+  startupProbe?: HealthCheckProbe;
 }

--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -16,6 +16,7 @@ import {
   gitUrlRegex,
   resourcesValidationSchema,
 } from './validation-schema';
+import { healthChecksProbesValidationSchema } from '../health-checks/health-check-probe-validation-utils';
 
 export const validationSchema = yup.object().shape({
   name: nameValidationSchema,
@@ -30,6 +31,7 @@ export const validationSchema = yup.object().shape({
   limits: limitsValidationSchema,
   build: buildValidationSchema,
   resources: resourcesValidationSchema,
+  healthChecks: healthChecksProbesValidationSchema,
 });
 
 const hasDomain = (url: string, domain: string): boolean => {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-serving-data.ts
@@ -5,6 +5,7 @@ import {
 } from '@console/dev-console/src/components/import/import-types';
 import { EventSourceFormData } from '../../components/add/import-types';
 import { RevisionModel } from '../../models';
+import { healthChecksProbeInitialData } from '@console/dev-console/src/components/health-checks/health-check-probe-utils';
 
 export const defaultData: DeployImageFormData = {
   project: {
@@ -103,6 +104,7 @@ export const defaultData: DeployImageFormData = {
       defaultLimitUnit: 'Mi',
     },
   },
+  healthChecks: healthChecksProbeInitialData,
 };
 
 export const deploymentData: K8sResourceKind = {

--- a/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-knative-utils.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { K8sResourceKind, ImagePullPolicy } from '@console/internal/module/k8s';
 import { getAppLabels, mergeData } from '@console/dev-console/src/utils/resource-label-utils';
+import { getProbesData } from '@console/dev-console/src/components/health-checks/create-health-check-probe-utils';
 import {
   DeployImageFormData,
   GitImportFormData,
@@ -29,6 +30,8 @@ export const getKnativeServiceDepResource = (
       env,
       triggers: { image: imagePolicy },
     },
+    healthChecks,
+    resources,
   } = formData;
   const contTargetPort = targetPort
     ? parseInt(targetPort.split('-')[0], 10)
@@ -114,13 +117,13 @@ export const getKnativeServiceDepResource = (
                   },
                 }),
               },
+              ...getProbesData(healthChecks, resources),
             },
           ],
         },
       },
     },
   };
-
   let knativeServiceUpdated = {};
   if (!_.isEmpty(originalKnativeService)) {
     knativeServiceUpdated = _.omit(originalKnativeService, [


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-3332

**Analysis / Root cause:**
There is no way the user can add health checks when creating an application.

**Solution Description**
Added a provision to allow the user to add Health Checks from the Advanced Options in the Add flow and also let the user make changes to the health check data when editing a workload.

**GIF**
Add Health Checks when creating an app
![create-HC](https://user-images.githubusercontent.com/22490998/79384504-a04c7f80-7f84-11ea-8367-073cc824b72f.gif)

Edit Health Checks when editing a workload
![Edit-hc](https://user-images.githubusercontent.com/22490998/79384616-da1d8600-7f84-11ea-93ce-0e986dc35c88.gif)

Health checks when Knative Service is selected
![knative-hc](https://user-images.githubusercontent.com/22490998/79384640-e6a1de80-7f84-11ea-8fbe-c0ae7d01039e.gif)

**TODO**
- [x] Add tests & fix existing tests

**Tests**
![ut-1](https://user-images.githubusercontent.com/22490998/79585633-b590ed80-80ed-11ea-85cd-7646c44d6462.png)

/kind feature