### PR TITLE
Bug 1827538: Fix create operand yaml editor runtime error

### DIFF
--- a/frontend/packages/console-shared/src/utils/yaml.ts
+++ b/frontend/packages/console-shared/src/utils/yaml.ts
@@ -1,0 +1,19 @@
+import { safeDump, safeLoad } from 'js-yaml';
+
+// Safely parse js obj to yaml. Returns fallback (emtpy string by default) on exception.
+export const safeJSToYAML = (js: any, fallback: string = '', options: any = {}): string => {
+  try {
+    return safeDump(js, options);
+  } catch {
+    return fallback;
+  }
+};
+
+// Safely parse yaml to js object. Returns fallback (empty object by default) on exception.
+export const safeYAMLToJS = (yaml: string, fallback: any = {}, options: any = {}): any => {
+  try {
+    return safeLoad(yaml, options);
+  } catch {
+    return fallback;
+  }
+};

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
@@ -92,10 +92,11 @@ export const CreateOperand: React.FC<CreateOperandProps> = ({
           </div>
           <SyncedEditor
             context={{
-              formContext: { csv, match, model, next, schema, providedAPI, initialValue: sample },
+              formContext: { csv, match, model, next, schema, providedAPI },
               yamlContext: { next, match },
             }}
             FormEditor={OperandForm}
+            initialData={sample}
             initialType={initialEditorType}
             onChangeEditorType={onChangeEditorType}
             YAMLEditor={OperandYAML}

--- a/frontend/public/components/create-yaml.tsx
+++ b/frontend/public/components/create-yaml.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { match as RouterMatch } from 'react-router-dom';
-
-import { safeLoad } from 'js-yaml';
 import { yamlTemplates } from '../models/yaml-templates';
 import { connectToPlural } from '../kinds';
 import { AsyncComponent } from './utils/async';
@@ -14,6 +12,7 @@ import {
   K8sResourceKind,
 } from '../module/k8s';
 import { ErrorPage404 } from './error';
+import { safeYAMLToJS } from '@console/shared/src/utils/yaml';
 
 export const CreateYAML = connectToPlural((props: CreateYAMLProps) => {
   const {
@@ -39,7 +38,7 @@ export const CreateYAML = connectToPlural((props: CreateYAMLProps) => {
     yamlTemplates.getIn([referenceForModel(kindObj), 'default']) ||
     yamlTemplates.getIn(['DEFAULT', 'default']);
 
-  const obj = safeLoad(template);
+  const obj = safeYAMLToJS(template);
   obj.kind = kindObj.kind;
   obj.metadata = obj.metadata || {};
   if (kindObj.namespaced) {


### PR DESCRIPTION
- Add try/catch block around `safeLoad` in CreateYAML component. This was the main cause of the runtime error.
- Adjust the logic in SyncedEditor so that the YAML state is only updated on switching to the YAML view. This was part of the problem as well. Every change in the YAML editor was updating the yaml state, and in turn the `template` prop in CreateYAML component. CreateYAML component was trying to parse yaml on every change, and throwing an exception when the yaml could not be parsed.
- Minimize syncing logic in SyncedEditor component by making `formData` the source of truth for both YAML and Form editors. YAML editor content only gets synced from `formData` when toggling into the YAML view, then each change in the YAML editor triggers an update to `formData`.  Previously, syncing was happening in both directions on every change, which was unnecessary.