### PR TITLE
Bug 1820067: Dont show start guied on virtualization tabs

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-templates/vm-template.tsx
@@ -30,7 +30,6 @@ import {
   K8sEntityMap,
 } from '@console/shared';
 import { match } from 'react-router';
-import { withStartGuide } from '@console/internal/components/start-guide';
 import { VM_TEMPLATE_LABEL_PLURAL } from '../../constants/vm-templates';
 import {
   getTemplateOperatingSystems,
@@ -199,7 +198,7 @@ const getCreateProps = ({ namespace }: { namespace: string }) => {
   };
 };
 
-const WrappedVirtualMachineTemplatesPage: React.FC<VirtualMachineTemplatesPageProps &
+const VirtualMachineTemplatesPage: React.FC<VirtualMachineTemplatesPageProps &
   React.ComponentProps<typeof ListPage>> = (props) => {
   const { skipAccessReview, noProjectsAvailable, showTitle } = props.customData;
   const namespace = props.match.params.ns;
@@ -245,8 +244,6 @@ const WrappedVirtualMachineTemplatesPage: React.FC<VirtualMachineTemplatesPagePr
     />
   );
 };
-
-const VirtualMachineTemplatesPage = withStartGuide(WrappedVirtualMachineTemplatesPage);
 
 type VirtualMachineTemplatesPageProps = {
   match: match<{ ns?: string }>;

--- a/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/virtualization.tsx
@@ -71,7 +71,7 @@ export const WrappedVirtualizationPage: React.FC<VirtualizationPageProps> = (pro
         pages={pages}
         match={props.match}
         obj={obj}
-        customData={{ showTitle: false }}
+        customData={{ showTitle: false, noProjectsAvailable: props.noProjectsAvailable }}
       />
     </>
   );

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm.tsx
@@ -14,7 +14,6 @@ import {
   getOwnerReferences,
   getUID,
 } from '@console/shared';
-import { withStartGuide } from '@console/internal/components/start-guide';
 import { compareOwnerReference } from '@console/shared/src/utils/owner-references';
 import { NamespaceModel, PodModel, NodeModel } from '@console/internal/models';
 import {
@@ -191,7 +190,7 @@ const getCreateProps = ({ namespace }: { namespace: string }) => {
   };
 };
 
-export const WrappedVirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) => {
+const VirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (props) => {
   const { skipAccessReview, noProjectsAvailable, showTitle } = props.customData;
   const namespace = props.match.params.ns;
 
@@ -371,8 +370,6 @@ export const WrappedVirtualMachinesPage: React.FC<VirtualMachinesPageProps> = (p
     />
   );
 };
-
-const VirtualMachinesPage = withStartGuide(WrappedVirtualMachinesPage);
 
 type ObjectBundle = {
   vm: VMKind;


### PR DESCRIPTION
Fix unecessary "Getting Started" in virtualization page for normal user

Screenshot:
After:
![screenshot-localhost_9000-2020 05 12-10_23_43(1)](https://user-images.githubusercontent.com/2181522/81650601-c0b01280-943a-11ea-99da-17e860c4b250.png)

Before:
![screenshot-localhost_9000-2020 05 12-10_25_27](https://user-images.githubusercontent.com/2181522/81650849-f0f7b100-943a-11ea-9c34-70c90f15a176.png)
