### PR TITLE
Bug 1831084: Adjust Pipeline Details Tooltip for Clarity

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationStepList.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationStepList.scss
@@ -20,11 +20,19 @@
 
   &__step {
     display: flex;
-    margin-bottom: 10px;
+    margin-bottom: var(--pf-global--spacer--xs);
+
+    &--task-run {
+      margin-bottom: var(--pf-global--spacer--sm);
+    }
 
     &:last-child {
       margin-bottom: 0;
     }
+  }
+
+  &__bullet {
+    font-size: 1rem;
   }
 
   &__icon {

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationStepList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationStepList.tsx
@@ -51,19 +51,20 @@ export const PipelineVisualizationStepList: React.FC<PipelineVisualizationStepLi
     <div className="odc-pipeline-vis-steps-list__task-name">{taskName}</div>
     {steps.map(({ duration, name, runStatus: status }) => {
       return (
-        <div className="odc-pipeline-vis-steps-list__step" key={name}>
-          {!isSpecOverview && (
+        <div
+          className={classNames('odc-pipeline-vis-steps-list__step', {
+            'odc-pipeline-vis-steps-list__step--task-run': !isSpecOverview,
+          })}
+          key={name}
+        >
+          {!isSpecOverview ? (
             <div className="odc-pipeline-vis-steps-list__icon">
               <TooltipColoredStatusIcon status={status} />
             </div>
+          ) : (
+            <span className="odc-pipeline-vis-steps-list__bullet">&bull;</span>
           )}
-          <div
-            className={classNames('odc-pipeline-vis-steps-list__name', {
-              'is-main-focus': isSpecOverview,
-            })}
-          >
-            {name}
-          </div>
+          <div className="odc-pipeline-vis-steps-list__name">{name}</div>
           {!isSpecOverview && (
             <div className="odc-pipeline-vis-steps-list__duration">{duration}</div>
           )}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2301

**Analysis / Root cause**: 
Hard to tell the difference between the title of the tooltip (the Task name) and the steps of the task.

**Solution Description**: 
Adjust the styling to help make it more apparent.

**Screen shots / Gifs for design review**: 
Designs already ran past Serena, but FYI @openshift/team-devconsole-ux

![Screen Shot 2020-05-04 at 11 25 02 AM](https://user-images.githubusercontent.com/8126518/80984586-0bf37100-8dfc-11ea-8551-26e4ecaf0564.png)
![Screen Shot 2020-05-04 at 11 25 07 AM](https://user-images.githubusercontent.com/8126518/80984588-0c8c0780-8dfc-11ea-8144-c466ffde3af2.png)
![Screen Shot 2020-05-04 at 11 25 19 AM](https://user-images.githubusercontent.com/8126518/80984589-0d249e00-8dfc-11ea-9713-e94ba96d6a56.png)
![Screen Shot 2020-05-04 at 11 25 29 AM](https://user-images.githubusercontent.com/8126518/80984590-0d249e00-8dfc-11ea-8db2-a9efbbf1e326.png)

**Test setup:**

* Pipeline Operator
* A Pipeline (could use the add flow one like the screenshots above)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge