### PR TITLE
Bug 1829648: Monitoring: Fix sort order on silence list page

### DIFF
--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -11,8 +11,12 @@ import {
   nodePods,
 } from '@console/shared';
 import * as UIActions from '../../actions/ui';
+import {
+  alertStateOrder,
+  silenceFiringAlertsOrder,
+  silenceStateOrder,
+} from '../../reducers/monitoring';
 import { ingressValidHosts } from '../ingress';
-import { alertStateOrder, silenceStateOrder } from '../../reducers/monitoring';
 import { convertToBaseValue, EmptyBox, StatusBox, WithScrollContainer } from '../utils';
 import {
   getClusterOperatorStatus,
@@ -123,6 +127,7 @@ const sorts = {
   pvStorage: (pv) => _.toInteger(convertToBaseValue(pv?.spec?.capacity?.storage)),
   pvcStorage: (pvc) => _.toInteger(convertToBaseValue(pvc?.status?.capacity?.storage)),
   serviceClassDisplayName,
+  silenceFiringAlertsOrder,
   silenceStateOrder,
   string: (val) => JSON.stringify(val),
   number: (val) => _.toNumber(val),

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -362,7 +362,7 @@ const silenceTableHeader = () => [
   },
   {
     title: 'Firing Alerts',
-    sortField: 'firingAlerts.length',
+    sortFunc: 'silenceFiringAlertsOrder',
     transforms: [sortable],
     props: { className: tableSilenceClasses[1] },
   },

--- a/frontend/public/reducers/monitoring.ts
+++ b/frontend/public/reducers/monitoring.ts
@@ -75,6 +75,15 @@ export const alertStateOrder = (alert) => [
     : _.get(alert, 'activeAt'),
 ];
 
+export const silenceFiringAlertsOrder = (silence) => {
+  const severityCounts = _.countBy(silence.firingAlerts, 'labels.severity');
+  return [
+    severityCounts[AlertSeverity.Critical],
+    severityCounts[AlertSeverity.Warning],
+    silence.firingAlerts.length,
+  ];
+};
+
 export const silenceStateOrder = (silence) => [
   [SilenceStates.Active, SilenceStates.Pending, SilenceStates.Expired].indexOf(
     silenceState(silence),


### PR DESCRIPTION
Now that we display a count for each severity type, the sort order for
the column should reflect that.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/460802/80442468-ebcd3900-8947-11ea-9c55-4a749668aa0d.png) | ![after](https://user-images.githubusercontent.com/460802/80442477-f091ed00-8947-11ea-8100-64ca8a5dab85.png) |
