### PR TITLE
Bug 1832141: make tag as optional field in traffic split modal

### DIFF
--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
@@ -59,8 +59,9 @@ const TrafficSplitting: React.FC<TrafficSplittingProps> = ({
       onSubmit={handleSubmit}
       onReset={cancel}
       initialStatus={{ error: '' }}
-      render={(props) => <TrafficSplittingModal {...props} revisionItems={revisionItems} />}
-    />
+    >
+      {(props) => <TrafficSplittingModal {...props} revisionItems={revisionItems} />}
+    </Formik>
   );
 };
 export default TrafficSplitting;

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
@@ -41,7 +41,7 @@ const TrafficSplittingModal: React.FC<Props> = ({
             style={{ maxWidth: '100%' }}
             required
           />
-          <InputField name="tag" type={TextInputTypes.text} required />
+          <InputField name="tag" type={TextInputTypes.text} />
           <DropdownField
             name="revisionName"
             items={revisionItems}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2433

**Analysis / Root cause**: 
Tag in traffic split modal was required field earlier and now it's optional based on change in api spec

**Solution Description**: 
Made Tag in traffic split modal as optional field

**Screen shots / Gifs for design review**: 
<img width="658" alt="Screenshot 2020-05-06 at 1 01 15 PM" src="https://user-images.githubusercontent.com/5129024/81148330-b5239e00-8f99-11ea-830a-58fae8ed1c81.png">



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/kind bug
