### PR TITLE
CNV: Don't set net-attach-def type at root

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -29,7 +29,6 @@ import NetworkTypeOptions from './NetworkTypeOptions';
 const buildConfig = (name, networkType, typeParamsData): NetworkAttachmentDefinitionConfig => {
   const config: NetworkAttachmentDefinitionConfig = {
     name,
-    type: networkType,
     cniVersion: '0.3.1',
   };
 
@@ -53,6 +52,7 @@ const buildConfig = (name, networkType, typeParamsData): NetworkAttachmentDefini
     ];
   } else if (networkType === 'sriov') {
     config.ipam = ipam;
+    config.type = networkType;
   }
 
   return config;


### PR DESCRIPTION
When NetworkAttachmentDefinion carries a chain of plugins in "plugins"
attribute, it should not define any "type" at the root of the "config".
If it does, the "plugins" list is ignored and the config is passed to
the CNI set in "type".

With this patch, we keep "type" only in "plugins" when cnv-bridge is
used. For SR-IOV, we keep it in root since there is no "plugins" list.

Fixes BZBZ1831069.

Signed-off-by: Petr Horacek <phoracek@redhat.com>