### PR TITLE
Bug 1838617: remove build decorator from the revision node

### DIFF
--- a/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
+++ b/frontend/packages/dev-console/src/components/topology/data-transforms/transform-utils.ts
@@ -98,7 +98,7 @@ export const createTopologyNodeData = (
         type && (type === TYPE_EVENT_SOURCE || type === TYPE_KNATIVE_REVISION)
           ? true
           : isKnativeServing(deploymentConfig, 'metadata.labels'),
-      build: _.get(buildConfigs[0], 'builds[0]'),
+      build: buildConfigs?.[0]?.builds?.[0],
       connectedPipeline: {
         pipeline: pipelines[0],
         pipelineRuns,

--- a/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
+++ b/frontend/packages/knative-plugin/src/topology/knative-topology-utils.ts
@@ -394,8 +394,9 @@ export const transformKnNodeData = (
         break;
       }
       case NodeType.Revision: {
+        const revisionItem = _.omit(item, ['pipelines', 'pipelineRuns', 'buildConfigs']);
         knDataModel.topology[uid] = createTopologyNodeData(
-          item.pipelines ? _.omit(item, ['pipelines', 'pipelineRuns']) : item,
+          revisionItem,
           type,
           getImageForIconClass(`icon-openshift`),
         );


### PR DESCRIPTION
**Fixes**: https://issues.redhat.com/browse/ODC-3944
<!-- For e.g Fixes: https://issues.redhat.com/browse/ODC-XXX -->

**Analysis / Root cause**: Build Decorator appearing on both knative service and revision
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution Description**: remove build decorator from revision
<!-- Describe your code changes in detail and explain the solution -->

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->


**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
