### PR TITLE
Bug 1826937:  Fix bug where subscription channel name can overflow box

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.tsx
@@ -458,11 +458,11 @@ export class SubscriptionUpdates extends React.Component<
                     type="button"
                     isInline
                     onClick={channelModal}
-                    variant={!pkg ? 'plain' : 'link'}
+                    variant="link"
                     isDisabled={!pkg}
                   >
                     {obj.spec.channel || 'default'}
-                    <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+                    {pkg && <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />}
                   </Button>
                 )}
               </dd>


### PR DESCRIPTION
And also removes pencil icon if the channel is not editable.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1826937

Before:
<img width="537" alt="Screen Shot 2020-04-22 at 3 29 39 PM" src="https://user-images.githubusercontent.com/895728/80029317-9ced5280-84b4-11ea-8cce-eff270ec85dc.png">

After:
<img width="731" alt="Screen Shot 2020-04-22 at 4 07 20 PM" src="https://user-images.githubusercontent.com/895728/80029296-97900800-84b4-11ea-95d2-31dbaa9b5d0a.png">
