### PR TITLE
Bug 1835975: use Chrome version from builder image

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,31 +210,14 @@ If you your local Chrome version doesn't match the Chromedriver version from the
 ```
 yarn run webdriver-update --versions.chrome=77.0.3865.120
 ```
-Or if you are using macOS (OS X), run:
+For Fedora, you can use:
 ```
-# automatically select the correct Chrome version
+yarn run webdriver-update-fedora
+```
+For macOS, you can use:
+```
 yarn run webdriver-update-macos
 ```
-
-
-You can look up the version number you need at [omahaProxy.appspot.com](https://omahaproxy.appspot.com/).
-
-#### Using specific version of Chrome browser (Linux only)
-
-Integration tests are run in a headless Chrome driven by a [ChromeDriver](https://chromedriver.chromium.org/downloads). Each ChromeDriver supports specific Chrome versions.
-
-By default test use the Chrome browser installed by the system. On Linux systems, it is possible to [download](https://www.chromium.org/getting-involved/download-chromium)
-a specific version of Chrome browser by setting a [branch position](https://omahaproxy.appspot.com/) and sha256sum (of zip package) using environment variables.
-Downloading chrome requires `curl`, `unzip`, and `sha256sum` command line utilities installed.
-
-```
-# # For Chrome Version 76.0.3809.0 (Developer Build) (64-bit)
-$ export FORCE_CHROME_BRANCH_BASE="665006"
-$ export FORCE_CHROME_BRANCH_SHA256SUM="a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"
-$ ./test-gui.sh e2e
-```
-
-Chromium version to be used by CI jobs is defined in [chromium-version.sh](chromium-version.sh) script.
 
 #### How the Integration Tests Run in CI
 

--- a/chromium-version.sh
+++ b/chromium-version.sh
@@ -1,6 +1,0 @@
-# shellcheck shell=bash
-# Source this script: "source ./chromium-version.sh"
-
-# Chrome Version 76.0.3809.0 (Developer Build) (64-bit)
-export FORCE_CHROME_BRANCH_BASE="665006"
-export FORCE_CHROME_BRANCH_SHA256SUM="a1ae2e0950828f991119825f62c24464ab3765aa219d150a94fb782a4c66a744"

--- a/test-gui.sh
+++ b/test-gui.sh
@@ -4,42 +4,14 @@ set -exuo pipefail
 
 cd frontend
 
-if [ -v FORCE_CHROME_BRANCH_BASE ];
-then
-  BRANCH_BASE=${FORCE_CHROME_BRANCH_BASE}
-  export CHROME_BINARY_PATH="${PWD}/__chrome_browser__/${BRANCH_BASE}/chrome-linux/chrome"
-
-  # look for chrome binary
-  if [ -x "${CHROME_BINARY_PATH}" ];
-  then
-    echo "chrmoe binary for branch ${BRANCH_BASE} already exists"
-  else
-    CHROME_DIR="${PWD}/__chrome_browser__"
-    CHROME_DOWNLOAD_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots"
-
-    # download
-    mkdir -p "${CHROME_DIR}/${BRANCH_BASE}"
-    curl -G "${CHROME_DOWNLOAD_URL}/o/Linux_x64%2F${BRANCH_BASE}%2Fchrome-linux.zip" \
-        -d "alt=media" \
-        > "${CHROME_DIR}/chrome-linux-${BRANCH_BASE}.zip"
-    unzip "${CHROME_DIR}/chrome-linux-${BRANCH_BASE}.zip" -d "${CHROME_DIR}/${BRANCH_BASE}"
-
-    # check sha256sum
-    if [ "$(sha256sum "${CHROME_DIR}/chrome-linux-${BRANCH_BASE}.zip" | cut -f 1 -d ' ')" != "${FORCE_CHROME_BRANCH_SHA256SUM}" ];
-    then
-      rm -rf "${CHROME_DIR:?}/${BRANCH_BASE}"
-
-      echo "ERROR: chrmoe binary sha256 missmatch"
-      exit 1
-    fi
-  fi
+yarn install
+if [ -z "${CHROME_VERSION-}" ]; then
+ yarn run webdriver-update
+else
+ yarn run webdriver-update --versions.chrome="$CHROME_VERSION"
 fi
 
-yarn install
-yarn run webdriver-update
-
-if [ $# -gt 0 ] && [ -n "$1" ];
-then
+if [ $# -gt 0 ] && [ -n "$1" ]; then
   yarn run test-suite --suite "$1" --params.openshift true
 else
   yarn run test-gui --params.openshift true

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -27,7 +27,4 @@ export BRIDGE_BASE_ADDRESS
 oc apply -f ./frontend/integration-tests/data/htpasswd-secret.yaml
 oc patch oauths cluster --patch "$(cat ./frontend/integration-tests/data/patch-htpasswd.yaml)" --type=merge
 
-# get the branch base position for a specific chromium version using https://omahaproxy.appspot.com/
-source ./chromium-version.sh
-
-./test-gui.sh "${1:-e2e}"
+CHROME_VERSION=$(google-chrome --version) ./test-gui.sh "${1:-e2e}"


### PR DESCRIPTION
Justification:

* We now have a way to version the builder image per branch, so updating the builder image in master won't break older release-* branches.
* The versions downloaded from omahaproxy are prerelease versions. We should be testing against stable Chrome.
* For local development, we can always override the ChromeDriver version:
  ```
  yarn webdriver-update --versions.chrome="$CHROME_VERSION"
  ```
* We have scripts `webdriver-update-fedora` and `webdriver-update-macos` to make this easy on Fedora and macOS.

/cc @benjaminapetersen @christianvogt @yaacov 

@dtaylor113 This should address the ChromeDriver error you were seeing.