### PR TITLE
Bug 1827356: fix event source form for single event source

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
@@ -35,16 +35,23 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
     },
     [setFieldValue, setFieldTouched, validateForm],
   );
-  return (
+
+  const itemSelectorField = (
+    <ItemSelectorField
+      itemList={eventSourceList}
+      loadingItems={!eventSourceItems}
+      name="type"
+      onSelect={handleItemChange}
+      autoSelect
+    />
+  );
+
+  return eventSourceItems > 1 ? (
     <FormSection title="Type" fullWidth extraMargin>
-      <ItemSelectorField
-        itemList={eventSourceList}
-        loadingItems={!eventSourceItems}
-        name="type"
-        onSelect={handleItemChange}
-        autoSelect
-      />
+      {itemSelectorField}
     </FormSection>
+  ) : (
+    itemSelectorField
   );
 };
 

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
@@ -4,6 +4,7 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import { ItemSelectorField } from '@console/shared';
 import EventSourcesSelector from '../EventSourcesSelector';
 import * as sourceUtils from '../../../../utils/create-eventsources-utils';
+import FormSection from '@console/dev-console/src/components/import/section/FormSection';
 
 type EventSourcesSelectorProps = React.ComponentProps<typeof EventSourcesSelector>;
 
@@ -25,6 +26,38 @@ describe('EventSourcesSelector', () => {
   beforeEach(() => {
     const eventSourceList = {};
     wrapper = shallow(<EventSourcesSelector eventSourceList={eventSourceList} />);
+  });
+
+  it('should not render FormSection if no more than one eventSource present', () => {
+    const eventSourceList = {
+      SinkBinding: {
+        title: 'sinkBinding',
+        iconUrl: 'sinkBindingIcon',
+        name: 'SinkBinding',
+        displayName: 'Sink Binding',
+      },
+    };
+    wrapper = shallow(<EventSourcesSelector eventSourceList={eventSourceList} />);
+    expect(wrapper.find(FormSection).exists()).toBe(false);
+  });
+
+  it('should render FormSection if more than one eventSource present', () => {
+    const eventSourceList = {
+      SinkBinding: {
+        title: 'sinkBinding',
+        iconUrl: 'sinkBindingIcon',
+        name: 'SinkBinding',
+        displayName: 'Sink Binding',
+      },
+      PingSource: {
+        title: 'pingSource',
+        iconUrl: 'pingSourceIcon',
+        name: 'PingSource',
+        displayName: 'Ping Source',
+      },
+    };
+    wrapper = shallow(<EventSourcesSelector eventSourceList={eventSourceList} />);
+    expect(wrapper.find(FormSection).exists()).toBe(true);
   });
 
   it('should render ItemSelectorField', () => {


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-3624

**Analysis / Root cause:**
event source form renders event source type section even if there is a single event source

**Solution Description:**
Remove the event source type section when there is only one event source

**Screens:**
![Screenshot from 2020-04-23 22-16-13](https://user-images.githubusercontent.com/38663217/80129102-3e0f0280-85b4-11ea-95d2-122e941ac128.png)
![Screenshot from 2020-04-23 22-18-38](https://user-images.githubusercontent.com/38663217/80129127-45cea700-85b4-11ea-8996-77b3f442d0e3.png)
![Screenshot from 2020-04-23 22-17-31](https://user-images.githubusercontent.com/38663217/80129141-4b2bf180-85b4-11ea-8dc6-0efe3b7845e3.png)

**Test Coverage:**
![Screenshot from 2020-04-23 22-38-16](https://user-images.githubusercontent.com/38663217/80130414-259fe780-85b6-11ea-8f48-f67f990b8efd.png)
![event-source-coverage](https://user-images.githubusercontent.com/38663217/80130368-15880800-85b6-11ea-89b3-19e1e3f77d7e.png)

Browser Conformance:
- [x] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge