### PR TITLE
Turn off webpack devServer.contentBase option

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -41,6 +41,7 @@ const config: Configuration = {
     progress: true,
     hot: HOT_RELOAD !== 'false',
     inline: HOT_RELOAD !== 'false',
+    contentBase: false,
   },
   resolve: {
     extensions: ['.glsl', '.ts', '.tsx', '.js', '.jsx'],


### PR DESCRIPTION
Console UI uses webpack [dev-server](https://webpack.js.org/configuration/dev-server/) to facilitate hot code reloading for better development.

By default, webpack dev-server also [serves static files](https://webpack.js.org/configuration/dev-server/#devservercontentbase) from the current working directory:

```
Content not from webpack is served from /home/vszocs/go/src/github.com/openshift/console/frontend
```

We already use the Bridge server endpoint `/static` to serve files under `frontend/public/dist`.