### PR TITLE
Bug 1826015: Align action button colors in multi/single column field

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/TextColumnField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/TextColumnField.tsx
@@ -1,8 +1,16 @@
 import * as React from 'react';
 import { FieldArray, useField } from 'formik';
-import { Flex, FlexItem, FlexModifiers, FormGroup, TextInputTypes } from '@patternfly/react-core';
+import {
+  Flex,
+  FlexItem,
+  FlexModifiers,
+  FormGroup,
+  TextInputTypes,
+  Button,
+  ButtonVariant,
+  ButtonType,
+} from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
-import { global_disabled_color_200 as disabledColor } from '@patternfly/react-tokens';
 import { InputField, useFormikValidationFix } from '@console/shared';
 import MultiColumnFieldFooter from './multi-column-field/MultiColumnFieldFooter';
 import { getFieldId } from './field-utils';
@@ -25,6 +33,7 @@ const TextColumnField: React.FC<TextColumnFieldProps> = ({
   helpText,
   placeholder,
   isReadOnly,
+  disableDeleteRow,
 }) => {
   const [field, { touched, error }] = useField<string[]>(name);
   useFormikValidationFix(field.value);
@@ -60,16 +69,18 @@ const TextColumnField: React.FC<TextColumnFieldProps> = ({
                     </FlexItem>
                     {!isReadOnly && (
                       <FlexItem>
-                        <MinusCircleIcon
-                          aria-hidden="true"
-                          style={{ color: rowValues.length === 1 ? disabledColor.value : null }}
+                        <Button
+                          aria-label="Delete"
+                          variant={ButtonVariant.plain}
+                          type={ButtonType.button}
+                          isInline
+                          isDisabled={disableDeleteRow}
                           onClick={() => {
-                            if (rowValues.length === 1) {
-                              return;
-                            }
                             arrayHelpers.remove(idx);
                           }}
-                        />
+                        >
+                          <MinusCircleIcon />
+                        </Button>
                       </FlexItem>
                     )}
                   </Flex>

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.scss
@@ -17,11 +17,7 @@
     cursor: pointer;
     line-height: var(--pf-global--spacer--xl);
     position: absolute;
-    right: -16px;
-    &.is-disabled {
-      pointer-events: none;
-      color: var(--pf-global--disabled-color--200);
-    }
+    right: -30px;
   }
   &__empty-message {
     margin-bottom: var(--pf-global--spacer--sm);

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldRow.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldRow.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import cx from 'classnames';
 import { MinusCircleIcon } from '@patternfly/react-icons';
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip, Button, ButtonVariant, ButtonType } from '@patternfly/react-core';
 import './MultiColumnField.scss';
 
 export interface MultiColumnFieldRowProps {
@@ -16,8 +15,17 @@ export interface MultiColumnFieldRowProps {
 
 const minusCircleIcon = (onDelete: () => void, disableDeleteRow?: boolean, toolTip?: string) => {
   return (
-    <div className={cx('odc-multi-column-field__col--button', { 'is-disabled': disableDeleteRow })}>
-      <MinusCircleIcon aria-hidden="true" onClick={onDelete} />
+    <div className={'odc-multi-column-field__col--button'}>
+      <Button
+        aria-label="Delete"
+        variant={ButtonVariant.plain}
+        type={ButtonType.button}
+        isInline
+        onClick={onDelete}
+        isDisabled={disableDeleteRow}
+      >
+        <MinusCircleIcon />
+      </Button>
       <span className="sr-only">{toolTip || 'Delete'}</span>
     </div>
   );

--- a/frontend/packages/dev-console/src/components/health-checks/RequestTypeForms.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/RequestTypeForms.tsx
@@ -122,6 +122,10 @@ export const TCPRequestTypeForm: React.FC<RequestTypeFormProps> = ({ ports, prob
 };
 
 export const CommandRequestTypeForm: React.FC<RequestTypeFormProps> = ({ probeType }) => {
+  const {
+    values: { healthChecks },
+  } = useFormikContext<FormikValues>();
+  const commands = healthChecks?.[probeType]?.data?.exec?.command;
   return (
     <TextColumnField
       name={`healthChecks.${probeType}.data.exec.command`}
@@ -130,6 +134,7 @@ export const CommandRequestTypeForm: React.FC<RequestTypeFormProps> = ({ probeTy
       placeholder="argument"
       helpText="The command to run inside the container."
       required
+      disableDeleteRow={commands.length === 1}
     />
   );
 };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3592

**Problem:** 
Align the action button with the colors provided by UX.

**Solution:**
Added colors for active/hover/disabled state of an action button in single/multi column fields.

**Screenshot:**

![multicolumfield](https://user-images.githubusercontent.com/9964343/80030811-5a546600-8506-11ea-8334-555b37defe40.gif)

![singleColumnfield](https://user-images.githubusercontent.com/9964343/80030832-617b7400-8506-11ea-918c-85233c6f5f1e.gif)


Browser conformance:

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @serenamarie125 