### PR TITLE
Bug 1828928: Fix fieldDependency spec descriptor for create operand form

### DIFF
--- a/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/fields.tsx
@@ -52,19 +52,10 @@ const FieldWrapper: React.FC<FieldProps> = ({
   );
 };
 
-export const ResourceRequirementsField: React.FC<FieldProps> = ({
-  formData,
-  idSchema,
-  name,
-  onChange,
-  required,
-  schema,
-  uiSchema,
-}) => {
-  const options = getUiOptions(uiSchema);
-  const title = (options?.title || schema?.title || name) as string;
+export const ResourceRequirementsField: React.FC<FieldProps> = (props) => {
+  const { formData, idSchema, onChange } = props;
   return (
-    <FieldSet title={title} idSchema={idSchema} required={required}>
+    <FieldSet {...props}>
       <dl id={idSchema.$id} style={{ marginLeft: '15px' }}>
         <dt>Limits</dt>
         <dd>
@@ -121,15 +112,10 @@ export const UpdateStrategyField: React.FC<FieldProps> = (props) => {
   );
 };
 
-export const NodeAffinityField: React.FC<FieldProps> = ({
-  formData,
-  idSchema,
-  name,
-  onChange,
-  required,
-}) => {
+export const NodeAffinityField: React.FC<FieldProps> = (props) => {
+  const { formData, idSchema, onChange } = props;
   return (
-    <FieldSet title={name} idSchema={idSchema} required={required}>
+    <FieldSet {...props}>
       <NodeAffinity
         affinity={formData}
         onChange={(affinity) => onChange(affinity)}
@@ -139,22 +125,10 @@ export const NodeAffinityField: React.FC<FieldProps> = ({
   );
 };
 
-export const PodAffinityField: React.FC<FieldProps> = ({
-  formData,
-  idSchema,
-  name,
-  onChange,
-  required,
-  schema,
-  uiSchema,
-}) => {
-  const options = getUiOptions(uiSchema);
+export const PodAffinityField: React.FC<FieldProps> = (props) => {
+  const { formData, idSchema, onChange } = props;
   return (
-    <FieldSet
-      title={(options?.title as string) || schema?.title || name}
-      idSchema={idSchema}
-      required={required}
-    >
+    <FieldSet {...props}>
       <PodAffinity
         affinity={formData}
         onChange={(affinity) => onChange(affinity)}
@@ -205,25 +179,15 @@ export const LabelsField: React.FC<FieldProps> = (props) => {
   );
 };
 
-export const SelectField: React.FC<FieldProps> = ({
+export const DropdownField: React.FC<FieldProps> = ({
   formData,
   idSchema,
   name,
   onChange,
   schema,
-  uiSchema,
+  uiSchema = {},
 }) => {
-  const { enumOptions = [], title } = getUiOptions(uiSchema);
-  const items = _.reduce(
-    enumOptions as OptionsList,
-    (itemAccumulator, option) => {
-      return {
-        ...itemAccumulator,
-        [option.label]: option.value,
-      };
-    },
-    {},
-  );
+  const { items = {}, title } = getUiOptions(uiSchema);
   return (
     <Dropdown
       id={idSchema.$id}
@@ -237,25 +201,23 @@ export const SelectField: React.FC<FieldProps> = ({
 };
 
 export const CustomSchemaField: React.FC<SchemaFieldProps> = (props) => {
-  const errors = getSchemaErrors(props.schema);
+  const errors = getSchemaErrors(props.schema ?? {});
   if (errors.length) {
     // eslint-disable-next-line no-console
     console.warn('DynamicForm component does not support the provided JSON schema: ', errors);
+    return null;
   }
-  return errors.length ? null : <SchemaField {...props} />;
+
+  return <SchemaField {...props} />;
 };
 
 export const HiddenField = () => null;
 export const NullField = () => null;
 
-type OptionsList = {
-  label: string;
-  value: string;
-}[];
-
 export default {
   BooleanField,
   DescriptionField,
+  DropdownField,
   HiddenField,
   LabelsField,
   MatchExpressionsField,
@@ -264,6 +226,5 @@ export default {
   PodAffinityField,
   ResourceRequirementsField,
   SchemaField: CustomSchemaField,
-  SelectField,
   UpdateStrategyField,
 };

--- a/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/index.tsx
@@ -63,7 +63,7 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
           ArrayFieldTemplate={ArrayFieldTemplate}
           fields={{ ...defaultFields, ...fields }}
           FieldTemplate={FieldTemplate}
-          formContext={formContext}
+          formContext={{ ...formContext, formData }}
           formData={formData}
           noHtml5Validate
           ObjectFieldTemplate={ObjectFieldTemplate}

--- a/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
+++ b/frontend/packages/console-shared/src/components/dynamic-form/widgets.tsx
@@ -2,56 +2,19 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { Checkbox } from '@patternfly/react-core';
 import { WidgetProps } from 'react-jsonschema-form';
-import { NumberSpinner, ListDropdown } from '@console/internal/components/utils';
+import { NumberSpinner, ListDropdown, Dropdown } from '@console/internal/components/utils';
 import { K8sKind, GroupVersionKind, ImagePullPolicy } from '@console/internal/module/k8s';
 import { RadioGroup } from '@console/internal/components/radio';
 
-export const BaseInput: React.FC<WidgetProps> = ({
-  disabled = false,
-  formContext,
-  id,
-  label,
-  onBlur,
-  onChange,
-  onFocus,
-  options,
-  readonly = false,
-  required = false,
-  schema,
-  value = '',
-  ...inputProps
-}) => {
-  return (
-    <input
-      className="pf-c-form-control"
-      disabled={disabled}
-      id={id}
-      key={id}
-      onBlur={onBlur && ((event) => onBlur(id, event.target.value))}
-      onChange={({ currentTarget }) => onChange(currentTarget.value)}
-      onFocus={onFocus && ((event) => onFocus(id, event.target.value))}
-      readOnly={readonly}
-      required={required}
-      type={(options.inputType as string) || 'text'}
-      value={value}
-      {...inputProps}
-    />
-  );
-};
-
 export const TextWidget: React.FC<WidgetProps> = ({
   disabled = false,
-  formContext,
   id,
-  label,
   onBlur,
   onChange,
   onFocus,
-  options,
   readonly = false,
   required = false,
   value = '',
-  ...inputProps
 }) => {
   return (
     <input
@@ -66,12 +29,12 @@ export const TextWidget: React.FC<WidgetProps> = ({
       required={required}
       type="text"
       value={value}
-      {...inputProps}
     />
   );
 };
 
 export const NumberWidget: React.FC<WidgetProps> = ({ value, id, onChange }) => {
+  const numberValue = _.toNumber(value);
   return (
     <input
       className="pf-c-form-control"
@@ -81,7 +44,7 @@ export const NumberWidget: React.FC<WidgetProps> = ({ value, id, onChange }) => 
         onChange(currentTarget.value !== '' ? _.toNumber(currentTarget.value) : '')
       }
       type="number"
-      value={value !== '' ? _.toNumber(value) : ''}
+      value={_.isFinite(numberValue) ? numberValue : ''}
     />
   );
 };
@@ -177,6 +140,42 @@ export const ImagePullPolicyWidget: React.FC<WidgetProps> = ({ id, value, onChan
   );
 };
 
+export const SelectWidget: React.FC<WidgetProps> = ({
+  id,
+  label,
+  onChange,
+  options,
+  schema,
+  value,
+}) => {
+  const { enumOptions = [], title } = options;
+  const items = _.reduce(
+    enumOptions as OptionsList,
+    (itemAccumulator, option) => {
+      return {
+        ...itemAccumulator,
+        [option.label]: option.value,
+      };
+    },
+    {},
+  );
+  return (
+    <Dropdown
+      id={id}
+      key={id}
+      title={`Select ${title || schema?.title || label}`}
+      selectedKey={value}
+      items={items}
+      onChange={(val) => onChange(val)}
+    />
+  );
+};
+
+type OptionsList = {
+  label: string;
+  value: string;
+}[];
+
 type K8sResourceWidgetProps = WidgetProps & {
   options: {
     model: K8sKind;
@@ -185,13 +184,14 @@ type K8sResourceWidgetProps = WidgetProps & {
 };
 
 export default {
-  BaseInput,
+  BaseInput: TextWidget,
   CheckboxWidget,
   ImagePullPolicyWidget,
   K8sResourceWidget,
   NumberWidget,
   PasswordWidget,
   PodCountWidget,
+  SelectWidget,
   TextWidget,
   int32: NumberWidget,
   int64: NumberWidget,

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/mocks.tsx
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/mocks.tsx
@@ -111,6 +111,7 @@ export const testCRD = {
               },
               select: {
                 type: 'string',
+                title: 'Select',
                 enum: ['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'],
               },
               fieldGroup: {
@@ -130,9 +131,11 @@ export const testCRD = {
                   type: 'object',
                   properties: {
                     itemOne: {
+                      title: 'Item One',
                       type: 'string',
                     },
                     itemTwo: {
+                      title: 'Item Two',
                       type: 'integer',
                     },
                   },
@@ -173,6 +176,7 @@ export const testCR = {
         itemTwo: 2,
       },
     ],
+    select: 'WARN',
     ...Object.keys(SpecCapability)
       .filter((c) => !prefixedCapabilities.has(SpecCapability[c]))
       .reduce(
@@ -180,7 +184,7 @@ export const testCR = {
           ...acc,
           [cur]: defaultValueFor(SpecCapability[cur]),
         }),
-        { select: 'WARN' },
+        {},
       ),
   },
   status: {

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/scenarios/descriptors.scenario.ts
@@ -23,6 +23,7 @@ import {
   HIDDEN_FIELD_ID,
   LABELS_FIELD_ID,
   NAME_FIELD_ID,
+  SELECT_FIELD_ID,
 } from '../views/descriptors.view';
 
 describe('Using OLM descriptor components', () => {
@@ -129,6 +130,15 @@ describe('Using OLM descriptor components', () => {
     });
   });
 
+  it('pre-populates Select field', async () => {
+    const field = getOperandFormField(SELECT_FIELD_ID);
+    await field.element.isPresent();
+    expect(field.label.getText()).toEqual('Select');
+    expect(field.element.$('.pf-c-dropdown__toggle-text').getText()).toEqual(
+      testCR?.spec?.select.toString(),
+    );
+  });
+
   it('pre-populates Labels field', async () => {
     const field = getOperandFormField(LABELS_FIELD_ID);
     await field.element.isPresent();
@@ -146,9 +156,9 @@ describe('Using OLM descriptor components', () => {
     expect(fieldGroup.label.getText()).toEqual('Field Group');
     await fieldGroup.toggleButton.click();
     await browser.wait(until.and(until.presenceOf(item1.element), until.presenceOf(item2.element)));
-    expect(item1.label.getText()).toEqual('Item One');
+    expect(item1.label.getText()).toEqual('itemOne');
     expect(item1.input.getAttribute('value')).toEqual(testCR.spec.fieldGroup.itemOne);
-    expect(item2.label.getText()).toEqual('Item Two');
+    expect(item2.label.getText()).toEqual('itemTwo');
     expect(item2.input.getAttribute('value')).toEqual(testCR.spec.fieldGroup.itemTwo.toString());
   });
 

--- a/frontend/packages/operator-lifecycle-manager/integration-tests/views/descriptors.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests/views/descriptors.view.ts
@@ -22,11 +22,6 @@ export const atomicFields = [
     id: PASSWORD_FIELD_ID,
   },
   {
-    label: 'Select',
-    path: 'spec.select',
-    id: SELECT_FIELD_ID,
-  },
-  {
     label: 'Number',
     path: 'spec.number',
     id: NUMBER_FIELD_ID,

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/spec-descriptor-input.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/spec-descriptor-input.tsx
@@ -15,6 +15,7 @@ import {
   PasswordWidget,
   TextWidget,
   PodCountWidget,
+  SelectWidget,
 } from '@console/shared/src/components/dynamic-form/widgets';
 
 export const capabilityFieldMap = Immutable.Map({
@@ -34,4 +35,5 @@ export const capabilityWidgetMap = Immutable.Map({
   [SpecCapability.password]: PasswordWidget,
   [SpecCapability.podCount]: PodCountWidget,
   [SpecCapability.text]: TextWidget,
+  [SpecCapability.select]: SelectWidget,
 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/const.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/const.ts
@@ -33,13 +33,23 @@ export const DEFAULT_K8S_SCHEMA: JSONSchema6 = {
   },
 };
 
-export const K8S_RESOURCE_CAPABILITY_PATTERN = _.escapeRegExp(SpecCapability.k8sResourcePrefix);
-export const K8S_RESOURCE_SUFFIX_MATCH_PATTERN = new RegExp(
-  `^${K8S_RESOURCE_CAPABILITY_PATTERN}(?:core~v1~)?(.*)$`,
+export const REGEXP_K8S_RESOURCE_CAPABILITY = _.escapeRegExp(SpecCapability.k8sResourcePrefix);
+export const REGEXP_FIELD_DEPENDENCY_CAPABILITY = _.escapeRegExp(SpecCapability.fieldDependency);
+export const REGEXP_SELECT_CAPABILITY = _.escapeRegExp(SpecCapability.select);
+
+export const REGEXP_K8S_RESOURCE_SUFFIX = new RegExp(
+  `^${REGEXP_K8S_RESOURCE_CAPABILITY}(?:core~v1~)?(.*)$`,
 );
-export const SELECT_CAPABILITY_PATTERN = _.escapeRegExp(SpecCapability.select);
-export const SELECT_OPTION_MATCH_PATTERN = new RegExp(`${SELECT_CAPABILITY_PATTERN}(.*)$`);
+export const REGEXP_SELECT_OPTION = new RegExp(`${REGEXP_SELECT_CAPABILITY}(.*)$`);
+export const REGEXP_FIELD_DEPENDENCY_PATH_VALUE = new RegExp(
+  `^${REGEXP_FIELD_DEPENDENCY_CAPABILITY}([^:]*):(.*)$`,
+);
 export const HIDDEN_UI_SCHEMA = {
   'ui:widget': 'hidden',
   'ui:options': { label: false },
 };
+
+const SORT_WEIGHT_BASE = 10;
+export const SORT_WEIGHT_SCALE_1 = SORT_WEIGHT_BASE ** 1;
+export const SORT_WEIGHT_SCALE_2 = SORT_WEIGHT_BASE ** 2;
+export const SORT_WEIGHT_SCALE_3 = SORT_WEIGHT_BASE ** 3;

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
@@ -43,10 +43,10 @@ describe('getJSONSchemaOrder', () => {
       'number',
       'fieldGroup',
       'arrayFieldGroup',
-      '*',
+      'hiddenFieldGroup',
     ]);
-    expect(uiOrder.fieldGroup['ui:order']).toEqual(['itemTwo', '*']);
-    expect(uiOrder.arrayFieldGroup.items['ui:order']).toEqual(['itemTwo', '*']);
+    expect(uiOrder.fieldGroup['ui:order']).toEqual(['itemTwo', 'itemOne']);
+    expect(uiOrder.arrayFieldGroup.items['ui:order']).toEqual(['itemTwo', 'itemOne']);
   });
 });
 
@@ -67,14 +67,14 @@ describe('capabilitiesToUISchema', () => {
       `${SpecCapability.select}ERROR`,
       `${SpecCapability.select}FATAL`,
     ] as SpecCapability[]);
-    expect(uiSchema['ui:options'].enumOptions).toEqual([
-      { label: 'DEBUG', value: 'DEBUG' },
-      { label: 'INFO', value: 'INFO' },
-      { label: 'WARN', value: 'WARN' },
-      { label: 'ERROR', value: 'ERROR' },
-      { label: 'FATAL', value: 'FATAL' },
-    ]);
-    expect(uiSchema['ui:field']).toEqual('SelectField');
+    expect(uiSchema['ui:items']).toEqual({
+      DEBUG: 'DEBUG',
+      INFO: 'INFO',
+      WARN: 'WARN',
+      ERROR: 'ERROR',
+      FATAL: 'FATAL',
+    });
+    expect(uiSchema['ui:field']).toEqual('DropdownField');
   });
 });
 


### PR DESCRIPTION
- Fix fieldDependency regression
- Fix minor issue where descriptor displayName was not taking precedence over schema title in some cases.
- Fix NodeAffinity, PodAffinity, and ResourceRequirement FieldSet wrapper props to be consistent with other custom fields.
- Fall back to schema property key without title case as form field label. Using title case was causing strange behavior for some properties that use acronyms or abbreviations. (e.g. k8sResource -> K 8 S Resource).
- Remove extraneous BaseInput component as it was a duplicate of the TextInput field. Just export the TextInput field as BaseInput in the default export instead.
- Fix console errors related to the props being forwarded to the html input element in the text input field. These were not causing any unexpected behavior, but were causing a lot of console output.
- Fix SelectWidget and SelectField components which were not receiving expected properties from uiSchema.