### PR TITLE
Bug 1828128: Fix issue with adding access in the Project Acess Page

### DIFF
--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccessPage.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccessPage.tsx
@@ -16,7 +16,7 @@ const ProjectAccessPage: React.FC<ProjectAccessPageProps> = ({ customData }) => 
     <Firehose
       resources={[
         {
-          activeNamespace,
+          namespace: activeNamespace,
           kind: 'RoleBinding',
           prop: 'roleBindings',
           isList: true,


### PR DESCRIPTION
**FIxes**
https://issues.redhat.com/browse/ODC-3677

**Analysis / Root cause**
In the Firehose resources of the `ProjectAccessPage` component, the namespace is not being sent properly.

**Solution Description**
Sending the namespace properly in the Firehose resources.

**GIF**
![fix-pa](https://user-images.githubusercontent.com/22490998/80228091-37dc5d00-866c-11ea-92d2-acdc0058e9c9.gif)

/kind bug