### PR TITLE
Bug 1787503:  Add error if `metadata` not found in YAML

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -259,7 +259,12 @@ export const EditYAML_ = connect(stateToProps)(
         return;
       }
 
-      // If this is a namesapced resource, default to the active namespace when none is specified in the YAML.
+      if (!obj.metadata) {
+        this.handleError('No "metadata" field found in YAML.');
+        return;
+      }
+
+      // If this is a namespaced resource, default to the active namespace when none is specified in the YAML.
       if (!obj.metadata.namespace && model.namespaced) {
         if (this.props.activeNamespace === ALL_NAMESPACES_KEY) {
           this.handleError('No "metadata.namespace" field found in YAML.');


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1787503

Since schema validation is not yet possible, the simple fix here is to follow the existing error handling pattern in use for `apiVersion` and `kind` and add an additional check for `metadata`.

After:
<img width="900" alt="Screen Shot 2020-05-12 at 11 28 55 AM" src="https://user-images.githubusercontent.com/895728/81713445-e0980400-9443-11ea-8809-a20c0199d701.png">
