### PR TITLE
Bug 1839080: fix empty Content in coFetchText causes PipelineLogs to show error

### DIFF
--- a/frontend/public/co-fetch.js
+++ b/frontend/public/co-fetch.js
@@ -149,7 +149,7 @@ export const coFetchCommon = (url, method = 'GET', options = {}, timeout) => {
 
     // If the response has no body, return promise that resolves with an empty object
     if (response.headers.get('Content-Length') === '0') {
-      return Promise.resolve({});
+      return Promise.resolve(response.headers.get('Content-Type') === 'text/plain' ? '' : {});
     }
     if (response.headers.get('Content-Type') === 'text/plain') {
       return response.text();


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ODC-3725

**Problem**:
![image (5)](https://user-images.githubusercontent.com/9964343/82668699-b1f60680-9c57-11ea-86ad-6fb3cce12bfc.png)

Visiting the pipeline run logs page, the logs component shows the error due to the string method is applied on a object.

**Solution:**
Add additional checks to make sure the string method is used on a string and if it is not a string added a empty array as a fallback.

**Screenshots:**
![PipelineRunlogsError](https://user-images.githubusercontent.com/9964343/82668893-0a2d0880-9c58-11ea-96ca-3dfe0182e390.gif)

