### PR TITLE
Bug 1834409: Fix alert msg when image is detected but has no builder image

### DIFF
--- a/frontend/packages/dev-console/src/components/import/builder/BuilderImageSelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/builder/BuilderImageSelector.tsx
@@ -17,16 +17,14 @@ const BuilderImageSelector: React.FC<BuilderImageSelectorProps> = ({
   builderImages,
 }) => {
   const { values, setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
+  const { selected, recommended, isRecommending, couldNotRecommend } = values.image;
 
   React.useEffect(() => {
-    if (values.image.selected) {
-      setFieldValue(
-        'image.tag',
-        _.get(builderImages, `${values.image.selected}.recentTag.name`, ''),
-      );
+    if (selected) {
+      setFieldValue('image.tag', _.get(builderImages, `${selected}.recentTag.name`, ''));
       setFieldTouched('image.tag', true);
     }
-  }, [values.image.selected, setFieldValue, setFieldTouched, builderImages]);
+  }, [selected, setFieldValue, setFieldTouched, builderImages]);
 
   const fieldId = getFieldId('image.name', 'selector');
 
@@ -36,19 +34,19 @@ const BuilderImageSelector: React.FC<BuilderImageSelectorProps> = ({
         itemList={builderImages}
         name="image.selected"
         loadingItems={loadingImageStream}
-        recommended={values.image.recommended}
+        recommended={recommended}
       />
     );
   }
 
   return (
     <FormGroup fieldId={fieldId} label="Builder Image">
-      {values.image.isRecommending && (
+      {isRecommending && (
         <>
           <LoadingInline /> Detecting recommended builder images...
         </>
       )}
-      {values.image.recommended && (
+      {recommended && builderImages.hasOwnProperty(recommended) && (
         <>
           <Alert variant="success" title="Builder image(s) detected." isInline>
             Recommended builder images are represented by{' '}
@@ -57,7 +55,7 @@ const BuilderImageSelector: React.FC<BuilderImageSelectorProps> = ({
           <br />
         </>
       )}
-      {values.image.couldNotRecommend && (
+      {(couldNotRecommend || (recommended && !builderImages.hasOwnProperty(recommended))) && (
         <>
           <Alert variant="warning" title="Unable to detect the builder image." isInline>
             Select the most appropriate one from the list to continue.


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3663

This PR -
- Fixes the alert shown when builder image is dected but their is no builder image to select in the selector.
- Instead of saying builder image detected successfully, now the alert says could not detect builder image.

Screecast - 
cc: @openshift/team-devconsole-ux 

![Peek 2020-05-11 21-53](https://user-images.githubusercontent.com/6041994/81586705-9119ef80-93d3-11ea-9dc7-a6bd799587aa.gif)

