### PR TITLE
Bug 1822331: Add workload badge/name to monitoring dashboard when navigating to it from the Side Panel monitoring tab

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.scss
@@ -7,7 +7,7 @@ $no-wrap-breakpoint: 915px;
     position: absolute;
     right: 30px;
     top: -65px;
-    @media(max-width: $no-wrap-breakpoint) {
+    @media (max-width: $no-wrap-breakpoint) {
       display: block;
       margin-left: 15px;
       margin-top: 15px;
@@ -18,7 +18,7 @@ $no-wrap-breakpoint: 915px;
     }
 
     .monitoring-dashboards__dropdown-wrap {
-      @media(max-width: $no-wrap-breakpoint) {
+      @media (max-width: $no-wrap-breakpoint) {
         display: inline-block;
         .monitoring-dashboards__dropdown-title {
           margin-right: 10px;
@@ -28,5 +28,8 @@ $no-wrap-breakpoint: 915px;
         margin-right: 0;
       }
     }
+  }
+  &__resource-link {
+    padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--xl);
   }
 }

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/MonitoringDashboard.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
 import Dashboard from '@console/shared/src/components/dashboard/Dashboard';
 import { RootState } from '@console/internal/redux';
-import { getURLSearchParams } from '@console/internal/components/utils';
+import { getURLSearchParams, ResourceLink } from '@console/internal/components/utils';
 import {
   TimespanDropdown,
   PollIntervalDropdown,
@@ -36,10 +36,10 @@ export const MonitoringDashboard: React.FC<Props> = ({ match, timespan, pollInte
   const namespace = match.params.ns;
   const params = getURLSearchParams();
   const { workloadName, workloadType } = params;
-  const queries: MonitoringQuery[] =
-    workloadName && workloadType
-      ? [...topWorkloadMetricsQueries, ...workloadMetricsQueries]
-      : monitoringDashboardQueries;
+  const workLoadPresent = workloadName && workloadType;
+  const queries: MonitoringQuery[] = workLoadPresent
+    ? [...topWorkloadMetricsQueries, ...workloadMetricsQueries]
+    : monitoringDashboardQueries;
 
   return (
     <>
@@ -51,13 +51,25 @@ export const MonitoringDashboard: React.FC<Props> = ({ match, timespan, pollInte
           <TimespanDropdown />
           <PollIntervalDropdown />
         </div>
+        {workLoadPresent && (
+          <div className="odc-monitoring-dashboard__resource-link">
+            Showing metrics for &nbsp;
+            <ResourceLink
+              kind={workloadType}
+              name={workloadName}
+              namespace={namespace}
+              title={workloadName}
+              inline
+            />
+          </div>
+        )}
         <Dashboard>
           {_.map(queries, (q) => (
             <ConnectedMonitoringDashboardGraph
               title={q.title}
               namespace={namespace}
               graphType={q.chartType}
-              query={q.query({ namespace, workloadName, workloadType })}
+              query={q.query({ namespace, workloadName, workloadType: _.toLower(workloadType) })}
               humanize={q.humanize}
               byteDataType={q.byteDataType}
               key={q.title}

--- a/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboard.spec.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/dashboard/__tests__/MonitoringDashboard.spec.tsx
@@ -37,7 +37,7 @@ describe('Monitoring Dashboard Tab', () => {
       workloadType: 'deployment',
     });
     const spygetURLSearchParams = jest.spyOn(link, 'getURLSearchParams');
-    spygetURLSearchParams.mockReturnValue({ workloadName: 'dotnet', workloadType: 'deployment' });
+    spygetURLSearchParams.mockReturnValue({ workloadName: 'dotnet', workloadType: 'Deployment' });
     const wrapper = shallow(<MonitoringDashboard {...monitoringDashboardProps} />);
     expect(
       wrapper
@@ -66,5 +66,22 @@ describe('Monitoring Dashboard Tab', () => {
     const wrapper = shallow(<MonitoringDashboard {...monitoringDashboardProps} />);
     expect(wrapper.find(TimespanDropdown).exists()).toBe(true);
     expect(wrapper.find(PollIntervalDropdown).exists()).toBe(true);
+  });
+
+  it('should render ResourceLink for workload queries dashboard', () => {
+    const spygetURLSearchParams = jest.spyOn(link, 'getURLSearchParams');
+    spygetURLSearchParams.mockReturnValue({
+      workloadName: 'calculator-react',
+      workloadType: 'Deployment',
+    });
+    const wrapper = shallow(<MonitoringDashboard {...monitoringDashboardProps} />);
+    expect(wrapper.find(link.ResourceLink).exists()).toBe(true);
+  });
+
+  it('should not render ResourceLink for namespace queries dashboard', () => {
+    const spygetURLSearchParams = jest.spyOn(link, 'getURLSearchParams');
+    spygetURLSearchParams.mockReturnValue({});
+    const wrapper = shallow(<MonitoringDashboard {...monitoringDashboardProps} />);
+    expect(wrapper.find(link.ResourceLink).exists()).toBe(false);
   });
 });

--- a/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/overview/MonitoringOverview.tsx
@@ -124,9 +124,7 @@ const MonitoringOverview: React.FC<MonitoringOverviewProps> = (props) => {
               <>
                 <div className="odc-monitoring-overview__view-monitoring-dashboard">
                   <Link
-                    to={`/dev-monitoring/ns/${resource?.metadata?.namespace}/?workloadName=${
-                      resource?.metadata?.name
-                    }&workloadType=${resource?.kind?.toLowerCase()}`}
+                    to={`/dev-monitoring/ns/${resource?.metadata?.namespace}/?workloadName=${resource?.metadata?.name}&workloadType=${resource?.kind}`}
                   >
                     View monitoring dashboard
                   </Link>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3295

**Analysis / Root cause**: 
No context has been set for the workload on the monitoring dashboard when the user visits the monitoring dashboard from the monitoring tab of the topology side panel.

**Solution Description**: 
Add a resource link on the top of the dashboard graph card.

**Screen shots / Gifs for design review**: 
<img width="1632" alt="Screenshot 2020-04-22 at 8 31 27 PM" src="https://user-images.githubusercontent.com/2561818/79998718-ab4d6580-84d8-11ea-98b2-7a7013d6a4a5.png">



**Unit test coverage report**: 
<img width="761" alt="Screenshot 2020-04-21 at 7 56 07 PM" src="https://user-images.githubusercontent.com/2561818/79879815-d10d3880-840c-11ea-9221-87608766b041.png">

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
