### PR TITLE
Bug 1838698: Show alert when operator-recommended namespace already exists

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -342,17 +342,26 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
   const showMonitoringCheckbox =
     operatorRequestsMonitoring && _.startsWith(selectedTargetNamespace, 'openshift-');
 
-  const createNamespaceDetails = isSuggestedNamespaceSelected && !suggestedNamespaceExists && (
+  const suggestedNamespaceDetails = isSuggestedNamespaceSelected && (
     <>
       <Alert
         isInline
         className="co-alert co-alert--scrollable"
-        variant="info"
-        title="Namespace creation"
+        variant={suggestedNamespaceExists ? 'warning' : 'info'}
+        title={suggestedNamespaceExists ? 'Namespace already exists' : 'Namespace creation'}
       >
-        Namespace <b>{suggestedNamespace}</b> does not exist and will be created.
+        {suggestedNamespaceExists ? (
+          <>
+            Namespace <b>{suggestedNamespace}</b> already exists and will be used. Other users can
+            already have access to this namespace.
+          </>
+        ) : (
+          <>
+            Namespace <b>{suggestedNamespace}</b> does not exist and will be created.
+          </>
+        )}
       </Alert>
-      {showMonitoringCheckbox && (
+      {showMonitoringCheckbox && !suggestedNamespaceExists && (
         <div className="co-form-subsection">
           <Checkbox
             id="enable-monitoring-checkbox"
@@ -409,7 +418,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
           }}
         />
       </div>
-      {createNamespaceDetails}
+      {suggestedNamespaceDetails}
     </>
   );
 
@@ -434,7 +443,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
         <ResourceIcon kind="Project" />
         <b>{suggestedNamespace}</b>
       </RadioInput>
-      {useSuggestedNSForSingleInstallMode && createNamespaceDetails}
+      {useSuggestedNSForSingleInstallMode && suggestedNamespaceDetails}
       <RadioInput
         onChange={() => {
           setUseSuggestedNSForSingleInstallMode(false);


### PR DESCRIPTION
Wasnt really sure if we want to somehow make "Namespace already exists" alert more informative, since the administrator might not realize the namespace isn't being created just for the operator, and other users on the cluster could already have admin access to that namespace.

Screen:
<img width="605" alt="Screenshot 2020-05-22 at 15 23 19" src="https://user-images.githubusercontent.com/1668218/82673290-e1017d80-9c41-11ea-81cb-8147d1919f35.png">

Will probably conflict with https://github.com/openshift/console/pull/5529

/assign @spadgett 