### PR TITLE
Bug 1833217: Monitoring: Fix JS warning on silence save form

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1389,8 +1389,10 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
         refreshNotificationPollers();
         history.push(`${SilenceResource.plural}/${encodeURIComponent(_.get(data, 'silenceId'))}`);
       })
-      .catch((err) => setError(_.get(err, 'json.error') || err.message || 'Error saving Silence'))
-      .then(() => setInProgress(false));
+      .catch((err) => {
+        setError(_.get(err, 'json.error') || err.message || 'Error saving Silence');
+        setInProgress(false);
+      });
   };
 
   return (


### PR DESCRIPTION
`setInProgress` was being called after navigating to a new page, which
caused a warning about trying to set component state after the component
was unmounted. The solution is to simply not call `setInProgress` in
this case since the component is unmounting anyway.