### PR TITLE
Bug 1837860: Monitoring: Fix Show / Hide Graph behavior for zoomed graphs

### DIFF
--- a/frontend/public/components/monitoring/_monitoring.scss
+++ b/frontend/public/components/monitoring/_monitoring.scss
@@ -391,6 +391,15 @@ $screen-phone-landscape-min-width: 567px;
   overflow: visible;
   padding: 10px;
   width: 100%;
+
+  &--hidden {
+    border-bottom: none;
+    border-top: none;
+    height: 0;
+    margin: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+  }
 }
 
 .query-browser__zoom {


### PR DESCRIPTION
Resizing the window while the graph was hidden was not handled
correctly.

This was most obvious for zoomed graphs, which would fail to render when
the Show Graph button was clicked.

It also cased non-zoomed graphs to briefly render with the incorrect width.

To fix this, ensure that the graph container is rendered even when the
graph is hidden so we can continue to track its width.

Fix https://github.com/openshift/console/pull/5478 was similar, but didn't fully fix the issue.

As with https://github.com/openshift/console/pull/5478, this bug was not noticeable until #4841 changed the `useRefWidth` logic