### PR TITLE
Bug 1836028: fix traffic splitting required fields

### DIFF
--- a/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
+++ b/frontend/packages/console-shared/src/components/formik-fields/field-types.ts
@@ -77,7 +77,7 @@ export interface MultiColumnFieldProps extends FieldProps {
   toolTip?: string;
   emptyValues: { [name: string]: string };
   emptyMessage?: string;
-  headers: string[];
+  headers: ({ name: string; required: boolean } | string)[];
   children: React.ReactNode;
   spans?: gridItemSpanValueShape[];
 }

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.scss
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnField.scss
@@ -20,4 +20,9 @@
   &__empty-message {
     margin-bottom: var(--pf-global--spacer--sm);
   }
+  &__header--required-label {
+    margin-left: var(--pf-global--spacer--xs);
+    font-size: var(--pf-global--FontSize--sm);
+    color: var(--pf-global--danger-color--100);
+  }
 }

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldHeader.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/MultiColumnFieldHeader.tsx
@@ -3,7 +3,7 @@ import { Grid, GridItem, gridItemSpanValueShape } from '@patternfly/react-core';
 import './MultiColumnField.scss';
 
 export interface MultiColumnFieldHeaderProps {
-  headers: string[];
+  headers: ({ name: string; required: boolean } | string)[];
   spans: gridItemSpanValueShape[];
 }
 
@@ -11,8 +11,24 @@ const MultiColumnFieldHeader: React.FC<MultiColumnFieldHeaderProps> = ({ headers
   <div className="odc-multi-column-field__row">
     <Grid className="odc-multi-column-field__row">
       {headers.map((header, i) => (
-        <GridItem span={spans[i]} key={header}>
-          <div className="odc-multi-column-field__col">{header}</div>
+        <GridItem span={spans[i]} key={typeof header === 'string' ? header : header.name}>
+          <div className="odc-multi-column-field__col">
+            {typeof header === 'string' ? (
+              header
+            ) : (
+              <>
+                {header.name}
+                {header.required && (
+                  <span
+                    className="odc-multi-column-field__header--required-label"
+                    aria-hidden="true"
+                  >
+                    *
+                  </span>
+                )}
+              </>
+            )}
+          </div>
         </GridItem>
       ))}
     </Grid>

--- a/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/__tests__/MultiColumnFieldHeader.spec.tsx
+++ b/frontend/packages/console-shared/src/components/formik-fields/multi-column-field/__tests__/MultiColumnFieldHeader.spec.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { gridItemSpanValueShape } from '@patternfly/react-core';
+import MultiColumnFieldHeader, { MultiColumnFieldHeaderProps } from '../MultiColumnFieldHeader';
+
+describe('MultiColumnFieldHeader', () => {
+  let headerProps: MultiColumnFieldHeaderProps;
+  let wrapper: ShallowWrapper<MultiColumnFieldHeaderProps>;
+
+  beforeEach(() => {
+    headerProps = {
+      headers: [
+        {
+          name: 'Test Field',
+          required: true,
+        },
+      ],
+      spans: [12 as gridItemSpanValueShape],
+    };
+    wrapper = shallow(<MultiColumnFieldHeader {...headerProps} />);
+  });
+
+  it('should render required label when prop is of type Object[] with property required set to true', () => {
+    expect(wrapper.contains('*')).toBe(true);
+  });
+
+  it('should not render required label when prop is of type string[]', () => {
+    headerProps.headers = ['Testing Field'];
+    wrapper = shallow(<MultiColumnFieldHeader {...headerProps} />);
+    expect(wrapper.contains('*')).toBe(false);
+  });
+});

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingFields.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplittingFields.tsx
@@ -15,7 +15,7 @@ const TrafficSplittingFields: React.FC<Props> = ({ revisionItems, values }) => {
     <MultiColumnField
       name="trafficSplitting"
       addLabel="Add Revision"
-      headers={['Split', 'Tag', 'Revision']}
+      headers={[{ name: 'Split', required: true }, 'Tag', { name: 'Revision', required: true }]}
       emptyValues={{ percent: '', tag: '', revisionName: '' }}
       disableDeleteRow={values.trafficSplitting.length === 1}
       spans={[2, 3, 7]}
@@ -23,7 +23,6 @@ const TrafficSplittingFields: React.FC<Props> = ({ revisionItems, values }) => {
       <InputField
         name="percent"
         type={TextInputTypes.number}
-        placeholder="100"
         style={{ maxWidth: '100%' }}
         required
       />


### PR DESCRIPTION
Fixes:
https://issues.redhat.com/browse/ODC-3798

Analysis / Root cause:
In Traffic split modal split field has placeholder `100`
required fields are not marked with asterisk(*) in traffic modal

Solution Description:
add support for required label(*) in multicolumnfield headers
remove placeholder for traffic split
mark the required fields with asterisk(*)

Screens:
![Screenshot from 2020-05-15 06-21-37](https://user-images.githubusercontent.com/38663217/82000132-01936b80-9675-11ea-861e-d238d622d059.png)

Code Coverage:
![Screenshot from 2020-05-15 05-47-18](https://user-images.githubusercontent.com/38663217/81999835-09064500-9674-11ea-92a7-5ec20829141c.png)

Browser Conformance:
- [x] Firefox
- [x] Chrome
- [ ] Safari
- [ ] Edge