### PR TITLE
Bug 1834260: Update vm teamplates kebab lables

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/menu-actions.tsx
@@ -1,12 +1,13 @@
 import { getName, getNamespace } from '@console/shared';
 import { K8sKind, TemplateKind } from '@console/internal/module/k8s';
-import { asAccessReview, Kebab } from '@console/internal/components/utils';
+import { asAccessReview, Kebab, KebabOption } from '@console/internal/components/utils';
+import { deleteModal } from '@console/internal/components/modals/delete-modal';
 import { VMWizardName, VMWizardMode } from '../../constants/vm';
 import { VirtualMachineModel } from '../../models';
 import { getVMWizardCreateLink } from '../../utils/url';
 
 const vmTemplateEditAction = (kind: K8sKind, obj: TemplateKind) => ({
-  label: `Edit VM Template`,
+  label: `Edit Virtual Machine Template`,
   href: `/k8s/ns/${getNamespace(obj)}/vmtemplates/${getName(obj)}/yaml`,
   accessReview: asAccessReview(kind, obj, 'update'),
 });
@@ -22,10 +23,24 @@ const vmTemplateCreateVMAction = (kind: K8sKind, obj: TemplateKind) => ({
   accessReview: { model: VirtualMachineModel, namespace: getNamespace(obj), verb: 'create' },
 });
 
+export const menuActionDeleteVMTemplate = (
+  kindObj: K8sKind,
+  vmTempalte: TemplateKind,
+): KebabOption => ({
+  label: `Delete Virtual Machine Template`,
+  callback: () =>
+    deleteModal({
+      kind: kindObj,
+      resource: vmTempalte,
+      redirectTo: `/k8s/ns/${getNamespace(vmTempalte)}/virtualization/templates`,
+    }),
+  accessReview: asAccessReview(kindObj, vmTempalte, 'delete'),
+});
+
 export const menuActions = [
   Kebab.factory.ModifyLabels,
   Kebab.factory.ModifyAnnotations,
   vmTemplateEditAction,
   vmTemplateCreateVMAction,
-  Kebab.factory.Delete,
+  menuActionDeleteVMTemplate,
 ];


### PR DESCRIPTION
Use consistent terms and always refer to vm templates as "Virtaual Machine Template".

Screenshots:
![screenshot-localhost_9000-2020 05 11-18_30_24](https://user-images.githubusercontent.com/2181522/81580141-b435a680-93b5-11ea-9d43-01020a50d95d.png)
![screenshot-localhost_9000-2020 05 11-18_31_17](https://user-images.githubusercontent.com/2181522/81580144-b566d380-93b5-11ea-8567-8fa7721e4e0e.png)

Ref:
https://bugzilla.redhat.com/show_bug.cgi?id=1810379
https://bugzilla.redhat.com/show_bug.cgi?id=1834260