### PR TITLE
Bug 1834446: fix learn more link for health checks

### DIFF
--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
+import Helmet from 'react-helmet';
 import { FormikProps, FormikValues } from 'formik';
 import { Form, Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
@@ -9,15 +10,15 @@ import {
   PageHeading,
   ResourceLink,
   ResourceIcon,
+  openshiftHelpBase,
 } from '@console/internal/components/utils';
+import { ContainerModel } from '@console/internal/models';
 import { K8sResourceKind, referenceFor, modelFor } from '@console/internal/module/k8s';
 import { FormFooter } from '@console/shared';
 import { getResourcesType } from '../edit-application/edit-application-utils';
 import HealthChecks from './HealthChecks';
-import Helmet from 'react-helmet';
-import { ContainerModel } from '@console/internal/models';
-import './AddHealthChecks.scss';
 import { getHealthChecksData } from './create-health-checks-probe-utils';
+import './AddHealthChecks.scss';
 
 type AddHealthChecksProps = {
   resource?: K8sResourceKind;
@@ -75,7 +76,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
             <Button
               variant="link"
               component="a"
-              href="https://docs.openshift.com/container-platform/3.11/dev_guide/application_health.html"
+              href={`${openshiftHelpBase}applications/application-health.html`}
               target="_blank"
             >
               Learn More <ExternalLinkAltIcon />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3620

**Analysis / Root cause**: 
Learn More link on health checks page redirects to 3.11 openshift doc.

**Solution Description**: 
use ```openshiftHelpBase``` to create the doc link. Which gives the latest doc link.

**Screen shots / Gifs for design review**: 
![health-checks-link](https://user-images.githubusercontent.com/2561818/81593597-5026d880-93dd-11ea-921b-74e38cf60bf0.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
