### PR TITLE
Bug 1834345: Handle import for all namespaces in dev perspective

### DIFF
--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -737,7 +737,7 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       perspective: 'dev',
       exact: false,
-      path: ['/k8s/all-namespaces/:plural'],
+      path: ['/k8s/all-namespaces/((!import):plural)'],
       loader: async () =>
         (
           await import(


### PR DESCRIPTION
Handling of plural cases of all-namespaces urls in the dev perspective caused an issue trying to view the Import YAML page when using `all-namspaces`. 

Adds a route for the import for all-namespaces route in the dev perspective.

Tested all other Add pages and other existing pages in the dev perspective and no other issues for the all-namespaces case.