### PR TITLE
Bug 1828784: fix(prun): rerun cancelled run

### DIFF
--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -89,6 +89,7 @@ export const getPipelineRunData = (
       },
       resources,
       ...(params && { params }),
+      status: null,
     },
   };
 


### PR DESCRIPTION

## Fixes:
Addresses https://issues.redhat.com/browse/ODC-3526
https://bugzilla.redhat.com/show_bug.cgi?id=1828784

## Analysis / Root cause:
Rerunning cancelled pipelinerun doesn't work

## Solution Description:
Added status field as null which was added as PipelineRunCancelled...hence it never started
## Screenshot
![Screencast from 04-24-2020 05_02_28 PM](https://user-images.githubusercontent.com/24852534/80212301-d957b480-8654-11ea-88c5-62876d8f6ca9.gif)


## Browser conformation
Chrome 73