### PR TITLE
Bug 1826065: Fix Add/Edit Health Check page URL for resources with crd true

### DIFF
--- a/frontend/packages/dev-console/src/actions/modify-application.ts
+++ b/frontend/packages/dev-console/src/actions/modify-application.ts
@@ -1,6 +1,6 @@
 import { KebabOption } from '@console/internal/components/utils';
 import { truncateMiddle } from '@console/internal/components/utils/truncate-middle';
-import { K8sResourceKind, K8sKind, referenceForModel } from '@console/internal/module/k8s';
+import { K8sResourceKind, K8sKind, referenceFor } from '@console/internal/module/k8s';
 import { ServiceModel as KnativeServiceModel } from '@console/knative-plugin';
 import { RESOURCE_NAME_TRUNCATE_LENGTH } from '../const';
 import { editApplicationModal } from '../components/modals';
@@ -43,13 +43,15 @@ export const EditApplication = (model: K8sKind, obj: K8sResourceKind): KebabOpti
 };
 
 export const EditHealthCheck = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
+  const {
+    kind,
+    metadata: { name, namespace },
+  } = obj;
+  const resourceKind = model.crd ? referenceFor(obj) : kind;
+  const containerName = obj?.spec?.template?.spec?.containers?.[0]?.name;
   return {
     label: 'Edit Health Checks',
-    href: `/k8s/ns/${obj.metadata.namespace}/${
-      model.kind === KnativeServiceModel.kind ? referenceForModel(KnativeServiceModel) : model.kind
-    }/${obj.metadata.name}/containers/${
-      obj?.spec?.template?.spec?.containers?.[0]?.name
-    }/health-checks`,
+    href: `/k8s/ns/${namespace}/${resourceKind}/${name}/containers/${containerName}/health-checks`,
     accessReview: {
       group: model.apiGroup,
       resource: model.plural,

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -10,7 +10,7 @@ import {
   ResourceLink,
   ResourceIcon,
 } from '@console/internal/components/utils';
-import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceFor, modelFor } from '@console/internal/module/k8s';
 import { FormFooter } from '@console/shared';
 import { getResourcesType } from '../edit-application/edit-application-utils';
 import HealthChecks from './HealthChecks';
@@ -43,6 +43,12 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
   );
   const containersByKey = _.keyBy(containers, 'name');
   const pageTitle = healthCheckAdded ? 'Edit Health Checks' : 'Add Health Checks';
+  const {
+    kind,
+    metadata: { name, namespace },
+  } = resource;
+  const kindForCRDResource = referenceFor(resource);
+  const resourceKind = modelFor(kindForCRDResource).crd ? kindForCRDResource : kind;
 
   const handleSelectContainer = (containerName: string) => {
     const containerIndex = _.findIndex(resource.spec.template.spec.containers, [
@@ -53,7 +59,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
     setFieldValue('containerName', containerName);
     setFieldValue('healthChecks', getHealthChecksData(resource, containerIndex));
     history.replace(
-      `/k8s/ns/${resource.metadata.namespace}/${resource.kind}/${resource.metadata.name}/containers/${containerName}/health-checks`,
+      `/k8s/ns/${namespace}/${resourceKind}/${name}/containers/${containerName}/health-checks`,
     );
   };
 
@@ -82,9 +88,9 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
           Health checks for &nbsp;
           <ResourceLink
             kind={referenceFor(resource)}
-            name={resource.metadata.name}
-            namespace={resource.metadata.namespace}
-            title={resource.metadata.name}
+            name={name}
+            namespace={namespace}
+            title={name}
             inline
           />
         </p>


### PR DESCRIPTION
**Fixes**: 
Bug: https://issues.redhat.com/browse/ODC-3621

**Analysis / Root cause**: 
Currently, Add/Edit Health Check Page URL manually handle for only knative resource. It should be generic and handle for all resources for resources with card true.

**Solution Description**: 
Handle Add/Edit Health Check Page URL for all resources on the basis of crd true/false.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
