### PR TITLE
Bug 1826481: Fix confusing subscription status for manual approve

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/subscription.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/subscription.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as _ from 'lodash';
-import { referenceForModel, K8sResourceKind } from '@console/internal/module/k8s';
+import { referenceForModel } from '@console/internal/module/k8s';
 import {
   Table,
   MultiListPage,
@@ -37,6 +37,7 @@ import {
   SubscriptionUpdates,
   SubscriptionUpdatesProps,
   SubscriptionUpdatesState,
+  SubscriptionStatus,
 } from './subscription';
 import { Button } from '@patternfly/react-core';
 
@@ -51,7 +52,7 @@ describe('SubscriptionTableRow', () => {
   let subscription: SubscriptionKind;
 
   const updateWrapper = () => {
-    const rowArgs: RowFunctionArgs<K8sResourceKind> = {
+    const rowArgs: RowFunctionArgs<SubscriptionKind> = {
       obj: subscription,
       index: 0,
       key: '0',
@@ -195,6 +196,7 @@ describe('SubscriptionTableRow', () => {
       wrapper
         .find('tr')
         .childAt(2)
+        .find(SubscriptionStatus)
         .shallow()
         .text(),
     ).toContain('Upgrade available');
@@ -205,6 +207,7 @@ describe('SubscriptionTableRow', () => {
       wrapper
         .find('tr')
         .childAt(2)
+        .find(SubscriptionStatus)
         .shallow()
         .text(),
     ).toEqual('Unknown failure');
@@ -218,6 +221,7 @@ describe('SubscriptionTableRow', () => {
       wrapper
         .find('tr')
         .childAt(2)
+        .find(SubscriptionStatus)
         .shallow()
         .text(),
     ).toContain('Upgrading');
@@ -231,6 +235,7 @@ describe('SubscriptionTableRow', () => {
       wrapper
         .find('tr')
         .childAt(2)
+        .find(SubscriptionStatus)
         .shallow()
         .text(),
     ).toContain('Up to date');

--- a/frontend/packages/operator-lifecycle-manager/src/status/csv-status.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/status/csv-status.ts
@@ -56,23 +56,30 @@ export const getCSVStatus = (
   };
 };
 
-export const getSubscriptionStatus = (
-  subscription: SubscriptionKind,
-): { status: SubscriptionState; title?: string } => {
-  const state = _.get(subscription, 'status.state', SubscriptionState.SubscriptionStateNone);
-  let title: string;
-  switch (state) {
+export const getSubscriptionStatus = (subscription: SubscriptionKind): SubscriptionStatus => {
+  const status = subscription?.status?.state ?? SubscriptionState.SubscriptionStateNone;
+  switch (status) {
     case SubscriptionState.SubscriptionStateUpgradeAvailable:
-      title = 'Upgrade available';
-      break;
+      return {
+        status,
+        title: 'Upgrade available',
+      };
     case SubscriptionState.SubscriptionStateUpgradePending:
-      title = 'Upgrading';
-      break;
+      return {
+        status,
+        title: 'Upgrading',
+      };
     case SubscriptionState.SubscriptionStateAtLatest:
-      title = 'Up to date';
-      break;
+      return {
+        status,
+        title: 'Up to date',
+      };
     default:
-      title = '';
+      return {
+        status,
+        title: '',
+      };
   }
-  return { status: state, title };
 };
+
+type SubscriptionStatus = { status: SubscriptionState; title?: string };

--- a/frontend/public/components/_detail-table.scss
+++ b/frontend/public/components/_detail-table.scss
@@ -1,7 +1,7 @@
 .co-detail-table {
   text-align: center;
   border-width: 1px;
-  max-width: 600px;
+  max-width: 610px;
   white-space: nowrap;
 
   &--lg {
@@ -15,7 +15,8 @@
     margin-right: 0;
   }
 
-  &, &__section {
+  &,
+  &__section {
     border-color: #eee;
     border-style: solid;
   }


### PR DESCRIPTION
When a subscription shows an upgrade avaiable, but has a manual update approval strategy, installed operators, operator details > Subsctription, and Search > Subscription pages now provide a link to the install plan details page instead of showing 'Upgrading' status.

![manual upgrade](https://user-images.githubusercontent.com/22625502/82259885-4693f800-992a-11ea-95df-ef3e4ed4b36b.gif)

![manual upgrade 2](https://user-images.githubusercontent.com/22625502/82259953-64615d00-992a-11ea-9204-8fa914d780f4.gif)
