### PR TITLE
Bug 1830181: Hide 'Start Last Run' button on topology overview page when no PLR present

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/triggered-by/hooks.ts
+++ b/frontend/packages/dev-console/src/components/pipelineruns/triggered-by/hooks.ts
@@ -26,7 +26,7 @@ export const useUserLabelForManualStart = (): LabelMap => {
 export const usePipelineRunWithUserLabel = (plr: PipelineRun): PipelineRun => {
   const labels = useUserLabelForManualStart();
 
-  return mergeLabelsWithResource(labels, plr);
+  return plr && mergeLabelsWithResource(labels, plr);
 };
 
 export const useMenuActionsWithUserLabel = (menuActions: KebabAction[]): KebabAction[] => {

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/PipelineOverview.tsx
@@ -52,7 +52,7 @@ const PipelinesOverview: React.FC<PipelinesOverviewProps> = ({
               />
             </FlexItem>
             <FlexItem>
-              <TriggerLastRunButton pipelineRuns={pipelineRuns} />
+              <TriggerLastRunButton pipelineRuns={pipelineRuns} namespace={namespace} />
             </FlexItem>
           </Flex>
         </li>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/TriggerLastRunButton.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-overview/TriggerLastRunButton.tsx
@@ -1,30 +1,48 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import { connect } from 'react-redux';
+import { Button } from '@patternfly/react-core';
 import { impersonateStateToProps } from '@console/internal/reducers/ui';
 import { useAccessReview } from '@console/internal/components/utils';
-import { Button } from '@patternfly/react-core';
+import { AccessReviewResourceAttributes } from '@console/internal/module/k8s';
 import { rerunPipelineAndStay } from '../../../utils/pipeline-actions';
-import { PipelineModel } from '../../../models';
+import { PipelineRunModel } from '../../../models';
 import { usePipelineRunWithUserLabel } from '../../pipelineruns/triggered-by';
 import { getLatestRun, PipelineRun } from '../../../utils/pipeline-augment';
 
 type TriggerLastRunButtonProps = {
   pipelineRuns: PipelineRun[];
+  namespace: string;
   impersonate?;
 };
 
 const TriggerLastRunButton: React.FC<TriggerLastRunButtonProps> = ({
   pipelineRuns,
+  namespace,
   impersonate,
 }) => {
   const latestRun = usePipelineRunWithUserLabel(
     getLatestRun({ data: pipelineRuns }, 'startTimestamp'),
   );
-  const { label, callback, accessReview } = rerunPipelineAndStay(PipelineModel, latestRun);
+  const { label, callback, accessReview: utilityAccessReview } = rerunPipelineAndStay(
+    PipelineRunModel,
+    latestRun,
+  );
+  const defaultAccessReview: AccessReviewResourceAttributes = {
+    group: PipelineRunModel.apiGroup,
+    resource: PipelineRunModel.plural,
+    namespace,
+    verb: 'create',
+  };
+  const accessReview = _.isEmpty(utilityAccessReview) ? defaultAccessReview : utilityAccessReview;
   const isAllowed = useAccessReview(accessReview, impersonate);
   return (
     isAllowed && (
-      <Button variant="secondary" onClick={callback} isDisabled={pipelineRuns.length === 0}>
+      <Button
+        variant="secondary"
+        onClick={callback}
+        isDisabled={pipelineRuns.length === 0 && !callback}
+      >
         {label}
       </Button>
     )


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2403

**Analysis / Root cause**: 
When viewing the Pipeline Runs in the overview sidebar of topology, the consoledeveloper doesn't see the button when there are no pipeline runs, but does as soon as there are.

**Solution Description**: 
Hide 'Start Last Run' button on topology overview page when no PLR present. For admin as well as for developer.

**Screen shots / Gifs for design review**: 
<img width="1521" alt="Screenshot 2020-05-05 at 1 51 38 AM" src="https://user-images.githubusercontent.com/2561818/81010203-827f8580-8e73-11ea-81bb-bdd53c1f3ce5.png">
<img width="1512" alt="Screenshot 2020-05-05 at 1 52 14 AM" src="https://user-images.githubusercontent.com/2561818/81010213-86aba300-8e73-11ea-953c-51d146c8e36a.png">
<img width="1508" alt="Screenshot 2020-05-05 at 1 47 07 AM" src="https://user-images.githubusercontent.com/2561818/81010251-975c1900-8e73-11ea-953f-962f7c914d01.png">
<img width="1517" alt="Screenshot 2020-05-05 at 1 49 09 AM" src="https://user-images.githubusercontent.com/2561818/81010261-9b883680-8e73-11ea-9c05-6095fe9cbfec.png">
<img width="1504" alt="Screenshot 2020-05-05 at 1 46 37 AM" src="https://user-images.githubusercontent.com/2561818/81010381-d4c0a680-8e73-11ea-92be-6ea7731c2429.png">




**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
