### PR TITLE
Bug 1829567: Pipeline Builder treats task param default properly

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/__tests__/utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/__tests__/utils.spec.ts
@@ -1,0 +1,30 @@
+import { PipelineResourceTaskParam } from '../../../../utils/pipeline-augment';
+import { taskParamIsRequired } from '../utils';
+
+describe('taskParamIsRequired properly detects what is required', () => {
+  const structure: PipelineResourceTaskParam = {
+    name: 'test-param',
+    description: 'some description',
+    type: 'string',
+  };
+
+  it('expect an empty param to result in needing a default', () => {
+    expect(taskParamIsRequired({} as any)).toBe(true);
+  });
+
+  it('expect no default property to mean required', () => {
+    expect(taskParamIsRequired(structure)).toBe(true);
+  });
+
+  it('expect a string default of a truthy value to mean not required', () => {
+    expect(taskParamIsRequired({ ...structure, default: 'truthy' })).toBe(false);
+  });
+
+  it('expect an empty string default to mean not required', () => {
+    expect(taskParamIsRequired({ ...structure, default: '' })).toBe(false);
+  });
+
+  it('expect an array default to always be not required', () => {
+    expect(taskParamIsRequired({ ...structure, type: 'array', default: [] })).toBe(false);
+  });
+});

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/task-sidebar/TaskSidebarParam.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FormGroup } from '@patternfly/react-core';
 import { PipelineResourceTaskParam, PipelineTaskParam } from '../../../../utils/pipeline-augment';
+import { taskParamIsRequired } from '../utils';
 import { ArrayParam, ParameterProps, SidebarInputWrapper, StringParam } from './temp-utils';
 
 type TaskSidebarParamProps = {
@@ -15,7 +16,7 @@ const TaskSidebarParam: React.FC<TaskSidebarParamProps> = (props) => {
   const [dirty, setDirty] = React.useState(false);
 
   const currentValue = taskParam?.value;
-  const emptyIsInvalid = !resourceParam.default;
+  const emptyIsInvalid = taskParamIsRequired(resourceParam);
 
   const isValid = !(dirty && hasParamError && emptyIsInvalid && currentValue != null);
 

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/update-utils.ts
@@ -24,7 +24,7 @@ import {
   UpdateTaskParamData,
   UpdateTaskResourceData,
 } from './types';
-import { convertResourceToTask } from './utils';
+import { convertResourceToTask, taskParamIsRequired } from './utils';
 
 const mapReplaceRelatedInOthers = <TaskType extends PipelineBuilderTaskBase>(
   taskName: string,
@@ -115,9 +115,7 @@ const mapAddRelatedToOthers = <TaskType extends PipelineBuilderTaskBase>(
 const getErrors = (task: PipelineTask, resource: PipelineResourceTask): TaskErrorMap => {
   const params = getTaskParameters(resource);
   const resourceParams = params || [];
-  const requiredParamNames = resourceParams
-    .filter((param) => !param.default)
-    .map((param) => param.name);
+  const requiredParamNames = resourceParams.filter(taskParamIsRequired).map((param) => param.name);
   const hasNonDefaultParams = task.params
     ?.filter(({ name }) => requiredParamNames.includes(name))
     ?.map(({ value }) => !value)

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/utils.ts
@@ -1,7 +1,12 @@
 import { history, resourcePathFromModel } from '@console/internal/components/utils';
 import { apiVersionForModel, referenceForModel } from '@console/internal/module/k8s';
 import { ClusterTaskModel, PipelineModel } from '../../../models';
-import { Pipeline, PipelineResourceTask, PipelineTask } from '../../../utils/pipeline-augment';
+import {
+  Pipeline,
+  PipelineResourceTask,
+  PipelineResourceTaskParam,
+  PipelineTask,
+} from '../../../utils/pipeline-augment';
 import { getTaskParameters } from '../resource-utils';
 import { TASK_ERROR_STRINGS, TaskErrorType } from './const';
 import { PipelineBuilderFormikValues, PipelineBuilderFormValues, TaskErrorMap } from './types';
@@ -18,6 +23,10 @@ export const getErrorMessage = (errorTypes: TaskErrorType[], errorMap: TaskError
 
   const hasRequestedError = errorList.filter((error) => errorTypes.includes(error));
   return hasRequestedError.length > 0 ? TASK_ERROR_STRINGS[hasRequestedError[0]] : null;
+};
+
+export const taskParamIsRequired = (param: PipelineResourceTaskParam): boolean => {
+  return !('default' in param);
 };
 
 export const convertResourceToTask = (

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -182,12 +182,12 @@ export interface Param {
 }
 
 export interface PipelineParam extends Param {
-  default?: string;
+  default?: string | string[];
   description?: string;
 }
 
 export interface PipelineRunParam extends Param {
-  value: string;
+  value: string | string[];
   input?: string;
   output?: string;
   resource?: object;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3606

**Analysis / Root cause**: 
When the Pipeline Builder was coded originally in 4.4, it incorrectly took a shortcut around the default value of a Task parameter. An empty string for a default means it has a default of no value. 

**Solution Description**: 
Check for the existence of `default` the value does not matter. If it has a default of any kind, we can assume it is not required to be entered to use the Task.

**Screen shots / Gifs for design review**: 

Before:
![image](https://user-images.githubusercontent.com/8126518/80637057-653e5780-8a2c-11ea-86c7-164ec00a67e3.png)

After:
![image](https://user-images.githubusercontent.com/8126518/80636956-3c1dc700-8a2c-11ea-85af-46e30ac61174.png)


cc @openshift/team-devconsole-ux
cc @siamaksade 

**Unit test coverage report**: 

```
 PASS  packages/dev-console/src/components/pipelines/pipeline-builder/__tests__/utils.spec.ts (5.611s)
  taskParamIsRequired properly detects what is required
    ✓ expect an empty param to result in needing a default (2ms)
    ✓ expect no default property to mean required
    ✓ expect a string default of a truthy value to mean not required
    ✓ expect an empty string default to mean not required
    ✓ expect an array default to always be not required (1ms)
```

**Test setup:**

* Just the Pipeline Operator 0.11+ (`canary` channel)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge