### PR TITLE
Bug 1826882: fix builder section in s2i form

### DIFF
--- a/frontend/packages/dev-console/src/components/import/builder/BuilderImageSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderImageSelector.tsx
@@ -30,6 +30,17 @@ const BuilderImageSelector: React.FC<BuilderImageSelectorProps> = ({
 
   const fieldId = getFieldId('image.name', 'selector');
 
+  if (_.keys(builderImages).length === 1) {
+    return (
+      <ItemSelectorField
+        itemList={builderImages}
+        name="image.selected"
+        loadingItems={loadingImageStream}
+        recommended={values.image.recommended}
+      />
+    );
+  }
+
   return (
     <FormGroup fieldId={fieldId} label="Builder Image">
       {values.image.isRecommending && (

--- a/frontend/packages/dev-console/src/components/import/builder/__tests__/BuilderImageSelector.spec.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/__tests__/BuilderImageSelector.spec.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import * as _ from 'lodash';
+import { ItemSelectorField } from '@console/shared';
+import { FormGroup } from '@patternfly/react-core';
+import BuilderImageSelector from '../BuilderImageSelector';
+import { NormalizedBuilderImages } from '../../../../utils/imagestream-utils';
+
+jest.mock('formik', () => ({
+  useFormikContext: jest.fn(() => ({
+    setFieldValue: jest.fn(),
+    setFieldTouched: jest.fn(),
+    values: {
+      image: {
+        selected: '',
+        recommended: '',
+        tag: '',
+        tagObj: {},
+        ports: [],
+        isRecommending: false,
+        couldNotRecommend: false,
+      },
+    },
+  })),
+  getFieldId: jest.fn(),
+}));
+
+type BuilderImageSelectorProps = React.ComponentProps<typeof BuilderImageSelector>;
+let props: BuilderImageSelectorProps;
+
+describe('BuilderImageSelector', () => {
+  const builderImages: NormalizedBuilderImages = {
+    nodejs: {
+      obj: {},
+      name: 'nodejs',
+      displayName: 'Node.js',
+      title: 'Node.js',
+      iconUrl: '',
+      tags: [],
+      recentTag: {
+        name: '',
+        annotations: {},
+        generation: 2,
+      },
+      imageStreamNamespace: 'openshift',
+    },
+    golang: {
+      obj: {},
+      name: 'golang',
+      displayName: 'Go',
+      title: 'Go',
+      iconUrl: '',
+      tags: [],
+      recentTag: {
+        name: '',
+        annotations: {},
+        generation: 2,
+      },
+      imageStreamNamespace: 'openshift',
+    },
+  };
+
+  beforeEach(() => {
+    props = {
+      builderImages,
+      loadingImageStream: false,
+    };
+  });
+
+  it('should render FormGroup when there are more than one builderImages', () => {
+    const builderImageSelector = shallow(<BuilderImageSelector {...props} />);
+    expect(builderImageSelector.find(FormGroup)).toHaveLength(1);
+    expect(builderImageSelector.find(ItemSelectorField)).toHaveLength(1);
+  });
+
+  it('should not render FormGroup when there are no more than one builderImage', () => {
+    const singleBuilderImage = _.omit(_.cloneDeep(builderImages), 'golang');
+    const builderImageSelector = shallow(
+      <BuilderImageSelector {...props} builderImages={singleBuilderImage} />,
+    );
+    expect(builderImageSelector.find(FormGroup)).toHaveLength(0);
+    expect(builderImageSelector.find(ItemSelectorField)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
**Fixes**:
https://issues.redhat.com/browse/ODC-3632

**Analysis / Root cause**:
S2I form has an empty `BuilderImage` section in the Builder section

**Solution Description**:
Remove the `BuilderImage` section when there is only one builder image

**Screens**:
![Screenshot from 2020-04-22 22-02-09](https://user-images.githubusercontent.com/38663217/80008800-dd18f900-84e5-11ea-8d5f-f57bfbd6702d.png)

**Test Coverage**:
![Screenshot from 2020-04-22 22-14-37](https://user-images.githubusercontent.com/38663217/80009588-e8b8ef80-84e6-11ea-9669-d60429ebb388.png)
![Screenshot from 2020-04-22 22-13-57](https://user-images.githubusercontent.com/38663217/80009602-ed7da380-84e6-11ea-9033-140adfe5dd8a.png)

**Browser Conformance**:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge