### PR TITLE
Bug 1826768: Fix for topology layout 2 layout keeping nodes separated

### DIFF
--- a/frontend/packages/topology/src/behavior/useDragNode.tsx
+++ b/frontend/packages/topology/src/behavior/useDragNode.tsx
@@ -18,7 +18,7 @@ export const DRAG_NODE_EVENT = 'drag_node';
 export const DRAG_NODE_START_EVENT = `${DRAG_NODE_EVENT}_start`;
 export const DRAG_NODE_END_EVENT = `${DRAG_NODE_EVENT}_end`;
 
-export type DragNodeEventListener = EventListener<[Node, DragEvent, string]>;
+export type DragNodeEventListener = EventListener<[Node, DragEvent, DragOperationWithType]>;
 
 export const DRAG_MOVE_OPERATION = 'move.useDragNode';
 

--- a/frontend/packages/topology/src/layouts/BaseLayout.ts
+++ b/frontend/packages/topology/src/layouts/BaseLayout.ts
@@ -24,6 +24,7 @@ import {
   DRAG_NODE_START_EVENT,
   DragEvent,
   DragNodeEventListener,
+  DragOperationWithType,
 } from '../behavior';
 import { BaseEdge } from '../elements';
 import { ForceSimulation } from './ForceSimulation';
@@ -283,19 +284,19 @@ class BaseLayout implements Layout {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected initDrag(element: Node, event: DragEvent, operation: string): void {}
+  protected initDrag(element: Node, event: DragEvent, operation: DragOperationWithType): void {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected endDrag(element: Node, event: DragEvent, operation: string): void {}
+  protected endDrag(element: Node, event: DragEvent, operation: DragOperationWithType): void {}
 
-  handleDragStart = (element: Node, event: DragEvent, operation: string) => {
+  handleDragStart = (element: Node, event: DragEvent, operation: DragOperationWithType) => {
     this.initDrag(element, event, operation);
 
     if (!this.options.layoutOnDrag) {
       return;
     }
 
-    if (operation !== DRAG_MOVE_OPERATION) {
+    if (operation.type !== DRAG_MOVE_OPERATION) {
       this.forceSimulation.stopSimulation();
       return;
     }
@@ -326,14 +327,14 @@ class BaseLayout implements Layout {
     }
   };
 
-  handleDragEnd = (element: Node, event: DragEvent, operation: string) => {
+  handleDragEnd = (element: Node, event: DragEvent, operation: DragOperationWithType) => {
     this.endDrag(element, event, operation);
 
     if (!this.options.layoutOnDrag) {
       return;
     }
 
-    if (operation !== DRAG_MOVE_OPERATION) {
+    if (operation.type !== DRAG_MOVE_OPERATION) {
       this.forceSimulation.restart();
       return;
     }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3576

When using Layout 2 in the topology view, the layout should keep nodes separated when being dragged. The nodes are not keeping separated until the drag is ended, then the separation occurs.

**Analysis / Root cause**: 
The operation type was changed from a string indicating type to an object containing a field `type` to indicate the operation type. The check for a move operation was not updated to handle the change.

**Solution Description**: 
Fix the check on the operation type when dragging

/kind bug
