### PR TITLE
Bug 1825962: remove the placeholder in traffic modal tag field

### DIFF
--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
@@ -41,7 +41,7 @@ const TrafficSplittingModal: React.FC<Props> = ({
             style={{ maxWidth: '100%' }}
             required
           />
-          <InputField name="tag" type={TextInputTypes.text} placeholder="Unique Tag" required />
+          <InputField name="tag" type={TextInputTypes.text} required />
           <DropdownField
             name="revisionName"
             items={revisionItems}


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3422

**Problem**:
The placeholder text should be avoided unless they are used as real values in traffic distribution modal

**Solution**:
Removed the `Unique Id` placeholder text from the traffic distribution modal

**Screenshot**:
![image](https://user-images.githubusercontent.com/9964343/79730447-7db4c080-830e-11ea-921b-6744d276fd87.png)

cc: @serenamarie125 