### PR TITLE
Bug 1828490: Add identifier for tab names that are CRD specific

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -973,7 +973,9 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
                 ...acc,
                 {
                   href: referenceForProvidedAPI(desc),
-                  name: desc.displayName,
+                  name: ['Details', 'YAML', 'Subscription', 'Events'].includes(desc.displayName)
+                    ? `${desc.displayName} Operand`
+                    : desc.displayName,
                   component: React.memo(
                     () => (
                       <ProvidedAPIPage


### PR DESCRIPTION
Some tab names can be repeated on the operator detail page if the CRD api has the same name.  As mention in the bug, this is expected but confusing.
For now, I have appended the [CRD] string to the tab name to show it comes from the CRD.  I am open to suggestions for how to display this. @benjaminapetersen @spadgett 

![Screenshot_2020-05-08 multicluster-operators-subscription v0 1 5 · Details · OKD](https://user-images.githubusercontent.com/18728857/81426675-c34af900-9116-11ea-9ad3-be5a3d501d5f.png)
