### PR TITLE
Bug 1828964: Adjust kubevirt modals footer buttons

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.scss
@@ -1,0 +1,3 @@
+.kubevirt-boot-order-modal__footer {
+    padding: 0;
+}

--- a/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/boot-order-modal/boot-order-modal.tsx
@@ -14,6 +14,8 @@ import { BootOrder, deviceKey } from '../../boot-order';
 import { DeviceType } from '../../../constants';
 import { ModalFooter } from '../modal/modal-footer';
 
+import './boot-order-modal.scss';
+
 const modalTitle = 'Virtual machine boot order';
 
 const BootOrderModalComponent = ({
@@ -136,6 +138,7 @@ const BootOrderModalComponent = ({
           .
         </>
       }
+      className={'kubevirt-boot-order-modal__footer'}
     />
   );
 
@@ -146,7 +149,8 @@ const BootOrderModalComponent = ({
       isSmall
       onClose={() => setOpen(false)}
       footer={footer}
-      isFooterLeftAligned
+      showClose={false}
+      isFooterLeftAligned={false}
     >
       <BootOrder devices={devices} setDevices={setDevices} />
     </Modal>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.scss
@@ -1,3 +1,3 @@
-.kubevirt-create-nic-modal__buttons {
-  text-align: left;
+.kubevirt-modal-footer__buttons {
+  width: 100%;
 }

--- a/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { Alert, Button, AlertProps, ActionGroup } from '@patternfly/react-core';
+import { Alert, Button, ButtonVariant, AlertProps, ActionGroup } from '@patternfly/react-core';
 import { LoadingInline } from '@console/internal/components/utils';
 
 import './modal-footer.scss';
@@ -84,13 +84,18 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
     <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
       <Button
         type="button"
-        variant="secondary"
+        variant={ButtonVariant.secondary}
         data-test-id="modal-cancel-action"
         onClick={onCancel}
       >
         {cancelButtonText}
       </Button>
-      <Button variant="primary" isDisabled={isDisabled} id="confirm-action" onClick={onSubmit}>
+      <Button
+        variant={ButtonVariant.primary}
+        isDisabled={isDisabled}
+        id="confirm-action"
+        onClick={onSubmit}
+      >
         {submitButtonText}
       </Button>
     </ActionGroup>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/modal/modal-footer.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { Alert, Button, ButtonVariant, AlertProps } from '@patternfly/react-core';
+import { Alert, Button, AlertProps, ActionGroup } from '@patternfly/react-core';
 import { LoadingInline } from '@console/internal/components/utils';
-import { prefixedID } from '../../../utils';
 
 import './modal-footer.scss';
 
@@ -59,7 +58,6 @@ type ModalFooterProps = {
 };
 
 export const ModalFooter: React.FC<ModalFooterProps> = ({
-  id,
   className = '',
   errorMessage = null,
   warningMessage = null,
@@ -74,10 +72,7 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
   infoTitle = null,
 }) => (
   <footer
-    className={classNames(
-      'co-m-btn-bar modal-footer kubevirt-create-nic-modal__buttons',
-      className,
-    )}
+    className={classNames('co-m-btn-bar modal-footer kubevirt-modal-footer__buttons', className)}
   >
     {warningMessage && isSimpleError && (
       <ModalSimpleMessage message={warningMessage} variant="warning" />
@@ -85,17 +80,21 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
     {errorMessage && isSimpleError && <ModalSimpleMessage message={errorMessage} />}
     {errorMessage && !isSimpleError && <ModalErrorMessage message={errorMessage} />}
     {infoTitle && <ModalInfoMessage title={infoTitle}>{infoMessage}</ModalInfoMessage>}
-    <Button
-      variant={ButtonVariant.primary}
-      onClick={onSubmit}
-      id={prefixedID(id, 'submit')}
-      isDisabled={isDisabled}
-    >
-      {submitButtonText}
-    </Button>
-    <Button variant={ButtonVariant.link} onClick={onCancel} id={prefixedID(id, 'cancel')}>
-      {cancelButtonText}
-    </Button>
+
+    <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
+      <Button
+        type="button"
+        variant="secondary"
+        data-test-id="modal-cancel-action"
+        onClick={onCancel}
+      >
+        {cancelButtonText}
+      </Button>
+      <Button variant="primary" isDisabled={isDisabled} id="confirm-action" onClick={onSubmit}>
+        {submitButtonText}
+      </Button>
+    </ActionGroup>
+
     {inProgress && <LoadingInline />}
   </footer>
 );


### PR DESCRIPTION
The CNV details view modals do not align with what OCP has. We should adjust them to align them visually. CNV has set out to align better with Patternfly 4 but we should in the short term ensure we have a similar experience to the rest of the console.

This BZ align kubevirt plugin modal:

  - [x]  Do not include an "X" to close
  - [x]  Align actions to the right
  - [x]  Use the modifier .pf-m-secondary for the cancel action
  - [x]  Use a spacer between the footer actions (32px)

Note: In the case of boot-order modal we also need to top align the modal, this is not easily done for PF4 modal, IMHO we can wait until reset of the console will migrate to PF4, or find a fix that is PF4 ready, before fixing that.

Screenshots:
Before
![screenshot-console-openshift-console apps ostest test metalkube org-2020 04 30-14_27_01](https://user-images.githubusercontent.com/2181522/80707662-02fc5a00-8af3-11ea-9cad-b4e901cc36cd.png)
After:
![screenshot-localhost_9000-2020 04 30-14_27_40](https://user-images.githubusercontent.com/2181522/80707666-0394f080-8af3-11ea-8fa8-8c850b2e83cb.png)

![screenshot-localhost_9000-2020 04 30-15_54_44](https://user-images.githubusercontent.com/2181522/80712684-0267c180-8afb-11ea-8947-2df5464a4a12.png)

![screenshot-localhost_9000-2020 04 30-15_54_09](https://user-images.githubusercontent.com/2181522/80712682-01cf2b00-8afb-11ea-8c37-90cf4dac3f0f.png)
