### PR TITLE
Bug 1830144:  Fix bug where edit yaml sidebar contents can be narrowe…

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -452,7 +452,7 @@ export const EditYAML_ = connect(stateToProps)(
             </div>
           )}
 
-          <div className="pf-c-form co-m-page__body" style={{ display: 'flex', flexGrow: 1 }}>
+          <div className="pf-c-form co-m-page__body">
             <div className="co-p-has-sidebar">
               <div className="co-p-has-sidebar__body">
                 <div

--- a/frontend/public/components/sidebars/resource-sidebar.jsx
+++ b/frontend/public/components/sidebars/resource-sidebar.jsx
@@ -21,7 +21,7 @@ class ResourceSidebarWrapper extends React.Component {
 
     return (
       <div className="co-p-has-sidebar__sidebar co-p-has-sidebar__sidebar--bordered hidden-sm hidden-xs">
-        <div className="co-m-pane__body" style={{ position: 'absolute' }}>
+        <div className="co-m-pane__body co-p-has-sidebar__sidebar-body">
           <Button
             type="button"
             className="co-p-has-sidebar__sidebar-close"

--- a/frontend/public/style/_layout.scss
+++ b/frontend/public/style/_layout.scss
@@ -57,6 +57,11 @@ body,
     }
   }
 
+  &__sidebar-body {
+    position: absolute;
+    width: 100%;
+  }
+
   &__sidebar-heading {
     @include co-break-word;
     margin-bottom: 20px;


### PR DESCRIPTION
…r than sidebar

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1830144

Before:
<img width="2065" alt="Screen Shot 2020-04-30 at 6 33 36 PM" src="https://user-images.githubusercontent.com/895728/80765482-20402100-8b11-11ea-92a9-996121f0c280.png">

After:
<img width="2064" alt="Screen Shot 2020-04-30 at 6 31 51 PM" src="https://user-images.githubusercontent.com/895728/80765429-fdae0800-8b10-11ea-8e74-979054d6c4fd.png">
