### PR TITLE
Bug 1838659: Fix "SyntaxError: Unexpected identifier 'e'" in Safari (production build only)

### DIFF
--- a/frontend/public/components/edit-yaml.jsx
+++ b/frontend/public/components/edit-yaml.jsx
@@ -356,10 +356,12 @@ export const EditYAML_ = connect(stateToProps)(
         const sampleObj = generateObjToLoad(kind, id, yaml, this.props.obj.metadata.namespace);
         this.setState({ sampleObj });
         return sampleObj;
-      } catch ({ message, name }) {
+      } catch (error) {
         errorModal({
           title: 'Failed to Parse YAML Sample',
-          error: <div className="co-pre-line">{message || name || 'An error occurred.'}</div>,
+          error: (
+            <div className="co-pre-line">{error.message || error.name || 'An error occurred.'}</div>
+          ),
         });
       }
     }

--- a/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
+++ b/frontend/public/components/monitoring/receiver-forms/alert-manager-receiver-forms.tsx
@@ -550,9 +550,10 @@ const ReceiverWrapper: React.FC<ReceiverFormsWrapperProps> = React.memo(({ obj, 
             const { global } = safeLoad(originalAlertmanagerConfigJSON);
             setAlertmanagerGlobals(global);
             setLoaded(true);
-          } catch ({ message }) {
+          } catch (error) {
             setLoadError({
-              message: `Error parsing Alertmanager config.original: ${message || 'invalid YAML'}`,
+              message: `Error parsing Alertmanager config.original: ${error.message ||
+                'invalid YAML'}`,
             });
           }
         }


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3941

**Analysis / Root cause**: 
There is a JS minify issue which generates invalid JavaScript for Safari. This happen only in the production build and only on Safari. (Chrome and Firefox works fine.)

**Solution Description**: 
Do not use the destruction operator in a catch-clause.

Use

```tsx
catch (error) {
  console.log(error.message);
}
```

instead of 

```tsx
catch ({ message }) {
  console.log(message);
}
```

**Screen shots / Gifs for design review**: 
Not affected

**Unit test coverage report**: 
Not affected

**Test setup:**
It's required to run a production build with `yarn run build` and validate this with Safari.

See Jira ticket for more details about the test setup.

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge

edit:
Tested this with the latest stable Safari on macOS (Safari 13.1 on macOS 10.15.4)