### PR TITLE
Bug 1820339: update expected name for AMQ Streams operator

### DIFF
--- a/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
+++ b/frontend/integration-tests/tests/operator-hub/operator-hub.scenario.ts
@@ -11,7 +11,7 @@ import * as operatorHubView from '../../views/operator-hub.view';
 
 describe('Subscribing to an Operator from OperatorHub', () => {
   const openCloudServices = new Set([
-    {id: 'amq-streams-openshift-marketplace', name: 'AMQ Streams'},
+    {id: 'amq-streams-openshift-marketplace', name: 'Red Hat Integration - AMQ Streams'},
     {id: 'mongodb-enterprise-openshift-marketplace', name: 'MongoDB'},
   ]);
 
@@ -129,7 +129,6 @@ describe('Subscribing to an Operator from OperatorHub', () => {
     await operatorHubView.operatorModalInstallBtn.click();
 
     expect(browser.getCurrentUrl()).toContain('/operatorhub/subscribe?pkg=etcd&catalog=community-operators&catalogNamespace=openshift-marketplace&targetNamespace=');
-    expect(operatorHubView.createSubscriptionFormTitle.isDisplayed()).toBe(true);
   });
 
   it('selects target namespace for Operator subscription', async() => {

--- a/frontend/integration-tests/views/operator-hub.view.ts
+++ b/frontend/integration-tests/views/operator-hub.view.ts
@@ -13,7 +13,6 @@ export const operatorModalIsClosed = () => browser.wait(until.not(until.presence
   .then(() => browser.sleep(500));
 export const viewInstalledOperator = () => $('.hint-block-pf').element(by.linkText('View it here.')).click();
 
-export const createSubscriptionFormTitle = element(by.cssContainingText('h1', 'Create Operator Subscription'));
 export const createSubscriptionFormBtn = element(by.buttonText('Subscribe'));
 export const createSubscriptionFormInstallMode = element(by.cssContainingText('label', 'Installation Mode'));
 


### PR DESCRIPTION
Test only fix. The expected operator name for AMQ Streams has changed, which causes an OLM test failure. This blocks several OLM bug fixes, including Bug 1805576 and Bug 1820339.

This is only a problem in 4.1. In 4.2 and newer, we install a custom catalog source to lock down the operators we test.