### PR TITLE
Bug 1828791: Fix pipeline bar unnecessary animations

### DIFF
--- a/frontend/packages/dev-console/src/components/charts/HorizontalStackedBars.tsx
+++ b/frontend/packages/dev-console/src/components/charts/HorizontalStackedBars.tsx
@@ -10,7 +10,6 @@ export type StackedValue = {
 
 export type HorizontalStackedBarsProps = {
   barGap?: number;
-  disableAnimation?: boolean;
   height?: number | string;
   inline?: boolean;
   values: StackedValue[];
@@ -19,7 +18,6 @@ export type HorizontalStackedBarsProps = {
 
 const HorizontalStackedBars: React.FC<HorizontalStackedBarsProps> = ({
   barGap,
-  disableAnimation,
   height,
   inline,
   values,
@@ -38,7 +36,6 @@ const HorizontalStackedBars: React.FC<HorizontalStackedBarsProps> = ({
             style={{
               background: color,
               flexGrow: size,
-              transition: disableAnimation ? 'initial' : undefined,
             }}
           />
         ))}

--- a/frontend/packages/dev-console/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/status/LinkedPipelineRunTaskStatus.tsx
@@ -18,14 +18,15 @@ const LinkedPipelineRunTaskStatus: React.FC<LinkedPipelineRunTaskStatusProps> = 
   pipeline,
   pipelineRun,
 }) => {
-  const pipelineStatus = <PipelineTaskStatus pipeline={pipeline} pipelinerun={pipelineRun} />;
+  const pipelineStatus = (
+    <PipelineTaskStatus
+      key={pipelineRun.metadata?.name}
+      pipeline={pipeline}
+      pipelinerun={pipelineRun}
+    />
+  );
 
-  if (
-    pipelineRun &&
-    pipelineRun.metadata &&
-    pipelineRun.metadata.name &&
-    pipelineRun.metadata.namespace
-  ) {
+  if (pipelineRun.metadata?.name && pipelineRun.metadata?.namespace) {
     return (
       <Link
         to={`${resourcePathFromModel(

--- a/frontend/packages/dev-console/src/components/pipelineruns/status/PipelineBars.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/status/PipelineBars.tsx
@@ -16,20 +16,11 @@ export interface PipelineBarProps {
 }
 
 export const PipelineBars: React.FC<PipelineBarProps> = ({ pipelinerun, pipeline }) => {
-  const pipelineIdentifier =
-    pipelinerun.metadata && pipelinerun.metadata.name ? pipelinerun.metadata.name : undefined;
-  const data = pipeline && pipeline.data ? pipeline.data : undefined;
-  const taskStatus = getTaskStatus(pipelinerun, data);
+  const taskStatus = getTaskStatus(pipelinerun, pipeline?.data);
 
-  // Tooltip key is necessary to disable the animations between two different Pipeline runs that
-  // have different names. Typically this should be able to go on HorizontalStackedBars but there
-  // is an issue with Tooltip and losing its mounted child node that breaks the popup.
   return (
-    <Tooltip key={pipelineIdentifier} content={<TaskStatusToolTip taskStatus={taskStatus} />}>
+    <Tooltip content={<TaskStatusToolTip taskStatus={taskStatus} />}>
       <HorizontalStackedBars
-        // Note: disableAnimation is used here to prevent a no-key situation where React will try to
-        // reuse elements and inadvertently cause animations BETWEEN different pipeline status'
-        disableAnimation={!pipelineIdentifier}
         height="1em"
         inline
         values={Object.keys(runStatus).map((status) => ({

--- a/frontend/packages/dev-console/src/components/pipelineruns/status/PipelineTaskStatus.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/status/PipelineTaskStatus.tsx
@@ -14,13 +14,7 @@ export const PipelineTaskStatus: React.FC<PipelineTaskStatusProps> = ({
   pipelinerun,
   pipeline,
 }) => {
-  return !pipeline &&
-    pipelinerun &&
-    pipelinerun.spec &&
-    pipelinerun.spec.pipelineRef &&
-    pipelinerun.spec.pipelineRef.name &&
-    pipelinerun.metadata &&
-    pipelinerun.metadata.namespace ? (
+  return !pipeline && pipelinerun.spec?.pipelineRef?.name && pipelinerun.metadata?.namespace ? (
     <Firehose
       resources={[
         {


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-2564

- This PR adds a key to the `PipelineTaskStatus` component to stop it from reanimating when data changes from firehose or when the list is sorted. 

Screencast - 
![Peek 2020-04-28 16-53](https://user-images.githubusercontent.com/6041994/80481768-bab52e80-8970-11ea-9d7b-9cd3ca35f582.gif)
