### PR TITLE
Bug 1839233: send activity tick to keep the cloud shell terminal alive

### DIFF
--- a/frontend/packages/console-app/src/components/cloud-shell/__tests__/useActivityTick.spec.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/__tests__/useActivityTick.spec.ts
@@ -1,0 +1,52 @@
+import useActivityTick from '../useActivityTick';
+import * as cloudShellUtils from '../cloud-shell-utils';
+import { testHook } from '@console/shared/src/test-utils/hooks-utils';
+
+describe('useActivityTick', () => {
+  beforeEach(() => {
+    jest.spyOn(cloudShellUtils, 'sendActivityTick').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should notify if activity occurs after 1 min', () => {
+    let mockNow = Date.now();
+    jest.spyOn(Date, 'now').mockImplementation(() => mockNow);
+    const sendActivityTickMock = jest
+      .spyOn(cloudShellUtils, 'sendActivityTick')
+      .mockImplementation(() => {});
+    testHook(() => {
+      const tick = useActivityTick('testName', 'testNamespace');
+
+      // send initial tick
+      tick();
+      expect(sendActivityTickMock).toHaveBeenCalledWith('testName', 'testNamespace');
+      sendActivityTickMock.mockReset();
+
+      // elapsed time isn't long enough to trigger sending a new tick
+      mockNow += 59000;
+      tick();
+
+      // reset mock to test count
+      expect(sendActivityTickMock).toHaveBeenCalledTimes(0);
+
+      // elapsed time is now long enough to trigger sending a tick
+      mockNow += 1000;
+      tick();
+      expect(sendActivityTickMock).toHaveBeenCalledWith('testName', 'testNamespace');
+      expect(sendActivityTickMock).toHaveBeenCalledTimes(1);
+
+      // multiple ticks within the time interval does not result sending tick
+      tick();
+      tick();
+      expect(sendActivityTickMock).toHaveBeenCalledTimes(1);
+
+      // advance time enough to send a tick
+      mockNow += 600000;
+      tick();
+      expect(sendActivityTickMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -62,26 +62,13 @@ export const newCloudShellWorkSpace = (name: string, namespace: string): CloudSh
     devfile: {
       apiVersion: '1.0.0',
       metadata: {
-        name,
+        name: 'command-line-terminal',
       },
       components: [
         {
           alias: 'command-line-terminal',
           type: 'cheEditor',
           id: 'che-incubator/command-line-terminal/4.5.0',
-        },
-        {
-          type: 'dockerimage',
-          memoryLimit: '256Mi',
-          alias: 'dev',
-          image: 'registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1',
-          args: ['tail', '-f', '/dev/null'],
-          env: [
-            {
-              value: '\\[\\e[34m\\]>\\[\\e[m\\]\\[\\e[33m\\]>\\[\\e[m\\]',
-              name: 'PS1',
-            },
-          ],
         },
       ],
     },

--- a/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts
@@ -1,6 +1,6 @@
 import { K8sResourceKind } from '@console/internal/module/k8s';
 import { getRandomChars } from '@console/shared';
-import { coFetchJSON } from '@console/internal/co-fetch';
+import { coFetchJSON, coFetch } from '@console/internal/co-fetch';
 
 type environment = {
   value: string;
@@ -102,3 +102,9 @@ export const initTerminal = (
   };
   return coFetchJSON.post(url, payload);
 };
+
+export const sendActivityTick = (workspaceName: string, namespace: string): void => {
+  coFetch(`/api/terminal/proxy/${namespace}/${workspaceName}/activity/tick`, { method: 'POST' });
+};
+
+export const checkTerminalAvailable = () => coFetch('/api/terminal/available');

--- a/frontend/packages/console-app/src/components/cloud-shell/useActivityTick.ts
+++ b/frontend/packages/console-app/src/components/cloud-shell/useActivityTick.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { sendActivityTick } from './cloud-shell-utils';
+
+// 1 minute
+const TICK_INTERVAL = 60000;
+
+const useActivityTick = (workspaceName: string, namespace: string) => {
+  const lastTick = React.useRef<number>(0);
+
+  const tick = React.useCallback(() => {
+    const now = Date.now();
+    if (now - lastTick.current >= TICK_INTERVAL) {
+      sendActivityTick(workspaceName, namespace);
+      lastTick.current = now;
+    }
+  }, [workspaceName, namespace]);
+
+  return tick;
+};
+
+export default useActivityTick;


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-3926
Also removed `dockerimage` from the workspace resource as per https://github.com/che-incubator/che-workspace-operator/pull/82

**Analysis / Root cause**: 
Cloudshell pod never scales to zero. Therefore indefinitely consuming resources per user per terminal.

**Solution Description**: 
A new endpoint is created in the backend at `/api/$namespace/$workspaceName/terminal/activity/tick`
We notify this endpoint every minute while there is activity in the console.
The controller will keep the pod alive so long as there has been a tick within a certain time frame (TBD and set on the controller).

Also using the new endpoint to check if the terminal is available before enabling the masthead button.

**Unit test coverage report**: 
<!-- Attach test coverage report -->
![image](https://user-images.githubusercontent.com/14068621/82702273-b57d9380-9c3f-11ea-9116-148fcbba8679.png)

**Test setup:**
Requires https://github.com/openshift/console/pull/5332
When using local bridge. Need to do the following: https://gist.github.com/amisevsk/de48e5e2664857fcd53f0f9550a92082
https://gist.github.com/amisevsk/788ade83b172259f1130691a8c4a1a25

**Browser conformance**: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
