### PR TITLE
Bug 1821259: Look for VMI list instead of VMI obj

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/types.ts
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/types.ts
@@ -7,7 +7,7 @@ import { V1alpha1DataVolume } from '../../types/vm/disk/V1alpha1DataVolume';
 export type VMTabProps = {
   obj?: VMILikeEntityKind;
   vm?: VMKind;
-  vmi?: VMIKind;
+  vmis?: VMIKind[];
   pods?: PodKind[];
   migrations?: K8sResourceKind[];
   templates?: TemplateKind[];

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-console.tsx
@@ -129,7 +129,7 @@ const VmConsolesWrapper: React.FC<VmConsolesWrapperProps> = (props) => {
 export const VMConsoleFirehose: React.FC<VMTabProps> = ({
   obj: objProp,
   vm: vmProp,
-  vmi: vmiProp,
+  vmis: vmisProp,
   vmImports,
   pods,
   migrations,
@@ -137,7 +137,7 @@ export const VMConsoleFirehose: React.FC<VMTabProps> = ({
   customData: { kindObj },
 }) => {
   const vm = kindObj === VirtualMachineModel && isVM(objProp) ? objProp : vmProp;
-  const vmi = kindObj === VirtualMachineInstanceModel && isVMI(objProp) ? objProp : vmiProp;
+  const vmi = kindObj === VirtualMachineInstanceModel && isVMI(objProp) ? objProp : vmisProp[0];
 
   const namespace = getNamespace(vm);
 

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-dashboard.tsx
@@ -22,7 +22,7 @@ export const VMDashboard: React.FC<VMTabProps> = (props) => {
   const {
     obj: objProp,
     vm: vmProp,
-    vmi: vmiProp,
+    vmis: vmisProp,
     pods,
     migrations,
     dataVolumes,
@@ -30,7 +30,7 @@ export const VMDashboard: React.FC<VMTabProps> = (props) => {
   } = props;
 
   const vm = asVM(objProp) || (isVM(vmProp) && vmProp);
-  const vmi = (isVMI(objProp) && objProp) || vmiProp;
+  const vmi = (isVMI(objProp) && objProp) || vmisProp[0];
 
   const vmStatusBundle = getVMStatus({
     vm,

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details-page.tsx
@@ -90,11 +90,11 @@ export const VirtualMachinesDetailsPage: React.FC<VirtualMachinesDetailsPageProp
 
   const resources = [
     getResource(VirtualMachineInstanceModel, {
-      name,
       namespace,
-      isList: false,
-      prop: 'vmi',
+      isList: true,
+      prop: 'vmis',
       optional: true,
+      fieldSelector: `metadata.name=${name}`, // Note(yaacov): we look for a list, instead of one obj, to avoid 404 response if no VMI exist.
     }),
     getResource(PodModel, { namespace, prop: 'pods' }),
     getResource(VirtualMachineInstanceMigrationModel, { namespace, prop: 'migrations' }),

--- a/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/vm-details.tsx
@@ -25,7 +25,7 @@ import { isVM, isVMI } from '../../selectors/check-type';
 export const VMDetailsFirehose: React.FC<VMTabProps> = ({
   obj: objProp,
   vm: vmProp,
-  vmi: vmiProp,
+  vmis: vmisProp,
   vmImports,
   pods,
   migrations,
@@ -38,8 +38,8 @@ export const VMDetailsFirehose: React.FC<VMTabProps> = ({
   const vmi =
     kindObj === VirtualMachineInstanceModel && isVMI(objProp)
       ? objProp
-      : isVMI(vmiProp)
-      ? vmiProp
+      : isVMI(vmisProp[0])
+      ? vmisProp[0]
       : null;
 
   const resources = [


### PR DESCRIPTION
When clicking to view the newly created VM, the VMI requests return 404.

This PR replaces the call for a VMI object, with a list request.

Screenshot:
![Peek 2020-05-18 00-06](https://user-images.githubusercontent.com/2181522/82160142-ed7d8300-989b-11ea-8709-5cac6f03cfeb.gif)
