### PR TITLE
Bug 1833343: Remove fetch timeout for Helm actions

### DIFF
--- a/frontend/packages/dev-console/src/actions/modify-helm-release.ts
+++ b/frontend/packages/dev-console/src/actions/modify-helm-release.ts
@@ -13,7 +13,12 @@ export const deleteHelmRelease = (releaseName: string, namespace: string, redire
         actionLabel: 'Uninstall',
         redirect,
         onSubmit: () => {
-          return coFetchJSON.delete(`/api/helm/release?name=${releaseName}&ns=${namespace}`);
+          return coFetchJSON.delete(
+            `/api/helm/release?name=${releaseName}&ns=${namespace}`,
+            null,
+            null,
+            -1,
+          );
         },
       });
     },

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallUpgradePage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallUpgradePage.tsx
@@ -130,7 +130,7 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
       helmAction === HelmActionType.Install || helmActionOrigin === HelmActionOrigins.topology;
 
     config
-      .fetch('/api/helm/release', payload)
+      .fetch('/api/helm/release', payload, null, -1)
       .then(async (res: HelmRelease) => {
         let redirect = config.redirectURL;
 

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseRollbackPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseRollbackPage.tsx
@@ -63,7 +63,7 @@ const HelmReleaseRollbackPage: React.FC<HelmReleaseRollbackPageProps> = ({ match
     };
 
     config
-      .fetch('/api/helm/release', payload)
+      .fetch('/api/helm/release', payload, null, -1)
       .then(() => {
         actions.setStatus({ isSubmitting: false });
         history.push(config.redirectURL);

--- a/frontend/packages/dev-console/src/components/helm/helm-types.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-types.ts
@@ -70,7 +70,7 @@ export interface HelmActionConfigType {
   title: string;
   subTitle: string;
   helmReleaseApi: string;
-  fetch: (url: any, json: any, options?: {}) => Promise<any>;
+  fetch: (url: string, json: any, options?: {}, timeout?: number) => Promise<any>;
   redirectURL: string;
 }
 


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3810

This PR - 
- Sends `-1` as fetch timeout to remove the timeout from fetch requests of Helm actions like install, upgrade, rollback and delete.