### PR TITLE
Bug 1838065: Add validation for the app name length (max 63 characters)

### DIFF
--- a/frontend/packages/dev-console/src/components/import/validation-schema.ts
+++ b/frontend/packages/dev-console/src/components/import/validation-schema.ts
@@ -34,10 +34,13 @@ export const projectNameValidationSchema = yup.object().shape({
 
 export const applicationNameValidationSchema = yup.object().shape({
   selectedKey: yup.string(),
-  name: yup.string().when('selectedKey', {
-    is: CREATE_APPLICATION_KEY,
-    then: yup.string().required('Required'),
-  }),
+  name: yup
+    .string()
+    .max(63, 'Cannot be longer than 63 characters.')
+    .when('selectedKey', {
+      is: CREATE_APPLICATION_KEY,
+      then: yup.string().required('Required'),
+    }),
 });
 
 export const deploymentValidationSchema = yup.object().shape({


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-2510

**Analysis / Root cause**: 
Form does not validate application name length.

**Solution Description**: 
Extend the form validation from "required string" to "required string, max 63. charachters".

**Screen shots / Gifs for design review**: 
Before:
![before](https://user-images.githubusercontent.com/139310/82447060-035f9380-9aa8-11ea-8a0e-ed9565801593.png)

After:
![after](https://user-images.githubusercontent.com/139310/82447076-065a8400-9aa8-11ea-8f56-db2d7b3604fb.png)

**Unit test coverage report**: 
Did not change any test.

**Test setup:**
1. Switch into the Developer console
2. Select Add+ > Container Image
3. Under General > Application Name select "Create Application"
4. Enter a long application name into the text field "Name". (More than 63 characters)

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
