### PR TITLE
Remove method searchYAML from console-shared

### DIFF
--- a/frontend/packages/console-shared/src/test-utils/utils.ts
+++ b/frontend/packages/console-shared/src/test-utils/utils.ts
@@ -161,19 +161,6 @@ export const waitForStringNotInElement = (elem: any, needle: string) => {
   };
 };
 
-/**
- * Search YAML manifest for a given string. Return true if found.
- * @param     {string}    needle    String to search in YAML.
- * @param     {string}    name      Name of the resource.
- * @param     {string}    namespace Namespace of the resource.
- * @param     {string}    kind      Kind of the resource.
- * @returns   {boolean}             True if found, false otherwise.
- */
-export function searchYAML(needle: string, name: string, namespace: string, kind: string): boolean {
-  const result = execSync(`kubectl get -o yaml -n ${namespace} ${kind} ${name}`).toString();
-  return result.search(needle) >= 0;
-}
-
 type CardInfo = {
   text: string;
   index: number;

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/models/detailView.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/models/detailView.ts
@@ -5,6 +5,7 @@ import { isLoaded, resourceTitle } from '@console/internal-integration-tests/vie
 import { activeTab } from '../../views/detailView.view';
 import * as VmsListView from '../../views/vms.list.view';
 import { TAB } from '../utils/consts';
+import { getResourceObject } from '../utils/utils';
 
 export class DetailView {
   readonly name: string;
@@ -17,6 +18,10 @@ export class DetailView {
     this.name = instance.name;
     this.namespace = instance.namespace;
     this.kind = instance.kind;
+  }
+
+  getResource() {
+    return getResourceObject(this.name, this.namespace, this.kind);
   }
 
   static async getResourceTitle() {

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.clone.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.clone.scenario.ts
@@ -12,7 +12,6 @@ import {
 import {
   removeLeakedResources,
   waitForCount,
-  searchYAML,
   withResource,
   createResources,
   deleteResources,
@@ -22,6 +21,7 @@ import {
 } from '@console/shared/src/test-utils/utils';
 import * as cloneDialogView from '../views/dialogs/cloneVirtualMachineDialog.view';
 import { getVolumes, getDataVolumeTemplates } from '../../src/selectors/vm/selectors';
+import { getLabels } from '../../src/selectors/selectors';
 import { getResourceObject, getRandStr, createProject } from './utils/utils';
 import {
   CLONE_VM_TIMEOUT_SECS,
@@ -225,8 +225,8 @@ describe('Test clone VM.', () => {
 
     it('Cloned VM has vm.kubevirt.io/name label.', () => {
       expect(
-        searchYAML(`vm.kubevirt.io/name: ${vm.name}`, clonedVM.name, clonedVM.namespace, 'vm'),
-      ).toBeTruthy();
+        _.has(getLabels(getResourceObject(vm.name, vm.namespace, 'vmi')), 'vm.kubevirt.io/name'),
+      ).toBe(true);
     });
   });
 

--- a/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.resources.scenario.ts
+++ b/frontend/packages/kubevirt-plugin/integration-tests/tests/vm.resources.scenario.ts
@@ -8,7 +8,6 @@ import {
   deleteResources,
   createResource,
   deleteResource,
-  searchYAML,
   withResource,
 } from '@console/shared/src/test-utils/utils';
 import { createNICButton } from '../views/kubevirtDetailView.view';
@@ -82,7 +81,12 @@ describe('Add/remove disks and NICs on respective VM pages', () => {
       await vm.addNIC(multusNetworkInterface);
       expect(await vm.getAttachedNICs()).toContain(multusNetworkInterface);
       await vm.action(VM_ACTION.Start);
-      expect(searchYAML(multusNetworkInterface.network, vm.name, vm.namespace, 'vmi')).toBe(true);
+      expect(
+        _.find(
+          getInterfaces(getResourceObject(vm.name, vm.namespace, 'vmi')),
+          (o) => o.name === multusNetworkInterface.name,
+        ),
+      ).toBeDefined();
       await vm.action(VM_ACTION.Stop);
       await vm.removeNIC(multusNetworkInterface.name);
       expect(await vm.getAttachedNICs()).not.toContain(multusNetworkInterface);
@@ -100,9 +104,9 @@ describe('Add/remove disks and NICs on respective VM pages', () => {
     }
 
     // Verify the NIC is added in VM Manifest
-    const resource = getResourceObject(vm.name, vm.namespace, vm.kind);
-    const nic = _.find(getInterfaces(resource), (o) => o.name === multusNetworkInterface.name);
-    expect(nic).not.toBe(undefined);
+    expect(
+      _.find(getInterfaces(vm.getResource()), (o) => o.name === multusNetworkInterface.name),
+    ).toBeDefined();
 
     // Try to add the NIC again
     await click(createNICButton, 1000);


### PR DESCRIPTION
As pointed out by @spadgett  in #2125,
searchYAML has several pitfalls and should not be used.

Removed this method from console-shared and updated test cases that used this method.