### PR TITLE
Bug 1832582: Do not force a min with on images in the Add selector cards

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/SelectorCard.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/item-selector-field/SelectorCard.scss
@@ -8,8 +8,7 @@
 
   &__icon {
     height: 32px;
-    max-width: 80px;
-    min-width: 40px;
+    max-width: 100%;
   }
 
   &__title {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3781

**Analysis / Root cause**: 
The height of the image was set along with a min and max width, for square images this can be a problem since the min width was 40 but the height was 32.

**Solution Description**: 
Set the height to 32px but only set a maximum width

**Screen shots / Gifs for design review**:
![image](https://user-images.githubusercontent.com/11633780/81229234-77387100-8fbd-11ea-9a8a-cca4c666004e.png)

![image](https://user-images.githubusercontent.com/11633780/81229256-7f90ac00-8fbd-11ea-8f64-b76b6e4644aa.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley 

/kind bug