### PR TITLE
Bug 1818722: Query Browser: Add text wrapping for table headers

### DIFF
--- a/frontend/public/components/monitoring/metrics.tsx
+++ b/frontend/public/components/monitoring/metrics.tsx
@@ -23,7 +23,6 @@ import {
   TimesIcon,
 } from '@patternfly/react-icons';
 import {
-  IDecorator,
   ISortBy,
   sortable,
   Table,
@@ -31,6 +30,7 @@ import {
   TableGridBreakpoint,
   TableHeader,
   TableVariant,
+  wrappable,
 } from '@patternfly/react-table';
 import * as React from 'react';
 import { Helmet } from 'react-helmet';
@@ -677,7 +677,7 @@ const QueryTable_: React.FC<QueryTableProps> = ({
 
   const cellProps = {
     props: { className: 'query-browser__table-cell' },
-    transforms: [sortable as (v: unknown) => IDecorator],
+    transforms: [sortable, wrappable],
   };
 
   // TableBody's shouldComponentUpdate seems to struggle with SeriesButton, so add a unique key to help TableBody


### PR DESCRIPTION
Also remove the type definition for `sortable`, which seems to no longer
be necessary.

FYI @sg00dwin, @spadgett 

### Before
![before](https://user-images.githubusercontent.com/460802/82169000-16813080-98fb-11ea-80d0-9f3004c34421.png)

### After
![after](https://user-images.githubusercontent.com/460802/82169006-1bde7b00-98fb-11ea-907d-aa85ef5f03e9.png)