### PR TITLE
kubevirt: fix ovirt provider bugs + VM navigation on delete 

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/providers/ovirt/ovirt-prefill-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/providers/ovirt/ovirt-prefill-vm.ts
@@ -116,6 +116,7 @@ export const getNics = (vm: OvirtVM): VMWizardNetwork[] => {
         .asResource(),
       importData: {
         id: nic.id,
+        netID: nic.netid,
       },
       editConfig: {
         disableEditing: true,

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/types.ts
@@ -281,6 +281,7 @@ export type VMWizardNetwork = {
   editConfig?: UINetworkEditConfig;
   importData?: {
     id?: string;
+    netID?: string;
   };
 };
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -9,7 +9,7 @@ import { isVMImporting, isVMRunning, isVMRunningWithVMI } from '../../selectors/
 import { getMigrationVMIName, isMigrating, findVMIMigration } from '../../selectors/vmi-migration';
 import { VirtualMachineInstanceMigrationModel } from '../../models';
 import { VMMultiStatus } from '../../types';
-import { restartVM, startVM, stopVM, VMActionType } from '../../k8s/requests/vm';
+import { deleteVM, restartVM, startVM, stopVM, VMActionType } from '../../k8s/requests/vm';
 import { startVMIMigration } from '../../k8s/requests/vmi';
 import { cancelMigration } from '../../k8s/requests/vmim';
 import { cloneVMModal } from '../modals/clone-vm-modal';
@@ -18,6 +18,7 @@ import { getVMStatus } from '../../statuses/vm/vm';
 import { isVMIPaused } from '../../selectors/vmi';
 import { unpauseVMI, VMIActionType } from '../../k8s/requests/vmi/actions';
 import { VMImportKind } from '../../types/vm-import/ovirt/vm-import';
+import { getVMLikeModelListPath } from '../../utils/utils';
 
 type ActionArgs = {
   migration?: K8sResourceKind;
@@ -164,6 +165,13 @@ const menuActionCdEdit = (kindObj: K8sKind, vm: VMKind, { vmStatus }: ActionArgs
   };
 };
 
+export const menuActionDelete = (kindObj: K8sKind, vm: VMKind): KebabOption => ({
+  label: `Delete ${kindObj.label}`,
+  href: getVMLikeModelListPath(false, getNamespace(vm)),
+  callback: () => deleteVM(vm),
+  accessReview: asAccessReview(kindObj, vm, 'delete'),
+});
+
 export const vmMenuActions = [
   menuActionStart,
   menuActionStop,
@@ -175,7 +183,7 @@ export const vmMenuActions = [
   menuActionCdEdit,
   Kebab.factory.ModifyLabels,
   Kebab.factory.ModifyAnnotations,
-  Kebab.factory.Delete,
+  menuActionDelete,
 ];
 
 export const vmiMenuActions = [

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/import-ovirt.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/v2v/import/import-ovirt.ts
@@ -80,13 +80,16 @@ const getDiskMappings = (storage: VMWizardStorage[]) =>
     .filter(({ type, importData }) => type === VMWizardStorageType.V2V_OVIRT_IMPORT && importData)
     .map(({ persistentVolumeClaim, importData: { id } }) => {
       const pvcWrapper = new PersistentVolumeClaimWrapper(persistentVolumeClaim);
-      return {
-        source: { id },
-        target: {
-          name: pvcWrapper.getStorageClassName() || null,
-        },
-      } as DiskMapping;
-    });
+      return pvcWrapper.getStorageClassName()
+        ? ({
+            source: { id },
+            target: {
+              name: pvcWrapper.getStorageClassName(),
+            },
+          } as DiskMapping)
+        : null;
+    })
+    .filter((m) => m);
 
 const createVMImport = async (
   {
@@ -117,7 +120,6 @@ const createVMImport = async (
     .getOvirtSourceWrapper()
 
     .setVM(vm?.id)
-    .setStorageMappings([]) // TODO may not be needed in the future to send empty
     .setNetworkMappings(getNetworkMappings(networks))
     .setDiskMappings(getDiskMappings(storages));
 

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/actions.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/actions.ts
@@ -1,9 +1,16 @@
-import { k8sPatch, resourceURL } from '@console/internal/module/k8s';
-import { getName, getNamespace } from '@console/shared';
+import { k8sGet, k8sKill, k8sPatch, resourceURL } from '@console/internal/module/k8s';
+import {
+  getName,
+  getNamespace,
+  getOwnerReferences,
+  getDeletetionTimestamp,
+} from '@console/shared/src';
 import { coFetch } from '@console/internal/co-fetch';
 import { getPxeBootPatch } from '../../patches/vm/vm-boot-patches';
-import { VirtualMachineModel } from '../../../models';
+import { VirtualMachineImportModel, VirtualMachineModel } from '../../../models';
 import { VMKind } from '../../../types/vm';
+import { buildOwnerReferenceForModel } from '../../../utils';
+import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
 
 export enum VMActionType {
   Start = 'start',
@@ -41,3 +48,26 @@ export const VMActionWithPXERequest = async (vm: VMKind, action: VMActionType) =
 export const startVM = async (vm: VMKind) => VMActionWithPXERequest(vm, VMActionType.Start);
 export const stopVM = async (vm: VMKind) => VMActionRequest(vm, VMActionType.Stop);
 export const restartVM = async (vm: VMKind) => VMActionWithPXERequest(vm, VMActionType.Restart);
+export const deleteVM = async (vm: VMKind) => {
+  const vmImportOwnerReference = (getOwnerReferences(vm) || []).find((reference) =>
+    compareOwnerReference(reference, buildOwnerReferenceForModel(VirtualMachineImportModel), true),
+  );
+
+  if (vmImportOwnerReference) {
+    const namespace = getNamespace(vm);
+    await k8sKill(VirtualMachineImportModel, {
+      metadata: { name: vmImportOwnerReference.name, namespace },
+    });
+    try {
+      const deletingVM = await k8sGet(VirtualMachineModel, getName(vm), namespace);
+      if (deletingVM && !getDeletetionTimestamp(deletingVM)) {
+        // just lost reference - kill again
+        await k8sKill(VirtualMachineModel, vm);
+      }
+    } catch (ignored) {
+      // 404 expected
+    }
+  } else {
+    await k8sKill(VirtualMachineModel, vm);
+  }
+};

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm-import/vm-import-ovirt-source-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm-import/vm-import-ovirt-source-wrapper.ts
@@ -26,6 +26,7 @@ export class VMImportOvirtSourceWrappper extends Wrapper<
   setNetworkMappings = (networkMappings: NetworkMapping[]) => {
     this.ensurePath('mappings');
     this.data.mappings.networkMappings = networkMappings;
+    this.clearIfEmpty('mappings.networkMappings');
     this.clearIfEmpty('mappings');
     return this;
   };
@@ -33,6 +34,7 @@ export class VMImportOvirtSourceWrappper extends Wrapper<
   setStorageMappings = (storageMappings: StorageMapping[]) => {
     this.ensurePath('mappings');
     this.data.mappings.storageMappings = storageMappings;
+    this.clearIfEmpty('mappings.storageMappings');
     this.clearIfEmpty('mappings');
     return this;
   };
@@ -40,6 +42,7 @@ export class VMImportOvirtSourceWrappper extends Wrapper<
   setDiskMappings = (diskMappings: DiskMapping[]) => {
     this.ensurePath('mappings');
     this.data.mappings.diskMappings = diskMappings;
+    this.clearIfEmpty('mappings.diskMappings');
     this.clearIfEmpty('mappings');
     return this;
   };

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm-import/vm-import-ovirt-source-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm-import/vm-import-ovirt-source-wrapper.ts
@@ -24,17 +24,23 @@ export class VMImportOvirtSourceWrappper extends Wrapper<
   };
 
   setNetworkMappings = (networkMappings: NetworkMapping[]) => {
-    this.data.networkMappings = networkMappings;
+    this.ensurePath('mappings');
+    this.data.mappings.networkMappings = networkMappings;
+    this.clearIfEmpty('mappings');
     return this;
   };
 
   setStorageMappings = (storageMappings: StorageMapping[]) => {
-    this.data.storageMappings = storageMappings;
+    this.ensurePath('mappings');
+    this.data.mappings.storageMappings = storageMappings;
+    this.clearIfEmpty('mappings');
     return this;
   };
 
   setDiskMappings = (diskMappings: DiskMapping[]) => {
-    this.data.diskMappings = diskMappings;
+    this.ensurePath('mappings');
+    this.data.mappings.diskMappings = diskMappings;
+    this.clearIfEmpty('mappings');
     return this;
   };
 }

--- a/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm-import/vm-import-wrapper.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/wrapper/vm-import/vm-import-wrapper.ts
@@ -57,6 +57,8 @@ export class VMImportWrappper extends K8sResourceObjectWithTypePropertyWrapper<
       : undefined;
   };
 
+  getResolvedVMTargetName = () => this.data.status?.targetVmName || this.data.spec?.targetVmName;
+
   protected sanitize(type: VMImportType, data: VMImportOvirtSource) {
     return super.sanitize(type, data) || ({} as any);
   }

--- a/frontend/packages/kubevirt-plugin/src/types/vm-import/ovirt/ovirt-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/vm-import/ovirt/ovirt-vm.ts
@@ -1,5 +1,7 @@
 export type OvirtNIC = {
   id: string;
+  netid: string;
+  netname: string;
   name: string;
   mac: string;
   interface: string;

--- a/frontend/packages/kubevirt-plugin/src/types/vm-import/ovirt/vm-import.ts
+++ b/frontend/packages/kubevirt-plugin/src/types/vm-import/ovirt/vm-import.ts
@@ -33,9 +33,11 @@ export type VMImportOvirtSource = {
       id?: string;
     };
   };
-  networkMappings?: NetworkMapping[];
-  storageMappings?: StorageMapping[];
-  diskMappings?: DiskMapping[];
+  mappings: {
+    networkMappings?: NetworkMapping[];
+    storageMappings?: StorageMapping[];
+    diskMappings?: DiskMapping[];
+  };
 };
 
 export type VMImportKind = {


### PR DESCRIPTION
- navigate to vms tab on vm delete from detail
- fix mappings location
- allow empty storage classNames
- remove VM import in progress when removing VM
- do not send empty mappings