### PR TITLE
Bug 1826385: Truncate condition messages

### DIFF
--- a/frontend/public/components/_conditions.scss
+++ b/frontend/public/components/_conditions.scss
@@ -1,0 +1,3 @@
+.co-conditions__message {
+  @include co-line-clamp(10);
+}

--- a/frontend/public/components/conditions.tsx
+++ b/frontend/public/components/conditions.tsx
@@ -20,7 +20,7 @@ export const Conditions: React.SFC<ConditionsProps> = ({ conditions }) => {
         <CamelCaseWrap value={condition.reason} />
       </div>
       {/* remove initial newline which appears in route messages */}
-      <div className="hidden-xs col-sm-5 col-md-4 co-break-word co-pre-line">
+      <div className="hidden-xs col-sm-5 col-md-4 co-break-word co-pre-line co-conditions__message">
         {condition.message?.trim() || '-'}
       </div>
     </div>

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -97,6 +97,7 @@
 @import 'components/radio';
 @import 'components/filter-toolbar';
 @import 'components/autocomplete';
+@import 'components/conditions';
 
 @import 'components/dashboard/dashboards-page/cluster-dashboard/activity-card';
 @import 'components/dashboard/dashboards-page/cluster-dashboard/status-card';


### PR DESCRIPTION
Applied truncation class to messages so they won't overwhelm the table at their longest lengths.

The default is three lines. @spadgett, let me know if you want longer lengths.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1826385.