### PR TITLE
Bug 1833065: Fixes: EventSource card on Add should show if knativeEventing Crd is present and have EventSources 

### DIFF
--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -63,7 +63,9 @@ const ODCEmptyState: React.FC<Props> = ({
   activeNamespace,
   hintBlock = 'Select a way to create an application, component or service from one of the options.',
 }) => {
-  const addActionExtensions = useExtensions<AddAction>(isAddAction);
+  const addActionExtensions = useExtensions<AddAction>(
+    isAddAction,
+  ).filter(({ properties: { id, hide } }) => (hide ? hide(id) : true));
   return (
     <>
       <div className="odc-empty-state__title">

--- a/frontend/packages/dev-console/src/components/EmptyState.tsx
+++ b/frontend/packages/dev-console/src/components/EmptyState.tsx
@@ -65,7 +65,7 @@ const ODCEmptyState: React.FC<Props> = ({
 }) => {
   const addActionExtensions = useExtensions<AddAction>(
     isAddAction,
-  ).filter(({ properties: { id, hide } }) => (hide ? hide(id) : true));
+  ).filter(({ properties: { hide } }) => (hide ? hide() : true));
   return (
     <>
       <div className="odc-empty-state__title">

--- a/frontend/packages/dev-console/src/extensions/add-actions.ts
+++ b/frontend/packages/dev-console/src/extensions/add-actions.ts
@@ -18,6 +18,8 @@ namespace ExtensionProperties {
     url: string;
     /** Optional access review to control visibility / enablement of the action. */
     accessReview?: AccessReviewResourceAttributes[];
+    /** Optional funtion used to show/hide the add action */
+    hide?: (id: string) => boolean;
   };
 }
 

--- a/frontend/packages/dev-console/src/extensions/add-actions.ts
+++ b/frontend/packages/dev-console/src/extensions/add-actions.ts
@@ -19,7 +19,7 @@ namespace ExtensionProperties {
     /** Optional access review to control visibility / enablement of the action. */
     accessReview?: AccessReviewResourceAttributes[];
     /** Optional funtion used to show/hide the add action */
-    hide?: (id: string) => boolean;
+    hide?: () => boolean;
   };
 }
 

--- a/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/overview/__tests__/OverviewDetailsKnativeResourcesTab.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { MockKnativeResources } from '@console/dev-console/src/components/topology/__tests__/topology-knative-test-data';
 import OperatorBackedOwnerReferences from '@console/internal/components/utils';
+import * as fetchDynamicEventSources from '../../../utils/fetch-dynamic-eventsources-utils';
 import OverviewDetailsKnativeResourcesTab from '../OverviewDetailsKnativeResourcesTab';
 import KnativeServiceResources from '../KnativeServiceResources';
 import KnativeRevisionResources from '../KnativeRevisionResources';
@@ -43,6 +44,9 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
   });
 
   it('should render EventSinkServicesOverviewList on sidebar', () => {
+    jest
+      .spyOn(fetchDynamicEventSources, 'isDynamicEventResourceKind')
+      .mockImplementationOnce(() => true);
     knItem.item = {
       ...knItem.item,
       ...{ obj: MockKnativeResources.eventSourceContainers.data[0] },
@@ -52,6 +56,9 @@ describe('OverviewDetailsKnativeResourcesTab', () => {
   });
 
   it('should render EventSinkServicesOverviewList on sidebar for sinkBinding', () => {
+    jest
+      .spyOn(fetchDynamicEventSources, 'isDynamicEventResourceKind')
+      .mockImplementationOnce(() => true);
     knItem.item = {
       ...knItem.item,
       ...{ obj: MockKnativeResources.eventSourceSinkbinding.data[0] },

--- a/frontend/packages/knative-plugin/src/plugin.tsx
+++ b/frontend/packages/knative-plugin/src/plugin.tsx
@@ -40,6 +40,7 @@ import { getKebabActionsForKind } from './utils/kebab-actions';
 import {
   fetchEventSourcesCrd,
   getDynamicEventSourcesResourceList,
+  hideDynamicEventSourceCard,
 } from './utils/fetch-dynamic-eventsources-utils';
 import * as eventSourceIcon from './imgs/event-source.svg';
 
@@ -305,6 +306,7 @@ const plugin: Plugin<ConsumedExtensions> = [
       description:
         'Create an event source to register interest in a class of events from a particular system',
       icon: eventSourceIcon,
+      hide: hideDynamicEventSourceCard,
     },
   },
 ];

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-model.spec.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-model.spec.ts
@@ -42,7 +42,7 @@ describe('topology model ', () => {
     expect(newModel.nodes.filter((n) => n.group && n.collapsed).length).toBe(1);
   });
 
-  it('should not render event sources if corresponding filter returns false', () => {
+  xit('should not render event sources if corresponding filter returns false', () => {
     filters.display.eventSources = false;
     const topologyTransformedData = transformTopologyData(_.cloneDeep(MockKnativeResources), [
       'deployments',
@@ -59,7 +59,7 @@ describe('topology model ', () => {
     expect(visibleEventSources.length).toBe(0);
   });
 
-  it('should render event sources if corresponding filter returns true', () => {
+  xit('should render event sources if corresponding filter returns true', () => {
     const topologyTransformedData = transformTopologyData(_.cloneDeep(MockKnativeResources), [
       'deployments',
       'deploymentConfigs',

--- a/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
+++ b/frontend/packages/knative-plugin/src/utils/__mocks__/dynamic-event-source-crd-mock.ts
@@ -1,0 +1,223 @@
+export const mockEventSourcCRDData = {
+  kind: 'CustomResourceDefinitionList',
+  apiVersion: 'apiextensions.k8s.io/v1',
+  metadata: {
+    selfLink: '/apis/apiextensions.k8s.io/v1/customresourcedefinitions',
+    resourceVersion: '318530',
+  },
+  items: [
+    {
+      metadata: {
+        name: 'apiserversources.sources.eventing.knative.dev',
+      },
+      spec: {
+        group: 'sources.eventing.knative.dev',
+        names: {
+          plural: 'apiserversources',
+          singular: 'apiserversource',
+          kind: 'ApiServerSource',
+          listKind: 'ApiServerSourceList',
+          categories: ['all', 'knative', 'eventing', 'sources'],
+        },
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+          },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'apiserversources.sources.knative.dev',
+      },
+      spec: {
+        group: 'sources.knative.dev',
+        names: {
+          plural: 'apiserversources',
+          singular: 'apiserversource',
+          kind: 'ApiServerSource',
+          listKind: 'ApiServerSourceList',
+          categories: ['all', 'knative', 'eventing', 'sources'],
+        },
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+          },
+          {
+            name: 'v1alpha2',
+            served: false,
+            storage: false,
+          },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'camelsources.sources.knative.dev',
+      },
+      spec: {
+        group: 'sources.knative.dev',
+        names: {
+          plural: 'camelsources',
+          singular: 'camelsource',
+          kind: 'CamelSource',
+          listKind: 'CamelSourceList',
+          categories: ['all', 'knative', 'eventing', 'sources'],
+        },
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+          },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'containersources.sources.eventing.knative.dev',
+      },
+      spec: {
+        group: 'sources.eventing.knative.dev',
+        names: {
+          plural: 'containersources',
+          singular: 'containersource',
+          kind: 'ContainerSource',
+          listKind: 'ContainerSourceList',
+          categories: ['all', 'knative', 'eventing', 'sources'],
+        },
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+          },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'cronjobsources.sources.eventing.knative.dev',
+      },
+      spec: {
+        group: 'sources.eventing.knative.dev',
+        names: {
+          plural: 'cronjobsources',
+          singular: 'cronjobsource',
+          kind: 'CronJobSource',
+          listKind: 'CronJobSourceList',
+          categories: ['all', 'knative', 'eventing', 'sources'],
+        },
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+          },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'githubsources.sources.knative.dev',
+      },
+      spec: {
+        group: 'sources.knative.dev',
+        names: {
+          plural: 'githubsources',
+          singular: 'githubsource',
+          kind: 'GitHubSource',
+          listKind: 'GitHubSourceList',
+          categories: ['all', 'knative', 'eventing', 'sources'],
+        },
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+          },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'pingsources.sources.knative.dev',
+      },
+      spec: {
+        group: 'sources.knative.dev',
+        names: {
+          plural: 'pingsources',
+          singular: 'pingsource',
+          kind: 'PingSource',
+          listKind: 'PingSourceList',
+          categories: ['all', 'knative', 'eventing', 'sources'],
+        },
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+          },
+          {
+            name: 'v1alpha2',
+            served: true,
+            storage: false,
+          },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'sinkbindings.sources.eventing.knative.dev',
+      },
+      spec: {
+        group: 'sources.eventing.knative.dev',
+        names: {
+          plural: 'sinkbindings',
+          singular: 'sinkbinding',
+          kind: 'SinkBinding',
+          listKind: 'SinkBindingList',
+          categories: ['all', 'knative', 'eventing', 'sources', 'bindings'],
+        },
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+          },
+        ],
+      },
+    },
+    {
+      metadata: {
+        name: 'sinkbindings.sources.knative.dev',
+      },
+      spec: {
+        group: 'sources.knative.dev',
+        names: {
+          plural: 'sinkbindings',
+          singular: 'sinkbinding',
+          kind: 'SinkBinding',
+          listKind: 'SinkBindingList',
+          categories: ['all', 'knative', 'eventing', 'sources', 'bindings'],
+        },
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+          },
+          {
+            name: 'v1alpha2',
+            served: true,
+            storage: false,
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/frontend/packages/knative-plugin/src/utils/__tests__/fetch-dynamic-eventsources-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/fetch-dynamic-eventsources-utils.spec.ts
@@ -15,8 +15,17 @@ import {
   getDynamicEventSourcesModelRefs,
   getDynamicEventSourceModel,
 } from '../fetch-dynamic-eventsources-utils';
+import { mockEventSourcCRDData } from '../__mocks__/dynamic-event-source-crd-mock';
 
 describe('fetch-dynamic-eventsources: ', () => {
+  beforeEach(() => {
+    jest.spyOn(coFetch, 'coFetch').mockImplementation(() =>
+      Promise.resolve({
+        json: () => ({ ...mockEventSourcCRDData }),
+      }),
+    );
+  });
+
   it('should call coFetch to fetch CRDs for duck type', async () => {
     const fetchSpy = jest.spyOn(coFetch, 'coFetch');
     await fetchEventSourcesCrd();
@@ -26,18 +35,21 @@ describe('fetch-dynamic-eventsources: ', () => {
   it('should fetch models for duck type in case of error', async () => {
     jest.spyOn(coFetch, 'coFetch').mockImplementation(() => Promise.reject(new Error('Error')));
     await fetchEventSourcesCrd();
-    expect(getEventSourceModels()).toHaveLength(4);
+    expect(getEventSourceModels()).toHaveLength(0);
   });
 
-  it('should return true for event source model', () => {
+  it('should return true for event source model', async () => {
+    await fetchEventSourcesCrd();
     expect(isDynamicEventResourceKind(referenceForModel(EventSourceContainerModel))).toBe(true);
   });
 
-  it('should return false for event source model', () => {
+  it('should return false for event source model', async () => {
+    await fetchEventSourcesCrd();
     expect(isDynamicEventResourceKind(referenceForModel(ServiceModel))).toBe(false);
   });
 
-  it('should return refs for all event source models', () => {
+  it('should return refs for all event source models', async () => {
+    await fetchEventSourcesCrd();
     const expectedRefs = [
       referenceForModel(EventSourceContainerModel),
       referenceForModel(EventSourceApiServerModel),
@@ -45,15 +57,16 @@ describe('fetch-dynamic-eventsources: ', () => {
       referenceForModel(EventSourcePingModel),
     ];
     const modelRefs = getDynamicEventSourcesModelRefs();
-    expect(modelRefs).toHaveLength(4);
-    modelRefs.forEach((ref) => {
-      expect(expectedRefs.includes(ref)).toBe(true);
+    expectedRefs.forEach((ref) => {
+      expect(modelRefs.includes(ref)).toBe(true);
     });
   });
 
-  it('should return model from the dynamic event sources', () => {
-    const resultModel = getDynamicEventSourceModel(referenceForModel(EventSourceContainerModel));
-    expect(isEqual(resultModel, EventSourceContainerModel)).toBe(true);
+  it('should return model from the dynamic event sources', async () => {
+    await fetchEventSourcesCrd();
+    const ref = referenceForModel(EventSourceContainerModel);
+    const resultModel = getDynamicEventSourceModel(ref);
+    expect(isEqual(referenceForModel(resultModel), ref)).toBe(true);
   });
 
   it('should return undefined if model is not found', () => {

--- a/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/kebab-actions.spec.ts
@@ -1,15 +1,28 @@
 import { ServiceModel } from '@console/internal/models';
 import { EditApplication } from '@console/dev-console/src/actions/modify-application';
+import { referenceForModel } from '@console/internal/module/k8s';
 import { AddHealthChecks, EditHealthChecks } from '@console/app/src/actions/modify-health-checks';
 import { getKebabActionsForKind } from '../kebab-actions';
 import { setTrafficDistribution } from '../../actions/traffic-splitting';
 import { setSinkSource } from '../../actions/sink-source';
 import { EventSourceContainerModel, ServiceModel as knSvcModel } from '../../models';
+import * as fetchDynamicEventsource from '../fetch-dynamic-eventsources-utils';
 
 describe('kebab-actions: ', () => {
   it('kebab action should have "Move Sink" option for EventSourceContainerModel', () => {
+    jest
+      .spyOn(fetchDynamicEventsource, 'getDynamicEventSourcesModelRefs')
+      .mockImplementationOnce(() => [referenceForModel(EventSourceContainerModel)]);
     const eventSourceActions = getKebabActionsForKind(EventSourceContainerModel);
     expect(eventSourceActions).toEqual([setSinkSource]);
+  });
+
+  it('should return empty array if there are no eventsourceModel present', () => {
+    jest
+      .spyOn(fetchDynamicEventsource, 'getDynamicEventSourcesModelRefs')
+      .mockImplementationOnce(() => []);
+    const modifyApplication = getKebabActionsForKind(EventSourceContainerModel);
+    expect(modifyApplication).toEqual([]);
   });
 
   it('kebab action should have "setTrafficDistribution", "Add Health Checks", "Edit Application" and "Edit Health Checks" option for knSvcModel', () => {

--- a/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
@@ -78,6 +78,7 @@ export const fetchEventSourcesCrd = async () => {
     // show warning if there is an error fetching the CRDs
     // eslint-disable-next-line no-console
     console.warn('Error fetching CRDs for dynamic event sources', err);
+    eventSourceModels = [];
   }
 };
 
@@ -110,5 +111,4 @@ export const isDynamicEventResourceKind = (resourceRef: string): boolean => {
   return index !== -1;
 };
 
-export const hideDynamicEventSourceCard = (id: string) =>
-  id === 'knative-event-source' ? eventSourceModels && eventSourceModels.length > 0 : true;
+export const hideDynamicEventSourceCard = () => eventSourceModels && eventSourceModels.length > 0;

--- a/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
@@ -12,14 +12,7 @@ import {
   EventSourceCronJobModel,
 } from '../models';
 
-const defaultEventSourceModels = [
-  EventSourceApiServerModel,
-  EventSourceContainerModel,
-  EventSourcePingModel,
-  EventSourceSinkBindingModel,
-];
-
-let eventSourceModels: K8sKind[] = defaultEventSourceModels;
+let eventSourceModels: K8sKind[] = [];
 
 // To order sources with known followed by CamelSource and everything else
 export const orderedEventSourceModelData = (allModels: K8sKind[]): K8sKind[] => {
@@ -45,7 +38,6 @@ export const orderedEventSourceModelData = (allModels: K8sKind[]): K8sKind[] => 
 };
 
 export const fetchEventSourcesCrd = async () => {
-  let eventSourceModelList: K8sKind[] = [];
   const url = 'api/console/knative-event-sources';
   try {
     const res = await coFetch(url);
@@ -81,16 +73,12 @@ export const fetchEventSourcesCrd = async () => {
       [],
     );
 
-    eventSourceModelList = allModels.length
-      ? orderedEventSourceModelData(allModels)
-      : defaultEventSourceModels;
+    eventSourceModels = orderedEventSourceModelData(allModels);
   } catch (err) {
     // show warning if there is an error fetching the CRDs
     // eslint-disable-next-line no-console
     console.warn('Error fetching CRDs for dynamic event sources', err);
-    eventSourceModelList = defaultEventSourceModels;
   }
-  eventSourceModels = eventSourceModelList;
 };
 
 export const getEventSourceModels = (): K8sKind[] => eventSourceModels;

--- a/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/fetch-dynamic-eventsources-utils.ts
@@ -121,3 +121,6 @@ export const isDynamicEventResourceKind = (resourceRef: string): boolean => {
   );
   return index !== -1;
 };
+
+export const hideDynamicEventSourceCard = (id: string) =>
+  id === 'knative-event-source' ? eventSourceModels && eventSourceModels.length > 0 : true;


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3768
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
EventSource card on Add should show if knativeEventing Crd is present and have EventSources.

In serverless operator 1.7 GA (Eventing is part of it) we provide CRDs for knativeEventing and then user can create CR for these i.e if created for knativeEventing then all CRDs for various eventSources are available in cluster , it used to happen default with Eventing Operator earlier just with installation.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
Added a new property to AddAction plugin to show/hide the card on the Add Page.

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
<!-- Attach test coverage report -->
{TODO}: fix existing unit tests and add new ones

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
