### PR TITLE
Bug 1830010: Event streaming grid is inaccessible on events page

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/activity-card/EventItem.tsx
@@ -20,7 +20,7 @@ const EventItem: React.FC<EventItemProps> = React.memo(({ event, isExpanded, onT
   const isWarning = typeFilter('warning', event);
   const expanded = isExpanded(metadata.uid);
   return (
-    <div className="co-recent-item__body" role="gridcell">
+    <div className="co-recent-item__body">
       <AccordionItem>
         <AccordionToggle
           onClick={() => onToggle(metadata.uid)}

--- a/frontend/public/components/events.jsx
+++ b/frontend/public/components/events.jsx
@@ -100,7 +100,7 @@ const Inner = connectToFlags(FLAGS.CAN_LIST_NODE)(
             <i className="co-sysevent-icon" title={tooltipMsg} />
             <div className="co-sysevent__icon-line" />
           </div>
-          <div className="co-sysevent__box">
+          <div className="co-sysevent__box" role="gridcell">
             <div className="co-sysevent__header">
               <div className="co-sysevent__subheader">
                 <ResourceLink


### PR DESCRIPTION
This fixes the accessibility of the event streaming grid on the events page by adding a role, allowing the screen reader to understand all of the elements of the grid and read it. Without the role, VO is unable to enter into the grid and read off any of the information, making it inaccessible.

It also looks like the dashboard events stream was altered in this PR: https://github.com/openshift/console/commit/0d1ceff0d731e4ba117a38223cfa9bf201415582 
This alters the structure of the event stream that appears on the dashboard and makes the previously added role unnecessary. I like this structure better as it makes it more sturdy to future changes, but it now throws an axe error because the parent roles are no longer in use with this structure. (Before the structure was more like a grid that needed roles to navigate, this structure looks more in line with an accordion that just has an expandable/collapsible button which subsequently doesn't need any roles added.