### PR TITLE
Bug 1806528: Correct no services found message in VM details tab

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
@@ -113,7 +113,7 @@ export const VMDetails: React.FC<VMDetailsProps> = (props) => {
       </div>
       <div className="co-m-pane__body">
         <SectionHeading text="Services" />
-        <ServicesList {...restProps} data={vmServicesData} />
+        <ServicesList {...restProps} data={vmServicesData} label="Services" />
       </div>
     </StatusBox>
   );


### PR DESCRIPTION
This PR changes the message displayed when no services are found in the VM details tab from 'Not Found' to 'No Services Found'.