### PR TITLE
Bug 1840294: Support Singular Tech Preview status for Pipelines

### DIFF
--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineSection.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { connectToFlags, FlagsObject } from '@console/internal/reducers/features';
-import { Alert } from '@patternfly/react-core';
+import { Alert, Split, SplitItem } from '@patternfly/react-core';
 import { getActiveNamespace } from '@console/internal/actions/ui';
 import { useAccessReview } from '@console/internal/components/utils';
+import { TechPreviewBadge } from '@console/shared';
 import { useFormikContext, FormikValues } from 'formik';
 import { PipelineModel, PipelineResourceModel } from '../../../models';
 import { FLAG_OPENSHIFT_PIPELINE, CLUSTER_PIPELINE_NS } from '../../../const';
@@ -46,8 +47,16 @@ const PipelineSection: React.FC<PipelineSectionProps> = ({ flags, builderImages 
   const hasCreatePipelineAccess = usePipelineAccessReview();
 
   if (flags[FLAG_OPENSHIFT_PIPELINE] && hasCreatePipelineAccess) {
+    const title = (
+      <Split gutter="md">
+        <SplitItem className="odc-form-section__heading">Pipelines</SplitItem>
+        <SplitItem>
+          <TechPreviewBadge />
+        </SplitItem>
+      </Split>
+    );
     return (
-      <FormSection title="Pipelines">
+      <FormSection title={title}>
         {values.image.selected || values.build.strategy === 'Docker' ? (
           <PipelineTemplate builderImages={builderImages} />
         ) : (

--- a/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
+++ b/frontend/packages/dev-console/src/components/import/pipeline/PipelineTemplate.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { LoadingInline } from '@console/internal/components/utils';
 import { k8sList } from '@console/internal/module/k8s';
 import { useFormikContext, FormikValues } from 'formik';
-import { Alert, Expandable, Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
-import { CheckboxField, InlineDevPreviewBadge } from '@console/shared';
+import { Alert, Expandable } from '@patternfly/react-core';
+import { CheckboxField } from '@console/shared';
 import { CLUSTER_PIPELINE_NS } from '../../../const';
 import { PipelineModel } from '../../../models';
 import PipelineVisualization from '../../pipelines/detail-page-tabs/pipeline-details/PipelineVisualization';
@@ -104,14 +104,7 @@ const PipelineTemplate: React.FC<PipelineTemplateProps> = ({ builderImages }) =>
 
   return pipeline.template ? (
     <>
-      <Flex>
-        <FlexItem breakpointMods={[{ modifier: FlexModifiers['align-self-center'] }]}>
-          <CheckboxField label="Add pipeline" name="pipeline.enabled" />
-        </FlexItem>
-        <FlexItem>
-          <InlineDevPreviewBadge />
-        </FlexItem>
-      </Flex>
+      <CheckboxField label="Add pipeline" name="pipeline.enabled" />
       <Expandable
         toggleText={`${isExpanded ? 'Hide' : 'Show'} pipeline visualization`}
         isExpanded={isExpanded}

--- a/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
+++ b/frontend/packages/dev-console/src/components/pipelines/pipeline-builder/PipelineBuilderHeader.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, Flex, FlexItem, FlexItemModifiers } from '@patternfly/react-core';
 import { warnYAML } from './modals';
-import { DevPreviewBadge } from '@console/shared';
+import { TechPreviewBadge } from '@console/shared';
 import { Pipeline } from '../../../utils/pipeline-augment';
 import { goToYAML } from './utils';
 
@@ -32,7 +32,7 @@ const PipelineBuilderHeader: React.FC<PipelineBuilderHeaderProps> = (props) => {
           </Button>
         </FlexItem>
         <FlexItem>
-          <DevPreviewBadge />
+          <TechPreviewBadge />
         </FlexItem>
       </Flex>
       <hr />

--- a/frontend/packages/dev-console/src/models/pipelines.ts
+++ b/frontend/packages/dev-console/src/models/pipelines.ts
@@ -75,7 +75,7 @@ export const PipelineResourceModel: K8sKind = {
   id: 'pipelineresource',
   labelPlural: 'Pipeline Resources',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };
 
@@ -120,7 +120,7 @@ export const TriggerBindingModel: K8sKind = {
   id: 'triggerbinding',
   labelPlural: 'Trigger Bindings',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };
 
@@ -135,7 +135,7 @@ export const ClusterTriggerBindingModel: K8sKind = {
   id: 'clustertriggerbinding',
   labelPlural: 'Cluster Trigger Bindings',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };
 
@@ -150,7 +150,7 @@ export const TriggerTemplateModel: K8sKind = {
   id: 'triggertemplate',
   labelPlural: 'Trigger Templates',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };
 
@@ -165,6 +165,6 @@ export const EventListenerModel: K8sKind = {
   id: 'eventlistener',
   labelPlural: 'Event Listeners',
   crd: true,
-  badge: BadgeType.DEV,
+  badge: BadgeType.TECH,
   color,
 };


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3955

**Analysis / Root cause**: 
For the first release after going Tech Preview, all of the Pipeline usages in OpenShift Console will need to show the Tech Preview badge, irrespective of their api version for consistency.

**Solution Description**: 
Apply Tech Preview labels to all areas of OpenShift Pipelines

**Screen shots / Gifs for design review**: 
@openshift/team-devconsole-ux 

Add Flow:
![Screen Shot 2020-05-21 at 10 20 03 PM](https://user-images.githubusercontent.com/8126518/82625587-91747080-9bb3-11ea-893d-4e18ac4541e6.png)

Pipeline Builder:
![Screen Shot 2020-05-21 at 10 25 32 PM](https://user-images.githubusercontent.com/8126518/82625589-92a59d80-9bb3-11ea-813d-c6ee1b1dab98.png)

Even Trigger pages:
![Screen Shot 2020-05-21 at 10 25 47 PM](https://user-images.githubusercontent.com/8126518/82625591-933e3400-9bb3-11ea-9ff0-d80147edf9ef.png)

**Test setup:**

- Tech Preview Pipeline Operator

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge