### PR TITLE
Bug 1834467: Alert manager missing <dl> for proper structure in alert routing section

### DIFF
--- a/frontend/public/components/monitoring/alert-manager-config.tsx
+++ b/frontend/public/components/monitoring/alert-manager-config.tsx
@@ -50,10 +50,14 @@ const AlertRouting = () => {
       </SectionHeading>
       <div className="row">
         <div className="col-sm-6">
-          <dt>Group By</dt>
-          <dd data-test-id="group_by_value">{_.isEmpty(groupBy) ? '-' : _.join(groupBy, ', ')}</dd>
-          <dt>Group Wait</dt>
-          <dd data-test-id="group_wait_value">{_.get(config, ['route', 'group_wait'], '-')}</dd>
+          <dl className="co-m-pane__details">
+            <dt>Group By</dt>
+            <dd data-test-id="group_by_value">
+              {_.isEmpty(groupBy) ? '-' : _.join(groupBy, ', ')}
+            </dd>
+            <dt>Group Wait</dt>
+            <dd data-test-id="group_wait_value">{_.get(config, ['route', 'group_wait'], '-')}</dd>
+          </dl>
         </div>
         <div className="col-sm-6">
           <dl className="co-m-pane__details">


### PR DESCRIPTION
This adds a `<dl>` to fix the structure of the Alert Manager's alert routing section (http://localhost:9000/monitoring/alertmanagerconfig) and fixes the following axe error: 
```
{
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Group By</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd data-test-id="group_by_value">namespace</dd>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Group Wait</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd data-test-id="group_wait_value">30s</dd>"
      }
    ]
  }
```