### PR TITLE
Bug 1835833: Fix for topology crash on reload

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/Topology.tsx
+++ b/frontend/packages/dev-console/src/components/topology/Topology.tsx
@@ -57,7 +57,7 @@ import {
   TopologyFilters,
   TOPOLOGY_SEARCH_FILTER_KEY,
   FILTER_ACTIVE_CLASS,
-} from './filters/filter-utils';
+} from './filters';
 import TopologyHelmReleasePanel from './helm/TopologyHelmReleasePanel';
 import { TYPE_HELM_RELEASE } from './helm/components/const';
 import { HelmComponentFactory } from './helm/components/helmComponentFactory';

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/topology-model.spec.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/__tests__/topology-model.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../../__tests__/topology-test-data';
 import { topologyModelFromDataModel } from '../topology-model';
 import { transformTopologyData } from '../data-transformer';
-import { TopologyFilters } from '../../filters/filter-utils';
+import { TopologyFilters } from '../../filters';
 import { allowedResources } from '../../topology-utils';
 import { DEFAULT_TOPOLOGY_FILTERS } from '../../redux/const';
 

--- a/frontend/packages/dev-console/src/components/topology/data-transforms/topology-model.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/topology-model.ts
@@ -16,7 +16,7 @@ import {
   getOperatorGroupModel,
   getOperatorNodeModel,
 } from '../operators/operators-topology-model';
-import { TopologyFilters } from '../filters/filter-utils';
+import { TopologyFilters } from '../filters';
 import { TopologyDataModel, TopologyDataObject, Node } from '../topology-types';
 import {
   TYPE_APPLICATION_GROUP,

--- a/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/FilterDropdown.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Select, SelectVariant, SelectOption, SelectGroup } from '@patternfly/react-core';
-import { ShowFiltersKeyValue, ExpandFiltersKeyValue, DisplayFilters } from './filter-utils';
+import { ShowFiltersKeyValue, ExpandFiltersKeyValue, DisplayFilters } from './filter-types';
 
 type FilterDropdownProps = {
   filters: DisplayFilters;

--- a/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/TopologyFilterBar.tsx
@@ -7,12 +7,8 @@ import { TextFilter } from '@console/internal/components/factory';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { Visualization } from '@console/topology';
 import { setTopologyFilters } from '../redux/action';
-import {
-  TopologyFilters,
-  DisplayFilters,
-  getTopologyFilters,
-  getTopologySearchQuery,
-} from './filter-utils';
+import { TopologyFilters, DisplayFilters } from './filter-types';
+import { getTopologyFilters, getTopologySearchQuery } from './filter-utils';
 
 import FilterDropdown from './FilterDropdown';
 import './TopologyFilterBar.scss';

--- a/frontend/packages/dev-console/src/components/topology/filters/__tests__/FilterDropdown.spec.tsx
+++ b/frontend/packages/dev-console/src/components/topology/filters/__tests__/FilterDropdown.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { SelectOption } from '@patternfly/react-core';
 import FilterDropdown from '../FilterDropdown';
-import { DisplayFilters } from '../filter-utils';
+import { DisplayFilters } from '../filter-types';
 
 const VALID_FILTERS = {
   podCount: true,

--- a/frontend/packages/dev-console/src/components/topology/filters/filter-types.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/filter-types.ts
@@ -1,0 +1,31 @@
+export const TOPOLOGY_SEARCH_FILTER_KEY = 'searchQuery';
+export const FILTER_ACTIVE_CLASS = 'odc-m-filter-active';
+
+export enum ShowFiltersKeyValue {
+  podCount = 'Pod Count',
+  eventSources = 'Event Sources',
+  virtualMachines = 'Virtual Machines',
+  showLabels = 'Show Labels',
+}
+
+export enum ExpandFiltersKeyValue {
+  appGrouping = 'Application Groupings',
+  helmGrouping = 'Helm Releases',
+  knativeServices = 'Knative Services',
+  operatorGrouping = 'Operator Groupings',
+}
+
+export type TopologyFilters = {
+  display: DisplayFilters;
+};
+
+export type DisplayFilters = {
+  podCount: boolean;
+  eventSources: boolean;
+  virtualMachines: boolean;
+  showLabels: boolean;
+  knativeServices: boolean;
+  appGrouping: boolean;
+  operatorGrouping: boolean;
+  helmGrouping: boolean;
+};

--- a/frontend/packages/dev-console/src/components/topology/filters/filter-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/filter-utils.ts
@@ -1,42 +1,11 @@
 import { RootState } from '@console/internal/redux';
 import { getQueryArgument } from '@console/internal/components/utils';
+import { getDefaultTopologyFilters } from '../redux/reducer';
+import { TOPOLOGY_SEARCH_FILTER_KEY, TopologyFilters } from './filter-types';
 
-export const TOPOLOGY_SEARCH_FILTER_KEY = 'searchQuery';
-export const FILTER_ACTIVE_CLASS = 'odc-m-filter-active';
-
-export enum ShowFiltersKeyValue {
-  podCount = 'Pod Count',
-  eventSources = 'Event Sources',
-  virtualMachines = 'Virtual Machines',
-  showLabels = 'Show Labels',
-}
-
-export enum ExpandFiltersKeyValue {
-  appGrouping = 'Application Groupings',
-  helmGrouping = 'Helm Releases',
-  knativeServices = 'Knative Services',
-  operatorGrouping = 'Operator Groupings',
-}
-
-export const getTopologyFilters = ({
-  plugins: {
-    devconsole: { topology },
-  },
-}: RootState): TopologyFilters => topology.get('filters');
+export const getTopologyFilters = (state: RootState): TopologyFilters => {
+  const topology = state?.plugins?.devconsole?.topology;
+  return topology ? topology.get('filters') : getDefaultTopologyFilters();
+};
 
 export const getTopologySearchQuery = () => getQueryArgument(TOPOLOGY_SEARCH_FILTER_KEY) ?? '';
-
-export type TopologyFilters = {
-  display: DisplayFilters;
-};
-
-export type DisplayFilters = {
-  podCount: boolean;
-  eventSources: boolean;
-  virtualMachines: boolean;
-  showLabels: boolean;
-  knativeServices: boolean;
-  appGrouping: boolean;
-  operatorGrouping: boolean;
-  helmGrouping: boolean;
-};

--- a/frontend/packages/dev-console/src/components/topology/filters/index.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/index.ts
@@ -1,3 +1,4 @@
+export * from './filter-types';
 export * from './filter-utils';
 export * from './useSearchFilter';
 export * from './useDisplayFilters';

--- a/frontend/packages/dev-console/src/components/topology/filters/useDisplayFilters.ts
+++ b/frontend/packages/dev-console/src/components/topology/filters/useDisplayFilters.ts
@@ -3,7 +3,8 @@
 // @ts-ignore
 import { useSelector } from 'react-redux';
 import { RootState } from '@console/internal/redux';
-import { DisplayFilters, getTopologyFilters } from './filter-utils';
+import { DisplayFilters } from './filter-types';
+import { getTopologyFilters } from './filter-utils';
 
 const useDisplayFilters = (): DisplayFilters => {
   return useSelector((state: RootState) => getTopologyFilters(state).display);

--- a/frontend/packages/dev-console/src/components/topology/helm/helm-topology-model.ts
+++ b/frontend/packages/dev-console/src/components/topology/helm/helm-topology-model.ts
@@ -1,5 +1,5 @@
 import { NodeModel, EdgeModel } from '@console/topology';
-import { TopologyFilters as Filters } from '../filters/filter-utils';
+import { TopologyFilters as Filters } from '../filters';
 import {
   TopologyDataModel as DataModel,
   TopologyDataObject,

--- a/frontend/packages/dev-console/src/components/topology/operators/operators-topology-model.ts
+++ b/frontend/packages/dev-console/src/components/topology/operators/operators-topology-model.ts
@@ -1,5 +1,5 @@
 import { NodeModel, EdgeModel } from '@console/topology';
-import { TopologyFilters as Filters } from '../filters/filter-utils';
+import { TopologyFilters as Filters } from '../filters';
 import {
   TopologyDataModel as DataModel,
   TopologyDataObject,

--- a/frontend/packages/dev-console/src/components/topology/redux/action.ts
+++ b/frontend/packages/dev-console/src/components/topology/redux/action.ts
@@ -1,5 +1,5 @@
 import { action, ActionType } from 'typesafe-actions';
-import { TopologyFilters } from '../filters/filter-utils';
+import { TopologyFilters } from '../filters/filter-types';
 import { TOPOLOGY_DISPLAY_FILTERS_LOCAL_STORAGE_KEY } from './const';
 
 export enum Actions {

--- a/frontend/packages/knative-plugin/src/topology/__tests__/topology-model.spec.ts
+++ b/frontend/packages/knative-plugin/src/topology/__tests__/topology-model.spec.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { ALL_APPLICATIONS_KEY } from '@console/shared/src';
 import { DEFAULT_TOPOLOGY_FILTERS } from '@console/dev-console/src/components/topology/redux/const';
-import { TopologyFilters } from '@console/dev-console/src/components/topology/filters/filter-utils';
+import { TopologyFilters } from '@console/dev-console/src/components/topology/filters';
 import {
   transformTopologyData,
   topologyModelFromDataModel,

--- a/frontend/packages/kubevirt-plugin/src/topology/__tests__/kubevirt-topology-model.spec.ts
+++ b/frontend/packages/kubevirt-plugin/src/topology/__tests__/kubevirt-topology-model.spec.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { ALL_APPLICATIONS_KEY } from '@console/shared/src';
 import { DEFAULT_TOPOLOGY_FILTERS } from '@console/dev-console/src/components/topology/redux/const';
-import { TopologyFilters } from '@console/dev-console/src/components/topology/filters/filter-utils';
+import { TopologyFilters } from '@console/dev-console/src/components/topology/filters';
 import {
   transformTopologyData,
   topologyModelFromDataModel,


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3845

**Analysis / Root cause**: 
The topology filters state is being pulled from the current UI state. In rare instances on reload, the state is not yet set causing an NPE

**Solution Description**: 
Use optional chaining when getting the filter states and if not set use the default filters state.

/kind bug