### PR TITLE
Bug 1827344:Alert graph timespan dropdown button needs proper label to be read by screen reader 

### DIFF
--- a/frontend/public/components/monitoring/query-browser.tsx
+++ b/frontend/public/components/monitoring/query-browser.tsx
@@ -120,6 +120,7 @@ const SpanControls: React.FC<SpanControlsProps> = React.memo(
           value={text}
         />
         <Dropdown
+          ariaLabel="graph timespan"
           buttonClassName="dropdown-button--icon-only"
           items={dropdownItems}
           menuClassName="query-browser__span-dropdown-menu"

--- a/frontend/public/components/utils/dropdown.jsx
+++ b/frontend/public/components/utils/dropdown.jsx
@@ -410,6 +410,7 @@ export class Dropdown extends DropdownMixin {
       favoriteKey,
     } = this.state;
     const {
+      ariaLabel,
       autocompleteFilter,
       autocompletePlaceholder,
       className,
@@ -563,6 +564,7 @@ export class Dropdown extends DropdownMixin {
           )}
         >
           <button
+            aria-label={ariaLabel}
             aria-haspopup="true"
             aria-expanded={this.state.active}
             className={classNames('pf-c-dropdown__toggle', buttonClassName)}


### PR DESCRIPTION
This adds an aria label to the alert graph timespan dropdown button. It fixes the following axe error:
```
[
  {
    "data": "",
    "id": "button-has-visible-text",
    "impact": "critical",
    "message": "Element does not have inner text that is visible to screen readers",
    "relatedNodes": [
      {
        "html": "<button aria-haspopup="true" aria-expanded="false" class="pf-c-dropdown__toggle dropdown-button--icon-only" data-test-id="dropdown-button" type="button">"
      }
    ]
  }
]
```