### PR TITLE
Bug 1835092: In VM status popup link to pod events instead of pod overview

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vm-status/vm-status.tsx
@@ -105,7 +105,7 @@ const ImporterPods: React.FC<ImporterPodsProps> = ({ statuses }) => (
   </>
 );
 
-const VIEW_POD_OVERVIEW = 'View pod overview';
+const VIEW_POD_EVENTS = 'View pod events';
 const VIEW_VM_EVENTS = 'View VM events';
 
 const getPodLink = (pod: PodKind) =>
@@ -134,7 +134,7 @@ export const VMStatus: React.FC<VMStatusProps> = ({ vm, vmi, vmStatusBundle }) =
   }
 
   if (pod) {
-    links.push({ to: getPodLink(pod), message: VIEW_POD_OVERVIEW });
+    links.push({ to: `${getPodLink(pod)}/events`, message: VIEW_POD_EVENTS });
   }
 
   let icon = UnknownIcon;


### PR DESCRIPTION
In VM status popup link to pod events instead of pod overview

Screenshot:
![Peek 2020-05-13 11-41](https://user-images.githubusercontent.com/2181522/81791466-6fbe1e00-950f-11ea-8d1c-a6a928b04104.gif)
