### PR TITLE
Bug 1821577: No info "badge" on alert details page for Alert Watchdog after alert name at the top

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -244,7 +244,7 @@ const Severity: React.FC<{ severity: string }> = ({ severity }) =>
   );
 
 const SeverityBadge: React.FC<{ severity: string }> = ({ severity }) =>
-  _.isNil(severity) || severity === 'none' ? null : (
+  _.isNil(severity) ? null : (
     <span className="co-resource-item__resource-status">
       <Badge className="co-resource-item__resource-status-badge" isRead>
         <Severity severity={severity} />


### PR DESCRIPTION
### Added badges

![image](https://user-images.githubusercontent.com/12733153/81303727-15721880-904a-11ea-9ad3-01d80e40a0bd.png)

![image](https://user-images.githubusercontent.com/12733153/81303743-1b67f980-904a-11ea-985a-b2e4d37f8de4.png)
