### PR TITLE
Image Vulnerabilities Tab for Pod Detail View

### DIFF
--- a/frontend/packages/container-security/src/const.ts
+++ b/frontend/packages/container-security/src/const.ts
@@ -11,7 +11,7 @@ import {
 import { Map as ImmutableMap } from 'immutable';
 import { ImageManifestVuln } from './types';
 
-export const SecurityLabellerFlag = 'SECURITY_LABELLER';
+export const ContainerSecurityFlag = 'SECURITY_LABELLER';
 
 export enum Priority {
   Defcon1 = 'Defcon1',

--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -10,13 +10,15 @@ import {
   RoutePage,
   ResourceDetailsPage,
   ResourceNSNavItem,
+  HorizontalNavTab,
 } from '@console/plugin-sdk';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import { ImageManifestVulnModel } from './models';
-import { SecurityLabellerFlag } from './const';
+import { ContainerSecurityFlag } from './const';
 import { securityHealthHandler } from './components/summary';
 import { getKebabActionsForKind } from './kebab-actions';
 import { WatchImageVuln } from './types';
+import { PodModel } from '@console/internal/models';
 
 type ConsumedExtensions =
   | ModelDefinition
@@ -27,7 +29,8 @@ type ConsumedExtensions =
   | DashboardsOverviewHealthResourceSubsystem<WatchImageVuln>
   | RoutePage
   | KebabActions
-  | ResourceNSNavItem;
+  | ResourceNSNavItem
+  | HorizontalNavTab;
 
 const plugin: Plugin<ConsumedExtensions> = [
   {
@@ -40,7 +43,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'FeatureFlag/Model',
     properties: {
       model: ImageManifestVulnModel,
-      flag: SecurityLabellerFlag,
+      flag: ContainerSecurityFlag,
     },
   },
   {
@@ -110,7 +113,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         ),
     },
     flags: {
-      required: [SecurityLabellerFlag],
+      required: [ContainerSecurityFlag],
     },
   },
   {
@@ -132,7 +135,24 @@ const plugin: Plugin<ConsumedExtensions> = [
       },
     },
     flags: {
-      required: [SecurityLabellerFlag],
+      required: [ContainerSecurityFlag],
+    },
+  },
+  {
+    type: 'HorizontalNavTab',
+    properties: {
+      model: PodModel,
+      page: {
+        name: 'Vulnerabilities',
+        href: 'vulnerabilities',
+      },
+      loader: () =>
+        import(
+          './components/image-manifest-vuln' /* webpackChunkName: "container-security" */
+        ).then((m) => m.ImageManifestVulnPodTab),
+    },
+    flags: {
+      required: [ContainerSecurityFlag],
     },
   },
 ];

--- a/frontend/public/components/pod.tsx
+++ b/frontend/public/components/pod.tsx
@@ -225,7 +225,7 @@ const PodTableHeader = () => {
 };
 PodTableHeader.displayName = 'PodTableHeader';
 
-const ContainerLink: React.FC<ContainerLinkProps> = ({ pod, name }) => (
+export const ContainerLink: React.FC<ContainerLinkProps> = ({ pod, name }) => (
   <span className="co-resource-item co-resource-item--inline">
     <ResourceIcon kind="Container" />
     <Link to={`/k8s/ns/${pod.metadata.namespace}/pods/${pod.metadata.name}/containers/${name}`}>
@@ -233,6 +233,7 @@ const ContainerLink: React.FC<ContainerLinkProps> = ({ pod, name }) => (
     </Link>
   </span>
 );
+ContainerLink.displayName = 'ContainerLink';
 
 export const ContainerRow: React.FC<ContainerRowProps> = ({ pod, container }) => {
   const cstatus = getContainerStatus(pod, container.name);


### PR DESCRIPTION
### Description

Allow users to view possible vulnerabilities in the containers running in their pods by consuming the new [`HorizontalNavTab` extension](https://github.com/openshift/console/pull/3917) in the Container Security Operator plugin.

### Screenshots

**Vulnerabilities tab in Pod detail view:**
![Screenshot_20200416_155234](https://user-images.githubusercontent.com/11700385/79514145-5900d600-7ffa-11ea-8e2b-a66a9cfe5bda.png)

Addresses https://issues.redhat.com/browse/PROJQUAY-200