### PR TITLE
Bug 1837739: use user creator label to identify workspace resource instead of annotation

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/CloudShellTerminal.spec.tsx
@@ -5,6 +5,7 @@ import { StatusBox } from '@console/internal/components/utils/status-box';
 import { InternalCloudShellTerminal } from '../CloudShellTerminal';
 import TerminalLoadingBox from '../TerminalLoadingBox';
 import CloudShellSetup from '../setup/CloudShellSetup';
+import { user } from './cloud-shell-test-data';
 
 jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
   useK8sWatchResource: jest.fn(),
@@ -13,19 +14,19 @@ jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
 describe('CloudShellTerminal', () => {
   it('should display loading box', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([null, false]);
-    const wrapper = shallow(<InternalCloudShellTerminal username="user" />);
+    const wrapper = shallow(<InternalCloudShellTerminal user={user} />);
     expect(wrapper.find(TerminalLoadingBox)).toHaveLength(1);
   });
 
   it('should display error statusBox', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([null, false, true]);
-    const wrapper = shallow(<InternalCloudShellTerminal username="user" />);
+    const wrapper = shallow(<InternalCloudShellTerminal user={user} />);
     expect(wrapper.find(StatusBox)).toHaveLength(1);
   });
 
   it('should display form if loaded and no workspace', () => {
     (useK8sWatchResource as jest.Mock).mockReturnValueOnce([[], true]);
-    const wrapper = shallow(<InternalCloudShellTerminal username="user" />);
+    const wrapper = shallow(<InternalCloudShellTerminal user={user} />);
     expect(wrapper.find(CloudShellSetup)).toHaveLength(1);
   });
 });

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/cloud-shell-test-data.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/cloud-shell-test-data.ts
@@ -1,0 +1,12 @@
+import { UserKind } from '@console/internal/module/k8s';
+
+export const user: UserKind = {
+  kind: 'User',
+  apiVersion: 'user.openshift.io/v1',
+  identities: null,
+  metadata: {
+    name: 'consoledeveloper',
+    selfLink: '/apis/user.openshift.io/v1/users/kube%3Aadmin',
+    uid: '53093d25-830b-4ab2-b723-ac8659b5a176',
+  },
+};

--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/cloud-shell-utils.spec.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/cloud-shell-utils.spec.ts
@@ -1,7 +1,7 @@
 import {
   newCloudShellWorkSpace,
   CLOUD_SHELL_LABEL,
-  CLOUD_SHELL_USER_ANNOTATION,
+  CLOUD_SHELL_IMMUTABLE_ANNOTATION,
 } from '../cloud-shell-utils';
 
 describe('CloudShell Utils', () => {
@@ -9,13 +9,12 @@ describe('CloudShell Utils', () => {
     const name = 'cloudshell';
     const namespace = 'default';
     const kind = 'Workspace';
-    const username = 'test-user';
 
-    const newResource = newCloudShellWorkSpace(name, namespace, username);
+    const newResource = newCloudShellWorkSpace(name, namespace);
     expect(newResource.kind).toEqual(kind);
     expect(newResource.metadata.name).toEqual(name);
     expect(newResource.metadata.namespace).toEqual(namespace);
     expect(newResource.metadata.labels[CLOUD_SHELL_LABEL]).toEqual('true');
-    expect(newResource.metadata.annotations[CLOUD_SHELL_USER_ANNOTATION]).toEqual(username);
+    expect(newResource.metadata.annotations[CLOUD_SHELL_IMMUTABLE_ANNOTATION]).toEqual('true');
   });
 });

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -39,15 +39,12 @@ export type CloudShellResource = K8sResourceKind & {
 export type TerminalInitData = { pod: string; container: string; cmd: string[] };
 
 export const CLOUD_SHELL_LABEL = 'console.openshift.io/cloudshell';
-export const CLOUD_SHELL_USER_ANNOTATION = 'console.openshift.io/cloudshell-user';
+export const CLOUD_SHELL_CREATOR_LABEL = 'org.eclipse.che.workspace/creator';
+export const CLOUD_SHELL_IMMUTABLE_ANNOTATION = 'org.eclipse.che.workspace/immutable';
 
 export const createCloudShellResourceName = () => `terminal-${getRandomChars(6)}`;
 
-export const newCloudShellWorkSpace = (
-  name: string,
-  namespace: string,
-  username: string,
-): CloudShellResource => ({
+export const newCloudShellWorkSpace = (name: string, namespace: string): CloudShellResource => ({
   apiVersion: 'workspace.che.eclipse.org/v1alpha1',
   kind: 'Workspace',
   metadata: {
@@ -57,7 +54,7 @@ export const newCloudShellWorkSpace = (
       [CLOUD_SHELL_LABEL]: 'true',
     },
     annotations: {
-      [CLOUD_SHELL_USER_ANNOTATION]: username,
+      [CLOUD_SHELL_IMMUTABLE_ANNOTATION]: 'true',
     },
   },
   spec: {
@@ -96,7 +93,7 @@ export const initTerminal = (
   workspaceName: string,
   workspaceNamespace: string,
 ): Promise<TerminalInitData> => {
-  const url = `/api/terminal/${workspaceNamespace}/${workspaceName}/exec/init`;
+  const url = `/api/terminal/proxy/${workspaceNamespace}/${workspaceName}/exec/init`;
   const payload = {
     kubeconfig: {
       username,

--- a/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellSetup.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellSetup.tsx
@@ -29,7 +29,6 @@ const CloudShellSetup: React.FunctionComponent<Props> = ({
   activeNamespace,
   onSubmit,
   onCancel,
-  username,
 }) => {
   const initialValues: CloudShellSetupFormData = {
     namespace: activeNamespace === ALL_NAMESPACES_KEY ? undefined : activeNamespace,
@@ -49,7 +48,7 @@ const CloudShellSetup: React.FunctionComponent<Props> = ({
       }
       await k8sCreate(
         WorkspaceModel,
-        newCloudShellWorkSpace(createCloudShellResourceName(), namespace, username),
+        newCloudShellWorkSpace(createCloudShellResourceName(), namespace),
       );
       onSubmit && onSubmit();
     } catch (err) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3615

Now, we have ```org.eclipse.che.workspace/creator: <user UID>``` label in the workspace. So, this PR start using this label instead of annotation ```console.openshift.io/cloudshell-user: <username>``` to get the workspace.