### PR TITLE
Bug 1830095: Update Control Plane status logic to include no. of not healthy compo…

### DIFF
--- a/frontend/packages/console-app/src/components/dashboards-page/ControlPlaneStatus.tsx
+++ b/frontend/packages/console-app/src/components/dashboards-page/ControlPlaneStatus.tsx
@@ -18,14 +18,15 @@ const ControlPlanePopup: React.FC<PrometheusHealthPopupProps> = ({ responses }) 
     <StatusPopupSection firstColumn="Components" secondColumn="Response rate">
       {responses.map(({ response, error }, index) => {
         const health = getControlPlaneComponentHealth(response, error);
-        let icon: React.ReactNode;
-        if (health.state === HealthState.LOADING) {
-          icon = <div className="skeleton-health" />;
-        } else if (health.state !== HealthState.NOT_AVAILABLE) {
-          icon = healthStateMapping[health.state].icon;
-        }
+        const icon =
+          health.state === HealthState.LOADING ? (
+            <div className="skeleton-health" />
+          ) : (
+            healthStateMapping[health.state].icon
+          );
+        const value = health.message || healthStateMapping[health.state]?.message;
         return (
-          <Status key={titles[index]} value={health.message} icon={icon}>
+          <Status key={titles[index]} value={value} icon={icon}>
             {titles[index]}
           </Status>
         );

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/state-utils.ts
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/state-utils.ts
@@ -5,7 +5,7 @@ import {
   OperatorHealth,
   GetOperatorStatusPriority,
 } from '@console/plugin-sdk';
-import { operatorHealthPriority, HealthState } from './states';
+import { healthPriority, HealthState } from './states';
 
 export const getMostImportantStatuses = (
   operatorStatuses: OperatorStatusWithResources[],
@@ -21,7 +21,7 @@ export const getOperatorsStatus = <R extends K8sResourceCommon>(
   if (!operators.length) {
     return {
       status: {
-        ...operatorHealthPriority[HealthState.OK],
+        ...healthPriority[HealthState.OK],
         title: 'Available',
       },
       operators: [],
@@ -62,7 +62,7 @@ export const getOperatorsHealthState = (
     return { health: HealthState.LOADING, detailMessage: undefined };
   }
   const sortedStatuses = healthStatuses.sort(
-    (a, b) => operatorHealthPriority[b.health].priority - operatorHealthPriority[a.health].priority,
+    (a, b) => healthPriority[b.health].priority - healthPriority[a.health].priority,
   );
   const groupedStatuses = _.groupBy(sortedStatuses, (s) => s.health);
   const statusKeys = Object.keys(groupedStatuses);
@@ -87,8 +87,8 @@ export const getOperatorsHealthState = (
 
   return {
     health: HealthState[statusKeys[0]],
-    detailMessage: operatorHealthPriority[statusKeys[0]].message
-      ? `${finalCount} ${operatorHealthPriority[statusKeys[0]].message}`
+    detailMessage: healthPriority[statusKeys[0]].message
+      ? `${finalCount} ${healthPriority[statusKeys[0]].message.toLowerCase()}`
       : undefined,
   };
 };

--- a/frontend/packages/console-shared/src/components/dashboard/status-card/states.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/status-card/states.tsx
@@ -49,11 +49,8 @@ export const healthStateMapping: { [key in HealthStateMappingKeys]: HealthStateM
   },
 };
 
-export const operatorHealthPriority: {
-  [key in HealthStateMappingKeys]: {
-    priority: number;
-    health: HealthState;
-  } & HealthStateMappingValues;
+export const healthPriority: {
+  [key in HealthStateMappingKeys]: PriorityHealthState;
 } = {
   [HealthState.OK]: {
     priority: 0,
@@ -91,6 +88,11 @@ export const operatorHealthPriority: {
     ...healthStateMapping[HealthState.NOT_AVAILABLE],
   },
 };
+
+export type PriorityHealthState = {
+  priority: number;
+  health: HealthState;
+} & HealthStateMappingValues;
 
 type HealthStateMappingKeys = Exclude<keyof typeof HealthState, 'LOADING'>;
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/dashboard/utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/dashboard/utils.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import {
   HealthState,
-  operatorHealthPriority,
+  healthPriority,
 } from '@console/shared/src/components/dashboard/status-card/states';
 import { OperatorStatusPriority, GetOperatorsWithStatuses } from '@console/plugin-sdk';
 import { getOperatorsStatus } from '@console/shared/src/components/dashboard/status-card/state-utils';
@@ -36,12 +36,12 @@ const getOperatorStatus = (
     subscriptionStatus.status === SubscriptionState.SubscriptionStateUpgradePending
   ) {
     return {
-      ...operatorHealthPriority[HealthState.UPDATING],
+      ...healthPriority[HealthState.UPDATING],
       title: subscriptionStatus.title,
     };
   }
   return {
-    ...operatorHealthPriority[operatorHealth],
+    ...healthPriority[operatorHealth],
     title: csvStatus.title,
   };
 };


### PR DESCRIPTION
…ments

![Screenshot from 2020-05-07 20-33-46](https://user-images.githubusercontent.com/2078045/81331751-585fda80-90a2-11ea-974f-8ebd7fb369eb.png)
![Screenshot from 2020-05-07 20-34-12](https://user-images.githubusercontent.com/2078045/81331757-5b5acb00-90a2-11ea-9713-264f85ae1d89.png)

@andybraren 
If data fetching from Prometheus failed we show `x not available`
If there are no data -> `x unknown`
If the success rate is low -> `x degraded`

Does that make sense ? Do you think its worth having not available and unknown status here ? We already have that for Operators health.