### PR TITLE
Bug 1835296: Use updated filter bar for helm releases

### DIFF
--- a/frontend/packages/dev-console/src/components/custom-resource-list/__tests__/CustomResourceList.spec.tsx
+++ b/frontend/packages/dev-console/src/components/custom-resource-list/__tests__/CustomResourceList.spec.tsx
@@ -2,18 +2,10 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import * as fuzzy from 'fuzzysearch';
 import { SortByDirection, sortable } from '@patternfly/react-table';
-import {
-  TableRow,
-  TableData,
-  Table,
-  TextFilter,
-  RowFunction,
-} from '@console/internal/components/factory';
+import { TableRow, TableData, Table, RowFunction } from '@console/internal/components/factory';
+import { RowFilter, FilterToolbar } from '@console/internal/components/filter-toolbar';
 import CustomResourceList from '../CustomResourceList';
-import {
-  CustomResourceListProps,
-  CustomResourceListRowFilter,
-} from '../custom-resource-list-types';
+import { CustomResourceListProps } from '../custom-resource-list-types';
 
 let customResourceListProps: CustomResourceListProps;
 
@@ -91,10 +83,10 @@ describe('CustomeResourceList', () => {
 
   const mockSelectedStatuses = ['successful', 'failed'];
 
-  const mockRowFilters: CustomResourceListRowFilter[] = [
+  const mockRowFilters: RowFilter[] = [
     {
+      filterGroupName: 'Status',
       type: 'mock-filter',
-      selected: mockSelectedStatuses,
       reducer: mockReducer,
       items: mockSelectedStatuses.map((status) => ({
         id: status,
@@ -106,6 +98,7 @@ describe('CustomeResourceList', () => {
   customResourceListProps = {
     queryArg: '',
     fetchCustomResources: getItems,
+    textFilter: 'name',
     rowFilters: mockRowFilters,
     sortBy: 'version',
     sortOrder: SortByDirection.desc,
@@ -115,15 +108,31 @@ describe('CustomeResourceList', () => {
     resourceHeader: MockTableHeader,
   };
 
-  const customResourceList = shallow(<CustomResourceList {...customResourceListProps} />);
   it('should render Table component', () => {
+    const customResourceList = shallow(<CustomResourceList {...customResourceListProps} />);
     expect(customResourceList.find(Table).exists()).toBe(true);
   });
 
-  it('should render TextFilter component only when textFilterReducer is present', () => {
-    expect(customResourceList.find(TextFilter).exists()).toBe(true);
-    customResourceListProps.textFilterReducer = undefined;
-    const customResourceListNew = shallow(<CustomResourceList {...customResourceListProps} />);
-    expect(customResourceListNew.find(TextFilter).exists()).toBe(false);
+  it('should render FilterToolbar component when either rowFilters or textFilter is present', () => {
+    let customResourceList;
+
+    // Both filters
+    customResourceList = shallow(<CustomResourceList {...customResourceListProps} />);
+    expect(customResourceList.find(FilterToolbar).exists()).toBe(true);
+
+    // Only text filter
+    customResourceListProps.rowFilters = undefined;
+    customResourceList = shallow(<CustomResourceList {...customResourceListProps} />);
+    expect(customResourceList.find(FilterToolbar).exists()).toBe(true);
+
+    // Neither text nor row filters
+    customResourceListProps.textFilter = undefined;
+    customResourceList = shallow(<CustomResourceList {...customResourceListProps} />);
+    expect(customResourceList.find(FilterToolbar).exists()).toBe(false);
+
+    // Only row filters
+    customResourceListProps.rowFilters = mockRowFilters;
+    customResourceList = shallow(<CustomResourceList {...customResourceListProps} />);
+    expect(customResourceList.find(FilterToolbar).exists()).toBe(true);
   });
 });

--- a/frontend/packages/dev-console/src/components/custom-resource-list/custom-resource-list-types.ts
+++ b/frontend/packages/dev-console/src/components/custom-resource-list/custom-resource-list-types.ts
@@ -1,16 +1,10 @@
 import { RowFunction } from '@console/internal/components/factory';
 import { SortByDirection } from '@patternfly/react-table';
-
-export interface CustomResourceListRowFilter {
-  type: string;
-  selected: string[];
-  reducer: (item: { [key: string]: any }) => string;
-  items: { [key: string]: any }[];
-}
+import { RowFilter } from '@console/internal/components/filter-toolbar';
 
 export interface CustomResourceListProps {
   queryArg?: string;
-  rowFilters?: CustomResourceListRowFilter[];
+  rowFilters?: RowFilter[];
   sortBy: string;
   sortOrder: SortByDirection;
   resourceRow: RowFunction;
@@ -21,6 +15,7 @@ export interface CustomResourceListProps {
     items: { [key: string]: any }[],
     filters: string | string[],
   ) => { [key: string]: any }[];
+  textFilter?: string;
   textFilterReducer?: (
     items: { [key: string]: any }[],
     filters: string,

--- a/frontend/packages/dev-console/src/components/helm/helm-utils.ts
+++ b/frontend/packages/dev-console/src/components/helm/helm-utils.ts
@@ -12,7 +12,7 @@ import {
   HelmActionConfigType,
   HelmActionOrigins,
 } from './helm-types';
-import { CustomResourceListRowFilter } from '../custom-resource-list/custom-resource-list-types';
+import { RowFilter } from '@console/internal/components/filter-toolbar';
 
 export const HelmReleaseStatusLabels = {
   [HelmReleaseStatus.Deployed]: 'Deployed',
@@ -43,10 +43,10 @@ export const releaseStatusReducer = (release: HelmRelease) => {
   return release.info.status;
 };
 
-export const helmReleasesRowFilters: CustomResourceListRowFilter[] = [
+export const helmReleasesRowFilters: RowFilter[] = [
   {
+    filterGroupName: 'Status',
     type: 'helm-release-status',
-    selected: SelectedReleaseStatuses,
     reducer: releaseStatusReducer,
     items: SelectedReleaseStatuses.map((status) => ({
       id: status,

--- a/frontend/packages/dev-console/src/components/helm/list/HelmReleaseList.tsx
+++ b/frontend/packages/dev-console/src/components/helm/list/HelmReleaseList.tsx
@@ -30,6 +30,7 @@ const HelmReleaseList: React.FC<HelmReleaseListProps> = ({ namespace, secrets })
       fetchCustomResources={getHelmReleases}
       dependentResource={memoizedSecrets}
       queryArg="rowFilter-helm-release-status"
+      textFilter="name"
       rowFilters={helmReleasesRowFilters}
       sortBy="name"
       sortOrder={SortByDirection.asc}

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { withRouter, RouteComponentProps } from 'react-router';
-import { compose } from 'redux';
 import { connect } from 'react-redux';
 import {
   Checkbox,
@@ -352,5 +351,5 @@ export type RowFilter = {
   filter?: any;
 };
 
-export const FilterToolbar = compose(withRouter, connect(null, { filterList }))(FilterToolbar_);
+export const FilterToolbar = withRouter(connect(null, { filterList })(FilterToolbar_));
 FilterToolbar.displayName = 'FilterToolbar';


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3633

**Analysis / Root cause**: 
Helm release page is not using the latest FilterToolbar component

**Solution Description**: 
Update the `CustomResourceList` component to use the `FilterToolbar` component rather than using a text filter and `Checkboxes` component

**Screen shots / Gifs for design review**:

![image](https://user-images.githubusercontent.com/11633780/81829495-f1f71400-9508-11ea-9ee7-d9f1c255d9ac.png)

![image](https://user-images.githubusercontent.com/11633780/81829519-f91e2200-9508-11ea-8ce5-8023cf151f24.png)

**Browser conformance**: 
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

cc @openshift/team-devconsole-ux @serenamarie125 @beaumorley 

/kind bug