### PR TITLE
Bug 1826664: handle Builder image detection when url is changed

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/ItemSelectorField.tsx
@@ -58,12 +58,22 @@ const ItemSelectorField: React.FC<ItemSelectorFieldProps> = ({
     }
     if (!selected.value && recommended) {
       handleItemChange(recommended);
+      setFieldTouched(name, false);
     }
     if (!selected.value && autoSelect && !_.isEmpty(itemList)) {
       const image = _.get(_.keys(itemList), 0);
       handleItemChange(itemList[image]?.name);
     }
-  }, [autoSelect, itemCount, itemList, handleItemChange, selected.value, recommended]);
+  }, [
+    autoSelect,
+    itemCount,
+    itemList,
+    handleItemChange,
+    selected.value,
+    recommended,
+    name,
+    setFieldTouched,
+  ]);
 
   if (itemCount === 1) {
     return null;

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -18,6 +18,7 @@ export interface GitSectionProps {
 const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
   const { values, setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
   const [, { touched: gitTypeTouched }] = useField('git.type');
+  const [, { touched: userSelection }] = useField('image.selected');
   const tag = values.image.tagObj;
   const sampleRepo = showSample && getSampleRepo(tag);
 
@@ -72,9 +73,13 @@ const GitSection: React.FC<GitSectionProps> = ({ showSample }) => {
 
   const handleGitUrlChange: React.ReactEventHandler = React.useCallback(() => {
     setFieldValue('git.urlValidation', ValidatedOptions.default);
+    if (!userSelection) {
+      setFieldValue('image.selected', '');
+      setFieldValue('image.tag', '');
+    }
     values.image.recommended && setFieldValue('image.recommended', '');
     values.image.couldNotRecommend && setFieldValue('image.couldNotRecommend', false);
-  }, [setFieldValue, values.image.couldNotRecommend, values.image.recommended]);
+  }, [setFieldValue, values.image.couldNotRecommend, values.image.recommended, userSelection]);
 
   const fillSample: React.ReactEventHandler<HTMLButtonElement> = React.useCallback(() => {
     const url = sampleRepo;


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-3159

**Analysis / Root cause**
When the URL is unreachable, we don't have the capability to decide whether it's invalid or a private one because in both cases it will show the same error.

**Solution Description**
In this bug fix, I am trying to ensure that the builder image is reset if the user never manually touched the field, in that case, the form will wait for validation of the URL and auto/manual selection of builder image.

**GIF**
![git-url-validation](https://user-images.githubusercontent.com/22490998/80756572-6a94c280-8b50-11ea-9034-cde329ec179f.gif)


/kind bug