### PR TITLE
Bug 1830259: Do not allow regrouping of helm charts or OBS groupings

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/actions/workloadActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/actions/workloadActions.ts
@@ -5,31 +5,38 @@ import { menuActions as deploymentConfigMenuActions } from '@console/internal/co
 import { menuActions as deploymentMenuActions } from '@console/internal/components/deployment';
 import { menuActions as statefulSetMenuActions } from '@console/internal/components/stateful-set';
 import { menuActions as daemonSetMenuActions } from '@console/internal/components/daemon-set';
+import { ModifyApplication } from '../../../actions/modify-application';
 import { TopologyDataObject } from '../topology-types';
 import { getTopologyResourceObject } from '../topology-utils';
 
-export const workloadActions = (workload: TopologyDataObject): KebabOption[] => {
+export const workloadActions = (
+  workload: TopologyDataObject,
+  allowRegroup: boolean = true,
+): KebabOption[] => {
   const contextMenuResource = getTopologyResourceObject(workload);
   if (!contextMenuResource) {
     return null;
   }
 
-  let menuActions: KebabAction[];
+  const menuActions: KebabAction[] = [];
+  if (allowRegroup) {
+    menuActions.push(ModifyApplication);
+  }
   switch (contextMenuResource.kind) {
     case 'DeploymentConfig':
-      menuActions = deploymentConfigMenuActions;
+      menuActions.push(...deploymentConfigMenuActions);
       break;
     case 'Deployment':
-      menuActions = deploymentMenuActions;
+      menuActions.push(...deploymentMenuActions);
       break;
     case 'StatefulSet':
-      menuActions = statefulSetMenuActions;
+      menuActions.push(...statefulSetMenuActions);
       break;
     case 'DaemonSet':
-      menuActions = daemonSetMenuActions;
+      menuActions.push(...daemonSetMenuActions);
       break;
     default:
-      menuActions = [];
+      break;
   }
 
   return _.map(menuActions, (a) =>

--- a/frontend/packages/dev-console/src/components/topology/components/nodeContextMenu.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodeContextMenu.tsx
@@ -14,7 +14,6 @@ import { nodeActions } from '../actions/nodeActions';
 import { graphActions } from '../actions/graphActions';
 import { TopologyApplicationObject } from '../topology-types';
 import { regroupActions } from '../actions/regroupActions';
-import { helmReleaseActions } from '../actions/helmReleaseActions';
 
 const onKebabOptionClick = (option: KebabOption) => {
   if (option.callback) {
@@ -42,6 +41,9 @@ export const createMenuItems = (actions: KebabMenuOption[]) =>
 export const workloadContextMenu = (element: Node) =>
   createMenuItems(kebabOptionsToMenu(workloadActions(element.getData())));
 
+export const noRegroupWorkloadContextMenu = (element: Node) =>
+  createMenuItems(kebabOptionsToMenu(workloadActions(element.getData(), false)));
+
 export const groupContextMenu = (element: Node, connectorSource?: Node) => {
   const applicationData: TopologyApplicationObject = {
     id: element.getId(),
@@ -65,6 +67,3 @@ export const regroupContextMenu = (element: Node) =>
 
 export const regroupGroupContextMenu = (element: Node) =>
   createMenuItems(kebabOptionsToMenu(regroupActions(element, true)));
-
-export const helmReleaseContextMenu = (element: Node) =>
-  createMenuItems(kebabOptionsToMenu(helmReleaseActions(element)));

--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleasePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleasePanel.tsx
@@ -11,8 +11,8 @@ import {
 import * as UIActions from '@console/internal/actions/ui';
 import { Node } from '@console/topology';
 import HelmReleaseOverview from '../../helm/details/overview/HelmReleaseOverview';
+import { helmReleaseActions } from './actions/helmReleaseActions';
 import TopologyHelmReleaseResourcesPanel from './TopologyHelmReleaseResourcesPanel';
-import { helmReleaseActions } from '../actions/helmReleaseActions';
 import TopologyHelmReleaseNotesPanel from './TopologyHelmReleaseNotesPanel';
 
 type PropsFromState = {

--- a/frontend/packages/dev-console/src/components/topology/helm/actions/helmReleaseActions.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/actions/helmReleaseActions.ts
@@ -4,8 +4,8 @@ import {
   deleteHelmRelease,
   upgradeHelmRelease,
   rollbackHelmRelease,
-} from '../../../actions/modify-helm-release';
-import { HelmActionOrigins } from '../../helm/helm-types';
+} from '../../../../actions/modify-helm-release';
+import { HelmActionOrigins } from '../../../helm/helm-types';
 
 export const helmReleaseActions = (helmRelease: Node): KebabOption[] => {
   const name = helmRelease.getLabel();

--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseGroup.tsx
@@ -40,18 +40,12 @@ const HelmReleaseGroup: React.FC<HelmReleaseGroupProps> = ({
 }) => {
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
-  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_HELM_RELEASE, true, editAccess),
-    {
-      element,
-    },
-  );
-  const [{ dragging: labelDragging, regrouping: labelRegrouping }, dragLabelRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_HELM_RELEASE, true, editAccess),
-    {
-      element,
-    },
-  );
+  const dragSpec = nodeDragSourceSpec(TYPE_HELM_RELEASE, false);
+  const [{ dragging, regrouping }, dragNodeRef] = useDragNode(dragSpec, { element });
+  const [
+    { dragging: labelDragging, regrouping: labelRegrouping },
+    dragLabelRef,
+  ] = useDragNode(dragSpec, { element });
 
   const nodeRefs = useCombineRefs(innerHoverRef, dragNodeRef);
   const [filtered] = useSearchFilter(element.getLabel());

--- a/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/HelmReleaseNode.tsx
@@ -41,12 +41,9 @@ const HelmReleaseNode: React.FC<HelmReleaseNodeProps> = ({
 }) => {
   useAnchor(React.useCallback((node: Node) => new RectAnchor(node, 1.5), []));
   const [hover, hoverRef] = useHover();
-  const [{ dragging }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_HELM_RELEASE, true, editAccess),
-    {
-      element,
-    },
-  );
+  const [{ dragging }, dragNodeRef] = useDragNode(nodeDragSourceSpec(TYPE_HELM_RELEASE, false), {
+    element,
+  });
   const refs = useCombineRefs<SVGRectElement>(dragNodeRef, dndDropRef, hoverRef);
   const [filtered] = useSearchFilter(element.getLabel());
   const { width, height } = element.getDimensions();

--- a/frontend/packages/dev-console/src/components/topology/helm/components/helmComponentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/components/helmComponentFactory.ts
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import {
+  Node,
   GraphElement,
   ComponentFactory as TopologyComponentFactory,
   withDragNode,
   withSelection,
   withDndDrop,
 } from '@console/topology';
+import { kebabOptionsToMenu } from '@console/internal/components/utils';
 import { WorkloadNode } from '../../components/nodes';
-import { workloadContextMenu, helmReleaseContextMenu } from '../../components/nodeContextMenu';
+import { noRegroupWorkloadContextMenu, createMenuItems } from '../../components/nodeContextMenu';
 import {
   NodeComponentProps,
   nodeDragSourceSpec,
@@ -15,10 +17,14 @@ import {
   withContextMenu,
   withNoDrop,
 } from '../../components/componentUtils';
-import { TYPE_HELM_RELEASE, TYPE_HELM_WORKLOAD } from './const';
 import { withEditReviewAccess } from '../../components/withEditReviewAccess';
-import HelmRelease from './HelmRelease';
 import { AbstractSBRComponentFactory } from '../../components/AbstractSBRComponentFactory';
+import { helmReleaseActions } from '../actions/helmReleaseActions';
+import { TYPE_HELM_RELEASE, TYPE_HELM_WORKLOAD } from './const';
+import HelmRelease from './HelmRelease';
+
+export const helmReleaseContextMenu = (element: Node) =>
+  createMenuItems(kebabOptionsToMenu(helmReleaseActions(element)));
 
 class HelmComponentFactory extends AbstractSBRComponentFactory {
   getFactory = (): TopologyComponentFactory => {
@@ -39,7 +45,10 @@ class HelmComponentFactory extends AbstractSBRComponentFactory {
             >(nodeDropTargetSpec)(
               withEditReviewAccess('patch')(
                 withDragNode(nodeDragSourceSpec(type, false))(
-                  withSelection(false, true)(withContextMenu(workloadContextMenu)(WorkloadNode)),
+                  withSelection(
+                    false,
+                    true,
+                  )(withContextMenu(noRegroupWorkloadContextMenu)(WorkloadNode)),
                 ),
               ),
             ),

--- a/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceGroup.tsx
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/OperatorBackedServiceGroup.tsx
@@ -41,13 +41,13 @@ const OperatorBackedServiceGroup: React.FC<OperatorBackedServiceGroupProps> = ({
   const [hover, hoverRef] = useHover();
   const [innerHover, innerHoverRef] = useHover();
   const [{ dragging, regrouping }, dragNodeRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, true, editAccess),
+    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
     {
       element,
     },
   );
   const [{ dragging: labelDragging, regrouping: labelRegrouping }, dragLabelRef] = useDragNode(
-    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, true, editAccess),
+    nodeDragSourceSpec(TYPE_OPERATOR_BACKED_SERVICE, false),
     {
       element,
     },

--- a/frontend/packages/dev-console/src/components/topology/operators/components/operatorsComponentFactory.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/components/operatorsComponentFactory.ts
@@ -8,8 +8,7 @@ import {
 } from '@console/topology';
 import { WorkloadNode } from '../../components/nodes';
 import {
-  workloadContextMenu,
-  regroupGroupContextMenu,
+  noRegroupWorkloadContextMenu,
   NodeComponentProps,
   nodeDragSourceSpec,
   nodeDropTargetSpec,
@@ -26,10 +25,7 @@ class OperatorsComponentFactory extends AbstractSBRComponentFactory {
     return (kind, type): React.ComponentType<{ element: GraphElement }> | undefined => {
       switch (type) {
         case TYPE_OPERATOR_BACKED_SERVICE:
-          return withSelection(
-            false,
-            true,
-          )(withContextMenu(regroupGroupContextMenu)(withNoDrop()(OperatorBackedService)));
+          return withSelection(false, true)(withNoDrop()(OperatorBackedService));
         case TYPE_OPERATOR_WORKLOAD:
           return this.withAddResourceConnector()(
             withEditReviewAccess('patch')(
@@ -40,7 +36,10 @@ class OperatorsComponentFactory extends AbstractSBRComponentFactory {
                 NodeComponentProps
               >(nodeDropTargetSpec)(
                 withDragNode(nodeDragSourceSpec(type, false))(
-                  withSelection(false, true)(withContextMenu(workloadContextMenu)(WorkloadNode)),
+                  withSelection(
+                    false,
+                    true,
+                  )(withContextMenu(noRegroupWorkloadContextMenu)(WorkloadNode)),
                 ),
               ),
             ),

--- a/frontend/packages/dev-console/src/utils/__tests__/kebab-actions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/kebab-actions.spec.ts
@@ -1,15 +1,15 @@
 import { DeploymentConfigModel, ReplicaSetModel } from '@console/internal/models';
 import { getKebabActionsForKind } from '../kebab-actions';
-import { ModifyApplication, EditApplication } from '../../actions/modify-application';
+import { EditApplication } from '../../actions/modify-application';
 
 describe('kebab-actions: ', () => {
-  it('kebab action should have "Edit Application Grouping", "Edit Application" and "Edit Health Checks" option for deploymentConfig', () => {
-    const modifyApplication = getKebabActionsForKind(DeploymentConfigModel);
-    expect(modifyApplication).toEqual([ModifyApplication, EditApplication]);
+  it('kebab action should have "Edit Application" option for deploymentConfig', () => {
+    const deploymentConfigActions = getKebabActionsForKind(DeploymentConfigModel);
+    expect(deploymentConfigActions).toEqual([EditApplication]);
   });
 
-  it('kebab action should not have "Edit Application Grouping" option for replicaSet', () => {
-    const modifyApplication = getKebabActionsForKind(ReplicaSetModel);
-    expect(modifyApplication).toEqual([]);
+  it('kebab action should not have options for replicaSet', () => {
+    const replicaSetActions = getKebabActionsForKind(ReplicaSetModel);
+    expect(replicaSetActions).toEqual([]);
   });
 });

--- a/frontend/packages/dev-console/src/utils/kebab-actions.ts
+++ b/frontend/packages/dev-console/src/utils/kebab-actions.ts
@@ -7,7 +7,7 @@ import {
   DeploymentModel,
   StatefulSetModel,
 } from '@console/internal/models';
-import { ModifyApplication, EditApplication } from '../actions/modify-application';
+import { EditApplication } from '../actions/modify-application';
 
 const modifyWebConsoleApplicationRefs = [
   referenceForModel(DeploymentConfigModel),
@@ -29,7 +29,6 @@ export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => 
 
   return _.includes(modifyWebConsoleApplicationRefs, referenceForModel(resourceKind))
     ? [
-        ModifyApplication,
         ...(_.includes(editApplicationRefs, referenceForModel(resourceKind))
           ? [EditApplication]
           : []),

--- a/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/KnativeResourceOverviewPage.tsx
@@ -5,12 +5,13 @@ import { ResourceOverviewDetails } from '@console/internal/components/overview/r
 import { groupVersionFor, K8sKind, referenceForModel } from '@console/internal/module/k8s';
 import { RootState } from '@console/internal/redux';
 import { OverviewItem } from '@console/shared';
+import { ModifyApplication } from '@console/dev-console/src/actions/modify-application';
 import { KNATIVE_SERVING_APIGROUP } from '../../const';
+import { RevisionModel, ServiceModel } from '../../models';
+import { getRevisionActions } from '../../actions/getRevisionActions';
 import { isDynamicEventResourceKind } from '../../utils/fetch-dynamic-eventsources-utils';
 import OverviewDetailsKnativeResourcesTab from './OverviewDetailsKnativeResourcesTab';
 import KnativeOverview from './KnativeOverview';
-import { RevisionModel } from '../../models';
-import { getRevisionActions } from '../../actions/getRevisionActions';
 
 interface StateProps {
   kindsInFlight?: boolean;
@@ -47,9 +48,15 @@ export const KnativeResourceOverviewPage: React.ComponentType<KnativeResourceOve
       model.apiGroup === apiInfo.group &&
       model.apiVersion === apiInfo.version,
   );
-  let actions = [...Kebab.getExtensionsActionsForKind(resourceModel), ...Kebab.factory.common];
+
+  const actions = [];
+  if (resourceModel.kind === ServiceModel.kind) {
+    actions.push(ModifyApplication);
+  }
   if (resourceModel.kind === RevisionModel.kind) {
-    actions = getRevisionActions();
+    actions.push(...getRevisionActions());
+  } else {
+    actions.push(...Kebab.getExtensionsActionsForKind(resourceModel), ...Kebab.factory.common);
   }
 
   return (

--- a/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
@@ -1,8 +1,5 @@
 import { ServiceModel } from '@console/internal/models';
-import {
-  ModifyApplication,
-  EditApplication,
-} from '@console/dev-console/src/actions/modify-application';
+import { EditApplication } from '@console/dev-console/src/actions/modify-application';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { getKebabActionsForKind } from '../kebab-actions';
 import { setTrafficDistribution } from '../../actions/traffic-splitting';
@@ -10,15 +7,14 @@ import { setSinkSource } from '../../actions/sink-source';
 import { EventSourceContainerModel, ServiceModel as knSvcModel } from '../../models';
 
 describe('kebab-actions: ', () => {
-  it('kebab action should have "Edit Application Grouping" and "Move Sink" option for EventSourceContainerModel', () => {
-    const modifyApplication = getKebabActionsForKind(EventSourceContainerModel);
-    expect(modifyApplication).toEqual([ModifyApplication, setSinkSource]);
+  it('kebab action should have "Move Sink" option for EventSourceContainerModel', () => {
+    const eventSourceActions = getKebabActionsForKind(EventSourceContainerModel);
+    expect(eventSourceActions).toEqual([setSinkSource]);
   });
 
-  it('kebab action should have "setTrafficDistribution", "Add Health Checks", "Edit Application Grouping", "Edit Application" and "Edit Health Checks" option for knSvcModel', () => {
-    const modifyApplication = getKebabActionsForKind(knSvcModel);
-    expect(modifyApplication).toEqual([
-      ModifyApplication,
+  it('kebab action should have "setTrafficDistribution", "Add Health Checks", "Edit Application" and "Edit Health Checks" option for knSvcModel', () => {
+    const knSvcActions = getKebabActionsForKind(knSvcModel);
+    expect(knSvcActions).toEqual([
       setTrafficDistribution,
       AddHealthChecks,
       EditApplication,
@@ -26,8 +22,8 @@ describe('kebab-actions: ', () => {
     ]);
   });
 
-  it('kebab action should not have "Edit Application Grouping" option for ServiceModel', () => {
-    const modifyApplication = getKebabActionsForKind(ServiceModel);
-    expect(modifyApplication).toEqual([]);
+  it('kebab action should not have options for ServiceModel', () => {
+    const serviceActions = getKebabActionsForKind(ServiceModel);
+    expect(serviceActions).toEqual([]);
   });
 });

--- a/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
+++ b/frontend/packages/knative-plugin/src/utils/kebab-actions.ts
@@ -1,10 +1,7 @@
 import * as _ from 'lodash';
 import { K8sKind, referenceForModel } from '@console/internal/module/k8s';
 import { KebabAction } from '@console/internal/components/utils';
-import {
-  ModifyApplication,
-  EditApplication,
-} from '@console/dev-console/src/actions/modify-application';
+import { EditApplication } from '@console/dev-console/src/actions/modify-application';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { setTrafficDistribution } from '../actions/traffic-splitting';
 import { setSinkSource } from '../actions/sink-source';
@@ -14,14 +11,7 @@ import { getDynamicEventSourcesModelRefs } from './fetch-dynamic-eventsources-ut
 export const getKebabActionsForKind = (resourceKind: K8sKind): KebabAction[] => {
   const menuActions: KebabAction[] = [];
   const eventSourceModelrefs: string[] = getDynamicEventSourcesModelRefs();
-  const modifyApplicationRefs: string[] = [
-    ...eventSourceModelrefs,
-    referenceForModel(ServiceModel),
-  ];
   if (resourceKind) {
-    if (_.includes(modifyApplicationRefs, referenceForModel(resourceKind))) {
-      menuActions.push(ModifyApplication);
-    }
     if (referenceForModel(resourceKind) === referenceForModel(ServiceModel)) {
       menuActions.push(setTrafficDistribution, AddHealthChecks, EditApplication, EditHealthChecks);
     }

--- a/frontend/packages/kubevirt-plugin/src/topology/components/kubevirtComponentFactory.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/components/kubevirtComponentFactory.ts
@@ -20,6 +20,7 @@ import {
   TopologyDataObject,
   getTopologyResourceObject,
 } from '@console/dev-console/src/components/topology';
+import { ModifyApplication } from '@console/dev-console/src/actions/modify-application';
 import { vmMenuActions } from '../../components/vms/menu-actions';
 import { VmNode } from './nodes/VmNode';
 import { TYPE_VIRTUAL_MACHINE } from './const';
@@ -35,13 +36,15 @@ export const vmActions = (vm: TopologyDataObject<VMNodeData>): KebabOption[] => 
   } = vm;
 
   const model = modelFor(referenceFor(contextMenuResource));
-
-  return vmMenuActions.map((action) => {
-    return action(model, contextMenuResource, {
-      vmi,
-      vmStatusBundle,
-    });
-  });
+  return [
+    ModifyApplication(model, contextMenuResource),
+    ...vmMenuActions.map((action) => {
+      return action(model, contextMenuResource, {
+        vmi,
+        vmStatusBundle,
+      });
+    }),
+  ];
 };
 
 export const vmContextMenu = (element: Node) => {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3674

**Analysis / Root cause**: 
Helm Charts and Operator Backed Services and their workloads were given the option to add/remove/edit their application groupings. This was thought to be desirable, but we found that these objects are controlled by other forces and the settings should be left to those.

**Solution Description**: 
Remove the kebab options for `Edit Application Grouping` from these items. Remove the ability to regroup these items via drag/drop in topology.

Decision was made to remove the `Edit Application Grouping` from kebabs outside of the topology view as it is only pertinent there (for now) and distinguishing the workloads as being part of helm charts / operator backed services would required extra data fetching in those instances.

/kind bug

@openshift/team-devconsole-ux @serenamarie125 