### PR TITLE
Bug 1827204: Knative service revision deployments should not be editable via add flows

### DIFF
--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -11,13 +11,13 @@ import { k8sCreate, K8sResourceKind, K8sVerb, k8sUpdate } from '@console/interna
 import { ServiceModel as KnServiceModel } from '@console/knative-plugin';
 import { getKnativeServiceDepResource } from '@console/knative-plugin/src/utils/create-knative-utils';
 import { getRandomChars } from '@console/shared/src/utils';
-import { getAppLabels, getPodLabels, mergeData } from '../../utils/resource-label-utils';
 import {
-  createRoute,
-  createService,
-  annotations,
-  dryRunOpt,
-} from '../../utils/shared-submit-utils';
+  getAppLabels,
+  getPodLabels,
+  mergeData,
+  getCommonAnnotations,
+} from '../../utils/resource-label-utils';
+import { createRoute, createService, dryRunOpt } from '../../utils/shared-submit-utils';
 import { getProbesData } from '../health-checks/create-health-checks-probe-utils';
 import { RegistryType } from '../../utils/imagestream-utils';
 import { AppResources } from '../edit-application/edit-application-types';
@@ -79,7 +79,7 @@ export const createOrUpdateImageStream = (
         {
           name: tag,
           annotations: {
-            ...annotations,
+            ...getCommonAnnotations(),
             'openshift.io/imported-from': isiName,
           },
           from: {
@@ -148,6 +148,7 @@ export const createOrUpdateDeployment = (
     healthChecks,
   } = formData;
 
+  const annotations = getCommonAnnotations();
   const defaultAnnotations = {
     ...annotations,
     'alpha.image.policy.openshift.io/resolve-names': '*',
@@ -247,6 +248,7 @@ export const createOrUpdateDeploymentConfig = (
   } = formData;
 
   const { labels, podLabels, volumes, volumeMounts } = getMetadata(formData);
+  const annotations = getCommonAnnotations();
   const newDeploymentConfig = {
     kind: 'DeploymentConfig',
     apiVersion: 'apps.openshift.io/v1',
@@ -434,7 +436,6 @@ export const createOrUpdateDeployImageResources = async (
       internalImageName || name,
       imageStreamTag,
       internalImageNamespace,
-      annotations,
       _.get(appResources, 'editAppResource.data'),
     );
     requests.push(

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -19,7 +19,8 @@ import { getRandomChars } from '@console/shared/src/utils';
 import {
   getAppLabels,
   getPodLabels,
-  getAppAnnotations,
+  getGitAnnotations,
+  getCommonAnnotations,
   mergeData,
 } from '../../utils/resource-label-utils';
 import { createService, createRoute, dryRunOpt } from '../../utils/shared-submit-utils';
@@ -76,7 +77,7 @@ export const createOrUpdateImageStream = (
   } = formData;
   const imageStreamName = imageStreamData && imageStreamData.metadata.name;
   const defaultLabels = getAppLabels(name, application, imageStreamName, tag);
-  const defaultAnnotations = getAppAnnotations(repository, ref);
+  const defaultAnnotations = { ...getGitAnnotations(repository, ref), ...getCommonAnnotations() };
   const newImageStream = {
     apiVersion: 'image.openshift.io/v1',
     kind: 'ImageStream',
@@ -141,7 +142,7 @@ export const createOrUpdateBuildConfig = (
   const imageStreamNamespace = imageStream && imageStream.metadata.namespace;
 
   const defaultLabels = getAppLabels(name, application, imageStreamName, selectedTag);
-  const defaultAnnotations = getAppAnnotations(repository, ref);
+  const defaultAnnotations = { ...getGitAnnotations(repository, ref), ...getCommonAnnotations() };
   let buildStrategyData;
 
   switch (buildStrategy) {
@@ -243,7 +244,8 @@ export const createOrUpdateDeployment = (
   const imageStreamName = imageStream && imageStream.metadata.name;
   const defaultLabels = getAppLabels(name, application, imageStreamName, tag);
   const annotations = {
-    ...getAppAnnotations(repository, ref),
+    ...getGitAnnotations(repository, ref),
+    ...getCommonAnnotations(),
     'alpha.image.policy.openshift.io/resolve-names': '*',
     'image.openshift.io/triggers': JSON.stringify([
       {
@@ -330,7 +332,7 @@ export const createOrUpdateDeploymentConfig = (
 
   const imageStreamName = imageStream && imageStream.metadata.name;
   const defaultLabels = getAppLabels(name, application, imageStreamName, tag);
-  const defaultAnnotations = getAppAnnotations(repository, ref);
+  const defaultAnnotations = { ...getGitAnnotations(repository, ref), ...getCommonAnnotations() };
   const podLabels = getPodLabels(name);
 
   const newDeploymentConfig = {
@@ -455,7 +457,7 @@ export const createOrUpdateResources = async (
 
   verb === 'create' && requests.push(createWebhookSecret(formData, 'generic', dryRun));
 
-  const defaultAnnotations = getAppAnnotations(repository, ref);
+  const defaultAnnotations = getGitAnnotations(repository, ref);
 
   if (pipeline.enabled && pipeline.template && !dryRun) {
     requests.push(createPipelineForImportFlow(formData));

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -31,11 +31,16 @@ export const getAppLabels = (
   return labels;
 };
 
-export const getAppAnnotations = (gitURL: string, gitRef: string) => {
+export const getGitAnnotations = (gitURL: string, gitRef?: string) => {
   const ref = gitRef || 'master';
   return {
     'app.openshift.io/vcs-uri': gitURL,
     'app.openshift.io/vcs-ref': ref,
+  };
+};
+
+export const getCommonAnnotations = () => {
+  return {
     'openshift.io/generated-by': 'OpenShiftWebConsole',
   };
 };

--- a/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
+++ b/frontend/packages/dev-console/src/utils/shared-submit-utils.ts
@@ -1,12 +1,14 @@
 import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { GitImportFormData, DeployImageFormData } from '../components/import/import-types';
-import { getAppLabels, getPodLabels, getAppAnnotations, mergeData } from './resource-label-utils';
+import {
+  getAppLabels,
+  getPodLabels,
+  getGitAnnotations,
+  getCommonAnnotations,
+  mergeData,
+} from './resource-label-utils';
 import { makePortName } from './imagestream-utils';
-
-export const annotations = {
-  'openshift.io/generated-by': 'OpenShiftWebConsole',
-};
 
 export const dryRunOpt = { queryParams: { dryRun: 'All' } };
 
@@ -34,7 +36,9 @@ export const createService = (
 
   const defaultLabels = getAppLabels(name, application, imageStreamName, imageTag);
   const podLabels = getPodLabels(name);
-  const defaultAnnotations = git ? getAppAnnotations(git.url, git.ref) : annotations;
+  const defaultAnnotations = git
+    ? { ...getGitAnnotations(git.url, git.ref), ...getCommonAnnotations() }
+    : getCommonAnnotations();
 
   let ports = imagePorts;
   if (_.get(formData, 'build.strategy') === 'Docker') {
@@ -91,7 +95,9 @@ export const createRoute = (
   const git = _.get(formData, 'git');
 
   const defaultLabels = getAppLabels(name, application, imageStreamName, imageTag);
-  const defaultAnnotations = git ? getAppAnnotations(git.url, git.ref) : annotations;
+  const defaultAnnotations = git
+    ? { ...getGitAnnotations(git.url, git.ref), ...getCommonAnnotations() }
+    : getCommonAnnotations();
 
   let ports = imagePorts;
   if (isDeployImageFormData(formData)) {

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -2,8 +2,11 @@ import * as _ from 'lodash';
 import { safeLoad } from 'js-yaml';
 import { K8sResourceKind, K8sKind, referenceForModel } from '@console/internal/module/k8s';
 import { useAccessReview } from '@console/internal/components/utils';
-import { getAppLabels } from '@console/dev-console/src/utils/resource-label-utils';
-import { annotations } from '@console/dev-console/src/utils/shared-submit-utils';
+import {
+  getAppLabels,
+  getCommonAnnotations,
+} from '@console/dev-console/src/utils/resource-label-utils';
+
 import {
   EventSources,
   EventSourceFormData,
@@ -38,7 +41,7 @@ export const getEventSourcesDepResource = (formData: EventSourceFormData): K8sRe
       labels: {
         ...defaultLabel,
       },
-      annotations,
+      annotations: getCommonAnnotations(),
     },
     spec: {
       sink: {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/ODC-3487

**Analysis / Root cause**
Knservice resources such as revision deployments were editable even though they are not created using the add flows becuase `openshift.io/generated-by: OpenshiftWebConsole` annotation was being added to these resources.

**Solution Description**
Remove `openshift.io/generated-by: OpenshiftWebConsole` annotation  from knservice so that it doesnt get propagated to its dependent resources.

**Screenshots**
![image](https://user-images.githubusercontent.com/20724543/80097908-ab596e00-8589-11ea-844a-4a67b29141d9.png)


/kind bug

