### PR TITLE
Bug 1753666: Don't redirect back to error page after login

### DIFF
--- a/frontend/public/module/auth.js
+++ b/frontend/public/module/auth.js
@@ -15,8 +15,11 @@ const setNext = (next) => {
   if (!next) {
     return;
   }
+
   try {
-    localStorage.setItem('next', stripBasePath(next));
+    // Don't redirect the user back to the error page after logging in.
+    const path = stripBasePath(next);
+    localStorage.setItem('next', path.startsWith('/error') ? '/' : path);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(e);


### PR DESCRIPTION
If the user is currently on the error page, don't set that as the next path after login.

/assign @rhamilto 