### PR TITLE
Bug 1835603: Remove affinity from yaml when no affinties

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/helpers.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/helpers.ts
@@ -150,6 +150,10 @@ const getPreferredPodTermFromRowData = ({
 });
 
 export const getAffinityFromRowsData = (affinityRows: AffinityRowData[]) => {
+  if (affinityRows.length === 0) {
+    return null;
+  }
+
   const pickRows = (rowType, rowCondition, mapper) =>
     affinityRows
       .filter(({ type, condition }) => type === rowType && condition === rowCondition)

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-resource.tsx
@@ -275,7 +275,11 @@ export const VMSchedulingList: React.FC<VMSchedulingListProps> = ({
               affinityModal({ vmLikeEntity: vm, blocking: true, modalClassName: 'modal-lg' })
             }
           >
-            {affinityWrapperCount} {'Affinity rules'}
+            {affinityWrapperCount > 0 ? (
+              `${affinityWrapperCount} Affinity rules`
+            ) : (
+              <p className="text-muted">No Affinity rules</p>
+            )}
           </VMDetailsItem>
         </dl>
       </div>


### PR DESCRIPTION
When an affinity rule is added and removed, the VM fails to be scheduled.
Error:
`Error creating pod: Pod "virt-launcher-vm-example3-vsfg7" is invalid: spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms: Required value: must have at least one node selector term`

  - [x] remove affinity from yaml if no affinity is set.
  - [x] change "0 affinity rulles" to greyed  "no affinty rules"

Screenshot:
Affinty removed from yaml:
![Peek 2020-05-17 00-53](https://user-images.githubusercontent.com/2181522/82130962-d4f86480-97d8-11ea-8a48-17e158315ed7.gif)

Greyed "No Affinity rulles":
![screenshot-localhost_9000-2020 05 17-00_47_15](https://user-images.githubusercontent.com/2181522/82130896-3409a980-97d8-11ea-86e1-99ce0c34de25.png)
