### PR TITLE
Bug 1826088: Events stream button needs proper label to be read by screen reader

### DIFF
--- a/frontend/public/components/utils/toggle-play.jsx
+++ b/frontend/public/components/utils/toggle-play.jsx
@@ -16,7 +16,14 @@ export class TogglePlay extends React.Component {
       this.props.className,
       this.props.active ? 'co-toggle-play--active' : 'co-toggle-play--inactive',
     );
-    return <Button variant="plain" className={klass} onClick={this.props.onClick} />;
+    return (
+      <Button
+        variant="plain"
+        className={klass}
+        onClick={this.props.onClick}
+        aria-label={this.props.active ? 'Pause event streaming' : 'Start streaming events'}
+      />
+    );
   }
 }
 TogglePlay.propTypes = {


### PR DESCRIPTION
This adds an aria label to the events stream play/pause button. It fixes the following axe error:
```
[
  {
    "data": "",
    "id": "button-has-visible-text",
    "impact": "critical",
    "message": "Element does not have inner text that is visible to screen readers",
    "relatedNodes": [
      {
        "html": "<button class="pf-c-button pf-m-plain co-toggle-play fa co-sysevent-stream__timeline__btn co-toggle-play--active" type="button"></button>"
      }
    ]
  }
]
```