### PR TITLE
Bug 1828448: Align VM tab order with other resources

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -51,7 +51,7 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
 
   const consolePage = {
     href: VM_DETAIL_CONSOLES_HREF,
-    name: 'Consoles',
+    name: 'Console',
     component: VMConsoleFirehose,
   };
 
@@ -77,11 +77,11 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
     dashboardPage,
     overviewPage,
     navFactory.editYaml(),
-    consolePage,
+    environmentPage,
     navFactory.events(VMEvents),
+    consolePage,
     nicsPage,
     disksPage,
-    environmentPage,
   ];
 
   const resources = [


### PR DESCRIPTION
The previous order was: 
Overview | Details | YAML | Console | Events | Network Interfaces | Disks | Environment

The new order is:
Overview | Details | YAML | Environment | Events | Console | Network Interfaces | Disks