### PR TITLE
Bug 1839075: updates helptext for eventSources

### DIFF
--- a/frontend/packages/knative-plugin/src/components/add/event-sources/ApiServerSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/ApiServerSection.tsx
@@ -36,7 +36,12 @@ const ApiServerSection: React.FC = () => {
   const fieldId = getFieldId(values.type, 'res-input');
   return (
     <FormSection title="ApiServerSource" extraMargin>
-      <FormGroup fieldId={fieldId} label="Resource" isRequired>
+      <FormGroup
+        fieldId={fieldId}
+        label="Resource"
+        helperText="The list of resources to watch"
+        isRequired
+      >
         <AsyncComponent
           loader={() =>
             import('@console/internal/components/utils/name-value-editor').then(
@@ -57,6 +62,7 @@ const ApiServerSection: React.FC = () => {
         label="Mode"
         items={modeItems}
         title={modeItems.Ref}
+        helpText="The mode the receive adapter controller runs under"
         fullWidth
       />
       <ServiceAccountDropdown name="data.apiserversource.serviceAccountName" />

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/ContainerSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/ContainerSourceSection.tsx
@@ -47,6 +47,7 @@ const ContainerSourceSection: React.FC = () => {
         type={TextInputTypes.text}
         name={containerPaths.Image}
         label="Image"
+        helpText="The image to run inside of the container"
         required
         onChange={(e) => {
           setFieldValue(containerPaths.Name, getSuggestedName(e.target.value));
@@ -57,6 +58,7 @@ const ContainerSourceSection: React.FC = () => {
         type={TextInputTypes.text}
         name={containerPaths.Name}
         label="Name"
+        helpText="The name of the image"
       />
       <TextColumnField
         data-test-id="container-arg-field"
@@ -64,10 +66,14 @@ const ContainerSourceSection: React.FC = () => {
         label="Arguments"
         addLabel="Add args"
         placeholder="argument"
-        helpText="The command to run inside the container."
+        helpText="Arguments passed to the container"
         disableDeleteRow={args?.length === 1}
       />
-      <FormGroup fieldId="containersource-env" label="Environment variables">
+      <FormGroup
+        fieldId="containersource-env"
+        label="Environment variables"
+        helperText="The list of variables to set in the container"
+      >
         <AsyncComponent
           loader={() =>
             import('@console/internal/components/utils/name-value-editor').then(

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/CronJobSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/CronJobSection.tsx
@@ -5,7 +5,12 @@ import FormSection from '@console/dev-console/src/components/import/section/Form
 
 const CronJobSection: React.FC = () => (
   <FormSection title="CronJobSource" extraMargin>
-    <InputField type={TextInputTypes.text} name="data.cronjobsource.data" label="Data" />
+    <InputField
+      type={TextInputTypes.text}
+      name="data.cronjobsource.data"
+      label="Data"
+      helpText="The data posted to the target function"
+    />
     <InputField
       type={TextInputTypes.text}
       name="data.cronjobsource.schedule"

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/KafkaSourceSection.tsx
@@ -20,6 +20,7 @@ const KafkaSourceSection: React.FC = () => {
         name="data.kafkasource.bootstrapServers"
         label="BootstrapServers"
         addLabel="Add Bootstrapservers"
+        helpText="The address of the Kafka broker"
         required
         disableDeleteRow={bootstrapServers?.length === 1}
       />
@@ -28,6 +29,7 @@ const KafkaSourceSection: React.FC = () => {
         name="data.kafkasource.topics"
         label="Topics"
         addLabel="Add Topics"
+        helpText="Virtual groups across Kafka brokers"
         required
         disableDeleteRow={topics?.length === 1}
       />
@@ -36,6 +38,7 @@ const KafkaSourceSection: React.FC = () => {
         type={TextInputTypes.text}
         name="data.kafkasource.consumerGroup"
         label="ConsumerGroup"
+        helpText="A group that tracks maximum offset consumed"
         required
       />
       <KafkaSourceNetSection />

--- a/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/event-sources/PingSourceSection.tsx
@@ -5,7 +5,12 @@ import FormSection from '@console/dev-console/src/components/import/section/Form
 
 const PingSourceSection: React.FC = () => (
   <FormSection title="PingSource" extraMargin>
-    <InputField type={TextInputTypes.text} name="data.pingsource.data" label="Data" />
+    <InputField
+      type={TextInputTypes.text}
+      name="data.pingsource.data"
+      label="Data"
+      helpText="The data posted to the target function"
+    />
     <InputField
       type={TextInputTypes.text}
       name="data.pingsource.schedule"

--- a/frontend/packages/knative-plugin/src/components/dropdowns/ServiceAccountDropdown.tsx
+++ b/frontend/packages/knative-plugin/src/components/dropdowns/ServiceAccountDropdown.tsx
@@ -36,6 +36,7 @@ const ServiceAccountDropdown: React.FC<ServiceAccountDropdownProps & StateProps>
       dataSelector={['metadata', 'name']}
       placeholder="Select a Service Account Name"
       autocompleteFilter={autocompleteFilter}
+      helpText="The name of Service Account use to run this"
       fullWidth
       showBadge
     />


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3414

**Analysis / Root cause**: 
HelpText were missing for some of the sources

**Solution Description**: 
Updated helpText for sources

**Screen shots / Gifs for design review**: 
<img width="995" alt="Screenshot 2020-05-22 at 6 45 15 PM" src="https://user-images.githubusercontent.com/5129024/82671478-89bcd680-9c5c-11ea-8ddc-0501515d58bb.png">

<img width="987" alt="Screenshot 2020-05-22 at 6 05 08 PM" src="https://user-images.githubusercontent.com/5129024/82668774-d3ef8900-9c57-11ea-8664-76ec1a587e55.png">

<img width="837" alt="Screenshot 2020-05-22 at 6 05 21 PM" src="https://user-images.githubusercontent.com/5129024/82668784-d6ea7980-9c57-11ea-927d-e5d6fbcd4593.png">


cc @openshift/team-devconsole-ux @beaumorley 

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
