### PR TITLE
Bug 1833146: Hide Project Access Tab when the user have no access to role bindings

### DIFF
--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -104,7 +104,6 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ formName, namespace, role
         />{' '}
         .
       </PageHeading>
-      <hr />
       <div className="co-m-pane__body">
         {roleBindings.loadError ? (
           <StatusBox loaded={roleBindings.loaded} loadError={roleBindings.loadError} />

--- a/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { match as RMatch } from 'react-router';
-import { history } from '@console/internal/components/utils';
+import { history, useAccessReview } from '@console/internal/components/utils';
 import { ALL_NAMESPACES_KEY } from '@console/shared';
 import { NamespaceDetails, projectMenuActions } from '@console/internal/components/namespace';
-import { ProjectModel } from '@console/internal/models';
+import { ProjectModel, RoleBindingModel } from '@console/internal/models';
 import { DetailsPage } from '@console/internal/components/factory';
 import { ProjectDashboard } from '@console/internal/components/dashboard/project-dashboard/project-dashboard';
 import { withStartGuide } from '@console/internal/components/start-guide';
@@ -28,6 +28,20 @@ const handleNamespaceChange = (newNamespace: string): void => {
 
 export const ProjectDetailsPage: React.FC<MonitoringPageProps> = ({ match, ...props }) => {
   const activeNamespace = match.params.ns;
+
+  const canListRoleBindings = useAccessReview({
+    group: RoleBindingModel.apiGroup,
+    resource: RoleBindingModel.plural,
+    verb: 'list',
+    namespace: activeNamespace,
+  });
+
+  const canCreateRoleBindings = useAccessReview({
+    group: RoleBindingModel.apiGroup,
+    resource: RoleBindingModel.plural,
+    verb: 'create',
+    namespace: activeNamespace,
+  });
 
   return (
     <>
@@ -60,11 +74,12 @@ export const ProjectDetailsPage: React.FC<MonitoringPageProps> = ({ match, ...pr
                 name: 'Details',
                 component: NamespaceDetails,
               },
-              {
-                href: 'access',
-                name: 'Project Access',
-                component: ProjectAccessPage,
-              },
+              canListRoleBindings &&
+                canCreateRoleBindings && {
+                  href: 'access',
+                  name: 'Project Access',
+                  component: ProjectAccessPage,
+                },
             ]}
           />
         ) : (

--- a/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/__tests__/ProjectDetailsPage.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { BreadCrumbs } from '@console/internal/components/utils';
+import * as _ from 'lodash';
+import * as utils from '@console/internal/components/utils';
 import { ProjectDetailsPage } from '../ProjectDetailsPage';
 import ProjectListPage from '../../ProjectListPage';
 import NamespacedPage from '../../../NamespacedPage';
@@ -27,6 +28,14 @@ describe('ProjectDetailsPage', () => {
     // Currently rendering the breadcrumbs will buck-up against the redirects and not work as expected
     const component = shallow(<ProjectDetailsPage match={testProjectMatch} />);
 
-    expect(component.find(BreadCrumbs).exists()).not.toBe(true);
+    expect(component.find(utils.BreadCrumbs).exists()).not.toBe(true);
+  });
+
+  it('should not render the Project Access tab if user has no access to role bindings', () => {
+    const spyUseAccessReview = jest.spyOn(utils, 'useAccessReview');
+    spyUseAccessReview.mockReturnValue(false);
+    const component = shallow(<ProjectDetailsPage match={testProjectMatch} />);
+    const pages = component.find(DetailsPage).prop('pages');
+    expect(_.find(pages, { name: 'Project Access' })).toBe(undefined);
   });
 });


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-3733

**Root Cause/Analysis**
Previously `Project Access` was an independent nav item in the Dev perspective, which is now one of the tabs in the Project Details page.

**Solution Description**
`list` & `create` access check has been added before rendering the `Project Access` tab. If the user has no permission to `list` or `create` project access, it will be hidden

**GIF/Screenshot**
![pa-view](https://user-images.githubusercontent.com/22490998/81347567-0aff5f80-90da-11ea-88ae-468de9ee1039.gif)
![pa-edit](https://user-images.githubusercontent.com/22490998/81347577-105caa00-90da-11ea-9987-0c657ac51e00.gif)

![Screenshot from 2020-05-09 12-37-10](https://user-images.githubusercontent.com/22490998/81468064-c9b2a100-91fa-11ea-9267-babd5338f33d.png)

**Unit test coverage report**
![test_pa](https://user-images.githubusercontent.com/22490998/81348078-06877680-90db-11ea-8a2e-5624a9cb4ce7.png)



/kind bug 