### PR TITLE
Bug 1838472: Disable add button for unfilled healthchecks form

### DIFF
--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -35,6 +35,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
   isSubmitting,
   setFieldValue,
   values,
+  dirty,
 }) => {
   const [currentKey, setCurrentKey] = React.useState(currentContainer);
   const containers = resource?.spec?.template?.spec?.containers;
@@ -118,7 +119,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
             errorMessage={status && status?.errors?.json?.message}
             isSubmitting={isSubmitting}
             submitLabel={healthCheckAdded ? 'Save' : 'Add'}
-            disableSubmit={isFormClean || !_.isEmpty(errors)}
+            disableSubmit={isFormClean || !dirty || !_.isEmpty(errors)}
             resetLabel="Cancel"
           />
         </Form>

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import Helmet from 'react-helmet';
-import { useFormikContext, FormikProps, FormikValues } from 'formik';
+import { FormikProps, FormikValues } from 'formik';
 import { Form, Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import {
@@ -34,6 +34,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
   status,
   isSubmitting,
   setFieldValue,
+  values,
 }) => {
   const [currentKey, setCurrentKey] = React.useState(currentContainer);
   const containers = resource?.spec?.template?.spec?.containers;
@@ -49,10 +50,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
   } = resource;
   const kindForCRDResource = referenceFor(resource);
   const resourceKind = modelFor(kindForCRDResource).crd ? kindForCRDResource : kind;
-  const {
-    values: { healthChecks },
-  } = useFormikContext<FormikValues>();
-  const isFormClean = _.every(healthChecks, { enabled: false });
+  const isFormClean = _.every(values.healthChecks, { modified: false });
 
   const handleSelectContainer = (containerName: string) => {
     const containerIndex = _.findIndex(resource.spec.template.spec.containers, [

--- a/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/AddHealthChecks.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import Helmet from 'react-helmet';
-import { FormikProps, FormikValues } from 'formik';
+import { useFormikContext, FormikProps, FormikValues } from 'formik';
 import { Form, Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import {
@@ -30,7 +30,6 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
   currentContainer,
   handleSubmit,
   handleReset,
-  dirty,
   errors,
   status,
   isSubmitting,
@@ -50,6 +49,10 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
   } = resource;
   const kindForCRDResource = referenceFor(resource);
   const resourceKind = modelFor(kindForCRDResource).crd ? kindForCRDResource : kind;
+  const {
+    values: { healthChecks },
+  } = useFormikContext<FormikValues>();
+  const isFormClean = _.every(healthChecks, { enabled: false });
 
   const handleSelectContainer = (containerName: string) => {
     const containerIndex = _.findIndex(resource.spec.template.spec.containers, [
@@ -117,7 +120,7 @@ const AddHealthChecks: React.FC<FormikProps<FormikValues> & AddHealthChecksProps
             errorMessage={status && status?.errors?.json?.message}
             isSubmitting={isSubmitting}
             submitLabel={healthCheckAdded ? 'Save' : 'Add'}
-            disableSubmit={!dirty || !_.isEmpty(errors)}
+            disableSubmit={isFormClean || !_.isEmpty(errors)}
             resetLabel="Cancel"
           />
         </Form>

--- a/frontend/packages/dev-console/src/components/health-checks/HealthChecksProbe.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/HealthChecksProbe.tsx
@@ -25,6 +25,11 @@ const HealthCheckProbe: React.FC<HealthCheckProbeProps> = ({ probeType }) => {
 
   const handleDeleteProbe = () => {
     setFieldValue(`healthChecks.${probeType}`, healthChecksDefaultValues);
+    if (healthChecks?.[probeType]?.modified) {
+      setFieldValue(`healthChecks.${probeType}.modified`, false);
+    } else {
+      setFieldValue(`healthChecks.${probeType}.modified`, true);
+    }
   };
 
   const handleReset = () => {
@@ -34,11 +39,13 @@ const HealthCheckProbe: React.FC<HealthCheckProbeProps> = ({ probeType }) => {
       setFieldValue(`healthChecks.${probeType}.showForm`, false);
       setFieldValue(`healthChecks.${probeType}.data`, temporaryProbeData);
     }
+    setFieldValue(`healthChecks.${probeType}.modified`, false);
   };
 
   const handleSubmit = () => {
     setFieldValue(`healthChecks.${probeType}.showForm`, false);
     setFieldValue(`healthChecks.${probeType}.enabled`, true);
+    setFieldValue(`healthChecks.${probeType}.modified`, true);
   };
 
   const handleAddProbe = () => {

--- a/frontend/packages/dev-console/src/components/health-checks/__tests__/AddHealthChecks.spec.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/__tests__/AddHealthChecks.spec.tsx
@@ -9,6 +9,8 @@ import { getHealthChecksData } from '../create-health-checks-probe-utils';
 import { getResourcesType } from '../../edit-application/edit-application-utils';
 import HealthChecks from '../HealthChecks';
 
+jest.mock('formik', () => ({ useFormikContext: () => ({ values: [] }) }));
+
 let addHealthCheckProbs: React.ComponentProps<typeof AddHealthChecks>;
 
 describe('AddHealthCheck', () => {

--- a/frontend/packages/dev-console/src/components/health-checks/__tests__/AddHealthChecks.spec.tsx
+++ b/frontend/packages/dev-console/src/components/health-checks/__tests__/AddHealthChecks.spec.tsx
@@ -9,8 +9,6 @@ import { getHealthChecksData } from '../create-health-checks-probe-utils';
 import { getResourcesType } from '../../edit-application/edit-application-utils';
 import HealthChecks from '../HealthChecks';
 
-jest.mock('formik', () => ({ useFormikContext: () => ({ values: [] }) }));
-
 let addHealthCheckProbs: React.ComponentProps<typeof AddHealthChecks>;
 
 describe('AddHealthCheck', () => {

--- a/frontend/packages/dev-console/src/components/health-checks/__tests__/create-health-checks-probe-data.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/__tests__/create-health-checks-probe-data.ts
@@ -6,6 +6,7 @@ export const healthChecksData: HealthChecksData = {
   readinessProbe: {
     showForm: false,
     enabled: true,
+    modified: false,
     data: {
       failureThreshold: 3,
       requestType: RequestType.HTTPGET,
@@ -24,6 +25,7 @@ export const healthChecksData: HealthChecksData = {
   livenessProbe: {
     showForm: false,
     enabled: true,
+    modified: false,
     data: {
       failureThreshold: 3,
       requestType: RequestType.ContainerCommand,
@@ -42,6 +44,7 @@ export const healthChecksInputData = {
     readinessProbe: {
       showForm: false,
       enabled: true,
+      modified: false,
       data: {
         ...healthChecksDefaultValues.data,
         httpGet: {
@@ -56,6 +59,7 @@ export const healthChecksInputData = {
     startupProbe: {
       showForm: false,
       enabled: true,
+      modified: false,
       data: {
         ...healthChecksDefaultValues.data,
         requestType: RequestType.TCPSocket,

--- a/frontend/packages/dev-console/src/components/health-checks/__tests__/health-checks-probe-validation-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/__tests__/health-checks-probe-validation-utils.spec.ts
@@ -13,6 +13,7 @@ describe('healthChecksValidationSchema', () => {
   beforeEach(() => {
     mockData = cloneDeep(mockHealthCheckFormData);
     mockData.healthChecks.readinessProbe.showForm = true;
+    mockData.healthChecks.readinessProbe.modified = false;
   });
 
   it('should validate the form data', async () => {

--- a/frontend/packages/dev-console/src/components/health-checks/create-health-checks-probe-utils.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/create-health-checks-probe-utils.ts
@@ -52,6 +52,7 @@ export const getHealthChecksData = (
   const healthChecks = {
     readinessProbe: {
       showForm: false,
+      modified: false,
       enabled: !_.isEmpty(readinessProbe),
       data: !_.isEmpty(readinessProbe)
         ? {
@@ -65,6 +66,7 @@ export const getHealthChecksData = (
     },
     livenessProbe: {
       showForm: false,
+      modified: false,
       enabled: !_.isEmpty(livenessProbe),
       data: !_.isEmpty(livenessProbe)
         ? {
@@ -78,6 +80,7 @@ export const getHealthChecksData = (
     },
     startupProbe: {
       showForm: false,
+      modified: false,
       enabled: !_.isEmpty(startupProbe),
       data: !_.isEmpty(startupProbe)
         ? {

--- a/frontend/packages/dev-console/src/components/health-checks/health-checks-probe-utils.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/health-checks-probe-utils.ts
@@ -31,6 +31,7 @@ export const getHealthChecksProbeConfig = (probe: string) => {
 export const healthChecksDefaultValues: HealthCheckProbe = {
   showForm: false,
   enabled: false,
+  modified: false,
   data: {
     failureThreshold: 3,
     requestType: RequestType.HTTPGET,

--- a/frontend/packages/dev-console/src/components/health-checks/health-checks-probe-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/health-checks-probe-validation-utils.ts
@@ -6,6 +6,7 @@ export const healthChecksValidationSchema = yup.object().shape({
   containerName: yup.string(),
   showForm: yup.boolean(),
   enabled: yup.boolean(),
+  modified: yup.boolean(),
   data: yup.object().when('showForm', {
     is: true,
     then: yup.object().shape({

--- a/frontend/packages/dev-console/src/components/health-checks/health-checks-types.ts
+++ b/frontend/packages/dev-console/src/components/health-checks/health-checks-types.ts
@@ -34,5 +34,6 @@ export interface HealthCheckProbeData {
 export interface HealthCheckProbe {
   showForm?: boolean;
   enabled?: boolean;
+  modified?: boolean;
   data: HealthCheckProbeData;
 }


### PR DESCRIPTION
**Fixes**:
https://issues.redhat.com/browse/ODC-3815

**Analysis / Root cause**:
Add button from Health checks page gets activated and clickable even though we don't add anything.

**Solution Description**:
Only enable "Add" button if any of the health probes prop `enabled` is `true`.

**Screen shots / Gifs for design review**: 
![healthcheck-add](https://user-images.githubusercontent.com/20013884/82542200-36208f00-9b6f-11ea-9508-94067085b81c.gif)


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
