### PR TITLE
Update monitoring pages to use new common filter component

### DIFF
--- a/frontend/integration-tests/views/monitoring.view.ts
+++ b/frontend/integration-tests/views/monitoring.view.ts
@@ -8,7 +8,7 @@ export const wait = async (condition) => await browser.wait(condition, 20000);
 
 // List pages
 export const listPageHeading = $('.co-m-pane__heading');
-export const createButton = $('.co-m-pane__filter-bar-group button');
+export const createButton = $('.co-m-pane__createLink--no-title button');
 
 // Details pages
 export const actionButton = $('.co-m-nav-title .pf-m-primary.co-action-buttons__btn');

--- a/frontend/packages/console-shared/src/utils/label-filter.ts
+++ b/frontend/packages/console-shared/src/utils/label-filter.ts
@@ -1,10 +1,9 @@
 import * as _ from 'lodash';
-import { K8sResourceCommon } from '@console/internal/module/k8s';
 import { toRequirements } from '@console/internal/module/k8s/selector';
 import { requirementToString } from '@console/internal/module/k8s/selector-requirement';
 
-export const getLabelsAsString = (obj: K8sResourceCommon): string[] => {
-  const { labels } = obj.metadata;
+export const getLabelsAsString = (obj: any, path: string = 'metadata.labels'): string[] => {
+  const labels = _.get(obj, path);
   const requirements = toRequirements(labels);
   return _.map(requirements, requirementToString);
 };

--- a/frontend/public/components/autocomplete.tsx
+++ b/frontend/public/components/autocomplete.tsx
@@ -3,13 +3,12 @@ import * as classNames from 'classnames';
 import { useDocumentListener, getLabelsAsString } from '@console/shared';
 import { KeyEventModes } from '@console/shared/src/hooks';
 import { fuzzyCaseInsensitive } from './factory/table-filters';
-import { K8sResourceCommon } from '../module/k8s';
 import { TextFilter } from './factory';
 
 const MAX_SUGGESTIONS = 5;
 
-const labelParser = (resources: K8sResourceCommon[], labelPath: string): Set<string> => {
-  return resources.reduce((acc: Set<string>, resource: K8sResourceCommon) => {
+const labelParser = (resources: any, labelPath: string): Set<string> => {
+  return resources.reduce((acc: Set<string>, resource: any) => {
     getLabelsAsString(resource, labelPath).forEach((label) => acc.add(label));
     return acc;
   }, new Set<string>());

--- a/frontend/public/components/autocomplete.tsx
+++ b/frontend/public/components/autocomplete.tsx
@@ -8,9 +8,9 @@ import { TextFilter } from './factory';
 
 const MAX_SUGGESTIONS = 5;
 
-const labelParser = (resources: K8sResourceCommon[]): Set<string> => {
+const labelParser = (resources: K8sResourceCommon[], labelPath: string): Set<string> => {
   return resources.reduce((acc: Set<string>, resource: K8sResourceCommon) => {
-    getLabelsAsString(resource).forEach((label) => acc.add(label));
+    getLabelsAsString(resource, labelPath).forEach((label) => acc.add(label));
     return acc;
   }, new Set<string>());
 };
@@ -56,13 +56,13 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = (props) => {
 
   React.useEffect(() => {
     if (textValue && visible && showSuggestions) {
-      const processed = labelParser(data);
+      const processed = labelParser(data, props.labelPath);
       const filtered = [...processed]
         .filter((item) => fuzzyCaseInsensitive(textValue, item))
         .slice(0, MAX_SUGGESTIONS);
       setSuggestions(filtered);
     }
-  }, [visible, textValue, showSuggestions, data]);
+  }, [visible, textValue, showSuggestions, data, props.labelPath]);
 
   return (
     <div className="co-suggestion-box" ref={ref}>
@@ -106,6 +106,7 @@ type AutocompleteInputProps = {
   setTextValue: React.Dispatch<React.SetStateAction<String>>;
   className?: string;
   data?: any;
+  labelPath?: string;
 };
 
 const SuggestionLine: React.FC<SuggestionLineProps> = ({ suggestion, onClick, className }) => {

--- a/frontend/public/components/factory/list-page.jsx
+++ b/frontend/public/components/factory/list-page.jsx
@@ -249,11 +249,7 @@ export const FireMan_ = connect(null, { filterList })(
             className={classNames({ 'co-m-nav-title--row': createLink })}
           >
             {createLink && (
-              <div
-                className={classNames('co-m-pane__createLink', {
-                  'co-m-pane__createLink--no-title': !title,
-                })}
-              >
+              <div className={classNames({ 'co-m-pane__createLink--no-title': !title })}>
                 {createLink}
               </div>
             )}

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -44,7 +44,7 @@ export const tableFilters: TableFilterMap = {
     return haystack.includes(needle);
   },
 
-  'alert-list-label': (values, alert) => {
+  alerts: (values, alert) => {
     const labels = getLabelsAsString(alert, 'labels');
     if (!values.all) {
       return true;
@@ -60,16 +60,7 @@ export const tableFilters: TableFilterMap = {
 
   'alerting-rule-name': (filter, rule) => fuzzyCaseInsensitive(filter, rule.name),
 
-  'alerting-rule-label': (values, rule) => {
-    const labels = getLabelsAsString(rule, 'labels');
-    if (!values.all) {
-      return true;
-    }
-    return !!values.all.every((v) => labels.includes(v));
-  },
-
-  'silence-name': (filter, silence) =>
-    fuzzyCaseInsensitive(filter, silence.name) || _.isEmpty(filter.selected),
+  'silence-name': (filter, silence) => fuzzyCaseInsensitive(filter, silence.name),
 
   'silence-state': (filter, silence) =>
     filter.selected.has(silenceState(silence)) || _.isEmpty(filter.selected),

--- a/frontend/public/components/factory/table-filters.ts
+++ b/frontend/public/components/factory/table-filters.ts
@@ -44,15 +44,35 @@ export const tableFilters: TableFilterMap = {
     return haystack.includes(needle);
   },
 
-  'alert-state': (filter, alert) => filter.selected.has(alertState(alert)),
+  'alert-list-label': (values, alert) => {
+    const labels = getLabelsAsString(alert, 'labels');
+    if (!values.all) {
+      return true;
+    }
+    return !!values.all.every((v) => labels.includes(v));
+  },
 
-  'alerting-rule-active': (filter, rule) => filter.selected.has(alertingRuleIsActive(rule)),
+  'alert-state': (filter, alert) =>
+    filter.selected.has(alertState(alert)) || _.isEmpty(filter.selected),
+
+  'alerting-rule-active': (filter, rule) =>
+    filter.selected.has(alertingRuleIsActive(rule)) || _.isEmpty(filter.selected),
 
   'alerting-rule-name': (filter, rule) => fuzzyCaseInsensitive(filter, rule.name),
 
-  'silence-name': (filter, silence) => fuzzyCaseInsensitive(filter, silence.name),
+  'alerting-rule-label': (values, rule) => {
+    const labels = getLabelsAsString(rule, 'labels');
+    if (!values.all) {
+      return true;
+    }
+    return !!values.all.every((v) => labels.includes(v));
+  },
 
-  'silence-state': (filter, silence) => filter.selected.has(silenceState(silence)),
+  'silence-name': (filter, silence) =>
+    fuzzyCaseInsensitive(filter, silence.name) || _.isEmpty(filter.selected),
+
+  'silence-state': (filter, silence) =>
+    filter.selected.has(silenceState(silence)) || _.isEmpty(filter.selected),
 
   // Filter role by role kind
   'role-kind': (filter, role) => filter.selected.has(roleType(role)) || filter.selected.size === 0,

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -235,6 +235,14 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Default filters
+  React.useEffect(() => {
+    if (_.isEmpty(selectedRowFilters)) {
+      rowFilters.forEach((filter) => updateRowFilterSelected(filter.defaultSelected));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const switchFilter = (type: FilterType) => {
     setFilterType(FilterType[type]);
     setInputText(nameFilter && FilterType[type] === FilterType.NAME ? nameFilter : '');
@@ -343,6 +351,7 @@ type FilterToolbarProps = {
 };
 
 export type RowFilter = {
+  defaultSelected?: string[];
   filterGroupName: string;
   type: string;
   items?: {

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -161,7 +161,6 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   };
 
   const updateSearchFilter = (value: string) => {
-    // If it is handled externally then do nothing
     switch (filterType) {
       case FilterType.NAME:
         updateNameFilter(value);

--- a/frontend/public/components/filter-toolbar.tsx
+++ b/frontend/public/components/filter-toolbar.tsx
@@ -84,6 +84,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
     hideLabelFilter,
     location,
     textFilter = filterTypeMap[FilterType.NAME],
+    labelFilter = filterTypeMap[FilterType.LABEL],
   } = props;
 
   const [inputText, setInputText] = React.useState('');
@@ -119,7 +120,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   const { name: nameFilter, labels: labelFilters, rowFiltersFromURL: selectedRowFilters } = (() => {
     const rowFiltersFromURL: string[] = [];
     const params = new URLSearchParams(location.search);
-    const q = params.get('label');
+    const q = params.get(labelFilter);
     const name = params.get(textFilter);
     _.map(filterKeys, (f) => {
       const vals = params.get(f);
@@ -134,16 +135,16 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   /* Logic for Name and Label Filter */
 
   const applyFilter = (input: string | string[], type: FilterType) => {
-    const filter = type === FilterType.NAME ? textFilter : filterTypeMap[FilterType.LABEL];
+    const filter = type === FilterType.NAME ? textFilter : labelFilter;
     const value = type === FilterType.NAME ? input : { all: input };
     props.reduxIDs.forEach((id) => props.filterList(id, filter, value));
   };
 
   const updateLabelFilter = (filterValues: string[]) => {
     if (filterValues.length > 0) {
-      setQueryArgument('label', filterValues.join(','));
+      setQueryArgument(labelFilter, filterValues.join(','));
     } else {
-      removeQueryArgument('label');
+      removeQueryArgument(labelFilter);
     }
     setInputText('');
     applyFilter(filterValues, FilterType.LABEL);
@@ -160,6 +161,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
   };
 
   const updateSearchFilter = (value: string) => {
+    // If it is handled externally then do nothing
     switch (filterType) {
       case FilterType.NAME:
         updateNameFilter(value);
@@ -315,6 +317,7 @@ const FilterToolbar_: React.FC<FilterToolbarProps & RouteComponentProps> = (prop
                       FilterType.NAME === filterType ? 'Search by name...' : 'app=frontend'
                     }
                     data={data}
+                    labelPath={props.labelPath}
                   />
                 )}
               </div>
@@ -333,9 +336,11 @@ type FilterToolbarProps = {
   filterList?: any;
   textFilter?: string;
   hideNameFilter?: boolean;
+  labelFilter?: string;
   hideLabelFilter?: boolean;
   parseAutoComplete?: any;
   kinds?: any;
+  labelPath?: string;
 };
 
 export type RowFilter = {

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -993,6 +993,7 @@ const HeaderAlertmanagerLink = ({ path }) =>
   );
 
 const alertsRowFilter: RowFilter = {
+  defaultSelected: [AlertStates.Firing],
   type: 'alert-state',
   filterGroupName: 'Alert',
   reducer: alertState,
@@ -1173,6 +1174,7 @@ const RulesPage_ = (props) => (
 const RulesPage = withFallback(connect(rulesToProps)(RulesPage_));
 
 const silencesRowFilter: RowFilter = {
+  defaultSelected: [SilenceStates.Active, SilenceStates.Pending],
   type: 'silence-state',
   filterGroupName: 'Silence',
   reducer: silenceState,

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1162,12 +1162,12 @@ const RulesPage_ = (props) => (
     {...props}
     Header={ruleTableHeader}
     kindPlural="Alerting Rules"
-    nameFilterID="alerting-rule-name"
     labelFilter="alerts"
+    labelPath="labels"
+    nameFilterID="alerting-rule-name"
     reduxID="monitoringRules"
     Row={RuleTableRow}
     rowFilter={rulesRowFilter}
-    labelPath="labels"
   />
 );
 const RulesPage = withFallback(connect(rulesToProps)(RulesPage_));

--- a/frontend/public/components/monitoring.tsx
+++ b/frontend/public/components/monitoring.tsx
@@ -1051,7 +1051,7 @@ const MonitoringListPage = connect(filtersToProps)(
           </Helmet>
           <div className="co-m-pane__body">
             {CreateButton && (
-              <div className="co-m-pane__createLink co-m-pane__createLink--no-title">
+              <div className="co-m-pane__createLink--no-title">
                 <CreateButton />
               </div>
             )}
@@ -1095,7 +1095,7 @@ const AlertsPage_ = (props) => (
     reduxID="monitoringAlerts"
     Row={AlertTableRow}
     rowFilter={alertsRowFilter}
-    labelFilter="alert-list-label"
+    labelFilter="alerts"
     labelPath="labels"
   />
 );
@@ -1163,7 +1163,7 @@ const RulesPage_ = (props) => (
     Header={ruleTableHeader}
     kindPlural="Alerting Rules"
     nameFilterID="alerting-rule-name"
-    labelFilter="alerting-rule-label"
+    labelFilter="alerts"
     reduxID="monitoringRules"
     Row={RuleTableRow}
     rowFilter={rulesRowFilter}

--- a/frontend/public/components/monitoring/types.ts
+++ b/frontend/public/components/monitoring/types.ts
@@ -96,13 +96,17 @@ export type ListPageProps = {
   loadError?: string;
   match: { path: string };
   nameFilterID: string;
+  labelFilter?: string;
   reduxID: string;
   Row: RowFunction;
   rowFilter: {
+    filterGroupName: string;
     type: string;
     selected: string[];
     reducer: (monitoringResource: Alert | Rule | Silence) => string;
     items: { id: string; title: string }[];
   };
   showTitle?: boolean;
+  hideLabelFilter?: boolean;
+  labelPath?: string;
 };


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/CONSOLE-2307

Convert monitoring page filters to use common component.

Thanks to @bipuladh for the common component/type ahead label filter help.

cc: @dtaylor113 

![Screen Shot 2020-05-21 at 4 29 34 PM](https://user-images.githubusercontent.com/35978579/82603278-5e64b980-9b80-11ea-96a1-f38401bee97c.png)
