### PR TITLE
Bug 1829552: cloudshell: hide create project option with rbac check

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/setup/__tests__/NamespaceSection.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/__tests__/NamespaceSection.spec.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useFormikContext, useField } from 'formik';
 import { shallow } from 'enzyme';
-import { InputField, ResourceDropdownField } from '@console/shared';
-import NamespaceSection from '../NamespaceSection';
+import { InputField, ResourceDropdownField, FLAGS } from '@console/shared';
+import { InternalNamespaceSection } from '../NamespaceSection';
 import { CREATE_NAMESPACE_KEY } from '../cloud-shell-setup-utils';
 
 jest.mock('formik', () => {
@@ -18,18 +18,21 @@ jest.mock('formik', () => {
   };
 });
 
+const canCreateFlags = { [FLAGS.CAN_CREATE_PROJECT]: true };
+const noFlags = {};
+
 describe('NamespaceSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
   it('should display InputField whent creating namespace', () => {
     (useField as jest.Mock).mockImplementationOnce(() => [{ value: CREATE_NAMESPACE_KEY }]);
-    const wrapper = shallow(<NamespaceSection />);
+    const wrapper = shallow(<InternalNamespaceSection flags={canCreateFlags} />);
     expect(wrapper.find(InputField).exists()).toBe(true);
   });
 
   it('should switch to create namespace mode if there are no projects', () => {
-    const wrapper = shallow(<NamespaceSection />);
+    const wrapper = shallow(<InternalNamespaceSection flags={canCreateFlags} />);
     wrapper
       .find(ResourceDropdownField)
       .props()
@@ -39,13 +42,35 @@ describe('NamespaceSection', () => {
       CREATE_NAMESPACE_KEY,
     );
   });
+  it('should switch from active namespace to no namespace no projects and user cannot create a project', () => {
+    (useField as jest.Mock).mockReturnValueOnce([{ value: 'test-namespace' }]);
+
+    const wrapper = shallow(<InternalNamespaceSection flags={noFlags} />);
+    wrapper
+      .find(ResourceDropdownField)
+      .props()
+      .onLoad({});
+    expect(useFormikContext().setFieldValue).toHaveBeenCalledWith('namespace', undefined);
+  });
 
   it('should update namespace value', () => {
-    const wrapper = shallow(<NamespaceSection />);
+    const wrapper = shallow(<InternalNamespaceSection flags={canCreateFlags} />);
     wrapper
       .find(ResourceDropdownField)
       .props()
       .onChange('test');
     expect(useFormikContext().setFieldValue).toHaveBeenCalledWith('namespace', 'test');
+  });
+
+  it('should include create project action when user can create a project', () => {
+    const wrapper = shallow(<InternalNamespaceSection flags={canCreateFlags} />);
+    expect(wrapper.find(ResourceDropdownField).props().actionItems?.[0]?.actionKey).toBe(
+      CREATE_NAMESPACE_KEY,
+    );
+  });
+
+  it('should omit create project action when user can create a project', () => {
+    const wrapper = shallow(<InternalNamespaceSection flags={noFlags} />);
+    expect(wrapper.find(ResourceDropdownField).props().actionItems).toBeUndefined();
   });
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3686

**Analysis / Root cause**: 
A user without access to create a project could see the `Create Project` option in the UI when provisioning a cloud shell terminal.

**Solution Description**: 
Use rbac check to hide the `Create Project` option.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Added new tests:
![image](https://user-images.githubusercontent.com/14068621/80401359-37b9a880-888a-11ea-8cff-dc05a7e75da4.png)

**Test setup:**
Install https://github.com/che-incubator/che-workspace-operator to enable the cloud shell terminal.
Create a user without ability to create projects.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [x] Safari
- [x] Edge

cc @abhinandan13jan 