### PR TITLE
Bug 1828588:  Fix bug where masthead dropdown item spacing is inconsi…

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -96,16 +96,11 @@ h6 {
   margin-top: var(--pf-global--spacer--lg);
 }
 
-// Temp fix to adjust dropdown item spacing until issue can be addressed upstream in PatternFly
-.pf-c-app-launcher {
-  &__group {
-    padding-top: 0 !important;
-  }
-  &__group-title {
-    font-family: $font-family-base;
-    padding-top: 8px !important;
-  }
+.pf-c-app-launcher__group-title {
+  // Reset font to RedHatText so it doesn't appear too bold
+  font-family: $font-family-base;
 }
+
 // Temp fix to adjust user menu dropdown toggle padding until it can be converted back to a standard dropdown
 .co-user-menu .pf-c-app-launcher__toggle {
   padding-left: 0;


### PR DESCRIPTION
…stent

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1828588

Before:
<img width="304" alt="Screen Shot 2020-04-27 at 4 57 07 PM" src="https://user-images.githubusercontent.com/895728/80420036-267f9480-88a8-11ea-8c5a-8c92284f122b.png">


After:
<img width="311" alt="Screen Shot 2020-04-27 at 4 56 27 PM" src="https://user-images.githubusercontent.com/895728/80419989-123b9780-88a8-11ea-9b61-7bc3b48c3bbc.png">
