### PR TITLE
Bug 1828157: adds list of stop words to filter Acronym and trim it to handle Badge Acronym

### DIFF
--- a/frontend/public/module/k8s/get-resources.ts
+++ b/frontend/public/module/k8s/get-resources.ts
@@ -15,7 +15,11 @@ const ADMIN_RESOURCES = new Set([
   'secrets',
 ]);
 
-export const kindToAbbr = (kind) => (kind.replace(/[^A-Z]/g, '') || kind.toUpperCase()).slice(0, 3);
+const abbrBlacklist = ['ASS'];
+export const kindToAbbr = (kind) => {
+  const abbrKind = (kind.replace(/[^A-Z]/g, '') || kind.toUpperCase()).slice(0, 3);
+  return abbrBlacklist.includes(abbrKind) ? abbrKind.slice(0, -1) : abbrKind;
+};
 
 export const cacheResources = (resources) =>
   new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3630

**Analysis / Root cause**: 
The current badge acronym for ApiSyncSource is ASS, it needs to be updated

**Solution Description**: 
Added list to have StopWords which can be modified.

**Screen shots / Gifs for design review**: 
<img width="1447" alt="Screenshot 2020-04-27 at 1 12 52 PM" src="https://user-images.githubusercontent.com/5129024/80346742-db09be00-8888-11ea-86d5-7db87e80693a.png">

<img width="1426" alt="Screenshot 2020-04-27 at 1 10 06 PM" src="https://user-images.githubusercontent.com/5129024/80346765-e3fa8f80-8888-11ea-960a-fb050e6ae8a5.png">



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
