### PR TITLE
Bug 1835632: fixes eventsource icon in context menu

### DIFF
--- a/frontend/packages/knative-plugin/src/actions/add-event-source.tsx
+++ b/frontend/packages/knative-plugin/src/actions/add-event-source.tsx
@@ -1,13 +1,21 @@
 import * as React from 'react';
-import { HelpIcon } from '@patternfly/react-icons';
 import {
   createKebabAction,
   KebabAction,
 } from '@console/dev-console/src/utils/add-resources-menu-utils';
 import { ImportOptions } from '@console/dev-console/src/components/import/import-types';
+import * as eventSourceImg from '../imgs/event-source.svg';
+
+const eventSourceIconStyle = {
+  width: '1em',
+  height: '1em',
+};
+const EventSourceIcon: React.FC = () => {
+  return <img style={eventSourceIconStyle} src={eventSourceImg} alt="" />;
+};
 
 export const addEventSource: KebabAction = createKebabAction(
   'Event Source',
-  <HelpIcon />,
+  <EventSourceIcon />,
   ImportOptions.EVENTSOURCE,
 );


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3865

**Analysis / Root cause**: 
Default icon for eventSource should be shown for context-menu in topology view , it shows help icon.

**Solution Description**: 
Updated the icon

**Screen shots / Gifs for design review**: 
<img width="735" alt="Screenshot 2020-05-14 at 2 06 32 PM" src="https://user-images.githubusercontent.com/5129024/81912409-2abbe980-95ec-11ea-8d42-d2c7877812ae.png">


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

cc: @openshift/team-devconsole-ux