### PR TITLE
Bug 1825982: fixes camel source to show yaml editor

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/import-types.ts
+++ b/frontend/packages/knative-plugin/src/components/add/import-types.ts
@@ -6,7 +6,6 @@ import {
   EventSourceKafkaModel,
   EventSourcePingModel,
   EventSourceSinkBindingModel,
-  EventSourceCamelModel,
 } from '../../models';
 
 export const EventSources = {
@@ -16,7 +15,6 @@ export const EventSources = {
   KafkaSource: EventSourceKafkaModel.kind,
   PingSource: EventSourcePingModel.kind,
   SinkBinding: EventSourceSinkBindingModel.kind,
-  CamelSource: EventSourceCamelModel.kind,
 };
 
 export interface ProjectData {

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -111,6 +111,7 @@ export const getEventSourceResource = (formData: EventSourceFormData): K8sResour
     case EventSources.CronJobSource:
     case EventSources.ApiServerSource:
     case EventSources.SinkBinding:
+    case EventSources.PingSource:
       return getEventSourcesDepResource(formData);
     default:
       return safeLoad(formData.yamlData);


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3635

**Analysis / Root cause**: 
Camel source was in known source as well so showed Yaml Editor along with formElements 

**Solution Description**: 
Camel source should show only Yaml Editor

**Screen shots / Gifs for design review**: 
<img width="1446" alt="Screenshot 2020-04-20 at 9 35 25 PM" src="https://user-images.githubusercontent.com/5129024/79773286-e4f26500-834e-11ea-9702-930ef18a8d04.png">



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
