### PR TITLE
Bug 1834263: Fixing statuses on dashboards

### DIFF
--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/activity-card/activity-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/activity-card/activity-card.tsx
@@ -6,11 +6,7 @@ import DashboardCardHeader from '@console/shared/src/components/dashboard/dashbo
 import DashboardCardTitle from '@console/shared/src/components/dashboard/dashboard-card/DashboardCardTitle';
 import { EventKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { FirehoseResource, FirehoseResult } from '@console/internal/components/utils';
-import {
-  EventModel,
-  PersistentVolumeClaimModel,
-  PersistentVolumeModel,
-} from '@console/internal/models';
+import { EventModel, PersistentVolumeClaimModel } from '@console/internal/models';
 import ActivityBody, {
   RecentEventsBody,
   OngoingActivityBody,
@@ -51,10 +47,11 @@ export const getOCSSubscription = (subscriptions: FirehoseResult): SubscriptionK
   return _.find(itemsData, (item) => item?.spec?.name === OCS_OPERATOR) as SubscriptionKind;
 };
 
-const ocsEventNamespaceKindFilter = (event: EventKind): boolean =>
-  getNamespace(event) === CEPH_STORAGE_NAMESPACE ||
-  _.get(event, 'involvedObject.kind') ===
-    (PersistentVolumeClaimModel.kind || PersistentVolumeModel.kind);
+const ocsEventNamespaceKindFilter = (event: EventKind): boolean => {
+  const eventKind = event?.involvedObject?.kind;
+  const eventNamespace = getNamespace(event);
+  return eventNamespace === CEPH_STORAGE_NAMESPACE || eventKind === PersistentVolumeClaimModel.kind;
+};
 
 const RecentEvent = withDashboardResources(
   ({ watchK8sResource, stopWatchK8sResource, resources }: DashboardItemProps) => {

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/status-card.tsx
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/status-card.tsx
@@ -39,7 +39,7 @@ export const CephAlerts = withDashboardResources(
     return (
       <AlertsBody error={!_.isEmpty(loadError)}>
         {loaded &&
-          alerts.length &&
+          alerts.length > 0 &&
           alerts.map((alert) => <AlertItem key={alertURL(alert, alert.rule.id)} alert={alert} />)}
       </AlertsBody>
     );
@@ -55,7 +55,6 @@ export const StatusCard: React.FC<DashboardItemProps> = ({
 
   React.useEffect(() => {
     watchPrometheus(resiliencyProgressQuery);
-
     return () => {
       stopWatchPrometheusQuery(resiliencyProgressQuery);
     };
@@ -81,10 +80,18 @@ export const StatusCard: React.FC<DashboardItemProps> = ({
         <HealthBody>
           <Gallery className="co-overview-status__health" gutter="md">
             <GalleryItem>
-              <HealthItem title="OCS Cluster" state={cephHealthState.state} />
+              <HealthItem
+                title="OCS Cluster"
+                state={cephHealthState.state}
+                details={cephHealthState.message}
+              />
             </GalleryItem>
             <GalleryItem>
-              <HealthItem title="Data Resiliency" state={dataResiliencyState.state} />
+              <HealthItem
+                title="Data Resiliency"
+                state={dataResiliencyState.state}
+                details={dataResiliencyState.message}
+              />
             </GalleryItem>
           </Gallery>
         </HealthBody>

--- a/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/utils.ts
+++ b/frontend/packages/ceph-storage-plugin/src/components/dashboard-page/storage-dashboard/status-card/utils.ts
@@ -12,6 +12,7 @@ const CephHealthStatus = {
   },
   HEALTH_ERR: {
     state: HealthState.ERROR,
+    message: 'Error',
   },
 };
 
@@ -43,7 +44,7 @@ export const getDataResiliencyState: PrometheusHealthHandler = (responses) => {
     return { state: HealthState.UNKNOWN };
   }
   if (progress < 1) {
-    return { state: HealthState.PROGRESS };
+    return { state: HealthState.PROGRESS, message: 'Progressing' };
   }
   return { state: HealthState.OK };
 };

--- a/frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/status-card/status-card.tsx
@@ -139,7 +139,11 @@ const StatusCard: React.FC<DashboardItemProps> = ({
               />
             </GalleryItem>
             <GalleryItem>
-              <HealthItem title="Data Resiliency" state={dataResiliencyState.state} />
+              <HealthItem
+                title="Data Resiliency"
+                state={dataResiliencyState.state}
+                details={dataResiliencyState.message}
+              />
             </GalleryItem>
           </Gallery>
         </HealthBody>


### PR DESCRIPTION
**Bug**
![Screenshot from 2020-05-08 20-54-33](https://user-images.githubusercontent.com/25664409/81420856-32a00780-916e-11ea-83bc-107f71062465.png)

**Fix**
- In case of no alerts , fixed not showing '0'
- Fix data resiliency message during rebuilding to  be 'Pending' and not 'Progressing'
- Fix status of Ceph cluster on error to be 'Error' and not 'Degraded'
![Screenshot from 2020-05-08 19-32-29](https://user-images.githubusercontent.com/25664409/81420545-c02f2780-916d-11ea-9096-058d5d559641.png)
![Screenshot from 2020-05-08 19-46-09](https://user-images.githubusercontent.com/25664409/81420549-c1f8eb00-916d-11ea-9b38-49b1178c0000.png)
