### PR TITLE
Bug 1834455: match available queries on dashboards and metrics tabs

### DIFF
--- a/frontend/packages/dev-console/src/components/monitoring/queries.ts
+++ b/frontend/packages/dev-console/src/components/monitoring/queries.ts
@@ -22,6 +22,10 @@ export const metricsQuery = {
   PODS_BY_FILESYSTEM: 'Filesystem Usage',
   PODS_BY_NETWORK_IN: 'Receive Bandwidth',
   PODS_BY_NETWORK_OUT: 'Transmit Bandwidth',
+  RATE_OF_RECEIVED_PACKETS: 'Rate of Received Packets',
+  RATE_OF_TRANSMITTED_PACKETS: 'Rate of Transmitted Packets',
+  RATE_OF_RECEIVED_PACKETS_DROPPED: 'Rate of Received Packets Dropped',
+  RATE_OF_TRANSMITTED_PACKETS_DROPPED: 'Rate of Transmitted Packets Dropped',
 };
 
 export const monitoringDashboardQueries: MonitoringQuery[] = [
@@ -218,6 +222,10 @@ const topMetricsQueries = {
   ),
   PODS_BY_NETWORK_IN: getMetricsQuery('Receive Bandwidth'),
   PODS_BY_NETWORK_OUT: getMetricsQuery('Transmit Bandwidth'),
+  RATE_OF_RECEIVED_PACKETS: getMetricsQuery('Rate of Received Packets'),
+  RATE_OF_TRANSMITTED_PACKETS: getMetricsQuery('Rate of Transmitted Packets'),
+  RATE_OF_RECEIVED_PACKETS_DROPPED: getMetricsQuery('Rate of Received Packets Dropped'),
+  RATE_OF_TRANSMITTED_PACKETS_DROPPED: getMetricsQuery('Rate of Transmitted Packets Dropped'),
 };
 
 export const getTopMetricsQueries = (namespace: string) => ({
@@ -232,4 +240,20 @@ export const getTopMetricsQueries = (namespace: string) => ({
   [metricsQuery.PODS_BY_NETWORK_OUT]: topMetricsQueries.PODS_BY_NETWORK_OUT({
     namespace,
   }),
+  [metricsQuery.RATE_OF_RECEIVED_PACKETS]: topMetricsQueries.RATE_OF_RECEIVED_PACKETS({
+    namespace,
+  }),
+  [metricsQuery.RATE_OF_TRANSMITTED_PACKETS]: topMetricsQueries.RATE_OF_TRANSMITTED_PACKETS({
+    namespace,
+  }),
+  [metricsQuery.RATE_OF_RECEIVED_PACKETS_DROPPED]: topMetricsQueries.RATE_OF_RECEIVED_PACKETS_DROPPED(
+    {
+      namespace,
+    },
+  ),
+  [metricsQuery.RATE_OF_TRANSMITTED_PACKETS_DROPPED]: topMetricsQueries.RATE_OF_TRANSMITTED_PACKETS_DROPPED(
+    {
+      namespace,
+    },
+  ),
 });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3612

**Analysis / Root cause**: 
Some dashboard cards are not available in the metrics query selector
Rate of Received Packets
Rate of Transmitted Packets
Rate of Received Packets Dropped
Rate of Transmitted Packets Dropped

These queries should be made available in the dropdown

**Solution Description**: 
match available queries on dashboards and metrics tabs

**Screen shots / Gifs for design review**: 
![monitoring-metrics](https://user-images.githubusercontent.com/2561818/81596170-3b4c4400-93e1-11ea-9c99-b75fb6c59c89.gif)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
