### PR TITLE
Use last namespace for nav/breadcrumbs

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -85,6 +85,7 @@ import { createUninstallOperatorModal } from './modals/uninstall-operator-modal'
 import { operatorGroupFor, operatorNamespaceFor } from './operator-group';
 import { SubscriptionDetails, catalogSourceForSubscription } from './subscription';
 import { ClusterServiceVersionLogo, referenceForProvidedAPI, providedAPIsFor } from './index';
+import { getBreadcrumbPath } from '@console/internal/components/utils/breadcrumbs';
 
 const clusterServiceVersionStateToProps = (state: RootState): ClusterServiceVersionStateProps => {
   return {
@@ -1034,7 +1035,7 @@ export const ClusterServiceVersionsDetailsPage: React.FC<ClusterServiceVersionsD
       breadcrumbsFor={() => [
         {
           name: 'Installed Operators',
-          path: `/k8s/ns/${props.match.params.ns}/${props.match.params.plural}`,
+          path: getBreadcrumbPath(props.match),
         },
         { name: 'Operator Details', path: props.match.url },
       ]}

--- a/frontend/public/components/container.tsx
+++ b/frontend/public/components/container.tsx
@@ -28,6 +28,7 @@ import {
   Timestamp,
 } from './utils';
 import { resourcePath } from './utils/resource-link';
+import { getBreadcrumbPath } from '@console/internal/components/utils/breadcrumbs';
 
 const formatComputeResources = (resources: ResourceList) =>
   _.map(resources, (v, k) => `${k}: ${v}`).join(', ');
@@ -383,7 +384,7 @@ export const ContainersDetailsPage: React.FC<ContainerDetailsPageProps> = (props
         title={props.match.params.name}
         kind="Container"
         breadcrumbsFor={() => [
-          { name: 'Pods', path: `/k8s/ns/${props.match.params.ns}/pods` },
+          { name: 'Pods', path: getBreadcrumbPath(props.match, 'pods') },
           {
             name: props.match.params.podName,
             path: resourcePath('Pod', props.match.params.podName, props.match.params.ns),

--- a/frontend/public/components/image-stream-tag.tsx
+++ b/frontend/public/components/image-stream-tag.tsx
@@ -8,6 +8,7 @@ import { Kebab, SectionHeading, navFactory, ResourceSummary } from './utils';
 import { humanizeBinaryBytes } from './utils/units';
 import { ExampleDockerCommandPopover } from './image-stream';
 import { ImageStreamTimeline } from './image-stream-timeline';
+import { getBreadcrumbPath } from '@console/internal/components/utils/breadcrumbs';
 
 const ImageStreamTagsReference: K8sResourceKindReference = 'ImageStreamTag';
 const ImageStreamsReference: K8sResourceKindReference = 'ImageStream';
@@ -178,10 +179,10 @@ export const ImageStreamTagsDetailsPage: React.SFC<ImageStreamTagsDetailsPagePro
     breadcrumbsFor={(obj) => {
       const { imageStreamName } = getImageStreamNameAndTag(obj);
       return [
-        { name: 'Image Streams', path: `/k8s/ns/${props.match.params.ns}/imagestreams` },
+        { name: 'Image Streams', path: getBreadcrumbPath(props.match, 'imagestreams') },
         {
           name: imageStreamName,
-          path: `/k8s/ns/${props.match.params.ns}/imagestreams/${imageStreamName}`,
+          path: `${getBreadcrumbPath(props.match, 'imagestreams')}/${imageStreamName}`,
         },
         {
           name: 'Image Stream Tag Details',

--- a/frontend/public/components/nav/items.tsx
+++ b/frontend/public/components/nav/items.tsx
@@ -11,6 +11,8 @@ import * as plugins from '../../plugins';
 import { featureReducerName } from '../../reducers/features';
 import { RootState } from '../../redux';
 import { getActiveNamespace } from '../../reducers/ui';
+import { LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY } from '@console/shared/src/constants';
+import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
 
 export const matchesPath = (resourcePath, prefix) =>
   resourcePath === prefix || _.startsWith(resourcePath, `${prefix}/`);
@@ -87,7 +89,11 @@ export class ResourceNSLink extends NavLink<ResourceNSLinkProps> {
 
   get to() {
     const { resource, activeNamespace } = this.props;
-    return formatNamespacedRouteForResource(resource, activeNamespace);
+    const lastNamespace = localStorage.getItem(LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY);
+    return formatNamespacedRouteForResource(
+      resource,
+      lastNamespace === ALL_NAMESPACES_KEY ? lastNamespace : activeNamespace,
+    );
   }
 }
 

--- a/frontend/public/components/utils/breadcrumbs.ts
+++ b/frontend/public/components/utils/breadcrumbs.ts
@@ -1,11 +1,21 @@
 import { K8sKind } from '../../module/k8s';
+import { LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY } from '@console/shared/src/constants';
+import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
+
+export const getBreadcrumbPath = (match: any, customPlural?: string) => {
+  const lastNamespace = localStorage.getItem(LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY);
+  if (match.params.ns) {
+    return lastNamespace === ALL_NAMESPACES_KEY
+      ? `/k8s/all-namespaces/${customPlural || match.params.plural}`
+      : `/k8s/ns/${match.params.ns}/${customPlural || match.params.plural}`;
+  }
+  return `/k8s/cluster/${customPlural || match.params.plural}`;
+};
 
 export const breadcrumbsForDetailsPage = (kindObj: K8sKind, match: any) => () => [
   {
     name: `${kindObj.labelPlural}`,
-    path: match.params.ns
-      ? `/k8s/ns/${match.params.ns}/${match.params.plural}`
-      : `/k8s/cluster/${match.params.plural}`,
+    path: getBreadcrumbPath(match),
   },
   { name: `${kindObj.label} Details`, path: `${match.url}` },
 ];


### PR DESCRIPTION
Updated breadcrumbs and resource nav items to use the last namespace (if available) when generating the path.

Dev perspective looks ok as-is and it looks like topology, etc. default to "all projects" on first log in already, unless I'm missing something.

Screen recording: https://recordit.co/G8VVwm7JbG

Fixes https://issues.redhat.com/projects/CONSOLE/issues/CONSOLE-2228.