### PR TITLE
Bug 1825709: Monitoring: Don't allow silence comments to only contain whitespace

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1338,6 +1338,12 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
   const onSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
 
+    // Don't allow comments to only contain whitespace
+    if (_.trim(comment) === '') {
+      setError('Comment is required.');
+      return;
+    }
+
     const { alertManagerBaseURL } = window.SERVER_FLAGS;
     if (!alertManagerBaseURL) {
       setError('Alertmanager URL not set');


### PR DESCRIPTION
The `textarea`'s `required` attribute catches the case where Comment is
not provided, so this error message is just for the case where Comment
is provided by only contains whitespace characters.

![screenshot](https://user-images.githubusercontent.com/460802/79734675-13157c00-8332-11ea-8a48-ac574ce258d2.png)