### PR TITLE
Bug 1829722: Fix various search input focus bugs

### DIFF
--- a/frontend/packages/console-shared/src/hooks/document-listener.ts
+++ b/frontend/packages/console-shared/src/hooks/document-listener.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { isModalOpen } from '@console/internal/components/modals';
 
 /**
  * Use this hook for components that require visibility only
@@ -21,13 +22,23 @@ export const useDocumentListener = <T extends HTMLElement>(keyEventMap: KeyEvent
   };
 
   const handleKeyEvents = (e) => {
+    // Don't steal focus from a modal open on top of the page.
+    if (isModalOpen()) {
+      return;
+    }
+    const { nodeName } = e.target;
     switch (keyEventMap[e.key]) {
       case KeyEventModes.HIDE:
         setVisible(false);
         ref.current.blur();
         break;
       case KeyEventModes.FOCUS:
-        if (document.activeElement !== ref.current) {
+        if (
+          document.activeElement !== ref.current &&
+          // Don't steal focus if the user types the focus shortcut in another text input.
+          nodeName !== 'INPUT' &&
+          nodeName !== 'TEXTAREA'
+        ) {
           ref.current.focus();
           e.preventDefault();
         }

--- a/frontend/public/components/modals/index.ts
+++ b/frontend/public/components/modals/index.ts
@@ -1,5 +1,9 @@
 // This module utilizes dynamic `import()` to enable lazy-loading for each modal instead of including them in the main bundle.
 
+// Helper to detect if a modal is open. This is used to disable autofocus in elements under a modal.
+// TODO: Improve focus and keybinding handling, see https://issues.redhat.com/browse/ODC-3554
+export const isModalOpen = () => document.body.classList.contains('ReactModal__Body--open');
+
 export const configureCountModal = (props) =>
   import('./configure-count-modal' /* webpackChunkName: "configure-count-modal" */).then((m) =>
     m.configureCountModal(props),

--- a/frontend/public/components/utils/tile-view-page.jsx
+++ b/frontend/public/components/utils/tile-view-page.jsx
@@ -21,6 +21,7 @@ import {
 } from '@patternfly/react-core';
 
 import { history } from './router';
+import { isModalOpen } from '../modals';
 import { Dropdown } from '../utils';
 
 export const FilterTypes = {
@@ -666,7 +667,11 @@ export class TileViewPage extends React.Component {
 
     this.updateMountedState(this.getUpdatedState(categories, selectedCategoryId, clearedFilters));
 
-    this.filterByKeywordInput.focus({ preventScroll: true });
+    // Don't take focus if a modal was opened while the page was loading.
+    if (!isModalOpen()) {
+      this.filterByKeywordInput.focus({ preventScroll: true });
+    }
+
     if (this.props.storeFilterKey) {
       localStorage.removeItem(this.props.storeFilterKey);
     }

--- a/frontend/public/style/_forms.scss
+++ b/frontend/public/style/_forms.scss
@@ -53,11 +53,15 @@
   }
 }
 
-.co-text-filter {
-  min-width: 270px;
-  &:focus + .form-control-feedback--keyboard-hint {
+.co-suggestion-box input:focus,
+.co-text-filter:focus {
+  + .form-control-feedback--keyboard-hint {
     display: none;
   }
+}
+
+.co-text-filter {
+  min-width: 270px;
 }
 
 .form-control-feedback--keyboard-hint {


### PR DESCRIPTION
* Don't autofocus the OperatorHub search input if a modal was opened while the page was loading.
* Don't steal focus if a `/` character is typed in another text input.
* Hide the focus keyboard hint when the search input is focused.

https://bugzilla.redhat.com/show_bug.cgi?id=1829722
https://issues.redhat.com/browse/ODC-3554

@christianvogt This is a little hacky. I was looking for a non-invasive way to address the regression in 4.5. I'm on board doing something better long term. Let me know what you think.