### PR TITLE
Bug 1832280: Fix visual connector to distinguish between nodes of different kinds

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -238,6 +238,8 @@ export type KialiEdge = {
   };
 };
 
+export type ConnectsToData = { apiVersion: string; kind: string; name: string };
+
 export type NodeProvider = (type: string) => ComponentType<NodeProps>;
 
 export type EdgeProvider = (type: string) => ComponentType<EdgeProps>;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-2478

**Analysis / Root cause:**
Visual connector was created based on the name of the resource alone and since there can be multiple resources with same name it was not able to distinguish between nodes of different kinds.

**Solution Description:**
Create visual connector based on both resource name and kind.

**Gif**
![Peek 2020-05-08 02-24](https://user-images.githubusercontent.com/20724543/81343675-0d11f000-90d3-11ea-99b6-edbe5c1f66ca.gif)


/kind bug