### PR TITLE
Bug 1821432: Toggle controls in OLM CR details page do not update the CR correctly

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts
@@ -58,6 +58,7 @@ export type DescriptorProps = {
   obj: K8sResourceKind;
   model: K8sKind;
   namespace?: string;
+  onHandleError?: (message: string) => void;
 };
 
 export type CapabilityProps<C extends SpecCapability | StatusCapability> = {
@@ -67,4 +68,7 @@ export type CapabilityProps<C extends SpecCapability | StatusCapability> = {
   obj?: K8sResourceKind;
   model?: K8sKind;
   namespace?: string;
+  onHandleError?: (message: string) => void;
 };
+
+export type Error = { message: string };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -58,7 +58,8 @@ import { StatusCapability, Descriptor } from '../descriptors/types';
 import { Resources } from '../k8s-resource';
 import { referenceForProvidedAPI } from '../index';
 import { OperandLink } from './operand-link';
-import { FlagsObject, WithFlagsProps, connectToFlags } from '@console/internal/reducers/features';
+import { FlagsObject, connectToFlags, WithFlagsProps } from '@console/internal/reducers/features';
+import ErrorAlert from '@console/shared/src/components/alerts/error';
 
 const csvName = () =>
   window.location.pathname
@@ -514,6 +515,9 @@ export const OperandDetails = connectToModel((props: OperandDetailsProps) => {
     );
   });
 
+  const [errorMessage, setErrorMessage] = React.useState(null);
+  const handleError = (errorMsg: string) => setErrorMessage(errorMsg);
+
   const details = (
     <div className="co-operand-details__section co-operand-details__section--info">
       <div className="row">
@@ -540,6 +544,7 @@ export const OperandDetails = connectToModel((props: OperandDetailsProps) => {
               model={props.kindObj}
               value={blockValue(specDescriptor, spec)}
               descriptor={specDescriptor}
+              onHandleError={handleError}
             />
           </div>
         ))}
@@ -570,6 +575,7 @@ export const OperandDetails = connectToModel((props: OperandDetailsProps) => {
     <div className="co-operand-details co-m-pane">
       {_.isEmpty(primaryDescriptors) ? (
         <div className="co-m-pane__body">
+          {errorMessage && <ErrorAlert message={errorMessage} />}
           {header}
           {details}
         </div>


### PR DESCRIPTION
/assign @TheRealJon
/cc @benjaminapetersen @spadgett @tlwu2013 


Fixed this bug. However  I observed that when there is a server error - 500, no error message is shown to the user. For example, in the Resource Requirements modal, error message is displayed whenever there is a server error. 
I think it would be nice to show the user error message whenever there is a  server error. What do you think? 

![Screen Shot 2020-04-16 at 11 41 21 AM](https://user-images.githubusercontent.com/15249132/79505914-214a5c00-8003-11ea-9f51-da52b9f74794.png)
![Screen Shot 2020-04-16 at 11 42 41 AM](https://user-images.githubusercontent.com/15249132/79505917-214a5c00-8003-11ea-9dc5-5fde772861b5.png)

Resolved the above concern. Please see error screenshot:
![Screen Shot 2020-04-28 at 2 07 56 PM](https://user-images.githubusercontent.com/15249132/80523989-ec23ff00-895c-11ea-932f-ea4c1e724565.png)
