### PR TITLE
Bug 1833449: Show better messaging when releses are not found

### DIFF
--- a/frontend/packages/dev-console/src/components/custom-resource-list/__tests__/CustomResourceList.spec.tsx
+++ b/frontend/packages/dev-console/src/components/custom-resource-list/__tests__/CustomResourceList.spec.tsx
@@ -4,6 +4,8 @@ import * as fuzzy from 'fuzzysearch';
 import { SortByDirection, sortable } from '@patternfly/react-table';
 import { TableRow, TableData, Table, RowFunction } from '@console/internal/components/factory';
 import { RowFilter, FilterToolbar } from '@console/internal/components/filter-toolbar';
+import { EmptyState } from '@patternfly/react-core';
+import { LoadingBox } from '@console/internal/components/utils';
 import CustomResourceList from '../CustomResourceList';
 import { CustomResourceListProps } from '../custom-resource-list-types';
 
@@ -53,23 +55,20 @@ describe('CustomeResourceList', () => {
     return item.status;
   };
 
-  const getItems = () => {
-    const items = [
-      { name: 'item1', version: '1', status: 'successful' },
-      {
-        name: 'item2',
-        version: '2',
-        status: 'successful',
-      },
-      { name: 'item3', version: '3', status: 'failed' },
-      {
-        name: 'item4',
-        version: '4',
-        status: 'failed',
-      },
-    ];
-    return Promise.resolve(items);
-  };
+  const resources = [
+    { name: 'item1', version: '1', status: 'successful' },
+    {
+      name: 'item2',
+      version: '2',
+      status: 'successful',
+    },
+    { name: 'item3', version: '3', status: 'failed' },
+    {
+      name: 'item4',
+      version: '4',
+      status: 'failed',
+    },
+  ];
 
   const getFilteredItemsByRow = (items: any, filters: string[]) => {
     return items.filter((item) => {
@@ -97,7 +96,7 @@ describe('CustomeResourceList', () => {
 
   customResourceListProps = {
     queryArg: '',
-    fetchCustomResources: getItems,
+    resources,
     textFilter: 'name',
     rowFilters: mockRowFilters,
     sortBy: 'version',
@@ -134,5 +133,19 @@ describe('CustomeResourceList', () => {
     customResourceListProps.rowFilters = mockRowFilters;
     customResourceList = shallow(<CustomResourceList {...customResourceListProps} />);
     expect(customResourceList.find(FilterToolbar).exists()).toBe(true);
+  });
+
+  it('should render the EmptyState component by default', () => {
+    const customResourceList = shallow(
+      <CustomResourceList {...customResourceListProps} resources={[]} />,
+    );
+    expect(customResourceList.find(EmptyState).exists()).toBe(true);
+  });
+
+  it('should render the loading box while loading', () => {
+    const customResourceList = shallow(
+      <CustomResourceList {...customResourceListProps} loaded={false} />,
+    );
+    expect(customResourceList.find(LoadingBox).exists()).toBe(true);
   });
 });

--- a/frontend/packages/dev-console/src/components/custom-resource-list/custom-resource-list-types.ts
+++ b/frontend/packages/dev-console/src/components/custom-resource-list/custom-resource-list-types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { RowFunction } from '@console/internal/components/factory';
 import { SortByDirection } from '@patternfly/react-table';
 import { RowFilter } from '@console/internal/components/filter-toolbar';
@@ -8,9 +9,10 @@ export interface CustomResourceListProps {
   sortBy: string;
   sortOrder: SortByDirection;
   resourceRow: RowFunction;
-  dependentResource?: any;
+  resources?: { [key: string]: any }[];
   resourceHeader: () => { [key: string]: any }[];
-  fetchCustomResources: () => Promise<{ [key: string]: any }[]>;
+  EmptyMsg?: React.ComponentType;
+  loaded?: boolean;
   rowFilterReducer?: (
     items: { [key: string]: any }[],
     filters: string | string[],

--- a/frontend/packages/dev-console/src/components/helm/HelmReleaseListPage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmReleaseListPage.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router';
 import Helmet from 'react-helmet';
-import { PageHeading, Firehose } from '@console/internal/components/utils';
-import { SecretModel } from '@console/internal/models';
+import { PageHeading } from '@console/internal/components/utils';
 import ProjectListPage from '../projects/ProjectListPage';
 import NamespacedPage, { NamespacedPageVariants } from '../NamespacedPage';
 import HelmReleaseList from './list/HelmReleaseList';
@@ -15,17 +14,6 @@ export const HelmReleaseListPage: React.FC<HelmReleaseListPageProps> = (props) =
       params: { ns: namespace },
     },
   } = props;
-
-  const resources = [
-    {
-      isList: true,
-      namespace,
-      kind: SecretModel.kind,
-      prop: 'secrets',
-      optional: true,
-      selector: { owner: 'helm' },
-    },
-  ];
   return namespace ? (
     <NamespacedPage variant={NamespacedPageVariants.light} hideApplications>
       <Helmet>
@@ -33,9 +21,7 @@ export const HelmReleaseListPage: React.FC<HelmReleaseListPageProps> = (props) =
       </Helmet>
       <div>
         <PageHeading title="Helm Releases" />
-        <Firehose resources={resources}>
-          <HelmReleaseList namespace={namespace} />
-        </Firehose>
+        <HelmReleaseList namespace={namespace} />
       </div>
     </NamespacedPage>
   ) : (

--- a/frontend/packages/dev-console/src/components/helm/details/history/HelmReleaseHistory.tsx
+++ b/frontend/packages/dev-console/src/components/helm/details/history/HelmReleaseHistory.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { match as RMatch } from 'react-router';
-import { coFetchJSON } from '@console/internal/co-fetch';
 import { SortByDirection } from '@patternfly/react-table';
-import { K8sResourceKind } from '@console/internal/module/k8s';
 import { useDeepCompareMemoize } from '@console/shared';
-
-import { HelmRelease } from '../../helm-types';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { coFetchJSON } from '@console/internal/co-fetch';
+import { StatusBox } from '@console/internal/components/utils';
 import CustomResourceList from '../../../custom-resource-list/CustomResourceList';
 import HelmReleaseHistoryRow from './HelmReleaseHistoryRow';
 import HelmReleaseHistoryHeader from './HelmReleaseHistoryHeader';
@@ -21,17 +20,40 @@ interface HelmReleaseHistoryProps {
 const HelmReleaseHistory: React.FC<HelmReleaseHistoryProps> = ({ match, obj }) => {
   const namespace = match.params.ns;
   const helmReleaseName = match.params.name;
-
+  const [revisionsLoaded, setRevisionsLoaded] = React.useState<boolean>(false);
+  const [loadError, setLoadError] = React.useState<string>();
+  const [revisions, setRevisions] = React.useState([]);
   const memoizedObj = useDeepCompareMemoize(obj);
 
-  const getHelmReleaseRevisions = (): Promise<HelmRelease[]> => {
-    return coFetchJSON(`/api/helm/release/history?ns=${namespace}&name=${helmReleaseName}`);
-  };
+  React.useEffect(() => {
+    let destroyed = false;
+    coFetchJSON(`/api/helm/release/history?ns=${namespace}&name=${helmReleaseName}`)
+      .then((items) => {
+        if (!destroyed) {
+          setLoadError(null);
+          setRevisionsLoaded(true);
+          setRevisions(items);
+        }
+      })
+      .catch((err) => {
+        if (!destroyed) {
+          setRevisionsLoaded(true);
+          setLoadError(err.message || 'Unable to load Helm Release history');
+        }
+      });
+    return () => {
+      destroyed = true;
+    };
+  }, [helmReleaseName, namespace, memoizedObj]);
+
+  if (loadError) {
+    return <StatusBox loaded loadError={loadError} label="Helm Release history" />;
+  }
 
   return (
     <CustomResourceList
-      fetchCustomResources={getHelmReleaseRevisions}
-      dependentResource={memoizedObj}
+      resources={revisions}
+      loaded={revisionsLoaded}
       sortBy="version"
       sortOrder={SortByDirection.desc}
       resourceRow={HelmReleaseHistoryRow}

--- a/frontend/packages/dev-console/src/components/helm/list/HelmReleaseList.scss
+++ b/frontend/packages/dev-console/src/components/helm/list/HelmReleaseList.scss
@@ -1,0 +1,9 @@
+.odc-helm-release__empty-list {
+  &__title {
+    font-size: var(--pf-global--FontSize--lg);
+  }
+  &__image {
+    height: var(--pf-c-empty-state__icon--FontSize);
+    max-width: 100%;
+  }
+}

--- a/frontend/packages/dev-console/src/components/helm/list/HelmReleaseList.tsx
+++ b/frontend/packages/dev-console/src/components/helm/list/HelmReleaseList.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
-import { FirehoseResult } from '@console/internal/components/utils';
-import { useDeepCompareMemoize } from '@console/shared';
+import { Link } from 'react-router-dom';
+import { EmptyState, EmptyStateIcon, EmptyStateVariant } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
+import { K8sResourceKind } from '@console/internal/module/k8s';
+import { SecretModel } from '@console/internal/models';
+import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
+import { StatusBox } from '@console/internal/components/utils';
+import { getImageForIconClass } from '@console/internal/components/catalog/catalog-item-icon';
 import CustomResourceList from '../../custom-resource-list/CustomResourceList';
 import {
   helmReleasesRowFilters,
@@ -11,24 +16,97 @@ import {
 } from '../helm-utils';
 import HelmReleaseListRow from './HelmReleaseListRow';
 import HelmReleaseListHeader from './HelmReleaseListHeader';
-import { HelmRelease } from '../helm-types';
+
+import './HelmReleaseList.scss';
 
 interface HelmReleaseListProps {
   namespace: string;
-  secrets?: FirehoseResult;
 }
 
-const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets }) => {
-  const memoizedSecrets = useDeepCompareMemoize(secrets?.data);
+const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace }) => {
+  const secretsCountRef = React.useRef<number>(0);
+  const [releasesLoaded, setReleasesLoaded] = React.useState<boolean>(false);
+  const [loadError, setLoadError] = React.useState<string>();
+  const [releases, setReleases] = React.useState([]);
+  const secretResource = React.useMemo(
+    () => ({
+      isList: true,
+      namespace,
+      kind: SecretModel.kind,
+      namespaced: true,
+      optional: true,
+      selector: { matchLabels: { owner: 'helm' } },
+    }),
+    [namespace],
+  );
+  const [secretsData, secretsLoaded, secretsLoadError] = useK8sWatchResource<K8sResourceKind[]>(
+    secretResource,
+  );
+  const newCount = secretsData?.length ?? 0;
 
-  const getHelmReleases = (): Promise<HelmRelease[]> => {
-    return fetchHelmReleases(namespace);
+  React.useEffect(() => {
+    setReleasesLoaded(false);
+    secretsCountRef.current = 0;
+  }, [namespace]);
+
+  React.useEffect(() => {
+    let destroyed = false;
+    if (secretsLoaded && !secretsLoadError) {
+      if (newCount === 0) {
+        setLoadError(null);
+        setReleasesLoaded(true);
+        setReleases([]);
+      } else if (newCount !== secretsCountRef.current) {
+        setReleasesLoaded(false);
+        fetchHelmReleases(namespace)
+          .then((helmReleases) => {
+            if (!destroyed) {
+              setReleases(helmReleases);
+              setReleasesLoaded(true);
+              setLoadError(null);
+            }
+          })
+          .catch((err) => {
+            if (!destroyed) {
+              setReleasesLoaded(true);
+              setLoadError(err.message || 'Unable to load Helm Releases');
+            }
+          });
+      }
+      secretsCountRef.current = newCount;
+    }
+    return () => {
+      destroyed = true;
+    };
+  }, [namespace, newCount, secretsLoadError, secretsLoaded]);
+
+  if (secretsLoadError || loadError) {
+    return <StatusBox loaded loadError={secretsLoadError || loadError} label="Helm Releases" />;
+  }
+
+  const emptyState = () => {
+    const helmImage = () => (
+      <img
+        className="odc-helm-release__empty-list__image"
+        src={getImageForIconClass('icon-helm')}
+        alt=""
+      />
+    );
+    const installURL = { pathname: `/catalog/ns/${namespace}`, search: '?kind=%5B"HelmChart"%5D' };
+    return (
+      <EmptyState variant={EmptyStateVariant.full}>
+        <p className="odc-helm-release__empty-list__title">No Helm Releases found</p>
+        <EmptyStateIcon variant="container" component={helmImage} />
+        <Link to={installURL}>Install a Helm Chart from the developer catalog</Link>
+      </EmptyState>
+    );
   };
 
   return (
     <CustomResourceList
-      fetchCustomResources={getHelmReleases}
-      dependentResource={memoizedSecrets}
+      resources={releases}
+      loaded={secretsLoaded && releasesLoaded && newCount === secretsCountRef.current}
+      EmptyMsg={emptyState}
       queryArg="rowFilter-helm-release-status"
       textFilter="name"
       rowFilters={helmReleasesRowFilters}


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3125

**Analysis / Root cause**: 
Simple message of `Not Found` was shown when there are no releases

**Solution Description**: 
If there are no secrets, do not fetch the helm releases. Update helm releases when the number of secrets changes (to retrieve any changes to the helm releases list).
If there are no helm releases display an empty state informing the user that there are no installed helm releases and provide a link to the developer catalog to create one if desired.

**Screen shots / Gifs for design review**:
![image](https://user-images.githubusercontent.com/11633780/81430513-8807f480-912d-11ea-9485-44759eb8f3c0.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley 

/kind bug