### PR TITLE
Show release notes in topology after Helm install

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
+++ b/frontend/packages/dev-console/src/components/helm/form/HelmInstallUpgradeForm.tsx
@@ -47,9 +47,9 @@ const HelmInstallUpgradeForm: React.FC<FormikProps<FormikValues> & HelmInstallUp
       <FormFooter
         handleReset={handleReset}
         errorMessage={status && status.submitError}
-        isSubmitting={isSubmitting}
+        isSubmitting={status?.isSubmitting || isSubmitting}
         submitLabel={submitLabel}
-        disableSubmit={(chartVersion && !dirty) || !_.isEmpty(errors)}
+        disableSubmit={(chartVersion && !dirty) || status?.isSubmitting || !_.isEmpty(errors)}
         resetLabel="Cancel"
       />
     </FlexForm>

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -44,6 +44,7 @@ export interface HelmChartMetaData {
 
 export interface HelmReleaseResourcesData {
   releaseName: string;
+  releaseVersion: number | string;
   chartIcon: string;
   manifestResources: K8sResourceKind[];
   releaseNotes: string;

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -106,7 +106,7 @@ export const getHelmActionConfig = (
         subTitle: 'The helm chart will be installed using the YAML shown in the editor below.',
         helmReleaseApi: `/api/helm/chart?url=${chartURL}`,
         fetch: coFetchJSON.post,
-        redirectURL: `/topology/ns/${namespace}`,
+        redirectURL: `/topology/ns/${namespace}/graph`,
       };
     case HelmActionType.Upgrade:
       return {

--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -78,6 +78,7 @@ const Controller: React.FC<ControllerProps> = ({
                   if (!acc.hasOwnProperty(resourceKindName)) {
                     acc[resourceKindName] = {
                       releaseName: release.name,
+                      releaseVersion: release.version,
                       chartIcon: release.chart.metadata.icon,
                       manifestResources,
                       releaseNotes: release.info.notes,

--- a/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/topology-test-data.ts
@@ -2166,6 +2166,7 @@ export const sampleHelmChartDeploymentConfig = {
 export const sampleHelmResourcesMap = {
   'DeploymentConfig---nodejs-helm': {
     releaseName: 'nodejs-helm',
+    releaseVersion: 1,
     chartIcon: '',
     manifestResources: [sampleHelmChartDeploymentConfig],
     releaseNotes: 'test release notes',

--- a/frontend/packages/dev-console/src/components/topology/helm/helm-data-transformer.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/helm-data-transformer.ts
@@ -41,6 +41,7 @@ export const getTopologyHelmReleaseGroupItem = (
   const resourceKindName = getHelmReleaseKey(obj);
   const helmResources = helmResourcesMap[resourceKindName];
   const releaseName = helmResources?.releaseName;
+  const releaseVersion = helmResources?.releaseVersion;
   const releaseNotes = helmResources?.releaseNotes;
   const uid = _.get(obj, ['metadata', 'uid'], null);
   const returnData = { groups: [], dataModel: {} };
@@ -51,7 +52,7 @@ export const getTopologyHelmReleaseGroupItem = (
 
   const secret = secrets.find((nextSecret) => {
     const { labels } = nextSecret.metadata;
-    return labels && labels.name && labels.name.includes(releaseName);
+    return labels?.name?.includes(releaseName) && labels?.version === releaseVersion.toString();
   });
 
   if (secret) {


### PR DESCRIPTION
**Fixes**: 
- https://issues.redhat.com/browse/ODC-3328
- https://issues.redhat.com/browse/ODC-2978

**Analysis / Root cause**: User needs to see the release notes of a helm chart after the installation is complete. For that we need to open the Topology side panel after the redirect from Helm Install form. There is no way currently in Topology to handle pre selected node items.

**Solution Description**: 
- Add support pre-selecting nodes in Topology. 
- On selection of nodes update the URL with `selectId` parameter.
- Fetch release secret resource after Helm install and get the `uid` of the resource.
- Use that `uid` to redirect to Topology in pre-selected mode.
- Add support in topology to pre-select a tab in side panel.
- Also updated the form to disable submit button and show progress animation while installation is happening.
**Screen shots / Gifs for design review**: 
![Release Notes](https://user-images.githubusercontent.com/6041994/79378383-ddac0f80-7f7a-11ea-94ab-e5f51fc1382b.gif)


**Unit test coverage report**: 
![Screenshot from 2020-04-16 00-42-12](https://user-images.githubusercontent.com/6041994/79378555-2c59a980-7f7b-11ea-887f-65d547c6dd21.png)
![Screenshot from 2020-04-16 00-42-47](https://user-images.githubusercontent.com/6041994/79378557-2e236d00-7f7b-11ea-9c9d-34b68809301c.png)


**Test setup:** While running locally update `HelmInstallUpgradePage:125` to run even when there is no release notes in response.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge