### PR TITLE
Bug 1836902: validate event sources form and enable create button on  yaml form

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
@@ -91,6 +91,8 @@ const EventSource: React.FC<Props> = ({ namespace, activeApplication, contextSou
       initialValues={initialValues}
       onSubmit={handleSubmit}
       onReset={history.goBack}
+      validateOnBlur={false}
+      validateOnChange={false}
       validationSchema={eventSourceValidationSchema}
     >
       {(props) => <EventSourceForm {...props} namespace={namespace} />}

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourceSection.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useFormikContext, FormikValues } from 'formik';
 import * as _ from 'lodash';
+import { useFormikValidationFix } from '@console/shared';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import AppSection from '@console/dev-console/src/components/import/app/AppSection';
@@ -25,11 +26,10 @@ const EventSourceSection: React.FC<EventSourceSectionProps> = ({ namespace }) =>
   const { values } = useFormikContext<FormikValues>();
   const projectResource = { kind: ProjectModel.kind, prop: ProjectModel.id, isList: true };
   const [data, loaded] = useK8sWatchResource<K8sResourceKind[]>(projectResource);
-
+  useFormikValidationFix(values);
   if (!values.type) {
     return null;
   }
-
   let EventSource: React.ReactElement;
   switch (values.type) {
     case EventSources.CronJobSource:

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/EventSourcesSelector.tsx
@@ -14,9 +14,12 @@ interface EventSourcesSelectorProps {
 
 const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSourceList }) => {
   const eventSourceItems = Object.keys(eventSourceList).length;
-  const { setFieldValue, setFieldTouched, validateForm } = useFormikContext<FormikValues>();
+  const { setFieldValue, setFieldTouched, validateForm, setErrors } = useFormikContext<
+    FormikValues
+  >();
   const handleItemChange = React.useCallback(
     (item: string) => {
+      setErrors({});
       if (isKnownEventSource(item)) {
         const nameData = `data.${item.toLowerCase()}`;
         const sourceData = getEventSourceData(item.toLowerCase());
@@ -33,7 +36,7 @@ const EventSourcesSelector: React.FC<EventSourcesSelectorProps> = ({ eventSource
       setFieldTouched('apiVersion', true);
       validateForm();
     },
-    [setFieldValue, setFieldTouched, validateForm],
+    [setErrors, setFieldValue, setFieldTouched, validateForm],
   );
 
   const itemSelectorField = (

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
@@ -5,34 +5,32 @@ import { TextInputTypes } from '@patternfly/react-core';
 import KafkaSourceNetSection from './KafkaSourceNetSection';
 import ServiceAccountDropdown from '../../dropdowns/ServiceAccountDropdown';
 
-const KafkaSourceSection: React.FC = () => {
-  return (
-    <FormSection title="KafkaSource" extraMargin>
-      <InputField
-        data-test-id="kafkasource-bootstrapservers-field"
-        type={TextInputTypes.text}
-        name="data.kafkasource.bootstrapServers"
-        label="BootstrapServers"
-        required
-      />
-      <InputField
-        data-test-id="kafkasource-topics-field"
-        type={TextInputTypes.text}
-        name="data.kafkasource.topics"
-        label="Topics"
-        required
-      />
-      <InputField
-        data-test-id="kafkasource-consumergoup-field"
-        type={TextInputTypes.text}
-        name="data.kafkasource.consumerGroup"
-        label="ConsumerGroup"
-        required
-      />
-      <KafkaSourceNetSection />
-      <ServiceAccountDropdown name="data.kafkasource.serviceAccountName" />
-    </FormSection>
-  );
-};
+const KafkaSourceSection: React.FC = () => (
+  <FormSection title="KafkaSource" extraMargin>
+    <InputField
+      data-test-id="kafkasource-bootstrapservers-field"
+      type={TextInputTypes.text}
+      name="data.kafkasource.bootstrapServers"
+      label="BootstrapServers"
+      required
+    />
+    <InputField
+      data-test-id="kafkasource-topics-field"
+      type={TextInputTypes.text}
+      name="data.kafkasource.topics"
+      label="Topics"
+      required
+    />
+    <InputField
+      data-test-id="kafkasource-consumergoup-field"
+      type={TextInputTypes.text}
+      name="data.kafkasource.consumerGroup"
+      label="ConsumerGroup"
+      required
+    />
+    <KafkaSourceNetSection />
+    <ServiceAccountDropdown name="data.kafkasource.serviceAccountName" />
+  </FormSection>
+);
 
 export default KafkaSourceSection;

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/__tests__/EventSourcesSelector.spec.tsx
@@ -14,6 +14,7 @@ jest.mock('formik', () => ({
     setFieldValue: jest.fn(),
     setFieldTouched: jest.fn(),
     validateForm: jest.fn(),
+    setErrors: jest.fn(),
     values: {
       type: 'SinkBinding',
       name: 'sink-binding',


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3591
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: 
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
`create` button on the YAML form for event sources is disabled which should be enabled. yup validation was being called for other forms even when YAML form card was selected. For example: Initially ApiServeSource form is selected and when camel form(yaml form) card is clicked on form is switched to camel but the validation error from the ApiServerSource form remains because of which create button was disabled.

**Solution Description**: 
<!-- Describe your code changes in detail and explain the solution -->
fixed the yup validation by making it manual instead of being called through `ValidationOnChange` and `ValidationOnBlur`.


**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->
![Peek 2020-05-18 18-44](https://user-images.githubusercontent.com/9278015/82217181-ad6bde00-9937-11ea-8bc2-489bf88c782c.gif)


**Unit test coverage report**: 
<!-- Attach test coverage report -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
