### PR TITLE
Bug 1834886: Machine details page missing <dl> for proper structure

### DIFF
--- a/frontend/public/components/machine.tsx
+++ b/frontend/public/components/machine.tsx
@@ -149,52 +149,54 @@ const MachineDetails: React.SFC<MachineDetailsProps> = ({ obj }: { obj: MachineK
               <ResourceSummary resource={obj} />
             </div>
             <div className="col-sm-6">
-              <DetailsItem label="Phase" obj={obj} path="status.phase">
-                <Status status={getMachinePhase(obj)} />
-              </DetailsItem>
-              <DetailsItem
-                label="Provider State"
-                obj={obj}
-                path="status.providerStatus.instanceState"
-              >
-                {providerState}
-              </DetailsItem>
-              {nodeName && (
-                <>
-                  <dt>Node</dt>
-                  <dd>
-                    <NodeLink name={nodeName} />
-                  </dd>
-                </>
-              )}
-              {machineRole && (
-                <>
-                  <dt>Machine Role</dt>
-                  <dd>{machineRole}</dd>
-                </>
-              )}
-              {instanceType && (
-                <>
-                  <dt>Instance Type</dt>
-                  <dd>{instanceType}</dd>
-                </>
-              )}
-              {region && (
-                <>
-                  <dt>Region</dt>
-                  <dd>{region}</dd>
-                </>
-              )}
-              {zone && (
-                <>
-                  <dt>Availability Zone</dt>
-                  <dd>{zone}</dd>
-                </>
-              )}
-              <dt>Machine Addresses</dt>
-              <dd>
-                <NodeIPList ips={getMachineAddresses(obj)} expand />
-              </dd>
+              <dl className="co-m-pane__details">
+                <DetailsItem label="Phase" obj={obj} path="status.phase">
+                  <Status status={getMachinePhase(obj)} />
+                </DetailsItem>
+                <DetailsItem
+                  label="Provider State"
+                  obj={obj}
+                  path="status.providerStatus.instanceState"
+                >
+                  {providerState}
+                </DetailsItem>
+                {nodeName && (
+                  <>
+                    <dt>Node</dt>
+                    <dd>
+                      <NodeLink name={nodeName} />
+                    </dd>
+                  </>
+                )}
+                {machineRole && (
+                  <>
+                    <dt>Machine Role</dt>
+                    <dd>{machineRole}</dd>
+                  </>
+                )}
+                {instanceType && (
+                  <>
+                    <dt>Instance Type</dt>
+                    <dd>{instanceType}</dd>
+                  </>
+                )}
+                {region && (
+                  <>
+                    <dt>Region</dt>
+                    <dd>{region}</dd>
+                  </>
+                )}
+                {zone && (
+                  <>
+                    <dt>Availability Zone</dt>
+                    <dd>{zone}</dd>
+                  </>
+                )}
+                <dt>Machine Addresses</dt>
+                <dd>
+                  <NodeIPList ips={getMachineAddresses(obj)} expand />
+                </dd>
+              </dl>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This adds `<dl>`s to fix the structure of the Machine details page (From the navigation, go to Machines under Compute then select an option) and fixes the following axe error (which occurs 16 places on each machine details page):
```
{
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Phase</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Provider State</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>running</dd>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Node</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Machine Role</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>master</dd>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Instance Type</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>m4.xlarge</dd>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Region</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>us-east-2</dd>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Availability Zone</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>us-east-2a</dd>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dt>Machine Addresses</dt>"
      }
    ]
  },
  {
    "data": null,
    "id": "dlitem",
    "impact": "serious",
    "message": "Description list item does not have a <dl> parent element",
    "relatedNodes": [
      {
        "html": "<dd>"
      }
    ]
  }
```