### PR TITLE
Bug 1825966: When grouped by operators, the operators should be listed alphabetically

### DIFF
--- a/frontend/public/components/catalog/catalog-items.tsx
+++ b/frontend/public/components/catalog/catalog-items.tsx
@@ -226,11 +226,18 @@ const setURLParams = (params): void => {
   history.replace(`${url.pathname}${searchParams}`);
 };
 
+const sortByOperators = (items: Record<string, Item[]>): Record<string, Item[]> => {
+  const sortedItemsByOperators = {};
+  _.forEach(Object.keys(items).sort(), (key) => (sortedItemsByOperators[key] = items[key]));
+  return sortedItemsByOperators;
+};
+
 export const groupItems = (items: Item[], groupBy: string): Item[] | Record<string, Item[]> => {
   if (groupBy === GroupByTypes.Operator) {
     const installedOperators = _.filter(items, (item) => item.kind === 'InstalledOperator');
     const nonOperators = _.filter(items, (item) => item.kind !== 'InstalledOperator');
-    const groupedOperators = _.groupBy(installedOperators, (item) => item.obj.csv.spec.displayName);
+    let groupedOperators = _.groupBy(installedOperators, (item) => item.obj.csv.spec.displayName);
+    groupedOperators = sortByOperators(groupedOperators);
     const groupAllItems = { ...groupedOperators, 'Non Operators': nonOperators };
     return groupAllItems;
   }


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-3298

**Analysis / Root cause**
when grouped by operators, the operators are not listed alphabetically

**Solution Description**
added sorting logic on the grouped items

**GIF**

Before fix:
![before-fix](https://user-images.githubusercontent.com/22490998/79745610-45b97780-8326-11ea-884f-8015397d44e0.gif)

After fix:
![after-fix](https://user-images.githubusercontent.com/22490998/79745672-5c5fce80-8326-11ea-9cc7-06720d7839d9.gif)

/kind bug