### PR TITLE
Bug 1830935: Fix helm resource tab to show all resources

### DIFF
--- a/frontend/packages/dev-console/src/components/helm/details/resources/HelmReleaseResourcesRow.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/resources/HelmReleaseResourcesRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { Link } from 'react-router-dom';
-import { K8sResourceKind } from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
 import { Status } from '@console/shared';
 import { ResourceLink, Timestamp, resourcePath } from '@console/internal/components/utils';
 import { TableData, TableRow, RowFunction } from '@console/internal/components/factory';
@@ -13,13 +13,10 @@ const HelmReleaseResourcesRow: RowFunction<K8sResourceKind> = ({
   key,
   style,
 }) => {
+  const kind = referenceFor(resource);
   const status = resource.status?.replicas ? (
     <Link
-      to={`${resourcePath(
-        resource.kind,
-        resource.metadata.name,
-        resource.metadata.namespace,
-      )}/pods`}
+      to={`${resourcePath(kind, resource.metadata.name, resource.metadata.namespace)}/pods`}
       title="pods"
     >
       {resource.status.replicas || 0} of {resource.spec.replicas} pods
@@ -31,7 +28,7 @@ const HelmReleaseResourcesRow: RowFunction<K8sResourceKind> = ({
     <TableRow id={resource.metadata.uid} index={index} trKey={key} style={style}>
       <TableData className={tableColumnClasses.name}>
         <ResourceLink
-          kind={resource.kind}
+          kind={kind}
           name={resource.metadata.name}
           namespace={resource.metadata.namespace}
         />


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3734

This PR -
- Fixes the resources tab in helm details page to show all the resources including CRs based on CRDs.

![Screenshot from 2020-05-04 17-08-21](https://user-images.githubusercontent.com/6041994/80962026-da919a00-8e29-11ea-8515-ceee258c6717.png)
