### PR TITLE
Bug 1838754: Update endpoint to include labels in knative event source crd response

### DIFF
--- a/pkg/knative/types.go
+++ b/pkg/knative/types.go
@@ -1,0 +1,42 @@
+package knative
+
+import (
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EventSourceVersion describes a version for CRD.
+type EventSourceVersion struct {
+	Name    string `json:"name" protobuf:"bytes,1,opt,name=name"`
+	Served  bool   `json:"served" protobuf:"varint,2,opt,name=served"`
+	Storage bool   `json:"storage" protobuf:"varint,3,opt,name=storage"`
+}
+
+// EventSourceSpec describes how a user wants their resource to appear
+type EventSourceSpec struct {
+	Group    string                                      `json:"group" protobuf:"bytes,1,opt,name=group"`
+	Names    apiextensions.CustomResourceDefinitionNames `json:"names" protobuf:"bytes,3,opt,name=names"`
+	Versions []EventSourceVersion                        `json:"versions" protobuf:"bytes,7,rep,name=versions"`
+}
+
+// EventSourceMeta is metadata that all persisted resources must have, which includes all objects users must create
+type EventSourceMeta struct {
+	Name   string            `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	Labels map[string]string `json:"labels,omitempty" protobuf:"bytes,11,rep,name=labels"`
+}
+
+// EventSourceDefinition represents a resource that should be exposed on the API server.
+type EventSourceDefinition struct {
+	metav1.TypeMeta `json:",inline"`
+	EventSourceMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	EventSourceSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
+}
+
+// EventSourceList is a list of EventSourceDefinition objects.
+type EventSourceList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// items list individual EventSourceDefinition objects
+	Items []EventSourceDefinition `json:"items" protobuf:"bytes,2,rep,name=items"`
+}

--- a/pkg/knative/utils.go
+++ b/pkg/knative/utils.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/coreos/pkg/capnslog"
 	"github.com/openshift/console/pkg/serverutils"
 )
@@ -14,41 +11,6 @@ import (
 var (
 	plog = capnslog.NewPackageLogger("github.com/openshift/console", "knative")
 )
-
-// EventSourceVersion describes a version for CRD.
-type EventSourceVersion struct {
-	Name    string `json:"name" protobuf:"bytes,1,opt,name=name"`
-	Served  bool   `json:"served" protobuf:"varint,2,opt,name=served"`
-	Storage bool   `json:"storage" protobuf:"varint,3,opt,name=storage"`
-}
-
-// EventSourceSpec describes how a user wants their resource to appear
-type EventSourceSpec struct {
-	Group    string                                      `json:"group" protobuf:"bytes,1,opt,name=group"`
-	Names    apiextensions.CustomResourceDefinitionNames `json:"names" protobuf:"bytes,3,opt,name=names"`
-	Versions []EventSourceVersion                        `json:"versions" protobuf:"bytes,7,rep,name=versions"`
-}
-
-// EventSourceMeta is metadata that all persisted resources must have, which includes all objects users must create
-type EventSourceMeta struct {
-	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
-}
-
-// EventSourceDefinition represents a resource that should be exposed on the API server.
-type EventSourceDefinition struct {
-	metav1.TypeMeta `json:",inline"`
-	EventSourceMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	EventSourceSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
-}
-
-// EventSourceList is a list of EventSourceDefinition objects.
-type EventSourceList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-
-	// items list individual EventSourceDefinition objects
-	Items []EventSourceDefinition `json:"items" protobuf:"bytes,2,rep,name=items"`
-}
 
 // EventSourceFilter shall filter partial metadata from knative event sources CRDs before propagating
 func EventSourceFilter(w http.ResponseWriter, r *http.Response) {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3787
https://bugzilla.redhat.com/show_bug.cgi?id=1838754

**Analysis / Root cause**: 
Currently we have an endpoint in console backend `api/console/knative-event-sources` to fetch EventSources on cluster based on DuckType and it fetches as all sources. Serverless 1.7.x contains deprecated sources, but there is no indication which is deprecated or not. So they have introduced following label to identify deprecated event sources.
`eventing.knative.dev/deprecated: "true"`

**Solution Description**: 
`labels` need to be included in CRD response so that frontend can identify deprecated event sources & filter them. As part of this change, all structs have been extracted to separate file.

**Screen shots / Gifs for design review**: N/A

**Test setup:**
Install 'OpenShift Serverless Operator' & create CR for 'Knative Eventing'

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
