### PR TITLE
Bug 1835445:  Correct visuals of reveal value button in Operator details view

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/descriptors/spec/index.tsx
@@ -198,20 +198,28 @@ const Secret: React.FC<SpecCapabilityProps> = (props) => {
 
   return (
     <>
-      <Button type="button" onClick={() => setReveal(!reveal)}>
-        {reveal ? (
-          <>
-            <EyeSlashIcon className="co-icon-space-r" />
-            Hide Values
-          </>
-        ) : (
-          <>
-            <EyeIcon className="co-icon-space-r" />
-            Reveal Values
-          </>
-        )}
-      </Button>
-      <SecretValue value={props.value} encoded={false} reveal={reveal} />
+      <div className="co-toggle-reveal-value">
+        <Button
+          type="button"
+          variant="link"
+          isInline
+          className="pf-m-link--align-right co-toggle-reveal-value__btn"
+          onClick={() => setReveal(!reveal)}
+        >
+          {reveal ? (
+            <>
+              <EyeSlashIcon className="co-icon-space-r" />
+              Hide Values
+            </>
+          ) : (
+            <>
+              <EyeIcon className="co-icon-space-r" />
+              Reveal Values
+            </>
+          )}
+        </Button>
+        <SecretValue value={props.value} encoded={false} reveal={reveal} />
+      </div>
     </>
   );
 };

--- a/frontend/public/components/_reveal-value.scss
+++ b/frontend/public/components/_reveal-value.scss
@@ -1,0 +1,8 @@
+.co-toggle-reveal-value {
+  display: flex;
+  flex-direction: column;
+
+  &__btn {
+    align-self: flex-end;
+  }
+}

--- a/frontend/public/style.scss
+++ b/frontend/public/style.scss
@@ -63,6 +63,7 @@
 @import 'components/secrets/create-secret';
 @import 'components/resource';
 @import 'components/resource-dropdown';
+@import 'components/reveal-value';
 @import 'components/row-filter';
 @import 'components/route';
 @import 'components/service';


### PR DESCRIPTION
Fix Bug https://bugzilla.redhat.com/show_bug.cgi?id=1835445
Text button variant and right aligned

<img width="409" alt="Screen Shot 2020-05-18 at 4 28 51 PM" src="https://user-images.githubusercontent.com/1874151/82256633-b0110800-9924-11ea-8228-6e38a98b6361.png">
