### PR TITLE
Bug 1826489: Inconsistent experience between notification drawer and dashboard status

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/AlertItem.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { alertActions } from '@console/internal/components/notification-drawer';
 import { Timestamp } from '@console/internal/components/utils/timestamp';
 import { alertURL, Alert } from '@console/internal/components/monitoring';
 import { RedExclamationCircleIcon, YellowExclamationTriangleIcon } from '../../status/icons';
@@ -39,15 +40,22 @@ export const StatusItem: React.FC<StatusItemProps> = ({ Icon, timestamp, message
   );
 };
 
-const AlertItem: React.FC<AlertItemProps> = ({ alert }) => (
-  <StatusItem
-    Icon={getSeverityIcon(getAlertSeverity(alert))}
-    timestamp={getAlertTime(alert)}
-    message={getAlertDescription(alert) || getAlertMessage(alert)}
-  >
-    <Link to={alertURL(alert, alert.rule.id)}>View details</Link>
-  </StatusItem>
-);
+const AlertItem: React.FC<AlertItemProps> = ({ alert }) => {
+  const action = alertActions.get(alert.rule.name);
+  return (
+    <StatusItem
+      Icon={getSeverityIcon(getAlertSeverity(alert))}
+      timestamp={getAlertTime(alert)}
+      message={getAlertDescription(alert) || getAlertMessage(alert)}
+    >
+      {action ? (
+        <Link to={action.path}>{action.text}</Link>
+      ) : (
+        <Link to={alertURL(alert, alert.rule.id)}>View details</Link>
+      )}
+    </StatusItem>
+  );
+};
 
 export default AlertItem;
 

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -66,13 +66,10 @@ const AlertEmptyState: React.FC<AlertEmptyProps> = ({ drawerToggle }) => (
   </EmptyState>
 );
 
-const actionAlerts: ActionAlertType[] = [
-  {
-    name: 'AlertmanagerReceiversNotConfigured',
-    text: 'Configure receivers',
-    path: '/monitoring/alertmanagerconfig',
-  },
-];
+export const alertActions = new Map().set('AlertmanagerReceiversNotConfigured', {
+  text: 'Configure',
+  path: '/monitoring/alertmanagerconfig',
+});
 
 const getAlertNotificationEntries = (
   isLoaded: boolean,
@@ -84,9 +81,7 @@ const getAlertNotificationEntries = (
     ? alertData
         .filter((a) => (isCritical ? criticalCompare(a) : otherAlertCompare(a)))
         .map((alert, i) => {
-          const actionAlertMatch = actionAlerts.find(
-            (actionAlert) => actionAlert.name === alert.rule.name,
-          );
+          const action = alertActions.get(alert.rule.name);
           return (
             <NotificationEntry
               key={`${i}_${alert.activeAt}`}
@@ -96,8 +91,8 @@ const getAlertNotificationEntries = (
               title={getAlertName(alert)}
               toggleNotificationDrawer={toggleNotificationDrawer}
               targetPath={alertURL(alert, alert.rule.id)}
-              actionText={actionAlertMatch?.text}
-              actionPath={actionAlertMatch?.path}
+              actionText={action?.text}
+              actionPath={action?.path}
             />
           );
         })
@@ -335,12 +330,6 @@ const notificationStateToProps = ({ UI }: RootState): WithNotificationsProps => 
   alerts: UI.getIn(['monitoring', 'notificationAlerts']),
   silences: UI.getIn(['monitoring', 'silences']),
 });
-
-type ActionAlertType = {
-  name: string;
-  text: string;
-  path: string;
-};
 
 type AlertErrorProps = {
   errorText: string;


### PR DESCRIPTION
This PR updates dashboard cards which show alerts to use the same 'alert actions' text and url shown in the Notification Drawer.  For 'AlertmanagerReceiversNotConfigured` it also changes the long link text from 'Configure receivers' to just 'Configure'.

### Before
![image](https://user-images.githubusercontent.com/12733153/80007272-0872f800-8494-11ea-9287-bd4f56ca9f83.png)
![image](https://user-images.githubusercontent.com/12733153/80007285-0dd04280-8494-11ea-98e1-72571cbb7258.png)

### After
![image](https://user-images.githubusercontent.com/12733153/80007491-4e2fc080-8494-11ea-8dfa-80a167c86394.png)
![image](https://user-images.githubusercontent.com/12733153/80007476-496b0c80-8494-11ea-91de-d6dda01b80e4.png)


