### PR TITLE
Bug 1831735: Disable Pipeline Secret resource link

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/SecretsList.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/SecretsList.tsx
@@ -48,6 +48,7 @@ const Secrets: React.FC<SecretsProps> = ({ secrets, serviceaccounts }) => {
               name={secret.metadata.name}
               namespace={secret.metadata.namespace}
               title={secret.metadata.name}
+              linkTo={false}
             />
           );
         })}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3566

**Analysis / Root cause**: 
The Secret resources created in the Start Pipeline modal have a resource link, but when it's clicked it does not close the modal, thus putting us on the Secret details page with the Start modal open.

**Solution Description**: 
Just don't make the Secret resource clickable... there is no reason to have that navigation.

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux

Before:
![Screen Shot 2020-05-05 at 10 27 45 AM](https://user-images.githubusercontent.com/8126518/81078252-fba2cb00-8ebb-11ea-908c-b9e647fa1a3c.png)

After:
![Screen Shot 2020-05-05 at 10 27 09 AM](https://user-images.githubusercontent.com/8126518/81078267-01001580-8ebc-11ea-9b4e-7f65d3815f70.png)

**Test setup:**

- Pipeline Operator
- Pipeline (use the add flow if needed)
- Using the Start modal add a secret

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge