### PR TITLE
Bug 1832576: Fix type error

### DIFF
--- a/frontend/public/components/resource-dropdown.tsx
+++ b/frontend/public/components/resource-dropdown.tsx
@@ -127,7 +127,7 @@ const ResourceListDropdown_: React.SFC<ResourceListDropdownProps> = (props) => {
   };
 
   const handleSelected = (value: string) => {
-    onChange(referenceForModel(modelFor(value)));
+    value === 'All' ? onChange('All') : onChange(referenceForModel(modelFor(value)));
   };
 
   return (


### PR DESCRIPTION
Adjusted what gets passed to onChange in ResourceListDropdown to fix the following type error: "cannot read property apiGroup of undefined." 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1832576.