### PR TITLE
Bug 1839036: handle embedded pipeline spec in pipelinerun scenario

### DIFF
--- a/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunVisualization.tsx
+++ b/frontend/packages/dev-console/src/components/pipelineruns/detail-page-tabs/PipelineRunVisualization.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { K8sResourceKind, k8sGet } from '@console/internal/module/k8s';
 import { getPipelineTasks } from '../../../utils/pipeline-utils';
+import { pipelineRefExists } from '../../../utils/pipeline-augment';
 import { PipelineModel } from '../../../models';
 import { pipelineRunFilterReducer } from '../../../utils/pipeline-filter-reducer';
 import { PipelineVisualizationGraph } from '../../pipelines/detail-page-tabs/pipeline-details/PipelineVisualizationGraph';
@@ -27,22 +28,24 @@ export class PipelineRunVisualization extends React.Component<
   }
 
   componentDidMount() {
-    k8sGet(
-      PipelineModel,
-      this.props.pipelineRun.spec.pipelineRef.name,
-      this.props.pipelineRun.metadata.namespace,
-    )
-      .then((res) => {
-        this.setState({
-          pipeline: res,
-        });
-      })
-      .catch((error) => this.setState({ errorCode: error.response.status }));
+    if (pipelineRefExists(this.props.pipelineRun)) {
+      k8sGet(
+        PipelineModel,
+        this.props.pipelineRun.spec.pipelineRef.name,
+        this.props.pipelineRun.metadata.namespace,
+      )
+        .then((res) => {
+          this.setState({
+            pipeline: res,
+          });
+        })
+        .catch((error) => this.setState({ errorCode: error.response.status }));
+    }
   }
 
   render() {
     const { pipelineRun } = this.props;
-    if (this.state.errorCode === 404) {
+    if (!pipelineRefExists(pipelineRun) || this.state.errorCode === 404) {
       return null;
     }
     return (

--- a/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment.spec.ts
+++ b/frontend/packages/dev-console/src/utils/__tests__/pipeline-augment.spec.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { pipelineTestData, DataState, PipelineExampleNames } from '../../test/pipeline-data';
 import {
   getResources,
@@ -8,6 +9,7 @@ import {
   getRunStatusColor,
   runStatus,
   getResourceModelFromTask,
+  pipelineRefExists,
 } from '../pipeline-augment';
 import { ClusterTaskModel, TaskModel } from '../../models';
 import { testData } from './pipeline-augment-test-data';
@@ -271,5 +273,25 @@ describe('PipelineAugment test successfully determine Task type', () => {
 
     const model = getResourceModelFromTask(complexTestData.pipeline.spec.tasks[0]);
     expect(model).toBe(ClusterTaskModel);
+  });
+});
+
+describe('Pipeline exists test to determine whether a pipeline is linked to a pipelinerun', () => {
+  it('expect to return true if pipelineref is available in pipelinerun spec', () => {
+    const pipelineRunWithPipelineRef =
+      pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[DataState.SUCCESS];
+
+    const pipelineFound = pipelineRefExists(pipelineRunWithPipelineRef);
+    expect(pipelineFound).toBeTruthy();
+  });
+
+  it('expect to return false if pipelineref is missing in pipelinerun spec', () => {
+    const pipelineRunWithoutPipelineRef = _.omit(
+      pipelineTestData[PipelineExampleNames.SIMPLE_PIPELINE].pipelineRuns[DataState.SUCCESS],
+      'spec.pipelineRef',
+    );
+
+    const pipelineFound = pipelineRefExists(pipelineRunWithoutPipelineRef);
+    expect(pipelineFound).toBeFalsy();
   });
 });

--- a/frontend/packages/dev-console/src/utils/pipeline-augment.ts
+++ b/frontend/packages/dev-console/src/utils/pipeline-augment.ts
@@ -75,7 +75,7 @@ export interface Pipeline extends K8sResourceKind {
 
 export interface PipelineRun extends K8sResourceKind {
   spec?: {
-    pipelineRef: { name: string };
+    pipelineRef?: { name: string };
     params?: PipelineRunParam[];
     resources?: PipelineResource[];
     serviceAccountName?: string;
@@ -307,4 +307,8 @@ export const getResourceModelFromTask = (task: PipelineTask): K8sKind => {
   } = task;
 
   return kind === ClusterTaskModel.kind ? ClusterTaskModel : TaskModel;
+};
+
+export const pipelineRefExists = (pipelineRun: K8sResourceKind): boolean => {
+  return !!pipelineRun.spec.pipelineRef && pipelineRun.spec.pipelineRef.name.length > 0;
 };


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-3675

Problem:
Devconsole UI breaks when user creates pipelinerun with embedded pipeline spec and visits the pipeline run details page

Solution:
Add checks and conditionally rendering the pipelinerun visualization component based on the pipelineRef field in the pipelinerun spec.

This is a manual cherry pick for the PR https://github.com/openshift/console/pull/5526