### PR TITLE
Bug 1827551: fix(pipelinerun-table): Fix Status column sortfield value

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/list-page/PipelineRunHeader.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/list-page/PipelineRunHeader.tsx
@@ -17,13 +17,13 @@ const PipelineRunHeader = () => {
     },
     {
       title: 'Status',
-      sortField: 'status.completionTime',
+      sortField: 'status.conditions[0].reason',
       transforms: [sortable],
       props: { className: tableColumnClasses[2] },
     },
     {
       title: 'Task Status',
-      sortField: 'status.completionTime',
+      sortField: 'status.conditions[0].reason',
       transforms: [sortable],
       props: { className: tableColumnClasses[3] },
     },


### PR DESCRIPTION
## Fixes:
Addresses https://issues.redhat.com/browse/ODC-2565

## Analysis / Root cause:
Pipeline Run Table Sort Appears UnImplemented

## Solution Description:
Changes sortfield for Status and TaskStatus

## Screenshot
![Task status sortfield](https://user-images.githubusercontent.com/24852534/79871001-64407100-8401-11ea-94c4-954ca5a29a2a.gif)

## Browser conformation
Chrome 73