### PR TITLE
Bug 1829753: Update VM doc href in VMI details hint box

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vmi-details-page.tsx
@@ -112,7 +112,7 @@ export const VirtualMachinesInstanceDetailsPage: React.FC<VirtualMachinesInstanc
           the cluster.
         </p>
         <ExternalLink
-          href="https://kubevirt.io/user-guide/docs/latest/architecture/virtual-machine.html"
+          href="https://kubevirt.io/user-guide/#/architecture?id=virtualmachine"
           text="Learn more"
         />
       </HintBlock>


### PR DESCRIPTION
In VMI hint box, Virtual Machine documentation href link is obsolete.

Screenshot:
Fixed:
![Peek 2020-04-30 12-16](https://user-images.githubusercontent.com/2181522/80695895-4056ec80-8adf-11ea-827a-b2c5a5265649.gif)
Broken:
![Peek 2020-04-30 12-17](https://user-images.githubusercontent.com/2181522/80695900-4220b000-8adf-11ea-80ab-bd16a97884b3.gif)
