### PR TITLE
Bug 1834163: Don't check for nodes when form is empty or invalid

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-edit/affinity-edit.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/modals/scheduling-modals/affinity-modal/components/affinity-edit/affinity-edit.tsx
@@ -250,7 +250,8 @@ export const AffinityEdit: React.FC<AffinityEditProps> = ({
                   onDelete={onFieldDelete}
                 />
               </FormRow>
-              <NodeChecker qualifiedNodes={getQualifiedNodes()} />
+              {(affinityExpressions.length > 0 || affinityFields.length > 0) &&
+                !isAffinityInvalid && <NodeChecker qualifiedNodes={getQualifiedNodes()} />}
             </>
           )}
         </Form>


### PR DESCRIPTION
Don't check for nodes when form is empty or  invalid

Screenshot:
![Peek 2020-05-17 01-31](https://user-images.githubusercontent.com/2181522/82131465-235c3200-97de-11ea-917a-c5f744b1a3ca.gif)
