### PR TITLE
Bug 1826913: Fix topology to prevent initial drawing of new nodes at upper left

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -51,7 +51,7 @@ import { topologyModelFromDataModel } from './data-transforms/topology-model';
 import { layoutFactory, COLA_LAYOUT, COLA_FORCE_LAYOUT } from './layouts/layoutFactory';
 import { TYPE_APPLICATION_GROUP, ComponentFactory } from './components';
 import TopologyFilterBar from './filters/TopologyFilterBar';
-import { DisplayFilters, getTopologyFilters, TopologyFilters } from './filters/filter-utils';
+import { getTopologyFilters, TopologyFilters } from './filters/filter-utils';
 import TopologyHelmReleasePanel from './helm/TopologyHelmReleasePanel';
 import { TYPE_HELM_RELEASE } from './helm/components/const';
 import { HelmComponentFactory } from './helm/components/helmComponentFactory';
@@ -99,7 +99,6 @@ const Topology: React.FC<ComponentProps> = ({
 }) => {
   const visRef = React.useRef<Visualization | null>(null);
   const applicationRef = React.useRef<string>(null);
-  const displayFiltersRef = React.useRef<DisplayFilters>(null);
   const componentFactoryRef = React.useRef<ComponentFactory | null>(null);
   const knativeComponentFactoryRef = React.useRef<KnativeComponentFactory | null>(null);
   const helmComponentFactoryRef = React.useRef<HelmComponentFactory | null>(null);
@@ -183,24 +182,6 @@ const Topology: React.FC<ComponentProps> = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
-
-  React.useEffect(() => {
-    if (!displayFiltersRef.current) {
-      displayFiltersRef.current = filters.display;
-      return;
-    }
-
-    if (
-      (filters.display.eventSources && !displayFiltersRef.current.eventSources) ||
-      (filters.display.virtualMachines && !displayFiltersRef.current.virtualMachines)
-    ) {
-      action(() => {
-        visRef.current.getGraph().reset();
-        visRef.current.getGraph().layout();
-      })();
-    }
-    displayFiltersRef.current = filters.display;
-  }, [filters.display]);
 
   React.useEffect(() => {
     if (!applicationRef.current) {

--- a/frontend/packages/topology/src/elements/BaseElement.ts
+++ b/frontend/packages/topology/src/elements/BaseElement.ts
@@ -10,6 +10,7 @@ import {
   ModelKind,
   ADD_CHILD_EVENT,
   REMOVE_CHILD_EVENT,
+  ELEMENT_VISIBILITY_CHANGE_EVENT,
 } from '../types';
 import Stateful from '../utils/Stateful';
 import { Translatable } from '../geom/types';
@@ -125,7 +126,12 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
   }
 
   setVisible(visible: boolean): void {
-    this.visible = visible;
+    if (this.visible !== visible) {
+      this.visible = visible;
+      if (this.controller) {
+        this.controller.fireEvent(ELEMENT_VISIBILITY_CHANGE_EVENT, { visible, target: this });
+      }
+    }
   }
 
   isVisible(): boolean {

--- a/frontend/packages/topology/src/layouts/ColaLayout.ts
+++ b/frontend/packages/topology/src/layouts/ColaLayout.ts
@@ -79,7 +79,8 @@ class ColaLayout extends BaseLayout implements Layout {
     this.d3Cola.avoidOverlaps(true);
     this.d3Cola.linkDistance(this.getLinkDistance);
     this.d3Cola.on('tick', () => {
-      if (this.tickCount++ % this.options.simulationSpeed === 0) {
+      this.tickCount++;
+      if (this.tickCount === 1 || this.tickCount % this.options.simulationSpeed === 0) {
         action(() => this.nodes.forEach((d) => d.update()))();
       }
       if (this.colaOptions.maxTicks >= 0 && this.tickCount > this.colaOptions.maxTicks) {
@@ -87,6 +88,7 @@ class ColaLayout extends BaseLayout implements Layout {
       }
     });
     this.d3Cola.on('end', () => {
+      this.tickCount = 0;
       action(() => {
         if (this.destroyed) {
           return;
@@ -161,6 +163,7 @@ class ColaLayout extends BaseLayout implements Layout {
   protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
     // start the layout
     this.d3Cola.alpha(0.2);
+    this.tickCount = 0;
     this.d3Cola.start(
       addingNodes ? 0 : this.colaOptions.initialUnconstrainedIterations,
       addingNodes ? 0 : this.colaOptions.initialUserConstraintIterations,

--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -224,14 +224,18 @@ export interface Controller extends WithState {
   getElements(): GraphElement[];
 }
 
-type ElementEvent = { target: GraphElement };
+export type ElementEvent = { target: GraphElement };
+export type ElementVisibilityChangeEvent = ElementEvent & { visible: boolean };
+
 export type ElementChildEventListener = EventListener<[ElementEvent & { child: GraphElement }]>;
+export type ElementVisibilityChangeEventListener = EventListener<[ElementVisibilityChangeEvent]>;
 
 export type NodeCollapseChangeEventListener = EventListener<[{ node: Node }]>;
 
 export type GraphLayoutEndEventListener = EventListener<[{ graph: Graph }]>;
 
 export const ADD_CHILD_EVENT = 'element-add-child';
+export const ELEMENT_VISIBILITY_CHANGE_EVENT = 'element-visibility-change';
 export const REMOVE_CHILD_EVENT = 'element-remove-child';
 export const NODE_COLLAPSE_CHANGE_EVENT = 'node-collapse-change';
 export const GRAPH_LAYOUT_END_EVENT = 'graph-layout-end';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2690
https://issues.redhat.com/browse/ODC-3616

**Analysis / Root cause**: 
Nodes initial locations are set to 0,0 and were being redrawn before the layout was run. 

**Solution Description**: 
Change from a timeout to a requestAnimationFrame function when running the layout on node additions so the layout runs before the nodes are redrawn.

Also, use events on hide/show of nodes rather than checking display filters specifically and re-running the full layout.

/kind bug
