### PR TITLE
Bug 1834621: add validation to traffic modal

### DIFF
--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
@@ -5,6 +5,7 @@ import { K8sResourceKind, k8sUpdate } from '@console/internal/module/k8s';
 import { ServiceModel } from '../../models';
 import { getRevisionItems, constructObjForUpdate } from '../../utils/traffic-splitting-utils';
 import TrafficSplittingModal from './TrafficSplittingModal';
+import { trafficModalValidationSchema } from '../../utils/trafficSplitting-validation-utils';
 
 export interface TrafficSplittingProps {
   service: K8sResourceKind;
@@ -59,6 +60,7 @@ const TrafficSplitting: React.FC<TrafficSplittingProps> = ({
       onSubmit={handleSubmit}
       onReset={cancel}
       initialStatus={{ error: '' }}
+      validationSchema={trafficModalValidationSchema}
     >
       {(props) => <TrafficSplittingModal {...props} revisionItems={revisionItems} />}
     </Formik>

--- a/frontend/packages/knative-plugin/src/utils/__tests__/trafficSplitting-validation-utils.spec.ts
+++ b/frontend/packages/knative-plugin/src/utils/__tests__/trafficSplitting-validation-utils.spec.ts
@@ -1,0 +1,53 @@
+import { trafficModalValidationSchema } from '../trafficSplitting-validation-utils';
+import { mockTrafficData } from '../__mocks__/traffic-splitting-utils-mock';
+import { TrafficSplittingType } from '../../components/traffic-splitting/TrafficSplitting';
+
+describe('Traffic Splitting Validation Utils', () => {
+  let mockTraffic: TrafficSplittingType;
+  beforeEach(() => {
+    mockTraffic = {
+      trafficSplitting: mockTrafficData,
+    };
+  });
+
+  it('should validate the form data', async () => {
+    await trafficModalValidationSchema
+      .isValid(mockTraffic)
+      .then((valid) => expect(valid).toEqual(true));
+  });
+
+  it('should throw error for required field if empty', async () => {
+    const mockErroneousTrafficData = mockTrafficData;
+    mockErroneousTrafficData.push({
+      percent: undefined,
+      tag: undefined,
+      revisionName: 'overlayimage-fdqsf',
+    });
+    mockTraffic = {
+      trafficSplitting: mockErroneousTrafficData,
+    };
+    await trafficModalValidationSchema
+      .isValid(mockTraffic)
+      .then((valid) => expect(valid).toEqual(false));
+    await trafficModalValidationSchema.validate(mockTraffic).catch((err) => {
+      expect(err.message).toBe('Required');
+      expect(err.type).toBe('required');
+    });
+  });
+
+  it('should trhow error if tag name contains special character', async () => {
+    const mockErroneousTrafficData = mockTrafficData;
+    mockErroneousTrafficData[0].tag = 't.0';
+    mockTraffic = {
+      trafficSplitting: mockErroneousTrafficData,
+    };
+    await trafficModalValidationSchema
+      .isValid(mockTraffic)
+      .then((valid) => expect(valid).toEqual(false));
+    await trafficModalValidationSchema.validate(mockTraffic).catch((err) => {
+      expect(err.message).toBe(
+        'tag name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+      );
+    });
+  });
+});

--- a/frontend/packages/knative-plugin/src/utils/trafficSplitting-validation-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/trafficSplitting-validation-utils.ts
@@ -1,0 +1,23 @@
+import * as yup from 'yup';
+
+const nameRegex = /^([a-z]([-a-z0-9]*[a-z0-9])?)*$/;
+
+export const trafficModalValidationSchema = yup.object().shape({
+  trafficSplitting: yup.array().of(
+    yup.object({
+      percent: yup
+        .number()
+        .required('Required')
+        .max(100, 'cannot exceed 100%'),
+      tag: yup
+        .string()
+        .matches(nameRegex, {
+          message:
+            'tag name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
+          excludeEmptyString: true,
+        })
+        .max(253, 'Cannot be longer than 253 characters.'),
+      revisionName: yup.string().required('Required'),
+    }),
+  ),
+});


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-3355

Analysis / Root cause:
Including a period "." in the tag causes the traffic distribution action to not work. Although there is no error messages or notification to the user to let them know

Solution Description:
add proper validation to traffic modal

Screens:
![Screenshot from 2020-05-12 09-47-34](https://user-images.githubusercontent.com/38663217/81638798-c6582900-9437-11ea-9f7a-c66fa1ffb8bc.png)
![Screenshot from 2020-05-12 09-48-07](https://user-images.githubusercontent.com/38663217/81638810-cc4e0a00-9437-11ea-9126-550d75008f19.png)

Code Coverage:
![Screenshot from 2020-05-12 09-49-17](https://user-images.githubusercontent.com/38663217/81638821-d53edb80-9437-11ea-8ca3-89d917790e25.png)

Browser Conformance:
- [x] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge