### PR TITLE
[Release 4.4] Bug 1826512: Include an override to use PF4 link colors in the catalog vertical-tabs

### DIFF
--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -377,7 +377,7 @@ $catalog-tile-width: $co-m-catalog-tile-width;
 // Remove once https://github.com/patternfly/patternfly-react/issues/4117 is fixed
 .vertical-tabs-pf-tab {
   &.active a {
-    color: var(--pf-global--link--Color);
+    color: var(--pf-global--link--Color) !important;
 
     &::before {
       background: var(--pf-global--link--Color);
@@ -385,7 +385,6 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   }
 
   > a {
-    color: var(--pf-global--link--Color);
     font-size: $font-size-base;
 
     &:focus,

--- a/frontend/public/components/catalog/_catalog.scss
+++ b/frontend/public/components/catalog/_catalog.scss
@@ -373,7 +373,24 @@ $catalog-tile-width: $co-m-catalog-tile-width;
   list-style: none;
 }
 
-// set font size to 14px
-.vertical-tabs-pf-tab > a {
-  font-size: $font-size-base;
+// Override upstream issue where PF3 colors are still being used.
+// Remove once https://github.com/patternfly/patternfly-react/issues/4117 is fixed
+.vertical-tabs-pf-tab {
+  &.active a {
+    color: var(--pf-global--link--Color);
+
+    &::before {
+      background: var(--pf-global--link--Color);
+    }
+  }
+
+  > a {
+    color: var(--pf-global--link--Color);
+    font-size: $font-size-base;
+
+    &:focus,
+    &:hover {
+      color: var(--pf-global--link--Color--hover);
+    }
+  }
 }


### PR DESCRIPTION
This is a manual cherry pick of https://github.com/openshift/console/pull/5169 and  https://github.com/openshift/console/pull/5180 

To address https://bugzilla.redhat.com/show_bug.cgi?id=1826512

Override upstream issue where `.vertical-tabs-pf-tab` is using older PF3 colors.