### PR TITLE
Bug 1824356: Make RoleBinding row filter static

### DIFF
--- a/frontend/public/components/RBAC/bindings.jsx
+++ b/frontend/public/components/RBAC/bindings.jsx
@@ -268,18 +268,13 @@ const roleResources = [
 const rowFilters = [
   {
     type: 'role-binding-kind',
-    selected: ['cluster', 'namespace'],
+    filterGroupName: 'Scope',
     reducer: bindingType,
-    items: ({ ClusterRoleBinding: data }) => {
-      const items = [
-        { id: 'namespace', title: 'Namespace Role Bindings' },
-        { id: 'system', title: 'System Role Bindings' },
-      ];
-      if (data && data.loaded && !data.loadError) {
-        items.unshift({ id: 'cluster', title: 'Cluster-wide Role Bindings' });
-      }
-      return items;
-    },
+    items: [
+      { id: 'cluster', title: 'Cluster-wide Role Bindings' },
+      { id: 'system', title: 'System Role Bindings' },
+      { id: 'namespace', title: 'Namespace Role Bindings' },
+    ],
   },
 ];
 

--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -306,7 +306,7 @@ export const RolesPage = ({ namespace, mock, showTitle }) => {
       rowFilters={[
         {
           type: 'role-kind',
-          selected: ['cluster', 'namespace'],
+          filterGroupName: 'Scope',
           reducer: roleType,
           items: [
             { id: 'cluster', title: 'Cluster-wide Roles' },


### PR DESCRIPTION
The RowFilter for the role bindings as a function was introduced back in old bridge repository. Not really sure what was the motivation behind it but in https://github.com/openshift/console/pull/4765 the filtering logic was rewritten and now the RowFilter `items` are typed as [array](https://github.com/openshift/console/blob/master/frontend/public/components/filter-toolbar.tsx#L343). Unfortunately we are still using JSX in the `binding.jsx`.
For the Role list page we are using similar [static list](https://github.com/openshift/console/blob/master/frontend/public/components/RBAC/role.jsx#L311-L315).

/assign @spadgett 