### PR TITLE
Bug 1830121: Enable pod list to display node instead of owner

### DIFF
--- a/frontend/public/components/daemon-set.tsx
+++ b/frontend/public/components/daemon-set.tsx
@@ -15,6 +15,7 @@ import {
   detailsPage,
   LabelList,
   navFactory,
+  PodsComponent,
   ResourceKebab,
   ResourceLink,
   ResourceSummary,
@@ -204,6 +205,10 @@ export const DaemonSetsPage: React.FC<DaemonSetsPageProps> = (props) => (
   <ListPage canCreate={true} ListComponent={DaemonSets} kind={kind} {...props} />
 );
 
+const DaemonSetPods: React.FC<DaemonSetPodsProps> = (props) => (
+  <PodsComponent {...props} customData={{ showNodes: true }} />
+);
+
 export const DaemonSetsDetailsPage: React.FC<DaemonSetsDetailsPageProps> = (props) => (
   <DetailsPage
     {...props}
@@ -212,7 +217,7 @@ export const DaemonSetsDetailsPage: React.FC<DaemonSetsDetailsPageProps> = (prop
     pages={[
       details(detailsPage(DaemonSetDetails)),
       editYaml(),
-      pods(),
+      pods(DaemonSetPods),
       envEditor(EnvironmentTab),
       events(ResourceEventStream),
     ]}
@@ -242,6 +247,10 @@ type DaemonSetsPageProps = {
   showTitle?: boolean;
   namespace?: string;
   selector?: any;
+};
+
+type DaemonSetPodsProps = {
+  obj: K8sResourceKind;
 };
 
 type DaemonSetsDetailsPageProps = {

--- a/frontend/public/components/job.tsx
+++ b/frontend/public/components/job.tsx
@@ -5,7 +5,7 @@ import * as classNames from 'classnames';
 import { sortable } from '@patternfly/react-table';
 
 import { Status } from '@console/shared';
-import { getJobTypeAndCompletions, K8sKind, JobKind } from '../module/k8s';
+import { getJobTypeAndCompletions, K8sKind, JobKind, K8sResourceKind } from '../module/k8s';
 import { Conditions } from './conditions';
 import { DetailsPage, ListPage, Table, TableRow, TableData, RowFunction } from './factory';
 import { configureJobParallelismModal } from './modals';
@@ -15,6 +15,7 @@ import {
   Kebab,
   KebabAction,
   LabelList,
+  PodsComponent,
   ResourceKebab,
   ResourceLink,
   ResourceSummary,
@@ -193,6 +194,10 @@ const JobDetails: React.FC<JobsDetailsProps> = ({ obj: job }) => (
   </>
 );
 
+const JobPods: React.FC<JobPodsProps> = (props) => (
+  <PodsComponent {...props} customData={{ showNodes: true }} />
+);
+
 const { details, pods, editYaml, events } = navFactory;
 const JobsDetailsPage: React.FC<JobsDetailsPageProps> = (props) => (
   <DetailsPage
@@ -200,7 +205,7 @@ const JobsDetailsPage: React.FC<JobsDetailsPageProps> = (props) => (
     getResourceStatus={jobStatus}
     kind={kind}
     menuActions={menuActions}
-    pages={[details(JobDetails), editYaml(), pods(), events(ResourceEventStream)]}
+    pages={[details(JobDetails), editYaml(), pods(JobPods), events(ResourceEventStream)]}
   />
 );
 const JobsList: React.FC = (props) => (
@@ -226,6 +231,10 @@ type JobsPageProps = {
   showTitle?: boolean;
   namespace?: string;
   selector?: any;
+};
+
+type JobPodsProps = {
+  obj: K8sResourceKind;
 };
 
 type JobsDetailsPageProps = {

--- a/frontend/public/components/replicaset.jsx
+++ b/frontend/public/components/replicaset.jsx
@@ -21,6 +21,7 @@ import {
   ResourceKebab,
   OwnerReferences,
   Timestamp,
+  PodsComponent,
 } from './utils';
 import { ResourceEventStream } from './events';
 import { VolumesTable } from './volumes-table';
@@ -89,6 +90,8 @@ const environmentComponent = (props) => (
   />
 );
 
+const ReplicaSetPods = (props) => <PodsComponent {...props} customData={{ showNodes: true }} />;
+
 const { details, editYaml, pods, envEditor, events } = navFactory;
 const ReplicaSetsDetailsPage = (props) => (
   <DetailsPage
@@ -97,7 +100,7 @@ const ReplicaSetsDetailsPage = (props) => (
     pages={[
       details(Details),
       editYaml(),
-      pods(),
+      pods(ReplicaSetPods),
       envEditor(environmentComponent),
       events(ResourceEventStream),
     ]}

--- a/frontend/public/components/replication-controller.jsx
+++ b/frontend/public/components/replication-controller.jsx
@@ -22,6 +22,7 @@ import {
   asAccessReview,
   OwnerReferences,
   Timestamp,
+  PodsComponent,
 } from './utils';
 
 import { VolumesTable } from './volumes-table';
@@ -131,6 +132,10 @@ const CancelAction = (kind, obj) => ({
   accessReview: asAccessReview(kind, obj, 'patch'),
 });
 
+const ReplicationControllerPods = (props) => (
+  <PodsComponent {...props} customData={{ showNodes: true }} />
+);
+
 const menuActions = [CancelAction, ...replicaSetMenuActions];
 
 export const ReplicationControllersDetailsPage = (props) => (
@@ -143,7 +148,7 @@ export const ReplicationControllersDetailsPage = (props) => (
     pages={[
       details(Details),
       editYaml(),
-      pods(),
+      pods(ReplicationControllerPods),
       envEditor(environmentComponent),
       events(ResourceEventStream),
     ]}

--- a/frontend/public/components/stateful-set.tsx
+++ b/frontend/public/components/stateful-set.tsx
@@ -18,6 +18,7 @@ import {
   SectionHeading,
   navFactory,
   LoadingInline,
+  PodsComponent,
 } from './utils';
 import { VolumesTable } from './volumes-table';
 import { StatefulSetModel } from '../models';
@@ -115,10 +116,14 @@ export const StatefulSetsPage: React.FC<StatefulSetsPageProps> = (props) => (
   <ListPage {...props} ListComponent={StatefulSetsList} kind={kind} canCreate={true} />
 );
 
+const StatefulSetPods: React.FC<StatefulSetPodsProps> = (props) => (
+  <PodsComponent {...props} customData={{ showNodes: true }} />
+);
+
 const pages = [
   navFactory.details(StatefulSetDetails),
   navFactory.editYaml(),
-  navFactory.pods(),
+  navFactory.pods(StatefulSetPods),
   navFactory.envEditor(EnvironmentTab),
   navFactory.events(ResourceEventStream),
 ];
@@ -146,6 +151,10 @@ type StatefulSetsPageProps = {
   showTitle?: boolean;
   namespace?: string;
   selector?: any;
+};
+
+type StatefulSetPodsProps = {
+  obj: K8sResourceKind;
 };
 
 type StatefulSetsDetailsPageProps = {

--- a/frontend/public/components/utils/horizontal-nav.tsx
+++ b/frontend/public/components/utils/horizontal-nav.tsx
@@ -22,12 +22,13 @@ export const viewYamlComponent = (props) => (
   />
 );
 
-class PodsComponent extends React.PureComponent<PodsComponentProps> {
+export class PodsComponent extends React.PureComponent<PodsComponentProps> {
   render() {
     const {
       metadata: { namespace },
       spec: { selector },
     } = this.props.obj;
+    const { customData } = this.props;
     if (_.isEmpty(selector)) {
       return <EmptyBox label="Pods" />;
     }
@@ -36,7 +37,13 @@ class PodsComponent extends React.PureComponent<PodsComponentProps> {
     // Otherwise it might seem like you click "Create Pod" to add replicas instead
     // of scaling the owner.
     return (
-      <PodsPage showTitle={false} namespace={namespace} selector={selector} canCreate={false} />
+      <PodsPage
+        showTitle={false}
+        namespace={namespace}
+        selector={selector}
+        canCreate={false}
+        customData={customData}
+      />
     );
   }
 }
@@ -251,6 +258,7 @@ export const HorizontalNav = React.memo((props: HorizontalNavProps) => {
 
 export type PodsComponentProps = {
   obj: K8sResourceKind;
+  customData?: any;
 };
 
 export type NavBarProps = {


### PR DESCRIPTION
and enable for daemon sets, jobs, replica sets, replication controllers, and stateful sets

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1830121

![localhost_9000_k8s_ns_openshift-controller-manager_daemonsets_controller-manager_pods(5  PFXL)](https://user-images.githubusercontent.com/895728/81446605-408f6180-9149-11ea-9dbd-f43706f5274b.png)
