### PR TITLE
Bug 1834822: Fix edit and import flows deployment triggers

### DIFF
--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
@@ -34,7 +34,7 @@ describe('Import Submit Utils', () => {
       const annotations = _.get(returnValue, 'data.metadata.annotations');
       expect(JSON.parse(annotations['image.openshift.io/triggers'])).toEqual([
         {
-          from: { kind: 'ImageStreamTag', name: 'nodejs-ex-git:latest' },
+          from: { kind: 'ImageStreamTag', name: 'nodejs-ex-git:latest', namespace: 'gijohn' },
           fieldPath: 'spec.template.spec.containers[?(@.name=="nodejs-ex-git")].image',
         },
       ]);

--- a/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/AdvancedSection.tsx
@@ -57,7 +57,6 @@ const AdvancedSection: React.FC<AdvancedSectionProps> = ({ values, appResources 
           <DeploymentConfigSection
             namespace={values.project.name}
             resource={appResources?.editAppResource?.data}
-            isServerless={values.resources === Resources.KnativeService}
           />
         </ProgressiveListItem>
         <ProgressiveListItem name="Scaling">

--- a/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/advanced/DeploymentConfigSection.tsx
@@ -3,18 +3,21 @@ import * as _ from 'lodash';
 import { CheckboxField, EnvironmentField } from '@console/shared';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import FormSection from '../section/FormSection';
+import { useFormikContext, FormikValues } from 'formik';
+import { Resources } from '../import-types';
 
 export interface DeploymentConfigSectionProps {
   namespace: string;
   resource?: K8sResourceKind;
-  isServerless?: boolean;
 }
 
 const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
   namespace,
   resource,
-  isServerless,
 }) => {
+  const {
+    values: { resources },
+  } = useFormikContext<FormikValues>();
   const deploymentConfigObj = resource || {
     kind: 'DeploymentConfig',
     metadata: {
@@ -28,7 +31,7 @@ const DeploymentConfigSection: React.FC<DeploymentConfigSectionProps> = ({
         name="deployment.triggers.image"
         label="Auto deploy when new image is available"
       />
-      {!isServerless && (
+      {resources === Resources.OpenShift && (
         <CheckboxField
           name="deployment.triggers.config"
           label="Auto deploy when deployment configuration changes"

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -235,7 +235,11 @@ export const createOrUpdateDeployment = (
     project: { name: namespace },
     application: { name: application },
     image: { ports, tag },
-    deployment: { env, replicas },
+    deployment: {
+      env,
+      replicas,
+      triggers: { image: imageChange },
+    },
     labels: userLabels,
     limits: { cpu, memory },
     git: { url: repository, ref },
@@ -248,7 +252,7 @@ export const createOrUpdateDeployment = (
     ...getGitAnnotations(repository, ref),
     ...getCommonAnnotations(),
     'alpha.image.policy.openshift.io/resolve-names': '*',
-    ...getTriggerAnnotation(name),
+    ...(imageChange && getTriggerAnnotation(name, namespace)),
   };
   const podLabels = getPodLabels(name);
 
@@ -472,7 +476,7 @@ export const createOrUpdateResources = async (
       imageStreamName,
       undefined,
       undefined,
-      { ...defaultAnnotations, ...getTriggerAnnotation(name) },
+      { ...defaultAnnotations, ...getTriggerAnnotation(name, namespace) },
       _.get(appResources, 'editAppResource.data'),
     );
     return Promise.all([

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -46,10 +46,10 @@ export const getCommonAnnotations = () => {
   };
 };
 
-export const getTriggerAnnotation = (name: string) => ({
+export const getTriggerAnnotation = (name: string, namespace: string, tag: string = 'latest') => ({
   [TRIGGERS_ANNOTATION]: JSON.stringify([
     {
-      from: { kind: 'ImageStreamTag', name: `${name}:latest` },
+      from: { kind: 'ImageStreamTag', name: `${name}:${tag}`, namespace },
       fieldPath: `spec.template.spec.containers[?(@.name=="${name}")].image`,
     },
   ]),
@@ -65,6 +65,9 @@ export const getPodLabels = (name: string) => {
 export const mergeData = (originalResource: K8sResourceKind, newResource: K8sResourceKind) => {
   const mergedData = _.merge({}, originalResource || {}, newResource);
   mergedData.metadata.labels = newResource.metadata.labels;
+  if (mergedData.metadata.annotations) {
+    mergedData.metadata.annotations = newResource.metadata.annotations;
+  }
   if (mergedData.spec?.template?.metadata?.labels) {
     mergedData.spec.template.metadata.labels = newResource.spec?.template?.metadata?.labels;
   }
@@ -73,6 +76,9 @@ export const mergeData = (originalResource: K8sResourceKind, newResource: K8sRes
   }
   if (mergedData?.spec?.strategy) {
     mergedData.spec.strategy = newResource.spec.strategy;
+  }
+  if (mergedData.spec?.triggers) {
+    mergedData.spec.triggers = newResource.spec.triggers;
   }
   return mergedData;
 };


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-3290

**Analysis / Root cause:**
Deployment image trigger was showing as unchecked in edit form even when it was checked previously since deployment doesn't have the triggers feature and OpenShift Container Platform uses annotations to allow users to request triggering.

**Solution Description:**
While creating edit form values check for `image.openshift.io/triggers` and accordingly set image trigger value.

 **Refactor work:**

- Not showing config change trigger checkbox for deployment since it doesn't have triggers feature and also it was not being used while creating deployment resource.
- Using image trigger checkbox value to determine whether to add image trigger annotation in deployment or not.

**Gif:**
![Peek 2020-05-13 00-38](https://user-images.githubusercontent.com/20724543/81735022-0e1b9680-94b2-11ea-8f94-153f0c5308f7.gif)


/kind bug 
