### PR TITLE
Bug 1833222: Update yaml template meter example to current year

### DIFF
--- a/frontend/public/models/yaml-templates.ts
+++ b/frontend/public/models/yaml-templates.ts
@@ -201,8 +201,8 @@ metadata:
   namespace: openshift-metering
 spec:
   query: namespace-memory-request
-  reportingStart: '2019-01-01T00:00:00Z'
-  reportingEnd: '2019-12-30T23:59:59Z'
+  reportingStart: '${new Date().getFullYear()}-01-01T00:00:00Z'
+  reportingEnd: '${new Date().getFullYear()}-12-31T23:59:59Z'
   runImmediately: true
 `,
   )


### PR DESCRIPTION
Update yaml template metering example to current year.

![Screenshot_2020-05-11 OKD(1)](https://user-images.githubusercontent.com/18728857/81596833-f5ac5e80-9381-11ea-962d-815601980049.png)
