### PR TITLE
Bug 1827297: Fix resource limits validation error

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/ResourceLimitField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/ResourceLimitField.tsx
@@ -35,8 +35,8 @@ const ResourceLimitField: React.FC<ResourceLimitFieldProps> = ({
         {...props}
         onChange={(val) => {
           setFieldValue(props.name, val.value);
-          setFieldValue(unitName, val.unit);
           setFieldTouched(props.name, true);
+          setFieldValue(unitName, val.unit);
         }}
         dropdownUnits={unitOptions}
         defaultRequestSizeUnit={defaultUnitSize}

--- a/frontend/packages/dev-console/src/components/import/validation-schema.ts
+++ b/frontend/packages/dev-console/src/components/import/validation-schema.ts
@@ -156,8 +156,8 @@ export const limitsValidationSchema = yup.object().shape({
         },
         message: 'CPU request must be less than or equal to limit.',
       }),
-    requestUnit: yup.string('Unit must be millicores or cores.'),
-    limitUnit: yup.string('Unit must be millicores or cores.'),
+    requestUnit: yup.string('Unit must be millicores or cores.').ensure(),
+    limitUnit: yup.string('Unit must be millicores or cores.').ensure(),
     limit: yup
       .number()
       .transform((limit) => (_.isNaN(limit) ? undefined : limit))


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-3111

**Analysis / Root cause**
when unit `cores` is selected the value of the unit is read as undefined, which when concatenated with the numeric value and passed to `convertToBaseValue`, `null` is returned. 

**Solution Description**
added `ensure()` in the yup validation of `requestUnit` and `limitUnit` so that it accepts `<empty-string>` and don't consider them as undefined. 

**GIF**
![RL](https://user-images.githubusercontent.com/22490998/80104647-16f50880-8595-11ea-964b-2cbe22e939de.gif)


/kind bug