### PR TITLE
Remove selectId from URL when sidebar is closed

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -133,7 +133,7 @@ const Topology: React.FC<ComponentProps> = ({
         removeQueryArgument('selectId');
       } else {
         setSelectedIds(ids);
-        setQueryArgument('selectId', ids[0]);
+        ids.length > 0 ? setQueryArgument('selectId', ids[0]) : removeQueryArgument('selectId');
       }
     });
     visRef.current.addEventListener<ShowGroupingHintEventListener>(
@@ -219,6 +219,7 @@ const Topology: React.FC<ComponentProps> = ({
 
   const onSidebarClose = () => {
     setSelectedIds([]);
+    removeQueryArgument('selectId');
   };
 
   const renderControlBar = () => {


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3607

This PR -
- Fixes the issue where `selectId` would persist even after closing the sidebar.

Gif - 

![Peek 2020-04-17 19-26](https://user-images.githubusercontent.com/6041994/79576779-6d6bce00-80e1-11ea-9763-c621a18bbdf9.gif)
