### PR TITLE
Bug 1830878: event source connector drop target should only be knative service

### DIFF
--- a/frontend/packages/knative-plugin/src/topology/components/knativeComponentUtils.ts
+++ b/frontend/packages/knative-plugin/src/topology/components/knativeComponentUtils.ts
@@ -17,7 +17,7 @@ import {
   EdgeComponentProps,
   EditableDragOperationType,
 } from '@console/dev-console/src/components/topology';
-import { TYPE_EVENT_SOURCE_LINK } from '../const';
+import { TYPE_EVENT_SOURCE_LINK, TYPE_KNATIVE_SERVICE } from '../const';
 import { createSinkConnection } from '../knative-topology-utils';
 
 export const MOVE_EV_SRC_CONNECTOR_OPERATION = 'moveeventsourceconnector';
@@ -30,6 +30,7 @@ export const nodesEdgeIsDragging = (monitor, props) =>
 
 export const canDropEventSourceSinkOnNode = (operation: string, edge: Edge, node: Node): boolean =>
   edge.getSource() !== node &&
+  node.getType() === TYPE_KNATIVE_SERVICE &&
   operation === MOVE_EV_SRC_CONNECTOR_OPERATION &&
   !node.getTargetEdges().find((e) => e.getSource() === edge.getSource());
 


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3739

**Analysis / Root cause**: 
EventSource connector was droppable on workload of kind deployment/deploymentConfig, however should only be dropped/sinked to knative service

**Solution Description**: 
Updated the drop condition to check type of node as well i.e restricting sink to only be in knative service

**Screen shots / Gifs for design review**: 
![issueDndSources](https://user-images.githubusercontent.com/5129024/80947332-9395ab80-8e0d-11ea-8c1b-af8327fad7d8.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
