### PR TITLE
Bug 1834354: Fix helm resource link in topology side panel

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleasePanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleasePanel.tsx
@@ -58,7 +58,10 @@ export const ConnectedTopologyHelmReleasePanel: React.FC<TopologyHelmReleasePane
 
   const resourcesComponent = () =>
     manifestResources ? (
-      <TopologyHelmReleaseResourcesPanel manifestResources={manifestResources} />
+      <TopologyHelmReleaseResourcesPanel
+        manifestResources={manifestResources}
+        releaseNamespace={namespace}
+      />
     ) : null;
 
   const releaseNotesComponent = () =>

--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseResourceItem.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseResourceItem.tsx
@@ -1,24 +1,28 @@
 import * as React from 'react';
 import { ResourceLink } from '@console/internal/components/utils';
-import { K8sResourceKind, referenceFor } from '@console/internal/module/k8s';
+import { K8sResourceKind, referenceFor, modelFor } from '@console/internal/module/k8s';
 
 type TopologyHelmReleaseResourceItemProps = {
   item: K8sResourceKind;
+  releaseNamespace: string;
 };
 
 const TopologyHelmReleaseResourceItem: React.FC<TopologyHelmReleaseResourceItemProps> = ({
   item,
+  releaseNamespace,
 }) => {
   const {
     metadata: { name, namespace },
   } = item;
   const kind = referenceFor(item);
+  const model = modelFor(kind);
+  const resourceNamespace = model.namespaced ? namespace || releaseNamespace : null;
 
   return (
     <li className="list-group-item container-fluid">
       <div className="row">
         <span className="col-xs-12">
-          <ResourceLink kind={kind} name={name} namespace={namespace} />
+          <ResourceLink kind={kind} name={name} namespace={resourceNamespace} />
         </span>
       </div>
     </li>

--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseResourceList.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseResourceList.tsx
@@ -4,17 +4,23 @@ import TopologyHelmReleaseResourceItem from './TopologyHelmReleaseResourceItem';
 
 type TopologyHelmReleaseResourceListProps = {
   resources: K8sResourceKind[];
+  releaseNamespace: string;
 };
 
 const TopologyHelmReleaseResourceList: React.FC<TopologyHelmReleaseResourceListProps> = ({
   resources,
+  releaseNamespace,
 }) => {
   return (
     <ul className="list-group">
       {resources
         .sort((r1, r2) => r1.metadata.name.localeCompare(r2.metadata.name))
         .map((resource) => (
-          <TopologyHelmReleaseResourceItem key={resource.metadata.name} item={resource} />
+          <TopologyHelmReleaseResourceItem
+            key={resource.metadata.name}
+            item={resource}
+            releaseNamespace={releaseNamespace}
+          />
         ))}
     </ul>
   );

--- a/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseResourcesPanel.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/TopologyHelmReleaseResourcesPanel.tsx
@@ -5,10 +5,12 @@ import TopologyHelmReleaseResourceList from './TopologyHelmReleaseResourceList';
 
 type TopologyHelmReleaseResourcesPanelProps = {
   manifestResources: K8sResourceKind[];
+  releaseNamespace: string;
 };
 
 const TopologyHelmReleaseResourcesPanel: React.SFC<TopologyHelmReleaseResourcesPanelProps> = ({
   manifestResources,
+  releaseNamespace,
 }) => {
   const kinds = manifestResources
     .reduce((resourceKinds, resource) => {
@@ -27,7 +29,10 @@ const TopologyHelmReleaseResourcesPanel: React.SFC<TopologyHelmReleaseResourcesP
       lists.push(
         <div key={model.kind}>
           <SidebarSectionHeading text={model.labelPlural} />
-          <TopologyHelmReleaseResourceList resources={resources} />
+          <TopologyHelmReleaseResourceList
+            resources={resources}
+            releaseNamespace={releaseNamespace}
+          />
         </div>,
       );
     }

--- a/frontend/packages/dev-console/src/components/topology/helm/__tests__/TopologyHelmReleasePanel.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/helm/__tests__/TopologyHelmReleasePanel.spec.tsx
@@ -43,7 +43,10 @@ describe('TopologyHelmReleaseResourcesPanel', () => {
 
   it('should render the correct number of resource categories', () => {
     const component = shallow(
-      <TopologyHelmReleaseResourcesPanel manifestResources={manifestResources} />,
+      <TopologyHelmReleaseResourcesPanel
+        manifestResources={manifestResources}
+        releaseNamespace="mock-ns"
+      />,
     );
     expect(component.find(SidebarSectionHeading)).toHaveLength(5);
   });


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3755

This PR -
- Fixes the resource link creation for some of the Helm charts installed using CLI. Now the link uses release namespace if the resource manifest doesn't have a namespace metadata.

![Peek 2020-05-11 20-29](https://user-images.githubusercontent.com/6041994/81576725-36c66200-93c6-11ea-81f8-10c6d6d4ec07.gif)
