### PR TITLE
Bug 1824358: null creationTimestamp shows as relative time of 50 years ago

### DIFF
--- a/frontend/public/components/utils/timestamp.tsx
+++ b/frontend/public/components/utils/timestamp.tsx
@@ -60,6 +60,11 @@ const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean) => {
 const nowStateToProps = ({ UI }) => ({ now: UI.get('lastTick') });
 
 export const Timestamp = connect(nowStateToProps)((props: TimestampProps) => {
+  // Check for null. If props.timestamp is null, it returns incorrect date and time of Wed Dec 31 1969 19:00:00 GMT-0500 (Eastern Standard Time)
+  if (!props.timestamp) {
+    return <div className="co-timestamp">-</div>;
+  }
+
   const mdate = props.isUnix
     ? new Date((props.timestamp as number) * 1000)
     : new Date(props.timestamp);


### PR DESCRIPTION
/assign @TheRealJon
/cc @benjaminapetersen @spadgett

This PR is a follow-on to PR #5197.
The PR #5197 added null value check to fromNow function in datetime.js to fix bug 1824358. However a recent change in the default-resource.js of  fromNow  to Timestamp component impacted the change because Timestamp component doesn't check for null. This PR add a null value check to Timestamp component.