### PR TITLE
Bug 1827753: autoselect query from metric dropdown

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/metrics/MonitoringMetrics.tsx
+++ b/frontend/packages/dev-console/src/components/monitoring/metrics/MonitoringMetrics.tsx
@@ -16,8 +16,10 @@ export const MonitoringMetrics: React.FC<MonitoringMetricsProps> = ({ patchQuery
   const params = getURLSearchParams();
   const query = params.query0;
   React.useEffect(() => {
-    patchQuery({ text: query });
-    runQueries();
+    if (query) {
+      patchQuery({ text: query });
+      runQueries();
+    }
   }, [query, patchQuery, runQueries]);
 
   return (
@@ -26,7 +28,7 @@ export const MonitoringMetrics: React.FC<MonitoringMetricsProps> = ({ patchQuery
         <title>Metrics</title>
       </Helmet>
       <div className="co-m-pane__body">
-        <MetricsQueryInput />
+        <MetricsQueryInput query={query} />
         <div className="row">
           <div className="col-xs-12">
             <ConnectedMetricsChart />

--- a/frontend/packages/dev-console/src/components/monitoring/queries.ts
+++ b/frontend/packages/dev-console/src/components/monitoring/queries.ts
@@ -24,42 +24,10 @@ export const metricsQuery = {
   PODS_BY_NETWORK_OUT: 'Transmit Bandwidth',
 };
 
-const topMetricsQueries = {
-  [metricsQuery.PODS_BY_CPU]: _.template(
-    `topk(25, sort_desc(sum(avg_over_time(pod:container_cpu_usage:sum{container="",pod!="",namespace='<%= namespace %>'}[5m])) BY (pod, namespace)))`,
-  ),
-  [metricsQuery.PODS_BY_MEMORY]: _.template(
-    `topk(25, sort_desc(sum(avg_over_time(container_memory_working_set_bytes{container="",pod!="",namespace='<%= namespace %>'}[5m])) BY (pod, namespace)))`,
-  ),
-  [metricsQuery.PODS_BY_FILESYSTEM]: _.template(
-    `topk(25, sort_desc(sum(pod:container_fs_usage_bytes:sum{container="",pod!="",namespace='<%= namespace %>'}) BY (pod, namespace)))`,
-  ),
-  [metricsQuery.PODS_BY_NETWORK_IN]: _.template(
-    `topk(25, sort_desc(sum(rate(container_network_receive_bytes_total{ container="POD", pod!= "", namespace='<%= namespace %>'}[5m])) BY (namespace, pod)))`,
-  ),
-  [metricsQuery.PODS_BY_NETWORK_OUT]: _.template(
-    `topk(25, sort_desc(sum(rate(container_network_transmit_bytes_total{ container="POD", pod!= "", namespace='<%= namespace %>'}[5m])) BY (namespace, pod)))`,
-  ),
-};
-
-export const getTopMetricsQueries = (namespace: string) => ({
-  [metricsQuery.PODS_BY_CPU]: topMetricsQueries[metricsQuery.PODS_BY_CPU]({ namespace }),
-  [metricsQuery.PODS_BY_MEMORY]: topMetricsQueries[metricsQuery.PODS_BY_MEMORY]({ namespace }),
-  [metricsQuery.PODS_BY_FILESYSTEM]: topMetricsQueries[metricsQuery.PODS_BY_FILESYSTEM]({
-    namespace,
-  }),
-  [metricsQuery.PODS_BY_NETWORK_IN]: topMetricsQueries[metricsQuery.PODS_BY_NETWORK_IN]({
-    namespace,
-  }),
-  [metricsQuery.PODS_BY_NETWORK_OUT]: topMetricsQueries[metricsQuery.PODS_BY_NETWORK_OUT]({
-    namespace,
-  }),
-});
-
 export const monitoringDashboardQueries: MonitoringQuery[] = [
   {
     query: _.template(
-      `sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster="",namespace='<%= namespace %>'}) by (pod)`,
+      `sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster="", namespace='<%= namespace %>'}) by (pod)`,
     ),
     chartType: GraphTypes.area,
     title: 'CPU Usage',
@@ -236,3 +204,32 @@ export const workloadMetricsQueries: MonitoringQuery[] = [
     ),
   },
 ];
+
+const getMetricsQuery = (title: string): _.TemplateExecutor => {
+  const queryObject = _.find(monitoringDashboardQueries, (q) => q.title === title);
+  return queryObject.query;
+};
+
+const topMetricsQueries = {
+  PODS_BY_CPU: getMetricsQuery('CPU Usage'),
+  PODS_BY_MEMORY: getMetricsQuery('Memory Usage'),
+  PODS_BY_FILESYSTEM: _.template(
+    `topk(25, sort_desc(sum(pod:container_fs_usage_bytes:sum{container="",pod!="",namespace='<%= namespace %>'}) BY (pod, namespace)))`,
+  ),
+  PODS_BY_NETWORK_IN: getMetricsQuery('Receive Bandwidth'),
+  PODS_BY_NETWORK_OUT: getMetricsQuery('Transmit Bandwidth'),
+};
+
+export const getTopMetricsQueries = (namespace: string) => ({
+  [metricsQuery.PODS_BY_CPU]: topMetricsQueries.PODS_BY_CPU({ namespace }),
+  [metricsQuery.PODS_BY_MEMORY]: topMetricsQueries.PODS_BY_MEMORY({ namespace }),
+  [metricsQuery.PODS_BY_FILESYSTEM]: topMetricsQueries.PODS_BY_FILESYSTEM({
+    namespace,
+  }),
+  [metricsQuery.PODS_BY_NETWORK_IN]: topMetricsQueries.PODS_BY_NETWORK_IN({
+    namespace,
+  }),
+  [metricsQuery.PODS_BY_NETWORK_OUT]: topMetricsQueries.PODS_BY_NETWORK_OUT({
+    namespace,
+  }),
+});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3064

**Analysis / Root cause**: 
When clicking on any metrics graph in the dashboard or sidebar in topology view takes you to metrics in the monitoring tab but the query field remains unchanged

**Solution Description**: 
autoselect query from the metric dropdown if it matches.

**Screen shots / Gifs for design review**: 
![monitoring](https://user-images.githubusercontent.com/2561818/80240963-5cdacb00-8680-11ea-9731-d125f87bfe29.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
