### PR TITLE
Bug 1831758: Search page inputs need proper label 

### DIFF
--- a/frontend/public/components/search-filter-dropdown.tsx
+++ b/frontend/public/components/search-filter-dropdown.tsx
@@ -60,6 +60,7 @@ export const SearchFilterDropdown: React.SFC<SearchFilterDropdownProps> = (props
         id="search-filter-input"
         value={selected === searchFilterValues.Label ? labelFilterInput : nameFilterInput}
         onKeyDown={handleKeyDown}
+        aria-labelledby="toggle-id"
       />
     </div>
   );


### PR DESCRIPTION
This adds an `aria-labelledby` to the search input field which associates it to the dropdown. When the dropdown selects either Label or Name, the `aria-labelledby` is updated accordingly, fixing the following axe error:
```
{
    "data": null,
    "id": "aria-label",
    "impact": "serious",
    "message": "aria-label attribute does not exist or is empty",
    "relatedNodes": [
      {
        "html": "<input placeholder="app=frontend" name="search-filter-input" id="search-filter-input" class="pf-c-form-control" type="text" aria-invalid="false" value="">"
      }
    ]
  }
```