### PR TITLE
Bug 1828164: Fixes: Crash-looping pods shouldn't show up as Failed in the pod ring

### DIFF
--- a/frontend/packages/console-shared/src/constants/pod.ts
+++ b/frontend/packages/console-shared/src/constants/pod.ts
@@ -12,6 +12,7 @@ export enum AllPodStatus {
   Idle = 'Idle',
   AutoScaledTo0 = 'Autoscaled to 0',
   ScalingUp = 'Scaling Up',
+  CrashLoopBackOff = 'CrashLoopBackOff',
 }
 
 export const podColor = {
@@ -28,4 +29,5 @@ export const podColor = {
   [AllPodStatus.Idle]: '#FFFFFF',
   [AllPodStatus.AutoScaledTo0]: '#FFFFFF',
   [AllPodStatus.ScalingUp]: '#FFFFFF',
+  [AllPodStatus.CrashLoopBackOff]: '#CC0000',
 };

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-utils.spec.ts
@@ -5,6 +5,7 @@ import {
   getPodStatus,
   getPodData,
   checkPodEditAccess,
+  isContainerLoopingFilter,
 } from '../pod-utils';
 import {
   deploymentConfig,
@@ -43,6 +44,22 @@ describe('Pod Utils:', () => {
   it('getPodStatus should return `pending` phase', () => {
     const mData = { ...mockPod, status: { phase: 'Pending' } };
     expect(getPodStatus(mData)).toBe('Pending');
+  });
+
+  it('should return CrashLoopBackOff status', () => {
+    const mData = {
+      ...mockPod,
+      status: {
+        phase: 'Running',
+        containerStatuses: [{ state: { waiting: { reason: 'CrashLoopBackOff' } } }],
+      },
+    };
+    expect(getPodStatus(mData)).toBe('CrashLoopBackOff');
+  });
+
+  it('isContainerLoopingFilter should return true', () => {
+    const containerStatus = { state: { waiting: { reason: 'CrashLoopBackOff' } } };
+    expect(isContainerLoopingFilter(containerStatus)).toBe(true);
   });
 
   it('should return pods if there are no rolling strategy', () => {


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3157
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
CrashLoopBackOff pods were shown as failed on the pod ring

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
created a new status for pod ring i.e. CrashLoopBackOff

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screenshot from 2020-04-27 13-03-24](https://user-images.githubusercontent.com/9278015/80348081-e231cb80-888a-11ea-914d-2f19476e6b71.png)



**Unit test coverage report**: 
<!-- Attach test coverage report -->
![Screenshot from 2020-04-27 13-21-12](https://user-images.githubusercontent.com/9278015/80348087-e3fb8f00-888a-11ea-922a-65eba1800490.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
