### PR TITLE
Bug 1830096: Fix helm side panel in topology

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseResourceItem.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseResourceItem.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ResourceLink } from '@console/internal/components/utils';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 
 type TopologyHelmReleaseResourceItemProps = {
   item: K8sResourceKind;
@@ -10,9 +10,9 @@ const TopologyHelmReleaseResourceItem: React.FC<TopologyHelmReleaseResourceItemP
   item,
 }) => {
   const {
-    kind,
     metadata: { name, namespace },
   } = item;
+  const kind = referenceFor(item);
 
   return (
     <li className="list-group-item container-fluid">

--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseResourcesPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseResourcesPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { K8sResourceKind, modelFor } from '@console/internal/module/k8s';
+import { K8sResourceKind, modelFor, referenceFor } from '@console/internal/module/k8s';
 import { SidebarSectionHeading } from '@console/internal/components/utils';
 import TopologyHelmReleaseResourceList from './TopologyHelmReleaseResourceList';
 
@@ -12,8 +12,9 @@ const TopologyHelmReleaseResourcesPanel: React.SFC<TopologyHelmReleaseResourcesP
 }) => {
   const kinds = manifestResources
     .reduce((resourceKinds, resource) => {
-      if (!resourceKinds.includes(resource.kind)) {
-        resourceKinds.push(resource.kind);
+      const kind = referenceFor(resource);
+      if (!resourceKinds.includes(kind)) {
+        resourceKinds.push(kind);
       }
       return resourceKinds;
     }, [])


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3729

**Analysis / Root cause**: The topology side panel for helm was using `resource.kind` to get the model from `modelFor`. Some of the resources like `SecurityContextConstraints` need use group and api versions to create kind. Then only `modelFor` would return correct model. This was not happening and the code was trying to do `model.kind` where `model` was `undefined`. So the UI was breaking with white screen.

**Solution Description**: Use `referenceFor(resource)` to get fully functional `kind` strings of the resource which would then return correct model when used with `modelFor`. Also using `referenceFor` when creating resource link.

**Screen shots / Gifs for design review**: 
![Peek 2020-05-01 01-53](https://user-images.githubusercontent.com/6041994/80755555-aa5aaa80-8b4e-11ea-9685-bd85d6a2fab3.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge