### PR TITLE
Bug 1830841: updates api-endpoint to fetch event sources and update default sources

### DIFF
--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
@@ -43,7 +43,10 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
   });
 
   it('should render EventSinkServicesOverviewList on sidebar', () => {
-    knItem.item = { ...knItem.item, ...{ obj: MockKnativeResources.eventSourceCronjob.data[0] } };
+    knItem.item = {
+      ...knItem.item,
+      ...{ obj: MockKnativeResources.eventSourceContainers.data[0] },
+    };
     const wrapper = shallow(<OverviewDetailsKnativeResourcesTab {...knItem} />);
     expect(wrapper.find(EventSinkServicesOverviewList)).toHaveLength(1);
   });

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-knative-test-data.ts
@@ -18,6 +18,7 @@ import {
   EventSourceKafkaModel,
   EventSourcePingModel,
   EventSourceSinkBindingModel,
+  EventSourceApiServerModel,
 } from '../../models';
 import {
   RevisionKind,
@@ -611,5 +612,6 @@ export const MockKnativeResources: TopologyDataResources = {
   [referenceForModel(EventSourceKafkaModel)]: getEventSourceResponse(EventSourceKafkaModel),
   [referenceForModel(EventSourceSinkBindingModel)]: sampleEventSourceSinkbinding,
   [referenceForModel(EventSourcePingModel)]: getEventSourceResponse(EventSourcePingModel),
+  [referenceForModel(EventSourceApiServerModel)]: getEventSourceResponse(EventSourceApiServerModel),
   clusterServiceVersions: sampleClusterServiceVersions,
 };

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-model.spec.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-model.spec.ts
@@ -55,7 +55,7 @@ describe('topology model ', () => {
     );
     const eventSources = newModel.nodes.filter((n) => n.type === TYPE_EVENT_SOURCE);
     const visibleEventSources = eventSources.filter((n) => n.visible);
-    expect(eventSources.length).toBe(5);
+    expect(eventSources.length).toBe(4);
     expect(visibleEventSources.length).toBe(0);
   });
 
@@ -71,7 +71,7 @@ describe('topology model ', () => {
     );
     const eventSources = newModel.nodes.filter((n) => n.type === TYPE_EVENT_SOURCE);
     const visibleEventSources = eventSources.filter((n) => n.visible);
-    expect(eventSources.length).toBe(5);
-    expect(visibleEventSources.length).toBe(5);
+    expect(eventSources.length).toBe(4);
+    expect(visibleEventSources.length).toBe(4);
   });
 });

--- a/frontend/packages/knative-plugin/src/utils/__tests__/fetch-dynamic-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/fetch-dynamic-eventsources-utils.spec.ts
@@ -4,10 +4,8 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import {
   EventSourceApiServerModel,
   EventSourceSinkBindingModel,
-  EventSourceKafkaModel,
-  EventSourceCronJobModel,
   EventSourceContainerModel,
-  EventSourceCamelModel,
+  EventSourcePingModel,
   ServiceModel,
 } from '../../models';
 import {
@@ -28,11 +26,11 @@ describe('fetch-dynamic-eventsources: ', () => {
   it('should fetch models for duck type in case of error', async () => {
     jest.spyOn(coFetch, 'coFetch').mockImplementation(() => Promise.reject(new Error('Error')));
     await fetchEventSourcesCrd();
-    expect(getEventSourceModels()).toHaveLength(6);
+    expect(getEventSourceModels()).toHaveLength(4);
   });
 
   it('should return true for event source model', () => {
-    expect(isDynamicEventResourceKind(referenceForModel(EventSourceCronJobModel))).toBe(true);
+    expect(isDynamicEventResourceKind(referenceForModel(EventSourceContainerModel))).toBe(true);
   });
 
   it('should return false for event source model', () => {
@@ -41,23 +39,21 @@ describe('fetch-dynamic-eventsources: ', () => {
 
   it('should return refs for all event source models', () => {
     const expectedRefs = [
-      referenceForModel(EventSourceCronJobModel),
       referenceForModel(EventSourceContainerModel),
       referenceForModel(EventSourceApiServerModel),
       referenceForModel(EventSourceSinkBindingModel),
-      referenceForModel(EventSourceKafkaModel),
-      referenceForModel(EventSourceCamelModel),
+      referenceForModel(EventSourcePingModel),
     ];
     const modelRefs = getDynamicEventSourcesModelRefs();
-    expect(modelRefs).toHaveLength(6);
+    expect(modelRefs).toHaveLength(4);
     modelRefs.forEach((ref) => {
       expect(expectedRefs.includes(ref)).toBe(true);
     });
   });
 
   it('should return model from the dynamic event sources', () => {
-    const resultModel = getDynamicEventSourceModel(referenceForModel(EventSourceCronJobModel));
-    expect(isEqual(resultModel, EventSourceCronJobModel)).toBe(true);
+    const resultModel = getDynamicEventSourceModel(referenceForModel(EventSourceContainerModel));
+    expect(isEqual(resultModel, EventSourceContainerModel)).toBe(true);
   });
 
   it('should return undefined if model is not found', () => {

--- a/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
@@ -1,23 +1,21 @@
 import * as _ from 'lodash';
 import { coFetch } from '@console/internal/co-fetch';
 import { K8sKind, kindToAbbr, referenceForModel } from '@console/internal/module/k8s';
-import { CustomResourceDefinitionModel } from '@console/internal/models';
 import { chart_color_red_300 as knativeEventingColor } from '@patternfly/react-tokens';
 import {
-  EventSourceCronJobModel,
   EventSourceContainerModel,
   EventSourceApiServerModel,
   EventSourceSinkBindingModel,
-  EventSourceKafkaModel,
   EventSourceCamelModel,
+  EventSourcePingModel,
+  EventSourceKafkaModel,
+  EventSourceCronJobModel,
 } from '../models';
 
 const defaultEventSourceModels = [
   EventSourceApiServerModel,
-  EventSourceCamelModel,
   EventSourceContainerModel,
-  EventSourceCronJobModel,
-  EventSourceKafkaModel,
+  EventSourcePingModel,
   EventSourceSinkBindingModel,
 ];
 
@@ -26,58 +24,66 @@ let eventSourceModels: K8sKind[] = defaultEventSourceModels;
 // To order sources with known followed by CamelSource and everything else
 export const orderedEventSourceModelData = (allModels: K8sKind[]): K8sKind[] => {
   const sortModels = _.orderBy(allModels, ['kind'], ['asc']);
-  const knownSourcesCrd = _.filter(
-    sortModels,
-    (model) =>
-      !!_.find(defaultEventSourceModels, { kind: model?.kind }) &&
-      model?.kind !== EventSourceCamelModel.kind,
-  );
+  const knownSourcesList = [
+    EventSourceApiServerModel.kind,
+    EventSourceContainerModel.kind,
+    EventSourceCronJobModel.kind,
+    EventSourceKafkaModel.kind,
+    EventSourcePingModel.kind,
+    EventSourceSinkBindingModel.kind,
+  ];
+  const knownSourcesCrd = _.filter(sortModels, (model) => knownSourcesList.includes(model.kind));
   const camelSourcesCrd = _.filter(
     sortModels,
     (model) => model?.kind === EventSourceCamelModel.kind,
   );
   const dynamicSourcesCrd = _.filter(
     sortModels,
-    (model) =>
-      !_.find(defaultEventSourceModels, { kind: model?.kind }) &&
-      model?.kind !== EventSourceCamelModel.kind,
+    (model) => !knownSourcesList.includes(model.kind) && model.kind !== EventSourceCamelModel.kind,
   );
   return [...knownSourcesCrd, ...camelSourcesCrd, ...dynamicSourcesCrd];
 };
 
 export const fetchEventSourcesCrd = async () => {
   let eventSourceModelList: K8sKind[] = [];
-  const url = `api/kubernetes/apis/${CustomResourceDefinitionModel.apiGroup}/${
-    CustomResourceDefinitionModel.apiVersion
-  }/${CustomResourceDefinitionModel.plural}?limit=250&labelSelector=${encodeURIComponent(
-    'duck.knative.dev/source=true',
-  )}`;
+  const url = 'api/console/knative-event-sources';
   try {
     const res = await coFetch(url);
     const resolvedRes = await res.json();
-    const allModels = _.map(resolvedRes?.items, (crd) => {
-      const {
-        spec: {
-          group,
-          version,
-          names: { kind, plural, singular },
-        },
-      } = crd;
-      return {
-        apiGroup: group,
-        apiVersion: version,
-        kind,
-        plural,
-        id: singular,
-        label: singular,
-        labelPlural: plural,
-        abbr: kindToAbbr(kind),
-        namespaced: true,
-        crd: true,
-        color: knativeEventingColor.value,
-      };
-    });
-    eventSourceModelList = orderedEventSourceModelData(allModels);
+    const allModels = _.reduce(
+      resolvedRes?.items,
+      (accumulator, crd) => {
+        const {
+          spec: {
+            group,
+            versions,
+            names: { kind, plural, singular },
+          },
+        } = crd;
+        const { name: version } = versions?.find((ver) => ver.served && ver.storage);
+        if (version) {
+          accumulator.push({
+            apiGroup: group,
+            apiVersion: version,
+            kind,
+            plural,
+            id: singular,
+            label: singular,
+            labelPlural: plural,
+            abbr: kindToAbbr(kind),
+            namespaced: true,
+            crd: true,
+            color: knativeEventingColor.value,
+          });
+        }
+        return accumulator;
+      },
+      [],
+    );
+
+    eventSourceModelList = allModels.length
+      ? orderedEventSourceModelData(allModels)
+      : defaultEventSourceModels;
   } catch (err) {
     // show warning if there is an error fetching the CRDs
     // eslint-disable-next-line no-console


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3683

**Analysis / Root cause**: 
Currently fetching dynamic sources with making direct call to CRD with version `v1beta` based on label selector ducktype

**Solution Description**: 
Update ApiEnd point to fetch CRDs for event sources (api using CRD version "v1") i.e `api/console/knative-event-sources` and return Default Sources in order

**Screen shots / Gifs for design review**: 
![May-04-2020 11-03-36](https://user-images.githubusercontent.com/5129024/80938509-05aec600-8df7-11ea-824e-ad73221b4c93.gif)

<img width="1734" alt="Screenshot 2020-05-04 at 11 04 46 AM" src="https://user-images.githubusercontent.com/5129024/80938534-19f2c300-8df7-11ea-9210-8aa67eee7f12.png">



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
