### PR TITLE
Bug 1835425: Don't show Remove Trigger when there are no triggers

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineDetails.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/pipeline-details/PipelineDetails.tsx
@@ -6,17 +6,20 @@ import {
   PipelineTask,
 } from '../../../../utils/pipeline-augment';
 import { TriggerTemplateModel } from '../../../../models';
-import { usePipelineTriggerTemplateNames, RouteTemplate } from '../../utils/triggers';
+import { RouteTemplate } from '../../utils/triggers';
 import DynamicResourceLinkList from '../../resource-overview/DynamicResourceLinkList';
 import TriggerTemplateResourceLink from '../../resource-overview/TriggerTemplateResourceLink';
 import PipelineVisualization from './PipelineVisualization';
 
 interface PipelineDetailsProps {
   obj: Pipeline;
+  customData: RouteTemplate[];
 }
 
-const PipelineDetails: React.FC<PipelineDetailsProps> = ({ obj: pipeline }) => {
-  const routeTemplates: RouteTemplate[] = usePipelineTriggerTemplateNames(pipeline) || [];
+const PipelineDetails: React.FC<PipelineDetailsProps> = ({
+  obj: pipeline,
+  customData: routeTemplates,
+}) => {
   const taskLinks = pipeline.spec.tasks
     .filter((pipelineTask: PipelineTask) => !!pipelineTask.taskRef)
     .map((task) => ({

--- a/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineRow.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineRow.tsx
@@ -6,10 +6,9 @@ import { referenceForModel } from '@console/internal/module/k8s';
 import { pipelineFilterReducer } from '../../../utils/pipeline-filter-reducer';
 import { Pipeline } from '../../../utils/pipeline-augment';
 import { PipelineModel, PipelineRunModel } from '../../../models';
-import { getPipelineKebabActions } from '../../../utils/pipeline-actions';
 import LinkedPipelineRunTaskStatus from '../../pipelineruns/status/LinkedPipelineRunTaskStatus';
-import { ResourceKebabWithUserLabel } from '../../pipelineruns/triggered-by';
 import { tableColumnClasses } from './pipeline-table';
+import PipelineRowKebabActions from './PipelineRowKebabActions';
 
 const pipelineReference = referenceForModel(PipelineModel);
 const pipelinerunReference = referenceForModel(PipelineRunModel);
@@ -62,11 +61,7 @@ const PipelineRow: RowFunction<Pipeline> = ({ obj, index, key, style }) => {
           '-'}
       </TableData>
       <TableData className={tableColumnClasses[6]}>
-        <ResourceKebabWithUserLabel
-          actions={getPipelineKebabActions(obj.latestRun)}
-          kind={pipelineReference}
-          resource={obj}
-        />
+        <PipelineRowKebabActions pipeline={obj} />
       </TableData>
     </TableRow>
   );

--- a/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineRowKebabActions.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/list-page/PipelineRowKebabActions.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { referenceForModel } from '@console/internal/module/k8s';
+import { ResourceKebabWithUserLabel } from '../../pipelineruns/triggered-by';
+import { getPipelineKebabActions } from '../../../utils/pipeline-actions';
+import { Pipeline } from '../../../utils/pipeline-augment';
+import { PipelineModel } from '../../../models';
+import { usePipelineTriggerTemplateNames } from '../utils/triggers';
+
+type PipelineRowKebabActionsProps = {
+  pipeline: Pipeline;
+};
+
+const pipelineReference = referenceForModel(PipelineModel);
+
+const PipelineRowKebabActions: React.FC<PipelineRowKebabActionsProps> = ({ pipeline }) => {
+  const {
+    metadata: { name, namespace },
+  } = pipeline;
+  const templateNames = usePipelineTriggerTemplateNames(name, namespace) || [];
+
+  return (
+    <ResourceKebabWithUserLabel
+      actions={getPipelineKebabActions(pipeline.latestRun, templateNames.length > 0)}
+      kind={pipelineReference}
+      resource={pipeline}
+    />
+  );
+};
+
+export default PipelineRowKebabActions;

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/TriggerTemplateSelector.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/TriggerTemplateSelector.tsx
@@ -14,11 +14,15 @@ type TriggerTemplateSelectorProps = {
 
 const TriggerTemplateSelector: React.FC<TriggerTemplateSelectorProps> = (props) => {
   const { name, pipeline, placeholder } = props;
+  const {
+    metadata: { name: pipelineName, namespace },
+  } = pipeline;
 
   const [field] = useField(name);
   const selection = field.value;
 
-  const templateNames: RouteTemplate[] = usePipelineTriggerTemplateNames(pipeline) || [];
+  const templateNames: RouteTemplate[] =
+    usePipelineTriggerTemplateNames(pipelineName, namespace) || [];
   const items = templateNames.reduce(
     (acc, { triggerTemplateName }) => ({ ...acc, [triggerTemplateName]: triggerTemplateName }),
     {},

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-actions.spec.ts
@@ -4,6 +4,7 @@ import {
   rerunPipelineAndRedirect,
   reRunPipelineRun,
   startPipeline,
+  getPipelineKebabActions,
 } from '../pipeline-actions';
 import { PipelineRun, Pipeline } from '../pipeline-augment';
 
@@ -81,5 +82,34 @@ describe('PipelineAction testing stopPipelineRun create correct labels and callb
     expect(stopAction.label).toBe('Stop');
     expect(stopAction.callback).not.toBeNull();
     expect(stopAction.hidden).not.toBeFalsy();
+  });
+});
+
+describe('getPipelineKebabActions', () => {
+  it('expect Remove Trigger option is present', () => {
+    const pipelineKebabActions = getPipelineKebabActions(actionPipelineRuns[0], true);
+    expect(pipelineKebabActions.length).toBe(6);
+    expect(pipelineKebabActions[3](PipelineModel, actionPipelines[0]).label).toBe('Remove Trigger');
+  });
+  it('expect Remove Trigger option is not present', () => {
+    const pipelineKebabActions = getPipelineKebabActions(actionPipelineRuns[0], false);
+    expect(pipelineKebabActions.length).toBe(5);
+    expect(pipelineKebabActions[3](PipelineModel, actionPipelines[0]).label).not.toBe(
+      'Remove Trigger',
+    );
+  });
+  it('expect Start Last Run option is present', () => {
+    const pipelineKebabActions = getPipelineKebabActions(actionPipelineRuns[0], false);
+    expect(pipelineKebabActions.length).toBe(5);
+    expect(pipelineKebabActions[1](PipelineRunModel, actionPipelineRuns[0]).label).toBe(
+      'Start Last Run',
+    );
+  });
+  it('expect Start Last Run option is not present', () => {
+    const pipelineKebabActions = getPipelineKebabActions(undefined, false);
+    expect(pipelineKebabActions.length).toBe(4);
+    expect(pipelineKebabActions[1](PipelineRunModel, actionPipelineRuns[0]).label).not.toBe(
+      'Start Last Run',
+    );
   });
 });

--- a/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
+++ b/frontend/packages/dev-console/src/utils/pipeline-actions.tsx
@@ -228,11 +228,14 @@ const removeTrigger: KebabAction = (kind: K8sKind, pipeline: Pipeline) => ({
     verb: 'delete',
   },
 });
-export const getPipelineKebabActions = (pipelineRun?: PipelineRun): KebabAction[] => [
+export const getPipelineKebabActions = (
+  pipelineRun?: PipelineRun,
+  isTriggerPresent?: boolean,
+): KebabAction[] => [
   (model, resource: Pipeline) => startPipeline(model, resource, handlePipelineRunSubmit),
   ...(pipelineRun ? [() => rerunPipelineAndRedirect(PipelineRunModel, pipelineRun)] : []),
   (model, pipeline) => addTrigger(EventListenerModel, pipeline),
-  (model, pipeline) => removeTrigger(EventListenerModel, pipeline),
+  ...(isTriggerPresent ? [(model, pipeline) => removeTrigger(EventListenerModel, pipeline)] : []),
   editPipeline,
   Kebab.factory.Delete,
 ];


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3589

**Analysis / Root cause**: 
When there are no triggers, the modal opens with a disabled dropdown.

We should do better, like disabling the kebab menu option... unfortunately the information is not readably available... so we'll have to fetch it which may not be cheap. Some thinking needs to be done here.

**Solution Description**: 
Remove the ```Remove Trigger``` option from the kebab menu of the pipeline when there are no triggers.

Remove the ```Remove Trigger``` option from the actions menu of the pipeline details page when there are no triggers.

**Screen shots / Gifs for design review**: 
![pipeline-detail-trigger](https://user-images.githubusercontent.com/2561818/81849312-fdcbf000-9573-11ea-83c2-b627cccea1d3.gif)
![pipeline-trigger](https://user-images.githubusercontent.com/2561818/81849375-0fad9300-9574-11ea-8c45-11184e7258ba.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
