### PR TITLE
Bug 1830080: Prompt user to update traffic on revision deletion

### DIFF
--- a/frontend/packages/knative-plugin/src/actions/delete-revision.ts
+++ b/frontend/packages/knative-plugin/src/actions/delete-revision.ts
@@ -1,0 +1,20 @@
+import { KebabOption } from '@console/internal/components/utils';
+import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { deleteRevisionModal } from '../components/modals';
+
+export const deleteRevision = (model: K8sKind, revision: K8sResourceKind): KebabOption => {
+  return {
+    label: `Delete ${model.label}`,
+    callback: () =>
+      deleteRevisionModal({
+        revision,
+      }),
+    accessReview: {
+      group: model.apiGroup,
+      resource: model.plural,
+      name: revision.metadata.name,
+      namespace: revision.metadata.namespace,
+      verb: 'delete',
+    },
+  };
+};

--- a/frontend/packages/knative-plugin/src/actions/getRevisionActions.ts
+++ b/frontend/packages/knative-plugin/src/actions/getRevisionActions.ts
@@ -1,0 +1,18 @@
+import { Kebab } from '@console/internal/components/utils';
+import { RevisionModel } from '../models';
+import { deleteRevision } from './delete-revision';
+
+export const getRevisionActions = () => {
+  let deleteFound = false;
+  const commonActions = Kebab.factory.common.map((action) => {
+    if (action.name === 'Delete') {
+      deleteFound = true;
+      return deleteRevision;
+    }
+    return action;
+  });
+  if (!deleteFound) {
+    commonActions.push(deleteRevision);
+  }
+  return [...Kebab.getExtensionsActionsForKind(RevisionModel), ...commonActions];
+};

--- a/frontend/packages/knative-plugin/src/components/modals/index.ts
+++ b/frontend/packages/knative-plugin/src/components/modals/index.ts
@@ -7,3 +7,8 @@ export const setSinkSourceModal = (props) =>
   import('../sink-source/SinkSourceController' /* webpackChunkName: "sink-source" */).then((m) =>
     m.sinkModalLauncher(props),
   );
+
+export const deleteRevisionModal = (props) =>
+  import(
+    '../revisions/DeleteRevisionModalController' /* webpackChunkName: "delete-revision" */
+  ).then((m) => m.deleteRevisionModalLauncher(props));

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -9,6 +9,8 @@ import { KNATIVE_SERVING_APIGROUP } from '../../const';
 import { isDynamicEventResourceKind } from '../../utils/fetch-dynamic-eventsources-utils';
 import OverviewDetailsKnativeResourcesTab from './OverviewDetailsKnativeResourcesTab';
 import KnativeOverview from './KnativeOverview';
+import { RevisionModel } from '../../models';
+import { getRevisionActions } from '../../actions/getRevisionActions';
 
 interface StateProps {
   kindsInFlight?: boolean;
@@ -45,11 +47,16 @@ export const KnativeResourceOverviewPage: React.ComponentType<KnativeResourceOve
       model.apiGroup === apiInfo.group &&
       model.apiVersion === apiInfo.version,
   );
+  let actions = [...Kebab.getExtensionsActionsForKind(resourceModel), ...Kebab.factory.common];
+  if (resourceModel.kind === RevisionModel.kind) {
+    actions = getRevisionActions();
+  }
+
   return (
     <ResourceOverviewDetails
       item={item}
       kindObj={resourceModel}
-      menuActions={[...Kebab.getExtensionsActionsForKind(resourceModel), ...Kebab.factory.common]}
+      menuActions={actions}
       tabs={tabs}
     />
   );

--- a/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModal.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { FormikProps, FormikValues } from 'formik';
+import { Alert } from '@patternfly/react-core';
+import { YellowExclamationTriangleIcon } from '@console/shared';
+import {
+  ModalTitle,
+  ModalBody,
+  ModalSubmitFooter,
+} from '@console/internal/components/factory/modal';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { RevisionModel } from '../../models';
+import TrafficSplittingFields from '../traffic-splitting/TrafficSplittingFields';
+import { RevisionItems } from '../../utils/traffic-splitting-utils';
+import { KNATIVE_SERVING_LABEL } from '../../const';
+
+interface TrafficSplittingDeleteModalProps {
+  revisionItems: RevisionItems;
+  deleteRevision: K8sResourceKind;
+  showTraffic: boolean;
+}
+
+type Props = FormikProps<FormikValues> & TrafficSplittingDeleteModalProps;
+
+const DeleteRevisionModal: React.FC<Props> = (props) => {
+  const { deleteRevision, handleSubmit, handleReset, isSubmitting, status, showTraffic } = props;
+  const serviceName = deleteRevision.metadata.labels[KNATIVE_SERVING_LABEL];
+
+  return (
+    <form className="modal-content" onSubmit={handleSubmit}>
+      <ModalTitle>
+        <YellowExclamationTriangleIcon className="co-icon-space-r" /> Delete {RevisionModel.label}?
+      </ModalTitle>
+      <ModalBody>
+        <p>
+          Are you sure you want to delete{' '}
+          <strong className="co-break-word">{deleteRevision.metadata.name}</strong> from{' '}
+          <strong className="co-break-word">{serviceName}</strong> in namespace{' '}
+          <strong>{deleteRevision.metadata.namespace}</strong>?
+        </p>
+        {showTraffic && (
+          <>
+            <Alert
+              isInline
+              className="co-alert"
+              variant="default"
+              title="Update the traffic distribution among the remaining Revisions"
+            />
+            <TrafficSplittingFields {...props} />
+          </>
+        )}
+      </ModalBody>
+      <ModalSubmitFooter
+        inProgress={isSubmitting}
+        submitText="Delete"
+        cancel={handleReset}
+        errorMessage={status.error}
+        submitDanger
+      />
+    </form>
+  );
+};
+
+export default DeleteRevisionModal;

--- a/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModalController.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/DeleteRevisionModalController.tsx
@@ -1,0 +1,190 @@
+import * as React from 'react';
+import { Formik, FormikHelpers, FormikValues } from 'formik';
+import { ActionGroup, Button } from '@patternfly/react-core';
+import { RedExclamationCircleIcon } from '@console/shared';
+import {
+  k8sKill,
+  K8sResourceKind,
+  k8sUpdate,
+  referenceForModel,
+} from '@console/internal/module/k8s';
+import {
+  Firehose,
+  FirehoseResult,
+  history,
+  resourceListPathFromModel,
+} from '@console/internal/components/utils';
+import {
+  createModalLauncher,
+  ModalBody,
+  ModalComponentProps,
+  ModalFooter,
+  ModalTitle,
+} from '@console/internal/components/factory';
+import { KNATIVE_SERVING_LABEL } from '../../const';
+import { RevisionModel, ServiceModel } from '../../models';
+import {
+  transformTrafficSplittingData,
+  knativeServingResourcesTrafficSplitting,
+  getRevisionItems,
+  constructObjForUpdate,
+} from '../../utils/traffic-splitting-utils';
+import { TrafficSplittingType } from '../traffic-splitting/TrafficSplitting';
+import DeleteRevisionModal from './DeleteRevisionModal';
+
+type ControllerProps = {
+  loaded?: boolean;
+  revision?: K8sResourceKind;
+  resources?: {
+    configurations: FirehoseResult;
+    revisions: FirehoseResult;
+    services: FirehoseResult;
+  };
+  cancel?: () => void;
+  close?: () => void;
+};
+
+const Controller: React.FC<ControllerProps> = ({ loaded, resources, revision, cancel, close }) => {
+  if (!loaded) {
+    return null;
+  }
+  const service = resources.services.data.find((s: K8sResourceKind) => {
+    return revision.metadata.labels[KNATIVE_SERVING_LABEL] === s.metadata.name;
+  });
+
+  const revisions = transformTrafficSplittingData(service, resources).filter(
+    (r) => revision.metadata.uid !== r.metadata.uid,
+  );
+
+  if (revisions.length === 0) {
+    return (
+      <form className="modal-content" onSubmit={close}>
+        <ModalTitle>
+          <RedExclamationCircleIcon className="co-icon-space-r" />
+          Unable to delete {RevisionModel.label}
+        </ModalTitle>
+        <ModalBody>
+          <p>
+            You cannot delete the last {RevisionModel.label} for the {ServiceModel.label}.
+          </p>
+        </ModalBody>
+        <ModalFooter inProgress={false}>
+          <ActionGroup className="pf-c-form pf-c-form__actions--right pf-c-form__group--no-top-margin">
+            <Button
+              type="button"
+              variant="secondary"
+              data-test-id="modal-cancel-action"
+              onClick={close}
+            >
+              OK
+            </Button>
+          </ActionGroup>
+        </ModalFooter>
+      </form>
+    );
+  }
+
+  const revisionItems = getRevisionItems(revisions);
+
+  const traffic = service?.status?.traffic ?? [{ percent: 0, tag: '', revisionName: '' }];
+  const deleteTraffic = traffic.find((t) => t.revisionName === revision.metadata.name);
+
+  const initialValues: TrafficSplittingType = {
+    trafficSplitting: traffic.reduce((acc, t) => {
+      if (!t.revisionName || revisions.find((r) => r.metadata.name === t.revisionName)) {
+        acc.push({
+          percent: t.percent,
+          tag: t.tag || '',
+          revisionName: t.revisionName || '',
+        });
+      }
+      return acc;
+    }, []),
+  };
+
+  if (initialValues.trafficSplitting.length === 0 && revisions.length > 0) {
+    initialValues.trafficSplitting.push({
+      percent: 0,
+      tag: '',
+      revisionName: revisions[0].metadata.name,
+    });
+  }
+
+  const deleteRevision = (action: FormikHelpers<FormikValues>) => {
+    k8sKill(RevisionModel, revision)
+      .then(() => {
+        close();
+        // If we are currently on the deleted revision's page, redirect to the list page
+        const re = new RegExp(`/${revision.metadata.name}(/|$)`);
+        if (re.test(window.location.pathname)) {
+          history.push(resourceListPathFromModel(RevisionModel, revision.metadata.namespace));
+        }
+      })
+      .catch((err) => {
+        action.setStatus({ error: err.message || 'An error occurred. Please try again' });
+      });
+  };
+
+  const handleSubmit = (values: FormikValues, action: FormikHelpers<FormikValues>) => {
+    const obj = constructObjForUpdate(values.trafficSplitting, service);
+    if (!deleteTraffic || deleteTraffic.percent === 0) {
+      deleteRevision(action);
+      return;
+    }
+
+    k8sUpdate(ServiceModel, obj)
+      .then(() => {
+        deleteRevision(action);
+      })
+      .catch((err) => {
+        action.setStatus({ error: err.message || 'An error occurred. Please try again' });
+      });
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      onSubmit={handleSubmit}
+      onReset={cancel}
+      initialStatus={{ error: '' }}
+    >
+      {(modalProps) => (
+        <DeleteRevisionModal
+          {...modalProps}
+          revisionItems={revisionItems}
+          deleteRevision={revision}
+          showTraffic={deleteTraffic?.percent > 0}
+        />
+      )}
+    </Formik>
+  );
+};
+
+type DeleteRevisionModalControllerProps = {
+  revision: K8sResourceKind;
+};
+
+const DeleteRevisionModalController: React.FC<DeleteRevisionModalControllerProps> = (props) => {
+  const {
+    metadata: { namespace },
+  } = props.revision;
+  const resources = knativeServingResourcesTrafficSplitting(namespace);
+  resources.push({
+    isList: true,
+    kind: referenceForModel(ServiceModel),
+    namespace,
+    prop: 'services',
+  });
+
+  return (
+    <Firehose resources={resources}>
+      <Controller {...props} />
+    </Firehose>
+  );
+};
+
+type Props = DeleteRevisionModalControllerProps & ModalComponentProps;
+
+export const deleteRevisionModalLauncher = createModalLauncher<Props>(
+  DeleteRevisionModalController,
+);

--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionDetailsPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionDetailsPage.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { DetailsPage } from '@console/internal/components/factory';
+import { navFactory } from '@console/internal/components/utils';
+import { DetailsForKind } from '@console/internal/components/default-resource';
+import { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
+import { getRevisionActions } from '../../actions/getRevisionActions';
+
+const RevisionsPage: React.FC<React.ComponentProps<typeof DetailsPage>> = (props) => {
+  const pages = [navFactory.details(DetailsForKind(props.kind)), navFactory.editYaml()];
+  const menuActionsCreator = (kindObj: K8sKind, obj: K8sResourceKind) =>
+    getRevisionActions().map((action) => action(kindObj, obj));
+
+  return <DetailsPage {...props} pages={pages} menuActions={menuActionsCreator} />;
+};
+
+export default RevisionsPage;

--- a/frontend/packages/knative-plugin/src/components/revisions/RevisionRow.tsx
+++ b/frontend/packages/knative-plugin/src/components/revisions/RevisionRow.tsx
@@ -2,12 +2,13 @@ import * as React from 'react';
 import * as cx from 'classnames';
 import * as _ from 'lodash';
 import { TableRow, TableData, RowFunction } from '@console/internal/components/factory';
-import { Kebab, ResourceLink, ResourceKebab, Timestamp } from '@console/internal/components/utils';
+import { ResourceLink, ResourceKebab, Timestamp } from '@console/internal/components/utils';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { RevisionModel, ServiceModel } from '../../models';
 import { getConditionString, getCondition } from '../../utils/condition-utils';
 import { RevisionKind, ConditionTypes } from '../../types';
 import { tableColumnClasses } from './revision-table';
+import { getRevisionActions } from '../../actions/getRevisionActions';
 
 const revisionReference = referenceForModel(RevisionModel);
 const serviceReference = referenceForModel(ServiceModel);
@@ -53,7 +54,7 @@ const RevisionRow: RowFunction<RevisionKind> = ({ obj, index, key, style }) => {
         {(readyCondition && readyCondition.message) || '-'}
       </TableData>
       <TableData className={tableColumnClasses[7]}>
-        <ResourceKebab actions={Kebab.factory.common} kind={revisionReference} resource={obj} />
+        <ResourceKebab actions={getRevisionActions()} kind={revisionReference} resource={obj} />
       </TableData>
     </TableRow>
   );

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
@@ -18,7 +18,7 @@ export interface TrafficSplittingType {
     percent: number;
     tag: string;
     revisionName: string;
-  };
+  }[];
 }
 
 const TrafficSplitting: React.FC<TrafficSplittingProps> = ({

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingController.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingController.tsx
@@ -3,7 +3,7 @@ import { K8sResourceKind } from '@console/internal/module/k8s';
 import { Firehose, FirehoseResult } from '@console/internal/components/utils';
 import { createModalLauncher, ModalComponentProps } from '@console/internal/components/factory';
 import {
-  transformTrafficSplitingData,
+  transformTrafficSplittingData,
   knativeServingResourcesTrafficSplitting,
 } from '../../utils/traffic-splitting-utils';
 import TrafficSplitting from './TrafficSplitting';
@@ -19,7 +19,7 @@ type ControllerProps = {
 
 const Controller: React.FC<ControllerProps> = (props) => {
   const { loaded, obj, resources } = props;
-  const revisions = transformTrafficSplitingData(obj, resources);
+  const revisions = transformTrafficSplittingData(obj, resources);
   return loaded ? <TrafficSplitting {...props} service={obj} revisions={revisions} /> : null;
 };
 

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingFields.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingFields.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { FormikProps, FormikValues } from 'formik';
+import { TextInputTypes } from '@patternfly/react-core';
+import { MultiColumnField, InputField, DropdownField } from '@console/shared';
+import { RevisionItems } from '../../utils/traffic-splitting-utils';
+
+interface TrafficSplittingFieldProps {
+  revisionItems: RevisionItems;
+}
+
+type Props = FormikProps<FormikValues> & TrafficSplittingFieldProps;
+
+const TrafficSplittingFields: React.FC<Props> = ({ revisionItems, values }) => {
+  return (
+    <MultiColumnField
+      name="trafficSplitting"
+      addLabel="Add Revision"
+      headers={['Split', 'Tag', 'Revision']}
+      emptyValues={{ percent: '', tag: '', revisionName: '' }}
+      disableDeleteRow={values.trafficSplitting.length === 1}
+      spans={[2, 3, 7]}
+    >
+      <InputField
+        name="percent"
+        type={TextInputTypes.number}
+        placeholder="100"
+        style={{ maxWidth: '100%' }}
+        required
+      />
+      <InputField name="tag" type={TextInputTypes.text} />
+      <DropdownField
+        name="revisionName"
+        items={revisionItems}
+        title="Select a revision"
+        fullWidth
+        required
+      />
+    </MultiColumnField>
+  );
+};
+
+export default TrafficSplittingFields;

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
@@ -5,52 +5,23 @@ import {
   ModalBody,
   ModalSubmitFooter,
 } from '@console/internal/components/factory/modal';
-import { TextInputTypes } from '@patternfly/react-core';
-import { MultiColumnField, InputField, DropdownField } from '@console/shared';
+import TrafficSplittingFields from './TrafficSplittingFields';
+import { RevisionItems } from '../../utils/traffic-splitting-utils';
 
-export interface TrafficSplittingModalProps {
-  revisionItems: any;
+interface TrafficSplittingModalProps {
+  revisionItems: RevisionItems;
 }
 
 type Props = FormikProps<FormikValues> & TrafficSplittingModalProps;
 
-const TrafficSplittingModal: React.FC<Props> = ({
-  revisionItems,
-  handleSubmit,
-  handleReset,
-  isSubmitting,
-  status,
-  values,
-}) => {
+const TrafficSplittingModal: React.FC<Props> = (props) => {
+  const { handleSubmit, handleReset, isSubmitting, status } = props;
   return (
     <form className="modal-content" onSubmit={handleSubmit}>
       <ModalTitle>Set Traffic Distribution</ModalTitle>
       <ModalBody>
         <p>Set traffic distribution for the Revisions of the Knative Service</p>
-        <MultiColumnField
-          name="trafficSplitting"
-          addLabel="Add Revision"
-          headers={['Split', 'Tag', 'Revision']}
-          emptyValues={{ percent: '', tag: '', revisionName: '' }}
-          disableDeleteRow={values.trafficSplitting.length === 1}
-          spans={[2, 3, 7]}
-        >
-          <InputField
-            name="percent"
-            type={TextInputTypes.number}
-            placeholder="100"
-            style={{ maxWidth: '100%' }}
-            required
-          />
-          <InputField name="tag" type={TextInputTypes.text} />
-          <DropdownField
-            name="revisionName"
-            items={revisionItems}
-            title="Select a revision"
-            fullWidth
-            required
-          />
-        </MultiColumnField>
+        <TrafficSplittingFields {...props} />
       </ModalBody>
       <ModalSubmitFooter
         inProgress={isSubmitting}

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingFields.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingFields.spec.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { MultiColumnField } from '@console/shared';
+import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
+import {
+  mockTrafficData,
+  mockRevisionItems,
+} from '../../../utils/__mocks__/traffic-splitting-utils-mock';
+import TrafficSplittingFields from '../TrafficSplittingFields';
+
+const formProps = {
+  ...formikFormProps,
+  status: { error: 'checkErrorProp' },
+  values: { trafficSplitting: mockTrafficData },
+  revisionItems: mockRevisionItems,
+};
+
+describe('TrafficSplittingFields', () => {
+  it('should disable delete row button for one value', () => {
+    const wrapper = shallow(
+      <TrafficSplittingFields
+        {...formProps}
+        revisionItems={{ 'overlayimage-fdqsf': 'overlayimage-fdqsf' }}
+        values={{ trafficSplitting: [{ percent: 100, revisionName: 'overlayimage-fdqsf' }] }}
+      />,
+    );
+    expect(
+      wrapper
+        .find(MultiColumnField)
+        .first()
+        .props().disableDeleteRow,
+    ).toBe(true);
+  });
+
+  it('should not disable delete row button for more than one values', () => {
+    const wrapper = shallow(<TrafficSplittingFields {...formProps} />);
+    expect(
+      wrapper
+        .find(MultiColumnField)
+        .first()
+        .props().disableDeleteRow,
+    ).toBe(false);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingModal.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingModal.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
-import { MultiColumnField } from '@console/shared';
-import { ModalBody, ModalSubmitFooter } from '@console/internal/components/factory/modal';
+import { ModalSubmitFooter } from '@console/internal/components/factory/modal';
 import { formikFormProps } from '@console/shared/src/test-utils/formik-props-utils';
 import TrafficSplittingModal from '../TrafficSplittingModal';
 import {
@@ -22,35 +21,6 @@ describe('TrafficSplittingModal', () => {
       revisionItems: mockRevisionItems,
     };
     wrapper = shallow(<TrafficSplittingModal {...formProps} />);
-  });
-
-  it('should disable delete row button for one value', () => {
-    wrapper = shallow(
-      <TrafficSplittingModal
-        {...formProps}
-        revisionItems={[{ 'overlayimage-fdqsf': 'overlayimage-fdqsf' }]}
-        values={{ trafficSplitting: [{ percent: 100, revisionName: 'overlayimage-fdqsf' }] }}
-      />,
-    );
-    expect(
-      wrapper
-        .find(ModalBody)
-        .dive()
-        .find(MultiColumnField)
-        .first()
-        .props().disableDeleteRow,
-    ).toBe(true);
-  });
-
-  it('should not disable delete row button for more than one values', () => {
-    expect(
-      wrapper
-        .find(ModalBody)
-        .dive()
-        .find(MultiColumnField)
-        .first()
-        .props().disableDeleteRow,
-    ).toBe(false);
   });
 
   it('should render modal footer with proper values', () => {

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -222,6 +222,18 @@ const plugin: Plugin<ConsumedExtensions> = [
     },
   },
   {
+    type: 'Page/Resource/Details',
+    properties: {
+      model: models.RevisionModel,
+      loader: async () =>
+        (
+          await import(
+            './components/revisions/RevisionDetailsPage' /* webpackChunkName: "knative-revisions-details page" */
+          )
+        ).default,
+    },
+  },
+  {
     type: 'Page/Resource/List',
     properties: {
       model: models.ServiceModel,

--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentFactory.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   GraphElement,
+  Node,
   ComponentFactory as TopologyComponentFactory,
   withDragNode,
   withTargetDrag,
@@ -15,6 +16,9 @@ import {
   nodeDragSourceSpec,
   withEditReviewAccess,
   nodeContextMenu,
+  createMenuItems,
+  TopologyDataObject,
+  getTopologyResourceObject,
 } from '@console/dev-console/src/components/topology';
 import {
   TYPE_EVENT_SOURCE,
@@ -33,6 +37,22 @@ import {
   eventSourceTargetSpec,
   knativeServiceDropTargetSpec,
 } from './knativeComponentUtils';
+import { KebabOption, kebabOptionsToMenu } from '@console/internal/components/utils';
+import { RevisionModel } from '../../models';
+import { getRevisionActions } from '../../actions/getRevisionActions';
+
+const revisionActions = (node: TopologyDataObject): KebabOption[] => {
+  const contextMenuResource = getTopologyResourceObject(node);
+  if (!contextMenuResource) {
+    return null;
+  }
+
+  const menuActions = getRevisionActions();
+  return menuActions.map((a) => a(RevisionModel, contextMenuResource));
+};
+
+const revisionContextMenu = (element: Node) =>
+  createMenuItems(kebabOptionsToMenu(revisionActions(element.getData())));
 
 class KnativeComponentFactory extends AbstractSBRComponentFactory {
   getFactory = (): TopologyComponentFactory => {
@@ -69,7 +89,7 @@ class KnativeComponentFactory extends AbstractSBRComponentFactory {
             withSelection(
               false,
               true,
-            )(withContextMenu(nodeContextMenu)(withNoDrop()(RevisionNode))),
+            )(withContextMenu(revisionContextMenu)(withNoDrop()(RevisionNode))),
           );
         case TYPE_REVISION_TRAFFIC:
           return TrafficLink;

--- a/frontend/packages/knative-plugin/src/utils/traffic-splitting-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/traffic-splitting-utils.ts
@@ -7,11 +7,13 @@ import {
   knativeServingResourcesConfigurations,
 } from './get-knative-resources';
 
-export const getRevisionItems = (revisions: K8sResourceKind[]) => {
+export type RevisionItems = { [name: string]: string };
+
+export const getRevisionItems = (revisions: K8sResourceKind[]): RevisionItems => {
   return revisions.reduce((acc, currValue) => {
     acc[currValue.metadata.name] = currValue.metadata.name;
     return acc;
-  }, {});
+  }, {} as RevisionItems);
 };
 
 export const constructObjForUpdate = (traffic, service) => {
@@ -22,7 +24,7 @@ export const constructObjForUpdate = (traffic, service) => {
   };
 };
 
-export const transformTrafficSplitingData = (
+export const transformTrafficSplittingData = (
   obj: K8sResourceKind,
   resources,
 ): K8sResourceKind[] => {

--- a/frontend/public/components/default-resource.jsx
+++ b/frontend/public/components/default-resource.jsx
@@ -88,7 +88,7 @@ const TableRowForKind = ({ obj, index, key, style, customData }) => {
   );
 };
 
-const DetailsForKind = (kind) =>
+export const DetailsForKind = (kind) =>
   function DetailsForKind_({ obj }) {
     const conditions = obj.status && obj.status.conditions;
     return (


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2413

**Analysis / Root cause**: 
Users are allowed to delete revisions w/o adjusting traffic distribution.
Users are allowed to delete the last revision in a knative service.

**Solution Description**: 
When a revision is deleted, check if it is the only revision in the service, if so prevent the deletions and inform the user.

When a revision is ok to delete, prompt the user to update the traffic distribution prior to deleting the revision.

**Screen shots / Gifs for design review**:
Single Revision being deleted:
![image](https://user-images.githubusercontent.com/11633780/80754782-a3577c00-8afd-11ea-9a60-2fa4a485129d.png)

One of three revisions being deleted:
![image](https://user-images.githubusercontent.com/11633780/80754818-b1a59800-8afd-11ea-9483-6c61ead82a06.png)

One of two revisions being deleted where the second currently receives no traffic:
![image](https://user-images.githubusercontent.com/11633780/80754841-b9fdd300-8afd-11ea-8190-cba61adebcfc.png)

Process of deleting a revision:
![DeleteRev](https://user-images.githubusercontent.com/11633780/80755728-54aae180-8aff-11ea-99b0-97134343f1fb.gif)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley 

/kind bug