### PR TITLE
Bug 1829869: Add confirmation step when toggling from yaml to form during operand creation

### DIFF
--- a/frontend/packages/console-shared/src/components/synced-editor/styles.scss
+++ b/frontend/packages/console-shared/src/components/synced-editor/styles.scss
@@ -1,7 +1,13 @@
+@import '../../../../../public/style/vars';
+
 .co-synced-editor__editor-toggle {
   padding: 8px 30px;
   border-bottom: 1px solid #ddd;
   & label {
     margin: 0;
   }
+}
+
+.co-synced-editor__yaml-warning {
+  margin: $grid-gutter-width $grid-gutter-width 0;
 }

--- a/frontend/packages/console-shared/src/utils/yaml.ts
+++ b/frontend/packages/console-shared/src/utils/yaml.ts
@@ -17,3 +17,25 @@ export const safeYAMLToJS = (yaml: string, fallback: any = {}, options: any = {}
     return fallback;
   }
 };
+
+export const asyncJSToYAML = (js: any, options: any = {}): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    try {
+      const yaml = safeDump(js, options);
+      resolve(yaml);
+    } catch (e) {
+      reject(e);
+    }
+  });
+};
+
+export const asyncYAMLToJS = (yaml: string, options: any = {}): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    try {
+      const js = safeLoad(yaml, options);
+      resolve(js);
+    } catch (e) {
+      reject(e);
+    }
+  });
+};


### PR DESCRIPTION
Add a confirmation step when toggling to the form view if YAML data will be lost.

![screenshot-localhost_9000-2020 05 06-10_32_12](https://user-images.githubusercontent.com/22625502/81192530-5c97d500-8f88-11ea-852c-8713da74763f.gif)
