### PR TITLE
Bug 1833034: fix traffic percentage shown for same revisions in topology sidebar

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/topology-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/topology-types.ts
@@ -57,7 +57,7 @@ export interface Edge {
   type?: string;
   source: string;
   target: string;
-  data?: {};
+  data?: { [key: string]: any };
 }
 
 export interface Group {

--- a/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RevisionsOverviewListItem.tsx
@@ -4,6 +4,7 @@ import { PodStatus } from '@console/shared';
 import { ChartLabel } from '@patternfly/react-charts';
 import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
 import { ResourceLink } from '@console/internal/components/utils';
+import { Traffic } from '../../types';
 import { RevisionModel } from '../../models';
 import './RevisionsOverviewListItem.scss';
 
@@ -26,7 +27,11 @@ const RevisionsOverviewListItem: React.FC<RevisionsOverviewListItemProps> = ({
     if (!traffic || !traffic.length) {
       return null;
     }
-    const trafficPercent = _.get(_.find(traffic, { revisionName: revName }), 'percent', null);
+    const trafficPercent = traffic
+      .filter((t: Traffic) => t.revisionName === revName)
+      .map((tr: Traffic) => tr.percent)
+      .reduce((a: number, b: number) => a + b, 0);
+
     return trafficPercent ? `${trafficPercent}%` : null;
   };
   const deploymentData = _.get(revision, 'resources.current.obj.metadata.ownerReferences[0]', {});

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewList.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewList.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { SidebarSectionHeading } from '@console/internal/components/utils';
+import { getKnativeRoutesLinks } from '../../utils/resource-overview-utils';
 import RoutesOverviewListItem from './RoutesOverviewListItem';
 
 export type RoutesOverviewListProps = {
@@ -16,9 +17,12 @@ const RoutesOverviewList: React.FC<RoutesOverviewListProps> = ({ ksroutes, resou
       <span className="text-muted">No Routes found for this resource.</span>
     ) : (
       <ul className="list-group">
-        {_.map(ksroutes, (route) => (
-          <RoutesOverviewListItem key={route.metadata.uid} route={route} resource={resource} />
-        ))}
+        {_.map(ksroutes, (route) => {
+          const routeLinks = getKnativeRoutesLinks(route, resource);
+          return routeLinks.map((routeLink) => (
+            <RoutesOverviewListItem key={routeLink.uid} routeLink={routeLink} />
+          ));
+        })}
       </ul>
     )}
   </>

--- a/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewListItem.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/RoutesOverviewListItem.tsx
@@ -1,30 +1,30 @@
 import * as React from 'react';
-import * as _ from 'lodash';
-import { K8sResourceKind, referenceForModel } from '@console/internal/module/k8s';
+import { referenceForModel } from '@console/internal/module/k8s';
 import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
 import { RouteModel } from '../../models';
+import { RoutesOverviewListItem } from '../../types';
 
 export type RoutesOverviewListItemProps = {
-  route: K8sResourceKind;
-  resource: K8sResourceKind;
+  routeLink: RoutesOverviewListItem;
 };
 
-const RoutesOverviewListItem: React.FC<RoutesOverviewListItemProps> = ({ route, resource }) => {
-  const {
-    metadata: { name, namespace },
-    status: { url },
-  } = route;
-  const trafficData = _.find(route.status.traffic, {
-    revisionName: resource.metadata.name,
-  });
-  const routeUrl = _.get(trafficData, 'url', url);
-  return (
-    <li className="list-group-item">
-      <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
-      <span className="text-muted">Location: </span>
-      <ExternalLink href={routeUrl} additionalClassName="co-external-link--block" text={routeUrl} />
-    </li>
-  );
-};
+const RoutesOverviewListItem: React.FC<RoutesOverviewListItemProps> = ({
+  routeLink: { url, name, namespace, percent },
+}) => (
+  <li className="list-group-item">
+    <div className="row">
+      <div className="col-xs-10">
+        <ResourceLink kind={referenceForModel(RouteModel)} name={name} namespace={namespace} />
+        {url.length > 0 && (
+          <>
+            <span className="text-muted">Location: </span>
+            <ExternalLink href={url} additionalClassName="co-external-link--block" text={url} />
+          </>
+        )}
+      </div>
+      {percent.length > 0 && <span className="col-xs-2 text-right">{percent}</span>}
+    </div>
+  </li>
+);
 
 export default RoutesOverviewListItem;

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RevisionsOverviewListItem.spec.tsx
@@ -54,6 +54,23 @@ describe('RevisionsOverviewListItem', () => {
     expect(wrapper.find('.odc-revision-deployment-list').exists()).toBeFalsy();
   });
 
+  it('should sum the traffic percentage for the same revision', () => {
+    const { revisionName } = MockKnativeResources.ksservices.data[0].status.traffic[0];
+    const mockServiceData = {
+      ...MockKnativeResources.ksservices.data[0],
+      status: {
+        ...MockKnativeResources.ksservices.data[0].status,
+        traffic: [
+          { percent: 50, tag: 'tag-1', revisionName },
+          { percent: 50, tag: 'tag-2', revisionName },
+        ],
+      },
+    };
+    wrapper.setProps({ service: mockServiceData });
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+    expect(wrapper.find('span.text-right').text()).toBe('100%');
+  });
+
   describe('RevisionsOverviewListItem: deployments', () => {
     beforeEach(() => {
       const resources = {

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewListItem.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/RoutesOverviewListItem.spec.tsx
@@ -5,18 +5,18 @@ import { ResourceLink, ExternalLink } from '@console/internal/components/utils';
 import { MockKnativeResources } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
 import { RouteModel } from '../../../models';
 import RoutesOverviewListItem from '../RoutesOverviewListItem';
+import { getKnativeRoutesLinks } from '../../../utils/resource-overview-utils';
 
 type RoutesOverviewListItemProps = React.ComponentProps<typeof RoutesOverviewListItem>;
 
 describe('RoutesOverviewListItem', () => {
   let wrapper: ShallowWrapper<RoutesOverviewListItemProps>;
   beforeEach(() => {
-    wrapper = shallow(
-      <RoutesOverviewListItem
-        route={MockKnativeResources.ksroutes.data[0]}
-        resource={MockKnativeResources.revisions.data[0]}
-      />,
+    const [routeLink] = getKnativeRoutesLinks(
+      MockKnativeResources.ksroutes.data[0],
+      MockKnativeResources.revisions.data[0],
     );
+    wrapper = shallow(<RoutesOverviewListItem routeLink={routeLink} />);
   });
 
   it('should list the Route', () => {
@@ -64,12 +64,11 @@ describe('RoutesOverviewListItem', () => {
         ],
       },
     };
-    wrapper = shallow(
-      <RoutesOverviewListItem
-        route={mockRouteData}
-        resource={MockKnativeResources.revisions.data[0]}
-      />,
+    const [routeLink] = getKnativeRoutesLinks(
+      mockRouteData,
+      MockKnativeResources.revisions.data[0],
     );
+    wrapper.setProps({ routeLink });
     expect(wrapper.find(ExternalLink)).toHaveLength(1);
     expect(
       wrapper
@@ -79,5 +78,29 @@ describe('RoutesOverviewListItem', () => {
     ).toEqual(
       'http://abc-overlayimage.knativeapps.apps.bpetersen-june-23.devcluster.openshift.com',
     );
+  });
+  it('should not show the route url and traffic percentage section, if there are not available', () => {
+    const mockRouteData = {
+      ...MockKnativeResources.ksroutes.data[0],
+      status: {
+        ...MockKnativeResources.ksroutes.data[0].status,
+        url: undefined,
+        traffic: [
+          {
+            ...MockKnativeResources.ksroutes.data[0].status.traffic[0],
+            percent: undefined,
+            url: undefined,
+          },
+        ],
+      },
+    };
+    const [routeLink] = getKnativeRoutesLinks(
+      mockRouteData,
+      MockKnativeResources.revisions.data[0],
+    );
+    wrapper.setProps({ routeLink });
+    expect(wrapper.find(ResourceLink)).toHaveLength(1);
+    expect(wrapper.find(ExternalLink)).toHaveLength(0);
+    expect(wrapper.find('span.text-right')).toHaveLength(0);
   });
 });

--- a/frontend/packages/knative-plugin/src/types.ts
+++ b/frontend/packages/knative-plugin/src/types.ts
@@ -41,4 +41,13 @@ export type Traffic = {
   percent: number;
   latestRevision?: boolean;
   tag?: string;
+  url?: string;
+};
+
+export type RoutesOverviewListItem = {
+  uid: string;
+  url: string;
+  percent: string;
+  name: string;
+  namespace: string;
 };

--- a/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/knative-topology-utils.spec.ts
@@ -100,6 +100,20 @@ describe('knative topology utils', () => {
     expect(knRevisionsEdge[0].type).toBe('revision-traffic');
   });
 
+  it('expect getTrafficTopologyEdgeItems to return the sum of the percentage if there are multiple same revisions', () => {
+    const ksvc = _.cloneDeep(MockKnativeResources.ksservices.data[0]);
+    const { uid, name: revisionName } = MockKnativeResources.revisions.data[0].metadata;
+    ksvc.status = {
+      traffic: [
+        { uid, revisionName, percent: 40 },
+        { uid, revisionName, percent: 60 },
+      ],
+    };
+    const knRevisionsEdge = getTrafficTopologyEdgeItems(ksvc, MockKnativeResources.revisions);
+    expect(knRevisionsEdge).toBeDefined();
+    expect(knRevisionsEdge).toHaveLength(1);
+    expect(knRevisionsEdge[0].data.percent).toBe(100);
+  });
   it('should only return revisions which are in the service traffic status', () => {
     expect(filterRevisionsBaseOnTrafficStatus(mockServiceData, mockRevisions)).toHaveLength(1);
     const mockRev = {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/resource-overview-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/resource-overview-utils.spec.ts
@@ -1,0 +1,58 @@
+import { MockKnativeResources } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
+import { getKnativeRoutesLinks } from '../resource-overview-utils';
+
+describe('resource overview utils', () => {
+  const multipleRevisionsData = {
+    ...MockKnativeResources.ksroutes.data[0],
+    status: {
+      ...MockKnativeResources.ksroutes.data[0].status,
+      traffic: [
+        {
+          ...MockKnativeResources.ksroutes.data[0].status.traffic[0],
+          percent: 50,
+          tag: 'tag-one',
+          url: 'http://testing.apps.bpetersen-june-23.devcluster.openshift.com',
+        },
+        {
+          ...MockKnativeResources.ksroutes.data[0].status.traffic[0],
+          percent: 25,
+        },
+        {
+          ...MockKnativeResources.ksroutes.data[0].status.traffic[0],
+          revisionName: 'test',
+          percent: 25,
+        },
+      ],
+    },
+  };
+  it('expect getKnativeRoutesLinks to return array of resource overview item', () => {
+    const routeLinks = getKnativeRoutesLinks(
+      MockKnativeResources.ksroutes.data[0],
+      MockKnativeResources.revisions.data[0],
+    );
+    expect(routeLinks).toHaveLength(1);
+  });
+  it('should return all the revisions in the traffic block if service is passed', () => {
+    const routeLinks = getKnativeRoutesLinks(
+      multipleRevisionsData,
+      MockKnativeResources.ksservices.data[0],
+    );
+    expect(routeLinks).toHaveLength(3);
+  });
+
+  it('should return only the matching revisions in the traffic block if revision is passed', () => {
+    const routeLinks = getKnativeRoutesLinks(
+      multipleRevisionsData,
+      MockKnativeResources.revisions.data[0],
+    );
+    expect(routeLinks).toHaveLength(2);
+  });
+
+  it('should return empty array if the resource does not match with traffic revision name', () => {
+    const routeLinks = getKnativeRoutesLinks(
+      multipleRevisionsData,
+      MockKnativeResources.services.data[0],
+    );
+    expect(routeLinks).toHaveLength(0);
+  });
+});

--- a/frontend/packages/knative-plugin/src/utils/resource-overview-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/resource-overview-utils.ts
@@ -1,0 +1,36 @@
+import { K8sResourceKind, referenceFor, referenceForModel } from '@console/internal/module/k8s';
+import { ServiceModel as knServiceModel, RevisionModel } from '../models';
+import { Traffic, RoutesOverviewListItem } from '../types';
+/**
+ * Return the knative routes list items.
+ * @param route
+ * @param resource | resource can be a knative service or revision;
+ */
+export const getKnativeRoutesLinks = (
+  route: K8sResourceKind,
+  resource: K8sResourceKind,
+): RoutesOverviewListItem[] => {
+  if (!route.status) {
+    return [];
+  }
+  const {
+    metadata: { name, namespace },
+    status: {
+      url = '',
+      traffic: trafficData = [{ revisionName: resource.metadata.name, url: route?.status?.url }],
+    },
+  } = route;
+  const filterTrafficBasedOnResource = (tr: Traffic) =>
+    referenceFor(resource) === referenceForModel(knServiceModel) ||
+    (referenceFor(resource) === referenceForModel(RevisionModel) &&
+      tr.revisionName === resource.metadata.name);
+  return trafficData
+    .filter(filterTrafficBasedOnResource)
+    .map((traffic: Traffic, index: number) => ({
+      uid: `${traffic.revisionName}-${traffic?.tag ? traffic?.tag : 'tag'}-${index}`,
+      url: traffic?.url || url,
+      percent: traffic.percent ? `${traffic.percent}%` : '',
+      name,
+      namespace,
+    }));
+};


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-2479

**Problem:**
When traffic is split to the same revision but with different tags, the topology and sidebar do not show the correct traffic % to the revision.



**Solution:**
For the same revision with diff tags i.e **rev1 with tag1 - 60%** and **rev1 with tag2 40%**, the highest traffic revision's route will be linked to topology route decorator and the percentage will be the sum of both the tags (60+40 = 100) and In sidebar we are now showing all associated routes for revisions with associated percentage

**Screeshot/gif:**

![traffic-split](https://user-images.githubusercontent.com/9964343/81321886-c4493f80-90b0-11ea-804d-00f61a65fb82.gif)

**Unit coverage:**

Added tests in RoutesOverviewListItem.tsx, RevisionsOverviewListItem.spec.tsx, knative-topology-utils.spec.tsx

![image](https://user-images.githubusercontent.com/9964343/81321621-73d1e200-90b0-11ea-95f7-cbd78f24b1b1.png)

![image](https://user-images.githubusercontent.com/9964343/81321563-5f8de500-90b0-11ea-99b5-27b299ef10e6.png)

![image](https://user-images.githubusercontent.com/9964343/81321830-b3003300-90b0-11ea-90c6-14cc6de82ec5.png)
resource-overview-utils.spec.ts
![image](https://user-images.githubusercontent.com/9964343/81582206-6036bc00-93cd-11ea-9920-8691d558cf08.png)

**Browser Conformance:**

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @openshift/team-devconsole-ux @serenamarie125 