### PR TITLE
Bug 1826680:  Fix bug where K8sResourceLink lacks empty state

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/index.tsx
@@ -71,14 +71,17 @@ const K8sPhaseReason: React.SFC<StatusCapabilityProps> = ({ value }) =>
     <pre style={{ width: 'max-content' }}>{value}</pre>
   );
 
-const K8sResourceLink: React.SFC<StatusCapabilityProps> = (props) => (
-  <ResourceLink
-    kind={props.capability.substr(StatusCapability.k8sResourcePrefix.length)}
-    name={props.value}
-    namespace={props.namespace}
-    title={props.value}
-  />
-);
+const K8sResourceLink: React.SFC<StatusCapabilityProps> = ({ capability, namespace, value }) =>
+  _.isEmpty(value) ? (
+    <span className="text-muted">None</span>
+  ) : (
+    <ResourceLink
+      kind={capability.substr(StatusCapability.k8sResourcePrefix.length)}
+      name={value}
+      namespace={namespace}
+      title={value}
+    />
+  );
 
 const capabilityComponents = ImmutableMap<
   StatusCapability,


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1826680

After:
<img width="1237" alt="Screen Shot 2020-04-22 at 1 47 52 PM" src="https://user-images.githubusercontent.com/895728/80016298-ea5fc480-84a0-11ea-95c4-d8b5efc0073a.png">
