### PR TITLE
Bug 1833616:  fix bug where create dropdown menu positioning is incor…

### DIFF
--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -210,7 +210,7 @@ export const FireMan_ = connect(null, { filterList })(
               <Dropdown
                 buttonClassName="pf-m-primary"
                 id="item-create"
-                menuClassName="pf-m-align-right-on-md"
+                menuClassName={classNames({ 'pf-m-align-right-on-md': title })}
                 title={createButtonText}
                 noSelection
                 items={createProps.items}


### PR DESCRIPTION
…rect when no title is present

After:
<img width="1294" alt="Screen Shot 2020-05-14 at 11 20 19 AM" src="https://user-images.githubusercontent.com/895728/81952852-f688fe80-95d4-11ea-85a9-699f91901fde.png">
<img width="528" alt="Screen Shot 2020-05-14 at 11 20 30 AM" src="https://user-images.githubusercontent.com/895728/81952853-f7ba2b80-95d4-11ea-8888-50d74caeb0e9.png">
<img width="1032" alt="Screen Shot 2020-05-14 at 11 19 54 AM" src="https://user-images.githubusercontent.com/895728/81952855-f852c200-95d4-11ea-8b4d-005b4abe7558.png">
<img width="734" alt="Screen Shot 2020-05-14 at 11 20 04 AM" src="https://user-images.githubusercontent.com/895728/81952859-f8eb5880-95d4-11ea-97cd-9f61fc932b76.png">
