### PR TITLE
Bug 1833877: Update virtualization breadcumbs

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template-details-page.tsx
@@ -14,7 +14,7 @@ export const breadcrumbsForVMTemplatePage = (match: any) => () => [
     path: `/k8s/ns/${match.params.ns || 'default'}/virtualization`,
   },
   {
-    name: 'Templates',
+    name: 'Virtual Machines Templates',
     path: `/k8s/ns/${match.params.ns || 'default'}/virtualization/templates`,
   },
   { name: `${match.params.name} Details`, path: `${match.url}` },

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -31,6 +31,10 @@ export const breadcrumbsForVMPage = (match: any) => () => [
     name: 'Virtualization',
     path: `/k8s/ns/${match.params.ns || 'default'}/virtualization`,
   },
+  {
+    name: 'Virtual Machines',
+    path: `/k8s/ns/${match.params.ns || 'default'}/virtualization`,
+  },
   { name: `${match.params.name} Details`, path: `${match.url}` },
 ];
 


### PR DESCRIPTION
Update breadcrumbs for virtualization details page:

Screenshots:

Virtual machines
![screenshot-localhost_9000-2020 05 11-18_06_44](https://user-images.githubusercontent.com/2181522/81577570-3fad3880-93b2-11ea-83a7-7dd3faa549bb.png)

Templates:
![screenshot-localhost_9000-2020 05 11-18_07_35](https://user-images.githubusercontent.com/2181522/81577659-62d7e800-93b2-11ea-9f62-d5a3b1d6e866.png)
