### PR TITLE
Bug 1831315: Improve formatting of markdown tables

### DIFF
--- a/frontend/public/components/markdown-view.tsx
+++ b/frontend/public/components/markdown-view.tsx
@@ -100,14 +100,15 @@ export class SyncMarkdownView extends React.Component<
         min-width: auto !important;
       }
       table {
+        display: block;
         margin-bottom: 11.5px;
+        overflow-x: auto;
       }
       td,
       th {
         border-bottom: 1px solid #ededed;
         padding: 10px;
         vertical-align: top;
-        word-break: break-word;
       }
       th {
         padding-top: 0;


### PR DESCRIPTION
`word-break: break-word` was causing later table columns to get squished
to a few characters when the first column had a long string. Switch to
horizontal scrolling to handle table cells with a lot of content, which
should also work better at mobile.

/assign @rhamilto 

Before:

<img width="608" alt="Screen Shot 2020-05-06 at 10 27 58 AM" src="https://user-images.githubusercontent.com/1167259/81190050-50f6df00-8f85-11ea-8e7e-568afc9174a7.png">

After:

<img width="885" alt="Screen Shot 2020-05-06 at 10 32 37 AM" src="https://user-images.githubusercontent.com/1167259/81190092-5bb17400-8f85-11ea-8d53-dc0e5df1e4a7.png">

Unbroken strings will scroll horizontally:

<img width="916" alt="Screen Shot 2020-05-06 at 10 36 12 AM" src="https://user-images.githubusercontent.com/1167259/81190219-8ac7e580-8f85-11ea-8a87-4fb531f6ea16.png">
