### PR TITLE
Fix multi dev console warnings

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellSetup.tsx
+++ b/frontend/packages/console-app/src/components/cloud-shell/setup/CloudShellSetup.tsx
@@ -66,7 +66,7 @@ const CloudShellSetup: React.FunctionComponent<Props> = ({
         onReset={onCancel}
         validate={cloudShellSetupValidation}
       >
-        {(props) => <CloudSehellSetupForm {...props} />}
+        {(formikProps) => <CloudSehellSetupForm {...formikProps} />}
       </Formik>
     </div>
   );

--- a/frontend/packages/dev-console/src/components/edit-application/EditApplication.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplication.tsx
@@ -82,8 +82,9 @@ const EditApplication: React.FC<EditApplicationProps & StateProps> = ({
       validationSchema={
         _.get(initialValues, 'build.strategy') ? gitValidationSchema : deployValidationSchema
       }
-      render={renderForm}
-    />
+    >
+      {renderForm}
+    </Formik>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/edit-application/EditApplication.tsx
+++ b/frontend/packages/dev-console/src/components/edit-application/EditApplication.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Formik } from 'formik';
+import { Formik, FormikProps } from 'formik';
 import * as _ from 'lodash';
 import { connect } from 'react-redux';
 import { getActivePerspective } from '@console/internal/reducers/ui';
@@ -62,12 +62,12 @@ const EditApplication: React.FC<EditApplicationProps & StateProps> = ({
       });
   };
 
-  const renderForm = (props) => {
+  const renderForm = (formikProps: FormikProps<any>) => {
     return (
       <EditApplicationForm
-        {...props}
+        {...formikProps}
         appResources={appResources}
-        enableReinitialize="true"
+        enableReinitialize
         createFlowType={pageHeading}
         builderImages={builderImages}
       />

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecksForm.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecksForm.tsx
@@ -69,8 +69,12 @@ const AddHealthChecksForm: React.FC<AddHealthChecksFormProps> = ({
       onSubmit={handleSubmit}
       onReset={history.goBack}
     >
-      {(props) => (
-        <AddHealthChecks resource={resource.data} currentContainer={currentContainer} {...props} />
+      {(formikProps) => (
+        <AddHealthChecks
+          resource={resource.data}
+          currentContainer={currentContainer}
+          {...formikProps}
+        />
       )}
     </Formik>
   );

--- a/frontend/packages/dev-console/src/components/helm/HelmInstallUpgradePage.tsx
+++ b/frontend/packages/dev-console/src/components/helm/HelmInstallUpgradePage.tsx
@@ -173,9 +173,9 @@ const HelmInstallUpgradePage: React.FunctionComponent<HelmInstallUpgradePageProp
           onReset={history.goBack}
           validationSchema={getHelmActionValidationSchema(helmAction)}
         >
-          {(props) => (
+          {(formikProps) => (
             <HelmInstallUpgradeForm
-              {...props}
+              {...formikProps}
               chartHasValues={chartHasValues}
               helmAction={helmAction}
             />

--- a/frontend/packages/dev-console/src/components/import/DeployImage.tsx
+++ b/frontend/packages/dev-console/src/components/import/DeployImage.tsx
@@ -177,7 +177,7 @@ const DeployImage: React.FC<Props> = ({
       onReset={history.goBack}
       validationSchema={deployValidationSchema}
     >
-      {(props) => <DeployImageForm {...props} projects={projects} />}
+      {(formikProps) => <DeployImageForm {...formikProps} projects={projects} />}
     </Formik>
   );
 };

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Formik } from 'formik';
+import { Formik, FormikProps } from 'formik';
 import * as _ from 'lodash';
 import { ValidatedOptions } from '@patternfly/react-core';
 import { history, AsyncComponent } from '@console/internal/components/utils';
@@ -182,10 +182,10 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       });
   };
 
-  const renderForm = (props) => {
+  const renderForm = (formikProps: FormikProps<any>) => {
     return (
       <AsyncComponent
-        {...props}
+        {...formikProps}
         projects={projects}
         builderImages={builderImages}
         loader={importData.loader}

--- a/frontend/packages/dev-console/src/components/import/ImportForm.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportForm.tsx
@@ -199,8 +199,9 @@ const ImportForm: React.FC<ImportFormProps & StateProps> = ({
       onSubmit={handleSubmit}
       onReset={history.goBack}
       validationSchema={validationSchema}
-      render={renderForm}
-    />
+    >
+      {renderForm}
+    </Formik>
   );
 };
 

--- a/frontend/packages/dev-console/src/components/modals/DeleteResourceModal.tsx
+++ b/frontend/packages/dev-console/src/components/modals/DeleteResourceModal.tsx
@@ -91,7 +91,7 @@ class DeleteResourceModal extends PromiseComponent<
     };
     return (
       <Formik initialValues={initialValues} onSubmit={this.handleSubmit}>
-        {(formProps) => <DeleteResourceForm {...formProps} {...this.props} />}
+        {(formikProps) => <DeleteResourceForm {...formikProps} {...this.props} />}
       </Formik>
     );
   }

--- a/frontend/packages/dev-console/src/components/modals/EditApplicationModal.tsx
+++ b/frontend/packages/dev-console/src/components/modals/EditApplicationModal.tsx
@@ -97,13 +97,11 @@ class EditApplicationModal extends PromiseComponent<
       },
     };
     return (
-      <Formik
-        initialValues={initialValues}
-        onSubmit={this.handleSubmit}
-        render={(formProps) => (
+      <Formik initialValues={initialValues} onSubmit={this.handleSubmit}>
+        {(formProps) => (
           <EditApplicationForm {...formProps} {...this.props} initialApplication={application} />
         )}
-      />
+      </Formik>
     );
   }
 }
@@ -144,10 +142,8 @@ class GroupEditApplicationModal extends PromiseComponent<
       },
     };
     return (
-      <Formik
-        initialValues={initialValues}
-        onSubmit={this.handleSubmit}
-        render={(formProps) => (
+      <Formik initialValues={initialValues} onSubmit={this.handleSubmit}>
+        {(formProps) => (
           <EditApplicationForm
             {...formProps}
             {...this.props}
@@ -155,7 +151,7 @@ class GroupEditApplicationModal extends PromiseComponent<
             initialApplication={application}
           />
         )}
-      />
+      </Formik>
     );
   }
 }

--- a/frontend/packages/dev-console/src/components/modals/EditApplicationModal.tsx
+++ b/frontend/packages/dev-console/src/components/modals/EditApplicationModal.tsx
@@ -98,8 +98,8 @@ class EditApplicationModal extends PromiseComponent<
     };
     return (
       <Formik initialValues={initialValues} onSubmit={this.handleSubmit}>
-        {(formProps) => (
-          <EditApplicationForm {...formProps} {...this.props} initialApplication={application} />
+        {(formikProps) => (
+          <EditApplicationForm {...formikProps} {...this.props} initialApplication={application} />
         )}
       </Formik>
     );

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
@@ -59,7 +59,9 @@ const PipelineForm: React.FC<PipelineFormProps> = ({
         onReset={handleReset}
         validationSchema={validationSchema}
       >
-        {(props) => <PipelineFormComponent namespace={obj.metadata.namespace} {...props} />}
+        {(formikProps) => (
+          <PipelineFormComponent namespace={obj.metadata.namespace} {...formikProps} />
+        )}
       </Formik>
     </div>
   );

--- a/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/detail-page-tabs/PipelineForm.tsx
@@ -58,8 +58,9 @@ const PipelineForm: React.FC<PipelineFormProps> = ({
         onSubmit={handleSubmit}
         onReset={handleReset}
         validationSchema={validationSchema}
-        render={(props) => <PipelineFormComponent namespace={obj.metadata.namespace} {...props} />}
-      />
+      >
+        {(props) => <PipelineFormComponent namespace={obj.metadata.namespace} {...props} />}
+      </Formik>
     </div>
   );
 };

--- a/frontend/packages/dev-console/src/components/pipelines/modals/common/PipelineSecretSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/common/PipelineSecretSection.tsx
@@ -80,7 +80,7 @@ const PipelineSecretSection: React.FC<PipelineSecretSectionProps> = ({ namespace
                 onSubmit={handleSubmit}
                 onReset={handleReset}
               >
-                {(props) => <SecretForm {...props} />}
+                {(formikProps) => <SecretForm {...formikProps} />}
               </Formik>
             </div>
           ) : (

--- a/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/start-pipeline/StartPipelineModal.tsx
@@ -57,9 +57,9 @@ const StartPipelineModal: React.FC<StartPipelineModalProps & ModalComponentProps
       onSubmit={handleSubmit}
       validationSchema={startPipelineSchema}
     >
-      {(props) => (
-        <ModalStructure submitBtnText="Start" title="Start Pipeline" close={close} {...props}>
-          <StartPipelineForm {...props} />
+      {(formikProps) => (
+        <ModalStructure submitBtnText="Start" title="Start Pipeline" close={close} {...formikProps}>
+          <StartPipelineForm {...formikProps} />
         </ModalStructure>
       )}
     </Formik>

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/AddTriggerModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/AddTriggerModal.tsx
@@ -45,9 +45,9 @@ const AddTriggerModal: React.FC<AddTriggerModalProps> = ({ pipeline, close }) =>
       onSubmit={handleSubmit}
       validationSchema={addTriggerSchema}
     >
-      {(props) => (
-        <ModalStructure submitBtnText="Add" title="Add Trigger" close={close} {...props}>
-          <AddTriggerForm {...props} />
+      {(formikProps) => (
+        <ModalStructure submitBtnText="Add" title="Add Trigger" close={close} {...formikProps}>
+          <AddTriggerForm {...formikProps} />
         </ModalStructure>
       )}
     </Formik>

--- a/frontend/packages/dev-console/src/components/pipelines/modals/triggers/RemoveTriggerModal.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/modals/triggers/RemoveTriggerModal.tsx
@@ -40,9 +40,9 @@ const RemoveTriggerModal: React.FC<RemoveTriggerModalProps> = ({ pipeline, close
       onSubmit={handleSubmit}
       validationSchema={removeTriggerSchema}
     >
-      {(props) => (
+      {(formikProps) => (
         <ModalStructure
-          {...props}
+          {...formikProps}
           submitBtnText="Remove"
           submitDanger
           title="Remove Trigger"

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderPage.tsx
@@ -74,14 +74,15 @@ const PipelineBuilderPage: React.FC<PipelineBuilderPageProps> = (props) => {
         onSubmit={handleSubmit}
         onReset={history.goBack}
         validationSchema={validationSchema}
-        render={(formikProps) => (
+      >
+        {(formikProps) => (
           <PipelineBuilderForm
             {...formikProps}
             namespace={ns}
             existingPipeline={existingPipeline}
           />
         )}
-      />
+      </Formik>
     </div>
   );
 };

--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -114,7 +114,7 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ formName, namespace, role
             onReset={handleReset}
             validationSchema={validationSchema}
           >
-            {(props) => <ProjectAccessForm {...props} />}
+            {(formikProps) => <ProjectAccessForm {...formikProps} />}
           </Formik>
         )}
       </div>

--- a/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
+++ b/frontend/packages/dev-console/src/components/project-access/ProjectAccess.tsx
@@ -113,8 +113,9 @@ const ProjectAccess: React.FC<ProjectAccessProps> = ({ formName, namespace, role
             onSubmit={handleSubmit}
             onReset={handleReset}
             validationSchema={validationSchema}
-            render={(props) => <ProjectAccessForm {...props} />}
-          />
+          >
+            {(props) => <ProjectAccessForm {...props} />}
+          </Formik>
         )}
       </div>
     </>

--- a/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
+++ b/frontend/packages/dev-console/src/components/projects/details/ProjectDetailsPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { match as RMatch } from 'react-router';
-import { history, useAccessReview } from '@console/internal/components/utils';
+import { history, useAccessReview, Page } from '@console/internal/components/utils';
 import { ALL_NAMESPACES_KEY } from '@console/shared';
 import { NamespaceDetails, projectMenuActions } from '@console/internal/components/namespace';
 import { ProjectModel, RoleBindingModel } from '@console/internal/models';
@@ -48,6 +48,26 @@ export const PageContents: React.FC<MonitoringPageProps> = ({
     namespace: activeNamespace,
   });
 
+  const pages: Page[] = [
+    {
+      href: '',
+      name: 'Overview',
+      component: ProjectDashboard,
+    },
+    {
+      href: 'details',
+      name: 'Details',
+      component: NamespaceDetails,
+    },
+  ];
+  if (canListRoleBindings && canCreateRoleBindings) {
+    pages.push({
+      href: 'access',
+      name: 'Project Access',
+      component: ProjectAccessPage,
+    });
+  }
+
   return !noProjectsAvailable && activeNamespace ? (
     <DetailsPage
       {...props}
@@ -58,24 +78,7 @@ export const PageContents: React.FC<MonitoringPageProps> = ({
       kindObj={ProjectModel}
       menuActions={projectMenuActions}
       customData={{ activeNamespace, hideHeading: true }}
-      pages={[
-        {
-          href: '',
-          name: 'Overview',
-          component: ProjectDashboard,
-        },
-        {
-          href: 'details',
-          name: 'Details',
-          component: NamespaceDetails,
-        },
-        canListRoleBindings &&
-          canCreateRoleBindings && {
-            href: 'access',
-            name: 'Project Access',
-            component: ProjectAccessPage,
-          },
-      ]}
+      pages={pages}
     />
   ) : (
     <ProjectListPage title="Project Details">Select a project to view its details</ProjectListPage>

--- a/frontend/packages/dev-console/src/components/topology/components/MoveConnectionModal.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/MoveConnectionModal.tsx
@@ -149,11 +149,9 @@ class MoveConnectionModal extends PromiseComponent<
       target: edge.getTarget(),
     };
     return (
-      <Formik
-        initialValues={initialValues}
-        onSubmit={this.handleSubmit}
-        render={(formProps) => <MoveConnectionForm {...formProps} {...this.props} />}
-      />
+      <Formik initialValues={initialValues} onSubmit={this.handleSubmit}>
+        {(formProps) => <MoveConnectionForm {...formProps} {...this.props} />}
+      </Formik>
     );
   }
 }

--- a/frontend/packages/dev-console/src/components/topology/components/MoveConnectionModal.tsx
+++ b/frontend/packages/dev-console/src/components/topology/components/MoveConnectionModal.tsx
@@ -150,7 +150,7 @@ class MoveConnectionModal extends PromiseComponent<
     };
     return (
       <Formik initialValues={initialValues} onSubmit={this.handleSubmit}>
-        {(formProps) => <MoveConnectionForm {...formProps} {...this.props} />}
+        {(formikProps) => <MoveConnectionForm {...formikProps} {...this.props} />}
       </Formik>
     );
   }

--- a/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/EventSource.tsx
@@ -101,8 +101,12 @@ const EventSource: React.FC<Props> = ({
       validateOnChange={false}
       validationSchema={eventSourceValidationSchema}
     >
-      {(props) => (
-        <EventSourceForm {...props} namespace={namespace} eventSourceStatus={eventSourceStatus} />
+      {(formikProps) => (
+        <EventSourceForm
+          {...formikProps}
+          namespace={namespace}
+          eventSourceStatus={eventSourceStatus}
+        />
       )}
     </Formik>
   );

--- a/frontend/packages/knative-plugin/src/components/sink-source/SinkSource.tsx
+++ b/frontend/packages/knative-plugin/src/components/sink-source/SinkSource.tsx
@@ -51,8 +51,13 @@ const SinkSource: React.FC<SinkSourceProps> = ({ source, cancel, close }) => {
       onReset={cancel}
       initialStatus={{ error: '' }}
     >
-      {(props) => (
-        <SinkSourceModal {...props} namespace={namespace} resourceName={name} cancel={cancel} />
+      {(formikProps) => (
+        <SinkSourceModal
+          {...formikProps}
+          namespace={namespace}
+          resourceName={name}
+          cancel={cancel}
+        />
       )}
     </Formik>
   );

--- a/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
+++ b/frontend/packages/knative-plugin/src/components/traffic-splitting/TrafficSplitting.tsx
@@ -60,8 +60,8 @@ const TrafficSplitting: React.FC<TrafficSplittingProps> = ({
       onReset={cancel}
       initialStatus={{ error: '' }}
     >
-      {(props) => (
-        <TrafficSplittingModal {...props} cancel={cancel} revisionItems={revisionItems} />
+      {(formikProps) => (
+        <TrafficSplittingModal {...formikProps} cancel={cancel} revisionItems={revisionItems} />
       )}
     </Formik>
   );

--- a/frontend/packages/metal3-plugin/src/components/baremetal-hosts/add-baremetal-host/AddBareMetalHost.tsx
+++ b/frontend/packages/metal3-plugin/src/components/baremetal-hosts/add-baremetal-host/AddBareMetalHost.tsx
@@ -118,8 +118,8 @@ const AddBareMetalHost: React.FC<AddBareMetalHostProps> = ({
       onReset={() => setReload(true)}
       validationSchema={addHostValidationSchema}
     >
-      {(props) => (
-        <AddBareMetalHostForm {...props} isEditing={isEditing} showUpdated={showUpdated} />
+      {(formikProps) => (
+        <AddBareMetalHostForm {...formikProps} isEditing={isEditing} showUpdated={showUpdated} />
       )}
     </Formik>
   );

--- a/frontend/public/components/catalog/catalog-page.tsx
+++ b/frontend/public/components/catalog/catalog-page.tsx
@@ -238,13 +238,13 @@ export const CatalogListPage = withExtensions<CatalogListPageExtensionProps>({
 
             const maintainers = chart.maintainers?.length > 0 && (
               <>
-                {chart.maintainers?.map((maintainer) => (
-                  <>
+                {chart.maintainers?.map((maintainer, index) => (
+                  <React.Fragment key={index}>
                     {maintainer.name}
                     <br />
                     <a href={`mailto:${maintainer.email}`}>{maintainer.email}</a>
                     <br />
-                  </>
+                  </React.Fragment>
                 ))}
               </>
             );

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -33,13 +33,14 @@ export const TextFilter = (props) => {
     placeholder = `Filter ${label}...`,
     autoFocus = false,
     parentClassName,
+    ...otherInputProps
   } = props;
   const { ref } = useDocumentListener();
 
   return (
     <div className={classNames('has-feedback', parentClassName)}>
       <TextInput
-        {...props}
+        {...otherInputProps}
         className={classNames('co-text-filter', className)}
         data-test-id="item-filter"
         aria-label={placeholder}


### PR DESCRIPTION
**Fixes**
https://issues.redhat.com/browse/ODC-4093

**Analysis / Root cause and Solution Description for Commit 1**:
Replace deprecated Formik render function with child callback function.

This removes a technical deps and allow us to update Formik in the future. It also removes this warning when the user opens the screen:

Warning: <Formik render> has been deprecated and will be removed in future versions of Formik. Please use a child callback function instead. To get rid of this warning, replace `<Formik render={(props) => ...} />` with `<Formik>{(props) => ...}</Formik>`

**Analysis / Root cause and Solution Description for Commit 2**:
Fix react warning when open the project overview screen without 'Project Access' permissions.

When open the screen without this permissions, `false` was added to the list of pages. In the `DetailsPage` > `HorizontalNav` this pages was used to render a list of `Route`s where the key was then `(false).name`

https://github.com/openshift/console/blob/master/frontend/public/components/utils/horizontal-nav.tsx#L239

Warning: Each child in a list should have a unique "key" prop. See https://fb.me/react-warning-keys for more information.

**Analysis / Root cause and Solution Description for Commit 3**:
Fix react warning when open the dev console search.

Do not all props of the TextFilter to the TextInput. Skip custom ones.

Warning: React does not recognize the `parentClassName` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `parentclassname` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

**Analysis / Root cause and Solution Description for Commit 4**:
Added a missing React key attribute when open the Add page > Catalog.

Warning: Each child in a list should have a unique "key" prop. See https://fb.me/react-warning-keys for more information.

**Unit test coverage report**: 
No unit tests affected.

**Test setup:**
Open the browser console and open the screens named above.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
