### PR TITLE
Bug 1825999: updates default icon for unknown/dynamic sources

### DIFF
--- a/frontend/packages/knative-plugin/src/utils/get-knative-icon.ts
+++ b/frontend/packages/knative-plugin/src/utils/get-knative-icon.ts
@@ -1,10 +1,10 @@
 import { referenceForModel } from '@console/internal/module/k8s';
-import * as knativeImg from '@console/internal/imgs/logos/knative.svg';
 import * as apiServerSourceImg from '../imgs/logos/apiserversource.png';
 import * as camelSourceImg from '../imgs/logos/camelsource.svg';
 import * as containerSourceImg from '../imgs/logos/containersource.png';
 import * as cronJobSourceImg from '../imgs/logos/cronjobsource.png';
 import * as kafkaSourceImg from '../imgs/logos/kafkasource.svg';
+import * as eventSourceImg from '../imgs/event-source.svg';
 import {
   EventSourceCronJobModel,
   EventSourceContainerModel,
@@ -26,6 +26,6 @@ export const getKnativeEventSourceIcon = (kind: string): string => {
     case referenceForModel(EventSourceKafkaModel):
       return kafkaSourceImg;
     default:
-      return knativeImg;
+      return eventSourceImg;
   }
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3531

**Analysis / Root cause**: 
Icon for unknown/dynamic sources shown knative icon and needs to be updated based on UXD

**Solution Description**: 
Update default icon for unknown/dynamic sources

**Screen shots / Gifs for design review**: 
<img width="924" alt="Screenshot 2020-04-20 at 1 53 41 PM" src="https://user-images.githubusercontent.com/5129024/79731194-8f4a9800-830f-11ea-89ba-fc3e4669ac2d.png">

cc @openshift/team-devconsole-ux/ @serenamarie125 


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
