### PR TITLE
Bug 1826962: Limit the amount a user can zoom in/out in topology

### DIFF
--- a/frontend/packages/topology/src/behavior/useDragNode.tsx
+++ b/frontend/packages/topology/src/behavior/useDragNode.tsx
@@ -11,6 +11,7 @@ import {
   DragObjectWithType,
   DragSpecOperationType,
   DragOperationWithType,
+  DragSourceMonitor,
 } from './dnd-types';
 import { useDndManager } from './useDndManager';
 
@@ -59,7 +60,7 @@ export const useDragNode = <
     React.useMemo(() => {
       const sourceSpec: DragSourceSpec<any, any, any, any, Props> = {
         item: (spec && spec.item) || { type: '#useDragNode#' },
-        operation: (monitor, p) => {
+        operation: (monitor: DragSourceMonitor, p: Props) => {
           if (spec) {
             const operation =
               typeof spec.operation === 'function' ? spec.operation(monitor, p) : spec.operation;

--- a/frontend/packages/topology/src/behavior/usePanZoom.tsx
+++ b/frontend/packages/topology/src/behavior/usePanZoom.tsx
@@ -5,16 +5,8 @@ import { action, autorun, IReactionDisposer } from 'mobx';
 import ElementContext from '../utils/ElementContext';
 import useCallbackRef from '../utils/useCallbackRef';
 import Point from '../geom/Point';
-import { isGraph, ModelKind } from '../types';
+import { Graph, isGraph, ModelKind } from '../types';
 import { ATTR_DATA_KIND } from '../const';
-
-export type PanZoomTransform = {
-  x: number;
-  y: number;
-  k: number;
-};
-
-const ZOOM_EXTENT: [number, number] = [0.25, 4];
 
 export type PanZoomRef = (node: SVGGElement | null) => void;
 
@@ -23,116 +15,106 @@ const propagatePanZoomMouseEvent = (e: Event): void => {
   document.dispatchEvent(new MouseEvent(e.type, e));
 };
 
-export const usePanZoom = (zoomExtent: [number, number] = ZOOM_EXTENT): PanZoomRef => {
+export const usePanZoom = (): PanZoomRef => {
   const element = React.useContext(ElementContext);
   if (!isGraph(element)) {
     throw new Error('usePanZoom must be used within the scope of a Graph');
   }
-  const elementRef = React.useRef(element);
+  const elementRef = React.useRef<Graph>(element);
   elementRef.current = element;
 
-  const refCallback = useCallbackRef<PanZoomRef>(
-    React.useCallback(
-      (node: SVGGElement | null) => {
-        let disposeListener: IReactionDisposer | undefined;
-        if (node) {
-          // TODO fix any type
-          const $svg = d3.select(node.ownerSVGElement) as any;
-          if (node && node.ownerSVGElement) {
-            node.ownerSVGElement.addEventListener('mousedown', propagatePanZoomMouseEvent);
-            node.ownerSVGElement.addEventListener('click', propagatePanZoomMouseEvent);
+  return useCallbackRef<PanZoomRef>((node: SVGGElement | null) => {
+    let disposeListener: IReactionDisposer | undefined;
+    if (node) {
+      // TODO fix any type
+      const $svg = d3.select(node.ownerSVGElement) as any;
+      if (node && node.ownerSVGElement) {
+        node.ownerSVGElement.addEventListener('mousedown', propagatePanZoomMouseEvent);
+        node.ownerSVGElement.addEventListener('click', propagatePanZoomMouseEvent);
+      }
+      const zoom = d3
+        .zoom()
+        .scaleExtent(elementRef.current.getScaleExtent())
+        .on(
+          'zoom',
+          action(() => {
+            elementRef.current.setPosition(new Point(d3.event.transform.x, d3.event.transform.y));
+            elementRef.current.setScale(d3.event.transform.k);
+          }),
+        )
+        .filter(() => {
+          if (d3.event.ctrlKey || d3.event.button) {
+            return false;
           }
-          const zoom = d3
-            .zoom()
-            .scaleExtent(zoomExtent)
-            .on(
-              'zoom',
-              action(() => {
-                elementRef.current.setPosition(
-                  new Point(d3.event.transform.x, d3.event.transform.y),
-                );
-                elementRef.current.setScale(d3.event.transform.k);
-              }),
-            )
-            .filter(() => {
-              if (d3.event.ctrlKey || d3.event.button) {
-                return false;
-              }
-              // only allow zoom from double clicking the graph directly
-              if (d3.event.type === 'dblclick') {
-                // check if target is not within a node or edge
-                const svg = node.ownerSVGElement;
-                let p: Node | null = d3.event.target;
-                while (p && p !== svg) {
-                  if (p instanceof Element) {
-                    const kind = p.getAttribute(ATTR_DATA_KIND);
-                    if (kind) {
-                      if (kind !== ModelKind.graph) {
-                        return false;
-                      }
-                      break;
-                    }
+          // only allow zoom from double clicking the graph directly
+          if (d3.event.type === 'dblclick') {
+            // check if target is not within a node or edge
+            const svg = node.ownerSVGElement;
+            let p: Node | null = d3.event.target;
+            while (p && p !== svg) {
+              if (p instanceof Element) {
+                const kind = p.getAttribute(ATTR_DATA_KIND);
+                if (kind) {
+                  if (kind !== ModelKind.graph) {
+                    return false;
                   }
-                  p = p.parentNode;
+                  break;
                 }
               }
-              return true;
-            });
-          zoom($svg);
-
-          // Update the d3 transform whenever the scale or bounds change.
-          // This is kinda hacky because when d3 has already made the most recent transform update,
-          // we listen for the model change, due to the above, only to update the d3 transform again.
-          disposeListener = autorun(() => {
-            const scale = elementRef.current.getScale();
-
-            // update the min scaling value such that the user can zoom out to the new scale in case
-            // it is smaller than the default zoom out scale
-            zoom.scaleExtent([Math.min(scale, zoomExtent[0]), zoomExtent[1]]);
-            const b = elementRef.current.getBounds();
-
-            // update d3 zoom data directly
-            // eslint-disable-next-line no-underscore-dangle
-            Object.assign($svg.node().__zoom, {
-              k: scale,
-              x: b.x,
-              y: b.y,
-            });
-          });
-
-          // disable double click zoom
-          // $svg.on('dblclick.zoom', null);
-        }
-        return () => {
-          disposeListener && disposeListener();
-          if (node) {
-            // remove all zoom listeners
-            d3.select(node.ownerSVGElement).on('.zoom', null);
-            if (node.ownerSVGElement) {
-              node.ownerSVGElement.removeEventListener('mousedown', propagatePanZoomMouseEvent);
-              node.ownerSVGElement.removeEventListener('click', propagatePanZoomMouseEvent);
+              p = p.parentNode;
             }
           }
-        };
-      },
-      [zoomExtent],
-    ),
-  );
+          return true;
+        });
+      zoom($svg);
 
-  return refCallback;
+      // Update the d3 transform whenever the scale or bounds change.
+      // This is kinda hacky because when d3 has already made the most recent transform update,
+      // we listen for the model change, due to the above, only to update the d3 transform again.
+      disposeListener = autorun(() => {
+        const scale = elementRef.current.getScale();
+        const scaleExtent = elementRef.current.getScaleExtent();
+
+        // update the min scaling value such that the user can zoom out to the new scale in case
+        // it is smaller than the default zoom out scale
+        zoom.scaleExtent([Math.min(scale, scaleExtent[0]), scaleExtent[1]]);
+        const b = elementRef.current.getBounds();
+
+        // update d3 zoom data directly
+        // eslint-disable-next-line no-underscore-dangle
+        Object.assign($svg.node().__zoom, {
+          k: scale,
+          x: b.x,
+          y: b.y,
+        });
+      });
+
+      // disable double click zoom
+      // $svg.on('dblclick.zoom', null);
+    }
+    return () => {
+      disposeListener && disposeListener();
+      if (node) {
+        // remove all zoom listeners
+        d3.select(node.ownerSVGElement).on('.zoom', null);
+        if (node.ownerSVGElement) {
+          node.ownerSVGElement.removeEventListener('mousedown', propagatePanZoomMouseEvent);
+          node.ownerSVGElement.removeEventListener('click', propagatePanZoomMouseEvent);
+        }
+      }
+    };
+  });
 };
 
 export type WithPanZoomProps = {
   panZoomRef: PanZoomRef;
 };
 
-export const withPanZoom = (zoomExtent: [number, number] = ZOOM_EXTENT) => <
-  P extends WithPanZoomProps
->(
+export const withPanZoom = () => <P extends WithPanZoomProps>(
   WrappedComponent: React.ComponentType<P>,
 ) => {
   const Component: React.FC<Omit<P, keyof WithPanZoomProps>> = (props) => {
-    const panZoomRef = usePanZoom(zoomExtent);
+    const panZoomRef = usePanZoom();
     return <WrappedComponent {...(props as any)} panZoomRef={panZoomRef} />;
   };
   return observer(Component);

--- a/frontend/packages/topology/src/elements/BaseGraph.ts
+++ b/frontend/packages/topology/src/elements/BaseGraph.ts
@@ -3,7 +3,17 @@ import Rect from '../geom/Rect';
 import Point from '../geom/Point';
 import Dimensions from '../geom/Dimensions';
 import { DEFAULT_LAYERS } from '../const';
-import { Graph, Edge, Node, GraphModel, ModelKind, isNode, isEdge, Layout } from '../types';
+import {
+  Graph,
+  Edge,
+  Node,
+  GraphModel,
+  ModelKind,
+  isNode,
+  isEdge,
+  Layout,
+  ScaleExtent,
+} from '../types';
 import BaseElement from './BaseElement';
 
 export default class BaseGraph<E extends GraphModel = GraphModel, D = any> extends BaseElement<E, D>
@@ -25,6 +35,9 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any> exten
 
   private currentLayout?: Layout;
 
+  @observable.ref
+  private scaleExtent: ScaleExtent = [0.25, 4];
+
   @computed
   private get edges(): Edge[] {
     return this.getChildren().filter(isEdge);
@@ -45,6 +58,14 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any> exten
 
   setLayers(layers: string[]): void {
     this.layers = layers;
+  }
+
+  getScaleExtent(): ScaleExtent {
+    return this.scaleExtent;
+  }
+
+  setScaleExtent(scaleExtent: ScaleExtent): void {
+    this.scaleExtent = scaleExtent;
   }
 
   getBounds(): Rect {
@@ -132,7 +153,11 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any> exten
     const c = location || b.getCenter().translate(-x, -y);
     x = (c.x - x) / this.scale;
     y = (c.y - y) / this.scale;
-    this.scale *= scale;
+    const newScale = Math.max(
+      Math.min(this.scale * scale, this.scaleExtent[1]),
+      this.scaleExtent[0],
+    );
+    this.setScale(newScale);
     x = c.x - x * this.scale;
     y = c.y - y * this.scale;
     this.position = new Point(x, y);
@@ -237,6 +262,9 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any> exten
     }
     if ('layout' in model) {
       this.setLayout(model.layout);
+    }
+    if (model.scaleExtent?.length === 2) {
+      this.setScaleExtent(model.scaleExtent);
     }
     if ('scale' in model && typeof model.scale === 'number') {
       this.setScale(+model.scale);

--- a/frontend/packages/topology/src/elements/__tests__/BaseGraph.spec.ts
+++ b/frontend/packages/topology/src/elements/__tests__/BaseGraph.spec.ts
@@ -32,8 +32,8 @@ describe('BaseGraph', () => {
 
   it('should update scale', () => {
     expect(graph.getScale()).toBe(1);
-    graph.setScale(4.5);
-    expect(graph.getScale()).toBe(4.5);
+    graph.setScale(3.5);
+    expect(graph.getScale()).toBe(3.5);
   });
 
   it('should reset position and scale', () => {
@@ -118,6 +118,7 @@ describe('BaseGraph', () => {
 
   it('should adjust bounds to fit nodes', () => {
     graph.setBounds(new Rect(0, 0, 100, 100));
+    graph.setScaleExtent([0.1, 100]);
 
     // no change if no nodes
     graph.fit();
@@ -267,7 +268,7 @@ describe('BaseGraph', () => {
     const model: GraphModel = {
       id: 'g',
       type: ModelKind.graph,
-      scale: 5,
+      scale: 4,
     };
     graph.setModel(model);
     expect(graph.getScale()).toBe(model.scale);
@@ -310,5 +311,24 @@ describe('BaseGraph', () => {
 
     graph.translateToParent(p);
     expect(p).toEqual({ x: 5, y: 6 });
+  });
+
+  it('should set scale extents based on model', () => {
+    graph.setModel({
+      id: 'test-graph-id',
+      type: 'graph',
+      scaleExtent: [0.2, 3.0],
+      scale: 5.5,
+    });
+    expect(graph.getScale()).toBe(5.5);
+    const scaleExtent = graph.getScaleExtent();
+    expect(scaleExtent[0]).toBe(0.2);
+    expect(scaleExtent[1]).toBe(3.0);
+
+    // Scale extents do NOT prevent setting scale out of range
+    graph.setScale(10);
+    expect(graph.getScale()).toBe(10);
+    graph.setScale(0.1);
+    expect(graph.getScale()).toBe(0.1);
   });
 });

--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -65,11 +65,16 @@ export interface EdgeModel extends ElementModel {
   bendpoints?: PointTuple[];
 }
 
+// Scale extent: [min scale, max scale]
+export type ScaleExtent = [number, number];
+
 export interface GraphModel extends ElementModel {
   layout?: string;
   x?: number;
   y?: number;
   scale?: number;
+  scaleExtent?: ScaleExtent;
+  maxScale?: number;
   layers?: string[];
 }
 
@@ -158,6 +163,8 @@ export interface Graph<E extends GraphModel = GraphModel, D = any> extends Graph
   setPosition(location: Point): void;
   getDimensions(): Dimensions;
   setDimensions(dimensions: Dimensions): void;
+  getScaleExtent(): ScaleExtent;
+  setScaleExtent(scaleExtent: ScaleExtent): void;
   getScale(): number;
   setScale(scale: number): void;
   getLayout(): string | undefined;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3490

**Analysis / Root cause**: 
The graph scale did not include any zoom extent boundaries so the zoom buttons allowed for infinite zoom in/out.

**Solution Description**: 
Add zoomExtents to the BaseGraph to prevent setting the scale out of the extent boundaries.

/kind bug
