### PR TITLE
Bug 1826526: Improves Start Pipeline Resource section

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/PipelineResourceDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/PipelineResourceDropdown.tsx
@@ -79,7 +79,7 @@ const PipelineResourceDropdown: React.FC<PipelineResourceDropdownProps> = (props
         setExpanded(false);
       }}
       placeholderText={!loaded ? <LoadingInline /> : 'Select Pipeline Resource'}
-      isDisabled={loaded && resources.length === 0}
+      isDisabled={loaded && availableResources.length === 0}
     >
       {options.map(({ label, value }) => (
         <SelectOption key={value} value={value}>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceParam.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceParam.scss
@@ -1,4 +1,0 @@
-.odc-pipeline-resource-param {
-  border: 1px dashed var(--pf-global--BorderColor--100);
-  padding: var(--pf-global--spacer--sm);
-}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceParam.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-resource/PipelineResourceParam.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
+import FormSection from '../../import/section/FormSection';
 import PipelineGitOptions from './PipelineGitOptions';
 import PipelineImageOptions from './PipelineImageOptions';
 import PipelineClusterOptions from './PipelineClusterOptions';
 import PipelineStorageOptions from './PipelineStorageOptions';
-
-import './PipelineResourceParam.scss';
 
 export interface PipelineResourceParamProps {
   name: string;
@@ -29,7 +28,7 @@ const PipelineResourceParam: React.FC<PipelineResourceParamProps> = (props) => {
     }
   };
 
-  return <div className="odc-pipeline-resource-param">{renderTypeFields()}</div>;
+  return <FormSection fullWidth>{renderTypeFields()}</FormSection>;
 };
 
 export default PipelineResourceParam;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3405

**Analysis / Root cause**: 
Pipeline Resources section was not ideal.

**Solution Description**: 
Disable the dropdown when no items are selectable & space the content out more.

**Screen shots / Gifs for design review**: 

@openshift/team-devconsole-ux

Before (when the ticket was logged - used the cluster directly):
![image](https://user-images.githubusercontent.com/8126518/79916089-1e31e000-83f6-11ea-9465-cd9691808cd1.png)

After (with Triggers work + this PR):
![image](https://user-images.githubusercontent.com/8126518/79916221-59341380-83f6-11ea-9c1b-e90a07d0cb91.png)

**Test setup:**

* Pipeline Operator
* Pipeline needing resources
* Start Modal action with no Pipeline Resources created (to force the initial empty state)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge