### PR TITLE
Bug 1836763: Fixed legends on data consumption card

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card-utils.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/components/data-consumption-card/data-consumption-card-utils.ts
@@ -126,14 +126,14 @@ export const getDataConsumptionChartData: GetDataConsumptionChartData = (
       max = firstBarMax.value > secondBarMax.value ? firstBarMax : secondBarMax;
       chartData = [
         getChartData(
-          result.physicalUsage,
+          result.logicalUsage,
           metric,
           humanizeBinaryBytes,
           max.unit,
           'Total Logical Used Capacity',
         ),
         getChartData(
-          result.logicalUsage,
+          result.physicalUsage,
           metric,
           humanizeBinaryBytes,
           max.unit,
@@ -143,13 +143,13 @@ export const getDataConsumptionChartData: GetDataConsumptionChartData = (
       legendData = [
         {
           name: `Total Logical Used Capacity ${getLegendData(
-            result.totalPhysicalUsage,
+            result.totalLogicalUsage,
             humanizeBinaryBytes,
           )}`,
         },
         {
           name: `Total Physical Used Capacity ${getLegendData(
-            result.totalLogicalUsage,
+            result.totalPhysicalUsage,
             humanizeBinaryBytes,
           )}`,
         },

--- a/frontend/packages/noobaa-storage-plugin/src/constants/queries.ts
+++ b/frontend/packages/noobaa-storage-plugin/src/constants/queries.ts
@@ -10,24 +10,24 @@ export const DATA_CONSUMPTION_QUERIES: DataConsumptionQueriesType = {
   [ObjectServiceDashboardQuery.ACCOUNTS_BY_IOPS]: {
     read: 'topk(5,NooBaa_accounts_usage_read_count)',
     write: 'topk(5,NooBaa_accounts_usage_write_count)',
-    totalRead: 'sum(NooBaa_accounts_usage_read_count)',
-    totalWrite: 'sum(NooBaa_accounts_usage_write_count)',
+    totalRead: 'sum(topk(5,NooBaa_accounts_usage_read_count))',
+    totalWrite: 'sum(topk(5,NooBaa_accounts_usage_write_count))',
   },
   [ObjectServiceDashboardQuery.ACCOUNTS_BY_LOGICAL_USAGE]: {
     logicalUsage: 'topk(5,NooBaa_accounts_usage_logical)',
-    totalLogicalUsage: 'sum(NooBaa_accounts_usage_logical)',
+    totalLogicalUsage: 'sum(topk(5,NooBaa_accounts_usage_logical))',
   },
   [ObjectServiceDashboardQuery.PROVIDERS_BY_IOPS]: {
     read: 'topk(5,NooBaa_providers_ops_read_num)',
     write: 'topk(5,NooBaa_providers_ops_write_num)',
-    totalRead: 'sum(NooBaa_providers_ops_read_num)',
-    totalWrite: 'sum(NooBaa_providers_ops_write_num)',
+    totalRead: 'sum(topk(5,NooBaa_providers_ops_read_num))',
+    totalWrite: 'sum(topk(5,NooBaa_providers_ops_write_num))',
   },
   [ObjectServiceDashboardQuery.PROVIDERS_BY_PHYSICAL_VS_LOGICAL_USAGE]: {
     physicalUsage: 'topk(5,NooBaa_providers_physical_size)',
     logicalUsage: 'topk(5,NooBaa_providers_logical_size)',
-    totalPhysicalUsage: 'sum(NooBaa_providers_physical_size)',
-    totalLogicalUsage: 'sum(NooBaa_providers_logical_size)',
+    totalPhysicalUsage: 'sum(topk(5,NooBaa_providers_physical_size))',
+    totalLogicalUsage: 'sum(topk(5,NooBaa_providers_logical_size))',
   },
   [ObjectServiceDashboardQuery.PROVIDERS_BY_EGRESS]: {
     egress: 'topk(5,NooBaa_providers_bandwidth_read_size + NooBaa_providers_bandwidth_write_size)',


### PR DESCRIPTION
- the legends of total logical usage and total physical usage were swapped for providers
- made changes in queries of accounts and providers to get top 5 only. This is required for accounts but not for providers. Adding for providers will help in filtering if any support of more than five providers is added.
