### PR TITLE
Bug 1831741: Operator hub and catalog need proper input field labels

### DIFF
--- a/frontend/public/components/utils/tile-view-page.jsx
+++ b/frontend/public/components/utils/tile-view-page.jsx
@@ -910,6 +910,7 @@ export class TileViewPage extends React.Component {
                   bsClass="pf-c-form-control"
                   value={activeFilters.keyword.value}
                   onChange={(e) => this.onKeywordChange(e.target.value)}
+                  aria-label="Filter by keyword..."
                 />
                 {groupItems && (
                   <Dropdown


### PR DESCRIPTION
Adds a label to the input field on both the operator hub and catalog pages, fixes the following axe error: 

```
{
    "data": null,
    "id": "aria-label",
    "impact": "serious",
    "message": "aria-label attribute does not exist or is empty",
    "relatedNodes": [
      {
        "html": "<input placeholder="Filter by keyword..." type="text" class="co-catalog-page__input pf-c-form-control" value="">"
      }
    ]
  }
```