### PR TITLE
Bug 1825191: Disallow user to select the same channel installation strategy

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/installplan-approval-modal.tsx
@@ -18,6 +18,13 @@ import { RadioInput } from '@console/internal/components/radio';
 import { SubscriptionKind, InstallPlanApproval, InstallPlanKind } from '../../types';
 import { SubscriptionModel, InstallPlanModel } from '../../models';
 
+const getApprovalStrategy = (props: InstallPlanApprovalModalProps) =>
+  (referenceFor(props.obj) === referenceForModel(SubscriptionModel) &&
+    _.get(props.obj, 'spec.installPlanApproval')) ||
+  (referenceFor(props.obj) === referenceForModel(InstallPlanModel) &&
+    _.get(props.obj, 'spec.approval')) ||
+  InstallPlanApproval.Automatic;
+
 export class InstallPlanApprovalModal extends PromiseComponent<
   InstallPlanApprovalModalProps,
   InstallPlanApprovalModalState
@@ -27,12 +34,7 @@ export class InstallPlanApprovalModal extends PromiseComponent<
   constructor(public props: InstallPlanApprovalModalProps) {
     super(props);
 
-    this.state.selectedApprovalStrategy =
-      (referenceFor(props.obj) === referenceForModel(SubscriptionModel) &&
-        _.get(props.obj, 'spec.installPlanApproval')) ||
-      (referenceFor(props.obj) === referenceForModel(InstallPlanModel) &&
-        _.get(props.obj, 'spec.approval')) ||
-      InstallPlanApproval.Automatic;
+    this.state.selectedApprovalStrategy = getApprovalStrategy(props);
   }
 
   private submit(event): void {
@@ -94,6 +96,7 @@ export class InstallPlanApprovalModal extends PromiseComponent<
           errorMessage={this.state.errorMessage}
           cancel={() => this.props.cancel()}
           submitText="Save"
+          submitDisabled={getApprovalStrategy(this.props) === this.state.selectedApprovalStrategy}
         />
       </form>
     );

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/subscription-channel-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/subscription-channel-modal.tsx
@@ -12,6 +12,9 @@ import { RadioInput } from '@console/internal/components/radio';
 import { SubscriptionKind, PackageManifestKind } from '../../types';
 import { SubscriptionModel, ClusterServiceVersionModel } from '../../models';
 
+const getSelectedChannel = (props: SubscriptionChannelModalProps) =>
+  props.subscription.spec.channel || props.pkg.status.channels[0].name;
+
 export class SubscriptionChannelModal extends PromiseComponent<
   SubscriptionChannelModalProps,
   SubscriptionChannelModalState
@@ -21,8 +24,7 @@ export class SubscriptionChannelModal extends PromiseComponent<
   constructor(public props: SubscriptionChannelModalProps) {
     super(props);
 
-    this.state.selectedChannel =
-      props.subscription.spec.channel || props.pkg.status.channels[0].name;
+    this.state.selectedChannel = getSelectedChannel(props);
   }
 
   private submit(event): void {
@@ -69,6 +71,7 @@ export class SubscriptionChannelModal extends PromiseComponent<
           errorMessage={this.state.errorMessage}
           cancel={() => this.props.cancel()}
           submitText="Save"
+          submitDisabled={this.state.selectedChannel === getSelectedChannel(this.props)}
         />
       </form>
     );


### PR DESCRIPTION
OLM shows progress icon in `Channel` and `Approval` under `Subscription`. It shows loading when a request is sent and stop showing so, only when prop changes(`spec.channel` or `spec.installPlanApproval`). Hence, the user should not be allowed to click "Save" if the same channel/Installation strategy is chosen.
Scrhots:
![Screenshot from 2020-05-06 01-35-21](https://user-images.githubusercontent.com/54092533/81111736-2849f780-8f3b-11ea-8700-2b1b72024a91.png)
![Screenshot from 2020-05-06 01-35-13](https://user-images.githubusercontent.com/54092533/81111742-2a13bb00-8f3b-11ea-9d16-54b18ddb371d.png)

/assign @TheRealJon 
cc @spadgett 