### PR TITLE
Bug 1830046: Helm redirects based on the origin of the action

### DIFF
--- a/frontend/packages/dev-console/src/actions/modify-helm-release.ts
+++ b/frontend/packages/dev-console/src/actions/modify-helm-release.ts
@@ -20,16 +20,28 @@ export const deleteHelmRelease = (releaseName: string, namespace: string, redire
   };
 };
 
-export const upgradeHelmRelease = (releaseName: string, namespace: string) => ({
-  label: 'Upgrade Helm Release',
+export const upgradeHelmRelease = (
+  releaseName: string,
+  namespace: string,
+  actionOrigin: string,
+) => ({
+  label: 'Upgrade',
   callback: () => {
-    history.push(`/helm-releases/ns/${namespace}/${releaseName}/upgrade`);
+    history.push(
+      `/helm-releases/ns/${namespace}/${releaseName}/upgrade?actionOrigin=${actionOrigin}`,
+    );
   },
 });
 
-export const rollbackHelmRelease = (releaseName: string, namespace: string) => ({
+export const rollbackHelmRelease = (
+  releaseName: string,
+  namespace: string,
+  actionOrigin: string,
+) => ({
   label: 'Rollback',
   callback: () => {
-    history.push(`/helm-releases/ns/${namespace}/${releaseName}/rollback`);
+    history.push(
+      `/helm-releases/ns/${namespace}/${releaseName}/rollback?actionOrigin=${actionOrigin}`,
+    );
   },
 });

--- a/frontend/packages/dev-console/src/components/helm/details/HelmReleaseDetails.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/HelmReleaseDetails.tsx
@@ -23,7 +23,7 @@ import {
   rollbackHelmRelease,
 } from '../../../actions/modify-helm-release';
 import HelmReleaseNotes from './HelmReleaseNotes';
-import { HelmRelease } from '../helm-types';
+import { HelmRelease, HelmActionOrigins } from '../helm-types';
 
 const SecretReference: K8sResourceKindReference = 'Secret';
 const HelmReleaseReference = 'HelmRelease';
@@ -77,8 +77,8 @@ export const LoadedHelmReleaseDetails: React.FC<LoadedHelmReleaseDetailsProps> =
   );
 
   const menuActions = [
-    () => rollbackHelmRelease(releaseName, namespace),
-    () => upgradeHelmRelease(releaseName, namespace),
+    () => upgradeHelmRelease(releaseName, namespace, HelmActionOrigins.details),
+    () => rollbackHelmRelease(releaseName, namespace, HelmActionOrigins.details),
     () => deleteHelmRelease(releaseName, namespace, `/helm-releases/ns/${namespace}`),
   ];
 

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -63,6 +63,7 @@ export enum HelmReleaseStatus {
 export enum HelmActionType {
   Install = 'Install',
   Upgrade = 'Upgrade',
+  Rollback = 'Rollback',
 }
 
 export interface HelmActionConfigType {
@@ -71,4 +72,10 @@ export interface HelmActionConfigType {
   helmReleaseApi: string;
   fetch: (url: any, json: any, options?: {}) => Promise<any>;
   redirectURL: string;
+}
+
+export enum HelmActionOrigins {
+  details = 'details',
+  list = 'list',
+  topology = 'topology',
 }

--- a/frontend/packages/dev-console/src/components/helm/list/HelmReleaseListRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/list/HelmReleaseListRow.tsx
@@ -4,7 +4,7 @@ import { Status } from '@console/shared';
 import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
 import { Timestamp, Kebab, ResourceIcon } from '@console/internal/components/utils';
 import { Link } from 'react-router-dom';
-import { HelmRelease } from '../helm-types';
+import { HelmRelease, HelmActionOrigins } from '../helm-types';
 import { tableColumnClasses } from './HelmReleaseListHeader';
 import {
   deleteHelmRelease,
@@ -14,8 +14,8 @@ import {
 
 const HelmReleaseListRow: RowFunction<HelmRelease> = ({ obj, index, key, style }) => {
   const menuActions = [
-    rollbackHelmRelease(obj.name, obj.namespace),
-    upgradeHelmRelease(obj.name, obj.namespace),
+    upgradeHelmRelease(obj.name, obj.namespace, HelmActionOrigins.list),
+    rollbackHelmRelease(obj.name, obj.namespace, HelmActionOrigins.list),
     deleteHelmRelease(obj.name, obj.namespace),
   ];
   return (

--- a/frontend/packages/dev-console/src/components/topology/actions/helmReleaseActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/helmReleaseActions.ts
@@ -1,21 +1,20 @@
 import { KebabOption } from '@console/internal/components/utils/kebab';
 import { Node } from '@console/topology';
-import { regroupActions } from './regroupActions';
 import {
   deleteHelmRelease,
   upgradeHelmRelease,
   rollbackHelmRelease,
 } from '../../../actions/modify-helm-release';
+import { HelmActionOrigins } from '../../helm/helm-types';
 
 export const helmReleaseActions = (helmRelease: Node): KebabOption[] => {
   const name = helmRelease.getLabel();
   const { namespace } = helmRelease.getData().groupResources[0].resources.obj.metadata;
   return name && namespace
     ? [
-        rollbackHelmRelease(name, namespace),
-        upgradeHelmRelease(name, namespace),
+        upgradeHelmRelease(name, namespace, HelmActionOrigins.topology),
+        rollbackHelmRelease(name, namespace, HelmActionOrigins.topology),
         deleteHelmRelease(name, namespace),
-        ...regroupActions(helmRelease),
       ]
     : [];
 };


### PR DESCRIPTION
**Fixes**:  https://issues.redhat.com/browse/ODC-3676

**Analysis / Root cause**: The helm action forms like upgrade or rollback were not designed to redirect based on context of the origin of the action.

**Solution Description**: Added origin context to helm actions which is then used by the forms to redirect to correct origin of that action.

This PR also includes small changes suggested by UX in final designs like the order and label of Helm actions. It also updates upgrade form description.

**Screen shots / Gifs for design review**: 
cc: @openshift/team-devconsole-ux  @parvathyvr 

Rollback - 
![Rollback Redirects](https://user-images.githubusercontent.com/6041994/80751048-b93d5f00-8b46-11ea-8ce9-c884a23b5445.gif)

Upgrade - 
![Upgrade Redirects](https://user-images.githubusercontent.com/6041994/80751120-e0942c00-8b46-11ea-99ff-1a9faa6a1b33.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge