### PR TITLE
Bug 1828478: Action menu should be 'Add Health Checks' when no probes is added

### DIFF
--- a/frontend/packages/console-app/src/actions/__tests__/modify-health-checks.spec.ts
+++ b/frontend/packages/console-app/src/actions/__tests__/modify-health-checks.spec.ts
@@ -1,0 +1,19 @@
+import { sampleDeployments } from '@console/dev-console/src/components/topology/__tests__/topology-test-data';
+import { AddHealthChecks, EditHealthChecks } from '../modify-health-checks';
+import { DeploymentModel } from '@console/internal/models';
+
+describe('modify health checks action', () => {
+  it('"Edit Health Checks" option should be visible for Deployments with probes', () => {
+    const editHealthChecksoption = EditHealthChecks(DeploymentModel, sampleDeployments.data[2]);
+    const addHealthChecksoption = AddHealthChecks(DeploymentModel, sampleDeployments.data[2]);
+    expect(editHealthChecksoption.hidden).toBe(false);
+    expect(addHealthChecksoption.hidden).toBe(true);
+  });
+
+  it('"Add Health Checks" option should be visible for Deployments with no probes', () => {
+    const editHealthCheckoption = EditHealthChecks(DeploymentModel, sampleDeployments.data[1]);
+    const addHealthChecksoption = AddHealthChecks(DeploymentModel, sampleDeployments.data[1]);
+    expect(editHealthCheckoption.hidden).toBe(true);
+    expect(addHealthChecksoption.hidden).toBe(false);
+  });
+});

--- a/frontend/packages/console-app/src/actions/modify-health-checks.ts
+++ b/frontend/packages/console-app/src/actions/modify-health-checks.ts
@@ -1,0 +1,52 @@
+import * as _ from 'lodash';
+import { K8sKind, K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
+import { KebabOption } from '@console/internal/components/utils';
+
+const healthChecksAdded = (resource: K8sResourceKind): boolean => {
+  const containers = resource?.spec?.template?.spec?.containers;
+  return _.every(
+    containers,
+    (container) => container.readinessProbe || container.livenessProbe || container.startupProbe,
+  );
+};
+
+const healthChecksUrl = (model: K8sKind, obj: K8sResourceKind): string => {
+  const {
+    kind,
+    metadata: { name, namespace },
+  } = obj;
+  const resourceKind = model.crd ? referenceFor(obj) : kind;
+  const containers = obj?.spec?.template?.spec?.containers;
+  const containerName = containers?.[0]?.name;
+  return `/k8s/ns/${namespace}/${resourceKind}/${name}/containers/${containerName}/health-checks`;
+};
+
+export const AddHealthChecks = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
+  return {
+    label: 'Add Health Checks',
+    hidden: healthChecksAdded(obj),
+    href: healthChecksUrl(model, obj),
+    accessReview: {
+      group: model.apiGroup,
+      resource: model.plural,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'update',
+    },
+  };
+};
+
+export const EditHealthChecks = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
+  return {
+    label: 'Edit Health Checks',
+    hidden: !healthChecksAdded(obj),
+    href: healthChecksUrl(model, obj),
+    accessReview: {
+      group: model.apiGroup,
+      resource: model.plural,
+      name: obj.metadata.name,
+      namespace: obj.metadata.namespace,
+      verb: 'update',
+    },
+  };
+};

--- a/frontend/packages/dev-console/src/actions/modify-application.ts
+++ b/frontend/packages/dev-console/src/actions/modify-application.ts
@@ -1,6 +1,6 @@
 import { KebabOption } from '@console/internal/components/utils';
 import { truncateMiddle } from '@console/internal/components/utils/truncate-middle';
-import { K8sResourceKind, K8sKind, referenceFor } from '@console/internal/module/k8s';
+import { K8sResourceKind, K8sKind } from '@console/internal/module/k8s';
 import { ServiceModel as KnativeServiceModel } from '@console/knative-plugin';
 import { RESOURCE_NAME_TRUNCATE_LENGTH } from '../const';
 import { editApplicationModal } from '../components/modals';
@@ -32,26 +32,6 @@ export const EditApplication = (model: K8sKind, obj: K8sResourceKind): KebabOpti
     hidden: obj.kind !== KnativeServiceModel.kind && annotation !== 'OpenShiftWebConsole',
     href: `/edit/ns/${obj.metadata.namespace}?name=${obj.metadata.name}&kind=${obj.kind ||
       model.kind}`,
-    accessReview: {
-      group: model.apiGroup,
-      resource: model.plural,
-      name: obj.metadata.name,
-      namespace: obj.metadata.namespace,
-      verb: 'update',
-    },
-  };
-};
-
-export const EditHealthCheck = (model: K8sKind, obj: K8sResourceKind): KebabOption => {
-  const {
-    kind,
-    metadata: { name, namespace },
-  } = obj;
-  const resourceKind = model.crd ? referenceFor(obj) : kind;
-  const containerName = obj?.spec?.template?.spec?.containers?.[0]?.name;
-  return {
-    label: 'Edit Health Checks',
-    href: `/k8s/ns/${namespace}/${resourceKind}/${name}/containers/${containerName}/health-checks`,
     accessReview: {
       group: model.apiGroup,
       resource: model.plural,

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -115,7 +115,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
             handleReset={handleReset}
             errorMessage={status && status?.errors?.json?.message}
             isSubmitting={isSubmitting}
-            submitLabel={healthCheckAdded ? 'Edit' : 'Add'}
+            submitLabel={healthCheckAdded ? 'Save' : 'Add'}
             disableSubmit={!dirty || !_.isEmpty(errors)}
             resetLabel="Cancel"
           />

--- a/frontend/packages/dev-console/src/components/health-checks/ProbeForm.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/ProbeForm.tsx
@@ -51,13 +51,6 @@ const ProbeForm: React.FC<ProbeFormProps> = ({ onSubmit, onClose, containerPorts
   return (
     <div className="odc-heath-check-probe-form">
       <FormSection>
-        <InputField
-          type={TextInputTypes.number}
-          name={`healthChecks.${probeType}.data.failureThreshold`}
-          label="Failure Threshold"
-          style={{ maxWidth: '100%' }}
-          helpText="How many times the probe will try starting or restarting before giving up."
-        />
         <DropdownField
           name={`healthChecks.${probeType}.data.requestType`}
           label="Type"
@@ -70,6 +63,20 @@ const ProbeForm: React.FC<ProbeFormProps> = ({ onSubmit, onClose, containerPorts
           probeType,
           containerPorts,
         )}
+        <InputField
+          type={TextInputTypes.number}
+          name={`healthChecks.${probeType}.data.failureThreshold`}
+          label="Failure Threshold"
+          style={{ maxWidth: '100%' }}
+          helpText="How many times the probe will try starting or restarting before giving up."
+        />
+        <InputField
+          type={TextInputTypes.number}
+          name={`healthChecks.${probeType}.data.successThreshold`}
+          label="Success Threshold"
+          style={{ maxWidth: '100%' }}
+          helpText="How many consecutive successes for the probe to be considered successful after having failed."
+        />
         <InputGroupField
           type={TextInputTypes.number}
           name={`healthChecks.${probeType}.data.initialDelaySeconds`}
@@ -93,13 +100,6 @@ const ProbeForm: React.FC<ProbeFormProps> = ({ onSubmit, onClose, containerPorts
           helpText="How long to wait for the probe to finish, if the time is exceeded, the probe is considered failed."
           afterInput={<InputGroupText>{'seconds'}</InputGroupText>}
           style={{ maxWidth: '100%' }}
-        />
-        <InputField
-          type={TextInputTypes.number}
-          name={`healthChecks.${probeType}.data.successThreshold`}
-          label="Success Threshold"
-          style={{ maxWidth: '100%' }}
-          helpText="How many consecutive successes for the probe to be considered successful after having failed."
         />
       </FormSection>
       <ActionGroupWithIcons

--- a/frontend/packages/dev-console/src/utils/__tests__/kebab-actions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/kebab-actions.spec.ts
@@ -1,15 +1,11 @@
 import { DeploymentConfigModel, ReplicaSetModel } from '@console/internal/models';
 import { getKebabActionsForKind } from '../kebab-actions';
-import {
-  ModifyApplication,
-  EditApplication,
-  EditHealthCheck,
-} from '../../actions/modify-application';
+import { ModifyApplication, EditApplication } from '../../actions/modify-application';
 
 describe('kebab-actions: ', () => {
   it('kebab action should have "Edit Application Grouping", "Edit Application" and "Edit Health Checks" option for deploymentConfig', () => {
     const modifyApplication = getKebabActionsForKind(DeploymentConfigModel);
-    expect(modifyApplication).toEqual([ModifyApplication, EditHealthCheck, EditApplication]);
+    expect(modifyApplication).toEqual([ModifyApplication, EditApplication]);
   });
 
   it('kebab action should not have "Edit Application Grouping" option for replicaSet', () => {

--- a/frontend/packages/dev-console/src/utils/kebab-actions.ts
+++ b/frontend/packages/dev-console/src/utils/kebab-actions.ts
@@ -7,7 +7,7 @@ import {
   DeploymentModel,
   StatefulSetModel,
 } from '@console/internal/models';
-import { ModifyApplication, EditApplication, EditHealthCheck } from '../actions/modify-application';
+import { ModifyApplication, EditApplication } from '../actions/modify-application';
 
 const modifyWebConsoleApplicationRefs = [
   referenceForModel(DeploymentConfigModel),
@@ -30,7 +30,6 @@ export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => 
   return _.includes(modifyWebConsoleApplicationRefs, referenceForModel(resourceKind))
     ? [
         ModifyApplication,
-        EditHealthCheck,
         ...(_.includes(editApplicationRefs, referenceForModel(resourceKind))
           ? [EditApplication]
           : []),

--- a/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
@@ -2,8 +2,8 @@ import { ServiceModel } from '@console/internal/models';
 import {
   ModifyApplication,
   EditApplication,
-  EditHealthCheck,
 } from '@console/dev-console/src/actions/modify-application';
+import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { getKebabActionsForKind } from '../kebab-actions';
 import { setTrafficDistribution } from '../../actions/traffic-splitting';
 import { setSinkSource } from '../../actions/sink-source';
@@ -15,13 +15,14 @@ describe('kebab-actions: ', () => {
     expect(modifyApplication).toEqual([ModifyApplication, setSinkSource]);
   });
 
-  it('kebab action should have "setTrafficDistribution", "Edit Application Grouping" and "Edit Application" option for knSvcModel', () => {
+  it('kebab action should have "setTrafficDistribution", "Add Health Checks", "Edit Application Grouping", "Edit Application" and "Edit Health Checks" option for knSvcModel', () => {
     const modifyApplication = getKebabActionsForKind(knSvcModel);
     expect(modifyApplication).toEqual([
       ModifyApplication,
       setTrafficDistribution,
-      EditHealthCheck,
+      AddHealthChecks,
       EditApplication,
+      EditHealthChecks,
     ]);
   });
 

--- a/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
+++ b/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
@@ -4,8 +4,8 @@ import { KebabAction } from '@console/internal/components/utils';
 import {
   ModifyApplication,
   EditApplication,
-  EditHealthCheck,
 } from '@console/dev-console/src/actions/modify-application';
+import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { setTrafficDistribution } from '../actions/traffic-splitting';
 import { setSinkSource } from '../actions/sink-source';
 import { ServiceModel } from '../models';
@@ -23,7 +23,7 @@ export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => 
       menuActions.push(ModifyApplication);
     }
     if (referenceForModel(resourceKind) === referenceForModel(ServiceModel)) {
-      menuActions.push(setTrafficDistribution, EditHealthCheck, EditApplication);
+      menuActions.push(setTrafficDistribution, AddHealthChecks, EditApplication, EditHealthChecks);
     }
     if (_.includes(eventSourceModelrefs, referenceForModel(resourceKind))) {
       menuActions.push(setSinkSource);

--- a/frontend/public/components/daemon-set.tsx
+++ b/frontend/public/components/daemon-set.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
+import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { K8sResourceKind } from '../module/k8s';
 import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import {
@@ -25,8 +26,10 @@ import { VolumesTable } from './volumes-table';
 import { DaemonSetModel } from '../models';
 
 export const menuActions: KebabAction[] = [
+  AddHealthChecks,
   Kebab.factory.AddStorage,
   ...Kebab.getExtensionsActionsForKind(DaemonSetModel),
+  EditHealthChecks,
   ...Kebab.factory.common,
 ];
 

--- a/frontend/public/components/deployment-config.tsx
+++ b/frontend/public/components/deployment-config.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 
 import { Status, PodRingController } from '@console/shared';
+import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
+import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { k8sCreate, K8sKind, K8sResourceKind, K8sResourceKindReference } from '../module/k8s';
 import { errorModal } from './modals';
 import { DeploymentConfigModel } from '../models';
@@ -27,7 +29,6 @@ import {
 import { ReplicationControllersPage } from './replication-controller';
 
 import { WorkloadTableRow, WorkloadTableHeader } from './workload-table';
-import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 
 const DeploymentConfigsReference: K8sResourceKindReference = 'DeploymentConfig';
 
@@ -82,8 +83,10 @@ export const menuActions: KebabAction[] = [
   RolloutAction,
   PauseAction,
   ModifyCount,
+  AddHealthChecks,
   AddStorage,
   ...getExtensionsKebabActionsForKind(DeploymentConfigModel),
+  EditHealthChecks,
   ...common,
 ];
 

--- a/frontend/public/components/deployment.tsx
+++ b/frontend/public/components/deployment.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
 import { Status, PodRingController } from '@console/shared';
+import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
+import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { DeploymentModel } from '../models';
 import { DeploymentKind, K8sKind, K8sResourceKindReference } from '../module/k8s';
 import { configureUpdateStrategyModal, errorModal } from './modals';
@@ -24,7 +26,6 @@ import {
 } from './utils';
 import { ReplicaSetsPage } from './replicaset';
 import { WorkloadTableRow, WorkloadTableHeader } from './workload-table';
-import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
 
 const deploymentsReference: K8sResourceKindReference = 'Deployment';
 const { ModifyCount, AddStorage, common } = Kebab.factory;
@@ -56,9 +57,11 @@ const PauseAction: KebabAction = (kind: K8sKind, obj: DeploymentKind) => ({
 export const menuActions = [
   ModifyCount,
   PauseAction,
+  AddHealthChecks,
   AddStorage,
   UpdateStrategy,
   ...Kebab.getExtensionsActionsForKind(DeploymentModel),
+  EditHealthChecks,
   ...common,
 ];
 

--- a/frontend/public/components/stateful-set.tsx
+++ b/frontend/public/components/stateful-set.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
+import { PodRingController } from '@console/shared';
+import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { K8sResourceKind } from '../module/k8s';
 import { ResourceEventStream } from './events';
 import { DetailsPage, ListPage, Table, RowFunction } from './factory';
@@ -18,13 +21,13 @@ import {
 } from './utils';
 import { VolumesTable } from './volumes-table';
 import { StatefulSetModel } from '../models';
-import PodRingSet from '@console/shared/src/components/pod/PodRingSet';
-import { PodRingController } from '@console/shared';
 
 const { AddStorage, common } = Kebab.factory;
 export const menuActions: KebabAction[] = [
+  AddHealthChecks,
   AddStorage,
   ...Kebab.getExtensionsActionsForKind(StatefulSetModel),
+  EditHealthChecks,
   ...common,
 ];
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3692

**Analysis / Root cause**: 
Action menu option is always "Edit Health Checks".

**Solution Description**: 
Action menu for D/DC/DS/SS/Kn services should be "Add Health Checks" when no probes have been added and "Edit Health Checks" when probes is present.

**Screen shots / Gifs for design review**: 
<img width="1069" alt="Screenshot 2020-04-29 at 3 09 33 AM" src="https://user-images.githubusercontent.com/2561818/80540442-f2e75c00-89c6-11ea-9967-d94bf3d3dec3.png">

<img width="798" alt="Screenshot 2020-04-29 at 2 41 18 AM" src="https://user-images.githubusercontent.com/2561818/80538758-e6adcf80-89c3-11ea-84d6-5f9fd2adb9bc.png">
<img width="865" alt="Screenshot 2020-04-29 at 2 42 27 AM" src="https://user-images.githubusercontent.com/2561818/80538796-f4635500-89c3-11ea-8eb3-8466c3921120.png">
<img width="816" alt="Screenshot 2020-04-29 at 2 42 47 AM" src="https://user-images.githubusercontent.com/2561818/80538840-034a0780-89c4-11ea-851d-ae74a1347f78.png">



**Unit test coverage report**: 
<img width="790" alt="Screenshot 2020-04-29 at 2 32 47 AM" src="https://user-images.githubusercontent.com/2561818/80538693-ca119780-89c3-11ea-86aa-ee07de16bb57.png">



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
