### PR TITLE
topology: compute dimensions of nodes if none explicitly set

### DIFF
--- a/frontend/packages/topology/src/components/ComputeElementDimensions.tsx
+++ b/frontend/packages/topology/src/components/ComputeElementDimensions.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { action } from 'mobx';
+import { observer } from 'mobx-react';
+import Dimensions from '../geom/Dimensions';
+import { Node } from '../types';
+
+type ComputeElementDimensionsProps = {
+  element: Node;
+};
+
+const ComputeElementDimensions: React.FC<ComputeElementDimensionsProps> = ({
+  element,
+  children,
+}) => {
+  const gRef = React.useRef<SVGGElement>(null);
+  React.useEffect(() => {
+    if (gRef.current && !element.isDimensionsInitialized()) {
+      const { width, height } = gRef.current.getBBox();
+      action(() => element.setDimensions(new Dimensions(width, height)))();
+    }
+  }, [element]);
+
+  // render an invisible node
+  return (
+    <g ref={gRef} style={{ visibility: 'hidden' }}>
+      {children}
+    </g>
+  );
+};
+
+// export for testing
+export const InternalComputeElementDimensions = ComputeElementDimensions;
+
+export default observer(ComputeElementDimensions);

--- a/frontend/packages/topology/src/components/__tests__/ComputeElementDimensions.spec.tsx
+++ b/frontend/packages/topology/src/components/__tests__/ComputeElementDimensions.spec.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import BaseNode from '../../elements/BaseNode';
+import ComputeElementDimensions from '../ComputeElementDimensions';
+
+describe('ComputeElementDimensions', () => {
+  it('should render invisible group', () => {
+    const wrapper = shallow(<ComputeElementDimensions element={new BaseNode()} />);
+    expect(wrapper.props().style?.visibility).toBe('hidden');
+  });
+});

--- a/frontend/packages/topology/src/elements/BaseNode.ts
+++ b/frontend/packages/topology/src/elements/BaseNode.ts
@@ -33,6 +33,9 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
   @observable.ref
   private dimensions = new Dimensions();
 
+  @observable
+  private dimensionsInitialized = false;
+
   @observable.ref
   private position = new Point();
 
@@ -148,6 +151,21 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
 
   setDimensions(dimensions: Dimensions): void {
     this.dimensions = dimensions;
+    this.dimensionsInitialized = true;
+  }
+
+  isDimensionsInitialized(): boolean {
+    if (!this.dimensionsInitialized && this.isGroup()) {
+      const nodes = this.getChildren().filter(isNode);
+      if (nodes.length === 0) {
+        return this.dimensionsInitialized;
+      }
+      const result = nodes.every((c) => c.isDimensionsInitialized());
+      if (result) {
+        this.dimensionsInitialized = true;
+      }
+    }
+    return this.dimensionsInitialized;
   }
 
   getAnchor(end?: AnchorEnd, type?: string): Anchor {
@@ -216,6 +234,10 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
 
   getTargetEdges(): Edge[] {
     return this.targetEdges;
+  }
+
+  isVisible(): boolean {
+    return super.isVisible() && this.isDimensionsInitialized();
   }
 
   setModel(model: E): void {

--- a/frontend/packages/topology/src/elements/__tests__/BaseNode.spec.ts
+++ b/frontend/packages/topology/src/elements/__tests__/BaseNode.spec.ts
@@ -1,0 +1,47 @@
+import Dimensions from '../../geom/Dimensions';
+import BaseNode from '../BaseNode';
+
+describe('BaseNode', () => {
+  it('should init dimensions', () => {
+    let node = new BaseNode();
+    expect(node.isDimensionsInitialized()).toBe(false);
+    node.setDimensions(new Dimensions());
+    expect(node.isDimensionsInitialized()).toBe(true);
+    node = new BaseNode();
+    node.setModel({
+      id: 'test',
+      type: 'test',
+      width: 1,
+      height: 1,
+    });
+    expect(node.isDimensionsInitialized()).toBe(true);
+  });
+
+  it('should be invisible until dimensions are set', () => {
+    const node = new BaseNode();
+    node.setVisible(true);
+    expect(node.isDimensionsInitialized()).toBe(false);
+    expect(node.isVisible()).toBe(false);
+    node.setDimensions(new Dimensions());
+    expect(node.isDimensionsInitialized()).toBe(true);
+    expect(node.isVisible()).toBe(true);
+  });
+
+  it('should init group dimensions based on child state', () => {
+    const node = new BaseNode();
+    node.setGroup(true);
+    expect(node.isDimensionsInitialized()).toBe(false);
+
+    const c1 = new BaseNode();
+    node.appendChild(c1);
+    expect(node.isDimensionsInitialized()).toBe(false);
+    c1.setDimensions(new Dimensions());
+    expect(node.isDimensionsInitialized()).toBe(true);
+
+    node.removeChild(c1);
+    expect(node.isDimensionsInitialized()).toBe(true);
+
+    node.setGroup(false);
+    expect(node.isDimensionsInitialized()).toBe(true);
+  });
+});

--- a/frontend/packages/topology/src/layouts/BaseLayout.ts
+++ b/frontend/packages/topology/src/layouts/BaseLayout.ts
@@ -48,7 +48,7 @@ class LayoutNode {
 
   public readonly distance: number;
 
-  public parent: LayoutGroup;
+  public parent?: LayoutGroup;
 
   public index: number;
 
@@ -157,11 +157,11 @@ class LayoutNode {
 class LayoutGroup {
   protected readonly node: Node;
 
-  public leaves: LayoutNode[];
+  public leaves: LayoutNode[] = [];
 
-  public groups: LayoutGroup[];
+  public groups: LayoutGroup[] = [];
 
-  public parent: LayoutGroup;
+  public parent?: LayoutGroup;
 
   public padding: number;
 

--- a/frontend/packages/topology/src/layouts/DagreLayout.ts
+++ b/frontend/packages/topology/src/layouts/DagreLayout.ts
@@ -34,7 +34,7 @@ class DagreNode extends LayoutNode implements dagre.Node {
 class DagreGroup extends LayoutGroup {}
 
 class DagreLink extends LayoutLink {
-  public points: any[];
+  public points?: { x: number; y: number }[];
 
   updateBendpoints(): void {
     if (this.points && !this.isFalse && this.points.length > 2) {

--- a/frontend/packages/topology/src/layouts/ForceSimulation.ts
+++ b/frontend/packages/topology/src/layouts/ForceSimulation.ts
@@ -32,10 +32,7 @@ class ForceSimulation {
       ...options,
     };
 
-    this.setupForceSimulation();
-  }
-
-  private setupForceSimulation(): void {
+    // Setup Force Simulation
     this.simulation = d3.forceSimulation<ForceSimulationNode>();
     this.simulation.force(
       'collide',

--- a/frontend/packages/topology/src/types.ts
+++ b/frontend/packages/topology/src/types.ts
@@ -136,6 +136,7 @@ export interface Node<E extends NodeModel = NodeModel, D = any> extends GraphEle
   setNodeShape(shape: NodeShape): void;
   getSourceEdges(): Edge[];
   getTargetEdges(): Edge[];
+  isDimensionsInitialized(): boolean;
 }
 
 export interface Edge<E extends EdgeModel = EdgeModel, D = any> extends GraphElement<E, D> {

--- a/frontend/packages/topology/tsconfig.json
+++ b/frontend/packages/topology/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "declaration": true,


### PR DESCRIPTION
**Fixes**: 
Topology enhancement.

**Analysis / Root cause**: 
The usefulness of using react with topology comes from being able to keep all visual logic in the react component. However topology today required the dimensions of a fixed size node to be specified in the data model before rendering.

**Solution Description**: 
If no dimensions are specified in the data model, the node is now rendered invisible and then the rendered dimensions are captured and set internally before making the node visible again. The react component can now create a fixed sized node and the rest of the visualization can update according to the measured size. Thus keeping anchors and edges in sync with the dimensions of the node.

**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/14068621/81017229-f8fa9400-8e2f-11ea-84a3-e89b914ff2cf.png)

**Test setup:**
Created new storybook story:
`Basic -> Auto Size Node`

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge

cc @jeff-phillips-18 