### PR TITLE
Bug 1831087: Storage persistent volume claim form inputs need proper labels

### DIFF
--- a/frontend/public/components/storage/create-pvc.tsx
+++ b/frontend/public/components/storage/create-pvc.tsx
@@ -266,6 +266,7 @@ export const CreatePVCForm: React.FC<CreatePVCFormProps> = (props) => {
         defaultRequestSizeValue={requestSizeValue}
         dropdownUnits={dropdownUnits}
         describedBy="request-size-help"
+        inputID="request-size-input"
       />
       <p className="help-block" id="request-size-help">
         Desired storage capacity.

--- a/frontend/public/components/utils/request-size-input.tsx
+++ b/frontend/public/components/utils/request-size-input.tsx
@@ -19,7 +19,7 @@ export class RequestSizeInput extends React.Component<RequestSizeInputProps> {
   };
 
   render() {
-    const { describedBy, name } = this.props;
+    const { describedBy, name, inputID } = this.props;
     const inputName = `${name}Value`;
     const dropdownName = `${name}Unit`;
     return (
@@ -33,6 +33,7 @@ export class RequestSizeInput extends React.Component<RequestSizeInputProps> {
             placeholder={this.props.placeholder}
             aria-describedby={describedBy}
             name={inputName}
+            id={inputID}
             required={this.props.required}
             value={this.props.defaultRequestSizeValue}
             min={this.props.minValue}
@@ -45,6 +46,7 @@ export class RequestSizeInput extends React.Component<RequestSizeInputProps> {
             items={this.props.dropdownUnits}
             onChange={this.onUnitChange}
             required={this.props.required}
+            ariaLabel={`Number of ${this.props.dropdownUnits[this.props.defaultRequestSizeUnit]}`}
           />
         </div>
       </div>
@@ -64,4 +66,5 @@ export type RequestSizeInputProps = {
   step?: number;
   minValue?: number;
   inputClassName?: string;
+  inputID?: string;
 };


### PR DESCRIPTION
This adds an id to the size input field which associates it to the above label, fixing the following axe error: 
```
{
    "data": null,
    "id": "aria-label",
    "impact": "serious",
    "message": "aria-label attribute does not exist or is empty",
    "relatedNodes": [
      {
        "html": "<input class="pf-c-form-control" type="number" step="any" aria-describedby="request-size-help" name="requestSizeValue" required="" value="">"
      }
    ]
  }
```
A label was also added to the dropdown beside the input field to make it clear to assistive technology.