### PR TITLE
Bug 1834486: Make empty state page for topology list/graph consistent

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
+++ b/frontend/packages/dev-console/src/components/topology/TopologyPage.tsx
@@ -161,6 +161,8 @@ export const TopologyPage: React.FC<TopologyPageProps> = ({ match }) => {
                   mock={false}
                   match={match}
                   title=""
+                  EmptyMsg={EmptyMsg}
+                  emptyBodyClass="odc-namespaced-page__content"
                   loader={() =>
                     import(
                       '@console/internal/components/overview' /* webpackChunkName: "topology-overview" */

--- a/frontend/public/components/overview/index.tsx
+++ b/frontend/public/components/overview/index.tsx
@@ -373,8 +373,8 @@ class OverviewMainContent_ extends React.Component<
   }
 
   render() {
-    const { loaded, loadError, project, namespace } = this.props;
-    const { filteredItems, groupedItems } = this.state;
+    const { loaded, loadError, project, namespace, EmptyMsg, emptyBodyClass } = this.props;
+    const { items, filteredItems, groupedItems } = this.state;
     const OverviewEmptyState = () => (
       <MsgBox
         title="No Workloads Found."
@@ -396,17 +396,22 @@ class OverviewMainContent_ extends React.Component<
       </div>
     );
 
+    const hasItems = items?.length > 0;
     return (
       <div className="co-m-pane">
-        <OverviewHeading project={_.get(project, 'data')} />
-        <div className="co-m-pane__body co-m-pane__body--no-top-margin">
+        {hasItems && <OverviewHeading project={_.get(project, 'data')} />}
+        <div
+          className={
+            (!hasItems && emptyBodyClass) || 'co-m-pane__body co-m-pane__body--no-top-margin'
+          }
+        >
           <StatusBox
             skeleton={skeletonOverview}
             data={filteredItems}
             label="Resources"
             loaded={loaded}
             loadError={loadError}
-            EmptyMsg={OverviewEmptyState}
+            EmptyMsg={EmptyMsg || OverviewEmptyState}
           >
             <ProjectOverview groups={groupedItems} />
           </StatusBox>
@@ -448,6 +453,8 @@ const Overview_: React.SFC<OverviewProps> = ({
   resourceList,
   title,
   dismissDetails,
+  EmptyMsg,
+  emptyBodyClass,
 }) => {
   const namespace = _.get(match, 'params.name');
   const sidebarOpen = !_.isEmpty(selectedItem);
@@ -487,6 +494,8 @@ const Overview_: React.SFC<OverviewProps> = ({
               selectedItem={selectedItem}
               title={title}
               utils={utils}
+              EmptyMsg={EmptyMsg}
+              emptyBodyClass={emptyBodyClass}
             />
           </Firehose>
         </div>
@@ -586,6 +595,8 @@ type OverviewMainContentOwnProps = {
   title?: string;
   clusterServiceVersions?: FirehoseResult<ClusterServiceVersionKind[]>;
   utils?: Function[];
+  EmptyMsg?: React.ComponentType;
+  emptyBodyClass?: string;
 };
 
 export type OverviewMainContentProps = OverviewMainContentPropsFromState &
@@ -611,6 +622,8 @@ type OverviewOwnProps = {
   mock: boolean;
   match: any;
   title: string;
+  EmptyMsg?: React.ComponentType;
+  emptyBodyClass?: string;
 };
 
 type OverviewProps = OverviewPropsFromState & OverviewPropsFromDispatch & OverviewOwnProps;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3658

**Analysis / Root cause**: 
List view for topology was showing the same empty state as the admin project workloads view.

**Solution Description**: 
Update the empty state view for the topology list view to be the same view as the graph's view.

**Screen shots / Gifs for design review**:
List View:
![image](https://user-images.githubusercontent.com/11633780/81605178-13d48780-939f-11ea-8fff-6ca73fd1ffe3.png)

Graph View:
![image](https://user-images.githubusercontent.com/11633780/81605207-1e8f1c80-939f-11ea-8376-c090a0dd04bb.png)

Admin project workloads view:
(minor change to remove the `group by` and `filter` controls when empty @beanh66 )
![image](https://user-images.githubusercontent.com/11633780/81605257-323a8300-939f-11ea-997c-ac57966939bb.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley @beanh66 

/kind bug