### PR TITLE
Bug 1832609: Use the same icon in the template catalog list and the detail overlay

### DIFF
--- a/frontend/__mocks__/catalogItemsMocks.ts
+++ b/frontend/__mocks__/catalogItemsMocks.ts
@@ -210,6 +210,24 @@ export const catalogListPageProps = {
           removedFromBrokerCatalog: false,
         },
       },
+      {
+        metadata: {
+          name: 'c01f3bb8-c641-11e8-be32-54e1ad486c15',
+          uid: 'cbe7e8db-c641-11e8-8889-0242ac110004',
+        },
+        spec: {
+          tags: ['quickstart', 'fa-icon'],
+          externalMetadata: {
+            'console.openshift.io/iconClass': 'fa fa-fill-drip',
+            displayName: 'FA icon example',
+            providerDisplayName: 'Red Hat, Inc.',
+          },
+          description: 'Example to validate icon',
+        },
+        status: {
+          removedFromBrokerCatalog: false,
+        },
+      },
     ],
     filters: {},
     loadError: '',

--- a/frontend/__tests__/components/catalog.spec.tsx
+++ b/frontend/__tests__/components/catalog.spec.tsx
@@ -53,7 +53,7 @@ describe(CatalogTileViewPage.displayName, () => {
     expect(filterItems.at(2).props().checked).toBe(false); // filter templates should be false by default
     expect(filterItems.at(3).props().count).toBe(2); // total count for imagestreams
     expect(filterItems.at(3).props().checked).toBe(false); // filter imagestreams should be false by default
-    expect(filterItems.at(4).props().count).toBe(11); // total count for clusterServiceClasses
+    expect(filterItems.at(4).props().count).toBe(12); // total count for clusterServiceClasses
     expect(filterItems.at(4).props().checked).toBe(false); // filter clusterServiceClasses should be false by default
   });
 
@@ -67,7 +67,7 @@ describe(CatalogTileViewPage.displayName, () => {
     const tiles = wrapper.find<any>(CatalogTile);
 
     expect(tiles.exists()).toBe(true);
-    expect(tiles.length).toEqual(22);
+    expect(tiles.length).toEqual(23);
 
     const cakeSqlTileProps = tiles.at(2).props();
     expect(cakeSqlTileProps.title).toEqual('CakePHP + MySQL');
@@ -80,7 +80,7 @@ describe(CatalogTileViewPage.displayName, () => {
       ),
     ).toBe(true);
 
-    const amqTileProps = tiles.at(19).props();
+    const amqTileProps = tiles.at(20).props();
     expect(amqTileProps.title).toEqual('Red Hat JBoss A-MQ 6.3 (Ephemeral, no SSL)');
     expect(amqTileProps.iconImg).toEqual('test-file-stub');
     expect(amqTileProps.iconClass).toBe(null);
@@ -91,7 +91,7 @@ describe(CatalogTileViewPage.displayName, () => {
       ),
     ).toBe(true);
 
-    const wildflyTileProps = tiles.at(21).props();
+    const wildflyTileProps = tiles.at(22).props();
     expect(wildflyTileProps.title).toEqual('WildFly');
     expect(wildflyTileProps.iconImg).toEqual('test-file-stub');
     expect(wildflyTileProps.iconClass).toBe(null);
@@ -101,6 +101,13 @@ describe(CatalogTileViewPage.displayName, () => {
         'Build and run WildFly 10.1 applications on CentOS 7. For more information about using this builder image',
       ),
     ).toBe(true);
+
+    const faIconTileProps = tiles.at(5).props();
+    expect(faIconTileProps.title).toEqual('FA icon example');
+    expect(faIconTileProps.iconImg).toBe(null);
+    expect(faIconTileProps.iconClass).toBe('fa fa-fill-drip');
+    expect(faIconTileProps.vendor).toEqual('provided by Red Hat, Inc.');
+    expect(faIconTileProps.description).toEqual('Example to validate icon');
   });
 
   it('categorizes catalog items', () => {

--- a/frontend/public/components/catalog/catalog-item-icon.tsx
+++ b/frontend/public/components/catalog/catalog-item-icon.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as _ from 'lodash-es';
 import * as classNames from 'classnames';
 
-import { K8sResourceKind, TemplateKind } from '../../module/k8s';
+import { K8sResourceKind, TemplateKind, PartialObjectMetadata } from '../../module/k8s';
 import * as threeScaleImg from '../../imgs/logos/3scale.svg';
 import * as aerogearImg from '../../imgs/logos/aerogear.svg';
 import * as amqImg from '../../imgs/logos/amq.svg';
@@ -216,7 +216,7 @@ export const getImageStreamIcon = (tag: string): string => {
   return _.get(tag, 'annotations.iconClass');
 };
 
-export const getTemplateIcon = (template: TemplateKind): string => {
+export const getTemplateIcon = (template: TemplateKind | PartialObjectMetadata): string => {
   return _.get(template, 'metadata.annotations.iconClass');
 };
 

--- a/frontend/public/components/catalog/catalog-items.tsx
+++ b/frontend/public/components/catalog/catalog-items.tsx
@@ -318,11 +318,9 @@ export class CatalogTileViewPage extends React.Component<
     if (!item) {
       return null;
     }
-    const { obj, tileName, tileImgUrl, tileIconClass, tileProvider, tileDescription, kind } = item;
+    const { obj, tileName, tileProvider, tileDescription, kind } = item;
     const uid = obj.metadata.uid;
-    const iconClass = tileIconClass ? normalizeIconClass(tileIconClass) : null;
     const vendor = tileProvider ? `provided by ${tileProvider}` : null;
-    const iconImgUrl = tileImgUrl || catalogImg;
     const { kind: filters } = getAvailableFilters({ kind });
     const filter = _.find(filters, ['value', kind]);
     return (
@@ -336,8 +334,7 @@ export class CatalogTileViewPage extends React.Component<
             <Badge isRead>{filter.label}</Badge>
           </CatalogTileBadge>,
         ]}
-        iconImg={iconImgUrl}
-        iconClass={iconClass}
+        {...this.getIconProps(item)}
         vendor={vendor}
         description={tileDescription}
         data-test={`${kind}-${obj.metadata.name}`}
@@ -357,10 +354,7 @@ export class CatalogTileViewPage extends React.Component<
             <CatalogItemHeader
               title={detailsItem.tileName}
               vendor={detailsItem.tileProvider ? `Provided by ${detailsItem.tileProvider}` : null}
-              iconClass={
-                detailsItem.tileIconClass ? normalizeIconClass(detailsItem.tileIconClass) : null
-              }
-              iconImg={detailsItem.tileImgUrl}
+              {...this.getIconProps(detailsItem)}
             />
             <div className="co-catalog-page__overlay-actions">
               <Link
@@ -382,5 +376,15 @@ export class CatalogTileViewPage extends React.Component<
         <CatalogTileDetails item={detailsItem} closeOverlay={this.closeOverlay} />
       </Modal>
     );
+  };
+
+  getIconProps = (item: Item) => {
+    const { tileImgUrl, tileIconClass } = item;
+    if (tileImgUrl) {
+      return { iconImg: tileImgUrl, iconClass: null };
+    } else if (tileIconClass) {
+      return { iconImg: null, iconClass: normalizeIconClass(tileIconClass) };
+    }
+    return { iconImg: catalogImg, iconClass: null };
   };
 }

--- a/frontend/public/components/catalog/catalog-items.tsx
+++ b/frontend/public/components/catalog/catalog-items.tsx
@@ -285,6 +285,35 @@ export class CatalogTileViewPage extends React.Component<
     this.setState({ detailsItem: null });
   };
 
+  render() {
+    const { items } = this.props;
+    const { detailsItem } = this.state;
+    return (
+      <>
+        <TileViewPage
+          items={items}
+          itemsSorter={(itemsToSort) =>
+            _.sortBy(itemsToSort, ({ tileName }) => tileName.toLowerCase())
+          }
+          getAvailableCategories={() => catalogCategories}
+          // TODO(alecmerdler): Dynamic filters for each Operator and its provided APIs
+          getAvailableFilters={getAvailableFilters}
+          filterGroups={filterGroups}
+          storeFilterKey={filterKey}
+          filterGroupNameMap={filterGroupNameMap}
+          keywordCompare={keywordCompare}
+          filterRetentionPreference={filterPreference}
+          renderTile={this.renderTile}
+          pageDescription={pageDescription}
+          emptyStateInfo="No developer catalog items are being shown due to the filters being applied."
+          groupItems={groupItems}
+          groupByTypes={GroupByTypes}
+        />
+        {this.renderModal(detailsItem)}
+      </>
+    );
+  }
+
   renderTile = (item: Item): React.ReactElement => {
     if (!item) {
       return null;
@@ -316,66 +345,42 @@ export class CatalogTileViewPage extends React.Component<
     );
   };
 
-  render() {
-    const { items } = this.props;
-    const { detailsItem } = this.state;
+  renderModal = (detailsItem: Item) => {
+    if (!detailsItem) {
+      return null;
+    }
     return (
-      <>
-        <TileViewPage
-          items={items}
-          itemsSorter={(itemsToSort) =>
-            _.sortBy(itemsToSort, ({ tileName }) => tileName.toLowerCase())
-          }
-          getAvailableCategories={() => catalogCategories}
-          // TODO(alecmerdler): Dynamic filters for each Operator and its provided APIs
-          getAvailableFilters={getAvailableFilters}
-          filterGroups={filterGroups}
-          storeFilterKey={filterKey}
-          filterGroupNameMap={filterGroupNameMap}
-          keywordCompare={keywordCompare}
-          filterRetentionPreference={filterPreference}
-          renderTile={this.renderTile}
-          pageDescription={pageDescription}
-          emptyStateInfo="No developer catalog items are being shown due to the filters being applied."
-          groupItems={groupItems}
-          groupByTypes={GroupByTypes}
-        />
-        {detailsItem && (
-          <Modal
-            className="co-catalog-page__overlay co-catalog-page__overlay--right"
-            header={
-              <>
-                <CatalogItemHeader
-                  title={detailsItem.tileName}
-                  vendor={
-                    detailsItem.tileProvider ? `Provided by ${detailsItem.tileProvider}` : null
-                  }
-                  iconClass={
-                    detailsItem.tileIconClass ? normalizeIconClass(detailsItem.tileIconClass) : null
-                  }
-                  iconImg={detailsItem.tileImgUrl}
-                />
-                <div className="co-catalog-page__overlay-actions">
-                  <Link
-                    className="pf-c-button pf-m-primary co-catalog-page__overlay-action"
-                    to={detailsItem.href}
-                    role="button"
-                    title={detailsItem.createLabel}
-                    onClick={this.closeOverlay}
-                  >
-                    {detailsItem.createLabel}
-                  </Link>
-                </div>
-              </>
-            }
-            isOpen={!!detailsItem}
-            onClose={this.closeOverlay}
-            title={detailsItem.tileName}
-          >
-            <CatalogTileDetails item={detailsItem} closeOverlay={this.closeOverlay} />
-          </Modal>
-        )}
-      </>
+      <Modal
+        className="co-catalog-page__overlay co-catalog-page__overlay--right"
+        header={
+          <>
+            <CatalogItemHeader
+              title={detailsItem.tileName}
+              vendor={detailsItem.tileProvider ? `Provided by ${detailsItem.tileProvider}` : null}
+              iconClass={
+                detailsItem.tileIconClass ? normalizeIconClass(detailsItem.tileIconClass) : null
+              }
+              iconImg={detailsItem.tileImgUrl}
+            />
+            <div className="co-catalog-page__overlay-actions">
+              <Link
+                className="pf-c-button pf-m-primary co-catalog-page__overlay-action"
+                to={detailsItem.href}
+                role="button"
+                title={detailsItem.createLabel}
+                onClick={this.closeOverlay}
+              >
+                {detailsItem.createLabel}
+              </Link>
+            </div>
+          </>
+        }
+        isOpen={!!detailsItem}
+        onClose={this.closeOverlay}
+        title={detailsItem.tileName}
+      >
+        <CatalogTileDetails item={detailsItem} closeOverlay={this.closeOverlay} />
+      </Modal>
     );
-  }
+  };
 }

--- a/frontend/public/components/catalog/catalog-items.tsx
+++ b/frontend/public/components/catalog/catalog-items.tsx
@@ -15,7 +15,7 @@ import { normalizeIconClass } from './catalog-item-icon';
 import { CatalogTileDetails } from './catalog-item-details';
 import { TileViewPage } from '../utils/tile-view-page';
 
-type Metadata = { uid?: string; name: string; namespace?: string };
+type Metadata = { uid?: string; name?: string; namespace?: string };
 
 export type Item = {
   obj?: {
@@ -31,7 +31,11 @@ export type Item = {
   tileProvider?: string;
   tileDescription?: string;
   tags?: string[];
-  documentationUrl?: string | undefined;
+  longDescription?: string;
+  documentationUrl?: string;
+  supportUrl?: string;
+  markdownDescription?: () => Promise<string>;
+  customProperties?: React.ReactElement;
 };
 
 export type CatalogTileViewPageProps = {

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -5,7 +5,7 @@ import { safeLoad } from 'js-yaml';
 
 import { PropertyItem } from '@patternfly/react-catalog-view-extension';
 import { ANNOTATIONS, FLAGS, APIError } from '@console/shared';
-import { CatalogTileViewPage } from './catalog-items';
+import { CatalogTileViewPage, Item } from './catalog-items';
 import {
   k8sListPartialMetadata,
   referenceForModel,
@@ -13,6 +13,7 @@ import {
   K8sResourceCommon,
   K8sResourceKind,
   PartialObjectMetadata,
+  TemplateKind,
 } from '../../module/k8s';
 import { withStartGuide } from '../start-guide';
 import { connectToFlags, flagPending, FlagsObject } from '../../reducers/features';
@@ -69,7 +70,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
     }
   }
 
-  getItems() {
+  getItems(): Item[] {
     const extensionItems = _.flatten(
       plugins.registry
         .getDevCatalogModels()
@@ -77,7 +78,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
         .map(({ properties }) =>
           properties.normalize(_.get(this.props, [referenceForModel(properties.model), 'data'])),
         ),
-    );
+    ) as Item[];
 
     const {
       clusterServiceClasses,
@@ -87,11 +88,11 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
       helmCharts,
       loaded,
     } = this.props;
-    let clusterServiceClassItems = [];
-    let imageStreamItems = [];
-    let templateItems = [];
-    let projectTemplateItems = [];
-    let helmChartItems = [];
+    let clusterServiceClassItems: Item[] = [];
+    let imageStreamItems: Item[] = [];
+    let templateItems: Item[] = [];
+    let projectTemplateItems: Item[] = [];
+    let helmChartItems: Item[] = [];
 
     if (!loaded) {
       return [];
@@ -119,7 +120,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
       helmChartItems = this.normalizeHelmCharts(helmCharts);
     }
 
-    const items = [
+    const items: Item[] = [
       ...clusterServiceClassItems,
       ...imageStreamItems,
       ...templateItems,
@@ -131,7 +132,7 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
     return _.sortBy(items, 'tileName');
   }
 
-  normalizeClusterServiceClasses(serviceClasses) {
+  normalizeClusterServiceClasses(serviceClasses: K8sResourceKind[]) {
     const { namespace = '' } = this.props;
     return _.reduce(
       serviceClasses,
@@ -164,11 +165,11 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
         });
         return acc;
       },
-      [],
+      [] as Item[],
     );
   }
 
-  normalizeTemplates(templates) {
+  normalizeTemplates(templates: Array<TemplateKind | PartialObjectMetadata>): Item[] {
     return _.reduce(
       templates,
       (acc, template) => {
@@ -197,11 +198,11 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
         });
         return acc;
       },
-      [],
+      [] as Item[],
     );
   }
 
-  normalizeHelmCharts(chartEntries: HelmChartEntries) {
+  normalizeHelmCharts(chartEntries: HelmChartEntries): Item[] {
     const { namespace: currentNamespace = '' } = this.props;
 
     return _.reduce(
@@ -275,11 +276,11 @@ export class CatalogListPage extends React.Component<CatalogListPageProps, Catal
         });
         return normalizedCharts;
       },
-      [],
+      [] as Item[],
     );
   }
 
-  normalizeImageStreams(imageStreams) {
+  normalizeImageStreams(imageStreams: K8sResourceKind[]): Item[] {
     const builderimageStreams = _.filter(imageStreams, isBuilder);
     return _.map(builderimageStreams, (imageStream) => {
       const { namespace: currentNamespace = '' } = this.props;
@@ -488,7 +489,7 @@ export type CatalogListPageProps = {
 };
 
 export type CatalogListPageState = {
-  items: any[];
+  items: Item[];
 };
 
 export type CatalogProps = {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3811

**Analysis / Root cause**: 
The template `catalog-page.tsx` and `catalog-items.tsx` uses slightly different algorithm and icon fallbacks if no iconClass is provided.

**Solution Description**: 
* Remove the fallback mechanism from `catalog-items.tsx` and use the provided props to render the same icon as on the list.
* Add the fallback to `catalog-icon.svg` also to the list, so that we show now also an icon if no `iconClass` is provided in the template.

**Screen shots for design review**: 

Old behavior / without this change:

Template list:
![before-list](https://user-images.githubusercontent.com/139310/81814733-68a40980-9529-11ea-97a6-648c41c103ce.png)

Template overlay with a known icon:
![before-detail-with-known-icon](https://user-images.githubusercontent.com/139310/81814728-680b7300-9529-11ea-840d-2d980739a2bc.png)

Template overlay with a fa-icon:
![before-detail-with-fa-icon](https://user-images.githubusercontent.com/139310/81814726-680b7300-9529-11ea-9a86-322f7b95ba6f.png)

Template overlay without an icon (no iconClass annotation):
![before-detail-without-icon](https://user-images.githubusercontent.com/139310/81814724-6772dc80-9529-11ea-9bdf-09c1ad38ed0f.png)

With this PR:

Template list:
![after-list](https://user-images.githubusercontent.com/139310/81814723-66da4600-9529-11ea-8c9d-b4f45ca8b3fd.png)

Template overlay with a known icon:
![after-detail-with-known-icon](https://user-images.githubusercontent.com/139310/81814720-66da4600-9529-11ea-9e09-e3cb2e075d80.png)

Template overlay with a fa-icon:
![after-detail-with-fa-icon](https://user-images.githubusercontent.com/139310/81814717-6641af80-9529-11ea-9b00-79cebe73dc1e.png)

Template overlay without an icon (no iconClass annotation):
![after-detail-without-icon](https://user-images.githubusercontent.com/139310/81814713-65a91900-9529-11ea-8a26-80e7876d2941.png)

**Unit test coverage report**: 
No change

**Test setup:**
As described in https://bugzilla.redhat.com/show_bug.cgi?id=1832609 by Sergio:

1. Create a template with a custom icon: metadata.annotations.iconClass = "fa fa-fill-drip"
2. Find the template in the catalog and see how the icon is not shown
3. Click on the template to see the details and see how the icon is properly shown
4. Click on "instantiate template" and see how the icon is properly shown in the next screen

I recommend to create a project first and import then the template files with `oc create -f template-test.yaml -n yourProject`. I uploaded 3 template files to bugzilla.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

/cc @openshift/team-devconsole-ux