### PR TITLE
Bug 1836775: Fix Network Attachment Definitions page breaking issue

### DIFF
--- a/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
+++ b/frontend/packages/network-attachment-definition-plugin/src/components/network-attachment-definitions/NetworkAttachmentDefinition.tsx
@@ -123,7 +123,7 @@ NetworkAttachmentDefinitionsList.displayName = 'NetworkAttachmentDefinitionsList
 export const NetworkAttachmentDefinitionsPage: React.FC<NetworkAttachmentDefinitionsPageProps> = (
   props,
 ) => {
-  const namespace = props.namespace || props.match.params.ns || 'default';
+  const namespace = props.namespace || props.match?.params?.ns || 'default';
   const createProps = {
     to: `/k8s/ns/${namespace}/${referenceForModel(NetworkAttachmentDefinitionModel)}/~new/form`,
   };


### PR DESCRIPTION
After:
![Screenshot from 2020-05-18 11-50-42](https://user-images.githubusercontent.com/54092533/82180273-d2435f80-98fd-11ea-8679-255c0e032d53.png)
