### PR TITLE
Bug 1830378: Query input needs accessible label on metrics page

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -461,6 +461,7 @@ const QueryInput_: React.FC<QueryInputProps> = ({
   return (
     <div className="query-browser__query pf-c-dropdown">
       <textarea
+        aria-label="Expression (press Shift+Enter for newlines)"
         autoFocus
         className="pf-c-form-control query-browser__query-input"
         onBlur={onBlur}


### PR DESCRIPTION
This adds an aria label to the metrics query input field. It fixes the following axe error:

```  {
    "data": null,
    "id": "aria-label",
    "impact": "serious",
    "message": "aria-label attribute does not exist or is empty",
    "relatedNodes": [
      {
        "html": "<textarea class="pf-c-form-control query-browser__query-input" placeholder="Expression (press Shift+Enter for newlines)" rows="2" spellcheck="false"></textarea>"
      }
    ]
  }```