### PR TITLE
Add install page for operators

### DIFF
--- a/frontend/packages/console-shared/src/components/status/icons.tsx
+++ b/frontend/packages/console-shared/src/components/status/icons.tsx
@@ -19,16 +19,20 @@ import {
   global_warning_color_100 as warningColor,
 } from '@patternfly/react-tokens';
 
-export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
-  <CheckCircleIcon color={okColor.value} className={className} alt={alt} />
+export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({ className, alt, size }) => (
+  <CheckCircleIcon size={size} color={okColor.value} className={className} alt={alt} />
 );
 
-export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
-  <ExclamationCircleIcon color={dangerColor.value} className={className} alt={alt} />
+export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({ className, alt, size }) => (
+  <ExclamationCircleIcon size={size} color={dangerColor.value} className={className} alt={alt} />
 );
 
-export const YellowExclamationTriangleIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
-  <ExclamationTriangleIcon color={warningColor.value} className={className} alt={alt} />
+export const YellowExclamationTriangleIcon: React.FC<ColoredIconProps> = ({
+  className,
+  alt,
+  size,
+}) => (
+  <ExclamationTriangleIcon size={size} color={warningColor.value} className={className} alt={alt} />
 );
 
 export const BlueInfoCircleIcon: React.FC<ColoredIconProps> = ({ className, alt }) => (
@@ -58,4 +62,5 @@ export const BlueArrowCircleUpIcon: React.FC<ColoredIconProps> = ({ className, a
 export type ColoredIconProps = {
   className?: string;
   alt?: string;
+  size?: 'sm' | 'md' | 'lg' | 'xl';
 };

--- a/frontend/packages/dev-console/integration-tests/tests/pipeline.scenario.ts
+++ b/frontend/packages/dev-console/integration-tests/tests/pipeline.scenario.ts
@@ -90,6 +90,8 @@ describe('Pipeline', async () => {
     expect(operatorHubView.createSubscriptionError.isPresent()).toBe(false);
     expect(operatorHubView.createSubscriptionFormBtn.getAttribute('disabled')).toEqual(null);
     await operatorHubView.createSubscriptionFormBtn.click();
+    await operatorHubView.operatorInstallPageLoaded();
+    await operatorHubView.viewInstalledOperatorsBtn.click();
     await crudView.isLoaded();
     await browser.get(`${appHost}/operatorhub/ns/${testName}`);
     await crudView.isLoaded();

--- a/frontend/packages/knative-plugin/integration-tests/tests/serverless.scenario.ts
+++ b/frontend/packages/knative-plugin/integration-tests/tests/serverless.scenario.ts
@@ -75,6 +75,8 @@ describe('Serverless', async () => {
     expect(operatorHubView.createSubscriptionError.isPresent()).toBe(false);
     expect(operatorHubView.createSubscriptionFormBtn.getAttribute('disabled')).toEqual(null);
     await operatorHubView.createSubscriptionFormBtn.click();
+    await operatorHubView.operatorInstallPageLoaded();
+    await operatorHubView.viewInstalledOperatorsBtn.click();
     await crudView.isLoaded();
     await browser.get(`${appHost}/operatorhub/ns/${testName}`);
     await crudView.isLoaded();

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/global-installmode.scenario.ts
@@ -58,7 +58,9 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
     );
     await new Promise((resolve) =>
       (function checkForPackages() {
-        const output = execSync(`kubectl get packagemanifests -n ${testName} -o json`);
+        const output = execSync(
+          `kubectl get packagemanifests -n ${testName} --selector=catalog=console-e2e -o json`,
+        );
         if (
           JSON.parse(output.toString('utf-8')).items.find(
             (pkg) => pkg.status.catalogSource === catalogSource.metadata.name,
@@ -105,13 +107,14 @@ describe('Interacting with an `AllNamespaces` install mode Operator (Jaeger)', (
   it('selects all namespaces for Operator subscription', async () => {
     await browser.wait(until.visibilityOf(operatorHubView.createSubscriptionFormInstallMode));
     await operatorHubView.allNamespacesInstallMode.click();
-
     expect(operatorHubView.createSubscriptionError.isPresent()).toBe(false);
     expect(operatorHubView.createSubscriptionFormBtn.getAttribute('disabled')).toEqual(null);
   });
 
   it('displays Operator as subscribed in OperatorHub', async () => {
     await operatorHubView.createSubscriptionFormBtn.click();
+    await operatorHubView.operatorInstallPageLoaded();
+    await operatorHubView.viewInstalledOperatorsBtn.click();
     await crudView.isLoaded();
     await browser.get(`${appHost}/operatorhub/ns/${testName}`);
     await crudView.isLoaded();

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/operator-hub.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/operator-hub.scenario.ts
@@ -29,7 +29,9 @@ describe('Interacting with OperatorHub', () => {
     execSync(`echo '${JSON.stringify(catalogSource)}' | kubectl create -n ${testName} -f -`);
     await new Promise((resolve) =>
       (function checkForPackages() {
-        const output = execSync(`kubectl get packagemanifests -n ${testName} -o json`);
+        const output = execSync(
+          `kubectl get packagemanifests -n ${testName} --selector=catalog=console-e2e -o json`,
+        );
         if (
           JSON.parse(output.toString('utf-8')).items.find(
             (pkg) => pkg.status.catalogSource === catalogSource.metadata.name,

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator-hub.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/views/operator-hub.view.ts
@@ -56,3 +56,6 @@ export const acceptForeverCommunityWarningModal = () =>
     .$('input')
     .click()
     .then(() => acceptCommunityWarningModal());
+export const viewInstalledOperatorsBtn = $('[data-test="view-installed-operators-btn"]');
+export const operatorInstallPageLoaded = () =>
+  browser.wait(until.presenceOf(viewInstalledOperatorsBtn), 20000);

--- a/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/install-plan.tsx
@@ -328,8 +328,8 @@ export class InstallPlanPreview extends React.Component<
   }
 
   render() {
-    const { obj } = this.props;
-    const subscription = obj.metadata.ownerReferences.find(
+    const { obj, hideApprovalBlock = false } = this.props;
+    const subscription = obj?.metadata?.ownerReferences.find(
       (ref) => referenceForOwnerRef(ref) === referenceForModel(SubscriptionModel),
     );
 
@@ -359,7 +359,7 @@ export class InstallPlanPreview extends React.Component<
         {this.state.error && (
           <div className="co-clusterserviceversion-detail__error-box">{this.state.error}</div>
         )}
-        {this.state.needsApproval && (
+        {this.state.needsApproval && !hideApprovalBlock && (
           <div className="co-m-pane__body">
             <HintBlock title="Review Manual Install Plan">
               <p>
@@ -489,6 +489,7 @@ export type InstallPlanDetailsPageProps = {
 
 export type InstallPlanPreviewProps = {
   obj: InstallPlanKind;
+  hideApprovalBlock?: boolean;
 };
 
 export type InstallPlanPreviewState = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -15,7 +15,6 @@ import {
   StatusBox,
   ResourceIcon,
   ResourceName,
-  resourceListPathFromModel,
 } from '@console/internal/components/utils';
 import {
   K8sResourceCommon,
@@ -29,12 +28,7 @@ import {
 } from '@console/internal/module/k8s';
 import { RadioGroup, RadioInput } from '@console/internal/components/radio';
 import { fromRequirements } from '@console/internal/module/k8s/selector';
-import {
-  SubscriptionModel,
-  OperatorGroupModel,
-  PackageManifestModel,
-  ClusterServiceVersionModel,
-} from '../../models';
+import { SubscriptionModel, OperatorGroupModel, PackageManifestModel } from '../../models';
 import { NamespaceModel, RoleBindingModel, RoleModel } from '@console/internal/models';
 import {
   OperatorGroupKind,
@@ -54,10 +48,12 @@ import {
 import { installedFor, supports, providedAPIsFor, isGlobal } from '../operator-group';
 import { CRDCard } from '../clusterserviceversion';
 import { getInternalObjects, isInternalObject } from '../../utils';
+import { OperatorInstallStatusPage } from '../operator-install-page';
 
 export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> = (props) => {
   const [targetNamespace, setTargetNamespace] = React.useState(null);
   const [installMode, setInstallMode] = React.useState(null);
+  const [showInstallStatusPage, setShowInstallStatusPage] = React.useState(false);
   const [updateChannel, setUpdateChannel] = React.useState(null);
   const [approval, setApproval] = React.useState(InstallPlanApproval.Automatic);
   const [cannotResolve, setCannotResolve] = React.useState(false);
@@ -77,6 +73,12 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     catalogSource,
     catalogSourceNamespace,
   } = props.packageManifest.data[0].status;
+
+  const search = new URLSearchParams({
+    'details-item': `${new URLSearchParams(window.location.search).get(
+      'pkg',
+    )}-${new URLSearchParams(window.location.search).get('catalogNamespace')}`,
+  });
 
   const selectedUpdateChannel = updateChannel || defaultChannelFor(props.packageManifest.data[0]);
   const selectedInstallMode =
@@ -305,12 +307,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
         await k8sCreate(OperatorGroupModel, operatorGroup);
       }
       await k8sCreate(SubscriptionModel, subscription);
-      history.push(
-        resourceListPathFromModel(
-          ClusterServiceVersionModel,
-          targetNamespace || props.targetNamespace || selectedTargetNamespace,
-        ),
-      );
+      setShowInstallStatusPage(true);
     } catch (err) {
       setError(err.message || 'Could not create operator subscription.');
     }
@@ -511,132 +508,14 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     selectedUpdateChannel,
   ).filter((item) => !isInternalObject(internalObjects, item.name));
 
-  return (
-    <div className="row">
-      <div className="col-xs-6">
-        <>
-          <div className="form-group">
-            <Tooltip content="The channel to track and receive the updates from.">
-              <h5 className="co-required">Update Channel</h5>
-            </Tooltip>
-            <RadioGroup
-              currentValue={selectedUpdateChannel}
-              items={channels.map((ch) => ({ value: ch.name, title: ch.name }))}
-              onChange={(e) => {
-                setUpdateChannel(e.currentTarget.value);
-                setInstallMode(null);
-              }}
-            />
-          </div>
-          <div className="form-group">
-            <h5 className="co-required">Installation Mode</h5>
-            <div>
-              <RadioInput
-                onChange={(e) => {
-                  setInstallMode(e.target.value);
-                  setTargetNamespace(null);
-                  setCannotResolve(false);
-                }}
-                value={InstallModeType.InstallModeTypeAllNamespaces}
-                checked={selectedInstallMode === InstallModeType.InstallModeTypeAllNamespaces}
-                disabled={!supportsGlobal}
-                title="All namespaces on the cluster"
-                subTitle="(default)"
-              >
-                <div className="co-m-radio-desc">
-                  <p className="text-muted">
-                    {descFor(InstallModeType.InstallModeTypeAllNamespaces)}
-                  </p>
-                </div>
-              </RadioInput>
-            </div>
-            <div>
-              <RadioInput
-                onChange={(e) => {
-                  setInstallMode(e.target.value);
-                  setTargetNamespace(
-                    useSuggestedNSForSingleInstallMode ? suggestedNamespace : null,
-                  );
-                  setCannotResolve(false);
-                }}
-                value={InstallModeType.InstallModeTypeOwnNamespace}
-                checked={selectedInstallMode === InstallModeType.InstallModeTypeOwnNamespace}
-                disabled={!supportsSingle}
-                title="A specific namespace on the cluster"
-              >
-                <div className="co-m-radio-desc">
-                  <p className="text-muted">
-                    {descFor(InstallModeType.InstallModeTypeOwnNamespace)}
-                  </p>
-                </div>
-              </RadioInput>
-            </div>
-          </div>
-          <div className="form-group">
-            <h5 className="co-required">Installed Namespace</h5>
-            {selectedInstallMode === InstallModeType.InstallModeTypeAllNamespaces &&
-              globalNamespaceInstallMode}
-            {selectedInstallMode === InstallModeType.InstallModeTypeOwnNamespace &&
-              singleNamespaceInstallMode}
-          </div>
-          <div className="form-group">
-            <Tooltip content="The strategy to determine either manual or automatic updates.">
-              <h5 className="co-required">Approval Strategy</h5>
-            </Tooltip>
-            <RadioGroup
-              currentValue={selectedApproval}
-              items={[
-                { value: InstallPlanApproval.Automatic, title: 'Automatic' },
-                { value: InstallPlanApproval.Manual, title: 'Manual' },
-              ]}
-              onChange={(e) => setApproval(e.currentTarget.value)}
-            />
-          </div>
-        </>
-        <div className="co-form-section__separator" />
-        {formError()}
-        <ActionGroup className="pf-c-form">
-          <Button onClick={() => submit()} isDisabled={formValid()} variant="primary">
-            Install
-          </Button>
-          <Button variant="secondary" onClick={() => history.push('/operatorhub')}>
-            Cancel
-          </Button>
-        </ActionGroup>
-      </div>
-      <div className="col-xs-6">
-        <ClusterServiceVersionLogo
-          displayName={_.get(channels, '[0].currentCSVDesc.displayName')}
-          icon={iconFor(props.packageManifest.data[0])}
-          provider={provider}
-        />
-        <h4>Provided APIs</h4>
-        <div className="co-crd-card-row">
-          {!providedAPIs.length ? (
-            <span className="text-muted">No Kubernetes APIs are provided by this Operator.</span>
-          ) : (
-            providedAPIs.map((api) => (
-              <CRDCard key={referenceForProvidedAPI(api)} canCreate={false} crd={api} csv={null} />
-            ))
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const OperatorHubSubscribe: React.FC<OperatorHubSubscribeFormProps> = (props) => (
-  <StatusBox data={props.packageManifest.data[0]} loaded={props.loaded} loadError={props.loadError}>
-    <OperatorHubSubscribeForm {...props} />
-  </StatusBox>
-);
-
-export const OperatorHubSubscribePage: React.SFC<OperatorHubSubscribePageProps> = (props) => {
-  const search = new URLSearchParams({
-    'details-item': `${new URLSearchParams(window.location.search).get(
-      'pkg',
-    )}-${new URLSearchParams(window.location.search).get('catalogNamespace')}`,
-  });
+  if (showInstallStatusPage) {
+    return (
+      <OperatorInstallStatusPage
+        targetNamespace={selectedTargetNamespace}
+        pkgNameWithVersion={channels.find((ch) => ch.name === selectedUpdateChannel).currentCSV}
+      />
+    );
+  }
 
   return (
     <>
@@ -657,44 +536,168 @@ export const OperatorHubSubscribePage: React.SFC<OperatorHubSubscribePageProps> 
         </p>
       </div>
       <div className="co-m-pane__body">
-        <Firehose
-          resources={[
-            {
-              isList: true,
-              kind: referenceForModel(OperatorGroupModel),
-              prop: 'operatorGroup',
-            },
-            {
-              isList: true,
-              kind: referenceForModel(PackageManifestModel),
-              namespace: new URLSearchParams(window.location.search).get('catalogNamespace'),
-              fieldSelector: `metadata.name=${new URLSearchParams(window.location.search).get(
-                'pkg',
-              )}`,
-              selector: {
-                matchLabels: {
-                  catalog: new URLSearchParams(window.location.search).get('catalog'),
-                },
-              },
-              prop: 'packageManifest',
-            },
-            {
-              isList: true,
-              kind: referenceForModel(SubscriptionModel),
-              prop: 'subscription',
-            },
-          ]}
-        >
-          {/* FIXME(alecmerdler): Hack because `Firehose` injects props without TypeScript knowing about it */}
-          <OperatorHubSubscribe
-            {...(props as any)}
-            targetNamespace={
-              new URLSearchParams(window.location.search).get('targetNamespace') || null
-            }
-          />
-        </Firehose>
+        <div className="row">
+          <div className="col-xs-6">
+            <>
+              <div className="form-group">
+                <Tooltip content="The channel to track and receive the updates from.">
+                  <h5 className="co-required">Update Channel</h5>
+                </Tooltip>
+                <RadioGroup
+                  currentValue={selectedUpdateChannel}
+                  items={channels.map((ch) => ({ value: ch.name, title: ch.name }))}
+                  onChange={(e) => {
+                    setUpdateChannel(e.currentTarget.value);
+                    setInstallMode(null);
+                  }}
+                />
+              </div>
+              <div className="form-group">
+                <h5 className="co-required">Installation Mode</h5>
+                <div>
+                  <RadioInput
+                    onChange={(e) => {
+                      setInstallMode(e.target.value);
+                      setTargetNamespace(null);
+                      setCannotResolve(false);
+                    }}
+                    value={InstallModeType.InstallModeTypeAllNamespaces}
+                    checked={selectedInstallMode === InstallModeType.InstallModeTypeAllNamespaces}
+                    disabled={!supportsGlobal}
+                    title="All namespaces on the cluster"
+                    subTitle="(default)"
+                  >
+                    <div className="co-m-radio-desc">
+                      <p className="text-muted">
+                        {descFor(InstallModeType.InstallModeTypeAllNamespaces)}
+                      </p>
+                    </div>
+                  </RadioInput>
+                </div>
+                <div>
+                  <RadioInput
+                    onChange={(e) => {
+                      setInstallMode(e.target.value);
+                      setTargetNamespace(
+                        useSuggestedNSForSingleInstallMode ? suggestedNamespace : null,
+                      );
+                      setCannotResolve(false);
+                    }}
+                    value={InstallModeType.InstallModeTypeOwnNamespace}
+                    checked={selectedInstallMode === InstallModeType.InstallModeTypeOwnNamespace}
+                    disabled={!supportsSingle}
+                    title="A specific namespace on the cluster"
+                  >
+                    <div className="co-m-radio-desc">
+                      <p className="text-muted">
+                        {descFor(InstallModeType.InstallModeTypeOwnNamespace)}
+                      </p>
+                    </div>
+                  </RadioInput>
+                </div>
+              </div>
+              <div className="form-group">
+                <h5 className="co-required">Installed Namespace</h5>
+                {selectedInstallMode === InstallModeType.InstallModeTypeAllNamespaces &&
+                  globalNamespaceInstallMode}
+                {selectedInstallMode === InstallModeType.InstallModeTypeOwnNamespace &&
+                  singleNamespaceInstallMode}
+              </div>
+              <div className="form-group">
+                <Tooltip content="The strategy to determine either manual or automatic updates.">
+                  <h5 className="co-required">Approval Strategy</h5>
+                </Tooltip>
+                <RadioGroup
+                  currentValue={selectedApproval}
+                  items={[
+                    { value: InstallPlanApproval.Automatic, title: 'Automatic' },
+                    { value: InstallPlanApproval.Manual, title: 'Manual' },
+                  ]}
+                  onChange={(e) => setApproval(e.currentTarget.value)}
+                />
+              </div>
+            </>
+            <div className="co-form-section__separator" />
+            {formError()}
+            <ActionGroup className="pf-c-form">
+              <Button onClick={() => submit()} isDisabled={formValid()} variant="primary">
+                Install
+              </Button>
+              <Button variant="secondary" onClick={() => history.push('/operatorhub')}>
+                Cancel
+              </Button>
+            </ActionGroup>
+          </div>
+          <div className="col-xs-6">
+            <ClusterServiceVersionLogo
+              displayName={_.get(channels, '[0].currentCSVDesc.displayName')}
+              icon={iconFor(props.packageManifest.data[0])}
+              provider={provider}
+            />
+            <h4>Provided APIs</h4>
+            <div className="co-crd-card-row">
+              {!providedAPIs.length ? (
+                <span className="text-muted">
+                  No Kubernetes APIs are provided by this Operator.
+                </span>
+              ) : (
+                providedAPIs.map((api) => (
+                  <CRDCard
+                    key={referenceForProvidedAPI(api)}
+                    canCreate={false}
+                    crd={api}
+                    csv={null}
+                  />
+                ))
+              )}
+            </div>
+          </div>
+        </div>
       </div>
     </>
+  );
+};
+
+const OperatorHubSubscribe: React.FC<OperatorHubSubscribeFormProps> = (props) => (
+  <StatusBox data={props.packageManifest.data[0]} loaded={props.loaded} loadError={props.loadError}>
+    <OperatorHubSubscribeForm {...props} />
+  </StatusBox>
+);
+
+export const OperatorHubSubscribePage: React.SFC<OperatorHubSubscribePageProps> = (props) => {
+  return (
+    <Firehose
+      resources={[
+        {
+          isList: true,
+          kind: referenceForModel(OperatorGroupModel),
+          prop: 'operatorGroup',
+        },
+        {
+          isList: true,
+          kind: referenceForModel(PackageManifestModel),
+          namespace: new URLSearchParams(window.location.search).get('catalogNamespace'),
+          fieldSelector: `metadata.name=${new URLSearchParams(window.location.search).get('pkg')}`,
+          selector: {
+            matchLabels: {
+              catalog: new URLSearchParams(window.location.search).get('catalog'),
+            },
+          },
+          prop: 'packageManifest',
+        },
+        {
+          isList: true,
+          kind: referenceForModel(SubscriptionModel),
+          prop: 'subscription',
+        },
+      ]}
+    >
+      {/* FIXME(alecmerdler): Hack because `Firehose` injects props without TypeScript knowing about it */}
+      <OperatorHubSubscribe
+        {...(props as any)}
+        targetNamespace={new URLSearchParams(window.location.search).get('targetNamespace') || null}
+      />
+    </Firehose>
   );
 };
 
@@ -705,6 +708,7 @@ export type OperatorHubSubscribeFormProps = {
   targetNamespace?: string;
   operatorGroup: { loaded: boolean; data: OperatorGroupKind[] };
   packageManifest: { loaded: boolean; data: PackageManifestKind[] };
+  match: match;
   subscription: { loaded: boolean; data: SubscriptionKind[] };
 };
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-install-page.tsx
@@ -1,0 +1,456 @@
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+import { ClusterServiceVersionLogo, iconFor } from './index';
+import {
+  ActionGroup,
+  Alert,
+  Bullseye,
+  Button,
+  Card,
+  CardBody,
+  Spinner,
+} from '@patternfly/react-core';
+import {
+  Firehose,
+  FirehoseResult,
+  ResourceLink,
+  ResourceStatus,
+  resourcePathFromModel,
+} from '@console/internal/components/utils';
+import {
+  groupVersionFor,
+  k8sPatch,
+  referenceForModel,
+  referenceForGroupVersionKind,
+} from '@console/internal/module/k8s';
+import { errorModal } from '@console/internal/components/modals';
+import {
+  ClusterServiceVersionModel,
+  InstallPlanModel,
+  PackageManifestModel,
+  SubscriptionModel,
+} from '../models';
+import {
+  ClusterServiceVersionKind,
+  SubscriptionKind,
+  InstallPlanKind,
+  PackageManifestKind,
+} from '../types';
+import { StatusIconAndText } from '@console/shared';
+import {
+  GreenCheckCircleIcon,
+  RedExclamationCircleIcon,
+  YellowExclamationTriangleIcon,
+} from '@console/shared/src/components/status/icons';
+import { InstallPlanPreview } from './install-plan';
+
+const getCRDFromObject = (obj: ClusterServiceVersionKind | InstallPlanKind | SubscriptionKind) => {
+  return obj?.metadata?.annotations?.['operatorframework.io/initialization-resource'];
+};
+
+const ViewInstalledOperatorsButton: React.FC<ViewOperatorButtonProps> = ({ namespace }) => (
+  <div className="co-operator-install-page__link">
+    <Link
+      data-test="view-installed-operators-btn"
+      to={resourcePathFromModel(ClusterServiceVersionModel, null, namespace)}
+    >
+      View Installed Operators in{' '}
+      {namespace ? (
+        <>
+          namespace <b>{namespace}</b>
+        </>
+      ) : (
+        <b>all namespaces</b>
+      )}
+    </Link>
+  </div>
+);
+
+const InstallFailedMessage: React.FC<InstallFailedMessageProps> = ({ namespace, csvName, obj }) => {
+  const crdMessage = getCRDFromObject(obj)
+    ? "The required custom resource can be created in the Operator's details view."
+    : '';
+
+  return (
+    <>
+      <h2 className="co-clusterserviceversion-install__heading">Operator installation failed</h2>
+      <p>The operator did not install successfully. {crdMessage}</p>
+      <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
+        <Link to={resourcePathFromModel(ClusterServiceVersionModel, csvName, namespace)}>
+          <Button variant="primary">View Error</Button>
+        </Link>
+        <ViewInstalledOperatorsButton namespace={namespace} />
+      </ActionGroup>
+    </>
+  );
+};
+
+const InstallNeedsApprovalMessage: React.FC<InstallNeedsApprovalMessageProps> = ({
+  namespace,
+  obj,
+  approve,
+}) => (
+  <>
+    <h2 className="co-clusterserviceversion-install__heading">Manual approval required</h2>
+    <p>
+      Review the manual install plan. Once approved, the following resources will be created in
+      order to satisfy the requirements for the components specified in the plan. Click the resource
+      name to view the resource in detail.
+    </p>
+    <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
+      <Button variant="primary" onClick={approve}>
+        Approve
+      </Button>
+      <Link
+        to={`${resourcePathFromModel(
+          SubscriptionModel,
+          obj?.metadata?.name,
+          namespace,
+        )}?showDelete=true`}
+      >
+        <Button className="co-clusterserviceversion__button" variant="secondary">
+          Deny
+        </Button>
+      </Link>
+      <ViewInstalledOperatorsButton namespace={namespace} />
+    </ActionGroup>
+  </>
+);
+
+const CreateCRDButton: React.FC<CRDButtonProps> = ({ obj, disabled }) => {
+  if (!getCRDFromObject(obj)) {
+    return null;
+  }
+  let cr = null;
+  try {
+    cr = JSON.parse(getCRDFromObject(obj));
+  } catch (error) {
+    const errorMsg = error.message;
+    errorModal({ errorMsg });
+  }
+  const crNamespace = cr?.[0]?.metadata.namespace;
+  const apiVersion = cr?.[0]?.apiVersion;
+  const kind = cr?.[0]?.kind;
+  const { group, version } = groupVersionFor(apiVersion);
+  const reference = referenceForGroupVersionKind(group)(version)(kind);
+  return (
+    <Link
+      to={`${resourcePathFromModel(
+        ClusterServiceVersionModel,
+        obj.metadata.name,
+        crNamespace,
+      )}/${reference}/~new`}
+    >
+      <Button isDisabled={disabled} variant="primary">
+        Create {kind}
+      </Button>
+    </Link>
+  );
+};
+
+const InstallPageCRDRequiredMessage: React.FC<InstallCRDMessageProps> = ({ obj }) => {
+  if (!getCRDFromObject(obj)) {
+    return null;
+  }
+  let cr = null;
+  try {
+    cr = JSON.parse(getCRDFromObject(obj));
+  } catch (error) {
+    const errorMsg = error.message;
+    errorModal({ errorMsg });
+  }
+  const crdKind = cr?.[0]?.kind;
+  const crNamespace = cr?.[0]?.metadata?.namespace;
+  const description = obj?.metadata?.annotations?.description;
+  return (
+    <div className="co-clusterserviceversion__box">
+      <span className="co-resource-item">
+        <ResourceLink kind={crdKind} name={crdKind} namepace={crNamespace} />
+        <ResourceStatus badgeAlt>
+          <StatusIconAndText icon={<RedExclamationCircleIcon />} title="Required" />
+        </ResourceStatus>
+      </span>
+      <p>{description}</p>
+    </div>
+  );
+};
+
+const InstallSucceededMessage: React.FC<InstallSuccededMessageProps> = ({
+  namespace,
+  csvName,
+  obj,
+}) => {
+  const crdMessage = getCRDFromObject(obj)
+    ? 'The operator has installed successfully. Create the required custom resource to be able to use this operator.'
+    : '';
+  return (
+    <>
+      <h2 className="co-clusterserviceversion-install__heading">
+        Installed operator - ready for use
+      </h2>
+      <span>{crdMessage}</span>
+      <InstallPageCRDRequiredMessage obj={obj} />
+      <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
+        {!getCRDFromObject(obj) && (
+          <Link to={resourcePathFromModel(ClusterServiceVersionModel, csvName, namespace)}>
+            <Button variant="primary">View Operator</Button>
+          </Link>
+        )}
+        <CreateCRDButton obj={obj} />
+        <ViewInstalledOperatorsButton namespace={namespace} />
+      </ActionGroup>
+    </>
+  );
+};
+const InstallingMessage: React.FC<InstallingMessageProps> = ({ namespace, obj }) => {
+  const reason = (obj as ClusterServiceVersionKind)?.status?.reason || '';
+  const message = (obj as ClusterServiceVersionKind)?.status?.message || '';
+  const crdMessage = getCRDFromObject(obj)
+    ? 'Once the operator is installed the required custom resource will be available for creation.'
+    : '';
+  const installMessage = `The operator is being installed. This may take a few minutes. ${crdMessage}`;
+  return (
+    <>
+      <h2 className="co-clusterserviceversion-install__heading">Installing operator</h2>
+      {reason && (
+        <div className="text-muted">
+          {reason}: {message}
+        </div>
+      )}
+      <p>{installMessage}</p>
+      <InstallPageCRDRequiredMessage obj={obj} />
+      <ActionGroup className="pf-c-form pf-c-form__group--no-top-margin">
+        {getCRDFromObject(obj) && <CreateCRDButton obj={obj} disabled />}
+        <ViewInstalledOperatorsButton namespace={namespace} />
+      </ActionGroup>
+    </>
+  );
+};
+
+const OperatorInstallStatus: React.FC<OperatorInstallPageProps> = (props) => {
+  const { resources, targetNamespace, pkgNameWithVersion } = props;
+
+  let loading = true;
+  let status = '';
+  let installObj: ClusterServiceVersionKind | InstallPlanKind =
+    resources?.clusterServiceVersions?.data;
+  const subscription = resources?.subscription?.data;
+  status = installObj?.status?.phase;
+  if (installObj && status) {
+    loading = false;
+  } else if (subscription) {
+    // There is no ClusterServiceVersion for the package, so look at Subscriptions/InstallPlans
+    status = subscription?.status?.state || null;
+    const installPlanName = subscription?.status?.installplan?.name || '';
+    const installPlan: InstallPlanKind = resources?.installPlan?.data?.find(
+      (ip) => ip.metadata.name === installPlanName,
+    );
+    if (installPlan) {
+      installObj = installPlan;
+      loading = false;
+    }
+  }
+
+  const isStatusSucceeded = status === 'Succeeded';
+  const isStatusFailed = status === 'Failed';
+  const isApprovalNeeded =
+    installObj?.spec?.approval === 'Manual' && installObj?.spec?.approved === false;
+
+  const approve = () => {
+    k8sPatch(InstallPlanModel, installObj, [
+      { op: 'replace', path: '/spec/approved', value: true },
+    ]).catch((error) => {
+      const errorMsg = error.message;
+      errorModal({ errorMsg });
+    });
+  };
+
+  let indicator = <Spinner size="lg" />;
+  if (isStatusFailed) {
+    indicator = <RedExclamationCircleIcon size="lg" />;
+  }
+  if (isApprovalNeeded) {
+    indicator = <YellowExclamationTriangleIcon size="lg" />;
+  }
+  if (isStatusSucceeded) {
+    indicator = <GreenCheckCircleIcon size="lg" />;
+  }
+
+  let installMessage = <InstallingMessage namespace={targetNamespace} obj={installObj} />;
+  if (isStatusFailed) {
+    installMessage = (
+      <InstallFailedMessage
+        namespace={targetNamespace}
+        obj={installObj}
+        csvName={pkgNameWithVersion}
+      />
+    );
+  } else if (isApprovalNeeded) {
+    installMessage = (
+      <InstallNeedsApprovalMessage
+        namespace={targetNamespace}
+        obj={subscription}
+        approve={approve}
+      />
+    );
+  } else if (isStatusSucceeded) {
+    installMessage = (
+      <InstallSucceededMessage
+        namespace={targetNamespace}
+        csvName={pkgNameWithVersion}
+        obj={installObj}
+      />
+    );
+  }
+
+  const pkgManifest = resources.packageManifest.data[0];
+  const channels = pkgManifest.status?.channels || [];
+  const channel = channels.find((ch) => ch.currentCSV === pkgNameWithVersion) || channels[0];
+  const displayName = channel?.currentCSVDesc?.displayName || '';
+  const logoVersion = channel?.currentCSVDesc?.version || '';
+
+  const CSVLogo = (
+    <ClusterServiceVersionLogo
+      displayName={displayName}
+      icon={iconFor(pkgManifest)}
+      provider={pkgManifest.status?.provider?.name || ''}
+      version={logoVersion}
+    />
+  );
+
+  return (
+    <>
+      <div className="co-operator-install-page__main">
+        <Helmet>
+          <title>Installing Operator</title>
+        </Helmet>
+        <Bullseye>
+          <div id="operator-install-page">
+            {loading && (
+              <div>
+                Installing... <Spinner size="lg" />
+              </div>
+            )}
+            {!loading && isStatusFailed && (
+              <Alert variant="danger" isInline title="Installation Failed">
+                {status}: {(installObj as ClusterServiceVersionKind)?.status?.message || ''}
+              </Alert>
+            )}
+            {!loading && (
+              <Card>
+                <CardBody>
+                  <div className="co-operator-install-page__pkg-indicator">
+                    <div>{CSVLogo}</div>
+                    <div>{indicator}</div>
+                  </div>
+                </CardBody>
+              </Card>
+            )}
+            {!loading && (
+              <Card>
+                <CardBody>{installMessage}</CardBody>
+              </Card>
+            )}
+          </div>
+        </Bullseye>
+      </div>
+      {!loading && isApprovalNeeded && (
+        <InstallPlanPreview obj={installObj as InstallPlanKind} hideApprovalBlock />
+      )}
+    </>
+  );
+};
+
+export const OperatorInstallStatusPage: React.FC<OperatorInstallPageProps> = (props) => {
+  const { pkgNameWithVersion, targetNamespace } = props;
+  const namespace = targetNamespace;
+  const pkg = new URLSearchParams(window.location.search).get('pkg');
+  const installPageResources = [
+    {
+      kind: referenceForModel(ClusterServiceVersionModel),
+      namespaced: true,
+      isList: false,
+      name: pkgNameWithVersion,
+      namespace,
+      prop: 'clusterServiceVersions',
+    },
+    {
+      kind: referenceForModel(SubscriptionModel),
+      namespaced: true,
+      isList: false,
+      name: pkg,
+      namespace,
+      optional: true,
+      prop: 'subscription',
+    },
+    {
+      kind: referenceForModel(InstallPlanModel),
+      prop: 'installPlan',
+      namespaced: true,
+      namespace,
+      isList: true,
+      optional: true,
+    },
+    {
+      isList: true,
+      kind: referenceForModel(PackageManifestModel),
+      namespace: new URLSearchParams(window.location.search).get('catalogNamespace'),
+      fieldSelector: `metadata.name=${pkg}`,
+      selector: {
+        matchLabels: {
+          catalog: new URLSearchParams(window.location.search).get('catalog'),
+        },
+      },
+      prop: 'packageManifest',
+    },
+  ];
+
+  return (
+    <Firehose resources={installPageResources}>
+      <OperatorInstallStatus {...props} />
+    </Firehose>
+  );
+};
+
+export type OperatorInstallPageProps = {
+  targetNamespace: string;
+  pkgNameWithVersion: string;
+  resources?: OperatorResources;
+};
+
+type InstallSuccededMessageProps = {
+  namespace: string;
+  obj: ClusterServiceVersionKind | InstallPlanKind;
+  csvName: string;
+};
+type InstallNeedsApprovalMessageProps = {
+  namespace: string;
+  obj: SubscriptionKind;
+  approve: () => void;
+};
+type InstallingMessageProps = {
+  namespace: string;
+  obj: ClusterServiceVersionKind | InstallPlanKind;
+};
+type InstallFailedMessageProps = {
+  namespace: string;
+  obj: ClusterServiceVersionKind | InstallPlanKind;
+  csvName: string;
+};
+type InstallCRDMessageProps = {
+  obj: ClusterServiceVersionKind | InstallPlanKind;
+};
+type CRDButtonProps = {
+  obj: ClusterServiceVersionKind | InstallPlanKind | SubscriptionKind;
+  disabled?: boolean;
+};
+type ViewOperatorButtonProps = {
+  namespace: string;
+};
+export interface OperatorResources {
+  clusterServiceVersions: FirehoseResult<ClusterServiceVersionKind>;
+  subscription: FirehoseResult<SubscriptionKind>;
+  installPlan: FirehoseResult<InstallPlanKind[]>;
+  packageManifest: FirehoseResult<PackageManifestKind[]>;
+}

--- a/frontend/packages/operator-lifecycle-manager/src/style.scss
+++ b/frontend/packages/operator-lifecycle-manager/src/style.scss
@@ -254,3 +254,44 @@ $co-affinity-row-margin: 15px;
 .olm-descriptor__title {
   display: inline-block;
 }
+
+#operator-install-page .pf-c-card {
+  margin-bottom: 5px;
+  max-width: 600px;
+  // margin-top: auto;
+}
+
+#operator-install-page .pf-c-alert {
+  margin-bottom: 5px;
+}
+
+#operator-install-page .pf-c-button.co-clusterserviceversion__button {
+  margin-left: 10px;
+}
+
+.co-clusterserviceversion-install__heading {
+  font-weight: bold;
+  padding-bottom: 10px;
+}
+
+.co-clusterserviceversion__box {
+  border: 1px solid black;
+  padding: 15px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.co-operator-install-page__pkg-indicator {
+  display: flex;
+  justify-content: space-between;
+}
+
+.co-operator-install-page__main {
+  background-color: #f0f0f0;
+  height: 100%;
+}
+
+.co-operator-install-page__link {
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
When a user installs an operator, an install page will now show to indicate what is happening with that process.
Also, from the 'Installed Operators' page, the link for the operator will now go to the install page if the status is InstallReady or Installing.

![Screenshot_2020-04-14 Operator Install · OKD(1)](https://user-images.githubusercontent.com/18728857/79291743-aa8b5280-7e8c-11ea-87dd-3ab377d9a0d4.png)
Updated style spacing here:
![Screenshot_2020-07-22 View Install · OKD(4)](https://user-images.githubusercontent.com/18728857/88221464-c6d42380-cc21-11ea-80c8-5a8cd7239a2f.png)
![Screenshot_2020-07-22 View Install · OKD(3)](https://user-images.githubusercontent.com/18728857/88221489-d2274f00-cc21-11ea-9318-b7671e271fcd.png)



Error Conditions:
![Screenshot_2020-04-14 Operator Install · OKD(6)](https://user-images.githubusercontent.com/18728857/79291903-11107080-7e8d-11ea-837c-0f972652ca57.png)

Manual Approval: 
![Screenshot_2020-07-21 View Install · OKD(1)](https://user-images.githubusercontent.com/18728857/88221583-ee2af080-cc21-11ea-9b6a-41964bec766d.png)

![Screenshot_2020-07-22 View Install · OKD(3)](https://user-images.githubusercontent.com/18728857/88221522-db182080-cc21-11ea-9f31-48c96e1382e7.png)

Also add CRD creation buton to the install page:
![Screenshot_2020-04-20 View Install · OKD](https://user-images.githubusercontent.com/18728857/79790903-b2724900-8309-11ea-9d4a-f7ad585b1523.png)
![Screenshot_2020-04-20 View Install · OKD(2)](https://user-images.githubusercontent.com/18728857/79790931-bbfbb100-8309-11ea-9620-9e567f8c09e9.png)










