### PR TITLE
Bug 1830929: Feat(pl-filter-status): Add others as a filter status

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineAugmentRuns.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineAugmentRuns.tsx
@@ -22,6 +22,7 @@ export const filters = [
       { id: ListFilterId.Running, title: ListFilterLabels[ListFilterId.Running] },
       { id: ListFilterId.Failed, title: ListFilterLabels[ListFilterId.Failed] },
       { id: ListFilterId.Cancelled, title: ListFilterLabels[ListFilterId.Cancelled] },
+      { id: ListFilterId.Other, title: ListFilterLabels[ListFilterId.Other] },
     ],
     filter: pipelineStatusFilter,
   },

--- a/frontend/packages/dev-console/src/utils/pipeline-utils.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-utils.ts
@@ -74,6 +74,7 @@ export enum ListFilterId {
   Failed = 'Failed',
   Succeeded = 'Succeeded',
   Cancelled = 'Cancelled',
+  Other = '-',
 }
 
 export const ListFilterLabels = {
@@ -81,6 +82,7 @@ export const ListFilterLabels = {
   [ListFilterId.Failed]: 'Failed',
   [ListFilterId.Succeeded]: 'Complete',
   [ListFilterId.Cancelled]: 'Cancelled',
+  [ListFilterId.Other]: 'Other',
 };
 
 // to be used by both Pipeline and Pipelinerun visualisation


### PR DESCRIPTION

## Fixes:
https://issues.redhat.com/browse/ODC-2401

## Analysis / Root cause:
Other status to be set as a Pipeline List filter

## Solution Description:
Added a new filter status Other to filters of Pipeline List

## Screenshot
![PLR-others](https://user-images.githubusercontent.com/24852534/80727326-348d1980-8b23-11ea-9cef-6491956c877d.gif)

## Browser conformation
Chrome 73