### PR TITLE
Bug 1837846: Fix actions in vm details page

### DIFF
--- a/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
+++ b/frontend/packages/kubevirt-plugin/src/components/vms/menu-actions.tsx
@@ -261,7 +261,7 @@ export const vmImportMenuActions = [
 ];
 
 export type ExtraResources = {
-  vmi: VMIKind;
+  vmis: VMIKind[];
   pods: PodKind[];
   migrations: K8sResourceKind[];
   dataVolumes: V1alpha1DataVolume[];
@@ -271,8 +271,9 @@ export type ExtraResources = {
 export const vmMenuActionsCreator = (
   kindObj: K8sKind,
   vm: VMKind,
-  { vmi, pods, migrations, vmImports, dataVolumes }: ExtraResources,
+  { vmis, pods, migrations, vmImports, dataVolumes }: ExtraResources,
 ) => {
+  const vmi = vmis && vmis[0];
   const vmStatusBundle = getVMStatus({ vm, vmi, pods, migrations, dataVolumes, vmImports });
 
   return vmMenuActions.map((action) => {


### PR DESCRIPTION
In https://github.com/openshift/console/pull/5472 I changed `vmi` to `vmis` and forgot to update the actions, this PR update the actions to use vmis instead of vmi.

What users see:
On a running machine, the actions in the details page will be missing migration and restart actions.

Screenshot:
![screenshot-localhost_9000-2020 05 20-10_10_59](https://user-images.githubusercontent.com/2181522/82429008-f3d64f80-9a93-11ea-99d0-95eec8012985.png)
