### PR TITLE
Bug 1824029: Handle undefined MachineConfigPools status

### DIFF
--- a/frontend/public/components/machine-config-pool.tsx
+++ b/frontend/public/components/machine-config-pool.tsx
@@ -52,7 +52,7 @@ const getConditionStatus = (
   mcp: MachineConfigPoolKind,
   type: MachineConfigPoolConditionType,
 ): K8sResourceCondition['status'] => {
-  const { conditions } = mcp.status;
+  const { conditions } = mcp.status || {};
   const condition = _.find(conditions, { type });
   return condition ? condition.status : K8sResourceConditionStatus.Unknown;
 };


### PR DESCRIPTION
When creating a fresh MCP and immediately redirecting to the MCP list page, the created MCP is missing the `status` field.  Defaulting to `Unknown` for the condition columns when the status is missing.
Screen:
![Screenshot 2020-04-16 at 09 29 55](https://user-images.githubusercontent.com/1668218/79428586-a8c5aa00-7fc6-11ea-8ae4-c7179f63ec61.png)

Wasnt really sure here if `Unknown` is better then `-`

/assign @spadgett 