### PR TITLE
Bug 1835005: [OperandForm] Only use descriptors to define form widgets

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.spec.ts
@@ -109,57 +109,6 @@ describe('hasNoFields', () => {
 });
 
 describe('getDefaultUISchema', () => {
-  it('Creates correct default ui schema based on property names', () => {
-    const schema = {
-      type: SchemaType.object,
-      properties: {
-        resources: { type: SchemaType.string },
-        installPlan: { type: SchemaType.string },
-        imagePullPolicy: { type: SchemaType.string },
-        updateStrategy: { type: SchemaType.string },
-        nodeAffinity: { type: SchemaType.string },
-        podAffinity: { type: SchemaType.string },
-        podAntiAffinity: { type: SchemaType.string },
-        replicas: { type: SchemaType.string },
-        matchExpressions: { type: SchemaType.string },
-      },
-    };
-    const uiSchema = getDefaultUISchema(schema);
-    expect(uiSchema.resources).toEqual({
-      'ui:field': 'ResourceRequirementsField',
-      'ui:title': 'Resource Requirements',
-    });
-    expect(uiSchema.installPlan).toEqual({
-      'ui:field': 'InstallPlanField',
-      'ui:title': 'Install Plan',
-    });
-    expect(uiSchema.imagePullPolicy).toEqual({
-      'ui:widget': 'ImagePullPolicyWidget',
-      'ui:title': 'Image Pull Policy',
-    });
-    expect(uiSchema.updateStrategy).toEqual({
-      'ui:field': 'UpdateStrategyField',
-      'ui:title': 'Update Strategy',
-    });
-    expect(uiSchema.nodeAffinity).toEqual({
-      'ui:field': 'NodeAffinityField',
-      'ui:title': 'Node Affinity',
-    });
-    expect(uiSchema.podAffinity).toEqual({
-      'ui:field': 'PodAffinityField',
-      'ui:title': 'Pod Affinity',
-    });
-    expect(uiSchema.podAntiAffinity).toEqual({
-      'ui:field': 'PodAffinityField',
-      'ui:title': 'Pod Anti-Affinity',
-    });
-    expect(uiSchema.replicas).toEqual({ 'ui:widget': 'PodCountWidget', 'ui:title': 'Replicas' });
-    expect(uiSchema.matchExpressions).toEqual({
-      'ui:field': 'MatchExpressionsField',
-      'ui:title': 'Match Expressions',
-    });
-  });
-
   it('Creates correct ui schema for empty schema property', () => {
     const uiSchema = getDefaultUISchema(testCRD.spec.validation.openAPIV3Schema as JSONSchema6);
     expect(uiSchema.spec.hiddenFieldGroup).toEqual(HIDDEN_UI_SCHEMA);

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/utils.ts
@@ -46,20 +46,6 @@ export const hideAllExistingProperties = (schema: JSONSchema6) => {
   );
 };
 
-// Map common json schem property names to default widgets or fields
-export const getDefaultUISchemaForPropertyName = (name) =>
-  ({
-    resources: { 'ui:field': 'ResourceRequirementsField', 'ui:title': 'Resource Requirements' },
-    installPlan: { 'ui:field': 'InstallPlanField', 'ui:title': 'Install Plan' },
-    imagePullPolicy: { 'ui:widget': 'ImagePullPolicyWidget', 'ui:title': 'Image Pull Policy' },
-    updateStrategy: { 'ui:field': 'UpdateStrategyField', 'ui:title': 'Update Strategy' },
-    nodeAffinity: { 'ui:field': 'NodeAffinityField', 'ui:title': 'Node Affinity' },
-    podAffinity: { 'ui:field': 'PodAffinityField', 'ui:title': 'Pod Affinity' },
-    podAntiAffinity: { 'ui:field': 'PodAffinityField', 'ui:title': 'Pod Anti-Affinity' },
-    replicas: { 'ui:widget': 'PodCountWidget', 'ui:title': 'Replicas' },
-    matchExpressions: { 'ui:field': 'MatchExpressionsField', 'ui:title': 'Match Expressions' },
-  }?.[name] ?? {});
-
 // Determine if a schema will produce an empty form field.
 export const hasNoFields = (jsonSchema: JSONSchema6): boolean => {
   const type = getSchemaType(jsonSchema ?? {}) ?? '';
@@ -93,27 +79,21 @@ export const getDefaultUISchema = (jsonSchema: JSONSchema6): UiSchema => {
   }
 
   const handleArray = () => {
-    const descendatnUISchema = getDefaultUISchema(jsonSchema.items as JSONSchema6);
-    return !_.isEmpty(descendatnUISchema) ? { items: descendatnUISchema } : {};
+    const itemsUISchema = getDefaultUISchema(jsonSchema.items as JSONSchema6);
+    return !_.isEmpty(itemsUISchema) ? { items: itemsUISchema } : {};
   };
 
   const handleObject = () => {
     return _.reduce(
       jsonSchema.properties,
       (uiSchemaAccumulator: UiSchema, property: JSONSchema6, name: string) => {
-        const defaultSchema = getDefaultUISchemaForPropertyName(name);
-        const schemaForProperty = {
-          ...defaultSchema,
-          ...getDefaultUISchema(property),
-        };
-        if (_.isEmpty(schemaForProperty)) {
-          return uiSchemaAccumulator;
-        }
-
-        return {
-          ...(uiSchemaAccumulator ?? {}),
-          [name]: schemaForProperty,
-        };
+        const propertyUISchema = getDefaultUISchema(property);
+        return _.isEmpty(propertyUISchema)
+          ? uiSchemaAccumulator
+          : {
+              ...(uiSchemaAccumulator ?? {}),
+              [name]: propertyUISchema,
+            };
       },
       {},
     );


### PR DESCRIPTION
Remove logic that maps certain schema names to widgets. Discussed with @tlwu2013, decided this should be an opt-in feature. 

Resoning: It's possible that an unintended naming collision could happen, causing an unexpected widget to be rendered on the form. It would then be impossible to revert to the default schema-generated form logic unless the corresponding schema property name was changed. Since the automatic widget mapping feature is new, not documented, and not opt-in, this unexpected behavior would likely be perceived as a bug.

See https://issues.redhat.com/browse/CONSOLE-2256