### PR TITLE
Bug 1783109: Use buttons for perspective switcher dropdown items

### DIFF
--- a/frontend/public/components/nav/nav-header.tsx
+++ b/frontend/public/components/nav/nav-header.tsx
@@ -72,7 +72,7 @@ const NavHeader_: React.FC<NavHeaderProps & StateProps> = ({
             onPerspectiveSelect(event, nextPerspective)
           }
           isHovered={nextPerspective.properties.id === activePerspective}
-          href="#"
+          component="button"
         >
           <Title size="md">
             <span className="oc-nav-header__icon">{nextPerspective.properties.icon}</span>


### PR DESCRIPTION
This is better for accessibility and prevents an "Open in New Window" context menu item, which won't work.

There is no change to the dropdown item appearance.

/assign @rhamilto 