### PR TITLE
Bug 1831240: Avoid multiple rerendering of tab components registered via plugin

### DIFF
--- a/frontend/packages/console-shared/src/hooks/__tests__/usePluginsOverviewTabSection.spec.ts
+++ b/frontend/packages/console-shared/src/hooks/__tests__/usePluginsOverviewTabSection.spec.ts
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { useExtensions, OverviewTabSection, LazyLoader } from '@console/plugin-sdk';
+import {
+  knativeServiceObj,
+  sampleKnativeRevisions,
+} from '@console/knative-plugin/src/topology/__tests__/topology-knative-test-data';
+import { OverviewItem } from '../../types/resource';
+import { testHook } from '../../test-utils/hooks-utils';
+import { usePluginsOverviewTabSection } from '../plugins-overview-tab-section';
+
+jest.mock('@console/plugin-sdk/src/useExtensions', () => ({
+  useExtensions: jest.fn(),
+}));
+describe('usePluginsOverviewTabSection', () => {
+  let item: OverviewItem;
+  beforeEach(() => {
+    item = {
+      revisions: sampleKnativeRevisions.data,
+      obj: knativeServiceObj,
+      buildConfigs: [],
+    } as OverviewItem;
+  });
+
+  it('should be empty, if there is no overview tab section registered', () => {
+    testHook(() => {
+      (useExtensions as jest.Mock).mockReturnValue([]);
+      expect(usePluginsOverviewTabSection(item)).toHaveLength(0);
+    });
+  });
+  it('should not be empty, when there is overview tab section registered', () => {
+    const loader: LazyLoader = jasmine
+      .createSpy('loader')
+      .and.returnValue(Promise.resolve(React.createElement(Button)));
+
+    const tabSection: OverviewTabSection = {
+      type: 'Overview/Section',
+      properties: {
+        key: 'revisions',
+        loader,
+      },
+    };
+    testHook(() => {
+      (useExtensions as jest.Mock).mockReturnValue([tabSection]);
+      expect(usePluginsOverviewTabSection(item)).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/packages/console-shared/src/hooks/plugins-overview-tab-section.ts
+++ b/frontend/packages/console-shared/src/hooks/plugins-overview-tab-section.ts
@@ -11,10 +11,16 @@ export const usePluginsOverviewTabSection = (
   item: OverviewItem,
 ): { Component: React.FC<AsyncComponentProps>; key: string }[] => {
   const tabSections = useExtensions(isOverviewTabSection);
-  return tabSections
-    .filter((section) => item[section.properties.key])
-    .map((section: OverviewTabSection) => ({
-      Component: getResourceTabSectionComp(section),
-      key: section.properties.key,
-    }));
+  return React.useMemo(
+    () =>
+      tabSections
+        .filter((section) => item[section.properties.key])
+        .map((section: OverviewTabSection) => ({
+          Component: getResourceTabSectionComp(section),
+          key: section.properties.key,
+        })),
+    // `item` is complex object but we only use the presence of keys as a dependency
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(Object.keys(item).sort())],
+  );
 };

--- a/frontend/public/components/overview/resource-overview-page.tsx
+++ b/frontend/public/components/overview/resource-overview-page.tsx
@@ -13,30 +13,15 @@ import { BuildOverview } from './build-overview';
 import { NetworkingOverview } from './networking-overview';
 import { PodsOverview } from './pods-overview';
 import { resourceOverviewPages } from './resource-overview-pages';
-import { OverviewItem } from '@console/shared';
-import * as plugins from '../../plugins';
+import { OverviewItem, usePluginsOverviewTabSection } from '@console/shared';
 
 const { common } = Kebab.factory;
-
-const getResourceTabSectionComp = (t) => (props) => (
-  <AsyncComponent {...props} loader={t.properties.loader} />
-);
-
-const getPluginTabSectionResource = (item) => {
-  return plugins.registry
-    .getOverviewTabSections()
-    .filter((section) => item[section.properties.key])
-    .map((section) => ({
-      Component: getResourceTabSectionComp(section),
-      key: section.properties.key,
-    }));
-};
 
 export const OverviewDetailsResourcesTab: React.SFC<OverviewDetailsResourcesTabProps> = ({
   item,
 }) => {
   const { buildConfigs, routes, services, pods, obj } = item;
-  const pluginComponents = getPluginTabSectionResource(item);
+  const pluginComponents = usePluginsOverviewTabSection(item);
   return (
     <div className="overview__sidebar-pane-body">
       <OperatorBackedOwnerReferences item={item} />


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-2122

**Problem:**
While using the PipelineOverview component through a plugin in the sidebar. It mounts and unmounts continuously. Plugin is being used in `resource-overview-page.tsx` and defined in dev-console `plugin.tsx`.

**Solution:**
Added  useEffect hook to mount the async components only once instead of re creating the components for every small updates from firehose.

**Screeshot/gif:**
![pipeline-overview-component](https://user-images.githubusercontent.com/9964343/80997734-64a82580-8e5f-11ea-891f-e0227f2b82b1.gif)

Unit test coverage:
![image](https://user-images.githubusercontent.com/9964343/81109074-2c741600-8f37-11ea-9429-00519d8af5e8.png)

Browser Conformance:

 - [x] Chrome
 - [x] Firefox
 - [ ] Safari
 - [ ] Edge

cc: @christianvogt @sahil143 
/kind bug