### PR TITLE
Bug 1830921: Project Access form should not reorder on save

### DIFF
--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -13,7 +13,6 @@ import { RoleBindingModel, RoleModel } from '@console/internal/models';
 import { filterRoleBindings, getUserRoleBindings } from './project-access-form-utils';
 import {
   getRolesWithNameChange,
-  getFinalRoles,
   sendRoleBindingRequest,
   getNewRoles,
   getRemovedRoles,
@@ -44,17 +43,6 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ formName, namespace, role
   const handleSubmit = (values, actions) => {
     let newRoles = getNewRoles(initialValues.projectAccess, values.projectAccess);
     let removeRoles = getRemovedRoles(initialValues.projectAccess, values.projectAccess);
-    if (_.isEmpty(newRoles) && _.isEmpty(removeRoles)) {
-      actions.setSubmitting(false);
-      actions.resetForm({
-        values: {
-          projectAccess: initialValues.projectAccess,
-        },
-        status: { success: `Successfully updated the ${formName}.` },
-      });
-      return;
-    }
-
     const updateRoles = getRolesWithNameChange(newRoles, removeRoles);
 
     if (!_.isEmpty(updateRoles)) {
@@ -67,10 +55,6 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ formName, namespace, role
         (o1) => !updateRoles.find((o2) => o1.roleBindingName === o2.roleBindingName),
       );
     }
-
-    const finalValues = _.isEmpty(newRoles)
-      ? values.projectAccess
-      : getFinalRoles(initialValues.projectAccess, removeRoles, newRoles);
 
     const roleBindingRequests = [];
     roleBinding.metadata.namespace = namespace;
@@ -91,7 +75,7 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ formName, namespace, role
         actions.setSubmitting(false);
         actions.resetForm({
           values: {
-            projectAccess: finalValues,
+            projectAccess: values.projectAccess,
           },
           status: { success: `Successfully updated the ${formName}.` },
         });

--- a/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/project-access/__tests__/project-access-form-submit-utils.spec.ts
@@ -1,6 +1,5 @@
 import {
   getRolesWithNameChange,
-  getFinalRoles,
   getNewRoles,
   getRemovedRoles,
 } from '../project-access-form-submit-utils';
@@ -8,10 +7,6 @@ import {
   roleBindingsToBeCreated1,
   rolesBindingsToBeRemoved1,
   rolesWithNameChangeResult,
-  initialRoles2,
-  roleBindingsToBeCreated3,
-  rolesBindingsToBeRemoved2,
-  displayRoleBindings,
   initialRoles1,
   formValues1,
   rolesBindingsToBeRemoved,
@@ -36,14 +31,5 @@ describe('Project Access handleSubmit Utils', () => {
       rolesBindingsToBeRemoved1,
     );
     expect(rolesWithNameChange).toEqual(rolesWithNameChangeResult);
-  });
-
-  it('should get the final list of roles to be displayed in the form', async () => {
-    const finalRoles = getFinalRoles(
-      initialRoles2,
-      rolesBindingsToBeRemoved2,
-      roleBindingsToBeCreated3,
-    );
-    expect(finalRoles).toEqual(displayRoleBindings);
   });
 });

--- a/frontend/packages/dev-console/src/components/project-access/project-access-form-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/project-access/project-access-form-submit-utils.ts
@@ -21,18 +21,6 @@ export const getRolesWithNameChange = (
   return rolesWithNameChange;
 };
 
-export const getFinalRoles = (
-  initialValues: UserRoleBinding[],
-  removeRoles: UserRoleBinding[],
-  newRoles: UserRoleBinding[],
-) => {
-  const finalRoles = _.filter(
-    initialValues,
-    (o1) => !removeRoles.find((o2) => o1.roleBindingName === o2.roleBindingName),
-  );
-  return [...finalRoles, ...newRoles];
-};
-
 export const sendK8sRequest = (verb: string, roleBinding): Promise<K8sResourceKind> => {
   switch (verb) {
     case Verb.Create:


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-2405

**Analysis / Root cause:**
Project Access form reordered on save since the form was not getting correctly ordered values on save

**Solution Description:**
Add the correctly ordered values in form on save

**Gif**
![Peek 2020-05-04 16-22](https://user-images.githubusercontent.com/20724543/80958957-7a97f500-8e23-11ea-8e32-0b197c1c8e3b.gif)

/kind bug