### PR TITLE
Bug 1828479: Move topology search query from localstorage to url param

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyPage.spec.tsx
@@ -16,6 +16,15 @@ type RenderTopologyProps = React.ComponentProps<typeof renderTopology>;
 let topologyProps: TopologyPageProps;
 let renderTopologyProps: RenderTopologyProps;
 
+jest.mock('react-redux', () => {
+  const ActualReactRedux = require.requireActual('react-redux');
+  return {
+    ...ActualReactRedux,
+    useSelector: jest.fn(),
+    useDispatch: jest.fn(),
+  };
+});
+
 describe('Topology page tests', () => {
   beforeEach(() => {
     topologyProps = {

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
@@ -6,9 +6,11 @@ import { RootState } from '@console/internal/redux';
 import { TextFilter } from '@console/internal/components/factory';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { Visualization } from '@console/topology';
+import { setQueryArgument, removeQueryArgument } from '@console/internal/components/utils';
 import { setTopologyFilters } from '../redux/action';
-import FilterDropdown from './FilterDropdown';
+import { TOPOLOGY_SEARCH_FILTER_KEY } from '../redux/const';
 import { TopologyFilters, DisplayFilters, getTopologyFilters } from './filter-utils';
+import FilterDropdown from './FilterDropdown';
 import './TopologyFilterBar.scss';
 
 type StateProps = {
@@ -98,6 +100,11 @@ const mergeProps = (
   },
   onSearchQueryChange: (searchQuery) => {
     onFiltersChange({ ...filters, searchQuery });
+    if (searchQuery.length > 0) {
+      setQueryArgument(TOPOLOGY_SEARCH_FILTER_KEY, searchQuery);
+    } else {
+      removeQueryArgument(TOPOLOGY_SEARCH_FILTER_KEY);
+    }
   },
   visualization,
 });

--- a/frontend/packages/dev-console/src/components/topology/redux/action.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/action.ts
@@ -1,13 +1,13 @@
 import { action, ActionType } from 'typesafe-actions';
 import { TopologyFilters } from '../filters/filter-utils';
-import { TOPOLOGGY_FILTERS_LOCAL_STORAGE_KEY } from './const';
+import { TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY } from './const';
 
 export enum Actions {
   topologyFilters = 'topologyFilters',
 }
 
 export const setTopologyFilters = (filters: TopologyFilters) => {
-  localStorage.setItem(TOPOLOGGY_FILTERS_LOCAL_STORAGE_KEY, JSON.stringify(filters));
+  localStorage.setItem(TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY, JSON.stringify(filters.display));
   return action(Actions.topologyFilters, { filters });
 };
 

--- a/frontend/packages/dev-console/src/components/topology/redux/const.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/const.ts
@@ -1,4 +1,5 @@
-export const TOPOLOGGY_FILTERS_LOCAL_STORAGE_KEY = `bridge/topology-filters`;
+export const TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY = `bridge/topology-display-filters`;
+export const TOPOLOGY_SEARCH_FILTER_KEY = 'searchQuery';
 export const DEFAULT_TOPOLOGY_FILTERS = {
   display: {
     podCount: false,

--- a/frontend/packages/dev-console/src/components/topology/redux/reducer.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/reducer.ts
@@ -13,19 +13,19 @@ export const getDefaultTopologyFilters = () => {
   const displayFilters = localStorage.getItem(TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY);
   const searchQuery = new URLSearchParams(window.location.search).get(TOPOLOGY_SEARCH_FILTER_KEY);
 
-  if (displayFilters && searchQuery) {
-    return merge({}, DEFAULT_TOPOLOGY_FILTERS, {
-      display: JSON.parse(displayFilters),
-      searchQuery,
-    });
+  if (!displayFilters) {
+    localStorage.setItem(
+      TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY,
+      JSON.stringify(DEFAULT_TOPOLOGY_FILTERS.display),
+    );
   }
 
-  localStorage.setItem(
-    TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY,
-    JSON.stringify(DEFAULT_TOPOLOGY_FILTERS.display),
-  );
+  const filters = merge({}, DEFAULT_TOPOLOGY_FILTERS, {
+    display: JSON.parse(displayFilters) ?? {},
+    searchQuery: searchQuery ?? '',
+  });
 
-  return DEFAULT_TOPOLOGY_FILTERS;
+  return filters;
 };
 
 export default (state: State, action: TopologyAction) => {

--- a/frontend/packages/dev-console/src/components/topology/redux/reducer.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/reducer.ts
@@ -1,19 +1,30 @@
 import { Map } from 'immutable';
 import { merge } from 'lodash';
 import { TopologyAction, Actions } from './action';
-import { TOPOLOGGY_FILTERS_LOCAL_STORAGE_KEY, DEFAULT_TOPOLOGY_FILTERS } from './const';
+import {
+  TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY,
+  DEFAULT_TOPOLOGY_FILTERS,
+  TOPOLOGY_SEARCH_FILTER_KEY,
+} from './const';
 
 export type State = Map<string, any>;
 
 export const getDefaultTopologyFilters = () => {
-  const filters = localStorage.getItem(TOPOLOGGY_FILTERS_LOCAL_STORAGE_KEY);
-  if (filters) {
-    return merge({}, DEFAULT_TOPOLOGY_FILTERS, JSON.parse(filters));
+  const displayFilters = localStorage.getItem(TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY);
+  const searchQuery = new URLSearchParams(window.location.search).get(TOPOLOGY_SEARCH_FILTER_KEY);
+
+  if (displayFilters && searchQuery) {
+    return merge({}, DEFAULT_TOPOLOGY_FILTERS, {
+      display: JSON.parse(displayFilters),
+      searchQuery,
+    });
   }
+
   localStorage.setItem(
-    TOPOLOGGY_FILTERS_LOCAL_STORAGE_KEY,
-    JSON.stringify(DEFAULT_TOPOLOGY_FILTERS),
+    TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY,
+    JSON.stringify(DEFAULT_TOPOLOGY_FILTERS.display),
   );
+
   return DEFAULT_TOPOLOGY_FILTERS;
 };
 


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3058

This PR -
- Updates the logic of saving topology filters in local storage.
- Now the topology saves only display filters in localstorage and saves search filter in the URL.
- Search filter is reset when changing the namespace.

Screencast - 

![filters](https://user-images.githubusercontent.com/6041994/80413483-29e93f00-88ed-11ea-9217-8226fb85caf3.gif)
 