### PR TITLE
Bug 1838258: Fix operand list layout

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/index.tsx
@@ -160,17 +160,17 @@ export const OperandTableHeader = () => {
       title: 'Labels',
       sortField: 'metadata.labels',
       transforms: [sortable],
-      props: { className: tableColumnClasses[4] },
+      props: { className: tableColumnClasses[3] },
     },
     {
       title: 'Last Updated',
       sortField: 'metadata.creationTimestamp',
       transforms: [sortable],
-      props: { className: tableColumnClasses[5] },
+      props: { className: tableColumnClasses[4] },
     },
     {
       title: '',
-      props: { className: tableColumnClasses[6] },
+      props: { className: tableColumnClasses[5] },
     },
   ];
 };
@@ -258,13 +258,13 @@ export const OperandTableRow: React.FC<OperandTableRowProps> = ({
       <TableData className={tableColumnClasses[2]}>
         <OperandStatus operand={obj} />
       </TableData>
-      <TableData className={tableColumnClasses[4]}>
+      <TableData className={tableColumnClasses[3]}>
         <LabelList kind={obj.kind} labels={obj.metadata.labels} />
       </TableData>
-      <TableData className={tableColumnClasses[5]}>
+      <TableData className={tableColumnClasses[4]}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
       </TableData>
-      <TableData className={tableColumnClasses[6]}>
+      <TableData className={tableColumnClasses[5]}>
         <ResourceKebab actions={actions} kind={referenceFor(obj)} resource={obj} />
       </TableData>
     </TableRow>


### PR DESCRIPTION
A column was removed from the table, but the other table column classes weren't adjusted.

/assign @rhamilto 
cc @tlwu2013 

Before:

<img width="1052" alt="Screen Shot 2020-05-20 at 2 40 46 PM" src="https://user-images.githubusercontent.com/1167259/82484433-ef1b9680-9aa7-11ea-9870-5581aa71b707.png">

After:

![Screenshot_2020-05-20 argocd-operator v0 0 8 · Details · OKD](https://user-images.githubusercontent.com/1167259/82484362-d4492200-9aa7-11ea-921a-801eb984eea1.png)
