### PR TITLE
Bug 1835151: Fix rare crash in the "Add" page when a service fetch fail

### DIFF
--- a/frontend/packages/dev-console/src/components/AddPage.tsx
+++ b/frontend/packages/dev-console/src/components/AddPage.tsx
@@ -17,10 +17,10 @@ export interface AddPageProps {
 }
 
 interface ResourcesType {
-  deploymentConfigs: K8sResourceKind;
-  deployments: K8sResourceKind;
-  daemonSets: K8sResourceKind;
-  statefulSets: K8sResourceKind;
+  deploymentConfigs?: K8sResourceKind;
+  deployments?: K8sResourceKind;
+  daemonSets?: K8sResourceKind;
+  statefulSets?: K8sResourceKind;
   knativeService?: K8sResourceKind;
 }
 interface EmptyStateLoaderProps {
@@ -34,29 +34,25 @@ const handleProjectCreate = (project: K8sResourceKind) =>
 
 const EmptyStateLoader: React.FC<EmptyStateLoaderProps> = ({ resources, loaded, loadError }) => {
   const [noWorkloads, setNoWorkloads] = React.useState(false);
-  const knativeData = _.get(resources, ['knativeService', 'data'], null);
+  const daemonSets = resources?.daemonSets?.data;
+  const deploymentConfigs = resources?.deploymentConfigs?.data;
+  const deployments = resources?.deployments?.data;
+  const statefulSets = resources?.statefulSets?.data;
+  const knativeService = resources?.knativeService?.data;
 
   React.useEffect(() => {
     if (loaded) {
       setNoWorkloads(
-        _.isEmpty(resources.deploymentConfigs.data) &&
-          _.isEmpty(resources.deployments.data) &&
-          _.isEmpty(resources.daemonSets.data) &&
-          _.isEmpty(resources.statefulSets.data) &&
-          _.isEmpty(knativeData),
+        _.isEmpty(daemonSets) &&
+          _.isEmpty(deploymentConfigs) &&
+          _.isEmpty(deployments) &&
+          _.isEmpty(statefulSets) &&
+          _.isEmpty(knativeService),
       );
     } else if (loadError) {
       setNoWorkloads(false);
     }
-  }, [
-    loadError,
-    loaded,
-    resources.daemonSets.data,
-    resources.deploymentConfigs.data,
-    resources.deployments.data,
-    resources.statefulSets.data,
-    knativeData,
-  ]);
+  }, [loaded, loadError, daemonSets, deploymentConfigs, deployments, statefulSets, knativeService]);
   return noWorkloads ? (
     <ODCEmptyState
       title="Add"


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3316

**Analysis / Root cause**: 
In the case that one of the five a `FirehoseResource` fetch fails, it still access all resource data properties.

**Solution Description**: 
The change uses `_.get` for all resource data.

**Unit test coverage report**: 
Does not effect coverage

**Test setup:**
The origin bug is hard to reproduce because it requires failing networking calls.

I changed the `const resources: FirehoseResource[] = [ ...` definition in `AddPage.tsx`. For example change

```diff
  const resources: FirehoseResource[] = [
    {
      isList: true,
      kind: 'DeploymentConfig',
      namespace,
-      prop: 'deploymentConfigs',
+      prop: 'deploymentConfigs_FAILING',
      limit: 1,
    },
```

With this change the old code crashs, while the new is safe.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
