### PR TITLE
Bug 1788810: deprecate usage of flavor.template.kubevirt.io/Custom label

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/initial-state/vm-settings-tab-initial-state.ts
@@ -3,6 +3,7 @@ import { CommonData, VMSettingsField, VMWizardProps } from '../../types';
 import { asDisabled, asHidden, asRequired } from '../../utils/utils';
 import { ProvisionSource } from '../../../../constants/vm/provision-source';
 import { InitialStepStateGetter, VMSettings } from './types';
+import { CUSTOM_FLAVOR } from '../../../../constants/vm';
 
 export const getInitialVmSettings = (data: CommonData): VMSettings => {
   const {
@@ -53,6 +54,7 @@ export const getInitialVmSettings = (data: CommonData): VMSettings => {
     },
     [VMSettingsField.FLAVOR]: {
       isRequired: asRequired(true),
+      value: CUSTOM_FLAVOR,
     },
     [VMSettingsField.MEMORY]: {
       binaryUnitValidation: true,

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/prefill-vm-template-state-update.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/redux/state-update/prefill-vm-template-state-update.ts
@@ -20,7 +20,6 @@ import { iGetNetworks } from '../../selectors/immutable/networks';
 import { podNetwork } from '../initial-state/networks-tab-initial-state';
 import { vmWizardInternalActions } from '../internal-actions';
 import {
-  CUSTOM_FLAVOR,
   DataVolumeSourceType,
   DiskBus,
   DiskType,
@@ -63,6 +62,7 @@ import { joinIDs } from '../../../../utils';
 import { VM_TEMPLATE_NAME_PARAMETER } from '../../../../constants/vm-templates';
 import { selectVM } from '../../../../selectors/vm-template/basic';
 import { convertToHighestUnitFromUnknown } from '../../../form/size-unit-utils';
+import { toUIFlavor, isCustomFlavor } from '../../../../selectors/vm-like/flavor';
 
 export const prefillVmTemplateUpdater = ({ id, dispatch, getState }: UpdateOptions) => {
   const state = getState();
@@ -122,8 +122,10 @@ export const prefillVmTemplateUpdater = ({ id, dispatch, getState }: UpdateOptio
 
     // update flavor
     const [flavor] = getTemplateFlavors([userTemplate]);
-    vmSettingsUpdate[VMSettingsField.FLAVOR] = { value: flavor };
-    if (flavor === CUSTOM_FLAVOR) {
+    vmSettingsUpdate[VMSettingsField.FLAVOR] = {
+      value: toUIFlavor(flavor),
+    };
+    if (isCustomFlavor(flavor)) {
       vmSettingsUpdate[VMSettingsField.CPU] = { value: parseCPU(getCPU(vm), DEFAULT_CPU).cores }; // TODO also add sockets + threads
       const memory = convertToHighestUnitFromUnknown(getMemory(vm));
       vmSettingsUpdate[VMSettingsField.MEMORY] = {
@@ -259,7 +261,9 @@ export const prefillVmTemplateUpdater = ({ id, dispatch, getState }: UpdateOptio
       },
     );
     if (flavors.length === 1) {
-      vmSettingsUpdate[VMSettingsField.FLAVOR] = { value: flavors[0] };
+      vmSettingsUpdate[VMSettingsField.FLAVOR] = {
+        value: toUIFlavor(flavors[0]),
+      };
     }
 
     const newSourceStorage = getProvisionSourceStorage(

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/wizard-selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/selectors/immutable/wizard-selectors.ts
@@ -8,9 +8,9 @@ import {
   VMWizardTabsMetadata,
 } from '../../types';
 import { getStringEnumValues } from '../../../../utils/types';
-import { CUSTOM_FLAVOR } from '../../../../constants/vm/constants';
 import { iGetCreateVMWizardTabs } from './common';
 import { iGetCommonData } from './selectors';
+import { isCustomFlavor } from '../../../../selectors/vm-like/flavor';
 
 const getTabBoolean = (state, wizardID: string, stepId: VMWizardTab, key) =>
   !!iGetIn(iGetCreateVMWizardTabs(state, wizardID), [stepId, key]);
@@ -88,6 +88,6 @@ export const isWizardEmpty = (state, wizardID: string) => {
 
   return ![...fields].some((fieldKey) => {
     const value = iGetIn(stepData, [VMWizardTab.VM_SETTINGS, 'value', fieldKey, 'value']);
-    return fieldKey === VMSettingsField.FLAVOR && value === CUSTOM_FLAVOR ? null : value;
+    return fieldKey === VMSettingsField.FLAVOR && isCustomFlavor(value) ? null : value;
   });
 };

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/utils.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/review-tab/utils.ts
@@ -3,12 +3,12 @@ import { getBooleanReadableValue } from '../../../../utils/strings';
 import { iGetFieldValue } from '../../selectors/immutable/field';
 import { VMSettingsField } from '../../types';
 import { iGet, iGetIn, toShallowJS } from '../../../../utils/immutable';
-import { CUSTOM_FLAVOR } from '../../../../constants/vm';
 import { iGetRelevantTemplate } from '../../../../selectors/immutable/template/combined';
 import { VMTemplateWrapper } from '../../../../k8s/wrapper/vm/vm-template-wrapper';
 import { Map as ImmutableMap } from 'immutable';
 import { ITemplate } from '../../../../types/template';
 import { getFlavorText } from '../../../../selectors/vm/flavor-text';
+import { isCustomFlavor } from '../../../../selectors/vm-like/flavor';
 
 export const getReviewValue = (field: any, fieldType: FormFieldType) => {
   const value = iGetFieldValue(field);
@@ -33,7 +33,7 @@ export const getFlavorValue = ({
   let cpu;
   let memory;
 
-  if (flavor === CUSTOM_FLAVOR) {
+  if (isCustomFlavor(flavor)) {
     cpu = {
       sockets: 1,
       cores: parseInt(getFieldValue(iVMSettings, VMSettingsField.CPU), 10),

--- a/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/create-vm-wizard/tabs/vm-settings-tab/os-flavor.tsx
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import * as React from 'react';
 import { FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { ValidationErrorType, asValidationObject } from '@console/shared/src/utils/validation';
@@ -125,7 +126,7 @@ export const OSFlavor: React.FC<OSFlavorProps> = React.memo(
                 isDisabled={!!flavor}
               />
               {flavors.map((f) => {
-                return <FormSelectOption key={f} value={f} label={f} />;
+                return <FormSelectOption key={f} value={f} label={_.capitalize(f)} />;
               })}
             </FormSelect>
           </FormField>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/clone-vm-modal/configuration-summary.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/clone-vm-modal/configuration-summary.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { DASH, getName, getNamespace } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
-import { CUSTOM_FLAVOR } from '../../../constants/vm';
 import { VMKind } from '../../../types/vm';
 import {
+  getCPU,
   getDataVolumeTemplates,
   getDisks,
   getFlavor,
-  getFlavorDescription,
   getInterfaces,
+  getMemory,
   getOperatingSystemName,
   getVolumes,
   getWorkloadProfile,
@@ -19,6 +19,7 @@ import {
   getDataVolumeStorageClassName,
 } from '../../../selectors/dv/selectors';
 import { getPvcResources, getPvcStorageClassName } from '../../../selectors/pvc/selectors';
+import { getFlavorText } from '../../../selectors/vm/flavor-text';
 
 import './_clone-vm-modal.scss';
 
@@ -64,15 +65,6 @@ const getDisksDescription = (
   });
 };
 
-const getFullFlavorDescription = (vm: VMKind) => {
-  const flavorDesc = getFlavorDescription(vm);
-  const flavor = getFlavor(vm) || CUSTOM_FLAVOR;
-  if (!flavorDesc) {
-    return flavor;
-  }
-  return `${flavor} - ${flavorDesc}`;
-};
-
 export const ConfigurationSummary: React.FC<ConfigurationSummaryProps> = ({
   id,
   vm,
@@ -86,7 +78,13 @@ export const ConfigurationSummary: React.FC<ConfigurationSummaryProps> = ({
       <dt>Operating System</dt>
       <dd>{getOperatingSystemName(vm) || DASH}</dd>
       <dt>Flavor</dt>
-      <dd>{getFullFlavorDescription(vm)}</dd>
+      <dd>
+        {getFlavorText({
+          flavor: getFlavor(vm),
+          cpu: getCPU(vm),
+          memory: getMemory(vm),
+        })}
+      </dd>
       <dt>Workload Profile</dt>
       <dd>{getWorkloadProfile(vm) || DASH}</dd>
       <dt>NICs</dt>

--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-resource.tsx
@@ -146,7 +146,7 @@ export const VMTemplateSchedulingList: React.FC<VMTemplateResourceSummaryProps> 
   const vm = asVM(template);
   const vmWrapper = new VMWrapper(vm);
   const flavorText = getFlavorText({
-    flavor: getFlavor(vm),
+    flavor: getFlavor(template),
     cpu: vmWrapper.getCPU(),
     memory: vmWrapper.getMemory(),
   });

--- a/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
+++ b/frontend/packages/kubevirt-plugin/src/constants/vm/constants.ts
@@ -21,6 +21,7 @@ export const TEMPLATE_WORKLOAD_LABEL = 'workload.template.kubevirt.io';
 export const TEMPLATE_VM_NAME_LABEL = 'vm.kubevirt.io/name';
 export const TEMPLATE_OS_NAME_ANNOTATION = 'name.os.template.kubevirt.io';
 export const TEMPLATE_VM_DOMAIN_LABEL = 'kubevirt.io/domain';
+export const TEMPLATE_VM_SIZE_LABEL = 'kubevirt.io/size';
 
 export const LABEL_USED_TEMPLATE_NAME = 'vm.kubevirt.io/template';
 export const LABEL_USED_TEMPLATE_NAMESPACE = 'vm.kubevirt.io/template.namespace';

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/common.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/common.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../../constants/vm';
 import { VMWrapper } from '../../../wrapper/vm/vm-wrapper';
 import { VMTemplateWrapper } from '../../../wrapper/vm/vm-template-wrapper';
+import { isCustomFlavor } from '../../../../selectors/vm-like/flavor';
 
 export const initializeCommonMetadata = (
   settings: {
@@ -34,7 +35,10 @@ export const initializeCommonMetadata = (
   }
 
   entity.addLabel(`${TEMPLATE_OS_LABEL}/${settings.osID}`, 'true');
-  entity.addLabel(`${TEMPLATE_FLAVOR_LABEL}/${settings[VMSettingsField.FLAVOR]}`, 'true');
+
+  if (!isCustomFlavor(settings[VMSettingsField.FLAVOR])) {
+    entity.addLabel(`${TEMPLATE_FLAVOR_LABEL}/${settings[VMSettingsField.FLAVOR]}`, 'true');
+  }
 
   if (settings[VMSettingsField.WORKLOAD_PROFILE]) {
     entity.addLabel(
@@ -75,7 +79,10 @@ export const initializeCommonVMMetadata = (
   // show metadata inside a VMI
 
   entity.addTemplateLabel(`${TEMPLATE_OS_LABEL}/${settings.osID}`, 'true');
-  entity.addTemplateLabel(`${TEMPLATE_FLAVOR_LABEL}/${settings[VMSettingsField.FLAVOR]}`, 'true');
+
+  if (!isCustomFlavor(settings[VMSettingsField.FLAVOR])) {
+    entity.addTemplateLabel(`${TEMPLATE_FLAVOR_LABEL}/${settings[VMSettingsField.FLAVOR]}`, 'true');
+  }
 
   if (settings[VMSettingsField.WORKLOAD_PROFILE]) {
     entity.addTemplateLabel(

--- a/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/initialize-vm.ts
+++ b/frontend/packages/kubevirt-plugin/src/k8s/requests/vm/create/initialize-vm.ts
@@ -6,7 +6,6 @@ import {
 import {
   ANNOTATION_FIRST_BOOT,
   ANNOTATION_PXE_INTERFACE,
-  CUSTOM_FLAVOR,
   DataVolumeSourceType,
   VolumeType,
 } from '../../../../constants/vm';
@@ -24,6 +23,7 @@ import { StorageUISource } from '../../../../components/modals/disk-modal/storag
 import { insertName, joinIDs } from '../../../../utils';
 import { VM_TEMPLATE_NAME_PARAMETER } from '../../../../constants/vm-templates';
 import { CreateVMParams } from './types';
+import { isCustomFlavor } from '../../../../selectors/vm-like/flavor';
 
 const resolveDataVolumeName = (
   dataVolumeWrapper: DataVolumeWrapper,
@@ -111,7 +111,7 @@ export const initializeVM = (params: CreateVMParams, vm: VMWrapper) => {
   const settings = asSimpleSettings(vmSettings);
   const isRunning = settings[VMSettingsField.START_VM];
 
-  if (settings[VMSettingsField.FLAVOR] === CUSTOM_FLAVOR) {
+  if (isCustomFlavor(settings[VMSettingsField.FLAVOR])) {
     vm.setCPU({ sockets: 1, cores: parseInt(settings[VMSettingsField.CPU], 10), threads: 1 });
     vm.setMemory(settings[VMSettingsField.MEMORY]);
   }

--- a/frontend/packages/kubevirt-plugin/src/models/templates/vm-template-yaml.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/templates/vm-template-yaml.ts
@@ -11,7 +11,6 @@ metadata:
   labels:
     template.kubevirt.io/type: vm
     os.template.kubevirt.io/fedora31: 'true'
-    flavor.template.kubevirt.io/Custom: 'true'
     workload.template.kubevirt.io/server: 'true'
   annotations:
     name.os.template.kubevirt.io/fedora31: Fedora 31
@@ -29,7 +28,6 @@ objects:
         metadata:
           labels:
             kubevirt.io/domain: '\${NAME}'
-            kubevirt.io/size: Custom
         spec:
           domain:
             cpu:

--- a/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
+++ b/frontend/packages/kubevirt-plugin/src/models/templates/vm-yaml.ts
@@ -11,7 +11,6 @@ metadata:
   labels:
     app: vm-example
     os.template.kubevirt.io/fedora31: 'true'
-    flavor.template.kubevirt.io/Custom: 'true'
     workload.template.kubevirt.io/server: 'true'
   annotations:
     name.os.template.kubevirt.io/fedora31: Fedora 31
@@ -22,10 +21,8 @@ spec:
     metadata:
       labels:
         kubevirt.io/domain: vm-example
-        kubevirt.io/size: Custom
         vm.kubevirt.io/name: vm-example
         os.template.kubevirt.io/fedora31: 'true'
-        flavor.template.kubevirt.io/Custom: 'true'
         workload.template.kubevirt.io/server: 'true'
     spec:
       domain:

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-like/flavor.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-like/flavor.ts
@@ -1,0 +1,9 @@
+import * as _ from 'lodash';
+import { CUSTOM_FLAVOR } from '../../constants/vm';
+
+export const isCustomFlavor = (flavor: string) =>
+  !flavor || flavor?.toLowerCase() === CUSTOM_FLAVOR.toLowerCase();
+
+// UI representation of flavor tiny|small|medium|large|Custom
+export const toUIFlavor = (flavor: string) => (isCustomFlavor(flavor) ? CUSTOM_FLAVOR : flavor);
+export const toUIFlavorLabel = (flavor: string) => _.capitalize(toUIFlavor(flavor));

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm-template/combined-dependent.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm-template/combined-dependent.ts
@@ -16,6 +16,7 @@ import {
   getTemplatesWithLabels,
   getTemplateWorkloadProfiles,
 } from './advanced';
+import { isCustomFlavor } from '../vm-like/flavor';
 
 const getLabel = (labelPrefix: string, value: string) => {
   if (!value) {
@@ -27,7 +28,7 @@ const getLabel = (labelPrefix: string, value: string) => {
 export const getWorkloadLabel = (workload: string) => getLabel(TEMPLATE_WORKLOAD_LABEL, workload);
 export const getOsLabel = (os: string) => getLabel(TEMPLATE_OS_LABEL, os);
 export const getFlavorLabel = (flavor: string) => {
-  if (flavor && flavor !== CUSTOM_FLAVOR) {
+  if (!isCustomFlavor(flavor)) {
     return `${TEMPLATE_FLAVOR_LABEL}/${flavor}`;
   }
   return undefined;
@@ -84,9 +85,8 @@ export const getFlavors = (
       [getWorkloadLabel(workload), getOsLabel(os)],
     );
   }
-  const flavors = getTemplateFlavors(templatesWithLabels);
-  if (!flavors.some((flavor) => flavor === CUSTOM_FLAVOR)) {
-    flavors.push(CUSTOM_FLAVOR);
-  }
+  const flavors = getTemplateFlavors(templatesWithLabels).filter((f) => !isCustomFlavor(f));
+  flavors.push(CUSTOM_FLAVOR);
+
   return flavors;
 };

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/flavor-text.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/flavor-text.ts
@@ -1,8 +1,8 @@
-import * as _ from 'lodash';
 import { CPURaw } from '../../types/vm';
 import { vCPUCount } from './cpu';
 import { humanizeBinaryBytes } from '@console/internal/components/utils';
 import { convertToBytes } from '../../components/form/size-unit-utils';
+import { toUIFlavorLabel } from '../vm-like/flavor';
 
 export const getFlavorText = ({
   cpu,
@@ -19,5 +19,5 @@ export const getFlavorText = ({
   const memoryBase = convertToBytes(memory);
   const memoryText = humanizeBinaryBytes(memoryBase).string;
 
-  return `${_.capitalize(flavor) || ''}${flavor ? ': ' : ''}${vcpusText}, ${memoryText} Memory`;
+  return `${toUIFlavorLabel(flavor)}: ${vcpusText}, ${memoryText} Memory`;
 };

--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -20,7 +20,6 @@ import {
   getVolumePersistentVolumeClaimName,
   getVolumeCloudInitNoCloud,
 } from './volume';
-import { vCPUCount } from './cpu';
 import { getVMIDisks } from '../vmi/basic';
 import { VirtualMachineModel } from '../../models';
 import { V1Volume } from '../../types/vm/disk/V1Volume';
@@ -91,15 +90,6 @@ export const getUsedNetworks = (vm: VMKind): NetworkWrapper[] => {
   return interfaces
     .map((i) => new NetworkWrapper(networkLookup[i.name]))
     .filter((i) => i.getType());
-};
-
-export const getFlavorDescription = (vm: VMKind) => {
-  const cpu = vCPUCount(getCPU(vm));
-  const memory = getMemory(vm);
-  const cpuStr = cpu ? `${cpu} CPU` : '';
-  const memoryStr = memory ? `${memory} Memory` : '';
-  const resourceStr = cpuStr && memoryStr ? `${cpuStr}, ${memoryStr}` : `${cpuStr}${memoryStr}`;
-  return resourceStr || undefined;
 };
 
 export const getVMStatusConditions = (vm: VMILikeEntityKind) =>

--- a/frontend/packages/kubevirt-plugin/src/utils/sort.ts
+++ b/frontend/packages/kubevirt-plugin/src/utils/sort.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
-import { CUSTOM_FLAVOR } from '../constants/vm';
 import { OperatingSystemRecord } from '../types';
+import { isCustomFlavor } from '../selectors/vm-like/flavor';
 
 const FLAVOR_ORDER = {
   tiny: 0,
@@ -11,10 +11,10 @@ const FLAVOR_ORDER = {
 
 export const flavorSort = (array: string[] = []) =>
   array.sort((a, b) => {
-    if (a === CUSTOM_FLAVOR) {
+    if (isCustomFlavor(a)) {
       return 1;
     }
-    if (b === CUSTOM_FLAVOR) {
+    if (isCustomFlavor(b)) {
       return -1;
     }
     const resolvedFlavorA = FLAVOR_ORDER[a];


### PR DESCRIPTION
- use Custom only internally by the UI and acknowledge missing label as Custom flavor
- remove kubevirt.io/size: Custom label as well
- capitalize flavors in VM Wizard
- fix display of VM template flavor