### PR TITLE
Bug 1834774: Solve React warning when closing Traffic Splitting dialog

### DIFF
--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
@@ -60,7 +60,9 @@ const TrafficSplitting: React.FC<TrafficSplittingProps> = ({
       onReset={cancel}
       initialStatus={{ error: '' }}
     >
-      {(props) => <TrafficSplittingModal {...props} revisionItems={revisionItems} />}
+      {(props) => (
+        <TrafficSplittingModal {...props} cancel={cancel} revisionItems={revisionItems} />
+      )}
     </Formik>
   );
 };

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingModal.tsx
@@ -4,6 +4,7 @@ import {
   ModalTitle,
   ModalBody,
   ModalSubmitFooter,
+  ModalComponentProps,
 } from '@console/internal/components/factory/modal';
 import TrafficSplittingFields from './TrafficSplittingFields';
 import { RevisionItems } from '../../utils/traffic-splitting-utils';
@@ -12,10 +13,10 @@ interface TrafficSplittingModalProps {
   revisionItems: RevisionItems;
 }
 
-type Props = FormikProps<FormikValues> & TrafficSplittingModalProps;
+type Props = FormikProps<FormikValues> & TrafficSplittingModalProps & ModalComponentProps;
 
 const TrafficSplittingModal: React.FC<Props> = (props) => {
-  const { handleSubmit, handleReset, isSubmitting, status } = props;
+  const { handleSubmit, cancel, isSubmitting, status } = props;
   return (
     <form className="modal-content" onSubmit={handleSubmit}>
       <ModalTitle>Set Traffic Distribution</ModalTitle>
@@ -26,7 +27,7 @@ const TrafficSplittingModal: React.FC<Props> = (props) => {
       <ModalSubmitFooter
         inProgress={isSubmitting}
         submitText="Save"
-        cancel={handleReset}
+        cancel={cancel}
         errorMessage={status.error}
       />
     </form>

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingModal.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/__tests__/TrafficSplittingModal.spec.tsx
@@ -19,6 +19,7 @@ describe('TrafficSplittingModal', () => {
       status: { error: 'checkErrorProp' },
       values: { trafficSplitting: mockTrafficData },
       revisionItems: mockRevisionItems,
+      cancel: jest.fn(),
     };
     wrapper = shallow(<TrafficSplittingModal {...formProps} />);
   });


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2356

**Analysis / Root cause**: 
"Can't perform a React state update" warning happend because the Dialog resets the formik state after unmounting it.

**Solution Description**: 
Just close the dialog instead. Similar to some other modal dialogs, like:

https://github.com/openshift/console/blob/master/frontend/packages/dev-console/src/components/modals/EditApplicationModal.tsx#L61

**Test setup:**
Not changed a test

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
