### PR TITLE
Bug 1825109: Fix action text annotation name

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/index.ts
@@ -58,7 +58,7 @@ export enum OperatorHubCSVAnnotationKey {
   description = 'description',
   categories = 'categories',
   capabilities = 'capabilities',
-  actionText = 'marketplace.openshift.io/actionText',
+  actionText = 'marketplace.openshift.io/action-text',
   remoteWorkflow = 'marketplace.openshift.io/remote-workflow',
   supportWorkflow = 'marketplace.openshift.io/support-workflow',
   infrastructureFeatures = 'operators.openshift.io/infrastructure-features',


### PR DESCRIPTION
There was a typo made to the name of the annotation; fixing the name fixes the issue.

<img width="797" alt="Screen Shot 2020-04-17 at 10 26 56 AM" src="https://user-images.githubusercontent.com/7014965/79579800-11c82300-8096-11ea-9f24-960dc5575767.png">

Looks like it was introduced here: https://github.com/openshift/console/commit/0bd2d9f172b66e6712f490ee02c5edbb3f002a48#diff-b5902ca185fff71450cd70b8bfcfccc5

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1825109.