### PR TITLE
Bug 1822860: Fix Img Alt text size to make it look better

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
@@ -84,7 +84,7 @@ export const ClusterServiceVersionLogo: React.SFC<ClusterServiceVersionLogoProps
         <img
           className="co-catalog-item-icon__img co-catalog-item-icon__img--large"
           src={imgSrc}
-          alt={displayName}
+          alt=""
         />
       </div>
       <div className="co-clusterserviceversion-logo__name">


### PR DESCRIPTION
The icon for this operator is not valid which is a problem with the operator, however it does reveal an issue with how the "alt" text of the img gets displayed and how it over runs the other text elements.
I have simply blanked out the alt tag:
![Screenshot_2020-05-08 OperatorHub Subscription · OKD](https://user-images.githubusercontent.com/18728857/81456062-5ce1cd00-914e-11ea-8020-f6e82e603785.png)




OLD SOLUTION
I have put a span around the img to reduce the size of the alt text.  This should have no affect on images. 

![Screenshot_2020-05-07 OperatorHub Subscription · OKD](https://user-images.githubusercontent.com/18728857/81362536-53992780-909e-11ea-9e87-4952a19029a8.png)

Here is it before:
<img width="1332" alt="Screen Shot 2020-04-10 at 2 25 42 PM" src="https://user-images.githubusercontent.com/18728857/81362616-77f50400-909e-11ea-8b0a-6acafd487a8f.png">
