### PR TITLE
Monitoring: Add alert description with resource links

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -1,5 +1,9 @@
 $tooltip-background-color: #151515;
 
+.co-resource-item.co-resource-item--monitoring-alert {
+  margin: 0 5px;
+}
+
 .graph-empty-state {
   min-height: 310px;
 }


### PR DESCRIPTION
Adds alert `description` (or `message` if there is no `description`) to
the page header. Replaces the names of some resources in the text with
links to those resource's details pages.

Will probably add some more resource types with a follow up PR after reviewing the existing alert descriptions.

FYI @cshinn 

![screenshot](https://user-images.githubusercontent.com/460802/79477083-b91c6a00-8044-11ea-9ae7-6ea85c1ed0b6.png)
