### PR TITLE
Bug 1827116: fix broken layout for add page and topology in safari browser

### DIFF
--- a/frontend/packages/dev-console/src/components/EmptyState.scss
+++ b/frontend/packages/dev-console/src/components/EmptyState.scss
@@ -8,12 +8,11 @@
 
   &__title {
     background-color: var(--pf-global--BackgroundColor--light-100);
-    display: flex;
-    flex-direction: column;
   }
 
   &__content {
     padding: var(--pf-global--spacer--lg);
+    flex: 1;
   }
 
   &__tile {

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
@@ -38,14 +38,14 @@
 
       &.pf-m-active {
         background-color: var(--pf-global--Color--light-300);
-        color: var(--pf-global--icon--Color--dark	);
+        color: var(--pf-global--icon--Color--dark);
       }
 
       &:hover {
         z-index: 20;
         color: var(--pf-global--active-color--400);
         &.pf-m-active {
-          color: var(--pf-global--icon--Color--dark	);
+          color: var(--pf-global--icon--Color--dark);
         }
       }
     }
@@ -71,8 +71,7 @@
     margin-right: var(--pf-global--spacer--2xl);
   }
 
-  // WORKAROUND: see https://github.com/patternfly/patternfly-react/issues/3312
-  .pf-topology-container__with-sidebar {
-    flex: 1;
+  .pf-topology-container {
+    display: flex;
   }
 }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3417

**Analysis / Root cause**: 
Add page and topology page layout was broken on resizing the window.

**Solution Description**: 
Add and remove the flex properties at the right place.

**Screen shots / Gifs for design review**: 
**Safari**
![safari](https://user-images.githubusercontent.com/2561818/80084211-316aba00-8574-11ea-989f-b74ea368437f.gif)

**Chrome**
![chrome](https://user-images.githubusercontent.com/2561818/80084615-bb1a8780-8574-11ea-86b9-2e12c43b6ea3.gif)

**Firefox**
![firefox](https://user-images.githubusercontent.com/2561818/80084827-0896f480-8575-11ea-900b-b8f1ccaeca51.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
