### PR TITLE
Bug 1836113: fixes issue with error being shown across sources

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
@@ -14,12 +14,13 @@ interface EventSourcesSelectorProps {
 
 const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSourceList }) => {
   const eventSourceItems = Object.keys(eventSourceList).length;
-  const { setFieldValue, setFieldTouched, validateForm, setErrors } = useFormikContext<
+  const { setFieldValue, setFieldTouched, validateForm, setErrors, setStatus } = useFormikContext<
     FormikValues
   >();
   const handleItemChange = React.useCallback(
     (item: string) => {
       setErrors({});
+      setStatus({});
       if (isKnownEventSource(item)) {
         const nameData = `data.${item.toLowerCase()}`;
         const sourceData = getEventSourceData(item.toLowerCase());
@@ -36,7 +37,7 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
       setFieldTouched('apiVersion', true);
       validateForm();
     },
-    [setErrors, setFieldValue, setFieldTouched, validateForm],
+    [setErrors, setStatus, setFieldValue, setFieldTouched, validateForm],
   );
 
   const itemSelectorField = (

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
@@ -13,6 +13,7 @@ jest.mock('formik', () => ({
   useFormikContext: jest.fn(() => ({
     setFieldValue: jest.fn(),
     setFieldTouched: jest.fn(),
+    setStatus: jest.fn(),
     validateForm: jest.fn(),
     setErrors: jest.fn(),
     values: {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3598

**Analysis / Root cause**: 
Error created on Source creation is shown even in case of different sources

**Solution Description**: 
Clear status in formik on Card selection for source

**Screen shots / Gifs for design review**: 
![errorSources](https://user-images.githubusercontent.com/5129024/82027879-851f7d80-96b2-11ea-8dfd-aed622b26bba.gif)



**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
