### PR TITLE
Bug 1837934: Fix Backing Store creation request

### DIFF
--- a/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
+++ b/frontend/packages/noobaa-storage-plugin/src/components/create-backingstore-page/create-bs.tsx
@@ -198,6 +198,12 @@ const PVCType: React.FC<PVCTypeProps> = ({ state, dispatch }) => {
     TiB: 'TiB',
   };
 
+  // Noobaa expected Ti console standrad is to show TiB
+  const unitConverter = {
+    GiB: 'Gi',
+    TiB: 'Ti',
+  };
+
   // Fix for updating the storage class by force rerender
   const forceUpdate = React.useCallback(() => updateState({}), []);
 
@@ -207,7 +213,7 @@ const PVCType: React.FC<PVCTypeProps> = ({ state, dispatch }) => {
 
   const onChange = (event) => {
     const { value, unit } = event;
-    const input = `${value} ${unit}`;
+    const input = `${value}${unitConverter[unit]}`;
     setSize(value);
     dispatch({ type: 'setVolumeSize', value: input });
   };
@@ -546,6 +552,11 @@ const CreateBackingStoreForm: React.FC<CreateBackingStoreFormProps> = withHandle
       bsPayload.spec['pvPool'] = {
         numVolumes: providerDataState.numVolumes,
         storageClass: providerDataState.storageClass,
+        resources: {
+          requests: {
+            storage: providerDataState.volumeSize,
+          },
+        },
       };
     } else if (externalProviders.includes(provider)) {
       bsPayload.spec = {


### PR DESCRIPTION
The screenshot shows the request going through as expected: 
![Screenshot from 2020-05-20 13-51-29](https://user-images.githubusercontent.com/54092533/82423765-df00b880-9aa1-11ea-942e-6564e27dfaa3.png)

 Payload updated to contain the field resources.request.storage.