### PR TITLE
Bug 1827404: Enable content-scrollable to scroll correctly on Firefox

### DIFF
--- a/frontend/public/style/_overrides.scss
+++ b/frontend/public/style/_overrides.scss
@@ -236,6 +236,7 @@ h6 {
   }
 
   .pf-c-page__main-section {
+    overflow: hidden; // needed for Firefox to enable proper scrolling of content-scrollable
     --pf-c-page__main-section--PaddingBottom: 0;
     --pf-c-page__main-section--PaddingLeft: 0;
     --pf-c-page__main-section--PaddingRight: 0;


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1827404

cc @benjaminapetersen 

**Before**
![Screen Shot 2020-04-28 at 14 49 01-fullpage](https://user-images.githubusercontent.com/1874151/80528212-930b9980-8963-11ea-9c62-9806dcce09f4.png)

![Screen Shot 2020-04-28 at 14 51 55-fullpage](https://user-images.githubusercontent.com/1874151/80528202-90a93f80-8963-11ea-8381-e4967776a610.png)

---

**After**

![Screen Shot 2020-04-28 at 14 58 02-fullpage](https://user-images.githubusercontent.com/1874151/80528236-9c950180-8963-11ea-849b-72e301cba935.png)
![Screen Shot 2020-04-28 at 14 57 46-fullpage](https://user-images.githubusercontent.com/1874151/80528238-9d2d9800-8963-11ea-84f0-08fd32617b14.png)
