### PR TITLE
Bug 1835325: Add default value to buffer prop to prevent runtime error

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/create-operand-form.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/create-operand-form.tsx
@@ -513,7 +513,7 @@ const OperandFormInputGroup: React.FC<OperandFormInputGroupProps> = ({ error, fi
 // We should also break this down into smaller components and dispatch actions from those
 // components to update parent state.
 export const CreateOperandForm: React.FC<CreateOperandFormProps> = ({
-  buffer,
+  buffer = {},
   clusterServiceVersion,
   openAPI,
   operandModel,


### PR DESCRIPTION
Add default value to CreateOpereandForm buffer prop to prevent runtime error when csv annotations.almExamples is undefined.