### PR TITLE
Bug 1829549: fix resizing issues with cloud shell terminal drawer

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellDrawer.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellDrawer.tsx
@@ -18,14 +18,12 @@ const getMastheadHeight = (): number => {
 };
 
 const CloudShellDrawer: React.FC<CloudShellDrawerProps> = ({ children, onClose }) => {
-  const [height, setHeight] = React.useState(365);
   const [expanded, setExpanded] = React.useState<boolean>(true);
   const onMRButtonClick = (expandedState: boolean) => {
     setExpanded(!expandedState);
   };
-  const handleChange = (openState: boolean, resizeHeight: number) => {
+  const handleChange = (openState: boolean) => {
     setExpanded(openState);
-    setHeight(resizeHeight);
   };
   const header = (
     <Flex style={{ flexGrow: 1 }}>
@@ -65,7 +63,7 @@ const CloudShellDrawer: React.FC<CloudShellDrawerProps> = ({ children, onClose }
   return (
     <Drawer
       open={expanded}
-      height={height}
+      defaultHeight={365}
       header={header}
       maxHeight={`calc(100vh - ${getMastheadHeight()}px)`}
       onChange={handleChange}

--- a/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminalFrame.scss
+++ b/frontend/packages/console-app/src/components/cloud-shell/CloudShellTerminalFrame.scss
@@ -5,6 +5,7 @@
   height: 100%;
   color: var(--pf-global--Color--light-100);
   overflow: hidden;
+  position: absolute;
 
   & > iframe {
     height: 100%;

--- a/frontend/packages/console-shared/src/components/drawer/DraggableCoreIFrameFix.scss
+++ b/frontend/packages/console-shared/src/components/drawer/DraggableCoreIFrameFix.scss
@@ -1,0 +1,5 @@
+.ocs-draggable-core-iframe-fix {
+  & iframe {
+    pointer-events: none !important;
+  }
+}

--- a/frontend/packages/console-shared/src/components/drawer/DraggableCoreIFrameFix.tsx
+++ b/frontend/packages/console-shared/src/components/drawer/DraggableCoreIFrameFix.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { DraggableCore, DraggableEvent, DraggableData } from 'react-draggable';
+
+import './DraggableCoreIFrameFix.scss';
+
+const DraggableCoreIFrameFix: React.FC<React.ComponentProps<typeof DraggableCore>> = ({
+  onStart,
+  onStop,
+  ...other
+}) => {
+  const onStartFn =
+    // rule is inconsistent with typescript return type
+    // eslint-disable-next-line consistent-return
+    (e: DraggableEvent, data: DraggableData): false | void => {
+      document.body.classList.add('ocs-draggable-core-iframe-fix');
+      if (onStart) {
+        return onStart(e, data);
+      }
+    };
+
+  const onStopFn =
+    // rule is inconsistent with typescript return type
+    // eslint-disable-next-line consistent-return
+    (e: DraggableEvent, data: DraggableData): false | void => {
+      document.body.classList.remove('ocs-draggable-core-iframe-fix');
+      if (onStop) {
+        return onStop(e, data);
+      }
+    };
+
+  return <DraggableCore {...other} onStart={onStartFn} onStop={onStopFn} />;
+};
+
+export default DraggableCoreIFrameFix;

--- a/frontend/packages/console-shared/src/components/drawer/__tests__/DraggableCoreIFrameFix.spec.tsx
+++ b/frontend/packages/console-shared/src/components/drawer/__tests__/DraggableCoreIFrameFix.spec.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import DraggableCoreIFrameFix from '../DraggableCoreIFrameFix';
+import { DraggableCore, DraggableEvent, DraggableData } from 'react-draggable';
+
+describe('DraggableCoreIFrameFix', () => {
+  it('should execute handlers and apply fix class', () => {
+    const onStart = jest.fn();
+    const onStop = jest.fn();
+    const event = {} as DraggableEvent;
+    const data = {} as DraggableData;
+    const wrapper = shallow(<DraggableCoreIFrameFix onStart={onStart} onStop={onStop} />);
+
+    wrapper
+      .find(DraggableCore)
+      .props()
+      .onStart(event, data);
+    expect(document.body.className).toBe('ocs-draggable-core-iframe-fix');
+
+    wrapper
+      .find(DraggableCore)
+      .props()
+      .onStop(event, data);
+    expect(document.body.className).toBe('');
+
+    expect(onStart).toHaveBeenCalledWith(event, data);
+    expect(onStop).toHaveBeenCalledWith(event, data);
+  });
+});


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3702

**Analysis / Root cause**: 
There are two issues with the current drawer:

1. dragging over a mouse over an iframe swallows mouse events
2. when dragging the window larger than the maximum height, the height was incorrectly calculated

**Solution Description**: 
1. use event `pageY` to compute height of drawer relative to mouse because react-draggable data isn't compatible with our use case when dragging the drawer beyond its bounds
2. Implemented a fix for react-draggable which will apply `pointer-events: none` to all iframes on the page.

**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/14068621/80540112-b2f88880-8976-11ea-815f-aa4a5d9888a2.png)
![image](https://user-images.githubusercontent.com/14068621/80540159-c60b5880-8976-11ea-9815-df54a4ee51b0.png)

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
Install https://github.com/che-incubator/che-workspace-operator to enable the cloud shell terminal.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [x] Safari
- [x] Edge