### PR TITLE
[WIP] Replace dropdown with select

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,7 +78,7 @@
     "@fortawesome/fontawesome-free": "^5.9.0",
     "@patternfly/patternfly": "2.71.5",
     "@patternfly/react-charts": "5.3.19",
-    "@patternfly/react-core": "3.153.13",
+    "@patternfly/react-core": "3.158.0",
     "@patternfly/react-table": "2.28.39",
     "@patternfly/react-tokens": "2.8.13",
     "@patternfly/react-topology": "2.14.58",

--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -70,6 +70,14 @@
 
 .co-type-selector {
   min-width: 290px;
+  .pf-c-select__menu {
+    max-height: 58vh;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+  .pf-c-check__input {
+    margin: 0;
+  }
   @media (min-width: 480px) {
     min-width: 350px;
   }

--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -69,15 +69,13 @@
 }
 
 .co-type-selector {
-  .pf-c-dropdown__menu {
-    min-width: 290px;
-    @media (min-width: 480px) {
-      min-width: 350px;
-    }
-    .co-resource-item__tech-dev-preview {
-      color: red;
-      margin-left: 10px;
-    }
+  min-width: 290px;
+  @media (min-width: 480px) {
+    min-width: 350px;
+  }
+  .co-resource-item__tech-dev-preview {
+    color: red;
+    margin-left: 10px;
   }
 }
 

--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -69,17 +69,18 @@
 }
 
 .co-type-selector {
-  min-width: 290px;
+  max-width: 190px !important;
   .pf-c-select__menu {
     max-height: 58vh;
     overflow-x: hidden;
     overflow-y: auto;
   }
-  .pf-c-check__input {
-    margin: 0;
+  .pf-c-select__menu-item {
+    display: flex;
+    align-items: flex-start;
   }
-  @media (min-width: 480px) {
-    min-width: 350px;
+  .pf-c-check__input {
+    margin-right: var(--pf-global--spacer--sm);
   }
   .co-resource-item__tech-dev-preview {
     color: red;

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -167,25 +167,31 @@ export class EventsList extends React.Component {
       type: 'all',
       textFilter: '',
       selected: new Set(['All']),
+      customBadgeText: 'All'
     };
   }
 
   toggleSelected = (selection) => {
-    if (this.state.selected.has('All') || selection === 'All') {
-      this.setState({ selected: new Set([selection]) });
+    if (selection === 'All') {
+      this.setState({ selected: new Set([selection]), customBadgeText: 'All' });
     } else {
-      const updateItems = new Set(this.state.selected);
+      let updateItems;
+      if (this.state.selected.has('All')) {
+        updateItems = new Set([]);
+      } else {
+        updateItems = new Set(this.state.selected);
+      }
       updateItems.has(selection) ? updateItems.delete(selection) : updateItems.add(selection);
-      this.setState({ selected: updateItems });
+      this.setState({ selected: updateItems, customBadgeText: null });
     }
   };
 
   clearSelection = () => {
-    this.setState({ selected: new Set(['All']) });
+    this.setState({ selected: new Set(['All']), customBadgeText: 'All' });
   };
 
   render() {
-    const { type, selected, textFilter } = this.state;
+    const { customBadgeText, type, selected, textFilter } = this.state;
     const { autoFocus = true } = this.props;
 
     return (
@@ -198,6 +204,7 @@ export class EventsList extends React.Component {
               showAll
               clearSelection={this.clearSelection}
               className="co-search-group__resource"
+              customBadgeText={customBadgeText}
             />
             <Dropdown
               className="btn-group co-search-group__resource"

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -220,10 +220,10 @@ export class EventsList extends React.Component {
             />
           </div>
           <div className="form-group">
-            <ChipGroup withToolbar defaultIsOpen={false}>
+            {[...selected].filter(chip => chip !== 'All').length >= 1 && <ChipGroup withToolbar defaultIsOpen={false}>
               <ChipGroupToolbarItem key="resources-category" categoryName="Resource">
-                {[...selected].map((chip) => (
-                  chip !== 'All' && <Chip key={chip} onClick={() => this.toggleSelected(chip)}>
+                {[...selected].filter(chip => chip !== 'All').map((chip) => (
+                  <Chip key={chip} onClick={() => this.toggleSelected(chip)}>
                     <ResourceIcon kind={chip} />
                     {kindForReference(chip)}
                   </Chip>
@@ -236,7 +236,7 @@ export class EventsList extends React.Component {
                   </>
                 )}
               </ChipGroupToolbarItem>
-            </ChipGroup>
+            </ChipGroup>}
           </div>
         </PageHeading>
         <EventStream

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -223,7 +223,7 @@ export class EventsList extends React.Component {
             <ChipGroup withToolbar defaultIsOpen={false}>
               <ChipGroupToolbarItem key="resources-category" categoryName="Resource">
                 {[...selected].map((chip) => (
-                  <Chip key={chip} onClick={() => this.toggleSelected(chip)}>
+                  chip !== 'All' && <Chip key={chip} onClick={() => this.toggleSelected(chip)}>
                     <ResourceIcon kind={chip} />
                     {kindForReference(chip)}
                   </Chip>

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -1,19 +1,18 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import { connect } from 'react-redux';
-import { Map as ImmutableMap, OrderedMap, Set as ImmutableSet } from 'immutable';
+import { Map as ImmutableMap, Set as ImmutableSet } from 'immutable';
 import * as classNames from 'classnames';
 import * as fuzzy from 'fuzzysearch';
 
-import { Dropdown, ResourceIcon } from './utils';
+import { ResourceIcon } from './utils';
 import {
   apiVersionForReference,
   K8sKind,
   K8sResourceKindReference,
-  modelFor,
   referenceForModel,
 } from '../module/k8s';
-import { Badge, Checkbox } from '@patternfly/react-core';
+import { Select, SelectVariant, SelectOption } from '@patternfly/react-core';
 
 // Blacklist known duplicate resources.
 const blacklistGroups = ImmutableSet([
@@ -26,34 +25,9 @@ const blacklistResources = ImmutableSet([
   'events.k8s.io/v1beta1.Event',
 ]);
 
-const DropdownItem: React.SFC<DropdownItemProps> = ({ model, showGroup, checked }) => (
-  <>
-    <span className={'co-resource-item'}>
-      <Checkbox
-        tabIndex={-1}
-        id={`${model.apiGroup}:${model.apiVersion}:${model.kind}`}
-        isChecked={checked}
-      />
-      <span className="co-resource-icon--fixed-width">
-        <ResourceIcon kind={referenceForModel(model)} />
-      </span>
-      <span className="co-resource-item__resource-name">
-        <span>
-          {model.kind}
-          {model.badge && <span className="co-resource-item__tech-dev-preview">{model.badge}</span>}
-        </span>
-        {showGroup && (
-          <span className="co-resource-item__resource-api text-muted co-truncate show co-nowrap small">
-            {model.apiGroup || 'core'}/{model.apiVersion}
-          </span>
-        )}
-      </span>
-    </span>
-  </>
-);
-
 const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
   const { selected, onChange, allModels, showAll, className, preferredVersions } = props;
+  const [isExpanded, setExpanded] = React.useState(false);
 
   const resources = allModels
     .filter(({ apiGroup, apiVersion, kind, verbs }) => {
@@ -90,63 +64,82 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
   const isKindSelected = (kind: string) => {
     return _.includes(selected, kind);
   };
-  // Create dropdown items for each resource.
-  const items = resources.map((model) => (
-    <DropdownItem
+
+  // Create select option for each resource.
+  const items = resources.toArray().map((model) => (
+    <SelectOption
       key={referenceForModel(model)}
-      model={model}
-      showGroup={isDup(model.kind)}
-      checked={isKindSelected(referenceForModel(model))}
-    />
-  )) as OrderedMap<string, JSX.Element>;
-  // Add an "All" item to the top if `showAll`.
-  const allItems = (showAll
-    ? OrderedMap({
-        All: (
-          <>
-            <span className="co-resource-item">
-              <Checkbox id="all-resources" isChecked={isKindSelected('All')} />
-              <span className="co-resource-icon--fixed-width">
-                <ResourceIcon kind="All" />
-              </span>
-              <span className="co-resource-item__resource-name">All Resources</span>
+      value={model}
+      isChecked={isKindSelected(referenceForModel(model))}
+    >
+      <span className={'co-resource-item'}>
+        <span className="co-resource-icon--fixed-width">
+          <ResourceIcon kind={referenceForModel(model)} />
+        </span>
+        <span className="co-resource-item__resource-name">
+          <span>
+            {model.kind}
+            {model.badge && (
+              <span className="co-resource-item__tech-dev-preview">{model.badge}</span>
+            )}
+          </span>
+          {isDup(model.kind) && (
+            <span className="co-resource-item__resource-api text-muted co-truncate show co-nowrap small">
+              {model.apiGroup || 'core'}/{model.apiVersion}
             </span>
-          </>
-        ),
-      }).concat(items)
-    : items
-  ).toJS() as { [s: string]: JSX.Element };
+          )}
+        </span>
+      </span>
+    </SelectOption>
+  ));
 
-  const autocompleteFilter = (text, item) => {
-    const { model } = item.props;
-    if (!model) {
-      return false;
+  // Add an "All" item to the top if `showAll`.
+  const allItems = showAll
+    ? [
+        <SelectOption key="All" value="All" isChecked={isKindSelected('All')}>
+          <span className={'co-resource-item'}>
+            <span className="co-resource-icon--fixed-width">
+              <ResourceIcon kind="All" />
+            </span>
+            <span className="co-resource-item__resource-name">All Resources</span>
+          </span>
+        </SelectOption>,
+      ].concat(items)
+    : items;
+
+  const onFilter = (event) => {
+    const textInput = event.target.value;
+    if (textInput === '') {
+      return allItems;
     }
-
-    return fuzzy(_.toLower(text), _.toLower(model.kind));
+    return allItems.filter((item) => fuzzy(_.toLower(textInput), _.toLower(item.props.value.kind)));
   };
 
-  const handleSelected = (value: string) => {
-    value === 'All' ? onChange('All') : onChange(referenceForModel(modelFor(value)));
+  const onToggle = (isOpen) => {
+    setExpanded(isOpen);
+  };
+
+  const handleSelected = (event, value: K8sKind) => {
+    value === 'All' ? onChange(value) : onChange(referenceForModel(value));
   };
 
   return (
-    <Dropdown
-      menuClassName="dropdown-menu--text-wrap"
+    <Select
+      variant={SelectVariant.checkbox}
+      placeholderText="Resources"
+      selections={selected}
+      isExpanded={isExpanded}
+      ariaLabelledBy="Resources"
+      isGrouped
+      hasInlineFilter
+      onToggle={onToggle}
+      onFilter={onFilter}
+      onSelect={handleSelected}
       className={classNames('co-type-selector', className)}
-      items={allItems}
-      title={
-        <div key="title-resource">
-          Resources{' '}
-          <Badge isRead>
-            {selected.length === 1 && selected[0] === 'All' ? 'All' : selected.length}
-          </Badge>
-        </div>
-      }
-      onChange={handleSelected}
-      autocompleteFilter={autocompleteFilter}
-      autocompletePlaceholder="Select Resource"
-    />
+      noResultsFoundText=""
+    >
+      {allItems}
+    </Select>
   );
 };
 
@@ -161,16 +154,10 @@ export const ResourceListDropdown = connect(resourceListDropdownStateToProps)(
 
 export type ResourceListDropdownProps = {
   selected: K8sResourceKindReference[];
-  onChange: (value: string) => void;
+  onChange: (selection: string) => void;
   allModels: ImmutableMap<K8sResourceKindReference, K8sKind>;
   preferredVersions: { groupVersion: string; version: string }[];
   className?: string;
   id?: string;
   showAll?: boolean;
-};
-
-type DropdownItemProps = {
-  model: K8sKind;
-  showGroup?: boolean;
-  checked?: boolean;
 };

--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -26,10 +26,11 @@ const blacklistResources = ImmutableSet([
 ]);
 
 const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
-  const { selected, onChange, allModels, showAll, className, preferredVersions } = props;
+  const { selected, onChange, allModels, showAll, className, preferredVersions, customBadgeText } = props;
   const [isExpanded, setExpanded] = React.useState(false);
 
-  const resources = [...allModels.values()]
+  // @ts-ignore
+  const resources = Array.from(allModels.values())
     .filter(({ apiGroup, apiVersion, kind, verbs }) => {
       // Remove blacklisted items.
       if (
@@ -127,7 +128,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
     setExpanded(isOpen);
   };
 
-  const handleSelected = (event, value: (K8sKind | string)) => {
+  const handleSelected = (event, value: any) => {
     value === 'All' ? onChange(value) : onChange(referenceForModel(value));
   };
 
@@ -145,6 +146,8 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
       onSelect={handleSelected}
       className={classNames('co-type-selector', className)}
       noResultsFoundText=""
+      customBadgeText={customBadgeText}
+      inlineFilterPlaceholderText="Select Resource"
     >
       {allItems}
     </Select>
@@ -168,4 +171,5 @@ export type ResourceListDropdownProps = {
   className?: string;
   id?: string;
   showAll?: boolean;
+  customBadgeText?: string | number;
 };

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -96,13 +96,15 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
     // Ensure that the "kind" route parameter is a valid resource kind ID
     kind = kind || '';
     if (kind !== '') {
-      setSelectedItems(new Set(kind.split(',')));
+      const kindArray = kind.split(',');
+      const kindLength = kindArray.length;
+      setSelectedItems(new Set(kindArray));
+      setCustomBadgeText(kindLength);
     }
     const tags = split(q || '');
     const validTags = _.reject(tags, (tag) => requirementFromString(tag) === undefined);
     setLabelFilter(validTags);
     setTypeaheadNameFilter(name || '');
-    setCustomBadgeText([...selectedItems].length);
   }, []);
 
   const updateSelectedItems = (selection: string) => {

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -80,6 +80,7 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
   const [labelFilter, setLabelFilter] = React.useState([]);
   const [labelFilterInput, setLabelFilterInput] = React.useState('');
   const [typeaheadNameFilter, setTypeaheadNameFilter] = React.useState('');
+  const [customBadgeText, setCustomBadgeText] = React.useState(0);
   const { namespace, noProjectsAvailable, pinnedResources } = props;
 
   // Set state variables from the URL
@@ -101,6 +102,7 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
     const validTags = _.reject(tags, (tag) => requirementFromString(tag) === undefined);
     setLabelFilter(validTags);
     setTypeaheadNameFilter(name || '');
+    setCustomBadgeText([...selectedItems].length);
   }, []);
 
   const updateSelectedItems = (selection: string) => {
@@ -108,6 +110,7 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
     updateItems.has(selection) ? updateItems.delete(selection) : updateItems.add(selection);
     setSelectedItems(updateItems);
     setQueryArgument('kind', [...updateItems].join(','));
+    setCustomBadgeText([...updateItems].length === 0 ? 0 : null);
   };
 
   const updateNewItems = (filter: string, { key }: DataToolbarChip) => {
@@ -120,6 +123,7 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
   const clearSelectedItems = () => {
     setSelectedItems(new Set([]));
     setQueryArgument('kind', '');
+    setCustomBadgeText(0);
   };
 
   const clearNameFilter = () => {
@@ -226,6 +230,7 @@ const SearchPage_: React.FC<SearchProps & StateProps & DispatchProps> = (props) 
                 <ResourceListDropdown
                   selected={[...selectedItems]}
                   onChange={updateSelectedItems}
+                  customBadgeText={customBadgeText}
                 />
               </DataToolbarFilter>
             </DataToolbarItem>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1231,7 +1231,19 @@
     file-saver "^1.3.8"
     xterm "^3.3.0"
 
-"@patternfly/react-core@3.153.13", "@patternfly/react-core@^3.153.13":
+"@patternfly/react-core@3.158.0":
+  version "3.158.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.158.0.tgz#1c0103f57411edef6013244f3534a1f4ee6ad846"
+  integrity sha512-QBGhA5sP5auQ9ixoo9aLoyQEg7BA7Zic7LBlFnSRxPypBeTJ82hChf0qFDdN//439fVmE6wMjZeWWHB+hpekjQ==
+  dependencies:
+    "@patternfly/react-icons" "^3.15.16"
+    "@patternfly/react-styles" "^3.7.13"
+    "@patternfly/react-tokens" "^2.8.13"
+    focus-trap "4.0.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+
+"@patternfly/react-core@^3.153.13":
   version "3.153.13"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.153.13.tgz#f05dead48f3fff7dae156798c6a5b4c244d77c9d"
   integrity sha512-OyssAlsdsHWXRuKXvkcagG8PcplpE02FSLClON+407Fzhj4t0BLGWECI8RQwZ0Tapr+qVXikKQRukM5MY9zIqg==


### PR DESCRIPTION
Replaced ResourceListDropdown implementation with a PatternFly Select.

What we'd lose out of the box:
* Filter placeholder text
* 0 or "All" selected indicator
* Scroll

<img width="994" alt="Screen Shot 2020-04-30 at 8 17 02 PM" src="https://user-images.githubusercontent.com/7014965/80982873-e2d1e100-8df9-11ea-997f-5802c3816128.png">

Filtering:
<img width="1004" alt="Screen Shot 2020-04-30 at 8 17 13 PM" src="https://user-images.githubusercontent.com/7014965/80982896-e8c7c200-8df9-11ea-83af-989885c56e69.png">

Selected:
<img width="996" alt="Screen Shot 2020-04-30 at 8 17 30 PM" src="https://user-images.githubusercontent.com/7014965/80982905-ed8c7600-8df9-11ea-9ab4-0a2eb0af6924.png">

"All" badge:
<img width="1003" alt="Screen Shot 2020-05-04 at 11 25 50 AM" src="https://user-images.githubusercontent.com/7014965/80982995-0b59db00-8dfa-11ea-8d6b-557c2f9d9320.png">

Update 5/6:
* PR for placeholder text: https://github.com/patternfly/patternfly-react/pull/4185 (merged)
* PR for All/None badges: https://github.com/patternfly/patternfly-react/pull/4198 (just merged as of 5/8)

This will require a PF4 version update. We can fix scroll on the OpenShift side and it looks like other styling-related comments will be fixed by a version update.
