### PR TITLE
Bug 1835332: Fix kafka source values and validations

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/SecretKeySelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/SecretKeySelector.tsx
@@ -6,7 +6,7 @@ import { SecretModel } from '@console/internal/models';
 import { errorModal } from '@console/internal/components/modals/error-modal';
 import { FormGroup } from '@patternfly/react-core';
 import { ValueFromPair } from '@console/internal/components/utils/value-from-pair';
-import { getFieldId } from '@console/shared';
+import { getFieldId, useFormikValidationFix } from '@console/shared';
 import { getActiveNamespace } from '@console/internal/reducers/ui';
 import { RootState } from '@console/internal/redux';
 
@@ -29,7 +29,19 @@ const SecretKeySelector: React.FC<SecretKeySelectorProps & StateProps> = ({
   const [secrets, setSecrets] = React.useState({});
   const fieldId = getFieldId(name, 'secret-key-input');
   const isValid = !(touched && error);
-  const errorMessage = !isValid ? error : '';
+
+  const getErrorMessage = (err: string | { name?: string; key?: string }): string => {
+    let errMsg = '';
+    if (typeof err === 'string') {
+      errMsg = err;
+    } else {
+      errMsg = err?.name || err?.key;
+    }
+    return errMsg;
+  };
+  const errorMessage = !isValid ? getErrorMessage(error) : '';
+
+  useFormikValidationFix(field.value);
 
   React.useEffect(() => {
     k8sGet(SecretModel, null, namespace)
@@ -44,7 +56,13 @@ const SecretKeySelector: React.FC<SecretKeySelectorProps & StateProps> = ({
   }, [namespace]);
 
   return (
-    <FormGroup fieldId={fieldId} label={label} helperTextInvalid={errorMessage} isValid={isValid}>
+    <FormGroup
+      fieldId={fieldId}
+      label={label}
+      helperTextInvalid={errorMessage}
+      isValid={isValid}
+      isRequired
+    >
       <ValueFromPair
         pair={{ secretKeyRef: field.value }}
         secrets={secrets}

--- a/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
+++ b/frontend/packages/knative-plugin/src/components/add/eventSource-validation-utils.ts
@@ -80,6 +80,59 @@ export const sourceDataSpecSchema = yup
         bootstrapServers: yup.string().required('Required'),
         consumerGroup: yup.string().required('Required'),
         topics: yup.string().required('Required'),
+        net: yup.object().shape({
+          sasl: yup.object().shape({
+            enable: yup.boolean(),
+            user: yup.object().when('enable', {
+              is: true,
+              then: yup.object().shape({
+                secretKeyRef: yup.object().shape({
+                  name: yup.string().required('Required'),
+                  key: yup.string().required('Required'),
+                }),
+              }),
+            }),
+            password: yup.object().when('enable', {
+              is: true,
+              then: yup.object().shape({
+                secretKeyRef: yup.object().shape({
+                  name: yup.string().required('Required'),
+                  key: yup.string().required('Required'),
+                }),
+              }),
+            }),
+          }),
+          tls: yup.object().shape({
+            enable: yup.boolean(),
+            caCert: yup.object().when('enable', {
+              is: true,
+              then: yup.object().shape({
+                secretKeyRef: yup.object().shape({
+                  name: yup.string().required('Required'),
+                  key: yup.string().required('Required'),
+                }),
+              }),
+            }),
+            cert: yup.object().when('enable', {
+              is: true,
+              then: yup.object().shape({
+                secretKeyRef: yup.object().shape({
+                  name: yup.string().required('Required'),
+                  key: yup.string().required('Required'),
+                }),
+              }),
+            }),
+            key: yup.object().when('enable', {
+              is: true,
+              then: yup.object().shape({
+                secretKeyRef: yup.object().shape({
+                  name: yup.string().required('Required'),
+                  key: yup.string().required('Required'),
+                }),
+              }),
+            }),
+          }),
+        }),
       }),
     }),
   })

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -63,6 +63,12 @@ export const getKafkaSourceResource = (formData: EventSourceFormData): K8sResour
     limits: { cpu, memory },
   } = formData;
   const baseResource = getEventSourcesDepResource(formData);
+  const { net } = baseResource.spec;
+  baseResource.spec.net = {
+    ...net,
+    ...(!net.sasl?.enable && { sasl: { user: {}, password: {} } }),
+    ...(!net.tls?.enable && { tls: { caCert: {}, cert: {}, key: {} } }),
+  };
   const kafkaSource = {
     spec: {
       resources: {


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-3843

**Analysis / Root cause:**
The issue occurred because if `enable` is `false` , `name` is an `' '` then these values are now getting removed in backend and the values do not match with our initial values and also if `name`and `key` are mentioned they cannot be `' '` as per the mentioned error in above issue. 

**Solution:**
If sasl/tls are not enabled adding appropriate sasl and tls values. Added required validations

**Gif:**
![image](https://user-images.githubusercontent.com/20724543/81836163-b851f780-9560-11ea-8c64-3093246f3ac0.png)

/kind bug