### PR TITLE
[release-4.4] bug 1831821: Remove 'type' key from Network Attachment Definition config

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinitionsForm.tsx
@@ -29,7 +29,6 @@ import NetworkTypeOptions from './NetworkTypeOptions';
 const buildConfig = (name, networkType, typeParamsData): NetworkAttachmentDefinitionConfig => {
   const config: NetworkAttachmentDefinitionConfig = {
     name,
-    type: networkType,
     cniVersion: '0.3.1',
   };
 

--- a/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
+++ b/frontend/packages/network-attachment-definition-plugin/src/types/types.ts
@@ -18,7 +18,7 @@ export type NetworkAttachmentDefinitionPlugin = {
 export type NetworkAttachmentDefinitionConfig = {
   cniVersion: string;
   name: string;
-  type: string;
+  type?: string;
   bridge?: string;
   isGateway?: true;
   ipam?: IPAMConfig;


### PR DESCRIPTION
Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>