### PR TITLE
Bug 1826354: Container Security Fixes

### DIFF
--- a/frontend/packages/container-security/src/components/__tests__/image-manifest-vuln.spec.tsx
+++ b/frontend/packages/container-security/src/components/__tests__/image-manifest-vuln.spec.tsx
@@ -12,7 +12,7 @@ import {
   ImageManifestVulnDetailsProps,
 } from '../image-manifest-vuln';
 import { fakeVulnFor } from '../../../integration-tests/bad-pods';
-import { Priority, vulnPriority, totalFor } from '../../const';
+import { Priority, vulnPriority, totalFor, priorityFor } from '../../const';
 
 describe(ImageVulnerabilityRow.displayName, () => {
   let wrapper: ShallowWrapper<ImageVulnerabilityRowProps>;
@@ -45,7 +45,7 @@ describe(ImageVulnerabilitiesTable.displayName, () => {
     expect(wrapper.find(ImageVulnerabilityRow).length).toEqual(3);
     const indexes = wrapper
       .find(ImageVulnerabilityRow)
-      .map((r) => vulnPriority.find((p) => p.title === r.props().vulnerability.severity).index);
+      .map((r) => priorityFor(r.props().vulnerability.severity).index);
     expect(indexes).toEqual(_.sortBy(indexes));
   });
 });

--- a/frontend/packages/container-security/src/const.ts
+++ b/frontend/packages/container-security/src/const.ts
@@ -125,3 +125,6 @@ export const totalFor = (priority: Priority) => (obj: ImageManifestVuln) => {
       return 0;
   }
 };
+
+export const priorityFor = (severity: string) =>
+  vulnPriority.find(({ title }) => title === severity) || vulnPriority.get(Priority.Unknown);

--- a/frontend/packages/container-security/src/plugin.ts
+++ b/frontend/packages/container-security/src/plugin.ts
@@ -96,7 +96,7 @@ const plugin: Plugin<ConsumedExtensions> = [
   {
     type: 'Dashboards/Overview/Health/Resource',
     properties: {
-      title: 'Quay Image Security',
+      title: 'Image Vulnerabilities',
       resources: {
         imageManifestVuln: {
           kind: referenceForModel(ImageManifestVulnModel),
@@ -105,7 +105,7 @@ const plugin: Plugin<ConsumedExtensions> = [
         },
       },
       healthHandler: securityHealthHandler,
-      popupTitle: 'Quay Image Security breakdown',
+      popupTitle: 'Image Vulnerabilities breakdown',
       popupComponent: () =>
         import('./components/summary' /* webpackChunkName: "container-security" */).then(
           (m) => m.SecurityBreakdownPopup,
@@ -122,7 +122,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       section: 'Administration',
       mergeBefore: 'Custom Resource Definitions',
       componentProps: {
-        name: 'Image Manifest Vulnerabilities',
+        name: 'Image Vulnerabilities',
         resource: referenceForModel(ImageManifestVulnModel),
         testID: 'imagemanifestvuln-header',
       },


### PR DESCRIPTION
### Description

Addresses a few issues in the UI for the Container Security Operator, including clarification of text on the popover card, fixing link creation, and fixing page crashes caused by unsafe k8s property access.

### Screenshots

**Image Security breakdown card (vulns present):**
![Screenshot_20200507_133122](https://user-images.githubusercontent.com/11700385/81342454-22056980-9068-11ea-8200-bb28f6481d13.png)

**Image Security breakdown card (no vulns present):**
![Screenshot_20200504_153545](https://user-images.githubusercontent.com/11700385/81020114-f5114680-8e1c-11ea-97a2-91b8164990a5.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1826354
Fixes https://issues.redhat.com/browse/PROJQUAY-676
Addresses https://issues.redhat.com/browse/PROJQUAY-482