### PR TITLE
Bug 1828954: Handle cluster-scoped operands in the OperandForm

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-form.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-form.tsx
@@ -26,7 +26,7 @@ export const OperandForm: React.FC<OperandFormProps> = ({
     return {
       metadata: {
         ...metadata,
-        ...(match?.params?.ns && { namespace: match.params.ns }),
+        ...(match?.params?.ns && model.namespaced && { namespace: match.params.ns }),
       },
       spec: prune(spec),
       ...rest,


### PR DESCRIPTION
The `OperandForm` was incorrectly including a namespace when trying to
create cluster-scoped operands. Check the `model.namespaced` property
before adding the current namespace to the operand `metadata`.

/assign @rhamilto 