### PR TITLE
Bug 1827415: Fix imagestream icon in internal registry flow

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/deployImage-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/deployImage-submit-utils.spec.ts
@@ -88,6 +88,50 @@ describe('DeployImage Submit Utils', () => {
         });
     });
 
+    it('should create deployment with the internal imagestream labels instead of creating new imagestream name', (done) => {
+      const internalImageStreamData = _.merge(_.cloneDeep(internalImageData), {
+        isi: {
+          image: {
+            metadata: {
+              labels: {
+                'app.kubernetes.io/name': 'nodejs',
+                'app.openshift.io/runtime': 'nodejs',
+                'app.openshift.io/runtime-version': '10-SCL',
+              },
+            },
+          },
+        },
+      });
+
+      createOrUpdateDeployment(internalImageStreamData, false)
+        .then((returnValue) => {
+          const { data: Deployment } = returnValue;
+          expect(Deployment.metadata.labels.app).toEqual('react-web-app');
+          expect(Deployment.metadata.labels['app.kubernetes.io/name']).toEqual('nodejs');
+          expect(Deployment.metadata.labels['app.kubernetes.io/runtime']).toEqual('nodejs');
+          expect(Deployment.metadata.labels['app.kubernetes.io/runtime-version']).toEqual('10-SCL');
+          done();
+        })
+        .catch(() => {
+          done();
+        });
+    });
+
+    it('should not have the internal imagestream labels', (done) => {
+      createOrUpdateDeployment(internalImageData, false)
+        .then((returnValue) => {
+          const { data: Deployment } = returnValue;
+          expect(Deployment.metadata.labels.app).toEqual('react-web-app');
+          expect(Deployment.metadata.labels['app.kubernetes.io/name']).toBeUndefined();
+          expect(Deployment.metadata.labels['app.kubernetes.io/runtime']).toBeUndefined();
+          expect(Deployment.metadata.labels['app.kubernetes.io/runtime-version']).toBeUndefined();
+          done();
+        })
+        .catch(() => {
+          done();
+        });
+    });
+
     it('should assign limits on creating Deployment', (done) => {
       const data = _.cloneDeep(defaultData);
       data.limits = {

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -19,7 +19,7 @@ import {
 } from '../../utils/resource-label-utils';
 import { createRoute, createService, dryRunOpt } from '../../utils/shared-submit-utils';
 import { getProbesData } from '../health-checks/create-health-checks-probe-utils';
-import { RegistryType } from '../../utils/imagestream-utils';
+import { RegistryType, getRuntime } from '../../utils/imagestream-utils';
 import { AppResources } from '../edit-application/edit-application-types';
 import { DeployImageFormData, Resources } from './import-types';
 
@@ -104,10 +104,10 @@ const getMetadata = (formData: DeployImageFormData) => {
     name,
     isi: { image },
     labels: userLabels,
-    imageStream: { image: imgName, tag: imgTag, namespace: imgNamespace },
+    imageStream: { tag: imgTag, namespace: imgNamespace },
   } = formData;
-
-  const defaultLabels = getAppLabels(name, application, imgName || undefined, imgTag, imgNamespace);
+  const imgStreamName = getRuntime(image.metadata?.labels);
+  const defaultLabels = getAppLabels(name, application, imgStreamName, imgTag, imgNamespace);
   const labels = { ...defaultLabels, ...userLabels };
   const podLabels = getPodLabels(name);
 
@@ -355,9 +355,9 @@ export const createOrUpdateDeployImageResources = async (
     registry,
     route: { create: canCreateRoute, disable },
     isi: { ports, tag: imageStreamTag, image },
-    imageStream: { image: internalImageName, namespace: internalImageNamespace },
+    imageStream: { namespace: internalImageNamespace },
   } = formData;
-
+  const internalImageName = getRuntime(image.metadata?.labels);
   const requests: Promise<K8sResourceKind>[] = [];
   if (registry === RegistryType.Internal) {
     formData.imageStream.grantAccess &&

--- a/frontend/packages/dev-console/src/utils/imagestream-utils.ts
+++ b/frontend/packages/dev-console/src/utils/imagestream-utils.ts
@@ -36,6 +36,11 @@ export interface NormalizedBuilderImages {
   [builderImageName: string]: BuilderImage;
 }
 
+export const imageStreamLabels = ['app.kubernetes.io/name', 'app.openshift.io/runtime'];
+
+export const getRuntime = (labels: { [key: string]: string }) =>
+  labels?.['app.openshift.io/runtime'] || labels?.['app.kubernetes.io/name'];
+
 export const getSampleRepo = (tag) => _.get(tag, 'annotations.sampleRepo', '');
 export const getSampleRef = (tag) => _.get(tag, 'annotations.sampleRef', '');
 export const getSampleContextDir = (tag) => _.get(tag, 'annotations.sampleContextDir', '');


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3379

**Problem:**
When using the internal imagestream flow, it uses the custom imagestream name rather than using the actual builder image name, so instead of actual builder image icon it shows defalut openshift icon in topology.

**Solution:**
Reusing the lables from the selected imagestream to show the proper builder image icon in topology

**Screenshot:**
![deploy-image-icon](https://user-images.githubusercontent.com/9964343/80253306-a33b2480-8696-11ea-8921-0e9f1de2b0a2.gif)


**Unit test coverage:**
![image](https://user-images.githubusercontent.com/9964343/80147656-74a74600-85d1-11ea-8844-282f9e129837.png)

/kind bug
