### PR TITLE
Search Toolbar: Add delete all in category X using bugfix from pf in latest upgrade.

### DIFF
--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -210,6 +210,7 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
           <DataToolbarContent>
             <DataToolbarItem>
               <DataToolbarFilter
+                deleteChipGroup={clearSelectedItems}
                 chips={[...selectedItems].map((resourceKind) => ({
                   key: resourceKind,
                   node: (
@@ -230,6 +231,7 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
             </DataToolbarItem>
             <DataToolbarItem className="co-search-group__filter">
               <DataToolbarFilter
+                deleteChipGroup={clearLabelFilter}
                 chips={[...labelFilter]}
                 deleteChip={removeLabelFilter}
                 categoryName="Label"


### PR DESCRIPTION
Add delete all in category except name since its only a single filter with an existing X to delete.

![Screen Shot 2020-04-18 at 3 39 58 PM](https://user-images.githubusercontent.com/35978579/79669633-e2471280-818a-11ea-85f2-c9a2da8cbae2.png)

