### PR TITLE
Bug 1821387: Reenable performance test "downloads new bundle for ${routeName}"

### DIFF
--- a/frontend/integration-tests/tests/performance.scenario.ts
+++ b/frontend/integration-tests/tests/performance.scenario.ts
@@ -62,7 +62,7 @@ describe('Performance test', () => {
     };
 
     // Temporarily disable performance tests.
-    xit(`downloads new bundle for ${routeName}`, async () => {
+    it(`downloads new bundle for ${routeName}`, async () => {
       await browser.get(`${appHost}/k8s/cluster/namespaces`);
       await crudView.isLoaded();
       await browser.executeScript(() => performance.setResourceTimingBufferSize(1000));


### PR DESCRIPTION
Potentially for https://bugzilla.redhat.com/show_bug.cgi?id=1821387
- Opened against 4.3.z
- Disabled this set of tests due to https://bugzilla.redhat.com/show_bug.cgi?id=1811886 (fixed)
- Reenabling the test to see if it's in a functional state now.
