### PR TITLE
Bug 1827654: Include an override to use PF4 link colors in the catalog vertical-tabs

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -371,7 +371,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
 // Remove once https://github.com/patternfly/patternfly-react/issues/4117 is fixed
 .vertical-tabs-pf-tab {
   &.active a {
-    color: var(--pf-global--link--Color);
+    color: var(--pf-global--link--Color) !important;
 
     &::before {
       background: var(--pf-global--link--Color);
@@ -379,7 +379,6 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   }
 
   > a {
-    color: var(--pf-global--link--Color);
     font-size: $font-size-base;
 
     &:focus,


### PR DESCRIPTION
Correct the previous fix https://github.com/openshift/console/pull/5169 

bug https://bugzilla.redhat.com/show_bug.cgi?id=1826508



