### PR TITLE
Bug 1836177: Fix create button for cluster-scope operand instances tab

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -29,7 +29,6 @@ import {
   StatusBox,
   Timestamp,
   navFactory,
-  resourcePathFromModel,
 } from '@console/internal/components/utils';
 import { connectToModel, connectToPlural } from '@console/internal/kinds';
 import {
@@ -441,9 +440,7 @@ export const ProvidedAPIPage = connectToModel((props: ProvidedAPIPageProps) => {
     );
   }
 
-  const to = kindObj.namespaced
-    ? `/k8s/ns/${csv.metadata.namespace}/${ClusterServiceVersionModel.plural}/${csv.metadata.name}/${kind}/~new`
-    : `${resourcePathFromModel(kindObj)}/~new`;
+  const to = `/k8s/ns/${csv.metadata.namespace}/${ClusterServiceVersionModel.plural}/${csv.metadata.name}/${kind}/~new`;
   return (
     <ListPage
       kind={kind}


### PR DESCRIPTION
The create button on the instances tab for cluster-scope operands was using `resourcePathForModel` helper, which omitted the CSV context from the URL, causing the incorrect component to be rendered for cluster-scope operand creation. Update this create button link to use the same url as the card on the Overview page.