### PR TITLE
Bug 1823616: Make Tag field optional for the ImageStreamImport validation schema

### DIFF
--- a/frontend/packages/dev-console/src/components/import/validation-schema.ts
+++ b/frontend/packages/dev-console/src/components/import/validation-schema.ts
@@ -253,6 +253,6 @@ export const searchTermValidationSchema = yup.string().required('Required');
 export const isiValidationSchema = yup.object().shape({
   name: yup.string().required('Required'),
   image: yup.object().required('Required'),
-  tag: yup.string().required('Required'),
+  tag: yup.string(),
   status: yup.string().required('Required'),
 });


### PR DESCRIPTION
When trying to import IS with without specifying the Tag, then `latest` is imported, which is valid.
But then importing  a IS using fullspec with SHA, then the Tag is not imported, which makes the Deploy Image form invalid. For this case the Tag field should not be required.

 /assign @andrewballantyne