### PR TITLE
Bug 1830312: Remove Filter button - Search Page

### DIFF
--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -83,6 +83,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
     data,
     hideNameFilter,
     hideLabelFilter,
+    hideRowFilter,
     location,
     textFilter = filterTypeMap[FilterType.NAME],
   } = props;
@@ -245,7 +246,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   return (
     <DataToolbar id="filter-toolbar" clearAllFilters={clearAll}>
       <DataToolbarContent>
-        {rowFilters.length > 0 && (
+        {!hideRowFilter && rowFilters.length > 0 && (
           <DataToolbarItem>
             {_.reduce(
               Object.keys(filters),
@@ -337,6 +338,7 @@ type FilterToolbarProps = {
   textFilter?: string;
   hideNameFilter?: boolean;
   hideLabelFilter?: boolean;
+  hideRowFilter?: boolean;
   parseAutoComplete?: any;
   kinds?: any;
 };

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -55,12 +55,12 @@ const ResourceList = connectToModel(({ kindObj, mock, namespace, selector, nameF
       nameFilter={nameFilter}
       kind={kindObj.crd ? referenceForModel(kindObj) : kindObj.kind}
       showTitle={false}
-      hideTextFilter
       autoFocus={false}
       mock={mock}
       badge={getBadgeFromType(kindObj.badge)}
       hideNameFilter
       hideLabelFilter
+      hideRowFilter
     />
   );
 });

--- a/frontend/public/components/utils/resource-link.tsx
+++ b/frontend/public/components/utils/resource-link.tsx
@@ -46,6 +46,10 @@ export const resourcePathFromModel = (model: K8sKind, name?: string, namespace?:
 export const resourceListPathFromModel = (model: K8sKind, namespace: string) =>
   resourcePathFromModel(model, null, namespace);
 
+export const newResourcePathFromModel = (model: K8sKind, namespace: string) => {
+  return `${resourceListPathFromModel(model, namespace)}/~new`;
+};
+
 /**
  * NOTE: This will not work for runtime-defined resources. Use a `connect`-ed component like `ResourceLink` instead.
  */


### PR DESCRIPTION
Removed the filter button in results section of the search. BZ1830312
Now:
![Screenshot_2020-05-15 Search · OKD(1)](https://user-images.githubusercontent.com/18728857/82082287-f821f780-96a4-11ea-9266-e8a740b75c18.png)
Before:
![Screenshot_2020-05-15 Installed Operators · OKD](https://user-images.githubusercontent.com/18728857/82082864-fe64a380-96a5-11ea-9440-4f0a3d09dd8f.png)
