### PR TITLE
[Fix][DevConsole] Use helm get release api call on release details page

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/details/HelmReleaseDetails.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/HelmReleaseDetails.tsx
@@ -13,7 +13,7 @@ import { DetailsPage } from '@console/internal/components/factory';
 import { K8sResourceKindReference } from '@console/internal/module/k8s';
 import { Status } from '@console/shared';
 import { Badge } from '@patternfly/react-core';
-import { fetchHelmReleases } from '../helm-utils';
+import { fetchHelmRelease } from '../helm-utils';
 import HelmReleaseResources from './resources/HelmReleaseResources';
 import HelmReleaseOverview from './overview/HelmReleaseOverview';
 import HelmReleaseHistory from './history/HelmReleaseHistory';
@@ -133,10 +133,9 @@ const HelmReleaseDetails: React.FC<HelmReleaseDetailsProps> = ({ secret, match }
 
     const getHelmReleases = async () => {
       try {
-        const helmReleases = await fetchHelmReleases(namespace);
+        const helmRelease = await fetchHelmRelease(namespace, helmReleaseName);
         if (!ignore) {
-          const releaseData = helmReleases.find((release) => release.name === helmReleaseName);
-          setHelmReleaseData(releaseData);
+          setHelmReleaseData(helmRelease);
         }
         // eslint-disable-next-line no-empty
       } catch {}

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -68,7 +68,7 @@ export const filterHelmReleasesByName = (releases: HelmRelease[], filter: string
 
 export const fetchHelmRelease = (
   namespace: string,
-  helmReleaseName?: string,
+  helmReleaseName: string,
 ): Promise<HelmRelease> => {
   const fetchString = `/api/helm/release?ns=${namespace}&release_name=${helmReleaseName}`;
   return coFetchJSON(fetchString);

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -66,6 +66,14 @@ export const filterHelmReleasesByName = (releases: HelmRelease[], filter: string
   return releases.filter((release: HelmRelease) => fuzzy(filter, release.name));
 };
 
+export const fetchHelmRelease = (
+  namespace: string,
+  helmReleaseName?: string,
+): Promise<HelmRelease> => {
+  const fetchString = `/api/helm/release?ns=${namespace}&release_name=${helmReleaseName}`;
+  return coFetchJSON(fetchString);
+};
+
 export const fetchHelmReleases = (
   namespace: string,
   helmReleaseName?: string,


### PR DESCRIPTION
Existing implementation uses `/api/helm/releases` api call to get release details information on release details page, which can be replaced by `/api/helm/release` to fetch single release information.

Doc ref: https://github.com/openshift/console/tree/master/docs/helm#get-helm-release