### PR TITLE
Bug 1835416: Fix for all-projects view for dev perspective resources

### DIFF
--- a/frontend/packages/dev-console/src/plugin.tsx
+++ b/frontend/packages/dev-console/src/plugin.tsx
@@ -737,7 +737,21 @@ const plugin: Plugin<ConsumedExtensions> = [
     properties: {
       perspective: 'dev',
       exact: false,
-      path: ['/k8s/all-namespaces/((!import):plural)'],
+      path: ['/k8s/all-namespaces/import'],
+      loader: async () =>
+        (
+          await import(
+            '@console/internal/components/import-yaml' /* webpackChunkName: "import-yaml" */
+          )
+        ).ImportYamlPage,
+    },
+  },
+  {
+    type: 'Page/Route',
+    properties: {
+      perspective: 'dev',
+      exact: false,
+      path: ['/k8s/all-namespaces/:plural'],
       loader: async () =>
         (
           await import(


### PR DESCRIPTION
**Analysis / Root cause**: 
The regex used to route users to the project selection page was mistaken

**Solution Description**: 
Remove the regex for the plural pages in the dev perspective, add the special case for the import page for all namespaces in the dev perspective.

/kind bug