### PR TITLE
Bug 1838792: handle embedded pipeline spec in pipelinerun scenario

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunVisualization.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunVisualization.tsx
@@ -3,7 +3,7 @@ import { Alert } from '@patternfly/react-core';
 import { k8sGet } from '@console/internal/module/k8s';
 import { PipelineModel } from '../../../models';
 import PipelineVisualization from '../../pipelines/detail-page-tabs/pipeline-details/PipelineVisualization';
-import { Pipeline, PipelineRun } from '../../../utils/pipeline-augment';
+import { Pipeline, PipelineRun, pipelineRefExists } from '../../../utils/pipeline-augment';
 
 type PipelineRunVisualizationProps = {
   pipelineRun: PipelineRun;
@@ -14,11 +14,13 @@ const PipelineRunVisualization: React.FC<PipelineRunVisualizationProps> = ({ pip
   const [pipeline, setPipeline] = React.useState<Pipeline>(null);
 
   React.useEffect(() => {
-    k8sGet(PipelineModel, pipelineRun.spec.pipelineRef.name, pipelineRun.metadata.namespace)
-      .then((res: Pipeline) => setPipeline(res))
-      .catch((error) =>
-        setErrorMessage(error?.message || 'Could not load visualization at this time.'),
-      );
+    if (pipelineRefExists(pipelineRun)) {
+      k8sGet(PipelineModel, pipelineRun.spec.pipelineRef.name, pipelineRun.metadata.namespace)
+        .then((res: Pipeline) => setPipeline(res))
+        .catch((error) =>
+          setErrorMessage(error?.message || 'Could not load visualization at this time.'),
+        );
+    }
   }, [pipelineRun, setPipeline]);
 
   if (errorMessage) {

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment.spec.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { pipelineTestData, DataState, PipelineExampleNames } from '../../test/pipeline-data';
 import {
   getResources,
@@ -8,6 +9,7 @@ import {
   getRunStatusColor,
   runStatus,
   getResourceModelFromTask,
+  pipelineRefExists,
 } from '../pipeline-augment';
 import { ClusterTaskModel, TaskModel } from '../../models';
 import { testData } from './pipeline-augment-test-data';
@@ -271,5 +273,25 @@ describe('PipelineAugment test successfully determine Task type', () => {
 
     const model = getResourceModelFromTask(complexTestData.pipeline.spec.tasks[0]);
     expect(model).toBe(ClusterTaskModel);
+  });
+});
+
+describe('Pipeline exists test to determine whether a pipeline is linked to a pipelinerun', () => {
+  it('expect to return true if pipelineref is available in pipelinerun spec', () => {
+    const pipelineRunWithPipelineRef =
+      pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[DataState.SUCCESS];
+
+    const pipelineFound = pipelineRefExists(pipelineRunWithPipelineRef);
+    expect(pipelineFound).toBeTruthy();
+  });
+
+  it('expect to return false if pipelineref is missing in pipelinerun spec', () => {
+    const pipelineRunWithoutPipelineRef = _.omit(
+      pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[DataState.SUCCESS],
+      'spec.pipelineRef',
+    );
+
+    const pipelineFound = pipelineRefExists(pipelineRunWithoutPipelineRef);
+    expect(pipelineFound).toBeFalsy();
   });
 });

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -91,7 +91,7 @@ export interface Pipeline extends K8sResourceKind {
 
 export interface PipelineRun extends K8sResourceKind {
   spec?: {
-    pipelineRef: { name: string };
+    pipelineRef?: { name: string };
     params?: PipelineRunParam[];
     resources?: PipelineResource[];
     serviceAccountName?: string;
@@ -352,3 +352,6 @@ export const getResourceModelFromTask = (task: PipelineTask): K8sKind => {
 
   return getResourceModelFromTaskKind(kind);
 };
+
+export const pipelineRefExists = (pipelineRun: PipelineRun): boolean =>
+  !!pipelineRun.spec.pipelineRef?.name;


### PR DESCRIPTION

Fixes: https://issues.redhat.com/browse/ODC-3675

Problem:
Devconsole UI breaks when user creates pipelinerun with embedded pipeline spec and visits the pipeline run details page

Solution:
Add checks and conditionally rendering the pipelinerun visualization component based on the pipelineRef field in the pipelinerun spec.


This is a manual cherry pick for the PR https://github.com/openshift/console/pull/5425