### PR TITLE
Bug 1834304: Always show dialog message when `Edit YAML` link in Pipeline Builder Page is clicked

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderForm.tsx
@@ -92,11 +92,7 @@ const PipelineBuilderForm: React.FC<PipelineBuilderFormProps> = (props) => {
   return (
     <Stack className="odc-pipeline-builder-form">
       <StackItem>
-        <PipelineBuilderHeader
-          formIsDirty={dirty}
-          existingPipeline={existingPipeline}
-          namespace={namespace}
-        />
+        <PipelineBuilderHeader existingPipeline={existingPipeline} namespace={namespace} />
       </StackItem>
       <StackItem isFilled className="odc-pipeline-builder-form__content">
         <Form className="odc-pipeline-builder-form__grid" onSubmit={handleSubmit}>

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
@@ -9,12 +9,11 @@ import './PipelineBuilderHeader.scss';
 
 type PipelineBuilderHeaderProps = {
   existingPipeline: Pipeline;
-  formIsDirty: boolean;
   namespace: string;
 };
 
 const PipelineBuilderHeader: React.FC<PipelineBuilderHeaderProps> = (props) => {
-  const { existingPipeline, formIsDirty, namespace } = props;
+  const { existingPipeline, namespace } = props;
 
   return (
     <div className="odc-pipeline-builder-header">
@@ -26,11 +25,7 @@ const PipelineBuilderHeader: React.FC<PipelineBuilderHeaderProps> = (props) => {
           <Button
             variant="link"
             onClick={() => {
-              if (formIsDirty) {
-                warnYAML(() => goToYAML(existingPipeline, namespace));
-              } else {
-                goToYAML(existingPipeline, namespace);
-              }
+              warnYAML(() => goToYAML(existingPipeline, namespace));
             }}
           >
             Edit YAML

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/modals/index.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/modals/index.tsx
@@ -31,7 +31,8 @@ export const warnYAML = (onAccept: ModalCallback) => {
       <ModalContent
         icon={<ExclamationTriangleIcon size="lg" color={warningColor.value} />}
         title="Switch to YAML Editor?"
-        message="Your changes will be lost if you continue. Are you sure you want to leave this form?"
+        message="Switching to YAML will lose any unsaved changes in this pipeline builder and allow you to build your pipeline in YAML.
+        Are you sure you want to switch?"
       />
     ),
     submitDanger: true,


### PR DESCRIPTION
**Fixes**:
https://issues.redhat.com/browse/ODC-3286

**Root Cause/Analysis**:
The dialog is shown only when values have been entered in the form.

**Solution Description**:
- always showing the dialog when the `Edit Yaml` link is clicked
- the dialog text is modified

**GIF**:
![pipeline](https://user-images.githubusercontent.com/22490998/81549465-652f4780-939c-11ea-9fe5-0121bae0ef18.gif)

/kind bug