### PR TITLE
Bug 1828844: Fix for node/group background issue in firefox

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyDataController.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { match as RMatch } from 'react-router';
 import { Firehose } from '@console/internal/components/utils';
 import * as plugins from '@console/internal/plugins';
 import { getResourceList } from '@console/shared';
@@ -38,7 +39,9 @@ export interface ControllerProps {
 }
 
 export interface TopologyDataControllerProps extends StateProps {
-  namespace: string;
+  match: RMatch<{
+    name?: string;
+  }>;
   render(RenderProps): React.ReactElement;
 }
 
@@ -111,11 +114,12 @@ const Controller: React.FC<ControllerProps> = ({
 };
 
 export const TopologyDataController: React.FC<TopologyDataControllerProps> = ({
-  namespace,
+  match,
   render,
   resourceList,
   serviceBinding,
 }) => {
+  const namespace = match.params.name;
   const { resources, utils } = getResourceList(namespace, resourceList);
   if (serviceBinding) {
     resources.push({

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.scss
@@ -1,11 +1,10 @@
 .odc-topology {
-  display: flex;
-  flex-direction: column;
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
+  display: grid;
+  height: 100%;
+
+  .pf-topology-container__with-sidebar .pf-topology-content {
+    position: relative;
+  }
 
   &__hint-container {
     align-items: center;

--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -141,7 +141,7 @@ export const TopologyPage: React.FC<TopologyPageProps> = ({ match }) => {
                   }
                 />
               ) : (
-                <ConnectedTopologyDataController namespace={namespace} render={renderTopology} />
+                <ConnectedTopologyDataController match={match} render={renderTopology} />
               )
             ) : (
               <ProjectListPage title="Topology">

--- a/frontend/packages/dev-console/src/components/topology/__tests__/TopologyDataController.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/__tests__/TopologyDataController.spec.tsx
@@ -3,6 +3,7 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import { TopologyDataControllerProps, TopologyDataController } from '../TopologyDataController';
 
 const TestInner = () => null;
+const testProjectMatch = { url: '', params: { name: 'namespace' }, isExact: true, path: '' };
 
 describe('TopologyDataController', () => {
   let wrapper: ShallowWrapper<TopologyDataControllerProps>;
@@ -11,7 +12,7 @@ describe('TopologyDataController', () => {
     wrapper = shallow(
       <TopologyDataController
         resourceList={[]}
-        namespace="namespace"
+        match={testProjectMatch}
         serviceBinding={false}
         render={() => <TestInner />}
       />,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3041

**Analysis / Root cause**: 
absolute positioning and not updating when the page selection changes caused the nodes not to redraw correctly.

**Solution Description**: 
Remove absolute positioning, update the page on selection change.

/kind bug
