### PR TITLE
Bug 1819892:  display 'Version not found' for update status when vers…

### DIFF
--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -127,7 +127,10 @@ const ErrorRetrievingMessage: React.SFC<CVStatusMessageProps> = ({ cv }) => {
   ) : (
     <Tooltip content={truncateMiddle(retrievedUpdatesCondition.message, { length: 256 })}>
       <span>
-        <RedExclamationCircleIcon /> Error retrieving
+        <RedExclamationCircleIcon />{' '}
+        {retrievedUpdatesCondition.reason === 'VersionNotFound'
+          ? 'Version not found'
+          : 'Error retrieving'}
       </span>
     </Tooltip>
   );


### PR DESCRIPTION
…ion is not available instead of 'Error retrieving'

After:
<img width="984" alt="Screen Shot 2020-05-12 at 10 02 03 AM" src="https://user-images.githubusercontent.com/895728/81701180-a7f22d80-9437-11ea-9e32-7d42d95c64ca.png">
Note the tooltip content did not change
<img width="979" alt="Screen Shot 2020-05-12 at 9 46 30 AM" src="https://user-images.githubusercontent.com/895728/81701051-77aa8f00-9437-11ea-92d2-6698f63ab769.png">

