### PR TITLE
Bug 1827688: kubvirt redirect vm, vmi and vmtemplates to virtualization page

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
@@ -5,9 +5,20 @@ import { K8sResourceKindReference } from '@console/internal/module/k8s';
 import { TemplateModel } from '@console/internal/models';
 import { VMDisksFirehose } from '../vm-disks';
 import { VMNics } from '../vm-nics';
-import { breadcrumbsForVMPage } from '../vms/vm-details-page';
 import { menuActions } from './menu-actions';
 import { VMTemplateDetailsConnected } from './vm-template-details';
+
+export const breadcrumbsForVMTemplatePage = (match: any) => () => [
+  {
+    name: 'Virtualization',
+    path: `/k8s/ns/${match.params.ns || 'default'}/virtualization`,
+  },
+  {
+    name: 'Templates',
+    path: `/k8s/ns/${match.params.ns || 'default'}/virtualization/templates`,
+  },
+  { name: `${match.params.name} Details`, path: `${match.url}` },
+];
 
 export const VMTemplateDetailsPage: React.FC<VMTemplateDetailsPageProps> = (props) => {
   const nicsPage = {
@@ -38,7 +49,7 @@ export const VMTemplateDetailsPage: React.FC<VMTemplateDetailsPageProps> = (prop
       namespace={props.match.params.ns}
       menuActions={menuActions}
       pages={pages}
-      breadcrumbsFor={breadcrumbsForVMPage(props.match)}
+      breadcrumbsFor={breadcrumbsForVMTemplatePage(props.match)}
     />
   );
 };

--- a/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
@@ -16,7 +16,7 @@ export const RedirectToVirtualizationPage: React.FC<VirtualizationPageProps> = (
       pathname: props.match.ns
         ? `/k8s/ns/${props.match.ns}/virtualization`
         : `/k8s/all-namespaces/virtualization`,
-      search: decodeURI(props.location.search),
+      search: decodeURI(props.location?.search),
     }}
   />
 );
@@ -25,9 +25,9 @@ export const RedirectToVirtualizationTemplatePage: React.FC<VirtualizationPagePr
   <Redirect
     to={{
       pathname: props.match.ns
-        ? `/k8s/ns/${props.match.ns}/virtualization/templates${search && `?${search}`}`
-        : `/k8s/all-namespaces/virtualization/templates${search && `?${search}`}`,
-      search: decodeURI(props.location.search),
+        ? `/k8s/ns/${props.match.ns}/virtualization/templates`
+        : `/k8s/all-namespaces/virtualization/templates`,
+      search: decodeURI(props.location?.search),
     }}
   />
 );

--- a/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Redirect } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { compose } from 'redux';
 import { withStartGuide } from '@console/internal/components/start-guide';
@@ -8,6 +9,26 @@ import { FLAGS } from '@console/shared';
 import { VirtualMachinesPage } from './vm';
 import { VirtualMachineTemplatesPage } from '../vm-templates/vm-template';
 import { VirtualMachineModel } from '../../models';
+
+export const RedirectToVirtualizationPage: React.FC<VirtualizationPageProps> = (props) => (
+  <Redirect
+    to={
+      props.match.ns
+        ? `/k8s/ns/${props.match.ns}/virtualization`
+        : `/k8s/all-namespaces/virtualization`
+    }
+  />
+);
+
+export const RedirectToVirtualizationTemplatePage: React.FC<VirtualizationPageProps> = (props) => (
+  <Redirect
+    to={
+      props.match.ns
+        ? `/k8s/ns/${props.match.ns}/virtualization/templates`
+        : `/k8s/all-namespaces/virtualization/templates`
+    }
+  />
+);
 
 export const WrappedVirtualizationPage: React.FC<VirtualizationPageProps> = (props) => {
   const title = 'Virtualization';

--- a/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Redirect } from 'react-router-dom';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { compose } from 'redux';
 import { withStartGuide } from '@console/internal/components/start-guide';
@@ -10,24 +10,28 @@ import { VirtualMachinesPage } from './vm';
 import { VirtualMachineTemplatesPage } from '../vm-templates/vm-template';
 import { VirtualMachineModel } from '../../models';
 
-export const RedirectToVirtualizationPage: React.FC<VirtualizationPageProps> = (props) => (
+export const RedirectToVirtualizationPage: React.FC<RouteComponentProps<{ ns: string }>> = (
+  props,
+) => (
   <Redirect
     to={{
-      pathname: props.match.ns
-        ? `/k8s/ns/${props.match.ns}/virtualization`
+      pathname: props.match.params.ns
+        ? `/k8s/ns/${props.match.params.ns}/virtualization`
         : `/k8s/all-namespaces/virtualization`,
-      search: decodeURI(props.location?.search),
+      search: decodeURI(props.location.search),
     }}
   />
 );
 
-export const RedirectToVirtualizationTemplatePage: React.FC<VirtualizationPageProps> = (props) => (
+export const RedirectToVirtualizationTemplatePage: React.FC<RouteComponentProps<{ ns: string }>> = (
+  props,
+) => (
   <Redirect
     to={{
-      pathname: props.match.ns
-        ? `/k8s/ns/${props.match.ns}/virtualization/templates`
+      pathname: props.match.params.ns
+        ? `/k8s/ns/${props.match.params.ns}/virtualization/templates`
         : `/k8s/all-namespaces/virtualization/templates`,
-      search: decodeURI(props.location?.search),
+      search: decodeURI(props.location.search),
     }}
   />
 );

--- a/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
@@ -12,21 +12,23 @@ import { VirtualMachineModel } from '../../models';
 
 export const RedirectToVirtualizationPage: React.FC<VirtualizationPageProps> = (props) => (
   <Redirect
-    to={
-      props.match.ns
+    to={{
+      pathname: props.match.ns
         ? `/k8s/ns/${props.match.ns}/virtualization`
-        : `/k8s/all-namespaces/virtualization`
-    }
+        : `/k8s/all-namespaces/virtualization`,
+      search: decodeURI(props.location.search),
+    }}
   />
 );
 
 export const RedirectToVirtualizationTemplatePage: React.FC<VirtualizationPageProps> = (props) => (
   <Redirect
-    to={
-      props.match.ns
-        ? `/k8s/ns/${props.match.ns}/virtualization/templates`
-        : `/k8s/all-namespaces/virtualization/templates`
-    }
+    to={{
+      pathname: props.match.ns
+        ? `/k8s/ns/${props.match.ns}/virtualization/templates${search && `?${search}`}`
+        : `/k8s/all-namespaces/virtualization/templates${search && `?${search}`}`,
+      search: decodeURI(props.location.search),
+    }}
   />
 );
 
@@ -76,6 +78,7 @@ type VirtualizationPageProps = {
   skipAccessReview?: boolean;
   noProjectsAvailable?: boolean;
   flags: FlagsObject;
+  location?: { search?: string };
 };
 
 const VirtualizationPage = withStartGuide(

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -208,6 +208,35 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Page/Route',
     properties: {
+      exact: true,
+      path: [
+        '/k8s/ns/:ns/virtualmachines',
+        '/k8s/all-namespaces/virtualmachines',
+        '/k8s/ns/:ns/virtualmachineinstances',
+        '/k8s/all-namespaces/virtualmachineinstances',
+      ],
+      loader: () =>
+        import('./components/vms/virtualization' /* webpackChunkName: "kubevirt" */).then(
+          (m) => m.RedirectToVirtualizationPage,
+        ),
+      required: FLAG_KUBEVIRT,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      exact: true,
+      path: ['/k8s/ns/:ns/vmtemplates', '/k8s/all-namespaces/vmtemplates'],
+      loader: () =>
+        import('./components/vms/virtualization' /* webpackChunkName: "kubevirt" */).then(
+          (m) => m.RedirectToVirtualizationTemplatePage,
+        ),
+      required: FLAG_KUBEVIRT,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
       path: '/k8s/ns/:ns/vmtemplates/:name',
       loader: () =>
         import(

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -212,8 +212,6 @@ const plugin: Plugin<ConsumedExtensions> = [
       path: [
         '/k8s/ns/:ns/virtualmachines',
         '/k8s/all-namespaces/virtualmachines',
-        '/k8s/ns/:ns/virtualmachineinstances',
-        '/k8s/all-namespaces/virtualmachineinstances',
       ],
       loader: () =>
         import('./components/vms/virtualization' /* webpackChunkName: "kubevirt" */).then(

--- a/frontend/packages/kubevirt-plugin/src/plugin.tsx
+++ b/frontend/packages/kubevirt-plugin/src/plugin.tsx
@@ -209,10 +209,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     type: 'Page/Route',
     properties: {
       exact: true,
-      path: [
-        '/k8s/ns/:ns/virtualmachines',
-        '/k8s/all-namespaces/virtualmachines',
-      ],
+      path: ['/k8s/ns/:ns/virtualmachines', '/k8s/all-namespaces/virtualmachines'],
       loader: () =>
         import('./components/vms/virtualization' /* webpackChunkName: "kubevirt" */).then(
           (m) => m.RedirectToVirtualizationPage,


### PR DESCRIPTION
After changing the Virtualization structure, when a user navigates to 
k8s/<namespace>/virtualmachines
There is list of virtual machines, which displays only some VM attributes and does't allow all actions from the kebab menu.

This PR add redirects to virtualization page:

  - [x] Changing of namespace while in details page redirect to virtualization correctly.
  - [x] Link from overview dashbord redirect to virtualization correctly.
  - [x] Breadcrumbs from template page redirect to virtualization templates correctly.

Screenshots:
Dashbord link:
![link-from-dashboard](https://user-images.githubusercontent.com/2181522/81042382-aa450c80-8eb8-11ea-9732-073c544b9390.gif)


Template breadcrumbs:
![template-breadcrumbs](https://user-images.githubusercontent.com/2181522/81042372-a618ef00-8eb8-11ea-855a-724705d53999.gif)


Nmaespace change:
![namespace](https://user-images.githubusercontent.com/2181522/81042362-a2856800-8eb8-11ea-8895-8e1e9df207c9.gif)

Ref:
https://bugzilla.redhat.com/show_bug.cgi?id=1829213
https://bugzilla.redhat.com/show_bug.cgi?id=1827688