### PR TITLE
Bug 1826682: fix validation issue with bitbucket repository

### DIFF
--- a/frontend/packages/git-service/src/services/bitbucket-service.ts
+++ b/frontend/packages/git-service/src/services/bitbucket-service.ts
@@ -48,7 +48,7 @@ export class BitbucketService extends BaseService {
         repo_slug: this.metadata.repoName,
         username: this.metadata.owner,
       });
-      return data.name === this.metadata.repoName;
+      return data.name.toLocaleLowerCase() === this.metadata.repoName.toLocaleLowerCase();
     } catch (e) {
       return false;
     }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2666

**Analysis / Root cause**: 
Bitbucket repo URL gives an error ```Git repository is not reachable.``` even if the repository is public and exist. Because the repository URL and repository name is not sensitive.

**Solution Description**: 
comparing the repository after lowercase the repository name.

**Screen shots / Gifs for design review**: 
![Kapture 2020-04-22 at 15 23 30](https://user-images.githubusercontent.com/2561818/79969777-96101100-84af-11ea-8d82-74628328a353.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
