### PR TITLE
Bug 1823870:  Improve display and layout of operand status descriptors

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/pods.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/pods.spec.tsx
@@ -19,8 +19,8 @@ describe(PodStatusChart.displayName, () => {
   });
 
   it('renders a donut chart component with correct props', () => {
-    expect(wrapper.find(ChartDonut).props().subTitle).toEqual(descriptor.path);
     expect(wrapper.find(ChartDonut).props().title).toEqual('0');
+    expect(wrapper.find('[data-test-id="chart-donut-subtitle"]').text()).toEqual(descriptor.path);
   });
 
   it('passes data to donut chart', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/pods.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/status/pods.tsx
@@ -32,10 +32,13 @@ export const PodStatusChart: React.SFC<PodStatusChartProps> = ({ statuses, statu
         colorScale={colorScale}
         data={data}
         height={width}
-        subTitle={statusDescriptor.path}
         title={total.toString()}
         width={width}
       />
+      {/* Use instead of `subTitle` on <ChartDonut> so long paths do not clip  */}
+      <div className="graph-donut-subtitle" data-test-id="chart-donut-subtitle">
+        {statusDescriptor.path}
+      </div>
     </div>
   );
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -503,15 +503,13 @@ export const OperandDetails = connectToModel((props: OperandDetailsProps) => {
 
   const primaryDescriptor = primaryDescriptors.map((statusDescriptor: Descriptor) => {
     return (
-      <div className="row" key={statusDescriptor.displayName}>
-        <div className="col-sm-6 col-md-4">
-          <StatusDescriptor
-            descriptor={statusDescriptor}
-            value={blockValue(statusDescriptor, status)}
-            obj={props.obj}
-            model={props.kindObj}
-          />
-        </div>
+      <div key={statusDescriptor.displayName} className="col-sm-6">
+        <StatusDescriptor
+          descriptor={statusDescriptor}
+          value={blockValue(statusDescriptor, status)}
+          obj={props.obj}
+          model={props.kindObj}
+        />
       </div>
     );
   });
@@ -519,11 +517,11 @@ export const OperandDetails = connectToModel((props: OperandDetailsProps) => {
   const details = (
     <div className="co-operand-details__section co-operand-details__section--info">
       <div className="row">
-        <div className="col-xs-6">
+        <div className="col-sm-6">
           <ResourceSummary resource={props.obj} />
         </div>
         {currentStatus && (
-          <div className="col-xs-6" key={currentStatus.path}>
+          <div className="col-sm-6" key={currentStatus.path}>
             <StatusDescriptor
               namespace={metadata.namespace}
               obj={props.obj}
@@ -535,7 +533,7 @@ export const OperandDetails = connectToModel((props: OperandDetailsProps) => {
         )}
 
         {specDescriptors.map((specDescriptor: Descriptor) => (
-          <div key={specDescriptor.path} className="col-xs-6">
+          <div key={specDescriptor.path} className="col-sm-6">
             <SpecDescriptor
               namespace={metadata.namespace}
               obj={props.obj}
@@ -553,7 +551,7 @@ export const OperandDetails = connectToModel((props: OperandDetailsProps) => {
           .map((statusDescriptor: Descriptor) => {
             const statusValue = blockValue(statusDescriptor, status);
             return (
-              <div className="col-xs-6" key={statusDescriptor.path}>
+              <div className="col-sm-6" key={statusDescriptor.path}>
                 <StatusDescriptor
                   namespace={metadata.namespace}
                   obj={props.obj}
@@ -579,7 +577,7 @@ export const OperandDetails = connectToModel((props: OperandDetailsProps) => {
         <>
           <div className="co-m-pane__body">
             {header}
-            {primaryDescriptor}
+            <div className="row">{primaryDescriptor}</div>
           </div>
           <div className="co-m-pane__body">{details}</div>
         </>

--- a/frontend/public/components/graphs/_graphs.scss
+++ b/frontend/public/components/graphs/_graphs.scss
@@ -6,7 +6,17 @@
   text-align: left;
   text-overflow: ellipsis;
   overflow: hidden;
-  white-space: nowrap; 
+  white-space: nowrap;
+}
+
+.graph-donut-subtitle {
+  bottom: 20px;
+  color: var(--pf-global--palette--black-400);
+  line-height: 1.1;
+  margin: 0 0 10px;
+  position: relative;
+  text-align: center;
+  @include co-break-word;
 }
 
 .graph-wrapper {


### PR DESCRIPTION
And align operand details to match other resource detail pages.  

Note upstream bugs in PatternFly are blocking use of `subTitleComponent` in order to fix the clipping issue of `subTitle` within `<ChartDonut>`.  @TheRealJon is investigating and going to open an upstream issue.  I figure this workaround is a good interim step to resolving the bug.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1823870

Before:
![console-openshift-console apps rhamilto44 devcluster openshift com_k8s_ns_openshift-logging_clusterserviceversions_clusterlogging 4 3 16-202004240713_logging openshift io_v1_ClusterLogging_instance(5  PFXL) (1)](https://user-images.githubusercontent.com/895728/80832094-060e4d80-8bba-11ea-98f9-b87837ccbe12.png)
![console-openshift-console apps rhamilto44 devcluster openshift com_k8s_ns_openshift-logging_clusterserviceversions_clusterlogging 4 3 16-202004240713_logging openshift io_v1_ClusterLogging_instance(iPhone X)](https://user-images.githubusercontent.com/895728/80832098-07d81100-8bba-11ea-9871-1cf2aaf7b65e.png)

After:
![localhost_9000_k8s_ns_openshift-logging_clusterserviceversions_clusterlogging 4 3 16-202004240713_logging openshift io_v1_ClusterLogging_instance(5  PFXL)](https://user-images.githubusercontent.com/895728/80832125-145c6980-8bba-11ea-9afd-fb81b1175654.png)
![localhost_9000_k8s_ns_openshift-logging_clusterserviceversions_clusterlogging 4 3 16-202004240713_logging openshift io_v1_ClusterLogging_instance(iPhone X) (1)](https://user-images.githubusercontent.com/895728/80832131-16262d00-8bba-11ea-9d15-c743db5bec82.png)
