### PR TITLE
 fix top three statuses in Dashboard's Inventory Card

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/inventory-card/InventoryItem.tsx
@@ -52,7 +52,7 @@ const getTop3Groups = (groups: DashboardsInventoryItemGroup[], groupIDs: string[
     }
   });
   groupStatuses.push(InventoryStatusGroup.UNKNOWN);
-  return groupIDs.sort((a, b) => groupStatuses.indexOf(b) - groupStatuses.indexOf(a)).slice(0, 3);
+  return groupIDs.sort((a, b) => groupStatuses.indexOf(a) - groupStatuses.indexOf(b)).slice(0, 3);
 };
 
 export const InventoryItem: React.FC<InventoryItemProps> = React.memo(


### PR DESCRIPTION
was showing bottom three instead, for example I cannot see that I have a VM with an Error in this example

![inv](https://user-images.githubusercontent.com/3648838/79566502-f3245500-80b2-11ea-8a1a-211edbd5b9d6.png)
