### PR TITLE
Bug 1834499: Storage Class details page missing <dl> for proper structure

### DIFF
--- a/frontend/public/components/storage-class.tsx
+++ b/frontend/public/components/storage-class.tsx
@@ -107,10 +107,12 @@ const StorageClassDetails: React.SFC<StorageClassDetailsProps> = ({ obj }) => (
           </ResourceSummary>
         </div>
         <div className="col-sm-6">
-          <DetailsItem label="Reclaim Policy" obj={obj} path="reclaimPolicy" />
-          <dt>Default Class</dt>
-          <dd>{isDefaultClass(obj).toString()}</dd>
-          <DetailsItem label="Volume Binding Mode" obj={obj} path="volumeBindingMode" />
+          <dl className="co-m-pane__details">
+            <DetailsItem label="Reclaim Policy" obj={obj} path="reclaimPolicy" />
+            <dt>Default Class</dt>
+            <dd>{isDefaultClass(obj).toString()}</dd>
+            <DetailsItem label="Volume Binding Mode" obj={obj} path="volumeBindingMode" />
+          </dl>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This adds a `<dl>` to fix the structure of the Storage Class details pages (ex: http://localhost:9000/k8s/cluster/storageclasses/gp2) and fixes the following axe error:
```
[
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt><button class="pf-c-button pf-m-plain co-m-pane__details-popover-button" type="button" aria-expanded="false">Reclaim Policy</button></dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>Delete</dd>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Default Class</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>true</dd>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt><button class="pf-c-button pf-m-plain co-m-pane__details-popover-button" type="button" aria-expanded="false">Volume Binding Mode</button></dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>WaitForFirstConsumer</dd>"
      }
    ]
  }
```