### PR TITLE
[release-4.4] Bug 1823855: Use ordered-values.yaml in Helm install

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/HelmInstallPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallPage.tsx
@@ -24,7 +24,7 @@ export const HelmInstallPage: React.FunctionComponent<HelmInstallPageProps> = ({
   const chartURL = decodeURIComponent(searchParams.get('chartURL'));
   const chartName = searchParams.get('chartName');
   const preselectedNamespace = searchParams.get('preselected-ns');
-  const [chartData, setChartData] = React.useState<HelmChart>();
+  const [YAMLData, setYAMLData] = React.useState<string>('');
   const [chartDataLoaded, setChartDataLoaded] = React.useState(false);
   const [chartHasValues, setChartHasValues] = React.useState(false);
 
@@ -40,9 +40,14 @@ export const HelmInstallPage: React.FunctionComponent<HelmInstallPageProps> = ({
       }
       if (ignore) return;
 
-      setChartData(res);
+      const orderedValuesFile = res?.files?.find((file) => file.name === 'ordered-values.yaml');
+      const orderedValues = orderedValuesFile ? atob(orderedValuesFile.data) : '';
+      const unorderedValues = !_.isEmpty(res?.values) ? safeDump(res?.values) : '';
+      const values = orderedValues || unorderedValues;
+
+      setYAMLData(values);
+      setChartHasValues(!!values);
       setChartDataLoaded(true);
-      !_.isEmpty(res.values) && setChartHasValues(true);
     };
 
     fetchHelmReleases();
@@ -54,7 +59,7 @@ export const HelmInstallPage: React.FunctionComponent<HelmInstallPageProps> = ({
 
   const initialValues: HelmInstallFormData = {
     releaseName: chartName || '',
-    chartValuesYAML: chartData ? safeDump(chartData.values) : undefined,
+    chartValuesYAML: YAMLData,
   };
 
   const validationSchema = yup.object().shape({

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -18,7 +18,7 @@ export interface HelmRelease {
 }
 
 export interface HelmChart {
-  files: object[];
+  files: { name: string; data: string }[];
   metadata: {
     name: string;
     version: string;


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/console/pull/5037.

Fixes - https://issues.redhat.com/browse/ODC-3485
Fixes - #4736

This PR -
- Updates the logic of getting chart values in Helm Install form.
- Now the form gives a preference to ordered-values.yaml

Screencast - 
![Peek 2020-04-20 22-21](https://user-images.githubusercontent.com/6041994/79777733-4d444500-8355-11ea-8cf0-2199cebe71de.gif)
