### PR TITLE
fix(idletask-loglink): remove log link from idle task bubble in viz

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.scss
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.scss
@@ -48,13 +48,19 @@ $border-color: var(--pf-global--BorderColor--light-100);
     display: flex;
     flex-direction: column;
     min-width: 0;
-    &:hover {
-      cursor: pointer;
-    }
+
     &.is-text-center {
       text-align: center;
       margin: 0 auto;
       flex: 0 0 100px;
+    }
+  }
+
+  &.is-linked {
+    &__title-wrapper {
+      &:hover {
+        cursor: pointer;
+      }
     }
   }
 

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationTask.tsx
@@ -122,6 +122,12 @@ const TaskComponent: React.FC<TaskProps> = ({
     ? `${resourcePathFromModel(PipelineRunModel, pipelineRunName, namespace)}/logs/${name}`
     : undefined;
 
+  const enableLogLink =
+    status?.reason !== runStatus.Idle &&
+    status?.reason !== runStatus.Pending &&
+    status?.reason !== runStatus.Cancelled &&
+    !!path;
+
   let taskPill = (
     <div className={cx('odc-pipeline-vis-task__content', { 'is-selected': selected })}>
       <div
@@ -164,6 +170,8 @@ const TaskComponent: React.FC<TaskProps> = ({
     </>
   );
   return (
-    <div className="odc-pipeline-vis-task">{path ? <Link to={path}>{visTask}</Link> : visTask}</div>
+    <div className={cx('odc-pipeline-vis-task', { 'is-linked': enableLogLink })}>
+      {enableLogLink ? <Link to={path}>{visTask}</Link> : visTask}
+    </div>
   );
 };


### PR DESCRIPTION
## Fixes:
https://issues.redhat.com/browse/ODC-2415

## Analysis / Root cause:
Pending/Idle task in visualization takes user to logs
1. Removed log links from cancelled, pending and idle tasks 
2. Remove cursor pointer for tasks without log links

## Solution Description:
remove log links from pending/idle tasks of a prun viz.

## Screenshot
![log-link_1](https://user-images.githubusercontent.com/24852534/81073148-d0909980-8f04-11ea-83fa-e678cf9f7ba1.gif)

![Failed Task link removed](https://user-images.githubusercontent.com/24852534/81177692-b5855e80-8fc4-11ea-91f6-f5c924c376cf.gif)


## Browser conformation
Chrome 73