### PR TITLE
Bug 1822112: include OpenShift Project as part of deployImage flow

### DIFF
--- a/frontend/packages/console-shared/src/components/dropdown/ResourceDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/dropdown/ResourceDropdown.tsx
@@ -34,6 +34,10 @@ interface State {
   title: React.ReactNode;
 }
 
+export interface ResourceDropdownItems {
+  [key: string]: string | React.ReactElement;
+}
+
 interface ResourceDropdownProps {
   id?: string;
   className?: string;
@@ -63,9 +67,10 @@ interface ResourceDropdownProps {
   autoSelect?: boolean;
   resourceFilter?: (resource: K8sResourceKind) => boolean;
   onChange?: (key: string, name?: string | object, isListEmpty?: boolean) => void;
-  onLoad?: (items: { [key: string]: string }) => void;
+  onLoad?: (items: ResourceDropdownItems) => void;
   showBadge?: boolean;
   autocompleteFilter?: (strText: string, item: object) => boolean;
+  appendItems?: ResourceDropdownItems;
 }
 
 class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
@@ -143,10 +148,11 @@ class ResourceDropdown extends React.Component<ResourceDropdownProps, State> {
       transformLabel,
       allSelectorItem,
       showBadge = false,
+      appendItems,
     }: ResourceDropdownProps,
     updateSelection: boolean,
   ) => {
-    const unsortedList = {};
+    const unsortedList = { ...appendItems };
     _.each(resources, ({ data, kind }) => {
       _.reduce(
         data,

--- a/frontend/packages/console-shared/src/components/formik-fields/ResourceDropdownField.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/ResourceDropdownField.tsx
@@ -4,7 +4,7 @@ import { useField, useFormikContext, FormikValues } from 'formik';
 import { FormGroup } from '@patternfly/react-core';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { Firehose, FirehoseResource } from '@console/internal/components/utils';
-import ResourceDropdown from '../dropdown/ResourceDropdown';
+import ResourceDropdown, { ResourceDropdownItems } from '../dropdown/ResourceDropdown';
 import { DropdownFieldProps } from './field-types';
 import { getFieldId } from './field-utils';
 import { useFormikValidationFix } from '../../hooks';
@@ -13,7 +13,7 @@ export interface ResourceDropdownFieldProps extends DropdownFieldProps {
   dataSelector: string[] | number[] | symbol[];
   resources: FirehoseResource[];
   showBadge?: boolean;
-  onLoad?: (items: { [key: string]: string }) => void;
+  onLoad?: (items: ResourceDropdownItems) => void;
   onChange?: (key: string, name?: string | object) => void;
   resourceFilter?: (resource: K8sResourceKind) => boolean;
   autoSelect?: boolean;
@@ -22,6 +22,7 @@ export interface ResourceDropdownFieldProps extends DropdownFieldProps {
     actionTitle: string;
     actionKey: string;
   }[];
+  appendItems?: ResourceDropdownItems;
 }
 
 const ResourceDropdownField: React.FC<ResourceDropdownFieldProps> = ({

--- a/frontend/packages/dev-console/src/components/import/image-search/ImageStream.tsx
+++ b/frontend/packages/dev-console/src/components/import/image-search/ImageStream.tsx
@@ -61,7 +61,9 @@ const ImageStream: React.FC = () => {
   } = state;
 
   React.useEffect(() => {
-    setFieldValue('imageStream.grantAccess', true);
+    if (imageStream.namespace !== BuilderImagesNamespace.Openshift) {
+      setFieldValue('imageStream.grantAccess', true);
+    }
   }, [imageStream.namespace, setFieldValue]);
   const imageStreamTagList = getImageStreamTags(selectedImageStream as K8sResourceKind);
   const isNamespaceSelected = imageStream.namespace !== '' && !accessLoading;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3523

**Analysis / Root cause**: 
The "openshift" has been always there to provide templates and images, user can use those via CLI but can't fetch images in deploy image flow from DevConsole

**Solution Description**: 
include OpenShift Project as part of deployImage flow irrespective of user-role

**Screen shots / Gifs for design review**: 
![Apr-27-2020 18-41-28](https://user-images.githubusercontent.com/5129024/80377335-c3e2c480-88b8-11ea-9853-0e464445c864.gif)

<img width="1733" alt="Screenshot 2020-04-27 at 7 02 07 PM" src="https://user-images.githubusercontent.com/5129024/80378004-a7935780-88b9-11ea-8ee3-b399bb05e4ab.png">



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge