### PR TITLE
Bug 1829928: Fixes: missing pod donut for DS in sidebar overview tab

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodRing.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRing.tsx
@@ -13,7 +13,7 @@ interface PodRingProps {
   obj: K8sResourceKind;
   rc?: K8sResourceKind;
   resourceKind: K8sKind;
-  path: string;
+  path?: string;
   impersonate?: string;
   enableScaling?: boolean;
 }

--- a/frontend/packages/console-shared/src/components/pod/PodRingDataController.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRingDataController.tsx
@@ -1,7 +1,16 @@
 import * as React from 'react';
 import { Firehose, FirehoseResource } from '@console/internal/components/utils';
 import { PodRingResources, PodRingData } from '../../types';
-import { transformPodRingData } from '../../utils';
+import { transformPodRingData, podRingFirehoseProps } from '../../utils';
+import {
+  DaemonSetModel,
+  PodModel,
+  ReplicaSetModel,
+  ReplicationControllerModel,
+  DeploymentModel,
+  DeploymentConfigModel,
+  StatefulSetModel,
+} from '@console/internal/models';
 
 interface RenderPropsType {
   loaded: boolean;
@@ -37,45 +46,59 @@ const PodRingController: React.FC<PodRingDataControllerProps> = ({ namespace, ki
   const resources: FirehoseResource[] = [
     {
       isList: true,
-      kind: 'Pod',
+      kind: PodModel.kind,
       namespace,
-      prop: 'pods',
+      prop: podRingFirehoseProps[PodModel.kind],
     },
     {
       isList: true,
-      kind: 'ReplicaSet',
+      kind: ReplicaSetModel.kind,
       namespace,
-      prop: 'replicaSets',
+      prop: podRingFirehoseProps[ReplicaSetModel.kind],
     },
     {
       isList: true,
-      kind: 'ReplicationController',
+      kind: ReplicationControllerModel.kind,
       namespace,
-      prop: 'replicationControllers',
+      prop: podRingFirehoseProps[ReplicationControllerModel.kind],
     },
   ];
 
-  if (kind === 'Deployment') {
-    resources.push({
-      isList: true,
-      kind: 'Deployment',
-      namespace,
-      prop: 'deployments',
-    });
-  } else if (kind === 'DeploymentConfig') {
-    resources.push({
-      isList: true,
-      kind: 'DeploymentConfig',
-      namespace,
-      prop: 'deploymentConfigs',
-    });
-  } else if (kind === 'StatefulSet') {
-    resources.push({
-      isList: true,
-      kind: 'StatefulSet',
-      namespace,
-      prop: 'statefulSets',
-    });
+  switch (kind) {
+    case DeploymentModel.kind:
+      resources.push({
+        isList: true,
+        kind,
+        namespace,
+        prop: podRingFirehoseProps[kind],
+      });
+      break;
+    case DeploymentConfigModel.kind:
+      resources.push({
+        isList: true,
+        kind,
+        namespace,
+        prop: podRingFirehoseProps[kind],
+      });
+      break;
+    case StatefulSetModel.kind:
+      resources.push({
+        isList: true,
+        kind,
+        namespace,
+        prop: podRingFirehoseProps[kind],
+      });
+      break;
+    case DaemonSetModel.kind:
+      resources.push({
+        isList: true,
+        kind,
+        namespace,
+        prop: podRingFirehoseProps[kind],
+      });
+      break;
+    default:
+      break;
   }
 
   return (

--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -5,6 +5,9 @@ import {
   DeploymentModel,
   DaemonSetModel,
   StatefulSetModel,
+  ReplicationControllerModel,
+  ReplicaSetModel,
+  PodModel,
 } from '@console/internal/models';
 import { ChartLabel } from '@patternfly/react-charts';
 import {
@@ -20,6 +23,7 @@ import {
   getPodsForDeploymentConfigs,
   getPodsForDeployments,
   getPodsForStatefulSets,
+  getPodsForDaemonSets,
 } from './resource-utils';
 
 type PodRingLabelType = {
@@ -27,6 +31,16 @@ type PodRingLabelType = {
   title: string;
   titleComponent: React.ReactElement;
   subTitleComponent: React.ReactElement;
+};
+
+export const podRingFirehoseProps = {
+  [PodModel.kind]: 'pods',
+  [ReplicaSetModel.kind]: 'replicaSets',
+  [ReplicationControllerModel.kind]: 'replicationControllers',
+  [DeploymentModel.kind]: 'deployments',
+  [DeploymentConfigModel.kind]: 'deploymentConfigs',
+  [StatefulSetModel.kind]: 'statefulSets',
+  [DaemonSetModel.kind]: 'daemonSets',
 };
 
 const applyPods = (podsData: PodRingData, dc: PodRCData) => {
@@ -176,13 +190,7 @@ export const usePodScalingAccessStatus = (
 };
 
 export const transformPodRingData = (resources: PodRingResources, kind: string): PodRingData => {
-  const resourceKinds = {
-    [DeploymentModel.kind]: 'deployments',
-    [DeploymentConfigModel.kind]: 'deploymentConfigs',
-    [StatefulSetModel.kind]: 'statefulSets',
-  };
-
-  const targetResource = resourceKinds[kind];
+  const targetResource = podRingFirehoseProps[kind];
 
   if (!targetResource) {
     throw new Error(`Invalid target resource: (${targetResource})`);
@@ -204,6 +212,10 @@ export const transformPodRingData = (resources: PodRingResources, kind: string):
 
   if (kind === StatefulSetModel.kind) {
     return getPodsForStatefulSets(resourceData, resources).reduce(applyPods, podsData);
+  }
+
+  if (kind === DaemonSetModel.kind) {
+    return getPodsForDaemonSets(resourceData, resources).reduce(applyPods, podsData);
   }
 
   return podsData;

--- a/frontend/packages/console-shared/src/utils/resource-utils.ts
+++ b/frontend/packages/console-shared/src/utils/resource-utils.ts
@@ -992,3 +992,20 @@ export const getPodsForStatefulSets = (ss: K8sResourceKind[], resources: any): P
     };
   });
 };
+
+export const getPodsForDaemonSets = (ds: K8sResourceKind[], resources: any): PodRCData[] => {
+  return _.map(ds, (d) => {
+    const obj: K8sResourceKind = {
+      ...d,
+      apiVersion: apiVersionForModel(StatefulSetModel),
+      kind: StatefulSetModel.kind,
+    };
+    return {
+      obj,
+      current: undefined,
+      previous: undefined,
+      isRollingOut: undefined,
+      pods: getPodsForResource(d, resources),
+    };
+  });
+};

--- a/frontend/public/components/daemon-set.tsx
+++ b/frontend/public/components/daemon-set.tsx
@@ -20,10 +20,12 @@ import {
   ResourceSummary,
   SectionHeading,
   Selector,
+  LoadingInline,
 } from './utils';
 import { ResourceEventStream } from './events';
 import { VolumesTable } from './volumes-table';
 import { DaemonSetModel } from '../models';
+import { PodRingController, PodRing } from '@console/shared';
 
 export const menuActions: KebabAction[] = [
   AddHealthChecks,
@@ -135,6 +137,23 @@ const DaemonSetDetails: React.FC<DaemonSetDetailsProps> = ({ obj: daemonset }) =
   <>
     <div className="co-m-pane__body">
       <SectionHeading text="Daemon Set Details" />
+      <PodRingController
+        namespace={daemonset.metadata.namespace}
+        kind={daemonset.kind}
+        render={(d) => {
+          return d.loaded ? (
+            <PodRing
+              key={daemonset.metadata.uid}
+              pods={d.data[daemonset.metadata.uid].pods}
+              obj={daemonset}
+              resourceKind={DaemonSetModel}
+              enableScaling={false}
+            />
+          ) : (
+            <LoadingInline />
+          );
+        }}
+      />
       <div className="row">
         <div className="col-lg-6">
           <ResourceSummary resource={daemonset} showPodSelector showNodeSelector showTolerations />

--- a/frontend/public/components/overview/daemon-set-overview.tsx
+++ b/frontend/public/components/overview/daemon-set-overview.tsx
@@ -1,20 +1,23 @@
 import * as React from 'react';
-
+import { OverviewItem, PodRing } from '@console/shared';
 import { DaemonSetModel } from '../../models';
 import { ResourceSummary } from '../utils';
 import { menuActions, DaemonSetDetailsList } from '../daemon-set';
-
 import { OverviewDetailsResourcesTab } from './resource-overview-page';
 import { ResourceOverviewDetails } from './resource-overview-details';
-import { OverviewItem } from '@console/shared';
 
-const DaemonSetOverviewDetails: React.SFC<DaemonSetOverviewDetailsProps> = ({ item }) => (
+const DaemonSetOverviewDetails: React.SFC<DaemonSetOverviewDetailsProps> = ({
+  item: { obj, pods },
+}) => (
   <div className="overview__sidebar-pane-body resource-overview__body">
+    <div className="resource-overview__pod-counts">
+      <PodRing pods={pods} resourceKind={DaemonSetModel} obj={obj} enableScaling={false} />
+    </div>
     <div className="resource-overview__summary">
-      <ResourceSummary resource={item.obj} showPodSelector showNodeSelector showTolerations />
+      <ResourceSummary resource={obj} showPodSelector showNodeSelector showTolerations />
     </div>
     <div className="resource-overview__details">
-      <DaemonSetDetailsList ds={item.obj} />
+      <DaemonSetDetailsList ds={obj} />
     </div>
   </div>
 );

--- a/frontend/public/components/stateful-set.tsx
+++ b/frontend/public/components/stateful-set.tsx
@@ -22,9 +22,10 @@ import {
 import { VolumesTable } from './volumes-table';
 import { StatefulSetModel } from '../models';
 
-const { AddStorage, common } = Kebab.factory;
+const { AddStorage, common, ModifyCount } = Kebab.factory;
 export const menuActions: KebabAction[] = [
   AddHealthChecks,
+  ModifyCount,
   AddStorage,
   ...Kebab.getExtensionsActionsForKind(StatefulSetModel),
   EditHealthChecks,


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3114
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Missing PodRing for Daemon set overview page and sidebar
Missing EditPodCount action for StatefulSets menu action on sidebar

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added PodRing for Daemon and  EditPodCount action for StatefulSets menu action 

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Screenshot from 2020-04-30 20-42-09](https://user-images.githubusercontent.com/9278015/80727439-5a1a2300-8b23-11ea-91ce-730de40ed65b.png)
![Screenshot from 2020-04-30 20-42-23](https://user-images.githubusercontent.com/9278015/80727445-5b4b5000-8b23-11ea-93f6-310ef68511b3.png)
![Screenshot from 2020-04-30 20-42-33](https://user-images.githubusercontent.com/9278015/80727446-5be3e680-8b23-11ea-936f-92dcee1d1f1b.png)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
