### PR TITLE
Bug 1826488:  Remove `Edit ClusterServiceVersion` menu options from C…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.spec.tsx
@@ -106,7 +106,7 @@ describe(ClusterServiceVersionTableRow.displayName, () => {
     expect(col.find(ResourceKebab).props().kind).toEqual(
       referenceForModel(ClusterServiceVersionModel),
     );
-    expect(col.find(ResourceKebab).props().actions.length).toEqual(3);
+    expect(col.find(ResourceKebab).props().actions.length).toEqual(2);
   });
 
   it('renders clickable column for app logo and name', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -202,12 +202,8 @@ const menuActionsForCSV = (
   subscription: SubscriptionKind,
 ): KebabAction[] => {
   return _.isEmpty(subscription)
-    ? [Kebab.factory.Edit, Kebab.factory.Delete]
-    : [
-        Kebab.factory.Edit,
-        () => editSubscription(subscription),
-        () => uninstall(subscription, csv),
-      ];
+    ? [Kebab.factory.Delete]
+    : [() => editSubscription(subscription), () => uninstall(subscription, csv)];
 };
 
 const ClusterServiceVersionStatus: React.FC<ClusterServiceVersionStatusProps> = ({
@@ -1004,7 +1000,6 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
   ) => {
     const subscription = subscriptionForCSV(subscriptions, obj);
     return [
-      Kebab.factory.Edit(model, obj),
       ...(_.isEmpty(subscription)
         ? [Kebab.factory.Delete(model, obj)]
         : [editSubscription(subscription), uninstall(subscription, obj)]),


### PR DESCRIPTION
…SV list and details pages

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1826488

After:

<img width="1230" alt="Screen Shot 2020-04-22 at 3 27 56 PM" src="https://user-images.githubusercontent.com/895728/80026007-6e20ad80-84af-11ea-8a4a-4b24f3f453e3.png">
<img width="1230" alt="Screen Shot 2020-04-22 at 3 28 12 PM" src="https://user-images.githubusercontent.com/895728/80026008-6e20ad80-84af-11ea-9e6e-ab8c1c2d01fc.png">
