### PR TITLE
Update action/install buttons

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-items.tsx
@@ -469,44 +469,45 @@ export const OperatorHubTileView: React.FC<OperatorHubTileViewProps> = (props) =
                 data-test-id="operator-modal-header"
               />
               <div className="co-catalog-page__overlay-actions">
-                {detailsItem.marketplaceRemoteWorkflow && (
+                {detailsItem.marketplaceRemoteWorkflow && detailsItem.marketplaceActionText && (
                   <ExternalLink
                     additionalClassName="pf-c-button pf-m-primary co-catalog-page__overlay-action"
                     href={detailsItem.marketplaceRemoteWorkflow}
                     text={
                       <>
                         <div className="co-catalog-page__overlay-action-label">
-                          {detailsItem.marketplaceActionText || 'Purchase'}
+                          {detailsItem.marketplaceActionText}
                         </div>
                         <ExternalLinkAltIcon className="co-catalog-page__overlay-action-icon" />
                       </>
                     }
                   />
                 )}
-                {!detailsItem.installed ? (
-                  <Link
-                    className={classNames(
-                      'pf-c-button',
-                      { 'pf-m-secondary': detailsItem.marketplaceRemoteWorkflow },
-                      { 'pf-m-primary': !detailsItem.marketplaceRemoteWorkflow },
-                      'co-catalog-page__overlay-action',
-                    )}
-                    data-test-id="operator-install-btn"
-                    to={createLink}
-                  >
-                    Install
-                  </Link>
-                ) : (
-                  <Button
-                    className="co-catalog-page__overlay-action"
-                    data-test-id="operator-uninstall-btn"
-                    isDisabled={!detailsItem.installed}
-                    onClick={() => history.push(uninstallLink())}
-                    variant="secondary"
-                  >
-                    Uninstall
-                  </Button>
-                )}
+                {!detailsItem.marketplaceActionText &&
+                  (!detailsItem.installed ? (
+                    <Link
+                      className={classNames(
+                        'pf-c-button',
+                        { 'pf-m-secondary': detailsItem.marketplaceActionText },
+                        { 'pf-m-primary': !detailsItem.marketplaceActionText },
+                        'co-catalog-page__overlay-action',
+                      )}
+                      data-test-id="operator-install-btn"
+                      to={createLink}
+                    >
+                      Install
+                    </Link>
+                  ) : (
+                    <Button
+                      className="co-catalog-page__overlay-action"
+                      data-test-id="operator-uninstall-btn"
+                      isDisabled={!detailsItem.installed}
+                      onClick={() => history.push(uninstallLink())}
+                      variant="secondary"
+                    >
+                      Uninstall
+                    </Button>
+                  ))}
               </div>
             </>
           }


### PR DESCRIPTION
When there is an action text annotation, show only the button with that text/remote workflow. When there is not, show the usual install/uninstall workflow.

I'm not including screenshots because I can't get any action text annotations to show up locally; otherwise I would.

Fixes https://issues.redhat.com/browse/CONSOLE-2104.