### PR TITLE
Bug 1830373:  Fix bug where too much whitespace can appear above YAML…

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -465,7 +465,7 @@ export const EditYAML_ = connect(stateToProps)(
                     options={options}
                     showShortcuts={!genericYAML}
                     minHeight="100px"
-                    toolbarLinks={[sidebarLink]}
+                    toolbarLinks={sidebarLink ? [sidebarLink] : []}
                     onChange={(newValue) =>
                       this.setState({ yaml: newValue }, () => onChange(newValue))
                     }


### PR DESCRIPTION
… editor

Before:
![Screenshot_2020-05-01 Alerting Â· OKD](https://user-images.githubusercontent.com/895728/81181645-c27d6000-8f7a-11ea-8fc6-a8506eb7cd2e.png)

After:
![localhost_9000_monitoring_alertmanageryaml(4  PFLG)](https://user-images.githubusercontent.com/895728/81181630-bbeee880-8f7a-11ea-85a1-d54ffa075725.png)

cc: @rohitkrai03 