### PR TITLE
Bug 1828591: Fix heading issues in console and cleanup CSS for filters

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -41,7 +41,6 @@ import {
   Kebab,
   MsgBox,
   navFactory,
-  PageHeading,
   ResourceKebab,
   ResourceLink,
   Timestamp,
@@ -643,7 +642,6 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
       <Helmet>
         <title>{title}</title>
       </Helmet>
-      <PageHeading title={title} />
       <MultiListPage
         {...props}
         resources={[
@@ -663,11 +661,11 @@ export const ClusterServiceVersionsPage: React.FC<ClusterServiceVersionsPageProp
             optional: true,
           },
         ]}
+        title={title}
         flatten={flatten}
         namespace={props.namespace}
         ListComponent={ClusterServiceVersionList}
         helpText={helpText}
-        showTitle={false}
       />
     </>
   );

--- a/frontend/public/components/_nav-title.scss
+++ b/frontend/public/components/_nav-title.scss
@@ -31,6 +31,7 @@
     @media (min-width: $screen-sm) {
       display: flex;
       flex-direction: row;
+      justify-content: space-between;
     }
   }
   &--detail {

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -270,28 +270,22 @@ export const FireMan_ = connect(null, { filterList })(
 
       return (
         <>
-          <PageHeading title={title} badge={badge} className="co-m-nav-title--row">
-            <div
-              className={classNames(
-                { 'co-m-pane__filter-bar--inline': (createLink || helpText) && title },
-                { 'co-m-pane__filter-bar--no-title': !title },
-                { 'co-m-pane__filter-bar': !createLink || helpText },
-                {
-                  'co-m-pane__filter-bar--with-help-text': helpText && !createLink,
-                },
-              )}
-            >
-              {createLink && (
-                <div className="co-m-pane__filter-bar-group co-m-pane__createLink">
-                  {createLink}
-                </div>
-              )}
-              {!title && badge && (
-                <div className="co-m-pane__filter-bar-group co-m-pane__filter-bar-group--badge">
-                  {badge}
-                </div>
-              )}
-            </div>
+          {/* Badge rendered from PageHeading only when title is present */}
+          <PageHeading
+            title={title}
+            badge={title ? badge : null}
+            className={classNames({ 'co-m-nav-title--row': createLink })}
+          >
+            {createLink && (
+              <div
+                className={classNames('co-m-pane__createLink', {
+                  'co-m-pane__createLink--no-title': !title,
+                })}
+              >
+                {createLink}
+              </div>
+            )}
+            {!title && badge && <div>{badge}</div>}
           </PageHeading>
           {helpText && <p className="co-m-pane__help-text co-help-text">{helpText}</p>}
           <div className="co-m-pane__body co-m-pane__body--no-top-margin">

--- a/frontend/public/style/_common.scss
+++ b/frontend/public/style/_common.scss
@@ -20,10 +20,28 @@ $co-external-link-padding-right: 15px;
   }
 }
 
+.co-m-pane__createLink--no-title {
+  margin-bottom: $grid-gutter-width;
+}
+
+.co-m-pane__filter-bar,
+.co-m-pane__help-text {
+  margin: 20px ($grid-gutter-width / 2);
+  @media (min-width: $grid-float-breakpoint) {
+    margin-left: $grid-gutter-width;
+    margin-right: $grid-gutter-width;
+    margin-top: $grid-gutter-width;
+  }
+}
+
 .co-m-pane__filter-bar {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+  &--alt {
+    margin-left: 0;
+    margin-right: 0;
+  }
   &--with-help-text {
     align-items: baseline;
     flex-wrap: nowrap;
@@ -39,26 +57,6 @@ $co-external-link-padding-right: 15px;
   .btn-group {
     margin-right: 10px;
     min-width: 0; // enables truncation of selected item, if needed
-  }
-  &--inline {
-    margin-left: auto;
-  }
-  &--no-title {
-    margin-bottom: 30px;
-  }
-}
-
-.co-m-pane__filter-bar,
-.co-m-pane__help-text {
-  margin: 20px ($grid-gutter-width / 2);
-  @media (min-width: $grid-float-breakpoint) {
-    margin-left: $grid-gutter-width;
-    margin-right: $grid-gutter-width;
-    margin-top: $grid-gutter-width;
-    &--alt {
-      margin-left: 0;
-      margin-right: 0;
-    }
   }
 }
 
@@ -80,10 +78,6 @@ $co-external-link-padding-right: 15px;
     flex: 1 0 auto;
     justify-content: flex-end;
   }
-}
-
-.co-m-pane__filter-bar-group--full-width {
-  flex-basis: 100%;
 }
 
 .co-m-pane__filter-bar-group--help-text {
@@ -113,7 +107,9 @@ $co-external-link-padding-right: 15px;
 
 .co-m-pane__heading-badge {
   line-height: 0;
-  margin-left: var(--pf-global--spacer--sm);
+  @media (min-width: $screen-sm-min) {
+    margin-left: var(--pf-global--spacer--sm);
+  }
 }
 
 .co-m-pane__heading-link {


### PR DESCRIPTION
Before: 
![80419159-98ef7500-88a6-11ea-838b-685bd04ad353](https://user-images.githubusercontent.com/54092533/80590539-b0129c00-8a39-11ea-8eab-65115ed4fea4.png)
![Screenshot_2020-04-27 Installed Operators Â· Red Hat OpenShift Container Platform](https://user-images.githubusercontent.com/54092533/80590651-e7814880-8a39-11ea-9031-8770cfbec5e1.png)

After:
![Screenshot from 2020-04-29 16-52-24](https://user-images.githubusercontent.com/54092533/80590620-da645980-8a39-11ea-9d73-53d9440022cc.png)
![Screenshot from 2020-04-29 16-50-24](https://user-images.githubusercontent.com/54092533/80590623-db958680-8a39-11ea-8093-cb844c340388.png)

/assign @rhamilto 
cc @andrewballantyne @spadgett 
This will fix the issues seen in Installed Operators and Search Page. I am going to close one of the bugs. Since the same underlying issue caused both of them.
@rhamilto I have accommodated https://github.com/openshift/console/pull/5217 
 