### PR TITLE
Bug 1826408: Automate webdriver update for fedora

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "debug-test": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "webdriver-update": "webdriver-manager update",
     "webdriver-update-macos": "CHROME_VERSION=$(/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --version) && yarn webdriver-update --versions.chrome=\"${CHROME_VERSION}\"",
+    "webdriver-update-fedora": "CHROME_VERSION=$(/usr/bin/google-chrome-stable --version) && yarn webdriver-update --versions.chrome=\"${CHROME_VERSION}\"",
     "test-gui-tap": "TAP=true yarn run test-gui",
     "test-gui-openshift": "yarn run test-suite --suite crud --params.openshift true",
     "test-gui": "yarn run test-suite --suite all",


### PR DESCRIPTION
Fedora does not properly update the webdrive when doing local integration testing.  This script should resolve those problems by running: `yarn webdriver-update-fedora`