### PR TITLE
Bug 1624328: Filter on both role ref name and kind

### DIFF
--- a/frontend/public/components/RBAC/role.jsx
+++ b/frontend/public/components/RBAC/role.jsx
@@ -231,7 +231,7 @@ export const BindingsForRolePage = (props) => {
         }/rolebindings/~new?rolekind=${kind}&rolename=${name}`,
       }}
       ListComponent={BindingsListComponent}
-      staticFilters={[{ 'role-binding-roleRef': name }]}
+      staticFilters={[{ 'role-binding-roleRef-name': name }, { 'role-binding-roleRef-kind': kind }]}
       resources={resources}
       textFilter="role-binding"
       filterLabel="by role or subject"

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -68,7 +68,10 @@ export const tableFilters: TableFilterMap = {
   },
 
   // Filter role bindings by roleRef name
-  'role-binding-roleRef': (roleRef, binding) => binding.roleRef.name === roleRef,
+  'role-binding-roleRef-name': (name: string, binding) => binding.roleRef.name === name,
+
+  // Filter role bindings by roleRef kind
+  'role-binding-roleRef-kind': (kind: string, binding) => binding.roleRef.kind === kind,
 
   // Filter role bindings by user name
   'role-binding-user': (userName, binding) =>


### PR DESCRIPTION
Make sure to include the role ref kind as a filter in the `BindingsForRolePage` tab. This prevents ClusterRoles from showing bindings that reference namespaced Roles with the same name.

/assign @rhamilto 

