### PR TITLE
Bug 1830846: updates apiGroup for KnativeEventing to latest supported

### DIFF
--- a/frontend/packages/knative-plugin/src/models.ts
+++ b/frontend/packages/knative-plugin/src/models.ts
@@ -40,7 +40,7 @@ export const KnativeServingModel: K8sKind = {
 };
 
 export const KnativeEventingModel: K8sKind = {
-  apiGroup: 'eventing.knative.dev',
+  apiGroup: 'operator.knative.dev',
   apiVersion: 'v1alpha1',
   kind: 'KnativeEventing',
   label: 'Knative Eventing',


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3728

**Analysis / Root cause**: 
With serverless GA eventing is part of it and user need not install knative Eventing operator[0]
with this there is change in group for KnativeEventing it has been moved to operator.knative.dev but in eventing operator it's still eventing.knative.dev (this will be deprecated) in devConsole we are leveraging KnativeEventing for feature flagging so Eventing maynot be shown if eventing is installed as part of serverless 1.7 GA. So going forward we need to be supporting operator.knative.dev

[0] https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/serverless_applications/index#serverless-getting-started 

**Solution Description**: 
updates apiGroup for KnativeEventing to latest supported i.e `operator.knative.dev`


**Screen shots / Gifs for design review**: 
TBD

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
