### PR TITLE
Bug 1826344: add pipeline decorator and sidebar on the Knative service

### DIFF
--- a/frontend/packages/console-shared/src/hooks/index.ts
+++ b/frontend/packages/console-shared/src/hooks/index.ts
@@ -3,3 +3,4 @@ export * from './deep-compare-memoize';
 export * from './document-listener';
 export * from './fullscreen';
 export * from './scroll';
+export * from './plugins-overview-tab-section';

--- a/frontend/packages/console-shared/src/hooks/plugins-overview-tab-section.ts
+++ b/frontend/packages/console-shared/src/hooks/plugins-overview-tab-section.ts
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { AsyncComponent, AsyncComponentProps } from '@console/internal/components/utils';
+import { OverviewTabSection, isOverviewTabSection, useExtensions } from '@console/plugin-sdk';
+import { OverviewItem } from '../types';
+
+export const getResourceTabSectionComp = (t: OverviewTabSection): React.FC<AsyncComponentProps> => (
+  props: AsyncComponentProps,
+) => React.createElement(AsyncComponent, { ...props, loader: t.properties.loader });
+
+export const usePluginsOverviewTabSection = (
+  item: OverviewItem,
+): { Component: React.FC<AsyncComponentProps>; key: string }[] => {
+  const tabSections = useExtensions(isOverviewTabSection);
+  return tabSections
+    .filter((section) => item[section.properties.key])
+    .map((section: OverviewTabSection) => ({
+      Component: getResourceTabSectionComp(section),
+      key: section.properties.key,
+    }));
+};

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -21,6 +21,7 @@ import {
   getPodLabels,
   getGitAnnotations,
   getCommonAnnotations,
+  getTriggerAnnotation,
   mergeData,
 } from '../../utils/resource-label-utils';
 import { createService, createRoute, dryRunOpt } from '../../utils/shared-submit-utils';
@@ -247,12 +248,7 @@ export const createOrUpdateDeployment = (
     ...getGitAnnotations(repository, ref),
     ...getCommonAnnotations(),
     'alpha.image.policy.openshift.io/resolve-names': '*',
-    'image.openshift.io/triggers': JSON.stringify([
-      {
-        from: { kind: 'ImageStreamTag', name: `${name}:latest` },
-        fieldPath: `spec.template.spec.containers[?(@.name=="${name}")].image`,
-      },
-    ]),
+    ...getTriggerAnnotation(name),
   };
   const podLabels = getPodLabels(name);
 
@@ -476,7 +472,7 @@ export const createOrUpdateResources = async (
       imageStreamName,
       undefined,
       undefined,
-      defaultAnnotations,
+      { ...defaultAnnotations, ...getTriggerAnnotation(name) },
       _.get(appResources, 'editAppResource.data'),
     );
     return Promise.all([

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -45,6 +45,15 @@ export const getCommonAnnotations = () => {
   };
 };
 
+export const getTriggerAnnotation = (name: string) => ({
+  'image.openshift.io/triggers': JSON.stringify([
+    {
+      from: { kind: 'ImageStreamTag', name: `${name}:latest` },
+      fieldPath: `spec.template.spec.containers[?(@.name=="${name}")].image`,
+    },
+  ]),
+});
+
 export const getPodLabels = (name: string) => {
   return {
     app: name,

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -1,5 +1,6 @@
-import { K8sResourceKind } from '@console/internal/module/k8s';
 import * as _ from 'lodash';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { TRIGGERS_ANNOTATION } from '@console/shared';
 
 export const getAppLabels = (
   name: string,
@@ -46,7 +47,7 @@ export const getCommonAnnotations = () => {
 };
 
 export const getTriggerAnnotation = (name: string) => ({
-  'image.openshift.io/triggers': JSON.stringify([
+  [TRIGGERS_ANNOTATION]: JSON.stringify([
     {
       from: { kind: 'ImageStreamTag', name: `${name}:latest` },
       fieldPath: `spec.template.spec.containers[?(@.name=="${name}")].image`,

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
@@ -1,30 +1,14 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { podPhase } from '@console/internal/module/k8s';
-import { isOverviewTabSection, useExtensions } from '@console/internal/plugins';
-import { AsyncComponent } from '@console/internal/components/utils';
 import { BuildOverview } from '@console/internal/components/overview/build-overview';
 import { PodModel } from '@console/internal/models';
-import { AllPodStatus, OverviewItem } from '@console/shared';
+import { AllPodStatus, OverviewItem, usePluginsOverviewTabSection } from '@console/shared';
 import { PodsOverview } from '@console/internal/components/overview/pods-overview';
 import RevisionsOverviewList from './RevisionsOverviewList';
 import KSRoutesOverviewList from './RoutesOverviewList';
 
 const REVISIONS_AUTOSCALED = 'All Revisions are autoscaled to 0';
-
-const getResourceTabSectionComp = (t) => (props) => (
-  <AsyncComponent {...props} loader={t.properties.loader} />
-);
-
-const usePluginTabSectionResource = (item: OverviewItem) => {
-  const tabSections = useExtensions(isOverviewTabSection);
-  return tabSections
-    .filter((section) => item[section.properties.key])
-    .map((section) => ({
-      Component: getResourceTabSectionComp(section),
-      key: section.properties.key,
-    }));
-};
 
 type KnativeServiceResourceProps = {
   item: OverviewItem;
@@ -40,7 +24,7 @@ const KnativeServiceResources: React.FC<KnativeServiceResourceProps> = ({ item }
   const linkUrl = `/search/ns/${namespace}?kind=${PodModel.kind}&q=${encodeURIComponent(
     `serving.knative.dev/${resKind.toLowerCase()}=${name}`,
   )}`;
-  const pluginComponents = usePluginTabSectionResource(item);
+  const pluginComponents = usePluginsOverviewTabSection(item);
   return (
     <>
       <PodsOverview

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
-import * as plugins from '@console/internal/plugins';
 import { podPhase } from '@console/internal/module/k8s';
+import { isOverviewTabSection, useExtensions } from '@console/internal/plugins';
 import { AsyncComponent } from '@console/internal/components/utils';
 import { BuildOverview } from '@console/internal/components/overview/build-overview';
 import { PodModel } from '@console/internal/models';
@@ -16,9 +16,9 @@ const getResourceTabSectionComp = (t) => (props) => (
   <AsyncComponent {...props} loader={t.properties.loader} />
 );
 
-const getPluginTabSectionResource = (item: OverviewItem) => {
-  return plugins.registry
-    .getOverviewTabSections()
+const usePluginTabSectionResource = (item: OverviewItem) => {
+  const tabSections = useExtensions(isOverviewTabSection);
+  return tabSections
     .filter((section) => item[section.properties.key])
     .map((section) => ({
       Component: getResourceTabSectionComp(section),
@@ -40,7 +40,7 @@ const KnativeServiceResources: React.FC<KnativeServiceResourceProps> = ({ item }
   const linkUrl = `/search/ns/${namespace}?kind=${PodModel.kind}&q=${encodeURIComponent(
     `serving.knative.dev/${resKind.toLowerCase()}=${name}`,
   )}`;
-  const pluginComponents = getPluginTabSectionResource(item);
+  const pluginComponents = usePluginTabSectionResource(item);
   return (
     <>
       <PodsOverview

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeServiceResources.tsx
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import * as plugins from '@console/internal/plugins';
 import { podPhase } from '@console/internal/module/k8s';
 import { AsyncComponent } from '@console/internal/components/utils';
+import { BuildOverview } from '@console/internal/components/overview/build-overview';
 import { PodModel } from '@console/internal/models';
 import { AllPodStatus, OverviewItem } from '@console/shared';
 import { PodsOverview } from '@console/internal/components/overview/pods-overview';
@@ -15,7 +16,7 @@ const getResourceTabSectionComp = (t) => (props) => (
   <AsyncComponent {...props} loader={t.properties.loader} />
 );
 
-const getPluginTabSectionResource = (item) => {
+const getPluginTabSectionResource = (item: OverviewItem) => {
   return plugins.registry
     .getOverviewTabSections()
     .filter((section) => item[section.properties.key])
@@ -30,7 +31,7 @@ type KnativeServiceResourceProps = {
 };
 
 const KnativeServiceResources: React.FC<KnativeServiceResourceProps> = ({ item }) => {
-  const { revisions, ksroutes, obj, pods } = item;
+  const { revisions, ksroutes, obj, pods, buildConfigs } = item;
   const {
     kind: resKind,
     metadata: { name, namespace },
@@ -48,11 +49,12 @@ const KnativeServiceResources: React.FC<KnativeServiceResourceProps> = ({ item }
         emptyText={REVISIONS_AUTOSCALED}
         allPodsLink={linkUrl}
       />
+      <RevisionsOverviewList revisions={revisions} service={obj} />
+      <KSRoutesOverviewList ksroutes={ksroutes} resource={obj} />
+      {buildConfigs.length > 0 && <BuildOverview buildConfigs={buildConfigs} />}
       {pluginComponents.map(({ Component, key }) => (
         <Component key={key} item={item} />
       ))}
-      <RevisionsOverviewList revisions={revisions} service={obj} />
-      <KSRoutesOverviewList ksroutes={ksroutes} resource={obj} />
     </>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/OverviewDetailsKnativeResourcesTab.tsx
@@ -15,14 +15,8 @@ type OverviewDetailsResourcesTabProps = {
   item: OverviewItem;
 };
 
-const getSidebarResources = ({
-  obj,
-  ksroutes,
-  revisions,
-  configurations,
-  pods,
-  current,
-}: OverviewItem) => {
+const getSidebarResources = (item: OverviewItem) => {
+  const { obj, ksroutes, revisions, configurations, pods, current } = item;
   if (isDynamicEventResourceKind(referenceFor(obj))) {
     return <EventSinkServicesOverviewList obj={obj} pods={pods} current={current} />;
   }
@@ -38,9 +32,7 @@ const getSidebarResources = ({
         />
       );
     case ServiceModel.kind:
-      return (
-        <KnativeServiceResources ksroutes={ksroutes} obj={obj} revisions={revisions} pods={pods} />
-      );
+      return <KnativeServiceResources item={item} />;
     default:
       return (
         <>

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { useExtensions } from '@console/plugin-sdk';
 import { PodsOverview } from '@console/internal/components/overview/pods-overview';
 import {
   sampleKnativePods,
@@ -13,7 +14,15 @@ import KnativeServiceResources from '../KnativeServiceResources';
 import KSRoutesOverviewList from '../RoutesOverviewList';
 import RevisionsOverviewList from '../RevisionsOverviewList';
 
+jest.mock('@console/plugin-sdk/src/useExtensions', () => ({
+  useExtensions: jest.fn(),
+}));
+
 describe('KnativeServiceResources', () => {
+  beforeEach(() => {
+    (useExtensions as jest.Mock).mockReturnValueOnce([]);
+  });
+
   it('should render KnativeServiceResources', () => {
     const item = {
       revisions: sampleKnativeRevisions.data,

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
@@ -7,6 +7,7 @@ import {
   sampleKnativeRevisions,
   knativeServiceObj,
 } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import { BuildOverview } from '@console/internal/components/overview/build-overview';
 import { OverviewItem } from '@console/shared';
 import KnativeServiceResources from '../KnativeServiceResources';
 import KSRoutesOverviewList from '../RoutesOverviewList';
@@ -19,10 +20,24 @@ describe('KnativeServiceResources', () => {
       ksroutes: sampleKnativeRoutes.data,
       obj: knativeServiceObj,
       pods: sampleKnativePods.data,
+      buildConfigs: [],
     } as OverviewItem;
     const wrapper = shallow(<KnativeServiceResources item={item} />);
     expect(wrapper.find(PodsOverview)).toHaveLength(1);
     expect(wrapper.find(KSRoutesOverviewList)).toHaveLength(1);
     expect(wrapper.find(RevisionsOverviewList)).toHaveLength(1);
+    expect(wrapper.find(BuildOverview)).toHaveLength(0);
+  });
+
+  it('should render buildOverview if buildconfigs is present', () => {
+    const item = {
+      revisions: sampleKnativeRevisions.data,
+      ksroutes: sampleKnativeRoutes.data,
+      obj: knativeServiceObj,
+      pods: sampleKnativePods.data,
+      buildConfigs: [{}],
+    } as OverviewItem;
+    const wrapper = shallow(<KnativeServiceResources item={item} />);
+    expect(wrapper.find(BuildOverview)).toHaveLength(1);
   });
 });

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/KnativeServiceResources.spec.tsx
@@ -7,20 +7,20 @@ import {
   sampleKnativeRevisions,
   knativeServiceObj,
 } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import { OverviewItem } from '@console/shared';
 import KnativeServiceResources from '../KnativeServiceResources';
 import KSRoutesOverviewList from '../RoutesOverviewList';
 import RevisionsOverviewList from '../RevisionsOverviewList';
 
 describe('KnativeServiceResources', () => {
   it('should render KnativeServiceResources', () => {
-    const wrapper = shallow(
-      <KnativeServiceResources
-        revisions={sampleKnativeRevisions.data}
-        ksroutes={sampleKnativeRoutes.data}
-        obj={knativeServiceObj}
-        pods={sampleKnativePods.data}
-      />,
-    );
+    const item = {
+      revisions: sampleKnativeRevisions.data,
+      ksroutes: sampleKnativeRoutes.data,
+      obj: knativeServiceObj,
+      pods: sampleKnativePods.data,
+    } as OverviewItem;
+    const wrapper = shallow(<KnativeServiceResources item={item} />);
     expect(wrapper.find(PodsOverview)).toHaveLength(1);
     expect(wrapper.find(KSRoutesOverviewList)).toHaveLength(1);
     expect(wrapper.find(RevisionsOverviewList)).toHaveLength(1);

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
@@ -30,6 +30,7 @@ import {
 } from '@console/dev-console/src/components/topology';
 import { TYPE_KNATIVE_SERVICE } from '../../const';
 import RevisionTrafficSourceAnchor from '../anchors/RevisionTrafficSourceAnchor';
+import BuildDecorator from '@console/dev-console/src/components/topology/components/nodes/build-decorators/BuildDecorator';
 
 export type KnativeServiceGroupProps = {
   element: Node;
@@ -166,6 +167,7 @@ const KnativeServiceGroup: React.FC<KnativeServiceGroupProps> = ({
             </Decorator>
           </Tooltip>
         )}
+        <BuildDecorator x={x} y={y + height} radius={DECORATOR_RADIUS} workloadData={data} />
         {showLabels && (data.kind || element.getLabel()) && (
           <SvgBoxedText
             className="odc-knative-service__label odc-base-node__label"

--- a/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
+++ b/frontend/packages/knative-plugin/src/topology/components/groups/KnativeServiceGroup.tsx
@@ -28,9 +28,9 @@ import {
   useSearchFilter,
   useDisplayFilters,
 } from '@console/dev-console/src/components/topology';
+import BuildDecorator from '@console/dev-console/src/components/topology/components/nodes/build-decorators/BuildDecorator';
 import { TYPE_KNATIVE_SERVICE } from '../../const';
 import RevisionTrafficSourceAnchor from '../anchors/RevisionTrafficSourceAnchor';
-import BuildDecorator from '@console/dev-console/src/components/topology/components/nodes/build-decorators/BuildDecorator';
 
 export type KnativeServiceGroupProps = {
   element: Node;

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -13,7 +13,6 @@ import {
   getResourcePausedAlert,
   getBuildAlerts,
   getOwnedResources,
-  OverviewItem,
   OperatorBackedServiceKindMap,
 } from '@console/shared';
 import {
@@ -30,6 +29,7 @@ import {
   getRoutesURL,
   filterBasedOnActiveApplication,
   getTopologyResourceObject,
+  TopologyOverviewItem,
 } from '@console/dev-console/src/components/topology';
 import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import { DeploymentModel } from '@console/internal/models';
@@ -111,6 +111,7 @@ export const filterRevisionsByActiveApplication = (
 export const getKnativeServiceData = (
   resource: K8sResourceKind,
   resources: TopologyDataResources,
+  utils?: Function[],
 ): KnativeItem => {
   const configurations = getOwnedResources(resource, resources.configurations.data);
   const revisions =
@@ -146,12 +147,19 @@ export const getKnativeServiceData = (
   const ksroutes = resources.ksroutes
     ? getOwnedResources(resource, resources.ksroutes.data)
     : undefined;
-  return {
+
+  const overviewItem = {
     configurations,
     revisions: revisionsDeploymentData.revisionsDep,
     ksroutes,
     pods: revisionsDeploymentData.allPods,
   };
+  if (utils) {
+    return utils.reduce((acc, element) => {
+      return { ...acc, ...element(resource, resources) };
+    }, overviewItem);
+  }
+  return overviewItem;
 };
 
 /**
@@ -161,7 +169,7 @@ const createKnativeDeploymentItems = (
   resource: K8sResourceKind,
   resources: TopologyDataResources,
   utils?: Function[],
-): OverviewItem => {
+): TopologyOverviewItem => {
   const transformResourceData = new TransformResourceData(resources, utils);
   const associatedDeployment = getOwnedResources(resource, resources.deployments.data);
   if (!_.isEmpty(associatedDeployment)) {
@@ -199,7 +207,7 @@ const createKnativeDeploymentItems = (
     }
     return overviewItems;
   }
-  const knResources = getKnativeServiceData(resource, resources);
+  const knResources = getKnativeServiceData(resource, resources, utils);
   return {
     obj: resource,
     buildConfigs: [],
@@ -307,10 +315,11 @@ export const getTrafficTopologyEdgeItems = (resource: K8sResourceKind, { data })
  * create all data that need to be shown on a topology data for knative service
  */
 export const createTopologyServiceNodeData = (
-  svcRes: OverviewItem,
+  svcRes: TopologyOverviewItem,
   operatorBackedServiceKindMap: OperatorBackedServiceKindMap,
   type: string,
 ): TopologyDataObject => {
+  const { pipelines = [], pipelineRuns = [] } = svcRes;
   const { obj: knativeSvc } = svcRes;
   const uid = _.get(knativeSvc, 'metadata.uid');
   const labels = _.get(knativeSvc, 'metadata.labels', {});
@@ -328,6 +337,10 @@ export const createTopologyServiceNodeData = (
       editURL: annotations['app.openshift.io/edit-url'],
       vcsURI: annotations['app.openshift.io/vcs-uri'],
       isKnativeResource: true,
+      connectedPipeline: {
+        pipeline: pipelines[0],
+        pipelineRuns,
+      },
     },
   };
 };


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3120
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Missing pipeline decorator and section for knative service node and sidebar

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
added pipeline decorator and section for knative service.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screenshot from 2020-04-21 17-27-21](https://user-images.githubusercontent.com/9278015/79871742-6eaf3a80-8402-11ea-9460-1e5356c083e0.png)
![Screenshot from 2020-04-23 19-03-29](https://user-images.githubusercontent.com/9278015/80104858-66d3cf80-8595-11ea-8683-a280f9ca5bf0.png)
![Screenshot from 2020-04-23 19-03-48](https://user-images.githubusercontent.com/9278015/80104866-69362980-8595-11ea-8f7a-5ef27120b524.png)

**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
