### PR TITLE
Bug 1827361: Show the project selection list when a pinned item is shown for all projects

### DIFF
--- a/frontend/packages/dev-console/src/components/ProjectSelectPage.tsx
+++ b/frontend/packages/dev-console/src/components/ProjectSelectPage.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Helmet } from 'react-helmet';
+import { match } from 'react-router';
+import { LoadingBox } from '@console/internal/components/utils';
+import { connectToPlural } from '@console/internal/kinds';
+import {
+  apiVersionForReference,
+  isGroupVersionKind,
+  kindForReference,
+} from '@console/internal/module/k8s';
+import { ErrorPage404 } from '@console/internal/components/error';
+import { withStartGuide } from '@console/internal/components/start-guide';
+import ProjectListPage from './projects/ProjectListPage';
+import { getBadgeFromType } from '@console/shared/src';
+
+export interface ProjectSelectPageProps {
+  match: match<any>;
+}
+
+const allParams = (props) => Object.assign({}, props?.match?.params, props);
+
+const ProjectSelectPage: React.FC<ProjectSelectPageProps> = (props) => {
+  const { kindObj, kindsInFlight, plural } = allParams(props);
+
+  if (!kindObj) {
+    if (kindsInFlight) {
+      return <LoadingBox />;
+    }
+    const missingType = isGroupVersionKind(plural)
+      ? `"${kindForReference(plural)}" in "${apiVersionForReference(plural)}"`
+      : `"${plural}"`;
+    return (
+      <ErrorPage404
+        message={`The server doesn't have a resource type ${missingType}. Try refreshing the page if it was recently added.`}
+      />
+    );
+  }
+  return (
+    <>
+      <Helmet>
+        <title>{kindObj.labelPlural}</title>
+      </Helmet>
+      <ProjectListPage title={kindObj.labelPlural} badge={getBadgeFromType(kindObj.badge)}>
+        Select a project to view the list of {kindObj.labelPlural}
+      </ProjectListPage>
+    </>
+  );
+};
+
+export default connectToPlural(withStartGuide(ProjectSelectPage));

--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import { CodeIcon, BoltIcon, DatabaseIcon, CatalogIcon } from '@patternfly/react-icons';
 import {
   Plugin,
   ModelDefinition,
@@ -20,9 +21,18 @@ import {
   ReduxReducer,
 } from '@console/plugin-sdk';
 import { NamespaceRedirect } from '@console/internal/components/utils/namespace-redirect';
-import { CodeIcon, BoltIcon, DatabaseIcon, CatalogIcon } from '@patternfly/react-icons';
 import { FLAGS } from '@console/shared/src/constants';
 import { referenceForModel } from '@console/internal/module/k8s';
+import {
+  BuildConfigModel,
+  ImageStreamModel,
+  DeploymentConfigModel,
+  SecretModel,
+  RouteModel,
+  ServiceModel,
+  ImageStreamImportsModel,
+  ConfigMapModel,
+} from '@console/internal/models';
 import * as helmIcon from '@console/internal/imgs/logos/helm.svg';
 import * as models from './models';
 import { getKebabActionsForKind } from './utils/kebab-actions';
@@ -40,16 +50,6 @@ import {
 } from './templates';
 import reducer from './utils/reducer';
 import { AddAction } from './extensions/add-actions';
-import {
-  BuildConfigModel,
-  ImageStreamModel,
-  DeploymentConfigModel,
-  SecretModel,
-  RouteModel,
-  ServiceModel,
-  ImageStreamImportsModel,
-  ConfigMapModel,
-} from '@console/internal/models';
 import * as yamlIcon from './images/yaml.svg';
 import * as importGitIcon from './images/from-git.svg';
 import * as dockerfileIcon from './images/dockerfile.svg';
@@ -728,6 +728,20 @@ const plugin: Plugin<ConsumedExtensions> = [
         (
           await import(
             './components/health-checks/HealthChecksPage' /* webpackChunkName: "dev-console-healthCheck" */
+          )
+        ).default,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      perspective: 'dev',
+      exact: false,
+      path: ['/k8s/all-namespaces/:plural'],
+      loader: async () =>
+        (
+          await import(
+            './components/ProjectSelectPage' /* webpackChunkName: "dev-console-projectselectpage" */
           )
         ).default,
     },


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-3653

**Analysis / Root cause**: 
Pinned items show the standard resources list page in the dev perspective

**Solution Description**: 
Add a Page/Route plugin for resources in the dev perspective plugin to show the project select page when using all-namespaces.

/kind bug