### PR TITLE
Bug 1831002: Fix for pod text / icon overlap in topology

### DIFF
--- a/frontend/packages/console-shared/src/components/pod/PodRing.tsx
+++ b/frontend/packages/console-shared/src/components/pod/PodRing.tsx
@@ -68,11 +68,7 @@ const PodRing: React.FC<PodRingProps> = ({
     handleScaling(clickCount + operation);
   };
   const resourceObj = rc || obj;
-  const { title, subTitle, titleComponent, subTitleComponent } = podRingLabel(
-    resourceObj,
-    obj.kind,
-    pods,
-  );
+  const { title, subTitle, titleComponent } = podRingLabel(resourceObj, obj.kind, pods);
 
   return (
     <Split>
@@ -84,7 +80,6 @@ const PodRing: React.FC<PodRingProps> = ({
             subTitle={subTitle}
             title={title}
             titleComponent={titleComponent}
-            subTitleComponent={subTitleComponent}
           />
         </div>
       </SplitItem>

--- a/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/pod-ring-utils.spec.ts
@@ -36,7 +36,7 @@ describe('pod-ring utils:', () => {
     ).toEqual('');
   });
 
-  it('should return title 0, subtitle scaling to 2 and no titleComponent, subtitleComponent for podRingLabel when scaling from 1 to 2 pods', () => {
+  it('should return title 0, subtitle scaling to 2 and titleComponent for podRingLabel when scaling from 1 to 2 pods', () => {
     const deploymentWithReplicas = _.set(_.cloneDeep(deployment), 'spec.replicas', 2);
     const mockDeploymentData = _.set(deploymentWithReplicas, 'status.readyReplicas', 1);
     expect(
@@ -48,14 +48,10 @@ describe('pod-ring utils:', () => {
     expect(
       podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind])
         .titleComponent,
-    ).toEqual(undefined);
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind])
-        .subTitleComponent,
-    ).toEqual(undefined);
+    ).not.toBeUndefined();
   });
 
-  it('should return title 0, subtitle scaling to 1 and no titleComponent, subtitleComponent for podRingLabel when the first pod is being created', () => {
+  it('should return title 0, subtitle scaling to 1 and titleComponent for podRingLabel when the first pod is being created', () => {
     const deploymentWithReplicas = _.set(_.cloneDeep(deployment), 'spec.replicas', 1);
     const mockDeploymentData = _.set(deploymentWithReplicas, 'status.readyReplicas', 0);
     expect(
@@ -67,14 +63,10 @@ describe('pod-ring utils:', () => {
     expect(
       podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind])
         .titleComponent,
-    ).toEqual(undefined);
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPod as ExtPodKind])
-        .subTitleComponent,
-    ).toEqual(undefined);
+    ).not.toBeUndefined();
   });
 
-  it('should return title 0, subtitle scaling to 1 and no titleComponent, subtitleComponent for podRingLabel when pod count is 1 and status is pending', () => {
+  it('should return title 0, subtitle scaling to 1 and titleComponent for podRingLabel when pod count is 1 and status is pending', () => {
     const mockDeploymentData = _.set(_.cloneDeep(deployment), 'spec.replicas', 1);
     const mockPodData = _.set(_.cloneDeep(mockPod), 'status.phase', 'Pending');
     expect(
@@ -87,11 +79,7 @@ describe('pod-ring utils:', () => {
     expect(
       podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPodData as ExtPodKind])
         .titleComponent,
-    ).toEqual(undefined);
-    expect(
-      podRingLabel(mockDeploymentData, mockDeploymentData.kind, [mockPodData as ExtPodKind])
-        .subTitleComponent,
-    ).toEqual(undefined);
+    ).not.toBeUndefined();
   });
 
   it('should return proper title, subtitle for podRingLabel for Daemon sets', () => {

--- a/frontend/packages/console-shared/src/utils/pod-ring-text.scss
+++ b/frontend/packages/console-shared/src/utils/pod-ring-text.scss
@@ -1,0 +1,22 @@
+@import '~@patternfly/patternfly/sass-utilities/colors';
+
+.pod-ring__center-text {
+  tspan {
+    font-size: 14px !important;
+    fill: var(--pf-global--Color--200) !important;
+  }
+  tspan:first-of-type {
+    font-size: 24px !important;
+    fill: var(--pf-global--Color--100) !important;
+  }
+}
+
+.pod-ring__center-text--reversed {
+  tspan {
+    font-size: 14px !important;
+    fill: var(--pf-global--Color--200) !important;
+  }
+  tspan:first-of-type {
+    fill: var(--pf-global--Color--100) !important;
+  }
+}

--- a/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-ring-utils.ts
@@ -22,11 +22,12 @@ import {
   getPodsForStatefulSets,
 } from './resource-utils';
 
+import './pod-ring-text.scss';
+
 type PodRingLabelType = {
   subTitle: string;
   title: string;
   titleComponent: React.ReactElement;
-  subTitleComponent: React.ReactElement;
 };
 
 const applyPods = (podsData: PodRingData, dc: PodRCData) => {
@@ -64,40 +65,40 @@ const getTitleAndSubtitle = (
   desiredPodCount: number,
 ) => {
   let titlePhrase;
-  let subTitlePhrase;
+  let subTitlePhrase = '';
+  let longSubtitle = false;
 
-  // handles the intial state when the first pod is coming up and the state for no pods(scaled to zero)
+  // handles the initial state when the first pod is coming up and the state for no pods(scaled to zero)
   if (!currentPodCount) {
     titlePhrase = isPending ? '0' : `Scaled to 0`;
-    subTitlePhrase = desiredPodCount ? `scaling to ${desiredPodCount}` : '';
+    if (desiredPodCount) {
+      subTitlePhrase = `scaling to ${desiredPodCount}`;
+      longSubtitle = true;
+    }
   }
 
   // handles the idle state or scaling to desired no. of pods
   if (currentPodCount) {
     titlePhrase = currentPodCount.toString();
-    subTitlePhrase =
-      currentPodCount === desiredPodCount
-        ? pluralizeString(currentPodCount, 'pod')
-        : `scaling to ${desiredPodCount}`;
+    if (currentPodCount === desiredPodCount) {
+      subTitlePhrase = pluralizeString(currentPodCount, 'pod');
+    } else {
+      subTitlePhrase = `scaling to ${desiredPodCount}`;
+      longSubtitle = true;
+    }
   }
 
-  return { title: titlePhrase, subTitle: subTitlePhrase };
+  return { title: titlePhrase, subTitle: subTitlePhrase, longSubtitle };
 };
 
-const getTitleAndSubtitleComponent = (
-  isPending: boolean,
-  currentPodCount: number,
-  kind: string,
-) => ({
-  titleComponent:
-    !currentPodCount && !isPending
-      ? React.createElement(ChartLabel, { style: { fontSize: '14px' } })
-      : undefined,
-  subTitleComponent:
-    kind === 'Revision'
-      ? React.createElement(ChartLabel, { style: { fontSize: '14px' } })
-      : undefined,
-});
+const getTitleComponent = (longSubtitle: boolean = false, reversed: boolean = false) =>
+  React.createElement(ChartLabel, {
+    dy: longSubtitle ? -5 : 0,
+    style: { lineHeight: '11px' },
+    className: `pf-chart-donut-title ${
+      reversed ? 'pod-ring__center-text--reversed' : 'pod-ring__center-text'
+    }`,
+  });
 
 export const podRingLabel = (
   obj: K8sResourceKind,
@@ -109,14 +110,18 @@ export const podRingLabel = (
   let title;
   let subTitle;
   let isPending;
+  let titleData;
   switch (ownerKind) {
     case DaemonSetModel.kind:
       currentPodCount = obj.status?.currentNumberScheduled;
       desiredPodCount = obj.status?.desiredNumberScheduled;
+      desiredPodCount = obj.status?.desiredNumberScheduled;
       isPending = isPendingPods(pods, currentPodCount, desiredPodCount);
+      titleData = getTitleAndSubtitle(isPending, currentPodCount, desiredPodCount);
       return {
-        ...getTitleAndSubtitle(isPending, currentPodCount, desiredPodCount),
-        ...getTitleAndSubtitleComponent(isPending, currentPodCount, ownerKind),
+        title: titleData.title,
+        subTitle: titleData.subTitle,
+        titleComponent: getTitleComponent(titleData.longSubtitle),
       };
     case RevisionModel.kind:
       currentPodCount = obj.status?.readyReplicas;
@@ -125,7 +130,13 @@ export const podRingLabel = (
       if (!isPending && !desiredPodCount) {
         title = 'Autoscaled';
         subTitle = 'to 0';
-      } else if (isPending) {
+        return {
+          title,
+          subTitle,
+          titleComponent: getTitleComponent(false, true),
+        };
+      }
+      if (isPending) {
         title = '0';
         subTitle = `scaling to ${desiredPodCount}`;
       } else {
@@ -135,15 +146,17 @@ export const podRingLabel = (
       return {
         title,
         subTitle,
-        ...getTitleAndSubtitleComponent(isPending, currentPodCount, ownerKind),
+        titleComponent: getTitleComponent(),
       };
     default:
       currentPodCount = obj.status?.readyReplicas;
       desiredPodCount = obj.spec?.replicas;
       isPending = isPendingPods(pods, currentPodCount, desiredPodCount);
+      titleData = getTitleAndSubtitle(isPending, currentPodCount, desiredPodCount);
       return {
-        ...getTitleAndSubtitle(isPending, currentPodCount, desiredPodCount),
-        ...getTitleAndSubtitleComponent(isPending, currentPodCount, ownerKind),
+        title: titleData.title,
+        subTitle: titleData.subTitle,
+        titleComponent: getTitleComponent(titleData.longSubtitle),
       };
   }
 };

--- a/frontend/packages/console-shared/src/utils/pod-utils.ts
+++ b/frontend/packages/console-shared/src/utils/pod-utils.ts
@@ -105,6 +105,7 @@ export const calculateRadius = (size: number) => {
     podStatusOuterRadius,
     decoratorRadius,
     podStatusStrokeWidth,
+    podStatusInset,
   };
 };
 
@@ -156,6 +157,19 @@ const getScalingUp = (dc: K8sResourceKind): ExtPodKind => {
       phase: AllPodStatus.ScalingUp,
     },
   };
+};
+
+export const podDataInProgress = (
+  dc: K8sResourceKind,
+  current: PodControllerOverviewItem,
+  isRollingOut: boolean,
+): boolean => {
+  const strategy: DeploymentStrategy = dc?.spec?.strategy?.type;
+  return (
+    current?.phase !== DEPLOYMENT_PHASE.complete &&
+    (strategy === DEPLOYMENT_STRATEGY.recreate || strategy === DEPLOYMENT_STRATEGY.rolling) &&
+    isRollingOut
+  );
 };
 
 export const getPodData = (

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/BaseNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/BaseNode.tsx
@@ -24,6 +24,7 @@ import { NodeShadows, NODE_SHADOW_FILTER_ID_HOVER, NODE_SHADOW_FILTER_ID } from 
 import './BaseNode.scss';
 
 export type BaseNodeProps = {
+  className: string;
   outerRadius: number;
   innerRadius?: number;
   icon?: string;
@@ -42,6 +43,7 @@ export type BaseNodeProps = {
   WithCreateConnectorProps;
 
 const ObservedBaseNode: React.FC<BaseNodeProps> = ({
+  className,
   outerRadius,
   innerRadius,
   icon,
@@ -94,7 +96,7 @@ const ObservedBaseNode: React.FC<BaseNodeProps> = ({
 
   return (
     <g
-      className={classNames('odc-base-node', {
+      className={classNames('odc-base-node', className, {
         'is-hover': hover || contextMenuOpen,
         'is-highlight': canDrop,
         'is-dragging': dragging || edgeDragging,

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.scss
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.scss
@@ -1,0 +1,13 @@
+.odc-workload-node {
+  .pod-ring__center-text {
+    tspan {
+      font-size: 11px !important;
+    }
+  }
+
+  .pod-ring__center-text--reversed {
+    tspan {
+      font-size: 11px !important;
+    }
+  }
+}

--- a/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/nodes/WorkloadNode.tsx
@@ -15,11 +15,13 @@ import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { routeDecoratorIcon } from '../../../import/render-utils';
 import { Decorator } from './Decorator';
-import PodSet from './PodSet';
+import PodSet, { podSetInnerRadius } from './PodSet';
 import BuildDecorator from './build-decorators/BuildDecorator';
 import { BaseNode } from './BaseNode';
 import { getCheURL, getEditURL, getServiceBindingStatus } from '../../topology-utils';
 import { useDisplayFilters } from '../../filters/useDisplayFilters';
+
+import './WorkloadNode.scss';
 
 interface StateProps {
   serviceBinding: boolean;
@@ -74,8 +76,9 @@ const ObservedWorkloadNode: React.FC<WorkloadNodeProps> = ({
         tippyProps={{ duration: 0, delay: 0 }}
       >
         <BaseNode
+          className="odc-workload-node"
           outerRadius={radius}
-          innerRadius={donutStatus && donutStatus.isRollingOut ? radius * 0.45 : radius * 0.55}
+          innerRadius={podSetInnerRadius(size, donutStatus)}
           icon={!filters.podCount ? workloadData.builderImage : undefined}
           kind={workloadData.kind}
           element={element}
@@ -123,13 +126,7 @@ const ObservedWorkloadNode: React.FC<WorkloadNodeProps> = ({
             />,
           ]}
         >
-          <PodSet
-            size={size}
-            x={cx}
-            y={cy}
-            data={workloadData.donutStatus}
-            showPodCount={filters.podCount}
-          />
+          <PodSet size={size} x={cx} y={cy} data={donutStatus} showPodCount={filters.podCount} />
         </BaseNode>
       </Tooltip>
     </g>


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3036

**Analysis / Root cause**: 
Pod text was too large for where it was positioned within the Pod rings. Attempt was made to setup a subtitle component for the longer text but that component is not used in react-charts when positioned in the center.

**Solution Description**: 
Update the styling of the created tspan's for the pod text. Position the text in order to make longer text be in the middle of the pod ring to give more horizontal space for the text.

**Screen shots / Gifs for design review**:
Before:
![image](https://user-images.githubusercontent.com/11633780/80974589-eb70ea00-8dee-11ea-8fea-460ac4dbbc33.png)
![image](https://user-images.githubusercontent.com/11633780/80974631-f9266f80-8dee-11ea-926c-b9d8dd6a70cd.png)

After:
![image](https://user-images.githubusercontent.com/11633780/80974659-06435e80-8def-11ea-8d1d-a7b4f460ef30.png)


**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley 

/kind bug