### PR TITLE
Bug 1839032: Fix build status not shown in sidebar when trigger is disabled

### DIFF
--- a/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
+++ b/frontend/packages/dev-console/src/components/edit-application/__tests__/edit-application-data.ts
@@ -416,7 +416,7 @@ export const gitImportInitialValues: GitImportFormData = {
   },
   git: {
     url: 'https://github.com/divyanshiGupta/nationalparks-py',
-    type: 'Git',
+    type: 'github',
     ref: '',
     dir: '/',
     showGitType: false,

--- a/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
+++ b/frontend/packages/dev-console/src/components/import/__tests__/import-submit-utils.spec.ts
@@ -34,8 +34,13 @@ describe('Import Submit Utils', () => {
       const annotations = _.get(returnValue, 'data.metadata.annotations');
       expect(JSON.parse(annotations['image.openshift.io/triggers'])).toEqual([
         {
-          from: { kind: 'ImageStreamTag', name: 'nodejs-ex-git:latest', namespace: 'gijohn' },
+          from: {
+            kind: 'ImageStreamTag',
+            name: 'nodejs-ex-git:latest',
+            namespace: 'gijohn',
+          },
           fieldPath: 'spec.template.spec.containers[?(@.name=="nodejs-ex-git")].image',
+          pause: 'false',
         },
       ]);
       done();

--- a/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/deployImage-submit-utils.ts
@@ -157,8 +157,12 @@ export const createOrUpdateDeployment = (
   const defaultAnnotations = {
     ...annotations,
     'alpha.image.policy.openshift.io/resolve-names': '*',
-    ...(imageChange &&
-      getTriggerAnnotation(imgName || name, imgNamespace || namespace, imageStreamTag)),
+    ...getTriggerAnnotation(
+      imgName || name,
+      imgNamespace || namespace,
+      imageChange,
+      imageStreamTag,
+    ),
   };
 
   const { labels, podLabels, volumes, volumeMounts } = getMetadata(formData);
@@ -354,6 +358,9 @@ export const createOrUpdateDeployImageResources = async (
     route: { create: canCreateRoute, disable },
     isi: { ports, tag: imageStreamTag, image },
     imageStream: { image: internalImageStreamName, namespace: internalImageStreamNamespace },
+    deployment: {
+      triggers: { image: imageChange },
+    },
   } = formData;
   const internalImageName = getRuntime(image.metadata?.labels);
   const requests: Promise<K8sResourceKind>[] = [];
@@ -432,6 +439,7 @@ export const createOrUpdateDeployImageResources = async (
     const triggerAnnotations = getTriggerAnnotation(
       internalImageStreamName || name,
       internalImageStreamNamespace || namespace,
+      imageChange,
       imageStreamTag,
     );
     const annotations = {

--- a/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-submit-utils.ts
@@ -252,7 +252,7 @@ export const createOrUpdateDeployment = (
     ...getGitAnnotations(repository, ref),
     ...getCommonAnnotations(),
     'alpha.image.policy.openshift.io/resolve-names': '*',
-    ...(imageChange && getTriggerAnnotation(name, namespace)),
+    ...getTriggerAnnotation(name, namespace, imageChange),
   };
   const podLabels = getPodLabels(name);
 
@@ -417,6 +417,9 @@ export const createOrUpdateResources = async (
       strategy: buildStrategy,
       triggers: { webhook: webhookTrigger },
     },
+    deployment: {
+      triggers: { image: imageChange },
+    },
     git: { url: repository, type: gitType, ref },
     pipeline,
     resources,
@@ -472,7 +475,11 @@ export const createOrUpdateResources = async (
     const imageStreamURL = imageStreamResponse.status.dockerImageRepository;
 
     const originalAnnotations = appResources?.editAppResource?.data?.metadata?.annotations || {};
-    const triggerAnnotations = getTriggerAnnotation(generatedImageStreamName || name, namespace);
+    const triggerAnnotations = getTriggerAnnotation(
+      generatedImageStreamName || name,
+      namespace,
+      imageChange,
+    );
     const annotations = {
       ...originalAnnotations,
       ...defaultAnnotations,

--- a/frontend/packages/dev-console/src/utils/resource-label-utils.ts
+++ b/frontend/packages/dev-console/src/utils/resource-label-utils.ts
@@ -46,11 +46,17 @@ export const getCommonAnnotations = () => {
   };
 };
 
-export const getTriggerAnnotation = (name: string, namespace: string, tag: string = 'latest') => ({
+export const getTriggerAnnotation = (
+  name: string,
+  namespace: string,
+  imageTrigger: boolean,
+  tag: string = 'latest',
+) => ({
   [TRIGGERS_ANNOTATION]: JSON.stringify([
     {
       from: { kind: 'ImageStreamTag', name: `${name}:${tag}`, namespace },
       fieldPath: `spec.template.spec.containers[?(@.name=="${name}")].image`,
+      pause: `${!imageTrigger}`,
     },
   ]),
 });


### PR DESCRIPTION
**Fixes:** https://issues.redhat.com/browse/ODC-3958

**Solution:**
Keeping the trigger annotation always and setting its pause prop based on image trigger value.
Refer: https://docs.openshift.com/container-platform/3.11/dev_guide/managing_images.html#image-stream-kubernetes-resources

**Gif:**
![build](https://user-images.githubusercontent.com/20724543/82663094-a94c0300-9c4c-11ea-8348-6be0f4e95d83.gif)


/kind bug