### PR TITLE
Bug 1835596: Tolarations modal sould refere to taints and not labels

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/LabelsList/consts.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/LabelsList/consts.ts
@@ -1,4 +1,5 @@
 export const ADD_LABEL = 'Add Label';
 export const EMPTY_ADD_LABEL = 'Add Label to specify qualifying nodes';
 export const LABEL_KEY = 'Key';
+export const LABEL_TAINT_KEY = 'Taint Key';
 export const LABEL_VALUE = 'Value';

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/affinity-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/affinity-modal.tsx
@@ -38,7 +38,8 @@ import {
   columnClasses,
 } from './helpers';
 import { getAffinityPatch } from '../../../../k8s/patches/vm/vm-scheduling-patches';
-import './affinity-modal.scss';
+
+import '../shared/scheduling-modals.scss';
 
 export const AffinityModal = withHandlePromise<AffinityModalProps>(
   ({
@@ -142,7 +143,7 @@ export const AffinityModal = withHandlePromise<AffinityModalProps>(
             <ModalTitle>{modalTitle}</ModalTitle>
           </SplitItem>
           <SplitItem isFilled />
-          <SplitItem className="affinity-modal__add-btn">
+          <SplitItem className="scheduling-modals__add-btn">
             {!isEditing && affinities.length > 0 && (
               <Button onClick={() => onAffinityClickAdd()} variant="secondary">
                 Add Affinity rule
@@ -161,19 +162,19 @@ export const AffinityModal = withHandlePromise<AffinityModalProps>(
           <>
             <ModalBody>
               {affinities.length > 0 && (
-                <div className="affinity-modal__desc-container">
-                  <Text className="affinity-modal__desc" component={TextVariants.small}>
+                <div className="scheduling-modals__desc-container">
+                  <Text className="scheduling-modals__desc" component={TextVariants.small}>
                     {
                       'Set scheduling requirements and affect the ranking of the nodes candidate for scheduling.'
                     }
                   </Text>
-                  <Text className="affinity-modal__desc" component={TextVariants.small}>
+                  <Text className="scheduling-modals__desc" component={TextVariants.small}>
                     {
                       "Rules with 'Preferred' condition will stack with an 'AND' relation between them."
                     }
                   </Text>
 
-                  <Text className="affinity-modal__desc" component={TextVariants.small}>
+                  <Text className="scheduling-modals__desc" component={TextVariants.small}>
                     {
                       "Rules with 'Required' condition will stack with an 'OR' relation between them."
                     }
@@ -198,19 +199,19 @@ export const AffinityModal = withHandlePromise<AffinityModalProps>(
                     No Affinity rules found
                   </Title>
                   <EmptyStateBody>
-                    <div className="affinity-modal__desc-container">
-                      <Text className="affinity-modal__desc" component={TextVariants.small}>
+                    <div className="scheduling-modals__desc-container">
+                      <Text className="scheduling-modals__desc" component={TextVariants.small}>
                         {
                           'Set scheduling requirements and affect the ranking of the nodes candidate for scheduling.'
                         }
                       </Text>
-                      <Text className="affinity-modal__desc" component={TextVariants.small}>
+                      <Text className="scheduling-modals__desc" component={TextVariants.small}>
                         {
                           "Rules with 'Preferred' condition will stack with an 'AND' relation between them."
                         }
                       </Text>
 
-                      <Text className="affinity-modal__desc" component={TextVariants.small}>
+                      <Text className="scheduling-modals__desc" component={TextVariants.small}>
                         {
                           "Rules with 'Required' condition will stack with an 'OR' relation between them."
                         }

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-edit/affinity-edit.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-edit/affinity-edit.tsx
@@ -98,8 +98,8 @@ export const AffinityEdit: React.FC<AffinityEditProps> = ({
   return (
     <>
       <ModalBody>
-        <div className="affinity-modal__desc-container">
-          <Text className="affinity-modal__desc" component={TextVariants.small}>
+        <div className="scheduling-modals__desc-container">
+          <Text className="scheduling-modals__desc" component={TextVariants.small}>
             {
               'Define an affinity rule. This rule will be added to the list of affinity rules applied to this workload.'
             }
@@ -203,24 +203,24 @@ export const AffinityEdit: React.FC<AffinityEditProps> = ({
                 : 'Missing fields in workload labels'
             }
           >
-            <div className="affinity-modal__desc-container">
+            <div className="scheduling-modals__desc-container">
               {isNodeAffinity ? (
                 <>
-                  <Text className="affinity-modal__desc" component={TextVariants.small}>
+                  <Text className="scheduling-modals__desc" component={TextVariants.small}>
                     {'Select nodes that must have all the following expressions.'}
                   </Text>
-                  <Text className="affinity-modal__desc" component={TextVariants.small}>
+                  <Text className="scheduling-modals__desc" component={TextVariants.small}>
                     {
                       'Note that for Node field expressions, entering a full path is required in the Key field (e.g. `metadata.name: value`)'
                     }
                   </Text>
-                  <Text className="affinity-modal__desc" component={TextVariants.small}>
+                  <Text className="scheduling-modals__desc" component={TextVariants.small}>
                     {'A list of matching nodes will be provided on label input below.'}
                   </Text>
                 </>
               ) : (
                 <>
-                  <Text className="affinity-modal__desc" component={TextVariants.small}>
+                  <Text className="scheduling-modals__desc" component={TextVariants.small}>
                     {'Select workloads that must have all the following expressions.'}
                   </Text>
                 </>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/NodeChecker/node-checker.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/NodeChecker/node-checker.tsx
@@ -23,7 +23,11 @@ import {
 } from '../consts';
 import './node-checker.scss';
 
-export const NodeChecker: React.FC<NodeCheckerProps> = ({ qualifiedNodes }) => {
+export const NodeChecker: React.FC<NodeCheckerProps> = ({
+  qualifiedNodes,
+  wariningTitle,
+  warningMessage,
+}) => {
   const size = qualifiedNodes.length;
   const buttonText = pluralize(size, 'Node');
   return (
@@ -31,7 +35,11 @@ export const NodeChecker: React.FC<NodeCheckerProps> = ({ qualifiedNodes }) => {
       className="kv-node-checker"
       variant={size > 0 ? 'success' : 'warning'}
       isInline
-      title={size > 0 ? SCHEDULING_NODES_MATCH_TEXT(size) : SCHEDULING_NO_NODES_MATCH_TEXT}
+      title={
+        size > 0
+          ? SCHEDULING_NODES_MATCH_TEXT(size)
+          : wariningTitle || SCHEDULING_NO_NODES_MATCH_TEXT
+      }
     >
       <Popover
         headerContent={<div>{buttonText} found</div>}
@@ -49,7 +57,7 @@ export const NodeChecker: React.FC<NodeCheckerProps> = ({ qualifiedNodes }) => {
           <Text component={TextVariants.h4}>
             {size > 0
               ? SCHEDULING_NODES_MATCH_BUTTON_TEXT(size)
-              : SCHEDULING_NO_NODES_MATCH_BUTTON_TEXT}
+              : warningMessage || SCHEDULING_NO_NODES_MATCH_BUTTON_TEXT}
           </Text>
         </Button>
       </Popover>
@@ -59,4 +67,6 @@ export const NodeChecker: React.FC<NodeCheckerProps> = ({ qualifiedNodes }) => {
 
 type NodeCheckerProps = {
   qualifiedNodes: NodeKind[];
+  wariningTitle?: string;
+  warningMessage?: string;
 };

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/consts.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/consts.ts
@@ -4,12 +4,15 @@ import { AffinityRowData } from '../affinity-modal/types';
 // Node Checker
 const pluralNode = (size) => pluralize(size, 'node', 'nodes', false);
 export const SCHEDULING_NODES_MATCH_TEXT = (nodeAmount) =>
-  `${nodeAmount} matching ${pluralNode(nodeAmount)} found for the labels mentioned above`;
+  `${nodeAmount} matching ${pluralNode(nodeAmount)} found`;
 export const SCHEDULING_NODES_MATCH_BUTTON_TEXT = (nodeAmount) =>
   `View ${nodeAmount} matching ${pluralNode(nodeAmount)}`;
 export const SCHEDULING_NO_NODES_MATCH_BUTTON_TEXT =
   'Scheduling will not be possible at this state';
+export const SCHEDULING_NO_NODES_TAINTED_MATCH_BUTTON_TEXT =
+  'No new nodes will be added to scheduler';
 export const SCHEDULING_NO_NODES_MATCH_TEXT = 'No matching nodes found for the labels';
+export const SCHEDULING_NO_NODES_TAINTED_MATCH_TEXT = 'No matching tainted nodes found';
 
 // Node Selector
 export const NODE_SELECTOR_MODAL_TITLE = 'Node Selector';

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/hooks.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/hooks.ts
@@ -65,7 +65,8 @@ export const useNodeQualifier = <T extends IDLabel = IDLabel>(
             nodeTaints &&
             filteredConstraints.every(({ key, value, effect }) =>
               nodeTaints.some(
-                (taint) => taint.key === key && taint.value === value && taint.effect === effect,
+                (taint) =>
+                  taint.key === key && (!value || taint.value === value) && taint.effect === effect,
               ),
             )
           ) {

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/scheduling-modals.scss
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/shared/scheduling-modals.scss
@@ -1,13 +1,13 @@
-.affinity-modal__add-btn {
+.scheduling-modals__add-btn {
   padding: var(--pf-global--spacer--xl);
 }
 
-.affinity-modal__desc-container {
+.scheduling-modals__desc-container {
   display: flex;
   flex-direction: column;
   margin-bottom: var(--pf-global--spacer--md);
 
-  .affinity-modal__desc {
+  .scheduling-modals__desc {
     color: var(--pf-global--Color--200);
   }
 }

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/tolerations-modal/toleration-header.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/tolerations-modal/toleration-header.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { GridItem, Text, TextVariants } from '@patternfly/react-core';
-import { LABEL_VALUE, LABEL_KEY } from '../../../LabelsList/consts';
+import { LABEL_VALUE, LABEL_TAINT_KEY } from '../../../LabelsList/consts';
 
 export const TolerationHeader = () => {
   return (
     <>
       <GridItem span={4}>
-        <Text component={TextVariants.h4}>{LABEL_KEY}</Text>
+        <Text component={TextVariants.h4}>{LABEL_TAINT_KEY}</Text>
       </GridItem>
       <GridItem span={4}>
         <Text component={TextVariants.h4}>{LABEL_VALUE}</Text>

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/tolerations-modal/toleration-row.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/tolerations-modal/toleration-row.tsx
@@ -13,7 +13,7 @@ export const TolerationRow = ({ label, onChange, onDelete }: TolerationRowProps)
         <TextInput
           id={`toleration-${id}-key-input`}
           className="kv-label__key"
-          placeholder="key"
+          placeholder="taint key"
           isRequired
           type="text"
           value={key}
@@ -25,7 +25,7 @@ export const TolerationRow = ({ label, onChange, onDelete }: TolerationRowProps)
         <TextInput
           id={`toleration-${id}-value-input`}
           className="kv-label__value"
-          placeholder="value"
+          placeholder="taint value"
           isRequired
           type="text"
           value={value}

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/tolerations-modal/tolerations-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/tolerations-modal/tolerations-modal.tsx
@@ -32,7 +32,7 @@ import { TolerationRow } from './toleration-row';
 import { TolerationHeader } from './toleration-header';
 import { TolerationLabel } from './types';
 
-import '../affinity-modal/affinity-modal.scss';
+import '../shared/scheduling-modals.scss';
 
 export const TModal = withHandlePromise(
   ({
@@ -104,13 +104,13 @@ export const TModal = withHandlePromise(
       <div className="modal-content">
         <ModalTitle>{TOLERATIONS_MODAL_TITLE}</ModalTitle>
         <ModalBody>
-          <div className="affinity-modal__desc-container">
-            <Text className="affinity-modal__desc" component={TextVariants.small}>
+          <div className="scheduling-modals__desc-container">
+            <Text className="scheduling-modals__desc" component={TextVariants.small}>
               {
                 'Tolerations are applied to VMs, and allow (but do not require) the VMs to schedule onto nodes with matching taints.'
               }
             </Text>
-            <Text className="affinity-modal__desc" component={TextVariants.small}>
+            <Text className="scheduling-modals__desc" component={TextVariants.small}>
               {'Add tolerations to allow a VM to schedule onto nodes with matching taints.'}
             </Text>
             <ExternalLink

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/tolerations-modal/tolerations-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/tolerations-modal/tolerations-modal.tsx
@@ -15,11 +15,19 @@ import { ModalFooter } from '../../modal/modal-footer';
 import { VMLikeEntityKind } from '../../../../types/vmLike';
 import { getVMLikeTolerations } from '../../../../selectors/vm-like/selectors';
 import { getVMLikeModel } from '../../../../selectors/vm';
+import { NodeChecker } from '../shared/NodeChecker/node-checker';
+import { useNodeQualifier } from '../shared/hooks';
 import { getTolerationsPatch } from '../../../../k8s/patches/vm/vm-scheduling-patches';
 import { LabelsList } from '../../../LabelsList/labels-list';
-import { TOLERATIONS_MODAL_TITLE, TOLERATIONS_EFFECTS } from '../shared/consts';
+import {
+  TOLERATIONS_MODAL_TITLE,
+  TOLERATIONS_EFFECTS,
+  SCHEDULING_NO_NODES_TAINTED_MATCH_TEXT,
+  SCHEDULING_NO_NODES_TAINTED_MATCH_BUTTON_TEXT,
+} from '../shared/consts';
 import { useIDEntities } from '../../../../hooks/use-id-entities';
 import { useCollisionChecker } from '../../../../hooks/use-collision-checker';
+
 import { TolerationRow } from './toleration-row';
 import { TolerationHeader } from './toleration-header';
 import { TolerationLabel } from './types';
@@ -48,6 +56,8 @@ export const TModal = withHandlePromise(
     ] = useIDEntities<TolerationLabel>(
       getVMLikeTolerations(vmLikeEntity)?.map((toleration, id) => ({ ...toleration, id })),
     );
+
+    const qualifiedNodes = useNodeQualifier(nodes, 'taint', tolerationsLabels);
 
     const [showCollisionAlert, reload] = useCollisionChecker<VMLikeEntityKind>(
       vmLikeFinal,
@@ -131,6 +141,13 @@ export const TModal = withHandlePromise(
               </>
             )}
           </LabelsList>
+          {tolerationsLabels.length > 0 && isLoaded(nodes) && !inProgress && !loadError && (
+            <NodeChecker
+              qualifiedNodes={qualifiedNodes}
+              wariningTitle={SCHEDULING_NO_NODES_TAINTED_MATCH_TEXT}
+              warningMessage={SCHEDULING_NO_NODES_TAINTED_MATCH_BUTTON_TEXT}
+            />
+          )}
         </ModalBody>
         <ModalFooter
           id="tolerations"

--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/tolerations-modal/tolerations-modal.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/tolerations-modal/tolerations-modal.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { ModalTitle, ModalBody, ModalComponentProps } from '@console/internal/components/factory';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button, ButtonVariant, Text, TextVariants } from '@patternfly/react-core';
 import {
   FirehoseResult,
   withHandlePromise,
   HandlePromiseProps,
+  ExternalLink,
 } from '@console/internal/components/utils';
 import { k8sPatch, NodeKind } from '@console/internal/module/k8s';
 import { NodeModel } from '@console/internal/models';
@@ -15,8 +16,6 @@ import { VMLikeEntityKind } from '../../../../types/vmLike';
 import { getVMLikeTolerations } from '../../../../selectors/vm-like/selectors';
 import { getVMLikeModel } from '../../../../selectors/vm';
 import { getTolerationsPatch } from '../../../../k8s/patches/vm/vm-scheduling-patches';
-import { NodeChecker } from '../shared/NodeChecker/node-checker';
-import { useNodeQualifier } from '../shared/hooks';
 import { LabelsList } from '../../../LabelsList/labels-list';
 import { TOLERATIONS_MODAL_TITLE, TOLERATIONS_EFFECTS } from '../shared/consts';
 import { useIDEntities } from '../../../../hooks/use-id-entities';
@@ -24,6 +23,8 @@ import { useCollisionChecker } from '../../../../hooks/use-collision-checker';
 import { TolerationRow } from './toleration-row';
 import { TolerationHeader } from './toleration-header';
 import { TolerationLabel } from './types';
+
+import '../affinity-modal/affinity-modal.scss';
 
 export const TModal = withHandlePromise(
   ({
@@ -47,8 +48,6 @@ export const TModal = withHandlePromise(
     ] = useIDEntities<TolerationLabel>(
       getVMLikeTolerations(vmLikeEntity)?.map((toleration, id) => ({ ...toleration, id })),
     );
-
-    const qualifiedNodes = useNodeQualifier(nodes, 'taint', tolerationsLabels);
 
     const [showCollisionAlert, reload] = useCollisionChecker<VMLikeEntityKind>(
       vmLikeFinal,
@@ -95,6 +94,22 @@ export const TModal = withHandlePromise(
       <div className="modal-content">
         <ModalTitle>{TOLERATIONS_MODAL_TITLE}</ModalTitle>
         <ModalBody>
+          <div className="affinity-modal__desc-container">
+            <Text className="affinity-modal__desc" component={TextVariants.small}>
+              {
+                'Tolerations are applied to VMs, and allow (but do not require) the VMs to schedule onto nodes with matching taints.'
+              }
+            </Text>
+            <Text className="affinity-modal__desc" component={TextVariants.small}>
+              {'Add tolerations to allow a VM to schedule onto nodes with matching taints.'}
+            </Text>
+            <ExternalLink
+              text="Taints and Tolerations documentation"
+              href={
+                'https://kubevirt.io/user-guide/#/usage/node-placement?id=taints-and-tolerations'
+              }
+            />
+          </div>
           <LabelsList
             isEmpty={tolerationsLabels.length === 0}
             kind="Node"
@@ -116,7 +131,6 @@ export const TModal = withHandlePromise(
               </>
             )}
           </LabelsList>
-          <NodeChecker qualifiedNodes={qualifiedNodes} />
         </ModalBody>
         <ModalFooter
           id="tolerations"

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -229,11 +229,7 @@ export const VMSchedulingList: React.FC<VMSchedulingListProps> = ({
   });
   const isCPUPinned = vmiLikeWrapper?.isDedicatedCPUPlacement();
   const nodeSelector = vmiLikeWrapper?.getNodeSelector();
-  const tolerations = vmiLikeWrapper?.getTolerations() || [];
-  const tolerationsLabels = tolerations.reduce((acc, { key, value }) => {
-    acc[key] = value;
-    return acc;
-  }, {});
+  const tolerationsWrapperCount = (vmiLikeWrapper?.getTolerations() || []).length;
   const affinityWrapperCount = getRowsDataFromAffinity(vmiLikeWrapper?.getAffinity())?.length;
 
   return (
@@ -263,7 +259,11 @@ export const VMSchedulingList: React.FC<VMSchedulingListProps> = ({
               })
             }
           >
-            <Selector kind="Node" selector={tolerationsLabels} />
+            {tolerationsWrapperCount > 0 ? (
+              `${tolerationsWrapperCount} Tolerations rules`
+            ) : (
+              <p className="text-muted">No tolerations</p>
+            )}
           </VMDetailsItem>
 
           <VMDetailsItem


### PR DESCRIPTION
Toleration dialog Key input should be called Taint Key (or suggest in some way that the keys are looked for in the Taints dictionary of the node)

  - [x] Update column header from "Key" to "Taint Key"
  - [x] Add hint educating users about tolerations with an external link
  - [x] Fix node search to work with "Exists" effect.
  - [x] Update warning labels to mention taints instead of labels.
  - [x] Update requirement item to not use labels

Refs:
http://openshift.github.io/openshift-origin-design/designs/virtualization/4.5/Scheduling/Tolerations/tolerations.html
https://kubevirt.io/user-guide/#/usage/node-placement?id=taints-and-tolerations

Screenshots:
Add hint educating about tolerations with an external link, change header to "taint key":
![screenshot-localhost_9000-2020 05 16-23_41_37](https://user-images.githubusercontent.com/2181522/82129961-9ca05880-97cf-11ea-83ac-a852b6a822db.png)

Fix node finder for "Exist" effect:
![screenshot-localhost_9000-2020 05 17-08_32_08](https://user-images.githubusercontent.com/2181522/82136737-4eb04280-9819-11ea-9620-a1b92342dbaa.png)

Update warning labels:
![screenshot-localhost_9000-2020 05 17-08_31_01](https://user-images.githubusercontent.com/2181522/82136742-57a11400-9819-11ea-96c5-5f95b116f816.png)

Update requirement item to not use labels:
![screenshot-localhost_9000-2020 05 16-23_32_16](https://user-images.githubusercontent.com/2181522/82129956-9ad69500-97cf-11ea-89d3-fd216e642e69.png)

![screenshot-localhost_9000-2020 05 16-23_33_07](https://user-images.githubusercontent.com/2181522/82129959-9c07c200-97cf-11ea-8d05-904ca60047f1.png)
