### PR TITLE
Bug 1834671: Check runStrategy when checking for running vm

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
+++ b/frontend/packages/kubevirt-plugin/src/selectors/vm/selectors.ts
@@ -71,7 +71,10 @@ export const getFlavor = (vmLike: VMGenericLikeEntityKind) =>
   findKeySuffixValue(getLabels(vmLike), TEMPLATE_FLAVOR_LABEL);
 
 export const isVMRunning = (value: VMKind) =>
-  _.get(value, 'spec.running', false) as VMKind['spec']['running'];
+  (_.get(value, 'spec.runStrategy', null) === null &&
+    _.get(value, 'spec.running', null) === true) ||
+  (_.get(value, 'spec.running', null) === null &&
+    _.get(value, 'spec.runStrategy', null) !== 'Halted');
 
 export const isVMReady = (value: VMKind) =>
   _.get(value, 'status.ready', false) as VMKind['status']['ready'];


### PR DESCRIPTION
A running VM with runStrategy attribute (instead of 'running' attribute) has a running VMI but the VM status in the UI is 'Stopping'

Ref:
https://github.com/kubevirt/kubevirt/blob/master/pkg/virt-controller/watch/vm.go#L1268

Screenshots:
After:
![screenshot-localhost_9000-2020 05 12-13_15_57](https://user-images.githubusercontent.com/2181522/81672840-6a030280-9453-11ea-85bd-5a42120bacbe.png)

Before:
![screenshot-localhost_9000-2020 05 12-13_17_54](https://user-images.githubusercontent.com/2181522/81672848-6cfdf300-9453-11ea-9136-fe63e4e931b5.png)
