### PR TITLE
Monitoring: Switch to Alertmanager API v2 for `silences` endpoint

### DIFF
--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -143,7 +143,7 @@ const cancelSilence = (silence: Silence) => ({
       btnText: 'Expire Silence',
       executeFn: () =>
         coFetchJSON
-          .delete(`${window.SERVER_FLAGS.alertManagerBaseURL}/api/v1/silence/${silence.id}`)
+          .delete(`${window.SERVER_FLAGS.alertManagerBaseURL}/api/v2/silence/${silence.id}`)
           .then(() => refreshNotificationPollers()),
     }),
 });
@@ -1387,11 +1387,11 @@ const SilenceForm_: React.FC<SilenceFormProps> = ({ defaults, Info, title }) => 
     };
 
     coFetchJSON
-      .post(`${alertManagerBaseURL}/api/v1/silences`, body)
-      .then(({ data }) => {
+      .post(`${alertManagerBaseURL}/api/v2/silences`, body)
+      .then(({ silenceID }) => {
         setError(undefined);
         refreshNotificationPollers();
-        history.push(`${SilenceResource.plural}/${encodeURIComponent(_.get(data, 'silenceId'))}`);
+        history.push(`${SilenceResource.plural}/${encodeURIComponent(silenceID)}`);
       })
       .catch((err) => {
         setError(_.get(err, 'json.error') || err.message || 'Error saving Silence');

--- a/frontend/public/components/notification-drawer.tsx
+++ b/frontend/public/components/notification-drawer.tsx
@@ -160,9 +160,9 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
     }
 
     if (alertManagerBaseURL) {
-      poll(`${alertManagerBaseURL}/api/v1/silences`, 'silences', ({ data }) => {
+      poll(`${alertManagerBaseURL}/api/v2/silences`, 'silences', (silences) => {
         // Set a name field on the Silence to make things easier
-        _.each(data, (s) => {
+        _.each(silences, (s) => {
           s.name = _.get(_.find(s.matchers, { name: 'alertname' }), 'value');
           if (!s.name) {
             // No alertname, so fall back to displaying the other matchers
@@ -171,7 +171,7 @@ export const ConnectedNotificationDrawer_: React.FC<ConnectedNotificationDrawerP
               .join(', ');
           }
         });
-        return data;
+        return silences;
       });
     } else {
       store.dispatch(


### PR DESCRIPTION
This eliminates the remaining use of Alertmanager API v1